### PR TITLE
chore(premium): set b4m-optihashi overlay pin to ffc769f04fb6bb3ef004e23358c6984068c48f31

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "21dbc15bf04c97702b403616e9d097f323cfaf7f",
   "b4m-libreoncology": "46c40b7e942efadf81f98b219792eca4d32fb4aa",
-  "b4m-optihashi": "faddd9b87bc36e6478dc067e933d8eaa1b38844e",
+  "b4m-optihashi": "ffc769f04fb6bb3ef004e23358c6984068c48f31",
   "b4m-pi": "c95fc844445c8d3ae7b930acf6d4452ace25ae32",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Overlay-pin-only change: bumps the `b4m-optihashi` pin in `premium-overlay.lock.json` to `ffc769f04fb6bb3ef004e23358c6984068c48f31`. No application source changes; the other four overlay pins are unchanged.

A preview deploy validates the host build against the new overlay SHA before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)