### PR TITLE
fix: close mobile side nav on profile menu navigation

### DIFF
--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -23,6 +23,8 @@ import { premiumNavItems } from '@client/app/premium-generated/premiumNavItems.g
 import { openExternalLinkByKey } from '@client/app/utils/externalLinks';
 import { greenAlpha } from '@client/app/utils/themes/colors';
 import { useAccounts } from '@client/app/components/Credits/AccountSelector';
+import { useIsMobile } from '@client/app/hooks/useIsMobile';
+import { useNotebookLayout } from '..';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
@@ -229,11 +231,18 @@ const ProfileMenu = () => {
   const { mutate: logout, isPending: isPendingLogout } = useUserLogout();
   const appVersion = useAppVersion();
 
+  const isMobile = useIsMobile();
+  const setOpenSideNav = useNotebookLayout(s => s.setOpenSideNav);
+
   const rootRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
   const [isCreditsModalOpen, setIsCreditsModalOpen] = useState(false);
   const [isSubscriptionModalOpen, setIsSubscriptionModalOpen] = useState(false);
+
+  const closeOnMobile = () => {
+    if (isMobile) setOpenSideNav(false);
+  };
 
   const closeAll = () => {
     setOpen(false);
@@ -326,6 +335,7 @@ const ProfileMenu = () => {
               icon={<AdminPanelSettingsIcon sx={{ fontSize: '18px' }} />}
               label={t('admin.title', 'Admin')}
               onClick={() => {
+                closeOnMobile();
                 navigate({ to: '/admin' });
                 setOpen(false);
               }}
@@ -343,6 +353,7 @@ const ProfileMenu = () => {
               ) : undefined
             }
             onClick={() => {
+              closeOnMobile();
               navigate({ to: '/profile' });
               setOpen(false);
             }}
@@ -352,6 +363,7 @@ const ProfileMenu = () => {
             icon={<ExtensionIcon sx={{ fontSize: '18px' }} />}
             label={t('skills.title', 'Skills')}
             onClick={() => {
+              closeOnMobile();
               navigate({ to: '/skills' });
               setOpen(false);
             }}
@@ -361,6 +373,7 @@ const ProfileMenu = () => {
             icon={<KeyOutlinedIcon sx={{ fontSize: '18px' }} />}
             label={t('apiKeys.title', 'API Keys')}
             onClick={() => {
+              closeOnMobile();
               navigate({ to: '/profile', search: { tab: 'api-keys' } });
               setOpen(false);
             }}
@@ -370,6 +383,7 @@ const ProfileMenu = () => {
             icon={<BusinessIcon sx={{ fontSize: '18px' }} />}
             label={t('organization.teams', 'Teams')}
             onClick={() => {
+              closeOnMobile();
               navigate({ to: '/organizations' });
               setOpen(false);
             }}
@@ -564,6 +578,7 @@ const ProfileMenu = () => {
                     icon={<AutoAwesomeIcon sx={{ fontSize: '18px' }} />}
                     label={t('quests.my_quests', 'My Quests')}
                     onClick={() => {
+                      closeOnMobile();
                       navigate({ to: '/quests' });
                       closeAll();
                     }}
@@ -579,6 +594,7 @@ const ProfileMenu = () => {
                       // Premium routes are registered at runtime via the codegen
                       // glue, so their paths can't appear in the static route-tree
                       // union - erase the typed `to` here.
+                      closeOnMobile();
                       navigate({ to: item.path as never });
                       closeAll();
                     }}


### PR DESCRIPTION
## Summary

Fixes #459

On mobile, opening Profile (or Skills, API Keys, Teams, Admin, Quests, or premium items) from the account menu left the side nav open. Since the open side nav covers most of a phone screen, the user could not tell the page changed and had to manually close the nav.

## Root Cause

`ProfileMenu.tsx` only managed its own popup state (`setOpen(false)`) and never called `setOpenSideNav(false)`, unlike `SidenavNav.tsx` which uses the `closeOnMobile` pattern before every `navigate` call.

## Changes

- Imported `useNotebookLayout` and `useIsMobile` into `ProfileMenu.tsx`
- Added the same `closeOnMobile` helper used in `SidenavNav.tsx`
- Added `closeOnMobile()` call before every `navigate()` in ProfileMenu's route-click handlers:
  - Admin
  - Profile
  - Skills
  - API Keys
  - Teams
  - Quests
  - Premium nav items

## Testing

- [x] On mobile: tap Profile from account menu → side nav closes and Profile page is visible
- [x] On mobile: tap Skills/API Keys/Teams/Admin/Quests → side nav closes
- [x] On desktop: no behavior change (closeOnMobile is a no-op on desktop)
- [x] Modal actions (Credits, Subscriptions, Inbox, Invite) unaffected