### PR TITLE
fix(agent-mode): honor briefcase toolsOverride on the orchestration path

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/resolveDispatchTools.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/resolveDispatchTools.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import type { B4MLLMTools } from '@bike4mind/common';
+import { resolveDispatchTools } from './resolveDispatchTools';
+
+/**
+ * Before/after regression for #95. Drives the real dispatch decision the hook
+ * uses, comparing it against the pre-fix behavior (the agent-executor branch
+ * always used the agent's own whitelist, ignoring the briefcase override).
+ */
+
+// Pre-fix behavior: `const enabledTools = orchestrationAgent?.allowedTools`.
+const beforeFix = (
+  _toolsOverride: B4MLLMTools[] | undefined,
+  _effectiveTools: B4MLLMTools[],
+  agentAllowedTools: string[] | undefined
+): string[] | undefined => agentAllowedTools;
+
+interface Scenario {
+  name: string;
+  toolsOverride: B4MLLMTools[] | undefined;
+  effectiveTools: B4MLLMTools[];
+  agentAllowedTools: string[] | undefined;
+  expected: string[] | undefined;
+  changedByFix: boolean;
+}
+
+const scenarios: Scenario[] = [
+  {
+    name: 'briefcase override + @mentioned agent',
+    toolsOverride: ['web_search'],
+    effectiveTools: ['web_search'],
+    agentAllowedTools: ['mermaid_chart'],
+    expected: ['web_search'], // the bug: was ['mermaid_chart']
+    changedByFix: true,
+  },
+  {
+    name: 'no override, @mentioned agent (unchanged)',
+    toolsOverride: undefined,
+    effectiveTools: [],
+    agentAllowedTools: ['mermaid_chart'],
+    expected: ['mermaid_chart'],
+    changedByFix: false,
+  },
+  {
+    name: 'no override, agentless (unchanged, synthetic profile)',
+    toolsOverride: undefined,
+    effectiveTools: [],
+    agentAllowedTools: undefined,
+    expected: undefined,
+    changedByFix: false,
+  },
+  {
+    name: 'empty override is not a real override (unchanged)',
+    toolsOverride: [],
+    effectiveTools: ['recharts'],
+    agentAllowedTools: ['mermaid_chart'],
+    expected: ['mermaid_chart'],
+    changedByFix: false,
+  },
+];
+
+describe('resolveDispatchTools (#95 before/after regression)', () => {
+  it('prints the before/after table', () => {
+    const rows = scenarios.map(s => {
+      const before = beforeFix(s.toolsOverride, s.effectiveTools, s.agentAllowedTools);
+      const after = resolveDispatchTools(s.toolsOverride, s.effectiveTools, s.agentAllowedTools);
+      return {
+        scenario: s.name,
+        before: JSON.stringify(before),
+        after: JSON.stringify(after),
+        changed: JSON.stringify(before) !== JSON.stringify(after),
+      };
+    });
+    console.table(rows);
+    expect(rows).toHaveLength(scenarios.length);
+  });
+
+  it.each(scenarios)('$name', s => {
+    const after = resolveDispatchTools(s.toolsOverride, s.effectiveTools, s.agentAllowedTools);
+    // New behavior matches expectation.
+    expect(after).toEqual(s.expected);
+    // Only the bug scenario changes vs the pre-fix behavior; everything else holds.
+    const before = beforeFix(s.toolsOverride, s.effectiveTools, s.agentAllowedTools);
+    expect(JSON.stringify(before) !== JSON.stringify(after)).toBe(s.changedByFix);
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/resolveDispatchTools.ts
+++ b/apps/client/app/components/Session/SessionBottom/resolveDispatchTools.ts
@@ -1,0 +1,15 @@
+import type { B4MLLMTools } from '@bike4mind/common';
+
+/**
+ * Tool whitelist for an agent-executor dispatch: a non-empty briefcase
+ * `toolsOverride` wins (already resolved into `effectiveTools`) so an
+ * `@`-mention can't drop the tools the prompt pinned; otherwise the agent's own
+ * whitelist. The `length > 0` guard matches `resolveTools` (empty is no override).
+ */
+export function resolveDispatchTools(
+  toolsOverride: B4MLLMTools[] | undefined,
+  effectiveTools: B4MLLMTools[],
+  agentAllowedTools: string[] | undefined
+): string[] | undefined {
+  return toolsOverride && toolsOverride.length > 0 ? effectiveTools : agentAllowedTools;
+}

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts
@@ -15,7 +15,7 @@ import { resolve } from 'path';
  * consumes ~15 context providers, so a full render adds little signal beyond
  * locking these invariants.
  */
-describe('useSendMessage — briefcase toolsOverride on the orchestration path (#95)', () => {
+describe('useSendMessage - briefcase toolsOverride on the orchestration path (#95)', () => {
   const source = readFileSync(resolve(__dirname, 'useSendMessage.ts'), 'utf8');
 
   it('threads the briefcase override into the agent-executor dispatch, else falls back to the agent whitelist', () => {

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts
@@ -3,9 +3,10 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 /**
- * Regression guard for #95: when a briefcase prompt @-mentions an orchestration
- * agent, the agent-executor branch must still honor the briefcase `toolsOverride`
- * rather than dropping it for the agent's own `allowedTools`.
+ * Wiring guard for #95. The dispatch *behavior* is verified in
+ * `resolveDispatchTools.test.ts`; this locks that the hook actually uses that
+ * decision for the agent-executor dispatch, and that the unsupported-tool
+ * refusal still runs first.
  *
  * Source-level assertions (not `renderHook`) match the sibling
  * `useSendMessage.hostCreate.test.ts`: the hook pulls in ~15 providers, so a
@@ -14,9 +15,9 @@ import { resolve } from 'path';
 describe('useSendMessage - briefcase toolsOverride on the orchestration path (#95)', () => {
   const source = readFileSync(resolve(__dirname, 'useSendMessage.ts'), 'utf8');
 
-  it('threads the briefcase override into the agent-executor dispatch, else falls back to the agent whitelist', () => {
+  it('derives enabledTools from resolveDispatchTools(toolsOverride, effectiveTools, agent whitelist)', () => {
     expect(source).toMatch(
-      /const enabledTools\s*=\s*options\?\.toolsOverride\s*\?\s*effectiveTools\s*:\s*orchestrationAgent\?\.allowedTools;/
+      /const enabledTools\s*=\s*resolveDispatchTools\(\s*options\?\.toolsOverride,\s*effectiveTools,\s*orchestrationAgent\?\.allowedTools\s*\);/
     );
   });
 

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression guard for #95: a briefcase launch pins the tools its prompt needs
+ * via `toolsOverride`. When that prompt also @-mentions an orchestration agent,
+ * `useSendMessage` routes the send through the agent-executor branch. That
+ * branch must still honor the briefcase override rather than sourcing
+ * `enabledTools` solely from the agent's `allowedTools` (which would drop the
+ * briefcase's required tools and run the prompt without them).
+ *
+ * A source-level assertion is used (rather than a full `renderHook`) to match
+ * the sibling `useSendMessage.hostCreate.test.ts` guard: `useSendMessage`
+ * consumes ~15 context providers, so a full render adds little signal beyond
+ * locking these invariants.
+ */
+describe('useSendMessage — briefcase toolsOverride on the orchestration path (#95)', () => {
+  const source = readFileSync(resolve(__dirname, 'useSendMessage.ts'), 'utf8');
+
+  it('threads the briefcase override into the agent-executor dispatch, else falls back to the agent whitelist', () => {
+    // `enabledTools` prefers the resolved `effectiveTools` (the
+    // BRIEFCASE_DISALLOWED-stripped override the normal path uses) when a
+    // briefcase `toolsOverride` is present, and falls back to the orchestration
+    // agent's own whitelist otherwise.
+    expect(source).toMatch(
+      /const enabledTools\s*=\s*options\?\.toolsOverride\s*\?\s*effectiveTools\s*:\s*orchestrationAgent\?\.allowedTools;/
+    );
+  });
+
+  it('assigns enabledTools inside the agent-executor branch and passes it to agentExecution.start', () => {
+    const branchIdx = source.indexOf("routeTarget === 'agent_executor'");
+    const enabledToolsIdx = source.indexOf('const enabledTools =');
+    const startIdx = source.indexOf('agentExecution.start(');
+    expect(branchIdx).toBeGreaterThan(-1);
+    // The whitelist is derived inside the branch and forwarded to the dispatch.
+    expect(enabledToolsIdx).toBeGreaterThan(branchIdx);
+    expect(startIdx).toBeGreaterThan(enabledToolsIdx);
+    expect(source).toMatch(/agentExecution\.start\(\{[\s\S]*?\benabledTools\b[\s\S]*?\}\);/);
+  });
+
+  it('keeps the unsupported-tool refusal ahead of the orchestration branch (refusal still applies)', () => {
+    // The refusal guard for a briefcase override on a tools-incapable model runs
+    // unconditionally before routing, so the agent-executor branch never needs
+    // its own refusal handling. This ordering is load-bearing.
+    const refusedIdx = source.indexOf('if (refused)');
+    const branchIdx = source.indexOf("routeTarget === 'agent_executor'");
+    expect(refusedIdx).toBeGreaterThan(-1);
+    expect(branchIdx).toBeGreaterThan(-1);
+    expect(refusedIdx).toBeLessThan(branchIdx);
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts
@@ -3,26 +3,18 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 /**
- * Regression guard for #95: a briefcase launch pins the tools its prompt needs
- * via `toolsOverride`. When that prompt also @-mentions an orchestration agent,
- * `useSendMessage` routes the send through the agent-executor branch. That
- * branch must still honor the briefcase override rather than sourcing
- * `enabledTools` solely from the agent's `allowedTools` (which would drop the
- * briefcase's required tools and run the prompt without them).
+ * Regression guard for #95: when a briefcase prompt @-mentions an orchestration
+ * agent, the agent-executor branch must still honor the briefcase `toolsOverride`
+ * rather than dropping it for the agent's own `allowedTools`.
  *
- * A source-level assertion is used (rather than a full `renderHook`) to match
- * the sibling `useSendMessage.hostCreate.test.ts` guard: `useSendMessage`
- * consumes ~15 context providers, so a full render adds little signal beyond
- * locking these invariants.
+ * Source-level assertions (not `renderHook`) match the sibling
+ * `useSendMessage.hostCreate.test.ts`: the hook pulls in ~15 providers, so a
+ * full render adds little over locking these invariants.
  */
 describe('useSendMessage - briefcase toolsOverride on the orchestration path (#95)', () => {
   const source = readFileSync(resolve(__dirname, 'useSendMessage.ts'), 'utf8');
 
   it('threads the briefcase override into the agent-executor dispatch, else falls back to the agent whitelist', () => {
-    // `enabledTools` prefers the resolved `effectiveTools` (the
-    // BRIEFCASE_DISALLOWED-stripped override the normal path uses) when a
-    // briefcase `toolsOverride` is present, and falls back to the orchestration
-    // agent's own whitelist otherwise.
     expect(source).toMatch(
       /const enabledTools\s*=\s*options\?\.toolsOverride\s*\?\s*effectiveTools\s*:\s*orchestrationAgent\?\.allowedTools;/
     );
@@ -33,16 +25,14 @@ describe('useSendMessage - briefcase toolsOverride on the orchestration path (#9
     const enabledToolsIdx = source.indexOf('const enabledTools =');
     const startIdx = source.indexOf('agentExecution.start(');
     expect(branchIdx).toBeGreaterThan(-1);
-    // The whitelist is derived inside the branch and forwarded to the dispatch.
     expect(enabledToolsIdx).toBeGreaterThan(branchIdx);
     expect(startIdx).toBeGreaterThan(enabledToolsIdx);
     expect(source).toMatch(/agentExecution\.start\(\{[\s\S]*?\benabledTools\b[\s\S]*?\}\);/);
   });
 
   it('keeps the unsupported-tool refusal ahead of the orchestration branch (refusal still applies)', () => {
-    // The refusal guard for a briefcase override on a tools-incapable model runs
-    // unconditionally before routing, so the agent-executor branch never needs
-    // its own refusal handling. This ordering is load-bearing.
+    // The refusal runs before routing, so the agent-executor branch needs none
+    // of its own. This ordering is load-bearing.
     const refusedIdx = source.indexOf('if (refused)');
     const branchIdx = source.indexOf("routeTarget === 'agent_executor'");
     expect(refusedIdx).toBeGreaterThan(-1);

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -24,6 +24,7 @@ import { useSessions, useWorkBenchFiles } from '@client/app/contexts/SessionsCon
 import { handleLLMCommand } from '@client/app/components/commands/LLMCommand';
 import { commandHandlers } from './sessionBottomConstants';
 import { pickRoutingSource } from './pickRoutingSource';
+import { resolveDispatchTools } from './resolveDispatchTools';
 import { useSessionCacheMigration } from '../hooks/useSessionCacheMigration';
 import { useLLMSettingsAssembly } from '../hooks/useLLMSettingsAssembly';
 import { useProgrammaticSubmit } from '../hooks/useProgrammaticSubmit';
@@ -831,10 +832,13 @@ export function useSendMessage({
         // the executor fills it from admin defaults.
         const thoroughness = orchestrationAgent?.defaultThoroughness ?? 'medium';
         const maxIters = orchestrationAgent?.maxIterations?.[thoroughness];
-        // A briefcase `toolsOverride` wins the whitelist (`effectiveTools` is the
-        // resolved override), so an `@`-mention can't drop the tools the prompt
-        // needs. Otherwise use the agent's own whitelist.
-        const enabledTools = options?.toolsOverride ? effectiveTools : orchestrationAgent?.allowedTools;
+        // A briefcase `toolsOverride` wins the whitelist so an `@`-mention can't
+        // drop the tools the prompt needs (see `resolveDispatchTools`).
+        const enabledTools = resolveDispatchTools(
+          options?.toolsOverride,
+          effectiveTools,
+          orchestrationAgent?.allowedTools
+        );
         // Per-message file attachments - dedupe against the session-level set
         // so the same fabFileId isn't materialized twice into the first
         // iteration. Mirrors the dedup the `chat_completion` flow does in

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -758,8 +758,8 @@ export function useSendMessage({
     // L251), so the optimistic client-side ID won't work - we must create
     // the session first. The dispatch payload differs by mode:
     //   - With `orchestrationAgent`: use its preferred model + tool whitelist
-    //     (preserves the earlier `@specific-agent` UX), except a briefcase
-    //     `toolsOverride` still pins the tool whitelist (see `enabledTools` below).
+    //     (preserves the earlier `@specific-agent` UX). A briefcase
+    //     `toolsOverride` still wins the whitelist (see `enabledTools` below).
     //   - Without (toggle ON or `@agent` literal): dispatch agentless and let
     //     the executor build a synthetic profile from admin defaults.
     if (routeTarget === 'agent_executor') {
@@ -827,24 +827,13 @@ export function useSendMessage({
         // optimistic bubble instead of waiting for the persisted Quest on reload.
         createOptimisticPromptBubble(queryClient, dispatchSessionId, prompt, routingSource);
 
-        // When dispatched with a specific orchestration agent, source the
-        // per-thoroughness iteration cap from the agent doc. When dispatched
-        // agentless (toggle / `@agent` literal), leave it unset so the
-        // executor's synthetic-profile builder fills it from admin defaults.
-        // (Tool whitelist precedence is handled separately just below.)
+        // Iteration cap comes from the agent doc; left unset when agentless so
+        // the executor fills it from admin defaults.
         const thoroughness = orchestrationAgent?.defaultThoroughness ?? 'medium';
         const maxIters = orchestrationAgent?.maxIterations?.[thoroughness];
-        // Tool whitelist precedence. A briefcase launch pins the tools its
-        // prompt needs via `toolsOverride`; honor that here just as the
-        // non-orchestration path does (`resolveTools` short-circuits its whole
-        // ladder on an override). Without it, a briefcase prompt that happens to
-        // @-mention an orchestration agent would silently run under the agent's
-        // `allowedTools` and drop the briefcase's required tools. `effectiveTools`
-        // is the same value the normal path sends: the `BRIEFCASE_DISALLOWED`-
-        // stripped override (the unsupported-model refusal already fired above,
-        // so we never reach here with a broken override). Absent a briefcase
-        // override, fall back to the orchestration agent's own whitelist (or
-        // `undefined` when agentless, which triggers the synthetic-profile path).
+        // A briefcase `toolsOverride` wins the whitelist (`effectiveTools` is the
+        // resolved override), so an `@`-mention can't drop the tools the prompt
+        // needs. Otherwise use the agent's own whitelist.
         const enabledTools = options?.toolsOverride ? effectiveTools : orchestrationAgent?.allowedTools;
         // Per-message file attachments - dedupe against the session-level set
         // so the same fabFileId isn't materialized twice into the first

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -828,10 +828,10 @@ export function useSendMessage({
         createOptimisticPromptBubble(queryClient, dispatchSessionId, prompt, routingSource);
 
         // When dispatched with a specific orchestration agent, source the
-        // per-thoroughness iteration cap + tool whitelist from the agent doc.
-        // When dispatched agentless (toggle / `@agent` literal), leave both
-        // unset so the executor's synthetic-profile builder fills them from
-        // admin defaults.
+        // per-thoroughness iteration cap from the agent doc. When dispatched
+        // agentless (toggle / `@agent` literal), leave it unset so the
+        // executor's synthetic-profile builder fills it from admin defaults.
+        // (Tool whitelist precedence is handled separately just below.)
         const thoroughness = orchestrationAgent?.defaultThoroughness ?? 'medium';
         const maxIters = orchestrationAgent?.maxIterations?.[thoroughness];
         // Tool whitelist precedence. A briefcase launch pins the tools its

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -758,7 +758,8 @@ export function useSendMessage({
     // L251), so the optimistic client-side ID won't work - we must create
     // the session first. The dispatch payload differs by mode:
     //   - With `orchestrationAgent`: use its preferred model + tool whitelist
-    //     (preserves the earlier `@specific-agent` UX).
+    //     (preserves the earlier `@specific-agent` UX), except a briefcase
+    //     `toolsOverride` still pins the tool whitelist (see `enabledTools` below).
     //   - Without (toggle ON or `@agent` literal): dispatch agentless and let
     //     the executor build a synthetic profile from admin defaults.
     if (routeTarget === 'agent_executor') {
@@ -833,7 +834,18 @@ export function useSendMessage({
         // admin defaults.
         const thoroughness = orchestrationAgent?.defaultThoroughness ?? 'medium';
         const maxIters = orchestrationAgent?.maxIterations?.[thoroughness];
-        const enabledTools = orchestrationAgent?.allowedTools;
+        // Tool whitelist precedence. A briefcase launch pins the tools its
+        // prompt needs via `toolsOverride`; honor that here just as the
+        // non-orchestration path does (`resolveTools` short-circuits its whole
+        // ladder on an override). Without it, a briefcase prompt that happens to
+        // @-mention an orchestration agent would silently run under the agent's
+        // `allowedTools` and drop the briefcase's required tools. `effectiveTools`
+        // is the same value the normal path sends: the `BRIEFCASE_DISALLOWED`-
+        // stripped override (the unsupported-model refusal already fired above,
+        // so we never reach here with a broken override). Absent a briefcase
+        // override, fall back to the orchestration agent's own whitelist (or
+        // `undefined` when agentless, which triggers the synthetic-profile path).
+        const enabledTools = options?.toolsOverride ? effectiveTools : orchestrationAgent?.allowedTools;
         // Per-message file attachments - dedupe against the session-level set
         // so the same fabFileId isn't materialized twice into the first
         // iteration. Mirrors the dedup the `chat_completion` flow does in


### PR DESCRIPTION
## Optional Screenshot/Video

[pr146-briefcase-toolsoverride.webm](https://github.com/user-attachments/assets/75607b79-5215-4ed9-bc3c-58fff311bc81)

*Live preview capture: a briefcase prompt pinning `web_search` that also @-mentions an orchestration agent (whose own `allowedTools` is `mermaid_chart`) dispatches `agent_execute` with `enabledTools: ["web_search"]` via `routingSource: mention` - the briefcase's pinned tool reaches the agent instead of being replaced by the agent's own whitelist.*

## Description
Closes #95.

When a briefcase prompt's `promptText` contains an `@agent-name` mention, `useSendMessage` routes the send through the orchestration (agent-executor) branch. That branch sourced the dispatched tool whitelist (`enabledTools`) solely from the mentioned agent's `allowedTools` and never forwarded the briefcase's `toolsOverride`. As a result, a briefcase prompt that happens to @-mention an orchestration agent ran without the tools the briefcase pinned as required.

The fix threads the already-resolved `effectiveTools` (the same `BRIEFCASE_DISALLOWED`-stripped override the non-orchestration path sends) into the agent-executor dispatch whenever a briefcase `toolsOverride` is present, falling back to the agent's own whitelist otherwise. Precedence: a non-empty briefcase override wins over the agent whitelist, matching the non-orchestration path where `resolveTools` short-circuits its whole ladder on an override.

### Scope note (issue text was partly stale)
The issue also described the unsupported-tool refusal as bypassed. In the current code that refusal (`resolveTools` -> `if (refused) return`) already runs unconditionally before the routing branch, so it applies to the orchestration path today; no change was needed there. This PR is scoped to the remaining, real gap: the tool-whitelist bypass. A test locks the refusal ordering so it stays that way.

## Changes
- `apps/client/app/components/Session/SessionBottom/resolveDispatchTools.ts` (new): a pure `resolveDispatchTools(toolsOverride, effectiveTools, agentAllowedTools)` that encodes the precedence - a non-empty briefcase override wins (returns the resolved `effectiveTools`), otherwise the agent's own whitelist. The `length > 0` guard matches `resolveTools`, so an empty `requiredTools` list does not divert from the agent whitelist.
- `apps/client/app/components/Session/SessionBottom/useSendMessage.ts`: the `agent_executor` branch now derives `enabledTools` via `resolveDispatchTools(...)` instead of sourcing it only from `orchestrationAgent?.allowedTools`. Adjacent dispatch comments updated so they no longer imply the tool whitelist always comes from the agent doc.
- `apps/client/app/components/Session/SessionBottom/resolveDispatchTools.test.ts` (new): behavioral before/after regression that drives the real decision function over four scenarios and asserts only the bug case changes vs the pre-fix behavior.
- `apps/client/app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts` (new): source-level wiring guard (mirrors the sibling `useSendMessage.hostCreate.test.ts`, since the hook consumes ~15 context providers) asserting the hook uses `resolveDispatchTools` for the dispatch and that the unsupported-tool refusal still precedes the orchestration branch.

## Guide for Testers
This is a client dispatch-logic change; the effect is which tools the agent-executor receives, not a visual difference.

1. Unit tests (authoritative). Run:
   `pnpm --filter @bike4mind/client exec vitest run app/components/Session/SessionBottom/resolveDispatchTools.test.ts app/components/Session/SessionBottom/useSendMessage.toolsOverride.test.ts`
   - Expected: 2 files passed, 8 tests passed. The `resolveDispatchTools` suite prints a before/after table where only the "briefcase override + @mentioned agent" row changes (pre-fix `mermaid_chart` -> post-fix `web_search`).
2. Behavioral evidence (attached video). On the PR preview, a briefcase prompt pinning `web_search` that @-mentions an orchestration agent (own tools `mermaid_chart`) was launched; the intercepted `agent_execute` frame carried `enabledTools: ["web_search"]`.
3. Manual regression (optional): launch a briefcase prompt whose text pins required tools AND @-mentions an orchestration agent -> the agent run has the briefcase's required tools. Launch a plain `@agent` prompt with NO briefcase override -> unchanged (uses the agent's own `allowedTools`, or the synthetic-profile default when agentless).

### What NOT to test
No schema, infra, or server changes. No new UI surface. The agent-executor server contract (`enabledTools`) is unchanged; only which value the client forwards changed.

## Additional Information
Low-likelihood path (a briefcase prompt explicitly @-mentioning an orchestration agent), originally deferred and filed as #95 so it was tracked rather than living only in a code comment.

## Developer Notes (Optional)
- Pulls the dispatch tool-whitelist decision into a small pure function (`resolveDispatchTools`) so the exact value reaching `agentExecution.start` is directly unit-testable.
- Reinforces the invariant that a briefcase `toolsOverride` is authoritative for tool selection across BOTH send paths (chat-completion and agent-executor), not just the non-orchestration one.

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc