### PR TITLE
fix(client): send only edited fields from ProfileDataForm on save

### DIFF
--- a/apps/client/app/components/ProfileModal/ProfileDataForm.test.tsx
+++ b/apps/client/app/components/ProfileModal/ProfileDataForm.test.tsx
@@ -1,0 +1,91 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { IUserDocument, WithOrgRef } from '@bike4mind/common';
+import ProfileDataForm from './ProfileDataForm';
+
+const { mockMutate } = vi.hoisted(() => ({ mockMutate: vi.fn() }));
+
+vi.mock('@client/app/hooks/data/user', () => ({
+  useUpdateUser: () => ({ mutate: mockMutate, isPending: false }),
+}));
+
+// SingleOrganizationSelector fetches org data + reads the user context; stub it out.
+vi.mock('@client/app/components/common/SingleOrganizationSelector', () => ({
+  default: () => null,
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const makeUser = (): WithOrgRef<IUserDocument> =>
+  ({
+    id: 'user-1',
+    name: 'Original Name',
+    username: 'orig',
+    email: 'orig@example.com',
+    team: 'Team A',
+    role: 'Engineer',
+    // Fields the form does NOT manage - must never appear in the save payload:
+    userNotes: [{ timestamp: '2026-01-01', note: 'admin note', userName: 'admin' }],
+    securityQuestions: [{ question: 'Q1', answer: 'A1' }],
+    isAdmin: true,
+    isBanned: false,
+    isModerated: false,
+  }) as unknown as WithOrgRef<IUserDocument>;
+
+const renderForm = (adminMode = true) =>
+  render(<ProfileDataForm userData={makeUser()} adminMode={adminMode} />, { wrapper: TestWrapper });
+
+beforeEach(() => {
+  mockMutate.mockReset();
+});
+
+describe('ProfileDataForm', () => {
+  it('sends only the edited field, never re-sending unmanaged fields', () => {
+    const { container } = renderForm();
+
+    const nameInput = container.querySelector('input[name="name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'New Name' } });
+
+    fireEvent.click(screen.getByTestId('profile-save-btn'));
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const [payload] = mockMutate.mock.calls[0];
+    expect(payload).toEqual({ id: 'user-1', data: { name: 'New Name' } });
+    // Regression guard for issue #466: unmanaged fields must not round-trip.
+    expect(payload.data).not.toHaveProperty('userNotes');
+    expect(payload.data).not.toHaveProperty('securityQuestions');
+    expect(payload.data).not.toHaveProperty('isAdmin');
+    expect(payload.data).not.toHaveProperty('isBanned');
+    expect(payload.data).not.toHaveProperty('isModerated');
+  });
+
+  it('includes securityQuestions (with the edit) only when the user touches them', () => {
+    renderForm();
+
+    const questionInput = screen.getByDisplayValue('Q1') as HTMLInputElement;
+    fireEvent.change(questionInput, { target: { value: 'Q1-edited' } });
+
+    fireEvent.click(screen.getByTestId('profile-save-btn'));
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const [payload] = mockMutate.mock.calls[0];
+    expect(payload.data.securityQuestions).toEqual([{ question: 'Q1-edited', answer: 'A1' }]);
+    // Only the touched field ships; unmanaged/untouched fields stay out.
+    expect(payload.data).not.toHaveProperty('userNotes');
+    expect(payload.data).not.toHaveProperty('name');
+  });
+
+  it('does not call the mutation when nothing was edited', () => {
+    renderForm();
+
+    fireEvent.click(screen.getByTestId('profile-save-btn'));
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/ProfileModal/ProfileDataForm.tsx
+++ b/apps/client/app/components/ProfileModal/ProfileDataForm.tsx
@@ -20,7 +20,11 @@ interface ProfileDataFormProps {
 const ProfileDataForm: React.FC<ProfileDataFormProps> = ({ userData, adminMode, onCancel }) => {
   const [editUser, setEditUser] = useState<IUserDocument>({ ...userData, organizationId: userData.organizationId?.id });
   const [editing, setEditing] = useState(false);
-  const [dirty, setDirty] = useState(false);
+  // Track which fields the user actually edited so handleSave only sends those.
+  // Re-sending unedited fields is a read-modify-write hazard: the update endpoint
+  // $sets whatever it receives, so a stale/absent value can clobber stored data.
+  const [editedFields, setEditedFields] = useState<Partial<Record<keyof IUserDocument, boolean>>>({});
+  const dirty = Object.keys(editedFields).length > 0;
   const contactOptions = ['Text', 'Call', 'Email'];
   const shirtOptions = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
   const updateUser = useUpdateUser();
@@ -35,7 +39,7 @@ const ProfileDataForm: React.FC<ProfileDataFormProps> = ({ userData, adminMode, 
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
-    setDirty(true);
+    setEditedFields(prev => ({ ...prev, [name]: true }));
     setEditUser(prev => ({ ...prev, [name]: value }));
   };
 
@@ -50,6 +54,7 @@ const ProfileDataForm: React.FC<ProfileDataFormProps> = ({ userData, adminMode, 
           );
           const data = await response.json();
 
+          setEditedFields(prev => ({ ...prev, geoLocation: true }));
           setEditUser({ ...editUser, geoLocation: data.locality });
         },
         () => {
@@ -69,17 +74,17 @@ const ProfileDataForm: React.FC<ProfileDataFormProps> = ({ userData, adminMode, 
       formattedInput = `${formattedInput.slice(0, 9)}-${formattedInput.slice(9, 13)}`;
     }
 
-    setDirty(true);
+    setEditedFields(prev => ({ ...prev, phone: true }));
     setEditUser(prev => ({ ...prev, phone: formattedInput }));
   };
 
   const handlePreferredContact = (event: React.ChangeEvent | null, value: string) => {
-    setDirty(true);
+    setEditedFields(prev => ({ ...prev, preferredContact: true }));
     setEditUser(prev => ({ ...prev, preferredContact: value }));
   };
 
   const handlePreferredShirt = (event: React.ChangeEvent | null, value: string) => {
-    setDirty(true);
+    setEditedFields(prev => ({ ...prev, tshirtSize: true }));
     setEditUser(prev => ({ ...prev, tshirtSize: value }));
   };
 
@@ -88,11 +93,13 @@ const ProfileDataForm: React.FC<ProfileDataFormProps> = ({ userData, adminMode, 
     if (updatedQuestions[index]) {
       updatedQuestions[index][key] = value;
     }
+    setEditedFields(prev => ({ ...prev, securityQuestions: true }));
     setEditUser(prev => ({ ...prev, securityQuestions: updatedQuestions }));
   };
 
   const handleAddSecurityQuestion = () => {
     const newQuestion: ISecurityQuestion = { question: '', answer: '' };
+    setEditedFields(prev => ({ ...prev, securityQuestions: true }));
     setEditUser(prev => ({
       ...prev,
       securityQuestions: [...(prev.securityQuestions || []), newQuestion],
@@ -100,6 +107,7 @@ const ProfileDataForm: React.FC<ProfileDataFormProps> = ({ userData, adminMode, 
   };
 
   const handleDeleteSecurityQuestion = (index: number) => {
+    setEditedFields(prev => ({ ...prev, securityQuestions: true }));
     setEditUser(prev => ({
       ...prev,
       securityQuestions: prev.securityQuestions ? prev.securityQuestions?.filter((_, i) => i !== index) : [],
@@ -107,36 +115,33 @@ const ProfileDataForm: React.FC<ProfileDataFormProps> = ({ userData, adminMode, 
   };
 
   const handleSave = async () => {
-    try {
-      if (!editUser.id) {
-        throw new Error('User ID not found');
-      }
-
-      // Destructure fields that shouldn't be updated from editUser to avoid sending them
-      const { lastCreditsPurchasedAt, lastNotebookId, ...userDataToUpdate } = editUser;
-
-      // Ensure arrays are initialized
-      const dataToUpdate = {
-        ...userDataToUpdate,
-        userNotes: editUser.userNotes || [],
-        // Convert boolean fields
-        isAdmin: Boolean(editUser.isAdmin),
-        isBanned: Boolean(editUser.isBanned),
-        isModerated: Boolean(editUser.isModerated),
-      };
-
-      setEditing(true);
-      setDirty(false);
-      updateUser.mutate(
-        {
-          id: editUser.id,
-          data: dataToUpdate,
-        },
-        { onSettled: () => setEditing(false) }
-      );
-    } catch (error) {
-      console.error('Failed to update user:', error);
+    if (!editUser.id) {
+      console.error('Failed to update user: User ID not found');
+      return;
     }
+
+    // Send only the fields the user actually edited. Fields the form does not
+    // manage (userNotes, isAdmin/isBanned/isModerated, ...) are never included,
+    // so they cannot be clobbered by a stale/absent value on save.
+    const editedKeys = (Object.keys(editedFields) as (keyof IUserDocument)[]).filter(key => editedFields[key]);
+
+    // Nothing edited -> no PUT (avoids a no-op write that only bumps updatedAt).
+    if (editedKeys.length === 0) {
+      return;
+    }
+
+    const data = Object.fromEntries(editedKeys.map(key => [key, editUser[key]])) as Partial<IUserDocument>;
+
+    setEditing(true);
+    setEditedFields({});
+
+    updateUser.mutate(
+      {
+        id: editUser.id,
+        data,
+      },
+      { onSettled: () => setEditing(false) }
+    );
   };
   return (
     <>
@@ -191,7 +196,10 @@ const ProfileDataForm: React.FC<ProfileDataFormProps> = ({ userData, adminMode, 
             </Typography>
             <SingleOrganizationSelector
               currentOrgId={editUser.organizationId}
-              onChange={orgId => setEditUser(prev => ({ ...prev, organizationId: orgId }))}
+              onChange={orgId => {
+                setEditedFields(prev => ({ ...prev, organizationId: true }));
+                setEditUser(prev => ({ ...prev, organizationId: orgId }));
+              }}
             />
           </Grid>
           <Grid className="profile-data-form-field-container" data-testid="profile-form-field" xs={12} sm={6} md={4}>


### PR DESCRIPTION
## Description

`ProfileDataForm` was a read-modify-write hazard. On save it spread the entire loaded user object into the update payload, plus forced `userNotes: editUser.userNotes || []` and re-sent `securityQuestions` and `isAdmin`/`isBanned`/`isModerated` verbatim -- even though the form only has UI for ~10 fields.

The update endpoint merges `{ ...dbUser, ...params }` and `$set`s the whole doc, so any field the form re-sends with a concrete-but-stale value overwrites the stored one. Concretely: on the admin path, `userNotes || []` forces an empty array that wipes stored admin notes. It's latent today (the GET returns those fields, so there's no active wipe), but it breaks the moment the response shape changes.

This PR tracks which fields the form actually edits and sends only those, so unmanaged fields can never be clobbered. Closes #466.

## Changes

- Replace the single `dirty` boolean with per-field `editedFields` tracking; every change handler marks its field.
- Rewrite `handleSave` to build the payload from edited fields only -- drops the whole-object spread, the `userNotes || []` coercion, and the `Boolean(...)` flag coercions.
- Mark `securityQuestions` edits dirty in all three handlers, fixing a related latent bug where a background React Query refetch could reset in-progress security-question edits.
- Skip the mutation entirely when nothing changed (no no-op PUT).
- Add `ProfileDataForm.test.tsx` (the component was previously untested).

## Guide for Testers

Prerequisite: an admin account and a target user that has security questions set.

1. Sign in as an admin.
2. Open **Sidebar -> Admin -> Users**, find the target user, and open their profile (Admin Profile modal).
3. In the profile form, change only the **Name** field to `QA Rename Test`.
4. Click **Save Changes**. Expected: the save succeeds with no error and the new name persists.
5. Reload the page and reopen the same user's profile. Expected: the **Security Questions** section still shows the user's existing questions (they were NOT wiped), and any admin notes on the user are still present.
6. In the profile form, edit one **Security Question** value, click **Save Changes**, reload, and reopen. Expected: only the edited question changed; nothing else was lost.

### Regression Checks

- Editing any single field (Name, Team, Role, Phone, Preferred Contact, T-shirt Size, Geo Location, Organization) and saving persists that field correctly.
- Saving with no edits does nothing (no network request, no error).
- Non-admin self-profile edit (open your own profile via the normal profile page, edit Name, save) still works.

### What NOT to test

- `isAdmin`/`isBanned`/`isModerated` and role/tag changes are intentionally NOT managed by this form -- they are changed via the admin Users view (Roles / Product Access), and this PR deliberately removes them from this form's save payload.

## Additional Information

Out of scope for this PR, but worth a separate issue: GET `/api/users/[id]` returns security-question answers in cleartext to self/admin. That is a data-exposure concern independent of this change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
