### PR TITLE
feat(client): sidebar & profile dropdown UI/UX polish

### DIFF
--- a/apps/client/app/components/Agent/SidenavItem.tsx
+++ b/apps/client/app/components/Agent/SidenavItem.tsx
@@ -11,9 +11,11 @@ interface AgentSidenavItemProps {
     visual?: { portraitUrl?: string };
   };
   onClick?: () => void;
+  /** Highlights the row (blue bar + focused bg) when its dedicated agent screen is open. */
+  isSelected?: boolean;
 }
 
-const AgentSidenavItem: FC<AgentSidenavItemProps> = ({ agent, onClick }) => {
+const AgentSidenavItem: FC<AgentSidenavItemProps> = ({ agent, onClick, isSelected }) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
@@ -29,6 +31,7 @@ const AgentSidenavItem: FC<AgentSidenavItemProps> = ({ agent, onClick }) => {
       className="agent-sidenav-item"
       onClick={handleClick}
       sx={theme => ({
+        position: 'relative',
         borderRadius: '8px',
         gap: '12px',
         padding: '6px 12px',
@@ -36,9 +39,23 @@ const AgentSidenavItem: FC<AgentSidenavItemProps> = ({ agent, onClick }) => {
         display: 'flex',
         alignItems: 'center',
         cursor: 'pointer',
-        backgroundColor: 'transparent',
+        backgroundColor: isSelected ? theme.palette.notebooklist.focusedBackground : 'transparent',
+        // Blue left active-indicator bar, matching the notebook row's selected state.
+        '&::before': isSelected
+          ? {
+              content: '""',
+              position: 'absolute',
+              left: 0,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              width: '2px',
+              height: '80%',
+              backgroundColor: theme.palette.primary[500],
+              borderRadius: '1px',
+            }
+          : {},
         '&:hover': {
-          backgroundColor: theme.palette.notebooklist.hoverBg,
+          backgroundColor: isSelected ? undefined : theme.palette.notebooklist.hoverBg,
         },
         transition: 'background 0.2s',
       })}

--- a/apps/client/app/components/Project/SidenavItem.tsx
+++ b/apps/client/app/components/Project/SidenavItem.tsx
@@ -17,6 +17,11 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
   const textRef = useRef<HTMLDivElement>(null);
   const [isTextTruncated, setIsTextTruncated] = useState(false);
 
+  // A project with no member notebooks has nothing to expand into, so we drop the chevron
+  // and show a muted "No notebooks" label in its place. Derived from sessionIds (always
+  // present on the document) so we know it without the lazy per-project session fetch.
+  const isEmpty = (project.sessionIds?.length ?? 0) === 0;
+
   const handleClick = () => {
     if (onClick) {
       onClick();
@@ -44,7 +49,8 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
       onClick={handleClick}
       sx={theme => ({
         borderRadius: '8px',
-        padding: onToggleExpand !== undefined ? '6px 6px 6px 12px' : '6px 12px',
+        // Tighter right padding only when the 24px chevron occupies the right slot.
+        padding: onToggleExpand !== undefined && !isEmpty ? '6px 6px 6px 12px' : '6px 12px',
         minHeight: '36px',
         display: 'flex',
         alignItems: 'center',
@@ -80,7 +86,7 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
           >
             <HubOutlinedIcon
               sx={theme => ({
-                fontSize: '14px',
+                fontSize: '12px',
                 color: theme.palette.mode === 'dark' ? '#81C784' : '#388E3C',
               })}
             />
@@ -105,46 +111,54 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
           </Typography>
         </Tooltip>
       </Box>
-      {onToggleExpand !== undefined && (
-        <IconButton
-          data-testid="project-expand-btn"
-          aria-label={isExpanded ? 'Collapse project' : 'Expand project'}
-          aria-expanded={isExpanded}
-          variant="plain"
-          color="neutral"
-          size="sm"
-          onClick={e => {
-            e.stopPropagation();
-            onToggleExpand();
-          }}
-          sx={{
-            minWidth: '24px',
-            minHeight: '24px',
-            width: '24px',
-            height: '24px',
-            p: 0,
-            ml: '4px',
-            flexShrink: 0,
-            '--IconButton-size': '24px',
-            // Always visible (unlike the notebook three-dot, which is hover-gated), but reuse the
-            // notebook button's color logic: icon at 50% by default, full on hover, no bg change.
-            '& .MuiSvgIcon-root': {
-              opacity: 0.5,
-              transition: 'opacity 0.3s ease, transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
-              // Points down when collapsed, flips up when expanded.
-              transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-            },
-            '&:hover, &:focus-visible, &:active': {
-              backgroundColor: 'transparent',
+      {onToggleExpand !== undefined &&
+        (isEmpty ? (
+          <Typography
+            level="body-xs"
+            sx={{ color: 'text.tertiary', fontSize: '11px', flexShrink: 0, ml: '8px', whiteSpace: 'nowrap' }}
+          >
+            No notebooks
+          </Typography>
+        ) : (
+          <IconButton
+            data-testid="project-expand-btn"
+            aria-label={isExpanded ? 'Collapse project' : 'Expand project'}
+            aria-expanded={isExpanded}
+            variant="plain"
+            color="neutral"
+            size="sm"
+            onClick={e => {
+              e.stopPropagation();
+              onToggleExpand();
+            }}
+            sx={{
+              minWidth: '24px',
+              minHeight: '24px',
+              width: '24px',
+              height: '24px',
+              p: 0,
+              ml: '4px',
+              flexShrink: 0,
+              '--IconButton-size': '24px',
+              // Always visible (unlike the notebook three-dot, which is hover-gated), but reuse the
+              // notebook button's color logic: icon at 50% by default, full on hover, no bg change.
               '& .MuiSvgIcon-root': {
-                opacity: 1,
+                opacity: 0.5,
+                transition: 'opacity 0.3s ease, transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
+                // Points down when collapsed, flips up when expanded.
+                transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
               },
-            },
-          }}
-        >
-          <KeyboardArrowDownIcon sx={{ fontSize: '16px' }} />
-        </IconButton>
-      )}
+              '&:hover, &:focus-visible, &:active': {
+                backgroundColor: 'transparent',
+                '& .MuiSvgIcon-root': {
+                  opacity: 1,
+                },
+              },
+            }}
+          >
+            <KeyboardArrowDownIcon sx={{ fontSize: '16px' }} />
+          </IconButton>
+        ))}
     </Box>
   );
 };

--- a/apps/client/app/components/Project/SidenavItem.tsx
+++ b/apps/client/app/components/Project/SidenavItem.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, Tooltip, IconButton } from '@mui/joy';
 import { FC, memo, useRef, useState, useEffect } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 
 interface ProjectSidenavItemProps {
   project: IProjectDocument;
@@ -44,7 +44,7 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
       onClick={handleClick}
       sx={theme => ({
         borderRadius: '8px',
-        padding: onToggleExpand !== undefined ? '6px 12px 6px 4px' : '6px 12px',
+        padding: onToggleExpand !== undefined ? '6px 6px 6px 12px' : '6px 12px',
         minHeight: '36px',
         display: 'flex',
         alignItems: 'center',
@@ -56,33 +56,6 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
         transition: 'background 0.2s',
       })}
     >
-      {onToggleExpand !== undefined && (
-        <IconButton
-          data-testid="project-expand-btn"
-          aria-label={isExpanded ? 'Collapse project' : 'Expand project'}
-          aria-expanded={isExpanded}
-          variant="plain"
-          color="neutral"
-          size="sm"
-          onClick={e => {
-            e.stopPropagation();
-            onToggleExpand();
-          }}
-          sx={{
-            minWidth: '20px',
-            minHeight: '20px',
-            width: '20px',
-            height: '20px',
-            p: 0,
-            flexShrink: 0,
-            transition: 'transform 0.15s',
-            transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
-            '--IconButton-size': '20px',
-          }}
-        >
-          <ChevronRightIcon sx={{ fontSize: '16px' }} />
-        </IconButton>
-      )}
       <Box
         sx={{
           display: 'flex',
@@ -90,7 +63,6 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
           gap: '8px',
           flex: 1,
           overflow: 'hidden',
-          pl: onToggleExpand !== undefined ? '4px' : 0,
         }}
       >
         <Tooltip title="Project" placement="top">
@@ -133,6 +105,46 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
           </Typography>
         </Tooltip>
       </Box>
+      {onToggleExpand !== undefined && (
+        <IconButton
+          data-testid="project-expand-btn"
+          aria-label={isExpanded ? 'Collapse project' : 'Expand project'}
+          aria-expanded={isExpanded}
+          variant="plain"
+          color="neutral"
+          size="sm"
+          onClick={e => {
+            e.stopPropagation();
+            onToggleExpand();
+          }}
+          sx={{
+            minWidth: '24px',
+            minHeight: '24px',
+            width: '24px',
+            height: '24px',
+            p: 0,
+            ml: '4px',
+            flexShrink: 0,
+            '--IconButton-size': '24px',
+            // Always visible (unlike the notebook three-dot, which is hover-gated), but reuse the
+            // notebook button's color logic: icon at 50% by default, full on hover, no bg change.
+            '& .MuiSvgIcon-root': {
+              opacity: 0.5,
+              transition: 'opacity 0.3s ease, transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
+              // Points down when collapsed, flips up when expanded.
+              transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+            },
+            '&:hover, &:focus-visible, &:active': {
+              backgroundColor: 'transparent',
+              '& .MuiSvgIcon-root': {
+                opacity: 1,
+              },
+            },
+          }}
+        >
+          <KeyboardArrowDownIcon sx={{ fontSize: '16px' }} />
+        </IconButton>
+      )}
     </Box>
   );
 };

--- a/apps/client/app/components/Project/SidenavItem.tsx
+++ b/apps/client/app/components/Project/SidenavItem.tsx
@@ -10,9 +10,17 @@ interface ProjectSidenavItemProps {
   onClick?: () => void;
   isExpanded?: boolean;
   onToggleExpand?: () => void;
+  /** Highlights the row (blue bar + focused bg) when its dedicated project screen is open. */
+  isSelected?: boolean;
 }
 
-const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isExpanded, onToggleExpand }) => {
+const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({
+  project,
+  onClick,
+  isExpanded,
+  onToggleExpand,
+  isSelected,
+}) => {
   const navigate = useNavigate();
   const textRef = useRef<HTMLDivElement>(null);
   const [isTextTruncated, setIsTextTruncated] = useState(false);
@@ -48,6 +56,7 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
       className="project-sidenav-item"
       onClick={handleClick}
       sx={theme => ({
+        position: 'relative',
         borderRadius: '8px',
         // Tighter right padding only when the 24px chevron occupies the right slot.
         padding: onToggleExpand !== undefined && !isEmpty ? '6px 6px 6px 12px' : '6px 12px',
@@ -55,9 +64,24 @@ const ProjectSidenavItem: FC<ProjectSidenavItemProps> = ({ project, onClick, isE
         display: 'flex',
         alignItems: 'center',
         cursor: 'pointer',
-        backgroundColor: 'transparent',
+        backgroundColor: isSelected ? theme.palette.notebooklist.focusedBackground : 'transparent',
+        // Left active-indicator bar, matching the notebook row's selected state.
+        '&::before': isSelected
+          ? {
+              content: '""',
+              position: 'absolute',
+              left: 0,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              width: '2px',
+              height: '80%',
+              // Match the project tag icon's green.
+              backgroundColor: theme.palette.mode === 'dark' ? '#81C784' : '#388E3C',
+              borderRadius: '1px',
+            }
+          : {},
         '&:hover': {
-          backgroundColor: theme.palette.notebooklist.hoverBg,
+          backgroundColor: isSelected ? undefined : theme.palette.notebooklist.hoverBg,
         },
         transition: 'background 0.2s',
       })}

--- a/apps/client/app/components/Session/SidenavItem.tsx
+++ b/apps/client/app/components/Session/SidenavItem.tsx
@@ -317,10 +317,10 @@ const SessionSidenavItem: FC<{
             left: 0,
             top: '50%',
             transform: 'translateY(-50%)',
-            width: '3px',
-            height: '70%',
+            width: '2px',
+            height: '80%',
             backgroundColor: theme.palette.primary[500],
-            borderRadius: '0 2px 2px 0',
+            borderRadius: '1px',
           }
         : {},
       '&:hover': {

--- a/apps/client/app/components/Tutorials/FTUESlider.tsx
+++ b/apps/client/app/components/Tutorials/FTUESlider.tsx
@@ -216,7 +216,12 @@ const FTUESlider: React.FC<FTUESliderProps> = ({ onComplete }) => {
         backgroundColor: theme => (theme.palette.mode === 'dark' ? theme.palette.background.surface2 : undefined),
         borderRadius: '12px',
         overflow: 'hidden',
-        boxShadow: 'lg',
+        // Soft, diffuse lift: a wide low-opacity ambient layer plus a tighter contact layer.
+        // Stronger in dark mode, where light shadows all but disappear against the background.
+        boxShadow: theme =>
+          theme.palette.mode === 'dark'
+            ? '0 24px 70px rgba(0, 0, 0, 0.28), 0 8px 20px rgba(0, 0, 0, 0.14)'
+            : '0 24px 30px rgba(0, 0, 0, 0.03), 0 8px 20px rgba(0, 0, 0, 0.02)',
         display: 'flex',
         flexDirection: 'column',
         m: isMobile ? '16px' : 'auto',

--- a/apps/client/app/components/Tutorials/FTUESlider.tsx
+++ b/apps/client/app/components/Tutorials/FTUESlider.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Box, Typography, IconButton, Sheet } from '@mui/joy';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import { useMediaQuery } from '@mui/system';
 import { APP_NAME } from '@client/config/general';
 
@@ -211,14 +212,44 @@ const FTUESlider: React.FC<FTUESliderProps> = ({ onComplete }) => {
         maxWidth: isMobile ? '100%' : 'unset',
         height: isMobile ? 'calc(100vh - 32px)' : '720px',
         maxHeight: isMobile ? 'calc(100vh - 32px)' : '720px',
+        // Dark mode matches the sidebar surface; light mode keeps the Sheet default.
+        backgroundColor: theme => (theme.palette.mode === 'dark' ? theme.palette.background.surface2 : undefined),
         borderRadius: '12px',
         overflow: 'hidden',
         boxShadow: 'lg',
         display: 'flex',
         flexDirection: 'column',
         m: isMobile ? '16px' : 'auto',
+        // Positioning context for the corner close button.
+        position: 'relative',
       }}
     >
+      {/* Dismiss the tutorial - leads to a fresh session (New Chat), wired via onComplete. */}
+      <IconButton
+        data-testid="tutorial-close-btn"
+        aria-label="Close tutorial"
+        variant="plain"
+        color="neutral"
+        size="sm"
+        onClick={() => onComplete?.()}
+        sx={theme => ({
+          position: 'absolute',
+          top: 12,
+          right: 12,
+          zIndex: 10,
+          // Transparent at rest and on hover; only the icon tint changes (tertiary -> primary).
+          // Joy SvgIcons read --Icon-color, not `color`, so tint via that variable.
+          backgroundColor: 'transparent',
+          '--Icon-color': theme.palette.text.tertiary,
+          '& svg': { transition: 'color 0.2s ease' },
+          '&:hover': {
+            backgroundColor: 'transparent',
+            '--Icon-color': theme.palette.text.primary,
+          },
+        })}
+      >
+        <CloseRoundedIcon />
+      </IconButton>
       <Box
         sx={{
           display: 'flex',

--- a/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
@@ -655,9 +655,7 @@ const CombinedNotebooks = () => {
                     display: 'flex',
                     alignItems: 'center',
                     cursor: 'pointer',
-                    backgroundColor: isSelected
-                      ? theme.palette.notebooklist.focusedBackground
-                      : theme.palette.background.panel,
+                    backgroundColor: isSelected ? theme.palette.notebooklist.focusedBackground : 'transparent',
                     '&:hover': {
                       backgroundColor: isSelected ? undefined : theme.palette.notebooklist.hoverBg,
                     },

--- a/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
@@ -45,6 +45,17 @@ const CombinedNotebooks = () => {
   const isAgentsEnabled = isFeatureEnabled('enableAgents');
   const location = useLocation();
 
+  // Route-driven sidebar selection. Anywhere in the projects section (the /projects grid or a
+  // specific /projects/:id screen) the stale current-session highlight should be dropped
+  // (currentSessionId is a persisted store value that isn't cleared on project navigation).
+  // A specific project screen additionally highlights its own row. Computed once here so the
+  // hot per-notebook rows don't each subscribe to the router.
+  const onProjectsSection = location.pathname === '/projects' || location.pathname.startsWith('/projects/');
+  const activeProjectId = useMemo(() => {
+    const match = location.pathname.match(/^\/projects\/([^/]+)/);
+    return match ? match[1] : null;
+  }, [location.pathname]);
+
   // The shared sidebar serves the default surface (surface:null). Product surfaces like /opti
   // own a dedicated, fully scoped nav (e.g. OptiSidenav) and no longer render this component, so
   // it carries no surface-specific branching.
@@ -738,6 +749,7 @@ const CombinedNotebooks = () => {
                         isShared={false}
                         favoriteSessions={favoriteSessions}
                         showMessageCount={false}
+                        suppressActive={onProjectsSection}
                         onNavigate={handleItemNavigate}
                         onNotebookClick={handleNotebookClick}
                         onToggle={handleToggleItemSelection}
@@ -766,12 +778,14 @@ const CombinedNotebooks = () => {
                     isExpanded={expandedProjects.has(project.id)}
                     onToggleExpand={() => handleToggleProject(project.id)}
                     onClick={() => handleItemNavigate(`/projects/${project.id}`)}
+                    isSelected={project.id === activeProjectId}
                   />
                   {expandedProjects.has(project.id) && (
                     <ProjectSessionList
                       project={project as IProjectDocument}
                       onNotebookClick={handleNotebookClick}
                       favoriteSessions={favoriteSessions}
+                      suppressActive={onProjectsSection}
                     />
                   )}
                 </Box>
@@ -787,6 +801,7 @@ const CombinedNotebooks = () => {
             selectedItems={selectedItems}
             favoriteSessions={favoriteSessions}
             showMessageCount={showMessageCounts}
+            suppressActive={onProjectsSection}
             onNavigate={handleItemNavigate}
             onNotebookClick={handleNotebookClick}
             onToggle={handleToggleItemSelection}

--- a/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
@@ -45,14 +45,20 @@ const CombinedNotebooks = () => {
   const isAgentsEnabled = isFeatureEnabled('enableAgents');
   const location = useLocation();
 
-  // Route-driven sidebar selection. Anywhere in the projects section (the /projects grid or a
-  // specific /projects/:id screen) the stale current-session highlight should be dropped
-  // (currentSessionId is a persisted store value that isn't cleared on project navigation).
-  // A specific project screen additionally highlights its own row. Computed once here so the
-  // hot per-notebook rows don't each subscribe to the router.
+  // Route-driven sidebar selection. Anywhere in the projects/agents sections (the grid or a
+  // specific /:id screen) the stale current-session highlight should be dropped (currentSessionId
+  // is a persisted store value that isn't cleared on navigation). A specific project/agent screen
+  // additionally highlights its own row. Computed once here so the hot per-notebook rows don't
+  // each subscribe to the router.
   const onProjectsSection = location.pathname === '/projects' || location.pathname.startsWith('/projects/');
+  const onAgentsSection = location.pathname === '/agents' || location.pathname.startsWith('/agents/');
+  const suppressNotebookHighlight = onProjectsSection || onAgentsSection;
   const activeProjectId = useMemo(() => {
     const match = location.pathname.match(/^\/projects\/([^/]+)/);
+    return match ? match[1] : null;
+  }, [location.pathname]);
+  const activeAgentId = useMemo(() => {
+    const match = location.pathname.match(/^\/agents\/([^/]+)/);
     return match ? match[1] : null;
   }, [location.pathname]);
 
@@ -749,7 +755,8 @@ const CombinedNotebooks = () => {
                         isShared={false}
                         favoriteSessions={favoriteSessions}
                         showMessageCount={false}
-                        suppressActive={onProjectsSection}
+                        suppressActive={suppressNotebookHighlight}
+                        activeAgentId={activeAgentId}
                         onNavigate={handleItemNavigate}
                         onNotebookClick={handleNotebookClick}
                         onToggle={handleToggleItemSelection}
@@ -785,7 +792,7 @@ const CombinedNotebooks = () => {
                       project={project as IProjectDocument}
                       onNotebookClick={handleNotebookClick}
                       favoriteSessions={favoriteSessions}
-                      suppressActive={onProjectsSection}
+                      suppressActive={suppressNotebookHighlight}
                     />
                   )}
                 </Box>
@@ -801,7 +808,8 @@ const CombinedNotebooks = () => {
             selectedItems={selectedItems}
             favoriteSessions={favoriteSessions}
             showMessageCount={showMessageCounts}
-            suppressActive={onProjectsSection}
+            suppressActive={suppressNotebookHighlight}
+            activeAgentId={activeAgentId}
             onNavigate={handleItemNavigate}
             onNotebookClick={handleNotebookClick}
             onToggle={handleToggleItemSelection}

--- a/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/CombinedNotebooks.tsx
@@ -648,7 +648,21 @@ const CombinedNotebooks = () => {
                   };
                 }}
               >
-                <BookOpen size={18} style={{ color: 'inherit' }} />
+                {/* 20x20 frame around an 18px SVG, matching the top SidenavNav icon slots.
+                    Pin the child svg to 18px so it can't stretch to fill the 20px frame. */}
+                <Box
+                  sx={{
+                    width: 20,
+                    height: 20,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                    '& svg': { width: '18px', height: '18px' },
+                  }}
+                >
+                  <BookOpen style={{ color: 'inherit' }} />
+                </Box>
                 <Typography
                   level="body-xs"
                   sx={theme => ({

--- a/apps/client/app/components/layouts/Notebook/Sidenav/NotebookGroupList.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/NotebookGroupList.tsx
@@ -14,6 +14,8 @@ interface NotebookGroupListProps {
   selectedItems: Set<string>;
   favoriteSessions?: ISessionFavoriteItem[];
   showMessageCount: boolean;
+  /** Force all session rows unselected (e.g. while a dedicated project screen is open). */
+  suppressActive?: boolean;
   onNavigate: (path: string) => void;
   onNotebookClick: (session: ISessionDocument) => void;
   onToggle: (id: string) => void;
@@ -31,6 +33,7 @@ export default function NotebookGroupList({
   selectedItems,
   favoriteSessions,
   showMessageCount,
+  suppressActive,
   onNavigate,
   onNotebookClick,
   onToggle,
@@ -83,6 +86,7 @@ export default function NotebookGroupList({
                   isShared={'isShared' in d ? d.isShared : false}
                   favoriteSessions={favoriteSessions}
                   showMessageCount={showMessageCount}
+                  suppressActive={suppressActive}
                   onNavigate={onNavigate}
                   onNotebookClick={onNotebookClick}
                   onToggle={onToggle}

--- a/apps/client/app/components/layouts/Notebook/Sidenav/NotebookGroupList.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/NotebookGroupList.tsx
@@ -16,6 +16,8 @@ interface NotebookGroupListProps {
   showMessageCount: boolean;
   /** Force all session rows unselected (e.g. while a dedicated project screen is open). */
   suppressActive?: boolean;
+  /** Id of the agent whose dedicated screen is open, so its row highlights. */
+  activeAgentId?: string | null;
   onNavigate: (path: string) => void;
   onNotebookClick: (session: ISessionDocument) => void;
   onToggle: (id: string) => void;
@@ -34,6 +36,7 @@ export default function NotebookGroupList({
   favoriteSessions,
   showMessageCount,
   suppressActive,
+  activeAgentId,
   onNavigate,
   onNotebookClick,
   onToggle,
@@ -87,6 +90,7 @@ export default function NotebookGroupList({
                   favoriteSessions={favoriteSessions}
                   showMessageCount={showMessageCount}
                   suppressActive={suppressActive}
+                  activeAgentId={activeAgentId}
                   onNavigate={onNavigate}
                   onNotebookClick={onNotebookClick}
                   onToggle={onToggle}

--- a/apps/client/app/components/layouts/Notebook/Sidenav/NotebookRow.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/NotebookRow.tsx
@@ -24,6 +24,7 @@ const NotebookRow = memo(function NotebookRow({
   isShared,
   favoriteSessions,
   showMessageCount,
+  suppressActive,
   onNavigate,
   onNotebookClick,
   onToggle,
@@ -34,6 +35,9 @@ const NotebookRow = memo(function NotebookRow({
   isShared: boolean;
   favoriteSessions?: ISessionFavoriteItem[];
   showMessageCount: boolean;
+  /** When true, force this session row unselected (e.g. while a dedicated project screen is
+   *  open, so the stale current-session highlight doesn't linger). */
+  suppressActive?: boolean;
   onNavigate: (path: string) => void;
   onNotebookClick: (session: ISessionDocument) => void;
   onToggle: (id: string) => void;
@@ -61,6 +65,8 @@ const NotebookRow = memo(function NotebookRow({
       onToggleSelection={() => onToggle(item.id)}
       isShared={isShared}
       showMessageCount={showMessageCount}
+      // undefined -> fall back to the default currentSessionId comparison; false -> force off.
+      selected={suppressActive ? false : undefined}
     />
   );
 });

--- a/apps/client/app/components/layouts/Notebook/Sidenav/NotebookRow.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/NotebookRow.tsx
@@ -25,6 +25,7 @@ const NotebookRow = memo(function NotebookRow({
   favoriteSessions,
   showMessageCount,
   suppressActive,
+  activeAgentId,
   onNavigate,
   onNotebookClick,
   onToggle,
@@ -38,13 +39,21 @@ const NotebookRow = memo(function NotebookRow({
   /** When true, force this session row unselected (e.g. while a dedicated project screen is
    *  open, so the stale current-session highlight doesn't linger). */
   suppressActive?: boolean;
+  /** Id of the agent whose dedicated screen is open, so its row highlights. */
+  activeAgentId?: string | null;
   onNavigate: (path: string) => void;
   onNotebookClick: (session: ISessionDocument) => void;
   onToggle: (id: string) => void;
 }) {
   if ('isAgent' in item && item.isAgent) {
     // any: CombinedItem's agent variant is structurally looser than AgentSidenavItem's prop
-    return <AgentSidenavItem agent={item as any} onClick={() => onNavigate(`/agents/${item.id}`)} />;
+    return (
+      <AgentSidenavItem
+        agent={item as any}
+        onClick={() => onNavigate(`/agents/${item.id}`)}
+        isSelected={item.id === activeAgentId}
+      />
+    );
   }
   if ('isProject' in item && item.isProject) {
     // any: CombinedItem's project variant is structurally looser than IProjectDocument

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -20,31 +20,29 @@ import { useFeatureEnabled } from '@client/app/hooks/useFeatureEnabled';
 import { useEntitlements } from '@client/app/hooks/data/entitlements';
 import { filterVisiblePremiumNavItems } from '@client/app/utils/premiumNav';
 import { premiumNavItems } from '@client/app/premium-generated/premiumNavItems.generated';
-import { openHelpPanel } from '@client/app/hooks/useHelpPanel';
 import { openExternalLinkByKey } from '@client/app/utils/externalLinks';
 import { greenAlpha } from '@client/app/utils/themes/colors';
 import { useAccounts } from '@client/app/components/Credits/AccountSelector';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
+import ManageAccountsIcon from '@mui/icons-material/ManageAccountsOutlined';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
-import BusinessIcon from '@mui/icons-material/Business';
-import MonetizationOnIcon from '@mui/icons-material/MonetizationOn';
-import HelpCenterIcon from '@mui/icons-material/HelpCenter';
-import Brightness4Icon from '@mui/icons-material/Brightness4';
-import DarkModeIcon from '@mui/icons-material/DarkMode';
-import LightModeIcon from '@mui/icons-material/LightMode';
+import BusinessIcon from '@mui/icons-material/BusinessOutlined';
+import MonetizationOnIcon from '@mui/icons-material/MonetizationOnOutlined';
+import Brightness4Icon from '@mui/icons-material/Brightness4Outlined';
+import DarkModeIcon from '@mui/icons-material/DarkModeOutlined';
+import LightModeIcon from '@mui/icons-material/LightModeOutlined';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
-import PersonAddIcon from '@mui/icons-material/PersonAdd';
-import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import PersonAddIcon from '@mui/icons-material/PersonAddOutlined';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettingsOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import GavelIcon from '@mui/icons-material/Gavel';
-import ExtensionIcon from '@mui/icons-material/Extension';
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import GavelIcon from '@mui/icons-material/GavelOutlined';
+import ExtensionIcon from '@mui/icons-material/ExtensionOutlined';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesomeOutlined';
 import LogoDevIcon from '@mui/icons-material/LogoDev';
-import LogoutIcon from '@mui/icons-material/Logout';
-import RefreshIcon from '@mui/icons-material/Refresh';
+import LogoutIcon from '@mui/icons-material/LogoutOutlined';
+import RefreshIcon from '@mui/icons-material/RefreshOutlined';
 
 // Strip the trailing " (Personal)" suffix that useAccounts appends to the personal account name.
 const stripPersonalSuffix = (name: string) => name.replace(/ \(Personal\)$/, '');
@@ -377,16 +375,6 @@ const ProfileMenu = () => {
               }}
             />
           )}
-          <MenuRow
-            testId="profile-menu-help"
-            icon={<HelpCenterIcon sx={{ fontSize: '18px' }} />}
-            label={t('help.center', 'Help Center')}
-            onClick={() => {
-              openHelpPanel();
-              setOpen(false);
-            }}
-          />
-
           {modeToggleEnabled && (
             <Box
               sx={theme2 => ({

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -267,7 +267,12 @@ const ProfileMenu = () => {
     backgroundColor: t2.palette.background.popup,
     border: `1px solid ${t2.palette.divider}`,
     borderRadius: '12px',
-    boxShadow: t2.shadow.lg,
+    // Soft, diffuse lift (same recipe as the tutorial frame): a wide low-opacity ambient layer
+    // plus a tighter contact layer, stronger in dark mode where light shadows disappear.
+    boxShadow:
+      t2.palette.mode === 'dark'
+        ? '0 24px 70px rgba(0, 0, 0, 0.28), 0 8px 20px rgba(0, 0, 0, 0.14)'
+        : '0 24px 30px rgba(0, 0, 0, 0.03), 0 8px 20px rgba(0, 0, 0, 0.02)',
     p: 1,
   });
 
@@ -281,7 +286,6 @@ const ProfileMenu = () => {
             ...panelSx(theme2),
             backgroundColor: theme2.palette.background.surface, // #0E1214 in dark
             borderRadius: '8px',
-            boxShadow: 'none',
             position: 'absolute',
             bottom: 'calc(100% + 8px)',
             left: 0,
@@ -467,7 +471,6 @@ const ProfileMenu = () => {
                 sx={theme2 => ({
                   ...panelSx(theme2),
                   backgroundColor: theme2.palette.background.surface, // match the panel surface (#0E1214 in dark)
-                  boxShadow: 'none',
                   position: 'absolute',
                   left: 'calc(100% + 16px)',
                   bottom: 0,

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -424,20 +424,48 @@ const ProfileMenu = () => {
               >
                 <IconButton
                   size="sm"
-                  variant={mode === 'dark' ? 'soft' : 'plain'}
-                  color={mode === 'dark' ? 'primary' : 'neutral'}
+                  variant="plain"
+                  color="neutral"
                   onClick={() => setMode('dark')}
-                  sx={{ borderRadius: '999px', minHeight: 26, minWidth: 26 }}
+                  // Selected circle matches a selected notebook/project; non-selected uses the same
+                  // hover background as a notebook row.
+                  sx={theme2 => ({
+                    borderRadius: '999px',
+                    minHeight: 26,
+                    minWidth: 26,
+                    ...(mode === 'dark'
+                      ? {
+                          backgroundColor: theme2.palette.notebooklist.focusedBackground,
+                          '&:hover': { backgroundColor: theme2.palette.notebooklist.focusedBackground },
+                        }
+                      : {
+                          '&:hover': { backgroundColor: theme2.palette.notebooklist.hoverBg },
+                        }),
+                  })}
                   aria-label="Dark mode"
                 >
                   <DarkModeIcon sx={{ fontSize: '15px' }} />
                 </IconButton>
                 <IconButton
                   size="sm"
-                  variant={mode === 'light' ? 'soft' : 'plain'}
-                  color={mode === 'light' ? 'warning' : 'neutral'}
+                  variant="plain"
+                  color="neutral"
                   onClick={() => setMode('light')}
-                  sx={{ borderRadius: '999px', minHeight: 26, minWidth: 26 }}
+                  // Selected circle matches a selected notebook/project; non-selected uses the same
+                  // hover background as a notebook row.
+                  sx={theme2 => ({
+                    borderRadius: '999px',
+                    minHeight: 26,
+                    minWidth: 26,
+                    ...(mode === 'light'
+                      ? {
+                          backgroundColor: theme2.palette.notebooklist.focusedBackground,
+                          '&:hover': { backgroundColor: theme2.palette.notebooklist.focusedBackground },
+                        }
+                      : {
+                          '&:hover': { backgroundColor: theme2.palette.notebooklist.hoverBg },
+                        }),
+                  })}
                   aria-label="Light mode"
                 >
                   <LightModeIcon sx={{ fontSize: '15px' }} />

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { Avatar, Box, Chip, CircularProgress, Divider, IconButton, Radio, Stack, Typography } from '@mui/joy';
 import { useColorScheme, useTheme } from '@mui/joy/styles';
 import { useNavigate } from '@tanstack/react-router';
@@ -226,6 +226,7 @@ const ProfileMenu = () => {
   const { mutate: logout, isPending: isPendingLogout } = useUserLogout();
   const appVersion = useAppVersion();
 
+  const rootRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
   const [isCreditsModalOpen, setIsCreditsModalOpen] = useState(false);
@@ -235,6 +236,29 @@ const ProfileMenu = () => {
     setOpen(false);
     setMoreOpen(false);
   };
+
+  // Dismiss the menu on any pointer-down outside the whole profile control, or on Escape.
+  // A DOM-level listener is used instead of a fixed-position overlay: the sidebar wrapper
+  // carries a `transform` (see Sidenav index.tsx), which traps `position: fixed` to the
+  // sidebar box, so an overlay would only cover the sidebar and leave clicks in the main
+  // content area unable to close the menu.
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        closeAll();
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeAll();
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
 
   const planLabel =
     selectedAccount && !selectedAccount.personal ? t('account.team', 'Team') : t('account.personal', 'Personal');
@@ -248,322 +272,319 @@ const ProfileMenu = () => {
   });
 
   return (
-    <Box sx={{ position: 'relative' }}>
+    <Box ref={rootRef} sx={{ position: 'relative' }}>
       {open && (
-        <>
-          <Box onClick={closeAll} sx={{ position: 'fixed', inset: 0, zIndex: 10000 }} />
-          <Box
-            data-testid="profile-menu-panel"
-            role="menu"
-            sx={theme2 => ({
-              ...panelSx(theme2),
-              backgroundColor: theme2.palette.background.surface, // #0E1214 in dark
-              borderRadius: '8px',
-              boxShadow: 'none',
-              position: 'absolute',
-              bottom: 'calc(100% + 8px)',
-              left: 0,
-              right: 0,
-              zIndex: 10001,
-            })}
-          >
-            <Stack sx={{ gap: 1, p: 0.5 }}>
-              {accounts.map(account => (
-                <AccountCard
-                  key={account.id}
-                  name={stripPersonalSuffix(account.name)}
-                  typeLabel={showAccountType ? (account.personal ? '(Personal)' : '(Team)') : null}
-                  credits={account.credits}
-                  selected={selectedAccount?.id === account.id}
-                  onSelect={() => setSelectedAccount(account)}
-                  bare={accounts.length === 1}
-                />
-              ))}
-            </Stack>
-
-            <Divider sx={{ my: 1 }} />
-
-            {isAdmin && (
-              <MenuRow
-                testId="profile-menu-admin"
-                icon={<AdminPanelSettingsIcon sx={{ fontSize: '18px' }} />}
-                label={t('admin.title', 'Admin')}
-                onClick={() => {
-                  navigate({ to: '/admin' });
-                  setOpen(false);
-                }}
+        <Box
+          data-testid="profile-menu-panel"
+          role="menu"
+          sx={theme2 => ({
+            ...panelSx(theme2),
+            backgroundColor: theme2.palette.background.surface, // #0E1214 in dark
+            borderRadius: '8px',
+            boxShadow: 'none',
+            position: 'absolute',
+            bottom: 'calc(100% + 8px)',
+            left: 0,
+            right: 0,
+            zIndex: 10001,
+          })}
+        >
+          <Stack sx={{ gap: 1, p: 0.5 }}>
+            {accounts.map(account => (
+              <AccountCard
+                key={account.id}
+                name={stripPersonalSuffix(account.name)}
+                typeLabel={showAccountType ? (account.personal ? '(Personal)' : '(Team)') : null}
+                credits={account.credits}
+                selected={selectedAccount?.id === account.id}
+                onSelect={() => setSelectedAccount(account)}
+                bare={accounts.length === 1}
               />
-            )}
-            <MenuRow
-              testId="profile-menu-profile"
-              icon={<ManageAccountsIcon sx={{ fontSize: '18px' }} />}
-              label={t('profile.title', 'Profile')}
-              endDecorator={
-                friendRequests?.length ? (
-                  <Chip size="sm" color="danger" variant="solid">
-                    {friendRequests.length}
-                  </Chip>
-                ) : undefined
-              }
-              onClick={() => {
-                navigate({ to: '/profile' });
-                setOpen(false);
-              }}
-            />
-            <MenuRow
-              testId="profile-menu-skills"
-              icon={<ExtensionIcon sx={{ fontSize: '18px' }} />}
-              label={t('skills.title', 'Skills')}
-              onClick={() => {
-                navigate({ to: '/skills' });
-                setOpen(false);
-              }}
-            />
-            <MenuRow
-              testId="profile-menu-teams"
-              icon={<BusinessIcon sx={{ fontSize: '18px' }} />}
-              label={t('organization.teams', 'Teams')}
-              onClick={() => {
-                navigate({ to: '/organizations' });
-                setOpen(false);
-              }}
-            />
-            {isCreditsEnabled && (
-              <MenuRow
-                testId="profile-menu-credits"
-                icon={<Bike4MindIcon size="18" />}
-                label={t('credits.title', 'Credits')}
-                onClick={() => {
-                  logEvent.mutate({ type: UiNavigationEvents.MORE_CREDITS_CLICKED });
-                  setIsCreditsModalOpen(true);
-                  setOpen(false);
-                }}
-              />
-            )}
-            {isCreditsEnabled && (
-              <MenuRow
-                testId="profile-menu-subscriptions"
-                icon={<MonetizationOnIcon sx={{ fontSize: '18px' }} />}
-                label={t('subscriptions.title', 'Subscriptions')}
-                onClick={() => {
-                  setIsSubscriptionModalOpen(true);
-                  setOpen(false);
-                }}
-              />
-            )}
-            <MenuRow
-              testId="profile-menu-help"
-              icon={<HelpCenterIcon sx={{ fontSize: '18px' }} />}
-              label={t('help.center', 'Help Center')}
-              onClick={() => {
-                openHelpPanel();
-                setOpen(false);
-              }}
-            />
+            ))}
+          </Stack>
 
-            {modeToggleEnabled && (
+          <Divider sx={{ my: 1 }} />
+
+          {isAdmin && (
+            <MenuRow
+              testId="profile-menu-admin"
+              icon={<AdminPanelSettingsIcon sx={{ fontSize: '18px' }} />}
+              label={t('admin.title', 'Admin')}
+              onClick={() => {
+                navigate({ to: '/admin' });
+                setOpen(false);
+              }}
+            />
+          )}
+          <MenuRow
+            testId="profile-menu-profile"
+            icon={<ManageAccountsIcon sx={{ fontSize: '18px' }} />}
+            label={t('profile.title', 'Profile')}
+            endDecorator={
+              friendRequests?.length ? (
+                <Chip size="sm" color="danger" variant="solid">
+                  {friendRequests.length}
+                </Chip>
+              ) : undefined
+            }
+            onClick={() => {
+              navigate({ to: '/profile' });
+              setOpen(false);
+            }}
+          />
+          <MenuRow
+            testId="profile-menu-skills"
+            icon={<ExtensionIcon sx={{ fontSize: '18px' }} />}
+            label={t('skills.title', 'Skills')}
+            onClick={() => {
+              navigate({ to: '/skills' });
+              setOpen(false);
+            }}
+          />
+          <MenuRow
+            testId="profile-menu-teams"
+            icon={<BusinessIcon sx={{ fontSize: '18px' }} />}
+            label={t('organization.teams', 'Teams')}
+            onClick={() => {
+              navigate({ to: '/organizations' });
+              setOpen(false);
+            }}
+          />
+          {isCreditsEnabled && (
+            <MenuRow
+              testId="profile-menu-credits"
+              icon={<Bike4MindIcon size="18" />}
+              label={t('credits.title', 'Credits')}
+              onClick={() => {
+                logEvent.mutate({ type: UiNavigationEvents.MORE_CREDITS_CLICKED });
+                setIsCreditsModalOpen(true);
+                setOpen(false);
+              }}
+            />
+          )}
+          {isCreditsEnabled && (
+            <MenuRow
+              testId="profile-menu-subscriptions"
+              icon={<MonetizationOnIcon sx={{ fontSize: '18px' }} />}
+              label={t('subscriptions.title', 'Subscriptions')}
+              onClick={() => {
+                setIsSubscriptionModalOpen(true);
+                setOpen(false);
+              }}
+            />
+          )}
+          <MenuRow
+            testId="profile-menu-help"
+            icon={<HelpCenterIcon sx={{ fontSize: '18px' }} />}
+            label={t('help.center', 'Help Center')}
+            onClick={() => {
+              openHelpPanel();
+              setOpen(false);
+            }}
+          />
+
+          {modeToggleEnabled && (
+            <Box
+              sx={theme2 => ({
+                display: 'flex',
+                alignItems: 'center',
+                gap: '12px',
+                px: '10px',
+                height: '40px',
+                color: theme2.palette.sidenav?.navItemText,
+              })}
+            >
+              <Box
+                sx={theme2 => ({
+                  width: 22,
+                  height: 22,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  '--Icon-color': theme2.palette.text.tertiary,
+                })}
+              >
+                <Brightness4Icon sx={{ fontSize: '18px' }} />
+              </Box>
+              <Typography level="body-sm" sx={{ flex: 1, color: 'inherit', fontSize: '14px', fontWeight: 400 }}>
+                {t('theme.title', 'Theme')}
+              </Typography>
               <Box
                 sx={theme2 => ({
                   display: 'flex',
-                  alignItems: 'center',
-                  gap: '12px',
-                  px: '10px',
-                  height: '40px',
-                  color: theme2.palette.sidenav?.navItemText,
+                  gap: '2px',
+                  p: '2px',
+                  border: `1px solid ${theme2.palette.neutral.outlinedBorder}`,
+                  borderRadius: '999px',
                 })}
               >
-                <Box
-                  sx={theme2 => ({
-                    width: 22,
-                    height: 22,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    '--Icon-color': theme2.palette.text.tertiary,
-                  })}
+                <IconButton
+                  size="sm"
+                  variant={mode === 'dark' ? 'soft' : 'plain'}
+                  color={mode === 'dark' ? 'primary' : 'neutral'}
+                  onClick={() => setMode('dark')}
+                  sx={{ borderRadius: '999px', minHeight: 26, minWidth: 26 }}
+                  aria-label="Dark mode"
                 >
-                  <Brightness4Icon sx={{ fontSize: '18px' }} />
-                </Box>
-                <Typography level="body-sm" sx={{ flex: 1, color: 'inherit', fontSize: '14px', fontWeight: 400 }}>
-                  {t('theme.title', 'Theme')}
-                </Typography>
-                <Box
-                  sx={theme2 => ({
-                    display: 'flex',
-                    gap: '2px',
-                    p: '2px',
-                    border: `1px solid ${theme2.palette.neutral.outlinedBorder}`,
-                    borderRadius: '999px',
-                  })}
+                  <DarkModeIcon sx={{ fontSize: '15px' }} />
+                </IconButton>
+                <IconButton
+                  size="sm"
+                  variant={mode === 'light' ? 'soft' : 'plain'}
+                  color={mode === 'light' ? 'warning' : 'neutral'}
+                  onClick={() => setMode('light')}
+                  sx={{ borderRadius: '999px', minHeight: 26, minWidth: 26 }}
+                  aria-label="Light mode"
                 >
-                  <IconButton
-                    size="sm"
-                    variant={mode === 'dark' ? 'soft' : 'plain'}
-                    color={mode === 'dark' ? 'primary' : 'neutral'}
-                    onClick={() => setMode('dark')}
-                    sx={{ borderRadius: '999px', minHeight: 26, minWidth: 26 }}
-                    aria-label="Dark mode"
-                  >
-                    <DarkModeIcon sx={{ fontSize: '15px' }} />
-                  </IconButton>
-                  <IconButton
-                    size="sm"
-                    variant={mode === 'light' ? 'soft' : 'plain'}
-                    color={mode === 'light' ? 'warning' : 'neutral'}
-                    onClick={() => setMode('light')}
-                    sx={{ borderRadius: '999px', minHeight: 26, minWidth: 26 }}
-                    aria-label="Light mode"
-                  >
-                    <LightModeIcon sx={{ fontSize: '15px' }} />
-                  </IconButton>
-                </Box>
+                  <LightModeIcon sx={{ fontSize: '15px' }} />
+                </IconButton>
+              </Box>
+            </Box>
+          )}
+
+          <Box sx={{ position: 'relative' }}>
+            <MenuRow
+              testId="profile-menu-more"
+              icon={<FormatListBulletedIcon sx={{ fontSize: '18px' }} />}
+              label={t('common.more', 'More')}
+              endDecorator={
+                <ChevronLeftIcon
+                  sx={{
+                    fontSize: '18px',
+                    color: 'text.tertiary',
+                    transition: 'transform 0.2s ease',
+                    // Points right when closed; rotates to the open (left) state on expand.
+                    transform: moreOpen ? 'rotate(0deg)' : 'rotate(180deg)',
+                  }}
+                />
+              }
+              onClick={() => setMoreOpen(v => !v)}
+            />
+            {moreOpen && (
+              <Box
+                data-testid="profile-menu-more-flyout"
+                role="menu"
+                sx={theme2 => ({
+                  ...panelSx(theme2),
+                  backgroundColor: theme2.palette.background.surface, // match the panel surface (#0E1214 in dark)
+                  boxShadow: 'none',
+                  position: 'absolute',
+                  left: 'calc(100% + 16px)',
+                  bottom: 0,
+                  minWidth: 220,
+                  zIndex: 10002,
+                })}
+              >
+                <MenuRow
+                  testId="profile-more-inbox"
+                  icon={
+                    <InboxBadge>
+                      <MailOutlineIcon sx={{ fontSize: '18px' }} />
+                    </InboxBadge>
+                  }
+                  label={t('inbox.title', 'Inbox')}
+                  onClick={() => {
+                    setInboxOpen(true);
+                    closeAll();
+                  }}
+                />
+                <MenuRow
+                  testId="profile-more-invite"
+                  icon={<PersonAddIcon sx={{ fontSize: '18px' }} />}
+                  label={t('inviteShort', 'Invite')}
+                  onClick={() => {
+                    toggleReferralModal();
+                    closeAll();
+                  }}
+                />
+                <MenuRow
+                  testId="profile-more-about"
+                  icon={<InfoOutlinedIcon sx={{ fontSize: '18px' }} />}
+                  label={t('intro.title', 'About Us')}
+                  onClick={() => {
+                    openExternalLinkByKey('about');
+                    closeAll();
+                  }}
+                />
+                <MenuRow
+                  testId="profile-more-terms"
+                  icon={<GavelIcon sx={{ fontSize: '18px' }} />}
+                  label={t('terms_policies', 'Terms & Policies')}
+                  onClick={() => {
+                    openExternalLinkByKey('terms');
+                    closeAll();
+                  }}
+                />
+                {isQuestMasterEnabled && (
+                  <MenuRow
+                    testId="profile-more-quests"
+                    icon={<AutoAwesomeIcon sx={{ fontSize: '18px' }} />}
+                    label={t('quests.my_quests', 'My Quests')}
+                    onClick={() => {
+                      navigate({ to: '/quests' });
+                      closeAll();
+                    }}
+                  />
+                )}
+                {visiblePremiumNavItems.map(item => (
+                  <MenuRow
+                    key={item.path}
+                    testId={item.testId}
+                    icon={item.icon ? <item.icon /> : undefined}
+                    label={item.label}
+                    onClick={() => {
+                      // Premium routes are registered at runtime via the codegen
+                      // glue, so their paths can't appear in the static route-tree
+                      // union - erase the typed `to` here.
+                      navigate({ to: item.path as never });
+                      closeAll();
+                    }}
+                  />
+                ))}
+                <MenuRow
+                  testId="profile-more-changelog"
+                  icon={<LogoDevIcon sx={{ fontSize: '18px' }} />}
+                  label={t('changelog.title', 'Changelog')}
+                  onClick={() => {
+                    openExternalLinkByKey('changelog');
+                    closeAll();
+                  }}
+                />
               </Box>
             )}
+          </Box>
 
-            <Box sx={{ position: 'relative' }}>
-              <MenuRow
-                testId="profile-menu-more"
-                icon={<FormatListBulletedIcon sx={{ fontSize: '18px' }} />}
-                label={t('common.more', 'More')}
-                endDecorator={
-                  <ChevronLeftIcon
-                    sx={{
-                      fontSize: '18px',
-                      color: 'text.tertiary',
-                      transition: 'transform 0.2s ease',
-                      // Points right when closed; rotates to the open (left) state on expand.
-                      transform: moreOpen ? 'rotate(0deg)' : 'rotate(180deg)',
-                    }}
-                  />
-                }
-                onClick={() => setMoreOpen(v => !v)}
-              />
-              {moreOpen && (
-                <Box
-                  data-testid="profile-menu-more-flyout"
-                  role="menu"
-                  sx={theme2 => ({
-                    ...panelSx(theme2),
-                    backgroundColor: theme2.palette.background.surface, // match the panel surface (#0E1214 in dark)
-                    boxShadow: 'none',
-                    position: 'absolute',
-                    left: 'calc(100% + 16px)',
-                    bottom: 0,
-                    minWidth: 220,
-                    zIndex: 10002,
-                  })}
-                >
-                  <MenuRow
-                    testId="profile-more-inbox"
-                    icon={
-                      <InboxBadge>
-                        <MailOutlineIcon sx={{ fontSize: '18px' }} />
-                      </InboxBadge>
-                    }
-                    label={t('inbox.title', 'Inbox')}
-                    onClick={() => {
-                      setInboxOpen(true);
-                      closeAll();
-                    }}
-                  />
-                  <MenuRow
-                    testId="profile-more-invite"
-                    icon={<PersonAddIcon sx={{ fontSize: '18px' }} />}
-                    label={t('inviteShort', 'Invite')}
-                    onClick={() => {
-                      toggleReferralModal();
-                      closeAll();
-                    }}
-                  />
-                  <MenuRow
-                    testId="profile-more-about"
-                    icon={<InfoOutlinedIcon sx={{ fontSize: '18px' }} />}
-                    label={t('intro.title', 'About Us')}
-                    onClick={() => {
-                      openExternalLinkByKey('about');
-                      closeAll();
-                    }}
-                  />
-                  <MenuRow
-                    testId="profile-more-terms"
-                    icon={<GavelIcon sx={{ fontSize: '18px' }} />}
-                    label={t('terms_policies', 'Terms & Policies')}
-                    onClick={() => {
-                      openExternalLinkByKey('terms');
-                      closeAll();
-                    }}
-                  />
-                  {isQuestMasterEnabled && (
-                    <MenuRow
-                      testId="profile-more-quests"
-                      icon={<AutoAwesomeIcon sx={{ fontSize: '18px' }} />}
-                      label={t('quests.my_quests', 'My Quests')}
-                      onClick={() => {
-                        navigate({ to: '/quests' });
-                        closeAll();
-                      }}
-                    />
-                  )}
-                  {visiblePremiumNavItems.map(item => (
-                    <MenuRow
-                      key={item.path}
-                      testId={item.testId}
-                      icon={item.icon ? <item.icon /> : undefined}
-                      label={item.label}
-                      onClick={() => {
-                        // Premium routes are registered at runtime via the codegen
-                        // glue, so their paths can't appear in the static route-tree
-                        // union - erase the typed `to` here.
-                        navigate({ to: item.path as never });
-                        closeAll();
-                      }}
-                    />
-                  ))}
-                  <MenuRow
-                    testId="profile-more-changelog"
-                    icon={<LogoDevIcon sx={{ fontSize: '18px' }} />}
-                    label={t('changelog.title', 'Changelog')}
-                    onClick={() => {
-                      openExternalLinkByKey('changelog');
-                      closeAll();
-                    }}
-                  />
-                </Box>
-              )}
-            </Box>
+          <Divider sx={{ my: 1 }} />
 
-            <Divider sx={{ my: 1 }} />
-
-            {hasReturnToken && (
-              <MenuRow
-                testId="profile-menu-return"
-                danger
-                icon={<RefreshIcon sx={{ fontSize: '18px' }} />}
-                label={t('return_to_safety', 'Return to safety')}
-                onClick={() => {
-                  returnToAdmin.mutate();
-                  setOpen(false);
-                }}
-              />
-            )}
+          {hasReturnToken && (
             <MenuRow
-              testId="logout-btn"
-              icon={isPendingLogout ? <CircularProgress size="sm" /> : <LogoutIcon sx={{ fontSize: '18px' }} />}
-              label={t('logout', 'Log Out')}
-              // Version sits opposite the Logout label (trimmed to major.minor.patch, e.g. v0.7.25).
-              endDecorator={
-                <Typography level="body-xs" sx={{ color: 'text.tertiary', fontSize: '11px' }}>
-                  v{appVersion.data?.version?.split('.').slice(0, 3).join('.')}
-                </Typography>
-              }
-              // Guard against re-firing the logout mutation while one is already in flight
-              // (the old footer used disabled={isPendingLogout}; MenuRow has no disabled prop).
+              testId="profile-menu-return"
+              danger
+              icon={<RefreshIcon sx={{ fontSize: '18px' }} />}
+              label={t('return_to_safety', 'Return to safety')}
               onClick={() => {
-                if (!isPendingLogout) logout();
+                returnToAdmin.mutate();
+                setOpen(false);
               }}
             />
-          </Box>
-        </>
+          )}
+          <MenuRow
+            testId="logout-btn"
+            icon={isPendingLogout ? <CircularProgress size="sm" /> : <LogoutIcon sx={{ fontSize: '18px' }} />}
+            label={t('logout', 'Log Out')}
+            // Version sits opposite the Logout label (trimmed to major.minor.patch, e.g. v0.7.25).
+            endDecorator={
+              <Typography level="body-xs" sx={{ color: 'text.tertiary', fontSize: '11px' }}>
+                v{appVersion.data?.version?.split('.').slice(0, 3).join('.')}
+              </Typography>
+            }
+            // Guard against re-firing the logout mutation while one is already in flight
+            // (the old footer used disabled={isPendingLogout}; MenuRow has no disabled prop).
+            onClick={() => {
+              if (!isPendingLogout) logout();
+            }}
+          />
+        </Box>
       )}
 
       <Box

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProjectSessionList.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProjectSessionList.tsx
@@ -8,9 +8,11 @@ interface ProjectSessionListProps {
   project: IProjectDocument;
   onNotebookClick: (session: ISessionDocument) => void;
   favoriteSessions?: ISessionFavoriteItem[];
+  /** Force nested session rows unselected (e.g. while a dedicated project screen is open). */
+  suppressActive?: boolean;
 }
 
-function ProjectSessionList({ project, onNotebookClick, favoriteSessions }: ProjectSessionListProps) {
+function ProjectSessionList({ project, onNotebookClick, favoriteSessions, suppressActive }: ProjectSessionListProps) {
   const { data: sessions, isLoading } = useGetProjectSessions(project.id);
 
   return (
@@ -30,6 +32,7 @@ function ProjectSessionList({ project, onNotebookClick, favoriteSessions }: Proj
             isChecked={false}
             isShared={false}
             showMessageCount={false}
+            selected={suppressActive ? false : undefined}
           />
         ))
       ) : (

--- a/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
@@ -179,8 +179,10 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
     {
       key: 'projects',
       label: t('projects.projects'),
+      // Active only on the overall projects grid, not a specific project screen (/projects/:id),
+      // which highlights its own row in the list below instead.
       icon: iconSlot(<HubOutlinedIcon sx={{ fontSize: '18px' }} />),
-      isActive: location.pathname.startsWith('/projects'),
+      isActive: location.pathname === '/projects',
       onClick: () => {
         closeOnMobile();
         navigate({ to: '/projects' });

--- a/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
@@ -168,7 +168,9 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
             key: 'agents',
             label: t('agents.title'),
             icon: iconSlot(<SmartToyOutlinedIcon sx={{ fontSize: '18px' }} />),
-            isActive: location.pathname.startsWith('/agents'),
+            // Active only on the overall agents grid, not a specific agent screen (/agents/:id),
+            // which highlights its own row in the list below instead.
+            isActive: location.pathname === '/agents',
             onClick: () => {
               closeOnMobile();
               navigate({ to: '/agents' });

--- a/apps/client/app/routes/tutorials.tsx
+++ b/apps/client/app/routes/tutorials.tsx
@@ -5,8 +5,9 @@ import { useNavigate } from '@tanstack/react-router';
 const TutorialsPage = () => {
   const navigate = useNavigate();
 
+  // Dismissing the tutorial behaves like the sidebar "New Chat" button: a blank session view.
   const handleComplete = () => {
-    navigate({ to: '/' });
+    navigate({ to: '/new' });
   };
 
   return (

--- a/apps/client/app/utils/themes/components/notebooklist.ts
+++ b/apps/client/app/utils/themes/components/notebooklist.ts
@@ -1,8 +1,9 @@
 import { grayAlpha, brandAlpha } from '../colors';
 
 // Custom values with unique opacity not in theme defaults.
-// Selected (focusedBackground) matches hover so both share one highlight color:
-// #2A2C38 @ 70% (grayAlpha[775][70]) in dark, the light-blue tint in light mode.
+// Dark: selected (focusedBackground) matches hover, both #2A2C38 @ 70% (grayAlpha[775][70]).
+// Light: hover is the light-blue tint @ 30%; selected is the same blue @ 50% so it reads a bit
+// stronger than hover (brand[100] = #D1E4F4).
 export const notebooklistTheme = {
   dark: {
     hoverBg: grayAlpha[775][70],
@@ -10,6 +11,6 @@ export const notebooklistTheme = {
   },
   light: {
     hoverBg: brandAlpha[100][30],
-    focusedBackground: brandAlpha[100][30],
+    focusedBackground: brandAlpha[100][50],
   },
 };


### PR DESCRIPTION
## Assorted UI/UX polish across the notebook sidebar, project/agent selection, the profile dropdown, and the "How to get started" tutorial.

### Sidebar selection states
- **Route-driven, mutually-exclusive highlighting.** Opening a project or agent now highlights that row and clears the stale notebook highlight (previously the last-opened notebook stayed lit because selection read a persisted store value, not the route).
- Project rows get a **green** active bar; notebooks and agents get a **blue** one.
- Restyled the active-indicator bar: 2px wide, 80% tall, 1px radius (was 3px/70%/split corners).
- **Projects** and **Agents** top-nav buttons now highlight only on their grid pages (`/projects`, `/agents`), not on a specific item screen.
- Light-mode selected background bumped from 30% -> 50% opacity (same brand blue) so it's less pale.

### Project rows
- Moved the expand chevron to the right edge, always visible, 24px frame, points down/up with a smooth transition, using the notebook button's hover-tint logic.
- Empty projects drop the chevron and show a muted "No notebooks" label instead (derived from `sessionIds`, no extra fetch).

### Profile dropdown
- Clicking outside now dismisses it (the old fixed overlay was trapped by the sidebar's `transform`); added Escape-to-close.
- Removed the duplicate **Help Center** row (already always visible in the sidebar nav).
- All menu icons unified to their outlined variants.
- Theme switcher: selected state now uses the standard selected background (matching notebooks/projects) with matching hover.
- Added a soft, diffuse shadow to the panel.

### "How to get started" tutorial
- Content frame background matches the sidebar surface in dark mode.
- Added a top-right close button that dismisses to a blank session (like New Chat).
- Softer, diffuse frame shadow; icon-frame sizing fix.
- Fixed the sidebar tutorial item's background to match other notebook rows.

### Verification
- Typecheck, ESLint, and the full client test suite (5047 tests) all pass.

---

<img width="1588" height="630" alt="image" src="https://github.com/user-attachments/assets/ffe875ed-d2e2-4ec8-b1fe-3128136497b4" />

<img width="3846" height="1684" alt="image" src="https://github.com/user-attachments/assets/5741b232-dcbe-4ee0-abe5-63e14e1a85e1" />

<img width="1562" height="1290" alt="image" src="https://github.com/user-attachments/assets/52bd700e-ea7b-44f9-8ad5-1b5100733082" />

