### PR TITLE
fix(gears): count live agents so the Agents gear actually unlocks

### DIFF
--- a/apps/client/app/components/commands/CreateAgentCommand.ts
+++ b/apps/client/app/components/commands/CreateAgentCommand.ts
@@ -3,6 +3,7 @@ import { api } from '@client/app/contexts/ApiContext';
 import { toast } from 'sonner';
 import { QueryClient } from '@tanstack/react-query';
 import { createOptimisticQuest } from '@client/app/utils/llm';
+import { GearsStatusResponse } from '@client/app/hooks/useGearsStatus';
 
 interface CreateAgentCommandArgs {
   params: string; // Agent name from command
@@ -50,6 +51,13 @@ export const handleCreateAgentCommand = async (args: CreateAgentCommandArgs): Pr
 
         // Invalidate agent queries to refresh the list
         queryClient.invalidateQueries({ queryKey: ['agents'] });
+        // A first agent unlocks the 'agents' gear - refresh the earned-nav
+        // state (see routes/agents/new.tsx for the same first-create pattern).
+        const gearsStatus = queryClient.getQueryData<GearsStatusResponse>(['gears', 'status']);
+        const agentsGear = gearsStatus?.gears.find(g => g.key === 'agents');
+        if (!agentsGear || !agentsGear.unlocked) {
+          void queryClient.invalidateQueries({ queryKey: ['gears', 'status'] });
+        }
 
         const quest = {
           id: response.data.agent.id,

--- a/apps/client/app/routes/agents/new.tsx
+++ b/apps/client/app/routes/agents/new.tsx
@@ -6,6 +6,7 @@ import { createAgentToServer } from '@client/app/utils/agentsAPICalls';
 import AgentForm from '@client/app/components/Agent/AgentForm';
 import { useUser } from '@client/app/contexts/UserContext';
 import { useQueryClient } from '@tanstack/react-query';
+import { GearsStatusResponse } from '@client/app/hooks/useGearsStatus';
 
 const NewAgentPage: React.FC = () => {
   const navigate = useNavigate();
@@ -31,6 +32,17 @@ const NewAgentPage: React.FC = () => {
 
         toast.success('Agent created successfully!');
         queryClient.invalidateQueries({ queryKey: ['agents'] });
+        // A first agent unlocks the 'agents' gear server-side, but the Gears
+        // status query has a 5-minute staleTime - without an explicit
+        // invalidation the sidenav keeps hiding the earned Agents row until a
+        // reload. Only invalidate while the gear is still locked so routine
+        // creations don't refetch the status (same pattern as SessionFilePond's
+        // first-upload invalidation for the files gear).
+        const gearsStatus = queryClient.getQueryData<GearsStatusResponse>(['gears', 'status']);
+        const agentsGear = gearsStatus?.gears.find(g => g.key === 'agents');
+        if (!agentsGear || !agentsGear.unlocked) {
+          void queryClient.invalidateQueries({ queryKey: ['gears', 'status'] });
+        }
         navigate({ to: `/agents/${newAgent.id}` });
       } catch (error) {
         console.error('Error creating agent:', error);
@@ -39,7 +51,7 @@ const NewAgentPage: React.FC = () => {
         setIsSubmitting(false);
       }
     },
-    [navigate, currentUser, setCurrentUser]
+    [navigate, currentUser, setCurrentUser, queryClient]
   );
 
   return (

--- a/packages/database/src/models/ai/AgentModel.ts
+++ b/packages/database/src/models/ai/AgentModel.ts
@@ -56,7 +56,7 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
     const result = await this.agentModel.find({
       $or: [{ userId }, { 'users.userId': userId }],
       triggerWords: { $in: triggerWords },
-      deletedAt: { $exists: false },
+      deletedAt: null,
     });
 
     return result.map(doc => doc.toJSON());
@@ -84,7 +84,7 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
         { 'users.userId': userId }, // User is a shared member
       ],
       ...(filters.query || {}),
-      deletedAt: { $exists: false },
+      deletedAt: null,
     };
 
     if (search) {
@@ -211,7 +211,7 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
   async findHeartbeatEligible(): Promise<IAgentDocument[]> {
     const now = new Date();
     const result = await this.agentModel.find({
-      deletedAt: { $exists: false },
+      deletedAt: null,
       'heartbeatConfig.enabled': true,
       $or: [
         { 'heartbeatConfig.lastHeartbeatAt': { $exists: false } },
@@ -259,7 +259,7 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
 
   async bulkSetHeartbeatEnabled(userId: string, enabled: boolean): Promise<{ modifiedCount: number }> {
     const result = await this.agentModel.updateMany(
-      { userId, deletedAt: { $exists: false } },
+      { userId, deletedAt: null },
       { $set: { 'heartbeatConfig.enabled': enabled } }
     );
     return { modifiedCount: result.modifiedCount };
@@ -274,7 +274,12 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
   }
 
   async countByUserId(userId: string): Promise<number> {
-    return this.agentModel.countDocuments({ userId, deletedAt: { $exists: false } });
+    // deletedAt must be `null`, not `$exists: false`: softDeletePlugin defaults
+    // the field to null on every document, so `$exists: false` matches nothing.
+    // find()/findOne() were shielded (the plugin's pre-hooks overwrite the
+    // condition) but countDocuments has no hook, which left this count at 0 for
+    // everyone and kept the Agents gear permanently locked.
+    return this.agentModel.countDocuments({ userId, deletedAt: null });
   }
 
   async setHeartbeatStarted(agentId: string): Promise<void> {
@@ -308,17 +313,17 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
   // ServerAgentStore construction.
 
   async listForUser(userId: string): Promise<IAgent[]> {
-    const results = await this.agentModel.find({ userId, deletedAt: { $exists: false } }).sort({ name: 1 });
+    const results = await this.agentModel.find({ userId, deletedAt: null }).sort({ name: 1 });
     return results.map(doc => doc.toJSON());
   }
 
   async listForOrganization(organizationId: string): Promise<IAgent[]> {
-    const results = await this.agentModel.find({ organizationId, deletedAt: { $exists: false } }).sort({ name: 1 });
+    const results = await this.agentModel.find({ organizationId, deletedAt: null }).sort({ name: 1 });
     return results.map(doc => doc.toJSON());
   }
 
   async listSystem(): Promise<IAgent[]> {
-    const results = await this.agentModel.find({ isSystem: true, deletedAt: { $exists: false } }).sort({ name: 1 });
+    const results = await this.agentModel.find({ isSystem: true, deletedAt: null }).sort({ name: 1 });
     return results.map(doc => doc.toJSON());
   }
 
@@ -327,15 +332,13 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
    * surfaced to all users on the /agents Voice Agents tab).
    */
   async listPublicVoiceAgents(): Promise<IAgent[]> {
-    const results = await this.agentModel
-      .find({ type: 'voice', isPublic: true, deletedAt: { $exists: false } })
-      .sort({ name: 1 });
+    const results = await this.agentModel.find({ type: 'voice', isPublic: true, deletedAt: null }).sort({ name: 1 });
     return results.map(doc => doc.toJSON());
   }
 
   /** Lists every voice agent (used by admin Voice Settings page; includes non-public). */
   async listAllVoiceAgents(): Promise<IAgent[]> {
-    const results = await this.agentModel.find({ type: 'voice', deletedAt: { $exists: false } }).sort({ name: 1 });
+    const results = await this.agentModel.find({ type: 'voice', deletedAt: null }).sort({ name: 1 });
     return results.map(doc => doc.toJSON());
   }
 
@@ -344,7 +347,7 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
     const result = await this.agentModel.findOne({
       type: 'voice',
       isDefaultVoiceAgent: true,
-      deletedAt: { $exists: false },
+      deletedAt: null,
     });
     return result?.toJSON() ?? null;
   }
@@ -359,7 +362,7 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
   }
 
   async findByNameForUser(userId: string, name: string): Promise<IAgent | null> {
-    const result = await this.agentModel.findOne({ userId, name, deletedAt: { $exists: false } });
+    const result = await this.agentModel.findOne({ userId, name, deletedAt: null });
     return result?.toJSON() ?? null;
   }
 
@@ -367,7 +370,7 @@ export class AgentRepository extends BaseRepository<IAgentDocument> implements I
     const result = await this.agentModel.findOne({
       organizationId,
       name,
-      deletedAt: { $exists: false },
+      deletedAt: null,
     });
     return result?.toJSON() ?? null;
   }

--- a/packages/database/src/models/ai/__tests__/AgentModel.test.ts
+++ b/packages/database/src/models/ai/__tests__/AgentModel.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { createMongoServer } from '../../../__test__/createMongoServer';
-import Agent from '../AgentModel';
+import Agent, { agentRepository } from '../AgentModel';
 
 const baseAgentData = {
   name: 'Test Agent',
@@ -119,6 +119,39 @@ describe('AgentModel', () => {
 
     it('should reject a non-integer turnTimeoutSeconds (mirrors the API .int() rule)', async () => {
       await expect(Agent.create({ ...baseAgentData, turnTimeoutSeconds: 1.5 })).rejects.toThrow(/turnTimeoutSeconds/i);
+    });
+  });
+
+  describe('countByUserId vs softDeletePlugin deletedAt default', () => {
+    it('stores deletedAt: null (field present) on a freshly created agent', async () => {
+      // Pins the softDeletePlugin premise the count filter depends on: if this
+      // ever flips to field-absent, revisit every deletedAt filter in the model.
+      const agent = await Agent.create(baseAgentData);
+      const raw = await mongoose.connection.db!.collection('agents').findOne({ _id: agent._id });
+      expect(raw).not.toBeNull();
+      expect('deletedAt' in raw!).toBe(true);
+      expect(raw!.deletedAt).toBeNull();
+    });
+
+    it('counts live agents even though deletedAt is stored as null', async () => {
+      // Regression: `deletedAt: { $exists: false }` matched nothing (the plugin
+      // stores null), so the Agents gear never unlocked - even right after a
+      // create. countDocuments has no plugin pre-hook to rescue the filter.
+      await Agent.create(baseAgentData);
+      await Agent.create({ ...baseAgentData, name: 'Second Agent' });
+      expect(await agentRepository.countByUserId(baseAgentData.userId)).toBe(2);
+    });
+
+    it('excludes soft-deleted agents from the count', async () => {
+      const agent = await Agent.create(baseAgentData);
+      agent.deletedAt = new Date();
+      await agent.save();
+      expect(await agentRepository.countByUserId(baseAgentData.userId)).toBe(0);
+    });
+
+    it('does not count agents owned by other users', async () => {
+      await Agent.create({ ...baseAgentData, userId: 'someone-else' });
+      expect(await agentRepository.countByUserId(baseAgentData.userId)).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Description

The Agents gear ("Build your first agent") never unlocked - not for users with existing agents, and not after creating a new one. Reproduced on prod: `/api/gears/status` returned `agents.unlocked: false` for an account whose agents list returned 10 live agents.

Root cause: the gear check counts via `agentRepository.countByUserId`, whose filter used `deletedAt: { $exists: false }`. `softDeletePlugin` defaults `deletedAt` to `null` on every document, so the field always exists and the count was 0 for everyone. `find()`/`findOne()` callers were shielded by the plugin's pre-hooks (which overwrite the `deletedAt` condition at exec time), but `countDocuments` and `updateMany` have no such hook - so `countByUserId`, `searchAccessible`'s pagination `total`, and `bulkSetHeartbeatEnabled` all silently matched nothing.

### Changes

- **`packages/database` AgentModel**: normalize every `deletedAt` filter to `deletedAt: null`, which matches both stored-null (plugin-created) and legacy field-absent documents. For `.find()` paths this is a no-op (the hook already rewrote the condition); for the unhooked `countDocuments`/`updateMany` paths it fixes real bugs.
- **Client**: creating an agent (Create Agent page and the `/create-agent` session command) now invalidates the cached gears status while the agents gear is still locked, so the earned sidenav row and Gears card update without a reload - same first-use pattern as the files gear (#553).
- **Tests**: regression suite pins the plugin's stored-null premise (raw-collection assertion), the live count, soft-delete exclusion, and owner scoping.

Same family as #609 (projects gear queried a nonexistent path) - these receipt-based unlock checks fail silently when the filter doesn't match how the data is actually written.

### Note for reviewers

Other models mix `deletedAt: null` with the `$or: [{ deletedAt: null }, { $exists: false }]` belt-and-suspenders idiom; a few bare `$exists: false` filters remain outside AgentModel (e.g. `SessionModel.ts:469`, `ProjectModel.ts:58`). Left out of scope here - happy to sweep those in a follow-up.

## Verification

- `packages/database` AgentModel suite: 15/15 pass (4 new regression tests; new count tests fail against the old filter).
- Typecheck clean on `@bike4mind/database` and `client` after core rebuild.
- Pre-existing `CreditTransactionModel` test failures reproduce identically on clean main (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ycNYRYoJtbidGR432sTrX