### PR TITLE
fix(agent): persist promptMeta.finishReason on agent-mode completions

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -1998,7 +1998,7 @@ async function processExecution(
       }
     }
 
-    await persistRunAsQuest(executionId, replyText, logger, generatedImages);
+    await persistRunAsQuest(executionId, replyText, logger, generatedImages, finalCheckpoint.finishReason);
 
     // Memento parity with chat_completion. Fires only when the user
     // (or admin default) opted into mementos for this run; skipped for

--- a/apps/client/server/utils/persistRunAsQuest.test.ts
+++ b/apps/client/server/utils/persistRunAsQuest.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks (registered before the SUT import) ---
+const findByIdMock = vi.fn();
+const findOneAndUpdateMock = vi.fn();
+const createMock = vi.fn();
+
+vi.mock('@bike4mind/database', () => ({
+  agentExecutionRepository: {
+    findById: (...args: unknown[]) => findByIdMock(...args),
+  },
+  Quest: {
+    findOneAndUpdate: (...args: unknown[]) => findOneAndUpdateMock(...args),
+    create: (...args: unknown[]) => createMock(...args),
+  },
+}));
+
+// The naming/summary dispatch is fire-and-forget; stub it so tests don't
+// depend on the event bus (which pulls in sst/queue wiring).
+vi.mock('@server/utils/eventBus', () => ({
+  SessionEvents: {
+    AutoName: { publish: vi.fn().mockResolvedValue(undefined) },
+    Summarize: { publish: vi.fn().mockResolvedValue(undefined) },
+  },
+}));
+
+const { persistRunAsQuest } = await import('./persistRunAsQuest');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any;
+
+const EXECUTION_ID = 'exec-1';
+
+function stubExecution(overrides: Record<string, unknown> = {}) {
+  findByIdMock.mockResolvedValue({
+    sessionId: 's1',
+    userId: 'u1',
+    query: 'hello',
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  stubExecution();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('persistRunAsQuest finishReason (#293)', () => {
+  describe('UPDATE branch (existing Quest patched)', () => {
+    beforeEach(() => {
+      findOneAndUpdateMock.mockResolvedValue({ _id: 'q1' }); // truthy → update path taken
+    });
+
+    it('sets promptMeta.finishReason in $set when finishReason is passed', async () => {
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger, undefined, 'end_turn');
+
+      const [, update] = findOneAndUpdateMock.mock.calls[0];
+      expect(update.$set['promptMeta.finishReason']).toBe('end_turn');
+      expect(update.$set.replies).toEqual(['reply']);
+      expect(createMock).not.toHaveBeenCalled();
+    });
+
+    it('coexists with promptMeta.context.mementoIds (no clobber)', async () => {
+      stubExecution({ usedMementoIds: ['m1', 'm2'] });
+
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger, undefined, 'end_turn');
+
+      const [, update] = findOneAndUpdateMock.mock.calls[0];
+      expect(update.$set['promptMeta.finishReason']).toBe('end_turn');
+      expect(update.$set['promptMeta.context.mementoIds']).toEqual(['m1', 'm2']);
+    });
+
+    it('omits promptMeta.finishReason when finishReason is absent', async () => {
+      stubExecution({ usedMementoIds: ['m1'] });
+
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger);
+
+      const [, update] = findOneAndUpdateMock.mock.calls[0];
+      expect(update.$set).not.toHaveProperty('promptMeta.finishReason');
+      // mementoIds untouched by the finishReason change
+      expect(update.$set['promptMeta.context.mementoIds']).toEqual(['m1']);
+    });
+  });
+
+  describe('CREATE branch (no existing Quest)', () => {
+    beforeEach(() => {
+      findOneAndUpdateMock.mockResolvedValue(null); // falsy → create path taken
+    });
+
+    it('writes promptMeta.finishReason on create', async () => {
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger, undefined, 'end_turn');
+
+      const [doc] = createMock.mock.calls[0];
+      expect(doc.promptMeta).toEqual({ finishReason: 'end_turn' });
+    });
+
+    it('composes finishReason AND mementoIds without either clobbering the other', async () => {
+      stubExecution({ usedMementoIds: ['m1', 'm2'] });
+
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger, undefined, 'max_tokens');
+
+      const [doc] = createMock.mock.calls[0];
+      expect(doc.promptMeta).toEqual({ finishReason: 'max_tokens', context: { mementoIds: ['m1', 'm2'] } });
+    });
+
+    it('still writes mementoIds when only those are present', async () => {
+      stubExecution({ usedMementoIds: ['m1'] });
+
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger);
+
+      const [doc] = createMock.mock.calls[0];
+      expect(doc.promptMeta).toEqual({ context: { mementoIds: ['m1'] } });
+    });
+
+    it('omits promptMeta entirely when neither finishReason nor mementoIds are present', async () => {
+      await persistRunAsQuest(EXECUTION_ID, 'reply', logger);
+
+      const [doc] = createMock.mock.calls[0];
+      expect(doc).not.toHaveProperty('promptMeta');
+    });
+  });
+});

