### PR TITLE
chore: scrub lumina5 codename (tier 1 - package metadata)

### DIFF
--- a/b4m-core/auth/package.json
+++ b/b4m-core/auth/package.json
@@ -6,7 +6,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MillionOnMars/lumina5.git",
+    "url": "https://github.com/Bike4Mind/bike4mind.git",
     "directory": "b4m-core/auth"
   },
   "type": "module",

--- a/b4m-core/fab-pipeline/package.json
+++ b/b4m-core/fab-pipeline/package.json
@@ -6,7 +6,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MillionOnMars/lumina5.git",
+    "url": "https://github.com/Bike4Mind/bike4mind.git",
     "directory": "b4m-core/fab-pipeline"
   },
   "type": "module",

--- a/b4m-core/infra/package.json
+++ b/b4m-core/infra/package.json
@@ -6,7 +6,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MillionOnMars/lumina5.git",
+    "url": "https://github.com/Bike4Mind/bike4mind.git",
     "directory": "b4m-core/infra"
   },
   "type": "module",

--- a/b4m-core/llm-adapters/package.json
+++ b/b4m-core/llm-adapters/package.json
@@ -6,7 +6,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MillionOnMars/lumina5.git",
+    "url": "https://github.com/Bike4Mind/bike4mind.git",
     "directory": "b4m-core/llm-adapters"
   },
   "type": "module",

--- a/b4m-core/voice/package.json
+++ b/b4m-core/voice/package.json
@@ -6,7 +6,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/MillionOnMars/lumina5.git",
+    "url": "https://github.com/Bike4Mind/bike4mind.git",
     "directory": "b4m-core/voice"
   },
   "type": "module",


### PR DESCRIPTION
## What

First slice of the `lumina5` codename scrub. The codename appears ~70 files across the public source; the refs fall into distinct risk tiers, so this lands as one PR built up in tiered commits rather than a blind find-replace.

**This commit (tier 1 - safe, zero behavioral impact):**
- Point the `repository` URL in five `@bike4mind/*` package manifests at `Bike4Mind/bike4mind` (they still pointed at the old private repo, and it surfaces on npm).

## Remaining tiers (held pending decisions - see review thread)

- **Tier 2 - CloudWatch metric namespaces (`Lumina5/*`, ~25 files).** Live on both the publish side (crons, handlers, `cloudwatch.ts`, `llm-adapters`) and read side (`infra/alarms.ts`, `dashboard.ts`). Renaming is all-or-nothing and breaks historical-metric continuity. Monitoring migration, not a scrub.
- **Tier 3 - default ops repo slug (`MillionOnMars/lumina5`, ~14 spots).** The SRE/SecOps/LiveOps tooling defaults to our repo. For open-core this should likely become env-only (no baked-in default) rather than a rename - ties to the operational-exclusion work.
- **Tier 4 - Chess `localStorage` keys.** Need a read-old / write-new migration so existing users don't lose saved state.
- Prose comments mentioning the codename: folded in where they're pure prose; skipped where the comment describes actual matching on the literal string.

The notebook-export `platform` field (which shipped the codename into user downloads) is already fixed in the docs-transfer PR.
