### PR TITLE
ci: stop gating the release bot's changeset PR; grant publish-comment write

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -47,7 +47,8 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.base.ref != 'prod' &&
-      github.event.pull_request.head.ref != 'prod' && (
+      github.event.pull_request.head.ref != 'prod' &&
+      !startsWith(github.event.pull_request.head.ref, 'changeset-release/') && (
         github.event.action != 'labeled' ||
         github.event.label.name == 'bot-review'
       )

--- a/.github/workflows/snapshot-publish.yaml
+++ b/.github/workflows/snapshot-publish.yaml
@@ -261,7 +261,7 @@ jobs:
     # explicit grant (PR comments ride the issues API).
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     steps:
       - name: Find associated PR


### PR DESCRIPTION
## Description

Clears the two red checks that appear on the release bot's `chore(release): version packages` PR (and any bot-authored PR), which were cosmetic-but-noisy.

## Changes

- **pr-bot-review.yml** — skip `changeset-release/*` branches. The agent review refuses bot-initiated runs (`Workflow initiated by non-human actor`), so it can only fail on the release bot's version PR. There's no value in reviewing a mechanical version bump.
- **snapshot-publish.yaml** — grant `pull-requests: write` on `comment-published-versions` so the "Published Packages" comment posts (the job already had `issues: write`; this makes the comment path bulletproof).

## Not included (already handled)

- **CLA on the bot PR** was failing only because the `cla-signatures` branch didn't exist on this repo yet — that branch is now restored, and `cla.yml`'s `allowlist:` already includes `*[bot]`, which covers the release bot. No change needed here.

## Tests

No test files; these are CI-config changes. Verified by the checks on this PR (poysama-authored, non-changeset branch → CLA passes, bot-review runs normally) and by the release bot's next changeset PR no longer triggering bot-review.

## Guide for Testers

1. After merge, confirm the release bot's `chore(release): version packages` PR no longer runs `pr-bot-review` (no failing "review" check).
2. On the next snapshot publish, confirm the "Published Packages" comment posts without a 403.
