### PR TITLE
fix(agent): stop the opti loop from re-decomposing mid-run (#666)

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.optiProfile.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.optiProfile.ts
@@ -87,6 +87,11 @@ Loop:
 This is an AUTONOMOUS run -- see it through in ONE turn:
 - NEVER ask the user for permission to continue, and NEVER end a turn with a question like "Ready to proceed
   to step 2?" or "Say the word and I'll continue." Just proceed to the next step yourself.
+- Call optihashi_decompose AT MOST ONCE. Once the plan exists, NEVER decompose again -- you already have the
+  ordered plan and step 1 is loaded; re-decomposing restarts the walk and resets your progress. Advance the
+  plan you have; do not re-plan.
+- Work ONE step at a time: formulate the NEXT step, solve it, read its result, then move on. Do not formulate
+  several steps up front -- keep the plan and the console in lock-step.
 - Do not stop after step 1. Keep going -- formulate and solve every planned step -- before the final answer.
 - Only stop when every planned step has been solved (or a step is genuinely infeasible even after one retry
   -- then say so briefly and move to the next step; do not halt the whole run).

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -81,6 +81,7 @@ import { creditService, apiKeyService } from '@bike4mind/services';
 // continuation-fallback rationale.
 import { resolveLatticeTools, buildSubagentLatticeToolPool } from './agentExecutor.latticeTools';
 import { selectGatedAction } from './agentExecutorUtils/toolPermissions';
+import { guardDecomposeOnce } from './agentExecutorUtils/decomposeGuard';
 import { buildDagResumeReport, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
 import { collectDagChildArtifactBlocks } from './agentExecutor.dagArtifacts';
 import type { DagHandoffSignal } from '@bike4mind/services';
@@ -1229,11 +1230,20 @@ async function processExecution(
     // `buildSubagentLatticeToolPool` and `ServerOrchestratorDeps.optInTools`.
     const subagentLatticeTools = buildSubagentLatticeToolPool(toolDeps, toolCallbacks, subagentToolConfig);
 
+    // Let optihashi_decompose run only ONCE per run (#666). The loop occasionally re-plans
+    // mid-run, which reloads step 1 (a console yank), burns an iteration, and re-sources;
+    // the guard turns any repeat into a no-op redirect that steers the agent back to
+    // advancing its existing plan. Only affects opti runs (decompose isn't offered elsewhere).
+    const decomposeGuard = { used: false };
+    const guardedPremiumTools = guardDecomposeOnce(premiumLlmTools, decomposeGuard, () =>
+      logger.info('[opti] blocked a repeat optihashi_decompose call (advancing existing plan)', { executionId })
+    );
+
     const tools = buildSharedTools({ ...toolDeps, optInTools: subagentLatticeTools }, toolCallbacks, {
       // Dedupe: a caller may already have enabled create_mission/mission_status;
       // a raw append would make buildSharedTools wrap the same tool twice.
       enabledTools: [...new Set([...profileEnabledTools, ...MISSION_CHAT_TOOL_NAMES, ...latticeEnabledTools])],
-      externalTools: { ...premiumLlmTools, ...missionChatTools, ...latticeExternalTools },
+      externalTools: { ...guardedPremiumTools, ...missionChatTools, ...latticeExternalTools },
       config: subagentToolConfig,
       mcpToolsByServer,
       agentOnlyMcpServers,

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ToolDefinition } from '@bike4mind/services';
+import { guardDecomposeOnce, DECOMPOSE_ALREADY_DONE_MSG } from './decomposeGuard';
+
+// Minimal fake tool: implementation() returns a toolFn that records its calls.
+function fakeDecompose(): { tool: ToolDefinition; calls: unknown[] } {
+  const calls: unknown[] = [];
+  const tool = {
+    name: 'optihashi_decompose',
+    implementation: () => ({
+      toolFn: async (params?: unknown) => {
+        calls.push(params);
+        return 'PLAN CREATED';
+      },
+      toolSchema: { name: 'optihashi_decompose', description: '', parameters: { type: 'object', properties: {} } },
+    }),
+  } as unknown as ToolDefinition;
+  return { tool, calls };
+}
+
+const run = (t: ToolDefinition, params?: unknown) =>
+  t.implementation({} as never, undefined).toolFn(params);
+
+describe('guardDecomposeOnce', () => {
+  it('runs the real decompose on the FIRST call', async () => {
+    const { tool, calls } = fakeDecompose();
+    const state = { used: false };
+    const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state);
+    const out = await run(guarded.optihashi_decompose, { scenario: 'x' });
+    expect(out).toBe('PLAN CREATED');
+    expect(calls).toHaveLength(1);
+    expect(state.used).toBe(true);
+  });
+
+  it('blocks a SECOND call with the redirect message and does not re-run decompose', async () => {
+    const { tool, calls } = fakeDecompose();
+    const state = { used: false };
+    const onBlocked = vi.fn();
+    const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state, onBlocked);
+    await run(guarded.optihashi_decompose); // first - runs
+    const second = await run(guarded.optihashi_decompose); // repeat - blocked
+    expect(second).toBe(DECOMPOSE_ALREADY_DONE_MSG);
+    expect(calls).toHaveLength(1); // real decompose ran only once
+    expect(onBlocked).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the map unchanged when there is no optihashi_decompose (non-opti run)', () => {
+    const other = { name: 'web_search', implementation: () => ({ toolFn: async () => 'ok', toolSchema: {} }) } as unknown as ToolDefinition;
+    const map = { web_search: other };
+    const guarded = guardDecomposeOnce(map, { used: false });
+    expect(guarded).toBe(map);
+  });
+
+  it('does not mutate the input map', () => {
+    const { tool } = fakeDecompose();
+    const map = { optihashi_decompose: tool };
+    const guarded = guardDecomposeOnce(map, { used: false });
+    expect(guarded).not.toBe(map);
+    expect(map.optihashi_decompose).toBe(tool); // original entry untouched
+  });
+});

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
@@ -1,0 +1,58 @@
+import type { ToolDefinition } from '@bike4mind/services';
+
+/**
+ * Message returned when the opti loop tries to decompose a second time. It tells the
+ * agent to advance the plan it already has instead of re-planning.
+ */
+export const DECOMPOSE_ALREADY_DONE_MSG =
+  'You already created the plan for this run, so decomposition is done. Do NOT call ' +
+  'optihashi_decompose again -- re-planning restarts the walk and resets your progress. ' +
+  'Advance the EXISTING plan instead: call optihashi_formulate on the next un-solved step, ' +
+  'then optihashi_schedule (scheduling) or optihashi_solve (any other family) to solve it. ' +
+  'When every planned step is solved, write the final summary.';
+
+/**
+ * Guard optihashi_decompose so it can run at most ONCE per execution (#666).
+ *
+ * The opti loop prompt says to decompose exactly once, but the model occasionally re-plans
+ * mid-run -- which reloads step 1 (a visible console yank), burns an iteration, and re-sources
+ * the dataset. This wraps the tool so the FIRST call runs normally and any repeat is a no-op
+ * redirect (no re-plan, no populateDecomposition side-effect) that steers the agent back to
+ * advancing its existing plan.
+ *
+ * Returns a NEW map (never mutates the input). If the map has no optihashi_decompose (e.g. a
+ * non-opti run where the overlay tool isn't present), it's returned unchanged.
+ *
+ * `state.used` is the per-execution flag; keep it in the caller's execution closure so it's
+ * shared across tool-map rebuilds. In-memory per Lambda invocation: a continuation Lambda
+ * resets it, but a re-decompose almost always happens within a single invocation.
+ */
+export function guardDecomposeOnce(
+  tools: Record<string, ToolDefinition>,
+  state: { used: boolean },
+  onBlocked?: () => void
+): Record<string, ToolDefinition> {
+  const raw = tools['optihashi_decompose'];
+  if (!raw) return tools;
+  return {
+    ...tools,
+    optihashi_decompose: {
+      ...raw,
+      implementation: (context, config) => {
+        const inner = raw.implementation(context, config);
+        const run = inner.toolFn;
+        return {
+          ...inner,
+          toolFn: (parameters?: unknown, apiKey?: string) => {
+            if (state.used) {
+              onBlocked?.();
+              return Promise.resolve(DECOMPOSE_ALREADY_DONE_MSG);
+            }
+            state.used = true;
+            return run(parameters, apiKey);
+          },
+        };
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Description

Closes #666.

The optimizer agent loop occasionally re-runs `optihashi_decompose` partway through a run instead of advancing the plan it already made. That reloads step 1 (a visible console yank), burns an iteration, and re-sources the dataset — and it happens **frequently** on retry-heavy runs.

**Why it happens (not amnesia):** the ReAct loop re-derives its next move from the whole transcript each turn. As a run grows — especially with #67 formulate retries filling the context with error observations — the original plan gets diluted/buried, and the strong "decompose is the obvious first move" prior plus an after-error re-planning reflex win out. The old prompt only *suggested* "once."

## Fix (defense in depth)

1. **Code guard** (`agentExecutorUtils/decomposeGuard.ts`) — `optihashi_decompose` runs **at most once per execution**. The first call runs normally; any repeat is a **no-op redirect** (no re-plan, no `populateDecomposition` side-effect) that steers the agent to advance its existing plan. Wrapped where `premiumLlmTools` merge into `externalTools`; returns a new map, never mutates the import; only affects opti runs (the tool isn't offered elsewhere). In-memory per Lambda invocation (a continuation resets it, but re-decompose almost always happens within one invocation).
2. **Loop prompt** (`agentExecutor.optiProfile.ts`) — explicit "**call decompose AT MOST ONCE, never re-plan**" and "**one step at a time** (don't batch-formulate)".

Prompt lowers the frequency; the guard removes the damage regardless of what the model decides.

## Changes
- `agentExecutorUtils/decomposeGuard.ts` (new) — `guardDecomposeOnce()` + redirect message.
- `agentExecutorUtils/decomposeGuard.test.ts` (new) — first-call-runs / repeat-blocked / no-decompose-passthrough / no-mutation (4 tests).
- `agentExecutor.ts` — build a guarded `premiumLlmTools` and use it in `externalTools`.
- `agentExecutor.optiProfile.ts` — loop-prompt hardening.

## Guide for Testers
1. `/opti`, Agent mode ON, send a multi-family prompt (e.g. the São Paulo warehouse scheduling + prioritization + routing one).
2. Let it run to completion (it will hit some retries — expected).
3. **Expected:** it calls `optihashi_decompose` exactly **once** at the start; it never re-decomposes / restarts the plan mid-run. If the model *tries* to, the logs show `[opti] blocked a repeat optihashi_decompose call` and the run advances instead of yanking back to step 1.

### Regression
- A normal single decompose + full walk still works end to end (the guard is transparent on the first call).
- Non-opti agent runs are unaffected (decompose isn't in their toolbelt).

## Notes
- Related: #67 (formulate reliability — fewer retries → less context dilution → fewer re-decompose attempts; the two reinforce each other).
- Follow-up option (not in this PR): persist the "decomposed" flag in the checkpoint so the guard also holds across a continuation Lambda.
