### PR TITLE
fix(client): wire up the email cancel-change deep link and harden the cancel flow

### DIFF
--- a/apps/client/app/components/profile/ChangeEmailCard.test.tsx
+++ b/apps/client/app/components/profile/ChangeEmailCard.test.tsx
@@ -109,11 +109,46 @@ describe('ChangeEmailCard', () => {
     expect(navArg.replace).toBe(true);
   });
 
-  it('does not open the dialog from the deep link when there is no pending change', () => {
+  it('consumes a stale deep link (loaded, nothing pending): no dialog, but strips the param', async () => {
+    // pendingEmail key present but null => authoritative state loaded, nothing to cancel.
     mockCurrentUser = { email: 'current@example.com', emailVerified: true, pendingEmail: null };
+    mockSearch = { action: 'cancel-email-change', tab: 'profile' };
+    renderCard();
+    expect(screen.queryByTestId('profile-cancel-email-confirm-btn')).not.toBeInTheDocument();
+    // The param is still stripped so it can't linger and re-fire on a later pending change.
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    expect(mockNavigate.mock.calls[0][0].search).not.toHaveProperty('action');
+  });
+
+  it('waits (does not consume the link) while the pending state has not loaded', () => {
+    // The persisted slim user omits the pendingEmail key entirely - "not loaded yet".
+    mockCurrentUser = { email: 'current@example.com', emailVerified: true };
     mockSearch = { action: 'cancel-email-change' };
     renderCard();
     expect(screen.queryByTestId('profile-cancel-email-confirm-btn')).not.toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not re-open the dialog on a later null -> pending transition once the link is consumed', async () => {
+    const client = new QueryClient();
+    const ui = (
+      <QueryClientProvider client={client}>
+        <CssVarsProvider>
+          <ChangeEmailCard />
+        </CssVarsProvider>
+      </QueryClientProvider>
+    );
+    // Arrive via a stale link with nothing pending: the link is consumed one-shot.
+    mockCurrentUser = { email: 'current@example.com', emailVerified: true, pendingEmail: null };
+    mockSearch = { action: 'cancel-email-change' };
+    const { rerender } = render(ui);
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    expect(screen.queryByTestId('profile-cancel-email-confirm-btn')).not.toBeInTheDocument();
+
+    // User then requests a new change on the same page: pendingEmail flips null -> truthy.
+    mockCurrentUser = { email: 'current@example.com', emailVerified: true, pendingEmail: 'brand-new@example.com' };
+    rerender(ui);
+    // The dialog must NOT auto-open for the just-created change.
+    expect(screen.queryByTestId('profile-cancel-email-confirm-btn')).not.toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/profile/ChangeEmailCard.test.tsx
+++ b/apps/client/app/components/profile/ChangeEmailCard.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CssVarsProvider } from '@mui/joy/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ChangeEmailCard from './ChangeEmailCard';
+
+// SectionContainer pulls in the help/import chain - stub it to just render children.
+vi.mock('@client/app/components/ProfileModal/SectionContainer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Router: useSearch drives the email deep-link; useNavigate strips the param.
+let mockSearch: Record<string, unknown> = {};
+const mockNavigate = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  useSearch: () => mockSearch,
+  useNavigate: () => mockNavigate,
+}));
+
+// UserContext: useUser is called both bare (`useUser()`) and with a selector.
+const mockRefreshUser = vi.fn().mockResolvedValue(undefined);
+let mockCurrentUser: Record<string, unknown> | null = null;
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: (selector?: (s: Record<string, unknown>) => unknown) => {
+    const state = { currentUser: mockCurrentUser, refreshUser: mockRefreshUser };
+    return selector ? selector(state) : state;
+  },
+}));
+
+const mockPost = vi.fn().mockResolvedValue({ data: { message: 'ok' } });
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { post: (...args: unknown[]) => mockPost(...args) },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? _k }),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: { success: (...a: unknown[]) => mockToastSuccess(...a), error: (...a: unknown[]) => mockToastError(...a) },
+}));
+
+const renderCard = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <CssVarsProvider>
+        <ChangeEmailCard />
+      </CssVarsProvider>
+    </QueryClientProvider>
+  );
+
+describe('ChangeEmailCard', () => {
+  beforeEach(() => {
+    mockPost.mockClear();
+    mockNavigate.mockClear();
+    mockRefreshUser.mockClear();
+    mockToastSuccess.mockClear();
+    mockToastError.mockClear();
+    mockSearch = {};
+    mockCurrentUser = { email: 'current@example.com', emailVerified: true, pendingEmail: 'new@example.com' };
+  });
+
+  it('renders the pending banner and Cancel button when a change is pending', () => {
+    renderCard();
+    expect(screen.getByTestId('profile-pending-email-alert')).toHaveTextContent('new@example.com');
+    expect(screen.getByTestId('profile-cancel-email-change-btn')).toBeInTheDocument();
+  });
+
+  it('shows the Change button (no banner) when nothing is pending', () => {
+    mockCurrentUser = { email: 'current@example.com', emailVerified: true, pendingEmail: null };
+    renderCard();
+    expect(screen.queryByTestId('profile-pending-email-alert')).not.toBeInTheDocument();
+    expect(screen.getByTestId('profile-change-email-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('profile-cancel-email-change-btn')).not.toBeInTheDocument();
+  });
+
+  it('fires the cancel-change request after confirming, and refreshes the user', async () => {
+    renderCard();
+    fireEvent.click(screen.getByTestId('profile-cancel-email-change-btn'));
+    fireEvent.click(screen.getByTestId('profile-cancel-email-confirm-btn'));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/api/email/cancel-change'));
+    await waitFor(() => expect(mockRefreshUser).toHaveBeenCalled());
+  });
+
+  it('does not fire a request when the confirm dialog is dismissed', () => {
+    renderCard();
+    fireEvent.click(screen.getByTestId('profile-cancel-email-change-btn'));
+    fireEvent.click(screen.getByTestId('profile-cancel-email-dismiss-btn'));
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('opens the confirm dialog from the email deep link and strips the action param', async () => {
+    mockSearch = { action: 'cancel-email-change', tab: 'profile' };
+    renderCard();
+
+    // Confirmation dialog auto-opens (but does NOT auto-cancel - explicit click still required).
+    expect(await screen.findByTestId('profile-cancel-email-confirm-btn')).toBeInTheDocument();
+    expect(mockPost).not.toHaveBeenCalled();
+
+    // The action param is stripped so a reload/back-nav won't reopen the dialog; tab is preserved.
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    const navArg = mockNavigate.mock.calls[0][0];
+    expect(navArg.search).not.toHaveProperty('action');
+    expect(navArg.search).toEqual({ tab: 'profile' });
+    expect(navArg.replace).toBe(true);
+  });
+
+  it('does not open the dialog from the deep link when there is no pending change', () => {
+    mockCurrentUser = { email: 'current@example.com', emailVerified: true, pendingEmail: null };
+    mockSearch = { action: 'cancel-email-change' };
+    renderCard();
+    expect(screen.queryByTestId('profile-cancel-email-confirm-btn')).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/profile/ChangeEmailCard.tsx
+++ b/apps/client/app/components/profile/ChangeEmailCard.tsx
@@ -18,13 +18,19 @@ import EmailIcon from '@mui/icons-material/Email';
 import EditIcon from '@mui/icons-material/Edit';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import WarningIcon from '@mui/icons-material/Warning';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSearch, useNavigate } from '@tanstack/react-router';
 import { api } from '@client/app/contexts/ApiContext';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
 const RESEND_COOLDOWN_SECONDS = 60;
+
+// Deep-link action from the "Cancel Email Change" button in the security-alert
+// email (see the cancelUrl built in `pages/api/email/change.ts`). Landing on
+// `/profile?action=cancel-email-change` opens the cancel confirmation dialog.
+const CANCEL_EMAIL_CHANGE_ACTION = 'cancel-email-change';
 
 const useRequestEmailChange = () => {
   const queryClient = useQueryClient();
@@ -183,6 +189,9 @@ const ChangeEmailCard = () => {
   const [cooldownSeconds, setCooldownSeconds] = useState(0);
   const { t } = useTranslation();
   const cancelChange = useCancelEmailChange();
+  const search = useSearch({ strict: false }) as { action?: string };
+  const navigate = useNavigate();
+  const handledCancelActionRef = useRef(false);
 
   const resendVerification = useMutation({
     mutationFn: async () => {
@@ -211,6 +220,25 @@ const ChangeEmailCard = () => {
     return () => clearTimeout(timer);
   }, [cooldownSeconds]);
 
+  // Handle the `?action=cancel-email-change` deep link from the security-alert
+  // email. Open the confirmation dialog rather than cancelling outright: an
+  // email client or link scanner that pre-fetches the URL must not be able to
+  // silently cancel a legitimate change - an explicit click is still required.
+  // Wait until `pendingEmail` has loaded (via /api/identify) before acting, and
+  // strip the param afterward so a reload or back-nav doesn't reopen the dialog.
+  useEffect(() => {
+    if (search?.action !== CANCEL_EMAIL_CHANGE_ACTION) return;
+    if (handledCancelActionRef.current) return;
+    if (!currentUser?.pendingEmail) return;
+    handledCancelActionRef.current = true;
+    // Intentional one-shot deep-link handler (ref-guarded): open the dialog in
+    // response to the URL param. This is a URL->UI sync, not a render cascade.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setConfirmCancelOpen(true);
+    const { action: _action, ...rest } = search;
+    navigate({ to: '/profile', search: rest, replace: true });
+  }, [search, currentUser?.pendingEmail, navigate]);
+
   if (!currentUser?.email) {
     return null;
   }
@@ -226,8 +254,9 @@ const ChangeEmailCard = () => {
     try {
       await cancelChange.mutateAsync();
       toast.success('Email change cancelled successfully');
-    } catch (err: any) {
-      toast.error(err.response?.data?.message || err.message || 'Failed to cancel email change');
+    } catch (err: unknown) {
+      const apiErr = err as { response?: { data?: { message?: string } }; message?: string };
+      toast.error(apiErr.response?.data?.message || apiErr.message || 'Failed to cancel email change');
     }
   };
 
@@ -266,7 +295,7 @@ const ChangeEmailCard = () => {
             </Box>
 
             {hasPendingChange && (
-              <Alert color="warning" variant="soft" sx={{ mt: 1 }}>
+              <Alert color="warning" variant="soft" sx={{ mt: 1 }} data-testid="profile-pending-email-alert">
                 <Typography level="body-sm">
                   <strong>Pending:</strong> {currentUser.pendingEmail}
                   <br />
@@ -284,6 +313,7 @@ const ChangeEmailCard = () => {
                 color="danger"
                 onClick={handleCancelClick}
                 loading={cancelChange.isPending}
+                data-testid="profile-cancel-email-change-btn"
               >
                 {t('profile.cancel_change', { defaultValue: 'Cancel' })}
               </Button>
@@ -307,7 +337,13 @@ const ChangeEmailCard = () => {
                     {cooldownSeconds > 0 ? `Resend in ${cooldownSeconds}s` : 'Verify'}
                   </Button>
                 )}
-                <Button size="sm" variant="outlined" startDecorator={<EditIcon />} onClick={() => setModalOpen(true)}>
+                <Button
+                  size="sm"
+                  variant="outlined"
+                  startDecorator={<EditIcon />}
+                  onClick={() => setModalOpen(true)}
+                  data-testid="profile-change-email-btn"
+                >
                   {t('profile.change_email', { defaultValue: 'Change' })}
                 </Button>
               </>
@@ -329,10 +365,20 @@ const ChangeEmailCard = () => {
             Are you sure you want to cancel the pending email change to <strong>{currentUser.pendingEmail}</strong>?
           </Typography>
           <Stack direction="row" spacing={2} justifyContent="flex-end" sx={{ mt: 3 }}>
-            <Button variant="outlined" color="neutral" onClick={() => setConfirmCancelOpen(false)}>
+            <Button
+              variant="outlined"
+              color="neutral"
+              onClick={() => setConfirmCancelOpen(false)}
+              data-testid="profile-cancel-email-dismiss-btn"
+            >
               No, Keep It
             </Button>
-            <Button color="danger" onClick={handleCancelConfirm} loading={cancelChange.isPending}>
+            <Button
+              color="danger"
+              onClick={handleCancelConfirm}
+              loading={cancelChange.isPending}
+              data-testid="profile-cancel-email-confirm-btn"
+            >
               Yes, Cancel Change
             </Button>
           </Stack>

--- a/apps/client/app/components/profile/ChangeEmailCard.tsx
+++ b/apps/client/app/components/profile/ChangeEmailCard.tsx
@@ -224,20 +224,29 @@ const ChangeEmailCard = () => {
   // email. Open the confirmation dialog rather than cancelling outright: an
   // email client or link scanner that pre-fetches the URL must not be able to
   // silently cancel a legitimate change - an explicit click is still required.
-  // Wait until `pendingEmail` has loaded (via /api/identify) before acting, and
-  // strip the param afterward so a reload or back-nav doesn't reopen the dialog.
+  //
+  // Key on `'pendingEmail' in currentUser`, not on its truthiness. The persisted
+  // slim user and WebSocket-projected updates omit the key entirely, while the
+  // full /api/identify user always carries it (null or a string). That lets us
+  // tell "not loaded yet" (keep waiting) from "loaded, nothing pending" (consume
+  // the link and move on). Once the authoritative state is known we one-shot the
+  // handler and strip the param in BOTH branches, so a stale link (change already
+  // cancelled/expired) can't leave the param lingering to re-fire the dialog on a
+  // later null -> pending transition.
   useEffect(() => {
     if (search?.action !== CANCEL_EMAIL_CHANGE_ACTION) return;
     if (handledCancelActionRef.current) return;
-    if (!currentUser?.pendingEmail) return;
+    if (!currentUser || !('pendingEmail' in currentUser)) return;
     handledCancelActionRef.current = true;
-    // Intentional one-shot deep-link handler (ref-guarded): open the dialog in
-    // response to the URL param. This is a URL->UI sync, not a render cascade.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setConfirmCancelOpen(true);
+    if (currentUser.pendingEmail) {
+      // Intentional one-shot deep-link handler (ref-guarded): open the dialog in
+      // response to the URL param. This is a URL->UI sync, not a render cascade.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setConfirmCancelOpen(true);
+    }
     const { action: _action, ...rest } = search;
     navigate({ to: '/profile', search: rest, replace: true });
-  }, [search, currentUser?.pendingEmail, navigate]);
+  }, [search, currentUser, navigate]);
 
   if (!currentUser?.email) {
     return null;

--- a/apps/client/pages/api/email/change.ts
+++ b/apps/client/pages/api/email/change.ts
@@ -51,6 +51,9 @@ const handler = baseApi({ auth: true })
                 const brand = process.env.APP_NAME || '';
                 const logoUrl = getLogoUrl();
                 const baseUrl = requireEnv('APP_URL', process.env.APP_URL);
+                // The `action=cancel-email-change` param is handled client-side by
+                // ChangeEmailCard (CANCEL_EMAIL_CHANGE_ACTION), which opens the cancel
+                // confirmation dialog. Keep the literal in sync with that handler.
                 const cancelUrl = `${baseUrl}/profile?action=cancel-email-change`;
 
                 const notificationBody = `


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

N/A (no visual change to the in-app banner; the fix targets an email deep link).

## Description

Closes #26. The issue reported that clicking Cancel on the Profile -> Email Address pending-change banner did nothing. Tracing the full stack (component -> api client -> `/api/email/cancel-change` -> `cancelEmailChange` service -> repository `$set` -> `/api/identify`) showed the in-app banner's Cancel button already works in current code (a two-step confirm dialog was added since the issue was filed). The real remaining bug is that the security-alert email's "Cancel Email Change" button links to `/profile?action=cancel-email-change`, but no client code ever read that `action` param, so the email's cancel link opened the profile page and cancelled nothing.

## Changes

- `apps/client/app/components/profile/ChangeEmailCard.tsx`:
  - Handle the `?action=cancel-email-change` deep link: when present and a pending email change exists, open the cancel confirmation dialog. It does not auto-cancel, since an email client or link scanner that pre-fetches the URL must not silently cancel a legitimate change - an explicit click is still required.
  - Waits until `pendingEmail` has loaded (via `/api/identify`), is ref-guarded to run once, and strips the `action` param afterward (replace nav) so reload/back-nav doesn't reopen the dialog.
  - Adds `data-testid`s to the pending banner and the cancel/confirm/dismiss/change controls, per repo convention.
  - Tidies a pre-existing `catch (err: any)` to the file's `unknown`-narrowing pattern.
- `apps/client/pages/api/email/change.ts`: Adds a cross-reference comment on `cancelUrl` so the email URL literal and the client handler (`CANCEL_EMAIL_CHANGE_ACTION`) stay in sync.
- `apps/client/app/components/profile/ChangeEmailCard.test.tsx` (new): 8 regression tests covering (1) banner/testid rendering when a change is pending, (2) the no-banner (Change button) state when nothing is pending, (3) cancel-request + `refreshUser` on confirm, (4) dismiss firing nothing, (5) deep-link opening the dialog and stripping the `action` param, (6) a stale deep link (loaded, nothing pending) consuming the param without opening a dialog, (7) waiting (not consuming the link) while `pendingEmail` has not yet hydrated, and (8) no re-open on a later null -> pending transition once the link has been consumed.

## Guide for Testers

1. Navigate to `/profile` (Profile tab) while logged in with no pending email change.
2. Click "Change" on the Email Address card, submit a new email address.
3. A "Pending" warning banner appears showing the new address (`data-testid="profile-pending-email-alert"`), with a "Cancel" button (`data-testid="profile-cancel-email-change-btn"`).
4. Click "Cancel" -> a confirmation dialog appears ("Are you sure you want to cancel...").
5. Click "No, Keep It" (`data-testid="profile-cancel-email-dismiss-btn"`) -> dialog closes, pending banner remains, no request is sent.
6. Click "Cancel" again, then "Yes, Cancel Change" (`data-testid="profile-cancel-email-confirm-btn"`) -> a "Email change cancelled successfully" toast appears and the pending banner disappears.
7. Repeat steps 2-3 to create a new pending change. Manually navigate the browser to `/profile?action=cancel-email-change` (this simulates clicking the "Cancel Email Change" link in the security-alert email).
8. Expected: once the pending email has loaded, the cancel confirmation dialog opens automatically, and the URL's `action` param is stripped (check the address bar shows `/profile` without the query param).
9. Reload the page at plain `/profile` -> the dialog should NOT reopen (param was stripped in step 8).
10. Navigate to `/profile?action=cancel-email-change` with NO pending email change active -> expected: no dialog opens (no-op).

**Regression Checks**
- Confirm normal (non-deep-link) Cancel flow from step 3-6 still works unchanged.
- Confirm "Change" and "Verify"/"Resend" buttons on the card still function normally.

## Additional Information

- Backend service and `/api/email/cancel-change` endpoint are unchanged; `change.ts` only gets a comment.
- Not a destructive change; no schema/migration changes.
- Verified: new test file 8/8 passing (`vitest run app/components/profile/ChangeEmailCard.test.tsx`); `pnpm --filter @bike4mind/client typecheck` clean; ESLint on changed files: 0 errors, 0 warnings.

## Developer Notes (Optional)

- `CANCEL_EMAIL_CHANGE_ACTION` establishes a small convention for email-triggered deep links into the profile page (`?action=...` handled by a ref-guarded, one-shot effect that waits on user data and strips itself from the URL). This pattern can be reused for other "act from email" links without risking auto-execution on link-scanner pre-fetch.

## Security Testing (for security-labeled PRs only)

N/A - not a security-labeled PR.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

