### PR TITLE
test(sre): lock in that escalation never consumes a CI-retry slot

### DIFF
--- a/apps/client/server/queueHandlers/sreRevision.test.ts
+++ b/apps/client/server/queueHandlers/sreRevision.test.ts
@@ -6,6 +6,7 @@ const mockCountConsecutiveFailures = vi.fn();
 const mockCountFixesDispatchedToday = vi.fn();
 const mockFindByPrNumber = vi.fn();
 const mockDeleteByKey = vi.fn();
+const mockClaimCiRetry = vi.fn();
 
 vi.mock('@bike4mind/database', () => ({
   adminSettingsRepository: {
@@ -20,6 +21,7 @@ vi.mock('@bike4mind/database', () => ({
     countConsecutiveFailures: (...args: unknown[]) => mockCountConsecutiveFailures(...args),
     countFixesDispatchedToday: (...args: unknown[]) => mockCountFixesDispatchedToday(...args),
     findByPrNumber: (...args: unknown[]) => mockFindByPrNumber(...args),
+    claimCiRetry: (...args: unknown[]) => mockClaimCiRetry(...args),
   },
 }));
 
@@ -530,6 +532,11 @@ describe('sreRevision handler', () => {
       );
       expect(mockSendToQueue).not.toHaveBeenCalled();
       expect(mockPostSreNoFixNeededMessage).not.toHaveBeenCalled();
+      // Escalation is terminal, not a retry: it must never consume a CI-retry slot.
+      // claimCiRetry (the only path that increments ciRetryCount) is owned by
+      // workflow-callback.ts; the revision handler must never call it, so a single
+      // failing CI run can never double-count against maxCiRetries.
+      expect(mockClaimCiRetry).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/client/server/queueHandlers/sreRevision.test.ts
+++ b/apps/client/server/queueHandlers/sreRevision.test.ts
@@ -491,6 +491,9 @@ describe('sreRevision handler', () => {
         expect.stringContaining('Self-Heal Escalation')
       );
       expect(mockSendToQueue).not.toHaveBeenCalled();
+      // Same invariant as the explicit escalate:true case: this terminal failure path
+      // is not a retry, so it must never consume a CI-retry slot.
+      expect(mockClaimCiRetry).not.toHaveBeenCalled();
     });
 
     it('does NOT post an escalation comment on a human-review revision failure (no ciFailureOutput)', async () => {


### PR DESCRIPTION
## Description

Regression lock-in: confirm a single failing CI run can never double-count against `maxCiRetries`.

`claimCiRetry` (in `SreErrorTrackingModel`) is the only code path that increments `ciRetryCount`, and it is owned by `workflow-callback.ts`. The terminal escalation paths in `runSreRevision` (`escalate:true` and diagnosis-null) transition `revision_requested -> failed` via `atomicTransition` and must never claim a retry. The invariant already holds; this adds explicit tests so a future refactor that wrongly adds a claim to the revision path fails CI.

## Changes

- `apps/client/server/queueHandlers/sreRevision.test.ts`
  - Add `claimCiRetry` to the `@bike4mind/database` mock.
  - Assert `claimCiRetry` is never called on the two terminal escalation paths.

No production code changes.

## Tests

- `pnpm --filter @bike4mind/client exec vitest run server/queueHandlers/sreRevision.test.ts` -> 15 passed.
- Verified the assertion is non-vacuous: with an inverted `toHaveBeenCalled()` the test fails (the escalate branch executes and `claimCiRetry` is genuinely absent), confirming it is not passing trivially.

## Guide for Testers

Run the file above; all 15 tests pass. No runtime behavior changes.