### PR TITLE
fix(client): close cold-load auth interceptor hydration race

### DIFF
--- a/apps/client/app/contexts/ApiContext.test.tsx
+++ b/apps/client/app/contexts/ApiContext.test.tsx
@@ -277,4 +277,51 @@ describe('ApiProvider 401 interceptor -> login redirect', () => {
     await expect(api.get('/api/mcp-servers')).rejects.toBeTruthy();
     expect(replace).not.toHaveBeenCalled();
   });
+
+  // --- #627: interceptors must be live BEFORE ApiProvider mounts ---
+  // The auth interceptors are registered at module scope, not in ApiProvider's
+  // useEffect. This is what closes the cold-load race: a query gated on the
+  // synchronously-rehydrated persisted `currentUser` (e.g. useGetOwnSessions) can
+  // fire through `api` on the very first render, before any effect has run. If the
+  // interceptors only existed after mount, that request would go out with no token,
+  // 401, and never refresh-retry - leaving the sidebar/UI empty until a manual
+  // reload. These two tests deliberately do NOT render <ApiProvider>, exercising
+  // exactly that pre-mount window; they fail on the old useEffect-registered code.
+
+  it('attaches the bearer token to a request fired WITHOUT mounting ApiProvider (#627)', async () => {
+    useAccessToken.setState({ accessToken: 'tok-abc', refreshToken: 'refresh', expired: false, mfaPending: false });
+    let seenAuth: string | undefined;
+    api.defaults.adapter = ((config: InternalAxiosRequestConfig) => {
+      seenAuth = config.headers?.Authorization as string | undefined;
+      return Promise.resolve(ok(config, { ok: true }));
+    }) as AxiosAdapter;
+
+    // No render(<ApiProvider>) - this is the cold-load window before any effect runs.
+    const res = await api.get('/api/sessions');
+
+    expect(res.data).toEqual({ ok: true });
+    expect(seenAuth).toBe('Bearer tok-abc');
+  });
+
+  it('refresh-retries a 401 fired WITHOUT mounting ApiProvider, so the cold-load query self-heals (#627)', async () => {
+    useAccessToken.setState({ accessToken: 'stale', refreshToken: 'refresh', expired: false, mfaPending: false });
+    let dataCalls = 0;
+    api.defaults.adapter = ((config: InternalAxiosRequestConfig) => {
+      if (config.url === '/api/auth/refreshToken') {
+        return Promise.resolve(ok(config, { accessToken: 'new-access', refreshToken: 'new-refresh' }));
+      }
+      dataCalls += 1;
+      // First call 401s (token stale); the post-refresh retry succeeds with real data.
+      return dataCalls === 1
+        ? Promise.reject(make401(config))
+        : Promise.resolve(ok(config, { data: [{ id: 's1' }], hasMore: false }));
+    }) as AxiosAdapter;
+
+    // Again, no ApiProvider mount.
+    const res = await api.get('/api/sessions');
+
+    expect(res.data).toEqual({ data: [{ id: 's1' }], hasMore: false });
+    expect(replace).not.toHaveBeenCalled();
+    expect(useAccessToken.getState().accessToken).toBe('new-access');
+  });
 });

--- a/apps/client/app/contexts/ApiContext.tsx
+++ b/apps/client/app/contexts/ApiContext.tsx
@@ -1,6 +1,6 @@
 import axios, { isAxiosError } from 'axios';
 import qs from 'qs';
-import React, { PropsWithChildren, useEffect } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { useAccessToken } from '../hooks/useAccessToken';
 import { getOrCreateIdempotencyKeyWithUUID } from '@client/lib/utils/idempotency';
 import { clearClientCaches } from '@client/app/utils/clearClientCaches';
@@ -109,157 +109,158 @@ api.interceptors.request.use(config => {
   return config;
 });
 
