### PR TITLE
feat(admin): validate partner-signup-rule entitlement keys against known keys

### DIFF
--- a/apps/client/app/components/admin/LLMDashboardTab.tsx
+++ b/apps/client/app/components/admin/LLMDashboardTab.tsx
@@ -40,13 +40,7 @@ import {
 } from '@client/app/hooks/data/llmModelConfig';
 import { useGetUsers } from '@client/app/hooks/data/user';
 import ContextHelpButton from '@client/app/components/help/ContextHelpButton';
-import { allKnownEntitlementKeys } from '@client/lib/entitlements/registry';
-
-// Entitlement keys known to the subscription registry (e.g. `medlib:pro`),
-// offered as columns alongside the user-tag gates so an admin can grant a model
-// to a subscription product without minting a comp tag. New products surface
-// here automatically as they are added to the registry - no edit needed.
-const KNOWN_ENTITLEMENT_KEYS: string[] = [...allKnownEntitlementKeys()].sort();
+import { KNOWN_ENTITLEMENT_KEYS } from '@client/lib/entitlements/registry';
 
 // Available user tags for permissions (used in table display)
 // 'admin' access is handled via user.isAdmin property, not tags

--- a/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
+++ b/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import {
   Alert,
+  Autocomplete,
   Box,
   Button,
   Chip,
@@ -31,6 +32,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useDebounceValue } from '@client/app/hooks/useDebouncedValue';
 import type { IPartnerSignupRuleDocument } from '@bike4mind/common';
