### PR TITLE
fix(client): relax OTC/auth-strategy rate limits under E2E

### DIFF
--- a/apps/client/e2e/mfa.spec.ts
+++ b/apps/client/e2e/mfa.spec.ts
@@ -1,4 +1,4 @@
-import { type APIRequestContext, type Page } from '@playwright/test';
+import { type APIRequestContext } from '@playwright/test';
 import { test, expect } from './fixtures';
 import { apiCreateTestUser, apiGetOtcCode } from './helpers/api';
 import { enrollMfa, generateTotp } from './helpers/mfa';
@@ -8,40 +8,10 @@ import type { LoginPage } from './pages/LoginPage';
 /**
  * Submit the email step and read back the emailed OTC via the non-prod test endpoint (same
  * pattern as auth.spec.ts / signup.spec.ts - there is no test mailbox harness).
- *
- * Rate-limit escape hatch: the OTC send (5/15min per IP) and auth-strategy (10/min per IP)
- * checks are rate limited server-side; on the shared CI egress IP a run can legitimately draw
- * a 429, which leaves the form stuck on the email step. That's an infra limit, not a product
- * regression - annotate + skip rather than fail red (mirrors signup.spec.ts).
  */
-async function sendOtcAndReadCode(
-  page: Page,
-  loginPage: LoginPage,
-  request: APIRequestContext,
-  email: string
-): Promise<string> {
-  let rateLimited = false;
-  page.on('response', resp => {
-    if (resp.status() === 429 && /\/api\/(otc\/send|auth\/strategy)/.test(resp.url())) {
-      rateLimited = true;
-    }
-  });
-
+async function sendOtcAndReadCode(loginPage: LoginPage, request: APIRequestContext, email: string): Promise<string> {
   await loginPage.submitEmail(email);
-  try {
-    await loginPage.expectOtcStep();
-  } catch (err) {
-    if (rateLimited) {
-      test.info().annotations.push({
-        type: 'rate-limited',
-        description:
-          'OTC send / auth-strategy returned 429 on the shared CI IP (send 5/15min, strategy 10/min). ' +
-          'Infra rate limit, not a product failure - skipping.',
-      });
-      test.skip();
-    }
-    throw err;
-  }
+  await loginPage.expectOtcStep();
 
   return apiGetOtcCode(request, email);
 }
@@ -60,7 +30,7 @@ test.describe('MFA', () => {
 
     await basePage.clearAllStorage();
     await loginPage.goto();
-    const code = await sendOtcAndReadCode(page, loginPage, request, email);
+    const code = await sendOtcAndReadCode(loginPage, request, email);
     await loginPage.fillOtc(code);
     await loginPage.submitOtcExpectingMfa();
 
@@ -85,7 +55,7 @@ test.describe('MFA', () => {
 
     await basePage.clearAllStorage();
     await loginPage.goto();
-    const code = await sendOtcAndReadCode(page, loginPage, request, email);
+    const code = await sendOtcAndReadCode(loginPage, request, email);
     await loginPage.fillOtc(code);
     await loginPage.submitOtcExpectingMfa();
 

--- a/apps/client/e2e/pages/LoginPage.ts
+++ b/apps/client/e2e/pages/LoginPage.ts
@@ -14,8 +14,8 @@ export class LoginPage extends BasePage {
   }
 
   /**
-   * Fill the email and click Continue WITHOUT waiting for the OTC step, so a caller can inspect the
-   * strategy/send responses first (e.g. to skip on a shared-IP 429) before asserting the code step.
+   * Fill the email and click Continue WITHOUT waiting for the OTC step, so callers that assert the
+   * code step separately can call expectOtcStep() themselves.
    */
   async submitEmail(email: string) {
     await this.fillMuiInput(this.page.getByTestId('login-email-input').getByRole('textbox'), email);

--- a/apps/client/e2e/signup.spec.ts
+++ b/apps/client/e2e/signup.spec.ts
@@ -66,33 +66,8 @@ test.describe('Signup', () => {
     await basePage.clearAllStorage();
     await loginPage.goto();
 
-    // Rate-limit escape hatch. The OTC send (5/15min per IP) and auth-strategy (10/min per IP)
-    // checks are rate limited server-side; on the shared CI egress IP a run can legitimately draw
-    // a 429, which leaves the form stuck on the email step. That's an infra limit, not a product
-    // regression - annotate + skip rather than fail red. We flag only an *observed* 429, so any
-    // other reason the OTC step fails to appear still fails the test.
-    let rateLimited = false;
-    page.on('response', resp => {
-      if (resp.status() === 429 && /\/api\/(otc\/send|auth\/strategy)/.test(resp.url())) {
-        rateLimited = true;
-      }
-    });
-
-    await loginPage.submitEmail(email); // clicks Continue; sends the code (no OTC-step wait yet)
-    try {
-      await loginPage.expectOtcStep();
-    } catch (err) {
-      if (rateLimited) {
-        test.info().annotations.push({
-          type: 'rate-limited',
-          description:
-            'OTC send / auth-strategy returned 429 on the shared CI IP (send 5/15min, strategy 10/min). ' +
-            'Infra rate limit, not a product failure — skipping.',
-        });
-        test.skip();
-      }
-      throw err; // not a 429 → a real failure, surface it
-    }
+    await loginPage.submitEmail(email);
+    await loginPage.expectOtcStep();
 
     const code = await apiGetOtcCode(request, email);
     await loginPage.fillOtc(code);

--- a/apps/client/pages/api/auth/strategy.ts
+++ b/apps/client/pages/api/auth/strategy.ts
@@ -2,6 +2,7 @@ import { userRepository, identityProviderRepository } from '@bike4mind/database'
 import { baseApi } from '@server/middlewares/baseApi';
 import { checkBlockedIP } from '@server/middlewares/checkBlockedIP';
 import { rateLimit } from '@server/middlewares/rateLimit';
+import { isE2EEnabled } from '@server/utils/config';
 
 // This endpoint's response necessarily varies by account existence (it routes
 // SSO users to their provider), so it can't be made fully enumeration-proof
@@ -9,7 +10,15 @@ import { rateLimit } from '@server/middlewares/rateLimit';
 // per-IP rate limit instead.
 const handler = baseApi({ auth: false })
   .use(checkBlockedIP())
-  .use(rateLimit({ limit: 10, windowMs: 60 * 1000 }))
+  .use(
+    rateLimit({
+      // E2E (non-prod only - isE2EEnabled is hard-false on production) hammers this
+      // endpoint from a single shared CI IP alongside otc/send; lift the cap there
+      // so specs never race a 429 on the email step.
+      limit: () => (isE2EEnabled() ? Infinity : 10),
+      windowMs: 60 * 1000,
+    })
+  )
   .get(async (req, res) => {
     const { email } = req.query;
 

--- a/apps/client/pages/api/otc/__tests__/send.test.ts
+++ b/apps/client/pages/api/otc/__tests__/send.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+// Middleware is stripped so the handler body runs directly (same pattern as verify.test.ts).
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const chain: any = { use: () => chain, post: (fn: any) => fn };
+    return chain;
+  },
+}));
+vi.mock('@server/middlewares/checkBlockedIP', () => ({
+  checkBlockedIP: () => (_req: any, _res: any, next: any) => next?.(),
+}));
+vi.mock('@server/middlewares/rateLimit', () => ({ rateLimit: () => (_req: any, _res: any, next: any) => next?.() }));
+vi.mock('@server/utils/eventBus', () => ({ EmailEvents: { Send: { publish: vi.fn(() => Promise.resolve()) } } }));
+vi.mock('@server/utils/mailer/emailHelpers', () => ({ getLogoUrl: () => undefined }));
+vi.mock('jsonwebtoken', () => ({ default: { sign: () => 'signed-pending-token' } }));
+
+const mockIsE2EEnabled = vi.fn();
+vi.mock('@server/utils/config', () => ({
+  Config: { JWT_SECRET: 'test-secret' },
+  isE2EEnabled: () => mockIsE2EEnabled(),
+}));
+
+const mockTryReserveSlot = vi.fn();
+const mockConfirmReservation = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  pendingOtcTokenRepository: {
+    tryReserveSlot: (...a: any[]) => mockTryReserveSlot(...a),
+    confirmReservation: (...a: any[]) => mockConfirmReservation(...a),
+  },
+}));
+
+const mockSendOTC = vi.fn();
+vi.mock('@bike4mind/services', () => ({
+  userService: { sendOTC: (...a: any[]) => mockSendOTC(...a) },
+}));
+
+import handler from '@pages/api/otc/send';
+
+const EMAIL = 'someone@example.com';
+
+function makeReqRes(email: string = EMAIL) {
+  const { req, res } = createMocks({ method: 'POST' });
+  (req as any).body = { email };
+  return { req, res };
+}
+
+describe('/api/otc/send', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsE2EEnabled.mockReturnValue(false);
+    mockSendOTC.mockResolvedValue({ pendingToken: 'pending-token', nonce: 'real-nonce', code: '123456' });
+  });
+
+  it('passes cooldownMs 0 to tryReserveSlot when E2E is enabled, and the prod cooldown otherwise', async () => {
+    mockIsE2EEnabled.mockReturnValue(true);
+    mockTryReserveSlot.mockResolvedValue({ allowed: true, reservedAt: new Date('2026-01-01T00:00:00.000Z') });
+    mockConfirmReservation.mockResolvedValue(true);
+    const { req, res } = makeReqRes();
+
+    await handler(req, res);
+
+    expect(mockTryReserveSlot).toHaveBeenCalledWith(EMAIL, 0);
+  });
+
+  it('enforces the 30s prod cooldown when E2E is not enabled', async () => {
+    mockTryReserveSlot.mockResolvedValue({ allowed: true, reservedAt: new Date('2026-01-01T00:00:00.000Z') });
+    mockConfirmReservation.mockResolvedValue(true);
+    const { req, res } = makeReqRes();
+
+    await handler(req, res);
+
+    expect(mockTryReserveSlot).toHaveBeenCalledWith(EMAIL, 30 * 1000);
+  });
+
+  it('returns 429 with Retry-After when the reservation is not allowed', async () => {
+    mockTryReserveSlot.mockResolvedValue({ allowed: false, retryAfterSeconds: 12 });
+    const { req, res } = makeReqRes();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(429);
+    expect(res.getHeader('Retry-After')).toBe('12');
+    expect(mockSendOTC).not.toHaveBeenCalled();
+  });
+
+  it('never returns 200 with a pendingToken when confirmReservation loses the race', async () => {
+    // A newer concurrent request for the same email superseded this reservation
+    // before this one could persist its nonce - this token would never verify.
+    mockTryReserveSlot.mockResolvedValue({ allowed: true, reservedAt: new Date('2026-01-01T00:00:00.000Z') });
+    mockConfirmReservation.mockResolvedValue(false);
+    const { req, res } = makeReqRes();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getJSONData()).not.toHaveProperty('pendingToken');
+  });
+
+  it('confirms the reservation with the real nonce and returns 200 on the happy path', async () => {
+    const reservedAt = new Date('2026-01-01T00:00:00.000Z');
+    mockTryReserveSlot.mockResolvedValue({ allowed: true, reservedAt });
+    mockConfirmReservation.mockResolvedValue(true);
+    const { req, res } = makeReqRes();
+
+    await handler(req, res);
+
+    expect(mockConfirmReservation).toHaveBeenCalledWith(EMAIL, reservedAt, 'real-nonce', undefined);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ pendingToken: 'pending-token' });
+  });
+
+  it('persists the plaintext debugCode only when E2E is enabled', async () => {
+    mockIsE2EEnabled.mockReturnValue(true);
+    const reservedAt = new Date('2026-01-01T00:00:00.000Z');
+    mockTryReserveSlot.mockResolvedValue({ allowed: true, reservedAt });
+    mockConfirmReservation.mockResolvedValue(true);
+    const { req, res } = makeReqRes();
+
+    await handler(req, res);
+
+    expect(mockConfirmReservation).toHaveBeenCalledWith(EMAIL, reservedAt, 'real-nonce', '123456');
+  });
+});

