### PR TITLE
fix(client): hide credit UI when enforceCredits is off

### DIFF
--- a/apps/client/app/components/Session/AgentExecution/CreditCounter.test.tsx
+++ b/apps/client/app/components/Session/AgentExecution/CreditCounter.test.tsx
@@ -6,6 +6,7 @@ import { getThemeConfig } from '@client/app/utils/themes';
 
 const mocks = vi.hoisted(() => ({
   totalCreditsUsed: undefined as number | undefined,
+  enforceCredits: true as unknown,
 }));
 
 vi.mock('@client/app/stores/useAgentExecutionStore', () => {
@@ -13,6 +14,10 @@ vi.mock('@client/app/stores/useAgentExecutionStore', () => {
   const useAgentExecutionStore = (selector: (s: unknown) => unknown) => selector({});
   return { useAgentExecutionStore, selectExecution };
 });
+
+vi.mock('@client/app/hooks/data/settings', () => ({
+  useGetSettingsValue: () => mocks.enforceCredits,
+}));
 
 import CreditCounter from './CreditCounter';
 
@@ -26,6 +31,7 @@ const EXECUTION_ID = 'exec-credit-1';
 describe('CreditCounter', () => {
   beforeEach(() => {
     mocks.totalCreditsUsed = undefined;
+    mocks.enforceCredits = true;
   });
 
   it('renders null when execution is missing from the store', () => {
@@ -56,5 +62,27 @@ describe('CreditCounter', () => {
       </TestWrapper>
     );
     expect(screen.getByText('1,235 credits')).toBeInTheDocument();
+  });
+
+  it('renders null when enforceCredits is off, even mid-run', () => {
+    mocks.enforceCredits = false;
+    mocks.totalCreditsUsed = 42;
+    const { container } = render(
+      <TestWrapper>
+        <CreditCounter executionId={EXECUTION_ID} />
+      </TestWrapper>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders null when enforceCredits is undefined (settings still resolving)', () => {
+    mocks.enforceCredits = undefined;
+    mocks.totalCreditsUsed = 42;
+    const { container } = render(
+      <TestWrapper>
+        <CreditCounter executionId={EXECUTION_ID} />
+      </TestWrapper>
+    );
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/apps/client/app/components/Session/AgentExecution/CreditCounter.tsx
+++ b/apps/client/app/components/Session/AgentExecution/CreditCounter.tsx
@@ -16,6 +16,7 @@
 import { FC } from 'react';
 import { Chip } from '@mui/joy';
 import { useAgentExecutionStore, selectExecution } from '@client/app/stores/useAgentExecutionStore';
+import { useGetSettingsValue } from '@client/app/hooks/data/settings';
 
 interface CreditCounterProps {
   executionId: string;
@@ -30,7 +31,11 @@ function formatCredits(credits: number): string {
 }
 
 const CreditCounter: FC<CreditCounterProps> = ({ executionId }) => {
+  const enforceCredits = !!useGetSettingsValue('enforceCredits');
   const totalCreditsUsed = useAgentExecutionStore(state => selectExecution(executionId)(state)?.totalCreditsUsed);
+
+  // Nothing decrements while enforcement is off, so a running tally would be cosmetic.
+  if (!enforceCredits) return null;
 
   // `undefined` only when the execution isn't in the store yet; once it's
   // there the field is 0+. Hide on undefined; show even at 0 so the user

--- a/apps/client/app/components/Session/MessageContent.gating.test.tsx
+++ b/apps/client/app/components/Session/MessageContent.gating.test.tsx
@@ -15,11 +15,16 @@ import type { IChatHistoryItem } from '@bike4mind/common';
  * mocked to a stub so the test exercises only the real menu markup.
  */
 
+const mocks = vi.hoisted(() => ({
+  showCreditsUsed: true,
+  serverSettings: [] as Array<{ settingName: string; settingValue: unknown }>,
+}));
+
 // --- context / data hooks -------------------------------------------------
 vi.mock('@client/app/contexts/UserContext', () => ({
   // organizationId is the org the server (checkScopePermission) will accept a Team publish for;
   // the Team option is gated on the selected org matching it.
-  useUser: () => ({ currentUser: { id: 'user-1', organizationId: 'org_42' } }),
+  useUser: () => ({ currentUser: { id: 'user-1', organizationId: 'org_42', showCreditsUsed: mocks.showCreditsUsed } }),
 }));
 vi.mock('@client/app/contexts/SessionsContext', () => ({
   useSessions: () => ({ currentSession: null, setCurrentSession: vi.fn() }),
@@ -48,7 +53,7 @@ vi.mock('@client/app/hooks/data/useModelInfo', () => ({
   useModelInfo: () => ({ data: [] }),
 }));
 vi.mock('@client/app/hooks/data/settings', () => ({
-  useSettingsFromServer: () => ({ data: [] }),
+  useSettingsFromServer: () => ({ data: mocks.serverSettings }),
 }));
 // Capturable across renders so the share-wiring tests can assert the exact options
 // handleShareReply passes (esp. whether orgOption is supplied).
@@ -128,12 +133,12 @@ const messageData = {
   status: 'done',
 } as unknown as IChatHistoryItem;
 
-function renderAndOpenActionsMenu() {
+function renderMessageContent(data: IChatHistoryItem = messageData) {
   render(
     <TestWrapper>
       <MessageContent
         sessionId="session-1"
-        messageData={messageData}
+        messageData={data}
         index={0}
         onDelete={vi.fn()}
         onPinToggle={vi.fn()}
@@ -145,8 +150,17 @@ function renderAndOpenActionsMenu() {
       />
     </TestWrapper>
   );
+}
+
+function renderAndOpenActionsMenu() {
+  renderMessageContent();
   fireEvent.click(screen.getByTestId('message-actions-menu-btn'));
 }
+
+beforeEach(() => {
+  mocks.showCreditsUsed = true;
+  mocks.serverSettings = [];
+});
 
 describe('MessageContent actions menu - EnableDataLakes gating', () => {
   beforeEach(() => {
@@ -237,5 +251,38 @@ describe('MessageContent share reply - org (Team) visibility wiring', () => {
     await waitFor(() => expect(publishAndShareSpy).toHaveBeenCalledTimes(1));
     expect(publishAndShareSpy.mock.calls[0][0].orgOption).toBeUndefined();
     expect(replyPublisherMock).toHaveBeenCalledWith(expect.objectContaining({ orgId: undefined }));
+  });
+});
+
+describe('MessageContent per-message credits-used chip - enforceCredits gating', () => {
+  // Regression coverage: nothing decrements while enforceCredits is off, so the chip
+  // must stay hidden even when the user has opted in and the message carries a value.
+  const creditsMessageData = { ...messageData, creditsUsed: 42 } as unknown as IChatHistoryItem;
+
+  it('shows the chip when enforcement is on and the user opted in', () => {
+    mocks.serverSettings = [{ settingName: 'enforceCredits', settingValue: true }];
+    mocks.showCreditsUsed = true;
+
+    renderMessageContent(creditsMessageData);
+
+    expect(screen.getByTestId('credits-used')).toBeInTheDocument();
+  });
+
+  it('hides the chip when enforceCredits is off, even with a credits value present', () => {
+    mocks.serverSettings = [{ settingName: 'enforceCredits', settingValue: false }];
+    mocks.showCreditsUsed = true;
+
+    renderMessageContent(creditsMessageData);
+
+    expect(screen.queryByTestId('credits-used')).not.toBeInTheDocument();
+  });
+
+  it('hides the chip when the enforceCredits setting is unset (self-host default)', () => {
+    mocks.serverSettings = [];
+    mocks.showCreditsUsed = true;
+
+    renderMessageContent(creditsMessageData);
+
+    expect(screen.queryByTestId('credits-used')).not.toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.test.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { AccountCard } from './ProfileMenu';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+describe('ProfileMenu AccountCard - enforceCredits gating', () => {
+  it('shows the credit balance chip when showCredits is true', () => {
+    render(
+      <TestWrapper>
+        <AccountCard name="Jane" typeLabel={null} credits={1234} selected onSelect={vi.fn()} showCredits />
+      </TestWrapper>
+    );
+
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+  });
+
+  it('hides the credit balance chip when showCredits is false (enforceCredits off)', () => {
+    render(
+      <TestWrapper>
+        <AccountCard name="Jane" typeLabel={null} credits={1234} selected onSelect={vi.fn()} showCredits={false} />
+      </TestWrapper>
+    );
+
+    expect(screen.queryByText('1,234')).not.toBeInTheDocument();
+    // The rest of the card still renders - only the balance disappears.
+    expect(screen.getByText('Jane')).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -114,10 +114,12 @@ type AccountCardProps = {
   onSelect: () => void;
   // Sole account (no team/other accounts to switch to): hide the radio, it's not a choice.
   bare?: boolean;
+  // Nothing decrements while enforceCredits is off, so the balance is misleading - hide it.
+  showCredits: boolean;
 };
 
 /** Account switcher card (Personal / Team) shown at the top of the expanded profile menu. */
-const AccountCard = ({ name, typeLabel, credits, selected, onSelect, bare }: AccountCardProps) => (
+export const AccountCard = ({ name, typeLabel, credits, selected, onSelect, bare, showCredits }: AccountCardProps) => (
   <Box
     data-testid="profile-account-option"
     onClick={onSelect}
@@ -167,23 +169,25 @@ const AccountCard = ({ name, typeLabel, credits, selected, onSelect, bare }: Acc
         />
       )}
     </Box>
-    <Chip
-      size="sm"
-      variant="plain"
-      startDecorator={<Bike4MindIcon size="12" />}
-      sx={theme => ({
-        alignSelf: 'flex-start',
-        backgroundColor: 'transparent',
-        border: 'none',
-        px: 0,
-        fontSize: '13px',
-        gap: '6px',
-        // Bike4MindIcon fills with var(--Icon-color); tint it tertiary.
-        '--Icon-color': theme.palette.text.tertiary,
-      })}
-    >
-      {credits.toLocaleString()}
-    </Chip>
+    {showCredits && (
+      <Chip
+        size="sm"
+        variant="plain"
+        startDecorator={<Bike4MindIcon size="12" />}
+        sx={theme => ({
+          alignSelf: 'flex-start',
+          backgroundColor: 'transparent',
+          border: 'none',
+          px: 0,
+          fontSize: '13px',
+          gap: '6px',
+          // Bike4MindIcon fills with var(--Icon-color); tint it tertiary.
+          '--Icon-color': theme.palette.text.tertiary,
+        })}
+      >
+        {credits.toLocaleString()}
+      </Chip>
+    )}
   </Box>
 );
 
@@ -213,7 +217,7 @@ const ProfileMenu = () => {
   // filterVisiblePremiumNavItems - see its doc comment and unit tests.
   const { data: entitlements } = useEntitlements();
   const visiblePremiumNavItems = filterVisiblePremiumNavItems(premiumNavItems, entitlements, currentUser?.tags);
-  const isCreditsEnabled = useGetSettingsValue('enforceCredits');
+  const isCreditsEnabled = !!useGetSettingsValue('enforceCredits');
 
   const { setOpen: setInboxOpen } = useInbox.getState();
   const toggleReferralModal = useReferralModal(s => s.toggle);
@@ -301,6 +305,7 @@ const ProfileMenu = () => {
                 selected={selectedAccount?.id === account.id}
                 onSelect={() => setSelectedAccount(account)}
                 bare={accounts.length === 1}
+                showCredits={isCreditsEnabled}
               />
             ))}
           </Stack>


### PR DESCRIPTION
## Summary
When the `enforceCredits` admin setting is off, nothing decrements a credit balance and no ledger entry is written, so the previously-shown credit numbers on chat surfaces were misleading. This hides them entirely (no relabel/badge) while leaving usage recording untouched.

- Account-switcher balance chip (`AccountCard`) now takes a required `showCredits` prop; `ProfileMenu` passes `!!useGetSettingsValue('enforceCredits')` and the chip only renders when true.
- `CreditCounter` (live agent-run credit counter) self-gates with the same `!!useGetSettingsValue('enforceCredits')` check and returns `null` when off.
- Per-message "credits used" chip in `MessageContent` was already gated correctly on `adminSettings.enforceCredits`; added a regression test locking that behavior in.

Server-side usage recording (`UsageEvent`) and all credit reservation/settlement logic are untouched - this is a client display-only change.

Fixes https://github.com/Bike4Mind/bike4mind/issues/435

## Test plan
- [x] `pnpm turbo:typecheck` green
- [x] `pnpm --filter @bike4mind/client test` green (5369 passed / 81 skipped / 0 failed)
- [x] `pnpm lint:check` green
- [x] Extended `CreditCounter.test.tsx`, added `ProfileMenu.test.tsx` coverage for `AccountCard`, and extended `MessageContent.gating.test.tsx` - all assert the credit surfaces render when `enforceCredits` is on and are absent when off/undefined