### PR TITLE
chore(premium): bump b4m-overwatch pin to 21dbc15b

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,5 +1,5 @@
 {
-  "b4m-overwatch": "f300c80507cedcf95b86f56eebbd2082b20f7757",
+  "b4m-overwatch": "21dbc15bf04c97702b403616e9d097f323cfaf7f",
   "b4m-libreoncology": "6c198d67ffce265dc66cf7ef879c84a00847554c",
   "b4m-optihashi": "38384564b88e5830487b6eedb80aeae45816353f",
   "b4m-pi": "c95fc844445c8d3ae7b930acf6d4452ace25ae32",


### PR DESCRIPTION
Sets the b4m-overwatch overlay pin to 21dbc15bf04c97702b403616e9d097f323cfaf7f. Overlay-pin-only change; no application source changes.