### PR TITLE
chore(premium): set b4m-libreoncology overlay pin to f3e2a06884f21b47a22f3ebcbc3023495cd7d994

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,6 +1,6 @@
 {
   "b4m-overwatch": "3c5914574e5bdfe61a1403fc98dcf31e2962ca48",
-  "b4m-libreoncology": "43707c30d7d8f8ce3c7746711acca1177807fc40",
+  "b4m-libreoncology": "f3e2a06884f21b47a22f3ebcbc3023495cd7d994",
   "b4m-optihashi": "f0b0d79c3a415305340cd64a995c538bc2763557",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"


### PR DESCRIPTION
Sets the b4m-libreoncology overlay pin to f3e2a06884f21b47a22f3ebcbc3023495cd7d994. Overlay-pin-only change; no application source changes.