### PR TITLE
ci(e2e): post e2e/smoke status + enforce-ready gate_run trigger

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -40,6 +40,14 @@ on:
         description: 'Tester ID for user isolation (e.g. alice)'
         type: string
         required: false
+      # Internal: set to 'true' only by the deployer's staging-deploy trigger when
+      # REQUIRE_E2E is enabled. Coalesces rapid gate runs to the latest tip; leave
+      # 'false' for manual/scheduled runs (which keep their existing behavior).
+      gate_run:
+        description: 'Internal: deploy-triggered gate run (leave false for manual runs)'
+        type: string
+        default: 'false'
+        required: false
 
 env:
   AWS_REGION: us-east-2
@@ -57,9 +65,12 @@ jobs:
       statuses: write
     # Serialize per-stage so an overlapping scheduled + manual run (or two
     # manual runs) can't stomp each other's global-setup data cleanup.
+    # Gate runs (deploy-triggered) share one group and coalesce to the latest tip
+    # via cancel-in-progress. Manual/scheduled runs keep their exact prior behavior:
+    # per-target group, no cancellation (gate_run is unset -> the else branch).
     concurrency:
-      group: e2e-manual-${{ inputs.pr_number || inputs.stage || 'dev' }}
-      cancel-in-progress: false
+      group: ${{ inputs.gate_run == 'true' && 'e2e-manual-gate' || format('e2e-manual-{0}', inputs.pr_number || inputs.stage || 'dev') }}
+      cancel-in-progress: ${{ inputs.gate_run == 'true' }}
 
     steps:
       - name: Resolve configuration

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -138,23 +138,31 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEV_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      # Capture the SHA currently deployed to staging (SST stage `dev`) BEFORE the
-      # suite runs, so a mid-run staging redeploy can't mislabel it. Only the
-      # full-suite dev/staging run stamps the promotable frontier (P0-2): skip
-      # previews and scoped single-project dispatches. Best-effort by design.
+      # Capture the SHA currently live on staging BEFORE the suite runs, so a mid-
+      # run staging redeploy can't mislabel it. Source of truth = the newest main
+      # commit whose `staging/deploy` status is success (the same signal the
+      # console's staging gate reads) - resolved via GITHUB_TOKEN, no AWS/SSM.
+      # Only the full-suite dev/staging run stamps the promotable frontier (P0-2):
+      # skip previews and scoped single-project dispatches. Best-effort by design.
       - name: Resolve tested SHA for e2e/smoke status
         id: tested_sha
         if: github.event_name == 'schedule' || (inputs.pr_number == '' && (inputs.test_project == '' || inputs.test_project == 'All tests'))
         continue-on-error: true
-        run: |
-          SHA=$(aws ssm get-parameter --name /b4m-deployer/last-deployed-sha/staging \
-            --query 'Parameter.Value' --output text --region "$AWS_REGION" 2>/dev/null || true)
-          if printf '%s' "$SHA" | grep -qE '^[0-9a-f]{40}$'; then
-            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-            echo "Tested staging SHA: $SHA"
-          else
-            echo "No valid staging SHA from SSM (got '$SHA'); e2e/smoke status will be skipped."
-          fi
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = 'Bike4Mind', repo = 'bike4mind';
+            const { data: commits } = await github.rest.repos.listCommits({ owner, repo, sha: 'main', per_page: 20 });
+            for (const c of commits) {
+              const { data: st } = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: c.sha });
+              if (st.statuses.some(s => s.context === 'staging/deploy' && s.state === 'success')) {
+                core.setOutput('sha', c.sha);
+                core.info(`Tested staging SHA = ${c.sha} (newest with staging/deploy=success)`);
+                return;
+              }
+            }
+            core.warning('No recent main commit has staging/deploy=success; e2e/smoke status will be skipped.');
 
       - name: Install Playwright Chromium
         working-directory: apps/client

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -53,6 +53,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      # Post the e2e/smoke commit status the prod-promotion console reads (P0-2).
+      statuses: write
     # Serialize per-stage so an overlapping scheduled + manual run (or two
     # manual runs) can't stomp each other's global-setup data cleanup.
     concurrency:
