### PR TITLE
chore(premium): set b4m-optihashi overlay pin to e0f61f0d9231f2048356d99661dd192615751928

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -2,7 +2,7 @@
   "b4m-bob": "72235ca1b3fa53421917a1e7c1f244af18d2ed2b",
   "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
   "b4m-libreoncology": "c917641b8155c311d217b021e414bba33c9eb72a",
-  "b4m-optihashi": "79b55bf8edcda005292ac4c6a88dfaa5dbec3078",
+  "b4m-optihashi": "e0f61f0d9231f2048356d99661dd192615751928",
   "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Overlay-pin-only change; no application source changes.

Bumps the `b4m-optihashi` overlay pin from `79b55bf` to `e0f61f0`.

## Guide for Testers
Pin-only change (a single line in `premium-overlay.lock.json`); no application source changes in this repo. Standard overlay-pin validation:

1. CI green (typecheck + test).
2. Boot a preview off this PR (deployer `preview.yml`) so the `preview-deployed` label is applied -- that preview build is the SST-bundle validation the pin PR gate requires.
3. On the preview, run an optimizer session in agent mode and confirm formulate/solve still behave normally end to end.

Regression checks: existing optimizer flows (guided + agent) behave as before; nothing outside the optimizer surface is touched.