### PR TITLE
fix(client): harden Notion integration reliability

### DIFF
--- a/apps/client/pages/api/mcp-servers/notion/callback.ts
+++ b/apps/client/pages/api/mcp-servers/notion/callback.ts
@@ -8,6 +8,9 @@ import { IntegrationAuditLogger } from '@server/integrations/integrationAuditLog
 import { encryptToken } from '@server/security/tokenEncryption';
 
 const OAUTH_TIMEOUT = 30000;
+const NOTION_API_TIMEOUT = 10000;
+const NOTION_API_BASE_URL = 'https://api.notion.com/v1';
+const NOTION_VERSION = '2022-06-28';
 
 interface NotionTokenResponse {
   access_token: string;
@@ -213,7 +216,20 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
     `[Notion Callback] Successfully obtained access token for workspace: ${tokenData.workspace_name || tokenData.workspace_id}`
   );
 
-  // Step 2: Store tokens in User model
+  // Step 2: Auto-detect a root page ID from pages the integration can access
+  let rootPageId: string | undefined;
+  try {
+    rootPageId = await detectRootPageId(tokenData.access_token);
+    if (rootPageId) {
+      console.log(`[Notion Callback] Auto-detected root page ID: ${rootPageId}`);
+    } else {
+      console.log('[Notion Callback] No root page auto-detected (user can set one manually)');
+    }
+  } catch (detectError) {
+    console.warn('[Notion Callback] Root page detection failed, skipping:', detectError);
+  }
+
+  // Step 3: Store tokens in User model
   const notionConnect = {
     accessToken: encryptToken(tokenData.access_token)!,
     workspaceId: tokenData.workspace_id,
@@ -235,6 +251,8 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
       : undefined,
     connectedAt: new Date(),
     status: 'connected' as const,
+    writeEnabled: true,
+    ...(rootPageId && { rootPageId }),
   };
 
   await userRepository.update({
@@ -244,19 +262,65 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
 
   console.log(`[Notion Callback] Tokens stored for user ${userId}, status: connected`);
 
-  // Step 3: Set up MCP server
+  // Step 4: Set up MCP server
   try {
     await NotionTokenManager.syncMcpServer(userId, tokenData.access_token, tokenData.workspace_id);
   } catch (mcpError) {
-    // Don't fail the callback if MCP setup fails
     console.error('[Notion Callback] MCP server setup failed, but OAuth succeeded:', mcpError);
   }
 
   auditLogger.success({ workspaceName: tokenData.workspace_name });
 
-  // Step 4: Set cookie and redirect to profile page with success status
+  // Step 5: Set cookie and redirect to profile page with success status
   res.setHeader('Set-Cookie', [`notion_connected=true; Path=/; Max-Age=60; SameSite=Lax; Secure`]);
   return res.redirect('/profile?tab=integrations&notion=connected');
 });
+
+/**
+ * Queries the Notion search API for top-level pages accessible to the integration
+ * and returns the first one as a default root page. This gives new connections a
+ * working write target without manual configuration.
+ */
+async function detectRootPageId(accessToken: string): Promise<string | undefined> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), NOTION_API_TIMEOUT);
+
+  try {
+    const response = await fetch(`${NOTION_API_BASE_URL}/search`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        filter: { value: 'page', property: 'object' },
+        sort: { direction: 'ascending', timestamp: 'last_edited_time' },
+        page_size: 10,
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) return undefined;
+
+    const data = (await response.json()) as {
+      results: Array<{
+        id: string;
+        parent?: { type: string; workspace?: boolean };
+      }>;
+    };
+
+    // Prefer a workspace-level page (top of the tree)
+    const workspacePage = data.results.find(p => p.parent?.type === 'workspace');
+    if (workspacePage) return workspacePage.id;
+
+    // Fall back to the first accessible page
+    return data.results[0]?.id;
+  } catch {
+    clearTimeout(timeoutId);
+    return undefined;
+  }
+}
 
 export default handler;

--- a/apps/client/pages/api/mcp-servers/notion/callback.ts
+++ b/apps/client/pages/api/mcp-servers/notion/callback.ts
@@ -1,6 +1,11 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { userRepository } from '@bike4mind/database';
-import { getNotionOAuthConfig, NOTION_OAUTH_TOKEN_URL } from '@server/integrations/notion';
+import {
+  getNotionOAuthConfig,
+  NOTION_OAUTH_TOKEN_URL,
+  NOTION_API_BASE_URL,
+  NOTION_VERSION,
+} from '@server/integrations/notion';
 import { NotionTokenManager } from '@server/integrations/notion/notionTokenManager';
 import { Config } from '@server/utils/config';
 import crypto from 'crypto';
@@ -9,8 +14,6 @@ import { encryptToken } from '@server/security/tokenEncryption';
 
 const OAUTH_TIMEOUT = 30000;
 const NOTION_API_TIMEOUT = 10000;
-const NOTION_API_BASE_URL = 'https://api.notion.com/v1';
-const NOTION_VERSION = '2022-06-28';
 
 interface NotionTokenResponse {
   access_token: string;
@@ -295,12 +298,12 @@ async function detectRootPageId(accessToken: string): Promise<string | undefined
       },
       body: JSON.stringify({
         filter: { value: 'page', property: 'object' },
+        // Ascending = oldest-edited first, so we pick the longest-lived root page
         sort: { direction: 'ascending', timestamp: 'last_edited_time' },
         page_size: 10,
       }),
       signal: controller.signal,
     });
-    clearTimeout(timeoutId);
 
     if (!response.ok) return undefined;
 
@@ -318,8 +321,9 @@ async function detectRootPageId(accessToken: string): Promise<string | undefined
     // Fall back to the first accessible page
     return data.results[0]?.id;
   } catch {
-    clearTimeout(timeoutId);
     return undefined;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/apps/client/pages/api/mcp-servers/notion/settings.ts
+++ b/apps/client/pages/api/mcp-servers/notion/settings.ts
@@ -1,7 +1,8 @@
 import { baseApi } from '@server/middlewares/baseApi';
-import { userRepository } from '@bike4mind/database';
+import { mcpServerRepository, userRepository } from '@bike4mind/database';
+import { McpServerName } from '@bike4mind/common';
 import { NotionTokenManager } from '@server/integrations/notion/notionTokenManager';
-import { decryptToken } from '@server/security/tokenEncryption';
+import { decryptToken, decryptEnvVariables, encryptEnvVariables } from '@server/security/tokenEncryption';
 
 const NOTION_UUID_REGEX = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
 const MAX_ALLOWED_PAGES = 50;
@@ -122,6 +123,21 @@ const handler = baseApi().patch(async (req, res) => {
       } catch (syncError) {
         console.warn('[Notion Settings] MCP sync failed after settings update:', syncError);
       }
+    } else {
+      // Token decryption failed (e.g. key rotation) but the MCP server may still
+      // have working env vars. Patch the settings-related env vars in place.
+      console.warn('[Notion Settings] Token decryption failed, using fallback env var patch');
+      try {
+        await patchMcpServerEnvVars(userId, {
+          writeEnabled: typeof writeEnabled === 'boolean' ? writeEnabled : user.notionConnect.writeEnabled,
+          rootPageId: rootPageId !== undefined ? rootPageId : (user.notionConnect.rootPageId ?? null),
+          accessMode: accessMode ?? user.notionConnect.accessMode ?? 'all',
+          allowedPages: allowedPages ?? user.notionConnect.allowedPages ?? [],
+          excludedPageIds: excludedPageIds ?? user.notionConnect.excludedPageIds ?? [],
+        });
+      } catch (patchError) {
+        console.warn('[Notion Settings] Fallback MCP env patch failed:', patchError);
+      }
     }
 
     res.status(200).json({ success: true });
@@ -130,5 +146,66 @@ const handler = baseApi().patch(async (req, res) => {
     res.status(500).json({ error: 'Failed to update Notion settings' });
   }
 });