--- a/apps/client/server/utils/persistRunAsQuest.ts
+++ b/apps/client/server/utils/persistRunAsQuest.ts
@@ -25,7 +25,14 @@ export async function persistRunAsQuest(
    * Written to `quest.images` so the inline image grid renders in chat history - the agent
    * path has no live quest to accrete these into, unlike classic chat. See agentExecutor.
    */
-  generatedImages?: string[]
+  generatedImages?: string[],
+  /**
+   * Provider stop reason of the run's final LLM completion (from the agent
+   * checkpoint). Written to `quest.promptMeta.finishReason` for parity with
+   * chat, which the client reads to tell a truncated artifact from a completed
+   * reply that merely contains an unclosed `<artifact>` tag in prose.
+   */
+  finishReason?: string
 ): Promise<void> {
   const images = generatedImages?.length ? generatedImages : undefined;
   try {
@@ -58,6 +65,8 @@ export async function persistRunAsQuest(
           status: 'done',
           updatedAt: new Date(),
           ...(execution.usedMementoIds?.length ? { 'promptMeta.context.mementoIds': execution.usedMementoIds } : {}),
+          // Dotted key coexists with `promptMeta.context.mementoIds` above - no clobber.
+          ...(finishReason ? { 'promptMeta.finishReason': finishReason } : {}),
         },
         // $addToSet (not $set) so images contributed by subagents - which write to this same
         // Quest from their own Lambdas via addImagesByAgentExecutionId - aren't clobbered.
@@ -77,9 +86,15 @@ export async function persistRunAsQuest(
         // Link back to the AgentExecution so the client can lazy-load the
         // iteration trace on a "Show reasoning" disclosure under the reply.
         agentExecutionId: executionId,
-        ...(execution.usedMementoIds?.length
-          ? { promptMeta: { context: { mementoIds: execution.usedMementoIds } } }
-          : {}),
+        // Compose one promptMeta from both sources so neither clobbers the
+        // other; omit it entirely when both are absent.
+        ...(() => {
+          const promptMeta = {
+            ...(finishReason ? { finishReason } : {}),
+            ...(execution.usedMementoIds?.length ? { context: { mementoIds: execution.usedMementoIds } } : {}),
+          };
+          return Object.keys(promptMeta).length ? { promptMeta } : {};
+        })(),
       });
     }
 

