### PR TITLE
fix(agent): soften recovered tool-error observations in the iteration stream

### DIFF
--- a/apps/client/app/components/Session/AgentExecution/IterationStep.test.tsx
+++ b/apps/client/app/components/Session/AgentExecution/IterationStep.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { IAgentStep } from '@bike4mind/common';
+import IterationStep, { isErrorObservation } from './IterationStep';
+
+/**
+ * Covers the tool-error observation treatment (issue #653): a recovered error
+ * reads as a calm, collapsed "Retried" note; a fatal error (run failed) stays
+ * expanded and danger-toned; normal steps are untouched.
+ */
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+  React.createElement(CssVarsProvider, { theme: appTheme }, children);
+
+const step = (over: Partial<IAgentStep> = {}): IAgentStep => ({
+  type: 'observation',
+  content: 'ok result',
+  metadata: { timestamp: 1, toolName: 'optihashi_formulate' },
+  ...over,
+});
+
+const ERROR = 'Error: Could not parse the model response as JSON.\n\nPlease rephrase with more specifics.';
+
+describe('isErrorObservation', () => {
+  it('matches an observation whose content starts with "Error:"', () => {
+    expect(isErrorObservation(step({ content: ERROR }))).toBe(true);
+    expect(isErrorObservation(step({ content: '  Error: leading whitespace' }))).toBe(true);
+  });
+  it('does not match a normal observation or a non-observation containing "Error:"', () => {
+    expect(isErrorObservation(step({ content: 'sourced instance ok' }))).toBe(false);
+    expect(isErrorObservation(step({ type: 'action', content: 'Error: not an observation' }))).toBe(false);
+    expect(isErrorObservation(step({ type: 'thought', content: 'thinking about the Error: case' }))).toBe(false);
+  });
+});
+
+describe('IterationStep - tool-error observation', () => {
+  it('recovered (default): shows a "Retried" chip and collapses the error detail', () => {
+    render(<IterationStep step={step({ content: ERROR })} />, { wrapper: Wrapper });
+    expect(screen.getByText('Retried')).toBeTruthy();
+    expect(screen.getByText(/the agent hit a tool error here and retried/i)).toBeTruthy();
+    // Detail hidden until expanded.
+    expect(screen.queryByText(/Could not parse the model response/)).toBeNull();
+    const box = screen.getByTestId('iteration-step-observation');
+    expect(box.getAttribute('data-error-tone')).toBe('recovered');
+  });
+
+  it('recovered: "Show detail" reveals the raw error, "Hide detail" collapses it again', () => {
+    render(<IterationStep step={step({ content: ERROR })} />, { wrapper: Wrapper });
+    fireEvent.click(screen.getByTestId('iteration-step-observation-toggle'));
+    expect(screen.getByText(/Could not parse the model response/)).toBeTruthy();
+    fireEvent.click(screen.getByTestId('iteration-step-observation-toggle'));
+    expect(screen.queryByText(/Could not parse the model response/)).toBeNull();
+  });
+
+  it('fatal (recovered=false): shows a "Tool error" chip with the detail expanded', () => {
+    render(<IterationStep step={step({ content: ERROR })} recovered={false} />, { wrapper: Wrapper });
+    expect(screen.getByText('Tool error')).toBeTruthy();
+    expect(screen.getByText(/Could not parse the model response/)).toBeTruthy();
+    const box = screen.getByTestId('iteration-step-observation');
+    expect(box.getAttribute('data-error-tone')).toBe('fatal');
+  });
+
+  it('a normal observation is unaffected by the error treatment', () => {
+    render(<IterationStep step={step({ content: 'sourced instance ok' })} recovered={false} />, { wrapper: Wrapper });
+    expect(screen.getByText('Observation')).toBeTruthy();
+    expect(screen.getByText('sourced instance ok')).toBeTruthy();
+    expect(screen.queryByText('Retried')).toBeNull();
+    expect(screen.queryByText('Tool error')).toBeNull();
+  });
+});

--- a/apps/client/app/components/Session/AgentExecution/IterationStep.tsx
+++ b/apps/client/app/components/Session/AgentExecution/IterationStep.tsx
@@ -5,6 +5,11 @@
  * Each gets a label + icon and an indented content block. Long tool
  * observations are truncated to 2KB on the server, so we don't repeat
  * truncation here.
+ *
+ * Tool-error observations get a distinct treatment (see ErrorObservation):
+ * when the run recovered from the error (retried and continued), the error is
+ * shown softly and collapsed so a successful run doesn't read as broken; when
+ * the run actually failed, it stays expanded and danger-toned.
  */
 
 import { FC, ReactNode, useMemo, useState } from 'react';
