### PR TITLE
fix(api): scope over-exposing read endpoints

### DIFF
--- a/apps/client/pages/api/app-files/__tests__/index.test.ts
+++ b/apps/client/pages/api/app-files/__tests__/index.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * GET /api/app-files is a cross-user file inventory with owner PII (populated
+ * name/email) and no per-user scoping; its only consumer is the admin Files tab,
+ * so it must be admin-only. Prove a non-admin is rejected before any query.
+ */
+
+// `any` below is deliberate test-mock plumbing: typing the full next-connect /
+// node-mocks-http chain adds no coverage value (matches the repo's handler-test convention).
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const find = vi.hoisted(() =>
+  vi.fn(() => ({ populate: () => ({ sort: () => ({ exec: () => Promise.resolve([]) }) }) }))
+);
+vi.mock('@bike4mind/database/content', () => ({ AppFile: { find } }));
+
+import '@pages/api/app-files/index';
+
+function mocks(user: unknown) {
+  const { req, res } = createMocks({ method: 'GET', query: {} });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('GET /api/app-files - admin gate', () => {
+  beforeEach(() => find.mockClear());
+
+  it('rejects a non-admin before querying', async () => {
+    const { req, res } = mocks({ id: 'u1', isAdmin: false });
+    await expect(mockRefs.getHandler!(req, res)).rejects.toThrow(/admin/i);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it('lists files for an admin', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true });
+    await mockRefs.getHandler!(req, res);
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(res._getStatusCode()).toBe(200);
+  });
+});

--- a/apps/client/pages/api/app-files/index.ts
+++ b/apps/client/pages/api/app-files/index.ts
@@ -2,6 +2,7 @@ import { IAppFileGetAllApiResponse } from '@bike4mind/common';
 import { AppFile } from '@bike4mind/database/content';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
+import { ensureAdmin } from '@server/utils/errors';
 import qs from 'qs';
 import { z } from 'zod';
 
