### PR TITLE
refactor(client): extract useEntitlementGate hook from RestrictedPage

### DIFF
--- a/apps/client/app/components/common/RestrictedPage.tsx
+++ b/apps/client/app/components/common/RestrictedPage.tsx
@@ -1,8 +1,6 @@
 import { useUser } from '@client/app/contexts/UserContext';
-import { useEntitlements } from '@client/app/hooks/data/entitlements';
-import { normalizeTag } from '@client/lib/entitlements/registry';
+import { useEntitlementGate, EntitlementGateState } from '@client/app/hooks/useEntitlementGate';
 import { applyRedirect, buildRedirectTo } from '@client/app/utils/authRedirect';
-import { userIsDeveloper } from '@client/app/utils/user';
 import { useRouter, useNavigate } from '@tanstack/react-router';
 import { FC, PropsWithChildren, useEffect } from 'react';
 
@@ -28,9 +26,6 @@ interface RestrictedPageProps {
   fallbackPath?: string;
 }
 
-/** A set requirement is satisfied, definitively unsatisfied, or still resolving. */
-type GateState = 'satisfied' | 'denied' | 'pending';
-
 const RestrictedPage: FC<PropsWithChildren<RestrictedPageProps>> = ({
   children,
   requireAdmin = false,
@@ -43,41 +38,23 @@ const RestrictedPage: FC<PropsWithChildren<RestrictedPageProps>> = ({
   const navigate = useNavigate();
   const pathname = router.state.location.pathname;
 
-  const bypass = !!currentUser && (currentUser.isAdmin || userIsDeveloper(currentUser));
+  // Membership decision (bypass, normalized-key compare, fail-open on query
+  // error) lives in the shared hook so nav-visibility checks match this gate.
+  const { state: entitlementState, bypass } = useEntitlementGate(requireEntitlement);
 
-  const entitlementQuery = useEntitlements({
-    enabled: !!requireEntitlement && !!currentUser && !bypass,
-  });
-
-  const tagState: GateState | undefined = !requireFeatureTag
+  const tagState: EntitlementGateState | undefined = !requireFeatureTag
     ? undefined
     : bypass || (currentUser?.tags ?? []).some(tag => tag.toLowerCase() === requireFeatureTag.toLowerCase())
       ? 'satisfied'
       : 'denied';
 
-  let entitlementState: GateState | undefined;
-  if (requireEntitlement) {
-    if (bypass) {
-      entitlementState = 'satisfied';
-    } else if (entitlementQuery.isSuccess) {
-      entitlementState = (entitlementQuery.data ?? []).includes(normalizeTag(requireEntitlement))
-        ? 'satisfied'
-        : 'denied';
-    } else if (entitlementQuery.isError) {
-      // Fail-open by design: this gate is UX, not a security control - the
-      // server enforces entitlements on the APIs behind it. A transient
-      // /api/entitlements failure must not eject a paying user.
-      entitlementState = 'satisfied';
-    } else {
-      entitlementState = 'pending';
-    }
-  }
-
   // No requirements set = login-only mode. With requirements, satisfying any
   // one grants (OR); a pending entitlement query holds (render null, no
   // redirect); only an all-requirements-denied state ejects.
-  const requirementStates = [tagState, entitlementState].filter((state): state is GateState => state !== undefined);
-  const accessState: GateState =
+  const requirementStates = [tagState, entitlementState].filter(
+    (state): state is EntitlementGateState => state !== undefined
+  );
+  const accessState: EntitlementGateState =
     requirementStates.length === 0 || requirementStates.includes('satisfied')
       ? 'satisfied'
       : requirementStates.includes('pending')

--- a/apps/client/app/hooks/useEntitlementGate.test.ts
+++ b/apps/client/app/hooks/useEntitlementGate.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useEntitlementGate } from './useEntitlementGate';
+
+const mockUseUser = vi.fn();
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: () => mockUseUser(),
+}));
+
+const mockUserIsDeveloper = vi.fn();
+vi.mock('@client/app/utils/user', () => ({
+  userIsDeveloper: (user: unknown) => mockUserIsDeveloper(user),
+}));
+
+const mockUseEntitlements = vi.fn();
+vi.mock('@client/app/hooks/data/entitlements', () => ({
+  useEntitlements: (options: { enabled?: boolean }) => mockUseEntitlements(options),
+}));
+
+/** Query-state shorthands matching the RestrictedPage test conventions. */
+const entitlementsQuery = {
+  success: (entitlements: string[]) => ({ data: entitlements, isSuccess: true, isError: false }),
+  pending: () => ({ data: undefined, isSuccess: false, isError: false }),
+  error: () => ({ data: undefined, isSuccess: false, isError: true }),
+};
+
+const learner = { id: 'u1', isAdmin: false, tags: [] as string[] };
+
+describe('useEntitlementGate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUser.mockReturnValue({ currentUser: learner });
+    mockUserIsDeveloper.mockReturnValue(false);
+    mockUseEntitlements.mockReturnValue(entitlementsQuery.pending());
+  });
+
+  it('returns undefined state (no requirement) when no key is passed', () => {
+    const { result } = renderHook(() => useEntitlementGate());
+
+    expect(result.current.state).toBeUndefined();
+    expect(mockUseEntitlements).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('satisfied when the server-resolved entitlements include the key', () => {
+    mockUseEntitlements.mockReturnValue(entitlementsQuery.success(['someproduct:pro']));
+
+    const { result } = renderHook(() => useEntitlementGate('someproduct:pro'));
+
+    expect(result.current.state).toBe('satisfied');
+  });
+
+  it('normalizes the required key before comparing', () => {
+    mockUseEntitlements.mockReturnValue(entitlementsQuery.success(['someproduct:pro']));
+
+    const { result } = renderHook(() => useEntitlementGate('  SomeProduct:PRO '));
+
+    expect(result.current.state).toBe('satisfied');
+  });
+
+  it('denied when the resolved entitlements lack the key', () => {
+    mockUseEntitlements.mockReturnValue(entitlementsQuery.success(['other:pro']));
+
+    const { result } = renderHook(() => useEntitlementGate('someproduct:pro'));
+
+    expect(result.current.state).toBe('denied');
+  });
+
+  it('pending while the entitlement query is in flight', () => {
+    const { result } = renderHook(() => useEntitlementGate('someproduct:pro'));
+
+    expect(result.current.state).toBe('pending');
+  });
+
+  it('fails open on a query error (UX gate, not a security control)', () => {
+    mockUseEntitlements.mockReturnValue(entitlementsQuery.error());
+
+    const { result } = renderHook(() => useEntitlementGate('someproduct:pro'));
+
+    expect(result.current.state).toBe('satisfied');
+  });
+
+  it('admins bypass without fetching entitlements', () => {
+    mockUseUser.mockReturnValue({ currentUser: { id: 'a1', isAdmin: true, tags: [] } });
+
+    const { result } = renderHook(() => useEntitlementGate('someproduct:pro'));
+
+    expect(result.current.state).toBe('satisfied');
+    expect(result.current.bypass).toBe(true);
+    expect(mockUseEntitlements).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('developers bypass without fetching entitlements', () => {
+    mockUserIsDeveloper.mockReturnValue(true);
+
+    const { result } = renderHook(() => useEntitlementGate('someproduct:pro'));
+
+    expect(result.current.state).toBe('satisfied');
+    expect(result.current.bypass).toBe(true);
+    expect(mockUseEntitlements).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('no user: pending (query disabled), no bypass', () => {
+    mockUseUser.mockReturnValue({ currentUser: null });
+
+    const { result } = renderHook(() => useEntitlementGate('someproduct:pro'));
+
+    expect(result.current.state).toBe('pending');
+    expect(result.current.bypass).toBe(false);
+    expect(mockUseEntitlements).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+});

--- a/apps/client/app/hooks/useEntitlementGate.ts
+++ b/apps/client/app/hooks/useEntitlementGate.ts
@@ -1,0 +1,59 @@
+import { useUser } from '@client/app/contexts/UserContext';
+import { useEntitlements } from '@client/app/hooks/data/entitlements';
+import { normalizeTag } from '@client/lib/entitlements/registry';
+import { userIsDeveloper } from '@client/app/utils/user';
+
+/** A gate requirement is satisfied, definitively unsatisfied, or still resolving. */
+export type EntitlementGateState = 'satisfied' | 'denied' | 'pending';
+
+export interface EntitlementGateResult {
+  /**
+   * The membership decision for `entitlementKey`, or `undefined` when no key
+   * was passed (no requirement to evaluate). `'pending'` while the entitlement
+   * query is in flight - callers decide whether pending renders as hidden
+   * (nav links) or as a hold-without-redirect (route gates).
+   */
+  state: EntitlementGateState | undefined;
+  /** Admins and developers bypass entitlement checks entirely. */
+  bypass: boolean;
+}
+
+/**
+ * The client-side entitlement membership decision, extracted from
+ * `RestrictedPage` so nav-visibility hooks (e.g. premium overlays' membership
+ * checks) share one implementation:
+ *
+ * - bypass = `isAdmin || userIsDeveloper` (no entitlement fetch when bypassed)
+ * - otherwise the server-resolved entitlement list (`useEntitlements`) must
+ *   contain the normalized key
+ * - a query ERROR fails open by design: this gate is UX, not a security
+ *   control - the server enforces entitlements on the APIs behind it. A
+ *   transient /api/entitlements failure must not eject (or hide the UI from)
+ *   a paying user.
+ */
+export const useEntitlementGate = (entitlementKey?: string): EntitlementGateResult => {
+  const { currentUser } = useUser();
+
+  const bypass = !!currentUser && (currentUser.isAdmin || userIsDeveloper(currentUser));
+
+  const entitlementQuery = useEntitlements({
+    enabled: !!entitlementKey && !!currentUser && !bypass,
+  });
+
+  let state: EntitlementGateState | undefined;
+  if (entitlementKey) {
+    if (bypass) {
+      state = 'satisfied';
+    } else if (entitlementQuery.isSuccess) {
+      state = (entitlementQuery.data ?? []).includes(normalizeTag(entitlementKey))
+        ? 'satisfied'
+        : 'denied';
+    } else if (entitlementQuery.isError) {
+      state = 'satisfied';
+    } else {
+      state = 'pending';
+    }
+  }
+
+  return { state, bypass };
+};


### PR DESCRIPTION
## What

Extracts the entitlement membership decision out of `RestrictedPage` into a shared hook, `apps/client/app/hooks/useEntitlementGate.ts`:

- bypass = `isAdmin || userIsDeveloper` (no entitlement fetch when bypassed)
- otherwise the server-resolved entitlement list (`useEntitlements`) must contain the `normalizeTag`-normalized key
- a query **error fails open** by design — this gate is UX, not a security control; the server enforces entitlements on the APIs behind it

`RestrictedPage` now consumes the hook. **Behavior is unchanged** — the existing `RestrictedPage` test suite passes without modification, and the hook gets its own unit tests (9 cases: satisfied/denied/pending/fail-open/admin+developer bypass/normalization/no-user/no-key).

## Why

Premium overlays need nav-visibility checks that agree with route gating (e.g. showing a link only to users holding a given entitlement key). Without a shared hook, each overlay would re-implement the bypass + normalize + fail-open rules and drift from `RestrictedPage`. A first overlay consumer lands separately in its own repo.

## Testing

- `vitest run app/hooks/useEntitlementGate.test.ts app/components/common/RestrictedPage.test.tsx` — 29 passed
- `pnpm --filter @bike4mind/client typecheck` — clean
- eslint on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)