### PR TITLE
fix(client): dedupe username on OAuth account creation to prevent lockout

### DIFF
--- a/apps/client/server/utils/auth/verifyCallback.test.ts
+++ b/apps/client/server/utils/auth/verifyCallback.test.ts
@@ -370,6 +370,131 @@ describe('verifyCallback - catch block surfaces the error', () => {
   });
 });
 
+describe('verifyCallback - OAuth create: username dedupe on collision', () => {
+  // Real MongoDB E11000 shape includes `code`, `keyPattern`, `keyValue` directly on
+  // the thrown error (verified against a live duplicate-key error during the incident
+  // this fix closes).
+  const usernameDupErr = () =>
+    Object.assign(new Error('E11000 duplicate key error collection: dev.users index: username_1'), {
+      code: 11000,
+      keyPattern: { username: 1 },
+      keyValue: { username: 'Ken Wallace' },
+    });
+
+  it('dedupes with a numeric suffix when the base username is already taken', async () => {
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockCreate
+      .mockRejectedValueOnce(usernameDupErr())
+      .mockResolvedValueOnce({ _id: 'new-id', username: 'Ken Wallace 2' });
+
+    const { err, user } = await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-kw',
+      displayName: 'Ken Wallace',
+      emails: [{ value: 'ken@bike4mind.com', verified: true }],
+    });
+
+    expect(err).toBeNull();
+    expect(user).toBeDefined();
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(mockCreate.mock.calls[0][0].username).toBe('Ken Wallace');
+    expect(mockCreate.mock.calls[1][0].username).toBe('Ken Wallace 2');
+  });
+
+  it('retries through multiple numeric suffixes, then a short random suffix, before giving up', async () => {
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    // 5 collisions (base, base 2, base 3, base 4, base 5); the 6th attempt (random suffix) succeeds.
+    for (let i = 0; i < 5; i++) mockCreate.mockRejectedValueOnce(usernameDupErr());
+    mockCreate.mockResolvedValueOnce({ _id: 'new-id', username: 'taken-abc123' });
+
+    const { err, user } = await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-taken',
+      displayName: 'taken',
+      emails: [{ value: 'taken@example.com', verified: true }],
+    });
+
+    expect(err).toBeNull();
+    expect(user).toBeDefined();
+    expect(mockCreate).toHaveBeenCalledTimes(6);
+    expect(mockCreate.mock.calls.map(c => c[0].username)).toEqual([
+      'taken',
+      'taken 2',
+      'taken 3',
+      'taken 4',
+      'taken 5',
+      expect.stringMatching(/^taken-[a-f0-9]{6}$/),
+    ]);
+  });
+
+  it('fails clean after exhausting all retries instead of looping forever', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    for (let i = 0; i < 6; i++) mockCreate.mockRejectedValueOnce(usernameDupErr());
+
+    const { err, user, info } = await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-alwaystaken',
+      displayName: 'alwaystaken',
+      emails: [{ value: 'alwaystaken@example.com', verified: true }],
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(6); // bounded - never retries forever
+    expect(err).toBeNull();
+    expect(user).toBeUndefined();
+    expect((info as { message: string }).message).toContain('E11000');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('does NOT retry on an email-index collision - fails clean rather than risking a duplicate-email account', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    const emailDupErr = Object.assign(new Error('E11000 duplicate key error collection: dev.users index: email_1'), {
+      code: 11000,
+      keyPattern: { email: 1 },
+      keyValue: { email: 'race@example.com' },
+    });
+    mockCreate.mockRejectedValueOnce(emailDupErr);
+
+    const { err, user, info } = await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-race',
+      displayName: 'Race Condition',
+      emails: [{ value: 'race@example.com', verified: true }],
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1); // no retry attempted on a non-username collision
+    expect(err).toBeNull();
+    expect(user).toBeUndefined();
+    expect((info as { message: string }).message).toContain('E11000');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('derives a fallback username from the email local-part when the provider gives no username or displayName', async () => {
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({ _id: 'new-id', username: 'nodisplay' });
+
+    await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-nodisplay',
+      username: '', // Google never sends this, but be defensive about an empty string
+      emails: [{ value: 'nodisplay@example.com', verified: true }],
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate.mock.calls[0][0].username).toBe('nodisplay');
+  });
+
+  it('derives a random fallback username when even the email local-part is empty', async () => {
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({ _id: 'new-id', username: 'user-abc12345' });
+
+    await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-emptylocal',
+      username: '',
+      emails: [{ value: '@example.com', verified: true }],
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate.mock.calls[0][0].username).toMatch(/^user-[a-f0-9]{8}$/);
+  });
+});
+
 describe('verifyCallback - Google "with params" callback signature', () => {
   it('strips the params arg and forwards profile + done correctly', async () => {
     mockFindOne.mockResolvedValueOnce(null);

--- a/apps/client/server/utils/auth/verifyCallback.test.ts
+++ b/apps/client/server/utils/auth/verifyCallback.test.ts
@@ -480,6 +480,25 @@ describe('verifyCallback - OAuth create: username dedupe on collision', () => {
     expect(mockCreate.mock.calls[0][0].username).toBe('nodisplay');
   });
 
+  it('never creates with an empty name (required field) - falls back to the derived username', async () => {
+    // A minimal provider assertion: only an email, no displayName/name/username. Without
+    // the fallback, `name: ''` would throw a non-E11000 validation error and lock the user
+    // out - the same class of opaque OAuth-create failure this helper prevents.
+    mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({ _id: 'new-id', username: 'onlyemail', name: 'onlyemail' });
+
+    await runStandard(AuthStrategy.Google, {
+      id: 'google-sub-onlyemail',
+      emails: [{ value: 'onlyemail@example.com', verified: true }],
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const createArg = mockCreate.mock.calls[0][0];
+    expect(createArg.name).toBeTruthy();
+    expect(createArg.name).toBe('onlyemail'); // derived username reused as the name
+    expect(createArg.username).toBe('onlyemail');
+  });
+
   it('derives a random fallback username when even the email local-part is empty', async () => {
     mockFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
     mockCreate.mockResolvedValueOnce({ _id: 'new-id', username: 'user-abc12345' });

--- a/apps/client/server/utils/auth/verifyCallback.ts
+++ b/apps/client/server/utils/auth/verifyCallback.ts
@@ -16,11 +16,18 @@ import {
 // username collision; if that many are exhausted something else is wrong.
 const MAX_USERNAME_RETRIES = 5;
 
-/** True only for a MongoDB E11000 on the `username` unique index specifically. */
+/**
+ * True only for a MongoDB E11000 on the `username` unique index specifically.
+ * Requires a SINGLE-key keyPattern of exactly `username`: today the only unique
+ * indexes are single-field (`username_1`, partial `email_1`), but if the compound
+ * `{username, email}` index ever became unique its keyPattern would contain
+ * `username` too - the length guard keeps this from being mis-classified as a
+ * plain username collision (which would then retry with the same colliding email).
+ */
 function isUsernameDuplicateKeyError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   const e = err as { code?: number; keyPattern?: Record<string, unknown> };
-  return e.code === 11000 && !!e.keyPattern && 'username' in e.keyPattern;
+  return e.code === 11000 && !!e.keyPattern && Object.keys(e.keyPattern).length === 1 && 'username' in e.keyPattern;
 }
 
 /**
@@ -62,8 +69,14 @@ async function createUniqueOAuthUser(params: {
   oauthCredentials: Record<string, unknown>;
 }) {
   const { name, baseUsername, email, oauthCredentials } = params;
+  // `name` is a required field. Providers that send neither a displayName/name
+  // nor a username (a minimal OIDC/SAML assertion carrying only an email) would
+  // otherwise create with name='' -> a non-E11000 validation error that is not
+  // retried and fails the whole sign-in - the same class of opaque OAuth-create
+  // lockout this helper exists to prevent. baseUsername is guaranteed non-empty.
+  const safeName = name || baseUsername;
   const buildDoc = (username: string) => ({
-    name,
+    name: safeName,
     username,
     password: null,
     isAdmin: false,
@@ -77,8 +90,12 @@ async function createUniqueOAuthUser(params: {
     try {
       const user = await User.create(buildDoc(candidate));
       if (retry > 0) {
+        // Strip control chars before logging: baseUsername/candidate derive from
+        // the provider displayName (attacker-controllable) and this is raw console
+        // output, so a CRLF/ANSI-laden display name could forge adjacent log lines.
+        const safe = (s: string) => s.replace(/[\r\n\t]/g, ' ');
         console.info(
-          `[verifyCallback] oauth create: username "${baseUsername}" was taken - created "${candidate}" (retry ${retry})`
+          `[verifyCallback] oauth create: username "${safe(baseUsername)}" was taken - created "${safe(candidate)}" (retry ${retry})`
         );
       }
       return user;

--- a/apps/client/server/utils/auth/verifyCallback.ts
+++ b/apps/client/server/utils/auth/verifyCallback.ts
@@ -1,6 +1,7 @@
 import { AuthStrategy, IAuthProviders } from '@bike4mind/common';
 import { User } from '@bike4mind/database';
 import { escapeRegex } from '@bike4mind/utils/escapeRegex';
+import { randomUUID } from 'crypto';
 import { omit } from 'lodash';
 import { requireNonSystemUser } from '@server/auth/requireNonSystemUser';
 import {
@@ -9,6 +10,94 @@ import {
   ACCOUNT_LINK_VERIFICATION_REQUIRED,
   ACCOUNT_LINK_EMAIL_MISMATCH,
 } from './oauthAccountLink';
+
+// Bounded retries for the username-collision dedupe below. Not a tunable -
+// six total create attempts (base + 5 retries) is already generous for a
+// username collision; if that many are exhausted something else is wrong.
+const MAX_USERNAME_RETRIES = 5;
+
+/** True only for a MongoDB E11000 on the `username` unique index specifically. */
+function isUsernameDuplicateKeyError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { code?: number; keyPattern?: Record<string, unknown> };
+  return e.code === 11000 && !!e.keyPattern && 'username' in e.keyPattern;
+}
+
+/**
+ * Derive the username for a brand-new OAuth account. Providers rarely give a
+ * stable, unique handle (Google has no `username` field at all - only a
+ * displayName), so this can legitimately be empty; User.create requires a
+ * non-empty username, so fall back to the email local-part, then a random
+ * handle. Never return ''.
+ */
+function deriveOAuthUsername(rawUsername: string | null, name: string, email: string | null): string {
+  const base = rawUsername ?? name;
+  if (base) return base;
+  const emailLocalPart = email?.split('@')[0];
+  if (emailLocalPart) return emailLocalPart;
+  return `user-${randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * Create a new OAuth user, retrying with a disambiguated username on a
+ * collision. This is what closes the "Google displayName collides with an
+ * existing username" lockout: OAuth-derived usernames aren't unique by
+ * construction, so a plain create can E11000 on the `username` index and
+ * fail the whole sign-in with an opaque error.
+ *
+ * Optimistic-create-then-retry (not check-then-create) so this is race-safe
+ * under concurrent signups. Only retries on a USERNAME collision - a
+ * collision on the `email` unique index is a different, much rarer case (a
+ * concurrent same-email signup race, since Stage 2 above already excludes a
+ * non-race match) and is deliberately NOT retried here: re-matching and
+ * returning the other create's user would hand out an account without ever
+ * running the account-link security gate above. Letting it throw sends it to
+ * the outer catch, which fails clean; a real retry (e.g. a page reload) then
+ * goes through Stage 1/2 and links properly through the gate.
+ */
+async function createUniqueOAuthUser(params: {
+  name: string;
+  baseUsername: string;
+  email: string | null;
+  oauthCredentials: Record<string, unknown>;
+}) {
+  const { name, baseUsername, email, oauthCredentials } = params;
+  const buildDoc = (username: string) => ({
+    name,
+    username,
+    password: null,
+    isAdmin: false,
+    oauthCredentials,
+    authProviders: [oauthCredentials],
+    ...(email ? { email } : {}),
+  });
+
+  let candidate = baseUsername;
+  for (let retry = 0; retry <= MAX_USERNAME_RETRIES; retry++) {
+    try {
+      const user = await User.create(buildDoc(candidate));
+      if (retry > 0) {
+        console.info(
+          `[verifyCallback] oauth create: username "${baseUsername}" was taken - created "${candidate}" (retry ${retry})`
+        );
+      }
+      return user;
+    } catch (err) {
+      if (!isUsernameDuplicateKeyError(err) || retry === MAX_USERNAME_RETRIES) {
+        throw err;
+      }
+      // Readable increments for the common case (one or two prior accounts
+      // with the same display name); a short random suffix on the final
+      // retry in case the numeric suffixes are also taken.
+      candidate =
+        retry < MAX_USERNAME_RETRIES - 1
+          ? `${baseUsername} ${retry + 2}`
+          : `${baseUsername}-${randomUUID().slice(0, 6)}`;
+    }
+  }
+  // Unreachable: the loop above always returns or throws.
+  throw new Error('createUniqueOAuthUser: exhausted retries');
+}
 
 // Core authentication logic shared by all strategies
 const authenticateUser = async (
@@ -129,15 +218,8 @@ const authenticateUser = async (
       done(null, linkedUser);
     } else {
       const name = profile?.displayName ?? profile?.name ?? username ?? '';
-      user = await User.create({
-        name,
-        username: username ?? name,
-        password: null,
-        isAdmin: false,
-        oauthCredentials,
-        authProviders: [oauthCredentials],
-        ...(email ? { email } : {}),
-      });
+      const baseUsername = deriveOAuthUsername(username, name, email);
+      user = await createUniqueOAuthUser({ name, baseUsername, email, oauthCredentials });
       // Transient flag (not persisted), mirroring isNewOAuthLink above: lets
       // the callback endpoint log the registration and forward a one-shot
       // signup signal to the client for ad-conversion tracking.


### PR DESCRIPTION
## Summary

A brand-new OAuth (Google/GitHub/etc.) sign-in derives the username from the provider's displayName/handle with no uniqueness check. If that collides with an existing account's username, `User.create` throws an unhandled `E11000` on the unique `username` index, and the whole sign-in fails with an opaque error - no account is created, no useful signal either.

This is exactly what locked a real dev account out of Google sign-in: the Google `displayName` "Ken Wallace" collided with an existing account already named "Ken Wallace" (a stray GitHub-test account). Root-caused live via CloudWatch + dev DB inspection and worked around with direct DB edits (email migration + removing the stray account) - this PR closes the underlying code gap so the next collision doesn't lock anyone out.

Plan: `~/Dev/planning/bike4mind/oauth-verifycallback-username-dedupe.md` (reviewed via `/expert-plan-review` + `/adjudicate-review`).

## Changes

`apps/client/server/utils/auth/verifyCallback.ts`:
- **`createUniqueOAuthUser()`** - optimistic create + retry-on-`E11000`, scoped strictly to the `username` unique index (checked via `err.keyPattern.username`, matching the real MongoDB error shape). An `email`-index collision is NOT retried here - it's a rare concurrent same-email-signup race, and retrying by re-matching would hand out an account without ever running the existing account-link security gate. It fails clean instead; a retry (e.g. a page reload) goes through Stage 1/2 and links properly through the gate.
- Bounded retries (5): readable numeric suffixes first (`"Name 2"`, `"Name 3"`, ...), a short random suffix on the last attempt, then fail clean - never loops forever.
- **`deriveOAuthUsername()`** - some providers (Google) have no `username` field at all, only a displayName, so the derived base can legitimately be empty. Falls back to the email local-part, then a random handle. Never creates with `''`.
- Logs (`console.info`) when a dedupe actually fires, so this class of collision is visible operationally instead of only surfacing as a support ticket / silent lockout.

The existing-user link path and its account-link security gate (email verification + match) are untouched.

## Test plan

- [x] `apps/client/server/utils/auth/verifyCallback.test.ts` - 7 new cases added (25/25 passing): numeric-suffix dedupe, multi-retry through numeric + random suffix, bounded-retry exhaustion fails clean, email-index collision does NOT retry, fallback to email local-part, fallback to random handle when local-part is also empty. All 18 pre-existing cases (account-link gate, create-path username handling, catch-block behavior, Google "with params" signature) still pass unmodified.
- [x] `pnpm --filter @bike4mind/client typecheck` - clean
- [x] `eslint` on both changed files - 0 errors (3 pre-existing `any` warnings on lines this PR didn't touch)
- [x] No non-ASCII characters in any added line

## Notes

- Auth-critical path - recommend `/expert-review` on this PR before merge (per the plan's own risk note).
- Scope: this fixes the *code* gap only. The specific dev-account data issue (stale `@milliononmars.com` email + a stray test account) was already fixed directly in the dev DB and is not part of this diff.
- Out of scope (per plan): improving Stage 2 email/username matching, and login-UI OTC-fallback resilience for social-only accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)