### PR TITLE
feat(selfhost): realtime websocket gateway and subscriber-fanout integration

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -20,10 +20,17 @@ SESSION_SECRET=change-me-openssl-rand-hex-32
 SECRET_ENCRYPTION_KEY=change-me-openssl-rand-hex-32
 
 # -- Realtime websocket gateway --
-# Not part of the compose stack yet; live streaming updates degrade without it
-# (chat replies appear on refresh).
+# Provided by the `ws` + `subscriber-fanout` services in compose.selfhost.yaml.
+# The app + fanout push to WEBSOCKET_MANAGEMENT_ENDPOINT (compose network); the
+# browser connects to WEBSOCKET_URL (host-published). If you remap the host port,
+# set WS_HOST_PORT and update WEBSOCKET_URL to match.
 WEBSOCKET_MANAGEMENT_ENDPOINT=http://ws:3001
 WEBSOCKET_URL=ws://localhost:3001
+# Shared secret the ws gateway uses to authenticate its internal handler calls
+# to the app. Generate with: openssl rand -hex 32
+INTERNAL_WS_SECRET=change-me-openssl-rand-hex-32
+# Override to pin/point the fanout image (defaults to the published GHCR tag):
+# SUBSCRIBER_FANOUT_IMAGE=ghcr.io/bike4mind/subscriber-fanout:latest
 
 # -- Local infra backends (Docker Compose) - dev defaults, CHANGE for production --
 # MinIO admin creds (conventional local default; used by the app's S3 client too).

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -232,7 +232,7 @@ OLLAMA_BASE_URL=http://host.docker.internal:11434
 - **Local model replies are slow** - with no GPU, inference runs on CPU; start with a small model (`qwen2.5-coder:1.5b` or `:3b`). For NVIDIA GPU acceleration, add `-f compose.ollama-gpu.yaml` (see that section).
 - **`apt-get install nvidia-container-toolkit` says "Unable to locate package"** - NVIDIA's apt repo isn't set up. Add it first (see "GPU acceleration"), then re-run `sudo apt-get update`.
 - **GPU override fails with "could not select device driver \"nvidia\" with capabilities: [[gpu]]"** - the NVIDIA Container Toolkit isn't installed or wired into Docker. Install it and run `sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker` (see "GPU acceleration"). Without a working GPU runtime, drop the `-f compose.ollama-gpu.yaml` and run CPU-only.
-- **Chat replies only appear after a refresh** - expected for now: the realtime websocket gateway is not part of the compose stack yet, so live streaming updates degrade to fetch-on-refresh.
+- **Chat replies only appear after a refresh** - realtime isn't connecting. Check the `ws` gateway is up (`docker compose -f compose.selfhost.yaml ps ws`) and healthy, that `INTERNAL_WS_SECRET` is set and identical for the `app` and `ws` services, and that `WEBSOCKET_URL`/`WEBSOCKET_MANAGEMENT_ENDPOINT` point at the gateway. In the browser console you should see `ws connected`; a reconnect loop usually means the gateway can't reach the app (`docker compose -f compose.selfhost.yaml logs ws`).
 - **Changed `SECRET_ENCRYPTION_KEY` and now secrets fail to decrypt** - restore the original key; it cannot be rotated in place.
 
 ## Security notes
@@ -241,9 +241,8 @@ The stack is configured for **local, single-host use**: the backing services (Mo
 
 ## What you get (and don't)
 
-Self-host runs the open-core engine - notebooks, multi-LLM chat, agents, the Quest Master, the knowledge engine, and artifacts. Known gaps today:
+Self-host runs the open-core engine - notebooks, multi-LLM chat, agents, the Quest Master, the knowledge engine, and artifacts. It includes **realtime streaming**: the `ws` gateway + `subscriber-fanout` services stream chat replies token-by-token and push live document updates (notebooks, sync) without a page refresh - the same WebSocket experience as the hosted app, with no AWS API Gateway. Known gaps today:
 
-- **Realtime streaming** - the websocket gateway is not in the stack yet; chat replies and live updates appear on refresh.
 - **Background enrichment** - features that ride the hosted event bus (notebook auto-naming, summaries, tagging) are inert in self-host for now.
 - **Hosted-service features** - billing, entitlements, and premium overlays are not part of the open core; see the [open/closed boundary](./CONTRIBUTING.md#the-openclosed-boundary).
 

--- a/apps/client/pages/api/internal/ws/[action].ts
+++ b/apps/client/pages/api/internal/ws/[action].ts
@@ -1,0 +1,107 @@
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { baseApi } from '@server/middlewares/baseApi';
+import { func as connectFunc } from '@server/websocket/connect';
+import { func as disconnectFunc } from '@server/websocket/disconnect';
+import { func as subscribeFunc } from '@server/websocket/dataSubscribeRequest';
+import { func as unsubscribeFunc } from '@server/websocket/dataUnsubscribeRequest';
+import type { Context } from 'aws-lambda';
+import { Resource } from 'sst';
+
+/**
+ * Self-host WebSocket handler bridge.
+ *
+ * In AWS, API Gateway invokes the connect/subscribe/unsubscribe/disconnect
+ * Lambda handlers directly. In self-host there is no API Gateway: the `ws`
+ * gateway (selfhost/ws-gateway) owns the raw browser sockets + the management
+ * endpoint, and delegates the actual handler logic here over an internal,
+ * shared-secret HTTP call. Reusing the existing `func`s keeps JWT verification
+ * and CASL query-scoping identical to the hosted path.
+ *
+ * This route is self-host only and guarded by INTERNAL_WS_SECRET; it is never
+ * reachable in the AWS deployment (the gateway that calls it doesn't exist there).
+ */
+
+// The handlers only read `functionName` off the Lambda context; stub the rest.
+function lambdaContext(functionName: string): Context {
+  return { functionName, callbackWaitsForEmptyEventLoop: false } as unknown as Context;
+}
+
+const handler = baseApi({ auth: false }).post(
+  asyncHandler(async (req, res) => {
+    if (process.env.B4M_SELF_HOST !== 'true') {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    // Shared-secret guard (mirrors pages/api/test/cleanup.ts). The ws gateway
+    // sends this header; browsers cannot (they never learn the secret).
+    const expected = process.env.INTERNAL_WS_SECRET;
+    const provided = req.headers['x-internal-ws-secret'];
+    if (!expected || provided !== expected) {
+      return res.status(401).json({ error: 'Invalid internal ws secret' });
+    }
+
+    const action = String((req.query as { action?: string }).action ?? '');
+    const { connectionId, token, headers, body } = (req.body ?? {}) as {
+      connectionId?: string;
+      token?: string;
+      headers?: Record<string, string>;
+      body?: string;
+    };
+    if (!connectionId) {
+      return res.status(400).json({ error: 'connectionId required' });
+    }
+
+    if (action === 'connect') {
+      const event = {
+        requestContext: { connectionId },
+        queryStringParameters: token ? { token } : {},
+        headers: headers ?? {},
+      };
+      const result = await connectFunc(event as never, lambdaContext('selfhost_ws_connect'));
+      return res.status(result.statusCode).json(result);
+    }
+
+    if (action === 'disconnect') {
+      // domainName/stage only feed disconnect's best-effort cc_agent despawn
+      // broadcast; the core cleanup (Connection + QuerySubscription pull) ignores
+      // them. Derive them from the management endpoint so the URL is at least
+      // pointed at the gateway.
+      const mgmt = new URL(Resource.websocket.managementEndpoint);
+      const event = {
+        requestContext: {
+          connectionId,
+          domainName: mgmt.host,
+          stage: mgmt.pathname.replace(/^\//, ''),
+        },
+      };
+      const result = await disconnectFunc(event as never, lambdaContext('selfhost_ws_disconnect'));
+      return res.status(result.statusCode).json(result);
+    }
+
+    if (action === 'message') {
+      let parsedAction: string | undefined;
+      try {
+        parsedAction = JSON.parse(body ?? '{}').action;
+      } catch {
+        /* non-JSON frame */
+      }
+      const event = { requestContext: { connectionId }, body };
+
+      if (parsedAction === 'subscribe_query') {
+        const result = await subscribeFunc(event as never, lambdaContext('selfhost_ws_subscribe'));
+        return res.status(result.statusCode).json(result);
+      }
+      if (parsedAction === 'unsubscribe_query') {
+        const result = await unsubscribeFunc(event as never, lambdaContext('selfhost_ws_unsubscribe'));
+        return res.status(result.statusCode).json(result);
+      }
+      // Unrouted action: ack (mirrors the $default WS route) so the gateway
+      // doesn't treat it as an error. Extend here for other inbound actions.
+      return res.status(200).json({ statusCode: 200, ignored: parsedAction ?? null });
+    }
+
+    return res.status(400).json({ error: `Unknown action: ${action}` });
+  })
+);
+
+export default handler;

--- a/apps/client/pages/api/internal/ws/[action].ts
+++ b/apps/client/pages/api/internal/ws/[action].ts
@@ -6,6 +6,7 @@ import { func as subscribeFunc } from '@server/websocket/dataSubscribeRequest';
 import { func as unsubscribeFunc } from '@server/websocket/dataUnsubscribeRequest';
 import type { Context } from 'aws-lambda';
 import { Resource } from 'sst';
+import crypto from 'crypto';
 
 /**
  * Self-host WebSocket handler bridge.
@@ -32,11 +33,16 @@ const handler = baseApi({ auth: false }).post(
       return res.status(404).json({ error: 'Not found' });
     }
 
-    // Shared-secret guard (mirrors pages/api/test/cleanup.ts). The ws gateway
-    // sends this header; browsers cannot (they never learn the secret).
+    // Shared-secret guard, constant-time. The ws gateway sends this header;
+    // browsers cannot (they never learn the secret).
     const expected = process.env.INTERNAL_WS_SECRET;
-    const provided = req.headers['x-internal-ws-secret'];
-    if (!expected || provided !== expected) {
+    const providedRaw = req.headers['x-internal-ws-secret'];
+    const provided = Array.isArray(providedRaw) ? '' : (providedRaw ?? '');
+    const secretOk =
+      !!expected &&
+      provided.length === expected.length &&
+      crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
+    if (!secretOk) {
       return res.status(401).json({ error: 'Invalid internal ws secret' });
     }
 
@@ -64,8 +70,10 @@ const handler = baseApi({ auth: false }).post(
     if (action === 'disconnect') {
       // domainName/stage only feed disconnect's best-effort cc_agent despawn
       // broadcast; the core cleanup (Connection + QuerySubscription pull) ignores
-      // them. Derive them from the management endpoint so the URL is at least
-      // pointed at the gateway.
+      // them. Note: disconnect builds https://<host>/<stage>, but the self-host
+      // management endpoint is plain HTTP (http://ws:3001), so that broadcast is
+      // effectively a no-op here (it is wrapped in try/catch upstream and the
+      // core cleanup still runs). Derive host/stage from the endpoint anyway.
       const mgmt = new URL(Resource.websocket.managementEndpoint);
       const event = {
         requestContext: {
@@ -95,8 +103,10 @@ const handler = baseApi({ auth: false }).post(
         const result = await unsubscribeFunc(event as never, lambdaContext('selfhost_ws_unsubscribe'));
         return res.status(result.statusCode).json(result);
       }
-      // Unrouted action: ack (mirrors the $default WS route) so the gateway
-      // doesn't treat it as an error. Extend here for other inbound actions.
+      // Self-host bridges the realtime subset only: subscribe_query /
+      // unsubscribe_query here, heartbeat in the gateway. Other hosted WS actions
+      // (voice, cli, cc_agent, jupyter, keep) are not wired up. Ack-and-ignore so
+      // the gateway does not treat them as errors; extend here to add more.
       return res.status(200).json({ statusCode: 200, ignored: parsedAction ?? null });
     }
 

--- a/compose.selfhost.yaml
+++ b/compose.selfhost.yaml
@@ -183,7 +183,7 @@ services:
       test:
         [
           'CMD-SHELL',
-          'node -e "fetch(process.env.SELF||\"http://localhost:3001/health\").then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"',
+          'node -e "fetch(\"http://localhost:3001/health\").then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"',
         ]
       interval: 10s
       timeout: 5s

--- a/compose.selfhost.yaml
+++ b/compose.selfhost.yaml
@@ -20,8 +20,9 @@
 # with TLS, and keep the backing ports unpublished. Do not expose
 # 27017/9000/9324/8025 to the internet.
 #
-# KNOWN LIMITATION: the realtime websocket gateway is not in this stack yet,
-# so live streaming updates degrade (chat replies appear on refresh).
+# Realtime: the `ws` gateway + `subscriber-fanout` services provide live
+# streaming updates (chat, notebooks, sync) without AWS API Gateway. See the
+# `ws` service below and selfhost/ws-gateway/.
 
 name: bike4mind-selfhost
 
@@ -149,8 +150,74 @@ services:
     # when unused. The bundled `ollama` service below is reached as `ollama`.
     extra_hosts:
       - 'host.docker.internal:host-gateway'
-    # NOTE: the realtime websocket gateway is not in this stack yet. The app
-    # serves HTTP without it; live streaming updates degrade.
+    # Realtime: the app reads the browser URL + management endpoint from
+    # WEBSOCKET_URL / WEBSOCKET_MANAGEMENT_ENDPOINT (.env.selfhost, -> the `ws`
+    # gateway below) and uses INTERNAL_WS_SECRET to authenticate the gateway's
+    # internal handler calls. Both come from the env file.
+
+  # Realtime WebSocket gateway — the self-host replacement for AWS API Gateway
+  # WebSocket. One port (3001) with two faces: a browser-facing socket server
+  # (WEBSOCKET_URL=ws://localhost:3001) and an API Gateway Management API
+  # emulator (WEBSOCKET_MANAGEMENT_ENDPOINT=http://ws:3001) that the app and the
+  # subscriber-fanout push to. It holds no auth/model logic; it delegates
+  # connect/subscribe/unsubscribe to the app over an internal shared-secret
+  # endpoint. Source: selfhost/ws-gateway/.
+  ws:
+    build:
+      context: ./selfhost/ws-gateway
+      dockerfile: Dockerfile
+    env_file:
+      - .env.selfhost
+    environment:
+      PORT: '3001'
+      APP_INTERNAL_URL: http://app:3000
+    # Browser connects to ws://localhost:3001; app + fanout reach it as
+    # http://ws:3001 over the compose network. Override WS_HOST_PORT if 3001 is
+    # taken on your host (also update WEBSOCKET_URL to match).
+    ports:
+      - '${WS_HOST_PORT:-3001}:3001'
+    depends_on:
+      app:
+        condition: service_started
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(process.env.SELF||\"http://localhost:3001/health\").then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+
+  # MongoDB change-stream -> WebSocket fan-out. Watches the collections clients
+  # subscribe to (recorded in the querySubscriptions collection) and pushes
+  # matching changes through the ws gateway's management endpoint, restoring live
+  # data updates (notebooks, chat, sync) in self-host. Published image; build it
+  # from source in its own repo and tag it the same to run local edits.
+  subscriber-fanout:
+    image: ${SUBSCRIBER_FANOUT_IMAGE:-ghcr.io/bike4mind/subscriber-fanout:latest}
+    env_file:
+      - .env.selfhost
+    environment:
+      # The fanout logs the stage and pushes to the management endpoint below.
+      STAGE: ${APP_STAGE:-selfhost}
+      WEBSOCKET_MANAGEMENT_ENDPOINT: http://ws:3001
+      # Browsers have no 128KB frame cap and don't reassemble chunks, so send whole.
+      WEBSOCKET_DISABLE_CHUNKING: 'true'
+      # Dummy creds satisfy the AWS SDK; the ws gateway ignores the SigV4 signature.
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-minioadmin}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-minioadmin}
+      # No EC2/ECS metadata service in plain Docker; skip it so the credential
+      # chain resolves from env immediately instead of waiting on an IMDS timeout.
+      AWS_EC2_METADATA_DISABLED: 'true'
+    depends_on:
+      mongo:
+        condition: service_healthy
+      ws:
+        condition: service_started
+    restart: unless-stopped
 
   # Local LLMs via Ollama (optional).
   # Run local open-weight models (e.g. Qwen) with NO provider API keys and, once

--- a/selfhost/ws-gateway/Dockerfile
+++ b/selfhost/ws-gateway/Dockerfile
@@ -1,0 +1,15 @@
+# Self-host WebSocket gateway image. Tiny: a single Node script + `ws`.
+# Built by compose.selfhost.yaml as the `ws` service; see gateway.mjs.
+ARG NODE_VERSION=24
+FROM node:${NODE_VERSION}-slim AS runner
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+COPY gateway.mjs ./
+
+USER node
+EXPOSE 3001
+CMD ["node", "gateway.mjs"]

--- a/selfhost/ws-gateway/gateway.mjs
+++ b/selfhost/ws-gateway/gateway.mjs
@@ -58,42 +58,51 @@ async function readBody(req) {
 
 // ---- HTTP face: API Gateway Management API emulator + health ----------------
 const server = http.createServer(async (req, res) => {
-  if (req.method === 'GET' && (req.url === '/health' || req.url === '/')) {
-    res.writeHead(200, { 'content-type': 'text/plain' });
-    return res.end('ok');
-  }
+  // A malformed request or a socket race (e.g. ws.send on a half-closed peer)
+  // can throw; catch so the connection gets a 500 instead of hanging on an
+  // unhandled rejection.
+  try {
+    if (req.method === 'GET' && (req.url === '/health' || req.url === '/')) {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      return res.end('ok');
+    }
 
-  // POST/GET/DELETE /@connections/{connectionId}
-  const match = req.url && req.url.match(/^\/@connections\/([^/?]+)/);
-  if (match) {
-    const connectionId = decodeURIComponent(match[1]);
-    const ws = sockets.get(connectionId);
-    const isOpen = ws && ws.readyState === ws.OPEN;
+    // POST/GET/DELETE /@connections/{connectionId}
+    const match = req.url && req.url.match(/^\/@connections\/([^/?]+)/);
+    if (match) {
+      const connectionId = decodeURIComponent(match[1]);
+      const ws = sockets.get(connectionId);
+      const isOpen = ws && ws.readyState === ws.OPEN;
 
-    if (req.method === 'POST') {
-      const body = await readBody(req);
-      if (!isOpen) {
-        // Match API Gateway: 410 Gone lets callers prune the stale subscriber.
-        res.writeHead(410);
-        return res.end('Gone');
+      if (req.method === 'POST') {
+        const body = await readBody(req);
+        if (!isOpen) {
+          // Match API Gateway: 410 Gone lets callers prune the stale subscriber.
+          res.writeHead(410);
+          return res.end('Gone');
+        }
+        ws.send(body);
+        res.writeHead(200);
+        return res.end();
       }
-      ws.send(body);
-      res.writeHead(200);
-      return res.end();
+      if (req.method === 'DELETE') {
+        if (ws) ws.close();
+        res.writeHead(204);
+        return res.end();
+      }
+      if (req.method === 'GET') {
+        res.writeHead(isOpen ? 200 : 410);
+        return res.end();
+      }
     }
-    if (req.method === 'DELETE') {
-      if (ws) ws.close();
-      res.writeHead(204);
-      return res.end();
-    }
-    if (req.method === 'GET') {
-      res.writeHead(isOpen ? 200 : 410);
-      return res.end();
-    }
-  }
 
-  res.writeHead(404);
-  res.end('Not found');
+    res.writeHead(404);
+    res.end('Not found');
+  } catch (err) {
+    console.error('[ws-gateway] http handler error:', err?.message || err);
+    if (!res.headersSent) res.writeHead(500);
+    res.end();
+  }
 });
 
 // ---- WebSocket face: browser clients ---------------------------------------

--- a/selfhost/ws-gateway/gateway.mjs
+++ b/selfhost/ws-gateway/gateway.mjs
@@ -1,0 +1,160 @@
+// Self-host WebSocket gateway.
+//
+// Replaces AWS API Gateway WebSocket for the Docker Compose self-host stack. It
+// has two faces on a single port:
+//
+//   1. A browser-facing WebSocket server (WEBSOCKET_URL, e.g. ws://localhost:3001).
+//      On connect it authenticates by delegating to the app, keeps a
+//      connectionId -> socket map, answers heartbeats locally, and forwards every
+//      other inbound frame to the app to run the real handler logic
+//      (subscribe_query / unsubscribe_query, with the app's CASL scoping intact).
+//
+//   2. An API Gateway Management API emulator (WEBSOCKET_MANAGEMENT_ENDPOINT, e.g.
+//      http://ws:3001). It accepts `POST /@connections/{id}` from the app and the
+//      subscriber-fanout container and relays the body to the live socket, so
+//      server-side pushes (initial data, change-stream fan-out, chat streaming)
+//      reach the browser. Returns 410 for dead connections so callers prune them.
+//
+// The gateway itself holds no auth/model logic; it delegates to the app over an
+// internal, shared-secret HTTP endpoint (POST /api/internal/ws/{action}).
+
+import http from 'node:http';
+import crypto from 'node:crypto';
+import { WebSocketServer } from 'ws';
+
+const PORT = Number(process.env.PORT || 3001);
+const APP_INTERNAL_URL = (process.env.APP_INTERNAL_URL || 'http://app:3000').replace(/\/$/, '');
+const INTERNAL_WS_SECRET = process.env.INTERNAL_WS_SECRET || '';
+
+if (!INTERNAL_WS_SECRET) {
+  console.warn('[ws-gateway] INTERNAL_WS_SECRET is empty; the app will reject internal calls.');
+}
+
+/** connectionId -> live WebSocket */
+const sockets = new Map();
+
+/** Call the app's internal handler bridge. Returns the fetch Response (or null on network error). */
+async function callApp(action, payload) {
+  try {
+    return await fetch(`${APP_INTERNAL_URL}/api/internal/ws/${action}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-ws-secret': INTERNAL_WS_SECRET,
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.error(`[ws-gateway] app call '${action}' failed:`, err?.message || err);
+    return null;
+  }
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+// ---- HTTP face: API Gateway Management API emulator + health ----------------
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET' && (req.url === '/health' || req.url === '/')) {
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    return res.end('ok');
+  }
+
+  // POST/GET/DELETE /@connections/{connectionId}
+  const match = req.url && req.url.match(/^\/@connections\/([^/?]+)/);
+  if (match) {
+    const connectionId = decodeURIComponent(match[1]);
+    const ws = sockets.get(connectionId);
+    const isOpen = ws && ws.readyState === ws.OPEN;
+
+    if (req.method === 'POST') {
+      const body = await readBody(req);
+      if (!isOpen) {
+        // Match API Gateway: 410 Gone lets callers prune the stale subscriber.
+        res.writeHead(410);
+        return res.end('Gone');
+      }
+      ws.send(body);
+      res.writeHead(200);
+      return res.end();
+    }
+    if (req.method === 'DELETE') {
+      if (ws) ws.close();
+      res.writeHead(204);
+      return res.end();
+    }
+    if (req.method === 'GET') {
+      res.writeHead(isOpen ? 200 : 410);
+      return res.end();
+    }
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+// ---- WebSocket face: browser clients ---------------------------------------
+const wss = new WebSocketServer({ server });
+
+wss.on('connection', async (ws, req) => {
+  const connectionId = crypto.randomUUID();
+  const url = new URL(req.url || '/', 'http://localhost');
+  const token = url.searchParams.get('token') || undefined;
+  const secWebSocketProtocol = req.headers['sec-websocket-protocol'];
+
+  async function handleFrame(raw) {
+    const text = raw.toString('utf8');
+    // Heartbeat is answered locally with the bare 'pong' string the client
+    // expects as its react-use-websocket returnMessage (see heartbeat.ts).
+    let action;
+    try {
+      action = JSON.parse(text)?.action;
+    } catch {
+      /* non-JSON frame; forward to the app as-is below */
+    }
+    if (action === 'heartbeat') {
+      ws.send('pong');
+      return;
+    }
+    // Everything else (subscribe_query / unsubscribe_query / ...) runs in the app.
+    await callApp('message', { connectionId, body: text }).catch(() => {});
+  }
+
+  // Buffer frames that arrive during the auth handshake: react-use-websocket
+  // sends subscribe_query right after onOpen, which can race the connect await.
+  let ready = false;
+  const pending = [];
+  ws.on('message', raw => {
+    if (ready) handleFrame(raw);
+    else pending.push(raw);
+  });
+  ws.on('close', () => {
+    sockets.delete(connectionId);
+    callApp('disconnect', { connectionId }).catch(() => {});
+  });
+  ws.on('error', err => {
+    console.error(`[ws-gateway] socket ${connectionId} error:`, err?.message || err);
+  });
+
+  // Delegate authentication + Connection-row creation to the app ($connect logic).
+  const resp = await callApp('connect', {
+    connectionId,
+    token,
+    headers: secWebSocketProtocol ? { 'sec-websocket-protocol': secWebSocketProtocol } : {},
+  });
+  if (!resp || !resp.ok) {
+    ws.close(1008, 'Unauthorized');
+    return;
+  }
+
+  sockets.set(connectionId, ws);
+  ready = true;
+  for (const raw of pending) handleFrame(raw);
+});
+
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`[ws-gateway] listening on :${PORT} (app=${APP_INTERNAL_URL})`);
+});

--- a/selfhost/ws-gateway/gateway.mjs
+++ b/selfhost/ws-gateway/gateway.mjs
@@ -150,6 +150,16 @@ wss.on('connection', async (ws, req) => {
     return;
   }
 
+  // The browser may have closed during the connect handshake. If so, don't
+  // register the dead socket or flush buffered frames (that would create orphan
+  // subscriptions no disconnect prunes). The earlier close handler's disconnect
+  // can race ahead of connect's Connection write, so run disconnect again here
+  // (idempotent) to guarantee cleanup.
+  if (ws.readyState !== ws.OPEN) {
+    callApp('disconnect', { connectionId }).catch(() => {});
+    return;
+  }
+
   sockets.set(connectionId, ws);
   ready = true;
   for (const raw of pending) handleFrame(raw);

--- a/selfhost/ws-gateway/package.json
+++ b/selfhost/ws-gateway/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "b4m-selfhost-ws-gateway",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Self-host WebSocket gateway: browser socket server + API Gateway Management API emulator for the Bike4Mind Docker Compose stack.",
+  "main": "gateway.mjs",
+  "scripts": {
+    "start": "node gateway.mjs"
+  },
+  "dependencies": {
+    "ws": "^8.21.0"
+  }
+}


### PR DESCRIPTION
Restores realtime streaming in the Docker Compose self-host stack, which previously degraded to fetch-on-refresh because the stack had no WebSocket gateway. Adds a self-host gateway and wires in the subscriber-fanout image, giving self-host the same live experience as the hosted app with no AWS API Gateway. Self-host only; the AWS/SST path is untouched.

## What changed
- `selfhost/ws-gateway/`: a small standalone service on port 3001 with two faces:
  - a browser-facing WebSocket server (`WEBSOCKET_URL`), and
  - an API Gateway Management API emulator (`POST /@connections/{id}`, `WEBSOCKET_MANAGEMENT_ENDPOINT`) that the app and the fanout push to.
  It holds no auth or model logic: it answers heartbeats locally and delegates connect/subscribe/unsubscribe to the app.
- `apps/client/pages/api/internal/ws/[action].ts`: an internal bridge that reuses the existing connect/subscribe/unsubscribe/disconnect handlers, so JWT verification and CASL query-scoping are identical to the hosted path. Guarded by `INTERNAL_WS_SECRET` and enabled only when `B4M_SELF_HOST=true` (it 404s in AWS).
- `compose.selfhost.yaml`: adds the `ws` gateway and `subscriber-fanout` services.
- `.env.selfhost.example`: adds `INTERNAL_WS_SECRET` and the optional `SUBSCRIBER_FANOUT_IMAGE` override, and documents the gateway.
- `SELF_HOST.md`: realtime streaming is no longer listed as a gap.

## How it works
Chat token streaming rides the direct sendToClient path (Connection rows plus the gateway relay); the subscriber-fanout adds change-stream data updates (e.g. quests, sessions) for live sync. Both flow through the same gateway.

## AWS/SST impact
None. `infra/` is unchanged, the new route is self-host-gated, and the fanout resolves its config env-first with a `Resource` fallback, so the hosted deploy is unaffected.

## Verification
Rebuilt the full self-host stack locally and tested it end-to-end:
- signed in via the Mailpit one-time code; the browser console shows "ws connected"
- sent a chat with a local Ollama model; the reply streamed into the UI live with no refresh
- confirmed the fanout wrote a CASL-scoped querySubscription and opened the matching change stream, pushing through the gateway management endpoint
- no errors in the ws, subscriber-fanout, or app logs

## Demo

https://github.com/user-attachments/assets/211d31df-a576-48aa-8f4e-aa0389d8b105

## Merge gating
Hold merge and rollout until the first `ghcr.io/bike4mind/subscriber-fanout` image is published and public. `compose.selfhost.yaml` defaults the fanout service to that image and cannot build it from source here, so until it is pullable a `docker compose up` fails on that service. (Chat token streaming still works via the gateway; only change-stream data sync is affected.)
