### PR TITLE
chore(premium): bump b4m-tavern pin for heartbeat usage-event restore

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -3,5 +3,5 @@
   "b4m-libreoncology": "43707c30d7d8f8ce3c7746711acca1177807fc40",
   "b4m-optihashi": "b2039ec53c54264186a116b06726074f773eabf2",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",
-  "b4m-tavern": "20b3303d8da64425c399bae4000359cdf7388f10"
+  "b4m-tavern": "d69973c5b62c76e0e800218686ae23aaf515ac54"
 }

--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -3,5 +3,5 @@
   "b4m-libreoncology": "43707c30d7d8f8ce3c7746711acca1177807fc40",
   "b4m-optihashi": "b2039ec53c54264186a116b06726074f773eabf2",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",
-  "b4m-tavern": "d69973c5b62c76e0e800218686ae23aaf515ac54"
+  "b4m-tavern": "0a5be6f8cd0fb595ea7f0ad6dd88fd4bb805dd28"
 }

--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -3,5 +3,5 @@
   "b4m-libreoncology": "43707c30d7d8f8ce3c7746711acca1177807fc40",
   "b4m-optihashi": "b2039ec53c54264186a116b06726074f773eabf2",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",
-  "b4m-tavern": "0a5be6f8cd0fb595ea7f0ad6dd88fd4bb805dd28"
+  "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
## Description

Advances the b4m-tavern pin to the merge commit of Bike4Mind/b4m-tavern#34, which restores the heartbeat usage-event dual-write lost in the overlay extraction. That PR has landed, so this pins to its merge commit `2ed2ff9` (now the head of tavern main) and is ready to merge.

## Changes

- `premium-overlay.lock.json`: b4m-tavern `20b3303` to `2ed2ff9` (merge commit of tavern#34).

## Testing

- b4m-tavern package typecheck clean with the overlay hydrated at the new SHA.
- Preview deploy on this PR exercised the change end to end (overlay-import breaks only surface in the full hydrated build).

Part of the tool-usage-events chain (#121, with #132).
