### PR TITLE
chore(premium): bump libreoncology overlay pin a44c7f8 → 6c198d67

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,6 +1,6 @@
 {
   "b4m-overwatch": "3c5914574e5bdfe61a1403fc98dcf31e2962ca48",
-  "b4m-libreoncology": "a44c7f8fc4a89adce670c36ce6f293049641c136",
+  "b4m-libreoncology": "6c198d67ffce265dc66cf7ef879c84a00847554c",
   "b4m-optihashi": "f8d7c0755af0023d50b53cf0bceadb094a0ed0ef",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"


### PR DESCRIPTION
Overlay-pin-only change: bumps the `b4m-libreoncology` pin in `premium-overlay.lock.json` to `6c198d67ffce265dc66cf7ef879c84a00847554c`. No application source changes; the other four overlay pins are unchanged.

A preview deploy validates the host build against the new overlay SHA before merge.