### PR TITLE
chore(gitignore): ignore optihashi premium overlay clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,12 @@ packages/premium/pi/
 # clones the pinned ref from premium-overlay.lock.json before pnpm install.
 packages/premium/tavern/
 
+# Premium overlay snapshot for b4m-optihashi, hydrated at pinned ref by the deploy
+# job (clones from premium-overlay.lock.json before pnpm install). Missing entry
+# meant a local `pnpm bootstrap:premium` clone showed as untracked and one bulk
+# `git add` away from publishing private overlay code.
+packages/premium/optihashi/
+
 # Docusaurus
 docs-site/build/
 docs-site/.docusaurus/


### PR DESCRIPTION
## Description

Four of the five premium overlays have per-directory ignore entries in `.gitignore`; `packages/premium/optihashi/` was missed. A locally bootstrapped clone (`pnpm bootstrap:premium`) therefore showed as untracked, one bulk `git add` away from staging private overlay code into the public repo.

## Changes

- `.gitignore`: add `packages/premium/optihashi/` with a comment matching the sibling entries.

## Testing

`git check-ignore` now reports all five overlay paths ignored.