@@ -13,10 +18,19 @@ import PsychologyOutlinedIcon from '@mui/icons-material/PsychologyOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ReplayOutlinedIcon from '@mui/icons-material/ReplayOutlined';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import type { IAgentStep } from '@bike4mind/common';
 
 interface IterationStepProps {
   step: IAgentStep;
+  /**
+   * Whether the run recovered from an error at this step. Only meaningful for a
+   * tool-error observation: `true` (default) presents it as a soft, collapsed
+   * "retried" note; `false` (the run failed on it) keeps it expanded and
+   * danger-toned. Passed down from the stream, which knows the run's status.
+   */
+  recovered?: boolean;
 }
 
 const STEP_META: Record<
@@ -36,9 +50,28 @@ const STEP_META: Record<
 // observation (the common case) renders untouched.
 const OBSERVATION_PREVIEW_LINES = 6;
 
-const IterationStep: FC<IterationStepProps> = ({ step }) => {
-  const meta = STEP_META[step.type];
+// A failed tool call surfaces as an observation whose content the server
+// prefixes with "Error: " (ReActAgent.observationForResult). Aborts/cancels
+// use a different placeholder, so this only matches genuine tool errors.
+export function isErrorObservation(step: IAgentStep): boolean {
+  return step.type === 'observation' && /^\s*Error:/.test(step.content);
+}
+
+const IterationStep: FC<IterationStepProps> = ({ step, recovered = true }) => {
   const toolName = step.metadata?.toolName;
+
+  // Tool errors the agent recovered from (or that the run ultimately survived)
+  // shouldn't read as a broken run. Give them their own softened render.
+  // Branch here (no hooks in this dispatcher) so each render path keeps a
+  // stable, unconditional hook order.
+  if (isErrorObservation(step)) {
+    return <ErrorObservation step={step} toolName={toolName} recovered={recovered} />;
+  }
+  return <StandardStep step={step} toolName={toolName} />;
+};
+
+const StandardStep: FC<{ step: IAgentStep; toolName?: string }> = ({ step, toolName }) => {
+  const meta = STEP_META[step.type];
 
   // Only observations get truncated - thought/action are typically short
   // and truncating a final_answer would defeat the point of showing it.
@@ -95,6 +128,89 @@ const IterationStep: FC<IterationStepProps> = ({ step }) => {
             : `Show full result (${hiddenLineCount} more line${hiddenLineCount === 1 ? '' : 's'})`}
         </Link>
       ) : null}
+    </Box>
+  );
+};
+
+/**
+ * A tool-error observation. Recovered errors (the run retried/continued) read as
+ * a calm, collapsed "retried" note in warning tone - honest but not alarming,
+ * so a completed run doesn't look broken. A fatal error (the run failed on it)
+ * stays expanded in danger tone.
+ */
+const ErrorObservation: FC<{ step: IAgentStep; toolName?: string; recovered: boolean }> = ({
+  step,
+  toolName,
+  recovered,
+}) => {
+  // Recovered errors start collapsed (detail on demand); fatal errors start open.
+  const [open, setOpen] = useState(!recovered);
+  const tone = recovered ? 'warning' : 'danger';
+
+  return (
+    <Box
+      data-testid="iteration-step-observation"
+      data-error-tone={recovered ? 'recovered' : 'fatal'}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 0.5,
+        pl: 2,
+        py: 0.75,
+        borderLeft: theme => `2px solid ${theme.palette[tone].outlinedBorder}`,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Chip
+          size="sm"
+          color={tone}
+          variant="soft"
+          startDecorator={recovered ? <ReplayOutlinedIcon fontSize="small" /> : <ErrorOutlineIcon fontSize="small" />}
+        >
+          {recovered ? 'Retried' : 'Tool error'}
+        </Chip>
+        {toolName ? (
+          <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+            {toolName}
+          </Typography>
+        ) : null}
+      </Box>
+
+      {recovered && !open ? (
+        <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+          The agent hit a tool error here and retried.{' '}
+          <Link
+            component="button"
+            level="body-sm"
+            underline="hover"
+            onClick={() => setOpen(true)}
+            data-testid="iteration-step-observation-toggle"
+          >
+            Show detail
+          </Link>
+        </Typography>
+      ) : (
+        <>
+          <Typography
+            level="body-sm"
+            sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', color: `${tone}.plainColor` }}
+          >
+            {step.content}
+          </Typography>
+          {recovered ? (
+            <Link
+              component="button"
+              level="body-xs"
+              underline="hover"
+              onClick={() => setOpen(false)}
+              sx={{ alignSelf: 'flex-start', color: 'text.tertiary' }}
+              data-testid="iteration-step-observation-toggle"
+            >
+              Hide detail
+            </Link>
+          ) : null}
+        </>
+      )}
     </Box>
   );
 };

--- a/apps/client/app/components/Session/AgentExecution/IterationStream.tsx
+++ b/apps/client/app/components/Session/AgentExecution/IterationStream.tsx
@@ -278,7 +278,10 @@ const IterationStream: FC<IterationStreamProps> = ({ executionId, hideFinalAnswe
                       const nestedChildId = stepToChildId.get(stepKey);
                       return (
                         <Box key={stepKey}>
-                          <IterationStep step={s.step} />
+                          {/* A tool-error observation is "recovered" unless the run
+                              actually failed - the stream knows the run status, the
+                              step doesn't. */}
+                          <IterationStep step={s.step} recovered={execution.status !== 'failed'} />
                           {/* Inline child render for `delegate_to_agent` actions
                               that dispatched a foreground subagent. Background
                               subagents surface in the header badge instead. */}

--- a/apps/client/app/components/Session/AgentExecution/SubagentStepNest.tsx
+++ b/apps/client/app/components/Session/AgentExecution/SubagentStepNest.tsx
@@ -124,7 +124,7 @@ const SubagentStepNest: FC<SubagentStepNestProps> = ({ topLevelExecutionId, chil
               const grandchild = grandchildId ? child.childExecutions[grandchildId] : undefined;
               return (
                 <Box key={stepKey}>
-                  <IterationStep step={s.step} />
+                  <IterationStep step={s.step} recovered={child.status !== 'failed'} />
                   {grandchild && depth < MAX_INLINE_DEPTH && (
                     <SubagentStepNest topLevelExecutionId={topLevelExecutionId} child={grandchild} depth={depth + 1} />
                   )}


### PR DESCRIPTION
## Description

Closes #653.

When an agent tool call returns an error that the agent then **recovers from** (retries, or the run continues and completes), the failed attempt used to render as a plain red-looking `Error: ...` observation in the iteration stream. A successful run looked broken. Reported live: `optihashi_formulate` returned `Error: Could not parse the model response as JSON` on one iteration; a later iteration succeeded and the run completed, but the scary error stayed in the trace with no indication it was recovered.

Now a tool-error observation is presented by outcome:
- **Recovered** (run did not fail) -> a calm, collapsed **"Retried"** note in warning tone: _"The agent hit a tool error here and retried."_ with a **Show detail** toggle for the raw error.
- **Fatal** (run actually failed) -> stays **expanded** in danger tone (**"Tool error"**), so real failures are still surfaced clearly.

## How it works

- `IterationStep` detects an error observation via the server's canonical prefix (`ReActAgent.observationForResult` writes `Error: <message>`; aborts/cancels use a different placeholder, so they aren't misdetected).
- The **stream** knows the run status, the step doesn't - so `recovered` is passed down: `execution.status !== 'failed'` for the top-level stream, `child.status !== 'failed'` for subagent steps.
- The dispatcher branches with no hooks of its own (stable hook order); normal steps render exactly as before.

## Changes

- `apps/client/.../AgentExecution/IterationStep.tsx` - error-observation detection (`isErrorObservation`), `recovered` prop, and the recovered/fatal render (`ErrorObservation`); normal render extracted to `StandardStep`.
- `apps/client/.../AgentExecution/IterationStream.tsx` - pass `recovered={execution.status !== 'failed'}`.
- `apps/client/.../AgentExecution/SubagentStepNest.tsx` - pass `recovered={child.status !== 'failed'}`.
- `apps/client/.../AgentExecution/IterationStep.test.tsx` - new: recovered collapses + "Retried" chip; toggle reveals/hides detail; fatal expands + "Tool error" chip; normal observations unaffected; `isErrorObservation` matching.

## Guide for Testers

**What you're testing:** that an agent run which hits a tool error but still finishes no longer looks like it failed.

1. Open an agent-mode session (e.g. `/opti` with Agent mode ON) and send a multi-step prompt that runs several tool calls. (Occasionally a formulate/tool step returns an error the agent recovers from - that's the case this targets.)
2. In the iteration trace, find an iteration whose tool call errored but the **run still completed**.
   - **Expected:** that step shows a **"Retried"** chip (amber/warning) and the one-line text _"The agent hit a tool error here and retried."_ - **not** a raw `Error: ...` dump. The overall run still shows **Completed** with its final answer.
3. Click **Show detail** on that step.
   - **Expected:** the raw error text expands; **Hide detail** collapses it again.
4. (Failure path) If you can force a run to actually **fail** on a tool error, that error should render **expanded** with a red **"Tool error"** chip - fatal errors stay loud.

### Regression checks
- Normal (non-error) observations, thoughts, actions, and final answers render exactly as before, including the existing "Show full result" truncation on long observations.
- Subagent (delegated) steps get the same treatment based on the child's status.

### What NOT to test
- Backend/tool behavior is unchanged - this is presentation only. It does not change whether a tool errors or how the agent recovers.

## Checklist
- [x] New unit test added and passing (`IterationStep.test.tsx`, 6 tests)
- [x] Lint clean on touched files
- [x] Presentation-only; no execution behavior change
