### PR TITLE
fix(cli): exempt numeric values from generic secret-assignment redaction

### DIFF
--- a/packages/cli/src/utils/toolOutputSanitizer.test.ts
+++ b/packages/cli/src/utils/toolOutputSanitizer.test.ts
@@ -61,6 +61,21 @@ describe('redactSecrets', () => {
     expect(out).toContain('[REDACTED]');
   });
 
+  it('leaves numeric-valued token-accounting fields untouched', () => {
+    expect(redactSecrets('totalTokens: 1523')).toBe('totalTokens: 1523');
+    expect(redactSecrets('tokenCount: 42')).toBe('tokenCount: 42');
+    expect(redactSecrets('promptTokens=900')).toBe('promptTokens=900');
+    expect(redactSecrets('{"completionTokens": 623, "totalTokens": 1523}')).toBe(
+      '{"completionTokens": 623, "totalTokens": 1523}'
+    );
+  });
+
+  it('still redacts a secret-named assignment whose value merely starts with digits', () => {
+    const out = redactSecrets('API_TOKEN=1523abcXYZ');
+    expect(out).not.toContain('1523abcXYZ');
+    expect(out).toContain('[REDACTED]');
+  });
+
   it('leaves ordinary tool output untouched', () => {
     const content = 'export function add(a: number, b: number) { return a + b; }\n/Users/dev/project/src/add.ts:1';
     expect(redactSecrets(content)).toBe(content);

--- a/packages/cli/src/utils/toolOutputSanitizer.ts
+++ b/packages/cli/src/utils/toolOutputSanitizer.ts
@@ -88,9 +88,14 @@ const SECRET_PATTERNS: Array<{ pattern: RegExp; replacement: string }> = [
   },
   // Generic secret-ish assignments (KEY=value / "key": "value") - keep the key,
   // redact the value. Anchored on names that denote a credential.
+  //
+  // The lookahead exempts a purely-numeric value. `TOKEN` matches LLM-accounting
+  // fields this agent reasons over (`totalTokens: 1523`, `promptTokens=900`), and
+  // redacting those loses real information. No credential shape we redact is a bare
+  // integer, so the exemption costs no coverage.
   {
     pattern:
-      /\b([A-Za-z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIALS?)[A-Za-z0-9_]*)(["']?\s*[=:]\s*["']?)([^\s"',}]+)/gi,
+      /\b([A-Za-z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIALS?)[A-Za-z0-9_]*)(["']?\s*[=:]\s*["']?)(?!\d+(?![^\s"',}]))([^\s"',}]+)/gi,
     replacement: `$1$2${REDACTED}`,
   },
 ];


### PR DESCRIPTION
## Description

The generic secret-assignment pattern in `toolOutputSanitizer` redacts the value of any `KEY=VALUE` / `"key": "value"` pair whose key name contains a credential word (`SECRET`, `TOKEN`, `PASSWORD`, `API_KEY`, ...). Because `TOKEN` is one of those words, benign LLM-accounting fields were being clobbered on the way to the model:

```
totalTokens: 1523  ->  totalTokens: [REDACTED]
tokenCount: 42     ->  tokenCount: [REDACTED]
promptTokens=900   ->  promptTokens=[REDACTED]
```

This is a ReAct agent whose tool output routinely carries `totalTokens` / `promptTokens` / `completionTokens`, and every tool result is routed through the sanitizer at the single choke point in `ToolRouter.executeTool`. So the agent lost usage numbers it may reason over, on every result carrying them.

It erred safe (over-redact, never leak), so this was a small recurring functional degradation rather than a security hole.

The fix exempts a purely-numeric value from the generic assignment pattern only. No credential shape this scrubber recognizes is a bare integer, so the exemption costs no redaction coverage. The specific credential-shape patterns (Stripe, AWS, GitHub, JWT, connection strings, Bearer) are untouched.

Follow-up from #306. Closes #429.

## Changes

- `packages/cli/src/utils/toolOutputSanitizer.ts` — added a negative lookahead, `(?!\d+(?![^\s"',}]))`, before the value capture group in the generic `KEY=VALUE` pattern. It skips redaction only when the value is digits all the way to a delimiter or end-of-string. Implemented as a lookahead rather than a post-hoc `/^\d+$/` check on the captured value so the pattern table stays declarative and `redactSecrets` remains a plain loop over `replace(pattern, replacement)`.
- `packages/cli/src/utils/toolOutputSanitizer.test.ts` — two regression tests: numeric token fields pass through untouched (bare and inside a JSON object, since the comma-delimited case is where a sloppy exemption breaks), and a value that merely *starts* with digits (`API_TOKEN=1523abcXYZ`) is still redacted.

## Guide for Testers

This is a pure-function change in the CLI's tool-output scrubber. There is no UI surface.

**Automated (the real check):**

1. From the repo root, run `pnpm --filter @bike4mind/cli test`.
2. Expected: the full CLI suite passes. The two new cases are in `redactSecrets` — "leaves numeric-valued token-accounting fields untouched" and "still redacts a secret-named assignment whose value merely starts with digits".
3. The nine pre-existing credential-shape assertions in the same file (Mongo/Postgres URIs, JWT, `sk-ant-`, Stripe, AWS, GitHub, Slack, Bearer, `MY_API_KEY=`) are the regression guard for this change — confirm they still pass.

**Manual spot-check of behavior:**

1. From `packages/cli`, run:
   ```
   npx tsx -e "import { redactSecrets } from './src/utils/toolOutputSanitizer'; console.log(redactSecrets('totalTokens: 1523')); console.log(redactSecrets('API_KEY=abc123'));"
   ```
2. Expected output, exactly:
   ```
   totalTokens: 1523
   API_KEY=[REDACTED]
   ```

**Regression Checks:**

- Secrets on the right-hand side of a secret-named assignment are still redacted: `MY_API_KEY=super-secret-value-123`, `DB_PASSWORD=hunter2`, `GITHUB_TOKEN=ghp_...` all still produce `[REDACTED]`.
- A value starting with digits but containing letters is still redacted: `API_TOKEN=1523abcXYZ` -> `API_TOKEN=[REDACTED]`.
- The output ceiling (`enforceOutputCeiling`) and redact-then-truncate ordering in `sanitizeToolOutput` are unchanged.

**What NOT to test:** there is no client/UI behavior in this PR. No AdminSettings, no telemetry fields, no DB shape changes.

## Additional Information

**Known, deliberate trade-off — worth a reviewer's explicit sign-off.** Any numeric exemption means a purely-numeric secret is no longer redacted by the *generic* pattern:

```
API_KEY=12345678  ->  API_KEY=12345678   (now passes through)
```

This is inherent to the approach the issue proposes, not to this particular implementation. My judgment is that it is acceptable: no credential format this scrubber recognizes, and none in `.gitleaks.toml`, is a bare integer, and the scrubber is explicitly documented as matching known secret *shapes* rather than entropy. It is called out in a code comment at the pattern.

If a reviewer would rather narrow the exemption, the tightest version is to bound the digit count (e.g. 1-6 digits), which still covers plausible token counts while excluding key-length numbers. Happy to change it.

Non-goals, per #306 review: entropy-based scanning and `error.stack` sanitizing remain out of scope.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas — the lookahead carries a comment explaining why numeric values are exempt
- [x] My changes generate no new warnings — `pnpm --filter @bike4mind/cli typecheck` and `pnpm lint:check` both clean
