### PR TITLE
fix(publish): publish real fabfile content and render embedded artifacts in the fabfile viewer (#722)

### DIFF
--- a/apps/client/pages/api/publish/__tests__/fabfile.test.ts
+++ b/apps/client/pages/api/publish/__tests__/fabfile.test.ts
@@ -136,6 +136,21 @@ describe('POST /api/publish/fabfile - body sourcing (#722)', () => {
     expect(snapshottedBody()).toBe('text extracted from the pdf at ingest');
   });
 
+  it('rejects a text file whose S3 object is empty and has no fallback text (422)', async () => {
+    mocks.fileLean.mockResolvedValue({
+      userId: OWNER,
+      moderationStatus: 'clean',
+      mimeType: 'text/markdown',
+      text: '',
+      filePath: 'user/fab1/empty.md',
+    });
+    mocks.download.mockResolvedValue(Buffer.from('   \n', 'utf-8')); // 0-byte/whitespace-only object
+
+    const res = await run(makeReq());
+    expect(res.statusCode).toBe(422);
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
   it('rejects a text file that has neither filePath nor text (422)', async () => {
     mocks.fileLean.mockResolvedValue({
       userId: OWNER,

--- a/apps/client/pages/api/publish/__tests__/fabfile.test.ts
+++ b/apps/client/pages/api/publish/__tests__/fabfile.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// fabfile.ts wires an Express-style handler at module load and imports server-only deps; stub them
+// so we can drive the handler (default export) in isolation. @bike4mind/common is NOT mocked - the
+// handler relies on the real PublishFabFileRequestSchema + SupportedFabFileMimeTypes.
+const mocks = vi.hoisted(() => ({
+  fileLean: vi.fn(),
+  publishedFindOneLean: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+  download: vi.fn(),
+}));
+
+// baseApi().post(fn) returns fn, so `export default handler` IS the handler function.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const chain: Record<string, unknown> = {};
+    Object.assign(chain, { use: () => chain, post: (fn: unknown) => fn });
+    return chain;
+  },
+}));
+vi.mock('@bike4mind/database', () => ({
+  FabFile: { findById: () => ({ select: () => ({ lean: mocks.fileLean }) }) },
+  PublishedArtifact: {
+    findOne: () => ({ lean: mocks.publishedFindOneLean }),
+    findOneAndUpdate: mocks.findOneAndUpdate,
+  },
+}));
+vi.mock('@server/services/publish', () => ({
+  resolveVisibility: () => ({ ok: true, visibility: 'public' }),
+  checkScopePermission: () => ({ ok: true }),
+  checkPublishQuota: () => ({ ok: true }),
+}));
+vi.mock('@server/utils/storage', () => ({
+  getFilesStorage: () => ({ download: mocks.download }),
+}));
+
+import handler from '../fabfile';
+
+const OWNER = 'owner-user-id';
+
+type Res = {
+  statusCode: number;
+  body: unknown;
+  status: (code: number) => Res;
+  json: (obj: unknown) => Res;
+};
+const makeRes = (): Res => {
+  const res = { statusCode: 0, body: undefined as unknown } as Res;
+  res.status = (code: number) => ((res.statusCode = code), res);
+  res.json = (obj: unknown) => ((res.body = obj), res);
+  return res;
+};
+const makeReq = () => ({
+  user: { id: OWNER, isAdmin: false, organizationId: null, username: 'u' },
+  body: { fabFileId: 'fab1', tier: 'user', visibility: 'public' },
+  logger: { info: () => {} },
+});
+const run = (req: unknown) => {
+  const res = makeRes();
+  return (handler as (req: unknown, res: unknown) => Promise<void>)(req, res).then(() => res);
+};
+
+// The renderedBody the handler snapshotted, read off the findOneAndUpdate $set.
+const snapshottedBody = (): string => {
+  const [, update] = mocks.findOneAndUpdate.mock.calls[0];
+  return (update as { $set: { renderedBody: string } }).$set.renderedBody;
+};
+
+describe('POST /api/publish/fabfile - body sourcing (#722)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.publishedFindOneLean.mockResolvedValue(null);
+    mocks.findOneAndUpdate.mockResolvedValue({ publicId: 'f-abc', slug: 'f-abc' });
+  });
+
+  it('sources a text file body from S3 (filePath), not the empty file.text', async () => {
+    mocks.fileLean.mockResolvedValue({
+      userId: OWNER,
+      fileName: 'notes.md',
+      text: '', // "Save as Text" leaves this empty; real content is in S3
+      mimeType: 'text/markdown',
+      filePath: 'user/fab1/notes.md',
+    });
+    mocks.download.mockResolvedValue(Buffer.from('# Real content\nfrom S3', 'utf-8'));
+
+    const res = await run(makeReq());
+    expect(res.statusCode).toBe(200);
+    expect(mocks.download).toHaveBeenCalledWith('user/fab1/notes.md');
+    expect(snapshottedBody()).toBe('# Real content\nfrom S3');
+  });
+
+  it('falls back to file.text when the S3 download fails', async () => {
+    mocks.fileLean.mockResolvedValue({
+      userId: OWNER,
+      mimeType: 'text/plain',
+      text: 'already extracted text',
+      filePath: 'user/fab1/x.txt',
+    });
+    mocks.download.mockRejectedValue(new Error('NoSuchKey'));
+
+    const res = await run(makeReq());
+    expect(res.statusCode).toBe(200);
+    expect(snapshottedBody()).toBe('already extracted text');
+  });
+
+  it('rejects a non-text (binary) file with no extracted text (415)', async () => {
+    mocks.fileLean.mockResolvedValue({
+      userId: OWNER,
+      mimeType: 'application/pdf',
+      text: '',
+      filePath: 'user/fab1/doc.pdf',
+    });
+
+    const res = await run(makeReq());
+    expect(res.statusCode).toBe(415);
+    expect(mocks.download).not.toHaveBeenCalled();
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('publishes a binary file using its already-extracted text when present', async () => {
+    mocks.fileLean.mockResolvedValue({
+      userId: OWNER,
+      mimeType: 'application/pdf',
+      text: 'text extracted from the pdf at ingest',
+      filePath: 'user/fab1/doc.pdf',
+    });
+
+    const res = await run(makeReq());
+    expect(res.statusCode).toBe(200);
+    // Binary bytes are never decoded as UTF-8; the pre-extracted text is used verbatim.
+    expect(mocks.download).not.toHaveBeenCalled();
+    expect(snapshottedBody()).toBe('text extracted from the pdf at ingest');
+  });
+
+  it('rejects a text file that has neither filePath nor text (422)', async () => {
+    mocks.fileLean.mockResolvedValue({
+      userId: OWNER,
+      mimeType: 'text/markdown',
+      text: '',
+    });
+
+    const res = await run(makeReq());
+    expect(res.statusCode).toBe(422);
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/publish/__tests__/fabfile.test.ts
+++ b/apps/client/pages/api/publish/__tests__/fabfile.test.ts
@@ -76,6 +76,7 @@ describe('POST /api/publish/fabfile - body sourcing (#722)', () => {
   it('sources a text file body from S3 (filePath), not the empty file.text', async () => {
     mocks.fileLean.mockResolvedValue({
       userId: OWNER,
+      moderationStatus: 'clean',
       fileName: 'notes.md',
       text: '', // "Save as Text" leaves this empty; real content is in S3
       mimeType: 'text/markdown',
@@ -92,6 +93,7 @@ describe('POST /api/publish/fabfile - body sourcing (#722)', () => {
   it('falls back to file.text when the S3 download fails', async () => {
     mocks.fileLean.mockResolvedValue({
       userId: OWNER,
+      moderationStatus: 'clean',
       mimeType: 'text/plain',
       text: 'already extracted text',
       filePath: 'user/fab1/x.txt',
@@ -106,6 +108,7 @@ describe('POST /api/publish/fabfile - body sourcing (#722)', () => {
   it('rejects a non-text (binary) file with no extracted text (415)', async () => {
     mocks.fileLean.mockResolvedValue({
       userId: OWNER,
+      moderationStatus: 'clean',
       mimeType: 'application/pdf',
       text: '',
       filePath: 'user/fab1/doc.pdf',
@@ -120,6 +123,7 @@ describe('POST /api/publish/fabfile - body sourcing (#722)', () => {
   it('publishes a binary file using its already-extracted text when present', async () => {
     mocks.fileLean.mockResolvedValue({
       userId: OWNER,
+      moderationStatus: 'clean',
       mimeType: 'application/pdf',
       text: 'text extracted from the pdf at ingest',
       filePath: 'user/fab1/doc.pdf',
@@ -135,12 +139,43 @@ describe('POST /api/publish/fabfile - body sourcing (#722)', () => {
   it('rejects a text file that has neither filePath nor text (422)', async () => {
     mocks.fileLean.mockResolvedValue({
       userId: OWNER,
+      moderationStatus: 'clean',
       mimeType: 'text/markdown',
       text: '',
     });
 
     const res = await run(makeReq());
     expect(res.statusCode).toBe(422);
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  // Hold-until-scanned: never publish (serve) a file that has not cleared moderation.
+  it('refuses to publish a file still being scanned (409)', async () => {
+    mocks.fileLean.mockResolvedValue({
+      userId: OWNER,
+      moderationStatus: 'pending',
+      mimeType: 'text/markdown',
+      text: 'content',
+      filePath: 'user/fab1/notes.md',
+    });
+
+    const res = await run(makeReq());
+    expect(res.statusCode).toBe(409);
+    expect(mocks.download).not.toHaveBeenCalled();
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('refuses to publish a moderation-blocked file (403)', async () => {
+    mocks.fileLean.mockResolvedValue({
+      userId: OWNER,
+      moderationStatus: 'blocked',
+      mimeType: 'text/markdown',
+      text: 'content',
+      filePath: 'user/fab1/notes.md',
+    });
+
+    const res = await run(makeReq());
+    expect(res.statusCode).toBe(403);
     expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/pages/api/publish/fabfile.ts
+++ b/apps/client/pages/api/publish/fabfile.ts
@@ -1,8 +1,9 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { randomUUID } from 'node:crypto';
 import { FabFile, PublishedArtifact } from '@bike4mind/database';
-import { PublishFabFileRequestSchema, type PublishResult } from '@bike4mind/common';
+import { PublishFabFileRequestSchema, SupportedFabFileMimeTypes, type PublishResult } from '@bike4mind/common';
 import { resolveVisibility, checkScopePermission, checkPublishQuota, type PublishUser } from '@server/services/publish';
+import { getFilesStorage } from '@server/utils/storage';
 
 /**
  * POST /api/publish/fabfile - publish a FabFile as a public viewer page at
@@ -13,6 +14,74 @@ import { resolveVisibility, checkScopePermission, checkPublishQuota, type Publis
 
 function publicId(): string {
   return randomUUID().replace(/-/g, '').slice(0, 12);
+}
+
+// Mime types whose stored bytes ARE text-representable, so they can back a text viewer page. This
+// is an allowlist (fail-closed): anything not listed - Office/PDF (need extraction), raster images
+// (no text), or a future/unknown type - is treated as non-text so we never store decoded binary
+// garbage. SVG is XML text, so its source is publishable as literal text.
+const TEXT_MIME_TYPES = new Set<string>([
+  SupportedFabFileMimeTypes.TXT_PLAIN,
+  SupportedFabFileMimeTypes.TXT_MARKDOWN,
+  SupportedFabFileMimeTypes.TXT_MD_LEGACY,
+  SupportedFabFileMimeTypes.JSON,
+  SupportedFabFileMimeTypes.HTML,
+  SupportedFabFileMimeTypes.CSV,
+  SupportedFabFileMimeTypes.XML,
+  SupportedFabFileMimeTypes.SVG,
+  SupportedFabFileMimeTypes.JS,
+  SupportedFabFileMimeTypes.JSX,
+  SupportedFabFileMimeTypes.TS,
+  SupportedFabFileMimeTypes.TSX,
+  SupportedFabFileMimeTypes.PY,
+  SupportedFabFileMimeTypes.JAVA,
+  SupportedFabFileMimeTypes.CPP,
+  SupportedFabFileMimeTypes.CS,
+  SupportedFabFileMimeTypes.PHP,
+  SupportedFabFileMimeTypes.RUBY,
+  SupportedFabFileMimeTypes.GO,
+  SupportedFabFileMimeTypes.SWIFT,
+  SupportedFabFileMimeTypes.KOTLIN,
+  SupportedFabFileMimeTypes.RUST,
+  SupportedFabFileMimeTypes.CSS,
+  SupportedFabFileMimeTypes.LESS,
+  SupportedFabFileMimeTypes.SASS,
+  SupportedFabFileMimeTypes.SCSS,
+  SupportedFabFileMimeTypes.YAML,
+  SupportedFabFileMimeTypes.TOML,
+  SupportedFabFileMimeTypes.SH,
+  SupportedFabFileMimeTypes.BASH,
+  SupportedFabFileMimeTypes.INI,
+  SupportedFabFileMimeTypes.CONF,
+]);
+
+/**
+ * Source the publishable text body for a fabfile. "Save as Text" / uploaded files keep their content
+ * in S3 at `filePath`, not in `file.text` (which is often empty), so for text-representable types we
+ * snapshot the S3 bytes and fall back to `file.text`. Non-text types (pdf/office/image or unknown)
+ * have no text body for a viewer page - use already-extracted `file.text` if present, else reject.
+ * Server analogue of the client `getContentFromFabfile`, minus the browser-only extractors/settings.
+ */
+async function sourceFabFileBody(file: {
+  text?: string | null;
+  mimeType?: string;
+  filePath?: string;
+}): Promise<{ ok: true; body: string } | { ok: false; status: number; error: string }> {
+  const existingText = file.text?.trim() ? file.text : '';
+  if (!file.mimeType || !TEXT_MIME_TYPES.has(file.mimeType)) {
+    if (existingText) return { ok: true, body: existingText };
+    return { ok: false, status: 415, error: `Cannot publish a ${file.mimeType ?? 'binary'} file as a viewer page` };
+  }
+  if (file.filePath) {
+    try {
+      const buf = await getFilesStorage().download(file.filePath);
+      return { ok: true, body: buf.toString('utf-8') };
+    } catch {
+      // Storage miss/expired object: fall through to any already-extracted text.
+    }
+  }
+  if (existingText) return { ok: true, body: existingText };
+  return { ok: false, status: 422, error: 'File has no readable content to publish' };
 }
 
 const handler = baseApi().post(async (req, res) => {
@@ -27,9 +96,13 @@ const handler = baseApi().post(async (req, res) => {
   const body = parsed.data;
   const userId = String(req.user.id);
 
-  const file = await FabFile.findById(body.fabFileId)
-    .select('userId fileName text mimeType')
-    .lean<{ userId: string; fileName?: string; text?: string | null; mimeType?: string } | null>();
+  const file = await FabFile.findById(body.fabFileId).select('userId fileName text mimeType filePath').lean<{
+    userId: string;
+    fileName?: string;
+    text?: string | null;
+    mimeType?: string;
+    filePath?: string;
+  } | null>();
   if (!file) {
     return res.status(404).json({ error: 'File not found' });
   }
@@ -71,7 +144,11 @@ const handler = baseApi().post(async (req, res) => {
 
   const id = existing?.publicId ?? publicId();
   const slug = existing?.slug ?? `f-${id}`;
-  const body_ = (file.text ?? '').toString();
+  const sourced = await sourceFabFileBody(file);
+  if (!sourced.ok) {
+    return res.status(sourced.status).json({ error: sourced.error });
+  }
+  const body_ = sourced.body;
 
   // Cumulative per-owner quota. Re-publishing the same file (existing) overwrites
   // in place, so exclude that key from usage; a fresh publish counts as a new row.

--- a/apps/client/pages/api/publish/fabfile.ts
+++ b/apps/client/pages/api/publish/fabfile.ts
@@ -79,8 +79,11 @@ async function sourceFabFileBody(file: {
   }
   if (file.filePath) {
     try {
-      const buf = await getFilesStorage().download(file.filePath);
-      return { ok: true, body: buf.toString('utf-8') };
+      const decoded = (await getFilesStorage().download(file.filePath)).toString('utf-8');
+      // Only accept a non-empty object; a 0-byte/whitespace-only download falls through to
+      // file.text (else 422) rather than publishing an empty <pre>. Returns the untrimmed body
+      // so real content keeps its exact whitespace.
+      if (decoded.trim()) return { ok: true, body: decoded };
     } catch {
       // Storage miss/expired object: fall through to any already-extracted text.
     }
@@ -163,6 +166,10 @@ const handler = baseApi().post(async (req, res) => {
 
   const id = existing?.publicId ?? publicId();
   const slug = existing?.slug ?? `f-${id}`;
+  // Sourcing runs before the quota check because quota needs the sourced byte length
+  // (Buffer.byteLength below). The whole object is read into memory here; acceptable since the
+  // caller can only publish a file they own (checked above) - revisit if publish ever accepts
+  // files not owned by the caller.
   const sourced = await sourceFabFileBody(file);
   if (!sourced.ok) {
     return res.status(sourced.status).json({ error: sourced.error });

--- a/apps/client/pages/api/publish/fabfile.ts
+++ b/apps/client/pages/api/publish/fabfile.ts
@@ -1,7 +1,12 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { randomUUID } from 'node:crypto';
 import { FabFile, PublishedArtifact } from '@bike4mind/database';
-import { PublishFabFileRequestSchema, SupportedFabFileMimeTypes, type PublishResult } from '@bike4mind/common';
+import {
+  PublishFabFileRequestSchema,
+  SupportedFabFileMimeTypes,
+  isImageServeable,
+  type PublishResult,
+} from '@bike4mind/common';
 import { resolveVisibility, checkScopePermission, checkPublishQuota, type PublishUser } from '@server/services/publish';
 import { getFilesStorage } from '@server/utils/storage';
 
@@ -96,18 +101,32 @@ const handler = baseApi().post(async (req, res) => {
   const body = parsed.data;
   const userId = String(req.user.id);
 
-  const file = await FabFile.findById(body.fabFileId).select('userId fileName text mimeType filePath').lean<{
-    userId: string;
-    fileName?: string;
-    text?: string | null;
-    mimeType?: string;
-    filePath?: string;
-  } | null>();
+  const file = await FabFile.findById(body.fabFileId)
+    .select('userId fileName text mimeType filePath moderationStatus')
+    .lean<{
+      userId: string;
+      fileName?: string;
+      text?: string | null;
+      mimeType?: string;
+      filePath?: string;
+      moderationStatus?: string | null;
+    } | null>();
   if (!file) {
     return res.status(404).json({ error: 'File not found' });
   }
   if (file.userId !== userId && !req.user.isAdmin) {
     return res.status(403).json({ error: 'You can only publish your own files' });
+  }
+  // Hold-until-scanned: publishing serves the file's bytes on a public page, so never publish a
+  // file that has not cleared moderation. isImageServeable is fail-closed on ALL mime types
+  // (serveable only when moderationStatus === 'clean'), so this also covers a mislabeled image.
+  if (!isImageServeable(file)) {
+    const blocked = file.moderationStatus === 'blocked';
+    return res.status(blocked ? 403 : 409).json({
+      error: blocked
+        ? 'This file was blocked by content moderation and cannot be published'
+        : 'This file is still being scanned; try publishing again shortly',
+    });
   }
 
   const tier = body.tier;

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -1228,6 +1228,10 @@ function renderViewerPage(
       // trims cleanedContent, so use the raw body to preserve leading/trailing whitespace).
       contentHtml = `<pre class="b4m-pre">${escapeHtml(body)}</pre>`;
     } else {
+      // All non-artifact text collapses into one <pre> rendered BEFORE the artifact frames (same
+      // shape as the reply branch's article-then-blocks). So text interleaved between multiple
+      // artifacts loses document order; the common case (prose then one trailing artifact) is fine.
+      // Revisit if fabfiles ever need interleaved text/artifact authoring.
       const pre = cleanedContent ? `<pre class="b4m-pre">${escapeHtml(cleanedContent)}</pre>` : '';
       const blocks = artifacts.map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts)).join('\n');
       contentHtml = `${pre}${blocks}`;

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -35,6 +35,7 @@ import {
 } from '@server/services/publish/viewerSecurity';
 import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
 import {
+  parseArtifacts,
   parseArtifactsWithFallback,
   type ParsedArtifact,
   type ArtifactParseResult,
@@ -356,18 +357,18 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
 
   // -- Reply / fabfile: render the snapshot body to a sanitized viewer page. --
   if (artifact.source.kind === 'reply' || artifact.source.kind === 'fabfile') {
-    // Reply artifact sub-document (`?a={index}`): serve one embedded HTML/SVG artifact as a
+    // Reply/fabfile artifact sub-document (`?a={index}`): serve one embedded HTML/SVG artifact as a
     // standalone SANDBOXED document for the viewer page's iframe. Author JS runs, but the
     // response's `sandbox allow-scripts` CSP forces an opaque origin (NO allow-same-origin)
     // even on a direct top-level navigation, so it can never read the app origin's token -
-    // the same isolation the bundle path relies on. Reply-only, and the viewer only emits
-    // `?a` for html/svg artifacts, so an out-of-range or non-embeddable index is a 404. The
-    // visibility gate already ran above, so this reads only content the caller is authorized for.
-    // Require a non-empty `a` so `?a=` doesn't coerce to index 0 (Number('') === 0); an empty
-    // value falls through to the normal page render instead.
-    if (artifact.source.kind === 'reply' && typeof req.query.a === 'string' && req.query.a !== '') {
+    // the same isolation the bundle path relies on. The viewer only emits `?a` for html/svg
+    // artifacts, so an out-of-range or non-embeddable index is a 404. The visibility gate already
+    // ran above, so this reads only content the caller is authorized for. Require a non-empty `a`
+    // so `?a=` doesn't coerce to index 0 (Number('') === 0); an empty value falls through to the
+    // normal page render instead.
+    if (typeof req.query.a === 'string' && req.query.a !== '') {
       const idx = Number(req.query.a);
-      const { artifacts } = extractViewerArtifacts(artifact.renderedBody ?? '');
+      const { artifacts } = extractViewerArtifacts(artifact.renderedBody ?? '', artifact.source.kind);
       const target = Number.isInteger(idx) && idx >= 0 ? artifacts[idx] : undefined;
       if (!target || (target.type !== 'html' && target.type !== 'svg')) {
         return res.status(404).json({ error: 'Not found' });
@@ -404,8 +405,8 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     }
     // Base URL this page was reached at, so the embedded-artifact iframes point back to the
     // same route (`/p/r|f/{publicId}` or the `/a/{token}` share) carrying the same authorization.
-    // selfPath + canFrameArtifacts are consumed only by the reply render below; the fabfile branch
-    // of renderViewerPage ignores them (it emits an escaped <pre>, no artifact frames).
+    // Both the reply and fabfile branches of renderViewerPage consume selfPath + canFrameArtifacts
+    // to frame embedded html/svg artifacts (fabfile keeps its non-artifact text as escaped <pre>).
     const sourcePrefix = artifact.source.kind === 'reply' ? 'r' : 'f';
     const selfPath = isShare ? `/a/${encodeURIComponent(shareToken)}` : `/p/${sourcePrefix}/${artifact.publicId}`;
     // Whether an embedded artifact can be framed via its `?a=` sub-document. The artifact iframe
@@ -1139,15 +1140,19 @@ function sendRawArtifact(
 }
 
 /**
- * parseArtifactsWithFallback, but with artifacts in DOCUMENT order. `parseArtifacts` returns them
- * reverse-sorted by position (a side effect of its back-to-front tag-removal pass), which would
- * otherwise render a multi-artifact reply bottom-up. Sorting by `startIndex` restores document
- * order for the common case (explicit `<artifact>` tags share one coordinate space). The viewer
- * render and the `?a=` sub-document handler BOTH extract via this helper, so an iframe's `?a={i}`
- * always indexes the same artifact the viewer framed at slot i.
+ * Extract embedded artifacts for the viewer, in DOCUMENT order. Parser choice is kind-dependent:
+ * - reply: `parseArtifactsWithFallback` also promotes fenced code / bare-HTML docs to artifacts,
+ *   matching the in-app render of agent markdown.
+ * - fabfile: `parseArtifacts` (explicit `<artifact>` blocks ONLY). A fabfile is literal file text,
+ *   so a ```code``` fence in an uploaded markdown file is file content, not an artifact, and must
+ *   stay verbatim in the <pre> - fence promotion would wrongly hoist it into a card.
+ * Both parsers return artifacts reverse-sorted by position (a side effect of the back-to-front
+ * tag-removal pass); sorting by `startIndex` restores document order. The viewer render and the
+ * `?a=` sub-document handler BOTH extract via this helper with the SAME kind, so an iframe's
+ * `?a={i}` always indexes the same artifact the viewer framed at slot i.
  */
-function extractViewerArtifacts(body: string): ArtifactParseResult {
-  const result = parseArtifactsWithFallback(body);
+function extractViewerArtifacts(body: string, kind: string): ArtifactParseResult {
+  const result = kind === 'fabfile' ? parseArtifacts(body) : parseArtifactsWithFallback(body);
   return { ...result, artifacts: [...result.artifacts].sort((a, b) => a.startIndex - b.startIndex) };
 }
 
@@ -1189,8 +1194,9 @@ function renderArtifactBlock(artifact: ParsedArtifact, index: number, selfPath: 
  * Render a reply/fabfile snapshot to a standalone HTML page. Replies are markdown (rendered via
  * marked) with any embedded `<artifact>` blocks extracted: the surrounding prose renders inline,
  * and each HTML/SVG artifact renders in its own sandboxed `?a=` iframe (non-embeddable types get
- * a placeholder card). Fabfiles render as escaped <pre>. The PAGE is served with script-src 'none'
- * so injected markup cannot execute; artifact JS runs only inside the sandboxed sub-document.
+ * a placeholder card). Fabfiles render their literal text as an escaped <pre>, with only explicit
+ * embedded `<artifact>` blocks extracted and framed the same way. The PAGE is served with
+ * script-src 'none' so injected markup cannot execute; artifact JS runs only inside the sandbox.
  */
 function renderViewerPage(
   artifact: PublishedArtifactLean,
@@ -1202,7 +1208,7 @@ function renderViewerPage(
   let contentHtml: string;
   let displayTitle = artifact.title || SHARED_FALLBACK_TITLE;
   if (artifact.source.kind === 'reply') {
-    const { artifacts, cleanedContent } = extractViewerArtifacts(body);
+    const { artifacts, cleanedContent } = extractViewerArtifacts(body, 'reply');
     const article = cleanedContent
       ? sanitizeRenderedHtml(marked.parse(cleanedContent, { async: false }) as string)
       : '';
@@ -1210,7 +1216,23 @@ function renderViewerPage(
     contentHtml = `${article}${blocks}`;
     displayTitle = cleanViewerTitle(artifact.title, artifacts);
   } else {
-    contentHtml = `<pre class="b4m-pre">${escapeHtml(body)}</pre>`;
+    // Fabfile: a file is literal text, not markdown prose, so the non-artifact remainder stays an
+    // escaped <pre> (no marked). Only EXPLICIT <artifact> blocks are extracted (parseArtifacts via
+    // extractViewerArtifacts('fabfile')) - a code fence in an uploaded file is file content, not an
+    // artifact. Embedded html/svg artifacts frame via the same sandboxed `?a=` path as the reply
+    // branch, and the SAME parser+kind runs here and in the `?a=` handler, so `?a={i}` resolves to
+    // the block rendered at index i.
+    const { artifacts, cleanedContent } = extractViewerArtifacts(body, 'fabfile');
+    if (artifacts.length === 0) {
+      // No embedded artifacts: render the file body exactly as before, verbatim (parseArtifacts
+      // trims cleanedContent, so use the raw body to preserve leading/trailing whitespace).
+      contentHtml = `<pre class="b4m-pre">${escapeHtml(body)}</pre>`;
+    } else {
+      const pre = cleanedContent ? `<pre class="b4m-pre">${escapeHtml(cleanedContent)}</pre>` : '';
+      const blocks = artifacts.map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts)).join('\n');
+      contentHtml = `${pre}${blocks}`;
+    }
+    displayTitle = cleanViewerTitle(artifact.title, artifacts);
   }
   const titleHtml = escapeHtml(displayTitle);
   const noindexHead = noindex ? `\n${SHARE_NOINDEX_META}` : '';

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -679,6 +679,166 @@ describe('GET /api/publish/serve - reply embedded HTML artifact (#708)', () => {
   });
 });
 
+describe('GET /api/publish/serve - fabfile embedded HTML artifact (#722)', () => {
+  // A fabfile is literal file text (kept as escaped <pre>), but an embedded <artifact> block frames
+  // via the same sandboxed ?a= path as the reply viewer. The leading text uses markdown syntax to
+  // prove the fabfile branch does NOT marked-render it.
+  const FAB_BODY =
+    '# My File\n' +
+    '<artifact identifier="w" type="text/html" title="Widget">' +
+    '<!DOCTYPE html><html><body><h1>FAB_WIDGET</h1><script>window.fab=1</script></body></html>' +
+    '</artifact>';
+
+  const htmlFab = (over: Record<string, unknown> = {}) => ({
+    publicId: 'fhtml',
+    title: 'notes.md',
+    visibility: 'public',
+    ownerId: 'owner1',
+    source: { kind: 'fabfile' },
+    renderedBody: FAB_BODY,
+    storageKeyPrefix: '',
+    manifest: [],
+    tier: 'user',
+    scopeId: 's',
+    slug: 'fhtml',
+    ...over,
+  });
+
+  it('frames the embedded artifact and keeps the remaining fabfile text as literal escaped <pre> (not markdown)', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlFab());
+    const { res, promise } = run(['f', 'fhtml']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain('sandbox="allow-scripts"');
+    expect(data).toContain('src="/p/f/fhtml?a=0"');
+    // Non-artifact text stays literal in a <pre>: the markdown heading is NOT rendered to <h1>.
+    expect(data).toContain('<pre class="b4m-pre">');
+    expect(data).toContain('# My File');
+    expect(data).not.toContain('<h1>My File</h1>');
+    // The artifact's inner markup must NOT leak into the page (it lives in the iframe sub-doc).
+    expect(data).not.toContain('FAB_WIDGET');
+    const csp = res.getHeader('Content-Security-Policy') as string;
+    expect(csp).toContain("script-src 'none'");
+    expect(csp).toContain("frame-src 'self'");
+  });
+
+  it('serves the fabfile ?a= sub-document as a sandboxed HTML doc that runs the artifact JS in isolation', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlFab());
+    const { res, promise } = run(['f', 'fhtml'], { a: '0' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('Content-Type')).toContain('text/html');
+    expect(res._getData() as string).toContain('window.fab=1');
+    const csp = res.getHeader('Content-Security-Policy') as string;
+    expect(csp).toContain('sandbox allow-scripts');
+    expect(csp).not.toContain("script-src 'none'");
+  });
+
+  it('404s an out-of-range fabfile ?a= index', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlFab());
+    const { res, promise } = run(['f', 'fhtml'], { a: '7' });
+    await promise;
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('renders a placeholder card (no iframe) for a non-embeddable fabfile artifact type, and 404s its ?a=', async () => {
+    const reactFab = htmlFab({
+      publicId: 'freact',
+      slug: 'freact',
+      renderedBody:
+        '<artifact identifier="c" type="application/vnd.ant.react" title="Counter">export default function C(){return null}</artifact>',
+    });
+    mockArtifactFindOne.mockReturnValue(reactFab);
+
+    const { res: pageRes, promise: pagePromise } = run(['f', 'freact']);
+    await pagePromise;
+    const page = pageRes._getData() as string;
+    expect(page).toContain('b4m-artifact-card');
+    expect(page).not.toContain('<iframe');
+
+    const { res: subRes, promise: subPromise } = run(['f', 'freact'], { a: '0' });
+    await subPromise;
+    expect(subRes._getStatusCode()).toBe(404);
+  });
+
+  it('renders a placeholder card (not a frame) for a Bearer-gated org fabfile', async () => {
+    const gated = htmlFab({
+      publicId: 'f-org-html',
+      slug: 'f-org-html',
+      visibility: 'organization',
+      tier: 'organization',
+      scopeId: 'org_42',
+    });
+    mockArtifactFindOne.mockReturnValue(gated);
+    const { res, promise } = run(['f', 'f-org-html'], { user: { id: 'member', organizationId: 'org_42' } });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain('b4m-artifact-card');
+    expect(data).not.toContain('<iframe');
+  });
+
+  it('frames the fabfile artifact on a /a/{token} share, pointing the iframe back at the token path', async () => {
+    mockArtifactFindOne.mockReturnValue(htmlFab({ publicId: 'f-shared', slug: 'f-shared' }));
+
+    const { res: pageRes, promise: pagePromise } = run(['a', 'ftok']);
+    await pagePromise;
+    expect(pageRes._getStatusCode()).toBe(200);
+    expect(pageRes._getData() as string).toContain('src="/a/ftok?a=0"');
+
+    const { res: subRes, promise: subPromise } = run(['a', 'ftok'], { a: '0' });
+    await subPromise;
+    expect(subRes._getStatusCode()).toBe(200);
+    expect(subRes._getData() as string).toContain('window.fab=1');
+  });
+
+  it('renders a plain-text fabfile (no artifact) as an escaped <pre>, unchanged - no iframe', async () => {
+    const plain = htmlFab({
+      publicId: 'fplain',
+      slug: 'fplain',
+      renderedBody: 'line one\nif (a < b && c) {}\nline three',
+    });
+    mockArtifactFindOne.mockReturnValue(plain);
+    const { res, promise } = run(['f', 'fplain']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain('<pre class="b4m-pre">');
+    expect(data).not.toContain('<iframe');
+    // Special chars are HTML-escaped, so the literal text is safe and preserved.
+    expect(data).toContain('a &lt; b &amp;&amp; c');
+  });
+
+  it('keeps a ```-fenced code block in a fabfile VERBATIM in the <pre> (no fence promotion to a card)', async () => {
+    // A fabfile is literal file text: a code fence in an uploaded markdown file is content, not an
+    // artifact. Fabfiles parse with parseArtifacts (explicit <artifact> only), so - unlike a reply -
+    // the fence is NOT hoisted into an "open in the app" card and must stay in the escaped <pre>.
+    const fenced = htmlFab({
+      publicId: 'ffence',
+      slug: 'ffence',
+      renderedBody: '# Cheatsheet\n\n```python\nimport numpy as np\ndef go():\n    print("hi")\n```\n',
+    });
+    mockArtifactFindOne.mockReturnValue(fenced);
+    const { res, promise } = run(['f', 'ffence']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain('<pre class="b4m-pre">');
+    expect(data).not.toContain('<iframe');
+    // The card CLASS is always in the page CSS; assert no card ELEMENT was emitted.
+    expect(data).not.toContain('<div class="b4m-artifact-card"');
+    // The fenced code stays literal in the <pre> (escaped), not extracted into an artifact.
+    expect(data).toContain('import numpy as np');
+    expect(data).toContain('```python');
+  });
+});
+
 describe('GET /api/publish/serve - reply/fabfile organization visibility', () => {
   // Org-tier reply/fabfile records store the org id as scopeId; the gate authorizes a viewer
   // whose organizationId matches. This is the path #174 re-enables for reply/fabfile shares.


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

All four tests in the Guide for Testers were verified on the PR preview. Recording per test:

**Test 1 - Embedded HTML artifact renders + JS runs (main fix)** - PASS


https://github.com/user-attachments/assets/00f901bb-49d8-483c-88a6-5586cee948f4


**Test 2 - Code fence stays literal, not promoted (P1 fix)** - PASS


https://github.com/user-attachments/assets/5abba501-b5ac-4e10-8820-dca9280f0e8e



**Test 3 - Binary file rejected (`415`)** - PASS


https://github.com/user-attachments/assets/5fae2181-fc5a-468b-8cf0-455f38b98467



**Test 4 - Plain text escaped in `<pre>` (regression)** - PASS


https://github.com/user-attachments/assets/339f516b-d8fa-4e3c-9e20-ea05b31a1675



## Description

Closes #722. Follow-up to #708 / PR #711 (reply viewer artifact render).

The published fabfile viewer (`/p/f/{publicId}`) had two bugs on the shared render path that made it non-functional end to end:

1. **Publish stored an empty body.** `POST /api/publish/fabfile` snapshotted `file.text` into `renderedBody`. For "Save as Text" / uploaded files the content lives in S3 (at the file's `filePath`), not in `file.text`, so the viewer page rendered blank.
2. **Render never surfaced embedded artifacts.** The #708 sandboxing machinery (the `?a=` sub-document, `renderArtifactBlock`, `buildReplyArtifactCsp`) was guarded to `source.kind === 'reply'`; the fabfile branch dumped the whole body as an escaped `<pre>`, so an embedded `<artifact type="text/html">` showed as escaped text (and today, nothing, because the body was empty).

This PR sources the real file content from S3 at publish time and extends the render path so a fabfile's embedded HTML/SVG artifacts render in the same sandboxed iframe as replies, while the rest of the file stays literal.

## Changes

- **Publish (`apps/client/pages/api/publish/fabfile.ts`)**
  - Added `sourceFabFileBody`: downloads the real bytes from storage via `getFilesStorage().download(file.filePath)` and decodes text mime types, instead of snapshotting the empty `file.text`. Falls back to already-extracted `file.text` when present.
  - Text mime types are gated by a `TEXT_MIME_TYPES` allowlist (fail-closed): non-text types (pdf/office/raster image or unknown) return `415` unless they have pre-extracted text, and a file with no readable content returns `422`.
  - Hold-until-scanned: gates on `isImageServeable(file)` before sourcing/serving bytes, so a file that has not cleared moderation is never published - `blocked` returns `403`, `pending`/`scanning`/unknown returns `409`. (Publishing serves the file's bytes on a public page, so it must respect the same moderation gate as the serve paths.)
  - `.select` now includes `filePath` and `moderationStatus`; quota/byte accounting is charged against the sourced content.
- **Render (`apps/client/pages/api/publish/serve/[...path].ts`)**
  - Broadened the `?a=` sub-document guard from reply-only to reply-or-fabfile.
  - The fabfile branch of `renderViewerPage` now extracts explicit `<artifact>` blocks and frames HTML/SVG ones in a sandboxed iframe, keeping the remaining file text as an escaped `<pre>` (no markdown rendering).
  - Made the artifact extractor kind-aware: fabfiles use `parseArtifacts` (explicit `<artifact>` blocks only) so a code fence in an uploaded markdown file stays verbatim, rather than being promoted into an "open in the app" card. The render path and the `?a=` handler use the same parser + kind, so `?a={i}` always resolves to the block rendered at slot `i`.
  - A fabfile with no embedded artifacts renders its body exactly as before (verbatim, no whitespace trimming).

## Guide for Testers

Publishing a fabfile has no UI button in this PR, so publish via the API. Once logged in, grab your
JWT from any `/api/...` request in DevTools -> Network (the value after `Authorization: Bearer `).

Setup:
```bash
export BASE="<the preview link>"     # no trailing slash; use a SINGLE slash before /api
export JWT="<paste-token>"
```

The publish call (reused in every test); get `<file-id>` from the app's Network calls after
saving/uploading the file:
```bash
curl -si -X POST "$BASE/api/publish/fabfile" \
  -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
  -d '{"fabFileId":"<file-id>","tier":"user","visibility":"public"}'
```
A `200` returns JSON with `"url":"/p/f/<id>"`.

### Test 1 - Embedded HTML artifact renders and its JS runs (main fix)
1. In a chat session, prompt: `Create a self-contained HTML artifact: a button labeled "Click me" that, when clicked, changes its own text to "Clicked!" and turns green. No alert(). Title it "Widget".`
2. On the reply, `...` menu -> **Save as Text**.
3. Publish that file id, open `$BASE/p/f/<id>`.
   Expected: the prose shows as literal text and the button renders live in a bordered iframe;
   clicking it changes it to "Clicked!" and green (sandboxed JS runs). Page is not blank; no raw
   `<artifact>` markup leaks.
4. Open `$BASE/p/f/<id>?a=0`.
   Expected: the artifact HTML served as its own standalone sandboxed page; the button behaves the same.
5. Open `$BASE/p/f/<id>?a=9` (out-of-range index).
   Expected: `404`.

Note: `alert()`/`confirm()`/`prompt()` are intentionally suppressed - the artifact iframe is
`sandbox="allow-scripts"` with no `allow-modals`/`allow-same-origin`, matching the reply viewer
(#708). Use a DOM-mutating artifact (as above) to verify JS execution.

### Test 2 - A code fence stays literal, not promoted (P1 fix)
1. In a chat session, prompt: `In your reply, show a short Python snippet (about 3 lines that print "hello") inside a normal markdown python code fence.` The chat renders it as a code artifact panel.
2. On the reply, `...` menu -> **Save as Code** (Save as Text does not appear for a code artifact).
3. Publish that file id, open `$BASE/p/f/<id>`.
   Expected: the file body - including the ```` ```python ```` fence and the code - renders VERBATIM
   in an escaped `<pre>`. It is NOT turned into an "open in the app" card, and there is no iframe.
   (A published reply with the same fence would promote it to a card; the fabfile path keeps it literal.)

### Test 3 - Binary file is rejected
1. In **Files Manager**, upload an image (`.png`/`.jpg`); wait until it finishes processing.
2. Get its file id (DevTools -> Network, the 24-hex value in the file's request URL), publish it.
   Expected: `415`, body `{"error":"Cannot publish a image/png file as a viewer page"}`; nothing is
   published (no `url`, no `/p/f/...` page). (Edge cases: `200` if the image record carries extracted
   text - correct fallback; `422` if it has no content at all.)

### Test 4 - Plain text unchanged (regression)
1. In **Files Manager**, upload a `plain.txt` containing: `The condition if (a < b) {} should hold.`
2. Publish its file id, open `$BASE/p/f/<id>`.
   Expected: the text shows inside a `<pre>` with `if (a < b) {}` displayed correctly (nothing
   swallowed), no iframe and no artifact card - the `<` is safely escaped as `&lt;` in the HTML.

### Additional Regression Checks
1. Confirm a published reply (`$BASE/p/r/<id>`) with an embedded HTML artifact still renders unchanged
   (the reply path was not narrowed).
2. Re-publish the same file id a second time.
   Expected: `200` with the SAME `publicId`/`url` (re-publish updates in place, no duplicate).

### What NOT to test
- There is no in-app UI button to publish a fabfile in this PR (out of scope for #722); publishing is API-only.
- No changes to the bundle publish path (`/p/{tier}/{scopeId}/{slug}`) or to reply publishing behavior.
- `alert()`/`confirm()`/`prompt()` inside an artifact: intentionally blocked by the sandbox (not a bug).

## Tests

- `apps/client/pages/api/publish/__tests__/fabfile.test.ts` (new): publish body sourcing - S3 sourcing over empty `file.text`, fallback to `file.text` on download failure, `415` for a binary file with no text, `200` for a binary file with pre-extracted text, `422` for a text file with neither `filePath` nor `text`, plus the moderation gate (`409` while scanning, `403` when blocked).
- `apps/client/pages/api/publish/serve/__tests__/serve.test.ts`: fabfile embedded-artifact render mirroring the #708 reply suite - sandboxed iframe at `?a=0`, `?a=` sub-document CSP, out-of-range `404`, non-embeddable placeholder card, bearer-gated card, `/a/{token}` share frame, plain-text unchanged, and a fenced-code fabfile staying verbatim (no promotion).

## Additional Information

Security posture carries over from #708 unchanged: the viewer page stays `script-src 'none'`; artifact JS runs only inside the sandboxed `?a=` sub-document (`sandbox allow-scripts`, opaque origin, no `allow-same-origin`). Bearer-gated (org/domain) fabfiles render the placeholder card instead of a frame, since an iframe navigation cannot carry the Authorization header. Sourcing content by the file's own S3 key (not a user-supplied URL) means there is no SSRF surface. The publish path also respects the hold-until-scanned moderation gate (`isImageServeable`), so unscanned/blocked content can never be published to a public page.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
