### PR TITLE
chore(premium): pin b4m-optihashi overlay for preview testing [DO NOT MERGE]

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "3c5914574e5bdfe61a1403fc98dcf31e2962ca48",
   "b4m-libreoncology": "a44c7f8fc4a89adce670c36ce6f293049641c136",
-  "b4m-optihashi": "f0b0d79c3a415305340cd64a995c538bc2763557",
+  "b4m-optihashi": "cf495e0d78afb05a18168da6827cbcaa4cb97d6a",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — preview-only

Overlay-pin-only change to associate a **preview environment** for verification. Points the `b4m-optihashi` overlay pin at an unmerged commit, so this must not reach `main` (the SHA-on-main guard would happily accept it — the block here is human: do not merge).

## What

Sets the `b4m-optihashi` overlay pin to `cf495e0d78afb05a18168da6827cbcaa4cb97d6a`. Overlay-pin-only change; no application source changes.

## Why

To spin a preview that hydrates the current overlay build for manual verification, then tear it down. The pin will be reverted / resolved to a merged SHA before this branch is ever considered for merge (it will simply be closed once verification is done).
