### PR TITLE
docs(agents): document the persisted bound on direct-invoke resumes

### DIFF
--- a/apps/client/server/websocket/agentExecute.ts
+++ b/apps/client/server/websocket/agentExecute.ts
@@ -645,8 +645,10 @@ async function handlePermissionResponse(
   // Re-invoke Lambda to resume execution.
   // Note: checkpointDepth is not carried here - it lives in the SQS message from the previous
   // Lambda handoff, not in the AgentExecution document, so this handler cannot read it.
-  // The resumed Lambda starts at depth 0. This is safe: permission pauses are user-driven,
-  // not loop-driven, so they cannot cause runaway self-dispatch on their own.
+  // The resumed Lambda starts at depth 0. This is safe on two counts: permission pauses are
+  // user-driven, not loop-driven, so they cannot self-dispatch a runaway on their own; and the
+  // resume runs as status `continuing`, which the executor still bounds via the persisted
+  // `lambdaInvocationCount` guard (MAX_LAMBDA_HANDOFFS) - a counter the message payload cannot reset.
   await agentExecutionRepository.updateStatus(cmd.executionId, 'continuing');
 
   await lambdaClient.send(
@@ -762,7 +764,8 @@ async function handleGateResponse(
   await agentExecutionRepository.updateStatus(cmd.executionId, 'continuing');
 
   // Note: checkpointDepth is not carried here - same limitation as the permission_response
-  // path above. Gate resumes are user-driven and cannot cause a runaway loop on their own.
+  // path above. Gate resumes are user-driven and cannot cause a runaway loop on their own, and
+  // are likewise bounded by the persisted `lambdaInvocationCount` guard (MAX_LAMBDA_HANDOFFS).
   await lambdaClient.send(
     new InvokeCommand({
       FunctionName: Resource.AgentExecutor.name,


### PR DESCRIPTION
# Description

Closes #84

## What

Two comment edits in `agentExecute.ts`, at the permission_response and gate_response resume paths.

## Why

These paths intentionally do not carry `checkpointDepth`, so a resumed Lambda restarts at depth 0. The old comments said this was "safe" but didn't say why. It looked like a hole in the runaway-agent guard.

It isn't. Both paths resume as status `continuing`, which the executor caps via the persisted `lambdaInvocationCount` guard (`MAX_LAMBDA_HANDOFFS`) - a counter stored on the AgentExecution document that the message payload cannot reset. So the resume is already bounded; the checkpoint-depth reset is not an unbounded runaway.

The comments now name that guard, turning a "known gap" into a documented, intentional invariant. This resolves the last open item in #84 (the earlier PR covered the terminate-path test and the doc-arithmetic fix).

## Risk

None. Comment-only, no behavior change. The claim is verified from the code paths (`continuing` status -> `lambdaInvocationCount` guard); it does not assert anything about whether the guards are well-designed.
