### PR TITLE
feat(publish): temporary lockout for passphrase-gated share links

### DIFF
--- a/apps/client/pages/api/publish/gate/__tests__/passphrase.test.ts
+++ b/apps/client/pages/api/publish/gate/__tests__/passphrase.test.ts
@@ -10,13 +10,24 @@ const { mocks } = vi.hoisted(() => ({
   },
 }));
 
+const { lockout } = vi.hoisted(() => ({
+  lockout: {
+    checkLock: vi.fn(),
+    recordFailure: vi.fn(),
+    clear: vi.fn(() => Promise.resolve()),
+  },
+}));
+
 vi.mock('@server/middlewares/baseApi', () => ({
   baseApi: () => {
     const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
-    const chain = Object.assign((req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res), {
-      use: () => chain,
-      post: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.POST = fns[fns.length - 1]), chain),
-    });
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
+      {
+        use: () => chain,
+        post: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.POST = fns[fns.length - 1]), chain),
+      }
+    );
     return chain;
   },
 }));
@@ -43,6 +54,7 @@ vi.mock('@server/services/publish/parsePublishPath', () => ({
   parsePublishPath: () => ({ kind: 'bundle', tier: 'user', scopeId: 'scope', slug: 'slug', assetPath: null }),
 }));
 vi.mock('@server/services/publish/publishGateToken', () => ({ setGateProofCookie: () => true }));
+vi.mock('@server/services/publish/passphraseLockout', () => lockout);
 vi.mock('bcryptjs', () => ({ default: { compare: () => Promise.resolve(true) } }));
 
 import handler from '../passphrase';
@@ -53,14 +65,21 @@ const run = (body: unknown) => {
   return { res, promise: (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res) };
 };
 
