### PR TITLE
chore(deps): upgrade @anthropic-ai/sdk to 0.111.0

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -41,7 +41,7 @@
     "help:build": "pnpm help:build-index && pnpm help:bundle-content"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.97.1",
+    "@anthropic-ai/sdk": "^0.111.0",
     "@aws-sdk/client-apigatewaymanagementapi": "^3.1080.0",
     "@aws-sdk/client-bedrock": "^3.1080.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1080.0",

--- a/b4m-core/llm-adapters/package.json
+++ b/b4m-core/llm-adapters/package.json
@@ -50,7 +50,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.97.1",
+    "@anthropic-ai/sdk": "^0.111.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1080.0",
     "@aws-sdk/client-cloudwatch": "^3.1080.0",
     "@bike4mind/common": "workspace:*",

--- a/b4m-core/mcp/package.json
+++ b/b4m-core/mcp/package.json
@@ -70,7 +70,7 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.97.1",
+    "@anthropic-ai/sdk": "^0.111.0",
     "@bike4mind/common": "workspace:*",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@octokit/rest": "^22.0.1",

--- a/b4m-core/services/package.json
+++ b/b4m-core/services/package.json
@@ -187,7 +187,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.97.1",
+    "@anthropic-ai/sdk": "^0.111.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1080.0",
     "@aws-sdk/client-s3": "^3.1080.0",
     "@aws-sdk/client-transcribe": "^3.1080.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "1.2.0",
-    "@anthropic-ai/sdk": "^0.97.1",
+    "@anthropic-ai/sdk": "^0.111.0",
     "@aws-sdk/client-apigatewaymanagementapi": "^3.1080.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1080.0",
     "@aws-sdk/client-cloudwatch": "^3.1080.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
   apps/client:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.97.1
-        version: 0.97.1(zod@4.4.3)
+        specifier: ^0.111.0
+        version: 0.111.0(zod@4.4.3)
       '@aws-sdk/client-apigatewaymanagementapi':
         specifier: ^3.1080.0
         version: 3.1080.0
@@ -1099,8 +1099,8 @@ importers:
   b4m-core/llm-adapters:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.97.1
-        version: 0.97.1(zod@4.4.3)
+        specifier: ^0.111.0
+        version: 0.111.0(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.1080.0
         version: 3.1080.0
@@ -1154,8 +1154,8 @@ importers:
   b4m-core/mcp:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.97.1
-        version: 0.97.1(zod@4.4.3)
+        specifier: ^0.111.0
+        version: 0.111.0(zod@4.4.3)
       '@bike4mind/common':
         specifier: workspace:*
         version: link:../common
@@ -1209,8 +1209,8 @@ importers:
   b4m-core/services:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.97.1
-        version: 0.97.1(zod@4.4.3)
+        specifier: ^0.111.0
+        version: 0.111.0(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.1080.0
         version: 3.1080.0
@@ -1595,8 +1595,8 @@ importers:
         specifier: 1.2.0
         version: 1.2.0(zod@4.4.3)
       '@anthropic-ai/sdk':
-        specifier: ^0.97.1
-        version: 0.97.1(zod@4.4.3)
+        specifier: ^0.111.0
+        version: 0.111.0(zod@4.4.3)
       '@aws-sdk/client-apigatewaymanagementapi':
         specifier: ^3.1080.0
         version: 3.1080.0
@@ -2074,8 +2074,8 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/sdk@0.97.1':
-    resolution: {integrity: sha512-wOf7AUeJPitcVpvKO4UMu63mWH5SaVipkGd7OOQJt/G6VYGlV8D2Gp9dLxOrttDJh/9gqPqdaBwDGcBevumeAg==}
+  '@anthropic-ai/sdk@0.111.0':
+    resolution: {integrity: sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -12259,7 +12259,7 @@ snapshots:
       package-manager-detector: 1.7.0
       tinyexec: 1.2.4
 
-  '@anthropic-ai/sdk@0.97.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.111.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -20282,7 +20282,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}


### PR DESCRIPTION
## Description

Routine dependency maintenance: bumps the `@anthropic-ai/sdk` across a 14-minor
range (0.97 -> 0.111). Kept separate from `openai` since they're independent
providers. Part of the `/upgrade-deps` sweep (Tier B).

**Release notes reviewed (0.98 -> 0.111):** no breaking changes to public APIs.
All changes are additive -- new model support (claude-opus-4-8, claude-sonnet-5,
claude-fable-5/mythos-5), new beta headers (thinking token counts, dreaming,
agent-memory), client middleware + server-side fallback support, Managed Agents
surface, and lazy partial-tool-JSON stream parsing. TypeScript consumers require
no code changes.

## Changes

- `@anthropic-ai/sdk`: `0.97.1` -> `0.111.0`

Consumed by: `@bike4mind/llm-adapters`, `@bike4mind/services`, `@bike4mind/mcp`,
and `apps/client` (incl. the tavern RLM tools).

## Guide for Testers

Backend LLM-SDK dependency change. Verification is the type + test gates plus a
live smoke of a Claude-backed path.

1. Check out the branch, run `pnpm i -r`, then `pnpm turbo:typecheck`.
   - Expected: all packages typecheck (verified locally: 36/36 green).
2. Run the Anthropic-consuming suites:
   `VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/llm-adapters --filter @bike4mind/services --filter @bike4mind/mcp test`.
   - Expected: pass (verified locally: llm-adapters 275, services 1816 [11
     skipped], mcp 439 -- 0 failed).
3. In the app, run a chat completion against a Claude model (e.g. Claude Sonnet
   / Opus) and confirm streaming works end to end.
   - Expected: tokens stream, final message renders, no parse errors.
4. Exercise a tool-calling / structured-output path against a Claude model.
   - Expected: tools invoke and results parse as before.

### Regression Checks
- Claude chat streaming (token stream + final message).
- Claude tool calling / structured outputs via the llm-adapters + services path.
- MCP tool flows that use the Anthropic SDK.

### What NOT to test
- Non-Anthropic providers are untouched (OpenAI SDK is a separate PR). No infra
  or env changes.
