### PR TITLE
fix(client): gate Send to Data Lake entry points behind EnableDataLakes

### DIFF
--- a/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.test.tsx
@@ -135,4 +135,20 @@ describe('SendToDataLakeModal', () => {
     expect(useDataLakes).toHaveBeenCalledWith(false);
     expect(screen.queryByTestId('send-to-datalake-option-lake-1')).toBeNull();
   });
+
+  it('does not render at all when EnableDataLakes is off, even if the store is open', () => {
+    isFeatureEnabled.mockReturnValue(false);
+
+    render(
+      <TestWrapper>
+        <SendToDataLakeModal />
+      </TestWrapper>
+    );
+
+    // The modal is the shared choke point for every "Send to Data Lake" entry point.
+    // Rendering it with the feature off would surface a dead-end empty state pointing
+    // at a Files -> Data Lakes entry that is itself hidden, so it must return null
+    // (mirroring CreateDataLakeButton in FileBrowser).
+    expect(screen.queryByTestId('send-to-datalake-modal')).toBeNull();
+  });
 });

--- a/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.tsx
@@ -93,6 +93,12 @@ export default function SendToDataLakeModal() {
     }
   };
 
+  // Shared choke point for every "Send to Data Lake" entry point: with the feature
+  // off, never render - even if some (future) ungated caller opens the store, the
+  // dead-end empty state must not surface. Mirrors CreateDataLakeButton's gate.
+  // Placed after all hooks so the hook order is stable across flag changes.
+  if (!isFeatureEnabled('EnableDataLakes')) return null;
+
   return (
     <Modal open={isOpen} onClose={close}>
       <ModalDialog data-testid="send-to-datalake-modal" sx={{ width: { xs: '95%', sm: '28rem' }, maxWidth: '28rem' }}>

--- a/apps/client/app/components/Session/MessageContent.gating.test.tsx
+++ b/apps/client/app/components/Session/MessageContent.gating.test.tsx
@@ -1,0 +1,176 @@
+import React, { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { IChatHistoryItem } from '@bike4mind/common';
+
+/**
+ * Gating coverage for the per-reply "Send to Data Lake" menu item: it must be
+ * hidden when EnableDataLakes is off (otherwise it opens the app-level modal
+ * into a dead-end empty state), and stay functional when the feature is on.
+ *
+ * MessageContent is a heavy component; everything around the actions menu is
+ * mocked to a stub so the test exercises only the real menu markup.
+ */
+
+// --- context / data hooks -------------------------------------------------
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: () => ({ currentUser: { id: 'user-1' } }),
+}));
+vi.mock('@client/app/contexts/SessionsContext', () => ({
+  useSessions: () => ({ currentSession: null, setCurrentSession: vi.fn() }),
+  useWorkBenchFiles: () => [],
+  useWorkBenchActions: () => ({ setWorkBenchFiles: vi.fn() }),
+}));
+vi.mock('@client/app/contexts/LLMContext', () => {
+  const state = { researchMode: { enabled: false }, setLLM: vi.fn() };
+  return { useLLM: (selector: (s: typeof state) => unknown) => selector(state) };
+});
+vi.mock('@client/app/contexts/WebsocketContext', () => ({
+  useWebsocket: () => ({ subscribeToAction: vi.fn(() => vi.fn()) }),
+}));
+vi.mock('@client/app/hooks/data/sessions', () => ({
+  useForkSession: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useSnipSession: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@client/app/hooks/data/quests', () => ({
+  useGetQuest: () => ({ data: undefined, isLoading: false }),
+  useUpdateQuest: () => Object.assign(vi.fn(), { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@client/app/hooks/data/fabFiles', () => ({
+  useGetFabFilesByQuestId: () => ({ data: [] }),
+}));
+vi.mock('@client/app/hooks/data/useModelInfo', () => ({
+  useModelInfo: () => ({ data: [] }),
+}));
+vi.mock('@client/app/hooks/data/settings', () => ({
+  useSettingsFromServer: () => ({ data: [] }),
+}));
+vi.mock('@client/app/hooks/usePublishShare', () => ({
+  usePublishShare: () => ({ publishAndShare: vi.fn(), modal: null }),
+}));
+vi.mock('@client/app/hooks/useMessageEditMode', () => {
+  const state = { triggerEdit: vi.fn() };
+  return { useMessageEditMode: (selector: (s: typeof state) => unknown) => selector(state) };
+});
+vi.mock('@client/app/components/Session/PromptMetaInspector', () => {
+  const state = { setPromptMeta: vi.fn() };
+  return { usePromptMetaInspector: (selector: (s: typeof state) => unknown) => selector(state) };
+});
+vi.mock('@client/app/hooks/useSubscribeChatCompletion', () => ({
+  useSubscribeChatCompletion: vi.fn(),
+}));
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+// --- utils with API/server dependencies ------------------------------------
+vi.mock('@client/app/utils/fabFileUtils', () => ({
+  saveToFileAndWorkbench: vi.fn(),
+}));
+vi.mock('@client/app/utils/publishApi', () => ({
+  publishReply: vi.fn(),
+}));
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// --- heavy child components (not under test) --------------------------------
+vi.mock('@client/app/components/Session/PromptReplies', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/UserPrompt', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/CopyTextButton', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/ToolsUsed', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/AgentExecution/ReasoningDisclosure', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/AgentExecution/AutoRouteBadge', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/ResearchModeResponseDisplay', () => ({ default: () => null }));
+vi.mock('@client/app/components/ConfirmActionModal', () => ({ default: () => null }));
+vi.mock('@client/app/components/BugReportModal', () => ({ default: () => null }));
+vi.mock('@client/app/components/ProfileModal/ContentPreviewModal', () => ({ default: () => null }));
+vi.mock('../common/DownloadMenu', () => ({ default: () => null, downloadFile: vi.fn() }));
+
+// --- the flag under test ----------------------------------------------------
+// Default (flag on) is established in beforeEach; tests override per-case.
+const isFeatureEnabled = vi.fn();
+vi.mock('@client/app/hooks/useAdminSettingsCache', () => ({
+  useAdminSettingsCache: () => ({ isFeatureEnabled }),
+}));
+
+import { useSendToDataLakeStore } from '@client/app/stores/useSendToDataLakeStore';
+import MessageContent from './MessageContent';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+  </QueryClientProvider>
+);
+
+const messageData = {
+  id: 'quest-1',
+  prompt: 'hello',
+  replies: ['a reply worth saving'],
+  status: 'done',
+} as unknown as IChatHistoryItem;
+
+function renderAndOpenActionsMenu() {
+  render(
+    <TestWrapper>
+      <MessageContent
+        sessionId="session-1"
+        messageData={messageData}
+        index={0}
+        onDelete={vi.fn()}
+        onPinToggle={vi.fn()}
+        onSendMessage={vi.fn()}
+        isLastMessage={false}
+        model="gpt-4o"
+        totalMessages={1}
+        canUseAdminTools={false}
+      />
+    </TestWrapper>
+  );
+  fireEvent.click(screen.getByTestId('message-actions-menu-btn'));
+}
+
+describe('MessageContent actions menu - EnableDataLakes gating', () => {
+  beforeEach(() => {
+    isFeatureEnabled.mockReset();
+    isFeatureEnabled.mockReturnValue(true);
+    useSendToDataLakeStore.setState({ isOpen: false });
+  });
+
+  it('shows the Send to Data Lake item when the feature is on', () => {
+    renderAndOpenActionsMenu();
+
+    expect(screen.getByTestId('message-send-to-datalake')).toBeInTheDocument();
+  });
+
+  it('hides the Send to Data Lake item when the feature is off', () => {
+    isFeatureEnabled.mockImplementation((key: string) => key !== 'EnableDataLakes');
+
+    renderAndOpenActionsMenu();
+
+    expect(screen.queryByTestId('message-send-to-datalake')).not.toBeInTheDocument();
+  });
+
+  it('keeps the neighboring actions available when the feature is off', () => {
+    isFeatureEnabled.mockImplementation((key: string) => key !== 'EnableDataLakes');
+
+    renderAndOpenActionsMenu();
+
+    // Share sits right after the gated item; Delete closes the menu - both must survive.
+    expect(screen.getByTestId('message-share-reply')).toBeInTheDocument();
+    expect(screen.getByText('Toggle Code View')).toBeInTheDocument();
+    expect(screen.getByText(/^Save as/)).toBeInTheDocument();
+  });
+
+  it('still opens the Send to Data Lake modal from the item when the feature is on', () => {
+    renderAndOpenActionsMenu();
+
+    fireEvent.click(screen.getByTestId('message-send-to-datalake'));
+
+    expect(useSendToDataLakeStore.getState().isOpen).toBe(true);
+  });
+});

--- a/apps/client/app/components/Session/MessageContent.tsx
+++ b/apps/client/app/components/Session/MessageContent.tsx
@@ -37,6 +37,7 @@ import { useModelInfo } from '@client/app/hooks/data/useModelInfo';
 import { useGetFabFilesByQuestId } from '@client/app/hooks/data/fabFiles';
 import { Save as SaveIcon, Add as AddIcon, Storage as StorageIcon } from '@mui/icons-material';
 import { useSendToDataLakeStore } from '@client/app/stores/useSendToDataLakeStore';
+import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import { usePromptMetaInspector } from '@client/app/components/Session/PromptMetaInspector';
 import HiveIcon from '@mui/icons-material/Hive';
 import ContentPreviewModal from '@client/app/components/ProfileModal/ContentPreviewModal';
@@ -197,6 +198,7 @@ const MessageContent: React.FC<ContentProps> = memo(
 
     // Opens the app-level Send-to-Data-Lake modal (singleton in ProviderBundle) for one reply.
     const openSendToDataLake = useSendToDataLakeStore(s => s.open);
+    const { isFeatureEnabled } = useAdminSettingsCache();
 
     const handleSendReplyToDataLake = useCallback(
       (messageData: IChatHistoryItem) => {
@@ -764,6 +766,7 @@ const MessageContent: React.FC<ContentProps> = memo(
                   <Dropdown>
                     <Tooltip title="More options">
                       <MenuButton
+                        data-testid="message-actions-menu-btn"
                         slots={{ root: IconButton }}
                         slotProps={{ root: { variant: 'outlined', color: 'neutral', size: 'sm' } }}
                         sx={{
@@ -861,15 +864,17 @@ const MessageContent: React.FC<ContentProps> = memo(
                         </ListItemDecorator>
                         Save as {detectChatContentType(messageData.replies?.[0] || '')}
                       </MenuItem>
-                      <MenuItem
-                        onClick={() => handleSendReplyToDataLake(messageData)}
-                        data-testid="message-send-to-datalake"
-                      >
-                        <ListItemDecorator>
-                          <StorageIcon />
-                        </ListItemDecorator>
-                        Send to Data Lake
-                      </MenuItem>
+                      {isFeatureEnabled('EnableDataLakes') && (
+                        <MenuItem
+                          onClick={() => handleSendReplyToDataLake(messageData)}
+                          data-testid="message-send-to-datalake"
+                        >
+                          <ListItemDecorator>
+                            <StorageIcon />
+                          </ListItemDecorator>
+                          Send to Data Lake
+                        </MenuItem>
+                      )}
                       {hasShareableReply && (
                         <MenuItem onClick={handleShareReply} data-testid="message-share-reply">
                           <ListItemDecorator>
@@ -920,6 +925,7 @@ const MessageContent: React.FC<ContentProps> = memo(
                   <Dropdown>
                     <Tooltip title="More options">
                       <MenuButton
+                        data-testid="message-actions-menu-btn"
                         slots={{ root: IconButton }}
                         slotProps={{ root: { variant: 'outlined', color: 'neutral', size: 'sm' } }}
                         sx={{
@@ -1017,15 +1023,17 @@ const MessageContent: React.FC<ContentProps> = memo(
                         </ListItemDecorator>
                         Save as {detectChatContentType(messageData.replies?.[0] || '')}
                       </MenuItem>
-                      <MenuItem
-                        onClick={() => handleSendReplyToDataLake(messageData)}
-                        data-testid="message-send-to-datalake"
-                      >
-                        <ListItemDecorator>
-                          <StorageIcon />
-                        </ListItemDecorator>
-                        Send to Data Lake
-                      </MenuItem>
+                      {isFeatureEnabled('EnableDataLakes') && (
+                        <MenuItem
+                          onClick={() => handleSendReplyToDataLake(messageData)}
+                          data-testid="message-send-to-datalake"
+                        >
+                          <ListItemDecorator>
+                            <StorageIcon />
+                          </ListItemDecorator>
+                          Send to Data Lake
+                        </MenuItem>
+                      )}
                       {hasShareableReply && (
                         <MenuItem onClick={handleShareReply} data-testid="message-share-reply">
                           <ListItemDecorator>

--- a/apps/client/app/components/Session/SessionExportMenu.test.tsx
+++ b/apps/client/app/components/Session/SessionExportMenu.test.tsx
@@ -1,0 +1,113 @@
+import React, { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { IChatHistoryItemDocument, ISessionDocument } from '@bike4mind/common';
+import { useSendToDataLakeStore } from '@client/app/stores/useSendToDataLakeStore';
+import SessionExportMenu from './SessionExportMenu';
+
+/**
+ * Gating coverage for the "Send to Data Lake" entry point (issue: the menu item
+ * must be hidden when EnableDataLakes is off, matching the rest of the data-lake
+ * surface - otherwise it opens the modal into a dead-end empty state that points
+ * at a Files entry which is itself hidden).
+ */
+
+// The export utils pull in heavy generators (exceljs/docx); the menu only needs
+// their return values, so stub the whole module.
+vi.mock('@client/app/utils/sessionExport', () => ({
+  toExportableSession: vi.fn(() => ({})),
+  sessionToMarkdown: vi.fn(() => '# session'),
+  sessionToJSON: vi.fn(() => '{}'),
+  sessionToCSV: vi.fn(() => ''),
+  sessionToExcel: vi.fn(async () => undefined),
+  sessionToDocx: vi.fn(async () => undefined),
+  getSessionExportFilename: vi.fn(() => 'session-export'),
+}));
+
+vi.mock('@client/app/components/common/DownloadMenu', () => ({
+  default: () => null,
+  downloadFile: vi.fn(),
+}));
+
+vi.mock('@client/app/hooks/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({ handleCopyToClipboard: vi.fn() }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Default (flag on) is established in beforeEach; tests override per-case.
+const isFeatureEnabled = vi.fn();
+
+vi.mock('@client/app/hooks/useAdminSettingsCache', () => ({
+  useAdminSettingsCache: () => ({ isFeatureEnabled }),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const session = { name: 'Test Session' } as ISessionDocument;
+const chatHistory = [] as IChatHistoryItemDocument[];
+
+function renderAndOpenMenu() {
+  render(
+    <TestWrapper>
+      <SessionExportMenu session={session} chatHistory={chatHistory} />
+    </TestWrapper>
+  );
+  fireEvent.click(screen.getByTestId('session-export-menu-btn'));
+}
+
+describe('SessionExportMenu - EnableDataLakes gating', () => {
+  beforeEach(() => {
+    isFeatureEnabled.mockReset();
+    isFeatureEnabled.mockReturnValue(true);
+    useSendToDataLakeStore.setState({ isOpen: false });
+  });
+
+  it('shows the Send to Data Lake item (and its Knowledge section) when the feature is on', () => {
+    renderAndOpenMenu();
+
+    expect(screen.getByTestId('session-send-to-datalake')).toBeInTheDocument();
+    expect(screen.getByText('Knowledge')).toBeInTheDocument();
+  });
+
+  it('hides the Send to Data Lake item and the whole Knowledge section when the feature is off', () => {
+    isFeatureEnabled.mockImplementation((key: string) => key !== 'EnableDataLakes');
+
+    renderAndOpenMenu();
+
+    expect(screen.queryByTestId('session-send-to-datalake')).not.toBeInTheDocument();
+    // The item is the only entry under "Knowledge" - hiding the item must not
+    // leave an orphaned section header behind.
+    expect(screen.queryByText('Knowledge')).not.toBeInTheDocument();
+  });
+
+  it('keeps the export and copy actions available regardless of the flag', () => {
+    isFeatureEnabled.mockImplementation((key: string) => key !== 'EnableDataLakes');
+
+    renderAndOpenMenu();
+
+    expect(screen.getByTestId('session-export-markdown')).toBeInTheDocument();
+    expect(screen.getByTestId('session-export-json')).toBeInTheDocument();
+    expect(screen.getByTestId('session-export-csv')).toBeInTheDocument();
+    expect(screen.getByTestId('session-export-excel')).toBeInTheDocument();
+    expect(screen.getByTestId('session-export-docx')).toBeInTheDocument();
+    expect(screen.getByTestId('session-copy-markdown')).toBeInTheDocument();
+    expect(screen.getByTestId('session-copy-json')).toBeInTheDocument();
+  });
+
+  it('still opens the Send to Data Lake modal from the item when the feature is on', () => {
+    renderAndOpenMenu();
+
+    fireEvent.click(screen.getByTestId('session-send-to-datalake'));
+
+    expect(useSendToDataLakeStore.getState().isOpen).toBe(true);
+    expect(useSendToDataLakeStore.getState().fileName).toBe('session-export.md');
+  });
+});

--- a/apps/client/app/components/Session/SessionExportMenu.tsx
+++ b/apps/client/app/components/Session/SessionExportMenu.tsx
@@ -21,6 +21,7 @@ import {
   Storage as StorageIcon,
 } from '@mui/icons-material';
 import { useSendToDataLakeStore } from '@client/app/stores/useSendToDataLakeStore';
+import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import {
   CircularProgress,
   Divider,
@@ -53,6 +54,7 @@ const SessionExportMenu: React.FC<SessionExportMenuProps> = ({
   const [isExcelGenerating, setIsExcelGenerating] = useState(false);
   const [isDocxGenerating, setIsDocxGenerating] = useState(false);
   const openSendToDataLake = useSendToDataLakeStore(s => s.open);
+  const { isFeatureEnabled } = useAdminSettingsCache();
 
   const filename = getSessionExportFilename(session.name);
   const isExporting = isExcelGenerating || isDocxGenerating;
@@ -225,19 +227,25 @@ const SessionExportMenu: React.FC<SessionExportMenuProps> = ({
           Copy as JSON
         </MenuItem>
 
-        <Divider sx={{ my: 0.5 }} />
+        {/* Data Lake Section - the item is the section's only entry, so hide the
+            header and divider with it when the feature is off (matches the rest of
+            the data-lake surface, e.g. CreateDataLakeButton in FileBrowser). */}
+        {isFeatureEnabled('EnableDataLakes') && (
+          <>
+            <Divider sx={{ my: 0.5 }} />
 
-        {/* Data Lake Section */}
-        <Typography level="body-xs" sx={{ px: 1.5, py: 0.5, fontWeight: 'bold', color: 'neutral.500' }}>
-          Knowledge
-        </Typography>
+            <Typography level="body-xs" sx={{ px: 1.5, py: 0.5, fontWeight: 'bold', color: 'neutral.500' }}>
+              Knowledge
+            </Typography>
 
-        <MenuItem data-testid="session-send-to-datalake" onClick={handleSendToDataLake}>
-          <ListItemDecorator>
-            <StorageIcon fontSize="small" />
-          </ListItemDecorator>
-          Send to Data Lake
-        </MenuItem>
+            <MenuItem data-testid="session-send-to-datalake" onClick={handleSendToDataLake}>
+              <ListItemDecorator>
+                <StorageIcon fontSize="small" />
+              </ListItemDecorator>
+              Send to Data Lake
+            </MenuItem>
+          </>
+        )}
       </Menu>
     </Dropdown>
   );

--- a/apps/client/app/components/Session/SidenavItem.gating.test.tsx
+++ b/apps/client/app/components/Session/SidenavItem.gating.test.tsx
@@ -1,0 +1,123 @@
+import React, { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { ISessionDocument } from '@bike4mind/common';
+
+/**
+ * Gating coverage for the sidenav session menu's "Send to Data Lake" item: it
+ * must be hidden when EnableDataLakes is off, in BOTH menu variants (the
+ * default sidenav row menu and the location="header" dropdown), matching the
+ * other gated entry points (SessionExportMenu, MessageContent).
+ */
+
+// --- contexts / data hooks ---------------------------------------------------
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: () => ({ currentUser: { id: 'user-1' }, isAdmin: false }),
+}));
+vi.mock('@client/app/contexts/SessionsContext', () => ({
+  useSessions: () => ({ currentSessionId: null }),
+}));
+const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
+vi.mock('@client/app/hooks/data/sessions', () => ({
+  useAutoRenameSession: () => mutation(),
+  useCloneSession: () => mutation(),
+  useCopySessionAsMarkdown: () => mutation(),
+  useDeleteSession: () => mutation(),
+  useDownloadSession: () => mutation(),
+  useExportSessionToExcel: () => mutation(),
+  useExportSessionToWord: () => mutation(),
+  useSendSessionToDataLake: () => mutation(),
+  useSummarizeSession: () => mutation(),
+  useToggleFavoriteSession: () => mutation(),
+  useUpdateSessionTags: () => mutation(),
+}));
+vi.mock('@client/app/hooks/data/agentProactiveMessaging', () => ({
+  useTriggerProactiveMessages: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@client/app/hooks/useUnreadProactiveMessages', () => ({
+  useSessionUnreadCount: () => 0,
+}));
+vi.mock('@client/app/hooks/useJobStatus', () => ({
+  useJobStatus: () => ({ isJobRunning: () => false, getRunningJobs: () => [] }),
+}));
+vi.mock('@client/app/components/Project/ProjectAddToModal', () => ({
+  useProjectAddToModal: () => ({ openModal: vi.fn() }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+// --- heavy child components (not under test) --------------------------------
+vi.mock('@client/app/components/common/SessionMetadataModal', () => ({ default: () => null }));
+vi.mock('@client/app/components/common/ShareModal', () => ({ default: () => null }));
+vi.mock('@client/app/components/Session/RenameInput', () => ({ default: () => null }));
+vi.mock('@client/app/components/ConfirmActionModal', () => ({ default: () => null }));
+vi.mock('@client/app/components/ProfileModal/NotebookCurationModal', () => ({ default: () => null }));
+
+// --- the flag under test -----------------------------------------------------
+const isFeatureEnabled = vi.fn();
+vi.mock('@client/app/hooks/useAdminSettingsCache', () => ({
+  useAdminSettingsCache: () => ({ isFeatureEnabled }),
+}));
+
+import SidenavItem from './SidenavItem';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+// currentUser.id === session.userId, so canUpdate/canShare resolve as owner.
+const session = {
+  id: 'session-1',
+  name: 'Test Session',
+  userId: 'user-1',
+  users: [],
+} as unknown as ISessionDocument;
+
+function renderAndOpenMenu(location?: 'header') {
+  render(
+    <TestWrapper>
+      <SidenavItem session={session} location={location} />
+    </TestWrapper>
+  );
+  fireEvent.click(screen.getByTestId('sidenav-item-menu-btn'));
+}
+
+describe.each([
+  ['default sidenav menu', undefined],
+  ['header dropdown menu', 'header'],
+] as const)('SidenavItem %s - EnableDataLakes gating', (_label, location) => {
+  beforeEach(() => {
+    isFeatureEnabled.mockReset();
+    isFeatureEnabled.mockReturnValue(true);
+  });
+
+  it('shows the Send to Data Lake item when the feature is on', () => {
+    renderAndOpenMenu(location);
+
+    expect(screen.getByTestId('sidenav-item-menuitem-send-datalake')).toBeInTheDocument();
+  });
+
+  it('hides the Send to Data Lake item when the feature is off', () => {
+    isFeatureEnabled.mockImplementation((key: string) => key !== 'EnableDataLakes');
+
+    renderAndOpenMenu(location);
+
+    expect(screen.queryByTestId('sidenav-item-menuitem-send-datalake')).not.toBeInTheDocument();
+  });
+
+  it('keeps the neighboring export actions available when the feature is off', () => {
+    isFeatureEnabled.mockImplementation((key: string) => key !== 'EnableDataLakes');
+
+    renderAndOpenMenu(location);
+
+    expect(screen.getByTestId('sidenav-item-menuitem-export-excel')).toBeInTheDocument();
+    expect(screen.getByTestId('sidenav-item-menuitem-export-word')).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/Session/SidenavItem.tsx
+++ b/apps/client/app/components/Session/SidenavItem.tsx
@@ -13,6 +13,7 @@ import {
   useUpdateSessionTags,
 } from '@client/app/hooks/data/sessions';
 import { useJobStatus } from '@client/app/hooks/useJobStatus';
+import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import { ISessionDocument, ISessionFavoriteItem, InviteType } from '@bike4mind/common';
 import { formatSessionTitle } from '@client/app/utils/sessionTitle';
 import CloseIcon from '@mui/icons-material/Close';
@@ -126,6 +127,7 @@ const SessionSidenavItem: FC<{
   const exportToExcel = useExportSessionToExcel();
   const exportToWord = useExportSessionToWord();
   const sendToDataLake = useSendSessionToDataLake();
+  const { isFeatureEnabled } = useAdminSettingsCache();
   const summarizeSession = useSummarizeSession();
   const toggleFavoriteSession = useToggleFavoriteSession(session.id);
   const updateSessionTags = useUpdateSessionTags();
@@ -526,14 +528,16 @@ const SessionSidenavItem: FC<{
               >
                 <ArticleIcon /> Export to Word
               </MenuItem>
-              <MenuItem
-                onClick={handleSendToDataLake}
-                className="sidenav-item-menuitem-send-datalake"
-                data-testid="sidenav-item-menuitem-send-datalake"
-                disabled={sendToDataLake.isPending}
-              >
-                <StorageIcon /> Send to Data Lake
-              </MenuItem>
+              {isFeatureEnabled('EnableDataLakes') && (
+                <MenuItem
+                  onClick={handleSendToDataLake}
+                  className="sidenav-item-menuitem-send-datalake"
+                  data-testid="sidenav-item-menuitem-send-datalake"
+                  disabled={sendToDataLake.isPending}
+                >
+                  <StorageIcon /> Send to Data Lake
+                </MenuItem>
+              )}
               {canUpdate && (
                 <>
                   <MenuItem onClick={handleSummarizeSession} className="sidenav-item-menuitem-summarize">
@@ -862,14 +866,16 @@ const SessionSidenavItem: FC<{
                     >
                       <ArticleIcon /> Export to Word
                     </MenuItem>
-                    <MenuItem
-                      onClick={handleSendToDataLake}
-                      className="sidenav-item-menuitem-send-datalake"
-                      data-testid="sidenav-item-menuitem-send-datalake"
-                      disabled={sendToDataLake.isPending}
-                    >
-                      <StorageIcon /> Send to Data Lake
-                    </MenuItem>
+                    {isFeatureEnabled('EnableDataLakes') && (
+                      <MenuItem
+                        onClick={handleSendToDataLake}
+                        className="sidenav-item-menuitem-send-datalake"
+                        data-testid="sidenav-item-menuitem-send-datalake"
+                        disabled={sendToDataLake.isPending}
+                      >
+                        <StorageIcon /> Send to Data Lake
+                      </MenuItem>
+                    )}
                   </>
                 )}
                 {canUpdate && (


### PR DESCRIPTION
# Pull Request

Closes #196

## Description

With `EnableDataLakes` off, the "Send to Data Lake" menu items still rendered and opened the app-level modal into a dead-end empty state ("No data lakes yet. Create one first from Files → Data Lakes") — pointing at a Files entry that is itself hidden when the flag is off. This PR hides every entry point behind the same flag the rest of the data-lake surface uses, and adds a structural guard in the shared modal.

**Beyond the issue's list:** review found two more ungated entry points in `SidenavItem` (the session "..." menu, both its default and header variants) — gated here too. And as defense-in-depth, the shared `SendToDataLakeModal` now returns `null` when the feature is off, so no present or *future* ungated caller can surface the dead end (mirrors `CreateDataLakeButton`'s early-return gate).

## Changes

- `SessionExportMenu.tsx` — the whole "Knowledge" section (divider + header + item) hides when the flag is off; the item was the section's only entry, so no orphaned header remains.
- `MessageContent.tsx` — the item is gated in both the desktop and mobile action menus; added `data-testid="message-actions-menu-btn"` to the menu triggers (test hook, behavior-neutral).
- `SidenavItem.tsx` — the item is gated in both the default sidenav menu and the `location="header"` dropdown.
- `SendToDataLakeModal.tsx` — early `return null` when the feature is off (placed after all hooks; hook order stable).
- New consumer-level tests (TDD, red-green): `SessionExportMenu.test.tsx`, `MessageContent.gating.test.tsx`, `SidenavItem.gating.test.tsx`, plus a new render-guard case in `SendToDataLakeModal.test.tsx`. 17 tests across the four files: flag off → item absent; flag on → item present and the modal opens; neighboring menu actions unaffected in both states.

All gates use `useAdminSettingsCache().isFeatureEnabled('EnableDataLakes')` — the exact pattern and flag key used by `FileBrowser.tsx` (`CreateDataLakeButton`) and the server middleware (`requireFeatureEnabled('EnableDataLakes')`).

## Guide for Testers

1. As an admin, turn the `EnableDataLakes` admin setting **off** for your account/environment.
2. Open any notebook → open the session export menu (down-arrow icon next to a session's title bar). Expected: no "Knowledge" section and no "Send to Data Lake" item; Markdown/JSON/CSV/Excel/Word export and Copy actions all still present.
3. On any completed reply, open the "..." (More options) menu. Expected: no "Send to Data Lake" item; Try Again / Re-prompt / Toggle Code View / Save as / Share / Delete all still present.
4. In the left sidenav, open a session's "..." menu. Expected: no "Send to Data Lake" item; Export to Excel / Export to Word still present.
5. Turn `EnableDataLakes` **on** (and have at least one data lake). Repeat steps 2-4: the item appears in all three menus, and clicking it opens the "Send to Data Lake" modal listing your lakes.

**Regression checks:** with the flag on, send a reply to a data lake end-to-end (pick lake → Send → success toast). With the flag off, watch the browser console on any notebook route: no `FEATURE_DISABLED` / 403 errors (protects the #123 fix).

## Additional Information

**Review process on this branch:** 8 independent finder agents (line-by-line, removed-behavior, cross-file tracer, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) → per-candidate adversarial verification → fixes applied → a final independent verification agent swept all `useSendToDataLakeStore` callers and confirmed **no ungated entry point remains**. Full client suite green (4920 tests), typecheck 35/35, lint clean.

One **pre-existing** adjacent gap surfaced by the final sweep (out of scope here — it's a *manage-lakes* entry, not a "Send to Data Lake" item): `Files/Browser/Content.tsx` passes `onCreateDataLake` unconditionally, so `UploadActionsSelect` shows a "Data Lakes" option that opens the manager modal (whose `useDataLakes()` fetch 403s) when the flag is off. Happy to file a follow-up issue.

## Checklist

- [x] I have made the UI/UX feel good (no orphaned section headers; menus unchanged for entitled users)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (gate rationale at each site + modal choke-point comment)
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
