### PR TITLE
feat(billing): record usage events for tool-settled charges

### DIFF
--- a/b4m-core/services/src/llm/agents/ServerSubagentOrchestrator.ts
+++ b/b4m-core/services/src/llm/agents/ServerSubagentOrchestrator.ts
@@ -286,6 +286,8 @@ export interface ServerAgentExecutionResult extends AgentResult {
   agentName: string;
   thoroughness: ThoroughnessLevel;
   summary: string;
+  /** Model the delegation actually ran on, for cost attribution by the caller. */
+  model: string;
 }
 
 /**
@@ -520,6 +522,7 @@ export class ServerSubagentOrchestrator {
         agentName: agentDef.name,
         thoroughness: effectiveThoroughness,
         summary,
+        model: effectiveModel,
       };
 
       if (this.deps.tracker && childExecutionId) {
@@ -570,6 +573,7 @@ export class ServerSubagentOrchestrator {
           agentName: agentDef.name,
           thoroughness: effectiveThoroughness,
           summary: `⚠️ **Partial results (timed out after ${Math.round(duration / 1000)}s)**\n\n${summary}`,
+          model: effectiveModel,
         };
 
         if (this.deps.tracker && childExecutionId) {
@@ -762,7 +766,7 @@ export class ServerSubagentOrchestrator {
         this.deps.logger.info(
           `🤖⏸  [SubagentOrchestrator] Parent deadline approaching; handing off subagent "${agentDef.name}" (childExecutionId: ${childExecutionId})`
         );
-        return this.buildPlaceholderResult(agentDef, thoroughness, childExecutionId);
+        return this.buildPlaceholderResult(agentDef, thoroughness, childExecutionId, effectiveModel);
       }
 
       const status = await this.deps.tracker.pollChildStatus(childExecutionId);
@@ -771,10 +775,13 @@ export class ServerSubagentOrchestrator {
       }
 
       if (status.status === 'completed') {
-        return this.buildResultFromChildStatus(agentDef, thoroughness, status, { partial: false });
+        return this.buildResultFromChildStatus(agentDef, thoroughness, status, effectiveModel, { partial: false });
       }
       if (status.status === 'aborted') {
-        return this.buildResultFromChildStatus(agentDef, thoroughness, status, { partial: true, aborted: true });
+        return this.buildResultFromChildStatus(agentDef, thoroughness, status, effectiveModel, {
+          partial: true,
+          aborted: true,
+        });
       }
       if (status.status === 'failed') {
         throw new Error(`Subagent "${agentDef.name}" failed: ${status.error ?? 'unknown error'}`);
@@ -793,7 +800,8 @@ export class ServerSubagentOrchestrator {
   private buildPlaceholderResult(
     agentDef: ServerAgentDefinition,
     thoroughness: ThoroughnessLevel,
-    childExecutionId: string
+    childExecutionId: string,
+    model: string
   ): ServerAgentExecutionResult {
     const summary =
       `**${agentDef.name} Agent — Dispatched**\n\n` +
@@ -803,6 +811,7 @@ export class ServerSubagentOrchestrator {
       agentName: agentDef.name,
       thoroughness,
       summary,
+      model,
       finalAnswer: summary,
       steps: [],
       completionInfo: {
@@ -820,6 +829,7 @@ export class ServerSubagentOrchestrator {
     agentDef: ServerAgentDefinition,
     thoroughness: ThoroughnessLevel,
     status: ChildExecutionStatus,
+    model: string,
     opts: { partial: boolean; aborted?: boolean }
   ): ServerAgentExecutionResult {
     const result = status.result;
@@ -846,6 +856,7 @@ export class ServerSubagentOrchestrator {
       ...partialResult,
       agentName: agentDef.name,
       thoroughness,
+      model,
       summary,
     };
   }

--- a/b4m-core/services/src/llm/sharedToolBuilder.ts
+++ b/b4m-core/services/src/llm/sharedToolBuilder.ts
@@ -20,7 +20,7 @@ import type { ServerSubagentTracker, SubagentHandoffSignal } from './agents/Serv
 import { b4mTools, generateTools, type LlmTools } from './tools/index';
 import type { ToolContext } from './tools/base/types';
 import type { ToolDefinition } from './tools/base/types';
-import { createDelegateToAgentTool } from './tools/implementation/delegateToAgent';
+import { createDelegateToAgentTool, type SubagentUsageMeta } from './tools/implementation/delegateToAgent';
 import { createCoordinateTaskTool } from './tools/implementation/coordinateTask';
 import type { DagDispatcher, DagHandoffSignal } from './tools/implementation/coordinateTask';
 import { extractAndSaveEntitiesFromToolResult, shouldExtractEntitiesFromTool } from '../conversationContextService';
@@ -150,8 +150,8 @@ export interface ToolBuilderCallbacks {
   /** Session ID for entity extraction from tool results */
   sessionId?: string;
 
-  /** Called when delegate_to_agent accumulates credits */
-  onSubagentCredits?: (credits: number) => void;
+  /** Called when delegate_to_agent accumulates credits; meta carries cost attribution when resolvable */
+  onSubagentCredits?: (credits: number, meta?: SubagentUsageMeta) => void;
 
   /** Called when a subagent completes with telemetry */
   onSubagentTelemetry?: (telemetry: unknown) => void;
@@ -329,7 +329,9 @@ export function buildSharedTools(
     logger,
     parentTools,
     getSignal: getAbortSignal,
-    onCredits: callbacks.onSubagentCredits ? (credits: number) => callbacks.onSubagentCredits!(credits) : undefined,
+    onCredits: callbacks.onSubagentCredits
+      ? (credits: number, meta?: SubagentUsageMeta) => callbacks.onSubagentCredits!(credits, meta)
+      : undefined,
     availableModels: deps.precomputed?.models,
     onStatusUpdate: callbacks.onSubagentStatusUpdate
       ? async (status: string) => callbacks.onSubagentStatusUpdate!(status)

--- a/b4m-core/services/src/llm/tools/ToolBuilder.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.ts
@@ -1,4 +1,12 @@
-import { IChatHistoryItemDocument, IMessage, IUserDocument, IOrganizationDocument, ModelInfo } from '@bike4mind/common';
+import {
+  CreditHolderType,
+  IChatHistoryItemDocument,
+  IMessage,
+  IUserDocument,
+  IOrganizationDocument,
+  IUsageEventInput,
+  ModelInfo,
+} from '@bike4mind/common';
 import { type ApiKeyTable, type ICompletionBackend, type ICompletionOptionTools } from '@bike4mind/llm-adapters';
 import type { Logger } from '@bike4mind/observability';
 import { z } from 'zod';
@@ -14,6 +22,50 @@ import {
 import { buildSharedTools } from '../sharedToolBuilder';
 import type { SubagentTelemetryData } from './implementation/delegateToAgent';
 import type { IChatCompletionServiceOptions, QuestStartBodySchema } from '../ChatCompletionFeatures';
+
+/** Usage-event input shared by both tool settlement sites. Analytics only, never billing. */
+export function buildToolUsageEvent(params: {
+  quest: IChatHistoryItemDocument;
+  user: IUserDocument;
+  organization?: IOrganizationDocument | null;
+  provider: string;
+  model: string;
+  costUsd: number;
+  creditsCharged: number;
+  units?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}): IUsageEventInput {
+  const { quest, user, organization } = params;
+  return {
+    requestId: quest.id,
+    userId: user.id,
+    ownerId: organization ? organization.id : user.id,
+    ownerType: organization ? CreditHolderType.Organization : CreditHolderType.User,
+    sessionId: quest.sessionId,
+    feature: 'tool',
+    provider: params.provider,
+    model: params.model,
+    inputTokens: params.inputTokens ?? 0,
+    outputTokens: params.outputTokens ?? 0,
+    cachedInputTokens: 0,
+    cacheWriteTokens: 0,
+    units: params.units,
+    costUsd: params.costUsd,
+    creditsCharged: params.creditsCharged,
+    status: 'ok',
+  };
+}
+
+/** Fire-and-forget dual-write: a failed analytics record must never throw into billing. */
+export function recordToolUsageEvent(
+  db: IChatCompletionServiceOptions['db'],
+  logger: Logger,
+  toolName: string,
+  event: IUsageEventInput
+): void {
+  db.usageEvents?.record(event).catch(err => logger.warn(`[toolUsageEvent] failed for ${toolName}:`, err));
+}
 
 type SendStatusUpdate = (
   q: IChatHistoryItemDocument,
@@ -421,7 +473,7 @@ export class ToolBuilder {
               const modelInfo = availableModels.find(m => m.id === toolModel);
               if (!modelInfo) return;
 
-              const creditsUsed = await validateUserCredits(
+              const { requiredCredits: creditsUsed, usdCost } = await validateUserCredits(
                 this.deps.user,
                 modelInfo,
                 n || 1,
@@ -433,6 +485,21 @@ export class ToolBuilder {
               this.deps.toolCreditsMap.set(toolName, creditsUsed);
               quest.creditsUsed = (quest.creditsUsed ?? 0) + creditsUsed;
               await saveQuest(quest);
+              recordToolUsageEvent(
+                this.deps.db,
+                this.deps.logger,
+                toolName,
+                buildToolUsageEvent({
+                  quest,
+                  user: this.deps.user,
+                  organization,
+                  provider: modelInfo.backend,
+                  model: toolModel,
+                  costUsd: usdCost,
+                  creditsCharged: creditsUsed,
+                  units: n || 1,
+                })
+              );
             }
           }
         },
@@ -482,8 +549,27 @@ export class ToolBuilder {
           return undefined; // Use default simplified result
         },
         sessionId: quest.sessionId,
-        onSubagentCredits: credits => {
+        onSubagentCredits: (credits, meta) => {
           this.deps.toolCreditsMap.set('delegate_to_agent', credits);
+          // No meta == model unresolvable; skip rather than fabricate a zero-cost event.
+          if (meta) {
+            recordToolUsageEvent(
+              this.deps.db,
+              this.deps.logger,
+              'delegate_to_agent',
+              buildToolUsageEvent({
+                quest,
+                user: this.deps.user,
+                organization,
+                provider: meta.provider,
+                model: meta.model,
+                costUsd: meta.usdCost,
+                creditsCharged: credits,
+                inputTokens: meta.inputTokens,
+                outputTokens: meta.outputTokens,
+              })
+            );
+          }
         },
         onSubagentTelemetry: telemetryData => {
           const typed = telemetryData as SubagentTelemetryData;

--- a/b4m-core/services/src/llm/tools/ToolBuilder.usageEvents.test.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.usageEvents.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CreditHolderType } from '@bike4mind/common';
+import { buildToolUsageEvent, recordToolUsageEvent } from './ToolBuilder';
+
+const quest = { id: 'q1', sessionId: 's1' } as never;
+const user = { id: 'u1' } as never;
+
+describe('buildToolUsageEvent', () => {
+  it('maps an image tool charge to a tool usage event owned by the user', () => {
+    const event = buildToolUsageEvent({
+      quest,
+      user,
+      provider: 'openai',
+      model: 'gpt-image-1',
+      costUsd: 0.08,
+      creditsCharged: 400,
+      units: 2,
+    });
+    expect(event).toMatchObject({
+      requestId: 'q1',
+      userId: 'u1',
+      ownerId: 'u1',
+      ownerType: CreditHolderType.User,
+      sessionId: 's1',
+      feature: 'tool',
+      provider: 'openai',
+      model: 'gpt-image-1',
+      inputTokens: 0,
+      outputTokens: 0,
+      units: 2,
+      costUsd: 0.08,
+      creditsCharged: 400,
+      status: 'ok',
+    });
+  });
+
+  it('attributes the charge to the organization when one is present', () => {
+    const event = buildToolUsageEvent({
+      quest,
+      user,
+      organization: { id: 'org1' } as never,
+      provider: 'bedrock',
+      model: 'm',
+      costUsd: 1,
+      creditsCharged: 5000,
+    });
+    expect(event.ownerId).toBe('org1');
+    expect(event.ownerType).toBe(CreditHolderType.Organization);
+  });
+
+  it('carries subagent token counts when provided', () => {
+    const event = buildToolUsageEvent({
+      quest,
+      user,
+      provider: 'bedrock',
+      model: 'm',
+      costUsd: 0.01,
+      creditsCharged: 50,
+      inputTokens: 1200,
+      outputTokens: 300,
+    });
+    expect(event.inputTokens).toBe(1200);
+    expect(event.outputTokens).toBe(300);
+    expect(event.units).toBeUndefined();
+  });
+});
+
+describe('recordToolUsageEvent', () => {
+  it('swallows a rejected record and warns instead of throwing into billing', async () => {
+    const warn = vi.fn();
+    const db = { usageEvents: { record: vi.fn().mockRejectedValue(new Error('db down')) } };
+    recordToolUsageEvent(db as never, { warn } as never, 'image_generation', {} as never);
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+    expect(db.usageEvents.record).toHaveBeenCalled();
+  });
+
+  it('is a no-op when the usage events repository is absent', () => {
+    expect(() => recordToolUsageEvent({} as never, { warn: vi.fn() } as never, 'x', {} as never)).not.toThrow();
+  });
+});

--- a/b4m-core/services/src/llm/tools/base/utils.test.ts
+++ b/b4m-core/services/src/llm/tools/base/utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ImageModels, ModelInfo } from '@bike4mind/common';
+import { usdToCredits } from '@bike4mind/utils';
+import { validateUserCredits } from './utils';
+
+const logger = { updateMetadata: vi.fn(), error: vi.fn() } as never;
+const fluxModel = { id: ImageModels.FLUX_PRO } as ModelInfo;
+
+describe('validateUserCredits', () => {
+  it('returns the n-scaled usd cost alongside the credits charged', async () => {
+    const user = { id: 'u1', currentCredits: 1_000_000 };
+    const { requiredCredits, usdCost } = await validateUserCredits(user, fluxModel, 2, { model: fluxModel.id }, logger);
+    expect(usdCost).toBeGreaterThan(0);
+    expect(requiredCredits).toBe(usdToCredits(usdCost));
+  });
+
+  it('still rejects when the owner lacks credits', async () => {
+    const user = { id: 'u1', currentCredits: 0 };
+    await expect(validateUserCredits(user, fluxModel, 1, { model: fluxModel.id }, logger)).rejects.toThrow(
+      /enough personal credits/
+    );
+  });
+});

--- a/b4m-core/services/src/llm/tools/base/utils.ts
+++ b/b4m-core/services/src/llm/tools/base/utils.ts
@@ -13,7 +13,7 @@ export async function validateUserCredits(
   input: CostInput,
   logger: Logger,
   organization?: IOrganizationDocument | null
-): Promise<number> {
+): Promise<{ requiredCredits: number; usdCost: number }> {
   let userCredits = user.currentCredits ?? 0;
 
   if (organization) {
@@ -54,7 +54,8 @@ export async function validateUserCredits(
     throw new Error('Model not supported');
   }
 
-  const requiredCredits = usdToCredits(usdCost * n);
+  const totalUsdCost = usdCost * n;
+  const requiredCredits = usdToCredits(totalUsdCost);
 
   if (!Number.isFinite(requiredCredits)) {
     throw new UnprocessableEntityError(`Unable to compute credit cost for model "${modelInfo.id}" (got ${usdCost}).`);
@@ -67,5 +68,6 @@ export async function validateUserCredits(
     );
   }
 
-  return requiredCredits;
+  // usdCost is the n-scaled total so it describes the same quantity as requiredCredits.
+  return { requiredCredits, usdCost: totalUsdCost };
 }

--- a/b4m-core/services/src/llm/tools/implementation/delegateToAgent.ts
+++ b/b4m-core/services/src/llm/tools/implementation/delegateToAgent.ts
@@ -2,7 +2,7 @@ import type { ApiKeyTable, ICompletionBackend, ICompletionOptionTools } from '@b
 import { getLlmByModel } from '@bike4mind/llm-adapters';
 import type { Logger } from '@bike4mind/observability';
 import type { ThoroughnessLevel } from '@bike4mind/agents';
-import type { ModelInfo } from '@bike4mind/common';
+import { getTextModelCost, type ModelInfo } from '@bike4mind/common';
 import { ServerSubagentOrchestrator } from '../../agents/ServerSubagentOrchestrator';
 import type { ServerSubagentTracker, SubagentHandoffSignal } from '../../agents/ServerSubagentOrchestrator';
 import { ServerAgentStore } from '../../agents/ServerAgentStore';
@@ -42,6 +42,19 @@ export interface SubagentTelemetryData {
 }
 
 /**
+ * Cost attribution for a completed delegation, so the caller can record a
+ * usage event. Absent when the model can't be resolved; callers must not
+ * fabricate an event from zeros.
+ */
+export interface SubagentUsageMeta {
+  usdCost: number;
+  provider: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
  * Dependencies for creating the delegate_to_agent tool
  */
 export interface DelegateToAgentToolDeps {
@@ -57,7 +70,7 @@ export interface DelegateToAgentToolDeps {
    */
   getSignal?: () => AbortSignal | undefined;
   /** Callback to report credits used by the agent delegation */
-  onCredits?: (credits: number) => void;
+  onCredits?: (credits: number, meta?: SubagentUsageMeta) => void;
   /** Available models for credit computation */
   availableModels?: ModelInfo[];
   /** Callback to send status updates to the client during subagent execution */
@@ -303,7 +316,21 @@ export function createDelegateToAgentTool(deps: DelegateToAgentToolDeps): ICompl
         const durationMs = Date.now() - startTime;
 
         if (result.completionInfo.totalCredits && deps.onCredits) {
-          deps.onCredits(result.completionInfo.totalCredits);
+          const modelInfo = deps.availableModels?.find(m => m.id === result.model);
+          const inputTokens = result.completionInfo.totalInputTokens ?? 0;
+          const outputTokens = result.completionInfo.totalOutputTokens ?? 0;
+          deps.onCredits(
+            result.completionInfo.totalCredits,
+            modelInfo
+              ? {
+                  usdCost: getTextModelCost(modelInfo, inputTokens, outputTokens),
+                  provider: modelInfo.backend,
+                  model: result.model,
+                  inputTokens,
+                  outputTokens,
+                }
+              : undefined
+          );
         }
 
         // Report telemetry for successful execution


### PR DESCRIPTION
## Description

Closes #121.

Tool-invoked provider calls charge credits but write no usage event, so the margin views miss them (the chat settlement event deliberately records text-only cost and credits). This dual-writes a `feature: 'tool'` event at both tool settlement sites. Fire-and-forget; no billing behavior change.

## Changes

- `tools/base/utils.ts`: `validateUserCredits` returns `{ requiredCredits, usdCost }` (n-scaled) instead of discarding the cost it already computes; single caller updated.
- `tools/ToolBuilder.ts`: shared `buildToolUsageEvent` / `recordToolUsageEvent` helpers; events recorded for `image_generation`/`edit_image` at charge time and for `delegate_to_agent` when cost attribution is resolvable (never fabricated from zeros). Uses the existing `db.usageEvents` injection; no new plumbing.
- `delegateToAgent.ts` + `sharedToolBuilder.ts`: `onCredits`/`onSubagentCredits` widened with an optional `SubagentUsageMeta` (usd cost, provider, model, token counts); backward compatible.
- `ServerSubagentOrchestrator.ts`: execution results now carry the effective `model` for cost attribution.

## Testing

7 new tests (event field mapping, org vs user attribution, subagent token carry-through, rejected record never throws into billing, no-op without the repository). Full `@bike4mind/services` suite 1605 passed; services and client typecheck clean.