### PR TITLE
fix(client): drop dead invite code + ?code= link from referral email

### DIFF
--- a/apps/client/pages/api/reg-invites/__tests__/refer.test.ts
+++ b/apps/client/pages/api/reg-invites/__tests__/refer.test.ts
@@ -19,7 +19,10 @@ vi.mock('@server/utils/mailer/emailHelpers', () => ({
   buildEmailLogoImg: vi.fn(() => ''),
 }));
 vi.mock('@server/integrations/slack/slack', () => ({ postMessageToSlack: vi.fn() }));
-vi.mock('@server/utils/eventBus', () => ({ EmailEvents: { Send: { publish: vi.fn() } } }));
+const mockEmailPublish = vi.fn();
+vi.mock('@server/utils/eventBus', () => ({
+  EmailEvents: { Send: { publish: (...a: any[]) => mockEmailPublish(...a) } },
+}));
 
 const mockUserUpdate = vi.fn();
 const mockInviteFindOne = vi.fn();
@@ -38,6 +41,7 @@ vi.mock('@bike4mind/utils', () => ({
   getSettingsValue: vi.fn(() => false),
 }));
 
+import { getSettingsValue } from '@bike4mind/utils';
 import handler from '@pages/api/reg-invites/refer';
 
 function makeReqRes(user: Record<string, unknown>) {
@@ -102,5 +106,36 @@ describe('/api/reg-invites/refer — sender verification gate', () => {
 
     expect(res._getStatusCode()).toBe(201);
     expect(res._getJSONData().sent).toEqual(['friend@example.com']);
+  });
+});
+
+describe('/api/reg-invites/refer — passwordless email content', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInviteFindOne.mockResolvedValue(null);
+    mockUserUpdate.mockResolvedValue(undefined);
+    process.env.APP_URL = 'https://app.test.local';
+    // Enable the email path so the body is published and can be asserted.
+    vi.mocked(getSettingsValue).mockImplementation((key: string) => key === 'EnableReferralToEmail');
+  });
+
+  it('omits the invite code and the ?code= param from the referral email', async () => {
+    const { req, res } = makeReqRes({
+      id: 'user-1',
+      emailVerified: true,
+      authProviders: [],
+      numReferralsAvailable: 3,
+    });
+
+    await handler(req as any, res as any);
+
+    expect(mockEmailPublish).toHaveBeenCalledTimes(1);
+    const { body } = mockEmailPublish.mock.calls[0][0] as { body: string };
+    // Register link points at the bare /register page - no invite-code query param.
+    expect(body).toContain('href="https://app.test.local/register"');
+    expect(body).not.toContain('?code=');
+    // The dead "invite code to sign up" copy is gone (code is CODE123 per the mock).
+    expect(body).not.toContain('invite code to sign up');
+    expect(body).not.toContain('CODE123');
   });
 });

--- a/apps/client/pages/api/reg-invites/refer.ts
+++ b/apps/client/pages/api/reg-invites/refer.ts
@@ -108,8 +108,9 @@ const handler = baseApi().post(
           inviteCode = existingInvite.code;
         }
 
-        const registrationLinkWithCode = `${registrationLink}?code=${inviteCode}`;
-
+        // Passwordless registration has no invite-code field, so the email links to
+        // the bare /register page - no `?code=` (dead copy the form can't consume).
+        // The invite record + code are still minted for referral tracking below.
         const finalBody = `
             <!DOCTYPE html>
             <html>
@@ -136,8 +137,7 @@ const handler = baseApi().post(
               <div class="content">
                 ${buildEmailLogoImg(brand, logoUrl)}
                 <p>${escape(emailBody)}</p>
-                <p>Use the following invite code to sign up: <strong>${escape(inviteCode)}</strong></p>
-                <p><a href="${escape(registrationLinkWithCode)}">Click here to register</a></p>
+                <p><a href="${escape(registrationLink)}">Click here to register</a></p>
               </div>
             </body>
             </html>


### PR DESCRIPTION
## Description

After the passwordless migration, the `/register` form has **no invite-code field**, but the referral/invite email (`apps/client/pages/api/reg-invites/refer.ts`) still embedded a live invite code (`Use the following invite code to sign up: XXXX-XXXX-XXXX-XXXX`) and a `?code=XXXX...` registration link the form can't consume — dead copy. This removes both.

Closes #157.

## Changes

- **`reg-invites/refer.ts`**
  - Removed the `Use the following invite code to sign up: <code>` line from the referral email template.
  - Register link now points at the bare `/register` page (dropped the `?code=` query param and the now-unused `registrationLinkWithCode` local).
  - **Unchanged:** the invite record + code are still minted (`createRegInvite` / `generateCode`) and the code still appears in the internal Slack notification and `regInvites` tracking — only the dead *email* copy is removed. This is cleanup, not a behavior change to referral accounting (issue notes it's non-functional / not a security issue).
- **`reg-invites/__tests__/refer.test.ts`** — added a test that enables the email path and asserts the published email body (see Tests).

## Guide for Testers

This is an API-only change (email template). Verify by exercising the referral endpoint and inspecting the email that arrives.

1. Ensure `EnableReferralToEmail=true` in admin settings, and use a verified-email (or OAuth) sender account.
2. `POST /api/reg-invites/refer` with a body like:
   ```
   { "userName": "Tester", "friendEmail": ["<an address you can read>"], "emailTitle": "Join me", "emailBody": "Come try this" }
   ```
3. Open the received email.
   - **Expected (after fix):** a single **"Click here to register"** link pointing at `.../register` — **no** `?code=` on the URL, and **no** "Use the following invite code to sign up: ..." line.
   - **Before the fix:** the email contained the invite-code line and a `.../register?code=XXXX-XXXX-XXXX-XXXX` link.

## Tests

- `reg-invites/__tests__/refer.test.ts` — new case `omits the invite code and the ?code= param from the referral email`: enables `EnableReferralToEmail`, captures the published email body, and asserts it links to bare `/register` (no `?code=`), and contains neither the "invite code to sign up" copy nor the generated code. The 3 existing sender-verification-gate tests still pass (4 total).

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
