### PR TITLE
chore: set b4m-optihashi overlay pin to 38384564b88e5830487b6eedb80aeae45816353f

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "5d24e2b2ed7873e5426d28a75d332ce0c61a8308",
   "b4m-libreoncology": "6c198d67ffce265dc66cf7ef879c84a00847554c",
-  "b4m-optihashi": "c03425e4fd36354c35ad6771a36b96709d6dc828",
+  "b4m-optihashi": "38384564b88e5830487b6eedb80aeae45816353f",
   "b4m-pi": "c95fc844445c8d3ae7b930acf6d4452ace25ae32",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Sets the b4m-optihashi overlay pin to 38384564b88e5830487b6eedb80aeae45816353f. Overlay-pin-only change; no application source changes.

https://claude.ai/code/session_01EgYuQGCALS5TZSzaxBXuru