### PR TITLE
fix(client): block Enter-to-send while a response is still streaming

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -472,7 +472,14 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
 
                         setShowSlashSuggestions(shouldShowSlashSuggestions);
                       }}
-                      onSubmit={async () => await handleSendClick()}
+                      onSubmit={async () => {
+                        // Block Enter-to-send while a response is still streaming (the toolbar
+                        // shows Stop, not Send, so the button path is already gated). Without
+                        // this, a second prompt sent mid-response makes the two quests' status
+                        // timers fight in the progress area. See #285.
+                        if (shouldShowStopButton || submitting) return;
+                        await handleSendClick();
+                      }}
                       onPaste={handlePaste}
                       placeholder={`${t('session.typeYourMessage')}...`}
                       agents={lexicalAgents}

--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -473,10 +473,7 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
                         setShowSlashSuggestions(shouldShowSlashSuggestions);
                       }}
                       onSubmit={async () => {
-                        // Block Enter-to-send while a response is still streaming (the toolbar
-                        // shows Stop, not Send, so the button path is already gated). Without
-                        // this, a second prompt sent mid-response makes the two quests' status
-                        // timers fight in the progress area. See #285.
+                        // Block Enter-to-send while a response is still streaming.
                         if (shouldShowStopButton || submitting) return;
                         await handleSendClick();
                       }}


### PR DESCRIPTION
## Description

Fixes #285. Sending a second prompt via **Enter** while the prior response was still streaming let both quests run at once, so their status/timer progress fought over the progress area.

Root cause: the Send **button** is already gated during a response — the toolbar swaps it for the **Stop** button (`shouldShowStopButton`) — but the **Enter-to-send** path (`LexicalChatInput`'s `onSubmit`) called `handleSendClick()` unconditionally, bypassing that gate.

## Changes

- `SessionBottom.tsx`: gate the `onSubmit` (Enter) handler on `shouldShowStopButton || submitting`, so Enter is a no-op while a response is streaming — matching the already-hidden Send button. One-line guard at the single Enter entry point; the button and programmatic (`submitting`-gated) paths were already covered.

## Why the minimal fix (and not queuing)

The issue lists two options for expected behavior:
1. **Queue** the second message and auto-send it at a breakpoint (local queue requiring the tab stay open, or a server-side queue that survives closing the notebook, possibly with ReAct-loop steering).
2. **Minimal:** *"simply block sending until the prior action is finished."*

I went with **#2**. Option #1 is a genuine feature — the issue itself notes "some of that might transition from a bug ticket into a feature ticket, TBD after investigation" (local vs. server queue, breakpoint auto-send, real-time steering are all design decisions). This PR is scoped to **stopping the broken behavior now**; message queuing is worth a dedicated follow-up feature ticket rather than being bundled into a bug fix.

## Guide for Testers

1. Open a new chat and send a prompt with a non-instant response (e.g. generate an artifact / research the web).
2. While it is still responding (Stop button showing), type another prompt and press **Enter**.
3. **Expected:** the second prompt does **not** send while the first is still streaming — no second quest starts, no fighting status timers. Once the first response completes, Enter sends normally again.
4. Regression: clicking Send (when not streaming), Enter on a normal turn, and Stop all behave as before.

## Additional Information

- Follow-up (feature): local/server-side message queue with breakpoint auto-send — the "best" option from the issue, intentionally out of scope here.
- `pnpm --filter client typecheck` passes; ESLint on the file: 0 errors.

