### PR TITLE
test: raise shared vitest timeout floor to de-flake Mongo-backed suites

### DIFF
--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -41,4 +41,20 @@ if (raw && maxWorkers === undefined) {
   );
 }
 
-export const sharedTest = maxWorkers !== undefined ? { maxWorkers, minWorkers: 1 } : {};
+// vitest's defaults (5s per test, 10s per hook) suit pure unit tests but are too tight for
+// the I/O-bound suites - real MongoMemoryServer via createMongoServer, solver benchmarks -
+// once CI shards the matrix and VITEST_MAX_WORKERS packs several packages onto the same
+// cores. Under that contention a trivial DB seed can stall past 5s purely on CPU starvation,
+// not because anything is wrong, which surfaces as a spurious timeout failure (a flaky red).
+// Raise the floor so contention shows up as slowness rather than failure; a genuinely hung
+// test still fails, just after a longer wait. Because every package spreads `sharedTest`
+// FIRST, any package needing a different value (e.g. `@bike4mind/database`'s hookTimeout:
+// 60000 for the one-time Mongo binary download) overrides it by setting the key afterward.
+const TEST_TIMEOUT_MS = 15_000;
+const HOOK_TIMEOUT_MS = 30_000;
+
+export const sharedTest = {
+  testTimeout: TEST_TIMEOUT_MS,
+  hookTimeout: HOOK_TIMEOUT_MS,
+  ...(maxWorkers !== undefined ? { maxWorkers, minWorkers: 1 } : {}),
+};


### PR DESCRIPTION
## Description

De-flakes the CI test job. The `Run Tests (client)` / `Run Tests` matrix intermittently fails a single unrelated test with `Test timed out in 5000ms` - most recently `server/services/groupInviteAuth.e2e.test.ts` ([failing run](https://github.com/Bike4Mind/bike4mind/actions/runs/29728261662/job/88306665239)), where 6307 tests passed and 1 timed out inside a trivial `seedGroupInvite()` (3 inserts).

Root cause is not the test - it's the timeout floor. vitest's defaults (5s per test, 10s per hook) are calibrated for pure unit tests. The I/O-bound suites - real `MongoMemoryServer` via `createMongoServer`, plus the solver benchmarks - do real async work, and once CI shards the matrix and `VITEST_MAX_WORKERS` packs several packages onto the same cores, a trivial DB seed can stall past 5s purely on CPU starvation. The work isn't hung; it's waiting for a core. That surfaces as a spurious red.

~27 test files spin up a real Mongo; most rely on the 5s default for their test bodies (the `@bike4mind/database` config already bumps `hookTimeout` to 60s for the binary download but leaves `testTimeout` at the default). This raises the shared floor so contention shows up as slowness rather than failure.

## Changes

- `vitest.shared.ts` - `sharedTest` now sets `testTimeout: 15_000` and `hookTimeout: 30_000`. Because every package spreads `sharedTest` **first** in its `test` config, any package that needs a different value (e.g. `@bike4mind/database`'s `hookTimeout: 60000`) still overrides it by setting the key afterward. A genuinely hung test still fails - just after a longer wait.

## Guide for Testers

This is a test-infra change; there is nothing to click in the app.

1. Check out this branch and run a Mongo-backed suite, e.g. `pnpm --filter @bike4mind/client test server/services/groupInviteAuth.e2e.test.ts`. Expected: 4 tests pass; no `Test timed out in 5000ms`.
2. Confirm the config still loads for a non-Mongo package, e.g. `pnpm --filter @bike4mind/utils test`. Expected: passes as before.
3. On CI: the `Run Tests (client)`, `Run Tests`, and `CI Complete` checks pass without the sporadic single-test timeout.

### Regression Checks
- No test's behavior changes; only the maximum time a test/hook is allowed to run before the harness aborts it increases.
- Per-package timeout overrides (notably `@bike4mind/database`'s 60s hook timeout) still take effect.

### What NOT to test
- No application/runtime behavior changes - this only affects the vitest harness.

## Additional Information

Complements the existing contention mitigations (matrix sharding + `VITEST_MAX_WORKERS` worker budget); the per-test timeout was the missing third lever. `15s` / `30s` are conservative floors and easy to tune.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


Closes #730
