### PR TITLE
fix(scripts): derive a descriptive changelog fallback title from commits

### DIFF
--- a/packages/scripts/src/generateChangelog.test.ts
+++ b/packages/scripts/src/generateChangelog.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildFallbackTitle } from './generateChangelog';
+
+describe('buildFallbackTitle', () => {
+  it('uses the single change as the title, capitalized', () => {
+    expect(
+      buildFallbackTitle([{ type: 'features', items: ['add settlement view to admin usage-margin endpoint'] }])
+    ).toBe('Add settlement view to admin usage-margin endpoint');
+  });
+
+  it('summarizes multiple changes across sections by count', () => {
+    expect(
+      buildFallbackTitle([
+        { type: 'features', items: ['a', 'b', 'c'] },
+        { type: 'fixes', items: ['x', 'y'] },
+      ])
+    ).toBe('3 features and 2 fixes');
+  });
+
+  it('uses singular nouns for single-item sections in a multi-section summary', () => {
+    expect(
+      buildFallbackTitle([
+        { type: 'features', items: ['a'] },
+        { type: 'fixes', items: ['x'] },
+      ])
+    ).toBe('1 feature and 1 fix');
+  });
+
+  it('oxford-joins three or more sections', () => {
+    expect(
+      buildFallbackTitle([
+        { type: 'features', items: ['a', 'b'] },
+        { type: 'fixes', items: ['x'] },
+        { type: 'performance', items: ['p', 'q'] },
+      ])
+    ).toBe('2 features, 1 fix, and 2 performance improvements');
+  });
+
+  it('ignores empty sections when counting', () => {
+    expect(
+      buildFallbackTitle([
+        { type: 'features', items: [] },
+        { type: 'fixes', items: ['only one'] },
+      ])
+    ).toBe('Only one');
+  });
+
+  it('degrades to a generic title only when nothing is categorized', () => {
+    expect(buildFallbackTitle([])).toBe('Production Release');
+    expect(buildFallbackTitle([{ type: 'internal', items: [] }])).toBe('Production Release');
+  });
+});

--- a/packages/scripts/src/generateChangelog.ts
+++ b/packages/scripts/src/generateChangelog.ts
@@ -271,6 +271,45 @@ Return ONLY a valid JSON object in this exact format (no markdown, no code block
 }`;
 }
 
+const SECTION_NOUNS: Record<ChangelogSection['type'], [singular: string, plural: string]> = {
+  features: ['feature', 'features'],
+  fixes: ['fix', 'fixes'],
+  performance: ['performance improvement', 'performance improvements'],
+  internal: ['internal change', 'internal changes'],
+  hotfix: ['hotfix', 'hotfixes'],
+};
+
+function capitalizeFirst(text: string): string {
+  return text.length ? text[0].toUpperCase() + text.slice(1) : text;
+}
+
+function joinWithAnd(parts: string[]): string {
+  if (parts.length <= 1) return parts.join('');
+  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
+  return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]}`;
+}
+
+/**
+ * Build a descriptive release title from parsed sections, for when the AI
+ * generator is unavailable. A single change becomes its own subject (e.g.
+ * "Add settlement view to admin usage-margin endpoint"); multiple changes become
+ * a count summary ("3 features and 2 fixes"). Only degrades to the generic
+ * "Production Release" when nothing categorizable is left. Exported for testing.
+ */
+export function buildFallbackTitle(sections: ChangelogSection[]): string {
+  const withItems = sections.filter(s => s.items.length > 0);
+  const total = withItems.reduce((n, s) => n + s.items.length, 0);
+
+  if (total === 0) return 'Production Release';
+  if (total === 1) return capitalizeFirst(withItems.flatMap(s => s.items)[0]);
+
+  const parts = withItems.map(s => {
+    const [singular, plural] = SECTION_NOUNS[s.type];
+    return `${s.items.length} ${s.items.length === 1 ? singular : plural}`;
+  });
+  return capitalizeFirst(joinWithAnd(parts));
+}
+
 /**
  * Generate fallback changelog if AI fails
  */
@@ -306,7 +345,7 @@ function generateFallbackChangelog(commits: GitHubCommit[], prNumbers: number[])
   }
 
   return {
-    title: 'Production Release',
+    title: buildFallbackTitle(sections),
     sections,
     briefSummary: briefSummary.slice(0, 5),
     metadata: {


### PR DESCRIPTION
## Problem

When the AI changelog generator falls back to conventional-commit parsing (AI unavailable, a parse error, or an invalid response shape), the GitHub Release title was hardcoded to the generic "Production Release", even though the release body was fully populated from the commits. A recent production release shipped titled "Production Release" for exactly this reason.

## Fix

`generateFallbackChangelog` now builds a title from the parsed sections instead of a constant:

- A single categorized change uses that change as the title, capitalized (e.g. "Add settlement view to admin usage-margin endpoint").
- Multiple changes become a count summary (e.g. "3 features and 2 fixes", oxford-joined for 3+ sections).
- It only degrades to the generic "Production Release" when there is nothing categorizable to summarize.

The AI-generated title remains the primary path and is unchanged; this only improves the fallback so a title always carries signal.

## Tests

Added `buildFallbackTitle` (extracted + exported) with unit coverage for the single-change, multi-section count, singular/plural, oxford-join, empty-section, and fully-generic cases. `pnpm --filter @bike4mind/scripts test` and `typecheck` pass.
