### PR TITLE
feat(api): serve public v2 chat completions from the always-on QuestProcessorService

### DIFF
--- a/apps/client/server/quest/completionsRoute.ts
+++ b/apps/client/server/quest/completionsRoute.ts
@@ -1,0 +1,279 @@
+import express, { type Request, type Response, type Express } from 'express';
+import {
+  CompletionRequestSchema,
+  LEGACY_REQUEST_ID_HEADER,
+  REQUEST_ID_HEADER,
+  buildMetaEvent,
+  buildSSEEvent,
+  formatSSEError,
+  normalizeCompletionRequest,
+  resolveApiCompletionSource,
+  resolveRequestId,
+  serializeSSEEvent,
+  SSE_DONE_SIGNAL,
+  SSE_KEEPALIVE,
+  type CompletionSource,
+} from '@bike4mind/common';
+import { Logger } from '@bike4mind/observability';
+import { executeCompletion } from '@bike4mind/services';
+import {
+  connectDB,
+  mongoose,
+  adminSettingsRepository,
+  apiKeyRepository,
+  creditTransactionRepository,
+  userRepository,
+  userApiKeyRepository,
+} from '@bike4mind/database';
+import {
+  verifyJwtToken,
+  checkRateLimit,
+  verifyApiKey,
+  checkApiKeyRateLimitOrThrow,
+  type ApiKeyInfo,
+} from '@server/cli/auth';
+import { logCompletionAnalytics } from '@server/utils/logCompletionAnalytics';
+import { Config } from '@server/utils/config';
+import { z } from 'zod';
+
+/**
+ * v2 CLI/3rd-party completions - served by the always-on QuestProcessorService (Fargate)
+ * instead of the v1 `cliLlmHandler` Lambda. Same wire contract (OpenAI-ish SSE), same auth
+ * (user API key or JWT - NOT the shared-secret `/process` gate), same request schema and
+ * analytics. The only difference from v1 is the transport: Express `res` streaming here vs
+ * Lambda response streaming there. v1 is kept alongside for A/B comparison and to serve
+ * existing clients; once v2 is validated the shared orchestration can be unified.
+ *
+ * Why Fargate: no cold start and no 15-minute Lambda ceiling on the steady-state path.
+ * Trade-off inherited from the service: a deploy/scale-in SIGTERM drains for up to 120s
+ * (DRAIN_TIMEOUT_MS in server.ts) before SIGKILL, so a completion still streaming past that
+ * window is cut off - the v1 Lambda allowed up to 15 minutes.
+ */
+
+const V2_ENDPOINT = '/api/ai/v2/completions';
+
+// Periodic SSE comment so an intermediary (CloudFront / socket layer) doesn't close the
+// connection during a token-less gap (e.g. extended thinking). Matches the v1 cadence.
+const HEARTBEAT_INTERVAL_MS = 10_000;
+
+/**
+ * Express headers are `string | string[] | undefined`; the auth/source helpers want a flat
+ * `Record<string, string | undefined>`. Lowercase keys and take the first value of any array.
+ */
+function flattenHeaders(headers: Request['headers']): Record<string, string | undefined> {
+  const flat: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    flat[key.toLowerCase()] = Array.isArray(value) ? value[0] : value;
+  }
+  return flat;
+}
+
+/**
+ * Register `POST /api/ai/v2/completions` on the QuestProcessorService Express app.
+ *
+ * @param track - registers the request's completion promise with the service's SIGTERM
+ *   drain set, so an in-flight stream finishes (bounded by DRAIN_TIMEOUT_MS) before exit.
+ */
+export function registerCompletionsV2Route(app: Express, track: (p: Promise<void>) => void): void {
+  app.post(V2_ENDPOINT, express.json({ limit: '25mb' }), async (req: Request, res: Response) => {
+    // Resolve when the response finishes or the client disconnects - tracked for drain.
+    const done = new Promise<void>(resolve => {
+      res.on('finish', resolve);
+      res.on('close', resolve);
+    });
+    track(done);
+
+    const startTime = Date.now();
+    const headers = flattenHeaders(req.headers);
+    const logger = new Logger({ metadata: { service: 'questProcessorService', endpoint: V2_ENDPOINT } });
+
+    // Correlation ID - accept the caller's value (sanitized) or generate one. #8439
+    const requestId = resolveRequestId(
+      headers[REQUEST_ID_HEADER.toLowerCase()],
+      headers[LEGACY_REQUEST_ID_HEADER.toLowerCase()]
+    );
+    logger.updateMetadata({ requestId });
+
+    // Distinguish CLI from 3rd-party API by the `b4m-cli/<version>` UA the CLI sets.
+    // Used for both the credit transaction and analytics so usage breaks down by surface.
+    const source: CompletionSource = resolveApiCompletionSource(headers);
+
+    // Write helpers guard against a closed socket (client disconnect / already-ended stream).
+    const write = (chunk: string) => {
+      if (!res.writableEnded) res.write(chunk);
+    };
+    let ended = false;
+    const end = () => {
+      if (!ended) {
+        ended = true;
+        res.end();
+      }
+    };
+
+    // SSE headers, then an immediate keep-alive + meta event to establish the stream before
+    // the pre-LLM work (DB connect, auth, rate limiting) can trip an intermediary timeout.
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+    write(SSE_KEEPALIVE);
+    write(serializeSSEEvent(buildMetaEvent(requestId)));
+
+    const heartbeat = setInterval(() => write(SSE_KEEPALIVE), HEARTBEAT_INTERVAL_MS);
+
+    let body: z.infer<typeof CompletionRequestSchema> | undefined;
+    let userId: string | undefined;
+    let apiKeyInfo: ApiKeyInfo | undefined;
+    let apiKeyInfoForCompletion: { keyId: string; keyName: string } | undefined;
+
+    try {
+      // 1. Ensure DB connectivity (the service connects at boot in the background, but a
+      // request can land before that resolves; connectDB is a no-op if already connected).
+      if (mongoose.connection.readyState !== 1) {
+        await connectDB(Config.MONGODB_URI.replace('%STAGE%', Config.STAGE), logger);
+      }
+
+      // 2. Validate request body (already JSON-parsed by express.json above).
+      try {
+        body = normalizeCompletionRequest(CompletionRequestSchema.parse(req.body));
+      } catch {
+        write(serializeSSEEvent(formatSSEError(new Error('Invalid request body'), requestId)));
+        end();
+        return;
+      }
+
+      // 3. Authenticate - API key first, then JWT (mirrors v1).
+      try {
+        apiKeyInfo = await verifyApiKey(headers);
+        userId = apiKeyInfo.userId;
+        logger.info('[CLI_LLM_V2] Authenticated via API key', { keyId: apiKeyInfo.keyId });
+
+        await checkApiKeyRateLimitOrThrow(apiKeyInfo, {
+          userId: apiKeyInfo.userId,
+          endpoint: V2_ENDPOINT,
+          method: req.method,
+        });
+      } catch (apiKeyError) {
+        // API key path failed (missing/invalid key, or rate limit). If a key was present and
+        // valid but rate-limited, surface that rather than falling through to JWT.
+        if (apiKeyInfo) {
+          write(
+            serializeSSEEvent(
+              formatSSEError(apiKeyError instanceof Error ? apiKeyError : new Error('Rate limit exceeded'), requestId)
+            )
+          );
+          end();
+          return;
+        }
+
+        const token = headers.authorization?.replace('Bearer ', '');
+        try {
+          const user = await verifyJwtToken(token);
+          userId = user.id;
+          logger.info('[CLI_LLM_V2] Authenticated via JWT', { userId });
+          await checkRateLimit(userId, source);
+        } catch (jwtError) {
+          write(
+            serializeSSEEvent(
+              formatSSEError(new Error('Authentication failed. Provide a valid API key or JWT token.'), requestId)
+            )
+          );
+          end();
+          return;
+        }
+      }
+
+      logger.updateMetadata({ userId, model: body.model, apiKeyId: apiKeyInfo?.keyId });
+      logger.info(`[CLI_LLM_V2] Starting completion for user ${userId}, model: ${body.model}`, {
+        authMethod: apiKeyInfo ? 'api_key' : 'jwt',
+      });
+
+      // 4. Resolve API key name for credit attribution.
+      if (apiKeyInfo) {
+        const userApiKey = await userApiKeyRepository.findById(apiKeyInfo.keyId);
+        if (userApiKey) {
+          apiKeyInfoForCompletion = { keyId: userApiKey.id, keyName: userApiKey.name };
+        }
+      }
+
+      // 5. Stream the completion, tracking usage for analytics.
+      let finalInputTokens = 0;
+      let finalOutputTokens = 0;
+      let hasToolCalls = false;
+
+      await executeCompletion({
+        userId,
+        model: body.model,
+        messages: body.messages,
+        options: body.options,
+        db: {
+          adminSettings: adminSettingsRepository,
+          apiKeys: apiKeyRepository,
+          creditTransactions: creditTransactionRepository,
+          users: userRepository,
+        },
+        apiKeyInfo: apiKeyInfoForCompletion,
+        source,
+        logger,
+        onChunk: async (text, info) => {
+          if (info?.inputTokens) finalInputTokens = info.inputTokens;
+          if (info?.outputTokens) finalOutputTokens = info.outputTokens;
+          if (info?.toolsUsed && info.toolsUsed.length > 0) hasToolCalls = true;
+          write(serializeSSEEvent(buildSSEEvent(text, info)));
+        },
+      });
+
+      // 6. Close the stream and log success analytics.
+      write(SSE_DONE_SIGNAL);
+      end();
+      logger.info('[CLI_LLM_V2] Completion stream finished successfully');
+
+      await logCompletionAnalytics({
+        type: 'success',
+        requestId,
+        userId,
+        body,
+        apiKeyInfo: apiKeyInfoForCompletion,
+        source,
+        startTime,
+        endpoint: V2_ENDPOINT,
+        method: req.method,
+        finalInputTokens,
+        finalOutputTokens,
+        hasToolCalls,
+        db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository },
+        logger,
+      });
+    } catch (error) {
+      logger.error('[CLI_LLM_V2] Handler error', { error: error instanceof Error ? error.message : String(error) });
+
+      if (userId && body) {
+        await logCompletionAnalytics({
+          type: 'failure',
+          requestId,
+          userId,
+          body,
+          apiKeyInfo: apiKeyInfoForCompletion,
+          source,
+          startTime,
+          endpoint: V2_ENDPOINT,
+          method: req.method,
+          error,
+          db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository },
+          logger,
+        }).catch(() => {}); // analytics failure must not mask the original error
+      }
+
+      try {
+        write(serializeSSEEvent(formatSSEError(error, requestId)));
+        end();
+      } catch (streamError) {
+        logger.error('[CLI_LLM_V2] Failed to write error to stream', {
+          error: streamError instanceof Error ? streamError.message : String(streamError),
+        });
+      }
+    } finally {
+      clearInterval(heartbeat);
+    }
+  });
+}

