### PR TITLE
test(agent-executor): guard buildSubagentLatticeToolPool resolves lattice_* from real deps

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.latticeTools.integration.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.latticeTools.integration.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { LATTICE_TOOL_NAMES } from '@bike4mind/services';
+import { buildSubagentLatticeToolPool } from './agentExecutor.latticeTools';
+import { makeToolBuilderDeps, makeToolBuilderCallbacks } from './toolBuilderDeps.fixture';
+
+/**
+ * End-to-end guard for issue #214.
+ *
+ * The sibling `agentExecutor.latticeTools.test.ts` mocks `buildSharedTools`, so
+ * it only proves the RIGHT ARGUMENTS are passed - not that real deps actually
+ * resolve `lattice_*` tools out the other end. This is the exact class of
+ * silent no-op the feature already hit once (a missing backing adapter made the
+ * whole path resolve to nothing until the post-review wiring fix).
+ *
+ * This test deliberately does NOT mock `buildSharedTools`: it runs the real
+ * resolution pipeline (`generateTools` -> `latticeToolDefinitions` merged into
+ * `externalTools`, filtered by `LATTICE_TOOL_NAMES`) against a real - if lightly
+ * stubbed - `ToolBuilderDeps`, and asserts the pool contains the Lattice tools
+ * by name. A future `buildSharedTools` refactor that stops mapping
+ * `enabledTools`/`externalTools` -> tools would make this go red instead of
+ * silently returning `[]`.
+ */
+describe('buildSubagentLatticeToolPool (integration, real buildSharedTools)', () => {
+  const pool = buildSubagentLatticeToolPool(makeToolBuilderDeps(), makeToolBuilderCallbacks(), undefined);
+
+  it('resolves EXACTLY the lattice_* tools from real ToolBuilderDeps', () => {
+    // Exact set-equality proves both halves of the contract at once: every
+    // lattice name resolves (no silent-drop no-op) AND nothing else leaks in
+    // (the agentStore short-circuit keeps delegate_to_agent / coordinate_task
+    // out). A buildSharedTools refactor that stops mapping enabledTools /
+    // externalTools -> tools turns this red instead of returning [].
+    expect(pool.map(tool => tool.toolSchema.name).sort()).toEqual([...LATTICE_TOOL_NAMES].sort());
+  });
+
+  it('backs every resolved name with a callable toolFn', () => {
+    // The one signal set-equality can't give: a name present but unbacked would
+    // be a silent no-op at execution time. buildSharedTools drops unbacked
+    // names, so each entry that survives must be a real, callable tool.
+    expect(pool.every(tool => typeof tool.toolFn === 'function')).toBe(true);
+  });
+});

