### PR TITLE
test(agents): cover the checkpoint-depth terminate path

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.checkpointDepth.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.checkpointDepth.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   MAX_CHECKPOINT_DEPTH,
   CHECKPOINT_DEPTH_WARNING,
   classifyCheckpointDepth,
+  enforceCheckpointDepth,
 } from './agentExecutor.checkpointDepth';
 // Import the REAL schemas (not mirrors) so these tests break if someone accidentally
 // removes checkpointDepth or changes it from optional to required.
@@ -98,5 +99,73 @@ describe('TaggedQueueMessageSchema continuation branch checkpointDepth', () => {
 
   it('rejects non-integer depths', () => {
     expect(TaggedQueueMessageSchema.safeParse({ ...base, checkpointDepth: 0.5 }).success).toBe(false);
+  });
+});
+
+// enforceCheckpointDepth: the side effects processExecution relies on. The classifier above
+// is pure; these tests pin what the guard actually DOES at each verdict, which is the part
+// that silently regresses (a dropped markFailed leaves the execution hung in `running`).
+describe('enforceCheckpointDepth', () => {
+  const makeDeps = () => ({
+    executionId: 'exec-1',
+    logger: { warn: vi.fn(), error: vi.fn() },
+    emitMetric: vi.fn().mockResolvedValue(undefined),
+    markFailed: vi.fn().mockResolvedValue(undefined),
+    sendWs: vi.fn().mockResolvedValue(undefined),
+  });
+
+  const metricNames = (deps: ReturnType<typeof makeDeps>) => deps.emitMetric.mock.calls.map(call => call[1]);
+
+  it('does nothing below the warning threshold', async () => {
+    const deps = makeDeps();
+    await expect(enforceCheckpointDepth(0, deps)).resolves.toBe(false);
+    expect(deps.emitMetric).not.toHaveBeenCalled();
+    expect(deps.markFailed).not.toHaveBeenCalled();
+    expect(deps.sendWs).not.toHaveBeenCalled();
+  });
+
+  it('warns without terminating between the warning threshold and the hard limit', async () => {
+    const deps = makeDeps();
+    await expect(enforceCheckpointDepth(CHECKPOINT_DEPTH_WARNING, deps)).resolves.toBe(false);
+    expect(metricNames(deps)).toEqual(['CheckpointDepthWarning']);
+    // The execution must survive a warn - only the hard limit is allowed to kill it.
+    expect(deps.markFailed).not.toHaveBeenCalled();
+    expect(deps.sendWs).not.toHaveBeenCalled();
+  });
+
+  it('terminates at the hard limit: emits the exceeded metric, marks failed, notifies the client', async () => {
+    const deps = makeDeps();
+    await expect(enforceCheckpointDepth(MAX_CHECKPOINT_DEPTH, deps)).resolves.toBe(true);
+
+    expect(metricNames(deps)).toEqual(['CheckpointDepthWarning', 'CheckpointDepthExceeded']);
+    expect(deps.emitMetric).toHaveBeenCalledWith('Lumina5/AgentExecutor', 'CheckpointDepthExceeded', 1, {
+      executionId: 'exec-1',
+    });
+    expect(deps.markFailed).toHaveBeenCalledWith('exec-1', {
+      message: expect.stringContaining(`maximum self-dispatch depth (${MAX_CHECKPOINT_DEPTH})`),
+    });
+    // The client listens for this exact reason string to render the runaway-loop failure.
+    expect(deps.sendWs).toHaveBeenCalledWith('failed', {
+      executionId: 'exec-1',
+      reason: 'max_checkpoint_depth_exceeded',
+    });
+  });
+
+  it('terminates above the hard limit', async () => {
+    const deps = makeDeps();
+    await expect(enforceCheckpointDepth(MAX_CHECKPOINT_DEPTH + 10, deps)).resolves.toBe(true);
+    expect(metricNames(deps)).toContain('CheckpointDepthExceeded');
+    expect(deps.markFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the execution failed before notifying the client, so a failed send cannot leave it running', async () => {
+    const deps = makeDeps();
+    const order: string[] = [];
+    deps.markFailed.mockImplementation(async () => void order.push('markFailed'));
+    deps.sendWs.mockImplementation(async () => void order.push('sendWs'));
+
+    await enforceCheckpointDepth(MAX_CHECKPOINT_DEPTH, deps);
+
+    expect(order).toEqual(['markFailed', 'sendWs']);
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutor.checkpointDepth.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.checkpointDepth.ts
@@ -37,3 +37,60 @@ export function classifyCheckpointDepth(depth: number): CheckpointDepthVerdict {
   if (depth >= CHECKPOINT_DEPTH_WARNING) return 'warn';
   return 'ok';
 }
+
+/**
+ * Collaborators the guard needs, declared structurally so this module stays free
+ * of the executor's Mongo/AWS/SST imports (see the file header) and so the guard
+ * can be driven with plain fakes in tests.
+ */
+export interface CheckpointDepthGuardDeps {
+  executionId: string;
+  logger: {
+    warn(message: string, metadata?: Record<string, unknown>): void;
+    error(message: string, metadata?: Record<string, unknown>): void;
+  };
+  emitMetric: (
+    namespace: string,
+    metricName: string,
+    value: number,
+    dimensions?: Record<string, string>
+  ) => Promise<void>;
+  markFailed: (executionId: string, failure: { message: string }) => Promise<unknown>;
+  sendWs: (action: string, payload?: Record<string, unknown>) => Promise<void>;
+}
+
+/**
+ * Apply the two-tier depth guard at the top of processExecution.
+ *
+ * Returns `true` when the execution was terminated, in which case the caller
+ * MUST return immediately without loading the execution: terminating before any
+ * DB work is the whole point of the guard, since a runaway agent would otherwise
+ * chain Lambdas indefinitely.
+ */
+export async function enforceCheckpointDepth(depth: number, deps: CheckpointDepthGuardDeps): Promise<boolean> {
+  const { executionId, logger, emitMetric, markFailed, sendWs } = deps;
+  const verdict = classifyCheckpointDepth(depth);
+
+  if (verdict === 'warn' || verdict === 'terminate') {
+    logger.warn('[CheckpointDepth] Self-dispatch depth approaching hard limit', {
+      checkpointDepth: depth,
+      executionId,
+    });
+    void emitMetric('Lumina5/AgentExecutor', 'CheckpointDepthWarning', 1, { executionId });
+  }
+
+  if (verdict === 'terminate') {
+    logger.error('[CheckpointDepth] Max self-dispatch depth exceeded - terminating execution', {
+      checkpointDepth: depth,
+      executionId,
+    });
+    void emitMetric('Lumina5/AgentExecutor', 'CheckpointDepthExceeded', 1, { executionId });
+    await markFailed(executionId, {
+      message: `Execution exceeded maximum self-dispatch depth (${MAX_CHECKPOINT_DEPTH}) - possible runaway agent loop`,
+    });
+    await sendWs('failed', { executionId, reason: 'max_checkpoint_depth_exceeded' });
+    return true;
+  }
+
+  return false;
+}

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -109,7 +109,7 @@ import {
   type StartExecutionPayload,
   type SubagentDispatchPayload,
 } from './agentExecutor.schemas';
-import { MAX_CHECKPOINT_DEPTH, classifyCheckpointDepth } from './agentExecutor.checkpointDepth';
+import { enforceCheckpointDepth } from './agentExecutor.checkpointDepth';
 import { Config } from '@server/utils/config';
 import { Resource } from 'sst';
 import { getFilesStorage, getGeneratedImageStorage } from '@server/utils/storage';
@@ -550,26 +550,17 @@ async function processExecution(
 
   // Depth guard: refuse to process if this execution has self-dispatched too many times.
   // A runaway agent (infinite tool loop, stuck abort signal) would otherwise chain Lambdas
-  // indefinitely. Hard limit at MAX_CHECKPOINT_DEPTH; warning metric at CHECKPOINT_DEPTH_WARNING.
-  // classifyCheckpointDepth is a pure helper (agentExecutor.checkpointDepth.ts) so the
-  // thresholds and boundary logic can be unit-tested independently.
-  const depthVerdict = classifyCheckpointDepth(checkpointDepth);
-  if (depthVerdict === 'warn' || depthVerdict === 'terminate') {
-    logger.warn('[CheckpointDepth] Self-dispatch depth approaching hard limit', { checkpointDepth, executionId });
-    void emitMetric('Lumina5/AgentExecutor', 'CheckpointDepthWarning', 1, { executionId });
-  }
-  if (depthVerdict === 'terminate') {
-    logger.error('[CheckpointDepth] Max self-dispatch depth exceeded — terminating execution', {
-      checkpointDepth,
-      executionId,
-    });
-    void emitMetric('Lumina5/AgentExecutor', 'CheckpointDepthExceeded', 1, { executionId });
-    await agentExecutionRepository.markFailed(executionId, {
-      message: `Execution exceeded maximum self-dispatch depth (${MAX_CHECKPOINT_DEPTH}) — possible runaway agent loop`,
-    });
-    await sendWs('failed', { executionId, reason: 'max_checkpoint_depth_exceeded' });
-    return;
-  }
+  // indefinitely. Must stay above the DB load below - terminating before any DB work is the
+  // point of the guard. The guard itself lives in agentExecutor.checkpointDepth.ts so its
+  // thresholds and side effects can be unit-tested without this module's Mongo/AWS/SST deps.
+  const terminated = await enforceCheckpointDepth(checkpointDepth, {
+    executionId,
+    logger,
+    emitMetric,
+    markFailed: agentExecutionRepository.markFailed.bind(agentExecutionRepository),
+    sendWs,
+  });
+  if (terminated) return;
 
   try {
     // Load execution document

--- a/infra/alarms.ts
+++ b/infra/alarms.ts
@@ -109,10 +109,10 @@ if (isMonitoredStage) {
    * Alarm: Agent Checkpoint Depth Warning
    *
    * Fires when an execution's agentContinuationQueue self-dispatch depth exceeds 25.
-   * Depth 25 = ~6h of wall-clock time (25 × 15 min); any legitimate run should be
+   * Depth 25 = ~6.25h of wall-clock time (25 x 15 min); any legitimate run should be
    * done well before this. Indicates a runaway agent loop or a stuck abort signal.
-   * Hard limit at depth 50 terminates the execution automatically; this alarm fires
-   * at 25 so ops can investigate before the hard limit is reached.
+   * Hard limit at depth 50 (~12.5h) terminates the execution automatically; this alarm
+   * fires at 25 so ops can investigate before the hard limit is reached.
    *
    * Metric emitted by: agentExecutor.ts → processExecution()
    * Namespace: Lumina5/AgentExecutor / CheckpointDepthWarning


### PR DESCRIPTION
## Description

Refs #84

The checkpoint-depth guard terminates a runaway agent execution once its self-dispatch depth reaches `MAX_CHECKPOINT_DEPTH`. The thresholds already had boundary tests via the pure `classifyCheckpointDepth` helper, but the part that actually _does_ something -- emitting the exceeded metric, marking the execution failed, and telling the client -- was verify-by-inspection only. That is the half that regresses silently: drop the `markFailed` call and the execution hangs in `running` forever while every existing test stays green.

This PR adds that coverage, plus the P3 doc-arithmetic fix from the issue.

**Why this differs from the issue.** #84 asks for an integration test on `processExecution`, which is not workable as written: it is module-private, and the only way in -- the exported `handler` -- connects to Mongo on its first line and pulls in `sst`, `mongoose`, `@bike4mind/database`, and `@bike4mind/agents`. Every `agentExecutor*.test.ts` in the repo tests an _extracted_ module instead; none imports `agentExecutor.ts`. This follows that convention: the guard's side effects move into the existing pure module, where they can be driven with plain fakes.

## Changes

- `agentExecutor.checkpointDepth.ts` -- new `enforceCheckpointDepth(depth, deps)`, which performs the warn/terminate side effects and returns `true` when it terminated. Collaborators are declared structurally (a minimal logger shape, not the real `Logger`), so the module stays free of the executor's Mongo/AWS/SST deps.
- `agentExecutor.ts` -- `processExecution` delegates to the guard and returns early on `true`. Same behavior, same ordering, still above the DB load.
- `agentExecutor.checkpointDepth.test.ts` -- five new tests: no-op below the warning threshold; warn band emits `CheckpointDepthWarning` but must **not** terminate; at and above the hard limit it emits `CheckpointDepthExceeded`, calls `markFailed`, and sends the `max_checkpoint_depth_exceeded` websocket reason; and `markFailed` runs **before** `sendWs`, so a failing send cannot leave the execution stuck in `running`.
- `infra/alarms.ts` -- doc fix. It said depth 25 was `~6h`; 25 x 15 min is 6.25h, which is what the constant's own JSDoc says.

## Guide for Testers

**Backend only -- no runtime surface, nothing to click.** Verification is by test suite.

1. Run `pnpm turbo:core:build`. Expected: succeeds. (Skipping this produces unrelated typecheck errors in the admin transaction-ledger files from a stale `@bike4mind/common` dist.)
2. Run `pnpm --filter @bike4mind/client typecheck`. Expected: clean.
3. Run `cd apps/client && npx vitest run server/queueHandlers/agentExecutor.checkpointDepth.test.ts`. Expected: `21 passed`.
4. Run `pnpm --filter @bike4mind/client test`. Expected: no new failures.

### Regression Checks

Behavior must be unchanged. Confirm from the diff:

5. `enforceCheckpointDepth(...)` and its `if (terminated) return;` still sit **above** the `try {` block that loads the execution -- terminating before any DB work is the point of the guard.
6. The websocket reason string is still exactly `max_checkpoint_depth_exceeded` (the client keys off it), and the metric names are still `CheckpointDepthWarning` / `CheckpointDepthExceeded` in `Lumina5/AgentExecutor` (the CloudWatch alarm depends on both).

### What NOT to test

Do not try to reproduce a real depth-50 runaway: reaching the hard limit takes ~12.5h of wall-clock self-dispatch by design, which is why this path is unit-tested rather than driven end-to-end. No preview env needed.

## Additional Information

**One user-visible string changes.** The log and persisted `markFailed` messages used em-dashes; CLAUDE.md mandates ASCII-only, so they are hyphens now (`depth (50) - possible runaway agent loop`). Nothing parses this string -- the client keys off `reason`, which is unchanged -- but flagging it rather than burying it in the diff.

**Mutation-checked.** Deleting the `markFailed` call fails 3 of the new tests; restored and re-confirmed green. The tests bite.

**`Refs`, not `Closes`.** The remaining P2 bullet -- depth resetting to 0 on direct-invoke resumes -- is untouched and still real. The self-dispatch sites carry `checkpointDepth + 1` in their SQS messages and the SQS path reads it back, but the direct-invoke resumes in `agentExecute.ts` send only `{executionId, connectionId}`, so a run at depth 30 that hits a permission prompt resumes at depth 0 with a fresh budget of 50. Fixing it means persisting depth on `AgentExecution`, which needs a DB read *before* the guard and so weakens its "terminate before any DB work" property -- that deserves its own PR and its own review. Low real-world risk meanwhile: direct-invoke resumes are user-driven, so a runaway agent cannot loop through a permission gate unattended.

## Developer Notes

**Structural deps over module mocks.** `enforceCheckpointDepth` declares its collaborators (`logger`, `emitMetric`, `markFailed`, `sendWs`) as a structural interface rather than importing them. That is what lets a side-effecting slice of `agentExecutor.ts` be tested with plain `vi.fn()` fakes and no `vi.mock` of `sst`/`mongoose`/`@bike4mind/database`. `agentExecutor.ts` has no direct test coverage anywhere in the repo -- the handler's import graph makes it impractical -- so extraction is the established way to cover logic trapped inside it, and the same move works for any other branch in `processExecution`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] No new AdminSettings, UI surface, telemetry fields, or docs changes (beyond the `infra/alarms.ts` JSDoc fix included here)
