### PR TITLE
fix(client): hide irrelevant settings tabs and admin-disabled beta features

### DIFF
--- a/apps/client/app/components/ProfileModal/ExperimentalFeatureToggle.tsx
+++ b/apps/client/app/components/ProfileModal/ExperimentalFeatureToggle.tsx
@@ -153,39 +153,39 @@ export default function ExperimentalFeatureToggle() {
         loading={false}
         onChange={() => handleToggle('enableBmPi')}
       />
-      <FeatureContainer
-        title="Lattice"
-        featureKey="enableLattice"
-        description="Create and manipulate financial pro-forma models using natural language. Build spreadsheet-like models through conversation."
-        helpId="features/lattice"
-        enabled={isFeatureEnabled('enableLattice')}
-        disabled={!getServerSettingValue('EnableLattice')}
-        disabledReason={!getServerSettingValue('EnableLattice') ? 'Disabled by administrator' : undefined}
-        loading={false}
-        onChange={() => handleToggle('enableLattice')}
-      />
-      <FeatureContainer
-        title="Mementos"
-        featureKey="enableMementos"
-        description="Save and revisit important moments from your learning sessions with AI-generated summaries."
-        helpId="features/mementos"
-        enabled={isFeatureEnabled('enableMementos')}
-        disabled={!getServerSettingValue('EnableMementos')}
-        disabledReason={!getServerSettingValue('EnableMementos') ? 'Disabled by administrator' : undefined}
-        loading={false}
-        onChange={() => handleToggle('enableMementos')}
-      />
-      <FeatureContainer
-        title="Private Model Hub"
-        featureKey="enableOllama"
-        description="Access our exclusive collection of privately hosted cutting-edge models, including DeepSeek, Qwen, and other frontier models not available through mainstream providers."
-        helpId="features/private-model-hub"
-        enabled={isFeatureEnabled('enableOllama')}
-        disabled={!getServerSettingValue('EnableOllama')}
-        disabledReason={!getServerSettingValue('EnableOllama') ? 'Disabled by administrator' : undefined}
-        loading={false}
-        onChange={() => handleToggle('enableOllama')}
-      />
+      {getServerSettingValue('EnableLattice') && (
+        <FeatureContainer
+          title="Lattice"
+          featureKey="enableLattice"
+          description="Create and manipulate financial pro-forma models using natural language. Build spreadsheet-like models through conversation."
+          helpId="features/lattice"
+          enabled={isFeatureEnabled('enableLattice')}
+          loading={false}
+          onChange={() => handleToggle('enableLattice')}
+        />
+      )}
+      {getServerSettingValue('EnableMementos') && (
+        <FeatureContainer
+          title="Mementos"
+          featureKey="enableMementos"
+          description="Save and revisit important moments from your learning sessions with AI-generated summaries."
+          helpId="features/mementos"
+          enabled={isFeatureEnabled('enableMementos')}
+          loading={false}
+          onChange={() => handleToggle('enableMementos')}
+        />
+      )}
+      {getServerSettingValue('EnableOllama') && (
+        <FeatureContainer
+          title="Private Model Hub"
+          featureKey="enableOllama"
+          description="Access our exclusive collection of privately hosted cutting-edge models, including DeepSeek, Qwen, and other frontier models not available through mainstream providers."
+          helpId="features/private-model-hub"
+          enabled={isFeatureEnabled('enableOllama')}
+          loading={false}
+          onChange={() => handleToggle('enableOllama')}
+        />
+      )}
       <FeatureContainer
         title="Quest Master"
         featureKey="enableQuestMaster"

--- a/apps/client/app/components/ProfileModal/ExperimentalFeatureToggle.tsx
+++ b/apps/client/app/components/ProfileModal/ExperimentalFeatureToggle.tsx
@@ -153,35 +153,41 @@ export default function ExperimentalFeatureToggle() {
         loading={false}
         onChange={() => handleToggle('enableBmPi')}
       />
-      {getServerSettingValue('EnableLattice') && (
+      {(getServerSettingValue('EnableLattice') || currentUser?.isAdmin) && (
         <FeatureContainer
           title="Lattice"
           featureKey="enableLattice"
           description="Create and manipulate financial pro-forma models using natural language. Build spreadsheet-like models through conversation."
           helpId="features/lattice"
           enabled={isFeatureEnabled('enableLattice')}
+          disabled={!getServerSettingValue('EnableLattice')}
+          disabledReason={!getServerSettingValue('EnableLattice') ? 'Disabled by administrator' : undefined}
           loading={false}
           onChange={() => handleToggle('enableLattice')}
         />
       )}
-      {getServerSettingValue('EnableMementos') && (
+      {(getServerSettingValue('EnableMementos') || currentUser?.isAdmin) && (
         <FeatureContainer
           title="Mementos"
           featureKey="enableMementos"
           description="Save and revisit important moments from your learning sessions with AI-generated summaries."
           helpId="features/mementos"
           enabled={isFeatureEnabled('enableMementos')}
+          disabled={!getServerSettingValue('EnableMementos')}
+          disabledReason={!getServerSettingValue('EnableMementos') ? 'Disabled by administrator' : undefined}
           loading={false}
           onChange={() => handleToggle('enableMementos')}
         />
       )}
-      {getServerSettingValue('EnableOllama') && (
+      {(getServerSettingValue('EnableOllama') || currentUser?.isAdmin) && (
         <FeatureContainer
           title="Private Model Hub"
           featureKey="enableOllama"
           description="Access our exclusive collection of privately hosted cutting-edge models, including DeepSeek, Qwen, and other frontier models not available through mainstream providers."
           helpId="features/private-model-hub"
           enabled={isFeatureEnabled('enableOllama')}
+          disabled={!getServerSettingValue('EnableOllama')}
+          disabledReason={!getServerSettingValue('EnableOllama') ? 'Disabled by administrator' : undefined}
           loading={false}
           onChange={() => handleToggle('enableOllama')}
         />

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/SettingsTabContent.test.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/SettingsTabContent.test.tsx
@@ -20,10 +20,15 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-// Non-admin user: personal Custom Instructions must stay reachable for regular
-// users, not gated behind admin.
+// Non-admin user with email configured: personal Custom Instructions must stay
+// reachable for regular users, not gated behind admin.
+let mockUser: Record<string, unknown> = {
+  id: 'u1',
+  name: 'Test User',
+  platformEmailAddress: 'user@app.example.com',
+};
 vi.mock('@client/app/contexts/UserContext', () => ({
-  useUser: () => ({ currentUser: { id: 'u1', name: 'Test User' }, isAdmin: false }),
+  useUser: () => ({ currentUser: mockUser }),
 }));
 
 // Mementos visibility is driven by useFeatureEnabled so the admin `EnableMementos`
@@ -63,6 +68,7 @@ describe('SettingsTabContent sub-tabs', () => {
     searchValue = {};
     enableMementos = false;
     featureLoading = false;
+    mockUser = { id: 'u1', name: 'Test User', platformEmailAddress: 'user@app.example.com' };
   });
 
   it('exposes Custom Instructions to a non-admin user (no regression)', () => {
@@ -74,6 +80,12 @@ describe('SettingsTabContent sub-tabs', () => {
     renderSettings();
     expect(screen.getByTestId('settings-subtab-general')).toBeInTheDocument();
     expect(screen.getByTestId('settings-subtab-email-inbox')).toBeInTheDocument();
+  });
+
+  it('hides the Email Inbox sub-tab when user has no platform email configured', () => {
+    mockUser = { id: 'u1', name: 'Test User' };
+    renderSettings();
+    expect(screen.queryByTestId('settings-subtab-email-inbox')).not.toBeInTheDocument();
   });
 
   // Billing (credit analytics) was promoted out to the top-level `usage` tab,

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/index.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/index.tsx
@@ -50,6 +50,7 @@ const SettingsTabContent = () => {
   // of the tree until both admin + user settings hydrate to avoid a flash.
   const { isFeatureEnabled, isLoading } = useFeatureEnabled();
   const enableMementos = !isLoading && isFeatureEnabled('enableMementos');
+  const hasEmailIntegration = !!currentUser?.platformEmailAddress;
 
   // Fall back to General when the requested sub-tab isn't actually rendered - e.g.
   // `?subtab=mementos` with the flag off (the legacy `?tab=mementos` redirect always
@@ -60,7 +61,7 @@ const SettingsTabContent = () => {
   const renderedSubTabs = new Set<string>([
     SettingsSubTab.General,
     SettingsSubTab.CustomInstructions,
-    SettingsSubTab.EmailInbox,
+    ...(hasEmailIntegration ? [SettingsSubTab.EmailInbox] : []),
     ...(enableMementos ? [SettingsSubTab.Mementos] : []),
   ]);
   const requestedSubTab = search?.subtab || SettingsSubTab.General;
@@ -93,12 +94,14 @@ const SettingsTabContent = () => {
           </Box>
         </StyledSubTab>
 
-        <StyledSubTab data-testid="settings-subtab-email-inbox" value={SettingsSubTab.EmailInbox}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <MailOutlineIcon sx={{ fontSize: '16px' }} />
-            <Typography sx={{ display: { xs: 'none', sm: 'block' } }}>Email Inbox</Typography>
-          </Box>
-        </StyledSubTab>
+        {hasEmailIntegration && (
+          <StyledSubTab data-testid="settings-subtab-email-inbox" value={SettingsSubTab.EmailInbox}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <MailOutlineIcon sx={{ fontSize: '16px' }} />
+              <Typography sx={{ display: { xs: 'none', sm: 'block' } }}>Email Inbox</Typography>
+            </Box>
+          </StyledSubTab>
+        )}
 
         {enableMementos && (
           <StyledSubTab data-testid="settings-subtab-mementos" value={SettingsSubTab.Mementos}>
@@ -118,9 +121,11 @@ const SettingsTabContent = () => {
         {activeSubTab === SettingsSubTab.CustomInstructions && currentUser && <SystemPromptsTab user={currentUser} />}
       </StyledSubTabPanel>
 
-      <StyledSubTabPanel value={SettingsSubTab.EmailInbox}>
-        {activeSubTab === SettingsSubTab.EmailInbox && <EmailInboxTabContent />}
-      </StyledSubTabPanel>
+      {hasEmailIntegration && (
+        <StyledSubTabPanel value={SettingsSubTab.EmailInbox}>
+          {activeSubTab === SettingsSubTab.EmailInbox && <EmailInboxTabContent />}
+        </StyledSubTabPanel>
+      )}
 
       {enableMementos && (
         <StyledSubTabPanel value={SettingsSubTab.Mementos}>

--- a/apps/client/app/routes/profile/index.tsx
+++ b/apps/client/app/routes/profile/index.tsx
@@ -84,7 +84,11 @@ const ProfilePage = () => {
   const { data: friendRequests } = useGetFriendRequests(currentUser?.id);
   const { currentSession } = useSessions();
   const isAdmin = currentUser?.isAdmin ?? false;
-  const { data: publishedArtifacts, isPending: publishedPending } = useQuery({
+  const {
+    data: publishedArtifacts,
+    isPending: publishedPending,
+    isError: publishedError,
+  } = useQuery({
     queryKey: ['published-artifacts', 'mine'],
     queryFn: listMyPublishedArtifacts,
     enabled: !!currentUser,
@@ -118,11 +122,11 @@ const ProfilePage = () => {
       navigate({ to: '/profile', search: { tab: ProfileTab.Profile }, replace: true });
       return;
     }
-    if (rawTab === ProfileTab.Published && !publishedPending && !hasPublishedArtifacts) {
+    if (rawTab === ProfileTab.Published && !publishedPending && !publishedError && !hasPublishedArtifacts) {
       navigate({ to: '/profile', search: { tab: ProfileTab.Profile }, replace: true });
       return;
     }
-  }, [rawTab, rawSubtab, navigate, currentUser, isAdmin, publishedPending, hasPublishedArtifacts]);
+  }, [rawTab, rawSubtab, navigate, currentUser, isAdmin, publishedPending, publishedError, hasPublishedArtifacts]);
 
   const profileName = currentUser?.name || currentUser?.username;
   useDocumentTitle(profileName ? `${profileName}'s Profile` : 'Profile');

--- a/apps/client/app/routes/profile/index.tsx
+++ b/apps/client/app/routes/profile/index.tsx
@@ -20,6 +20,8 @@ import { useSessions } from '@client/app/contexts/SessionsContext';
 import CommunityTabContent from '@client/app/components/ProfileModal/CommunityTabContent';
 import { ContextHelpButton } from '@client/app/components/help';
 import { profileTabListSx } from './profileTabListSx';
+import { useQuery } from '@tanstack/react-query';
+import { listMyPublishedArtifacts } from '@client/app/utils/publishApi';
 
 const SettingsTabContent = dynamic(() => import('@client/app/components/ProfileModal/SettingsTabContent'), {
   ssr: false,
@@ -81,6 +83,13 @@ const ProfilePage = () => {
   const { t } = useTranslation();
   const { data: friendRequests } = useGetFriendRequests(currentUser?.id);
   const { currentSession } = useSessions();
+  const isAdmin = currentUser?.isAdmin ?? false;
+  const { data: publishedArtifacts } = useQuery({
+    queryKey: ['published-artifacts', 'mine'],
+    queryFn: listMyPublishedArtifacts,
+    enabled: !!currentUser,
+  });
+  const hasPublishedArtifacts = (publishedArtifacts?.length ?? 0) > 0;
 
   // Redirect legacy tab values to their new homes (see LEGACY_SETTINGS_REDIRECTS).
   useEffect(() => {
@@ -99,8 +108,18 @@ const ProfilePage = () => {
     const subtab = LEGACY_SETTINGS_REDIRECTS[rawTab];
     if (subtab) {
       navigate({ to: '/profile', search: { tab: ProfileTab.Settings, subtab }, replace: true });
+      return;
     }
-  }, [rawTab, rawSubtab, navigate]);
+    // Redirect to Profile if user navigates to a hidden tab
+    if (rawTab === ProfileTab.Security && !isAdmin) {
+      navigate({ to: '/profile', search: { tab: ProfileTab.Profile }, replace: true });
+      return;
+    }
+    if (rawTab === ProfileTab.Published && !hasPublishedArtifacts) {
+      navigate({ to: '/profile', search: { tab: ProfileTab.Profile }, replace: true });
+      return;
+    }
+  }, [rawTab, rawSubtab, navigate, isAdmin, hasPublishedArtifacts]);
 
   const profileName = currentUser?.name || currentUser?.username;
   useDocumentTitle(profileName ? `${profileName}'s Profile` : 'Profile');
@@ -212,23 +231,29 @@ const ProfilePage = () => {
             </Tooltip>
           </StyledTab>
 
-          <StyledTab data-testid="security-tab" value={ProfileTab.Security}>
-            <Tooltip title="View security events and alerts">
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <SecurityIcon sx={{ color: 'text.primary', fontSize: '16px' }} />
-                <Typography sx={{ display: { xs: 'none', sm: 'block' }, color: 'text.primary' }}>Security</Typography>
-              </Box>
-            </Tooltip>
-          </StyledTab>
+          {isAdmin && (
+            <StyledTab data-testid="security-tab" value={ProfileTab.Security}>
+              <Tooltip title="View security events and alerts">
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <SecurityIcon sx={{ color: 'text.primary', fontSize: '16px' }} />
+                  <Typography sx={{ display: { xs: 'none', sm: 'block' }, color: 'text.primary' }}>Security</Typography>
+                </Box>
+              </Tooltip>
+            </StyledTab>
+          )}
 
-          <StyledTab data-testid="published-tab" value={ProfileTab.Published}>
-            <Tooltip title="Manage your published & shared artifacts">
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <ShareIcon sx={{ color: 'text.primary', fontSize: '16px' }} />
-                <Typography sx={{ display: { xs: 'none', sm: 'block' }, color: 'text.primary' }}>Published</Typography>
-              </Box>
-            </Tooltip>
-          </StyledTab>
+          {hasPublishedArtifacts && (
+            <StyledTab data-testid="published-tab" value={ProfileTab.Published}>
+              <Tooltip title="Manage your published & shared artifacts">
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <ShareIcon sx={{ color: 'text.primary', fontSize: '16px' }} />
+                  <Typography sx={{ display: { xs: 'none', sm: 'block' }, color: 'text.primary' }}>
+                    Published
+                  </Typography>
+                </Box>
+              </Tooltip>
+            </StyledTab>
+          )}
         </TabList>
 
         {/* Tab Panels */}
@@ -253,13 +278,17 @@ const ProfilePage = () => {
           {activeTab === ProfileTab.Integrations && <IntegrationsTabContent />}
         </StyledTabPanel>
 
-        <StyledTabPanel value={ProfileTab.Security}>
-          {activeTab === ProfileTab.Security && <SecurityTabContent />}
-        </StyledTabPanel>
+        {isAdmin && (
+          <StyledTabPanel value={ProfileTab.Security}>
+            {activeTab === ProfileTab.Security && <SecurityTabContent />}
+          </StyledTabPanel>
+        )}
 
-        <StyledTabPanel value={ProfileTab.Published}>
-          {activeTab === ProfileTab.Published && <PublishedArtifactsTabContent />}
-        </StyledTabPanel>
+        {hasPublishedArtifacts && (
+          <StyledTabPanel value={ProfileTab.Published}>
+            {activeTab === ProfileTab.Published && <PublishedArtifactsTabContent />}
+          </StyledTabPanel>
+        )}
       </Tabs>
     </Box>
   );

--- a/apps/client/app/routes/profile/index.tsx
+++ b/apps/client/app/routes/profile/index.tsx
@@ -84,7 +84,7 @@ const ProfilePage = () => {
   const { data: friendRequests } = useGetFriendRequests(currentUser?.id);
   const { currentSession } = useSessions();
   const isAdmin = currentUser?.isAdmin ?? false;
-  const { data: publishedArtifacts } = useQuery({
+  const { data: publishedArtifacts, isPending: publishedPending } = useQuery({
     queryKey: ['published-artifacts', 'mine'],
     queryFn: listMyPublishedArtifacts,
     enabled: !!currentUser,
@@ -110,16 +110,19 @@ const ProfilePage = () => {
       navigate({ to: '/profile', search: { tab: ProfileTab.Settings, subtab }, replace: true });
       return;
     }
-    // Redirect to Profile if user navigates to a hidden tab
+    // Redirect to Profile if user navigates to a hidden tab.
+    // Wait for currentUser to hydrate before checking admin status, and for
+    // the published query to settle, to avoid bouncing users who are still loading.
+    if (!currentUser) return;
     if (rawTab === ProfileTab.Security && !isAdmin) {
       navigate({ to: '/profile', search: { tab: ProfileTab.Profile }, replace: true });
       return;
     }
-    if (rawTab === ProfileTab.Published && !hasPublishedArtifacts) {
+    if (rawTab === ProfileTab.Published && !publishedPending && !hasPublishedArtifacts) {
       navigate({ to: '/profile', search: { tab: ProfileTab.Profile }, replace: true });
       return;
     }
-  }, [rawTab, rawSubtab, navigate, isAdmin, hasPublishedArtifacts]);
+  }, [rawTab, rawSubtab, navigate, currentUser, isAdmin, publishedPending, hasPublishedArtifacts]);
 
   const profileName = currentUser?.name || currentUser?.username;
   useDocumentTitle(profileName ? `${profileName}'s Profile` : 'Profile');

--- a/apps/client/app/routes/profile/profileTabs.test.tsx
+++ b/apps/client/app/routes/profile/profileTabs.test.tsx
@@ -3,10 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Mocks
 const mockNavigate = vi.fn();
 let searchValue: Record<string, unknown> = {};
+let mockUser: Record<string, unknown> | null = { id: 'u1', name: 'Test User', isAdmin: false };
+let mockPublishedArtifacts: unknown[] = [];
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => mockNavigate,
@@ -18,7 +21,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@client/app/contexts/UserContext', () => ({
-  useUser: () => ({ currentUser: { id: 'u1', name: 'Test User' }, isAdmin: false }),
+  useUser: () => ({ currentUser: mockUser }),
 }));
 
 vi.mock('@client/app/contexts/SessionsContext', () => ({
@@ -37,6 +40,10 @@ vi.mock('@client/app/components/help', () => ({
   ContextHelpButton: () => null,
 }));
 
+vi.mock('@client/app/utils/publishApi', () => ({
+  listMyPublishedArtifacts: () => Promise.resolve(mockPublishedArtifacts),
+}));
+
 // next/dynamic + static tab content are irrelevant to the strip itself; stub them
 // so the test stays focused on which tabs render and the redirect behavior.
 vi.mock('next/dynamic', () => ({
@@ -52,9 +59,14 @@ vi.mock('@client/app/components/ProfileModal/CommunityTabContent', () => ({
 import ProfilePage from './index';
 
 const appTheme = extendTheme({ ...getThemeConfig() });
-const Wrapper = ({ children }: { children: React.ReactNode }) => (
-  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
-);
+const Wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+    </QueryClientProvider>
+  );
+};
 
 const renderPage = () =>
   render(
@@ -67,18 +79,36 @@ describe('ProfilePage tab strip', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     searchValue = {};
+    mockUser = { id: 'u1', name: 'Test User', isAdmin: false };
+    mockPublishedArtifacts = [];
   });
 
-  it('renders exactly the six consolidated top-level tabs', () => {
+  it('renders the core tabs visible to all users (no Security or Published for non-admin with no artifacts)', () => {
     renderPage();
 
     expect(screen.getByTestId('profile-tab')).toBeInTheDocument();
     expect(screen.getByTestId('community-tab')).toBeInTheDocument();
     expect(screen.getByTestId('settings-tab')).toBeInTheDocument();
-    // Credit Usage promoted to its own top-level tab.
     expect(screen.getByTestId('usage-tab')).toBeInTheDocument();
     expect(screen.getByTestId('integrations-tab')).toBeInTheDocument();
+    // Non-admin: Security tab hidden
+    expect(screen.queryByTestId('security-tab')).not.toBeInTheDocument();
+    // No published artifacts: Published tab hidden
+    expect(screen.queryByTestId('published-tab')).not.toBeInTheDocument();
+  });
+
+  it('shows the Security tab for admin users', () => {
+    mockUser = { id: 'u1', name: 'Admin User', isAdmin: true };
+    renderPage();
+
     expect(screen.getByTestId('security-tab')).toBeInTheDocument();
+  });
+
+  it('hides the Security tab for non-admin users', () => {
+    mockUser = { id: 'u1', name: 'Test User', isAdmin: false };
+    renderPage();
+
+    expect(screen.queryByTestId('security-tab')).not.toBeInTheDocument();
   });
 
   it('no longer renders the tabs that moved into /admin or Settings', () => {
@@ -141,6 +171,26 @@ describe('ProfilePage tab strip', () => {
 
   it('does not redirect for a current, valid tab', () => {
     searchValue = { tab: 'settings' };
+    renderPage();
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('redirects non-admin away from ?tab=security', () => {
+    mockUser = { id: 'u1', name: 'Test User', isAdmin: false };
+    searchValue = { tab: 'security' };
+    renderPage();
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/profile',
+      search: { tab: '' },
+      replace: true,
+    });
+  });
+
+  it('does not redirect admin away from ?tab=security', () => {
+    mockUser = { id: 'u1', name: 'Admin User', isAdmin: true };
+    searchValue = { tab: 'security' };
     renderPage();
 
     expect(mockNavigate).not.toHaveBeenCalled();


### PR DESCRIPTION

- Hide Lattice, Mementos, and Private Model Hub from beta features when admin has disabled them (instead of showing "Disabled by administrator" to non-admin users)
- Hide Security tab for non-workspace administrators
- Hide Published Artifacts tab when user has no published artifacts
- Hide Email Inbox sub-tab until user has configured a platform email
- Redirect direct navigation to hidden tabs back to Profile

# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description
<!--
Provide a detailed description of what this PR does. Explain the problem you're solving or the feature you're adding.
-->

## Changes
<!--
List the changes you've made in this PR. This is to help the reviewers understand the impact of your changes.
- Change 1
- Change 2
- ...
-->

## Guide for Testers
<!--
Write step-by-step instructions that both human QA testers AND AI agents (e.g., Playwright) can follow without codebase knowledge.

Requirements:
- Number every step — one action per step
- Use exact navigation paths: "Sidebar → Admin → DLQ Management"
- Use exact URLs: "app.staging.bike4mind.com"
- Use exact input values: type `Hello, how are you?` in the message input
- State expected results after each step: "A response appears within 10 seconds with no errors"
- Include a "Regression Checks" section for refactors
- Include a "What NOT to test" section for infra/backend-only PRs

See CLAUDE.md → "Test Guide Standards" for full guidelines and examples.
-->

## Additional Information
<!--
Include any additional information or context that you think would be helpful for your reviewers.
-->

## Developer Notes (Optional)
<!--
Document capability unlocks, architectural improvements, and reusable patterns introduced by this PR.
This helps future developers understand what new building blocks are available.

Categories to consider:
- **New Extension Points**: Components/interfaces that accept new props, hooks, or configuration
- **Reusable Patterns**: New components, utilities, or approaches that can be applied elsewhere
- **Data Model Changes**: New fields, types, or structures that enable future features
- **Architecture Decisions**: Why something was built a certain way (not just what changed)

Example:
- `SchedulerTab` now accepts a `familyId` prop — any new pattern family automatically gets a Learn tab
- `ComingSoonPanel` component can be dropped into any tab to indicate future work
- `effectiveTab` pattern shows how to handle persisted tab state when tabs become conditionally disabled
-->

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
