### PR TITLE
fix(client): prevent chat composer draft loss on mobile signal return

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -29,7 +29,7 @@ import { setKnowledgeViewer } from '@client/app/components/Knowledge/KnowledgeVi
 import { useGetAgents, useGetSessionAgents } from '@client/app/hooks/data/agents';
 import { useGetSessionQuests } from '@client/app/hooks/data/sessions';
 import { useGetSettingsValue } from '@client/app/hooks/data/settings';
-import { useChatInput } from '@client/app/hooks/useChatInput';
+import { useChatInput, NEW_NOTEBOOK_DRAFT_KEY } from '@client/app/hooks/useChatInput';
 import { useShallow } from 'zustand/react/shallow';
 import { useIsMobile } from '@client/app/hooks/useIsMobile';
 import { useIsPWA } from '@client/app/hooks/useIsPWA';
@@ -106,8 +106,8 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
   const [, setAgentBenchCollapsed] = useState<boolean>(false);
   const [filesDropdownOpen, setFilesDropdownOpen] = useState<boolean>(false);
 
-  const [chatInputValue, setChatInputValue, setDraft, getDraft] = useChatInput(
-    useShallow(s => [s.chatInputValue, s.setChatInputValue, s.setDraft, s.getDraft])
+  const [chatInputValue, setChatInputValue, setDraft, getDraft, clearDraft] = useChatInput(
+    useShallow(s => [s.chatInputValue, s.setChatInputValue, s.setDraft, s.getDraft, s.clearDraft])
   );
   const [rephraseGlow, setRephraseGlow] = useState(false);
   const [showSlashSuggestions, setShowSlashSuggestions] = useState(false);
@@ -262,7 +262,7 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
   useAutoFocus(lexicalInputRef as any, { enabled: true });
 
   // Persists draft per session and restores it on session switch
-  useMessageDraft(currentSessionId, setChatInputValue, setDraft, getDraft);
+  useMessageDraft(currentSessionId, setChatInputValue, setDraft, getDraft, clearDraft);
 
   const canAttachFiles = enableFileAttachments;
 
@@ -461,10 +461,10 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
                       onChange={newValue => {
                         setChatInputValue(newValue);
 
-                        // Save draft as user types
-                        if (currentSessionId) {
-                          setDraft(currentSessionId, newValue);
-                        }
+                        // Save draft as user types. A new notebook has no id yet, so
+                        // draft under the stable new-notebook key - it survives a
+                        // full-page reload and is restored by useMessageDraft.
+                        setDraft(currentSessionId ?? NEW_NOTEBOOK_DRAFT_KEY, newValue);
 
                         const shouldShowSlashSuggestions =
                           typeof newValue === 'string' &&

--- a/apps/client/app/components/Session/SessionBottom/useMessageDraft.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useMessageDraft.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useMessageDraft } from './useMessageDraft';
+import { NEW_NOTEBOOK_DRAFT_KEY } from '@client/app/hooks/useChatInput';
+
+// useMessageDraft reads the live input via useChatInput.getState().chatInputValue.
+const h = vi.hoisted(() => ({ chatInputValue: '' }));
+vi.mock('@client/app/hooks/useChatInput', async importActual => {
+  const actual = await importActual<typeof import('@client/app/hooks/useChatInput')>();
+  return {
+    ...actual,
+    useChatInput: { getState: () => ({ chatInputValue: h.chatInputValue }) },
+  };
+});
+
+function setup(drafts: Record<string, string> = {}) {
+  const store = { ...drafts };
+  const setChatInputValue = vi.fn((v: string) => {
+    h.chatInputValue = v;
+  });
+  const setDraft = vi.fn((id: string, v: string) => {
+    store[id] = v;
+  });
+  const getDraft = vi.fn((id: string) => store[id] ?? '');
+  const clearDraft = vi.fn((id: string) => {
+    delete store[id];
+  });
+  return { store, setChatInputValue, setDraft, getDraft, clearDraft };
+}
+
+describe('useMessageDraft', () => {
+  beforeEach(() => {
+    h.chatInputValue = '';
+  });
+
+  it('restores a saved draft for the session on first mount', () => {
+    const { setChatInputValue, setDraft, getDraft, clearDraft } = setup({ s1: 'hello' });
+    renderHook(() => useMessageDraft('s1', setChatInputValue, setDraft, getDraft, clearDraft));
+    expect(setChatInputValue).toHaveBeenCalledWith('hello');
+  });
+
+  it('does not clobber the input on first mount when there is no saved draft', () => {
+    const { setChatInputValue, setDraft, getDraft, clearDraft } = setup();
+    renderHook(() => useMessageDraft('s1', setChatInputValue, setDraft, getDraft, clearDraft));
+    expect(setChatInputValue).not.toHaveBeenCalled();
+  });
+
+  it('restores the new-notebook draft on first mount when there is no session id', () => {
+    const { setChatInputValue, setDraft, getDraft, clearDraft } = setup({
+      [NEW_NOTEBOOK_DRAFT_KEY]: 'unsent text',
+    });
+    renderHook(() => useMessageDraft(null, setChatInputValue, setDraft, getDraft, clearDraft));
+    expect(setChatInputValue).toHaveBeenCalledWith('unsent text');
+  });
+
+  it('saves the outgoing draft and restores the incoming one on a session switch', () => {
+    const { store, setChatInputValue, setDraft, getDraft, clearDraft } = setup({ s2: 'draft two' });
+    h.chatInputValue = 'draft one';
+    const { rerender } = renderHook(
+      ({ id }) => useMessageDraft(id, setChatInputValue, setDraft, getDraft, clearDraft),
+      { initialProps: { id: 's1' as string | null } }
+    );
+    rerender({ id: 's2' });
+    expect(store.s1).toBe('draft one');
+    expect(setChatInputValue).toHaveBeenLastCalledWith('draft two');
+  });
+
+  it('drops the new-notebook draft and restores the target when a null session resolves to an id', () => {
+    const { store, setChatInputValue, setDraft, getDraft, clearDraft } = setup({
+      [NEW_NOTEBOOK_DRAFT_KEY]: 'stale',
+    });
+    const { rerender } = renderHook(
+      ({ id }) => useMessageDraft(id, setChatInputValue, setDraft, getDraft, clearDraft),
+      { initialProps: { id: null as string | null } }
+    );
+    rerender({ id: 's9' });
+    expect(store[NEW_NOTEBOOK_DRAFT_KEY]).toBeUndefined();
+    expect(setChatInputValue).toHaveBeenLastCalledWith('');
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/useMessageDraft.ts
+++ b/apps/client/app/components/Session/SessionBottom/useMessageDraft.ts
@@ -1,33 +1,60 @@
 import { useEffect, useRef } from 'react';
 
-import { useChatInput } from '@client/app/hooks/useChatInput';
+import { useChatInput, NEW_NOTEBOOK_DRAFT_KEY } from '@client/app/hooks/useChatInput';
 
 /**
  * Persists the chat input draft per session.
  * - When the session changes, saves the current input as a draft for the previous session.
  * - Restores the draft (or an empty string) for the incoming session.
+ * - A brand-new notebook (null id) drafts under NEW_NOTEBOOK_DRAFT_KEY so its text
+ *   survives a full-page reload; the draft is cleared once the notebook resolves to
+ *   a real id (its text is not carried forward - see the null->id branch below).
  */
 export function useMessageDraft(
   currentSessionId: string | null,
   setChatInputValue: (value: string) => void,
   setDraft: (sessionId: string, value: string) => void,
-  getDraft: (sessionId: string) => string
+  getDraft: (sessionId: string) => string,
+  clearDraft: (sessionId: string) => void
 ): void {
-  const prevSessionIdRef = useRef<string | null>(null);
+  // undefined = never run yet; distinguishes the first mount from a genuine null session.
+  const prevSessionIdRef = useRef<string | null | undefined>(undefined);
 
   useEffect(() => {
-    if (!currentSessionId) return;
-
     const prevSessionId = prevSessionIdRef.current;
+    const currentKey = currentSessionId ?? NEW_NOTEBOOK_DRAFT_KEY;
 
-    if (prevSessionId && prevSessionId !== currentSessionId) {
-      const currentValue = useChatInput.getState().chatInputValue;
-      if (currentValue) {
-        setDraft(prevSessionId, currentValue);
+    // First mount: restore the saved draft for this session (or the new-notebook draft).
+    if (prevSessionId === undefined) {
+      const restored = getDraft(currentKey);
+      if (restored) {
+        setChatInputValue(restored);
       }
+      prevSessionIdRef.current = currentSessionId;
+      return;
     }
 
-    setChatInputValue(getDraft(currentSessionId));
+    if (prevSessionId === currentSessionId) return;
+
+    // Leaving a new notebook (null) for a real id - either it resolved after the
+    // first send (text already consumed) or the user navigated to another notebook.
+    // Both cases: restore the target's own draft and drop the shared new-notebook
+    // key so its text can't leak into an unrelated session. (Not carried forward:
+    // null->id is ambiguous between "same notebook resolved" and "switched away".)
+    if (prevSessionId === null && currentSessionId) {
+      setChatInputValue(getDraft(currentSessionId));
+      clearDraft(NEW_NOTEBOOK_DRAFT_KEY);
+      prevSessionIdRef.current = currentSessionId;
+      return;
+    }
+
+    // Normal session switch: save the outgoing session's text, restore the incoming one's.
+    const prevKey = prevSessionId ?? NEW_NOTEBOOK_DRAFT_KEY;
+    const currentValue = useChatInput.getState().chatInputValue;
+    if (currentValue) {
+      setDraft(prevKey, currentValue);
+    }
+    setChatInputValue(getDraft(currentKey));
     prevSessionIdRef.current = currentSessionId;
-  }, [currentSessionId, setChatInputValue, setDraft, getDraft]);
+  }, [currentSessionId, setChatInputValue, setDraft, getDraft, clearDraft]);
 }

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -30,7 +30,7 @@ import { useLLMSettingsAssembly } from '../hooks/useLLMSettingsAssembly';
 import { useProgrammaticSubmit } from '../hooks/useProgrammaticSubmit';
 import { useGetAgents, useGetSessionAgents } from '@client/app/hooks/data/agents';
 import { useGetSettingsValue } from '@client/app/hooks/data/settings';
-import { useChatInput } from '@client/app/hooks/useChatInput';
+import { useChatInput, NEW_NOTEBOOK_DRAFT_KEY } from '@client/app/hooks/useChatInput';
 import useSessionLayout, {
   setSessionLayout,
   setPendingMessageFiles,
@@ -900,6 +900,10 @@ export function useSendMessage({
         });
         setChatInputValue('');
         clearDraft(dispatchSessionId);
+        // A first send from a new notebook drafted under the new-notebook key
+        // (currentSessionId was null); clear it too so the sent text can't
+        // resurface in a later new notebook if the composer remounts mid-resolve.
+        clearDraft(NEW_NOTEBOOK_DRAFT_KEY);
         if (chatInputRef.current) chatInputRef.current.value = '';
         setPendingMessageFiles([]);
         setSubmitting(false);
@@ -930,6 +934,10 @@ export function useSendMessage({
     if (currentSessionId) {
       clearDraft(currentSessionId);
     }
+    // Also drop the new-notebook draft: a first send starts with a null
+    // currentSessionId, so the guarded clear above misses the key the text was
+    // saved under, and it would otherwise resurface in a later new notebook.
+    clearDraft(NEW_NOTEBOOK_DRAFT_KEY);
     if (chatInputRef.current) {
       chatInputRef.current.value = '';
     }

--- a/apps/client/app/components/Session/SyncValuePlugin.tsx
+++ b/apps/client/app/components/Session/SyncValuePlugin.tsx
@@ -12,7 +12,12 @@ interface SyncValuePluginProps {
 export function SyncValuePlugin({ value, skipSyncRef }: SyncValuePluginProps): null {
   const [editor] = useLexicalComposerContext();
   const isUpdatingRef = useRef(false);
-  const previousValueRef = useRef(value);
+  // Seed empty (not `value`) so the first effect run hydrates the editor from a
+  // non-empty `value` on mount. On a remount (e.g. a layout flip rebuilds this
+  // subtree) the store still holds the in-progress text, and seeding to `value`
+  // would early-return on equality and leave the editor blank - dropping the
+  // draft. The currentText check below keeps the mount-time write idempotent.
+  const previousValueRef = useRef('');
 
   useEffect(() => {
     // Skip if we're in the middle of an update

--- a/apps/client/app/hooks/useChatInput.ts
+++ b/apps/client/app/hooks/useChatInput.ts
@@ -2,6 +2,12 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { IResolvedPromptDispatch } from '@bike4mind/common';
 
+// Stable draft key for a brand-new / unsaved notebook that has no session id yet.
+// Lets the in-progress text ride the persisted `drafts` map (session-scoped) so a
+// full-page reload before the first send doesn't lose it. Cleared once the notebook
+// resolves to a real session id. See useMessageDraft.
+export const NEW_NOTEBOOK_DRAFT_KEY = '__new_notebook__';
+
 interface ChatInputStore {
   // Current active session's input value (for real-time editing)
   chatInputValue: string;

--- a/apps/client/app/hooks/useChatInput.ts
+++ b/apps/client/app/hooks/useChatInput.ts
@@ -6,6 +6,10 @@ import type { IResolvedPromptDispatch } from '@bike4mind/common';
 // Lets the in-progress text ride the persisted `drafts` map (session-scoped) so a
 // full-page reload before the first send doesn't lose it. Cleared once the notebook
 // resolves to a real session id. See useMessageDraft.
+// Single-slot by design: because it persists to localStorage, two tabs both composing
+// a new notebook share this key and will clobber each other's draft. Acceptable (rare,
+// and no worse than before, when nothing was persisted); per-tab isolation would need
+// sessionStorage or a tab-scoped suffix.
 export const NEW_NOTEBOOK_DRAFT_KEY = '__new_notebook__';
 
 interface ChatInputStore {

--- a/apps/client/app/providers.tsx
+++ b/apps/client/app/providers.tsx
@@ -59,6 +59,12 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
+      // Off by default so a mobile signal-return (Android fires online +
+      // visibilitychange/focus at once) can't trigger a broad refetch storm that
+      // churns layout state and remounts the chat composer, losing typed text.
+      // Queries that genuinely need it opt in explicitly (see hooks/data/*).
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
     },
     mutations: {
       retry: false,


### PR DESCRIPTION
# Pull Request

Closes #455

## Screenshot/Video

https://github.com/user-attachments/assets/60b338f9-7ed6-49a3-af02-8e1981654c2c

## Description

On mobile (Android + Chrome) with low signal, a network transition (signal dropping and returning) made the chat UI visibly "reload" and cleared the prompt the user was typing in the composer, with no recovery. This is a data-loss-class bug on the primary chat input.

The loss came from three defects combining:

1. When signal returns, Android fires `online` + `visibilitychange`/`focus` together. TanStack Query's default `refetchOnWindowFocus`/`refetchOnReconnect` (both `true`) turned that into a broad refetch storm - the visible "reload" - whose state churn could flip `useSessionLayout.layout`.
2. `SessionContainer` renders `SessionBottom` in different subtrees per layout, so a layout flip unmounts and remounts the Lexical composer.
3. On remount the typed text is still in the Zustand store, but `SyncValuePlugin` only wrote `value` into the editor when it *changed*, not on mount - so the editor came back blank and the next keystroke overwrote the stored draft.

For a brand-new / unsaved notebook the loss was total: the per-keystroke draft save was skipped when there was no session id, and the live value was never persisted, so a genuine reload left nothing to restore.

This PR implements suggested fixes 1-3 from the issue. Fix 4 (render a single `SessionBottom` and reposition via portal/CSS) is intentionally deferred to a follow-up - fixes 1 and 3 already make any remount both rare and harmless, so it is a structural nice-to-have rather than a requirement to close the data loss.

## Changes

- **Hydrate the composer on mount** (`SyncValuePlugin.tsx`): seed `previousValueRef` empty so the first effect run reconciles the editor against a non-empty `value`. On a remount the store still holds the text, so the composer repopulates instead of coming back blank. The existing `currentText !== displayValue` guard keeps the mount-time write idempotent.
- **Persist the unsaved-notebook draft** (`useChatInput.ts`, `useMessageDraft.ts`, `SessionBottom.tsx`): a new notebook (null id) now drafts under a stable `NEW_NOTEBOOK_DRAFT_KEY` inside the already-persisted `drafts` map, so its text survives a full-page reload. `useMessageDraft` restores it on mount and clears it once the notebook resolves to a real id. The text is deliberately not carried forward on resolve, because a null -> id transition is ambiguous between "same notebook resolved" and "navigated to a different notebook" - carrying it forward would leak text across notebooks. This is why the scoped draft key was chosen over persisting the global `chatInputValue`.
- **Clear the new-notebook draft on send** (`useSendMessage.ts`): a first send starts with a null `currentSessionId`, so the existing guarded `clearDraft(currentSessionId)` missed the key the text was saved under. Both send paths now also `clearDraft(NEW_NOTEBOOK_DRAFT_KEY)` so a sent message cannot resurface in a later new notebook.
- **Disable refetch-on-focus/reconnect globally** (`providers.tsx`): set `refetchOnWindowFocus: false` and `refetchOnReconnect: false` on the query defaults. Queries that genuinely need it already opt in explicitly (see `hooks/data/*`), and real-time freshness is driven by the WebSocket invalidation listener, so this removes the phantom reload and the remount trigger without stranding live data.

## Tests

- `useMessageDraft.test.ts` (new): covers the draft-persistence branches - restore a saved draft on first mount, do not clobber the input when there is no draft, restore the new-notebook draft when there is no session id, save-and-restore on a session switch, and drop the new-notebook key when a null session resolves to an id.

## Guide for Testers

The bug reproduces most deterministically on a new notebook. Use Chrome with the Device Toolbar on (mobile viewport). Note: you must use the Network panel's "Offline" setting - throttle profiles like "Slow 3G" do not fire the `online` event.

### Scenario A - remount loss (network signal return)

1. Open the preview link in Chrome, open DevTools, turn on Device Toolbar and pick a mobile viewport (e.g. Pixel 7).
2. Click New Notebook.
3. In the message composer, type `REPRO-A canary: this text must survive a signal drop and return.` and do NOT send.
4. In the Network panel, set throttling to `Offline` and wait about 3 seconds.
5. Set throttling back to `No throttling`.
6. Switch to another browser tab, wait 1 second, then switch back.
7. Expected: the composer still shows the full `REPRO-A canary...` text. There is no visible "reload"/refetch burst on reconnect. (Repeat steps 4-6 a couple of times to be sure.)

### Scenario B - total loss on reload (unsaved notebook)

1. Open the preview link, click New Notebook.
2. Type `REPRO-B canary: an unsaved notebook must survive a hard refresh.` and do NOT send.
3. Hard-refresh the page.
4. Expected: the composer repopulates with the full `REPRO-B canary...` text.

### Regression Checks

1. Existing notebook drafts still work: open an existing notebook, type text, switch to a different notebook and back - the draft is preserved per notebook.
2. Sending clears the input: type a message, send it, confirm the composer empties and the sent text does not reappear when you next open a New Notebook.
3. Send from a new notebook: New Notebook -> type -> send -> a session is created and the message sends normally; the composer is empty afterward.
4. Slash commands and mentions still behave: type `/` and confirm slash suggestions appear; type `@` and confirm agent mention typeahead works.

### What NOT to test

- Admin/settings/live-balance screens refreshing on tab-focus: those queries opt into focus/reconnect refetch explicitly and are unaffected by this change.

## Additional Information

Verified live on staging (bug reproduced) and on a local dev build of this branch (both scenarios fixed). Typecheck is clean, the new unit tests pass, and lint reports no new errors on the touched files.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