+
+/**
+ * Patches settings-related env vars on an existing Notion MCP server without
+ * needing the raw access token. Used when the User model's encrypted token
+ * can't be decrypted but the MCP server's own env vars are still valid.
+ */
+async function patchMcpServerEnvVars(
+  userId: string,
+  settings: {
+    writeEnabled?: boolean;
+    rootPageId: string | null;
+    accessMode: 'all' | 'selected';
+    allowedPages: AllowedPage[];
+    excludedPageIds: string[];
+  }
+) {
+  const notionServer = await mcpServerRepository.findOne({
+    name: McpServerName.Notion,
+    userId,
+  });
+
+  if (!notionServer?.envVariables?.length) {
+    console.warn('[Notion Settings] No existing MCP server to patch');
+    return;
+  }
+
+  const envVars = decryptEnvVariables(notionServer.envVariables);
+  const envMap = new Map(envVars.map(v => [v.key, v.value]));
+
+  envMap.set('NOTION_WRITE_ENABLED', settings.writeEnabled ? 'true' : 'false');
+
+  if (settings.rootPageId) {
+    envMap.set('NOTION_ROOT_PAGE_ID', settings.rootPageId);
+  } else {
+    envMap.delete('NOTION_ROOT_PAGE_ID');
+  }
+
+  envMap.set('NOTION_ACCESS_MODE', settings.accessMode);
+
+  if (settings.accessMode === 'selected' && settings.allowedPages.length > 0) {
+    const compactPages = settings.allowedPages.map(p => ({ id: p.id, access: p.access }));
+    envMap.set('NOTION_ALLOWED_PAGES', JSON.stringify(compactPages));
+  } else {
+    envMap.delete('NOTION_ALLOWED_PAGES');
+  }
+
+  if (settings.excludedPageIds.length > 0) {
+    envMap.set('NOTION_EXCLUDED_PAGE_IDS', settings.excludedPageIds.join(','));
+  } else {
+    envMap.delete('NOTION_EXCLUDED_PAGE_IDS');
+  }
+
+  const updatedVars = Array.from(envMap, ([key, value]) => ({ key, value }));
+
+  await mcpServerRepository.update({
+    id: notionServer.id,
+    envVariables: encryptEnvVariables(updatedVars),
+  });
+
+  console.log('[Notion Settings] Patched MCP server env vars via fallback path');
+}
 
 export default handler;

--- a/apps/client/server/integrations/notion/index.ts
+++ b/apps/client/server/integrations/notion/index.ts
@@ -3,6 +3,7 @@ export {
   NOTION_OAUTH_AUTHORIZE_URL,
   NOTION_OAUTH_TOKEN_URL,
   NOTION_API_BASE_URL,
+  NOTION_VERSION,
 } from './notionConfig';
 
 export { NotionTokenManager, NotionReconnectRequiredError } from './notionTokenManager';

--- a/apps/client/server/integrations/notion/notionConfig.ts
+++ b/apps/client/server/integrations/notion/notionConfig.ts
@@ -39,8 +39,9 @@ export const getNotionOAuthConfig = async (): Promise<NotionOAuthConfig> => {
 };
 
 /**
- * Notion API endpoints
+ * Notion API endpoints and version
  */
 export const NOTION_OAUTH_AUTHORIZE_URL = 'https://api.notion.com/v1/oauth/authorize';
 export const NOTION_OAUTH_TOKEN_URL = 'https://api.notion.com/v1/oauth/token';
 export const NOTION_API_BASE_URL = 'https://api.notion.com/v1';
+export const NOTION_VERSION = '2022-06-28';

--- a/apps/client/server/integrations/notion/notionTokenManager.ts
+++ b/apps/client/server/integrations/notion/notionTokenManager.ts
@@ -3,6 +3,8 @@ import { McpServerName } from '@bike4mind/common';
 import { decryptToken, encryptEnvVariables } from '@server/security/tokenEncryption';
 import { NOTION_API_BASE_URL } from './notionConfig';
 
+const TOKEN_VALIDATION_TIMEOUT = 10000;
+
 /**
  * Signals expected token revocation, distinct from unexpected errors.
  */
@@ -24,6 +26,8 @@ export class NotionTokenManager {
    * Notion tokens don't expire, so validity only means "not revoked" - checked via a test API call.
    */
   private static async validateToken(accessToken: string): Promise<boolean> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TOKEN_VALIDATION_TIMEOUT);
     try {
       const response = await fetch(`${NOTION_API_BASE_URL}/users/me`, {
         method: 'GET',
@@ -32,10 +36,12 @@ export class NotionTokenManager {
           'Notion-Version': '2022-06-28',
           'Content-Type': 'application/json',
         },
+        signal: controller.signal,
       });
-
+      clearTimeout(timeoutId);
       return response.ok;
     } catch {
+      clearTimeout(timeoutId);
       return false;
     }
   }

--- a/apps/client/server/integrations/notion/notionTokenManager.ts
+++ b/apps/client/server/integrations/notion/notionTokenManager.ts
@@ -1,7 +1,7 @@
 import { userRepository, mcpServerRepository } from '@bike4mind/database';
 import { McpServerName } from '@bike4mind/common';
 import { decryptToken, encryptEnvVariables } from '@server/security/tokenEncryption';
-import { NOTION_API_BASE_URL } from './notionConfig';
+import { NOTION_API_BASE_URL, NOTION_VERSION } from './notionConfig';
 
 const TOKEN_VALIDATION_TIMEOUT = 10000;
 
@@ -33,16 +33,16 @@ export class NotionTokenManager {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${accessToken}`,
-          'Notion-Version': '2022-06-28',
+          'Notion-Version': NOTION_VERSION,
           'Content-Type': 'application/json',
         },
         signal: controller.signal,
       });
-      clearTimeout(timeoutId);
       return response.ok;
     } catch {
-      clearTimeout(timeoutId);
       return false;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION
- Auto-detect root page ID during OAuth callback so write tools work out of the box without manual configuration
- Enable writeEnabled by default on new connections
- Add fallback env var patch in settings API when User model token decryption fails, so settings changes (rootPageId, writeEnabled, etc.) still propagate to the MCP server
- Add 10s timeout to Notion token validation to prevent Lambda hangs

# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description
<!--
Provide a detailed description of what this PR does. Explain the problem you're solving or the feature you're adding.
-->

## Changes
<!--
List the changes you've made in this PR. This is to help the reviewers understand the impact of your changes.
- Change 1
- Change 2
- ...
-->

## Guide for Testers
<!--
Write step-by-step instructions that both human QA testers AND AI agents (e.g., Playwright) can follow without codebase knowledge.

Requirements:
- Number every step — one action per step
- Use exact navigation paths: "Sidebar → Admin → DLQ Management"
- Use exact URLs: "app.staging.bike4mind.com"
- Use exact input values: type `Hello, how are you?` in the message input
- State expected results after each step: "A response appears within 10 seconds with no errors"
- Include a "Regression Checks" section for refactors
- Include a "What NOT to test" section for infra/backend-only PRs

See CLAUDE.md → "Test Guide Standards" for full guidelines and examples.
-->

## Additional Information
<!--
Include any additional information or context that you think would be helpful for your reviewers.
-->

## Developer Notes (Optional)
<!--
Document capability unlocks, architectural improvements, and reusable patterns introduced by this PR.
This helps future developers understand what new building blocks are available.

Categories to consider:
- **New Extension Points**: Components/interfaces that accept new props, hooks, or configuration
- **Reusable Patterns**: New components, utilities, or approaches that can be applied elsewhere
- **Data Model Changes**: New fields, types, or structures that enable future features
- **Architecture Decisions**: Why something was built a certain way (not just what changed)

Example:
- `SchedulerTab` now accepts a `familyId` prop — any new pattern family automatically gets a Learn tab
- `ComingSoonPanel` component can be dropped into any tab to indicate future work
- `effectiveTab` pattern shows how to handle persisted tab state when tabs become conditionally disabled
-->

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
