### PR TITLE
docs: replace internal codename in LICENSE Licensed Work parameter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -9,7 +9,7 @@ Parameters
 
 Licensor:             Bike4Mind, Inc.
 
-Licensed Work:        Bike4Mind (the lumina5 repository and the components
+Licensed Work:        Bike4Mind (this repository and the components
                       distributed under this License).
                       The Licensed Work is (c) 2026 Bike4Mind, Inc.
 


### PR DESCRIPTION
# Pull Request

Closes #10

## Description

The LICENSE's **Licensed Work** parameter referenced the internal pre-cut codename ("the lumina5 repository"), which is meaningless or confusing to external readers of the public `Bike4Mind/bike4mind` repository. This PR applies the exact wording suggested in the issue:

> Licensed Work: Bike4Mind (this repository and the components distributed under this License).

Since this is license text, final wording sign-off is Erik's call (acting counsel) per the issue — flagging for his review before merge.

## Changes

- `LICENSE`: reworded the Licensed Work parameter from "the lumina5 repository" to "this repository". One line changed.
- **Not** touched: Change Date, Change License, Additional Use Grant, or any other license parameter (per the issue's "clock/grant unchanged" note).

## Guide for Testers

**What NOT to test:** docs-only change to LICENSE text; there is no runtime surface, UI, or API impact.

1. Open the `LICENSE` file diff in this PR.
2. Expected: exactly one line changed — "the lumina5 repository" is now "this repository"; everything else in the file is untouched.

## Additional Information

While verifying this was the only occurrence, I found other `lumina5` mentions outside the LICENSE (comments in `.gitignore` / `.gitattributes` / `.gitleaksignore`, `.cursorrules`, `flake.nix` description, and a `"platform": "lumina5"` value in `sample-notebook-export.json`). They are outside the scope of #10 (which is specifically about the license text) — can file a follow-up issue if desired.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] AdminSettings / UI-UX / code comments / documentation / telemetry items — N/A (docs-only LICENSE change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
