### PR TITLE
feat(sre): hide closed-GitHub-issue tracking in Pipeline Status by default

### DIFF
--- a/apps/client/__tests__/api/webhooks/github/sre.handler.test.ts
+++ b/apps/client/__tests__/api/webhooks/github/sre.handler.test.ts
@@ -63,8 +63,10 @@ vi.mock('@bike4mind/observability', () => {
 });
 
 const mockDispatchIssueToSre = vi.fn().mockResolvedValue({ dispatched: true });
+const mockSyncSreIssueStateFromWebhook = vi.fn().mockResolvedValue(undefined);
 vi.mock('@server/integrations/github/sreWebhookDispatch', () => ({
   dispatchIssueToSre: (...args: unknown[]) => mockDispatchIssueToSre(...args),
+  syncSreIssueStateFromWebhook: (...args: unknown[]) => mockSyncSreIssueStateFromWebhook(...args),
   SreIssuePayloadSchema: { safeParse: (payload: unknown) => ({ success: true, data: payload }) },
 }));
 
@@ -159,5 +161,24 @@ describe('SRE webhook handler — secret decrypt with key rotation', () => {
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(mockDispatchIssueToSre).not.toHaveBeenCalled();
+  });
+
+  it('syncs githubIssueState for a valid issues event (keeps the admin filter fresh)', async () => {
+    mockResolveWebhookSecret.mockReturnValue(secretEncryptedWithPreviousKey);
+    const closedBody = JSON.stringify({
+      action: 'closed',
+      issue: { number: 7, title: 't', body: 'b', labels: [] },
+      repository: { full_name: REPO_SLUG },
+      sender: { login: 'octocat' },
+    });
+
+    const { req, res } = createReqRes(closedBody, signPayload(closedBody, PLAINTEXT_SECRET));
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockSyncSreIssueStateFromWebhook).toHaveBeenCalledTimes(1);
+    // Handler forwards the parsed payload; the sync fn decides open/closed from action.
+    expect(mockSyncSreIssueStateFromWebhook.mock.calls[0][0]).toMatchObject({ action: 'closed' });
   });
 });

--- a/apps/client/app/components/admin/SreAgentTab.tsx
+++ b/apps/client/app/components/admin/SreAgentTab.tsx
@@ -1263,7 +1263,11 @@ export function PipelineTrackingCard({ doc }: { doc: TrackingDocSummary }) {
     staleTime: 30_000,
   });
 
