### PR TITLE
refactor(client): dedupe chat panel controls, copy-markdown, and drop overlay

### DIFF
--- a/apps/client/app/components/Session/ChatPanelControls.tsx
+++ b/apps/client/app/components/Session/ChatPanelControls.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/joy';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import VerticalSplitIcon from '@mui/icons-material/VerticalSplit';
+import HorizontalSplitIcon from '@mui/icons-material/HorizontalSplit';
+import { setSessionLayout } from '@client/app/hooks/useSessionLayout';
+import { useCopySessionMarkdown } from './useCopySessionMarkdown';
+
+interface ChatPanelControlsProps {
+  /** data-testid prefix, e.g. 'docked-chat' or 'floating-chat' */
+  testIdPrefix: string;
+  /** Current docked layout; highlights the matching dock button and is recorded
+   *  as previousLayout when switching to float. Omit in the floating window. */
+  activeLayout?: 'dockRight' | 'dockBottom';
+  /** Render the "Float" button (docked panels only). */
+  showFloat?: boolean;
+}
+
+/**
+ * The window-control cluster shared by DockedChatPanel and FloatingChatWindow:
+ * copy-as-markdown, optional Float, and the two dock-direction buttons.
+ * Panel-specific trailing buttons (Minimize/Close) stay in the panels.
+ */
+const ChatPanelControls: React.FC<ChatPanelControlsProps> = ({ testIdPrefix, activeLayout, showFloat = false }) => {
+  const { copyMarkdown, copied } = useCopySessionMarkdown();
+
+  return (
+    <>
+      <Tooltip title={copied ? 'Copied!' : 'Copy chat as Markdown'} disableInteractive>
+        <IconButton
+          size="sm"
+          variant="plain"
+          color={copied ? 'success' : 'neutral'}
+          onClick={copyMarkdown}
+          data-testid={`${testIdPrefix}-copy-markdown`}
+          sx={{ '--IconButton-size': '28px' }}
+        >
+          {copied ? <CheckIcon sx={{ fontSize: 16 }} /> : <ContentCopyIcon sx={{ fontSize: 14 }} />}
+        </IconButton>
+      </Tooltip>
+      {showFloat && (
+        <Tooltip title="Float" disableInteractive>
+          <IconButton
+            size="sm"
+            variant="plain"
+            color="neutral"
+            onClick={() => setSessionLayout({ layout: 'floatingChat', previousLayout: activeLayout })}
+            data-testid={`${testIdPrefix}-float`}
+            sx={{ '--IconButton-size': '28px' }}
+          >
+            <OpenInNewIcon sx={{ fontSize: 16 }} />
+          </IconButton>
+        </Tooltip>
+      )}
+      <Tooltip title="Dock right" disableInteractive>
+        <IconButton
+          size="sm"
+          variant={activeLayout === 'dockRight' ? 'soft' : 'plain'}
+          color={activeLayout === 'dockRight' ? 'primary' : 'neutral'}
+          onClick={() => setSessionLayout({ layout: 'dockRight' })}
+          data-testid={`${testIdPrefix}-dock-right`}
+          sx={{ '--IconButton-size': '28px' }}
+        >
+          <VerticalSplitIcon sx={{ fontSize: 16 }} />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Dock bottom" disableInteractive>
+        <IconButton
+          size="sm"
+          variant={activeLayout === 'dockBottom' ? 'soft' : 'plain'}
+          color={activeLayout === 'dockBottom' ? 'primary' : 'neutral'}
+          onClick={() => setSessionLayout({ layout: 'dockBottom' })}
+          data-testid={`${testIdPrefix}-dock-bottom`}
+          sx={{ '--IconButton-size': '28px' }}
+        >
+          <HorizontalSplitIcon sx={{ fontSize: 16 }} />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+};
+
+export default ChatPanelControls;

--- a/apps/client/app/components/Session/DockedChatPanel.tsx
+++ b/apps/client/app/components/Session/DockedChatPanel.tsx
@@ -1,18 +1,10 @@
 'use client';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { Box, IconButton, Typography, Tooltip } from '@mui/joy';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import VerticalSplitIcon from '@mui/icons-material/VerticalSplit';
-import HorizontalSplitIcon from '@mui/icons-material/HorizontalSplit';
 import CloseIcon from '@mui/icons-material/Close';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import CheckIcon from '@mui/icons-material/Check';
 import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSessionLayout';
-import { useSessions } from '@client/app/contexts/SessionsContext';
-import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
-import type { IChatHistoryItemDocument } from '@bike4mind/common';
-import { convertSessionToMarkdown } from '@client/app/utils/sessionMarkdownExport';
+import ChatPanelControls from './ChatPanelControls';
 
 interface DockedChatPanelProps {
   children: React.ReactNode;
@@ -20,43 +12,7 @@ interface DockedChatPanelProps {
 }
 
 const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActions }) => {
-  const [copied, setCopied] = useState(false);
   const layout = useSessionLayout(s => s.layout);
-  const { currentSessionId } = useSessions();
-  const queryClient = useQueryClient();
-
-  const handleCopyMarkdown = useCallback(async () => {
-    if (!currentSessionId) return;
-    try {
-      const queryData = queryClient.getQueryData<InfiniteData<{ data: IChatHistoryItemDocument[] }>>([
-        'quests',
-        'session',
-        currentSessionId,
-      ]);
-      if (!queryData?.pages) return;
-
-      const quests = queryData.pages.flatMap(p => p.data).reverse();
-      const markdown = convertSessionToMarkdown(quests);
-
-      await navigator.clipboard.writeText(markdown);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy markdown:', err);
-    }
-  }, [currentSessionId, queryClient]);
-
-  const handleSwitchToFloat = useCallback(() => {
-    setSessionLayout({ layout: 'floatingChat', previousLayout: layout });
-  }, [layout]);
-
-  const handleSwitchToDockRight = useCallback(() => {
-    setSessionLayout({ layout: 'dockRight' });
-  }, []);
-
-  const handleSwitchToDockBottom = useCallback(() => {
-    setSessionLayout({ layout: 'dockBottom' });
-  }, []);
 
   const handleClose = useCallback(() => {
     setSessionLayout({ layout: 'floatingChat' });
@@ -102,54 +58,11 @@ const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActio
           {/* Session actions first (headerActions leads with the primary New Chat),
               then window controls. */}
           {headerActions}
-          <Tooltip title={copied ? 'Copied!' : 'Copy chat as Markdown'} disableInteractive>
-            <IconButton
-              size="sm"
-              variant="plain"
-              color={copied ? 'success' : 'neutral'}
-              onClick={handleCopyMarkdown}
-              data-testid="docked-chat-copy-markdown"
-              sx={{ '--IconButton-size': '28px' }}
-            >
-              {copied ? <CheckIcon sx={{ fontSize: 16 }} /> : <ContentCopyIcon sx={{ fontSize: 14 }} />}
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Float" disableInteractive>
-            <IconButton
-              size="sm"
-              variant="plain"
-              color="neutral"
-              onClick={handleSwitchToFloat}
-              data-testid="docked-chat-float"
-              sx={{ '--IconButton-size': '28px' }}
-            >
-              <OpenInNewIcon sx={{ fontSize: 16 }} />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Dock right" disableInteractive>
-            <IconButton
-              size="sm"
-              variant={layout === 'dockRight' ? 'soft' : 'plain'}
-              color={layout === 'dockRight' ? 'primary' : 'neutral'}
-              onClick={handleSwitchToDockRight}
-              data-testid="docked-chat-dock-right"
-              sx={{ '--IconButton-size': '28px' }}
-            >
-              <VerticalSplitIcon sx={{ fontSize: 16 }} />
-            </IconButton>
-          </Tooltip>
-          <Tooltip title="Dock bottom" disableInteractive>
-            <IconButton
-              size="sm"
-              variant={layout === 'dockBottom' ? 'soft' : 'plain'}
-              color={layout === 'dockBottom' ? 'primary' : 'neutral'}
-              onClick={handleSwitchToDockBottom}
-              data-testid="docked-chat-dock-bottom"
-              sx={{ '--IconButton-size': '28px' }}
-            >
-              <HorizontalSplitIcon sx={{ fontSize: 16 }} />
-            </IconButton>
-          </Tooltip>
+          <ChatPanelControls
+            testIdPrefix="docked-chat"
+            activeLayout={layout === 'dockRight' || layout === 'dockBottom' ? layout : undefined}
+            showFloat
+          />
           <Tooltip title="Close" disableInteractive>
             <IconButton
               size="sm"

--- a/apps/client/app/components/Session/FloatingChatWindow.tsx
+++ b/apps/client/app/components/Session/FloatingChatWindow.tsx
@@ -9,15 +9,8 @@ import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import CloseIcon from '@mui/icons-material/Close';
 import MinimizeIcon from '@mui/icons-material/Minimize';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import CheckIcon from '@mui/icons-material/Check';
-import VerticalSplitIcon from '@mui/icons-material/VerticalSplit';
-import HorizontalSplitIcon from '@mui/icons-material/HorizontalSplit';
 import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSessionLayout';
-import { useSessions } from '@client/app/contexts/SessionsContext';
-import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
-import type { IChatHistoryItemDocument } from '@bike4mind/common';
-import { convertSessionToMarkdown } from '@client/app/utils/sessionMarkdownExport';
+import ChatPanelControls from './ChatPanelControls';
 
 // react-draggable v4.7 types DraggableProps to cover nodeRef/handle/position/
 // bounds/onDrag/onStop directly, so no cast is needed.
@@ -91,9 +84,6 @@ const getCursorForHandle = (position: string): string => {
 const FloatingChatWindow: React.FC<FloatingChatWindowProps> = ({ children, headerActions }) => {
   const nodeRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const { currentSessionId } = useSessions();
-  const queryClient = useQueryClient();
 
   // Get state from Zustand store
   const position = useSessionLayout(s => s.floatingChatPosition);
@@ -113,28 +103,6 @@ const FloatingChatWindow: React.FC<FloatingChatWindowProps> = ({ children, heade
     el.addEventListener('wheel', handleWheel, { passive: true });
     return () => el.removeEventListener('wheel', handleWheel);
   }, [isMinimized]);
-
-  // Copy entire chat history as markdown to clipboard
-  const handleCopyMarkdown = useCallback(async () => {
-    if (!currentSessionId) return;
-    try {
-      const queryData = queryClient.getQueryData<InfiniteData<{ data: IChatHistoryItemDocument[] }>>([
-        'quests',
-        'session',
-        currentSessionId,
-      ]);
-      if (!queryData?.pages) return;
-
-      const quests = queryData.pages.flatMap(p => p.data).reverse(); // chronological order
-      const markdown = convertSessionToMarkdown(quests);
-
-      await navigator.clipboard.writeText(markdown);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy markdown:', err);
-    }
-  }, [currentSessionId, queryClient]);
 
   // Local state for drag/resize operations (for smooth updates)
   const [localPosition, setLocalPosition] = useState(position);
@@ -456,42 +424,7 @@ const FloatingChatWindow: React.FC<FloatingChatWindowProps> = ({ children, heade
             onPointerDown={e => e.stopPropagation()}
           >
             {headerActions}
-            <Tooltip title={copied ? 'Copied!' : 'Copy chat as Markdown'} disableInteractive>
-              <IconButton
-                size="sm"
-                variant="plain"
-                color={copied ? 'success' : 'neutral'}
-                onClick={handleCopyMarkdown}
-                data-testid="floating-chat-copy-markdown"
-                sx={{ '--IconButton-size': '28px' }}
-              >
-                {copied ? <CheckIcon sx={{ fontSize: 16 }} /> : <ContentCopyIcon sx={{ fontSize: 14 }} />}
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Dock right" disableInteractive>
-              <IconButton
-                size="sm"
-                variant="plain"
-                color="neutral"
-                onClick={() => setSessionLayout({ layout: 'dockRight' })}
-                data-testid="floating-chat-dock-right"
-                sx={{ '--IconButton-size': '28px' }}
-              >
-                <VerticalSplitIcon sx={{ fontSize: 16 }} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Dock bottom" disableInteractive>
-              <IconButton
-                size="sm"
-                variant="plain"
-                color="neutral"
-                onClick={() => setSessionLayout({ layout: 'dockBottom' })}
-                data-testid="floating-chat-dock-bottom"
-                sx={{ '--IconButton-size': '28px' }}
-              >
-                <HorizontalSplitIcon sx={{ fontSize: 16 }} />
-              </IconButton>
-            </Tooltip>
+            <ChatPanelControls testIdPrefix="floating-chat" />
             <Tooltip title="Minimize" disableInteractive>
               <IconButton
                 size="sm"

--- a/apps/client/app/components/Session/SessionContainer.tsx
+++ b/apps/client/app/components/Session/SessionContainer.tsx
@@ -148,6 +148,33 @@ const PendingFirstMessage: FC<{ message: string; isFullWidth?: boolean }> = ({ m
   </Box>
 );
 
+/** Full-container blur overlay shown while files are dragged over the chat. */
+const DropFilesOverlay: FC = () => (
+  <Box
+    sx={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: theme => theme.palette.session.overlayBackground,
+      backdropFilter: 'blur(10px)',
+      zIndex: 110,
+      outline: '2px dashed',
+      outlineColor: 'primary',
+      outlineOffset: '-10px',
+    }}
+  >
+    <Box sx={{ textAlign: 'center', display: 'flex', gap: '.5rem', zIndex: 110 }}>
+      <CloudUploadIcon />
+      <span>Drop files here to upload</span>
+    </Box>
+  </Box>
+);
+
 const SessionContainer: FC<SessionLayoutProps> = ({
   listClosed,
   currentSessionId,
@@ -429,31 +456,7 @@ const SessionContainer: FC<SessionLayoutProps> = ({
             onDragOver={handleDragOver}
             onDrop={handleDrop}
           >
-            {isDraggingOver && (
-              <Box
-                sx={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  height: '100%',
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  backgroundColor: (theme: any) => theme.palette.session.overlayBackground,
-                  backdropFilter: 'blur(10px)',
-                  zIndex: 110,
-                  outline: '2px dashed',
-                  outlineColor: 'primary',
-                  outlineOffset: '-10px',
-                }}
-              >
-                <Box sx={{ textAlign: 'center', display: 'flex', gap: '.5rem', zIndex: 110 }}>
-                  <CloudUploadIcon />
-                  <span>Drop files here to upload</span>
-                </Box>
-              </Box>
-            )}
+            {isDraggingOver && <DropFilesOverlay />}
             <Box
               sx={{
                 width: '100%',
@@ -578,33 +581,7 @@ const SessionContainer: FC<SessionLayoutProps> = ({
               onDragOver={handleDragOver}
               onDrop={handleDrop}
             >
-              {isDraggingOver && (
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    width: '100%',
-                    height: '100%',
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    backgroundColor: (theme: unknown) =>
-                      (theme as { palette: { session: { overlayBackground: string } } }).palette.session
-                        .overlayBackground,
-                    backdropFilter: 'blur(10px)',
-                    zIndex: 110,
-                    outline: '2px dashed',
-                    outlineColor: 'primary',
-                    outlineOffset: '-10px',
-                  }}
-                >
-                  <Box sx={{ textAlign: 'center', display: 'flex', gap: '.5rem', zIndex: 110 }}>
-                    <CloudUploadIcon />
-                    <span>Drop files here to upload</span>
-                  </Box>
-                </Box>
-              )}
+              {isDraggingOver && <DropFilesOverlay />}
               {/* Chat content without SessionTop header for compact floating view.
                   pb mirrors the docked panel: keeps the last message's action row
                   off the input divider since the input has no top padding. */}
@@ -673,33 +650,7 @@ const SessionContainer: FC<SessionLayoutProps> = ({
               onDragOver={handleDragOver}
               onDrop={handleDrop}
             >
-              {isDraggingOver && (
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    width: '100%',
-                    height: '100%',
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    backgroundColor: (theme: unknown) =>
-                      (theme as { palette: { session: { overlayBackground: string } } }).palette.session
-                        .overlayBackground,
-                    backdropFilter: 'blur(10px)',
-                    zIndex: 110,
-                    outline: '2px dashed',
-                    outlineColor: 'primary',
-                    outlineOffset: '-10px',
-                  }}
-                >
-                  <Box sx={{ textAlign: 'center', display: 'flex', gap: '.5rem', zIndex: 110 }}>
-                    <CloudUploadIcon />
-                    <span>Drop files here to upload</span>
-                  </Box>
-                </Box>
-              )}
+              {isDraggingOver && <DropFilesOverlay />}
               {/* pb keeps the last message's action row from touching the input divider
                   now that the docked input has no top padding of its own. */}
               <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', pb: '12px' }}>

--- a/apps/client/app/components/Session/useCopySessionMarkdown.ts
+++ b/apps/client/app/components/Session/useCopySessionMarkdown.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react';
+import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
+import type { IChatHistoryItemDocument } from '@bike4mind/common';
+import { useSessions } from '@client/app/contexts/SessionsContext';
+import { convertSessionToMarkdown } from '@client/app/utils/sessionMarkdownExport';
+
+/**
+ * Copy the current session's chat history to the clipboard as Markdown,
+ * read from the react-query cache (no refetch). `copied` flips true for 2s
+ * after a successful copy so callers can swap in a confirmation icon.
+ */
+export function useCopySessionMarkdown() {
+  const [copied, setCopied] = useState(false);
+  const { currentSessionId } = useSessions();
+  const queryClient = useQueryClient();
+
+  const copyMarkdown = useCallback(async () => {
+    if (!currentSessionId) return;
+    try {
+      const queryData = queryClient.getQueryData<InfiniteData<{ data: IChatHistoryItemDocument[] }>>([
+        'quests',
+        'session',
+        currentSessionId,
+      ]);
+      if (!queryData?.pages) return;
+
+      const quests = queryData.pages.flatMap(p => p.data).reverse(); // chronological order
+      const markdown = convertSessionToMarkdown(quests);
+
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy markdown:', err);
+    }
+  }, [currentSessionId, queryClient]);
+
+  return { copyMarkdown, copied };
+}


### PR DESCRIPTION
## Summary

Removes three verbatim duplicates shared by the docked and floating chat surfaces. Pure extraction — no behavior, styling, or `data-testid` changes.

- **`useCopySessionMarkdown`** (new hook): the copy-chat-as-markdown callback and its 2s `copied` flag were duplicated line-for-line in `DockedChatPanel` and `FloatingChatWindow`.
- **`ChatPanelControls`** (new component): the copy / Float / Dock right / Dock bottom icon-button cluster, parameterized by `testIdPrefix` (so `docked-chat-*` / `floating-chat-*` testids are unchanged) and `activeLayout` (drives the soft/primary highlight on the active dock button, exactly as before). Panel-specific Minimize/Close buttons stay in their panels.
- **`DropFilesOverlay`** (local to `SessionContainer`): the drag-over blur overlay was repeated three times (normal, floating, docked branches); also drops the `theme: any`/`theme: unknown` casts in favor of the typed sx callback.

Button order, tooltips, sizes, and active-state logic are preserved in both panels.

## Testing

- `pnpm --filter @bike4mind/client typecheck` — clean
- `vitest run app/components/Session` — 334 passed, 35 skipped
- Verified live on a self-host dev stack: dockRight/dockBottom/floating headers render identically, dock switching, float, minimize, close, and copy-markdown all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)