### PR TITLE
fix(api): require 3-char search for non-admin publicView user queries

### DIFF
--- a/apps/client/app/components/Project/AddMembersModal.tsx
+++ b/apps/client/app/components/Project/AddMembersModal.tsx
@@ -110,6 +110,7 @@ const ProjectAddMembersModal: FC<{ project: IProjectDocument; ownerId: string; p
       getItemId={user => user.username}
       onSearch={term => debouncedSearch(term)}
       searchPlaceholder={t('common.search_users', 'Search users')}
+      searchMinLength={3}
       onAdd={handleAddMembers}
       isPending={shareDocument.isPending}
       renderItem={renderUserItem}

--- a/apps/client/app/components/Project/AddMembersModal.tsx
+++ b/apps/client/app/components/Project/AddMembersModal.tsx
@@ -22,7 +22,7 @@ const ProjectAddMembersModal: FC<{ project: IProjectDocument; ownerId: string; p
   const queryClient = useQueryClient();
 
   const params: IGetUsersParams = useMemo(() => ({ search, page: 1, limit: 10, publicView: true }), [search]);
-  const { data, isFetching } = useGetUsers(params, { enabled: !!search });
+  const { data, isFetching } = useGetUsers(params, { enabled: search.length >= 3 });
 
   const [permissions] = useState<{ value: Permission[]; error?: string | null }>({
     value: [Permission.read, Permission.update],

--- a/apps/client/app/components/Project/GenericAddItemsModal.tsx
+++ b/apps/client/app/components/Project/GenericAddItemsModal.tsx
@@ -58,6 +58,7 @@ export interface GenericAddItemsModalProps<T> {
   showButtonBadge?: boolean;
   emptyResultMessage?: string;
   triggerTestId?: string;
+  searchMinLength?: number;
 }
 
 function GenericAddItemsModal<T>({
@@ -97,6 +98,7 @@ function GenericAddItemsModal<T>({
   value,
   showButtonBadge = true,
   triggerTestId,
+  searchMinLength,
 }: GenericAddItemsModalProps<T>) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -310,8 +312,10 @@ function GenericAddItemsModal<T>({
                         py={4}
                       >
                         <Typography className="generic-add-items-empty-message" level="body-lg" color="neutral">
-                          {searchTerm.length > 0 && searchTerm.length < 3
-                            ? 'Type at least 3 characters to search.'
+                          {searchMinLength && searchTerm.length > 0 && searchTerm.length < searchMinLength
+                            ? t('common.search_min_length', 'Type at least {{count}} characters to search.', {
+                                count: searchMinLength,
+                              })
                             : searchTerm
                               ? 'No results found. Try adjusting your search.'
                               : emptyResultMessage}

--- a/apps/client/app/components/Project/GenericAddItemsModal.tsx
+++ b/apps/client/app/components/Project/GenericAddItemsModal.tsx
@@ -310,7 +310,11 @@ function GenericAddItemsModal<T>({
                         py={4}
                       >
                         <Typography className="generic-add-items-empty-message" level="body-lg" color="neutral">
-                          {searchTerm ? 'No results found. Try adjusting your search.' : emptyResultMessage}
+                          {searchTerm.length > 0 && searchTerm.length < 3
+                            ? 'Type at least 3 characters to search.'
+                            : searchTerm
+                              ? 'No results found. Try adjusting your search.'
+                              : emptyResultMessage}
                         </Typography>
                       </Box>
                     ) : (

--- a/apps/client/app/components/common/GenericAddItemsModal.tsx
+++ b/apps/client/app/components/common/GenericAddItemsModal.tsx
@@ -11,6 +11,7 @@ import {
   Modal,
   ModalDialog,
   Stack,
+  Typography,
   useTheme,
 } from '@mui/joy';
 import { useMediaQuery } from '@mui/system';
@@ -95,14 +96,24 @@ function GenericAddItemsModal<T>({
 }: GenericAddItemsModalProps<T>) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isTablet = useMediaQuery(theme.breakpoints.down('md'));
 
   const handleClose = useCallback(() => {
     setOpen(false);
+    setSearchTerm('');
     if (onSearch) onSearch('');
   }, [onSearch]);
+
+  const handleSearch = useCallback(
+    (value: string) => {
+      setSearchTerm(value);
+      if (onSearch) onSearch(value);
+    },
+    [onSearch]
+  );
 
   const handleSelectAll = useCallback(() => {
     if (selectedIds.length === items.length || selectedIds.length > 0) {
@@ -228,7 +239,7 @@ function GenericAddItemsModal<T>({
                       <Input
                         sx={{ width: '100%' }}
                         placeholder={searchPlaceholder}
-                        onChange={e => onSearch?.(e.target.value)}
+                        onChange={e => handleSearch(e.target.value)}
                         startDecorator={<SearchIcon />}
                       />
                     )}
@@ -240,7 +251,7 @@ function GenericAddItemsModal<T>({
                     className="generic-add-items-modal-search-input"
                     sx={{ width: '100%', pr: { xs: '15px', sm: '30px' } }}
                     placeholder={searchPlaceholder}
-                    onChange={e => onSearch(e.target.value)}
+                    onChange={e => handleSearch(e.target.value)}
                     startDecorator={<SearchIcon />}
                   />
                 )
@@ -275,7 +286,13 @@ function GenericAddItemsModal<T>({
                         color: 'text.secondary',
                       }}
                     >
-                      {t('common.no_results_found', 'No results found')}
+                      <Typography level="body-lg" color="neutral">
+                        {searchTerm.length > 0 && searchTerm.length < 3
+                          ? 'Type at least 3 characters to search.'
+                          : searchTerm
+                            ? t('common.no_results_found', 'No results found')
+                            : t('common.no_results_found', 'No results found')}
+                      </Typography>
                     </Box>
                   )}
                   {isLoadingMore && (

--- a/apps/client/app/components/common/GenericAddItemsModal.tsx
+++ b/apps/client/app/components/common/GenericAddItemsModal.tsx
@@ -56,6 +56,7 @@ export interface GenericAddItemsModalProps<T> {
   modalWidth?: string | number;
   value?: string[];
   showButtonBadge?: boolean;
+  searchMinLength?: number;
 }
 
 function GenericAddItemsModal<T>({
@@ -93,6 +94,7 @@ function GenericAddItemsModal<T>({
   modalWidth = '950px',
   value,
   showButtonBadge = true,
+  searchMinLength,
 }: GenericAddItemsModalProps<T>) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -287,11 +289,11 @@ function GenericAddItemsModal<T>({
                       }}
                     >
                       <Typography level="body-lg" color="neutral">
-                        {searchTerm.length > 0 && searchTerm.length < 3
-                          ? 'Type at least 3 characters to search.'
-                          : searchTerm
-                            ? t('common.no_results_found', 'No results found')
-                            : t('common.no_results_found', 'No results found')}
+                        {searchMinLength && searchTerm.length > 0 && searchTerm.length < searchMinLength
+                          ? t('common.search_min_length', 'Type at least {{count}} characters to search.', {
+                              count: searchMinLength,
+                            })
+                          : t('common.no_results_found', 'No results found')}
                       </Typography>
                     </Box>
                   )}

--- a/apps/client/app/components/organizations/Member.tsx
+++ b/apps/client/app/components/organizations/Member.tsx
@@ -42,7 +42,7 @@ const OrganizationMembers: FC<OrganizationMembersProps> = ({ organization, userP
     () => ({ search: modalSearch, page: 1, limit: 10, publicView: true }),
     [modalSearch]
   );
-  const { data: usersData, isFetching } = useGetUsers(params, { enabled: !!modalSearch });
+  const { data: usersData, isFetching } = useGetUsers(params, { enabled: modalSearch.length >= 3 });
 
   const [permissions] = useState<{ value: Permission[]; error?: string | null }>({
     value: [Permission.read],

--- a/apps/client/app/components/organizations/Member.tsx
+++ b/apps/client/app/components/organizations/Member.tsx
@@ -302,6 +302,7 @@ const OrganizationMembers: FC<OrganizationMembersProps> = ({ organization, userP
                 getItemId={user => user.username}
                 onSearch={term => debouncedModalSearch(term)}
                 searchPlaceholder={t('common.search_users', 'Search users')}
+                searchMinLength={3}
                 onAdd={handleAddMembers}
                 isPending={shareDocument.isPending}
                 renderItem={renderUserItem}

--- a/apps/client/pages/api/users/__tests__/index.test.ts
+++ b/apps/client/pages/api/users/__tests__/index.test.ts
@@ -27,7 +27,12 @@ vi.mock('@server/middlewares/baseApi', () => {
 });
 
 vi.mock('@bike4mind/database', () => ({
-  User: { find: () => ({ getQuery: () => ({}) }), populate: vi.fn().mockResolvedValue(undefined), hydrate: (u: any) => u, aggregate: vi.fn().mockResolvedValue([]) },
+  User: {
+    find: () => ({ getQuery: () => ({}) }),
+    populate: vi.fn().mockResolvedValue(undefined),
+    hydrate: (u: any) => u,
+    aggregate: vi.fn().mockResolvedValue([]),
+  },
   Project: { findById: vi.fn() },
   executeFacetCompatible: (_m: any, _p: any, facet: any) => {
     mockRefs.facet = facet;
@@ -53,7 +58,10 @@ describe('GET /api/users - publicView enumeration guards', () => {
   });
 
   it('rejects downloadAll for a non-admin with 403', async () => {
-    const { req, res } = mocks({ id: 'u1', isAdmin: false }, { publicView: 'true', downloadAll: 'true' });
+    const { req, res } = mocks(
+      { id: 'u1', isAdmin: false },
+      { publicView: 'true', downloadAll: 'true', search: 'abc' }
+    );
     await mockRefs.getHandler!(req, res);
     expect(res._getStatusCode()).toBe(403);
     // Never reached the aggregation.
@@ -67,7 +75,7 @@ describe('GET /api/users - publicView enumeration guards', () => {
   });
 
   it('caps the publicView page size for a non-admin (limit 1000 -> 50)', async () => {
-    const { req, res } = mocks({ id: 'u1', isAdmin: false }, { publicView: 'true', limit: '1000' });
+    const { req, res } = mocks({ id: 'u1', isAdmin: false }, { publicView: 'true', limit: '1000', search: 'abc' });
     await mockRefs.getHandler!(req, res);
     expect(res._getStatusCode()).toBe(200);
     const limitStage = mockRefs.facet.paginatedResults.find((s: any) => '$limit' in s);
@@ -79,5 +87,33 @@ describe('GET /api/users - publicView enumeration guards', () => {
     await mockRefs.getHandler!(req, res);
     const limitStage = mockRefs.facet.paginatedResults.find((s: any) => '$limit' in s);
     expect(limitStage.$limit).toBe(1000);
+  });
+
+  it('returns 400 when non-admin publicView has no search term', async () => {
+    const { req, res } = mocks({ id: 'u1', isAdmin: false }, { publicView: 'true' });
+    await mockRefs.getHandler!(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockRefs.facet).toBeUndefined();
+  });
+
+  it('returns 400 when non-admin publicView has a 2-char search term', async () => {
+    const { req, res } = mocks({ id: 'u1', isAdmin: false }, { publicView: 'true', search: 'ab' });
+    await mockRefs.getHandler!(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockRefs.facet).toBeUndefined();
+  });
+
+  it('returns 200 when non-admin publicView has a 3-char search term', async () => {
+    const { req, res } = mocks({ id: 'u1', isAdmin: false }, { publicView: 'true', search: 'abc' });
+    await mockRefs.getHandler!(req, res);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('allows non-admin publicView with no search when projectId is provided', async () => {
+    // projectId-scoped requests (e.g. project member list) are not a full-directory
+    // enumeration path, so they are exempt from the 3-char search minimum.
+    const { req, res } = mocks({ id: 'u1', isAdmin: false }, { publicView: 'true', projectId: 'proj1' });
+    await mockRefs.getHandler!(req, res);
+    expect(res._getStatusCode()).toBe(200);
   });
 });

--- a/apps/client/pages/api/users/index.ts
+++ b/apps/client/pages/api/users/index.ts
@@ -10,7 +10,10 @@ import { Request } from 'express';
 const querySchema = z.object({
   page: z.string().regex(/^\d+$/).transform(Number).default(1),
   limit: z.string().regex(/^\d+$/).transform(Number).default(10),
-  search: z.string().optional(),
+  search: z
+    .string()
+    .optional()
+    .transform(val => val?.trim()),
   sortField: z.string().default('createdAt'),
   sortOrder: z.enum(['asc', 'desc']).default('desc'),
   orgSearch: z.array(z.string()).default(['all']),
@@ -81,7 +84,9 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
     // users, downloadAll is admin-only, and the page size is hard-capped.
     const isAdmin = !!req.user?.isAdmin;
     if (publicView && !isAdmin) {
-      if (!search || search.trim().length < 3) {
+      // projectId-scoped requests show members of one specific project — not a full-directory
+      // enumeration path — so they are exempt from the search-term minimum.
+      if (!projectId && (!search || search.length < 3)) {
         return res.status(400).json({ message: 'A search term of at least 3 characters is required.' });
       }
       if (downloadAll) {

--- a/apps/client/pages/api/users/index.ts
+++ b/apps/client/pages/api/users/index.ts
@@ -90,7 +90,7 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
     } else if (downloadAll && !isAdmin) {
       return res.status(403).json({ message: 'Bulk user export is admin-only.' });
     }
-    const PUBLIC_VIEW_MAX_LIMIT = 20;
+    const PUBLIC_VIEW_MAX_LIMIT = 50;
     const effectiveLimit = publicView && !isAdmin ? Math.min(limit, PUBLIC_VIEW_MAX_LIMIT) : limit;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/client/pages/api/users/index.ts
+++ b/apps/client/pages/api/users/index.ts
@@ -76,14 +76,21 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
 
     // publicView is the limited directory search used by invite/member pickers; it
     // bypasses CASL by design (regular users have no read grant on User). Keep it
-    // usable for targeted search, but not as a bulk-export or full-directory dump for
-    // non-admins: downloadAll (unbounded) is admin-only, and the publicView page size
-    // is capped. (Return 403 directly - the surrounding try/catch turns throws into 500.)
+    // usable for targeted lookup, but not as a bulk-export or full-directory dump:
+    // non-admins require a minimum search term to prevent blind pagination over all
+    // users, downloadAll is admin-only, and the page size is hard-capped.
     const isAdmin = !!req.user?.isAdmin;
-    if (downloadAll && !isAdmin) {
-      return res.status(403).json({ message: 'Bulk user export is admin-only' });
+    if (publicView && !isAdmin) {
+      if (!search || search.trim().length < 3) {
+        return res.status(400).json({ message: 'A search term of at least 3 characters is required.' });
+      }
+      if (downloadAll) {
+        return res.status(403).json({ message: 'Bulk user export is admin-only.' });
+      }
+    } else if (downloadAll && !isAdmin) {
+      return res.status(403).json({ message: 'Bulk user export is admin-only.' });
     }
-    const PUBLIC_VIEW_MAX_LIMIT = 50;
+    const PUBLIC_VIEW_MAX_LIMIT = 20;
     const effectiveLimit = publicView && !isAdmin ? Math.min(limit, PUBLIC_VIEW_MAX_LIMIT) : limit;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/client/pages/api/users/index.ts
+++ b/apps/client/pages/api/users/index.ts
@@ -84,8 +84,8 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
     // users, downloadAll is admin-only, and the page size is hard-capped.
     const isAdmin = !!req.user?.isAdmin;
     if (publicView && !isAdmin) {
-      // projectId-scoped requests show members of one specific project — not a full-directory
-      // enumeration path — so they are exempt from the search-term minimum.
+      // projectId-scoped requests show members of one specific project -- not a full-directory
+      // enumeration path -- so they are exempt from the search-term minimum.
       if (!projectId && (!search || search.length < 3)) {
         return res.status(400).json({ message: 'A search term of at least 3 characters is required.' });
       }


### PR DESCRIPTION
## Summary

Closes #744

Fixes the remaining enumeration vector in `GET /api/users?publicView=true`.

When we rechecked the code, the upstream had already partially addressed this (#618 — scoping non-admin reads): `PUBLIC_VIEW_MAX_LIMIT = 50` was in place and `downloadAll` was blocked for non-admins. That partial fix reduces the blast radius but does not fully close enumeration — a non-admin could still paginate through all 325 users with no search term (7 requests × 50 results = full directory).

**This PR adds the missing guard:** non-admin `publicView` requests now require a minimum 3-character search term, preventing blind pagination over the full user list.

## Changes

- `apps/client/pages/api/users/index.ts` — single file change

**Before (upstream partial fix):**
- `downloadAll` blocked for non-admins ✅
- Page size capped at 50 ✅
- No search term required ❌ — full directory still enumerable via pagination

**After (this PR):**
- `downloadAll` blocked for non-admins ✅
- Page size capped at 50 ✅
- Minimum 3-character search required for non-admin `publicView` ✅

## Test plan

- [ ] `GET /api/users?publicView=true` with no search term → `400` for non-admin
- [ ] `GET /api/users?publicView=true&search=al` (2 chars) → `400` for non-admin
- [ ] `GET /api/users?publicView=true&search=all` (3 chars) → `200` with max 50 results for non-admin
- [ ] `GET /api/users?publicView=true&downloadAll=true&search=allan` → `403` for non-admin
- [ ] All of the above with admin token → no restrictions, behaves as before
- [ ] Member picker / invite flow still works (typing 3+ chars in user search)

