### PR TITLE
feat(publish): add Team (org) visibility to the artifact Share dialog

### DIFF
--- a/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
@@ -80,6 +80,7 @@ import DownloadMenu, { downloadFile, copyToClipboard } from '../common/DownloadM
 import ShareIcon from '@mui/icons-material/Share';
 import { useUser } from '@client/app/contexts/UserContext';
 import { usePublishShare } from '@client/app/hooks/usePublishShare';
+import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
 import { buildArtifactPublishWiring } from '@client/app/utils/publishApi';
 import JSONViewer from './JSONViewer';
 import { api } from '@client/app/contexts/ApiContext';
@@ -310,6 +311,9 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
   const [isCopying, setIsCopying] = useState(false);
   // Publish-and-share for the artifact currently in the viewer.
   const shareUser = useUser(s => s.currentUser);
+  // Active account-switcher org (null in personal context) - enables Team/org-scoped publishing.
+  const selectedAccount = useSelectedAccount(s => s.selectedAccount);
+  const activeOrg = selectedAccount && !selectedAccount.personal ? selectedAccount : null;
   const { publishAndShare: publishAndShareArtifact, modal: artifactShareModal } = usePublishShare();
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDiffPreviewOpen, setIsDiffPreviewOpen] = useState(false);
@@ -974,7 +978,15 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
     }
     publishAndShareArtifact({
       title,
-      ...buildArtifactPublishWiring({ artifactId, type, content, title, userId: String(shareUser.id) }),
+      ...(activeOrg ? { orgOption: { label: 'Team', hint: `Members of ${activeOrg.name}` } } : {}),
+      ...buildArtifactPublishWiring({
+        artifactId,
+        type,
+        content,
+        title,
+        userId: String(shareUser.id),
+        orgId: activeOrg?.id,
+      }),
     });
   };
 

--- a/apps/client/app/components/artifacts/ArtifactGallery.tsx
+++ b/apps/client/app/components/artifacts/ArtifactGallery.tsx
@@ -51,6 +51,7 @@ import { toast } from 'sonner';
 import { type BaseArtifact } from '@bike4mind/common';
 import { useUser } from '@client/app/contexts/UserContext';
 import { usePublishShare } from '@client/app/hooks/usePublishShare';
+import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
 import { buildArtifactPublishWiring } from '@client/app/utils/publishApi';
 
 // Types
@@ -127,8 +128,13 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
   onArtifactCreate,
   onArtifactEdit,
 }) => {
-  // Publish-and-share: render an artifact to a hosted static bundle (/p/u/...).
+  // Publish-and-share: render an artifact to a hosted static bundle (/p/u/... or, in a Team
+  // account context, an org-scoped /p/o/...).
   const currentUser = useUser(s => s.currentUser);
+  // Active account-switcher org (null in personal context). Enables the dialog's Team option
+  // and org-scoped publishing; the server re-validates membership before trusting it.
+  const selectedAccount = useSelectedAccount(s => s.selectedAccount);
+  const activeOrg = selectedAccount && !selectedAccount.personal ? selectedAccount : null;
   const { publishAndShare, modal: publishShareModal } = usePublishShare();
   const handlePublishArtifact = useCallback(
     (artifact: ArtifactWithContent) => {
@@ -148,16 +154,18 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
       }
       publishAndShare({
         title: artifact.title || 'Shared artifact',
+        ...(activeOrg ? { orgOption: { label: 'Team', hint: `Members of ${activeOrg.name}` } } : {}),
         ...buildArtifactPublishWiring({
           artifactId,
           type: artifact.type,
           content: artifact.content ?? '',
           title: artifact.title,
           userId: String(currentUser.id),
+          orgId: activeOrg?.id,
         }),
       });
     },
-    [currentUser, publishAndShare]
+    [currentUser, activeOrg, publishAndShare]
   );
 
   // State

