### PR TITLE
fix(scripts): repoint verify-agentless-dispatch to OTC auth

### DIFF
--- a/scripts/verify-agentless-dispatch.mjs
+++ b/scripts/verify-agentless-dispatch.mjs
@@ -18,9 +18,17 @@
  *
  * Usage:
  *   BASE_URL=https://app.pr8933.preview.bike4mind.com \
- *   TEST_EMAIL=test@test.com \
- *   TEST_PASSWORD=$(./for-env dev seed-password) \
+ *   TEST_EMAIL=agentless-e2e@test.com \
+ *   E2E_CLEANUP_SECRET=<the stage's shared E2E secret (SST E2E_CLEANUP_SECRET)> \
  *   node scripts/verify-agentless-dispatch.mjs
+ *
+ * Auth is passwordless (email OTC), so the script authenticates through the
+ * E2E test plumbing instead of a mailbox: it mints the account via the gated
+ * /api/test/create-user endpoint (which returns tokens directly), falling back
+ * to the OTC flow (/api/otc/send -> /api/test/otc-code -> /api/otc/verify) when
+ * the account already exists. Both paths require an `-e2e@test.com` email and
+ * the shared E2E secret, and only work on non-production stages (the test
+ * endpoints are hard-disabled on prod).
  *
  * Credentials are read from env vars (never argv) to keep them out of shell
  * history and process listings. The script does not log the access token.
@@ -29,8 +37,8 @@
 // Node 22+ provides global WebSocket — no dependency needed.
 
 const BASE_URL = process.env.BASE_URL;
-const TEST_EMAIL = process.env.TEST_EMAIL ?? 'test@test.com';
-const TEST_PASSWORD = process.env.TEST_PASSWORD;
+const TEST_EMAIL = process.env.TEST_EMAIL ?? 'agentless-e2e@test.com';
+const E2E_CLEANUP_SECRET = process.env.E2E_CLEANUP_SECRET;
 
 if (!BASE_URL) {
   // Fail fast rather than silently hit a stale default — a hard-coded preview
@@ -49,9 +57,15 @@ const RECONNECT_QUERY =
 const RUN_TIMEOUT_MS = Number(process.env.RUN_TIMEOUT_MS ?? 180_000);
 const SKIP_RECONNECT = process.env.SKIP_RECONNECT === '1';
 
-if (!TEST_PASSWORD) {
-  console.error('TEST_PASSWORD env var is required.');
-  console.error('Tip: TEST_PASSWORD=$(./for-env dev seed-password) ...');
+if (!E2E_CLEANUP_SECRET) {
+  console.error('E2E_CLEANUP_SECRET env var is required (the stage\'s shared E2E secret).');
+  process.exit(2);
+}
+
+// The test auth endpoints only serve -e2e@test.com accounts; fail fast with a
+// clear message instead of a confusing 400 from the server.
+if (!/-e2e@test\.com$/i.test(TEST_EMAIL)) {
+  console.error(`TEST_EMAIL must end with -e2e@test.com (got ${TEST_EMAIL}).`);
   process.exit(2);
 }
 
@@ -61,10 +75,10 @@ const log = (...args) => console.log(`[${new Date().toISOString()}]`, ...args);
 // HTTP helpers
 // ---------------------------------------------------------------------------
 
-async function postJson(url, body) {
+async function postJson(url, body, headers = {}) {
   const res = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -94,6 +108,66 @@ async function postAuthed(url, accessToken, body) {
     throw new Error(`POST ${url} failed: ${res.status} ${res.statusText} — ${text.slice(0, 200)}`);
   }
   return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Auth — passwordless (OTC) via the E2E test plumbing
+// ---------------------------------------------------------------------------
+
+/**
+ * Obtain an access token for TEST_EMAIL without a mailbox.
+ *
+ * Fast path: /api/test/create-user mints the account AND returns a token pair
+ * in one call. When the account already exists that call fails, so fall back
+ * to a real OTC login: /api/otc/send issues the pending token, the gated
+ * /api/test/otc-code hands back the plaintext code (non-prod,
+ * -e2e@test.com accounts only), and /api/otc/verify exchanges them for tokens.
+ * Mirrors apps/client/e2e/helpers/api.ts (apiCreateTestUser / apiGetOtcCode).
+ */
+async function obtainAccessToken() {
+  const secretHeader = { 'x-e2e-cleanup-secret': E2E_CLEANUP_SECRET };
+  const username = TEST_EMAIL.split('@')[0];
+
+  try {
+    const created = await postJson(
+      `${BASE_URL}/api/test/create-user`,
+      // Passwordless account: empty password matches how OTC registration seeds users.
+      { username, email: TEST_EMAIL, name: username, password: '' },
+      secretHeader
+    );
+    log(`Created test user ${TEST_EMAIL}`);
+    return { accessToken: created.accessToken, userId: created.user?.id ?? '<unknown>' };
+  } catch (err) {
+    // 401/403 mean a bad secret or a production stage — the OTC fallback needs
+    // the same secret, so surface the real problem instead of failing twice.
+    if (/ 40[13] /.test(err.message)) throw err;
+    log(`create-user unavailable (${err.message.slice(0, 120)}) — falling back to OTC login`);
+  }
+
+  // /api/otc/send enforces a 30s per-recipient cooldown (429) — reruns within
+  // that window just need to wait it out.
+  const { pendingToken } = await postJson(`${BASE_URL}/api/otc/send`, { email: TEST_EMAIL });
+
+  const codeRes = await fetch(`${BASE_URL}/api/test/otc-code?email=${encodeURIComponent(TEST_EMAIL)}`, {
+    headers: secretHeader,
+  });
+  if (!codeRes.ok) {
+    const text = await codeRes.text().catch(() => '');
+    throw new Error(`GET /api/test/otc-code failed: ${codeRes.status} — ${text.slice(0, 200)}`);
+  }
+  const { code } = await codeRes.json();
+
+  const verifyRes = await postJson(`${BASE_URL}/api/otc/verify`, { email: TEST_EMAIL, code, pendingToken });
+  if (verifyRes.registrationRequired) {
+    throw new Error(`No account for ${TEST_EMAIL} and create-user failed — cannot register via this path.`);
+  }
+  if (verifyRes.mfaRequired || verifyRes.mfaSetupRequired) {
+    throw new Error(`Account ${TEST_EMAIL} requires MFA — use a plain -e2e@test.com account without MFA.`);
+  }
+  if (!verifyRes.accessToken) {
+    throw new Error('OTC verify response did not include accessToken.');
+  }
+  return { accessToken: verifyRes.accessToken, userId: verifyRes.id ?? verifyRes._id ?? '<unknown>' };
 }
 
 // ---------------------------------------------------------------------------
@@ -345,18 +419,10 @@ async function reconnectDispatch(accessToken, wsUrl, sessionId) {
 async function main() {
   log(`Target: ${BASE_URL}`);
 
-  // Login
-  log(`Logging in as ${TEST_EMAIL}…`);
-  const loginRes = await postJson(`${BASE_URL}/api/password/login`, {
-    username: TEST_EMAIL,
-    password: TEST_PASSWORD,
-  });
-  if (!loginRes.accessToken) {
-    throw new Error('Login response did not include accessToken (MFA required? force password change?)');
-  }
-  const accessToken = loginRes.accessToken;
-  const userId = loginRes.id ?? loginRes.userId ?? '<unknown>';
-  log(`Logged in (userId=${userId})`);
+  // Login (passwordless — via the E2E test plumbing)
+  log(`Authenticating as ${TEST_EMAIL}…`);
+  const { accessToken, userId } = await obtainAccessToken();
+  log(`Authenticated (userId=${userId})`);
 
   // Server config → WebSocket URL
   const serverConfig = await getJson(`${BASE_URL}/api/settings/serverConfig`, accessToken);


### PR DESCRIPTION
## Description

Closes #159.

`scripts/verify-agentless-dispatch.mjs` (the agentless `agent_executor` dispatch smoke test) authenticated by POSTing to `/api/password/login`, which was deleted by the passwordless OTC login migration — every run failed at the login step before reaching the WebSocket dispatch it exists to verify. This repoints the script to the OTC flow via the same E2E test plumbing the Playwright suite uses.

## Changes

- New `obtainAccessToken()` replaces the password login block:
  - Fast path: `POST /api/test/create-user` (gated by `x-e2e-cleanup-secret`) mints the `-e2e@test.com` account and returns a token pair in one call.
  - Fallback when the account already exists: `POST /api/otc/send` → `GET /api/test/otc-code` (gated plaintext code) → `POST /api/otc/verify`.
- Env contract (as anticipated in the issue): `TEST_PASSWORD` dropped; `E2E_CLEANUP_SECRET` now required; `TEST_EMAIL` defaults to `agentless-e2e@test.com` and is validated against the `-e2e@test.com` pattern the test endpoints enforce.
- Clear failure modes: 401/403 from create-user (bad secret / prod stage) surfaces immediately instead of failing twice; explicit errors for `registrationRequired` and MFA-enabled accounts.
- Usage docs in the header comment updated; `postJson` gains an optional headers param.

## Guide for Testers

Backend-tooling-only change (a verification script); nothing user-facing.

1. On a preview/dev stage, run: `BASE_URL=<stage URL> E2E_CLEANUP_SECRET=<stage E2E secret> node scripts/verify-agentless-dispatch.mjs`
2. Expected: log lines show `Authenticating as agentless-e2e@test.com…` then `Authenticated (userId=…)`, followed by the two existing phases (smoke + reconnect) completing with the final report and exit code 0.
3. Re-run the same command immediately. Expected: create-user fails (account exists), the script logs `falling back to OTC login`, authenticates via the OTC path, and both phases still pass. (If re-run within 30s, `/api/otc/send` may 429 due to the per-recipient cooldown — wait 30s and retry.)

### What NOT to test
- No application/UI behavior changes — the diff touches only `scripts/verify-agentless-dispatch.mjs`.

## Additional Information

Verified locally against a mock of the five auth endpoints: fresh-account path, existing-account OTC fallback, wrong-secret 401, and all env-var fail-fast paths (`node --check` clean). The WebSocket phases are unchanged. Non-prod only by design — the test endpoints are hard-disabled on production, matching the issue's intent.
