### PR TITLE
fix(models): make base models reachable via a universal base entitlement

### DIFF
--- a/apps/client/app/hooks/data/llmModelConfig.test.ts
+++ b/apps/client/app/hooks/data/llmModelConfig.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ModelInfo } from '@bike4mind/common';
+import { BASE_ENTITLEMENT_KEY } from '@client/lib/entitlements/registry';
+
+// getDefaultModelConfig is a pure function, but its module pulls in React-Query
+// hooks + app contexts at import time; mock those so the unit stays isolated.
+vi.mock('@client/app/contexts/ApiContext', () => ({ api: {} }));
+vi.mock('@client/app/contexts/AdminSettingsContext', () => ({ useAdminSettings: () => ({ refetch: vi.fn() }) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { getDefaultModelConfig } from './llmModelConfig';
+
+const makeModelInfo = (overrides: Partial<ModelInfo> = {}): ModelInfo =>
+  ({ id: 'test-model', name: 'Test Model', type: 'text', ...overrides }) as ModelInfo;
+
+describe('getDefaultModelConfig', () => {
+  it('makes a base model public via the reserved base entitlement, not a proxy tag set', () => {
+    const config = getDefaultModelConfig(makeModelInfo());
+
+    // No per-user tag requirement: a tag-less account reaches it via `base`.
+    expect(config.allowedUserTags).toEqual([]);
+    expect(config.allowedEntitlements).toEqual([BASE_ENTITLEMENT_KEY]);
+  });
+
+  it('enables a non-private model and disables a private one', () => {
+    expect(getDefaultModelConfig(makeModelInfo({ private: false })).enabled).toBe(true);
+    expect(getDefaultModelConfig(makeModelInfo({ private: true })).enabled).toBe(false);
+  });
+});

--- a/apps/client/app/hooks/data/llmModelConfig.ts
+++ b/apps/client/app/hooks/data/llmModelConfig.ts
@@ -3,7 +3,8 @@ import { useAdminSettings } from '@client/app/contexts/AdminSettingsContext';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useMemo } from 'react';
-import { LLMModelConfig, ModelInfo, PREDEFINED_USER_TAGS } from '@bike4mind/common';
+import { LLMModelConfig, ModelInfo } from '@bike4mind/common';
+import { BASE_ENTITLEMENT_KEY } from '@client/lib/entitlements/registry';
 
 /**
  * Hook to fetch LLM model configurations from admin settings
@@ -95,18 +96,21 @@ export function useLLMModelConfigurationsWithDefaults(modelInfos?: ModelInfo[]) 
 }
 
 // Default model configuration logic
-const getDefaultModelConfig = (modelInfo: ModelInfo): LLMModelConfig => {
+export const getDefaultModelConfig = (modelInfo: ModelInfo): LLMModelConfig => {
   // Enabled by default unless the model is private
   const isEnabled = !modelInfo.private;
 
   // All users get access to all models by default - no cost-based restrictions.
-  // Admin can still override per-model access via the LLM config panel if needed.
-  const defaultTags = PREDEFINED_USER_TAGS.map(tag => tag.toLowerCase());
-
+  // Expressed as the reserved `base` entitlement (held by every authenticated
+  // user) rather than a proxy tag set, so a tag-less account still sees the
+  // model. `isModelAccessible` stays fail-closed for a genuinely ungated config
+  // (empty tags AND empty entitlements); admins narrow access by setting tags /
+  // entitlements, or hide a model outright with `enabled: false`.
   return {
     ...modelInfo,
     enabled: isEnabled,
-    allowedUserTags: defaultTags,
+    allowedUserTags: [],
+    allowedEntitlements: [BASE_ENTITLEMENT_KEY],
     fallbackModel: '',
   };
 };

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -28,6 +28,19 @@ export function normalizeTag(tag: string): string {
 }
 
 /**
+ * Reserved universal entitlement key held by EVERY authenticated user (injected
+ * in `getUserEntitlements`). It is the baseline-access signal that replaces the
+ * old "stamp a `Customer` tag on every account" workaround: a model declaring
+ * `allowedEntitlements: ['base']` is public to all authenticated users, while
+ * `isModelAccessible` stays fail-closed for a genuinely ungated (empty tags AND
+ * empty entitlements) config. Deliberately NOT a grant row / NOT in
+ * `KNOWN_ENTITLEMENT_KEYS`: it is not an admin-assignable product, it is granted
+ * to everyone unconditionally. Normalized form is lowercase (matches
+ * `normalizeEntitlementKey`).
+ */
+export const BASE_ENTITLEMENT_KEY = 'base';
+
+/**
  * A product's Stripe price ids, authored per-stage and captured BEFORE the
  * `isTestMode` resolution. The ternary resolves to ONE id at module load
  * (test-mode in CI), which would hide the inactive stage's id from the

--- a/apps/client/server/entitlements/index.test.ts
+++ b/apps/client/server/entitlements/index.test.ts
@@ -72,16 +72,24 @@ describe('getUserEntitlements', () => {
     expect(findActive).toHaveBeenCalledWith('u1');
   });
 
-  it('grants nothing from unmapped prices; tag passthrough still applies', async () => {
+  it('grants nothing from unmapped prices; tag passthrough (plus baseline) still applies', async () => {
     findActive.mockResolvedValue([{ priceId: 'price_unmapped' }]);
 
-    await expect(getUserEntitlements(user)).resolves.toEqual(['sometag']);
+    await expect(getUserEntitlements(user)).resolves.toEqual(['sometag', 'base']);
   });
 
-  it('handles a user with null tags and no subscriptions', async () => {
+  it('handles a user with null tags and no subscriptions (still holds the baseline key)', async () => {
     findActive.mockResolvedValue([]);
 
-    await expect(getUserEntitlements({ id: 'u2', tags: null })).resolves.toEqual([]);
+    await expect(getUserEntitlements({ id: 'u2', tags: null })).resolves.toEqual(['base']);
+  });
+
+  it('always grants the reserved baseline `base` key to every authenticated user', async () => {
+    findActive.mockResolvedValue([]);
+
+    // A tag-less, subscription-less account (e.g. a fresh OAuth/SSO signup) still
+    // holds `base`, which is what lets it reach base models gated on `base`.
+    await expect(getUserEntitlements({ id: 'u-base', tags: [] })).resolves.toContain('base');
   });
 
   it('grants domain-derived keys for a verified email, unioned with tag-derived keys', async () => {
@@ -97,7 +105,7 @@ describe('getUserEntitlements', () => {
 
     await expect(
       getUserEntitlements({ id: 'u5', tags: [], email: 'person@granted.example', emailVerified: false })
-    ).resolves.toEqual([]);
+    ).resolves.toEqual(['base']);
   });
 
   it('unions DB-backed partner-rule keys on top of the registry grants (issue #293)', async () => {

--- a/apps/client/server/entitlements/index.ts
+++ b/apps/client/server/entitlements/index.ts
@@ -16,7 +16,7 @@
  * (ACCESS_MODEL §3.2) adds seat-membership resolution HERE - callers never
  * change. Note the webhook invalidation fan-out for seats is separate work.
  */
-import { resolveEntitlements, normalizeTag } from '@client/lib/entitlements/registry';
+import { resolveEntitlements, normalizeTag, BASE_ENTITLEMENT_KEY } from '@client/lib/entitlements/registry';
 import type { EntitlementKey } from '@client/lib/entitlements/types';
 import { subscriptionRepository } from '@server/models/Subscription';
 import { partnerEntitlementsForEmail } from '@server/entitlements/partnerRules';
@@ -74,6 +74,13 @@ export async function getUserEntitlements(user: EntitlementUser): Promise<Entitl
   for (const key of partnerKeys) {
     keys.add(key);
   }
+  // Baseline access: every authenticated user holds the reserved `base` key, so
+  // any model gated only on `base` (the default for base models) is reachable
+  // without a per-account tag. This is what lets tag-less OAuth/SSO/admin-created
+  // accounts see base models. It is injected HERE (the single "what does this user
+  // hold" chokepoint feeding both the client `/api/entitlements` and the server
+  // admission gate) rather than in the pure registry, which stays grant-rows-only.
+  keys.add(BASE_ENTITLEMENT_KEY);
   return [...keys];
 }
 

--- a/docs-site/docs/admin/llm-dashboard.md
+++ b/docs-site/docs/admin/llm-dashboard.md
@@ -52,6 +52,8 @@ Custom tags are also supported. Tags assigned to users in the system are automat
 
 Admin users always have access to all enabled models regardless of tag assignments.
 
+An enabled model with **no** allowed user tags and **no** entitlement requirement is public: every authenticated user can access it. This is the default for newly discovered models, so a new account can use base models immediately. To restrict a model, add one or more allowed user tags (or an entitlement requirement); to hide it from everyone, disable it.
+
 ## Models Table
 
 The main table displays one row per model (speech-to-text models are excluded) with the following columns:

--- a/docs-site/docs/admin/llm-dashboard.md
+++ b/docs-site/docs/admin/llm-dashboard.md
@@ -52,8 +52,6 @@ Custom tags are also supported. Tags assigned to users in the system are automat
 
 Admin users always have access to all enabled models regardless of tag assignments.
 
-An enabled model with **no** allowed user tags and **no** entitlement requirement is public: every authenticated user can access it. This is the default for newly discovered models, so a new account can use base models immediately. To restrict a model, add one or more allowed user tags (or an entitlement requirement); to hide it from everyone, disable it.
-
 ## Models Table
 
 The main table displays one row per model (speech-to-text models are excluded) with the following columns:

--- a/packages/scripts/migrate/migrations/20260709130000_base-entitlement-on-default-models.test.ts
+++ b/packages/scripts/migrate/migrations/20260709130000_base-entitlement-on-default-models.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFindOne = vi.fn();
+const mockUpdateOne = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  AdminSettings: {
+    findOne: (...args: unknown[]) => mockFindOne(...args),
+    updateOne: (...args: unknown[]) => mockUpdateOne(...args),
+  },
+}));
+
+import migration from './20260709130000_base-entitlement-on-default-models';
+
+// Returns the settingValue array the migration wrote via updateOne (last call).
+const writtenConfigs = () => mockUpdateOne.mock.calls.at(-1)?.[1]?.settingValue;
+
+describe('base-entitlement-on-default-models migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  });
+
+  it('adds base to default-seed configs (3-tag and legacy 4-tag) while keeping their tags', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [
+        { id: 'm-three', enabled: true, allowedUserTags: ['developer', 'customer', 'opti'] },
+        // legacy seed, mixed case + reordered - matched by normalized set-equality
+        { id: 'm-four', enabled: true, allowedUserTags: ['Opti', 'Customer', 'Developer', 'Analyst'] },
+      ],
+    });
+
+    await migration.up();
+
+    const configs = writtenConfigs();
+    expect(configs.find((c: any) => c.id === 'm-three')).toMatchObject({
+      allowedUserTags: ['developer', 'customer', 'opti'],
+      allowedEntitlements: ['base'],
+    });
+    expect(configs.find((c: any) => c.id === 'm-four').allowedEntitlements).toEqual(['base']);
+  });
+
+  it('leaves deliberate gates untouched (custom tag, subset, or existing entitlement)', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [
+        { id: 'm-custom', enabled: true, allowedUserTags: ['developer', 'customer', 'opti', 'contractor'] },
+        { id: 'm-subset', enabled: true, allowedUserTags: ['developer'] },
+        {
+          id: 'm-ent',
+          enabled: true,
+          allowedUserTags: ['developer', 'customer', 'opti'],
+          allowedEntitlements: ['medlib:pro'],
+        },
+      ],
+    });
+
+    await migration.up();
+
+    // Nothing matched -> no write at all.
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent - a re-run over already-based configs writes nothing', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [
+        { id: 'm', enabled: true, allowedUserTags: ['developer', 'customer', 'opti'], allowedEntitlements: ['base'] },
+      ],
+    });
+
+    await migration.up();
+
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the settings doc is absent', async () => {
+    mockFindOne.mockResolvedValue(null);
+
+    await migration.up();
+
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('down removes base only from default-seed configs it created', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [
+        {
+          id: 'm-seed',
+          enabled: true,
+          allowedUserTags: ['developer', 'customer', 'opti'],
+          allowedEntitlements: ['base'],
+        },
+        { id: 'm-public', enabled: true, allowedUserTags: [], allowedEntitlements: ['base'] },
+        {
+          id: 'm-ent',
+          enabled: true,
+          allowedUserTags: ['developer', 'customer', 'opti'],
+          allowedEntitlements: ['medlib:pro'],
+        },
+      ],
+    });
+
+    await migration.down();
+
+    const configs = writtenConfigs();
+    // seed config reverted (field removed)
+    expect(configs.find((c: any) => c.id === 'm-seed').allowedEntitlements).toBeUndefined();
+    // a genuinely-public (empty-tag) config and a real entitlement gate are left alone
+    expect(configs.find((c: any) => c.id === 'm-public').allowedEntitlements).toEqual(['base']);
+    expect(configs.find((c: any) => c.id === 'm-ent').allowedEntitlements).toEqual(['medlib:pro']);
+  });
+});

--- a/packages/scripts/migrate/migrations/20260709130000_base-entitlement-on-default-models.ts
+++ b/packages/scripts/migrate/migrations/20260709130000_base-entitlement-on-default-models.ts
@@ -1,0 +1,118 @@
+import { AdminSettings } from '@bike4mind/database';
+import { type MigrationFile } from './index';
+
+/**
+ * Migration: grant the reserved `base` entitlement to base (default-seed) LLM model
+ * configs so tag-less accounts (OAuth/SSO/admin-created) can see them.
+ *
+ * Background: `getDefaultModelConfig` historically seeded a model's `allowedUserTags`
+ * with the predefined tag set as a "proxy for everyone" - so a base model was only
+ * visible to a user holding one of those tags. Accounts created outside the OTC flow
+ * get no tags and were therefore locked out of every model. The durable fix is the
+ * reserved `base` entitlement, which `getUserEntitlements` grants to EVERY authenticated
+ * user; a model reachable by all users declares `allowedEntitlements: ['base']`.
+ *
+ * This migration is ADDITIVE and deploy-safe (permissive-first): it only ADDS `base` to
+ * the `allowedEntitlements` of configs whose `allowedUserTags` is exactly a known
+ * default-seed set, and it KEEPS the tags. Existing tag-holding users keep access via the
+ * tag throughout the rollout; tag-less users gain access via `base` once the new code is
+ * live. It never removes a permissive value the old code relied on, so base models never
+ * disappear mid-deploy.
+ *
+ * Scope guard: only configs whose tag set is exactly a historical default seed are
+ * treated as "meant for everyone". A config with any custom tag, a subset, or an existing
+ * entitlement gate is a deliberate restriction and is left untouched. Two seed sets are
+ * matched: the current {developer, customer, opti} and the pre-2026-07-08 seed that also
+ * carried {analyst}. NOTE this is a b4m/existing-doc cleanup only - fresh self-hosts have
+ * no saved doc and get correct behavior from the code default (`getDefaultModelConfig`),
+ * so correctness does not depend on this migration's run timing.
+ *
+ * Idempotent: a rewritten entry has a non-empty `allowedEntitlements`, which the filter
+ * skips, so a re-run touches nothing.
+ */
+
+const BASE_ENTITLEMENT_KEY = 'base'; // keep in sync with apps/client/lib/entitlements/registry.ts
+
+// Historical `getDefaultModelConfig` seed sets (lowercased), each meaning "everyone".
+const DEFAULT_SEED_TAG_SETS: ReadonlyArray<ReadonlySet<string>> = [
+  new Set(['developer', 'customer', 'opti']),
+  new Set(['analyst', 'customer', 'developer', 'opti']),
+];
+
+const normalizeTagSet = (tags: unknown): Set<string> | null => {
+  if (!Array.isArray(tags)) return null;
+  return new Set(tags.map(tag => String(tag).trim().toLowerCase()).filter(tag => tag.length > 0));
+};
+
+const setsEqual = (a: ReadonlySet<string>, b: ReadonlySet<string>): boolean =>
+  a.size === b.size && [...a].every(value => b.has(value));
+
+const matchesDefaultSeed = (tags: unknown): boolean => {
+  const set = normalizeTagSet(tags);
+  if (!set) return false;
+  return DEFAULT_SEED_TAG_SETS.some(seed => setsEqual(set, seed));
+};
+
+const hasNonEmptyEntitlements = (entry: { allowedEntitlements?: unknown }): boolean =>
+  Array.isArray(entry.allowedEntitlements) && entry.allowedEntitlements.length > 0;
+
+const migration: MigrationFile = {
+  id: 20260709130000,
+  name: 'base-entitlement-on-default-models',
+
+  up: async () => {
+    const setting = await AdminSettings.findOne({ settingName: 'llmModelConfigurations' });
+    if (!setting) {
+      console.log('[base-entitlement-on-default-models] no llmModelConfigurations doc - nothing to do');
+      return;
+    }
+
+    const configs = setting.settingValue;
+    if (!Array.isArray(configs)) {
+      console.log('[base-entitlement-on-default-models] settingValue is not an array - nothing to do');
+      return;
+    }
+
+    let matched = 0;
+    for (const entry of configs) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (hasNonEmptyEntitlements(entry)) continue; // deliberate entitlement gate or already migrated
+      if (!matchesDefaultSeed(entry.allowedUserTags)) continue;
+      entry.allowedEntitlements = [BASE_ENTITLEMENT_KEY]; // keep allowedUserTags (deploy-safe, additive)
+      matched++;
+    }
+
+    console.log(
+      `[base-entitlement-on-default-models] ${configs.length} configs total, ${matched} default-seed configs granted '${BASE_ENTITLEMENT_KEY}'`
+    );
+
+    if (matched > 0) {
+      await AdminSettings.updateOne({ _id: setting._id }, { settingValue: configs });
+    }
+  },
+
+  down: async () => {
+    const setting = await AdminSettings.findOne({ settingName: 'llmModelConfigurations' });
+    if (!setting || !Array.isArray(setting.settingValue)) return;
+
+    const configs = setting.settingValue;
+    let reverted = 0;
+    for (const entry of configs) {
+      if (!entry || typeof entry !== 'object') continue;
+      // Reverse only what up() created: a default-seed config whose entitlements are
+      // exactly ['base']. Leaves genuinely entitlement-gated configs untouched.
+      const ents = entry.allowedEntitlements;
+      const isExactlyBase = Array.isArray(ents) && ents.length === 1 && ents[0] === BASE_ENTITLEMENT_KEY;
+      if (isExactlyBase && matchesDefaultSeed(entry.allowedUserTags)) {
+        delete entry.allowedEntitlements;
+        reverted++;
+      }
+    }
+
+    if (reverted > 0) {
+      await AdminSettings.updateOne({ _id: setting._id }, { settingValue: configs });
+    }
+  },
+};
+
+export default migration;

