### PR TITLE
chore(deploy): retire the main->prod deploy trigger (prod ships via the console now)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,13 @@ name: Deploy
 
 on:
   push:
-    branches: [main, prod]
+    # Production is no longer shipped by pushing to a `prod` branch. It is promoted
+    # from the deploy console (deploy.bike4mind.com), which dispatches deploy-tier.yml
+    # + prod-release.yml directly. Dropping `prod` here retires the old main->prod PR
+    # path so merging into `prod` no longer deploys. The now-unreachable prod-specific
+    # steps below (is_push_prod matrix entry, prod-failure alert) are dead and can be
+    # cleaned up in a follow-up.
+    branches: [main]
   pull_request:
     # Exclude prod-targeted PRs — those are the staging→production promotion
     # and `main` already validates them; a redundant CI run isn't worth it.


### PR DESCRIPTION
## What

Drops `prod` from `deploy.yml`'s `push` branches. That trigger was the last thing that made merging a `main`->`prod` PR ship production. With it gone, the old release-PR path is inert.

## Why this is safe

Production is now promoted from the deploy console (deploy.bike4mind.com), which dispatches `deploy-tier.yml` (the actual prod deploy) and `prod-release.yml` (changelog) directly. it does not go through the `prod` branch. The console has already shipped a real production release (`v2026.07.10.1`), so the new path is proven. Post-cutover, push-to-`main` already no longer deploys (the deployer owns staging), so after this change `deploy.yml` runs tests/checks only and deploys nothing. exactly the intended end state.

`prod-release.yml` keeps working: the console triggers it via `workflow_dispatch`; only its `workflow_run` (Deploy @ prod) trigger goes idle, which is correct since Deploy no longer runs on `prod`.

## Not in this PR (follow-ups, in order, before deleting the branch)

1. **Repoint `generate-whats-new-modal-production.yml`** . it reads commits from the `prod` branch (`target_branch: prod`). Once `prod` stops moving, that digest goes stale. switch its source to `main` or the latest `prod-YYYY-MM-DD-x` tag first.
2. **Delete the `prod` branch + its protection ruleset** only after (1), so nothing is still reading it.

The now-unreachable prod-specific steps inside `deploy.yml` (the `is_push_prod` matrix entry, the prod-failure alert) are dead but harmless; left for a follow-up cleanup to keep this PR minimal.

## Verify

`deploy.yml` still triggers on push to `main`, PRs, and merge_group (tests + checks intact); it just no longer deploys on push to `prod`.