--- a/b4m-core/agents/src/ReActAgent.finishReason.test.ts
+++ b/b4m-core/agents/src/ReActAgent.finishReason.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for ReActAgent provider-stop-reason capture (#293).
+ *
+ * The agent receives `CompletionInfo.stopReason` through the same
+ * `backend.complete()` callback chat uses, but historically dropped it. It is
+ * now captured (preserve-last-non-null) into `lastStopReason`, surfaced on the
+ * checkpoint as `finishReason`, and persisted to `Quest.promptMeta.finishReason`
+ * by the executor - so the client can tell a truncated artifact from a completed
+ * reply that merely contains an unclosed `<artifact>` tag in prose.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ReActAgent } from './ReActAgent';
+import type { AgentContext } from './types';
+import type { ICompletionBackend, CompletionInfo, ICompletionOptions } from '@bike4mind/llm-adapters';
+import type { IMessage } from '@bike4mind/common';
+
+function createMockLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+/**
+ * Mock backend that resolves a single completion, driving the callback with the
+ * provided frames. Each frame is `[texts, completionInfo?]`; frames without a
+ * `stopReason` exercise the preserve-last-non-null guard.
+ */
+function createFramedLlm(frames: Array<[(string | null)[], CompletionInfo?]>): ICompletionBackend {
+  return {
+    currentModel: 'test-model',
+    getModelInfo: async () => [],
+    complete: async (
+      _model: string,
+      _messages: IMessage[],
+      _options: Partial<ICompletionOptions>,
+      callback: (text: (string | null | undefined)[], completionInfo?: CompletionInfo) => Promise<void>
+    ) => {
+      for (const [texts, info] of frames) {
+        await callback(texts, info);
+      }
+    },
+    pushToolMessages: vi.fn(),
+  };
+}
+
+function createContext(llm: ICompletionBackend, overrides: Partial<AgentContext> = {}): AgentContext {
+  return {
+    userId: 'u1',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logger: createMockLogger() as any,
+    llm,
+    model: 'test-model',
+    tools: [],
+    maxIterations: 5,
+    ...overrides,
+  };
+}
+
+const PING_TOOL = {
+  toolFn: vi.fn(async () => 'pong'),
+  toolSchema: {
+    name: 'ping',
+    description: 'ping',
+    parameters: { type: 'object' as const, properties: {}, required: [] as string[] },
+  },
+};
+
+describe('ReActAgent finishReason capture (#293)', () => {
+  it('captures a clean end_turn stop reason on the checkpoint', async () => {
+    const llm = createFramedLlm([
+      [['All done.'], { inputTokens: 10, outputTokens: 5, toolsUsed: [], stopReason: 'end_turn' }],
+    ]);
+    const agent = new ReActAgent(createContext(llm));
+
+    await agent.run('do the thing');
+
+    expect(agent.toCheckpoint().finishReason).toBe('end_turn');
+  });
+
+  it('captures max_tokens (truncation) as the stop reason', async () => {
+    const llm = createFramedLlm([
+      [['Partial repl'], { inputTokens: 10, outputTokens: 4096, toolsUsed: [], stopReason: 'max_tokens' }],
+    ]);
+    const agent = new ReActAgent(createContext(llm));
+
+    await agent.run('write a long thing');
+
+    expect(agent.toCheckpoint().finishReason).toBe('max_tokens');
+  });
+
+  it('lets the final no-tool completion overwrite an earlier tool_use stop reason', async () => {
+    // Iteration 1 ends on tool_use; iteration 2 (the final answer) ends on end_turn.
+    // The finishReason read after the run must reflect the LAST completion.
+    let callIndex = 0;
+    const llm: ICompletionBackend = {
+      currentModel: 'test-model',
+      getModelInfo: async () => [],
+      complete: async (
+        _model: string,
+        _messages: IMessage[],
+        _options: Partial<ICompletionOptions>,
+        callback: (text: (string | null | undefined)[], completionInfo?: CompletionInfo) => Promise<void>
+      ) => {
+        callIndex++;
+        if (callIndex === 1) {
+          await callback(['calling the tool'], {
+            inputTokens: 10,
+            outputTokens: 5,
+            toolsUsed: [{ name: 'ping', arguments: '{}', id: 'tool1' }],
+            stopReason: 'tool_use',
+          });
+        } else {
+          await callback(['final answer'], { inputTokens: 5, outputTokens: 2, toolsUsed: [], stopReason: 'end_turn' });
+        }
+      },
+      pushToolMessages: vi.fn(),
+    };
+
+    const agent = new ReActAgent(createContext(llm, { tools: [PING_TOOL] }));
+    await agent.run('use the tool then answer');
+
+    expect(agent.toCheckpoint().finishReason).toBe('end_turn');
+  });
+
+  it('preserves the last non-null stop reason across streaming frames', async () => {
+    // The final message_delta carries the stop reason; a trailing usage-only
+    // frame must NOT clobber it back to undefined (the `!= null` guard).
+    const llm = createFramedLlm([
+      [['answer'], { inputTokens: 10, outputTokens: 5, toolsUsed: [], stopReason: 'end_turn' }],
+      [[null], { inputTokens: 0, outputTokens: 0, toolsUsed: [] }],
+    ]);
+    const agent = new ReActAgent(createContext(llm));
+
+    await agent.run('answer me');
+
+    expect(agent.toCheckpoint().finishReason).toBe('end_turn');
+  });
+
+  it('leaves finishReason undefined when the backend reports none', async () => {
+    const llm = createFramedLlm([[['answer'], { inputTokens: 10, outputTokens: 5, toolsUsed: [] }]]);
+    const agent = new ReActAgent(createContext(llm));
+
+    await agent.run('answer me');
+
+    expect(agent.toCheckpoint().finishReason).toBeUndefined();
+  });
+
+  it('captures the stop reason through the runIteration() executor path', async () => {
+    const llm = createFramedLlm([
+      [['done'], { inputTokens: 10, outputTokens: 5, toolsUsed: [], stopReason: 'end_turn' }],
+    ]);
+    const agent = new ReActAgent(createContext(llm));
+
+    const result = await agent.runIteration('do it', { maxHistoryIterations: 0 });
+
+    expect(result.isComplete).toBe(true);
+    expect(result.checkpoint.finishReason).toBe('end_turn');
+  });
+
+  it('survives a checkpoint round-trip through fromCheckpoint (AC5)', async () => {
+    const llm = createFramedLlm([
+      [['done'], { inputTokens: 10, outputTokens: 5, toolsUsed: [], stopReason: 'end_turn' }],
+    ]);
+    const agent = new ReActAgent(createContext(llm));
+    await agent.run('do it');
+
+    // Serialize + restore in a fresh agent, mimicking a continuation Lambda.
+    const serialized = JSON.parse(JSON.stringify(agent.toCheckpoint()));
+    const resumed = new ReActAgent(createContext(createFramedLlm([[['x'], { toolsUsed: [] }]])));
+    resumed.fromCheckpoint(serialized);
+
+    expect(resumed.toCheckpoint().finishReason).toBe('end_turn');
+  });
+});

