### PR TITLE
chore(premium): set b4m-optihashi overlay pin to 1a70163f442946eb0508e0ed786b489cfe98b11a

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,7 +1,7 @@
 {
   "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
   "b4m-libreoncology": "c917641b8155c311d217b021e414bba33c9eb72a",
-  "b4m-optihashi": "08ea741aef15e9391148e5eb24c1e4c04557486b",
+  "b4m-optihashi": "1a70163f442946eb0508e0ed786b489cfe98b11a",
   "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Overlay-pin-only change; no application source changes.

Bumps the `b4m-optihashi` overlay pin from `08ea741` to `1a70163`.

## Guide for Testers
This is a pin-only change (a single line in `premium-overlay.lock.json`); there are no application source changes in this repo. Validation is the standard overlay-pin flow:

1. CI must be green (typecheck + test).
2. Boot a preview off this PR (deployer `preview.yml`) so the `preview-deployed` label is applied -- that preview build is the SST-bundle validation the pin PR gate requires.
3. On the preview, run an optimizer session in agent mode with a multi-step scenario and confirm it completes end to end with a coherent final summary.

Regression checks: existing optimizer flows (guided + agent) behave as before; no change to any non-overlay behavior.

What NOT to test: nothing outside the optimizer surface is touched by this pin.