### PR TITLE
refactor(admin): tighten ledger type validation + audit-faithful sign (M3 review nits)

### DIFF
--- a/apps/client/app/components/admin/CreditAnalysis/components/TransactionLedger.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/TransactionLedger.tsx
@@ -30,7 +30,6 @@ import { formatCredits, numberCell } from '../utils/format';
 import { useTransactionLedger, LedgerFilters } from '../hooks/useTransactionLedger';
 
 const DAY_OPTIONS = [7, 30, 90, 365] as const;
-const DEDUCT_TYPES = new Set<CreditTransactionType>(CREDIT_DEDUCT_TRANSACTION_TYPES);
 const ALL_TYPES: CreditTransactionType[] = [...CREDIT_ADD_TRANSACTION_TYPES, ...CREDIT_DEDUCT_TRANSACTION_TYPES];
 
 const labelFor = (t: string) => t.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
@@ -193,7 +192,10 @@ export const TransactionLedger: React.FC = () => {
               </thead>
               <tbody>
                 {rows.map(r => {
-                  const isDeduct = DEDUCT_TYPES.has(r.type);
+                  // Sign comes from the ledger's own value (usage is stored negative),
+                  // not from the type - so a mis-signed row stays visible in this audit view.
+                  const negative = r.credits < 0;
+                  const sessionId = r.sessionId;
                   return (
                     <tr key={r.id}>
                       <td>{formatWhen(r.createdAt)}</td>
@@ -202,19 +204,19 @@ export const TransactionLedger: React.FC = () => {
                       <td title={r.model}>{r.model ?? '—'}</td>
                       <td title={r.actingUserId}>{r.actingUserName ?? (r.actingUserId ? 'Unknown user' : '—')}</td>
                       <td style={{ textAlign: 'right', ...numberCell }}>
-                        <Chip size="sm" variant="soft" color={isDeduct ? 'danger' : 'success'}>
-                          {isDeduct ? '-' : '+'}
+                        <Chip size="sm" variant="soft" color={negative ? 'danger' : 'success'}>
+                          {negative ? '-' : '+'}
                           {formatCredits(Math.abs(r.credits))}
                         </Chip>
                       </td>
                       <td>
-                        {r.sessionId && (
+                        {sessionId && (
                           <Tooltip title="Open session">
                             <IconButton
                               size="sm"
                               variant="plain"
                               data-testid="ledger-drilldown-btn"
-                              onClick={() => navigate({ to: '/notebooks/$id', params: { id: r.sessionId! } })}
+                              onClick={() => navigate({ to: '/notebooks/$id', params: { id: sessionId } })}
                             >
                               <OpenInNewIcon fontSize="small" />
                             </IconButton>

--- a/apps/client/pages/api/admin/transactions.ts
+++ b/apps/client/pages/api/admin/transactions.ts
@@ -3,6 +3,8 @@ import { creditTransactionRepository } from '@bike4mind/database';
 import {
   CreditHolderType,
   COMPLETION_SOURCES,
+  CREDIT_ADD_TRANSACTION_TYPES,
+  CREDIT_DEDUCT_TRANSACTION_TYPES,
   type CreditTransactionType,
   type IAdminLedgerResponse,
   type ILedgerRow,
@@ -11,18 +13,28 @@ import { ForbiddenError } from '@server/utils/errors';
 import { resolveUserNames } from '@server/utils/resolveUserNames';
 import { z } from 'zod';
 
-/** Accept a repeated (`type=a&type=b`) or comma-joined (`type=a,b`) query param as a string array. */
-const csvArray = z
+const TRANSACTION_TYPES = [...CREDIT_ADD_TRANSACTION_TYPES, ...CREDIT_DEDUCT_TRANSACTION_TYPES] as [
+  CreditTransactionType,
+  ...CreditTransactionType[],
+];
+
+/**
+ * A repeated (`type=a&type=b`) or comma-joined (`type=a,b`) param, validated
+ * against the known transaction types so a bogus value 422s (parity with
+ * `source`) rather than silently matching nothing.
+ */
+const typeParam = z
   .union([z.string(), z.array(z.string())])
   .optional()
-  .transform(v => (v === undefined ? [] : (Array.isArray(v) ? v : v.split(',')).map(s => s.trim()).filter(Boolean)));
+  .transform(v => (v === undefined ? [] : (Array.isArray(v) ? v : v.split(',')).map(s => s.trim()).filter(Boolean)))
+  .pipe(z.array(z.enum(TRANSACTION_TYPES)));
 
 const QuerySchema = z.object({
   organizationId: z.string().min(1),
   page: z.coerce.number().int().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
   days: z.coerce.number().int().min(1).max(365).optional(),
-  type: csvArray,
+  type: typeParam,
   source: z.enum(COMPLETION_SOURCES).optional(),
   model: z.string().min(1).optional(),
 });
@@ -47,7 +59,7 @@ const handler = baseApi().get(async (req, res) => {
   const { data, total } = await creditTransactionRepository.queryLedgerPage(
     organizationId,
     CreditHolderType.Organization,
-    { days, transactionTypes: type as CreditTransactionType[], source, model, limit, skip: (page - 1) * limit }
+    { days, transactionTypes: type, source, model, limit, skip: (page - 1) * limit }
   );
 
   // Resolve the acting-member ids that some rows carry to display names.

--- a/packages/database/src/models/billing/CreditTransactionModel.ts
+++ b/packages/database/src/models/billing/CreditTransactionModel.ts
@@ -212,7 +212,9 @@ export class CreditTransactionRepository
     }
 
     // count + page share the {ownerId, ownerType, createdAt} index; run them
-    // together since a busy org can have tens of thousands of rows.
+    // together since a busy org can have tens of thousands of rows. Not a single
+    // transaction: a concurrent write between the two can make total differ from
+    // the page by one - acceptable for a read-only admin view.
     const [data, total] = await Promise.all([
       this.model.find(query).sort({ createdAt: -1 }).skip(options.skip).limit(options.limit).exec(),
       this.model.countDocuments(query),


### PR DESCRIPTION
## Description

Follow-up to the merged **#521** (M3 org transaction-ledger), addressing the three non-blocking review nits from @jjmarfa's approve-with-comments. #521 was squash-merged before these landed, so they ship here. Part of #334 (M3). No behavior change beyond the validation tightening below.

## Changes

- **`pages/api/admin/transactions.ts`** — `?type` is now validated against the known transaction types (`z.enum` via `.pipe`) instead of an unchecked cast, so a bogus value returns **422** for parity with `source`, rather than silently matching nothing.
- **`packages/database/.../CreditTransactionModel.ts`** — documented that the `find`/`countDocuments` pair in `queryLedgerPage` is not a single transaction (a concurrent write can make `total` differ from the page by one; acceptable for a read-only admin view).
- **`TransactionLedger.tsx`** — removed the redundant `sessionId!` non-null assertion via a narrowable local; and derive the credit sign from the ledger's stored value (`credits < 0`) rather than a type set, so a mis-signed row stays visible in the audit view (dropped the now-unused `DEDUCT_TYPES`).

## Guide for Testers

1. Admin -> Credit Analytics -> **Ledger**; select a team org.
2. In the browser devtools/network, confirm changing the **Type** filter still refetches `/api/admin/transactions` with `type=<value>` and returns 200.
3. `GET /api/admin/transactions?organizationId=<id>&type=bogus` with an admin token now returns **422** (previously 200 with an empty result). Valid types still return 200.
4. Deduction rows still show a red `-N` chip and additions a green `+N` chip (sign now taken from the stored value; identical for well-formed data).

### Regression Checks
- The Ledger tab and its filters/pagination/drill-down behave exactly as in #521; sibling Credit Analytics tabs unaffected.

### What NOT to test
- No new surface; this is a validation/clarity refinement of #521.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Docs / AdminSettings / telemetry - N/A
