### PR TITLE
feat(entitlements): add grantable opti-hardware compute entitlement tier

### DIFF
--- a/apps/client/lib/entitlements/registry.test.ts
+++ b/apps/client/lib/entitlements/registry.test.ts
@@ -129,6 +129,15 @@ describe('entitlementsForTags', () => {
   it('ignores empty/whitespace tags', () => {
     expect(entitlementsForTags(['', '   '])).toEqual(new Set());
   });
+
+  it('bridges the opti-hardware tag to the real-money hardware entitlement', () => {
+    // Pins the exact grant path an operator uses to authorize a partner account for real
+    // IonQ hardware spend: tagging `opti-hardware` must confer `optihashi:hardware`, the key
+    // the server hardware submit gate checks. A rename/removal here silently locks everyone
+    // (incl. non-admins) out of hardware compute, so lock it by name, not just table-coverage.
+    const granted = entitlementsForTags(['opti-hardware']);
+    expect(granted.has('optihashi:hardware')).toBe(true);
+  });
 });
 
 describe('entitlementsForPriceIds', () => {

--- a/apps/client/lib/entitlements/registry.test.ts
+++ b/apps/client/lib/entitlements/registry.test.ts
@@ -130,13 +130,16 @@ describe('entitlementsForTags', () => {
     expect(entitlementsForTags(['', '   '])).toEqual(new Set());
   });
 
-  it('bridges the opti-hardware tag to the real-money hardware entitlement', () => {
-    // Pins the exact grant path an operator uses to authorize a partner account for real
-    // IonQ hardware spend: tagging `opti-hardware` must confer `optihashi:hardware`, the key
-    // the server hardware submit gate checks. A rename/removal here silently locks everyone
-    // (incl. non-admins) out of hardware compute, so lock it by name, not just table-coverage.
-    const granted = entitlementsForTags(['opti-hardware']);
-    expect(granted.has('optihashi:hardware')).toBe(true);
+  it('grants optihashi:hardware ONLY via opti-hardware, never via a cheaper tier', () => {
+    // Pins the exact grant path an operator uses to authorize a partner account for
+    // external-provider hardware spend: tagging `opti-hardware` must confer `optihashi:hardware`,
+    // the key the overlay's hardware submit gate reads. A rename/removal here silently locks
+    // everyone (incl. non-admins) out of hardware compute, so lock it by name.
+    expect(entitlementsForTags(['opti-hardware']).has('optihashi:hardware')).toBe(true);
+    // The invariant that actually matters: cheaper tiers must NOT confer real-money hardware.
+    // Fails loudly if someone later widens a cheaper row into hardware.
+    expect(entitlementsForTags(['opti-compute']).has('optihashi:hardware')).toBe(false);
+    expect(entitlementsForTags(['opti']).has('optihashi:hardware')).toBe(false);
   });
 });
 

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -120,7 +120,7 @@ const TAG_GRANT_ROWS: TagGrantRow[] = [
   // `optihashi:hardware`, the entitlement the server checks in the hardware submit gate
   // (`requestHasHardwareComputeAccess`) before spending real external-provider money.
   // Deliberately its own tag, NOT implied by `optihashi:compute` (classical/simulator) or
-  // `optihashi:pro` (local) — a compute-tier user must not silently reach real-money spend.
+  // `optihashi:pro` (local) -- a compute-tier user must not silently reach real-money spend.
   // Granted-only (no Stripe price yet) and intentionally absent from DOMAIN_GRANT_ROWS /
   // INTERNAL_STAFF_ENTITLEMENTS / SIGNUP_CREDIT_ROWS: admins reach it via bypass, and it is
   // granted per-account (e.g. specific external partner users) rather than by domain/signup.

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -116,6 +116,15 @@ const TAG_GRANT_ROWS: TagGrantRow[] = [
   // internal users reach it via admin/developer bypass, and no signup credits
   // attach to the compute tier.
   { tag: 'opti-compute', entitlements: ['optihashi:compute'] },
+  // Real hardware compute is the STRICTEST tier: the `opti-hardware` tag bridges to
+  // `optihashi:hardware`, the entitlement the server checks in the hardware submit gate
+  // (`requestHasHardwareComputeAccess`) before spending real external-provider money.
+  // Deliberately its own tag, NOT implied by `optihashi:compute` (classical/simulator) or
+  // `optihashi:pro` (local) — a compute-tier user must not silently reach real-money spend.
+  // Granted-only (no Stripe price yet) and intentionally absent from DOMAIN_GRANT_ROWS /
+  // INTERNAL_STAFF_ENTITLEMENTS / SIGNUP_CREDIT_ROWS: admins reach it via bypass, and it is
+  // granted per-account (e.g. specific external partner users) rather than by domain/signup.
+  { tag: 'opti-hardware', entitlements: ['optihashi:hardware'] },
   // [DELETION-FOOTPRINT] Overwatch comp grant: the `overwatch` tag bridges to
   // `overwatch:pro`. Admin-only gate was a stopgap before the entitlement model
   // existed (Open Core M0). No Stripe price yet; granted-only initially. Removed

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -117,13 +117,14 @@ const TAG_GRANT_ROWS: TagGrantRow[] = [
   // attach to the compute tier.
   { tag: 'opti-compute', entitlements: ['optihashi:compute'] },
   // Real hardware compute is the STRICTEST tier: the `opti-hardware` tag bridges to
-  // `optihashi:hardware`, the entitlement the server checks in the hardware submit gate
-  // (`requestHasHardwareComputeAccess`) before spending real external-provider money.
-  // Deliberately its own tag, NOT implied by `optihashi:compute` (classical/simulator) or
-  // `optihashi:pro` (local) -- a compute-tier user must not silently reach real-money spend.
-  // Granted-only (no Stripe price yet) and intentionally absent from DOMAIN_GRANT_ROWS /
-  // INTERNAL_STAFF_ENTITLEMENTS / SIGNUP_CREDIT_ROWS: admins reach it via bypass, and it is
-  // granted per-account (e.g. specific external partner users) rather than by domain/signup.
+  // `optihashi:hardware`. Like `opti-compute` above, no gate in THIS repo reads the key yet -
+  // the hardware submit gate lives in the premium overlay - so this row is inert host-side
+  // until that overlay is composed in; it exists so the key is grantable/known here.
+  // Deliberately its own tier, NOT implied by `optihashi:compute` (classical/simulator) or
+  // `optihashi:pro` (local): a compute-tier user must not silently reach real external-provider
+  // (real-money) spend. Granted-only (no Stripe price yet) and intentionally absent from
+  // DOMAIN_GRANT_ROWS / INTERNAL_STAFF_ENTITLEMENTS / SIGNUP_CREDIT_ROWS - admins reach it via
+  // bypass, and it is granted per-account rather than by domain/signup.
   { tag: 'opti-hardware', entitlements: ['optihashi:hardware'] },
   // [DELETION-FOOTPRINT] Overwatch comp grant: the `overwatch` tag bridges to
   // `overwatch:pro`. Admin-only gate was a stopgap before the entitlement model


### PR DESCRIPTION
## What

Adds a `TAG_GRANT_ROW` bridging the `opti-hardware` comp tag to the `optihashi:hardware` entitlement — the key the server hardware-compute submit gate checks before spending real external-provider money.

Until now `optihashi:hardware` had **no grant source**, so hardware compute was effectively admin-only. This lets an operator authorize specific accounts (e.g. external partner users) via the admin "Grant (opti-hardware)" button — which surfaces automatically because `KNOWN_ENTITLEMENT_KEYS` derives from the grant rows.

## Design

- Mirrors the existing `opti-compute -> optihashi:compute` pattern.
- Deliberately its **own tier** — not implied by `optihashi:compute` (classical/simulator) or `optihashi:pro` (local). A compute-tier user must not silently reach real-money spend.
- Intentionally **absent** from domain / internal-staff / signup grant sources: it is granted per-account, not by email domain or signup.

## Tests

Adds an explicit test pinning `opti-hardware -> optihashi:hardware` by name (a rename/removal would silently lock everyone out of hardware compute). The existing table-driven registry tests auto-cover the new row. `registry.test.ts` green (40/40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)