### PR TITLE
fix(client): share consent-redirect guard across rootRoute children

### DIFF
--- a/apps/client/app/router.tsx
+++ b/apps/client/app/router.tsx
@@ -12,8 +12,8 @@ import { TanStackRouterDevtools } from '@tanstack/router-devtools';
 import { CircularProgress, Box, Typography } from '@mui/joy';
 import NotebookLayout from '@client/app/components/layouts/Notebook';
 import { useUser } from '@client/app/contexts/UserContext';
-import { useAccessToken } from '@client/app/hooks/useAccessToken';
-import { buildRedirectTo, shouldRedirectToConsent } from '@client/app/utils/authRedirect';
+import { buildRedirectTo } from '@client/app/utils/authRedirect';
+import { enforceConsentRedirect } from '@client/app/utils/consentGuard';
 
 // Keep layout components as eager imports for optimal performance
 import RestrictedPage from './components/common/RestrictedPage';
@@ -142,6 +142,9 @@ const builtStandalonePremiumRoutes = premiumRoutes
     return createRoute({
       getParentRoute: () => rootRoute,
       path: descriptor.path,
+      // Standalone premium pages bypass the layoutRoute consent guard (they hang off rootRoute),
+      // so opt them in via the shared guard like the other standalone routes (issue #382).
+      beforeLoad: ({ location }) => enforceConsentRedirect(location),
       component: () => <ProviderBundle>{gated}</ProviderBundle>,
     });
   });
