### PR TITLE
feat(e2e): added test coverage for data-lake

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -29,6 +29,7 @@ on:
           - Profile
           - Tavern
           - Search
+          - Data Lake
           - Skills
         default: All tests
       pr_number:
@@ -197,6 +198,7 @@ jobs:
             "Profile")         PW_ARGS="--project=profile" ;;
             "Tavern")          PW_ARGS="--project=tavern" ;;
             "Search")          PW_ARGS="--project=search" ;;
+            "Data Lake")       PW_ARGS="--project=data-lake" ;;
             "Skills")          PW_ARGS="--project=skills" ;;
             *)                 echo "Unknown test selection: '$TEST_PROJECT' — running full suite" ;;
           esac

--- a/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
@@ -70,6 +70,7 @@ const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps)
 
   return (
     <Box
+      data-testid="taxonomy-tag-card"
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -132,10 +133,22 @@ const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps)
       {/* Actions */}
       {!isEditing && (
         <Stack direction="row" gap={0}>
-          <IconButton size="sm" variant="plain" color="neutral" onClick={() => setIsEditing(true)}>
+          <IconButton
+            size="sm"
+            variant="plain"
+            color="neutral"
+            data-testid="taxonomy-tag-edit"
+            onClick={() => setIsEditing(true)}
+          >
             <EditIcon sx={{ fontSize: 14 }} />
           </IconButton>
-          <IconButton size="sm" variant="plain" color="danger" onClick={() => onDelete(tag.name)}>
+          <IconButton
+            size="sm"
+            variant="plain"
+            color="danger"
+            data-testid="taxonomy-tag-delete"
+            onClick={() => onDelete(tag.name)}
+          >
             <DeleteOutlineIcon sx={{ fontSize: 14 }} />
           </IconButton>
         </Stack>

--- a/apps/client/app/components/datalake/DataLakeTree.tsx
+++ b/apps/client/app/components/datalake/DataLakeTree.tsx
@@ -141,6 +141,7 @@ export default function DataLakeTree({
             color="neutral"
             onClick={() => setSortBy(prev => (prev === 'count' ? 'alpha' : 'count'))}
             data-testid="datalake-sort-toggle"
+            data-sort={sortBy}
             sx={{ flexShrink: 0 }}
           >
             <SortByAlphaIcon sx={{ fontSize: 18 }} />

--- a/apps/client/e2e/data-lake.setup.ts
+++ b/apps/client/e2e/data-lake.setup.ts
@@ -1,0 +1,23 @@
+import { setupSpecUser } from './helpers/spec-setup';
+import { apiEnableDataLakes } from './helpers/api';
+import { getTestUsers } from './helpers/test-users';
+
+/**
+ * Data Lakes are gated by the admin-level `EnableDataLakes` setting (default off), so every
+ * `/api/data-lakes/*` endpoint 403s until it's turned on. We flip it once here using the core
+ * admin token (core.setup.ts runs first via the warmup dependency), then seed the data-lake
+ * spec user. The user is granted the `e2e-datalake` tag so it can hold access to a tag-gated
+ * lake in the sharing/permission specs.
+ *
+ * Note: EnableDataLakes is a GLOBAL admin flag — enabling it affects the whole stage for the
+ * duration of the run. It is left on afterwards (idempotent, and other suites don't touch it).
+ */
+setupSpecUser({
+  key: 'dataLake',
+  authFile: 'data-lake-user.json',
+  tags: ['e2e-datalake'],
+  afterCreate: async ({ request }) => {
+    const { admin } = getTestUsers();
+    await apiEnableDataLakes(request, admin.accessToken);
+  },
+});

--- a/apps/client/e2e/data-lake.spec.ts
+++ b/apps/client/e2e/data-lake.spec.ts
@@ -95,7 +95,7 @@ test.describe('Data Lake - management panel', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Group A/B/M — Create wizard (drive the steps we can without a live S3/vectorize upload)
+// Create wizard (drive the steps we can without a live S3/vectorize upload)
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Data Lake - create wizard', () => {
   test('step gating: Next is disabled until files are selected, enabled after', async ({ dataLakePage }) => {
@@ -129,7 +129,7 @@ test.describe('Data Lake - create wizard', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Group G — Append mode
+// Append mode
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Data Lake - append mode', () => {
   test('add-files wizard opens titled for the target lake', async ({ request, dataLakePage }) => {
@@ -148,7 +148,7 @@ test.describe('Data Lake - append mode', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Group I — Lifecycle (archive → deleted → purge) through the UI
+// Lifecycle (archive → deleted → purge) through the UI
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Data Lake - lifecycle', () => {
   test('archive moves the lake to the Archived section', async ({ request, dataLakePage }) => {
@@ -193,7 +193,7 @@ test.describe('Data Lake - lifecycle', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Group H — Settings modal (rename + gate can't-clear rule)
+// Settings modal (rename + gate can't-clear rule)
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Data Lake - settings', () => {
   test('rename a lake via the settings modal', async ({ request, dataLakePage }) => {
@@ -248,7 +248,7 @@ test.describe('Data Lake - settings', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Group J — Viewer
+// Viewer
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Data Lake - viewer', () => {
   test('opens the viewer with a filterable tree', async ({ request, dataLakePage }) => {

--- a/apps/client/e2e/data-lake.spec.ts
+++ b/apps/client/e2e/data-lake.spec.ts
@@ -20,6 +20,21 @@ import { getTestUsers } from './helpers/test-users';
 const RUN = Date.now().toString().slice(-6);
 const FIXTURE = path.resolve(__dirname, 'fixtures/uploads/recipe.txt');
 
+/**
+ * Build an in-memory upload whose content is unique per (RUN, label). Upload dedup is
+ * scoped per-user by content hash (see /api/files/check-duplicates), NOT per-lake, so
+ * success-path upload tests that reused the shared FIXTURE poisoned each other: the first
+ * upload registered the hash and every later one got "All files are duplicates (skipped)".
+ * Appending a unique marker gives each test a distinct hash. Use FIXTURE (verbatim) only
+ * where a duplicate is intentional (the conflict-resolution test) or nothing is uploaded
+ * (taxonomy/source steps).
+ */
+function uniqueUpload(label: string): { name: string; mimeType: string; buffer: Buffer }[] {
+  const bytes = fs.readFileSync(FIXTURE);
+  const buffer = Buffer.concat([bytes, Buffer.from(`\n# e2e-unique ${RUN} ${label}\n`)]);
+  return [{ name: `recipe-${label}-${RUN}.txt`, mimeType: 'text/plain', buffer }];
+}
+
 // Track every lake created via API so we can purge them regardless of which test made them.
 const created: string[] = [];
 
@@ -355,7 +370,7 @@ test.describe('Data Lake - create wizard (full upload)', () => {
 
     await dataLakePage.openManagerFromHome();
     await dataLakePage.startCreate();
-    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.selectFiles(uniqueUpload('full'));
     await dataLakePage.advanceToConfig();
 
     await dataLakePage.fillMuiInput(dataLakePage.configNameInput, name);
@@ -367,16 +382,13 @@ test.describe('Data Lake - create wizard (full upload)', () => {
     expect(lake, 'created lake should be listed').toBeTruthy();
   });
 
-  test('DL-E5: access-tag + entitlement gates set via the wizard persist on the lake', async ({
-    request,
-    dataLakePage,
-  }) => {
+  test('access-tag + entitlement gates set via the wizard persist on the lake', async ({ request, dataLakePage }) => {
     test.setTimeout(3 * TIMEOUTS.TEST);
     const name = `E2E Create Gated ${RUN}`;
 
     await dataLakePage.openManagerFromHome();
     await dataLakePage.startCreate();
-    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.selectFiles(uniqueUpload('gated'));
     await dataLakePage.advanceToConfig();
 
     await dataLakePage.fillMuiInput(dataLakePage.configNameInput, name);
@@ -399,7 +411,7 @@ test.describe('Data Lake - create wizard (full upload)', () => {
     );
   });
 
-  test('DL-E2: selecting a file that already exists surfaces the conflict-resolution UI', async ({
+  test('selecting a file that already exists surfaces the conflict-resolution UI', async ({
     request,
     dataLakePage,
   }) => {
@@ -431,7 +443,7 @@ test.describe('Data Lake - create wizard (full upload)', () => {
 // Group D — Taxonomy tag editing
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Data Lake - taxonomy', () => {
-  test('DL-D2: deleting a suggested tag removes it from the list', async ({ dataLakePage }) => {
+  test('deleting a suggested tag removes it from the list', async ({ dataLakePage }) => {
     test.setTimeout(3 * TIMEOUTS.TEST);
 
     await dataLakePage.openManagerFromHome();
@@ -449,7 +461,7 @@ test.describe('Data Lake - taxonomy', () => {
 // Group G — Append: full upload into an existing lake
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Data Lake - append (full upload)', () => {
-  test('DL-G1: uploads a file into an existing lake (no taxonomy step)', async ({ request, dataLakePage }) => {
+  test('uploads a file into an existing lake (no taxonomy step)', async ({ request, dataLakePage }) => {
     test.setTimeout(2 * TIMEOUTS.TEST);
     const lake = await seedLake(request, ownerToken(), {
       name: `E2E Append Full ${RUN}`,
@@ -458,7 +470,7 @@ test.describe('Data Lake - append (full upload)', () => {
 
     await dataLakePage.openManagerFromHome();
     await dataLakePage.startAppend(lake.id);
-    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.selectFiles(uniqueUpload('appendf'));
     await dataLakePage.advanceToConfig(); // append skips taxonomy; config is pre-filled + locked
     await dataLakePage.startUploadAndWaitComplete();
   });
@@ -468,7 +480,7 @@ test.describe('Data Lake - append (full upload)', () => {
 // Group J — Viewer / explorer article (seeded via API to avoid the upload pipeline)
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Data Lake - explorer article', () => {
-  test('DL-J6: "Ask about" an article prefills chat and navigates to a new session', async ({
+  test('"Ask about" an article prefills chat and navigates to a new session', async ({
     request,
     dataLakePage,
     page,
@@ -487,7 +499,7 @@ test.describe('Data Lake - explorer article', () => {
     await expect(page).toHaveURL(/\/new/, { timeout: TIMEOUTS.NAVIGATION });
   });
 
-  test('DL-J2: the sort toggle flips sort state', async ({ request, dataLakePage }) => {
+  test('the sort toggle flips sort state', async ({ request, dataLakePage }) => {
     const lake = await seedLake(request, ownerToken(), {
       name: `E2E Sort ${RUN}`,
       fileTagPrefix: `e2esort${RUN}:`,

--- a/apps/client/e2e/data-lake.spec.ts
+++ b/apps/client/e2e/data-lake.spec.ts
@@ -345,8 +345,8 @@ test.describe('Data Lake - sharing & permissions', () => {
     request,
   }) => {
     // The seeded owner is in a personal context only, so promotion to organization visibility
-    // has no target org and the server rejects it. (Full cross-org member-visibility is a
-    // multi-org fixture not modeled here — see data-lake.scenarios.md N1/N10.)
+    // has no target org and the server rejects it. (Full cross-org member-visibility needs a
+    // multi-org fixture not modeled here.)
     const lake = await seedLake(request, ownerToken(), {
       name: `E2E OrgShare ${RUN}`,
       fileTagPrefix: `e2eorg${RUN}:`,
@@ -512,9 +512,9 @@ test.describe('Data Lake - explorer article', () => {
     await dataLakePage.gotoDataLakes();
     await expect(dataLakePage.sortToggle).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
 
-    // No dedicated hook for sort state; the Joy IconButton variant flips plain -> soft on toggle.
-    await expect(dataLakePage.sortToggle).toHaveClass(/variantPlain/);
+    // Sort state is exposed via the stable data-sort attribute (defaults to count, flips to alpha).
+    await expect(dataLakePage.sortToggle).toHaveAttribute('data-sort', 'count');
     await dataLakePage.sortToggle.click();
-    await expect(dataLakePage.sortToggle).toHaveClass(/variantSoft/);
+    await expect(dataLakePage.sortToggle).toHaveAttribute('data-sort', 'alpha');
   });
 });

--- a/apps/client/e2e/data-lake.spec.ts
+++ b/apps/client/e2e/data-lake.spec.ts
@@ -167,6 +167,7 @@ test.describe('Data Lake - append mode', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('Data Lake - lifecycle', () => {
   test('archive moves the lake to the Archived section', async ({ request, dataLakePage }) => {
+    test.setTimeout(2 * TIMEOUTS.TEST);
     const lake = await seedLake(request, ownerToken(), {
       name: `E2E Archive ${RUN}`,
       fileTagPrefix: `e2earch${RUN}:`,

--- a/apps/client/e2e/data-lake.spec.ts
+++ b/apps/client/e2e/data-lake.spec.ts
@@ -1,0 +1,507 @@
+import fs from 'fs';
+import crypto from 'crypto';
+import path from 'path';
+import { test, expect } from './fixtures';
+import { TIMEOUTS } from './constants';
+import {
+  apiCreateDataLake,
+  apiCreateFile,
+  apiDeleteDataLake,
+  apiListDataLakes,
+  apiListDataLakesStatus,
+  apiLakeLifecycle,
+  apiSeedLakeArticle,
+  apiUpdateDataLake,
+  apiSetDataLakeVisibility,
+  type DataLake,
+} from './helpers/api';
+import { getTestUsers } from './helpers/test-users';
+
+const RUN = Date.now().toString().slice(-6);
+const FIXTURE = path.resolve(__dirname, 'fixtures/uploads/recipe.txt');
+
+// Track every lake created via API so we can purge them regardless of which test made them.
+const created: string[] = [];
+
+function ownerToken(): string {
+  const { specUsers } = getTestUsers();
+  const owner = specUsers.dataLake;
+  if (!owner) throw new Error('data-lake spec user missing — data-lake.setup.ts must run first');
+  return owner.accessToken;
+}
+
+async function seedLake(
+  request: Parameters<typeof apiCreateDataLake>[0],
+  token: string,
+  overrides: Parameters<typeof apiCreateDataLake>[2]
+): Promise<DataLake> {
+  const lake = await apiCreateDataLake(request, token, overrides);
+  created.push(lake.id);
+  return lake;
+}
+
+/** Look up a lake the wizard created (by exact name), register it for teardown, and return it. */
+async function trackLakeByName(
+  request: Parameters<typeof apiListDataLakes>[0],
+  token: string,
+  name: string
+): Promise<DataLake | undefined> {
+  const lakes = await apiListDataLakes(request, token);
+  const lake = lakes.find(l => l.name === name);
+  if (lake) created.push(lake.id);
+  return lake;
+}
+
+test.afterAll(async ({ request }) => {
+  const token = ownerToken();
+  for (const id of created) {
+    await apiDeleteDataLake(request, token, id);
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Feature gating (smoke that setup enabled EnableDataLakes)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - feature gate', () => {
+  test('list endpoint is enabled for the owner (setup flipped EnableDataLakes)', async ({ request }) => {
+    const status = await apiListDataLakesStatus(request, ownerToken());
+    expect(status).toBe(200);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// List panel & management UI
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - management panel', () => {
+  test('opens the manager and lists a seeded lake with its tag-prefix chip', async ({ request, dataLakePage }) => {
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E List ${RUN}`,
+      fileTagPrefix: `e2elist${RUN}:`,
+    });
+
+    await dataLakePage.openManagerFromHome();
+
+    const card = dataLakePage.card(lake.id);
+    await expect(card).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+    await expect(card).toContainText(`E2E List ${RUN}`);
+    await expect(card).toContainText(`e2elist${RUN}:`);
+  });
+
+  test('Create button opens the wizard', async ({ dataLakePage }) => {
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.startCreate();
+    await expect(dataLakePage.wizardModal).toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group A/B/M — Create wizard (drive the steps we can without a live S3/vectorize upload)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - create wizard', () => {
+  test('step gating: Next is disabled until files are selected, enabled after', async ({ dataLakePage }) => {
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.startCreate();
+
+    // 5-step CREATE order shown in the indicator.
+    await expect(dataLakePage.wizardStepIndicator).toBeVisible();
+
+    // Source step: no files -> Next disabled.
+    await expect(dataLakePage.wizardNextBtn).toBeDisabled();
+
+    // Select a file -> Next enables and advances the wizard off the source step.
+    // (A flat, single-file selection has no folder structure to review, so the wizard
+    // skips the preview step straight to AI Taxonomy — assert we advanced, not the
+    // specific next step.)
+    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.wizardNext();
+    await expect(dataLakePage.wizardSourceStep).toBeHidden({ timeout: TIMEOUTS.VISIBLE });
+  });
+
+  test('closing with loaded files prompts the unsaved-progress confirm', async ({ dataLakePage }) => {
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.startCreate();
+    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.wizardNext();
+
+    await dataLakePage.closeWizardAcceptingConfirm();
+    await expect(dataLakePage.wizardModal).toBeHidden({ timeout: TIMEOUTS.MODAL });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group G — Append mode
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - append mode', () => {
+  test('add-files wizard opens titled for the target lake', async ({ request, dataLakePage }) => {
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Append ${RUN}`,
+      fileTagPrefix: `e2eappend${RUN}:`,
+    });
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.startAppend(lake.id);
+
+    // Header reads "Add Files — <name>" (em-dash); match loosely to avoid dash-char pitfalls.
+    await expect(dataLakePage.wizardModal).toContainText('Add Files', { timeout: TIMEOUTS.MODAL });
+    await expect(dataLakePage.wizardModal).toContainText(`E2E Append ${RUN}`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group I — Lifecycle (archive → deleted → purge) through the UI
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - lifecycle', () => {
+  test('archive moves the lake to the Archived section', async ({ request, dataLakePage }) => {
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Archive ${RUN}`,
+      fileTagPrefix: `e2earch${RUN}:`,
+    });
+
+    await dataLakePage.openManagerFromHome();
+    await expect(dataLakePage.card(lake.id)).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+
+    await dataLakePage.archive(lake.id);
+    await dataLakePage.expandArchived();
+    await expect(dataLakePage.page.getByTestId(`datalake-archived-section-card-${lake.id}`)).toBeVisible({
+      timeout: TIMEOUTS.VISIBLE,
+    });
+  });
+
+  test('purge confirmation dialog appears and irreversibly removes a deleted lake', async ({
+    request,
+    dataLakePage,
+  }) => {
+    // Fast-path the lake into the recoverable-deleted state via API, then purge through the UI.
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Purge ${RUN}`,
+      fileTagPrefix: `e2epurge${RUN}:`,
+    });
+    expect(await apiLakeLifecycle(request, ownerToken(), lake.id, 'archive')).toBe(200);
+    expect(await apiLakeLifecycle(request, ownerToken(), lake.id, 'delete')).toBe(200);
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.expandDeleted();
+    await expect(dataLakePage.page.getByTestId(`datalake-deleted-section-card-${lake.id}`)).toBeVisible({
+      timeout: TIMEOUTS.VISIBLE,
+    });
+
+    await dataLakePage.purge(lake.id);
+    await expect(dataLakePage.page.getByTestId(`datalake-deleted-section-card-${lake.id}`)).toBeHidden({
+      timeout: TIMEOUTS.ACTION,
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group H — Settings modal (rename + gate can't-clear rule)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - settings', () => {
+  test('rename a lake via the settings modal', async ({ request, dataLakePage }) => {
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Rename ${RUN}`,
+      fileTagPrefix: `e2eren${RUN}:`,
+    });
+    const renamed = `E2E Renamed ${RUN}`;
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.openSettings(lake.id);
+
+    await dataLakePage.fillSettingsField('datalake-settings-name', renamed);
+    await dataLakePage.saveSettings();
+    await dataLakePage.waitForToast('Data lake updated');
+
+    await expect(dataLakePage.card(lake.id)).toContainText(renamed, { timeout: TIMEOUTS.VISIBLE });
+  });
+
+  test('an existing access gate cannot be cleared from settings (warning + kept)', async ({
+    request,
+    dataLakePage,
+  }) => {
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Gate ${RUN}`,
+      fileTagPrefix: `e2egate${RUN}:`,
+      requiredUserTag: 'e2e-datalake',
+    });
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.openSettings(lake.id);
+
+    // Blank the previously-set access tag and save — the backend rejects clearing, and the
+    // UI warns that the existing tag was kept.
+    await dataLakePage.fillSettingsField('datalake-settings-usertag', '');
+    await dataLakePage.saveSettings();
+    await dataLakePage.waitForToast('not cleared');
+  });
+
+  test('org visibility is disabled in a personal (non-team) context', async ({ request, dataLakePage }) => {
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Vis ${RUN}`,
+      fileTagPrefix: `e2evis${RUN}:`,
+    });
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.openSettings(lake.id);
+
+    // The seeded spec user has no team org, so promotion to "Organization" is not offered.
+    await expect(dataLakePage.orgVisibilityRadioInput).toBeDisabled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group J — Viewer
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - viewer', () => {
+  test('opens the viewer with a filterable tree', async ({ request, dataLakePage }) => {
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Viewer ${RUN}`,
+      fileTagPrefix: `e2eview${RUN}:`,
+    });
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.openViewer(lake.id);
+
+    await expect(dataLakePage.viewer).toBeVisible();
+    await expect(dataLakePage.viewerTree).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+
+    // The filter input is present and accepts input (empty lake shows no categories).
+    await dataLakePage.searchViewer('nothing-matches-this');
+    await expect(dataLakePage.viewer).toContainText(/No matches|No categories|No files/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group N — Sharing & permissions (server-side boundary, asserted via API tokens)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - sharing & permissions', () => {
+  test('a private lake is not visible to another user', async ({ request }) => {
+    const { manager } = getTestUsers();
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Private ${RUN}`,
+      fileTagPrefix: `e2epriv${RUN}:`,
+    });
+
+    const ownerLakes = await apiListDataLakes(request, ownerToken());
+    expect(ownerLakes.map(l => l.id)).toContain(lake.id);
+
+    const managerLakes = await apiListDataLakes(request, manager.accessToken);
+    expect(managerLakes.map(l => l.id)).not.toContain(lake.id);
+  });
+
+  test('a tag-gated lake is hidden from a user without the required tag', async ({ request }) => {
+    const { manager } = getTestUsers();
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E TagGate ${RUN}`,
+      fileTagPrefix: `e2etag${RUN}:`,
+      requiredUserTag: `e2e-nobody-${RUN}`,
+    });
+
+    const managerLakes = await apiListDataLakes(request, manager.accessToken);
+    expect(managerLakes.map(l => l.id)).not.toContain(lake.id);
+  });
+
+  test('an entitlement-gated lake is hidden from a user without the entitlement', async ({ request }) => {
+    const { manager } = getTestUsers();
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E EntGate ${RUN}`,
+      fileTagPrefix: `e2eent${RUN}:`,
+      requiredEntitlement: `e2e:only-${RUN}`,
+    });
+
+    const managerLakes = await apiListDataLakes(request, manager.accessToken);
+    expect(managerLakes.map(l => l.id)).not.toContain(lake.id);
+  });
+
+  test('a non-owner cannot archive or update a lake they do not own', async ({ request }) => {
+    const { manager } = getTestUsers();
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E NoControl ${RUN}`,
+      fileTagPrefix: `e2enoctl${RUN}:`,
+    });
+
+    const archiveStatus = await apiLakeLifecycle(request, manager.accessToken, lake.id, 'archive');
+    expect(archiveStatus).toBeGreaterThanOrEqual(400);
+
+    const updateStatus = await apiUpdateDataLake(request, manager.accessToken, lake.id, { name: 'hijacked' });
+    expect(updateStatus).toBeGreaterThanOrEqual(400);
+  });
+
+  test('sharing a lake to an organization requires a team context (rejected in personal scope)', async ({
+    request,
+  }) => {
+    // The seeded owner is in a personal context only, so promotion to organization visibility
+    // has no target org and the server rejects it. (Full cross-org member-visibility is a
+    // multi-org fixture not modeled here — see data-lake.scenarios.md N1/N10.)
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E OrgShare ${RUN}`,
+      fileTagPrefix: `e2eorg${RUN}:`,
+    });
+    const status = await apiSetDataLakeVisibility(request, ownerToken(), lake.id, 'organization');
+    expect(status).toBeGreaterThanOrEqual(400);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group A/E — Full create-to-upload through the wizard UI
+// (Upload "complete" fires when the S3 puts finish — it does NOT wait for
+// vectorization — so this is fast with a small file. Taxonomy runs a real AI call.)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - create wizard (full upload)', () => {
+  test('creates a lake end-to-end: source -> taxonomy -> config -> upload complete', async ({
+    request,
+    dataLakePage,
+  }) => {
+    test.setTimeout(3 * TIMEOUTS.TEST);
+    const name = `E2E Create Full ${RUN}`;
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.startCreate();
+    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.advanceToConfig();
+
+    await dataLakePage.fillMuiInput(dataLakePage.configNameInput, name);
+    await dataLakePage.fillMuiInput(dataLakePage.configTagPrefixInput, `e2efull${RUN}:`);
+    await dataLakePage.startUploadAndWaitComplete();
+
+    // The lake now exists server-side.
+    const lake = await trackLakeByName(request, ownerToken(), name);
+    expect(lake, 'created lake should be listed').toBeTruthy();
+  });
+
+  test('DL-E5: access-tag + entitlement gates set via the wizard persist on the lake', async ({
+    request,
+    dataLakePage,
+  }) => {
+    test.setTimeout(3 * TIMEOUTS.TEST);
+    const name = `E2E Create Gated ${RUN}`;
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.startCreate();
+    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.advanceToConfig();
+
+    await dataLakePage.fillMuiInput(dataLakePage.configNameInput, name);
+    await dataLakePage.fillMuiInput(dataLakePage.configTagPrefixInput, `e2egated${RUN}:`);
+    await dataLakePage.fillMuiInput(dataLakePage.configAccessTagInput, 'e2e-datalake');
+    await dataLakePage.fillMuiInput(dataLakePage.configEntitlementInput, `e2e:pro-${RUN}`);
+    await dataLakePage.startUploadAndWaitComplete();
+
+    const lake = await trackLakeByName(request, ownerToken(), name);
+    expect(lake, 'gated lake should be listed').toBeTruthy();
+
+    // Reopen its settings and confirm the gates were persisted.
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.openSettings(lake!.id);
+    await expect(dataLakePage.settingsModal.getByTestId('datalake-settings-usertag').locator('input')).toHaveValue(
+      'e2e-datalake'
+    );
+    await expect(dataLakePage.settingsModal.getByTestId('datalake-settings-entitlement').locator('input')).toHaveValue(
+      `e2e:pro-${RUN}`
+    );
+  });
+
+  test('DL-E2: selecting a file that already exists surfaces the conflict-resolution UI', async ({
+    request,
+    dataLakePage,
+  }) => {
+    test.setTimeout(2 * TIMEOUTS.TEST);
+
+    // Seed a FabFile whose content hash matches the fixture, so the config-step dedup check
+    // (which hashes the selected file and calls /api/files/check-duplicates) flags it.
+    const bytes = fs.readFileSync(FIXTURE);
+    const contentHash = crypto.createHash('sha256').update(bytes).digest('hex');
+    await apiCreateFile(request, ownerToken(), {
+      fileName: `dup-seed-${RUN}.txt`,
+      content: bytes.toString('utf-8'),
+      contentHash,
+    });
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.startCreate();
+    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.advanceToConfig();
+
+    // Duplicate detected -> the conflict-resolution controls render.
+    await expect(dataLakePage.configStep).toContainText(/Duplicate File Handling|already exist/i, {
+      timeout: TIMEOUTS.ACTION,
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group D — Taxonomy tag editing
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - taxonomy', () => {
+  test('DL-D2: deleting a suggested tag removes it from the list', async ({ dataLakePage }) => {
+    test.setTimeout(3 * TIMEOUTS.TEST);
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.startCreate();
+    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.advanceToTaxonomy();
+
+    const before = await dataLakePage.deleteFirstTaxonomyTag();
+    expect(before).toBeGreaterThan(0);
+    await expect(dataLakePage.taxonomyTagCards).toHaveCount(before - 1, { timeout: TIMEOUTS.VISIBLE });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group G — Append: full upload into an existing lake
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - append (full upload)', () => {
+  test('DL-G1: uploads a file into an existing lake (no taxonomy step)', async ({ request, dataLakePage }) => {
+    test.setTimeout(2 * TIMEOUTS.TEST);
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Append Full ${RUN}`,
+      fileTagPrefix: `e2eappf${RUN}:`,
+    });
+
+    await dataLakePage.openManagerFromHome();
+    await dataLakePage.startAppend(lake.id);
+    await dataLakePage.selectFiles([FIXTURE]);
+    await dataLakePage.advanceToConfig(); // append skips taxonomy; config is pre-filled + locked
+    await dataLakePage.startUploadAndWaitComplete();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group J — Viewer / explorer article (seeded via API to avoid the upload pipeline)
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe('Data Lake - explorer article', () => {
+  test('DL-J6: "Ask about" an article prefills chat and navigates to a new session', async ({
+    request,
+    dataLakePage,
+    page,
+  }) => {
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E AskAbout ${RUN}`,
+      fileTagPrefix: `e2eask${RUN}:`,
+    });
+    const fileId = await apiSeedLakeArticle(request, ownerToken(), lake, {
+      fileName: `ask-about-${RUN}.txt`,
+      content: 'Sinigang is a sour Filipino soup made with tamarind, pork, and vegetables.',
+    });
+
+    await dataLakePage.gotoArticle(fileId);
+    await dataLakePage.askAboutBtn.click();
+    await expect(page).toHaveURL(/\/new/, { timeout: TIMEOUTS.NAVIGATION });
+  });
+
+  test('DL-J2: the sort toggle flips sort state', async ({ request, dataLakePage }) => {
+    const lake = await seedLake(request, ownerToken(), {
+      name: `E2E Sort ${RUN}`,
+      fileTagPrefix: `e2esort${RUN}:`,
+    });
+    // Two articles so the tree has content to sort.
+    await apiSeedLakeArticle(request, ownerToken(), lake, { fileName: `sort-a-${RUN}.txt`, content: 'alpha one' });
+    await apiSeedLakeArticle(request, ownerToken(), lake, { fileName: `sort-b-${RUN}.txt`, content: 'beta two' });
+
+    await dataLakePage.gotoDataLakes();
+    await expect(dataLakePage.sortToggle).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+
+    // No dedicated hook for sort state; the Joy IconButton variant flips plain -> soft on toggle.
+    await expect(dataLakePage.sortToggle).toHaveClass(/variantPlain/);
+    await dataLakePage.sortToggle.click();
+    await expect(dataLakePage.sortToggle).toHaveClass(/variantSoft/);
+  });
+});

--- a/apps/client/e2e/fixtures.ts
+++ b/apps/client/e2e/fixtures.ts
@@ -16,6 +16,7 @@ import { ProfilePage } from './pages/ProfilePage';
 import { AgentsPage } from './pages/AgentsPage';
 import { AdminPage } from './pages/AdminPage';
 import { TavernPage } from './pages/TavernPage';
+import { DataLakePage } from './pages/DataLakePage';
 import { SkillsPage } from './pages/SkillsPage';
 import { getTestUsers } from './helpers/test-users';
 
@@ -41,6 +42,7 @@ type TestFixtures = {
   agentsPage: AgentsPage;
   adminPage: AdminPage;
   tavernPage: TavernPage;
+  dataLakePage: DataLakePage;
   skillsPage: SkillsPage;
   loginAsAdmin: () => Promise<void>;
   loginAsUser: (user: { accessToken: string; refreshToken: string }) => Promise<void>;
@@ -113,6 +115,10 @@ export const test = base.extend<TestFixtures>({
 
   tavernPage: async ({ page }, use) => {
     await use(new TavernPage(page));
+  },
+
+  dataLakePage: async ({ page }, use) => {
+    await use(new DataLakePage(page));
   },
 
   skillsPage: async ({ page }, use) => {

--- a/apps/client/e2e/helpers/api.ts
+++ b/apps/client/e2e/helpers/api.ts
@@ -1,5 +1,6 @@
 import { type APIRequestContext } from '@playwright/test';
 import { Resource } from 'sst';
+import crypto from 'crypto';
 
 interface LoginResponse {
   accessToken: string;
@@ -164,7 +165,15 @@ export async function apiGetOtcCode(request: APIRequestContext, email: string): 
 export async function apiCreateFile(
   request: APIRequestContext,
   token: string,
-  params: { fileName: string; content: string; mimeType?: string }
+  params: {
+    fileName: string;
+    content: string;
+    mimeType?: string;
+    /** Tag the file (e.g. a data lake's datalakeTag) so it surfaces as a lake article. */
+    tags?: { name: string; strength?: number }[];
+    /** Explicit content hash — set to sha256Hex(content) to make the file a dedup match. */
+    contentHash?: string;
+  }
 ): Promise<string> {
   const baseURL = process.env.API_URL || 'http://localhost:3000';
   const response = await request.post(`${baseURL}/api/files/createFabFile`, {
@@ -175,6 +184,8 @@ export async function apiCreateFile(
       fileSize: Buffer.byteLength(params.content, 'utf-8'),
       type: 'FILE',
       content: params.content,
+      ...(params.tags ? { tags: params.tags.map(t => ({ name: t.name, strength: t.strength ?? 1 })) } : {}),
+      ...(params.contentHash ? { contentHash: params.contentHash } : {}),
     },
   });
 
@@ -184,6 +195,30 @@ export async function apiCreateFile(
 
   const body = await response.json();
   return body.id || body._id;
+}
+
+/** SHA-256 hex of a string — matches the client-side hash the dedup check computes over file bytes. */
+export function sha256Hex(content: string): string {
+  return crypto.createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+/**
+ * Seed a file directly INTO a lake by tagging it with the lake's datalakeTag, so it shows up as
+ * an article without driving the (heavy) upload wizard. Pass `contentHash` to also make it a
+ * dedup match for a wizard upload of the same content.
+ */
+export async function apiSeedLakeArticle(
+  request: APIRequestContext,
+  token: string,
+  lake: { datalakeTag: string },
+  params: { fileName: string; content: string; contentHash?: string }
+): Promise<string> {
+  return apiCreateFile(request, token, {
+    fileName: params.fileName,
+    content: params.content,
+    contentHash: params.contentHash,
+    tags: [{ name: lake.datalakeTag, strength: 1 }],
+  });
 }
 
 export async function apiUpdateAdminSetting(
@@ -270,6 +305,177 @@ export async function apiUpdateUser(
   if (!response.ok()) {
     throw new Error(`Update user failed: ${response.status()} ${response.statusText()}`);
   }
+}
+
+// ── Data Lakes ────────────────────────────────────────────────────────────────
+// Helpers for the data-lake E2E suite. The feature is gated by the EnableDataLakes
+// admin setting (default off) — enable it once in setup with an admin token, then
+// pre-seed / tear down lakes via these instead of driving the (heavy) upload wizard.
+
+export interface DataLake {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string;
+  fileTagPrefix: string;
+  requiredUserTag?: string;
+  requiredEntitlement?: string;
+  organizationId?: string;
+  datalakeTag: string;
+  fileCount?: number;
+  createdAt: string;
+}
+
+/** Turn a display name into a schema-valid slug (lowercase alphanumeric + hyphens, 2–60 chars). */
+export function toDataLakeSlug(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+  // Schema requires min length 2 and no leading/trailing hyphen.
+  return slug.length >= 2 ? slug : `dl-${slug}`;
+}
+
+/** Enable the admin-gated EnableDataLakes feature flag (idempotent). Requires an admin token. */
+export async function apiEnableDataLakes(request: APIRequestContext, adminToken: string): Promise<void> {
+  await apiUpdateAdminSetting(request, adminToken, 'EnableDataLakes', true);
+}
+
+export async function apiCreateDataLake(
+  request: APIRequestContext,
+  token: string,
+  params: {
+    name: string;
+    /** Defaults to a slug derived from `name`. Must be lowercase alphanumeric + hyphens. */
+    slug?: string;
+    /** Must end with ":" (e.g. "e2e:"). Defaults to a prefix derived from the slug. */
+    fileTagPrefix?: string;
+    description?: string;
+    requiredUserTag?: string;
+    requiredEntitlement?: string;
+    organizationId?: string;
+  }
+): Promise<DataLake> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const slug = params.slug ?? toDataLakeSlug(params.name);
+  const fileTagPrefix = params.fileTagPrefix ?? `${slug.replace(/-/g, '').slice(0, 20) || 'e2e'}:`;
+  const response = await request.post(`${baseURL}/api/data-lakes`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      name: params.name,
+      slug,
+      fileTagPrefix,
+      ...(params.description ? { description: params.description } : {}),
+      ...(params.requiredUserTag ? { requiredUserTag: params.requiredUserTag } : {}),
+      ...(params.requiredEntitlement ? { requiredEntitlement: params.requiredEntitlement } : {}),
+      ...(params.organizationId ? { organizationId: params.organizationId } : {}),
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Create data lake failed: ${response.status()} ${response.statusText()}`);
+  }
+
+  const body = await response.json();
+  return { ...body, id: body.id || body._id } as DataLake;
+}
+
+/** List active data lakes accessible to the caller. */
+export async function apiListDataLakes(request: APIRequestContext, token: string): Promise<DataLake[]> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const response = await request.get(`${baseURL}/api/data-lakes`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok()) {
+    throw new Error(`List data lakes failed: ${response.status()} ${response.statusText()}`);
+  }
+  const body = await response.json();
+  return body.data as DataLake[];
+}
+
+/** Raw status of the list endpoint for a token — used to assert the gate (403 when the feature is off). */
+export async function apiListDataLakesStatus(request: APIRequestContext, token: string): Promise<number> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const response = await request.get(`${baseURL}/api/data-lakes`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return response.status();
+}
+
+/** Raw GET of a lake's articles — asserts the SERVER-side access boundary (403/404) for a given token. */
+export async function apiGetDataLakeArticlesStatus(
+  request: APIRequestContext,
+  token: string,
+  dataLakeId: string
+): Promise<number> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const response = await request.get(`${baseURL}/api/data-lakes/${dataLakeId}/articles`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return response.status();
+}
+
+export type DataLakeLifecycleAction = 'archive' | 'unarchive' | 'restore' | 'delete' | 'cleanup';
+
+/** Drive a lake lifecycle transition. Returns the response status (so callers can assert 403 for non-owners). */
+export async function apiLakeLifecycle(
+  request: APIRequestContext,
+  token: string,
+  dataLakeId: string,
+  action: DataLakeLifecycleAction
+): Promise<number> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const response = await request.post(`${baseURL}/api/data-lakes/${dataLakeId}/lifecycle`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { action },
+  });
+  return response.status();
+}
+
+export async function apiSetDataLakeVisibility(
+  request: APIRequestContext,
+  token: string,
+  dataLakeId: string,
+  visibility: 'private' | 'organization',
+  organizationId?: string
+): Promise<number> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const response = await request.post(`${baseURL}/api/data-lakes/${dataLakeId}/visibility`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { visibility, ...(organizationId ? { organizationId } : {}) },
+  });
+  return response.status();
+}
+
+export async function apiUpdateDataLake(
+  request: APIRequestContext,
+  token: string,
+  dataLakeId: string,
+  fields: { name?: string; description?: string; requiredUserTag?: string; requiredEntitlement?: string }
+): Promise<number> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const response = await request.put(`${baseURL}/api/data-lakes/${dataLakeId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: fields,
+  });
+  return response.status();
+}
+
+/**
+ * Best-effort teardown for a created lake. Tries the hard DELETE first; if the env only
+ * exposes lifecycle transitions, falls back to soft-delete → cleanup (purge). Never throws
+ * so an afterAll cleanup can't fail a green run.
+ */
+export async function apiDeleteDataLake(request: APIRequestContext, token: string, dataLakeId: string): Promise<void> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const del = await request
+    .delete(`${baseURL}/api/data-lakes/${dataLakeId}`, { headers: { Authorization: `Bearer ${token}` } })
+    .catch(() => null);
+  if (del && del.ok()) return;
+  // Fallback: soft-delete then irreversible purge.
+  await apiLakeLifecycle(request, token, dataLakeId, 'delete').catch(() => 0);
+  await apiLakeLifecycle(request, token, dataLakeId, 'cleanup').catch(() => 0);
 }
 
 interface SkillSeed {

--- a/apps/client/e2e/helpers/api.ts
+++ b/apps/client/e2e/helpers/api.ts
@@ -463,17 +463,12 @@ export async function apiUpdateDataLake(
 }
 
 /**
- * Best-effort teardown for a created lake. Tries the hard DELETE first; if the env only
- * exposes lifecycle transitions, falls back to soft-delete → cleanup (purge). Never throws
- * so an afterAll cleanup can't fail a green run.
+ * Best-effort teardown for a created lake. Purges via the lifecycle: soft-delete (phase 1)
+ * then irreversible cleanup (phase 2). The DELETE route only *archives* (reversible), which
+ * would leave test lakes accumulating on the shared stage, so we drive the purge directly.
+ * Never throws so an afterAll cleanup can't fail a green run.
  */
 export async function apiDeleteDataLake(request: APIRequestContext, token: string, dataLakeId: string): Promise<void> {
-  const baseURL = process.env.API_URL || 'http://localhost:3000';
-  const del = await request
-    .delete(`${baseURL}/api/data-lakes/${dataLakeId}`, { headers: { Authorization: `Bearer ${token}` } })
-    .catch(() => null);
-  if (del && del.ok()) return;
-  // Fallback: soft-delete then irreversible purge.
   await apiLakeLifecycle(request, token, dataLakeId, 'delete').catch(() => 0);
   await apiLakeLifecycle(request, token, dataLakeId, 'cleanup').catch(() => 0);
 }

--- a/apps/client/e2e/helpers/test-users.ts
+++ b/apps/client/e2e/helpers/test-users.ts
@@ -42,6 +42,7 @@ const SPEC_KEYS = [
   'profile',
   'tavern',
   'search',
+  'dataLake',
   'skills',
 ];
 

--- a/apps/client/e2e/pages/BasePage.ts
+++ b/apps/client/e2e/pages/BasePage.ts
@@ -143,7 +143,11 @@ export class BasePage {
     // Wait for the SPA to fully hydrate before checking for modals.
     // domcontentloaded fires when HTML is parsed, but React hasn't mounted yet.
     // 'load' waits for all sub-resources (scripts, styles) so the SPA is interactive.
-    await this.page.waitForLoadState('load');
+    // Bound this wait: under parallel load a preview's 'load' event can lag well past a minute,
+    // which would hang here forever. Cap at NAVIGATION and continue - the per-page readiness
+    // assertions (e.g. an explorer/panel toBeVisible) are the real gate, and every modal handler
+    // below already probes defensively, so proceeding before 'load' is safe.
+    await this.page.waitForLoadState('load', { timeout: TIMEOUTS.NAVIGATION }).catch(() => {});
     // Clear the AUP/ToS consent gate first - while it's up, the app chrome (and every other
     // modal) isn't mounted, so this must run before we probe for the What's New / verification modals.
     await this.handleAcceptPoliciesInterstitial();

--- a/apps/client/e2e/pages/DataLakePage.ts
+++ b/apps/client/e2e/pages/DataLakePage.ts
@@ -1,0 +1,314 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { TIMEOUTS } from '../constants';
+import { BasePage } from './BasePage';
+
+/**
+ * Page object for the Data Lakes surface: the `/data-lakes` explorer, the management
+ * panel (list + lifecycle), the create/append wizard, the settings modal, and the
+ * lake viewer. Selectors mirror the data-testid attributes in
+ * `app/components/datalake/*` and `app/components/DataLakeWizard/*`.
+ */
+export class DataLakePage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  // ── Explorer / manager ──────────────────────────────────────────────────
+  get manageBtn(): Locator {
+    return this.page.getByTestId('datalake-manage-btn');
+  }
+  get listPanel(): Locator {
+    return this.page.getByTestId('datalake-list-panel');
+  }
+  get createBtn(): Locator {
+    return this.listPanel.getByRole('button', { name: 'Create' });
+  }
+
+  // ── Wizard ────────────────────────────────────────────────────────────────
+  get wizardModal(): Locator {
+    return this.page.getByTestId('data-lake-wizard-modal');
+  }
+  get wizardSourceStep(): Locator {
+    return this.page.getByTestId('wizard-source-step');
+  }
+  get wizardNextBtn(): Locator {
+    return this.page.getByTestId('wizard-next-btn');
+  }
+  get wizardStartUploadBtn(): Locator {
+    return this.page.getByTestId('wizard-start-upload-btn');
+  }
+  get wizardStepIndicator(): Locator {
+    return this.page.getByTestId('wizard-step-indicator');
+  }
+  get selectFilesInput(): Locator {
+    // The two hidden inputs are the folder input (first) and the plain multi-file input (last).
+    return this.wizardSourceStep.locator('input[type="file"]').last();
+  }
+
+  // ── Settings modal ──────────────────────────────────────────────────────
+  get settingsModal(): Locator {
+    return this.page.getByTestId('datalake-settings-modal');
+  }
+
+  // ── Viewer ─────────────────────────────────────────────────────────────
+  get viewer(): Locator {
+    return this.page.getByTestId('datalake-viewer');
+  }
+  get viewerSearch(): Locator {
+    return this.viewer.getByPlaceholder('Filter...');
+  }
+  /** The tag tree scoped to the viewer modal (the explorer behind it renders its own). */
+  get viewerTree(): Locator {
+    return this.viewer.getByTestId('datalake-tree');
+  }
+
+  // ── Navigation ────────────────────────────────────────────────────────────
+
+  /** Open the `/data-lakes` explorer home and clear startup modals. */
+  async gotoDataLakes() {
+    await this.page.goto('/data-lakes');
+    await this.dismissModals();
+    await expect(this.page.getByTestId('opti-datalake-explorer')).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+  }
+
+  /** From the explorer, open the management panel (list of lakes + lifecycle). */
+  async openManager() {
+    await this.manageBtn.click();
+    await expect(this.listPanel).toBeVisible({ timeout: TIMEOUTS.MODAL });
+  }
+
+  /** Convenience: land on `/data-lakes` and open the manager panel. */
+  async openManagerFromHome() {
+    await this.gotoDataLakes();
+    await this.openManager();
+  }
+
+  // ── Card lookups (by lake id) ────────────────────────────────────────────
+  card(id: string): Locator {
+    return this.page.getByTestId(`datalake-card-${id}`);
+  }
+  addFilesBtn(id: string): Locator {
+    return this.page.getByTestId(`datalake-addfiles-btn-${id}`);
+  }
+  settingsBtn(id: string): Locator {
+    return this.page.getByTestId(`datalake-settings-btn-${id}`);
+  }
+  archiveBtn(id: string): Locator {
+    return this.page.getByTestId(`datalake-archive-btn-${id}`);
+  }
+
+  // ── Wizard flows ──────────────────────────────────────────────────────────
+
+  /** Open the create wizard from the manager panel. */
+  async startCreate() {
+    await this.createBtn.click();
+    await expect(this.wizardModal).toBeVisible({ timeout: TIMEOUTS.MODAL });
+    await expect(this.wizardSourceStep).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+  }
+
+  /** Open the append ("Add files") wizard for an existing lake. */
+  async startAppend(id: string) {
+    await this.addFilesBtn(id).click();
+    await expect(this.wizardModal).toBeVisible({ timeout: TIMEOUTS.MODAL });
+  }
+
+  /** Attach files to the wizard's plain (non-folder) file input. */
+  async selectFiles(filePaths: string[]) {
+    await this.selectFilesInput.setInputFiles(filePaths);
+  }
+
+  async wizardNext() {
+    await expect(this.wizardNextBtn).toBeEnabled({ timeout: TIMEOUTS.ELEMENT_STATE });
+    await this.wizardNextBtn.click();
+  }
+
+  // ── Wizard step content ──────────────────────────────────────────────────
+  get configStep(): Locator {
+    return this.page.getByTestId('wizard-config-step');
+  }
+  get taxonomyStep(): Locator {
+    return this.page.getByTestId('wizard-taxonomy-step');
+  }
+  get uploadStep(): Locator {
+    return this.page.getByTestId('wizard-upload-step');
+  }
+  get configNameInput(): Locator {
+    return this.page.getByTestId('config-name-input').locator('input');
+  }
+  /** Config-step inputs have no testids; locate them by placeholder within the config step. */
+  get configTagPrefixInput(): Locator {
+    return this.configStep.getByPlaceholder('e.g. legal:');
+  }
+  get configAccessTagInput(): Locator {
+    return this.configStep.getByPlaceholder('e.g. LegalTeam');
+  }
+  get configEntitlementInput(): Locator {
+    return this.configStep.getByPlaceholder('e.g. product:pro');
+  }
+  get taxonomyTagCards(): Locator {
+    return this.taxonomyStep.getByTestId('taxonomy-tag-card');
+  }
+
+  /**
+   * Click Next until the Config step is reached. Handles the Taxonomy step, whose Next stays
+   * disabled until AI analysis completes (waited for with the AI_RESPONSE budget), and the
+   * Preview step (auto-skipped for flat file selections).
+   */
+  async advanceToConfig() {
+    for (let i = 0; i < 6; i++) {
+      if (await this.configStep.isVisible().catch(() => false)) return;
+      await expect(this.wizardNextBtn).toBeEnabled({ timeout: TIMEOUTS.AI_RESPONSE });
+      await this.wizardNextBtn.click();
+    }
+    await expect(this.configStep).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+  }
+
+  /** Wait for the taxonomy step's AI analysis to finish (tag cards rendered, Next enabled). */
+  async waitForTaxonomyReady() {
+    await expect(this.taxonomyStep).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+    await expect(this.taxonomyTagCards.first()).toBeVisible({ timeout: TIMEOUTS.AI_RESPONSE });
+  }
+
+  /**
+   * Click Next until the Taxonomy step is reached and its analysis has finished. The Preview
+   * step (auto-skipped for flat file selections) is clicked through if it appears. We check
+   * visibility BEFORE clicking so we stop ON taxonomy rather than advancing past it to Config.
+   */
+  async advanceToTaxonomy() {
+    for (let i = 0; i < 4; i++) {
+      if (await this.taxonomyStep.isVisible().catch(() => false)) {
+        await this.waitForTaxonomyReady();
+        return;
+      }
+      await expect(this.wizardNextBtn).toBeEnabled({ timeout: TIMEOUTS.AI_RESPONSE });
+      await this.wizardNextBtn.click();
+    }
+    await this.waitForTaxonomyReady();
+  }
+
+  /** Delete the first taxonomy tag card and return the card count before deletion. */
+  async deleteFirstTaxonomyTag(): Promise<number> {
+    const before = await this.taxonomyTagCards.count();
+    await this.taxonomyStep.getByTestId('taxonomy-tag-delete').first().click();
+    return before;
+  }
+
+  /**
+   * Start the upload and wait for it to reach the completed state (fires when the S3 puts
+   * finish — it does NOT wait for vectorization). Races the success toast against an error
+   * toast so a create/batch/upload failure fails fast with the server message instead of
+   * timing out on the success matcher. Uses the AI_RESPONSE budget because presign + S3 puts
+   * can exceed the 30s ACTION window on a loaded stage.
+   */
+  async startUploadAndWaitComplete() {
+    await expect(this.wizardStartUploadBtn).toBeEnabled({ timeout: TIMEOUTS.ELEMENT_STATE });
+    await this.wizardStartUploadBtn.click();
+
+    const success = this.page.locator('[data-sonner-toast]').filter({ hasText: /uploaded successfully|uploaded,/ });
+    const errorToast = this.page.locator('[data-sonner-toast][data-type="error"]');
+
+    const outcome = await Promise.race([
+      success
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.AI_RESPONSE })
+        .then(() => 'success' as const)
+        .catch(() => 'timeout' as const),
+      errorToast
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.AI_RESPONSE })
+        .then(() => 'error' as const)
+        .catch(() => 'timeout' as const),
+    ]);
+
+    if (outcome === 'error') {
+      const message = await errorToast
+        .first()
+        .innerText()
+        .catch(() => '(could not read toast)');
+      throw new Error(`Data lake upload failed: ${message}`);
+    }
+    await expect(success).toBeVisible({ timeout: TIMEOUTS.POST_ACTION });
+  }
+
+  // ── Explorer article (deep-linked) ────────────────────────────────────────
+  get article(): Locator {
+    return this.page.getByTestId('datalake-article');
+  }
+  get askAboutBtn(): Locator {
+    return this.page.getByTestId('datalake-ask-about');
+  }
+  get sortToggle(): Locator {
+    return this.page.getByTestId('datalake-sort-toggle');
+  }
+
+  /** Open a lake article directly via the explorer's deep-link search param. */
+  async gotoArticle(fabFileId: string) {
+    await this.page.goto(`/data-lakes?article=${fabFileId}`);
+    await this.dismissModals();
+    await expect(this.article).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+  }
+
+  /** Close the wizard via the footer Cancel, accepting the unsaved-progress confirm dialog. */
+  async closeWizardAcceptingConfirm() {
+    this.page.once('dialog', dialog => dialog.accept());
+    await this.wizardModal.getByRole('button', { name: 'Cancel' }).click();
+  }
+
+  // ── Settings ──────────────────────────────────────────────────────────────
+
+  async openSettings(id: string) {
+    await this.settingsBtn(id).click();
+    await expect(this.settingsModal).toBeVisible({ timeout: TIMEOUTS.MODAL });
+  }
+
+  /**
+   * Fill a MUI Joy field in the settings modal. The data-testid sits on the Joy Input
+   * wrapper, so we target the inner native <input> — calling the value setter on the
+   * wrapper div throws "Illegal invocation".
+   */
+  async fillSettingsField(testid: string, value: string) {
+    await this.fillMuiInput(this.settingsModal.getByTestId(testid).locator('input'), value);
+  }
+
+  /** Inner radio <input> of the "Organization" visibility option (for enabled/disabled checks). */
+  get orgVisibilityRadioInput(): Locator {
+    return this.settingsModal.getByTestId('datalake-settings-visibility-org').locator('input');
+  }
+
+  async saveSettings() {
+    await this.settingsModal.getByTestId('datalake-settings-save-btn').click();
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  async archive(id: string) {
+    await this.archiveBtn(id).click();
+    await expect(this.card(id)).toBeHidden({ timeout: TIMEOUTS.VISIBLE });
+  }
+
+  async expandArchived() {
+    await this.page.getByTestId('datalake-archived-section-toggle').click();
+  }
+
+  async expandDeleted() {
+    await this.page.getByTestId('datalake-deleted-section-toggle').click();
+  }
+
+  /** From the Deleted section, purge a lake permanently (through the confirm dialog). */
+  async purge(id: string) {
+    await this.page.getByTestId(`datalake-purge-btn-${id}`).click();
+    const confirm = this.page.getByTestId('datalake-purge-confirm');
+    await expect(confirm).toBeVisible({ timeout: TIMEOUTS.MODAL });
+    await this.page.getByTestId('datalake-purge-confirm-btn').click();
+  }
+
+  // ── Viewer ─────────────────────────────────────────────────────────────
+
+  /** Open a lake's viewer by clicking its card. */
+  async openViewer(id: string) {
+    await this.card(id).click();
+    await expect(this.viewer).toBeVisible({ timeout: TIMEOUTS.MODAL });
+  }
+
+  async searchViewer(query: string) {
+    await this.viewerSearch.fill(query);
+  }
+}

--- a/apps/client/e2e/pages/DataLakePage.ts
+++ b/apps/client/e2e/pages/DataLakePage.ts
@@ -66,7 +66,11 @@ export class DataLakePage extends BasePage {
 
   /** Open the `/data-lakes` explorer home and clear startup modals. */
   async gotoDataLakes() {
-    await this.page.goto('/data-lakes');
+    // Navigate on 'domcontentloaded', not the default 'load'. Under parallel load the preview's
+    // heavy SPA bundles can delay the 'load' event 60s+, hanging goto() on about:blank even though
+    // the shell responds in ~2s and the app is otherwise fine. The explorer-visible assertion below
+    // is the real readiness gate, so we don't need to block navigation on full 'load'.
+    await this.page.goto('/data-lakes', { waitUntil: 'domcontentloaded' });
     await this.dismissModals();
     await expect(this.page.getByTestId('opti-datalake-explorer')).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
   }
@@ -281,7 +285,33 @@ export class DataLakePage extends BasePage {
 
   async archive(id: string) {
     await this.archiveBtn(id).click();
-    await expect(this.card(id)).toBeHidden({ timeout: TIMEOUTS.VISIBLE });
+
+    // Archive cancels in-flight batches and soft-hides files server-side, then invalidates and
+    // refetches the active-lakes query before the card leaves the list. On a loaded stage that
+    // round-trip exceeds the VISIBLE budget, so gate on the success toast first (racing an error
+    // toast so a real archive failure fails fast with the server message instead of timing out on
+    // toBeHidden), then assert the card is gone on the larger ACTION budget.
+    const success = this.page.locator('[data-sonner-toast]').filter({ hasText: 'Data lake archived' });
+    const errorToast = this.page.locator('[data-sonner-toast][data-type="error"]');
+    const outcome = await Promise.race([
+      success
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.ACTION })
+        .then(() => 'success' as const)
+        .catch(() => 'timeout' as const),
+      errorToast
+        .waitFor({ state: 'visible', timeout: TIMEOUTS.ACTION })
+        .then(() => 'error' as const)
+        .catch(() => 'timeout' as const),
+    ]);
+    if (outcome === 'error') {
+      const message = await errorToast
+        .first()
+        .innerText()
+        .catch(() => '(could not read toast)');
+      throw new Error(`Data lake archive failed: ${message}`);
+    }
+
+    await expect(this.card(id)).toBeHidden({ timeout: TIMEOUTS.ACTION });
   }
 
   async expandArchived() {

--- a/apps/client/e2e/pages/DataLakePage.ts
+++ b/apps/client/e2e/pages/DataLakePage.ts
@@ -113,8 +113,8 @@ export class DataLakePage extends BasePage {
   }
 
   /** Attach files to the wizard's plain (non-folder) file input. */
-  async selectFiles(filePaths: string[]) {
-    await this.selectFilesInput.setInputFiles(filePaths);
+  async selectFiles(files: string[] | { name: string; mimeType: string; buffer: Buffer }[]) {
+    await this.selectFilesInput.setInputFiles(files);
   }
 
   async wizardNext() {

--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -65,6 +65,12 @@ const specProjects = [
     auth: './e2e/.auth/search-user.json',
   },
   {
+    name: 'data-lake',
+    setupMatch: /(?:^|\/)data-lake\.setup\.ts$/,
+    testMatch: /(?:^|\/)data-lake\.spec\.ts$/,
+    auth: './e2e/.auth/data-lake-user.json',
+  },
+  {
     name: 'skills',
     setupMatch: /(?:^|\/)skills\.setup\.ts$/,
     testMatch: /(?:^|\/)skills\.spec\.ts$/,
@@ -73,31 +79,31 @@ const specProjects = [
   // AI latency suites: only included when AI_LATENCY_RUN=true (e2e-ai-latency workflow)
   ...(process.env.AI_LATENCY_RUN === 'true'
     ? [
-        {
-          name: 'ai-latency-short-answers',
-          setupMatch: /(?:^|\/)ai-latency-short-answers\.setup\.ts$/,
-          testMatch: /(?:^|\/)ai-latency-short-answers\.spec\.ts$/,
-          auth: './e2e/.auth/ai-latency-short-answers-user.json',
-        },
-        {
-          name: 'ai-latency-long-answers',
-          setupMatch: /(?:^|\/)ai-latency-long-answers\.setup\.ts$/,
-          testMatch: /(?:^|\/)ai-latency-long-answers\.spec\.ts$/,
-          auth: './e2e/.auth/ai-latency-long-answers-user.json',
-        },
-        {
-          name: 'ai-latency-tool-prompts',
-          setupMatch: /(?:^|\/)ai-latency-tool-prompts\.setup\.ts$/,
-          testMatch: /(?:^|\/)ai-latency-tool-prompts\.spec\.ts$/,
-          auth: './e2e/.auth/ai-latency-tool-prompts-user.json',
-        },
-        {
-          name: 'ai-latency-intermediate-tools',
-          setupMatch: /(?:^|\/)ai-latency-intermediate-tools\.setup\.ts$/,
-          testMatch: /(?:^|\/)ai-latency-intermediate-tools\.spec\.ts$/,
-          auth: './e2e/.auth/ai-latency-intermediate-tools-user.json',
-        },
-      ]
+      {
+        name: 'ai-latency-short-answers',
+        setupMatch: /(?:^|\/)ai-latency-short-answers\.setup\.ts$/,
+        testMatch: /(?:^|\/)ai-latency-short-answers\.spec\.ts$/,
+        auth: './e2e/.auth/ai-latency-short-answers-user.json',
+      },
+      {
+        name: 'ai-latency-long-answers',
+        setupMatch: /(?:^|\/)ai-latency-long-answers\.setup\.ts$/,
+        testMatch: /(?:^|\/)ai-latency-long-answers\.spec\.ts$/,
+        auth: './e2e/.auth/ai-latency-long-answers-user.json',
+      },
+      {
+        name: 'ai-latency-tool-prompts',
+        setupMatch: /(?:^|\/)ai-latency-tool-prompts\.setup\.ts$/,
+        testMatch: /(?:^|\/)ai-latency-tool-prompts\.spec\.ts$/,
+        auth: './e2e/.auth/ai-latency-tool-prompts-user.json',
+      },
+      {
+        name: 'ai-latency-intermediate-tools',
+        setupMatch: /(?:^|\/)ai-latency-intermediate-tools\.setup\.ts$/,
+        testMatch: /(?:^|\/)ai-latency-intermediate-tools\.spec\.ts$/,
+        auth: './e2e/.auth/ai-latency-intermediate-tools-user.json',
+      },
+    ]
     : []),
 ];
 
@@ -176,16 +182,16 @@ export default defineConfig({
     // short-answers test user/auth so it sees the same modal a latency spec would.
     ...(process.env.AI_LATENCY_RUN === 'true'
       ? [
-          {
-            name: 'ai-latency-discover',
-            use: {
-              ...devices['Desktop Chrome'],
-              storageState: './e2e/.auth/ai-latency-short-answers-user.json',
-            },
-            dependencies: ['setup-ai-latency-short-answers'],
-            testMatch: [/(?:^|\/)ai-latency-discover\.spec\.ts$/],
+        {
+          name: 'ai-latency-discover',
+          use: {
+            ...devices['Desktop Chrome'],
+            storageState: './e2e/.auth/ai-latency-short-answers-user.json',
           },
-        ]
+          dependencies: ['setup-ai-latency-short-answers'],
+          testMatch: [/(?:^|\/)ai-latency-discover\.spec\.ts$/],
+        },
+      ]
       : []),
   ],
 });


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
**Local Run**
<img width="1905" height="1071" alt="Screenshot 2026-07-07 at 5 36 33 PM" src="https://github.com/user-attachments/assets/0731f8b4-5f8b-4d92-97b4-a4b6dd09f04c" />

<img width="1905" height="1071" alt="Screenshot 2026-07-07 at 5 36 43 PM" src="https://github.com/user-attachments/assets/6826c597-3579-4db5-8fad-64a7e60f51d0" />



## Description

Adds end-to-end Playwright coverage for the Data Lake feature and wires it into the manual E2E CI workflow as its own `data-lake` project.

The suite exercises the feature through the UI where it matters (the create wizard: source -> AI taxonomy -> config -> upload) and via API helpers where it does not (seeding lakes, articles, and files directly), so slow paths stay fast and isolated. It covers feature gating, the create/append wizard flows, taxonomy tag editing, lifecycle, settings, sharing & permissions, and the explorer/viewer.

It also fixes a test-isolation defect surfaced while running the suite: upload dedup is scoped **per-user by content hash** (`/api/files/check-duplicates`), not per-lake. The success-path upload tests all reused a single shared fixture, so the first upload registered that content hash and every later upload of the same bytes failed with *"All files are duplicates (skipped)."* Each upload test now sends unique content.

## Changes

- **Test suite (`apps/client/e2e/`)**
  - `data-lake.spec.ts` - full spec: feature gating, create wizard (source -> taxonomy -> config -> upload), append mode, lifecycle, settings, sharing & permissions, taxonomy tag editing, and the explorer article/viewer.
  - `pages/DataLakePage.ts` - page object for wizard navigation, file selection, upload completion (races the success toast against an error toast so failures surface fast with the server message), settings, and article deep-linking.
  - `helpers/api.ts` - API helpers to seed/list/update/archive lakes, seed articles, set visibility, and create files directly.
  - `data-lake.setup.ts`, `helpers/test-users.ts`, `fixtures.ts` - a dedicated authenticated data-lake test user and fixtures.
  - `playwright.config.ts` - registers the `data-lake` project.
- **CI (`.github/workflows/e2e-manual.yml`)**
  - Adds **Data Lake** to the manual E2E test selector (`--project=data-lake`).
- **Product test hooks (`app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx`)**
  - Adds `data-testid` attributes (`taxonomy-tag-card`, `taxonomy-tag-edit`, `taxonomy-tag-delete`) to taxonomy tag cards. Selection hooks only - no behavioral change.
- **Test-isolation fix**
  - Added a `uniqueUpload(label)` helper that appends a per-run, per-label marker to the fixture bytes and feeds it as an in-memory Playwright payload, giving each upload test a distinct content hash.
  - Widened `DataLakePage.selectFiles()` to accept in-memory `{ name, mimeType, buffer }` payloads alongside file paths.
  - Removed internal `DL-XX:` prefixes from test descriptions for cleaner reporter output.

## Guide for Testers

These tests run against a deployed stage that has the E2E test endpoints enabled (non-production only). Test on the **preview** stage (`pr239`), not staging: the newly added `data-testid` attributes are not yet deployed to staging - only to the preview environment.

1. Get the E2E cleanup secret. This is **not yet set up in the bike4mind repo**, so run it from the **Lumina5** repo: `./for-env dev npx sst secret list --stage pr239 | grep E2E_CLEANUP_SECRET`. Copy the value and save it into `apps/client/.env.e2e` as `E2E_CLEANUP_SECRET=<value>`. Expected: the command prints the `E2E_CLEANUP_SECRET=...` line, and `.env.e2e` now contains it.
2. From the repo root, authenticate to AWS for the preview stage: run `aws sso login --profile bike4mind-previews` and complete the browser login. Expected: `Successfully logged into Start URL`.
3. Run the suite against the preview stage: `AWS_PROFILE=bike4mind-previews pnpm sst shell --stage pr239 -- pnpm --filter client run test:e2e -- data-lake.spec.ts`. Expected: the `data-lake` spec runs to completion with all tests passing and no `duplicates (skipped)` errors.
4. (Optional) To watch it interactively, use the UI runner instead: `AWS_PROFILE=bike4mind-previews pnpm sst shell --stage pr239 -- pnpm --filter client run test:e2e:ui -- data-lake.spec.ts`. Expected: the Playwright UI opens filtered to the data-lake spec; running all shows green.
5. (CI) In GitHub Actions, open the **Manual E2E** workflow, choose **Data Lake** in the test selector. **Note: this cannot currently run against a preview environment on CI** - the run fails with `Unexpected error occurred. Please run with --print-logs or check .sst/log/sst.log if available.` This is expected for now (see Additional Information). CI runs against preview are blocked until the cleanup-secret retrieval is moved into the bike4mind repo.

### Regression Checks
1. Run the create wizard end-to-end test and confirm a lake is created and listed server-side after upload completes.
2. Run the conflict-resolution test and confirm that selecting a file whose content hash already exists still surfaces the duplicate-handling UI (this path intentionally reuses the shared fixture).
3. Confirm taxonomy tag edit/delete still work in the wizard (the new `data-testid`s are additive and must not change rendering or behavior).

### What NOT to test
- This PR adds test coverage, one CI selector option, and additive `data-testid` attributes. There are no user-facing product behavior changes to validate beyond the flows the tests already assert.

## Additional Information

- **Preview runs on CI are currently blocked.** Running the suite against a preview environment on CI fails with `Unexpected error occurred. Please run with --print-logs or check .sst/log/sst.log if available.` The likely cause is two-fold: (1) the cleanup-secret retrieval still lives in the **Lumina5** repo rather than bike4mind, and (2) the `E2E_CLEANUP_SECRET` **rotates per preview environment** - each preview gets its own value - whereas staging's does not rotate. Until the secret retrieval is moved into the bike4mind repo (and CI can resolve the per-preview rotated value), preview runs must be done **locally** following steps 1-4 above; staging is not an option yet because the new `data-testid`s are only deployed to preview.
- Upload dedup is per-user by content hash, not per-lake. Any future upload test that must succeed with a fresh file should use `uniqueUpload(...)`; tests that intentionally trigger a duplicate should keep using the shared fixture verbatim.
- The suite mixes UI and API paths deliberately: UI for the wizard flows that carry the risk, API helpers for seeding so setup stays fast and deterministic.

## Developer Notes (Optional)

- **Reusable pattern**: `uniqueUpload(label)` produces content-unique, in-memory upload payloads keyed per run/label - the pattern to follow for any content-hash-dedup-sensitive upload test.
- **New Extension Point**: `DataLakePage.selectFiles()` now accepts in-memory `{ name, mimeType, buffer }` payloads as well as file paths, so tests can vary upload content without on-disk fixtures.
- **Reusable pattern**: `startUploadAndWaitComplete()` races the success toast against an error toast, so upload failures fail fast with the server message instead of timing out on the success matcher.

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A (test-only + additive test hooks)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A

