### PR TITLE
chore(deps): upgrade archive/zip deps (yauzl, unzipper)

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -223,7 +223,7 @@
     "uuid": "^13.0.2",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "yargs": "^18.0.0",
-    "yauzl": "^3.3.0",
+    "yauzl": "^3.4.0",
     "zod": "^4.4.3",
     "zod-validation-error": "^5.0.0",
     "zustand": "^5.0.13"

--- a/b4m-core/mcp/package.json
+++ b/b4m-core/mcp/package.json
@@ -74,7 +74,7 @@
     "@bike4mind/common": "workspace:*",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@octokit/rest": "^22.0.1",
-    "unzipper": "^0.12.3",
+    "unzipper": "^0.12.5",
     "zod": "^4.4.3"
   }
 }

--- a/b4m-core/services/package.json
+++ b/b4m-core/services/package.json
@@ -227,7 +227,7 @@
     "tiktoken": "^1.0.22",
     "turndown": "^7.2.4",
     "uuid": "^13.0.2",
-    "yauzl": "^3.3.0",
+    "yauzl": "^3.4.0",
     "zod": "^4.4.3",
     "zod-validation-error": "^5.0.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -120,7 +120,7 @@
     "ws": "^8.21.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "yargs": "^18.0.0",
-    "yauzl": "^3.3.0",
+    "yauzl": "^3.4.0",
     "zod": "^4.4.3",
     "zod-validation-error": "^5.0.0",
     "zustand": "^5.0.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -664,8 +664,8 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
       yauzl:
-        specifier: ^3.3.0
-        version: 3.3.0
+        specifier: ^3.4.0
+        version: 3.4.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -831,7 +831,7 @@ importers:
         version: 9.4.0
       serwist:
         specifier: 9.5.3
-        version: 9.5.3(browserslist@4.28.1)(typescript@5.9.3)
+        version: 9.5.3(browserslist@4.28.2)(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.11)(@types/node@24.12.3)(typescript@5.9.3)
@@ -1155,8 +1155,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       unzipper:
-        specifier: ^0.12.3
-        version: 0.12.3
+        specifier: ^0.12.5
+        version: 0.12.5
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1318,8 +1318,8 @@ importers:
         specifier: ^13.0.2
         version: 13.0.2
       yauzl:
-        specifier: ^3.3.0
-        version: 3.3.0
+        specifier: ^3.4.0
+        version: 3.4.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1794,8 +1794,8 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
       yauzl:
-        specifier: ^3.3.0
-        version: 3.3.0
+        specifier: ^3.4.0
+        version: 3.4.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -7563,6 +7563,10 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs-extra@11.3.1:
+    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
+    engines: {node: '>=14.14'}
+
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
@@ -8486,6 +8490,9 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
@@ -11387,8 +11394,8 @@ packages:
   unzipper@0.10.14:
     resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
 
-  unzipper@0.12.3:
-    resolution: {integrity: sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==}
+  unzipper@0.12.5:
+    resolution: {integrity: sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -11829,8 +11836,8 @@ packages:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yauzl@3.3.0:
-    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
     engines: {node: '>=12'}
 
   yjs@13.6.27:
@@ -15116,6 +15123,10 @@ snapshots:
   '@serwist/utils@9.5.3(browserslist@4.28.1)':
     optionalDependencies:
       browserslist: 4.28.1
+
+  '@serwist/utils@9.5.3(browserslist@4.28.2)':
+    optionalDependencies:
+      browserslist: 4.28.2
 
   '@serwist/window@9.5.3(browserslist@4.28.1)(typescript@5.9.3)':
     dependencies:
@@ -18661,6 +18672,12 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs-extra@11.3.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
@@ -19765,6 +19782,12 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsonpointer@5.0.1: {}
 
   jsonrepair@3.14.0: {}
@@ -20718,7 +20741,7 @@ snapshots:
       semver: 7.8.4
       tar-stream: 3.2.0
       tslib: 2.8.1
-      yauzl: 3.3.0
+      yauzl: 3.4.0
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -22223,6 +22246,15 @@ snapshots:
     transitivePeerDependencies:
       - browserslist
 
+  serwist@9.5.3(browserslist@4.28.2)(typescript@5.9.3):
+    dependencies:
+      '@serwist/utils': 9.5.3(browserslist@4.28.2)
+      idb: 8.0.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - browserslist
+
   set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
@@ -23184,11 +23216,11 @@ snapshots:
       readable-stream: 2.3.8
       setimmediate: 1.0.5
 
-  unzipper@0.12.3:
+  unzipper@0.12.5:
     dependencies:
       bluebird: 3.7.2
       duplexer2: 0.1.4
-      fs-extra: 11.3.5
+      fs-extra: 11.3.1
       graceful-fs: 4.2.11
       node-int64: 0.4.0
 
@@ -23674,9 +23706,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
-  yauzl@3.3.0:
+  yauzl@3.4.0:
     dependencies:
-      buffer-crc32: 0.2.13
       pend: 1.2.0
 
   yjs@13.6.27:


### PR DESCRIPTION
## Description

Routine dependency maintenance: bumps the zip/archive decompression libraries to
their latest patch/minor releases. All within-major bumps, no API changes for
our usage. Part of the `/upgrade-deps` misc sweep, grouped by functional domain
and isolated for independent review/rollback.

## Changes

- `yauzl`: `3.3.0` -> `3.4.0`
- `unzipper`: `0.12.3` -> `0.12.5`

Note: `@types/yauzl` (2.x -> 3.x, a major bump) is intentionally left for the
separate major-version upgrade round; the existing 2.x types already typecheck
cleanly against yauzl 3.x.

## Guide for Testers

Backend/CLI dependency-only change (patch/minor). No web UI. Verification is the
type gate plus a smoke of any zip extraction path.

1. Check out the branch, run `pnpm i -r`, then `pnpm turbo:typecheck`.
   - Expected: all packages typecheck (verified locally: 35/35 green).
2. Exercise a code path that unzips/extracts an archive (e.g. importing or
   processing an uploaded `.zip`).
   - Expected: the archive extracts and its entries are read as before.

### Regression Checks
- Zip extraction via `yauzl` and `unzipper` (uploads / imports that unpack
  archives).

### What NOT to test
- No frontend/UI, infra, or env changes. No new admin settings or flags.
