### PR TITLE
feat(api): return ready-to-use image URLs from the quest poll endpoint

### DIFF
--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -152,15 +152,19 @@ GET /api/quests/[id]
     "artifacts": []
   },
   "images": ["a1b2c3.png"],
-  "imageUrls": ["https://cdn.example.com/generated/a1b2c3.png"],
+  "files": [
+    { "name": "a1b2c3.png", "url": "https://cdn.example.com/generated/a1b2c3.png", "isImage": true }
+  ],
   "createdAt": "2025-01-15T10:30:00Z",
   "completedAt": "2025-01-15T10:30:05Z"
 }
 \`\`\`
 
-For image/file-generating quests, \`images\` lists the generated file basenames and \`imageUrls\`
-lists the same files as ready-to-use CDN URLs (empty until \`status\` is \`done\`). Prefer
-\`imageUrls\` - it saves you having to know the CDN path convention.
+For file-generating quests (image generation, editing, etc.), \`images\` lists the raw generated
+file basenames and \`files\` lists each as a descriptor with a ready-to-use CDN \`url\` and an
+\`isImage\` flag (empty until \`status\` is \`done\`). Prefer \`files\` - it saves you knowing the CDN
+path convention, and \`isImage\` lets you pick out renderable images (not every generated file is
+one, e.g. a spreadsheet export).
 
 #### Get Quest Files
 
@@ -629,7 +633,7 @@ POST /api/ai/generate-image
 Generation is asynchronous - the request enqueues work and returns immediately with a quest
 (no image yet). It never blocks on generation, so it is not subject to the API-gateway request
 timeout. Retrieve the result by polling \`GET /api/quests/{id}\` until \`status\` is \`done\`, then
-read \`imageUrls\` (see [Poll Quest Status](#poll-quest-status)).
+read \`files\` (see [Poll Quest Status](#poll-quest-status)).
 
 **Response:**
 

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -625,7 +625,7 @@ POST /api/ai/generate-image
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | prompt | string | Yes | Image description |
-| model | string | No | Image model identifier |
+| model | string | Yes | Image model identifier (e.g. \`gpt-image-1\`); a request without a supported model is rejected \`422\` |
 | n | number | No | Number of images (1-10) |
 | size | string | No | Image dimensions (e.g. \`1024x1024\`) |
 | sessionId | string | No | Existing session; a new one is created if omitted |

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -151,10 +151,16 @@ GET /api/quests/[id]
     "sources": [],
     "artifacts": []
   },
+  "images": ["a1b2c3.png"],
+  "imageUrls": ["https://cdn.example.com/generated/a1b2c3.png"],
   "createdAt": "2025-01-15T10:30:00Z",
   "completedAt": "2025-01-15T10:30:05Z"
 }
 \`\`\`
+
+For image/file-generating quests, \`images\` lists the generated file basenames and \`imageUrls\`
+lists the same files as ready-to-use CDN URLs (empty until \`status\` is \`done\`). Prefer
+\`imageUrls\` - it saves you having to know the CDN path convention.
 
 #### Get Quest Files
 
@@ -601,6 +607,38 @@ POST /api/ai/llm
 | temperature | number | No | Sampling temperature |
 | maxTokens | number | No | Max output tokens |
 | systemPrompt | string | No | System prompt override |
+
+#### Image Generation (async)
+
+\`\`\`
+POST /api/ai/generate-image
+\`\`\`
+
+**Required API-key scope:** \`ai:generate\`.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| prompt | string | Yes | Image description |
+| model | string | No | Image model identifier |
+| n | number | No | Number of images (1-10) |
+| size | string | No | Image dimensions (e.g. \`1024x1024\`) |
+| sessionId | string | No | Existing session; a new one is created if omitted |
+
+Generation is asynchronous - the request enqueues work and returns immediately with a quest
+(no image yet). It never blocks on generation, so it is not subject to the API-gateway request
+timeout. Retrieve the result by polling \`GET /api/quests/{id}\` until \`status\` is \`done\`, then
+read \`imageUrls\` (see [Poll Quest Status](#poll-quest-status)).
+
+**Response:**
+
+\`\`\`json
+{
+  "quest": { "id": "quest_abc123", "status": "pending" },
+  "session": { "id": "sess_xyz789" }
+}
+\`\`\`
 
 #### AI Endpoints Summary
 

--- a/apps/client/pages/api/ai/__tests__/generate-image.integration.test.ts
+++ b/apps/client/pages/api/ai/__tests__/generate-image.integration.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+/**
+ * Integration test for POST /api/ai/generate-image scope enforcement.
+ *
+ * Drives the real next-connect chain `baseApi` assembles (see quests/[id] and
+ * events integration tests for the rationale) to prove the
+ * `baseApi({ requiredScopes: [AI_GENERATE] })` wiring reaches `apiKeyAuth`: a
+ * key lacking `ai:generate` is rejected 403 before the handler runs (and before
+ * any billable generation is enqueued); a key holding it, and JWT callers, pass
+ * through. This guards a billable + access-control surface against an accidental
+ * future removal of `requiredScopes`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { createMocks } from 'node-mocks-http';
+
+const {
+  mockValidate,
+  mockUserFindById,
+  mockRateLimit,
+  mockGetOrCreateSession,
+  mockInvoke,
+  mockResolveImagePrompt,
+  mockGetRecentHistory,
+} = vi.hoisted(() => ({
+  mockValidate: vi.fn(),
+  mockUserFindById: vi.fn(),
+  mockRateLimit: vi.fn(),
+  mockGetOrCreateSession: vi.fn(),
+  mockInvoke: vi.fn(),
+  mockResolveImagePrompt: vi.fn(),
+  mockGetRecentHistory: vi.fn(),
+}));
+
+const RATE_LIMIT_HEADERS = {
+  'X-RateLimit-Limit-Minute': '60',
+  'X-RateLimit-Remaining-Minute': '59',
+  'X-RateLimit-Reset-Minute': '0',
+  'X-RateLimit-Limit-Day': '1000',
+  'X-RateLimit-Remaining-Day': '999',
+  'X-RateLimit-Reset-Day': '0',
+};
+
+vi.mock('@server/utils/apiKeyRateLimitCheck', () => ({
+  checkApiKeyRateLimit: (...a: unknown[]) => mockRateLimit(...a),
+}));
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('@bike4mind/services', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  return {
+    ...actual,
+    userApiKeyService: {
+      ...(actual.userApiKeyService as object),
+      validateUserApiKey: (...a: unknown[]) => mockValidate(...a),
+    },
+  };
+});
+
+vi.mock('@bike4mind/database', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  const RealUser = actual.User as Record<string, unknown>;
+  return {
+    ...actual,
+    connectDB: vi.fn().mockResolvedValue(undefined),
+    User: Object.assign(Object.create(RealUser), { findById: (...a: unknown[]) => mockUserFindById(...a) }),
+    questRepository: {
+      ...(actual.questRepository as object),
+      getMostRecentChatHistory: (...a: unknown[]) => mockGetRecentHistory(...a),
+    },
+  };
+});
+
+vi.mock('@server/managers/sessionManager', () => ({
+  getOrCreateSession: (...a: unknown[]) => mockGetOrCreateSession(...a),
+}));
+
+vi.mock('@server/queueHandlers/imageGeneration', () => ({
+  getImageGeneration: () => ({ invoke: (...a: unknown[]) => mockInvoke(...a) }),
+}));
+
+vi.mock('@server/utils/resolveImagePrompt', () => ({
+  resolveImagePrompt: (...a: unknown[]) => mockResolveImagePrompt(...a),
+  HISTORY_LOOKBACK: 10,
+}));
+
+const JWT_USER = { id: 'jwt-user', _id: 'jwt-user', isBanned: false, disputePending: false };
+vi.mock('@server/auth/auth', async orig => {
+  const actual = await orig<Record<string, unknown>>();
+  return {
+    ...actual,
+    // any: node-mocks-http req/res aren't structurally the Express types this seam is typed for.
+    auth: (req: any, _res: any, next: any) => {
+      if (!req.user) req.user = JWT_USER;
+      next();
+    },
+  };
+});
+
+import handler from '../generate-image';
+import { ApiKeyScope } from '@bike4mind/common';
+
+const VALID_KEY = 'sk-test-valid-key';
+
+function fire({ apiKey = VALID_KEY as string | null }: { apiKey?: string | null } = {}) {
+  const { req, res } = createMocks(
+    {
+      method: 'POST',
+      url: '/api/ai/generate-image',
+      body: { prompt: 'a red bicycle on a white background' },
+      headers: { ...(apiKey ? { 'x-api-key': apiKey } : {}) },
+    },
+    { eventEmitter: EventEmitter }
+  );
+  // any: node-mocks-http mocks aren't structurally the Express Request/Response types.
+  return { req: req as any, res: res as any };
+}
+
+function validateWithScopes(scopes: ApiKeyScope[] | string[]) {
+  mockValidate.mockResolvedValue({
+    isValid: true,
+    keyId: 'k1',
+    userId: 'user-1',
+    scopes,
+    rateLimit: { requestsPerMinute: 60, requestsPerDay: 1000 },
+  });
+}
+
+describe('POST /api/ai/generate-image (integration — ai:generate scope enforcement)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserFindById.mockResolvedValue({ id: 'user-1', _id: 'user-1', isBanned: false, disputePending: false });
+    mockRateLimit.mockResolvedValue({ allowed: true, retryAfter: undefined, headers: RATE_LIMIT_HEADERS });
+    mockGetRecentHistory.mockResolvedValue([]);
+    mockResolveImagePrompt.mockResolvedValue({ rewrittenPrompt: 'a red bicycle', intent: 'fresh' });
+    mockGetOrCreateSession.mockResolvedValue({
+      sessionId: 'sess-1',
+      asyncPromises: [],
+      session: { id: 'sess-1' },
+    });
+    mockInvoke.mockResolvedValue({ id: 'quest-1', status: 'pending' });
+  });
+
+  it('rejects a key lacking ai:generate (403) before enqueuing generation', async () => {
+    validateWithScopes([ApiKeyScope.READ_FILES]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error).toMatch(/insufficient/i);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('accepts a key with ai:generate (200) and enqueues generation', async () => {
+    validateWithScopes([ApiKeyScope.AI_GENERATE]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({ quest: { id: 'quest-1' } });
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves JWT/browser callers unaffected (200, no api key)', async () => {
+    const { req, res } = fire({ apiKey: null });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/client/pages/api/ai/generate-image.ts
+++ b/apps/client/pages/api/ai/generate-image.ts
@@ -3,7 +3,7 @@ import { getImageGeneration } from '@server/queueHandlers/imageGeneration';
 
 import { Request } from 'express';
 import { z } from 'zod';
-import { GenerateImageRequestBodySchema, GenerateImageIvokeParams } from '@bike4mind/common';
+import { GenerateImageRequestBodySchema, GenerateImageIvokeParams, ApiKeyScope } from '@bike4mind/common';
 import { getOrCreateSession } from '@server/managers/sessionManager';
 import { questRepository } from '@bike4mind/database';
 import { resolveImagePrompt, HISTORY_LOOKBACK, type PromptResolution } from '@server/utils/resolveImagePrompt';
@@ -11,7 +11,11 @@ import { resolveImagePrompt, HISTORY_LOOKBACK, type PromptResolution } from '@se
 type GenerateImageRequestBody = z.infer<typeof GenerateImageRequestBodySchema>;
 type GenerateImageRequest = Request<unknown, unknown, GenerateImageRequestBody>;
 
-const handler = baseApi().post(async (req: GenerateImageRequest, res) => {
+// Gate API-key callers on `ai:generate` so this billable action is auditable and a
+// least-privilege image-only key can drive the whole POST -> poll GET /api/quests/{id} flow
+// (the poll endpoint already accepts ai:generate). Scope checks apply only to API-key
+// requests; browser/JWT sessions fall through untouched (see apiKeyAuth).
+const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(async (req: GenerateImageRequest, res) => {
   req.logger.updateMetadata({
     userId: req.user?.id,
     userEmail: req.user?.email,

--- a/apps/client/pages/api/quests/[id]/__tests__/index.integration.test.ts
+++ b/apps/client/pages/api/quests/[id]/__tests__/index.integration.test.ts
@@ -162,7 +162,7 @@ describe('GET /api/quests/[id] (integration — scope enforcement via real middl
     expect(mockValidate).not.toHaveBeenCalled();
   });
 
-  it('derives ready-to-use CDN imageUrls from quest.images basenames', async () => {
+  it('resolves quest.images basenames into typed CDN file descriptors', async () => {
     const prev = process.env.NEXT_PUBLIC_CDN_URL;
     process.env.NEXT_PUBLIC_CDN_URL = 'https://cdn.example.com';
     mockQuestFindById.mockResolvedValue({
@@ -172,24 +172,28 @@ describe('GET /api/quests/[id] (integration — scope enforcement via real middl
       reply: {},
       replies: [],
       promptMeta: {},
-      images: ['a1b2c3.png', 'doc.xlsx'],
+      images: ['a1b2c3.png', 'report.xlsx'],
     });
     validateWithScopes([ApiKeyScope.AI_GENERATE]);
     const { req, res } = fire();
     await handler(req, res);
     expect(res._getStatusCode()).toBe(200);
+    // Raw basenames preserved; files[] carries ready-to-use URLs and flags the non-image .xlsx.
     expect(res._getJSONData()).toMatchObject({
-      images: ['a1b2c3.png', 'doc.xlsx'],
-      imageUrls: ['https://cdn.example.com/generated/a1b2c3.png', 'https://cdn.example.com/generated/doc.xlsx'],
+      images: ['a1b2c3.png', 'report.xlsx'],
+      files: [
+        { name: 'a1b2c3.png', url: 'https://cdn.example.com/generated/a1b2c3.png', isImage: true },
+        { name: 'report.xlsx', url: 'https://cdn.example.com/generated/report.xlsx', isImage: false },
+      ],
     });
     process.env.NEXT_PUBLIC_CDN_URL = prev;
   });
 
-  it('returns empty images/imageUrls when the quest generated nothing', async () => {
+  it('returns empty images/files when the quest generated nothing', async () => {
     validateWithScopes([ApiKeyScope.AI_GENERATE]);
     const { req, res } = fire();
     await handler(req, res);
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData()).toMatchObject({ images: [], imageUrls: [] });
+    expect(res._getJSONData()).toMatchObject({ images: [], files: [] });
   });
 });

--- a/apps/client/pages/api/quests/[id]/__tests__/index.integration.test.ts
+++ b/apps/client/pages/api/quests/[id]/__tests__/index.integration.test.ts
@@ -161,4 +161,35 @@ describe('GET /api/quests/[id] (integration — scope enforcement via real middl
     expect(res._getStatusCode()).toBe(200);
     expect(mockValidate).not.toHaveBeenCalled();
   });
+
+  it('derives ready-to-use CDN imageUrls from quest.images basenames', async () => {
+    const prev = process.env.NEXT_PUBLIC_CDN_URL;
+    process.env.NEXT_PUBLIC_CDN_URL = 'https://cdn.example.com';
+    mockQuestFindById.mockResolvedValue({
+      id: 'quest-1',
+      sessionId: 'sess-1',
+      status: 'done',
+      reply: {},
+      replies: [],
+      promptMeta: {},
+      images: ['a1b2c3.png', 'doc.xlsx'],
+    });
+    validateWithScopes([ApiKeyScope.AI_GENERATE]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({
+      images: ['a1b2c3.png', 'doc.xlsx'],
+      imageUrls: ['https://cdn.example.com/generated/a1b2c3.png', 'https://cdn.example.com/generated/doc.xlsx'],
+    });
+    process.env.NEXT_PUBLIC_CDN_URL = prev;
+  });
+
+  it('returns empty images/imageUrls when the quest generated nothing', async () => {
+    validateWithScopes([ApiKeyScope.AI_GENERATE]);
+    const { req, res } = fire();
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({ images: [], imageUrls: [] });
+  });
 });

--- a/apps/client/pages/api/quests/[id]/index.ts
+++ b/apps/client/pages/api/quests/[id]/index.ts
@@ -2,6 +2,7 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { BadRequestError, NotFoundError } from '@server/utils/errors';
 import { questRepository, sessionRepository } from '@bike4mind/database';
 import { ApiKeyScope } from '@bike4mind/common';
+import { toGeneratedFiles } from '@server/utils/generatedFiles';
 import type { Request } from 'express';
 
 // Reading a quest is the documented poll step after POST /api/chat, so an AI
@@ -34,14 +35,13 @@ const handler = baseApi({
     throw new NotFoundError('Quest not found');
   }
 
-  // `quest.images` holds bare generated-file basenames (e.g. `<uuid>.png`) served from the CDN
-  // under `/generated`. Programmatic pollers shouldn't have to know that path convention, so we
-  // derive ready-to-use URLs server-side - the single source of truth - mirroring the web client
-  // (PromptReplies.tsx). `images` (raw basenames) is kept for parity with the WebSocket payload.
-  // Skip URL building when no CDN is configured rather than emit a misleading relative path.
-  const cdnUrl = process.env.NEXT_PUBLIC_CDN_URL || '';
+  // `quest.images` holds bare generated-file basenames (e.g. `<uuid>.png`, or a `.xlsx` from
+  // excel_generation - not everything here is an image). Programmatic pollers shouldn't have to
+  // know the CDN path convention, so we resolve each into a typed descriptor with a ready-to-use
+  // URL server-side (the single source of truth). `images` (raw basenames) is kept for parity
+  // with the WebSocket payload; `files[].isImage` lets a caller pick out renderable images.
   const images = quest.images ?? [];
-  const imageUrls = cdnUrl ? images.map(name => `${cdnUrl}/generated/${name}`) : [];
+  const files = toGeneratedFiles(images);
 
   return res.json({
     id: quest.id,
@@ -50,7 +50,7 @@ const handler = baseApi({
     reply: quest.reply,
     replies: quest.replies,
     images,
-    imageUrls,
+    files,
     createdAt: quest.createdAt,
     updatedAt: quest.updatedAt,
     promptMeta: quest.promptMeta,

--- a/apps/client/pages/api/quests/[id]/index.ts
+++ b/apps/client/pages/api/quests/[id]/index.ts
@@ -34,12 +34,23 @@ const handler = baseApi({
     throw new NotFoundError('Quest not found');
   }
 
+  // `quest.images` holds bare generated-file basenames (e.g. `<uuid>.png`) served from the CDN
+  // under `/generated`. Programmatic pollers shouldn't have to know that path convention, so we
+  // derive ready-to-use URLs server-side - the single source of truth - mirroring the web client
+  // (PromptReplies.tsx). `images` (raw basenames) is kept for parity with the WebSocket payload.
+  // Skip URL building when no CDN is configured rather than emit a misleading relative path.
+  const cdnUrl = process.env.NEXT_PUBLIC_CDN_URL || '';
+  const images = quest.images ?? [];
+  const imageUrls = cdnUrl ? images.map(name => `${cdnUrl}/generated/${name}`) : [];
+
   return res.json({
     id: quest.id,
     status: quest.status,
     sessionId: quest.sessionId,
     reply: quest.reply,
     replies: quest.replies,
+    images,
+    imageUrls,
     createdAt: quest.createdAt,
     updatedAt: quest.updatedAt,
     promptMeta: quest.promptMeta,

--- a/apps/client/server/utils/generatedFiles.test.ts
+++ b/apps/client/server/utils/generatedFiles.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+import { describe, it, expect, afterEach } from 'vitest';
+import { toGeneratedFiles } from './generatedFiles';
+
+const ORIGINAL_CDN = process.env.NEXT_PUBLIC_CDN_URL;
+
+afterEach(() => {
+  process.env.NEXT_PUBLIC_CDN_URL = ORIGINAL_CDN;
+});
+
+describe('toGeneratedFiles', () => {
+  it('builds fully-qualified CDN URLs under /generated', () => {
+    process.env.NEXT_PUBLIC_CDN_URL = 'https://cdn.example.com';
+    expect(toGeneratedFiles(['a1b2c3.png'])).toEqual([
+      { name: 'a1b2c3.png', url: 'https://cdn.example.com/generated/a1b2c3.png', isImage: true },
+    ]);
+  });
+
+  it('flags non-image files (e.g. .xlsx) with isImage: false', () => {
+    process.env.NEXT_PUBLIC_CDN_URL = 'https://cdn.example.com';
+    const [file] = toGeneratedFiles(['report.xlsx']);
+    expect(file).toMatchObject({ name: 'report.xlsx', isImage: false });
+  });
+
+  it('normalizes a trailing slash on the CDN URL so paths never double-slash', () => {
+    process.env.NEXT_PUBLIC_CDN_URL = 'https://cdn.example.com/';
+    expect(toGeneratedFiles(['a.png'])[0].url).toBe('https://cdn.example.com/generated/a.png');
+  });
+
+  it('returns [] when no CDN is configured rather than a misleading relative path', () => {
+    process.env.NEXT_PUBLIC_CDN_URL = '';
+    expect(toGeneratedFiles(['a.png'])).toEqual([]);
+  });
+
+  it('recognizes common image extensions case-insensitively', () => {
+    process.env.NEXT_PUBLIC_CDN_URL = 'https://cdn.example.com';
+    const files = toGeneratedFiles(['x.PNG', 'y.jpeg', 'z.WEBP', 'a.svg', 'b.txt']);
+    expect(files.map(f => f.isImage)).toEqual([true, true, true, true, false]);
+  });
+});

--- a/apps/client/server/utils/generatedFiles.ts
+++ b/apps/client/server/utils/generatedFiles.ts
@@ -1,0 +1,32 @@
+/**
+ * A file produced by a quest tool (image_generation, edit_image, excel_generation, ...),
+ * exposed to programmatic API consumers with a ready-to-use URL so they don't have to know
+ * the CDN path convention. `isImage` lets a caller pick out renderable images without
+ * re-parsing extensions - not every generated file is an image (excel_generation drops an
+ * .xlsx into the same list).
+ */
+export type GeneratedFile = {
+  name: string;
+  url: string;
+  isImage: boolean;
+};
+
+// Matches the extensions the web client treats as inline-renderable (PromptReplies.tsx).
+const IMAGE_EXTENSION_RE = /\.(png|jpe?g|webp|gif|svg|bmp|avif)$/i;
+
+/**
+ * Map bare generated-file basenames (as stored on `quest.images`) to descriptors with
+ * fully-qualified CDN URLs. Generated files are served under `<cdnUrl>/generated/<name>`.
+ * Returns [] when no CDN is configured rather than emit a misleading relative path.
+ */
+export function toGeneratedFiles(names: string[]): GeneratedFile[] {
+  const cdnUrl = (process.env.NEXT_PUBLIC_CDN_URL || '').replace(/\/+$/, '');
+  if (!cdnUrl) {
+    return [];
+  }
+  return names.map(name => ({
+    name,
+    url: `${cdnUrl}/generated/${name}`,
+    isImage: IMAGE_EXTENSION_RE.test(name),
+  }));
+}


### PR DESCRIPTION
## Description

Improves the developer experience for generating images programmatically via the public HTTP API. Image generation is asynchronous (the work runs in the SQS worker, well clear of the API-gateway request timeout), so the intended flow is `POST /api/ai/generate-image` -> poll `GET /api/quests/{id}` until done -> read the result. Two papercuts in that flow are fixed here:

1. The poll endpoint didn't return usable file URLs -- callers had to dig filenames out of an internal `promptMeta` field and reconstruct the CDN path (logic that lived only in the web client).
2. `POST /api/ai/generate-image` required no API-key scope, so the billable action was ungated while *reading* the result required a scope.

Closes #720

## Changes

- `GET /api/quests/[id]` now returns a structured `files[]` array of `{ name, url, isImage }` alongside the raw `images[]` basenames (kept for WebSocket-payload parity). `quest.images` really holds *all* files a quest generated (an `.xlsx` from excel_generation lands there too), so a typed descriptor list -- rather than a bare `imageUrls` string array -- serves both image and non-image consumers, never omits files, and can be extended (dimensions, content-type) without a breaking rename.
- URLs are derived server-side via a single `toGeneratedFiles()` helper (the source of truth), which also normalizes a trailing slash on `NEXT_PUBLIC_CDN_URL` so paths never double-slash. Returns `[]` when no CDN is configured rather than emitting a misleading relative path.
- `POST /api/ai/generate-image` now requires the `ai:generate` API-key scope. Scope checks apply only to API-key callers; browser/JWT sessions fall through untouched (`apiKeyAuth` short-circuits before the scope check when no key header is present).
- Added a `generate-image` scope-gate regression test (403 without `ai:generate`, 200 with it, JWT unaffected), a unit test for `toGeneratedFiles`, and extended the quest-poll integration test.
- Added an async "Image Generation" section to the in-app API reference and documented the new poll-response fields.

## Guide for Testers

This is a backend/API + docs change. Verify via API calls with an API key.

**Prep**
1. In the app, go to **Profile -> API Keys** (or `POST /api/user-api-keys`) and create a key with the `ai:generate` scope. Copy the key.
2. Create a second key WITHOUT the `ai:generate` scope (e.g. `files:read` only) for the negative test.

**Happy path (scoped key)**
3. `POST https://app.staging.bike4mind.com/api/ai/generate-image` with header `x-api-key: <ai:generate key>` and JSON body `{ "prompt": "a red bicycle on a white background" }`.
4. Expected: `200` with a body containing `quest.id`. It returns immediately (no image yet, no timeout).
5. Poll `GET https://app.staging.bike4mind.com/api/quests/<quest.id>` with the same `x-api-key` header every ~2s.
6. Expected: while generating, `status` is not `done` and `files` is `[]`. Once complete, `status` is `done`, `images` lists a basename like `<uuid>.png`, and `files` lists `{ "name": "<uuid>.png", "url": "https://<cdn>/generated/<uuid>.png", "isImage": true }`.
7. Open the `files[0].url` in a browser. Expected: the generated image loads.

