### PR TITLE
chore(premium): set b4m-optihashi overlay pin to e49652b2907dc546d2f53232c051f02293b79ca4

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
   "b4m-libreoncology": "c917641b8155c311d217b021e414bba33c9eb72a",
-  "b4m-optihashi": "15177d29c422750dad50c65ce617b9988e4e15b4",
+  "b4m-optihashi": "e49652b2907dc546d2f53232c051f02293b79ca4",
   "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Sets the b4m-optihashi overlay pin to e49652b2907dc546d2f53232c051f02293b79ca4. Overlay-pin-only change; no application source changes.