### PR TITLE
fix(github): treat missing SECRET_ENCRYPTION_KEY as permanent in forSystem

### DIFF
--- a/apps/client/server/services/githubService.test.ts
+++ b/apps/client/server/services/githubService.test.ts
@@ -262,14 +262,18 @@ describe('GitHubService', () => {
         await expect(GitHubService.forSystem(logger)).rejects.toThrow('DB connection failed');
       });
 
-      it('should throw if SECRET_ENCRYPTION_KEY is not configured', async () => {
+      it('should return null when SECRET_ENCRYPTION_KEY is not configured (permanent config error)', async () => {
         mockConfig.SECRET_ENCRYPTION_KEY = '';
         mockRepository.findSystemDefaultWithCredentials.mockResolvedValue({
           ...mockConnection,
           isSystemDefault: true,
         });
 
-        await expect(GitHubService.forSystem(logger)).rejects.toThrow('GitHub service configuration error');
+        // Missing key is a permanent deploy misconfiguration - forSystem returns null so
+        // the SQS consumer swallows the message instead of retrying.
+        await expect(GitHubService.forSystem(logger)).resolves.toBeNull();
+        // ...and logs the permanent-config reason so the swallow is not silent.
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('SECRET_ENCRYPTION_KEY not configured'));
       });
 
       it('should throw on auth init failure so the caller can retry (transient failure)', async () => {

--- a/apps/client/server/services/githubService.ts
+++ b/apps/client/server/services/githubService.ts
@@ -246,11 +246,13 @@ export class GitHubService {
   /**
    * Factory method to create a GitHubService using the system default connection.
    *
-   * Returns null for permanent config states (no connection / disabled / suspended) -
-   * callers should swallow the message without retrying since retries will never help.
+   * Returns null for permanent config states (no connection / disabled / suspended /
+   * missing SECRET_ENCRYPTION_KEY) - callers should swallow the message without retrying
+   * since retries will never help.
    *
-   * Throws for transient failures (DB error, auth init failure) so SQS retries the
-   * message and routes it to the DLQ if retries are exhausted.
+   * Throws for transient failures (DB error, or auth-init failure inside
+   * createFromConnection) so SQS retries the message and routes it to the DLQ if retries
+   * are exhausted.
    */
   static async forSystem(logger: Logger): Promise<GitHubService | null> {
     // DB failure is transient - propagates so callers retry rather than silently drop.
@@ -274,8 +276,17 @@ export class GitHubService {
       return null;
     }
 
-    // Auth init failure propagates for retry or DLQ escalation - covers both transient
-    // (network unreachable) and permanent config errors (wrong encryption key).
+    // Missing encryption key is a permanent deploy misconfiguration, not transient:
+    // stored credentials can never be decrypted, so retrying will never succeed. Return
+    // null (like disabled/suspended) so the SQS consumer swallows the message rather than
+    // retrying it to the DLQ.
+    if (!Config.SECRET_ENCRYPTION_KEY) {
+      logger.error('[GitHubService] SECRET_ENCRYPTION_KEY not configured - permanent config error, not retrying');
+      return null;
+    }
+
+    // DB failure (above) and auth-init failure (inside createFromConnection) remain
+    // transient and propagate so the SQS consumer retries / escalates to the DLQ.
     return GitHubService.createFromConnection(connection, logger);
   }
 


### PR DESCRIPTION
## Problem

`GitHubService.forSystem()` classifies startup failures for its SQS consumers via a throw/return contract: return `null` = permanent config state (swallow, do not retry); throw = transient (rethrow so SQS retries, then DLQ).

`forSystem()` returned the async `createFromConnection()` promise **without awaiting** it. When `SECRET_ENCRYPTION_KEY` is absent, `createFromConnection()` throws before its octokit try-catch, so that rejection propagated straight to the SQS consumer and got retried (~2 attempts, ~16 min) before DLQ routing. A missing key is a **permanent deploy misconfiguration** - retrying can never help - so it was misclassified as transient.

## Fix

Add a synchronous guard in `forSystem()`, alongside the existing `!enabled` / `suspendedAt` permanent-config early returns: if `SECRET_ENCRYPTION_KEY` is missing, log the reason and return `null` before `createFromConnection()` is ever called.

- `createFromConnection()` is unchanged. It still throws on a missing key, which is the behavior `forOrganization()` (a request path, not an SQS consumer) relies on - so surfacing an error there is intentional and different from the SQS consumer that should swallow it.
- The `forSystem()` JSDoc was updated to list missing-key as a permanent null case and to correct the now-inaccurate transient note.

## Testing

- Flipped the `forSystem` missing-key unit test: now asserts it resolves `null` and logs the permanent-config reason (so the swallow is not silent).
- Regression tests unchanged and still green: `forSystem` DB-error -> throws (transient), `forSystem` auth-init failure -> throws, `forOrganization` missing-key -> throws.
- Full `githubService` suite: 71/71 pass; typecheck clean.

## Out of scope

- Reclassifying wrong/corrupt-key decryption failures as permanent (mentioned only in passing in the source ticket).
- `liveOpsTriage` rethrows every `null` from `forSystem()` into a DLQ-bound throw (a pre-existing gap, independent of this change) - filed as a separate follow-up.

Closes #87