### PR TITLE
fix(client): give favorited notebooks the full 3-dot menu

### DIFF
--- a/apps/client/app/components/Session/SidenavItem.gating.test.tsx
+++ b/apps/client/app/components/Session/SidenavItem.gating.test.tsx
@@ -120,4 +120,18 @@ describe.each([
     expect(screen.getByTestId('sidenav-item-menuitem-export-excel')).toBeInTheDocument();
     expect(screen.getByTestId('sidenav-item-menuitem-export-word')).toBeInTheDocument();
   });
+
+  // Parity: the menu is identical for every notebook (favorites included). There
+  // is no longer a slimmed-down variant - the former `disableExportOps` flag,
+  // which the Favorites list set to hide Download/Copy/Export/Send, was removed
+  // so all rows expose the full export action set.
+  it('shows the full export action set (download, copy-markdown, excel, word)', () => {
+    renderAndOpenMenu(location);
+
+    expect(screen.getByText('notebooks.download')).toBeInTheDocument();
+    expect(screen.getByText('Copy as Markdown')).toBeInTheDocument();
+    expect(screen.getByTestId('sidenav-item-menuitem-export-excel')).toBeInTheDocument();
+    expect(screen.getByTestId('sidenav-item-menuitem-export-word')).toBeInTheDocument();
+    expect(screen.getByTestId('sidenav-item-menuitem-send-datalake')).toBeInTheDocument();
+  });
 });

