### PR TITLE
refactor(client): tighten InboxBadge type safety

### DIFF
--- a/apps/client/app/components/inbox/Badge.tsx
+++ b/apps/client/app/components/inbox/Badge.tsx
@@ -15,7 +15,7 @@ const InboxBadge: FC<{ children: ReactNode }> = ({ children }) => {
   const userEmail = currentUser?.email;
 
   const { data: inbox } = useGetInbox(currentUser?.id || '');
-  const { data: invites } = useGetUserInvites(currentUser!.id);
+  const { data: invites } = useGetUserInvites(currentUser?.id || '');
 
   const debounceFetch = useMemo(
     () =>
@@ -52,7 +52,7 @@ const InboxBadge: FC<{ children: ReactNode }> = ({ children }) => {
     const unreadInbox = inbox?.some(item => {
       // Only count messages that would actually be displayed in the message list
       // Skip messages without sender data (except SYSTEM messages)
-      if (item.userId !== 'SYSTEM' && !(item as any).sender) {
+      if (item.userId !== 'SYSTEM' && !item.sender) {
         return false;
       }
       return !item.readAt;

--- a/apps/client/app/utils/inboxAPICalls.ts
+++ b/apps/client/app/utils/inboxAPICalls.ts
@@ -1,12 +1,19 @@
 import { api } from '@client/app/contexts/ApiContext';
 import { IInboxDocument } from '@bike4mind/common';
 
+// The inbox read endpoint enriches each message with its sender via a $lookup on the users
+// collection (see InboxModel.findByReceiverId). It's a query-time projection, not part of the
+// persisted IInbox entity, so it lives as a client read-model type rather than on the core type.
+// Absent when the message is a SYSTEM message or the sender user no longer exists.
+export type InboxMessageSender = { _id?: string; username?: string; name?: string };
+export type InboxMessageWithSender = IInboxDocument & { sender?: InboxMessageSender };
+
 export const readInboxMessages = async (ids: string[]) => {
   const response = await api.post('/api/inbox/read', { ids });
   return response.data;
 };
 
-export const fetchInbox = async (userId?: string): Promise<IInboxDocument[]> => {
+export const fetchInbox = async (userId?: string): Promise<InboxMessageWithSender[]> => {
   try {
     const response = await api.get('/api/inbox', {
       params: userId ? { userId } : {},


### PR DESCRIPTION
## Description

Tightens type safety in the `InboxBadge` notification path. Two pre-existing smells surfaced while reviewing #381, which wraps `InboxBadge` around the side-nav "More" row and so relies on this component more heavily. Pure refactor — **no behavior change**.

1. **Unsafe non-null assertion (`Badge.tsx`).** `useGetUserInvites(currentUser!.id)` asserted `currentUser` non-null while the line right above it (`useGetInbox(currentUser?.id || '')`) guarded the exact same value. If `InboxBadge` ever renders while `currentUser` is momentarily null (logout / token refresh), the `.id` deref throws — and since the always-mounted profile avatar renders an `InboxBadge`, that would take out the side nav, not just the badge. Now guarded the same way. Both hooks already short-circuit on an empty id via `enabled: !!userId`, so passing `''` fires no request.

2. **`(item as any).sender` cast (`Badge.tsx`).** The unread filter cast to `any` to read a `sender` field that `IInboxDocument` doesn't model. That field is a query-time `$lookup` projection added by `InboxModel.findByReceiverId`, not part of the persisted `IInbox` entity — so it's now modeled as a client read-model type (`InboxMessageWithSender`) on `fetchInbox`'s return, and the filter reads `item.sender` with no cast.

## Changes

- `apps/client/app/utils/inboxAPICalls.ts` — add `InboxMessageSender` / `InboxMessageWithSender` read-model types; `fetchInbox` now returns `InboxMessageWithSender[]` (flows through `useGetInbox` to consumers).
- `apps/client/app/components/inbox/Badge.tsx` — guard `currentUser?.id || ''` in `useGetUserInvites`; drop the `as any` on the sender check.

## Guide for Testers

This is a type-safety refactor with no intended behavior change. Verify the notification dot still behaves exactly as before.

**Setup**
1. Sign in to a preview/staging env with an account that has either an unread inbox message or a pending invite.

**Behavior checks**
2. Open the profile menu from the side nav (click the account card at the bottom of the side nav).
   - Expected: the red notification dot shows on the profile avatar/card.
3. Look at the **More** row in the profile menu.
   - Expected: the red dot shows on the More row (the #381 behavior — unchanged here).
4. Click **More** to open the flyout, look at the **Inbox** item.
   - Expected: the Inbox item shows its own red dot.
5. Open the Inbox, read the message (or accept/decline the pending invite) to clear the unread state, then reopen the profile menu.
   - Expected: the dot disappears from the avatar, the More row, and the Inbox item.

**Regression Checks**
6. Account with NO unread inbox and NO pending invite: open the profile menu.
   - Expected: no dot anywhere (avatar, More row, Inbox item).
7. Log out and back in.
   - Expected: no console error / crash from the side nav during the transition (this is the case the removed non-null assertion could have thrown on).

**What NOT to test**
- No API, schema, or persisted-data changes — inbox/invite contents, read state, and delivery are untouched.
- No visual/styling changes to the badge itself.

## Additional Information

Sibling call sites (`InboxTabs.tsx`, `Messages.tsx`) still use `(item as any).sender`. They now receive the typed field for free where they consume `useGetInbox`, so their casts are redundant, but cleaning them up is left out to keep this PR focused on the `InboxBadge` path #381 touches. Easy follow-up.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (typecheck + eslint clean)
