### PR TITLE
fix(client): scope QuestMasterPlan fan-out subscriptions by plan access

### DIFF
--- a/apps/client/server/websocket/dataSubscribeRequest.ts
+++ b/apps/client/server/websocket/dataSubscribeRequest.ts
@@ -21,6 +21,7 @@ import {
 import { Session as SessionModel } from '@bike4mind/database/auth';
 import { accessibleBy } from '@casl/mongoose';
 import { Subscription } from '@server/models/Subscription';
+import { questMasterPlanSubscriptionScope } from '@server/websocket/subscriptionScopes';
 import { NotFoundError } from '@server/utils/errors';
 import { sendToConnection, withWebSocketContext } from '@server/websocket/utils';
 import crypto from 'crypto';
@@ -74,7 +75,12 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
     scope = { sessionId: { $in: accessibleSessions.map(s => s._id) } };
   } else if (collectionName === QuestMasterPlan.collection.collectionName) {
     const accessibleSessions = await SessionModel.find(accessibleBy(userAbility).ofType(SessionModel), { _id: true });
-    scope = { notebookId: { $in: accessibleSessions.map(s => s._id) } };
+    // Plan access is user-based (owner/shared/public) with a session-based
+    // fallback for legacy and session-visibility plans
+    scope = questMasterPlanSubscriptionScope(
+      user._id.toString(),
+      accessibleSessions.map(s => s._id)
+    );
   } else if (collectionName === Invite.collection.collectionName) {
     const canShareProjectsQuery = accessibleBy(userAbility, Permission.share).ofType(Project);
     const shareableProjectIds = await Project.find(canShareProjectsQuery).distinct('_id');

--- a/apps/client/server/websocket/subscriptionScopes.test.ts
+++ b/apps/client/server/websocket/subscriptionScopes.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { Types } from 'mongoose';
+import { questMasterPlanSubscriptionScope } from './subscriptionScopes';
+
+describe('questMasterPlanSubscriptionScope', () => {
+  const userId = new Types.ObjectId().toString();
+  const sessionIds = [new Types.ObjectId(), new Types.ObjectId()];
+
+  it('includes owner, shared, public, and session arms', () => {
+    const scope = questMasterPlanSubscriptionScope(userId, sessionIds);
+
+    expect(scope.$or).toEqual([
+      { userId },
+      { sharedWith: userId },
+      { visibility: 'public' },
+      { notebookId: { $in: sessionIds } },
+    ]);
+  });
+
+  it('matches a plan owned by the user', () => {
+    const scope = questMasterPlanSubscriptionScope(userId, []);
+
+    expect(scope.$or).toContainEqual({ userId });
+  });
+
+  it('matches a plan shared with the user regardless of session access', () => {
+    const scope = questMasterPlanSubscriptionScope(userId, []);
+
+    expect(scope.$or).toContainEqual({ sharedWith: userId });
+    // No session access required for the shared arm
+    expect(scope.$or).toContainEqual({ notebookId: { $in: [] } });
+  });
+
+  it('keeps the session-based arm for legacy plans', () => {
+    const scope = questMasterPlanSubscriptionScope(userId, sessionIds);
+
+    expect(scope.$or).toContainEqual({ notebookId: { $in: sessionIds } });
+  });
+
+  it('does not widen the userId arms beyond the requesting user', () => {
+    const otherUser = new Types.ObjectId().toString();
+    const scope = questMasterPlanSubscriptionScope(userId, sessionIds);
+
+    expect(scope.$or).not.toContainEqual({ userId: otherUser });
+    expect(scope.$or).not.toContainEqual({ sharedWith: otherUser });
+  });
+});

--- a/apps/client/server/websocket/subscriptionScopes.ts
+++ b/apps/client/server/websocket/subscriptionScopes.ts
@@ -1,0 +1,30 @@
+import type { mongoose } from '@bike4mind/database';
+
+/**
+ * Fan-out scope for QuestMasterPlan change-stream subscriptions.
+ *
+ * Plan access is user-based (owner, shared collaborator, or public
+ * visibility), while legacy plans (no userId) and session-visibility plans
+ * are reachable through session membership. The subscription scope must
+ * cover both dimensions; a session-only scope silently drops live updates
+ * for shared collaborators who work from their own sessions and for plans
+ * attached to placeholder notebook ids.
+ *
+ * The scope is ANDed with the client-supplied query, so the public arm only
+ * streams documents the client explicitly subscribed to.
+ */
+export function questMasterPlanSubscriptionScope(
+  userId: string,
+  accessibleSessionIds: mongoose.Types.ObjectId[]
+): mongoose.FilterQuery<unknown> {
+  return {
+    $or: [
+      { userId },
+      { sharedWith: userId },
+      { visibility: 'public' },
+      // Legacy plans (no userId) and session-visibility plans remain
+      // reachable through the sessions the user can access
+      { notebookId: { $in: accessibleSessionIds } },
+    ],
+  };
+}


### PR DESCRIPTION
## Description

QuestMasterPlan websocket (change-stream) subscriptions were scoped by session membership, while API access to a plan is user-based (owner, shared collaborator, or public visibility). A shared collaborator working from their own session could read and write a plan through the API but never received live updates for it; the same applied to plans attached to placeholder notebook ids.

PR 3 of the QuestMaster consolidation series (PR 1: #169, PR 2: #189).

## Changes

- Subscription scope for `questmasterplans` now mirrors plan access: `userId`, `sharedWith`, `visibility: 'public'`, plus the original session-based arm (kept for legacy plans without `userId` and session-visibility plans) - strictly additive, no delivery removed
- Scope builder extracted to `server/websocket/subscriptionScopes.ts` as a pure function with unit tests (+5)
- The scope remains ANDed with the client-supplied query, so the public arm only streams documents the client explicitly subscribed to

## Tests

- `pnpm --filter @bike4mind/client typecheck` - pass
- `pnpm --filter @bike4mind/client test` - 4865 passed / 81 skipped
- `pnpm lint:check` - pass

## Guide for Testers

- User A creates a plan and shares it with user B (`sharedWith`); user B opens the plan board from their own session: sub-quest status changes made by A now appear live for B (previously required a refresh)
- Owner flows are unchanged; legacy plans still stream via session ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)