### PR TITLE
fix(gears): project membership unlock queried a nonexistent users.id path

### DIFF
--- a/apps/client/pages/api/gears/__tests__/status.test.ts
+++ b/apps/client/pages/api/gears/__tests__/status.test.ts
@@ -174,8 +174,10 @@ describe('GET /api/gears/status', () => {
   it('unlock by receipt: project membership (not just ownership) is queried', async () => {
     const { promise } = run({ id: 'u1' });
     await promise;
+    // users.userId is the stored membership path (sharingService pushShareable
+    // writes { userId, permissions }); users.id matches nothing in Mongo.
     expect(mocks.projectExists).toHaveBeenCalledWith({
-      $or: [{ userId: 'u1' }, { 'users.id': 'u1' }],
+      $or: [{ userId: 'u1' }, { 'users.userId': 'u1' }],
     });
   });
 });

--- a/apps/client/pages/api/gears/status.ts
+++ b/apps/client/pages/api/gears/status.ts
@@ -134,8 +134,9 @@ const GEARS: GearDef[] = [
     key: 'projects',
     credits: 1000,
     kind: 'destination',
-    // Owner OR member - same membership arms as the publish project-visibility gate.
-    check: async ({ userId }) => !!(await Project.exists({ $or: [{ userId }, { 'users.id': userId }] })),
+    // Owner OR member. Membership rows are { userId, permissions } (see
+    // sharingService pushShareable) - the path is users.userId, NOT users.id.
+    check: async ({ userId }) => !!(await Project.exists({ $or: [{ userId }, { 'users.userId': userId }] })),
   },
   {
     key: 'agents',

--- a/packages/database/src/models/content/ProjectModel.ts
+++ b/packages/database/src/models/content/ProjectModel.ts
@@ -127,6 +127,12 @@ ProjectSchema.plugin(softDeletePlugin);
 // Optimized index for searchCollections query - projects collection
 ProjectSchema.index({ userId: 1, deletedAt: 1, name: 'text', updatedAt: -1 });
 
+// Membership arm of accessibility checks (gears status, shared-project lookups).
+// Without it, the $or's users.userId clause forces a collection scan on every
+// /api/gears/status poll (Mongo can only index-union an $or when EVERY clause
+// is indexed).
+ProjectSchema.index({ 'users.userId': 1 });
+
 // Unique constraint on project name per user (excluding soft-deleted projects)
 ProjectSchema.index(
   { userId: 1, name: 1 },


### PR DESCRIPTION
## Summary

PR #390's Gears rollout promised receipt-based unlock for the Projects destination ("a project you were added to unlocks Projects"), but the membership arm of the check queried `'users.id'`:

```ts
Project.exists({ $or: [{ userId }, { 'users.id': userId }] })
```

Shared-membership rows are written as `{ userId, permissions, projectId }` (`sharingService` `pushShareable`), and `UserShareableSchema` sets `_id: false, id: false` — so `users.id` exists on no document and the arm matched nothing.

**User-facing impact:** under earned-nav, a collaborator who accepts a project invite but has never created a project of their own never unlocks the Projects gear — so the Projects sidenav row stays hidden and they can't reach the project they were just invited to.

## Fix

- Query `'users.userId'` (the same path used by `ability.ts`, `AgentModel`, `SkillModel`, and the `SessionModel`/`FabFileModel` membership indexes).
- The receipt-unlock test previously asserted the dead path verbatim; it now asserts the stored one.

## Verification

- `pnpm --filter` gears status tests: 17/17 pass
- `pnpm turbo:typecheck` clean, `pnpm lint:check` clean

## Note on siblings

The same dead `users.id` arm exists in pre-open-core code (`ProjectModel.searchAccessible`, `publish/checkVisibility.ts`, `publish/checkScopePermission.ts`, `publish/artifacts/index.ts`, slack `AppHomeDataService`). Those predate #390 and are deliberately out of scope here — follow-up issue to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)