### PR TITLE
fix(cli): set B4M_SOURCE_MODE in the pnpm dev script so source runs default to the local dev server

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "dev": "tsx src/index.tsx",
+    "dev": "B4M_SOURCE_MODE=1 tsx src/index.tsx",
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
     "typecheck:native": "tsgo --noEmit --types node",


### PR DESCRIPTION
## Summary

`pnpm dev` in `packages/cli` fails at startup with:

```
ApiEndpointUnconfiguredError: No API endpoint configured.
```

Source-mode runs are supposed to default to the local dev server (`http://localhost:3001`) — see `resolveApiEndpoint()` / `isSourceMode()` in `src/utils/apiUrl.ts`, whose docstring explicitly lists `pnpm dev` as a source-mode case. But source mode is signaled via `B4M_SOURCE_MODE=1`, which only `bin/bike4mind-cli.mjs` sets — and the `dev` script runs `tsx src/index.tsx` directly, bypassing the bin. With no baked brand default in a source run and no custom URL, endpoint resolution lands on `unconfigured` and startup throws.

## Change

Set `B4M_SOURCE_MODE=1` in the `dev` script, matching what the bin launcher does for source runs.

## Verification

Ran `pnpm dev` before and after: before it throws `ApiEndpointUnconfiguredError`; after it initializes and renders the app (pointed at the dev-default endpoint).