### PR TITLE
fix(scripts): cover drifted default-seed model configs with base entitlement

### DIFF
--- a/packages/scripts/migrate/migrations/20260710160000_base-entitlement-cover-drifted-seed-configs.test.ts
+++ b/packages/scripts/migrate/migrations/20260710160000_base-entitlement-cover-drifted-seed-configs.test.ts
@@ -120,6 +120,14 @@ describe('base-entitlement-cover-drifted-seed-configs migration', () => {
     expect(mockUpdateOne).not.toHaveBeenCalled();
   });
 
+  it('no-ops when settingValue exists but is not an array', async () => {
+    mockFindOne.mockResolvedValue({ _id: 'doc1', settingValue: { not: 'an array' } });
+
+    await migration.up();
+
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
   it('down removes base only from customer-bearing seeds it created', async () => {
     mockFindOne.mockResolvedValue({
       _id: 'doc1',

--- a/packages/scripts/migrate/migrations/20260710160000_base-entitlement-cover-drifted-seed-configs.test.ts
+++ b/packages/scripts/migrate/migrations/20260710160000_base-entitlement-cover-drifted-seed-configs.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFindOne = vi.fn();
+const mockUpdateOne = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  AdminSettings: {
+    findOne: (...args: unknown[]) => mockFindOne(...args),
+    updateOne: (...args: unknown[]) => mockUpdateOne(...args),
+  },
+}));
+
+import migration from './20260710160000_base-entitlement-cover-drifted-seed-configs';
+
+// Returns the settingValue array the migration wrote via updateOne (last call).
+const writtenConfigs = () => mockUpdateOne.mock.calls.at(-1)?.[1]?.settingValue;
+
+describe('base-entitlement-cover-drifted-seed-configs migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  });
+
+  it('adds base to customer-bearing drifted seeds the first pass missed (keeping tags)', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [
+        // pre-opti 3-tag seed - the dominant prod shape the exact-match pass skipped
+        { id: 'm-analyst3', enabled: true, allowedUserTags: ['analyst', 'customer', 'developer'] },
+        { id: 'm-custdev', enabled: true, allowedUserTags: ['customer', 'developer'] },
+        { id: 'm-custonly', enabled: true, allowedUserTags: ['Customer'] }, // case-insensitive
+      ],
+    });
+
+    await migration.up();
+
+    const configs = writtenConfigs();
+    for (const id of ['m-analyst3', 'm-custdev', 'm-custonly']) {
+      expect(configs.find((c: any) => c.id === id).allowedEntitlements).toEqual(['base']);
+    }
+    // tags are preserved, not rewritten
+    expect(configs.find((c: any) => c.id === 'm-analyst3').allowedUserTags).toEqual([
+      'analyst',
+      'customer',
+      'developer',
+    ]);
+  });
+
+  it('leaves customer-less gates alone (deliberate restriction never seen by baseline users)', async () => {
+    // The key safety property: a model an operator restricted to developers-only (customer
+    // removed) must NOT become public - on B4M prod or a self-host install.
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [
+        { id: 'm-devonly', enabled: true, allowedUserTags: ['developer'] },
+        { id: 'm-analystdev', enabled: true, allowedUserTags: ['analyst', 'developer'] },
+        { id: 'm-optionly', enabled: true, allowedUserTags: ['opti'] },
+      ],
+    });
+
+    await migration.up();
+
+    // None contain `customer` -> nothing matched -> no write at all.
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('leaves custom tags, existing entitlements, and empty tags untouched', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [
+        { id: 'm-custom', enabled: true, allowedUserTags: ['customer', 'contractor'] }, // custom tag alongside customer
+        {
+          id: 'm-ent',
+          enabled: true,
+          allowedUserTags: ['customer', 'developer'],
+          allowedEntitlements: ['medlib:pro'], // real entitlement gate - never made public
+        },
+        { id: 'm-empty', enabled: true, allowedUserTags: [] }, // genuinely ungated (fail-closed) - left alone
+      ],
+    });
+
+    await migration.up();
+
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent - configs already carrying base (from the first pass) are skipped', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [
+        {
+          id: 'm',
+          enabled: true,
+          allowedUserTags: ['analyst', 'customer', 'developer', 'opti'],
+          allowedEntitlements: ['base'],
+        },
+      ],
+    });
+
+    await migration.up();
+
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('adds base to a disabled customer-bearing seed (enabled still gates visibility)', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [{ id: 'm-off', enabled: false, allowedUserTags: ['customer', 'developer'] }],
+    });
+
+    await migration.up();
+
+    expect(writtenConfigs().find((c: any) => c.id === 'm-off').allowedEntitlements).toEqual(['base']);
+  });
+
+  it('no-ops when the settings doc is absent', async () => {
+    mockFindOne.mockResolvedValue(null);
+
+    await migration.up();
+
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('down removes base only from customer-bearing seeds it created', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'doc1',
+      settingValue: [
+        { id: 'm-seed', enabled: true, allowedUserTags: ['customer', 'developer'], allowedEntitlements: ['base'] },
+        { id: 'm-public', enabled: true, allowedUserTags: [], allowedEntitlements: ['base'] },
+        { id: 'm-devonly', enabled: true, allowedUserTags: ['developer'], allowedEntitlements: ['base'] },
+      ],
+    });
+
+    await migration.down();
+
+    const configs = writtenConfigs();
+    expect(configs.find((c: any) => c.id === 'm-seed').allowedEntitlements).toBeUndefined();
+    // empty-tag public and customer-less (dev-only) base grants are NOT ours to revert
+    expect(configs.find((c: any) => c.id === 'm-public').allowedEntitlements).toEqual(['base']);
+    expect(configs.find((c: any) => c.id === 'm-devonly').allowedEntitlements).toEqual(['base']);
+  });
+});

--- a/packages/scripts/migrate/migrations/20260710160000_base-entitlement-cover-drifted-seed-configs.ts
+++ b/packages/scripts/migrate/migrations/20260710160000_base-entitlement-cover-drifted-seed-configs.ts
@@ -1,0 +1,127 @@
+import { AdminSettings } from '@bike4mind/database';
+import { type MigrationFile } from './index';
+
+/**
+ * Migration: extend the reserved `base` entitlement to default-seed LLM model configs
+ * whose `allowedUserTags` DRIFTED away from the exact seed sets the first pass matched -
+ * WITHOUT opening any model a baseline user could not already see.
+ *
+ * Background: `20260709130000_base-entitlement-on-default-models` granted `base` only to
+ * configs whose tag set was EXACTLY `{developer,customer,opti}` or
+ * `{analyst,customer,developer,opti}`. That covered environments seeded with the current
+ * default, but long-lived installs accumulated configs seeded by OLDER generations of
+ * `getDefaultModelConfig` (before `opti` was added, while `analyst` still existed) - e.g.
+ * `{analyst,customer,developer}`, `{customer,developer}`, `{customer}`. None matched the
+ * exact-seed guard, so those models stayed tag-only gated and remained invisible to
+ * tag-less (OAuth/SSO/admin-created) accounts even after the fix shipped.
+ *
+ * Match rule - anchored on `customer`, the historical "everyone" baseline tag. Every
+ * `getDefaultModelConfig` seed has always included `customer`, so a config that still
+ * carries `customer` (alongside only other predefined tags) is a drifted default seen by
+ * baseline users; a config from which `customer` was REMOVED (e.g. `{developer}` only) is a
+ * deliberate operator restriction that baseline users never saw. Grant `base` iff:
+ *   (a) NO existing `allowedEntitlements` (empty/absent), AND
+ *   (b) `allowedUserTags` is NON-EMPTY, contains `customer`, and every tag is in the
+ *       predefined "audience" universe {analyst, customer, developer, opti}.
+ * This makes a tag-less account see exactly what a baseline `customer`-tagged user already
+ * sees - no more. A `{developer}`-only (or otherwise customer-less) gate, a custom tag, or
+ * an existing entitlement gate is left untouched, so no deliberately restricted model - on
+ * B4M prod OR a self-host install - is ever made public by this migration.
+ *
+ * ADDITIVE and deploy-safe: `base` is ADDED, `allowedUserTags` is KEPT, so tag-holders are
+ * unaffected and no permissive value the old code relied on is removed. Idempotent: a config
+ * that already carries any entitlement (including the `['base']` from the first pass) is
+ * skipped, so a re-run is a no-op. Fresh installs need no migration - the code default
+ * (`getDefaultModelConfig`) already seeds `allowedEntitlements: ['base']`.
+ *
+ * Superset note: this pass re-covers the first pass's matches (both exact seed sets contain
+ * `customer`), but those already carry `['base']` and are skipped by the entitlement guard,
+ * so there is no double-write.
+ */
+
+const BASE_ENTITLEMENT_KEY = 'base'; // keep in sync with apps/client/lib/entitlements/registry.ts
+const BASELINE_TAG = 'customer'; // the historical "everyone" tag every default seed carried
+
+// Historical `getDefaultModelConfig` "audience" tag universe (lowercased). `analyst` is
+// included because pre-2026-07-08 seeds carried it; `opti` because current seeds do.
+const PREDEFINED_AUDIENCE_TAGS: ReadonlySet<string> = new Set(['analyst', 'customer', 'developer', 'opti']);
+
+const normalizeTagSet = (tags: unknown): Set<string> | null => {
+  if (!Array.isArray(tags)) return null;
+  return new Set(tags.map(tag => String(tag).trim().toLowerCase()).filter(tag => tag.length > 0));
+};
+
+// True iff tags is a drifted default seed: non-empty, contains the baseline `customer` tag,
+// and draws only from the predefined audience universe (no custom tag). A customer-less set
+// (e.g. `{developer}`) is a deliberate restriction and returns false.
+const isBaselineCustomerSeed = (tags: unknown): boolean => {
+  const set = normalizeTagSet(tags);
+  if (!set || set.size === 0 || !set.has(BASELINE_TAG)) return false;
+  return [...set].every(tag => PREDEFINED_AUDIENCE_TAGS.has(tag));
+};
+
+const hasNonEmptyEntitlements = (entry: { allowedEntitlements?: unknown }): boolean =>
+  Array.isArray(entry.allowedEntitlements) && entry.allowedEntitlements.length > 0;
+
+const migration: MigrationFile = {
+  id: 20260710160000,
+  name: 'base-entitlement-cover-drifted-seed-configs',
+
+  up: async () => {
+    const setting = await AdminSettings.findOne({ settingName: 'llmModelConfigurations' });
+    if (!setting) {
+      console.log('[base-entitlement-cover-drifted-seed-configs] no llmModelConfigurations doc - nothing to do');
+      return;
+    }
+
+    const configs = setting.settingValue;
+    if (!Array.isArray(configs)) {
+      console.log('[base-entitlement-cover-drifted-seed-configs] settingValue is not an array - nothing to do');
+      return;
+    }
+
+    let matched = 0;
+    for (const entry of configs) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (hasNonEmptyEntitlements(entry)) continue; // entitlement gate or already migrated - never touch
+      if (!isBaselineCustomerSeed(entry.allowedUserTags)) continue; // customer-less / custom / empty - leave as-is
+      entry.allowedEntitlements = [BASE_ENTITLEMENT_KEY]; // keep allowedUserTags (deploy-safe, additive)
+      matched++;
+    }
+
+    console.log(
+      `[base-entitlement-cover-drifted-seed-configs] ${configs.length} configs total, ${matched} drifted default-seed configs granted '${BASE_ENTITLEMENT_KEY}'`
+    );
+
+    if (matched > 0) {
+      await AdminSettings.updateOne({ _id: setting._id }, { settingValue: configs });
+    }
+  },
+
+  down: async () => {
+    const setting = await AdminSettings.findOne({ settingName: 'llmModelConfigurations' });
+    if (!setting || !Array.isArray(setting.settingValue)) return;
+
+    const configs = setting.settingValue;
+    let reverted = 0;
+    for (const entry of configs) {
+      if (!entry || typeof entry !== 'object') continue;
+      // Reverse only what up() created: a baseline-customer seed whose entitlements are
+      // exactly ['base']. Leaves genuinely entitlement-gated configs untouched. This also
+      // reverts the first pass's writes for configs in this superset, which is acceptable -
+      // both passes express the same "default seed -> base" intent.
+      const ents = entry.allowedEntitlements;
+      const isExactlyBase = Array.isArray(ents) && ents.length === 1 && ents[0] === BASE_ENTITLEMENT_KEY;
+      if (isExactlyBase && isBaselineCustomerSeed(entry.allowedUserTags)) {
+        delete entry.allowedEntitlements;
+        reverted++;
+      }
+    }
+
+    if (reverted > 0) {
+      await AdminSettings.updateOne({ _id: setting._id }, { settingValue: configs });
+    }
+  },
+};
+
+export default migration;

