### PR TITLE
fix(client): filter private/reserved IPv6 in getClientIp

### DIFF
--- a/apps/client/server/utils/ip.test.ts
+++ b/apps/client/server/utils/ip.test.ts
@@ -68,6 +68,24 @@ describe('getClientIp', () => {
     expect(getClientIp(req)).toBe('203.0.113.7');
   });
 
+  it('uses a public IPv6 x-forwarded-for when it is the only header present', () => {
+    const req = mockReq({ headers: { 'x-forwarded-for': '2001:db8::1' } });
+    expect(getClientIp(req)).toBe('2001:db8::1');
+  });
+
+  it.each([
+    ['loopback ::1', '::1'],
+    ['link-local fe80::/10', 'fe80::abcd'],
+    ['unique-local fc00::/7', 'fc00::1'],
+    ['unique-local fd00::/8', 'fd12:3456::1'],
+  ])('filters a private/reserved IPv6 (%s) and falls back to the socket', (_label, addr) => {
+    const req = mockReq({
+      headers: { 'x-forwarded-for': addr },
+      socketIp: '203.0.113.7',
+    });
+    expect(getClientIp(req)).toBe('203.0.113.7');
+  });
+
   it('does NOT blindly trust the leftmost x-forwarded-for when a higher-priority header exists', () => {
     const req = mockReq({
       headers: {

--- a/apps/client/server/utils/ip.test.ts
+++ b/apps/client/server/utils/ip.test.ts
@@ -73,11 +73,19 @@ describe('getClientIp', () => {
     expect(getClientIp(req)).toBe('2001:db8::1');
   });
 
+  it('accepts a public IPv4-mapped IPv6 (strip must not over-reject)', () => {
+    const req = mockReq({ headers: { 'x-forwarded-for': '::ffff:203.0.113.7' } });
+    expect(getClientIp(req)).toBe('::ffff:203.0.113.7');
+  });
+
   it.each([
     ['loopback ::1', '::1'],
+    ['expanded loopback', '0:0:0:0:0:0:0:1'],
+    ['unspecified ::', '::'],
     ['link-local fe80::/10', 'fe80::abcd'],
     ['unique-local fc00::/7', 'fc00::1'],
     ['unique-local fd00::/8', 'fd12:3456::1'],
+    ['IPv4-mapped private', '::ffff:10.0.0.1'],
   ])('filters a private/reserved IPv6 (%s) and falls back to the socket', (_label, addr) => {
     const req = mockReq({
       headers: { 'x-forwarded-for': addr },

--- a/apps/client/server/utils/ip.ts
+++ b/apps/client/server/utils/ip.ts
@@ -6,8 +6,12 @@ import type { Request } from 'express';
 
 const PRIVATE_IPV4_RANGES: RegExp[] = [/^10\./, /^127\./, /^169\.254\./, /^172\.(1[6-9]|2\d|3[0-1])\./, /^192\.168\./];
 
-function isPrivateIpv4(ip: string): boolean {
-  return PRIVATE_IPV4_RANGES.some(r => r.test(ip));
+// Loopback (::1), link-local (fe80::/10 -> fe80..febf), and unique-local (fc00::/7 -> fc00..fdff).
+// Matched case-insensitively on the leading hextets.
+const PRIVATE_IPV6_RANGES: RegExp[] = [/^::1$/i, /^fe[89ab][0-9a-f]:/i, /^f[cd][0-9a-f]{2}:/i];
+
+function isPrivateIp(ip: string): boolean {
+  return PRIVATE_IPV4_RANGES.some(r => r.test(ip)) || PRIVATE_IPV6_RANGES.some(r => r.test(ip));
 }
 
 function cleanIp(raw: string | undefined | null): string | null {
@@ -30,6 +34,9 @@ export function getClientIp(req: Request): string {
   // The port is always the trailing `:<digits>` for both IPv4 and IPv6 forms.
   const cfViewer = req.headers?.['cloudfront-viewer-address'];
   if (typeof cfViewer === 'string' && cfViewer.trim()) {
+    // CloudFront delivers this as unbracketed IPv6/IPv4 plus a decimal ephemeral
+    // port, so the trailing `:<digits>` is always the port. Do not reuse this
+    // regex on a port-less value - it would strip a final IPv6 hextet.
     const ip = cfViewer.trim().replace(/:\d+$/, '');
     if (ip) return ip;
   }
@@ -47,7 +54,7 @@ export function getClientIp(req: Request): string {
     // Callers may pass a NextApiRequest-like object whose `headers` is absent
     // (e.g. some handler/test contexts); without this guard the loop throws.
     const ip = cleanIp(req.headers?.[header] as string | undefined);
-    if (ip && !isPrivateIpv4(ip)) return ip;
+    if (ip && !isPrivateIp(ip)) return ip;
   }
 
   const socketIp = cleanIp((req.socket as any)?.remoteAddress || (req.connection as any)?.remoteAddress);

--- a/apps/client/server/utils/ip.ts
+++ b/apps/client/server/utils/ip.ts
@@ -6,12 +6,28 @@ import type { Request } from 'express';
 
 const PRIVATE_IPV4_RANGES: RegExp[] = [/^10\./, /^127\./, /^169\.254\./, /^172\.(1[6-9]|2\d|3[0-1])\./, /^192\.168\./];
 
-// Loopback (::1), link-local (fe80::/10 -> fe80..febf), and unique-local (fc00::/7 -> fc00..fdff).
+// Loopback (::1 and its fully-expanded 0:0:0:0:0:0:0:1 form), unspecified (::),
+// link-local (fe80::/10 -> fe80..febf), and unique-local (fc00::/7 -> fc00..fdff).
 // Matched case-insensitively on the leading hextets.
-const PRIVATE_IPV6_RANGES: RegExp[] = [/^::1$/i, /^fe[89ab][0-9a-f]:/i, /^f[cd][0-9a-f]{2}:/i];
+const PRIVATE_IPV6_RANGES: RegExp[] = [
+  /^::1$/i,
+  /^(?:0{1,4}:){7}0{0,3}1$/i,
+  /^::$/,
+  /^fe[89ab][0-9a-f]:/i,
+  /^f[cd][0-9a-f]{2}:/i,
+];
+
+// Matches the ::ffff:<IPv4> mapped prefix so we can re-check the embedded dotted
+// IPv4 against the private ranges. The exotic hex-encoded mapped form
+// (::ffff:0a00:0001) is intentionally not normalized - see follow-up.
+const IPV4_MAPPED_PREFIX = /^::ffff:/i;
 
 function isPrivateIp(ip: string): boolean {
-  return PRIVATE_IPV4_RANGES.some(r => r.test(ip)) || PRIVATE_IPV6_RANGES.some(r => r.test(ip));
+  if (PRIVATE_IPV4_RANGES.some(r => r.test(ip))) return true;
+  if (PRIVATE_IPV6_RANGES.some(r => r.test(ip))) return true;
+  // IPv4-mapped IPv6 (e.g. ::ffff:10.0.0.1): strip the prefix and re-test as IPv4.
+  const mapped = ip.replace(IPV4_MAPPED_PREFIX, '');
+  return mapped !== ip && PRIVATE_IPV4_RANGES.some(r => r.test(mapped));
 }
 
 function cleanIp(raw: string | undefined | null): string | null {


### PR DESCRIPTION
# Pull Request

## Proof it works

Backend-only change, no UI to screenshot. The proof is the test suite (30 passed, including the new private/reserved-IPv6 filter cases). Reproduce with:

```
cd apps/client && pnpm vitest run server/utils/ip.test.ts --reporter=verbose
```

<img width="3588" height="1916" alt="image" src="https://github.com/user-attachments/assets/7b2951e8-a2c3-4c74-9435-e0061852082a" />

## Description

IPv6 hardening follow-ups for `getClientIp` in `apps/client/server/utils/ip.ts` (closes #180).

The client-IP resolver's private-range filter only knew IPv4, so private/reserved IPv6 addresses (`::1`, `fe80::/10`, `fc00::/7`) could pass the `!isPrivate...` check in the header loop and be recorded as a "public" client IP. This PR teaches the filter about those IPv6 ranges and documents the CloudFront port-strip assumption.

This is P3 hardening, not a live bug fix. Neither edge case is exploitable in the current topology: on the CloudFront edge, `cloudfront-viewer-address` short-circuits `getClientIp` before the header loop runs, so a private IPv6 never reaches the filter today. The change matters only if the app is ever fronted by IPv6-aware infrastructure that populates `cf-connecting-ip` / `true-client-ip` / `x-real-ip` / `x-forwarded-for`.

## Changes

- Add `PRIVATE_IPV6_RANGES` covering loopback (`::1` and its expanded `0:0:0:0:0:0:0:1` form), unspecified (`::`), link-local (`fe80::/10` -> `fe80..febf`), and unique-local (`fc00::/7` -> `fc00..fdff`).
- Also strip the `::ffff:` prefix from IPv4-mapped IPv6 and re-check the embedded dotted IPv4 against the private ranges (e.g. `::ffff:10.0.0.1`). The exotic hex-encoded mapped form (`::ffff:0a00:0001`) is intentionally not normalized; a normalized `net`/`ipaddr.js` parse would close that too, but is out of scope for this hardening item.
- Rename `isPrivateIpv4` -> `isPrivateIp` and union the IPv4 + IPv6 checks; use it in the header loop.
- Add a comment on the `cloudfront-viewer-address` port-strip regex noting CloudFront always appends a decimal ephemeral port, so the trailing `:<digits>` is always the port - and warning against reusing the regex on a port-less value (it would strip a final IPv6 hextet).
- No behavior change for public IPv4, public IPv6, or the CloudFront viewer address; only private/reserved-IPv6 rejection in the header loop is new.

## Tests

- `apps/client/server/utils/ip.test.ts`:
  - Public IPv6 `x-forwarded-for` is accepted; public IPv4-mapped (`::ffff:203.0.113.7`) is accepted (the mapped strip must not over-reject).
  - Parameterized reject of private/reserved IPv6 (`::1`, expanded `0:0:0:0:0:0:0:1`, unspecified `::`, `fe80::abcd`, `fc00::1`, `fd12:3456::1`, IPv4-mapped `::ffff:10.0.0.1`), falling back to the socket address.
  - (The IPv6 `cloudfront-viewer-address` port-strip case was already covered.)
- Full client suite green; `ip.test.ts` 30 passed.

## Guide for Testers

This is a backend-only change to an internal IP-resolution utility with no UI surface, and the affected code path is unreachable in the current CloudFront topology. There is no manual black-box repro to run.

### What NOT to test

- Do not attempt to trigger the private-IPv6 filter through the app - `cloudfront-viewer-address` short-circuits the resolver before the header loop, so the path cannot be reached from normal traffic.
- No web UI, admin settings, or telemetry field changes.

### Regression Checks

- Confirm normal traffic still records correct public client IPs in audit/telemetry logs (behavior for public IPv4 and the CloudFront viewer address is unchanged).

## Security Testing (for security-labeled PRs only)

This issue is security-labeled but explicitly non-exploitable: the vulnerable header loop is unreachable behind CloudFront, so there is no live vulnerability to reproduce on staging or a preview environment.

Correctness is proven at the unit-test layer instead. Reverting the one-line filter swap (`isPrivateIp` -> `isPrivateIpv4`) turns the private-IPv6 tests red; restoring it turns them green - demonstrating the tests exercise the changed behavior rather than passing vacuously.

- [ ] Vulnerability reproduced on staging - N/A: code path unreachable in current topology (see above).
- [ ] Fix verified on PR preview - N/A: no live repro; verified via red/green unit tests.
- [x] Production is assumed to match staging (no direct-to-prod deploys).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
