### PR TITLE
fix(client): cap email test-mode fan-out to one send per test address

### DIFF
--- a/apps/client/app/components/admin/email/EmailJobDetail.tsx
+++ b/apps/client/app/components/admin/email/EmailJobDetail.tsx
@@ -838,9 +838,10 @@ export default function EmailJobDetail({ jobId, onBack }: EmailJobDetailProps) {
                       </FormControl>
 
                       <Alert color="warning" variant="soft">
-                        Test Mode is enabled. Emails will be composed as if sending to{' '}
-                        {recipientPreviewData?.eligibleCount || 0} recipients, but will be delivered to the test address
-                        instead.
+                        Test Mode is enabled.{' '}
+                        {Math.min(recipientPreviewData?.eligibleCount || 0, parseTestEmails().length)} test email(s)
+                        will be sent (one per test address below), composed using real recipient data for a
+                        personalization preview.
                       </Alert>
                     </>
                   )}
@@ -982,9 +983,9 @@ export default function EmailJobDetail({ jobId, onBack }: EmailJobDetailProps) {
                   {/* Recipient count reminder */}
                   {recipientPreviewData && (
                     <Alert color="primary" variant="soft">
-                      Will send to {recipientPreviewData.eligibleCount} recipients
-                      {formData.isTestMode &&
-                        ` (test mode - will redirect to ${parseTestEmails().length} test address(es))`}
+                      {formData.isTestMode
+                        ? `Will send ${Math.min(recipientPreviewData.eligibleCount, parseTestEmails().length)} test email(s) (one per test address)`
+                        : `Will send to ${recipientPreviewData.eligibleCount} recipients`}
                     </Alert>
                   )}
 

--- a/apps/client/server/queueHandlers/emailJobOrchestrator.test.ts
+++ b/apps/client/server/queueHandlers/emailJobOrchestrator.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { buildTestRecipients, type Recipient } from './emailJobOrchestrator';
+
+function makeRecipients(count: number): Recipient[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `user-${i}`,
+    type: 'user' as const,
+    email: `real${i}@example.com`,
+  }));
+}
+
+describe('buildTestRecipients', () => {
+  it('sends exactly one email per test address, not one per real recipient', () => {
+    const realRecipients = makeRecipients(20);
+    const testRecipients = ['test@example.com'];
+
+    const result = buildTestRecipients(realRecipients, testRecipients);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].email).toBe('test@example.com');
+  });
+
+  it('pairs each test address with a distinct real recipient for personalization', () => {
+    const realRecipients = makeRecipients(5);
+    const testRecipients = ['a@example.com', 'b@example.com', 'c@example.com'];
+
+    const result = buildTestRecipients(realRecipients, testRecipients);
+
+    expect(result).toHaveLength(3);
+    expect(result.map(r => r.email)).toEqual(['a@example.com', 'b@example.com', 'c@example.com']);
+    expect(result.map(r => r.originalRecipient)).toEqual([
+      'real0@example.com',
+      'real1@example.com',
+      'real2@example.com',
+    ]);
+    expect(result.every(r => r.isTestEmail)).toBe(true);
+  });
+
+  it('caps at the number of real recipients when there are more test addresses than real recipients', () => {
+    const realRecipients = makeRecipients(2);
+    const testRecipients = ['a@example.com', 'b@example.com', 'c@example.com'];
+
+    const result = buildTestRecipients(realRecipients, testRecipients);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('normalizes test email addresses', () => {
+    const realRecipients = makeRecipients(1);
+    const testRecipients = ['  Test@Example.com  '];
+
+    const result = buildTestRecipients(realRecipients, testRecipients);
+
+    expect(result[0].email).toBe('test@example.com');
+  });
+
+  it('returns an empty list when there are no real recipients', () => {
+    expect(buildTestRecipients([], ['test@example.com'])).toEqual([]);
+  });
+});

--- a/apps/client/server/queueHandlers/emailJobOrchestrator.ts
+++ b/apps/client/server/queueHandlers/emailJobOrchestrator.ts
@@ -38,7 +38,7 @@ const JobStartPayload = z.object({
 const EMAILS_PER_BATCH = 25; // Number of emails per SQS message/batch
 const SQS_BATCH_SIZE = 10; // Max SQS messages per SendMessageBatch call (AWS limit)
 
-interface Recipient {
+export interface Recipient {
   id: string;
   type: 'user' | 'subscriber' | 'direct';
   email: string;
@@ -110,24 +110,10 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
         ? await buildRecipientListForUserIds(userIds, logger)
         : await buildRecipientListFromFilter(effectiveRecipientFilter, logger);
 
+      recipients = buildTestRecipients(realRecipients, testRecipients);
       logger.info(
-        `Test mode: ${realRecipients.length} real recipients, redirecting to ${testRecipients.length} test addresses`
+        `Test mode: ${realRecipients.length} real recipients, sending ${recipients.length} email(s) to ${testRecipients.length} test address(es)`
       );
-
-      // Create test recipients with original recipient tracking
-      // Preserve original recipient ID and type so we can look up user data for personalization
-      recipients = [];
-      for (let i = 0; i < realRecipients.length; i++) {
-        const realRecipient = realRecipients[i];
-        const testEmail = testRecipients[i % testRecipients.length]; // Round-robin test addresses
-        recipients.push({
-          id: realRecipient.id, // Preserve original ID for user data lookup
-          type: realRecipient.type, // Preserve type (user/subscriber) for correct data fetch
-          email: testEmail.toLowerCase().trim(), // Actual delivery address is the test email
-          originalRecipient: realRecipient.email, // Track original for display/personalization
-          isTestEmail: true,
-        });
-      }
     }
     // Option 2: Specific userIds provided (partial send)
     else if (userIds?.length) {
@@ -224,6 +210,28 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     throw error;
   }
 });
+
+// Caps fan-out at the number of test addresses so each test address receives
+// exactly one email, regardless of how large the real audience is.
+// Preserves original recipient ID/type for personalization, paired 1:1 with a test address.
+export function buildTestRecipients(realRecipients: Recipient[], testRecipients: string[]): Recipient[] {
+  const sampleSize = Math.min(realRecipients.length, testRecipients.length);
+  const recipients: Recipient[] = [];
+
+  for (let i = 0; i < sampleSize; i++) {
+    const realRecipient = realRecipients[i];
+    const testEmail = testRecipients[i];
+    recipients.push({
+      id: realRecipient.id,
+      type: realRecipient.type,
+      email: testEmail.toLowerCase().trim(),
+      originalRecipient: realRecipient.email,
+      isTestEmail: true,
+    });
+  }
+
+  return recipients;
+}
 
 async function buildRecipientListFromFilter(
   filter: z.infer<typeof RecipientFilterSchema> | undefined,


### PR DESCRIPTION
## Description

Fixes #45. In Admin -> User Ops -> Email Marketing, enabling **Test Mode** and sending a campaign to a single test address delivered ~20 duplicate copies to that one inbox instead of one.

Root cause: the orchestrator built one send attempt per *real audience member* matching the campaign's recipient filter, then round-robin'd those attempts across the (usually much smaller) list of test addresses. With a 20-person audience and 1 test address, all 20 attempts landed on that same address. Test mode is meant to preview personalization using real recipient data while only ever delivering to the entered test address(es) — it should never fan out more than one email per test address.

## Changes

- `buildTestRecipients()` (new, in [emailJobOrchestrator.ts](apps/client/server/queueHandlers/emailJobOrchestrator.ts)) caps test-mode fan-out at `min(realRecipients.length, testRecipients.length)`, so each test address receives exactly one email, still personalized from a distinct real recipient's data where available.
- Extracted this into a standalone exported function so the fan-out logic is unit-testable without mocking the DB/SQS dependencies of `dispatch`.
- Updated the two "will send to N recipients" alerts in [EmailJobDetail.tsx](apps/client/app/components/admin/email/EmailJobDetail.tsx) so the copy reflects the capped test-mode count instead of implying one email per audience member.
- Added [emailJobOrchestrator.test.ts](apps/client/server/queueHandlers/emailJobOrchestrator.test.ts).

## Guide for Testers

1. Log in as an admin and navigate to "Sidebar -> Admin -> User Ops -> Email Marketing -> Campaigns".
2. Click "New Campaign". Enter a Campaign Name and select any Template.
3. Set the recipient filter to an audience with more than one member (e.g. "All Subscribers", assuming more than 1 exists) so `eligibleCount` > 1.
4. Check "Enable Test Mode". In "Test Email Addresses", enter exactly one address you control. Confirm the field below it reads "1 valid test email(s)".
5. Confirm the warning alert now reads "1 test email(s) will be sent (one per test address below)..." rather than implying it will compose for the full audience.
6. Click "Send Test (Save & Send)".
7. Open the test inbox. Expected result: exactly **one** copy of the campaign email arrives, not one per audience member.
8. Repeat with 2-3 test addresses entered (one per line). Expected result: each test address receives exactly one email (no duplicates), and the "Will send N test email(s)" alert above the send button reflects the number of test addresses (capped by audience size).

<img width="626" height="659" alt="image" src="https://github.com/user-attachments/assets/99e9e340-374e-4f04-b09f-a4ba30b3412d" />

**Regression checks**
- With Test Mode **disabled**, sending to a real recipient filter still creates one send attempt per eligible recipient (unchanged, non-test-mode path).
- Sending to specific `userIds` (no test mode) still behaves as before.

## Additional Information

- `pnpm --filter client typecheck` and `pnpm lint:check` pass.
- New unit tests (`pnpm --filter client exec vitest run server/queueHandlers/emailJobOrchestrator.test.ts`) cover: the reported 20-real/1-test-address bug, multiple test addresses paired with distinct real recipients, more test addresses than real recipients, test-email normalization, and an empty real-recipient list.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
