### PR TITLE
fix(client): show notification badge on More menu

### DIFF
--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -468,15 +468,17 @@ const ProfileMenu = () => {
               icon={<FormatListBulletedIcon sx={{ fontSize: '18px' }} />}
               label={t('common.more', 'More')}
               endDecorator={
-                <ChevronLeftIcon
-                  sx={{
-                    fontSize: '18px',
-                    color: 'text.tertiary',
-                    transition: 'transform 0.2s ease',
-                    // Points right when closed; rotates to the open (left) state on expand.
-                    transform: moreOpen ? 'rotate(0deg)' : 'rotate(180deg)',
-                  }}
-                />
+                <InboxBadge>
+                  <ChevronLeftIcon
+                    sx={{
+                      fontSize: '18px',
+                      color: 'text.tertiary',
+                      transition: 'transform 0.2s ease',
+                      // Points right when closed; rotates to the open (left) state on expand.
+                      transform: moreOpen ? 'rotate(0deg)' : 'rotate(180deg)',
+                    }}
+                  />
+                </InboxBadge>
               }
               onClick={() => setMoreOpen(v => !v)}
             />


### PR DESCRIPTION
## Description

Closes #377.

This fixes the notification dot not appearing on the intermediate More row in the side-nav profile menu.

## Changes

- Wraps the More menu chevron with `InboxBadge`
- Allows unread inbox messages or pending invites to bubble up to the More menu row
- Keeps the existing Inbox flyout badge behavior unchanged

## Guide for Testers

1. Use an account with an unread inbox message or pending invite.
2. Open the profile menu from the side nav.
3. Verify the More row shows the notification dot.
4. Open More and verify the Inbox item still shows its badge.

## Additional Information

The existing `InboxBadge` component already aggregates unread inbox messages and pending invites. This change reuses that component instead of duplicating notification-state logic.

## Developer Notes (Optional)

Validated locally with:

- `pnpm exec eslint apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx`
- `git diff --check`

## Security Testing (for security-labeled PRs only)

Not applicable.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings