### PR TITLE
fix(e2e): reach agents directly (earned-nav hides the sidenav row)

### DIFF
--- a/apps/client/e2e/agents.spec.ts
+++ b/apps/client/e2e/agents.spec.ts
@@ -18,12 +18,14 @@ test.describe('Agents - Navigation, CRUD & Validation', () => {
     agentsPage,
   }) => {
     test.slow();
-    await test.step('navigate to agents via sidenav', async () => {
-      await page.goto('/');
+    await test.step('navigate to agents', async () => {
+      // Agents is an earned-nav destination (Gears): its sidenav row appears only
+      // once the account has >=1 agent. A fresh run starts with zero (the prior run
+      // deletes the agent it created), so the row is hidden - navigate directly, the
+      // way a first-time user reaches it via the Gears "Build your first agent" CTA.
+      await page.goto('/agents');
       await page.waitForLoadState('domcontentloaded');
       await basePage.dismissModals();
-
-      await page.getByTestId('sidenav-nav-agents').click();
 
       // Verify we landed on the agents page
       await expect(page).toHaveURL(/.*\/agents.*/);


### PR DESCRIPTION
## The failure

The E2E run's `agents.spec.ts` failed at its first step:

```
Error: locator.click: Test timeout of 180000ms exceeded.
  - waiting for getByTestId('sidenav-nav-agents')
```

## Root cause (earned-nav / Gears)

`sidenav-nav-agents` is now an **earned-nav destination**. The sidenav's permanent rail is New Chat / Gears / Help; every other destination (agents, projects, data lakes, files, published) only appears once the account has used it. The unlock is **live-derived** server-side: `agents` shows only when `Agent.exists({ userId })` is true (`pages/api/gears/status.ts`), and the sidenav hides a row when the status endpoint explicitly returns it unearned (`SidenavNav.tsx` `gearOpen`).

The agents test **creates and then deletes** an agent, so each run starts with **zero agents** -> `agents: false` -> the sidenav row is hidden -> the first-step click waits forever. (Projects/files stay green because the shared test account keeps persistent resources across runs; only agents reverts.)

## Fix

Navigate to `/agents` directly - exactly how a first-time user reaches it (the Gears "Build your first agent" CTA, which is a `navigate:/agents`). The rest of the test is unchanged; it creates an agent immediately after, which is what earns the sidenav row in real use.

## Not in scope: the image-generation failure

The same run also failed `image-generation.spec.ts` (`ai-response-image` never visible after 360s). That is **not** a selector regression - the testids still exist in `ImageContainer.tsx` / `PromptReplies.tsx`. The image simply wasn't produced in the e2e environment (provider / credits / backend), which isn't fixable from the test code. Flagging it as a separate, likely-environmental issue for its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011e2ABgTgg2E1jjspHFtXxi