### PR TITLE
feat(billing): make credit valuation configurable via environment

### DIFF
--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -741,10 +741,9 @@ jobs:
           # no fallback; empty == only the base opti-knowledge lake. Keeps customer lake identity out
           # of open-core — set NEXT_PUBLIC_PREMIUM_DATA_LAKES to a JSON array of DataLakeConfig.
           NEXT_PUBLIC_PREMIUM_DATA_LAKES: ${{ vars.NEXT_PUBLIC_PREMIUM_DATA_LAKES }}
-          # Credit-valuation knobs (b4m-core/common/src/pricing.ts). Build-time NEXT_PUBLIC_*
-          # inlined into the client AND read by billing lambdas at runtime via
-          # DEFAULT_LAMBDA_ENVIRONMENT. Set both per stage or neither; empty == in-source
-          # defaults. Invalid values are ignored with a warning, never applied partially.
+          # Credit-valuation knobs (b4m-core/common/src/pricing.ts), build-time NEXT_PUBLIC_*
+          # also read by billing lambdas at runtime. Set both per stage or neither; empty ==
+          # in-source defaults, invalid values ignored with a warning.
           NEXT_PUBLIC_PRICE_MARGIN: ${{ vars.NEXT_PUBLIC_PRICE_MARGIN }}
           NEXT_PUBLIC_USD_TO_CREDITS_RATE: ${{ vars.NEXT_PUBLIC_USD_TO_CREDITS_RATE }}
           # Account-tied subscriber-fanout image reference (registry + tag). Set the

--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -741,6 +741,12 @@ jobs:
           # no fallback; empty == only the base opti-knowledge lake. Keeps customer lake identity out
           # of open-core — set NEXT_PUBLIC_PREMIUM_DATA_LAKES to a JSON array of DataLakeConfig.
           NEXT_PUBLIC_PREMIUM_DATA_LAKES: ${{ vars.NEXT_PUBLIC_PREMIUM_DATA_LAKES }}
+          # Credit-valuation knobs (b4m-core/common/src/pricing.ts). Build-time NEXT_PUBLIC_*
+          # inlined into the client AND read by billing lambdas at runtime via
+          # DEFAULT_LAMBDA_ENVIRONMENT. Set both per stage or neither; empty == in-source
+          # defaults. Invalid values are ignored with a warning, never applied partially.
+          NEXT_PUBLIC_PRICE_MARGIN: ${{ vars.NEXT_PUBLIC_PRICE_MARGIN }}
+          NEXT_PUBLIC_USD_TO_CREDITS_RATE: ${{ vars.NEXT_PUBLIC_USD_TO_CREDITS_RATE }}
           # Account-tied subscriber-fanout image reference (registry + tag). Set the
           # SUBSCRIBER_FANOUT_IMAGE repo/org variable to your published image; no brand
           # fallback. Bump the variable to roll forward (no in-tree Dockerfile to maintain).

--- a/b4m-core/common/src/__tests__/pricing.test.ts
+++ b/b4m-core/common/src/__tests__/pricing.test.ts
@@ -8,8 +8,7 @@ const importPricing = async () => {
 
 describe('pricing utils', () => {
   describe('usdToCredits', () => {
-    // Baseline behavior must not depend on ambient env: once the override
-    // feature is in use, dev shells and CI may have these vars set.
+    // Isolate from ambient env: dev shells and CI may set these vars once the feature is in use.
     let usdToCredits: (usd: number) => number;
 
     beforeAll(async () => {
@@ -103,8 +102,7 @@ describe('pricing utils', () => {
     });
 
     it('falls back to defaults when the derived credits-per-USD would round to zero', async () => {
-      // rate misconfigured as credits-per-USD: margin/rate = 0.0006 -> round -> 0,
-      // which would collapse every charge to the 1-credit minimum
+      // margin/rate rounds to 0, which would collapse every charge to 1 credit
       vi.stubEnv('NEXT_PUBLIC_USD_TO_CREDITS_RATE', '5000');
       const pricing = await importPricing();
       expect(pricing.usdToCredits(1)).toBe(5000);

--- a/b4m-core/common/src/__tests__/pricing.test.ts
+++ b/b4m-core/common/src/__tests__/pricing.test.ts
@@ -1,8 +1,28 @@
-import { describe, it, expect } from 'vitest';
-import { usdToCredits } from '../pricing';
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+
+/** Re-imports pricing so module-load env reads see the stubbed vars. */
+const importPricing = async () => {
+  vi.resetModules();
+  return await import('../pricing');
+};
 
 describe('pricing utils', () => {
   describe('usdToCredits', () => {
+    // Baseline behavior must not depend on ambient env: once the override
+    // feature is in use, dev shells and CI may have these vars set.
+    let usdToCredits: (usd: number) => number;
+
+    beforeAll(async () => {
+      vi.stubEnv('NEXT_PUBLIC_PRICE_MARGIN', undefined);
+      vi.stubEnv('NEXT_PUBLIC_USD_TO_CREDITS_RATE', undefined);
+      ({ usdToCredits } = await importPricing());
+    });
+
+    afterAll(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
+
     it('should convert $1 USD to 5000 credits with markup', () => {
       expect(usdToCredits(1)).toBe(5000);
     });
@@ -37,6 +57,74 @@ describe('pricing utils', () => {
       // 50000.00000000001 for $10; ceil would add a phantom credit.
       expect(usdToCredits(10)).toBe(50000);
       expect(usdToCredits(0.0002)).toBe(1);
+    });
+  });
+
+  describe('env-configured valuation', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
+
+    it('uses NEXT_PUBLIC_PRICE_MARGIN and NEXT_PUBLIC_USD_TO_CREDITS_RATE when set', async () => {
+      vi.stubEnv('NEXT_PUBLIC_PRICE_MARGIN', '2');
+      vi.stubEnv('NEXT_PUBLIC_USD_TO_CREDITS_RATE', '0.001');
+      const pricing = await importPricing();
+      expect(pricing.usdToCredits(1)).toBe(2000);
+    });
+
+    it('overrides one knob independently of the other', async () => {
+      vi.stubEnv('NEXT_PUBLIC_PRICE_MARGIN', '6');
+      const pricing = await importPricing();
+      // margin 6 over the default $0.0006/credit rate
+      expect(pricing.usdToCredits(1)).toBe(10000);
+    });
+
+    it.each(['abc', '', '0', '-1'])('falls back to defaults when a var is %j', async raw => {
+      vi.stubEnv('NEXT_PUBLIC_PRICE_MARGIN', raw);
+      vi.stubEnv('NEXT_PUBLIC_USD_TO_CREDITS_RATE', raw);
+      const pricing = await importPricing();
+      expect(pricing.usdToCredits(1)).toBe(5000);
+    });
+
+    it('keeps the phantom-credit guard when values come from env', async () => {
+      vi.stubEnv('NEXT_PUBLIC_PRICE_MARGIN', '3');
+      vi.stubEnv('NEXT_PUBLIC_USD_TO_CREDITS_RATE', '0.0006');
+      const pricing = await importPricing();
+      expect(pricing.usdToCredits(10)).toBe(50000);
+      expect(pricing.usdToCredits(100)).toBe(500000);
+    });
+
+    it('rejects partially numeric values instead of truncating them', async () => {
+      // parseFloat would read "2,5" as 2 and silently bill at the wrong margin
+      vi.stubEnv('NEXT_PUBLIC_PRICE_MARGIN', '2,5');
+      const pricing = await importPricing();
+      expect(pricing.usdToCredits(1)).toBe(5000);
+    });
+
+    it('falls back to defaults when the derived credits-per-USD would round to zero', async () => {
+      // rate misconfigured as credits-per-USD: margin/rate = 0.0006 -> round -> 0,
+      // which would collapse every charge to the 1-credit minimum
+      vi.stubEnv('NEXT_PUBLIC_USD_TO_CREDITS_RATE', '5000');
+      const pricing = await importPricing();
+      expect(pricing.usdToCredits(1)).toBe(5000);
+    });
+
+    it('warns when a set override is rejected', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.stubEnv('NEXT_PUBLIC_PRICE_MARGIN', 'abc');
+      await importPricing();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('NEXT_PUBLIC_PRICE_MARGIN'));
+      warn.mockRestore();
+    });
+
+    it('does not warn when the vars are simply unset', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.stubEnv('NEXT_PUBLIC_PRICE_MARGIN', undefined);
+      vi.stubEnv('NEXT_PUBLIC_USD_TO_CREDITS_RATE', undefined);
+      await importPricing();
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
     });
   });
 });

--- a/b4m-core/common/src/pricing.ts
+++ b/b4m-core/common/src/pricing.ts
@@ -1,23 +1,64 @@
+const DEFAULT_PRICE_MARGIN = 3;
+const DEFAULT_USD_TO_CREDITS_RATE = 0.0006;
+
+/**
+ * Accepts an env override only if it is a strictly parsed positive finite
+ * number. Number() (not parseFloat) so a truncated value like "2,5" is
+ * rejected rather than silently billed as 2. Zero or negative would mean
+ * free or negative billing. Warns on rejected values so a discarded
+ * override is distinguishable from an applied one; unset stays silent.
+ */
+const envNumber = (name: string, raw: string | undefined, fallback: number): number => {
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`[pricing] Ignoring invalid ${name}="${raw}"; using default ${fallback}`);
+  return fallback;
+};
+
+// Literal process.env.NEXT_PUBLIC_* member access is required for Next.js to
+// inline the values into the client bundle (same pattern as constants/dataLakes.ts),
+// keeping displayed prices and server billing on the same value when the var is
+// set in the shared deploy config for both build and runtime. The typeof guard
+// keeps non-Next browser bundles (no process global) importable.
+const hasProcess = typeof process !== 'undefined';
+
 /**
  * Target markup multiple over provider COGS (3 = charge 3x what the provider bills us).
  * Covers payment fees, infrastructure, and provider price wobble.
  */
-const PRICE_MARGIN = 3;
+const PRICE_MARGIN = envNumber(
+  'NEXT_PUBLIC_PRICE_MARGIN',
+  hasProcess ? process.env.NEXT_PUBLIC_PRICE_MARGIN : undefined,
+  DEFAULT_PRICE_MARGIN
+);
 
 /**
  * What a credit actually sells for, anchored to the cheapest purchase route
  * (Professional subscription: $30 / 50,000 credits = $0.0006). Every route
  * then yields at least PRICE_MARGIN over COGS; pricier packs yield more.
- * Must be re-anchored if packs or subscriptions are repriced.
+ * Must be re-anchored (in code or via env) if packs or subscriptions are repriced.
  */
-const USD_TO_CREDITS_RATE = 0.0006;
+const USD_TO_CREDITS_RATE = envNumber(
+  'NEXT_PUBLIC_USD_TO_CREDITS_RATE',
+  hasProcess ? process.env.NEXT_PUBLIC_USD_TO_CREDITS_RATE : undefined,
+  DEFAULT_USD_TO_CREDITS_RATE
+);
 
 /**
  * Integer credits charged per $1 of provider cost. Derived once with rounding
  * because the raw division carries float noise (0.0006 is inexact in binary):
  * naive ceil((usd * 3) / 0.0006) charges a phantom credit on exact multiples.
+ * The derived value is guarded: env values that individually pass validation
+ * can still round to 0 here (margin/rate < 0.5), which would collapse every
+ * charge to the 1-credit minimum.
  */
-const CREDITS_PER_USD_COST = Math.round(PRICE_MARGIN / USD_TO_CREDITS_RATE);
+const CREDITS_PER_USD_COST = (() => {
+  const derived = Math.round(PRICE_MARGIN / USD_TO_CREDITS_RATE);
+  if (Number.isFinite(derived) && derived >= 1) return derived;
+  console.warn(`[pricing] Env-configured margin/rate derive ${derived} credits per USD cost; using defaults`);
+  return Math.round(DEFAULT_PRICE_MARGIN / DEFAULT_USD_TO_CREDITS_RATE);
+})();
 
 /**
  * Converts a USD cost to credits, including markup

--- a/b4m-core/common/src/pricing.ts
+++ b/b4m-core/common/src/pricing.ts
@@ -2,11 +2,9 @@ const DEFAULT_PRICE_MARGIN = 3;
 const DEFAULT_USD_TO_CREDITS_RATE = 0.0006;
 
 /**
- * Accepts an env override only if it is a strictly parsed positive finite
- * number. Number() (not parseFloat) so a truncated value like "2,5" is
- * rejected rather than silently billed as 2. Zero or negative would mean
- * free or negative billing. Warns on rejected values so a discarded
- * override is distinguishable from an applied one; unset stays silent.
+ * Env override: strict positive finite Number only ("2,5" is rejected,
+ * not truncated to 2; zero or negative would bill free or negative).
+ * Warns on rejected values; unset stays silent.
  */
 const envNumber = (name: string, raw: string | undefined, fallback: number): number => {
   if (raw === undefined || raw === '') return fallback;
@@ -16,11 +14,9 @@ const envNumber = (name: string, raw: string | undefined, fallback: number): num
   return fallback;
 };
 
-// Literal process.env.NEXT_PUBLIC_* member access is required for Next.js to
-// inline the values into the client bundle (same pattern as constants/dataLakes.ts),
-// keeping displayed prices and server billing on the same value when the var is
-// set in the shared deploy config for both build and runtime. The typeof guard
-// keeps non-Next browser bundles (no process global) importable.
+// Literal process.env.NEXT_PUBLIC_* access is required for Next.js to inline
+// the values into the client bundle (see constants/dataLakes.ts); the typeof
+// guard keeps non-Next browser bundles (no process global) importable.
 const hasProcess = typeof process !== 'undefined';
 
 /**
@@ -49,9 +45,8 @@ const USD_TO_CREDITS_RATE = envNumber(
  * Integer credits charged per $1 of provider cost. Derived once with rounding
  * because the raw division carries float noise (0.0006 is inexact in binary):
  * naive ceil((usd * 3) / 0.0006) charges a phantom credit on exact multiples.
- * The derived value is guarded: env values that individually pass validation
- * can still round to 0 here (margin/rate < 0.5), which would collapse every
- * charge to the 1-credit minimum.
+ * Guarded because individually valid env values can still derive 0
+ * (margin/rate < 0.5), collapsing every charge to the 1-credit minimum.
  */
 const CREDITS_PER_USD_COST = (() => {
   const derived = Math.round(PRICE_MARGIN / USD_TO_CREDITS_RATE);

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -36,10 +36,8 @@ export const DEFAULT_LAMBDA_ENVIRONMENT = {
   NEXT_PUBLIC_STRIPE_PRICE_LIBONC_PROD: process.env.NEXT_PUBLIC_STRIPE_PRICE_LIBONC_PROD || '',
   NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_TEST: process.env.NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_TEST || '',
   NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_PROD: process.env.NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_PROD || '',
-  // Credit-valuation knobs (b4m-core/common/src/pricing.ts). Same dual nature as the
-  // Stripe ids above: `next build` inlines them into the client bundle, and every
-  // billing lambda reads them from process.env at runtime; both must see one value
-  // or displayed prices diverge from charges. Empty == in-source defaults.
+  // Credit-valuation knobs (b4m-core/common/src/pricing.ts). Same dual nature as
+  // the Stripe ids above: build-time inlined and runtime-read. Empty == in-source defaults.
   NEXT_PUBLIC_PRICE_MARGIN: process.env.NEXT_PUBLIC_PRICE_MARGIN || '',
   NEXT_PUBLIC_USD_TO_CREDITS_RATE: process.env.NEXT_PUBLIC_USD_TO_CREDITS_RATE || '',
   // Enable What's New modal distribution (S3 upload) for main production only

--- a/infra/constants.ts
+++ b/infra/constants.ts
@@ -36,6 +36,12 @@ export const DEFAULT_LAMBDA_ENVIRONMENT = {
   NEXT_PUBLIC_STRIPE_PRICE_LIBONC_PROD: process.env.NEXT_PUBLIC_STRIPE_PRICE_LIBONC_PROD || '',
   NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_TEST: process.env.NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_TEST || '',
   NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_PROD: process.env.NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_PROD || '',
+  // Credit-valuation knobs (b4m-core/common/src/pricing.ts). Same dual nature as the
+  // Stripe ids above: `next build` inlines them into the client bundle, and every
+  // billing lambda reads them from process.env at runtime; both must see one value
+  // or displayed prices diverge from charges. Empty == in-source defaults.
+  NEXT_PUBLIC_PRICE_MARGIN: process.env.NEXT_PUBLIC_PRICE_MARGIN || '',
+  NEXT_PUBLIC_USD_TO_CREDITS_RATE: process.env.NEXT_PUBLIC_USD_TO_CREDITS_RATE || '',
   // Enable What's New modal distribution (S3 upload) for main production only
   // Fork environments should NOT set this - they consume via WHATS_NEW_DISTRIBUTION_URL
   ENABLE_WHATS_NEW_DISTRIBUTION: process.env.ENABLE_WHATS_NEW_DISTRIBUTION || '',


### PR DESCRIPTION
## Description

Credit valuation (markup multiple and USD-per-credit rate) was hardcoded in `b4m-core/common/src/pricing.ts`. This makes both configurable per deployment via `NEXT_PUBLIC_PRICE_MARGIN` and `NEXT_PUBLIC_USD_TO_CREDITS_RATE`, so operators and self-hosts can tune pricing without a source change. Unset vars keep the in-source defaults; no billing behavior changes for existing deployments.

## Changes

- `b4m-core/common/src/pricing.ts`: strict env parsing (positive finite numbers only, warn on rejected values, silent when unset), a guard on the derived credits-per-USD so misconfiguration can never collapse charges to the 1-credit minimum, and a `typeof process` guard for non-Next bundlers.
- `infra/constants.ts`, `.github/workflows/_deploy-env.yml`: plumb both vars to every billing lambda and the client build so all paths bill on one value (same dual-nature pattern as the Stripe price ids).
- `pricing.test.ts`: overrides, single-var independence, invalid-value fallback, derived-value guard, warn behavior; baseline suite now isolated from ambient env.

## Testing

- 839/839 `@bike4mind/common` tests, lint, typecheck.
- Full client build with a sentinel value confirms Next inlines the vars from the prebuilt dist into the client bundle, so displayed prices and billing share the value.

Deploy note: nothing required at merge. To override later, set both repo variables per stage (both or neither).