### PR TITLE
fix(selfhost): raise mongo nofile ulimit and make published host ports overridable

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -29,6 +29,19 @@ WEBSOCKET_URL=ws://localhost:3001
 # MinIO admin creds (conventional local default; used by the app's S3 client too).
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
+
+# -- Published host ports (override only if a port is already taken on your host) --
+# These change the HOST side of the port publish only; services still talk to
+# each other over the compose network on their fixed internal ports. Example: a
+# local mongod already on 27017 -> set MONGO_HOST_PORT=27018. Leave unset to keep
+# the defaults shown.
+# APP_HOST_PORT=3000
+# MONGO_HOST_PORT=27017
+# MINIO_HOST_PORT=9000
+# MINIO_CONSOLE_HOST_PORT=9001
+# SQS_HOST_PORT=9324
+# SQS_UI_HOST_PORT=9325
+# MAIL_UI_HOST_PORT=8025
 # Point the app's AWS SDK (S3 + SQS) at the local MinIO/ElasticMQ services.
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=minioadmin

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -71,7 +71,13 @@ This pulls the app image and starts it alongside MongoDB, MinIO, ElasticMQ, and 
 http://localhost:3000
 ```
 
-**Building from source instead** (optional): the prebuilt image is the supported path, but you can build locally with `docker compose -f compose.selfhost.yaml --env-file .env.selfhost build`. The Next.js monorepo build needs ~12-16 GB of Docker memory (Docker Desktop: Settings > Resources).
+**Building from source**: if the `docker pull` step fails with `unauthorized` or `manifest unknown` (the CI-published image is not available to your account, or hasn't been published yet), build the image locally instead:
+
+```bash
+docker compose -f compose.selfhost.yaml --env-file .env.selfhost build
+```
+
+Compose tags the build with the same name the stack expects, so the subsequent `up` uses your local image and won't try to pull. The Next.js monorepo build needs ~12-16 GB of memory available to Docker (Docker Desktop: Settings > Resources; on Linux this is just host RAM). A from-source build takes several minutes and produces a ~1 GB image.
 
 ## 4. Sign in
 
@@ -106,6 +112,9 @@ The same header works as `Authorization: ApiKey <key>`. Keys, scopes, and rate l
 
 ## Troubleshooting
 
+- **`docker pull` fails with `unauthorized` / `manifest unknown`** - the prebuilt image isn't available to your account (or isn't published yet). Build it from source instead - see "Building from source" in step 3.
+- **`Error ... address already in use` / `failed to bind host port`** - another process on your host already owns one of the published ports (a local `mongod` on 27017 is the common one; also 3000, 9000, 9001, 9324, 9325, 8025). Override just the host side with the matching `*_HOST_PORT` var in `.env.selfhost` (e.g. `MONGO_HOST_PORT=27018`) - the services still reach each other over the compose network on their fixed internal ports, so nothing else needs to change.
+- **MongoDB crashes on first boot with `WT_PANIC` / `Too many open files`** - WiredTiger opens a file per collection and index and needs a high open-files limit; Docker's default (1024) is far below MongoDB's documented minimum. The bundled `mongo` service raises `nofile` to 64000 via `ulimits`. If you've customized the compose file or run mongo outside it, set that limit yourself, then wipe the half-initialized volume and restart: `docker compose -f compose.selfhost.yaml --env-file .env.selfhost down -v && ... up -d`.
 - **App can't reach Mongo / "no primary" errors** - MongoDB must run as a replica set (`--replSet rs0`) for transactions; the bundled `mongo` service is configured for this. Give it a few seconds to elect a primary on first boot.
 - **No sign-in email arrives** - check Mailpit at `http://localhost:8025`; if it's empty, check `docker compose -f compose.selfhost.yaml logs app` for mail errors and verify the `MAIL_*` values.
 - **A model returns "unauthorized"** - that provider's API key is missing or wrong in `.env.selfhost`. Only the providers you set keys for are available.

--- a/compose.selfhost.yaml
+++ b/compose.selfhost.yaml
@@ -31,9 +31,20 @@ services:
     command: ['mongod', '--replSet', 'rs0', '--bind_ip_all']
     volumes:
       - mongo-data:/data/db
+    # MongoDB/WiredTiger opens a file per collection + index. Docker's default
+    # soft nofile limit (1024) is far below MongoDB's documented minimum (64000):
+    # the server fatally panics with a WiredTiger "Too many open files" (EMFILE)
+    # error the moment the app creates its collections. Raise it here.
+    ulimits:
+      nofile:
+        soft: 64000
+        hard: 64000
     # Bound to loopback — reachable by the app over the compose network, not off-host.
+    # The app connects over the compose network (mongo:27017); this published port
+    # is only for host-side tooling. Override MONGO_HOST_PORT if 27017 is already
+    # taken on your host (e.g. a local mongod). The internal port never changes.
     ports:
-      - '127.0.0.1:27017:27017'
+      - '127.0.0.1:${MONGO_HOST_PORT:-27017}:27017'
     # Single-node replica set (the app requires a replica set for transactions).
     # The healthcheck initiates rs0 on first run, then reports healthy once up.
     healthcheck:
@@ -63,9 +74,10 @@ services:
     volumes:
       - minio-data:/data
     # Loopback-only. Override MINIO_ROOT_USER/PASSWORD for anything but local eval.
+    # Override MINIO_HOST_PORT / MINIO_CONSOLE_HOST_PORT if those ports are taken.
     ports:
-      - '127.0.0.1:9000:9000'
-      - '127.0.0.1:9001:9001'
+      - '127.0.0.1:${MINIO_HOST_PORT:-9000}:9000'
+      - '127.0.0.1:${MINIO_CONSOLE_HOST_PORT:-9001}:9001'
     healthcheck:
       test: ['CMD-SHELL', 'curl -sf http://localhost:9000/minio/health/live || exit 1']
       interval: 10s
@@ -96,17 +108,19 @@ services:
     volumes:
       - ./elasticmq.conf:/opt/elasticmq.conf:ro
     # Loopback-only — ElasticMQ has no auth; never expose it off-host.
+    # Override SQS_HOST_PORT / SQS_UI_HOST_PORT if those ports are taken.
     ports:
-      - '127.0.0.1:9324:9324'
-      - '127.0.0.1:9325:9325'
+      - '127.0.0.1:${SQS_HOST_PORT:-9324}:9324'
+      - '127.0.0.1:${SQS_UI_HOST_PORT:-9325}:9325'
 
   # Local mail catcher: all outgoing mail (including sign-in codes) lands here.
   # Read it at http://localhost:8025. Point MAIL_* at a real SMTP provider instead
   # for anything beyond local use.
   mail:
     image: axllent/mailpit
+    # Override MAIL_UI_HOST_PORT if 8025 is taken on your host.
     ports:
-      - '127.0.0.1:8025:8025'
+      - '127.0.0.1:${MAIL_UI_HOST_PORT:-8025}:8025'
 
   app:
     # Default: pull the CI-published multi-arch image (linux/amd64 + linux/arm64).
@@ -127,8 +141,9 @@ services:
         condition: service_started
       mail:
         condition: service_started
+    # Override APP_HOST_PORT to serve the app on a different host port.
     ports:
-      - '3000:3000'
+      - '${APP_HOST_PORT:-3000}:3000'
     # NOTE: the realtime websocket gateway is not in this stack yet. The app
     # serves HTTP without it; live streaming updates degrade.
 


### PR DESCRIPTION
Two fixes found bringing the self-host stack up from scratch on a stock Docker install. Both block `docker compose -f compose.selfhost.yaml up` before this change.

## Mongo nofile ulimit
MongoDB/WiredTiger opens a file per collection and index and needs a high open-files limit. Docker's default soft nofile (1024) is far below MongoDB's documented minimum (64000), so mongod fatally panics with a WiredTiger "Too many open files" error the moment the app creates its collections. The container then drops off the compose network and the app fails with `ENOTFOUND mongo`. Fixed by setting the mongo service nofile ulimit to 64000.

## Overridable published host ports
Published host ports were hardcoded, so any pre-existing service on the host (commonly a local mongod on 27017) made the stack fail with "address already in use". Each published port is now overridable via a `*_HOST_PORT` env var (APP_HOST_PORT, MONGO_HOST_PORT, MINIO_HOST_PORT, MINIO_CONSOLE_HOST_PORT, SQS_HOST_PORT, SQS_UI_HOST_PORT, MAIL_UI_HOST_PORT); defaults are unchanged. Internal compose-network ports are untouched, so nothing else needs reconfiguring.

## Docs
SELF_HOST.md and .env.selfhost.example document both, plus a build-from-source fallback for when the CI-published image can't be pulled (unauthorized / manifest unknown).

Verified by bringing the full stack (mongo, minio, elasticmq, mailpit, app) up to a working email sign-in.
