### PR TITLE
fix(agent): stop opti loop re-doing solved steps + graceful cap-hit summary (#674)

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -83,6 +83,7 @@ import { resolveLatticeTools, buildSubagentLatticeToolPool } from './agentExecut
 import { selectGatedAction } from './agentExecutorUtils/toolPermissions';
 import { guardDecomposeOnce } from './agentExecutorUtils/decomposeGuard';
 import { buildTruncatedRunReply } from './agentExecutorUtils/truncatedReply';
+import { guardPlanCompletion, type PlanProgressState } from './agentExecutorUtils/planCompletionGuard';
 import { buildDagResumeReport, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
 import { collectDagChildArtifactBlocks } from './agentExecutor.dagArtifacts';
 import type { DagHandoffSignal } from '@bike4mind/services';
@@ -1236,8 +1237,18 @@ async function processExecution(
     // the guard turns any repeat into a no-op redirect that steers the agent back to
     // advancing its existing plan. Only affects opti runs (decompose isn't offered elsewhere).
     const decomposeGuard = { used: false };
-    const guardedPremiumTools = guardDecomposeOnce(premiumLlmTools, decomposeGuard, () =>
-      logger.info('[opti] blocked a repeat optihashi_decompose call (advancing existing plan)', { executionId })
+    // Two complementary opti-loop guards: #666 stops re-PLANNING (decompose at most once); the
+    // plan-completion guard stops re-SOLVING (once every planned step has a solver result, further
+    // formulate/solve calls redirect to "write the final summary"). Without the latter the agent
+    // -- which has no reliable memory of which steps it finished -- re-does solved families until
+    // it hits the iteration ceiling. Both are inert on non-opti runs (decompose isn't offered).
+    const planProgress: PlanProgressState = { needed: null, solved: {} };
+    const guardedPremiumTools = guardPlanCompletion(
+      guardDecomposeOnce(premiumLlmTools, decomposeGuard, () =>
+        logger.info('[opti] blocked a repeat optihashi_decompose call (advancing existing plan)', { executionId })
+      ),
+      planProgress,
+      () => logger.info('[opti] plan complete -- all planned steps solved; steering to final summary', { executionId })
     );
 
     const tools = buildSharedTools({ ...toolDeps, optInTools: subagentLatticeTools }, toolCallbacks, {

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -82,6 +82,7 @@ import { creditService, apiKeyService } from '@bike4mind/services';
 import { resolveLatticeTools, buildSubagentLatticeToolPool } from './agentExecutor.latticeTools';
 import { selectGatedAction } from './agentExecutorUtils/toolPermissions';
 import { guardDecomposeOnce } from './agentExecutorUtils/decomposeGuard';
+import { buildTruncatedRunReply } from './agentExecutorUtils/truncatedReply';
 import { buildDagResumeReport, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
 import { collectDagChildArtifactBlocks } from './agentExecutor.dagArtifacts';
 import type { DagHandoffSignal } from '@bike4mind/services';
@@ -2118,18 +2119,23 @@ async function processExecution(
     const updatedExecution = await agentExecutionRepository.findById(executionId);
     const finalCheckpoint = agent.toCheckpoint();
     const finalAnswer = extractFinalAnswer(finalCheckpoint.steps);
+    // A run that stopped on the iteration ceiling (not model completion) leaves `finalAnswer` as
+    // a mid-sentence fragment; wrap it in a deterministic truncation notice so the user sees an
+    // honest "partial, hit the limit" reply instead of a trailed-off thought. See #674.
+    const reachedMaxIterations = iterationResult?.reachedMaxIterations ?? false;
+    const displayAnswer = reachedMaxIterations ? buildTruncatedRunReply(maxIterations, finalAnswer) : finalAnswer;
 
     await agentExecutionRepository.markComplete(executionId, {
-      answer: finalAnswer,
+      answer: displayAnswer,
       steps: finalCheckpoint.steps,
       totalTokens: finalCheckpoint.totalTokens,
       totalIterations: finalCheckpoint.iteration,
-      reachedMaxIterations: iterationResult?.reachedMaxIterations ?? false,
+      reachedMaxIterations,
     });
 
     await sendWs('completed', {
       executionId,
-      answer: finalAnswer,
+      answer: displayAnswer,
       totalIterations: finalCheckpoint.iteration,
       totalCreditsUsed: updatedExecution?.totalCreditsUsed ?? 0,
       // Surface memento IDs in the WS event so the client can populate the
@@ -2141,7 +2147,7 @@ async function processExecution(
 
     // Persist a Quest so the run survives page refresh - see persistRunAsQuest
     // docstring. Best-effort; failures are logged but don't fail the run.
-    let replyText = finalAnswer ?? 'Agent execution completed without a final answer.';
+    let replyText = displayAnswer ?? 'Agent execution completed without a final answer.';
 
     // DAG subagent artifact bubble-up. The parent re-summarizes the aggregated
     // child report and may drop the raw `<artifact>` blocks the workers emitted,

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ToolDefinition } from '@bike4mind/services';
+import {
+  guardPlanCompletion,
+  planIsComplete,
+  capturePlan,
+  familyForSolveCall,
+  PLAN_COMPLETE_MSG,
+  type PlanProgressState,
+} from './planCompletionGuard';
+
+const planResult = (families: string[]) =>
+  JSON.stringify({
+    type: 'populateDecomposition',
+    payload: { decomposition: { steps: families.map((familyId, i) => ({ familyId, order: i + 1 })) } },
+    displayMessage: 'Loaded step 1',
+  });
+
+// Fake tool whose toolFn returns a canned result and records the params it saw.
+function fakeTool(
+  name: string,
+  result: string | ((p?: unknown) => string)
+): { tool: ToolDefinition; calls: unknown[] } {
+  const calls: unknown[] = [];
+  const tool = {
+    name,
+    implementation: () => ({
+      toolFn: async (params?: unknown) => {
+        calls.push(params);
+        return typeof result === 'function' ? result(params) : result;
+      },
+      toolSchema: { name, description: '', parameters: { type: 'object', properties: {} } },
+    }),
+  } as unknown as ToolDefinition;
+  return { tool, calls };
+}
+
+const run = (t: ToolDefinition, params?: unknown) => t.implementation({} as never, undefined).toolFn(params);
+
+function makeOptiTools() {
+  const decompose = fakeTool('optihashi_decompose', planResult(['scheduling', 'selection', 'routing']));
+  const formulate = fakeTool('optihashi_formulate', '## Formulated: "X" **selection problem**');
+  const schedule = fakeTool('optihashi_schedule', '## Scheduling Results for "X" ### Winner: SA');
+  const solve = fakeTool('optihashi_solve', '## Results for "X" (selection) ### Winner: Tabu');
+  return {
+    map: {
+      optihashi_decompose: decompose.tool,
+      optihashi_formulate: formulate.tool,
+      optihashi_schedule: schedule.tool,
+      optihashi_solve: solve.tool,
+    },
+    calls: { decompose: decompose.calls, formulate: formulate.calls, schedule: schedule.calls, solve: solve.calls },
+  };
+}
+
+describe('pure helpers', () => {
+  it('capturePlan counts plan steps per family; null for non-plan results', () => {
+    expect(capturePlan(planResult(['scheduling', 'selection', 'routing']))).toEqual({
+      scheduling: 1,
+      selection: 1,
+      routing: 1,
+    });
+    expect(capturePlan(planResult(['scheduling', 'scheduling']))).toEqual({ scheduling: 2 });
+    expect(capturePlan('Error: something broke')).toBeNull();
+    expect(capturePlan(JSON.stringify({ type: 'somethingElse' }))).toBeNull();
+  });
+
+  it('familyForSolveCall maps schedule->scheduling and reads solve problem.family', () => {
+    expect(familyForSolveCall('optihashi_schedule', undefined)).toBe('scheduling');
+    expect(familyForSolveCall('optihashi_solve', { problem: { family: 'routing' } })).toBe('routing');
+    expect(familyForSolveCall('optihashi_solve', {})).toBeNull();
+  });
+
+  it('planIsComplete needs every planned family covered; min-caps re-solves', () => {
+    expect(planIsComplete({ needed: null, solved: {} })).toBe(false);
+    expect(planIsComplete({ needed: { scheduling: 1, routing: 1 }, solved: { scheduling: 1 } })).toBe(false);
+    // over-solving one family doesn't mask an unsolved one
+    expect(planIsComplete({ needed: { scheduling: 1, routing: 1 }, solved: { scheduling: 5 } })).toBe(false);
+    expect(planIsComplete({ needed: { scheduling: 1, routing: 1 }, solved: { scheduling: 1, routing: 1 } })).toBe(true);
+  });
+});
+
+describe('guardPlanCompletion', () => {
+  it('lets each planned step solve once, then blocks re-doing and steers to the summary', async () => {
+    const { map, calls } = makeOptiTools();
+    const state: PlanProgressState = { needed: null, solved: {} };
+    const onComplete = vi.fn();
+    const g = guardPlanCompletion(map, state, onComplete);
+
+    await run(g.optihashi_decompose); // captures plan
+    expect(state.needed).toEqual({ scheduling: 1, selection: 1, routing: 1 });
+
+    expect(await run(g.optihashi_schedule)).toMatch(/Scheduling Results/); // scheduling solved
+    expect(await run(g.optihashi_solve, { problem: { family: 'selection' } })).toMatch(/Results for/);
+    expect(onComplete).not.toHaveBeenCalled(); // 2 of 3 so far
+    expect(await run(g.optihashi_solve, { problem: { family: 'routing' } })).toMatch(/Results for/);
+    expect(onComplete).toHaveBeenCalledTimes(1); // all 3 covered
+
+    // Now every further loop-driver is redirected to the summary and does NOT run the real tool.
+    expect(await run(g.optihashi_schedule)).toBe(PLAN_COMPLETE_MSG);
+    expect(await run(g.optihashi_solve, { problem: { family: 'scheduling' } })).toBe(PLAN_COMPLETE_MSG);
+    expect(await run(g.optihashi_formulate)).toBe(PLAN_COMPLETE_MSG);
+    expect(calls.schedule).toHaveLength(1); // real schedule ran only the once
+    expect(calls.formulate).toHaveLength(0); // formulate never ran post-completion
+  });
+
+  it('does not count failed solves toward completion', async () => {
+    const solve = fakeTool('optihashi_solve', 'Error: invalid selection problem -- missing budget');
+    const map = {
+      optihashi_decompose: fakeTool('optihashi_decompose', planResult(['selection'])).tool,
+      optihashi_solve: solve.tool,
+    };
+    const state: PlanProgressState = { needed: null, solved: {} };
+    const g = guardPlanCompletion(map, state);
+    await run(g.optihashi_decompose);
+    await run(g.optihashi_solve, { problem: { family: 'selection' } }); // errors -> not counted
+    expect(planIsComplete(state)).toBe(false);
+    // a real subsequent solve is still allowed (not blocked)
+    expect(await run(g.optihashi_solve, { problem: { family: 'selection' } })).toMatch(/Error/);
+  });
+
+  it('stays inert until a plan is captured (single-problem formulate+solve runs freely)', async () => {
+    const { map } = makeOptiTools();
+    const state: PlanProgressState = { needed: null, solved: {} };
+    const g = guardPlanCompletion(map, state);
+    // No decompose called -> needed stays null -> nothing is ever blocked.
+    expect(await run(g.optihashi_formulate)).toMatch(/Formulated/);
+    expect(await run(g.optihashi_solve, { problem: { family: 'selection' } })).toMatch(/Results for/);
+  });
+
+  it('returns the map unchanged for a non-opti run (no decompose tool)', () => {
+    const other = fakeTool('web_search', 'ok').tool;
+    const map = { web_search: other };
+    const g = guardPlanCompletion(map, { needed: null, solved: {} });
+    expect(g).toBe(map);
+  });
+});

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
@@ -1,0 +1,153 @@
+import type { ToolDefinition } from '@bike4mind/services';
+
+/**
+ * Message returned once every planned step has a solver result, when the agent tries to
+ * formulate/solve yet again. It tells the agent the walk is done and to write the summary.
+ */
+export const PLAN_COMPLETE_MSG =
+  'All planned steps for this run have been solved -- each step already has a solver result in ' +
+  'your history above. Do NOT formulate, schedule, or solve anything else, and do NOT re-do a ' +
+  'step. Write your FINAL SUMMARY now: for each step name the winning solver and its objective ' +
+  'value, then stop.';
+
+/**
+ * Per-execution plan progress. `needed` is captured from the decompose result (familyId -> number
+ * of plan steps of that family); it stays null until a decomposition loads, so single-problem runs
+ * (formulate+solve, no decompose) are never gated. `solved` counts SUCCESSFUL schedule/solve calls
+ * per family. Keep this in the caller's execution closure so it survives tool-map rebuilds.
+ */
+export type PlanProgressState = {
+  needed: Record<string, number> | null;
+  solved: Record<string, number>;
+};
+
+type ToolFn = (parameters?: unknown, apiKey?: string) => Promise<string>;
+
+/** Parse the decompose tool result and count plan steps per family. Null if it isn't a plan. */
+export function capturePlan(result: string): Record<string, number> | null {
+  try {
+    const parsed = JSON.parse(result) as {
+      type?: string;
+      payload?: { decomposition?: { steps?: Array<{ familyId?: unknown }> } };
+    };
+    if (parsed?.type !== 'populateDecomposition') return null;
+    const steps = parsed.payload?.decomposition?.steps;
+    if (!Array.isArray(steps) || steps.length === 0) return null;
+    const needed: Record<string, number> = {};
+    for (const step of steps) {
+      const fam = step?.familyId;
+      if (typeof fam === 'string') needed[fam] = (needed[fam] ?? 0) + 1;
+    }
+    return Object.keys(needed).length > 0 ? needed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The family a schedule/solve call targets: scheduling for schedule, `problem.family` for solve. */
+export function familyForSolveCall(toolName: string, parameters: unknown): string | null {
+  if (toolName === 'optihashi_schedule') return 'scheduling';
+  if (toolName === 'optihashi_solve') {
+    const fam = (parameters as { problem?: { family?: unknown } } | undefined)?.problem?.family;
+    return typeof fam === 'string' ? fam : null;
+  }
+  return null;
+}
+
+/** A tool result is a success unless it is one of the tools' `Error: ...` returns. */
+function isToolSuccess(result: string): boolean {
+  return !result.trimStart().toLowerCase().startsWith('error');
+}
+
+/**
+ * Complete when every planned family has at least as many successful solves as the plan calls for.
+ * `min(solved, needed)` per family caps re-solves so over-solving one step can't mask an unsolved
+ * one; the run is done only when the covered-step count reaches the plan length.
+ */
+export function planIsComplete(state: PlanProgressState): boolean {
+  if (!state.needed) return false;
+  let planSteps = 0;
+  let covered = 0;
+  for (const [fam, n] of Object.entries(state.needed)) {
+    planSteps += n;
+    covered += Math.min(state.solved[fam] ?? 0, n);
+  }
+  return planSteps > 0 && covered >= planSteps;
+}
+
+function wrap(tool: ToolDefinition, makeFn: (run: ToolFn) => ToolFn): ToolDefinition {
+  return {
+    ...tool,
+    implementation: (context, config) => {
+      const inner = tool.implementation(context, config);
+      return { ...inner, toolFn: makeFn(inner.toolFn as ToolFn) };
+    },
+  };
+}
+
+/**
+ * Stop the opti loop from re-doing already-solved steps (the dominant iteration-budget drain).
+ *
+ * A decompose plan is an ordered set of single-family sub-problems. The agent has no reliable
+ * memory of which steps it already solved -- it re-derives from a long transcript each turn -- so
+ * it repeatedly re-formulates and re-solves families it already covered, running to the iteration
+ * ceiling. This guard captures the plan from the decompose result, counts successful solves per
+ * family, and once every planned step has a result it turns any further formulate/schedule/solve
+ * into a no-op redirect telling the agent to write its final summary. The #666 decompose guard is
+ * complementary (it blocks re-PLANNING; this blocks re-SOLVING).
+ *
+ * Returns a NEW map (never mutates the input). Only wraps opti tools that are present, and stays
+ * inert until a decomposition loads, so non-opti and single-problem runs are unaffected.
+ */
+export function guardPlanCompletion(
+  tools: Record<string, ToolDefinition>,
+  state: PlanProgressState,
+  onComplete?: () => void
+): Record<string, ToolDefinition> {
+  // Only the decompose-driven multi-step loop has a "plan" to complete.
+  if (!tools['optihashi_decompose']) return tools;
+
+  const guarded = { ...tools };
+
+  // Capture the plan when decompose runs. Does not block repeats -- that's the #666 guard's job.
+  const decompose = tools['optihashi_decompose'];
+  guarded.optihashi_decompose = wrap(decompose, run => async (parameters, apiKey) => {
+    const out = await run(parameters, apiKey);
+    if (!state.needed) {
+      const captured = capturePlan(out);
+      if (captured) state.needed = captured;
+    }
+    return out;
+  });
+
+  // Formulate: once the plan is complete, don't build another instance -- redirect to summary.
+  const formulate = tools['optihashi_formulate'];
+  if (formulate) {
+    guarded.optihashi_formulate = wrap(formulate, run => async (parameters, apiKey) => {
+      if (planIsComplete(state)) return PLAN_COMPLETE_MSG;
+      return run(parameters, apiKey);
+    });
+  }
+
+  // Schedule / solve: block once complete; otherwise run and count a successful solve. The call
+  // that finishes the last step still runs (not yet complete when it starts); the NEXT one blocks.
+  for (const name of ['optihashi_schedule', 'optihashi_solve'] as const) {
+    const tool = tools[name];
+    if (!tool) continue;
+    guarded[name] = wrap(tool, run => async (parameters, apiKey) => {
+      if (planIsComplete(state)) return PLAN_COMPLETE_MSG;
+      const out = await run(parameters, apiKey);
+      if (isToolSuccess(out)) {
+        const fam = familyForSolveCall(name, parameters);
+        if (fam) {
+          const wasComplete = planIsComplete(state);
+          state.solved[fam] = (state.solved[fam] ?? 0) + 1;
+          if (!wasComplete && planIsComplete(state)) onComplete?.();
+        }
+      }
+      return out;
+    });
+  }
+
+  return guarded;
+}

--- a/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { buildTruncatedRunReply } from './truncatedReply';
+
+describe('buildTruncatedRunReply', () => {
+  it('states the run was truncated and names the iteration limit', () => {
+    const out = buildTruncatedRunReply(30, 'Solved steps 1 and 2.');
+    expect(out).toContain('30-iteration limit');
+    expect(out).toMatch(/partial/i);
+  });
+
+  it('includes the partial answer when one exists', () => {
+    const out = buildTruncatedRunReply(30, 'Solved steps 1 and 2.');
+    expect(out).toContain('Solved steps 1 and 2.');
+    expect(out).toMatch(/continue/i);
+  });
+
+  it('still returns a coherent notice when there is no partial answer', () => {
+    const out = buildTruncatedRunReply(16);
+    expect(out).toContain('16-iteration limit');
+    expect(out).toMatch(/continue/i);
+    // No stray blank block where the (absent) partial answer would go.
+    expect(out).not.toMatch(/\n\n\n/);
+  });
+
+  it('trims whitespace-only answers to the no-partial form', () => {
+    const withPartial = buildTruncatedRunReply(30, 'real content');
+    const whitespaceOnly = buildTruncatedRunReply(30, '   \n  ');
+    const noArg = buildTruncatedRunReply(30);
+    expect(whitespaceOnly).toBe(noArg);
+    expect(withPartial).not.toBe(noArg);
+  });
+});

--- a/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
@@ -1,0 +1,16 @@
+/**
+ * Build the user-facing reply for a run that stopped because it hit the iteration ceiling
+ * (rather than the model signaling completion).
+ *
+ * On that path the extracted "final answer" is whatever the model happened to be mid-sentence
+ * on -- often a trailed-off intent ("...let me close the loop on the third one now") that then
+ * just stops. Surfacing that verbatim reads as a broken, useless response. Instead we wrap it in
+ * a deterministic, honest notice: the run was truncated, here is the partial progress, and the
+ * user can continue with a follow-up. Pure + side-effect-free so it is unit-testable. See #674.
+ */
+export function buildTruncatedRunReply(maxIterations: number, finalAnswer?: string): string {
+  const partial = finalAnswer?.trim();
+  const header = `This run reached its ${maxIterations}-iteration limit before finishing, so the result below is partial.`;
+  const footer = 'Send a follow-up to continue from where this left off.';
+  return partial ? `${header}\n\n${partial}\n\n${footer}` : `${header}\n\n${footer}`;
+}


### PR DESCRIPTION
Closes #674

Two complementary fixes for #674 ("opti run hits iteration cap mid-plan with a cut-off summary; overhead eats the budget"), verified against a live preview run.

## Root cause (found by watching a live preview run)
On a clean 3-step plan (scheduling -> selection -> routing), the agent solved **all three steps by iteration 9**, then kept re-formulating and re-solving the same families through iteration 23+ and would have hit the 30 cap. At iter 17 its own thought was "now let me cover the scheduling and order-prioritization pieces" -- steps it had already solved four times. The agent has **no reliable memory of which plan steps it finished**; it re-derives from a long transcript each turn and loops. (#666 blocks re-*planning* but not re-*solving*.)

## Fix 1 (primary) -- plan-completion guard
New host guard `agentExecutorUtils/planCompletionGuard.ts`, same shape as the #666 decompose guard:
- Captures the plan from the decompose result (family counts).
- Counts **successful** schedule/solve calls per family.
- Once every planned step has a result, turns any further formulate/schedule/solve into a no-op redirect: "all steps solved -- write your final summary now."
- `min(solved, needed)` per family caps re-solves so over-solving one step can't mask an unsolved one.
- Inert on non-opti and single-problem runs (no decompose plan).

This would have ended the observed run at ~iteration 10 instead of looping to 30.

## Fix 2 (safety net) -- graceful cap-hit summary
`agentExecutorUtils/truncatedReply.ts`: if a run still hits the ceiling, the reply is a deterministic "reached the N-iteration limit; here's the partial progress; send a follow-up to continue" notice instead of the model's trailed-off mid-sentence. Applied to the live WS event, the stored record, and the persisted Quest.

## Tests
- `planCompletionGuard.test.ts` (7): plan capture, family mapping, min-cap completion, blocks re-do + steers to summary, ignores failed solves, inert without a plan, unchanged map on non-opti runs.
- `truncatedReply.test.ts` (4): names the limit + partial, includes/omits partial answer, trims whitespace-only.

## Verified working alongside (same preview)
- #67 (formulate in-tool repair) deployed; `optihashi_solve` registered; all families solved.
- #654 recovered-error chips render.
- #666 re-decompose guard fired in the wild (blocked an iter-17 re-decompose).

## Guide for Testers
1. Agent mode on `/opti`, a multi-step scenario (e.g. warehouse: sequence stations, prioritize orders, route vans).
2. Expect the run to **stop shortly after each planned step has one result** and write a final summary -- not loop re-solving the same families.
3. Check logs for `[opti] plan complete -- all planned steps solved; steering to final summary`.
4. If a run still hits the cap, the final message is the "reached the N-iteration limit ... partial ... send a follow-up" notice, not a cut-off sentence.
5. Regression: a single-problem run (no decompose) is unaffected; a normal completing run shows its real summary with no truncation notice.