### PR TITLE
fix(billing): guard model price seed against unbumped generatedAt

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -23,7 +23,8 @@
     "typecheck:fast": "tsgo --noEmit --types node || tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "generate:model-price-seed": "tsx src/seeds/regenerateModelPriceSeed.ts"
   },
   "dependencies": {
     "@bike4mind/common": "workspace:*",
@@ -42,6 +43,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/ui": "^4.1.9",
     "mongodb-memory-server": "^11.2.0",
+    "tsx": "^4.23.0",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.9"
   }

--- a/packages/database/src/models/billing/ModelPriceModel.test.ts
+++ b/packages/database/src/models/billing/ModelPriceModel.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ModelPrice, modelPriceRepository } from './ModelPriceModel';
+import { SEED_NOTE } from '../../seeds/seedModelPrices';
 import { setupMongoTest } from '../../__test__/utils';
 
 const tier = { input: 2e-6, output: 8e-6 };
@@ -17,7 +18,7 @@ describe('ModelPriceRepository', () => {
       unit: 'per_token',
       pricing: { '200000': { ...tier, cache_read: 1e-6, cache_write: 3e-6 } },
       effectiveFrom: new Date('2026-07-01T00:00:00Z'),
-      note: 'adapter-seed',
+      note: SEED_NOTE,
     });
 
     const [row] = await modelPriceRepository.rowsInForce(new Date('2026-07-15T00:00:00Z'));

--- a/packages/database/src/priceCatalogBootstrap.test.ts
+++ b/packages/database/src/priceCatalogBootstrap.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock every collaborator so the module-level wiring latch is the only thing
+// under test; no mongoose or real backend is touched.
+const baseConnectDB = vi.fn();
+const setModelPriceRowsProvider = vi.fn();
+const rowsInForce = vi.fn();
+const seedModelPrices = vi.fn();
+
+vi.mock('@bike4mind/db-core', () => ({ connectDB: baseConnectDB }));
+vi.mock('@bike4mind/llm-adapters', () => ({ setModelPriceRowsProvider }));
+vi.mock('./models/billing/ModelPriceModel', () => ({ modelPriceRepository: { rowsInForce } }));
+vi.mock('./seeds/seedModelPrices', () => ({ seedModelPrices }));
+
+async function freshConnectDB() {
+  // The wired-once latch is module state; a fresh import isolates each test.
+  vi.resetModules();
+  const { connectDB } = await import('./priceCatalogBootstrap');
+  return connectDB;
+}
+
+describe('priceCatalogBootstrap.connectDB', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    baseConnectDB.mockResolvedValue('connection');
+    seedModelPrices.mockResolvedValue({ inserted: 0, skipped: 0 });
+  });
+
+  it('wires the rows provider and seeds exactly once across repeated connects', async () => {
+    const connectDB = await freshConnectDB();
+    await expect(connectDB('mongodb://x')).resolves.toBe('connection');
+    await connectDB('mongodb://x');
+
+    expect(setModelPriceRowsProvider).toHaveBeenCalledTimes(1);
+    expect(seedModelPrices).toHaveBeenCalledTimes(1);
+    expect(baseConnectDB).toHaveBeenCalledTimes(2);
+
+    const provider = setModelPriceRowsProvider.mock.calls[0][0];
+    await provider();
+    expect(rowsInForce).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reject the connect when fire-and-forget seeding fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    seedModelPrices.mockRejectedValue(new Error('mongo down'));
+
+    const connectDB = await freshConnectDB();
+    await expect(connectDB('mongodb://x')).resolves.toBe('connection');
+    // Flush the detached seeding promise before asserting on its handler.
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('seeding failed'), expect.any(Error));
+    warn.mockRestore();
+  });
+
+  it('leaves the latch open when the underlying connect fails, so a retry still wires', async () => {
+    baseConnectDB.mockRejectedValueOnce(new Error('refused'));
+
+    const connectDB = await freshConnectDB();
+    await expect(connectDB('mongodb://x')).rejects.toThrow('refused');
+    expect(setModelPriceRowsProvider).not.toHaveBeenCalled();
+
+    await connectDB('mongodb://x');
+    expect(setModelPriceRowsProvider).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/database/src/seeds/modelPriceSeed.test.ts
+++ b/packages/database/src/seeds/modelPriceSeed.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { collectStaticTextModels, generateModelPriceSeed } from './generateModelPriceSeed';
 import { seedModelPrices, SEED_NOTE } from './seedModelPrices';
 import seedFile from './modelPrices.seed.json';
@@ -15,6 +15,7 @@ describe('model price seed (no DB)', () => {
   it('the checked-in seed file is fresh (regenerating from the adapter tables produces it)', async () => {
     // Fails when an adapter price literal changes without regenerating the
     // seed - the diff of modelPrices.seed.json IS the price-change review.
+    // Fix with: pnpm --filter @bike4mind/database generate:model-price-seed
     const generated = await generateModelPriceSeed();
     expect(generated).toEqual(seed.entries);
   });
@@ -74,6 +75,31 @@ describe('seedModelPrices (round-trip)', () => {
     const history = await modelPriceRepository.historyForModel(target.modelId);
     expect(history).toHaveLength(2);
     expect(history[0].effectiveFrom.toISOString()).toBe(new Date(seed.generatedAt).toISOString());
+  });
+
+  it('warns loudly when a seed entry changed without a generatedAt bump (hand-edit footgun)', async () => {
+    // entries edited in place with generatedAt untouched: the alreadyCurrent
+    // skip drops the price change, leaving deployments on the stale row. The
+    // seeder cannot fix it (equal effectiveFrom collides on the unique index)
+    // but it must not stay silent about it.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const target = seed.entries[0];
+    await modelPriceRepository.append({
+      modelId: target.modelId,
+      unit: 'per_token',
+      pricing: { '1000': { input: 99e-6, output: 99e-6 } },
+      effectiveFrom: new Date(seed.generatedAt),
+      note: SEED_NOTE,
+    });
+
+    await seedModelPrices(modelPriceRepository);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain(target.modelId);
+    expect(warn.mock.calls[0][0]).toContain('generate:model-price-seed');
+    const history = await modelPriceRepository.historyForModel(target.modelId);
+    expect(history).toHaveLength(1);
+    warn.mockRestore();
   });
 
   it('skips an older seed row whose pricing already matches (no churn rows)', async () => {

--- a/packages/database/src/seeds/modelPriceSeed.test.ts
+++ b/packages/database/src/seeds/modelPriceSeed.test.ts
@@ -31,6 +31,12 @@ describe('model price seed (no DB)', () => {
     expect(uncovered.map(m => m.id)).toEqual([]);
   });
 
+  it('pins SEED_NOTE to the persisted value (data contract with rows already in production)', () => {
+    // Renaming the constant would reclassify every existing adapter-seed row
+    // as an operator reprice, permanently freezing price corrections.
+    expect(SEED_NOTE).toBe('adapter-seed');
+  });
+
   it('every seed entry carries a nonzero price (a zero row would settle calls free)', () => {
     const zeroPriced = seed.entries.filter(
       entry => !Object.values(entry.pricing).some(tier => tier.input > 0 || tier.output > 0)
@@ -97,6 +103,28 @@ describe('seedModelPrices (round-trip)', () => {
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain(target.modelId);
     expect(warn.mock.calls[0][0]).toContain('generate:model-price-seed');
+    const history = await modelPriceRepository.historyForModel(target.modelId);
+    expect(history).toHaveLength(1);
+    warn.mockRestore();
+  });
+
+  it('does not warn on a strictly newer seed row (rollback / mixed-version fleet, not a hand-edit)', async () => {
+    // An older-code instance booting after a newer seed landed sees exactly
+    // "newest row differs, alreadyCurrent" - that is version skew, not the
+    // unbumped-generatedAt footgun. Only equal timestamps indicate a hand-edit.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const target = seed.entries[0];
+    await modelPriceRepository.append({
+      modelId: target.modelId,
+      unit: 'per_token',
+      pricing: { '1000': { input: 99e-6, output: 99e-6 } },
+      effectiveFrom: new Date(new Date(seed.generatedAt).getTime() + 86_400_000),
+      note: SEED_NOTE,
+    });
+
+    await seedModelPrices(modelPriceRepository);
+
+    expect(warn).not.toHaveBeenCalled();
     const history = await modelPriceRepository.historyForModel(target.modelId);
     expect(history).toHaveLength(1);
     warn.mockRestore();

--- a/packages/database/src/seeds/regenerateModelPriceSeed.test.ts
+++ b/packages/database/src/seeds/regenerateModelPriceSeed.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { buildModelPriceSeedFile } from './regenerateModelPriceSeed';
+import { generateModelPriceSeed } from './generateModelPriceSeed';
+
+describe('buildModelPriceSeedFile', () => {
+  it('stamps generatedAt from the given time and regenerates entries together', async () => {
+    // Bumping generatedAt alongside entries is what makes seedModelPrices
+    // treat regenerated prices as a new version; a hand-edit that skips the
+    // bump is silently dropped by the alreadyCurrent skip.
+    const now = new Date('2026-07-10T06:00:00Z');
+    const file = await buildModelPriceSeedFile(now);
+    expect(file.generatedAt).toBe(now.toISOString());
+    expect(file.entries).toEqual(await generateModelPriceSeed());
+  });
+});

--- a/packages/database/src/seeds/regenerateModelPriceSeed.test.ts
+++ b/packages/database/src/seeds/regenerateModelPriceSeed.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { buildModelPriceSeedFile } from './regenerateModelPriceSeed';
-import { generateModelPriceSeed } from './generateModelPriceSeed';
 
 describe('buildModelPriceSeedFile', () => {
-  it('stamps generatedAt from the given time and regenerates entries together', async () => {
+  it('stamps generatedAt from the given time alongside regenerated entries', async () => {
     // Bumping generatedAt alongside entries is what makes seedModelPrices
     // treat regenerated prices as a new version; a hand-edit that skips the
-    // bump is silently dropped by the alreadyCurrent skip.
+    // bump is silently dropped by the alreadyCurrent skip. Entry correctness
+    // itself is covered by the freshness test in modelPriceSeed.test.ts.
     const now = new Date('2026-07-10T06:00:00Z');
     const file = await buildModelPriceSeedFile(now);
     expect(file.generatedAt).toBe(now.toISOString());
-    expect(file.entries).toEqual(await generateModelPriceSeed());
+    expect(file.entries.length).toBeGreaterThan(0);
+    expect(file.entries[0]).toHaveProperty('modelId');
+    expect(file.entries[0]).toHaveProperty('pricing');
   });
 });

--- a/packages/database/src/seeds/regenerateModelPriceSeed.ts
+++ b/packages/database/src/seeds/regenerateModelPriceSeed.ts
@@ -1,12 +1,8 @@
-import { writeFileSync } from 'fs';
+import { realpathSync, writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { generateModelPriceSeed, ModelPriceSeedEntry } from './generateModelPriceSeed';
-
-export interface ModelPriceSeedFileContents {
-  generatedAt: string;
-  entries: ModelPriceSeedEntry[];
-}
+import { generateModelPriceSeed } from './generateModelPriceSeed';
+import type { ModelPriceSeedFile } from './seedModelPrices';
 
 /**
  * generatedAt doubles as every row's effectiveFrom, so it MUST move whenever
@@ -14,11 +10,21 @@ export interface ModelPriceSeedFileContents {
  * alreadyCurrent skip. This builder is the only supported way to update the
  * seed: pnpm --filter @bike4mind/database generate:model-price-seed
  */
-export async function buildModelPriceSeedFile(now: Date): Promise<ModelPriceSeedFileContents> {
+export async function buildModelPriceSeedFile(now: Date): Promise<ModelPriceSeedFile> {
   return { generatedAt: now.toISOString(), entries: await generateModelPriceSeed() };
 }
 
-const isCliInvocation = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+// realpath both sides: argv[1] and import.meta.url can disagree on symlinked
+// checkout paths (e.g. macOS /tmp), which would make the CLI a silent no-op.
+function canonical(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+const isCliInvocation = process.argv[1] && canonical(process.argv[1]) === canonical(fileURLToPath(import.meta.url));
 if (isCliInvocation) {
   const file = await buildModelPriceSeedFile(new Date());
   const target = join(dirname(fileURLToPath(import.meta.url)), 'modelPrices.seed.json');

--- a/packages/database/src/seeds/regenerateModelPriceSeed.ts
+++ b/packages/database/src/seeds/regenerateModelPriceSeed.ts
@@ -1,0 +1,27 @@
+import { writeFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { generateModelPriceSeed, ModelPriceSeedEntry } from './generateModelPriceSeed';
+
+export interface ModelPriceSeedFileContents {
+  generatedAt: string;
+  entries: ModelPriceSeedEntry[];
+}
+
+/**
+ * generatedAt doubles as every row's effectiveFrom, so it MUST move whenever
+ * entries do; an in-place entry edit is dropped by seedModelPrices'
+ * alreadyCurrent skip. This builder is the only supported way to update the
+ * seed: pnpm --filter @bike4mind/database generate:model-price-seed
+ */
+export async function buildModelPriceSeedFile(now: Date): Promise<ModelPriceSeedFileContents> {
+  return { generatedAt: now.toISOString(), entries: await generateModelPriceSeed() };
+}
+
+const isCliInvocation = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isCliInvocation) {
+  const file = await buildModelPriceSeedFile(new Date());
+  const target = join(dirname(fileURLToPath(import.meta.url)), 'modelPrices.seed.json');
+  writeFileSync(target, JSON.stringify(file, null, 2) + '\n');
+  console.info(`[modelPriceCatalog] wrote ${file.entries.length} entries to ${target}`);
+}

--- a/packages/database/src/seeds/seedModelPrices.ts
+++ b/packages/database/src/seeds/seedModelPrices.ts
@@ -66,6 +66,15 @@ export async function seedModelPrices(
       const isSeedRow = current.note === SEED_NOTE;
       const alreadyCurrent = current.effectiveFrom.getTime() >= effectiveFrom.getTime();
       const samePrice = normalizePricing(current.pricing) === normalizePricing(entry.pricing);
+      if (isSeedRow && alreadyCurrent && !samePrice) {
+        // Entries were edited without bumping generatedAt: the change cannot
+        // be versioned (equal effectiveFrom collides on the unique index), so
+        // deployments keep billing from the stale row. Be loud about it.
+        console.warn(
+          `[modelPriceCatalog] seed entry for ${entry.modelId} (${entry.unit}) differs from the newest seed row but generatedAt was not bumped; ` +
+            'regenerate the seed instead of editing entries: pnpm --filter @bike4mind/database generate:model-price-seed'
+        );
+      }
       if (!isSeedRow || alreadyCurrent || samePrice) {
         skipped += 1;
         continue;

--- a/packages/database/src/seeds/seedModelPrices.ts
+++ b/packages/database/src/seeds/seedModelPrices.ts
@@ -8,7 +8,7 @@ const FAR_FUTURE = new Date('9999-01-01T00:00:00Z');
  * reprices and are never superseded by seeding. */
 export const SEED_NOTE = 'adapter-seed';
 
-interface ModelPriceSeedFile {
+export interface ModelPriceSeedFile {
   /** Generation timestamp, stamped by the regeneration script. Doubles as the
    * deterministic effectiveFrom for every row of this seed version, so
    * concurrent seeders collide on the unique index instead of duplicating. */
@@ -66,12 +66,15 @@ export async function seedModelPrices(
       const isSeedRow = current.note === SEED_NOTE;
       const alreadyCurrent = current.effectiveFrom.getTime() >= effectiveFrom.getTime();
       const samePrice = normalizePricing(current.pricing) === normalizePricing(entry.pricing);
-      if (isSeedRow && alreadyCurrent && !samePrice) {
+      const sameVersion = current.effectiveFrom.getTime() === effectiveFrom.getTime();
+      if (isSeedRow && sameVersion && !samePrice) {
         // Entries were edited without bumping generatedAt: the change cannot
         // be versioned (equal effectiveFrom collides on the unique index), so
         // deployments keep billing from the stale row. Be loud about it.
+        // Strict equality only: a strictly newer row just means an older-code
+        // instance is booting after a newer seed landed (rollback / canary).
         console.warn(
-          `[modelPriceCatalog] seed entry for ${entry.modelId} (${entry.unit}) differs from the newest seed row but generatedAt was not bumped; ` +
+          `[modelPriceCatalog] seed entry for ${entry.modelId} (${entry.unit}) differs from the newest seed row but generatedAt (${seed.generatedAt}) was not bumped; ` +
             'regenerate the seed instead of editing entries: pnpm --filter @bike4mind/database generate:model-price-seed'
         );
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1921,6 +1921,9 @@ importers:
       mongodb-memory-server:
         specifier: ^11.2.0
         version: 11.2.0(@aws-sdk/credential-providers@3.1050.0)(socks@2.8.6)
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
       vite-tsconfig-paths:
         specifier: ^6.1.1
         version: 6.1.1(typescript@5.9.3)(vite@8.1.0(@types/node@25.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.44.1)(tsx@4.23.0)(yaml@2.8.2))


### PR DESCRIPTION
Follow-up to #376, closing the non-blocking observations from its automated review.

## Problem

`generatedAt` doubles as every seed row's `effectiveFrom`. If a contributor edits `modelPrices.seed.json` entries in place without bumping it, `seedModelPrices` skips the change on the `alreadyCurrent` check and deployments keep billing from the stale row, silently.

## Changes

- `regenerateModelPriceSeed.ts` + `pnpm --filter @bike4mind/database generate:model-price-seed`: the supported way to update the seed; rewrites entries and stamps a fresh `generatedAt` together. Verified it reproduces the checked-in seed byte-identically (only the timestamp moves).
- `seedModelPrices.ts`: loud `console.warn` naming the model and the regen command when the hand-edit case is detected at boot.
- `priceCatalogBootstrap.test.ts`: direct tests for the previously untested wiring latch (wires/seeds once, fire-and-forget seed failure does not reject, failed connect leaves the latch open). Mutation-checked.
- `ModelPriceModel.test.ts`: import `SEED_NOTE` instead of hardcoding the string.

## Verification

Database suite 599/599, typecheck, lint, ASCII hygiene sweep all green; regen CLI run end-to-end.