### PR TITLE
chore: gitignore local env-file secret backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ cdk.context.json
 .env
 .env.secrets
 .env.selfhost
+.env.e2e
+# Local env-file secret backups: a *.bak of an env file (tooling and editors
+# write these) and .env.e2e can both hold real secrets - never commit them.
+.env.bak
+.env.*.bak
 .direnv
 
 # Local-only docker compose override (per-developer mongo port/container)


### PR DESCRIPTION
## What

Adds three ignore patterns so local env-file secret backups can never be committed:

- `.env.e2e` - a common target for a local env file used by e2e runs
- `.env.bak`, `.env.*.bak` - `*.bak` copies of env files (various tooling and editors write these automatically)

## Why

`.gitignore` already covers `.env`, `.env.secrets`, and `.env.selfhost`, but not their `.bak` backups or `.env.e2e`. Any tool or manual step that produces one of these leaves a real-secret-bearing file untracked and one `git add` away from landing in public history. The gitleaks hook is a backstop, not the guard - ignoring these by name closes the gap at the source.

Verified: the new patterns ignore `.env.bak` / `.env.e2e` / `.env.selfhost.bak`, and the tracked templates (`.env.example`, `.env.secrets.example`, `.env.selfhost.example`) stay trackable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)