### PR TITLE
chore: set b4m-optihashi overlay pin to faddd9b87bc36e6478dc067e933d8eaa1b38844e

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "21dbc15bf04c97702b403616e9d097f323cfaf7f",
   "b4m-libreoncology": "46c40b7e942efadf81f98b219792eca4d32fb4aa",
-  "b4m-optihashi": "cd0f47730f2b7d16780603b05c4b810938ad1b91",
+  "b4m-optihashi": "faddd9b87bc36e6478dc067e933d8eaa1b38844e",
   "b4m-pi": "c95fc844445c8d3ae7b930acf6d4452ace25ae32",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Sets the b4m-optihashi overlay pin to faddd9b87bc36e6478dc067e933d8eaa1b38844e. Overlay-pin-only change; no application source changes.

https://claude.ai/code/session_01EgYuQGCALS5TZSzaxBXuru