### PR TITLE
feat(publish): support TypeScript React artifacts

### DIFF
--- a/apps/client/pages/api/__tests__/react-artifact-sandbox.test.ts
+++ b/apps/client/pages/api/__tests__/react-artifact-sandbox.test.ts
@@ -180,12 +180,20 @@ describe('GET /api/react-artifact-sandbox', () => {
   // binding and must be stripped BEFORE the regex require-rewrite, else they emit invalid
   // `const { type X } = ...`. Structural guard (in-browser transform has no unit seam); mirrors
   // stripTypeOnlyImports in the publish transpiler (transpileReactArtifact.ts).
-  it('strips TS type-only imports before rewriting to require()', () => {
+  it('strips TS type-only imports BEFORE the multi-file (relative-import) guard runs', () => {
+    // Regression: a type-only relative import (`import type Foo from './x'`) carries no runtime
+    // reference and must be stripped before the relative-import guard, or the preview wrongly
+    // aborts with "Multi-file artifacts are not supported" while publish handles it fine. The
+    // strip must (a) exist, (b) run before the guard, and (c) feed the guard its stripped view.
     const { res, getBody } = makeRes();
     handler(makeReq('GET'), res);
     const body = getBody();
-    expect(body).toContain('withoutTypeImports'); // the strip pass is wired ahead of the rewrite
+    expect(body).toContain('var withoutTypeImports'); // the strip pass is wired
     expect(body).toContain('import\\s+type\\s+'); // whole-clause type-only import removal
+    // strip is computed before the relative-import guard...
+    expect(body.indexOf('var withoutTypeImports')).toBeLessThan(body.indexOf('var relImport'));
+    // ...and the guard checks the stripped view, not the raw code.
+    expect(body).toContain('withoutTypeImports.match(');
   });
 
   // Regression guard: a literal `</script>` inside a JS comment in the

--- a/apps/client/pages/api/__tests__/react-artifact-sandbox.test.ts
+++ b/apps/client/pages/api/__tests__/react-artifact-sandbox.test.ts
@@ -165,6 +165,29 @@ describe('GET /api/react-artifact-sandbox', () => {
     expect(body).not.toMatch(/presets:\s*\['react'\]/);
   });
 
+  // Regression: the transform MUST include preset-typescript (the assistant emits TS by default:
+  // types, generics, interfaces). Structural guard - the in-browser transform has no unit seam, so
+  // assert the served shell wires it. Must stay in sync with transpileReactArtifact.ts (publish).
+  it('includes the typescript preset and a .tsx filename so TS artifacts transpile', () => {
+    const { res, getBody } = makeRes();
+    handler(makeReq('GET'), res);
+    const body = getBody();
+    expect(body).toContain("'typescript'"); // preset-typescript strips TS before the JSX transform
+    expect(body).toContain("filename: 'component.tsx'"); // TSX detected via extension
+  });
+
+  // Regression: TS type-only imports (`import type ...`, inline `{ type X }`) carry no runtime
+  // binding and must be stripped BEFORE the regex require-rewrite, else they emit invalid
+  // `const { type X } = ...`. Structural guard (in-browser transform has no unit seam); mirrors
+  // stripTypeOnlyImports in the publish transpiler (transpileReactArtifact.ts).
+  it('strips TS type-only imports before rewriting to require()', () => {
+    const { res, getBody } = makeRes();
+    handler(makeReq('GET'), res);
+    const body = getBody();
+    expect(body).toContain('withoutTypeImports'); // the strip pass is wired ahead of the rewrite
+    expect(body).toContain('import\\s+type\\s+'); // whole-clause type-only import removal
+  });
+
   // Regression guard: a literal `</script>` inside a JS comment in the
   // inline <script> block terminates script data early (the HTML tokenizer doesn't parse
   // JS), truncating the script (-> "Unexpected end of input") and dumping the rest of the

--- a/apps/client/pages/api/react-artifact-sandbox.ts
+++ b/apps/client/pages/api/react-artifact-sandbox.ts
@@ -167,10 +167,26 @@ const SANDBOX_HTML = `<!DOCTYPE html>
           throw new Error('Module "' + module + '" is not available');
         };
 
+        // Strip TS type-only import syntax before rewriting to require(): whole \`import type ...\`
+        // statements and inline \`{ type X, y }\` specifiers carry no runtime binding, and this
+        // rewrite runs BEFORE Babel's typescript preset. A binding named \`type\` (\`type as T\`) is
+        // kept. Mirrors stripTypeOnlyImports in the publish transpiler (transpileReactArtifact.ts).
+        var withoutTypeImports = code
+          .replace(/import\\s+type\\s+[\\s\\S]*?\\s+from\\s+['"][^'"]+['"]\\s*;?/g, '')
+          .replace(/import\\s+([\\s\\S]*?)\\s+from\\s+['"][^'"]+['"]\\s*;?/g, function (stmt, clause) {
+            var brace = clause.match(/\\{([\\s\\S]*?)\\}/);
+            if (!brace) return stmt;
+            var kept = brace[1].split(',').map(function (s) { return s.trim(); })
+              .filter(Boolean).filter(function (s) { return !/^type\\s+(?!as\\b)\\w/.test(s); });
+            var beforeBrace = clause.slice(0, clause.indexOf('{')).replace(/,\\s*$/, '').trim();
+            if (!kept.length && !beforeBrace) return '';
+            return stmt.replace(/\\{[\\s\\S]*?\\}/, '{ ' + kept.join(', ') + ' }');
+          });
+
         // Normalize ESM "X as Y" renames to valid destructuring "X: Y" (a raw { X as Y } in a
         // const-destructure is a syntax error). Kept in sync with the publish transpiler.
         var renameNamed = function (clause) { return clause.replace(/(\\w+)\\s+as\\s+(\\w+)/g, '$1: $2'); };
-        var transformedCode = code.replace(/import\\s+([\\s\\S]*?)\\s+from\\s+['"]([^'"]+)['"]/g, function (match, imports, module) {
+        var transformedCode = withoutTypeImports.replace(/import\\s+([\\s\\S]*?)\\s+from\\s+['"]([^'"]+)['"]/g, function (match, imports, module) {
           if (module === 'react') return '// React is global';
           if (imports.trim().match(/^\\w+$/)) return 'const ' + imports.trim() + " = require('" + module + "');";
           // Namespace import (import * as d3 from 'd3') -> const d3 = require('d3'). Without this it
@@ -198,9 +214,14 @@ const SANDBOX_HTML = `<!DOCTYPE html>
           // throws "Cannot use import statement outside a module" and nothing renders. The
           // classic runtime emits React.createElement, which resolves against the in-scope
           // React global. (#9506 follow-up — surfaced once #9539 fixed the script truncation.)
+          // The \`typescript\` preset strips TS syntax (types/generics/interfaces the assistant
+          // emits by default) before the JSX transform (presets run last-to-first). TSX is detected
+          // via the \`.tsx\` filename, NOT preset-typescript allExtensions/isTSX (those conflict with
+          // preset-react JSX detection and break plain JS). Keep in sync with
+          // transpileReactArtifact.ts so the published bundle matches this preview.
           processedCode = Babel.transform(transformedCode, {
-            presets: [['react', { runtime: 'classic' }]],
-            filename: 'component.jsx',
+            presets: [['react', { runtime: 'classic' }], 'typescript'],
+            filename: 'component.tsx',
           }).code;
         } catch (e) {
           processedCode = transformedCode;

--- a/apps/client/pages/api/react-artifact-sandbox.ts
+++ b/apps/client/pages/api/react-artifact-sandbox.ts
@@ -134,16 +134,35 @@ const SANDBOX_HTML = `<!DOCTYPE html>
     ${LUCIDE_WRAPPER_FN}
 
     function renderArtifact(code, dependencies, mode) {
+      // Strip TS type-only import syntax FIRST, before any check or rewrite below sees it: whole
+      // \`import type ...\` statements and inline \`{ type X, y }\` specifiers carry no runtime
+      // binding. This must precede the relative-import guard so a type-only relative import
+      // (\`import type Foo from './x'\`) is not misread as a multi-file artifact - matches the
+      // publish transpiler, which strips before findRelativeImport (transpileReactArtifact.ts).
+      // A binding named \`type\` (\`type as T\`) is kept. Mirrors stripTypeOnlyImports there.
+      var withoutTypeImports = code
+        .replace(/import\\s+type\\s+[\\s\\S]*?\\s+from\\s+['"][^'"]+['"]\\s*;?/g, '')
+        .replace(/import\\s+([\\s\\S]*?)\\s+from\\s+['"][^'"]+['"]\\s*;?/g, function (stmt, clause) {
+          var brace = clause.match(/\\{([\\s\\S]*?)\\}/);
+          if (!brace) return stmt;
+          var kept = brace[1].split(',').map(function (s) { return s.trim(); })
+            .filter(Boolean).filter(function (s) { return !/^type\\s+(?!as\\b)\\w/.test(s); });
+          var beforeBrace = clause.slice(0, clause.indexOf('{')).replace(/,\\s*$/, '').trim();
+          if (!kept.length && !beforeBrace) return '';
+          return stmt.replace(/\\{[\\s\\S]*?\\}/, '{ ' + kept.join(', ') + ' }');
+        });
+
       // Multi-file artifacts aren't supported yet (#9403 follow-up): the require() shim below
       // resolves only npm packages, not sibling artifact files. Detect a relative import up
       // front and show a clear message instead of a cryptic "Cannot use import statement" /
       // "Module not available" further down.
       // Catch every relative-reference form: import-from, export-from, side-effect import,
       // and require() of a "./" or "../" path — all unresolvable by the npm-only shim below.
+      // Run on the type-stripped view so a type-only relative import is already gone.
       var relImport =
-        code.match(/(?:import|export)\\b[^;'"]*\\bfrom\\s*['"](\\.\\.?\\/[^'"]+)['"]/) ||
-        code.match(/\\bimport\\s*['"](\\.\\.?\\/[^'"]+)['"]/) ||
-        code.match(/\\brequire\\(\\s*['"](\\.\\.?\\/[^'"]+)['"]\\s*\\)/);
+        withoutTypeImports.match(/(?:import|export)\\b[^;'"]*\\bfrom\\s*['"](\\.\\.?\\/[^'"]+)['"]/) ||
+        withoutTypeImports.match(/\\bimport\\s*['"](\\.\\.?\\/[^'"]+)['"]/) ||
+        withoutTypeImports.match(/\\brequire\\(\\s*['"](\\.\\.?\\/[^'"]+)['"]\\s*\\)/);
       if (relImport) {
         var msg = 'Multi-file artifacts are not supported yet — this one references "' + relImport[1] +
           '" from a separate file. Ask for a single, self-contained component (one file, one default export).';
@@ -166,22 +185,6 @@ const SANDBOX_HTML = `<!DOCTYPE html>
           if (Object.prototype.hasOwnProperty.call(moduleMap, module)) return moduleMap[module];
           throw new Error('Module "' + module + '" is not available');
         };
-
-        // Strip TS type-only import syntax before rewriting to require(): whole \`import type ...\`
-        // statements and inline \`{ type X, y }\` specifiers carry no runtime binding, and this
-        // rewrite runs BEFORE Babel's typescript preset. A binding named \`type\` (\`type as T\`) is
-        // kept. Mirrors stripTypeOnlyImports in the publish transpiler (transpileReactArtifact.ts).
-        var withoutTypeImports = code
-          .replace(/import\\s+type\\s+[\\s\\S]*?\\s+from\\s+['"][^'"]+['"]\\s*;?/g, '')
-          .replace(/import\\s+([\\s\\S]*?)\\s+from\\s+['"][^'"]+['"]\\s*;?/g, function (stmt, clause) {
-            var brace = clause.match(/\\{([\\s\\S]*?)\\}/);
-            if (!brace) return stmt;
-            var kept = brace[1].split(',').map(function (s) { return s.trim(); })
-              .filter(Boolean).filter(function (s) { return !/^type\\s+(?!as\\b)\\w/.test(s); });
-            var beforeBrace = clause.slice(0, clause.indexOf('{')).replace(/,\\s*$/, '').trim();
-            if (!kept.length && !beforeBrace) return '';
-            return stmt.replace(/\\{[\\s\\S]*?\\}/, '{ ' + kept.join(', ') + ' }');
-          });
 
         // Normalize ESM "X as Y" renames to valid destructuring "X: Y" (a raw { X as Y } in a
         // const-destructure is a syntax error). Kept in sync with the publish transpiler.

--- a/apps/client/server/services/publish/transpileReactArtifact.test.ts
+++ b/apps/client/server/services/publish/transpileReactArtifact.test.ts
@@ -100,6 +100,15 @@ function C() { return <div>ok</div>; }
 export default C;`;
     await expect(transpileReactSource(src)).resolves.toContain('React.createElement');
   });
+
+  it('does not misread a type-only RELATIVE import as a multi-file artifact', async () => {
+    // The type-only import has no runtime reference, so it must be stripped BEFORE the
+    // relative-import (multi-file) guard runs - not rejected as a sibling-file reference.
+    const src = `import type Foo from './types';
+function C() { return <div>ok</div>; }
+export default C;`;
+    await expect(transpileReactSource(src)).resolves.toContain('React.createElement');
+  });
 });
 
 describe('buildReactArtifactBundle', () => {

--- a/apps/client/server/services/publish/transpileReactArtifact.test.ts
+++ b/apps/client/server/services/publish/transpileReactArtifact.test.ts
@@ -3,6 +3,7 @@ import {
   buildReactArtifactBundle,
   transpileReactSource,
   rewriteImportsToRequire,
+  stripTypeOnlyImports,
   UnsupportedReactDependencyError,
   ReactArtifactTranspileError,
 } from './transpileReactArtifact';
@@ -33,6 +34,72 @@ describe('transpileReactSource', () => {
     // default export is rewritten to the local the bootstrap reads
     expect(out).toContain('__DEFAULT_EXPORT__');
   });
+
+  it('strips TypeScript syntax (interface, generic hook, param annotations, type imports) before the JSX transform', async () => {
+    const TS = `import { useState, type FC } from 'react';
+import type { ReactNode } from 'react';
+interface Props { label: string; }
+const Counter: FC<Props> = ({ label }) => {
+  const [count, setCount] = useState<number>(0);
+  const bump = (by: number): void => setCount(c => c + by);
+  const wrap = (n: ReactNode): ReactNode => n;
+  return (
+    <div className="p-4">
+      <span>{wrap(label)}: {count}</span>
+      <button onClick={() => bump(1)}>+</button>
+    </div>
+  );
+}
+export default Counter;`;
+    const out = await transpileReactSource(TS);
+    expect(out).toContain('React.createElement');
+    // TS-only syntax is gone: no interface, no <number> generic arg, no `: type` annotations,
+    // and no leftover `type` import specifier that would blank the page as invalid destructuring.
+    expect(out).not.toMatch(/\binterface\b/);
+    expect(out).not.toContain('useState<number>');
+    expect(out).not.toMatch(/:\s*Props\b/);
+    expect(out).not.toMatch(/:\s*void\b/);
+    expect(out).not.toMatch(/\btype\s+FC\b/);
+    expect(out).not.toMatch(/\bReactNode\b/);
+  });
+});
+
+describe('stripTypeOnlyImports', () => {
+  it('drops a whole-clause `import type { X } from` statement', () => {
+    expect(stripTypeOnlyImports(`import type { Opts } from 'lodash';\nconst x = 1;`)).not.toMatch(/\bimport\b/);
+  });
+
+  it('drops inline `type` specifiers but keeps value bindings from the same clause', () => {
+    const out = stripTypeOnlyImports(`import { type Opts, merge, type Cfg } from 'lodash';`);
+    expect(out).toContain('merge');
+    expect(out).not.toMatch(/\btype\b/);
+    expect(out).not.toContain('Opts');
+    expect(out).not.toContain('Cfg');
+  });
+
+  it('drops the whole import when every named specifier is type-only and there is no default', () => {
+    expect(stripTypeOnlyImports(`import { type A, type B } from 'some-types';`).trim()).toBe('');
+  });
+
+  it('keeps the default binding when only the named specifiers are type-only', () => {
+    const out = stripTypeOnlyImports(`import Foo, { type Bar } from 'mod';`);
+    expect(out).toContain('Foo');
+    expect(out).not.toContain('Bar');
+  });
+
+  it('preserves a binding literally named `type` (not a type modifier)', () => {
+    // `import { type as T }` renames the value `type` to T; `import type from` is a default `type`.
+    expect(stripTypeOnlyImports(`import { type as T } from 'm';`)).toContain('type as T');
+    expect(stripTypeOnlyImports(`import type from 'm';`)).toContain("import type from 'm'");
+  });
+
+  it('does not gate a type-only import as a missing runtime dependency', async () => {
+    // `some-types` is not a publishable dep; a type-only import of it must NOT throw.
+    const src = `import type { Whatever } from 'some-types';
+function C() { return <div>ok</div>; }
+export default C;`;
+    await expect(transpileReactSource(src)).resolves.toContain('React.createElement');
+  });
 });
 
 describe('buildReactArtifactBundle', () => {
@@ -51,6 +118,24 @@ describe('buildReactArtifactBundle', () => {
     const result = validateBundle({ indexHtml, manifest: INDEX_MANIFEST });
     expect(result.violations).toEqual([]);
     expect(result.valid).toBe(true);
+  });
+
+  it('builds a valid inert bundle from a TypeScript artifact end-to-end (types stripped)', async () => {
+    const TS = `import { useState, type FC } from 'react';
+interface Props { start: number; }
+const Counter: FC<Props> = ({ start }) => {
+  const [count, setCount] = useState<number>(start);
+  return <button onClick={() => setCount(c => c + 1)}>{count}</button>;
+};
+export default Counter;`;
+    const { indexHtml } = await buildReactArtifactBundle({ source: TS, title: 'TS Counter' });
+
+    for (const { pattern, reason } of __testing.FORBIDDEN_INLINE_PATTERNS) {
+      expect(pattern.test(indexHtml), `forbidden pattern hit: ${reason}`).toBe(false);
+    }
+    expect(indexHtml).toContain('React.createElement');
+    expect(indexHtml).not.toMatch(/\binterface\b/); // TS stripped, not shipped as broken JS
+    expect(validateBundle({ indexHtml, manifest: INDEX_MANIFEST }).valid).toBe(true);
   });
 
   it('handles a mixed default+named React import (import React, { useState })', async () => {

--- a/apps/client/server/services/publish/transpileReactArtifact.ts
+++ b/apps/client/server/services/publish/transpileReactArtifact.ts
@@ -82,6 +82,37 @@ function findRelativeImport(source: string): string | null {
   return null;
 }
 
+/**
+ * Remove TypeScript type-only import syntax, which carries no runtime binding. The import rewrite
+ * and dependency scan below are regex passes that run BEFORE Babel's typescript preset, so they'd
+ * otherwise emit broken `const { type Foo } = ...` or gate a type-only package as a missing runtime
+ * dep. Runs on the raw source so the whole pipeline (relative-import guard, dep gating, rewrite)
+ * sees value imports only. Idempotent. Kept in sync with the sandbox preview
+ * (react-artifact-sandbox.ts).
+ *
+ * Handles: whole-clause `import type { X } from 'm'` / `import type X from 'm'` (dropped), and
+ * inline `import { type X, y } from 'm'` -> `import { y } from 'm'`. A binding literally named
+ * `type` (`import type from 'm'`, `import { type as T } from 'm'`) is preserved - `type` is only
+ * a modifier when followed by another binding identifier that is not `as`.
+ */
+export function stripTypeOnlyImports(source: string): string {
+  return source
+    .replace(/import\s+type\s+[\s\S]*?\s+from\s+['"][^'"]+['"]\s*;?/g, '')
+    .replace(/import\s+([\s\S]*?)\s+from\s+['"][^'"]+['"]\s*;?/g, (stmt: string, clause: string) => {
+      const braceMatch = clause.match(/\{([\s\S]*?)\}/);
+      if (!braceMatch) return stmt;
+      const kept = braceMatch[1]
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+        .filter(spec => !/^type\s+(?!as\b)\w/.test(spec));
+      // No value bindings left and no default/namespace before the brace -> whole import was type-only.
+      const beforeBrace = clause.slice(0, clause.indexOf('{')).replace(/,\s*$/, '').trim();
+      if (!kept.length && !beforeBrace) return '';
+      return stmt.replace(/\{[\s\S]*?\}/, `{ ${kept.join(', ')} }`);
+    });
+}
+
 /** React APIs pre-injected as bare globals in the bootstrap (see HOOK_GLOBALS). A named import of
  *  one of these is dropped (already global); any OTHER named React import is bound from `React`. */
 const HOOK_GLOBAL_NAMES: readonly string[] = [
@@ -104,7 +135,8 @@ const HOOK_GLOBAL_NAMES: readonly string[] = [
  * Uses lazy `[\s\S]*?` (not greedy `[^;]+`) so adjacent semicolon-less imports (valid via ASI) are
  * not conflated into one broken match. Exported for unit tests.
  */
-export function rewriteImportsToRequire(source: string): string {
+export function rewriteImportsToRequire(rawSource: string): string {
+  const source = stripTypeOnlyImports(rawSource); // TS type imports have no runtime binding
   // Convert ESM `X as Y` renames in a named-imports clause to valid destructuring `X: Y`
   // (a raw `const { X as Y } = ...` is a syntax error that would blank the published page).
   const renameNamedBindings = (named: string): string =>
@@ -151,7 +183,8 @@ export function rewriteImportsToRequire(source: string): string {
 }
 
 /** Module specifiers from real `import ... from '...'` statements (non-relative only). */
-function extractImportedModules(source: string): string[] {
+function extractImportedModules(rawSource: string): string[] {
+  const source = stripTypeOnlyImports(rawSource); // don't gate a type-only import as a runtime dep
   const mods = new Set<string>();
   const re = /import\s+[\s\S]*?\s+from\s+['"]([^'"]+)['"]/g;
   let m: RegExpExecArray | null;
@@ -190,7 +223,9 @@ export function assertPublishableDependencies(source: string): void {
  * bootstrap reads. Output contains no import/export statements and no eval.
  */
 export async function transpileReactSource(source: string): Promise<string> {
-  const relImport = findRelativeImport(source);
+  // Strip type-only imports first so a type-only relative import isn't misread as a multi-file ref.
+  const cleaned = stripTypeOnlyImports(source);
+  const relImport = findRelativeImport(cleaned);
   if (relImport) {
     throw new ReactArtifactTranspileError(
       `Multi-file artifacts are not supported: this one references "${relImport}" from a separate file. ` +
@@ -199,17 +234,21 @@ export async function transpileReactSource(source: string): Promise<string> {
   }
 
   const Babel = await getBabel();
-  const withRequires = rewriteImportsToRequire(source);
+  const withRequires = rewriteImportsToRequire(cleaned);
 
   let transformed: string | null | undefined;
   try {
     // Classic runtime: emit React.createElement against the React global (the AUTOMATIC runtime
     // injects `import { jsx } from "react/jsx-runtime"`, fatal in a no-module-loader script).
+    // The `typescript` preset strips TS syntax (types/generics/interfaces the assistant emits by
+    // default); presets run last-to-first, so types are stripped BEFORE the JSX transform. TSX is
+    // detected via the `.tsx` filename - NOT preset-typescript's allExtensions/isTSX options, which
+    // conflict with preset-react JSX detection and break the plain-JS path.
     // Identical config to the in-app sandbox (react-artifact-sandbox.ts) so a published artifact
-    // renders the same as the chat preview.
+    // renders the same as the chat preview - keep the two in sync.
     transformed = Babel.transform(withRequires, {
-      presets: [['react', { runtime: 'classic' }]],
-      filename: 'component.jsx',
+      presets: [['react', { runtime: 'classic' }], 'typescript'],
+      filename: 'component.tsx',
     }).code;
   } catch (e) {
     throw new ReactArtifactTranspileError(`JSX transform failed: ${(e as Error).message}`);


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

- TypeScript React artifact rendering live in the in-app viewer, no `JSX transformation failed` error.
  
https://github.com/user-attachments/assets/fcbbd3be-2b96-4064-a003-2e06c17ce83c

- The same artifact published to a `/p/...` link and rendering live in a fresh tab.

https://github.com/user-attachments/assets/15aacb75-55a0-4637-8edd-b206979a4b50


- Type-only imports (`import type` / inline `{ type X }`) rendering in the viewer.

https://github.com/user-attachments/assets/623b4996-7a5b-487e-aa2a-a19ee9f4e30a


- A type-only import of an unknown package rendering and publishing, not gated as an unsupported dependency.

https://github.com/user-attachments/assets/696b41ee-0e0f-43cc-931a-33c018217f5f


- Regression: a plain-JavaScript artifact still rendering and publishing.

https://github.com/user-attachments/assets/0282ea78-8a8b-4af8-9617-14818b57752e

- Regression: a hand-broken artifact failing cleanly with an error box, not a crash or blank card.

https://github.com/user-attachments/assets/3b65b702-36da-4972-b80f-e11fbb028e8d


## Description

React artifacts are transpiled with Babel's classic JSX (`react`) preset only. The assistant
frequently emits TypeScript by default (type annotations, generics, interfaces), which that preset
cannot parse - so the in-app viewer shows `JSX transformation failed. Use React.createElement()
syntax.` and publishing returns a 422. A valid TypeScript React artifact therefore fails to render
or publish, and the user has to know to explicitly ask for plain JavaScript.

This adds Babel's `typescript` preset to BOTH transpile paths so TS syntax is stripped before the
JSX transform, on the publish path and the in-app preview path, keeping the two in sync.

While in the area, this also handles TypeScript type-only imports, which the pre-Babel regex passes
would otherwise mishandle (emit broken `const { type Foo } = ...`, gate a type-only package as a
missing runtime dependency, or misread a type-only relative import as a multi-file reference).

Closes #650. Part of #21.

## Changes

- Add the `typescript` Babel preset and a `.tsx` filename to both transpile surfaces:
  - `apps/client/server/services/publish/transpileReactArtifact.ts` (publish)
  - `apps/client/pages/api/react-artifact-sandbox.ts` (in-app preview)
  - Presets run last-to-first, so types are stripped before the JSX transform. TSX is detected via
    the `.tsx` filename, NOT preset-typescript's `allExtensions`/`isTSX` options (those conflict
    with preset-react JSX detection and break the plain-JS path).
  - No new dependency: `@babel/standalone@8.x` (already used on both surfaces) ships
    preset-typescript.
- Add `stripTypeOnlyImports` (publish) plus a mirrored strip pass (preview) that runs before the
  regex import-rewrite and dependency scan:
  - Drops whole-clause `import type { X } from 'm'` and inline `{ type X, y }` specifiers, which
    carry no runtime binding.
  - Preserves a binding literally named `type` (`import type from 'm'`, `import { type as T }`).
  - Wired into `rewriteImportsToRequire`, `extractImportedModules`, and `transpileReactSource` so
    the whole pipeline (relative-import guard, dep gating, rewrite) sees value imports only.
- Add regression tests: real-TypeScript transpile (interface, `useState<number>()` generic, param
  annotations, type imports), an end-to-end `buildReactArtifactBundle` TS test asserting the bundle
  still passes `validateBundle`, a focused `stripTypeOnlyImports` unit block, and structural guards
  that the sandbox shell wires the preset and the type-only strip.

## Guide for Testers

Note: in-app rendering can be checked locally; the `/p/` publish path needs a deployed environment
(the isolated serve origin + CSP), so run the publish steps on the preview link.

The assistant tends to downgrade a TypeScript request to a static code artifact. Every prompt below
forces a live artifact. If any step yields a static, non-interactive code listing (not a rendered,
clickable component), reply `Re-emit it as a LIVE application/vnd.ant.react artifact with the
TypeScript kept as-is - not a text or code artifact.` and retry before judging pass/fail.

1. TypeScript renders. Send: `Emit a LIVE interactive React artifact (application/vnd.ant.react),
   NOT a text or code artifact. Keep it as real TypeScript - do not convert to JavaScript. Make it a
   minimal counter (a number with a + and a - button) using an interface for its props, a
   useState<number>() generic, and typed function parameters. Single self-contained file, default
   export.`
   - Expected: a live, interactive counter renders (clickable `+` / `-`), with NO `JSX
     transformation failed` error.
2. TypeScript publishes. Publish the step 1 artifact via its Share/Publish action.
   - Expected: publish succeeds (no 422); you get a `/p/...` link. Open it in a fresh/incognito tab
     and confirm it renders identically to the in-app preview.
3. Type-only imports render. Send: `Emit a LIVE application/vnd.ant.react artifact, keep the
   TypeScript. Use import type { ReactNode } from 'react' and an inline
   import { useState, type FC } from 'react'. Make it a small typed card with a default export.`
   - Expected: renders in the in-app viewer. (Before this change the inline `type FC` emitted broken
     `const { type FC } = React` and blanked the page.) Publishing the type-only case is covered by
     step 4.
4. Type-only import of an unknown package renders and publishes. Send: `Emit a LIVE
   application/vnd.ant.react artifact, keep the TypeScript. At the top include a made-up type-only
   import: import type { Foo } from 'some-types-pkg' (used only as a type). Make it a small typed
   card with a default export.` Then publish it.
   - Expected: renders in the viewer AND publishes to a `/p/` link with no 422. A type-only import
     of a non-publishable package is NOT gated as an unsupported dependency.

### Regression Checks

5. Plain JavaScript. Send: `Emit a LIVE application/vnd.ant.react artifact in plain JavaScript (no
   TypeScript): a minimal button that counts clicks, default export.` Then publish it.
   - Expected: renders in-app and publishes to a working `/p/` link, exactly as before.
6. Broken artifact fails cleanly. Open a working artifact, click Enable Edit Mode, delete a closing
   brace to introduce a syntax error, and let it re-render. (Don't prompt for broken code - the
   model refuses; break it by hand.)
   - Expected: the preview shows a clean error state (an error box), not a browser crash or a
     silently blank card. Attempting to publish the broken version is rejected (no broken `/p/`
     page is produced).

### What NOT to test

- Whether the assistant naturally chooses to emit a TypeScript React artifact without being forced.
  That is model steering, out of scope here - this PR makes the platform transpile TS when a TS
  React artifact reaches it.

## Additional Information

Both transpile surfaces carry reciprocal "keep in sync" comments so the publish bundle always
matches the chat preview.

## Developer Notes (Optional)

- `stripTypeOnlyImports` (exported from `transpileReactArtifact.ts`) is a reusable, idempotent
  preprocessor for the artifact import pipeline: run it before any regex pass that treats imports
  as runtime bindings, so type-only syntax never reaches the rewrite/dep-scan stages.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
