### PR TITLE
refactor(cli): extract session lifecycle into session/lifecycle (#228)

### DIFF
--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -44,18 +44,15 @@ import {
   parseApiUrl,
   processFileReferences,
   formatStep,
-  extractCompactInstructions,
 } from './utils';
 import { getTokenCounter } from './utils/tokenCounter.js';
 import { ConversationContext, reconstructTurnBlocks } from './context/ConversationContext.js';
-import { buildCompactionPrompt, createCompactedSession } from './utils/compaction.js';
 import { createReactiveCompactionHandler } from './utils/reactiveCompaction.js';
 import { getProcessHooks } from './utils/processHooks.js';
 import {
   buildHandoffPrompt,
   parseHandoffResponse,
   formatHandoffOutput,
-  injectHandoffMessage,
   SHORT_SESSION_THRESHOLD,
   buildLocalHandoff,
   writeLocalHandoffFile,
@@ -131,7 +128,7 @@ import { logger } from './utils/Logger';
 import { startPeonNotifier, emitPeonSessionEnd } from './utils/peonNotifier';
 import packageJson from '../package.json';
 import type { ICreditTransactionResponse, ModelInfo } from '@bike4mind/common';
-import { CREDIT_DEDUCT_TRANSACTION_TYPES, ChatModels } from '@bike4mind/common';
+import { CREDIT_DEDUCT_TRANSACTION_TYPES } from '@bike4mind/common';
 import { USAGE_DAYS, MODEL_NAME_COLUMN_WIDTH, USAGE_CACHE_TTL } from './config/constants';
 import { mergeCommands } from './config/commands.js';
 import { SubagentOrchestrator } from './agents/SubagentOrchestrator.js';
@@ -170,6 +167,13 @@ import { buildAgent } from './bootstrap/buildAgent.js';
 import { wireAgentEvents } from './bootstrap/wireAgentEvents.js';
 import { dispatch as dispatchCommand } from './commands/registry.js';
 import { runTurn } from './session/turnController.js';
+import {
+  createFreshSession,
+  resumeSession,
+  compactSession,
+  rewindSession,
+  type SessionLifecycleContext,
+} from './session/lifecycle.js';
 import { printDecisions, printBlockers, printReviewGates } from './commands/handlers/workflowViews.js';
 
 interface PermissionPromptState {
@@ -1480,6 +1484,25 @@ function CliApp() {
     });
   handleMessageRef.current = handleMessage;
 
+  // Builds a React-free SessionLifecycleContext from the current render state
+  // (issue #228, phase 3). The create/resume/compact/rewind command handlers are
+  // thin wrappers over session/lifecycle.ts; the UI-bound pieces (console.clear,
+  // renderBanner, the interactive selectors, rewind prefill) stay in those wrappers.
+  const buildLifecycleContext = (): SessionLifecycleContext => ({
+    agent: state.agent,
+    sessionStore: state.sessionStore,
+    checkpointStore: state.checkpointStore,
+    defaultModel: state.config?.defaultModel,
+    contextContent: state.contextContent,
+    decisionStore: decisionStoreRef.current,
+    blockerStore: blockerStoreRef.current,
+    reviewGateStore: reviewGateStoreRef.current,
+    onSessionReplaced: () => {
+      usageCache = null;
+    },
+    drainReviewGatePrompt: dequeueReviewGatePrompt,
+  });
+
   /**
    * Handle background agent completion - runs agent to process results silently
    * without adding a user message to the conversation.
@@ -1691,36 +1714,6 @@ function CliApp() {
   /**
    * Recalculate session metadata from current messages
    */
-  const recalculateSessionMetadata = (messages: Message[]) => {
-    let totalTokens = 0;
-    let totalCost = 0;
-    let toolCallCount = 0;
-
-    for (const msg of messages) {
-      if (msg.metadata) {
-        if (msg.metadata.tokenUsage) {
-          totalTokens += msg.metadata.tokenUsage.total || 0;
-        }
-
-        if (msg.metadata.cost) {
-          totalCost += msg.metadata.cost;
-        }
-
-        // Count tool calls from steps (observations = completed tools)
-        if (msg.metadata.steps) {
-          const observations = msg.metadata.steps.filter(s => s.type === 'observation');
-          toolCallCount += observations.length;
-        }
-      }
-    }
-
-    return {
-      totalTokens,
-      totalCost,
-      toolCallCount,
-    };
-  };
-
   /**
    * Helper to display agents grouped by source
    */
@@ -2203,7 +2196,8 @@ function CliApp() {
           break;
         }
 
-        // Define handler for session selection
+        // Define handler for session selection; the load/handoff/install core
+        // lives in session/lifecycle.
         const handleSessionSelect = async (selectedSession: Session | null) => {
           setState(prev => ({ ...prev, sessionSelector: null }));
 
@@ -2211,49 +2205,7 @@ function CliApp() {
             return;
           }
 
-          // Load full session from disk
-          const loadedSession = await state.sessionStore.load(selectedSession.id);
-
-          if (!loadedSession) {
-            console.log(`❌ Failed to load session: ${selectedSession.name}`);
-            console.log('   The session file may be corrupted or deleted.');
-            return;
-          }
-
-          // Reinitialize logger for resumed session
-          await logger.initialize(loadedSession.id);
-          logger.debug('=== Session Resumed ===');
-
-          // Update checkpoint store for resumed session
-          if (state.checkpointStore) {
-            state.checkpointStore.setSessionId(loadedSession.id);
-          }
-
-          // Inject handoff as a system message so the AI picks up structured
-          // continuity context, not just raw chat history. injectHandoffMessage
-          // replaces any prior injected handoff to avoid stacking on repeated
-          // save/resume cycles.
-          const handoff = loadedSession.metadata.workflow?.handoff;
-          const sessionForState: Session = handoff
-            ? { ...loadedSession, messages: injectHandoffMessage(loadedSession.messages, handoff) }
-            : loadedSession;
-
-          // Update the session in the store (single source of truth)
-          setStoreSession(sessionForState);
-          useCliStore.getState().clearPendingMessages();
-
-          // Clear usage cache
-          usageCache = null;
-
-          console.log(`\n✅ Session resumed: "${sessionForState.name}"`);
-          console.log(
-            `📝 ${sessionForState.messages.length} messages | 🤖 ${sessionForState.model} | 📊 ${sessionForState.metadata.totalTokens.toLocaleString()} tokens\n`
-          );
-
-          if (handoff) {
-            console.log('🤝 Session handoff:\n');
-            console.log(formatHandoffOutput(handoff));
-          }
+          await resumeSession(buildLifecycleContext(), selectedSession);
         };
 
         // Show interactive selector
@@ -2491,67 +2443,7 @@ function CliApp() {
         console.clear();
         renderBanner();
 
-        // Create new session (preserving model from current session or config).
-        // Pinned-session mode (host board pane): keep the SAME uuid so the host's
-        // --resume still finds this conversation after a /clear.
-        const currentSession = useCliStore.getState().session;
-        const model = currentSession?.model || state.config?.defaultModel || ChatModels.CLAUDE_4_5_SONNET;
-        const clearPinnedId = process.env.B4M_SESSION_ID || process.env.B4M_RESUME_ID;
-        const newSession: Session = {
-          id: clearPinnedId ? (currentSession?.id ?? clearPinnedId) : uuidv4(),
-          name: `Session ${new Date().toLocaleString()}`,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-          model,
-          messages: [],
-          metadata: {
-            totalTokens: 0,
-            totalCost: 0,
-            toolCallCount: 0,
-          },
-        };
-
-        // Reinitialize logger with new session ID
-        await logger.initialize(newSession.id);
-        logger.debug('=== New Session Started via /clear ===');
-
-        // Reset workflow stores so old decisions/blockers don't leak into new session
-        decisionStoreRef.current.decisions = [];
-        blockerStoreRef.current.blockers = [];
-
-        // Update checkpoint store for new session
-        if (state.checkpointStore) {
-          state.checkpointStore.setSessionId(newSession.id);
-        }
-
-        // Update the session in the store (single source of truth)
-        setStoreSession(newSession);
-
-        // Clear pending messages from Zustand store
-        useCliStore.getState().clearPendingMessages();
-
-        // Drain any stale review gate prompt from the UI queue. The agent
-        // shouldn't be running during /clear, but guard against an in-flight
-        // gate Promise leaking by resolving it as a rejection so the agent
-        // unwinds cleanly if it ever does.
-        const staleGate = useCliStore.getState().reviewGatePrompt;
-        if (staleGate) {
-          dequeueReviewGatePrompt();
-          staleGate.resolve({ decision: 'rejected', note: 'Session cleared.' });
-        }
-
-        // Reset reviewGates *after* the drained gate's toolFn continuation
-        // runs. The continuation is scheduled as a microtask by the resolve()
-        // above, and it pushes a rejection entry into store.reviewGates.
-        // Clearing synchronously here would let that push leak into the new
-        // session; deferring to the next microtask ensures we replace the
-        // array after the push, dropping the ghost entry with the old array.
-        queueMicrotask(() => {
-          reviewGateStoreRef.current.reviewGates = [];
-        });
-
-        // Clear usage cache for fresh data
-        usageCache = null;
+        const newSession = await createFreshSession(buildLifecycleContext());
 
         console.log('New session started.');
         console.log(`\n📝 Session: ${newSession.name}  |  🤖 Model: ${newSession.model}  |  📊 Tokens: 0\n`);
@@ -2585,7 +2477,7 @@ function CliApp() {
           return;
         }
 
-        // Show interactive selector
+        // Show interactive selector; the actual rewind lives in session/lifecycle.
         const handleRewindSelect = async (messageIndex: number | null) => {
           setState(prev => ({ ...prev, rewindSelector: null }));
 
@@ -2594,54 +2486,11 @@ function CliApp() {
             return;
           }
 
-          const activeSession = useCliStore.getState().session;
-          if (!activeSession) {
-            console.log('❌ No active session');
-            return;
+          const result = await rewindSession(buildLifecycleContext(), messageIndex);
+          if (result) {
+            // Prefill the input with the selected message so the user can edit and re-send.
+            setState((prev: CliState) => ({ ...prev, prefillInput: result.prefill }));
           }
-
-          // Get the selected message content to prefill the input
-          const selectedMessage = activeSession.messages[messageIndex];
-          const prefillContent = selectedMessage?.content || '';
-
-          // Remove the selected message and all messages after it
-          // The user will re-send the message (possibly edited) from the input
-          const rewindedMessages = activeSession.messages.slice(0, messageIndex);
-
-          // Recalculate metadata
-          const newMetadata = recalculateSessionMetadata(rewindedMessages);
-
-          // Create updated session
-          const rewindedSession: Session = {
-            ...activeSession,
-            messages: rewindedMessages,
-            updatedAt: new Date().toISOString(),
-            metadata: {
-              ...newMetadata,
-              // Not derivable from message data - carry forward rather than zeroing
-              subagentCalls: activeSession.metadata.subagentCalls,
-              subagentTokens: activeSession.metadata.subagentTokens,
-              subagentCost: activeSession.metadata.subagentCost,
-              subagentUsage: activeSession.metadata.subagentUsage,
-            },
-          };
-
-          // Prefill the input with the selected message
-          setState((prev: CliState) => ({
-            ...prev,
-            prefillInput: prefillContent,
-          }));
-
-          // Update the session in the store (single source of truth)
-          setStoreSession(rewindedSession);
-          useCliStore.getState().clearPendingMessages();
-
-          // Save session
-          await state.sessionStore.save(rewindedSession);
-
-          console.log('✅ Conversation rewound successfully');
-          console.log(`📊 Current state: ${rewindedMessages.length} messages, ${newMetadata.totalTokens} tokens`);
-          console.log(`📝 Your message has been placed in the input. Edit and send when ready.\n`);
         };
 
         setState(prev => ({
@@ -3021,64 +2870,7 @@ function CliApp() {
       }
 
       case 'compact': {
-        const session = useCliStore.getState().session;
-        if (!session || !state.agent) {
-          console.log('No active session');
-          break;
-        }
-
-        if (session.messages.length < 6) {
-          console.log('Not enough messages to compact (need at least 6)');
-          break;
-        }
-
-        const userInstructions = args.join(' ') || undefined;
-
-        const { prompt: compactionPrompt, preservedMessages } = buildCompactionPrompt(session.messages, {
-          userInstructions,
-          claudeMdInstructions: extractCompactInstructions(state.contextContent || ''),
-        });
-
-        if (!compactionPrompt) {
-          console.log('Not enough messages to compact');
-          break;
-        }
-
-        console.log('\u{1F5DC}\uFE0F  Compacting conversation...\n');
-
-        // Set thinking state
-        useCliStore.getState().setIsThinking(true);
-
-        try {
-          // Use agent to generate summary (single iteration, no tools)
-          const result = await state.agent.run(compactionPrompt, { maxIterations: 1 });
-          const summary = result.finalAnswer;
-
-          // Save old session first
-          await state.sessionStore.save(session);
-          const oldSessionName = session.name;
-
-          // Create new compacted session
-          const newSession = createCompactedSession(
-            session,
-            summary,
-            preservedMessages,
-            !!(process.env.B4M_SESSION_ID || process.env.B4M_RESUME_ID)
-          );
-
-          // Reinitialize logger with new session ID
-          await logger.initialize(newSession.id);
-
-          // Update the session in the store (single source of truth)
-          setStoreSession(newSession);
-          useCliStore.getState().clearPendingMessages();
-
-          console.log('\u2705 Conversation compacted');
-          console.log(`\u{1F4DD} New session: ${newSession.name}`);
-          console.log(`\u{1F4BE} Previous session preserved: ${oldSessionName}\n`);
-        } finally {
-          useCliStore.getState().setIsThinking(false);
-        }
+        await compactSession(buildLifecycleContext(), { userInstructions: args.join(' ') || undefined });
         break;
       }
 

--- a/packages/cli/src/session/lifecycle.test.ts
+++ b/packages/cli/src/session/lifecycle.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createFreshSession,
+  resumeSession,
+  compactSession,
+  rewindSession,
+  recalculateSessionMetadata,
+  type SessionLifecycleContext,
+} from './lifecycle';
+import { useCliStore } from '../store';
+import type { Session, Message, SessionStore } from '../storage';
+import type { ReActAgent } from '@bike4mind/agents';
+import type { DecisionStore, BlockerStore, ReviewGateStore } from '../tools';
+
+/**
+ * Boundary tests for the extracted session lifecycle (issue #228, phase 3). They
+ * drive create / resume / compact / rewind with fake stores and a fake agent,
+ * asserting the session transitions they produce - no React/Ink render, which is
+ * the point of lifting these out of the root component. The active session is
+ * read from / written to the real Zustand store (the single source of truth), so
+ * each test seeds and resets it directly.
+ */
+
+// Logger.initialize touches the filesystem; the transitions under test don't
+// depend on its effect, so stub it out.
+vi.mock('../utils/Logger', () => ({
+  logger: { initialize: vi.fn(async () => undefined), debug: vi.fn() },
+}));
+
+const ISO = '2026-01-01T00:00:00.000Z';
+
+function message(role: Message['role'], content: string, overrides: Partial<Message> = {}): Message {
+  return { id: `${role}-${content}`, role, content, timestamp: ISO, ...overrides };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-1',
+    name: 'test session',
+    createdAt: ISO,
+    updatedAt: ISO,
+    model: 'claude-sonnet-4-6',
+    messages: [],
+    metadata: { totalTokens: 0, totalCost: 0, toolCallCount: 0 },
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Partial<SessionLifecycleContext> = {}): SessionLifecycleContext {
+  // Each fake implements only the slice the lifecycle touches. Keeping `base`
+  // typed as SessionLifecycleContext (not casting the whole object) means a new
+  // required field on the interface fails this test until a fake exists.
+  const base: SessionLifecycleContext = {
+    agent: { run: vi.fn(async () => ({ finalAnswer: 'summary text' })) } as unknown as ReActAgent,
+    sessionStore: {
+      save: vi.fn(async () => undefined),
+      load: vi.fn(async () => null),
+    } as unknown as SessionStore,
+    checkpointStore: { setSessionId: vi.fn() } as unknown as SessionLifecycleContext['checkpointStore'],
+    defaultModel: undefined,
+    contextContent: '',
+    decisionStore: { decisions: [] } as DecisionStore,
+    blockerStore: { blockers: [] } as BlockerStore,
+    reviewGateStore: { reviewGates: [] } as ReviewGateStore,
+    onSessionReplaced: vi.fn(),
+    drainReviewGatePrompt: vi.fn(),
+  };
+  return { ...base, ...overrides };
+}
+
+describe('session lifecycle', () => {
+  beforeEach(() => {
+    useCliStore.setState({
+      session: null,
+      pendingMessages: [],
+      messageQueue: [],
+      isThinking: false,
+      reviewGatePrompt: null,
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('recalculateSessionMetadata', () => {
+    it('sums token usage and counts observation steps across messages', () => {
+      const messages: Message[] = [
+        message('user', 'hi'),
+        message('assistant', 'a', {
+          metadata: {
+            tokenUsage: { prompt: 0, completion: 0, total: 30 },
+            cost: 0.5,
+            steps: [
+              { type: 'observation', content: 'tool', metadata: { timestamp: 0 } },
+              { type: 'thought', content: 'think', metadata: { timestamp: 0 } },
+            ],
+          },
+        }),
+        message('assistant', 'b', {
+          metadata: { tokenUsage: { prompt: 0, completion: 0, total: 12 }, steps: [] },
+        }),
+      ];
+
+      expect(recalculateSessionMetadata(messages)).toEqual({
+        totalTokens: 42,
+        totalCost: 0.5,
+        toolCallCount: 1,
+      });
+    });
+  });
+
+  describe('createFreshSession', () => {
+    it('installs an empty session, inheriting the current model, and resets workflow stores', async () => {
+      useCliStore
+        .getState()
+        .setSession(makeSession({ id: 'old', model: 'claude-opus-4-8', messages: [message('user', 'x')] }));
+      const decisionStore = { decisions: [{ id: 'd1' }] } as unknown as DecisionStore;
+      const blockerStore = { blockers: [{ id: 'b1' }] } as unknown as BlockerStore;
+      const onSessionReplaced = vi.fn();
+      const ctx = makeCtx({ decisionStore, blockerStore, onSessionReplaced });
+
+      const created = await createFreshSession(ctx);
+
+      expect(created.messages).toHaveLength(0);
+      expect(created.model).toBe('claude-opus-4-8'); // inherited from prior session
+      expect(created.id).not.toBe('old'); // fresh uuid when not pinned
+      expect(useCliStore.getState().session).toBe(created);
+      expect(decisionStore.decisions).toEqual([]);
+      expect(blockerStore.blockers).toEqual([]);
+      expect(ctx.checkpointStore!.setSessionId).toHaveBeenCalledWith(created.id);
+      expect(onSessionReplaced).toHaveBeenCalledOnce();
+    });
+
+    it('falls back to the configured default model when there is no current session', async () => {
+      const created = await createFreshSession(makeCtx({ defaultModel: 'claude-haiku-4-5-20251001' }));
+      expect(created.model).toBe('claude-haiku-4-5-20251001');
+    });
+
+    it('preserves the session id in pinned-session mode', async () => {
+      const prev = process.env.B4M_SESSION_ID;
+      process.env.B4M_SESSION_ID = 'pinned-123';
+      try {
+        useCliStore.getState().setSession(makeSession({ id: 'pinned-123' }));
+        const created = await createFreshSession(makeCtx());
+        expect(created.id).toBe('pinned-123');
+      } finally {
+        if (prev === undefined) delete process.env.B4M_SESSION_ID;
+        else process.env.B4M_SESSION_ID = prev;
+      }
+    });
+  });
+
+  describe('resumeSession', () => {
+    it('loads the selected session from disk and installs it', async () => {
+      const stored = makeSession({ id: 'saved-1', name: 'saved', messages: [message('user', 'earlier')] });
+      const load = vi.fn(async () => stored);
+      const ctx = makeCtx({ sessionStore: { load, save: vi.fn() } as unknown as SessionStore });
+
+      const result = await resumeSession(ctx, makeSession({ id: 'saved-1' }));
+
+      expect(load).toHaveBeenCalledWith('saved-1');
+      expect(result).toEqual(stored);
+      expect(useCliStore.getState().session).toEqual(stored);
+      expect(ctx.checkpointStore!.setSessionId).toHaveBeenCalledWith('saved-1');
+      expect(ctx.onSessionReplaced).toHaveBeenCalledOnce();
+    });
+
+    it('returns null and leaves the store untouched when the load fails', async () => {
+      const current = makeSession({ id: 'current' });
+      useCliStore.getState().setSession(current);
+      const ctx = makeCtx({
+        sessionStore: { load: vi.fn(async () => null), save: vi.fn() } as unknown as SessionStore,
+      });
+
+      const result = await resumeSession(ctx, makeSession({ id: 'missing' }));
+
+      expect(result).toBeNull();
+      expect(useCliStore.getState().session).toBe(current);
+      expect(ctx.onSessionReplaced).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('compactSession', () => {
+    it('is a no-op when there is no active session', async () => {
+      const run = vi.fn();
+      await compactSession(makeCtx({ agent: { run } as unknown as ReActAgent }));
+      expect(run).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when there are too few messages to compact', async () => {
+      useCliStore.getState().setSession(makeSession({ messages: [message('user', 'a'), message('assistant', 'b')] }));
+      const run = vi.fn();
+      await compactSession(makeCtx({ agent: { run } as unknown as ReActAgent }));
+      expect(run).not.toHaveBeenCalled();
+    });
+
+    it('summarizes and installs a compacted session, preserving the old one to disk', async () => {
+      const messages: Message[] = [
+        message('user', 'u1'),
+        message('assistant', 'a1'),
+        message('user', 'u2'),
+        message('assistant', 'a2'),
+        message('user', 'u3'),
+        message('assistant', 'a3'),
+      ];
+      const original = makeSession({ messages });
+      useCliStore.getState().setSession(original);
+      const run = vi.fn(async () => ({ finalAnswer: 'the summary' }));
+      const save = vi.fn(async () => undefined);
+      const ctx = makeCtx({
+        agent: { run } as unknown as ReActAgent,
+        sessionStore: { save, load: vi.fn() } as unknown as SessionStore,
+      });
+
+      await compactSession(ctx, { userInstructions: 'focus on X' });
+
+      expect(run).toHaveBeenCalledOnce();
+      expect(save).toHaveBeenCalledWith(original); // old session preserved first
+      const compacted = useCliStore.getState().session!;
+      expect(compacted.id).not.toBe(original.id);
+      expect(compacted.messages[0].content).toContain('the summary');
+      // default preserves the last 2 exchanges (4 messages) verbatim after the summary
+      expect(compacted.messages).toHaveLength(5);
+      expect(useCliStore.getState().isThinking).toBe(false);
+    });
+  });
+
+  describe('rewindSession', () => {
+    it('truncates to before the selected message, recalculates metadata, and returns the prefill', async () => {
+      const messages: Message[] = [
+        message('user', 'first'),
+        message('assistant', 'reply', {
+          metadata: { tokenUsage: { prompt: 0, completion: 0, total: 20 }, steps: [] },
+        }),
+        message('user', 'second'),
+        message('assistant', 'reply2', {
+          metadata: { tokenUsage: { prompt: 0, completion: 0, total: 50 }, steps: [] },
+        }),
+      ];
+      useCliStore
+        .getState()
+        .setSession(makeSession({ messages, metadata: { totalTokens: 70, totalCost: 0, toolCallCount: 0 } }));
+      const save = vi.fn(async () => undefined);
+      const ctx = makeCtx({ sessionStore: { save, load: vi.fn() } as unknown as SessionStore });
+
+      const result = await rewindSession(ctx, 2); // drop from the second user message on
+
+      expect(result).toEqual({ prefill: 'second' });
+      const session = useCliStore.getState().session!;
+      expect(session.messages).toHaveLength(2);
+      expect(session.metadata.totalTokens).toBe(20); // recomputed from the survivors
+      expect(save).toHaveBeenCalledWith(session);
+    });
+
+    it('returns null when there is no active session', async () => {
+      const result = await rewindSession(makeCtx(), 1);
+      expect(result).toBeNull();
+    });
+
+    it('still returns the prefill when persisting the rewind fails', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      useCliStore
+        .getState()
+        .setSession(
+          makeSession({
+            messages: [message('user', 'first'), message('assistant', 'reply'), message('user', 'second')],
+          })
+        );
+      const save = vi.fn(async () => {
+        throw new Error('disk full');
+      });
+      const ctx = makeCtx({ sessionStore: { save, load: vi.fn() } as unknown as SessionStore });
+
+      const result = await rewindSession(ctx, 2);
+
+      // Save rejected, but the caller must still get the prefill so the user's
+      // message survives in the input (regression guard for the extraction).
+      expect(result).toEqual({ prefill: 'second' });
+      expect(useCliStore.getState().session!.messages).toHaveLength(2);
+    });
+  });
+});

--- a/packages/cli/src/session/lifecycle.test.ts
+++ b/packages/cli/src/session/lifecycle.test.ts
@@ -133,6 +133,27 @@ describe('session lifecycle', () => {
       expect(onSessionReplaced).toHaveBeenCalledOnce();
     });
 
+    it('drains a stale review-gate prompt and clears the gate store after the resolve microtask', async () => {
+      useCliStore.getState().setSession(makeSession());
+      const resolve = vi.fn();
+      useCliStore.setState({
+        reviewGatePrompt: { id: 'gate-1', description: 'approve?', resolve },
+      });
+      const reviewGateStore = { reviewGates: [{ id: 'g1' }] } as unknown as ReviewGateStore;
+      const drainReviewGatePrompt = vi.fn();
+      const ctx = makeCtx({ reviewGateStore, drainReviewGatePrompt });
+
+      await createFreshSession(ctx);
+      // Flush the deferred reviewGates reset (queued as a microtask so it lands
+      // after the drained gate's resolve continuation).
+      await Promise.resolve();
+
+      // The stale gate is drained from the UI queue and rejected so the agent unwinds.
+      expect(drainReviewGatePrompt).toHaveBeenCalledOnce();
+      expect(resolve).toHaveBeenCalledWith({ decision: 'rejected', note: 'Session cleared.' });
+      expect(reviewGateStore.reviewGates).toEqual([]);
+    });
+
     it('falls back to the configured default model when there is no current session', async () => {
       const created = await createFreshSession(makeCtx({ defaultModel: 'claude-haiku-4-5-20251001' }));
       expect(created.model).toBe('claude-haiku-4-5-20251001');
@@ -165,6 +186,41 @@ describe('session lifecycle', () => {
       expect(useCliStore.getState().session).toEqual(stored);
       expect(ctx.checkpointStore!.setSessionId).toHaveBeenCalledWith('saved-1');
       expect(ctx.onSessionReplaced).toHaveBeenCalledOnce();
+    });
+
+    it('injects the handoff as a leading message when the loaded session has one', async () => {
+      const stored = makeSession({
+        id: 'saved-1',
+        messages: [message('user', 'earlier')],
+        metadata: {
+          totalTokens: 0,
+          totalCost: 0,
+          toolCallCount: 0,
+          workflow: {
+            decisions: [],
+            blockers: [],
+            handoff: {
+              summary: 'pick up where we left off',
+              keyFindings: [],
+              nextSteps: [],
+              pendingDecisions: [],
+              blockers: [],
+              generatedAt: ISO,
+            },
+          },
+        },
+      });
+      const ctx = makeCtx({
+        sessionStore: { load: vi.fn(async () => stored), save: vi.fn() } as unknown as SessionStore,
+      });
+
+      const result = await resumeSession(ctx, makeSession({ id: 'saved-1' }));
+
+      const installed = useCliStore.getState().session!;
+      expect(installed.messages).toHaveLength(2); // handoff message prepended to the original one
+      expect(installed.messages[0].role).toBe('user');
+      expect(installed.messages[0].content).toContain('pick up where we left off');
+      expect(result).toBe(installed);
     });
 
     it('returns null and leaves the store untouched when the load fails', async () => {
@@ -261,13 +317,11 @@ describe('session lifecycle', () => {
 
     it('still returns the prefill when persisting the rewind fails', async () => {
       vi.spyOn(console, 'error').mockImplementation(() => {});
-      useCliStore
-        .getState()
-        .setSession(
-          makeSession({
-            messages: [message('user', 'first'), message('assistant', 'reply'), message('user', 'second')],
-          })
-        );
+      useCliStore.getState().setSession(
+        makeSession({
+          messages: [message('user', 'first'), message('assistant', 'reply'), message('user', 'second')],
+        })
+      );
       const save = vi.fn(async () => {
         throw new Error('disk full');
       });

--- a/packages/cli/src/session/lifecycle.ts
+++ b/packages/cli/src/session/lifecycle.ts
@@ -1,0 +1,319 @@
+/**
+ * Session lifecycle (issue #228, phase 3).
+ *
+ * These functions own the create / resume / compact / rewind transitions of the
+ * active conversation. Like `runTurn` (phase 2) they are transport-agnostic and
+ * React-free: every collaborator arrives through `SessionLifecycleContext`, and
+ * the active session is read from / written to the Zustand store (the single
+ * source of truth from #227) rather than React state. `index.tsx` keeps only
+ * thin wrappers that supply the context and the genuinely UI-bound pieces -
+ * `console.clear()` / `renderBanner()`, the interactive session/rewind selectors,
+ * and the rewind input prefill.
+ */
+import { v4 as uuidv4 } from 'uuid';
+import { ChatModels } from '@bike4mind/common';
+import { ReActAgent } from '@bike4mind/agents';
+import type { SessionStore, Session, Message } from '../storage';
+import type { CheckpointStore } from '../storage/CheckpointStore.js';
+import type { DecisionStore, BlockerStore, ReviewGateStore } from '../tools';
+import { useCliStore } from '../store';
+import { logger } from '../utils/Logger';
+import { buildCompactionPrompt, createCompactedSession } from '../utils/compaction.js';
+import { extractCompactInstructions } from '../utils';
+import { injectHandoffMessage, formatHandoffOutput } from '../utils/handoff.js';
+
+/**
+ * Collaborators the lifecycle transitions need. React-free by design: stores and
+ * services are injectable, the workflow stores are the same singletons the tools
+ * mutate, and the two callbacks let `index.tsx` run its remaining side effects
+ * (memoised-usage invalidation, review-gate queue drain) without this module
+ * knowing about React. The active session is deliberately absent - it lives
+ * solely in `useCliStore`.
+ */
+export interface SessionLifecycleContext {
+  agent: ReActAgent | null;
+  sessionStore: SessionStore;
+  checkpointStore: CheckpointStore | null;
+  /** Fallback model when there is no current session to inherit from. */
+  defaultModel: string | undefined;
+  /** Raw CLAUDE.md content, mined for user compaction instructions. */
+  contextContent: string;
+  decisionStore: DecisionStore;
+  blockerStore: BlockerStore;
+  reviewGateStore: ReviewGateStore;
+  /** Invalidate memoised /usage data so the next read reflects the new session. */
+  onSessionReplaced: () => void;
+  /** Drain any in-flight review-gate prompt from the UI queue (create only). */
+  drainReviewGatePrompt: () => void;
+}
+
+/**
+ * Recompute the token / cost / tool-call totals from the messages themselves.
+ * Used by rewind, where dropping messages must shrink the metadata to match.
+ */
+export function recalculateSessionMetadata(messages: Message[]): {
+  totalTokens: number;
+  totalCost: number;
+  toolCallCount: number;
+} {
+  let totalTokens = 0;
+  let totalCost = 0;
+  let toolCallCount = 0;
+
+  for (const msg of messages) {
+    if (msg.metadata) {
+      if (msg.metadata.tokenUsage) {
+        totalTokens += msg.metadata.tokenUsage.total || 0;
+      }
+
+      if (msg.metadata.cost) {
+        totalCost += msg.metadata.cost;
+      }
+
+      // Count tool calls from steps (observations = completed tools)
+      if (msg.metadata.steps) {
+        const observations = msg.metadata.steps.filter(s => s.type === 'observation');
+        toolCallCount += observations.length;
+      }
+    }
+  }
+
+  return {
+    totalTokens,
+    totalCost,
+    toolCallCount,
+  };
+}
+
+/**
+ * Create a fresh empty session and install it as the active one (the /new and
+ * /clear core). Inherits the model from the current session, else the configured
+ * default, else Sonnet. In pinned-session mode (host board pane, B4M_SESSION_ID /
+ * B4M_RESUME_ID) the id is preserved so the host's --resume still finds this
+ * conversation after a clear. Resets workflow state and the checkpoint session so
+ * old decisions/blockers/checkpoints don't leak forward. Returns the new session
+ * for the caller to log; screen-clear and banner re-render stay in the wrapper.
+ */
+export async function createFreshSession(ctx: SessionLifecycleContext): Promise<Session> {
+  const currentSession = useCliStore.getState().session;
+  const model = currentSession?.model || ctx.defaultModel || ChatModels.CLAUDE_4_5_SONNET;
+  const clearPinnedId = process.env.B4M_SESSION_ID || process.env.B4M_RESUME_ID;
+  const newSession: Session = {
+    id: clearPinnedId ? (currentSession?.id ?? clearPinnedId) : uuidv4(),
+    name: `Session ${new Date().toLocaleString()}`,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    model,
+    messages: [],
+    metadata: {
+      totalTokens: 0,
+      totalCost: 0,
+      toolCallCount: 0,
+    },
+  };
+
+  await logger.initialize(newSession.id);
+  logger.debug('=== New Session Started via /clear ===');
+
+  // Reset workflow stores so old decisions/blockers don't leak into new session
+  ctx.decisionStore.decisions = [];
+  ctx.blockerStore.blockers = [];
+
+  ctx.checkpointStore?.setSessionId(newSession.id);
+
+  useCliStore.getState().setSession(newSession);
+  useCliStore.getState().clearPendingMessages();
+
+  // Drain any stale review gate prompt from the UI queue. The agent shouldn't be
+  // running during /clear, but guard against an in-flight gate Promise leaking by
+  // resolving it as a rejection so the agent unwinds cleanly if it ever does.
+  const staleGate = useCliStore.getState().reviewGatePrompt;
+  if (staleGate) {
+    ctx.drainReviewGatePrompt();
+    staleGate.resolve({ decision: 'rejected', note: 'Session cleared.' });
+  }
+
+  // Reset reviewGates *after* the drained gate's toolFn continuation runs. The
+  // continuation is scheduled as a microtask by the resolve() above, and it
+  // pushes a rejection entry into the store. Clearing synchronously here would
+  // let that push leak into the new session; deferring to the next microtask
+  // ensures we replace the array after the push, dropping the ghost entry.
+  queueMicrotask(() => {
+    ctx.reviewGateStore.reviewGates = [];
+  });
+
+  ctx.onSessionReplaced();
+
+  return newSession;
+}
+
+/**
+ * Load a previously-saved session and install it as the active one (the /resume
+ * selector core). Injects any structured handoff as a system message so the AI
+ * picks up continuity context, not just raw chat history. Prints the resume
+ * summary and handoff. Returns the session as installed (with handoff injected),
+ * or null if the file could not be loaded.
+ */
+export async function resumeSession(ctx: SessionLifecycleContext, selected: Session): Promise<Session | null> {
+  const loadedSession = await ctx.sessionStore.load(selected.id);
+
+  if (!loadedSession) {
+    console.log(`❌ Failed to load session: ${selected.name}`);
+    console.log('   The session file may be corrupted or deleted.');
+    return null;
+  }
+
+  await logger.initialize(loadedSession.id);
+  logger.debug('=== Session Resumed ===');
+
+  ctx.checkpointStore?.setSessionId(loadedSession.id);
+
+  // injectHandoffMessage replaces any prior injected handoff to avoid stacking
+  // on repeated save/resume cycles.
+  const handoff = loadedSession.metadata.workflow?.handoff;
+  const sessionForState: Session = handoff
+    ? { ...loadedSession, messages: injectHandoffMessage(loadedSession.messages, handoff) }
+    : loadedSession;
+
+  useCliStore.getState().setSession(sessionForState);
+  useCliStore.getState().clearPendingMessages();
+  ctx.onSessionReplaced();
+
+  console.log(`\n✅ Session resumed: "${sessionForState.name}"`);
+  console.log(
+    `📝 ${sessionForState.messages.length} messages | 🤖 ${sessionForState.model} | 📊 ${sessionForState.metadata.totalTokens.toLocaleString()} tokens\n`
+  );
+
+  if (handoff) {
+    console.log('🤝 Session handoff:\n');
+    console.log(formatHandoffOutput(handoff));
+  }
+
+  return sessionForState;
+}
+
+/**
+ * Summarise the conversation into a fresh compacted session (the /compact core).
+ * Runs the agent for a single no-tool iteration to produce the summary, preserves
+ * the old session to disk first, then installs the compacted one. No-ops (with a
+ * console notice) when there is no session/agent or too little to compact.
+ */
+export async function compactSession(
+  ctx: SessionLifecycleContext,
+  options: { userInstructions?: string } = {}
+): Promise<void> {
+  const session = useCliStore.getState().session;
+  if (!session || !ctx.agent) {
+    console.log('No active session');
+    return;
+  }
+
+  if (session.messages.length < 6) {
+    console.log('Not enough messages to compact (need at least 6)');
+    return;
+  }
+
+  const { prompt: compactionPrompt, preservedMessages } = buildCompactionPrompt(session.messages, {
+    userInstructions: options.userInstructions,
+    claudeMdInstructions: extractCompactInstructions(ctx.contextContent || ''),
+  });
+
+  if (!compactionPrompt) {
+    console.log('Not enough messages to compact');
+    return;
+  }
+
+  console.log('\u{1F5DC}\uFE0F  Compacting conversation...\n');
+
+  useCliStore.getState().setIsThinking(true);
+
+  try {
+    // Single iteration, no tools - just summarise.
+    const result = await ctx.agent.run(compactionPrompt, { maxIterations: 1 });
+    const summary = result.finalAnswer;
+
+    // Save old session first so it is preserved before we swap in the new one.
+    await ctx.sessionStore.save(session);
+    const oldSessionName = session.name;
+
+    const newSession = createCompactedSession(
+      session,
+      summary,
+      preservedMessages,
+      !!(process.env.B4M_SESSION_ID || process.env.B4M_RESUME_ID)
+    );
+
+    await logger.initialize(newSession.id);
+
+    useCliStore.getState().setSession(newSession);
+    useCliStore.getState().clearPendingMessages();
+
+    console.log('✅ Conversation compacted');
+    console.log(`\u{1F4DD} New session: ${newSession.name}`);
+    console.log(`\u{1F4BE} Previous session preserved: ${oldSessionName}\n`);
+  } finally {
+    useCliStore.getState().setIsThinking(false);
+  }
+}
+
+/**
+ * Truncate the conversation to before the selected message and persist it (the
+ * /rewind selector-resolve core). The dropped message's content is returned as
+ * `prefill` so the caller can seed the input for the user to edit and re-send.
+ * Returns null if there is no active session. Metadata is recalculated from the
+ * remaining messages; subagent totals are carried forward since they are not
+ * derivable from message data.
+ */
+export async function rewindSession(
+  ctx: SessionLifecycleContext,
+  messageIndex: number
+): Promise<{ prefill: string } | null> {
+  const activeSession = useCliStore.getState().session;
+  if (!activeSession) {
+    console.log('❌ No active session');
+    return null;
+  }
+
+  const selectedMessage = activeSession.messages[messageIndex];
+  const prefillContent = selectedMessage?.content || '';
+
+  // Remove the selected message and everything after it; the user re-sends
+  // (possibly edited) from the input.
+  const rewindedMessages = activeSession.messages.slice(0, messageIndex);
+  const newMetadata = recalculateSessionMetadata(rewindedMessages);
+
+  const rewindedSession: Session = {
+    ...activeSession,
+    messages: rewindedMessages,
+    updatedAt: new Date().toISOString(),
+    metadata: {
+      ...newMetadata,
+      // Not derivable from message data - carry forward rather than zeroing
+      subagentCalls: activeSession.metadata.subagentCalls,
+      subagentTokens: activeSession.metadata.subagentTokens,
+      subagentCost: activeSession.metadata.subagentCost,
+      subagentUsage: activeSession.metadata.subagentUsage,
+    },
+  };
+
+  useCliStore.getState().setSession(rewindedSession);
+  useCliStore.getState().clearPendingMessages();
+
+  try {
+    await ctx.sessionStore.save(rewindedSession);
+  } catch (error) {
+    // The in-memory rewind has already applied, so a persist failure must still
+    // return the prefill: otherwise the caller never seeds the input and the
+    // user silently loses the message they were about to edit and re-send.
+    console.error(
+      `\n❌ Rewound, but failed to save the session: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    return { prefill: prefillContent };
+  }
+
+  console.log('✅ Conversation rewound successfully');
+  console.log(`📊 Current state: ${rewindedMessages.length} messages, ${newMetadata.totalTokens} tokens`);
+  console.log(`📝 Your message has been placed in the input. Edit and send when ready.\n`);
+
+  return { prefill: prefillContent };
+}

--- a/packages/cli/src/session/lifecycle.ts
+++ b/packages/cli/src/session/lifecycle.ts
@@ -215,7 +215,7 @@ export async function compactSession(
 
   const { prompt: compactionPrompt, preservedMessages } = buildCompactionPrompt(session.messages, {
     userInstructions: options.userInstructions,
-    claudeMdInstructions: extractCompactInstructions(ctx.contextContent || ''),
+    claudeMdInstructions: extractCompactInstructions(ctx.contextContent),
   });
 
   if (!compactionPrompt) {


### PR DESCRIPTION
## Description

Phase 3 of the `index.tsx` decomposition (issue #228). The CLI root Ink component still owned the session-lifecycle transitions - create (`/new`, `/clear`), resume (`/resume`, `/sessions`), compact (`/compact`), and rewind (`/rewind`) - welded to React state so they couldn't be tested without mounting Ink.

This PR lifts those four transitions into a new transport-agnostic, React-free `session/lifecycle.ts` module, mirroring the Phase 2 `session/turnController.ts` seam. The active session is read from / written to the Zustand store (the single source of truth); `index.tsx` keeps only thin wrappers for the genuinely UI-bound pieces. Pure code movement, behavior-preserving.

Closes #228 (Phases 1 and 2 already landed in #341 and #364; this completes the final phase, so the tracking issue can close).

## Changes

- **New `packages/cli/src/session/lifecycle.ts`** — `SessionLifecycleContext` interface plus `createFreshSession`, `resumeSession`, `compactSession`, `rewindSession`, and the `recalculateSessionMetadata` helper (moved out of the component). Collaborators are injected; no React.
- **`packages/cli/src/index.tsx`** — the `new`/`clear`, `resume`/`sessions`, `rewind`, `compact` command handlers are now thin wrappers over the lifecycle functions, sharing one `buildLifecycleContext()`. UI-bound bits stay put: `console.clear()`/`renderBanner()`, the interactive session/rewind selectors, and the rewind input prefill. Removed the now-inlined `recalculateSessionMetadata` and four newly-unused imports. Net -208 lines.
- **New `packages/cli/src/session/lifecycle.test.ts`** — 12 boundary tests driving all four transitions with a fake agent and fake stores against the real Zustand store, no Ink render.
- Hardened rewind: persisting the truncated session is now best-effort, so a save failure still returns the input prefill and the user's message survives (previously it would have been silently lost from the input box).

## Guide for Testers

This is a behavior-preserving CLI refactor - the goal is to confirm the four session commands still behave exactly as before. Run the interactive CLI locally (`pnpm --filter @bike4mind/cli dev`, or the built `b4m` binary) and log in.

**Regression Checks**

1. Start a session and send 2-3 messages (e.g. type `hello` and wait for a reply). A reply appears with no errors.
2. Run `/save my-test`. Expect `✅ Session saved as "my-test"`.
3. Run `/new`. Expect the screen to clear, the banner to re-render, and `New session started.` followed by a session summary line showing `Tokens: 0`. The prior conversation is gone from the view.
4. Run `/resume` (or `/sessions`). Expect an interactive session picker listing saved sessions. Select `my-test`. Expect `✅ Session resumed: "my-test"` with a message/model/token summary, and the prior messages back in view.
5. Send 6+ messages in a session, then run `/compact`. Expect `🗜️  Compacting conversation...`, then `✅ Conversation compacted`, a new-session line, and a "Previous session preserved" line. The conversation continues with a summary in place of the old history.
6. In a session with 2+ exchanges, run `/rewind`. Expect an interactive picker of your prior user messages. Select one. Expect `✅ Conversation rewound successfully`, the conversation truncated to before that message, and the selected message pre-loaded in the input box ready to edit and re-send.
7. Run `/rewind` and cancel the picker (Esc). Expect `❌ Rewind operation cancelled` and no change to the conversation.
8. Edge cases: `/rewind` on an empty conversation prints "Conversation is empty. Nothing to rewind."; `/compact` with <6 messages prints "Not enough messages to compact".

**What NOT to test**

- No UI/visual changes - this is a CLI/terminal refactor only; no web app, admin settings, or MongoDB changes.
- No new behavior to exercise beyond the commands above; anything that worked before should work identically.

## Additional Information

- `pnpm --filter @bike4mind/cli typecheck` ✓
- `pnpm --filter @bike4mind/cli test` ✓ (1689 passed, incl. 12 new boundary tests)
- `eslint` on changed files ✓
- Self-reviewed via a workflow-backed code review; the one confirmed regression (rewind prefill lost on save failure) is fixed and has a regression test.

## Developer Notes

- `session/lifecycle.ts` completes the `session/` module family started by `turnController.ts`: session mutation is now callable and unit-testable without React, so future work (headless session ops, alternate transports) can drive create/resume/compact/rewind directly.
- `SessionLifecycleContext` is the injection seam - add a collaborator there rather than reaching back into the Ink component.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — N/A
- [ ] I have made the UI/UX feel good — N/A (no UI changes)
- [ ] I have made corresponding changes to the documentation (if applicable) — N/A
