### PR TITLE
chore(premium): add b4m-bob overlay pin

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,4 +1,5 @@
 {
+  "b4m-bob": "72235ca1b3fa53421917a1e7c1f244af18d2ed2b",
   "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
   "b4m-libreoncology": "c917641b8155c311d217b021e414bba33c9eb72a",
   "b4m-optihashi": "8beeca04122d794e752d66288baab1b09df4b9b1",


### PR DESCRIPTION
Sets the b4m-bob overlay pin to 72235ca1b3fa53421917a1e7c1f244af18d2ed2b. Overlay-pin-only change; no application source changes.