### PR TITLE
fix(client): publish own reply as non-admin by checking session ownership (#740)

### DIFF
--- a/apps/client/pages/api/publish/__tests__/reply.test.ts
+++ b/apps/client/pages/api/publish/__tests__/reply.test.ts
@@ -1,23 +1,38 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // reply.ts wires an Express-style handler at module load and imports server-only deps; stub them
-// so we can import the pure deriveTitle helper in isolation. parseArtifactsWithFallback is NOT
-// mocked - deriveTitle relies on its real artifact extraction.
+// so we can drive the handler (default export) and the pure deriveTitle helper in isolation.
+// parseArtifactsWithFallback is NOT mocked - deriveTitle relies on its real artifact extraction.
+const dbMocks = vi.hoisted(() => ({
+  questLean: vi.fn(),
+  sessionLean: vi.fn(),
+  publishedFindOneLean: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+}));
+
+// baseApi().post(fn) returns fn, so `export default handler` IS the handler function.
 vi.mock('@server/middlewares/baseApi', () => ({
   baseApi: () => {
     const chain: Record<string, unknown> = {};
-    Object.assign(chain, { use: () => chain, post: () => chain });
+    Object.assign(chain, { use: () => chain, post: (fn: unknown) => fn });
     return chain;
   },
 }));
-vi.mock('@bike4mind/database', () => ({ Quest: {}, PublishedArtifact: {} }));
+vi.mock('@bike4mind/database', () => ({
+  Quest: { findOne: () => ({ select: () => ({ lean: dbMocks.questLean }) }) },
+  Session: { findById: () => ({ select: () => ({ lean: dbMocks.sessionLean }) }) },
+  PublishedArtifact: {
+    findOne: () => ({ lean: dbMocks.publishedFindOneLean }),
+    findOneAndUpdate: dbMocks.findOneAndUpdate,
+  },
+}));
 vi.mock('@server/services/publish', () => ({
-  resolveVisibility: () => ({}),
-  checkScopePermission: () => ({}),
-  checkPublishQuota: () => ({}),
+  resolveVisibility: () => ({ ok: true, visibility: 'public' }),
+  checkScopePermission: () => ({ ok: true }),
+  checkPublishQuota: () => ({ ok: true }),
 }));
 
-import { deriveTitle } from '../reply';
+import handler, { deriveTitle } from '../reply';
 
 describe('deriveTitle', () => {
   it('uses the first prose line, stripped of markdown heading markers', () => {
@@ -41,5 +56,73 @@ describe('deriveTitle', () => {
     const title = deriveTitle('<artifact type="text/html" title="Real Title"><label>x</label></artifact>');
     expect(title).not.toContain('<artifact');
     expect(title).toBe('Real Title');
+  });
+});
+
+// Ownership is read from the parent Session (its userId), NOT the Quest - a Quest
+// has no top-level userId, so reading it off the Quest silently 403s every
+// non-admin (#740).
+describe('POST /api/publish/reply - ownership', () => {
+  const OWNER = 'owner-user-id';
+  type Res = {
+    statusCode: number;
+    body: unknown;
+    status: (code: number) => Res;
+    json: (obj: unknown) => Res;
+  };
+  const makeRes = (): Res => {
+    const res = { statusCode: 0, body: undefined as unknown } as Res;
+    res.status = (code: number) => {
+      res.statusCode = code;
+      return res;
+    };
+    res.json = (obj: unknown) => {
+      res.body = obj;
+      return res;
+    };
+    return res;
+  };
+  const makeReq = (user: Partial<{ id: string; isAdmin: boolean }>) => ({
+    user: { id: OWNER, isAdmin: false, organizationId: null, username: 'u', ...user },
+    body: { sessionId: 'sess1', messageId: 'msg1' },
+    logger: { info: () => {} },
+  });
+  const run = (req: unknown) => {
+    const res = makeRes();
+    return (handler as (req: unknown, res: unknown) => Promise<void>)(req, res).then(() => res);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.questLean.mockResolvedValue({ reply: 'Hello world' });
+    dbMocks.sessionLean.mockResolvedValue({ userId: OWNER });
+    dbMocks.publishedFindOneLean.mockResolvedValue(null);
+    dbMocks.findOneAndUpdate.mockResolvedValue({ publicId: 'abc123', slug: 'r-abc123' });
+  });
+
+  it('lets a non-admin publish their OWN reply (session owner)', async () => {
+    const res = await run(makeReq({ id: OWNER, isAdmin: false }));
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ publicId: 'abc123', url: '/p/r/abc123' });
+  });
+
+  it('returns 403 when a non-admin is not the session owner', async () => {
+    dbMocks.sessionLean.mockResolvedValue({ userId: 'someone-else' });
+    const res = await run(makeReq({ id: OWNER, isAdmin: false }));
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: 'You can only publish your own replies' });
+  });
+
+  it('lets an admin publish a reply they do not own', async () => {
+    dbMocks.sessionLean.mockResolvedValue({ userId: 'someone-else' });
+    const res = await run(makeReq({ id: OWNER, isAdmin: true }));
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ publicId: 'abc123' });
+  });
+
+  it('returns 404 when the parent session is missing', async () => {
+    dbMocks.sessionLean.mockResolvedValue(null);
+    const res = await run(makeReq({ id: OWNER, isAdmin: false }));
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/apps/client/pages/api/publish/reply.ts
+++ b/apps/client/pages/api/publish/reply.ts
@@ -1,6 +1,6 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { randomUUID } from 'node:crypto';
-import { Quest, PublishedArtifact } from '@bike4mind/database';
+import { Quest, PublishedArtifact, Session } from '@bike4mind/database';
 import { PublishReplyRequestSchema, type PublishResult } from '@bike4mind/common';
 import { resolveVisibility, checkScopePermission, checkPublishQuota, type PublishUser } from '@server/services/publish';
 import { parseArtifactsWithFallback } from '@client/app/utils/artifactParser';
@@ -69,14 +69,13 @@ const handler = baseApi().post(async (req, res) => {
   const body = parsed.data;
   const userId = String(req.user.id);
 
-  // Load the message (a Quest) and verify ownership. The streamed answer lives in
-  // `replies[]` (authoritative), falling back to the flat `reply`, then to text
-  // blocks in `structuredReplies` - mirror the UI's extractReplies so a published
-  // reply matches what the user sees on screen.
+  // Load the message (a Quest). The streamed answer lives in `replies[]`
+  // (authoritative), falling back to the flat `reply`, then to text blocks in
+  // `structuredReplies` - mirror the UI's extractReplies so a published reply
+  // matches what the user sees on screen.
   const quest = await Quest.findOne({ _id: body.messageId, sessionId: body.sessionId })
-    .select('userId reply replies structuredReplies')
+    .select('reply replies structuredReplies')
     .lean<{
-      userId: string;
       reply?: string | null;
       replies?: string[] | null;
       structuredReplies?: Array<{ content?: unknown }> | null;
@@ -84,7 +83,15 @@ const handler = baseApi().post(async (req, res) => {
   if (!quest) {
     return res.status(404).json({ error: 'Reply not found' });
   }
-  if (quest.userId !== userId && !req.user.isAdmin) {
+
+  // Ownership lives on the Session, not the Quest: ChatHistoryItemSchema has no
+  // top-level userId, so read the owner from the parent session (userId is
+  // required there). Reading it off the Quest silently 403s every non-admin.
+  const session = await Session.findById(body.sessionId).select('userId').lean<{ userId: string } | null>();
+  if (!session) {
+    return res.status(404).json({ error: 'Reply not found' });
+  }
+  if (String(session.userId) !== userId && !req.user.isAdmin) {
     return res.status(403).json({ error: 'You can only publish your own replies' });
   }
   const markdown = extractReplyMarkdown(quest);


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

https://github.com/user-attachments/assets/a6716fe9-6f09-437d-8592-824750f06c12

## Description

Closes #740. A standard (non-admin) user could not create a public share link for their own assistant reply: `POST /api/publish/reply` returned `403 {error: "You can only publish your own replies"}`. The identical flow succeeded for admins.

Root cause: the handler read ownership from `quest.userId`, but a Quest (`ChatHistoryItemSchema`) has no top-level `userId` field, so the value was always `undefined`. `undefined !== userId` is always true, so every non-admin hit the 403; admins passed only because of the `!req.user.isAdmin` short-circuit. The `.select('userId')` plus `.lean<{ userId: string }>()` cast masked this at compile time.

The fix derives ownership from the parent Session instead. A Quest belongs to a Session, and `SessionModel.userId` is a required field, so it is the correct owner-of-record. The Quest is already loaded with a `sessionId` filter, so a caller can only publish messages that belong to a session they own - no cross-session access is introduced.

## Changes

- `apps/client/pages/api/publish/reply.ts`
  - Import `Session` from `@bike4mind/database`.
  - Remove the non-existent `userId` from the Quest `.select(...)` and its `.lean<>()` type.
  - Load the parent session (`Session.findById(sessionId).select('userId')`), return 404 if it is missing, and compare `String(session.userId)` against the caller (admins still bypass).
- `apps/client/pages/api/publish/__tests__/reply.test.ts`
  - Add handler-level ownership tests (the 403 path was previously untested): non-admin owner -> 200, non-admin non-owner -> 403, admin non-owner -> 200, missing session -> 404. Existing `deriveTitle` tests are retained.

## Guide for Testers

1. Log in as a standard (non-admin) account.
2. Start a new chat and send a prompt that yields an assistant reply, e.g. `Build me a self-contained tip calculator as a single HTML file.`
3. Wait for the assistant reply / artifact to finish generating.
4. On the assistant message, open the `...` (More options) menu and click `Share`.
5. In the Share dialog, keep Visibility = Public and Access = Anyone with the link.
6. Click `Create link`.
7. Expected: a public `/p/r/{id}` link is generated, and the dialog transitions to the "Shared & ready" state with the copyable link. No 403 in the network tab for `POST /api/publish/reply`.

### Regression Checks
1. Repeat the flow as an admin account -> publishing still succeeds.
2. Confirm a user cannot publish a reply from a session they do not own (still 403).

### What NOT to test
- The published reply render path (`/p/r/{id}` viewer) is unchanged by this PR.

## Additional Information

Pre-existing bug, reproducible in staging; not introduced by PR #711 (it was surfaced during #711 testing). Verified locally: `reply.test.ts` 9/9, full client suite passing, client typecheck clean, `lint:check` clean.

## Checklist

- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
