### PR TITLE
test(client): consumer-level regression test for Agent Mode admin kill switch

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/SessionToolbar.test.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionToolbar.test.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+/**
+ * Consumer-level regression guard for the Agent Mode admin kill switch.
+ *
+ * Agent Mode is admin-gated. A prior P1 fixed SessionToolbar bypassing the admin
+ * gate by reading `experimentalFeatures.agentMode` directly; it now resolves the
+ * Layer-1 gate via `useFeatureEnabled('agentMode')` (SessionToolbar.tsx:148-149),
+ * and both the bolt (AgentModeToggleButton) and the chip render only when that
+ * gate is true (SessionToolbar.tsx:339, :387).
+ *
+ * This test locks the consumer behavior: the bolt is present when the gate is on
+ * and absent when the admin kill switch is off. It fails if the render condition
+ * is swapped back to a raw `experimentalFeatures.agentMode` read, because the
+ * mock only controls the resolved `isFeatureEnabled('agentMode')` value.
+ */
+
+const mocks = vi.hoisted(() => ({
+  // Resolved value of isFeatureEnabled('agentMode') - the Layer-1 admin gate.
+  agentModeFlag: { value: false },
+}));
+
+// The kill switch under test: SessionToolbar reads the gate through this hook.
+vi.mock('@client/app/hooks/useFeatureEnabled', () => ({
+  useFeatureEnabled: () => ({
+    isFeatureEnabled: (feature: string) => (feature === 'agentMode' ? mocks.agentModeFlag.value : false),
+    isAdminFeatureEnabled: () => false,
+  }),
+}));
+
+// SessionToolbar imports `api` at module load (used inside onOptimizePrompt).
+vi.mock('@client/app/contexts/ApiContext', () => ({ api: { post: vi.fn(), get: vi.fn() } }));
+
+// The global WebsocketContext mock in vitest.setup.ts does NOT export `ReadyState`,
+// but SessionToolbar imports it (and this test uses ReadyState.OPEN for baseProps).
+// Re-mock locally to provide the enum plus a benign useWebsocket.
+vi.mock('@client/app/contexts/WebsocketContext', () => ({
+  ReadyState: { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 },
+  useWebsocket: () => ({ subscribe: vi.fn(), unsubscribe: vi.fn(), send: vi.fn(), isConnected: true }),
+}));
+
+// Stub every child SessionToolbar imports so only its own gate markup renders and
+// no child pulls in its own context/`@/`-alias chain. The two agent-mode children
+// keep their testids so the gate is observable without mounting LLMContext.
+vi.mock('@client/app/components/Session/SessionBottom/AgentModeToggleButton', () => ({
+  default: () => <div data-testid="agent-mode-toggle-btn" />,
+}));
+vi.mock('@client/app/components/Session/SessionBottom/AgentModeChip', () => ({
+  default: () => <div data-testid="agent-mode-chip" />,
+}));
+vi.mock('@client/app/components/Session/AttachFileButton', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/AISettings/FilesSection', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/AdvancedAISettings', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/RephraseButton', () => ({ default: () => null }));
+vi.mock('@client/app/components/common/VoiceRecordButton', () => {
+  const VoiceRecordButtonStub = React.forwardRef<HTMLDivElement>(() => null);
+  VoiceRecordButtonStub.displayName = 'VoiceRecordButtonStub';
+  return { default: VoiceRecordButtonStub };
+});
+vi.mock('@client/app/components/Session/VoiceSessionModal/VoiceInlineIndicator', () => ({
+  default: () => null,
+  VoiceControlsStrip: () => null,
+  VOICE_DEBUG_STATE: false,
+}));
+vi.mock('@client/app/components/Session/ConversationalVoice/ConversationalVoiceButton', () => ({
+  default: () => null,
+}));
+
+import { SessionToolbar } from './SessionToolbar';
+import { ReadyState } from '@client/app/contexts/WebsocketContext';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+// All ~40 SessionToolbar props (SessionToolbar.tsx:33-91). Handlers are vi.fn(),
+// the composer is empty and no voice session is active so the render stays on the
+// simplest branch (no send/stop button, no files dropdown).
+const baseProps = {
+  isMobile: false,
+  mode: 'light' as const,
+  canAttachFiles: true,
+  workBenchFiles: [],
+  currentSessionId: null,
+  currentSession: null,
+  setWorkBenchFiles: vi.fn(),
+  setCurrentSession: vi.fn(),
+  toggleFileUpload: vi.fn(),
+  setFileBrowserOpen: vi.fn(),
+  rollRandomDice: vi.fn(),
+  isSessionFileMode: false,
+  setIsSessionFileMode: vi.fn(),
+  totalFilesCount: 0,
+  hasEmbeddingMismatches: false,
+  model: 'gpt-4o',
+  filesDropdownOpen: false,
+  setFilesDropdownOpen: vi.fn(),
+  chatInputValue: '',
+  setChatInputValue: vi.fn(),
+  setRephraseGlow: vi.fn(),
+  stream: true,
+  setStream: vi.fn(),
+  spokenWords: 0,
+  setSpokenWords: vi.fn(),
+  submitting: false,
+  stoppingMessage: false,
+  shouldShowStopButton: false,
+  handleSendClick: vi.fn(),
+  handleStopMessage: vi.fn(),
+  pendingAutoSubmitGoal: null,
+  readyState: ReadyState.OPEN,
+  hasActiveUploads: false,
+  accessibleModels: [],
+  isModelsLoading: false,
+  isVoiceSessionEnabled: false,
+  voiceEngine: null,
+  creditsBlocked: false,
+  setDebugDrawerOpen: vi.fn(),
+};
+
+beforeEach(() => {
+  mocks.agentModeFlag.value = false;
+});
+
+describe('SessionToolbar - Agent Mode admin kill switch', () => {
+  it('renders the Agent-mode bolt when the agentMode gate is enabled', () => {
+    mocks.agentModeFlag.value = true; // admin gate ON
+    render(<SessionToolbar {...baseProps} />, { wrapper: Wrapper });
+    expect(screen.getByTestId('agent-mode-toggle-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-mode-chip')).toBeInTheDocument();
+  });
+
+  it('does NOT render the Agent-mode bolt when the admin kill switch is off', () => {
+    mocks.agentModeFlag.value = false; // admin kill switch OFF
+    render(<SessionToolbar {...baseProps} />, { wrapper: Wrapper });
+    expect(screen.queryByTestId('agent-mode-toggle-btn')).toBeNull();
+    expect(screen.queryByTestId('agent-mode-chip')).toBeNull();
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.killSwitch.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.killSwitch.test.ts
@@ -21,23 +21,32 @@ import { resolve } from 'path';
  */
 describe('useSendMessage - Agent Mode admin kill switch (regression)', () => {
   const source = readFileSync(resolve(__dirname, 'useSendMessage.ts'), 'utf8');
-  // Collapse whitespace so multi-line definitions match a single-line assertion.
-  const normalized = source.replace(/\s+/g, ' ');
+  // Strip comments first so a future comment mentioning the flag can't false-fail
+  // the negative assertions, then collapse whitespace so multi-line definitions
+  // match a single-line substring.
+  const codeOnly = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+  const normalized = codeOnly.replace(/\s+/g, ' ');
 
   it('resolves the Layer-1 gate through useFeatureEnabled, not a raw flag read', () => {
-    expect(source).toContain("isFeatureEnabled('agentMode')");
-    expect(source).toContain('const agentModeFeatureEnabled = isFeatureEnabled(');
+    expect(normalized).toContain("isFeatureEnabled('agentMode')");
+    expect(normalized).toContain('const agentModeFeatureEnabled = isFeatureEnabled(');
   });
 
   it('AND-gates every routing signal on agentModeFeatureEnabled', () => {
+    // All four signals that can route a send to agent_executor. autoRouteEnabled
+    // feeds routeQuery directly (the heuristic auto-route / recharts bypass path),
+    // so it must stay gated alongside the toggle/default/classifier signals.
     expect(normalized).toContain('const agentToggleActive = agentModeFeatureEnabled &&');
     expect(normalized).toContain('const agentDefaultOn = agentModeFeatureEnabled &&');
     expect(normalized).toContain('const classifierEligible = agentModeFeatureEnabled &&');
+    expect(normalized).toContain('const autoRouteEnabled = agentModeFeatureEnabled &&');
   });
 
   it('never reads the raw experimentalFeatures.agentMode flag (the bypass the P1 removed)', () => {
     // Covers dot, optional-chain, and bracket access:
     // experimentalFeatures.agentMode / ?.agentMode / ['agentMode'] / ["agentMode"].
-    expect(source).not.toMatch(/experimentalFeatures\s*\??\s*(\.\s*agentMode|\[\s*['"]agentMode['"]\s*\])/);
+    expect(codeOnly).not.toMatch(/experimentalFeatures\s*\??\s*(\.\s*agentMode|\[\s*['"]agentMode['"]\s*\])/);
+    // ...and destructure access: { agentMode } = experimentalFeatures.
+    expect(codeOnly).not.toMatch(/\{[^}]*\bagentMode\b[^}]*\}\s*=\s*experimentalFeatures/);
   });
 });

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.killSwitch.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.killSwitch.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Consumer-level regression guard for the Agent Mode admin kill switch in
+ * useSendMessage - the hook that actually routes a send to `agent_executor`.
+ *
+ * Agent Mode is admin-gated. A prior P1 fixed useSendMessage bypassing the admin
+ * gate by reading `experimentalFeatures.agentMode` directly; every routing signal
+ * (`agentToggleActive`, `agentDefaultOn`, `classifierEligible`) is now AND-gated on
+ * `agentModeFeatureEnabled = isFeatureEnabled('agentMode')`, so flipping the admin
+ * master gate (`EnableAgentMode`) off forces all three to false and no send routes
+ * to the executor via the toggle/default/classifier paths.
+ *
+ * A source-level assertion is used (rather than a full `renderHook`) because
+ * `useSendMessage` consumes ~15 context providers; this mirrors the existing
+ * useSendMessage.hostCreate.test.ts pattern and locks the invariant cheaply.
+ * The test fails if any gate is swapped back to a raw `experimentalFeatures.agentMode`
+ * read.
+ */
+describe('useSendMessage - Agent Mode admin kill switch (regression)', () => {
+  const source = readFileSync(resolve(__dirname, 'useSendMessage.ts'), 'utf8');
+  // Collapse whitespace so multi-line definitions match a single-line assertion.
+  const normalized = source.replace(/\s+/g, ' ');
+
+  it('resolves the Layer-1 gate through useFeatureEnabled, not a raw flag read', () => {
+    expect(source).toContain("isFeatureEnabled('agentMode')");
+    expect(source).toContain('const agentModeFeatureEnabled = isFeatureEnabled(');
+  });
+
+  it('AND-gates every routing signal on agentModeFeatureEnabled', () => {
+    expect(normalized).toContain('const agentToggleActive = agentModeFeatureEnabled &&');
+    expect(normalized).toContain('const agentDefaultOn = agentModeFeatureEnabled &&');
+    expect(normalized).toContain('const classifierEligible = agentModeFeatureEnabled &&');
+  });
+
+  it('never reads the raw experimentalFeatures.agentMode flag (the bypass the P1 removed)', () => {
+    expect(source).not.toMatch(/experimentalFeatures\s*\??\s*\.\s*agentMode/);
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.killSwitch.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.killSwitch.test.ts
@@ -36,6 +36,8 @@ describe('useSendMessage - Agent Mode admin kill switch (regression)', () => {
   });
 
   it('never reads the raw experimentalFeatures.agentMode flag (the bypass the P1 removed)', () => {
-    expect(source).not.toMatch(/experimentalFeatures\s*\??\s*\.\s*agentMode/);
+    // Covers dot, optional-chain, and bracket access:
+    // experimentalFeatures.agentMode / ?.agentMode / ['agentMode'] / ["agentMode"].
+    expect(source).not.toMatch(/experimentalFeatures\s*\??\s*(\.\s*agentMode|\[\s*['"]agentMode['"]\s*\])/);
   });
 });


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<!-- Not applicable: test-only change, no UI or visual behavior is modified. -->

N/A - test-only change, no UI modified.

## Description

Closes #85.

Agent Mode / Smart Routing is an admin-gated Beta feature. A prior P1 fixed two composer call sites that bypassed the admin gate by reading `experimentalFeatures.agentMode` directly; both now resolve the Layer-1 gate via `useFeatureEnabled('agentMode')`:

- `apps/client/app/components/Session/SessionBottom/SessionToolbar.tsx` (renders the Agent-mode bolt)
- `apps/client/app/components/Session/SessionBottom/useSendMessage.ts` (routes a send to `agent_executor`)

That fix was covered only at the gate level (`useFeatureEnabled.test.ts`). There was no consumer-level regression test, so a future refactor of either consumer could silently restore the raw read and CI would stay green. This PR adds consumer-side coverage for both call sites so the admin kill switch is provably enforced where it is consumed.

The `useSendMessage` guard is intentionally a source-level assertion (not a full `renderHook`) because that hook consumes ~15 context providers; this mirrors the existing `useSendMessage.hostCreate.test.ts` precedent and locks the invariant cheaply.

## Changes

- Add `SessionToolbar.test.tsx` (new; first component test in `SessionBottom/`):
  - Mounts `SessionToolbar` with `useFeatureEnabled` mocked and heavy children stubbed.
  - Asserts the Agent-mode bolt (`data-testid="agent-mode-toggle-btn"`) and chip (`agent-mode-chip`) render when the gate is on, and are absent when the admin kill switch is off.
- Add `useSendMessage.killSwitch.test.ts` (new; source-level regression):
  - Asserts the Layer-1 gate is resolved via `isFeatureEnabled('agentMode')`.
  - Asserts every routing signal (`agentToggleActive`, `agentDefaultOn`, `classifierEligible`) stays AND-gated on `agentModeFeatureEnabled`.
  - Asserts the hook never reads the raw `experimentalFeatures.agentMode` flag via dot, optional-chain, or bracket access (the exact bypass the P1 removed).
- No production code changed.

## Guide for Testers

This is a test-only PR - there is no UI to click. Verification is automated (Run Tests in CI). To validate locally:

1. From the repo root, run: `cd apps/client && pnpm test SessionToolbar.test useSendMessage.killSwitch`
2. Expected: 2 test files pass, 5 tests pass, no failures.

### Regression Checks (proves the guards actually bite)

1. Edit `apps/client/app/components/Session/SessionBottom/SessionToolbar.tsx` line ~339 and make the bolt render unconditionally (remove the `agentModeFeatureEnabled &&` guard).
2. Run `cd apps/client && pnpm test SessionToolbar.test`.
   - Expected: the "does NOT render the Agent-mode bolt when the admin kill switch is off" test FAILS. Revert the edit.
3. Edit `apps/client/app/components/Session/SessionBottom/useSendMessage.ts` line ~465 and drop `agentModeFeatureEnabled &&` from `agentToggleActive`.
4. Run `cd apps/client && pnpm test useSendMessage.killSwitch`.
   - Expected: the "AND-gates every routing signal" test FAILS. Revert the edit.

### What NOT to test

- No runtime/product behavior changes - do not look for UI differences in the composer.
- No API, database, telemetry, or infra changes.

## Additional Information

- Test runner: vitest (jsdom). Harness mirrors `apps/client/app/components/Session/AISettings/ToolsSection.gating.test.tsx`.
- One non-obvious detail handled: the global `WebsocketContext` mock in `vitest.setup.ts` does not export `ReadyState`, but `SessionToolbar` imports it, so the test re-mocks `WebsocketContext` locally to provide the `ReadyState` enum.
- CI gates verified locally: `pnpm turbo:typecheck` (44/44), `pnpm lint:check` (clean).

## Developer Notes (Optional)

- `SessionToolbar.test.tsx` establishes a reusable render-harness pattern for `SessionBottom/` components: `vi.hoisted` mutable gate flag + mocked `useFeatureEnabled` + child stubs (agent-mode children keep their testids) + `extendTheme(getThemeConfig())` / `CssVarsProvider` wrapper. Future `SessionBottom` component tests can copy this setup.
- The source-level regression pattern (read `useSendMessage.ts` and assert on gating idioms) is now used by two suites (`hostCreate`, `killSwitch`) as the standard way to lock invariants on this ~15-provider hook without a full render.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A (no AdminSettings changes)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A (test-only)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings
