### PR TITLE
fix(preview-remove): self-heal desynced teardowns (refresh + stage-scoped ALB reconcile)

### DIFF
--- a/.github/actions/sst-remove-idempotent/action.yml
+++ b/.github/actions/sst-remove-idempotent/action.yml
@@ -123,6 +123,50 @@ runs:
           fi
         fi
 
+        # Desync self-heal. An interrupted or partial prior remove (CI job-timeout
+        # kill, runner death, or an out-of-band delete) leaves state out of sync
+        # with AWS, and the retry then fails two ways:
+        #   - a resource deleted out-of-band but still in state -> the delete errors
+        #     "not found" (e.g. ListenerNotFound after its ALB was deleted), or
+        #   - a resource live in AWS but dropped from state -> its SG delete hits
+        #     DependencyViolation (the live ALB's ENI + the AlbToTask rule on the
+        #     shared default SG still pin it).
+        # Tier 1 is cheap and non-destructive: `sst refresh` reconciles state with
+        # reality (drops the already-gone resources), then retry. Tier 2 runs only
+        # if a DependencyViolation persists: a strictly stage-scoped reconcile that
+        # deletes the live untracked ALB, revokes the dangling AlbToTask rule, and
+        # deletes the SG, then refresh + retry.
+        echo "⚠️  Remove failed; attempting self-heal (sst refresh, then retry)..."
+        pnpm sst refresh --stage "${STAGE}" 2>&1 | tail -5 || true
+        attempt_remove
+        EXIT_CODE=$?
+        if [ "$EXIT_CODE" -eq 0 ]; then
+          echo "✅ Preview environment removed after refresh"
+          echo "existed=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        if echo "$OUTPUT" | grep -q "Stage not found"; then
+          echo "existed=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if echo "$OUTPUT" | grep -qE "DependencyViolation|has a dependent object"; then
+          echo "⚠️  DependencyViolation persists; running stage-scoped orphaned-ALB reconcile..."
+          bash "${GITHUB_ACTION_PATH}/reconcile-orphaned-alb.sh" "${STAGE}" || true
+          pnpm sst refresh --stage "${STAGE}" 2>&1 | tail -5 || true
+          attempt_remove
+          EXIT_CODE=$?
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "✅ Preview environment removed after reconcile"
+            echo "existed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if echo "$OUTPUT" | grep -q "Stage not found"; then
+            echo "existed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+        fi
+
         echo "❌ Failed to remove preview environment (exit code: $EXIT_CODE)"
         # Belt-and-suspenders: guarantee a non-zero exit even if EXIT_CODE
         # somehow ended up at 0. Without this, future regressions of the

--- a/.github/actions/sst-remove-idempotent/action.yml
+++ b/.github/actions/sst-remove-idempotent/action.yml
@@ -124,40 +124,49 @@ runs:
         fi
 
         # Desync self-heal. An interrupted or partial prior remove (CI job-timeout
-        # kill, runner death, or an out-of-band delete) leaves state out of sync
-        # with AWS, and the retry then fails two ways:
-        #   - a resource deleted out-of-band but still in state -> the delete errors
-        #     "not found" (e.g. ListenerNotFound after its ALB was deleted), or
+        # kill, runner death, or an out-of-band delete) leaves SST state out of sync
+        # with AWS, so the retry fails one of two ways:
+        #   - a resource deleted out-of-band but still in state -> its delete errors
+        #     "not found" (e.g. ListenerNotFound after its ALB was deleted). This is
+        #     the dominant case across the orphan backlog.
         #   - a resource live in AWS but dropped from state -> its SG delete hits
         #     DependencyViolation (the live ALB's ENI + the AlbToTask rule on the
         #     shared default SG still pin it).
-        # Tier 1 is cheap and non-destructive: `sst refresh` reconciles state with
-        # reality (drops the already-gone resources), then retry. Tier 2 runs only
-        # if a DependencyViolation persists: a strictly stage-scoped reconcile that
-        # deletes the live untracked ALB, revokes the dangling AlbToTask rule, and
-        # deletes the SG, then refresh + retry.
-        echo "⚠️  Remove failed; attempting self-heal (sst refresh, then retry)..."
-        pnpm sst refresh --stage "${STAGE}" 2>&1 | tail -5 || true
-        attempt_remove
-        EXIT_CODE=$?
-        if [ "$EXIT_CODE" -eq 0 ]; then
-          echo "✅ Preview environment removed after refresh"
-          echo "existed=true" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        if echo "$OUTPUT" | grep -q "Stage not found"; then
-          echo "existed=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        if echo "$OUTPUT" | grep -qE "DependencyViolation|has a dependent object"; then
-          echo "⚠️  DependencyViolation persists; running stage-scoped orphaned-ALB reconcile..."
-          bash "${GITHUB_ACTION_PATH}/reconcile-orphaned-alb.sh" "${STAGE}" || true
-          pnpm sst refresh --stage "${STAGE}" 2>&1 | tail -5 || true
+        # NOTE: `sst refresh` can NOT be used to reconcile here - it runs the program
+        # and bundles every function, which fails in this public checkout (premium
+        # handlers live only in the private overlay: "Handler not found ...premium-
+        # generated..."). `sst state ...` and `sst remove` do NOT bundle, so we heal
+        # via state surgery + retry. Bounded loop: each pass either drops the phantom
+        # (already-gone) resource named in the error from state, or runs the stage-
+        # scoped ALB reconcile, then retries.
+        echo "⚠️  Remove failed; attempting desync self-heal (state surgery + retry)..."
+        for heal in 1 2 3 4 5 6; do
+          if echo "$OUTPUT" | grep -qE "DependencyViolation|has a dependent object"; then
+            echo "  [heal ${heal}] DependencyViolation -> stage-scoped orphaned-ALB reconcile"
+            bash "${GITHUB_ACTION_PATH}/reconcile-orphaned-alb.sh" "${STAGE}" || true
+          elif echo "$OUTPUT" | grep -qiE "NotFound|does not exist"; then
+            # Logical name of the failed resource is the token before its
+            # " aws:/sst:/random:/command:" type on the sst "|  Error ..." line
+            # (last such token on the line, i.e. the child, not its parent).
+            PHANTOMS=$(echo "$OUTPUT" | grep -aE '^\|[[:space:]]+Error' \
+              | sed -E 's/.* ([A-Za-z0-9_]+) (aws|sst|random|command|pulumi[A-Za-z-]*):[A-Za-z].*/\1/' \
+              | grep -aE '^[A-Za-z0-9_]+$' | sort -u)
+            if [ -z "$PHANTOMS" ]; then
+              echo "  [heal ${heal}] not-found error but no resource parsed; stopping self-heal"
+              break
+            fi
+            for p in $PHANTOMS; do
+              echo "  [heal ${heal}] dropping phantom (already-gone) resource from state: ${p}"
+              printf 'y\n' | pnpm sst state remove "${p}" --stage "${STAGE}" >/dev/null 2>&1 || true
+            done
+          else
+            echo "  [heal ${heal}] failure is not a recoverable desync; stopping self-heal"
+            break
+          fi
           attempt_remove
           EXIT_CODE=$?
           if [ "$EXIT_CODE" -eq 0 ]; then
-            echo "✅ Preview environment removed after reconcile"
+            echo "✅ Preview environment removed after self-heal (pass ${heal})"
             echo "existed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -165,7 +174,7 @@ runs:
             echo "existed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-        fi
+        done
 
         echo "❌ Failed to remove preview environment (exit code: $EXIT_CODE)"
         # Belt-and-suspenders: guarantee a non-zero exit even if EXIT_CODE

