### PR TITLE
fix(scripts): anchor prod release tag to the deployed commit, not the prod branch

### DIFF
--- a/packages/scripts/src/createProductionRelease.ts
+++ b/packages/scripts/src/createProductionRelease.ts
@@ -194,7 +194,11 @@ async function main(): Promise<void> {
         tag: nextVersion,
         name: releaseName,
         body: releaseBody,
-        targetCommitish: 'prod',
+        // Anchor the release tag to the same ref the changelog was computed
+        // against (target-branch). For the prod-branch flow this is 'prod'
+        // (unchanged); for a SHA-promote (deploy console) it is the deployed
+        // commit, so the tag lands on what actually shipped, not a stale branch.
+        targetCommitish: targetBranch,
       });
       releaseUrl = release.html_url;
       console.log(`   ✅ Release created: ${releaseUrl}\n`);


### PR DESCRIPTION
## What

`createProductionRelease` hardcoded `targetCommitish: 'prod'`, so the `vN.N.N.N` GitHub Release tag was always placed at the `prod` branch tip.

Under the new SHA-promote model (the deploy console dispatches `deploy-tier.yml tier=production` for a specific `main` commit and does not move the `prod` branch), that tip is stale. The changelog range is already computed against `--target-branch`; this change anchors the release tag to the same ref, so the tag lands on exactly what shipped.

- Legacy push-to-prod flow: `--target-branch` is `prod`, so behavior is unchanged.
- SHA-promote flow: `--target-branch` is the deployed commit SHA, so the tag anchors to that commit.

## Why

Enables the prod-promotion console to reproduce the pretty changelog release on a console-driven promotion (the console never pushes the `prod` branch). Companion change: the deployer's `deploy-tier.yml` dispatches this workflow with `target_branch=<deployed sha>` after a successful production deploy.

## Notes

One-line change in `packages/scripts`. The local pre-push typecheck flagged unrelated pre-existing errors in `@bike4mind/cli` (missing local dev deps in my clone); CI validates the real state here.
