### PR TITLE
fix(e2e): resolve inline-register consent-checkbox check() timeout

### DIFF
--- a/apps/client/e2e/pages/BasePage.ts
+++ b/apps/client/e2e/pages/BasePage.ts
@@ -210,6 +210,22 @@ export class BasePage {
     await uiAssertion();
   }
 
+  /**
+   * Tick a MUI Joy `Checkbox` whose label contains policy links.
+   *
+   * MUI Joy overlays a transparent full-width `<input>` (the "action" area) at `zIndex: 1` over the
+   * whole control, but consent labels promote their policy `<Link>`s ABOVE that overlay
+   * (`CHECKBOX_LABEL_LINK_SX`, see app/utils/externalLinks.ts). Playwright's `.check()` clicks the
+   * input's center, which on a multi-line consent label lands on a link - Playwright reads that as
+   * an intercepted click and retries until it times out. Click the top-left instead (the checkbox
+   * square, never covered by a link), and only when not already checked so the toggle is idempotent.
+   */
+  async checkMuiCheckbox(checkbox: Locator) {
+    if (await checkbox.isChecked()) return;
+    await checkbox.click({ position: { x: 6, y: 6 } });
+    await expect(checkbox).toBeChecked({ timeout: TIMEOUTS.ELEMENT_STATE });
+  }
+
   async waitForLoaderToDisappear(selector: string) {
     // Wait directly for the hidden state. Playwright treats a not-yet-attached
     // element as already 'hidden', so this resolves immediately when the loader

--- a/apps/client/e2e/pages/LoginPage.ts
+++ b/apps/client/e2e/pages/LoginPage.ts
@@ -74,8 +74,8 @@ export class LoginPage extends BasePage {
    * Both gate the Create account button, and the server rejects account creation without them.
    */
   async acceptInlineRegisterPolicies() {
-    await this.page.getByTestId('login-register-aup-tos-checkbox').getByRole('checkbox').check();
-    await this.page.getByTestId('login-register-age-checkbox').getByRole('checkbox').check();
+    await this.checkMuiCheckbox(this.page.getByTestId('login-register-aup-tos-checkbox').getByRole('checkbox'));
+    await this.checkMuiCheckbox(this.page.getByTestId('login-register-age-checkbox').getByRole('checkbox'));
   }
 
   /** Submit the inline register step to create the account, then wait to be routed off /login. */

--- a/apps/client/e2e/pages/SignupPage.ts
+++ b/apps/client/e2e/pages/SignupPage.ts
@@ -32,8 +32,8 @@ export class SignupPage extends BasePage {
    * until both are checked. Must be called before submit() on the OTC request step.
    */
   async acceptPolicies() {
-    await this.page.getByTestId('register-aup-tos-checkbox').getByRole('checkbox').check();
-    await this.page.getByTestId('register-age-checkbox').getByRole('checkbox').check();
+    await this.checkMuiCheckbox(this.page.getByTestId('register-aup-tos-checkbox').getByRole('checkbox'));
+    await this.checkMuiCheckbox(this.page.getByTestId('register-age-checkbox').getByRole('checkbox'));
   }
 
   /** Submit the first step (username + email) to request a one-time code. */


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="684" height="645" alt="Screenshot 2026-07-08 at 12 39 41 PM" src="https://github.com/user-attachments/assets/5e8c0fe8-a034-4aa5-aefb-9c011ee717db" />


## Description

The E2E signup suite failed at the consent-checkbox step with a ~55s `.check()` timeout (`login-register-aup-tos-checkbox` on the inline-register flow).

Root cause is an interaction between MUI Joy and PR #243 ("make policy links clickable"). MUI Joy renders a Checkbox as a transparent, full-width `<input>` overlay at `zIndex: 1` covering the whole control (square + label). PR #243 promoted the consent label's policy links *above* that overlay (`CHECKBOX_LABEL_LINK_SX` = `position: relative; zIndex: 2`) so they're clickable. Playwright's `.check()` clicks the *center* of the input's bounding box — on the multi-line AUP/ToS label the center lands on the "Acceptable Use Policy" link, so Playwright reads every click as intercepted and retries until timeout. (The age checkbox has no link, so the run never reached it.)

## Changes

- Add a `checkMuiCheckbox()` helper to `BasePage` that clicks the top-left checkbox square (never covered by a link) instead of the center, skips if already checked (idempotent), and asserts the checked state.
- Route `LoginPage.acceptInlineRegisterPolicies()` through the helper.
- Route `SignupPage.acceptPolicies()` through the helper (same latent bug — `register-aup-tos-checkbox` carries the same links).

## Guide for Testers
Prerequisite: Allow self registration should be enabled.
1. Go to Github -> Actions and click the **E2E Tests (Manual)**.
2. Click **Run workflow**.
3. Select the **branch fix/e2e-signup-failure** in the branch dropdown.
4.  Click **Run workflow** button
Expected: After the run the Signup test should pass and should send a slack report summary.

### What NOT to test

- No product/runtime code changed — only Playwright page objects under `apps/client/e2e/pages/`. The checkbox component itself is untouched.

## Additional Information

Test-only change; no product code, schema, or telemetry affected.

## Developer Notes (Optional)
<!--
Document capability unlocks, architectural improvements, and reusable patterns introduced by this PR.
This helps future developers understand what new building blocks are available.

Categories to consider:
- **New Extension Points**: Components/interfaces that accept new props, hooks, or configuration
- **Reusable Patterns**: New components, utilities, or approaches that can be applied elsewhere
- **Data Model Changes**: New fields, types, or structures that enable future features
- **Architecture Decisions**: Why something was built a certain way (not just what changed)

Example:
- `SchedulerTab` now accepts a `familyId` prop — any new pattern family automatically gets a Learn tab
- `ComingSoonPanel` component can be dropped into any tab to indicate future work
- `effectiveTab` pattern shows how to handle persisted tab state when tabs become conditionally disabled
-->

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
