### PR TITLE
feat: polish login and register auth screen UI

### DIFF
--- a/apps/client/app/components/MultiStepLogin.test.tsx
+++ b/apps/client/app/components/MultiStepLogin.test.tsx
@@ -55,7 +55,10 @@ vi.mock('@client/app/hooks/useCommonStyles', () => ({
 vi.mock('@client/app/hooks/useGetLogo', () => ({ default: () => '/logo.png' }));
 vi.mock('@client/app/hooks/data/settings', () => ({ useBrandingSettings: () => ({}) }));
 vi.mock('next/image', () => ({ default: () => null }));
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+  Trans: ({ i18nKey }: { i18nKey?: string }) => i18nKey ?? null,
+}));
 vi.mock('sonner', () => ({ toast: mocks.toast }));
 
 const appTheme = extendTheme({ ...getThemeConfig() });

--- a/apps/client/app/components/MultiStepLogin.tsx
+++ b/apps/client/app/components/MultiStepLogin.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { applyRedirect, appendRedirectTo } from '@client/app/utils/authRedirect';
 import { getLoginErrorMessage } from '@client/app/utils/loginErrorMessages';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { toast } from 'sonner';
 import {
   Box,
@@ -574,7 +574,11 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
               className="otc-subtitle"
               sx={{ color: 'text.tertiary', fontSize: '14px', mt: '4px', textAlign: 'center' }}
             >
-              {t('auth.codeSentTo', { email: email.trim() })}
+              <Trans
+                i18nKey="auth.codeSentTo"
+                values={{ email: email.trim() }}
+                components={{ email: <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }} /> }}
+              />
             </Typography>
           )}
 
@@ -774,7 +778,7 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
                           fontWeight: 500,
                           fontSize: '14px',
                           cursor: 'pointer',
-                          transition: 'opacity 0.2s ease-in-out',
+                          transition: 'color 0.2s ease-in-out',
                           '&:hover': { textDecoration: 'underline' },
                         }}
                       >
@@ -819,11 +823,9 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
                     disabled={isVerifying}
                     sx={{
                       ...inputStyles,
-                      '--Input-minHeight': '48px',
-                      fontSize: '24px',
-                      letterSpacing: '8px',
+                      '--Input-minHeight': '40px',
                       textAlign: 'center',
-                      '& input': { textAlign: 'center' },
+                      '& input': { textAlign: 'center', letterSpacing: '4px' },
                     }}
                   />
                 </FormControl>
@@ -846,26 +848,10 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
                   </Typography>
                 </Button>
 
-                <Box sx={{ display: 'flex', justifyContent: 'center', mt: '20px', gap: 2 }}>
-                  <Link
-                    className="resend-code-link"
-                    data-testid="login-resend-btn"
-                    color="primary"
-                    onClick={handleResendCode}
-                    sx={{
-                      fontWeight: 500,
-                      fontSize: '14px',
-                      cursor: resendCooldown > 0 ? 'default' : 'pointer',
-                      opacity: resendCooldown > 0 ? 0.5 : 1,
-                      transition: 'opacity 0.2s ease-in-out',
-                      '&:hover': { textDecoration: resendCooldown > 0 ? 'none' : 'underline' },
-                    }}
-                  >
-                    {resendCooldown > 0 ? `${t('auth.resendCode')} (${resendCooldown}s)` : t('auth.resendCode')}
-                  </Link>
-                </Box>
-
-                <Box className="back-to-email-container" sx={{ display: 'flex', justifyContent: 'center', mt: '12px' }}>
+                <Box
+                  className="otc-actions-container"
+                  sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: '20px', gap: 2 }}
+                >
                   <Link
                     className="back-to-email-link"
                     data-testid="login-back-btn"
@@ -875,11 +861,28 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
                       fontWeight: 500,
                       fontSize: '14px',
                       cursor: 'pointer',
