### PR TITLE
fix(client): close profile navigation on mobile

### DIFF
--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.test.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { AccountCard, closeSideNavOnMobile } from './ProfileMenu';
+import { AccountCard, closeSideNavOnOverlay } from './ProfileMenu';
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -34,11 +34,11 @@ describe('ProfileMenu AccountCard - enforceCredits gating', () => {
   });
 });
 
-describe('closeSideNavOnMobile', () => {
-  it('closes the overlay sidenav on mobile navigation', () => {
+describe('closeSideNavOnOverlay', () => {
+  it('closes the overlay sidenav on phone and tablet navigation', () => {
     const setOpenSideNav = vi.fn();
 
-    closeSideNavOnMobile(true, setOpenSideNav);
+    closeSideNavOnOverlay(true, setOpenSideNav);
 
     expect(setOpenSideNav).toHaveBeenCalledWith(false);
   });
@@ -46,7 +46,7 @@ describe('closeSideNavOnMobile', () => {
   it('leaves the desktop sidenav state unchanged', () => {
     const setOpenSideNav = vi.fn();
 
-    closeSideNavOnMobile(false, setOpenSideNav);
+    closeSideNavOnOverlay(false, setOpenSideNav);
 
     expect(setOpenSideNav).not.toHaveBeenCalled();
   });

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.test.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { AccountCard } from './ProfileMenu';
+import { AccountCard, closeSideNavOnMobile } from './ProfileMenu';
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -31,5 +31,23 @@ describe('ProfileMenu AccountCard - enforceCredits gating', () => {
     expect(screen.queryByText('1,234')).not.toBeInTheDocument();
     // The rest of the card still renders - only the balance disappears.
     expect(screen.getByText('Jane')).toBeInTheDocument();
+  });
+});
+
+describe('closeSideNavOnMobile', () => {
+  it('closes the overlay sidenav on mobile navigation', () => {
+    const setOpenSideNav = vi.fn();
+
+    closeSideNavOnMobile(true, setOpenSideNav);
+
+    expect(setOpenSideNav).toHaveBeenCalledWith(false);
+  });
+
+  it('leaves the desktop sidenav state unchanged', () => {
+    const setOpenSideNav = vi.fn();
+
+    closeSideNavOnMobile(false, setOpenSideNav);
+
+    expect(setOpenSideNav).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -17,7 +17,7 @@ import { useGetFriendRequests, useReturnToAdmin, useUserLogout } from '@client/a
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import { useAppVersion } from '@client/app/hooks/useAppVersion';
 import { useFeatureEnabled } from '@client/app/hooks/useFeatureEnabled';
-import { useIsMobile } from '@client/app/hooks/useIsMobile';
+import { useIsTablet } from '@client/app/hooks/useIsMobile';
 import { useEntitlements } from '@client/app/hooks/data/entitlements';
 import { filterVisiblePremiumNavItems } from '@client/app/utils/premiumNav';
 import { premiumNavItems } from '@client/app/premium-generated/premiumNavItems.generated';
@@ -47,8 +47,8 @@ import LogoutIcon from '@mui/icons-material/LogoutOutlined';
 import RefreshIcon from '@mui/icons-material/RefreshOutlined';
 import { useNotebookLayout } from '..';
 
-export const closeSideNavOnMobile = (isMobile: boolean, setOpenSideNav: (open: boolean) => void) => {
-  if (isMobile) setOpenSideNav(false);
+export const closeSideNavOnOverlay = (isOverlay: boolean, setOpenSideNav: (open: boolean) => void) => {
+  if (isOverlay) setOpenSideNav(false);
 };
 
 // Strip the trailing " (Personal)" suffix that useAccounts appends to the personal account name.
@@ -207,7 +207,7 @@ export const AccountCard = ({ name, typeLabel, credits, selected, onSelect, bare
 const ProfileMenu = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const isMobile = useIsMobile();
+  const isOverlay = useIsTablet();
   const setOpenSideNav = useNotebookLayout(s => s.setOpenSideNav);
   const theme = useTheme();
   const { setMode } = useColorScheme();
@@ -249,7 +249,7 @@ const ProfileMenu = () => {
   };
 
   const closeNavigation = () => {
-    closeSideNavOnMobile(isMobile, setOpenSideNav);
+    closeSideNavOnOverlay(isOverlay, setOpenSideNav);
     closeAll();
   };
 

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -17,6 +17,7 @@ import { useGetFriendRequests, useReturnToAdmin, useUserLogout } from '@client/a
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import { useAppVersion } from '@client/app/hooks/useAppVersion';
 import { useFeatureEnabled } from '@client/app/hooks/useFeatureEnabled';
+import { useIsMobile } from '@client/app/hooks/useIsMobile';
 import { useEntitlements } from '@client/app/hooks/data/entitlements';
 import { filterVisiblePremiumNavItems } from '@client/app/utils/premiumNav';
 import { premiumNavItems } from '@client/app/premium-generated/premiumNavItems.generated';
@@ -44,6 +45,11 @@ import AutoAwesomeIcon from '@mui/icons-material/AutoAwesomeOutlined';
 import LogoDevIcon from '@mui/icons-material/LogoDev';
 import LogoutIcon from '@mui/icons-material/LogoutOutlined';
 import RefreshIcon from '@mui/icons-material/RefreshOutlined';
+import { useNotebookLayout } from '..';
+
+export const closeSideNavOnMobile = (isMobile: boolean, setOpenSideNav: (open: boolean) => void) => {
+  if (isMobile) setOpenSideNav(false);
+};
 
 // Strip the trailing " (Personal)" suffix that useAccounts appends to the personal account name.
 const stripPersonalSuffix = (name: string) => name.replace(/ \(Personal\)$/, '');
@@ -201,6 +207,8 @@ export const AccountCard = ({ name, typeLabel, credits, selected, onSelect, bare
 const ProfileMenu = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
+  const setOpenSideNav = useNotebookLayout(s => s.setOpenSideNav);
   const theme = useTheme();
   const { setMode } = useColorScheme();
   const mode = theme.palette.mode;
@@ -238,6 +246,11 @@ const ProfileMenu = () => {
   const closeAll = () => {
     setOpen(false);
     setMoreOpen(false);
+  };
+
+  const closeNavigation = () => {
+    closeSideNavOnMobile(isMobile, setOpenSideNav);
+    closeAll();
   };
 
   // Dismiss the menu on any pointer-down outside the whole profile control, or on Escape.
@@ -327,7 +340,7 @@ const ProfileMenu = () => {
               label={t('admin.title', 'Admin')}
               onClick={() => {
                 navigate({ to: '/admin' });
-                setOpen(false);
+                closeNavigation();
               }}
             />
           )}
@@ -344,7 +357,7 @@ const ProfileMenu = () => {
             }
             onClick={() => {
               navigate({ to: '/profile' });
-              setOpen(false);
+              closeNavigation();
             }}
           />
           <MenuRow
@@ -353,7 +366,7 @@ const ProfileMenu = () => {
             label={t('skills.title', 'Skills')}
             onClick={() => {
               navigate({ to: '/skills' });
-              setOpen(false);
+              closeNavigation();
             }}
           />
           <MenuRow
@@ -362,7 +375,7 @@ const ProfileMenu = () => {
             label={t('apiKeys.title', 'API Keys')}
             onClick={() => {
               navigate({ to: '/profile', search: { tab: 'api-keys' } });
-              setOpen(false);
+              closeNavigation();
             }}
           />
           <MenuRow
@@ -371,7 +384,7 @@ const ProfileMenu = () => {
             label={t('organization.teams', 'Teams')}
             onClick={() => {
               navigate({ to: '/organizations' });
-              setOpen(false);
+              closeNavigation();
             }}
           />
           {isCreditsEnabled && (
@@ -565,7 +578,7 @@ const ProfileMenu = () => {
                     label={t('quests.my_quests', 'My Quests')}
                     onClick={() => {
                       navigate({ to: '/quests' });
-                      closeAll();
+                      closeNavigation();
                     }}
                   />
                 )}
@@ -580,7 +593,7 @@ const ProfileMenu = () => {
                       // glue, so their paths can't appear in the static route-tree
                       // union - erase the typed `to` here.
                       navigate({ to: item.path as never });
-                      closeAll();
+                      closeNavigation();
                     }}
                   />
                 ))}


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

Not applicable: this changes navigation state after a tap and does not alter the rendered menu or destination page.

## Description

Route destinations opened from the profile menu closed the popup but left the full-screen mobile sidenav covering the destination. This mirrors the existing `SidenavNav` behavior by closing the overlay sidenav whenever profile-menu navigation occurs.

Closes #459.

## Changes

- Close the mobile sidenav for Profile, Skills, API Keys, Teams, Admin, Quests, and generated premium route destinations.
- Continue leaving the desktop sidenav state unchanged.
- Add focused regression coverage for mobile and desktop behavior.

## Guide for Testers

1. Open the Bike4Mind client in a viewport narrower than 600px.
2. Open the sidebar using the menu control; the full-screen sidebar is visible.
3. Open the account menu at the bottom of the sidebar.
4. Select `Profile`; the app navigates to `/profile` and the sidebar closes, revealing the Profile page.
5. Reopen the sidebar and account menu, then select `Skills`; the app navigates to `/skills` and the sidebar closes.
6. Repeat with `API Keys` and `Teams`; each destination is visible immediately after navigation.

### Regression Checks

1. Open the client in a desktop-width viewport.
2. Select a route from the account menu; navigation succeeds and the desktop sidebar remains open.

## Additional Information

Validation:

- `pnpm --filter @bike4mind/client test -- app/components/layouts/Notebook/Sidenav/ProfileMenu.test.tsx` (4 passed)
- all 15 `b4m-core` packages built with `tsdown`
- full client `tsc --noEmit`
- pre-push Turbo typecheck: 34/34 tasks passed
- changed-file ESLint with zero errors
- changed-file Prettier check
- `git diff --check`

The Windows pre-push hook reached 34/34 successful Turbo tasks, then its POSIX-only `[ -f ... ]` infra wrapper could not parse under native Windows. The application/typecheck gate itself passed.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not applicable; no user-facing workflow change)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification (not applicable)