### PR TITLE
fix(client): break the /login <-> /accept-policies terms-gate deadlock

### DIFF
--- a/apps/client/app/components/MultiStepLogin.tsx
+++ b/apps/client/app/components/MultiStepLogin.tsx
@@ -129,13 +129,17 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
     },
   };
 
-  // Redirect if already logged in
+  // Redirect away from /login only for a LIVE session: currentUser AND a present access token.
+  // A persisted currentUser can outlive its token; redirecting on the stale value alone bounces a
+  // dead session back into the app -> consent guard -> /accept-policies -> /login loop (see
+  // shouldRedirectToConsent). A user with a stale currentUser but no token must stay here to sign in.
+  const liveAccessToken = useAccessToken(s => s.accessToken);
   useEffect(() => {
-    if (currentUser) {
+    if (currentUser && liveAccessToken) {
       const searchParams = new URLSearchParams(window.location.search);
       applyRedirect(router.history, searchParams.get('redirectTo'), '/new', true);
     }
-  }, [currentUser, router]);
+  }, [currentUser, liveAccessToken, router]);
 
   // Surface SSO/OAuth failures
   useEffect(() => {

--- a/apps/client/app/router.tsx
+++ b/apps/client/app/router.tsx
@@ -12,6 +12,7 @@ import { TanStackRouterDevtools } from '@tanstack/router-devtools';
 import { CircularProgress, Box, Typography } from '@mui/joy';
 import NotebookLayout from '@client/app/components/layouts/Notebook';
 import { useUser } from '@client/app/contexts/UserContext';
+import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import { buildRedirectTo, shouldRedirectToConsent } from '@client/app/utils/authRedirect';
 
 // Keep layout components as eager imports for optimal performance
@@ -174,6 +175,7 @@ const layoutRoute = createRoute({
   id: 'layout',
   beforeLoad: ({ location }) => {
     const { currentUser, isHydrated } = useUser.getState();
+    const { accessToken } = useAccessToken.getState();
     if (!currentUser) {
       const redirectTo = buildRedirectTo(
         location.pathname,
@@ -192,7 +194,7 @@ const layoutRoute = createRoute({
     // smooth redirect. Gated on `isHydrated` so a rehydrated pre-deploy session (whose persisted
     // user stub predates `aupAcceptedVersion`) does not flash the interstitial before /api/identify
     // refetches the server-authoritative value - see shouldRedirectToConsent.
-    if (shouldRedirectToConsent({ currentUser, isHydrated })) {
+    if (shouldRedirectToConsent({ currentUser, isHydrated, hasLiveSession: !!accessToken })) {
       const redirectTo = buildRedirectTo(
         location.pathname,
         location.searchStr,

--- a/apps/client/app/utils/authRedirect.test.ts
+++ b/apps/client/app/utils/authRedirect.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { shouldRedirectToConsent } from './authRedirect';
+
+describe('shouldRedirectToConsent', () => {
+  const unconsented = { aupAcceptedVersion: undefined };
+  const consented = { aupAcceptedVersion: 'v1' };
+
+  it('redirects an authenticated, hydrated, unconsented user WITH a live session', () => {
+    expect(shouldRedirectToConsent({ currentUser: unconsented, isHydrated: true, hasLiveSession: true })).toBe(true);
+  });
+
+  it('does NOT redirect when there is no live session (the /login <-> /accept-policies trap fix)', () => {
+    // Stale currentUser persisted past its token: must go to /login, never to the consent gate,
+    // which cannot record acceptance without a live authenticated request.
+    expect(shouldRedirectToConsent({ currentUser: unconsented, isHydrated: true, hasLiveSession: false })).toBe(false);
+  });
+
+  it('does NOT redirect a consented user even with a live session', () => {
+    expect(shouldRedirectToConsent({ currentUser: consented, isHydrated: true, hasLiveSession: true })).toBe(false);
+  });
+
+  it('does NOT redirect when there is no currentUser', () => {
+    expect(shouldRedirectToConsent({ currentUser: null, isHydrated: true, hasLiveSession: true })).toBe(false);
+  });
+
+  it('does NOT redirect before hydration (avoids the pre-identify interstitial flash)', () => {
+    expect(shouldRedirectToConsent({ currentUser: unconsented, isHydrated: false, hasLiveSession: true })).toBe(false);
+  });
+
+  it('requires ALL of: live session, currentUser, hydrated, unconsented', () => {
+    // No single condition is sufficient on its own.
+    expect(shouldRedirectToConsent({ currentUser: unconsented, isHydrated: false, hasLiveSession: false })).toBe(false);
+  });
+});

--- a/apps/client/app/utils/authRedirect.ts
+++ b/apps/client/app/utils/authRedirect.ts
@@ -121,8 +121,17 @@ export function applyRedirect(
 export function shouldRedirectToConsent(params: {
   currentUser: { aupAcceptedVersion?: unknown } | null;
   isHydrated: boolean;
+  /**
+   * Whether there is a LIVE session (a present access token). Required because a persisted
+   * `currentUser` outlives its access token: without this gate, a stale-but-unconsented user
+   * whose session is gone is still sent to `/accept-policies`, which cannot record acceptance
+   * without an authenticated request (401), while `/login` bounces back on the same stale
+   * `currentUser` - an infinite `/login` <-> `/accept-policies` loop with no exit. A user with no
+   * live session must go to `/login` to re-authenticate, never to the consent gate.
+   */
+  hasLiveSession: boolean;
 }): boolean {
-  return !!params.currentUser && params.isHydrated && !params.currentUser.aupAcceptedVersion;
+  return params.hasLiveSession && !!params.currentUser && params.isHydrated && !params.currentUser.aupAcceptedVersion;
 }
 
 /**


### PR DESCRIPTION
Closes #386.

## Problem

A user who has not recorded AUP/ToS acceptance and whose client session is no longer live gets trapped: they can neither accept policies nor log in. The layout guard and `MultiStepLogin` both bounce between `/login` and `/accept-policies` with no exit. Surfaces on localhost/self-host and for any pre-existing session after the terms gate shipped.

## Root cause

A persisted `currentUser` acts as a false "authenticated" signal that **outlives its access token**. Both the layout `beforeLoad` guard (`shouldRedirectToConsent`) and `MultiStepLogin`'s auto-redirect trusted `currentUser` presence, so a stale-but-unconsented user with a dead session was sent to `/accept-policies` (which needs a live authenticated request to record acceptance -> 401), while `/login` bounced them straight back -> infinite loop.

## Fix

Gate both redirects on a **live session** (a present access token), not on stale `currentUser`:

- `shouldRedirectToConsent(...)` now requires `hasLiveSession`; the layout guard passes `!!accessToken`.
- `MultiStepLogin` only auto-redirects away from `/login` when `currentUser` **and** a live access token are present.

A user with no live session now lands on `/login` to re-authenticate; the consent gate only fires for a genuinely authenticated session (which can actually accept). The real new-OAuth/SAML-user gate is unchanged.

## Verification

- **Unit:** 6/6 new tests on `shouldRedirectToConsent` (live-session gating).
- **End-to-end (Playwright on localhost:3001):** build healthy, zero console errors; `/` and `/accept-policies` with no session resolve to `/login`; a **stale unconsented `currentUser` with no token now stays on `/login`** instead of bouncing to `/accept-policies` (loop broken). A full authenticated login was not driven (no credentials); the reporter's own stuck tab is the last-mile confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKLJThe7Cqxdg8nFPtsUoP