-                      transition: 'opacity 0.2s ease-in-out',
+                      transition: 'color 0.2s ease-in-out',
                       '&:hover': { textDecoration: 'underline' },
                     }}
                   >
                     ← {t('auth.backToEmail')}
+                  </Link>
+
+                  <Link
+                    className="resend-code-link"
+                    data-testid="login-resend-btn"
+                    color={resendCooldown > 0 ? 'neutral' : 'primary'}
+                    onClick={handleResendCode}
+                    sx={{
+                      fontWeight: 500,
+                      fontSize: '14px',
+                      color: resendCooldown > 0 ? 'text.tertiary' : undefined,
+                      cursor: resendCooldown > 0 ? 'default' : 'pointer',
+                      transition: 'color 0.2s ease-in-out',
+                      '&:hover': { textDecoration: resendCooldown > 0 ? 'none' : 'underline' },
+                    }}
+                  >
+                    {resendCooldown > 0 ? `${t('auth.resendCode')} (${resendCooldown}s)` : t('auth.resendCode')}
                   </Link>
                 </Box>
               </form>
@@ -1002,7 +1005,7 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
                       fontWeight: 500,
                       fontSize: '14px',
                       cursor: 'pointer',
-                      transition: 'opacity 0.2s ease-in-out',
+                      transition: 'color 0.2s ease-in-out',
                       '&:hover': { textDecoration: 'underline' },
                     }}
                   >

--- a/apps/client/app/components/Register.test.tsx
+++ b/apps/client/app/components/Register.test.tsx
@@ -54,7 +54,10 @@ vi.mock('@client/app/hooks/data/settings', () => ({
 }));
 vi.mock('./common/MFAModal', () => ({ default: () => null }));
 vi.mock('next/image', () => ({ default: () => null }));
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+  Trans: ({ i18nKey }: { i18nKey?: string }) => i18nKey ?? null,
+}));
 vi.mock('sonner', () => ({ toast: mocks.toast }));
 
 import Register from './Register';

--- a/apps/client/app/components/Register.tsx
+++ b/apps/client/app/components/Register.tsx
@@ -645,7 +645,7 @@ const Register: React.FC = () => {
                         Controller (not register spread): MUI Joy Checkbox forwards a ref to its
                         root span, not the <input>, so a bare register() would not reliably track
                         `checked`. Controller drives the boolean value explicitly. */}
-                    <Stack spacing={1} sx={{ mt: '20px' }}>
+                    <Stack sx={{ mt: '20px', gap: '8px' }}>
                       <Controller
                         control={control}
                         name="acceptPolicies"
@@ -654,6 +654,7 @@ const Register: React.FC = () => {
                             className="register-aup-tos-checkbox"
                             data-testid="register-aup-tos-checkbox"
                             size="sm"
+                            sx={{ alignItems: 'center' }}
                             checked={value === true}
                             onChange={e => onChange(e.target.checked)}
                             onBlur={onBlur}
@@ -714,7 +715,7 @@ const Register: React.FC = () => {
                       />
                     </Stack>
 
-                    <FormControl className="register-submit-control" sx={{ mt: '24px' }}>
+                    <FormControl className="register-submit-control" sx={{ mt: '32px' }}>
                       <Button
                         className="register-submit-button"
                         data-testid="register-submit-btn"
@@ -759,7 +760,7 @@ const Register: React.FC = () => {
                             fontWeight: 500,
                             fontSize: '14px',
                             cursor: 'pointer',
-                            transition: 'opacity 0.2s ease-in-out',
+                            transition: 'color 0.2s ease-in-out',
                             '&:hover': { textDecoration: 'underline' },
                           }}
                         >
@@ -839,7 +840,7 @@ const Register: React.FC = () => {
                     fontSize: '14px',
                     cursor: resendCooldown > 0 ? 'default' : 'pointer',
                     opacity: resendCooldown > 0 ? 0.5 : 1,
-                    transition: 'opacity 0.2s ease-in-out',
+                    transition: 'color 0.2s ease-in-out, opacity 0.2s ease-in-out',
                     '&:hover': { textDecoration: resendCooldown > 0 ? 'none' : 'underline' },
                   }}
                 >

