### PR TITLE
fix(client): align middleware and access checks across quest plan routes

### DIFF
--- a/apps/client/pages/api/quest-master-plans/[id]/blockers.ts
+++ b/apps/client/pages/api/quest-master-plans/[id]/blockers.ts
@@ -2,6 +2,8 @@ import { questMasterPlanRepository } from '@bike4mind/database';
 import { QuestBlocker } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
+import { csrfProtection } from '@server/middlewares/csrfProtection';
+import { requireFeatureEnabled } from '@server/middlewares/featureFlag';
 import { verifyQuestPlanWriteAccess, QUEST_ID_PATTERN } from '@server/utils/questMasterPlanAccess';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { v4 as uuidv4 } from 'uuid';
@@ -15,21 +17,23 @@ const AddBlockerSchema = z.object({
   relatedSubQuestId: z.string().min(1).max(100).regex(QUEST_ID_PATTERN, 'Invalid subQuestId format').optional(),
 });
 
-const handler = baseApi().post<NextApiRequest, NextApiResponse>(postRateLimit, async (req, res) => {
-  const planId = req.query.id as string;
-  await verifyQuestPlanWriteAccess(req.user?.id, planId);
+const handler = baseApi()
+  .use(requireFeatureEnabled('EnableQuestMaster'))
+  .post<NextApiRequest, NextApiResponse>(csrfProtection(), postRateLimit, async (req, res) => {
+    const planId = req.query.id as string;
+    await verifyQuestPlanWriteAccess(req.user?.id, planId);
 
-  const body = AddBlockerSchema.parse(req.body);
+    const body = AddBlockerSchema.parse(req.body);
 
-  const blocker: QuestBlocker = {
-    id: uuidv4(),
-    ...body,
-    createdAt: new Date(),
-  };
+    const blocker: QuestBlocker = {
+      id: uuidv4(),
+      ...body,
+      createdAt: new Date(),
+    };
 
-  const updatedPlan = await questMasterPlanRepository.addBlocker(planId, blocker);
+    const updatedPlan = await questMasterPlanRepository.addBlocker(planId, blocker);
 
-  res.json({ success: true, plan: updatedPlan, blockerId: blocker.id });
-});
+    res.json({ success: true, plan: updatedPlan, blockerId: blocker.id });
+  });
 
 export default handler;

--- a/apps/client/pages/api/quest-master-plans/[id]/decisions.ts
+++ b/apps/client/pages/api/quest-master-plans/[id]/decisions.ts
@@ -2,6 +2,8 @@ import { questMasterPlanRepository } from '@bike4mind/database';
 import { QuestDecision } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
+import { csrfProtection } from '@server/middlewares/csrfProtection';
+import { requireFeatureEnabled } from '@server/middlewares/featureFlag';
 import { verifyQuestPlanWriteAccess, QUEST_ID_PATTERN } from '@server/utils/questMasterPlanAccess';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { v4 as uuidv4 } from 'uuid';
@@ -17,21 +19,23 @@ const AddDecisionSchema = z.object({
   relatedSubQuestId: z.string().min(1).max(100).regex(QUEST_ID_PATTERN, 'Invalid subQuestId format').optional(),
 });
 
-const handler = baseApi().post<NextApiRequest, NextApiResponse>(postRateLimit, async (req, res) => {
-  const planId = req.query.id as string;
-  await verifyQuestPlanWriteAccess(req.user?.id, planId);
+const handler = baseApi()
+  .use(requireFeatureEnabled('EnableQuestMaster'))
+  .post<NextApiRequest, NextApiResponse>(csrfProtection(), postRateLimit, async (req, res) => {
+    const planId = req.query.id as string;
+    await verifyQuestPlanWriteAccess(req.user?.id, planId);
 
-  const body = AddDecisionSchema.parse(req.body);
+    const body = AddDecisionSchema.parse(req.body);
 
-  const decision: QuestDecision = {
-    id: uuidv4(),
-    ...body,
-    madeAt: new Date(),
-  };
+    const decision: QuestDecision = {
+      id: uuidv4(),
+      ...body,
+      madeAt: new Date(),
+    };
 
-  const updatedPlan = await questMasterPlanRepository.addDecision(planId, decision);
+    const updatedPlan = await questMasterPlanRepository.addDecision(planId, decision);
 
-  res.json({ success: true, plan: updatedPlan, decisionId: decision.id });
-});
+    res.json({ success: true, plan: updatedPlan, decisionId: decision.id });
+  });
 
 export default handler;