--- a/apps/client/app/components/common/PublishShareModal.test.tsx
+++ b/apps/client/app/components/common/PublishShareModal.test.tsx
@@ -160,3 +160,52 @@ describe('PublishShareModal — update re-asserts the PRESERVED comment policy',
     expect(apiPatch).not.toHaveBeenCalled();
   });
 });
+
+describe('PublishShareModal — Team (organization) visibility option', () => {
+  const publishResult: PublishResult = {
+    publicId: 'pub-org',
+    url: '/p/o/org_42/s',
+    tier: 'organization',
+    scopeId: 'org_42',
+    slug: 's',
+    visibility: 'organization',
+    publishedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('omits the Team option when no orgOption is given (personal context)', () => {
+    render(
+      <Wrapper>
+        <PublishShareModal open onClose={() => {}} publish={noopPublish} title="My artifact" />
+      </Wrapper>
+    );
+    expect(radio('public')).not.toBeNull();
+    expect(radio('private')).not.toBeNull();
+    expect(radio('organization')).toBeNull();
+  });
+
+  it('offers the Team option and publishes with organization visibility when picked', async () => {
+    const publish = vi.fn().mockResolvedValue(publishResult);
+    render(
+      <Wrapper>
+        <PublishShareModal
+          open
+          onClose={() => {}}
+          publish={publish}
+          title="My artifact"
+          defaultVisibility="public"
+          orgOption={{ label: 'Team', hint: 'Members of Acme' }}
+        />
+      </Wrapper>
+    );
+
+    const orgRadio = radio('organization');
+    expect(orgRadio).not.toBeNull();
+
+    fireEvent.click(orgRadio!);
+    fireEvent.click(screen.getByTestId('publish-share-create'));
+
+    await waitFor(() => expect(publish).toHaveBeenCalledTimes(1));
+    // The dialog hands 'organization' to the publish callback, which maps it to an org-tier page.
+    expect(publish).toHaveBeenCalledWith('organization', expect.objectContaining({ mode: 'new' }));
+  });
+});

--- a/apps/client/app/components/common/PublishShareModal.test.tsx
+++ b/apps/client/app/components/common/PublishShareModal.test.tsx
@@ -208,4 +208,69 @@ describe('PublishShareModal — Team (organization) visibility option', () => {
     // The dialog hands 'organization' to the publish callback, which maps it to an org-tier page.
     expect(publish).toHaveBeenCalledWith('organization', expect.objectContaining({ mode: 'new' }));
   });
+
+  it('does NOT offer Team in the shared phase after a user-tier publish (would 403 org members)', async () => {
+    // Regression: a user-tier page live-switched to org visibility is served only where
+    // scopeId === viewer.organizationId; scopeId is the user id, so org members get 403.
+    // Moving to org scope requires re-publishing, not a visibility PATCH - so Team must not
+    // be offered on a user-tier record in the shared phase.
+    const userTierResult: PublishResult = {
+      publicId: 'pub-user',
+      url: '/p/u/u1/s',
+      tier: 'user',
+      scopeId: 'u1',
+      slug: 's',
+      visibility: 'public',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const publish = vi.fn().mockResolvedValue(userTierResult);
+    render(
+      <Wrapper>
+        <PublishShareModal
+          open
+          onClose={() => {}}
+          publish={publish}
+          title="My artifact"
+          defaultVisibility="public"
+          orgOption={{ label: 'Team', hint: 'Members of Acme' }}
+        />
+      </Wrapper>
+    );
+
+    // Choose phase: Team is offered.
+    expect(radio('organization')).not.toBeNull();
+    fireEvent.click(screen.getByTestId('publish-share-create'));
+
+    // Shared phase (user-tier result): Team is withdrawn; only Public/Private remain.
+    await screen.findByTestId('publish-share-url');
+    expect(radio('public')).not.toBeNull();
+    expect(radio('private')).not.toBeNull();
+    expect(radio('organization')).toBeNull();
+  });
+
+  it('offers Team but not Private in the shared phase after an org-tier publish', async () => {
+    // org-tier record: 'private' is not a valid override (SCOPE_POLICY), so it must not be a
+    // dead-end option; Team/Public are the valid live changes.
+    const publish = vi.fn().mockResolvedValue(publishResult);
+    render(
+      <Wrapper>
+        <PublishShareModal
+          open
+          onClose={() => {}}
+          publish={publish}
+          title="My artifact"
+          defaultVisibility="public"
+          orgOption={{ label: 'Team', hint: 'Members of Acme' }}
+        />
+      </Wrapper>
+    );
+
+    fireEvent.click(radio('organization')!);
+    fireEvent.click(screen.getByTestId('publish-share-create'));
+
+    await screen.findByTestId('publish-share-url');
+    expect(radio('public')).not.toBeNull();
+    expect(radio('organization')).not.toBeNull();
+    expect(radio('private')).toBeNull();
+  });
 });

--- a/apps/client/app/components/common/PublishShareModal.tsx
+++ b/apps/client/app/components/common/PublishShareModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Modal,
   ModalDialog,
@@ -18,6 +18,7 @@ import {
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import PublicIcon from '@mui/icons-material/Public';
 import LockIcon from '@mui/icons-material/Lock';
+import GroupIcon from '@mui/icons-material/Group';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
@@ -61,21 +62,24 @@ export interface PublishShareModalProps {
     visibility: PublishVisibility;
     commentPolicy?: CommentPolicy;
   } | null>;
+  /**
+   * When set, offers a "Team" (organization) visibility choice, publishing an org-scoped
+   * page visible to org members. Supplied only when the caller is in an org ("Team") account
+   * context - the publish callback maps org visibility to an org-tier page. Omit for personal
+   * scope (only Public/Private are offered).
+   */
+  orgOption?: { label: string; hint: string };
 }
 
-const VISIBILITY_OPTIONS: Array<{
-  value: PublishVisibility;
-  label: string;
-  hint: string;
-  icon: React.ReactNode;
-}> = [
-  { value: 'public', label: 'Public', hint: 'Anyone with the link', icon: <PublicIcon /> },
-  { value: 'private', label: 'Private', hint: 'Only you', icon: <LockIcon /> },
-  // NOTE: 'organization' intentionally omitted - these share flows publish under
-  // the user scope, and org-visibility is gated by org-tier scopeId on the serve
-  // path, so it would 403 for org members. Proper org-scoped sharing is a
-  // tracked follow-up (needs org-tier publishing / owner-org gating).
-];
+type VisibilityOption = { value: PublishVisibility; label: string; hint: string; icon: React.ReactNode };
+
+const PUBLIC_OPTION: VisibilityOption = {
+  value: 'public',
+  label: 'Public',
+  hint: 'Anyone with the link',
+  icon: <PublicIcon />,
+};
+const PRIVATE_OPTION: VisibilityOption = { value: 'private', label: 'Private', hint: 'Only you', icon: <LockIcon /> };
 
 /** Amber accent for the currently-selected visibility - draws the eye to the
  *  active choice (and signals exposure when Public is selected). */
