### PR TITLE
ci(deploy): trust same-repo PRs so internal previews deploy (keep the gate)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -560,6 +560,10 @@ jobs:
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           PR_USER: ${{ github.event.pull_request.user.login }}
           PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          # Fork PRs have no secret access; same-repo PRs are trusted (pushing the
+          # head branch requires write). Mirrors is_trusted_context below / the
+          # deploy job's fork check. Empty/null on non-PR events → treated as fork.
+          PR_IS_FORK: ${{ github.event.pull_request.head.repo.fork == true && 'true' || 'false' }}
           ACTOR: ${{ github.actor }}
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
@@ -609,12 +613,18 @@ jobs:
           is_push_main = event == 'push' and ref == 'refs/heads/main'
           is_push_prod = event == 'push' and ref == 'refs/heads/prod'
           is_pr = event == 'pull_request'
-          # Anyone with read access can open a PR between two existing branches
-          # of this repo. Such a PR is same-repo (not a fork), so it lands in the
-          # trusted lane; without this check it would spawn a real preview stack.
-          # Only PR authors with write-level association get preview deploys.
-          # Tests and the rest of CI still run for everyone.
-          is_trusted_author = pr_author_association in ('OWNER', 'MEMBER', 'COLLABORATOR')
+          is_fork = os.environ.get('PR_IS_FORK', 'false') == 'true'
+          # A trusted author gets a preview deploy; the gate stays to keep untrusted
+          # actors from spawning a real preview stack. Same-repo (non-fork) PRs are
+          # trusted because pushing the head branch requires write access - and this
+          # matches the secret-access boundary GitHub itself enforces (fork PRs get
+          # no secrets/OIDC, so they can't deploy anyway; see is_trusted_context).
+          # Fork PRs fall back to author_association, so a public org member working
+          # from a fork still deploys while an external fork does not. Using the fork
+          # signal (not association alone) is what fixes previews for internal authors
+          # whose org membership is private - GitHub reports those as CONTRIBUTOR, so
+          # the old association-only check skipped their previews. CI runs for everyone.
+          is_trusted_author = (is_pr and not is_fork) or pr_author_association in ('OWNER', 'MEMBER', 'COLLABORATOR')
 
           skip_pr = is_dependabot or is_changeset_release or is_promotion_pr or (is_pr and not is_trusted_author)
 
@@ -632,7 +642,7 @@ jobs:
               # merge_group and skipped PRs => no deploy (test still runs)
 
           if is_pr and not is_trusted_author:
-              print(f"::notice::No preview deploy: PR author association '{pr_author_association}' is not OWNER/MEMBER/COLLABORATOR.")
+              print(f"::notice::No preview deploy: fork PR from an untrusted author (association '{pr_author_association}'). CI still runs.")
 
           deploy_json = json.dumps(deploy)
           print(f"Deploy matrix ({len(deploy)}): {deploy_json}")


### PR DESCRIPTION
## What

Preview deploys now fire for internal PRs, **without removing the safety gate**. The `plan` job keeps gating untrusted actors out of the preview (trusted) lane, but now recognizes same-repo (non-fork) PRs as trusted in addition to `author_association`.

## Why

The gate granted a preview only when `author_association` was OWNER/MEMBER/COLLABORATOR. GitHub only reports `MEMBER` when org membership is **public**, so internal authors with private membership (even org admins) show as `CONTRIBUTOR` and got **no preview** - that's why #115/#116 showed `deploy: skipping`.

## Fix

Trust same-repo PRs: pushing the head branch requires write access, and this mirrors the secret-access boundary GitHub already enforces (fork PRs get no secrets/OIDC and can't deploy regardless - see the existing `is_trusted_context` passed to `_deploy-env.yml`). Fork PRs still fall back to `author_association`, so a public org member working from a fork still deploys while an external fork does not.

Result: `is_trusted_author = (is_pr and not is_fork) or author_association in (OWNER/MEMBER/COLLABORATOR)`. The dependabot / changeset-release / main→prod skips are unchanged.

## Not included

Whether to keep deploy-by-default vs move to on-demand label-gated previews is a **separate** decision (to be surveyed) - deliberately out of scope here.
