### PR TITLE
fix(preview-remove): broaden self-heal to all gone/inactive desync signatures

### DIFF
--- a/.github/actions/sst-remove-idempotent/action.yml
+++ b/.github/actions/sst-remove-idempotent/action.yml
@@ -144,7 +144,14 @@ runs:
           if echo "$OUTPUT" | grep -qE "DependencyViolation|has a dependent object"; then
             echo "  [heal ${heal}] DependencyViolation -> stage-scoped orphaned-ALB reconcile"
             bash "${GITHUB_ACTION_PATH}/reconcile-orphaned-alb.sh" "${STAGE}" || true
-          elif echo "$OUTPUT" | grep -qiE "NotFound|does not exist"; then
+          elif echo "$OUTPUT" | grep -qiE "NotFound|does not exist|was not ACTIVE|ResourceNotFoundException|NoSuchEntity|no longer exists|could not be found"; then
+            # "Already gone / inactive parent" desync: the resource (or a parent
+            # it needs) was deleted out-of-band, so its delete errors. AWS phrases
+            # this differently per service - ListenerNotFound, ECS "Cluster was not
+            # ACTIVE" on ClusterCapacityProviders, IAM NoSuchEntity, Lambda
+            # ResourceNotFoundException, etc. - so match the family, not one string.
+            # Drop the phantom from state and retry. (DependencyViolation, i.e. a
+            # LIVE resource still pinning another, is handled by the branch above.)
             # Logical name of the failed resource is the token before its
             # " aws:/sst:/random:/command:" type on the sst "|  Error ..." line
             # (last such token on the line, i.e. the child, not its parent).


### PR DESCRIPTION
## Description

Follow-up to #370, from validating the self-heal on 5 real orphaned preview stages in CI: **4 cleared cleanly** (pr298, pr301, pr302, pr305), but **pr255 exposed a desync signature the loop did not recognize**.

pr255's self-heal worked for the first phantom (it dropped `QuestProcessorServiceListenerHTTP80` from state and retried), got further, then failed on a new error:

```
✕ Failed  Cluster → ClusterCapacityProviders aws:ecs:ClusterCapacityProviders
ClientException: Cluster was not ACTIVE.
```

That is the same "already gone / inactive parent" class (the ECS cluster was deleted out-of-band, so its capacity-providers child can't update), but the text is neither `NotFound` nor `DependencyViolation`, so the loop hit `else -> stop` and the stage stayed orphaned.

## Change

`.github/actions/sst-remove-idempotent/action.yml` — broaden the phantom-detection grep from `NotFound|does not exist` to the family of AWS gone/inactive signatures: `NotFound|does not exist|was not ACTIVE|ResourceNotFoundException|NoSuchEntity|no longer exists|could not be found`. These now drop-from-state and retry like the listener case. `DependencyViolation` (a live resource pinning another) is still routed to the ALB reconcile branch; genuinely unknown errors still stop and surface.

## Tests

- Confirmed the broadened regex matches the pr255 error string (`ClientException: Cluster was not ACTIVE.`) where the old one did not.
- `action.yml` parses (`yaml.safe_load`); the remove-step script passes `bash -n`.
- The 4/5 that already self-healed under #370 are unaffected (their path is unchanged).

## Guide for Testers

1. Re-dispatch the previously-failing pr255 remove after merge: `gh workflow run preview.yml -R Bike4Mind/bike4mind-deployer -f pr=255 -f action=remove`. Expect it to now self-heal past the `Cluster was not ACTIVE` step and remove the stage (state file gone from the previews bucket).
2. Re-run a handful of other closed-PR orphans and confirm they clear; then the sweep can drain the rest.