-export const ApiProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  useEffect(() => {
-    // Read token directly from store on each request to avoid race conditions
-    const intercepterRequest = api.interceptors.request.use(config => {
-      const currentToken = useAccessToken.getState().accessToken;
-      if (currentToken) {
-        config.headers.Authorization = `Bearer ${currentToken}`;
+// Auth interceptors are registered at MODULE scope (not inside ApiProvider's
+// useEffect) so they are active before the first React render or data query.
+// A useEffect runs AFTER children's effects/mount, so a cold-load query gated on
+// synchronously-rehydrated state (e.g. useGetOwnSessions, enabled once the
+// persisted currentUser rehydrates) could fire through `api` before the
+// token-attach + 401-retry interceptors existed - sending an unauthenticated
+// request that 401'd with no interceptor to refresh-and-retry it, leaving the
+// sidebar/UI empty until a manual reload (#627). Registering here closes that
+// window. `api` is a singleton, so one-time registration needs no eject.
+
+// Attach the current bearer token. Reads the store at request time so a
+// post-refresh token is always used (no stale closure).
+api.interceptors.request.use(config => {
+  const currentToken = useAccessToken.getState().accessToken;
+  if (currentToken) {
+    config.headers.Authorization = `Bearer ${currentToken}`;
+  }
+  return config;
+});
+
+// On 401: refresh the token once and retry; tear down cleanly if unrecoverable.
+api.interceptors.response.use(
+  response => response,
+  async error => {
+    const { setState, getState } = useAccessToken;
+
+    // Ignore cancelled requests (user-initiated abort)
+    if (axios.isCancel(error) || error.code === 'ERR_CANCELED') {
+      return Promise.reject(error);
+    }
+
+    // TODO: have graceful toasters for customers vs developers
+    // For now just a console.log
+    if (isAxiosError(error)) {
+      if (error.code === 'ERR_NETWORK' || error.message === 'Network Error') {
+        console.error('Network Error: Backend may not be running. Check that SST is started.');
+      } else {
+        console.error('Axios Error:', error.response?.data || error.message);
       }
-      return config;
-    });
-
-    return () => {
-      api.interceptors.request.eject(intercepterRequest);
-    };
-  }, []);
-
-  useEffect(() => {
-    const interceptResponse = api.interceptors.response.use(
-      response => response,
-      async error => {
-        const { setState, getState } = useAccessToken;
-
-        // Ignore cancelled requests (user-initiated abort)
-        if (axios.isCancel(error) || error.code === 'ERR_CANCELED') {
-          return Promise.reject(error);
-        }
-
-        // TODO: have graceful toasters for customers vs developers
-        // For now just a console.log
-        if (isAxiosError(error)) {
-          if (error.code === 'ERR_NETWORK' || error.message === 'Network Error') {
-            console.error('Network Error: Backend may not be running. Check that SST is started.');
-          } else {
-            console.error('Axios Error:', error.response?.data || error.message);
-          }
-        } else {
-          console.log('Axios Error', error);
-        }
-        /*
+    } else {
+      console.log('Axios Error', error);
+    }
+    /*
         toast.error(
           typeof error.response?.data?.error === 'string'
             ? error.response?.data?.error
             : error.response?.data?.message || error.message
         );
         */
-        if (error.response?.status === 401 && !isPublicPath(window.location.pathname)) {
-          // Skip refresh for requests that opted out (e.g., endpoints that return
-          // 401 for non-auth reasons like missing API keys).
-          if (error.config?.skipAuthRefresh) {
-            return Promise.reject(error);
-          }
-
-          const { refreshToken, expired, mfaPending } = getState();
-
-          // Already expired or no refresh token - don't attempt refresh.
-          if (expired || !refreshToken) {
-            // During mfaPending the login stage issues no refresh token by
-            // design (see useAccessToken.ts), so a 401 on a non-allowlisted
-            // endpoint lands here for a user who is mid-MFA-setup, not
-            // actually locked out - skip the forced redirect in that case.
-            if (!mfaPending) {
-              await forceSessionExpiredRedirect();
-            }
-            return Promise.reject(error);
-          }
-
-          // Prevent secondary loops: if this request was already retried after
-          // a successful refresh and still got 401, give up.
-          const retryCount = error.config?._retryCount || 0;
-          if (retryCount >= 1) {
-            return Promise.reject(error);
-          }
-
-          // If another request is already refreshing, wait for it then retry
-          if (refreshPromise) {
-            try {
-              await refreshPromise;
-              error.config._retryCount = retryCount + 1;
-              return api.request(error.config);
-            } catch {
-              return Promise.reject(error);
-            }
-          }
-
-          // This request initiates the refresh - all other 401s will queue on this promise
-          refreshPromise = (async () => {
-            try {
-              const response = await api.post<{ accessToken: string; refreshToken: string }>(
-                '/api/auth/refreshToken',
-                { token: refreshToken },
-                {
-                  skipAuthRefresh: true,
-                  // Bound the refresh attempt so a cold Lambda or hanging server
-                  // can't leave refreshPromise pending forever, which would cause
-                  // every concurrent 401 (including admin-settings) to hang and
-                  // keep "Checking security settings..." stuck indefinitely.
-                  timeout: 10000,
-                }
-              );
-              setState({
-                accessToken: response.data.accessToken,
-                refreshToken: response.data.refreshToken,
-              });
-            } catch (e) {
-              // Only the initiator runs the teardown. Distinguish a genuine
-              // revocation from a transient outage by the refresh endpoint's
-              // status: a 400 (invalid_grant) / 401 means the refresh token was
-              // rejected - the session can't be recovered, so tear down. A 5xx /
-              // network error / the 10s timeout is a transient outage (a cold or
-              // hanging refresh Lambda - the very case the timeout above guards) -
-              // reject and let the caller retry rather than logging the user out
-              // on a blip. This matters most during a deploy, when WS connections
-              // drop (triggering the WebsocketContext probe through this same
-              // interceptor) at the exact moment the refresh Lambda is coldest -
-              // without this gate that correlation causes spurious logout storms.
-              // Mirrors the CLI ApiClient's SessionRevokedError distinction.
-              //
-              // The teardown: forceSessionExpiredRedirect mirrors the reload-recovery
-              // path (RestrictedPage redirects on a missing user) and the logout
-              // redirect - a full-page window.location.replace (inside the helper)
-              // avoids a circular import on the user store, unmounts the app, and
-              // stops the in-flight 401 cascade. The session_expired code surfaces a
-              // toast on the login screen, and redirectTo returns the user to where
-              // they were after re-login.
-              const refreshStatus = getAxiosErrorStatus(e);
-              if (refreshStatus === 400 || refreshStatus === 401) {
-                await forceSessionExpiredRedirect();
-              }
-              throw e;
-            } finally {
-              refreshPromise = null;
-            }
-          })();
-
-          try {
-            await refreshPromise;
-            error.config._retryCount = retryCount + 1;
-            return api.request(error.config);
-          } catch {
-            return Promise.reject(error);
-          }
-        }
-
+    if (error.response?.status === 401 && !isPublicPath(window.location.pathname)) {
+      // Skip refresh for requests that opted out (e.g., endpoints that return
+      // 401 for non-auth reasons like missing API keys).
+      if (error.config?.skipAuthRefresh) {
         return Promise.reject(error);
       }
-    );
 
-    return () => {
-      api.interceptors.response.eject(interceptResponse);
-    };
-  }, []);
+      const { refreshToken, expired, mfaPending } = getState();
 
-  return <>{children}</>;
-};
+      // Already expired or no refresh token - don't attempt refresh.
+      if (expired || !refreshToken) {
+        // During mfaPending the login stage issues no refresh token by
+        // design (see useAccessToken.ts), so a 401 on a non-allowlisted
+        // endpoint lands here for a user who is mid-MFA-setup, not
+        // actually locked out - skip the forced redirect in that case.
+        if (!mfaPending) {
+          await forceSessionExpiredRedirect();
+        }
+        return Promise.reject(error);
+      }
+
+      // Prevent secondary loops: if this request was already retried after
+      // a successful refresh and still got 401, give up.
+      const retryCount = error.config?._retryCount || 0;
+      if (retryCount >= 1) {
+        return Promise.reject(error);
+      }
+
+      // If another request is already refreshing, wait for it then retry
+      if (refreshPromise) {
+        try {
+          await refreshPromise;
+          error.config._retryCount = retryCount + 1;
+          return api.request(error.config);
+        } catch {
+          return Promise.reject(error);
+        }
+      }
+
+      // This request initiates the refresh - all other 401s will queue on this promise
+      refreshPromise = (async () => {
+        try {
+          const response = await api.post<{ accessToken: string; refreshToken: string }>(
+            '/api/auth/refreshToken',
+            { token: refreshToken },
+            {
+              skipAuthRefresh: true,
+              // Bound the refresh attempt so a cold Lambda or hanging server
+              // can't leave refreshPromise pending forever, which would cause
+              // every concurrent 401 (including admin-settings) to hang and
+              // keep "Checking security settings..." stuck indefinitely.
+              timeout: 10000,
+            }
+          );
+          setState({
+            accessToken: response.data.accessToken,
+            refreshToken: response.data.refreshToken,
+          });
+        } catch (e) {
+          // Only the initiator runs the teardown. Distinguish a genuine
+          // revocation from a transient outage by the refresh endpoint's
+          // status: a 400 (invalid_grant) / 401 means the refresh token was
+          // rejected - the session can't be recovered, so tear down. A 5xx /
+          // network error / the 10s timeout is a transient outage (a cold or
+          // hanging refresh Lambda - the very case the timeout above guards) -
+          // reject and let the caller retry rather than logging the user out
+          // on a blip. This matters most during a deploy, when WS connections
+          // drop (triggering the WebsocketContext probe through this same
+          // interceptor) at the exact moment the refresh Lambda is coldest -
+          // without this gate that correlation causes spurious logout storms.
+          // Mirrors the CLI ApiClient's SessionRevokedError distinction.
+          //
+          // The teardown: forceSessionExpiredRedirect mirrors the reload-recovery
+          // path (RestrictedPage redirects on a missing user) and the logout
+          // redirect - a full-page window.location.replace (inside the helper)
+          // avoids a circular import on the user store, unmounts the app, and
+          // stops the in-flight 401 cascade. The session_expired code surfaces a
+          // toast on the login screen, and redirectTo returns the user to where
+          // they were after re-login.
+          const refreshStatus = getAxiosErrorStatus(e);
+          if (refreshStatus === 400 || refreshStatus === 401) {
+            await forceSessionExpiredRedirect();
+          }
+          throw e;
+        } finally {
+          refreshPromise = null;
+        }
+      })();
+
+      try {
+        await refreshPromise;
+        error.config._retryCount = retryCount + 1;
+        return api.request(error.config);
+      } catch {
+        return Promise.reject(error);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+// ApiProvider no longer registers interceptors (they live at module scope above,
+// so they're active before any render). Kept as a pass-through to preserve the
+// provider tree / mount point in providers.tsx.
+export const ApiProvider: React.FC<PropsWithChildren> = ({ children }) => <>{children}</>;


### PR DESCRIPTION
## Optional Screenshot/Video

Reproduced live on a pr628 preview (screenshots + network trace available to add on this PR's own preview): after corrupting the stored access token and reloading, the composer lost its model picker / Agents / Briefcase and authed data failed to load — while `/api/auth/refreshToken` returned `200`, i.e. the token *did* refresh but the UI never recovered until a manual reload.

## Description

Fixes the cold-load hydration race behind #627 (and the real cause of the symptom mislabeled in #626).

`ApiProvider` registered both auth interceptors — the token-attach request interceptor and the 401 refresh-retry response interceptor — inside `useEffect`. React runs a parent's effects **after** its children's effects/mount, so a query gated on the **synchronously-rehydrated** persisted `currentUser` (e.g. `useGetOwnSessions`, `enabled: !!currentUser`) can fire through the shared `api` instance on the **first render**, before those interceptors exist. That request goes out with **no `Authorization` header** and 401s with **no response interceptor to refresh-and-retry it** — so the query errors and never recovers, leaving the session sidebar / composer empty until a manual reload.

The fix registers both interceptors at **module scope** (matching the existing `X-Request-ID` interceptor), so they are active before any render or query — closing the race window entirely.

## Changes

- `apps/client/app/contexts/ApiContext.tsx`
  - Moved the token-attach request interceptor and the 401 refresh-retry response interceptor **out of `ApiProvider`'s `useEffect`** and registered them at **module scope**.
  - `ApiProvider` is now a thin pass-through (kept to preserve the provider tree / mount point); dropped the now-unused `useEffect` import.
  - No behavioral change to the interceptors' logic — the token-attach still reads `useAccessToken.getState()` at request time; the response interceptor still refreshes once and retries, and tears down cleanly on unrecoverable auth.
- `apps/client/app/contexts/ApiContext.test.tsx`
  - Added 2 regression tests that fire a request in the **pre-mount window** (no `<ApiProvider>` rendered) and assert (a) the bearer token is attached and (b) a 401 self-heals via refresh. Both **fail on the old `useEffect`-registered code** and pass on this change.

> Reviewer note: `ApiContext.tsx` shows a large changed-line count, but the logic is unchanged — most of the diff is re-indentation from un-nesting the interceptor bodies out of `useEffect` (prettier dedented them).

## Guide for Testers

On this PR's preview (`app.pr<N>.preview.bike4mind.com`):

1. Log in normally and confirm the sidebar + composer (model picker, Agents, Briefcase) render.
2. Open DevTools → Application → Local Storage → `access-token-storage`. Set `state.accessToken` to an expired/garbage JWT, keep `state.refreshToken` valid, and `state.expired: false`.
3. Hard-reload the page.
   - **Before this fix:** a burst of `401`s on `/api/sessions`, `/api/entitlements`, `/api/inbox`, `/api/sessions/{favorites,shared}`; `/api/auth/refreshToken` returns `200`, but the sidebar/composer stay degraded until a second manual reload.
   - **After this fix:** the initial `401`s are refresh-retried by the interceptor and the sidebar/composer populate **without** a manual reload.
4. Regression: a brand-new user with zero sessions still sees an empty sidebar cleanly (no error toast, no redirect loop).

Unit: `pnpm --filter @bike4mind/client test app/contexts/ApiContext.test.tsx` (11 pass; the 2 new `#627` tests fail if you revert `ApiContext.tsx`).

## Additional Information

- Empirically verified that `/api/sessions` (and the other listed endpoints) **require auth and return `401`** on a bad/absent token — they do **not** return `200 []`. This is why #626's proposed server-side fix would be a no-op; the real defect is this client-side non-recovery. This PR closes #627; it should also resolve #626's user-facing symptom.
- Scope is limited to interceptor registration timing; no endpoint, auth-flow, or token logic changed.

## Developer Notes (Optional)

Pattern: axios interceptors that must guard **all** requests (including those fired during the first render by synchronously-hydrated stores) should be registered at **module scope on the shared `api` singleton**, not inside a provider's `useEffect`. Effect-time registration always trails the first render, which is a race against persisted-state-gated queries.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — N/A
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) — N/A
- [x] My changes generate no new warnings

Closes #627