### PR TITLE
feat(client): hide fun/novelty tools behind collapsible section

### DIFF
--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -213,6 +213,7 @@ const ToolsSection = ({
   const { setState: setLLM } = useLLM;
   const { settings: userSettings, updatePreferences } = useUserSettings();
   const showIndividualTools = !userSettings.toolsCatalogCollapsed;
+  const showFunTools = userSettings.showFunTools;
   const {
     data: mcpServersData = [],
     isPending: isLoadingMcpServers,
@@ -244,6 +245,10 @@ const ToolsSection = ({
   const toggleCatalogCollapsed = useCallback(() => {
     updatePreferences({ toolsCatalogCollapsed: !userSettings.toolsCatalogCollapsed });
   }, [updatePreferences, userSettings.toolsCatalogCollapsed]);
+
+  const toggleFunTools = useCallback(() => {
+    updatePreferences({ showFunTools: !userSettings.showFunTools });
+  }, [updatePreferences, userSettings.showFunTools]);
 
   // Notify parent when modal opens/closes
   useEffect(() => {
@@ -996,24 +1001,6 @@ const ToolsSection = ({
               />
             </ToolContainer>
           </Grid>
-          {/* Weather Info */}
-          <Grid xs={12} className="tool-item tool-item-weather">
-            <ToolContainer sx={toolContainerSx} toolId="weather_info">
-              <Box
-                className="tool-content"
-                sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-              >
-                <WeatherIcon
-                  sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                />
-                <ToolLabel name={getToolDisplayName('weather_info')} description={getToolDescription('weather_info')} />
-              </Box>
-              <SquareSlideToggle
-                onChange={() => handleToggleTool('weather_info')}
-                checked={tools.includes('weather_info')}
-              />
-            </ToolContainer>
-          </Grid>
           {/* Quest Master */}
           {isQuestMasterFeatureEnabled && (
             <Grid xs={12} className="tool-item tool-item-quest-master">
@@ -1148,21 +1135,6 @@ const ToolsSection = ({
               />
             </ToolContainer>
           </Grid>
-          {/* Dice Roll */}
-          <Grid xs={12} className="tool-item tool-item-dice">
-            <ToolContainer sx={toolContainerSx} toolId="dice_roll">
-              <Box
-                className="tool-content"
-                sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-              >
-                <DiceIcon
-                  sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                />
-                <ToolLabel name={getToolDisplayName('dice_roll')} description={getToolDescription('dice_roll')} />
-              </Box>
-              <SquareSlideToggle onChange={() => handleToggleTool('dice_roll')} checked={tools.includes('dice_roll')} />
-            </ToolContainer>
-          </Grid>
           {/* Research Mode */}
           {isResearchModeFeatureEnabled && (
             <Grid xs={12} className="tool-item tool-item-research-mode">
@@ -1220,125 +1192,226 @@ const ToolsSection = ({
               </Box>
             </ToolContainer>
           </Grid>
-          {/* Chess Engine */}
-          <Grid xs={12} className="tool-item tool-item-chess-engine">
-            <ToolContainer sx={toolContainerSx} toolId="chess_engine">
-              <Box
-                className="tool-content"
-                sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-              >
-                <ChessIcon
-                  sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                />
-                <ToolLabel name={getToolDisplayName('chess_engine')} description={getToolDescription('chess_engine')} />
-              </Box>
-              <SquareSlideToggle
-                onChange={() => handleToggleTool('chess_engine')}
-                checked={tools.includes('chess_engine')}
-              />
-            </ToolContainer>
-          </Grid>
-          {/* On This Day (Wikipedia) */}
-          <Grid xs={12} className="tool-item tool-item-wikipedia-on-this-day">
-            <ToolContainer sx={toolContainerSx} toolId="wikipedia_on_this_day">
-              <Box
-                className="tool-content"
-                sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-              >
-                <HistoryIcon
-                  sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                />
-                <ToolLabel
-                  name={getToolDisplayName('wikipedia_on_this_day')}
-                  description={getToolDescription('wikipedia_on_this_day')}
-                />
-              </Box>
-              <SquareSlideToggle
-                onChange={() => handleToggleTool('wikipedia_on_this_day')}
-                checked={tools.includes('wikipedia_on_this_day')}
-              />
-            </ToolContainer>
-          </Grid>
-          {/* Moon Phase */}
-          <Grid xs={12} className="tool-item tool-item-moon-phase">
-            <ToolContainer sx={toolContainerSx} toolId="moon_phase">
-              <Box
-                className="tool-content"
-                sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-              >
-                <MoonIcon
-                  sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                />
-                <ToolLabel name={getToolDisplayName('moon_phase')} description={getToolDescription('moon_phase')} />
-              </Box>
-              <SquareSlideToggle
-                onChange={() => handleToggleTool('moon_phase')}
-                checked={tools.includes('moon_phase')}
-              />
-            </ToolContainer>
-          </Grid>
-          {/* Sunrise/Sunset */}
-          <Grid xs={12} className="tool-item tool-item-sunrise-sunset">
-            <ToolContainer sx={toolContainerSx} toolId="sunrise_sunset">
-              <Box
-                className="tool-content"
-                sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-              >
-                <SunriseIcon
-                  sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                />
-                <ToolLabel
-                  name={getToolDisplayName('sunrise_sunset')}
-                  description={getToolDescription('sunrise_sunset')}
-                />
-              </Box>
-              <SquareSlideToggle
-                onChange={() => handleToggleTool('sunrise_sunset')}
-                checked={tools.includes('sunrise_sunset')}
-              />
-            </ToolContainer>
-          </Grid>
-          {/* ISS Tracker */}
-          <Grid xs={12} className="tool-item tool-item-iss-tracker">
-            <ToolContainer sx={toolContainerSx} toolId="iss_tracker">
-              <Box
-                className="tool-content"
-                sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-              >
-                <SatelliteIcon
-                  sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                />
-                <ToolLabel name={getToolDisplayName('iss_tracker')} description={getToolDescription('iss_tracker')} />
-              </Box>
-              <SquareSlideToggle
-                onChange={() => handleToggleTool('iss_tracker')}
-                checked={tools.includes('iss_tracker')}
-              />
-            </ToolContainer>
-          </Grid>
-          {/* Planet Visibility */}
-          <Grid xs={12} className="tool-item tool-item-planet-visibility">
-            <ToolContainer sx={toolContainerSx} toolId="planet_visibility">
-              <Box
-                className="tool-content"
-                sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-              >
-                <PlanetIcon
-                  sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                />
-                <ToolLabel
-                  name={getToolDisplayName('planet_visibility')}
-                  description={getToolDescription('planet_visibility')}
-                />
-              </Box>
-              <SquareSlideToggle
-                onChange={() => handleToggleTool('planet_visibility')}
-                checked={tools.includes('planet_visibility')}
-              />
-            </ToolContainer>
-          </Grid>
         </Box>
       </ToolGateContext.Provider>
+
+      {/* Collapsible Fun & Novelty tools section (hidden by default for FTUE) */}
+      {showIndividualTools && (
+        <>
+          <Box
+            role="button"
+            tabIndex={0}
+            aria-expanded={showFunTools}
+            data-testid="tools-fun-toggle"
+            onClick={toggleFunTools}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleFunTools();
+              }
+            }}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              cursor: 'pointer',
+              py: 0.5,
+              mt: 1,
+              mb: showFunTools ? 1 : 0,
+              userSelect: 'none',
+              '&:hover': { opacity: 0.8 },
+            }}
+          >
+            <ExpandMoreIcon
+              sx={{
+                fontSize: '1rem',
+                transition: 'transform 0.2s',
+                transform: showFunTools ? 'rotate(0deg)' : 'rotate(-90deg)',
+                color: 'text.secondary',
+                mr: 0.5,
+              }}
+            />
+            <Typography level="body-xs" sx={{ color: 'text.secondary', flex: 1 }}>
+              Fun & Novelty
+            </Typography>
+          </Box>
+
+          <ToolGateContext.Provider value={getToolGate}>
+            <Box
+              className="tools-section-fun-grid"
+              sx={{
+                display: showFunTools ? 'grid' : 'none',
+                gridTemplateColumns: `repeat(${columns}, 1fr)`,
+                gap: columns,
+                width: '100%',
+                overflow: { xs: 'auto', sm: 'initial' },
+              }}
+            >
+              {/* Chess Engine */}
+              <Grid xs={12} className="tool-item tool-item-chess-engine">
+                <ToolContainer sx={toolContainerSx} toolId="chess_engine">
+                  <Box
+                    className="tool-content"
+                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                  >
+                    <ChessIcon
+                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                    />
+                    <ToolLabel
+                      name={getToolDisplayName('chess_engine')}
+                      description={getToolDescription('chess_engine')}
+                    />
+                  </Box>
+                  <SquareSlideToggle
+                    onChange={() => handleToggleTool('chess_engine')}
+                    checked={tools.includes('chess_engine')}
+                  />
+                </ToolContainer>
+              </Grid>
+              {/* Dice Roll */}
+              <Grid xs={12} className="tool-item tool-item-dice">
+                <ToolContainer sx={toolContainerSx} toolId="dice_roll">
+                  <Box
+                    className="tool-content"
+                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                  >
+                    <DiceIcon
+                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                    />
+                    <ToolLabel name={getToolDisplayName('dice_roll')} description={getToolDescription('dice_roll')} />
+                  </Box>
+                  <SquareSlideToggle
+                    onChange={() => handleToggleTool('dice_roll')}
+                    checked={tools.includes('dice_roll')}
+                  />
+                </ToolContainer>
+              </Grid>
+              {/* Weather Info */}
+              <Grid xs={12} className="tool-item tool-item-weather">
+                <ToolContainer sx={toolContainerSx} toolId="weather_info">
+                  <Box
+                    className="tool-content"
+                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                  >
+                    <WeatherIcon
+                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                    />
+                    <ToolLabel
+                      name={getToolDisplayName('weather_info')}
+                      description={getToolDescription('weather_info')}
+                    />
+                  </Box>
+                  <SquareSlideToggle
+                    onChange={() => handleToggleTool('weather_info')}
+                    checked={tools.includes('weather_info')}
+                  />
+                </ToolContainer>
+              </Grid>
+              {/* On This Day (Wikipedia) */}
+              <Grid xs={12} className="tool-item tool-item-wikipedia-on-this-day">
+                <ToolContainer sx={toolContainerSx} toolId="wikipedia_on_this_day">
+                  <Box
+                    className="tool-content"
+                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                  >
+                    <HistoryIcon
+                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                    />
+                    <ToolLabel
+                      name={getToolDisplayName('wikipedia_on_this_day')}
+                      description={getToolDescription('wikipedia_on_this_day')}
+                    />
+                  </Box>
+                  <SquareSlideToggle
+                    onChange={() => handleToggleTool('wikipedia_on_this_day')}
+                    checked={tools.includes('wikipedia_on_this_day')}
+                  />
+                </ToolContainer>
+              </Grid>
+              {/* ISS Tracker */}
+              <Grid xs={12} className="tool-item tool-item-iss-tracker">
+                <ToolContainer sx={toolContainerSx} toolId="iss_tracker">
+                  <Box
+                    className="tool-content"
+                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                  >
+                    <SatelliteIcon
+                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                    />
+                    <ToolLabel
+                      name={getToolDisplayName('iss_tracker')}
+                      description={getToolDescription('iss_tracker')}
+                    />
+                  </Box>
+                  <SquareSlideToggle
+                    onChange={() => handleToggleTool('iss_tracker')}
+                    checked={tools.includes('iss_tracker')}
+                  />
+                </ToolContainer>
+              </Grid>
+              {/* Sunrise/Sunset */}
+              <Grid xs={12} className="tool-item tool-item-sunrise-sunset">
+                <ToolContainer sx={toolContainerSx} toolId="sunrise_sunset">
+                  <Box
+                    className="tool-content"
+                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                  >
+                    <SunriseIcon
+                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                    />
+                    <ToolLabel
+                      name={getToolDisplayName('sunrise_sunset')}
+                      description={getToolDescription('sunrise_sunset')}
+                    />
+                  </Box>
+                  <SquareSlideToggle
+                    onChange={() => handleToggleTool('sunrise_sunset')}
+                    checked={tools.includes('sunrise_sunset')}
+                  />
+                </ToolContainer>
+              </Grid>
+              {/* Moon Phase */}
+              <Grid xs={12} className="tool-item tool-item-moon-phase">
+                <ToolContainer sx={toolContainerSx} toolId="moon_phase">
+                  <Box
+                    className="tool-content"
+                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                  >
+                    <MoonIcon
+                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                    />
+                    <ToolLabel name={getToolDisplayName('moon_phase')} description={getToolDescription('moon_phase')} />
+                  </Box>
+                  <SquareSlideToggle
+                    onChange={() => handleToggleTool('moon_phase')}
+                    checked={tools.includes('moon_phase')}
+                  />
+                </ToolContainer>
+              </Grid>
+              {/* Planet Visibility */}
+              <Grid xs={12} className="tool-item tool-item-planet-visibility">
+                <ToolContainer sx={toolContainerSx} toolId="planet_visibility">
+                  <Box
+                    className="tool-content"
+                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                  >
+                    <PlanetIcon
+                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                    />
+                    <ToolLabel
+                      name={getToolDisplayName('planet_visibility')}
+                      description={getToolDescription('planet_visibility')}
+                    />
+                  </Box>
+                  <SquareSlideToggle
+                    onChange={() => handleToggleTool('planet_visibility')}
+                    checked={tools.includes('planet_visibility')}
+                  />
+                </ToolContainer>
+              </Grid>
+            </Box>
+          </ToolGateContext.Provider>
+        </>
+      )}
 
       {/* Deep Research Config Modal */}
       <DeepResearchConfigModal open={deepResearchConfigOpen} onClose={() => setDeepResearchConfigOpen(false)} />

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -50,6 +50,7 @@ export interface UserSettings {
   toolsCatalogCollapsed: boolean;
   /** Layer-2 Agent-mode preference. Default `'off'` per `IUserPreferences`. */
   agentModeDefault: 'off' | 'auto' | 'on';
+  showFunTools: boolean;
 }
 
 interface UserSettingsContextProps {
@@ -96,6 +97,7 @@ const defaultSettings: UserSettings = {
   rechartsDisplayMode: 'inline',
   toolsCatalogCollapsed: false,
   agentModeDefault: 'off',
+  showFunTools: false,
 };
 
 /** Scalar keys shared between IUserPreferences and UserSettings. */
@@ -110,6 +112,7 @@ const SCALAR_PREF_KEYS = [
   'rechartsDisplayMode',
   'toolsCatalogCollapsed',
   'agentModeDefault',
+  'showFunTools',
 ] as const;
 
 /** Apply server preferences on top of defaults. Non-null server values win. */

--- a/b4m-core/common/src/types/entities/UserTypes.ts
+++ b/b4m-core/common/src/types/entities/UserTypes.ts
@@ -119,6 +119,8 @@ export interface IUserPreferences {
    * - `on`: agent_executor used by default; toggle starts in the ON state
    */
   agentModeDefault?: 'off' | 'auto' | 'on';
+  /** Whether to show fun/novelty tools (chess, dice, ISS tracker, etc.) in the tools catalog. Default: false. */
+  showFunTools?: boolean;
 }
 
 /** Source of a moderation flag - which moderation backend produced the hit. */


### PR DESCRIPTION
Move chess, dice, weather, on-this-day, ISS tracker, sunrise/sunset, moon phase, and planet visibility tools into a "Fun & Novelty" section that is collapsed by default. This keeps FTUE focused on useful prompting tools while still letting users opt in.

# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description
<!--
Provide a detailed description of what this PR does. Explain the problem you're solving or the feature you're adding.
-->

## Changes
<!--
List the changes you've made in this PR. This is to help the reviewers understand the impact of your changes.
- Change 1
- Change 2
- ...
-->

## Guide for Testers
<!--
Write step-by-step instructions that both human QA testers AND AI agents (e.g., Playwright) can follow without codebase knowledge.

Requirements:
- Number every step — one action per step
- Use exact navigation paths: "Sidebar → Admin → DLQ Management"
- Use exact URLs: "app.staging.bike4mind.com"
- Use exact input values: type `Hello, how are you?` in the message input
- State expected results after each step: "A response appears within 10 seconds with no errors"
- Include a "Regression Checks" section for refactors
- Include a "What NOT to test" section for infra/backend-only PRs

See CLAUDE.md → "Test Guide Standards" for full guidelines and examples.
-->

## Additional Information
<!--
Include any additional information or context that you think would be helpful for your reviewers.
-->

## Developer Notes (Optional)
<!--
Document capability unlocks, architectural improvements, and reusable patterns introduced by this PR.
This helps future developers understand what new building blocks are available.

Categories to consider:
- **New Extension Points**: Components/interfaces that accept new props, hooks, or configuration
- **Reusable Patterns**: New components, utilities, or approaches that can be applied elsewhere
- **Data Model Changes**: New fields, types, or structures that enable future features
- **Architecture Decisions**: Why something was built a certain way (not just what changed)

Example:
- `SchedulerTab` now accepts a `familyId` prop — any new pattern family automatically gets a Learn tab
- `ComingSoonPanel` component can be dropped into any tab to indicate future work
- `effectiveTab` pattern shows how to handle persisted tab state when tabs become conditionally disabled
-->

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
