### PR TITLE
ci: rename required CI-gate check "Deploy" -> "CI Complete"

### DIFF
--- a/.github/actions/changes-filter/README.md
+++ b/.github/actions/changes-filter/README.md
@@ -26,7 +26,7 @@ a code+docs PR is `true, true`; a `.changeset` or root-`README` change is
 
 - **Per-PR, not per-push.** GitHub `paths-ignore` (and `dorny/paths-filter`'s PR
   mode) match the *whole PR diff vs base*; a workflow-level `paths-ignore` also
-  skips the entire workflow, so a required `Deploy`/`Run Tests` context never
+  skips the entire workflow, so a required `CI Complete`/`Run Tests` context never
   reports and the PR hangs. Here the `changes` gate job always runs and downstream
   jobs skip via `if:`, which branch protection counts as passing.
 - **Merge-base scoped (per #4540).** On every `pull_request` action the diff is the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 # App CI: build, typecheck, lint, unit tests, and the CLI e2e harness. The merge
 # gate for this repo. Deploys no longer run here: staging + production are handled
 # by the internal deployer (deploy.bike4mind.com), and PR previews are created on
-# demand by maintainers there. See the `deploy-status` job for why the required
-# check is still named "Deploy".
+# demand by maintainers there. See the `ci-complete` job for the single required
+# "CI Complete" aggregate check.
 
 on:
   push:
@@ -16,7 +16,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     # NOTE: no workflow-level paths-ignore. The `changes` gate below evaluates
     # the per-PR (merge-base) diff and skips the build/test legs on non-deployable
-    # changes, while still reporting the required Deploy/Run Tests checks (a
+    # changes, while still reporting the required CI Complete/Run Tests checks (a
     # paths-ignore-skipped workflow never reports them and hangs the PR).
   merge_group:
     branches: [main]
@@ -523,30 +523,30 @@ jobs:
 
   # verify-docs-build removed: the Docusaurus scaffolding (docs-site/package.json,
   # lockfile, config) is not tracked in this repo, so the build can never succeed
-  # here and was failing the required Deploy check on every docs-touching PR.
+  # here and was failing the required CI Complete check on every docs-touching PR.
   # Markdown content is still validated by the help-content tests in the test
   # suite. Restore the job (and .github/workflows/_verify-docs-build.yml) when
   # the scaffolding lands.
 
   # ============================================================
   # CI gate aggregation. The branch rulesets (main-protection + prod-protection)
-  # require a status check named exactly "Deploy". Deploy itself moved out of
-  # this repo to the internal deployer, so this job no longer gates a deploy;
-  # it re-exposes a single stable "Deploy" check that turns red if any CI leg
-  # failed. The check name is deliberately kept as "Deploy" so the existing
-  # rulesets keep matching; renaming it to "CI" is a follow-up that must edit
-  # both rulesets in the same change (a required check with no matching job
-  # hangs every PR).
+  # require a single status check named exactly "CI Complete". Deploy moved out
+  # of this repo to the internal deployer, so there is no deploy to gate; this
+  # job re-exposes one stable check that turns red if any CI leg failed.
   #
   # Red when ANY CI leg (changes/core-build/typecheck/lint/test/cli-e2e)
   # genuinely FAILED. Green when everything succeeded OR was legitimately
   # skipped (a non-deployable change skips core-build..cli-e2e, and a skipped
   # required check counts as passing). This surfaces typecheck/lint/cli-e2e
   # failures (none of which are individually required checks) through the one
-  # required "Deploy" check instead of letting them pass silently.
+  # required "CI Complete" check instead of letting them pass silently.
+  #
+  # NOTE: this job name IS the required-check context. Renaming it must happen
+  # in lockstep with editing both rulesets, or a required check with no matching
+  # job hangs every PR.
   # ============================================================
-  deploy-status:
-    name: Deploy
+  ci-complete:
+    name: CI Complete
     needs: [changes, core-build, typecheck, lint, test, cli-e2e]
     if: always()
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}


### PR DESCRIPTION
Follow-up to #485. That PR kept the aggregate CI-gate job named `Deploy` so the branch rulesets kept matching after the deploy pipeline moved out of this repo. Nothing deploys from here anymore, so the name was misleading.

- Renames the terminal `deploy-status` job (nothing `needs:` it) to `ci-complete` / `name: CI Complete`, and repoints the comments.
- The job still does the same work: one required check that turns red if any CI leg (`changes/core-build/typecheck/lint/test/cli-e2e`) failed, green when all passed or were legitimately skipped.

**Coordinated ruleset edit (required, done in lockstep at merge):** the `main-protection` and `prod-protection` rulesets require a check named `Deploy`; both are being repointed to `CI Complete`. A required check with no matching job hangs every PR, so the ruleset edit and this merge happen together.

Note: other open PRs will need to rebase onto main after this lands to pick up the renamed job (their runs still emit `Deploy` until then).