--- a/.github/actions/sst-remove-idempotent/reconcile-orphaned-alb.sh
+++ b/.github/actions/sst-remove-idempotent/reconcile-orphaned-alb.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# reconcile-orphaned-alb.sh <stage>
+#
+# Self-heal for a DESYNCED preview teardown. An interrupted or partial prior
+# `sst remove` (CI job-timeout kill, runner death) can leave the ChatCompletion
+# ALB live in AWS but dropped from SST state. A retry then deletes the ALB's
+# security group while the live ALB - and the ingress rule on the shared VPC
+# `default` SG that references it as source - still pin it, so `sst remove`
+# fails with `DependencyViolation`. This clears those blockers directly so the
+# caller can retry `sst remove` cleanly.
+#
+# STRICTLY stage-scoped. It only acts on:
+#   - security groups tagged sst:stage=<stage> (SST-created; the shared `default`
+#     SG is NOT tagged per-stage, so it is never selected for deletion), and
+#   - ingress rules on the VPC `default` SG that REFERENCE those stage SGs.
+# It never touches prod or another stage. Every step is best-effort and idempotent.
+#
+# Requires AWS creds in the environment. AWS_REGION defaults to us-east-2.
+set -uo pipefail
+
+STAGE="${1:?usage: reconcile-orphaned-alb.sh <stage>}"
+REGION="${AWS_REGION:-us-east-2}"
+DRAIN_TRIES="${DRAIN_TRIES:-20}"   # x15s = up to 5 minutes
+log() { echo "[reconcile ${STAGE}] $*"; }
+
+# 1. SST-created security groups for this stage (the ALB SG). Tag-scoped, so the
+#    shared `default` SG (untagged per-stage) can never appear here.
+STAGE_SGS=$(aws ec2 describe-security-groups --region "$REGION" \
+  --filters "Name=tag:sst:stage,Values=${STAGE}" \
+  --query 'SecurityGroups[].GroupId' --output text 2>/dev/null | tr '\t' '\n' | grep -v '^$' || true)
+
+if [ -z "$STAGE_SGS" ]; then
+  log "no SST-tagged security groups for this stage; nothing to reconcile"
+fi
+
+# 2. Revoke dangling ingress rules on each stage SG's VPC `default` SG that
+#    reference the stage SG as source (the AlbToTask rule). A SG referenced as a
+#    rule source cannot be deleted until that rule is revoked.
+for sg in $STAGE_SGS; do
+  vpc=$(aws ec2 describe-security-groups --region "$REGION" --group-ids "$sg" \
+        --query 'SecurityGroups[0].VpcId' --output text 2>/dev/null || true)
+  if [ -z "$vpc" ] || [ "$vpc" = "None" ]; then continue; fi
+  default_sg=$(aws ec2 describe-security-groups --region "$REGION" \
+    --filters "Name=vpc-id,Values=${vpc}" "Name=group-name,Values=default" \
+    --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || true)
+  if [ -z "$default_sg" ] || [ "$default_sg" = "None" ]; then continue; fi
+  rules=$(aws ec2 describe-security-group-rules --region "$REGION" \
+    --filters "Name=group-id,Values=${default_sg}" \
+    --query "SecurityGroupRules[?ReferencedGroupInfo.GroupId=='${sg}'].SecurityGroupRuleId" \
+    --output text 2>/dev/null | tr '\t' '\n' | grep -v '^$' || true)
+  for rid in $rules; do
+    if aws ec2 revoke-security-group-ingress --region "$REGION" \
+         --group-id "$default_sg" --security-group-rule-ids "$rid" >/dev/null 2>&1; then
+      log "revoked dangling rule ${rid} on default SG ${default_sg} (referenced ${sg})"
+    else
+      log "could not revoke ${rid} (may already be gone)"
+    fi
+  done
+done
+
+# 3. Delete this stage's load balancer(s). An untracked ALB is invisible to
+#    `sst remove`, so delete it directly; its ENIs then drain and release the SG.
+albs=$(aws elbv2 describe-load-balancers --region "$REGION" \
+  --query 'LoadBalancers[].LoadBalancerArn' --output text 2>/dev/null | tr '\t' '\n' | grep -v '^$' || true)
+for arn in $albs; do
+  st=$(aws elbv2 describe-tags --region "$REGION" --resource-arns "$arn" \
+       --query "TagDescriptions[0].Tags[?Key=='sst:stage'].Value|[0]" --output text 2>/dev/null || true)
+  if [ "$st" = "$STAGE" ]; then
+    if aws elbv2 delete-load-balancer --region "$REGION" --load-balancer-arn "$arn" >/dev/null 2>&1; then
+      log "deleted orphaned ALB ${arn##*loadbalancer/}"
+    else
+      log "could not delete ALB ${arn##*loadbalancer/}"
+    fi
+  fi
+done
+
+# 4. Wait for ENIs to drain off each stage SG (the ALB's ENIs hold it until the
+#    ALB is fully gone), then delete the SG. If the SG is still tracked in state,
+#    the caller's retry `sst remove` no-ops on the already-deleted id.
+for sg in $STAGE_SGS; do
+  log "waiting for ENIs to drain off ${sg} (up to $((DRAIN_TRIES*15))s)..."
+  i=0
+  while [ "$i" -lt "$DRAIN_TRIES" ]; do
+    n=$(aws ec2 describe-network-interfaces --region "$REGION" \
+        --filters "Name=group-id,Values=${sg}" \
+        --query 'length(NetworkInterfaces)' --output text 2>/dev/null || echo 1)
+    [ "$n" = "0" ] && break
+    i=$((i+1)); sleep 15
+  done
+  if aws ec2 delete-security-group --region "$REGION" --group-id "$sg" >/dev/null 2>&1; then
+    log "deleted stage SG ${sg}"
+  else
+    log "did not delete SG ${sg} (already gone, or still pinned - retry sst remove will surface it)"
+  fi
+done
+
+log "reconcile complete"


