### PR TITLE
fix(client): stop users getting stranded on accept-policies

### DIFF
--- a/apps/client/app/contexts/ApiContext.tsx
+++ b/apps/client/app/contexts/ApiContext.tsx
@@ -80,6 +80,13 @@ export const isPublicPath = (path: string): boolean => {
 export const getAxiosErrorStatus = (error: unknown): number | undefined =>
   isAxiosError(error) ? error.response?.status : undefined;
 
+// Exported so callers can tell whether the interceptor already completed a full
+// refresh-succeeded-then-retried cycle for this error (stamped below as `_retryCount`) -
+// a stronger "already tried, still failed" signal than a bare 401 status, which a caller
+// can hit on its very first attempt whenever the refresh itself (not the retry) failed.
+export const getAxiosRetryCount = (error: unknown): number =>
+  (isAxiosError(error) ? (error.config as { _retryCount?: number } | undefined)?._retryCount : undefined) ?? 0;
+
 const IDEMPOTENT_METHODS = ['post', 'put', 'patch', 'delete'];
 
 export const api = axios.create({

--- a/apps/client/app/contexts/ApiContext.tsx
+++ b/apps/client/app/contexts/ApiContext.tsx
@@ -32,8 +32,12 @@ export function resetRedirectingGuard() {
  * to /login - so an unrecoverable session always ends in a clean sign-out
  * instead of silently flooding 401s with no prompt (the prior behavior for
  * the "already expired / no refresh token" branch).
+ *
+ * Exported so callers with their own unrecoverable-auth-failure signal (e.g.
+ * accept-policies.tsx, whose consent gate has no server session to fall back
+ * on) can reuse this teardown instead of duplicating it.
  */
-async function forceSessionExpiredRedirect(): Promise<void> {
+export async function forceSessionExpiredRedirect(): Promise<void> {
   // markSessionExpired() clears the tokens AND sets expired: true in a
   // single store write, so localStorage doesn't retain stale credentials
   // and background tabs receive exactly one storage event with the final
@@ -69,6 +73,12 @@ export const isPublicPath = (path: string): boolean => {
   // Match the /auth/*/callback pattern
   return /^\/auth\/[^/]+\/callback$/.test(path);
 };
+
+// Exported so callers outside the interceptor (e.g. accept-policies.tsx) can apply the
+// same "is this actually an unrecoverable auth rejection, or just a transient failure"
+// distinction the refresh-retry catch below makes, instead of re-deriving it per caller.
+export const getAxiosErrorStatus = (error: unknown): number | undefined =>
+  isAxiosError(error) ? error.response?.status : undefined;
 
 const IDEMPOTENT_METHODS = ['post', 'put', 'patch', 'delete'];
 
@@ -216,7 +226,7 @@ export const ApiProvider: React.FC<PropsWithChildren> = ({ children }) => {
               // stops the in-flight 401 cascade. The session_expired code surfaces a
               // toast on the login screen, and redirectTo returns the user to where
               // they were after re-login.
-              const refreshStatus = isAxiosError(e) ? e.response?.status : undefined;
+              const refreshStatus = getAxiosErrorStatus(e);
               if (refreshStatus === 400 || refreshStatus === 401) {
                 await forceSessionExpiredRedirect();
               }

--- a/apps/client/app/routes/accept-policies.test.tsx
+++ b/apps/client/app/routes/accept-policies.test.tsx
@@ -16,10 +16,15 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('@client/app/contexts/UserContext', () => ({
   useUser: () => ({ currentUser: { id: 'u1' }, setCurrentUser: vi.fn() }),
 }));
-const mockUseAccessToken = vi.fn();
-vi.mock('@client/app/hooks/useAccessToken', () => ({
-  useAccessToken: () => mockUseAccessToken(),
-}));
+// A plain mutable object (not a vi.fn() return-value mock) so both the hook call and the
+// imperative getState() call - which the component uses to re-read mfaPending live, not from
+// a stale closure - read the same live values, matching real zustand's single-store semantics.
+const mockAccessTokenState = { accessToken: 'atk' as string | null, mfaPending: false };
+vi.mock('@client/app/hooks/useAccessToken', () => {
+  const useAccessToken = () => mockAccessTokenState;
+  useAccessToken.getState = () => mockAccessTokenState;
+  return { useAccessToken };
+});
 const mockApiPost = vi.fn();
 const mockForceSessionExpiredRedirect = vi.fn().mockResolvedValue(undefined);
 vi.mock('@client/app/contexts/ApiContext', () => ({
@@ -63,21 +68,33 @@ const acceptForm = () => {
   fireEvent.click(screen.getByTestId('accept-policies-submit-btn'));
 };
 
-const confirmed401 = { response: { status: 401, data: { error: 'Unauthorized' } } };
-const serverError = { response: { status: 500, data: { error: 'Server error' } } };
+// withRetry (the real, unmocked implementation) coerces a thrown non-Error into a generic
+// Error before passing it to isRetryable, which would strip a plain-object fixture's
+// response/config - so fixtures must be real Error instances to survive that coercion intact.
+const makeAxiosError = (status: number, message: string, retryCount?: number) => {
+  const err = new Error(message) as Error & { response: unknown; config?: unknown };
+  err.response = { status, data: { error: message } };
+  if (retryCount !== undefined) {
+    err.config = { _retryCount: retryCount };
+  }
+  return err;
+};
+
+const serverError = makeAxiosError(500, 'Server error');
 // A first-attempt 401 (the interceptor's refresh attempt itself failed, not yet retried).
-const transient401 = { response: { status: 401, data: { error: 'Unauthorized' } }, config: { _retryCount: 0 } };
+const transient401 = makeAxiosError(401, 'Unauthorized', 0);
 // The interceptor already completed its own refresh-succeeded-then-retried cycle and still
 // got 401 - config._retryCount reflects that.
-const alreadyRetried401 = { response: { status: 401, data: { error: 'Unauthorized' } }, config: { _retryCount: 1 } };
-// Real timeout comfortably past SUBMIT_RETRY_DELAY_MS (1000ms in the component).
+const alreadyRetried401 = makeAxiosError(401, 'Unauthorized', 1);
+// Real timeout comfortably past SUBMIT_RETRY_DELAY_MS (1000ms in the component, plus jitter).
 const RETRY_WAIT_OPTS = { timeout: 2000 };
 
 describe('AcceptPoliciesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockForceSessionExpiredRedirect.mockResolvedValue(undefined);
-    mockUseAccessToken.mockReturnValue({ accessToken: 'atk', mfaPending: false });
+    mockAccessTokenState.accessToken = 'atk';
+    mockAccessTokenState.mfaPending = false;
     mockUseGetIdentify.mockReturnValue({ isError: false, error: null });
   });
 
@@ -108,16 +125,29 @@ describe('AcceptPoliciesPage', () => {
     expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
   });
 
-  // A bootstrap /api/identify that comes back with a confirmed 401 (a stale token whose refresh
-  // attempt itself failed) must not strand the user on this interstitial forever - it should fall
-  // back to the same clean-sign-out teardown used for any other unrecoverable 401, instead of
-  // silently sitting on a form the session can't actually submit.
-  it('tears down when identify fails with a confirmed 401', async () => {
-    mockUseGetIdentify.mockReturnValue({ isError: true, error: confirmed401 });
+  // Only once ApiContext's interceptor has completed its own refresh-succeeded-then-retried
+  // cycle and still gotten 401 (config._retryCount >= 1) is this genuinely unrecoverable - a
+  // first-attempt 401 (retryCount 0) can equally mean the refresh endpoint itself failed
+  // transiently, which the interceptor deliberately does NOT treat as unrecoverable.
+  it('tears down when identify fails with a confirmed, already-retried 401', async () => {
+    mockUseGetIdentify.mockReturnValue({ isError: true, error: alreadyRetried401 });
 
     renderPage();
 
     await waitFor(() => expect(mockForceSessionExpiredRedirect).toHaveBeenCalledTimes(1));
+  });
+
+  // A first-attempt 401 on identify (retryCount 0) can be a transient refresh-endpoint outage
+  // (e.g. a cold Lambda right after a deploy) - exactly the case ApiContext's own interceptor
+  // deliberately does not tear down for, to avoid a spurious logout storm. This page must not
+  // force a teardown on that signal alone either.
+  it('does not tear down when identify fails with a first-attempt (not-yet-retried) 401', () => {
+    mockUseGetIdentify.mockReturnValue({ isError: true, error: transient401 });
+
+    renderPage();
+
+    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
+    expect(checkboxInput('accept-policies-checkbox')).not.toBeDisabled();
   });
 
   // A background-refetch blip unrelated to auth (network drop, 5xx) says nothing about whether
@@ -135,8 +165,8 @@ describe('AcceptPoliciesPage', () => {
   // During mfaPending no refresh token is issued by design, so a 401 on identify is expected,
   // not a sign of a dead session - tearing down here would destroy an in-progress MFA setup.
   it('does not tear down on a confirmed 401 while mfaPending', () => {
-    mockUseAccessToken.mockReturnValue({ accessToken: 'atk', mfaPending: true });
-    mockUseGetIdentify.mockReturnValue({ isError: true, error: confirmed401 });
+    mockAccessTokenState.mfaPending = true;
+    mockUseGetIdentify.mockReturnValue({ isError: true, error: alreadyRetried401 });
 
     renderPage();
 
@@ -144,7 +174,7 @@ describe('AcceptPoliciesPage', () => {
   });
 
   it('disables the form while the session is unverified', () => {
-    mockUseGetIdentify.mockReturnValue({ isError: true, error: confirmed401 });
+    mockUseGetIdentify.mockReturnValue({ isError: true, error: alreadyRetried401 });
 
     renderPage();
 
@@ -173,8 +203,9 @@ describe('AcceptPoliciesPage', () => {
 
   // If the backoff retry also 401s, that's as far as this page can recover on its own - fall
   // back to the same clean sign-out used for any other unrecoverable session, rather than
-  // resubmitting forever or dead-ending on a raw error.
-  it('tears down if the backoff retry also 401s', async () => {
+  // resubmitting forever or dead-ending on a raw error. The real error text stays visible right
+  // up to that point rather than being silently dropped.
+  it('tears down if the backoff retry also 401s, showing the error first', async () => {
     mockApiPost.mockRejectedValue(transient401);
 
     renderPage();
@@ -182,6 +213,7 @@ describe('AcceptPoliciesPage', () => {
 
     await waitFor(() => expect(mockForceSessionExpiredRedirect).toHaveBeenCalledTimes(1), RETRY_WAIT_OPTS);
     expect(mockApiPost).toHaveBeenCalledTimes(2);
+    expect(screen.getByText('Unauthorized')).toBeInTheDocument();
     // isSubmitting must be reset even on the teardown path, so a no-op redirect (e.g. a
     // concurrent teardown already in flight) never leaves the button stuck loading.
     expect(screen.getByTestId('accept-policies-submit-btn')).not.toBeDisabled();
@@ -189,7 +221,7 @@ describe('AcceptPoliciesPage', () => {
 
   // If the interceptor already completed its own refresh-succeeded-then-retried cycle for this
   // error (config._retryCount already >= 1), a further client-side retry can't help - skip the
-  // backoff delay entirely and tear down immediately.
+  // backoff delay entirely and tear down immediately, still showing the error first.
   it('tears down immediately with no backoff retry when the interceptor already retried once', async () => {
     mockApiPost.mockRejectedValue(alreadyRetried401);
 
@@ -198,6 +230,7 @@ describe('AcceptPoliciesPage', () => {
 
     await waitFor(() => expect(mockForceSessionExpiredRedirect).toHaveBeenCalledTimes(1));
     expect(mockApiPost).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Unauthorized')).toBeInTheDocument();
   });
 
   // A failure unrelated to auth (an unrelated backend bug, a validation error) says nothing about
@@ -217,8 +250,8 @@ describe('AcceptPoliciesPage', () => {
   });
 
   it('does not tear down on repeated 401 submit failures while mfaPending', async () => {
-    mockUseAccessToken.mockReturnValue({ accessToken: 'atk', mfaPending: true });
-    mockApiPost.mockRejectedValue(confirmed401);
+    mockAccessTokenState.mfaPending = true;
+    mockApiPost.mockRejectedValue(alreadyRetried401);
 
     renderPage();
 
@@ -228,6 +261,26 @@ describe('AcceptPoliciesPage', () => {
     fireEvent.click(screen.getByTestId('accept-policies-submit-btn'));
     await waitFor(() => expect(mockApiPost).toHaveBeenCalledTimes(2));
 
+    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
+  });
+
+  // mfaPending is re-read live (useAccessToken.getState()) rather than closed over at the start
+  // of the submit, since the retry chain can run up to a second later - a cross-tab mfaPending
+  // rehydrate mid-wait must not be missed by a stale closure.
+  it('re-reads mfaPending fresh rather than using a stale value from when the submit started', async () => {
+    let callCount = 0;
+    mockApiPost.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 2) {
+        mockAccessTokenState.mfaPending = true;
+      }
+      return Promise.reject(transient401);
+    });
+
+    renderPage();
+    acceptForm();
+
+    await waitFor(() => expect(callCount).toBe(2), RETRY_WAIT_OPTS);
     expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/routes/accept-policies.test.tsx
+++ b/apps/client/app/routes/accept-policies.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
 import { ExternalLinks } from '@client/app/utils/externalLinks';
@@ -16,10 +16,23 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('@client/app/contexts/UserContext', () => ({
   useUser: () => ({ currentUser: { id: 'u1' }, setCurrentUser: vi.fn() }),
 }));
+const mockUseAccessToken = vi.fn();
 vi.mock('@client/app/hooks/useAccessToken', () => ({
-  useAccessToken: () => ({ accessToken: 'atk' }),
+  useAccessToken: () => mockUseAccessToken(),
 }));
-vi.mock('@client/app/contexts/ApiContext', () => ({ api: { post: vi.fn() } }));
+const mockApiPost = vi.fn();
+const mockForceSessionExpiredRedirect = vi.fn().mockResolvedValue(undefined);
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { post: (...args: unknown[]) => mockApiPost(...args) },
+  forceSessionExpiredRedirect: (...args: unknown[]) => mockForceSessionExpiredRedirect(...args),
+  // Mirrors the real helper's observable behavior (pull the status off an axios-shaped
+  // error) without depending on axios's actual isAxiosError marker in test fixtures.
+  getAxiosErrorStatus: (error: unknown) => (error as { response?: { status?: number } } | undefined)?.response?.status,
+}));
+const mockUseGetIdentify = vi.fn();
+vi.mock('@client/app/hooks/data/user', () => ({
+  useGetIdentify: () => mockUseGetIdentify(),
+}));
 vi.mock('@client/app/hooks/useGetLogo', () => ({ default: () => '/logo.png' }));
 vi.mock('@client/app/utils/authRedirect', () => ({ applyRedirect: vi.fn() }));
 vi.mock('next/image', () => ({ default: () => null }));
@@ -34,7 +47,31 @@ const renderPage = () =>
     </CssVarsProvider>
   );
 
+// MUI Joy's Checkbox puts the actual <input> (and its onChange, and its disabled state)
+// inside the data-testid'd root span - interact with the input directly, not the wrapper.
+const checkboxInput = (testId: string) => {
+  const input = screen.getByTestId(testId).querySelector('input');
+  if (!input) throw new Error(`No <input> found inside checkbox "${testId}"`);
+  return input;
+};
+
+const acceptForm = () => {
+  fireEvent.click(checkboxInput('accept-policies-checkbox'));
+  fireEvent.click(checkboxInput('accept-age-checkbox'));
+  fireEvent.click(screen.getByTestId('accept-policies-submit-btn'));
+};
+
+const confirmed401 = { response: { status: 401, data: { error: 'Unauthorized' } } };
+const serverError = { response: { status: 500, data: { error: 'Server error' } } };
+
 describe('AcceptPoliciesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockForceSessionExpiredRedirect.mockResolvedValue(undefined);
+    mockUseAccessToken.mockReturnValue({ accessToken: 'atk', mfaPending: false });
+    mockUseGetIdentify.mockReturnValue({ isError: false, error: null });
+  });
+
   // Regression guard for #59: the ToS/AUP/Privacy links in the acceptance-checkbox label must
   // point at the right policy pages and open in a new tab. (The underlying bug - clicks landing
   // on the checkbox's transparent input overlay instead of the anchor - is a visual stacking-order
@@ -54,5 +91,109 @@ describe('AcceptPoliciesPage', () => {
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     }
+  });
+
+  it('does not tear down while identify has not (yet) failed', () => {
+    renderPage();
+
+    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
+  });
+
+  // A bootstrap /api/identify that comes back with a confirmed 401 (a stale token whose refresh
+  // attempt itself failed) must not strand the user on this interstitial forever - it should fall
+  // back to the same clean-sign-out teardown used for any other unrecoverable 401, instead of
+  // silently sitting on a form the session can't actually submit.
+  it('tears down when identify fails with a confirmed 401', async () => {
+    mockUseGetIdentify.mockReturnValue({ isError: true, error: confirmed401 });
+
+    renderPage();
+
+    await waitFor(() => expect(mockForceSessionExpiredRedirect).toHaveBeenCalledTimes(1));
+  });
+
+  // A background-refetch blip unrelated to auth (network drop, 5xx) says nothing about whether
+  // this session is actually dead - tearing down on any identify error would log out users with
+  // perfectly valid sessions on a transient hiccup.
+  it('does not tear down when identify fails with a non-401 error', () => {
+    mockUseGetIdentify.mockReturnValue({ isError: true, error: serverError });
+
+    renderPage();
+
+    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
+    expect(checkboxInput('accept-policies-checkbox')).not.toBeDisabled();
+  });
+
+  // During mfaPending no refresh token is issued by design, so a 401 on identify is expected,
+  // not a sign of a dead session - tearing down here would destroy an in-progress MFA setup.
+  it('does not tear down on a confirmed 401 while mfaPending', () => {
+    mockUseAccessToken.mockReturnValue({ accessToken: 'atk', mfaPending: true });
+    mockUseGetIdentify.mockReturnValue({ isError: true, error: confirmed401 });
+
+    renderPage();
+
+    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
+  });
+
+  it('disables the form while the session is unverified', () => {
+    mockUseGetIdentify.mockReturnValue({ isError: true, error: confirmed401 });
+
+    renderPage();
+
+    expect(checkboxInput('accept-policies-checkbox')).toBeDisabled();
+    expect(checkboxInput('accept-age-checkbox')).toBeDisabled();
+    expect(screen.getByTestId('accept-policies-submit-btn')).toBeDisabled();
+  });
+
+  // The first submit failure should look recoverable (show the error, let the user retry) since
+  // a confirmed unrecoverable 401 already redirects via ApiContext's own interceptor before this
+  // catch ever runs. Only a second consecutive 401 - most likely a sustained transient refresh
+  // outage the interceptor deliberately didn't log out for - falls back to a clean sign-out
+  // instead of resubmitting forever, and the real error text stays visible right up to that point.
+  it('shows a retryable error on the first 401 submit failure, then tears down on the second', async () => {
+    mockApiPost.mockRejectedValue(confirmed401);
+
+    renderPage();
+
+    acceptForm();
+    await waitFor(() => expect(screen.getByText('Unauthorized')).toBeInTheDocument());
+    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
+    expect(screen.getByTestId('accept-policies-submit-btn')).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('accept-policies-submit-btn'));
+    await waitFor(() => expect(mockForceSessionExpiredRedirect).toHaveBeenCalledTimes(1));
+    // isSubmitting must be reset even on the teardown path, so a no-op redirect (e.g. a
+    // concurrent teardown already in flight) never leaves the button stuck loading.
+    expect(screen.getByTestId('accept-policies-submit-btn')).not.toBeDisabled();
+  });
+
+  // A failure unrelated to auth (an unrelated backend bug, a validation error) says nothing about
+  // the session - it must stay retryable indefinitely rather than eventually forcing a sign-out.
+  it('never tears down on repeated non-401 submit failures', async () => {
+    mockApiPost.mockRejectedValue(serverError);
+
+    renderPage();
+
+    acceptForm();
+    await waitFor(() => expect(screen.getByText('Server error')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('accept-policies-submit-btn'));
+    await waitFor(() => expect(mockApiPost).toHaveBeenCalledTimes(2));
+
+    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
+  });
+
+  it('does not tear down on repeated 401 submit failures while mfaPending', async () => {
+    mockUseAccessToken.mockReturnValue({ accessToken: 'atk', mfaPending: true });
+    mockApiPost.mockRejectedValue(confirmed401);
+
+    renderPage();
+
+    acceptForm();
+    await waitFor(() => expect(screen.getByText('Unauthorized')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('accept-policies-submit-btn'));
+    await waitFor(() => expect(mockApiPost).toHaveBeenCalledTimes(2));
+
+    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/routes/accept-policies.test.tsx
+++ b/apps/client/app/routes/accept-policies.test.tsx
@@ -25,9 +25,11 @@ const mockForceSessionExpiredRedirect = vi.fn().mockResolvedValue(undefined);
 vi.mock('@client/app/contexts/ApiContext', () => ({
   api: { post: (...args: unknown[]) => mockApiPost(...args) },
   forceSessionExpiredRedirect: (...args: unknown[]) => mockForceSessionExpiredRedirect(...args),
-  // Mirrors the real helper's observable behavior (pull the status off an axios-shaped
-  // error) without depending on axios's actual isAxiosError marker in test fixtures.
+  // Mirrors the real helpers' observable behavior (pull fields off an axios-shaped error)
+  // without depending on axios's actual isAxiosError marker in test fixtures.
   getAxiosErrorStatus: (error: unknown) => (error as { response?: { status?: number } } | undefined)?.response?.status,
+  getAxiosRetryCount: (error: unknown) =>
+    (error as { config?: { _retryCount?: number } } | undefined)?.config?._retryCount ?? 0,
 }));
 const mockUseGetIdentify = vi.fn();
 vi.mock('@client/app/hooks/data/user', () => ({
@@ -63,6 +65,13 @@ const acceptForm = () => {
 
 const confirmed401 = { response: { status: 401, data: { error: 'Unauthorized' } } };
 const serverError = { response: { status: 500, data: { error: 'Server error' } } };
+// A first-attempt 401 (the interceptor's refresh attempt itself failed, not yet retried).
+const transient401 = { response: { status: 401, data: { error: 'Unauthorized' } }, config: { _retryCount: 0 } };
+// The interceptor already completed its own refresh-succeeded-then-retried cycle and still
+// got 401 - config._retryCount reflects that.
+const alreadyRetried401 = { response: { status: 401, data: { error: 'Unauthorized' } }, config: { _retryCount: 1 } };
+// Real timeout comfortably past SUBMIT_RETRY_DELAY_MS (1000ms in the component).
+const RETRY_WAIT_OPTS = { timeout: 2000 };
 
 describe('AcceptPoliciesPage', () => {
   beforeEach(() => {
@@ -144,26 +153,51 @@ describe('AcceptPoliciesPage', () => {
     expect(screen.getByTestId('accept-policies-submit-btn')).toBeDisabled();
   });
 
-  // The first submit failure should look recoverable (show the error, let the user retry) since
-  // a confirmed unrecoverable 401 already redirects via ApiContext's own interceptor before this
-  // catch ever runs. Only a second consecutive 401 - most likely a sustained transient refresh
-  // outage the interceptor deliberately didn't log out for - falls back to a clean sign-out
-  // instead of resubmitting forever, and the real error text stays visible right up to that point.
-  it('shows a retryable error on the first 401 submit failure, then tears down on the second', async () => {
-    mockApiPost.mockRejectedValue(confirmed401);
+  // A first-attempt 401 (the interceptor's own refresh attempt itself failed, not yet retried)
+  // gets one automatic backoff retry before anything is shown to the user - a confirmed
+  // unrecoverable 401 already redirects via ApiContext's own interceptor before this catch ever
+  // runs, so this is specifically the "maybe it's already cleared up" case. If the retry
+  // recovers, the user never even sees an error.
+  it('auto-retries a first-attempt 401 once and succeeds silently if the retry recovers', async () => {
+    mockApiPost
+      .mockRejectedValueOnce(transient401)
+      .mockResolvedValueOnce({ data: { user: { id: 'u1', aupAcceptedVersion: 'v1' } } });
 
     renderPage();
-
     acceptForm();
-    await waitFor(() => expect(screen.getByText('Unauthorized')).toBeInTheDocument());
-    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
-    expect(screen.getByTestId('accept-policies-submit-btn')).not.toBeDisabled();
 
-    fireEvent.click(screen.getByTestId('accept-policies-submit-btn'));
-    await waitFor(() => expect(mockForceSessionExpiredRedirect).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockApiPost).toHaveBeenCalledTimes(2), RETRY_WAIT_OPTS);
+    expect(mockForceSessionExpiredRedirect).not.toHaveBeenCalled();
+    expect(screen.queryByText('Unauthorized')).not.toBeInTheDocument();
+  });
+
+  // If the backoff retry also 401s, that's as far as this page can recover on its own - fall
+  // back to the same clean sign-out used for any other unrecoverable session, rather than
+  // resubmitting forever or dead-ending on a raw error.
+  it('tears down if the backoff retry also 401s', async () => {
+    mockApiPost.mockRejectedValue(transient401);
+
+    renderPage();
+    acceptForm();
+
+    await waitFor(() => expect(mockForceSessionExpiredRedirect).toHaveBeenCalledTimes(1), RETRY_WAIT_OPTS);
+    expect(mockApiPost).toHaveBeenCalledTimes(2);
     // isSubmitting must be reset even on the teardown path, so a no-op redirect (e.g. a
     // concurrent teardown already in flight) never leaves the button stuck loading.
     expect(screen.getByTestId('accept-policies-submit-btn')).not.toBeDisabled();
+  });
+
+  // If the interceptor already completed its own refresh-succeeded-then-retried cycle for this
+  // error (config._retryCount already >= 1), a further client-side retry can't help - skip the
+  // backoff delay entirely and tear down immediately.
+  it('tears down immediately with no backoff retry when the interceptor already retried once', async () => {
+    mockApiPost.mockRejectedValue(alreadyRetried401);
+
+    renderPage();
+    acceptForm();
+
+    await waitFor(() => expect(mockForceSessionExpiredRedirect).toHaveBeenCalledTimes(1));
+    expect(mockApiPost).toHaveBeenCalledTimes(1);
   });
 
   // A failure unrelated to auth (an unrelated backend bug, a validation error) says nothing about

--- a/apps/client/app/routes/accept-policies.tsx
+++ b/apps/client/app/routes/accept-policies.tsx
@@ -131,6 +131,11 @@ const AcceptPoliciesPage = () => {
 
       if (!useAccessToken.getState().mfaPending && getAxiosErrorStatus(err) === 401) {
         // Retries exhausted (or none were warranted) - not something resubmitting can fix.
+        // Mirrors the mount effect's own guard: markSessionExpired() (inside
+        // forceSessionExpiredRedirect) clears accessToken synchronously, which would
+        // otherwise re-run that effect mid-await and fire a soft, uninformative /login
+        // navigation before this call's own hard redirect (with proper messaging) lands.
+        tearingDownRef.current = true;
         setError(message);
         await forceSessionExpiredRedirect();
         setIsSubmitting(false);

--- a/apps/client/app/routes/accept-policies.tsx
+++ b/apps/client/app/routes/accept-policies.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearch, useRouter } from '@tanstack/react-router';
 import { Box, Button, Checkbox, Container, Sheet, Stack, Typography, Link } from '@mui/joy';
 import GppGoodIcon from '@mui/icons-material/GppGood';
 import Image from 'next/image';
+import { withRetry } from '@bike4mind/common';
 
 import { useUser } from '@client/app/contexts/UserContext';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
@@ -17,13 +18,7 @@ import useGetLogo from '@client/app/hooks/useGetLogo';
 import { ExternalLinks, CHECKBOX_LABEL_LINK_SX } from '@client/app/utils/externalLinks';
 import { applyRedirect } from '@client/app/utils/authRedirect';
 
-// A 401 reaching handleSubmit's catch has already passed through ApiContext's own
-// refresh-retry interceptor once (it attempts a refresh on every 401 before rejecting) - a
-// confirmed 400/401 refresh rejection already redirects via the interceptor itself before
-// this catch ever runs. So a 401 here means either the refresh attempt itself failed (a
-// transient outage, retryCount still 0 - worth one backoff retry, since it may have already
-// cleared) or the refresh succeeded and the retried request 401'd anyway (retryCount >= 1 -
-// genuinely unrecoverable, not something a resubmit can fix). See getAxiosRetryCount.
+// One backoff retry before giving up on a submit 401 - see the isRetryable predicate below.
 const SUBMIT_RETRY_DELAY_MS = 1000;
 
 /**
@@ -47,24 +42,42 @@ const AcceptPoliciesPage = () => {
   const [confirmAdult, setConfirmAdult] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Set right before calling forceSessionExpiredRedirect() so the effect below (which
+  // re-runs when that call's markSessionExpired() clears accessToken) can tell "we're
+  // already mid-teardown, the hard redirect is already coming" apart from a page load
+  // that genuinely never had a token, and skip firing a second, uninformative soft nav.
+  const tearingDownRef = useRef(false);
+  // Aborted on unmount so a pending submit-retry backoff (see handleSubmit) doesn't fire
+  // a pointless extra request, or its follow-on state updates, after the user has left.
+  const submitAbortControllerRef = useRef<AbortController | null>(null);
+  useEffect(() => {
+    return () => submitAbortControllerRef.current?.abort();
+  }, []);
 
   const redirectTo = (search as { redirectTo?: string }).redirectTo;
 
-  // True when identify came back with a confirmed 401 (a stale token whose refresh attempt
-  // itself failed, per ApiContext's transient-vs-confirmed distinction) - this page then has no
-  // server-confirmed user to render off. Excludes mfaPending, which both ApiContext's interceptor
-  // and UserContext's bootstrap effect also exempt: during mfaPending no refresh token is issued
-  // by design, so a 401 here is expected, not a dead session. Also excludes anything other than a
-  // confirmed 401 (5xx, network, an unrelated background-refetch blip on an otherwise-valid
-  // session) - those say nothing about this session being unrecoverable.
-  const sessionUnverified = identity.isError && !mfaPending && getAxiosErrorStatus(identity.error) === 401;
+  // True only once identify has both a confirmed 401 (not mfaPending, which both ApiContext's
+  // interceptor and UserContext's bootstrap effect also exempt - no refresh token is issued
+  // during mfaPending by design, so a 401 there is expected) AND retryCount >= 1, meaning
+  // ApiContext's interceptor already completed its own refresh-succeeded-then-retried cycle
+  // and still got 401. A first-attempt 401 (retryCount 0) can equally mean the refresh
+  // endpoint itself failed transiently - a case the interceptor deliberately does NOT treat as
+  // unrecoverable, to avoid a spurious logout on e.g. a cold Lambda right after a deploy - so
+  // this page must not force a teardown on that signal alone either.
+  const sessionUnverified =
+    identity.isError &&
+    !mfaPending &&
+    getAxiosErrorStatus(identity.error) === 401 &&
+    getAxiosRetryCount(identity.error) >= 1;
 
   // Guard the guard: no token -> login; already-accepted user -> don't trap them on this page;
   // unverifiable session -> tear down the same way any other unrecoverable 401 does instead of
   // stranding the user on an interstitial their session can't back.
   useEffect(() => {
     if (!accessToken) {
-      navigate({ to: '/login', replace: true });
+      if (!tearingDownRef.current) {
+        navigate({ to: '/login', replace: true });
+      }
       return;
     }
     if (currentUser?.aupAcceptedVersion) {
@@ -72,47 +85,12 @@ const AcceptPoliciesPage = () => {
       return;
     }
     if (sessionUnverified) {
+      tearingDownRef.current = true;
       void forceSessionExpiredRedirect();
     }
   }, [accessToken, currentUser, sessionUnverified, navigate, redirectTo, router]);
 
   const isFormValid = acceptPolicies && confirmAdult;
-
-  // allowRetry is true only for the user-initiated attempt, so the one automatic backoff
-  // retry below can't itself trigger a further retry.
-  const submitPolicyAcceptance = async (allowRetry: boolean): Promise<void> => {
-    try {
-      const response = await api.post('/api/user/accept-policies', { ageAttestation: true });
-      // Update currentUser so the consent gate clears (both the server field and this client state).
-      setCurrentUser(response.data.user);
-      applyRedirect(router.history, redirectTo, '/', true);
-    } catch (err: unknown) {
-      if (!mfaPending && getAxiosErrorStatus(err) === 401) {
-        // First attempt at a transient (not-yet-retried) 401: give the refresh endpoint a
-        // moment to recover and retry once automatically, rather than dead-ending on an error
-        // or immediately signing the user out over a passing blip.
-        if (allowRetry && getAxiosRetryCount(err) === 0) {
-          await new Promise(resolve => setTimeout(resolve, SUBMIT_RETRY_DELAY_MS));
-          await submitPolicyAcceptance(false);
-          return;
-        }
-        // Either the backoff retry also 401'd, or the interceptor already completed its own
-        // refresh-succeeded-then-retried cycle and still got 401 - not something resubmitting
-        // can fix.
-        await forceSessionExpiredRedirect();
-        setIsSubmitting(false);
-        return;
-      }
-
-      // Unrelated to the session (5xx, validation, network) - just show it, retryable indefinitely.
-      const message =
-        (err as { response?: { data?: { error?: string } }; message?: string }).response?.data?.error ||
-        (err as Error).message ||
-        'Failed to record acceptance';
-      setError(message);
-      setIsSubmitting(false);
-    }
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -120,7 +98,49 @@ const AcceptPoliciesPage = () => {
 
     setError(null);
     setIsSubmitting(true);
-    await submitPolicyAcceptance(true);
+
+    const controller = new AbortController();
+    submitAbortControllerRef.current = controller;
+
+    try {
+      const { result: response } = await withRetry(
+        () => api.post('/api/user/accept-policies', { ageAttestation: true }),
+        {
+          maxRetries: 1,
+          initialDelayMs: SUBMIT_RETRY_DELAY_MS,
+          abortSignal: controller.signal,
+          // Only a first-attempt 401 (config._retryCount still 0 - the interceptor's own
+          // refresh attempt itself failed, not yet retried) is worth a retry: a confirmed
+          // 400/401 refresh rejection already redirects via the interceptor before this catch
+          // ever runs, so a persisting 401 here means either a transient refresh outage worth
+          // one more try, or (once retried) the interceptor's own refresh-succeeded-then-retried
+          // cycle already failed - not something a resubmit can fix. mfaPending is re-read live
+          // (not closed over) since this predicate can run up to a second after the original call.
+          isRetryable: err =>
+            !useAccessToken.getState().mfaPending && getAxiosErrorStatus(err) === 401 && getAxiosRetryCount(err) === 0,
+        }
+      );
+      // Update currentUser so the consent gate clears (both the server field and this client state).
+      setCurrentUser(response.data.user);
+      applyRedirect(router.history, redirectTo, '/', true);
+    } catch (err: unknown) {
+      const message =
+        (err as { response?: { data?: { error?: string } }; message?: string }).response?.data?.error ||
+        (err as Error).message ||
+        'Failed to record acceptance';
+
+      if (!useAccessToken.getState().mfaPending && getAxiosErrorStatus(err) === 401) {
+        // Retries exhausted (or none were warranted) - not something resubmitting can fix.
+        setError(message);
+        await forceSessionExpiredRedirect();
+        setIsSubmitting(false);
+        return;
+      }
+
+      // Unrelated to the session (5xx, validation, network) - just show it, retryable indefinitely.
+      setError(message);
+      setIsSubmitting(false);
+    }
   };
 
   return (

--- a/apps/client/app/routes/accept-policies.tsx
+++ b/apps/client/app/routes/accept-policies.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearch, useRouter } from '@tanstack/react-router';
 import { Box, Button, Checkbox, Container, Sheet, Stack, Typography, Link } from '@mui/joy';
 import GppGoodIcon from '@mui/icons-material/GppGood';
@@ -6,10 +6,20 @@ import Image from 'next/image';
 
 import { useUser } from '@client/app/contexts/UserContext';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
-import { api } from '@client/app/contexts/ApiContext';
+import { api, forceSessionExpiredRedirect, getAxiosErrorStatus } from '@client/app/contexts/ApiContext';
+import { useGetIdentify } from '@client/app/hooks/data/user';
 import useGetLogo from '@client/app/hooks/useGetLogo';
 import { ExternalLinks, CHECKBOX_LABEL_LINK_SX } from '@client/app/utils/externalLinks';
 import { applyRedirect } from '@client/app/utils/authRedirect';
+
+// A second consecutive 401 on submit here means the session couldn't be recovered
+// even after ApiContext's own refresh retry - most likely a sustained transient
+// refresh-endpoint outage (a confirmed 401/400 rejection already redirects via the
+// interceptor itself before this catch runs). Don't leave the user resubmitting into
+// a dead session forever; fall back to the same teardown used for any other
+// unrecoverable 401. Only a 401 counts toward this - an unrelated failure (5xx,
+// validation, network) says nothing about the session and should just be retryable.
+const MAX_SUBMIT_ATTEMPTS = 2;
 
 /**
  * P0-B abuse gate interstitial. Shown to any authenticated account that has not yet
@@ -24,17 +34,30 @@ const AcceptPoliciesPage = () => {
   const router = useRouter();
   const search = useSearch({ strict: false });
   const { currentUser, setCurrentUser } = useUser();
-  const { accessToken } = useAccessToken();
+  const { accessToken, mfaPending } = useAccessToken();
+  const identity = useGetIdentify();
   const logoUrl = useGetLogo();
 
   const [acceptPolicies, setAcceptPolicies] = useState(false);
   const [confirmAdult, setConfirmAdult] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const submitAttemptsRef = useRef(0);
 
   const redirectTo = (search as { redirectTo?: string }).redirectTo;
 
-  // Guard the guard: no token -> login; already-accepted user -> don't trap them on this page.
+  // True when identify came back with a confirmed 401 (a stale token whose refresh attempt
+  // itself failed, per ApiContext's transient-vs-confirmed distinction) - this page then has no
+  // server-confirmed user to render off. Excludes mfaPending, which both ApiContext's interceptor
+  // and UserContext's bootstrap effect also exempt: during mfaPending no refresh token is issued
+  // by design, so a 401 here is expected, not a dead session. Also excludes anything other than a
+  // confirmed 401 (5xx, network, an unrelated background-refetch blip on an otherwise-valid
+  // session) - those say nothing about this session being unrecoverable.
+  const sessionUnverified = identity.isError && !mfaPending && getAxiosErrorStatus(identity.error) === 401;
+
+  // Guard the guard: no token -> login; already-accepted user -> don't trap them on this page;
+  // unverifiable session -> tear down the same way any other unrecoverable 401 does instead of
+  // stranding the user on an interstitial their session can't back.
   useEffect(() => {
     if (!accessToken) {
       navigate({ to: '/login', replace: true });
@@ -42,8 +65,12 @@ const AcceptPoliciesPage = () => {
     }
     if (currentUser?.aupAcceptedVersion) {
       applyRedirect(router.history, redirectTo, '/', true);
+      return;
     }
-  }, [accessToken, currentUser, navigate, redirectTo, router]);
+    if (sessionUnverified) {
+      void forceSessionExpiredRedirect();
+    }
+  }, [accessToken, currentUser, sessionUnverified, navigate, redirectTo, router]);
 
   const isFormValid = acceptPolicies && confirmAdult;
 
@@ -55,6 +82,7 @@ const AcceptPoliciesPage = () => {
     setIsSubmitting(true);
     try {
       const response = await api.post('/api/user/accept-policies', { ageAttestation: true });
+      submitAttemptsRef.current = 0;
       // Update currentUser so the consent gate clears (both the server field and this client state).
       setCurrentUser(response.data.user);
       applyRedirect(router.history, redirectTo, '/', true);
@@ -64,6 +92,19 @@ const AcceptPoliciesPage = () => {
         (err as Error).message ||
         'Failed to record acceptance';
       setError(message);
+
+      // Only a confirmed 401 says anything about the session; an unrelated failure (5xx,
+      // validation, network) is retryable indefinitely and should never count toward teardown.
+      if (mfaPending || getAxiosErrorStatus(err) !== 401) {
+        submitAttemptsRef.current = 0;
+        setIsSubmitting(false);
+        return;
+      }
+
+      submitAttemptsRef.current += 1;
+      if (submitAttemptsRef.current >= MAX_SUBMIT_ATTEMPTS) {
+        await forceSessionExpiredRedirect();
+      }
       setIsSubmitting(false);
     }
   };
@@ -120,7 +161,7 @@ const AcceptPoliciesPage = () => {
                   data-testid="accept-policies-checkbox"
                   checked={acceptPolicies}
                   onChange={e => setAcceptPolicies(e.target.checked)}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || sessionUnverified}
                   label={
                     <Typography sx={{ fontSize: '14px' }}>
                       I agree to the{' '}
@@ -157,7 +198,7 @@ const AcceptPoliciesPage = () => {
                   data-testid="accept-age-checkbox"
                   checked={confirmAdult}
                   onChange={e => setConfirmAdult(e.target.checked)}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || sessionUnverified}
                   label={<Typography sx={{ fontSize: '14px' }}>I confirm I am 18 years of age or older</Typography>}
                 />
               </Stack>
@@ -167,7 +208,7 @@ const AcceptPoliciesPage = () => {
                 color="primary"
                 variant="solid"
                 loading={isSubmitting}
-                disabled={!isFormValid || isSubmitting}
+                disabled={!isFormValid || isSubmitting || sessionUnverified}
                 fullWidth
                 size="lg"
                 data-testid="accept-policies-submit-btn"

--- a/apps/client/app/routes/accept-policies.tsx
+++ b/apps/client/app/routes/accept-policies.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearch, useRouter } from '@tanstack/react-router';
 import { Box, Button, Checkbox, Container, Sheet, Stack, Typography, Link } from '@mui/joy';
 import GppGoodIcon from '@mui/icons-material/GppGood';
@@ -6,20 +6,25 @@ import Image from 'next/image';
 
 import { useUser } from '@client/app/contexts/UserContext';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
-import { api, forceSessionExpiredRedirect, getAxiosErrorStatus } from '@client/app/contexts/ApiContext';
+import {
+  api,
+  forceSessionExpiredRedirect,
+  getAxiosErrorStatus,
+  getAxiosRetryCount,
+} from '@client/app/contexts/ApiContext';
 import { useGetIdentify } from '@client/app/hooks/data/user';
 import useGetLogo from '@client/app/hooks/useGetLogo';
 import { ExternalLinks, CHECKBOX_LABEL_LINK_SX } from '@client/app/utils/externalLinks';
 import { applyRedirect } from '@client/app/utils/authRedirect';
 
-// A second consecutive 401 on submit here means the session couldn't be recovered
-// even after ApiContext's own refresh retry - most likely a sustained transient
-// refresh-endpoint outage (a confirmed 401/400 rejection already redirects via the
-// interceptor itself before this catch runs). Don't leave the user resubmitting into
-// a dead session forever; fall back to the same teardown used for any other
-// unrecoverable 401. Only a 401 counts toward this - an unrelated failure (5xx,
-// validation, network) says nothing about the session and should just be retryable.
-const MAX_SUBMIT_ATTEMPTS = 2;
+// A 401 reaching handleSubmit's catch has already passed through ApiContext's own
+// refresh-retry interceptor once (it attempts a refresh on every 401 before rejecting) - a
+// confirmed 400/401 refresh rejection already redirects via the interceptor itself before
+// this catch ever runs. So a 401 here means either the refresh attempt itself failed (a
+// transient outage, retryCount still 0 - worth one backoff retry, since it may have already
+// cleared) or the refresh succeeded and the retried request 401'd anyway (retryCount >= 1 -
+// genuinely unrecoverable, not something a resubmit can fix). See getAxiosRetryCount.
+const SUBMIT_RETRY_DELAY_MS = 1000;
 
 /**
  * P0-B abuse gate interstitial. Shown to any authenticated account that has not yet
@@ -42,7 +47,6 @@ const AcceptPoliciesPage = () => {
   const [confirmAdult, setConfirmAdult] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const submitAttemptsRef = useRef(0);
 
   const redirectTo = (search as { redirectTo?: string }).redirectTo;
 
@@ -74,39 +78,49 @@ const AcceptPoliciesPage = () => {
 
   const isFormValid = acceptPolicies && confirmAdult;
 
+  // allowRetry is true only for the user-initiated attempt, so the one automatic backoff
+  // retry below can't itself trigger a further retry.
+  const submitPolicyAcceptance = async (allowRetry: boolean): Promise<void> => {
+    try {
+      const response = await api.post('/api/user/accept-policies', { ageAttestation: true });
+      // Update currentUser so the consent gate clears (both the server field and this client state).
+      setCurrentUser(response.data.user);
+      applyRedirect(router.history, redirectTo, '/', true);
+    } catch (err: unknown) {
+      if (!mfaPending && getAxiosErrorStatus(err) === 401) {
+        // First attempt at a transient (not-yet-retried) 401: give the refresh endpoint a
+        // moment to recover and retry once automatically, rather than dead-ending on an error
+        // or immediately signing the user out over a passing blip.
+        if (allowRetry && getAxiosRetryCount(err) === 0) {
+          await new Promise(resolve => setTimeout(resolve, SUBMIT_RETRY_DELAY_MS));
+          await submitPolicyAcceptance(false);
+          return;
+        }
+        // Either the backoff retry also 401'd, or the interceptor already completed its own
+        // refresh-succeeded-then-retried cycle and still got 401 - not something resubmitting
+        // can fix.
+        await forceSessionExpiredRedirect();
+        setIsSubmitting(false);
+        return;
+      }
+
+      // Unrelated to the session (5xx, validation, network) - just show it, retryable indefinitely.
+      const message =
+        (err as { response?: { data?: { error?: string } }; message?: string }).response?.data?.error ||
+        (err as Error).message ||
+        'Failed to record acceptance';
+      setError(message);
+      setIsSubmitting(false);
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isFormValid || isSubmitting) return;
 
     setError(null);
     setIsSubmitting(true);
-    try {
-      const response = await api.post('/api/user/accept-policies', { ageAttestation: true });
-      submitAttemptsRef.current = 0;
-      // Update currentUser so the consent gate clears (both the server field and this client state).
-      setCurrentUser(response.data.user);
-      applyRedirect(router.history, redirectTo, '/', true);
-    } catch (err: unknown) {
-      const message =
-        (err as { response?: { data?: { error?: string } }; message?: string }).response?.data?.error ||
-        (err as Error).message ||
-        'Failed to record acceptance';
-      setError(message);
-
-      // Only a confirmed 401 says anything about the session; an unrelated failure (5xx,
-      // validation, network) is retryable indefinitely and should never count toward teardown.
-      if (mfaPending || getAxiosErrorStatus(err) !== 401) {
-        submitAttemptsRef.current = 0;
-        setIsSubmitting(false);
-        return;
-      }
-
-      submitAttemptsRef.current += 1;
-      if (submitAttemptsRef.current >= MAX_SUBMIT_ATTEMPTS) {
-        await forceSessionExpiredRedirect();
-      }
-      setIsSubmitting(false);
-    }
+    await submitPolicyAcceptance(true);
   };
 
   return (
@@ -133,7 +147,7 @@ const AcceptPoliciesPage = () => {
 
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.5 }}>
                 <GppGoodIcon sx={{ fontSize: 32, color: 'primary.500' }} />
-                <Typography level="h3">Before you continue</Typography>
+                <Typography level="h3">Before you continue!</Typography>
               </Box>
 
               <Typography level="body-md" sx={{ color: 'text.secondary', textAlign: 'center' }}>

--- a/apps/client/app/routes/accept-policies.tsx
+++ b/apps/client/app/routes/accept-policies.tsx
@@ -147,7 +147,7 @@ const AcceptPoliciesPage = () => {
 
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.5 }}>
                 <GppGoodIcon sx={{ fontSize: 32, color: 'primary.500' }} />
-                <Typography level="h3">Before you continue!</Typography>
+                <Typography level="h3">Before you continue</Typography>
               </Box>
 
               <Typography level="body-md" sx={{ color: 'text.secondary', textAlign: 'center' }}>


### PR DESCRIPTION
## Description

Closes #337 

A user could get permanently stranded on the `/accept-policies` consent interstitial (the "Before you continue" AUP/ToS/age-attestation screen shown to brand-new OAuth/SAML/OTC users) when their session couldn't be verified:

- If the bootstrap `/api/identify` call or the consent-submit call hit a `401` whose token refresh then failed, the page had no way to recover. The submit form showed a raw "Unauthorized" error and let the user resubmit forever, with no redirect back to login.
- `ApiContext.tsx`'s response interceptor already has logic to distinguish a **confirmed** unrecoverable session (refresh itself rejected with 400/401 - session dead, sign out) from a **transient** one (refresh endpoint 5xx/timeout/network error - e.g. a cold Lambda right after a deploy - don't punish the user for a blip). `/accept-policies` didn't have access to that distinction and could either strand the user (no recovery path) or, in an earlier iteration of this fix, over-correct and sign out a user whose session was actually fine.

This PR gives `/accept-policies` a path back to a working state in both failure modes, using the same signals `ApiContext`'s interceptor already tracks internally.

## Changes

- **`ApiContext.tsx`**: exported the previously-private `forceSessionExpiredRedirect()` teardown (clears tokens, wipes caches, hard-redirects to `/login`) so other call sites can reuse it instead of re-implementing sign-out. Added two small helpers, `getAxiosErrorStatus()` and `getAxiosRetryCount()`, so callers outside the interceptor can apply the same "confirmed vs. transient" classification the interceptor itself uses (`getAxiosRetryCount` reads the interceptor's own `_retryCount` bookkeeping - it's `>= 1` only once a refresh has actually succeeded and the retried request still got a 401).
- **`accept-policies.tsx`**:
  - The bootstrap-identify check now tears the session down only when identify fails with a **confirmed, already-retried** 401 (`getAxiosRetryCount >= 1`) and the user isn't mid-MFA-setup (`mfaPending` is exempted, matching the interceptor's own exemption - MFA setup issues no refresh token by design). A first-attempt 401 alone no longer forces a sign-out.
  - The form (checkboxes + submit button) disables itself while the session is in this unverified state, so a stray click can't fire a request against a session already being torn down.
  - The consent-submit flow now retries a first-attempt 401 once automatically (via the existing `withRetry()` helper from `@bike4mind/common`, already used elsewhere in the app for this exact retry-with-backoff shape) before giving up and signing out - so a passing blip on the user's very first interaction with the product doesn't immediately bounce them to `/login`. The retry is tied to a component-unmount abort signal, and `mfaPending` is re-read live rather than captured at submit time, since the retry can run up to ~1s after the original click.
  - The real server error message is now shown before the session is torn down, instead of being silently dropped.
- **`accept-policies.test.tsx`**: expanded coverage for the confirmed-vs-transient distinction on both the identify and submit paths, the mfaPending exemption, the auto-retry-then-recover and auto-retry-then-teardown cases, and the form-disabled state.

## Guide for Testers

1. On this PR's preview env (`pr<N>.preview.bike4mind.com`, linked in a bot comment on this PR once a maintainer triggers it - see CONTRIBUTING.md → "Preview deploys"), sign up as a **brand-new user via OAuth/SAML SSO** (not password/OTC registration, which already records acceptance at registration - see Regression Check 5 below), so the account has not yet accepted the AUP/ToS. Expected: you land on `/accept-policies` and see the "Before you continue" consent form.
2. Confirm a genuinely dead session still redirects to login cleanly: open DevTools Console and invalidate **both** stored tokens so the refresh itself is confirmed-rejected, not just blocked:

   ```js
   const raw = JSON.parse(localStorage.getItem('access-token-storage'));
   raw.state.accessToken = raw.state.accessToken.slice(0, -10) + 'deadbeef12';
   raw.state.refreshToken = raw.state.refreshToken.slice(0, -10) + 'deadbeef12';
   localStorage.setItem('access-token-storage', JSON.stringify(raw));
   ```

   Hard-reload (Cmd/Ctrl+Shift+R). Expected: within a couple of seconds you're redirected to `/login` with a "session expired" message - not left sitting on the interstitial. Log back in with the same account. Expected: since it still hasn't consented, you're routed straight back to `/accept-policies`.
   
   
<img width="1798" height="1422" alt="image" src="https://github.com/user-attachments/assets/fdc5c969-9876-4fce-9f97-4a353a6c05e2" />

3. Reproduce the original stranding bug end to end: in DevTools Console, invalidate only the access token (leaving the refresh token intact):

   ```js
   const raw = JSON.parse(localStorage.getItem('access-token-storage'));
   raw.state.accessToken = raw.state.accessToken.slice(0, -10) + 'deadbeef12';
   localStorage.setItem('access-token-storage', JSON.stringify(raw));
   ```

   In the Network tab, add a **Block request URL** rule for `**/api/auth/refreshToken`. Hard-reload (Cmd/Ctrl+Shift+R). Expected: the reload alone does **not** force a redirect - the form stays visible and interactive (this is intentional: a single blocked background refresh looks identical to a transient blip, so it's not treated as a confirmed-dead session on its own). Now check both checkboxes and click **Accept and continue**. Expected: within a couple of seconds you're cleanly signed out to `/login` with a "session expired" message - not left resubmitting into a raw "Unauthorized" error forever. Remove the block rule and log back in again.
4. Check both checkboxes ("I agree to the Terms of Service..." and "I confirm I am 18 years of age or older") and click **Accept and continue**. Expected: the form submits successfully and you land on the app's home page with the consent interstitial no longer appearing on future visits.

### What NOT to test

This PR does not change the server-side consent-gate enforcement (`apps/client/server/auth/auth.ts`) or the `/api/user/accept-policies` endpoint itself - only the client-side recovery behavior around session verification on this one page.

## Additional Information

This fix is intentionally scoped to `/accept-policies` only. The same underlying ambiguity (an identify failure being treated as fully confirmed regardless of whether the refresh failure was transient or permanent) exists more broadly in `UserContext.tsx`'s bootstrap identify effect, which every other authenticated route also depends on - that's a separate, larger piece of follow-up work and out of scope here.

## Developer Notes

- `getAxiosErrorStatus()` and `getAxiosRetryCount()` (`ApiContext.tsx`) are now available for any component that needs to react to a request failure with the same confirmed-vs-transient nuance the auth interceptor applies internally, without re-deriving it.
- `forceSessionExpiredRedirect()` is now a public export - any component with its own signal for "this session cannot be verified" can trigger the same clean sign-out path instead of building a bespoke one.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
