### PR TITLE
fix(client): restore the Files Manager earned sidenav row

### DIFF
--- a/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useLocation } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { Fragment, ReactNode } from 'react';
 import AddIcon from '@mui/icons-material/Add';
+import FolderSharedIcon from '@mui/icons-material/FolderSharedOutlined';
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import TempleBuddhistOutlinedIcon from '@mui/icons-material/TempleBuddhistOutlined';
@@ -18,6 +19,7 @@ import { useFeatureEnabled } from '@client/app/hooks/useFeatureEnabled';
 import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import { useUser } from '@client/app/contexts/UserContext';
 import { useOptiAccess } from '@client/app/hooks/data/opti';
+import { useFileBrowser } from '@client/app/components/Files/Browser';
 import { useIsMobile } from '@client/app/hooks/useIsMobile';
 import { useHelpPanel, openHelpPanel } from '@client/app/hooks/useHelpPanel';
 import { useGearUnlocks, type GearKey } from '@client/app/hooks/useGearsStatus';
@@ -35,10 +37,10 @@ type NavItem = {
 };
 
 /**
- * Primary sidebar navigation - a vertical icon list (New Chat, Agents, Projects, OptiHashi,
- * Tavern). OptiHashi/Tavern keep the same entitlement gating as the footer menu, and Agents
- * follows the `enableAgents` flag. The active row is highlighted by route. Files Manager is
- * deliberately NOT a sidenav destination - it is reachable only via the Gears page.
+ * Primary sidebar navigation - a vertical icon list (New Chat, Files Manager, Agents, Projects,
+ * OptiHashi, Tavern). OptiHashi/Tavern keep the same entitlement gating as the footer menu, and
+ * Agents follows the `enableAgents` flag. The active row is highlighted by route (Files Manager
+ * by the file-browser drawer's open state, since it isn't a route).
  */
 const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all' }) => {
   const theme = useTheme();
@@ -48,6 +50,7 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
   const currentUser = useUser(s => s.currentUser);
   const { isFeatureEnabled } = useFeatureEnabled();
   const { isFeatureEnabled: isAdminFeatureEnabled } = useAdminSettingsCache();
+  const { open: fileBrowserOpen, setOpen: setFileBrowserOpen } = useFileBrowser();
   const isMobile = useIsMobile();
   const setOpenSideNav = useNotebookLayout(s => s.setOpenSideNav);
 
@@ -73,7 +76,7 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
   // the rail settle once, on first paint only).
   const gearUnlocks = useGearUnlocks();
   // Fail OPEN unless a gear is EXPLICITLY present-and-unearned. These rows
-  // (Projects, Agents, ...) were unconditional before Gears, so a loading state,
+  // (Files, Projects, ...) were unconditional before Gears, so a loading state,
   // a catalog that omits/renames the key, or an admin override that drops it
   // must NOT silently remove core navigation app-wide - only a key the server
   // returns as `false` (a known, genuinely-unearned gear) hides its row.
@@ -160,6 +163,20 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
             onClick: () => {
               closeOnMobile();
               navigate({ to: '/data-lakes' });
+            },
+          },
+        ]
+      : []),
+    ...(gearOpen('files')
+      ? [
+          {
+            key: 'files',
+            label: t('files.manager', 'Files Manager'),
+            icon: iconSlot(<FolderSharedIcon sx={{ fontSize: '18px' }} />),
+            isActive: fileBrowserOpen,
+            onClick: () => {
+              closeOnMobile();
+              setFileBrowserOpen(true);
             },
           },
         ]
@@ -255,9 +272,8 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
 
   // Pinned vs scroll split for the unified-scroll sidebar: the first two items stay
   // pinned at the top. items[0] is always New Chat; items[1] is OptiHashi when Opti is
-  // enabled, otherwise the next earned destination (the conditional Opti/Data-Lakes
-  // entries shift the rest into the scroll slice). The split is purely positional, so
-  // it holds either way.
+  // enabled, otherwise Files Manager (the conditional Opti/Data-Lakes entries shift the
+  // rest into the scroll slice). The split is purely positional, so it holds either way.
   const shownItems = section === 'pinned' ? items.slice(0, 2) : section === 'scroll' ? items.slice(2) : items;
 
   return (

--- a/apps/client/app/hooks/useGearsStatus.ts
+++ b/apps/client/app/hooks/useGearsStatus.ts
@@ -10,7 +10,7 @@ import { api } from '@client/app/contexts/ApiContext';
 export type GearKind = 'destination' | 'skill';
 
 export type GearKey =
-  // destinations (earn a sidenav slot - except 'files', which stays Gears-page-only)
+  // destinations (earn a sidenav slot)
   | 'projects'
   | 'agents'
   | 'datalakes'

--- a/apps/client/e2e/pages/FileUploadPage.ts
+++ b/apps/client/e2e/pages/FileUploadPage.ts
@@ -48,16 +48,15 @@ export class FileUploadPage extends BasePage {
   }
 
   async openFileBrowser() {
-    // Close any existing dialog first so the composer is accessible.
+    // Close any existing dialog first to ensure the sidebar is accessible.
     await this.closeFileBrowser();
-    // Files Manager is deliberately NOT a sidenav destination (Gears-page-only), so
-    // open the browser via the composer's attach menu. The browser is a global drawer
-    // opened OVER the current page (e.g. the notebook the file is being added to), so
-    // it must NOT be reached by navigating away.
-    await this.page.getByTestId('attach-files-btn').click();
-    const browserItem = this.page.getByTestId('add-from-file-browser-btn');
-    await expect(browserItem).toBeVisible({ timeout: TIMEOUTS.ELEMENT_STATE });
-    await browserItem.click();
+    // NOTE: `files` is an earned-nav destination (Gears) - the sidenav row is hidden
+    // until the account has a file. That is NOT a problem here: every caller uploads
+    // or relies on a seeded file BEFORE opening the browser, so `files` is already
+    // earned and the row is present. The browser is also a global drawer opened OVER
+    // the current page (e.g. the notebook the file is being added to), so it must NOT
+    // be reached by navigating away.
+    await this.page.getByTestId('sidenav-nav-files').click();
   }
 
   async switchToListView() {


### PR DESCRIPTION
## Summary

**Prod regression:** the Files Manager row is missing from the left sidenav for every user, including accounts that have had files for years (reported by QA across multiple accounts).

**Root cause:** PR #553 removed the Files row from the sidenav entirely, on the strength of issue #533's claim that "per the intended design, Files Manager should NOT be a left-sidenav row." That claim was wrong — the issue itself flagged it as "needs confirmation vs. current implementation," and the Gears design (PR #390) explicitly lists Files among the destinations that **earn** a sidenav slot on first real use. The confirmation never happened and the removal shipped.

## Fix

Restores the pre-#553 behavior exactly:

- `SidenavNav.tsx`: Files Manager row back in the rail, gated by `gearOpen('files')` (earned-nav, fail-open), opening the file-browser drawer and highlighted by the drawer's open state.
- `useGearsStatus.ts`: comment back to "destinations (earn a sidenav slot)".
- `e2e/pages/FileUploadPage.ts`: `openFileBrowser()` back to the sidenav row (callers always have an uploaded/seeded file first, so the row is present).

**Kept from #553** (genuinely good, unrelated to the removal):
- The gears-status cache invalidation on first composer upload (Gears "Files" card flips to "Open" without a reload).
- The `add-from-file-browser-btn` testid on the attach menu.

## Verification

- Client `tsc --noEmit` clean
- Sidenav vitest suites: 4 files / 17 tests pass
- eslint clean on changed files

## Follow-up

Issue #533's Bug 1 premise should be closed as invalid so this doesn't get "re-fixed" — commenting there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)