### PR TITLE
fix(agent): hand per-step results to the plan-completion summary redirect (#674)

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -1248,7 +1248,7 @@ async function processExecution(
     // formulate/solve calls redirect to "write the final summary"). Without the latter the agent
     // -- which has no reliable memory of which steps it finished -- re-does solved families until
     // it hits the iteration ceiling. Both are inert on non-opti runs (decompose isn't offered).
-    const planProgress: PlanProgressState = { needed: null, solved: {} };
+    const planProgress: PlanProgressState = { steps: null, solved: {}, results: {} };
     // Outermost: give the loop the real active brief in-context (#57) so it passes the exact
     // problem to solve/edit instead of reconstructing it. Wraps the guarded tools last, so it
     // augments real tool observations and leaves guard redirects (non-envelope strings) untouched.

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.test.ts
@@ -5,18 +5,26 @@ import {
   planIsComplete,
   capturePlan,
   familyForSolveCall,
-  PLAN_COMPLETE_MSG,
+  extractResultDigest,
+  buildPlanCompleteMsg,
   type PlanProgressState,
 } from './planCompletionGuard';
 
 const planResult = (families: string[]) =>
   JSON.stringify({
     type: 'populateDecomposition',
-    payload: { decomposition: { steps: families.map((familyId, i) => ({ familyId, order: i + 1 })) } },
+    payload: {
+      decomposition: { steps: families.map((familyId, i) => ({ familyId, order: i + 1, title: `${familyId} step` })) },
+    },
     displayMessage: 'Loaded step 1',
   });
 
-// Fake tool whose toolFn returns a canned result and records the params it saw.
+const scheduleResult = '## Scheduling Results for "Sequencing" ### Winner: Simulated Annealing (makespan: 130) ###';
+const solveResultFor = (p?: unknown) => {
+  const fam = (p as { problem?: { family?: string } })?.problem?.family ?? 'selection';
+  return `## Results for "${fam} problem" (${fam}) ### Winner: Tabu Search (score: 42) ###`;
+};
+
 function fakeTool(
   name: string,
   result: string | ((p?: unknown) => string)
@@ -40,8 +48,8 @@ const run = (t: ToolDefinition, params?: unknown) => t.implementation({} as neve
 function makeOptiTools() {
   const decompose = fakeTool('optihashi_decompose', planResult(['scheduling', 'selection', 'routing']));
   const formulate = fakeTool('optihashi_formulate', '## Formulated: "X" **selection problem**');
-  const schedule = fakeTool('optihashi_schedule', '## Scheduling Results for "X" ### Winner: SA');
-  const solve = fakeTool('optihashi_solve', '## Results for "X" (selection) ### Winner: Tabu');
+  const schedule = fakeTool('optihashi_schedule', scheduleResult);
+  const solve = fakeTool('optihashi_solve', solveResultFor);
   return {
     map: {
       optihashi_decompose: decompose.tool,
@@ -53,14 +61,14 @@ function makeOptiTools() {
   };
 }
 
+const emptyState = (): PlanProgressState => ({ steps: null, solved: {}, results: {} });
+
 describe('pure helpers', () => {
-  it('capturePlan counts plan steps per family; null for non-plan results', () => {
-    expect(capturePlan(planResult(['scheduling', 'selection', 'routing']))).toEqual({
-      scheduling: 1,
-      selection: 1,
-      routing: 1,
-    });
-    expect(capturePlan(planResult(['scheduling', 'scheduling']))).toEqual({ scheduling: 2 });
+  it('capturePlan returns ordered steps with family + title; null for non-plan results', () => {
+    expect(capturePlan(planResult(['scheduling', 'selection']))).toEqual([
+      { family: 'scheduling', title: 'scheduling step' },
+      { family: 'selection', title: 'selection step' },
+    ]);
     expect(capturePlan('Error: something broke')).toBeNull();
     expect(capturePlan(JSON.stringify({ type: 'somethingElse' }))).toBeNull();
   });
@@ -71,59 +79,88 @@ describe('pure helpers', () => {
     expect(familyForSolveCall('optihashi_solve', {})).toBeNull();
   });
 
+  it('extractResultDigest pulls the title and winner+objective; null when no winner line', () => {
+    expect(extractResultDigest(scheduleResult)).toBe('Sequencing -- Simulated Annealing (makespan: 130)');
+    expect(extractResultDigest('### Winner: Greedy (bins: 4)')).toBe('Greedy (bins: 4)');
+    expect(extractResultDigest('Error: invalid problem')).toBeNull();
+  });
+
   it('planIsComplete needs every planned family covered; min-caps re-solves', () => {
-    expect(planIsComplete({ needed: null, solved: {} })).toBe(false);
-    expect(planIsComplete({ needed: { scheduling: 1, routing: 1 }, solved: { scheduling: 1 } })).toBe(false);
+    const steps = [
+      { family: 'scheduling', title: 's' },
+      { family: 'routing', title: 'r' },
+    ];
+    expect(planIsComplete(emptyState())).toBe(false);
+    expect(planIsComplete({ steps, solved: { scheduling: 1 }, results: {} })).toBe(false);
     // over-solving one family doesn't mask an unsolved one
-    expect(planIsComplete({ needed: { scheduling: 1, routing: 1 }, solved: { scheduling: 5 } })).toBe(false);
-    expect(planIsComplete({ needed: { scheduling: 1, routing: 1 }, solved: { scheduling: 1, routing: 1 } })).toBe(true);
+    expect(planIsComplete({ steps, solved: { scheduling: 5 }, results: {} })).toBe(false);
+    expect(planIsComplete({ steps, solved: { scheduling: 1, routing: 1 }, results: {} })).toBe(true);
+  });
+
+  it('buildPlanCompleteMsg lists every step in order with its captured result', () => {
+    const state: PlanProgressState = {
+      steps: [
+        { family: 'scheduling', title: 'seq' },
+        { family: 'routing', title: 'route' },
+      ],
+      solved: { scheduling: 1, routing: 1 },
+      results: { scheduling: 'Seq -- SA (makespan: 130)', routing: 'Route -- Tabu (84 km)' },
+    };
+    const msg = buildPlanCompleteMsg(state);
+    expect(msg).toMatch(/FINAL SUMMARY/i);
+    expect(msg).toContain('1. scheduling -- Seq -- SA (makespan: 130)');
+    expect(msg).toContain('2. routing -- Route -- Tabu (84 km)');
   });
 });
 
 describe('guardPlanCompletion', () => {
-  it('lets each planned step solve once, then blocks re-doing and steers to the summary', async () => {
+  it('solves each step once, captures results, then blocks with a result-laden summary redirect', async () => {
     const { map, calls } = makeOptiTools();
-    const state: PlanProgressState = { needed: null, solved: {} };
+    const state = emptyState();
     const onComplete = vi.fn();
     const g = guardPlanCompletion(map, state, onComplete);
 
     await run(g.optihashi_decompose); // captures plan
-    expect(state.needed).toEqual({ scheduling: 1, selection: 1, routing: 1 });
+    expect(state.steps?.map(s => s.family)).toEqual(['scheduling', 'selection', 'routing']);
 
-    expect(await run(g.optihashi_schedule)).toMatch(/Scheduling Results/); // scheduling solved
+    expect(await run(g.optihashi_schedule)).toMatch(/Scheduling Results/);
     expect(await run(g.optihashi_solve, { problem: { family: 'selection' } })).toMatch(/Results for/);
-    expect(onComplete).not.toHaveBeenCalled(); // 2 of 3 so far
+    expect(onComplete).not.toHaveBeenCalled(); // 2 of 3
     expect(await run(g.optihashi_solve, { problem: { family: 'routing' } })).toMatch(/Results for/);
     expect(onComplete).toHaveBeenCalledTimes(1); // all 3 covered
 
-    // Now every further loop-driver is redirected to the summary and does NOT run the real tool.
-    expect(await run(g.optihashi_schedule)).toBe(PLAN_COMPLETE_MSG);
-    expect(await run(g.optihashi_solve, { problem: { family: 'scheduling' } })).toBe(PLAN_COMPLETE_MSG);
-    expect(await run(g.optihashi_formulate)).toBe(PLAN_COMPLETE_MSG);
-    expect(calls.schedule).toHaveLength(1); // real schedule ran only the once
+    // results captured per family for the summary
+    expect(state.results.scheduling).toContain('Simulated Annealing (makespan: 130)');
+    expect(state.results.routing).toContain('routing problem');
+
+    // Further loop-drivers are redirected; the redirect carries every step's result.
+    const redirect = await run(g.optihashi_formulate);
+    expect(redirect).toMatch(/FINAL SUMMARY/i);
+    expect(redirect).toContain('1. scheduling');
+    expect(redirect).toContain('3. routing');
+    expect(await run(g.optihashi_schedule)).toMatch(/FINAL SUMMARY/i);
+    expect(calls.schedule).toHaveLength(1); // real schedule ran only once
     expect(calls.formulate).toHaveLength(0); // formulate never ran post-completion
   });
 
-  it('does not count failed solves toward completion', async () => {
+  it('does not count or capture results from failed solves', async () => {
     const solve = fakeTool('optihashi_solve', 'Error: invalid selection problem -- missing budget');
     const map = {
       optihashi_decompose: fakeTool('optihashi_decompose', planResult(['selection'])).tool,
       optihashi_solve: solve.tool,
     };
-    const state: PlanProgressState = { needed: null, solved: {} };
+    const state = emptyState();
     const g = guardPlanCompletion(map, state);
     await run(g.optihashi_decompose);
-    await run(g.optihashi_solve, { problem: { family: 'selection' } }); // errors -> not counted
+    await run(g.optihashi_solve, { problem: { family: 'selection' } }); // errors
     expect(planIsComplete(state)).toBe(false);
-    // a real subsequent solve is still allowed (not blocked)
-    expect(await run(g.optihashi_solve, { problem: { family: 'selection' } })).toMatch(/Error/);
+    expect(state.results.selection).toBeUndefined();
+    expect(await run(g.optihashi_solve, { problem: { family: 'selection' } })).toMatch(/Error/); // still allowed
   });
 
   it('stays inert until a plan is captured (single-problem formulate+solve runs freely)', async () => {
     const { map } = makeOptiTools();
-    const state: PlanProgressState = { needed: null, solved: {} };
-    const g = guardPlanCompletion(map, state);
-    // No decompose called -> needed stays null -> nothing is ever blocked.
+    const g = guardPlanCompletion(map, emptyState());
     expect(await run(g.optihashi_formulate)).toMatch(/Formulated/);
     expect(await run(g.optihashi_solve, { problem: { family: 'selection' } })).toMatch(/Results for/);
   });
@@ -131,7 +168,7 @@ describe('guardPlanCompletion', () => {
   it('returns the map unchanged for a non-opti run (no decompose tool)', () => {
     const other = fakeTool('web_search', 'ok').tool;
     const map = { web_search: other };
-    const g = guardPlanCompletion(map, { needed: null, solved: {} });
+    const g = guardPlanCompletion(map, emptyState());
     expect(g).toBe(map);
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.test.ts
@@ -19,10 +19,29 @@ const planResult = (families: string[]) =>
     displayMessage: 'Loaded step 1',
   });
 
-const scheduleResult = '## Scheduling Results for "Sequencing" ### Winner: Simulated Annealing (makespan: 130) ###';
+// The schedule/solve tools return a JSON envelope carrying the results markdown in `displayMessage`
+// (see quantumSchedule/quantumSolve). Mirror that exact shape so the guard + digest extractor are
+// exercised against what they actually receive in production -- escaped quotes, escaped newlines --
+// rather than a raw-markdown string the tools never emit.
+const envelope = (displayMessage: string, familyId?: string) =>
+  JSON.stringify({
+    __uiSideEffect: true,
+    type: familyId ? 'populateFamilyProblem' : 'populateProblem',
+    payload: familyId ? { familyId, problem: {} } : {},
+    displayMessage,
+  });
+
+const scheduleResult = envelope(
+  ['## Scheduling Results for "Sequencing"', 'Problem: 4 jobs, 4 machines', '', '### Winner: Simulated Annealing (makespan: 130)', '', '### Simulated Annealing'].join(
+    '\n'
+  )
+);
 const solveResultFor = (p?: unknown) => {
   const fam = (p as { problem?: { family?: string } })?.problem?.family ?? 'selection';
-  return `## Results for "${fam} problem" (${fam}) ### Winner: Tabu Search (score: 42) ###`;
+  return envelope(
+    [`## Results for "${fam} problem" (${fam})`, '', '### Winner: Tabu Search (score: 42)', '', '### Tabu Search'].join('\n'),
+    fam
+  );
 };
 
 function fakeTool(
@@ -79,9 +98,14 @@ describe('pure helpers', () => {
     expect(familyForSolveCall('optihashi_solve', {})).toBeNull();
   });
 
-  it('extractResultDigest pulls the title and winner+objective; null when no winner line', () => {
-    expect(extractResultDigest(scheduleResult)).toBe('Sequencing -- Simulated Annealing (makespan: 130)');
+  it('extractResultDigest unwraps the JSON envelope and pulls the winner+objective cleanly', () => {
+    // Real production shape: markdown lives in displayMessage. No trailing whitespace/newline artifact.
+    expect(extractResultDigest(scheduleResult)).toBe('Simulated Annealing (makespan: 130)');
+    expect(extractResultDigest(solveResultFor({ problem: { family: 'routing' } }))).toBe('Tabu Search (score: 42)');
+    // Falls back to raw markdown for callers/strings that aren't the envelope.
     expect(extractResultDigest('### Winner: Greedy (bins: 4)')).toBe('Greedy (bins: 4)');
+    // No winner line (single-solver run emits no Winner header) or an error -> null.
+    expect(extractResultDigest(envelope(['## Results for "X" (routing)', '', '### Concorde', 'tour: 88'].join('\n'), 'routing'))).toBeNull();
     expect(extractResultDigest('Error: invalid problem')).toBeNull();
   });
 
@@ -97,19 +121,28 @@ describe('pure helpers', () => {
     expect(planIsComplete({ steps, solved: { scheduling: 1, routing: 1 }, results: {} })).toBe(true);
   });
 
-  it('buildPlanCompleteMsg lists every step in order with its captured result', () => {
+  it('buildPlanCompleteMsg labels each step by its plan title, in order, with its captured result', () => {
     const state: PlanProgressState = {
       steps: [
-        { family: 'scheduling', title: 'seq' },
-        { family: 'routing', title: 'route' },
+        { family: 'scheduling', title: 'Sequence packing stations' },
+        { family: 'routing', title: 'Route delivery vans' },
       ],
       solved: { scheduling: 1, routing: 1 },
-      results: { scheduling: 'Seq -- SA (makespan: 130)', routing: 'Route -- Tabu (84 km)' },
+      results: { scheduling: 'SA (makespan: 130)', routing: 'Tabu (84 km)' },
     };
     const msg = buildPlanCompleteMsg(state);
     expect(msg).toMatch(/FINAL SUMMARY/i);
-    expect(msg).toContain('1. scheduling -- Seq -- SA (makespan: 130)');
-    expect(msg).toContain('2. routing -- Route -- Tabu (84 km)');
+    expect(msg).toContain('1. Sequence packing stations -- SA (makespan: 130)');
+    expect(msg).toContain('2. Route delivery vans -- Tabu (84 km)');
+  });
+
+  it('buildPlanCompleteMsg falls back for a step with no captured digest', () => {
+    const state: PlanProgressState = {
+      steps: [{ family: 'routing', title: 'Route vans' }],
+      solved: { routing: 1 },
+      results: {},
+    };
+    expect(buildPlanCompleteMsg(state)).toContain('1. Route vans -- solved (see result in your history above)');
   });
 });
 
@@ -129,15 +162,16 @@ describe('guardPlanCompletion', () => {
     expect(await run(g.optihashi_solve, { problem: { family: 'routing' } })).toMatch(/Results for/);
     expect(onComplete).toHaveBeenCalledTimes(1); // all 3 covered
 
-    // results captured per family for the summary
-    expect(state.results.scheduling).toContain('Simulated Annealing (makespan: 130)');
-    expect(state.results.routing).toContain('routing problem');
+    // results captured per family (winner + objective, unwrapped from the envelope -- no artifact)
+    expect(state.results.scheduling).toBe('Simulated Annealing (makespan: 130)');
+    expect(state.results.routing).toBe('Tabu Search (score: 42)');
 
-    // Further loop-drivers are redirected; the redirect carries every step's result.
+    // Further loop-drivers are redirected; the redirect labels each step by its plan title and
+    // carries its captured result, in plan order.
     const redirect = await run(g.optihashi_formulate);
     expect(redirect).toMatch(/FINAL SUMMARY/i);
-    expect(redirect).toContain('1. scheduling');
-    expect(redirect).toContain('3. routing');
+    expect(redirect).toContain('1. scheduling step -- Simulated Annealing (makespan: 130)');
+    expect(redirect).toContain('3. routing step -- Tabu Search (score: 42)');
     expect(await run(g.optihashi_schedule)).toMatch(/FINAL SUMMARY/i);
     expect(calls.schedule).toHaveLength(1); // real schedule ran only once
     expect(calls.formulate).toHaveLength(0); // formulate never ran post-completion

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
@@ -64,14 +64,33 @@ function isToolSuccess(result: string): boolean {
 }
 
 /**
- * Pull a compact "<problem title>: <winner + objective>" digest out of a schedule/solve result
- * (both render a `### Winner: <solver> (<objective>: N)` line). Null if no winner line is present.
+ * The schedule/solve tools return a JSON envelope ({ __uiSideEffect, type, payload, displayMessage })
+ * whose `displayMessage` carries the results markdown. Unwrap it so the digest regex matches against
+ * real markdown (real newlines, unescaped quotes) rather than the escaped JSON string. Falls back to
+ * the raw input when it isn't that envelope (e.g. a plain-markdown or error string).
+ */
+function resultMarkdown(result: string): string {
+  try {
+    const parsed = JSON.parse(result) as { displayMessage?: unknown };
+    if (typeof parsed?.displayMessage === 'string') return parsed.displayMessage;
+  } catch {
+    // not JSON -- treat the input as raw markdown
+  }
+  return result;
+}
+
+/**
+ * Pull the "<winner + objective>" digest out of a schedule/solve result (both render a
+ * `### Winner: <solver> (<objective>: N)` line in their `displayMessage` markdown). Null if no
+ * winner line is present (e.g. a single-solver run, which emits no Winner header, or an error).
+ * The per-step label is supplied by the plan (see `buildPlanCompleteMsg`), so this stays scoped to
+ * the outcome.
  */
 export function extractResultDigest(result: string): string | null {
-  const winner = result.match(/Winner:\s*([^\n#]+?)\s*(?:###|\n|$)/i)?.[1]?.trim();
-  if (!winner) return null;
-  const title = result.match(/Results for\s*"([^"]+)"/i)?.[1]?.trim();
-  return title ? `${title} -- ${winner}` : winner;
+  const winner = resultMarkdown(result)
+    .match(/Winner:\s*([^\n#]+?)\s*(?:###|\n|$)/i)?.[1]
+    ?.trim();
+  return winner || null;
 }
 
 /**
@@ -99,7 +118,7 @@ export function planIsComplete(state: PlanProgressState): boolean {
 export function buildPlanCompleteMsg(state: PlanProgressState): string {
   const lines = (state.steps ?? []).map((step, i) => {
     const digest = state.results[step.family];
-    return `${i + 1}. ${step.family}${digest ? ` -- ${digest}` : ' -- solved (see result in your history above)'}`;
+    return `${i + 1}. ${step.title}${digest ? ` -- ${digest}` : ' -- solved (see result in your history above)'}`;
   });
   return [
     'All planned steps for this run have been solved. Do NOT formulate, schedule, or solve anything',

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
@@ -1,47 +1,51 @@
 import type { ToolDefinition } from '@bike4mind/services';
 
-/**
- * Message returned once every planned step has a solver result, when the agent tries to
- * formulate/solve yet again. It tells the agent the walk is done and to write the summary.
- */
-export const PLAN_COMPLETE_MSG =
-  'All planned steps for this run have been solved -- each step already has a solver result in ' +
-  'your history above. Do NOT formulate, schedule, or solve anything else, and do NOT re-do a ' +
-  'step. Write your FINAL SUMMARY now: for each step name the winning solver and its objective ' +
-  'value, then stop.';
+/** One planned sub-problem: its family and the short title the decomposition gave it. */
+export type PlanStep = { family: string; title: string };
 
 /**
- * Per-execution plan progress. `needed` is captured from the decompose result (familyId -> number
- * of plan steps of that family); it stays null until a decomposition loads, so single-problem runs
- * (formulate+solve, no decompose) are never gated. `solved` counts SUCCESSFUL schedule/solve calls
- * per family. Keep this in the caller's execution closure so it survives tool-map rebuilds.
+ * Per-execution plan progress. `steps` is the ordered plan captured from the decompose result
+ * (null until a decomposition loads, so single-problem runs are never gated). `solved` counts
+ * SUCCESSFUL schedule/solve calls per family. `results` holds the first winning-result digest per
+ * family, so the completion redirect can hand the agent the actual per-step results to summarize --
+ * the agent's own transcript memory of earlier steps is unreliable (that's the bug we're fixing).
+ * Keep this in the caller's execution closure so it survives tool-map rebuilds.
  */
 export type PlanProgressState = {
-  needed: Record<string, number> | null;
+  steps: PlanStep[] | null;
   solved: Record<string, number>;
+  results: Record<string, string>;
 };
 
 type ToolFn = (parameters?: unknown, apiKey?: string) => Promise<string>;
 
-/** Parse the decompose tool result and count plan steps per family. Null if it isn't a plan. */
-export function capturePlan(result: string): Record<string, number> | null {
+/** Parse the decompose tool result into the ordered plan steps. Null if it isn't a plan. */
+export function capturePlan(result: string): PlanStep[] | null {
   try {
     const parsed = JSON.parse(result) as {
       type?: string;
-      payload?: { decomposition?: { steps?: Array<{ familyId?: unknown }> } };
+      payload?: { decomposition?: { steps?: Array<{ familyId?: unknown; title?: unknown }> } };
     };
     if (parsed?.type !== 'populateDecomposition') return null;
-    const steps = parsed.payload?.decomposition?.steps;
-    if (!Array.isArray(steps) || steps.length === 0) return null;
-    const needed: Record<string, number> = {};
-    for (const step of steps) {
-      const fam = step?.familyId;
-      if (typeof fam === 'string') needed[fam] = (needed[fam] ?? 0) + 1;
+    const rawSteps = parsed.payload?.decomposition?.steps;
+    if (!Array.isArray(rawSteps) || rawSteps.length === 0) return null;
+    const steps: PlanStep[] = [];
+    for (const step of rawSteps) {
+      if (typeof step?.familyId === 'string') {
+        steps.push({ family: step.familyId, title: typeof step.title === 'string' ? step.title : step.familyId });
+      }
     }
-    return Object.keys(needed).length > 0 ? needed : null;
+    return steps.length > 0 ? steps : null;
   } catch {
     return null;
   }
+}
+
+/** Planned count per family, derived from the ordered steps. */
+function neededByFamily(steps: PlanStep[]): Record<string, number> {
+  const needed: Record<string, number> = {};
+  for (const s of steps) needed[s.family] = (needed[s.family] ?? 0) + 1;
+  return needed;
 }
 
 /** The family a schedule/solve call targets: scheduling for schedule, `problem.family` for solve. */
@@ -60,19 +64,49 @@ function isToolSuccess(result: string): boolean {
 }
 
 /**
+ * Pull a compact "<problem title>: <winner + objective>" digest out of a schedule/solve result
+ * (both render a `### Winner: <solver> (<objective>: N)` line). Null if no winner line is present.
+ */
+export function extractResultDigest(result: string): string | null {
+  const winner = result.match(/Winner:\s*([^\n#]+?)\s*(?:###|\n|$)/i)?.[1]?.trim();
+  if (!winner) return null;
+  const title = result.match(/Results for\s*"([^"]+)"/i)?.[1]?.trim();
+  return title ? `${title} -- ${winner}` : winner;
+}
+
+/**
  * Complete when every planned family has at least as many successful solves as the plan calls for.
  * `min(solved, needed)` per family caps re-solves so over-solving one step can't mask an unsolved
  * one; the run is done only when the covered-step count reaches the plan length.
  */
 export function planIsComplete(state: PlanProgressState): boolean {
-  if (!state.needed) return false;
+  if (!state.steps) return false;
+  const needed = neededByFamily(state.steps);
   let planSteps = 0;
   let covered = 0;
-  for (const [fam, n] of Object.entries(state.needed)) {
+  for (const [fam, n] of Object.entries(needed)) {
     planSteps += n;
     covered += Math.min(state.solved[fam] ?? 0, n);
   }
   return planSteps > 0 && covered >= planSteps;
+}
+
+/**
+ * The redirect returned once every planned step has a result. It hands the agent the captured
+ * per-step results (in plan order) so it writes a COMPLETE, accurate final summary rather than
+ * re-deriving from its transcript (where earlier steps are buried and get forgotten/undersold).
+ */
+export function buildPlanCompleteMsg(state: PlanProgressState): string {
+  const lines = (state.steps ?? []).map((step, i) => {
+    const digest = state.results[step.family];
+    return `${i + 1}. ${step.family}${digest ? ` -- ${digest}` : ' -- solved (see result in your history above)'}`;
+  });
+  return [
+    'All planned steps for this run have been solved. Do NOT formulate, schedule, or solve anything',
+    'else, and do NOT re-do a step. Write your FINAL SUMMARY now, reporting the winning solver and',
+    'objective for EACH step below, then stop:',
+    ...lines,
+  ].join('\n');
 }
 
 function wrap(tool: ToolDefinition, makeFn: (run: ToolFn) => ToolFn): ToolDefinition {
@@ -91,20 +125,21 @@ function wrap(tool: ToolDefinition, makeFn: (run: ToolFn) => ToolFn): ToolDefini
  * A decompose plan is an ordered set of single-family sub-problems. The agent has no reliable
  * memory of which steps it already solved -- it re-derives from a long transcript each turn -- so
  * it repeatedly re-formulates and re-solves families it already covered, running to the iteration
- * ceiling. This guard captures the plan from the decompose result, counts successful solves per
- * family, and once every planned step has a result it turns any further formulate/schedule/solve
- * into a no-op redirect telling the agent to write its final summary. The #666 decompose guard is
+ * ceiling. This guard captures the plan from the decompose result, counts successful schedule/solve
+ * calls per family (and remembers each step's winning result), and once every planned step has a
+ * result it turns any further formulate/schedule/solve into a no-op redirect that hands the agent
+ * the per-step results and tells it to write its final summary. The #666 decompose guard is
  * complementary (it blocks re-PLANNING; this blocks re-SOLVING).
  *
- * Returns a NEW map (never mutates the input). Only wraps opti tools that are present, and stays
- * inert until a decomposition loads, so non-opti and single-problem runs are unaffected.
+ * Returns a NEW map (never mutates the input). Only meaningful for the decompose-driven multi-step
+ * loop, and stays inert until a decomposition loads, so non-opti and single-problem runs are
+ * unaffected.
  */
 export function guardPlanCompletion(
   tools: Record<string, ToolDefinition>,
   state: PlanProgressState,
   onComplete?: () => void
 ): Record<string, ToolDefinition> {
-  // Only the decompose-driven multi-step loop has a "plan" to complete.
   if (!tools['optihashi_decompose']) return tools;
 
   const guarded = { ...tools };
@@ -113,9 +148,9 @@ export function guardPlanCompletion(
   const decompose = tools['optihashi_decompose'];
   guarded.optihashi_decompose = wrap(decompose, run => async (parameters, apiKey) => {
     const out = await run(parameters, apiKey);
-    if (!state.needed) {
+    if (!state.steps) {
       const captured = capturePlan(out);
-      if (captured) state.needed = captured;
+      if (captured) state.steps = captured;
     }
     return out;
   });
@@ -124,25 +159,30 @@ export function guardPlanCompletion(
   const formulate = tools['optihashi_formulate'];
   if (formulate) {
     guarded.optihashi_formulate = wrap(formulate, run => async (parameters, apiKey) => {
-      if (planIsComplete(state)) return PLAN_COMPLETE_MSG;
+      if (planIsComplete(state)) return buildPlanCompleteMsg(state);
       return run(parameters, apiKey);
     });
   }
 
-  // Schedule / solve: block once complete; otherwise run and count a successful solve. The call
-  // that finishes the last step still runs (not yet complete when it starts); the NEXT one blocks.
+  // Schedule / solve: block once complete; otherwise run, count a successful solve, and remember
+  // the first winning result per family for the summary. The call that finishes the last step still
+  // runs (not complete when it starts); the NEXT one blocks. onComplete fires exactly once because
+  // after completion the top short-circuits before reaching the increment.
   for (const name of ['optihashi_schedule', 'optihashi_solve'] as const) {
     const tool = tools[name];
     if (!tool) continue;
     guarded[name] = wrap(tool, run => async (parameters, apiKey) => {
-      if (planIsComplete(state)) return PLAN_COMPLETE_MSG;
+      if (planIsComplete(state)) return buildPlanCompleteMsg(state);
       const out = await run(parameters, apiKey);
       if (isToolSuccess(out)) {
         const fam = familyForSolveCall(name, parameters);
         if (fam) {
-          const wasComplete = planIsComplete(state);
+          if (!(fam in state.results)) {
+            const digest = extractResultDigest(out);
+            if (digest) state.results[fam] = digest;
+          }
           state.solved[fam] = (state.solved[fam] ?? 0) + 1;
-          if (!wasComplete && planIsComplete(state)) onComplete?.();
+          if (planIsComplete(state)) onComplete?.();
         }
       }
       return out;


### PR DESCRIPTION
Follow-up to #676 (#674). Small, contained enhancement to the plan-completion guard.

## Why
#676 stops the re-solving loop, but on completion the agent still wrote its final summary from its own transcript memory -- the unreliable part. Observed on the #676 preview run: the summary correctly reported routing but claimed the already-solved scheduling and selection steps "weren't solved in this pass." The guard fixed the *loop*; this fixes the *summary*.

## What
Capture each step's winning result as it's solved and hand them back in the completion redirect, in plan order, so the agent reports every step from the provided data:
- Plan state carries the ordered `steps` (family + title) and a per-family `results` digest (`"<problem> -- <winning solver + objective>"`), captured from the first successful solve of each family.
- The completion redirect (`buildPlanCompleteMsg`) lists every planned step with its result and tells the agent to report each one, then stop.
- **Termination logic unchanged** -- `min(solved, needed)` per family is exactly as verified in #676. Also dropped the redundant `wasComplete` check the #676 review flagged (the top short-circuit already guarantees it's false there, so `onComplete` still fires exactly once).

## Tests
`planCompletionGuard.test.ts` (9): capturePlan ordered steps, familyForSolveCall, `extractResultDigest`, min-cap `planIsComplete`, `buildPlanCompleteMsg` ordering, result capture on success + no-capture on failed solves, block-with-summary-redirect, inert-until-plan, non-opti pass-through.

## Relationship to the durable ledger (#680)
This is the first slice of #680 (storing per-step results as source-of-truth for the summary). #680 remains the proper follow-up (moving this state into the durable checkpoint so it survives Lambda self-dispatch, and folding in #666).

## Guide for Testers
1. Agent mode on `/opti`, a multi-step scenario (warehouse: sequence stations, prioritize orders, route vans).
2. When the run finishes, the final summary should report **all** solved steps with their winning solver + objective -- not claim any solved step "wasn't done."
3. Logs still show `[opti] plan complete -- all planned steps solved; steering to final summary`.
4. Regression: single-problem runs (no decompose) unaffected; termination still stops the loop shortly after each step has a result.