### PR TITLE
docs(billing): document Bedrock cache-token forwarding in settlement invariant

### DIFF
--- a/b4m-core/llm-adapters/src/bedrockBackend/base.ts
+++ b/b4m-core/llm-adapters/src/bedrockBackend/base.ts
@@ -234,7 +234,8 @@ export abstract class BaseBedrockBackend implements ICompletionBackend {
         // Cache counts here come from Anthropic-native fields (input_tokens EXCLUDES
         // cache), so forwarding them is billing-safe. A Bedrock model reporting cache
         // with cache-INCLUSIVE input must not forward without subtracting (see the
-        // warnings in openaiBackend/geminiBackend).
+        // warnings in openaiBackend/geminiBackend). This is one of the two adapters
+        // covered by the disjoint-fields assumption in ChatCompletionProcess.ts.
         ...(cacheReadTokens > 0 ? { cacheReadInputTokens: cacheReadTokens } : {}),
         ...(cacheWriteTokens > 0 ? { cacheCreationInputTokens: cacheWriteTokens } : {}),
         ...(bestEffortFormat ? { responseFormatMode: 'best-effort' as const } : {}),

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -3015,9 +3015,11 @@ export class ChatCompletionProcess {
         // exactly the pre-provider-basis behavior. The bases never blend.
         //
         // Disjoint-fields assumption: cacheReadInputTokens is only forwarded by
-        // Anthropic-family adapters, whose input_tokens EXCLUDE cached tokens.
-        // OpenAI/Gemini/xAI report prompt tokens INCLUSIVE of cache and must not
-        // forward cache counts here without also subtracting them from input.
+        // Anthropic-family adapters - the direct Anthropic adapter and
+        // Claude-on-Bedrock (bedrockBackend/base.ts) - whose input_tokens EXCLUDE
+        // cached tokens. OpenAI/Gemini/xAI report prompt tokens INCLUSIVE of cache
+        // and must not forward cache counts here without also subtracting them
+        // from input.
         //
         // NOTE: the provider input (uncached tail) drives getTextModelCost's
         // pricing-tier selection. Every model today publishes a single tier, so


### PR DESCRIPTION
## Summary
- Expands the disjoint-fields settlement invariant comment in `ChatCompletionProcess.ts` to explicitly name Claude-on-Bedrock (`bedrockBackend/base.ts`) as one of the two adapters that forward cache token counts, alongside the direct Anthropic adapter.
- Adds a bidirectional back-reference from `bedrockBackend/base.ts` pointing at the invariant in `ChatCompletionProcess.ts`.

## What changed
Comment-only. No settlement logic, token math, or control flow changed.

- `b4m-core/services/src/llm/ChatCompletionProcess.ts`: invariant comment now names both forwarding adapters instead of leaving "Anthropic-family adapters" unstated.
- `b4m-core/llm-adapters/src/bedrockBackend/base.ts`: appends a one-line back-reference to the invariant it satisfies (the original warning is left intact).

## Why
The uncapped `cacheReadInputTokens` read on the provider-basis settlement path depends on a disjoint-fields assumption that only Anthropic-family adapters forward cache counts. The comment referenced "Anthropic-family adapters" without naming Claude-on-Bedrock as one of them, even though it forwards cache counts too. This makes the dependency explicit for future readers.

## Test plan
- [x] `git diff main...HEAD` touches only `//` comment lines in both files; settlement logic is byte-identical to main.
- [x] ASCII-only check on added lines (no smart punctuation).
- [x] `pnpm turbo:typecheck` passes.