### PR TITLE
feat(agent): optimizer agent solves any family (offer optihashi_solve + autonomous loop)

### DIFF
--- a/apps/client/app/components/Session/AgentExecution/loadingCopy.ts
+++ b/apps/client/app/components/Session/AgentExecution/loadingCopy.ts
@@ -52,6 +52,7 @@ const TOOL_RUNNING_COPY: Record<string, string> = {
   optihashi_formulate: 'Formulating the optimization model…',
   optihashi_edit_problem: 'Refining the model…',
   optihashi_schedule: 'Racing solvers…',
+  optihashi_solve: 'Racing solvers…',
 };
 
 export function copyForRunningTool(toolName: string | undefined): string {

--- a/apps/client/server/queueHandlers/agentExecutor.optiProfile.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.optiProfile.test.ts
@@ -10,6 +10,7 @@ describe('buildOptiOrchestrationProfile', () => {
     expect(profile.allowedTools).toContain('optihashi_formulate');
     expect(profile.allowedTools).toContain('optihashi_edit_problem');
     expect(profile.allowedTools).toContain('optihashi_schedule');
+    expect(profile.allowedTools).toContain('optihashi_solve');
     // No general-purpose escape hatches that would pull the loop off-task.
     expect(profile.allowedTools).not.toContain('image_generation');
     expect(profile.allowedTools).not.toContain('coordinate_task');

--- a/apps/client/server/queueHandlers/agentExecutor.optiProfile.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.optiProfile.ts
@@ -26,6 +26,7 @@ export const OPTI_AGENT_TOOLS: string[] = [
   'optihashi_formulate',
   'optihashi_edit_problem',
   'optihashi_schedule',
+  'optihashi_solve',
   'web_search',
   'current_datetime',
 ];
@@ -63,28 +64,37 @@ Tools:
 - optihashi_formulate: turn one well-posed problem (or one plan step) into a concrete, structured instance.
 - optihashi_edit_problem: adjust the currently loaded problem in place. It takes the current problem as
   an argument -- carry the latest formulated problem forward from your own prior observation and pass it.
-- optihashi_schedule: run solvers on a formulated problem and return results.
+- optihashi_schedule: run solvers on a job-shop SCHEDULING problem and return results.
+- optihashi_solve: run solvers on ANY OTHER family problem (routing, packing, assignment, network,
+  partitioning, selection, economic, continuous) and return results. Pass the formulated problem (with its
+  "family" field). Use optihashi_solve for every non-scheduling step; use optihashi_schedule only for scheduling.
 
 Loop:
 1. If the scenario spans multiple distinct problems, call optihashi_decompose ONCE with the full plan.
    IMPORTANT: optihashi_decompose automatically formulates and loads STEP 1 as the active brief -- do
    NOT call optihashi_formulate for step 1, it is already loaded. (Only if the scenario is a single
    well-posed problem with no decomposition: call optihashi_formulate once to load it.)
-2. Solve the currently loaded step: call optihashi_schedule to run solvers on the active brief, then READ
-   the result from the observation.
+2. Solve the currently loaded step: run solvers on the active brief -- optihashi_schedule if the step's
+   family is scheduling, otherwise optihashi_solve -- then READ the result from the observation.
 3. Advance to the NEXT planned step (2, 3, ...): call optihashi_formulate to build THAT step's instance
-   -- this is the ONLY time you formulate; never re-formulate a step that is already loaded -- then call
-   optihashi_schedule, then read the result. Repeat until every planned step has been solved.
-4. If optihashi_formulate returns a validation error, fix the specific field it names and retry that one
-   call once with corrected, complete parameters for the step's family. Use optihashi_edit_problem only to
-   adjust the CURRENT active brief when a solver result is poor or infeasible, then re-schedule.
+   -- this is the ONLY time you formulate; never re-formulate a step that is already loaded -- then run
+   solvers on it (optihashi_schedule or optihashi_solve, by family), then read the result. Repeat until
+   EVERY planned step has been formulated AND solved.
+4. If a formulate or solve call returns a validation error, fix the specific field it names and retry that
+   one call once with corrected, complete parameters for the step's family. Use optihashi_edit_problem only
+   to adjust the CURRENT active brief when a solver result is poor or infeasible, then re-run solvers.
+
+This is an AUTONOMOUS run -- see it through in ONE turn:
+- NEVER ask the user for permission to continue, and NEVER end a turn with a question like "Ready to proceed
+  to step 2?" or "Say the word and I'll continue." Just proceed to the next step yourself.
+- Do not stop after step 1. Keep going -- formulate and solve every planned step -- before the final answer.
+- Only stop when every planned step has been solved (or a step is genuinely infeasible even after one retry
+  -- then say so briefly and move to the next step; do not halt the whole run).
 
 Discipline:
 - Be conservative about compute tier: most scenarios are well served by classical/durable solvers; say so
   plainly. Never claim one approach "beats" another or assert any performance advantage you did not measure.
-- Do not loop for its own sake. Stop when: every planned step is formulated and solved, OR the next step
-  would add nothing to the user's answer, OR the user's ask is fully addressed.
-- When you stop, give a final answer that summarizes the walk and the result you read from each solve.
+- When you finish, give a final answer that summarizes the walk and the result you read from each solve.
 - Narrate as you go: before each tool call, write ONE short sentence saying what you're about to do and
   why (e.g. "Solving the staffing schedule now to see if resequencing beats the naive order."). This
   streams to the user live, so it keeps a multi-step run feeling responsive. Keep it to one sentence -

--- a/apps/client/server/queueHandlers/agentExecutorUtils/toolPermissions.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/toolPermissions.test.ts
@@ -48,15 +48,16 @@ describe('classifyToolPermission', () => {
     expect(classifyToolPermission('mermaid_chart', [], [])).toBe('allowed');
   });
 
-  it('treats all four OptiHashi tools as always-safe', () => {
+  it('treats all five OptiHashi tools as always-safe', () => {
     // Same risk surface (LLM/solver call + /opti-gated, undoable __uiSideEffect; no stored-data
     // mutation or external call) - must stay grouped so agent mode doesn't auto-run one while
-    // pausing its twin, and so the autonomous decompose -> formulate -> schedule loop isn't
+    // pausing its twin, and so the autonomous decompose -> formulate -> solve/schedule loop isn't
     // interrupted by an approval prompt at every step.
     expect(classifyToolPermission('optihashi_decompose', [], [])).toBe('allowed');
     expect(classifyToolPermission('optihashi_formulate', [], [])).toBe('allowed');
     expect(classifyToolPermission('optihashi_edit_problem', [], [])).toBe('allowed');
     expect(classifyToolPermission('optihashi_schedule', [], [])).toBe('allowed');
+    expect(classifyToolPermission('optihashi_solve', [], [])).toBe('allowed');
   });
 
   it('returns needs_approval for MCP tools', () => {

--- a/apps/client/server/queueHandlers/agentExecutorUtils/toolPermissions.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/toolPermissions.ts
@@ -31,6 +31,7 @@ const ALWAYS_SAFE_TOOLS = new Set([
   'optihashi_formulate',
   'optihashi_edit_problem',
   'optihashi_schedule',
+  'optihashi_solve',
 ]);
 
 // Tools with side effects that always require first-time approval

--- a/apps/client/server/queueHandlers/agentExecutorUtils/toolPermissions.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/toolPermissions.ts
@@ -21,7 +21,7 @@ const ALWAYS_SAFE_TOOLS = new Set([
   'recharts',
   'mermaid_chart',
   'chess_engine',
-  // All four OptiHashi tools share one risk surface: each invokes an LLM/solver and emits
+  // All five OptiHashi tools share one risk surface: each invokes an LLM/solver and emits
   // only an /opti-gated __uiSideEffect the user can Undo - none mutates stored user data or
   // calls out externally (durable/hardware compute submission is separately flag-gated). They
   // must stay grouped so agent mode doesn't auto-run one while pausing its twin for approval,

--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
   "b4m-libreoncology": "c917641b8155c311d217b021e414bba33c9eb72a",
-  "b4m-optihashi": "8beeca04122d794e752d66288baab1b09df4b9b1",
+  "b4m-optihashi": "fe8d5c8376399f7406a3157985874284616fcf53",
   "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }

--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
   "b4m-libreoncology": "c917641b8155c311d217b021e414bba33c9eb72a",
-  "b4m-optihashi": "fe8d5c8376399f7406a3157985874284616fcf53",
+  "b4m-optihashi": "08ea741aef15e9391148e5eb24c1e4c04557486b",
   "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
## Description

Companion to the overlay PR **Bike4Mind/b4m-optihashi#71** (issue #68). Together they let the optimizer agent **solve every pattern family**, not just scheduling — closing the gap where a decomposition that reached a non-scheduling step stalled after `decompose` or stopped to ask the user to continue.

This host PR:
- **Offers `optihashi_solve`** on the opti agent profile (`OPTI_AGENT_TOOLS`) — the overlay provides the implementation (the family counterpart to `optihashi_schedule`).
- **Rewrites the loop prompt** so the agent: runs `optihashi_schedule` for scheduling steps and `optihashi_solve` for every other family; **proceeds autonomously through ALL planned steps in one run** (never ends a turn with "Ready to proceed to step 2?" / "say the word and I'll continue"); and only stops when every step is solved.
- Marks `optihashi_solve` **always-safe** (no per-step approval prompt) and adds its "Racing solvers…" loading copy.

## Changes

- `apps/client/server/queueHandlers/agentExecutor.optiProfile.ts` — add `optihashi_solve` to `OPTI_AGENT_TOOLS`; rewrite `OPTI_AGENT_LOOP_PROMPT` (schedule-vs-solve by family + autonomous-through-all-steps + no "shall I continue?").
- `apps/client/server/queueHandlers/agentExecutorUtils/toolPermissions.ts` — `optihashi_solve` in `ALWAYS_SAFE_TOOLS`.
- `apps/client/app/components/Session/AgentExecution/loadingCopy.ts` — `optihashi_solve` loading copy.
- `premium-overlay.lock.json` — **test pin** to the #71 overlay branch so the preview hydrates the new tool. Re-pin to merged overlay `main` before merge.

## Guide for Testers

**Setup:** boot a preview of this PR (the pin hydrates the new tool), or test on staging after the overlay merges. Use `/opti`, Agent mode **ON**, model **Sonnet 4.6**, a credit-funded account.

1. Send a multi-family scenario, e.g.:
   > `Our São Paulo warehouse can't clear its daily order backlog — picking, packing, staging, and loading aren't sequenced well across our stations and shifts. Then figure out which orders to prioritize under limited capacity, and route the delivery vans. Model and solve the whole thing.`
2. **Expected:** the agent decomposes, then works **every** step in one run — running a solver on the scheduling step (`optihashi_schedule`) AND on the non-scheduling steps like selection/routing (`optihashi_solve`), advancing on its own.
3. ✅ It should **not** stop after step 1 and it should **not** ask "Ready to proceed to step 2?" — it proceeds autonomously and ends with a summary of every solve.
4. ✅ No "Approve/Deny" prompts mid-run.

### Regression checks
- A pure scheduling scenario still solves via `optihashi_schedule` as before.
- Agent mode OFF (guided) unchanged.

### What NOT to test
- Exact objective numbers — solver quality isn't the point here; the point is that non-scheduling steps now get solved at all.

## Notes
- Public-repo safe: only generic optimizer tool names + families; no provider/premium specifics.
- **Before merge:** re-pin `premium-overlay.lock.json` to the overlay's merged `main` SHA (currently a #71-branch test pin), and land #71 first.
