### PR TITLE
chore(premium): bump b4m-tavern pin for heartbeat usage-event restore

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -3,5 +3,5 @@
   "b4m-libreoncology": "43707c30d7d8f8ce3c7746711acca1177807fc40",
   "b4m-optihashi": "b2039ec53c54264186a116b06726074f773eabf2",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",
-  "b4m-tavern": "20b3303d8da64425c399bae4000359cdf7388f10"
+  "b4m-tavern": "d69973c5b62c76e0e800218686ae23aaf515ac54"
 }


### PR DESCRIPTION
## Description

**Preview form. do not merge yet.** Moves the b4m-tavern pin to the head of Bike4Mind/b4m-tavern#34 (restores the heartbeat usage-event dual-write lost in the overlay extraction) so the preview environment exercises the change end to end. Will be re-pinned to the merge commit once that PR lands; the main-branch SHA guard enforces this.

## Changes

- `premium-overlay.lock.json`: b4m-tavern `20b3303` to `d69973c` (one commit ahead of current main).

## Testing

- b4m-tavern package typecheck clean with the overlay hydrated at the new SHA.
- Preview deploy on this PR is the end-to-end check (overlay-import breaks only surface in the full hydrated build).

Part of the tool-usage-events chain (#121, with #124).