### PR TITLE
ci(release): use release-bot App token for the prod-release GitHub Release

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -53,6 +53,26 @@ jobs:
       pull-requests: read # Required for fetching PR details in changelog generation
 
     steps:
+      # Use b4m-release-bot App token (not GITHUB_TOKEN) to create the GitHub
+      # Release. GITHUB_TOKEN / github-actions[bot] is not a bypass actor on the
+      # release-tag-protection ruleset, so its tag creation is rejected (422
+      # "creations being restricted"). The release App is a bypass actor.
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Verify App token is non-empty
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ -z "$APP_TOKEN" ]; then
+            echo "::error::App token generation returned empty — check RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY."
+            exit 1
+          fi
+
       - name: Determine configuration
         id: config
         run: |
@@ -123,7 +143,9 @@ jobs:
           SEED_APP_NAME: ${{ steps.config.outputs.app_name }}
           SEED_STAGE_NAME: ${{ steps.config.outputs.stage }}
           AWS_REGION: ${{ env.AWS_REGION }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # b4m-release-bot App token so the GitHub Release tag creation passes
+          # the release-tag-protection ruleset (App is a bypass actor).
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           # For workflow_run events (auto-trigger), always send Slack
           # For manual runs, send only if the input is true


### PR DESCRIPTION
## What
The `prod-release.yml` "Create production release" step created the GitHub Release via `GITHUB_TOKEN` (`github-actions[bot]`). That identity is not a bypass actor on the `release-tag-protection` ruleset, so creating the release tag failed with `422 "Cannot create ref due to creations being restricted"` (run 28890596202).

## Change
- Add a "Generate App token" step (b4m-release-bot App, same `create-github-app-token@v3` pattern as `release.yaml`, using `vars.RELEASE_APP_ID` + `secrets.RELEASE_APP_PRIVATE_KEY`) + a non-empty verify guard.
- Point the release step's `GITHUB_TOKEN` at `steps.app-token.outputs.token` instead of `secrets.GITHUB_TOKEN`.

## Paired change (applied separately)
The b4m-release-bot App (id 4209659) is added as an `Integration` bypass actor on the `release-tag-protection` ruleset so its tag creation is allowed.

## Not touched
AWS/OIDC role path, changelog generation, Slack notification. The separate Bedrock IAM gap (AI changelog `AccessDenied`) is tracked independently.
