### PR TITLE
chore(premium): set b4m-optihashi overlay pin to f0b0d79c3a415305340cd64a995c538bc2763557

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "effd2f6a44603a6cf8368c88cf5bbeba48cdb4ec",
   "b4m-libreoncology": "43707c30d7d8f8ce3c7746711acca1177807fc40",
-  "b4m-optihashi": "ca5a1513866339aa771693d0409faa8a45b0f0fa",
+  "b4m-optihashi": "f0b0d79c3a415305340cd64a995c538bc2763557",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Sets the b4m-optihashi overlay pin to f0b0d79c3a415305340cd64a995c538bc2763557. Overlay-pin-only change; no application source changes.