### PR TITLE
ci: inline workflow-templates so the public repo is self-contained

### DIFF
--- a/.github/actions/sst-remove-idempotent/action.yml
+++ b/.github/actions/sst-remove-idempotent/action.yml
@@ -1,0 +1,133 @@
+name: 'SST Remove (Idempotent)'
+description: 'Removes an SST environment gracefully. Unlocks any stale state lock first, treats "stage not found" as success, and retries once if a lock is acquired mid-flight.'
+inputs:
+  stage:
+    description: 'SST stage name to remove'
+    required: true
+  capture_mongodb_uri:
+    description: 'Whether to capture MongoDB URI before removal'
+    required: false
+    default: 'true'
+outputs:
+  mongodb_uri:
+    description: 'MongoDB URI captured before removal (if enabled)'
+    value: ${{ steps.capture_secrets.outputs.mongodb_uri }}
+  environment_existed:
+    description: 'Whether the environment existed (true/false)'
+    value: ${{ steps.remove.outputs.existed }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Capture MongoDB URI from SST secrets
+      id: capture_secrets
+      if: inputs.capture_mongodb_uri == 'true'
+      shell: bash
+      run: |
+        echo "Capturing MongoDB URI from SST secrets..."
+        MONGODB_URI=$(pnpm sst secret list --stage ${{ inputs.stage }} 2>/dev/null | grep "MONGODB_URI" | sed 's/^MONGODB_URI[[:space:]]*=[[:space:]]*//' | sed 's/^MONGODB_URI[[:space:]]*//' || true)
+
+        if [ -n "$MONGODB_URI" ]; then
+          echo "::add-mask::$MONGODB_URI"
+          echo "mongodb_uri=$MONGODB_URI" >> $GITHUB_OUTPUT
+          echo "✅ Successfully captured MongoDB URI"
+        else
+          echo "⚠️  WARNING: Could not retrieve MONGODB_URI (stage may not exist)"
+          echo "mongodb_uri=" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Unlock stale SST state (if any)
+      shell: bash
+      env:
+        STAGE: ${{ inputs.stage }}
+      run: |
+        # Always attempt unlock first. sst unlock is idempotent: it succeeds
+        # whether or not a lock exists. This handles the common case where a
+        # previous deploy was interrupted (PR closed mid-run, runner died,
+        # quota hit) and never released the lock - leaving subsequent removes
+        # to fail with "Locked  A concurrent update was detected on the app".
+        echo "Pre-emptive unlock for stage ${STAGE}..."
+        pnpm sst unlock --stage "${STAGE}" || echo "Unlock returned non-zero (likely no lock present); continuing"
+
+    - name: Remove SST environment (idempotent)
+      id: remove
+      shell: bash
+      env:
+        STAGE: ${{ inputs.stage }}
+      run: |
+        # Composite actions inherit `set -e -o pipefail` from the GitHub
+        # runner's bash invocation. We capture sst's stdout/stderr inside
+        # `$(...)`, and a non-zero sst exit would trigger errexit before we
+        # get to inspect the output. We handle exit codes explicitly below,
+        # so disable errexit for this block.
+        set +e
+        attempt_remove() {
+          # Captures stdout+stderr to allow output inspection. Returns non-zero
+          # on either a non-zero sst exit OR a "✕ Failed" / "| Error" marker
+          # in the output. SST sometimes reports resource-level failures in
+          # its progress UI while still exiting 0 (see Starlight pr46 cleanup:
+          # DeleteAuthorizer ConflictException, sst exit 0). Without this
+          # parse, the cleanup workflow lies about success.
+          OUTPUT=$(pnpm sst remove --stage "${STAGE}" --yes 2>&1)
+          REMOVE_EXIT=$?
+          echo "$OUTPUT"
+          if [ "$REMOVE_EXIT" -ne 0 ]; then
+            return "$REMOVE_EXIT"
+          fi
+          if echo "$OUTPUT" | grep -qE '✕[[:space:]]+Failed|^\|[[:space:]]+Error'; then
+            echo "::warning::sst remove exited 0 but reported a resource failure; treating as failure."
+            return 1
+          fi
+          return 0
+        }
+
+        echo "Removing SST environment: ${STAGE}..."
+        # Capture attempt_remove's exit code directly. We can't use
+        # `if attempt_remove; then ... fi; EXIT_CODE=$?` because bash
+        # returns 0 from a skipped `if/fi` block, masking the real failure
+        # (this is exactly how the Starlight pr46 cleanup ended up reporting
+        # "exit code: 0" while the workflow showed ✕ Failed earlier).
+        attempt_remove
+        EXIT_CODE=$?
+
+        if [ "$EXIT_CODE" -eq 0 ]; then
+          echo "✅ Preview environment removed successfully"
+          echo "existed=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Idempotency: "Stage not found" means nothing to clean up.
+        if echo "$OUTPUT" | grep -q "Stage not found"; then
+          echo "ℹ️  Stage ${STAGE} does not exist - nothing to clean up"
+          echo "existed=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Lock race: a deploy acquired the lock between our pre-unlock and
+        # this remove call. Force-unlock and retry once. If it's still locked
+        # after that, a concurrent deploy is actively running and we should
+        # surface the failure rather than fight it.
+        if echo "$OUTPUT" | grep -q "Locked"; then
+          echo "⚠️  Stage ${STAGE} was locked mid-flight. Force-unlocking and retrying once..."
+          pnpm sst unlock --stage "${STAGE}" || true
+          attempt_remove
+          EXIT_CODE=$?
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "✅ Preview environment removed successfully on retry"
+            echo "existed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if echo "$OUTPUT" | grep -q "Stage not found"; then
+            echo "ℹ️  Stage ${STAGE} disappeared between attempts - treating as removed"
+            echo "existed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+        fi
+
+        echo "❌ Failed to remove preview environment (exit code: $EXIT_CODE)"
+        # Belt-and-suspenders: guarantee a non-zero exit even if EXIT_CODE
+        # somehow ended up at 0. Without this, future regressions of the
+        # if/fi-$? trap would silently re-introduce the orphan-on-failure bug.
+        if [ "$EXIT_CODE" -eq 0 ]; then
+          EXIT_CODE=1
+        fi
+        exit "$EXIT_CODE"

--- a/.github/actions/verify-pr-open/action.yml
+++ b/.github/actions/verify-pr-open/action.yml
@@ -1,0 +1,24 @@
+name: 'Verify PR is Open'
+description: 'Checks if a pull request is still open before proceeding with deployment'
+inputs:
+  pr_number:
+    description: 'Pull request number'
+    required: true
+  github_token:
+    description: 'GitHub token with PR read access'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Check PR state
+      shell: bash
+      run: |
+        PR_STATE=$(gh pr view ${{ inputs.pr_number }} --json state --jq '.state')
+        if [ "$PR_STATE" != "OPEN" ]; then
+          echo "❌ PR #${{ inputs.pr_number }} is no longer open (state: $PR_STATE)"
+          echo "Deployment cancelled to prevent deploying a closed/merged PR."
+          exit 1
+        fi
+        echo "✅ PR #${{ inputs.pr_number }} is still open. Proceeding with deployment."
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}

