### PR TITLE
chore(premium): bump b4m-optihashi overlay pin

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "3c5914574e5bdfe61a1403fc98dcf31e2962ca48",
   "b4m-libreoncology": "6c198d67ffce265dc66cf7ef879c84a00847554c",
-  "b4m-optihashi": "f8d7c0755af0023d50b53cf0bceadb094a0ed0ef",
+  "b4m-optihashi": "c03425e4fd36354c35ad6771a36b96709d6dc828",
   "b4m-pi": "4542610b9498485f8eb2fca7bbdd8a347832b794",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Sets the `b4m-optihashi` overlay pin to `c03425e4fd36354c35ad6771a36b96709d6dc828`. Overlay-pin-only change; no application source changes.