### PR TITLE
fix(client): keep Knowledge Base on newest artifact version on mobile (#457)

### DIFF
--- a/apps/client/app/components/GenAI/CodeArtifactPreviewCard.tsx
+++ b/apps/client/app/components/GenAI/CodeArtifactPreviewCard.tsx
@@ -11,6 +11,7 @@ import {
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter/dist/cjs';
 import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSessionLayout';
+import { useSelectedArtifactContentSync } from '@client/app/hooks/useSelectedArtifactContentSync';
 import { useSessions, useWorkBenchFiles, useWorkBenchActions } from '@client/app/contexts/SessionsContext';
 import { KnowledgeType } from '@bike4mind/common';
 import { createFabFileOnServerWithUpload } from '@client/app/utils/filesAPICalls';
@@ -140,25 +141,9 @@ const CodeArtifactPreviewCard: React.FC<CodeArtifactPreviewCardProps> = ({ data,
     }
   };
 
-  // Listen for selected artifact content changes and update the knowledge viewer
-  useEffect(() => {
-    const currentState = useSessionLayout.getState();
-
-    // Only update if this artifact is currently selected and the content has actually changed
-    if (currentState.selectedArtifactId === artifactId && currentState.artifactData?.type === 'code') {
-      const currentContent = currentState.artifactData.content as CodeArtifactData;
-
-      // Compare the actual content to avoid unnecessary updates
-      if (JSON.stringify(currentContent) !== JSON.stringify(data)) {
-        setSessionLayout({
-          artifactData: {
-            ...currentState.artifactData,
-            content: data,
-          },
-        });
-      }
-    }
-  }, [artifactId, data.code, data.title, data.description]);
+  // Propagate live content changes to the Knowledge Base without letting a scroll-driven
+  // (re)mount of a same-id card clobber the newest version - see the hook for the #457 detail.
+  useSelectedArtifactContentSync(artifactId, 'code', data.code, data);
 
   return (
     <Card

--- a/apps/client/app/components/GenAI/HtmlArtifactPreviewCard.syncGuard.test.tsx
+++ b/apps/client/app/components/GenAI/HtmlArtifactPreviewCard.syncGuard.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { HtmlArtifact } from '@bike4mind/common';
+
+// Regression guard for #457: an iterated artifact's v1/v2 chat cards share the same id, so a
+// same-id card that merely mounts (or re-mounts on scroll) must NOT overwrite the shared
+// Knowledge Base store with its own content. Only a content change observed while the card
+// stays mounted (live streaming) may propagate.
+
+vi.mock('./InlineArtifactPreview', () => ({ default: () => <div data-testid="inline-artifact-preview" /> }));
+
+vi.mock('@client/app/contexts/SessionsContext', () => ({
+  useSessions: () => ({ currentSession: null, setCurrentSession: vi.fn(), currentSessionId: 's1' }),
+  useWorkBenchFiles: () => [],
+  useWorkBenchActions: () => ({ setWorkBenchFiles: vi.fn() }),
+}));
+
+// Hoisted so the vi.mock factory (also hoisted) can close over them.
+const { setSessionLayout, getState } = vi.hoisted(() => ({
+  setSessionLayout: vi.fn(),
+  // The card is "selected" (viewer open on this id) so the sync effect's guard is exercised.
+  getState: () => ({
+    selectedArtifactId: 'a1',
+    artifactData: { type: 'html', id: 'a1', mimeType: 'text/html', content: { id: 'a1', content: '<old/>' } },
+  }),
+}));
+
+vi.mock('@client/app/hooks/useSessionLayout', () => {
+  const hook = () => undefined;
+  return {
+    default: Object.assign(hook, { getState }),
+    setSessionLayout,
+    setSelectedArtifactVersion: vi.fn(),
+  };
+});
+
+vi.mock('@client/app/hooks/useFeatureEnabled', () => ({
+  useFeatureEnabled: () => ({ isFeatureEnabled: () => false }),
+}));
+vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }));
+vi.mock('@client/app/utils/filesAPICalls', () => ({ createFabFileOnServerWithUpload: vi.fn() }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import HtmlArtifactPreviewCard from './HtmlArtifactPreviewCard';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const mk = (content: string) => ({ id: 'a1', title: 'T', content, metadata: {} }) as unknown as HtmlArtifact;
+
+describe('HtmlArtifactPreviewCard store-sync guard (#457)', () => {
+  beforeEach(() => setSessionLayout.mockClear());
+
+  it('does not push to the store on initial mount (scroll-in must not clobber)', () => {
+    render(
+      <TestWrapper>
+        <HtmlArtifactPreviewCard artifact={mk('<v2-red/>')} />
+      </TestWrapper>
+    );
+    expect(setSessionLayout).not.toHaveBeenCalled();
+  });
+
+  it('pushes when content changes while the card stays mounted (live streaming)', () => {
+    const { rerender } = render(
+      <TestWrapper>
+        <HtmlArtifactPreviewCard artifact={mk('<v2-partial/>')} />
+      </TestWrapper>
+    );
+    expect(setSessionLayout).not.toHaveBeenCalled();
+
+    rerender(
+      <TestWrapper>
+        <HtmlArtifactPreviewCard artifact={mk('<v2-final/>')} />
+      </TestWrapper>
+    );
+    expect(setSessionLayout).toHaveBeenCalledTimes(1);
+    expect(setSessionLayout.mock.calls[0][0].artifactData.content.content).toBe('<v2-final/>');
+  });
+
+  it('a freshly mounted older card does not clobber the store', () => {
+    // Simulate scrolling an old (v1) card into view: a brand-new component instance mounts.
+    const { unmount } = render(
+      <TestWrapper>
+        <HtmlArtifactPreviewCard artifact={mk('<v2-red/>')} />
+      </TestWrapper>
+    );
+    unmount();
+    setSessionLayout.mockClear();
+
+    render(
+      <TestWrapper>
+        <HtmlArtifactPreviewCard artifact={mk('<v1-blue/>')} />
+      </TestWrapper>
+    );
+    expect(setSessionLayout).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/GenAI/HtmlArtifactPreviewCard.tsx
+++ b/apps/client/app/components/GenAI/HtmlArtifactPreviewCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Box, Card, Typography, Chip, Stack, IconButton, Tooltip } from '@mui/joy';
 import {
   OpenInFull as ExpandIcon,
@@ -11,6 +11,7 @@ import {
 } from '@mui/icons-material';
 import InlineArtifactPreview from './InlineArtifactPreview';
 import useSessionLayout, { setSessionLayout, setSelectedArtifactVersion } from '@client/app/hooks/useSessionLayout';
+import { useSelectedArtifactContentSync } from '@client/app/hooks/useSelectedArtifactContentSync';
 import { useSessions, useWorkBenchFiles, useWorkBenchActions } from '@client/app/contexts/SessionsContext';
 import { KnowledgeType } from '@bike4mind/common';
 import { createFabFileOnServerWithUpload } from '@client/app/utils/filesAPICalls';
@@ -119,26 +120,9 @@ const HtmlArtifactPreviewCard: React.FC<HtmlArtifactPreviewCardProps> = ({ artif
     }
   };
 
-  // Listen for selected artifact content changes and update the knowledge viewer
-  useEffect(() => {
-    const currentState = useSessionLayout.getState();
-
-    // Only update if this artifact is currently selected and the content has actually changed
-    if (currentState.selectedArtifactId === effectiveArtifact.id && currentState.artifactData?.type === 'html') {
-      const currentContent = currentState.artifactData.content as HtmlArtifact;
-
-      // Compare the actual content to avoid unnecessary updates
-      if (JSON.stringify(currentContent) !== JSON.stringify(effectiveArtifact)) {
-        setSessionLayout({
-          artifactData: {
-            ...currentState.artifactData,
-            content: effectiveArtifact,
-          },
-        });
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [effectiveArtifact.id, effectiveArtifact.content, effectiveArtifact.metadata]);
+  // Propagate live content changes to the Knowledge Base without letting a scroll-driven
+  // (re)mount of a same-id card clobber the newest version - see the hook for the #457 detail.
+  useSelectedArtifactContentSync(effectiveArtifact.id, 'html', effectiveArtifact.content, effectiveArtifact);
 
   const lineCount = effectiveArtifact.content.split('\n').length;
   const complexityColor = getComplexityColor(effectiveArtifact.content);

--- a/apps/client/app/components/GenAI/ReactArtifactPreviewCard.tsx
+++ b/apps/client/app/components/GenAI/ReactArtifactPreviewCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Box, Card, Typography, Chip, Stack, IconButton, Tooltip } from '@mui/joy';
 import {
   Code as ReactIcon,
@@ -12,6 +12,7 @@ import {
 } from '@mui/icons-material';
 import InlineArtifactPreview from './InlineArtifactPreview';
 import useSessionLayout, { setSessionLayout, setSelectedArtifactVersion } from '@client/app/hooks/useSessionLayout';
+import { useSelectedArtifactContentSync } from '@client/app/hooks/useSelectedArtifactContentSync';
 import { useSessions, useWorkBenchFiles, useWorkBenchActions } from '@client/app/contexts/SessionsContext';
 import { KnowledgeType } from '@bike4mind/common';
 import { createFabFileOnServerWithUpload } from '@client/app/utils/filesAPICalls';
@@ -114,26 +115,9 @@ const ReactArtifactPreviewCard: React.FC<ReactArtifactPreviewCardProps> = ({ art
     }
   };
 
-  // Listen for selected artifact content changes and update the knowledge viewer
-  useEffect(() => {
-    const currentState = useSessionLayout.getState();
-
-    // Only update if this artifact is currently selected and the content has actually changed
-    if (currentState.selectedArtifactId === effectiveArtifact.id && currentState.artifactData?.type === 'react') {
-      const currentContent = currentState.artifactData.content as ReactArtifact;
-
-      // Compare the actual content to avoid unnecessary updates
-      if (JSON.stringify(currentContent) !== JSON.stringify(effectiveArtifact)) {
-        setSessionLayout({
-          artifactData: {
-            ...currentState.artifactData,
-            content: effectiveArtifact,
-          },
-        });
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [effectiveArtifact.id, effectiveArtifact.content, effectiveArtifact.metadata]);
+  // Propagate live content changes to the Knowledge Base without letting a scroll-driven
+  // (re)mount of a same-id card clobber the newest version - see the hook for the #457 detail.
+  useSelectedArtifactContentSync(effectiveArtifact.id, 'react', effectiveArtifact.content, effectiveArtifact);
 
   const dependencies = effectiveArtifact.metadata?.dependencies || [];
   const lineCount = effectiveArtifact.content.split('\n').length;

--- a/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
@@ -90,6 +90,7 @@ import { useArtifactPersistence } from '@client/app/hooks/useArtifactPersistence
 import ContentPreviewModal from '@client/app/components/ProfileModal/ContentPreviewModal';
 import { useAdminTools } from '@client/app/hooks/useAdminTools';
 import { useMessageFiles } from '@client/app/hooks/useMessageFiles';
+import { useIsMobile } from '@client/app/hooks/useIsMobile';
 import { useQuestExport } from '@client/app/hooks/data/useQuestExport';
 import ErrorBoundary from '@client/app/components/common/ErrorBoundary';
 
@@ -266,6 +267,39 @@ const useKnowledgeViewer = create<KnowledgeViewerState>(() => ({
 
 export const setKnowledgeViewer = useKnowledgeViewer.setState;
 
+/**
+ * Decides whether the KnowledgeViewer should overwrite the content it is currently showing
+ * with the copy fetched from the DB.
+ *
+ * The content shown when the viewer opens is the freshly-iterated/streamed version, which
+ * reaches memory (via the chat preview card and the one-shot write on open) BEFORE the async
+ * on-quest-completion persist finishes. During that window a DB read returns the PREVIOUS
+ * version. Blindly applying it is the #457 regression - the just-opened version flickers back
+ * to the stale one. The opened content carries no version of its own, so we cannot compare
+ * versions directly; instead we compare the DB version against a `baselineVersion` captured
+ * when the current content was pinned (the DB version present at open time):
+ *
+ *  - If the DB content already equals what we show, there is nothing to do.
+ *  - Otherwise adopt the DB copy ONLY when it is a strictly NEWER version than the baseline
+ *    (a genuine new persisted version), never a same-or-older-version stale read.
+ *
+ * Missing versions coerce to 0. Extracted as a pure predicate so the guard can be unit tested
+ * without mounting KnowledgeViewer.
+ */
+export const shouldSyncArtifactFromDb = (params: {
+  currentContent?: string;
+  latestContent?: string;
+  latestVersion?: number;
+  baselineVersion?: number;
+}): boolean => {
+  // Already showing the DB's content - nothing to sync.
+  if (params.latestContent === params.currentContent) return false;
+
+  // Content differs: adopt only a strictly newer version than the pinned baseline, so the
+  // stale read during the persist race cannot downgrade the just-opened version.
+  return (params.latestVersion ?? 0) > (params.baselineVersion ?? 0);
+};
+
 const isMarkdownFile = (item: KnowledgeItem | undefined) => {
   if (!item || item.type !== 'file') return false;
   const mime = item.content.mimeType;
@@ -334,6 +368,7 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
   const recentArtifacts = useSessionLayout(s => s.recentArtifacts);
   const selectedArtifactId = useSessionLayout(s => s.selectedArtifactId);
   const { canUseAdminTools } = useAdminTools();
+  const isMobile = useIsMobile();
   const { selectedTabIndex, showLineNumbers } = useKnowledgeViewer();
   const layout = useSessionLayout(s => s.layout);
   const questExport = useQuestExport();
@@ -358,9 +393,22 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
 
   // Ref tracks the last updated version to prevent infinite loops.
   const lastUpdatedVersionRef = React.useRef<number | undefined>(undefined);
+  // The artifact id (and DB version at that moment) that the currently-shown content was
+  // pinned to. Captured on (re)open so shouldSyncArtifactFromDb only adopts a strictly newer
+  // persisted version, never the stale read during the async persist race (#457).
+  const syncArtifactIdRef = React.useRef<string | undefined>(undefined);
+  const syncBaselineVersionRef = React.useRef<number | undefined>(undefined);
 
   useEffect(() => {
     if (latestArtifact?.artifact.id && artifactData?.id && artifactData.id === latestArtifact.artifact.id) {
+      // On switching to a different artifact, pin the baseline to the DB version present now
+      // (the version the just-opened content sits at or ahead of) and reset loop tracking.
+      if (syncArtifactIdRef.current !== artifactData.id) {
+        syncArtifactIdRef.current = artifactData.id;
+        syncBaselineVersionRef.current = latestArtifact.artifact.version;
+        lastUpdatedVersionRef.current = undefined;
+      }
+
       if (lastUpdatedVersionRef.current === latestArtifact.artifact.version) {
         return;
       }
@@ -373,12 +421,17 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
       type PersistedType = (typeof persistedTypes)[number];
       const isPersistedType = (persistedTypes as readonly string[]).includes(artifactData.type);
 
-      // Skip when nothing changed, to avoid infinite loops.
+      // Skip when nothing changed (avoids an infinite loop) and never regress to an older
+      // persisted version - see shouldSyncArtifactFromDb for the #457 rationale.
       // Loose cast: all persisted artifact shapes agree on `content: string`.
       const currentArtifact = artifactData.content as { content?: string; version?: number };
-      const needsUpdate =
-        latestArtifact.content?.content !== currentArtifact.content ||
-        latestArtifact.artifact.version !== currentArtifact.version;
+
+      const needsUpdate = shouldSyncArtifactFromDb({
+        currentContent: currentArtifact.content,
+        latestContent: latestArtifact.content?.content,
+        latestVersion: latestArtifact.artifact.version,
+        baselineVersion: syncBaselineVersionRef.current,
+      });
 
       if (!needsUpdate) {
         // Advance the ref even when skipping, so this version is not rechecked.
@@ -388,6 +441,8 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
 
       if (isPersistedType && artifactData.content) {
         lastUpdatedVersionRef.current = latestArtifact.artifact.version;
+        // Adopting a strictly newer version - advance the pinned baseline to it.
+        syncBaselineVersionRef.current = latestArtifact.artifact.version;
 
         // Generic persisted-artifact envelope. Each concrete type (ReactArtifact,
         // HtmlArtifact, etc.) has this shape plus type-specific metadata; keep the
@@ -1199,7 +1254,17 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
           gap: '8px',
         })}
       >
-        <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: '1rem', width: '100%' }}>
+        <Box
+          sx={{
+            display: 'grid',
+            // On phones the toolbar has too many icon buttons to fit beside the file
+            // selector, so stack them (selector on top, controls below) and let the
+            // controls row wrap - otherwise download/close overflow off-screen (#457).
+            gridTemplateColumns: isMobile ? '1fr' : '1fr auto',
+            gap: '1rem',
+            width: '100%',
+          }}
+        >
           <Grid sm xs={12}>
             <Select
               className="knowledge-viewer-select"
@@ -1229,8 +1294,10 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
           <Grid
             sx={(theme: Theme) => ({
               display: 'flex',
+              flexWrap: 'wrap',
+              rowGap: '8px',
               gap: '8px',
-              justifyContent: 'flex-end',
+              justifyContent: isMobile ? 'flex-start' : 'flex-end',
               '& .MuiSvgIcon-root, .lucide-picture-in-picture, .lucide-x': {
                 height: '16px',
                 width: '16px',

--- a/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
@@ -403,6 +403,10 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
     if (latestArtifact?.artifact.id && artifactData?.id && artifactData.id === latestArtifact.artifact.id) {
       // On switching to a different artifact, pin the baseline to the DB version present now
       // (the version the just-opened content sits at or ahead of) and reset loop tracking.
+      // Re-baseline keys on the artifact id only, NOT on close/reopen of the same id. That is
+      // safe because handleOpenInViewer invalidates the ['artifact', id] query on open and the
+      // "content matches" short-circuit in shouldSyncArtifactFromDb covers a same-id reopen; a
+      // refactor that removes either precondition must also re-pin the baseline on reopen.
       if (syncArtifactIdRef.current !== artifactData.id) {
         syncArtifactIdRef.current = artifactData.id;
         syncBaselineVersionRef.current = latestArtifact.artifact.version;

--- a/apps/client/app/components/Knowledge/__tests__/shouldSyncArtifactFromDb.test.ts
+++ b/apps/client/app/components/Knowledge/__tests__/shouldSyncArtifactFromDb.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { shouldSyncArtifactFromDb } from '../KnowledgeViewer';
+
+describe('shouldSyncArtifactFromDb', () => {
+  it('does not downgrade the just-opened version during the persist race (#457)', () => {
+    // We show the freshly-iterated v2 ("new"); the DB still holds the previous version ("old")
+    // at the same version number as the pinned baseline. Must NOT adopt it.
+    expect(
+      shouldSyncArtifactFromDb({
+        currentContent: 'new',
+        latestContent: 'old',
+        latestVersion: 1,
+        baselineVersion: 1,
+      })
+    ).toBe(false);
+  });
+
+  it('adopts the DB copy when it is a strictly newer version than the baseline', () => {
+    // The persist caught up / a genuinely newer version exists.
+    expect(
+      shouldSyncArtifactFromDb({
+        currentContent: 'shown',
+        latestContent: 'newer',
+        latestVersion: 2,
+        baselineVersion: 1,
+      })
+    ).toBe(true);
+  });
+
+  it('does nothing when the DB content already matches what is shown', () => {
+    expect(
+      shouldSyncArtifactFromDb({
+        currentContent: 'same',
+        latestContent: 'same',
+        latestVersion: 5,
+        baselineVersion: 1,
+      })
+    ).toBe(false);
+  });
+
+  it('does not adopt a differing DB copy at a lower version than the baseline', () => {
+    expect(
+      shouldSyncArtifactFromDb({
+        currentContent: 'shown',
+        latestContent: 'stale',
+        latestVersion: 1,
+        baselineVersion: 3,
+      })
+    ).toBe(false);
+  });
+
+  it('treats missing versions as 0 (equal -> no downgrade)', () => {
+    // Both undefined -> 0, not strictly greater, and content differs -> keep what is shown.
+    expect(
+      shouldSyncArtifactFromDb({
+        currentContent: 'fresh',
+        latestContent: 'stale',
+        latestVersion: undefined,
+        baselineVersion: undefined,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/client/app/hooks/useSelectedArtifactContentSync.test.tsx
+++ b/apps/client/app/hooks/useSelectedArtifactContentSync.test.tsx
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The store-sync guard shared by the Html/React/Code preview cards. An iterated artifact's
+// v1/v2 cards share the same id, so a card mounting (or re-mounting on scroll) must not
+// overwrite the shared store; only a change observed while mounted (live streaming) may push
+// (#457).
+
+const { setSessionLayout, getState } = vi.hoisted(() => ({
+  setSessionLayout: vi.fn(),
+  getState: vi.fn(),
+}));
+
+vi.mock('@client/app/hooks/useSessionLayout', () => {
+  const hook = () => undefined;
+  return { default: Object.assign(hook, { getState }), setSessionLayout };
+});
+
+import { useSelectedArtifactContentSync } from './useSelectedArtifactContentSync';
+
+// Card is selected and showing '<old/>' for id 'a1'.
+const selectedState = () => ({
+  selectedArtifactId: 'a1',
+  artifactData: { type: 'html', id: 'a1', mimeType: 'text/html', content: { id: 'a1', content: '<old/>' } },
+});
+
+const render = (id: string, type: string, key: string, obj: unknown) =>
+  renderHook(({ k, o }) => useSelectedArtifactContentSync(id, type as any, k, o as any), {
+    initialProps: { k: key, o: obj },
+  });
+
+describe('useSelectedArtifactContentSync (#457 guard)', () => {
+  beforeEach(() => {
+    setSessionLayout.mockClear();
+    getState.mockReset();
+    getState.mockImplementation(selectedState);
+  });
+
+  it('does not push on initial mount (scroll-in must not clobber)', () => {
+    render('a1', 'html', '<v2/>', { id: 'a1', content: '<v2/>' });
+    expect(setSessionLayout).not.toHaveBeenCalled();
+  });
+
+  it('pushes when the content key changes while mounted (live streaming)', () => {
+    const { rerender } = render('a1', 'html', '<v2-partial/>', { id: 'a1', content: '<v2-partial/>' });
+    expect(setSessionLayout).not.toHaveBeenCalled();
+
+    rerender({ k: '<v2-final/>', o: { id: 'a1', content: '<v2-final/>' } });
+    expect(setSessionLayout).toHaveBeenCalledTimes(1);
+    expect(setSessionLayout.mock.calls[0][0].artifactData.content.content).toBe('<v2-final/>');
+  });
+
+  it('does not push when this artifact is not the selected one', () => {
+    getState.mockImplementation(() => ({ selectedArtifactId: 'other', artifactData: null }));
+    const { rerender } = render('a1', 'html', '<a/>', { id: 'a1', content: '<a/>' });
+    rerender({ k: '<b/>', o: { id: 'a1', content: '<b/>' } });
+    expect(setSessionLayout).not.toHaveBeenCalled();
+  });
+
+  it('does not push when the type does not match the selected artifact', () => {
+    const { rerender } = render('a1', 'react', '<a/>', { id: 'a1', content: '<a/>' });
+    rerender({ k: '<b/>', o: { id: 'a1', content: '<b/>' } });
+    // Selected artifact is type 'html', hook is for 'react' -> never syncs.
+    expect(setSessionLayout).not.toHaveBeenCalled();
+  });
+
+  it('a freshly mounted older card (new hook instance) does not clobber', () => {
+    render('a1', 'html', '<v2/>', { id: 'a1', content: '<v2/>' }).unmount();
+    setSessionLayout.mockClear();
+    // Simulate scrolling the old v1 card into view: a brand-new mount with older content.
+    render('a1', 'html', '<v1/>', { id: 'a1', content: '<v1/>' });
+    expect(setSessionLayout).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/hooks/useSelectedArtifactContentSync.ts
+++ b/apps/client/app/hooks/useSelectedArtifactContentSync.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+import useSessionLayout, { setSessionLayout, type ArtifactData } from '@client/app/hooks/useSessionLayout';
+
+/**
+ * Propagates an artifact preview card's LIVE content changes to the shared Knowledge Base
+ * store, without letting a card overwrite the store merely by mounting.
+ *
+ * An iterated artifact's v1 and v2 chat cards share the same id (see ArtifactIdResolver) and
+ * carry no version, so any same-id card that mounts would otherwise overwrite the store with
+ * its own (possibly older) content - scrolling an old card into view downgraded the Knowledge
+ * Base to a stale version (#457). This seeds a ref on the first observation (mount / scroll-in)
+ * WITHOUT pushing, so only a content change seen while the card stays mounted (live streaming)
+ * propagates; a scroll-driven (re)mount can no longer clobber the newest version.
+ *
+ * @param artifactId    the card's resolved artifact id
+ * @param artifactType  the ArtifactData type this card represents (e.g. 'html' | 'react' | 'code')
+ * @param contentKey    the string that changes on a live content edit, used for change
+ *                      detection (e.g. the html/react content string, or the code body)
+ * @param contentObject the full content object written into the store when contentKey changes
+ */
+export function useSelectedArtifactContentSync(
+  artifactId: string,
+  artifactType: ArtifactData['type'],
+  contentKey: string,
+  contentObject: ArtifactData['content']
+): void {
+  const lastObservedContentRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const currentState = useSessionLayout.getState();
+
+    // Only sync while this artifact is the selected one.
+    if (currentState.selectedArtifactId === artifactId && currentState.artifactData?.type === artifactType) {
+      // First observation (mount / scroll-in): record, do not push - a remounted older card
+      // must not overwrite fresher content already in the store.
+      if (lastObservedContentRef.current === null) {
+        lastObservedContentRef.current = contentKey;
+        return;
+      }
+      if (lastObservedContentRef.current === contentKey) return;
+      lastObservedContentRef.current = contentKey;
+
+      // Compare the actual content to avoid unnecessary updates.
+      if (JSON.stringify(currentState.artifactData.content) !== JSON.stringify(contentObject)) {
+        setSessionLayout({
+          artifactData: {
+            ...currentState.artifactData,
+            content: contentObject,
+          },
+        });
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [artifactId, artifactType, contentKey]);
+}

--- a/apps/client/app/hooks/useSelectedArtifactContentSync.ts
+++ b/apps/client/app/hooks/useSelectedArtifactContentSync.ts
@@ -50,6 +50,12 @@ export function useSelectedArtifactContentSync(
         });
       }
     }
+    // Change detection intentionally keys on `contentKey` only (the streaming content), not on
+    // the whole `contentObject`: this is a content-propagation guard, and keying on the full
+    // object would both re-add per-render JSON.stringify churn and re-trigger on volatile fields
+    // (the handlers stamp a fresh createdAt/updatedAt each render). Consequence: a metadata-only
+    // change with identical content does not propagate - acceptable, since no such server update
+    // exists today. Revisit `contentKey` if metadata-only artifact updates ever ship.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [artifactId, artifactType, contentKey]);
 }


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

https://github.com/user-attachments/assets/24adb0d4-fb2a-4722-885c-0fc500a65d5c

## Description

Closes #457. On mobile, iterating on an artifact left the Knowledge Base (KB) viewer stuck on the OLD version while the chat showed the new one, so it looked like generation had failed. Desktop was unaffected.

Two mechanisms, both because the KB renders from an in-memory store rather than an authoritative source:

1. **Card mount-clobber** - an iterated artifact's v1 and v2 chat cards share the same id and carry no version, and each card pushed its content into the shared store on mount. So a same-id card mounting (or re-mounting while scrolling) overwrote the store with its own content - scrolling an older card into view downgraded the KB.
2. **DB stale-read** - opening the viewer refetches from the DB, but a streamed iteration persists asynchronously, so the DB could still return the previous version and overwrite the just-opened content (the "new version, then flickers back to old" symptom).

Secondary: the KB header toolbar overflowed at phone width, pushing download/close off-screen.

## Changes

- **`useSelectedArtifactContentSync` hook** - shared guard that seeds a ref on first observation (mount / scroll-in) without pushing, so only a change seen while the card stays mounted (live streaming) propagates. A (re)mount can no longer clobber the newest version. Adopted by the HTML, React, and Code preview cards (replaces the duplicated inline effect in each).
- **Monotonic DB-sync** (`shouldSyncArtifactFromDb` in `KnowledgeViewer`) - adopts the DB copy only when it is a strictly newer version than the baseline pinned at open, so a same-or-older-version stale read cannot downgrade the just-opened version.
- **Mobile header** - the KB toolbar wraps/stacks at phone width so download and close stay reachable.

## Guide for Testers

Use a mobile viewport (Chrome DevTools device toolbar -> iPhone SE).

1. Open the preview link, sign in, and open a notebook.
2. Send two short throwaway messages (e.g. `hi`, `tell me a joke`) so the chat can scroll.
3. Send: `Create a single self-contained HTML file with a big blue heading that says "Hello". Return it as an HTML artifact only, no explanation.` Expected: an HTML card showing a blue "Hello" page (v1).
4. Send: `Update that HTML file: make the heading red and say "Welcome", and add a table with 200 rows each showing a number and the word "item". Return the full HTML artifact only.` Expected: the card updates to a red "Welcome" page with a long table (v2).
5. On the v2 card, tap the rightmost toolbar icon (two diagonal arrows, "Open in full viewer"). Expected: the KB panel shows the red "Welcome" page and STAYS red - no flicker back to the blue "Hello".
6. With the panel open, scroll the chat up and down past both cards, then stop. Expected: the panel stays on red the whole time.
7. Check the KB panel's top toolbar. Expected: download and close (X) are fully visible and tappable (toolbar wraps rather than overflowing).
8. Turn off the device toolbar (desktop width) and reopen the artifact. Expected: shows red (v2).

### Regression Checks

1. Generate a single artifact (no iteration) and open it - shows the correct content.
2. Repeat steps 4-6 with a React artifact - KB stays on the newest version.
3. Iterate and open on desktop - KB shows the newest version, as before.
4. KB header copy / download / share actions still work.

## Additional Information

Content is persisted byte-for-byte (no server-side sanitize/normalize), so a differing same-version DB read is always stale, never a re-processed variant - which is why the monotonic guard is safe. React iterations bump the version (guard adopts on advance); HTML iterations do not re-version the same id (guard keeps the opened content, correct since that id's DB read stays stale). This does not rewrite the KB to read exclusively from the DB (larger, higher-risk); the two guards reach the same result at lower risk.

## Developer Notes (Optional)

- `useSelectedArtifactContentSync(artifactId, artifactType, contentKey, contentObject)` - reusable guard for any artifact preview card syncing into the session-layout store; new card types adopt it in one line.
- `shouldSyncArtifactFromDb({ currentContent, latestContent, latestVersion, baselineVersion })` - pure, exported predicate for the monotonic DB-sync rule; unit-tested in isolation.

## Tests

- `apps/client/app/hooks/useSelectedArtifactContentSync.test.tsx` - the shared guard hook (no push on mount, push on live change, no push when unselected/type-mismatched, remount-older does not clobber).
- `apps/client/app/components/GenAI/HtmlArtifactPreviewCard.syncGuard.test.tsx` - integration coverage that the HTML card wires the guard through.
- `apps/client/app/components/Knowledge/__tests__/shouldSyncArtifactFromDb.test.ts` - the monotonic DB-sync predicate.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