--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -539,7 +539,7 @@ jobs:
 
       - name: Verify PR is still open
         if: steps.cfg.outputs.is_preview == 'true' && inputs.pr_number != ''
-        uses: Bike4Mind/workflow-templates/.github/actions/verify-pr-open@main
+        uses: ./.github/actions/verify-pr-open
         with:
           pr_number: ${{ inputs.pr_number }}
           github_token: ${{ github.token }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -207,7 +207,7 @@ jobs:
           echo "Database cleanup succeeded."
 
       - name: Remove preview environment
-        uses: Bike4Mind/workflow-templates/.github/actions/sst-remove-idempotent@main
+        uses: ./.github/actions/sst-remove-idempotent
         with:
           stage: pr${{ github.event.number }}
         env:
@@ -265,7 +265,7 @@ jobs:
     name: Notify Cleanup Failure
     needs: cleanup-preview
     if: always() && (needs.cleanup-preview.result == 'failure' || needs.cleanup-preview.result == 'cancelled')
-    uses: Bike4Mind/workflow-templates/.github/workflows/notify-cleanup-failure.yml@main
+    uses: ./.github/workflows/notify-cleanup-failure.yml
     with:
       pr_number: '${{ github.event.number }}'
       pr_title: '${{ github.event.pull_request.title }}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1069,7 +1069,7 @@ jobs:
     name: Notify Production Failure
     needs: deploy
     if: always() && (needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled') && github.ref == 'refs/heads/prod'
-    uses: Bike4Mind/workflow-templates/.github/workflows/slack-notify.yml@main
+    uses: ./.github/workflows/slack-notify.yml
     with:
       status: ${{ needs.deploy.result }}
       environment: 'Production'

--- a/.github/workflows/notify-cleanup-failure.yml
+++ b/.github/workflows/notify-cleanup-failure.yml
@@ -1,0 +1,113 @@
+name: Notify Preview Cleanup Failure
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'Pull request number'
+        required: true
+        type: string
+      pr_title:
+        description: 'Pull request title'
+        required: false
+        type: string
+        default: ''
+      pr_author:
+        description: 'Pull request author'
+        required: false
+        type: string
+        default: ''
+      pr_url:
+        description: 'Pull request URL'
+        required: false
+        type: string
+        default: ''
+      stage_name:
+        description: 'SST stage name that failed to cleanup'
+        required: true
+        type: string
+      repository:
+        description: 'Repository name'
+        required: false
+        type: string
+        default: ''
+      workflow_run_url:
+        description: 'Workflow run URL'
+        required: false
+        type: string
+        default: ''
+      mention:
+        description: 'Slack mention for notifications'
+        required: false
+        type: string
+        default: '@here'
+    secrets:
+      SLACK_WEBHOOK_URL:
+        description: 'Slack webhook URL for notifications'
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "text": "${{ inputs.mention }} 🚨 Preview Cleanup Failed - PR #${{ inputs.pr_number }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🚨 Preview Environment Cleanup Failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:*\n${{ inputs.repository != '' && inputs.repository || github.repository }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*PR:*\n<${{ inputs.pr_url }}|#${{ inputs.pr_number }}${{ inputs.pr_title != '' && format(' - {0}', inputs.pr_title) || '' }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Stage:*\n`${{ inputs.stage_name }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Author:*\n${{ inputs.pr_author }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "⚠️ *Manual cleanup required* - This environment may be orphaned and consuming AWS resources."
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow Run"
+                      },
+                      "url": "${{ inputs.workflow_run_url != '' && inputs.workflow_run_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}"
+                    }${{ inputs.pr_url != '' && format(',{{"type": "button", "text": {{"type": "plain_text", "text": "View Pull Request"}}, "url": "{0}"}}', inputs.pr_url) || '' }}
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,169 @@
+name: Slack Notification
+
+on:
+  workflow_call:
+    inputs:
+      status:
+        description: 'Status of the workflow (success, failure, cancelled)'
+        required: true
+        type: string
+      environment:
+        description: 'Environment name (production, staging, preview)'
+        required: true
+        type: string
+      workflow_name:
+        description: 'Name of the workflow that triggered this notification'
+        required: true
+        type: string
+      repository:
+        description: 'Repository name (owner/repo)'
+        required: false
+        type: string
+        default: ''
+      branch:
+        description: 'Branch name'
+        required: false
+        type: string
+        default: ''
+      commit_sha:
+        description: 'Commit SHA'
+        required: false
+        type: string
+        default: ''
+      commit_message:
+        description: 'Commit message'
+        required: false
+        type: string
+        default: ''
+      commit_author:
+        description: 'Commit author name'
+        required: false
+        type: string
+        default: ''
+      commit_url:
+        description: 'Commit URL'
+        required: false
+        type: string
+        default: ''
+      workflow_run_url:
+        description: 'Workflow run URL'
+        required: false
+        type: string
+        default: ''
+      mention:
+        description: 'Slack mention (e.g., "@channel", "<!subteam^ID|@group>", or "" for no mention)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      SLACK_WEBHOOK_URL:
+        description: 'Slack webhook URL for notifications'
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine notification emoji and text
+        id: message
+        run: |
+          case "${{ inputs.status }}" in
+            success)
+              echo "emoji=✅" >> $GITHUB_OUTPUT
+              echo "status_text=Succeeded" >> $GITHUB_OUTPUT
+              ;;
+            failure)
+              echo "emoji=🚨" >> $GITHUB_OUTPUT
+              echo "status_text=Failed" >> $GITHUB_OUTPUT
+              ;;
+            cancelled)
+              echo "emoji=⚠️" >> $GITHUB_OUTPUT
+              echo "status_text=Cancelled" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "emoji=ℹ️" >> $GITHUB_OUTPUT
+              echo "status_text=${{ inputs.status }}" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Compute short commit SHA
+        id: short_sha
+        if: inputs.commit_sha != ''
+        run: echo "value=${SHA:0:7}" >> $GITHUB_OUTPUT
+        env:
+          SHA: ${{ inputs.commit_sha }}
+
+      - name: Prepare commit message for JSON
+        id: prepare
+        if: inputs.commit_message != ''
+        run: |
+          COMMIT_MSG=$(cat << 'COMMIT_MSG_EOF'
+          ${{ inputs.commit_message }}
+          COMMIT_MSG_EOF
+          )
+          # First line only, truncated to 200 Unicode code points (not bytes, so emoji
+          # are preserved intact), then JSON-escaped with outer quotes stripped so we
+          # can splice into the payload's mrkdwn string.
+          ESCAPED_MSG=$(printf '%s' "$COMMIT_MSG" | python3 -c '
+          import json, sys
+          lines = sys.stdin.read().strip().splitlines()
+          text = lines[0] if lines else ""
+          if len(text) > 200:
+              text = text[:197] + "..."
+          print(json.dumps(text)[1:-1])
+          ')
+          echo "escaped_message=$ESCAPED_MSG" >> $GITHUB_OUTPUT
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "text": "${{ inputs.mention != '' && format('{0} ', inputs.mention) || '' }}${{ steps.message.outputs.emoji }} ${{ inputs.environment }} - ${{ inputs.workflow_name }} ${{ steps.message.outputs.status_text }}",
+              "blocks": [
+                ${{ inputs.mention != '' && format('{{"type": "section", "text": {{"type": "mrkdwn", "text": "{0}"}}}},', inputs.mention) || '' }}
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ steps.message.outputs.emoji }} ${{ inputs.environment }} - ${{ inputs.workflow_name }} ${{ steps.message.outputs.status_text }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:*\n${{ inputs.repository != '' && inputs.repository || github.repository }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n${{ inputs.branch != '' && inputs.branch || github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Environment:*\n${{ inputs.environment }}"
+                    }
+                    ${{ inputs.commit_url != '' && inputs.commit_sha != '' && format(',{{"type": "mrkdwn", "text": "*Commit:*\n<{0}|{1}>"}}', inputs.commit_url, steps.short_sha.outputs.value) || '' }}
+                    ${{ inputs.commit_author != '' && format(',{{"type": "mrkdwn", "text": "*Author:*\n{0}"}}', inputs.commit_author) || '' }}
+                  ]
+                }
+                ${{ inputs.commit_message != '' && format(',{{"type": "section", "text": {{"type": "mrkdwn", "text": "*Commit Message:*\n{0}"}}}},', steps.prepare.outputs.escaped_message) || ',' }}
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow Run"
+                      },
+                      "url": "${{ inputs.workflow_run_url != '' && inputs.workflow_run_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## What

