### PR TITLE
fix(client): read the error field from the server envelope in margin invoice modal

### DIFF
--- a/apps/client/app/components/admin/CreditAnalysis/components/MarginDashboard.test.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/MarginDashboard.test.tsx
@@ -157,7 +157,7 @@ describe('MarginDashboard invoice reconciliation', () => {
   });
 
   it('surfaces a failed save inside the modal', async () => {
-    mockPost.mockRejectedValue({ response: { data: { message: 'note is required' } } });
+    mockPost.mockRejectedValue({ response: { data: { error: 'note is required' } } });
     renderDashboard();
     fireEvent.click(await screen.findByTestId('margin-invoice-enter-2026-06-openai'));
     const modal = await screen.findByTestId('margin-invoice-modal');

--- a/apps/client/app/components/admin/CreditAnalysis/components/MarginDashboard.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/MarginDashboard.tsx
@@ -57,11 +57,12 @@ const RatioChip: React.FC<{ credits: number; cogsUsd: number; target: number }> 
 
 const numberCell = { fontVariantNumeric: 'tabular-nums' } as const;
 
-// Axios errors carry the server's validation reason in response.data;
-// err.message is only the generic status-code string.
+// The server error envelope puts the human-readable reason in data.error
+// (see server/middlewares/errorHandler.ts); data.message and err.message
+// stay as fallbacks for endpoints that don't follow that envelope.
 const apiErrorMessage = (err: unknown, fallback: string) => {
-  const e = err as { response?: { data?: { message?: string } }; message?: string };
-  return e.response?.data?.message || e.message || fallback;
+  const e = err as { response?: { data?: { error?: string; message?: string } }; message?: string };
+  return e.response?.data?.error || e.response?.data?.message || e.message || fallback;
 };
 
 /** Reconciliation status vs the entered invoice, as % of invoice. */


### PR DESCRIPTION
## Summary
- The invoice-entry modal in the Margins dashboard showed the generic `Request failed with status code 400` instead of the server's actual rejection reason (e.g. "note is required: name the invoice and its billing period").
- The shared server error handler serializes errors as `{ name, error, request_id }` -- the human-readable reason lives in `error`, not `message`. The `apiErrorMessage` helper in `MarginDashboard.tsx` only checked `data.message`, so it always fell through to the generic axios string.
- Fixed the helper to read `data.error` first, keeping the existing fallback chain (`data.message` -> `err.message` -> fallback) so any endpoint that does emit `message` still works. Matches the reference-correct pattern already used in `adminOrganizations.ts`.

## Test plan
- [x] `pnpm --filter @bike4mind/client test` -- MarginDashboard suite green (regression test now rejects the POST with the real envelope shape `{ response: { data: { error: '...' } } }` and asserts the modal shows the server's reason)
- [x] `pnpm turbo:typecheck` clean
- [x] `pnpm lint:check` clean
- [x] Manually verified against a real server 400 in a running instance: the modal displayed the exact server `error` text, not the generic axios message