### PR TITLE
feat(export): reusable markdown to styled-HTML export utility

### DIFF
--- a/apps/client/app/components/Session/SessionExportMenu.test.tsx
+++ b/apps/client/app/components/Session/SessionExportMenu.test.tsx
@@ -19,7 +19,7 @@ import SessionExportMenu from './SessionExportMenu';
 // The export utils pull in heavy generators (exceljs/docx); the menu only needs
 // their return values, so stub the whole module.
 vi.mock('@client/app/utils/sessionExport', () => ({
-  toExportableSession: vi.fn(() => ({})),
+  toExportableSession: vi.fn(() => ({ name: 'Test Session' })),
   sessionToMarkdown: vi.fn(() => '# session'),
   sessionToJSON: vi.fn(() => '{}'),
   sessionToCSV: vi.fn(() => ''),

--- a/apps/client/app/components/Session/SessionExportMenu.test.tsx
+++ b/apps/client/app/components/Session/SessionExportMenu.test.tsx
@@ -1,10 +1,12 @@
 import React, { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
 import type { IChatHistoryItemDocument, ISessionDocument } from '@bike4mind/common';
 import { useSendToDataLakeStore } from '@client/app/stores/useSendToDataLakeStore';
+import { downloadFile } from '@client/app/components/common/DownloadMenu';
+import { renderMarkdownToStyledHtml } from '@client/app/utils/markdownToStyledHtml';
 import SessionExportMenu from './SessionExportMenu';
 
 /**
@@ -29,6 +31,10 @@ vi.mock('@client/app/utils/sessionExport', () => ({
 vi.mock('@client/app/components/common/DownloadMenu', () => ({
   default: () => null,
   downloadFile: vi.fn(),
+}));
+
+vi.mock('@client/app/utils/markdownToStyledHtml', () => ({
+  renderMarkdownToStyledHtml: vi.fn(async () => '<!DOCTYPE html><html></html>'),
 }));
 
 vi.mock('@client/app/hooks/useCopyToClipboard', () => ({
@@ -98,8 +104,24 @@ describe('SessionExportMenu - EnableDataLakes gating', () => {
     expect(screen.getByTestId('session-export-csv')).toBeInTheDocument();
     expect(screen.getByTestId('session-export-excel')).toBeInTheDocument();
     expect(screen.getByTestId('session-export-docx')).toBeInTheDocument();
+    expect(screen.getByTestId('session-export-html')).toBeInTheDocument();
     expect(screen.getByTestId('session-copy-markdown')).toBeInTheDocument();
     expect(screen.getByTestId('session-copy-json')).toBeInTheDocument();
+  });
+
+  it('exports styled HTML via the shared util when the HTML item is clicked', async () => {
+    renderAndOpenMenu();
+
+    fireEvent.click(screen.getByTestId('session-export-html'));
+
+    await waitFor(() =>
+      expect(renderMarkdownToStyledHtml).toHaveBeenCalledWith('# session', { title: 'Test Session' })
+    );
+    await waitFor(() => {
+      const [, name, mimeType] = vi.mocked(downloadFile).mock.calls.at(-1)!;
+      expect(name).toBe('session-export.html');
+      expect(mimeType).toBe('text/html');
+    });
   });
 
   it('still opens the Send to Data Lake modal from the item when the feature is on', () => {

--- a/apps/client/app/components/Session/SessionExportMenu.tsx
+++ b/apps/client/app/components/Session/SessionExportMenu.tsx
@@ -135,7 +135,8 @@ const SessionExportMenu: React.FC<SessionExportMenuProps> = ({
     setIsHtmlGenerating(true);
     try {
       const exportable = getExportableSession();
-      const html = await renderMarkdownToStyledHtml(sessionToMarkdown(exportable), { title: session.name });
+      // exportable.name is already formatSessionTitle-cleaned at the boundary.
+      const html = await renderMarkdownToStyledHtml(sessionToMarkdown(exportable), { title: exportable.name });
       downloadFile(html, `${filename}.html`, 'text/html');
       toast.success('HTML exported');
     } catch (error) {
@@ -144,7 +145,7 @@ const SessionExportMenu: React.FC<SessionExportMenuProps> = ({
     } finally {
       setIsHtmlGenerating(false);
     }
-  }, [getExportableSession, filename, session.name]);
+  }, [getExportableSession, filename]);
 
   const handleSendToDataLake = useCallback(() => {
     openSendToDataLake({

--- a/apps/client/app/components/Session/SessionExportMenu.tsx
+++ b/apps/client/app/components/Session/SessionExportMenu.tsx
@@ -10,6 +10,7 @@ import {
   getSessionExportFilename,
 } from '@client/app/utils/sessionExport';
 import { downloadFile } from '@client/app/components/common/DownloadMenu';
+import { renderMarkdownToStyledHtml } from '@client/app/utils/markdownToStyledHtml';
 import {
   SaveAlt as ExportIcon,
   Description as MarkdownIcon,
@@ -18,6 +19,7 @@ import {
   ContentCopy as CopyIcon,
   GridOn as ExcelIcon,
   Article as WordIcon,
+  Html as HtmlIcon,
   Storage as StorageIcon,
 } from '@mui/icons-material';
 import { useSendToDataLakeStore } from '@client/app/stores/useSendToDataLakeStore';
@@ -53,11 +55,12 @@ const SessionExportMenu: React.FC<SessionExportMenuProps> = ({
   const { handleCopyToClipboard } = useCopyToClipboard({ showToast: true });
   const [isExcelGenerating, setIsExcelGenerating] = useState(false);
   const [isDocxGenerating, setIsDocxGenerating] = useState(false);
+  const [isHtmlGenerating, setIsHtmlGenerating] = useState(false);
   const openSendToDataLake = useSendToDataLakeStore(s => s.open);
   const { isFeatureEnabled } = useAdminSettingsCache();
 
   const filename = getSessionExportFilename(session.name);
-  const isExporting = isExcelGenerating || isDocxGenerating;
+  const isExporting = isExcelGenerating || isDocxGenerating || isHtmlGenerating;
 
   const getExportableSession = useCallback(() => {
     return toExportableSession(session, chatHistory);
@@ -127,6 +130,21 @@ const SessionExportMenu: React.FC<SessionExportMenuProps> = ({
       setIsDocxGenerating(false);
     }
   }, [getExportableSession, filename]);
+
+  const handleHtmlExport = useCallback(async () => {
+    setIsHtmlGenerating(true);
+    try {
+      const exportable = getExportableSession();
+      const html = await renderMarkdownToStyledHtml(sessionToMarkdown(exportable), { title: session.name });
+      downloadFile(html, `${filename}.html`, 'text/html');
+      toast.success('HTML exported');
+    } catch (error) {
+      console.error('HTML export failed:', error);
+      toast.error('Failed to generate HTML file');
+    } finally {
+      setIsHtmlGenerating(false);
+    }
+  }, [getExportableSession, filename, session.name]);
 
   const handleSendToDataLake = useCallback(() => {
     openSendToDataLake({
@@ -200,6 +218,18 @@ const SessionExportMenu: React.FC<SessionExportMenuProps> = ({
           </ListItemDecorator>
           Word (.docx)
           {isDocxGenerating && (
+            <Typography level="body-xs" sx={{ ml: 1, color: 'neutral.500' }}>
+              Generating...
+            </Typography>
+          )}
+        </MenuItem>
+
+        <MenuItem data-testid="session-export-html" onClick={handleHtmlExport} disabled={isHtmlGenerating}>
+          <ListItemDecorator>
+            {isHtmlGenerating ? <CircularProgress size="sm" /> : <HtmlIcon fontSize="small" />}
+          </ListItemDecorator>
+          HTML (.html)
+          {isHtmlGenerating && (
             <Typography level="body-xs" sx={{ ml: 1, color: 'neutral.500' }}>
               Generating...
             </Typography>

--- a/apps/client/app/components/Session/SidenavItem.gating.test.tsx
+++ b/apps/client/app/components/Session/SidenavItem.gating.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@client/app/hooks/data/sessions', () => ({
   useDownloadSession: () => mutation(),
   useExportSessionToExcel: () => mutation(),
   useExportSessionToWord: () => mutation(),
+  useExportSessionToHtml: () => mutation(),
   useSendSessionToDataLake: () => mutation(),
   useSummarizeSession: () => mutation(),
   useToggleFavoriteSession: () => mutation(),
@@ -125,13 +126,14 @@ describe.each([
   // is no longer a slimmed-down variant - the former `disableExportOps` flag,
   // which the Favorites list set to hide Download/Copy/Export/Send, was removed
   // so all rows expose the full export action set.
-  it('shows the full export action set (download, copy-markdown, excel, word)', () => {
+  it('shows the full export action set (download, copy-markdown, excel, word, html)', () => {
     renderAndOpenMenu(location);
 
     expect(screen.getByText('notebooks.download')).toBeInTheDocument();
     expect(screen.getByText('Copy as Markdown')).toBeInTheDocument();
     expect(screen.getByTestId('sidenav-item-menuitem-export-excel')).toBeInTheDocument();
     expect(screen.getByTestId('sidenav-item-menuitem-export-word')).toBeInTheDocument();
+    expect(screen.getByTestId('sidenav-item-menuitem-export-html')).toBeInTheDocument();
     expect(screen.getByTestId('sidenav-item-menuitem-send-datalake')).toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/Session/SidenavItem.tsx
+++ b/apps/client/app/components/Session/SidenavItem.tsx
@@ -7,6 +7,7 @@ import {
   useDownloadSession,
   useExportSessionToExcel,
   useExportSessionToWord,
+  useExportSessionToHtml,
   useSendSessionToDataLake,
   useSummarizeSession,
   useToggleFavoriteSession,
@@ -23,6 +24,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 import EditIcon from '@mui/icons-material/Edit';
 import GridOnIcon from '@mui/icons-material/GridOn';
 import ArticleIcon from '@mui/icons-material/Article';
+import HtmlIcon from '@mui/icons-material/Html';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FolderCopyIcon from '@mui/icons-material/FolderCopy';
@@ -124,6 +126,7 @@ const SessionSidenavItem: FC<{
   const downloadSession = useDownloadSession();
   const exportToExcel = useExportSessionToExcel();
   const exportToWord = useExportSessionToWord();
+  const exportToHtml = useExportSessionToHtml();
   const sendToDataLake = useSendSessionToDataLake();
   const { isFeatureEnabled } = useAdminSettingsCache();
   const summarizeSession = useSummarizeSession();
@@ -221,6 +224,10 @@ const SessionSidenavItem: FC<{
   const handleExportToWord = useCallback(() => {
     exportToWord.mutate(session);
   }, [exportToWord, session]);
+
+  const handleExportToHtml = useCallback(() => {
+    exportToHtml.mutate(session);
+  }, [exportToHtml, session]);
 
   const handleCopyAsMarkdown = useCallback(() => {
     copySessionAsMarkdown.mutate(session);
@@ -525,6 +532,14 @@ const SessionSidenavItem: FC<{
                 disabled={exportToWord.isPending}
               >
                 <ArticleIcon /> Export to Word
+              </MenuItem>
+              <MenuItem
+                onClick={handleExportToHtml}
+                className="sidenav-item-menuitem-export-html"
+                data-testid="sidenav-item-menuitem-export-html"
+                disabled={exportToHtml.isPending}
+              >
+                <HtmlIcon /> Export to HTML
               </MenuItem>
               {isFeatureEnabled('EnableDataLakes') && (
                 <MenuItem
@@ -861,6 +876,14 @@ const SessionSidenavItem: FC<{
                   disabled={exportToWord.isPending}
                 >
                   <ArticleIcon /> Export to Word
+                </MenuItem>
+                <MenuItem
+                  onClick={handleExportToHtml}
+                  className="sidenav-item-menuitem-export-html"
+                  data-testid="sidenav-item-menuitem-export-html"
+                  disabled={exportToHtml.isPending}
+                >
+                  <HtmlIcon /> Export to HTML
                 </MenuItem>
                 {isFeatureEnabled('EnableDataLakes') && (
                   <MenuItem

--- a/apps/client/app/components/common/DownloadMenu.tsx
+++ b/apps/client/app/components/common/DownloadMenu.tsx
@@ -5,6 +5,7 @@ import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import { toast } from 'react-hot-toast';
 import { marked } from 'marked';
 import { Document, Paragraph, TextRun, Packer, Table, TableRow, TableCell, WidthType } from 'docx';
+import { renderMarkdownToStyledHtml } from '@client/app/utils/markdownToStyledHtml';
 
 // Utility: Download a file
 export const downloadFile = (content: string, fileName: string, mimeType: string) => {
@@ -197,15 +198,6 @@ export const convertMarkdownToDocx = async (markdown: string): Promise<Blob> => 
   return await Packer.toBlob(wordDoc);
 };
 
-// Utility: Convert Markdown to HTML
-export const convertMarkdownToHtml = async (markdown: string): Promise<string> => {
-  const html = await marked.parse(markdown);
-  if (typeof html !== 'string') {
-    throw new Error('Failed to convert markdown to HTML');
-  }
-  return `<!DOCTYPE html>\n<html>\n<head>\n  <meta charset=\"UTF-8\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n  <title>Converted Markdown</title>\n  <style>\n    body {\n      font-family: -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, Helvetica, Arial, sans-serif;\n      line-height: 1.6;\n      max-width: 800px;\n      margin: 0 auto;\n      padding: 2rem;\n      color: #333;\n    }\n    h1 { font-size: 2.5em; margin-bottom: 1rem; }\n    h2 { font-size: 2em; margin-bottom: 0.8rem; }\n    h3 { font-size: 1.75em; margin-bottom: 0.6rem; }\n    p { margin-bottom: 1rem; }\n    pre {\n      background-color: #f5f5f5;\n      padding: 1rem;\n      border-radius: 4px;\n      overflow-x: auto;\n      font-family: \"Courier New\", Courier, monospace;\n    }\n    code {\n      font-family: \"Courier New\", Courier, monospace;\n      background-color: #f5f5f5;\n      padding: 0.2em 0.4em;\n      border-radius: 3px;\n    }\n    ul, ol { margin-bottom: 1rem; }\n    li { margin-bottom: 0.5rem; }\n    a { color: #0066cc; text-decoration: none; }\n    a:hover { text-decoration: underline; }\n    blockquote {\n      border-left: 4px solid #ddd;\n      margin: 0;\n      padding-left: 1rem;\n      color: #666;\n    }\n    img { max-width: 100%; height: auto; }\n    table {\n      border-collapse: collapse;\n      width: 100%;\n      margin-bottom: 1rem;\n    }\n    th, td {\n      border: 1px solid #ddd;\n      padding: 0.5rem;\n      text-align: left;\n    }\n    th { background-color: #f5f5f5; }\n  </style>\n</head>\n<body>\n${html}\n</body>\n</html>`;
-};
-
 // Utility: Copy text to clipboard
 export const copyToClipboard = async (content: string): Promise<boolean> => {
   try {
@@ -273,7 +265,8 @@ const DownloadMenu: React.FC<{
           className="download-menu-item-html"
           onClick={async () => {
             try {
-              const html = await convertMarkdownToHtml(content);
+              const title = fileName.replace(/\.mdx?$/, '');
+              const html = await renderMarkdownToStyledHtml(content, { title });
               downloadFile(html, fileName.replace(/\.mdx?$/, '.html'), 'text/html');
             } catch (error) {
               console.error('Error converting to HTML:', error);

--- a/apps/client/app/hooks/data/sessions.ts
+++ b/apps/client/app/hooks/data/sessions.ts
@@ -902,7 +902,9 @@ export const useExportSessionToHtml = () => {
       const quests = await getChatMessages(session.id, { all: true });
       const exportable = toExportableSession(session, quests.data);
       const filename = getSessionExportFilename(session.name);
-      const html = await renderMarkdownToStyledHtml(sessionToMarkdown(exportable), { title: session.name });
+      // exportable.name is already formatSessionTitle-cleaned at the boundary;
+      // use it so <title>/<h1> match the body heading on legacy raw-name sessions.
+      const html = await renderMarkdownToStyledHtml(sessionToMarkdown(exportable), { title: exportable.name });
       downloadFile(html, `${filename}.html`, 'text/html');
     },
     onSuccess: (_, session) => {

--- a/apps/client/app/hooks/data/sessions.ts
+++ b/apps/client/app/hooks/data/sessions.ts
@@ -887,3 +887,29 @@ export const useExportSessionToWord = () => {
     },
   });
 };
+
+/**
+ * Hook to export a session to a self-contained, styled HTML document.
+ * Renders the session's markdown through the shared markdown->HTML utility.
+ */
+export const useExportSessionToHtml = () => {
+  return useMutation({
+    mutationFn: async (session: ISessionDocument) => {
+      const { toExportableSession, sessionToMarkdown, getSessionExportFilename } =
+        await import('@client/app/utils/sessionExport');
+      const { renderMarkdownToStyledHtml } = await import('@client/app/utils/markdownToStyledHtml');
+      const { downloadFile } = await import('@client/app/components/common/DownloadMenu');
+      const quests = await getChatMessages(session.id, { all: true });
+      const exportable = toExportableSession(session, quests.data);
+      const filename = getSessionExportFilename(session.name);
+      const html = await renderMarkdownToStyledHtml(sessionToMarkdown(exportable), { title: session.name });
+      downloadFile(html, `${filename}.html`, 'text/html');
+    },
+    onSuccess: (_, session) => {
+      toast.success(`Exported "${formatSessionTitle(session.name)}" to HTML`);
+    },
+    onError: (_, session) => {
+      toast.error(`Failed to export "${formatSessionTitle(session.name)}" to HTML`);
+    },
+  });
+};

--- a/apps/client/app/utils/__tests__/markdownToStyledHtml.test.ts
+++ b/apps/client/app/utils/__tests__/markdownToStyledHtml.test.ts
@@ -78,6 +78,14 @@ describe('renderMarkdownToStyledHtml', () => {
     expect(html).toContain('https://example.com/a.png');
   });
 
+  it('gives every heading a unique TOC anchor even when slugs would collide', async () => {
+    const md = '# Foo\n\n## Foo\n\n### Foo-1';
+    const html = await renderMarkdownToStyledHtml(md, { includeToc: true });
+    const anchors = [...html.matchAll(/href="#([^"]+)"/g)].map(m => m[1]);
+    expect(new Set(anchors).size).toBe(anchors.length);
+    expect(anchors).toContain('foo');
+  });
+
   it('adds a table of contents only when includeToc is set', async () => {
     const md = '# First\n\ntext\n\n## Second\n\nmore';
     const withToc = await renderMarkdownToStyledHtml(md, { includeToc: true });

--- a/apps/client/app/utils/__tests__/markdownToStyledHtml.test.ts
+++ b/apps/client/app/utils/__tests__/markdownToStyledHtml.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderMarkdownToStyledHtml } from '../markdownToStyledHtml';
+
+describe('renderMarkdownToStyledHtml', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('produces a complete, self-contained HTML document with inline styles', async () => {
+    const html = await renderMarkdownToStyledHtml('# Hello\n\nSome **bold** text.');
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(html).toContain('<html lang="en">');
+    expect(html).toContain('<style>');
+    expect(html).toContain('class="markdown-body"');
+    expect(html).toContain('<h1');
+    expect(html).toContain('Hello');
+    expect(html).toContain('<strong>bold</strong>');
+  });
+
+  it('strips scripts and event handlers from the rendered body', async () => {
+    const html = await renderMarkdownToStyledHtml(
+      'Text\n\n<script>alert(1)</script>\n\n<img src="x" onerror="alert(2)">'
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).not.toContain('onerror');
+  });
+
+  it('syntax-highlights fenced code blocks with a known language', async () => {
+    const md = '```js\nconst x = 1;\n```';
+    const html = await renderMarkdownToStyledHtml(md);
+    expect(html).toContain('language-js');
+    expect(html).toContain('class="token');
+  });
+
+  it('leaves an unknown code language as plain (escaped) text', async () => {
+    const md = '```notalang\nplain text\n```';
+    const html = await renderMarkdownToStyledHtml(md);
+    expect(html).toContain('plain text');
+    expect(html).toContain('language-notalang');
+  });
+
+  it('passes data: image URIs through untouched', async () => {
+    const dataUri = 'data:image/png;base64,iVBORw0KGgo=';
+    const html = await renderMarkdownToStyledHtml(`![pic](${dataUri})`);
+    expect(html).toContain(dataUri);
+  });
+
+  it('inlines remote images as base64 when inlineImages is on', async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        blob: async () => new Blob([bytes], { type: 'image/png' }),
+      }))
+    );
+    const html = await renderMarkdownToStyledHtml('![pic](https://example.com/a.png)', { inlineImages: true });
+    expect(html).toContain('data:image/png;base64,');
+    expect(html).not.toContain('https://example.com/a.png');
+  });
+
+  it('keeps the original src when remote image inlining fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('CORS');
+      })
+    );
+    const html = await renderMarkdownToStyledHtml('![pic](https://example.com/a.png)', { inlineImages: true });
+    expect(html).toContain('https://example.com/a.png');
+  });
+
+  it('does not fetch remote images when inlineImages is off', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const html = await renderMarkdownToStyledHtml('![pic](https://example.com/a.png)', { inlineImages: false });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(html).toContain('https://example.com/a.png');
+  });
+
+  it('adds a table of contents only when includeToc is set', async () => {
+    const md = '# First\n\ntext\n\n## Second\n\nmore';
+    const withToc = await renderMarkdownToStyledHtml(md, { includeToc: true });
+    expect(withToc).toContain('class="toc"');
+    expect(withToc).toContain('href="#first"');
+    expect(withToc).toContain('href="#second"');
+
+    const withoutToc = await renderMarkdownToStyledHtml(md);
+    expect(withoutToc).not.toContain('class="toc"');
+  });
+
+  it('includes the branded header/footer by default and omits it when branded is false', async () => {
+    const branded = await renderMarkdownToStyledHtml('# Doc', { title: 'My Report' });
+    expect(branded).toContain('class="export-header"');
+    expect(branded).toContain('My Report');
+    expect(branded).toContain('Exported from Bike4Mind');
+
+    const plain = await renderMarkdownToStyledHtml('# Doc', { title: 'My Report', branded: false });
+    expect(plain).not.toContain('class="export-header"');
+    expect(plain).not.toContain('class="export-footer"');
+  });
+
+  it('uses the title in the document <title> and escapes it', async () => {
+    const html = await renderMarkdownToStyledHtml('text', { title: 'A & B <c>' });
+    expect(html).toContain('<title>A &amp; B &lt;c&gt;</title>');
+  });
+
+  it('handles empty input without throwing', async () => {
+    const html = await renderMarkdownToStyledHtml('');
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+  });
+});

