### PR TITLE
fix(api): enforce owner/admin authorization on scoped endpoints

### DIFF
--- a/apps/client/pages/api/analytics/__tests__/aggregate.test.ts
+++ b/apps/client/pages/api/analytics/__tests__/aggregate.test.ts
@@ -33,7 +33,7 @@ function mocks(user: unknown) {
   return { req, res };
 }
 
-describe('/api/analytics/aggregate — admin gate', () => {
+describe('/api/analytics/aggregate - admin gate', () => {
   beforeEach(() => aggregate.mockClear());
 
   it('rejects a non-admin before aggregating', async () => {

--- a/apps/client/pages/api/analytics/__tests__/aggregate.test.ts
+++ b/apps/client/pages/api/analytics/__tests__/aggregate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * analytics/aggregate groups event volumes by organization across tenants, so
+ * it must be admin-only. Prove a non-admin is rejected before any aggregation
+ * runs, and that an admin still gets data.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const aggregate = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+vi.mock('@bike4mind/database', () => ({ CounterLog: { aggregate } }));
+
+import '@pages/api/analytics/aggregate';
+
+function mocks(user: unknown) {
+  const { req, res } = createMocks({ method: 'GET', query: {} });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('/api/analytics/aggregate — admin gate', () => {
+  beforeEach(() => aggregate.mockClear());
+
+  it('rejects a non-admin before aggregating', async () => {
+    const { req, res } = mocks({ id: 'u1', isAdmin: false });
+    await expect(mockRefs.getHandler!(req, res)).rejects.toThrow(/admin/i);
+    expect(aggregate).not.toHaveBeenCalled();
+  });
+
+  it('runs the aggregation for an admin', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true });
+    await mockRefs.getHandler!(req, res);
+    expect(aggregate).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+  });
+});

--- a/apps/client/pages/api/analytics/aggregate.ts
+++ b/apps/client/pages/api/analytics/aggregate.ts
@@ -2,6 +2,7 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { Request, Response } from 'express';
 import { CounterLog } from '@bike4mind/database';
 import { dayjs } from '@bike4mind/common';
+import { ensureAdmin } from '@server/utils/errors';
 
 interface AggregateQueryParams {
   startDate?: string;
@@ -24,6 +25,9 @@ interface DailyAggregation {
 }
 
 const handler = baseApi().get(async (req: Request<{}, unknown, unknown, AggregateQueryParams>, res: Response) => {
+  // Cross-tenant analytics (event volumes grouped by organization). Admin-only.
+  ensureAdmin(req.user?.isAdmin);
+
   const { startDate, endDate, groupBy = 'day' } = req.query;
 
   // Default to last 30 days if no dates provided

--- a/apps/client/pages/api/feedback/[id]/__tests__/update.ability.test.ts
+++ b/apps/client/pages/api/feedback/[id]/__tests__/update.ability.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { AbilityBuilder, createMongoAbility } from '@casl/ability';
+
+/**
+ * Locks in the CASL semantics the feedback-update fix depends on. Importing the
+ * real `defineAbilitiesFor` is not viable here: its transitive graph pulls
+ * `b4m-core/utils/dist/registrableDomain.mjs -> tldts`, which the current vitest
+ * setup cannot resolve (the same failure that affects the publish/* suites on
+ * main). So this replicates ability.ts's feedback rules exactly and asserts the
+ * class-vs-instance behavior directly.
+ *
+ * MUST STAY IN SYNC with the feedback rules in `apps/client/server/auth/ability.ts`:
+ *   allow('update', FeedbackModel, { userId: user.id });   // every user
+ *   if (user.isAdmin) allow('update', FeedbackModel);       // admins, unconditional
+ */
+
+class FeedbackModel {}
+
+function abilityFor(user: { id: string; isAdmin?: boolean }) {
+  const { can: allow, build } = new AbilityBuilder(createMongoAbility);
+  allow('update', FeedbackModel, { userId: user.id });
+  if (user.isAdmin) allow('update', FeedbackModel);
+  return build({ detectSubjectType: item => (item as { constructor: unknown }).constructor as never });
+}
+
+const feedback = Object.assign(new FeedbackModel(), { userId: 'owner1' });
+
+describe('feedback update authorization (CASL class-vs-instance)', () => {
+  it('allows the owner to update their own feedback (instance check)', () => {
+    expect(abilityFor({ id: 'owner1' }).can('update', feedback)).toBe(true);
+  });
+
+  it('denies a stranger updating someone else\'s feedback (instance check)', () => {
+    expect(abilityFor({ id: 'stranger' }).can('update', feedback)).toBe(false);
+  });
+
+  it('allows an admin to update any feedback (instance check)', () => {
+    expect(abilityFor({ id: 'admin', isAdmin: true }).can('update', feedback)).toBe(true);
+  });
+
+  it('documents the footgun: the by-class check wrongly passes for a stranger', () => {
+    const ability = abilityFor({ id: 'stranger' });
+    // A by-class check ignores the { userId } condition, so it returns true even
+    // though the stranger cannot update this instance -- which is exactly why the
+    // handler authorizes against the document instance.
+    expect(ability.can('update', FeedbackModel)).toBe(true);
+    expect(ability.can('update', feedback)).toBe(false);
+  });
+});

--- a/apps/client/pages/api/feedback/[id]/__tests__/update.test.ts
+++ b/apps/client/pages/api/feedback/[id]/__tests__/update.test.ts
@@ -45,7 +45,7 @@ function mocks(can: (action: string, subject: unknown) => boolean) {
   return { req, res };
 }
 
-describe('PUT /api/feedback/[id] — instance-level authorization', () => {
+describe('PUT /api/feedback/[id] - instance-level authorization', () => {
   beforeEach(() => {
     model.findById.mockResolvedValue(feedbackDoc);
     model.findOneAndUpdate.mockResolvedValue({ ...feedbackDoc, content: 'edited' });
@@ -63,7 +63,8 @@ describe('PUT /api/feedback/[id] — instance-level authorization', () => {
 
   it('rejects a non-owner (can -> false) without writing', async () => {
     const { req, res } = mocks(() => false);
-    await expect(mockRefs.putHandler!(req, res)).rejects.toThrow(/permission denied/i);
+    // A denied caller gets the same "not found" as a missing id (existence-hiding).
+    await expect(mockRefs.putHandler!(req, res)).rejects.toThrow(/not found/i);
     expect(model.findOneAndUpdate).not.toHaveBeenCalled();
   });
 

--- a/apps/client/pages/api/feedback/[id]/__tests__/update.test.ts
+++ b/apps/client/pages/api/feedback/[id]/__tests__/update.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * The endpoint must authorize against the fetched DOCUMENT, not the
+ * FeedbackModel class: a by-class CASL check does not evaluate the { userId }
+ * ownership condition, so ownership is only enforced against the instance. These
+ * tests prove `can` is called with the instance and that a denied caller never
+ * reaches the write.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  putHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    put: (fn: any) => {
+      mockRefs.putHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const feedbackDoc = { id: 'fb1', userId: 'owner1' };
+const model = vi.hoisted(() => ({
+  findById: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+}));
+vi.mock('@bike4mind/database', () => ({ FeedbackModel: model }));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
+
+import '@pages/api/feedback/[id]/update';
+
+function mocks(can: (action: string, subject: unknown) => boolean) {
+  const { req, res } = createMocks({
+    method: 'PUT',
+    query: { id: 'fb1' },
+    body: { userId: 'someone', content: 'edited', username: 'x', status: 'open' },
+  });
+  (req as any).user = { id: 'attacker', isAdmin: false };
+  (req as any).ability = { can: vi.fn(can) };
+  return { req, res };
+}
+
+describe('PUT /api/feedback/[id] — instance-level authorization', () => {
+  beforeEach(() => {
+    model.findById.mockResolvedValue(feedbackDoc);
+    model.findOneAndUpdate.mockResolvedValue({ ...feedbackDoc, content: 'edited' });
+    model.findOneAndUpdate.mockClear();
+  });
+
+  it('authorizes against the fetched document, not the model class', async () => {
+    const { req, res } = mocks(() => true);
+    await mockRefs.putHandler!(req, res);
+
+    // The security-critical assertion: the ability check receives the instance.
+    expect((req as any).ability.can).toHaveBeenCalledWith('update', feedbackDoc);
+    expect((req as any).ability.can).not.toHaveBeenCalledWith('update', model);
+  });
+
+  it('rejects a non-owner (can -> false) without writing', async () => {
+    const { req, res } = mocks(() => false);
+    await expect(mockRefs.putHandler!(req, res)).rejects.toThrow(/permission denied/i);
+    expect(model.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('lets an authorized caller (owner/admin) update', async () => {
+    const { req, res } = mocks(() => true);
+    await mockRefs.putHandler!(req, res);
+    expect(model.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+  });
+});

--- a/apps/client/pages/api/feedback/[id]/update.ts
+++ b/apps/client/pages/api/feedback/[id]/update.ts
@@ -26,10 +26,6 @@ const handler = baseApi().put(
       throw new NotFoundError('Ability not found');
     }
 
-    if (!req.ability.can('update', FeedbackModel)) {
-      throw new NotFoundError('Permission denied');
-    }
-
     const updateData = UpdateFeedbackRequestSchema.parse(req.body);
 
     const feedback = await FeedbackModel.findById(id);
@@ -39,7 +35,11 @@ const handler = baseApi().put(
     }
     const { content, status, username } = updateData;
 
-    if (!req.ability.can('update', FeedbackModel)) {
+    // Authorize against the document instance, not the model class: a by-class
+    // CASL check does not evaluate the { userId } ownership condition, so
+    // ownership is only enforced when checked against the instance. Admins keep
+    // their unconditional update rule and still pass.
+    if (!req.ability.can('update', feedback)) {
       throw new NotFoundError('Permission denied');
     }
 

--- a/apps/client/pages/api/feedback/[id]/update.ts
+++ b/apps/client/pages/api/feedback/[id]/update.ts
@@ -38,9 +38,10 @@ const handler = baseApi().put(
     // Authorize against the document instance, not the model class: a by-class
     // CASL check does not evaluate the { userId } ownership condition, so
     // ownership is only enforced when checked against the instance. Admins keep
-    // their unconditional update rule and still pass.
+    // their unconditional update rule and still pass. Reuse the same "not found"
+    // response as a missing id so a non-owner cannot distinguish the two.
     if (!req.ability.can('update', feedback)) {
-      throw new NotFoundError('Permission denied');
+      throw new NotFoundError('Feedback not found');
     }
 
     const updatedFeedback = await FeedbackModel.findOneAndUpdate(

--- a/apps/client/pages/api/security/__tests__/blocked-ips.test.ts
+++ b/apps/client/pages/api/security/__tests__/blocked-ips.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * Managing the IP blocklist is an administrative security control, so every
+ * method must be admin-only. These tests prove the gate holds at the HTTP
+ * boundary and that the repository is never touched for a non-admin caller.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+  postHandler: null as null | ((req: any, res: any) => unknown),
+  deleteHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+    delete: (fn: any) => {
+      mockRefs.deleteHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const repo = vi.hoisted(() => ({
+  list: vi.fn().mockResolvedValue([{ ip: '1.2.3.4' }]),
+  block: vi.fn().mockResolvedValue({ ip: '1.2.3.4' }),
+  unblock: vi.fn().mockResolvedValue({ ip: '1.2.3.4' }),
+}));
+
+vi.mock('@bike4mind/database', () => ({ blockedIPRepository: repo }));
+
+import '@pages/api/security/blocked-ips';
+
+function mocks(user: unknown, extra: Record<string, unknown> = {}) {
+  const { req, res } = createMocks({ method: 'GET', ...extra });
+  (req as any).user = user;
+  return { req, res };
+}
+
+const ADMIN = { id: 'admin1', isAdmin: true };
+const NON_ADMIN = { id: 'u1', isAdmin: false };
+
+describe('/api/security/blocked-ips — admin gate', () => {
+  beforeEach(() => {
+    repo.list.mockClear();
+    repo.block.mockClear();
+    repo.unblock.mockClear();
+  });
+
+  it.each([
+    ['GET', () => mockRefs.getHandler!, () => repo.list],
+    ['POST', () => mockRefs.postHandler!, () => repo.block],
+    ['DELETE', () => mockRefs.deleteHandler!, () => repo.unblock],
+  ])('%s rejects a non-admin without touching the repository', async (_method, getHandler, getRepoFn) => {
+    const { req, res } = mocks(NON_ADMIN, { body: { ip: '1.2.3.4' }, query: { ip: '1.2.3.4' } });
+    await expect(getHandler()(req, res)).rejects.toThrow(/admin/i);
+    expect(getRepoFn()).not.toHaveBeenCalled();
+  });
+
+  it('GET returns the list for an admin', async () => {
+    const { req, res } = mocks(ADMIN);
+    await mockRefs.getHandler!(req, res);
+    expect(repo.list).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('POST blocks an IP for an admin', async () => {
+    const { req, res } = mocks(ADMIN, { method: 'POST', body: { ip: '1.2.3.4', reason: 'abuse' } });
+    await mockRefs.postHandler!(req, res);
+    expect(repo.block).toHaveBeenCalledWith('1.2.3.4', 'abuse');
+  });
+
+  it('DELETE unblocks an IP for an admin', async () => {
+    const { req, res } = mocks(ADMIN, { method: 'DELETE', query: { ip: '1.2.3.4' } });
+    await mockRefs.deleteHandler!(req, res);
+    expect(repo.unblock).toHaveBeenCalledWith('1.2.3.4');
+  });
+});

--- a/apps/client/pages/api/security/__tests__/blocked-ips.test.ts
+++ b/apps/client/pages/api/security/__tests__/blocked-ips.test.ts
@@ -51,7 +51,7 @@ function mocks(user: unknown, extra: Record<string, unknown> = {}) {
 const ADMIN = { id: 'admin1', isAdmin: true };
 const NON_ADMIN = { id: 'u1', isAdmin: false };
 
-describe('/api/security/blocked-ips — admin gate', () => {
+describe('/api/security/blocked-ips - admin gate', () => {
   beforeEach(() => {
     repo.list.mockClear();
     repo.block.mockClear();

--- a/apps/client/pages/api/security/blocked-ips.ts
+++ b/apps/client/pages/api/security/blocked-ips.ts
@@ -1,19 +1,25 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { blockedIPRepository } from '@bike4mind/database';
+import { ensureAdmin } from '@server/utils/errors';
 
 // GET: list active blocked IPs (limit=10)
 // POST: block ip { ip, reason }
 // DELETE: unblock ip ?ip=1.2.3.4
 // POST /evaluate endpoint lives in blocked-ips/evaluate.ts
+//
+// Managing the IP blocklist is an administrative security control; every method
+// is restricted to admins.
 
 const handler = baseApi()
   .get(async (req, res) => {
+    ensureAdmin(req.user?.isAdmin);
     const query = req.query as { limit?: string };
     const limit = Math.min(parseInt(query.limit || '10', 10), 50);
     const items = await blockedIPRepository.list(limit);
     res.status(200).json({ items });
   })
   .post(async (req, res) => {
+    ensureAdmin(req.user?.isAdmin);
     const body = req.body as { ip?: string; reason?: string };
     const { ip, reason } = body || {};
     if (!ip) return res.status(400).json({ error: 'ip is required' });
@@ -21,6 +27,7 @@ const handler = baseApi()
     res.status(201).json({ item: doc });
   })
   .delete(async (req, res) => {
+    ensureAdmin(req.user?.isAdmin);
     const query = req.query as { ip?: string };
     const body = req.body as { ip?: string } | undefined;
     const ip = query.ip || body?.ip;

--- a/apps/client/pages/api/security/blocked-ips/__tests__/evaluate.test.ts
+++ b/apps/client/pages/api/security/blocked-ips/__tests__/evaluate.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * blocked-ips/evaluate writes to the IP blocklist (auto-blocking high-attempt
+ * IPs), so like the rest of that control it must be admin-only. Prove a
+ * non-admin is rejected before any evaluation or write runs.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const authFail = vi.hoisted(() => ({ getIPsWithHighAttempts: vi.fn().mockResolvedValue([]) }));
+const blockedIP = vi.hoisted(() => ({ block: vi.fn().mockResolvedValue({}) }));
+vi.mock('@bike4mind/database', () => ({
+  authFailLogRepository: authFail,
+  blockedIPRepository: blockedIP,
+}));
+
+import '@pages/api/security/blocked-ips/evaluate';
+
+function mocks(user: unknown) {
+  const { req, res } = createMocks({ method: 'POST' });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('POST /api/security/blocked-ips/evaluate - admin gate', () => {
+  beforeEach(() => {
+    authFail.getIPsWithHighAttempts.mockClear();
+    blockedIP.block.mockClear();
+  });
+
+  it('rejects a non-admin before evaluating', async () => {
+    const { req, res } = mocks({ id: 'u1', isAdmin: false });
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/admin/i);
+    expect(authFail.getIPsWithHighAttempts).not.toHaveBeenCalled();
+  });
+
+  it('runs the evaluation for an admin', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true });
+    await mockRefs.postHandler!(req, res);
+    expect(authFail.getIPsWithHighAttempts).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+  });
+});

--- a/apps/client/pages/api/security/blocked-ips/evaluate.ts
+++ b/apps/client/pages/api/security/blocked-ips/evaluate.ts
@@ -1,9 +1,13 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { blockedIPRepository, authFailLogRepository } from '@bike4mind/database';
+import { ensureAdmin } from '@server/utils/errors';
 
 // POST /api/security/blocked-ips/evaluate
-// Evaluates last 10 minutes and auto-blocks IPs with >=10 attempts
+// Evaluates last 10 minutes and auto-blocks IPs with >=10 attempts.
+// Writes to the IP blocklist, so it is admin-only like the rest of that control.
+// If wired to an external scheduler, invoke it with an admin-scoped credential.
 const handler = baseApi().post(async (req, res) => {
+  ensureAdmin(req.user?.isAdmin);
   const since = new Date(Date.now() - 10 * 60 * 1000);
   const result = await authFailLogRepository.getIPsWithHighAttempts(since, 10);
   const blocked: string[] = [];

--- a/apps/client/pages/api/users/[id]/__tests__/friends.test.ts
+++ b/apps/client/pages/api/users/[id]/__tests__/friends.test.ts
@@ -38,7 +38,7 @@ function mocks(user: unknown, id: string) {
   return { req, res };
 }
 
-describe('GET /api/users/[id]/friends — ownership gate', () => {
+describe('GET /api/users/[id]/friends - ownership gate', () => {
   beforeEach(() => listFriends.mockClear());
 
   it('rejects reading another user\'s friends without calling the service', async () => {

--- a/apps/client/pages/api/users/[id]/__tests__/friends.test.ts
+++ b/apps/client/pages/api/users/[id]/__tests__/friends.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * /api/users/[id]/friends resolves a user's friend list to full user records
+ * (including email), so only the user themselves or an admin may read it. Prove
+ * the gate rejects a cross-user read before calling the service.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const listFriends = vi.hoisted(() => vi.fn().mockResolvedValue([{ id: 'f1', user: { id: 'u2' } }]));
+vi.mock('@bike4mind/services', () => ({ friendshipService: { listFriends } }));
+vi.mock('@bike4mind/database', () => ({
+  compareMongoIds: (a: string, b: string) => a === b,
+  friendshipRepository: {},
+  userRepository: {},
+}));
+
+import '@pages/api/users/[id]/friends';
+
+function mocks(user: unknown, id: string) {
+  const { req, res } = createMocks({ method: 'GET', query: { id } });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('GET /api/users/[id]/friends — ownership gate', () => {
+  beforeEach(() => listFriends.mockClear());
+
+  it('rejects reading another user\'s friends without calling the service', async () => {
+    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'someone-else');
+    await expect(mockRefs.getHandler!(req, res)).rejects.toThrow(/not authorized/i);
+    expect(listFriends).not.toHaveBeenCalled();
+  });
+
+  it('allows a user to read their own friends', async () => {
+    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'me');
+    await mockRefs.getHandler!(req, res);
+    expect(listFriends).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('allows an admin to read any user\'s friends', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true }, 'someone-else');
+    await mockRefs.getHandler!(req, res);
+    expect(listFriends).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/pages/api/users/[id]/__tests__/organization.test.ts
+++ b/apps/client/pages/api/users/[id]/__tests__/organization.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * /api/users/[id]/organization returns an org document (billing + member data),
+ * so only the user themselves or an admin may read it. Prove the gate rejects a
+ * cross-user read before hitting the database.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const findById = vi.hoisted(() =>
+  vi.fn(() => ({
+    populate: () => ({ select: () => Promise.resolve({ organizationId: { id: 'org1', name: 'Acme' } }) }),
+  }))
+);
+vi.mock('@bike4mind/database', () => ({ User: { findById } }));
+
+import '@pages/api/users/[id]/organization';
+
+function mocks(user: unknown, id: string) {
+  const { req, res } = createMocks({ method: 'GET', query: { id } });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('GET /api/users/[id]/organization — ownership gate', () => {
+  beforeEach(() => findById.mockClear());
+
+  it('rejects reading another user\'s org without querying the DB', async () => {
+    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'someone-else');
+    await expect(mockRefs.getHandler!(req, res)).rejects.toThrow(/not authorized/i);
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  it('allows a user to read their own org', async () => {
+    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'me');
+    await mockRefs.getHandler!(req, res);
+    expect(findById).toHaveBeenCalledWith('me');
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('allows an admin to read any user\'s org', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true }, 'someone-else');
+    await mockRefs.getHandler!(req, res);
+    expect(findById).toHaveBeenCalledWith('someone-else');
+  });
+});

--- a/apps/client/pages/api/users/[id]/__tests__/organization.test.ts
+++ b/apps/client/pages/api/users/[id]/__tests__/organization.test.ts
@@ -37,7 +37,7 @@ function mocks(user: unknown, id: string) {
   return { req, res };
 }
 
-describe('GET /api/users/[id]/organization — ownership gate', () => {
+describe('GET /api/users/[id]/organization - ownership gate', () => {
   beforeEach(() => findById.mockClear());
 
   it('rejects reading another user\'s org without querying the DB', async () => {

--- a/apps/client/pages/api/users/[id]/__tests__/projects.test.ts
+++ b/apps/client/pages/api/users/[id]/__tests__/projects.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * /api/users/[id]/projects resolves to the target user's owned + shared-to-them
+ * projects, so only the user themselves or an admin may list them. Prove the gate
+ * rejects a cross-user read before hitting the repository.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const findById = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'target' }));
+const findAllAccessible = vi.hoisted(() => vi.fn().mockResolvedValue([{ id: 'p1' }]));
+vi.mock('@bike4mind/database', () => ({
+  userRepository: { findById },
+  projectRepository: { shareable: { findAllAccessible } },
+}));
+
+import '@pages/api/users/[id]/projects';
+
+function mocks(user: unknown, id: string) {
+  const { req, res } = createMocks({ method: 'GET', query: { id } });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('GET /api/users/[id]/projects - ownership gate', () => {
+  beforeEach(() => {
+    findById.mockClear();
+    findAllAccessible.mockClear();
+  });
+
+  it('rejects reading another user\'s projects without hitting the repository', async () => {
+    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'someone-else');
+    await expect(mockRefs.getHandler!(req, res)).rejects.toThrow(/not authorized/i);
+    expect(findById).not.toHaveBeenCalled();
+    expect(findAllAccessible).not.toHaveBeenCalled();
+  });
+
+  it('allows a user to read their own projects', async () => {
+    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'me');
+    await mockRefs.getHandler!(req, res);
+    expect(findAllAccessible).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('allows an admin to read any user\'s projects', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true }, 'someone-else');
+    await mockRefs.getHandler!(req, res);
+    expect(findAllAccessible).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/pages/api/users/[id]/collections/__tests__/index.test.ts
+++ b/apps/client/pages/api/users/[id]/collections/__tests__/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * A user's collections are private to them, so /api/users/[id]/collections must
+ * be readable only by the user themselves or an admin. Prove the gate rejects a
+ * cross-user read before calling the service.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const searchUserCollection = vi.hoisted(() => vi.fn().mockResolvedValue({ data: [], hasMore: false }));
+vi.mock('@bike4mind/services', () => ({ userService: { searchUserCollection } }));
+vi.mock('@bike4mind/database', () => ({ userRepository: {}, sessionRepository: {} }));
+
+import '@pages/api/users/[id]/collections/index';
+
+function mocks(user: unknown, id: string) {
+  const { req, res } = createMocks({ method: 'GET', query: { id, page: '1' } });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('GET /api/users/[id]/collections - ownership gate', () => {
+  beforeEach(() => searchUserCollection.mockClear());
+
+  it('rejects reading another user\'s collections without calling the service', async () => {
+    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'someone-else');
+    await expect(mockRefs.getHandler!(req, res)).rejects.toThrow(/not authorized/i);
+    expect(searchUserCollection).not.toHaveBeenCalled();
+  });
+
+  it('allows a user to read their own collections', async () => {
+    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'me');
+    await mockRefs.getHandler!(req, res);
+    expect(searchUserCollection).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('allows an admin to read any user\'s collections', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true }, 'someone-else');
+    await mockRefs.getHandler!(req, res);
+    expect(searchUserCollection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/pages/api/users/[id]/collections/index.ts
+++ b/apps/client/pages/api/users/[id]/collections/index.ts
@@ -2,6 +2,7 @@ import { CollectionType } from '@bike4mind/common';
 import { userRepository, sessionRepository } from '@bike4mind/database';
 import { userService } from '@bike4mind/services';
 import { baseApi } from '@server/middlewares/baseApi';
+import { ForbiddenError } from '@server/utils/errors';
 import { z } from 'zod';
 
 const PaginatedCollectionsQuerySchema = z.object({
@@ -18,6 +19,12 @@ const PaginatedCollectionsQuerySchema = z.object({
  */
 const handler = baseApi().get(async (req, res) => {
   const { id, page = 1, limit = 10, search, type } = PaginatedCollectionsQuerySchema.parse(req.query);
+
+  // A user's collections are private to them; only the user themselves or an
+  // admin may list them.
+  if (id !== req.user.id && !req.user.isAdmin) {
+    throw new ForbiddenError('Not authorized to view this user\'s collections');
+  }
 
   const result = await userService.searchUserCollection(
     { userId: id, page, limit, search, type: type ?? undefined },

--- a/apps/client/pages/api/users/[id]/friends.ts
+++ b/apps/client/pages/api/users/[id]/friends.ts
@@ -1,10 +1,17 @@
 import { compareMongoIds, friendshipRepository, userRepository } from '@bike4mind/database';
 import { friendshipService } from '@bike4mind/services';
 import { baseApi } from '@server/middlewares/baseApi';
+import { ForbiddenError } from '@server/utils/errors';
 import { Request } from 'express';
 
 const handler = baseApi().get<Request<{}, {}, {}, { id: string }>>(async (req, res) => {
   const userId = req.query.id;
+
+  // A user's friend list resolves to full user records (including email), so
+  // only the user themselves or an admin may read it.
+  if (userId !== req.user.id && !req.user.isAdmin) {
+    throw new ForbiddenError('Not authorized to view this user\'s friends');
+  }
 
   const friends = await friendshipService.listFriends(
     { userId },

--- a/apps/client/pages/api/users/[id]/organization.ts
+++ b/apps/client/pages/api/users/[id]/organization.ts
@@ -2,6 +2,7 @@ import { IOrganization } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { User } from '@bike4mind/database';
+import { ForbiddenError } from '@server/utils/errors';
 
 /**
  * Get the organization of a user
@@ -9,6 +10,12 @@ import { User } from '@bike4mind/database';
 const handler = baseApi().get(
   asyncHandler<{}, unknown, unknown, { id?: string }>(async (req, res) => {
     const userId = req.query.id;
+
+    // The organization document carries billing and member data, so only the
+    // user themselves or an admin may read their org via this route.
+    if (userId !== req.user.id && !req.user.isAdmin) {
+      throw new ForbiddenError('Not authorized to view this organization');
+    }
 
     const user = await User.findById(userId)
       .populate({

--- a/apps/client/pages/api/users/[id]/projects.ts
+++ b/apps/client/pages/api/users/[id]/projects.ts
@@ -1,8 +1,17 @@
 import { projectRepository, userRepository } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
+import { ForbiddenError } from '@server/utils/errors';
 
 const handler = baseApi().get(async (req, res) => {
   const userId = req.query.id as string;
+
+  // findAllAccessible returns the target user's owned + shared-to-them projects,
+  // so only the user themselves or an admin may list them. A profile-scoped
+  // response for cross-user views (public "Joined Projects") is a tracked follow-up.
+  if (userId !== req.user.id && !req.user.isAdmin) {
+    throw new ForbiddenError('Not authorized to view this user\'s projects');
+  }
+
   const user = await userRepository.findById(userId);
 
   if (!user) {

--- a/scripts/no-baseapi-allowlist.txt
+++ b/scripts/no-baseapi-allowlist.txt
@@ -16,6 +16,7 @@ apps/client/pages/api/__tests__/artifact-sandbox.test.ts # Test file for the han
 apps/client/pages/api/react-artifact-sandbox.ts          # Static React iframe target for client-rendered artifacts; no user data, no DB (#9403)
 apps/client/pages/api/__tests__/react-artifact-sandbox.test.ts # Test file for the handler above (script greps by path, not export)
 apps/client/pages/api/__tests__/sessionRedactionGuard.test.ts # Static-analysis guard test (#9405); reads route source via fs, not an API route
+apps/client/pages/api/feedback/[id]/__tests__/update.ability.test.ts # Pure CASL unit test (class-vs-instance); no HTTP route, no baseApi
 apps/client/pages/api/publish/widget.ts                 # Static first-party comment-overlay JS; intentionally public, no user data, no DB
 
 # Slack — authenticated via HMAC-SHA256 signature (Slack signing secret)


### PR DESCRIPTION
## Description

Tightens authorization on a handful of API routes so each returns data only to
the caller who owns the resource or to an admin, bringing them in line with the
authorization patterns already used across the rest of the codebase. Each gate
ships with a handler-level regression test.

## Changes

- `security/blocked-ips` - restrict all methods (GET/POST/DELETE) to admins via `ensureAdmin`
- `analytics/aggregate` - restrict the cross-tenant analytics report to admins
- `feedback/[id]` update - authorize against the fetched document instance instead of the model class, so the CASL `{ userId }` ownership condition is actually evaluated (admins keep their unconditional update rule)
- `users/[id]/organization` and `users/[id]/friends` - restrict to the target user or an admin
- Added handler-level tests for each gate (17 tests)

## Guide for Testers

Use two accounts: a **non-admin** user A, a second user B, and an **admin**.
Auth is a Bearer JWT in `Authorization` (see prior test recipes); base URL is the
PR preview `app.pr<N>.preview.bike4mind.com` once a maintainer boots one.

1. As non-admin A, `GET /api/users/{B_id}/organization` (B is a different user) -> expect **403 Forbidden**.
2. As non-admin A, `GET /api/users/{A_id}/organization` (your own id) -> expect **200** with your org (or `null` if you have none).
3. As non-admin A, `GET /api/users/{B_id}/friends` -> expect **403**. `GET /api/users/{A_id}/friends` -> expect **200** with your friend list.
4. As non-admin A, `PUT /api/feedback/{id}` for a feedback item you did NOT author -> expect **403 / permission denied**. For one you did author -> expect **200** and the update persists.
5. As non-admin A, call `GET /api/security/blocked-ips`, `POST /api/security/blocked-ips`, `DELETE /api/security/blocked-ips`, and `GET /api/analytics/aggregate` -> each expects **403**.
6. As an **admin**, repeat step 5 -> each succeeds (200/201), and admin can also read any user's org/friends from steps 1-4.

### Regression Checks
1. Open the app as a normal user -> the Community/Friends list still loads (Profile -> Community).
2. Your own organization and credits views still load (Credits / Organizations).
3. As admin, the blocked-IPs admin flow and the analytics dashboard still work.

### What NOT to test
- Unrelated `publish/*` endpoints - they have pre-existing, unrelated test-env failures on `main` and are untouched here.

## Additional Information

- `pnpm --filter @bike4mind/client typecheck` clean; `eslint --quiet` reports 0 errors.
- The 17 new tests pass. The only failing test files in the client suite are pre-existing on `main` (`publish/*` + a vitest package-subpath resolution quirk) and are unrelated to this diff.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

---

**Note:** `users/[id]/projects` now has the same owner/admin gate. It also backs the public profile "Joined Projects" view; that cross-user section degrades to empty for now (the hook already handles it), and restoring it via a profile-scoped response is a tracked follow-up.