### PR TITLE
fix(client): copy literal config export into generated premium webhook routes

### DIFF
--- a/apps/client/scripts/generate-premium-glue.mjs
+++ b/apps/client/scripts/generate-premium-glue.mjs
@@ -213,6 +213,52 @@ export const premiumNotebookSidenav: PremiumNotebookSidenav = dynamic(
 
 // --- Generate API route stubs ---
 
+// Resolve a validated bare specifier (e.g. '@bike4mind/premium-optihashi/api/webhooks/qwork')
+// declared by `pkg` back to the real source file on disk, via that package's own
+// `exports` map in its package.json - so we can inspect the source without executing it.
+// Returns null (never throws) for any shape this doesn't confidently recognize;
+// callers treat null as "no config to re-export", which is the pre-existing behavior.
+function resolveExportFromToSourceFile(pkg, exportFrom) {
+  let subpath;
+  if (exportFrom === pkg.name) subpath = '.';
+  else if (exportFrom.startsWith(`${pkg.name}/`)) subpath = `.${exportFrom.slice(pkg.name.length)}`;
+  else return null; // exportFrom names a different package - not resolvable from here.
+
+  const pkgJsonPath = join(PREMIUM_DIR, pkg.dir, 'package.json');
+  let pkgJson;
+  try {
+    pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+  } catch {
+    return null;
+  }
+  const target = pkgJson.exports?.[subpath];
+  if (typeof target !== 'string') return null; // conditional exports object, or no match - skip.
+
+  const resolved = resolve(join(PREMIUM_DIR, pkg.dir, target));
+  return existsSync(resolved) ? resolved : null;
+}
+
+// Next.js's Pages Router requires `export const config = {...}` to be a literal,
+// statically-analyzable object declared DIRECTLY in the route file - a bare
+// `export { config } from 'source'` re-export is not reliably picked up by Next's
+// build-time page-config analyzer. Dropping `config` silently re-enables Next's
+// default body parser, which then consumes a raw-body handler's request stream
+// before the handler's own manual read ever runs (verified live: a correctly-signed
+// webhook POST to a route missing this hung forever instead of getting a response).
+// So instead of re-exporting `config` across a module boundary, copy its literal
+// text into the generated glue file so Next analyzes it directly, in-file.
+function extractConfigLiteral(sourceFilePath) {
+  if (!sourceFilePath) return null;
+  let content;
+  try {
+    content = readFileSync(sourceFilePath, 'utf8');
+  } catch {
+    return null;
+  }
+  const match = content.match(/export\s+const\s+config\s*=\s*(\{[\s\S]*?\});/);
+  return match ? match[1] : null;
+}
+
 function generateApiStubs(packages) {
   // Wipe all previously-generated stubs so removing a package removes its stubs.
   // Pattern: pages/api/premium-* dirs (all premium API dirs are namespaced premium-*).
@@ -257,9 +303,15 @@ function generateApiStubs(packages) {
       // exportFrom is interpolated raw into `export { default } from '<spec>'`.
       assertModuleSpecifier(exportFrom, pkg.name, 'apiRouteStubs.exportFrom');
 
+      // If the source route exports a Next.js page `config` (e.g. { api: { bodyParser:
+      // false } } for a raw-body webhook handler), copy its literal text in - see
+      // extractConfigLiteral's comment for why this can't just be re-exported.
+      const configLiteral = extractConfigLiteral(resolveExportFromToSourceFile(pkg, exportFrom));
+      const configExport = configLiteral ? `export const config = ${configLiteral};\n` : '';
+
       writeFile(
         outPath,
-        `${GENERATED_BANNER}// Source: ${pkg.name} via b4mContributions.apiRouteStubs\nexport { default } from '${exportFrom}';\n`
+        `${GENERATED_BANNER}// Source: ${pkg.name} via b4mContributions.apiRouteStubs\nexport { default } from '${exportFrom}';\n${configExport}`
       );
     }
   }

--- a/apps/client/scripts/generate-premium-glue.mjs
+++ b/apps/client/scripts/generate-premium-glue.mjs
@@ -284,10 +284,14 @@ function extractConfigLiteral(sourceFilePath) {
   // Anchored to line start (with leading whitespace allowed) so a config-shaped literal
   // sitting inside a comment or string above the real declaration can't win the match -
   // otherwise `.match()` would still succeed there, skipping the fallback warning below
-  // while emitting whatever that comment/string literal happened to contain.
-  const match = content.match(/^\s*export\s+const\s+config\s*=\s*(\{[\s\S]*?\});/m);
+  // while emitting whatever that comment/string literal happened to contain. Tolerates an
+  // optional type annotation (`config: PageConfig =`) between the name and `=` - without
+  // it, an annotated declaration matches neither this regex nor the fallback trigger below,
+  // silently emitting no config export with no warning (no route currently uses this form,
+  // but nothing stops one from starting to).
+  const match = content.match(/^\s*export\s+const\s+config(?::\s*[A-Za-z_][A-Za-z0-9_.]*)?\s*=\s*(\{[\s\S]*?\});/m);
   if (match) return match[1];
-  if (/export\s+const\s+config\s*=/.test(content)) {
+  if (/export\s+const\s+config(?::\s*[A-Za-z_][A-Za-z0-9_.]*)?\s*=/.test(content)) {
     console.warn(
       `[codegen] WARNING: ${sourceFilePath} declares "export const config" but its literal object ` +
         `could not be extracted (unexpected formatting) - the generated stub will be missing this ` +

--- a/apps/client/scripts/generate-premium-glue.mjs
+++ b/apps/client/scripts/generate-premium-glue.mjs
@@ -234,7 +234,14 @@ function resolveExportFromToSourceFile(pkg, exportFrom) {
   const target = pkgJson.exports?.[subpath];
   if (typeof target !== 'string') return null; // conditional exports object, or no match - skip.
 
+  // Containment guard, mirroring the ones below for generatedPath (:293, :349):
+  // `target` comes from the overlay's own package.json, which is already fully
+  // trusted (its .ts source is compiled directly into the app elsewhere), but stay
+  // consistent with this file's own defense-in-depth convention regardless of that.
+  const pkgRoot = resolve(join(PREMIUM_DIR, pkg.dir));
   const resolved = resolve(join(PREMIUM_DIR, pkg.dir, target));
+  if (resolved !== pkgRoot && !resolved.startsWith(pkgRoot + sep)) return null;
+
   return existsSync(resolved) ? resolved : null;
 }
 
@@ -247,6 +254,12 @@ function resolveExportFromToSourceFile(pkg, exportFrom) {
 // webhook POST to a route missing this hung forever instead of getting a response).
 // So instead of re-exporting `config` across a module boundary, copy its literal
 // text into the generated glue file so Next analyzes it directly, in-file.
+//
+// The literal-extraction regex requires the closing `}` to be immediately followed
+// by `;` (no space) - true for this repo's own Prettier-formatted source today, but
+// a differently-formatted config would silently fail to extract and fall back to no
+// config export at all, i.e. reintroducing the exact hang this function exists to
+// prevent. Warn loudly in that case instead of failing silently.
 function extractConfigLiteral(sourceFilePath) {
   if (!sourceFilePath) return null;
   let content;
@@ -256,7 +269,15 @@ function extractConfigLiteral(sourceFilePath) {
     return null;
   }
   const match = content.match(/export\s+const\s+config\s*=\s*(\{[\s\S]*?\});/);
-  return match ? match[1] : null;
+  if (match) return match[1];
+  if (/export\s+const\s+config\s*=/.test(content)) {
+    console.warn(
+      `[codegen] WARNING: ${sourceFilePath} declares "export const config" but its literal object ` +
+        `could not be extracted (unexpected formatting) - the generated stub will be missing this ` +
+        `config, which can silently reintroduce a bodyParser-related hang.`
+    );
+  }
+  return null;
 }
 
 function generateApiStubs(packages) {

--- a/apps/client/scripts/generate-premium-glue.mjs
+++ b/apps/client/scripts/generate-premium-glue.mjs
@@ -232,7 +232,20 @@ function resolveExportFromToSourceFile(pkg, exportFrom) {
     return null;
   }
   const target = pkgJson.exports?.[subpath];
-  if (typeof target !== 'string') return null; // conditional exports object, or no match - skip.
+  if (target === undefined) return null; // no exports entry for this subpath - nothing to resolve.
+  if (typeof target !== 'string') {
+    // A conditional-exports object ({ import, require, ... }) or array target exists at this
+    // key but isn't a plain string path we can read - warn rather than silently returning null,
+    // matching extractConfigLiteral's posture: an unresolvable source file means any `config`
+    // export it might have is silently dropped from the generated stub, which can reintroduce
+    // the exact bodyParser hang this file exists to prevent.
+    console.warn(
+      `[codegen] WARNING: ${pkg.name}'s package.json exports["${subpath}"] is not a plain string ` +
+        `path (got ${JSON.stringify(target)}) - can't resolve it to check for a "config" export. ` +
+        `If this route needs Next's bodyParser config, the generated stub will be missing it.`
+    );
+    return null;
+  }
 
   // Containment guard, mirroring the ones below for generatedPath (:293, :349):
   // `target` comes from the overlay's own package.json, which is already fully
@@ -268,7 +281,11 @@ function extractConfigLiteral(sourceFilePath) {
   } catch {
     return null;
   }
-  const match = content.match(/export\s+const\s+config\s*=\s*(\{[\s\S]*?\});/);
+  // Anchored to line start (with leading whitespace allowed) so a config-shaped literal
+  // sitting inside a comment or string above the real declaration can't win the match -
+  // otherwise `.match()` would still succeed there, skipping the fallback warning below
+  // while emitting whatever that comment/string literal happened to contain.
+  const match = content.match(/^\s*export\s+const\s+config\s*=\s*(\{[\s\S]*?\});/m);
   if (match) return match[1];
   if (/export\s+const\s+config\s*=/.test(content)) {
     console.warn(


### PR DESCRIPTION
## Summary

Any premium overlay webhook route that needs Next.js's raw-body mode (`export const config = { api: { bodyParser: false } }`, used for HMAC signature verification over the exact request bytes) was silently broken: `generate-premium-glue.mjs`'s generated glue file only re-exported `default` from the source route, never `config`.

Next.js's Pages Router requires `config` to be a literal, statically-analyzable object declared directly in the route file - it isn't reliably picked up through a re-export across a module boundary. Without it, Next's default body parser silently consumes the request body before the handler runs, and the handler's own manual `getRawBody(req)` then hangs forever listening on an already-drained stream. **No response, no error, no timeout on the server side - the request just hangs.**

## Fix

Instead of re-exporting `config`, extract its literal object text from the source route file and copy it directly into the generated glue file, so Next's build-time analyzer sees it in the same file it's already scanning. This sidesteps entirely whether Next supports analyzing a re-exported `config` - it never has to.

Resolution is done via the target package's own `exports` map (already declared in its `package.json`), matching the `apiRouteStubs.exportFrom` specifier back to a real source file on disk - no new trust boundary, since overlay source is already fully trusted/compiled elsewhere in this codegen.

Went through three rounds of review (`/expert-review` + self-adjudication, a posted bot `CHANGES_REQUESTED` + adjudication, then a posted bot `APPROVED` with one non-blocking note + a final adjudication). All findings folded in - five hardening layers total, each closing a distinct way the "silently reintroduce the hang" failure mode could sneak back in:
1. `resolveExportFromToSourceFile` containment-checks the resolved path against the overlay's own package directory, mirroring the existing guards elsewhere in this file for `generatedPath`.
2. `extractConfigLiteral` warns loudly if a source file declares `export const config` but the literal-extraction regex fails to capture it, instead of silently falling back to no config export.
3. `resolveExportFromToSourceFile` warns when `package.json`'s `exports[subpath]` exists but isn't a plain string path (a conditional-exports object or array target) - previously silent, bypassing the warning in (2) entirely.
4. The config-literal regex is anchored to line start, so a config-shaped literal inside a comment or string above the real declaration can't win the match and get emitted verbatim instead of the real config.
5. Both the extraction regex and the fallback warning trigger now tolerate an optional type annotation (`config: PageConfig = {...}`) - previously either form bypassed both checks silently. No current route uses this form (verified via grep), but nothing stops one from starting to.

## Verification

This was found and fixed while dogfooding a related local-dev effort - discovered by actually running the generated code, not by inspection.

- [x] Verified live end-to-end against OptiHashi's real webhook handler (hydrated the real private overlay, ran the real bring-up sequence, built a real Docker image, brought up self-host for real):
  - **Before this fix:** a correctly HMAC-signed POST to `/api/premium-optihashi/webhooks/compute` hung indefinitely (curl `--max-time 15` timeout, zero response bytes).
  - **After this fix:** the identical request returns immediately and proceeds through signature verification, payload schema validation, and delivery-ID matching to a separate, unrelated downstream issue (a self-host resource-manifest gap, not in scope for this fix) - confirming the body-parsing hang is fully resolved, not just superficially different.
- [x] Confirmed this isn't a general self-host/Next-16 regression: the existing hand-written `/api/webhooks/github` route (identical `bodyParser:false`/`getRawBody` pattern, not codegen'd) responds instantly with or without this change.
- [x] Re-verified all five hardening layers against real fixtures: the anchored/annotation-tolerant regex still extracts OptiHashi's real config correctly; a JSDoc-comment-hijack fixture is correctly skipped; conditional-exports/array/absent-key `exports` shapes each warn or stay silent exactly as intended; a type-annotated config now extracts correctly, and a malformed-but-annotated one still fails extraction loudly (warns) rather than silently
- [x] `pnpm --filter @bike4mind/client typecheck` - clean
- [x] `pnpm lint:check` - clean
- [x] `pnpm --filter @bike4mind/client test` - full suite green (443 files / 4977 tests)
- [x] Pre-push `turbo typecheck:fast` across all 34 packages - passed

No new test file added for the codegen script itself - it has no existing test infrastructure, consistent with other `scripts/*.mjs` files in this repo, and the live verification above exercises the actual real-world failure mode (Next.js's build-time config analyzer behavior) more faithfully than a unit test could.