### PR TITLE
fix(client): hydrate artifact content before gallery share publish (#147)

### DIFF
--- a/apps/client/app/components/artifacts/ArtifactGallery.test.tsx
+++ b/apps/client/app/components/artifacts/ArtifactGallery.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+/**
+ * Regression guard for #147: the gallery renders from the list feed (/api/artifacts),
+ * which omits `content`. The card's Share action must hydrate the single artifact's
+ * content (via the :id GET, whose string lives at response.content.content) BEFORE
+ * wiring the publish dialog - otherwise publishArtifactBundle throws "no content to
+ * publish" before any network call and Share silently no-ops.
+ *
+ * These tests lock three behaviors: (1) a content-less list artifact gets hydrated and
+ * the wiring receives the real content, (2) a successful fetch that returns empty
+ * content shows the "no content" toast and never opens the dialog, and (3) a failed
+ * fetch is reported as a load error - distinct from "no content" - and never opens the
+ * dialog.
+ */
+
+const mocks = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  publishAndShare: vi.fn(),
+  buildArtifactPublishWiring: vi.fn(() => ({ resolveExisting: vi.fn(), publish: vi.fn() })),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: mocks.apiGet, post: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError, success: mocks.toastSuccess },
+}));
+// Zustand selector hooks: call the selector with a minimal state slice.
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: (selector: (s: any) => any) => selector({ currentUser: { id: 'u1' } }),
+}));
+vi.mock('@client/app/components/Credits/AccountSelector', () => ({
+  useSelectedAccount: (selector: (s: any) => any) => selector({ selectedAccount: null }),
+}));
+vi.mock('@client/app/hooks/usePublishShare', () => ({
+  usePublishShare: () => ({ publishAndShare: mocks.publishAndShare, modal: null }),
+}));
+// Mock the wiring builder so we can assert the exact `content` handed to it (the real
+// builder returns closures that capture content, which are otherwise opaque here).
+vi.mock('@client/app/utils/publishApi', () => ({
+  buildArtifactPublishWiring: mocks.buildArtifactPublishWiring,
+}));
+
+import { ArtifactGallery } from './ArtifactGallery';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const ARTIFACT_ID = 'artifact_html_demo_123';
+
+const TYPES_RESPONSE = {
+  types: [{ type: 'html', name: 'HTML', description: 'HTML page', category: 'web' }],
+  categories: ['web'],
+};
+
+// The list feed intentionally omits `content` - this is the exact shape the bug hit.
+const LIST_RESPONSE = {
+  artifacts: [
+    {
+      id: ARTIFACT_ID,
+      type: 'html',
+      title: 'My Demo Artifact',
+      status: 'draft',
+      contentSize: 2048,
+      contentHash: 'hash',
+      createdAt: new Date('2026-01-01').toISOString(),
+      updatedAt: new Date('2026-01-01').toISOString(),
+    },
+  ],
+  pagination: { total: 1, limit: 20, offset: 0, hasMore: false },
+};
+
+/** Route api.get by URL; the single-artifact GET is supplied per-test. */
+function wireApi(singleArtifact: () => Promise<any>) {
+  mocks.apiGet.mockImplementation((url: string) => {
+    if (url.startsWith('/api/artifacts/types')) return Promise.resolve({ data: TYPES_RESPONSE });
+    if (url.includes('includeContent=true')) return singleArtifact();
+    // Base list feed (starts with /api/artifacts but not a sub-resource we handle above).
+    if (url.startsWith('/api/artifacts')) return Promise.resolve({ data: LIST_RESPONSE });
+    return Promise.resolve({ data: {} });
+  });
+}
+
+/** Open the card's kebab menu and click Share. */
+async function openShare(user: ReturnType<typeof userEvent.setup>) {
+  // Wait for the list to render the card past the artifactTypes loading gate.
+  await screen.findByText('My Demo Artifact');
+  // The card's kebab is the only menu trigger without visible "Sort" text.
+  const triggers = Array.from(document.querySelectorAll('[aria-haspopup="menu"]')) as HTMLElement[];
+  const kebab = triggers.find(t => !/sort/i.test(t.textContent || ''));
+  expect(kebab).toBeTruthy();
+  await user.click(kebab!);
+  const share = await screen.findByTestId('artifact-publish-share');
+  await user.click(share);
+}
+
+describe('ArtifactGallery - Share hydrates content (#147)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hydrates content from the single-artifact GET and passes it to the publish wiring', async () => {
+    wireApi(() => Promise.resolve({ data: { content: { content: '<h1>hydrated</h1>' } } }));
+    const user = userEvent.setup();
+    render(
+      <TestWrapper>
+        <ArtifactGallery />
+      </TestWrapper>
+    );
+
+    await openShare(user);
+
+    await waitFor(() => {
+      expect(mocks.apiGet).toHaveBeenCalledWith(
+        `/api/artifacts/${encodeURIComponent(ARTIFACT_ID)}?includeContent=true`
+      );
+    });
+    await waitFor(() => {
+      expect(mocks.buildArtifactPublishWiring).toHaveBeenCalledWith(
+        expect.objectContaining({ artifactId: ARTIFACT_ID, content: '<h1>hydrated</h1>' })
+      );
+    });
+    expect(mocks.publishAndShare).toHaveBeenCalledTimes(1);
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it('shows a "no content" toast and does not publish when the fetch returns empty content', async () => {
+    wireApi(() => Promise.resolve({ data: { content: { content: '' } } }));
+    const user = userEvent.setup();
+    render(
+      <TestWrapper>
+        <ArtifactGallery />
+      </TestWrapper>
+    );
+
+    await openShare(user);
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith('This artifact has no content to publish');
+    });
+    expect(mocks.buildArtifactPublishWiring).not.toHaveBeenCalled();
+    expect(mocks.publishAndShare).not.toHaveBeenCalled();
+  });
+
+  it('reports a load error (distinct from "no content") and does not publish when the fetch fails', async () => {
+    wireApi(() => Promise.reject(new Error('boom')));
+    const user = userEvent.setup();
+    render(
+      <TestWrapper>
+        <ArtifactGallery />
+      </TestWrapper>
+    );
+
+    await openShare(user);
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith('Could not load artifact content, please try again');
+    });
+    expect(mocks.toastError).not.toHaveBeenCalledWith('This artifact has no content to publish');
+    expect(mocks.buildArtifactPublishWiring).not.toHaveBeenCalled();
+    expect(mocks.publishAndShare).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/artifacts/ArtifactGallery.test.tsx
+++ b/apps/client/app/components/artifacts/ArtifactGallery.test.tsx
@@ -95,11 +95,8 @@ function wireApi(singleArtifact: () => Promise<any>) {
 async function openShare(user: ReturnType<typeof userEvent.setup>) {
   // Wait for the list to render the card past the artifactTypes loading gate.
   await screen.findByText('My Demo Artifact');
-  // The card's kebab is the only menu trigger without visible "Sort" text.
-  const triggers = Array.from(document.querySelectorAll('[aria-haspopup="menu"]')) as HTMLElement[];
-  const kebab = triggers.find(t => !/sort/i.test(t.textContent || ''));
-  expect(kebab).toBeTruthy();
-  await user.click(kebab!);
+  const kebab = await screen.findByTestId('artifact-card-menu-btn');
+  await user.click(kebab);
   const share = await screen.findByTestId('artifact-publish-share');
   await user.click(share);
 }
@@ -169,5 +166,33 @@ describe('ArtifactGallery - Share hydrates content (#147)', () => {
     expect(mocks.toastError).not.toHaveBeenCalledWith('This artifact has no content to publish');
     expect(mocks.buildArtifactPublishWiring).not.toHaveBeenCalled();
     expect(mocks.publishAndShare).not.toHaveBeenCalled();
+  });
+
+  it('ignores a re-entrant Share click while a hydration fetch is already in flight', async () => {
+    // A deferred single-artifact fetch we control: keep it pending so the first Share click
+    // stays mid-hydration while we fire a second one. The in-flight guard must drop the second.
+    let resolveFetch!: (v: any) => void;
+    const pending = new Promise<any>(res => {
+      resolveFetch = res;
+    });
+    wireApi(() => pending);
+    const user = userEvent.setup();
+    render(
+      <TestWrapper>
+        <ArtifactGallery />
+      </TestWrapper>
+    );
+
+    await openShare(user); // first click: hydration fetch starts and stays pending
+    await openShare(user); // second click while in flight: should be ignored by the guard
+
+    const hydrationCalls = mocks.apiGet.mock.calls.filter(
+      ([url]: [string]) => typeof url === 'string' && url.includes('includeContent=true')
+    );
+    expect(hydrationCalls).toHaveLength(1);
+
+    // Let the first flow finish so it publishes exactly once and no pending work leaks.
+    resolveFetch({ data: { content: { content: '<h1>hydrated</h1>' } } });
+    await waitFor(() => expect(mocks.publishAndShare).toHaveBeenCalledTimes(1));
   });
 });

--- a/apps/client/app/components/artifacts/ArtifactGallery.tsx
+++ b/apps/client/app/components/artifacts/ArtifactGallery.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   Box,
   Typography,
@@ -136,6 +136,8 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
   const selectedAccount = useSelectedAccount(s => s.selectedAccount);
   const activeOrg = selectedAccount && !selectedAccount.personal ? selectedAccount : null;
   const { publishAndShare, modal: publishShareModal } = usePublishShare();
+  // Guards against re-entrant Share clicks racing two publishes onto the single dialog.
+  const publishingRef = useRef(false);
   const handlePublishArtifact = useCallback(
     async (artifact: ArtifactWithContent) => {
       if (!currentUser?.id) {
@@ -152,41 +154,52 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
         toast.error('This artifact has no stable id to publish');
         return;
       }
-      // The gallery renders from the list feed (/api/artifacts), which omits `content` to stay
-      // lean. publishArtifactBundle throws on empty content before any network call, so hydrate
-      // the single artifact (the :id GET includes content by default; the string lives at
-      // response.content.content) before wiring up the publish dialog.
-      let content = artifact.content ?? '';
-      if (!content) {
-        try {
-          const { data } = await api.get<{ content?: { content?: string } }>(
-            `/api/artifacts/${encodeURIComponent(artifactId)}?includeContent=true`
-          );
-          content = data.content?.content ?? '';
-        } catch (err) {
-          // A transport/auth failure is not the same as "empty content" - keep the two
-          // distinct so a transient error doesn't send anyone chasing a data problem.
-          console.error('Failed to load artifact content for publish:', err);
-          toast.error('Could not load artifact content, please try again');
+      // Ignore re-entrant clicks while a hydration fetch is already in flight: there is a
+      // single share dialog, so two racing publishes would let the last-resolved one win it.
+      // A ref (not state) keeps the guard synchronous and free of re-render churn.
+      if (publishingRef.current) return;
+      publishingRef.current = true;
+      try {
+        // The gallery renders from the list feed (/api/artifacts), which omits `content` to stay
+        // lean. publishArtifactBundle throws on empty content before any network call, so hydrate
+        // the single artifact (the :id GET includes content by default; the string lives at
+        // response.content.content) before wiring up the publish dialog.
+        let content = artifact.content ?? '';
+        if (!content) {
+          try {
+            const { data } = await api.get<{ content?: { content?: string } }>(
+              `/api/artifacts/${encodeURIComponent(artifactId)}?includeContent=true`
+            );
+            content = data.content?.content ?? '';
+          } catch (err) {
+            // A transport/auth failure is not the same as "empty content" - keep the two
+            // distinct so a transient error doesn't send anyone chasing a data problem.
+            console.error('Failed to load artifact content for publish:', err);
+            toast.error('Could not load artifact content, please try again');
+            return;
+          }
+        }
+        if (!content) {
+          toast.error('This artifact has no content to publish');
           return;
         }
+        publishAndShare({
+          title: artifact.title || 'Shared artifact',
+          ...(activeOrg ? { orgOption: { label: 'Team', hint: `Members of ${activeOrg.name}` } } : {}),
+          ...buildArtifactPublishWiring({
+            artifactId,
+            type: artifact.type,
+            content,
+            title: artifact.title,
+            userId: String(currentUser.id),
+            orgId: activeOrg?.id,
+          }),
+        });
+      } finally {
+        // Release once the dialog is open (or on any bail) - the guard only covers the
+        // async hydration window, which is where the race lives.
+        publishingRef.current = false;
       }
-      if (!content) {
-        toast.error('This artifact has no content to publish');
-        return;
-      }
-      publishAndShare({
-        title: artifact.title || 'Shared artifact',
-        ...(activeOrg ? { orgOption: { label: 'Team', hint: `Members of ${activeOrg.name}` } } : {}),
-        ...buildArtifactPublishWiring({
-          artifactId,
-          type: artifact.type,
-          content,
-          title: artifact.title,
-          userId: String(currentUser.id),
-          orgId: activeOrg?.id,
-        }),
-      });
     },
     [currentUser, activeOrg, publishAndShare]
   );
@@ -411,7 +424,7 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
             <Dropdown>
               <MenuButton
                 slots={{ root: IconButton }}
-                slotProps={{ root: { size: 'sm', variant: 'plain' } }}
+                slotProps={{ root: { size: 'sm', variant: 'plain', 'data-testid': 'artifact-card-menu-btn' } }}
                 onClick={e => e.stopPropagation()}
               >
                 <MoreIcon />
@@ -429,7 +442,9 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
                 <MenuItem
                   onClick={e => {
                     e.stopPropagation();
-                    handlePublishArtifact(artifact);
+                    // Deliberate fire-and-forget: the async handler drives its own toasts and
+                    // opens the dialog; the menu click doesn't await it. `void` marks intent.
+                    void handlePublishArtifact(artifact);
                   }}
                   data-testid="artifact-publish-share"
                 >

--- a/apps/client/app/components/artifacts/ArtifactGallery.tsx
+++ b/apps/client/app/components/artifacts/ArtifactGallery.tsx
@@ -137,7 +137,7 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
   const activeOrg = selectedAccount && !selectedAccount.personal ? selectedAccount : null;
   const { publishAndShare, modal: publishShareModal } = usePublishShare();
   const handlePublishArtifact = useCallback(
-    (artifact: ArtifactWithContent) => {
+    async (artifact: ArtifactWithContent) => {
       if (!currentUser?.id) {
         toast.error('You must be signed in to publish');
         return;
@@ -152,13 +152,32 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
         toast.error('This artifact has no stable id to publish');
         return;
       }
+      // The gallery renders from the list feed (/api/artifacts), which omits `content` to stay
+      // lean. publishArtifactBundle throws on empty content before any network call, so hydrate
+      // the single artifact (the :id GET includes content by default; the string lives at
+      // response.content.content) before wiring up the publish dialog.
+      let content = artifact.content ?? '';
+      if (!content) {
+        try {
+          const { data } = await api.get<{ content?: { content?: string } }>(
+            `/api/artifacts/${encodeURIComponent(artifactId)}?includeContent=true`
+          );
+          content = data.content?.content ?? '';
+        } catch {
+          content = '';
+        }
+      }
+      if (!content) {
+        toast.error('This artifact has no content to publish');
+        return;
+      }
       publishAndShare({
         title: artifact.title || 'Shared artifact',
         ...(activeOrg ? { orgOption: { label: 'Team', hint: `Members of ${activeOrg.name}` } } : {}),
         ...buildArtifactPublishWiring({
           artifactId,
           type: artifact.type,
-          content: artifact.content ?? '',
+          content,
           title: artifact.title,
           userId: String(currentUser.id),
           orgId: activeOrg?.id,

--- a/apps/client/app/components/artifacts/ArtifactGallery.tsx
+++ b/apps/client/app/components/artifacts/ArtifactGallery.tsx
@@ -163,8 +163,12 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
             `/api/artifacts/${encodeURIComponent(artifactId)}?includeContent=true`
           );
           content = data.content?.content ?? '';
-        } catch {
-          content = '';
+        } catch (err) {
+          // A transport/auth failure is not the same as "empty content" - keep the two
+          // distinct so a transient error doesn't send anyone chasing a data problem.
+          console.error('Failed to load artifact content for publish:', err);
+          toast.error('Could not load artifact content, please try again');
+          return;
         }
       }
       if (!content) {


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

https://github.com/user-attachments/assets/62addcab-af01-4b4d-9220-ba25e5b1a8ea

## Description

Closes #147. Publishing an artifact from an **Artifact Gallery** card's **Share -> Create share link** silently no-opped.

The gallery renders from the `/api/artifacts` **list** response, which omits the `content` field to stay lean. The Share handler passed `content: artifact.content ?? ''` (always empty for list data) into the publisher, and `publishArtifactBundle` throws `"This artifact has no content to publish"` **before any network call** - so the dialog stayed on the choose phase and no `upload-url` request ever fired.

The fix hydrates the artifact's content on demand (issue option 1) before wiring the publish dialog: when the card's `content` is empty, fetch the single artifact via `GET /api/artifacts/{id}?includeContent=true` (whose payload carries the string at `response.content.content`) and feed that into the publish flow. This keeps the list feed lean instead of fattening every row with content.

The KnowledgeViewer publish path is unaffected - it already sources content from the loaded artifact, not the list feed.

## Changes

- `apps/client/app/components/artifacts/ArtifactGallery.tsx`
  - `handlePublishArtifact` is now `async`; when the gallery artifact has no `content`, it hydrates via the single-artifact GET before calling `buildArtifactPublishWiring`.
  - A failed hydration fetch reports a distinct load error (`"Could not load artifact content, please try again"`) and aborts, kept separate from the genuinely-empty-content case (`"This artifact has no content to publish"`), so a transient error is not misattributed to missing data.
  - The `artifactId` is URL-encoded in the request path.
  - An in-flight guard (`publishingRef`) drops re-entrant Share clicks while a hydration fetch is running, so rapid clicks cannot race two publishes onto the single share dialog.
  - Added a `data-testid` on the card kebab trigger and marked the Share click a deliberate `void` fire-and-forget (review nits).
- `apps/client/app/components/artifacts/ArtifactGallery.test.tsx` (new) - regression tests, see the Tests section.

## Guide for Testers

1. Open the preview link and navigate to the `/artifacts-demo` page.
2. Ensure at least one artifact card is present. If the gallery is empty, click **Create Artifact**, create any artifact (for example an HTML one), and let it appear as a card.
3. Open your browser DevTools **Network** tab, filter to `Fetch/XHR`, and clear the log.
4. On an artifact card, click the **three-dots (kebab) menu** at the top-right of the card.
5. Click **Share**.
6. In the dialog, pick any visibility, then click **Create share link**.
7. Expected: no `"This artifact has no content to publish"` toast appears. In the Network tab you should see a `GET /api/artifacts/{id}?includeContent=true` request fire first, followed by the publish chain (`POST /api/publish/artifact/upload-url`, an S3 `PUT`, then `POST /api/publish/artifact/finalize`).
8. Expected: a share link is returned and opens the published page (`/p/u/...`).
9. In a Team (organization) account context, repeat steps 4-8 and choose the **Team** visibility. Expected: the link is org-scoped (`/p/o/{orgId}/...`).

### Regression Checks

1. Open an artifact in the full Knowledge viewer and use its **Share** action. Expected: still works and returns a link (this path was never affected).
2. Confirm the gallery still lists, filters, sorts, and deletes artifacts as before.

### Notes on local verification

- The published-artifacts bucket CORS allowlist includes `http://localhost:3000` only. If your dev server bumps to another port (for example 3001), the S3 preflight will 403 on the `PUT`. Run the client on port 3000 to verify the upload step locally.

### What NOT to test

- No API, database, or infra behavior changed. The only server interaction is the existing single-artifact GET, now called before publishing.

## Additional Information

- Discovered during E2E verification of #142 (org/"Team" publish visibility); orthogonal to that work - content hydration is unchanged by it.
- `/artifacts-demo` is the gallery surface exercised here.

## Developer Notes (Optional)

- The single-artifact GET response shape for content is `response.content.content` (the content document nested under `content`), distinct from the artifact metadata under `response.artifact`. Reusable when any other surface needs to hydrate artifact content on demand.
- Pattern: hydrate heavyweight fields (content) lazily at the action that needs them rather than inflating list responses.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A

## Tests

- `apps/client/app/components/artifacts/ArtifactGallery.test.tsx` (new): renders the gallery from a content-less list feed, opens a card's Share menu, and asserts four behaviors:
  1. Content is hydrated via `GET /api/artifacts/{id}?includeContent=true` and the real string is handed to `buildArtifactPublishWiring`.
  2. A successful fetch that returns empty content shows the "no content" toast and never opens the publish dialog.
  3. A failed fetch shows the load-error toast (not the "no content" one) and never opens the publish dialog.
  4. A re-entrant Share click while a hydration fetch is in flight is ignored (only one hydration request fires; publish opens exactly once after it resolves).