--- a/apps/client/app/utils/markdownToStyledHtml.ts
+++ b/apps/client/app/utils/markdownToStyledHtml.ts
@@ -108,10 +108,14 @@ function highlightCodeBlocks(doc: Document): void {
   });
 }
 
+// Per-image fetch timeout (ms) so a hung/slow origin can't wedge the export.
+const IMAGE_FETCH_TIMEOUT_MS = 10000;
+
 /**
  * Fetch remote http(s) images and rewrite them to base64 data: URIs so the
  * output is self-contained. Best-effort: data: URIs are left untouched, and any
- * fetch/CORS failure keeps the original URL rather than throwing.
+ * fetch/CORS failure (or the per-image timeout) keeps the original URL rather
+ * than throwing.
  */
 async function inlineRemoteImages(doc: Document): Promise<void> {
   const images = Array.from(doc.querySelectorAll('img'));
@@ -120,14 +124,18 @@ async function inlineRemoteImages(doc: Document): Promise<void> {
       const src = img.getAttribute('src');
       if (!src || src.startsWith('data:')) return;
       if (!/^https?:\/\//i.test(src)) return;
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), IMAGE_FETCH_TIMEOUT_MS);
       try {
-        const res = await fetch(src);
+        const res = await fetch(src, { signal: controller.signal });
         if (!res.ok) return;
         const blob = await res.blob();
         const dataUri = await blobToDataUri(blob);
         img.setAttribute('src', dataUri);
       } catch {
         // Leave the original src; a broken image beats a failed export.
+      } finally {
+        clearTimeout(timer);
       }
     })
   );
@@ -147,13 +155,16 @@ function buildTableOfContents(doc: Document): string {
   const headings = Array.from(doc.querySelectorAll('h1, h2, h3'));
   if (headings.length === 0) return '';
 
-  const seen = new Map<string, number>();
+  // Track every assigned id (not just base slugs) so a disambiguated `foo-1`
+  // can't collide with a heading whose text naturally slugifies to `foo-1`.
+  const used = new Set<string>();
   const items = headings.map(h => {
     const text = h.textContent ?? '';
-    let slug = slugify(text);
-    const count = seen.get(slug) ?? 0;
-    seen.set(slug, count + 1);
-    if (count > 0) slug = `${slug}-${count}`;
+    const base = slugify(text);
+    let slug = base;
+    let i = 1;
+    while (used.has(slug)) slug = `${base}-${i++}`;
+    used.add(slug);
     h.setAttribute('id', slug);
     const level = h.tagName.toLowerCase();
     return `<li class="toc-${level}"><a href="#${slug}">${escapeHtml(text)}</a></li>`;

--- a/apps/client/app/utils/markdownToStyledHtml.ts
+++ b/apps/client/app/utils/markdownToStyledHtml.ts
@@ -2,9 +2,10 @@ import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import Prism from 'prismjs';
 // Side-effect import: registers the repo's Prism language grammars on the shared
-// Prism singleton (HTML/JS/TS/python/bash/sql/...). Kept as the single source of
-// truth for which languages highlight - must stay in sync with the in-app code
-// viewer, which loads the same module.
+// Prism singleton (HTML/JS/TS/python/bash/sql/...). This is the single source of
+// truth for which languages highlight; the in-app code highlighter
+// (CodeHighlightPlugin) imports the same module, so export and in-app rendering
+// stay in sync.
 import '@client/app/components/Session/prism-languages';
 
 /**

--- a/apps/client/app/utils/markdownToStyledHtml.ts
+++ b/apps/client/app/utils/markdownToStyledHtml.ts
@@ -1,0 +1,302 @@
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+import Prism from 'prismjs';
+// Side-effect import: registers the repo's Prism language grammars on the shared
+// Prism singleton (HTML/JS/TS/python/bash/sql/...). Kept as the single source of
+// truth for which languages highlight - must stay in sync with the in-app code
+// viewer, which loads the same module.
+import '@client/app/components/Session/prism-languages';
+
+/**
+ * Reusable markdown -> self-contained, styled HTML export.
+ *
+ * Consolidates the ad-hoc markdown->HTML conversion that used to live inline in
+ * DownloadMenu into one utility so any feature wanting a styled HTML document
+ * (session export, download menus, future report exports) shares the same
+ * sanitization, syntax highlighting, print CSS, and branding.
+ *
+ * Security: marked v15 passes raw HTML through, so the markdown body is the
+ * untrusted input. We DOMPurify-sanitize the rendered body (stripping scripts,
+ * event handlers, and javascript: URIs) BEFORE wrapping it in the trusted
+ * document shell + <style>, so sanitization never touches our own CSS. This
+ * matches the repo convention that the sanitizer - not marked - is the security
+ * boundary (see server/utils/marketingReportRenderer.ts and utils/htmlSanitizer.ts).
+ *
+ * Output modes:
+ * - Single-file (implemented, the default): one self-contained .html with inline
+ *   CSS and base64-inlined images, openable offline and printable to PDF in any
+ *   browser. This is what the in-browser download consumers need.
+ * - Multi-file (documented alternative, not built): emit the same HTML with
+ *   images written as sibling asset files and referenced by relative path,
+ *   for callers that prefer a folder over one large data-URI-heavy file. No
+ *   current consumer downloads a folder, so only the single-file mode ships.
+ */
+export interface StyledHtmlOptions {
+  /** <title> and branded header heading. */
+  title?: string;
+  /** Include the branded header/footer template. Default true. */
+  branded?: boolean;
+  /** Prepend a table of contents built from h1-h3. Default false. */
+  includeToc?: boolean;
+  /** Best-effort fetch + base64-inline of remote images. Default true. */
+  inlineImages?: boolean;
+}
+
+const DEFAULT_TITLE = 'Export';
+
+export async function renderMarkdownToStyledHtml(markdown: string, options: StyledHtmlOptions = {}): Promise<string> {
+  const { title = DEFAULT_TITLE, branded = true, includeToc = false, inlineImages = true } = options;
+
+  const bodyHtml = marked.parse(markdown ?? '', { gfm: true, breaks: true, async: false }) as string;
+
+  // Post-process in a detached document so we can highlight, inline assets, and
+  // build the ToC against real DOM before serializing back to a string.
+  const doc = new DOMParser().parseFromString(`<body>${bodyHtml}</body>`, 'text/html');
+
+  highlightCodeBlocks(doc);
+  if (inlineImages) {
+    await inlineRemoteImages(doc);
+  }
+  const tocHtml = includeToc ? buildTableOfContents(doc) : '';
+
+  const safeBody = DOMPurify.sanitize(tocHtml + doc.body.innerHTML, {
+    // data: image URIs (from inlining) and inline <svg> are allowed by
+    // DOMPurify's defaults; we only extend it to keep links openable in a new
+    // tab. Scripts/handlers are stripped by default - this output is opened
+    // directly as a page, not in a sandbox, so scripts must never survive.
+    ADD_ATTR: ['target', 'rel'],
+    FORBID_TAGS: ['script', 'iframe', 'object', 'embed', 'style'],
+  });
+
+  const header = branded ? renderHeader(title) : '';
+  const footer = branded ? renderFooter() : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(title)}</title>
+<style>
+${BASE_STYLESHEET}
+${PRISM_STYLESHEET}
+</style>
+</head>
+<body>
+<main class="markdown-body">
+${header}
+${safeBody}
+${footer}
+</main>
+</body>
+</html>`;
+}
+
+/** Highlight fenced code blocks (`pre > code.language-*`) via Prism, in place. */
+function highlightCodeBlocks(doc: Document): void {
+  const blocks = doc.querySelectorAll('pre > code[class*="language-"]');
+  blocks.forEach(code => {
+    const languageClass = Array.from(code.classList).find(c => c.startsWith('language-'));
+    const language = languageClass?.replace('language-', '') ?? '';
+    const grammar = Prism.languages[language];
+    // textContent is the unescaped source; Prism.highlight returns token markup.
+    // Unknown languages have no grammar - leave the escaped plain text as-is.
+    if (grammar && code.textContent) {
+      code.innerHTML = Prism.highlight(code.textContent, grammar, language);
+    }
+  });
+}
+
+/**
+ * Fetch remote http(s) images and rewrite them to base64 data: URIs so the
+ * output is self-contained. Best-effort: data: URIs are left untouched, and any
+ * fetch/CORS failure keeps the original URL rather than throwing.
+ */
+async function inlineRemoteImages(doc: Document): Promise<void> {
+  const images = Array.from(doc.querySelectorAll('img'));
+  await Promise.all(
+    images.map(async img => {
+      const src = img.getAttribute('src');
+      if (!src || src.startsWith('data:')) return;
+      if (!/^https?:\/\//i.test(src)) return;
+      try {
+        const res = await fetch(src);
+        if (!res.ok) return;
+        const blob = await res.blob();
+        const dataUri = await blobToDataUri(blob);
+        img.setAttribute('src', dataUri);
+      } catch {
+        // Leave the original src; a broken image beats a failed export.
+      }
+    })
+  );
+}
+
+function blobToDataUri(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+/** Assign stable slug ids to h1-h3 and return a nav list linking to them. */
+function buildTableOfContents(doc: Document): string {
+  const headings = Array.from(doc.querySelectorAll('h1, h2, h3'));
+  if (headings.length === 0) return '';
+
+  const seen = new Map<string, number>();
+  const items = headings.map(h => {
+    const text = h.textContent ?? '';
+    let slug = slugify(text);
+    const count = seen.get(slug) ?? 0;
+    seen.set(slug, count + 1);
+    if (count > 0) slug = `${slug}-${count}`;
+    h.setAttribute('id', slug);
+    const level = h.tagName.toLowerCase();
+    return `<li class="toc-${level}"><a href="#${slug}">${escapeHtml(text)}</a></li>`;
+  });
+
+  return `<nav class="toc"><p class="toc-title">Contents</p><ul>${items.join('')}</ul></nav>`;
+}
+
+function slugify(text: string): string {
+  return (
+    text
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-') || 'section'
+  );
+}
+
+function renderHeader(title: string): string {
+  return `<header class="export-header"><h1 class="export-title">${escapeHtml(title)}</h1></header>`;
+}
+
+function renderFooter(): string {
+  const date = new Date().toISOString().slice(0, 10);
+  return `<footer class="export-footer">Exported from Bike4Mind on ${date}</footer>`;
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// GitHub-flavored base styling, adapted from the core FormatConverter
+// (b4m-core notebookCurationService/formatConverter.ts) and extended with a
+// branded header/footer, a table of contents, and print CSS.
+const BASE_STYLESHEET = `
+  :root { color-scheme: light; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    color: #24292e;
+    background-color: #fff;
+    margin: 0;
+  }
+  .markdown-body {
+    box-sizing: border-box;
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 45px;
+  }
+  .export-header {
+    border-bottom: 2px solid #0366d6;
+    margin-bottom: 24px;
+    padding-bottom: 12px;
+  }
+  .export-title { margin: 0; font-size: 1.6em; color: #0366d6; }
+  .export-footer {
+    margin-top: 32px;
+    padding-top: 12px;
+    border-top: 1px solid #eaecef;
+    color: #6a737d;
+    font-size: 0.85em;
+  }
+  .toc {
+    border: 1px solid #eaecef;
+    border-radius: 6px;
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    background-color: #f6f8fa;
+  }
+  .toc-title { margin: 0 0 8px 0; font-weight: 600; }
+  .toc ul { list-style: none; margin: 0; padding: 0; }
+  .toc li { margin: 2px 0; }
+  .toc-h2 { padding-left: 16px; }
+  .toc-h3 { padding-left: 32px; }
+  .toc a { color: #0366d6; text-decoration: none; }
+  h1, h2, h3, h4, h5, h6 {
+    margin-top: 24px;
+    margin-bottom: 16px;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+  h1 { font-size: 2em; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; }
+  h2 { font-size: 1.5em; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; }
+  h3 { font-size: 1.25em; }
+  p { margin-bottom: 16px; }
+  pre {
+    background-color: #f6f8fa;
+    border-radius: 6px;
+    padding: 16px;
+    overflow: auto;
+    font-size: 85%;
+    line-height: 1.45;
+  }
+  code {
+    background-color: rgba(27,31,35,0.05);
+    border-radius: 3px;
+    padding: 0.2em 0.4em;
+    font-family: 'SF Mono', Monaco, Menlo, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    font-size: 85%;
+  }
+  pre code { background-color: transparent; padding: 0; font-size: 100%; }
+  blockquote {
+    padding: 0 1em;
+    color: #6a737d;
+    border-left: 0.25em solid #dfe2e5;
+    margin: 0 0 16px 0;
+  }
+  ul, ol { margin-bottom: 16px; }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 16px;
+    overflow: auto;
+  }
+  table th { font-weight: 600; background-color: #f6f8fa; }
+  table th, table td { padding: 6px 13px; border: 1px solid #dfe2e5; }
+  table tr:nth-child(2n) { background-color: #f6f8fa; }
+  img { max-width: 100%; height: auto; }
+  svg { max-width: 100%; }
+  a { color: #0366d6; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  hr { height: 0.25em; margin: 24px 0; background-color: #e1e4e8; border: 0; }
+  @page { margin: 1.6cm; }
+  @media print {
+    .markdown-body { max-width: none; padding: 0; }
+    .export-header, .export-footer, .toc { break-inside: avoid; }
+    pre, blockquote, table, img { break-inside: avoid; }
+    a { color: #24292e; }
+  }
+`;
+
+// Minimal Prism token palette (light) so highlighted code renders with color in
+// the standalone document without pulling in an external Prism theme stylesheet.
+const PRISM_STYLESHEET = `
+  .token.comment, .token.prolog, .token.doctype, .token.cdata { color: #6a737d; }
+  .token.punctuation { color: #24292e; }
+  .token.property, .token.tag, .token.boolean, .token.number,
+  .token.constant, .token.symbol, .token.deleted { color: #005cc5; }
+  .token.selector, .token.attr-name, .token.string, .token.char,
+  .token.builtin, .token.inserted { color: #032f62; }
+  .token.operator, .token.entity, .token.url { color: #d73a49; }
+  .token.atrule, .token.attr-value, .token.keyword { color: #d73a49; }
+  .token.function, .token.class-name { color: #6f42c1; }
+  .token.regex, .token.important, .token.variable { color: #e36209; }
+`;


### PR DESCRIPTION
## Optional Screenshot/Video

<img width="1440" height="900" alt="Live session menu showing the new Export to HTML item" src="https://github.com/user-attachments/assets/3b0c0058-fbfd-4e06-9c75-eab4f17d2d3b" />
*Figure 1: the live per-session sidenav menu with the new "Export to HTML" entry alongside Excel/Word (issue #30).*

<img width="1440" height="1084" alt="Exported HTML rendered in a browser" src="https://github.com/user-attachments/assets/4e355258-c2ae-4002-ad15-cf0fd2027673" />
*Figure 2: the exported .html opened in a browser - branded header/footer, syntax-highlighted code block, GFM table, and a self-contained inline SVG image, all from the shared utility.*

## Description

HTML/document export was reinvented per feature. `DownloadMenu` carried an ad-hoc `convertMarkdownToHtml` (marked -> a full HTML doc with a hardcoded inline `<style>` and no sanitization), and there was no shared, branded, print-friendly, self-contained HTML export utility, so any new feature wanting styled HTML had to reinvent the pipeline.

This PR consolidates that into one reusable client utility, `renderMarkdownToStyledHtml`, migrates `DownloadMenu` onto it, and adds a live session HTML export as an additional consumer. QuestMaster Export already shipped (Markdown + PDF), so this is a consolidation/DX change, not a blocker for that feature. Closes #30.

## Changes

- **New `apps/client/app/utils/markdownToStyledHtml.ts`** - `renderMarkdownToStyledHtml(markdown, options)` renders markdown to a self-contained, styled HTML document:
  - `marked` (gfm + breaks) for rendering; **DOMPurify sanitizes the rendered body** before it is wrapped in the trusted shell + CSS (the sanitizer, not marked, is the security boundary - matches the repo convention in `marketingReportRenderer` / `htmlSanitizer`).
  - **Syntax highlighting** via Prism, reusing the repo's shared `prism-languages` grammar registrations (same module the in-app `CodeHighlightPlugin` loads).
  - **Self-contained output**: inline `<svg>` and `data:` image URIs pass through; remote images are fetched and base64-inlined best-effort (graceful fallback to the original URL on CORS/fetch failure).
  - Branded header/footer, optional table of contents, and **print CSS** (`@page` + `@media print`) so it prints to PDF cleanly in any browser.
  - Options: `title`, `branded`, `includeToc`, `inlineImages`.
- **`DownloadMenu.tsx` (migrated path)** - its inline, unsanitized `convertMarkdownToHtml` is removed; the HTML download now routes through the shared utility. Same download behavior (filename, error toast), now sanitized/highlighted/print-friendly.
- **Live session "Export to HTML" (additional consumer, proof of reuse)** - a new `useExportSessionToHtml` hook (`hooks/data/sessions.ts`) plus an "Export to HTML" item in the per-session sidenav menu (`SidenavItem.tsx`), the live session-export surface next to Export to Excel/Word. This is what the screenshots above exercise.
- **`SessionExportMenu.tsx`** - also gains an HTML (.html) option for consistency (this export-menu component likewise consumes the shared utility).
- Tests: new `markdownToStyledHtml.test.ts` (12 cases), a `SessionExportMenu` HTML case, and the `SidenavItem` gating test updated to cover the new item.

## Guide for Testers

Preview env: `app.pr576.preview.bike4mind.com` (see Figures 1-2 for the expected result).

**Live session HTML export (the additional consumer)**
1. Open or create a session that has some formatted content (a heading, a fenced code block, a table).
2. In the left sidebar, hover the session row and click its kebab (three-dot) menu.
3. Click **Export to HTML**. Expect a `.html` file to download and a success toast.
4. Open the downloaded file in a browser. Expect a styled, self-contained page: branded header/footer, headings/tables rendered, code blocks syntax-highlighted, inline images shown, no console errors (Figure 2).
5. Use the browser's **Print** (Cmd/Ctrl+P). Expect a clean, printable layout (margins applied, no clipped content).

**Download menu HTML export (migrated path)**
6. On a completed assistant reply, click the reply's **Download** (save) icon to open its menu.
7. Click **HTML**. Expect a `.html` file to download, rendered by the same shared utility as step 4.

**Regression Checks**
8. From the sidenav session menu, confirm **Export to Excel** and **Export to Word** still work (unchanged paths).
9. From the reply Download menu, confirm **Markdown** and **DOCX** still download correctly.

## Additional Information

Scope note (per issue #30 acceptance criteria): the reusable utility, the `DownloadMenu` migration, self-contained images/SVG + code highlighting + branded header/footer, and an additional live consumer (session sidenav "Export to HTML") all ship here. Output modes: **single-file self-contained** is implemented (the default, what the in-browser download consumers need); the **multi-file** mode is documented as the alternative in the utility's doc comment. Server-side `marked` sites (published-page rendering, marketing report, email) are separate consumers and are intentionally out of scope for this change.

Evidence note: the screenshots exercise the live sidenav "Export to HTML" path end-to-end. The `DownloadMenu` HTML export calls the identical `renderMarkdownToStyledHtml` and is covered by the utility's unit tests; its in-app menu only appears on a completed (status `done`) assistant reply.

## Developer Notes (Optional)

- `renderMarkdownToStyledHtml(markdown, { title?, branded?, includeToc?, inlineImages? })` is the reusable building block - any future feature wanting a styled HTML document (e.g. research-report export) can call it instead of reinventing a markdown->HTML pipeline.
- Security model: the markdown body is untrusted; it is DOMPurify-sanitized before being wrapped in the trusted document shell, so sanitization never strips the export's own CSS. Scripts/handlers never survive (output opens as a page, not in a sandbox).
- Prism grammar coverage is centralized in `prism-languages`; export and in-app code rendering stay in sync because both import that one module.

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc