### PR TITLE
chore(ci): skip pr-bot-review re-review when only a changeset landed since last review

### DIFF
--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -110,14 +110,19 @@ jobs:
           # only .changeset/config.json must still be reviewed. FAIL-OPEN - any ambiguity or
           # error resolves to "review" (a wrongly-skipped review is worse than one extra pass).
           # Every path calls emit() and exits 0, so a hiccup can never fail the step into a
-          # fail-CLOSED skip.
+          # fail-CLOSED skip. The || fallbacks below are load-bearing under the default
+          # `bash -e -o pipefail` shell (e.g. grep's no-match exit 1 must not fail the step).
+          # Author-name spoofing can't bypass this: skipping ALSO requires every changed path
+          # to be under .changeset/, so real code always gets reviewed (and this job is
+          # same-repo only, so no fork can reach it).
           emit() { echo "guard: skip=$1"; echo "skip=$1" >> "$GITHUB_OUTPUT"; exit 0; }
 
-          # Most recent claude[bot] review's reviewed SHA. --paginate: reviews come back
-          # ascending, 30/page, so the newest can be on a later page. DISMISSED reviews still
+          # Most recent claude[bot] review's reviewed SHA. --paginate walks all pages, but
+          # --jq runs PER PAGE, so stream the matching commit_ids (ascending) and take the
+          # global last with `tail -n1` rather than a per-page `last`. DISMISSED reviews still
           # carry a commit_id and count.
           LAST=$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR}/reviews" \
-                   --jq "map(select(.user.login==\"${BOT_REVIEW_LOGIN}\" and .commit_id != null)) | last | .commit_id" 2>/dev/null || echo "")
+                   --jq ".[] | select(.user.login==\"${BOT_REVIEW_LOGIN}\" and .commit_id != null) | .commit_id" 2>/dev/null | tail -n1 || echo "")
           if [ -z "$LAST" ] || [ "$LAST" = "null" ]; then echo "guard: no prior ${BOT_REVIEW_LOGIN} review"; emit false; fi
 
           HEAD_SHA=$(git rev-parse HEAD)
@@ -143,9 +148,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Best-effort feedback: a transient comment failure must not red the check
+          # (the review was correctly skipped either way).
           gh pr comment ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --body "🤖 Skipped re-review - the only new commits since the last bot review are the auto-generated changeset (no substantive changes). Push a code change and re-apply \`bot-review\` for a fresh review."
+            --body "🤖 Skipped re-review - the only new commits since the last bot review are the auto-generated changeset (no substantive changes). Push a code change and re-apply \`bot-review\` for a fresh review." || true
 
       - name: Run /bot-review
         id: bot_review

--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -21,6 +21,16 @@ name: pr-bot-review
 # the same pull_request trigger. The draft guard and size guard (>100 files)
 # are the primary cost controls; occasional docs-only or changeset PRs getting
 # reviewed is an acceptable trade-off.
+#
+# Double-review de-dupe (#166): opening/readying a PR already triggers a review,
+# but users also manually add `bot-review` to "request" one, firing two triggers
+# close together, and `auto-changeset.yml` pushes a `.changeset/pr-N.md` commit in
+# between, so the second pass reviews an identical diff plus a changeset. Two guards
+# stop the waste:
+#   1. concurrency `cancel-in-progress: true`: a newer trigger supersedes the
+#      in-flight run (handles the concurrent open+label window).
+#   2. the "substantive-change guard" step below: skips when the only commits since
+#      our last review are the b4m-release-bot changeset (handles a later re-label).
 
 on:
   pull_request:
@@ -35,7 +45,12 @@ permissions:
 
 concurrency:
   group: pr-bot-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  # A newer trigger for the same PR (e.g. a manual `bot-review` label added seconds
+  # after `opened`/`ready_for_review`) supersedes the in-flight run instead of
+  # serializing behind it, so the common "open + click the label" double-fire yields
+  # ONE review on the newer head. The superseded run is the `opened` run (no label to
+  # remove), so label hygiene is unaffected. (#166)
+  cancel-in-progress: true
 
 jobs:
   review:
@@ -80,9 +95,61 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Substantive-change guard - skip changeset-only re-reviews
+        id: substantive
+        if: steps.size_check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_REVIEW_LOGIN: 'claude[bot]'
+          CHANGESET_BOT: 'b4m-release-bot[bot]'
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # Skip a review pass when nothing a HUMAN did has landed since our last review:
+          # i.e. the only commits since the most recent claude[bot] review are the
+          # b4m-release-bot changeset. The signal is AUTHORSHIP, not path: a human editing
+          # only .changeset/config.json must still be reviewed. FAIL-OPEN - any ambiguity or
+          # error resolves to "review" (a wrongly-skipped review is worse than one extra pass).
+          # Every path calls emit() and exits 0, so a hiccup can never fail the step into a
+          # fail-CLOSED skip.
+          emit() { echo "guard: skip=$1"; echo "skip=$1" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          # Most recent claude[bot] review's reviewed SHA. --paginate: reviews come back
+          # ascending, 30/page, so the newest can be on a later page. DISMISSED reviews still
+          # carry a commit_id and count.
+          LAST=$(gh api --paginate "repos/${{ github.repository }}/pulls/${PR}/reviews" \
+                   --jq "map(select(.user.login==\"${BOT_REVIEW_LOGIN}\" and .commit_id != null)) | last | .commit_id" 2>/dev/null || echo "")
+          if [ -z "$LAST" ] || [ "$LAST" = "null" ]; then echo "guard: no prior ${BOT_REVIEW_LOGIN} review"; emit false; fi
+
+          HEAD_SHA=$(git rev-parse HEAD)
+          echo "guard: last-reviewed=$LAST head=$HEAD_SHA"
+
+          # A force-push/rebase can orphan the last-reviewed commit out of the fetched history.
+          git cat-file -e "${LAST}^{commit}" 2>/dev/null || { echo "guard: last-reviewed commit absent (force-push?)"; emit false; }
+
+          if [ "$LAST" = "$HEAD_SHA" ]; then echo "guard: head unchanged since last review"; emit true; fi
+
+          AUTHORS=$(git log --format='%an' "${LAST}..${HEAD_SHA}" 2>/dev/null || echo "")
+          if [ -z "$AUTHORS" ]; then echo "guard: empty commit range"; emit false; fi
+          NON_BOT=$(printf '%s\n' "$AUTHORS" | grep -vxF "$CHANGESET_BOT" || true)
+          NON_CHANGESET=$(git diff --name-only "$LAST" "$HEAD_SHA" 2>/dev/null | grep -v '^\.changeset/' || true)
+          if [ -z "$NON_BOT" ] && [ -z "$NON_CHANGESET" ]; then
+            echo "guard: only ${CHANGESET_BOT} changeset commits since last review"; emit true
+          else
+            echo "guard: substantive changes since last review"; emit false
+          fi
+
+      - name: Note changeset-only skip on a manual re-review
+        if: github.event.action == 'labeled' && steps.substantive.outputs.skip == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "🤖 Skipped re-review - the only new commits since the last bot review are the auto-generated changeset (no substantive changes). Push a code change and re-apply \`bot-review\` for a fresh review."
+
       - name: Run /bot-review
         id: bot_review
-        if: steps.size_check.outputs.skip == 'false'
+        if: steps.size_check.outputs.skip == 'false' && steps.substantive.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Fixes #166. `pr-bot-review` can run two full review passes on one PR: opening/readying it triggers auto review #1, and a user also manually adds the `bot-review` label (thinking that's how you request a review) triggering review #2. In between, `auto-changeset.yml` pushes a `.changeset/pr-N.md` commit, so review #2 re-reviews an identical diff plus a changeset - a wasted opus pass (~8 fan-out agents, up to 80 turns).

Two complementary guards (they cover different timings; neither alone is complete):

1. **`concurrency: cancel-in-progress: true`** - a newer trigger for the same PR supersedes the in-flight run, so the common concurrent open+label double-fire yields ONE review on the newer head. The superseded run is the label-less `opened` run, so label hygiene is unaffected. (Covers the window where the label arrives before review #1 has posted.)
2. **Substantive-change guard step** - finds the most recent `claude[bot]` review's `commit_id` (`gh api --paginate`) and skips only when every commit since is authored by `b4m-release-bot[bot]` **and** every changed path is under `.changeset/`. **Fails OPEN** on any ambiguity (no prior review, base orphaned by force-push, API/git error) so a review is never wrongly skipped. (Covers a later manual re-label after review #1 already posted.)

On a label-triggered skip it posts a one-line note and still removes the `bot-review` label so a later re-add re-triggers cleanly.

## Test plan
Workflow-only change; verified with `actionlint` (YAML + embedded shellcheck, clean). Behavioral acceptance on a live PR:
- [ ] Open a non-draft PR and add `bot-review` within a few seconds -> exactly **one** review completes (the older run is cancelled; confirm in the Actions UI).
- [ ] After a review posts, re-add `bot-review` with only a changeset since -> **skip** + one-line note.
- [ ] Re-add `bot-review` after a real code commit -> review **runs**.
- [ ] Confirm a cancelled run stays silent (no "incomplete review" comment).

Note: "open with no manual label -> one review" already passes today, so it does NOT exercise either guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)