### PR TITLE
fix(billing): allow pay-as-you-go credit purchase without a subscription

### DIFF
--- a/apps/client/lib/credits/schemas.ts
+++ b/apps/client/lib/credits/schemas.ts
@@ -6,7 +6,10 @@ const baseTransactionSchema = z.object({
 });
 export const perCreditSchema = baseTransactionSchema.extend({
   transactionType: z.literal(TransactionType.PerCredit),
-  credits: z.number(),
+  // Now that pay-as-you-go credits are reachable without a subscription, bound the
+  // requested amount: a positive integer with a sane cap, so arbitrary/zero/negative
+  // values never reach Stripe.
+  credits: z.number().int().positive().max(1_000_000),
 });
 export const packageSchema = baseTransactionSchema.extend({
   transactionType: z.literal(TransactionType.Package),

--- a/apps/client/pages/api/stripe/__tests__/start-payment.test.ts
+++ b/apps/client/pages/api/stripe/__tests__/start-payment.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { ForbiddenError } from '@server/utils/errors';
+import { CreditPackageId, TransactionType } from '@client/lib/credits/types';
+
+// baseApi: unwrap the chain so handler.post(fn) just returns fn, and .use() is a no-op.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => ({
+    use: function () {
+      return this;
+    },
+    post: (fn: unknown) => fn,
+  }),
+}));
+
+// requireStripeWebhook is applied via .use(), which our baseApi mock drops. Stub the
+// factory so importing the handler module doesn't touch real webhook config.
+vi.mock('@server/middlewares/requireStripeWebhook', () => ({
+  requireStripeWebhook: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const mockUserUpdate = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  userRepository: {
+    update: (...args: unknown[]) => mockUserUpdate(...args),
+  },
+}));
+
+const mockCreateCustomer = vi.fn();
+const mockPaymentIntentsCreate = vi.fn();
+vi.mock('@server/integrations/stripe/stripe', () => ({
+  createCustomer: (...args: unknown[]) => mockCreateCustomer(...args),
+  CustomerType: { User: 'user' },
+  stripe: {
+    paymentIntents: {
+      create: (...args: unknown[]) => mockPaymentIntentsCreate(...args),
+    },
+  },
+}));
+
+const mockHandlePerCredit = vi.fn();
+const mockHandlePackage = vi.fn();
+vi.mock('@client/lib/credits/utils', () => ({
+  handlePerCreditTransaction: (...args: unknown[]) => mockHandlePerCredit(...args),
+  handlePackageTransaction: (...args: unknown[]) => mockHandlePackage(...args),
+}));
+
+vi.mock('@server/utils/config', () => ({
+  Config: { STAGE: 'test', STRIPE_PUBLISHABLE_KEY: 'pk_test_123' },
+}));
+
+import handler from '../start-payment';
+
+type HandlerFn = (req: unknown, res: unknown) => Promise<unknown>;
+
+// A minimal non-subscribed user. The route no longer looks up subscriptions at all,
+// so the absence of any subscription state IS the "non-subscriber" case.
+function makeReq(body: unknown, userOverrides: Record<string, unknown> = {}) {
+  const { req, res } = createMocks({ method: 'POST' });
+  (req as Record<string, unknown>).body = body;
+  (req as Record<string, unknown>).user = {
+    id: 'user_1',
+    email: 'buyer@example.com',
+    name: 'Buyer',
+    stripeCustomerId: 'cus_existing',
+    disputePending: false,
+    ...userOverrides,
+  };
+  return { req, res };
+}
+
+describe('POST /api/stripe/start-payment (pay-as-you-go, no subscription required)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHandlePackage.mockResolvedValue({
+      amount: 1000,
+      description: 'credits package',
+      metadata: { credits: 10000, packageId: CreditPackageId.A },
+    });
+    mockHandlePerCredit.mockResolvedValue({
+      amount: 500,
+      description: 'credits',
+      metadata: { credits: 500, pricePerCredit: '0.01' },
+    });
+    mockPaymentIntentsCreate.mockResolvedValue({ client_secret: 'cs_test_abc', id: 'pi_1' });
+  });
+
+  it('creates a payment intent for a non-subscribed user buying a package', async () => {
+    const { req, res } = makeReq({ transactionType: TransactionType.Package, packageId: CreditPackageId.A });
+
+    await (handler as HandlerFn)(req, res);
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res._getData()).toEqual({ clientSecret: 'cs_test_abc', publishableKey: 'pk_test_123' });
+  });
+
+  it('creates a payment intent for a non-subscribed user buying per-credit', async () => {
+    const { req, res } = makeReq({ transactionType: TransactionType.PerCredit, credits: 500 });
+
+    await (handler as HandlerFn)(req, res);
+
+    expect(mockHandlePerCredit).toHaveBeenCalledTimes(1);
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('creates a Stripe customer on the fly when the user has none', async () => {
+    mockCreateCustomer.mockResolvedValue({ id: 'cus_new' });
+    const { req, res } = makeReq(
+      { transactionType: TransactionType.Package, packageId: CreditPackageId.A },
+      { stripeCustomerId: null }
+    );
+
+    await (handler as HandlerFn)(req, res);
+
+    expect(mockCreateCustomer).toHaveBeenCalledTimes(1);
+    expect(mockUserUpdate).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('blocks a user with an open payment dispute before creating any payment intent', async () => {
+    const { req, res } = makeReq(
+      { transactionType: TransactionType.Package, packageId: CreditPackageId.A },
+      { disputePending: true }
+    );
+
+    await expect((handler as HandlerFn)(req, res)).rejects.toBeInstanceOf(ForbiddenError);
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a per-credit request with a non-positive credit amount', async () => {
+    const { req, res } = makeReq({ transactionType: TransactionType.PerCredit, credits: 0 });
+
+    await expect((handler as HandlerFn)(req, res)).rejects.toBeTruthy();
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/stripe/start-payment.ts
+++ b/apps/client/pages/api/stripe/start-payment.ts
@@ -2,12 +2,10 @@ import { userRepository } from '@bike4mind/database';
 import { transactionSchema } from '@client/lib/credits/schemas';
 import { PaymentDetails, TransactionType } from '@client/lib/credits/types';
 import { handlePackageTransaction, handlePerCreditTransaction } from '@client/lib/credits/utils';
-import { SubscriptionOwnerType } from '@client/lib/subscriptions/types';
 import { baseApi } from '@server/middlewares/baseApi';
 import { requireStripeWebhook } from '@server/middlewares/requireStripeWebhook';
-import { subscriptionRepository } from '@server/models/Subscription';
 import { Config } from '@server/utils/config';
-import { BadRequestError } from '@server/utils/errors';
+import { BadRequestError, ForbiddenError } from '@server/utils/errors';
 import { createCustomer, CustomerType, stripe } from '@server/integrations/stripe/stripe';
 
 const handler = baseApi()
@@ -15,12 +13,11 @@ const handler = baseApi()
   .post(async (req, res) => {
     const parsedBody = transactionSchema.parse(req.body);
 
-    const activeSubscriptions = await subscriptionRepository.findActiveSubscriptionsByOwner(
-      SubscriptionOwnerType.User,
-      req.user.id
-    );
-    if (activeSubscriptions.length < 1) {
-      throw new BadRequestError('You must be subscribed to a plan to purchase credits');
+    // Credit purchases are pay-as-you-go and do not require an active subscription.
+    // We still block accounts with an open payment dispute (mirrors the API-key auth
+    // guard) so a flagged chargeback fraudster cannot keep buying credits.
+    if (req.user.disputePending) {
+      throw new ForbiddenError('Account suspended pending dispute resolution. Please contact support.');
     }
 
     const metadata: PaymentDetails['metadata'] = {


### PR DESCRIPTION
## Description

Closes #2.

Non-subscribers could not buy one-off credit packs. `POST /api/stripe/start-payment`
threw a `400 "You must be subscribed to a plan to purchase credits"` whenever the
user had zero active subscriptions, which blocked the FTUE "buy credits" path
entirely (for both `Package` and `PerCredit` transaction types).

The gate was not earning its keep: after PR #188 every metered charge is +20% gross
by construction, so a *paid* pack purchase is never a loss vector. Credit purchases
are pay-as-you-go and should not require a subscription. This removes the gate and
replaces it with a narrower, non-subscription safety guard (dispute-pending accounts).

The live credits modal (`subscription/CreditsModal.tsx`) already renders packs for any
personal account with no subscription check, so **no UI change is needed** — the only
real blocker was the server gate.

## Changes

- Remove the `activeSubscriptions.length < 1 -> 400` gate from `start-payment.ts`
  (covers both `Package` and `PerCredit`), and drop the now-unused
  `subscriptionRepository` / `SubscriptionOwnerType` imports.
- Add a `disputePending -> 403` guard, mirroring the existing API-key auth guard, so a
  flagged chargeback account cannot keep purchasing.
- Bound `perCreditSchema.credits` to a positive integer `<= 1,000,000` now that the
  route is reachable without a subscription.
- Add `pages/api/stripe/__tests__/start-payment.test.ts`: non-subscriber can buy
  (Package + PerCredit), customer is created on the fly, `disputePending` is blocked
  before any Stripe call, non-positive credits are rejected.

Rebased onto `main` after PR #188 so the packs render at the new uniform anchor
(A 16,667 / B 33,333 / C 58,333 credits).

## Guide for Testers

Preview: request a deploy in **#bike4mind-deploys** with `@Bike4Mind Deployer <pr#>`;
the bot replies with `https://app.pr<N>.preview.bike4mind.com`.

1. On the preview URL, create/sign in with a **fresh account that has NO active subscription**.
2. Open the credits modal: **Profile menu -> Buy Credits** (or the low-credits button in a session).
   Expected: the modal opens and shows credit packs (16,667 / 33,333 / 58,333 credits) with a `Purchase` button.
3. Click `Purchase` on any pack.
   Expected: the Stripe payment sheet mounts (no `400 "must be subscribed"` error). This is the core fix.
4. Pay with Stripe test card `4242 4242 4242 4242`, any future expiry, any CVC, any ZIP.
   Expected: payment succeeds and the modal shows a purchase-success toast.
5. Confirm the account's credit balance increases by the pack amount within a few seconds
   (added by the `payment_intent.succeeded` webhook).

### Regression Checks
- A **subscribed** account can still open the modal and buy a pack exactly as before.
- Organization (non-personal) selected account: the pack UI stays hidden (unchanged).

### What NOT to test
- Credit *consumption* / charging / settlement — untouched by this PR (see #190's charge-hot-path constraint).
- Subscription (Monthly/Yearly) purchase flows — unchanged.

## Additional Information

- Charge/settle hot path is untouched: no references to `currentCredits`, reservations,
  settlement, or the #188 stochastic rounding in this diff. Credit granting in
  `webhook.ts` (`payment_intent.succeeded`) is unchanged and already
  subscription-independent.
- Interaction with #190 (credit-lot expiry, @jjmarfa): non-subscriber pack purchases now
  flow through the same `payment_intent.succeeded` grant site, so once #190 stamps 12-month
  lots there, these purchases get stamped for free — no coordination needed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
