### PR TITLE
fix(client): freeze sidebar credit balance during streaming

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -93,7 +93,9 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
   const queryClient = useQueryClient();
   const theme = useTheme();
   const mode = theme.palette.mode;
-  const effectiveCredits = useEffectiveCredits();
+  // Gating (exhausted/low-credit warnings) reads the live balance, not the
+  // frozen display value - a genuine mid-turn exhaustion must still surface.
+  const effectiveCredits = useEffectiveCredits({ live: true });
 
   const { chatCompletion, setChatCompletion } = useSubscribeChatCompletion(currentSessionId);
 

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -130,7 +130,10 @@ export function useSendMessage({
 
   const workBenchFiles = useWorkBenchFiles(currentSessionId || undefined);
   const { currentUser } = useUser();
-  const effectiveCredits = useEffectiveCredits();
+  // Send-time validation must see the live balance - the server enforces
+  // credits on the reservation regardless, but the frozen display value
+  // would let this client-side check miss a genuine mid-turn exhaustion.
+  const effectiveCredits = useEffectiveCredits({ live: true });
   const { sendJsonMessage, readyState, resetLastJsonMessage } = useWebsocket();
   const queryClient = useQueryClient();
   const { migrateQuests, migrateSession, cleanupOptimistic } = useSessionCacheMigration();

--- a/apps/client/app/hooks/__tests__/useEffectiveCredits.test.ts
+++ b/apps/client/app/hooks/__tests__/useEffectiveCredits.test.ts
@@ -43,7 +43,7 @@ describe('useEffectiveCredits', () => {
     expect(result.current).toBe(1327);
   });
 
-  it('releases the freeze on error and on abort/cancel, not just on normal completion', () => {
+  it('releases the freeze on reset/abort (session removed from the map)', () => {
     const { result, rerender } = renderHook(() => useEffectiveCredits());
 
     act(() => useStreamingState.getState().startStreaming('session-1'));
@@ -55,6 +55,40 @@ describe('useEffectiveCredits', () => {
     mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 1400 } });
     rerender();
     expect(result.current).toBe(1400);
+  });
+
+  // The error/cancel paths (`useSubscribeChatCompletion`) do NOT delete the
+  // session - they leave the entry in the map with status 'error'/'cancelled'.
+  // Release therefore relies on `isAnyStreaming()` filtering on 'streaming'
+  // only; assert the freeze still lifts with the terminal entry still present.
+  it('releases the freeze on error, even though the errored session lingers in the map', () => {
+    const { result, rerender } = renderHook(() => useEffectiveCredits());
+
+    act(() => useStreamingState.getState().startStreaming('session-1'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 227 } });
+    rerender();
+    expect(result.current).toBe(1500);
+
+    act(() => useStreamingState.getState().errorStreaming('session-1'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 1400 } });
+    rerender();
+    expect(result.current).toBe(1400); // released despite the 'error' entry still in the map
+    expect(useStreamingState.getState().getStreamingStatus('session-1')).toBe('error');
+  });
+
+  it('releases the freeze on cancel, even though the cancelled session lingers in the map', () => {
+    const { result, rerender } = renderHook(() => useEffectiveCredits());
+
+    act(() => useStreamingState.getState().startStreaming('session-1'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 227 } });
+    rerender();
+    expect(result.current).toBe(1500);
+
+    act(() => useStreamingState.getState().cancelStreaming('session-1'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 1400 } });
+    rerender();
+    expect(result.current).toBe(1400); // released despite the 'cancelled' entry still in the map
+    expect(useStreamingState.getState().getStreamingStatus('session-1')).toBe('cancelled');
   });
 
   it('stays frozen until the last of several concurrent sessions finishes', () => {

--- a/apps/client/app/hooks/__tests__/useEffectiveCredits.test.ts
+++ b/apps/client/app/hooks/__tests__/useEffectiveCredits.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useEffectiveCredits } from '../useEffectiveCredits';
+import { useStreamingState } from '../useStreamingState';
+import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
+
+const mockUseUser = vi.fn();
+
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: () => mockUseUser(),
+}));
+
+describe('useEffectiveCredits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useStreamingState.setState({ sessions: new Map() });
+    useSelectedAccount.setState({ selectedAccount: null });
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 1500 } });
+  });
+
+  it('returns the live balance while idle', () => {
+    const { result } = renderHook(() => useEffectiveCredits());
+    expect(result.current).toBe(1500);
+  });
+
+  it('holds the pre-turn balance while streaming, then settles once on completion', () => {
+    const { result, rerender } = renderHook(() => useEffectiveCredits());
+    expect(result.current).toBe(1500);
+
+    // Streaming starts - the freeze snapshots the balance while it's still live.
+    act(() => useStreamingState.getState().startStreaming('session-1'));
+    expect(result.current).toBe(1500);
+
+    // Reserve lands mid-turn: worst-case dip, hidden behind the freeze.
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 227 } });
+    rerender();
+    expect(result.current).toBe(1500);
+
+    // Turn completes and reconcile settles the balance - one update, not a bounce.
+    act(() => useStreamingState.getState().completeStreaming('session-1'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 1327 } });
+    rerender();
+    expect(result.current).toBe(1327);
+  });
+
+  it('releases the freeze on error and on abort/cancel, not just on normal completion', () => {
+    const { result, rerender } = renderHook(() => useEffectiveCredits());
+
+    act(() => useStreamingState.getState().startStreaming('session-1'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 227 } });
+    rerender();
+    expect(result.current).toBe(1500);
+
+    act(() => useStreamingState.getState().resetStreaming('session-1'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 1400 } });
+    rerender();
+    expect(result.current).toBe(1400);
+  });
+
+  it('stays frozen until the last of several concurrent sessions finishes', () => {
+    const { result, rerender } = renderHook(() => useEffectiveCredits());
+
+    act(() => {
+      useStreamingState.getState().startStreaming('session-1');
+      useStreamingState.getState().startStreaming('session-2');
+    });
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 200 } });
+    rerender();
+    expect(result.current).toBe(1500);
+
+    act(() => useStreamingState.getState().completeStreaming('session-1'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 300 } });
+    rerender();
+    expect(result.current).toBe(1500);
+
+    act(() => useStreamingState.getState().completeStreaming('session-2'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 1350 } });
+    rerender();
+    expect(result.current).toBe(1350);
+  });
+
+  it('reflects a genuine balance change once idle (freeze does not permanently pin the value)', () => {
+    const { result, rerender } = renderHook(() => useEffectiveCredits());
+    expect(result.current).toBe(1500);
+
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 2500 } });
+    rerender();
+    expect(result.current).toBe(2500);
+  });
+
+  it('{ live: true } always reads the live balance, even mid-turn', () => {
+    const { result, rerender } = renderHook(() => useEffectiveCredits({ live: true }));
+
+    act(() => useStreamingState.getState().startStreaming('session-1'));
+    mockUseUser.mockReturnValue({ currentUser: { id: 'user-1', currentCredits: 227 } });
+    rerender();
+
+    expect(result.current).toBe(227);
+  });
+
+  it('uses the org account balance when a non-personal account is selected', () => {
+    useSelectedAccount.setState({
+      selectedAccount: { id: 'org-1', name: 'Org', personal: false, credits: 9000 },
+    });
+    const { result } = renderHook(() => useEffectiveCredits());
+    expect(result.current).toBe(9000);
+  });
+});

