### PR TITLE
fix(client): stop liveOpsTriage from rethrowing on permanent Slack misconfiguration

### DIFF
--- a/apps/client/server/queueHandlers/liveOpsTriage.test.ts
+++ b/apps/client/server/queueHandlers/liveOpsTriage.test.ts
@@ -169,6 +169,80 @@ describe('liveOpsTriage handler', () => {
     });
   });
 
+  describe('permanent Slack misconfiguration (getSlackBotToken returns null)', () => {
+    beforeEach(() => {
+      // Configured workspace not found, and no active workspace to fall back to.
+      mockFindByIdWithToken.mockResolvedValue(null);
+      mockFindAllActive.mockResolvedValue([]);
+    });
+
+    it('does NOT re-throw, so SQS will not retry', async () => {
+      await expect(
+        dispatch(
+          makeSqsEvent({ jobId: '507f1f77bcf86cd799439011', userId: 'u1', dryRun: false }),
+          mockContext,
+          mockLogger
+        )
+      ).resolves.toBeUndefined();
+    });
+
+    it('marks the job failed with a specific reason', async () => {
+      await dispatch(
+        makeSqsEvent({ jobId: '507f1f77bcf86cd799439011', userId: 'u1', dryRun: false }),
+        mockContext,
+        mockLogger
+      );
+
+      expect(mockMarkFailed).toHaveBeenCalledWith('507f1f77bcf86cd799439011', {
+        errorMessage: 'No active Slack workspace with bot token found',
+      });
+    });
+
+    it('emits a failure metric tagged as a permanent NoSlackWorkspace error', async () => {
+      await dispatch(
+        makeSqsEvent({ jobId: '507f1f77bcf86cd799439011', userId: 'u1', dryRun: true }),
+        mockContext,
+        mockLogger
+      );
+
+      expect(mockEmitMetric).toHaveBeenCalledWith(
+        expect.any(String),
+        'ManualRunFailure',
+        1,
+        expect.objectContaining({ ErrorType: 'NoSlackWorkspace' }),
+        expect.anything()
+      );
+    });
+
+    it('never reaches GitHub lookup or runTriage/runDryRun', async () => {
+      await dispatch(
+        makeSqsEvent({ jobId: '507f1f77bcf86cd799439011', userId: 'u1', dryRun: false }),
+        mockContext,
+        mockLogger
+      );
+
+      expect(mockForSystem).not.toHaveBeenCalled();
+      expect(mockRunTriage).not.toHaveBeenCalled();
+      expect(mockRunDryRun).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('transient getSlackBotToken failure', () => {
+    it('still re-throws so SQS retries', async () => {
+      mockFindOne.mockRejectedValue(new Error('DB connection lost'));
+
+      await expect(
+        dispatch(
+          makeSqsEvent({ jobId: '507f1f77bcf86cd799439011', userId: 'u1', dryRun: false }),
+          mockContext,
+          mockLogger
+        )
+      ).rejects.toThrow('DB connection lost');
+
+      expect(mockMarkFailed).toHaveBeenCalledWith('507f1f77bcf86cd799439011', { errorMessage: 'DB connection lost' });
+    });
+  });
+
   describe('happy path', () => {
     it('completes the job when GitHub and Slack are both available', async () => {
       mockForSystem.mockResolvedValue({ someGithubClient: true });

--- a/apps/client/server/queueHandlers/liveOpsTriage.ts
+++ b/apps/client/server/queueHandlers/liveOpsTriage.ts
@@ -134,10 +134,26 @@ export const dispatch = dispatchWithLogger(async (event: SQSEvent, context: Cont
   try {
     await updateProgress(5, 'Connecting to services...');
 
-    // Get Slack bot token
+    // Get Slack bot token. getSlackBotToken() returns null only for permanent config
+    // states (no workspace configured / no active workspace / workspace has no bot
+    // token stored) - swallow those here (log, markFailed, return) so SQS doesn't
+    // retry a message that can never succeed. A genuine decrypt failure (bad
+    // SECRET_ENCRYPTION_KEY, corrupted token) throws from decryptToken() itself and
+    // falls through to the outer catch for SQS retry.
     const slackBotToken = await getSlackBotToken(logger);
     if (!slackBotToken) {
-      throw new Error('No active Slack workspace with bot token found');
+      logger.warn('No active Slack workspace with bot token found - failing job without retry', { jobId });
+      await liveOpsTriageJobRepository.markFailed(jobId, {
+        errorMessage: 'No active Slack workspace with bot token found',
+      });
+      await emitMetric(
+        CLOUDWATCH_NAMESPACE,
+        'ManualRunFailure',
+        1,
+        { DryRun: String(dryRun), ErrorType: 'NoSlackWorkspace' },
+        StandardUnit.Count
+      );
+      return;
     }
 
     await updateProgress(10, 'Connecting to GitHub...');


### PR DESCRIPTION
## Description

Follow-up to #268. That PR fixed `liveOpsTriage.ts` so a permanent GitHub misconfiguration (`GitHubService.forSystem()` returning `null`) is treated as terminal: log, `markFailed`, emit a failure metric, and `return` — no rethrow, no wasted SQS retry/DLQ churn. The Slack side of the same handler still had the old behavior, tracked as #292.

`getSlackBotToken()` returns `null` for permanent config states (no Slack workspace configured, no active workspace to fall back to, or the workspace record has no bot token stored). The handler converted that `null` into a thrown `Error`, and the outer `catch` marks the job failed and then unconditionally rethrows — so every permanent Slack misconfiguration got retried by SQS and routed to the DLQ anyway, same class of bug as the GitHub case.

I traced through `getSlackBotToken`'s three `null`-return branches and `decryptToken` (`tokenEncryption.ts`) to confirm none of them mask a genuine transient failure: a real decryption failure (bad `SECRET_ENCRYPTION_KEY`, corrupted token) already `throw`s rather than returning `null`, so that path is unaffected and still retries as before.

## Changes

- `apps/client/server/queueHandlers/liveOpsTriage.ts`: when `getSlackBotToken()` returns `null`, log the reason, `markFailed` the job, emit a `ManualRunFailure` metric tagged `ErrorType: 'NoSlackWorkspace'`, and `return` — no throw, no rethrow, no SQS retry. This mirrors the `ErrorType: 'NoGitHubConnection'` handling added in #268.
- `apps/client/server/queueHandlers/liveOpsTriage.test.ts`: added a `permanent Slack misconfiguration` describe block (no rethrow, job marked failed with the specific reason, correct metric tag, confirms the GitHub lookup and `runTriage`/`runDryRun` are never reached) and a `transient getSlackBotToken failure` test (a rejected `AdminSettings.findOne` still rethrows, confirming retry behavior is preserved).

## Guide for Testers

This is a backend-only fix to an SQS-consumed Lambda queue handler with no UI entry point that can trigger the buggy branch deterministically from the product. Verify via the test suite instead:

1. From the repo root, run `pnpm --filter client test server/queueHandlers/liveOpsTriage.test.ts`.
2. Expect all 11 tests to pass, in particular:
   - `does NOT re-throw, so SQS will not retry` (Slack block)
   - `marks the job failed with a specific reason` (Slack block)
   - `never reaches GitHub lookup or runTriage/runDryRun`
   - `still re-throws so SQS retries` (transient `getSlackBotToken` case — confirms we did not weaken retry behavior for real transient failures)

<img width="572" height="289" alt="image" src="https://github.com/user-attachments/assets/7873a543-c8d4-4f27-b4b9-cfa7438b609d" />

## Additional Information

Closes #292, filed as a follow-up during review of #268 once the bot reviewer flagged that the Slack path has the same shape of bug.

## Developer Notes (Optional)

- No new patterns introduced — this brings the Slack-token path in `liveOpsTriage.ts` in line with the `forSystem()` null-vs-throw contract already used for the GitHub path (and by `sreRevision`, `sreFix`, `sreAnalysis`, `secopsTriageWorker`). Both permanent-failure branches in this handler now follow the same shape: log, `markFailed`, emit a tagged metric, `return`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
