### PR TITLE
fix(admin): engage horizontal scroll on the settings tab bar overflow

### DIFF
--- a/apps/client/app/components/admin/AdminSettingsTab.tsx
+++ b/apps/client/app/components/admin/AdminSettingsTab.tsx
@@ -988,7 +988,9 @@ const AdminSettingsTab: React.FC = () => {
             <Tabs
               value={activeTab}
               onChange={(_, value) => setActiveTab(value as string)}
-              sx={{ bgcolor: 'background.body' }}
+              // minWidth: 0 lets this flex child shrink below its content width so the
+              // TabList's overflowX can engage instead of the row spilling past the panel.
+              sx={{ bgcolor: 'background.body', minWidth: 0, maxWidth: '100%' }}
             >
               <TabList
                 variant="plain"
@@ -998,6 +1000,7 @@ const AdminSettingsTab: React.FC = () => {
                   '--ListItem-minHeight': '48px',
                   borderBottom: '1px solid',
                   borderColor: 'divider',
+                  minWidth: 0,
                   overflowX: 'auto',
                 }}
               >


### PR DESCRIPTION
## What

Fixes the Admin Settings tab bar overflow: the row of setting tabs (Permissions, AI, ... System, and beyond) was clipped at the right edge with no way to reach the trailing tabs.

Closes #734

## Why

The tab row in `AdminSettingsTab.tsx` already set `overflowX: 'auto'` on the `TabList`, but neither the inner `<Tabs>` wrapper nor the `TabList` clamped their flex width. Their default `auto` min-width resolves to min-content, so as flex descendants of the outer vertical `Tabs`/`TabPanel` in `AdminPage.tsx` the row grew to fit every tab and spilled past the panel edge instead of scrolling. The result: the last tab was truncated mid-label and the tabs beyond it were unreachable with no scroll affordance. This gets worse as more entries are added to `SETTING_TABS`.

## Change

- Add `minWidth: 0` (plus `maxWidth: '100%'`) to the inner `<Tabs>` wrapper and `minWidth: 0` to the `TabList`, so the flex chain can shrink below its content width and the existing `overflowX: 'auto'` actually engages.

Single-file, CSS-only (`sx`) change; no behavior change beyond enabling the intended horizontal scroll.

## Testing

- `pnpm --filter @bike4mind/client typecheck` passes.
- Manual: with the tab count exceeding the panel width, the row now scrolls horizontally instead of clipping, and every tab is reachable.

## Screenshots

Before: trailing tabs clipped at the panel edge, no scrollbar (see #734).
After: row scrolls horizontally; all tabs reachable.
