### PR TITLE
ci(e2e): wait out in-flight staging deploy before running e2e

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -183,6 +183,39 @@ jobs:
         timeout-minutes: 8
         run: npx playwright install chromium --with-deps
 
+      # A staging deploy in flight rotates E2E_CLEANUP_SECRET and swaps the Lambda,
+      # so running e2e against it 401s the create-test-user setup - which then skips
+      # the ENTIRE suite via Playwright's setup-dependency graph (one red, the rest
+      # "did not run"). /api/ping is not enough: CloudFront answers it green all
+      # through a deploy. So gate on the `staging/deploy` commit status: if the
+      # newest commit that has one is still `pending`, a deploy is running - wait it
+      # out. dev/staging only (a preview has its own env). Best-effort: warns +
+      # proceeds on timeout so a stuck status can't hang the job forever.
+      - name: Wait for staging deploy to settle (no deploy in flight)
+        if: github.event_name == 'schedule' || inputs.pr_number == ''
+        continue-on-error: true
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = 'Bike4Mind', repo = 'bike4mind';
+            const deployInFlight = async () => {
+              const { data: commits } = await github.rest.repos.listCommits({ owner, repo, sha: 'main', per_page: 10 });
+              for (const c of commits) {
+                const { data: st } = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: c.sha });
+                const s = st.statuses.find(x => x.context === 'staging/deploy');
+                if (!s) continue;              // no status on this commit yet; check older
+                return s.state === 'pending';  // the newest commit WITH a status decides
+              }
+              return false;
+            };
+            for (let i = 0; i < 30; i++) {     // up to ~10 min
+              if (!(await deployInFlight())) { core.info('No staging deploy in flight; proceeding.'); return; }
+              core.info(`Staging deploy in progress; waiting 20s (attempt ${i + 1}/30)...`);
+              await new Promise(r => setTimeout(r, 20000));
+            }
+            core.warning('Staging still deploying after ~10 min; proceeding anyway (the health probe below is the backstop).');
+
       - name: Wait for deployment to be healthy
         env:
           # Probe /api/ping (a real Lambda route) rather than the bare origin:


### PR DESCRIPTION
## Problem

The seed e2e run failed with `create test user failed: 401` in `core.setup.ts`, which (via Playwright's setup-dependency graph in `playwright.config.ts`) skipped the whole suite - "1 failed, 88 did not run". Root cause: it ran **mid-staging-deploy** (deploy 07:03->07:17, e2e 07:07->07:09). While a deploy is in flight the app + `E2E_CLEANUP_SECRET` are rotating, so the auth'd create-user call 401s. `/api/ping` didn't catch it because CloudFront answers that green all through a deploy.

## Fix

Before the health probe, wait until **no staging deploy is in flight**, detected via the `staging/deploy` commit status (which `announce-start` sets to `pending` during a deploy): if the newest commit that has a `staging/deploy` status is still `pending`, poll (20s x up to ~10 min) until it settles, then proceed. Uses the workflow's own `GITHUB_TOKEN` - no new perms.

- dev/staging only (`pr_number == ''`); a preview has its own env and its own health-wait.
- Best-effort (`continue-on-error`) and timeout-bounded: a stuck status can't hang the job - it warns and falls through to the existing `/api/ping` backstop.

## Why this is the right layer

The automated gate path (`trigger-e2e`) already fires only on `deploy.result == 'success'`, so it can't start mid-deploy. This closes the remaining hole for **manual / scheduled** runs that happen to overlap a deploy (exactly what bit the seed run).

## Not fixed here (separate)

- Setup-auth resilience (retry the create-user on transient 401) - app/QA test code.
- Treating a setup/infra failure as neutral rather than `e2e/smoke=failure` - a follow-up on the gate side.

## Verify

YAML parses clean. Behavior-additive: only inserts a wait step ahead of the existing health-wait for dev/staging runs.
