### PR TITLE
docs: note the Overwatch overlay mirrors the live-subscriber definition

### DIFF
--- a/apps/client/server/models/Subscription.ts
+++ b/apps/client/server/models/Subscription.ts
@@ -379,6 +379,12 @@ class SubscriptionRepository extends BaseRepository<ISubscription & IMongoDocume
       total: [{ $count: 'count' }],
 
       // Active subscriptions
+      // NOTE: "live subscriber" here = `status: 'active'` on User-owned subs.
+      // This exact definition is mirrored (hand-transcribed, raw collection)
+      // by the Overwatch product-stats self-report cron in the premium
+      // overlay, which cannot import this model. If the live-status set ever
+      // changes (e.g. counting `trialing`), update that mirror in the same
+      // change or the dashboard's subscriber count silently diverges.
       active: [{ $match: { status: 'active' } }, { $count: 'count' }],
 
       // Subscriptions expiring this month


### PR DESCRIPTION
Comment-only change to `Subscription.ts`: the premium overlay's product-stats self-report cron hand-transcribes this stats facet's definition of a live subscriber (raw `subscriptions` collection, `ownerType: 'User'`, `status: 'active'`) because the overlay cannot import this model without inverting the dependency. This note makes the coupling visible from the side most likely to change it, so a future change to the live-status set (e.g. counting `trialing`) updates the mirror in the same change instead of silently diverging the dashboard's subscriber count.

Requested in review on the overlay PR (Bike4Mind/b4m-overwatch#63, finding P2-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)