### PR TITLE
ci(deploy): gate preview deploys on PR author write association

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -675,6 +675,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           PR_USER: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           ACTOR: ${{ github.actor }}
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
@@ -709,6 +710,7 @@ jobs:
           pr_number = os.environ['PR_NUMBER']
           pr_labels = json.loads(os.environ['PR_LABELS']) if os.environ['PR_LABELS'] not in ('', 'null') else []
           pr_user = os.environ['PR_USER']
+          pr_author_association = os.environ['PR_AUTHOR_ASSOCIATION']
           actor = os.environ['ACTOR']
           head_ref = os.environ['HEAD_REF']
           base_ref = os.environ['BASE_REF']
@@ -723,8 +725,14 @@ jobs:
           is_push_main = event == 'push' and ref == 'refs/heads/main'
           is_push_prod = event == 'push' and ref == 'refs/heads/prod'
           is_pr = event == 'pull_request'
+          # Anyone with read access can open a PR between two existing branches
+          # of this repo. Such a PR is same-repo (not a fork), so it lands in the
+          # trusted lane; without this check it would spawn a real preview stack.
+          # Only PR authors with write-level association get preview deploys.
+          # Tests and the rest of CI still run for everyone.
+          is_trusted_author = pr_author_association in ('OWNER', 'MEMBER', 'COLLABORATOR')
 
-          skip_pr = is_dependabot or is_changeset_release or is_promotion_pr
+          skip_pr = is_dependabot or is_changeset_release or is_promotion_pr or (is_pr and not is_trusted_author)
 
           for tenant, tc in config['tenants'].items():
               label = tc.get('preview_label')
@@ -738,6 +746,9 @@ jobs:
                   if label is None or label in pr_labels:
                       deploy.append({"tenant": tenant, "tier": "preview", "pr_number": str(pr_number)})
               # merge_group and skipped PRs => no deploy (test still runs)
+
+          if is_pr and not is_trusted_author:
+              print(f"::notice::No preview deploy: PR author association '{pr_author_association}' is not OWNER/MEMBER/COLLABORATOR.")
 
           deploy_json = json.dumps(deploy)
           print(f"Deploy matrix ({len(deploy)}): {deploy_json}")


### PR DESCRIPTION
## Description

Anyone with read access to a public repo can open a PR between two existing branches of that repo — no push access required, they just propose merging an existing maintainer branch. Such a PR is same-repo (not a fork), so it bypasses every fork-PR protection: the external-contributor approval gate does not apply, and `is_trusted_context` evaluates true. Without a guard, each such PR spawns a full preview environment on paid deploy runners, and open/close cycles let an outsider churn preview stacks at will — a cost and quota denial-of-service vector (verified by reproducing with a non-collaborator account).

The attacker cannot control the code (they cannot push), so this is not a secret-exposure issue — it is a resource-spawn issue.

## Changes

- `deploy.yml` plan step: pass `github.event.pull_request.author_association` into the deploy-matrix script and add it to the existing `skip_pr` conditions. Preview deploys are only planned when the PR author is `OWNER`, `MEMBER`, or `COLLABORATOR` (write-level association). Everything else about the PR still runs — tests, typecheck, lint, CLI e2e — so outside contributors keep full CI feedback; they just do not spawn infrastructure.
- Emit a `::notice::` with the author association when a preview is skipped for this reason, so "why is there no preview on my PR" is answerable from the run log.

Pushes to `main`/`prod` and merge-group runs are untouched (the new clause is scoped to `pull_request` events). The `Deploy` aggregate check treats a skipped deploy as passing, same as the existing dependabot/changeset skips.

## Tests

No test files — CI-config change. Workflow YAML validated; the guard reuses the plan step's existing skip mechanism (same path dependabot and changeset-release PRs already take).

## Guide for Testers

1. On this PR (author is a member), open the `plan` job log. Confirm the deploy matrix still contains the preview entry and a preview deploys as usual.
2. With a non-collaborator account, open a PR from any existing branch of this repo against `main`. In its `plan` job log, confirm the notice `No preview deploy: PR author association 'NONE' ...` appears, the deploy matrix is empty, and no `pr<N>` preview stack is created — while tests and the other checks still run and report.
3. Close the test PR.
