### PR TITLE
ci(deploy): make preview deploys opt-in via the `preview` label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -60,6 +60,10 @@ Example:
 <!--
 Required for any PR closing a security-labeled issue. Delete this section
 if the PR is not security-related.
+
+Preview deploys are opt-in: add the `preview` label (or comment `/deploy preview`)
+to get a `pr<N>.preview.bike4mind.com` env. Remove the label (or `/deploy-preview off`)
+to stop and tear it down. See CONTRIBUTING.md → "Preview deploys are opt-in".
 -->
 
 - [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)

--- a/.github/variables.md
+++ b/.github/variables.md
@@ -225,13 +225,22 @@ RESOLVED_VARIABLE="$STAGING_VARIABLE"  # Uses staging infrastructure
 
 ## Preview Environment Configuration
 
-Preview environments (PR deployments) automatically use staging infrastructure:
+Preview environments (PR deployments) use staging infrastructure:
 - **VPC**: Uses resolved staging VPC ID
 - **Hosted Zone**: Uses resolved staging hosted zone
 - **ECR Cache**: Uses resolved staging ECR repository
 - **Domain**: Constructed as `pr{PR_NUMBER}.{PREVIEW_SERVER_DOMAIN}`
 
 This ensures preview environments are isolated from production but share staging infrastructure for cost efficiency.
+
+### Opt-in gating (`preview_label`)
+
+Preview deploys are **opt-in**. Each tenant in the `DEPLOY_TENANTS` repo variable carries a `preview_label` field, read by the `plan` job in `deploy.yml`:
+
+- `preview_label: "preview"` (current) — a PR deploys a preview **only** when it carries the `preview` label. No label ⇒ the deploy matrix is empty ⇒ CI runs but no preview is deployed (the required **Deploy** check still reports green).
+- `preview_label: null` — legacy "always deploy a preview on every trusted PR" behavior.
+
+`deploy.yml` also triggers on the `labeled` pull_request event, so adding the label deploys immediately rather than waiting for the next push. Maintainers can toggle the label from a PR comment via the `/deploy preview` (opt-in) and `/deploy-preview off` (opt-out + teardown) commands — see `.github/workflows/deploy-preview-command.yml`. Removing the label tears the preview down (`cleanup.yml`, `unlabeled` trigger). Fork PRs never deploy previews regardless of labels.
 
 ## Preview Domain Calculation
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -7,7 +7,11 @@ on:
     # the PR number, so the rest of this workflow handles arbitrary base refs.
     # Exclude prod-targeted PRs (no preview was created, nothing to clean up).
     branches-ignore: [prod]
-    types: [closed]
+    # closed: the PR is done — tear the preview down.
+    # unlabeled: previews are opt-in via the `preview` label (deploy.yml); removing
+    #   it means "stop previewing this PR", so tear the current preview down too
+    #   (the job `if` below restricts unlabeled teardown to the `preview` label).
+    types: [closed, unlabeled]
 
 env:
   AWS_REGION: us-east-2
@@ -41,7 +45,10 @@ jobs:
     # Skip for: dependabot PRs, main→prod promotion PRs, changeset release PRs
     # Note: use pull_request.user.login instead of github.actor so the check
     # still holds when a human syncs/updates a dependabot PR
+    # Event gate: run on PR close, or when the `preview` label is removed
+    # (opt-out teardown). An `unlabeled` event for any other label is ignored.
     if: |
+      (github.event.action == 'closed' || (github.event.action == 'unlabeled' && github.event.label.name == 'preview')) &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       !(github.event.pull_request.head.ref == 'main' && github.event.pull_request.base.ref == 'prod') &&
       !startsWith(github.event.pull_request.head.ref, 'changeset-release/')

