### PR TITLE
fix(publish): render embedded HTML artifacts in the published reply viewer (#708)

### DIFF
--- a/apps/client/pages/api/publish/__tests__/reply.test.ts
+++ b/apps/client/pages/api/publish/__tests__/reply.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// reply.ts wires an Express-style handler at module load and imports server-only deps; stub them
+// so we can import the pure deriveTitle helper in isolation. parseArtifactsWithFallback is NOT
+// mocked - deriveTitle relies on its real artifact extraction.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const chain: Record<string, unknown> = {};
+    Object.assign(chain, { use: () => chain, post: () => chain });
+    return chain;
+  },
+}));
+vi.mock('@bike4mind/database', () => ({ Quest: {}, PublishedArtifact: {} }));
+vi.mock('@server/services/publish', () => ({
+  resolveVisibility: () => ({}),
+  checkScopePermission: () => ({}),
+  checkPublishQuota: () => ({}),
+}));
+
+import { deriveTitle } from '../reply';
+
+describe('deriveTitle', () => {
+  it('uses the first prose line, stripped of markdown heading markers', () => {
+    expect(deriveTitle('# Hello world\n\nmore text')).toBe('Hello world');
+  });
+
+  it('prefers prose over a leading artifact block', () => {
+    expect(deriveTitle('Intro line\n<artifact type="text/html" title="Tip">y</artifact>')).toBe('Intro line');
+  });
+
+  it('falls back to the artifact title when the reply is nothing but an artifact', () => {
+    expect(deriveTitle('<artifact type="text/html" title="Tip Calculator">...</artifact>')).toBe('Tip Calculator');
+  });
+
+  it('falls back to "Shared reply" when there is no prose and no usable artifact title', () => {
+    // No title attribute -> parser assigns "Untitled Artifact", which deriveTitle skips.
+    expect(deriveTitle('<artifact type="text/html">y</artifact>')).toBe('Shared reply');
+  });
+
+  it('never returns the raw <artifact> wrapper tag as the title (#708)', () => {
+    const title = deriveTitle('<artifact type="text/html" title="Real Title"><label>x</label></artifact>');
+    expect(title).not.toContain('<artifact');
+    expect(title).toBe('Real Title');
+  });
+});

--- a/apps/client/pages/api/publish/reply.ts
+++ b/apps/client/pages/api/publish/reply.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { Quest, PublishedArtifact } from '@bike4mind/database';
 import { PublishReplyRequestSchema, type PublishResult } from '@bike4mind/common';
 import { resolveVisibility, checkScopePermission, checkPublishQuota, type PublishUser } from '@server/services/publish';
+import { parseArtifactsWithFallback } from '@client/app/utils/artifactParser';
 
 /**
  * POST /api/publish/reply - publish a single assistant reply as a public viewer
@@ -180,18 +181,27 @@ const handler = baseApi().post(async (req, res) => {
   return res.status(200).json(response);
 });
 
-/** First non-empty markdown line (stripped of leading #/*), capped, as a title. */
+/**
+ * First non-empty markdown line (stripped of leading #/*), capped, as a title. Embedded
+ * `<artifact>` blocks are removed first so a reply that LEADS with an artifact doesn't take
+ * the raw `<artifact ...>` wrapper tag as its title (#708); if the reply is nothing but an
+ * artifact, fall back to the artifact's own title attribute.
+ */
 function deriveTitle(markdown: string): string {
-  const firstLine =
-    markdown
-      .split('\n')
-      .map(l => l.trim())
-      .find(Boolean) ?? 'Shared reply';
-  const cleaned = firstLine
-    .replace(/^#+\s*/, '')
-    .replace(/^[*_>-]+\s*/, '')
-    .slice(0, 120);
-  return cleaned || 'Shared reply';
+  const { artifacts, cleanedContent } = parseArtifactsWithFallback(markdown);
+  const firstLine = cleanedContent
+    .split('\n')
+    .map(l => l.trim())
+    .find(Boolean);
+  if (firstLine) {
+    const cleaned = firstLine
+      .replace(/^#+\s*/, '')
+      .replace(/^[*_>-]+\s*/, '')
+      .slice(0, 120);
+    if (cleaned) return cleaned;
+  }
+  const named = artifacts.find(a => a.title && a.title !== 'Untitled Artifact');
+  return named?.title?.slice(0, 120) || 'Shared reply';
 }
 
 export const config = {

--- a/apps/client/pages/api/publish/reply.ts
+++ b/apps/client/pages/api/publish/reply.ts
@@ -187,7 +187,7 @@ const handler = baseApi().post(async (req, res) => {
  * the raw `<artifact ...>` wrapper tag as its title (#708); if the reply is nothing but an
  * artifact, fall back to the artifact's own title attribute.
  */
-function deriveTitle(markdown: string): string {
+export function deriveTitle(markdown: string): string {
   const { artifacts, cleanedContent } = parseArtifactsWithFallback(markdown);
   const firstLine = cleanedContent
     .split('\n')

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -352,15 +352,14 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
 
   // -- Reply / fabfile: render the snapshot body to a sanitized viewer page. --
   if (artifact.source.kind === 'reply' || artifact.source.kind === 'fabfile') {
-    // Artifact sub-document (`?a={index}`): serve one embedded HTML/SVG artifact as a
+    // Reply artifact sub-document (`?a={index}`): serve one embedded HTML/SVG artifact as a
     // standalone SANDBOXED document for the viewer page's iframe. Author JS runs, but the
     // response's `sandbox allow-scripts` CSP forces an opaque origin (NO allow-same-origin)
     // even on a direct top-level navigation, so it can never read the app origin's token -
-    // the same isolation the bundle path relies on. Covers reply AND fabfile (both render
-    // their snapshot body through renderViewerPage); the viewer only emits `?a` for html/svg
-    // artifacts, so an out-of-range or non-embeddable index is a 404. The visibility gate
-    // already ran above, so this reads only content the caller is authorized for.
-    if (typeof req.query.a === 'string') {
+    // the same isolation the bundle path relies on. Reply-only, and the viewer only emits
+    // `?a` for html/svg artifacts, so an out-of-range or non-embeddable index is a 404. The
+    // visibility gate already ran above, so this reads only content the caller is authorized for.
+    if (artifact.source.kind === 'reply' && typeof req.query.a === 'string') {
       const idx = Number(req.query.a);
       const { artifacts } = parseArtifactsWithFallback(artifact.renderedBody ?? '');
       const target = Number.isInteger(idx) && idx >= 0 ? artifacts[idx] : undefined;
@@ -1164,11 +1163,10 @@ function renderArtifactBlock(artifact: ParsedArtifact, index: number, selfPath: 
 }
 
 /**
- * Render a reply/fabfile snapshot to a standalone HTML page. Both extract any embedded
- * `<artifact>` blocks: each HTML/SVG artifact renders in its own sandboxed `?a=` iframe
- * (non-embeddable types get a placeholder card), so no artifact ever leaks as raw markup. The
- * surrounding text differs by kind - a reply is rendered as markdown (via marked), a fabfile as
- * escaped <pre> (a file is literal text, not prose). The PAGE is served with script-src 'none'
+ * Render a reply/fabfile snapshot to a standalone HTML page. Replies are markdown (rendered via
+ * marked) with any embedded `<artifact>` blocks extracted: the surrounding prose renders inline,
+ * and each HTML/SVG artifact renders in its own sandboxed `?a=` iframe (non-embeddable types get
+ * a placeholder card). Fabfiles render as escaped <pre>. The PAGE is served with script-src 'none'
  * so injected markup cannot execute; artifact JS runs only inside the sandboxed sub-document.
  */
 function renderViewerPage(
@@ -1178,16 +1176,20 @@ function renderViewerPage(
   canFrameArtifacts = false
 ): string {
   const body = artifact.renderedBody ?? '';
-  const { artifacts, cleanedContent } = parseArtifactsWithFallback(body);
-  // Reply prose is markdown; a fabfile is a literal file, so its remaining text stays escaped <pre>.
-  const article = cleanedContent
-    ? artifact.source.kind === 'reply'
+  let contentHtml: string;
+  let displayTitle = artifact.title || SHARED_FALLBACK_TITLE;
+  if (artifact.source.kind === 'reply') {
+    const { artifacts, cleanedContent } = parseArtifactsWithFallback(body);
+    const article = cleanedContent
       ? sanitizeRenderedHtml(marked.parse(cleanedContent, { async: false }) as string)
-      : `<pre class="b4m-pre">${escapeHtml(cleanedContent)}</pre>`
-    : '';
-  const blocks = artifacts.map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts)).join('\n');
-  const contentHtml = `${article}${blocks}`;
-  const titleHtml = escapeHtml(cleanViewerTitle(artifact.title, artifacts));
+      : '';
+    const blocks = artifacts.map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts)).join('\n');
+    contentHtml = `${article}${blocks}`;
+    displayTitle = cleanViewerTitle(artifact.title, artifacts);
+  } else {
+    contentHtml = `<pre class="b4m-pre">${escapeHtml(body)}</pre>`;
+  }
+  const titleHtml = escapeHtml(displayTitle);
   const noindexHead = noindex ? `\n${SHARE_NOINDEX_META}` : '';
 
   return `<!doctype html>

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -352,14 +352,15 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
 
   // -- Reply / fabfile: render the snapshot body to a sanitized viewer page. --
   if (artifact.source.kind === 'reply' || artifact.source.kind === 'fabfile') {
-    // Reply artifact sub-document (`?a={index}`): serve one embedded HTML/SVG artifact as a
+    // Artifact sub-document (`?a={index}`): serve one embedded HTML/SVG artifact as a
     // standalone SANDBOXED document for the viewer page's iframe. Author JS runs, but the
     // response's `sandbox allow-scripts` CSP forces an opaque origin (NO allow-same-origin)
     // even on a direct top-level navigation, so it can never read the app origin's token -
-    // the same isolation the bundle path relies on. Reply-only, and the viewer only emits
-    // `?a` for html/svg artifacts, so an out-of-range or non-embeddable index is a 404. The
-    // visibility gate already ran above, so this reads only content the caller is authorized for.
-    if (artifact.source.kind === 'reply' && typeof req.query.a === 'string') {
+    // the same isolation the bundle path relies on. Covers reply AND fabfile (both render
+    // their snapshot body through renderViewerPage); the viewer only emits `?a` for html/svg
+    // artifacts, so an out-of-range or non-embeddable index is a 404. The visibility gate
+    // already ran above, so this reads only content the caller is authorized for.
+    if (typeof req.query.a === 'string') {
       const idx = Number(req.query.a);
       const { artifacts } = parseArtifactsWithFallback(artifact.renderedBody ?? '');
       const target = Number.isInteger(idx) && idx >= 0 ? artifacts[idx] : undefined;
@@ -1163,10 +1164,11 @@ function renderArtifactBlock(artifact: ParsedArtifact, index: number, selfPath: 
 }
 
 /**
- * Render a reply/fabfile snapshot to a standalone HTML page. Replies are markdown (rendered via
- * marked) with any embedded `<artifact>` blocks extracted: the surrounding prose renders inline,
- * and each HTML/SVG artifact renders in its own sandboxed `?a=` iframe (non-embeddable types get
- * a placeholder card). Fabfiles render as escaped <pre>. The PAGE is served with script-src 'none'
+ * Render a reply/fabfile snapshot to a standalone HTML page. Both extract any embedded
+ * `<artifact>` blocks: each HTML/SVG artifact renders in its own sandboxed `?a=` iframe
+ * (non-embeddable types get a placeholder card), so no artifact ever leaks as raw markup. The
+ * surrounding text differs by kind - a reply is rendered as markdown (via marked), a fabfile as
+ * escaped <pre> (a file is literal text, not prose). The PAGE is served with script-src 'none'
  * so injected markup cannot execute; artifact JS runs only inside the sandboxed sub-document.
  */
 function renderViewerPage(
@@ -1176,20 +1178,16 @@ function renderViewerPage(
   canFrameArtifacts = false
 ): string {
   const body = artifact.renderedBody ?? '';
-  let contentHtml: string;
-  let displayTitle = artifact.title || SHARED_FALLBACK_TITLE;
-  if (artifact.source.kind === 'reply') {
-    const { artifacts, cleanedContent } = parseArtifactsWithFallback(body);
-    const article = cleanedContent
+  const { artifacts, cleanedContent } = parseArtifactsWithFallback(body);
+  // Reply prose is markdown; a fabfile is a literal file, so its remaining text stays escaped <pre>.
+  const article = cleanedContent
+    ? artifact.source.kind === 'reply'
       ? sanitizeRenderedHtml(marked.parse(cleanedContent, { async: false }) as string)
-      : '';
-    const blocks = artifacts.map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts)).join('\n');
-    contentHtml = `${article}${blocks}`;
-    displayTitle = cleanViewerTitle(artifact.title, artifacts);
-  } else {
-    contentHtml = `<pre class="b4m-pre">${escapeHtml(body)}</pre>`;
-  }
-  const titleHtml = escapeHtml(displayTitle);
+      : `<pre class="b4m-pre">${escapeHtml(cleanedContent)}</pre>`
+    : '';
+  const blocks = artifacts.map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts)).join('\n');
+  const contentHtml = `${article}${blocks}`;
+  const titleHtml = escapeHtml(cleanViewerTitle(artifact.title, artifacts));
   const noindexHead = noindex ? `\n${SHARE_NOINDEX_META}` : '';
 
   return `<!doctype html>

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -34,6 +34,7 @@ import {
   isAppWrapperHost,
 } from '@server/services/publish/viewerSecurity';
 import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
+import { parseArtifactsWithFallback, type ParsedArtifact } from '@client/app/utils/artifactParser';
 import { B4M_HORIZONTAL_LOGO_SVG } from '@client/app/utils/b4mLogo';
 import { WEBSITE_URL, getBrandName } from '@client/config/general';
 import type { PublishScopeTier, PublishVisibility } from '@bike4mind/common';
@@ -351,6 +352,36 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
 
   // -- Reply / fabfile: render the snapshot body to a sanitized viewer page. --
   if (artifact.source.kind === 'reply' || artifact.source.kind === 'fabfile') {
+    // Reply artifact sub-document (`?a={index}`): serve one embedded HTML/SVG artifact as a
+    // standalone SANDBOXED document for the viewer page's iframe. Author JS runs, but the
+    // response's `sandbox allow-scripts` CSP forces an opaque origin (NO allow-same-origin)
+    // even on a direct top-level navigation, so it can never read the app origin's token -
+    // the same isolation the bundle path relies on. Reply-only, and the viewer only emits
+    // `?a` for html/svg artifacts, so an out-of-range or non-embeddable index is a 404. The
+    // visibility gate already ran above, so this reads only content the caller is authorized for.
+    if (artifact.source.kind === 'reply' && typeof req.query.a === 'string') {
+      const idx = Number(req.query.a);
+      const { artifacts } = parseArtifactsWithFallback(artifact.renderedBody ?? '');
+      const target = Number.isInteger(idx) && idx >= 0 ? artifacts[idx] : undefined;
+      if (!target || (target.type !== 'html' && target.type !== 'svg')) {
+        return res.status(404).json({ error: 'Not found' });
+      }
+      const docOrigin = resolveDocOrigin(req.headers.host, req.headers['x-forwarded-proto']);
+      const { srcdoc } = renderSandboxedBundle({
+        indexHtml: target.content,
+        urlBase: '',
+        origin: docOrigin,
+        visibility: effectiveVisibility,
+        // Self-contained artifact (no manifest assets): inline mode with an empty asset
+        // map only absolutizes blessed-lib scripts and drops any stray relative refs.
+        assetMode: 'inline',
+      });
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.setHeader('Content-Security-Policy', buildReplyArtifactCsp(req));
+      res.setHeader('Cache-Control', isShare ? SHARE_CACHE_CONTROL : cacheControlFor(effectiveVisibility));
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      return res.status(200).send(srcdoc);
+    }
     if (isFormatRaw) {
       if (!isOpenPublic) {
         return res.status(404).json({ error: 'Not found' });
@@ -363,10 +394,23 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
         req.headers['user-agent']
       );
     }
-    const page = renderViewerPage(artifact, isShare);
+    // Base URL this page was reached at, so the embedded-artifact iframes point back to the
+    // same route (`/p/r|f/{publicId}` or the `/a/{token}` share) carrying the same authorization.
+    const sourcePrefix = artifact.source.kind === 'reply' ? 'r' : 'f';
+    const selfPath = isShare ? `/a/${encodeURIComponent(shareToken)}` : `/p/${sourcePrefix}/${artifact.publicId}`;
+    // Whether an embedded artifact can be framed via its `?a=` sub-document. The artifact iframe
+    // is a fresh same-origin request that carries only what the browser attaches automatically:
+    // an open-public page has no gate, a `/a/{token}` share re-authorizes by the token IN the
+    // path, and a passphrase gate re-verifies from the same-origin proof COOKIE. A Bearer-gated
+    // reply (org/domain visibility) authorizes off `req.user` from the Authorization header, which
+    // an iframe navigation cannot send - so it would dead-end at a nested loader shell. For those
+    // we render the placeholder card instead of a frame that can never load.
+    const canFrameArtifacts = isOpenPublic || isShare || passphraseVerified;
+    const page = renderViewerPage(artifact, isShare, selfPath, canFrameArtifacts);
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
-    // No scripts are needed for a rendered text/markdown page; 'none' neutralizes
-    // any markup that slipped through, so this page can't execute injected JS.
+    // The page itself stays script-free (`script-src 'none'` neutralizes any markup that
+    // slipped past the sanitizer); embedded artifacts run only inside their own sandboxed
+    // `?a=` iframe, permitted via `frame-src`/`child-src 'self'` (child-src for older UAs).
     res.setHeader(
       'Content-Security-Policy',
       [
@@ -375,6 +419,8 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
         "style-src 'unsafe-inline'",
         withAppHost("img-src 'self' data:"),
         "font-src 'self' https://fonts.gstatic.com",
+        "frame-src 'self'",
+        "child-src 'self'",
         "base-uri 'self'",
         "form-action 'none'",
         "frame-ancestors 'self'",
@@ -922,6 +968,32 @@ function buildWrapperCsp(req: Request, artifactHost?: string, embedOrigins: stri
   ].join('; ');
 }
 
+/**
+ * CSP for a reply's embedded-artifact sub-document (`/p/r/{publicId}?a={i}`). Author inline JS
+ * is ALLOWED here (an HTML/SVG artifact is meant to run), but the `sandbox allow-scripts`
+ * directive forces an OPAQUE origin with NO `allow-same-origin` - so even a DIRECT navigation
+ * to this URL can never read the app origin's token/cookies (the sandbox, not script-src, is the
+ * ATO boundary, exactly as on the bundle path). Blessed libs load from their absolute app-host
+ * URLs (renderSandboxedBundle absolutizes them); everything else is self-contained/data:.
+ */
+function buildReplyArtifactCsp(req: Request): string {
+  const blessedScriptSrc = buildBundleScriptSrc(req.headers.host, req.headers['x-forwarded-proto']);
+  return [
+    "default-src 'none'",
+    `script-src 'unsafe-inline' ${blessedScriptSrc}`.trim(),
+    withAppHost("style-src 'unsafe-inline'") + ' https://fonts.googleapis.com',
+    withAppHost("img-src 'self' data:"),
+    withAppHost("media-src 'self' data:"),
+    withAppHost("font-src 'self'") + ' https://fonts.gstatic.com',
+    "connect-src 'self'",
+    "base-uri 'self'",
+    "form-action 'none'",
+    "frame-ancestors 'self'",
+    // Opaque origin even on direct navigation; allow-scripts re-enables the artifact's own JS.
+    'sandbox allow-scripts',
+  ].join('; ');
+}
+
 // -- Types ---------------------------------------------------------------------
 interface PublishedArtifactLean {
   publicId: string;
@@ -1057,17 +1129,67 @@ function sendRawArtifact(
 }
 
 /**
- * Render a reply/fabfile snapshot to a standalone HTML page. Replies are
- * markdown (rendered via marked); fabfiles render as escaped <pre>. Served with
- * script-src 'none' so injected markup cannot execute.
+ * Clean a snapshot title for display. A reply that LEADS with an `<artifact ...>` tag was
+ * snapshotted with the raw wrapper tag as its title (deriveTitle took the first line); recover
+ * a sensible title from the first named embedded artifact, else the neutral fallback. New
+ * publishes no longer hit this (deriveTitle now skips artifact tags), but existing rows do.
  */
-function renderViewerPage(artifact: PublishedArtifactLean, noindex: boolean): string {
+function cleanViewerTitle(rawTitle: string | undefined, artifacts: ParsedArtifact[]): string {
+  const t = (rawTitle ?? '').trim();
+  if (t && !/^<artifact\b/i.test(t)) return t;
+  const named = artifacts.find(a => a.title && a.title !== 'Untitled Artifact');
+  return named?.title || SHARED_FALLBACK_TITLE;
+}
+
+/**
+ * Render one embedded artifact as viewer markup. An HTML/SVG artifact renders in its own
+ * SANDBOXED iframe pointed at the `?a={index}` sub-document (so its JS runs isolated on an
+ * opaque origin, never on the script-free reply page) - but ONLY when `canFrame` says the
+ * sub-request will authorize (see the call site); a Bearer-gated reply falls back to the card so
+ * we never emit a frame that dead-ends at a loader shell. Every other type (react/code/python/
+ * mermaid/recharts) needs the app runtime the static viewer can't provide, so it also gets a
+ * clean placeholder card instead of leaking raw markup. `index` MUST match the position in the
+ * same parseArtifactsWithFallback result the `?a` handler indexes into.
+ */
+function renderArtifactBlock(artifact: ParsedArtifact, index: number, selfPath: string, canFrame: boolean): string {
+  const title = escapeHtml(artifact.title || 'Artifact');
+  if (canFrame && selfPath && (artifact.type === 'html' || artifact.type === 'svg')) {
+    const src = escapeHtml(`${selfPath}?a=${index}`);
+    return `<iframe class="b4m-artifact" sandbox="allow-scripts" loading="lazy" title="${title}" src="${src}"></iframe>`;
+  }
+  return `<div class="b4m-artifact-card"><strong>${title}</strong><span>${escapeHtml(
+    artifact.type
+  )} artifact - open in the app to view</span></div>`;
+}
+
+/**
+ * Render a reply/fabfile snapshot to a standalone HTML page. Replies are markdown (rendered via
+ * marked) with any embedded `<artifact>` blocks extracted: the surrounding prose renders inline,
+ * and each HTML/SVG artifact renders in its own sandboxed `?a=` iframe (non-embeddable types get
+ * a placeholder card). Fabfiles render as escaped <pre>. The PAGE is served with script-src 'none'
+ * so injected markup cannot execute; artifact JS runs only inside the sandboxed sub-document.
+ */
+function renderViewerPage(
+  artifact: PublishedArtifactLean,
+  noindex: boolean,
+  selfPath = '',
+  canFrameArtifacts = false
+): string {
   const body = artifact.renderedBody ?? '';
-  const titleHtml = escapeHtml(artifact.title || SHARED_FALLBACK_TITLE);
-  const contentHtml =
-    artifact.source.kind === 'reply'
-      ? sanitizeRenderedHtml(marked.parse(body, { async: false }) as string)
-      : `<pre class="b4m-pre">${escapeHtml(body)}</pre>`;
+  let contentHtml: string;
+  let displayTitle = artifact.title || SHARED_FALLBACK_TITLE;
+  if (artifact.source.kind === 'reply') {
+    const { artifacts, cleanedContent } = parseArtifactsWithFallback(body);
+    const article = cleanedContent
+      ? sanitizeRenderedHtml(marked.parse(cleanedContent, { async: false }) as string)
+      : '';
+    const blocks = artifacts.map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts)).join('\n');
+    contentHtml = `${article}${blocks}`;
+    displayTitle = cleanViewerTitle(artifact.title, artifacts);
+  } else {
+    contentHtml = `<pre class="b4m-pre">${escapeHtml(body)}</pre>`;
+  }
+  const titleHtml = escapeHtml(displayTitle);
   const noindexHead = noindex ? `\n${SHARE_NOINDEX_META}` : '';
 
   return `<!doctype html>
@@ -1078,7 +1200,7 @@ function renderViewerPage(artifact: PublishedArtifactLean, noindex: boolean): st
 <!-- CSP as a meta so the no-JS posture survives when this page is injected as the loader
      shell's iframe srcdoc (a srcdoc carries no HTTP CSP header, and the shell's iframe is
      sandbox="allow-scripts"). Mirrors the direct-serve HTTP header's script-src 'none'. -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'none'; style-src 'unsafe-inline'; ${withAppHost("img-src 'self' data:")}; font-src 'self' https://fonts.gstatic.com; base-uri 'self'; form-action 'none'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'none'; style-src 'unsafe-inline'; ${withAppHost("img-src 'self' data:")}; font-src 'self' https://fonts.gstatic.com; frame-src 'self'; child-src 'self'; base-uri 'self'; form-action 'none'">
 <meta property="og:title" content="${titleHtml}">
 <meta property="og:description" content="${escapeHtml(SHARED_FALLBACK_TITLE)}">
 <title>${titleHtml}</title>
@@ -1091,6 +1213,11 @@ function renderViewerPage(artifact: PublishedArtifactLean, noindex: boolean): st
   pre.b4m-pre, pre { background: rgba(127,127,127,.12); padding: 1rem; border-radius: 8px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; }
   code { background: rgba(127,127,127,.15); padding: .15em .35em; border-radius: 4px; }
   img { max-width: 100%; height: auto; }
+  iframe.b4m-artifact { display: block; width: 100%; height: 600px; margin: 1.5rem 0; border: 1px solid rgba(127,127,127,.3);
+         border-radius: 8px; background: #fff; }
+  .b4m-artifact-card { display: flex; flex-direction: column; gap: .25rem; margin: 1.5rem 0; padding: 1rem 1.25rem;
+         border: 1px solid rgba(127,127,127,.3); border-radius: 8px; background: rgba(127,127,127,.08); }
+  .b4m-artifact-card span { font-size: .85rem; opacity: .75; }
   .b4m-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid rgba(127,127,127,.3); font-size: .85rem; opacity: .7; }
 </style>
 </head>

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -34,7 +34,11 @@ import {
   isAppWrapperHost,
 } from '@server/services/publish/viewerSecurity';
 import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
-import { parseArtifactsWithFallback, type ParsedArtifact } from '@client/app/utils/artifactParser';
+import {
+  parseArtifactsWithFallback,
+  type ParsedArtifact,
+  type ArtifactParseResult,
+} from '@client/app/utils/artifactParser';
 import { B4M_HORIZONTAL_LOGO_SVG } from '@client/app/utils/b4mLogo';
 import { WEBSITE_URL, getBrandName } from '@client/config/general';
 import type { PublishScopeTier, PublishVisibility } from '@bike4mind/common';
@@ -359,9 +363,11 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     // the same isolation the bundle path relies on. Reply-only, and the viewer only emits
     // `?a` for html/svg artifacts, so an out-of-range or non-embeddable index is a 404. The
     // visibility gate already ran above, so this reads only content the caller is authorized for.
-    if (artifact.source.kind === 'reply' && typeof req.query.a === 'string') {
+    // Require a non-empty `a` so `?a=` doesn't coerce to index 0 (Number('') === 0); an empty
+    // value falls through to the normal page render instead.
+    if (artifact.source.kind === 'reply' && typeof req.query.a === 'string' && req.query.a !== '') {
       const idx = Number(req.query.a);
-      const { artifacts } = parseArtifactsWithFallback(artifact.renderedBody ?? '');
+      const { artifacts } = extractViewerArtifacts(artifact.renderedBody ?? '');
       const target = Number.isInteger(idx) && idx >= 0 ? artifacts[idx] : undefined;
       if (!target || (target.type !== 'html' && target.type !== 'svg')) {
         return res.status(404).json({ error: 'Not found' });
@@ -380,6 +386,8 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
       res.setHeader('Content-Security-Policy', buildReplyArtifactCsp(req));
       res.setHeader('Cache-Control', isShare ? SHARE_CACHE_CONTROL : cacheControlFor(effectiveVisibility));
       res.setHeader('X-Content-Type-Options', 'nosniff');
+      // No bumpViewCount here: this sub-document is a sub-resource of the reply page (the iframe),
+      // which already counted the view; counting again would double every framed-artifact view.
       return res.status(200).send(srcdoc);
     }
     if (isFormatRaw) {
@@ -396,6 +404,8 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     }
     // Base URL this page was reached at, so the embedded-artifact iframes point back to the
     // same route (`/p/r|f/{publicId}` or the `/a/{token}` share) carrying the same authorization.
+    // selfPath + canFrameArtifacts are consumed only by the reply render below; the fabfile branch
+    // of renderViewerPage ignores them (it emits an escaped <pre>, no artifact frames).
     const sourcePrefix = artifact.source.kind === 'reply' ? 'r' : 'f';
     const selfPath = isShare ? `/a/${encodeURIComponent(shareToken)}` : `/p/${sourcePrefix}/${artifact.publicId}`;
     // Whether an embedded artifact can be framed via its `?a=` sub-document. The artifact iframe
@@ -1129,6 +1139,19 @@ function sendRawArtifact(
 }
 
 /**
+ * parseArtifactsWithFallback, but with artifacts in DOCUMENT order. `parseArtifacts` returns them
+ * reverse-sorted by position (a side effect of its back-to-front tag-removal pass), which would
+ * otherwise render a multi-artifact reply bottom-up. Sorting by `startIndex` restores document
+ * order for the common case (explicit `<artifact>` tags share one coordinate space). The viewer
+ * render and the `?a=` sub-document handler BOTH extract via this helper, so an iframe's `?a={i}`
+ * always indexes the same artifact the viewer framed at slot i.
+ */
+function extractViewerArtifacts(body: string): ArtifactParseResult {
+  const result = parseArtifactsWithFallback(body);
+  return { ...result, artifacts: [...result.artifacts].sort((a, b) => a.startIndex - b.startIndex) };
+}
+
+/**
  * Clean a snapshot title for display. A reply that LEADS with an `<artifact ...>` tag was
  * snapshotted with the raw wrapper tag as its title (deriveTitle took the first line); recover
  * a sensible title from the first named embedded artifact, else the neutral fallback. New
@@ -1179,7 +1202,7 @@ function renderViewerPage(
   let contentHtml: string;
   let displayTitle = artifact.title || SHARED_FALLBACK_TITLE;
   if (artifact.source.kind === 'reply') {
-    const { artifacts, cleanedContent } = parseArtifactsWithFallback(body);
+    const { artifacts, cleanedContent } = extractViewerArtifacts(body);
     const article = cleanedContent
       ? sanitizeRenderedHtml(marked.parse(cleanedContent, { async: false }) as string)
       : '';

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -636,6 +636,47 @@ describe('GET /api/publish/serve - reply embedded HTML artifact (#708)', () => {
     // camelCase SVG attributes must survive the cheerio round-trip, or the SVG renders broken.
     expect(svg).toContain('viewBox');
   });
+
+  it('maps ?a=0 and ?a=1 to the correct artifact when a reply embeds two HTML artifacts', async () => {
+    const twoReply = htmlReply({
+      publicId: 'r2',
+      slug: 'r2',
+      title: 'Two artifacts',
+      renderedBody:
+        '<artifact type="text/html" title="First"><body><h1>FIRST_ARTIFACT</h1></body></artifact>\n' +
+        '<artifact type="text/html" title="Second"><body><h1>SECOND_ARTIFACT</h1></body></artifact>',
+    });
+    mockArtifactFindOne.mockReturnValue(twoReply);
+
+    const { res: pageRes, promise: pagePromise } = run(['r', 'r2']);
+    await pagePromise;
+    const page = pageRes._getData() as string;
+    expect(page).toContain('src="/p/r/r2?a=0"');
+    expect(page).toContain('src="/p/r/r2?a=1"');
+
+    // Artifacts render in DOCUMENT order (extractViewerArtifacts sorts by startIndex), and the
+    // viewer + handler share that ordering, so ?a=0 is the first artifact and ?a=1 the second.
+    const { res: a0, promise: p0 } = run(['r', 'r2'], { a: '0' });
+    await p0;
+    const doc0 = a0._getData() as string;
+    expect(doc0).toContain('FIRST_ARTIFACT');
+    expect(doc0).not.toContain('SECOND_ARTIFACT');
+
+    const { res: a1, promise: p1 } = run(['r', 'r2'], { a: '1' });
+    await p1;
+    const doc1 = a1._getData() as string;
+    expect(doc1).toContain('SECOND_ARTIFACT');
+    expect(doc1).not.toContain('FIRST_ARTIFACT');
+  });
+
+  it('treats an empty ?a= as the normal page render, not artifact index 0', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlReply());
+    const { res, promise } = run(['r', 'rhtml'], { a: '' });
+    await promise;
+    expect(res._getStatusCode()).toBe(200);
+    // Fell through to the page (which frames artifact 0), rather than serving artifact 0's srcdoc.
+    expect(res._getData() as string).toContain('src="/p/r/rhtml?a=0"');
+  });
 });
 
 describe('GET /api/publish/serve - reply/fabfile organization visibility', () => {

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -65,16 +65,18 @@ type RunOpts = {
   cookie?: string;
   userAgent?: string;
   embed?: boolean;
+  a?: string;
 };
 const run = (
   segments: string[],
-  { user, host = 'app.bike4mind.com', raw, v, uc, format, cookie, userAgent, embed }: RunOpts = {}
+  { user, host = 'app.bike4mind.com', raw, v, uc, format, cookie, userAgent, embed, a }: RunOpts = {}
 ) => {
   const query: Record<string, unknown> = { path: segments };
   if (raw) query.raw = '1';
   if (v) query.v = v;
   if (format) query.format = format;
   if (embed) query.embed = '1';
+  if (a !== undefined) query.a = a;
   const effectiveHost = uc ? `${uc}.usercontent.app.bike4mind.com` : host;
   if (uc) query.__uc = '1';
   const headers: Record<string, string> = { host: effectiveHost };
@@ -475,6 +477,164 @@ describe('GET /api/publish/serve - reply/fabfile path is unchanged', () => {
     expect(data).not.toContain('<iframe'); // reply path does not use the sandbox iframe
     const csp = res.getHeader('Content-Security-Policy') as string;
     expect(csp).toContain("script-src 'none'");
+  });
+});
+
+describe('GET /api/publish/serve - reply embedded HTML artifact (#708)', () => {
+  const HTML_ARTIFACT =
+    '<artifact identifier="tip" type="text/html" title="Tip Calculator">' +
+    '<!DOCTYPE html><html><head><title>Tip</title></head>' +
+    '<body><label>Bill</label><input><script>window.ok=1</script></body></html>' +
+    '</artifact>';
+
+  const htmlReply = (over: Record<string, unknown> = {}) => ({
+    publicId: 'rhtml',
+    // Simulates the #708 title bug on an EXISTING row: the reply led with the artifact, so
+    // deriveTitle snapshotted the raw wrapper tag as the title.
+    title: '<artifact identifier="tip" type="text/html" title="Tip Calculator">',
+    visibility: 'public',
+    ownerId: 'owner1',
+    source: { kind: 'reply' },
+    renderedBody: HTML_ARTIFACT,
+    storageKeyPrefix: '',
+    manifest: [],
+    tier: 'user',
+    scopeId: 's',
+    slug: 'rhtml',
+    ...over,
+  });
+
+  it('renders the reply page with a sandboxed iframe pointing at the ?a= sub-document, not raw markup', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlReply());
+    const { res, promise } = run(['r', 'rhtml']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain('sandbox="allow-scripts"');
+    expect(data).toContain('src="/p/r/rhtml?a=0"');
+    // The artifact's inner markup must NOT leak into the reply page as text.
+    expect(data).not.toContain('<label>Bill</label>');
+    // Page itself stays script-free; the frame is permitted via frame-src.
+    const csp = res.getHeader('Content-Security-Policy') as string;
+    expect(csp).toContain("script-src 'none'");
+    expect(csp).toContain("frame-src 'self'");
+  });
+
+  it('recovers a sensible <title> when the stored title is the raw <artifact> tag', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlReply());
+    const { res, promise } = run(['r', 'rhtml']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain('<title>Tip Calculator</title>');
+    expect(data).not.toContain('<title>&lt;artifact');
+  });
+
+  it('serves the ?a= sub-document as a sandboxed HTML doc that runs the artifact JS in isolation', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlReply());
+    const { res, promise } = run(['r', 'rhtml'], { a: '0' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('Content-Type')).toContain('text/html');
+    const data = res._getData() as string;
+    expect(data).toContain('window.ok=1'); // author script preserved (runs in the sandbox)
+    expect(data).toContain('Bill');
+    const csp = res.getHeader('Content-Security-Policy') as string;
+    // Opaque origin even on direct nav; author inline JS allowed only inside the sandbox.
+    expect(csp).toContain('sandbox allow-scripts');
+    expect(csp).toContain("script-src 'unsafe-inline'");
+    expect(csp).not.toContain("script-src 'none'");
+  });
+
+  it('404s an out-of-range ?a= index', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlReply());
+    const { res, promise } = run(['r', 'rhtml'], { a: '7' });
+    await promise;
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('renders a placeholder card (no iframe) for a non-embeddable artifact type, and 404s its ?a=', async () => {
+    const reactReply = htmlReply({
+      publicId: 'rreact',
+      slug: 'rreact',
+      title: 'React demo',
+      renderedBody:
+        '<artifact identifier="c" type="application/vnd.ant.react" title="Counter">export default function C(){return null}</artifact>',
+    });
+    mockArtifactFindOne.mockReturnValue(reactReply);
+
+    const { res: pageRes, promise: pagePromise } = run(['r', 'rreact']);
+    await pagePromise;
+    const page = pageRes._getData() as string;
+    expect(page).toContain('b4m-artifact-card');
+    expect(page).not.toContain('<iframe');
+
+    const { res: subRes, promise: subPromise } = run(['r', 'rreact'], { a: '0' });
+    await subPromise;
+    expect(subRes._getStatusCode()).toBe(404);
+  });
+
+  it('renders a placeholder card (not a frame) for a Bearer-gated org reply, since the iframe could not authorize', async () => {
+    // An org-visibility reply authorizes off req.user (Bearer). An artifact iframe navigation
+    // cannot send that header, so framing would dead-end at a nested loader shell - render the
+    // card instead. (Public + share + passphrase-cookie cases still frame; covered elsewhere.)
+    const gated = htmlReply({
+      publicId: 'r-org-html',
+      slug: 'r-org-html',
+      visibility: 'organization',
+      tier: 'organization',
+      scopeId: 'org_42',
+    });
+    mockArtifactFindOne.mockReturnValue(gated);
+    const { res, promise } = run(['r', 'r-org-html'], { user: { id: 'member', organizationId: 'org_42' } });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain('b4m-artifact-card');
+    expect(data).not.toContain('<iframe');
+  });
+
+  it('frames the artifact on a /a/{token} share, pointing the iframe back at the token path', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlReply({ publicId: 'r-shared', slug: 'r-shared' }));
+
+    const { res: pageRes, promise: pagePromise } = run(['a', 'tokshare']);
+    await pagePromise;
+    expect(pageRes._getStatusCode()).toBe(200);
+    const page = pageRes._getData() as string;
+    expect(page).toContain('src="/a/tokshare?a=0"');
+
+    const { res: subRes, promise: subPromise } = run(['a', 'tokshare'], { a: '0' });
+    await subPromise;
+    expect(subRes._getStatusCode()).toBe(200);
+    expect(subRes._getData() as string).toContain('window.ok=1');
+  });
+
+  it('serves an embedded SVG artifact sub-document with its markup (viewBox case preserved)', async () => {
+    const svgReply = htmlReply({
+      publicId: 'rsvg',
+      slug: 'rsvg',
+      title: 'A drawing',
+      renderedBody:
+        '<artifact identifier="s" type="image/svg+xml" title="Circle">' +
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>' +
+        '</artifact>',
+    });
+    mockArtifactFindOne.mockReturnValue(svgReply);
+
+    const { res: pageRes, promise: pagePromise } = run(['r', 'rsvg']);
+    await pagePromise;
+    expect(pageRes._getData() as string).toContain('src="/p/r/rsvg?a=0"');
+
+    const { res: subRes, promise: subPromise } = run(['r', 'rsvg'], { a: '0' });
+    await subPromise;
+    expect(subRes._getStatusCode()).toBe(200);
+    const svg = subRes._getData() as string;
+    expect(svg).toContain('<circle');
+    // camelCase SVG attributes must survive the cheerio round-trip, or the SVG renders broken.
+    expect(svg).toContain('viewBox');
   });
 });
 

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -452,8 +452,8 @@ describe('GET /api/publish/serve - ?raw=1 authenticated render mode', () => {
   });
 });
 
-describe('GET /api/publish/serve - reply/fabfile plain render (no embedded artifact)', () => {
-  it('renders a public reply with script-src none and no artifact iframe', async () => {
+describe('GET /api/publish/serve - reply/fabfile path is unchanged', () => {
+  it('renders a public reply with script-src none (not the iframe path)', async () => {
     mockArtifactFindOne.mockReturnValue({
       publicId: 'r1',
       title: 'A reply',
@@ -635,41 +635,6 @@ describe('GET /api/publish/serve - reply embedded HTML artifact (#708)', () => {
     expect(svg).toContain('<circle');
     // camelCase SVG attributes must survive the cheerio round-trip, or the SVG renders broken.
     expect(svg).toContain('viewBox');
-  });
-
-  it('renders an embedded HTML artifact in a fabfile viewer too, framed at /p/f/{id}?a=0', async () => {
-    const fabReply = htmlReply({ publicId: 'f-html', slug: 'f-html', source: { kind: 'fabfile' } });
-    mockArtifactFindOne.mockReturnValue(fabReply);
-
-    const { res: pageRes, promise: pagePromise } = run(['f', 'f-html']);
-    await pagePromise;
-    expect(pageRes._getStatusCode()).toBe(200);
-    const page = pageRes._getData() as string;
-    expect(page).toContain('sandbox="allow-scripts"');
-    expect(page).toContain('src="/p/f/f-html?a=0"');
-    expect(page).not.toContain('<label>Bill</label>'); // no raw markup leak in the <pre>
-
-    const { res: subRes, promise: subPromise } = run(['f', 'f-html'], { a: '0' });
-    await subPromise;
-    expect(subRes._getStatusCode()).toBe(200);
-    expect(subRes._getData() as string).toContain('window.ok=1');
-  });
-
-  it('renders remaining fabfile text as escaped <pre> alongside the framed artifact', async () => {
-    const fab = htmlReply({
-      publicId: 'f-mixed',
-      slug: 'f-mixed',
-      source: { kind: 'fabfile' },
-      renderedBody: 'plain notes line\n' + HTML_ARTIFACT,
-    });
-    mockArtifactFindOne.mockReturnValue(fab);
-
-    const { res, promise } = run(['f', 'f-mixed']);
-    await promise;
-    const page = res._getData() as string;
-    expect(page).toContain('b4m-pre'); // fabfile text stays in a <pre>, not markdown-rendered
-    expect(page).toContain('plain notes line');
-    expect(page).toContain('src="/p/f/f-mixed?a=0"');
   });
 });
 

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -452,8 +452,8 @@ describe('GET /api/publish/serve - ?raw=1 authenticated render mode', () => {
   });
 });
 
-describe('GET /api/publish/serve - reply/fabfile path is unchanged', () => {
-  it('renders a public reply with script-src none (not the iframe path)', async () => {
+describe('GET /api/publish/serve - reply/fabfile plain render (no embedded artifact)', () => {
+  it('renders a public reply with script-src none and no artifact iframe', async () => {
     mockArtifactFindOne.mockReturnValue({
       publicId: 'r1',
       title: 'A reply',
@@ -635,6 +635,41 @@ describe('GET /api/publish/serve - reply embedded HTML artifact (#708)', () => {
     expect(svg).toContain('<circle');
     // camelCase SVG attributes must survive the cheerio round-trip, or the SVG renders broken.
     expect(svg).toContain('viewBox');
+  });
+
+  it('renders an embedded HTML artifact in a fabfile viewer too, framed at /p/f/{id}?a=0', async () => {
+    const fabReply = htmlReply({ publicId: 'f-html', slug: 'f-html', source: { kind: 'fabfile' } });
+    mockArtifactFindOne.mockReturnValue(fabReply);
+
+    const { res: pageRes, promise: pagePromise } = run(['f', 'f-html']);
+    await pagePromise;
+    expect(pageRes._getStatusCode()).toBe(200);
+    const page = pageRes._getData() as string;
+    expect(page).toContain('sandbox="allow-scripts"');
+    expect(page).toContain('src="/p/f/f-html?a=0"');
+    expect(page).not.toContain('<label>Bill</label>'); // no raw markup leak in the <pre>
+
+    const { res: subRes, promise: subPromise } = run(['f', 'f-html'], { a: '0' });
+    await subPromise;
+    expect(subRes._getStatusCode()).toBe(200);
+    expect(subRes._getData() as string).toContain('window.ok=1');
+  });
+
+  it('renders remaining fabfile text as escaped <pre> alongside the framed artifact', async () => {
+    const fab = htmlReply({
+      publicId: 'f-mixed',
+      slug: 'f-mixed',
+      source: { kind: 'fabfile' },
+      renderedBody: 'plain notes line\n' + HTML_ARTIFACT,
+    });
+    mockArtifactFindOne.mockReturnValue(fab);
+
+    const { res, promise } = run(['f', 'f-mixed']);
+    await promise;
+    const page = res._getData() as string;
+    expect(page).toContain('b4m-pre'); // fabfile text stays in a <pre>, not markdown-rendered
+    expect(page).toContain('plain notes line');
+    expect(page).toContain('src="/p/f/f-mixed?a=0"');
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

https://github.com/user-attachments/assets/0a66fdd8-df42-43b9-b775-6424220ac896

## Description

Closes #708. The published reply viewer (`/p/r/{publicId}`) rendered the snapshotted reply
body as plain markdown and never recognized an embedded `<artifact type="text/html">...</artifact>`
block. The artifact's inner markup fell through into the page as inert text (raw `<label>`,
`<input>`, `<script>` tags on screen), and a reply that led with an artifact took the raw
`<artifact ...>` wrapper tag as its page `<title>`. Only the reply/fabfile viewer was affected;
the interactive bundle path (`/p/{tier}/{scopeId}/{slug}`) already sandboxes artifacts correctly.

This PR teaches the reply viewer to extract embedded artifacts and render each HTML/SVG one in
its own sandboxed iframe, while keeping the reply page itself script-free. The key constraint from
the issue is honored: artifact JavaScript never runs on the reply page's origin. Instead of a
`srcdoc` iframe (which would inherit the page's `script-src 'none'` and be blocked), each HTML/SVG
artifact is served from its own URL on the same route the page was reached at
(`/p/r/{publicId}?a={i}`, or `/a/{token}?a={i}` for a share link) with its own `sandbox allow-scripts`
CSP - an opaque origin even on direct navigation, so the artifact can never read the app origin's
token. This mirrors the isolation model the bundle path already relies on.

Scope is the reply (`/p/r`) path - the reported and reproducible case. The fabfile (`/p/f`) viewer
shares this render path, but its publish flow has no UI trigger and stores an empty body today
(the endpoint reads `file.text`, which is empty for uploads whose content lives at `fileUrl`), so
there is no way to exercise a fabfile-with-artifact end to end. Extending the fix to fabfiles
(plus sourcing their body from `fileUrl`) is tracked in #722.

## Changes

- **`serve/[...path].ts`**
  - New `?a={index}` sub-document mode (reply): extracts the i-th embedded artifact from the reply
    body and serves the HTML/SVG one as a standalone sandboxed document via the existing
    `renderSandboxedBundle` serializer, with a `sandbox allow-scripts` CSP (opaque origin, no
    `allow-same-origin`). Out-of-range or non-embeddable indices return 404.
  - `renderViewerPage` now extracts `<artifact>` blocks with `parseArtifactsWithFallback`, renders
    the surrounding prose as before, and emits one sandboxed `<iframe src=".../?a=i">` per HTML/SVG
    artifact. Non-embeddable types (react/code/python/mermaid/recharts) get a clean placeholder
    card instead of leaking raw markup.
  - `canFrameArtifacts` gate: an artifact is framed only when the `?a=` sub-request can authorize
    on its own - open-public (no gate), a `/a/{token}` share (token in the path), or a
    passphrase-satisfied page (proof cookie). Bearer-gated org/domain replies render the placeholder
    card instead, since an iframe navigation can't carry the Authorization header.
  - `cleanViewerTitle` recovers a sensible `<title>` for existing rows whose stored title is the raw
    `<artifact>` tag.
  - Reply page CSP keeps `script-src 'none'` and adds `frame-src`/`child-src 'self'` so only the
    sandboxed artifact frame is permitted.
- **`reply.ts`**
  - `deriveTitle` strips embedded artifact blocks before picking the first line, so new publishes
    never snapshot the raw `<artifact>` tag as the title (falls back to the artifact's own title
    attribute when the reply is nothing but an artifact).

## Tests

- Reply with an embedded HTML artifact renders a sandboxed iframe pointing at `?a=0` (not raw markup).
- `<title>` is recovered when the stored title is the raw `<artifact>` tag.
- The `?a=` sub-document is served as sandboxed HTML that preserves the author script, with a
  `sandbox allow-scripts` CSP (and never `script-src 'none'`).
- Out-of-range `?a=` index returns 404.
- Non-embeddable artifact type renders a placeholder card (no iframe) and its `?a=` returns 404.
- Bearer-gated org reply renders the placeholder card (no iframe).
- `/a/{token}` share frames the artifact back at the token path and serves the sub-document.
- Embedded SVG sub-document preserves camelCase `viewBox` (guards the cheerio round-trip).

## Guide for Testers

1. Open a chat and send: `Build me a self-contained tip calculator as a single HTML file: a bill-amount input, a tip-percentage input, and a live-updating total. Put all CSS and JS inline in one document. Return only the HTML artifact, no explanation.`
2. Confirm the reply renders as an interactive HTML artifact in the app.
3. On that assistant message, open the `...` (More options) menu and click **Share** (the share-icon entry). Do NOT use "Publish" (that is the interactive bundle path and is not what this PR changes).
4. In the dialog, choose **Public** and confirm. Copy the returned `/p/r/{id}` link.
5. Open the `/p/r/{id}` link (use the preview link environment) in a new tab.
6. Expected: the tip calculator renders as a working widget inside a framed area, NOT as raw `<label>`/`<input>`/`<script>` text.
7. Expected: the browser tab `<title>` is a sensible title (e.g. the artifact's title), NOT a literal `<artifact ...>` string.

### Regression Checks

1. Publish a plain-text/markdown reply (no artifact) and open its `/p/r/` link - it renders as before, with no empty frames.
2. Publish an assistant reply containing a React (or Python/code) artifact - the reply page shows a clean placeholder card ("... artifact - open in the app to view"), not raw markup or a broken frame.
3. Open an existing interactive bundle share (`/p/{tier}/{scope}/{slug}`) - unchanged, still renders in its sandboxed iframe.

### What NOT to test

- The interactive bundle path behavior (`/p/{tier}/{scope}/{slug}`) - not modified here.
- Fabfile viewer (`/p/f/...`) rendering of embedded artifacts - out of scope for this PR (no publish UI, empty body today); tracked in #722.

## Additional Information

Security model: the reply page stays `script-src 'none'`, so any markup that slips past the
sanitizer still cannot execute on the app origin. Embedded artifact JS runs only inside the `?a=`
sub-document, which is served with a `sandbox allow-scripts` CSP - forcing an opaque origin (no
`allow-same-origin`) even on direct navigation, so it can never reach the app origin's
token/cookies. This is the same isolation posture the bundle path uses.

Behavior alignment (not a bug): the viewer uses `parseArtifactsWithFallback` (the same extractor the
in-app renderer uses), so a published reply now promotes bare fenced blocks (```html / ```svg, and
```tsx / ```python when the heuristics fire) into artifacts too - e.g. a fenced python block renders
as a placeholder card rather than a syntax-highlighted code block. This is intentional (the viewer
matches the app), but it does change how a pre-existing reply containing such fences renders.

Intended behavior (not a bug): a Bearer-gated reply (organization/domain visibility) opened at
`/p/r/...` shows the placeholder card rather than the live widget. Such a reply is viewed through
the loader shell, and the artifact iframe's `?a=` sub-request cannot carry the Authorization header,
so framing would dead-end. Public replies and `/a/{token}` shares (and passphrase-gated pages via
the proof cookie) render the live artifact. Fully closing the Bearer-gated case is a follow-up.

## Developer Notes (Optional)

- The `?a={index}` sub-document pattern is a reusable way to render a single sandboxed artifact
  extracted from a larger snapshotted body, without a separate published bundle.
- `canFrameArtifacts` documents exactly which gate kinds an iframe sub-request can satisfy
  (path-token, proof-cookie, or no gate) versus which cannot (Bearer/`req.user`), a distinction that
  applies to any future embedded-subresource-behind-a-gate feature.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