--- a/packages/scripts/migrate/migrations/index.ts
+++ b/packages/scripts/migrate/migrations/index.ts
@@ -61,6 +61,7 @@ import BackfillCreditLots from './20260707120000_backfill-credit-lots';
 import AddHasUsablePasswordToUsers from './20260709120000_add-hasusablepassword-to-users';
 import BaseEntitlementOnDefaultModels from './20260709130000_base-entitlement-on-default-models';
 import NullShellAccountPasswords from './20260710120000_null-shell-account-passwords';
+import BaseEntitlementCoverDriftedSeedConfigs from './20260710160000_base-entitlement-cover-drifted-seed-configs';
 
 export interface MigrationFile {
   id: number;
@@ -125,4 +126,5 @@ export const AvailableMigrations: MigrationFile[] = [
   AddHasUsablePasswordToUsers,
   BaseEntitlementOnDefaultModels,
   NullShellAccountPasswords,
+  BaseEntitlementCoverDriftedSeedConfigs,
 ];


### PR DESCRIPTION
## What & why

Follow-up to #389. That fix added the reserved `base` entitlement to model configs whose `allowedUserTags` was *exactly* `{developer,customer,opti}` or the legacy `{analyst,customer,developer,opti}`. Long-lived installs, however, accumulated configs seeded by **older** `getDefaultModelConfig` generations (pre-`opti`, `analyst`-era) whose tag sets don't match those exact seeds. Those base models kept tag-only gating and stayed invisible to tag-less (OAuth/SSO/admin-created) accounts even after #389 shipped. A freshly-seeded preview couldn't surface this because its configs were all current-seed.

## The rule (customer-anchored, fail-safe)

Grant `base` to a config **iff**:
- it has **no** existing `allowedEntitlements` (empty/absent), **and**
- its `allowedUserTags` is **non-empty**, **contains `customer`**, and draws **only** from the predefined audience universe `{analyst,customer,developer,opti}`.

`customer` was the historical "everyone" baseline tag present in every default seed, so its presence marks a drifted default; a config from which `customer` was removed (e.g. `developer`-only) is a **deliberate operator restriction** and is left untouched. Net effect: a tag-less account sees exactly what a baseline `customer`-tagged user already sees - no more.

### Left untouched (never opened)
- customer-less gates (`developer`-only, `analyst,developer`) - deliberate restrictions, including on self-host installs
- configs with a custom (non-predefined) tag
- configs with an existing entitlement gate
- empty-tag (genuinely ungated / fail-closed) configs

## Safety
- **Additive**: adds `base`, keeps `allowedUserTags`; tag-holders unaffected; removes no permissive value the old code relied on (safe across the deploy window).
- **Idempotent**: skips any config already carrying an entitlement (including the `['base']` from #389), so a re-run is a no-op and it composes cleanly on top of #389.
- **Fresh installs need no migration** - the code default (`getDefaultModelConfig`) already seeds `allowedEntitlements: ['base']`.

## Testing
- New unit suite (7 cases): customer-bearing drift gets `base`; customer-less/custom/entitled/empty left alone; disabled seed still tagged (visibility still gated by `enabled`); idempotent; `down` reverts only its own writes.
- `pnpm --filter @bike4mind/scripts typecheck` clean; full migrate suite (27 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)