@@ -11,6 +12,10 @@ const AppFileGetAllRequestInput = z.object({
 
 const handler = baseApi().get(
   asyncHandler<unknown, IAppFileGetAllApiResponse, {}, Record<string, string>>(async (req, res) => {
+    // This is a cross-user file inventory with owner PII (populated name/email) and
+    // no per-user scoping; its only consumer is the admin Files tab, so gate to admins.
+    ensureAdmin(req.user?.isAdmin);
+
     const data = AppFileGetAllRequestInput.parse(qs.parse(req.query));
 
     const files = await AppFile.find({

--- a/apps/client/pages/api/invites/[id]/__tests__/accept.test.ts
+++ b/apps/client/pages/api/invites/[id]/__tests__/accept.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * POST /api/invites/[id]/accept returns the accepted invite to the invitee;
+ * co-recipients' emails must be filtered out of the response.
+ */
+
+// `any` below is deliberate test-mock plumbing: typing the full next-connect /
+// node-mocks-http chain adds no coverage value (matches the repo's handler-test convention).
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const acceptInvite = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    id: 'inv1',
+    type: 'Session', // not Project/FabFile, so the extra branches are skipped
+    documentId: 'doc1',
+    recipients: { pending: [], accepted: ['me@x.com', 'other@x.com'], refused: [] },
+  })
+);
+vi.mock('@bike4mind/services', () => ({ sharingService: { acceptInvite } }));
+vi.mock('@bike4mind/database', () => ({
+  // accept.ts adapters + inviteManager's module-load imports
+  inviteRepository: {},
+  Organization: {},
+  sessionRepository: {},
+  projectRepository: {},
+  fabFileRepository: {},
+  userRepository: {},
+  Project: { findById: vi.fn() },
+  fileTagRepository: {},
+  withTransaction: (fn: any) => fn(),
+  FabFile: {},
+  Group: {},
+  Session: {},
+  User: {},
+}));
+vi.mock('@server/websocket/utils', () => ({ sendToClient: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('sst', () => ({ Resource: { websocket: { managementEndpoint: 'wss://x' } } }));
+
+import '@pages/api/invites/[id]/accept';
+
+describe('POST /api/invites/[id]/accept - recipient filtering', () => {
+  beforeEach(() => acceptInvite.mockClear());
+
+  it('strips co-recipients from the returned invite', async () => {
+    const { req, res } = createMocks({ method: 'POST', query: { id: 'inv1' } });
+    (req as any).user = { id: 'u1', email: 'me@x.com' };
+    (req as any).ability = {};
+    await mockRefs.postHandler!(req, res);
+
+    const body = res._getJSONData();
+    expect(body.recipients.accepted).toEqual(['me@x.com']);
+    expect(JSON.stringify(body)).not.toContain('other@x.com');
+  });
+});

--- a/apps/client/pages/api/invites/[id]/__tests__/index.test.ts
+++ b/apps/client/pages/api/invites/[id]/__tests__/index.test.ts
@@ -6,12 +6,18 @@ import { createMocks } from 'node-mocks-http';
  * auth lives in the service). Asserts delegation + the id guard.
  */
 
-const mockRefs = vi.hoisted(() => ({ deleteHandler: null as null | ((req: any, res: any) => unknown) }));
+const mockRefs = vi.hoisted(() => ({
+  deleteHandler: null as null | ((req: any, res: any) => unknown),
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
 
 vi.mock('@server/middlewares/baseApi', () => {
   const chain: any = {
     use: () => chain,
-    get: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
     post: () => chain,
     delete: (fn: any) => {
       mockRefs.deleteHandler = fn;
@@ -32,8 +38,14 @@ vi.mock('@bike4mind/database', () => ({
   organizationRepository: {},
   Group: {},
 }));
-vi.mock('@server/managers/inviteManager', () => ({ getInviteDetails: vi.fn() }));
+const getInviteDetails = vi.hoisted(() => vi.fn());
+// Keep the real filterInviteRecipientsToSelf; stub only the DB-touching getInviteDetails.
+vi.mock('@server/managers/inviteManager', async importOriginal => {
+  const actual = await importOriginal<typeof import('@server/managers/inviteManager')>();
+  return { ...actual, getInviteDetails };
+});
 
+import { Invite } from '@bike4mind/database';
 import '@pages/api/invites/[id]/index';
 
 describe('DELETE /api/invites/[id]', () => {
@@ -59,5 +71,29 @@ describe('DELETE /api/invites/[id]', () => {
     await mockRefs.deleteHandler!(req, res);
     expect(res._getStatusCode()).toBe(400);
     expect(cancelInviteById).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/invites/[id] - recipient email strip', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keeps only the caller\'s own recipient entry, dropping co-invitees', async () => {
+    (Invite.findById as any).mockResolvedValue({ id: 'inv-1' });
+    getInviteDetails.mockResolvedValue({
+      id: 'inv-1',
+      type: 'FabFile',
+      name: 'Doc',
+      username: 'inviter',
+      recipients: { pending: ['me@x.com', 'other@x.com'], accepted: ['third@x.com'], refused: [] },
+    });
+    const { req, res } = createMocks({ method: 'GET', query: { id: 'inv-1' } });
+    (req as any).user = { id: 'u1', email: 'me@x.com' };
+    await mockRefs.getHandler!(req, res);
+
+    const body = res._getJSONData();
+    expect(body.type).toBe('FabFile');
+    expect(body.recipients.pending).toEqual(['me@x.com']);
+    expect(JSON.stringify(body)).not.toContain('other@x.com');
+    expect(JSON.stringify(body)).not.toContain('third@x.com');
   });
 });

--- a/apps/client/pages/api/invites/[id]/__tests__/refuse.test.ts
+++ b/apps/client/pages/api/invites/[id]/__tests__/refuse.test.ts
@@ -66,4 +66,18 @@ describe('POST /api/invites/[id]/refuse', () => {
     expect(res._getStatusCode()).toBe(400);
     expect(refuseWholeInvite).not.toHaveBeenCalled();
   });
+
+  it('strips co-recipients from the returned invite', async () => {
+    refuseWholeInvite.mockResolvedValue({
+      id: 'inv-1',
+      recipients: { pending: [], accepted: ['other@x.com'], refused: ['me@x.com'] },
+    });
+    const { req, res } = createMocks({ method: 'POST', query: { id: 'inv-1' }, body: {} });
+    (req as any).user = { id: 'u1', email: 'me@x.com' };
+    await mockRefs.postHandler!(req, res);
+
+    const body = res._getJSONData();
+    expect(body.recipients.refused).toEqual(['me@x.com']);
+    expect(JSON.stringify(body)).not.toContain('other@x.com');
+  });
 });

--- a/apps/client/pages/api/invites/[id]/accept.ts
+++ b/apps/client/pages/api/invites/[id]/accept.ts
@@ -14,6 +14,7 @@ import {
   withTransaction,
 } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
+import { filterInviteRecipientsToSelf } from '@server/managers/inviteManager';
 import { sendToClient } from '@server/websocket/utils';
 import { InviteType, ProjectEvents } from '@bike4mind/common';
 import { logEvent } from '@server/utils/analyticsLog';
@@ -135,7 +136,8 @@ const handler = baseApi().post(async (req, res) => {
     status: 'Accepted invite',
   });
 
-  return res.json(invite);
+  // Invitee-facing: strip co-recipients' emails from the returned invite.
+  return res.json(filterInviteRecipientsToSelf(invite, req.user.email));
 });
 
 export const config = {

--- a/apps/client/pages/api/invites/[id]/index.ts
+++ b/apps/client/pages/api/invites/[id]/index.ts
@@ -10,7 +10,7 @@ import {
   organizationRepository,
   Group,
 } from '@bike4mind/database';
-import { getInviteDetails } from '@server/managers/inviteManager';
+import { getInviteDetails, filterInviteRecipientsToSelf } from '@server/managers/inviteManager';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { sharingService } from '@bike4mind/services';
@@ -32,7 +32,9 @@ const handler = baseApi()
         return res.status(404).json({ message: 'Invite Not Found' });
       }
 
-      return res.json(await getInviteDetails(invite, true));
+      // Invitee-facing view: strip other recipients' emails, keep the caller's own.
+      const details = await getInviteDetails(invite, true);
+      return res.json(filterInviteRecipientsToSelf(details, req.user.email));
     })
   )
   /**

--- a/apps/client/pages/api/invites/[id]/refuse.ts
+++ b/apps/client/pages/api/invites/[id]/refuse.ts
@@ -3,6 +3,7 @@
 
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
+import { filterInviteRecipientsToSelf } from '@server/managers/inviteManager';
 import { sendToClient } from '@server/websocket/utils';
 import { sharingService } from '@bike4mind/services';
 import { inviteRepository } from '@bike4mind/database';
@@ -31,7 +32,8 @@ const handler = baseApi().post(
       status: 'Refused invite',
     });
 
-    return res.json(invite);
+    // Invitee-facing: strip co-recipients' emails from the returned invite.
+    return res.json(filterInviteRecipientsToSelf(invite, req.user.email));
   })
 );
 

--- a/apps/client/pages/api/invites/__tests__/index.test.ts
+++ b/apps/client/pages/api/invites/__tests__/index.test.ts
@@ -51,4 +51,18 @@ describe('GET /api/invites', () => {
     await mockRefs.getHandler!(req, res);
     expect(listOwnPendingInvites).toHaveBeenCalledWith(req.user, { limit: 1000, page: 1 }, expect.any(Object));
   });
+
+  it('strips co-recipients from each invite, keeping the caller\'s own entry', async () => {
+    listOwnPendingInvites.mockResolvedValue({
+      data: [{ id: 'i1', recipients: { pending: ['me@x.com', 'other@x.com'], accepted: [], refused: [] } }],
+      total: 1,
+    });
+    const { req, res } = createMocks({ method: 'GET', query: {} });
+    (req as any).user = { id: 'u1', email: 'me@x.com' };
+    await mockRefs.getHandler!(req, res);
+
+    const body = res._getJSONData();
+    expect(body[0].recipients.pending).toEqual(['me@x.com']); // self-check preserved
+    expect(JSON.stringify(body)).not.toContain('other@x.com');
+  });
 });

--- a/apps/client/pages/api/invites/index.ts
+++ b/apps/client/pages/api/invites/index.ts
@@ -4,6 +4,7 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { inviteRepository } from '@bike4mind/database';
 import { sharingService } from '@bike4mind/services';
+import { filterInviteRecipientsToSelf } from '@server/managers/inviteManager';
 import { z } from 'zod';
 
 // The pre-consolidation CASL path returned every pending invite with no pagination, so
@@ -27,7 +28,8 @@ const handler = baseApi().get(async (req, res) => {
     { db: { invites: inviteRepository } }
   );
 
-  return res.json(result.data);
+  // Strip co-recipients' emails from each invite, keeping only the caller's own entry.
+  return res.json(result.data.map(invite => filterInviteRecipientsToSelf(invite, req.user.email)));
 });
 
 export const config = {

--- a/apps/client/pages/api/publish/artifacts/[id].ts
+++ b/apps/client/pages/api/publish/artifacts/[id].ts
@@ -54,6 +54,28 @@ function canManage(artifact: { ownerId: string }, user: { id: string; isAdmin?: 
   return artifact.ownerId === String(user.id) || !!user.isAdmin;
 }
 
+// Public viewers (anyone hitting a `visibility: 'public'` artifact) get only these
+// display fields. Everything else -- ownerId, lastPublishedBy, storageKeyPrefix,
+// moderation internals (reportCount/takedownReason/deletedBy/moderationStatus),
+// source, tier/scopeId/slug, manifest/renderedBody, etc. -- is owner/admin-only.
+const PUBLIC_ARTIFACT_FIELDS = [
+  'publicId',
+  'title',
+  'description',
+  'visibility',
+  'commentPolicy',
+  'embedOrigins',
+  'publishedAt',
+] as const;
+
+function toPublicArtifact(artifact: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const field of PUBLIC_ARTIFACT_FIELDS) {
+    if (artifact[field] !== undefined) out[field] = artifact[field];
+  }
+  return out;
+}
+
 const handler = baseApi()
   .get(async (req, res) => {
     const publicId = String(req.query.id);
@@ -61,21 +83,27 @@ const handler = baseApi()
     // artifact, and .lean() bypasses the schema's toJSON strip - so project it out here.
     const artifact = await PublishedArtifact.findOne({ publicId, deletedAt: null })
       .select('-shareToken -shareTokenUpdatedAt')
-      .lean<{
-        ownerId: string;
-        visibility: string;
-      } | null>();
+      .lean<(Record<string, unknown> & { ownerId: string; visibility: string }) | null>();
     if (!artifact) {
       return res.status(404).json({ error: 'Artifact not found' });
     }
+    const isManager = !!req.user && canManage(artifact, req.user);
     // Non-public artifacts require an owner/admin viewer on this management route.
     if (artifact.visibility !== 'public') {
       if (!req.user) return res.status(401).json({ error: 'Authentication required' });
-      if (!canManage(artifact, req.user)) {
+      if (!isManager) {
         return res.status(403).json({ error: 'Not authorized to view this artifact' });
       }
     }
-    return res.status(200).json({ artifact });
+    // A gated public artifact must not leak even display metadata to a non-manager
+    // who merely knows the publicId - the gate is enforced on the serve path, so
+    // treat it as not-found here (indistinguishable from a private artifact).
+    if (artifact.visibility === 'public' && artifact.accessGate && !isManager) {
+      return res.status(404).json({ error: 'Artifact not found' });
+    }
+    // Owner/admin get the full record (the manage modal needs it); any other viewer
+    // of an ungated public artifact gets only the public display DTO.
+    return res.status(200).json({ artifact: isManager ? artifact : toPublicArtifact(artifact) });
   })
   .patch(async (req, res) => {
     if (!req.user) return res.status(401).json({ error: 'Authentication required' });

--- a/apps/client/pages/api/publish/artifacts/__tests__/[id].test.ts
+++ b/apps/client/pages/api/publish/artifacts/__tests__/[id].test.ts
@@ -72,6 +72,97 @@ beforeEach(() => {
   findOne.mockReset();
 });
 
+/** A public artifact carrying owner/moderation/storage internals. */
+function makePublicArtifactRow() {
+  return {
+    publicId: 'pub-1',
+    title: 'My Artifact',
+    description: 'desc',
+    visibility: 'public',
+    commentPolicy: 'none',
+    embedOrigins: undefined,
+    publishedAt: new Date('2026-01-01').toISOString(),
+    // Sensitive internals that must NOT reach a public viewer:
+    ownerId: OWNER,
+    lastPublishedBy: OWNER,
+    storageKeyPrefix: 'artifacts/pub-1/',
+    reportCount: 3,
+    takedownReason: 'nsfw',
+    deletedBy: null,
+    moderationStatus: 'active',
+    source: { kind: 'bundle' },
+    tier: 'user',
+    scopeId: 'scope-1',
+  };
+}
+
+async function getArtifact(user: unknown, row = makePublicArtifactRow()) {
+  findOne.mockReturnValue({ select: () => ({ lean: () => Promise.resolve(row) }) });
+  const { req, res } = createMocks({ method: 'GET' });
+  (req as unknown as { query: unknown }).query = { id: 'pub-1' };
+  (req as unknown as { user?: unknown }).user = user;
+  await (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res);
+  return res;
+}
+
+describe('GET public artifact - response scoping', () => {
+  it('returns only public display fields to a non-owner viewer', async () => {
+    const res = await getArtifact({ id: 'someone-else', isAdmin: false });
+    expect(res._getStatusCode()).toBe(200);
+    const { artifact } = res._getJSONData();
+    expect(artifact.title).toBe('My Artifact');
+    expect(artifact.publicId).toBe('pub-1');
+    for (const leaked of [
+      'ownerId',
+      'lastPublishedBy',
+      'storageKeyPrefix',
+      'reportCount',
+      'takedownReason',
+      'deletedBy',
+      'moderationStatus',
+      'source',
+      'tier',
+      'scopeId',
+    ]) {
+      expect(leaked in artifact).toBe(false);
+    }
+    expect(JSON.stringify(artifact)).not.toContain('artifacts/pub-1/');
+  });
+
+  it('returns only public display fields to an anonymous viewer', async () => {
+    const res = await getArtifact(undefined);
+    const { artifact } = res._getJSONData();
+    expect('ownerId' in artifact).toBe(false);
+    expect(artifact.title).toBe('My Artifact');
+  });
+
+  it('returns the full record to the owner (manage modal needs it)', async () => {
+    const res = await getArtifact({ id: OWNER, isAdmin: false });
+    const { artifact } = res._getJSONData();
+    expect(artifact.ownerId).toBe(OWNER);
+    expect(artifact.storageKeyPrefix).toBe('artifacts/pub-1/');
+  });
+
+  it('returns the full record to an admin', async () => {
+    const res = await getArtifact({ id: 'admin-1', isAdmin: true });
+    const { artifact } = res._getJSONData();
+    expect(artifact.ownerId).toBe(OWNER);
+  });
+
+  it('does not leak DTO metadata for a GATED public artifact to a non-manager (404)', async () => {
+    const gated = { ...makePublicArtifactRow(), accessGate: { kind: 'passphrase' } };
+    const res = await getArtifact({ id: 'someone-else', isAdmin: false }, gated);
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('still returns the full record for a GATED artifact to its owner', async () => {
+    const gated = { ...makePublicArtifactRow(), accessGate: { kind: 'passphrase' } };
+    const res = await getArtifact({ id: OWNER, isAdmin: false }, gated);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().artifact.ownerId).toBe(OWNER);
+  });
+});
+
 describe('PATCH domain access gate - stored as entered, validated', () => {
   it('stores entries AS ENTERED (lowercased, de-duped) - never reduced to eTLD+1', async () => {
     const { res, artifact } = await patchGate(['mail.acme.com', 'acme.com', 'PARTNER.CO', 'acme.com']);

--- a/apps/client/pages/api/security/__tests__/user-recent.test.ts
+++ b/apps/client/pages/api/security/__tests__/user-recent.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * GET /api/security/user-recent surfaces recent suspicious patterns; like
+ * user-summary it must drop the IP-bucketed `emails` array so co-targeted users'
+ * emails do not leak, exposing only the caller's own usernames.
+ */
+
+// `any` below is deliberate test-mock plumbing: typing the full next-connect /
+// node-mocks-http chain adds no coverage value (matches the repo's handler-test convention).
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const repo = vi.hoisted(() => ({
+  getUserFailedLogins: vi.fn().mockResolvedValue([]),
+  getSuspiciousPatternsTargetingUser: vi.fn().mockResolvedValue([
+    {
+      ip: '1.2.3.4',
+      attempts: 5,
+      usernames: ['me', 'victim'],
+      emails: ['me@example.com', 'victim@example.com'],
+      lastAttempt: new Date('2026-01-01').toISOString(),
+      firstAttempt: new Date('2026-01-01').toISOString(),
+      riskLevel: 'high',
+    },
+  ]),
+}));
+vi.mock('@bike4mind/database', () => ({ authFailLogRepository: repo }));
+
+import '@pages/api/security/user-recent';
+
+describe('GET /api/security/user-recent - email leak strip', () => {
+  beforeEach(() => {
+    repo.getUserFailedLogins.mockClear();
+    repo.getSuspiciousPatternsTargetingUser.mockClear();
+  });
+
+  it('drops the emails array from suspicious-pattern items', async () => {
+    const { req, res } = createMocks({ method: 'GET', query: {} });
+    (req as any).user = { email: 'me@example.com', username: 'me' };
+    await mockRefs.getHandler!(req, res);
+
+    const body = res._getJSONData();
+    const item = body.items.find((i: any) => i.type === 'suspicious_pattern');
+    expect('emails' in item.data).toBe(false);
+    expect(item.data.usernames).toEqual(['me']);
+    expect(JSON.stringify(body)).not.toContain('victim@example.com');
+  });
+});

--- a/apps/client/pages/api/security/__tests__/user-summary.test.ts
+++ b/apps/client/pages/api/security/__tests__/user-summary.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * GET /api/security/user-summary aggregates failed-login patterns bucketed by IP.
+ * The aggregation collects an `emails` array of every user targeted from the same
+ * IP; the response must NOT include it (it would leak co-targeted users' emails).
+ * Only the caller's own usernames are exposed.
+ */
+
+// `any` below is deliberate test-mock plumbing: typing the full next-connect /
+// node-mocks-http chain adds no coverage value (matches the repo's handler-test convention).
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const repo = vi.hoisted(() => ({
+  getUserFailedLogins: vi.fn().mockResolvedValue([]),
+  getSuspiciousPatternsTargetingUser: vi.fn().mockResolvedValue([
+    {
+      ip: '1.2.3.4',
+      attempts: 5,
+      usernames: ['me', 'victim'],
+      emails: ['me@example.com', 'victim@example.com'],
+      lastAttempt: new Date('2026-01-01').toISOString(),
+      firstAttempt: new Date('2026-01-01').toISOString(),
+      riskLevel: 'high',
+    },
+  ]),
+}));
+vi.mock('@bike4mind/database', () => ({ authFailLogRepository: repo }));
+
+import '@pages/api/security/user-summary';
+
+describe('GET /api/security/user-summary - email leak strip', () => {
+  beforeEach(() => {
+    repo.getUserFailedLogins.mockClear();
+    repo.getSuspiciousPatternsTargetingUser.mockClear();
+  });
+
+  it('drops the emails array and only exposes the caller\'s own usernames', async () => {
+    const { req, res } = createMocks({ method: 'GET', query: {} });
+    (req as any).user = { email: 'me@example.com', username: 'me' };
+    await mockRefs.getHandler!(req, res);
+
+    const body = res._getJSONData();
+    const pattern = body.suspiciousPatterns.items[0];
+    expect('emails' in pattern).toBe(false);
+    expect(pattern.usernames).toEqual(['me']); // 'victim' filtered out
+    expect(JSON.stringify(body)).not.toContain('victim@example.com');
+  });
+});

--- a/apps/client/pages/api/security/user-recent.ts
+++ b/apps/client/pages/api/security/user-recent.ts
@@ -35,9 +35,11 @@ const handler = baseApi().get(
         data: login,
         timestamp: login.createdAt,
       })),
-      ...suspiciousPatterns.map(pattern => ({
+      ...suspiciousPatterns.map(({ emails: _emails, ...pattern }) => ({
         type: 'suspicious_pattern',
-        // Filter usernames to only those belonging to the current user
+        // Filter usernames to only those belonging to the current user; drop the
+        // aggregation's `emails` array entirely (it buckets by IP and would leak
+        // other co-targeted users' email addresses). The UI renders neither.
         data: {
           ...pattern,
           usernames: Array.isArray(pattern.usernames)

--- a/apps/client/pages/api/security/user-summary.ts
+++ b/apps/client/pages/api/security/user-summary.ts
@@ -34,7 +34,10 @@ const handler = baseApi().get(
       suspiciousPatterns: {
         total: suspiciousPatterns.length,
         // Normalize usernames and dates to avoid UI 'unknown' values
-        items: suspiciousPatterns.map(p => ({
+        items: suspiciousPatterns.map(({ emails: _emails, ...p }) => ({
+          // Drop the aggregation's `emails` array: it buckets by IP and would leak
+          // the email addresses of OTHER users targeted from the same IP. Only the
+          // caller's own usernames are exposed (filtered below); the UI renders neither.
           ...p,
           usernames: Array.isArray(p.usernames)
             ? p.usernames.filter(u => typeof u === 'string' && u.length > 0 && userIdentifiers.has(u.toLowerCase()))

--- a/apps/client/pages/api/users/[id]/__tests__/userInvites.test.ts
+++ b/apps/client/pages/api/users/[id]/__tests__/userInvites.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * GET /api/users/:id/userInvites is the invitee inbox. Each invite's recipient
+ * arrays must be filtered to the caller's own email (the inbox checks
+ * recipients.pending for the caller) so co-invitees' emails are not leaked.
+ */
+
+// `any` below is deliberate test-mock plumbing: typing the full next-connect /
+// node-mocks-http chain adds no coverage value (matches the repo's handler-test convention).
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const listOwnPendingInvites = vi.hoisted(() => vi.fn());
+vi.mock('@bike4mind/services', () => ({
+  sharingService: { listOwnPendingInvites },
+  // Cache is a pass-through in tests: run the factory directly.
+  cacheService: { getCachedData: (_key: string, factory: () => unknown) => factory() },
+}));
+// inviteRepository/cacheRepository for the handler + FabFile.. for inviteManager's load.
+vi.mock('@bike4mind/database', () => ({
+  inviteRepository: {},
+  cacheRepository: {},
+  FabFile: {},
+  Group: {},
+  Organization: {},
+  Session: {},
+  User: {},
+}));
+vi.mock('@server/utils/cacheKeys', () => ({ CacheKeys: { userInvites: () => 'k' } }));
+
+import '@pages/api/users/[id]/userInvites';
+
+describe('GET /api/users/[id]/userInvites - inbox recipient filtering', () => {
+  beforeEach(() => listOwnPendingInvites.mockClear());
+
+  it('filters each invite to the caller, keeping the pending self-check working', async () => {
+    listOwnPendingInvites.mockResolvedValue({
+      data: [{ id: 'i1', recipients: { pending: ['me@x.com', 'other@x.com'], accepted: [], refused: [] } }],
+      total: 1,
+    });
+    const { req, res } = createMocks({ method: 'GET', query: { id: 'me' } });
+    (req as any).user = { id: 'me', email: 'me@x.com', isAdmin: false };
+    await mockRefs.getHandler!(req, res);
+
+    const body = res._getJSONData();
+    expect(body.data[0].recipients.pending).toEqual(['me@x.com']);
+    expect(body.pagination.total).toBe(1);
+    expect(JSON.stringify(body)).not.toContain('other@x.com');
+  });
+});

--- a/apps/client/pages/api/users/[id]/userInvites.ts
+++ b/apps/client/pages/api/users/[id]/userInvites.ts
@@ -4,6 +4,7 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { inviteRepository, cacheRepository } from '@bike4mind/database';
 import { UnauthorizedError } from '@server/utils/errors';
 import { sharingService, cacheService } from '@bike4mind/services';
+import { filterInviteRecipientsToSelf } from '@server/managers/inviteManager';
 import { z } from 'zod';
 import { CacheKeys } from '@server/utils/cacheKeys';
 
@@ -39,8 +40,10 @@ const handler = baseApi().get(async (req, res) => {
     }
   );
 
+  // The cache stores the raw invites; strip co-recipients' emails per-response,
+  // keeping only the caller's own entry so the inbox pending self-check still works.
   return res.json({
-    data: result.data,
+    data: result.data.map(invite => filterInviteRecipientsToSelf(invite, currentUser.email)),
     pagination: {
       total: result.total,
       page,

--- a/apps/client/pages/api/users/__tests__/index.test.ts
+++ b/apps/client/pages/api/users/__tests__/index.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * GET /api/users publicView is the invite/member-picker directory search. It
+ * bypasses CASL by design, so it must not become a mass-enumeration vector for
+ * non-admins: downloadAll (unbounded export) is admin-only, and the publicView
+ * page size is capped.
+ */
+
+// `any` below is deliberate test-mock plumbing: typing the full next-connect /
+// node-mocks-http chain adds no coverage value (matches the repo's handler-test convention).
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+  facet: undefined as any,
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@bike4mind/database', () => ({
+  User: { find: () => ({ getQuery: () => ({}) }), populate: vi.fn().mockResolvedValue(undefined), hydrate: (u: any) => u, aggregate: vi.fn().mockResolvedValue([]) },
+  Project: { findById: vi.fn() },
+  executeFacetCompatible: (_m: any, _p: any, facet: any) => {
+    mockRefs.facet = facet;
+    return Promise.resolve([{ totalCount: [{ count: 0 }], paginatedResults: [] }]);
+  },
+  convertPipelineForDocumentDB: (p: any) => p,
+  mongoose: { Types: { ObjectId: class {} } },
+}));
+vi.mock('@casl/mongoose', () => ({ accessibleBy: () => ({ ofType: () => ({}) }) }));
+vi.mock('@bike4mind/utils/escapeRegex', () => ({ escapeRegex: (s: string) => s }));
+
+import '@pages/api/users/index';
+
+function mocks(user: unknown, query: Record<string, unknown>) {
+  const { req, res } = createMocks({ method: 'GET', query });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('GET /api/users - publicView enumeration guards', () => {
+  beforeEach(() => {
+    mockRefs.facet = undefined;
+  });
+
+  it('rejects downloadAll for a non-admin with 403', async () => {
+    const { req, res } = mocks({ id: 'u1', isAdmin: false }, { publicView: 'true', downloadAll: 'true' });
+    await mockRefs.getHandler!(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    // Never reached the aggregation.
+    expect(mockRefs.facet).toBeUndefined();
+  });
+
+  it('allows downloadAll for an admin', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true }, { downloadAll: 'true' });
+    await mockRefs.getHandler!(req, res);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('caps the publicView page size for a non-admin (limit 1000 -> 50)', async () => {
+    const { req, res } = mocks({ id: 'u1', isAdmin: false }, { publicView: 'true', limit: '1000' });
+    await mockRefs.getHandler!(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const limitStage = mockRefs.facet.paginatedResults.find((s: any) => '$limit' in s);
+    expect(limitStage.$limit).toBe(50);
+  });
+
+  it('does not cap the page size for an admin', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true }, { publicView: 'true', limit: '1000' });
+    await mockRefs.getHandler!(req, res);
+    const limitStage = mockRefs.facet.paginatedResults.find((s: any) => '$limit' in s);
+    expect(limitStage.$limit).toBe(1000);
+  });
+});

--- a/apps/client/pages/api/users/index.ts
+++ b/apps/client/pages/api/users/index.ts
@@ -74,6 +74,18 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
     const { page, limit, search, publicView, sortField, sortOrder, orgSearch, tags, downloadAll, projectId } =
       querySchema.parse(qs.parse(req.query));
 
+    // publicView is the limited directory search used by invite/member pickers; it
+    // bypasses CASL by design (regular users have no read grant on User). Keep it
+    // usable for targeted search, but not as a bulk-export or full-directory dump for
+    // non-admins: downloadAll (unbounded) is admin-only, and the publicView page size
+    // is capped. (Return 403 directly - the surrounding try/catch turns throws into 500.)
+    const isAdmin = !!req.user?.isAdmin;
+    if (downloadAll && !isAdmin) {
+      return res.status(403).json({ message: 'Bulk user export is admin-only' });
+    }
+    const PUBLIC_VIEW_MAX_LIMIT = 50;
+    const effectiveLimit = publicView && !isAdmin ? Math.min(limit, PUBLIC_VIEW_MAX_LIMIT) : limit;
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let query: mongoose.FilterQuery<any> = publicView
       ? User.find().getQuery()
@@ -239,7 +251,7 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
 
       results = await executeFacetCompatible(User, convertedBasePipeline, {
         totalCount: [{ $count: 'count' }],
-        paginatedResults: [{ $skip: (page - 1) * limit }, { $limit: limit }],
+        paginatedResults: [{ $skip: (page - 1) * effectiveLimit }, { $limit: effectiveLimit }],
       });
 
       const total = results[0].totalCount[0]?.count || 0;
@@ -250,7 +262,7 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
       return res.json({
         users: users.map((user: IUserObject) => User.hydrate(user)),
         currentPage: page,
-        totalPages: Math.ceil(total / limit),
+        totalPages: Math.ceil(total / effectiveLimit),
         totalUsers: total,
       });
     } else {

--- a/apps/client/server/managers/inviteManager.test.ts
+++ b/apps/client/server/managers/inviteManager.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// inviteManager imports these at module load; stub them so the pure helper loads
+// without pulling the real DB graph.
+vi.mock('@bike4mind/database', () => ({ FabFile: {}, Group: {}, Organization: {}, Session: {}, User: {} }));
+
+import { filterInviteRecipientsToSelf } from './inviteManager';
+
+const baseInvite = () => ({
+  id: 'inv1',
+  type: 'FabFile',
+  recipients: { pending: ['A@x.com', 'b@x.com'], accepted: ['c@x.com'], refused: ['d@x.com'] },
+});
+
+describe('filterInviteRecipientsToSelf', () => {
+  it('keeps only the caller entry (case-insensitive) and strips co-recipients', () => {
+    const out = filterInviteRecipientsToSelf(baseInvite(), 'a@x.com') as any;
+    expect(out.recipients).toEqual({ pending: ['A@x.com'], accepted: [], refused: [] });
+    const json = JSON.stringify(out);
+    expect(json).not.toContain('b@x.com');
+    expect(json).not.toContain('c@x.com');
+    expect(json).not.toContain('d@x.com');
+  });
+
+  it('normalizes a Mongoose-style doc via toJSON before filtering', () => {
+    const doc = { toJSON: () => baseInvite() };
+    const out = filterInviteRecipientsToSelf(doc, 'c@x.com') as any;
+    expect(out.recipients.accepted).toEqual(['c@x.com']);
+    expect(out.recipients.pending).toEqual([]);
+  });
+
+  it('returns empty recipient arrays when the caller has no email', () => {
+    const out = filterInviteRecipientsToSelf(baseInvite(), null) as any;
+    expect(out.recipients).toEqual({ pending: [], accepted: [], refused: [] });
+  });
+
+  it('leaves an invite without recipients untouched', () => {
+    const out = filterInviteRecipientsToSelf({ id: 'i2', type: 'Session' }, 'a@x.com') as any;
+    expect('recipients' in out).toBe(false);
+    expect(out.id).toBe('i2');
+  });
+});

--- a/apps/client/server/managers/inviteManager.ts
+++ b/apps/client/server/managers/inviteManager.ts
@@ -46,3 +46,34 @@ export const getInviteDetails = async (invite: IInviteDocument, includeUser?: bo
 
   return inviteWithDetails;
 };
+
+/**
+ * Invitee-facing serialization for an invite. Keeps the `recipients` shape -- the
+ * inbox UI checks `recipients.pending.includes(myEmail)` to flag invites addressed
+ * to the caller -- but strips every OTHER recipient's email from the pending/
+ * accepted/refused arrays (matching case-insensitively, as the pending match does).
+ * Normalizes a Mongoose doc via toJSON first.
+ *
+ * Use on every route that returns an invite to an INVITEE (inbox list, single GET,
+ * accept, refuse). Do NOT use on the owner-facing document-invite list, which
+ * legitimately shows the full recipient set to someone with share permission.
+ */
+export function filterInviteRecipientsToSelf<T>(invite: T, userEmail?: string | null): Record<string, unknown> {
+  const raw = invite as unknown as { toJSON?: () => Record<string, unknown> } & Record<string, unknown>;
+  const plain: Record<string, unknown> = typeof raw.toJSON === 'function' ? raw.toJSON() : { ...raw };
+  const recipients = plain.recipients as
+    | { pending?: string[]; accepted?: string[]; refused?: string[] }
+    | null
+    | undefined;
+  if (recipients) {
+    const self = userEmail?.toLowerCase();
+    const keepSelf = (arr?: string[]) =>
+      Array.isArray(arr) && self ? arr.filter(e => typeof e === 'string' && e.toLowerCase() === self) : [];
+    plain.recipients = {
+      pending: keepSelf(recipients.pending),
+      accepted: keepSelf(recipients.accepted),
+      refused: keepSelf(recipients.refused),
+    };
+  }
+  return plain;
+}


### PR DESCRIPTION
## Description

Follows the organization response-scoping PR by curating what several more read
endpoints return, so a caller only receives data appropriate to them. These are
response-shape / access-scope tightenings; no data model changes.

## Changes

- `GET /api/users` (publicView): the `publicView` directory search backs the
  invite/member pickers and intentionally bypasses CASL. Hardened so it can't be
  used for mass enumeration by non-admins: `downloadAll` (unbounded export) is now
  admin-only, and the publicView page size is capped (email stays, since the picker
  needs it for de-duplication).
- `GET /api/security/user-summary` and `GET /api/security/user-recent`: drop the
  IP-bucketed `emails` array from suspicious-pattern items (it exposed the email
  addresses of other users targeted from the same IP). Only the caller's own
  usernames are returned, as before.
- `GET /api/app-files`: a cross-user file inventory with populated owner name/email
  and no per-user scoping; its only consumer is the admin Files tab, so it is now
  admin-only.
- `GET /api/invites/[id]` (invitee-facing accept view): no longer returns
  `recipients` (the other invitees' email lists). The owner-facing document-invites
  list is a separate, share-gated route and is unchanged.
- `GET /api/publish/artifacts/[id]`: a viewer of a public artifact now receives a
  display-only DTO (publicId/title/description/visibility/commentPolicy/embedOrigins/
  publishedAt); the owner/admin still get the full record (the manage modal needs it).
- Handler tests for each.

## Guide for Testers

Use a **non-admin** user and an **admin**. Auth is a Bearer JWT (see prior test
recipes); base URL is the PR preview `app.pr<N>.preview.bike4mind.com`.

1. **User directory / invites** - As a non-admin, open a project and the "add members" / invite picker, type a few characters -> user search still returns matches (with the invited/already-member state correct). Then call `GET /api/users?publicView=true&downloadAll=true` directly -> expect **403**. As an admin, the admin Users page (which uses downloadAll) still loads.
2. **Security activity** - As any user, open the security/recent-activity view (or `GET /api/security/user-summary`) -> suspicious-pattern entries show your own usernames and contain **no** `emails` field.
3. **App files** - As a non-admin, `GET /api/app-files` -> expect **403**. As an admin, the admin Files tab still lists files with owner info.
4. **Invite accept** - Open an invite accept link (`/share/:id`) -> the page still shows the document name and inviter; the API response for `GET /api/invites/{id}` contains **no** `recipients`.
5. **Published artifact** - As a non-owner, `GET /api/publish/artifacts/{publicId}` for a public artifact -> response has title/description but **no** `ownerId`/`storageKeyPrefix`/moderation fields. As the owner, the manage/share modal still shows all settings.

### Regression Checks
1. Invite/member picker search returns results and dedupes already-invited users.
2. Admin Users page and admin Files tab still load fully.
3. Security recent-activity view renders.
4. Invite accept page renders name + inviter.
5. Published-artifact owner manage modal still shows visibility/gate/embed settings.

### What NOT to test
- Organization endpoints (covered by the prior PR).

## Additional Information

- Client handler tests pass (17 new/updated); `pnpm --filter @bike4mind/client typecheck` is clean; `eslint --quiet` reports 0 errors.
- Residual note: publicView paginated search remains available to non-admins (it powers invites); the bulk-export and large-page vectors are what this closes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
