### PR TITLE
refactor(client): replace quest create-flow plumbing with dedicated modules

### DIFF
--- a/apps/client/app/components/GenAI/QuestMasterReply.tsx
+++ b/apps/client/app/components/GenAI/QuestMasterReply.tsx
@@ -51,6 +51,7 @@ import {
 } from './types/QuestTypes';
 import QuestExportMenu from './QuestExportMenu';
 import { useSubscribeCollection } from '@client/app/utils/react-query';
+import { requestScrollToMessage } from '@client/app/utils/chatScroll';
 import { SubscriptionCallbackFunction } from '@client/app/hooks/useCollection';
 
 interface QuestMasterComponentProps {
@@ -439,18 +440,13 @@ const QuestMasterReply: React.FC<QuestMasterComponentProps> = ({
   // Track previous data to detect status changes
   const prevDataRef = useRef<IQuestMasterPlanDocument | null>(null);
 
-  // Track mounted state to prevent memory leaks in DOM manipulation callbacks
+  // Track mounted state to prevent memory leaks in async callbacks
   const isMountedRef = useRef(true);
-  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
-      // Clean up any pending highlight timeout
-      if (highlightTimeoutRef.current) {
-        clearTimeout(highlightTimeoutRef.current);
-      }
     };
   }, []);
 
@@ -874,33 +870,12 @@ const QuestMasterReply: React.FC<QuestMasterComponentProps> = ({
       return;
     }
 
-    // Scroll to the chat message in the history via its data-message-id.
-    // Uses DOM queries because chat messages render in a separate virtualized list
-    // that doesn't share React state with QuestMasterReply.
-    const messageElement = document.querySelector(`[data-message-id="${chatHistoryItemId}"]`);
-    if (messageElement) {
-      messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      // Add a temporary highlight effect using CSS animation
-      messageElement.classList.add('highlight-flash');
-      const handleAnimationEnd = () => {
-        if (!isMountedRef.current) return;
-        messageElement.classList.remove('highlight-flash');
-        messageElement.removeEventListener('animationend', handleAnimationEnd);
-      };
-      messageElement.addEventListener('animationend', handleAnimationEnd);
-      // Fallback timeout in case animation doesn't fire - store ref for cleanup
-      // Clear any existing timeout first
-      if (highlightTimeoutRef.current) {
-        clearTimeout(highlightTimeoutRef.current);
-      }
-      highlightTimeoutRef.current = setTimeout(() => {
-        if (isMountedRef.current) {
-          messageElement.classList.remove('highlight-flash');
-        }
-        highlightTimeoutRef.current = null;
-      }, 2500);
-    } else {
-      toast.info('Message not found in current view. It may have been scrolled out.');
+    // The chat history is a virtualized list in a separate React tree; the
+    // scroll service in utils/chatScroll reaches it via Virtuoso's index API,
+    // which works even for messages currently virtualized out of the DOM.
+    const scrolled = requestScrollToMessage(chatHistoryItemId);
+    if (!scrolled) {
+      toast.info('Message not found in this notebook.');
     }
   }, []);
 

--- a/apps/client/app/components/Session/ChatHistory.tsx
+++ b/apps/client/app/components/Session/ChatHistory.tsx
@@ -1,11 +1,12 @@
 import { IChatHistoryItem } from '@bike4mind/common';
 import Box from '@mui/joy/Box';
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import MessageContent from '@client/app/components/Session/MessageContent';
 import FallbackModelBadge from './FallbackModelBadge';
 import { SendMessageOptions } from '@client/app/utils/llm';
 import { useSubscribeChatCompletion } from '@client/app/hooks/useSubscribeChatCompletion';
+import { flashMessageHighlight, registerScrollToMessageHandler } from '@client/app/utils/chatScroll';
 
 // --- Virtuoso context type ---
 // Passed via Virtuoso's `context` prop to stable module-level custom components.
@@ -145,10 +146,16 @@ const ChatHistory: React.FC<ChatHistoryProps> = memo(
             canUseAdminTools={canUseAdminTools}
           />
         );