--- a/apps/client/server/quest/server.test.ts
+++ b/apps/client/server/quest/server.test.ts
@@ -13,13 +13,24 @@ vi.mock('sst', () => ({ Resource: mockResource }));
 const mockProcessQuest = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock('@server/queueHandlers/questProcessor', () => ({ processQuest: mockProcessQuest }));
 
-// questRepository.update - used in the error path; connectDB/mongoose unused by createApp.
+// questRepository.update - used in the error path; connectDB/mongoose unused by /process.
+// The remaining repos are pulled in by the v2 completions route (executeCompletion + credit
+// attribution); stubbed so importing the route doesn't drag in real DB models.
 const mockQuestUpdate = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock('@bike4mind/database', () => ({
   connectDB: vi.fn().mockResolvedValue(undefined),
   mongoose: { connection: { readyState: 1 } },
   questRepository: { update: mockQuestUpdate },
+  userApiKeyRepository: { findById: vi.fn().mockResolvedValue({ id: 'key1', name: 'Test Key' }) },
+  adminSettingsRepository: {},
+  apiKeyRepository: {},
+  creditTransactionRepository: {},
+  userRepository: {},
 }));
+
+// executeCompletion - the v2 route's LLM execution seam. Mock so tests drive its onChunk
+// callback without a real model call.
+const mockExecuteCompletion = vi.hoisted(() => vi.fn());
 
 // Replace the production schema (25+ fields) with a minimal one so the test can drive the
 // 400 (invalid) vs 202 (valid) branches without constructing a full QuestStartBody.