@@ -175,7 +178,7 @@ const layoutRoute = createRoute({
   getParentRoute: () => rootRoute,
   id: 'layout',
   beforeLoad: ({ location }) => {
-    const { currentUser, isHydrated } = useUser.getState();
+    const { currentUser } = useUser.getState();
     if (!currentUser) {
       const redirectTo = buildRedirectTo(
         location.pathname,
@@ -188,26 +191,10 @@ const layoutRoute = createRoute({
       });
     }
 
-    // P0-B abuse gate: route an authenticated-but-not-yet-consented account (in
-    // practice a brand-new OAuth/SAML/OTC user) to the acceptance interstitial. UX only - the
-    // server consent-gate middleware is the real enforcement - but it turns opaque 403s into a
-    // smooth redirect. Gated on `isHydrated` so a rehydrated pre-deploy session (whose persisted
-    // user stub predates `aupAcceptedVersion`) does not flash the interstitial before /api/identify
-    // refetches the server-authoritative value, and on a live `accessToken` so a token-less/broken
-    // session goes to /login (which can re-auth) rather than being trapped in a /login <->
-    // /accept-policies loop - see shouldRedirectToConsent and issue #386.
-    const { accessToken } = useAccessToken.getState();
-    if (shouldRedirectToConsent({ currentUser, isHydrated, accessToken })) {
-      const redirectTo = buildRedirectTo(
-        location.pathname,
-        location.searchStr,
-        location.hash ? `#${location.hash}` : ''
-      );
-      throw redirect({
-        to: '/accept-policies',
-        search: redirectTo ? { redirectTo } : undefined,
-      });
-    }
+    // P0-B abuse gate: route an authenticated-but-not-yet-consented account (in practice a
+    // brand-new OAuth/SAML/OTC user) to the acceptance interstitial. Shared with the standalone
+    // rootRoute children so the guard can't drift (see enforceConsentRedirect / issue #382).
+    enforceConsentRedirect(location);
 
     // Handle redirects stored in sessionStorage to work around CloudFront Access Denied
     // on SPA routes (CloudFront can only serve "/" directly; all other paths return 403).
@@ -801,6 +788,7 @@ const hudRoute = createRoute({
 const slackInstallRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/integrations/slack/install',
+  beforeLoad: ({ location }) => enforceConsentRedirect(location),
   component: () => (
     <Suspense fallback={<RouteLoadingFallback />}>
       <SlackInstallPage />
@@ -811,6 +799,7 @@ const slackInstallRoute = createRoute({
 const slackSuccessRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/integrations/slack/success',
+  beforeLoad: ({ location }) => enforceConsentRedirect(location),
   component: () => (
     <Suspense fallback={<RouteLoadingFallback />}>
       <SlackSuccessPage />
@@ -828,6 +817,7 @@ const slackSuccessRoute = createRoute({
 const slackErrorRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/integrations/slack/error',
+  beforeLoad: ({ location }) => enforceConsentRedirect(location),
   component: () => (
     <Suspense fallback={<RouteLoadingFallback />}>
       <SlackErrorPage />
@@ -845,6 +835,7 @@ const slackErrorRoute = createRoute({
 const atlassianSelectSiteRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/integrations/atlassian/select-site',
+  beforeLoad: ({ location }) => enforceConsentRedirect(location),
   component: () => (
     <Suspense fallback={<RouteLoadingFallback />}>
       <AtlassianSelectSitePage />
@@ -853,29 +844,16 @@ const atlassianSelectSiteRoute = createRoute({
 });
 
 // Device activation route (OAuth device flow). A rootRoute child (own chrome, not the notebook
-// layout), so it does NOT inherit the layoutRoute consent guard. Re-run just the consent check here
-// so an authenticated-but-not-yet-consented user is routed to /accept-policies (preserving a return
-// path back to /activate?code=...) instead of being shown the form only to have Approve Device fail
-// the server consent gate with a misleading 403. The unauthenticated -> /login redirect stays in the
-// component (shouldRedirectToConsent is a no-op without a currentUser). See issue #369.
+// layout), so it does NOT inherit the layoutRoute consent guard - it opts in via the shared
+// enforceConsentRedirect so an authenticated-but-not-yet-consented user is routed to
+// /accept-policies (preserving a return path back to /activate?code=...) instead of being shown the
+// form only to have Approve Device fail the server consent gate with a misleading 403. The
+// unauthenticated -> /login redirect stays in the component (the guard is a no-op without a
+// currentUser). See issues #369 and #382.
 const activateRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/activate',
-  beforeLoad: ({ location }) => {
-    const { currentUser, isHydrated } = useUser.getState();
-    const { accessToken } = useAccessToken.getState();
-    if (shouldRedirectToConsent({ currentUser, isHydrated, accessToken })) {
-      const redirectTo = buildRedirectTo(
-        location.pathname,
-        location.searchStr,
-        location.hash ? `#${location.hash}` : ''
-      );
-      throw redirect({
-        to: '/accept-policies',
-        search: redirectTo ? { redirectTo } : undefined,
-      });
-    }
-  },
+  beforeLoad: ({ location }) => enforceConsentRedirect(location),
   component: () => (
     <Suspense fallback={<RouteLoadingFallback />}>
       <ActivatePage />
@@ -892,6 +870,7 @@ const activateRoute = createRoute({
 const adminRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/admin',
+  beforeLoad: ({ location }) => enforceConsentRedirect(location),
   component: () => (
     <RestrictedPage requireAdmin={true}>
       {/* These providers are not usually needed in an unprotected page. This prevents unnecessary API fetch */}
@@ -929,6 +908,7 @@ const emailUnsubscribeRoute = createRoute({
 const oauthAuthorizeRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/oauth/authorize',
+  beforeLoad: ({ location }) => enforceConsentRedirect(location),
   component: () => (
     <Suspense fallback={<RouteLoadingFallback />}>
       <OAuthAuthorizePage />

--- a/apps/client/app/utils/consentGuard.test.ts
+++ b/apps/client/app/utils/consentGuard.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression coverage for issue #382: the consent-redirect guard shared by layoutRoute and the
+// standalone rootRoute children (e.g. /admin, /oauth/authorize, the Slack/Atlassian integration
+// pages). Exercises the glue - store reads + redirect throw - on top of the already-tested
+// shouldRedirectToConsent (see authRedirect.test.ts).
+
+// redirect() is mocked to a plain tagged object so the thrown value is inspectable without pulling
+// in TanStack Router's real Redirect internals.
+vi.mock('@tanstack/react-router', () => ({
+  redirect: vi.fn((opts: unknown) => ({ isRedirect: true, ...(opts as object) })),
+}));
+
+let userState: { currentUser: { aupAcceptedVersion?: unknown } | null; isHydrated: boolean };
+let tokenState: { accessToken: string | null };
+
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: { getState: () => userState },
+}));
+vi.mock('@client/app/hooks/useAccessToken', () => ({
+  useAccessToken: { getState: () => tokenState },
+}));
+
+import { enforceConsentRedirect } from './consentGuard';
+
+const TOKEN = 'live-access-token';
+const loc = (pathname: string, searchStr = '', hash = '') => ({ pathname, searchStr, hash });
+
+describe('enforceConsentRedirect', () => {
+  beforeEach(() => {
+    userState = { currentUser: null, isHydrated: true };
+    tokenState = { accessToken: TOKEN };
+  });
+
+  it('redirects a not-yet-consented account to /accept-policies with a return path', () => {
+    userState = { currentUser: { aupAcceptedVersion: undefined }, isHydrated: true };
+    expect(() => enforceConsentRedirect(loc('/admin'))).toThrow(
+      expect.objectContaining({ isRedirect: true, to: '/accept-policies', search: { redirectTo: '/admin' } })
+    );
+  });
+
+  it('preserves the full search string in the return path (the OAuth authorize case)', () => {
+    userState = { currentUser: {}, isHydrated: true };
+    expect(() => enforceConsentRedirect(loc('/oauth/authorize', '?client_id=abc&response_type=code'))).toThrow(
+      expect.objectContaining({
+        to: '/accept-policies',
+        search: { redirectTo: '/oauth/authorize?client_id=abc&response_type=code' },
+      })
+    );
+  });
+
+  it('omits redirectTo when the location is not worth preserving (home page)', () => {
+    userState = { currentUser: {}, isHydrated: true };
+    expect(() => enforceConsentRedirect(loc('/'))).toThrow(
+      expect.objectContaining({ to: '/accept-policies', search: undefined })
+    );
+  });
+
+  it('does NOT redirect an already-consented account', () => {
+    userState = { currentUser: { aupAcceptedVersion: 'v1' }, isHydrated: true };
+    expect(() => enforceConsentRedirect(loc('/admin'))).not.toThrow();
+  });
+
+  it('does NOT redirect a token-less / broken session (goes to /login instead, issue #386)', () => {
+    userState = { currentUser: {}, isHydrated: true };
+    tokenState = { accessToken: null };
+    expect(() => enforceConsentRedirect(loc('/admin'))).not.toThrow();
+  });
+
+  it('does NOT redirect before the server-confirmed user has hydrated', () => {
+    userState = { currentUser: {}, isHydrated: false };
+    expect(() => enforceConsentRedirect(loc('/admin'))).not.toThrow();
+  });
+
+  it('does NOT redirect when there is no user (that path bounces to /login)', () => {
+    userState = { currentUser: null, isHydrated: true };
+    expect(() => enforceConsentRedirect(loc('/admin'))).not.toThrow();
+  });
+});

--- a/apps/client/app/utils/consentGuard.ts
+++ b/apps/client/app/utils/consentGuard.ts
@@ -1,0 +1,30 @@
+import { redirect } from '@tanstack/react-router';
+import { useUser } from '@client/app/contexts/UserContext';
+import { useAccessToken } from '@client/app/hooks/useAccessToken';
+import { buildRedirectTo, shouldRedirectToConsent } from './authRedirect';
+
+/**
+ * Consent-redirect guard shared by the app-shell `layoutRoute` and every standalone
+ * `rootRoute` child an authenticated user can reach (see router.tsx). Routes an
+ * authenticated-but-not-yet-consented account - live `accessToken`, server-confirmed
+ * `currentUser` (`isHydrated`), no accepted policy version - to the /accept-policies
+ * interstitial, preserving a return path so the flow resumes after acceptance.
+ *
+ * Defined once so the guard cannot drift between the app shell and the standalone pages
+ * (issue #382). It is a `beforeLoad` helper: it THROWS a TanStack `redirect()`, which the
+ * router intercepts, so it must be called from inside a route's `beforeLoad` and not wrapped
+ * in a try/catch. UX only - the server consent-gate middleware (server/auth/auth.ts) is the
+ * real enforcement and fails closed. See shouldRedirectToConsent for the gate rationale
+ * (issues #369, #386).
+ */
+export function enforceConsentRedirect(location: { pathname: string; searchStr: string; hash: string }): void {
+  const { currentUser, isHydrated } = useUser.getState();
+  const { accessToken } = useAccessToken.getState();
+  if (shouldRedirectToConsent({ currentUser, isHydrated, accessToken })) {
+    const redirectTo = buildRedirectTo(location.pathname, location.searchStr, location.hash ? `#${location.hash}` : '');
+    throw redirect({
+      to: '/accept-policies',
+      search: redirectTo ? { redirectTo } : undefined,
+    });
+  }
+}


### PR DESCRIPTION
## Description

Fixes #382. Follow-up to #369 (fixed by #380), which was scoped narrowly to `/activate`. The underlying pattern is broader: the consent-redirect guard lived only in the `beforeLoad` of `layoutRoute`, so **any route declared as a `rootRoute` child bypassed it**. An authenticated-but-not-yet-consented account (in practice a brand-new OAuth/SAML/OTC user, or a freshly seeded account) reaching one of those pages was shown the page instead of being routed to `/accept-policies`; the first request to an `isPolicyConsentRequired`-gated endpoint then came back as an opaque `403 { policyAcceptanceRequired: true }` with no client-side path forward - the same dead-end `/activate` had.

Server enforcement (`server/auth/auth.ts`) is unchanged and remains the source of truth and fails closed; this is purely the client redirect/UX layer.

## Changes

- **`app/utils/consentGuard.ts` (new)** - single `enforceConsentRedirect(location)` helper that reads the user/token stores, runs the existing `shouldRedirectToConsent`, and throws a `redirect()` to `/accept-policies` with a preserved return path. Defined once so the guard can't drift between the app shell and the standalone routes.
- **`app/router.tsx`**
  - `layoutRoute` and `activateRoute` now call the shared helper (removing their duplicated inline consent blocks - including the bespoke copy added to `activateRoute` in #380).
  - Added the guard to every consent-requiring `rootRoute` child: `/admin`, `/oauth/authorize`, `/integrations/slack/install`, `/integrations/slack/success`, `/integrations/slack/error`, `/integrations/atlassian/select-site`, plus the standalone premium-route factory.
- **`app/utils/consentGuard.test.ts` (new)** - covers the redirect target + return path (including the OAuth-authorize search-string case) and each no-op branch (already-consented, token-less session #386, pre-hydration, no-user).

### Audit of all `rootRoute` children

**Guarded** (authenticated pages that reach gated endpoints): `/admin`, `/oauth/authorize`, `/integrations/slack/install`, `/integrations/slack/success`, `/integrations/slack/error`, `/integrations/atlassian/select-site`, `/activate`, standalone premium routes.

**Deliberately public / pre-consent** (kept outside the gate): `/login`, `/register`, `/accept-policies`, `/verify-email`, `/verify-change`, `/auth/$strategy/callback`, `/auth/success`, `/google-drive/callback` (OAuth/SAML callbacks), `/admin-emergency` (break-glass login), `/subscribe` (public waitlist form), `/email/unsubscribe` (public token-based page).

Implemented as a shared helper rather than a pathless wrapper route on purpose: `slack/install` uses `useSearch({ from: '/integrations/slack/install' })`, and reparenting under a pathless route risks disturbing that route id.

## Guide for Testers

**Environment:** a PR preview (once a maintainer deploys one) or `app.staging.bike4mind.com`. Substitute your host for `<host>`.

**Prerequisite:** an account that has **never** accepted the AUP/ToS - e.g. a freshly seeded preview admin, or a brand-new account created via OAuth/SAML on first login. Do **not** accept policies before starting.

### Scenario A - a guarded standalone page routes to accept-policies (the fix)
1. Log in with the not-yet-consented account (do not accept policies).
2. In the address bar, navigate to `https://<host>/admin`.
3. Expected: you are redirected to `https://<host>/accept-policies?redirectTo=%2Fadmin` - **not** shown the admin page followed by an opaque error.
4. Accept the policies on the interstitial.
5. Expected: you are returned to `/admin` and the page loads normally.

### Scenario B - repeat for the other guarded routes
6. Repeat steps 2-5 for `https://<host>/oauth/authorize?client_id=test&redirect_uri=https://example.com/cb&response_type=code`, `https://<host>/integrations/slack/install?workspaceId=<id>`, and `https://<host>/integrations/atlassian/select-site`.
7. Expected for each: redirect to `/accept-policies` with a `redirectTo` back to that page (full query string preserved), then a working return after acceptance.

### Regression Checks
8. As a **consented** account, navigate to each route above. Expected: no redirect to `/accept-policies`; the page behaves exactly as before.
9. As a **logged-out** visitor, navigate to `/admin`. Expected: redirected to `/login` (guard is a no-op without a session), unchanged from today.
10. Confirm the public routes are still reachable without any consent redirect: `/login`, `/register`, `/subscribe`, `/verify-email`, `/email/unsubscribe`, `/admin-emergency`, and the OAuth callback pages.
11. `/activate` (CLI device flow) still behaves as in #380: not-yet-consented -> `/accept-policies?redirectTo=/activate?code=...` -> back to activation.

### What NOT to test
- Server-side consent enforcement is unchanged; no backend behavior changes here.

## Additional Information

Verification: new `consentGuard.test.ts` (7/7) and existing `authRedirect.test.ts` + `activate.test.tsx` (38/38) pass; `pnpm --filter @bike4mind/client typecheck` and ESLint on changed files are clean.

## Developer Notes

- `enforceConsentRedirect(location)` in `app/utils/consentGuard.ts` is the single opt-in point for the consent gate on any standalone `rootRoute` child - use `beforeLoad: ({ location }) => enforceConsentRedirect(location)` on new pre-app pages that a logged-in user can reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
