### PR TITLE
chore(premium): set b4m-optihashi overlay pin to 79b55bf8edcda005292ac4c6a88dfaa5dbec3078

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -2,7 +2,7 @@
   "b4m-bob": "72235ca1b3fa53421917a1e7c1f244af18d2ed2b",
   "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
   "b4m-libreoncology": "c917641b8155c311d217b021e414bba33c9eb72a",
-  "b4m-optihashi": "1a70163f442946eb0508e0ed786b489cfe98b11a",
+  "b4m-optihashi": "79b55bf8edcda005292ac4c6a88dfaa5dbec3078",
   "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Overlay-pin-only change; no application source changes.

Bumps the `b4m-optihashi` overlay pin from `1a70163` to `79b55bf`.

## Guide for Testers
This is a pin-only change (a single line in `premium-overlay.lock.json`); there are no application source changes in this repo. Validation is the standard overlay-pin flow:

1. CI must be green (typecheck + test).
2. Boot a preview off this PR and smoke-test the OptiHashi surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)