+import { KNOWN_ENTITLEMENT_KEYS } from '@client/lib/entitlements/registry';
 import {
   fetchPartnerSignupRules,
   createPartnerSignupRule,
@@ -38,13 +40,16 @@ import {
   deletePartnerSignupRule,
 } from '@client/app/utils/partnerSignupRuleAPICalls';
 
+// Options for the entitlements picker; spread to a mutable array for Joy Autocomplete.
+const ENTITLEMENT_OPTIONS = [...KNOWN_ENTITLEMENT_KEYS];
+
 const QUERY_KEY = 'partner-signup-rules';
 const PAGE_LIMIT = 25;
 
 type FormState = {
   domain: string;
   label: string;
-  entitlements: string; // comma/space separated in the form; parsed to string[] on submit
+  entitlements: string[];
   signupCredits: string;
   notes: string;
   enabled: boolean;
@@ -53,26 +58,16 @@ type FormState = {
 const emptyForm: FormState = {
   domain: '',
   label: '',
-  entitlements: '',
+  entitlements: [],
   signupCredits: '0',
   notes: '',
   enabled: true,
 };
 
-/** Parse the comma/space separated entitlements field into a normalized, de-duplicated list. */
-const parseEntitlements = (raw: string): string[] => [
-  ...new Set(
-    raw
-      .split(/[,\s]+/)
-      .map(token => token.trim().toLowerCase())
-      .filter(Boolean)
-  ),
-];
-
 const ruleToForm = (rule: IPartnerSignupRuleDocument): FormState => ({
   domain: rule.domain,
   label: rule.label ?? '',
-  entitlements: (rule.entitlements ?? []).join(', '),
+  entitlements: rule.entitlements ?? [],
   signupCredits: String(rule.signupCredits ?? 0),
   notes: rule.notes ?? '',
   enabled: rule.enabled,
@@ -105,7 +100,7 @@ export default function PartnerSignupRulesTab() {
       // and the API only $sets keys it receives, so coalescing to undefined would make a
       // cleared field un-clearable (the old value would persist on update).
       const payload = {
-        entitlements: parseEntitlements(form.entitlements),
+        entitlements: form.entitlements,
         signupCredits: Number(form.signupCredits),
         label: form.label.trim(),
         notes: form.notes.trim(),
@@ -387,13 +382,18 @@ export default function PartnerSignupRulesTab() {
 
             <FormControl>
               <FormLabel>Entitlements</FormLabel>
-              <Input
-                placeholder="optihashi:pro, another:pro"
+              <Autocomplete
+                multiple
+                options={ENTITLEMENT_OPTIONS}
                 value={form.entitlements}
-                onChange={e => setForm(f => ({ ...f, entitlements: e.target.value }))}
+                onChange={(_event, value) => setForm(f => ({ ...f, entitlements: value }))}
+                placeholder={form.entitlements.length ? '' : 'Select entitlements to grant'}
                 data-testid="partner-rule-entitlements-input"
               />
-              <FormHelperText>Comma or space separated. Lowercased on save.</FormHelperText>
+              <FormHelperText>
+                Pick from the products the registry recognizes. A new product key must be added to the entitlement
+                registry before it appears here.
+              </FormHelperText>
             </FormControl>
 
             <FormControl>

--- a/apps/client/lib/entitlements/registry.test.ts
+++ b/apps/client/lib/entitlements/registry.test.ts
@@ -9,6 +9,8 @@ import {
   normalizeTag,
   resolveEntitlements,
   signupCreditsForEmail,
+  KNOWN_ENTITLEMENT_KEYS,
+  unknownEntitlementKeys,
 } from './registry';
 
 // Behavior tests are table-driven over the real registry rows (no product
@@ -302,5 +304,33 @@ describe('resolveEntitlements', () => {
 
   it('returns empty for a user with no tags, no subscriptions, and no email', () => {
     expect(resolveEntitlements({ tags: [], activePriceIds: [] })).toEqual([]);
+  });
+});
+
+describe('KNOWN_ENTITLEMENT_KEYS / unknownEntitlementKeys', () => {
+  it('is the sorted union of every grant source, deduped (matches allKnownEntitlementKeys)', () => {
+    const expected = Array.from(
+      new Set(
+        [
+          ...__registryRows.priceRows,
+          ...__registryRows.tagGrantRows,
+          ...__registryRows.domainGrantRows,
+        ].flatMap(r => r.entitlements)
+      )
+    ).sort();
+    expect([...KNOWN_ENTITLEMENT_KEYS]).toEqual(expected);
+    expect([...KNOWN_ENTITLEMENT_KEYS]).toEqual([...allKnownEntitlementKeys()].sort());
+    expect(new Set(KNOWN_ENTITLEMENT_KEYS).size).toBe(KNOWN_ENTITLEMENT_KEYS.length);
+  });
+
+  it('flags keys the registry does not recognize (normalized, de-duplicated)', () => {
+    const known = KNOWN_ENTITLEMENT_KEYS[0];
+    expect(unknownEntitlementKeys([known])).toEqual([]);
+    expect(unknownEntitlementKeys([`${known}`, ' BOGUS:key ', 'bogus:key'])).toEqual(['bogus:key']);
+  });
+
+  it('treats a known key as known regardless of case/whitespace', () => {
+    const known = KNOWN_ENTITLEMENT_KEYS[0];
+    expect(unknownEntitlementKeys([` ${known.toUpperCase()} `])).toEqual([]);
   });
 });

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -233,6 +233,31 @@ export const DOMAIN_GRANTS: ReadonlyMap<string, readonly EntitlementKey[]> = new
   DOMAIN_GRANT_ROWS.map(row => [normalizeTag(row.domain), row.entitlements])
 );
 
+/**
+ * Every entitlement key the registry recognizes as a grantable product, sorted - the union of
+ * every grant source (price, comp-tag, email-domain) via `allKnownEntitlementKeys`, so there is
+ * one source of truth for "what products exist" (e.g. `optihashi:pro`, `libreoncology:pro`). New
+ * products surface here automatically as their rows are added above. Admin surfaces that let an
+ * operator pick an entitlement to grant (LLM model gating, partner signup rules) source their
+ * options from this so a typo can't persist a dead grant.
+ */
+export const KNOWN_ENTITLEMENT_KEYS: readonly EntitlementKey[] = [...allKnownEntitlementKeys()].sort();
+
+/**
+ * The entitlement keys in `keys` the registry does NOT recognize (normalized, de-duplicated).
+ * Empty means every key is a known grantable product. Used to reject typo'd keys at admin
+ * write boundaries before they persist as a silent no-op grant.
+ */
+export function unknownEntitlementKeys(keys: Iterable<string>): string[] {
+  const known = new Set(KNOWN_ENTITLEMENT_KEYS);
+  const unknown = new Set<string>();
+  for (const raw of keys) {
+    const key = normalizeTag(raw);
+    if (key && !known.has(key)) unknown.add(key);
+  }
+  return [...unknown];
+}
+
 /** Entitlement keys granted by the given Stripe priceIds. */
 export function entitlementsForPriceIds(priceIds: readonly string[]): Set<EntitlementKey> {
   const keys = new Set<EntitlementKey>();

--- a/apps/client/pages/api/admin/partner-signup-rules/[id].ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/[id].ts
@@ -4,7 +4,7 @@ import { BadRequestError, ensureAdmin } from '@server/utils/errors';
 import { NotFoundError } from '@bike4mind/utils';
 import { partnerSignupRuleRepository } from '@bike4mind/database';
 import { updatePartnerSignupRuleSchema } from '@bike4mind/common';
-import { invalidatePartnerRuleCache } from '@server/entitlements/partnerRules';
+import { invalidatePartnerRuleCache, assertKnownEntitlements } from '@server/entitlements/partnerRules';
 import { z } from 'zod';
 
 interface RequestQuery {
@@ -27,6 +27,8 @@ const handler = baseApi()
         }
         throw error;
       }
+      // Only present on a partial update that touches entitlements.
+      if (data.entitlements) assertKnownEntitlements(data.entitlements);
 
       const updated = await partnerSignupRuleRepository.update({ id, ...data });
       // Null => the row was deleted between check and write (or never existed). 404 rather

--- a/apps/client/pages/api/admin/partner-signup-rules/__tests__/[id].test.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/__tests__/[id].test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+// Same middleware-strip pattern as index.test.ts: capture the handlers registered on the
+// baseApi chain so PUT/DELETE can be invoked directly. Everything referenced inside a
+// vi.mock factory must live in vi.hoisted (mocks are hoisted above const initialization).
+const { handlers, repo, invalidatePartnerRuleCache } = vi.hoisted(() => ({
+  handlers: {} as Record<string, (req: unknown, res: unknown) => unknown>,
+  repo: { update: vi.fn(), findById: vi.fn(), delete: vi.fn() },
+  invalidatePartnerRuleCache: vi.fn(),
+}));
+
+vi.mock('@server/middlewares/asyncHandler', () => ({ asyncHandler: (fn: unknown) => fn }));
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const chain: Record<string, (fn: (req: unknown, res: unknown) => unknown) => unknown> = {};
+    for (const method of ['get', 'post', 'put', 'delete']) {
+      chain[method] = (fn: (req: unknown, res: unknown) => unknown) => {
+        handlers[method] = fn;
+        return chain;
+      };
+    }
+    return chain;
+  },
+}));
+
+vi.mock('@bike4mind/database', () => ({ partnerSignupRuleRepository: repo }));
+// Keep assertKnownEntitlements real (exercises the actual known-key validation); spy only on invalidate.
+vi.mock('@server/entitlements/partnerRules', async importOriginal => ({
+  ...(await importOriginal<typeof import('@server/entitlements/partnerRules')>()),
+  invalidatePartnerRuleCache,
+}));
+
+// Importing the route registers handlers.put / handlers.delete via the mocked baseApi.
+import '@pages/api/admin/partner-signup-rules/[id]';
+
+type ReqOverrides = { user?: unknown; body?: unknown; query?: unknown };
+function makeReqRes(method: string, over: ReqOverrides = {}) {
+  const { req, res } = createMocks({ method });
+  (req as { user?: unknown }).user = 'user' in over ? over.user : { isAdmin: true, id: 'admin-1' };
+  (req as { body?: unknown }).body = over.body ?? {};
+  (req as { query?: unknown }).query = over.query ?? { id: 'r1' };
+  return { req, res };
+}
+
+describe('/api/admin/partner-signup-rules/[id] — update (PUT)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repo.update.mockResolvedValue({ id: 'r1', domain: 'partner.com', entitlements: ['optihashi:pro'], enabled: true });
+  });
+
+  it('rejects a non-admin with 403 (ForbiddenError) and never writes', async () => {
+    const { req, res } = makeReqRes('PUT', { user: { isAdmin: false }, body: { enabled: false } });
+    await expect(handlers.put(req, res)).rejects.toThrow(/admin access required/i);
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing id with a 400', async () => {
+    const { req, res } = makeReqRes('PUT', { query: {}, body: { enabled: false } });
+    await expect(handlers.put(req, res)).rejects.toThrow(/rule id required/i);
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  // Symmetric to the POST guard: a typo'd key must 400 on the update path too (issue #324).
+  it('rejects an unknown entitlement key with a 400 and never writes', async () => {
+    const { req, res } = makeReqRes('PUT', { body: { entitlements: ['optihash:pro'] } });
+    await expect(handlers.put(req, res)).rejects.toThrow(/unknown entitlement key/i);
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  // The assert is guarded by `if (data.entitlements)`, so an entitlements-less delta must not trip it.
+  it('applies an enabled-only update without touching entitlement validation', async () => {
+    const { req, res } = makeReqRes('PUT', { body: { enabled: false } });
+    await handlers.put(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(repo.update).toHaveBeenCalledWith(expect.objectContaining({ id: 'r1', enabled: false }));
+    expect(invalidatePartnerRuleCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies a valid entitlements update (200) and busts the cache', async () => {
+    const { req, res } = makeReqRes('PUT', { body: { entitlements: ['optihashi:pro'] } });
+    await handlers.put(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(repo.update).toHaveBeenCalledWith(expect.objectContaining({ id: 'r1', entitlements: ['optihashi:pro'] }));
+    expect(invalidatePartnerRuleCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 404 when the row was deleted between check and write', async () => {
+    repo.update.mockResolvedValue(null);
+    const { req, res } = makeReqRes('PUT', { body: { enabled: true } });
+    await expect(handlers.put(req, res)).rejects.toThrow(/not found/i);
+    expect(invalidatePartnerRuleCache).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/admin/partner-signup-rules/__tests__/index.test.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/__tests__/index.test.ts
@@ -26,7 +26,11 @@ vi.mock('@server/middlewares/baseApi', () => ({
 }));
 
 vi.mock('@bike4mind/database', () => ({ partnerSignupRuleRepository: repo }));
-vi.mock('@server/entitlements/partnerRules', () => ({ invalidatePartnerRuleCache }));
+// Keep assertKnownEntitlements real (exercises the actual known-key validation); spy only on invalidate.
+vi.mock('@server/entitlements/partnerRules', async importOriginal => ({
+  ...(await importOriginal<typeof import('@server/entitlements/partnerRules')>()),
+  invalidatePartnerRuleCache,
+}));
 
 // Importing the route registers handlers.get / handlers.post via the mocked baseApi.
 import '@pages/api/admin/partner-signup-rules/index';
@@ -58,6 +62,12 @@ describe('/api/admin/partner-signup-rules — create (POST)', () => {
   it('rejects an invalid body with a 400 (Zod message)', async () => {
     const { req, res } = makeReqRes('POST', { body: { ...validRule, domain: 'gmail.com' } });
     await expect(handlers.post(req, res)).rejects.toThrow(/public mail providers/i);
+    expect(repo.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown entitlement key with a 400 and never writes (issue #324)', async () => {
+    const { req, res } = makeReqRes('POST', { body: { ...validRule, entitlements: ['optihash:pro'] } });
+    await expect(handlers.post(req, res)).rejects.toThrow(/unknown entitlement key/i);
     expect(repo.create).not.toHaveBeenCalled();
   });
 

--- a/apps/client/pages/api/admin/partner-signup-rules/index.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/index.ts
@@ -3,8 +3,7 @@ import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { BadRequestError, ensureAdmin } from '@server/utils/errors';
 import { partnerSignupRuleRepository } from '@bike4mind/database';
 import { createPartnerSignupRuleSchema } from '@bike4mind/common';
-import { invalidatePartnerRuleCache } from '@server/entitlements/partnerRules';
-import { assertKnownEntitlements } from '@server/entitlements/partnerRules';
+import { invalidatePartnerRuleCache, assertKnownEntitlements } from '@server/entitlements/partnerRules';
 import { z } from 'zod';
 
 const listQuerySchema = z.object({

--- a/apps/client/pages/api/admin/partner-signup-rules/index.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/index.ts
@@ -4,6 +4,7 @@ import { BadRequestError, ensureAdmin } from '@server/utils/errors';
 import { partnerSignupRuleRepository } from '@bike4mind/database';
 import { createPartnerSignupRuleSchema } from '@bike4mind/common';
 import { invalidatePartnerRuleCache } from '@server/entitlements/partnerRules';
+import { assertKnownEntitlements } from '@server/entitlements/partnerRules';
 import { z } from 'zod';
 
 const listQuerySchema = z.object({
@@ -43,6 +44,7 @@ const handler = baseApi()
       } catch (error) {
         toBadRequest(error);
       }
+      assertKnownEntitlements(data.entitlements);
 
       // Fast, friendly duplicate check. This is a TOCTOU pre-check, not the guarantee - the
       // unique domain index is (see the create catch below).

--- a/apps/client/server/entitlements/partnerRules.ts
+++ b/apps/client/server/entitlements/partnerRules.ts
@@ -16,8 +16,9 @@
  * comparison rule shared with the registry so domain/key matching is identical.
  */
 import { partnerSignupRuleRepository } from '@bike4mind/database';
-import { normalizeTag } from '@client/lib/entitlements/registry';
+import { normalizeTag, KNOWN_ENTITLEMENT_KEYS, unknownEntitlementKeys } from '@client/lib/entitlements/registry';
 import type { EntitlementKey } from '@client/lib/entitlements/types';
+import { BadRequestError } from '@server/utils/errors';
 
 /** Resolved rule shape held in the cache (domain is the Map key). */
 type ResolvedRule = {
@@ -82,6 +83,21 @@ async function getRulesMap(): Promise<Map<string, ResolvedRule>> {
 /** Drop the cache so the next resolution reloads from the DB. Call after any admin write. */
 export function invalidatePartnerRuleCache(): void {
   cache = null;
+}
+
+/**
+ * Reject entitlement keys the registry doesn't recognize (issue #324). A typo like
+ * `optihash:pro` is a valid lowercase token to the Zod schema but grants nothing at
+ * derive-on-read, so it would persist as a silent no-op. Called by the admin create/update
+ * routes before write; the admin UI additionally constrains the picker to known keys.
+ */
+export function assertKnownEntitlements(entitlements: readonly string[]): void {
+  const unknown = unknownEntitlementKeys(entitlements);
+  if (unknown.length > 0) {
+    throw new BadRequestError(
+      `Unknown entitlement key(s): ${unknown.join(', ')}. Known keys: ${KNOWN_ENTITLEMENT_KEYS.join(', ')}`
+    );
+  }
 }
 
 /** The rule matching an email's verified domain, or null. Extracted like the registry (after last `@`). */


### PR DESCRIPTION
## Description

Partner-signup-rule entitlements were free text: a typo like `optihash:pro` passed the schema's
lowercase-token check but grants nothing at derive-on-read, silently persisting a dead rule.
This constrains entitlement keys to the products the registry actually recognizes, in the UI and
on the server.

Closes #324 (follow-up to #293 / #299).

## Changes

- **Registry** (`apps/client/lib/entitlements/registry.ts`): promoted the known-keys list to a shared
  `KNOWN_ENTITLEMENT_KEYS` export (union of price- and comp-tag-mapped keys) + added a pure
  `unknownEntitlementKeys()` helper. New products surface automatically as their rows are added.
- **DRY**: `LLMDashboardTab` now imports the shared export instead of its own local copy.
- **Admin UI** (`PartnerSignupRulesTab`): the entitlements field is now a Joy `Autocomplete` (multi,
  no free-solo) sourced from known keys — a typo can't be entered.
- **Admin routes** (`partner-signup-rules/{index,[id]}`): reject unknown keys with a 400 via
  `assertKnownEntitlements` (create + update), so API callers can't persist a dead grant either.

## Guide for Testers

Target: a PR preview (`app.pr<N>.preview.bike4mind.com`); admin account.

1. Navigate **Sidebar -> Admin -> User Ops -> Partner Signup Rules**, click **Add rule**.
2. Click the **Entitlements** field. Expected: a dropdown of known product keys (e.g. `optihashi:pro`,
   `libreoncology:pro`) — NOT a free-text box. You cannot type an arbitrary value.
3. Select `optihashi:pro`, fill Domain `testpartner.com`, Signup credits `150000`, Save.
   Expected: rule saves; row shows the `optihashi:pro` chip.
4. **Server guard:** `POST /api/admin/partner-signup-rules` with `{"domain":"x.com","entitlements":["optihash:pro"],"signupCredits":0}`
   (as admin). Expected: **400**, body `Unknown entitlement key(s): optihash:pro. Known keys: ...`.

### Regression Checks

5. **LLM Dashboard** tab (Admin -> AI & Agents -> LLM Dashboard) still renders its entitlement columns
   (it now consumes the shared `KNOWN_ENTITLEMENT_KEYS` export) — no missing/renamed columns.
6. Editing an existing rule still works: open a rule, the current entitlements show as chips, change
   credits, save.

### What NOT to test

- Domain grants / signup-credit behavior are unchanged by this PR (covered in #293/#299).
- Bonus-credit granting on the OTC "Register now" flow is a separate gap tracked in #323.

## Checklist

- [ ] AdminSettings hydration - N/A
- [x] UI/UX feels good (dropdown with chips, helper text)
- [x] Self-reviewed
- [x] Commented where non-obvious
- [ ] Docs - N/A
- [x] No new warnings

## Developer Notes

- `KNOWN_ENTITLEMENT_KEYS` + `unknownEntitlementKeys()` are now the shared source of truth for
  "which entitlements can an operator grant" — reuse them for any future admin grant surface instead
  of re-deriving from `PRICE_ENTITLEMENTS`/`TAG_GRANTS`.