@@ -100,7 +104,17 @@ export function PublishShareModal({
   markdown,
   defaultVisibility = 'public',
   resolveExisting,
+  orgOption,
 }: PublishShareModalProps) {
+  // Public, then Team (only in an org context), then Private - openness descending. The Team
+  // option publishes an org-scoped page; the publish callback maps it to an org-tier page.
+  const visibilityOptions = useMemo<VisibilityOption[]>(
+    () =>
+      orgOption
+        ? [PUBLIC_OPTION, { value: 'organization', ...orgOption, icon: <GroupIcon /> }, PRIVATE_OPTION]
+        : [PUBLIC_OPTION, PRIVATE_OPTION],
+    [orgOption]
+  );
   const [visibility, setVisibility] = useState<PublishVisibility>(defaultVisibility);
   const [commentsOn, setCommentsOn] = useState(true);
   const [result, setResult] = useState<PublishResult | null>(null);
@@ -291,7 +305,7 @@ export function PublishShareModal({
             data-testid="publish-share-visibility"
             sx={{ gap: 1 }}
           >
-            {VISIBILITY_OPTIONS.map(o => {
+            {visibilityOptions.map(o => {
               const selected = visibility === o.value;
               return (
                 <Box

--- a/apps/client/app/components/common/PublishShareModal.tsx
+++ b/apps/client/app/components/common/PublishShareModal.tsx
@@ -106,15 +106,6 @@ export function PublishShareModal({
   resolveExisting,
   orgOption,
 }: PublishShareModalProps) {
-  // Public, then Team (only in an org context), then Private - openness descending. The Team
-  // option publishes an org-scoped page; the publish callback maps it to an org-tier page.
-  const visibilityOptions = useMemo<VisibilityOption[]>(
-    () =>
-      orgOption
-        ? [PUBLIC_OPTION, { value: 'organization', ...orgOption, icon: <GroupIcon /> }, PRIVATE_OPTION]
-        : [PUBLIC_OPTION, PRIVATE_OPTION],
-    [orgOption]
-  );
   const [visibility, setVisibility] = useState<PublishVisibility>(defaultVisibility);
   const [commentsOn, setCommentsOn] = useState(true);
   const [result, setResult] = useState<PublishResult | null>(null);
@@ -179,6 +170,32 @@ export function PublishShareModal({
   const phase: 'choose' | 'shared' = result ? 'shared' : 'choose';
   const url = result ? toShareUrl(result) : '';
   const isPublic = visibility === 'public';
+
+  // Visibility choices, ordered by openness. The Team (org) entry appears only when the caller
+  // supplied `orgOption` (an org account context).
+  //
+  // In the SHARED phase we can only PATCH the existing record's `visibility` - we cannot migrate
+  // its scope tier - so the offered set must be valid for the published record's tier:
+  //   • user-tier page  -> Public/Private only. Offering Team here would PATCH visibility to
+  //     'organization' on a user-scoped record, whose scopeId is the user id, so the serve gate
+  //     would 403 every org member (moving to org scope requires re-publishing, not a PATCH).
+  //   • org-tier page   -> Public/Team only. 'private' isn't a valid override for org tier
+  //     (SCOPE_POLICY), so the server would reject it - don't offer a dead-end.
+  // In the CHOOSE phase the publish callback maps a Team pick to a real org-tier page, so the
+  // full set is safe.
+  const visibilityOptions = useMemo<VisibilityOption[]>(() => {
+    const orgEntry: VisibilityOption | null = orgOption
+      ? { value: 'organization', ...orgOption, icon: <GroupIcon /> }
+      : null;
+    if (result) {
+      return result.tier === 'organization'
+        ? orgEntry
+          ? [PUBLIC_OPTION, orgEntry]
+          : [PUBLIC_OPTION]
+        : [PUBLIC_OPTION, PRIVATE_OPTION];
+    }
+    return orgEntry ? [PUBLIC_OPTION, orgEntry, PRIVATE_OPTION] : [PUBLIC_OPTION, PRIVATE_OPTION];
+  }, [orgOption, result]);
 
   // Phase 1 -> publish with the chosen visibility.
   const handleCreate = async () => {

--- a/apps/client/app/hooks/usePublishShare.tsx
+++ b/apps/client/app/hooks/usePublishShare.tsx
@@ -26,6 +26,7 @@ interface ShareState {
   markdown?: string;
   defaultVisibility: PublishVisibility;
   resolveExisting?: () => Promise<ExistingPublication | null>;
+  orgOption?: { label: string; hint: string };
 }
 
 interface PublishAndShareOpts {
@@ -47,6 +48,12 @@ interface PublishAndShareOpts {
    * new". Runs only after the dialog opens, so it never publishes anything.
    */
   resolveExisting?: () => Promise<ExistingPublication | null>;
+  /**
+   * When set, the dialog offers a "Team" (organization) visibility choice. Pass only when the
+   * caller is in an org ("Team") account context and the publish callback can produce an
+   * org-scoped page. Omit for personal scope.
+   */
+  orgOption?: { label: string; hint: string };
 }
 
 /**
@@ -71,6 +78,7 @@ export function usePublishShare() {
       markdown: opts.markdown,
       defaultVisibility: opts.defaultVisibility ?? 'public',
       resolveExisting: opts.resolveExisting,
+      orgOption: opts.orgOption,
     });
   }, []);
 
@@ -85,6 +93,7 @@ export function usePublishShare() {
       markdown={state.markdown}
       defaultVisibility={state.defaultVisibility}
       resolveExisting={state.resolveExisting}
+      orgOption={state.orgOption}
     />
   );
 

--- a/apps/client/app/utils/__tests__/publishApi.test.ts
+++ b/apps/client/app/utils/__tests__/publishApi.test.ts
@@ -56,6 +56,13 @@ function uploadedSourceArtifactId(): string | undefined {
   return (call?.[1] as { source?: { artifactId?: string } }).source?.artifactId;
 }
 
+/** The {tier, scopeId} sent to upload-url (the scope finalize upserts the publication under). */
+function uploadedScope(): { tier: string; scopeId: string } {
+  const call = apiPost.mock.calls.find(c => c[0] === '/api/publish/artifact/upload-url');
+  const body = call?.[1] as { tier: string; scopeId: string };
+  return { tier: body.tier, scopeId: body.scopeId };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   // S3 PUT in step 2.
@@ -141,6 +148,32 @@ describe('publishArtifactBundle', () => {
     });
     expect(uploadedSlug()).toBe('chronosphere-artifa');
   });
+
+  it('defaults to user tier scoped to the user id when no scope is given', async () => {
+    wirePublishPosts();
+    await publishArtifactBundle({
+      artifactId: 'artifact_abcdef123456',
+      type: 'react',
+      content: 'export default () => null;',
+      title: 'Chronosphere',
+      userId: 'u1',
+    });
+    expect(uploadedScope()).toEqual({ tier: 'user', scopeId: 'u1' });
+  });
+
+  it('publishes under an explicit org tier + scope when provided', async () => {
+    wirePublishPosts();
+    await publishArtifactBundle({
+      artifactId: 'artifact_abcdef123456',
+      type: 'react',
+      content: 'export default () => null;',
+      title: 'Chronosphere',
+      userId: 'u1',
+      tier: 'organization',
+      scopeId: 'org_42',
+    });
+    expect(uploadedScope()).toEqual({ tier: 'organization', scopeId: 'org_42' });
+  });
 });
 
 describe('findPublishedByArtifact', () => {
@@ -219,6 +252,35 @@ describe('artifactBundlePublisher', () => {
     await publish('public');
 
     expect(uploadedSlug()).toBe('chronosphere-v2-artifa');
+  });
+
+  it('publishes an org-tier page (scopeId = org id) for org visibility when in a Team context', async () => {
+    wirePublishPosts();
+    const publish = artifactBundlePublisher({ ...baseInput, orgId: 'org_42' });
+
+    await publish('organization');
+
+    // Org visibility must land a real org-tier page - a user-tier page with org visibility
+    // would 403 for org members (its scopeId is the user id, never the viewer's org id).
+    expect(uploadedScope()).toEqual({ tier: 'organization', scopeId: 'org_42' });
+  });
+
+  it('keeps public/private on the user tier even when a Team context is available', async () => {
+    wirePublishPosts();
+    const publish = artifactBundlePublisher({ ...baseInput, orgId: 'org_42' });
+
+    await publish('public');
+
+    expect(uploadedScope()).toEqual({ tier: 'user', scopeId: 'u1' });
+  });
+
+  it('ignores org visibility without an active org (stays user tier - the option is not offered)', async () => {
+    wirePublishPosts();
+    const publish = artifactBundlePublisher(baseInput);
+
+    await publish('organization');
+
+    expect(uploadedScope()).toEqual({ tier: 'user', scopeId: 'u1' });
   });
 
   it('discriminates publish-as-new slugs even within the SAME millisecond (random tail)', async () => {

--- a/apps/client/app/utils/publishApi.ts
+++ b/apps/client/app/utils/publishApi.ts
@@ -149,6 +149,14 @@ export async function publishArtifactBundle(input: {
   content: string;
   title: string;
   userId: string;
+  /**
+   * Scope tier to publish under. Defaults to `'user'` (a personal `/p/u/{userId}` page).
+   * Pass `'organization'` with `scopeId` set to the org id to publish an org-scoped page
+   * (`/p/o/{orgId}`) that the serve gate authorizes to org members - see `artifactBundlePublisher`.
+   */
+  tier?: PublishScopeTier;
+  /** Scope id for `tier`. Defaults to `userId` (user tier). For org tier, the org id. */
+  scopeId?: string;
   visibility?: PublishVisibility;
   commentPolicy?: CommentPolicy;
   /**
@@ -184,8 +192,8 @@ export async function publishArtifactBundle(input: {
 
   // Step 1 - request a presigned PUT for index.html.
   const { data: draft } = await api.post<UploadUrlResponse>('/api/publish/artifact/upload-url', {
-    tier: 'user',
-    scopeId: input.userId,
+    tier: input.tier ?? 'user',
+    scopeId: input.scopeId ?? input.userId,
     slug,
     title: input.title || 'Shared artifact',
     visibility: input.visibility ?? DEFAULT_SHARE_VISIBILITY,
@@ -228,6 +236,13 @@ export interface ArtifactPublishOpts {
  * decides the mode: "update" reuses the existing publication's slug (passed back as
  * `existingSlug`) so finalize appends a version; "new" (the default) derives a fresh
  * slug for a separate page.
+ *
+ * When the caller is in an org ("Team") account context, `orgId` enables the dialog's
+ * Team option: picking `'organization'` visibility publishes an org-tier page
+ * (`tier:'organization'`, `scopeId=orgId` → `/p/o/{orgId}/{slug}`). This is the ONLY
+ * combination the serve gate authorizes to org members - a user-tier page with org
+ * visibility would 403 for everyone but the owner (its scopeId is the user id, never the
+ * viewer's org id). The server re-validates org membership before trusting the scope.
  */
 export function artifactBundlePublisher(input: {
   artifactId: string;
@@ -235,11 +250,18 @@ export function artifactBundlePublisher(input: {
   content: string;
   title: string;
   userId: string;
+  /** The caller's active org, when in a "Team" account context. Undefined for personal scope. */
+  orgId?: string;
 }): (visibility: PublishVisibility, opts?: ArtifactPublishOpts) => Promise<PublishResult> {
+  const { orgId, ...bundle } = input;
   return (visibility, opts) =>
     publishArtifactBundle({
-      ...input,
+      ...bundle,
       visibility,
+      // Org visibility publishes a real org-tier page (scopeId = org id) so same-org members
+      // can view it. Requires an active org; the dialog only offers the Team option when one
+      // exists, so this branch is unreachable without orgId.
+      ...(visibility === 'organization' && orgId ? { tier: 'organization' as const, scopeId: orgId } : {}),
       // 'update' pins the existing slug so finalize appends a version; 'new' with a prior
       // publication forces a unique slug so it can't collide back onto ANY existing one.
       ...(opts?.mode === 'update' && opts.existingSlug
@@ -265,6 +287,8 @@ export function buildArtifactPublishWiring(input: {
   content: string;
   title: string;
   userId: string;
+  /** The caller's active org, when in a "Team" account context. Enables org-scoped publishing. */
+  orgId?: string;
 }): {
   resolveExisting: () => Promise<ManagedArtifact | null>;
   publish: (visibility: PublishVisibility, opts?: ArtifactPublishOpts) => Promise<PublishResult>;


### PR DESCRIPTION
# Pull Request

## Description

Fixes #61. The artifact **Share** dialog only offered **Public** and **Private** (user-tier). Even when publishing from an org (**"Team"**) account context, the resulting artifact was always `tier:'user'`, `scopeId`=userId (`/p/u/…`) — the org-scoped visibility path was unreachable from the product.

The backend **already fully supports** org-tier publishing: `checkScopePermission` validates org membership, and the serve gate (`checkVisibility`) authorizes same-org members and denies cross-org/anonymous access. The gap was entirely client-side. This wires the missing path, mirroring the data-lakes `activeOrgId()` precedent.

Only `tier:'organization'` + `visibility:'organization'` + `scopeId=orgId` yields the intended "org members only, cross-org denied" behavior — a **user-tier** page with org visibility would 403 for everyone but the owner (its `scopeId` is the user id, never the viewer's org id).

## Changes

- **`utils/publishApi.ts`** — `publishArtifactBundle` accepts optional `tier`/`scopeId` (default `user`/`userId`). `artifactBundlePublisher`/`buildArtifactPublishWiring` accept `orgId`; picking `'organization'` visibility publishes an org-tier page (`scopeId=orgId` → `/p/o/{orgId}/{slug}`).
- **`components/common/PublishShareModal.tsx`** — renders a **Team** option (via optional `orgOption` prop) between Public and Private; dynamic options list.
- **`hooks/usePublishShare.tsx`** — threads `orgOption` through to the modal.
- **`ArtifactGallery.tsx` + `KnowledgeViewer.tsx`** — pass the active account-switcher org so the Team option appears (and org-scoping applies) only in a Team context; personal context is unchanged.
- Tests added for scope mapping (`publishApi.test.ts`) and the Team option render/publish (`PublishShareModal.test.tsx`).

## Guide for Testers

1. Sign in as a member of an organization.
2. Open the account switcher and select your org ("Team") account.
3. Generate or open an artifact, then click **Share** (chat artifact card or the full viewer).
4. In the Share dialog, confirm a **Team** visibility option now appears (labeled `Team`, hint `Members of <org name>`), alongside Public and Private.
5. Select **Team**, then click **Create share link**. Expected: publish succeeds and the resulting URL is an org-scoped `/p/o/<orgId>/<slug>` link.
6. Open the link as another **member of the same org** → the page loads.
7. Open the link as a user in a **different org** (or anonymous) → access is denied (403/401).

### Regression Checks
1. In **personal** account context, the Share dialog shows **only** Public and Private (no Team option).
2. Publishing Public/Private in either context still produces a user-tier `/p/u/<userId>/<slug>` link.
3. "Update existing version" vs "publish as new" still works.

### What NOT to test
- Multi-org edge case where the switcher org differs from the user's stored `organizationId` — see Additional Information.

## Additional Information

The org-scope authorization here relies on the existing publish gate (`checkScopePermission`), which validates the requested `scopeId` against `req.user.organizationId` (the user doc's membership field). For single-org users this equals the switcher selection, so it works. A multi-org user whose *switcher* org differs from their *stored* org would get a safe, fail-closed 403 — not a leak. Making that fully robust would mean migrating the publish gate to the data-lakes `resolveActiveOrg` body-param pattern; that touches shared server security code and is deliberately out of scope for this P3 UI fix.

## Developer Notes

- `PublishShareModal` now accepts an optional `orgOption: { label; hint }` — any publish surface can offer an org/Team visibility choice by supplying it.
- `publishArtifactBundle` / `buildArtifactPublishWiring` now accept `tier`/`scopeId`/`orgId`, so callers can publish to non-user scopes without touching the 3-step flow.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (typecheck, tests, lint all pass)