--- a/b4m-core/agents/src/ReActAgent.ts
+++ b/b4m-core/agents/src/ReActAgent.ts
@@ -57,6 +57,13 @@ export class ReActAgent extends EventEmitter {
   private totalCacheReadTokens = 0;
   private totalCacheWriteTokens = 0;
   private toolCallCount = 0;
+  /**
+   * Provider stop reason of the last LLM completion, preserve-last-non-null.
+   * Surfaced on the checkpoint and persisted to `promptMeta.finishReason` for
+   * chat parity - lets the client tell a truncated artifact from a completed
+   * reply that merely contains an unclosed `<artifact>` tag in prose.
+   */
+  private lastStopReason?: string;
   private observationQueue: Array<{ toolId: string; toolName: string; result: unknown }> = [];
   private confidenceLog: Array<{
     toolName: string;
@@ -142,6 +149,7 @@ export class ReActAgent extends EventEmitter {
     this.toolCallCount = 0;
     this.confidenceLog = [];
     this.iterationConfidences = [];
+    this.lastStopReason = undefined;
 
     const maxIterations = options.maxIterations ?? this.context.maxIterations ?? 50;
     const temperature = options.temperature ?? this.context.temperature ?? 0.7;
@@ -280,6 +288,12 @@ export class ReActAgent extends EventEmitter {
               this.totalTokens += inputTokens + outputTokens;
               this.totalInputTokens += inputTokens;
               this.totalOutputTokens += outputTokens;
+
+              // Preserve the last non-null stop reason (see lastStopReason).
+              // Early streaming frames carry none; the final frame does.
+              if (completionInfo.stopReason != null) {
+                this.lastStopReason = completionInfo.stopReason;
+              }
 
               // Accumulate cache stats if available
               if (completionInfo.cacheStats) {
@@ -749,6 +763,7 @@ Remember: You are an autonomous AGENT. Act independently and solve problems proa
       confidenceLog: structuredClone(this.confidenceLog),
       iterationConfidences: [...this.iterationConfidences],
       initialMessageCount: this.initialMessageCount,
+      finishReason: this.lastStopReason,
     };
   }
 
@@ -778,6 +793,9 @@ Remember: You are an autonomous AGENT. Act independently and solve problems proa
     // field existed; safe because at the point fromCheckpoint runs, no iteration
     // messages have been appended yet for the resumed run.
     this.initialMessageCount = checkpoint.initialMessageCount ?? this.messages.length;
+    // Restore so a run finishing in a continuation Lambda still persists the
+    // stop reason; the finishing Lambda's final completion re-sets it regardless.
+    this.lastStopReason = checkpoint.finishReason;
     // observationQueue is always drained within a single LLM callback -
     // it cannot contain data at checkpoint boundaries. Clear it explicitly.
     this.observationQueue = [];
@@ -839,6 +857,7 @@ Remember: You are an autonomous AGENT. Act independently and solve problems proa
       this.toolCallCount = 0;
       this.confidenceLog = [];
       this.iterationConfidences = [];
+      this.lastStopReason = undefined;
       this.iterations = 0;
 
       this.messages = [
@@ -964,6 +983,12 @@ Remember: You are an autonomous AGENT. Act independently and solve problems proa
             this.totalTokens += inputTokens + outputTokens;
             this.totalInputTokens += inputTokens;
             this.totalOutputTokens += outputTokens;
+
+            // Preserve the last non-null stop reason (see lastStopReason).
+            // A prior tool_use turn is overwritten by the final completion.
+            if (completionInfo.stopReason != null) {
+              this.lastStopReason = completionInfo.stopReason;
+            }
 
             if (completionInfo.cacheStats) {
               this.totalCacheReadTokens += completionInfo.cacheStats.cacheReadTokens || 0;

--- a/b4m-core/agents/src/types.ts
+++ b/b4m-core/agents/src/types.ts
@@ -293,6 +293,12 @@ export interface AgentCheckpoint {
    * with checkpoints written before this field existed.
    */
   initialMessageCount?: number;
+  /**
+   * Provider stop reason of the last LLM completion; persisted to
+   * `promptMeta.finishReason` for chat parity. Optional for backward
+   * compatibility with checkpoints written before this field existed.
+   */
+  finishReason?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Agent-mode completions never recorded the provider stop reason, unlike chat, so the client's truncated-vs-prose-artifact discrimination (`PromptReplies.tsx` `finishedCleanly` check) had no signal in agent mode.
- `ReActAgent` now captures `CompletionInfo.stopReason` (last-non-null across both `run()` and `runIteration()` completion callbacks) into `lastStopReason`, surfaces it on `AgentCheckpoint.finishReason`, and round-trips it through `toCheckpoint()`/`fromCheckpoint()` so it survives continuation-Lambda checkpoint serialization.
- `agentExecutor.ts` threads `finalCheckpoint.finishReason` into `persistRunAsQuest`, which now writes `promptMeta.finishReason` on both the update and create branches (composed alongside existing `mementoIds`, not clobbering it).
- Scope is deliberately narrow: only the normal-completion persist path is touched. The abort/gate-stop and error persist paths are left alone — an incomplete/errored run should not report a clean finish reason.

Stacked on `feat/107-agent-artifact-parity` (#280's branch) since that PR introduces the artifact-emission prompt that makes agent-mode `<artifact>` output (and thus this edge case) reachable.

## Test plan
- [x] `b4m-core/agents` unit tests: new `ReActAgent.finishReason.test.ts` (7 cases) — capture across run()/runIteration(), last-non-null-wins across iterations, checkpoint round-trip.
- [x] `apps/client` unit tests: new `persistRunAsQuest.test.ts` (7 cases) — `finishReason` written on update/create branches, coexists with `mementoIds`, omitted cleanly when absent.
- [x] `b4m-core/agents` full suite (342 tests) + typecheck green.
- [x] `apps/client` `tsgo` typecheck green.
- [x] Lint clean.
- [ ] Manual/live repro of the #280-Review case (unclosed `<artifact>` in prose renders as prose, not a mangled card) — reasoned through against the `PromptReplies.tsx` consumer; not driven in a live browser since this PR touches server-only code.