### PR TITLE
feat(e2e): add Skills UI coverage (list, create, edit, share)

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -29,6 +29,7 @@ on:
           - Profile
           - Tavern
           - Search
+          - Skills
         default: All tests
       pr_number:
         description: 'PR number for preview env (overrides stage, e.g. 123)'
@@ -196,6 +197,7 @@ jobs:
             "Profile")         PW_ARGS="--project=profile" ;;
             "Tavern")          PW_ARGS="--project=tavern" ;;
             "Search")          PW_ARGS="--project=search" ;;
+            "Skills")          PW_ARGS="--project=skills" ;;
             *)                 echo "Unknown test selection: '$TEST_PROJECT' — running full suite" ;;
           esac
           [ -n "$PW_ARGS" ] && echo "Running specific test: $TEST_PROJECT ($PW_ARGS)"

--- a/apps/client/e2e/fixtures.ts
+++ b/apps/client/e2e/fixtures.ts
@@ -16,6 +16,7 @@ import { ProfilePage } from './pages/ProfilePage';
 import { AgentsPage } from './pages/AgentsPage';
 import { AdminPage } from './pages/AdminPage';
 import { TavernPage } from './pages/TavernPage';
+import { SkillsPage } from './pages/SkillsPage';
 import { getTestUsers } from './helpers/test-users';
 
 type VerifyAnswersOptions = {
@@ -40,6 +41,7 @@ type TestFixtures = {
   agentsPage: AgentsPage;
   adminPage: AdminPage;
   tavernPage: TavernPage;
+  skillsPage: SkillsPage;
   loginAsAdmin: () => Promise<void>;
   loginAsUser: (user: { accessToken: string; refreshToken: string }) => Promise<void>;
 
@@ -111,6 +113,10 @@ export const test = base.extend<TestFixtures>({
 
   tavernPage: async ({ page }, use) => {
     await use(new TavernPage(page));
+  },
+
+  skillsPage: async ({ page }, use) => {
+    await use(new SkillsPage(page));
   },
 
   loginAsAdmin: async ({ page }, use) => {

--- a/apps/client/e2e/helpers/api.ts
+++ b/apps/client/e2e/helpers/api.ts
@@ -271,3 +271,64 @@ export async function apiUpdateUser(
     throw new Error(`Update user failed: ${response.status()} ${response.statusText()}`);
   }
 }
+
+interface SkillSeed {
+  name: string;
+  description: string;
+  body: string;
+  argumentHint?: string;
+  disableModelInvocation?: boolean;
+}
+
+/** Create a user-scoped skill via the API - for fast pre-seed of list/search/detail specs. */
+export async function apiCreateSkill(
+  request: APIRequestContext,
+  token: string,
+  params: SkillSeed
+): Promise<{ id: string; name: string }> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const response = await request.post(`${baseURL}/api/skills`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: params,
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Create skill failed: ${response.status()} ${response.statusText()}`);
+  }
+
+  const body = await response.json();
+  return { id: (body.id || body._id) as string, name: body.name };
+}
+
+/** List the caller's accessible skills (owned + shared + global-read). */
+export async function apiListSkills(
+  request: APIRequestContext,
+  token: string
+): Promise<Array<{ id: string; name: string }>> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const response = await request.get(`${baseURL}/api/skills?limit=100&page=1`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok()) {
+    return [];
+  }
+
+  const body = await response.json();
+  return (body.data || []).map((s: Record<string, unknown>) => ({ id: (s.id || s._id) as string, name: s.name }));
+}
+
+export async function apiDeleteSkill(request: APIRequestContext, token: string, skillId: string): Promise<void> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  await request.delete(`${baseURL}/api/skills/${skillId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+/** Delete every skill the caller owns - idempotent teardown so a shared preview stays clean. */
+export async function apiDeleteAllSkills(request: APIRequestContext, token: string): Promise<void> {
+  const skills = await apiListSkills(request, token);
+  for (const skill of skills) {
+    await apiDeleteSkill(request, token, skill.id);
+  }
+}

--- a/apps/client/e2e/helpers/test-users.ts
+++ b/apps/client/e2e/helpers/test-users.ts
@@ -42,6 +42,7 @@ const SPEC_KEYS = [
   'profile',
   'tavern',
   'search',
+  'skills',
 ];
 
 /**

--- a/apps/client/e2e/pages/SkillsPage.ts
+++ b/apps/client/e2e/pages/SkillsPage.ts
@@ -1,0 +1,222 @@
+import { expect, type Locator, type Response } from '@playwright/test';
+import { TIMEOUTS } from '../constants';
+import { BasePage } from './BasePage';
+
+export interface SkillFormValues {
+  name: string;
+  description: string;
+  body: string;
+  argumentHint?: string;
+  disableModelInvocation?: boolean;
+}
+
+/** POST /api/skills (create) - method + exact path, no id segment, ignoring any query. */
+const isCreateSkillResponse = (r: Response): boolean =>
+  r.request().method() === 'POST' && /\/api\/skills(?:\?|$)/.test(r.url());
+
+/** PUT /api/skills/:id (update) - has an id segment, not the /share sub-path. */
+const isUpdateSkillResponse = (r: Response): boolean =>
+  r.request().method() === 'PUT' && /\/api\/skills\/[^/?]+(?:\?|$)/.test(r.url());
+
+/** DELETE /api/skills/:id. */
+const isDeleteSkillResponse = (r: Response): boolean =>
+  r.request().method() === 'DELETE' && /\/api\/skills\/[^/?]+(?:\?|$)/.test(r.url());
+
+/** PUT /api/skills/:id/share (sharing config replace). */
+const isShareSkillResponse = (r: Response): boolean =>
+  r.request().method() === 'PUT' && /\/api\/skills\/[^/]+\/share(?:\?|$)/.test(r.url());
+
+/**
+ * Page object for the Skills management surface (`/skills`, `/skills/new`,
+ * `/skills/$id`, `/skills/$id/edit`) and the share dialog.
+ *
+ * Selector notes:
+ *  - The `SkillForm` inputs carry their `data-testid` on the NATIVE element via
+ *    `slotProps` (input / textarea), so they are `fill()`-able directly.
+ *  - The share dialog's email `Input` and the two `Switch`es put the testid on
+ *    the MUI Joy ROOT element, so the native control is reached via
+ *    `.locator('input')`.
+ */
+export class SkillsPage extends BasePage {
+  /** Navigate directly to the list via URL - fast, skips UI navigation. */
+  async gotoList() {
+    await this.page.goto('/skills');
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.dismissModals();
+    await expect(this.page.getByTestId('skills-list-page')).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+  }
+
+  /** Reach the list the way a user does: profile menu -> Skills. */
+  async openViaNav() {
+    await this.page.goto('/');
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.dismissModals();
+
+    await this.page.getByTestId('profile-menu-card').click();
+    const skillsItem = this.page.getByTestId('profile-menu-skills');
+    await expect(skillsItem).toBeVisible({ timeout: TIMEOUTS.MODAL });
+    await skillsItem.click();
+
+    await this.page.waitForURL('**/skills', { timeout: TIMEOUTS.NAVIGATION });
+    await expect(this.page.getByTestId('skills-list-page')).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+  }
+
+  async gotoCreate() {
+    await this.page.goto('/skills/new');
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.dismissModals();
+    await expect(this.page.getByTestId('new-skill-page')).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+  }
+
+  /** Fill only the provided fields. `clear` first for the edit flow's prefilled inputs. */
+  async fillForm(values: Partial<SkillFormValues>, opts: { clear?: boolean } = {}) {
+    if (values.name !== undefined) await this.setInput('skill-name-input', values.name, opts.clear);
+    if (values.description !== undefined)
+      await this.setInput('skill-description-input', values.description, opts.clear);
+    if (values.argumentHint !== undefined)
+      await this.setInput('skill-argument-hint-input', values.argumentHint, opts.clear);
+    if (values.body !== undefined) await this.setInput('skill-body-input', values.body, opts.clear);
+    if (values.disableModelInvocation !== undefined) {
+      const checkbox = this.page.getByTestId('skill-disable-model-invocation');
+      if ((await checkbox.isChecked()) !== values.disableModelInvocation) await checkbox.click();
+    }
+  }
+
+  private async setInput(testId: string, value: string, clear?: boolean) {
+    const el = this.page.getByTestId(testId);
+    await el.click();
+    if (clear) await el.clear();
+    await el.fill(value);
+  }
+
+  get submitButton(): Locator {
+    return this.page.getByTestId('skill-form-submit');
+  }
+
+  async submit() {
+    await expect(this.submitButton).toBeEnabled({ timeout: TIMEOUTS.ACTION });
+    await this.submitButton.click();
+  }
+
+  /** Create a skill through the form; asserts the POST fires and we land on the detail page. */
+  async createSkillViaUi(values: SkillFormValues) {
+    await this.gotoCreate();
+    await this.fillForm(values);
+    const [response] = await Promise.all([
+      this.page.waitForResponse(isCreateSkillResponse, { timeout: TIMEOUTS.ACTION }),
+      this.submit(),
+    ]);
+    await this.page.waitForURL(/\/skills\/[^/]+$/, { timeout: TIMEOUTS.NAVIGATION });
+    await expect(this.page.getByTestId('skill-detail-page')).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+    return response;
+  }
+
+  async openSkillFromList(name: string) {
+    const card = this.page.getByTestId(`skill-card-${name}`);
+    await expect(card).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+    await card.click();
+    await expect(this.page.getByTestId('skill-detail-page')).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+  }
+
+  async editFromDetail() {
+    const editBtn = this.page.getByTestId('skill-detail-edit');
+    await expect(editBtn).toBeVisible({ timeout: TIMEOUTS.ACTION });
+    await editBtn.click();
+    await expect(this.page.getByTestId('edit-skill-page')).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+  }
+
+  /** Save the edit form; asserts the PUT fires and we return to the detail page. */
+  async saveEdit() {
+    const [response] = await Promise.all([
+      this.page.waitForResponse(isUpdateSkillResponse, { timeout: TIMEOUTS.ACTION }),
+      this.submit(),
+    ]);
+    await this.page.waitForURL(/\/skills\/[^/]+$/, { timeout: TIMEOUTS.NAVIGATION });
+    await expect(this.page.getByTestId('skill-detail-page')).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+    return response;
+  }
+
+  /** Delete from the detail page. Accepts the native window.confirm and waits for the DELETE + redirect. */
+  async deleteFromDetail() {
+    this.page.once('dialog', dialog => dialog.accept());
+    const [response] = await Promise.all([
+      this.page.waitForResponse(isDeleteSkillResponse, { timeout: TIMEOUTS.ACTION }),
+      this.page.getByTestId('skill-detail-delete').click(),
+    ]);
+    await this.page.waitForURL('**/skills', { timeout: TIMEOUTS.NAVIGATION });
+    return response;
+  }
+
+  /** Delete from a list card. `accept: false` dismisses the confirm (cancel path). */
+  async deleteFromList(name: string, opts: { accept?: boolean } = {}) {
+    const accept = opts.accept ?? true;
+    this.page.once('dialog', dialog => (accept ? dialog.accept() : dialog.dismiss()));
+    await this.page.getByTestId(`skill-delete-${name}`).click();
+  }
+
+  async search(term: string) {
+    await this.page.getByTestId('skills-search-input').fill(term);
+  }
+
+  async expectCardVisible(name: string) {
+    await expect(this.page.getByTestId(`skill-card-${name}`)).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+  }
+
+  async expectCardHidden(name: string) {
+    await expect(this.page.getByTestId(`skill-card-${name}`)).toBeHidden({ timeout: TIMEOUTS.VISIBLE });
+  }
+
+  // --- Share dialog ---------------------------------------------------------
+
+  async openShareDialog() {
+    const shareBtn = this.page.getByTestId('skill-detail-share');
+    await expect(shareBtn).toBeVisible({ timeout: TIMEOUTS.ACTION });
+    await shareBtn.click();
+    await expect(this.page.getByTestId('skill-share-dialog')).toBeVisible({ timeout: TIMEOUTS.MODAL });
+  }
+
+  /** Try to add a share recipient by email (Add button). Returns without asserting outcome. */
+  async addShareByEmail(email: string) {
+    await this.page.getByTestId('skill-share-email-input').locator('input').fill(email);
+    await this.page.getByTestId('skill-share-add-btn').click();
+  }
+
+  /** Native checkbox inside a MUI Joy Switch (testid is on the switch root). */
+  private switchInput(testId: string): Locator {
+    return this.page.getByTestId(testId).locator('input');
+  }
+
+  async setGlobalRead(on: boolean) {
+    if ((await this.switchInput('skill-share-global-read').isChecked()) !== on) {
+      await this.page.getByTestId('skill-share-global-read').click();
+    }
+  }
+
+  async setGlobalWrite(on: boolean) {
+    if ((await this.switchInput('skill-share-global-write').isChecked()) !== on) {
+      await this.page.getByTestId('skill-share-global-write').click();
+    }
+  }
+
+  async expectGlobalReadChecked(checked: boolean) {
+    const input = this.switchInput('skill-share-global-read');
+    if (checked) await expect(input).toBeChecked();
+    else await expect(input).not.toBeChecked();
+  }
+
+  async expectGlobalWriteChecked(checked: boolean) {
+    const input = this.switchInput('skill-share-global-write');
+    if (checked) await expect(input).toBeChecked();
+    else await expect(input).not.toBeChecked();
+  }
+
+  /** Save the share dialog; asserts the PUT .../share fires and the dialog closes. */
+  async saveShare() {
+    const [response] = await Promise.all([
+      this.page.waitForResponse(isShareSkillResponse, { timeout: TIMEOUTS.ACTION }),
+      this.page.getByTestId('skill-share-save-btn').click(),
+    ]);
+    await expect(this.page.getByTestId('skill-share-dialog')).toBeHidden({ timeout: TIMEOUTS.MODAL });
+    return response;
+  }
+}

--- a/apps/client/e2e/skills.setup.ts
+++ b/apps/client/e2e/skills.setup.ts
@@ -1,0 +1,6 @@
+import { setupSpecUser } from './helpers/spec-setup';
+
+// Skills is ungated (no feature flag), so no extra prefs are needed - just a
+// dedicated user so the spec's create/edit/delete/share never collide with
+// another spec's data on a shared preview.
+setupSpecUser({ key: 'skills', authFile: 'skills-user.json' });

--- a/apps/client/e2e/skills.spec.ts
+++ b/apps/client/e2e/skills.spec.ts
@@ -1,0 +1,242 @@
+import { test, expect } from './fixtures';
+import { TIMEOUTS } from './constants';
+import { getTestUsers } from './helpers/test-users';
+import { apiCreateSkill, apiDeleteAllSkills } from './helpers/api';
+
+/**
+ * Skills web UI: list, create, detail, edit, share.
+ * See `e2e/skills.scenarios.md` for the scenario catalog.
+ *
+ * Serial mode: every test drives the SAME seeded backend user, so the
+ * empty-state and search assertions need a deterministic data set. Running in
+ * order (with API cleanup in before/after hooks) keeps one test's skills from
+ * leaking into another's list.
+ */
+test.describe.configure({ mode: 'serial' });
+
+// kebab-case only (SkillModel `name` regex); TEST_RUN_ID is digits, so it's valid.
+const TEST_RUN_ID = Date.now().toString().slice(-6);
+const SKILL_NAME = `e2e-skill-${TEST_RUN_ID}`;
+const SEARCH_HIT = `e2e-find-me-${TEST_RUN_ID}`;
+const SEARCH_MISS = `e2e-other-${TEST_RUN_ID}`;
+
+let token: string;
+
+test.describe('Skills - list, create, detail, edit, share', () => {
+  // `request` (test-scoped) isn't available in beforeAll/afterAll, so mint a
+  // short-lived API context from the worker-scoped `playwright` fixture.
+  test.beforeAll(async ({ playwright }) => {
+    token = getTestUsers().specUsers.skills.accessToken;
+    const ctx = await playwright.request.newContext();
+    // Clean slate so the empty-state assertion is deterministic.
+    await apiDeleteAllSkills(ctx, token);
+    await ctx.dispose();
+  });
+
+  test.afterAll(async ({ playwright }) => {
+    const ctx = await playwright.request.newContext();
+    await apiDeleteAllSkills(ctx, token);
+    await ctx.dispose();
+  });
+
+  // --- List page -----------------------------------------------------------
+
+  test('nav entry, empty state, then search filter', async ({ page, skillsPage, request }) => {
+    await test.step('reach /skills from the profile menu', async () => {
+      await skillsPage.openViaNav();
+      await expect(page.getByRole('heading', { name: 'Skills' })).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+    });
+
+    await test.step('empty state for a user with no skills', async () => {
+      const empty = page.getByTestId('skills-empty-state');
+      await expect(empty).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+      await expect(empty).toContainText('No skills yet');
+    });
+
+    await test.step('client-side search filters by name/description', async () => {
+      // Seed two skills via API (fast) and reload the list.
+      await apiCreateSkill(request, token, {
+        name: SEARCH_HIT,
+        description: 'A skill that should match the search',
+        body: 'Body for $ARGUMENTS',
+      });
+      await apiCreateSkill(request, token, {
+        name: SEARCH_MISS,
+        description: 'Unrelated template',
+        body: 'Body',
+      });
+      await skillsPage.gotoList();
+      await skillsPage.expectCardVisible(SEARCH_HIT);
+      await skillsPage.expectCardVisible(SEARCH_MISS);
+
+      await skillsPage.search('find-me');
+      await skillsPage.expectCardVisible(SEARCH_HIT);
+      await skillsPage.expectCardHidden(SEARCH_MISS);
+
+      // No match -> the "no results" empty state (distinct copy from the true-empty one).
+      await skillsPage.search('zzz-no-such-skill');
+      await expect(page.getByTestId('skills-empty-state')).toContainText('No skills match your search', {
+        timeout: TIMEOUTS.VISIBLE,
+      });
+    });
+
+    // Reset so the true-empty assertion in later runs / the lifecycle test isn't polluted.
+    await apiDeleteAllSkills(request, token);
+  });
+
+  // --- Full lifecycle ------------------------------------------------------
+
+  test('create, view, edit, share, delete a skill', async ({ page, skillsPage }) => {
+    test.slow();
+
+    await test.step('create a skill end-to-end', async () => {
+      await skillsPage.createSkillViaUi({
+        name: SKILL_NAME,
+        description: 'An E2E skill for automated testing',
+        body: 'Summarize the following: $ARGUMENTS',
+        argumentHint: '[topic]',
+      });
+    });
+
+    await test.step('detail page renders name, hint, and body', async () => {
+      const detailName = page.getByTestId('skill-detail-name');
+      await expect(detailName).toContainText(`/${SKILL_NAME}`);
+      await expect(detailName).toContainText('[topic]');
+      await expect(page.getByTestId('skill-detail-body')).toContainText('Summarize the following: $ARGUMENTS');
+    });
+
+    await test.step('owner sees Share / Edit / Delete actions', async () => {
+      await expect(page.getByTestId('skill-detail-share')).toBeVisible();
+      await expect(page.getByTestId('skill-detail-edit')).toBeVisible();
+      await expect(page.getByTestId('skill-detail-delete')).toBeVisible();
+    });
+
+    await test.step('skill appears on the list and opens from a card', async () => {
+      await skillsPage.gotoList();
+      await skillsPage.expectCardVisible(SKILL_NAME);
+      await skillsPage.openSkillFromList(SKILL_NAME);
+      await expect(page).toHaveURL(/\/skills\/[^/]+$/);
+    });
+
+    await test.step('edit prefills and persists a new description', async () => {
+      await skillsPage.editFromDetail();
+      // Form is prefilled from the existing skill.
+      await expect(page.getByTestId('skill-name-input')).toHaveValue(SKILL_NAME);
+      await skillsPage.fillForm({ description: 'Updated description for E2E' }, { clear: true });
+      await skillsPage.saveEdit();
+      await expect(page.getByTestId('skill-detail-page')).toContainText('Updated description for E2E', {
+        timeout: TIMEOUTS.VISIBLE,
+      });
+    });
+
+    await test.step('toggling "hide from LLM" shows the warning chip on detail', async () => {
+      await skillsPage.editFromDetail();
+      await skillsPage.fillForm({ disableModelInvocation: true });
+      await skillsPage.saveEdit();
+      await expect(page.getByTestId('skill-detail-page')).toContainText('Hidden from LLM auto-invocation', {
+        timeout: TIMEOUTS.VISIBLE,
+      });
+    });
+
+    await test.step('share dialog opens; unknown email surfaces an error', async () => {
+      await skillsPage.openShareDialog();
+      await expect(page.getByTestId('skill-share-dialog')).toContainText('Not shared with anyone yet');
+      await skillsPage.addShareByEmail(`nobody-${TEST_RUN_ID}@example.com`);
+      await expect(page.getByTestId('skill-share-error')).toContainText('No user found', {
+        timeout: TIMEOUTS.VISIBLE,
+      });
+    });
+
+    await test.step('global-write auto-enables global-read + warning, and PUT .../share fires', async () => {
+      await skillsPage.setGlobalWrite(true);
+      await skillsPage.expectGlobalWriteChecked(true);
+      await skillsPage.expectGlobalReadChecked(true); // write implies read (UI couples them)
+      await expect(page.getByTestId('skill-share-global-write-warning')).toBeVisible();
+
+      await skillsPage.saveShare();
+    });
+
+    await test.step('a fresh load shows the saved global-write state', async () => {
+      // The share dialog seeds its switch state once, at mount, from the detail
+      // page's cached skill. After save, that cache refetch is still in flight,
+      // so reopening immediately would re-mount against stale data. Reload to
+      // force a fresh GET /api/skills/:id, then reopen - now it seeds correctly.
+      await page.reload();
+      await page.waitForLoadState('domcontentloaded');
+      await skillsPage.dismissModals();
+      await expect(page.getByTestId('skill-detail-page')).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
+
+      await skillsPage.openShareDialog();
+      await skillsPage.expectGlobalWriteChecked(true);
+      await skillsPage.expectGlobalReadChecked(true);
+      // Close without changes.
+      await page.getByTestId('skill-share-dialog').getByRole('button', { name: 'Cancel' }).click();
+      await expect(page.getByTestId('skill-share-dialog')).toBeHidden({ timeout: TIMEOUTS.MODAL });
+    });
+
+    await test.step('delete from the detail page (confirm) removes it from the list', async () => {
+      await skillsPage.deleteFromDetail();
+      await skillsPage.gotoList();
+      await skillsPage.expectCardHidden(SKILL_NAME);
+    });
+  });
+
+  // --- Form validation -----------------------------------------------------
+
+  test('form validation gates submit', async ({ page, skillsPage }) => {
+    await skillsPage.gotoCreate();
+
+    await test.step('submit disabled with an empty form', async () => {
+      await expect(skillsPage.submitButton).toBeDisabled();
+    });
+
+    await test.step('invalid (non-kebab) name shows an error and keeps submit disabled', async () => {
+      await skillsPage.fillForm({ name: 'Bad Name' }); // spaces + uppercase
+      await expect(page.getByText('Use lowercase letters, digits, and hyphens', { exact: false })).toBeVisible({
+        timeout: TIMEOUTS.VISIBLE,
+      });
+      await expect(skillsPage.submitButton).toBeDisabled();
+    });
+
+    await test.step('name valid but description/body empty keeps submit disabled', async () => {
+      await skillsPage.fillForm({ name: `e2e-valid-${TEST_RUN_ID}` }, { clear: true });
+      await expect(skillsPage.submitButton).toBeDisabled();
+    });
+
+    await test.step('all fields valid enables submit', async () => {
+      await skillsPage.fillForm({ description: 'Valid description', body: 'Valid body' });
+      await expect(skillsPage.submitButton).toBeEnabled({ timeout: TIMEOUTS.VISIBLE });
+    });
+  });
+
+  // --- Cancel + duplicate name ---------------------------------------------
+
+  test('cancel discards, duplicate name is rejected', async ({ page, skillsPage, request }) => {
+    const dupeName = `e2e-dupe-${TEST_RUN_ID}`;
+
+    await test.step('cancel returns to the list without creating', async () => {
+      await skillsPage.gotoCreate();
+      await skillsPage.fillForm({ name: `e2e-cancel-${TEST_RUN_ID}`, description: 'x', body: 'y' });
+      await page.getByTestId('skill-form-cancel').click();
+      await page.waitForURL('**/skills', { timeout: TIMEOUTS.NAVIGATION });
+      await skillsPage.expectCardHidden(`e2e-cancel-${TEST_RUN_ID}`);
+    });
+
+    await test.step('creating a duplicate name is rejected (no navigation off the form)', async () => {
+      // Seed the first skill via API so the UI attempt is the duplicate.
+      await apiCreateSkill(request, token, { name: dupeName, description: 'first', body: 'first body' });
+
+      await skillsPage.gotoCreate();
+      await skillsPage.fillForm({ name: dupeName, description: 'second', body: 'second body' });
+      // The POST returns 400; the mutation rejects, so we stay on /skills/new.
+      const [response] = await Promise.all([
+        page.waitForResponse(r => r.request().method() === 'POST' && /\/api\/skills(?:\?|$)/.test(r.url()), {
+          timeout: TIMEOUTS.ACTION,
+        }),
+        skillsPage.submit(),
+      ]);
+      expect(response.status()).toBe(400);
+      await expect(page).toHaveURL(/\/skills\/new$/);
+    });
+  });
+});

--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -64,6 +64,12 @@ const specProjects = [
     testMatch: /(?:^|\/)search\.spec\.ts$/,
     auth: './e2e/.auth/search-user.json',
   },
+  {
+    name: 'skills',
+    setupMatch: /(?:^|\/)skills\.setup\.ts$/,
+    testMatch: /(?:^|\/)skills\.spec\.ts$/,
+    auth: './e2e/.auth/skills-user.json',
+  },
   // AI latency suites: only included when AI_LATENCY_RUN=true (e2e-ai-latency workflow)
   ...(process.env.AI_LATENCY_RUN === 'true'
     ? [


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="633" height="634" alt="Screenshot 2026-07-09 at 3 31 04 PM" src="https://github.com/user-attachments/assets/552b3d8d-70a6-4c7d-953c-2aa2d6b3b4ef" />


## Description

There was no end-to-end coverage for the **Skills** management surface (`/skills`) -- the UI where users author reusable `/name` instruction templates. This PR adds a self-contained Playwright suite that drives the real UI through the full author lifecycle (create -> view -> edit -> share -> delete), plus the form-validation, cancel, and duplicate-name paths.

The suite seeds its own dedicated test user, runs as its own Playwright project, and pre-seeds/cleans up its data via the API so it leaves no residue on the shared preview. Skills is ungated (no feature flag), so no admin setup is required beyond the seeded user.

## Changes

- Add `apps/client/e2e/skills.spec.ts` -- lifecycle + validation + sharing (serial describe, single seeded user).
- Add `apps/client/e2e/pages/SkillsPage.ts` -- page object for the list, form, detail page, and share dialog.
- Add `apps/client/e2e/skills.setup.ts` -- seeds the dedicated `skills` test user.
- Add skill helpers to `apps/client/e2e/helpers/api.ts` -- `apiCreateSkill`, `apiListSkills`, `apiDeleteSkill`, `apiDeleteAllSkills` for fast pre-seed and teardown.
- Register the `skillsPage` fixture in `apps/client/e2e/fixtures.ts`.
- Add `skills` to `SPEC_KEYS` in `apps/client/e2e/helpers/test-users.ts` so the seeded user/token loads.
- Add the `skills` spec project in `apps/client/playwright.config.ts` (`setup-skills` -> `skills`).
- Add a `Skills` option to the manual `test_project` dropdown in `.github/workflows/e2e-manual.yml`.

## Guide for Testers

1. Go to the **Github Actions** tab and select the **E2E Tests (Manual)** workflow.
2. Click **Run workflow**.
3. Set **Target environment** to `dev` (default).
4. Set **Specific test to run** to `Skills`.
5. Click **Run workflow**, then open the run. Expected: only the `skills` project runs; its setup dependency chain (`setup-core` -> `warmup` -> `setup-skills`) is pulled in automatically and creates the isolated user/auth.
6 Wait for the job to finish. Expected: green. On failure, download the **playwright-report-...** artifact and open `index.html`.
7. Summary of the test result will be sent in the slack channel.


## Additional Information

- **Manual CI run:** "All tests" (the default) already ran the full suite; this PR adds a **Skills** dropdown option so the spec can be targeted on its own, matching every other spec.
- **Determinism:** all tests drive the same backend user, so the describe runs serially and the `before/after` hooks clear the user's skills via the API, keeping the empty-state and search assertions stable.

## Developer Notes (Optional)

- **Reusable pattern -- `SkillsPage` page object:** encapsulates navigation, form fill/submit, detail actions, and the share dialog. Selector notes are documented in-file: `SkillForm` inputs carry their `data-testid` on the native element (directly fillable), while the share dialog's email `Input` and the two `Switch`es put the testid on the MUI Joy root, so the native control is reached via `.locator('input')`.
- **Reusable helpers:** `apiCreateSkill` / `apiListSkills` / `apiDeleteSkill` / `apiDeleteAllSkills` give any future skills spec fast pre-seed and idempotent teardown.
- **Pattern -- API context in `beforeAll`/`afterAll`:** since the test-scoped `request` fixture isn't available in those hooks, a short-lived context is minted from the worker-scoped `playwright` fixture for cleanup.
- **Pattern -- native `window.confirm`:** deletes are handled with a one-shot `page.on('dialog')` acceptor.

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- N/A
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) -- N/A (test-only)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) -- N/A
- [x] My changes generate no new warnings (typecheck + lint clean)
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc -- N/A

