### PR TITLE
ci(release): restore npm publishing (ENEEDAUTH guard, changelog repo, cli provenance casing)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "changelog": ["./changelog-github-retry.cjs", { "repo": "MillionOnMars/lumina5" }],
+  "changelog": ["./changelog-github-retry.cjs", { "repo": "Bike4Mind/bike4mind" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -281,6 +281,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # Publishing is OIDC-only (no token fallback), so a package missing its npm
+      # Trusted Publisher fails with ENEEDAUTH mid-publish - which changesets/action
+      # surfaces only as a bare red step. Spell out the fix so a broken release is
+      # self-diagnosing. (changesets/action doesn't expose per-package output here,
+      # so this is generic; the snapshot path names the exact packages.)
+      - name: Explain a likely npm auth failure
+        if: failure() && steps.changesets.outcome == 'failure'
+        run: |
+          echo "::error title=npm publish may have failed auth (ENEEDAUTH)::If the step above failed while publishing, a package is likely missing its npm Trusted Publisher (publishing is OIDC-only, no token fallback). Configure each published package at npmjs.com/package/<pkg>/access -> Trusted Publisher: Organization=Bike4Mind, Repository=bike4mind, Workflow=release.yaml, Environment=blank. Note: npm allows only ONE trusted publisher per package and it must point at THIS file (release.yaml)."
+
   # Snapshot (prerelease) publish for feature branches, triggered when the
   # "Branch Tests" workflow completes successfully. It lives in this file so
   # npm's single trusted publisher (this workflow) covers snapshot publishes

--- a/.github/workflows/snapshot-publish.yaml
+++ b/.github/workflows/snapshot-publish.yaml
@@ -235,7 +235,16 @@ jobs:
 
             # Retry only the transient registry race; surface anything else immediately.
             if ! grep -qiE 'E409|409 Conflict|packument' /tmp/publish-attempt.txt; then
-              echo "::error::changeset publish failed with a non-transient error (not an npm E409 packument race) — not retrying"
+              # ENEEDAUTH means npm had NO usable credential for the package. Since
+              # publishing is OIDC-only (no token, see release.yaml), this is almost
+              # always a missing npm Trusted Publisher on that package. Translate the
+              # cryptic error into the exact fix instead of a bare "non-transient" note.
+              if grep -qi 'ENEEDAUTH' /tmp/publish-attempt.txt; then
+                MISSING=$(grep -i 'ENEEDAUTH' /tmp/publish-attempt.txt | grep -oE '@bike4mind/[a-z-]+' | sort -u | tr '\n' ' ')
+                echo "::error title=npm Trusted Publisher missing::OIDC publish failed with ENEEDAUTH (no credential) for: ${MISSING:-one or more packages}. Publishing is OIDC-only with no token fallback, so each package needs a Trusted Publisher at npmjs.com/package/<pkg>/access -> Trusted Publisher: Organization=Bike4Mind, Repository=bike4mind, Workflow=release.yaml, Environment=blank."
+              else
+                echo "::error::changeset publish failed with a non-transient error (not an npm E409 packument race) — not retrying"
+              fi
               break
             fi
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "author": "Bike4Mind",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bike4mind/bike4mind.git"
+    "url": "git+https://github.com/Bike4Mind/bike4mind.git"
   },
   "homepage": "https://github.com/bike4mind/bike4mind#readme",
   "bugs": "https://github.com/bike4mind/bike4mind/issues",


### PR DESCRIPTION
Three release-pipeline fixes surfaced while restoring npm publishing (it had been failing since the Trusted Publishing / OIDC cutover, masked by manual publishes).

## 1. Surface ENEEDAUTH as a missing npm Trusted Publisher

Publishing is OIDC-only (no token fallback). A package with no configured Trusted Publisher fails mid-publish with `ENEEDAUTH`, which today surfaces only as a bare red step - easy to mistake for the transient E409 packument race the snapshot job already retries on.

- `snapshot-publish.yaml`: the non-transient bail branch now detects `ENEEDAUTH`, extracts the affected `@bike4mind/*` package names, and emits a `::error::` naming them plus the exact Trusted Publisher config to add.
- `release.yaml`: an `if: failure()` step after the changesets publish prints the same remediation for the stable path.

Messages are built only from publish-step output (no untrusted event input). npm validates the top-level workflow filename for Trusted Publishing; this edits only the body of `release.yaml`, not its name, so OIDC trust is unaffected.

## 2. Fix the changeset changelog repo pointer

`.changeset/config.json` pointed the changelog generator at `MillionOnMars/lumina5`, which no longer resolves - every release/snapshot run logged `Could not resolve to a Repository` and produced broken changelog links. Now points at `Bike4Mind/bike4mind`.

## 3. Fix @bike4mind/cli repository.url casing for provenance

`cli` is the only public package, so npm auto-attaches sigstore provenance on OIDC publish and validates `package.json` `repository.url` against the workflow's repository claim (`Bike4Mind/bike4mind`, canonical casing). The URL was lowercase `bike4mind`, so publish failed with `E422 Failed to validate repository information`. Casing now matches.

## Notes

No behavior change on the happy path; all three are correctness/observability fixes for the release pipeline.
