### PR TITLE
chore(nix): add python3 to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
               pkgs.ollama
               pkgs.stripe-cli
               pkgs.gitleaks
+              pkgs.python3
             ];
           };
         }


### PR DESCRIPTION
## Description

Adds `python3` to the Nix dev shell so the repository's Python scripts run out of the box in the `nix develop` environment.

The repo contains two Python scripts, both of which use **only the Python standard library** — no third-party packages:

- `scripts/local-llm-eval/chart.py` (`math`)
- `scripts/optimize-openai-history.py` (`sys`, `os`, `zipfile`, `tempfile`, `shutil`, `pathlib`)

So a bare `python3` interpreter is sufficient; no `python3.withPackages` wrapper or pip dependencies are needed. There are no `requirements.txt` / `pyproject.toml` files in the repo.

## Changes

- `flake.nix`: add `pkgs.python3` to the default dev shell `packages` list

## Guide for Testers

This is a developer-environment-only change. No application behavior is affected.

1. Check out this branch: `git checkout chore/flake-add-python3`
2. Enter the dev shell: `nix develop` (or `direnv reload` if you use direnv)
   - Expected: the shell builds/activates with no errors
3. Run `python3 --version`
   - Expected: a Python 3.x version prints (e.g. `Python 3.12.x`)
4. Run `python3 scripts/optimize-openai-history.py` with no args
   - Expected: it runs and prints its usage/error message without an `ImportError` — confirming stdlib imports resolve
5. Run `python3 -c "import math; print(math.pi)"`
   - Expected: prints `3.141592653589793`

### What NOT to test

- No UI, API, or runtime application behavior changes — this only affects the local Nix dev shell.
- No staging/preview deploy is needed; the change does not touch app code or infra.

## Additional Information

Reload the dev shell to pick up the change. If future scripts add third-party deps, swap `pkgs.python3` for `(pkgs.python3.withPackages (ps: [ ps.<pkg> ]))`.
