### PR TITLE
ci: make the validate check merge-queue compatible

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -8,20 +8,33 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
     branches: [main]
+  # Also run on the merge queue so the required "validate" check reports there.
+  # A merge_group has no PR title to lint, so the job no-ops and passes; without
+  # this, enabling a merge queue would hang forever waiting on a check that never
+  # runs on merge_group.
+  merge_group:
+    branches: [main]
 
 permissions:
   pull-requests: read
 
 jobs:
   validate:
-    # Skip forks, dependabot, and Version Packages PRs
-    if: >-
-      github.repository == (vars.CANONICAL_REPO || 'MillionOnMars/lumina5') &&
-      github.actor != 'dependabot[bot]' &&
-      !startsWith(github.head_ref, 'changeset-release/')
+    # Runs on the canonical repo for both pull_request and merge_group, so the
+    # required "validate" check always reports (forks are excluded and can't reach
+    # the merge queue anyway). The actual title lint is gated to real PRs below.
+    if: github.repository == (vars.CANONICAL_REPO || 'MillionOnMars/lumina5')
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Validate PR title (Conventional Commits)
+        # Enforce only on real PRs. Skip on merge_group (no title to lint),
+        # dependabot, and Version Packages PRs — a skipped step still succeeds,
+        # so the required "validate" check stays green in all those cases.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          !startsWith(github.head_ref, 'changeset-release/')
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## What

Makes the required `validate` check (semantic PR title) work under a merge queue, so you can enable "Require merge queue" without it deadlocking — and **without dropping `validate` as a hard gate on PRs**. Best of both.

## Why

Required checks are `validate`, `Run Tests`, `Deploy`. `Run Tests` + `Deploy` come from `deploy.yml`, which already triggers on `merge_group`. But `validate` (from `semantic-pr-title.yml`) ran on `pull_request` only. A merge queue tests each PR on a temporary `merge_group` ref and waits for every required check to report there — so `validate` would never appear and the queue would hang forever.

## Change

- Add `merge_group:` to the workflow triggers.
- Keep the `validate` job running (repo-guarded) on both events, but gate the actual title lint to `github.event_name == 'pull_request'`. On a `merge_group` there's no PR title, so the step is skipped and the job succeeds → the required `validate` check reports green.
- PR-title enforcement on real PRs is unchanged; dependabot / `changeset-release/*` still skip via the step condition (a skipped step still succeeds).

## After this merges

The merge queue is safe to enable: in the `main-protection` ruleset, check **Require merge queue** (merge method = Squash, to satisfy "Require linear history"). No need to remove `validate` from required checks. This kills the "branch out-of-date → Update branch" dance and the redundant preview-deploy re-triggers, and can batch PRs so `main` deploys once instead of per-merge.

## Testing

CI-config change; no test files. YAML parses and the job graph is intact. Behavior verified by reasoning: `merge_group` → step skipped → job green; `pull_request` → lint runs as before.
