### PR TITLE
fix(client): add key-rotation fallback to GitHubService credential decrypt

### DIFF
--- a/apps/client/server/services/githubService.test.ts
+++ b/apps/client/server/services/githubService.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock the dependencies using vi.hoisted
-const { mockOctokit, mockRepository, mockConfig, mockDecryptSecret, mockEncryptSecret, mockIsEncrypted, mockLogger } =
+const { mockOctokit, mockRepository, mockConfig, mockDecryptToken, mockEncryptSecret, mockIsEncrypted, mockLogger } =
   vi.hoisted(() => ({
     mockOctokit: {
       paginate: vi.fn(),
@@ -48,7 +48,7 @@ const { mockOctokit, mockRepository, mockConfig, mockDecryptSecret, mockEncryptS
     mockConfig: {
       SECRET_ENCRYPTION_KEY: 'a'.repeat(64), // Valid 64 hex char key
     },
-    mockDecryptSecret: vi.fn((val: string) => val),
+    mockDecryptToken: vi.fn((val: string) => val),
     mockEncryptSecret: vi.fn((val: string) => `encrypted:${val}`),
     mockIsEncrypted: vi.fn(() => false),
     mockLogger: {
@@ -83,9 +83,13 @@ vi.mock('@server/utils/config', () => ({
 
 // Mock secret encryption
 vi.mock('@server/security/secretEncryption', () => ({
-  decryptSecret: mockDecryptSecret,
   encryptSecret: mockEncryptSecret,
   isEncrypted: mockIsEncrypted,
+}));
+
+// Mock token encryption (rotation-aware decrypt: current key, then previous)
+vi.mock('@server/security/tokenEncryption', () => ({
+  decryptToken: mockDecryptToken,
 }));
 
 // Mock @bike4mind/common
@@ -281,10 +285,10 @@ describe('GitHubService', () => {
           ...mockConnection,
           isSystemDefault: true,
         });
-        // Mark the token as encrypted so decryptSecret is actually called,
+        // Mark the token as encrypted so decryptToken is actually called,
         // then make decryption blow up to simulate an auth init failure.
         mockIsEncrypted.mockReturnValueOnce(true);
-        mockDecryptSecret.mockImplementationOnce(() => {
+        mockDecryptToken.mockImplementationOnce(() => {
           throw new Error('decryption failed');
         });
 
@@ -303,7 +307,7 @@ describe('GitHubService', () => {
           isSystemDefault: true,
         });
         mockIsEncrypted.mockReturnValueOnce(true);
-        mockDecryptSecret.mockImplementationOnce(() => {
+        mockDecryptToken.mockImplementationOnce(() => {
           throw new Error('decryption failed');
         });
 
@@ -317,6 +321,28 @@ describe('GitHubService', () => {
             detail: 'Failed to decrypt credentials. Token may need rotation.',
           })
         );
+      });
+
+      // Regression (LiveOps/SRE outage): a github_app private key encrypted under a
+      // pre-rotation key must still authenticate. The auth-init path must decrypt via
+      // decryptToken (current key, then SECRET_ENCRYPTION_KEY_PREVIOUS), mirroring the
+      // GitHub webhook paths - not raw decryptSecret with the current key only.
+      it('should recover a github_app credential via the key-rotation fallback', async () => {
+        const encryptedPrivateKey = 'aa'.repeat(16) + ':' + 'bb'.repeat(16) + ':deadbeef';
+        const decryptedPem = '-----BEGIN RSA PRIVATE KEY-----\nrecovered\n-----END RSA PRIVATE KEY-----';
+        mockRepository.findSystemDefaultWithCredentials.mockResolvedValue({
+          ...mockAppConnection,
+          isSystemDefault: true,
+          privateKey: encryptedPrivateKey,
+        });
+        // Ciphertext looks encrypted; decryptToken succeeds (as it would using the previous key).
+        mockIsEncrypted.mockReturnValue(true);
+        mockDecryptToken.mockReturnValue(decryptedPem);
+
+        const service = await GitHubService.forSystem(logger);
+
+        expect(service).not.toBeNull();
+        expect(mockDecryptToken).toHaveBeenCalledWith(encryptedPrivateKey);
       });
 
       it('should log reason "missing-fields" when a github_app connection is missing required fields', async () => {
@@ -344,7 +370,7 @@ describe('GitHubService', () => {
           isSystemDefault: true,
         });
         mockIsEncrypted.mockReturnValueOnce(true);
-        mockDecryptSecret.mockImplementationOnce(() => {
+        mockDecryptToken.mockImplementationOnce(() => {
           throw new Error('cipher gcm tag mismatch: 0xDEADBEEF iv=abcdef');
         });
 

--- a/apps/client/server/services/githubService.ts
+++ b/apps/client/server/services/githubService.ts
@@ -27,7 +27,8 @@ import {
 } from '@bike4mind/common';
 import { orgGitHubConnectionRepository } from '@bike4mind/database';
 import { Config } from '@server/utils/config';
-import { decryptSecret, encryptSecret, isEncrypted } from '@server/security/secretEncryption';
+import { encryptSecret, isEncrypted } from '@server/security/secretEncryption';
+import { decryptToken } from '@server/security/tokenEncryption';
 
 const USER_AGENT = 'bike4mind-github-service/1.0';
 const GITHUB_REQUEST_TIMEOUT_MS = 10000; // 10s — fail fast on hung connections (GitHub gateway timeout is ~11s)
@@ -334,7 +335,7 @@ export class GitHubService {
       if (connection.connectionType === 'github_app') {
         octokit = await GitHubService.createOctokitForApp(connection, encryptionKey, logger);
       } else {
-        octokit = GitHubService.createOctokitForPAT(connection, encryptionKey, logger);
+        octokit = GitHubService.createOctokitForPAT(connection, logger);
       }
     } catch (error) {
       // Log a coarse reason plus a safe detail so operators can distinguish a misconfigured
@@ -378,11 +379,14 @@ export class GitHubService {
       throw new GitHubAuthInitError('GitHub App connection missing required fields', 'missing-fields');
     }
 
-    // Decrypt the private key with sanitized error handling
+    // Decrypt the private key with sanitized error handling. Route through decryptToken()
+    // for key-rotation fallback: it tries SECRET_ENCRYPTION_KEY, then
+    // SECRET_ENCRYPTION_KEY_PREVIOUS. This mirrors the GitHub webhook decrypt paths so a
+    // credential encrypted under a pre-rotation key still authenticates.
     let privateKey = connection.privateKey;
     if (isEncrypted(privateKey)) {
       try {
-        privateKey = decryptSecret(privateKey, encryptionKey);
+        privateKey = decryptToken(privateKey) ?? privateKey;
       } catch {
         // Never expose decryption errors - they may reveal encryption structure
         throw new GitHubAuthInitError('Failed to decrypt credentials. Key may need rotation.', 'decrypt-failed');
@@ -414,20 +418,17 @@ export class GitHubService {
    *
    * @throws Error if decryption fails (sanitized message)
    */
-  private static createOctokitForPAT(
-    connection: IOrgGitHubConnectionDocument,
-    encryptionKey: string,
-    _logger: Logger
-  ): Octokit {
+  private static createOctokitForPAT(connection: IOrgGitHubConnectionDocument, _logger: Logger): Octokit {
     if (!connection.accessToken) {
       throw new GitHubAuthInitError('Service account connection missing credentials', 'missing-fields');
     }
 
-    // Decrypt the token with sanitized error handling
+    // Decrypt the token with sanitized error handling. Route through decryptToken() for
+    // key-rotation fallback (current key, then SECRET_ENCRYPTION_KEY_PREVIOUS).
     let token = connection.accessToken;
     if (isEncrypted(token)) {
       try {
-        token = decryptSecret(token, encryptionKey);
+        token = decryptToken(token) ?? token;
       } catch {
         // Never expose decryption errors - they may reveal encryption structure
         throw new GitHubAuthInitError('Failed to decrypt credentials. Token may need rotation.', 'decrypt-failed');
@@ -465,7 +466,8 @@ export class GitHubService {
               let token = conn.cachedAccessToken;
               if (isEncrypted(token)) {
                 try {
-                  token = decryptSecret(token, encryptionKey);
+                  // Key-rotation fallback: current key, then SECRET_ENCRYPTION_KEY_PREVIOUS.
+                  token = decryptToken(token) ?? token;
                 } catch {
                   // Sanitize decryption errors
                   logger.warn('[GitHubService] Cached token decryption failed, will regenerate');


### PR DESCRIPTION
## Problem

`GitHubService` decrypted stored connection credentials using the current `SECRET_ENCRYPTION_KEY` only, through the raw `decryptSecret` helper. Once the encryption key is rotated, any credential that was encrypted under the prior key can no longer be decrypted, so GitHub App / PAT connections created before the rotation fail to authenticate. The failure surfaces as `reason: "decrypt-failed"` in the auth-init logs, and takes down the features that authenticate through this path (LiveOps config-health and the SRE Agent, which share a single `github_app` connection).

This is the same class of bug that was already fixed for the org and SRE GitHub webhook decrypt paths. The `GitHubService` auth-init path was simply missed in that pass, so it never gained the fallback that the `decryptToken`-based integrations (Jira, Notion, Slack) and the webhook handlers already have.

## Fix

Route the three `GitHubService` decrypt sites through `decryptToken`, which tries the current `SECRET_ENCRYPTION_KEY` first and then `SECRET_ENCRYPTION_KEY_PREVIOUS`:

- GitHub App private key (`createOctokitForApp`)
- PAT access token (`createOctokitForPAT`)
- cached installation token (`createTokenCache.get`)

Encryption of the cached token still uses the current key, so freshly written cache entries migrate forward. The now-unused `encryptionKey` parameter was dropped from the PAT helper. This is non-destructive: an affected connection recovers on the next deploy with no need to re-enter credentials, and future rotations no longer orphan GitHub credentials.

## Testing

- New regression test: a `github_app` private key that only the fallback can decrypt still authenticates, and the decrypt goes through `decryptToken`.
- Existing decrypt-failure tests migrated to the rotation-aware helper.
- `pnpm --filter @bike4mind/client test githubService.test.ts` -> 75 passed
- `pnpm --filter @bike4mind/client typecheck` -> clean
- eslint on the changed files -> clean
