### PR TITLE
ci(selfhost): variable-driven runner labels for the image build

### DIFF
--- a/.github/workflows/selfhost-image.yml
+++ b/.github/workflows/selfhost-image.yml
@@ -44,14 +44,17 @@ permissions:
 jobs:
   build:
     name: Build ${{ matrix.arch }}
-    runs-on: ${{ matrix.runner }}
+    # Runner labels are variable-driven so runner policy changes (e.g. moving
+    # amd64 to a larger paid pool) need no workflow edit. arm64 must stay on a
+    # native arm runner or the build falls back to emulation speed.
+    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(vars.RUNNER_LABEL_ARM || '["ubuntu-24.04-arm"]') || fromJSON(vars.RUNNER_LABEL_HEAVY || '["ubuntu-latest"]') }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       # PR validation stays amd64-only (build-only, no secrets needed);
       # main/dispatch builds both architectures natively in parallel.
       matrix:
-        include: ${{ github.event_name == 'pull_request' && fromJSON('[{"arch":"amd64","platform":"linux/amd64","runner":"ubuntu-latest"}]') || fromJSON('[{"arch":"amd64","platform":"linux/amd64","runner":"ubuntu-latest"},{"arch":"arm64","platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]') }}
+        include: ${{ github.event_name == 'pull_request' && fromJSON('[{"arch":"amd64","platform":"linux/amd64"}]') || fromJSON('[{"arch":"amd64","platform":"linux/amd64"},{"arch":"arm64","platform":"linux/arm64"}]') }}
     steps:
       - name: Derive lowercase image name
         env:


### PR DESCRIPTION
The image build legs now honor the same runner variables as the rest of CI: the amd64 leg follows `RUNNER_LABEL_HEAVY` (JSON array, default `["ubuntu-latest"]`) and the arm64 leg follows a new `RUNNER_LABEL_ARM` (default `["ubuntu-24.04-arm"]`). Upgrading the build to a larger pool later becomes a variable flip instead of a workflow edit.

Two operational notes. First, pointing `RUNNER_LABEL_HEAVY` at `ubuntu-latest-m` today would queue forever: the larger-runner group does not serve public repositories until that is allowed in the org runner-group settings, and larger runners bill per-minute on public repos while the standard runners are free. Second, the arm64 leg must stay on a native arm pool; putting it on any amd64 pool reintroduces emulation, which is what the native split removed.
