### PR TITLE
feat(publish): lead-gen livery on shared & embedded artifacts

### DIFF
--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -604,7 +604,9 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
   // the app root (the viewer is already on the canonical page). The bar only renders
   // for an own-tab open-public artifact.
   const marketing = (medium: string) =>
-    WEBSITE_URL ? `${WEBSITE_URL}/?utm_source=shared-artifact&utm_medium=${medium}&utm_campaign=publish` : '';
+    WEBSITE_URL
+      ? `${WEBSITE_URL.replace(/\/+$/, '')}/?utm_source=shared-artifact&utm_medium=${medium}&utm_campaign=publish`
+      : '';
   const pillHref = isEmbed ? marketing('embed-badge') || `${docOrigin}${canonicalPath}` : '';
   const barHref = !isEmbed && isOpenPublic ? marketing('share-bar') || `${docOrigin}/` : '';
   const wrapperPage = renderBundleWrapper(
@@ -627,6 +629,12 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
   bumpViewCount(artifact, req.user as { id?: string } | undefined, req.headers['user-agent']);
   return res.status(200).send(wrapperPage);
 });
+
+// Lead-gen livery palette. Reuses the SAME env knobs as the baked share footer
+// (buildShareFooterHtml), so a fork rebrands the footer and the wrapper pill/bar
+// with one set of vars; defaults are the project palette.
+const LIVERY_NAVY = process.env.NEXT_PUBLIC_SHARE_BRAND_NAVY || '#0d1830';
+const LIVERY_ORANGE = process.env.NEXT_PUBLIC_SHARE_BRAND_ORANGE || '#F26C1F';
 
 /**
  * Minimal trusted wrapper page hosting the bundle in an iframe. Runs no script of
@@ -722,16 +730,16 @@ function renderBundleWrapper(
   color:#cbd5e1;background:rgba(13,24,48,.78);padding:5px 9px;border-radius:8px;text-decoration:none;backdrop-filter:blur(4px)}
 .b4m-report:hover{color:#fff;background:rgba(13,24,48,.95)}
 .b4m-brand{position:fixed;bottom:10px;left:10px;z-index:2147483647;font:600 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
-  color:#fff;background:#F26C1F;padding:6px 11px;border-radius:8px;text-decoration:none;box-shadow:0 2px 10px rgba(0,0,0,.28)}
+  color:#fff;background:${LIVERY_ORANGE};padding:6px 11px;border-radius:8px;text-decoration:none;box-shadow:0 2px 10px rgba(0,0,0,.28)}
 .b4m-brand:hover{filter:brightness(1.07)}
 .b4m-bar{position:fixed;left:0;right:0;bottom:0;height:52px;box-sizing:border-box;z-index:2147483647;display:flex;
-  align-items:center;justify-content:space-between;gap:12px;padding:0 16px;background:#0d1830;color:#e2e8f0;
+  align-items:center;justify-content:space-between;gap:12px;padding:0 16px;background:${LIVERY_NAVY};color:#e2e8f0;
   border-top:1px solid rgba(255,255,255,.12);font:600 13px/1 ui-sans-serif,system-ui,-apple-system,sans-serif}
 .b4m-bar strong{color:#fff}
 .b4m-bar-r{display:flex;align-items:center;gap:14px}
 .b4m-bar-report{color:#94a3b8;text-decoration:none;font-weight:500;font-size:12px}
 .b4m-bar-report:hover{color:#cbd5e1}
-.b4m-bar-cta{padding:8px 14px;border-radius:9px;background:#F26C1F;color:#fff;font-weight:700;text-decoration:none;white-space:nowrap}
+.b4m-bar-cta{padding:8px 14px;border-radius:9px;background:${LIVERY_ORANGE};color:#fff;font-weight:700;text-decoration:none;white-space:nowrap}
 .b4m-bar-cta:hover{filter:brightness(1.07)}
 .b4m-ver{position:fixed;bottom:${barPresent ? '62px' : '10px'};left:10px;z-index:2147483647;display:flex;align-items:center;gap:8px;
   font:500 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;color:#cbd5e1;background:rgba(13,24,48,.78);

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -598,14 +598,15 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
           siteName: process.env.APP_NAME || '',
         })
       : null;
-  // Lead-gen target for the embed badge: the marketing site with UTM attribution
-  // when configured, else the artifact's own canonical page on the app (still a
-  // branded destination). Runtime-derived - no hardcoded brand host.
-  const brandHref = isEmbed
-    ? WEBSITE_URL
-      ? `${WEBSITE_URL}/?utm_source=embedded-artifact&utm_medium=embed-badge&utm_campaign=publish`
-      : `${docOrigin}${canonicalPath}`
-    : '';
+  // Lead-gen targets, both runtime-derived (no hardcoded brand host): the marketing
+  // site with UTM attribution when configured, else a branded fallback. The embed
+  // pill falls back to the artifact's canonical page; the own-tab bar falls back to
+  // the app root (the viewer is already on the canonical page). The bar only renders
+  // for an own-tab open-public artifact.
+  const marketing = (medium: string) =>
+    WEBSITE_URL ? `${WEBSITE_URL}/?utm_source=shared-artifact&utm_medium=${medium}&utm_campaign=publish` : '';
+  const pillHref = isEmbed ? marketing('embed-badge') || `${docOrigin}${canonicalPath}` : '';
+  const barHref = !isEmbed && isOpenPublic ? marketing('share-bar') || `${docOrigin}/` : '';
   const wrapperPage = renderBundleWrapper(
     artifact,
     srcdoc,
@@ -614,8 +615,9 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     shareMeta,
     isShare,
     isEmbed,
-    brandHref,
-    isEmbed ? getBrandName() : ''
+    pillHref,
+    barHref,
+    pillHref || barHref ? getBrandName() : ''
   );
 
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
@@ -644,7 +646,8 @@ function renderBundleWrapper(
   shareMeta: { metaTags: string; noscriptBody: string; alternateLink: string } | null,
   noindex: boolean,
   embed = false,
-  brandHref = '',
+  pillHref = '',
+  barHref = '',
   brandName = ''
 ): string {
   const titleHtml = escapeHtml(artifact.title || SHARED_FALLBACK_TITLE);
@@ -677,39 +680,67 @@ function renderBundleWrapper(
   // overlay) so the widget is just the content. The canonical link back to the
   // real page is already emitted for open-public renders via shareMeta.
   const chromeBody = embed ? '' : `\n${overlay}\n${versionBar}`;
-  // Lead-gen livery for a chrome-less embed: a "Built with {brand}" pill floating
-  // over the framed artifact (top-level link, not blocked by the wrapper CSP). This
-  // is the ONLY brand mark a third-party embed carries - the bundle's own share
-  // footer is baked into the content and absent from externally-built bundles - so
-  // it makes every embed do the powered-by lead-gen job. Embed mode only.
+
+  // Lead-gen livery. The bundle's own "powered-by" footer is baked into the CONTENT
+  // and absent from externally-built bundles, so the wrapper carries brand itself:
+  //   - embed (chrome-less): a small floating "Built with {brand}" pill.
+  //   - own-tab open-public: a persistent bottom bar with a "Try {brand}" CTA
+  //     (Anthropic-style); the iframe is shortened so the bar covers nothing.
+  // Both are top-level links (CSP-safe, no JS). barPresent also relocates the Report
+  // affordance INTO the bar and lifts the version switcher above it.
   const brandBadge =
-    embed && brandHref && brandName
-      ? `\n<a class="b4m-brand" href="${escapeHtml(brandHref)}" rel="noopener" target="_top">Built with ${escapeHtml(
+    embed && pillHref && brandName
+      ? `\n<a class="b4m-brand" href="${escapeHtml(pillHref)}" rel="noopener" target="_top">Built with ${escapeHtml(
           brandName
         )}</a>`
       : '';
+  const barPresent = !embed && !!barHref && !!brandName;
+  const bar = barPresent
+    ? `\n<div class="b4m-bar">
+  <span>Built with <strong>${escapeHtml(brandName)}</strong></span>
+  <span class="b4m-bar-r">
+    <a class="b4m-bar-report" href="${reportHref}" rel="nofollow" target="_top">Report</a>
+    <a class="b4m-bar-cta" href="${escapeHtml(
+      barHref
+    )}" target="_blank" rel="noopener noreferrer">Try ${escapeHtml(brandName)} &rarr;</a>
+  </span>
+</div>`
+    : '';
+  const floatingReport = barPresent
+    ? ''
+    : `\n<a class="b4m-report" href="${reportHref}" rel="nofollow" target="_top">&#9873; Report</a>`;
+  const iframeHeight = barPresent ? 'calc(100vh - 52px)' : '100vh';
+
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">${noindexHead}
 <title>${titleHtml}</title>${metaHead}
-<style>html,body{margin:0;padding:0;height:100%}iframe{border:0;display:block;width:100%;height:100vh}
+<style>html,body{margin:0;padding:0;height:100%}iframe{border:0;display:block;width:100%;height:${iframeHeight}}
 .b4m-report{position:fixed;bottom:10px;right:10px;z-index:2147483647;font:500 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
   color:#cbd5e1;background:rgba(13,24,48,.78);padding:5px 9px;border-radius:8px;text-decoration:none;backdrop-filter:blur(4px)}
 .b4m-report:hover{color:#fff;background:rgba(13,24,48,.95)}
 .b4m-brand{position:fixed;bottom:10px;left:10px;z-index:2147483647;font:600 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
   color:#fff;background:#F26C1F;padding:6px 11px;border-radius:8px;text-decoration:none;box-shadow:0 2px 10px rgba(0,0,0,.28)}
 .b4m-brand:hover{filter:brightness(1.07)}
-.b4m-ver{position:fixed;bottom:10px;left:10px;z-index:2147483647;display:flex;align-items:center;gap:8px;
+.b4m-bar{position:fixed;left:0;right:0;bottom:0;height:52px;box-sizing:border-box;z-index:2147483647;display:flex;
+  align-items:center;justify-content:space-between;gap:12px;padding:0 16px;background:#0d1830;color:#e2e8f0;
+  border-top:1px solid rgba(255,255,255,.12);font:600 13px/1 ui-sans-serif,system-ui,-apple-system,sans-serif}
+.b4m-bar strong{color:#fff}
+.b4m-bar-r{display:flex;align-items:center;gap:14px}
+.b4m-bar-report{color:#94a3b8;text-decoration:none;font-weight:500;font-size:12px}
+.b4m-bar-report:hover{color:#cbd5e1}
+.b4m-bar-cta{padding:8px 14px;border-radius:9px;background:#F26C1F;color:#fff;font-weight:700;text-decoration:none;white-space:nowrap}
+.b4m-bar-cta:hover{filter:brightness(1.07)}
+.b4m-ver{position:fixed;bottom:${barPresent ? '62px' : '10px'};left:10px;z-index:2147483647;display:flex;align-items:center;gap:8px;
   font:500 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;color:#cbd5e1;background:rgba(13,24,48,.78);
   padding:5px 9px;border-radius:8px;backdrop-filter:blur(4px)}
 .b4m-ver a{color:#8ab4ff;text-decoration:none;font-weight:600}
 .b4m-ver .b4m-vd{opacity:.4}</style>
 </head>
 <body>
-${iframeTag}${chromeBody}${brandBadge}
-<a class="b4m-report" href="${reportHref}" rel="nofollow" target="_top">⚑ Report</a>
+${iframeTag}${chromeBody}${brandBadge}${floatingReport}${bar}
 ${noscriptBody}
 </body>
 </html>`;

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -32,6 +32,7 @@ import {
   isAppWrapperHost,
 } from '@server/services/publish/viewerSecurity';
 import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
+import { WEBSITE_URL, getBrandName } from '@client/config/general';
 import type { PublishScopeTier, PublishVisibility } from '@bike4mind/common';
 
 /**
@@ -597,7 +598,25 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
           siteName: process.env.APP_NAME || '',
         })
       : null;
-  const wrapperPage = renderBundleWrapper(artifact, srcdoc, requestedVersion, isolatedSrc, shareMeta, isShare, isEmbed);
+  // Lead-gen target for the embed badge: the marketing site with UTM attribution
+  // when configured, else the artifact's own canonical page on the app (still a
+  // branded destination). Runtime-derived - no hardcoded brand host.
+  const brandHref = isEmbed
+    ? WEBSITE_URL
+      ? `${WEBSITE_URL}/?utm_source=embedded-artifact&utm_medium=embed-badge&utm_campaign=publish`
+      : `${docOrigin}${canonicalPath}`
+    : '';
+  const wrapperPage = renderBundleWrapper(
+    artifact,
+    srcdoc,
+    requestedVersion,
+    isolatedSrc,
+    shareMeta,
+    isShare,
+    isEmbed,
+    brandHref,
+    isEmbed ? getBrandName() : ''
+  );
 
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.setHeader('Content-Security-Policy', buildWrapperCsp(req, isolatedSrc ? artifactHost : '', embedGrants));
@@ -624,7 +643,9 @@ function renderBundleWrapper(
   isolatedSrc: string,
   shareMeta: { metaTags: string; noscriptBody: string; alternateLink: string } | null,
   noindex: boolean,
-  embed = false
+  embed = false,
+  brandHref = '',
+  brandName = ''
 ): string {
   const titleHtml = escapeHtml(artifact.title || SHARED_FALLBACK_TITLE);
   // HTML attribute escape: inside a double-quoted attribute value only `&` and `"` are
@@ -656,6 +677,17 @@ function renderBundleWrapper(
   // overlay) so the widget is just the content. The canonical link back to the
   // real page is already emitted for open-public renders via shareMeta.
   const chromeBody = embed ? '' : `\n${overlay}\n${versionBar}`;
+  // Lead-gen livery for a chrome-less embed: a "Built with {brand}" pill floating
+  // over the framed artifact (top-level link, not blocked by the wrapper CSP). This
+  // is the ONLY brand mark a third-party embed carries - the bundle's own share
+  // footer is baked into the content and absent from externally-built bundles - so
+  // it makes every embed do the powered-by lead-gen job. Embed mode only.
+  const brandBadge =
+    embed && brandHref && brandName
+      ? `\n<a class="b4m-brand" href="${escapeHtml(brandHref)}" rel="noopener" target="_top">Built with ${escapeHtml(
+          brandName
+        )}</a>`
+      : '';
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -666,6 +698,9 @@ function renderBundleWrapper(
 .b4m-report{position:fixed;bottom:10px;right:10px;z-index:2147483647;font:500 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
   color:#cbd5e1;background:rgba(13,24,48,.78);padding:5px 9px;border-radius:8px;text-decoration:none;backdrop-filter:blur(4px)}
 .b4m-report:hover{color:#fff;background:rgba(13,24,48,.95)}
+.b4m-brand{position:fixed;bottom:10px;left:10px;z-index:2147483647;font:600 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
+  color:#fff;background:#F26C1F;padding:6px 11px;border-radius:8px;text-decoration:none;box-shadow:0 2px 10px rgba(0,0,0,.28)}
+.b4m-brand:hover{filter:brightness(1.07)}
 .b4m-ver{position:fixed;bottom:10px;left:10px;z-index:2147483647;display:flex;align-items:center;gap:8px;
   font:500 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;color:#cbd5e1;background:rgba(13,24,48,.78);
   padding:5px 9px;border-radius:8px;backdrop-filter:blur(4px)}
@@ -673,7 +708,7 @@ function renderBundleWrapper(
 .b4m-ver .b4m-vd{opacity:.4}</style>
 </head>
 <body>
-${iframeTag}${chromeBody}
+${iframeTag}${chromeBody}${brandBadge}
 <a class="b4m-report" href="${reportHref}" rel="nofollow" target="_top">⚑ Report</a>
 ${noscriptBody}
 </body>

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -1307,9 +1307,12 @@ describe('GET /api/publish/serve - embed allowlist', () => {
     // Canonical is emitted once by shareMeta (not duplicated by the embed path).
     expect(data.match(/rel="canonical"/g)?.length).toBe(1);
     expect(data).toContain('href="https://app.bike4mind.com/p/u/scope123/my-slug"');
+    // Lead-gen livery: the embed carries a "Built with ..." brand pill linking out.
+    expect(data).toContain('<a class="b4m-brand"');
+    expect(data).toContain('Built with');
   });
 
-  it('normal (non-embed) render keeps the version bar', async () => {
+  it('normal (non-embed) render keeps the version bar and shows no floating brand pill', async () => {
     mockArtifactFindOne.mockReturnValue(
       bundle({ sha256Index: 'newSHA', versions: [{ sha256Index: 'oldSHA' }, { sha256Index: 'newSHA' }] })
     );
@@ -1317,6 +1320,8 @@ describe('GET /api/publish/serve - embed allowlist', () => {
 
     const { res, promise } = run(['u', 'scope123', 'my-slug']);
     await promise;
+    // The brand pill is embed-only (the normal page uses the baked footer + chrome).
+    expect(res._getData() as string).not.toContain('<a class="b4m-brand"');
 
     expect(res._getData() as string).toContain('<div class="b4m-ver">');
   });

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -1307,12 +1307,14 @@ describe('GET /api/publish/serve - embed allowlist', () => {
     // Canonical is emitted once by shareMeta (not duplicated by the embed path).
     expect(data.match(/rel="canonical"/g)?.length).toBe(1);
     expect(data).toContain('href="https://app.bike4mind.com/p/u/scope123/my-slug"');
-    // Lead-gen livery: the embed carries a "Built with ..." brand pill linking out.
+    // Lead-gen livery: the embed carries a "Built with ..." brand pill linking out,
+    // and NOT the persistent bottom bar (that's the own-tab treatment).
     expect(data).toContain('<a class="b4m-brand"');
     expect(data).toContain('Built with');
+    expect(data).not.toContain('<div class="b4m-bar">');
   });
 
-  it('normal (non-embed) render keeps the version bar and shows no floating brand pill', async () => {
+  it('own-tab (non-embed) open-public render shows the persistent lead-gen bar with an in-bar Report', async () => {
     mockArtifactFindOne.mockReturnValue(
       bundle({ sha256Index: 'newSHA', versions: [{ sha256Index: 'oldSHA' }, { sha256Index: 'newSHA' }] })
     );
@@ -1320,9 +1322,16 @@ describe('GET /api/publish/serve - embed allowlist', () => {
 
     const { res, promise } = run(['u', 'scope123', 'my-slug']);
     await promise;
-    // The brand pill is embed-only (the normal page uses the baked footer + chrome).
-    expect(res._getData() as string).not.toContain('<a class="b4m-brand"');
-
-    expect(res._getData() as string).toContain('<div class="b4m-ver">');
+    const data = res._getData() as string;
+    // The persistent bar (Anthropic-style) with a Try CTA; the floating pill is embed-only.
+    expect(data).toContain('<div class="b4m-bar">');
+    expect(data).toContain('class="b4m-bar-cta"');
+    expect(data).toContain('Try');
+    expect(data).not.toContain('<a class="b4m-brand"');
+    // Report moves INTO the bar, so the floating Report anchor is gone.
+    expect(data).toContain('class="b4m-bar-report"');
+    expect(data).not.toContain('<a class="b4m-report"');
+    // Chrome still present (version switcher), lifted above the bar.
+    expect(data).toContain('<div class="b4m-ver">');
   });
 });


### PR DESCRIPTION
## What

Follow-up to #451 (embed allowlist). Shared artifacts carried no reliable brand livery: the "powered by" footer is baked into the **bundle content**, so it's missing on externally-built artifacts and sits below the full-height iframe. This adds wrapper-level lead-gen so **every** shared view is branded, regardless of the bundle.

Two surfaces, two treatments:

- **Standalone shared page (own tab)** — an Anthropic-style **persistent bottom bar**: "Built with {brand}" + a "Try {brand}" CTA. The iframe is shortened so the bar covers nothing; the Report affordance moves into the bar and the version switcher lifts above it.
- **Embedded (`?embed=1`, chrome-less)** — a small **floating "Built with {brand}" pill** (a full bar would eat too much of a small embed).

## Details

- Both are top-level links, **CSP-safe** (plain anchors, no JS).
- Links to the marketing site with UTM attribution when `WEBSITE_URL` is configured; the bar falls back to the app root, the pill to the artifact's canonical page. All runtime-derived - **no hardcoded brand host**.
- **Fork-safe**: uses the configurable `getBrandName()` / `WEBSITE_URL` (renders "Built with the app" when no brand is set).
- Own-tab bar renders only for **open-public** artifacts.

## Tests

Serve-route tests assert: embed carries the pill and not the bar; own-tab open-public carries the bar (with in-bar Report + CTA) and not the pill; version switcher still present. Full serve suite green; tsc / lint / open-core gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011e2ABgTgg2E1jjspHFtXxi