### PR TITLE
feat(entitlements): add optihashi:compute entitlement + opti-compute grant

### DIFF
--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -90,10 +90,16 @@ const TAG_GRANT_ROWS: TagGrantRow[] = [
   // matching PRICE_ENTITLEMENTS row is deferred to the subscriptions phase (no
   // OptiHashi Stripe price minted yet); the email-domain grant lives in
   // DOMAIN_GRANT_ROWS below.
-  // The `opti` tag confers all OptiHashi access via the single `optihashi:pro`
-  // entitlement, including the external-compute (hardware-bridge) surfaces - there
-  // is one product tier, so no second entitlement key or comp tag to bridge.
+  // The `opti` tag confers local OptiHashi access via `optihashi:pro` (solver
+  // race, problem/run CRUD, UI/routing).
   { tag: 'opti', entitlements: ['optihashi:pro'] },
+  // Remote external-compute (hardware-bridge) is a SEPARATE, stricter tier from
+  // local OptiHashi: the `opti-compute` tag bridges to `optihashi:compute`.
+  // Holding `optihashi:pro` alone does NOT confer remote compute. Granted-only
+  // for now (no Stripe price yet); deliberately absent from DOMAIN_GRANT_ROWS /
+  // INTERNAL_STAFF_ENTITLEMENTS / SIGNUP_CREDIT_ROWS - internal users reach it via
+  // admin/developer bypass, and no signup credits attach to the compute tier.
+  { tag: 'opti-compute', entitlements: ['optihashi:compute'] },
   // [DELETION-FOOTPRINT] Overwatch comp grant: the `overwatch` tag bridges to
   // `overwatch:pro`. Admin-only gate was a stopgap before the entitlement model
   // existed (Open Core M0). No Stripe price yet; granted-only initially. Removed

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -93,12 +93,14 @@ const TAG_GRANT_ROWS: TagGrantRow[] = [
   // The `opti` tag confers local OptiHashi access via `optihashi:pro` (solver
   // race, problem/run CRUD, UI/routing).
   { tag: 'opti', entitlements: ['optihashi:pro'] },
-  // Remote external-compute (hardware-bridge) is a SEPARATE, stricter tier from
-  // local OptiHashi: the `opti-compute` tag bridges to `optihashi:compute`.
-  // Holding `optihashi:pro` alone does NOT confer remote compute. Granted-only
-  // for now (no Stripe price yet); deliberately absent from DOMAIN_GRANT_ROWS /
-  // INTERNAL_STAFF_ENTITLEMENTS / SIGNUP_CREDIT_ROWS - internal users reach it via
-  // admin/developer bypass, and no signup credits attach to the compute tier.
+  // Remote compute is a SEPARATE, stricter tier from local OptiHashi: the
+  // `opti-compute` tag bridges to `optihashi:compute`. Holding `optihashi:pro`
+  // alone will NOT confer remote compute once the server gate checks
+  // `optihashi:compute` (see M2) - until then this row is inert (no gate reads
+  // the key yet). Granted-only for now (no Stripe price yet); deliberately absent
+  // from DOMAIN_GRANT_ROWS / INTERNAL_STAFF_ENTITLEMENTS / SIGNUP_CREDIT_ROWS -
+  // internal users reach it via admin/developer bypass, and no signup credits
+  // attach to the compute tier.
   { tag: 'opti-compute', entitlements: ['optihashi:compute'] },
   // [DELETION-FOOTPRINT] Overwatch comp grant: the `overwatch` tag bridges to
   // `overwatch:pro`. Admin-only gate was a stopgap before the entitlement model


### PR DESCRIPTION
## Summary
Adds a separate **`optihashi:compute`** entitlement, granted via a new **`opti-compute`** comp tag, so OptiHashi remote compute can be gated as its own stricter tier — distinct from `optihashi:pro` (local access: solver race, problem/run CRUD, UI/routing).

This is **M1 of the compute-gate plan: the grant path only.** No gate consumes `optihashi:compute` yet — the server + client access gates flip to it in a follow-up. This PR is inert until then (it only makes the entitlement grantable).

## Details
- New `TAG_GRANT_ROWS` entry: `opti-compute → optihashi:compute`.
- Deliberately **not** added to `DOMAIN_GRANT_ROWS`, `INTERNAL_STAFF_ENTITLEMENTS`, or `SIGNUP_CREDIT_ROWS` — internal users reach compute via admin/developer bypass, and no signup credits attach to the compute tier.
- `EntitlementKey` is a string alias, so no type change is needed.

## Test plan
- [x] Registry invariant tests pass (`lib/entitlements/registry` — 31/31): key/tag normalized, no duplicates, row maps to an entitlement.
- [x] Grant-path only; no behavior change (nothing gates on the new entitlement in this PR).