--- a/apps/client/pages/api/otc/send.ts
+++ b/apps/client/pages/api/otc/send.ts
@@ -44,17 +44,19 @@ const handler = baseApi({ auth: false })
     }
 
     // Atomic per-recipient cooldown (enumeration-safe - see OTC_SEND_COOLDOWN_MS).
-    // tryReserveSlot atomically upserts a timestamp-gated placeholder; if a recent
-    // record already exists the upsert hits the unique-email index (E11000) and returns
-    // allowed:false. This replaces the previous check-then-act (non-atomic) pattern that
-    // allowed N concurrent requests to all read "no record" and all send an email.
-    // E2E (non-prod only) collapses the cooldown to 0 so repeated sends to the same
-    // address within a run never 429 - tryReserveSlot still writes/refreshes the
-    // PendingOtcToken record each time, so storeNonce and verify keep working below.
+    // tryReserveSlot atomically claims a reservation slot for this email; if the
+    // cooldown is still active, or a concurrent request already claimed it, it
+    // returns allowed:false. This replaces the previous check-then-act (non-atomic)
+    // pattern that allowed N concurrent requests to all read "no record" and all
+    // send an email. E2E (non-prod only) collapses the cooldown to 0 so repeated
+    // sends to the same address within a run never 429 on cooldown alone - the
+    // reservation is confirmed below with confirmReservation, which still detects
+    // (and rejects) a genuinely concurrent resend that would otherwise clobber
+    // this one's nonce.
     const cooldownMs = isE2EEnabled() ? 0 : OTC_SEND_COOLDOWN_MS;
-    const cooldownCheck = await pendingOtcTokenRepository.tryReserveSlot(normalizedEmail, cooldownMs);
-    if (!cooldownCheck.allowed) {
-      res.setHeader('Retry-After', String(cooldownCheck.retryAfterSeconds ?? 0));
+    const reservation = await pendingOtcTokenRepository.tryReserveSlot(normalizedEmail, cooldownMs);
+    if (!reservation.allowed) {
+      res.setHeader('Retry-After', String(reservation.retryAfterSeconds));
       return res.status(429).json({ error: 'Please wait before requesting another code.' });
     }
 
@@ -104,7 +106,19 @@ const handler = baseApi({ auth: false })
     // Playwright. Production never stores it - only the bcrypt hash lives (in the JWT).
     if (result.nonce) {
       const debugCode = isE2EEnabled() ? result.code : undefined;
-      await pendingOtcTokenRepository.storeNonce(normalizedEmail, result.nonce, debugCode);
+      const confirmed = await pendingOtcTokenRepository.confirmReservation(
+        normalizedEmail,
+        reservation.reservedAt,
+        result.nonce,
+        debugCode
+      );
+      if (!confirmed) {
+        // A newer concurrent request for this email superseded our reservation before
+        // we could persist our nonce - the token we'd return here could never verify,
+        // so tell the caller to retry instead of lying that it succeeded.
+        res.setHeader('Retry-After', '0');
+        return res.status(429).json({ error: 'Please wait before requesting another code.' });
+      }
     }
 
     // Uniform response - never reveals whether user exists

--- a/apps/client/pages/api/otc/send.ts
+++ b/apps/client/pages/api/otc/send.ts
@@ -21,7 +21,10 @@ const handler = baseApi({ auth: false })
   .use(checkBlockedIP())
   .use(
     rateLimit({
-      limit: 5,
+      // E2E (non-prod only - isE2EEnabled is hard-false on production) draws all sends
+      // from a single shared CI IP, so the per-IP cap is lifted there to let every
+      // OTC-requesting spec run to completion instead of racing a 429.
+      limit: () => (isE2EEnabled() ? Infinity : 5),
       windowMs: 15 * 60 * 1000, // 5 sends per 15 min per IP
     })
   )
@@ -45,7 +48,11 @@ const handler = baseApi({ auth: false })
     // record already exists the upsert hits the unique-email index (E11000) and returns
     // allowed:false. This replaces the previous check-then-act (non-atomic) pattern that
     // allowed N concurrent requests to all read "no record" and all send an email.
-    const cooldownCheck = await pendingOtcTokenRepository.tryReserveSlot(normalizedEmail, OTC_SEND_COOLDOWN_MS);
+    // E2E (non-prod only) collapses the cooldown to 0 so repeated sends to the same
+    // address within a run never 429 - tryReserveSlot still writes/refreshes the
+    // PendingOtcToken record each time, so storeNonce and verify keep working below.
+    const cooldownMs = isE2EEnabled() ? 0 : OTC_SEND_COOLDOWN_MS;
+    const cooldownCheck = await pendingOtcTokenRepository.tryReserveSlot(normalizedEmail, cooldownMs);
     if (!cooldownCheck.allowed) {
       res.setHeader('Retry-After', String(cooldownCheck.retryAfterSeconds ?? 0));
       return res.status(429).json({ error: 'Please wait before requesting another code.' });

--- a/apps/client/server/utils/config.test.ts
+++ b/apps/client/server/utils/config.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Real SST throws in the Resource property getter itself when a resource
 // isn't linked/provisioned on the current stage - simulate that here instead
@@ -122,5 +122,65 @@ describe('Config eager-read hardening', () => {
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('OPTIHASHI_API_URL'));
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('OVERWATCH_INGEST_ENABLED'));
     warnSpy.mockRestore();
+  });
+});
+
+describe('isE2EEnabled', () => {
+  const ENV_KEYS = ['E2E_ENDPOINTS_ENABLED', 'IS_LOCAL', 'NODE_ENV'] as const;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    savedEnv = Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]]));
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  it('is hard-false on production even when E2E_ENDPOINTS_ENABLED and dev-like env vars are set', async () => {
+    mockResourceWithUnlinked({ App: { stage: 'production' } });
+    process.env.E2E_ENDPOINTS_ENABLED = 'true';
+    process.env.IS_LOCAL = 'true';
+    process.env.NODE_ENV = 'development';
+
+    const { isE2EEnabled } = await import('./config');
+
+    expect(isE2EEnabled()).toBe(false);
+  });
+
+  it('is true on a non-production, non-staging stage when E2E_ENDPOINTS_ENABLED is set', async () => {
+    mockResourceWithUnlinked({ App: { stage: 'preview' } });
+    process.env.E2E_ENDPOINTS_ENABLED = 'true';
+    delete process.env.IS_LOCAL;
+    process.env.NODE_ENV = 'test';
+
+    const { isE2EEnabled } = await import('./config');
+
+    expect(isE2EEnabled()).toBe(true);
+  });
+
+  it('is false on staging with no E2E_ENDPOINTS_ENABLED flag, even though it is not production', async () => {
+    mockResourceWithUnlinked({ App: { stage: 'staging' } });
+    delete process.env.E2E_ENDPOINTS_ENABLED;
+    process.env.IS_LOCAL = 'true';
+
+    const { isE2EEnabled } = await import('./config');
+
+    expect(isE2EEnabled()).toBe(false);
+  });
+
+  it('falls back to isDevelopment on a plain non-deployed stage with no E2E flag', async () => {
+    mockResourceWithUnlinked({ App: { stage: 'test' } });
+    delete process.env.E2E_ENDPOINTS_ENABLED;
+    process.env.IS_LOCAL = 'true';
+    delete process.env.NODE_ENV;
+
+    const { isE2EEnabled } = await import('./config');
+
+    expect(isE2EEnabled()).toBe(true);
   });
 });