Removes the last cross-repo workflow dependency. `deploy.yml`, `_deploy-env.yml`, and `cleanup.yml` called reusable workflows / composite actions from `Bike4Mind/workflow-templates@main`. This inlines all four into the repo and repoints the call sites to local `./` refs.

## Changes

- Add `.github/workflows/slack-notify.yml` and `.github/workflows/notify-cleanup-failure.yml` (copied verbatim from the templates repo).
- Add composite actions `.github/actions/sst-remove-idempotent/` and `.github/actions/verify-pr-open/`.
- Repoint the four call sites (`deploy.yml`, `_deploy-env.yml`, `cleanup.yml`) from `uses: Bike4Mind/workflow-templates/...@main` to local `uses: ./...`.

## Why

Even public, depending on a second repo staying public is fragile and un-forkable-in-spirit: a fork's CI referenced our templates repo, not theirs. Now the repo has zero cross-repo workflow dependency and `workflow-templates` can be re-privatized or retired.

## Verification

- No `Bike4Mind/workflow-templates` references remain anywhere in `.github/`.
- Both jobs that use a local composite action check out the repo first (`cleanup-preview` at cleanup.yml:86 before :210; `deploy` at _deploy-env.yml:91 before :542). Local reusable workflows resolve from the same commit, no checkout needed.
- Inlined files scanned clean (no secrets, account IDs, or internal refs; secrets pass through from the caller).

Closes #6
