### PR TITLE
fix(e2e): reach projects directly (earned-nav) - defensive follow-up to #462

### DIFF
--- a/apps/client/e2e/notebook.spec.ts
+++ b/apps/client/e2e/notebook.spec.ts
@@ -154,7 +154,9 @@ test.describe('Notebook - Router resilience', () => {
       });
 
       await test.step('back/forward navigate between notebook and projects', async () => {
-        await page.getByTestId('sidenav-nav-projects').click();
+        // Direct nav (projects is earned-nav; the sidenav row may be hidden). goto still
+        // pushes a history entry, so the goBack/goForward assertions below hold.
+        await page.goto('/projects');
         await expect(page).toHaveURL(/\/projects/);
 
         await page.goBack();

--- a/apps/client/e2e/pages/FileUploadPage.ts
+++ b/apps/client/e2e/pages/FileUploadPage.ts
@@ -48,8 +48,14 @@ export class FileUploadPage extends BasePage {
   }
 
   async openFileBrowser() {
-    // Close any existing dialog first to ensure the sidebar is accessible
+    // Close any existing dialog first to ensure the sidebar is accessible.
     await this.closeFileBrowser();
+    // NOTE: `files` is an earned-nav destination (Gears) - the sidenav row is hidden
+    // until the account has a file. That is NOT a problem here: every caller uploads
+    // or relies on a seeded file BEFORE opening the browser, so `files` is already
+    // earned and the row is present. The browser is also a global drawer opened OVER
+    // the current page (e.g. the notebook the file is being added to), so it must NOT
+    // be reached by navigating away.
     await this.page.getByTestId('sidenav-nav-files').click();
   }
 

--- a/apps/client/e2e/pages/NavigationPage.ts
+++ b/apps/client/e2e/pages/NavigationPage.ts
@@ -7,7 +7,10 @@ export class NavigationPage extends BasePage {
   }
 
   async openProjects() {
-    await this.page.getByTestId('sidenav-nav-projects').click();
+    // Projects is an earned-nav destination (Gears): the sidenav row is hidden until
+    // the account has a project. Navigate directly, like a first-time user (Gears CTA).
+    await this.page.goto('/projects');
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async openProfile() {
@@ -16,7 +19,10 @@ export class NavigationPage extends BasePage {
   }
 
   async openAgents() {
-    await this.page.getByTestId('sidenav-nav-agents').click();
+    // Agents is an earned-nav destination (Gears): the sidenav row is hidden until
+    // the account has an agent. Navigate directly, like a first-time user (Gears CTA).
+    await this.page.goto('/agents');
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async openMenu() {

--- a/apps/client/e2e/pages/ProjectsPage.ts
+++ b/apps/client/e2e/pages/ProjectsPage.ts
@@ -12,9 +12,10 @@ export class ProjectsPage extends BasePage {
   }
 
   async navigateToProjects() {
-    await this.page.getByTestId('sidenav-nav-projects').click();
-    await this.page.waitForURL(/\/projects/);
-    await this.waitForProjectsReady();
+    // Projects is an earned-nav destination (Gears): the sidenav row is hidden until
+    // the account has a project. Navigate directly (like gotoProjects), robust to
+    // earned state - matches how a first-time user reaches it via the Gears CTA.
+    await this.gotoProjects();
   }
 
   /** Wait for project list to be fully loaded */

--- a/apps/client/e2e/projects.spec.ts
+++ b/apps/client/e2e/projects.spec.ts
@@ -10,12 +10,13 @@ const TEST_NOTEBOOK_NAME = 'E2E France Notebook';
 const TEST_FILE_NAME = 'recipe';
 
 test.describe('Projects - Navigation', () => {
-  test('should navigate to projects via sidenav', async ({ page, basePage }) => {
-    await page.goto('/');
+  test('should navigate to projects', async ({ page, basePage }) => {
+    // Projects is an earned-nav destination (Gears): the sidenav row is hidden until
+    // the account has a project. Navigate directly, like a first-time user reaches it
+    // via the Gears "Create your first project" CTA (a navigate:/projects).
+    await page.goto('/projects');
     await page.waitForLoadState('domcontentloaded');
     await basePage.dismissModals();
-
-    await page.getByTestId('sidenav-nav-projects').click();
 
     await expect(page).toHaveURL(/.*\/projects.*/);
     await expect(page.getByTestId('new-project-btn')).toBeVisible({


### PR DESCRIPTION
## Why

Follow-up to #462 (agents). The same earned-nav (Gears) pattern applies to **projects**: `sidenav-nav-projects` only renders once the account has a project, so any test that navigates via that row can hang for an account with zero projects. It's currently green only because the shared e2e account keeps persistent projects across runs - a latent flake, not a safe assumption.

## Change

Route projects navigation through the `/projects` URL (how a first-time user reaches it - the Gears "Create your first project" CTA is a `navigate:/projects`):

- `projects.spec.ts` - the "navigate to projects" test
- `notebook.spec.ts` - the back/forward step (goto still pushes history, so goBack/goForward hold)
- `ProjectsPage.navigateToProjects()` - now delegates to the existing `gotoProjects()`
- `NavigationPage.openProjects()` / `openAgents()` - direct goto (agents for consistency with #462)

## Files: investigated, deliberately NOT changed

`files` is also earned-nav, but it's a **non-issue** and changing it would break a passing test:
- Every caller **uploads or seeds a file first**, so `files` is already earned when `openFileBrowser()` runs and the sidenav row is present.
- The file browser is a **global drawer opened over the current page** (e.g. the notebook a file is being added to in `notebook-files.spec`). Reaching it by navigating away (there is no `/files` route) would destroy that context. So it stays on the sidenav click, with a comment explaining why.

## Note

I could not run the full E2E locally (needs the app + a seeded test account + Playwright infra); verified by lint + matching the direct-goto pattern already used in these files. The manual E2E workflow / CI is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011e2ABgTgg2E1jjspHFtXxi