--- a/.github/workflows/deploy-preview-command.yml
+++ b/.github/workflows/deploy-preview-command.yml
@@ -1,0 +1,100 @@
+name: Preview Deploy Command
+
+# Slash command to opt a PR in/out of preview deploys from a comment, instead of
+# clicking the label in the UI. Previews are OFF by default; this is a
+# convenience wrapper around the `preview` label — it does NOT deploy directly.
+#
+#   /deploy preview            -> add the `preview` label  (starts a preview)
+#   /deploy-preview            -> same
+#   /deploy preview off        -> remove the `preview` label (stops future
+#   /deploy-preview off           deploys and tears the current preview down)
+#
+# The label add/remove is performed with a GitHub App token, NOT the default
+# GITHUB_TOKEN: events produced by GITHUB_TOKEN do not trigger further workflow
+# runs, so a token-added label would never fire deploy.yml's `labeled` trigger.
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  toggle-preview:
+    name: Toggle preview label
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
+    # Trust + scope gate (mirrors deploy.yml's fork-safety):
+    #  - must be a comment on a PR (issue_comment fires for issues too);
+    #  - author must have write-level association (OWNER/MEMBER/COLLABORATOR),
+    #    the same set deploy.yml's `plan` job treats as a trusted preview author;
+    #  - body must start with the command. Cheap prefix filter so we don't mint
+    #    an app token for every comment. `contains`/`startsWith` on comment.body
+    #    in `if:` is safe — it is a boolean expression, not a shell.
+    if: >-
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+      (startsWith(github.event.comment.body, '/deploy preview') || startsWith(github.event.comment.body, '/deploy-preview'))
+    permissions:
+      # Fallback token scopes (used only if the app token can't be minted). The
+      # app token below is what actually lets the label change trigger deploys.
+      issues: write
+      pull-requests: write
+    steps:
+      # App identity so the label change triggers deploy.yml / cleanup.yml.
+      # Mirrors cleanup.yml: prefer the MillionOnMars ops app, fall back to the
+      # org release app (present on this repo). Needs Issues: write (or Pull
+      # requests: write) to manage labels.
+      - name: Generate app token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.GH_APP_ID || vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY || secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Add or remove the preview label
+        uses: actions/github-script@v8
+        env:
+          # Read the untrusted comment body via env, never interpolated into a
+          # shell or the script source (script-injection safe).
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          # App token drives the label change so downstream workflows fire; fall
+          # back to the default token (label still applies, but the immediate
+          # deploy/teardown trigger is suppressed — noted in the reply).
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
+          script: |
+            const LABEL = 'preview';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const usedAppToken = !!process.env.APP_TOKEN;
+
+            // First line, lower-cased. `off`/`remove`/`stop`/`down` after the
+            // command means opt-out; anything else means opt-in.
+            const line = (process.env.COMMENT_BODY || '').split('\n')[0].trim().toLowerCase();
+            const isOff = /\b(off|remove|stop|down|teardown|disable)\b/.test(line);
+
+            // 👀 acknowledge the command.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner, repo, comment_id: context.payload.comment.id, content: 'eyes',
+              });
+            } catch (e) { core.info(`reaction failed (non-fatal): ${e.message}`); }
+
+            const suppressedNote = usedAppToken ? '' :
+              '\n\n> Note: the app token was unavailable, so this label change will **not** auto-trigger the deploy/teardown. Push a commit or re-apply via the UI to trigger it.';
+
+            let body;
+            if (isOff) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: LABEL });
+                body = `🧹 Removed the \`${LABEL}\` label. Future pushes to this PR will **not** deploy a preview, and the existing \`pr${issue_number}\` preview will be torn down.` + suppressedNote;
+              } catch (e) {
+                if (e.status === 404) {
+                  body = `ℹ️ The \`${LABEL}\` label was not set — nothing to remove.`;
+                } else { throw e; }
+              }
+            } else {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [LABEL] });
+              body = `🚀 Added the \`${LABEL}\` label — a preview deploy for \`pr${issue_number}\` is starting. Track it in the **Deploy** check on the PR. Comment \`/deploy-preview off\` to stop and tear it down.` + suppressedNote;
+            }
+
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,14 @@ on:
     # prod-targeted PRs — those are the staging→production promotion and
     # `main` already validates them; a separate preview would be redundant.
     branches-ignore: [prod]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `labeled` is included so applying the opt-in `preview` label deploys a
