### PR TITLE
chore(ci): add @bike4mind/slack to release, snapshot-publish, and cleanup-packages workflows

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@bike4mind/slack"]
+  "ignore": []
 }

--- a/.github/workflows/cleanup-packages.yaml
+++ b/.github/workflows/cleanup-packages.yaml
@@ -121,6 +121,7 @@ jobs:
             "b4m-core/services"
             "b4m-core/utils"
             "b4m-core/mcp"
+            "b4m-core/slack"
             "packages/premium/optihashi/engine"
             "packages/cli"
           )

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,6 +130,7 @@ jobs:
             [services]="@bike4mind/services"
             [utils]="@bike4mind/utils"
             [mcp]="@bike4mind/mcp"
+            [slack]="@bike4mind/slack"
             [cli]="@bike4mind/cli"
           )
 
@@ -154,6 +155,7 @@ jobs:
               echo "\"@bike4mind/services\": $BUMP"
               echo "\"@bike4mind/utils\": $BUMP"
               echo "\"@bike4mind/mcp\": $BUMP"
+              echo "\"@bike4mind/slack\": $BUMP"
               echo "\"@bike4mind/cli\": $BUMP"
               echo "---"
               echo ""

--- a/.github/workflows/snapshot-publish.yaml
+++ b/.github/workflows/snapshot-publish.yaml
@@ -112,6 +112,7 @@ jobs:
             ["b4m-core/services"]="@bike4mind/services"
             ["b4m-core/utils"]="@bike4mind/utils"
             ["b4m-core/mcp"]="@bike4mind/mcp"
+            ["b4m-core/slack"]="@bike4mind/slack"
             ["packages/cli"]="@bike4mind/cli"
           )
 

--- a/b4m-core/slack/package.json
+++ b/b4m-core/slack/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@bike4mind/slack",
   "version": "0.0.1",
-  "private": true,
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Bike4Mind/bike4mind.git",
+    "directory": "b4m-core/slack"
+  },
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
# Pull Request

Closes #88

## Description

`@bike4mind/slack` was missing from all three CI workflow files that enumerate publishable packages. While implementing the fix I found the package was excluded at **two more layers** which the issue didn't mention, and which have to move together with the lists — otherwise the change is a no-op at best and breaks the release pipeline at worst:

1. `b4m-core/slack/package.json` had `"private": true` — the **only** private package in `b4m-core/*`. Changesets skips private packages at publish time, so adding it to the workflow lists alone would publish nothing.
2. `.changeset/config.json` listed `@bike4mind/slack` under `"ignore"`. `changeset version` **errors** when a changeset references an ignored package — so the manual "all" bump path in `release.yaml` (which would now include slack) would have crashed the release workflow.

Both look like leftovers from the package's bootstrap rather than a deliberate keep-private decision (every sibling in `b4m-core` is publishable, and #88 explicitly treats slack as part of the publishable family) — but this is exactly the part reviewers should confirm.

## Changes

- `.github/workflows/release.yaml`: added `[slack]` to the manual-bump scope map and `@bike4mind/slack` to the "all" bump changeset list (after `mcp`, matching existing order).
- `.github/workflows/snapshot-publish.yaml`: added `["b4m-core/slack"]="@bike4mind/slack"` to the directory→package map.
- `.github/workflows/cleanup-packages.yaml`: added `"b4m-core/slack"` to the published-packages directory list.
- `b4m-core/slack/package.json`: replaced `"private": true` with `"publishConfig": { "access": "restricted" }` + `"repository"` (same shape as `llm-adapters` and the other siblings).
- `.changeset/config.json`: removed `@bike4mind/slack` from `"ignore"`.

## Guide for Testers

**What NOT to test:** CI/publishing configuration only — no runtime, UI, or API surface changes.

**Regression checks:**
1. `pnpm --filter @bike4mind/slack build` — builds clean (tsdown, 4 dist files).
2. `pnpm --filter @bike4mind/slack test` — 397/397 tests pass.
3. `pnpm changeset status` — runs without the "ignored package" error.
4. All three workflow files parse as valid YAML.

The real proof is post-merge: the next release should version-bump and publish `@bike4mind/slack@0.0.x` (restricted), and a snapshot publish from a branch touching `b4m-core/slack` should produce a snapshot version.

## Additional Information

Unrelated but spotted nearby: `.changeset/config.json` points the changelog generator at `"repo": "MillionOnMars/lumina5"` — a stale internal-repo reference, so changelog links generated for public releases point at a repo external users can't see. Same family as #10; happy to file a follow-up issue.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] AdminSettings / UI-UX / documentation / telemetry items — N/A (CI config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
