### PR TITLE
chore(premium): set b4m-overwatch overlay pin to 3c5914574e5bdfe61a1403fc98dcf31e2962ca48

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,5 +1,5 @@
 {
-  "b4m-overwatch": "effd2f6a44603a6cf8368c88cf5bbeba48cdb4ec",
+  "b4m-overwatch": "3c5914574e5bdfe61a1403fc98dcf31e2962ca48",
   "b4m-libreoncology": "43707c30d7d8f8ce3c7746711acca1177807fc40",
   "b4m-optihashi": "f0b0d79c3a415305340cd64a995c538bc2763557",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",


### PR DESCRIPTION
Sets the b4m-overwatch overlay pin to 3c5914574e5bdfe61a1403fc98dcf31e2962ca48. Overlay-pin-only change; no application source changes.