### PR TITLE
fix(client): stop DOMPurify from deleting HTML-artifact scripts with `<` comparisons

### DIFF
--- a/apps/client/app/utils/htmlSanitizer.behavior.test.ts
+++ b/apps/client/app/utils/htmlSanitizer.behavior.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeHtmlForIframe } from './htmlSanitizer';
+
+/**
+ * End-to-end sanitizer behavior against the REAL DOMPurify (this file does not
+ * mock it, unlike htmlSanitizer.test.ts which asserts the config object).
+ *
+ * Guards the regression where DOMPurify's SAFE_FOR_XML mXSS heuristic
+ * (/<[/\w!]/ over raw-text nodes) force-removed any <script> containing a `<`
+ * glued to a word char - i.e. ordinary JS like `for(i=0;i<n;i++)` - leaving
+ * interactive HTML artifacts rendered but inert.
+ */
+describe('sanitizeHtmlForIframe (real DOMPurify)', () => {
+  const scriptDoc = (js: string) =>
+    `<!DOCTYPE html><html><body><canvas id="c"></canvas><script>${js}</script></body></html>`;
+
+  // `<` glued to a word char/digit - the exact shape that tripped the guard.
+  const comparisonJs = 'for(var i=0;i<TOTAL;i++){} if(g.x<0){} for(var i=0;i<grains.length;i++){}';
+
+  it('keeps a <script> whose body uses `<` comparisons when allowScripts is true', () => {
+    const { cleanHtml } = sanitizeHtmlForIframe(scriptDoc(comparisonJs), { allowScripts: true });
+    expect(cleanHtml).toContain('<script');
+    expect(cleanHtml).toContain('i<TOTAL');
+    expect(cleanHtml).toContain('g.x<0');
+  });
+
+  it('still strips <script> entirely when allowScripts is omitted', () => {
+    const { cleanHtml } = sanitizeHtmlForIframe(scriptDoc(comparisonJs));
+    expect(cleanHtml).not.toContain('<script');
+  });
+
+  it('still strips iframe/object/embed even with scripts allowed', () => {
+    const dirty =
+      '<!DOCTYPE html><html><body><script>var a=1<2;</script>' +
+      '<iframe src="https://evil.example"></iframe><object data="x"></object><embed src="y"></body></html>';
+    const { cleanHtml } = sanitizeHtmlForIframe(dirty, { allowScripts: true });
+    expect(cleanHtml).toContain('<script');
+    expect(cleanHtml).not.toContain('<iframe');
+    expect(cleanHtml).not.toContain('<object');
+    expect(cleanHtml).not.toContain('<embed');
+  });
+
+  it('still strips inline event-handler attributes with scripts allowed', () => {
+    const dirty = '<!DOCTYPE html><html><body><div onclick="steal()">x</div><script>var a=1<2;</script></body></html>';
+    const { cleanHtml } = sanitizeHtmlForIframe(dirty, { allowScripts: true });
+    expect(cleanHtml).not.toContain('onclick');
+  });
+});

--- a/apps/client/app/utils/htmlSanitizer.test.ts
+++ b/apps/client/app/utils/htmlSanitizer.test.ts
@@ -96,6 +96,23 @@ describe('sanitizeHtmlForIframe', () => {
       const config = mockSanitize.mock.calls[0][1];
       expect(config.ALLOWED_URI_REGEXP).toBeUndefined();
     });
