### PR TITLE
chore(premium): set b4m-overwatch overlay pin to 9110965564ff8316eb06ddcc9be88881deda7690

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,5 +1,5 @@
 {
-  "b4m-overwatch": "21dbc15bf04c97702b403616e9d097f323cfaf7f",
+  "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
   "b4m-libreoncology": "46c40b7e942efadf81f98b219792eca4d32fb4aa",
   "b4m-optihashi": "ffc769f04fb6bb3ef004e23358c6984068c48f31",
   "b4m-pi": "c95fc844445c8d3ae7b930acf6d4452ace25ae32",


### PR DESCRIPTION
Sets the `b4m-overwatch` pin in `premium-overlay.lock.json` to `9110965564ff8316eb06ddcc9be88881deda7690`. Overlay-pin-only change; no application source changes; the other four overlay pins are unchanged.

A staging/preview deploy validates the host build against the new overlay SHA before merge.