**Scope enforcement (negative)**
8. Repeat step 3 with the key that lacks `ai:generate`.
9. Expected: `403` with an "Insufficient API key permissions" error; no generation occurs.

**Docs**
10. In the app, open the **API Reference** (Admin -> API Reference). Under **AI Services** find "Image Generation (async)"; under **Chat** find the "Poll Quest Status" response now showing `images` and `files`.

## Regression Checks

- In the web app, generate an image through the normal chat/command flow and confirm the image still renders inline (browser/JWT path must be unaffected by the new scope gate).
- Confirm existing chat quest polling in the UI still works (the poll response only gained fields).

## What NOT to test

- No UI components were changed; there's no new screen to exercise beyond the docs page.
- No changes to the generation backends, models, moderation, or billing.

## Developer Notes

- `toGeneratedFiles(names)` (`apps/client/server/utils/generatedFiles.ts`) is the single server-side source of truth for turning `quest.images` basenames into `<cdnUrl>/generated/<name>` descriptors. Reuse it for any other endpoint that needs to expose generated-file URLs (edit-image, generate-video quests produce the same shape).
- The `files[]` descriptor (`{ name, url, isImage }`) is deliberately structured rather than a URL string list, so future metadata (width/height, content-type) is an additive change.

## Additional Information

`ai:generate` scope gating is a behavior change for any existing API key that currently generates images without holding that scope -- such keys will start receiving `403`. Reissue/rescope those keys if any exist.
