### PR TITLE
feat(entitlements): register bob:pro via a bob comp-tag grant

### DIFF
--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -140,6 +140,10 @@ const TAG_GRANT_ROWS: TagGrantRow[] = [
   // the tag->entitlement cutover (M3.5 migration). Call sites still use the legacy
   // tag predicates until M3.5 migrates them to `requestHasTavernAccess`.
   { tag: 'tavern', entitlements: ['tavern:pro'] },
+  // [DELETION-FOOTPRINT] Bob comp grant: the `bob` tag bridges to `bob:pro`, which
+  // gates Bob's `/bob` route and its nav entry (the premium-bob overlay). No Stripe
+  // price yet; granted-only initially. Removed when Bob is extracted.
+  { tag: 'bob', entitlements: ['bob:pro'] },
 ];
 
 /**


### PR DESCRIPTION
Registers a `bob:pro` entitlement so the premium-bob overlay's `/bob` route and nav item can gate on a real, grantable key.

**Why:** the overlay gates its route + nav via `requireEntitlement`, but a key only resolves if it's in the registry's `KNOWN_ENTITLEMENT_KEYS`. Gating on an unregistered key resolves for no one, so the route would deny everyone and the nav (which has no admin bypass) would show for no one.

**Change:** one `TAG_GRANT_ROWS` entry, `{ tag: 'bob', entitlements: ['bob:pro'] }` — same comp-grant pattern as `overwatch` / `pi` / `tavern`. `bob:pro` auto-registers in `KNOWN_ENTITLEMENT_KEYS` via the grant-row aggregation; tagging a user `bob` confers `bob:pro`. No Stripe price yet (granted-only).

**Verified:**
- `lib/entitlements` tests pass (40) — structural invariants (normalization, no dup tags, each row grants a key, 1:1 passthrough + remap) cover the new row.
- Runtime check: `KNOWN_ENTITLEMENT_KEYS` now includes `bob:pro`; `entitlementsForTags(['bob'])` -> `{bob, bob:pro}`; `grantTagForEntitlement('bob:pro')` -> `bob`.

Pairs with the overlay setting its gate key to `bob:pro`; both need to land before the Bob route is reachable. Also the grant path (`bob` tag -> `bob:pro`) is what the Bob e2e uses to seed an entitled test user.
