### PR TITLE
fix(selfhost): default chat model fallback, offline pyodide mirror, and completions API docs

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -171,7 +171,7 @@ OLLAMA_PULL_MODELS=qwen2.5-coder:7b
 # Python artifacts run in the browser via Pyodide (WebAssembly). By default the runtime
 # is fetched from the public jsDelivr CDN, so running a Python artifact needs internet.
 # For an air-gapped / offline deployment, host the Pyodide v0.25.1 "full" distribution on
-# your own server and point PYODIDE_BASE_URL at it (trailing slash required).
+# your own server and point PYODIDE_BASE_URL at it (a trailing slash is added for you if omitted).
 #
 # What to mirror (from the pyodide v0.25.1 full dist): pyodide.js, the asm wasm/js files,
 # the Python stdlib zip, repodata.json, and any package wheels your artifacts import.

--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -167,6 +167,19 @@ XAI_API_KEY=
 #   OLLAMA_PULL_MODELS=qwen2.5-coder:3b qwen2.5-coder:7b
 OLLAMA_PULL_MODELS=qwen2.5-coder:7b
 
+# -- Python artifacts offline (optional Pyodide mirror) ------------------------
+# Python artifacts run in the browser via Pyodide (WebAssembly). By default the runtime
+# is fetched from the public jsDelivr CDN, so running a Python artifact needs internet.
+# For an air-gapped / offline deployment, host the Pyodide v0.25.1 "full" distribution on
+# your own server and point PYODIDE_BASE_URL at it (trailing slash required).
+#
+# What to mirror (from the pyodide v0.25.1 full dist): pyodide.js, the asm wasm/js files,
+# the Python stdlib zip, repodata.json, and any package wheels your artifacts import.
+# A cross-origin mirror must send permissive CORS headers (the worker fetches these assets),
+# and its origin is added to the app CSP (script-src + connect-src) automatically. Leave
+# unset to use the default CDN.
+# PYODIDE_BASE_URL=http://localhost:8080/pyodide/v0.25.1/full/
+
 # -- Integrations (leave blank to disable that integration) --
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -144,7 +144,7 @@ On self-host it is served by the **`chatcompletion` container**, not the `app` c
 
 Authenticate with any one of: `x-api-key: b4m_...`, `Authorization: ApiKey b4m_...`, or `Authorization: Bearer <JWT>`.
 
-**Response** - a **custom SSE contract, not OpenAI's**: there is no `choices[].delta`. Each frame is either an SSE comment (a line starting with `:`) or a `data:` line carrying one JSON object, and every frame ends with a blank line (`\n\n`). In order:
+**Response** - a **custom SSE contract, not OpenAI's**: there is no `choices[].delta`. Each frame is either an SSE comment (a line starting with `:`) or a `data:` line carrying one JSON object, and every frame ends with a blank line (`\n\n`). The stream opens and closes in the order below, but the middle is a stream: `content` and `tool_use` frames interleave one per chunk (a tool-calling turn emits `tool_use` frames among the `content` ones), and keep-alive comments keep recurring (about every 10s) throughout:
 
 1. `: keep-alive` - an SSE comment sent immediately and then roughly every 10s so an intermediary does not drop an idle stream. EventSource ignores comment lines; a raw reader should skip any line starting with `:`.
 2. `data: {"type":"meta","requestId":"..."}` - always the first JSON event; use `requestId` to correlate with server logs.
@@ -300,6 +300,6 @@ Self-host runs the open-core engine - notebooks, multi-LLM chat, agents, the Que
 
 ### Python artifacts offline
 