@@ -32,8 +43,23 @@ vi.mock('@bike4mind/services', async () => {
       userId: z.string(),
       message: z.string().min(1),
     }),
+    executeCompletion: mockExecuteCompletion,
   };
 });
+
+// Auth is exercised by the v2 route; mock the whole module so we can drive the API-key /
+// JWT cascade and rate-limit branches without real key validation or JWT verification.
+const mockAuth = vi.hoisted(() => ({
+  verifyApiKey: vi.fn(),
+  verifyJwtToken: vi.fn(),
+  checkApiKeyRateLimitOrThrow: vi.fn(),
+  checkRateLimit: vi.fn(),
+}));
+vi.mock('@server/cli/auth', () => mockAuth);
+
+vi.mock('@server/utils/logCompletionAnalytics', () => ({
+  logCompletionAnalytics: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('@bike4mind/observability', () => ({
   Logger: class {
@@ -41,6 +67,7 @@ vi.mock('@bike4mind/observability', () => ({
     warn = vi.fn();
     error = vi.fn();
     debug = vi.fn();
+    updateMetadata = vi.fn();
   },
 }));
 
@@ -115,5 +142,74 @@ describe('QuestProcessorService /health', () => {
     const res = await fetch(`${baseUrl}/health`);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, readyState: 1 });
+  });
+});
+
+describe('QuestProcessorService /api/ai/v2/completions', () => {
+  const VALID_COMPLETION = { model: 'claude-test', messages: [{ role: 'user', content: 'hi' }] };
+
+  const postCompletion = (body: unknown, headers: Record<string, string> = {}) =>
+    fetch(`${baseUrl}/api/ai/v2/completions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    });
+
+  it('streams an SSE error and does not execute when both API key and JWT auth fail', async () => {
+    mockAuth.verifyApiKey.mockRejectedValue(new Error('No API key provided'));
+    mockAuth.verifyJwtToken.mockRejectedValue(new Error('No authorization token provided'));
+
+    const res = await postCompletion(VALID_COMPLETION);
+    // The SSE stream is established (200 + headers written) before auth runs, so the failure
+    // is delivered as an in-stream error event rather than an HTTP error status.
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const text = await res.text();
+    expect(text).toContain('Authentication failed');
+    expect(mockExecuteCompletion).not.toHaveBeenCalled();
+  });
+
+  it('streams an SSE error on an invalid request body (no execution)', async () => {
+    const res = await postCompletion({ messages: [] }); // missing required `model`
+    const text = await res.text();
+    expect(text).toContain('Invalid request body');
+    expect(mockExecuteCompletion).not.toHaveBeenCalled();
+  });
+
+  it('authenticates via API key, streams chunks, and terminates with [DONE]', async () => {
+    mockAuth.verifyApiKey.mockResolvedValue({
+      keyId: 'key1',
+      userId: 'u1',
+      scopes: [],
+      rateLimit: { requestsPerMinute: 60, requestsPerDay: 1000 },
+    });
+    mockAuth.checkApiKeyRateLimitOrThrow.mockResolvedValue({});
+    mockExecuteCompletion.mockImplementation(async ({ onChunk }) => {
+      await onChunk(['Hello', null], { outputTokens: 5 });
+    });
+
+    const res = await postCompletion(VALID_COMPLETION, { 'x-api-key': 'b4m_test' });
+    const text = await res.text();
+
+    expect(mockExecuteCompletion).toHaveBeenCalledTimes(1);
+    expect(mockExecuteCompletion.mock.calls[0][0]).toMatchObject({ userId: 'u1', model: 'claude-test' });
+    expect(text).toContain('data: [DONE]');
+  });
+
+  it('falls back to JWT auth when no API key is present', async () => {
+    mockAuth.verifyApiKey.mockRejectedValue(new Error('No API key provided'));
+    mockAuth.verifyJwtToken.mockResolvedValue({ id: 'u2', email: null, username: null, user: {} });
+    mockAuth.checkRateLimit.mockResolvedValue(undefined);
+    mockExecuteCompletion.mockImplementation(async ({ onChunk }) => {
+      await onChunk(['hi', null]);
+    });
+
+    const res = await postCompletion(VALID_COMPLETION, { authorization: 'Bearer jwt-token' });
+    const text = await res.text();
+
+    expect(mockAuth.verifyJwtToken).toHaveBeenCalledWith('jwt-token');
+    expect(mockExecuteCompletion).toHaveBeenCalledTimes(1);
+    expect(mockExecuteCompletion.mock.calls[0][0]).toMatchObject({ userId: 'u2' });
+    expect(text).toContain('data: [DONE]');
   });
 });

--- a/apps/client/server/quest/server.ts
+++ b/apps/client/server/quest/server.ts
@@ -7,21 +7,26 @@ import { registerProcessErrorHandlers } from '@bike4mind/utils';
 import { Logger } from '@bike4mind/observability';
 import { Config } from '@server/utils/config';
 import { processQuest } from '@server/queueHandlers/questProcessor';
+import { registerCompletionsV2Route } from './completionsRoute';
 
 /**
- * QuestProcessorService - always-on HTTP worker.
+ * QuestProcessorService - always-on HTTP worker (Fargate).
  *
- * Replaces the old EventBridge -> questProcessor Lambda. The frontend (`/api/ai/llm`,
- * `/api/chat`) creates the quest, then POSTs the QuestStartBody here and gets a 202
- * back in ~milliseconds. We process the quest in-process (the container outlives the
- * HTTP request, unlike a Lambda) and stream results over the existing WebSocket path.
+ * Replaces the old EventBridge -> questProcessor Lambda. Serves two surfaces:
+ *   - POST /process - the frontend (`/api/ai/llm`, `/api/chat`) creates the quest, POSTs the
+ *     QuestStartBody here, and gets a 202 back in ~milliseconds; we process it in-process (the
+ *     container outlives the request, unlike a Lambda) and stream results over WebSocket.
+ *   - POST /api/ai/v2/completions - the user-authenticated CLI/3rd-party SSE completions
+ *     endpoint (see completionsRoute.ts).
  *
  * Why this exists: a long-running container has no cold start and no 15-minute Lambda
  * timeout - the two problems the Lambda path suffered from.
  *
- * Reachability: served on a VPC-internal load balancer, so only the frontend Lambda
- * (same VPC) can reach it. A shared-secret bearer (SECRET_ENCRYPTION_KEY, which both
- * sides already link) is checked as defense-in-depth on top of the network boundary.
+ * Reachability: served on a PUBLIC load balancer (so /api/ai/v2/completions can be exposed
+ * under the bike4mind domain via CloudFront - see infra/questProcessorService.ts). /process is
+ * reachable on the same ALB but is NOT routed through CloudFront and is guarded by a
+ * shared-secret bearer (SECRET_ENCRYPTION_KEY, checked in `authorize` below); the v2 endpoint
+ * uses its own user auth (API key / JWT).
  */
 
 // Default to 8788 for local dev (8080 is commonly taken on dev machines, e.g. Docker
@@ -120,6 +125,14 @@ export function createApp() {
         inFlight.delete(task);
       });
     inFlight.add(task);
+  });
+
+  // v2 CLI/3rd-party completions endpoint (user-authenticated SSE stream). Registered on the
+  // always-on service so it has no cold start / 15-min Lambda ceiling. Its in-flight streams
+  // join the same drain set so SIGTERM lets them finish (bounded by DRAIN_TIMEOUT_MS).
+  registerCompletionsV2Route(app, promise => {
+    inFlight.add(promise);
+    void promise.finally(() => inFlight.delete(promise));
   });
 
   return app;

--- a/infra/questProcessorService.ts
+++ b/infra/questProcessorService.ts
@@ -3,7 +3,7 @@ import { DEFAULT_LAMBDA_ENVIRONMENT, PRODUCTION_STAGES } from './constants';
 import { eventBus } from './eventBus';
 import { imageProcessor } from './imageProcessor';
 import { mcpHandler } from './mcp';
-import { cdnUrlForLambdaEnv } from './router';
+import { cdnUrlForLambdaEnv, router, routePrefix } from './router';
 import { allSecrets } from './secrets';
 import { cluster, resolvedVpcId } from './vpc';
 import { websocketApi } from './websocket';
@@ -56,10 +56,14 @@ export const questProcessorService = new sst.aws.Service('QuestProcessorService'
   // Prebuilt image referenced by URI (built & pushed by CI — see note above). Building
   // out-of-band keeps `sst deploy` build-free, matching subscriberFanout.
   image: questProcessorImage,
-  // VPC-internal load balancer — only the frontend Lambda (same VPC) can reach it. The
-  // shared-secret bearer checked in server.ts is defense-in-depth on top of this.
+  // Internet-facing load balancer. Public so the v2 CLI/3rd-party completions endpoint
+  // (/api/ai/v2/completions) can be exposed under the bike4mind domain via the shared
+  // CloudFront router (route added below). /process is also reachable on this ALB but is
+  // NOT routed through CloudFront and stays guarded by the shared-secret bearer checked in
+  // server.ts. NOTE: the frontend Lambda's /process dispatch now targets the public ALB DNS
+  // (Resource.QuestProcessorService.url) and egresses via NAT rather than staying VPC-internal.
   loadBalancer: {
-    public: false,
+    public: true,
     rules: [{ listen: '80/http', forward: '8080/http' }],
     health: {
       '8080/http': {
@@ -152,6 +156,16 @@ export const questProcessorService = new sst.aws.Service('QuestProcessorService'
 // conflict on the shared `default` SG. Guarded on !$dev: in `sst dev` the Service runs via
 // dev.command with no load balancer, and accessing nodes.loadBalancer would throw.
 if (!$dev) {
+  // Expose the v2 CLI/3rd-party completions endpoint under the bike4mind domain via the
+  // shared CloudFront router (same distribution as the app and the v1 `cliLlmHandler`
+  // Lambda). CloudFront terminates TLS at the edge and forwards to the public ALB over
+  // http (:80 -> container :8080). Only this path is routed through CloudFront; /process is
+  // reachable only via the ALB directly. routePrefix namespaces the path per-stage on the
+  // shared dev distribution (empty on deployed dev/production). Guarded on !$dev because the
+  // load balancer (and thus `.url`) only exists when the Service runs in the cloud - under
+  // `sst dev` it runs via dev.command with no ALB, and the CLI reaches it on localhost:8788.
+  router.route(`${routePrefix}/api/ai/v2/completions`, questProcessorService.url);
+
   const defaultSecurityGroupId = aws.ec2
     .getSecurityGroupsOutput({
       filters: [


### PR DESCRIPTION
## Description

Ports the **public-API chat-completion endpoint onto the always-on Fargate `QuestProcessorService`**, alongside the existing `/process` quest surface. Adds `POST /api/ai/v2/completions` — the user-authenticated CLI / 3rd-party SSE completions endpoint — served in-process by the long-running container instead of the v1 `cliLlmHandler` Lambda.

**Why:** the container has no cold start and no 15-minute Lambda ceiling on the steady-state path. v1 is kept alongside for A/B comparison and existing clients; once v2 is validated the shared orchestration can be unified.

This mirrors the same change from the upstream (lumina5) repo. All the machinery it relies on (`executeCompletion`, the SSE helpers in `@bike4mind/common`, `@server/cli/auth`, `logCompletionAnalytics`, the infra `router`/`routePrefix`) already exists in this repo.

## Changes

- **`apps/client/server/quest/completionsRoute.ts`** (new): registers `POST /api/ai/v2/completions`. Same wire contract (OpenAI-ish SSE), same auth (user API key -> JWT cascade — **not** the shared-secret `/process` gate), same request schema and analytics as v1; the only difference is Express `res` streaming vs Lambda response streaming. In-flight streams join the service's SIGTERM drain set (bounded by `DRAIN_TIMEOUT_MS`).
- **`apps/client/server/quest/server.ts`**: register the v2 route on the app; document the two surfaces and the move to a public ALB.
- **`infra/questProcessorService.ts`**: make the ALB internet-facing (`public: true`) and expose **only** `/api/ai/v2/completions` under the bike4mind domain via the shared CloudFront router. `/process` stays off CloudFront, guarded by the shared-secret bearer.
- **`apps/client/server/quest/server.test.ts`**: cover the v2 route — auth failure, invalid body, API-key success terminating with `[DONE]`, and JWT fallback.

Not included (unrelated WIP that happened to be in the upstream working tree): a `pages/api/chat.ts` org-id-stringify bugfix and an untracked `apps/cli/` directory.

## Security note for reviewers

This flips the QuestProcessorService ALB from **VPC-internal to internet-facing**. The exposure is deliberately narrow:
- Only `/api/ai/v2/completions` is routed through CloudFront (TLS at the edge -> ALB :80 -> container :8080), and it enforces its own user auth (API key or JWT) + rate limiting.
- `/process` is reachable on the ALB but is **not** routed through CloudFront and remains behind the shared-secret bearer checked in `server.ts`.
- The frontend Lambda's `/process` dispatch now targets the public ALB DNS and egresses via NAT rather than staying VPC-internal.

## Guide for Testers

1. Deploy a preview/staging build of this branch.
2. Obtain a user API key (Profile -> API Keys) or a valid JWT.
3. `curl -N -X POST https://<stage>.bike4mind.com/api/ai/v2/completions -H 'x-api-key: <key>' -H 'content-type: application/json' -d '{"model":"claude-sonnet-5","messages":[{"role":"user","content":"say hi"}]}'`
4. Expected: an SSE stream — a `meta` event, then `data:` token chunks, terminating with `data: [DONE]`. No cold-start delay on repeat calls.
5. Auth failure: repeat with no/invalid key and no JWT. Expected: `200` with an in-stream SSE error event containing `Authentication failed` (the stream is opened before auth runs), and no completion executed.
6. Invalid body (omit `model`). Expected: in-stream `Invalid request body` error, no execution.

### Regression Checks
- `POST /process` still returns `202` for an authorized valid `QuestStartBody` and `401`/`400` otherwise (unchanged).
- The v1 `cliLlmHandler` Lambda endpoint still works for existing clients.
- WebSocket quest streaming (the `/process` path) is unaffected.

### What NOT to test
- No UI changes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings