### PR TITLE
feat(client): add "Copy as Markdown" button to Status Log time-waterfall

### DIFF
--- a/apps/client/app/components/Session/StatusTimeline.test.tsx
+++ b/apps/client/app/components/Session/StatusTimeline.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes/themePrimitives';
+
+// sonner's `toast` is called both as a function (success) and as `toast.error`.
+const toastFn = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: Object.assign((...args: unknown[]) => toastFn(...args), {
+    error: (...args: unknown[]) => toastError(...args),
+  }),
+}));
+
+import StatusTimeline, { buildStatusLogMarkdown, computeTimeline, type StatusLogEntry } from './StatusTimeline';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+// Fixed base + relative offsets keep deltas/total timezone-independent; the
+// absolute HH:mm:ss cells render in local time, so we assert their shape (regex)
+// rather than exact clock values.
+const base = new Date('2026-07-06T12:00:00.000Z').getTime();
+const at = (ms: number) => new Date(base + ms).toISOString();
+
+const log: StatusLogEntry[] = [
+  { status: 'Submitted from client', timestamp: at(0) },
+  { status: 'Received by backend', timestamp: at(460) },
+  { status: '🔎 Searching the data lake', timestamp: at(460 + 3100) },
+  { status: 'weird | label', timestamp: at(460 + 3100 + 2000) }, // total = 5560ms
+];
+
+describe('computeTimeline', () => {
+  it('computes per-stage deltas and total, first delta is 0', () => {
+    const { total, rows } = computeTimeline(log);
+    expect(total).toBe(5560);
+    expect(rows.map(r => r.delta)).toEqual([0, 460, 3100, 2000]);
+  });
+
+  it('sorts chronologically regardless of input order', () => {
+    const { rows } = computeTimeline([log[2], log[0], log[3], log[1]]);
+    expect(rows.map(r => r.entry.status)).toEqual([
+      'Submitted from client',
+      'Received by backend',
+      '🔎 Searching the data lake',
+      'weird | label',
+    ]);
+  });
+});
+
+describe('buildStatusLogMarkdown', () => {
+  const md = buildStatusLogMarkdown(log);
+
+  it('emits the header with total elapsed and an HH:mm:ss range', () => {
+    expect(md).toMatch(/^### Status Log — Total elapsed: 5\.6s \(\d\d:\d\d:\d\d → \d\d:\d\d:\d\d\)/);
+  });
+
+  it('emits a markdown table header + separator', () => {
+    expect(md).toContain('| Time | Δ | Step |');
+    expect(md).toContain('| --- | --- | --- |');
+  });
+
+  it('renders one row per stage with the right delta and label', () => {
+    expect(md).toContain('| start | Submitted from client |');
+    expect(md).toContain('| +460ms | Received by backend |');
+    expect(md).toContain('| +3.1s | 🔎 Searching the data lake |');
+    const dataRows = md.split('\n').filter(l => /^\| \d\d:\d\d:\d\d \|/.test(l));
+    expect(dataRows).toHaveLength(4);
+  });
+
+  it('escapes pipe characters in labels so the table is not broken', () => {
+    expect(md).toContain('| +2.0s | weird \\| label |');
+  });
+});
+
+describe('StatusTimeline copy button', () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    toastFn.mockClear();
+    toastError.mockClear();
+  });
+
+  it('renders the copy affordance and, on click, writes the markdown + toasts', async () => {
+    render(
+      <TestWrapper>
+        <StatusTimeline statusLog={log} />
+      </TestWrapper>
+    );
+    fireEvent.click(screen.getByTestId('status-log-copy-md-btn'));
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith(buildStatusLogMarkdown(log)));
+    expect(toastFn).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('toasts an error if the clipboard write fails', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'));
+    render(
+      <TestWrapper>
+        <StatusTimeline statusLog={log} />
+      </TestWrapper>
+    );
+    fireEvent.click(screen.getByTestId('status-log-copy-md-btn'));
+    await vi.waitFor(() => expect(toastError).toHaveBeenCalled());
+  });
+});

--- a/apps/client/app/components/Session/StatusTimeline.tsx
+++ b/apps/client/app/components/Session/StatusTimeline.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Box, Typography, Stack, Tooltip } from '@mui/joy';
+import { Box, Typography, Stack, Tooltip, IconButton } from '@mui/joy';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { toast } from 'sonner';
 import dayjs from 'dayjs';
 
 // Status Log timeline. Shared between the per-message Prompt Metadata inspector
@@ -16,6 +18,47 @@ export function formatDuration(ms: number): string {
   const m = Math.floor(ms / 60000);
   const s = Math.round((ms % 60000) / 1000);
   return `${m}m ${s}s`;
+}
+
+export type TimelineRow = { entry: StatusLogEntry; delta: number; offset: number; abs: number };
+
+/**
+ * Shared timeline math for the render and the Markdown export, so both reflect
+ * the same ordering/deltas. Sorts chronologically and computes each stage's gap
+ * from the previous stage (`delta`) plus its cumulative offset from the start.
+ */
+export function computeTimeline(statusLog: StatusLogEntry[]) {
+  const sorted = [...statusLog].sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+  const t0 = new Date(sorted[0].timestamp).getTime();
+  const tEnd = new Date(sorted[sorted.length - 1].timestamp).getTime();
+  const total = Math.max(tEnd - t0, 1); // guard divide-by-zero when all stamps equal
+  const rows: TimelineRow[] = sorted.map((entry, i) => {
+    const t = new Date(entry.timestamp).getTime();
+    const prev = i === 0 ? t : new Date(sorted[i - 1].timestamp).getTime();
+    return { entry, delta: t - prev, offset: prev - t0, abs: t };
+  });
+  return { sorted, t0, tEnd, total, rows };
+}
+
+/**
+ * The on-screen waterfall as a Markdown table (header line + one row per stage:
+ * absolute time, delta, label) so a latency breakdown can be pasted into
+ * issues/PRs/chat instead of screenshotted.
+ */
+export function buildStatusLogMarkdown(statusLog: StatusLogEntry[]): string {
+  const { t0, tEnd, total, rows } = computeTimeline(statusLog);
+  const header = `### Status Log — Total elapsed: ${formatDuration(total)} (${dayjs(t0).format('HH:mm:ss')} → ${dayjs(
+    tEnd
+  ).format('HH:mm:ss')})`;
+  const bodyRows = rows.map(
+    (row, i) =>
+      // Escape pipes in the label so a `|` in a status can't break the table.
+      `| ${dayjs(row.abs).format('HH:mm:ss')} | ${i === 0 ? 'start' : `+${formatDuration(row.delta)}`} | ${row.entry.status.replace(
+        /\|/g,
+        '\\|'
+      )} |`
+  );
+  return [header, '', '| Time | Δ | Step |', '| --- | --- | --- |', ...bodyRows].join('\n');
 }
 
 /**
@@ -36,19 +79,17 @@ const StatusTimeline: React.FC<{ statusLog: StatusLogEntry[] }> = ({ statusLog }
     );
   }
 
-  // Chronological order so deltas read top->bottom as the request progresses.
-  const sorted = [...statusLog].sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-  const t0 = new Date(sorted[0].timestamp).getTime();
-  const tEnd = new Date(sorted[sorted.length - 1].timestamp).getTime();
-  const total = Math.max(tEnd - t0, 1); // guard divide-by-zero when all stamps equal
-
-  // Per-stage gap (delta from previous) + cumulative offset from the start.
-  const rows = sorted.map((entry, i) => {
-    const t = new Date(entry.timestamp).getTime();
-    const prev = i === 0 ? t : new Date(sorted[i - 1].timestamp).getTime();
-    return { entry, delta: t - prev, offset: prev - t0, abs: t };
-  });
+  const { t0, tEnd, total, rows } = computeTimeline(statusLog);
   const maxDelta = Math.max(...rows.map(r => r.delta));
+
+  const handleCopyMarkdown = async () => {
+    try {
+      await navigator.clipboard.writeText(buildStatusLogMarkdown(statusLog));
+      toast('Status log copied as Markdown');
+    } catch {
+      toast.error('Failed to copy to clipboard');
+    }
+  };
 
   return (
     <Stack spacing={1.25} sx={{ p: 1 }}>
@@ -56,9 +97,23 @@ const StatusTimeline: React.FC<{ statusLog: StatusLogEntry[] }> = ({ statusLog }
         <Typography level="body-sm" sx={{ fontWeight: 'lg' }}>
           Total elapsed: {formatDuration(total)}
         </Typography>
-        <Typography level="body-xs" sx={{ color: 'text.tertiary', fontVariantNumeric: 'tabular-nums' }}>
-          {dayjs(t0).format('HH:mm:ss')} → {dayjs(tEnd).format('HH:mm:ss')}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+          <Typography level="body-xs" sx={{ color: 'text.tertiary', fontVariantNumeric: 'tabular-nums' }}>
+            {dayjs(t0).format('HH:mm:ss')} → {dayjs(tEnd).format('HH:mm:ss')}
+          </Typography>
+          <Tooltip title="Copy as Markdown" arrow placement="top">
+            <IconButton
+              size="sm"
+              variant="plain"
+              color="neutral"
+              onClick={handleCopyMarkdown}
+              data-testid="status-log-copy-md-btn"
+              aria-label="Copy status log as Markdown"
+            >
+              <ContentCopyIcon sx={{ fontSize: 14 }} />
+            </IconButton>
+          </Tooltip>
+        </Box>
       </Box>
 
       {rows.map((row, i) => {


### PR DESCRIPTION
## Description

The **Status Log** time-waterfall (Prompt Metadata inspector → Status Log tab) is the best artifact for diagnosing slow turns, but until now it could only be **screenshotted**. This adds a **"Copy as Markdown"** icon button that copies the whole step-by-step latency breakdown to the clipboard as a Markdown table, so latency reports can be pasted straight into issues, PRs, or chat.

Closes #11.

The Markdown mirrors the on-screen waterfall exactly — header line + one row per stage (absolute time, Δ, label):

```markdown
### Status Log — Total elapsed: 5.6s (12:37:03 → 12:37:09)

| Time | Δ | Step |
| --- | --- | --- |
| 12:37:03 | start | Submitted from client |
| 12:37:04 | +460ms | Received by backend |
| 12:37:07 | +3.1s | 🔎 Searching the data lake |
```

## Changes

- **`StatusTimeline.tsx`**
  - Extracted the timeline math into a shared, exported `computeTimeline()` used by both the render and the export, so the Markdown is guaranteed to match what's rendered (ordering + deltas).
  - Added exported pure `buildStatusLogMarkdown()` that produces the header + `| Time | Δ | Step |` table. Pipe characters in step labels are escaped (`\|`) so a status can't break the table.
  - Added a "Copy as Markdown" `IconButton` in the timeline header (beside the time range): click → `navigator.clipboard.writeText` → `sonner` toast (success + failure), reusing the repo's standard copy-link pattern. `data-testid="status-log-copy-md-btn"`, `aria-label` set.
- **`StatusTimeline.test.tsx`** (new) — 8 unit tests (see Tests).

## Guide for Testers

1. Open a session and send a prompt so a quest runs to completion.
2. Open the **Prompt Metadata inspector** for that message and select the **Status Log** tab. Confirm the waterfall renders as before (no layout change).
3. Confirm a small **copy icon** appears in the header row, to the right of the `HH:mm:ss → HH:mm:ss` time range. Hover → tooltip reads **"Copy as Markdown"**.
4. Click it. Confirm a toast **"Status log copied as Markdown"** appears.
5. Paste into any Markdown-aware field (a GitHub comment preview, chat, an editor). Confirm you get a `### Status Log — Total elapsed: …` header followed by a `| Time | Δ | Step |` table whose rows match the on-screen steps, timestamps, and deltas exactly (including any leading emoji/icon in a step label).
6. (Bonus surface) The same button also appears in **Admin → Model Metrics → Raw Data** where the timeline is reused — verify it copies there too.

## Additional Information

The copy button lives in the shared `StatusTimeline` component, so it appears both in the per-message Status Log tab and in **Admin → Model Metrics → Raw Data** (which reuses the timeline). This is intentional — the copy is useful in both places — and there is no layout regression to the existing waterfall.

## Developer Notes (Optional)

`computeTimeline()` and `buildStatusLogMarkdown()` are exported pure functions, so any future consumer (e.g. an "export whole turn" action) can reuse the same Markdown without re-deriving the delta math.

## Tests

- `StatusTimeline.test.tsx` — 8 tests:
  - `computeTimeline`: per-stage deltas + total; first delta is 0; sorts chronologically regardless of input order.
  - `buildStatusLogMarkdown`: header with total-elapsed + `HH:mm:ss` range; table header/separator; one row per stage with correct delta + label; pipe-escaping in labels.
  - `StatusTimeline` render: click writes the exact markdown to the clipboard + toasts success; clipboard-write failure toasts an error.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings