### PR TITLE
fix(admin): guard Admin Settings against unmapped icon names

### DIFF
--- a/apps/client/app/components/admin/AdminSettingsTab.tsx
+++ b/apps/client/app/components/admin/AdminSettingsTab.tsx
@@ -63,6 +63,7 @@ import ImageIcon from '@mui/icons-material/Image';
 import ChatIcon from '@mui/icons-material/Chat';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import NightsStayIcon from '@mui/icons-material/NightsStay';
+import SpeedIcon from '@mui/icons-material/Speed';
 
 const HEADER_HEIGHT = '100px';
 
@@ -338,7 +339,9 @@ type IconMapType = {
   [K: string]: React.FC<{ sx?: SvgIconProps['sx'] }>;
 };
 
-const IconMap: IconMapType = {
+// Exported for the icon-completeness test that guards against unmapped config
+// icon names (an unmapped name renders <undefined /> and crashes admin settings).
+export const IconMap: IconMapType = {
   SmartToy: JoyIcon(SmartToyIcon),
   Psychology: JoyIcon(PsychologyIcon),
   Assistant: JoyIcon(AssistantIcon),
@@ -369,6 +372,7 @@ const IconMap: IconMapType = {
   Chat: JoyIcon(ChatIcon),
   PictureAsPdf: JoyIcon(PictureAsPdfIcon),
   NightsStay: JoyIcon(NightsStayIcon),
+  Speed: JoyIcon(SpeedIcon),
 };
 
 const settingConfigs = Object.values(settingsMap);
@@ -693,7 +697,9 @@ const AdminSettingsTab: React.FC = () => {
 
   const renderSettingGroup = (settings: typeof settingConfigs, groupName?: string, groupId?: string) => {
     const groupInfo = groupId ? Object.values(API_SERVICE_GROUPS).find(g => g.id === groupId) : null;
-    const IconComponent = groupInfo?.icon ? IconMap[groupInfo.icon] : IconMap.Settings;
+    // Fall back to the Settings gear for a missing OR unmapped icon name so an
+    // unknown key never renders <undefined /> and crashes the tree.
+    const IconComponent = (groupInfo?.icon && IconMap[groupInfo.icon]) || IconMap.Settings;
 
     // Split settings into top-level entries and inline children.
     // A setting is an inline child when:
@@ -864,9 +870,7 @@ const AdminSettingsTab: React.FC = () => {
     data: { ungrouped: typeof settingConfigs; groups: Record<string, typeof settingConfigs> }
   ) => {
     const { ungrouped, groups } = data;
-    const CategoryIconComponent = CATEGORY_ICONS[category as keyof typeof CATEGORY_ICONS]
-      ? IconMap[CATEGORY_ICONS[category as keyof typeof CATEGORY_ICONS]]
-      : IconMap.Settings;
+    const CategoryIconComponent = IconMap[CATEGORY_ICONS[category as keyof typeof CATEGORY_ICONS]] || IconMap.Settings;
     return (
       <Stack key={`category-${category}`} spacing={2}>
         <Stack direction="row" alignItems="center" spacing={1}>
@@ -994,7 +998,7 @@ const AdminSettingsTab: React.FC = () => {
                 }}
               >
                 {Object.entries(SETTING_TABS).map(([tabId, tabInfo]) => {
-                  const TabIcon = IconMap[tabInfo.icon];
+                  const TabIcon = IconMap[tabInfo.icon] || IconMap.Settings;
                   return (
                     <Tab
                       key={tabId}

--- a/apps/client/app/components/admin/AdminSettingsTab.tsx
+++ b/apps/client/app/components/admin/AdminSettingsTab.tsx
@@ -375,6 +375,12 @@ export const IconMap: IconMapType = {
   Speed: JoyIcon(SpeedIcon),
 };
 
+// Resolve a settings icon name to a component, falling back to the Settings gear
+// for a missing OR unmapped name so an unknown key never renders <undefined /> and
+// crashes the tree. Exported for direct unit tests of the fallback behavior.
+export const resolveSettingsIcon = (icon: string | undefined): React.FC<{ sx?: SvgIconProps['sx'] }> =>
+  (icon && IconMap[icon]) || IconMap.Settings;
+
 const settingConfigs = Object.values(settingsMap);
 
 interface EnvVariable {
@@ -697,9 +703,7 @@ const AdminSettingsTab: React.FC = () => {
 
   const renderSettingGroup = (settings: typeof settingConfigs, groupName?: string, groupId?: string) => {
     const groupInfo = groupId ? Object.values(API_SERVICE_GROUPS).find(g => g.id === groupId) : null;
-    // Fall back to the Settings gear for a missing OR unmapped icon name so an
-    // unknown key never renders <undefined /> and crashes the tree.
-    const IconComponent = (groupInfo?.icon && IconMap[groupInfo.icon]) || IconMap.Settings;
+    const IconComponent = resolveSettingsIcon(groupInfo?.icon);
 
     // Split settings into top-level entries and inline children.
     // A setting is an inline child when:
@@ -870,7 +874,7 @@ const AdminSettingsTab: React.FC = () => {
     data: { ungrouped: typeof settingConfigs; groups: Record<string, typeof settingConfigs> }
   ) => {
     const { ungrouped, groups } = data;
-    const CategoryIconComponent = IconMap[CATEGORY_ICONS[category as keyof typeof CATEGORY_ICONS]] || IconMap.Settings;
+    const CategoryIconComponent = resolveSettingsIcon(CATEGORY_ICONS[category as keyof typeof CATEGORY_ICONS]);
     return (
       <Stack key={`category-${category}`} spacing={2}>
         <Stack direction="row" alignItems="center" spacing={1}>
@@ -998,7 +1002,7 @@ const AdminSettingsTab: React.FC = () => {
                 }}
               >
                 {Object.entries(SETTING_TABS).map(([tabId, tabInfo]) => {
-                  const TabIcon = IconMap[tabInfo.icon] || IconMap.Settings;
+                  const TabIcon = resolveSettingsIcon(tabInfo.icon);
                   return (
                     <Tab
                       key={tabId}

--- a/apps/client/app/components/admin/__tests__/adminSettingsIcons.test.ts
+++ b/apps/client/app/components/admin/__tests__/adminSettingsIcons.test.ts
@@ -24,7 +24,12 @@ describe('AdminSettingsTab IconMap completeness', () => {
     expect(IconMap[icon]).toBeDefined();
   });
 
-  it('maps the API Rate Limiting "Speed" icon (regression: All-Tabs white-screen crash)', () => {
+  // The it.each above already asserts 'Speed' is present (it's RATE_LIMITING's icon).
+  // This anchor adds the part that check can't: 'Speed' must be its OWN entry, not
+  // aliased to the Settings fallback -- otherwise the group would silently show the
+  // generic gear instead of the speedometer that regressed in production.
+  it('maps "Speed" to a dedicated icon, not the Settings fallback (regression: All-Tabs white-screen crash)', () => {
     expect(IconMap.Speed).toBeDefined();
+    expect(IconMap.Speed).not.toBe(IconMap.Settings);
   });
 });

--- a/apps/client/app/components/admin/__tests__/adminSettingsIcons.test.ts
+++ b/apps/client/app/components/admin/__tests__/adminSettingsIcons.test.ts
@@ -1,0 +1,30 @@
+/**
+ * IconMap completeness guard for AdminSettingsTab.
+ *
+ * renderSettingGroup / renderCategory / the tab bar resolve a group's, category's,
+ * or tab's icon name against IconMap and render it directly (`<IconComponent />`).
+ * When a configured icon name has no IconMap entry the lookup yields `undefined`,
+ * and rendering `<undefined />` throws "Element type is invalid" -- a white-screen
+ * crash. Production hit this via the API Rate Limiting group's 'Speed' icon, which
+ * only became visible in All-Tabs search mode. This test fails if any icon name in
+ * the settings config drifts away from IconMap again.
+ */
+import { describe, it, expect } from 'vitest';
+import { API_SERVICE_GROUPS, CATEGORY_ICONS, SETTING_TABS } from '@bike4mind/common';
+import { IconMap } from '../AdminSettingsTab';
+
+const referencedIcons: { icon: string; source: string }[] = [
+  ...Object.values(API_SERVICE_GROUPS).map(g => ({ icon: g.icon, source: `API_SERVICE_GROUPS.${g.id}` })),
+  ...Object.entries(CATEGORY_ICONS).map(([category, icon]) => ({ icon, source: `CATEGORY_ICONS.${category}` })),
+  ...Object.values(SETTING_TABS).map(t => ({ icon: t.icon, source: `SETTING_TABS.${t.id}` })),
+];
+
+describe('AdminSettingsTab IconMap completeness', () => {
+  it.each(referencedIcons)('maps "$icon" referenced by $source to a component', ({ icon }) => {
+    expect(IconMap[icon]).toBeDefined();
+  });
+
+  it('maps the API Rate Limiting "Speed" icon (regression: All-Tabs white-screen crash)', () => {
+    expect(IconMap.Speed).toBeDefined();
+  });
+});

--- a/apps/client/app/components/admin/__tests__/adminSettingsIcons.test.ts
+++ b/apps/client/app/components/admin/__tests__/adminSettingsIcons.test.ts
@@ -11,7 +11,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { API_SERVICE_GROUPS, CATEGORY_ICONS, SETTING_TABS } from '@bike4mind/common';
-import { IconMap } from '../AdminSettingsTab';
+import { IconMap, resolveSettingsIcon } from '../AdminSettingsTab';
 
 const referencedIcons: { icon: string; source: string }[] = [
   ...Object.values(API_SERVICE_GROUPS).map(g => ({ icon: g.icon, source: `API_SERVICE_GROUPS.${g.id}` })),
@@ -31,5 +31,21 @@ describe('AdminSettingsTab IconMap completeness', () => {
   it('maps "Speed" to a dedicated icon, not the Settings fallback (regression: All-Tabs white-screen crash)', () => {
     expect(IconMap.Speed).toBeDefined();
     expect(IconMap.Speed).not.toBe(IconMap.Settings);
+  });
+});
+
+describe('resolveSettingsIcon fallback', () => {
+  it('returns the mapped component for a known icon name', () => {
+    expect(resolveSettingsIcon('Speed')).toBe(IconMap.Speed);
+  });
+
+  it('falls back to the Settings gear for an unmapped name instead of undefined', () => {
+    // 'Speed' before it was added to IconMap is exactly this case -- the crash guard.
+    expect(resolveSettingsIcon('NotARealIcon')).toBe(IconMap.Settings);
+  });
+
+  it('falls back to the Settings gear for undefined and empty names', () => {
+    expect(resolveSettingsIcon(undefined)).toBe(IconMap.Settings);
+    expect(resolveSettingsIcon('')).toBe(IconMap.Settings);
   });
 });


### PR DESCRIPTION
# Pull Request

## Screenshots

<img width="1193" height="726" alt="Screenshot 2026-07-13 at 3 36 10 pm" src="https://github.com/user-attachments/assets/fd90e37f-cc04-4141-99f9-e0af55ad936f" />


## Description

Fixes #481. In production, Admin Settings white-screened while searching: type a query, enable **Search all tabs**, then delete characters to broaden the search. React threw `Element type is invalid ... but got: undefined` and crashed the client.

Root cause: the **API Rate Limiting** settings group (`API_SERVICE_GROUPS.RATE_LIMITING`) declares `icon: 'Speed'`, but `'Speed'` had no entry in the component's `IconMap`. The icon fallback (`groupInfo?.icon ? IconMap[groupInfo.icon] : IconMap.Settings`) only covered a *falsy* icon name -- a non-empty name with no `IconMap` key resolves to `undefined`, and rendering `<undefined />` throws.

The All-Tabs + delete-characters path is just the most common way to make that group visible from the default tab: broadening the query eventually matches the rate-limit settings, the group mounts, and the crash fires.

## Changes

- Add the missing `Speed` icon to `IconMap` so the API Rate Limiting group renders its intended speedometer icon.
- Fall back to `IconMap.Settings` for a missing **or unmapped** icon name at all three lookup sites -- group (`renderSettingGroup`), category (`renderCategory`), and the tab bar (which previously had no fallback at all). An unknown key can no longer render an undefined element.
- Add `apps/client/app/components/admin/__tests__/adminSettingsIcons.test.ts`: asserts every icon name referenced by the settings config (`API_SERVICE_GROUPS`, `CATEGORY_ICONS`, `SETTING_TABS`) resolves to a component in `IconMap`, with an explicit `Speed` regression case. This catches the whole class of config drift.

## Guide for Testers

1. Go to `app.staging.bike4mind.com` and sign in as an admin.
2. Open **Sidebar -> Admin -> Settings**.
3. In the settings search box, type `rate`. Expected: results filter, no crash.
4. Enable the **All Tabs** checkbox (`admin-settings-all-tabs-checkbox`). Expected: settings from every tab appear, no crash.
5. Delete characters from the search box one at a time until it is empty. Expected: the **API Rate Limiting** group appears (with a speedometer icon) and the screen keeps rendering -- no white screen, no console `Element type is invalid` error.
6. Open **Sidebar -> Admin -> Settings -> Security tab** directly and confirm the **API Rate Limiting** group renders with its icon.

### Regression Checks

1. Every settings tab (AI Configuration, External Integrations, Features, Security, User Management, Communications, Customization) still renders its tab icon and group/category icons correctly.
2. Toggling **All Tabs** on and off still filters settings without error.

### What NOT to test

- No backend, API, or data-model changes -- this is a client-only rendering fix.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
