### PR TITLE
fix(client): scope File Manager Select All and pagination to the active view

### DIFF
--- a/apps/client/app/components/Files/Browser/Content.tsx
+++ b/apps/client/app/components/Files/Browser/Content.tsx
@@ -1,4 +1,4 @@
-import { InviteType, KnowledgeType } from '@bike4mind/common';
+import { IFabFileDocument, InviteType, KnowledgeType } from '@bike4mind/common';
 import { useSessions, useWorkBenchFiles, useWorkBenchStore } from '@client/app/contexts/SessionsContext';
 import { useUser } from '@client/app/contexts/UserContext';
 import { useLLM } from '@client/app/contexts/LLMContext';
@@ -7,6 +7,7 @@ import {
   useBulkDeleteFiles,
   useCreateFabFile,
   usePaginatedSearchFabFiles,
+  useSearchFabFiles,
 } from '@client/app/hooks/data/fabFiles';
 import { useModelInfo } from '@client/app/hooks/data/useModelInfo';
 import { useUpdateSession } from '@client/app/hooks/data/sessions';
@@ -18,7 +19,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import { Box, Button, Chip, Typography, Modal, ModalDialog, ModalClose, Stack } from '@mui/joy';
 import { FieldTooltip } from '@client/app/components/help';
-import { FC, useState, useEffect } from 'react';
+import { FC, useState, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { useShallow } from 'zustand/react/shallow';
@@ -119,6 +120,14 @@ const FileBrowserContent = () => {
     page: currentPage,
   });
 
+  // Overview tab renders its own "Recent" list (separate from the paginated allFiles
+  // list below), so it's only fetched while that tab is active.
+  const { data: recentData, isLoading: isLoadingRecent } = useSearchFabFiles(
+    { order: { by: 'createdAt', direction: 'desc' }, pagination: { page: 1, limit: 8 } },
+    { enabled: viewAction.viewMode === 'home' }
+  );
+  const recentFiles = recentData?.data?.slice(0, 8) || [];
+
   const { mutateAsync: toggleTagToFiles } = useToggleTagToFiles();
   const { data: fileTags } = useGetFileTags();
   const { mutateAsync: deleteFiles } = useBulkDeleteFiles();
