### PR TITLE
feat(b4m-core): add confidence-gate telemetry (#56 M1.1)

### DIFF
--- a/apps/client/app/components/admin/AgentExecutionsTab.tsx
+++ b/apps/client/app/components/admin/AgentExecutionsTab.tsx
@@ -45,6 +45,9 @@ const formatAge = (updatedAt: string): string => {
 
 const truncate = (s: string, max = 80): string => (s.length <= max ? s : `${s.slice(0, max)}…`);
 
+const formatConfidenceTooltip = (t: NonNullable<StuckExecutionItem['confidenceTelemetry']>): string =>
+  `${t.evaluatedCount} evaluated · ${t.emittedCount} gated · avg ${t.avgConfidence.toFixed(2)} · min ${t.minConfidence.toFixed(2)}`;
+
 const USER_ID_DEBOUNCE_MS = 300;
 
 const AgentExecutionsTab: React.FC = () => {
@@ -222,12 +225,13 @@ const AgentExecutionsTab: React.FC = () => {
                 <th>Query</th>
                 <th style={{ width: 140 }}>Model</th>
                 <th style={{ width: 100 }}>Credits</th>
+                <th style={{ width: 150 }}>Confidence (avg/min)</th>
               </tr>
             </thead>
             <tbody>
               {items.length === 0 ? (
                 <tr>
-                  <td colSpan={7}>
+                  <td colSpan={8}>
                     <Typography level="body-sm" sx={{ textAlign: 'center', py: 3 }}>
                       No stuck executions match these filters.
                     </Typography>
@@ -270,6 +274,27 @@ const AgentExecutionsTab: React.FC = () => {
                       </td>
                       <td>
                         <Typography level="body-sm">{item.totalCreditsUsed.toFixed(2)}</Typography>
+                      </td>
+                      <td data-testid={`stuck-execution-confidence-${item.id}`}>
+                        {item.confidenceTelemetry ? (
+                          <Tooltip title={formatConfidenceTooltip(item.confidenceTelemetry)} placement="top">
+                            <Stack direction="row" spacing={0.5} alignItems="center">
+                              <Typography level="body-xs">
+                                {item.confidenceTelemetry.avgConfidence.toFixed(2)} /{' '}
+                                {item.confidenceTelemetry.minConfidence.toFixed(2)}
+                              </Typography>
+                              {item.confidenceTelemetry.emittedCount > 0 && (
+                                <Chip size="sm" variant="soft" color="warning">
+                                  {item.confidenceTelemetry.emittedCount} gated
+                                </Chip>
+                              )}
+                            </Stack>
+                          </Tooltip>
+                        ) : (
+                          <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                            —
+                          </Typography>
+                        )}
                       </td>
                     </tr>
                   );

--- a/apps/client/app/hooks/data/stuckAgentExecutions.ts
+++ b/apps/client/app/hooks/data/stuckAgentExecutions.ts
@@ -29,6 +29,16 @@ export type StuckExecutionItem = {
   updatedAt: string;
   totalIterations?: number;
   errorMessage?: string;
+  /**
+   * Confidence-gate telemetry (#56 M1.1); omitted when the gate never evaluated.
+   * `avgConfidence` is derived server-side from the stored confidence sum.
+   */
+  confidenceTelemetry?: {
+    evaluatedCount: number;
+    emittedCount: number;
+    minConfidence: number;
+    avgConfidence: number;
+  };
 };
 
 export type StuckExecutionsResponse = {

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -1857,6 +1857,14 @@ async function processExecution(
       // checked on non-terminal iterations (a final_answer iteration is
       // complete by definition; pausing it would discard the answer).
       const gate = readLastIterationConfidence();
+      if (gate !== null) {
+        // Telemetry (#56 M1.1): record every iteration the gate evaluates -
+        // including ones that complete in the same turn (isComplete=true) or
+        // clear the threshold - so `evaluatedCount` is the true denominator for
+        // fire rate. `recordGateEmitted` below increments the numerator only on
+        // a real pause. Baseline observability before touching signal quality.
+        await agentExecutionRepository.recordIterationConfidence(executionId, gate.confidence);
+      }
       if (
         gate !== null &&
         !iterationResult.isComplete &&
@@ -1887,6 +1895,9 @@ async function processExecution(
           await sendWs('failed', { executionId, reason: 'aborted' });
           return;
         }
+        // Telemetry (#56 M1.1): count this real pause only after `setPendingGate`
+        // confirms it landed (i.e. not raced by a concurrent abort).
+        await agentExecutionRepository.recordGateEmitted(executionId);
         await sendWs('confidence_gate', { executionId, ...gatePayload });
         // Emit a `progress` event with the paused status so the client's
         // existing `progress` subscriber flips `ExecutionStatusBanner` to

--- a/packages/database/src/models/billing/AgentExecutionModel.test.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.test.ts
@@ -943,6 +943,81 @@ describe('AgentExecutionRepository', () => {
     });
   });
 
+  // Confidence-gate telemetry (#56 M1.1). Locks the atomic accumulators and the
+  // derived read-facing summary (avgConfidence = sum / evaluated), including the
+  // continuation-Lambda invariant (increments compose across separate calls).
+  describe('confidence telemetry', () => {
+    it('initializes a fresh execution with a zeroed telemetry subdoc (min defaults to 1)', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution());
+
+      const created = await agentExecutionRepository.findById(exec.id);
+      expect(created?.confidenceTelemetry).toMatchObject({
+        evaluatedCount: 0,
+        emittedCount: 0,
+        minConfidence: 1,
+        confidenceSum: 0,
+      });
+    });
+
+    it('accumulates evaluated count, sum, and running min across calls', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution());
+
+      await agentExecutionRepository.recordIterationConfidence(exec.id, 0.7);
+      await agentExecutionRepository.recordIterationConfidence(exec.id, 0.1);
+      await agentExecutionRepository.recordIterationConfidence(exec.id, 0.7);
+
+      const updated = await agentExecutionRepository.findById(exec.id);
+      expect(updated?.confidenceTelemetry?.evaluatedCount).toBe(3);
+      expect(updated?.confidenceTelemetry?.confidenceSum).toBeCloseTo(1.5, 10);
+      expect(updated?.confidenceTelemetry?.minConfidence).toBeCloseTo(0.1, 10);
+      expect(updated?.confidenceTelemetry?.emittedCount).toBe(0);
+    });
+
+    it('increments emittedCount independently of evaluatedCount', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution());
+
+      await agentExecutionRepository.recordIterationConfidence(exec.id, 0.4);
+      await agentExecutionRepository.recordGateEmitted(exec.id);
+
+      const updated = await agentExecutionRepository.findById(exec.id);
+      expect(updated?.confidenceTelemetry?.evaluatedCount).toBe(1);
+      expect(updated?.confidenceTelemetry?.emittedCount).toBe(1);
+    });
+
+    it('derives avgConfidence and omits the summary when the gate never evaluated (via listStuck)', async () => {
+      const userId = new mongoose.Types.ObjectId().toString();
+      const evaluated = await agentExecutionRepository.create(
+        makeBaseExecution({ userId, status: 'paused', query: 'evaluated' })
+      );
+      await agentExecutionRepository.create(makeBaseExecution({ userId, status: 'paused', query: 'untouched' }));
+
+      await agentExecutionRepository.recordIterationConfidence(evaluated.id, 0.8);
+      await agentExecutionRepository.recordIterationConfidence(evaluated.id, 0.2);
+      await agentExecutionRepository.recordGateEmitted(evaluated.id);
+
+      const old = new Date(Date.now() - 60 * 60 * 1000);
+      await AgentExecutionModel.collection.updateMany({ userId, status: 'paused' }, { $set: { updatedAt: old } });
+
+      const items = await agentExecutionRepository.listStuck({
+        olderThan: new Date(Date.now() - 30 * 60 * 1000),
+        userId,
+        limit: 10,
+      });
+
+      const evaluatedItem = items.find(i => i.query === 'evaluated');
+      const untouchedItem = items.find(i => i.query === 'untouched');
+
+      expect(evaluatedItem?.confidenceTelemetry).toEqual({
+        evaluatedCount: 2,
+        emittedCount: 1,
+        minConfidence: expect.closeTo(0.2, 10),
+        avgConfidence: expect.closeTo(0.5, 10),
+      });
+      // evaluatedCount 0 -> no signal -> summary omitted (no misleading avg NaN).
+      expect(untouchedItem?.confidenceTelemetry).toBeUndefined();
+    });
+  });
+
   // Typed timeout signal replaces error.message substring matching.
   // These tests lock the contract end-to-end (write via `markFailed`, read via
   // `findById` and `getPollableStatus`) so a future projection or schema tweak

--- a/packages/database/src/models/billing/AgentExecutionModel.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.ts
@@ -53,6 +53,44 @@ export interface IPendingGate {
   requestedAt: Date;
 }
 
+// --- Confidence Telemetry ---
+
+/**
+ * Per-execution confidence-gate telemetry (issue #56 M1.1). Accumulated across
+ * every iteration the gate evaluates so we can measure the gate's real fire
+ * rate in production before investing in signal-quality work.
+ *
+ * Stored as raw accumulators rather than a pre-computed average: `avgConfidence`
+ * is derived as `confidenceSum / evaluatedCount` at read time, which is exact
+ * and drift-free. Incrementing a stored mean via `$inc` cannot be done
+ * correctly, so we never persist one.
+ *
+ * Counters are advanced with atomic `$inc`/`$min` (see `recordIterationConfidence`
+ * / `recordGateEmitted`) so they stay correct across continuation Lambdas, which
+ * restart with fresh memory and increment the same persisted document.
+ */
+export interface IConfidenceTelemetry {
+  /** Iterations for which the gate produced a confidence signal and evaluated it. */
+  evaluatedCount: number;
+  /** Times the gate actually fired and paused the run for human review. */
+  emittedCount: number;
+  /** Lowest per-iteration confidence observed across the run (1 until first eval). */
+  minConfidence: number;
+  /** Sum of per-iteration confidences; `avgConfidence = confidenceSum / evaluatedCount`. */
+  confidenceSum: number;
+}
+
+/**
+ * Read-facing confidence-telemetry summary exposed on list items. `avgConfidence`
+ * is derived from the stored `confidenceSum`; the raw sum never leaves the model.
+ */
+export type ConfidenceTelemetrySummary = {
+  evaluatedCount: number;
+  emittedCount: number;
+  minConfidence: number;
+  avgConfidence: number;
+};
+
 // --- Waiting On Subagent ---
 
 /**
@@ -236,6 +274,14 @@ export interface IAgentExecution {
    */
   pendingGate?: IPendingGate;
 
+  /**
+   * Confidence-gate telemetry (issue #56 M1.1). Accumulated every iteration the
+   * gate evaluates; backs the fire-rate metrics surfaced in the admin tab.
+   * Optional at the type level because it is a system-managed accumulator no
+   * caller sets at create time - the schema default guarantees it at runtime.
+   */
+  confidenceTelemetry?: IConfidenceTelemetry;
+
   // Billing
   iterationBilling: IIterationBilling[];
   totalCreditsUsed: number;
@@ -339,6 +385,19 @@ const PendingGateSchema = new mongoose.Schema(
     confidence: { type: Number, required: true },
     reason: { type: String, required: true },
     requestedAt: { type: Date, required: true },
+  },
+  { _id: false }
+);
+
+// `minConfidence` starts at 1 (the max possible) so the first `$min` update
+// with an observed confidence always wins. Do NOT default it to 0, or `$min`
+// would latch to 0 forever.
+const ConfidenceTelemetrySchema = new mongoose.Schema(
+  {
+    evaluatedCount: { type: Number, default: 0 },
+    emittedCount: { type: Number, default: 0 },
+    minConfidence: { type: Number, default: 1 },
+    confidenceSum: { type: Number, default: 0 },
   },
   { _id: false }
 );
@@ -500,6 +559,11 @@ const AgentExecutionSchema = new mongoose.Schema(
     // Confidence-gate state
     pendingGate: { type: PendingGateSchema, required: false },
 
+    // Confidence-gate telemetry (#56 M1.1). `default: () => ({})` instantiates
+    // the subdoc so its field defaults (evaluatedCount 0, minConfidence 1, ...)
+    // apply to every new execution.
+    confidenceTelemetry: { type: ConfidenceTelemetrySchema, default: () => ({}) },
+
     // Billing
     iterationBilling: { type: [IterationBillingSchema], default: [] },
     totalCreditsUsed: { type: Number, default: 0 },
@@ -603,6 +667,8 @@ export interface AgentExecutionListItem {
   abortedAt?: Date;
   totalIterations?: number;
   errorMessage?: string;
+  /** Confidence-gate telemetry (#56 M1.1); omitted when the gate never evaluated. */
+  confidenceTelemetry?: ConfidenceTelemetrySummary;
 }
 
 /**
@@ -641,6 +707,7 @@ const EXECUTION_LIST_PROJECTION = {
   abortedAt: 1,
   'result.totalIterations': 1,
   'error.message': 1,
+  confidenceTelemetry: 1,
 } as const;
 
 type ExecutionListLeanDoc = {
@@ -664,7 +731,23 @@ type ExecutionListLeanDoc = {
   abortedAt?: Date;
   result?: { totalIterations?: number };
   error?: { message: string };
+  confidenceTelemetry?: IConfidenceTelemetry;
 };
+
+/**
+ * Derive the read-facing telemetry summary. Returns `undefined` when the gate
+ * never evaluated (evaluatedCount 0), so the UI can render a clean "no signal"
+ * rather than a misleading `min 1.00 / avg NaN`.
+ */
+function toConfidenceSummary(telemetry: IConfidenceTelemetry | undefined): ConfidenceTelemetrySummary | undefined {
+  if (!telemetry || telemetry.evaluatedCount <= 0) return undefined;
+  return {
+    evaluatedCount: telemetry.evaluatedCount,
+    emittedCount: telemetry.emittedCount,
+    minConfidence: telemetry.minConfidence,
+    avgConfidence: telemetry.confidenceSum / telemetry.evaluatedCount,
+  };
+}
 
 function toListItem(doc: ExecutionListLeanDoc): AgentExecutionListItem {
   return {
@@ -688,6 +771,7 @@ function toListItem(doc: ExecutionListLeanDoc): AgentExecutionListItem {
     abortedAt: doc.abortedAt,
     totalIterations: doc.result?.totalIterations,
     errorMessage: doc.error?.message,
+    confidenceTelemetry: toConfidenceSummary(doc.confidenceTelemetry),
   };
 }
 
@@ -1086,6 +1170,35 @@ class AgentExecutionRepository extends BaseRepository<IAgentExecution> {
       { $unset: { pendingGate: '' } }
     );
     return result.modifiedCount > 0;
+  }
+
+  /**
+   * Record one gate-evaluated iteration's confidence (#56 M1.1). Atomic
+   * `$inc`/`$min` so the counters stay correct across continuation Lambdas,
+   * which restart with fresh memory and increment the same persisted doc.
+   * Called for every iteration the gate evaluates - including ones that
+   * complete in the same turn or clear the threshold - so `evaluatedCount` is
+   * the honest denominator for the gate's fire rate.
+   */
+  async recordIterationConfidence(id: string, confidence: number): Promise<void> {
+    await this.model.updateOne(
+      { _id: id },
+      {
+        $inc: {
+          'confidenceTelemetry.evaluatedCount': 1,
+          'confidenceTelemetry.confidenceSum': confidence,
+        },
+        $min: { 'confidenceTelemetry.minConfidence': confidence },
+      }
+    );
+  }
+
+  /**
+   * Increment the count of times the gate actually fired and paused the run
+   * (#56 M1.1). The numerator to `recordIterationConfidence`'s denominator.
+   */
+  async recordGateEmitted(id: string): Promise<void> {
+    await this.model.updateOne({ _id: id }, { $inc: { 'confidenceTelemetry.emittedCount': 1 } });
   }
 
   async addIterationBilling(id: string, billing: IIterationBilling): Promise<void> {


### PR DESCRIPTION
## Description

The confidence gate is wired end-to-end but structurally dormant: with current frontier LLMs the trigger condition almost never holds, and there is **zero observability** into how often it evaluates or fires. Before investing in signal-quality work (issue #56 M2+), we need a production baseline.

This PR is **M1.1** of #56: purely additive telemetry. It instruments the gate with per-execution counters and surfaces them in the admin tab. **No gate behavior changes** — the gate fires exactly as before; this only measures it.

Refs #56

## Changes

- **`AgentExecution` gains a `confidenceTelemetry` subdoc** — `evaluatedCount`, `emittedCount`, `minConfidence`, `confidenceSum`. Advanced with atomic `$inc`/`$min` (`recordIterationConfidence` / `recordGateEmitted`) so counters stay correct across continuation Lambdas, which restart with fresh memory and increment the same persisted document.
- **`avgConfidence` is derived** (`confidenceSum / evaluatedCount`) at read time — exact and drift-free. Incrementing a stored mean via `$inc` cannot be done correctly, so the raw sum is stored and the mean never persisted. The sum never leaves the model layer.
- **`agentExecutor`** records every gate-*evaluated* iteration (the honest denominator — including the "swallowed signal" case where a low-confidence iteration self-completes in the same turn) and each real pause (numerator, only after `setPendingGate` confirms it wasn't raced by a concurrent abort).
- **Admin "Stuck Agent Executions" tab** gets a "Confidence (avg/min)" column with an `evaluated / gated` tooltip and a warning chip when the gate actually fired. Shows `—` when the gate never evaluated (no misleading `avg NaN`).
- Unit tests for the accumulators, running min, independent emit counter, and the derived-summary-via-`listStuck` path (including the omit-when-never-evaluated case).

## Guide for Testers

This is a backend-instrumentation + minor admin-UI PR. The confidence gate itself is dormant by design (it rarely fires with modern LLMs — that's *why* this baseline exists), so testing focuses on **telemetry accumulation** and **admin display**, not on forcing a pause.

**Setup**
1. Deploy this branch to a preview/staging env with admin access.
2. Log in as an admin user.

**A. Telemetry accumulates on a normal agent run**
1. Open a chat session and switch to **Agent mode**.
2. Send a query that will use at least one tool, e.g. type `Search the web for the current time in Tokyo and tell me` in the message input and send.
3. Wait for the agent to complete (a normal answer appears; no pause is expected).
4. Expected: the run's `AgentExecution` document now has a `confidenceTelemetry` object with `evaluatedCount >= 1`, `minConfidence <= 1`, `confidenceSum > 0`, and (almost always) `emittedCount: 0`. `emittedCount: 0` is the **expected, correct baseline** — the gate legitimately does not fire on healthy runs.

**B. Admin column renders**
1. Navigate to **Sidebar → Admin → Agent Executions** (the "Stuck Agent Executions" tab).
2. Set **Older than (minutes)** to `1` so recent executions appear (or filter by your **User ID**).
3. Expected: the table shows a new **"Confidence (avg/min)"** column.
   - Rows for executions where the gate evaluated show `<avg> / <min>` (e.g. `0.70 / 0.10`); hover shows a tooltip like `3 evaluated · 0 gated · avg 0.70 · min 0.10`.
   - Rows for executions the gate never evaluated show `—`.
   - If any run actually tripped the gate, a warning chip `N gated` appears next to the numbers.

**Regression Checks**
1. Run a normal agent-mode query end to end — it completes exactly as before, with no new pauses, warnings, or errors.
2. The existing Stuck Executions columns (Status, Age, User, Query, Model, Credits) and the "Mark abandoned" cleanup flow all still work.
3. Continuation-heavy runs (long agent tasks that span multiple Lambda invocations) still complete; telemetry counters reflect the whole run, not just the last segment.

**What NOT to test**
- Do **not** try to force the confidence gate to pause — making it fire reliably is out of scope for M1.1 (that's M2/M3 of #56). `emittedCount: 0` on normal runs is the intended baseline.
- No user-facing chat behavior changes; the gate decision logic and threshold are untouched.

## Additional Information

**Performance:** purely additive observability. The only added runtime cost is one small `_id`-indexed `updateOne` per gate-evaluated iteration — sub-millisecond, dwarfed by the multi-second LLM call that dominates each iteration. No feature behavior changes.

**Telemetry data classification:** the added fields are non-PII operational integers/floats (iteration counts and confidence scores) — no user content or identifiers. The `docs-site/docs/security/telemetry-data-classification.md` doc referenced in the checklist is not present in this repository, so there is nothing to update; the classification concern (user-data sensitivity) does not apply to these operational counters.

## Developer Notes

- **Data model:** `IConfidenceTelemetry` (stored accumulators) vs `ConfidenceTelemetrySummary` (read-facing, with derived `avgConfidence`) is a reusable pattern — store raw accumulators, derive statistics at the read boundary so `$inc`-based updates stay correct.
- **Repo methods:** `recordIterationConfidence` / `recordGateEmitted` are continuation-safe by construction (atomic `$inc`/`$min`), the model for any future per-iteration counter that must survive Lambda handoffs.
- **Unblocks M1.2–M5 of #56:** with a real fire-rate signal in hand, the follow-up decision (improve the signal vs. remove dormant machinery) becomes data-driven rather than a guess.
