### PR TITLE
ci: guard pnpm-lock.yaml against integrity-less tarball entries

### DIFF
--- a/.github/workflows/lockfile-integrity.yml
+++ b/.github/workflows/lockfile-integrity.yml
@@ -1,0 +1,35 @@
+name: Lockfile Integrity
+
+# Blocks any pnpm-lock.yaml entry that resolves a dependency from a bare
+# tarball URL with no integrity hash and no git commit pin. pnpm serializes
+# three resolution shapes in the lockfile:
+#   1. registry/CDN tarball WITH integrity: {integrity: sha512-..., tarball: ...}
+#   2. git-hosted tarball, no integrity by design: {gitHosted: true, tarball: ...}
+#      (the commit SHA in the URL is the content pin; safe)
+#   3. bare tarball, no integrity, no commit pin: {tarball: ...} <- the hole
+# The grep below matches only shape 3, where `tarball` is the first (and
+# only) key in the resolution flow-map.
+
+on:
+  pull_request:
+    branches: [main]
+  # Also run on the merge queue so the check reports there if it later
+  # becomes a required branch-protection check (see semantic-pr-title.yml
+  # for why a required check must run on merge_group).
+  merge_group:
+    branches: [main]
+
+jobs:
+  check:
+    if: github.repository == (vars.CANONICAL_REPO || 'MillionOnMars/lumina5')
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check for integrity-less tarball entries in pnpm-lock.yaml
+        run: |
+          if grep -nE "resolution: \{tarball:" pnpm-lock.yaml; then
+            echo "ERROR: pnpm-lock.yaml contains tarball entries without integrity"
+            echo "Regenerate the lockfile under pnpm >=10.34.1 so a sha512 integrity hash is written."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a standalone `pull_request`/`merge_group` workflow that fails a PR to `main` if `pnpm-lock.yaml` contains a bare tarball resolution with no integrity hash (`resolution: {tarball: ...}`), reintroducing the class of hole closed by the pnpm 10.18.2 -> 10.34.1 bump (`ERR_PNPM_MISSING_TARBALL_INTEGRITY`).
- Modeled on `.github/workflows/semantic-pr-title.yml`: same canonical-repo guard, `RUNNER_LABEL` fallback, and `merge_group` handling so a required-check promotion won't hang the merge queue.
- Git-hosted tarball resolutions (`{gitHosted: true, tarball: ...}`) and registry/CDN tarballs with integrity (`{integrity: ..., tarball: ...}`) are unaffected -- only the bare, integrity-less shape trips the check.

## Test plan
- [x] Ran the grep against the current `pnpm-lock.yaml` -> no match -> check passes.
- [x] Confirmed the git-hosted `react-use-websocket@codeload.github.com` entry is present and does not trip the check.
- [x] Confirmed the CDN `xlsx@cdn.sheetjs.com` entry (has integrity) does not trip the check.
- [x] Injected `resolution: {tarball: https://example.com/x.tgz}` into a scratch copy of the lockfile -> check fails with the actionable message; removed it -> check passes again.
- [x] YAML parses cleanly; ASCII-only.

## Out of scope (follow-ups)
- Marking this check as a required status in branch protection (repo-settings change, not part of this PR).
- Corepack SHA digest pin for `packageManager`.
- Migrating `xlsx` off the SheetJS CDN.