### PR TITLE
chore(data-lakes): reword infer-taxonomy comment and cover gate-removal admit path

### DIFF
--- a/apps/client/pages/api/data-lakes/__tests__/infer-taxonomy.test.ts
+++ b/apps/client/pages/api/data-lakes/__tests__/infer-taxonomy.test.ts
@@ -1,16 +1,28 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { Request } from 'express';
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import type { Request, Response } from 'express';
 
-// isDevelopment is toggled per test via this hoisted flag (it reads SST Resource in prod code).
-const { devFlag } = vi.hoisted(() => ({ devFlag: { value: false } }));
+type RouteHandler = (req: Request, res: Response) => Promise<unknown>;
+
+// isDevelopment is toggled per test via devFlag (it reads SST Resource in prod code).
+// captured.handler holds the route's POST callback so a test can invoke the handler body
+// directly - that is where the removed admin/opti/developer tag gate used to live.
+const { devFlag, captured } = vi.hoisted(() => ({
+  devFlag: { value: false },
+  captured: {} as { handler?: RouteHandler },
+}));
 
 // Stub the middleware/service/db/openai imports so the route module loads without a real
 // stack. hasDeveloperUserTag (from @bike4mind/common) is intentionally NOT mocked - it is
-// the logic under test.
+// the logic under test. baseApi().post(fn) captures fn so the admit path can be exercised
+// directly; requireFeatureEnabled and rateLimit stay pass-through here because the gate the
+// tests care about (the removed tag gate) lived in the handler body, not those middlewares.
 vi.mock('@server/middlewares/baseApi', () => {
-  const chain: Record<string, () => unknown> = {};
+  const chain: Record<string, (fn?: RouteHandler) => unknown> = {};
   chain.use = () => chain;
-  chain.post = () => chain;
+  chain.post = (fn?: RouteHandler) => {
+    captured.handler = fn;
+    return chain;
+  };
   return { baseApi: () => chain };
 });
 vi.mock('@server/middlewares/featureFlag', () => ({
@@ -24,6 +36,7 @@ vi.mock('@bike4mind/services', () => ({ apiKeyService: { getEffectiveApiKey: vi.
 vi.mock('@bike4mind/database', () => ({ apiKeyRepository: {}, adminSettingsRepository: {} }));
 vi.mock('openai', () => ({ default: class {} }));
 
+import { apiKeyService } from '@bike4mind/services';
 import { resolveTaxonomyDailyLimit, TAXONOMY_INFERENCE_DAILY_CAP } from '../infer-taxonomy';
 
 const req = (user: unknown): Request => ({ user }) as unknown as Request;
@@ -49,6 +62,39 @@ describe('resolveTaxonomyDailyLimit', () => {
   it('caps other permitted (e.g. opti-tagged) users at the daily cap', () => {
     expect(resolveTaxonomyDailyLimit(req({ id: 'u', isAdmin: false, tags: ['opti'] }))).toBe(
       TAXONOMY_INFERENCE_DAILY_CAP
+    );
+  });
+});
+
+// #532 removed the admin/opti/developer tag gate: access is now the EnableDataLakes flag
+// alone (plus the daily rate cap). A feature-enabled, untagged, non-admin user used to be
+// 403'd here mid create-wizard; this locks in that they now reach the handler instead.
+describe('POST handler (gate-removal admit path)', () => {
+  beforeEach(() => {
+    devFlag.value = false;
+    (apiKeyService.getEffectiveApiKey as Mock).mockReset();
+  });
+
+  it('admits a feature-enabled, untagged, non-admin user and runs the handler', async () => {
+    // No OpenAI key -> the handler degrades to an empty taxonomy (non-blocking) with 200.
+    // Reaching this path at all proves the user was admitted rather than gate-rejected.
+    (apiKeyService.getEffectiveApiKey as Mock).mockResolvedValue(null);
+    const json = vi.fn();
+    const res = { json } as unknown as Response;
+    const request = {
+      user: { id: 'u', isAdmin: false, tags: [] },
+      body: { folderTree: [{ relativePath: 'docs/a.txt', fileName: 'a.txt', fileSize: 10 }] },
+    } as unknown as Request;
+
+    await captured.handler!(request, res);
+
+    expect(apiKeyService.getEffectiveApiKey).toHaveBeenCalledWith(
+      'u',
+      expect.objectContaining({ nullIfMissing: true }),
+      expect.anything()
+    );
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ suggestedPrefix: '', categories: [], fileAssignments: [] })
     );
   });
 });

--- a/apps/client/pages/api/data-lakes/infer-taxonomy.ts
+++ b/apps/client/pages/api/data-lakes/infer-taxonomy.ts
@@ -9,10 +9,11 @@ import { apiKeyRepository, adminSettingsRepository } from '@bike4mind/database';
 import OpenAI from 'openai';
 import { Request } from 'express';
 
-// Per-user/day cap on taxonomy inference. The endpoint is tag-gated (admin / opti /
-// developer), but a tagged user could otherwise burn OpenAI spend unbounded. Admins and
-// developer-tagged users stay uncapped; every other caller who reaches here gets the daily
-// cap. The limit trips in middleware, before any OpenAI call, so a rejected request is free.
+// Per-user/day cap on taxonomy inference. Access is the EnableDataLakes feature flag alone
+// (see the handler below), so any feature-enabled user reaches this endpoint and could
+// otherwise burn OpenAI spend unbounded. Admins and developer-tagged users stay uncapped;
+// every other caller gets the daily cap. The limit trips in middleware, before any OpenAI
+// call, so a rejected request is free.
 export const TAXONOMY_INFERENCE_DAILY_CAP = 50;
 const DAY_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Description

Follow-up to the review of PR No. 532 (data-lake public visibility), which also removed the admin/opti/developer tag gate on the OpenAI-backed `infer-taxonomy` endpoint so access is now the `EnableDataLakes` feature flag alone, plus a per-user daily rate cap (admins/developers uncapped). This PR closes out the two leftover code items from that review: a stale comment and missing test coverage for the new admit path. No runtime behavior changes.

## Changes

- Reworded the stale rate-limit comment at the top of `infer-taxonomy.ts` that still described the endpoint as tag-gated (admin / opti / developer). It now explains access is the `EnableDataLakes` feature flag alone, which is precisely why the daily cap bounds OpenAI spend.
- Added an admit-path test in `infer-taxonomy.test.ts`. The `baseApi` mock now captures the POST handler, and a new test drives it with a feature-enabled, untagged, non-admin user (the caller the removed gate used to 403 mid create-wizard) to assert the handler runs and returns the non-blocking empty-taxonomy response. The existing `resolveTaxonomyDailyLimit` tests are unchanged.

## Guide for Testers

Backend + test-only change; there is no UI and no runtime behavior change to exercise on staging.

Automated verification (run from repo root):

1. Run the test file: `pnpm --filter @bike4mind/client exec vitest run pages/api/data-lakes/__tests__/infer-taxonomy.test.ts`
   - Expected: `Test Files 1 passed`, `Tests 5 passed` (4 existing + 1 new admit-path test).
2. Typecheck: `pnpm --filter @bike4mind/client typecheck`
   - Expected: exits 0 with no `error TS` output.

### Regression Checks
- The full client suite passes locally (`6365 passed | 81 skipped`, 0 failed).

### What NOT to test
- No UI, endpoints, or feature flags to click through. This PR only touches an inline comment and a test file.

## Additional Information

The authz change itself was not called out in PR No. 532's description; since squash-merge makes the PR body permanent history, the "why" behind loosening the gate lives in the tracking issue.

Closes https://github.com/Bike4Mind/bike4mind/issues/738

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
