### PR TITLE
docs: add self-host rebuild-from-source and readiness-check steps

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -81,6 +81,24 @@ docker compose -f compose.selfhost.yaml --env-file .env.selfhost build
 
 Compose tags the build with the same name the stack expects, so the subsequent `up` uses your local image and won't try to pull. The Next.js monorepo build needs ~12-16 GB of memory available to Docker (Docker Desktop: Settings > Resources; on Linux this is just host RAM). A from-source build takes several minutes and produces a ~1 GB image.
 
+### Rebuild after local code changes
+
+Working from a checkout and want to run your own edits (or a freshly pulled `main`) instead of the published image? Build from your working tree and recreate the app in one step:
+
+```bash
+docker compose -f compose.selfhost.yaml --env-file .env.selfhost --profile ollama up -d --build
+```
+
+`--build` rebuilds the `app` image from the Dockerfile before starting; only `app` rebuilds, the backing services just restart. Drop `--profile ollama` if you are not running local models. Thanks to the pnpm store cache mount and Docker layer caching, a warm rebuild (only app source changed, deps unchanged) takes about 1-2 minutes; a cold first build takes several.
+
+Confirm it came up, then follow the logs:
+
+```bash
+docker compose -f compose.selfhost.yaml ps                      # services Up / healthy
+curl -s -o /dev/null -w '%{http_code}\n' localhost:3000         # expect 200
+docker compose -f compose.selfhost.yaml logs -f app             # follow app logs (Ctrl-C to stop)
+```
+
 ## 4. Sign in
 
 Bike4Mind signs you in with a one-time code sent by email. In the self-host stack, all outgoing mail is caught by the bundled **Mailpit** - nothing leaves your machine:


### PR DESCRIPTION
## Description

The self-host guide only documented the pull-based `up -d` path and framed building from source as a fallback for a failed `docker pull`. There was no one-command rebuild-and-run for local edits, and no readiness/log commands to confirm the stack is up. This adds a short subsection that covers both.

## Changes

- Add a "Rebuild after local code changes" subsection under step 3 of SELF_HOST.md:
  - `up -d --build` one-liner to build from the working tree and recreate the app.
  - Note that only `app` rebuilds, and how to drop the `ollama` profile.
  - Warm vs cold build timing (about 1-2 min warm, several cold) with the caching reason.
  - `ps` / `curl` / `logs -f app` commands to verify readiness and follow logs.

## Guide for Testers

1. Open SELF_HOST.md and read the new "Rebuild after local code changes" subsection under "3. Bring up the stack".
2. From a checkout, run the documented rebuild command; confirm the app rebuilds, `ps` shows it healthy, and `curl localhost:3000` returns 200.

Docs-only change, no screenshots.
