### PR TITLE
fix(client): make Files Manager Gears-page-only and refresh gears status on first upload

### DIFF
--- a/apps/client/app/components/Session/AttachFileButton.tsx
+++ b/apps/client/app/components/Session/AttachFileButton.tsx
@@ -584,6 +584,7 @@ const AttachFileButton = ({
                 {/* Files Section */}
                 <ListItem sx={{ p: 0 }}>
                   <ListItemButton
+                    data-testid="add-from-file-browser-btn"
                     onClick={() => {
                       setIsOpen(false);
                       setCurrentView('main');

--- a/apps/client/app/components/Session/SessionBottom/SessionFilePond.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionFilePond.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
 import { Box } from '@mui/joy';
 import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css';
 import 'filepond/dist/filepond.min.css';
@@ -11,6 +12,7 @@ import {
   consumeBufferedModerationStatus,
   patchPendingMessageFileModerationStatus,
 } from '@client/app/hooks/useSessionLayout';
+import { GearsStatusResponse } from '@client/app/hooks/useGearsStatus';
 import { LexicalChatInputRef } from '../LexicalChatInput';
 import styles from '../FilePond.module.css';
 
@@ -49,6 +51,20 @@ export function SessionFilePond({
   chatInputValue,
   setChatInputValue,
 }: SessionFilePondProps) {
+  const queryClient = useQueryClient();
+
+  // A first upload unlocks the 'files' gear server-side, but the Gears status
+  // query has a 5-minute staleTime - without an explicit invalidation the Gears
+  // page keeps showing the unearned "Upload your first file" CTA until a reload.
+  // Only invalidate while the gear is still locked so routine uploads don't
+  // refetch the status on every attachment.
+  const invalidateGearsStatusOnFirstFile = () => {
+    const status = queryClient.getQueryData<GearsStatusResponse>(['gears', 'status']);
+    const filesGear = status?.gears.find(g => g.key === 'files');
+    if (!filesGear || filesGear.unlocked) return;
+    void queryClient.invalidateQueries({ queryKey: ['gears', 'status'] });
+  };
+
   return (
     <Box
       sx={{
@@ -216,6 +232,8 @@ export function SessionFilePond({
                     setChatInputValue(newValue);
                   }
                 }
+
+                invalidateGearsStatusOnFirstFile();
 
                 load(fabFile.id);
 

--- a/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useLocation } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { Fragment, ReactNode } from 'react';
 import AddIcon from '@mui/icons-material/Add';
-import FolderSharedIcon from '@mui/icons-material/FolderSharedOutlined';
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import TempleBuddhistOutlinedIcon from '@mui/icons-material/TempleBuddhistOutlined';
@@ -19,7 +18,6 @@ import { useFeatureEnabled } from '@client/app/hooks/useFeatureEnabled';
 import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import { useUser } from '@client/app/contexts/UserContext';
 import { useOptiAccess } from '@client/app/hooks/data/opti';
-import { useFileBrowser } from '@client/app/components/Files/Browser';
 import { useIsMobile } from '@client/app/hooks/useIsMobile';
 import { useHelpPanel, openHelpPanel } from '@client/app/hooks/useHelpPanel';
 import { useGearUnlocks, type GearKey } from '@client/app/hooks/useGearsStatus';
@@ -37,10 +35,10 @@ type NavItem = {
 };
 
 /**
- * Primary sidebar navigation - a vertical icon list (New Chat, Files Manager, Agents, Projects,
- * OptiHashi, Tavern). OptiHashi/Tavern keep the same entitlement gating as the footer menu, and
- * Agents follows the `enableAgents` flag. The active row is highlighted by route (Files Manager
- * by the file-browser drawer's open state, since it isn't a route).
+ * Primary sidebar navigation - a vertical icon list (New Chat, Agents, Projects, OptiHashi,
+ * Tavern). OptiHashi/Tavern keep the same entitlement gating as the footer menu, and Agents
+ * follows the `enableAgents` flag. The active row is highlighted by route. Files Manager is
+ * deliberately NOT a sidenav destination - it is reachable only via the Gears page.
  */
 const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all' }) => {
   const theme = useTheme();
@@ -50,7 +48,6 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
   const currentUser = useUser(s => s.currentUser);
   const { isFeatureEnabled } = useFeatureEnabled();
   const { isFeatureEnabled: isAdminFeatureEnabled } = useAdminSettingsCache();
-  const { open: fileBrowserOpen, setOpen: setFileBrowserOpen } = useFileBrowser();
   const isMobile = useIsMobile();
   const setOpenSideNav = useNotebookLayout(s => s.setOpenSideNav);
 
@@ -76,7 +73,7 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
   // the rail settle once, on first paint only).
   const gearUnlocks = useGearUnlocks();
   // Fail OPEN unless a gear is EXPLICITLY present-and-unearned. These rows
-  // (Files, Projects, ...) were unconditional before Gears, so a loading state,
+  // (Projects, Agents, ...) were unconditional before Gears, so a loading state,
   // a catalog that omits/renames the key, or an admin override that drops it
   // must NOT silently remove core navigation app-wide - only a key the server
   // returns as `false` (a known, genuinely-unearned gear) hides its row.
@@ -163,20 +160,6 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
             onClick: () => {
               closeOnMobile();
               navigate({ to: '/data-lakes' });
-            },
-          },
-        ]
-      : []),
-    ...(gearOpen('files')
-      ? [
-          {
-            key: 'files',
-            label: t('files.manager', 'Files Manager'),
-            icon: iconSlot(<FolderSharedIcon sx={{ fontSize: '18px' }} />),
-            isActive: fileBrowserOpen,
-            onClick: () => {
-              closeOnMobile();
-              setFileBrowserOpen(true);
             },
           },
         ]
@@ -272,8 +255,9 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
 
   // Pinned vs scroll split for the unified-scroll sidebar: the first two items stay
   // pinned at the top. items[0] is always New Chat; items[1] is OptiHashi when Opti is
-  // enabled, otherwise Files Manager (the conditional Opti/Data-Lakes entries shift the
-  // rest into the scroll slice). The split is purely positional, so it holds either way.
+  // enabled, otherwise the next earned destination (the conditional Opti/Data-Lakes
+  // entries shift the rest into the scroll slice). The split is purely positional, so
+  // it holds either way.
   const shownItems = section === 'pinned' ? items.slice(0, 2) : section === 'scroll' ? items.slice(2) : items;
 
   return (

--- a/apps/client/app/hooks/useGearsStatus.ts
+++ b/apps/client/app/hooks/useGearsStatus.ts
@@ -10,7 +10,7 @@ import { api } from '@client/app/contexts/ApiContext';
 export type GearKind = 'destination' | 'skill';
 
 export type GearKey =
-  // destinations (earn a sidenav slot)
+  // destinations (earn a sidenav slot - except 'files', which stays Gears-page-only)
   | 'projects'
   | 'agents'
   | 'datalakes'

--- a/apps/client/e2e/pages/FileUploadPage.ts
+++ b/apps/client/e2e/pages/FileUploadPage.ts
@@ -48,15 +48,16 @@ export class FileUploadPage extends BasePage {
   }
 
   async openFileBrowser() {
-    // Close any existing dialog first to ensure the sidebar is accessible.
+    // Close any existing dialog first so the composer is accessible.
     await this.closeFileBrowser();
-    // NOTE: `files` is an earned-nav destination (Gears) - the sidenav row is hidden
-    // until the account has a file. That is NOT a problem here: every caller uploads
-    // or relies on a seeded file BEFORE opening the browser, so `files` is already
-    // earned and the row is present. The browser is also a global drawer opened OVER
-    // the current page (e.g. the notebook the file is being added to), so it must NOT
-    // be reached by navigating away.
-    await this.page.getByTestId('sidenav-nav-files').click();
+    // Files Manager is deliberately NOT a sidenav destination (Gears-page-only), so
+    // open the browser via the composer's attach menu. The browser is a global drawer
+    // opened OVER the current page (e.g. the notebook the file is being added to), so
+    // it must NOT be reached by navigating away.
+    await this.page.getByTestId('attach-files-btn').click();
+    const browserItem = this.page.getByTestId('add-from-file-browser-btn');
+    await expect(browserItem).toBeVisible({ timeout: TIMEOUTS.ELEMENT_STATE });
+    await browserItem.click();
   }
 
   async switchToListView() {


### PR DESCRIPTION
# Pull Request

## Description

Fixes #533.

Per the intended design, Files Manager should not be a left-sidenav destination - it should be reachable only via the Gears page's "Files" card. This PR removes the `files` entry from the sidenav's earned-nav destinations entirely (not just gated - the earned-promotion model no longer applies to `files`).

It also fixes the related staleness defect: when a brand-new user uploads their first file through the composer, the server unlocks the `files` gear but the client's Gears status query (5-minute `staleTime`) kept showing the unearned "Upload your first file" CTA until a reload. The composer upload success path now invalidates the `['gears', 'status']` query - only while the cached status still shows the files gear locked, so routine uploads don't refetch the status on every attachment.

## Changes

- `SidenavNav.tsx`: removed the Files Manager row from the earned-nav items, dropped the now-unused `FolderSharedIcon`/`useFileBrowser` imports, and updated comments that described Files Manager as a sidenav row.
- `SessionFilePond.tsx`: on successful composer upload, invalidate the Gears status cache while the `files` gear is still locked.
- `AttachFileButton.tsx`: added `data-testid="add-from-file-browser-btn"` to the "Add from File Browser" menu item (needed by e2e).
- `useGearsStatus.ts`: comment fix - `files` is a destination gear with no sidenav slot.
- `e2e/pages/FileUploadPage.ts`: `openFileBrowser()` now opens the browser via the composer's attach menu instead of the removed sidenav row (same global drawer, still opened over the current page without navigating away).

## Guide for Testers

Bug 1 - sidenav row removed:
1. Sign in with an account that has one or more uploaded files.
2. Look at the left sidenav. Expected: no "Files Manager" row (New Chat, Gears, Help, and other earned rows like Projects/Agents remain).
3. Navigate to the Gears page (Sidebar -> Gears). Expected: the "Files" card is present under Destinations and its button reads "Open".
4. Click "Open". Expected: the file browser drawer opens over the Gears page.

Bug 2 - Gears CTA freshness:
1. Sign in with a brand-new account that has never uploaded a file.
2. Open the Gears page. Expected: the "Files" card button reads "Upload your first file".
3. Open a New Chat. In the composer, click the attach (paperclip) button, choose "Upload from Device", and upload a small image. Wait for the file thumbnail to appear.
4. Without reloading, return to the Gears page. Expected: the "Files" card button now reads "Open" (no reload needed).

Regression checks:
- Composer attach menu: "Add from File Browser" still opens the file browser drawer.
- Uploading further files as an existing user works and does not visibly refetch/flicker the sidenav.
- Other earned sidenav rows (Projects, Agents, Data Lakes, Live Artifacts) still appear/hide per their gear state.

## Additional Information

Verified locally: `pnpm turbo:core:build`, client `typecheck`, vitest over the Sidenav and SessionBottom areas (12 files / 43 tests, all passing), eslint on changed files (0 errors). Playwright suites (`notebook-files.spec.ts`, `search.spec.ts`) run in CI - they use the updated `openFileBrowser()` path.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc