### PR TITLE
feat(agent): inject the active brief into the opti loop's observations (#57)

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -84,6 +84,7 @@ import { selectGatedAction } from './agentExecutorUtils/toolPermissions';
 import { guardDecomposeOnce } from './agentExecutorUtils/decomposeGuard';
 import { buildTruncatedRunReply } from './agentExecutorUtils/truncatedReply';
 import { guardPlanCompletion, type PlanProgressState } from './agentExecutorUtils/planCompletionGuard';
+import { injectBriefContext } from './agentExecutorUtils/briefContextInjector';
 import { buildDagResumeReport, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
 import { collectDagChildArtifactBlocks } from './agentExecutor.dagArtifacts';
 import type { DagHandoffSignal } from '@bike4mind/services';
@@ -1243,12 +1244,18 @@ async function processExecution(
     // -- which has no reliable memory of which steps it finished -- re-does solved families until
     // it hits the iteration ceiling. Both are inert on non-opti runs (decompose isn't offered).
     const planProgress: PlanProgressState = { needed: null, solved: {} };
-    const guardedPremiumTools = guardPlanCompletion(
-      guardDecomposeOnce(premiumLlmTools, decomposeGuard, () =>
-        logger.info('[opti] blocked a repeat optihashi_decompose call (advancing existing plan)', { executionId })
-      ),
-      planProgress,
-      () => logger.info('[opti] plan complete -- all planned steps solved; steering to final summary', { executionId })
+    // Outermost: give the loop the real active brief in-context (#57) so it passes the exact
+    // problem to solve/edit instead of reconstructing it. Wraps the guarded tools last, so it
+    // augments real tool observations and leaves guard redirects (non-envelope strings) untouched.
+    const guardedPremiumTools = injectBriefContext(
+      guardPlanCompletion(
+        guardDecomposeOnce(premiumLlmTools, decomposeGuard, () =>
+          logger.info('[opti] blocked a repeat optihashi_decompose call (advancing existing plan)', { executionId })
+        ),
+        planProgress,
+        () =>
+          logger.info('[opti] plan complete -- all planned steps solved; steering to final summary', { executionId })
+      )
     );
 
     const tools = buildSharedTools({ ...toolDeps, optInTools: subagentLatticeTools }, toolCallbacks, {

--- a/apps/client/server/queueHandlers/agentExecutorUtils/briefContextInjector.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/briefContextInjector.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import type { ToolDefinition } from '@bike4mind/services';
+import { injectBriefContext, appendBriefToObservation, extractLoadedProblem } from './briefContextInjector';
+
+const familyEnvelope = (problem: unknown, displayMessage = 'summary') =>
+  JSON.stringify({
+    __uiSideEffect: true,
+    type: 'populateFamilyProblem',
+    payload: { familyId: 'routing', problem },
+    displayMessage,
+  });
+const schedulingEnvelope = (problem: unknown) =>
+  JSON.stringify({ __uiSideEffect: true, type: 'populateProblem', payload: problem, displayMessage: 'sched' });
+const decompEnvelope = (instances: unknown[]) =>
+  JSON.stringify({
+    __uiSideEffect: true,
+    type: 'populateDecomposition',
+    payload: { decomposition: { steps: [] }, instances },
+    displayMessage: 'loaded step 1',
+  });
+
+function fakeTool(name: string, result: string): { tool: ToolDefinition; calls: unknown[] } {
+  const calls: unknown[] = [];
+  const tool = {
+    name,
+    implementation: () => ({
+      toolFn: async (p?: unknown) => {
+        calls.push(p);
+        return result;
+      },
+      toolSchema: { name, description: '', parameters: { type: 'object', properties: {} } },
+    }),
+  } as unknown as ToolDefinition;
+  return { tool, calls };
+}
+const run = (t: ToolDefinition, p?: unknown) => t.implementation({} as never, undefined).toolFn(p);
+
+describe('extractLoadedProblem', () => {
+  it('reads the problem from each populate* payload shape', () => {
+    expect(extractLoadedProblem('populateProblem', { name: 'S' })).toEqual({ name: 'S' });
+    expect(
+      extractLoadedProblem('populateFamilyProblem', { familyId: 'routing', problem: { family: 'routing' } })
+    ).toEqual({ family: 'routing' });
+    expect(
+      extractLoadedProblem('populateDecomposition', { instances: [{ problem: { family: 'scheduling' } }] })
+    ).toEqual({ family: 'scheduling' });
+  });
+  it('returns null for plan-only decomposition (instances[0] === null) and unknown types', () => {
+    expect(extractLoadedProblem('populateDecomposition', { instances: [null] })).toBeNull();
+    expect(extractLoadedProblem('somethingElse', { problem: {} })).toBeNull();
+  });
+});
+
+describe('appendBriefToObservation', () => {
+  it('appends the exact family problem JSON + a solve hint naming the family', () => {
+    const out = appendBriefToObservation(familyEnvelope({ family: 'routing', name: 'Route' }));
+    const env = JSON.parse(out);
+    expect(env.type).toBe('populateFamilyProblem'); // envelope + payload preserved
+    expect(env.payload.problem).toEqual({ family: 'routing', name: 'Route' });
+    expect(env.displayMessage).toContain('ACTIVE BRIEF');
+    expect(env.displayMessage).toContain('"family":"routing"');
+    expect(env.displayMessage).toMatch(/optihashi_solve.*"family" is already "routing"/s);
+    expect(env.displayMessage).toContain('summary'); // original summary retained
+  });
+
+  it('uses the scheduling hint for a populateProblem (no family field)', () => {
+    const out = appendBriefToObservation(schedulingEnvelope({ name: 'Shop', jobs: [] }));
+    expect(JSON.parse(out).displayMessage).toMatch(/optihashi_schedule/);
+  });
+
+  it('appends step-1 brief from a decomposition', () => {
+    const out = appendBriefToObservation(decompEnvelope([{ problem: { family: 'scheduling', name: 'Seq' } }]));
+    expect(JSON.parse(out).displayMessage).toContain('"name":"Seq"');
+  });
+
+  it('leaves plan-only decompositions, non-envelopes, and problemless envelopes untouched', () => {
+    const planOnly = decompEnvelope([null]);
+    expect(appendBriefToObservation(planOnly)).toBe(planOnly);
+    expect(appendBriefToObservation('Error: could not formulate')).toBe('Error: could not formulate');
+    const noProblem = JSON.stringify({
+      __uiSideEffect: true,
+      type: 'populateProblem',
+      payload: null,
+      displayMessage: 'x',
+    });
+    expect(appendBriefToObservation(noProblem)).toBe(noProblem);
+  });
+});
+
+describe('injectBriefContext', () => {
+  it('augments brief-setting tool observations and passes other tools through', async () => {
+    const formulate = fakeTool('optihashi_formulate', familyEnvelope({ family: 'selection', name: 'Pick' }));
+    const solve = fakeTool('optihashi_solve', '## Results ...');
+    const g = injectBriefContext({
+      optihashi_formulate: formulate.tool,
+      optihashi_solve: solve.tool,
+      optihashi_decompose: fakeTool('optihashi_decompose', '{}').tool,
+    });
+
+    const formOut = await run(g.optihashi_formulate);
+    expect(JSON.parse(formOut).displayMessage).toContain('ACTIVE BRIEF');
+    // solve is not a brief-setter -> untouched
+    expect(await run(g.optihashi_solve)).toBe('## Results ...');
+  });
+
+  it('returns the map unchanged for a non-opti run (no formulate/decompose)', () => {
+    const map = { web_search: fakeTool('web_search', 'ok').tool };
+    expect(injectBriefContext(map)).toBe(map);
+  });
+});

--- a/apps/client/server/queueHandlers/agentExecutorUtils/briefContextInjector.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/briefContextInjector.ts
@@ -1,0 +1,103 @@
+import type { ToolDefinition } from '@bike4mind/services';
+
+type ToolFn = (parameters?: unknown, apiKey?: string) => Promise<string>;
+
+/**
+ * Tools whose result loads or updates the active brief that the NEXT tool call must reference
+ * (optihashi_solve / optihashi_schedule take the problem as `problem`; optihashi_edit_problem
+ * takes it as `currentProblem`).
+ */
+const BRIEF_SETTING_TOOLS = ['optihashi_formulate', 'optihashi_decompose', 'optihashi_edit_problem'] as const;
+
+/** Pull the loaded problem out of a `populate*` side-effect payload. Null if there isn't one. */
+export function extractLoadedProblem(type: unknown, payload: unknown): unknown {
+  if (type === 'populateProblem') return payload ?? null; // scheduling problem IS the payload
+  if (type === 'populateFamilyProblem') return (payload as { problem?: unknown } | null)?.problem ?? null;
+  if (type === 'populateDecomposition') {
+    // Decompose loads step 1 as the active brief; its instance is instances[0] (null if plan-only).
+    const inst = (payload as { instances?: Array<{ problem?: unknown } | null> } | null)?.instances?.[0];
+    return inst?.problem ?? null;
+  }
+  return null;
+}
+
+function familyOf(problem: unknown): string | undefined {
+  const f = (problem as { family?: unknown } | null)?.family;
+  return typeof f === 'string' ? f : undefined;
+}
+
+/**
+ * Append the loaded brief's exact JSON to a tool observation, so the agent passes the real problem
+ * verbatim to the next solve/edit call instead of reconstructing it from a summary (the drain that
+ * produced wrong field names, e.g. `capacity` vs `budget`). The side-effect envelope's `payload` is
+ * left untouched (the client still gets the correct UI update); only `displayMessage` -- what the
+ * agent reads as the observation -- is augmented. Non-envelope results (e.g. `Error: ...` or a
+ * guard redirect) are returned unchanged.
+ */
+export function appendBriefToObservation(result: string): string {
+  let env: { __uiSideEffect?: unknown; type?: unknown; payload?: unknown; displayMessage?: unknown };
+  try {
+    env = JSON.parse(result);
+  } catch {
+    return result;
+  }
+  if (!env || env.__uiSideEffect !== true) return result;
+
+  const problem = extractLoadedProblem(env.type, env.payload);
+  if (problem == null || typeof problem !== 'object') return result;
+
+  const fam = familyOf(problem);
+  const passHint = fam
+    ? `Pass this EXACT object as \`problem\` to optihashi_solve (its "family" is already "${fam}").`
+    : 'Pass this EXACT object as `problem` to optihashi_schedule (this is a scheduling problem).';
+  const brief = [
+    '',
+    '---',
+    'ACTIVE BRIEF (now loaded). Do NOT retype or reconstruct it -- copy it verbatim from here:',
+    '```json',
+    JSON.stringify(problem),
+    '```',
+    `${passHint} To adjust it, pass the same object as \`currentProblem\` to optihashi_edit_problem.`,
+  ].join('\n');
+
+  const displayMessage = typeof env.displayMessage === 'string' ? env.displayMessage : '';
+  return JSON.stringify({ ...env, displayMessage: displayMessage + brief });
+}
+
+function wrap(tool: ToolDefinition, makeFn: (run: ToolFn) => ToolFn): ToolDefinition {
+  return {
+    ...tool,
+    implementation: (context, config) => {
+      const inner = tool.implementation(context, config);
+      return { ...inner, toolFn: makeFn(inner.toolFn as ToolFn) };
+    },
+  };
+}
+
+/**
+ * Give the autonomous opti loop the real active brief in-context (#57).
+ *
+ * In agent mode the opti tools populate the CLIENT-side brief via UI side-effects, but the side-
+ * effect extractor replaces the agent's observation with just the human-readable summary -- the
+ * full problem JSON is stripped. So when the agent then calls optihashi_solve/edit (which require
+ * the problem as an argument), it reconstructs it from the summary and gets fields wrong, forcing a
+ * retry. This wraps the brief-setting tools so their observation also carries the exact problem JSON
+ * for the agent to copy verbatim.
+ *
+ * Host-side and applied only in the agent-executor tool path, so the guided chat flow (which reaches
+ * the overlay tools directly) is unaffected -- no JSON blob in normal chat. Returns a NEW map;
+ * inert for non-opti runs.
+ */
+export function injectBriefContext(tools: Record<string, ToolDefinition>): Record<string, ToolDefinition> {
+  if (!tools['optihashi_formulate'] && !tools['optihashi_decompose']) return tools;
+  const guarded = { ...tools };
+  for (const name of BRIEF_SETTING_TOOLS) {
+    const tool = tools[name];
+    if (!tool) continue;
+    guarded[name] = wrap(
+      tool,
+      run => async (parameters, apiKey) => appendBriefToObservation(await run(parameters, apiKey))
+    );
+  }
+  return guarded;
+}


### PR DESCRIPTION
Implements Bike4Mind/b4m-optihashi#57 (host-side); relates to #108 (agent-context parity).

## Problem
In agent mode the opti tools populate the client-side active brief via UI side-effects, but the side-effect extractor replaces the agent's observation with only the human summary -- the full problem JSON is stripped. So when the agent then calls `optihashi_solve` / `optihashi_edit_problem` (which require the problem as an argument), it reconstructs it from the summary and gets fields wrong (e.g. `capacity` vs `budget`), forcing a retry that burns an iteration. This is the "Retried" chip pattern seen on every multi-step run.

## Fix
A host-side wrapper (`agentExecutorUtils/briefContextInjector.ts`, sibling to the plan-completion guard) appends the **loaded brief's exact JSON** to the `formulate` / `decompose` / `edit` observations, labeled "pass this EXACT object to solve/schedule/edit," so the agent copies the real problem verbatim.

- The side-effect **payload is untouched** (client UI unchanged); only `displayMessage` -- what the agent reads -- is augmented.
- Applied **only in the agent-executor tool path**, so the guided chat flow (which reaches the overlay tools directly) is unaffected: no JSON blob in normal chat.
- Composed **outermost** so guard redirects (non-envelope strings from #666 / plan-completion) pass through untouched.

## Why host-side (not the overlay tool)
The reconstruct-retry only happens in agent mode, and we don't want to pollute guided-mode chat with a JSON blob. Wrapping in the executor scopes it precisely to the agent path. ReActAgent's `run()` owns the loop and `AgentRunOptions.context` is static per-run, so there's no clean per-iteration host hook and a core change would touch every agent.

## Tests (`briefContextInjector.test.ts`, 8)
Payload extraction per shape (populateProblem / populateFamilyProblem / populateDecomposition), append with family vs scheduling hints, step-1 brief from a decomposition, and pass-through for plan-only / non-envelope / problemless results; wrapper augments brief-setters + passes other tools through. Full `agentExecutorUtils` suite green (42).

## Guide for Testers
1. Agent mode on `/opti`, a multi-step scenario (warehouse: sequence / prioritize / route).
2. Fewer or no "Retried" chips on the solve steps -- the agent should pass the correct problem the first time (no more `capacity` vs `budget` field-name fixes).
3. The formulate/decompose observation now shows an "ACTIVE BRIEF ... copy it verbatim" block with the problem JSON.
4. Regression: guided mode (agent mode OFF) chat is unchanged -- no JSON blob appended to formulate replies.