### PR TITLE
chore(premium): bump libreoncology overlay pin 6c198d67 → 46c40b7e

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,6 +1,6 @@
 {
   "b4m-overwatch": "21dbc15bf04c97702b403616e9d097f323cfaf7f",
-  "b4m-libreoncology": "6c198d67ffce265dc66cf7ef879c84a00847554c",
+  "b4m-libreoncology": "46c40b7e942efadf81f98b219792eca4d32fb4aa",
   "b4m-optihashi": "cd0f47730f2b7d16780603b05c4b810938ad1b91",
   "b4m-pi": "c95fc844445c8d3ae7b930acf6d4452ace25ae32",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"


### PR DESCRIPTION
Overlay-pin-only change: bumps the `b4m-libreoncology` pin in `premium-overlay.lock.json` to `46c40b7e942efadf81f98b219792eca4d32fb4aa`. No application source changes; the other four overlay pins are unchanged.

A preview deploy validates the host build against the new overlay SHA before merge.