--- a/apps/client/server/queueHandlers/toolBuilderDeps.fixture.ts
+++ b/apps/client/server/queueHandlers/toolBuilderDeps.fixture.ts
@@ -1,0 +1,89 @@
+/**
+ * Real (NOT mocked) `ToolBuilderDeps` / `ToolBuilderCallbacks` for
+ * `buildSharedTools`-level tests.
+ *
+ * The existing `buildSubagentLatticeToolPool` unit tests mock `buildSharedTools`
+ * wholesale, so they never prove that real deps actually resolve `lattice_*`
+ * tools out the other end (issue #214). This factory closes that gap cheaply:
+ * `buildSharedTools` materialises EVERY b4m tool up front (schema + a `toolFn`
+ * closure), but a tool's backing adapters - db repos, storage, llm - are only
+ * touched INSIDE its `toolFn` at execution time, never at build time. So the
+ * stubs here reject when called: a build-only test never runs a tool, and a
+ * future test that DOES execute one fails loudly with a clear message instead of
+ * silently reading `undefined`.
+ *
+ * Scope: the stubbed `db` covers the adapters the Lattice pool path resolves
+ * (`apiKeys` / `adminSettings` / `latticeModels`). A test that enables a
+ * different `enabledTools` set may need to stub additional adapters - the
+ * fail-loud stubs make any such gap obvious at build time rather than silent.
+ *
+ * `deps`/`callbacks` overrides are shallow-merged so a caller can drop in a real
+ * adapter (or a `vi.fn()`) for the one surface it exercises.
+ */
+import { Logger } from '@bike4mind/observability';
+import type { ToolBuilderDeps, ToolBuilderCallbacks } from '@bike4mind/services';
+import type { ICompletionBackend } from '@bike4mind/llm-adapters';
+import type { IUserDocument } from '@bike4mind/common';
+
+const rejectIfExecuted = (surface: string) => () => {
+  throw new Error(
+    `toolBuilderDeps.fixture: ${surface} was called - this fixture is build-only. ` +
+      `Pass a real adapter via overrides to execute tools.`
+  );
+};
+
+/**
+ * A backend stand-in. `complete` rejects because build-time tool materialisation
+ * never invokes the LLM.
+ */
+const fakeLlm = { complete: rejectIfExecuted('llm.complete') } as unknown as ICompletionBackend;
+
+const fakeStorage = {
+  upload: rejectIfExecuted('storage.upload'),
+  getSignedUrl: rejectIfExecuted('storage.getSignedUrl'),
+  getPublicUrl: rejectIfExecuted('storage.getPublicUrl'),
+} as unknown as ToolBuilderDeps['storage'];
+
+/** Minimal user document - build-time tool construction never reads its fields. */
+const fakeUser = { _id: 'fixture-user', id: 'fixture-user' } as unknown as IUserDocument;
+
+const fakeDb = {
+  apiKeys: {
+    findByUserIdAndType: rejectIfExecuted('db.apiKeys.findByUserIdAndType'),
+    findByUserIdAndTypes: rejectIfExecuted('db.apiKeys.findByUserIdAndTypes'),
+  },
+  adminSettings: {
+    findBySettingName: rejectIfExecuted('db.adminSettings.findBySettingName'),
+    findBySettingNames: rejectIfExecuted('db.adminSettings.findBySettingNames'),
+    findAll: rejectIfExecuted('db.adminSettings.findAll'),
+  },
+  // The Lattice adapter the tools persist through at execution time. Present so
+  // the pool matches production wiring; rejects here because it is build-only.
+  latticeModels: {
+    create: rejectIfExecuted('db.latticeModels.create'),
+    findById: rejectIfExecuted('db.latticeModels.findById'),
+    update: rejectIfExecuted('db.latticeModels.update'),
+  },
+} as unknown as ToolBuilderDeps['db'];
+
+export function makeToolBuilderDeps(overrides: Partial<ToolBuilderDeps> = {}): ToolBuilderDeps {
+  return {
+    userId: 'fixture-user',
+    user: fakeUser,
+    logger: new Logger(),
+    db: fakeDb,
+    storage: fakeStorage,
+    imageGenerateStorage: fakeStorage,
+    llm: fakeLlm,
+    ...overrides,
+  };
+}
+
+export function makeToolBuilderCallbacks(overrides: Partial<ToolBuilderCallbacks> = {}): ToolBuilderCallbacks {
+  return {
+    onStatusUpdate: async () => {},
+    onToolStart: async () => {},
+    onToolFinish: async () => {},
+    ...overrides,
+  };
+}

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -22,6 +22,7 @@
     "android",
     "**/*.test.ts",
     "**/*.test.tsx",
+    "**/*.fixture.ts",
     ".next/standalone",
     ".next/server",
     ".next/cache",


### PR DESCRIPTION
# Pull Request

## Description

Follow-up hardening from #149 (closes #55), which wired the subagent Lattice opt-in pool via `buildSubagentLatticeToolPool`.

The existing `buildSubagentLatticeToolPool` unit test **mocks `buildSharedTools`**, so it only proves the *right arguments* are passed (`enabledTools: LATTICE_TOOL_NAMES`, `externalTools: latticeToolDefinitions`, `config`) plus the post-filter. It never proves that real deps produce actual `lattice_*` tools out the other end. That is the exact class of silent no-op the feature already hit once: a missing backing adapter (`latticeModelRepository`) made the whole path resolve to nothing until the post-review wiring fix. A future `buildSharedTools` refactor that stopped mapping `enabledTools`/`externalTools` -> tools would make the pool silently return `[]`, subagent opt-in would quietly stop working, and no test would go red.

This PR adds an integration-style guard that runs the **real** `buildSharedTools` pipeline against a lightly-stubbed-but-not-mocked `ToolBuilderDeps`, asserting the pool resolves exactly the `lattice_*` tools by name. It also introduces the reusable deps factory #214 called for, so this and future `buildSharedTools`-level tests are cheap.

> Note: stacked on `fix/55-subagent-lattice-optin` (#149) because it guards code that only exists on that branch. Base against `main` once #149 merges.

Closes #214

## Changes

- Add `agentExecutor.latticeTools.integration.test.ts` — runs the real `buildSharedTools` (no mocking) and asserts the subagent Lattice pool resolves exactly the `lattice_*` tools, each backed by a callable `toolFn`.
- Add `toolBuilderDeps.fixture.ts` — a reusable `makeToolBuilderDeps()` / `makeToolBuilderCallbacks()` factory producing real, lightly-stubbed deps. Stubs reject on execution (fail-loud) since build-time tool materialisation only constructs schemas + closures, never runs them.

## Guide for Testers

This is a **test-only, backend PR** — no UI, no runtime behavior change. Verification is running the new test and confirming it guards the contract.

1. Check out this branch (`test/214-subagent-lattice-pool-integration`) locally.
2. From the repo root, build the core packages so the SUT's `.d.ts` is current: run `pnpm turbo:core:build`. Expected: completes successfully.
3. Run the Lattice tool tests: `cd apps/client && VITEST_MAX_WORKERS=2 npx vitest run server/queueHandlers/agentExecutor.latticeTools`. Expected: `Test Files 2 passed`, `Tests 9 passed`.
4. **Mutation check (proves the guard bites):** in `apps/client/server/queueHandlers/agentExecutor.latticeTools.ts`, temporarily change `externalTools: latticeToolDefinitions,` to `externalTools: {},` inside `buildSubagentLatticeToolPool`.
5. Re-run step 3's command against just the integration file: `VITEST_MAX_WORKERS=2 npx vitest run server/queueHandlers/agentExecutor.latticeTools.integration.test.ts`. Expected: the `resolves EXACTLY the lattice_* tools from real ToolBuilderDeps` test **fails** (the pool silently drops to `[]`).
6. Revert the change from step 4. Expected: tests pass again.

### Regression Checks

- Run `cd apps/client && npm run typecheck` (8GB heap). Expected: no TS errors.
- Confirm the sibling unit test `agentExecutor.latticeTools.test.ts` still passes unchanged — the two files coexist because the integration test uses a separate file (the unit test `vi.mock`s the whole `@bike4mind/services` module).

### What NOT to test

- No UI, no preview env, no browser flow — nothing user-facing changed.
- No production runtime path is altered; this adds test + fixture files only.

## Additional Information

The integration test must live in its own file: the sibling unit test mocks `@bike4mind/services` module-wide, which would also mock the `buildSharedTools` this test needs to exercise for real.

## Developer Notes (Optional)

- **Reusable pattern:** `toolBuilderDeps.fixture.ts` (`makeToolBuilderDeps` / `makeToolBuilderCallbacks`) unlocks cheap `buildSharedTools`-level integration tests without mocking the tool pipeline. Overrides are shallow-merged, so a test can drop in one real adapter (or a `vi.fn()`) for the single surface it exercises.
- **Fail-loud stubs:** the fixture's stubbed adapters throw a named error (`db.latticeModels.create was called - ...`) instead of returning `undefined`, so a test that accidentally executes a tool fails with a clear message rather than a silent corruption.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
