### PR TITLE
fix(client): persist preference toggles to the user store so they survive reload

### DIFF
--- a/apps/client/app/contexts/UserSettingsContext.test.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.test.tsx
@@ -19,9 +19,21 @@ const defaultMockUserState = (): MockUserState => ({
 
 let mockUserState: MockUserState = defaultMockUserState();
 
+// `updatePreferences` now writes through to the store via `useUser.getState().setCurrentUser(...)`,
+// so the mock must expose `getState` (real zustand does) whose `setCurrentUser` mutates the shared
+// mock state. Object.assign keeps the selector-call form typed without `any`.
 vi.mock('@client/app/contexts/UserContext', () => ({
-  useUser: (selector?: (s: MockUserState) => unknown) =>
-    selector ? selector(mockUserState) : mockUserState.currentUser,
+  useUser: Object.assign(
+    (selector?: (s: MockUserState) => unknown) => (selector ? selector(mockUserState) : mockUserState.currentUser),
+    {
+      getState: () => ({
+        currentUser: mockUserState.currentUser,
+        setCurrentUser: (user: unknown) => {
+          mockUserState.currentUser = user;
+        },
+      }),
+    }
+  ),
 }));
 
 vi.mock('@client/app/contexts/TranslationProvider', () => ({
@@ -97,6 +109,20 @@ describe('UserSettingsContext — rawExperimentalPreferences optimistic update',
 
     expect(result.current.rawExperimentalPreferences.enableArtifacts).toBe(true);
     expect(result.current.rawExperimentalPreferences.enableAgents).toBe(true);
+  });
+
+  // guards the store write-through in updatePreferences (delete that line -> this fails).
+  it('writes the toggled preference through to the useUser store', () => {
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.updatePreferences({ experimentalFeatures: { enableAgents: true } });
+    });
+
+    const stored = mockUserState.currentUser as {
+      preferences: { experimentalFeatures: Record<string, boolean> };
+    };
+    expect(stored.preferences.experimentalFeatures.enableAgents).toBe(true);
   });
 });
 

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -246,6 +246,10 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
             }
           : {}),
       };
+      // Write through to the store, not just the server: otherwise the stale value is persisted and
+      // reseeded as identify initialData (5-min staleTime skips the refetch), reverting on reload when
+      // the `users` socket is silent. See useGetIdentify initialData guard.
+      useUser.getState().setCurrentUser({ ...currentUser, preferences: fullPreferences });
       updateUserToServer(currentUser.id, { preferences: fullPreferences }).catch(() => {
         console.warn('[UserSettings] Failed to write preferences to server');
       });


### PR DESCRIPTION
## Problem

Toggling an experimental feature (e.g. **Agents**) in Profile - Settings, then refreshing the page, silently reverts the toggle to its previous value. The change appears to save, but is gone after reload.

## Root cause

`updatePreferences` (in `UserSettingsContext`) wrote the new preference to the server but never updated the zustand `useUser` store. `currentUser.preferences` was only reconciled via the `users` websocket echo. When that socket isn't delivering (e.g. local self-host without the subscriber-fanout/ws containers, or any dropped socket), the stale pre-toggle value stays in the store, gets persisted (zustand persist), and is reseeded as `useGetIdentify` `initialData` on reload. Under the 5-minute `staleTime`, that `initialData` suppresses the `/api/identify` network refetch entirely, so the freshly-saved value never lands and the toggle reverts.

This is why it works in production (the ws echo repairs the store between the write and the next reload) but fails whenever the socket is unavailable.

## Fix

Write the merged preferences straight into the store in `updatePreferences`, so the change is durable regardless of the websocket:

```ts
useUser.getState().setCurrentUser({ ...currentUser, preferences: fullPreferences });
```

## Verification

- Reproduced with the fix disabled + ws down: toggle OFF -> reload -> reverts to ON. Instrumented logs confirmed the exact chain (server write succeeds, store never updated, stale stub reseeds identify initialData, network identify suppressed by staleTime).
- With the fix: toggle OFF -> reload -> stays OFF; toggle ON -> reload -> stays ON. Both directions verified end-to-end on a clean self-host build.
- Added a regression test that pins the store write-through (deleting the fix line fails it). Updated the `UserContext` mock to expose `getState`/`setCurrentUser`. `UserSettingsContext.test.tsx`: 6/6 pass.