### PR TITLE
fix(admin): handle empty chat context in modal from-context

### DIFF
--- a/apps/client/app/services/adminTools/ModalManagementToolClient.ts
+++ b/apps/client/app/services/adminTools/ModalManagementToolClient.ts
@@ -181,7 +181,7 @@ export class ModalManagementToolClient implements AdminTool {
                   type: finalModal.isBanner ? ('banner' as const) : ('modal' as const),
                 },
               },
-              message: `✅ ${finalModal.isBanner ? 'Banner' : 'Modal'} "${finalModal.title}" created successfully!`,
+              message: `✅ ${finalModal.isBanner ? 'Banner' : 'Modal'} "${finalModal.title || finalModal.textMessage}" created successfully!`,
             };
           },
         },

--- a/apps/client/app/services/adminTools/ModalManagementToolClient.ts
+++ b/apps/client/app/services/adminTools/ModalManagementToolClient.ts
@@ -13,10 +13,9 @@ import {
   showHelp,
   buildModalFromParams,
   generateModalFromNaturalLanguage,
-  extractImagesFromChat,
-  summarizeChatContext,
+  generateModalContentFromContext,
+  NO_CHAT_CONTEXT_MESSAGE,
   suggestTags,
-  aiGenerateModalContent,
 } from './modalToolHelpers';
 
 /**
@@ -113,8 +112,17 @@ export class ModalManagementToolClient implements AdminTool {
     try {
       let modalData: Partial<IModal>;
 
-      if ((params.data as ModalGenerationParams)?.fromContext && context.chatHistory) {
-        modalData = await this.generateModalFromContext(context, params);
+      // from-context always builds from recent chat; if there is none we return
+      // a clear message rather than falling back to any query text below.
+      if ((params.data as ModalGenerationParams)?.fromContext) {
+        const contextModal = await this.generateModalFromContext(context, params);
+        if (!contextModal) {
+          return {
+            success: false,
+            error: NO_CHAT_CONTEXT_MESSAGE,
+          };
+        }
+        modalData = contextModal;
       } else if (params.query) {
         modalData = generateModalFromNaturalLanguage(
           params.query,
@@ -186,20 +194,23 @@ export class ModalManagementToolClient implements AdminTool {
     }
   }
 
-  // Generate modal from chat context
-  private async generateModalFromContext(context: AdminToolContext, params: AdminToolParams): Promise<Partial<IModal>> {
+  // Generate modal from chat context. Returns null when there is no usable
+  // recent context so the caller can surface a clear message.
+  private async generateModalFromContext(
+    context: AdminToolContext,
+    params: AdminToolParams
+  ): Promise<Partial<IModal> | null> {
     const contextMessages = (params.data as ModalGenerationParams)?.contextMessages || 5;
     const recentMessages = context.chatHistory?.slice(-contextMessages) || [];
 
-    const summary = summarizeChatContext(recentMessages);
-    const images = extractImagesFromChat(recentMessages);
-
-    const generatedContent = aiGenerateModalContent({
-      summary,
-      images,
+    const generatedContent = generateModalContentFromContext(recentMessages, {
       type: (params.data as ModalGenerationParams)?.type || 'modal',
       intent: params.query || '',
     });
+
+    if (!generatedContent) {
+      return null;
+    }
 
     return {
       ...generatedContent,

--- a/apps/client/app/services/adminTools/modalToolHelpers.test.ts
+++ b/apps/client/app/services/adminTools/modalToolHelpers.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { IChatHistoryItem } from '@bike4mind/common';
+import { summarizeChatContext, extractImagesFromChat, generateModalContentFromContext } from './modalToolHelpers';
+
+// The from-context helpers accept whatever the client sends as chatHistory, so
+// fixtures are cast through unknown to exercise both the legacy {content,text}
+// shape and the real IChatHistoryItem {prompt,reply,images} shape.
+const msg = (item: Record<string, unknown>): IChatHistoryItem => item as unknown as IChatHistoryItem;
+
+describe('summarizeChatContext', () => {
+  it('reflects the legacy {content} message shape', () => {
+    const summary = summarizeChatContext([msg({ content: 'We shipped a new feature today' })]);
+    expect(summary).toContain('new feature');
+  });
+
+  it('reflects the real IChatHistoryItem {prompt,reply} shape', () => {
+    const summary = summarizeChatContext([
+      msg({ prompt: 'Any maintenance planned?', reply: 'Yes, maintenance tonight' }),
+    ]);
+    expect(summary).toContain('maintenance');
+  });
+
+  it('returns an empty string for empty history', () => {
+    expect(summarizeChatContext([])).toBe('');
+  });
+
+  it('returns an empty string when messages carry no text', () => {
+    expect(summarizeChatContext([msg({ images: ['https://cdn.example.com/a.png'] })])).toBe('');
+  });
+});
+
+describe('extractImagesFromChat', () => {
+  it('collects image-generation results (type + url)', () => {
+    expect(extractImagesFromChat([msg({ type: 'image', url: 'https://cdn.example.com/gen.png' })])).toEqual([
+      'https://cdn.example.com/gen.png',
+    ]);
+  });
+
+  it('collects attached images', () => {
+    const images = extractImagesFromChat([
+      msg({ attachments: [{ type: 'image', url: 'https://cdn.example.com/att.png' }] }),
+    ]);
+    expect(images).toEqual(['https://cdn.example.com/att.png']);
+  });
+
+  it('ignores IChatHistoryItem.images (bucket keys, not usable URLs)', () => {
+    const images = extractImagesFromChat([msg({ prompt: 'look', images: ['sessions/abc/generated.png'] })]);
+    expect(images).toEqual([]);
+  });
+
+  it('returns an empty array for empty history', () => {
+    expect(extractImagesFromChat([])).toEqual([]);
+  });
+});
+
+describe('generateModalContentFromContext', () => {
+  it('builds text-only content that reflects the recent messages', () => {
+    const content = generateModalContentFromContext([msg({ prompt: 'Announcing our new feature launch' })], {
+      type: 'modal',
+    });
+
+    expect(content).not.toBeNull();
+    // 'feature' in the summary drives the templated title.
+    expect(content?.title).toBe('🚀 Exciting New Feature!');
+    expect(content?.description).toContain('new feature launch');
+    expect(content?.imageUrl).toBeUndefined();
+  });
+
+  it('populates imageUrl from an attached image in the recent messages', () => {
+    const content = generateModalContentFromContext(
+      [
+        msg({
+          prompt: 'here is a screenshot',
+          attachments: [{ type: 'image', url: 'https://cdn.example.com/shot.png' }],
+        }),
+      ],
+      { type: 'modal' }
+    );
+
+    expect(content).not.toBeNull();
+    expect(content?.imageUrl).toBe('https://cdn.example.com/shot.png');
+  });
+
+  it('builds banner content when type is banner', () => {
+    const content = generateModalContentFromContext([msg({ prompt: 'scheduled maintenance tonight' })], {
+      type: 'banner',
+    });
+
+    expect(content?.isBanner).toBe(true);
+    expect(content?.textMessage).toBeTruthy();
+  });
+
+  it('returns null for empty history so callers surface a clear message', () => {
+    expect(generateModalContentFromContext([], { type: 'modal' })).toBeNull();
+  });
+
+  it('returns null when messages carry no text and no images', () => {
+    expect(generateModalContentFromContext([msg({ prompt: '' }), msg({})], { type: 'modal' })).toBeNull();
+  });
+});

--- a/apps/client/app/services/adminTools/modalToolHelpers.test.ts
+++ b/apps/client/app/services/adminTools/modalToolHelpers.test.ts
@@ -81,6 +81,16 @@ describe('generateModalContentFromContext', () => {
     expect(content?.imageUrl).toBe('https://cdn.example.com/shot.png');
   });
 
+  it('populates imageUrl from an image-only message with no text', () => {
+    const content = generateModalContentFromContext(
+      [msg({ attachments: [{ type: 'image', url: 'https://cdn.example.com/only.png' }] })],
+      { type: 'modal' }
+    );
+
+    expect(content).not.toBeNull();
+    expect(content?.imageUrl).toBe('https://cdn.example.com/only.png');
+  });
+
   it('builds banner content when type is banner', () => {
     const content = generateModalContentFromContext([msg({ prompt: 'scheduled maintenance tonight' })], {
       type: 'banner',

--- a/apps/client/app/services/adminTools/modalToolHelpers.ts
+++ b/apps/client/app/services/adminTools/modalToolHelpers.ts
@@ -366,8 +366,11 @@ export function summarizeChatContext(messages: IChatHistoryItem[]): string {
         reply?: string | null;
         replies?: string[];
       };
+      // Prefer a single prompt source (legacy content/text OR the real prompt)
+      // so a message carrying both shapes is not concatenated twice.
+      const prompt = extra.content || extra.text || m.prompt;
       const reply = extra.reply || extra.replies?.find(Boolean);
-      return [extra.content, extra.text, m.prompt, reply].filter(Boolean).join(' ').trim();
+      return [prompt, reply].filter(Boolean).join(' ').trim();
     })
     .filter(Boolean);
   return texts.join(' ').slice(-500); // Last 500 chars

--- a/apps/client/app/services/adminTools/modalToolHelpers.ts
+++ b/apps/client/app/services/adminTools/modalToolHelpers.ts
@@ -434,7 +434,7 @@ export function aiGenerateModalContent(params: {
 // Shown when a from-context request has no recent chat to summarize, so callers
 // surface a clear message instead of a generic empty modal.
 export const NO_CHAT_CONTEXT_MESSAGE =
-  'No recent chat context found to build a modal from. Have a conversation (or attach an image) first, then try `/admin modal from-context` again.';
+  'No recent chat context found to build a modal from. Have a conversation first, then try `/admin modal from-context` again.';
 
 // Build modal content from recent chat context. Returns null when there is no
 // usable context (no text and no images) so callers can surface a clear

--- a/apps/client/app/services/adminTools/modalToolHelpers.ts
+++ b/apps/client/app/services/adminTools/modalToolHelpers.ts
@@ -343,6 +343,11 @@ export function extractImagesFromChat(messages: IChatHistoryItem[]): string[] {
         }
       });
     }
+
+    // NOTE: IChatHistoryItem.images is intentionally NOT read here. It holds
+    // storage bucket keys (not URLs) and can include non-image artifacts, so it
+    // would need key filtering + URL resolution before it could feed imageUrl.
+    // Only the {type:'image'|attachments} shapes above carry ready-to-use URLs.
   });
 
   return images;
@@ -350,9 +355,20 @@ export function extractImagesFromChat(messages: IChatHistoryItem[]): string[] {
 
 // Summarize chat context
 export function summarizeChatContext(messages: IChatHistoryItem[]): string {
-  // Simple summarization - in production, use LLM
+  // Simple summarization - in production, use LLM.
+  // Reads both the legacy {content,text} shape and the real IChatHistoryItem
+  // {prompt,reply/replies} shape so real chat history is actually reflected.
   const texts = messages
-    .map(m => (m as { content?: string; text?: string }).content || (m as { text?: string }).text)
+    .map(m => {
+      const extra = m as unknown as {
+        content?: string;
+        text?: string;
+        reply?: string | null;
+        replies?: string[];
+      };
+      const reply = extra.reply || extra.replies?.find(Boolean);
+      return [extra.content, extra.text, m.prompt, reply].filter(Boolean).join(' ').trim();
+    })
     .filter(Boolean);
   return texts.join(' ').slice(-500); // Last 500 chars
 }
@@ -413,6 +429,33 @@ export function aiGenerateModalContent(params: {
   };
 
   return baseModal;
+}
+
+// Shown when a from-context request has no recent chat to summarize, so callers
+// surface a clear message instead of a generic empty modal.
+export const NO_CHAT_CONTEXT_MESSAGE =
+  'No recent chat context found to build a modal from. Have a conversation (or attach an image) first, then try `/admin modal from-context` again.';
+
+// Build modal content from recent chat context. Returns null when there is no
+// usable context (no text and no images) so callers can surface a clear
+// "nothing to summarize" message rather than a generic empty modal.
+export function generateModalContentFromContext(
+  messages: IChatHistoryItem[],
+  options: { type?: 'modal' | 'banner'; intent?: string } = {}
+): Partial<IModal> | null {
+  const summary = summarizeChatContext(messages);
+  const images = extractImagesFromChat(messages);
+
+  if (!summary.trim() && images.length === 0) {
+    return null;
+  }
+
+  return aiGenerateModalContent({
+    summary,
+    images,
+    type: options.type || 'modal',
+    intent: options.intent || '',
+  });
 }
 
 // Generate modal from natural language

--- a/apps/client/server/tools/ModalManagementToolServer.ts
+++ b/apps/client/server/tools/ModalManagementToolServer.ts
@@ -14,10 +14,9 @@ import {
   showHelp,
   buildModalFromParams,
   generateModalFromNaturalLanguage,
-  extractImagesFromChat,
-  summarizeChatContext,
+  generateModalContentFromContext,
+  NO_CHAT_CONTEXT_MESSAGE,
   suggestTags,
-  aiGenerateModalContent,
   findModalByPartialId,
 } from '@client/app/services/adminTools/modalToolHelpers';
 
@@ -115,8 +114,17 @@ export class ModalManagementToolServer implements AdminTool {
     try {
       let modalData: Partial<IModal>;
 
-      if ((params.data as ModalGenerationParams)?.fromContext && context.chatHistory) {
-        modalData = await this.generateModalFromContext(context, params);
+      // from-context always builds from recent chat; if there is none we return
+      // a clear message rather than falling back to any query text below.
+      if ((params.data as ModalGenerationParams)?.fromContext) {
+        const contextModal = await this.generateModalFromContext(context, params);
+        if (!contextModal) {
+          return {
+            success: false,
+            error: NO_CHAT_CONTEXT_MESSAGE,
+          };
+        }
+        modalData = contextModal;
       } else if (params.query) {
         modalData = generateModalFromNaturalLanguage(
           params.query,
@@ -196,20 +204,23 @@ export class ModalManagementToolServer implements AdminTool {
     }
   }
 
-  // Generate modal from chat context
-  private async generateModalFromContext(context: AdminToolContext, params: AdminToolParams): Promise<Partial<IModal>> {
+  // Generate modal from chat context. Returns null when there is no usable
+  // recent context so the caller can surface a clear message.
+  private async generateModalFromContext(
+    context: AdminToolContext,
+    params: AdminToolParams
+  ): Promise<Partial<IModal> | null> {
     const contextMessages = (params.data as ModalGenerationParams)?.contextMessages || 5;
     const recentMessages = context.chatHistory?.slice(-contextMessages) || [];
 
-    const summary = summarizeChatContext(recentMessages);
-    const images = extractImagesFromChat(recentMessages);
-
-    const generatedContent = aiGenerateModalContent({
-      summary,
-      images,
+    const generatedContent = generateModalContentFromContext(recentMessages, {
       type: (params.data as ModalGenerationParams)?.type || 'modal',
       intent: params.query || '',
     });
+
+    if (!generatedContent) {
+      return null;
+    }
 
     return {
       ...generatedContent,


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

https://github.com/user-attachments/assets/ac910cc3-d55c-44c9-9777-f477a2a60107

Verifying the fix via the admin API. `call([])` returns `success: false` with
the "No recent chat context found..." message and creates no modal; a text
history returns `success: true` with the conversation reflected. Unit tests
(`modalToolHelpers.test.ts`) pass 14/14.

## Description

Closes #99.

The `/admin modal from-context` flow builds a modal or banner from recent chat
context. The generation path already existed; this PR verifies it end-to-end and
fixes the gaps found against the issue's acceptance criteria.

The main bug: the caller guarded on `fromContext && context.chatHistory`, but an
empty array is truthy, so an empty chat history produced a generic non-empty
modal instead of telling the admin there was nothing to summarize. This PR makes
the from-context generator return `null` when there is no usable context, and the
caller then returns a clear "no recent chat context" message. Along the way the
duplicated server/client generation logic is consolidated into one shared helper,
and the summarizer is fixed to read the real chat fields so text context is
actually reflected.

## Changes

- Add `generateModalContentFromContext(messages, options)` to `modalToolHelpers`
  - returns `null` when there is no usable context (no text and no images) so
    callers can surface a clear message instead of a generic empty modal
- Add `NO_CHAT_CONTEXT_MESSAGE` constant used by both the server and client tools
- `summarizeChatContext` now reads the real `IChatHistoryItem` fields
  (`prompt`, `reply`, `replies`) in addition to the legacy `content`/`text`
  shape, so recent messages are actually reflected in the generated content
- Document in `extractImagesFromChat` why `IChatHistoryItem.images` is
  intentionally not used (a NOTE comment - it was never read on `main` either):
  those are storage bucket keys, possibly non-image artifacts, not usable URLs.
  The function still reads only the `type:'image'` / `attachments[].url` shapes,
  which carry ready-to-use URLs
- `ModalManagementToolServer` and `ModalManagementToolClient` both delegate to
  the shared helper and return `NO_CHAT_CONTEXT_MESSAGE` when it yields `null`
  (removes the duplicated generation logic)
- Fix the client success message for banners created from-context: it showed
  `Banner "undefined"` because banners use `textMessage`, not `title`; now falls
  back to `title || textMessage`, mirroring the server side
- Add unit tests covering the from-context path: text-only history, attached
  image, empty history, and no-text/no-image history

## Guide for Testers

Backend/service change. There is no chat-UI entry point for from-context yet
(see "Additional Information"), so verify via the admin API endpoint below.

Prerequisites: you must be signed in as an admin user.

1. Open the preview link and sign in with an admin account.
2. Open browser DevTools -> Network tab, click any request to a `/api/` route,
   and copy the value of its `Authorization` header (the part after `Bearer `).
3. Open DevTools -> Console and paste the following, replacing
   `PASTE_TOKEN_HERE` with the token from step 2:
   ```js
   const TOKEN = 'PASTE_TOKEN_HERE';
   const call = chatHistory =>
     fetch('/api/admin/tools/execute', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
       body: JSON.stringify({
         tool: 'modal',
         params: { action: 'from-context', data: { fromContext: true, type: 'modal' } },
         context: { chatHistory },
       }),
     })
       .then(r => r.json())
       .then(console.log);
   ```
4. Run `call([])` in the console.
   - Expected: the response has `success: false` and an `error` beginning with
     "No recent chat context found to build a modal from...". This is the fix -
     an empty history returns a clear message instead of creating a blank modal.
5. Run `call([{ prompt: 'we are launching a new feature next week' }])`.
   - Expected: `success: true` and a created modal whose title/description reflect
     the message text (title "Exciting New Feature!", description containing the
     message text).
6. Run `call([{ prompt: 'here is a screenshot', attachments: [{ type: 'image', url: 'https://example.com/shot.png' }] }])`.
   - Expected: `success: true` and the created modal's `imageUrl` is set to the
     attached image URL.

### What NOT to test

- The chat-input `/admin` slash command - it is not wired to the tool (see "Additional Information").

## Additional Information

- Known limitation / suggested follow-up: the from-context command has no chat-UI
  entry point (the `AdminCommandSuggestions` palette is never rendered, the
  `/admin` dropdown is suppressed in `SessionBottom`, and `executeAdminTool` has
  no call sites). This PR fixes the generation logic; a follow-up is needed to
  make the feature reachable and demoable from the chat.
- The template-based content generation (keyword-driven title/description) is
  intentionally left as-is; richer LLM summarization is out of scope for this fix.

## Tests

- `apps/client/app/services/adminTools/modalToolHelpers.test.ts` (new)
  - `summarizeChatContext`: reflects legacy `{content}` shape, reflects real
    `{prompt,reply}` shape, returns empty string for empty/no-text history
  - `extractImagesFromChat`: collects `type:'image'` url, collects
    `attachments[].url`, ignores bucket-key `images[]`, empty for empty history
  - `generateModalContentFromContext`: text-only reflects messages, attached
    image populates `imageUrl`, banner type builds `textMessage`, empty and
    no-text/no-image histories return `null`

Run: `cd apps/client && pnpm vitest run app/services/adminTools/modalToolHelpers.test.ts`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a (no UI surface)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
