### PR TITLE
fix(client): keep agents search bar mounted on no-result search and clear

### DIFF
--- a/apps/client/app/components/AgentList/NoAgentsState.tsx
+++ b/apps/client/app/components/AgentList/NoAgentsState.tsx
@@ -3,9 +3,19 @@ import { Box, Typography } from '@mui/joy';
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 import CreateAgentButton from './CreateAgentButton';
 
-const NoAgentsState: FC = () => {
+interface NoAgentsStateProps {
+  /** 'empty' (default): first-run, no agents exist yet, offers Create.
+   *  'no-results': a search returned nothing - keep the user oriented, no Create. */
+  variant?: 'empty' | 'no-results';
+  /** The active search query, shown in the no-results copy. */
+  query?: string;
+}
+
+const NoAgentsState: FC<NoAgentsStateProps> = ({ variant = 'empty', query }) => {
+  const isNoResults = variant === 'no-results';
   return (
     <Box
+      data-testid={isNoResults ? 'agents-no-results' : 'agents-empty-state'}
       sx={{
         display: 'flex',
         flexDirection: 'column',
@@ -18,12 +28,14 @@ const NoAgentsState: FC = () => {
     >
       <SmartToyOutlinedIcon sx={{ fontSize: 64, color: 'text.tertiary', opacity: 0.5 }} />
       <Typography level="title-lg" sx={{ color: 'text.primary' }}>
-        No agents yet
+        {isNoResults ? 'No matching agents' : 'No agents yet'}
       </Typography>
       <Typography level="body-sm" sx={{ color: 'text.tertiary', textAlign: 'center', maxWidth: 360 }}>
-        Agents help with specific tasks and access specialized knowledge. Create one to get started.
+        {isNoResults
+          ? `No agents match "${query?.trim()}". Try a different search.`
+          : 'Agents help with specific tasks and access specialized knowledge. Create one to get started.'}
       </Typography>
-      <CreateAgentButton variant="empty" testId="agents-empty-create-btn" />
+      {!isNoResults && <CreateAgentButton variant="empty" testId="agents-empty-create-btn" />}
     </Box>
   );
 };

--- a/apps/client/app/routes/agents/index.test.tsx
+++ b/apps/client/app/routes/agents/index.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import AgentsPage from './index';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const renderWithTheme = (ui: React.ReactElement) => render(<CssVarsProvider theme={appTheme}>{ui}</CssVarsProvider>);
+
+// Server-side search: empty query returns one agent, any query returns no matches.
+// This is the exact shape that exposed the bug - a zero-result search set agents=[].
+const getAgentsFromServer = vi.fn((search?: string) =>
+  Promise.resolve({ data: search ? [] : [{ id: 'a1', name: 'Alpha' }] })
+);
+vi.mock('@client/app/utils/agentsAPICalls', () => ({
+  getAgentsFromServer: (search?: string) => getAgentsFromServer(search),
+}));
+
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: () => ({ currentUser: { currentCredits: 0 } }),
+}));
+
+vi.mock('@client/app/hooks/useDocumentTitle', () => ({ useDocumentTitle: () => {} }));
+
+// Header renders its rightActions (where the search bar lives) so gating is observable.
+vi.mock('@client/app/components/Agent/AgentPageHeader', () => ({
+  default: ({ rightActions }: { rightActions?: React.ReactNode }) => <div>{rightActions}</div>,
+}));
+
+// Both search-bar variants stub to a plain input wired to handleChange, so we can assert
+// the bar's presence (the fix) and drive a query without the real debounced component.
+// Defined inline per factory - vi.mock is hoisted, so it can't close over a top-level const.
+vi.mock('@client/app/components/Session/SearchBar', () => ({
+  default: ({ handleChange }: { handleChange: (v: string) => void }) => (
+    <input data-testid="agents-search" onChange={e => handleChange(e.target.value)} />
+  ),
+}));
+vi.mock('@client/app/components/Session/SearchBarWithToggle', () => ({
+  default: ({ handleChange }: { handleChange: (v: string) => void }) => (
+    <input data-testid="agents-search-toggle" onChange={e => handleChange(e.target.value)} />
+  ),
+}));
+vi.mock('@client/app/components/AgentList/AgentsGrid', () => ({
+  default: ({ agents }: { agents: { id: string; name: string }[] }) => (
+    <div data-testid="agents-grid">{agents.map(a => a.name).join(',')}</div>
+  ),
+}));
+vi.mock('@client/app/components/AgentList/CreateAgentButton', () => ({ default: () => <button>Create</button> }));
+vi.mock('@client/app/components/help', () => ({ ContextHelpButton: () => null }));
+
+describe('AgentsPage — search with no results', () => {
+  beforeEach(() => getAgentsFromServer.mockClear());
+
+  it('keeps the search bar and shows a no-results state (not the first-run empty state) on a zero-result search', async () => {
+    renderWithTheme(<AgentsPage />);
+
+    // Agent loads: grid + search bar visible.
+    expect(await screen.findByTestId('agents-grid')).toHaveTextContent('Alpha');
+    expect(screen.getByTestId('agents-search')).toBeInTheDocument();
+
+    // Search for something with no matches. (fireEvent is enough for a bare stub input;
+    // userEvent would only add setup ceremony here.)
+    fireEvent.change(screen.getByTestId('agents-search'), { target: { value: 'zzz' } });
+
+    const noResults = await screen.findByTestId('agents-no-results');
+    // The bug: the bar unmounted and the first-run empty state rendered. Guard both.
+    expect(screen.getByTestId('agents-search')).toBeInTheDocument();
+    expect(screen.queryByTestId('agents-empty-state')).not.toBeInTheDocument();
+    // the query is echoed in the copy (pins the query={search} wiring).
+    expect(noResults).toHaveTextContent('zzz');
+  });
+
+  it('keeps the search bar mounted while the search fetch is in flight (guards the isLoading gate removal)', async () => {
+    // First call (mount, empty query) returns an agent; the search call is deferred so we can
+    // assert mid-flight. The old gate included `!isLoading`, which unmounted the bar during
+    // every fetch - this pins its removal.
+    let resolveSearch: (value: { data: { id: string; name: string }[] }) => void = () => {};
+    getAgentsFromServer.mockResolvedValueOnce({ data: [{ id: 'a1', name: 'Alpha' }] });
+    getAgentsFromServer.mockImplementationOnce(() => new Promise(resolve => (resolveSearch = resolve)));
+
+    renderWithTheme(<AgentsPage />);
+    await screen.findByTestId('agents-grid');
+
+    fireEvent.change(screen.getByTestId('agents-search'), { target: { value: 'zzz' } });
+    // Fetch is still pending (isLoading true) - the bar must remain mounted.
+    expect(screen.getByTestId('agents-search')).toBeInTheDocument();
+
+    resolveSearch({ data: [] });
+    await screen.findByTestId('agents-no-results');
+    expect(screen.getByTestId('agents-search')).toBeInTheDocument();
+  });
+
+  it('keeps the search bar mounted when clearing a no-result search (guards the clear flicker)', async () => {
+    // Default mock: empty query -> one agent, any query -> none. So mount + clear both load the
+    // agent; only the query returns nothing. Reproduces type-no-match -> clear.
+    renderWithTheme(<AgentsPage />);
+    await screen.findByTestId('agents-grid');
+
+    fireEvent.change(screen.getByTestId('agents-search'), { target: { value: 'zzz' } });
+    await screen.findByTestId('agents-no-results');
+
+    // Clearing sets search='' while agents is still the stale [] from the no-match query and the
+    // refetch hasn't landed. Without the hasEverHadAgents latch the bar unmounts here (flicker).
+    fireEvent.change(screen.getByTestId('agents-search'), { target: { value: '' } });
+    expect(screen.getByTestId('agents-search')).toBeInTheDocument();
+
+    await screen.findByTestId('agents-grid');
+    expect(screen.getByTestId('agents-search')).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/routes/agents/index.tsx
+++ b/apps/client/app/routes/agents/index.tsx
@@ -18,16 +18,27 @@ const AgentsPage: FC = () => {
   const [agents, setAgents] = useState<IAgent[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [search, setSearch] = useState('');
+  // Latches true once any load returns agents, and never drops back. Gating the search UI on
+  // the live `agents.length` instead flickered the search bar + Create off for a frame when
+  // clearing a no-result search: `search` clears (hasSearch false) while `agents` is still the
+  // stale 0 from that search and the refetch hasn't repopulated. This keeps the affordance
+  // stable for anyone who has agents; only a genuine first-run (never loaded any) hides it.
+  const [hasEverHadAgents, setHasEverHadAgents] = useState(false);
   const { currentUser } = useUser();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const hasAgents = !isLoading && agents.length > 0;
+  const hasSearch = search.trim().length > 0;
+  const showSearchUI = hasEverHadAgents || hasSearch;
 
   useEffect(() => {
     const fetchAgents = async () => {
       setIsLoading(true);
       try {
-        const response = await getAgentsFromServer(search);
+        // Query the trimmed value so a whitespace-only search agrees with the UI gate
+        // (which uses `hasSearch = search.trim()`); otherwise "   " could refetch to [] and
+        // re-trigger the collapse-to-first-run this fix prevents.
+        const response = await getAgentsFromServer(search.trim());
         setAgents(response.data);
+        if (response.data.length > 0) setHasEverHadAgents(true);
       } catch (error) {
         console.error('Error fetching agents:', error);
       } finally {
@@ -73,7 +84,7 @@ const AgentsPage: FC = () => {
         }
         rightActions={
           <>
-            {hasAgents && (
+            {showSearchUI && (
               <>
                 <Box
                   sx={{
@@ -100,18 +111,18 @@ const AgentsPage: FC = () => {
             )}
 
             <ContextHelpButton helpId="features/agents" tooltipText="Learn about AI Agents" />
-            {hasAgents && <CreateAgentButton variant="header" />}
+            {showSearchUI && <CreateAgentButton variant="header" />}
           </>
         }
       />
 
-      <Box display="flex" flexDirection="column" flexGrow={1} px={hasAgents ? 1 : 0} py={hasAgents ? 2 : 0}>
+      <Box display="flex" flexDirection="column" flexGrow={1} px={showSearchUI ? 1 : 0} py={showSearchUI ? 2 : 0}>
         {isLoading ? (
           <Box display="flex" justifyContent="center" alignItems="center" flex={1}>
             <CircularProgress />
           </Box>
         ) : agents.length === 0 ? (
-          <NoAgentsState />
+          <NoAgentsState variant={hasSearch ? 'no-results' : 'empty'} query={search} />
         ) : (
           <AgentsGrid
             agents={agents}


### PR DESCRIPTION
## Problem

On `/agents`, searching a term with no matches collapsed the whole surface into the first-run "No agents yet" state **and** unmounted the search bar - leaving no way to clear or refine the query. Clearing a no-result search also flickered the search bar + New Agent button off for a frame.

Before:

https://github.com/user-attachments/assets/0b919e50-17a5-4520-8434-8c7c6c7efea5


After:

https://github.com/user-attachments/assets/d86b378f-7461-4076-8988-dd832ce23a57



## Root cause

Search is server-side (`getAgentsFromServer(search)` overwrites the agent list). The page gated the search bar, Create button, and empty state all on `hasAgents = !isLoading && agents.length > 0`:

- A zero-result search set `agents = []` -> `hasAgents` false -> search bar unmounted + first-run `NoAgentsState` rendered.
- The `!isLoading` term also dropped the bar mid-fetch.
- Clearing a no-result search kept the stale `agents = 0` while `search` cleared, so the bar flickered off until the refetch repopulated.

## Fix

- Split "search UI should show" from "has results": `showSearchUI = hasEverHadAgents || hasSearch`. `hasEverHadAgents` latches true once any load returns agents and never drops - the search bar + Create stay stable through no-result searches, mid-fetch, and clear->refetch.
- Empty branch renders `<NoAgentsState variant="no-results" query={search} />` when a query is active (distinct "No agents match X" copy, no Create); first-run state otherwise.
- Query the trimmed value (`getAgentsFromServer(search.trim())`) so a whitespace-only search agrees with the UI gate.

## Verification

- 3 unit tests (`index.test.tsx`): no-result search keeps the bar + shows the no-results state; bar stays mid-fetch; bar stays on clear (no flicker). All pass; typecheck clean.
- Driven end-to-end on a local self-host build - render-trace logs confirmed `showSearchUI` stays true through no-result search, mid-fetch, and clear; a whitespace-only query stays on the grid.