--- a/apps/client/app/hooks/useEffectiveCredits.ts
+++ b/apps/client/app/hooks/useEffectiveCredits.ts
@@ -1,12 +1,47 @@
+import { useState } from 'react';
 import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
 import { useUser } from '@client/app/contexts/UserContext';
+import { useStreamingState } from '@client/app/hooks/useStreamingState';
 
-export function useEffectiveCredits(): number {
+interface UseEffectiveCreditsOptions {
+  /**
+   * Bypass the mid-turn freeze below and read the live balance. Used by
+   * send-gating checks (exhausted/low-credit warnings, send validation) so a
+   * genuine mid-turn exhaustion is still enforced even while the *displayed*
+   * balance is held.
+   */
+  live?: boolean;
+}
+
+/**
+ * Server-side credit reservation dips the balance to a worst-case value for
+ * the duration of a turn, then reconciles it back up on settlement - correct
+ * overdraw protection, but shown raw it reads as a glitch (dip then bounce).
+ * While any turn is streaming, hold the balance at its pre-turn value and
+ * release to the live value once streaming ends (completion, error, or
+ * abort all clear `isAnyStreaming()` via `resetStreaming`/`completeStreaming`).
+ */
+export function useEffectiveCredits(options?: UseEffectiveCreditsOptions): number {
   const { selectedAccount } = useSelectedAccount();
   const { currentUser } = useUser();
+  const isAnyStreaming = useStreamingState(state => state.isAnyStreaming());
 
-  if (selectedAccount && !selectedAccount.personal) {
-    return selectedAccount.credits;
+  const liveCredits =
+    selectedAccount && !selectedAccount.personal ? selectedAccount.credits : currentUser?.currentCredits || 0;
+
+  // "Adjusting state when a prop changes" pattern (react.dev) - tracking the
+  // previous streaming flag alongside the frozen value lets the snapshot/release
+  // happen synchronously during render on the idle<->streaming edge, with no
+  // effect and no extra render pass.
+  const [prevIsStreaming, setPrevIsStreaming] = useState(isAnyStreaming);
+  const [frozenCredits, setFrozenCredits] = useState<number | null>(null);
+  if (isAnyStreaming !== prevIsStreaming) {
+    setPrevIsStreaming(isAnyStreaming);
+    setFrozenCredits(isAnyStreaming ? liveCredits : null);
   }
-  return currentUser?.currentCredits || 0;
+
+  if (options?.live) {
+    return liveCredits;
+  }
+  return frozenCredits ?? liveCredits;
 }


### PR DESCRIPTION
## Summary
- Sidebar credit balance no longer dips to the worst-case reservation mid-turn — it holds the pre-turn value while a turn streams, then updates once to the settled value on completion.
- Freeze applied at the display read path (`useEffectiveCredits`), gated by `useStreamingState.isAnyStreaming()`. Two gating call-sites (`SessionBottom.tsx`, `useSendMessage.ts`) opt into the live value via `{ live: true }` so send-time enforcement stays authoritative.
- Client-only: server reserve/reconcile logic, `incrementCredits`, and the persisted balance are unchanged.

Closes #231.

## Display consumers of the freeze
Every no-arg `useEffectiveCredits()` reader freezes mid-stream. In open-core that is the **Credits modal** (`subscription/CreditsModal.tsx:72`) — so the modal's balance now holds during a streaming turn too, consistent with intent (thanks @onoya for flagging). The `{ live: true }` gating call-sites are unaffected. The account-switcher chip (`AccountCard` → `currentUser.currentCredits`) does **not** read `useEffectiveCredits` and is unchanged by this PR.

## Test plan
- [x] 9 unit tests covering the freeze/release sequence (dip hidden, release on completion; release on reset/abort where the entry is deleted; release on error/cancel where the terminal entry **lingers** in the map; concurrent sessions; `{ live: true }` bypass; genuine balance change reflected once idle)
- [x] `typecheck:fast` clean
- [x] eslint clean (no new warnings)
- [ ] Manual/e2e confirmation on a premium-overlay deploy that the sidebar no longer shows the dip-and-bounce (open-core has no persistent credit number to observe locally — see spec's Open Questions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)