--- a/packages/database/src/__tests__/pending-otc-cooldown.test.ts
+++ b/packages/database/src/__tests__/pending-otc-cooldown.test.ts
@@ -8,7 +8,11 @@ import { setupMongoTest } from '../__test__/utils';
  * tryReserveSlot replaces the previous non-atomic check-then-act pattern
  * (getLastSentAt then storeNonce) that allowed N concurrent requests to all read
  * "no record" and all send an OTC email. The new approach uses the unique-email
- * index to ensure exactly one request wins per cooldown window.
+ * index (brand-new email) or a compare-and-swap on the existing record's
+ * createdAt (resend) to ensure exactly one request wins per cooldown window -
+ * including when cooldownMs is 0 (the E2E case), where a naive "createdAt < now"
+ * filter would otherwise let every racing request re-match a document a sibling
+ * had just written.
  */
 describe('PendingOtcToken.tryReserveSlot — atomic cooldown enforcement', () => {
   setupMongoTest();
@@ -63,12 +67,82 @@ describe('PendingOtcToken.tryReserveSlot — atomic cooldown enforcement', () =>
     expect(blocked).toHaveLength(4);
   });
 
-  it('storeNonce after a successful reserve updates the placeholder nonce', async () => {
-    await pendingOtcTokenRepository.tryReserveSlot(EMAIL, COOLDOWN_MS);
-    await pendingOtcTokenRepository.storeNonce(EMAIL, 'real-nonce-abc', 'debug-code');
+  it('confirmReservation after a successful reserve persists the real nonce', async () => {
+    const reservation = await pendingOtcTokenRepository.tryReserveSlot(EMAIL, COOLDOWN_MS);
+    expect(reservation.allowed).toBe(true);
+    if (!reservation.allowed) throw new Error('unreachable');
 
+    const confirmed = await pendingOtcTokenRepository.confirmReservation(
+      EMAIL,
+      reservation.reservedAt,
+      'real-nonce-abc',
+      'debug-code'
+    );
+
+    expect(confirmed).toBe(true);
     const doc = await PendingOtcTokenModel.findOne({ email: EMAIL });
     expect(doc?.nonce).toBe('real-nonce-abc');
     expect(doc?.debugCode).toBe('debug-code');
+  });
+
+  describe('cooldownMs = 0 (E2E bypass)', () => {
+    it('allows repeated sequential resends to the same email, each overwriting the last nonce', async () => {
+      const first = await pendingOtcTokenRepository.tryReserveSlot(EMAIL, 0);
+      expect(first.allowed).toBe(true);
+      if (!first.allowed) throw new Error('unreachable');
+      expect(await pendingOtcTokenRepository.confirmReservation(EMAIL, first.reservedAt, 'nonce-1')).toBe(true);
+
+      const second = await pendingOtcTokenRepository.tryReserveSlot(EMAIL, 0);
+      expect(second.allowed).toBe(true);
+      if (!second.allowed) throw new Error('unreachable');
+      expect(await pendingOtcTokenRepository.confirmReservation(EMAIL, second.reservedAt, 'nonce-2')).toBe(true);
+
+      const doc = await PendingOtcTokenModel.findOne({ email: EMAIL });
+      expect(doc?.nonce).toBe('nonce-2');
+      expect(await PendingOtcTokenModel.countDocuments({ email: EMAIL })).toBe(1);
+    });
+
+    it('concurrent reservations on an already-existing record: exactly one wins (the createdAt < now bug this closes)', async () => {
+      // Seed an existing record so every racer takes the "reclaim" branch, not the
+      // brand-new-email "create" branch (that one was already protected by the
+      // unique index, tested separately above).
+      await PendingOtcTokenModel.create({ email: EMAIL, nonce: 'seed-nonce', createdAt: new Date(Date.now() - 1000) });
+
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () => pendingOtcTokenRepository.tryReserveSlot(EMAIL, 0))
+      );
+
+      const allowed = results.filter(r => r.allowed);
+      const blocked = results.filter(r => !r.allowed);
+      // Before the fix, a bare `createdAt < now` filter matched for every racer
+      // (any prior write is always "in the past" relative to a later `now`), so
+      // all 5 would win here and each would silently overwrite the last one's nonce.
+      expect(allowed).toHaveLength(1);
+      expect(blocked).toHaveLength(4);
+    });
+
+    it('confirmReservation fails for a reservation a newer one has since superseded, instead of silently succeeding', async () => {
+      const first = await pendingOtcTokenRepository.tryReserveSlot(EMAIL, 0);
+      expect(first.allowed).toBe(true);
+      if (!first.allowed) throw new Error('unreachable');
+
+      // A second, later reservation for the same email lands before the first confirms
+      // - e.g. a genuinely concurrent resend that arrived just after the first claimed
+      // its slot but before it finished generating/sending its code.
+      const second = await pendingOtcTokenRepository.tryReserveSlot(EMAIL, 0);
+      expect(second.allowed).toBe(true);
+      if (!second.allowed) throw new Error('unreachable');
+
+      const firstConfirmed = await pendingOtcTokenRepository.confirmReservation(EMAIL, first.reservedAt, 'nonce-a');
+      expect(firstConfirmed).toBe(false);
+
+      const secondConfirmed = await pendingOtcTokenRepository.confirmReservation(EMAIL, second.reservedAt, 'nonce-b');
+      expect(secondConfirmed).toBe(true);
+
+      // Only the winner's nonce is ever persisted - never a value from a request
+      // that was told (incorrectly) that it succeeded.
+      const doc = await PendingOtcTokenModel.findOne({ email: EMAIL });
+      expect(doc?.nonce).toBe('nonce-b');
+    });
   });
 });