--- a/apps/client/pages/api/quest-master-plans/[id]/handoff.ts
+++ b/apps/client/pages/api/quest-master-plans/[id]/handoff.ts
@@ -2,6 +2,8 @@ import { questMasterPlanRepository } from '@bike4mind/database';
 import { QuestHandoff } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
+import { csrfProtection } from '@server/middlewares/csrfProtection';
+import { requireFeatureEnabled } from '@server/middlewares/featureFlag';
 import { verifyQuestPlanWriteAccess } from '@server/utils/questMasterPlanAccess';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
@@ -15,21 +17,23 @@ const HandoffSchema = z.object({
   blockers: z.array(z.string().min(1).max(1000)).max(50),
 });
 
-const handler = baseApi().post<NextApiRequest, NextApiResponse>(postRateLimit, async (req, res) => {
-  const planId = req.query.id as string;
-  await verifyQuestPlanWriteAccess(req.user?.id, planId);
+const handler = baseApi()
+  .use(requireFeatureEnabled('EnableQuestMaster'))
+  .post<NextApiRequest, NextApiResponse>(csrfProtection(), postRateLimit, async (req, res) => {
+    const planId = req.query.id as string;
+    await verifyQuestPlanWriteAccess(req.user?.id, planId);
 
-  const body = HandoffSchema.parse(req.body);
+    const body = HandoffSchema.parse(req.body);
 
-  const handoff: QuestHandoff = {
-    ...body,
-    lastUpdatedBy: req.user!.id,
-    updatedAt: new Date(),
-  };
+    const handoff: QuestHandoff = {
+      ...body,
+      lastUpdatedBy: req.user!.id,
+      updatedAt: new Date(),
+    };
 
-  const updatedPlan = await questMasterPlanRepository.updateHandoff(planId, handoff);
+    const updatedPlan = await questMasterPlanRepository.updateHandoff(planId, handoff);
 
-  res.json({ success: true, plan: updatedPlan });
-});
+    res.json({ success: true, plan: updatedPlan });
+  });
 
 export default handler;

--- a/apps/client/pages/api/quest-master-plans/[id]/index.ts
+++ b/apps/client/pages/api/quest-master-plans/[id]/index.ts
@@ -1,58 +1,19 @@
-import { questMasterPlanRepository, sessionRepository } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
+import { requireFeatureEnabled } from '@server/middlewares/featureFlag';
+import { verifyQuestPlanReadAccess } from '@server/utils/questMasterPlanAccess';
 import { Request } from 'express';
-import { Types } from 'mongoose';
-
-const isValidObjectId = (id: string): boolean => {
-  return Types.ObjectId.isValid(id) && new Types.ObjectId(id).toString() === id;
-};
 
 const getRateLimit = rateLimit({ limit: 100, windowMs: 60000 });
 
-const handler = baseApi().get(getRateLimit, async (req: Request<unknown, unknown, unknown, { id: string }>, res) => {
-  const userId = req.user?.id;
-  const { id } = req.query;
+const handler = baseApi()
+  .use(requireFeatureEnabled('EnableQuestMaster'))
+  .get(getRateLimit, async (req: Request<unknown, unknown, unknown, { id: string }>, res) => {
+    const { id } = req.query;
 
-  if (!userId) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
+    const questMasterPlan = await verifyQuestPlanReadAccess(req.user?.id, id);
 
-  if (!isValidObjectId(id)) {
-    return res.status(400).json({ error: 'Invalid plan ID format' });
-  }
-
-  const questMasterPlan = await questMasterPlanRepository.findById(id);
-
-  if (!questMasterPlan) {
-    return res.status(404).json({ error: 'Quest plan not found' });
-  }
-
-  let hasAccess = false;
-
-  if (questMasterPlan.userId) {
-    // New plans with userId field
-    hasAccess =
-      questMasterPlan.userId === userId ||
-      questMasterPlan.sharedWith?.includes(userId) ||
-      questMasterPlan.visibility === 'public';
-  } else {
-    // Legacy plans without userId - check session ownership
-    const session = await sessionRepository.findById(questMasterPlan.notebookId);
-    hasAccess = Boolean(session && session.userId === userId);
-
-    // Backfill userId for this legacy plan
-    if (hasAccess && session) {
-      questMasterPlan.userId = session.userId;
-      await questMasterPlanRepository.update(questMasterPlan);
-    }
-  }
-
-  if (!hasAccess) {
-    return res.status(403).json({ error: 'Access denied' });
-  }
-
-  return res.status(200).json(questMasterPlan);
-});
+    return res.status(200).json(questMasterPlan);
+  });
 
 export default handler;

