### PR TITLE
fix(session): allow scrolling up while a reply streams

### DIFF
--- a/apps/client/app/components/Session/hooks/__tests__/useVirtuosoPagination.test.ts
+++ b/apps/client/app/components/Session/hooks/__tests__/useVirtuosoPagination.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useVirtuosoPagination } from '../useVirtuosoPagination';
 
@@ -142,5 +142,184 @@ describe('useVirtuosoPagination', () => {
     });
 
     expect(result.current.scrollerElementRef.current).toBeNull();
+  });
+});
+
+describe('useVirtuosoPagination auto-scroll follow behavior', () => {
+  const baseParams = {
+    sessionId: 'session-1',
+    filteredChatHistory: makeItems(['q1', 'q2', 'q3']),
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+  };
+
+  // Manual RAF pump so the auto-scroll loop advances deterministically.
+  let rafCbs: FrameRequestCallback[] = [];
+  const flushRaf = (frames = 1) => {
+    for (let i = 0; i < frames; i++) {
+      const cbs = rafCbs;
+      rafCbs = [];
+      cbs.forEach(cb => cb(0));
+    }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    rafCbs = [];
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafCbs.push(cb);
+      return rafCbs.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  // A scroller stub with settable scrollTop/scrollHeight and a scrollTo spy that
+  // mirrors real behavior (updates scrollTop). `dims` lets a test grow content.
+  function makeScroller(dims: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'scrollHeight', { get: () => dims.scrollHeight, configurable: true });
+    Object.defineProperty(el, 'clientHeight', { get: () => dims.clientHeight, configurable: true });
+    Object.defineProperty(el, 'scrollTop', {
+      get: () => dims.scrollTop,
+      set: (v: number) => {
+        dims.scrollTop = v;
+      },
+      configurable: true,
+    });
+    el.scrollTo = vi.fn((opts?: ScrollToOptions | number) => {
+      if (opts && typeof opts === 'object' && typeof opts.top === 'number') dims.scrollTop = opts.top;
+    }) as typeof el.scrollTo;
+    return el;
+  }
+
+  function touchEvent(type: string, clientY: number | null) {
+    const e = new Event(type, { bubbles: true });
+    Object.defineProperty(e, 'touches', {
+      value: clientY == null ? [] : [{ clientY }],
+      configurable: true,
+    });
+    return e;
+  }
+
+  function setupActive(dims: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+    const el = makeScroller(dims);
+    const { result, rerender } = renderHook(({ isActive }) => useVirtuosoPagination({ ...baseParams, isActive }), {
+      initialProps: { isActive: false },
+    });
+    // Set the scroller ref BEFORE the effect runs with isActive=true, since the
+    // effect captures scrollerElementRef.current at run time.
+    act(() => {
+      result.current.handleScrollerRef(el);
+    });
+    act(() => {
+      rerender({ isActive: true });
+    });
+    return { el, dims };
+  }
+
+  it('pins to the bottom every frame while following and content is below the fold', () => {
+    const { el, dims } = setupActive({ scrollHeight: 1000, clientHeight: 500, scrollTop: 0 });
+
+    act(() => flushRaf());
+
+    expect(el.scrollTo).toHaveBeenCalledWith({ top: 1000 });
+    expect(dims.scrollTop).toBe(1000);
+  });
+
+  it('detaches following on a touch drag-down (scroll-up gesture) and stops pinning', () => {
+    const { el, dims } = setupActive({ scrollHeight: 1000, clientHeight: 500, scrollTop: 500 });
+
+    act(() => {
+      el.dispatchEvent(touchEvent('touchstart', 400));
+      el.dispatchEvent(touchEvent('touchmove', 450)); // finger moving down = scroll up
+    });
+    // User has scrolled up; content is now above the fold.
+    dims.scrollTop = 200;
+    act(() => flushRaf());
+
+    expect(el.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('does not re-arm following within the old 50px band - only at the true bottom', () => {
+    const { el, dims } = setupActive({ scrollHeight: 1000, clientHeight: 500, scrollTop: 500 });
+
+    // Desktop scroll-up detaches immediately.
+    act(() => {
+      el.dispatchEvent(new WheelEvent('wheel', { deltaY: -20 }));
+    });
+
+    // A scroll event 30px from the bottom (inside the OLD 50px band) must NOT re-arm.
+    dims.scrollTop = 470;
+    act(() => {
+      el.dispatchEvent(new Event('scroll'));
+      flushRaf();
+    });
+    expect(el.scrollTo).not.toHaveBeenCalled();
+
+    // Only a scroll to within the true-bottom epsilon re-arms following.
+    dims.scrollTop = 499; // 1px from bottom
+    act(() => {
+      el.dispatchEvent(new Event('scroll'));
+    });
+    // New tokens grow the content; the re-armed loop pins again.
+    dims.scrollHeight = 1400;
+    act(() => flushRaf());
+    expect(el.scrollTo).toHaveBeenCalledWith({ top: 1400 });
+  });
+
+  it('keeps following suppressed through momentum: a scroll near the bottom during touch does not re-arm', () => {
+    const { el, dims } = setupActive({ scrollHeight: 1000, clientHeight: 500, scrollTop: 500 });
+
+    // Quick flick up that begins at the bottom.
+    act(() => {
+      el.dispatchEvent(touchEvent('touchstart', 400));
+      el.dispatchEvent(touchEvent('touchmove', 420));
+      el.dispatchEvent(touchEvent('touchend', null));
+    });
+
+    // Momentum emits scroll events (no touchmove) while still near the bottom.
+    // Without the userInteracting guard, this would re-arm and snap back.
+    dims.scrollTop = 490; // 10px from bottom, within the momentum settle window
+    act(() => {
+      el.dispatchEvent(new Event('scroll'));
+      flushRaf();
+    });
+    expect(el.scrollTo).not.toHaveBeenCalled();
+
+    // Momentum carries the view further up before the settle timer elapses.
+    dims.scrollTop = 200;
+    act(() => {
+      vi.advanceTimersByTime(400); // TOUCH_SETTLE_MS
+      flushRaf();
+    });
+    // Settled away from the bottom -> following stays detached.
+    expect(el.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('re-arms following when a touch settles at the true bottom (scroll-to-bottom / drag back down)', () => {
+    const { el, dims } = setupActive({ scrollHeight: 1000, clientHeight: 500, scrollTop: 500 });
+
+    act(() => {
+      el.dispatchEvent(touchEvent('touchstart', 400));
+      el.dispatchEvent(touchEvent('touchmove', 450)); // scroll up -> detach
+      el.dispatchEvent(touchEvent('touchend', null));
+    });
+
+    // Finger released at the true bottom; settle timer re-arms following.
+    dims.scrollTop = 500;
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    // New content should now be pinned again.
+    dims.scrollHeight = 1400;
+    act(() => flushRaf());
+    expect(el.scrollTo).toHaveBeenCalledWith({ top: 1400 });
   });
 });

--- a/apps/client/app/components/Session/hooks/useVirtuosoPagination.ts
+++ b/apps/client/app/components/Session/hooks/useVirtuosoPagination.ts
@@ -3,6 +3,17 @@ import { type VirtuosoHandle } from 'react-virtuoso';
 
 const FIRST_ITEM_START = 100_000;
 
+// Re-arm auto-follow only at the TRUE bottom (small epsilon absorbs sub-pixel
+// rounding). A wide band is what trapped the user: a scroll-up during streaming
+// necessarily starts at the bottom, so a wide re-arm threshold snaps the view
+// back before the user can escape it.
+const AT_BOTTOM_EPSILON_PX = 2;
+// After a touch ends, keep auto-follow suppressed briefly. Inertial/momentum
+// scrolling emits `scroll` events but no `touchmove`, so without this settle a
+// flick that begins near the bottom would re-arm following mid-momentum and the
+// per-frame pin would kill the inertia and snap back.
+const TOUCH_SETTLE_MS = 400;
+
 type ChatHistoryItem = { id?: string };
 
 type UseVirtuosoPaginationParams = {
@@ -101,6 +112,11 @@ export function useVirtuosoPagination({
 
     let following = true;
     let rafId: number;
+    // True from touchstart until a short settle after touchend, spanning the
+    // momentum phase. While set, `scroll` events cannot re-arm following, so the
+    // user's inertial scroll-up is never grabbed back by the per-frame pin.
+    let userInteracting = false;
+    let settleTimer: ReturnType<typeof setTimeout> | undefined;
 
     // Wheel/touch are unambiguous user intent (unlike scrollTop, they're immune to the
     // layout jitter the per-frame pin causes), so ANY upward gesture detaches immediately
@@ -112,6 +128,8 @@ export function useVirtuosoPagination({
 
     let lastTouchY: number | null = null;
     const handleTouchStart = (e: TouchEvent) => {
+      userInteracting = true;
+      clearTimeout(settleTimer);
       lastTouchY = e.touches[0]?.clientY ?? null;
     };
     const handleTouchMove = (e: TouchEvent) => {
@@ -120,18 +138,34 @@ export function useVirtuosoPagination({
       if (lastTouchY != null && y != null && y > lastTouchY) following = false;
       lastTouchY = y;
     };
+    const handleTouchEnd = () => {
+      lastTouchY = null;
+      // Delay clearing so momentum scrolling stays covered. On expiry, re-arm
+      // only if inertia actually settled at the true bottom.
+      clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => {
+        userInteracting = false;
+        const distanceFromBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+        if (distanceFromBottom <= AT_BOTTOM_EPSILON_PX) following = true;
+      }, TOUCH_SETTLE_MS);
+    };
 
-    // Resume following once the viewport is back at the bottom (covers the scroll-to-bottom
-    // button, scrollbar drag back down, and end-of-momentum). Layout jitter never sets this
-    // to false, so it can only ever re-enable following - safe to drive off scrollTop here.
+    // Resume following once the viewport is back at the TRUE bottom (covers the
+    // scroll-to-bottom button, scrollbar drag back down, and end-of-momentum).
+    // Gated on !userInteracting so an in-progress touch/momentum scroll-up can't
+    // re-arm it. Layout jitter never sets this to false, so it can only ever
+    // re-enable following - safe to drive off scrollTop here.
     const handleScroll = () => {
+      if (userInteracting) return;
       const distanceFromBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
-      if (distanceFromBottom < 50) following = true;
+      if (distanceFromBottom <= AT_BOTTOM_EPSILON_PX) following = true;
     };
 
     scroller.addEventListener('wheel', handleWheel, { passive: true });
     scroller.addEventListener('touchstart', handleTouchStart, { passive: true });
     scroller.addEventListener('touchmove', handleTouchMove, { passive: true });
+    scroller.addEventListener('touchend', handleTouchEnd, { passive: true });
+    scroller.addEventListener('touchcancel', handleTouchEnd, { passive: true });
     scroller.addEventListener('scroll', handleScroll, { passive: true });
 
     const loop = () => {
@@ -148,9 +182,12 @@ export function useVirtuosoPagination({
     rafId = requestAnimationFrame(loop);
     return () => {
       cancelAnimationFrame(rafId);
+      clearTimeout(settleTimer);
       scroller.removeEventListener('wheel', handleWheel);
       scroller.removeEventListener('touchstart', handleTouchStart);
       scroller.removeEventListener('touchmove', handleTouchMove);
+      scroller.removeEventListener('touchend', handleTouchEnd);
+      scroller.removeEventListener('touchcancel', handleTouchEnd);
       scroller.removeEventListener('scroll', handleScroll);
     };
   }, [isActive]);


### PR DESCRIPTION
## Video

**Before**

https://github.com/user-attachments/assets/e2fc996e-fb4b-42d1-8acc-f5ee5a601456

**After**

https://github.com/user-attachments/assets/253b7581-30ee-4e81-8d6f-a8e22dd10cad

## Description

While an assistant reply is streaming, the chat aggressively pins the scroll to the bottom and the user cannot scroll up to read the start of the reply. You have to wait for the full stream to finish before you can scroll back, which negates the main benefit of streaming.

Two things in `useVirtuosoPagination` combined to trap the user:

1. A `requestAnimationFrame` loop re-pins the scroller to the bottom **every frame** while its `following` flag is set.
2. `handleScroll` re-enabled `following` whenever the viewport was within **50px** of the bottom.

A scroll-up during streaming necessarily _begins at the bottom_ (the user is pinned there), so the per-frame pin snapped the view back before the user could clear the 50px band, and each interleaved `scroll` event re-armed `following`. The result was a dead zone the user could not escape for the entire stream duration.

On touch it was worse: momentum/inertial scrolling emits `scroll` events but **no `touchmove`**, so the `touchmove`-based detach never fired during inertia. A flick that started inside the 50px band re-armed `following` immediately, and the RAF loop killed the inertia and snapped back.

Closes #456

## Changes

- **`useVirtuosoPagination.ts`**
  - Added a `userInteracting` flag, set on `touchstart` and cleared on a `TOUCH_SETTLE_MS` (400ms) timer after `touchend`/`touchcancel` so it spans the momentum phase. While set, `scroll` events cannot re-arm `following` — this is what fixes the mobile momentum case.
  - Tightened the re-arm threshold from `< 50px` to `<= 2px` (`AT_BOTTOM_EPSILON_PX`), i.e. the true bottom with a small epsilon for sub-pixel rounding. This fixes the desktop dead zone.
  - On settle-timer expiry, re-check position and re-arm `following` only if inertia actually landed at the true bottom — so dragging back down to the bottom still resumes auto-follow without waiting on a subsequent scroll event.
  - Registered `touchend`/`touchcancel` listeners and added timer cleanup to the effect teardown.
- **`__tests__/useVirtuosoPagination.test.ts`** — added 5 tests (see below).

**Deliberately unchanged:** the per-frame RAF pin is kept. It exists for the quest spin-up window, where bottom content reflows unpredictably (optimistic prompt bubble mounts, empty reply area sizes itself, optimistic -> streaming footer swaps) and a one-shot scroll undershoots, stranding the loading footer below the fold. Steady-state streaming stickiness is unaffected either way, since Virtuoso's already-wired `followOutput="auto"` handles "at bottom -> keep following". The RAF loop only needed to stop _fighting_ the user.

## Guide for Testers

Environment: the **PR preview** env for this PR, logged in. Preview envs are created on demand by a maintainer; once triggered, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR. Use that URL wherever the steps below say `pr<N>.preview.bike4mind.com`.

This is a client-side scroll fix, so the preview env is the only place the change can actually be observed — staging still has the old behavior until this merges. If you want a BEFORE reference to compare against, use `app.staging.bike4mind.com` and run steps 3 and 8 there: the view will snap back to the bottom.

### Mobile (primary — Android + Chrome, where this was reported)

1. On an Android phone in Chrome, go to `pr<N>.preview.bike4mind.com` and open (or create) a chat session.
2. Type `Write me a 600 word essay about the history of the bicycle` in the message input and send it.
3. As soon as text begins streaming in, flick upward on the message list to scroll back toward the top of the reply.
   - **Expected:** the view scrolls up and **stays** where you left it. Momentum/inertia is not cut short, and the view does not snap back to the bottom.
   - **Before this fix:** the view snapped back to the bottom within a fraction of a second and inertia was killed.
4. While still scrolled up and while the reply is still streaming, scroll around freely (up and down).
   - **Expected:** scrolling is unimpeded for the whole stream. The view never jumps to the bottom on its own.
5. Scroll all the way back down to the very bottom and lift your finger.
   - **Expected:** within about half a second, auto-follow resumes — new tokens keep the view pinned to the bottom as they arrive.
6. Wait for the reply to finish.
   - **Expected:** no snap, jump, or scroll-position jitter when the stream completes.

### Desktop

7. On desktop, open a chat session and send `Write me a 600 word essay about the history of the bicycle`.
8. While it streams, scroll up with the mouse wheel (or a two-finger trackpad swipe up).
   - **Expected:** the view detaches immediately on the first upward notch and stays put. It does not fight you or snap back.
9. Scroll back down to the very bottom.
   - **Expected:** auto-follow resumes and the view stays pinned as new tokens arrive.
10. Repeat step 8, then click the scroll-to-bottom button instead of scrolling manually.
    - **Expected:** the view jumps to the bottom and auto-follow resumes.

### Regression Checks

11. **Loading indicator stays in view on submit (the behavior the RAF loop exists for).** Scroll to the bottom of a session, send a message, and do not touch the scroll.
    - **Expected:** the view scrolls down and the "Running..." / loading status indicator is visible on screen — not stranded below the fold with only your prompt bubble showing.
12. **Same, but submitting while scrolled up.** Scroll up into older history, then send a message.
    - **Expected:** the view scrolls to the bottom and the loading indicator is visible.
13. **Pagination still works.** In a session with a long history, scroll to the very top.
    - **Expected:** older messages load and the scroll position is preserved (no jump to top/bottom).
14. **Session switching.** Switch between two sessions with different history lengths.
    - **Expected:** each opens scrolled to the bottom (newest message).

### What NOT to test

- Message content, model selection, or reply quality — this PR touches scroll behavior only.
- Backend/streaming transport — no server-side changes.

## Additional Information

Verified locally:

- `pnpm --filter @bike4mind/client typecheck` — clean
- `pnpm lint:check` — clean
- Session component tests: **45 files / 320 tests pass**, no regressions
- `useVirtuosoPagination.test.ts`: **14 pass** (9 pre-existing + 5 new)

The 5 new tests use a manual RAF pump plus a scroller stub (settable `scrollTop`/`scrollHeight`, `scrollTo` spy) so the auto-scroll loop advances deterministically. They cover:

1. Pinning to the bottom every frame while following and content is below the fold.
2. Touch drag-down (scroll-up gesture) detaches following and stops pinning.
3. **No re-arm inside the old 50px band** — only at the true bottom (the desktop dead zone).
4. **Following stays suppressed through momentum** — a scroll event near the bottom during the touch settle window does not re-arm (the mobile trap).
5. Following re-arms when a touch settles at the true bottom (drag back down / scroll-to-bottom).

Tests 3 and 4 both fail against the old implementation, so they lock in the fix.

## Developer Notes (Optional)

- **`userInteracting` is a reusable pattern for touch + momentum.** Any scroll handler that wants to distinguish "the user is driving" from "layout moved the scroller" needs to span the _momentum_ phase, not just the touch. `touchstart` -> (`touchend`/`touchcancel` + settle timer) is the shape, because inertial scrolling emits `scroll` with no `touchmove`. A naive `touchmove`-only guard silently fails on exactly the platform where it matters most.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
