### PR TITLE
ci(e2e): add Core gate workflow with dedicated e2e/core status

### DIFF
--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -7,6 +7,12 @@ name: E2E Tests (Core)
 # advisory full suite (`e2e-manual.yml`, status `e2e/smoke`) so one environment-sensitive
 # spec can't block the core signal. The Core set graduates over time - see
 # apps/client/e2e/README.md ("Core gate") for the criteria to add a project here.
+#
+# MUST STAY IN SYNC WITH e2e-manual.yml: the tested-SHA resolution, deploy-in-flight
+# wait, /api/ping health gate, jq results parser, and commit-status/Slack steps below
+# are near-identical to that workflow. A fix applied to one must be applied to the other,
+# or the e2e/core and e2e/smoke signals will silently diverge. Extracting the shared
+# plumbing into a composite action / reusable workflow_call is tracked as a follow-up.
 
 on:
   workflow_dispatch:
@@ -95,7 +101,15 @@ jobs:
 
       - name: Set trigger label
         id: trigger
-        run: echo "label=Run via Deployer" >> $GITHUB_OUTPUT
+        # gate_run=true is the deployer's post-staging-deploy dispatch; a plain manual
+        # dispatch is a QA run. Label accordingly so an on-call doesn't chase the deploy
+        # pipeline for a hand-triggered run.
+        run: |
+          if [ "${{ inputs.gate_run }}" = "true" ]; then
+            echo "label=Run via Deployer" >> $GITHUB_OUTPUT
+          else
+            echo "label=Run via Dispatch" >> $GITHUB_OUTPUT
+          fi
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -448,6 +462,10 @@ jobs:
               ]
             }
 
+      # Asymmetry by design: this fails the job only on a real test failure, but the
+      # e2e/core status above also posts `failure` when not_started > 0 (specs registered
+      # but never executed). So the run conclusion can be green while e2e/core is red.
+      # Consumers MUST read the e2e/core commit status, never poll this run's conclusion.
       - name: Fail if Core E2E tests failed
         if: steps.results.outputs.failed != '0'
         run: exit 1

--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -1,0 +1,453 @@
+name: E2E Tests (Core)
+
+# Curated Core gate: runs only the fast, deterministic "is the app fundamentally
+# alive" projects (auth/signup + notebook + basic prompt flow) in a SINGLE Playwright
+# invocation, and posts its own `e2e/core` commit status. This is deliberately NOT the
+# full suite: the heavy, AI-latency-dependent specs (image-gen, agents) stay in the
+# advisory full suite (`e2e-manual.yml`, status `e2e/smoke`) so one environment-sensitive
+# spec can't block the core signal. The Core set graduates over time - see
+# apps/client/e2e/README.md ("Core gate") for the criteria to add a project here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: 'Target environment'
+        type: choice
+        options:
+          - dev
+        default: dev
+      pr_number:
+        description: 'PR number for preview env (overrides stage, e.g. 123)'
+        type: string
+        required: false
+      e2e_test_id:
+        description: 'Tester ID for user isolation (e.g. alice)'
+        type: string
+        required: false
+      # Internal: set to 'true' only by the deployer's staging-deploy trigger when
+      # the Core gate is enforced. Coalesces rapid gate runs to the latest tip; leave
+      # 'false' for manual runs (which keep their existing behavior).
+      gate_run:
+        description: 'Internal: deploy-triggered gate run (leave false for manual runs)'
+        type: string
+        default: 'false'
+        required: false
+
+env:
+  AWS_REGION: us-east-2
+  NODE_VERSION: '24'
+  # The Core set: whole projects only, no positional spec filter. A positional spec
+  # filter applies globally to EVERY --project in the run, so mixing one in (as the
+  # Auth/Signup single-test selections do) would wrongly filter the other projects.
+  # `unauthenticated` covers both auth + signup. Graduate more projects in as they
+  # prove deterministic (see apps/client/e2e/README.md).
+  CORE_PROJECTS: '--project=unauthenticated --project=notebook --project=prompts'
+
+jobs:
+  e2e-core:
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
+    name: E2E Core Tests
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
+      # Post the e2e/core commit status the prod-promotion console can gate on.
+      statuses: write
+    # Serialize per-stage so overlapping runs (e.g. a gate run + a manual run) can't
+    # stomp each other's global-setup data cleanup. Gate runs (deploy-triggered) share
+    # one group and coalesce to the latest tip via cancel-in-progress; manual runs keep
+    # a per-target group with no cancellation.
+    concurrency:
+      group: ${{ inputs.gate_run == 'true' && 'e2e-core-gate' || format('e2e-core-{0}', inputs.pr_number || inputs.stage || 'dev') }}
+      cancel-in-progress: ${{ inputs.gate_run == 'true' }}
+
+    steps:
+      - name: Resolve configuration
+        id: config
+        env:
+          # Pass dispatch inputs through env (never interpolate attacker-
+          # influenceable values straight into the shell). pr_number flows into
+          # the SST stage and `sst shell --stage`, so it must be digits-only.
+          PR_NUMBER: ${{ inputs.pr_number }}
+          STAGE_INPUT: ${{ inputs.stage }}
+          PREVIEW_SERVER_DOMAIN: ${{ vars.PREVIEW_SERVER_DOMAIN }}
+          STAGING_SERVER_DOMAIN: ${{ vars.STAGING_SERVER_DOMAIN }}
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            if ! printf '%s' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+              echo "::error::pr_number must be digits-only; got '$PR_NUMBER'"
+              exit 1
+            fi
+            STAGE="pr${PR_NUMBER}"
+            API_URL="https://app.pr${PR_NUMBER}.${PREVIEW_SERVER_DOMAIN}"
+            ENV_LABEL="preview-${PR_NUMBER}"
+          else
+            STAGE="${STAGE_INPUT:-dev}"
+            API_URL="https://app.${STAGING_SERVER_DOMAIN}"
+            ENV_LABEL="Staging"
+          fi
+          echo "stage=$STAGE" >> $GITHUB_OUTPUT
+          echo "api_url=$API_URL" >> $GITHUB_OUTPUT
+          echo "env_label=$ENV_LABEL" >> $GITHUB_OUTPUT
+          echo "Stage: $STAGE"
+          echo "API URL: $API_URL"
+
+      - name: Set trigger label
+        id: trigger
+        run: echo "label=Run via Deployer" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Cache pnpm dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pnpm-store
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --recursive
+
+      - name: Build core packages
+        run: pnpm core:build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_DEV_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Capture the SHA currently live on staging BEFORE the suite runs, so a mid-run
+      # staging redeploy can't mislabel it. Source of truth = the newest main commit
+      # whose `staging/deploy` status is success (the same signal the console's staging
+      # gate reads). Only the dev/staging run stamps the frontier; skip previews.
+      - name: Resolve tested SHA for e2e/core status
+        id: tested_sha
+        if: inputs.pr_number == ''
+        continue-on-error: true
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = 'Bike4Mind', repo = 'bike4mind';
+            const { data: commits } = await github.rest.repos.listCommits({ owner, repo, sha: 'main', per_page: 20 });
+            for (const c of commits) {
+              const { data: st } = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: c.sha });
+              if (st.statuses.some(s => s.context === 'staging/deploy' && s.state === 'success')) {
+                core.setOutput('sha', c.sha);
+                core.info(`Tested staging SHA = ${c.sha} (newest with staging/deploy=success)`);
+                return;
+              }
+            }
+            core.warning('No recent main commit has staging/deploy=success; e2e/core status will be skipped.');
+
+      - name: Install Playwright Chromium
+        working-directory: apps/client
+        # Cap the install: the yauzl/Node>=24.16 extraction wedge
+        # (playwright#40724) can hang this step indefinitely, idling to the job
+        # cap. Fail fast instead.
+        timeout-minutes: 8
+        run: npx playwright install chromium --with-deps
+
+      # A staging deploy in flight rotates E2E_CLEANUP_SECRET and swaps the Lambda,
+      # so running e2e against it 401s the create-test-user setup - which then skips
+      # the affected projects via Playwright's setup-dependency graph. /api/ping is not
+      # enough: CloudFront answers it green all through a deploy. So gate on the
+      # `staging/deploy` commit status: if the newest commit that has one is still
+      # `pending`, a deploy is running - wait it out. dev/staging only (a preview has
+      # its own env). Best-effort: warns + proceeds on timeout.
+      - name: Wait for staging deploy to settle (no deploy in flight)
+        if: inputs.pr_number == ''
+        continue-on-error: true
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = 'Bike4Mind', repo = 'bike4mind';
+            const deployInFlight = async () => {
+              const { data: commits } = await github.rest.repos.listCommits({ owner, repo, sha: 'main', per_page: 10 });
+              for (const c of commits) {
+                const { data: st } = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: c.sha });
+                const s = st.statuses.find(x => x.context === 'staging/deploy');
+                if (!s) continue;              // no status on this commit yet; check older
+                return s.state === 'pending';  // the newest commit WITH a status decides
+              }
+              return false;
+            };
+            for (let i = 0; i < 30; i++) {     // up to ~10 min
+              if (!(await deployInFlight())) { core.info('No staging deploy in flight; proceeding.'); return; }
+              core.info(`Staging deploy in progress; waiting 20s (attempt ${i + 1}/30)...`);
+              await new Promise(r => setTimeout(r, 20000));
+            }
+            core.warning('Staging still deploying after ~10 min; proceeding anyway (the health probe below is the backstop).');
+
+      - name: Wait for deployment to be healthy
+        env:
+          # Probe /api/ping (a real Lambda route) rather than the bare origin:
+          # CloudFront can answer the apex with 200/302 before the function is
+          # warm, so a bare-origin check passes against a not-yet-ready deploy.
+          TARGET_URL: ${{ steps.config.outputs.api_url }}/api/ping
+        run: |
+          echo "Waiting for $TARGET_URL to be healthy..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$TARGET_URL" || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Deployment is healthy (HTTP $STATUS) after $((i * 10))s"
+              exit 0
+            fi
+            echo "Attempt $i: HTTP $STATUS - retrying in 10s..."
+            sleep 10
+          done
+          echo "Deployment did not become healthy within 300s"
+          exit 1
+
+      - name: Run Core E2E tests
+        id: e2e
+        env:
+          API_URL: ${{ steps.config.outputs.api_url }}
+          # E2E_CLEANUP_SECRET is read from SST (Resource.E2E_CLEANUP_SECRET.value) via the
+          # `sst shell` wrapper below - no GitHub-secret env override (issue #251).
+          E2E_TEST_ID: ${{ inputs.e2e_test_id }}
+          AI_LATENCY_RUN: 'false'
+          PW_WORKERS: '3'
+          CI: 'true'
+        run: |
+          set -o pipefail
+          # One Playwright run, multiple --project flags = one run, one report, one status.
+          # Each project pulls its own setup dependency chain (isolated test user/auth) in
+          # automatically. CORE_PROJECTS is whole projects only - see the env note above.
+          echo "Running Core projects: $CORE_PROJECTS"
+          pnpm sst shell --stage ${{ steps.config.outputs.stage }} -- pnpm --filter client exec playwright test $CORE_PROJECTS 2>&1 | tee apps/client/playwright-output.txt
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report-core-${{ steps.config.outputs.stage }}${{ inputs.e2e_test_id && format('-{0}', inputs.e2e_test_id) || '' }}
+          path: apps/client/playwright-report/
+          retention-days: 7
+
+      - name: Parse test results
+        id: results
+        if: always()
+        run: |
+          JSON_FILE="apps/client/pw-results.json"
+
+          if [ ! -f "$JSON_FILE" ]; then
+            echo "passed=0" >> $GITHUB_OUTPUT
+            echo "failed=0" >> $GITHUB_OUTPUT
+            echo "skipped=0" >> $GITHUB_OUTPUT
+            echo "not_started=0" >> $GITHUB_OUTPUT
+            echo "real_failed=0" >> $GITHUB_OUTPUT
+            echo "setup_failed=0" >> $GITHUB_OUTPUT
+            echo "total=0" >> $GITHUB_OUTPUT
+            echo "spec_summary=_No results available_" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          FAILED=$(jq '.stats.unexpected' "$JSON_FILE")
+          echo "failed=$FAILED" >> $GITHUB_OUTPUT
+
+          # A spec "ran" if at least one of its test entries has non-empty results.
+          # Tests registered but never started (global timeout / worker killed) appear in
+          # pw-results.json with ok:true but results:[] - gate on actual execution evidence.
+          SPEC_LINES=$(jq -r '[
+            .suites[] |
+            select(.title | test("\\.setup\\.ts$") | not) |
+            . as $suite |
+            ($suite.title | gsub("e2e/"; "") | gsub("\\.spec\\.ts$"; "")) as $raw |
+            ([$raw | split("-")[] | split("_")[] | (.[0:1] | ascii_upcase) + .[1:]] | join(" ")) as $name |
+            ([.. | objects | select(has("ok") and has("tests")) |
+              select(any(.tests[]?; (.results? // []) | length > 0))] | length) as $ran |
+            ([.. | objects | select(has("ok") and has("tests")) |
+              select(any(.tests[]?; (.results? // []) | length > 0)) |
+              select(.ok == true)] | length) as $passed |
+            ([.. | objects | select(has("ok") and has("tests") and ((.tests | length) > 0)) |
+              select(all(.tests[]?; (.results? // []) | length == 0))] | length) as $not_run |
+            (if $ran == 0 and $not_run > 0 then ":no_entry_sign:"
+             elif $ran > 0 and $ran - $passed > 0 then ":red_circle:"
+             else ":large_green_circle:" end) +
+            " " + $name + ": " + ($passed|tostring) + "/" + ($ran|tostring) +
+            (if $not_run > 0 then " (" + ($not_run|tostring) + " did not run)" else "" end)
+          ] | join("\\n")' "$JSON_FILE")
+          echo "spec_summary=$SPEC_LINES" >> $GITHUB_OUTPUT
+
+          # Count only specs that actually executed (results non-empty).
+          PASSED=$(jq '[
+            .suites[] |
+            select(.title | test("\\.setup\\.ts$") | not) |
+            [.. | objects | select(has("ok") and has("tests")) |
+              select(any(.tests[]?; (.results? // []) | length > 0)) |
+              select(.ok == true)] | length
+          ] | add // 0' "$JSON_FILE")
+          TOTAL_WITH_OK=$(jq '[
+            .suites[] |
+            select(.title | test("\\.setup\\.ts$") | not) |
+            [.. | objects | select(has("ok") and has("tests")) |
+              select(any(.tests[]?; (.results? // []) | length > 0))] | length
+          ] | add // 0' "$JSON_FILE")
+          SKIPPED=$(( TOTAL_WITH_OK - PASSED - FAILED ))
+          # Clamp to 0 - FAILED includes setup failures not in TOTAL_WITH_OK
+          [ "$SKIPPED" -lt 0 ] && SKIPPED=0
+          NOT_STARTED=$(jq '[
+            .suites[] |
+            select(.title | test("\\.setup\\.ts$") | not) |
+            [.. | objects | select(has("ok") and has("tests") and ((.tests | length) > 0)) |
+              select(all(.tests[]?; (.results? // []) | length == 0))] | length
+          ] | add // 0' "$JSON_FILE")
+          # Split failures into real-test vs setup so the commit-status step can leave
+          # e2e/core *missing* (not a sticky red) when the only failure is a global-setup
+          # infra flake (e.g. create-test-user 401), while a genuine test failure posts
+          # `failure`. Mirrors the PASSED computation, inverted.
+          REAL_FAILED=$(jq '[
+            .suites[] |
+            select(.title | test("\\.setup\\.ts$") | not) |
+            [.. | objects | select(has("ok") and has("tests")) |
+              select(any(.tests[]?; (.results? // []) | length > 0)) |
+              select(.ok != true)] | length
+          ] | add // 0' "$JSON_FILE")
+          SETUP_FAILED=$(jq '[
+            .suites[] |
+            select(.title | test("\\.setup\\.ts$")) |
+            [.. | objects | select(has("ok") and has("tests")) |
+              select(any(.tests[]?; (.results? // []) | length > 0)) |
+              select(.ok != true)] | length
+          ] | add // 0' "$JSON_FILE")
+          TOTAL=$((PASSED + SKIPPED + FAILED))
+          echo "passed=$PASSED" >> $GITHUB_OUTPUT
+          echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
+          echo "not_started=$NOT_STARTED" >> $GITHUB_OUTPUT
+          echo "real_failed=$REAL_FAILED" >> $GITHUB_OUTPUT
+          echo "setup_failed=$SETUP_FAILED" >> $GITHUB_OUTPUT
+          echo "total=$TOTAL" >> $GITHUB_OUTPUT
+
+      - name: Post e2e/core commit status
+        # Stamp the tested staging SHA with the Core result so the prod-promotion console
+        # can read a per-commit core signal. `success` only when nothing failed, nothing
+        # was left unstarted, and tests actually ran. A setup-only infra flake leaves the
+        # status MISSING (not `failure`) so a transient blip doesn't stick a red on the SHA.
+        # Best-effort: never fails the e2e run.
+        if: always() && steps.tested_sha.outputs.sha != ''
+        continue-on-error: true
+        uses: actions/github-script@v8
+        env:
+          TESTED_SHA: ${{ steps.tested_sha.outputs.sha }}
+          FAILED: ${{ steps.results.outputs.failed }}
+          NOT_STARTED: ${{ steps.results.outputs.not_started }}
+          REAL_FAILED: ${{ steps.results.outputs.real_failed }}
+          SETUP_FAILED: ${{ steps.results.outputs.setup_failed }}
+          PASSED: ${{ steps.results.outputs.passed }}
+          TOTAL: ${{ steps.results.outputs.total }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const sha = process.env.TESTED_SHA;
+            const total = Number(process.env.TOTAL || '0');
+            if (total === 0) {
+              core.warning('No e2e results parsed; skipping e2e/core status (leaves it missing = not promotable).');
+              return;
+            }
+            // Setup/infra flake (e.g. create-test-user 401): the only failures are in global
+            // setup and no actual test failed. Leave e2e/core MISSING (still not promotable,
+            // but re-seedable by a later run) rather than a sticky `failure` red on the SHA.
+            const realFailed = Number(process.env.REAL_FAILED || '0');
+            const setupFailed = Number(process.env.SETUP_FAILED || '0');
+            if (realFailed === 0 && setupFailed > 0) {
+              core.warning(`Setup failed (${setupFailed}) with no test failures; skipping e2e/core status (leaves it missing = re-seedable).`);
+              return;
+            }
+            const ok = process.env.FAILED === '0' && process.env.NOT_STARTED === '0';
+            const state = ok ? 'success' : 'failure';
+            const desc = (ok
+              ? `Core e2e subset passed (${process.env.PASSED}/${total})`
+              : `Core e2e subset: ${process.env.FAILED} failed, ${process.env.NOT_STARTED} not started`).slice(0, 140);
+            await github.rest.repos.createCommitStatus({
+              owner: 'Bike4Mind', repo: 'bike4mind', sha,
+              state, context: 'e2e/core', target_url: process.env.RUN_URL, description: desc,
+            });
+            core.info(`Posted e2e/core=${state} on ${sha.slice(0, 7)}`);
+
+      - name: Notify Slack
+        if: always()
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_E2E_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Playwright E2E Core (${{ steps.trigger.outputs.label }}) - ${{ steps.results.outputs.failed == '0' && steps.results.outputs.not_started == '0' && ':white_check_mark: Core passed' || steps.results.outputs.failed == '0' && steps.results.outputs.not_started != '0' && ':warning: Passed but some specs did not start' || ':x: Core failed' }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Playwright E2E Core (${{ steps.trigger.outputs.label }})"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status*\n${{ steps.results.outputs.failed == '0' && steps.results.outputs.not_started == '0' && ':white_check_mark: Passed' || steps.results.outputs.failed == '0' && steps.results.outputs.not_started != '0' && ':warning: Incomplete' || ':x: Failed' }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch*\n`${{ github.ref_name }}`"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Environment*\n<${{ steps.config.outputs.api_url }}|${{ steps.config.outputs.env_label }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Results*\n:white_check_mark: ${{ steps.results.outputs.passed }} passed  :x: ${{ steps.results.outputs.failed }} failed  :fast_forward: ${{ steps.results.outputs.skipped }} skipped  :no_entry_sign: ${{ steps.results.outputs.not_started }} not started  Total: ${{ steps.results.outputs.total }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Core Run Summary*\n${{ steps.results.outputs.spec_summary }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": { "type": "plain_text", "text": "View Report" },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts"
+                    }
+                  ]
+                }
+              ]
+            }
+
+      - name: Fail if Core E2E tests failed
+        if: steps.results.outputs.failed != '0'
+        run: exit 1

--- a/apps/client/e2e/README.md
+++ b/apps/client/e2e/README.md
@@ -298,6 +298,12 @@ block the "is the app fundamentally alive" check:
 | **Core** | `.github/workflows/e2e-core.yml` | `e2e/core` | Curated, fast, deterministic subset - the gate we can require |
 | **Full suite** | `.github/workflows/e2e-manual.yml` | `e2e/smoke` | Everything, including AI-latency-dependent specs - advisory, for triage |
 
+> **Never make `e2e/core` a branch-protection required check.** This workflow is
+> `workflow_dispatch`-only and stamps the status onto the tested *staging* SHA - it can
+> never report on a merge-queue SHA, so a required-check rule would deadlock the queue.
+> `e2e/core` is consumed by the prod-promotion console (which reads it per-commit), not by
+> GitHub branch protection.
+
 The **Core** run executes a fixed set of whole Playwright projects in a single invocation
 (one run, one report, one status). The current set is defined by `CORE_PROJECTS` in
 `e2e-core.yml`:
@@ -337,12 +343,12 @@ demoting a spec back to advisory over letting a red Core gate get ignored.
 
 ## CI Integration
 
-E2E tests run automatically on **pull request preview deployments** via GitHub Actions (`.github/workflows/ci.yml`):
+Preview deploys are created on demand by maintainers via the internal deployer (not by PR events). To run the suite against a PR preview, a maintainer adds the **`run-e2e`** label, which triggers `.github/workflows/e2e-on-label.yml`:
 
-1. After the preview deploys, CI waits for the URL to become healthy
-2. Tests run headless with 3 workers against the preview URL
+1. CI waits for the preview URL to become healthy
+2. Tests run headless (1 worker) against the preview URL
 3. Results are posted as a **comment on the PR** with pass/fail counts
-4. The **HTML report** is uploaded as a build artifact (`playwright-report-pr<N>`)
+4. The **HTML report** is uploaded as a build artifact (`playwright-report-pr<N>-label`)
 
 In CI, `API_URL` points at the deployment under test. `E2E_CLEANUP_SECRET` is **not** a GitHub secret — it lives only in SST: each `pr{n}` preview self-provisions a fresh random value at deploy time, and every Playwright step runs inside `pnpm sst shell`, so the test client reads `Resource.E2E_CLEANUP_SECRET.value` (the same value the cleanup/create-user API validates against). See issue #251.
 

--- a/apps/client/e2e/README.md
+++ b/apps/client/e2e/README.md
@@ -288,6 +288,53 @@ test.afterAll(async ({ request }) => {
 });
 ```
 
+## Core gate
+
+The E2E suite is split into two signals so a heavy, environment-sensitive spec can't
+block the "is the app fundamentally alive" check:
+
+| Signal | Workflow | Commit status | Role |
+|--------|----------|---------------|------|
+| **Core** | `.github/workflows/e2e-core.yml` | `e2e/core` | Curated, fast, deterministic subset - the gate we can require |
+| **Full suite** | `.github/workflows/e2e-manual.yml` | `e2e/smoke` | Everything, including AI-latency-dependent specs - advisory, for triage |
+
+The **Core** run executes a fixed set of whole Playwright projects in a single invocation
+(one run, one report, one status). The current set is defined by `CORE_PROJECTS` in
+`e2e-core.yml`:
+
+- `unauthenticated` - auth + signup
+- `notebook` - load a notebook
+- `prompts` - basic prompt flow
+
+Deliberately excluded: AI-latency-dependent and known-unstable specs (`image-gen`,
+`agents`, etc.). Those still run in the advisory full suite.
+
+> **Gotcha - whole projects only.** The Core set uses `--project=` flags with **no**
+> positional spec-file filter. A positional filter (e.g. `e2e/auth.spec.ts`, as the
+> full suite's single-test `Auth`/`Signup` selections use) applies globally to *every*
+> project in the run, so mixing one in would wrongly filter the other projects down to
+> files matching that path and break them. `--project=unauthenticated` alone runs both
+> auth + signup, which is what we want for Core.
+
+### Graduating a spec into Core
+
+The Core set is meant to grow as specs prove themselves. A project qualifies to be added
+to `CORE_PROJECTS` when it is:
+
+1. **Green over N consecutive runs** - at least the last 5, drawing on the deployer-
+   triggered `e2e-core` runs and the full suite's daily `e2e-manual` schedule, with no
+   real-test failures. Setup/infra flakes that leave the status *missing* don't reset the
+   count; a real red does.
+2. **Deterministic** - no dependence on AI latency, model output wording, or other
+   non-deterministic timing. If it needs `AI_RESPONSE`-tier waits or asserts on generated
+   content, it stays out.
+3. **Fast** - its contribution keeps the whole Core run comfortably under the job's
+   25-minute cap.
+
+To add one: append `--project=<name>` to `CORE_PROJECTS` in `e2e-core.yml` and update the
+list above. Removing a project that starts flaking is the same edit in reverse - prefer
+demoting a spec back to advisory over letting a red Core gate get ignored.
+
 ## CI Integration
 
 E2E tests run automatically on **pull request preview deployments** via GitHub Actions (`.github/workflows/ci.yml`):


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

**Issue:** [B4M-477](https://github.com/Bike4Mind/bike4mind/issues/477)

## Description

The E2E gate currently runs the **full** Playwright suite (~14 per-spec projects) and reports a single `e2e/smoke` commit status. Despite the name, `e2e/smoke` reflects the whole suite, not a curated smoke set. The full suite mixes fast, deterministic flows (auth, navigation) with heavy, AI-latency-dependent flows (image generation, agents) that are slower and more prone to environmental failure. Gating on the entire suite means one heavy or environment-sensitive spec can block the whole signal, which pushes us toward not enforcing the gate at all.

This PR splits the suite into a **Core** subset that is fast and deterministic enough to be a required gate, while the full suite keeps running as a non-blocking, advisory signal for triage. No new test framework or tagging infra is added: the per-spec Playwright projects already provide the selector, and Playwright accepts multiple `--project` flags in one invocation (one run, one report, one status).

The Core gate is delivered as a **new standalone workflow** (`e2e-core.yml`) so the existing `e2e-manual.yml` (the advisory full suite) is left completely untouched. The new workflow is `workflow_dispatch`-only and is intended to be triggered by the deployer right after a staging deploy.

## Changes

- **New workflow `.github/workflows/e2e-core.yml`:**
  - Runs a fixed, curated Core set in a **single** Playwright invocation: `--project=unauthenticated --project=notebook --project=prompts` (`unauthenticated` covers both auth + signup; plus load-a-notebook and a basic prompt flow). Defined once as the `CORE_PROJECTS` env var.
  - Posts its own **`e2e/core`** commit status - renamed off the misleading `smoke` label to reflect that it is a curated subset, not the full suite.
  - **`workflow_dispatch` only (no cron schedule)** - meant to be dispatched by the deployer after a staging deploy, with a manual-dispatch path retained for QA.
  - Accepts `stage`, `pr_number`, `e2e_test_id`, and an internal `gate_run` flag. When `gate_run='true'`, runs coalesce to the latest tip via a shared concurrency group + `cancel-in-progress`; manual runs keep a per-target group with no cancellation.
  - Reuses `e2e-manual.yml`'s proven plumbing: tested-SHA resolution against `staging/deploy=success`, the deploy-in-flight wait, the `/api/ping` health gate, and the setup-flake-vs-real-failure split (a pure infra flake leaves the status *missing* rather than sticking a red on the SHA).
  - Slack notification labeled **"Run via Deployer"**.
- **Docs `apps/client/e2e/README.md`:** new "Core gate" section documenting the two-signal split (Core = requirable / full suite = advisory), the current Core set, the whole-projects-only gotcha, and the criteria for a spec to **graduate** into Core.
- **`e2e-manual.yml` is intentionally NOT modified.**

## Guide for Testers

This is a CI/infra-only change (a new GitHub Actions workflow + docs). There is no app UI to exercise. Verify at the workflow level:

1. Go to the repo **Actions** tab and open **"E2E Tests (Core)"** in the workflow list.
2. Click **Run workflow** (manual dispatch), leave `stage` = `dev`, leave `pr_number` empty, and run it.
3. Confirm the run does the following in order, with no errors:
   - Resolves config and prints `Stage: dev`.
   - Resolves a tested staging SHA (the newest `main` commit with `staging/deploy=success`).
   - Waits for staging to be healthy (`/api/ping` returns 200).
   - Runs **only** the Core projects - the log shows `Running Core projects: --project=unauthenticated --project=notebook --project=prompts` and does NOT run image-gen, agents, admin, projects, etc.
4. When the run finishes green, open the tested commit on GitHub and confirm a **`e2e/core`** commit status is posted (state `success`, description like `Core e2e subset passed (N/N)`).
5. Confirm the Slack notification arrives with the header **"Playwright E2E Core (Run via Deployer)"** and a Core Run Summary listing only the Core specs.
6. Confirm the existing **`e2e/smoke`** status and the full suite (`e2e-manual.yml`) are unchanged and still run independently.

### Regression Checks

- `e2e-manual.yml` is byte-for-byte unchanged; the full suite still runs on its own schedule and still posts `e2e/smoke`.
- The Core run uses **whole projects only** (no positional spec-file filter). Confirm that the notebook and prompts projects each run their full spec (a positional filter would wrongly narrow them).

### What NOT to test

- No application/runtime behavior changes - do not look for UI, API, or DB differences.
- Do not expect the individual known-failing specs (notebook overlay wait, agents nav, image-gen hang) to be fixed here; that is tracked separately and is out of scope.

## Additional Information

- **Deployer wiring (follow-up / coordinated with the private deployer):** the deployer triggers this via the `workflow_dispatch` REST API (`POST /actions/workflows/e2e-core.yml/dispatches`) with `gate_run: 'true'` and the target `stage`/`pr_number`. Because the dispatch reference is the **filename**, renaming `e2e-core.yml` later would require updating the deployer too.
- **Gate promotion is deferred until Core proves itself.** The consumers that would flip Core to *required* and `e2e/smoke` to *advisory* (the `staging/deploy` signal, `REQUIRE_E2E`, and the prod-promotion console) live outside this public repo. Until the Core subset is green over several consecutive runs, this workflow runs alongside the full suite as its own signal; making `e2e/core` the required gate is a separate, infra/console-side change.

## Out of scope

- Fixing individual known-flaky specs (notebook overlay wait, agents nav, image-gen hang).
- Any change to `e2e-manual.yml` or the full-suite `e2e/smoke` behavior.
- Wiring `e2e/core` as a required branch/promotion gate (deferred until it proves reliable).

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [x] Self-review performed
- [x] Commented hard-to-understand areas (whole-projects gotcha, setup-flake handling)
- [x] Corresponding documentation updated (`apps/client/e2e/README.md` "Core gate")
- [x] ASCII-only in code and comments (public-repo standard)
- [x] `e2e-manual.yml` left untouched
- [ ] No new warnings (validate by running the workflow once from the Actions tab)

