### PR TITLE
fix(ci): grant pull-requests: write to Branch Tests publish job (startup failure)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,11 +97,13 @@ jobs:
   publish:
     needs: [check-repository, test]
     if: ${{ needs.check-repository.outputs.should-run == 'true' }}
-    # Reusable-workflow permissions flow from the CALLER: the called comment job
-    # can only use what is granted here (repo default token is read-only).
+    # Reusable-workflow permissions flow from the CALLER: a nested job can only
+    # use what is granted here. snapshot-publish's comment-published-versions job
+    # requests pull-requests: write, so the caller must grant at least that or the
+    # whole run fails at startup with a permissions-mismatch error.
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     uses: ./.github/workflows/snapshot-publish.yaml
     secrets:


### PR DESCRIPTION
## Problem

The `Branch Tests` workflow (`.github/workflows/test.yaml`) has failed at **startup on every branch push** since this repo was created - it has never once succeeded here. It triggers on `b4m-core/**` / `packages/cli/**` / `infra/**` changes, so it surfaces on most feature branches.

Root cause: the `publish` job calls the local reusable workflow `snapshot-publish.yaml`, whose `comment-published-versions` job declares `permissions: pull-requests: write`. The caller only granted `pull-requests: read`. A nested (reusable) job can't request more than the caller grants, so GitHub rejects the run at startup with:

> The nested job 'comment-published-versions' is requesting 'pull-requests: write', but is only allowed 'pull-requests: read'.

Because reusable-workflow calls are validated at startup **regardless of the `if:` guard**, the whole run failed even though `publish` would be skipped on most branches.

## Fix

Grant `pull-requests: write` in the `publish` caller's `permissions` block so it covers what the nested comment job needs. Audited the other reusable job (`snapshot-publish`) - it declares no `permissions` block, so it inherits the caller grant with no further mismatch.

## Not to be confused with #6

This is a **local** reusable-workflow permissions bug. #6 tracks a separate concern: the **cross-repo** `Bike4Mind/workflow-templates` dependency in `deploy.yml` / `cleanup.yml`. Different fix, different PR.

## Verifying

`test.yaml` doesn't trigger on `.github/**` changes, so it won't self-run on this branch. Once merged, the next `b4m-core/**` push runs `Branch Tests` past startup (it will then hit the repo-guard and run/skip normally). The permissions mismatch was the sole startup error (confirmed from the run annotation).