+    # preview immediately, without waiting for the next commit push. Previews
+    # are OFF by default (DEPLOY_TENANTS.<tenant>.preview_label = "preview"):
+    # with the label absent the `plan` job emits an empty matrix and the deploy
+    # is skipped. To avoid spinning up full CI on unrelated label churn (e.g.
+    # `run-e2e`, `stale`), the root `changes` job below skips `labeled` events
+    # whose label is not `preview`.
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     # NOTE: no workflow-level paths-ignore. The `changes` gate below evaluates
     # the per-PR (merge-base) diff and skips test + deploy on non-deployable
     # changes, while still reporting the required Deploy/Run Tests checks (a
@@ -43,6 +50,13 @@ jobs:
   # required checks always have a status to report. Logic + the default
   # exclude list live in the local composite action. Fails open on both.
   changes:
+    # Root of the whole DAG. On a `labeled` event only proceed when the added
+    # label is `preview` (the opt-in gate) — any other label add skips this job,
+    # which cascades to every downstream job (they all transitively need
+    # `changes`), so unrelated label churn doesn't burn a full CI + deploy run.
+    # Non-labeled events (opened/synchronize/reopened/ready_for_review, push,
+    # merge_group) have action != 'labeled' and always run.
+    if: github.event.action != 'labeled' || github.event.label.name == 'preview'
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,15 @@ Two notes specific to fork PRs:
 - CI for first-time contributors requires a maintainer to approve the workflow run — this is standard GitHub security, not a judgment on your PR. It happens quickly after triage.
 - Some internal automation (AI review bot, preview-environment deploys) doesn't run on fork PRs because it requires repository secrets. Maintainers will run those stages after initial review where relevant. Absence of a preview deploy on your PR is expected, not a failure.
 
+### Preview deploys are opt-in
+
+Preview environments (`pr<N>.preview.bike4mind.com`) are **off by default**. Every PR still runs the full CI suite (typecheck, lint, tests) — that always happens — but a preview stack is only deployed when a maintainer opts the PR in. There are two equivalent ways to opt in:
+
+- **Label**: add the `preview` label to the PR. The preview deploys immediately.
+- **Comment**: comment `/deploy preview` (or `/deploy-preview`) on the PR — a maintainer-only shortcut that applies the label for you.
+
+Removing the `preview` label — or commenting `/deploy-preview off` — stops future preview deploys for that PR and tears the current preview down. Both the label and the comment command are restricted to maintainers, and neither ever runs on fork PRs. The required **Deploy** check stays green whether or not a preview was requested; a skipped preview is not a failure.
+
 ## The review process
 
 1. **Automated checks run first.** Get them green — maintainers generally review PRs with passing checks before ones without.


### PR DESCRIPTION
## What / why

Preview deploys were "always on": every trusted (same-repo, non-fork) PR spun up a `pr<N>.preview.bike4mind.com` stack, because bike4mind's `preview_label` in the `DEPLOY_TENANTS` repo variable was `null` ("always deploy on PR"). This flips the default to **OFF** and makes previews opt-in per PR, via a `preview` label (with a `/deploy preview` comment shortcut).

## How the flip works (which change is actually needed)

The `plan` job in `deploy.yml` **already** supports per-tenant label gating: `if label is None or label in pr_labels`. So the flip itself needs **no plan-job code change**. It is a single repo-variable edit: set bike4mind's `preview_label` to `"preview"` in `DEPLOY_TENANTS`. Everything in this PR is the supporting machinery around that flip.

### Required activation step (post-merge)

The variable is live repo config, coupled to the `labeled` trigger that lands with this PR, so it is intentionally **not flipped in this PR** to avoid a degraded window (label added but no `labeled` trigger yet). Run this right after merge:

```bash
gh variable set DEPLOY_TENANTS --repo Bike4Mind/bike4mind --body "$(gh variable get DEPLOY_TENANTS --repo Bike4Mind/bike4mind | python3 -c 'import sys,json; c=json.load(sys.stdin); c["bike4mind"]["preview_label"]="preview"; print(json.dumps(c))')"
```

Rollback is the same command with `preview_label` set back to `null` (or delete the field). Until this variable is flipped, previews still deploy on every trusted PR — the code changes here are inert without it.

## Changes