--- a/apps/client/app/components/Session/SidenavItem.tsx
+++ b/apps/client/app/components/Session/SidenavItem.tsx
@@ -91,7 +91,6 @@ const SessionSidenavItem: FC<{
   onToggleSelection?: () => void;
   isShared?: boolean;
   showMessageCount?: boolean;
-  disableExportOps?: boolean;
   /** Override the rendered name (e.g. /opti shows still-default-named sessions as
    *  "New conversation"). Falsy values fall back to the formatted session name. */
   displayNameOverride?: string;
@@ -111,7 +110,6 @@ const SessionSidenavItem: FC<{
   onToggleSelection,
   isShared = false,
   showMessageCount = true,
-  disableExportOps = false,
   displayNameOverride,
   selected,
 }): React.JSX.Element => {
@@ -841,42 +839,38 @@ const SessionSidenavItem: FC<{
                 <MenuItem onClick={handleCloneSession} className="sidenav-item-menuitem-clone">
                   <FolderCopyIcon /> {t('notebooks.clone')}
                 </MenuItem>
-                {!disableExportOps && (
-                  <>
-                    <MenuItem onClick={handleDownloadSession} className="sidenav-item-menuitem-download">
-                      <DownloadIcon /> {t('notebooks.download')}
-                    </MenuItem>
-                    <MenuItem onClick={handleCopyAsMarkdown} className="sidenav-item-menuitem-copy-markdown">
-                      <ContentCopyIcon /> Copy as Markdown
-                    </MenuItem>
-                    <Divider sx={{ my: 1 }} />
-                    <MenuItem
-                      onClick={handleExportToExcel}
-                      className="sidenav-item-menuitem-export-excel"
-                      data-testid="sidenav-item-menuitem-export-excel"
-                      disabled={exportToExcel.isPending}
-                    >
-                      <GridOnIcon /> Export to Excel
-                    </MenuItem>
-                    <MenuItem
-                      onClick={handleExportToWord}
-                      className="sidenav-item-menuitem-export-word"
-                      data-testid="sidenav-item-menuitem-export-word"
-                      disabled={exportToWord.isPending}
-                    >
-                      <ArticleIcon /> Export to Word
-                    </MenuItem>
-                    {isFeatureEnabled('EnableDataLakes') && (
-                      <MenuItem
-                        onClick={handleSendToDataLake}
-                        className="sidenav-item-menuitem-send-datalake"
-                        data-testid="sidenav-item-menuitem-send-datalake"
-                        disabled={sendToDataLake.isPending}
-                      >
-                        <StorageIcon /> Send to Data Lake
-                      </MenuItem>
-                    )}
-                  </>
+                <MenuItem onClick={handleDownloadSession} className="sidenav-item-menuitem-download">
+                  <DownloadIcon /> {t('notebooks.download')}
+                </MenuItem>
+                <MenuItem onClick={handleCopyAsMarkdown} className="sidenav-item-menuitem-copy-markdown">
+                  <ContentCopyIcon /> Copy as Markdown
+                </MenuItem>
+                <Divider sx={{ my: 1 }} />
+                <MenuItem
+                  onClick={handleExportToExcel}
+                  className="sidenav-item-menuitem-export-excel"
+                  data-testid="sidenav-item-menuitem-export-excel"
+                  disabled={exportToExcel.isPending}
+                >
+                  <GridOnIcon /> Export to Excel
+                </MenuItem>
+                <MenuItem
+                  onClick={handleExportToWord}
+                  className="sidenav-item-menuitem-export-word"
+                  data-testid="sidenav-item-menuitem-export-word"
+                  disabled={exportToWord.isPending}
+                >
+                  <ArticleIcon /> Export to Word
+                </MenuItem>
+                {isFeatureEnabled('EnableDataLakes') && (
+                  <MenuItem
+                    onClick={handleSendToDataLake}
+                    className="sidenav-item-menuitem-send-datalake"
+                    data-testid="sidenav-item-menuitem-send-datalake"
+                    disabled={sendToDataLake.isPending}
+                  >
+                    <StorageIcon /> Send to Data Lake
+                  </MenuItem>
                 )}
                 {canUpdate && (
                   <>

--- a/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
@@ -724,7 +724,6 @@ const CombinedNotebooks = () => {
                         isShared={false}
                         favoriteSessions={favoriteSessions}
                         showMessageCount={false}
-                        disableExportOps
                         onNavigate={handleItemNavigate}
                         onNotebookClick={handleNotebookClick}
                         onToggle={handleToggleItemSelection}

--- a/apps/client/app/components/layouts/Notebook/Sidenav/NotebookGroupList.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/NotebookGroupList.tsx
@@ -83,7 +83,6 @@ export default function NotebookGroupList({
                   isShared={'isShared' in d ? d.isShared : false}
                   favoriteSessions={favoriteSessions}
                   showMessageCount={showMessageCount}
-                  disableExportOps={false}
                   onNavigate={onNavigate}
                   onNotebookClick={onNotebookClick}
                   onToggle={onToggle}

--- a/apps/client/app/components/layouts/Notebook/Sidenav/NotebookRow.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/NotebookRow.tsx
@@ -24,7 +24,6 @@ const NotebookRow = memo(function NotebookRow({
   isShared,
   favoriteSessions,
   showMessageCount,
-  disableExportOps,
   onNavigate,
   onNotebookClick,
   onToggle,
@@ -35,7 +34,6 @@ const NotebookRow = memo(function NotebookRow({
   isShared: boolean;
   favoriteSessions?: ISessionFavoriteItem[];
   showMessageCount: boolean;
-  disableExportOps: boolean;
   onNavigate: (path: string) => void;
   onNotebookClick: (session: ISessionDocument) => void;
   onToggle: (id: string) => void;
@@ -63,7 +61,6 @@ const NotebookRow = memo(function NotebookRow({
       onToggleSelection={() => onToggle(item.id)}
       isShared={isShared}
       showMessageCount={showMessageCount}
-      disableExportOps={disableExportOps}
     />
   );
 });

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProjectSessionList.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProjectSessionList.tsx
@@ -30,7 +30,6 @@ function ProjectSessionList({ project, onNotebookClick, favoriteSessions }: Proj
             isChecked={false}
             isShared={false}
             showMessageCount={false}
-            disableExportOps={false}
           />
         ))
       ) : (


### PR DESCRIPTION
## Problem

The sidenav **Favorites** list rendered a slimmed-down 3-dot menu. Compared to the regular notebook list, favorited notebooks were missing five actions:

- Download
- Copy as Markdown
- Export to Excel
- Export to Word
- Send to Data Lake

## Root cause

`SidenavItem` gated those five items behind `{!disableExportOps && (...)}`. The `disableExportOps` prop was set `true` in exactly one place — the Favorites-section `NotebookRow` in `CombinedNotebooks.tsx` — so only favorites lost them. Every other caller passed `false`.

## Fix

Every notebook should expose every action regardless of favorite status, so this removes the `disableExportOps` concept entirely rather than leaving an always-false flag:

- dropped the prop from `SidenavItem` (interface + default) and `NotebookRow` (destructure, type, forward)
- ungated the export block in the sidenav menu
- removed it from all three call sites: the Favorites row that set it `true`, plus `NotebookGroupList` and `ProjectSessionList` that passed `false`

No behavior change for non-favorite rows; favorites now match them exactly. The `EnableDataLakes` feature gate on Send to Data Lake is preserved.

## Tests

Adds a parity test to `SidenavItem.gating.test.tsx` asserting the full export set (download, copy-markdown, excel, word, send-datalake) renders — and it runs for **both** menu variants (default sidenav row + `location="header"` dropdown) via the existing `describe.each`.

`pnpm --filter @bike4mind/client typecheck`, the gating test file (8 passing), and `pnpm lint:check` are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)