### PR DESCRIPTION
## Description

P1 of the resilient-teardown work (P0 was deployer #19). Makes the `sst-remove-idempotent` composite action recover from a state desync instead of failing and leaving the stage orphaned.

Context from the live orphan backlog: the preview sweeper runs fine and dispatches removes, but the removes fail, so orphans persist (~250 stages in state vs ~15 open PRs). The failures are a desync left by an interrupted or partial prior remove (a CI job-timeout kill, a runner death, or an out-of-band delete). Two shapes, both seen on real stages:

- A resource deleted out-of-band but still in state -> the retry errors "not found", e.g. `ListenerNotFound` after its ALB was deleted. This is the dominant one across the backlog.
- A resource live in AWS but dropped from state -> its security-group delete hits `DependencyViolation`, because the live ALB's ENI and the `AlbToTask` rule on the shared `default` SG still pin it.

A clean single-shot `sst remove` always works; only a desynced state fails.

## Why not `sst refresh`

The obvious reconcile is `sst refresh`, but it can NOT be used here: refresh runs the program and bundles every function, which fails in the remove job's PUBLIC checkout because premium handlers exist only in the private overlay (`Handler not found ...premium-generated...`). It would be a no-op in CI. `sst state ...` and `sst remove` do NOT bundle, so the self-heal is done with state surgery instead.

## Changes

`.github/actions/sst-remove-idempotent/action.yml` — after the existing unlock/Locked handling, a bounded (6-pass) self-heal loop that only runs after a failed remove:

- Not-found error (`ListenerNotFound`, etc.): drop the phantom resource named on the sst `|  Error <parent> -> <name> <type>` line from state (`sst state remove <name>`), then retry. Clears the dominant backlog class.
- `DependencyViolation`: run `reconcile-orphaned-alb.sh`, then retry.
- Any other failure: stop and surface it.

`.github/actions/sst-remove-idempotent/reconcile-orphaned-alb.sh` (new) — strictly stage-scoped: acts only on SGs tagged `sst:stage=<stage>` and the ingress rules on the VPC `default` SG that reference them (never prod or another stage). Revokes the dangling `AlbToTask` rule, deletes the live untracked ALB, waits for ENI drain, deletes the SG. Best-effort and idempotent.

## Tests

- Real orphan `pr297` (`ListenerNotFound`): state-removing the one phantom listener let `sst remove` finish the whole teardown (the gone ALB deleted idempotently, SG deleted, no `DependencyViolation`). Stage fully removed.
- Testbed (mocked ALB topology), live-but-untracked ALB: reconcile -> retry removes it with zero residue (ALB, SG, dangling `AlbToTask` rule all gone).
- Confirmed `sst refresh` fails to bundle in the public checkout (premium handlers) while `sst state export`/`remove` and `sst remove` do not - hence the state-surgery approach.
- `action.yml` parses (`yaml.safe_load`); the remove-step script and `reconcile-orphaned-alb.sh` pass `bash -n`; the phantom-name parse extracts the child resource (not its parent).

## Guide for Testers

1. Re-run a currently-failing orphan remove and confirm it now self-heals: `gh workflow run preview.yml -R Bike4Mind/bike4mind-deployer -f pr=<a closed-PR stage> -f action=remove`. Expect the run to succeed where it previously failed with `ListenerNotFound` or `DependencyViolation`, and the stage's SST state + any leftover ALB/SG to be gone afterward.
2. Happy path unchanged: a normal remove of a live preview succeeds without entering the self-heal loop.
3. Scoping safety: the reconcile only selects SGs tagged `sst:stage=<that stage>`; a stage with no orphaned ALB is a no-op.