- **deploy.yml**: add `labeled` to the `pull_request` types so applying the `preview` label deploys immediately, not just on the next push. The root `changes` job now skips `labeled` events whose label isn't `preview` (`if: github.event.action != 'labeled' || github.event.label.name == 'preview'`), which cascades to the whole DAG, so unrelated label churn (`run-e2e`, `stale`, ...) doesn't burn a full CI + deploy run.
- **deploy-preview-command.yml** (new): `issue_comment` command. `/deploy preview` and `/deploy-preview` add the label; `/deploy-preview off` (also `remove`/`stop`/`down`) removes it. Gated to PR comments by trusted authors (`OWNER`/`MEMBER`/`COLLABORATOR`, the same set the `plan` job trusts). The label change is made with a GitHub App token, not the default `GITHUB_TOKEN`, because events produced by `GITHUB_TOKEN` do not trigger further workflow runs. so a token-added label would never fire the `labeled` trigger. Comment body is read via `env` → `process.env` in `github-script`, never shell-interpolated (injection-safe).
- **cleanup.yml**: also trigger on `unlabeled` and tear the `pr<N>` preview down when the `preview` label is removed (opt-out teardown), reusing the existing `sst remove` + DB-cleanup + state-prune machinery. Gated so only removal of the `preview` label triggers it; every other unlabel is ignored.
- **Docs**: CONTRIBUTING ("Preview deploys are opt-in"), PR template (Security Testing note), and `.github/variables.md` (`preview_label` gating) document the opt-in flow.

The `preview` label was created on the repo (green, `#0E8A16`).

## Verification. plan-job decision output

Ran the exact `plan`-job Python logic with `preview_label: "preview"` across the key cases:

```
[NO DEPLOY] PR by maintainer, NO preview label (default OFF)
            has-deploys=false  deploy-matrix=[]
[DEPLOY   ] PR by maintainer, preview label PRESENT (opt-in)
            has-deploys=true  deploy-matrix=[{"tenant": "bike4mind", "tier": "preview", "pr_number": "900"}]
[NO DEPLOY] PR by maintainer, OTHER label present (e.g. run-e2e), no preview
            has-deploys=false  deploy-matrix=[]
[NO DEPLOY] FORK PR (external contributor), preview label PRESENT -> still blocked
            has-deploys=false  deploy-matrix=[]
[DEPLOY   ] push to main (staging) -> unaffected
            has-deploys=true  deploy-matrix=[{"tenant": "bike4mind", "tier": "dev", "pr_number": ""}]
[DEPLOY   ] push to prod (production) -> unaffected
            has-deploys=true  deploy-matrix=[{"tenant": "bike4mind", "tier": "production", "pr_number": ""}]
```

- Label absent ⇒ empty matrix ⇒ CI runs, no deploy. The required **Deploy** check still goes green (empty plan ⇒ deploy job skips ⇒ `deploy-status` treats skipped as passing).
- Label present ⇒ preview deploys.
- Fork PR ⇒ still blocked even with the label (the existing `is_trusted_author` gate + the deploy job's `is_trusted_context` fork check are untouched).
- `push` to main/prod ⇒ unaffected. this is previews-only.

`actionlint` passes on all three workflows (only pre-existing shellcheck style notes on untouched lines; the new workflow is clean).

## Flags / things to confirm before merge

- **App-token permission (comment command)**: the label add/remove uses `vars.GH_APP_ID || vars.RELEASE_APP_ID`. On this repo that resolves to the release app (`RELEASE_APP_ID`). It needs **Issues: write** (or Pull requests: write) to manage labels. If it lacks that, the command falls back to the default token (the label still applies, and the reply says so) but won't auto-trigger the deploy. the human can still add the label via the UI, which always triggers. Worth a one-time check that the release app has label permissions.
- **Teardown on unlabel (deliverable 4)**: implemented, but this is the highest-risk piece since it modifies the teardown workflow. Removing the `preview` label now runs `sst remove` for `pr<N>`, not just "stop future deploys". That is the intended cost-saving behavior (previews don't linger until PR close), and it's cleanly gated to the `preview` label. If you'd rather ship the opt-in flip first and keep removal as "stop future deploys only", the `cleanup.yml` change is the one hunk to drop.

Holding for human merge. Do not auto-merge.
