### PR TITLE
fix(client): gate SendToDataLakeModal query behind EnableDataLakes (#83)

### DIFF
--- a/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.test.tsx
@@ -16,11 +16,23 @@ vi.mock('@client/app/utils/filesAPICalls', () => ({
   updateFabFileOnServer: (...args: unknown[]) => updateFabFileOnServer(...args),
 }));
 
+// Mirror React Query's `enabled` semantics: a disabled query never fetches, so it has no data.
+const useDataLakes = vi.fn((enabled: boolean = true) =>
+  enabled
+    ? { data: [{ id: 'lake-1', name: 'Test Lake', datalakeTag: 'lake:test' }], isLoading: false }
+    : { data: undefined, isLoading: false }
+);
+
 vi.mock('@client/app/hooks/data/dataLakeWizard', () => ({
-  useDataLakes: () => ({
-    data: [{ id: 'lake-1', name: 'Test Lake', datalakeTag: 'lake:test' }],
-    isLoading: false,
-  }),
+  useDataLakes: (enabled?: boolean) => useDataLakes(enabled),
+}));
+
+// The component reads the EnableDataLakes flag via useAdminSettingsCache; default it on so
+// the modal renders lakes. Individual tests can override isFeatureEnabled.
+const isFeatureEnabled = vi.fn(() => true);
+
+vi.mock('@client/app/hooks/useAdminSettingsCache', () => ({
+  useAdminSettingsCache: () => ({ isFeatureEnabled }),
 }));
 
 vi.mock('sonner', () => ({
@@ -41,6 +53,9 @@ describe('SendToDataLakeModal', () => {
   beforeEach(() => {
     createFabFileOnServerWithUpload.mockReset();
     updateFabFileOnServer.mockReset();
+    useDataLakes.mockClear();
+    isFeatureEnabled.mockReset();
+    isFeatureEnabled.mockReturnValue(true);
     useSendToDataLakeStore.setState({
       isOpen: true,
       content: 'hello world',
@@ -102,5 +117,22 @@ describe('SendToDataLakeModal', () => {
     screen.getByTestId('send-to-datalake-confirm-btn').click();
 
     await waitFor(() => expect(createFabFileOnServerWithUpload).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not run the lakes query when EnableDataLakes is off, even while open', () => {
+    isFeatureEnabled.mockReturnValue(false);
+
+    render(
+      <TestWrapper>
+        <SendToDataLakeModal />
+      </TestWrapper>
+    );
+
+    // The query gate is `isOpen && isFeatureEnabled('EnableDataLakes')`. The store is open
+    // (set in beforeEach), so with the flag off the hook must still be called with enabled=false
+    // to avoid the 403 on /api/data-lakes.
+    expect(isFeatureEnabled).toHaveBeenCalledWith('EnableDataLakes');
+    expect(useDataLakes).toHaveBeenCalledWith(false);
+    expect(screen.queryByTestId('send-to-datalake-option-lake-1')).toBeNull();
   });
 });

--- a/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.tsx
@@ -20,6 +20,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { KnowledgeType } from '@bike4mind/common';
 import { createFabFileOnServerWithUpload, updateFabFileOnServer } from '@client/app/utils/filesAPICalls';
 import { useDataLakes } from '@client/app/hooks/data/dataLakeWizard';
+import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import { useSendToDataLakeStore } from '@client/app/stores/useSendToDataLakeStore';
 
 /**
@@ -37,10 +38,8 @@ import { useSendToDataLakeStore } from '@client/app/stores/useSendToDataLakeStor
 export default function SendToDataLakeModal() {
   const { isOpen, content, fileName, mimeType, sourceLabel } = useSendToDataLakeStore();
   const closeStore = useSendToDataLakeStore(s => s.close);
-  // This modal is mounted app-wide (singleton) - only fetch lakes once it opens,
-  // otherwise every page fires the admin-gated /api/data-lakes call (a 403 when
-  // the feature is off).
-  const { data: lakes, isLoading } = useDataLakes(isOpen);
+  const { isFeatureEnabled } = useAdminSettingsCache();
+  const { data: lakes, isLoading } = useDataLakes(isOpen && isFeatureEnabled('EnableDataLakes'));
   const queryClient = useQueryClient();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);

--- a/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.tsx
@@ -38,6 +38,9 @@ import { useSendToDataLakeStore } from '@client/app/stores/useSendToDataLakeStor
 export default function SendToDataLakeModal() {
   const { isOpen, content, fileName, mimeType, sourceLabel } = useSendToDataLakeStore();
   const closeStore = useSendToDataLakeStore(s => s.close);
+  // Only fetch once the modal opens AND the feature is entitled - otherwise this app-wide
+  // singleton fires the admin-gated /api/data-lakes call on every page, which 403s when
+  // EnableDataLakes is off. The flag defaults closed while settings load, so no fetch races in.
   const { isFeatureEnabled } = useAdminSettingsCache();
   const { data: lakes, isLoading } = useDataLakes(isOpen && isFeatureEnabled('EnableDataLakes'));
   const queryClient = useQueryClient();


### PR DESCRIPTION
# Pull Request

## Description

Fixes #83.

The app-level singleton `SendToDataLakeModal` (mounted once in `ProviderBundle`) subscribed to the `useDataLakes()` query gated only by the modal's `isOpen` state. It did not check the `EnableDataLakes` feature flag. Because the server gates every `/api/data-lakes*` endpoint on that flag, any fetch made without the entitlement returns `403 FEATURE_DISABLED`, which the axios interceptor logs as a console error.

The rest of the data-lake surface is already flag-gated on the client (e.g. `CreateDataLakeButton` returns `null` when the feature is off). This change closes the remaining asymmetry so the query obeys the same gate.

## Changes

- `SendToDataLakeModal.tsx`: extend the existing `isOpen` gate with `isFeatureEnabled('EnableDataLakes')`, sourced from `useAdminSettingsCache` — the same pattern already used by `CreateDataLakeButton`. The lakes query now runs only when the feature is on **and** the modal is open.

## Guide for Testers

Feature-flag-gated, client-only change. No admin settings, migrations, or backend changes.

**Feature OFF (default) — the bug**
1. Ensure the `EnableDataLakes` admin setting is **off** for your account/environment (this is the default).
2. Log in.
3. Open DevTools, then select both the **Console** and **Network** panels.
4. Navigate to any notebook, e.g. `/notebooks/{sessionId}`.
5. Expected: **no** request to `GET /api/data-lakes` appears in Network, and **no** `FEATURE_DISABLED` error appears in Console.

**Feature ON — no regression**
1. Turn the `EnableDataLakes` admin setting **on** for your account/environment.
2. Trigger the "Send to Data Lake" flow (open the Send to Data Lake modal from any surface that offers it).
3. Expected: the modal opens and the list of data lakes loads. Selecting a lake and clicking **Send** saves the file into the lake as before.

**Regression Checks**
1. With the feature ON, confirm the lakes list still populates when the modal opens (query fires on open, not on page load).
2. With the feature OFF, confirm no data-lake entry points are visible and no `/api/data-lakes` calls fire on any route.

## Additional Information

The query hook `useDataLakes(enabled = true)` already threaded its argument into React Query's `enabled` option, so no hook changes were needed — only the call site was updated. This also avoids a redundant fetch for entitled users until the modal is actually opened.