+
+    // Regression: DOMPurify's SAFE_FOR_XML mXSS guard force-removes any <script>
+    // whose body contains `<` glued to a word char (`for(i=0;i<n;i++)`, `if(x<0)`),
+    // silently deleting the script and leaving interactive artifacts inert. The
+    // sandbox iframe + route CSP are the real boundary on this path, so the guard
+    // must be off here.
+    it('disables SAFE_FOR_XML so scripts with `<` comparisons survive', () => {
+      sanitizeHtmlForIframe('<p>hi</p>', { allowScripts: true });
+      const config = mockSanitize.mock.calls[0][1];
+      expect(config.SAFE_FOR_XML).toBe(false);
+    });
+  });
+
+  it('does NOT disable SAFE_FOR_XML when allowScripts is omitted (default guard stays on)', () => {
+    sanitizeHtmlForIframe('<p>hi</p>');
+    const config = mockSanitize.mock.calls[0][1];
+    expect(config.SAFE_FOR_XML).toBeUndefined();
   });
 
   it('does not add script to ADD_TAGS when allowScripts is omitted', () => {

--- a/apps/client/app/utils/htmlSanitizer.ts
+++ b/apps/client/app/utils/htmlSanitizer.ts
@@ -67,6 +67,11 @@ export interface SanitizeHtmlOptions {
    * `iframe`/`object`/`embed` so injected content cannot nest privileged frames
    * or plugins even when scripts are allowed.
    *
+   * This path also disables DOMPurify's SAFE_FOR_XML mXSS guard, which would
+   * otherwise force-remove any <script> whose body contains a `<` glued to a
+   * word char (ordinary JS like `for(i=0;i<n;i++)`); see the call site for the
+   * full rationale. The sandbox iframe + route CSP remain the boundary.
+   *
    * Callers that render into a NON-sandboxed context must leave this false.
    */
   allowScripts?: boolean;
@@ -122,6 +127,19 @@ export const sanitizeHtmlForIframe = (htmlContent: string, options: SanitizeHtml
     WHOLE_DOCUMENT: isCompleteDocument,
     ALLOW_DATA_ATTR: true,
     ALLOW_ARIA_ATTR: true,
+    // DOMPurify's SAFE_FOR_XML mXSS guard (on by default) force-removes any
+    // raw-text node whose content matches /<[/\w!]/ - i.e. a `<` glued to a
+    // letter/digit/`_`/`/`/`!`. That heuristic exists to catch namespace-
+    // confusion markup smuggled through text nodes, but it cannot tell HTML
+    // from JavaScript: ordinary comparison/loop code (`for(i=0;i<n;i++)`,
+    // `if(x<0)`, `a<b`) trips it, so DOMPurify silently deletes the WHOLE
+    // <script> and interactive artifacts render inert. Disable the guard ONLY
+    // on the allowScripts path, where the real boundary is already (1) the
+    // opaque-origin sandbox iframe (`allow-scripts`, no `allow-same-origin`)
+    // and (2) the /api/artifact-sandbox route CSP - and where the sanitized
+    // output is `document.write`n into that opaque origin, so mXSS cannot reach
+    // the app origin regardless. The default (guarded) path is untouched.
+    ...(allowScripts ? { SAFE_FOR_XML: false } : {}),
     ADD_TAGS: [...DOCUMENT_SHELL_TAGS, ...(allowScripts ? ['script'] : [])],
     ADD_ATTR: [...EXTRA_ATTRS, ...(allowScripts ? SCRIPT_ATTRS : [])],
     FORBID_ATTR: FORBIDDEN_EVENT_ATTRS,


### PR DESCRIPTION
## Symptom

Interactive HTML artifacts (e.g. a Chladni-plate canvas animation) render their static HTML/CSS but sit **inert** - the canvas shows its background, no animation runs, and there is **no CSP violation and no JS error** in the console. It looks like scripts are being blocked, but they aren't: `/api/artifact-sandbox` already serves `script-src 'unsafe-inline' ...` and both viewers already call the sanitizer with `allowScripts: true`.

## Root cause

DOMPurify's **`SAFE_FOR_XML` mXSS guard** (on by default) force-removes any raw-text node whose content matches `/<[/\w!]/` - a `<` glued to a letter/digit/`_`/`/`/`!`:

```js
const ELEMENT_MARKUP_PROBE = /<[/\w!]/g;
// _isUnsafeNode: matches textContent && innerHTML -> _forceRemove(node)
```

The heuristic targets namespace-confusion markup smuggled through text nodes, but it can't tell HTML from JavaScript. Ordinary loop/comparison code trips it constantly:

| script body | result |
|---|---|
| `for(i=0;i<TOTAL;i++)` | **stripped** |
| `if(g.x<0)` | **stripped** |
| `i < TOTAL` (space after `<`) | kept |
| `j>0` | kept |

So even though `allowScripts: true` puts `<script>` on the allow-list, DOMPurify deletes the whole script node anyway. The static HTML/CSS survives, which is exactly why the artifact renders but does nothing. Reproduced against the repo's pinned DOMPurify (3.4.11).

## Fix

Disable `SAFE_FOR_XML` **only on the `allowScripts` path**. The real security boundary there is already:
1. the opaque-origin sandbox iframe (`allow-scripts`, no `allow-same-origin`), and
2. the `/api/artifact-sandbox` route CSP,

and the sanitized output is `document.write`n into that opaque origin, so mXSS can't reach the app origin regardless. DOMPurify can't sanitize JS semantics anyway - its job on this path is stripping event-handler attrs / `javascript:` URIs, which is unchanged. The default (guarded) path for non-script HTML is untouched.

## Tests

- Unit test: asserts `SAFE_FOR_XML: false` is passed when `allowScripts` is set, and absent otherwise.
- New behavior test (`htmlSanitizer.behavior.test.ts`, real DOMPurify, no mock): proves a `<script>` using `<` comparisons **survives** with `allowScripts` and is **stripped** without it, while `iframe`/`object`/`embed` and inline `onclick` handlers stay stripped.

`pnpm --filter @bike4mind/client typecheck`, the two test files (29 passing), and `pnpm lint:check` are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)