### PR TITLE
ci(deploy): point premium overlay checkouts at Bike4Mind org

### DIFF
--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -180,10 +180,11 @@ jobs:
           client-id: ${{ vars.PREMIUM_OVERLAY_CLIENT_ID }}
           private-key: ${{ secrets.PREMIUM_OVERLAY_APP_PRIVATE_KEY }}
           # Owner of the premium overlay repos + the overlay GitHub App installation.
-          # Configurable so the open-core cutover (repos + app move MillionOnMars ->
-          # Bike4Mind) is an instant `PREMIUM_OVERLAY_OWNER` var flip, not a code change.
-          # Unset var falls back to MillionOnMars, so this is a no-op until the var is set.
-          owner: ${{ vars.PREMIUM_OVERLAY_OWNER || 'MillionOnMars' }}
+          # The open-core cutover (repos + app moved MillionOnMars -> Bike4Mind) is
+          # complete, so this defaults to Bike4Mind; `PREMIUM_OVERLAY_OWNER` stays
+          # configurable for any future org move. The overlay-checkout steps below use
+          # the SAME expression, so the token owner and the checkout owner can't drift.
+          owner: ${{ vars.PREMIUM_OVERLAY_OWNER || 'Bike4Mind' }}
           repositories: |
             b4m-overwatch
             b4m-libreoncology
@@ -204,7 +205,7 @@ jobs:
         if: inputs.is_trusted_context == 'true' && steps.premium-token.outcome == 'success'
         uses: actions/checkout@v6
         with:
-          repository: MillionOnMars/b4m-overwatch
+          repository: ${{ vars.PREMIUM_OVERLAY_OWNER || 'Bike4Mind' }}/b4m-overwatch
           token: ${{ steps.premium-token.outputs.token }}
           ref: ${{ steps.overlay-pin.outputs.b4m-overwatch-ref }}
           path: packages/premium/overwatch
@@ -238,7 +239,7 @@ jobs:
         if: inputs.is_trusted_context == 'true' && steps.premium-token.outcome == 'success'
         uses: actions/checkout@v6
         with:
-          repository: MillionOnMars/b4m-libreoncology
+          repository: ${{ vars.PREMIUM_OVERLAY_OWNER || 'Bike4Mind' }}/b4m-libreoncology
           token: ${{ steps.premium-token.outputs.token }}
           ref: ${{ steps.overlay-pin.outputs.b4m-libreoncology-ref }}
           path: packages/premium/libreoncology
@@ -272,7 +273,7 @@ jobs:
         if: inputs.is_trusted_context == 'true' && steps.premium-token.outcome == 'success'
         uses: actions/checkout@v6
         with:
-          repository: MillionOnMars/b4m-pi
+          repository: ${{ vars.PREMIUM_OVERLAY_OWNER || 'Bike4Mind' }}/b4m-pi
           token: ${{ steps.premium-token.outputs.token }}
           ref: ${{ steps.overlay-pin.outputs.b4m-pi-ref }}
           path: packages/premium/pi
@@ -306,7 +307,7 @@ jobs:
         if: inputs.is_trusted_context == 'true' && steps.premium-token.outcome == 'success'
         uses: actions/checkout@v6
         with:
-          repository: MillionOnMars/b4m-tavern
+          repository: ${{ vars.PREMIUM_OVERLAY_OWNER || 'Bike4Mind' }}/b4m-tavern
           token: ${{ steps.premium-token.outputs.token }}
           ref: ${{ steps.overlay-pin.outputs.b4m-tavern-ref }}
           path: packages/premium/tavern
@@ -339,7 +340,7 @@ jobs:
         if: inputs.is_trusted_context == 'true' && steps.premium-token.outcome == 'success'
         uses: actions/checkout@v6
         with:
-          repository: MillionOnMars/b4m-optihashi
+          repository: ${{ vars.PREMIUM_OVERLAY_OWNER || 'Bike4Mind' }}/b4m-optihashi
           token: ${{ steps.premium-token.outputs.token }}
           ref: ${{ steps.overlay-pin.outputs.b4m-optihashi-ref }}
           path: packages/premium/optihashi

--- a/scripts/bootstrap-premium.sh
+++ b/scripts/bootstrap-premium.sh
@@ -7,6 +7,9 @@
 # repo (open-core devs skip everything). After cloning, run `pnpm install`.
 #
 # Usage: pnpm bootstrap:premium
+#
+# Env (override the org):
+#   PREMIUM_OVERLAY_OWNER=Bike4Mind   # GitHub org/owner the overlays are cloned from
 set -euo pipefail
 
 LOCK_FILE="premium-overlay.lock.json"

--- a/scripts/bootstrap-premium.sh
+++ b/scripts/bootstrap-premium.sh
@@ -43,7 +43,7 @@ while IFS=$'\t' read -r key ref; do
     exit 1
   fi
 
-  repo="MillionOnMars/${key}"
+  repo="${PREMIUM_OVERLAY_OWNER:-Bike4Mind}/${key}"
   # Workspace dir: strip the 'b4m-' prefix (b4m-overwatch -> overwatch).
   overlay_dir="packages/premium/${key#b4m-}"
 


### PR DESCRIPTION
## Summary

- The premium overlay repos (`b4m-{overwatch,libreoncology,optihashi,pi,tavern}`) were transferred out of the `MillionOnMars` org to `Bike4Mind`. `MillionOnMars/b4m-*` still resolves today, but only via GitHub's transfer-redirect — a latent single point of failure if that redirect is ever dropped or the old name is reused.
- The token-minting step in `_deploy-env.yml` already had a configurable `owner: ${{ vars.PREMIUM_OVERLAY_OWNER || 'MillionOnMars' }}` with a comment promising "an instant var flip, not a code change" — but the 5 checkout steps hardcoded `repository: MillionOnMars/b4m-<name>`, so the var flip moved the token but not the checkouts. `scripts/bootstrap-premium.sh` hardcoded the org too, with no var at all.
- This PR parameterizes all 5 checkout steps (and the bootstrap script) on the **same** `PREMIUM_OVERLAY_OWNER` expression the token step uses, so checkout-owner can never drift from token-owner. Fallback default changes `MillionOnMars` -> `Bike4Mind` since that's now the canonical org.
- **Verified** (via `gh variable list`): `PREMIUM_OVERLAY_OWNER` is a repo var already set to `Bike4Mind`. Repo vars override any org-level var of the same name, so there's no drift risk — the fallback is belt-and-suspenders, not load-bearing.
- Not a live bug: the last trusted-context deploy was green with the old hardcoded refs, since the redirect currently works. This closes the latent risk before it becomes an active one.
- Scope is intentionally minimal: only the `b4m-*` overlay checkout org. Did not touch `CANONICAL_REPO` fallbacks, `generationScoping.ts` scrub patterns, `react-use-websocket`, or the much larger set of `MillionOnMars/lumina5` references (the main repo's own default slug across SRE/dashboard/whats-new code) — that's a separate, out-of-scope migration since the main repo itself hasn't moved orgs.

## Test plan

- [x] `git grep -n "MillionOnMars/b4m-"` returns no matches
- [x] `actionlint .github/workflows/_deploy-env.yml` — no new findings on touched lines (pre-existing findings on unrelated lines confirmed via `git blame` to predate this branch)
- [x] Diff limited to the 3 previously-hardcoded checkout lines (pi/tavern/optihashi — overwatch/libreoncology + the token-owner fallback were already parameterized on this branch) + 1 line in `bootstrap-premium.sh`
- [x] **Preview deploy validated pre-merge**: a trusted-context preview deploy (isolated stage `pr193`) hydrated all 5 overlays from the parameterized `Bike4Mind/b4m-*` checkouts and deployed cleanly — the real end-to-end validation, before touching dev/staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
