### PR TITLE
fix(client): gate the Files browser Data Lakes manager entry behind EnableDataLakes

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeListPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeListPanel.test.tsx
@@ -4,14 +4,34 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { DataLakeSettingsModal } from './DataLakeListPanel';
+import DataLakeListPanel, { DataLakeSettingsModal } from './DataLakeListPanel';
 
 const updateMutate = vi.fn();
 const warn = vi.fn();
 
-vi.mock('@client/app/hooks/data/dataLakes', () => ({
-  useUpdateDataLake: () => ({ mutate: updateMutate, isPending: false }),
-  useSetLakeVisibility: () => ({ mutate: vi.fn(), isPending: false }),
+vi.mock('@client/app/hooks/data/dataLakes', () => {
+  const mutation = () => ({ mutate: vi.fn(), isPending: false });
+  return {
+    useUpdateDataLake: () => ({ mutate: updateMutate, isPending: false }),
+    useSetLakeVisibility: () => ({ mutate: vi.fn(), isPending: false }),
+    useArchiveDataLake: mutation,
+    useUnarchiveDataLake: mutation,
+    useRestoreDeletedDataLake: mutation,
+    usePermanentDeleteDataLake: mutation,
+    useCleanupDataLake: mutation,
+    useGetArchivedDataLakes: () => ({ data: undefined }),
+    useGetDeletedDataLakes: () => ({ data: undefined }),
+  };
+});
+
+vi.mock('@client/app/hooks/data/dataLakeWizard', () => ({
+  useDataLakes: () => ({ data: [], isLoading: false }),
+}));
+
+// Default (flag on) is established per-describe; tests override per-case.
+const isFeatureEnabled = vi.fn();
+vi.mock('@client/app/hooks/useAdminSettingsCache', () => ({
+  useAdminSettingsCache: () => ({ isFeatureEnabled }),
 }));
 
 // The settings modal derives org-visibility state from the account switcher (useAccounts),
@@ -105,5 +125,37 @@ describe('DataLakeSettingsModal — clearing an access gate', () => {
     expect(updateMutate).toHaveBeenCalledTimes(1);
     // Unchanged gate is still sent so it's preserved.
     expect(updateMutate.mock.calls[0][0]).toMatchObject({ requiredUserTag: 'Opti' });
+  });
+});
+
+describe('DataLakeListPanel - EnableDataLakes gating', () => {
+  beforeEach(() => {
+    isFeatureEnabled.mockReset();
+    isFeatureEnabled.mockReturnValue(true);
+  });
+
+  it('renders the panel when the feature is on', () => {
+    render(
+      <Wrapper>
+        <DataLakeListPanel />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('datalake-list-panel')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the feature is off (shared choke point for every manager entry)', () => {
+    isFeatureEnabled.mockImplementation((key: string) => key !== 'EnableDataLakes');
+
+    render(
+      <Wrapper>
+        <DataLakeListPanel />
+      </Wrapper>
+    );
+
+    // The panel's lakes queries 403 when the feature is off, and its empty state
+    // is a dead end - so the panel must not render at all, mirroring
+    // SendToDataLakeModal's render guard.
+    expect(screen.queryByTestId('datalake-list-panel')).not.toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/DataLakeWizard/DataLakeListPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeListPanel.tsx
@@ -46,6 +46,7 @@ import {
 } from '@client/app/hooks/data/dataLakes';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import { useAccounts } from '@client/app/components/Credits/AccountSelector';
+import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import { toast } from 'sonner';
 import DataLakeViewer from './DataLakeViewer';
 
@@ -67,8 +68,15 @@ export default function DataLakeListPanel() {
 
   const { data: archivedLakes } = useGetArchivedDataLakes(showArchived);
   const { data: deletedLakes } = useGetDeletedDataLakes(showDeleted);
+  const { isFeatureEnabled } = useAdminSettingsCache();
 
   const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+  // Shared choke point for every manager entry point: with the feature off the
+  // lakes queries 403 and the empty panel is a dead end, so never render - even
+  // if some (future) ungated caller opens the manager. Mirrors the render guard
+  // in SendToDataLakeModal. Placed after all hooks so the hook order is stable.
+  if (!isFeatureEnabled('EnableDataLakes')) return null;
 
   return (
     <>

--- a/apps/client/app/components/Files/Browser/Content.gating.test.tsx
+++ b/apps/client/app/components/Files/Browser/Content.gating.test.tsx
@@ -1,0 +1,79 @@
+import React, { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+/**
+ * Gating coverage for the Files browser's "Data Lakes" upload-menu entry: the
+ * option must be hidden when EnableDataLakes is off - otherwise it opens the
+ * Data Lake manager panel, whose lakes query 403s (FEATURE_DISABLED) and whose
+ * empty state is a dead end. Exercises UploadDropdown (the desktop entry in
+ * Content.tsx); the mobile call site passes the same gated prop.
+ */
+
+vi.mock('@client/app/hooks/data/fabFiles', () => ({
+  useCreateFabFile: () => ({ mutate: vi.fn(), isPending: false }),
+  useBulkDeleteFiles: () => ({ mutate: vi.fn(), isPending: false }),
+  usePaginatedSearchFabFiles: vi.fn(),
+}));
+
+vi.mock('../../Knowledge/CreateKnowledgeFromUrl', () => ({ default: () => null }));
+
+vi.mock('../../Knowledge/KnowledgeModal', () => {
+  const state = { setOpen: vi.fn(), setSelectedFabFileId: vi.fn(), setViewOnly: vi.fn() };
+  return { useKnowledgeModal: (selector: (s: typeof state) => unknown) => selector(state) };
+});
+
+// Default (flag on) is established in beforeEach; tests override per-case.
+const isFeatureEnabled = vi.fn();
+vi.mock('@client/app/hooks/useAdminSettingsCache', () => ({
+  useAdminSettingsCache: () => ({ isFeatureEnabled }),
+}));
+
+import { UploadDropdown } from './Content';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+function renderAndOpenUploadMenu() {
+  render(
+    <TestWrapper>
+      <UploadDropdown isLoading={false} />
+    </TestWrapper>
+  );
+  fireEvent.click(screen.getByRole('combobox'));
+}
+
+describe('UploadDropdown - EnableDataLakes gating', () => {
+  beforeEach(() => {
+    isFeatureEnabled.mockReset();
+    isFeatureEnabled.mockReturnValue(true);
+  });
+
+  it('shows the Data Lakes option when the feature is on', () => {
+    renderAndOpenUploadMenu();
+
+    expect(screen.getByText('Data Lakes')).toBeInTheDocument();
+  });
+
+  it('hides the Data Lakes option when the feature is off', () => {
+    isFeatureEnabled.mockImplementation((key: string) => key !== 'EnableDataLakes');
+
+    renderAndOpenUploadMenu();
+
+    expect(screen.queryByText('Data Lakes')).not.toBeInTheDocument();
+  });
+
+  it('keeps the other upload actions available when the feature is off', () => {
+    isFeatureEnabled.mockImplementation((key: string) => key !== 'EnableDataLakes');
+
+    renderAndOpenUploadMenu();
+
+    expect(screen.getByText('From device')).toBeInTheDocument();
+    expect(screen.getByText('Add from URL')).toBeInTheDocument();
+    expect(screen.getByText('Create Knowledge')).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/Files/Browser/Content.tsx
+++ b/apps/client/app/components/Files/Browser/Content.tsx
@@ -40,6 +40,7 @@ import { MobileSearchFilter } from './MobileSearchFilter';
 import { useAddFilesToProject } from '@client/app/hooks/data/projects';
 import { UploadActionsSelect } from './UploadActionsSelect';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import { useFeatureEnabled } from '@client/app/hooks/useFeatureEnabled';
 import { useWebsocket } from '@client/app/contexts/WebsocketContext';
 import { useQueryClient } from '@tanstack/react-query';
@@ -61,6 +62,10 @@ const FileBrowserContent = () => {
   const isResearchEngineFeatureEnabled = isFeatureEnabled('enableResearchEngine');
 
   const openDataLakeManager = useDataLakeWizardStore(s => s.openManager);
+  // Admin flag (useAdminSettingsCache), distinct from the experimental-features
+  // isFeatureEnabled above: hide the Data Lakes manager entry when the feature is
+  // off, matching the rest of the data-lake surface (CreateDataLakeButton etc).
+  const { isFeatureEnabled: isAdminFeatureEnabled } = useAdminSettingsCache();
 
   // WebSocket subscription for real-time file vectorization updates
   const { subscribeToAction } = useWebsocket();
@@ -472,7 +477,7 @@ const FileBrowserContent = () => {
             onUploadFiles={handleUploadFiles}
             onAddFromUrl={handleAddFromUrl}
             onCreateKnowledge={handleCreateKnowledge}
-            onCreateDataLake={openDataLakeManager}
+            onCreateDataLake={isAdminFeatureEnabled('EnableDataLakes') ? openDataLakeManager : undefined}
             isUploading={createFile.isPending}
           />
 
@@ -890,9 +895,12 @@ const FileBrowserContent = () => {
   );
 };
 
-const UploadDropdown: FC<{ isLoading: boolean }> = ({ isLoading }) => {
+export const UploadDropdown: FC<{ isLoading: boolean }> = ({ isLoading }) => {
   const createFile = useCreateFabFile();
   const openDataLakeManager = useDataLakeWizardStore(s => s.openManager);
+  // Hide the Data Lakes manager entry when the feature is off, matching the rest
+  // of the data-lake surface (CreateDataLakeButton etc).
+  const { isFeatureEnabled } = useAdminSettingsCache();
   const [openUrl, setOpenUrl] = useState(false);
   const [setKnowledgeOpen, setSelectedFabFileId, setViewOnly] = useKnowledgeModal(
     useShallow(state => [state.setOpen, state.setSelectedFabFileId, state.setViewOnly] as const)
@@ -926,7 +934,7 @@ const UploadDropdown: FC<{ isLoading: boolean }> = ({ isLoading }) => {
         onUploadFiles={handleUploadFiles}
         onAddFromUrl={handleAddFromUrl}
         onCreateKnowledge={handleCreateKnowledge}
-        onCreateDataLake={openDataLakeManager}
+        onCreateDataLake={isFeatureEnabled('EnableDataLakes') ? openDataLakeManager : undefined}
         isUploading={createFile.isPending}
         variant="desktop"
       />


### PR DESCRIPTION
# Pull Request

Closes #245

## Description

Follow-up to #196 / #234. With `EnableDataLakes` off, the Files browser's upload-actions dropdown still offered a **"Data Lakes"** option that opened the manager panel — whose lakes query 403s (`FEATURE_DISABLED`) and whose empty state is a dead end. This gates that entry and adds the manager-side render guard as the structural backstop.

## Changes

- `Content.tsx` — `onCreateDataLake` is passed only when the flag is on, at **both** call sites (mobile in `FileBrowserContent`, desktop in `UploadDropdown`). `UploadActionsSelect` already hides the option when the prop is undefined, so no change needed there. Note: `FileBrowserContent` uses an `isAdminFeatureEnabled` alias because that component already destructures `isFeatureEnabled` from the *unrelated* experimental-features hook — the exact trap called out in #245.
- `DataLakeListPanel.tsx` — early `return null` when the feature is off (placed after all hooks). Shared choke point for every manager entry, mirroring the `SendToDataLakeModal` guard from #234.
- `UploadDropdown` is now exported for the consumer-level gating test.
- Tests (TDD, red-green): new `Content.gating.test.tsx` (renders `UploadDropdown` with the real `UploadActionsSelect` — flag off → no "Data Lakes" option, other upload actions intact; flag on → present) and two new cases in `DataLakeListPanel.test.tsx` (panel renders nothing when the flag is off). Existing settings-modal tests untouched and passing.

## Guide for Testers

1. As an admin, turn the `EnableDataLakes` admin setting **off**.
2. Open the Files browser → the upload-actions dropdown ("Upload Files"). Expected: options are From device / Add from URL / Create Knowledge — **no "Data Lakes"** — on both desktop and mobile layouts.
3. Watch the browser console while doing step 2: no `FEATURE_DISABLED` / 403 errors.
4. Turn `EnableDataLakes` **on**. Repeat: the "Data Lakes" option appears and opens the manager panel listing lakes; Create/archive/restore flows work as before.

**What NOT to test:** no server/API changes; `/data-lakes` direct-URL behavior is intentionally unchanged (see below).

## Additional Information

Independent verification swept all `openManager` / `openWizard` callers: with this PR, no gated-off user-visible path opens a functional manager. One deliberate residual: the `/data-lakes` **route** stays reachable by direct URL when the flag is off — that's a documented decision in `router.tsx` ("gated for discovery", server enforces the API). With the panel guard from this PR, that path now shows an empty closable dialog instead of a 403-spamming dead panel.

Verification: full client suite 4956 tests green, typecheck 35/35 tasks, lint clean, final independent verification agent — PASS.

## Checklist

- [x] I have made the UI/UX feel good (dead-end entry removed; entitled users unaffected)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (hook-alias rationale + choke-point comment)
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
