### PR TITLE
chore(premium): set b4m-overwatch overlay pin to 4afc25e5ab5844b3bfb61cc7994310fe9c966487

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,6 +1,6 @@
 {
   "b4m-bob": "72235ca1b3fa53421917a1e7c1f244af18d2ed2b",
-  "b4m-overwatch": "9110965564ff8316eb06ddcc9be88881deda7690",
+  "b4m-overwatch": "4afc25e5ab5844b3bfb61cc7994310fe9c966487",
   "b4m-libreoncology": "c917641b8155c311d217b021e414bba33c9eb72a",
   "b4m-optihashi": "e0f61f0d9231f2048356d99661dd192615751928",
   "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",


### PR DESCRIPTION
Sets the b4m-overwatch overlay pin to 4afc25e5ab5844b3bfb61cc7994310fe9c966487. Overlay-pin-only change; no application source changes.