### PR TITLE
feat(client): add empty-session splash slot to chat panel

### DIFF
--- a/apps/client/app/components/Session/SessionContainer.tsx
+++ b/apps/client/app/components/Session/SessionContainer.tsx
@@ -59,6 +59,8 @@ interface SessionLayoutProps {
   autoHideOnEmpty?: boolean;
   /** Custom splash to show instead of NotebookSplash when no session is active */
   customSplash?: React.ReactNode;
+  /** Opt-in splash shown inside the chat area when the active session has no messages yet. Forwarded to SessionMiddle. */
+  emptySessionSplash?: React.ReactNode;
   /** Extra action buttons rendered in the FloatingChatWindow header (before minimize/close) */
   floatingChatHeaderActions?: React.ReactNode;
   /** Called when the server auto-creates a session (e.g. first prompt with no session). Lets parent pages like /opti sync their local session state. */
@@ -181,6 +183,7 @@ const SessionContainer: FC<SessionLayoutProps> = ({
   isLoading,
   autoHideOnEmpty,
   customSplash,
+  emptySessionSplash,
   floatingChatHeaderActions,
   onSessionCreated,
 }) => {
@@ -505,7 +508,11 @@ const SessionContainer: FC<SessionLayoutProps> = ({
                     customSplash || <NotebookSplash />
                   ) : (
                     <Box sx={{ position: 'relative', flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-                      <SessionMiddle isFullWidth={isFullWidth} sessionId={currentSessionId} />
+                      <SessionMiddle
+                        isFullWidth={isFullWidth}
+                        sessionId={currentSessionId}
+                        emptySessionSplash={emptySessionSplash}
+                      />
                       {pendingFirstMessage && (
                         <Box
                           sx={{
@@ -599,7 +606,11 @@ const SessionContainer: FC<SessionLayoutProps> = ({
                       flexDirection: 'column',
                     }}
                   >
-                    <SessionMiddle isFullWidth={false} sessionId={currentSessionId} />
+                    <SessionMiddle
+                      isFullWidth={false}
+                      sessionId={currentSessionId}
+                      emptySessionSplash={emptySessionSplash}
+                    />
                     {pendingFirstMessage && (
                       <Box
                         sx={{
@@ -657,7 +668,11 @@ const SessionContainer: FC<SessionLayoutProps> = ({
                 {!currentSessionId ? (
                   customSplash || <NotebookSplash />
                 ) : (
-                  <SessionMiddle isFullWidth={false} sessionId={currentSessionId} />
+                  <SessionMiddle
+                    isFullWidth={false}
+                    sessionId={currentSessionId}
+                    emptySessionSplash={emptySessionSplash}
+                  />
                 )}
               </Box>
               <Box

--- a/apps/client/app/components/Session/SessionMiddle.tsx
+++ b/apps/client/app/components/Session/SessionMiddle.tsx
@@ -40,10 +40,14 @@ import { dispatchUiSideEffects } from '@client/app/utils/uiSideEffectDispatcher'
 import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSessionLayout';
 import { useVirtuosoPagination } from './hooks/useVirtuosoPagination';
 import { useStreamingMessageMerge } from './hooks/useStreamingMessageMerge';
+import { shouldShowEmptySessionSplash } from './emptySessionSplashGate';
 
 interface IProps {
   isFullWidth?: boolean;
   sessionId: string;
+  /** Opt-in content shown when the session is loaded and has no messages
+   *  (nothing streaming/pending). Hosts like /opti pass a welcome splash. */
+  emptySessionSplash?: React.ReactNode;
 }
 
 // Separate component for scroll button to prevent parent re-renders.
@@ -103,7 +107,7 @@ const commandHandlers: CommandHandlers = {
   '/edit_image': handleImageEditCommand,
 };
 
-const SessionMiddle: React.FC<IProps> = ({ isFullWidth = false, sessionId }) => {
+const SessionMiddle: React.FC<IProps> = ({ isFullWidth = false, sessionId, emptySessionSplash }) => {
   const queryClient = useQueryClient();
   const deleteQuest = useDeleteQuest(queryClient);
   const updateQuest = useUpdateQuest(queryClient);
@@ -464,6 +468,18 @@ const SessionMiddle: React.FC<IProps> = ({ isFullWidth = false, sessionId }) => 
           {/* Paint on read-gated /chat content without waiting on canRead's metadata fetch */}
           {!canShowConversation(canRead, flattenQuests.length > 0) ? (
             <NotebookSplash />
+          ) : shouldShowEmptySessionSplash({
+              hasSplash: Boolean(emptySessionSplash),
+              questCount: flattenQuests.length,
+              isFetching,
+              hasActiveQuest,
+            }) ? (
+            <Box
+              data-testid="session-middle-empty-splash"
+              sx={{ flex: 1, minHeight: 0, overflow: 'auto', display: 'flex', flexDirection: 'column' }}
+            >
+              {emptySessionSplash}
+            </Box>
           ) : (
             <ChatHistory
               filteredChatHistory={filteredChatHistory}

--- a/apps/client/app/components/Session/emptySessionSplashGate.test.ts
+++ b/apps/client/app/components/Session/emptySessionSplashGate.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowEmptySessionSplash } from './emptySessionSplashGate';
+
+const base = { hasSplash: true, questCount: 0, isFetching: false, hasActiveQuest: false };
+
+describe('shouldShowEmptySessionSplash', () => {
+  it('shows the splash for a loaded, empty session with nothing in flight', () => {
+    expect(shouldShowEmptySessionSplash(base)).toBe(true);
+  });
+
+  it('hides when no splash content was provided (default rendering)', () => {
+    expect(shouldShowEmptySessionSplash({ ...base, hasSplash: false })).toBe(false);
+  });
+
+  it('hides while quests are still fetching (no flash on sessions with history)', () => {
+    expect(shouldShowEmptySessionSplash({ ...base, isFetching: true })).toBe(false);
+  });
+
+  it('hides once the session has messages', () => {
+    expect(shouldShowEmptySessionSplash({ ...base, questCount: 3 })).toBe(false);
+  });
+
+  it('hides while a first message is streaming or optimistically pending', () => {
+    expect(shouldShowEmptySessionSplash({ ...base, hasActiveQuest: true })).toBe(false);
+  });
+});

--- a/apps/client/app/components/Session/emptySessionSplashGate.ts
+++ b/apps/client/app/components/Session/emptySessionSplashGate.ts
@@ -3,7 +3,7 @@ interface EmptySessionSplashGateArgs {
   hasSplash: boolean;
   /** Raw (unfiltered) quest count for the session. */
   questCount: number;
-  /** Quests query still in flight — bias to hidden so sessions with history never flash the splash. */
+  /** Quests query still in flight - bias to hidden so sessions with history never flash the splash. */
   isFetching: boolean;
   /** A message is streaming or optimistically pending (isStreaming || showOptimisticSpinner). */
   hasActiveQuest: boolean;

--- a/apps/client/app/components/Session/emptySessionSplashGate.ts
+++ b/apps/client/app/components/Session/emptySessionSplashGate.ts
@@ -1,0 +1,25 @@
+interface EmptySessionSplashGateArgs {
+  /** Whether the host page provided splash content at all. */
+  hasSplash: boolean;
+  /** Raw (unfiltered) quest count for the session. */
+  questCount: number;
+  /** Quests query still in flight — bias to hidden so sessions with history never flash the splash. */
+  isFetching: boolean;
+  /** A message is streaming or optimistically pending (isStreaming || showOptimisticSpinner). */
+  hasActiveQuest: boolean;
+}
+
+/**
+ * Gate for SessionMiddle's opt-in empty-session splash: only a loaded,
+ * genuinely empty session with nothing in flight shows it. Kept pure so the
+ * hide-on-first-send semantics are unit-testable without SessionMiddle's
+ * context web.
+ */
+export function shouldShowEmptySessionSplash({
+  hasSplash,
+  questCount,
+  isFetching,
+  hasActiveQuest,
+}: EmptySessionSplashGateArgs): boolean {
+  return hasSplash && questCount === 0 && !isFetching && !hasActiveQuest;
+}


### PR DESCRIPTION
## Summary

Adds a generic, opt-in `emptySessionSplash?: React.ReactNode` slot to the chat panel: host pages can now supply content to render inside the chat area when the active session exists but has no messages yet. With the prop omitted (the default everywhere), rendering is unchanged.

- `SessionMiddle` accepts the prop and shows it only when the session is loaded and genuinely empty with nothing in flight; the gate is a pure helper (`shouldShowEmptySessionSplash`) using the raw quest count (never the search-filtered list), `isFetching`, and the streaming/optimistic state, so the splash hides the instant a first message is sent and never flashes over sessions with history.
- `SessionContainer` forwards the prop to its three `SessionMiddle` render sites (fullwidth, floating window, docked panel).

## Testing

- New co-located unit tests for the gate helper (5 cases: shows on loaded-and-empty, hides when no content provided / while fetching / with messages / while streaming or optimistically pending).
- Full client suite green (5880 passed / 81 skipped); typecheck clean.
- Manually verified end-to-end in a running app via a host page passing the prop: splash renders on an empty session, disappears immediately on first send, no flash on sessions with history, and the default (prop omitted) rendering is unchanged.

Note: the render branch itself is covered by manual E2E rather than a SessionMiddle component test (deliberate: SessionMiddle's context web makes a render test cost far more than it verifies; the gate logic is unit-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
