### PR TITLE
chore: github restricted star data, remove history chart and add badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An open-core AI knowledge platform — a multi-model workspace where notebooks, 
 
 [![Chat on Bike4Mind](https://img.shields.io/badge/chat-Bike4Mind-6d28d9)](https://app.bike4mind.com) &nbsp;
 [![License: BUSL-1.1](https://img.shields.io/badge/license-BUSL--1.1-blue)](./LICENSE) &nbsp;
-[![Discussions](https://img.shields.io/badge/community-Discussions-24292f)](https://github.com/bike4mind/bike4mind/discussions)
+[![Discussions](https://img.shields.io/badge/community-Discussions-24292f)](https://github.com/bike4mind/bike4mind/discussions) &nbsp;
+[![GitHub stars](https://img.shields.io/github/stars/bike4mind/bike4mind?style=flat&label=stars&color=6d28d9)](https://github.com/bike4mind/bike4mind)
 
 </div>
 
@@ -83,15 +84,5 @@ Bike4Mind is licensed under the **[Business Source License 1.1](./LICENSE)** wit
 - 🕓 Each released version **converts to Apache-2.0** two years after its public release. This license will never be tightened.
 
 For alternative licensing, contact **licensing@bike4mind.com**.
-
-## Star History
-
-<a href="https://www.star-history.com/?repos=bike4mind%2Fbike4mind&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=bike4mind/bike4mind&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=bike4mind/bike4mind&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=bike4mind/bike4mind&type=date&legend=top-left" />
- </picture>
-</a>
 
 © 2026 Bike4Mind, Inc.


### PR DESCRIPTION
# Pull Request

## Screenshot
<img width="1028" height="356" alt="image" src="https://github.com/user-attachments/assets/de126f9c-d5bb-4dd4-bf73-add768f8ef72" />

## Description

Github restricted access to star data this week: https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/

Which breaks star-history charts. We could use the star-history CLI to generate history chart images and commit them to the repo (weekly job?) or etc, but that doesn't seem worth it for what it provides right now.

So:
- remove the history chart
- add the badge for the static count