-Python artifacts execute in the browser via Pyodide (WebAssembly), fetched by default from the public jsDelivr CDN - so a fully air-gapped box cannot run them out of the box. To run them offline, mirror the Pyodide v0.25.1 "full" distribution on a server you control and set `PYODIDE_BASE_URL` in `.env.selfhost` to that base (trailing slash required). A cross-origin mirror must send permissive CORS headers; its origin is added to the app CSP automatically. See the `PYODIDE_BASE_URL` block in `.env.selfhost.example` for what to mirror. Leave it unset to use the CDN.
+Python artifacts execute in the browser via Pyodide (WebAssembly), fetched by default from the public jsDelivr CDN - so a fully air-gapped box cannot run them out of the box. To run them offline, mirror the Pyodide v0.25.1 "full" distribution on a server you control and set `PYODIDE_BASE_URL` in `.env.selfhost` to that base (a trailing slash is added automatically if you omit it). A cross-origin mirror must send permissive CORS headers; its origin is added to the app CSP automatically. See the `PYODIDE_BASE_URL` block in `.env.selfhost.example` for what to mirror. Leave it unset to use the CDN.
 
 Need help? Ask in [Discussions](https://github.com/bike4mind/bike4mind/discussions).

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -296,5 +296,10 @@ Self-host runs the open-core engine - notebooks, multi-LLM chat, agents, the Que
 
 - **Background enrichment** - features that ride the hosted event bus (notebook auto-naming, summaries, tagging) are inert in self-host for now.
 - **Hosted-service features** - billing, entitlements, and premium overlays are not part of the open core; see the [open/closed boundary](./CONTRIBUTING.md#the-openclosed-boundary).
+- **Python artifacts need internet** - the in-browser Python runtime (Pyodide) is fetched from a public CDN, so running a Python artifact needs internet unless you point `PYODIDE_BASE_URL` at a local mirror (see below).
+
+### Python artifacts offline
+
+Python artifacts execute in the browser via Pyodide (WebAssembly), fetched by default from the public jsDelivr CDN - so a fully air-gapped box cannot run them out of the box. To run them offline, mirror the Pyodide v0.25.1 "full" distribution on a server you control and set `PYODIDE_BASE_URL` in `.env.selfhost` to that base (trailing slash required). A cross-origin mirror must send permissive CORS headers; its origin is added to the app CSP automatically. See the `PYODIDE_BASE_URL` block in `.env.selfhost.example` for what to mirror. Leave it unset to use the CDN.
 
 Need help? Ask in [Discussions](https://github.com/bike4mind/bike4mind/discussions).

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -139,8 +139,8 @@ On self-host it is served by the **`chatcompletion` container**, not the `app` c
 **Request** - OpenAI-shaped JSON:
 
 - `model` (**required**) - a model id from `GET /api/models`. Unlike `/api/chat`, this endpoint has **no server-side default**; omit it and the request is rejected.
-- `messages` (**required**) - `[{ "role": "user" | "assistant" | "system", "content": "..." }]`.
-- Optional: `temperature`, `max_tokens`, `tools`, `response_format`, `stream`.
+- `messages` (**required**) - `[{ "role": "user" | "assistant" | "system", "content": "..." }]`. `content` is a string or an array of content parts.
+- Optional: `temperature`, `max_tokens`, `tools`, `response_format`, `stream`. `tools` is **not** OpenAI-shaped - each entry is `{ toolSchema: { name, description, parameters } }` (see `CompletionToolSchema` in `b4m-core/common/src/schemas/cliCompletions.ts`), not `{ type: "function", function: {...} }`.
 
 Authenticate with any one of: `x-api-key: b4m_...`, `Authorization: ApiKey b4m_...`, or `Authorization: Bearer <JWT>`.
 

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -130,6 +130,57 @@ curl -X POST http://localhost:3000/api/chat \
 
 The same header works as `Authorization: ApiKey <key>`. Keys, scopes, and rate limits are managed per-user in Settings > API Keys.
 
+## Streaming completions API (`/api/ai/v1/completions`)
+
+`POST /api/chat` (above) is the high-level chat API. For a low-level streaming completion - one request in, a token-by-token Server-Sent Events (SSE) stream out - call `/api/ai/v1/completions`. This is the endpoint the CLI uses under the hood, and the one to target from a custom client or agent loop.
+
+On self-host it is served by the **`chatcompletion` container**, not the `app` container: reach it at `http://localhost:8788` by default (override the host port with `CHATCOMPLETION_HOST_PORT`, and advertise the external origin via `CHAT_COMPLETION_PUBLIC_URL`).
+
+**Request** - OpenAI-shaped JSON:
+
+- `model` (**required**) - a model id from `GET /api/models`. Unlike `/api/chat`, this endpoint has **no server-side default**; omit it and the request is rejected.
+- `messages` (**required**) - `[{ "role": "user" | "assistant" | "system", "content": "..." }]`.
+- Optional: `temperature`, `max_tokens`, `tools`, `response_format`, `stream`.
+
+Authenticate with any one of: `x-api-key: b4m_...`, `Authorization: ApiKey b4m_...`, or `Authorization: Bearer <JWT>`.
+
+**Response** - a **custom SSE contract, not OpenAI's**: there is no `choices[].delta`. Each frame is either an SSE comment (a line starting with `:`) or a `data:` line carrying one JSON object, and every frame ends with a blank line (`\n\n`). In order:
+
+1. `: keep-alive` - an SSE comment sent immediately and then roughly every 10s so an intermediary does not drop an idle stream. EventSource ignores comment lines; a raw reader should skip any line starting with `:`.
+2. `data: {"type":"meta","requestId":"..."}` - always the first JSON event; use `requestId` to correlate with server logs.
+3. `data: {"type":"content","text":"...","usage":{...}}` - zero or more content chunks. `text` is the incremental output; `usage`, when present, carries `inputTokens`/`outputTokens` (and Anthropic cache-token deltas).
+4. `data: {"type":"tool_use","text":"...","tools":[...]}` - sent instead of `content` for a chunk in which the model invoked a tool.
+5. `data: {"type":"error","message":"...","requestId":"..."}` - on failure (invalid body, auth failure, or a mid-stream error); the stream then ends.
+6. `data: [DONE]` - terminal sentinel on success.
+
+**Example** - a local Ollama model (`-N` disables curl buffering so the stream prints live):
+
+```bash
+curl -N -X POST http://localhost:8788/api/ai/v1/completions \
+  -H "x-api-key: $B4M_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "model": "qwen2.5-coder:7b",
+    "messages": [{ "role": "user", "content": "Say hello in five words." }]
+  }'
+```
+
+Sample transcript:
+
+```
+: keep-alive
+
+data: {"type":"meta","requestId":"1a2b3c4d"}
+
+data: {"type":"content","text":"Hello"}
+
+data: {"type":"content","text":" there, good"}
+
+data: {"type":"content","text":" to meet you","usage":{"inputTokens":13,"outputTokens":5}}
+
+data: [DONE]
+```
+
 ## Drive it with the CLI (`b4m`)
 
 Prefer the terminal? The [Bike4Mind CLI](./BIKE4MIND_CLI.md) talks to your self-hosted stack directly — the OAuth device-flow and chat APIs ship in the open core, so no hosted account or credits are involved.

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -614,7 +614,7 @@ POST /api/ai/llm
 | POST | /api/ai/generate-video | Video generation (Sora) |
 | POST | /api/ai/barkeep-chat | Tavern AI barkeep conversation |
 | POST | /api/ai/tavern-conversation | Tavern NPC conversation |
-| POST | /api/ai/v1/completions | OpenAI-compatible completions endpoint |
+| POST | /api/ai/v1/completions | Streaming completions (custom SSE contract, not OpenAI-compatible) |
 | GET | /api/ai/v1/tools | List available tools |
 | POST | /api/ai/optimize-input | Optimize/rewrite user input |
 | POST | /api/ai/refineText | Refine and improve text |

--- a/apps/client/app/hooks/__tests__/usePyodide.test.ts
+++ b/apps/client/app/hooks/__tests__/usePyodide.test.ts
@@ -51,19 +51,32 @@ vi.mock('@client/app/workers/pyodide/types', () => ({
   ExecutionResult: {},
 }));
 
-// usePyodide reads the public config to pick up an optional Pyodide mirror; stub it so the
-// hook renders without a react-query provider.
+// usePyodide reads the public config to pick up an optional Pyodide mirror; stub it (via a
+// hoisted, mutable holder) so the hook renders without a react-query provider and tests can
+// vary what the config returns.
+const { publicConfigRef } = vi.hoisted(() => ({
+  publicConfigRef: { current: undefined as { pyodideBaseUrl?: string } | undefined },
+}));
 vi.mock('@client/app/hooks/data/settings', () => ({
-  usePublicConfig: () => ({ data: undefined }),
+  usePublicConfig: () => ({ data: publicConfigRef.current }),
 }));
 
 describe('usePyodide', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    publicConfigRef.current = undefined;
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('configures the pyodide manager with the public pyodideBaseUrl when config arrives', async () => {
+    const { pyodideManager } = await import('@client/app/utils/pyodideManager');
+    publicConfigRef.current = { pyodideBaseUrl: 'http://mirror.local/pyodide/' };
+    const { usePyodide } = await import('../usePyodide');
+    renderHook(() => usePyodide());
+    expect(pyodideManager.configure).toHaveBeenCalledWith('http://mirror.local/pyodide/');
   });
 
   it('should return initial state', async () => {

--- a/apps/client/app/hooks/__tests__/usePyodide.test.ts
+++ b/apps/client/app/hooks/__tests__/usePyodide.test.ts
@@ -20,6 +20,7 @@ vi.mock('@client/app/utils/pyodideManager', () => {
         listeners.add(listener);
         return () => listeners.delete(listener);
       }),
+      configure: vi.fn(),
       initialize: vi.fn().mockResolvedValue(undefined),
       execute: vi.fn().mockResolvedValue({
         success: true,
@@ -48,6 +49,12 @@ vi.mock('@client/app/utils/pyodideManager', () => {
 
 vi.mock('@client/app/workers/pyodide/types', () => ({
   ExecutionResult: {},
+}));
+
+// usePyodide reads the public config to pick up an optional Pyodide mirror; stub it so the
+// hook renders without a react-query provider.
+vi.mock('@client/app/hooks/data/settings', () => ({
+  usePublicConfig: () => ({ data: undefined }),
 }));
 
 describe('usePyodide', () => {

--- a/apps/client/app/hooks/usePyodide.ts
+++ b/apps/client/app/hooks/usePyodide.ts
@@ -5,10 +5,18 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { pyodideManager, PyodideManagerState } from '@client/app/utils/pyodideManager';
+import { usePublicConfig } from '@client/app/hooks/data/settings';
 import type { ExecutionResult } from '@client/app/workers/pyodide/types';
 
 export function usePyodide() {
   const [state, setState] = useState<PyodideManagerState>(pyodideManager.getState());
+
+  // usePublicConfig (not useConfig) avoids the auth-timing race: the Pyodide mirror is a
+  // public, pre-login setting, and configure() must land before the consumer calls initialize().
+  const { data: publicConfig } = usePublicConfig();
+  useEffect(() => {
+    pyodideManager.configure(publicConfig?.pyodideBaseUrl || undefined);
+  }, [publicConfig?.pyodideBaseUrl]);
 
   useEffect(() => {
     return pyodideManager.subscribe(setState);

--- a/apps/client/app/utils/__tests__/pyodideManager.test.ts
+++ b/apps/client/app/utils/__tests__/pyodideManager.test.ts
@@ -235,6 +235,40 @@ from numpy import array
   });
 });
 
+describe('configure (Pyodide mirror baseUrl)', () => {
+  // Inject a fake worker so spawnWorker() (real `new Worker(new URL(...))`) is skipped, then
+  // assert the message the manager posts. initialize() posts synchronously before awaiting the
+  // 'ready' the fake never sends, so the pending promise is intentionally discarded.
+  const injectWorker = (mgr: unknown) => {
+    const worker = { onmessage: null, onerror: null, postMessage: vi.fn(), terminate: vi.fn() };
+    (mgr as { worker: typeof worker }).worker = worker;
+    return worker;
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards a configured baseUrl to the worker on initialize', async () => {
+    const { pyodideManager } = await import('../pyodideManager');
+    const worker = injectWorker(pyodideManager);
+    pyodideManager.configure('http://mirror.local/pyodide/');
+    void pyodideManager.initialize().catch(() => {});
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'initialize', baseUrl: 'http://mirror.local/pyodide/' });
+  });
+
+  it('sends baseUrl undefined when not configured (worker keeps the default CDN)', async () => {
+    const { pyodideManager } = await import('../pyodideManager');
+    const worker = injectWorker(pyodideManager);
+    void pyodideManager.initialize().catch(() => {});
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'initialize', baseUrl: undefined });
+  });
+});
+
 describe('execution timeout', () => {
   it('should have EXECUTION_TIMEOUT_MS constant defined', async () => {
     // The timeout constant is private, but we can verify the execute method

--- a/apps/client/app/utils/pyodideManager.ts
+++ b/apps/client/app/utils/pyodideManager.ts
@@ -54,6 +54,9 @@ class PyodideManager {
 
   private worker: Worker | null = null;
   private initPromise: Promise<void> | null = null;
+  // Optional Pyodide mirror (PYODIDE_BASE_URL), forwarded to the worker at initialize.
+  // Undefined keeps the worker's default public CDN.
+  private baseUrl?: string;
   private executeResolver: ((result: ExecutionResult) => void) | null = null;
   private executeRejecter: ((error: Error) => void) | null = null;
   private listeners: Set<(state: PyodideManagerState) => void> = new Set();
@@ -133,6 +136,14 @@ class PyodideManager {
   }
 
   /**
+   * Point Pyodide at a self-hosted mirror instead of the default public CDN.
+   * Must be called before initialize() to take effect for that worker.
+   */
+  configure(baseUrl?: string): void {
+    this.baseUrl = baseUrl;
+  }
+
+  /**
    * Initialize Pyodide (lazy-loaded singleton)
    */
   async initialize(): Promise<void> {
@@ -164,7 +175,7 @@ class PyodideManager {
         }
       };
 
-      const message: PyodideWorkerMessage = { type: 'initialize' };
+      const message: PyodideWorkerMessage = { type: 'initialize', baseUrl: this.baseUrl };
       this.worker.postMessage(message);
     });
 

--- a/apps/client/app/workers/pyodide/pyodide.worker.ts
+++ b/apps/client/app/workers/pyodide/pyodide.worker.ts
@@ -9,7 +9,11 @@
 
 import type { PyodideWorkerMessage, PyodideWorkerResponse, ExecutionResult } from './types';
 
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/';
+// Default Pyodide distribution (public CDN). The initialize message may override this with a
+// self-hosted mirror (PYODIDE_BASE_URL) so Python artifacts work offline / air-gapped.
+const DEFAULT_PYODIDE_BASE_URL = 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/';
+
+let pyodideBaseUrl = DEFAULT_PYODIDE_BASE_URL;
 
 // Supported packages (pre-built in Pyodide)
 const SUPPORTED_PACKAGES = ['numpy', 'pandas', 'matplotlib', 'scipy', 'seaborn', 'scikit-learn'];
@@ -38,7 +42,7 @@ interface PyodideInterface {
 }
 
 async function loadPyodideScript(): Promise<void> {
-  const scriptUrl = `${PYODIDE_CDN_URL}pyodide.js`;
+  const scriptUrl = `${pyodideBaseUrl}pyodide.js`;
 
   const response: PyodideWorkerResponse = {
     type: 'initializing',
@@ -75,7 +79,7 @@ async function initializePyodide(): Promise<void> {
     ).loadPyodide;
 
     pyodide = await loadPyodide({
-      indexURL: PYODIDE_CDN_URL,
+      indexURL: pyodideBaseUrl,
     });
 
     const micropipResponse: PyodideWorkerResponse = {
@@ -324,6 +328,11 @@ self.onmessage = async (e: MessageEvent<PyodideWorkerMessage>) => {
 
   switch (msg.type) {
     case 'initialize':
+      // A configured mirror overrides the default CDN. Normalize the trailing slash so
+      // both `${base}pyodide.js` and the loadPyodide indexURL resolve correctly.
+      if (msg.baseUrl) {
+        pyodideBaseUrl = msg.baseUrl.endsWith('/') ? msg.baseUrl : `${msg.baseUrl}/`;
+      }
       await initializePyodide();
       break;
 

--- a/apps/client/app/workers/pyodide/types.ts
+++ b/apps/client/app/workers/pyodide/types.ts
@@ -14,7 +14,7 @@ export interface ExecutionResult {
 
 /** Messages sent from main thread to worker */
 export type PyodideWorkerMessage =
-  | { type: 'initialize' }
+  | { type: 'initialize'; baseUrl?: string }
   | { type: 'execute'; code: string; packages: string[]; timeoutMs: number }
   | { type: 'cancel' };
 

--- a/apps/client/pages/api/__tests__/chat.integration.test.ts
+++ b/apps/client/pages/api/__tests__/chat.integration.test.ts
@@ -63,6 +63,11 @@ vi.mock('@server/utils/userRateTier', () => ({
 vi.mock('@server/utils/chatCompletionDefaults', () => ({
   getDefaultChatCompletionOptions: () => ({}),
   getSharedTokenizer: () => ({}),
+  // Hosted-path shape: no apiKeys/models, so chat.ts skips the self-host usability guard.
+  resolveDefaultChatModel: async ({ configuredModel }: { configuredModel?: string | null }) => ({
+    model: configuredModel || 'test-default-model',
+  }),
+  isChatModelUsable: () => true,
 }));
 
 // Only the data dependencies of the real apiKeyAuth middleware and the chat

--- a/apps/client/pages/api/__tests__/chat.integration.test.ts
+++ b/apps/client/pages/api/__tests__/chat.integration.test.ts
@@ -21,12 +21,22 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { createMocks } from 'node-mocks-http';
 
-const { mockValidate, mockFindById, mockRateLimit, mockInvoke, mockGetSettingsMap } = vi.hoisted(() => ({
+const {
+  mockValidate,
+  mockFindById,
+  mockRateLimit,
+  mockInvoke,
+  mockGetSettingsMap,
+  mockResolveDefaultChatModel,
+  mockIsChatModelUsable,
+} = vi.hoisted(() => ({
   mockValidate: vi.fn(),
   mockFindById: vi.fn(),
   mockRateLimit: vi.fn(),
   mockInvoke: vi.fn(),
   mockGetSettingsMap: vi.fn(),
+  mockResolveDefaultChatModel: vi.fn(),
+  mockIsChatModelUsable: vi.fn(),
 }));
 
 const RATE_LIMIT_HEADERS = {
@@ -63,11 +73,8 @@ vi.mock('@server/utils/userRateTier', () => ({
 vi.mock('@server/utils/chatCompletionDefaults', () => ({
   getDefaultChatCompletionOptions: () => ({}),
   getSharedTokenizer: () => ({}),
-  // Hosted-path shape: no apiKeys/models, so chat.ts skips the self-host usability guard.
-  resolveDefaultChatModel: async ({ configuredModel }: { configuredModel?: string | null }) => ({
-    model: configuredModel || 'test-default-model',
-  }),
-  isChatModelUsable: () => true,
+  resolveDefaultChatModel: (...a: unknown[]) => mockResolveDefaultChatModel(...a),
+  isChatModelUsable: (...a: unknown[]) => mockIsChatModelUsable(...a),
 }));
 
 // Only the data dependencies of the real apiKeyAuth middleware and the chat
@@ -189,6 +196,13 @@ describe('POST /api/chat (integration — scope enforcement via real middleware 
       })
     );
     mockRateLimit.mockResolvedValue({ allowed: true, retryAfter: undefined, headers: RATE_LIMIT_HEADERS });
+    // Hosted-path shape: no apiKeys/models, so chat.ts skips the self-host usability guard.
+    mockResolveDefaultChatModel.mockImplementation(
+      async ({ configuredModel }: { configuredModel?: string | null }) => ({
+        model: configuredModel || 'test-default-model',
+      })
+    );
+    mockIsChatModelUsable.mockReturnValue(true);
   });
 
   it('rejects a key holding neither ai:chat nor ai:generate (403)', async () => {
@@ -244,5 +258,19 @@ describe('POST /api/chat (integration — scope enforcement via real middleware 
     // scope validation never ran - this request was never an api-key caller
     expect(mockValidate).not.toHaveBeenCalled();
     expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 when the resolved default chat model is unusable (self-host, no key, no local model)', async () => {
+    // Self-host resolver shape: apiKeys/models ARE present (unlike the hosted default),
+    // so chat.ts runs its no-usable-model guard. An empty model list plus an unusable
+    // default trips the 400 before any quest is created.
+    validateWithScopes([ApiKeyScope.AI_CHAT]);
+    mockResolveDefaultChatModel.mockResolvedValue({ model: 'test-default-model', apiKeys: {}, models: [] });
+    mockIsChatModelUsable.mockReturnValue(false);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error).toMatch(/no usable default chat model/i);
+    expect(mockInvoke).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/pages/api/chat.ts
+++ b/apps/client/pages/api/chat.ts
@@ -1,13 +1,17 @@
 import { ChatCompletionFeature, ChatCompletionInvoke, ChatCompletionProcess, featureNames } from '@bike4mind/services';
-import { getSettingsMap, getSettingsValue, NotFoundError, SQSService } from '@bike4mind/utils';
-import { PipelineTimer } from '@bike4mind/llm-adapters';
+import { BadRequestError, getSettingsMap, getSettingsValue, NotFoundError, SQSService } from '@bike4mind/utils';
+import { getLlmByModel, PipelineTimer } from '@bike4mind/llm-adapters';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { resolveUserRateLimitPerMin } from '@server/utils/userRateTier';
-import { getDefaultChatCompletionOptions, getSharedTokenizer } from '@server/utils/chatCompletionDefaults';
+import {
+  getDefaultChatCompletionOptions,
+  getSharedTokenizer,
+  resolveDefaultChatModel,
+} from '@server/utils/chatCompletionDefaults';
 import { adminSettingsRepository, User, Session } from '@bike4mind/database';
 import { z } from 'zod';
-import { ApiKeyScope, B4MLLMTools, B4MLLMToolsList, ChatModels } from '@bike4mind/common';
+import { ApiKeyScope, B4MLLMTools, B4MLLMToolsList } from '@bike4mind/common';
 import { dispatchQuest } from '@server/utils/dispatchQuest';
 import { premiumLlmTools } from '@server/premium-generated/premiumLlmTools.generated';
 import { recommendTools, mergeTools } from '@client/app/utils/toolRecommender';
@@ -60,21 +64,35 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_CHAT, ApiKeyScope.AI_G
     const apiTimer = new PipelineTimer();
     apiTimer.phase('settings');
 
-    // Get default model from admin settings (uses the cached AdminSettingsCache)
+    // Admin settings (uses the cached AdminSettingsCache); reused below for the embedding model.
     const settings = await getSettingsMap({ adminSettings: adminSettingsRepository });
-    // `getSettingsValue` already returns the schema default (Bedrock Claude) when unset; the
-    // `||` is defense-in-depth and must match that default so a future refactor can't silently
-    // re-introduce the key-requiring Anthropic-hosted variant here.
-    let defaultModel = getSettingsValue('DefaultAPIModel', settings) || ChatModels.CLAUDE_5_SONNET_BEDROCK;
-    // Self-host has no Bedrock, so the schema-default model above can only fail
-    // there; substitute the direct-API equivalent (backed by the env/user key).
-    if (process.env.B4M_SELF_HOST === 'true' && defaultModel === ChatModels.CLAUDE_5_SONNET_BEDROCK) {
-      defaultModel = ChatModels.CLAUDE_5_SONNET;
-    }
 
     const simplifiedRequest = SimplifiedChatRequestSchema.parse(req.body);
 
-    const model = simplifiedRequest.model || defaultModel;
+    // An explicit request model wins. Otherwise fall back to the admin default, which on a
+    // local-only self-host box may itself need a fallback (see resolveDefaultChatModel), so
+    // only probe when no explicit model was sent.
+    let model = simplifiedRequest.model;
+    if (!model) {
+      const resolved = await resolveDefaultChatModel({
+        configuredModel: getSettingsValue('DefaultAPIModel', settings),
+        userId: req.user.id,
+        logger: req.logger,
+      });
+      model = resolved.model;
+      // Self-host, no-explicit-model guard: apiKeys/models are populated only on self-host.
+      // If even the resolved default is unusable (no provider key and no local model), fail
+      // fast with actionable guidance instead of a cryptic backend error deep in the pipeline.
+      if (resolved.apiKeys && resolved.models) {
+        const info = resolved.models.find(m => m.id === model);
+        if (!info || !getLlmByModel(resolved.apiKeys, { modelInfo: info, logger: req.logger })) {
+          throw new BadRequestError(
+            'No usable default chat model is configured. Set a provider key (e.g. ANTHROPIC_API_KEY) in ' +
+              '.env.selfhost, enable local models via OLLAMA_BASE_URL, or pass an explicit "model" from GET /api/models.'
+          );
+        }
+      }
+    }
 
     apiTimer.phase('session');
     const sessionId = await getSessionId(simplifiedRequest.sessionId ?? undefined, req.user.id);

--- a/apps/client/pages/api/chat.ts
+++ b/apps/client/pages/api/chat.ts
@@ -1,12 +1,13 @@
 import { ChatCompletionFeature, ChatCompletionInvoke, ChatCompletionProcess, featureNames } from '@bike4mind/services';
 import { BadRequestError, getSettingsMap, getSettingsValue, NotFoundError, SQSService } from '@bike4mind/utils';
-import { getLlmByModel, PipelineTimer } from '@bike4mind/llm-adapters';
+import { PipelineTimer } from '@bike4mind/llm-adapters';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { resolveUserRateLimitPerMin } from '@server/utils/userRateTier';
 import {
   getDefaultChatCompletionOptions,
   getSharedTokenizer,
+  isChatModelUsable,
   resolveDefaultChatModel,
 } from '@server/utils/chatCompletionDefaults';
 import { adminSettingsRepository, User, Session } from '@bike4mind/database';
@@ -85,7 +86,7 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_CHAT, ApiKeyScope.AI_G
       // fast with actionable guidance instead of a cryptic backend error deep in the pipeline.
       if (resolved.apiKeys && resolved.models) {
         const info = resolved.models.find(m => m.id === model);
-        if (!info || !getLlmByModel(resolved.apiKeys, { modelInfo: info, logger: req.logger })) {
+        if (!isChatModelUsable(resolved.apiKeys, info, req.logger)) {
           throw new BadRequestError(
             'No usable default chat model is configured. Set a provider key (e.g. ANTHROPIC_API_KEY) in ' +
               '.env.selfhost, enable local models via OLLAMA_BASE_URL, or pass an explicit "model" from GET /api/models.'

--- a/apps/client/pages/api/settings/serverConfigPublic.ts
+++ b/apps/client/pages/api/settings/serverConfigPublic.ts
@@ -8,6 +8,8 @@ export type ServerConfigPublic = {
   defaultTheme: string;
   /** When true, the registration form makes the invite code optional (self-serve signup). */
   allowOpenRegistration: boolean;
+  /** Optional Pyodide mirror for offline Python artifacts; empty string uses the default CDN. */
+  pyodideBaseUrl: string;
 };
 
 // Public pre-login config - minimal fields only.
@@ -37,6 +39,7 @@ const handler = baseApi({ auth: false }).get(
         : process.env.APP_URL || '',
       defaultTheme: 'bike4mind',
       allowOpenRegistration,
+      pyodideBaseUrl: process.env.PYODIDE_BASE_URL || '',
     };
 
     return res.json(config);

--- a/apps/client/proxy.test.ts
+++ b/apps/client/proxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 vi.mock('next/server', () => {
   class MockNextResponse {
@@ -190,5 +190,41 @@ describe('proxy CSP script-src — dev-only unsafe-eval boundary', () => {
     } finally {
       vi.unstubAllEnvs();
     }
+  });
+});
+
+describe('proxy CSP - optional PYODIDE_BASE_URL mirror', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const directive = (csp: string, name: string): string =>
+    csp
+      .split(';')
+      .map(d => d.trim())
+      .find(d => d.startsWith(`${name} `)) ?? '';
+
+  it('adds a valid mirror origin (no path) to both script-src and connect-src', () => {
+    vi.stubEnv('PYODIDE_BASE_URL', 'http://mirror.local:8080/pyodide/v0.25.1/full/');
+    const csp = proxy(makeRequest('https://app.bike4mind.com/dashboard')).headers.get('Content-Security-Policy') ?? '';
+    expect(directive(csp, 'script-src')).toContain('http://mirror.local:8080');
+    expect(directive(csp, 'connect-src')).toContain('http://mirror.local:8080');
+    expect(csp).not.toContain('/pyodide/v0.25.1/full/');
+  });
+
+  it('warns and omits an invalid mirror value rather than injecting extra directives', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv('PYODIDE_BASE_URL', 'http://evil ; script-src none');
+    const csp = proxy(makeRequest('https://app.bike4mind.com/dashboard')).headers.get('Content-Security-Policy') ?? '';
+    expect(csp).not.toContain('evil');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('leaves the default CDN allow-listed when unset', () => {
+    vi.stubEnv('PYODIDE_BASE_URL', '');
+    const csp = proxy(makeRequest('https://app.bike4mind.com/dashboard')).headers.get('Content-Security-Policy') ?? '';
+    expect(directive(csp, 'script-src')).toContain('https://cdn.jsdelivr.net');
+    expect(directive(csp, 'connect-src')).toContain('https://cdn.jsdelivr.net');
   });
 });

--- a/apps/client/proxy.test.ts
+++ b/apps/client/proxy.test.ts
@@ -221,10 +221,18 @@ describe('proxy CSP - optional PYODIDE_BASE_URL mirror', () => {
     warn.mockRestore();
   });
 
-  it('leaves the default CDN allow-listed when unset', () => {
+  it('adds nothing when unset, empty, or invalid - byte-identical to the no-var baseline', () => {
+    const url = 'https://app.bike4mind.com/dashboard';
+    // afterEach clears stubs and PYODIDE_BASE_URL is not in the base env, so this is the no-var baseline.
+    const baseline = proxy(makeRequest(url)).headers.get('Content-Security-Policy') ?? '';
+    expect(baseline).toContain('https://cdn.jsdelivr.net'); // the default CDN is already allow-listed
+
     vi.stubEnv('PYODIDE_BASE_URL', '');
-    const csp = proxy(makeRequest('https://app.bike4mind.com/dashboard')).headers.get('Content-Security-Policy') ?? '';
-    expect(directive(csp, 'script-src')).toContain('https://cdn.jsdelivr.net');
-    expect(directive(csp, 'connect-src')).toContain('https://cdn.jsdelivr.net');
+    expect(proxy(makeRequest(url)).headers.get('Content-Security-Policy')).toBe(baseline);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv('PYODIDE_BASE_URL', 'not a url');
+    expect(proxy(makeRequest(url)).headers.get('Content-Security-Policy')).toBe(baseline);
+    warn.mockRestore();
   });
 });

--- a/apps/client/proxy.ts
+++ b/apps/client/proxy.ts
@@ -115,13 +115,33 @@ export function proxy(request: NextRequest) {
     }
   }
 
+  // Optional self-host Pyodide mirror (PYODIDE_BASE_URL) for offline Python artifacts. When set to
+  // a non-self origin, its pyodide.js loads via script-src and its wasm/data assets fetch via
+  // connect-src, so the origin is allow-listed in both. Same validation as NEXT_PUBLIC_BLOG_HOST
+  // (parse to a single origin, reject whitespace/';', warn+omit on misconfig); http is allowed too
+  // since a LAN mirror may not have TLS. The default CDN origin is already listed on both lists.
+  const rawPyodideBase = process.env.PYODIDE_BASE_URL;
+  let pyodideHost = '';
+  if (rawPyodideBase) {
+    try {
+      if (/[\s;]/.test(rawPyodideBase)) throw new Error('contains whitespace or ";"');
+      const u = new URL(rawPyodideBase);
+      if (u.protocol !== 'https:' && u.protocol !== 'http:') throw new Error(`must be http(s) (got ${u.protocol})`);
+      pyodideHost = ` ${u.origin}`;
+    } catch (e) {
+      console.warn(
+        `[csp] ignoring invalid PYODIDE_BASE_URL "${rawPyodideBase}": ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+  }
+
   const cspHeader = `
     default-src 'self';
-    script-src ${scriptSrcPolicy};
+    script-src ${scriptSrcPolicy}${pyodideHost};
     style-src ${styleSrcPolicy};
     img-src 'self' blob: data: https://*.amazonaws.com https://www.google.com https://*.gstatic.com https://*.cloudfront.net${filesHost}${blogHost} https://avatars.githubusercontent.com https://*.google-analytics.com https://alb.reddit.com;
     font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com data:;
-    connect-src 'self' https://*.amazonaws.com wss://*.amazonaws.com https://*.googleapis.com https://*.google.com https://fonts.gstatic.com https://api.bigdatacloud.net https://*.anthropic.com https://*.mail.anthropic.com https://assets.mailerlite.com https://*.stripe.com ws://localhost:* wss://localhost:* http://127.0.0.1:48732 http://localhost:48732 https://*.openai.com https://unpkg.com https://*.cloudfront.net${filesHost}${blogHost} https://cdn.jsdelivr.net https://*.google-analytics.com https://pixel-config.reddit.com https://alb.reddit.com https://api.elevenlabs.io wss://api.elevenlabs.io https://*.livekit.cloud wss://*.livekit.cloud;
+    connect-src 'self' https://*.amazonaws.com wss://*.amazonaws.com https://*.googleapis.com https://*.google.com https://fonts.gstatic.com https://api.bigdatacloud.net https://*.anthropic.com https://*.mail.anthropic.com https://assets.mailerlite.com https://*.stripe.com ws://localhost:* wss://localhost:* http://127.0.0.1:48732 http://localhost:48732 https://*.openai.com https://unpkg.com https://*.cloudfront.net${filesHost}${blogHost} https://cdn.jsdelivr.net${pyodideHost} https://*.google-analytics.com https://pixel-config.reddit.com https://alb.reddit.com https://api.elevenlabs.io wss://api.elevenlabs.io https://*.livekit.cloud wss://*.livekit.cloud;
     frame-src 'self' blob: https://accounts.google.com https://js.stripe.com https://hooks.stripe.com https://docs.google.com https://drive.google.com https://sheets.google.com https://slides.google.com https://forms.google.com;
     object-src 'none';
     media-src 'self' blob: https://*.amazonaws.com https://*.cloudfront.net https://*.googleapis.com;

--- a/apps/client/server/utils/chatCompletionDefaults.test.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.test.ts
@@ -1,4 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChatModels, ModelBackend, type ModelInfo } from '@bike4mind/common';
+
+// Controllable mocks for resolveDefaultChatModel's three dependencies. Hoisted so the
+// vi.mock factories below can reference them; importOriginal preserves every other export
+// so the heavy import graph (and the lazy-contract tests) keep working unchanged.
+const { getEffectiveLLMApiKeysMock, getAvailableModelsMock, getLlmByModelMock } = vi.hoisted(() => ({
+  getEffectiveLLMApiKeysMock: vi.fn(),
+  getAvailableModelsMock: vi.fn(),
+  getLlmByModelMock: vi.fn(),
+}));
+
+vi.mock('@bike4mind/services', async importOriginal => {
+  const actual = await importOriginal<typeof import('@bike4mind/services')>();
+  return {
+    ...actual,
+    apiKeyService: { ...actual.apiKeyService, getEffectiveLLMApiKeys: getEffectiveLLMApiKeysMock },
+  };
+});
+
+vi.mock('@bike4mind/llm-adapters', async importOriginal => {
+  const actual = await importOriginal<typeof import('@bike4mind/llm-adapters')>();
+  return { ...actual, getAvailableModels: getAvailableModelsMock, getLlmByModel: getLlmByModelMock };
+});
 
 // Guardrail for the chat completion lazy contract:
 // `getDefaultChatCompletionOptions()` previously lived as a module-level
@@ -82,5 +105,73 @@ describe('chatCompletionDefaults factory lazy contract', () => {
     const first = mod.getDefaultChatCompletionOptions();
     const second = mod.getDefaultChatCompletionOptions();
     expect(first).toBe(second);
+  }, 20000);
+});
+
+const makeModel = (id: string, backend: ModelBackend, type: ModelInfo['type'] = 'text'): ModelInfo =>
+  ({ id, name: id, backend, type, contextWindow: 8192, max_tokens: 8192, pricing: {} }) as unknown as ModelInfo;
+
+describe('resolveDefaultChatModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('hosted: returns the Bedrock schema default and does no key/model probing', async () => {
+    vi.stubEnv('B4M_SELF_HOST', 'false');
+    const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+    const result = await resolveDefaultChatModel({ configuredModel: undefined, userId: 'u1' });
+    expect(result.model).toBe(ChatModels.CLAUDE_5_SONNET_BEDROCK);
+    expect(result.apiKeys).toBeUndefined();
+    expect(result.models).toBeUndefined();
+    expect(getEffectiveLLMApiKeysMock).not.toHaveBeenCalled();
+    expect(getAvailableModelsMock).not.toHaveBeenCalled();
+  }, 20000);
+
+  it('self-host with an Anthropic key: substitutes the Bedrock default for its direct-API twin', async () => {
+    vi.stubEnv('B4M_SELF_HOST', 'true');
+    getEffectiveLLMApiKeysMock.mockResolvedValue({ anthropic: 'sk-ant' });
+    getAvailableModelsMock.mockResolvedValue([makeModel(ChatModels.CLAUDE_5_SONNET, ModelBackend.Anthropic)]);
+    getLlmByModelMock.mockReturnValue({ backend: 'anthropic' });
+    const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+    const result = await resolveDefaultChatModel({ configuredModel: undefined, userId: 'u1' });
+    expect(result.model).toBe(ChatModels.CLAUDE_5_SONNET);
+    expect(result.models).toBeDefined();
+  }, 20000);
+
+  it('self-host, no cloud key, one local Ollama model: falls back to the local model', async () => {
+    vi.stubEnv('B4M_SELF_HOST', 'true');
+    getEffectiveLLMApiKeysMock.mockResolvedValue({ anthropic: null, ollama: 'http://ollama:11434' });
+    getAvailableModelsMock.mockResolvedValue([
+      makeModel(ChatModels.CLAUDE_5_SONNET, ModelBackend.Anthropic),
+      makeModel('qwen2.5-coder:7b', ModelBackend.Ollama),
+    ]);
+    getLlmByModelMock.mockReturnValue(null); // configured cloud default has no usable key
+    const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+    const result = await resolveDefaultChatModel({ configuredModel: ChatModels.CLAUDE_5_SONNET, userId: 'u1' });
+    expect(result.model).toBe('qwen2.5-coder:7b');
+  }, 20000);
+
+  it('self-host, nothing usable: returns the unusable cloud default so the caller can reject it', async () => {
+    vi.stubEnv('B4M_SELF_HOST', 'true');
+    getEffectiveLLMApiKeysMock.mockResolvedValue({ anthropic: null });
+    getAvailableModelsMock.mockResolvedValue([]);
+    getLlmByModelMock.mockReturnValue(null);
+    const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+    const result = await resolveDefaultChatModel({ configuredModel: ChatModels.CLAUDE_5_SONNET, userId: 'u1' });
+    expect(result.model).toBe(ChatModels.CLAUDE_5_SONNET);
+    // Populated so the route guard has what it needs to detect the unusable model and raise a 400.
+    expect(result.apiKeys).toBeDefined();
+    expect(result.models).toEqual([]);
+  }, 20000);
+
+  it('self-host: preserves an explicit admin default when its provider key is present', async () => {
+    vi.stubEnv('B4M_SELF_HOST', 'true');
+    getEffectiveLLMApiKeysMock.mockResolvedValue({ openai: 'sk-openai' });
+    getAvailableModelsMock.mockResolvedValue([makeModel(ChatModels.GPT5, ModelBackend.OpenAI)]);
+    getLlmByModelMock.mockReturnValue({ backend: 'openai' });
+    const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+    const result = await resolveDefaultChatModel({ configuredModel: ChatModels.GPT5, userId: 'u1' });
+    expect(result.model).toBe(ChatModels.GPT5);
   }, 20000);
 });

--- a/apps/client/server/utils/chatCompletionDefaults.test.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.test.ts
@@ -216,6 +216,56 @@ describe('resolveDefaultChatModel', () => {
     expect(result.apiKeys).toBeDefined();
     expect(result.models).toBeDefined();
   }, 20000);
+
+  it.each([
+    ['embedding listed first', ['nomic-embed-text:latest', 'qwen2.5-coder:7b']],
+    ['embedding listed last', ['qwen2.5-coder:7b', 'nomic-embed-text:latest']],
+  ])(
+    'self-host: skips Ollama embedding models and picks the chat model (%s)',
+    async (_label, ids) => {
+      vi.stubEnv('B4M_SELF_HOST', 'true');
+      getEffectiveLLMApiKeysMock.mockResolvedValue({ anthropic: null, ollama: 'http://ollama:11434' });
+      getAvailableModelsMock.mockResolvedValue(ids.map(id => makeModel(id, ModelBackend.Ollama)));
+      getLlmByModelMock.mockReturnValue(null); // no usable cloud key for the configured default
+      const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+      const result = await resolveDefaultChatModel({ configuredModel: ChatModels.CLAUDE_5_SONNET, userId: 'u1' });
+      expect(result.model).toBe('qwen2.5-coder:7b');
+    },
+    20000
+  );
+
+  it('self-host: an Ollama-only stack with just an embedding model falls through to the unusable default', async () => {
+    vi.stubEnv('B4M_SELF_HOST', 'true');
+    getEffectiveLLMApiKeysMock.mockResolvedValue({ anthropic: null, ollama: 'http://ollama:11434' });
+    getAvailableModelsMock.mockResolvedValue([makeModel('nomic-embed-text:latest', ModelBackend.Ollama)]);
+    getLlmByModelMock.mockReturnValue(null);
+    const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+    const result = await resolveDefaultChatModel({ configuredModel: ChatModels.CLAUDE_5_SONNET, userId: 'u1' });
+    // No non-embedding local model -> the (unusable) cloud default is returned so chat.ts raises the 400.
+    expect(result.model).toBe(ChatModels.CLAUDE_5_SONNET);
+    expect(result.model).not.toBe('nomic-embed-text:latest');
+    expect(result.models).toBeDefined();
+  }, 20000);
+});
+
+describe('isLikelyEmbeddingModel', () => {
+  it.each(['nomic-embed-text:latest', 'bge-m3', 'all-minilm'])(
+    'flags embedding model %s',
+    async id => {
+      const { isLikelyEmbeddingModel } = await import('./chatCompletionDefaults');
+      expect(isLikelyEmbeddingModel(id)).toBe(true);
+    },
+    20000
+  );
+
+  it.each(['qwen2.5-coder:7b', 'llama3.2:3b', 'gemma3:4b'])(
+    'does not flag chat model %s',
+    async id => {
+      const { isLikelyEmbeddingModel } = await import('./chatCompletionDefaults');
+      expect(isLikelyEmbeddingModel(id)).toBe(false);
+    },
+    20000
+  );
 });
 
 describe('isChatModelUsable', () => {

--- a/apps/client/server/utils/chatCompletionDefaults.test.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.test.ts
@@ -174,4 +174,81 @@ describe('resolveDefaultChatModel', () => {
     const result = await resolveDefaultChatModel({ configuredModel: ChatModels.GPT5, userId: 'u1' });
     expect(result.model).toBe(ChatModels.GPT5);
   }, 20000);
+
+  it('hosted: passes a non-default configured model through untouched with zero probing', async () => {
+    vi.stubEnv('B4M_SELF_HOST', 'false');
+    const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+    const result = await resolveDefaultChatModel({ configuredModel: ChatModels.GPT5, userId: 'u1' });
+    expect(result.model).toBe(ChatModels.GPT5);
+    expect(result.apiKeys).toBeUndefined();
+    expect(result.models).toBeUndefined();
+    expect(getEffectiveLLMApiKeysMock).not.toHaveBeenCalled();
+    expect(getAvailableModelsMock).not.toHaveBeenCalled();
+  }, 20000);
+
+  it('self-host, expired cloud key + local Ollama model: treats expired as unusable and falls back', async () => {
+    vi.stubEnv('B4M_SELF_HOST', 'true');
+    getEffectiveLLMApiKeysMock.mockResolvedValue({ anthropic: 'expired', ollama: 'http://ollama:11434' });
+    getAvailableModelsMock.mockResolvedValue([
+      makeModel(ChatModels.CLAUDE_5_SONNET, ModelBackend.Anthropic),
+      makeModel('qwen2.5-coder:7b', ModelBackend.Ollama),
+    ]);
+    // getLlmByModel throws for an expired key; the resolver must swallow it, not surface a 500.
+    getLlmByModelMock.mockImplementation(() => {
+      throw new Error('Anthropic API key is expired');
+    });
+    const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+    const result = await resolveDefaultChatModel({ configuredModel: ChatModels.CLAUDE_5_SONNET, userId: 'u1' });
+    expect(result.model).toBe('qwen2.5-coder:7b');
+  }, 20000);
+
+  it('self-host, expired cloud key + no local model: returns the unusable default (no throw)', async () => {
+    vi.stubEnv('B4M_SELF_HOST', 'true');
+    getEffectiveLLMApiKeysMock.mockResolvedValue({ anthropic: 'expired' });
+    getAvailableModelsMock.mockResolvedValue([makeModel(ChatModels.CLAUDE_5_SONNET, ModelBackend.Anthropic)]);
+    getLlmByModelMock.mockImplementation(() => {
+      throw new Error('Anthropic API key is expired');
+    });
+    const { resolveDefaultChatModel } = await import('./chatCompletionDefaults');
+    const result = await resolveDefaultChatModel({ configuredModel: ChatModels.CLAUDE_5_SONNET, userId: 'u1' });
+    // The chat.ts guard re-checks usability via isChatModelUsable (also throw-safe) and raises the 400.
+    expect(result.model).toBe(ChatModels.CLAUDE_5_SONNET);
+    expect(result.apiKeys).toBeDefined();
+    expect(result.models).toBeDefined();
+  }, 20000);
+});
+
+describe('isChatModelUsable', () => {
+  const makeLogger = () =>
+    ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) as unknown as import('@bike4mind/observability').Logger;
+  const modelInfo = makeModel(ChatModels.CLAUDE_5_SONNET, ModelBackend.Anthropic);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false for an undefined model', async () => {
+    const { isChatModelUsable } = await import('./chatCompletionDefaults');
+    expect(isChatModelUsable({}, undefined, makeLogger())).toBe(false);
+  }, 20000);
+
+  it('returns false when getLlmByModel returns null (no usable key)', async () => {
+    getLlmByModelMock.mockReturnValue(null);
+    const { isChatModelUsable } = await import('./chatCompletionDefaults');
+    expect(isChatModelUsable({ anthropic: null }, modelInfo, makeLogger())).toBe(false);
+  }, 20000);
+
+  it('returns false (not a throw) when getLlmByModel throws for an expired key', async () => {
+    getLlmByModelMock.mockImplementation(() => {
+      throw new Error('Anthropic API key is expired');
+    });
+    const { isChatModelUsable } = await import('./chatCompletionDefaults');
+    expect(isChatModelUsable({ anthropic: 'expired' }, modelInfo, makeLogger())).toBe(false);
+  }, 20000);
+
+  it('returns true when getLlmByModel resolves a backend', async () => {
+    getLlmByModelMock.mockReturnValue({ backend: 'anthropic' });
+    const { isChatModelUsable } = await import('./chatCompletionDefaults');
+    expect(isChatModelUsable({ anthropic: 'sk-ant' }, modelInfo, makeLogger())).toBe(true);
+  }, 20000);
 });

--- a/apps/client/server/utils/chatCompletionDefaults.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.ts
@@ -285,6 +285,22 @@ export function getSharedTokenizer(logger?: ILogger): ITokenizer {
   return sharedTokenizer;
 }
 
+/**
+ * Whether `modelInfo` can actually serve a completion with these keys. `getLlmByModel`
+ * returns null when the provider key is absent AND throws ('<provider> API key is expired')
+ * when a stored key is past its expiry - both mean "not usable" here, so the throw is
+ * swallowed rather than surfaced as a 500. Shared by the resolver's fallback decision and
+ * chat.ts's no-usable-model guard so they agree on what "usable" means.
+ */
+export function isChatModelUsable(apiKeys: ApiKeyTable, modelInfo: ModelInfo | undefined, logger: Logger): boolean {
+  if (!modelInfo) return false;
+  try {
+    return getLlmByModel(apiKeys, { modelInfo, logger }) !== null;
+  } catch {
+    return false;
+  }
+}
+
 export interface ResolvedDefaultChatModel {
   /** The model id to use when a request omits one. */
   model: string;
@@ -334,7 +350,7 @@ export async function resolveDefaultChatModel(params: {
   const models = await getAvailableModels(apiKeys);
 
   const configuredInfo = models.find(m => m.id === configuredDefault);
-  if (configuredInfo && getLlmByModel(apiKeys, { modelInfo: configuredInfo, logger })) {
+  if (isChatModelUsable(apiKeys, configuredInfo, logger)) {
     return { model: configuredDefault, apiKeys, models };
   }
 

--- a/apps/client/server/utils/chatCompletionDefaults.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.ts
@@ -371,6 +371,10 @@ export async function resolveDefaultChatModel(params: {
     m => m.backend === ModelBackend.Ollama && m.type === 'text' && !isLikelyEmbeddingModel(m.id)
   );
   if (localModel) {
+    // No isChatModelUsable re-check on this pick: the route guard (chat.ts) re-validates via
+    // isChatModelUsable, and an Ollama model is usable iff apiKeys.ollama is set - the same
+    // condition under which getAvailableModels enumerates it into `models`. So any Ollama model
+    // present here is already usable, and the guard and this fallback stay in agreement.
     return { model: localModel.id, apiKeys, models };
   }
 

--- a/apps/client/server/utils/chatCompletionDefaults.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.ts
@@ -29,15 +29,19 @@ import {
   dataLakeRepository,
 } from '@bike4mind/database';
 import {
+  ChatModels,
   ContextTelemetry,
   ContextTelemetryAlerts,
   IMcpServerDocument,
   IUserDocument,
+  ModelBackend,
   Permission,
+  type ModelInfo,
 } from '@bike4mind/common';
 import { MCPClient } from '@bike4mind/mcp';
-import { IChatCompletionServiceOptions } from '@bike4mind/services';
-import { ITokenizer, TiktokenTokenizer } from '@bike4mind/utils';
+import { apiKeyService, IChatCompletionServiceOptions } from '@bike4mind/services';
+import { ApiKeyTable, getAvailableModels, getLlmByModel } from '@bike4mind/llm-adapters';
+import { getSettingsByNames, ITokenizer, TiktokenTokenizer } from '@bike4mind/utils';
 import { ILogger, Logger } from '@bike4mind/observability';
 import { accessibleBy } from '@casl/mongoose';
 import { logEvent } from '@server/utils/analyticsLog';
@@ -279,4 +283,65 @@ export function getSharedTokenizer(logger?: ILogger): ITokenizer {
     return sharedTokenizer.withLogger(enrichedLogger);
   }
   return sharedTokenizer;
+}
+
+export interface ResolvedDefaultChatModel {
+  /** The model id to use when a request omits one. */
+  model: string;
+  /**
+   * Effective API keys and the available-models list. Computed only on self-host
+   * (undefined on hosted, where no per-request probing happens) and returned so the
+   * caller can judge the model's usability without re-running the two lookups.
+   */
+  apiKeys?: ApiKeyTable;
+  models?: ModelInfo[];
+}
+
+/**
+ * Resolve the default chat model for a request that omits `model`.
+ *
+ * Hosted (B4M_SELF_HOST !== 'true'): the Bedrock-backed schema default is always
+ * reachable via IAM, so return it directly with zero extra work.
+ *
+ * Self-host: Bedrock never works, so the schema default maps to its direct-API
+ * Anthropic twin - but a local-only box may have no ANTHROPIC_API_KEY at all. Probe
+ * the effective keys and the live model list, then keep the configured default when
+ * its provider key is usable, else fall back to the first local Ollama text model
+ * (needs no key), else return the (unusable) default so the caller can raise a clear
+ * error. The live Ollama /api/tags list is the source of truth for local models, not
+ * OLLAMA_PULL_MODELS.
+ */
+export async function resolveDefaultChatModel(params: {
+  configuredModel: string | null | undefined;
+  userId: string;
+  logger?: Logger;
+}): Promise<ResolvedDefaultChatModel> {
+  const cloudDefault = params.configuredModel || ChatModels.CLAUDE_5_SONNET_BEDROCK;
+
+  if (process.env.B4M_SELF_HOST !== 'true') {
+    return { model: cloudDefault };
+  }
+
+  const configuredDefault =
+    cloudDefault === ChatModels.CLAUDE_5_SONNET_BEDROCK ? ChatModels.CLAUDE_5_SONNET : cloudDefault;
+
+  const logger = params.logger ?? new Logger();
+  const apiKeys = (await apiKeyService.getEffectiveLLMApiKeys(
+    params.userId,
+    { db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository }, getSettingsByNames },
+    { logger }
+  )) as ApiKeyTable;
+  const models = await getAvailableModels(apiKeys);
+
+  const configuredInfo = models.find(m => m.id === configuredDefault);
+  if (configuredInfo && getLlmByModel(apiKeys, { modelInfo: configuredInfo, logger })) {
+    return { model: configuredDefault, apiKeys, models };
+  }
+
+  const localModel = models.find(m => m.backend === ModelBackend.Ollama && m.type === 'text');
+  if (localModel) {
+    return { model: localModel.id, apiKeys, models };
+  }
+
+  return { model: configuredDefault, apiKeys, models };
 }

--- a/apps/client/server/utils/chatCompletionDefaults.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.ts
@@ -301,6 +301,17 @@ export function isChatModelUsable(apiKeys: ApiKeyTable, modelInfo: ModelInfo | u
   }
 }
 
+/**
+ * Heuristic name match for an Ollama embedding model. The Ollama backend enumerates every
+ * pulled model as type 'text', so an embedding model (e.g. nomic-embed-text) would otherwise
+ * be a valid chat fallback and answer with empty replies. Matched by id against known
+ * embedding families; kept deliberately narrow so a general model like gemma3 does NOT trip
+ * the `embeddinggemma` term. Self-contained on purpose - do not couple to ollamaBackend.
+ */
+export function isLikelyEmbeddingModel(id: string): boolean {
+  return /embed|bge-|bge:|minilm|arctic-embed|embeddinggemma/i.test(id);
+}
+
 export interface ResolvedDefaultChatModel {
   /** The model id to use when a request omits one. */
   model: string;
@@ -322,10 +333,10 @@ export interface ResolvedDefaultChatModel {
  * Self-host: Bedrock never works, so the schema default maps to its direct-API
  * Anthropic twin - but a local-only box may have no ANTHROPIC_API_KEY at all. Probe
  * the effective keys and the live model list, then keep the configured default when
- * its provider key is usable, else fall back to the first local Ollama text model
- * (needs no key), else return the (unusable) default so the caller can raise a clear
- * error. The live Ollama /api/tags list is the source of truth for local models, not
- * OLLAMA_PULL_MODELS.
+ * its provider key is usable, else fall back to the first local Ollama chat model
+ * (needs no key; embedding models are skipped), else return the (unusable) default so
+ * the caller can raise a clear error. The live Ollama /api/tags list is the source of
+ * truth for local models, not OLLAMA_PULL_MODELS.
  */
 export async function resolveDefaultChatModel(params: {
   configuredModel: string | null | undefined;
@@ -350,11 +361,15 @@ export async function resolveDefaultChatModel(params: {
   const models = await getAvailableModels(apiKeys);
 
   const configuredInfo = models.find(m => m.id === configuredDefault);
-  if (isChatModelUsable(apiKeys, configuredInfo, logger)) {
+  if (isChatModelUsable(apiKeys, configuredInfo, logger) && !isLikelyEmbeddingModel(configuredDefault)) {
     return { model: configuredDefault, apiKeys, models };
   }
 
-  const localModel = models.find(m => m.backend === ModelBackend.Ollama && m.type === 'text');
+  // First local Ollama text model that is not an embedding model (those enumerate as 'text'
+  // but produce no chat reply, e.g. nomic-embed-text pulled alongside a coder model).
+  const localModel = models.find(
+    m => m.backend === ModelBackend.Ollama && m.type === 'text' && !isLikelyEmbeddingModel(m.id)
+  );
   if (localModel) {
     return { model: localModel.id, apiKeys, models };
   }


### PR DESCRIPTION
## Description

Three API issues on a local-only self-host box, reported in #694.

1. Default chat model. `POST /api/chat` with no `model` fell back to the Bedrock/Anthropic schema default. On a box with no Anthropic key and no Bedrock, every default-model chat failed with an error surfaced deep in the pipeline. The picker also had no notion of "unusable" beyond "missing", so a stored-but-expired provider key still counted as the default and failed the same way.

2. OpenAI-compat claim. `/api/ai/v1/completions` was described as an "OpenAI-compatible completions endpoint" in the admin API reference. It is not a drop-in for OpenAI clients: it streams a custom SSE contract (`meta` / `content` / `tool_use` / `error` frames, keep-alive comments, and a `[DONE]` sentinel) with no `choices[].delta`, and it has no server-side default model. Advertising it as OpenAI-compatible sends integrators down the wrong path.

3. Python artifacts offline. The Pyodide runtime was hard-coded to the public jsDelivr CDN, so Python artifacts could not run on an air-gapped box.

## Changes

Default chat model fallback (self-host only):
- New `resolveDefaultChatModel` in `chatCompletionDefaults.ts`. On hosted (`B4M_SELF_HOST !== 'true'`) it returns the Bedrock schema default with no extra work, so hosted behavior is byte-identical to before. On self-host it probes the effective API keys and the live model list, keeps the configured default when its provider key is usable, otherwise falls back to the first local Ollama chat model, otherwise returns the (unusable) default so the caller can raise a clear error.
- Ollama enumerates every pulled model as type `text`, including embedding models, so an embedding model like `nomic-embed-text` could be picked as a chat fallback and answer with empty replies. `isLikelyEmbeddingModel` skips known embedding families by id, kept deliberately narrow so a general model such as `gemma3` does not trip the `embeddinggemma` term.
- `isChatModelUsable` centralizes the "can this model actually serve a completion" check. It treats both a missing provider key (`getLlmByModel` returns null) and an expired stored key (`getLlmByModel` throws) as not usable, so the resolver and the `chat.ts` guard agree.
- `chat.ts` now only probes when the request omits a model. When even the resolved default is unusable it fails fast with a `BadRequestError` telling the operator to set a provider key, enable local models via `OLLAMA_BASE_URL`, or pass an explicit `model` from `GET /api/models`, instead of a cryptic downstream error.

Offline Pyodide mirror:
- `PYODIDE_BASE_URL` env var, surfaced through the public pre-login config (`serverConfigPublic`) so the mirror is applied before login and before the first artifact runs.
- The Pyodide worker takes a `baseUrl` on its `initialize` message and normalizes the trailing slash; unset keeps the default public CDN.
- `proxy.ts` adds the mirror origin to both `script-src` (loads `pyodide.js`) and `connect-src` (fetches the wasm/data assets) in the CSP. Same validation as `NEXT_PUBLIC_BLOG_HOST`: parse to a single origin, reject whitespace or `;`, warn and omit on misconfig. `http` is allowed since a LAN mirror may have no TLS. When unset the CSP is byte-identical to before.

Docs:
- API reference row for `/api/ai/v1/completions` corrected from "OpenAI-compatible" to "Streaming completions (custom SSE contract, not OpenAI-compatible)".
- `SELF_HOST.md` gains a section documenting the completions endpoint: it is served by the `chatcompletion` container, `model` is required (no server-side default), the auth options, and the full SSE frame contract with an example transcript.
- `SELF_HOST.md` and `.env.selfhost.example` document the offline Python artifacts path and what to mirror from the Pyodide v0.25.1 full distribution.

## Guide for Testers

Backend and self-host config change. The default-model behavior is only observable on a self-host stack with the local model provider configured and no cloud provider key.

Default chat model fallback (self-host):
1. Bring up the self-host stack with a local Ollama model pulled (e.g. `OLLAMA_PULL_MODELS=qwen2.5-coder:7b`) and no `ANTHROPIC_API_KEY` set.
2. Send a chat with no model: `curl -X POST http://localhost:3000/api/chat -H "x-api-key: $B4M_API_KEY" -H "content-type: application/json" -d '{"messages":[{"role":"user","content":"Say hello in five words."}]}'`.
3. Expected: a normal reply. The server picks the local chat model (`qwen2.5-coder:7b`), not the embedding model, and does not error.
4. Confirm the negative case: with no cloud key and no local model available, the same request returns a 400 with the "No usable default chat model is configured" message naming the three ways to fix it.

Offline Pyodide mirror:
5. Set `PYODIDE_BASE_URL` in `.env.selfhost` to a mirror of the Pyodide v0.25.1 full dist (e.g. `http://localhost:8080/pyodide/v0.25.1/full/`) and restart the app.
6. Open a Python artifact and run it. Expected: the runtime loads from the mirror origin with no CSP violation in the browser console, and the code executes.
7. Leave `PYODIDE_BASE_URL` unset and re-run: the runtime loads from the default CDN as before.

Regression checks:
- On a hosted deployment (`B4M_SELF_HOST` unset), `POST /api/chat` with no model still uses the Bedrock schema default with no extra probing.
- With `PYODIDE_BASE_URL` unset, the CSP header is unchanged.

What NOT to test:
- No UI surface changed; there is nothing to click through beyond running an artifact.
- Hosted billing, entitlements, and premium overlays are out of scope here.

## Additional Information

How this was verified: tested on a local self-host stack running this change together with the related self-host PRs. With no usable default model, the fallback picker skipped the Ollama embedding model and selected `qwen2.5-coder:7b`, which replied normally; before this change the picker could select `nomic-embed-text` and every default chat failed.

Unit tests cover the rest:
- `resolveDefaultChatModel`: hosted returns the schema default with no probing; self-host substitutes Bedrock for its direct-API twin, keeps an explicit admin default when its key is present, falls back to a local model when the cloud key is absent or expired, and returns the unusable default (no throw) when nothing is usable, including an Ollama-only stack that has only an embedding model.
- `isChatModelUsable`: false for undefined, false when the key is missing, false (not a throw) when the key is expired, true when a backend resolves.
- `isLikelyEmbeddingModel`: matches embedding families without tripping general models.
- proxy CSP: a valid mirror origin is added to both `script-src` and `connect-src`; an invalid value is warned and omitted; unset/empty/invalid is byte-identical to the no-var baseline.
- Pyodide manager and hook: a configured `baseUrl` is forwarded to the worker on initialize; unset sends `undefined` so the worker keeps the default CDN.

## Developer Notes (Optional)

- `resolveDefaultChatModel(configuredModel, userId, logger)` in `chatCompletionDefaults.ts` is the single place that decides the no-explicit-model default. It returns the effective API keys and live model list on self-host so a caller can judge usability without repeating the two lookups.
- `isChatModelUsable(apiKeys, modelInfo, logger)` is the shared "can serve a completion" predicate (missing key and expired key both count as unusable); reuse it anywhere a default/fallback model decision is made.
- The public pre-login config (`serverConfigPublic`) is the pattern for any setting that must be applied before login; `usePublicConfig` avoids the auth-timing race that `useConfig` would introduce.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (SELF_HOST.md, .env.selfhost.example, API reference)
- [x] My changes generate no new warnings
- [x] AdminSettings hydration: n/a, configured via the PYODIDE_BASE_URL env var, no new AdminSettings
- [x] UI/UX: n/a, no visible UI surface changed
- [x] Telemetry fields: n/a, no telemetry changes

Closes #694
