### PR TITLE
fix(e2e): dismiss GenericModal whats-new announcement in dismissModals

### DIFF
--- a/apps/client/e2e/pages/BasePage.ts
+++ b/apps/client/e2e/pages/BasePage.ts
@@ -38,7 +38,15 @@ export class BasePage {
   }
 
   async handleWhatsNewModal() {
-    const closeBtn = this.page.getByTestId('whats-new-slider-modal-close-btn-icon-container');
+    // The whats-new announcement renders as one of two variants once the app has fetched
+    // announcements: the multi-slide "slider" modal, or a single-card GenericModal (e.g. an
+    // "Announcement" broadcast). ModalManager shows at most one, never both. Dismiss whichever
+    // appears - either blocks the whole app behind a backdrop that intercepts pointer events, so
+    // a live announcement on the target env would otherwise fail every click/hover after it mounts.
+    const closeBtn = this.page
+      .getByTestId('whats-new-slider-modal-close-btn-icon-container')
+      .or(this.page.getByTestId('generic-modal-close-button-icon-container'))
+      .first();
     // The modal renders asynchronously after fetching announcements -
     // give it a brief window to appear before deciding it won't show.
     const appeared = await closeBtn


### PR DESCRIPTION
## What

`handleWhatsNewModal()` (called by `dismissModals()` on every page entry) now dismisses the whats-new announcement in **either** of its two rendered forms, not just one.

## Why

The whats-new feature renders as one of two variants once the app has fetched announcements: the multi-slide **slider** modal, or a single-card **GenericModal** (e.g. an "Announcement" broadcast). `ModalManager` shows at most one, never both. The harness only knew the slider variant (`whats-new-slider-modal-close-btn-icon-container`). When the GenericModal variant was live on the target env, the handler waited out the full 10s timeout for a slider that never appears, gave up, and left the announcement on screen. Its MUI backdrop intercepts pointer events, so every click/hover after it mounts silently fails.

This was the sole root cause of 4 feature specs failing on staging (`projects`, `agents`, `skills`, `profile`). Each stalled waiting to click/hover an element that Playwright itself reported as *visible, enabled and stable* - it just sat behind the Announcement backdrop. Confirmed via the failure DOM (`<h2>📣 Announcement</h2> ... intercepts pointer events`) and screenshot, and reproduced at `--workers=1` (so it was not worker contention, and the `data-testid`s all still exist, so not selector drift).

## How

Race both close buttons via `.or()` and click whichever becomes visible - the slider close or the `generic-modal-close-button-icon-container`. Cost-neutral: still a single bounded `waitFor`, and it resolves as soon as either appears.

## Testing

Against staging (`app.staging.bike4mind.com`), single worker, retries off:

- Before: `projects` + `profile` = **2 failed, 6 passed, 2 did not run**
- After: **10 passed, 0 failed, 0 flaky**

This unblocks seeding a green `e2e/smoke` (the last real blocker before `REQUIRE_E2E=true` can be flipped). Pairs with the setup-flake commit-status fix in the companion PR.