@@ -131,6 +140,36 @@ const FileBrowserContent = () => {
   const totalFiles = data?.total || 0;
   const totalPages = Math.ceil(totalFiles / FILES_PER_PAGE);
   const { mutate: addFilesToProject } = useAddFilesToProject();
+
+  // What Select All should select for the currently active tab: the Overview tab only
+  // ever shows the "Recent" files, not the full paginated list.
+  const selectableFiles = viewAction.viewMode === 'home' ? recentFiles : allFiles;
+
+  // Selection is shared global state that persists across tab switches, but Overview
+  // ("recent") and List/Grid ("paginated") show different file sets - carrying a
+  // selection across that boundary produces a count/checkmarks that don't match what's
+  // visible. Clear on crossing that boundary, but not when merely toggling List<->Grid,
+  // which show the same underlying list and where a persisted selection is useful.
+  const selectionScope = viewAction.viewMode === 'home' ? 'recent' : 'paginated';
+  const selectionScopeRef = useRef(selectionScope);
+  useEffect(() => {
+    if (selectionScopeRef.current !== selectionScope) {
+      setSelectedIds(new Set<string>());
+      selectionScopeRef.current = selectionScope;
+    }
+  }, [selectionScope, setSelectedIds]);
+
+  // Files can be selected from either list (Overview's recentFiles or the paginated
+  // allFiles), so bulk actions must resolve selections against both, not just allFiles.
+  const filesById = useMemo(() => {
+    const m = new Map<string, IFabFileDocument>();
+    for (const f of allFiles) m.set(f.id, f);
+    for (const f of recentFiles) m.set(f.id, f);
+    return m;
+  }, [allFiles, recentFiles]);
+  const selectedFiles = Array.from(selectedIds)
+    .map(id => filesById.get(id))
+    .filter((f): f is IFabFileDocument => Boolean(f));
 
   // Subscribe to WebSocket updates for file vectorization status
   useEffect(() => {
@@ -172,13 +211,13 @@ const FileBrowserContent = () => {
       setSelectedIds(new Set<string>());
       return;
     }
-    setSelectedIds(new Set(allFiles.map(f => f.id)));
+    setSelectedIds(new Set(selectableFiles.map(f => f.id)));
   }
 
   function handleAdd() {
     const { setWorkBenchFiles } = useWorkBenchStore.getState();
 
-    const applicableFiles = allFiles.filter(f => !workBenchFiles.some(w => w.id === f.id) && selectedIds.has(f.id));
+    const applicableFiles = selectedFiles.filter(f => !workBenchFiles.some(w => w.id === f.id));
 
     // Check if any images are too large for current model (legacy files only)
     const currentModelInfo = modelInfo?.find(m => m.id === model);
@@ -251,8 +290,8 @@ const FileBrowserContent = () => {
 
   async function handleDelete() {
     // Partition selected files into owned vs shared
-    const ownedCount = allFiles.filter(f => selectedIds.has(f.id) && f.userId === currentUser?.id).length;
-    const sharedCount = allFiles.filter(f => selectedIds.has(f.id) && f.userId !== currentUser?.id).length;
+    const ownedCount = selectedFiles.filter(f => f.userId === currentUser?.id).length;
+    const sharedCount = selectedFiles.filter(f => f.userId !== currentUser?.id).length;
 
     let title: string;
     let description: string;
@@ -600,6 +639,9 @@ const FileBrowserContent = () => {
           {viewAction.viewMode === 'home' && (
             <HomeViewPanel
               selectedIds={selectedIds}
+              recentFiles={recentFiles}
+              isLoadingRecent={isLoadingRecent}
+              recentTotal={recentData?.total}
               onNavigateToNamespace={namespace => {
                 if (namespace) {
                   setTagViewInitialNamespace(namespace);
@@ -776,7 +818,7 @@ const FileBrowserContent = () => {
                 tags: [tag],
               });
             }}
-            hasSelectedAll={selectedIds.size === allFiles.length}
+            hasSelectedAll={selectedIds.size === selectableFiles.length}
             selectedCount={selectedIds.size}
             onSelectAll={handleSelectAll}
             onDelete={handleDelete}
@@ -784,7 +826,7 @@ const FileBrowserContent = () => {
             onShare={handleBulkShare}
             currentPage={currentPage}
             totalPages={totalPages}
-            onPageChange={setCurrentPage}
+            onPageChange={viewAction.viewMode === 'home' ? undefined : setCurrentPage}
             isLoadingPage={isFetching}
           />
         </Box>
@@ -792,7 +834,7 @@ const FileBrowserContent = () => {
         {/* Bulk Share Modal */}
         {showBulkShareModal && (
           <ShareDocumentModal
-            files={allFiles.filter(file => selectedIds.has(file.id))}
+            files={selectedFiles}
             type={InviteType.FabFile}
             open={showBulkShareModal}
             onClose={() => {

--- a/apps/client/app/components/Files/Browser/HomeView/HomeViewPanel.tsx
+++ b/apps/client/app/components/Files/Browser/HomeView/HomeViewPanel.tsx
@@ -1,5 +1,4 @@
 import { IFabFileDocument } from '@bike4mind/common';
-import { useSearchFabFiles } from '@client/app/hooks/data/fabFiles';
 import { useGetTagCounts } from '@client/app/hooks/data/tag';
 import { Box, Card, Chip, CircularProgress, List, ListItemButton, ListItemContent, Stack, Typography } from '@mui/joy';
 import { FieldTooltip } from '@client/app/components/help';
@@ -20,6 +19,9 @@ interface HomeViewPanelProps {
   onNavigateToNamespace: (namespace: string) => void;
   onFileSelect: (fileId: string) => void;
   selectedIds: Set<string>;
+  recentFiles: IFabFileDocument[];
+  isLoadingRecent: boolean;
+  recentTotal?: number;
 }
 
 interface WorkspaceRow {
@@ -68,14 +70,16 @@ function buildWorkspaces(
     .sort((a, b) => b.totalCount - a.totalCount);
 }
 
-const HomeViewPanel: FC<HomeViewPanelProps> = ({ onNavigateToNamespace, onFileSelect, selectedIds }) => {
-  const { data: recentData, isLoading: isLoadingRecent } = useSearchFabFiles({
-    order: { by: 'createdAt', direction: 'desc' },
-    pagination: { page: 1, limit: 8 },
-  });
+const HomeViewPanel: FC<HomeViewPanelProps> = ({
+  onNavigateToNamespace,
+  onFileSelect,
+  selectedIds,
+  recentFiles,
+  isLoadingRecent,
+  recentTotal,
+}) => {
   const { data: tagCountsData, isLoading: isLoadingTags } = useGetTagCounts();
 
-  const recentFiles = recentData?.data?.slice(0, 8) || [];
   const workspaces = useMemo(
     () =>
       tagCountsData?.tagCounts ? buildWorkspaces(tagCountsData.tagCounts, tagCountsData.namespaceCounts ?? []) : [],
@@ -87,7 +91,7 @@ const HomeViewPanel: FC<HomeViewPanelProps> = ({ onNavigateToNamespace, onFileSe
 
   const debugDump = useMemo(() => {
     if (!showDebug || !tagCountsData) return '';
-    const totalSearchFiles = recentData?.total ?? '?';
+    const totalSearchFiles = recentTotal ?? '?';
     const nsCounts = tagCountsData.namespaceCounts ?? [];
     const tagCounts = tagCountsData.tagCounts ?? [];
 
@@ -108,7 +112,7 @@ const HomeViewPanel: FC<HomeViewPanelProps> = ({ onNavigateToNamespace, onFileSe
       tagCounts.length > 30 ? `  ... and ${tagCounts.length - 30} more` : '',
     ];
     return lines.join('\n');
-  }, [showDebug, tagCountsData, recentData, workspaces]);
+  }, [showDebug, tagCountsData, recentTotal, workspaces]);
 
   if (isLoadingRecent || isLoadingTags) {
     return (

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -494,7 +494,7 @@ export interface ISearchFabFilesParams {
   pagination?: { page: number; limit: number };
   order?: { by: 'fileName' | 'fileSize' | 'createdAt'; direction: 'asc' | 'desc' };
 }
-export function useSearchFabFiles(parameters?: ISearchFabFilesParams) {
+export function useSearchFabFiles(parameters?: ISearchFabFilesParams, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ['fabFiles', 'search', parameters],
     queryFn: async () => {
@@ -510,6 +510,7 @@ export function useSearchFabFiles(parameters?: ISearchFabFilesParams) {
       return response.data;
     },
     refetchOnWindowFocus: false,
+    enabled: options?.enabled, // undefined => defaults to true (existing callers unaffected)
   });
 }
 


### PR DESCRIPTION
## Summary

The File Manager modal's Overview tab showed a "Select All" count and pagination controls that never matched what was actually displayed, because Overview renders a separate, independently-fetched file list from the one those controls were wired to.

- **Select All count mismatch**: Overview renders up to 8 "Recent" files (its own `useSearchFabFiles` query, `limit: 8`), but Select All selected from the parent's paginated `allFiles` list (`usePaginatedSearchFabFiles`, `limit: 20`). Clicking Select All on Overview could report "20 files selected" while only ~8 cards were visible.
- **Stale selection across tabs**: selection is shared global state that persists across tab switches. Selecting all on List/Grid (up to 20) and then switching to Overview left a stale "20 selected" against the 8 visible Recent cards, and vice versa.
- **Dead pagination on Overview**: the bottom-bar Prev/Next/Page-X-of-Y controls were rendered unconditionally, driven by the paginated `allFiles` query/page state — but Overview's content (Recent files, Workspaces) never reads that page state, so clicking Next/Prev changed nothing on screen.
- **Related silent-drop risk**: `handleAdd`/`handleDelete`/bulk-share resolved selected files via `allFiles.filter(f => selectedIds.has(f.id))`. A file selected via Overview's Recent list (not present in `allFiles`) would silently be dropped from those actions.

## Changes

- **`apps/client/app/hooks/data/fabFiles.ts`**: `useSearchFabFiles` gains an optional `{ enabled }` option (backward-compatible; `undefined` preserves existing behavior for all current callers).
- **`apps/client/app/components/Files/Browser/Content.tsx`**:
  - Lifts the "Recent" files query up from `HomeViewPanel`, gated to only run while the Overview tab (`viewMode === 'home'`) is active.
  - `selectableFiles` picks the correct source per active tab (`recentFiles` on Overview, `allFiles` on List/Grid) and drives `handleSelectAll` / `hasSelectedAll`, so the Select All count always matches what's visible.
  - Selection is cleared when crossing between the Overview ("recent") and List/Grid ("paginated") scopes, but preserved when merely toggling List <-> Grid (which render the identical file list, so cross-page bulk selection there still works as before).
  - `handleAdd` / `handleDelete` / bulk-share now resolve selected files through a combined `filesById` lookup (covering both `allFiles` and `recentFiles`) instead of only `allFiles`, so a file selected on Overview is never silently dropped from a bulk action.
  - Pagination controls (`onPageChange`) are only wired up outside the Overview tab, since Overview has no paged list to page through.
- **`apps/client/app/components/Files/Browser/HomeView/HomeViewPanel.tsx`**: becomes a presentational component — `recentFiles` / `isLoadingRecent` / `recentTotal` are now passed in as props instead of the component fetching them itself.

## Test plan

- [x] `pnpm --filter client typecheck` - clean
- [x] `pnpm lint:check` - clean
- [x] `pnpm --filter client test` - 5224 passed / 81 skipped (full suite, no regressions)
- [ ] Manual: open File Manager -> Overview tab -> Select All -> confirm selected count equals the number of Recent cards shown (not 20)
- [ ] Manual: with files selected on Overview, confirm Add / Delete / Share operate on exactly those files
- [ ] Manual: Select All on List/Grid -> switch to Overview -> confirm selection resets (and vice versa)
- [ ] Manual: toggle List <-> Grid with a selection active -> confirm selection is preserved
- [ ] Manual: confirm pagination controls no longer appear on the Overview tab, and still work correctly on List/Grid

Manual verification requires the real dev backend (AWS-backed `sst dev` / `for-env local`), which wasn't available in the environment this change was authored in - flagging these as outstanding for the reviewer/author to click through.

Closes #411
