### PR TITLE
fix(client): stop mobile partial-copy from over-selecting assistant replies

### DIFF
--- a/apps/client/app/components/Session/PromptReplies.tsx
+++ b/apps/client/app/components/Session/PromptReplies.tsx
@@ -1242,39 +1242,44 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
   );
 
   const tableComponents = {
+    // Wide tables scroll horizontally inside their own wrapper. The reply body is
+    // no longer a scroll container (that caused Android to snap text selection to
+    // whole-block boundaries), so each element that can exceed the width owns its
+    // own overflow.
     table: ({ node, children, ref, ...props }: ComponentProps<'table'> & ExtraProps) => (
-      <Box
-        component="table"
-        sx={{
-          width: '100%',
-          borderCollapse: 'collapse',
-          margin: '1rem 0',
-          border: '1px solid',
-          borderColor: 'neutral.300',
-          borderRadius: '8px',
-          overflow: 'hidden',
-          color: 'text.primary',
-          '& th, & td': {
-            padding: '0.75rem',
+      <Box sx={{ overflowX: 'auto', maxWidth: '100%', margin: '1rem 0' }}>
+        <Box
+          component="table"
+          sx={{
+            width: '100%',
+            borderCollapse: 'collapse',
             border: '1px solid',
-            borderColor: 'divider',
+            borderColor: 'neutral.300',
+            borderRadius: '8px',
+            overflow: 'hidden',
             color: 'text.primary',
-          },
-          '& th': {
-            backgroundColor: 'background.level1',
-            fontWeight: 'bold',
-            borderBottom: '2px solid',
-            borderBottomColor: 'divider',
-            color: 'text.primary',
-          },
-          '& tr:nth-of-type(even)': {
-            backgroundColor: 'background.level1',
-            color: 'text.primary',
-          },
-        }}
-        {...props}
-      >
-        {children}
+            '& th, & td': {
+              padding: '0.75rem',
+              border: '1px solid',
+              borderColor: 'divider',
+              color: 'text.primary',
+            },
+            '& th': {
+              backgroundColor: 'background.level1',
+              fontWeight: 'bold',
+              borderBottom: '2px solid',
+              borderBottomColor: 'divider',
+              color: 'text.primary',
+            },
+            '& tr:nth-of-type(even)': {
+              backgroundColor: 'background.level1',
+              color: 'text.primary',
+            },
+          }}
+          {...props}
+        >
+          {children}
+        </Box>
       </Box>
     ),
     thead: ({ node, children, ref, ...props }: ComponentProps<'thead'> & ExtraProps) => (
@@ -1589,7 +1594,11 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
                       backgroundColor: 'chatbox.replyBg',
                       borderRadius: '8px',
                       color: 'text.primary',
-                      overflowX: 'auto',
+                      // Not a horizontal scroll container: wide children (tables,
+                      // code blocks) own their own overflow. Making the whole reply
+                      // scrollable made Android snap partial-copy selections to whole
+                      // block boundaries. Long unbroken tokens wrap instead.
+                      overflowWrap: 'anywhere',
                       position: 'relative',
                       scrollBehavior: 'smooth',
                       '& p:last-child': { mb: '0 !important' },

--- a/apps/client/app/components/Session/QuoteActions.test.tsx
+++ b/apps/client/app/components/Session/QuoteActions.test.tsx
@@ -34,12 +34,16 @@ function mockPointer(fine: boolean) {
   }));
 }
 
-// Make window.getSelection report a non-empty selection so a mouseup would
-// surface the toolbar - if (and only if) the listener is attached.
-function stubSelection(text = 'partial selection') {
+// Make window.getSelection report a non-empty selection anchored inside the
+// container, so a mouseup would surface the toolbar - if (and only if) the
+// listener is attached and the containment check passes.
+function stubSelection(container: HTMLElement, text = 'partial selection') {
+  const anchorNode = document.createTextNode(text);
+  container.appendChild(anchorNode);
   const range = { getBoundingClientRect: () => ({ left: 100, top: 50, width: 40, height: 16 }) };
   window.getSelection = vi.fn().mockReturnValue({
     toString: () => text,
+    anchorNode,
     getRangeAt: () => range,
     removeAllRanges: vi.fn(),
   }) as unknown as typeof window.getSelection;
@@ -52,7 +56,7 @@ describe('QuoteActions pointer gating', () => {
     vi.useFakeTimers();
     container = document.createElement('div');
     document.body.appendChild(container);
-    stubSelection();
+    stubSelection(container);
   });
 
   afterEach(() => {
@@ -92,5 +96,34 @@ describe('QuoteActions pointer gating', () => {
     });
 
     expect(screen.queryByText('Explain')).toBeNull();
+  });
+
+  it('ignores selections that start outside the reply container', () => {
+    mockPointer(true);
+    // The document-level listener must not fire the toolbar for a selection made
+    // elsewhere on the page (sidebar, another reply, etc.).
+    const outside = document.createElement('div');
+    outside.textContent = 'elsewhere';
+    document.body.appendChild(outside);
+    window.getSelection = vi.fn().mockReturnValue({
+      toString: () => 'elsewhere',
+      anchorNode: outside.firstChild,
+      getRangeAt: () => ({ getBoundingClientRect: () => ({ left: 0, top: 0, width: 10, height: 10 }) }),
+      removeAllRanges: vi.fn(),
+    }) as unknown as typeof window.getSelection;
+
+    render(
+      <Wrapper>
+        <QuoteActions containerRef={{ current: container }} />
+      </Wrapper>
+    );
+
+    act(() => {
+      fireEvent.mouseUp(document);
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(screen.queryByText('Explain')).toBeNull();
+    outside.remove();
   });
 });

--- a/apps/client/app/components/Session/QuoteActions.test.tsx
+++ b/apps/client/app/components/Session/QuoteActions.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { QuoteActions } from './QuoteActions';
+
+/**
+ * The quote toolbar is a desktop mouse feature. It must mount on fine (mouse)
+ * pointers and stay entirely absent on coarse (touch) pointers, where its
+ * mouse-emulation listeners fought native touch selection (see #458).
+ */
+
+vi.mock('@client/app/hooks/useChatInput', () => ({
+  useChatInput: (selector: (s: { setChatInputValue: () => void }) => unknown) =>
+    selector({ setChatInputValue: vi.fn() }),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+function mockPointer(fine: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes('pointer: fine') ? fine : !fine,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+// Make window.getSelection report a non-empty selection so a mouseup would
+// surface the toolbar - if (and only if) the listener is attached.
+function stubSelection(text = 'partial selection') {
+  const range = { getBoundingClientRect: () => ({ left: 100, top: 50, width: 40, height: 16 }) };
+  window.getSelection = vi.fn().mockReturnValue({
+    toString: () => text,
+    getRangeAt: () => range,
+    removeAllRanges: vi.fn(),
+  }) as unknown as typeof window.getSelection;
+}
+
+describe('QuoteActions pointer gating', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    stubSelection();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the quote toolbar after a mouse selection on fine (mouse) pointers', () => {
+    mockPointer(true);
+    render(
+      <Wrapper>
+        <QuoteActions containerRef={{ current: container }} />
+      </Wrapper>
+    );
+
+    act(() => {
+      fireEvent.mouseUp(container);
+      vi.advanceTimersByTime(100); // handleTextSelection re-reads the selection on a 100ms delay
+    });
+
+    expect(screen.getByText('Explain')).toBeTruthy();
+  });
+
+  it('never mounts the toolbar on coarse (touch) pointers', () => {
+    mockPointer(false);
+    render(
+      <Wrapper>
+        <QuoteActions containerRef={{ current: container }} />
+      </Wrapper>
+    );
+
+    act(() => {
+      fireEvent.mouseUp(container);
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(screen.queryByText('Explain')).toBeNull();
+  });
+});

--- a/apps/client/app/components/Session/QuoteActions.tsx
+++ b/apps/client/app/components/Session/QuoteActions.tsx
@@ -38,8 +38,15 @@ export const QuoteActions: FC<QuoteActionsProps> = ({ containerRef }) => {
     setTimeout(() => {
       const selection = window.getSelection();
       const selectionText = selection?.toString().trim() || '';
+      const container = containerRef.current;
 
-      if (selectionText) {
+      // The listener lives on document (so it still works when the reply bubble
+      // streams in after this component mounts), so scope to selections that
+      // actually start inside this reply's container.
+      const anchorNode = selection?.anchorNode ?? null;
+      const isInsideContainer = !!(container && anchorNode && container.contains(anchorNode));
+
+      if (selectionText && isInsideContainer) {
         const range = selection?.getRangeAt(0);
         const rect = range?.getBoundingClientRect();
         if (rect) {
@@ -54,7 +61,7 @@ export const QuoteActions: FC<QuoteActionsProps> = ({ containerRef }) => {
         setShowFloatingButtons(false);
       }
     }, 100);
-  }, []);
+  }, [containerRef]);
 
   const handleTextAction = useCallback(
     (text: string) => {
@@ -95,14 +102,11 @@ export const QuoteActions: FC<QuoteActionsProps> = ({ containerRef }) => {
   useEffect(() => {
     if (!isFinePointer) return;
 
-    const element = containerRef.current;
-    if (element) {
-      element.addEventListener('mouseup', handleTextSelection);
-      return () => {
-        element.removeEventListener('mouseup', handleTextSelection);
-      };
-    }
-  }, [isFinePointer, containerRef, handleTextSelection]);
+    document.addEventListener('mouseup', handleTextSelection);
+    return () => {
+      document.removeEventListener('mouseup', handleTextSelection);
+    };
+  }, [isFinePointer, handleTextSelection]);
 
   if (!isFinePointer || !showFloatingButtons) return null;
 

--- a/apps/client/app/components/Session/QuoteActions.tsx
+++ b/apps/client/app/components/Session/QuoteActions.tsx
@@ -19,6 +19,20 @@ export const QuoteActions: FC<QuoteActionsProps> = ({ containerRef }) => {
   const setChatInputValue = useChatInput(s => s.setChatInputValue);
   const floatingButtonsRef = useRef<HTMLDivElement>(null);
 
+  // This feature is driven entirely by desktop mouse events (mouseup/mousedown).
+  // On touch devices those events are emulated mid long-press / handle-drag, so
+  // clearing and re-reading the selection actively fights the native touch
+  // selection and makes partial copy glitchy. Gate it to fine (mouse) pointers.
+  const [isFinePointer, setIsFinePointer] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(pointer: fine)');
+    setIsFinePointer(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setIsFinePointer(e.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
   const handleTextSelection = useCallback(() => {
     // short delay to allow the selection to be made
     setTimeout(() => {
@@ -59,6 +73,8 @@ export const QuoteActions: FC<QuoteActionsProps> = ({ containerRef }) => {
   }, []);
 
   useEffect(() => {
+    if (!isFinePointer) return;
+
     const handleClickOutside = (event: MouseEvent) => {
       const target = event.target as Node;
       const isInsideContainer = containerRef.current?.contains(target);
@@ -74,9 +90,11 @@ export const QuoteActions: FC<QuoteActionsProps> = ({ containerRef }) => {
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [containerRef, showFloatingButtons, clearSelection]);
+  }, [isFinePointer, containerRef, showFloatingButtons, clearSelection]);
 
   useEffect(() => {
+    if (!isFinePointer) return;
+
     const element = containerRef.current;
     if (element) {
       element.addEventListener('mouseup', handleTextSelection);
@@ -84,9 +102,9 @@ export const QuoteActions: FC<QuoteActionsProps> = ({ containerRef }) => {
         element.removeEventListener('mouseup', handleTextSelection);
       };
     }
-  }, [containerRef, handleTextSelection]);
+  }, [isFinePointer, containerRef, handleTextSelection]);
 
-  if (!showFloatingButtons) return null;
+  if (!isFinePointer || !showFloatingButtons) return null;
 
   return (
     <FloatingButtons

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -585,6 +585,23 @@ ul.custom-mentions-menu-upward > li[aria-selected="true"] {
   }
 }
 
+/* KaTeX renders a visually-hidden MathML duplicate of every equation (default
+   output: 'htmlAndMathml'). It stays in the DOM for screen readers, but must be
+   excluded from text selection so partial copy does not pull in the duplicated
+   LaTeX/MathML alongside the visible equation (especially on mobile). */
+.katex-mathml {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* Wide display equations get their own horizontal scroll. KaTeX ships no
+   overflow on .katex-display, and the reply body is no longer a scroll
+   container, so without this a wide equation would push the page sideways. */
+.katex-display {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
 /* KaTeX Dark Mode Support */
 /* Override KaTeX default colors for dark mode compatibility */
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video


**Clip A - Math duplicate fixed (desktop):** selecting across an equation and copying now pastes the equation once, with no duplicated LaTeX/MathML.

https://github.com/user-attachments/assets/e7396454-ecc6-4fc8-a74c-c60dbfc7f8c3

**Clip B - No custom toolbar on touch (Android):** selecting text in a reply shows only the native Android menu; the Explain/Improve/Quote toolbar no longer appears.

https://github.com/user-attachments/assets/a41479f2-4a90-45ad-b676-85d91f12a34e

**Clip C - Desktop toolbar preserved:** selecting text in a reply still shows the Explain/Improve/Quote toolbar for mouse users.

https://github.com/user-attachments/assets/7eff9e3a-fb0b-4146-a6d1-aed3068d7853


## Description

Closes #458. On mobile (Android + Chrome), copying part of an assistant reply pulls in far more than the selection, and the highlight drag is glitchy. There is no JS clipboard override; the cause is three separate DOM/CSS issues:

1. KaTeX renders with its default `output: 'htmlAndMathml'`, which injects a visually-hidden MathML/LaTeX duplicate of every equation. Those hidden nodes stay selectable, so any selection touching math copies the equation twice. This one is not touch-specific and reproduces on desktop web too.
2. `QuoteActions` (the Explain/Improve/Quote toolbar) attaches desktop `mouseup`/`mousedown` listeners and calls `removeAllRanges()`, with no touch handling. On Android those events are emulated during long-press/handle-drag, so the in-progress touch selection gets wiped/re-read mid-drag.
3. The reply body is a single `overflowX: 'auto'` scroll container wrapping heterogeneous blocks, which makes Android snap partial selections to whole-block boundaries (from before the selection start to the end of the message).

## Changes

- `apps/client/app/globals.css`
  - Add `.katex-mathml { user-select: none }` so KaTeX's hidden MathML/LaTeX duplicate is excluded from selection/copy while staying in the DOM for screen readers. One central rule covers all three render sites (`PromptReplies`, `UserPrompt`, `MarkdownViewer`).
  - Add `.katex-display { overflow-x: auto; overflow-y: hidden }` so wide display equations scroll on their own now that the reply body is no longer a scroll container.
- `apps/client/app/components/Session/QuoteActions.tsx`
  - Gate the whole feature behind `(pointer: fine)`. On coarse-pointer (touch) devices the listeners never mount and nothing renders, so it stops fighting native touch selection. Desktop mouse behavior is unchanged. Includes an SSR guard and a `MediaQueryList` change listener with cleanup.
  - Move the `mouseup` listener from the container element to `document` (scoped by container containment). Previously the listener was attached once from `containerRef.current`, which was still `null` when the reply streamed in after mount - so on a newly created chat the toolbar did not appear until a page refresh. This makes it work regardless of when the reply bubble mounts.
- `apps/client/app/components/Session/PromptReplies.tsx`
  - Wrap tables in their own `overflowX: 'auto'` scroll box and remove `overflowX: 'auto'` from the reply body (replaced with `overflowWrap: 'anywhere'`), so the reply is no longer a single scroll container. Code blocks already scroll via `SyntaxHighlighter`.
- `apps/client/app/components/Session/QuoteActions.test.tsx`
  - New test covering the pointer gate.

## Guide for Testers

Test on an Android phone in Chrome via the preview link, plus one desktop check.

Setup:
1. Open a session and send this prompt: `Explain the Pythagorean theorem in three short paragraphs. Include the formula as a display equation, then give a worked example, then a bullet list of two real-world uses.`
2. Wait for the full reply to render (three paragraphs, an equation, a bullet list).

Math-duplicate copy (Android and desktop):
3. Drag a selection that overlaps the equation.
4. Copy, then paste into a plain-text field (chat input or Notes).
5. Expected: the equation appears exactly once - no duplicated LaTeX/MathML.

Quote toolbar on touch (Android):
6. Select a few words in a reply, then tap the highlighted text.
7. Expected: only the native Android selection menu appears. The custom Explain/Improve/Quote toolbar must never appear on touch.

Wide-content layout (desktop):
8. Send: `Show me a single line of JavaScript at least 300 characters long, all on one line, in a code block.`
9. Expected: the code block scrolls left/right on its own; the whole page never scrolls sideways.
10. Send a prompt for a wide markdown table; expected: the table fits or scrolls within the bubble and the page never scrolls sideways.

Regression Checks:
- Desktop: selecting text in a reply still shows the Explain/Improve/Quote toolbar (feature preserved for mouse users).
- Desktop: in a brand-new chat, selecting text in the first reply shows the toolbar without needing a page refresh.
- Tables, code blocks, and display equations still render correctly and do not overflow the page.

What NOT to test:
- The Android-only block-snapping symptom cannot be reproduced on every device (it is specific to certain Chrome/Android selection engines). Verification of that symptom relies on the original reporter's device.

## Additional Information

Verification status:
- Math-duplicate over-copy: verified fixed on desktop web and on an Android device.
- Pointer gate: verified via unit test and Chrome DevTools device emulation (toolbar hidden on coarse pointer, shown on fine).
- Reply container change: verified no desktop layout regression (tables fit, code scrolls, page does not scroll sideways). The Android block-snapping benefit needs the reporter's device to confirm.

## Developer Notes (Optional)

- The `(pointer: fine)` gate in `QuoteActions` is a reusable pattern for confining mouse-only affordances to non-touch devices.
- Wide-content overflow is now owned per element (tables, code, display math) rather than by the reply container, which keeps the top-level text flow from being a horizontal scroll container.

## Tests

- `apps/client/app/components/Session/QuoteActions.test.tsx` (new)
  - Toolbar mounts after a mouse selection on fine (mouse) pointers.
  - Toolbar never mounts on coarse (touch) pointers.
  - Selections that start outside the reply container are ignored (document-level listener scoping).

Run: `cd apps/client && pnpm vitest run app/components/Session/QuoteActions.test.tsx`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
