### PR TITLE
fix(scripts): clean error instead of raw stack trace on gh api failure in premium:pin

### DIFF
--- a/scripts/premium-pin.mjs
+++ b/scripts/premium-pin.mjs
@@ -95,9 +95,15 @@ function cmdMerged(pins, name) {
   const owner = process.env.PREMIUM_OVERLAY_OWNER || 'Bike4Mind';
   const repo = `${owner}/${key}`;
   console.log(`Resolving ${repo}@${ref} to its latest commit SHA...`);
-  const sha = execFileSync('gh', ['api', `repos/${repo}/commits/${ref}`, '--jq', '.sha'], {
-    encoding: 'utf8',
-  }).trim();
+  let sha;
+  try {
+    sha = execFileSync('gh', ['api', `repos/${repo}/commits/${ref}`, '--jq', '.sha'], {
+      encoding: 'utf8',
+    }).trim();
+  } catch (err) {
+    console.error(`Error: 'gh api' failed to resolve ${repo}@${ref}: ${(err.stderr || err.message).trim()}`);
+    process.exit(1);
+  }
   if (!SHA_RE.test(sha)) {
     console.error(`Error: unexpected response from gh api (not a 40-char SHA): '${sha}'`);
     process.exit(1);


### PR DESCRIPTION
## Summary
- `pnpm premium:pin <name> --merged` let a `gh api` failure (bad ref, expired `gh auth` session, etc.) surface as an uncaught exception with a raw Node stack trace, instead of the clean `Error: ...` + exit 1 pattern used everywhere else in this CLI.
- Follow-up from manual verification of #205; not a functional regression (exit code was already nonzero, lock file already untouched on failure) - purely an error-message quality fix.

## Test plan
- [x] Manually verified: `gh api` failure (nonexistent branch) now prints a single clean `Error: 'gh api' failed to resolve ...` line instead of a raw stack trace, still exits 1
- [x] Manually verified: happy path (`optihashi=main` -> `--merged` against the real repo) still resolves to a SHA correctly
- [x] `npx eslint scripts/premium-pin.mjs` - clean
- [x] `pnpm turbo:typecheck` - clean