+const gated = () =>
+  mocks.lean.mockResolvedValue({ publicId: 'pub1', accessGate: { kind: 'passphrase', passphraseHash: 'h' } });
+
 beforeEach(() => {
+  vi.restoreAllMocks(); // reset bcrypt.compare spy history between tests
   Object.values(mocks).forEach(m => (m as { mockReset?: () => void }).mockReset?.());
   mocks.stamp.mockResolvedValue(undefined);
+  lockout.checkLock.mockReset().mockResolvedValue({ locked: false, retryAfterMs: 0 });
+  lockout.recordFailure.mockReset().mockResolvedValue({ locked: false, retryAfterMs: 0 });
+  lockout.clear.mockReset().mockResolvedValue(undefined);
 });
 
 describe('POST /api/publish/gate/passphrase - projection safety (regression: MongoDB path collision)', () => {
   it('never projects a parent path together with its child sub-path', async () => {
-    mocks.lean.mockResolvedValue({ publicId: 'pub1', accessGate: { kind: 'passphrase', passphraseHash: 'h' } });
+    gated();
 
     const { res, promise } = run({ path: '/p/u/scope/slug', passphrase: 'hunter2secret' });
     await promise;
@@ -82,10 +101,65 @@ describe('POST /api/publish/gate/passphrase - projection safety (regression: Mon
   it('rejects a wrong passphrase with 403', async () => {
     const bcrypt = (await import('bcryptjs')).default as { compare: () => Promise<boolean> };
     vi.spyOn(bcrypt, 'compare').mockResolvedValueOnce(false);
-    mocks.lean.mockResolvedValue({ publicId: 'pub1', accessGate: { kind: 'passphrase', passphraseHash: 'h' } });
+    gated();
 
     const { res, promise } = run({ path: '/p/u/scope/slug', passphrase: 'wrongpassword' });
     await promise;
     expect(res._getStatusCode()).toBe(403);
+  });
+});
+
+describe('POST /api/publish/gate/passphrase - per-artifact lockout', () => {
+  it('returns 423 with Retry-After when the gate is already locked, before checking bcrypt', async () => {
+    const bcrypt = (await import('bcryptjs')).default as { compare: () => Promise<boolean> };
+    const compareSpy = vi.spyOn(bcrypt, 'compare');
+    lockout.checkLock.mockResolvedValue({ locked: true, retryAfterMs: 90_000 });
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug', passphrase: 'anything123' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(423);
+    expect(res.getHeader('Retry-After')).toBe(90);
+    expect(compareSpy).not.toHaveBeenCalled();
+    expect(lockout.recordFailure).not.toHaveBeenCalled();
+  });
+
+  it('returns 423 when a wrong attempt trips the lock', async () => {
+    const bcrypt = (await import('bcryptjs')).default as { compare: () => Promise<boolean> };
+    vi.spyOn(bcrypt, 'compare').mockResolvedValueOnce(false);
+    lockout.recordFailure.mockResolvedValue({ locked: true, retryAfterMs: 120_000 });
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug', passphrase: 'wrongpassword' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(423);
+    expect(res.getHeader('Retry-After')).toBe(120);
+    expect(lockout.recordFailure).toHaveBeenCalledWith('pub1');
+  });
+
+  it('records a failure but stays 403 while under the cap', async () => {
+    const bcrypt = (await import('bcryptjs')).default as { compare: () => Promise<boolean> };
+    vi.spyOn(bcrypt, 'compare').mockResolvedValueOnce(false);
+    lockout.recordFailure.mockResolvedValue({ locked: false, retryAfterMs: 0 });
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug', passphrase: 'wrongpassword' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(lockout.recordFailure).toHaveBeenCalledWith('pub1');
+  });
+
+  it('clears the lock on a correct passphrase', async () => {
+    gated();
+
+    const { res, promise } = run({ path: '/p/u/scope/slug', passphrase: 'hunter2secret' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(204);
+    expect(lockout.clear).toHaveBeenCalledWith('pub1');
+    expect(lockout.recordFailure).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/pages/api/publish/gate/passphrase.ts
+++ b/apps/client/pages/api/publish/gate/passphrase.ts
@@ -5,6 +5,7 @@ import bcrypt from 'bcryptjs';
 import { PublishedArtifact } from '@bike4mind/database';
 import { parsePublishPath, segmentsFromViewerPathname } from '@server/services/publish/parsePublishPath';
 import { setGateProofCookie } from '@server/services/publish/publishGateToken';
+import { checkLock, recordFailure, clear } from '@server/services/publish/passphraseLockout';
 
 /**
  * POST /api/publish/gate/passphrase - verify a passphrase for a gated published
@@ -13,9 +14,11 @@ import { setGateProofCookie } from '@server/services/publish/publishGateToken';
  * (renderPassphraseShell) with the viewer pathname + entered passphrase.
  *
  * Anonymous by design (the whole point is viewers without accounts). Brute force
- * is bounded by the per-IP rate limit below; responses are deliberately terse
- * (404 unknown/ungated, 403 wrong passphrase) so the endpoint confirms nothing
- * an anonymous caller couldn't learn from the viewer URL itself.
+ * is bounded on two axes: the per-IP rate limit below throttles one client
+ * across ALL gated artifacts (429), and the per-artifact lockout (passphraseLockout)
+ * locks a single artifact after too many wrong attempts (423). Responses are
+ * deliberately terse (404 unknown/ungated, 403 wrong passphrase, 423 locked) so
+ * the endpoint confirms nothing an anonymous caller couldn't learn from the URL.
  */
 
 const BodySchema = z.object({
@@ -64,10 +67,24 @@ const handler = baseApi({ auth: false })
       return res.status(404).json({ error: 'Not found' });
     }
 
+    // Locked gates reject BEFORE bcrypt so a locked artifact stays locked even
+    // for a correct passphrase until the window closes.
+    const lock = await checkLock(artifact.publicId);
+    if (lock.locked) {
+      res.setHeader('Retry-After', Math.ceil(lock.retryAfterMs / 1000));
+      return res.status(423).json({ error: 'Too many attempts' });
+    }
+
     const ok = await bcrypt.compare(parsed.data.passphrase, artifact.accessGate.passphraseHash);
     if (!ok) {
+      const failed = await recordFailure(artifact.publicId);
+      if (failed.locked) {
+        res.setHeader('Retry-After', Math.ceil(failed.retryAfterMs / 1000));
+        return res.status(423).json({ error: 'Too many attempts' });
+      }
       return res.status(403).json({ error: 'Incorrect passphrase' });
     }
+    await clear(artifact.publicId);
     if (!setGateProofCookie(res, artifact.publicId)) {
       // publicId failed the cookie-name safety check - treat as unservable.
       return res.status(500).json({ error: 'Unable to grant access' });

--- a/apps/client/server/services/publish/passphraseLockout.test.ts
+++ b/apps/client/server/services/publish/passphraseLockout.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { cache } = vi.hoisted(() => ({
+  cache: {
+    findByKey: vi.fn(),
+    tryIncrementWithinLimitFixedWindow: vi.fn(),
+    deleteByKey: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock('@bike4mind/database', () => ({ cacheRepository: cache }));
+
+import {
+  checkLock,
+  recordFailure,
+  clear,
+  PASSPHRASE_LOCKOUT_MAX_ATTEMPTS,
+  PASSPHRASE_LOCKOUT_WINDOW_MS,
+} from './passphraseLockout';
+
+const KEY = 'publish-gate-pp-lock:pub1';
+
+beforeEach(() => {
+  cache.findByKey.mockReset();
+  cache.tryIncrementWithinLimitFixedWindow.mockReset();
+  cache.deleteByKey.mockReset().mockResolvedValue(undefined);
+});
+
+describe('checkLock', () => {
+  it('is unlocked when no counter exists', async () => {
+    cache.findByKey.mockResolvedValue(null);
+    expect(await checkLock('pub1')).toEqual({ locked: false, retryAfterMs: 0 });
+    expect(cache.findByKey).toHaveBeenCalledWith(KEY);
+  });
+
+  it('is unlocked while under the cap', async () => {
+    cache.findByKey.mockResolvedValue({
+      result: { count: PASSPHRASE_LOCKOUT_MAX_ATTEMPTS - 1 },
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    expect(await checkLock('pub1')).toEqual({ locked: false, retryAfterMs: 0 });
+  });
+
+  it('is locked at/over the cap with time remaining', async () => {
+    const expiresAt = new Date(Date.now() + 120_000);
+    cache.findByKey.mockResolvedValue({ result: { count: PASSPHRASE_LOCKOUT_MAX_ATTEMPTS }, expiresAt });
+    const state = await checkLock('pub1');
+    expect(state.locked).toBe(true);
+    expect(state.retryAfterMs).toBeGreaterThan(0);
+    expect(state.retryAfterMs).toBeLessThanOrEqual(120_000);
+  });
+
+  it('is unlocked once the window has expired even at the cap', async () => {
+    cache.findByKey.mockResolvedValue({
+      result: { count: PASSPHRASE_LOCKOUT_MAX_ATTEMPTS + 3 },
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+    expect(await checkLock('pub1')).toEqual({ locked: false, retryAfterMs: 0 });
+  });
+
+  it('never mutates the counter (read-only peek)', async () => {
+    cache.findByKey.mockResolvedValue(null);
+    await checkLock('pub1');
+    expect(cache.tryIncrementWithinLimitFixedWindow).not.toHaveBeenCalled();
+    expect(cache.deleteByKey).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordFailure', () => {
+  it('does not lock while the incremented count stays under the cap', async () => {
+    cache.tryIncrementWithinLimitFixedWindow.mockResolvedValue({
+      success: true,
+      count: 1,
+      expiresAt: new Date(Date.now() + PASSPHRASE_LOCKOUT_WINDOW_MS),
+    });
+    expect(await recordFailure('pub1')).toEqual({ locked: false, retryAfterMs: 0 });
+    expect(cache.tryIncrementWithinLimitFixedWindow).toHaveBeenCalledWith(
+      KEY,
+      PASSPHRASE_LOCKOUT_MAX_ATTEMPTS,
+      PASSPHRASE_LOCKOUT_WINDOW_MS
+    );
+  });
+
+  it('locks on the failure that reaches the cap', async () => {
+    const expiresAt = new Date(Date.now() + PASSPHRASE_LOCKOUT_WINDOW_MS);
+    cache.tryIncrementWithinLimitFixedWindow.mockResolvedValue({
+      success: true,
+      count: PASSPHRASE_LOCKOUT_MAX_ATTEMPTS,
+      expiresAt,
+    });
+    const state = await recordFailure('pub1');
+    expect(state.locked).toBe(true);
+    expect(state.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('locks when the window is already at the cap (increment refused)', async () => {
+    const expiresAt = new Date(Date.now() + 30_000);
+    cache.tryIncrementWithinLimitFixedWindow.mockResolvedValue({
+      success: false,
+      count: PASSPHRASE_LOCKOUT_MAX_ATTEMPTS,
+      expiresAt,
+    });
+    const state = await recordFailure('pub1');
+    expect(state.locked).toBe(true);
+    expect(state.retryAfterMs).toBeGreaterThan(0);
+  });
+});
+
+describe('clear', () => {
+  it('deletes the per-artifact counter', async () => {
+    await clear('pub1');
+    expect(cache.deleteByKey).toHaveBeenCalledWith(KEY);
+  });
+});
+
+describe('key isolation', () => {
+  it('namespaces per artifact so one gate cannot lock another', async () => {
+    cache.findByKey.mockResolvedValue(null);
+    await checkLock('pubA');
+    await checkLock('pubB');
+    expect(cache.findByKey).toHaveBeenNthCalledWith(1, 'publish-gate-pp-lock:pubA');
+    expect(cache.findByKey).toHaveBeenNthCalledWith(2, 'publish-gate-pp-lock:pubB');
+  });
+});

--- a/apps/client/server/services/publish/passphraseLockout.ts
+++ b/apps/client/server/services/publish/passphraseLockout.ts
@@ -1,0 +1,66 @@
+import { cacheRepository } from '@bike4mind/database';
+
+/**
+ * Per-artifact passphrase lockout for the public gate (issue #383 Tier 2).
+ *
+ * Sits alongside the coarse per-IP rate limit on POST /api/publish/gate/passphrase:
+ * the IP limit throttles a single client across ALL gated artifacts, while this
+ * counts WRONG passphrases against ONE artifact and locks that artifact's gate for
+ * the rest of a fixed window once the count reaches MAX_ATTEMPTS. Together they are
+ * the acceptance's "rate-limit per token + IP; temporary lockout after N wrong attempts".
+ *
+ * The cache key is namespaced with `pp` so a future Tier 3 (domain) gate throttle
+ * gets its own bucket and passphrase failures can never cross-lock a different mode.
+ */
+
+/** Wrong attempts against one artifact before its gate locks (inclusive). */
+export const PASSPHRASE_LOCKOUT_MAX_ATTEMPTS = 5;
+/** Fixed window the lock and the failure count live in. */
+export const PASSPHRASE_LOCKOUT_WINDOW_MS = 15 * 60_000;
+
+const keyFor = (publicId: string) => `publish-gate-pp-lock:${publicId}`;
+
+export interface LockState {
+  locked: boolean;
+  /** ms until the window closes; 0 when not locked. */
+  retryAfterMs: number;
+}
+
+const remainingMs = (expiresAt?: Date | null): number =>
+  expiresAt ? Math.max(0, expiresAt.getTime() - Date.now()) : 0;
+
+/**
+ * Read-only check run BEFORE bcrypt so a locked gate rejects even a correct
+ * passphrase for the remainder of the window. Never mutates the counter, so
+ * hammering a locked gate cannot extend the lock.
+ */
+export async function checkLock(publicId: string): Promise<LockState> {
+  const doc = await cacheRepository.findByKey(keyFor(publicId));
+  if (!doc) return { locked: false, retryAfterMs: 0 };
+  const count = (doc.result as { count?: number })?.count ?? 0;
+  const expired = doc.expiresAt.getTime() <= Date.now();
+  if (expired || count < PASSPHRASE_LOCKOUT_MAX_ATTEMPTS) return { locked: false, retryAfterMs: 0 };
+  return { locked: true, retryAfterMs: remainingMs(doc.expiresAt) };
+}
+
+/**
+ * Record one wrong attempt and report whether the gate is now locked. Uses the
+ * fixed-window primitive so the window opens on the first failure and closes
+ * deterministically WINDOW_MS later (a stream of failures cannot slide it forward).
+ */
+export async function recordFailure(publicId: string): Promise<LockState> {
+  const { success, count, expiresAt } = await cacheRepository.tryIncrementWithinLimitFixedWindow(
+    keyFor(publicId),
+    PASSPHRASE_LOCKOUT_MAX_ATTEMPTS,
+    PASSPHRASE_LOCKOUT_WINDOW_MS
+  );
+  // !success == already at the cap (a prior request tipped it over); count>=cap
+  // == this failure was the one that reached it.
+  const locked = !success || count >= PASSPHRASE_LOCKOUT_MAX_ATTEMPTS;
+  return { locked, retryAfterMs: locked ? remainingMs(expiresAt) : 0 };
+}
+
+/** Clear the counter after a correct passphrase so a returning viewer starts fresh. */
+export async function clear(publicId: string): Promise<void> {
+  await cacheRepository.deleteByKey(keyFor(publicId));
+}

--- a/apps/client/server/services/publish/renderPassphraseShell.ts
+++ b/apps/client/server/services/publish/renderPassphraseShell.ts
@@ -37,6 +37,15 @@ export function renderPassphraseShell(): string {
         if (res.status === 204) { note('Unlocked - loading...'); location.reload(); return; }
         btn.disabled = false;
         if (res.status === 403) { note('That passphrase is not correct.'); return; }
+        if (res.status === 423) {
+          // Locked after too many wrong attempts. Keep the button disabled and
+          // surface the wait from Retry-After (seconds) rather than let them hammer on.
+          btn.disabled = true;
+          var secs = parseInt(res.headers.get('Retry-After'), 10);
+          var wait = (secs && secs > 60) ? (Math.ceil(secs / 60) + ' minutes') : 'a minute';
+          note('Too many incorrect attempts. Try again in ' + wait + '.');
+          return;
+        }
         if (res.status === 429) { note('Too many attempts - wait a minute and try again.'); return; }
         note('Something went wrong - try again.');
       })


### PR DESCRIPTION
Closes #407.

## Optional Screenshot/Video
Captured live on the PR preview (`app.pr475.preview.bike4mind.com`), driving the anonymous share link end-to-end. Steps map to the Guide for Testers below.

<img width="1000" height="760" alt="Passphrase prompt on a gated share link, viewed logged-out" src="https://github.com/user-attachments/assets/1ecb2975-3a8e-4e71-8028-f3fdcb5c9e69" />

*Figure 1 (step 3): a logged-out viewer opening a passphrase-gated link gets the prompt shell.*

<img width="1000" height="760" alt="Wrong passphrase shows 'That passphrase is not correct.'" src="https://github.com/user-attachments/assets/600e819a-d0e6-4f4f-a57c-7f6074e6d4dd" />

*Figure 2 (step 4): a wrong passphrase returns 403 - "That passphrase is not correct."*

<img width="1000" height="760" alt="Fifth wrong attempt locks the gate with a 15-minute lockout message" src="https://github.com/user-attachments/assets/93e7bfc4-c85a-45bc-a22d-acadf44affe4" />

*Figure 3 (step 5): the 5th wrong attempt locks the gate - "Too many incorrect attempts. Try again in 15 minutes." (423), Unlock disabled.*

<img width="1000" height="760" alt="Correct passphrase while locked is still rejected" src="https://github.com/user-attachments/assets/4f3055f9-f0d3-4787-9bd4-d883f8ca7383" />

*Figure 4 (step 6): while locked, even the CORRECT passphrase stays blocked (423) until the window passes.*

<img width="1000" height="760" alt="A different gated artifact shows a normal prompt, unaffected by the first artifact's lockout" src="https://github.com/user-attachments/assets/d14c7d20-6ed3-4407-a117-4f0a6574782b" />

*Figure 5 (step 7): a DIFFERENT gated artifact shows a normal prompt - locking one artifact does not lock another.*

<img width="1000" height="760" alt="The second artifact renders after its correct passphrase" src="https://github.com/user-attachments/assets/3c5e7ef5-bf84-48fd-9db3-c7a7874e4b06" />

*Figure 6 (steps 7-8): the second artifact unlocks and renders on its correct passphrase (per-artifact isolation + correct-passphrase regression).*

## Description
Tier 2 of the artifact-sharing epic (#383) shipped the passphrase gate itself (owner set/rotate, hashing, the public prompt + verify route, the proof cookie, and enforcement in `checkShareGrant`) alongside Tier 1 (#406). The one part of #407's acceptance still missing was **"rate-limit attempts per token + IP; temporary lockout after N wrong attempts."** The verify route had only a coarse per-IP window and no per-artifact lockout, so a distributed guesser (many IPs against one link) was never throttled per artifact.

This adds a **per-artifact wrong-attempt lockout** on the passphrase verify route, alongside the existing per-IP rate limit. After 5 wrong passphrases against one artifact within a 15-minute fixed window, that artifact's gate is locked for the remainder of the window and rejects further attempts (even a correct one) with `423 Locked` + `Retry-After`. A correct passphrase before the cap clears the counter.

## Changes
- **New `passphraseLockout` helper** (`server/services/publish/passphraseLockout.ts`): `checkLock` / `recordFailure` / `clear` over the existing `cacheRepository` fixed-window primitive. Per-artifact cache key namespaced `publish-gate-pp-lock:<publicId>`.
- **Verify route** (`pages/api/publish/gate/passphrase.ts`): peek the lock before bcrypt (locked -> 423 + Retry-After, no hash check), record each wrong attempt, clear on success. The coarse per-IP `rateLimit` middleware (429) is unchanged.
- **Prompt shell** (`server/services/publish/renderPassphraseShell.ts`): a distinct 423 branch reads `Retry-After`, tells the viewer how long the lockout lasts, and keeps the Unlock button disabled. Page stays fully static (no server interpolation).
- **Tests**: new `passphraseLockout.test.ts` (10) and extended `passphrase.test.ts` handler cases (already-locked -> 423 before bcrypt, wrong attempt trips lock, under-cap stays 403, correct clears lock).

## Guide for Testers
Preview login is passwordless OTC; use a `*-e2e@test.com` account only. The gate lives on a published **artifact bundle** - do NOT test via the "publish reply" action (that is a separate path). If you just need a ready-made gated link on the preview, ask and one can be provisioned.

1. Log in and publish an **HTML artifact** (an artifact bundle - e.g. an HTML/agent output, NOT a chat reply) with visibility **public**.
2. On the published artifact, open **Share**, choose **Passphrase required**, set a passphrase of 8+ characters (e.g. `hunter2secret`), and apply.
3. Copy the public share link and open it in a **logged-out** browser (or private window). Expected: a "This shared item is passphrase-protected" prompt.
4. Enter a **wrong** passphrase. Expected: "That passphrase is not correct." Repeat until you have entered a wrong passphrase **5 times total**.
5. On the 5th wrong attempt (and after), expected: the message changes to "Too many incorrect attempts. Try again in N minutes." and the Unlock button is disabled.
6. While locked, enter the **correct** passphrase. Expected: still blocked (423) with the lockout message - a locked gate does not open even for the right passphrase until the window passes.
7. On a **different** passphrase-gated artifact, confirm it is NOT locked (locking one artifact must not lock another).
8. Regression: on a freshly-gated artifact, enter the correct passphrase on the first try. Expected: it unlocks and the artifact renders.

## Additional Information
Security-sensitive (brute-force hardening), so this PR includes before/after evidence of the lockout on the preview env (see the figures above). The lockout lives entirely on the passphrase verify path and touches none of the shared visibility seams (`checkVisibility` / `checkShareGrant` / `checkAccessGate`) or the `accessGate` schema, so it has no overlap with the Tier 3 domain-visibility work (#408); the cache key is namespaced `pp` so a future domain-mode throttle gets its own bucket. Thresholds are named constants (`PASSPHRASE_LOCKOUT_MAX_ATTEMPTS = 5`, `PASSPHRASE_LOCKOUT_WINDOW_MS = 15 min`).

## Developer Notes (Optional)
- `passphraseLockout` is a reusable per-key fixed-window lockout pattern over `cacheRepository`; the peek/record/clear split keeps the handler thin and unit-testable.
- The per-artifact lock (423) and the per-IP rate limit (429) are deliberately distinct status codes so the static prompt shell can message them differently.

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc