### PR TITLE
feat(cli): add sub-agent session resume capability

### DIFF
--- a/packages/cli/src/acp/AcpServer.ts
+++ b/packages/cli/src/acp/AcpServer.ts
@@ -45,10 +45,12 @@ import { createToolSearchTool } from '../tools/toolSearchTool.js';
 import { deferredToolRegistry } from '../tools/deferredToolRegistry.js';
 import { createAgentDelegateTool } from '../agents/delegateTool.js';
 import { createBackgroundAgentTools } from '../agents/backgroundTools.js';
+import { createResumeAgentTool } from '../agents/resumeAgentTool.js';
 import { createCoordinateTaskTool } from '../agents/coordinatorTool.js';
 import type { SubagentOrchestrator } from '../agents/SubagentOrchestrator.js';
 import type { AgentStore } from '../agents/AgentStore.js';
 import type { BackgroundAgentManager } from '../agents/BackgroundAgentManager.js';
+import type { AgentHistoryStore } from '../agents/AgentHistoryStore.js';
 import {
   createWriteTodosTool,
   createTodoStore,
@@ -559,7 +561,7 @@ export class AcpServer {
     const additionalDirectories = await this.resolveAdditionalDirectories();
     const agentContext: AgentContext = { currentAgent: null, observationQueue: [] };
 
-    const { agentStore, contextResult, loadedB4mTools, orchestrator, backgroundManager, mcpManager } =
+    const { agentStore, contextResult, loadedB4mTools, orchestrator, backgroundManager, historyStore, mcpManager } =
       await buildSupportingStores({
         config,
         llm,
@@ -593,6 +595,7 @@ export class AcpServer {
       orchestrator,
       agentStore,
       backgroundManager,
+      historyStore,
       sessionId: stackSessionId,
     });
 
@@ -639,12 +642,14 @@ export class AcpServer {
     orchestrator: SubagentOrchestrator;
     agentStore: AgentStore;
     backgroundManager: BackgroundAgentManager;
+    historyStore: AgentHistoryStore;
     sessionId: string;
   }): ICompletionOptionTools[] {
-    const { config, orchestrator, agentStore, backgroundManager, sessionId } = input;
+    const { config, orchestrator, agentStore, backgroundManager, historyStore, sessionId } = input;
     const tools: ICompletionOptionTools[] = [
       createAgentDelegateTool(orchestrator, agentStore, sessionId, backgroundManager),
       ...createBackgroundAgentTools(backgroundManager),
+      createResumeAgentTool(orchestrator, historyStore, backgroundManager),
       createWriteTodosTool(createTodoStore()),
       createFindDefinitionTool(),
       createGetFileStructureTool(),

--- a/packages/cli/src/agents/AgentHistoryStore.test.ts
+++ b/packages/cli/src/agents/AgentHistoryStore.test.ts
@@ -1,7 +1,23 @@
 import { describe, it, expect } from 'vitest';
 import type { AgentCheckpoint } from '@bike4mind/agents';
 import { AgentHistoryStore, type StoredAgentHistory } from './AgentHistoryStore.js';
+import type { AgentDefinition } from './types.js';
 import { MAX_SUBAGENT_HISTORY_ENTRIES } from '../config/constants.js';
+
+function makeDefinition(): AgentDefinition {
+  return {
+    name: 'explore',
+    description: 'test agent',
+    model: 'test-model',
+    modelResolved: true,
+    systemPrompt: 'You are a test agent.',
+    maxIterations: { quick: 1, medium: 1, very_thorough: 1 },
+    defaultThoroughness: 'quick',
+    source: 'builtin',
+    filePath: '<test>',
+    retry: { maxRetries: 0, initialDelayMs: 0 },
+  };
+}
 
 function makeCheckpoint(): AgentCheckpoint {
   return {
@@ -27,6 +43,7 @@ function makeEntry(overrides: Partial<StoredAgentHistory> = {}): StoredAgentHist
   return {
     checkpoint: makeCheckpoint(),
     agentName: 'explore',
+    agentDefinition: makeDefinition(),
     thoroughness: 'medium',
     parentSessionId: 'session-1',
     endTime: Date.now(),

--- a/packages/cli/src/agents/AgentHistoryStore.test.ts
+++ b/packages/cli/src/agents/AgentHistoryStore.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentCheckpoint } from '@bike4mind/agents';
+import { AgentHistoryStore, type StoredAgentHistory } from './AgentHistoryStore.js';
+import { MAX_SUBAGENT_HISTORY_ENTRIES } from '../config/constants.js';
+
+function makeCheckpoint(): AgentCheckpoint {
+  return {
+    iteration: 1,
+    messages: [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+    ],
+    steps: [],
+    totalTokens: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    totalCredits: 0,
+    toolCallCount: 0,
+    confidenceLog: [],
+    iterationConfidences: [],
+  };
+}
+
+function makeEntry(overrides: Partial<StoredAgentHistory> = {}): StoredAgentHistory {
+  return {
+    checkpoint: makeCheckpoint(),
+    agentName: 'explore',
+    thoroughness: 'medium',
+    parentSessionId: 'session-1',
+    endTime: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('AgentHistoryStore', () => {
+  it('stores and retrieves an entry by id', () => {
+    const store = new AgentHistoryStore();
+    const entry = makeEntry();
+    store.set('bg-abc', entry);
+
+    expect(store.has('bg-abc')).toBe(true);
+    expect(store.get('bg-abc')).toBe(entry);
+    expect(store.size()).toBe(1);
+  });
+
+  it('returns undefined for an unknown id', () => {
+    const store = new AgentHistoryStore();
+    expect(store.get('missing')).toBeUndefined();
+    expect(store.has('missing')).toBe(false);
+  });
+
+  it('deletes an entry', () => {
+    const store = new AgentHistoryStore();
+    store.set('bg-abc', makeEntry());
+    expect(store.delete('bg-abc')).toBe(true);
+    expect(store.has('bg-abc')).toBe(false);
+    expect(store.delete('bg-abc')).toBe(false);
+  });
+
+  it('evicts entries older than the TTL when a new one is stored', () => {
+    const ttlMs = 1000;
+    const store = new AgentHistoryStore(ttlMs);
+    // An entry that finished well before the TTL window is evicted by the
+    // cleanup that set() runs immediately.
+    store.set('stale', makeEntry({ endTime: Date.now() - (ttlMs + 5000) }));
+    expect(store.has('stale')).toBe(false);
+
+    // A fresh entry is retained.
+    store.set('fresh', makeEntry());
+    expect(store.has('fresh')).toBe(true);
+  });
+
+  it('keeps entries within the TTL window', () => {
+    const store = new AgentHistoryStore(60_000);
+    store.set('a', makeEntry({ endTime: Date.now() - 1000 }));
+    store.set('b', makeEntry());
+    expect(store.has('a')).toBe(true);
+    expect(store.has('b')).toBe(true);
+    expect(store.size()).toBe(2);
+  });
+
+  it('caps total retained entries', () => {
+    // Long TTL so only the count cap can evict.
+    const store = new AgentHistoryStore(24 * 60 * 60 * 1000);
+    for (let i = 0; i < MAX_SUBAGENT_HISTORY_ENTRIES + 5; i++) {
+      store.set(`job-${i}`, makeEntry());
+    }
+    expect(store.size()).toBeLessThanOrEqual(MAX_SUBAGENT_HISTORY_ENTRIES);
+    // Oldest were dropped; the most recent survive.
+    expect(store.has(`job-${MAX_SUBAGENT_HISTORY_ENTRIES + 4}`)).toBe(true);
+    expect(store.has('job-0')).toBe(false);
+  });
+});

--- a/packages/cli/src/agents/AgentHistoryStore.test.ts
+++ b/packages/cli/src/agents/AgentHistoryStore.test.ts
@@ -98,6 +98,15 @@ describe('AgentHistoryStore', () => {
     expect(store.size()).toBe(2);
   });
 
+  it('falls back to the default TTL when given a non-positive value (never silently disables)', () => {
+    // 0 or negative would otherwise evict on the next set(); the store floors to the default.
+    for (const bad of [0, -1000]) {
+      const store = new AgentHistoryStore(bad);
+      store.set('a', makeEntry());
+      expect(store.has('a')).toBe(true);
+    }
+  });
+
   it('caps total retained entries', () => {
     // Long TTL so only the count cap can evict.
     const store = new AgentHistoryStore(24 * 60 * 60 * 1000);

--- a/packages/cli/src/agents/AgentHistoryStore.ts
+++ b/packages/cli/src/agents/AgentHistoryStore.ts
@@ -1,0 +1,85 @@
+import type { AgentCheckpoint, ThoroughnessLevel } from '@bike4mind/agents';
+import { DEFAULT_SUBAGENT_HISTORY_TTL_MS, MAX_SUBAGENT_HISTORY_ENTRIES } from '../config/constants.js';
+
+/**
+ * A completed sub-agent's conversation snapshot, retained so the orchestrator
+ * can resume the session with its full context via the resume_agent tool.
+ */
+export interface StoredAgentHistory {
+  /** Full ReActAgent checkpoint (messages + execution trace). @see ReActAgent.toCheckpoint() */
+  checkpoint: AgentCheckpoint;
+  /** Agent definition name to rebuild on resume. */
+  agentName: string;
+  /** Thoroughness the original run used, reused on resume. */
+  thoroughness: ThoroughnessLevel;
+  /** Parent session that owned the original run. */
+  parentSessionId: string;
+  /** Completion timestamp (ms); drives TTL eviction. */
+  endTime: number;
+}
+
+/**
+ * In-memory store of finished sub-agent conversations, keyed by resume id
+ * (the background job id for background runs, or a generated id for foreground).
+ *
+ * Eviction mirrors BackgroundAgentManager.cleanupOldJobs: opportunistic and
+ * lazy (run on each set()), never a timer. Entries do not survive a CLI restart
+ * by design - resume is a within-session affordance bounded by a configurable TTL.
+ */
+export class AgentHistoryStore {
+  private entries = new Map<string, StoredAgentHistory>();
+  private readonly ttlMs: number;
+
+  constructor(ttlMs: number = DEFAULT_SUBAGENT_HISTORY_TTL_MS) {
+    this.ttlMs = ttlMs;
+  }
+
+  set(id: string, entry: StoredAgentHistory): void {
+    this.entries.set(id, entry);
+    this.cleanup();
+  }
+
+  get(id: string): StoredAgentHistory | undefined {
+    return this.entries.get(id);
+  }
+
+  has(id: string): boolean {
+    return this.entries.has(id);
+  }
+
+  delete(id: string): boolean {
+    return this.entries.delete(id);
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Evict expired and excess histories. Two passes, matching the background-job
+   * cleanup: drop anything older than maxAgeMs, then, if still over the cap,
+   * drop the oldest until back under it. Returns the number evicted.
+   */
+  cleanup(maxAgeMs: number = this.ttlMs): number {
+    const now = Date.now();
+    let cleaned = 0;
+
+    for (const [id, entry] of this.entries.entries()) {
+      if (now - entry.endTime > maxAgeMs) {
+        this.entries.delete(id);
+        cleaned++;
+      }
+    }
+
+    if (this.entries.size > MAX_SUBAGENT_HISTORY_ENTRIES) {
+      const oldestFirst = Array.from(this.entries.entries()).sort((a, b) => a[1].endTime - b[1].endTime);
+      const overflow = this.entries.size - MAX_SUBAGENT_HISTORY_ENTRIES;
+      for (const [id] of oldestFirst.slice(0, overflow)) {
+        this.entries.delete(id);
+        cleaned++;
+      }
+    }
+
+    return cleaned;
+  }
+}

--- a/packages/cli/src/agents/AgentHistoryStore.ts
+++ b/packages/cli/src/agents/AgentHistoryStore.ts
@@ -37,7 +37,10 @@ export class AgentHistoryStore {
   private readonly ttlMs: number;
 
   constructor(ttlMs: number = DEFAULT_SUBAGENT_HISTORY_TTL_MS) {
-    this.ttlMs = ttlMs;
+    // A non-positive TTL would evict every entry on the next set() (now - endTime
+    // is already > 0), silently disabling resume. Fall back to the default rather
+    // than let a stray config value turn the feature off with no signal.
+    this.ttlMs = ttlMs > 0 ? ttlMs : DEFAULT_SUBAGENT_HISTORY_TTL_MS;
   }
 
   set(id: string, entry: StoredAgentHistory): void {

--- a/packages/cli/src/agents/AgentHistoryStore.ts
+++ b/packages/cli/src/agents/AgentHistoryStore.ts
@@ -1,4 +1,5 @@
 import type { AgentCheckpoint, ThoroughnessLevel } from '@bike4mind/agents';
+import type { AgentDefinition } from './types.js';
 import { DEFAULT_SUBAGENT_HISTORY_TTL_MS, MAX_SUBAGENT_HISTORY_ENTRIES } from '../config/constants.js';
 
 /**
@@ -10,6 +11,11 @@ export interface StoredAgentHistory {
   checkpoint: AgentCheckpoint;
   /** Agent definition name to rebuild on resume. */
   agentName: string;
+  /**
+   * The resolved agent definition, replayed on resume so a session spawned from
+   * an inline/dynamic definition (or one no longer in the store) still rebuilds.
+   */
+  agentDefinition: AgentDefinition;
   /** Thoroughness the original run used, reused on resume. */
   thoroughness: ThoroughnessLevel;
   /** Parent session that owned the original run. */

--- a/packages/cli/src/agents/BackgroundAgentManager.test.ts
+++ b/packages/cli/src/agents/BackgroundAgentManager.test.ts
@@ -21,6 +21,7 @@ function createMockOrchestrator(
     thoroughness: 'medium',
     summary: 'Test result summary',
     parentSessionId: 'test-session',
+    resumeId: 'test-resume-id',
     finalAnswer: 'Test answer',
     steps: [],
     completionInfo: {
@@ -61,6 +62,7 @@ function createSpawnOptions(overrides: Partial<SpawnAgentOptions> = {}): SpawnAg
     task: 'Test task',
     agentName: 'test-agent',
     parentSessionId: 'test-session',
+    resumeId: 'test-resume-id',
     ...overrides,
   };
 }
@@ -172,6 +174,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Result 1',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Answer 1',
         steps: [],
         completionInfo: {
@@ -194,6 +197,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Result 2',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Answer 2',
         steps: [],
         completionInfo: {
@@ -273,6 +277,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Done',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {
@@ -321,6 +326,7 @@ describe('BackgroundAgentManager', () => {
               thoroughness: 'medium',
               summary: 'Success result',
               parentSessionId: 'test-session',
+              resumeId: 'test-resume-id',
               finalAnswer: 'Done',
               steps: [],
               completionInfo: {
@@ -363,6 +369,7 @@ describe('BackgroundAgentManager', () => {
           thoroughness: 'medium',
           summary: 'Found 5 authentication files in src/auth/',
           parentSessionId: 'test-session',
+          resumeId: 'test-resume-id',
           finalAnswer: 'Done',
           steps: [],
           completionInfo: {
@@ -403,6 +410,7 @@ describe('BackgroundAgentManager', () => {
           thoroughness: 'medium',
           summary: 'Immediate result',
           parentSessionId: 'test-session',
+          resumeId: 'test-resume-id',
           finalAnswer: 'Done',
           steps: [],
           completionInfo: {
@@ -460,6 +468,7 @@ describe('BackgroundAgentManager', () => {
           thoroughness: 'quick',
           summary: 'Single agent result',
           parentSessionId: 'test-session',
+          resumeId: 'test-resume-id',
           finalAnswer: 'Done',
           steps: [],
           completionInfo: {
@@ -542,6 +551,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Group 2 result',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {
@@ -565,6 +575,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Group 1 result',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {
@@ -622,6 +633,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Done',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {
@@ -647,6 +659,7 @@ describe('BackgroundAgentManager', () => {
           thoroughness: 'medium',
           summary: 'Success content',
           parentSessionId: 'test-session',
+          resumeId: 'test-resume-id',
           finalAnswer: 'Done',
           steps: [],
           completionInfo: {
@@ -750,6 +763,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Found important files',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {
@@ -861,6 +875,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Done',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {
@@ -916,6 +931,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Done',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {
@@ -967,6 +983,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Done',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {
@@ -1231,6 +1248,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Done',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {
@@ -1314,6 +1332,7 @@ describe('BackgroundAgentManager', () => {
             thoroughness: 'medium',
             summary: 'Success',
             parentSessionId: 'test-session',
+            resumeId: 'test-resume-id',
             finalAnswer: 'Done',
             steps: [],
             completionInfo: {
@@ -1373,6 +1392,7 @@ describe('BackgroundAgentManager', () => {
           thoroughness: 'medium',
           summary: 'Found 10 matching files',
           parentSessionId: 'test-session',
+          resumeId: 'test-resume-id',
           finalAnswer: 'Done',
           steps: [],
           completionInfo: {
@@ -1412,6 +1432,7 @@ describe('BackgroundAgentManager', () => {
         thoroughness: 'medium',
         summary: 'Future result',
         parentSessionId: 'test-session',
+        resumeId: 'test-resume-id',
         finalAnswer: 'Done',
         steps: [],
         completionInfo: {

--- a/packages/cli/src/agents/BackgroundAgentManager.test.ts
+++ b/packages/cli/src/agents/BackgroundAgentManager.test.ts
@@ -1490,4 +1490,19 @@ describe('BackgroundAgentManager', () => {
       expect(resolved.summary).toBe('Test result summary');
     });
   });
+
+  describe('resume history linkage', () => {
+    it('delegates with resumeId set to the job id so history keys to it', async () => {
+      const orchestrator = createMockOrchestrator();
+      const manager = new BackgroundAgentManager(orchestrator);
+
+      // Pass a bogus resumeId; spawn must override it with the generated job id.
+      const jobId = manager.spawn(createSpawnOptions({ resumeId: 'ignored' }));
+      await waitForAllJobsTerminal(manager);
+
+      const delegate = vi.mocked(orchestrator.delegateToAgent);
+      expect(delegate).toHaveBeenCalledTimes(1);
+      expect(delegate.mock.calls[0][0].resumeId).toBe(jobId);
+    });
+  });
 });

--- a/packages/cli/src/agents/BackgroundAgentManager.ts
+++ b/packages/cli/src/agents/BackgroundAgentManager.ts
@@ -155,7 +155,9 @@ export class BackgroundAgentManager {
       groupDescription: options.groupDescription,
     };
 
-    const internal: InternalJob = { job, options, abortController };
+    // Key the stored history to the job id so resume_agent can continue this
+    // run under the same id the model already has.
+    const internal: InternalJob = { job, options: { ...options, resumeId: id }, abortController };
     this.jobs.set(id, internal);
     this.notifyStatusChange(job);
 

--- a/packages/cli/src/agents/SubagentOrchestrator.test.ts
+++ b/packages/cli/src/agents/SubagentOrchestrator.test.ts
@@ -215,6 +215,9 @@ describe('resume_agent end-to-end through the real orchestrator', () => {
     const resumedMessages = seenPerCall[0];
     expect(resumedMessages.some(c => c.includes('investigate the login bug'))).toBe(true);
     expect(resumedMessages.some(c => c.includes('now write the fix'))).toBe(true);
+    // The agent's own prior answer is replayed too, so the resumed run can act on
+    // what it previously concluded (final answers are captured as assistant turns).
+    expect(resumedMessages.filter(c => c === 'acknowledged').length).toBe(1);
     expect(resumedMessages.filter(c => c.startsWith('You are a test agent.')).length).toBe(1);
     expect(out).toContain('acknowledged');
   });

--- a/packages/cli/src/agents/SubagentOrchestrator.test.ts
+++ b/packages/cli/src/agents/SubagentOrchestrator.test.ts
@@ -1,6 +1,20 @@
-import { describe, it, expect } from 'vitest';
-import { SubagentOrchestrator, type OrchestratorDependencies } from './SubagentOrchestrator.js';
+import { describe, it, expect, vi } from 'vitest';
+import type { ICompletionBackend, CompletionInfo, ICompletionOptions } from '@bike4mind/llm-adapters';
+import type { IMessage } from '@bike4mind/common';
+import { SubagentOrchestrator, type OrchestratorDependencies, type SpawnAgentOptions } from './SubagentOrchestrator.js';
 import { MAX_SUBAGENT_DEPTH } from './types.js';
+import { AgentHistoryStore } from './AgentHistoryStore.js';
+
+// Stub tool generation so a real run needs no live apiClient/permission wiring.
+// The depth-cap tests below never reach this call (they throw at the agent
+// lookup first), so the stub only affects the capture test.
+vi.mock('../utils/toolsAdapter.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../utils/toolsAdapter.js')>();
+  return {
+    ...actual,
+    generateCliTools: vi.fn(async (...args: unknown[]) => ({ tools: [], agentContext: args[5] })),
+  };
+});
 
 /**
  * Minimal dependency stub. The depth guard runs before any dependency is
@@ -67,5 +81,92 @@ describe('SubagentOrchestrator depth cap', () => {
         parentSessionId: 'session-1',
       })
     ).rejects.toThrow(/Unknown agent/);
+  });
+});
+
+/** LLM that returns a final answer on its first call, so a run finishes in one iteration. */
+function createOneShotLlm(answer: string): ICompletionBackend {
+  return {
+    currentModel: 'test-model',
+    getModelInfo: async () => [],
+    complete: async (
+      _model: string,
+      _messages: IMessage[],
+      _options: Partial<ICompletionOptions>,
+      callback: (text: (string | null | undefined)[], info?: CompletionInfo) => Promise<void>
+    ) => {
+      await callback([answer], { inputTokens: 10, outputTokens: 5, toolsUsed: [] });
+    },
+    pushToolMessages: vi.fn(),
+  };
+}
+
+/** Inline agent definition (bypasses AgentStore) for a minimal, no-tools run. */
+function inlineAgent(): SpawnAgentOptions['agentDefinition'] {
+  return {
+    description: 'test agent',
+    model: 'test-model',
+    modelResolved: true,
+    systemPrompt: 'You are a test agent.',
+    maxIterations: { quick: 1, medium: 1, very_thorough: 1 },
+    defaultThoroughness: 'quick',
+    retry: { maxRetries: 0, initialDelayMs: 0 },
+  };
+}
+
+function createRunnableOrchestrator(historyStore: AgentHistoryStore, llm: ICompletionBackend): SubagentOrchestrator {
+  const deps = {
+    userId: 'test-user',
+    llm,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    permissionManager: {},
+    showPermissionPrompt: vi.fn(),
+    configStore: { get: async () => ({}) },
+    apiClient: {},
+    agentStore: { getAgent: () => undefined, getAgentNames: () => [] },
+    historyStore,
+  } as unknown as OrchestratorDependencies;
+  return new SubagentOrchestrator(deps);
+}
+
+describe('SubagentOrchestrator history capture', () => {
+  it('stores the finished conversation and returns a resume id', async () => {
+    const historyStore = new AgentHistoryStore();
+    const orchestrator = createRunnableOrchestrator(historyStore, createOneShotLlm('done'));
+
+    const result = await orchestrator.delegateToAgent({
+      task: 'do the thing',
+      agentName: 'tester',
+      parentSessionId: 'session-1',
+      agentDefinition: inlineAgent(),
+    });
+
+    expect(result.resumeId).toMatch(/^sub-/);
+    expect(historyStore.has(result.resumeId)).toBe(true);
+    const stored = historyStore.get(result.resumeId);
+    expect(stored?.agentName).toBe('tester');
+    expect(stored?.parentSessionId).toBe('session-1');
+    expect(stored?.checkpoint.messages.length).toBeGreaterThan(0);
+  });
+
+  it('stores under a caller-supplied resume id and replays previousMessages', async () => {
+    const historyStore = new AgentHistoryStore();
+    const orchestrator = createRunnableOrchestrator(historyStore, createOneShotLlm('done'));
+    const prior: IMessage[] = [{ role: 'user', content: 'earlier context marker' }];
+
+    const result = await orchestrator.delegateToAgent({
+      task: 'continue',
+      agentName: 'tester',
+      parentSessionId: 'session-1',
+      agentDefinition: inlineAgent(),
+      resumeId: 'bg-1234',
+      previousMessages: prior,
+    });
+
+    expect(result.resumeId).toBe('bg-1234');
+    const stored = historyStore.get('bg-1234');
+    // run() builds [system, ...previousMessages, user], so the prior message is replayed at index 1.
+    const replayed = stored?.checkpoint.messages.find(m => m.content === 'earlier context marker');
+    expect(replayed).toBeDefined();
   });
 });

--- a/packages/cli/src/agents/SubagentOrchestrator.test.ts
+++ b/packages/cli/src/agents/SubagentOrchestrator.test.ts
@@ -4,6 +4,7 @@ import type { IMessage } from '@bike4mind/common';
 import { SubagentOrchestrator, type OrchestratorDependencies, type SpawnAgentOptions } from './SubagentOrchestrator.js';
 import { MAX_SUBAGENT_DEPTH } from './types.js';
 import { AgentHistoryStore } from './AgentHistoryStore.js';
+import { createResumeAgentTool } from './resumeAgentTool.js';
 
 // Stub tool generation so a real run needs no live apiClient/permission wiring.
 // The depth-cap tests below never reach this call (they throw at the agent
@@ -168,5 +169,53 @@ describe('SubagentOrchestrator history capture', () => {
     // run() builds [system, ...previousMessages, user], so the prior message is replayed at index 1.
     const replayed = stored?.checkpoint.messages.find(m => m.content === 'earlier context marker');
     expect(replayed).toBeDefined();
+  });
+});
+
+describe('resume_agent end-to-end through the real orchestrator', () => {
+  it('a delegated session, resumed via the tool, replays its prior conversation into the new run', async () => {
+    // Records the messages the LLM sees on each call, so we can prove the
+    // resumed run received the first run's conversation.
+    const seenPerCall: string[][] = [];
+    const recordingLlm: ICompletionBackend = {
+      currentModel: 'test-model',
+      getModelInfo: async () => [],
+      complete: async (
+        _model: string,
+        messages: IMessage[],
+        _options: Partial<ICompletionOptions>,
+        callback: (text: (string | null | undefined)[], info?: CompletionInfo) => Promise<void>
+      ) => {
+        seenPerCall.push(messages.map(m => (typeof m.content === 'string' ? m.content : JSON.stringify(m.content))));
+        await callback(['acknowledged'], { inputTokens: 10, outputTokens: 5, toolsUsed: [] });
+      },
+      pushToolMessages: vi.fn(),
+    };
+
+    const historyStore = new AgentHistoryStore();
+    const orchestrator = createRunnableOrchestrator(historyStore, recordingLlm);
+    const resumeTool = createResumeAgentTool(orchestrator, historyStore);
+
+    // 1. Delegate an initial task.
+    const first = await orchestrator.delegateToAgent({
+      task: 'investigate the login bug',
+      agentName: 'tester',
+      parentSessionId: 'session-1',
+      agentDefinition: inlineAgent(),
+    });
+    expect(historyStore.has(first.resumeId)).toBe(true);
+
+    // 2. Resume it with a follow-up via the tool.
+    seenPerCall.length = 0;
+    const out = (await resumeTool.toolFn({ job_id: first.resumeId, task: 'now write the fix' })) as string;
+
+    // 3. The resumed run's messages must carry the original task AND the follow-up,
+    //    proving prior context was injected (and not double-counting a system prompt).
+    expect(seenPerCall.length).toBeGreaterThan(0);
+    const resumedMessages = seenPerCall[0];
+    expect(resumedMessages.some(c => c.includes('investigate the login bug'))).toBe(true);
+    expect(resumedMessages.some(c => c.includes('now write the fix'))).toBe(true);
+    expect(resumedMessages.filter(c => c.startsWith('You are a test agent.')).length).toBe(1);
+    expect(out).toContain('acknowledged');
   });
 });

--- a/packages/cli/src/agents/SubagentOrchestrator.ts
+++ b/packages/cli/src/agents/SubagentOrchestrator.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { randomBytes } from 'crypto';
 import { z } from 'zod';
 import { ReActAgent } from '@bike4mind/agents';
 import type { AgentResult, ThoroughnessLevel } from '@bike4mind/agents';
+import type { IMessage } from '@bike4mind/common';
 import type { ICompletionBackend, ICompletionOptionTools } from '@bike4mind/llm-adapters';
 import type { Logger } from '@bike4mind/observability';
 import type { PermissionManager } from '../utils/PermissionManager.js';
@@ -32,6 +34,7 @@ import { createSkillTool } from '../tools/skillTool.js';
 import { buildSkillsPromptSection } from '../core/skillsPrompt.js';
 import { isReadOnlyTool } from '../config/toolSafety.js';
 import type { CheckpointStore } from '../storage/CheckpointStore.js';
+import type { AgentHistoryStore } from './AgentHistoryStore.js';
 
 // Re-export ThoroughnessLevel for convenience
 export type { ThoroughnessLevel };
@@ -60,6 +63,17 @@ export interface SpawnAgentOptions {
   variables?: Record<string, string>;
   /** Parent session ID */
   parentSessionId: string;
+  /**
+   * Resume id to store this run's history under. When omitted, delegateToAgent
+   * generates one. Background runs pass their job id so the resumable key matches
+   * the id the model already sees.
+   */
+  resumeId?: string;
+  /**
+   * Prior conversation to replay into the agent (from a stored checkpoint) so a
+   * resumed run continues with full context. See resume_agent.
+   */
+  previousMessages?: IMessage[];
   /** Override model for this execution (takes precedence over agent default) */
   model?: string;
   /** Additional tool restrictions (merged with agent definition) */
@@ -111,6 +125,8 @@ export interface AgentExecutionResult extends AgentResult {
   summary: string;
   /** Parent session ID this agent was spawned from */
   parentSessionId: string;
+  /** Id under which this run's history was stored; pass to resume_agent to continue it. */
+  resumeId: string;
 }
 
 /**
@@ -134,6 +150,8 @@ export interface OrchestratorDependencies {
   showUserQuestion?: (payload: UserQuestionPayload) => Promise<UserQuestionResponse>;
   /** Optional: Checkpoint store for file change recovery */
   checkpointStore?: CheckpointStore | null;
+  /** Optional: retains completed sub-agent conversations for resume_agent. */
+  historyStore?: AgentHistoryStore | null;
 }
 
 /**
@@ -189,6 +207,9 @@ export class SubagentOrchestrator {
           `of ${MAX_SUBAGENT_DEPTH}. Deeper delegation is blocked to prevent unbounded recursion.`
       );
     }
+
+    // Id this run's history is stored under; background runs supply their job id.
+    const resumeId = options.resumeId ?? `sub-${randomBytes(4).toString('hex')}`;
 
     // Clamp the child's interaction mode so it never runs more permissively than
     // its parent. The parent ceiling defaults to the live store mode (the main
@@ -363,6 +384,7 @@ export class SubagentOrchestrator {
             parallelExecution: this.deps.enableParallelToolExecution === true,
             isReadOnlyTool,
             maxHistoryIterations: 4,
+            previousMessages: options.previousMessages,
           }),
         {
           maxRetries: agentDef.retry.maxRetries,
@@ -390,6 +412,7 @@ export class SubagentOrchestrator {
           thoroughness: effectiveThoroughness,
           summary: `Agent blocked: ${error.message}`,
           parentSessionId,
+          resumeId,
           finalAnswer: error.message,
           steps: [],
           completionInfo: {
@@ -435,6 +458,17 @@ export class SubagentOrchestrator {
     // Generate summary
     const summary = this.summarizeResult(result, agentDef);
 
+    // Persist the finished conversation so resume_agent can continue it.
+    if (this.deps.historyStore) {
+      this.deps.historyStore.set(resumeId, {
+        checkpoint: agent.toCheckpoint(),
+        agentName,
+        thoroughness: effectiveThoroughness,
+        parentSessionId,
+        endTime: Date.now(),
+      });
+    }
+
     // Return agent result
     return {
       ...result,
@@ -442,6 +476,7 @@ export class SubagentOrchestrator {
       thoroughness: effectiveThoroughness,
       summary,
       parentSessionId,
+      resumeId,
     };
   }
 

--- a/packages/cli/src/agents/SubagentOrchestrator.ts
+++ b/packages/cli/src/agents/SubagentOrchestrator.ts
@@ -460,8 +460,17 @@ export class SubagentOrchestrator {
 
     // Persist the finished conversation so resume_agent can continue it.
     if (this.deps.historyStore) {
+      const checkpoint = agent.toCheckpoint();
+      // run() records the final answer as a step, not a message, so the agent's
+      // own conclusion is absent from the checkpoint history. Append it as an
+      // assistant turn so a resumed run sees what it previously concluded (the
+      // whole point of "resume to fix the bug you found").
+      const last = checkpoint.messages[checkpoint.messages.length - 1];
+      if (result.finalAnswer && !(last?.role === 'assistant' && last.content === result.finalAnswer)) {
+        checkpoint.messages.push({ role: 'assistant', content: result.finalAnswer });
+      }
       this.deps.historyStore.set(resumeId, {
-        checkpoint: agent.toCheckpoint(),
+        checkpoint,
         agentName,
         agentDefinition: agentDef,
         thoroughness: effectiveThoroughness,

--- a/packages/cli/src/agents/SubagentOrchestrator.ts
+++ b/packages/cli/src/agents/SubagentOrchestrator.ts
@@ -463,6 +463,7 @@ export class SubagentOrchestrator {
       this.deps.historyStore.set(resumeId, {
         checkpoint: agent.toCheckpoint(),
         agentName,
+        agentDefinition: agentDef,
         thoroughness: effectiveThoroughness,
         parentSessionId,
         endTime: Date.now(),

--- a/packages/cli/src/agents/delegateTool.ts
+++ b/packages/cli/src/agents/delegateTool.ts
@@ -86,7 +86,7 @@ export function createAgentDelegateTool(
 
       // Foreground execution (default): block until complete
       const result = await orchestrator.delegateToAgent(spawnOptions);
-      return result.summary;
+      return `${result.summary}\n\n[resume id: ${result.resumeId} - use resume_agent with this id to continue this session]`;
     },
     toolSchema: {
       name: 'agent_delegate',

--- a/packages/cli/src/agents/resumeAgentTool.test.ts
+++ b/packages/cli/src/agents/resumeAgentTool.test.ts
@@ -6,6 +6,22 @@ import { AgentHistoryStore } from './AgentHistoryStore.js';
 import { ALWAYS_DENIED_FOR_AGENTS } from './types.js';
 import type { SubagentOrchestrator, SpawnAgentOptions, AgentExecutionResult } from './SubagentOrchestrator.js';
 import type { BackgroundAgentManager } from './BackgroundAgentManager.js';
+import type { AgentDefinition } from './types.js';
+
+function definition(): AgentDefinition {
+  return {
+    name: 'explore',
+    description: 'test agent',
+    model: 'test-model',
+    modelResolved: true,
+    systemPrompt: 'You are a test agent.',
+    maxIterations: { quick: 1, medium: 1, very_thorough: 1 },
+    defaultThoroughness: 'medium',
+    source: 'builtin',
+    filePath: '<test>',
+    retry: { maxRetries: 0, initialDelayMs: 0 },
+  };
+}
 
 function checkpointWith(messages: IMessage[]): AgentCheckpoint {
   return {
@@ -28,6 +44,7 @@ function seedHistory(store: AgentHistoryStore, id: string, messages: IMessage[])
   store.set(id, {
     checkpoint: checkpointWith(messages),
     agentName: 'explore',
+    agentDefinition: definition(),
     thoroughness: 'medium',
     parentSessionId: 'session-1',
     endTime: Date.now(),

--- a/packages/cli/src/agents/resumeAgentTool.test.ts
+++ b/packages/cli/src/agents/resumeAgentTool.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { AgentCheckpoint } from '@bike4mind/agents';
+import type { IMessage } from '@bike4mind/common';
+import { createResumeAgentTool } from './resumeAgentTool.js';
+import { AgentHistoryStore } from './AgentHistoryStore.js';
+import { ALWAYS_DENIED_FOR_AGENTS } from './types.js';
+import type { SubagentOrchestrator, SpawnAgentOptions, AgentExecutionResult } from './SubagentOrchestrator.js';
+import type { BackgroundAgentManager } from './BackgroundAgentManager.js';
+
+function checkpointWith(messages: IMessage[]): AgentCheckpoint {
+  return {
+    iteration: 1,
+    messages,
+    steps: [],
+    totalTokens: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    totalCredits: 0,
+    toolCallCount: 0,
+    confidenceLog: [],
+    iterationConfidences: [],
+  };
+}
+
+function seedHistory(store: AgentHistoryStore, id: string, messages: IMessage[]): void {
+  store.set(id, {
+    checkpoint: checkpointWith(messages),
+    agentName: 'explore',
+    thoroughness: 'medium',
+    parentSessionId: 'session-1',
+    endTime: Date.now(),
+  });
+}
+
+function mockOrchestrator(): { orchestrator: SubagentOrchestrator; calls: SpawnAgentOptions[] } {
+  const calls: SpawnAgentOptions[] = [];
+  const orchestrator = {
+    delegateToAgent: vi.fn(async (opts: SpawnAgentOptions): Promise<AgentExecutionResult> => {
+      calls.push(opts);
+      return {
+        agentName: opts.agentName,
+        thoroughness: 'medium',
+        summary: 'resumed summary',
+        parentSessionId: opts.parentSessionId,
+        resumeId: opts.resumeId ?? 'generated',
+        finalAnswer: 'done',
+        steps: [],
+        completionInfo: {
+          totalTokens: 0,
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
+          iterations: 1,
+          toolCalls: 0,
+          reachedMaxIterations: false,
+        },
+      };
+    }),
+  } as unknown as SubagentOrchestrator;
+  return { orchestrator, calls };
+}
+
+describe('resume_agent tool', () => {
+  it('is denied to sub-agents to prevent resume chaining', () => {
+    expect(ALWAYS_DENIED_FOR_AGENTS).toContain('resume_agent');
+  });
+
+  it('returns a friendly message when the session is unknown', async () => {
+    const store = new AgentHistoryStore();
+    const { orchestrator, calls } = mockOrchestrator();
+    const tool = createResumeAgentTool(orchestrator, store);
+
+    const out = (await tool.toolFn({ job_id: 'nope', task: 'fix it' })) as string;
+    expect(out).toMatch(/No resumable session/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('requires job_id and task', async () => {
+    const store = new AgentHistoryStore();
+    const { orchestrator } = mockOrchestrator();
+    const tool = createResumeAgentTool(orchestrator, store);
+
+    await expect(tool.toolFn({ task: 'x' })).rejects.toThrow(/job_id is required/);
+    await expect(tool.toolFn({ job_id: 'y' })).rejects.toThrow(/task is required/);
+  });
+
+  it('replays prior messages with the leading system message stripped', async () => {
+    const store = new AgentHistoryStore();
+    seedHistory(store, 'bg-1', [
+      { role: 'system', content: 'ORIGINAL SYSTEM PROMPT' },
+      { role: 'user', content: 'first task' },
+      { role: 'assistant', content: 'first answer' },
+    ]);
+    const { orchestrator, calls } = mockOrchestrator();
+    const tool = createResumeAgentTool(orchestrator, store);
+
+    const out = (await tool.toolFn({ job_id: 'bg-1', task: 'now fix the bug' })) as string;
+
+    expect(calls).toHaveLength(1);
+    const opts = calls[0];
+    expect(opts.task).toBe('now fix the bug');
+    expect(opts.agentName).toBe('explore');
+    expect(opts.parentSessionId).toBe('session-1');
+    expect(opts.resumeId).toBe('bg-1');
+    // System message dropped; the rest replayed.
+    expect(opts.previousMessages).toEqual([
+      { role: 'user', content: 'first task' },
+      { role: 'assistant', content: 'first answer' },
+    ]);
+    expect(out).toContain('resumed summary');
+  });
+
+  it('routes to the background manager when run_in_background is set', async () => {
+    const store = new AgentHistoryStore();
+    seedHistory(store, 'bg-1', [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'earlier' },
+    ]);
+    const { orchestrator, calls } = mockOrchestrator();
+    const spawn = vi.fn((_opts: SpawnAgentOptions) => 'bg-new');
+    const manager = { spawn } as unknown as BackgroundAgentManager;
+    const tool = createResumeAgentTool(orchestrator, store, manager);
+
+    const out = (await tool.toolFn({ job_id: 'bg-1', task: 'continue', run_in_background: true })) as string;
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(0); // foreground delegate not used
+    expect(out).toContain('bg-new');
+    const spawnedOpts = spawn.mock.calls[0][0];
+    expect(spawnedOpts.previousMessages).toEqual([{ role: 'user', content: 'earlier' }]);
+  });
+});

--- a/packages/cli/src/agents/resumeAgentTool.ts
+++ b/packages/cli/src/agents/resumeAgentTool.ts
@@ -41,6 +41,9 @@ export function createResumeAgentTool(
       const spawnOptions: SpawnAgentOptions = {
         task,
         agentName: stored.agentName,
+        // Replay the resolved definition so the agent rebuilds even if it was
+        // inline/dynamic or is no longer in the store.
+        agentDefinition: stored.agentDefinition,
         thoroughness: stored.thoroughness,
         parentSessionId: stored.parentSessionId,
         previousMessages,

--- a/packages/cli/src/agents/resumeAgentTool.ts
+++ b/packages/cli/src/agents/resumeAgentTool.ts
@@ -1,0 +1,85 @@
+import type { ICompletionOptionTools } from '@bike4mind/llm-adapters';
+import type { SubagentOrchestrator, SpawnAgentOptions } from './SubagentOrchestrator.js';
+import type { AgentHistoryStore } from './AgentHistoryStore.js';
+import type { BackgroundAgentManager } from './BackgroundAgentManager.js';
+
+/**
+ * Create the resume_agent tool.
+ *
+ * Lets the orchestrator continue a previously completed sub-agent session with
+ * its full conversation replayed, so a follow-up (e.g. "fix this bug") lands
+ * with all the original context instead of starting a fresh agent cold.
+ *
+ * resume_agent is orchestrator-only - it is listed in ALWAYS_DENIED_FOR_AGENTS
+ * so subagents cannot chain resumes.
+ */
+export function createResumeAgentTool(
+  orchestrator: SubagentOrchestrator,
+  historyStore: AgentHistoryStore,
+  backgroundManager?: BackgroundAgentManager
+): ICompletionOptionTools {
+  return {
+    toolFn: async (args: unknown) => {
+      const { job_id, task, run_in_background } = args as {
+        job_id: string;
+        task: string;
+        run_in_background?: boolean;
+      };
+
+      if (!job_id) throw new Error('resume_agent: job_id is required');
+      if (!task) throw new Error('resume_agent: task is required');
+
+      const stored = historyStore.get(job_id);
+      if (!stored) {
+        return `No resumable session found for ID "${job_id}". It may have expired (histories are retained for a limited time) or never existed. Delegate a fresh agent instead.`;
+      }
+
+      // run() prepends its own system prompt, so drop the checkpoint's leading
+      // system message to avoid a duplicate system message on resume.
+      const previousMessages = stored.checkpoint.messages.slice(1);
+
+      const spawnOptions: SpawnAgentOptions = {
+        task,
+        agentName: stored.agentName,
+        thoroughness: stored.thoroughness,
+        parentSessionId: stored.parentSessionId,
+        previousMessages,
+      };
+
+      if (run_in_background && backgroundManager) {
+        // spawn assigns a fresh job id and keys the resumed run's history to it.
+        const newJobId = backgroundManager.spawn(spawnOptions);
+        return `Resumed agent "${stored.agentName}" in the background. New job ID: ${newJobId}. Use check_agent_status with this ID to retrieve results, or resume_agent again to continue.`;
+      }
+
+      // Foreground: reuse the same id so the session keeps a stable handle across resumes.
+      const result = await orchestrator.delegateToAgent({ ...spawnOptions, resumeId: job_id });
+      return `${result.summary}\n\n[resumed session ${result.resumeId}; call resume_agent with this id to continue it]`;
+    },
+    toolSchema: {
+      name: 'resume_agent',
+      description:
+        'Resume a previously completed sub-agent session with its full context intact, giving it new instructions (e.g. to fix a bug in its earlier output). Prefer this over agent_delegate when following up on a specific prior run, so the agent keeps its original reasoning instead of starting from scratch. Sessions are retained for a limited time after they finish.',
+      parameters: {
+        type: 'object',
+        properties: {
+          job_id: {
+            type: 'string',
+            description:
+              'The resume id of the session to continue: the job ID from agent_delegate/check_agent_status for background runs, or the id surfaced in a foreground agent_delegate result.',
+          },
+          task: {
+            type: 'string',
+            description: 'New instructions for the resumed agent (e.g. "the fix broke the build, correct it").',
+          },
+          run_in_background: {
+            type: 'boolean',
+            description:
+              'Resume in the background (non-blocking). Returns a new job ID to poll with check_agent_status. Defaults to false (blocks until the resumed run completes).',
+          },
+        },
+        required: ['job_id', 'task'],
+      },
+    },
+  };
+}

--- a/packages/cli/src/agents/types.ts
+++ b/packages/cli/src/agents/types.ts
@@ -85,6 +85,7 @@ export const ALWAYS_DENIED_FOR_AGENTS = [
   'agent_delegate', // No agent chaining
   'create_dynamic_agent', // No recursive agent creation
   'coordinate_task', // No recursive coordination loops
+  'resume_agent', // Resume is orchestrator-only; subagents cannot resume sessions
 ] as const;
 
 /**

--- a/packages/cli/src/bootstrap/buildSupportingStores.ts
+++ b/packages/cli/src/bootstrap/buildSupportingStores.ts
@@ -11,6 +11,8 @@ import { McpManager } from '../utils/mcpAdapter';
 import { AgentStore } from '../agents/AgentStore.js';
 import { SubagentOrchestrator } from '../agents/SubagentOrchestrator.js';
 import { BackgroundAgentManager } from '../agents/BackgroundAgentManager.js';
+import { AgentHistoryStore } from '../agents/AgentHistoryStore.js';
+import { DEFAULT_SUBAGENT_HISTORY_TTL_MS } from '../config/constants.js';
 import { deferredToolRegistry } from '../tools/deferredToolRegistry.js';
 import type { UserQuestionPayload, UserQuestionResponse } from '@bike4mind/services';
 import type { PermissionResponse } from '../components';
@@ -53,6 +55,7 @@ export interface SupportingStores {
   deferredB4mTools: CliToolList;
   orchestrator: SubagentOrchestrator;
   backgroundManager: BackgroundAgentManager;
+  historyStore: AgentHistoryStore;
 }
 
 /**
@@ -158,6 +161,11 @@ export async function buildSupportingStores(input: BuildSupportingStoresInput): 
       `${agentSummary.builtin} built-in, ${agentSummary.global} global, ${agentSummary.project} project`
   );
 
+  // Retains completed sub-agent conversations for resume_agent.
+  const historyStore = new AgentHistoryStore(
+    config.preferences.subagentHistoryTtlMs ?? DEFAULT_SUBAGENT_HISTORY_TTL_MS
+  );
+
   // Initialize subagent orchestrator with agent store
   const orchestrator = new SubagentOrchestrator({
     userId: config.userId,
@@ -175,6 +183,7 @@ export async function buildSupportingStores(input: BuildSupportingStoresInput): 
     enableParallelToolExecution: config.preferences.enableParallelToolExecution === true,
     showUserQuestion: userQuestionFn,
     checkpointStore,
+    historyStore,
   });
 
   // Create background agent manager
@@ -191,5 +200,6 @@ export async function buildSupportingStores(input: BuildSupportingStoresInput): 
     deferredB4mTools,
     orchestrator,
     backgroundManager,
+    historyStore,
   };
 }

--- a/packages/cli/src/commands/headlessCommand.ts
+++ b/packages/cli/src/commands/headlessCommand.ts
@@ -33,6 +33,9 @@ import { SubagentOrchestrator } from '../agents/SubagentOrchestrator.js';
 import { BackgroundAgentManager } from '../agents/BackgroundAgentManager.js';
 import { createAgentDelegateTool } from '../agents/delegateTool.js';
 import { createBackgroundAgentTools } from '../agents/backgroundTools.js';
+import { createResumeAgentTool } from '../agents/resumeAgentTool.js';
+import { AgentHistoryStore } from '../agents/AgentHistoryStore.js';
+import { DEFAULT_SUBAGENT_HISTORY_TTL_MS } from '../config/constants.js';
 import { createCoordinateTaskTool } from '../agents/coordinatorTool.js';
 import {
   createWriteTodosTool,
@@ -393,6 +396,11 @@ export async function handleHeadlessCommand(options: HeadlessOptions): Promise<v
 
     const mcpTools = mcpManager.getTools();
 
+    // Retains completed sub-agent conversations for resume_agent.
+    const historyStore = new AgentHistoryStore(
+      config.preferences.subagentHistoryTtlMs ?? DEFAULT_SUBAGENT_HISTORY_TTL_MS
+    );
+
     // Initialize subagent orchestrator
     const orchestrator = new SubagentOrchestrator({
       userId: config.userId,
@@ -408,11 +416,13 @@ export async function handleHeadlessCommand(options: HeadlessOptions): Promise<v
       enableParallelToolExecution: config.preferences.enableParallelToolExecution === true,
       showUserQuestion: userQuestionFn,
       checkpointStore,
+      historyStore,
     });
 
     const backgroundManager = new BackgroundAgentManager(orchestrator);
     const agentDelegateTool = createAgentDelegateTool(orchestrator, agentStore, session.id, backgroundManager);
     const backgroundTools = createBackgroundAgentTools(backgroundManager);
+    const resumeAgentTool = createResumeAgentTool(orchestrator, historyStore, backgroundManager);
     const todoStore = createTodoStore();
     const writeTodosTool = createWriteTodosTool(todoStore);
     const findDefinitionTool = createFindDefinitionTool();
@@ -423,7 +433,14 @@ export async function handleHeadlessCommand(options: HeadlessOptions): Promise<v
       ? createSkillTool({ customCommandStore, subagentOrchestrator: orchestrator, sessionId: session.id })
       : null;
 
-    const cliTools = [agentDelegateTool, ...backgroundTools, writeTodosTool, findDefinitionTool, getFileStructureTool];
+    const cliTools = [
+      agentDelegateTool,
+      ...backgroundTools,
+      resumeAgentTool,
+      writeTodosTool,
+      findDefinitionTool,
+      getFileStructureTool,
+    ];
     if (skillTool) cliTools.push(skillTool);
 
     // Add coordinate_task tool (gated by config flag)

--- a/packages/cli/src/config/constants.ts
+++ b/packages/cli/src/config/constants.ts
@@ -18,6 +18,16 @@ export const MODEL_NAME_COLUMN_WIDTH = 18;
 export const USAGE_CACHE_TTL = 5 * 60 * 1000;
 
 /**
+ * Default TTL for a completed sub-agent's persisted conversation history, in ms
+ * (1 hour). After this, the checkpoint is evicted and the session can no longer
+ * be resumed. Overridable via CliConfig.preferences.subagentHistoryTtlMs.
+ */
+export const DEFAULT_SUBAGENT_HISTORY_TTL_MS = 60 * 60 * 1000;
+
+/** Hard cap on retained sub-agent histories, to bound memory if the TTL never fires. */
+export const MAX_SUBAGENT_HISTORY_ENTRIES = 100;
+
+/**
  * Minimum number of lines in a paste to trigger the compact indicator
  * instead of rendering all pasted text inline
  */

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -139,6 +139,7 @@ import { createAgentDelegateTool } from './agents/delegateTool.js';
 import { createDynamicAgentTool } from './agents/dynamicAgentTool.js';
 import { BackgroundAgentManager } from './agents/BackgroundAgentManager.js';
 import { createBackgroundAgentTools } from './agents/backgroundTools.js';
+import { createResumeAgentTool } from './agents/resumeAgentTool.js';
 import { createCoordinateTaskTool } from './agents/coordinatorTool.js';
 import { parseAgentConfig } from './tools/skillTool.js';
 import { deferredToolRegistry } from './tools/deferredToolRegistry.js';
@@ -775,6 +776,7 @@ function CliApp() {
         deferredB4mTools,
         orchestrator,
         backgroundManager,
+        historyStore,
       } = await buildSupportingStores({
         config,
         llm,
@@ -812,6 +814,9 @@ function CliApp() {
 
       // Create background agent control tools
       const backgroundTools = createBackgroundAgentTools(backgroundManager);
+
+      // Create resume_agent tool (orchestrator-only; continues a prior session)
+      const resumeAgentTool = createResumeAgentTool(orchestrator, historyStore, backgroundManager);
 
       // Wrap with FallbackLlmBackend if fallback models are configured
       const llmWithFallback =
@@ -887,6 +892,7 @@ function CliApp() {
       const cliTools = [
         agentDelegateTool,
         ...backgroundTools,
+        resumeAgentTool,
         writeTodosTool,
         decisionLogTool,
         ...blockerTools,

--- a/packages/cli/src/storage/ConfigStore.ts
+++ b/packages/cli/src/storage/ConfigStore.ts
@@ -263,6 +263,9 @@ const CliConfigSchema = z.object({
      * editing the config file directly.
      */
     promptVariant: z.enum(['current', 'minimal']).optional().prefault('current'),
+    // Retention window for resumable sub-agent history (ms). Absent = use
+    // DEFAULT_SUBAGENT_HISTORY_TTL_MS. See AgentHistoryStore / resume_agent.
+    subagentHistoryTtlMs: z.number().optional(),
   }),
   tools: z.object({
     enabled: z.array(z.string()),

--- a/packages/cli/src/storage/types.ts
+++ b/packages/cli/src/storage/types.ts
@@ -211,6 +211,11 @@ export interface CliConfig {
     promptVariant?: 'current' | 'minimal';
     /** Show the agent's thought steps in the chat trace. Default true. */
     showThoughts?: boolean;
+    /**
+     * How long a completed sub-agent's conversation history is retained for
+     * resume_agent, in ms. Defaults to DEFAULT_SUBAGENT_HISTORY_TTL_MS.
+     */
+    subagentHistoryTtlMs?: number;
   };
   /** Opt-in feature module toggles */
   features?: {


### PR DESCRIPTION
## Optional Screenshot/Video

<img width="1880" height="3954" alt="resume_agent runtime demonstration: delegate then resume with the full prior conversation replayed" src="https://github.com/user-attachments/assets/9adbd9d6-3a2c-4a51-8245-4a78409a0e92" />

*Figure: a live run of the real `SubagentOrchestrator` + `AgentHistoryStore` + `resume_agent` tool (deterministic in-process model, no network). Turn 2 shows the resumed model call receiving the original task, the agent's own prior answer, and the new instruction under a single system prompt (issue #20).*

## Description

Closes #20.

The CLI sub-agent system was ephemeral: `SubagentOrchestrator.delegateToAgent()` built a fresh `ReActAgent` per delegation and discarded its conversation as soon as the run returned. When the orchestrator later found a bug in a sub-agent's output, it had to re-explain the whole task to a brand-new agent, losing all prior reasoning.

This adds a `resume_agent` tool so the orchestrator can continue a previously completed sub-agent session with its full conversation replayed, giving it new instructions (e.g. "fix this bug") without starting cold.

The replay plumbing already existed and is reused rather than reinvented: `ReActAgent.toCheckpoint()` serializes the full message history, and `AgentRunOptions.previousMessages` replays it in `run()`. The new work is capturing that checkpoint, storing it keyed by an id, and exposing the resume tool.

## Changes

- **`AgentHistoryStore`** (new): in-memory store of finished sub-agent conversations keyed by resume id, with lazy TTL eviction mirroring `BackgroundAgentManager.cleanupOldJobs` (drop entries past the TTL, then cap total count). Retention is configurable via `DEFAULT_SUBAGENT_HISTORY_TTL_MS` and the `subagentHistoryTtlMs` preference.
- **Checkpoint capture**: `delegateToAgent` now threads `previousMessages` into `agent.run()` and, when a history store is wired, persists the finished agent's checkpoint (plus its resolved definition) keyed by a resume id. The id is returned on `AgentExecutionResult`.
- **Final answer captured in history**: `run()` records a final answer as a step, not a message, so the checkpoint omitted the agent's own conclusion. The final answer is now appended as an assistant turn at capture time, so a resumed session replays what the agent previously decided (essential for a "fix the bug you found" follow-up).
- **`resume_agent` tool** (new): looks up a stored session, strips the checkpoint's leading system message (so `run()`'s own system prompt is not duplicated), and re-delegates with the prior conversation replayed. Supports `run_in_background`.
- **Resume id / job id linkage**: background runs key their history to the job id, so the id the model already has doubles as the resume id. The foreground `agent_delegate` result now surfaces its resume id.
- **Chaining guard**: `resume_agent` is added to `ALWAYS_DENIED_FOR_AGENTS` so sub-agents cannot chain resumes (orchestrator-only).
- **Registration**: the shared history store + resume tool are wired into all three tool-assembly paths (interactive `index.tsx`, headless, and ACP).
- **Config**: `subagentHistoryTtlMs` declared in the `CliConfig` preferences zod schema so a user-set value survives loading.

## Guide for Testers

This is a CLI-internal orchestrator tool, not a web-app flow, so there is no preview environment to exercise. Verify via the test suite and the runtime demonstration above.

1. From the repo root, install and build core: `pnpm i -r && pnpm turbo:core:build`.
2. Run the CLI unit/integration tests: `pnpm --filter @bike4mind/cli test`. Expected: all tests pass, including `AgentHistoryStore.test.ts`, `resumeAgentTool.test.ts`, and the `SubagentOrchestrator` capture + end-to-end resume tests.
3. The end-to-end test (`resume_agent end-to-end through the real orchestrator` in `SubagentOrchestrator.test.ts`) is the key behavioral proof: it delegates a task through a real orchestrator, resumes it via the `resume_agent` tool, and asserts the resumed run's LLM receives the original task, the agent's own prior answer, AND the follow-up, under exactly one system prompt. Expected: this test passes. The screenshot above is a captured run of this exact flow.
4. Run the full checks: `pnpm turbo:typecheck && pnpm lint:check`. Expected: clean.

### Regression Checks
- Existing `agent_delegate`, `check_agent_status`, `list_background_agents`, and `cancel_background_agent` behavior is unchanged (the foreground delegate result now appends a `[resume id: ...]` line).
- Background-agent spawning, queuing, and grouped notifications behave as before.

### What NOT to test
- No web UI, staging, or preview-env steps apply. There is no user-facing screen for this feature.

## Additional Information

Resume history is intentionally in-memory and per-session: it is bounded by a configurable TTL and does not survive a CLI restart. Persisting across restarts (disk-backed) was considered and deferred as out of scope; the store is a small class that a future disk-backed implementation can swap in behind the same interface.

## Developer Notes (Optional)

- `AgentHistoryStore` is a reusable, TTL-bounded keyed store; its two-pass eviction mirrors `BackgroundAgentManager.cleanupOldJobs` so both stay consistent.
- `SpawnAgentOptions` now carries optional `resumeId` and `previousMessages`, and `AgentExecutionResult` returns `resumeId` — the extension points any future resume/replay caller should use.
- The stored `AgentDefinition` is replayed on resume, so sessions spawned from inline/dynamic definitions (or agents no longer in the store) still rebuild correctly.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc