### PR TITLE
docs(cli): document b4m-cli for hosted + self-hosted usage

### DIFF
--- a/BIKE4MIND_CLI.md
+++ b/BIKE4MIND_CLI.md
@@ -89,6 +89,7 @@ Notes for the self-host path:
 
 - **Port.** The Docker stack serves the app on `3000` by default (`--dev` is a *different* target — the dev server on `3001`). If you remapped the host port (`APP_HOST_PORT` in `.env.selfhost`), use that port in `--api-url`.
 - **Models.** Only models for providers you configured a key for appear — or your local Ollama models. See [Local models with Ollama](./SELF_HOST.md#local-models-with-ollama-no-api-keys). To surface a host-native Ollama in the picker without editing config, launch with `b4m --ollama-host http://localhost:11434`.
+- **Credits — you don't need them.** Self-host sets `B4M_SELF_HOST=true`, which defaults the **Enforce Credits** admin setting **off**, so usage is never metered: you don't grant yourself credits or top up (`/usage` just shows enforcement is disabled). Your only cost is your own LLM provider bill. An admin *can* turn on **Enforce Credits** (Admin → Settings → Credits) if you want to meter users on your instance.
 - **Streaming.** The self-host stack does not yet include the realtime websocket gateway; see the [self-host gaps](./SELF_HOST.md#what-you-get-and-dont).
 
 ## Pointing at any deployment (AWS, staging, …)

--- a/BIKE4MIND_CLI.md
+++ b/BIKE4MIND_CLI.md
@@ -1,0 +1,146 @@
+# Bike4Mind CLI (`b4m`)
+
+`b4m` is an interactive, terminal-based agent for Bike4Mind — chat, ReAct tool use, MCP integration, and session persistence, all from your shell. It can talk to **either** the hosted Bike4Mind service (using your account and purchased credits) **or** your own [self-hosted stack](./SELF_HOST.md) — you choose per environment and switch freely.
+
+This is the task-oriented guide. For the exhaustive flag/command reference and the contributor workflow, see [`packages/cli/README.md`](./packages/cli/README.md).
+
+## Contents
+
+- [Install](#install)
+- [Which backend am I talking to?](#which-backend-am-i-talking-to)
+- [Using the hosted service (and your credits)](#using-the-hosted-service-and-your-credits)
+- [Using your self-hosted stack](#using-your-self-hosted-stack)
+- [Pointing at any deployment (AWS, staging, …)](#pointing-at-any-deployment-aws-staging-)
+- [Switching between environments](#switching-between-environments)
+- [Tool API keys & MCP servers](#tool-api-keys--mcp-servers)
+- [Headless / scripting mode](#headless--scripting-mode)
+- [Troubleshooting](#troubleshooting)
+
+## Install
+
+Requires **Node.js 24+**.
+
+```bash
+npm install -g @bike4mind/cli      # install the `b4m` (and `bike4mind`) command
+# or run without installing:
+npx @bike4mind/cli
+```
+
+Verify:
+
+```bash
+b4m --version
+b4m doctor        # checks Node, npm registry, ripgrep, and native modules
+```
+
+Building the CLI from a checkout instead? See [Development](./packages/cli/README.md#development) in the package README.
+
+## Which backend am I talking to?
+
+The active backend is shown in the startup banner (`🌍 API Environment: …`) and via `/api-info` inside a session. The CLI resolves it in this order:
+
+1. A **custom URL** you set with `--api-url` / `/set-api` (self-hosted or any deployment).
+2. Otherwise, a **build-time default** baked into the published binary. The upstream `@bike4mind/cli` bakes the hosted service; an [open-core fork](./CONTRIBUTING.md#the-openclosed-boundary) that publishes its own CLI without setting `B4M_DEFAULT_API_URL` ships **empty** — a bare `b4m` then reads as `Unconfigured`, and you **must** point it somewhere with `--api-url` before signing in.
+
+Auth tokens are cached **per environment**, so pointing at a new backend prompts a one-time `/login`, and switching back later reuses the cached session.
+
+## Using the hosted service (and your credits)
+
+```bash
+b4m --prod        # select the hosted Bike4Mind service (remembered)
+b4m               # subsequent runs reuse the last environment
+```
+
+On first run you'll be prompted to sign in via the OAuth device flow:
+
+1. Run `b4m` (or `/login`).
+2. Open the verification URL shown in the terminal.
+3. Enter the user code to authorize the CLI — tokens are stored in `~/.bike4mind/config.json` (mode `0600`).
+
+Usage draws down your account's **credits**. Check your balance any time:
+
+```
+/usage
+```
+
+Buy or top up credits from your account on the hosted web app; the CLI links you there when a session runs out.
+
+## Using your self-hosted stack
+
+If you run the open core with the [self-host quickstart](./SELF_HOST.md), the OAuth device-flow and chat APIs are served by your own `app` container — so `b4m` works against it with **no hosted account and no credits**. Everything stays on your hardware.
+
+Assuming the default self-host setup (app on `http://localhost:3000`):
+
+```bash
+# 1. Point the CLI at your stack (clears any cached auth, then exits)
+b4m --api-url http://localhost:3000
+
+# 2. Start the CLI and sign in
+b4m
+#    → run /login, open the verification URL, and approve it.
+#    → the sign-in email is caught by Mailpit at http://localhost:8025
+#      (self-host uses one-time email codes; nothing leaves your machine).
+
+# 3. Chat as usual. Confirm the target any time with:
+/api-info
+```
+
+Notes for the self-host path:
+
+- **Port.** The Docker stack serves the app on `3000` by default (`--dev` is a *different* target — the dev server on `3001`). If you remapped the host port (`APP_HOST_PORT` in `.env.selfhost`), use that port in `--api-url`.
+- **Models.** Only models for providers you configured a key for appear — or your local Ollama models. See [Local models with Ollama](./SELF_HOST.md#local-models-with-ollama-no-api-keys). To surface a host-native Ollama in the picker without editing config, launch with `b4m --ollama-host http://localhost:11434`.
+- **Streaming.** The self-host stack does not yet include the realtime websocket gateway; see the [self-host gaps](./SELF_HOST.md#what-you-get-and-dont).
+
+## Pointing at any deployment (AWS, staging, …)
+
+`--api-url` accepts any reachable Bike4Mind URL — a cloud deployment, a staging box, a teammate's tunnel:
+
+```bash
+b4m --api-url https://app.your-company.example.com
+b4m --reset-api      # go back to the built-in default
+```
+
+## Switching between environments
+
+| Action | Command |
+| --- | --- |
+| Hosted production | `b4m --prod` |
+| Local dev server (`:3001`) | `b4m --dev` (alias `--local`) |
+| Self-host / custom URL | `b4m --api-url <url>` or in-session `/set-api <url>` |
+| Reset to default | `b4m --reset-api` or `/reset-api` |
+| Show current target | `/api-info` |
+
+Each environment keeps its **own cached login**, so hopping between your hosted account and your self-hosted stack does not force repeated re-authentication. A bare `b4m` always reopens whichever environment you last selected.
+
+## Tool API keys & MCP servers
+
+Some built-in tools (weather, web search, deep research) need provider keys, and you can attach MCP servers for extra capabilities. Both are configured in `~/.bike4mind/config.json` (or, for MCP, via `b4m mcp add …`). See:
+
+- [Tool API keys](./packages/cli/README.md#tool-api-keys)
+- [MCP servers](./packages/cli/README.md#optional-mcp-servers)
+
+## Headless / scripting mode
+
+Run a single query non-interactively — useful in scripts and CI:
+
+```bash
+b4m -p "Summarize CHANGELOG.md" --output-format text
+b4m -p "List the top 3 risks" --output-format json
+b4m -p "…" --output-format stream-json    # NDJSON of thoughts/actions/observations
+```
+
+Add `--dangerously-skip-permissions` to auto-approve tool prompts in an unattended run (use with care). Headless mode honors the same environment selection as interactive mode.
+
+## Troubleshooting
+
+- **Banner says `Unconfigured`** — you're on a fork build with no baked default. Point it somewhere: `b4m --api-url <url>` (or `--prod` on the upstream build).
+- **Can't reach a self-hosted stack** — confirm the app is up (`curl -s -o /dev/null -w '%{http_code}\n' localhost:3000` → `200`) and that you used the right host port. See [self-host troubleshooting](./SELF_HOST.md#troubleshooting).
+- **No sign-in code (self-host)** — the code is emailed to Mailpit, not your inbox. Read it at `http://localhost:8025`.
+- **Auth seems stuck after switching backends** — `--api-url` / `--reset-api` clear tokens for you; if needed, `/logout` then `/login`.
+- **Empty model picker** — no provider key and no local model on that backend. For self-host, set a key in `.env.selfhost` or enable Ollama, then restart the stack.
+- **Native-module errors on install** (`better-sqlite3`, `sharp`) — see [Build Requirements](./packages/cli/README.md#build-requirements).
+- **Deeper diagnosis** — run `b4m --verbose` (or `b4m doctor`); every session also writes a debug log to `~/.bike4mind/debug/`.
+
+---
+
+Need help? Ask in [Discussions](https://github.com/bike4mind/bike4mind/discussions).

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -130,6 +130,18 @@ curl -X POST http://localhost:3000/api/chat \
 
 The same header works as `Authorization: ApiKey <key>`. Keys, scopes, and rate limits are managed per-user in Settings > API Keys.
 
+## Drive it with the CLI (`b4m`)
+
+Prefer the terminal? The [Bike4Mind CLI](./BIKE4MIND_CLI.md) talks to your self-hosted stack directly — the OAuth device-flow and chat APIs ship in the open core, so no hosted account or credits are involved.
+
+```bash
+npm install -g @bike4mind/cli        # requires Node.js 24+
+b4m --api-url http://localhost:3000  # point it at your stack (use your APP_HOST_PORT if remapped)
+b4m                                  # start, then /login — read the sign-in code from Mailpit at :8025
+```
+
+Auth is cached per environment, so you can keep a separate hosted login and switch with `--prod` / `--api-url`. Full guide (hosted **and** self-host, switching, troubleshooting): [**BIKE4MIND_CLI.md**](./BIKE4MIND_CLI.md).
+
 ## Local models with Ollama (no API keys)
 
 Run open-weight models (Qwen, Llama, etc.) on your own hardware with **no provider API keys** and, once a model is pulled, **no internet**. Local models appear in the model picker under a **Local / Self-Hosted** section and work in chat like any other model.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -70,26 +70,73 @@ The CLI will prompt you to authenticate with your Bike4Mind account on first run
 ### CLI Flags
 
 ```bash
-b4m [options]
+b4m [options] ["initial prompt"]
 ```
 
-**Available flags:**
-- `--dev` - Point the CLI at the local dev server (`http://localhost:3001`) and remember it
-- `--prod` - Point the CLI at Bike4Mind production and remember it
-- `--verbose`, `-v` - Show debug logs in console (useful for troubleshooting)
-- `--help`, `-h` - Show help information
-- `--version`, `-V` - Show CLI version
+A bare positional argument seeds **and** submits the first turn while keeping the interactive UI open (e.g. `b4m "summarize the git log"`).
+
+**Environment / API** (see [API Configuration](#api-configuration)):
+
+| Flag | Effect |
+| --- | --- |
+| `--dev` | Point the CLI at the local dev server (`http://localhost:3001`) and remember it. Aliases: `--local`, single-dash forms. |
+| `--prod` | Point the CLI at Bike4Mind production and remember it. Alias: `--production`. |
+| `--api-url <url>` | Point the CLI at **any** instance — a self-hosted stack, an AWS deployment, `http://localhost:3000`, etc. Clears cached auth (bound to the old origin) and exits; run `b4m` again to sign in. |
+| `--reset-api` | Reset the API URL to the built-in default and clear auth, then exit. |
+
+**Session / behavior:**
+
+| Flag | Effect |
+| --- | --- |
+| `--verbose`, `-v` | Show debug logs in the console (also always written to file — see [Debug Logs](#debug-logs)). |
+| `--debug-stream` | Ultra-verbose: log every SSE event (stream-parser debugging). Implies `--verbose`. |
+| `--no-project-config` | Skip loading project-specific config (`.bike4mind/`). |
+| `--add-dir <dir>` | Grant file access to an additional directory. Repeatable. |
+| `--ollama-host <url>` | Add a local Ollama endpoint's models to the picker (e.g. `http://localhost:11434`). |
+| `--no-remote-skills` | Skip fetching remote B4M-web skills for this run (local files only). |
+
+**Headless / non-interactive** (for scripts and CI):
+
+| Flag | Effect |
+| --- | --- |
+| `-p`, `--prompt <query>` | Run a single query non-interactively and exit. |
+| `--output-format <fmt>` | Output when using `-p`: `text` (default), `json`, or `stream-json` (NDJSON of thoughts/actions/observations). |
+| `--dangerously-skip-permissions` | With `-p`, auto-allow all tool permission prompts. Use with caution in CI/CD. |
+
+**Info:**
+
+| Flag | Effect |
+| --- | --- |
+| `--help`, `-h` | Show help. |
+| `--version`, `-V` | Show CLI version. |
+
+> **Host / `claude`-drop-in flags** (`--mcp-config`, `--strict-mcp-config`, `--append-system-prompt`, `--allowedTools`, `--settings`, `--session-id`, `--resume`) are documented under [Running as a `claude` engine inside a host app](#running-as-a-claude-engine-inside-a-host-app).
 
 **Examples:**
 ```bash
+# Point at a self-hosted stack, then sign in
+b4m --api-url http://localhost:3000
+b4m
+
+# One-shot headless query, JSON output
+b4m -p "What is 2+2?" --output-format json
+
 # Run with debug logs visible
 b4m --verbose
 
-# Check version
-b4m --version
+# Seed and submit the first turn, stay interactive
+b4m "review the recent changes"
+```
 
-# Show help
-b4m --help
+### Subcommands
+
+```bash
+b4m mcp list                              # List configured MCP servers
+b4m mcp add <name> -- <command...>        # Add an MCP server
+b4m mcp remove <name>                     # Remove an MCP server
+b4m mcp enable <name> | disable <name>    # Toggle a server on/off
+b4m update                                # Check for and install CLI updates
+b4m doctor                                # Diagnose the CLI installation (Node, registry, ripgrep, native modules)
 ```
 
 ### Switching environments (`--dev` / `--prod`)
@@ -116,31 +163,64 @@ shown in the startup banner (`🌍 API Environment: …`).
 
 ## Commands
 
-While in interactive mode:
+While in interactive mode. This mirrors the registry in `src/config/commands.ts` — run `/help` in a session for the live list (which also includes any custom and project commands).
 
 **Authentication:**
 - `/login` - Authenticate with your B4M account
 - `/logout` - Clear authentication and sign out
 - `/whoami` - Show current authenticated user
 
-**Session Management:**
+**Session management:**
 - `/save <name>` - Save current session
-- `/resume` - List and resume saved sessions
+- `/resume` (alias `/sessions`) - List and resume saved sessions
+- `/clear` (alias `/new`) - Start a new session
+- `/compact [instructions]` - Compact the conversation into a new session
+- `/context` - Show context-window usage
+- `/usage` - Show credit usage and balance
 
-**API Configuration:**
-- `/set-api <url>` - Connect to self-hosted Bike4Mind instance
-- `/reset-api` - Reset to Bike4Mind main service
+**API configuration:**
+- `/set-api <url>` - Connect to a self-hosted / custom Bike4Mind instance
+- `/reset-api` - Reset to the Bike4Mind main service
 - `/api-info` - Show current API configuration
 
-**Tool Permissions:**
-- `/trust <tool-name>` - Trust a tool (won't ask permission again)
-- `/untrust <tool-name>` - Remove tool from trusted list
-- `/trusted` - List all trusted tools
+**Files & checkpoints:**
+- `/add-dir <path>` / `/remove-dir <path>` / `/dirs` - Manage accessible directories
+- `/undo` - Undo the last file change
+- `/checkpoints` - List file restore points
+- `/restore <number>` - Restore files to a checkpoint
+- `/diff [number]` - Diff current state against a checkpoint
+- `/rewind` - Rewind the conversation to a previous point
+
+**Tool permissions:**
+- `/trust <tool-name>` / `/untrust <tool-name>` / `/trusted` - Manage auto-approved tools
+
+**Sandbox** (OS-level isolation for `bash`):
+- `/sandbox` - Show sandbox status and configuration
+- `/sandbox:enable` / `/sandbox:disable` - Toggle the sandbox
+- `/sandbox:mode <auto-allow|permissions>` - Set enforcement mode
+- `/sandbox:trust-domain <domain> [...]` / `/sandbox:domains` - Manage the network allowlist
+- `/sandbox:violations [count]` / `/sandbox:violations:clear` - Inspect / clear violations
+
+**MCP & agents:**
+- `/mcp` (alias `/mcp:list`) - Show MCP server status and connected tools
+- `/agents` (alias `/agents:list`) - List available agents
+- `/agents:new <name>` / `/agents:reload` - Create / reload agent definitions
+
+**Custom commands:**
+- `/commands` - List all custom commands
+- `/commands:new <name>` / `/commands:reload` - Create / reload custom commands
+
+**Durable workflow** (cross-session continuity):
+- `/workflow [decisions|blockers|handoff|review-gates]` - Workflow overview or a section
+- `/decisions` / `/blockers` / `/review-gates` - Shortcuts for the sections above
+- `/handoff [generate|--local]` - Show or generate a session handoff (`--local` = LLM-free snapshot)
 
 **General:**
 - `/help` - Show help
-- `/exit` - Exit CLI
-- `/config` - Show configuration
+- `/config` - Open the interactive configuration editor
+- `/project-config` - Show merged project configuration
+- `/terminal-setup` - Configure Shift+Enter for multi-line input
+- `/exit` (alias `/quit`) - Exit the CLI
 
 ## Configuration
 
@@ -169,25 +249,27 @@ launch flags (see [Switching environments](#switching-environments---dev----prod
 They persist your choice and cache auth per-environment. The `/set-api`, `/reset-api`,
 and `/api-info` commands below operate on the same setting from inside a session.
 
-**For Self-Hosted Instances:**
+**For self-hosted / custom instances:**
 
-If your organization runs a self-hosted Bike4Mind instance, connect to it using:
+The CLI can point at **any** Bike4Mind deployment — a self-hosted Docker stack, an AWS deployment, or `http://localhost:3000` — because auth (the OAuth device flow) and the chat API ship in the open core and are served by that instance directly.
+
+From the launch line (clears auth, then exit — run `b4m` again to sign in):
+
+```bash
+b4m --api-url http://localhost:3000              # local self-host Docker stack
+b4m --api-url https://app.your-instance.example.com
+b4m --reset-api                                  # back to the built-in default
+```
+
+Or from inside a session:
 
 ```bash
 /set-api https://app.your-instance.example.com
+/reset-api    # return to the default service
+/api-info     # show the current API configuration
 ```
 
-To return to the main Bike4Mind service:
-
-```bash
-/reset-api
-```
-
-Check your current API configuration:
-
-```bash
-/api-info
-```
+Auth tokens are cached **per environment**, so switching between hosted and self-host does not force a re-login. For an end-to-end walkthrough (hosted **and** self-host, sign-in, credits, troubleshooting), see the top-level [**BIKE4MIND_CLI.md**](../../BIKE4MIND_CLI.md).
 
 ### Tool API Keys
 
@@ -547,7 +629,7 @@ packages/cli/
 │   │   └── ConfigStore.ts
 │   └── index.tsx         # Main entry point
 └── bin/
-    └── bike4mind-cli.js  # Executable
+    └── bike4mind-cli.mjs  # Executable (source/dist auto-detect + flag parsing)
 ```
 
 ## Dependencies

--- a/packages/cli/src/commands/doctorCommand.ts
+++ b/packages/cli/src/commands/doctorCommand.ts
@@ -27,13 +27,13 @@ export async function handleDoctorCommand(): Promise<void> {
   // 1. Node.js version
   const nodeVersion = process.version;
   const nodeMajor = parseInt(nodeVersion.slice(1).split('.')[0], 10);
-  if (nodeMajor >= 18) {
-    results.push({ name: 'Node.js version', status: 'pass', message: `${nodeVersion} (>= 18 required)` });
+  if (nodeMajor >= 24) {
+    results.push({ name: 'Node.js version', status: 'pass', message: `${nodeVersion} (>= 24 required)` });
   } else {
     results.push({
       name: 'Node.js version',
       status: 'fail',
-      message: `${nodeVersion} (>= 18 required, please upgrade)`,
+      message: `${nodeVersion} (>= 24 required, please upgrade)`,
     });
   }
 


### PR DESCRIPTION
## Description

The open-core self-hosting docs never mentioned the CLI, and the CLI's own reference had drifted far behind the source (5 of ~18 flags, 14 of ~37 slash commands documented). This PR makes the `b4m` docs accurate and gives self-hosters a proper end-to-end guide.

Investigation confirmed the mechanism already works — the CLI can point at any deployment via `--api-url`, and self-host serves the auth (OAuth device flow) + chat APIs — so this is documentation-first, plus one small DX fix.

Closes #64 (except the optional live-stack verification item, kept as a follow-up).

## Changes

- **New `BIKE4MIND_CLI.md`** (top-level): install, "which backend am I on", hosted usage + credits (`/usage`), full self-host walkthrough (`--api-url http://localhost:3000` → `/login` → Mailpit OTC), pointing at any AWS/staging deployment, per-env auth switching, MCP/keys, headless mode, troubleshooting.
- **`SELF_HOST.md`**: added a "Drive it with the CLI" section linking the new guide.
- **`packages/cli/README.md`**: rebuilt the flag table from `bin/bike4mind-cli.mjs` (adds `--api-url`, `--reset-api`, headless `-p`/`--output-format`/`--dangerously-skip-permissions`, `--add-dir`, `--ollama-host`, etc.); documented the `mcp`/`update`/`doctor` subcommands; expanded slash commands to the full ~37 from `src/config/commands.ts`; pointed self-hosting bits at the canonical doc; fixed stale `bike4mind-cli.js` → `.mjs`.
- **`packages/cli/src/commands/doctorCommand.ts`** (DX fix): `b4m doctor` reported `Node.js >= 18 required` while `engines` requires `>= 24` (would falsely pass on Node 18–23) — aligned the check and messages to `>= 24`.

## Guide for Testers

This is a docs + one-line-constant PR; no runtime/UI behavior changes.

1. Open `BIKE4MIND_CLI.md`, `SELF_HOST.md`, and `packages/cli/README.md` in the PR's **Files changed** tab. Expected: they render cleanly with no broken headings.
2. Click each inter-doc link (e.g. `SELF_HOST.md` → "Drive it with the CLI" → `BIKE4MIND_CLI.md`; `BIKE4MIND_CLI.md` → `packages/cli/README.md` anchors). Expected: every link resolves to an existing file/section.
3. Cross-check `packages/cli/README.md`'s flag table against `packages/cli/bin/bike4mind-cli.mjs` and the slash-command list against `packages/cli/src/config/commands.ts`. Expected: they match.
4. Review the `doctorCommand.ts` diff. Expected: the only change is `18` → `24` in the check and two message strings.

### What NOT to test

- No app/UI, API, or infra changes — nothing to exercise on staging/preview.
- The optional end-to-end CLI-against-`localhost:3000` run is intentionally out of scope here (tracked as the remaining item on #64).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