--- a/apps/client/app/components/Register.tsx
+++ b/apps/client/app/components/Register.tsx
@@ -29,7 +29,7 @@ import { Controller, useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import React, { useEffect, useState, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { toast } from 'sonner';
 import useGetLogo from '../hooks/useGetLogo';
 import { useBrandingSettings, usePublicConfig } from '../hooks/data/settings';
@@ -489,9 +489,15 @@ const Register: React.FC = () => {
               variant="plain"
               sx={{ textAlign: 'center', color: 'text.tertiary', fontSize: '14px', mt: '4px' }}
             >
-              {currentStep === 'form'
-                ? t('auth.createAccountDesc')
-                : t('auth.codeSentTo', { email: submittedData?.email })}
+              {currentStep === 'form' ? (
+                t('auth.createAccountDesc')
+              ) : (
+                <Trans
+                  i18nKey="auth.codeSentTo"
+                  values={{ email: submittedData?.email }}
+                  components={{ email: <Box component="span" sx={{ color: 'text.primary', fontWeight: 600 }} /> }}
+                />
+              )}
             </Typography>
           </Box>
 

--- a/apps/client/app/locales/en.json
+++ b/apps/client/app/locales/en.json
@@ -215,7 +215,7 @@
     "backToEmail": "Back to email",
     "checkYourEmail": "Check your email",
     "codeSent": "Verification code sent! Check your email.",
-    "codeSentTo": "We sent a code to {{email}}",
+    "codeSentTo": "We sent a code to <email>{{email}}</email>",
     "emailRequired": "Email is required",
     "enterEmail": "Enter your email address",
     "verifyCode": "Verify Code",


### PR DESCRIPTION
## Summary

UI polish pass on the login (`MultiStepLogin`) and registration (`Register`)
screens. No behavior or auth-flow changes - purely visual/interaction refinements.

## Changes

### Login - code verification (OTC) step
- Restyle the code input to match the email input (40px height, standard font
  size) instead of the oversized 48px/24px field; keep digits centered with
  `4px` letter-spacing on the inner input for readability.
- Combine the **Back to email** and **Resend code** actions into a single row
  (`space-between`): back-left, resend-right, replacing the previous stacked
  layout.
- Resend link now turns gray (`text.tertiary`) while the cooldown counts down and
  returns to primary once ready, instead of dimming via opacity.
- Highlight the recipient email in the "We sent a code to ..." subtitle
  (`text.primary`, weight 600) via a `<Trans>` placeholder so it stays
  translatable.

### Register screen
- Increase the Continue/Create-account button top margin `24px` -> `32px`.
- Set an explicit `8px` gap between the Terms/AUP/Privacy and age checkboxes.
- Vertically center the Terms/AUP/Privacy checkbox against its multi-line label
  (`alignItems: center`).

### Both screens
- Switch inline link hover transitions from `opacity` to `color`
  (Register-now, Login, Resend, Back-to-email) to match the Terms/Privacy links.

## Testing
- `pnpm lint:check` - passes.
- `pnpm --filter @bike4mind/client typecheck` - passes.
- `pnpm --filter @bike4mind/client test` - 4987 passed, 81 skipped, 0 failed.
- Manually verified the login OTC step and register form in light/dark mode.

## Notes
- i18n: `auth.codeSentTo` now wraps the email in an `<email>` placeholder. Other
  locales that still use plain `{{email}}` continue to render correctly (email
  just shows unstyled), so no translation breakage.
- Updated `MultiStepLogin.test.tsx` to stub `Trans` in the existing
  `react-i18next` mock (the component now renders `<Trans>`).
  
  --- 
  
  
<img width="1431" height="658" alt="Group 10" src="https://github.com/user-attachments/assets/e7ec6e57-a8ad-4ac3-9f14-481940e1d636" />

  
  