--- a/packages/database/src/models/auth/PendingOtcTokenModel.ts
+++ b/packages/database/src/models/auth/PendingOtcTokenModel.ts
@@ -78,56 +78,86 @@ export class PendingOtcTokenRepository {
   /**
    * Atomically enforce a per-recipient send cooldown before the OTC email is sent.
    *
-   * Returns `{ allowed: true }` when the slot was reserved (caller may proceed to
-   * generate and send the OTC); returns `{ allowed: false, retryAfterSeconds }` when
-   * the cooldown is still active.
+   * Returns `{ allowed: true, reservedAt }` when the slot was reserved (caller may
+   * proceed to generate and send the OTC, then MUST call `confirmReservation` with
+   * this same `reservedAt` to persist the real nonce - see that method for why the
+   * reservation alone isn't enough). Returns `{ allowed: false, retryAfterSeconds }`
+   * when the cooldown is still active or a concurrent request already claimed this
+   * slot.
    *
-   * Implementation (three steps):
-   * 1. Try to update an existing record whose createdAt is old enough (no upsert).
-   *    Only one concurrent request can match and update the same document - the
-   *    subsequent requests will find a recent createdAt and fall through to step 2.
-   * 2. If no old-enough record was updated, check whether a recent one exists.
-   *    If yes -> throttled.
-   * 3. If no record exists at all, create one. A plain insert (not upsert) lets the
-   *    unique-email index raise E11000 when two concurrent requests race, so exactly
-   *    one wins and the rest are treated as throttled.
-   *
-   * Callers MUST call `storeNonce` after OTC generation to replace the placeholder
-   * nonce written here with the real one.
+   * Implementation:
+   * 1. No existing record for this email - try to create one. A plain insert (not
+   *    upsert) lets the unique-email index raise E11000 when concurrent first-time
+   *    requests race, so exactly one wins and the rest are throttled.
+   * 2. Existing record younger than the cooldown window - throttled.
+   * 3. Existing record old enough - reclaim it via compare-and-swap on the
+   *    `createdAt` just read. This CAS is what actually enforces "only one
+   *    concurrent request wins" - a bare `createdAt < now` filter would let every
+   *    racing request re-match a document a sibling had *just* written (this is
+   *    what broke down when cooldownMs collapses to 0 for E2E: any prior write is
+   *    always "in the past" relative to a `now` evaluated moments later, so nothing
+   *    stopped every racer from re-claiming and silently clobbering the last
+   *    winner's nonce). The CAS fails deterministically for a loser instead.
    */
-  async tryReserveSlot(email: string, cooldownMs: number): Promise<{ allowed: boolean; retryAfterSeconds?: number }> {
+  async tryReserveSlot(
+    email: string,
+    cooldownMs: number
+  ): Promise<{ allowed: true; reservedAt: Date } | { allowed: false; retryAfterSeconds: number }> {
     const now = Date.now();
     const threshold = new Date(now - cooldownMs);
+    const reservedAt = new Date(now);
 
-    // Step 1: update an existing record that is past the cooldown window.
-    // No upsert - only matches documents that already exist and are old enough.
-    const updated = await PendingOtcTokenModel.findOneAndUpdate(
-      { email, createdAt: { $lt: threshold } },
-      { $set: { nonce: randomUUID(), createdAt: new Date(now), debugCode: null } },
-      { new: true }
-    );
-    if (updated) return { allowed: true };
-
-    // Step 2: no old-enough record was updated. Check if a recent record exists.
     const existing = await PendingOtcTokenModel.findOne({ email }).select('createdAt');
-    if (existing) {
-      const elapsed = Date.now() - existing.createdAt.getTime();
+
+    if (!existing) {
+      // No record for this email - try to create one.
+      // If concurrent requests race here, exactly one create wins; the rest hit E11000.
+      try {
+        await PendingOtcTokenModel.create({ email, nonce: randomUUID(), createdAt: reservedAt });
+        return { allowed: true, reservedAt };
+      } catch (err: unknown) {
+        if ((err as { code?: number }).code === 11000) {
+          const doc = await PendingOtcTokenModel.findOne({ email }).select('createdAt');
+          const elapsed = doc ? now - doc.createdAt.getTime() : cooldownMs;
+          return { allowed: false, retryAfterSeconds: Math.ceil(Math.max(0, cooldownMs - elapsed) / 1000) };
+        }
+        throw err;
+      }
+    }
+
+    if (existing.createdAt >= threshold) {
+      const elapsed = now - existing.createdAt.getTime();
       return { allowed: false, retryAfterSeconds: Math.ceil(Math.max(0, cooldownMs - elapsed) / 1000) };
     }
 
-    // Step 3: no record for this email - try to create one.
-    // If concurrent requests race here, exactly one create wins; the rest hit E11000.
-    try {
-      await PendingOtcTokenModel.create({ email, nonce: randomUUID(), createdAt: new Date(now) });
-      return { allowed: true };
-    } catch (err: unknown) {
-      if ((err as { code?: number }).code === 11000) {
-        const doc = await PendingOtcTokenModel.findOne({ email }).select('createdAt');
-        const elapsed = doc ? Date.now() - doc.createdAt.getTime() : cooldownMs;
-        return { allowed: false, retryAfterSeconds: Math.ceil(Math.max(0, cooldownMs - elapsed) / 1000) };
-      }
-      throw err;
+    const claimed = await PendingOtcTokenModel.findOneAndUpdate(
+      { email, createdAt: existing.createdAt },
+      { $set: { createdAt: reservedAt } },
+      { new: true }
+    );
+    if (!claimed) {
+      // A concurrent request claimed this same stale record between our read and write.
+      return { allowed: false, retryAfterSeconds: 0 };
     }
+    return { allowed: true, reservedAt };
+  }
+
+  /**
+   * Persist the real nonce for a reservation made by `tryReserveSlot`, guarded by a
+   * compare-and-swap on `reservedAt`. OTC generation runs between the reservation and
+   * this call (and may await IO); if a *newer* reservation for the same email lands
+   * in that window - e.g. a genuinely concurrent resend - this CAS fails and returns
+   * `false`. The caller MUST treat that as a failure, not a success: the nonce it's
+   * holding would never verify, since another request has already superseded this
+   * record.
+   */
+  async confirmReservation(email: string, reservedAt: Date, nonce: string, debugCode?: string): Promise<boolean> {
+    const result = await PendingOtcTokenModel.findOneAndUpdate(
+      { email, createdAt: reservedAt },
+      { $set: { nonce, debugCode: debugCode ?? null } },
+      { new: true }
+    );
+    return result !== null;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Under E2E only (hard-false on production via `isE2EEnabled()`), lift the per-IP rate caps on `/api/otc/send` (5/15min) and `/api/auth/strategy` (10/min), and collapse the per-recipient OTC send cooldown to 0, so the shared-CI-IP "unauthenticated" Playwright project (auth + signup + mfa specs) stops racing 429s.
- Remove the now-dead client-side 429 escape hatches / `test.skip()` branches in `signup.spec.ts` and `mfa.spec.ts` so those tests run their real assertions instead of silently skipping.
- Rewrite `PendingOtcTokenModel.tryReserveSlot` to a read-then-compare-and-swap flow, and add a new `confirmReservation` step, to close a concurrent-reservation race: with the cooldown collapsed to 0, truly-concurrent first-time sends to the same email could previously all return 200 while only the last writer's nonce was actually verifiable. Now exactly one request wins per reservation window; losers get a real 429 instead of a silently dead nonce.

## Test plan
- [x] `pnpm turbo:typecheck` (36/36 green)
- [x] `pnpm lint:check` (clean)
- [x] `@bike4mind/database` full suite (647/647 passed)
- [x] `apps/client` full suite (5690 passed, 81 pre-existing skips, 0 failed)
- [x] Live real-browser verification: 11 sequential `/api/otc/send` + 11 `/api/auth/strategy` requests from one IP, all 200 (no 429)
- [x] Live real-browser verification: concurrent same-email sends now yield exactly one verifiable nonce (no silent double-200)
- [ ] Full "unauthenticated" Playwright project green from a single IP (needs CI's environment; local runs are blocked by an unrelated missing `@bike4mind/mcp` build-output issue, tracked separately)