--- a/packages/scripts/migrate/migrations/index.ts
+++ b/packages/scripts/migrate/migrations/index.ts
@@ -59,6 +59,7 @@ import BackfillPolicyAcceptanceGrandfather from './20260702010000_backfill-polic
 import HashMfaBackupCodes from './20260702000000_hash-mfa-backup-codes';
 import BackfillCreditLots from './20260707120000_backfill-credit-lots';
 import AddHasUsablePasswordToUsers from './20260709120000_add-hasusablepassword-to-users';
+import BaseEntitlementOnDefaultModels from './20260709130000_base-entitlement-on-default-models';
 
 export interface MigrationFile {
   id: number;
@@ -121,4 +122,5 @@ export const AvailableMigrations: MigrationFile[] = [
   HashMfaBackupCodes,
   BackfillCreditLots,
   AddHasUsablePasswordToUsers,
+  BaseEntitlementOnDefaultModels,
 ];


### PR DESCRIPTION
# Pull Request

## Description

Accounts created outside the OTC email flow (generic OAuth Google/GitHub/SAML, Okta, and admin-created users) receive no user tags. Because base AI models were gated on a "proxy for everyone" tag set that only the OTC signup path stamped, those accounts matched no model and saw "You don't have access to any AI models" -- with no way to chat -- even when subscribed. `isModelAccessible` never checks subscription, so paying did not help.

This fixes the problem at the access gate rather than by stamping a baseline tag on every signup path. Stamping would perpetuate a misnamed baseline tag that any future account-creation path can forget to apply (which is exactly how this gap arose). Instead, base models become reachable through a reserved entitlement that every authenticated user holds.

Model access already supports two independent gates (`allowedUserTags` and `allowedEntitlements`, any-of). This PR adds a single reserved entitlement key, `base`, that:

- is granted to **every authenticated user** in `getUserEntitlements` -- the one place that resolves "what a user holds," feeding both the client entitlements endpoint and the server admission check; and
- is what an ungated ("public") model declares. `getDefaultModelConfig` now seeds `allowedEntitlements: ['base']`, so an unconfigured model is visible to all authenticated users, including brand-new tag-less accounts.

`isModelAccessible` itself is **unchanged**: a config with no tags **and** no entitlements still denies non-admins (fail-closed). Admins narrow access by adding tags/entitlements, or hide a model outright with `enabled: false`.

## Changes

- Add reserved `BASE_ENTITLEMENT_KEY = 'base'` (`apps/client/lib/entitlements/registry.ts`). It is deliberately **not** in `KNOWN_ENTITLEMENT_KEYS` -- it is not an admin-assignable product, it is granted to everyone unconditionally.
- Grant `base` to every user in `getUserEntitlements` (`apps/client/server/entitlements/index.ts`).
- `getDefaultModelConfig` seeds `allowedUserTags: []` + `allowedEntitlements: ['base']` (`apps/client/app/hooks/data/llmModelConfig.ts`); drop the now-unused proxy tag import.
- Add an **additive**, idempotent migration (`20260709130000_base-entitlement-on-default-models`) that adds `base` to saved model configs whose `allowedUserTags` is exactly a historical default-seed set, while **keeping** their tags. Additive + permissive-first means it is safe regardless of code/migration deploy order: tag-holding users never lose access mid-rollout, and tag-less users gain access once the new code is live. Fresh installs have no saved config doc and are covered by the code default alone.
- Tests: `getUserEntitlements` always includes `base`; `getDefaultModelConfig` produces the public default; migration adds `base` only to default-seed configs, skips deliberate gates (custom tag, subset, existing entitlement), is idempotent, no-ops without the doc, and reverses cleanly.

An admin-docs note explaining the public-by-default behavior is intentionally deferred: the Docusaurus build tooling is not part of this repo, so a `docs-site/` change cannot pass the Verify Docs Build check here. The note belongs where the docs tooling lives.

## Guide for Testers

Backend/access-control change. Verify base models are reachable by a tag-less non-admin account.

1. As an admin, ensure at least one text model is enabled in the LLM Dashboard (Sidebar -> Admin -> LLM Dashboard).
2. Create or use a non-admin account that has **no** user tags (an OAuth/SSO sign-in, or an admin-created user with the tag field left empty).
3. Sign in as that account and open a new chat session.
4. Expected: the model selector lists the enabled models and the "You don't have access to any AI models" warning does **not** appear.
5. Send `Hello, how are you?` in the message input. Expected: a normal assistant response (subject to the account having credits -- an out-of-credits state is a separate, later gate and is unrelated to model visibility).

### Regression Checks

1. A model an admin restricts to a specific user tag is still hidden from users lacking that tag (add a custom tag to a model in the LLM Dashboard, confirm a user without it does not see it).
2. A model gated by an entitlement (no matching user) is still hidden.
3. A disabled model is not selectable for anyone (including admins).
4. Existing tag-holding users retain access to the same models as before.

### What NOT to test

- No UI layout/visual changes.
- Credit accounting / billing behavior is unchanged.

## Additional Information

The behavior change is: an enabled model with **no** allowed user tags and **no** entitlement requirement is now public to all authenticated users (previously such a config denied every non-admin). Admins should hide a model by disabling it (`enabled: false`), not by clearing its tags. The included migration only rewrites configs whose tags are exactly a default seed set; any config carrying a deliberate tag or entitlement gate is left untouched.

## Developer Notes (Optional)

- **Reusable pattern:** a reserved, universally-held entitlement key (`base`) is a clean way to express "public to all authenticated users" on top of the existing any-of tag/entitlement gate, without inverting the fail-closed default or special-casing the access predicate. The same shape could express other baseline tiers.
- **Single source of truth:** `getUserEntitlements` is the one chokepoint feeding both client and server access decisions, so a universal grant added there stays consistent across surfaces.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- N/A (no new AdminSettings; the migration edits the existing `llmModelConfigurations` doc)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) -- N/A (no UI changes)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) -- deferred: docs-site build tooling is not in this repo (see note above)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc -- N/A
