### PR TITLE
fix(database): allow 'optihashi' as an IntegrationAuditLog integrationName

### DIFF
--- a/apps/client/pages/api/admin/integration-audit-logs/index.ts
+++ b/apps/client/pages/api/admin/integration-audit-logs/index.ts
@@ -1,4 +1,4 @@
-import { integrationAuditLogRepository } from '@bike4mind/database';
+import { integrationAuditLogRepository, INTEGRATION_AUDIT_INTEGRATION_NAMES } from '@bike4mind/database';
 import type {
   IntegrationAuditEntityType,
   IntegrationAuditIntegrationName,
@@ -13,7 +13,8 @@ const QuerySchema = z.object({
   startDate: z.string().optional(),
   endDate: z.string().optional(),
   entityType: z.enum(['oauth', 'webhook', 'mcp_tool', 'token_refresh']).optional(),
-  integrationName: z.enum(['github', 'atlassian', 'slack', 'linear', 'notion']).optional(),
+  // Shared const so this filter can never drift from the model's enum (e.g. omitting 'optihashi').
+  integrationName: z.enum(INTEGRATION_AUDIT_INTEGRATION_NAMES).optional(),
   outcome: z.enum(['success', 'failure', 'rate_limited']).optional(),
   userId: z.string().optional(),
   workspaceId: z.string().optional(),

--- a/apps/client/server/utils/invokeMcpHandler.test.ts
+++ b/apps/client/server/utils/invokeMcpHandler.test.ts
@@ -47,6 +47,8 @@ vi.mock('@bike4mind/database', () => ({
     getLatestByIntegration: vi.fn().mockResolvedValue(null),
     create: vi.fn(),
   },
+  // invokeMcpHandler builds AUDITABLE_INTEGRATIONS from this at module load.
+  INTEGRATION_AUDIT_INTEGRATION_NAMES: ['github', 'atlassian', 'slack', 'linear', 'notion', 'optihashi'],
 }));
 
 vi.mock('@server/utils/cloudwatch', () => ({

--- a/apps/client/server/utils/invokeMcpHandler.ts
+++ b/apps/client/server/utils/invokeMcpHandler.ts
@@ -5,7 +5,11 @@ import { isMcpServerAvailable } from '@server/services/integrationCircuitBreaker
 import { getBreaker, classifyOperation, CircuitBreakerError } from '@server/services/mcpCircuitBreakers';
 import { IntegrationAuditLogger } from '@server/integrations/integrationAuditLogger';
 import type { IntegrationAuditIntegrationName } from '@bike4mind/database';
-import { rateLimitSnapshotRepository, type IntegrationType } from '@bike4mind/database';
+import {
+  rateLimitSnapshotRepository,
+  type IntegrationType,
+  INTEGRATION_AUDIT_INTEGRATION_NAMES,
+} from '@bike4mind/database';
 import { recordRateLimitEvent, recordCircuitBreakerRejection } from '@server/utils/cloudwatch';
 import {
   normalizeEndpoint,
@@ -16,7 +20,8 @@ import {
 import { randomUUID } from 'crypto';
 import { Resource } from 'sst';
 
-const AUDITABLE_INTEGRATIONS = new Set<string>(['github', 'atlassian', 'slack', 'linear', 'notion']);
+// Shared const so the auditable set can never drift from the model's enum.
+const AUDITABLE_INTEGRATIONS = new Set<string>(INTEGRATION_AUDIT_INTEGRATION_NAMES);
 
 const shouldRunLocally = () => process.env.IS_LOCAL === 'true' || process.env.NODE_ENV === 'development';
 

--- a/packages/database/src/models/infra/integrations/IntegrationAuditLogModel.ts
+++ b/packages/database/src/models/infra/integrations/IntegrationAuditLogModel.ts
@@ -7,9 +7,21 @@ import BaseRepository from '@bike4mind/db-core';
 export type IntegrationAuditEntityType = 'oauth' | 'webhook' | 'mcp_tool' | 'token_refresh';
 
 /**
- * Supported integration names
+ * Supported integration names. Single source of truth for BOTH the TS type and
+ * the Mongoose schema enum below - keep them derived from this one const so they
+ * can never drift (a type that listed 'optihashi' while the schema enum did not
+ * caused every OptiHashi webhook's audit-log write to fail runtime validation).
  */
-export type IntegrationAuditIntegrationName = 'github' | 'atlassian' | 'slack' | 'linear' | 'notion' | 'optihashi';
+export const INTEGRATION_AUDIT_INTEGRATION_NAMES = [
+  'github',
+  'atlassian',
+  'slack',
+  'linear',
+  'notion',
+  'optihashi',
+] as const;
+
+export type IntegrationAuditIntegrationName = (typeof INTEGRATION_AUDIT_INTEGRATION_NAMES)[number];
 
 /**
  * Outcome of the audited operation
@@ -81,7 +93,8 @@ const IntegrationAuditLogSchema = new Schema<IIntegrationAuditLogDocument>(
     integrationName: {
       type: String,
       required: true,
-      enum: ['github', 'atlassian', 'slack', 'linear', 'notion'],
+      // Derived from the shared const so this can never drift from the TS type.
+      enum: [...INTEGRATION_AUDIT_INTEGRATION_NAMES],
     },
     action: { type: String, required: true },
     userId: { type: String, index: true },

--- a/packages/database/src/models/infra/integrations/__tests__/IntegrationAuditLogModel.test.ts
+++ b/packages/database/src/models/infra/integrations/__tests__/IntegrationAuditLogModel.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+import { createMongoServer } from '../../../../__test__/createMongoServer';
+import {
+  IntegrationAuditLogModel,
+  integrationAuditLogRepository,
+  INTEGRATION_AUDIT_INTEGRATION_NAMES,
+  type CreateIntegrationAuditLogInput,
+} from '../IntegrationAuditLogModel';
+
+const baseLog = (overrides: Partial<CreateIntegrationAuditLogInput> = {}): CreateIntegrationAuditLogInput => ({
+  entityType: 'webhook',
+  integrationName: 'optihashi',
+  action: 'webhook_run.completed',
+  requestId: 'req-1',
+  sourceIp: '127.0.0.1',
+  userAgent: 'test',
+  outcome: 'success',
+  durationMs: 0,
+  ...overrides,
+});
+
+describe('IntegrationAuditLogModel', () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await createMongoServer();
+    await mongoose.connect(mongoServer.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer?.stop();
+  });
+
+  afterEach(async () => {
+    await IntegrationAuditLogModel.deleteMany({});
+  });
+
+  // Regression: the schema enum previously omitted 'optihashi' while the TS type
+  // included it, so every OptiHashi webhook's audit write failed enum validation.
+  it("accepts 'optihashi' as a valid integrationName", async () => {
+    const log = await integrationAuditLogRepository.createLog(baseLog({ integrationName: 'optihashi' }));
+    expect(log.integrationName).toBe('optihashi');
+  });
+
+  it('accepts every name in the shared const (schema enum stays in sync with the type)', async () => {
+    for (const name of INTEGRATION_AUDIT_INTEGRATION_NAMES) {
+      const log = await integrationAuditLogRepository.createLog(baseLog({ integrationName: name }));
+      expect(log.integrationName).toBe(name);
+    }
+  });
+
+  it('still rejects an unknown integrationName (enum enforcement intact)', async () => {
+    await expect(
+      // @ts-expect-error - deliberately invalid value to prove enum still enforces
+      integrationAuditLogRepository.createLog(baseLog({ integrationName: 'bogus' }))
+    ).rejects.toThrow(/enum|validation/i);
+  });
+});


### PR DESCRIPTION
## Summary

The `IntegrationAuditLog` schema's `integrationName` enum omitted `'optihashi'` even though the TS type (`IntegrationAuditIntegrationName`) already listed it. As a result, every OptiHashi webhook's audit-log write failed runtime enum validation in production.

**Impact:** non-fatal — the webhook itself still processes (the audit-log write is a caught side effect, enqueued before it runs, so no 500 and no provider retry), but each delivery logged a validation error and dropped its audit record.

Observed live in prod during the compute test run:
```
IntegrationAuditLog validation failed: integrationName `optihashi` is not a
valid enum value for path `integrationName`. enumValues: [github,atlassian,slack,linear,notion]
```

## Fix

Derive **both** the TS type and the Mongoose schema enum from one shared const, `INTEGRATION_AUDIT_INTEGRATION_NAMES`, so the two can never drift again (the drift is exactly what caused this).

## Test plan

- [x] New model test (`createMongoServer`): `'optihashi'` is accepted, every name in the shared const is accepted, and an unknown name is still rejected (enum enforcement intact).
- [x] `@bike4mind/database` typecheck clean; lint clean on changed files.

_Note: 3 pre-existing `CreditLotModel` test/type failures on `main` are unrelated to this change (stale-dist / separate merge) and reproduce on a clean checkout._