### PR TITLE
chore(cli): point package repository metadata at bike4mind/bike4mind

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,10 +7,10 @@
   "author": "Bike4Mind",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bike4mind/lumina5.git"
+    "url": "git+https://github.com/bike4mind/bike4mind.git"
   },
-  "homepage": "https://github.com/bike4mind/lumina5#readme",
-  "bugs": "https://github.com/bike4mind/lumina5/issues",
+  "homepage": "https://github.com/bike4mind/bike4mind#readme",
+  "bugs": "https://github.com/bike4mind/bike4mind/issues",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Follow-up to #114, which updated `repository.url` on five `@bike4mind/*` package manifests but scoped out `@bike4mind/cli`.

`packages/cli/package.json` still had all three metadata fields pointing at the retired `github.com/bike4mind/lumina5`, which 404s today. `@bike4mind/cli` is published public (`publishConfig.access: "public"`) and was recently documented for external users in #74, so these URLs are exactly the "surfaces on npm" concern #114 cited.

## Changes

Updated three fields to the live public repo:

- `repository.url` → `git+https://github.com/bike4mind/bike4mind.git`
- `homepage` → `https://github.com/bike4mind/bike4mind#readme`
- `bugs` → `https://github.com/bike4mind/bike4mind/issues`

## Impact

npm-registry metadata only. Zero runtime impact.