--- a/apps/client/pages/api/quest-master-plans/[id]/resolve-blocker.ts
+++ b/apps/client/pages/api/quest-master-plans/[id]/resolve-blocker.ts
@@ -2,6 +2,8 @@ import { questMasterPlanRepository } from '@bike4mind/database';
 import { NotFoundError } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
+import { csrfProtection } from '@server/middlewares/csrfProtection';
+import { requireFeatureEnabled } from '@server/middlewares/featureFlag';
 import { verifyQuestPlanWriteAccess } from '@server/utils/questMasterPlanAccess';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
@@ -13,24 +15,26 @@ const ResolveBlockerSchema = z.object({
   resolution: z.string().min(1).max(2000),
 });
 
-const handler = baseApi().post<NextApiRequest, NextApiResponse>(postRateLimit, async (req, res) => {
-  const planId = req.query.id as string;
-  const plan = await verifyQuestPlanWriteAccess(req.user?.id, planId);
+const handler = baseApi()
+  .use(requireFeatureEnabled('EnableQuestMaster'))
+  .post<NextApiRequest, NextApiResponse>(csrfProtection(), postRateLimit, async (req, res) => {
+    const planId = req.query.id as string;
+    const plan = await verifyQuestPlanWriteAccess(req.user?.id, planId);
 
-  const { blockerId, resolution } = ResolveBlockerSchema.parse(req.body);
+    const { blockerId, resolution } = ResolveBlockerSchema.parse(req.body);
 
-  const blockerExists = plan.blockers?.some(b => b.id === blockerId);
-  if (!blockerExists) {
-    throw new NotFoundError('Blocker not found');
-  }
+    const blockerExists = plan.blockers?.some(b => b.id === blockerId);
+    if (!blockerExists) {
+      throw new NotFoundError('Blocker not found');
+    }
 
-  const updatedPlan = await questMasterPlanRepository.resolveBlocker(planId, blockerId, resolution);
+    const updatedPlan = await questMasterPlanRepository.resolveBlocker(planId, blockerId, resolution);
 
-  if (!updatedPlan) {
-    throw new NotFoundError('Blocker not found or already resolved');
-  }
+    if (!updatedPlan) {
+      throw new NotFoundError('Blocker not found or already resolved');
+    }
 
-  res.json({ success: true, plan: updatedPlan });
-});
+    res.json({ success: true, plan: updatedPlan });
+  });
 
 export default handler;

--- a/apps/client/pages/api/quest-master-plans/[id]/review-gate.ts
+++ b/apps/client/pages/api/quest-master-plans/[id]/review-gate.ts
@@ -2,6 +2,8 @@ import { questMasterPlanRepository } from '@bike4mind/database';
 import { BadRequestError } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
+import { csrfProtection } from '@server/middlewares/csrfProtection';
+import { requireFeatureEnabled } from '@server/middlewares/featureFlag';
 import { verifyQuestPlanWriteAccess, QUEST_ID_PATTERN } from '@server/utils/questMasterPlanAccess';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
@@ -15,27 +17,29 @@ const ReviewGateSchema = z.object({
   reviewNote: z.string().max(2000).optional(),
 });
 
-const handler = baseApi().post<NextApiRequest, NextApiResponse>(postRateLimit, async (req, res) => {
-  const planId = req.query.id as string;
-  const plan = await verifyQuestPlanWriteAccess(req.user?.id, planId);
+const handler = baseApi()
+  .use(requireFeatureEnabled('EnableQuestMaster'))
+  .post<NextApiRequest, NextApiResponse>(csrfProtection(), postRateLimit, async (req, res) => {
+    const planId = req.query.id as string;
+    const plan = await verifyQuestPlanWriteAccess(req.user?.id, planId);
 
-  const { questId, subQuestId, reviewStatus, reviewNote } = ReviewGateSchema.parse(req.body);
+    const { questId, subQuestId, reviewStatus, reviewNote } = ReviewGateSchema.parse(req.body);
 
-  const quest = plan.quests.find(q => q.id === questId);
-  const subQuest = quest?.subQuests.find(sq => sq.id === subQuestId);
-  if (!quest || !subQuest) {
-    throw new BadRequestError('Invalid quest or sub-quest ID');
-  }
+    const quest = plan.quests.find(q => q.id === questId);
+    const subQuest = quest?.subQuests.find(sq => sq.id === subQuestId);
+    if (!quest || !subQuest) {
+      throw new BadRequestError('Invalid quest or sub-quest ID');
+    }
 
-  const updatedPlan = await questMasterPlanRepository.updateReviewGate(
-    planId,
-    questId,
-    subQuestId,
-    reviewStatus,
-    reviewNote
-  );
+    const updatedPlan = await questMasterPlanRepository.updateReviewGate(
+      planId,
+      questId,
+      subQuestId,
+      reviewStatus,
+      reviewNote
+    );
 
-  res.json({ success: true, plan: updatedPlan });
-});
+    res.json({ success: true, plan: updatedPlan });
+  });
 
 export default handler;

--- a/apps/client/pages/api/quest-master-plans/[id]/subquest-progress.ts
+++ b/apps/client/pages/api/quest-master-plans/[id]/subquest-progress.ts
@@ -2,6 +2,8 @@ import { questMasterPlanRepository } from '@bike4mind/database';
 import { BadRequestError } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
+import { csrfProtection } from '@server/middlewares/csrfProtection';
+import { requireFeatureEnabled } from '@server/middlewares/featureFlag';
 import { verifyQuestPlanWriteAccess, QUEST_ID_PATTERN } from '@server/utils/questMasterPlanAccess';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
@@ -16,27 +18,29 @@ const SubquestProgressSchema = z.object({
   timeSpent: z.number().min(0).optional(),
 });
 
-const handler = baseApi().post<NextApiRequest, NextApiResponse>(postRateLimit, async (req, res) => {
-  const planId = req.query.id as string;
-  const plan = await verifyQuestPlanWriteAccess(req.user?.id, planId);
+const handler = baseApi()
+  .use(requireFeatureEnabled('EnableQuestMaster'))
+  .post<NextApiRequest, NextApiResponse>(csrfProtection(), postRateLimit, async (req, res) => {
+    const planId = req.query.id as string;
+    const plan = await verifyQuestPlanWriteAccess(req.user?.id, planId);
 
-  const { questId, subQuestId, status, evidence, timeSpent } = SubquestProgressSchema.parse(req.body);
+    const { questId, subQuestId, status, evidence, timeSpent } = SubquestProgressSchema.parse(req.body);
 
-  const quest = plan.quests.find(q => q.id === questId);
-  const subQuest = quest?.subQuests.find(sq => sq.id === subQuestId);
-  if (!quest || !subQuest) {
-    throw new BadRequestError('Invalid quest or sub-quest ID');
-  }
+    const quest = plan.quests.find(q => q.id === questId);
+    const subQuest = quest?.subQuests.find(sq => sq.id === subQuestId);
+    if (!quest || !subQuest) {
+      throw new BadRequestError('Invalid quest or sub-quest ID');
+    }
 
-  const updatedPlan = await questMasterPlanRepository.updateQuestProgress(
-    planId,
-    questId,
-    subQuestId,
-    { status, evidence, timeSpent },
-    { autoResumeIfPaused: status === 'in_progress' }
-  );
+    const updatedPlan = await questMasterPlanRepository.updateQuestProgress(
+      planId,
+      questId,
+      subQuestId,
+      { status, evidence, timeSpent },
+      { autoResumeIfPaused: status === 'in_progress' }
+    );
 
-  res.json({ success: true, plan: updatedPlan, metrics: updatedPlan?.metrics });
-});
+    res.json({ success: true, plan: updatedPlan, metrics: updatedPlan?.metrics });
+  });
 
 export default handler;

--- a/apps/client/pages/api/quest-plans/[id]/progress.ts
+++ b/apps/client/pages/api/quest-plans/[id]/progress.ts
@@ -1,15 +1,11 @@
-import { questMasterPlanRepository, sessionRepository } from '@bike4mind/database';
+import { questMasterPlanRepository } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { csrfProtection } from '@server/middlewares/csrfProtection';
 import { requireFeatureEnabled } from '@server/middlewares/featureFlag';
+import { verifyQuestPlanWriteAccess } from '@server/utils/questMasterPlanAccess';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Types } from 'mongoose';
 import { z } from 'zod';
-
-const isValidObjectId = (id: string): boolean => {
-  return Types.ObjectId.isValid(id) && new Types.ObjectId(id).toString() === id;
-};
 
 const progressRateLimit = rateLimit({ limit: 50, windowMs: 60000 });
 
@@ -29,102 +25,47 @@ const UpdateProgressSchema = z.object({
 const handler = baseApi()
   .use(requireFeatureEnabled('EnableQuestMaster'))
   .patch<NextApiRequest, NextApiResponse>(csrfProtection(), progressRateLimit, async (req, res) => {
-    try {
-      const userId = req.user?.id;
-      const planId = req.query.id as string;
+    const planId = req.query.id as string;
 
-      if (!userId) {
-        return res.status(401).json({ error: 'Unauthorized' });
-      }
-
-      if (!isValidObjectId(planId)) {
-        return res.status(400).json({ error: 'Invalid plan ID format' });
-      }
-
-      const bodyResult = UpdateProgressSchema.safeParse(req.body);
-      if (!bodyResult.success) {
-        return res.status(400).json({ error: 'Invalid input', details: z.treeifyError(bodyResult.error) });
-      }
-      const { questId, subQuestId, status, timeSpent, chatMessageId, startedAt } = bodyResult.data;
-
-      const plan = await questMasterPlanRepository.findById(planId);
-
-      if (!plan) {
-        return res.status(404).json({ error: 'Quest plan not found' });
-      }
-
-      // Check access - user can update progress if they own it or it's explicitly shared
-      // Public plans are read-only and cannot have progress updated by non-owners
-      let hasAccess = false;
-      let isOwner = false;
-
-      if (plan.userId) {
-        // New plans with userId field
-        isOwner = plan.userId === userId;
-        hasAccess = isOwner || (plan.sharedWith?.includes(userId) ?? false);
-      } else {
-        // Legacy plans without userId - check session ownership
-        // Validate that notebookId is a valid MongoDB ObjectId before querying
-        if (!isValidObjectId(plan.notebookId)) {
-          return res.status(403).json({ error: 'Access denied' });
-        }
-
-        const session = await sessionRepository.findById(plan.notebookId);
-
-        if (!session) {
-          return res.status(403).json({ error: 'Access denied' });
-        }
-
-        isOwner = session.userId === userId;
-        hasAccess = isOwner;
-
-        // Only backfill userId if user actually owns the session
-        // This prevents unauthorized users from claiming orphaned plans
-        if (isOwner) {
-          plan.userId = session.userId;
-          await questMasterPlanRepository.update(plan);
-        }
-      }
-
-      if (!hasAccess) {
-        // Use consistent error message to avoid leaking visibility information
-        return res.status(403).json({ error: 'Access denied' });
-      }
-
-      const quest = plan.quests.find(q => q.id === questId);
-      const subQuest = quest?.subQuests.find(sq => sq.id === subQuestId);
-      if (!quest || !subQuest) {
-        return res.status(400).json({ error: 'Invalid quest or sub-quest ID' });
-      }
-
-      // Update progress (auto-resume is handled atomically in the repository)
-      // Returns the updated plan with fresh metrics, avoiding a second fetch
-      const updatedPlan = await questMasterPlanRepository.updateQuestProgress(
-        planId,
-        questId,
-        subQuestId,
-        {
-          status,
-          timeSpent,
-          chatMessageId,
-          startedAt,
-        },
-        {
-          // Auto-resume paused quests when starting work on a subtask
-          autoResumeIfPaused: status === 'in_progress',
-        }
-      );
-
-      res.json({
-        success: true,
-        plan: updatedPlan,
-        metrics: updatedPlan?.metrics,
-      });
-    } catch (error: unknown) {
-      console.error('Error updating quest progress:', error);
-      // Return generic error to prevent information leakage
-      res.status(500).json({ error: 'Failed to update quest progress' });
+    const bodyResult = UpdateProgressSchema.safeParse(req.body);
+    if (!bodyResult.success) {
+      return res.status(400).json({ error: 'Invalid input', details: z.treeifyError(bodyResult.error) });
     }
+    const { questId, subQuestId, status, timeSpent, chatMessageId, startedAt } = bodyResult.data;
+
+    // Owner or shared collaborator; public plans are read-only. Legacy plans
+    // without userId are backfilled from session ownership inside the util.
+    const plan = await verifyQuestPlanWriteAccess(req.user?.id, planId);
+
+    const quest = plan.quests.find(q => q.id === questId);
+    const subQuest = quest?.subQuests.find(sq => sq.id === subQuestId);
+    if (!quest || !subQuest) {
+      return res.status(400).json({ error: 'Invalid quest or sub-quest ID' });
+    }
+
+    // Update progress (auto-resume is handled atomically in the repository)
+    // Returns the updated plan with fresh metrics, avoiding a second fetch
+    const updatedPlan = await questMasterPlanRepository.updateQuestProgress(
+      planId,
+      questId,
+      subQuestId,
+      {
+        status,
+        timeSpent,
+        chatMessageId,
+        startedAt,
+      },
+      {
+        // Auto-resume paused quests when starting work on a subtask
+        autoResumeIfPaused: status === 'in_progress',
+      }
+    );
+
+    res.json({
+      success: true,
+      plan: updatedPlan,
+      metrics: updatedPlan?.metrics,
+    });
   });
 
 export default handler;

--- a/apps/client/server/utils/questMasterPlanAccess.test.ts
+++ b/apps/client/server/utils/questMasterPlanAccess.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Types } from 'mongoose';
 import { BadRequestError, ForbiddenError, NotFoundError, UnauthorizedError } from '@bike4mind/common';
-import { verifyQuestPlanWriteAccess, isValidObjectId, QUEST_ID_PATTERN } from './questMasterPlanAccess';
+import {
+  verifyQuestPlanReadAccess,
+  verifyQuestPlanWriteAccess,
+  isValidObjectId,
+  QUEST_ID_PATTERN,
+} from './questMasterPlanAccess';
 
 const mockFindById = vi.fn();
 const mockUpdate = vi.fn();
@@ -141,6 +146,102 @@ describe('questMasterPlanAccess', () => {
         mockFindById.mockResolvedValue(plan);
 
         await expect(verifyQuestPlanWriteAccess(validUserId, validPlanId)).rejects.toThrow(ForbiddenError);
+        expect(mockSessionFindById).not.toHaveBeenCalled();
+      });
+    });
+
+    it('denies write access to public plans for non-collaborators', async () => {
+      const ownerId = new Types.ObjectId().toString();
+      const plan = { userId: ownerId, sharedWith: [], visibility: 'public' };
+      mockFindById.mockResolvedValue(plan);
+
+      await expect(verifyQuestPlanWriteAccess(validUserId, validPlanId)).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('verifyQuestPlanReadAccess', () => {
+    it('throws UnauthorizedError when userId is undefined', async () => {
+      await expect(verifyQuestPlanReadAccess(undefined, validPlanId)).rejects.toThrow(UnauthorizedError);
+    });
+
+    it('throws BadRequestError for invalid planId format', async () => {
+      await expect(verifyQuestPlanReadAccess(validUserId, 'bad-id')).rejects.toThrow(BadRequestError);
+    });
+
+    it('throws NotFoundError when plan does not exist', async () => {
+      mockFindById.mockResolvedValue(null);
+
+      await expect(verifyQuestPlanReadAccess(validUserId, validPlanId)).rejects.toThrow(NotFoundError);
+    });
+
+    it('grants access to plan owner', async () => {
+      const plan = { userId: validUserId, sharedWith: [] };
+      mockFindById.mockResolvedValue(plan);
+
+      const result = await verifyQuestPlanReadAccess(validUserId, validPlanId);
+
+      expect(result).toBe(plan);
+    });
+
+    it('grants access to shared collaborator', async () => {
+      const ownerId = new Types.ObjectId().toString();
+      const plan = { userId: ownerId, sharedWith: [validUserId] };
+      mockFindById.mockResolvedValue(plan);
+
+      const result = await verifyQuestPlanReadAccess(validUserId, validPlanId);
+
+      expect(result).toBe(plan);
+    });
+
+    it('grants access to any user for public plans', async () => {
+      const ownerId = new Types.ObjectId().toString();
+      const plan = { userId: ownerId, sharedWith: [], visibility: 'public' };
+      mockFindById.mockResolvedValue(plan);
+
+      const result = await verifyQuestPlanReadAccess(validUserId, validPlanId);
+
+      expect(result).toBe(plan);
+    });
+
+    it('denies access to private plans for non-collaborators', async () => {
+      const ownerId = new Types.ObjectId().toString();
+      const plan = { userId: ownerId, sharedWith: [], visibility: 'user' };
+      mockFindById.mockResolvedValue(plan);
+
+      await expect(verifyQuestPlanReadAccess(validUserId, validPlanId)).rejects.toThrow(ForbiddenError);
+    });
+
+    describe('legacy backfill', () => {
+      it('backfills userId from session ownership and grants access', async () => {
+        const plan = { userId: undefined, notebookId: validNotebookId, sharedWith: [] };
+        const session = { userId: validUserId };
+        mockFindById.mockResolvedValue(plan);
+        mockSessionFindById.mockResolvedValue(session);
+        mockUpdate.mockResolvedValue(undefined);
+
+        const result = await verifyQuestPlanReadAccess(validUserId, validPlanId);
+
+        expect(result).toBe(plan);
+        expect(plan.userId).toBe(validUserId);
+        expect(mockUpdate).toHaveBeenCalledWith(plan);
+      });
+
+      it('denies access when session owner does not match', async () => {
+        const differentUser = new Types.ObjectId().toString();
+        const plan = { userId: undefined, notebookId: validNotebookId };
+        const session = { userId: differentUser };
+        mockFindById.mockResolvedValue(plan);
+        mockSessionFindById.mockResolvedValue(session);
+
+        await expect(verifyQuestPlanReadAccess(validUserId, validPlanId)).rejects.toThrow(ForbiddenError);
+        expect(mockUpdate).not.toHaveBeenCalled();
+      });
+
+      it('denies access when notebookId is not a valid ObjectId', async () => {
+        const plan = { userId: undefined, notebookId: 'not-valid' };
+        mockFindById.mockResolvedValue(plan);
+
+        await expect(verifyQuestPlanReadAccess(validUserId, validPlanId)).rejects.toThrow(ForbiddenError);
         expect(mockSessionFindById).not.toHaveBeenCalled();
       });
     });

--- a/apps/client/server/utils/questMasterPlanAccess.ts
+++ b/apps/client/server/utils/questMasterPlanAccess.ts
@@ -1,8 +1,8 @@
 /**
  * Quest Master Plan Access Verification Utility
  *
- * Shared utility for verifying user write-access to quest master plan resources.
- * Used by quest-master-plans API endpoints (handoff, blockers, decisions, etc.)
+ * Shared utility for verifying user access to quest master plan resources.
+ * Used by the quest-master-plans and quest-plans API endpoints.
  *
  * Follows the same pattern as orgAccess.ts:
  * - Throws typed HTTPError subclasses (caught by baseApi's errorHandler)
@@ -10,7 +10,9 @@
  *
  * Security:
  * - Write access requires ownership or explicit sharing (public = read-only)
- * - Legacy plans without userId are backfilled on first write access
+ * - Read access additionally allows public visibility
+ * - Legacy plans without userId are backfilled from session ownership on
+ *   first successful access check (one-time migration)
  */
 
 import { questMasterPlanRepository, sessionRepository } from '@bike4mind/database';
@@ -24,6 +26,53 @@ export function isValidObjectId(id: string): boolean {
 
 /** Regex pattern for valid quest/sub-quest ID strings (alphanumeric, hyphens, underscores, dots) */
 export const QUEST_ID_PATTERN = /^[a-zA-Z0-9_.-]+$/;
+
+async function verifyQuestPlanAccess(
+  userId: string | undefined,
+  planId: string,
+  options: { allowPublicRead: boolean }
+): Promise<IQuestMasterPlanDocument> {
+  if (!userId) {
+    throw new UnauthorizedError('Unauthorized');
+  }
+
+  if (!isValidObjectId(planId)) {
+    throw new BadRequestError('Invalid plan ID format');
+  }
+
+  const plan = await questMasterPlanRepository.findById(planId);
+  if (!plan) {
+    throw new NotFoundError('Quest plan not found');
+  }
+
+  let hasAccess = false;
+
+  if (plan.userId) {
+    hasAccess =
+      plan.userId === userId ||
+      (plan.sharedWith?.includes(userId) ?? false) ||
+      (options.allowPublicRead && plan.visibility === 'public');
+  } else {
+    // Legacy plans without userId - check session ownership and backfill.
+    // Only backfill when the caller actually owns the session, so orphaned
+    // plans cannot be claimed by arbitrary users.
+    if (isValidObjectId(plan.notebookId)) {
+      const session = await sessionRepository.findById(plan.notebookId);
+      if (session && session.userId === userId) {
+        hasAccess = true;
+        plan.userId = session.userId;
+        await questMasterPlanRepository.update(plan);
+      }
+    }
+  }
+
+  if (!hasAccess) {
+    // Consistent error message avoids leaking visibility information
+    throw new ForbiddenError('Access denied');
+  }
+
+  return plan;
+}
 
 /**
  * Verify user has write access to a quest master plan.
@@ -46,38 +95,28 @@ export async function verifyQuestPlanWriteAccess(
   userId: string | undefined,
   planId: string
 ): Promise<IQuestMasterPlanDocument> {
-  if (!userId) {
-    throw new UnauthorizedError('Unauthorized');
-  }
+  return verifyQuestPlanAccess(userId, planId, { allowPublicRead: false });
+}
 
-  if (!isValidObjectId(planId)) {
-    throw new BadRequestError('Invalid plan ID format');
-  }
-
-  const plan = await questMasterPlanRepository.findById(planId);
-  if (!plan) {
-    throw new NotFoundError('Quest plan not found');
-  }
-
-  let hasAccess = false;
-
-  if (plan.userId) {
-    hasAccess = plan.userId === userId || (plan.sharedWith?.includes(userId) ?? false);
-  } else {
-    // Legacy plans without userId - check session ownership and backfill
-    if (isValidObjectId(plan.notebookId)) {
-      const session = await sessionRepository.findById(plan.notebookId);
-      if (session && session.userId === userId) {
-        hasAccess = true;
-        plan.userId = session.userId;
-        await questMasterPlanRepository.update(plan);
-      }
-    }
-  }
-
-  if (!hasAccess) {
-    throw new ForbiddenError('Access denied');
-  }
-
-  return plan;
+/**
+ * Verify user has read access to a quest master plan.
+ *
+ * Read access: plan owner, shared collaborator, or public visibility.
+ *
+ * @param userId - The authenticated user's ID (from req.user?.id)
+ * @param planId - The plan ID from the route parameter
+ * @returns The plan document if access is granted
+ * @throws UnauthorizedError if userId is missing
+ * @throws BadRequestError if planId is invalid format
+ * @throws NotFoundError if plan doesn't exist
+ * @throws ForbiddenError if user doesn't have read access
+ *
+ * @sideEffects For legacy plans without userId, backfills userId from session
+ * ownership on first successful read-access check (one-time migration).
+ */
+export async function verifyQuestPlanReadAccess(
+  userId: string | undefined,
+  planId: string
+): Promise<IQuestMasterPlanDocument> {
+  return verifyQuestPlanAccess(userId, planId, { allowPublicRead: true });
 }


### PR DESCRIPTION
## Description

Brings the `quest-master-plans/[id]/*` route family onto the same middleware stack as the `quest-plans/*` family, and collapses duplicated inline plan-access logic into the shared `questMasterPlanAccess` utility.

PR 2 of the QuestMaster consolidation series (PR 1: #169).

## Changes

- All seven `quest-master-plans/[id]` routes now apply `requireFeatureEnabled('EnableQuestMaster')`, matching the sibling family; the six POST routes (handoff, decisions, blockers, resolve-blocker, review-gate, subquest-progress) additionally apply `csrfProtection()` ahead of their rate limits
- `questMasterPlanAccess` gains `verifyQuestPlanReadAccess` (owner, shared collaborator, or public visibility) built on a shared core with the existing write check (owner or shared only); the legacy `userId` backfill keeps its owner-only claim guard
- `quest-master-plans/[id]` GET and `quest-plans/[id]/progress` PATCH use the shared utility instead of inline copies; typed errors flow through `baseApi`'s error handler exactly like the other durable-workflow routes
- Access utility tests extended: full read-access coverage plus an explicit public-plan write-denial case (+11 tests)

Behavior notes for reviewers:

- The `quest-master-plans` routes previously responded regardless of the `EnableQuestMaster` admin setting; they now return 403 `FEATURE_DISABLED` when the feature is off, consistent with `quest-plans/*`
- `quest-master-plans/[id]` GET error responses now come from the shared error handler (same status codes; message text unified with the sibling routes)

## Tests

- `pnpm --filter @bike4mind/client typecheck` - pass
- `pnpm --filter @bike4mind/client test` - 4871 passed / 81 skipped
- `pnpm lint:check` - pass
- Pre-push hook ran `turbo typecheck:fast` across 22 packages - pass

## Guide for Testers

- With QuestMaster enabled: open a plan, update sub-quest progress, add/resolve a blocker, set a review gate; all flows behave as before
- With the `EnableQuestMaster` admin setting disabled: the same calls return 403 `FEATURE_DISABLED`
- Public plans remain viewable by any signed-in user but reject writes from non-collaborators

🤖 Generated with [Claude Code](https://claude.com/claude-code)