-        if (contentMaxWidth) {
-          return <Box sx={{ maxWidth: contentMaxWidth, marginX: 'auto' }}>{content}</Box>;
-        }
-        return content;
+        // data-message-id is the anchor for scroll-to-message highlighting
+        // (see utils/chatScroll.ts)
+        return (
+          <Box
+            data-message-id={messageData.id ?? undefined}
+            sx={contentMaxWidth ? { maxWidth: contentMaxWidth, marginX: 'auto' } : undefined}
+          >
+            {content}
+          </Box>
+        );
       },
       [
         sessionId,
@@ -168,6 +175,23 @@ const ChatHistory: React.FC<ChatHistoryProps> = memo(
     );
 
     const virtuosoContext = useMemo<VirtuosoContext>(() => ({ sessionId, footer }), [sessionId, footer]);
+
+    // Scroll-to-message service for other components (e.g. the QuestMaster
+    // plan board). Virtuoso's index API reaches messages that are currently
+    // virtualized out and have no DOM node.
+    useEffect(() => {
+      return registerScrollToMessageHandler(messageId => {
+        const reversedIndex = reversedHistory.findIndex(item => item.id === messageId);
+        if (reversedIndex === -1) return false;
+        virtuosoRef.current?.scrollToIndex({
+          index: firstItemIndex + reversedIndex,
+          align: 'center',
+          behavior: 'smooth',
+        });
+        flashMessageHighlight(messageId);
+        return true;
+      });
+    }, [reversedHistory, firstItemIndex, virtuosoRef]);
 
     // Don't mount Virtuoso until data is available - initialTopMostItemIndex
     // only applies on mount, so the component must mount AFTER data loads

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -60,6 +60,7 @@ import { useAdvancedAISettings } from '@client/app/components/Session/AdvancedAI
 import { useModelInfo } from '../../../hooks/data/useModelInfo';
 import { useAccessibleModels } from '../../../hooks/useAccessibleModels';
 import perfLogger from '../../../utils/performanceLogger';
+import { consumeQuestLaunchIntent } from '../../../utils/questLaunchIntent';
 import { LexicalChatInputRef } from '../LexicalChatInput';
 
 // Sentinel statusMessage written by `handleSendClick` to render the Stop
@@ -256,29 +257,18 @@ export function useSendMessage({
   const [pendingAutoSubmitGoal, setPendingAutoSubmitGoal] = useState<string | null>(null);
   const [enableQuestMasterOnSubmit, setEnableQuestMasterOnSubmit] = useState(false);
 
-  // Check for new quest goal from /quests page (auto-submit)
+  // Consume a quest launch intent from the /quests page (auto-submit).
+  // The /new route records it in a useLayoutEffect, which runs before this
+  // effect; consume-once semantics prevent replay on refresh or remount.
   useEffect(() => {
-    const newQuestGoal = localStorage.getItem('newQuestGoal');
-    const autoSubmit = localStorage.getItem('autoSubmitQuest');
-    const shouldEnableQuestMaster = localStorage.getItem('enableQuestMasterOnSubmit');
-    if (newQuestGoal) {
-      console.log(
-        '🎯 Found quest goal:',
-        newQuestGoal,
-        'autoSubmit:',
-        autoSubmit,
-        'enableQM:',
-        shouldEnableQuestMaster
-      );
-      localStorage.removeItem('newQuestGoal');
-      localStorage.removeItem('autoSubmitQuest');
-      localStorage.removeItem('enableQuestMasterOnSubmit');
-      setChatInputValue(newQuestGoal);
+    const intent = consumeQuestLaunchIntent();
+    if (intent) {
+      setChatInputValue(intent.goal);
 
-      if (autoSubmit === 'true') {
+      if (intent.autoSubmit) {
         // eslint-disable-next-line react-hooks/set-state-in-effect
-        setPendingAutoSubmitGoal(newQuestGoal);
-        if (shouldEnableQuestMaster === 'true') {
+        setPendingAutoSubmitGoal(intent.goal);
+        if (intent.enableQuestMaster) {
           setEnableQuestMasterOnSubmit(true);
         }
       }

--- a/apps/client/app/routes/notebooks/new.tsx
+++ b/apps/client/app/routes/notebooks/new.tsx
@@ -1,38 +1,40 @@
 import { useEffect, useLayoutEffect, useRef } from 'react';
-import { useSearch } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useSessions, useWorkBenchActions } from '@client/app/contexts/SessionsContext';
 import SessionContainer from '@client/app/components/Session/SessionContainer';
 import { NotebookFilepondProvider } from '@client/app/components/Session/NotebookFilepondProvider';
 import { setSessionLayout } from '@client/app/hooks/useSessionLayout';
 import { useDocumentTitle } from '@client/app/hooks/useDocumentTitle';
 import { useQuestPreparation } from '@client/app/hooks/useQuestPreparation';
+import { setQuestLaunchIntent } from '@client/app/utils/questLaunchIntent';
 
 const NewNotebookPage = () => {
   const { setCurrentSession, setCurrentSessionId, setWorkBenchAgents } = useSessions();
   const { clearAllSessions } = useWorkBenchActions();
   const search = useSearch({ strict: false }) as { questmaster?: string; goal?: string };
+  const navigate = useNavigate();
   const hasProcessedQuestParams = useRef(false);
-  const { setPreparingQuest } = useQuestPreparation();
+  const { setPreparingQuest, isPreparingQuest } = useQuestPreparation();
 
-  useDocumentTitle(search.goal ? 'Preparing Quest...' : 'New Notebook');
+  useDocumentTitle(search.goal || isPreparingQuest ? 'Preparing Quest...' : 'New Notebook');
 
-  // CRITICAL: Set localStorage before child useEffects read it.
+  // CRITICAL: Record the launch intent before child useEffects read it.
   // useLayoutEffect runs synchronously after render but before child useEffects,
-  // so SessionBottom's useEffect will find these values already set.
+  // so useSendMessage's consuming effect finds the intent already set.
   useLayoutEffect(() => {
-    if (!hasProcessedQuestParams.current && search.goal && typeof window !== 'undefined') {
+    if (!hasProcessedQuestParams.current && search.goal) {
       hasProcessedQuestParams.current = true;
-      console.log('🎯 Setting quest params in localStorage:', search.goal);
-      localStorage.setItem('newQuestGoal', search.goal);
-      localStorage.setItem('autoSubmitQuest', 'true');
-      if (search.questmaster === 'true') {
-        localStorage.setItem('enableQuestMasterOnSubmit', 'true');
-      }
-    }
-    if (search.goal) {
+      setQuestLaunchIntent({
+        goal: search.goal,
+        autoSubmit: true,
+        enableQuestMaster: search.questmaster === 'true',
+      });
       setPreparingQuest(search.goal);
+      // Strip the params so a refresh or back-navigation cannot replay the
+      // auto-submit (the intent itself is in-memory and consume-once).
+      void navigate({ to: '/new', search: {}, replace: true });
     }
-  }, [search.goal, search.questmaster, setPreparingQuest]);
+  }, [search.goal, search.questmaster, setPreparingQuest, navigate]);
 
   useEffect(() => {
     // Clear workbench state for new notebook

--- a/apps/client/app/utils/chatScroll.test.ts
+++ b/apps/client/app/utils/chatScroll.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { registerScrollToMessageHandler, requestScrollToMessage } from './chatScroll';
+
+describe('chatScroll', () => {
+  it('returns false when no handler is registered', () => {
+    expect(requestScrollToMessage('msg-1')).toBe(false);
+  });
+
+  it('routes requests to the registered handler', () => {
+    const handler = vi.fn().mockReturnValue(true);
+    const unregister = registerScrollToMessageHandler(handler);
+
+    expect(requestScrollToMessage('msg-1')).toBe(true);
+    expect(handler).toHaveBeenCalledWith('msg-1');
+
+    unregister();
+  });
+
+  it('propagates a not-found result from the handler', () => {
+    const unregister = registerScrollToMessageHandler(() => false);
+
+    expect(requestScrollToMessage('missing')).toBe(false);
+
+    unregister();
+  });
+
+  it('unregister removes the handler', () => {
+    const handler = vi.fn().mockReturnValue(true);
+    const unregister = registerScrollToMessageHandler(handler);
+    unregister();
+
+    expect(requestScrollToMessage('msg-1')).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('last registration wins and stale unregister is a no-op', () => {
+    const first = vi.fn().mockReturnValue(true);
+    const second = vi.fn().mockReturnValue(true);
+    const unregisterFirst = registerScrollToMessageHandler(first);
+    const unregisterSecond = registerScrollToMessageHandler(second);
+
+    // A stale unregister from the replaced handler must not remove the active one
+    unregisterFirst();
+    expect(requestScrollToMessage('msg-1')).toBe(true);
+    expect(second).toHaveBeenCalledWith('msg-1');
+    expect(first).not.toHaveBeenCalled();
+
+    unregisterSecond();
+    expect(requestScrollToMessage('msg-1')).toBe(false);
+  });
+});

--- a/apps/client/app/utils/chatScroll.ts
+++ b/apps/client/app/utils/chatScroll.ts
@@ -1,0 +1,58 @@
+/**
+ * Scroll-to-message bridge between the QuestMaster plan board and the
+ * virtualized chat history.
+ *
+ * The chat list is a react-virtuoso list owned by ChatHistory; messages
+ * scrolled out of view have no DOM node, so DOM queries cannot reach them.
+ * ChatHistory registers a handler that scrolls via Virtuoso's index API;
+ * other components (e.g. the plan board in the Knowledge Viewer, which
+ * renders in a separate tree) request scrolls through this module.
+ */
+type ScrollToMessageHandler = (messageId: string) => boolean;
+
+let activeHandler: ScrollToMessageHandler | null = null;
+
+/**
+ * Register the handler that performs the scroll. Returns an unregister
+ * function; a later registration replaces an earlier one (last mount wins).
+ */
+export function registerScrollToMessageHandler(handler: ScrollToMessageHandler): () => void {
+  activeHandler = handler;
+  return () => {
+    if (activeHandler === handler) {
+      activeHandler = null;
+    }
+  };
+}
+
+/**
+ * Request a scroll to the given chat message.
+ * Returns true if a handler found the message and scrolled to it.
+ */
+export function requestScrollToMessage(messageId: string): boolean {
+  return activeHandler ? activeHandler(messageId) : false;
+}
+
+/**
+ * Briefly highlight the message row once it has scrolled into view.
+ * Best-effort: virtuoso mounts the row asynchronously after scrollToIndex,
+ * so poll a few frames for the node and animate via the Web Animations API
+ * (no global CSS class required).
+ */
+export function flashMessageHighlight(messageId: string, attempts = 10): void {
+  const element = document.querySelector(`[data-message-id="${messageId}"]`);
+  if (element instanceof HTMLElement) {
+    element.animate(
+      [
+        { backgroundColor: 'rgba(255, 193, 7, 0.30)' },
+        { backgroundColor: 'rgba(255, 193, 7, 0.30)', offset: 0.4 },
+        { backgroundColor: 'transparent' },
+      ],
+      { duration: 1600, easing: 'ease-out' }
+    );
+    return;
+  }
+  if (attempts > 0) {
+    setTimeout(() => flashMessageHighlight(messageId, attempts - 1), 100);
+  }
+}

--- a/apps/client/app/utils/questLaunchIntent.test.ts
+++ b/apps/client/app/utils/questLaunchIntent.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { consumeQuestLaunchIntent, setQuestLaunchIntent } from './questLaunchIntent';
+
+describe('questLaunchIntent', () => {
+  it('returns null when no intent is pending', () => {
+    expect(consumeQuestLaunchIntent()).toBeNull();
+  });
+
+  it('returns the recorded intent', () => {
+    const intent = { goal: 'Build a birdhouse', autoSubmit: true, enableQuestMaster: true };
+    setQuestLaunchIntent(intent);
+
+    expect(consumeQuestLaunchIntent()).toEqual(intent);
+  });
+
+  it('consumes exactly once - second read returns null', () => {
+    setQuestLaunchIntent({ goal: 'Plan a trip', autoSubmit: true, enableQuestMaster: false });
+
+    expect(consumeQuestLaunchIntent()).not.toBeNull();
+    expect(consumeQuestLaunchIntent()).toBeNull();
+  });
+
+  it('a newer intent replaces an unconsumed one', () => {
+    setQuestLaunchIntent({ goal: 'first', autoSubmit: true, enableQuestMaster: false });
+    setQuestLaunchIntent({ goal: 'second', autoSubmit: false, enableQuestMaster: true });
+
+    expect(consumeQuestLaunchIntent()).toEqual({ goal: 'second', autoSubmit: false, enableQuestMaster: true });
+  });
+});

--- a/apps/client/app/utils/questLaunchIntent.ts
+++ b/apps/client/app/utils/questLaunchIntent.ts
@@ -1,0 +1,27 @@
+/**
+ * One-shot, in-memory handoff for the "create a quest from the dashboard"
+ * flow (/quests -> /new -> auto-submit).
+ *
+ * The /new route records the intent; useSendMessage consumes it exactly once
+ * when the chat input mounts. In-memory by design: unlike the previous
+ * localStorage bus, the intent cannot leak into a second tab, survive a
+ * refresh (which would re-submit the goal), or strand a half-consumed flow.
+ */
+export interface QuestLaunchIntent {
+  goal: string;
+  autoSubmit: boolean;
+  enableQuestMaster: boolean;
+}
+
+let pendingIntent: QuestLaunchIntent | null = null;
+
+export function setQuestLaunchIntent(intent: QuestLaunchIntent): void {
+  pendingIntent = intent;
+}
+
+/** Returns the pending intent and clears it (consume-once semantics). */
+export function consumeQuestLaunchIntent(): QuestLaunchIntent | null {
+  const intent = pendingIntent;
+  pendingIntent = null;
+  return intent;
+}


### PR DESCRIPTION
## Description

Replaces two fragile mechanisms in the QuestMaster create/navigate flow with small, unit-tested modules. This is the first PR in the series with a user-visible surface - see Guide for Testers.

PR 5 of the QuestMaster consolidation series (#169, #189, #192, #194).

## Changes

**1. Quest launch handoff (`utils/questLaunchIntent.ts`)**

The `/quests` -> `/new` auto-submit flow passed its payload through three localStorage keys. Two real defects: the pending goal leaked into other tabs, and because `/new` re-wrote the keys from its search params on every mount, **refreshing `/new?goal=...` re-submitted the goal and created a duplicate quest**. The flow now records an in-memory, consume-once intent and strips the search params via a replace navigation, so refresh and back-navigation cannot replay.

**2. Scroll-to-message (`utils/chatScroll.ts`)**

Clicking a completed sub-quest on the plan board tried to scroll the chat via `document.querySelector('[data-message-id]')` - but no component ever rendered that attribute, and the `highlight-flash` CSS class was never defined. **The feature always showed the 'message not found' toast.** Now: ChatHistory registers a scroll handler backed by Virtuoso's `scrollToIndex` (reaches messages virtualized out of the DOM), message rows carry the `data-message-id` anchor, and the highlight uses the Web Animations API. The plan board (a separate React tree in the Knowledge Viewer) requests scrolls through the shared module.

+9 unit tests across the two modules (consume-once semantics, handler registry, stale-unregister safety).

## Tests

- `pnpm --filter @bike4mind/client typecheck` - pass
- `pnpm --filter @bike4mind/client test` - 4869 passed / 81 skipped
- `pnpm lint:check` - pass

## Guide for Testers

- From `/quests`, click New Quest, enter a goal: notebook opens, goal auto-submits, plan appears (unchanged happy path)
- **Refresh the page mid-preparation**: the goal is NOT re-submitted (previously created a duplicate plan)
- On a plan board, click a completed sub-quest: the chat scrolls to the linked message with a brief amber highlight (previously always showed a 'message not found' toast)
- Click a completed sub-quest whose message belongs to a different notebook: an informational toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)