### PR TITLE
chore(premium): set b4m-optihashi overlay pin to cd0f47730f2b7d16780603b05c4b810938ad1b91

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "21dbc15bf04c97702b403616e9d097f323cfaf7f",
   "b4m-libreoncology": "6c198d67ffce265dc66cf7ef879c84a00847554c",
-  "b4m-optihashi": "38384564b88e5830487b6eedb80aeae45816353f",
+  "b4m-optihashi": "cd0f47730f2b7d16780603b05c4b810938ad1b91",
   "b4m-pi": "c95fc844445c8d3ae7b930acf6d4452ace25ae32",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Sets the b4m-optihashi overlay pin to cd0f47730f2b7d16780603b05c4b810938ad1b91. Overlay-pin-only change; no application source changes.