### PR TITLE
docs: fix stale self-host streaming note in BIKE4MIND_CLI.md

### DIFF
--- a/BIKE4MIND_CLI.md
+++ b/BIKE4MIND_CLI.md
@@ -92,7 +92,7 @@ Notes for the self-host path:
 - **Port.** The Docker stack serves the app on `3000` by default (`--dev` is a *different* target — the dev server on `3001`). If you remapped the host port (`APP_HOST_PORT` in `.env.selfhost`), use that port in `--api-url`.
 - **Models.** Only models for providers you configured a key for appear — or your local Ollama models. See [Local models with Ollama](./SELF_HOST.md#local-models-with-ollama-no-api-keys). To surface a host-native Ollama in the picker without editing config, launch with `b4m --ollama-host http://localhost:11434`.
 - **Credits — you don't need them.** Self-host sets `B4M_SELF_HOST=true`, which defaults the **Enforce Credits** admin setting **off**, so usage is never metered: you don't grant yourself credits or top up (`/usage` just shows enforcement is disabled). Your only cost is your own LLM provider bill. An admin *can* turn on **Enforce Credits** (Admin → Settings → Credits) if you want to meter users on your instance.
-- **Streaming.** The self-host stack does not yet include the realtime websocket gateway; see the [self-host gaps](./SELF_HOST.md#what-you-get-and-dont).
+- **Streaming.** The self-host stack includes the realtime WebSocket gateway (the `ws` and `subscriber-fanout` services), so chat replies stream token-by-token and live document updates arrive without a refresh - the same experience as the hosted app, with no AWS API Gateway. See [what you get](./SELF_HOST.md#what-you-get-and-dont).
 
 ## Pointing at any deployment (AWS, staging, …)
 


### PR DESCRIPTION
## Description

BIKE4MIND_CLI.md still claimed the self-host stack lacks the realtime websocket gateway and linked it as a gap. The compose stack has shipped the ws and subscriber-fanout services for a while now, so the note was wrong and steered self-host CLI users away from a feature that works.

## Changes

- Replaced the "does not yet include the realtime websocket gateway" bullet with an accurate description: the stack includes the WebSocket gateway, chat replies stream token-by-token, and live document updates arrive without a refresh, same as the hosted app.

## Testing

- Docs-only change. Verified against a running self-host stack: the ws and subscriber-fanout containers are part of the default compose bring-up and chat replies stream live in the browser.

Closes #683