-  const isGithubIssue = doc.source === 'GITHUB_ISSUE' && !!doc.githubIssueNumber;
+  // Fire the issue-state self-heal for any GitHub-issue doc, even one whose issue
+  // number is not yet backfilled onto githubIssueNumber (it still lives in the
+  // server-side sourceRef URL, which the endpoint parses and backfills). Gating on
+  // githubIssueNumber here would leave such a doc unable to reconcile from its card.
+  const isGithubIssue = doc.source === 'GITHUB_ISSUE';
 
   const { data: issueState } = useQuery({
     queryKey: ['sre-issue-state', docId],

--- a/apps/client/app/components/admin/SreAgentTab.tsx
+++ b/apps/client/app/components/admin/SreAgentTab.tsx
@@ -17,6 +17,7 @@ import {
   Button,
   Card,
   CardContent,
+  Checkbox,
   Chip,
   CircularProgress,
   DialogActions,
@@ -1162,6 +1163,7 @@ type TrackingDocSummary = Partial<Pick<ISreErrorTracking, 'id'>> &
     | 'classification'
     | 'fixPrNumber'
     | 'githubIssueNumber'
+    | 'githubIssueState'
     | 'createdAt'
     | 'updatedAt'
   > & {
@@ -1175,6 +1177,44 @@ function getDocId(doc: TrackingDocSummary): string | undefined {
 }
 
 export { type TrackingDocSummary, getDocId };
+
+/**
+ * A doc is hidden by the "hide closed GitHub issues" filter only when its
+ * denormalized githubIssueState is 'closed'. CloudWatch-sourced docs (no linked
+ * issue) and GitHub docs whose state has not been observed yet (githubIssueState
+ * absent, or 'open') always stay visible - so the filter never hides in-flight
+ * work on a false or missing state.
+ */
+export function isClosedGithubIssueDoc(doc: Pick<TrackingDocSummary, 'githubIssueState'>): boolean {
+  return doc.githubIssueState === 'closed';
+}
+
+/** sessionStorage key persisting the Pipeline Status "hide closed GH issues" toggle across the session. */
+const HIDE_CLOSED_ISSUES_STORAGE_KEY = 'sre-pipeline-hide-closed-issues';
+
+/**
+ * Session-persisted boolean toggle, defaulting to `true` (hide closed-issue
+ * tracking on first open, per the issue's default view). Persistence uses
+ * sessionStorage so it survives tab navigation but resets in a new session.
+ */
+function useHideClosedIssues(): [boolean, (next: boolean) => void] {
+  const [hide, setHide] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
+    const stored = window.sessionStorage.getItem(HIDE_CLOSED_ISSUES_STORAGE_KEY);
+    return stored === null ? true : stored === 'true';
+  });
+
+  const update = useCallback((next: boolean) => {
+    setHide(next);
+    try {
+      window.sessionStorage.setItem(HIDE_CLOSED_ISSUES_STORAGE_KEY, String(next));
+    } catch {
+      // sessionStorage can throw (private mode / quota) - persistence is best-effort.
+    }
+  }, []);
+
+  return [hide, update];
+}
 
 // Keep in sync with RETRYABLE_STATUSES in packages/database/src/models/SreErrorTrackingModel.ts
 // (cannot import from @bike4mind/database in client components - pulls in node:fs via documentdb-cert-manager)
@@ -1894,8 +1934,9 @@ function ScanSection({ repoSlugs }: { repoSlugs: string[] }) {
   );
 }
 
-function PipelineStatusPanel({ repoSlugs }: { repoSlugs: string[] }) {
+export function PipelineStatusPanel({ repoSlugs }: { repoSlugs: string[] }) {
   const [selectedRepo, setSelectedRepo] = useState<string>('');
+  const [hideClosedIssues, setHideClosedIssues] = useHideClosedIssues();
 
   const { data: trackingDocs, isLoading } = useQuery({
     queryKey: ['sre-tracking-recent', selectedRepo],
@@ -1907,6 +1948,13 @@ function PipelineStatusPanel({ repoSlugs }: { repoSlugs: string[] }) {
     staleTime: 30_000,
     refetchInterval: 60_000,
   });
+
+  const visibleDocs = useMemo(
+    () => (hideClosedIssues ? (trackingDocs ?? []).filter(doc => !isClosedGithubIssueDoc(doc)) : (trackingDocs ?? [])),
+    [trackingDocs, hideClosedIssues]
+  );
+
+  const hiddenByFilterCount = (trackingDocs?.length ?? 0) - visibleDocs.length;
 
   return (
     <Stack spacing={1.5}>
@@ -1928,6 +1976,13 @@ function PipelineStatusPanel({ repoSlugs }: { repoSlugs: string[] }) {
           </Select>
         </FormControl>
       )}
+      <Checkbox
+        size="sm"
+        label="Hide tracking for closed GitHub issues"
+        checked={hideClosedIssues}
+        onChange={e => setHideClosedIssues(e.target.checked)}
+        data-testid="sre-pipeline-hide-closed-toggle"
+      />
       <ManualTriggerSection repoSlugs={repoSlugs} />
       <ScanSection repoSlugs={repoSlugs} />
       {isLoading ? (
@@ -1936,11 +1991,26 @@ function PipelineStatusPanel({ repoSlugs }: { repoSlugs: string[] }) {
         <Alert variant="soft" color="neutral">
           No tracked errors yet. The pipeline will populate this once errors are ingested.
         </Alert>
+      ) : !visibleDocs.length ? (
+        <Alert variant="soft" color="neutral" data-testid="sre-pipeline-all-hidden">
+          {hiddenByFilterCount === 1
+            ? '1 tracked error is for a closed GitHub issue. Uncheck the filter above to see it.'
+            : `${hiddenByFilterCount} tracked errors are for closed GitHub issues. Uncheck the filter above to see them.`}
+        </Alert>
       ) : (
-        trackingDocs.map(doc => {
-          const key = getDocId(doc) ?? doc.errorFingerprint;
-          return <PipelineTrackingCard key={key} doc={doc} />;
-        })
+        <>
+          {hideClosedIssues && hiddenByFilterCount > 0 && (
+            <Typography level="body-xs" sx={{ color: 'text.tertiary' }} data-testid="sre-pipeline-hidden-count">
+              {hiddenByFilterCount === 1
+                ? '1 closed-issue doc hidden'
+                : `${hiddenByFilterCount} closed-issue docs hidden`}
+            </Typography>
+          )}
+          {visibleDocs.map(doc => {
+            const key = getDocId(doc) ?? doc.errorFingerprint;
+            return <PipelineTrackingCard key={key} doc={doc} />;
+          })}
+        </>
       )}
     </Stack>
   );

--- a/apps/client/app/components/admin/__tests__/PipelineStatusPanel.test.tsx
+++ b/apps/client/app/components/admin/__tests__/PipelineStatusPanel.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: mockGet, post: mockPost },
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn(), warning: vi.fn() }),
+}));
+
+vi.mock('@client/app/utils/react-query', () => ({
+  replaceQueryData: vi.fn(),
+  setOptimisticQueryData: vi.fn(),
+  updateSingleQueryDataFast: vi.fn(),
+}));
+
+import { PipelineStatusPanel, isClosedGithubIssueDoc, type TrackingDocSummary } from '../SreAgentTab';
+
+const HIDE_TOGGLE_LABEL = 'Hide tracking for closed GitHub issues';
+const STORAGE_KEY = 'sre-pipeline-hide-closed-issues';
+
+// A: open GitHub issue (visible always). B: closed GitHub issue (hidden by default).
+// C: CloudWatch, no linked issue (visible always). D: GitHub issue, state never observed (visible always).
+const docs: TrackingDocSummary[] = [
+  {
+    id: 'A',
+    _id: 'A',
+    errorFingerprint: 'fpAAAAAAAAAA',
+    repoSlug: 'owner/repo',
+    source: 'GITHUB_ISSUE',
+    status: 'awaiting_approval',
+    githubIssueNumber: 1,
+    githubIssueState: 'open',
+    errorMessage: 'Open issue error',
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+  },
+  {
+    id: 'B',
+    _id: 'B',
+    errorFingerprint: 'fpBBBBBBBBBB',
+    repoSlug: 'owner/repo',
+    source: 'GITHUB_ISSUE',
+    status: 'fixed',
+    githubIssueNumber: 2,
+    githubIssueState: 'closed',
+    errorMessage: 'Closed issue error',
+    createdAt: new Date('2026-07-02T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-02T00:00:00.000Z'),
+  },
+  {
+    id: 'C',
+    _id: 'C',
+    errorFingerprint: 'fpCCCCCCCCCC',
+    repoSlug: 'owner/repo',
+    source: 'CLOUDWATCH',
+    status: 'analyzing',
+    errorMessage: 'CloudWatch error',
+    createdAt: new Date('2026-07-03T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-03T00:00:00.000Z'),
+  },
+  {
+    id: 'D',
+    _id: 'D',
+    errorFingerprint: 'fpDDDDDDDDDD',
+    repoSlug: 'owner/repo',
+    source: 'GITHUB_ISSUE',
+    status: 'failed',
+    githubIssueNumber: 4,
+    // githubIssueState intentionally absent - state not yet observed
+    errorMessage: 'Unobserved issue error',
+    createdAt: new Date('2026-07-04T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-04T00:00:00.000Z'),
+  },
+];
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const theme = extendTheme({ ...getThemeConfig() });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CssVarsProvider theme={theme}>
+        <PipelineStatusPanel repoSlugs={['owner/repo']} />
+      </CssVarsProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('isClosedGithubIssueDoc', () => {
+  it('is true only when githubIssueState is "closed"', () => {
+    expect(isClosedGithubIssueDoc({ githubIssueState: 'closed' })).toBe(true);
+    expect(isClosedGithubIssueDoc({ githubIssueState: 'open' })).toBe(false);
+    expect(isClosedGithubIssueDoc({ githubIssueState: undefined })).toBe(false);
+    expect(isClosedGithubIssueDoc({})).toBe(false);
+  });
+});
+
+describe('PipelineStatusPanel - closed-issue filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    mockGet.mockImplementation((url: string) => {
+      if (url.endsWith('/issue-state')) return Promise.resolve({ data: { state: 'open' } });
+      if (url === '/api/sre/tracking' || url.startsWith('/api/sre/tracking?')) {
+        return Promise.resolve({ data: docs });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    mockPost.mockResolvedValue({ data: {} });
+  });
+
+  it('checks the "hide closed issues" toggle by default and hides closed-issue docs', async () => {
+    renderPanel();
+
+    await screen.findByTestId('sre-tracking-card-A');
+
+    // Toggle is checked by default.
+    expect(screen.getByLabelText(HIDE_TOGGLE_LABEL)).toBeChecked();
+
+    // Open GitHub issue, CloudWatch, and never-observed GitHub docs stay visible.
+    expect(screen.getByTestId('sre-tracking-card-A')).toBeInTheDocument();
+    expect(screen.getByTestId('sre-tracking-card-C')).toBeInTheDocument();
+    expect(screen.getByTestId('sre-tracking-card-D')).toBeInTheDocument();
+
+    // Closed GitHub issue doc is hidden.
+    expect(screen.queryByTestId('sre-tracking-card-B')).not.toBeInTheDocument();
+
+    // Surfaces how many were hidden so operators know the tail exists.
+    expect(screen.getByTestId('sre-pipeline-hidden-count')).toHaveTextContent('1 closed-issue doc hidden');
+  });
+
+  it('shows closed-issue docs when the toggle is unchecked', async () => {
+    renderPanel();
+    await screen.findByTestId('sre-tracking-card-A');
+
+    fireEvent.click(screen.getByLabelText(HIDE_TOGGLE_LABEL));
+
+    await waitFor(() => expect(screen.getByTestId('sre-tracking-card-B')).toBeInTheDocument());
+    // All four now visible; nothing hidden.
+    expect(screen.getByTestId('sre-tracking-card-A')).toBeInTheDocument();
+    expect(screen.getByTestId('sre-tracking-card-C')).toBeInTheDocument();
+    expect(screen.getByTestId('sre-tracking-card-D')).toBeInTheDocument();
+    expect(screen.queryByTestId('sre-pipeline-hidden-count')).not.toBeInTheDocument();
+  });
+
+  it('never hides CloudWatch-sourced docs regardless of toggle state', async () => {
+    renderPanel();
+    await screen.findByTestId('sre-tracking-card-C');
+
+    // Visible while filter is on...
+    expect(screen.getByTestId('sre-tracking-card-C')).toBeInTheDocument();
+
+    // ...and still visible after toggling off.
+    fireEvent.click(screen.getByLabelText(HIDE_TOGGLE_LABEL));
+    await waitFor(() => expect(screen.getByTestId('sre-tracking-card-B')).toBeInTheDocument());
+    expect(screen.getByTestId('sre-tracking-card-C')).toBeInTheDocument();
+  });
+
+  it('persists the toggle state to sessionStorage and restores it on mount', async () => {
+    // Pre-seed an unchecked preference from a prior render in the same session.
+    window.sessionStorage.setItem(STORAGE_KEY, 'false');
+
+    renderPanel();
+    await screen.findByTestId('sre-tracking-card-A');
+
+    // Restored as unchecked -> closed doc B visible.
+    expect(screen.getByLabelText(HIDE_TOGGLE_LABEL)).not.toBeChecked();
+    expect(screen.getByTestId('sre-tracking-card-B')).toBeInTheDocument();
+
+    // Re-checking writes the preference back.
+    fireEvent.click(screen.getByLabelText(HIDE_TOGGLE_LABEL));
+    await waitFor(() => expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('true'));
+  });
+
+  it('shows an explanatory message when every doc is filtered out', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.endsWith('/issue-state')) return Promise.resolve({ data: { state: 'closed' } });
+      if (url === '/api/sre/tracking' || url.startsWith('/api/sre/tracking?')) {
+        return Promise.resolve({ data: [docs[1]] }); // only the closed-issue doc
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    renderPanel();
+
+    const emptyState = await screen.findByTestId('sre-pipeline-all-hidden');
+    expect(emptyState).toHaveTextContent('closed GitHub issue');
+    expect(screen.queryByTestId('sre-tracking-card-B')).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/admin/__tests__/PipelineStatusPanel.test.tsx
+++ b/apps/client/app/components/admin/__tests__/PipelineStatusPanel.test.tsx
@@ -182,6 +182,39 @@ describe('PipelineStatusPanel - closed-issue filter', () => {
     await waitFor(() => expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('true'));
   });
 
+  it('fires the issue-state self-heal for a GitHub-issue doc whose number is not yet backfilled', async () => {
+    // GITHUB_ISSUE doc with githubIssueNumber absent - its number lives only in the
+    // server-side sourceRef. The card must still call the issue-state endpoint so
+    // the server can parse sourceRef, backfill, and reconcile githubIssueState.
+    const numberless: TrackingDocSummary = {
+      id: 'E',
+      _id: 'E',
+      errorFingerprint: 'fpEEEEEEEEEE',
+      repoSlug: 'owner/repo',
+      source: 'GITHUB_ISSUE',
+      status: 'detected',
+      // githubIssueNumber intentionally absent
+      errorMessage: 'Numberless issue error',
+      createdAt: new Date('2026-07-05T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-05T00:00:00.000Z'),
+    };
+    mockGet.mockImplementation((url: string) => {
+      if (url.endsWith('/issue-state')) return Promise.resolve({ data: { state: 'open' } });
+      if (url === '/api/sre/tracking' || url.startsWith('/api/sre/tracking?')) {
+        return Promise.resolve({ data: [numberless, docs[2]] }); // numberless GH doc + a CloudWatch doc
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    renderPanel();
+    await screen.findByTestId('sre-tracking-card-E');
+
+    // The numberless GitHub-issue doc still triggers the self-heal fetch...
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith('/api/sre/tracking/E/issue-state'));
+    // ...while the CloudWatch doc (no linked issue) never does.
+    expect(mockGet).not.toHaveBeenCalledWith('/api/sre/tracking/C/issue-state');
+  });
+
   it('shows an explanatory message when every doc is filtered out', async () => {
     mockGet.mockImplementation((url: string) => {
       if (url.endsWith('/issue-state')) return Promise.resolve({ data: { state: 'closed' } });

--- a/apps/client/pages/api/sre/tracking/[id]/issue-state.ts
+++ b/apps/client/pages/api/sre/tracking/[id]/issue-state.ts
@@ -64,6 +64,19 @@ const handler = baseApi().get(
         return;
       }
 
+      // Self-heal the denormalized githubIssueState the admin filter relies on.
+      // The webhook handlers are the primary freshness source, but this backfills
+      // docs created before webhooks fired (or that missed a delivery): every time
+      // a GitHub-issue card renders it fetches live state here, so viewing the
+      // pipeline eventually reconciles stale/absent state without a cron sweep.
+      if (issue.state === 'open' || issue.state === 'closed') {
+        try {
+          await sreErrorTrackingRepository.setGithubIssueState(systemRepo, issueNumber, issue.state);
+        } catch (err) {
+          logger.warn('[SRE-ISSUE-STATE] Failed to persist githubIssueState', { id: doc.id, err });
+        }
+      }
+
       res.status(200).json({ state: issue.state, closedAt: issue.closed_at });
     } catch {
       res.status(200).json({ state: 'unknown', error: 'github-unavailable' });

--- a/apps/client/pages/api/sre/tracking/[id]/issue-state.ts
+++ b/apps/client/pages/api/sre/tracking/[id]/issue-state.ts
@@ -72,6 +72,13 @@ const handler = baseApi().get(
       if (issue.state === 'open' || issue.state === 'closed') {
         try {
           await sreErrorTrackingRepository.setGithubIssueState(systemRepo, issueNumber, issue.state);
+          // The bulk update above is scoped by repoSlug; a doc missing repoSlug is
+          // silently skipped (systemRepo fell back to the default, which won't match
+          // an absent field). We hold this doc's id, so reconcile it directly as a
+          // backstop for that edge - otherwise the viewed doc never self-heals.
+          if (!doc.repoSlug) {
+            await sreErrorTrackingRepository.setGithubIssueStateById(doc.id, issue.state);
+          }
         } catch (err) {
           logger.warn('[SRE-ISSUE-STATE] Failed to persist githubIssueState', { id: doc.id, err });
         }

--- a/apps/client/pages/api/webhooks/github/sre.ts
+++ b/apps/client/pages/api/webhooks/github/sre.ts
@@ -26,7 +26,11 @@ import {
 import { WebhookAuditLogger, extractWebhookMetadata } from '@server/integrations/github/WebhookAuditLogger';
 import { IntegrationAuditLogger } from '@server/integrations/integrationAuditLogger';
 import { decryptToken } from '@server/security/tokenEncryption';
-import { dispatchIssueToSre, SreIssuePayloadSchema } from '@server/integrations/github/sreWebhookDispatch';
+import {
+  dispatchIssueToSre,
+  syncSreIssueStateFromWebhook,
+  SreIssuePayloadSchema,
+} from '@server/integrations/github/sreWebhookDispatch';
 import { dispatchReviewToSreRevision } from '@server/integrations/github/sreRevisionDispatch';
 import { serializeError } from '@server/utils/serializeError';
 import { randomUUID } from 'crypto';
@@ -192,6 +196,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           });
           return res.status(200).json({ success: true, message: 'Accepted' });
         }
+
+        // Keep the denormalized githubIssueState fresh for the admin filter.
+        // Runs for closed/reopened (dispatchIssueToSre drops `closed` at its
+        // eligibility gate, so this is the only path that records a close here).
+        // No-ops for other actions; swallows its own errors.
+        await syncSreIssueStateFromWebhook(parseResult.data, logger);
 
         const result = await dispatchIssueToSre(parseResult.data, logger, correlationId);
         logger.info('[SRE-WEBHOOK] Issue dispatch complete', {

--- a/apps/client/server/integrations/github/handlers/IssuesHandler.ts
+++ b/apps/client/server/integrations/github/handlers/IssuesHandler.ts
@@ -27,7 +27,7 @@ import {
   buildIssueAssignedBlocks,
 } from '@bike4mind/slack';
 import { webhookSubscriptionRepository, User } from '@bike4mind/database';
-import { dispatchIssueToSre } from '../sreWebhookDispatch';
+import { dispatchIssueToSre, syncSreIssueStateFromWebhook } from '../sreWebhookDispatch';
 import { emptyNotifyResult, mergeNotifyResults, toHandlerResult } from './notifyResultUtils';
 
 export class IssuesHandler implements GitHubEventHandler {
@@ -228,6 +228,10 @@ export class IssuesHandler implements GitHubEventHandler {
     repo: string,
     options?: { orgId?: string }
   ): Promise<NotifyResult> {
+    // Keep the denormalized githubIssueState fresh for the SRE admin filter.
+    // Runs before the self-close early-return below so state is always recorded.
+    await syncSreIssueStateFromWebhook(issues, this.logger);
+
     const issueAuthor = issues.issue.user.login;
     const closedBy = issues.sender?.login || 'unknown';
 
@@ -313,6 +317,9 @@ export class IssuesHandler implements GitHubEventHandler {
    * prior fix on the same fingerprint and escalates to a human.
    */
   private async handleReopened(issues: GitHubIssuesPayload, repo: string): Promise<void> {
+    // Record the reopen (issue is open again) before re-dispatching for analysis.
+    await syncSreIssueStateFromWebhook(issues, this.logger);
+
     try {
       await this.dispatchToSreIfMatching(issues, repo);
     } catch (error) {

--- a/apps/client/server/integrations/github/handlers/__tests__/IssuesHandler.test.ts
+++ b/apps/client/server/integrations/github/handlers/__tests__/IssuesHandler.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Hoist mock functions to avoid initialization issues
-const { mockNotify, mockFindByOrgAndRepo, mockUserFind, mockDispatchIssueToSre } = vi.hoisted(() => ({
-  mockNotify: vi.fn(),
-  mockFindByOrgAndRepo: vi.fn(),
-  mockUserFind: vi.fn(),
-  mockDispatchIssueToSre: vi.fn(),
-}));
+const { mockNotify, mockFindByOrgAndRepo, mockUserFind, mockDispatchIssueToSre, mockSyncSreIssueState } = vi.hoisted(
+  () => ({
+    mockNotify: vi.fn(),
+    mockFindByOrgAndRepo: vi.fn(),
+    mockUserFind: vi.fn(),
+    mockDispatchIssueToSre: vi.fn(),
+    mockSyncSreIssueState: vi.fn(),
+  })
+);
 
 vi.mock('@bike4mind/slack', () => ({
   GitHubSlackNotifier: vi.fn().mockImplementation(function () {
@@ -28,6 +31,7 @@ vi.mock('@bike4mind/database', () => ({
 
 vi.mock('@server/integrations/github/sreWebhookDispatch', () => ({
   dispatchIssueToSre: mockDispatchIssueToSre,
+  syncSreIssueStateFromWebhook: mockSyncSreIssueState,
 }));
 
 import { IssuesHandler } from '@server/integrations/github/handlers/IssuesHandler';
@@ -76,6 +80,7 @@ describe('IssuesHandler', () => {
       }),
     });
     mockDispatchIssueToSre.mockResolvedValue({ dispatched: false, reason: 'pipeline-disabled' });
+    mockSyncSreIssueState.mockResolvedValue(undefined);
     const notifier = new GitHubSlackNotifier({} as never);
     handler = new IssuesHandler(notifier);
   });
@@ -165,6 +170,39 @@ describe('IssuesHandler', () => {
         expect(mockDispatchIssueToSre).toHaveBeenCalled();
       }
     );
+  });
+
+  describe('githubIssueState sync (admin "hide closed issues" filter)', () => {
+    it('syncs issue state on "closed" so the tracking doc reflects the close', async () => {
+      const payload = createIssuesPayload({ action: 'closed' });
+      (payload as GitHubIssuesPayload).sender = { login: 'closer-user' } as GitHubIssuesPayload['sender'];
+      await handler.handle(payload, mockMcpServer);
+      expect(mockSyncSreIssueState).toHaveBeenCalledTimes(1);
+      expect(mockSyncSreIssueState.mock.calls[0][0]).toBe(payload);
+    });
+
+    it('syncs issue state on "closed" even when the author closed their own issue (no Slack notification path)', async () => {
+      // Author == closer short-circuits the Slack notification, but the state
+      // sync must still run - it's placed before that early return.
+      const payload = createIssuesPayload({ action: 'closed', author: 'self-closer' });
+      (payload as GitHubIssuesPayload).sender = { login: 'self-closer' } as GitHubIssuesPayload['sender'];
+      await handler.handle(payload, mockMcpServer);
+      expect(mockNotify).not.toHaveBeenCalled();
+      expect(mockSyncSreIssueState).toHaveBeenCalledTimes(1);
+    });
+
+    it('syncs issue state on "reopened"', async () => {
+      const payload = createIssuesPayload({ action: 'reopened' });
+      await handler.handle(payload, mockMcpServer);
+      expect(mockSyncSreIssueState).toHaveBeenCalledTimes(1);
+      expect(mockSyncSreIssueState.mock.calls[0][0]).toBe(payload);
+    });
+
+    it('does not sync issue state on "opened" (state is already open at creation)', async () => {
+      const payload = createIssuesPayload({ action: 'opened' });
+      await handler.handle(payload, mockMcpServer);
+      expect(mockSyncSreIssueState).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleOpened - assignee notifications', () => {

--- a/apps/client/server/integrations/github/sreWebhookDispatch.test.ts
+++ b/apps/client/server/integrations/github/sreWebhookDispatch.test.ts
@@ -6,6 +6,7 @@ const mockSendToQueue = vi.fn();
 const mockGetSourceQueueUrl = vi.fn(() => 'https://sqs.example.com/sreJobQueue');
 const mockResolveFullConfig = vi.fn();
 const mockGetConfiguredRepoSlugs = vi.fn();
+const mockSetGithubIssueState = vi.fn();
 
 vi.mock('@bike4mind/database', () => ({
   adminSettingsRepository: {
@@ -13,6 +14,9 @@ vi.mock('@bike4mind/database', () => ({
   },
   cacheRepository: {
     incrementCounterConditional: (...args: unknown[]) => mockIncrementCounterConditional(...args),
+  },
+  sreErrorTrackingRepository: {
+    setGithubIssueState: (...args: unknown[]) => mockSetGithubIssueState(...args),
   },
 }));
 
@@ -32,7 +36,7 @@ vi.mock('@server/utils/sqs', () => ({
   sendToQueue: (...args: unknown[]) => mockSendToQueue(...args),
 }));
 
-import { dispatchIssueToSre, type SreIssuePayload } from './sreWebhookDispatch';
+import { dispatchIssueToSre, syncSreIssueStateFromWebhook, type SreIssuePayload } from './sreWebhookDispatch';
 
 function makePayload(overrides: Partial<SreIssuePayload> = {}): SreIssuePayload {
   return {
@@ -237,5 +241,50 @@ describe('dispatchIssueToSre', () => {
       expect(result).toEqual({ dispatched: false, reason: 'already-dispatched' });
       expect(mockSendToQueue).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('syncSreIssueStateFromWebhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSetGithubIssueState.mockResolvedValue(1);
+  });
+
+  it('sets githubIssueState to `closed` on a `closed` action', async () => {
+    await syncSreIssueStateFromWebhook(makePayload({ action: 'closed' }));
+
+    expect(mockSetGithubIssueState).toHaveBeenCalledTimes(1);
+    expect(mockSetGithubIssueState).toHaveBeenCalledWith('MillionOnMars/lumina5', 42, 'closed');
+  });
+
+  it('sets githubIssueState to `open` on a `reopened` action', async () => {
+    await syncSreIssueStateFromWebhook(makePayload({ action: 'reopened' }));
+
+    expect(mockSetGithubIssueState).toHaveBeenCalledTimes(1);
+    expect(mockSetGithubIssueState).toHaveBeenCalledWith('MillionOnMars/lumina5', 42, 'open');
+  });
+
+  it.each(['opened', 'labeled', 'edited', 'assigned', 'manual-trigger'])(
+    'no-ops for the non-state-changing `%s` action',
+    async action => {
+      await syncSreIssueStateFromWebhook(makePayload({ action }));
+
+      expect(mockSetGithubIssueState).not.toHaveBeenCalled();
+    }
+  );
+
+  it('no-ops when the repository is missing (cannot scope the update)', async () => {
+    const payload = makePayload({ action: 'closed' });
+    delete (payload as { repository?: unknown }).repository;
+
+    await syncSreIssueStateFromWebhook(payload);
+
+    expect(mockSetGithubIssueState).not.toHaveBeenCalled();
+  });
+
+  it('swallows repository errors so the webhook is never failed by a state write', async () => {
+    mockSetGithubIssueState.mockRejectedValue(new Error('DB down'));
+
+    await expect(syncSreIssueStateFromWebhook(makePayload({ action: 'closed' }))).resolves.toBeUndefined();
   });
 });

--- a/apps/client/server/integrations/github/sreWebhookDispatch.ts
+++ b/apps/client/server/integrations/github/sreWebhookDispatch.ts
@@ -17,7 +17,7 @@ import {
   SRE_DEFAULT_REPO_SLUG,
   type SreJobType,
 } from '@bike4mind/common';
-import { adminSettingsRepository, cacheRepository } from '@bike4mind/database';
+import { adminSettingsRepository, cacheRepository, sreErrorTrackingRepository } from '@bike4mind/database';
 import { createHash } from 'crypto';
 import { getSourceQueueUrl } from '@server/utils/dlqRegistry';
 import { sendToQueue } from '@server/utils/sqs';
@@ -105,6 +105,58 @@ export function parseIssueNumberFromUrl(url: string | undefined): number | undef
   if (!url) return undefined;
   const match = url.match(/\/issues\/(\d+)/);
   return match ? Number(match[1]) : undefined;
+}
+
+/**
+ * Denormalize a GitHub issue's open/closed state onto any SRE tracking docs for
+ * that issue when a webhook reports the issue was closed or reopened.
+ *
+ * This is the authoritative freshness source for `githubIssueState`: GitHub fires
+ * `issues.closed`/`issues.reopened` whenever an issue changes state - whether SRE
+ * merged a fix (`Closes #N`), a human resolved it, or the bot closed it as
+ * `already_fixed` - so a single touchpoint keeps the admin "hide closed-issue
+ * tracking" filter accurate regardless of who closed the issue.
+ *
+ * Deliberately decoupled from `dispatchIssueToSre`'s eligibility gate: `closed`
+ * is intentionally NOT an SRE-eligible action (re-ingesting it would trigger a
+ * false-positive fix-loop alert), but we still want to record the state change.
+ *
+ * No-ops for any action other than `closed`/`reopened`, and swallows its own
+ * errors: a failed state write must never fail the webhook (GitHub would retry
+ * the delivery and re-dispatch the issue for analysis).
+ *
+ * Callable with either the loose `SreIssuePayload` (SRE endpoint) or the org
+ * webhook's `GitHubIssuesPayload` - both satisfy this structural shape.
+ */
+export async function syncSreIssueStateFromWebhook(
+  payload: { action: string; issue: { number: number }; repository?: { full_name?: string } },
+  logger?: Logger
+): Promise<void> {
+  const state = payload.action === 'closed' ? 'closed' : payload.action === 'reopened' ? 'open' : undefined;
+  if (!state) return;
+
+  const repoSlug = payload.repository?.full_name;
+  if (!repoSlug) return;
+
+  try {
+    const updated = await sreErrorTrackingRepository.setGithubIssueState(repoSlug, payload.issue.number, state);
+    if (updated > 0) {
+      logger?.info('[SRE-SENTINEL] Synced githubIssueState from webhook', {
+        action: payload.action,
+        issueNumber: payload.issue.number,
+        repoSlug,
+        state,
+        updated,
+      });
+    }
+  } catch (error) {
+    logger?.warn('[SRE-SENTINEL] Failed to sync githubIssueState (non-fatal)', {
+      action: payload.action,
+      issueNumber: payload.issue.number,
+      repoSlug,
+      error,
+    });
+  }
 }
 
 export interface SreDispatchResult {

--- a/packages/database/src/models/infra/ops/SreErrorTrackingModel.ts
+++ b/packages/database/src/models/infra/ops/SreErrorTrackingModel.ts
@@ -80,6 +80,14 @@ export interface ISreErrorTracking {
   };
   /** GitHub issue number (if applicable) */
   githubIssueNumber?: number;
+  /**
+   * Denormalized open/closed state of the linked GitHub issue.
+   * Kept fresh by the webhook handlers (issues.closed/reopened) and self-healed
+   * on-view by the issue-state endpoint. Absent for CloudWatch-sourced docs and
+   * for GitHub docs whose state has not yet been observed. The admin Pipeline
+   * Status filter hides docs where this is 'closed' by default.
+   */
+  githubIssueState?: 'open' | 'closed';
   /** Fix PR number */
   fixPrNumber?: number;
   /** Fix PR SHA (for rollback detection) */
@@ -161,6 +169,7 @@ const SreErrorTrackingSchema = new mongoose.Schema(
     affectedUserIds: { type: [String], default: [] },
     diagnosisResult: { type: mongoose.Schema.Types.Mixed },
     githubIssueNumber: { type: Number },
+    githubIssueState: { type: String, enum: ['open', 'closed'] },
     fixPrNumber: { type: Number },
     fixPrSha: { type: String },
     fixMergedAt: { type: Date },
@@ -202,6 +211,8 @@ SreErrorTrackingSchema.index({ repoSlug: 1, errorFingerprint: 1, status: 1 }, { 
 SreErrorTrackingSchema.index({ affectedUserIds: 1 });
 // For looking up by PR number (scoped to repo - PR numbers are unique per-repo, not globally)
 SreErrorTrackingSchema.index({ repoSlug: 1, fixPrNumber: 1 }, { sparse: true });
+// For webhook-driven githubIssueState updates: setGithubIssueState filters on { repoSlug, githubIssueNumber }
+SreErrorTrackingSchema.index({ repoSlug: 1, githubIssueNumber: 1 }, { sparse: true });
 // Covers recurrence guard queries: { errorFingerprint, status: 'fixed', fixMergedAt: { $gte } }
 SreErrorTrackingSchema.index({ repoSlug: 1, errorFingerprint: 1, status: 1, fixMergedAt: 1 });
 // For staleness timeout detection
@@ -401,6 +412,25 @@ class SreErrorTrackingRepository extends BaseRepository<ISreErrorTracking> {
     updates?: Partial<ISreErrorTracking>
   ): Promise<void> {
     await this.model.updateOne({ _id: id }, { $set: { status, ...updates } });
+  }
+
+  /**
+   * Denormalize the linked GitHub issue's open/closed state onto every tracking
+   * doc for that issue. Called from the webhook handlers (issues.closed/reopened)
+   * and the issue-state endpoint (self-heal on view). Updates ALL docs for the
+   * (repoSlug, issueNumber) pair - a single issue can have multiple tracking docs
+   * across its lifecycle (different statuses + dismissed audit history), and all
+   * should reflect the same current issue state for the admin filter.
+   *
+   * Returns the number of docs updated (0 when no tracking doc exists for the
+   * issue, which is the common case for issues that never entered the pipeline).
+   */
+  async setGithubIssueState(repoSlug: string, issueNumber: number, state: 'open' | 'closed'): Promise<number> {
+    const result = await this.model.updateMany(
+      { repoSlug, githubIssueNumber: issueNumber },
+      { $set: { githubIssueState: state } }
+    );
+    return result.modifiedCount ?? 0;
   }
 
   /**

--- a/packages/database/src/models/infra/ops/SreErrorTrackingModel.ts
+++ b/packages/database/src/models/infra/ops/SreErrorTrackingModel.ts
@@ -434,6 +434,17 @@ class SreErrorTrackingRepository extends BaseRepository<ISreErrorTracking> {
   }
 
   /**
+   * Backstop for the on-view self-heal: reconcile githubIssueState on a single
+   * doc by its _id. setGithubIssueState scopes its bulk update by repoSlug, so a
+   * doc missing repoSlug is silently skipped there (the fallback repoSlug won't
+   * match an absent field). The issue-state endpoint holds the viewed doc's id
+   * and calls this to guarantee that doc is reconciled regardless of repoSlug.
+   */
+  async setGithubIssueStateById(id: string, state: 'open' | 'closed'): Promise<void> {
+    await this.model.updateOne({ _id: id }, { $set: { githubIssueState: state } });
+  }
+
+  /**
    * Atomic state transition: only updates if current status matches expectedStatus.
    * Returns the updated document, or null if the transition was not possible.
    */

--- a/packages/database/src/models/infra/ops/__tests__/SreErrorTrackingModel.test.ts
+++ b/packages/database/src/models/infra/ops/__tests__/SreErrorTrackingModel.test.ts
@@ -424,4 +424,96 @@ describe('SreErrorTrackingModel — recurrence queries', () => {
       }
     });
   });
+
+  describe('setGithubIssueState', () => {
+    it('updates every tracking doc for the (repoSlug, issueNumber) pair and returns the count', async () => {
+      // Two docs for the same issue (distinct fingerprint/status to satisfy the unique index).
+      await SreErrorTrackingModel.create({
+        errorFingerprint: 'fp-issue42-a',
+        repoSlug: 'owner/repo',
+        source: 'GITHUB_ISSUE',
+        sourceRef: 'https://github.com/owner/repo/issues/42',
+        status: 'fixed',
+        githubIssueNumber: 42,
+      });
+      await SreErrorTrackingModel.create({
+        errorFingerprint: 'fp-issue42-b',
+        repoSlug: 'owner/repo',
+        source: 'GITHUB_ISSUE',
+        sourceRef: 'https://github.com/owner/repo/issues/42',
+        status: 'dismissed',
+        githubIssueNumber: 42,
+      });
+
+      const updated = await sreErrorTrackingRepository.setGithubIssueState('owner/repo', 42, 'closed');
+
+      expect(updated).toBe(2);
+      const docs = await SreErrorTrackingModel.find({ repoSlug: 'owner/repo', githubIssueNumber: 42 }).lean();
+      expect(docs.map(d => d.githubIssueState)).toEqual(['closed', 'closed']);
+    });
+
+    it('does not touch docs for a different issue, a different repo, or CloudWatch docs', async () => {
+      const otherIssue = await SreErrorTrackingModel.create({
+        errorFingerprint: 'fp-issue99',
+        repoSlug: 'owner/repo',
+        source: 'GITHUB_ISSUE',
+        sourceRef: 'https://github.com/owner/repo/issues/99',
+        status: 'fixed',
+        githubIssueNumber: 99,
+      });
+      const otherRepo = await SreErrorTrackingModel.create({
+        errorFingerprint: 'fp-otherrepo',
+        repoSlug: 'other/repo',
+        source: 'GITHUB_ISSUE',
+        sourceRef: 'https://github.com/other/repo/issues/42',
+        status: 'fixed',
+        githubIssueNumber: 42,
+      });
+      const cloudwatch = await SreErrorTrackingModel.create({
+        errorFingerprint: 'fp-cw',
+        repoSlug: 'owner/repo',
+        source: 'CLOUDWATCH',
+        sourceRef: 'log-group',
+        status: 'analyzing',
+      });
+      const target = await SreErrorTrackingModel.create({
+        errorFingerprint: 'fp-issue42-target',
+        repoSlug: 'owner/repo',
+        source: 'GITHUB_ISSUE',
+        sourceRef: 'https://github.com/owner/repo/issues/42',
+        status: 'fixed',
+        githubIssueNumber: 42,
+      });
+
+      const updated = await sreErrorTrackingRepository.setGithubIssueState('owner/repo', 42, 'closed');
+
+      expect(updated).toBe(1);
+      expect((await SreErrorTrackingModel.findById(target.id).lean())?.githubIssueState).toBe('closed');
+      expect((await SreErrorTrackingModel.findById(otherIssue.id).lean())?.githubIssueState).toBeUndefined();
+      expect((await SreErrorTrackingModel.findById(otherRepo.id).lean())?.githubIssueState).toBeUndefined();
+      expect((await SreErrorTrackingModel.findById(cloudwatch.id).lean())?.githubIssueState).toBeUndefined();
+    });
+
+    it('flips state back to open on reopen', async () => {
+      const doc = await SreErrorTrackingModel.create({
+        errorFingerprint: 'fp-reopen',
+        repoSlug: 'owner/repo',
+        source: 'GITHUB_ISSUE',
+        sourceRef: 'https://github.com/owner/repo/issues/7',
+        status: 'fixed',
+        githubIssueNumber: 7,
+        githubIssueState: 'closed',
+      });
+
+      const updated = await sreErrorTrackingRepository.setGithubIssueState('owner/repo', 7, 'open');
+
+      expect(updated).toBe(1);
+      expect((await SreErrorTrackingModel.findById(doc.id).lean())?.githubIssueState).toBe('open');
+    });
+
+    it('returns 0 when no tracking doc exists for the issue', async () => {
+      const updated = await sreErrorTrackingRepository.setGithubIssueState('owner/repo', 12345, 'closed');
+      expect(updated).toBe(0);
+    });
+  });
 });

--- a/packages/database/src/models/infra/ops/__tests__/SreErrorTrackingModel.test.ts
+++ b/packages/database/src/models/infra/ops/__tests__/SreErrorTrackingModel.test.ts
@@ -516,4 +516,46 @@ describe('SreErrorTrackingModel — recurrence queries', () => {
       expect(updated).toBe(0);
     });
   });
+
+  describe('setGithubIssueStateById', () => {
+    it('reconciles a doc by id even when the repoSlug-scoped bulk update misses it', async () => {
+      // Simulate a legacy doc with no repoSlug field (raw insert bypasses the
+      // schema default) - the exact case the repoSlug-scoped bulk update skips.
+      const inserted = await SreErrorTrackingModel.collection.insertOne({
+        errorFingerprint: 'fp-no-reposlug',
+        source: 'GITHUB_ISSUE',
+        sourceRef: 'https://github.com/owner/repo/issues/55',
+        status: 'detected',
+        githubIssueNumber: 55,
+        affectedUserIds: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      const id = String(inserted.insertedId);
+
+      // The bulk update (fallback repoSlug) silently matches nothing...
+      const bulk = await sreErrorTrackingRepository.setGithubIssueState('MillionOnMars/lumina5', 55, 'closed');
+      expect(bulk).toBe(0);
+      expect((await SreErrorTrackingModel.findById(id).lean())?.githubIssueState).toBeUndefined();
+
+      // ...but the id-anchored backstop reconciles the viewed doc.
+      await sreErrorTrackingRepository.setGithubIssueStateById(id, 'closed');
+      expect((await SreErrorTrackingModel.findById(id).lean())?.githubIssueState).toBe('closed');
+    });
+
+    it('flips state back to open', async () => {
+      const doc = await SreErrorTrackingModel.create({
+        errorFingerprint: 'fp-byid-reopen',
+        repoSlug: 'owner/repo',
+        source: 'GITHUB_ISSUE',
+        sourceRef: 'https://github.com/owner/repo/issues/8',
+        status: 'fixed',
+        githubIssueNumber: 8,
+        githubIssueState: 'closed',
+      });
+
+      await sreErrorTrackingRepository.setGithubIssueStateById(doc.id, 'open');
+      expect((await SreErrorTrackingModel.findById(doc.id).lean())?.githubIssueState).toBe('open');
+    });
+  });
 });


### PR DESCRIPTION
## Screenshots


<img width="1370" height="872" alt="Screenshot 2026-07-09 at 4 27 53 pm" src="https://github.com/user-attachments/assets/851d5da5-b7dd-41b9-af82-aebd72495fc3" />
<img width="1390" height="814" alt="Screenshot 2026-07-09 at 4 27 49 pm" src="https://github.com/user-attachments/assets/9cf87920-56e7-4b8a-a0d8-e7079dc0543d" />

## Description

Closes #183.

Operators triaging the SRE pipeline only had a "Filter by Repository" select; everything else was a flat reverse-chronological feed. Most of the noise is tracking docs whose **linked GitHub issue is already closed** (SRE merged a fix, a human resolved it, or the bot closed it as `already_fixed`).

This adds a **"Hide tracking for closed GitHub issues"** filter to the Pipeline Status panel — checked by default — backed by a new denormalized `githubIssueState` on the tracking doc that is kept fresh by the webhook handlers (design option `a`, the recommended one). CloudWatch-sourced docs (no linked issue) always stay visible.

## Changes

- **Model (`SreErrorTrackingModel`)**: added `githubIssueState?: 'open' | 'closed'`, a sparse `{ repoSlug, githubIssueNumber }` index, and `setGithubIssueState(repoSlug, issueNumber, state)` — an `updateMany` that flips **every** doc for an issue (a single issue can have multiple docs across its lifecycle + dismissed audit history).
- **Webhook freshness (authoritative)**: new shared `syncSreIssueStateFromWebhook()` records `closed`→`'closed'` / `reopened`→`'open'`, no-ops otherwise, and swallows its own errors so a state write never fails the webhook. It runs **before and independent of** dispatch, so it works even when the SRE agent is gated off. Wired at **both** entry points:
  - the dedicated SRE endpoint (`pages/api/webhooks/github/sre.ts`), which drops `closed` at its dispatch eligibility gate, so this is the only path that records a close there;
  - the org `IssuesHandler` (`handleClosed` / `handleReopened`), placed before the self-close early-return.
  - GitHub fires `issues.closed` for *every* close, so this one touchpoint covers SRE merges, human closes, and `already_fixed` bot closes alike.
- **Self-heal backfill (no cron)**: the per-card `issue-state` endpoint — already hit on every GitHub-issue card render — now persists live open/closed state via `setGithubIssueState`, reconciling docs created before webhooks fired.
- **Client (`SreAgentTab`)**: "Hide tracking for closed GitHub issues" checkbox, **checked by default**, persisted in **sessionStorage**. Filter hides only `githubIssueState === 'closed'`; CloudWatch and unobserved/open docs always show. Adds a hidden-count hint and an explanatory empty-state.

## Guide for Testers

The closed-issue filter is client-side over the denormalized `githubIssueState` field; the only backend job is keeping that field fresh on `issues.closed`/`reopened`.

### A. UI walkthrough

1. Log in as an admin and go to Sidebar → Admin → SRE Agent → **Pipeline Status**.
2. Confirm the **"Hide tracking for closed GitHub issues"** checkbox is present and **checked** on first load.
3. Confirm tracking cards for closed GitHub issues are hidden, and a "N closed-issue docs hidden" line appears when any are hidden.
4. **Uncheck** the box — expected: the closed-issue cards now appear.
5. Navigate away and back to the tab — expected: the toggle keeps the state you left it in (sessionStorage).
6. Confirm CloudWatch-sourced cards (Source chip "CW") are visible in **both** toggle states.

### B. curl method (no SRE agent required)

In a preview the SRE agent pipeline is gated off and GitHub won't deliver webhooks to it, so you replay the `issues` webhook yourself. The state-sync runs before dispatch, so state still updates. (Signing + payload shape verified against the real `verifyGitHubSignature` and `SreIssuePayloadSchema`.)

**Prerequisites**
```bash
BASE="https://<preview-host>"                      # preview URL (internal deploys channel)
COOKIE="<admin session Cookie header from browser devtools>"
SECRET="<SRE webhook secret (plaintext) for the repo — from a maintainer/admin config>"
REPO="MillionOnMars/lumina5"                        # a configured SRE repo slug
```

**1. Find a GitHub-sourced tracking doc; note its issue number + current state**
```bash
curl -s "$BASE/api/sre/tracking" -H "Cookie: $COOKIE" \
  | jq '[.[] | select(.source=="GITHUB_ISSUE" and .githubIssueNumber!=null)
        | {id, repoSlug, githubIssueNumber, githubIssueState, status}]'
```
Pick one → `ISSUE=<n>`. (If the list is empty, the preview has no SRE docs to filter — ask a maintainer to seed one; the client filter logic itself is covered by unit tests.)

**2. Replay the GitHub `issues` webhook (signs + posts like GitHub would)**
```bash
send_issue_event () {   # usage: send_issue_event <closed|reopened> <issueNumber>
  local body
  body=$(jq -nc --arg a "$1" --argjson n "$2" --arg repo "$REPO" \
    '{action:$a, issue:{number:$n, title:"curl test",
      html_url:("https://github.com/"+$repo+"/issues/"+($n|tostring)),
      body:"", labels:[]}, repository:{full_name:$repo}}')
  local sig="sha256=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $NF}')"
  curl -s -X POST "$BASE/api/webhooks/github/sre" \
    -H "Content-Type: application/json" \
    -H "x-github-event: issues" \
    -H "x-github-delivery: curl-$(date +%s)-$RANDOM" \
    -H "x-hub-signature-256: $sig" \
    --data-raw "$body"; echo
}

send_issue_event closed "$ISSUE"     # expect: {"success":true,"message":"Accepted"}
```
Notes: a **fresh `x-github-delivery`** each call (the endpoint dedups deliveries — the function handles it). `labels:[]` keeps `reopened` from enqueuing to the agent, so you get a clean 200 while state still updates.

**3. Confirm state flipped to `closed`**
```bash
curl -s "$BASE/api/sre/tracking" -H "Cookie: $COOKIE" \
  | jq --argjson n "$ISSUE" '[.[] | select(.githubIssueNumber==$n) | {id, githubIssueState}]'
# expect githubIssueState: "closed" on every doc for that issue
```

**4. Reopen and confirm it flips back to `open`**
```bash
send_issue_event reopened "$ISSUE"
curl -s "$BASE/api/sre/tracking" -H "Cookie: $COOKIE" \
  | jq --argjson n "$ISSUE" '[.[] | select(.githubIssueNumber==$n) | {id, githubIssueState}]'
# expect "open"
```

**5. UI cross-check** — after step 3 the doc is hidden by default (toggle checked); after step 4 it's back in the default view.

**Fallback without the webhook secret** — the admin-authed issue-state endpoint self-heals `githubIssueState` from live GitHub (needs GitHub configured in the preview, but no secret and no agent):
```bash
curl -s "$BASE/api/sre/tracking/<id>/issue-state" -H "Cookie: $COOKIE"   # reads live state AND persists it
# then re-run step 1 and confirm githubIssueState now matches GitHub
```

### What NOT to test
- No infra/AdminSettings changes; no new env vars or cron.
- Non-admins cannot reach this panel or these endpoints.

## Additional Information

Intentionally **not** wired into `workflow-callback.ts` or a `wont_fix` auto-close path (both listed as candidate touchpoints in the issue): workflow-callback success is PR *creation* (issue still open), there is no SRE `wont_fix` auto-close in the code, and the `issues.closed` webhook already catches every close — so those would be redundant. Used self-heal-on-view instead of a dedicated backfill cron.

## Developer Notes

- **Data model**: `githubIssueState` is a general denormalized field other SRE features can read without a GitHub round-trip.
- **Reusable pattern**: `syncSreIssueStateFromWebhook()` accepts a structural payload shape, so both the loose `SreIssuePayload` and the org `GitHubIssuesPayload` can call it.
- `PipelineStatusPanel` and the pure `isClosedGithubIssueDoc()` helper are now exported for testing.

## Testing

- `pnpm turbo:typecheck` — 35/35 packages pass
- `pnpm lint:check` — clean
- New tests: `setGithubIssueState` scoping/reopen/no-match (db), webhook sync on close/reopen at both entry points, and client default-checked / toggle-off / CloudWatch-unaffected / sessionStorage-persistence / empty-state.
- curl recipe (section B) verified locally: the `openssl` signature matches the server's `verifyGitHubSignature`, the `jq` payload passes `SreIssuePayloadSchema`, and the state-sync maps `closed`→`'closed'` / `reopened`→`'open'`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