@@ -135,6 +137,24 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_DEV_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+
+      # Capture the SHA currently deployed to staging (SST stage `dev`) BEFORE the
+      # suite runs, so a mid-run staging redeploy can't mislabel it. Only the
+      # full-suite dev/staging run stamps the promotable frontier (P0-2): skip
+      # previews and scoped single-project dispatches. Best-effort by design.
+      - name: Resolve tested SHA for e2e/smoke status
+        id: tested_sha
+        if: github.event_name == 'schedule' || (inputs.pr_number == '' && (inputs.test_project == '' || inputs.test_project == 'All tests'))
+        continue-on-error: true
+        run: |
+          SHA=$(aws ssm get-parameter --name /b4m-deployer/last-deployed-sha/staging \
+            --query 'Parameter.Value' --output text --region "$AWS_REGION" 2>/dev/null || true)
+          if printf '%s' "$SHA" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+            echo "Tested staging SHA: $SHA"
+          else
+            echo "No valid staging SHA from SSM (got '$SHA'); e2e/smoke status will be skipped."
+          fi
 
       - name: Install Playwright Chromium
         working-directory: apps/client
@@ -286,6 +306,41 @@ jobs:
           echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
           echo "not_started=$NOT_STARTED" >> $GITHUB_OUTPUT
           echo "total=$TOTAL" >> $GITHUB_OUTPUT
+
+      - name: Post e2e/smoke commit status (P0-2 console gate)
+        # Stamp the tested staging SHA with the full-suite result so the prod-
+        # promotion console can read a per-commit e2e signal. `success` only when
+        # nothing failed, nothing was left unstarted, and tests actually ran.
+        # Best-effort: never fails the e2e run.
+        if: always() && steps.tested_sha.outputs.sha != ''
+        continue-on-error: true
+        uses: actions/github-script@v8
+        env:
+          TESTED_SHA: ${{ steps.tested_sha.outputs.sha }}
+          FAILED: ${{ steps.results.outputs.failed }}
+          NOT_STARTED: ${{ steps.results.outputs.not_started }}
+          PASSED: ${{ steps.results.outputs.passed }}
+          TOTAL: ${{ steps.results.outputs.total }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const sha = process.env.TESTED_SHA;
+            const total = Number(process.env.TOTAL || '0');
+            if (total === 0) {
+              core.warning('No e2e results parsed; skipping e2e/smoke status (leaves it missing = not promotable).');
+              return;
+            }
+            const ok = process.env.FAILED === '0' && process.env.NOT_STARTED === '0';
+            const state = ok ? 'success' : 'failure';
+            const desc = (ok
+              ? `Full e2e suite passed (${process.env.PASSED}/${total})`
+              : `Full e2e suite: ${process.env.FAILED} failed, ${process.env.NOT_STARTED} not started`).slice(0, 140);
+            await github.rest.repos.createCommitStatus({
+              owner: 'Bike4Mind', repo: 'bike4mind', sha,
+              state, context: 'e2e/smoke', target_url: process.env.RUN_URL, description: desc,
+            });
+            core.info(`Posted e2e/smoke=${state} on ${sha.slice(0, 7)}`);
 
       - name: Parse credits data
         id: credits


### PR DESCRIPTION
## What

Two additive changes to `e2e-manual.yml`, both feeding the prod-promotion console's e2e gate:

1. **Post `e2e/smoke`** (success/failure) on the tested staging SHA after a full-suite run, so the console has a per-commit e2e signal. The SHA is resolved as the newest `main` commit with `staging/deploy=success` (the same signal the console's staging gate reads), captured before the suite runs. `GITHUB_TOKEN` with `statuses: write` - no new app/secret, no AWS/SSM.
2. **`gate_run` input + tip-coalescing concurrency** (enforce-ready). When the deployer dispatches this workflow with `gate_run=true` (only when `REQUIRE_E2E` is on - see deployer PR #38), the run uses a dedicated concurrency group with `cancel-in-progress: true` so a burst of staging deploys collapses to one run on the latest tip.

## Why

QA confirmed the full `e2e-manual` suite is the viable e2e check. Piece 1 makes the console's (already shipped, inert) e2e gate consumable. Piece 2 makes it *fresh* under enforcement: paired with deployer #38, a staging deploy triggers e2e on the new tip immediately, so an enforced gate has no ~12h schedule lag.

## Backward compatibility (important)

- **Scheduled + manual runs are unchanged.** `gate_run` defaults to `'false'`; the concurrency group + `cancel-in-progress` for non-gate runs resolve to exactly the prior values (`e2e-manual-<pr|stage|dev>`, no cancel). Only an explicit `gate_run=true` dispatch takes the new path.
- Posting `e2e/smoke` is additive and advisory - `REQUIRE_E2E` stays off, so nothing is gated yet.

## Rollout

Non-blocking today. When ready to enforce: land this + deployer #38, confirm the suite is reliably green, then flip `REQUIRE_E2E=true` (one variable turns on both the gate requirement and the fresh-signal trigger).

## Verify

Best-effort throughout (resolve + post steps are `continue-on-error`); YAML parses clean; the workflow's own token only. Self-contained in this repo - no IAM/SSM grant.
