### PR TITLE
chore(premium): bump overlay pins to current overlay main

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
-  "b4m-overwatch": "21dbc15bf04c97702b403616e9d097f323cfaf7f",
-  "b4m-libreoncology": "46c40b7e942efadf81f98b219792eca4d32fb4aa",
-  "b4m-optihashi": "ffc769f04fb6bb3ef004e23358c6984068c48f31",
-  "b4m-pi": "c95fc844445c8d3ae7b930acf6d4452ace25ae32",
+  "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
+  "b4m-libreoncology": "c917641b8155c311d217b021e414bba33c9eb72a",
+  "b4m-optihashi": "15177d29c422750dad50c65ce617b9988e4e15b4",
+  "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Bumps the premium overlay pins to current overlay `main`:

- `b4m-overwatch` -> `9110965564ff8316eb06ddcc9be88881deda7690`
- `b4m-libreoncology` -> `c917641b8155c311d217b021e414bba33c9eb72a`
- `b4m-optihashi` -> `15177d29c422750dad50c65ce617b9988e4e15b4`
- `b4m-pi` -> `6bc009c8b0bcc80c3688db0ee5c546e384ead133`

Overlay-pin-only change; no application source changes.
