### PR TITLE
feat(admin): model pricing catalog manager

### DIFF
--- a/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.test.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.test.tsx
@@ -51,14 +51,14 @@ describe('ModelPricingCatalog', () => {
 
   it('renders in-force rows with seed/operator source chips', async () => {
     renderCatalog();
-    expect(await screen.findByTestId('model-pricing-row-gpt-x')).toBeInTheDocument();
-    expect(screen.getByTestId('model-pricing-source-gpt-x')).toHaveTextContent('seed');
-    expect(screen.getByTestId('model-pricing-source-gpt-y')).toHaveTextContent('operator');
+    expect(await screen.findByTestId('model-pricing-row-gpt-x-per_token')).toBeInTheDocument();
+    expect(screen.getByTestId('model-pricing-source-gpt-x-per_token')).toHaveTextContent('seed');
+    expect(screen.getByTestId('model-pricing-source-gpt-y-per_token')).toHaveTextContent('operator');
   });
 
   it('reprice requires a note before saving, then posts the new rates', async () => {
     renderCatalog();
-    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-x'));
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-x-per_token'));
 
     const save = screen.getByTestId('reprice-save-btn');
     expect(save).toHaveAttribute('disabled');
@@ -80,14 +80,90 @@ describe('ModelPricingCatalog', () => {
 
   it('revert-to-seed is offered only on operator rows and posts the action after confirm', async () => {
     renderCatalog();
-    await screen.findByTestId('model-pricing-row-gpt-x');
-    expect(screen.queryByTestId('model-pricing-revert-gpt-x')).toBeNull();
+    await screen.findByTestId('model-pricing-row-gpt-x-per_token');
+    expect(screen.queryByTestId('model-pricing-revert-gpt-x-per_token')).toBeNull();
 
-    fireEvent.click(screen.getByTestId('model-pricing-revert-gpt-y'));
+    fireEvent.click(screen.getByTestId('model-pricing-revert-gpt-y-per_token'));
     fireEvent.click(screen.getByTestId('revert-confirm-btn'));
 
     await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
     expect(mockPost.mock.calls[0][1]).toMatchObject({ modelId: 'gpt-y', action: 'revert-to-seed' });
+  });
+
+  it('formats non-token units at face value with a unit label (a per-minute rate must not be inflated x1M)', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        rows: [
+          ...ROWS,
+          {
+            modelId: 'voice-conversational',
+            unit: 'per_minute',
+            pricing: { '0': { input: 0.06, output: 0 } },
+            effectiveFrom: '2026-07-01T00:00:00.000Z',
+            note: 'adapter-seed',
+          },
+        ],
+      },
+    });
+    renderCatalog();
+    const row = await screen.findByTestId('model-pricing-row-voice-conversational-per_minute');
+    expect(row).toHaveTextContent('$0.06');
+    expect(row).not.toHaveTextContent('60,000');
+    expect(row).toHaveTextContent('per minute');
+  });
+
+  it('surfaces the server validation message inside the open reprice modal on failure', async () => {
+    mockPost.mockRejectedValue({
+      message: 'Request failed with status code 400',
+      response: { data: { message: "note 'adapter-seed' is reserved for seed provenance" } },
+    });
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-x-per_token'));
+    fireEvent.change(screen.getByTestId('reprice-note-input'), { target: { value: 'adapter-seed' } });
+    fireEvent.click(screen.getByTestId('reprice-save-btn'));
+
+    const alert = await screen.findByTestId('reprice-modal-error');
+    expect(alert).toHaveTextContent('reserved for seed provenance');
+  });
+
+  it('ignores a stale history response when a newer model was opened (no cross-model audit mixups)', async () => {
+    renderCatalog();
+    await screen.findByTestId('model-pricing-row-gpt-x-per_token');
+
+    let resolveSlow: (v: unknown) => void = () => {};
+    const slow = new Promise(resolve => (resolveSlow = resolve));
+    mockGet.mockReturnValueOnce(slow); // gpt-x history: slow
+    fireEvent.click(screen.getByTestId('model-pricing-history-gpt-x-per_token'));
+
+    mockGet.mockResolvedValueOnce({
+      data: {
+        history: [
+          {
+            modelId: 'gpt-y',
+            pricing: { '0': { input: 9e-6, output: 27e-6 } },
+            effectiveFrom: '2026-07-05T00:00:00.000Z',
+            note: 'manual reprice per invoice',
+          },
+        ],
+      },
+    });
+    fireEvent.click(screen.getByTestId('model-pricing-history-gpt-y-per_token'));
+    await screen.findAllByTestId('history-row');
+
+    resolveSlow({
+      data: {
+        history: [
+          {
+            modelId: 'gpt-x',
+            pricing: { '0': { input: 1e-6, output: 2e-6 } },
+            effectiveFrom: '2026-06-01T00:00:00.000Z',
+            note: 'stale gpt-x row',
+          },
+        ],
+      },
+    });
+    await waitFor(() => expect(screen.getByTestId('history-drawer')).toHaveTextContent('gpt-y'));
+    expect(screen.getByTestId('history-drawer')).not.toHaveTextContent('stale gpt-x row');
   });
 
   it('history drawer fetches and lists the audit trail for one model', async () => {
@@ -110,7 +186,7 @@ describe('ModelPricingCatalog', () => {
         ],
       },
     });
-    fireEvent.click(await screen.findByTestId('model-pricing-history-gpt-y'));
+    fireEvent.click(await screen.findByTestId('model-pricing-history-gpt-y-per_token'));
 
     await waitFor(() => expect(mockGet).toHaveBeenCalledWith('/api/admin/model-prices?history=gpt-y'));
     expect(await screen.findByTestId('history-drawer')).toBeInTheDocument();

--- a/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.test.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: (...a: unknown[]) => mockGet(...a), post: (...a: unknown[]) => mockPost(...a) },
+}));
+
+import { ModelPricingCatalog } from './ModelPricingCatalog';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const ROWS = [
+  {
+    modelId: 'gpt-x',
+    unit: 'per_token',
+    pricing: { '0': { input: 4e-6, output: 16e-6 } },
+    effectiveFrom: '2026-07-01T00:00:00.000Z',
+    note: 'adapter-seed',
+  },
+  {
+    modelId: 'gpt-y',
+    unit: 'per_token',
+    pricing: { '0': { input: 9e-6, output: 27e-6 } },
+    effectiveFrom: '2026-07-05T00:00:00.000Z',
+    note: 'manual reprice per invoice',
+  },
+];
+
+function renderCatalog() {
+  return render(
+    <TestWrapper>
+      <ModelPricingCatalog />
+    </TestWrapper>
+  );
+}
+
+describe('ModelPricingCatalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ data: { rows: ROWS } });
+    mockPost.mockResolvedValue({ data: { row: {} } });
+  });
+
+  it('renders in-force rows with seed/operator source chips', async () => {
+    renderCatalog();
+    expect(await screen.findByTestId('model-pricing-row-gpt-x')).toBeInTheDocument();
+    expect(screen.getByTestId('model-pricing-source-gpt-x')).toHaveTextContent('seed');
+    expect(screen.getByTestId('model-pricing-source-gpt-y')).toHaveTextContent('operator');
+  });
+
+  it('reprice requires a note before saving, then posts the new rates', async () => {
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-x'));
+
+    const save = screen.getByTestId('reprice-save-btn');
+    expect(save).toHaveAttribute('disabled');
+    expect(mockPost).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '0.000005' } });
+    fireEvent.change(screen.getByTestId('reprice-note-input'), { target: { value: 'openai price page 2026-07' } });
+    fireEvent.click(screen.getByTestId('reprice-save-btn'));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    const [url, body] = mockPost.mock.calls[0] as [string, Record<string, unknown>];
+    expect(url).toBe('/api/admin/model-prices');
+    expect(body).toMatchObject({
+      modelId: 'gpt-x',
+      note: 'openai price page 2026-07',
+      pricing: { '0': { input: 0.000005, output: 16e-6 } },
+    });
+  });
+
+  it('revert-to-seed is offered only on operator rows and posts the action after confirm', async () => {
+    renderCatalog();
+    await screen.findByTestId('model-pricing-row-gpt-x');
+    expect(screen.queryByTestId('model-pricing-revert-gpt-x')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('model-pricing-revert-gpt-y'));
+    fireEvent.click(screen.getByTestId('revert-confirm-btn'));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    expect(mockPost.mock.calls[0][1]).toMatchObject({ modelId: 'gpt-y', action: 'revert-to-seed' });
+  });
+
+  it('history drawer fetches and lists the audit trail for one model', async () => {
+    renderCatalog();
+    mockGet.mockResolvedValueOnce({
+      data: {
+        history: [
+          {
+            modelId: 'gpt-y',
+            pricing: { '0': { input: 9e-6, output: 27e-6 } },
+            effectiveFrom: '2026-07-05T00:00:00.000Z',
+            note: 'manual reprice per invoice',
+          },
+          {
+            modelId: 'gpt-y',
+            pricing: { '0': { input: 8e-6, output: 24e-6 } },
+            effectiveFrom: '2026-07-01T00:00:00.000Z',
+            note: 'adapter-seed',
+          },
+        ],
+      },
+    });
+    fireEvent.click(await screen.findByTestId('model-pricing-history-gpt-y'));
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith('/api/admin/model-prices?history=gpt-y'));
+    expect(await screen.findByTestId('history-drawer')).toBeInTheDocument();
+    expect(screen.getAllByTestId('history-row')).toHaveLength(2);
+  });
+});

--- a/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.tsx
@@ -1,0 +1,411 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Drawer,
+  FormControl,
+  FormLabel,
+  IconButton,
+  Input,
+  Modal,
+  ModalDialog,
+  Sheet,
+  Stack,
+  Table,
+  Textarea,
+  Typography,
+} from '@mui/joy';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import EditIcon from '@mui/icons-material/Edit';
+import HistoryIcon from '@mui/icons-material/History';
+import ReplayIcon from '@mui/icons-material/Replay';
+import { api } from '@client/app/contexts/ApiContext';
+
+/** Wire shape of one pricing tier (mirrors ModelPriceTier in common, which
+ * gains optional audio fields in the realtime-voice catalog PR). */
+interface PriceTier {
+  input: number;
+  output: number;
+  cache_read?: number;
+  cache_write?: number;
+  audio_input?: number;
+  audio_cache_read?: number;
+  audio_output?: number;
+}
+
+/** Wire shape of a catalog row (dates arrive as ISO strings). */
+interface PriceRow {
+  modelId: string;
+  unit: string;
+  pricing: Record<string, PriceTier>;
+  effectiveFrom: string;
+  note?: string;
+}
+
+const SEED_NOTE = 'adapter-seed';
+const isSeedRow = (row: PriceRow) => row.note === SEED_NOTE;
+
+/** Every rate field a tier can carry, in display order. */
+const RATE_FIELDS = [
+  'input',
+  'output',
+  'cache_read',
+  'cache_write',
+  'audio_input',
+  'audio_cache_read',
+  'audio_output',
+] as const;
+type RateField = (typeof RATE_FIELDS)[number];
+const RATE_LABELS: Record<RateField, string> = {
+  input: 'Input',
+  output: 'Output',
+  cache_read: 'Cache read',
+  cache_write: 'Cache write',
+  audio_input: 'Audio in',
+  audio_cache_read: 'Audio cache',
+  audio_output: 'Audio out',
+};
+
+const perMillion = (usdPerToken: number | undefined) =>
+  usdPerToken === undefined
+    ? '-'
+    : `$${(usdPerToken * 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
+
+const numberCell = { fontVariantNumeric: 'tabular-nums' } as const;
+
+/**
+ * Admin manager for the versioned model price catalog. Rates are provider
+ * cost beliefs in USD (shown per 1M tokens); what users pay is always this
+ * cost times the published uniform markup, so nothing here touches markup.
+ * All writes are append-only rows via /api/admin/model-prices.
+ */
+export const ModelPricingCatalog: React.FC = () => {
+  const [rows, setRows] = useState<PriceRow[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [repriceTarget, setRepriceTarget] = useState<PriceRow | null>(null);
+  const [draftRates, setDraftRates] = useState<Record<string, Record<string, string>>>({});
+  const [note, setNote] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const [revertTarget, setRevertTarget] = useState<PriceRow | null>(null);
+  const [historyModel, setHistoryModel] = useState<string | null>(null);
+  const [history, setHistory] = useState<PriceRow[] | null>(null);
+
+  const fetchRows = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await api.get<{ rows: PriceRow[] }>('/api/admin/model-prices');
+      setRows([...res.data.rows].sort((a, b) => a.modelId.localeCompare(b.modelId)));
+    } catch (err) {
+      setError((err as Error)?.message || 'Failed to load the price catalog');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchRows();
+  }, [fetchRows]);
+
+  const openReprice = (row: PriceRow) => {
+    const drafts: Record<string, Record<string, string>> = {};
+    for (const [threshold, tier] of Object.entries(row.pricing)) {
+      drafts[threshold] = {};
+      for (const field of RATE_FIELDS) {
+        const value = tier[field];
+        if (value !== undefined) drafts[threshold][field] = String(value);
+      }
+    }
+    setDraftRates(drafts);
+    setNote('');
+    setRepriceTarget(row);
+  };
+
+  const submitReprice = async () => {
+    if (!repriceTarget) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      const pricing: Record<string, Record<string, number>> = {};
+      for (const [threshold, fields] of Object.entries(draftRates)) {
+        pricing[threshold] = {};
+        for (const [field, raw] of Object.entries(fields)) {
+          pricing[threshold][field] = Number(raw);
+        }
+      }
+      await api.post('/api/admin/model-prices', {
+        modelId: repriceTarget.modelId,
+        unit: repriceTarget.unit,
+        pricing,
+        note: note.trim(),
+      });
+      setRepriceTarget(null);
+      await fetchRows();
+    } catch (err) {
+      setError((err as Error)?.message || 'Reprice failed');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const submitRevert = async () => {
+    if (!revertTarget) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      await api.post('/api/admin/model-prices', {
+        modelId: revertTarget.modelId,
+        unit: revertTarget.unit,
+        action: 'revert-to-seed',
+      });
+      setRevertTarget(null);
+      await fetchRows();
+    } catch (err) {
+      setError((err as Error)?.message || 'Revert failed');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const openHistory = async (modelId: string) => {
+    setHistoryModel(modelId);
+    setHistory(null);
+    try {
+      const res = await api.get<{ history: PriceRow[] }>(
+        `/api/admin/model-prices?history=${encodeURIComponent(modelId)}`
+      );
+      setHistory(res.data.history);
+    } catch (err) {
+      setError((err as Error)?.message || 'Failed to load history');
+      setHistoryModel(null);
+    }
+  };
+
+  const draftInvalid = useMemo(
+    () =>
+      Object.values(draftRates).some(fields =>
+        Object.values(fields).some(raw => raw.trim() === '' || !Number.isFinite(Number(raw)) || Number(raw) < 0)
+      ),
+    [draftRates]
+  );
+
+  return (
+    <Box data-testid="model-pricing-catalog">
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
+        <Box>
+          <Typography level="title-md">Model pricing (provider cost, USD per 1M tokens)</Typography>
+          <Typography level="body-sm" color="neutral">
+            Users pay this cost times the published uniform markup. Changes append versioned rows; history is never
+            edited.
+          </Typography>
+        </Box>
+        <IconButton size="sm" onClick={fetchRows} disabled={isLoading} data-testid="model-pricing-refresh-btn">
+          <RefreshIcon />
+        </IconButton>
+      </Stack>
+
+      {error && (
+        <Alert color="danger" sx={{ mb: 1 }} data-testid="model-pricing-error">
+          {error}
+        </Alert>
+      )}
+
+      {isLoading && rows.length === 0 ? (
+        <CircularProgress size="sm" />
+      ) : (
+        <Sheet sx={{ maxHeight: 480, overflow: 'auto' }}>
+          <Table stickyHeader hoverRow size="sm" data-testid="model-pricing-table">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>Input</th>
+                <th>Output</th>
+                <th>Audio in</th>
+                <th>Audio out</th>
+                <th>Effective from</th>
+                <th>Source</th>
+                <th aria-label="actions" />
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(row => {
+                const tier = Object.values(row.pricing)[0] ?? { input: 0, output: 0 };
+                return (
+                  <tr key={`${row.modelId}|${row.unit}`} data-testid={`model-pricing-row-${row.modelId}`}>
+                    <td>
+                      <Typography level="body-sm">{row.modelId}</Typography>
+                      {Object.keys(row.pricing).length > 1 && (
+                        <Typography level="body-xs" color="neutral">
+                          {Object.keys(row.pricing).length} tiers
+                        </Typography>
+                      )}
+                    </td>
+                    <td style={numberCell}>{perMillion(tier.input)}</td>
+                    <td style={numberCell}>{perMillion(tier.output)}</td>
+                    <td style={numberCell}>{perMillion(tier.audio_input)}</td>
+                    <td style={numberCell}>{perMillion(tier.audio_output)}</td>
+                    <td>{new Date(row.effectiveFrom).toLocaleDateString()}</td>
+                    <td>
+                      <Chip
+                        size="sm"
+                        color={isSeedRow(row) ? 'neutral' : 'primary'}
+                        variant="soft"
+                        data-testid={`model-pricing-source-${row.modelId}`}
+                      >
+                        {isSeedRow(row) ? 'seed' : 'operator'}
+                      </Chip>
+                    </td>
+                    <td>
+                      <Stack direction="row" spacing={0.5}>
+                        <IconButton
+                          size="sm"
+                          title="Reprice"
+                          onClick={() => openReprice(row)}
+                          data-testid={`model-pricing-reprice-${row.modelId}`}
+                        >
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="sm"
+                          title="History"
+                          onClick={() => openHistory(row.modelId)}
+                          data-testid={`model-pricing-history-${row.modelId}`}
+                        >
+                          <HistoryIcon fontSize="small" />
+                        </IconButton>
+                        {!isSeedRow(row) && (
+                          <IconButton
+                            size="sm"
+                            title="Revert to seed pricing"
+                            onClick={() => setRevertTarget(row)}
+                            data-testid={`model-pricing-revert-${row.modelId}`}
+                          >
+                            <ReplayIcon fontSize="small" />
+                          </IconButton>
+                        )}
+                      </Stack>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        </Sheet>
+      )}
+
+      <Modal open={repriceTarget !== null} onClose={() => setRepriceTarget(null)}>
+        <ModalDialog sx={{ minWidth: 420 }} data-testid="reprice-modal">
+          <Typography level="title-md">Reprice {repriceTarget?.modelId}</Typography>
+          <Typography level="body-sm" color="neutral">
+            USD per token. This appends a new operator row taking effect immediately; seeding will no longer manage this
+            model until reverted.
+          </Typography>
+          <Stack spacing={1} sx={{ mt: 1 }}>
+            {Object.entries(draftRates).map(([threshold, fields]) => (
+              <Box key={threshold}>
+                {Object.keys(draftRates).length > 1 && (
+                  <Typography level="body-xs" color="neutral">
+                    Tier threshold {Number(threshold).toLocaleString()} tokens
+                  </Typography>
+                )}
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {Object.entries(fields).map(([field, raw]) => (
+                    <FormControl key={field} sx={{ width: 130 }}>
+                      <FormLabel>{RATE_LABELS[field as RateField]}</FormLabel>
+                      <Input
+                        size="sm"
+                        value={raw}
+                        onChange={e =>
+                          setDraftRates(prev => ({
+                            ...prev,
+                            [threshold]: { ...prev[threshold], [field]: e.target.value },
+                          }))
+                        }
+                        slotProps={{ input: { 'data-testid': `reprice-rate-${threshold}-${field}` } }}
+                      />
+                    </FormControl>
+                  ))}
+                </Stack>
+              </Box>
+            ))}
+            <FormControl required>
+              <FormLabel>Note (audit trail: where does this price come from?)</FormLabel>
+              <Textarea
+                minRows={2}
+                value={note}
+                onChange={e => setNote(e.target.value)}
+                slotProps={{ textarea: { 'data-testid': 'reprice-note-input' } }}
+              />
+            </FormControl>
+            <Stack direction="row" spacing={1} justifyContent="flex-end">
+              <Button variant="plain" color="neutral" onClick={() => setRepriceTarget(null)}>
+                Cancel
+              </Button>
+              <Button
+                disabled={note.trim() === '' || draftInvalid || isSaving}
+                loading={isSaving}
+                onClick={submitReprice}
+                data-testid="reprice-save-btn"
+              >
+                Append price row
+              </Button>
+            </Stack>
+          </Stack>
+        </ModalDialog>
+      </Modal>
+
+      <Modal open={revertTarget !== null} onClose={() => setRevertTarget(null)}>
+        <ModalDialog data-testid="revert-modal">
+          <Typography level="title-md">Revert {revertTarget?.modelId} to seed pricing?</Typography>
+          <Typography level="body-sm" color="neutral">
+            Appends the adapter table&apos;s current rates under the seed note, so future adapter reprices flow to this
+            model automatically again. The operator row stays in history.
+          </Typography>
+          <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ mt: 1 }}>
+            <Button variant="plain" color="neutral" onClick={() => setRevertTarget(null)}>
+              Cancel
+            </Button>
+            <Button color="warning" loading={isSaving} onClick={submitRevert} data-testid="revert-confirm-btn">
+              Revert
+            </Button>
+          </Stack>
+        </ModalDialog>
+      </Modal>
+
+      <Drawer anchor="right" open={historyModel !== null} onClose={() => setHistoryModel(null)} size="md">
+        <Box sx={{ p: 2 }} data-testid="history-drawer">
+          <Typography level="title-md" sx={{ mb: 1 }}>
+            Price history: {historyModel}
+          </Typography>
+          {history === null ? (
+            <CircularProgress size="sm" />
+          ) : (
+            <Stack spacing={1}>
+              {history.map((row, idx) => {
+                const tier = Object.values(row.pricing)[0] ?? { input: 0, output: 0 };
+                return (
+                  <Sheet key={idx} variant="soft" sx={{ p: 1, borderRadius: 'sm' }} data-testid="history-row">
+                    <Typography level="body-sm">
+                      {new Date(row.effectiveFrom).toLocaleString()} - {row.note || 'no note'}
+                    </Typography>
+                    <Typography level="body-xs" sx={numberCell}>
+                      in {perMillion(tier.input)} / out {perMillion(tier.output)}
+                      {tier.audio_input !== undefined &&
+                        ` / audio in ${perMillion(tier.audio_input)} / audio out ${perMillion(tier.audio_output)}`}
+                    </Typography>
+                  </Sheet>
+                );
+              })}
+            </Stack>
+          )}
+        </Box>
+      </Drawer>
+    </Box>
+  );
+};

--- a/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Box,
@@ -45,6 +45,8 @@ interface PriceRow {
   note?: string;
 }
 
+// Mirrors SEED_NOTE in @bike4mind/database (a server-only package; importing
+// it here would pull mongoose into the client bundle). Pinned by a test there.
 const SEED_NOTE = 'adapter-seed';
 const isSeedRow = (row: PriceRow) => row.note === SEED_NOTE;
 
@@ -69,12 +71,30 @@ const RATE_LABELS: Record<RateField, string> = {
   audio_output: 'Audio out',
 };
 
-const perMillion = (usdPerToken: number | undefined) =>
-  usdPerToken === undefined
-    ? '-'
-    : `$${(usdPerToken * 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
+const UNIT_SUFFIX: Record<string, string> = {
+  per_token: 'per 1M tokens',
+  per_minute: 'per minute',
+  per_image: 'per image',
+};
+
+// per_token rates are USD per single token and read best scaled to 1M; other
+// units are already human-scale and must NOT be inflated.
+const formatRate = (unit: string, value: number | undefined) => {
+  if (value === undefined) return '-';
+  const scaled = unit === 'per_token' ? value * 1_000_000 : value;
+  return `$${scaled.toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
+};
+
+const firstTier = (row: PriceRow): PriceTier => Object.values(row.pricing)[0] ?? { input: 0, output: 0 };
 
 const numberCell = { fontVariantNumeric: 'tabular-nums' } as const;
+
+// Axios errors carry the server's validation reason in response.data, while
+// err.message is the useless generic 'Request failed with status code 400'.
+const apiErrorMessage = (err: unknown, fallback: string) => {
+  const e = err as { response?: { data?: { message?: string } }; message?: string };
+  return e?.response?.data?.message || e?.message || fallback;
+};
 
 /**
  * Admin manager for the versioned model price catalog. Rates are provider
@@ -95,6 +115,9 @@ export const ModelPricingCatalog: React.FC = () => {
   const [revertTarget, setRevertTarget] = useState<PriceRow | null>(null);
   const [historyModel, setHistoryModel] = useState<string | null>(null);
   const [history, setHistory] = useState<PriceRow[] | null>(null);
+  // Latest requested history model; a slower earlier response must not
+  // overwrite the drawer for the model currently displayed.
+  const historyRequestRef = useRef<string | null>(null);
 
   const fetchRows = useCallback(async () => {
     setIsLoading(true);
@@ -103,7 +126,7 @@ export const ModelPricingCatalog: React.FC = () => {
       const res = await api.get<{ rows: PriceRow[] }>('/api/admin/model-prices');
       setRows([...res.data.rows].sort((a, b) => a.modelId.localeCompare(b.modelId)));
     } catch (err) {
-      setError((err as Error)?.message || 'Failed to load the price catalog');
+      setError(apiErrorMessage(err, 'Failed to load the price catalog'));
     } finally {
       setIsLoading(false);
     }
@@ -124,6 +147,7 @@ export const ModelPricingCatalog: React.FC = () => {
     }
     setDraftRates(drafts);
     setNote('');
+    setError(null);
     setRepriceTarget(row);
   };
 
@@ -148,7 +172,7 @@ export const ModelPricingCatalog: React.FC = () => {
       setRepriceTarget(null);
       await fetchRows();
     } catch (err) {
-      setError((err as Error)?.message || 'Reprice failed');
+      setError(apiErrorMessage(err, 'Reprice failed'));
     } finally {
       setIsSaving(false);
     }
@@ -167,22 +191,25 @@ export const ModelPricingCatalog: React.FC = () => {
       setRevertTarget(null);
       await fetchRows();
     } catch (err) {
-      setError((err as Error)?.message || 'Revert failed');
+      setError(apiErrorMessage(err, 'Revert failed'));
     } finally {
       setIsSaving(false);
     }
   };
 
   const openHistory = async (modelId: string) => {
+    historyRequestRef.current = modelId;
     setHistoryModel(modelId);
     setHistory(null);
     try {
       const res = await api.get<{ history: PriceRow[] }>(
         `/api/admin/model-prices?history=${encodeURIComponent(modelId)}`
       );
+      if (historyRequestRef.current !== modelId) return;
       setHistory(res.data.history);
     } catch (err) {
-      setError((err as Error)?.message || 'Failed to load history');
+      if (historyRequestRef.current !== modelId) return;
+      setError(apiErrorMessage(err, 'Failed to load history'));
       setHistoryModel(null);
     }
   };
@@ -199,7 +226,7 @@ export const ModelPricingCatalog: React.FC = () => {
     <Box data-testid="model-pricing-catalog">
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
         <Box>
-          <Typography level="title-md">Model pricing (provider cost, USD per 1M tokens)</Typography>
+          <Typography level="title-md">Model pricing (provider cost, USD; token rates shown per 1M)</Typography>
           <Typography level="body-sm" color="neutral">
             Users pay this cost times the published uniform markup. Changes append versioned rows; history is never
             edited.
@@ -224,6 +251,7 @@ export const ModelPricingCatalog: React.FC = () => {
             <thead>
               <tr>
                 <th>Model</th>
+                <th>Unit</th>
                 <th>Input</th>
                 <th>Output</th>
                 <th>Audio in</th>
@@ -235,9 +263,9 @@ export const ModelPricingCatalog: React.FC = () => {
             </thead>
             <tbody>
               {rows.map(row => {
-                const tier = Object.values(row.pricing)[0] ?? { input: 0, output: 0 };
+                const tier = firstTier(row);
                 return (
-                  <tr key={`${row.modelId}|${row.unit}`} data-testid={`model-pricing-row-${row.modelId}`}>
+                  <tr key={`${row.modelId}|${row.unit}`} data-testid={`model-pricing-row-${row.modelId}-${row.unit}`}>
                     <td>
                       <Typography level="body-sm">{row.modelId}</Typography>
                       {Object.keys(row.pricing).length > 1 && (
@@ -246,17 +274,18 @@ export const ModelPricingCatalog: React.FC = () => {
                         </Typography>
                       )}
                     </td>
-                    <td style={numberCell}>{perMillion(tier.input)}</td>
-                    <td style={numberCell}>{perMillion(tier.output)}</td>
-                    <td style={numberCell}>{perMillion(tier.audio_input)}</td>
-                    <td style={numberCell}>{perMillion(tier.audio_output)}</td>
+                    <td>{UNIT_SUFFIX[row.unit] ?? row.unit}</td>
+                    <td style={numberCell}>{formatRate(row.unit, tier.input)}</td>
+                    <td style={numberCell}>{formatRate(row.unit, tier.output)}</td>
+                    <td style={numberCell}>{formatRate(row.unit, tier.audio_input)}</td>
+                    <td style={numberCell}>{formatRate(row.unit, tier.audio_output)}</td>
                     <td>{new Date(row.effectiveFrom).toLocaleDateString()}</td>
                     <td>
                       <Chip
                         size="sm"
                         color={isSeedRow(row) ? 'neutral' : 'primary'}
                         variant="soft"
-                        data-testid={`model-pricing-source-${row.modelId}`}
+                        data-testid={`model-pricing-source-${row.modelId}-${row.unit}`}
                       >
                         {isSeedRow(row) ? 'seed' : 'operator'}
                       </Chip>
@@ -267,7 +296,7 @@ export const ModelPricingCatalog: React.FC = () => {
                           size="sm"
                           title="Reprice"
                           onClick={() => openReprice(row)}
-                          data-testid={`model-pricing-reprice-${row.modelId}`}
+                          data-testid={`model-pricing-reprice-${row.modelId}-${row.unit}`}
                         >
                           <EditIcon fontSize="small" />
                         </IconButton>
@@ -275,7 +304,7 @@ export const ModelPricingCatalog: React.FC = () => {
                           size="sm"
                           title="History"
                           onClick={() => openHistory(row.modelId)}
-                          data-testid={`model-pricing-history-${row.modelId}`}
+                          data-testid={`model-pricing-history-${row.modelId}-${row.unit}`}
                         >
                           <HistoryIcon fontSize="small" />
                         </IconButton>
@@ -284,7 +313,7 @@ export const ModelPricingCatalog: React.FC = () => {
                             size="sm"
                             title="Revert to seed pricing"
                             onClick={() => setRevertTarget(row)}
-                            data-testid={`model-pricing-revert-${row.modelId}`}
+                            data-testid={`model-pricing-revert-${row.modelId}-${row.unit}`}
                           >
                             <ReplayIcon fontSize="small" />
                           </IconButton>
@@ -302,6 +331,11 @@ export const ModelPricingCatalog: React.FC = () => {
       <Modal open={repriceTarget !== null} onClose={() => setRepriceTarget(null)}>
         <ModalDialog sx={{ minWidth: 420 }} data-testid="reprice-modal">
           <Typography level="title-md">Reprice {repriceTarget?.modelId}</Typography>
+          {error && (
+            <Alert color="danger" size="sm" data-testid="reprice-modal-error">
+              {error}
+            </Alert>
+          )}
           <Typography level="body-sm" color="neutral">
             USD per token. This appends a new operator row taking effect immediately; seeding will no longer manage this
             model until reverted.
@@ -363,6 +397,11 @@ export const ModelPricingCatalog: React.FC = () => {
       <Modal open={revertTarget !== null} onClose={() => setRevertTarget(null)}>
         <ModalDialog data-testid="revert-modal">
           <Typography level="title-md">Revert {revertTarget?.modelId} to seed pricing?</Typography>
+          {error && (
+            <Alert color="danger" size="sm" data-testid="revert-modal-error">
+              {error}
+            </Alert>
+          )}
           <Typography level="body-sm" color="neutral">
             Appends the adapter table&apos;s current rates under the seed note, so future adapter reprices flow to this
             model automatically again. The operator row stays in history.
@@ -388,16 +427,17 @@ export const ModelPricingCatalog: React.FC = () => {
           ) : (
             <Stack spacing={1}>
               {history.map((row, idx) => {
-                const tier = Object.values(row.pricing)[0] ?? { input: 0, output: 0 };
+                const tier = firstTier(row);
                 return (
                   <Sheet key={idx} variant="soft" sx={{ p: 1, borderRadius: 'sm' }} data-testid="history-row">
                     <Typography level="body-sm">
                       {new Date(row.effectiveFrom).toLocaleString()} - {row.note || 'no note'}
                     </Typography>
                     <Typography level="body-xs" sx={numberCell}>
-                      in {perMillion(tier.input)} / out {perMillion(tier.output)}
+                      in {formatRate(row.unit, tier.input)} / out {formatRate(row.unit, tier.output)}
                       {tier.audio_input !== undefined &&
-                        ` / audio in ${perMillion(tier.audio_input)} / audio out ${perMillion(tier.audio_output)}`}
+                        ` / audio in ${formatRate(row.unit, tier.audio_input)} / audio out ${formatRate(row.unit, tier.audio_output)}`}{' '}
+                      ({UNIT_SUFFIX[row.unit] ?? row.unit})
                     </Typography>
                   </Sheet>
                 );

--- a/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.tsx
@@ -22,25 +22,14 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import EditIcon from '@mui/icons-material/Edit';
 import HistoryIcon from '@mui/icons-material/History';
 import ReplayIcon from '@mui/icons-material/Replay';
+import type { IModelPriceTier } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
-
-/** Wire shape of one pricing tier (mirrors ModelPriceTier in common, which
- * gains optional audio fields in the realtime-voice catalog PR). */
-interface PriceTier {
-  input: number;
-  output: number;
-  cache_read?: number;
-  cache_write?: number;
-  audio_input?: number;
-  audio_cache_read?: number;
-  audio_output?: number;
-}
 
 /** Wire shape of a catalog row (dates arrive as ISO strings). */
 interface PriceRow {
   modelId: string;
   unit: string;
-  pricing: Record<string, PriceTier>;
+  pricing: Record<string, IModelPriceTier>;
   effectiveFrom: string;
   note?: string;
 }
@@ -85,7 +74,7 @@ const formatRate = (unit: string, value: number | undefined) => {
   return `$${scaled.toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
 };
 
-const firstTier = (row: PriceRow): PriceTier => Object.values(row.pricing)[0] ?? { input: 0, output: 0 };
+const firstTier = (row: PriceRow): IModelPriceTier => Object.values(row.pricing)[0] ?? { input: 0, output: 0 };
 
 const numberCell = { fontVariantNumeric: 'tabular-nums' } as const;
 

--- a/apps/client/app/components/admin/CreditAnalysis/index.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/index.tsx
@@ -2,7 +2,9 @@ import React, { useState } from 'react';
 import { Box, Tabs, TabList, Tab, TabPanel } from '@mui/joy';
 import PeopleIcon from '@mui/icons-material/People';
 import InsightsIcon from '@mui/icons-material/Insights';
+import PriceChangeIcon from '@mui/icons-material/PriceChange';
 import { MarginDashboard } from './components/MarginDashboard';
+import { ModelPricingCatalog } from './components/ModelPricingCatalog';
 import { UserCreditsManager } from './components/UserCreditsManager';
 import AdminProfileModal from '../AdminProfileModal';
 import ContextHelpButton from '@client/app/components/help/ContextHelpButton';
@@ -20,6 +22,12 @@ export const CreditAnalyticsTab: React.FC = () => {
               <Box sx={{ display: { xs: 'none', sm: 'inline' } }}>User Credits</Box>
             </Box>
           </Tab>
+          <Tab value="pricing" data-testid="credit-analysis-pricing-tab">
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <PriceChangeIcon sx={{ fontSize: '18px' }} />
+              <Box sx={{ display: { xs: 'none', sm: 'inline' } }}>Model Pricing</Box>
+            </Box>
+          </Tab>
           <Tab value="margins" data-testid="credit-analysis-margins-tab">
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <InsightsIcon sx={{ fontSize: '18px' }} />
@@ -31,6 +39,10 @@ export const CreditAnalyticsTab: React.FC = () => {
 
         <TabPanel value="users" sx={{ p: 0 }}>
           <UserCreditsManager />
+        </TabPanel>
+
+        <TabPanel value="pricing" sx={{ p: 0 }}>
+          <ModelPricingCatalog />
         </TabPanel>
 
         <TabPanel value="margins" sx={{ p: 0 }}>

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -851,6 +851,8 @@ Admin endpoints require the \`admin:*\` scope or superuser role.
 | GET | /api/admin/model-logs | LLM request logs |
 | GET | /api/admin/event-metrics | Event metrics |
 | GET | /api/admin/help-analytics | Help system analytics |
+| GET | /api/admin/model-prices | Model price catalog rows in force (?history=modelId for audit trail) |
+| POST | /api/admin/model-prices | Append an operator reprice or revert a model to seed pricing |
 
 ### DLQ (Dead Letter Queue) Management
 

--- a/apps/client/app/generated/help-index.json
+++ b/apps/client/app/generated/help-index.json
@@ -1030,7 +1030,7 @@
     {
       "slug": "admin/credit-analytics",
       "title": "Credit Analytics",
-      "description": "Manage user credit balances and review margin analytics for the platform",
+      "description": "Manage user credit balances, model pricing, and margin analytics for the platform",
       "category": "admin",
       "sidebarPosition": 12,
       "tags": [
@@ -1074,6 +1074,11 @@
           "level": 3,
           "text": "Pagination",
           "anchor": "pagination"
+        },
+        {
+          "level": 2,
+          "text": "Model Pricing",
+          "anchor": "model-pricing"
         },
         {
           "level": 2,
@@ -10433,7 +10438,7 @@
         {
           "slug": "admin/credit-analytics",
           "title": "Credit Analytics",
-          "description": "Manage user credit balances and review margin analytics for the platform",
+          "description": "Manage user credit balances, model pricing, and margin analytics for the platform",
           "category": "admin",
           "sidebarPosition": 12,
           "tags": [
@@ -10477,6 +10482,11 @@
               "level": 3,
               "text": "Pagination",
               "anchor": "pagination"
+            },
+            {
+              "level": 2,
+              "text": "Model Pricing",
+              "anchor": "model-pricing"
             },
             {
               "level": 2,
@@ -18815,5 +18825,5 @@
       "accessLevel": "public"
     }
   ],
-  "version": "2026-07-10T07:10:47.939Z"
+  "version": "2026-07-10T10:45:05.182Z"
 }

--- a/apps/client/pages/api/admin/__tests__/model-prices.test.ts
+++ b/apps/client/pages/api/admin/__tests__/model-prices.test.ts
@@ -74,6 +74,9 @@ describe('POST /api/admin/model-prices', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAppend.mockResolvedValue({ id: 'row1' });
+    // gpt-x is a known (seeded) model with no prior operator rows by default.
+    mockGenerateSeed.mockResolvedValue([{ modelId: 'gpt-x', unit: 'per_token', pricing: { '0': TIER } }]);
+    mockRowsInForce.mockResolvedValue([]);
   });
 
   it('appends an operator reprice with a server-side effectiveFrom', async () => {
@@ -86,6 +89,57 @@ describe('POST /api/admin/model-prices', () => {
     const row = mockAppend.mock.calls[0][0];
     expect(row).toMatchObject({ modelId: 'gpt-x', note: 'provider price page 2026-07' });
     expect(row.effectiveFrom).toBeInstanceOf(Date);
+  });
+
+  it('rejects a reprice for a model unknown to the catalog and the seed (typo protection)', async () => {
+    const { run } = call({
+      method: 'POST',
+      body: { modelId: 'gpt-5-minl', unit: 'per_token', pricing: { '0': TIER }, note: 'typo reprice' },
+    });
+    await expect(run()).rejects.toThrow(/unknown model/i);
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown tier rate fields instead of silently stripping them (audio_* before the tier schema learns them)', async () => {
+    const { run } = call({
+      method: 'POST',
+      body: {
+        modelId: 'gpt-x',
+        unit: 'per_token',
+        pricing: { '0': { ...TIER, audio_inputt: 32e-6 } },
+        note: 'invoice',
+      },
+    });
+    await expect(run()).rejects.toThrow();
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('rejects an all-zero reprice as a 400-class validation error, not a 500', async () => {
+    const { run } = call({
+      method: 'POST',
+      body: { modelId: 'gpt-x', unit: 'per_token', pricing: { '0': { input: 0, output: 0 } }, note: 'zero it out' },
+    });
+    await expect(run()).rejects.toMatchObject({ statusCode: 400 });
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: an identical resubmit returns the existing row instead of appending a duplicate', async () => {
+    mockRowsInForce.mockResolvedValue([
+      {
+        modelId: 'gpt-x',
+        unit: 'per_token',
+        pricing: { '0': TIER },
+        note: 'provider price page 2026-07',
+        effectiveFrom: new Date(),
+      },
+    ]);
+    const { res, run } = call({
+      method: 'POST',
+      body: { modelId: 'gpt-x', unit: 'per_token', pricing: { '0': TIER }, note: 'provider price page 2026-07' },
+    });
+    await run();
+    expect(mockAppend).not.toHaveBeenCalled();
+    expect(res._getJSONData().row).toMatchObject({ note: 'provider price page 2026-07' });
   });
 
   it('rejects a reprice without a note (the note IS the audit trail)', async () => {

--- a/apps/client/pages/api/admin/__tests__/model-prices.test.ts
+++ b/apps/client/pages/api/admin/__tests__/model-prices.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+// Middleware stripped so the handler body runs directly (same pattern as
+// pages/api/email/__tests__/verify.test.ts). The chain object doubles as the
+// exported handler and dispatches on req.method.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const handlers: Record<string, (req: unknown, res: unknown) => Promise<unknown>> = {};
+    const chain = async (req: { method: string }, res: unknown) => handlers[req.method](req, res);
+    chain.use = () => chain;
+    chain.get = (fn: (typeof handlers)[string]) => {
+      handlers.GET = fn;
+      return chain;
+    };
+    chain.post = (fn: (typeof handlers)[string]) => {
+      handlers.POST = fn;
+      return chain;
+    };
+    return chain;
+  },
+}));
+
+const mockRowsInForce = vi.fn();
+const mockHistoryForModel = vi.fn();
+const mockAppend = vi.fn();
+const mockGenerateSeed = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  modelPriceRepository: {
+    rowsInForce: (...a: unknown[]) => mockRowsInForce(...a),
+    historyForModel: (...a: unknown[]) => mockHistoryForModel(...a),
+    append: (...a: unknown[]) => mockAppend(...a),
+  },
+  generateModelPriceSeed: (...a: unknown[]) => mockGenerateSeed(...a),
+  SEED_NOTE: 'adapter-seed',
+}));
+
+import handler from '../model-prices';
+
+const TIER = { input: 4e-6, output: 16e-6 };
+
+function call(options: { method: 'GET' | 'POST'; isAdmin?: boolean; query?: object; body?: object }) {
+  const { req, res } = createMocks({ method: options.method, query: options.query ?? {}, body: options.body });
+  (req as unknown as { user: { isAdmin: boolean } }).user = { isAdmin: options.isAdmin ?? true };
+  return { req, res, run: () => (handler as unknown as (rq: unknown, rs: unknown) => Promise<unknown>)(req, res) };
+}
+
+describe('GET /api/admin/model-prices', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects non-admin users', async () => {
+    const { run } = call({ method: 'GET', isAdmin: false });
+    await expect(run()).rejects.toThrow(/[Aa]dmin/);
+    expect(mockRowsInForce).not.toHaveBeenCalled();
+  });
+
+  it('returns the rows in force', async () => {
+    mockRowsInForce.mockResolvedValue([{ modelId: 'gpt-x', unit: 'per_token', pricing: { '0': TIER } }]);
+    const { res, run } = call({ method: 'GET' });
+    await run();
+    expect(res._getJSONData().rows).toHaveLength(1);
+  });
+
+  it('returns per-model history when requested', async () => {
+    mockHistoryForModel.mockResolvedValue([{ modelId: 'gpt-x', note: 'manual reprice' }]);
+    const { res, run } = call({ method: 'GET', query: { history: 'gpt-x' } });
+    await run();
+    expect(mockHistoryForModel).toHaveBeenCalledWith('gpt-x');
+    expect(res._getJSONData().history).toHaveLength(1);
+  });
+});
+
+describe('POST /api/admin/model-prices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAppend.mockResolvedValue({ id: 'row1' });
+  });
+
+  it('appends an operator reprice with a server-side effectiveFrom', async () => {
+    const { run } = call({
+      method: 'POST',
+      body: { modelId: 'gpt-x', unit: 'per_token', pricing: { '0': TIER }, note: 'provider price page 2026-07' },
+    });
+    await run();
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    const row = mockAppend.mock.calls[0][0];
+    expect(row).toMatchObject({ modelId: 'gpt-x', note: 'provider price page 2026-07' });
+    expect(row.effectiveFrom).toBeInstanceOf(Date);
+  });
+
+  it('rejects a reprice without a note (the note IS the audit trail)', async () => {
+    const { run } = call({
+      method: 'POST',
+      body: { modelId: 'gpt-x', unit: 'per_token', pricing: { '0': TIER }, note: '  ' },
+    });
+    await expect(run()).rejects.toThrow(/note/i);
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('rejects the reserved adapter-seed note (would masquerade as seed provenance)', async () => {
+    const { run } = call({
+      method: 'POST',
+      body: { modelId: 'gpt-x', unit: 'per_token', pricing: { '0': TIER }, note: 'adapter-seed' },
+    });
+    await expect(run()).rejects.toThrow(/reserved/i);
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('revert-to-seed appends the CURRENT generator rates under the seed note (server-computed, not client-supplied)', async () => {
+    mockGenerateSeed.mockResolvedValue([
+      { modelId: 'gpt-x', unit: 'per_token', pricing: { '0': { input: 9e-6, output: 27e-6 } } },
+    ]);
+    const { run } = call({ method: 'POST', body: { modelId: 'gpt-x', unit: 'per_token', action: 'revert-to-seed' } });
+    await run();
+    const row = mockAppend.mock.calls[0][0];
+    expect(row).toMatchObject({
+      modelId: 'gpt-x',
+      note: 'adapter-seed',
+      pricing: { '0': { input: 9e-6, output: 27e-6 } },
+    });
+  });
+
+  it('rejects revert for a model the seed does not manage', async () => {
+    mockGenerateSeed.mockResolvedValue([]);
+    const { run } = call({
+      method: 'POST',
+      body: { modelId: 'ghost-model', unit: 'per_token', action: 'revert-to-seed' },
+    });
+    await expect(run()).rejects.toThrow(/not seed-managed/);
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/admin/model-prices.ts
+++ b/apps/client/pages/api/admin/model-prices.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+import { baseApi } from '@server/middlewares/baseApi';
+import { generateModelPriceSeed, modelPriceRepository, SEED_NOTE } from '@bike4mind/database';
+import { MODEL_PRICE_UNITS, ModelPriceTier } from '@bike4mind/common';
+import { ForbiddenError, BadRequestError } from '@server/utils/errors';
+
+/**
+ * Admin surface over the versioned model price catalog. Prices here are
+ * provider cost beliefs in USD - what a user pays is always this cost times
+ * the published uniform markup, so this endpoint manages COGS data, never
+ * markup. Append-only throughout: a reprice or revert is a NEW row.
+ *
+ * GET                       -> { rows } in force
+ * GET ?history=<modelId>    -> { history } (audit trail, newest first)
+ * POST { modelId, unit, pricing, note }        -> operator reprice
+ * POST { modelId, unit, action: 'revert-to-seed' } -> hand the model back to
+ *   seed management: appends the adapter literal's CURRENT rates (computed
+ *   server-side) under the seed note, so boot seeding resumes versioning it.
+ */
+const RepriceBody = z.object({
+  modelId: z.string().min(1),
+  unit: z.enum(MODEL_PRICE_UNITS).default('per_token'),
+  pricing: z.record(z.string().regex(/^\d+$/, 'tier keys must be numeric token thresholds'), ModelPriceTier),
+  note: z.string(),
+});
+
+const RevertBody = z.object({
+  modelId: z.string().min(1),
+  unit: z.enum(MODEL_PRICE_UNITS).default('per_token'),
+  action: z.literal('revert-to-seed'),
+});
+
+const handler = baseApi()
+  .get(async (req, res) => {
+    if (!req.user?.isAdmin) throw new ForbiddenError('Admin access required');
+
+    const history = req.query.history;
+    if (typeof history === 'string' && history.length > 0) {
+      return res.json({ history: await modelPriceRepository.historyForModel(history) });
+    }
+    return res.json({ rows: await modelPriceRepository.rowsInForce() });
+  })
+  .post(async (req, res) => {
+    if (!req.user?.isAdmin) throw new ForbiddenError('Admin access required');
+
+    if ((req.body as { action?: string })?.action === 'revert-to-seed') {
+      const parsed = RevertBody.safeParse(req.body);
+      if (!parsed.success) throw new BadRequestError(parsed.error.issues[0]?.message ?? 'invalid revert request');
+      const { modelId, unit } = parsed.data;
+      const entry = (await generateModelPriceSeed()).find(e => e.modelId === modelId && e.unit === unit);
+      if (!entry) {
+        throw new BadRequestError(`${modelId} (${unit}) is not seed-managed; nothing to revert to`);
+      }
+      const row = await modelPriceRepository.append({
+        modelId,
+        unit,
+        pricing: entry.pricing,
+        effectiveFrom: new Date(),
+        note: SEED_NOTE,
+      });
+      return res.json({ row });
+    }
+
+    const parsed = RepriceBody.safeParse(req.body);
+    if (!parsed.success) throw new BadRequestError(parsed.error.issues[0]?.message ?? 'invalid reprice request');
+    const note = parsed.data.note.trim();
+    if (!note) throw new BadRequestError('note is required: it is the audit trail for this price change');
+    if (note === SEED_NOTE) {
+      throw new BadRequestError(
+        `note '${SEED_NOTE}' is reserved for seed provenance; describe the source of the reprice`
+      );
+    }
+    // append() re-validates (zod, empty map, all-zero) before persisting.
+    const row = await modelPriceRepository.append({
+      modelId: parsed.data.modelId,
+      unit: parsed.data.unit,
+      pricing: parsed.data.pricing,
+      effectiveFrom: new Date(),
+      note,
+    });
+    return res.json({ row });
+  });
+
+export default handler;

--- a/apps/client/pages/api/admin/model-prices.ts
+++ b/apps/client/pages/api/admin/model-prices.ts
@@ -20,9 +20,27 @@ import { ForbiddenError, BadRequestError } from '@server/utils/errors';
 const RepriceBody = z.object({
   modelId: z.string().min(1),
   unit: z.enum(MODEL_PRICE_UNITS).default('per_token'),
-  pricing: z.record(z.string().regex(/^\d+$/, 'tier keys must be numeric token thresholds'), ModelPriceTier),
+  // strict(): reject unknown rate fields rather than silently stripping them
+  // (a rate the schema does not know yet must fail loudly, not vanish with 200).
+  pricing: z.record(z.string().regex(/^\d+$/, 'tier keys must be numeric token thresholds'), ModelPriceTier.strict()),
   note: z.string(),
 });
+
+/** Stable serialization for idempotency comparison (mirrors the seeder's normalizePricing). */
+function normalizePricing(pricing: Record<string, Record<string, number | undefined>>): string {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(pricing).sort()) {
+    const tier = pricing[key];
+    const normalized: Record<string, number> = {};
+    for (const field of Object.keys(tier).sort()) {
+      if (tier[field] !== undefined) normalized[field] = tier[field] as number;
+    }
+    out[key] = normalized;
+  }
+  return JSON.stringify(out);
+}
+
+const FAR_FUTURE = new Date('9999-01-01T00:00:00Z');
 
 const RevertBody = z.object({
   modelId: z.string().min(1),
@@ -63,6 +81,7 @@ const handler = baseApi()
 
     const parsed = RepriceBody.safeParse(req.body);
     if (!parsed.success) throw new BadRequestError(parsed.error.issues[0]?.message ?? 'invalid reprice request');
+    const { modelId, unit, pricing } = parsed.data;
     const note = parsed.data.note.trim();
     if (!note) throw new BadRequestError('note is required: it is the audit trail for this price change');
     if (note === SEED_NOTE) {
@@ -70,11 +89,37 @@ const handler = baseApi()
         `note '${SEED_NOTE}' is reserved for seed provenance; describe the source of the reprice`
       );
     }
-    // append() re-validates (zod, empty map, all-zero) before persisting.
+    // 400-class validation here; append()'s own checks would surface as 500s.
+    const hasNonzeroTier = Object.values(pricing).some(tier => tier.input > 0 || tier.output > 0);
+    if (Object.keys(pricing).length === 0 || !hasNonzeroTier) {
+      throw new BadRequestError('all-zero or empty pricing would settle calls free; mark the model freeToRun instead');
+    }
+
+    // Only models the catalog already knows (seeded or previously priced) can
+    // be repriced: a typoed modelId must not mint a phantom in-force row.
+    const [seedEntries, newestRows] = await Promise.all([
+      generateModelPriceSeed(),
+      modelPriceRepository.rowsInForce(FAR_FUTURE),
+    ]);
+    const knownModel =
+      seedEntries.some(e => e.modelId === modelId && e.unit === unit) ||
+      newestRows.some(r => r.modelId === modelId && r.unit === unit);
+    if (!knownModel) {
+      throw new BadRequestError(`unknown model ${modelId} (${unit}): reprice targets an existing catalog model`);
+    }
+
+    // Idempotency: a resubmit of the identical reprice (double-click, network
+    // retry, second tab) returns the existing row instead of appending a
+    // duplicate; the append-only audit trail must not record phantom changes.
+    const newest = newestRows.find(r => r.modelId === modelId && r.unit === unit);
+    if (newest && newest.note === note && normalizePricing(newest.pricing) === normalizePricing(pricing)) {
+      return res.json({ row: newest });
+    }
+
     const row = await modelPriceRepository.append({
-      modelId: parsed.data.modelId,
-      unit: parsed.data.unit,
-      pricing: parsed.data.pricing,
+      modelId,
+      unit,
+      pricing,
       effectiveFrom: new Date(),
       note,
     });

--- a/docs-site/docs/admin/credit-analytics.md
+++ b/docs-site/docs/admin/credit-analytics.md
@@ -1,13 +1,13 @@
 ---
 title: Credit Analytics
-description: Manage user credit balances and review margin analytics for the platform
+description: Manage user credit balances, model pricing, and margin analytics for the platform
 sidebar_position: 12
 tags: [admin, credits, analytics, billing]
 ---
 
 # Credit Analytics
 
-The Credit Analytics tab provides tools for managing the platform's credit economy. It is organized into two sub-tabs: **User Credits** for viewing and adjusting individual user credit balances, and **Margins** for reviewing revenue-versus-cost analytics. Per-model prices are managed by the versioned model price catalog, not through this screen.
+The Credit Analytics tab provides tools for managing the platform's credit economy. It is organized into three sub-tabs: **User Credits** for viewing and adjusting individual user credit balances, **Model Pricing** for managing the versioned model price catalog, and **Margins** for reviewing revenue-versus-cost analytics.
 
 ## User Credits Manager
 
@@ -66,6 +66,18 @@ Pagination controls appear above and below the user table:
 - **Page indicator** showing "Page X of Y"
 - **Items per page** selector with options: 10, 20, 50, or 100 per page
 - **Total Users** count
+
+## Model Pricing
+
+The Model Pricing sub-tab manages the versioned model price catalog. **Rates are provider costs in USD (displayed per 1M tokens), not credit prices**: what a user pays is always this cost multiplied by the platform's published uniform markup, so this screen manages cost data and never markup.
+
+Each row shows the price currently in force for one model: input/output rates (plus audio rates for realtime voice models), the date it took effect, and a source chip - `seed` for prices managed automatically from the adapter tables, `operator` for manual reprices.
+
+| Action | Description |
+|--------|-------------|
+| **Reprice** | Appends a new operator price row taking effect immediately. Requires a note documenting where the price comes from (an invoice, a provider pricing page); the note is the audit trail. While an operator row is newest, automatic seed updates skip that model. |
+| **History** | Shows every price the model has ever had, with dates and notes. Rows are append-only and never edited, so history is complete by construction. |
+| **Revert** | Offered on operator-priced rows. Appends the adapter table's current rates back under seed management, so future automatic price updates flow to the model again. The operator row remains in history. |
 
 ## Margins
 

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -7,6 +7,7 @@ mongoose.plugin(mongooseLeanVirtuals);
 
 export * from './models';
 export * from './seeds/seedModelPrices';
+export * from './seeds/generateModelPriceSeed';
 export * from './queries/fabFileSearchQuery';
 export * from './queries/collectionSearchQuery';
 export * from '@bike4mind/db-core';


### PR DESCRIPTION
Replacement UI for the screen #400 removed. Originally stacked on #400; now rebased onto main with #400, #423, and #431 merged.

## What it is

A Model Pricing sub-tab in admin Credit Analytics, taking the removed screen's slot, backed by the versioned price catalog (#376). Unlike its inert predecessor, every action here is real.

**The semantic the old screen got wrong, fixed:** rates are provider cost beliefs in USD (displayed per 1M tokens), never credit prices. What users pay is always this cost times the published uniform markup; the UI manages COGS data and cannot touch markup.

## Changes

- `apps/client/pages/api/admin/model-prices.ts`: admin-gated route. GET rows in force / per-model history; POST appends an operator reprice (required note, `adapter-seed` note rejected as reserved) or reverts a model to seed pricing. Revert rates are computed server-side from `generateModelPriceSeed()`, so a client cannot fake them, and the newest row carrying the seed note means boot seeding resumes managing the model with zero seeder changes. Everything reuses `append()`'s existing validation; append-only throughout.
- `ModelPricingCatalog.tsx`: table of in-force rows (rates incl. audio columns for voice models, effectiveFrom, seed/operator source chip), reprice modal (per-tier USD inputs, note required before save), revert confirm (operator rows only), history drawer (full audit trail per model). Tier wire type is `IModelPriceTier` from `@bike4mind/common` (available since #423 merged; replaced the temporary local mirror).
- `packages/database`: export `generateModelPriceSeed` from the barrel (server-side revert needs it).
- Docs: Model Pricing section in the credit-analytics help article (help index regenerated, validate clean); two API-reference rows.

## Test steps

1. Admin > Credit Analytics > Model Pricing: rows for all seeded models with source chips.
2. Reprice a model with a note: new operator row effective immediately; chip flips to operator; History shows both rows.
3. Revert it: chip returns to seed; the operator row remains in history.
4. Reprice with empty note: save disabled. Non-admin GET/POST: 403.

## Verification

TDD (route and component tests watched RED first): 12 route tests + 7 component tests green (grew during review hardening), client typecheck, lint, help validation, ASCII sweep.
