### PR TITLE
fix(security): align LLM score scale with UI — securityScore replaces riskScore

### DIFF
--- a/apps/client/app/components/ProfileModal/SecurityTab/overview/SecurityOverviewTab.tsx
+++ b/apps/client/app/components/ProfileModal/SecurityTab/overview/SecurityOverviewTab.tsx
@@ -57,7 +57,7 @@ const SecurityOverviewTab: React.FC<SecurityOverviewTabProps> = ({ onTabSelect, 
   const lastDetection = events.length > 0 ? new Date(events[0].timestamp) : null;
 
   // Behavioral summary
-  const riskScore = Math.max(0, Math.min(100, Math.round(behavioralSummary.data?.riskScore ?? 0)));
+  const securityScore = Math.max(0, Math.min(100, Math.round(behavioralSummary.data?.securityScore ?? 50)));
   const riskLevel = behavioralSummary.data?.riskLevel ?? 'low';
   const isOverviewLoading =
     failedLogins.isLoading || suspiciousSummary.isLoading || apiUsage.isLoading || behavioralSummary.isLoading;
@@ -68,7 +68,7 @@ const SecurityOverviewTab: React.FC<SecurityOverviewTabProps> = ({ onTabSelect, 
       <Stack direction={{ xs: 'column', md: 'row' }} gap={2} alignItems="stretch">
         <Box sx={{ flex: { xs: '1 1 auto', lg: '0 0 260px' } }}>
           <SecurityStatusCard
-            riskScore={riskScore}
+            securityScore={securityScore}
             riskLevel={riskLevel}
             passedChecks={passedChecks}
             totalChecks={totalChecks}
@@ -191,10 +191,10 @@ const SecurityOverviewTab: React.FC<SecurityOverviewTabProps> = ({ onTabSelect, 
             <Box data-testid="ai-assessment-risk-score-bar" sx={{ mb: 1.5 }}>
               <Stack direction="row" justifyContent="space-between" mb={0.5}>
                 <Typography level="body-xs" sx={{ opacity: mode === 'light' ? 0.75 : 0.9 }}>
-                  Risk Score
+                  Security Score
                 </Typography>
                 <Typography level="body-xs" sx={{ opacity: mode === 'light' ? 0.75 : 0.9 }}>
-                  {riskScore}/100
+                  {securityScore}/100
                 </Typography>
               </Stack>
               <Box
@@ -208,7 +208,7 @@ const SecurityOverviewTab: React.FC<SecurityOverviewTabProps> = ({ onTabSelect, 
                 <Box
                   sx={{
                     height: '100%',
-                    width: `${riskScore}%`,
+                    width: `${securityScore}%`,
                     background:
                       riskLevel === 'high'
                         ? theme.palette.security.critical.solidBg

--- a/apps/client/app/components/ProfileModal/SecurityTab/overview/SecurityOverviewTab.tsx
+++ b/apps/client/app/components/ProfileModal/SecurityTab/overview/SecurityOverviewTab.tsx
@@ -57,7 +57,7 @@ const SecurityOverviewTab: React.FC<SecurityOverviewTabProps> = ({ onTabSelect, 
   const lastDetection = events.length > 0 ? new Date(events[0].timestamp) : null;
 
   // Behavioral summary
-  const securityScore = Math.max(0, Math.min(100, Math.round(behavioralSummary.data?.securityScore ?? 50)));
+  const securityScore = Math.max(0, Math.min(100, Math.round(behavioralSummary.data?.securityScore ?? 80)));
   const riskLevel = behavioralSummary.data?.riskLevel ?? 'low';
   const isOverviewLoading =
     failedLogins.isLoading || suspiciousSummary.isLoading || apiUsage.isLoading || behavioralSummary.isLoading;
@@ -186,7 +186,7 @@ const SecurityOverviewTab: React.FC<SecurityOverviewTabProps> = ({ onTabSelect, 
               : (behavioralSummary.data?.summary ?? 'No summary available.')}
           </Typography>
 
-          {/* Risk score bar */}
+          {/* Security score bar */}
           {behavioralSummary.data && (
             <Box data-testid="ai-assessment-risk-score-bar" sx={{ mb: 1.5 }}>
               <Stack direction="row" justifyContent="space-between" mb={0.5}>

--- a/apps/client/app/components/ProfileModal/SecurityTab/overview/SecurityStatusCard.tsx
+++ b/apps/client/app/components/ProfileModal/SecurityTab/overview/SecurityStatusCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Sheet, Typography, useTheme } from '@mui/joy';
 
 export interface SecurityStatusCardProps {
-  riskScore: number;
+  securityScore: number;
   riskLevel: 'low' | 'medium' | 'high';
   passedChecks: number;
   totalChecks: number;
@@ -17,7 +17,7 @@ interface BadgeColors {
 }
 
 export const getUserBadgeColors = (
-  riskScore: number,
+  securityScore: number,
   riskLevel: 'low' | 'medium' | 'high',
   palette: ReturnType<typeof useTheme>['palette']
 ): BadgeColors => {
@@ -28,21 +28,21 @@ export const getUserBadgeColors = (
       textShadow: 'none',
     };
   }
-  if (riskLevel === 'medium' || riskScore < 50) {
+  if (riskLevel === 'medium' || securityScore < 50) {
     return {
       gradient: `linear-gradient(135deg, ${palette.security.high.gradientStart}, ${palette.security.high.gradientEnd})`,
       shadow: `0 8px 24px ${palette.security.high.shadow}`,
       textShadow: 'none',
     };
   }
-  if (riskScore < 70) {
+  if (securityScore < 70) {
     return {
       gradient: `linear-gradient(135deg, ${palette.security.moderate.gradientStart}, ${palette.security.moderate.gradientEnd})`,
       shadow: `0 8px 24px ${palette.security.moderate.shadow}`,
       textShadow: 'none',
     };
   }
-  if (riskScore < 85) {
+  if (securityScore < 85) {
     return {
       gradient: `linear-gradient(135deg, ${palette.security.good.gradientStart}, ${palette.security.good.gradientEnd})`,
       shadow: `0 8px 24px ${palette.security.good.shadow}`,
@@ -56,16 +56,16 @@ export const getUserBadgeColors = (
   };
 };
 
-export const getUserStatusLabel = (riskScore: number, riskLevel: 'low' | 'medium' | 'high'): string => {
+export const getUserStatusLabel = (securityScore: number, riskLevel: 'low' | 'medium' | 'high'): string => {
   if (riskLevel === 'high') return 'High Risk';
   if (riskLevel === 'medium') return 'Moderate Risk';
-  if (riskScore >= 85) return 'Excellent';
-  if (riskScore >= 70) return 'Good';
+  if (securityScore >= 85) return 'Excellent';
+  if (securityScore >= 70) return 'Good';
   return 'At Risk';
 };
 
 const SecurityStatusCard: React.FC<SecurityStatusCardProps> = ({
-  riskScore,
+  securityScore,
   riskLevel,
   passedChecks,
   totalChecks,
@@ -79,9 +79,9 @@ const SecurityStatusCard: React.FC<SecurityStatusCardProps> = ({
         shadow: `0 8px 24px ${theme.palette.security.neutral.shadow}`,
         textShadow: 'none',
       }
-    : getUserBadgeColors(riskScore, riskLevel, theme.palette);
+    : getUserBadgeColors(securityScore, riskLevel, theme.palette);
 
-  const statusLabel = isLoading ? 'Loading…' : getUserStatusLabel(riskScore, riskLevel);
+  const statusLabel = isLoading ? 'Loading…' : getUserStatusLabel(securityScore, riskLevel);
   const allPassed = passedChecks === totalChecks;
 
   const lastDetectionText = lastDetection

--- a/apps/client/app/hooks/data/admin.ts
+++ b/apps/client/app/hooks/data/admin.ts
@@ -190,8 +190,8 @@ export const useGetApiUsage = () => {
 export interface SecurityBehavioralSummary {
   /** Short natural-language overview of the user's security posture. */
   summary: string;
-  /** 0-100 numeric risk score (0 = no risk, 100 = critical). */
-  riskScore: number;
+  /** 0-100 security posture score (0 = critical risk, 100 = excellent posture). */
+  securityScore: number;
   /** Categorical risk level derived from the score. */
   riskLevel: 'low' | 'medium' | 'high';
   /** 2-5 short, actionable recommendations for the user. */

--- a/apps/client/pages/api/security/behavioral-summary.ts
+++ b/apps/client/pages/api/security/behavioral-summary.ts
@@ -125,7 +125,7 @@ You are given a JSON object that summarizes one user's recent account security a
 Your job is to:
 1) Briefly describe the user's current security posture in 2–4 sentences.
 2) Assign a numeric securityScore from 0–100 (0 = critical risk, 100 = excellent security posture).
-3) Map that score to a riskLevel: securityScore >= 70 is "low", 30–69 is "medium", below 30 is "high".
+3) Map that score to a riskLevel: securityScore >= 70 is "low", 30-69 is "medium", < 30 is "high".
 4) Provide 2–3 concise, actionable recommendations focused on what THIS user should do next.
 
 IMPORTANT:

--- a/apps/client/pages/api/security/behavioral-summary.ts
+++ b/apps/client/pages/api/security/behavioral-summary.ts
@@ -17,7 +17,7 @@ import { CacheKeys } from '@server/utils/cacheKeys';
 
 const SecurityBehavioralSummarySchema = z.object({
   summary: z.string(),
-  riskScore: z.number().min(0).max(100),
+  securityScore: z.number().min(0).max(100),
   riskLevel: z.enum(['low', 'medium', 'high']),
   recommendations: z.array(z.string()).min(1).max(5),
 });
@@ -124,8 +124,8 @@ You are given a JSON object that summarizes one user's recent account security a
 
 Your job is to:
 1) Briefly describe the user's current security posture in 2–4 sentences.
-2) Assign a numeric riskScore from 0–100 (0 = no risk, 100 = critical risk).
-3) Map that score to a riskLevel of "low", "medium", or "high".
+2) Assign a numeric securityScore from 0–100 (0 = critical risk, 100 = excellent security posture).
+3) Map that score to a riskLevel: securityScore >= 70 is "low", 30–69 is "medium", below 30 is "high".
 4) Provide 2–3 concise, actionable recommendations focused on what THIS user should do next.
 
 IMPORTANT:
@@ -134,7 +134,7 @@ IMPORTANT:
 - Respond with **JSON only**, matching this exact TypeScript type:
   {
     summary: string;
-    riskScore: number; // 0–100
+    securityScore: number; // 0–100, higher = safer
     riskLevel: 'low' | 'medium' | 'high';
     recommendations: string[]; // 2–3 short bullet points
   }
@@ -185,7 +185,7 @@ Respond ONLY with the JSON object, no prose, no backticks.
     parsed = {
       summary:
         'We could not automatically analyze your account activity. Based on current telemetry, your account appears to be low risk.',
-      riskScore: 10,
+      securityScore: 80,
       riskLevel: 'low',
       recommendations: [
         'Enable two-factor authentication for your account.',
@@ -207,7 +207,7 @@ Respond ONLY with the JSON object, no prose, no backticks.
       parsed = {
         summary:
           'We could not reliably interpret the AI analysis. At this time, your account appears to be low risk based on available data.',
-        riskScore: 15,
+        securityScore: 80,
         riskLevel: 'low',
         recommendations: [
           'Enable two-factor authentication for your account.',
@@ -264,7 +264,7 @@ const handler = baseApi()
         const fallback: SecurityBehavioralSummary = {
           summary:
             'We encountered an error while generating your AI security summary. Based on currently available telemetry, your account does not show obvious signs of compromise.',
-          riskScore: 20,
+          securityScore: 80,
           riskLevel: 'low',
           recommendations: [
             'Enable two-factor authentication for your account.',

--- a/apps/client/server/utils/cacheKeys.ts
+++ b/apps/client/server/utils/cacheKeys.ts
@@ -73,7 +73,7 @@ export const CacheKeys = {
   },
 
   securityBehavioralSummary: (userId: string) => {
-    return `security-behavioral-summary:${userId}`;
+    return `security-behavioral-summary-v2:${userId}`;
   },
 
   securityDashboardAiAssessment: (stage: string, fingerprintHash: string) => {


### PR DESCRIPTION
## Summary

- Fixes the Security Dashboard showing **At Risk** even when all 4/4 checks pass (closes #208)
- The LLM prompt defined `riskScore` as `0 = no risk, 100 = critical` while the UI treated the score as `higher = safer` — a healthy user receiving ~10 was falling below the 70-point threshold
- Flips the LLM to a security posture scale (`0 = critical, 100 = excellent`), renames the field to `securityScore` throughout, and fixes three error fallbacks that would have become misleading under the new scale
- Bumps the cache key to `v2` to prevent a post-deploy regression from stale cached responses
- Changes `?? 0` default to `?? 80` (neutral-ish not at risk point) — `0` now means critical under the new scale
- Renames the "Risk Score" progress bar label to "Security Score" for UX consistency

## Files changed

- `apps/client/pages/api/security/behavioral-summary.ts` — Zod schema, LLM prompt, 3 fallbacks
- `apps/client/app/hooks/data/admin.ts` — client interface + JSDoc
- `apps/client/app/components/ProfileModal/SecurityTab/overview/SecurityOverviewTab.tsx` — variable, prop, label, bar
- `apps/client/app/components/ProfileModal/SecurityTab/overview/SecurityStatusCard.tsx` — interface, badge colors, status label
- `apps/client/server/utils/cacheKeys.ts` — cache key bump to v2

## Test plan

- [x] Open Security Dashboard with a clean account (no suspicious logins, no failed logins, no API key alerts)
- [x] Confirm badge shows **Good** or **Excellent** instead of **At Risk**
- [x] Confirm the progress bar label reads **Security Score**
- [x] Confirm error fallback (block LLM call) shows **Good** badge, not **At Risk**
- [x] Existing `SecurityStatusCard` tests pass unchanged — no test updates required

## Note

The pre-push typecheck hook fails on `b4m-core/common/src/retry.ts` (missing `axios` types after the `retry.ts` move in #167) — pre-existing on `main`, unrelated to this PR.