### PR TITLE
chore(ci): drop dead PR-era code from the deploy.yml e2e job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -877,12 +877,10 @@ jobs:
     # separately by e2e-on-label.yml. The `stage == 'dev'` guard also excludes push
     # to prod (stage == 'production'), where E2E should not run.
     if: needs.deploy.outputs.stage == 'dev' && github.event_name == 'push'
-    # Soft-fail on PRs — results are posted as a PR comment, no red X on the workflow.
-    # E2E remains a hard failure on main (staging gate).
-    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    # Staging gate: runs only on push to main (dev), and a failure here is a
+    # hard failure. PR-triggered E2E is handled separately by e2e-on-label.yml.
     permissions:
       contents: read
-      pull-requests: write
       id-token: write
 
     steps:
@@ -976,57 +974,6 @@ jobs:
           name: playwright-report-${{ needs.deploy.outputs.stage }}
           path: apps/client/playwright-report/
           retention-days: 7
-
-      - name: Comment PR with E2E results
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            const output = fs.readFileSync('apps/client/playwright-output.txt', 'utf8');
-
-            // Extract summary line (e.g., "10 passed", "2 failed, 8 passed")
-            const summaryMatch = output.match(/\d+ (?:passed|failed|skipped|flaky)[\s\S]*?(?=\n|$)/);
-            const summary = summaryMatch ? summaryMatch[0].trim() : 'See report for details';
-
-            const passed = '${{ steps.e2e.outcome }}' === 'success';
-            const icon = passed ? '✅' : '❌';
-            const status = passed ? 'Passed' : 'Failed';
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-
-            const body = `${icon} **E2E Tests ${status}**
-
-            **Results:** ${summary}
-            **Preview:** \`https://app.${process.env.PREVIEW_URL}\`
-            **Report:** [Download from artifacts](${runUrl})
-
-            <sub>Tested against preview deployment for PR #${context.issue.number}</sub>`;
-
-            // Find and update existing e2e comment, or create new one
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const existing = comments.find(c => c.body.includes('**E2E Tests'));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                comment_id: existing.id,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body,
-              });
-            }
-        env:
-          PREVIEW_URL: ${{ needs.deploy.outputs.preview-url }}
 
       - name: Fail if E2E tests failed
         if: steps.e2e.outcome == 'failure'


### PR DESCRIPTION
## What

A focused cleanup of `deploy.yml` after the preview cutover (#167). **Staging and prod still run through this workflow**, so this only removes code that is now provably unreachable — nothing that serves a live path.

The `e2e` job runs **only on push to main** (staging gate):
```
if: needs.deploy.outputs.stage == 'dev' && github.event_name == 'push'
```
Everything gated on `github.event_name == 'pull_request'` inside it was dead after the cutover (PR-triggered E2E moved to `e2e-on-label.yml`). Removed:

- The **"Comment PR with E2E results"** github-script step — `if: … github.event_name == 'pull_request'` can never be true inside a push-only job. It also posted a "preview deployment" PR comment that no longer applies.
- `continue-on-error: ${{ github.event_name == 'pull_request' }}` — always `false` here; the intent is a hard failure on the staging gate.
- `pull-requests: write` on the `e2e` job — only the removed comment step used it (least privilege).

Net: 2 insertions, 55 deletions, all inside the `e2e` job.

## Explicitly NOT touched (still live)
- Staging (`push`→`main`→dev) and prod (`push`→`prod`→production) deploy paths.
- The `unlock` orphaned-lock backstop, `notify-production-failure`, and the E2E staging run itself.
- All PR CI gates (`changes`, `core-build`, `typecheck`, `lint`, `test`, `cli-e2e`, `verify-docs-build`, `plan`, `deploy-status`).
- The vestigial-but-harmless `pr_number` matrix field and `is_trusted_context` fork ternary — left alone because changing them means touching the shared `_deploy-env.yml` interface, out of scope for this pass.

## Testing
- YAML parses; `actionlint` clean on the changed section (the one pre-existing `SC2086` note in `core-build` is untouched).
