### PR TITLE
feat(image-gen): make Prompt Builder orientation hint model-aware

### DIFF
--- a/apps/client/app/components/Session/PromptBuilder/PromptBuilderModal.test.tsx
+++ b/apps/client/app/components/Session/PromptBuilder/PromptBuilderModal.test.tsx
@@ -62,10 +62,26 @@ describe('PromptBuilderModal', () => {
     fireEvent.click(screen.getByTestId('pb-chip-a portrait of a person'));
     const rec = screen.getByTestId('prompt-builder-recommendation');
     expect(rec).toHaveTextContent('portrait');
+    expect(rec).toHaveTextContent('aspect ratio');
 
-    fireEvent.click(screen.getByTestId('prompt-builder-apply-aspect-btn'));
+    fireEvent.click(screen.getByTestId('prompt-builder-apply-recommendation-btn'));
     expect(useLLM.getState().aspect_ratio).toBe('3:4');
     // Once applied, the recommendation (which only shows on a mismatch) disappears.
+    expect(screen.queryByTestId('prompt-builder-recommendation')).toBeNull();
+  });
+
+  it('recommends a size (not aspect ratio) on a GPT-Image model and applies it (M3)', () => {
+    // GPT-Image steers orientation via size; default size 1024x1024, so a portrait
+    // subject should recommend 1024x1536 as a size change.
+    useLLM.getState().setLLM({ model: 'gpt-image-1' });
+    renderModal();
+    fireEvent.click(screen.getByTestId('pb-chip-a portrait of a person'));
+    const rec = screen.getByTestId('prompt-builder-recommendation');
+    expect(rec).toHaveTextContent('size');
+
+    fireEvent.click(screen.getByTestId('prompt-builder-apply-recommendation-btn'));
+    expect(useLLM.getState().size).toBe('1024x1536');
+    expect(useLLM.getState().aspect_ratio).toBe('16:9'); // aspect_ratio left untouched
     expect(screen.queryByTestId('prompt-builder-recommendation')).toBeNull();
   });
 

--- a/apps/client/app/components/Session/PromptBuilder/PromptBuilderModal.tsx
+++ b/apps/client/app/components/Session/PromptBuilder/PromptBuilderModal.tsx
@@ -5,7 +5,7 @@ import { AutoAwesome as SuggestIcon } from '@mui/icons-material';
 import { useChatInput } from '@client/app/hooks/useChatInput';
 import { useLLM } from '@client/app/contexts/LLMContext';
 import { useAdvancedAISettings } from '../AISettings/useAdvancedAISettingsStore';
-import { recommendAspectRatio } from './recommendations';
+import { recommendOrientation } from './recommendations';
 import {
   assemblePrompt,
   EMPTY_SELECTIONS,
@@ -24,7 +24,9 @@ export const PromptBuilderModal: FC = () => {
   const open = useAdvancedAISettings(s => s.promptBuilderOpen);
   const setOpen = useAdvancedAISettings(s => s.setPromptBuilderOpen);
   const setChatInputValue = useChatInput(s => s.setChatInputValue);
+  const model = useLLM(s => s.model);
   const aspectRatio = useLLM(s => s.aspect_ratio);
+  const size = useLLM(s => s.size);
   const setLLM = useLLM(s => s.setLLM);
 
   const [selections, setSelections] = useState<PromptSelections>(EMPTY_SELECTIONS);
@@ -32,10 +34,12 @@ export const PromptBuilderModal: FC = () => {
 
   const preview = useMemo(() => assemblePrompt(selections, extras.join(', ')), [selections, extras]);
 
-  // M3: recommend an aspect ratio from prompt keywords; show only when it differs
-  // from the current setting.
-  const recommendation = useMemo(() => recommendAspectRatio(preview), [preview]);
-  const showRecommendation = recommendation && recommendation.aspectRatio !== aspectRatio;
+  // M3: recommend an orientation setting from prompt keywords, model-aware
+  // (aspect_ratio for most models, size for GPT-Image). Show only when the
+  // recommended value differs from the model's current relevant setting.
+  const recommendation = useMemo(() => recommendOrientation(preview, model), [preview, model]);
+  const currentValue = recommendation?.settingKey === 'size' ? size : aspectRatio;
+  const showRecommendation = recommendation && recommendation.value !== currentValue;
 
   const toggleChip = (key: PromptCategoryKey, value: string) =>
     setSelections(prev => {
@@ -134,16 +138,17 @@ export const PromptBuilderModal: FC = () => {
           >
             <SuggestIcon sx={{ fontSize: 16 }} />
             <Typography level="body-xs" sx={{ flex: 1 }}>
-              This looks like a {recommendation.label} image. Set the aspect ratio to {recommendation.aspectRatio}?
+              This looks like a {recommendation.label} image. Set the{' '}
+              {recommendation.settingKey === 'size' ? 'size' : 'aspect ratio'} to {recommendation.value}?
             </Typography>
             <Button
               size="sm"
               variant="solid"
               color="primary"
-              data-testid="prompt-builder-apply-aspect-btn"
-              onClick={() => setLLM({ aspect_ratio: recommendation.aspectRatio })}
+              data-testid="prompt-builder-apply-recommendation-btn"
+              onClick={() => setLLM({ [recommendation.settingKey]: recommendation.value })}
             >
-              Use {recommendation.aspectRatio}
+              Use {recommendation.value}
             </Button>
           </Sheet>
         )}

--- a/apps/client/app/components/Session/PromptBuilder/recommendations.test.ts
+++ b/apps/client/app/components/Session/PromptBuilder/recommendations.test.ts
@@ -1,30 +1,65 @@
 import { describe, it, expect } from 'vitest';
-import { recommendAspectRatio } from './recommendations';
+import { recommendOrientation } from './recommendations';
 
-describe('recommendAspectRatio', () => {
-  it('recommends 3:4 for portrait-ish prompts', () => {
-    expect(recommendAspectRatio('A photorealistic portrait of a person')?.aspectRatio).toBe('3:4');
-    expect(recommendAspectRatio('full-body shot, standing')?.label).toBe('portrait');
+// A non-GPT model steers orientation via aspect_ratio; a GPT-Image model via size.
+const FLUX = 'flux-pro-1.1';
+const GPT = 'gpt-image-1';
+
+describe('recommendOrientation', () => {
+  describe('non-GPT models (aspect_ratio)', () => {
+    it('recommends 3:4 for portrait-ish prompts', () => {
+      expect(recommendOrientation('A photorealistic portrait of a person', FLUX)).toEqual({
+        label: 'portrait',
+        settingKey: 'aspect_ratio',
+        value: '3:4',
+      });
+      expect(recommendOrientation('full-body shot, standing', FLUX)?.label).toBe('portrait');
+    });
+
+    it('recommends 16:9 for landscape-ish prompts', () => {
+      expect(recommendOrientation('a sweeping mountain landscape at dawn', FLUX)?.value).toBe('16:9');
+      expect(recommendOrientation('a city skyline panorama', FLUX)?.value).toBe('16:9');
+    });
+
+    it('recommends 1:1 for square-ish prompts', () => {
+      expect(recommendOrientation('a minimalist logo', FLUX)?.value).toBe('1:1');
+      expect(recommendOrientation('a profile picture avatar', FLUX)?.value).toBe('1:1');
+    });
   });
 
-  it('recommends 16:9 for landscape-ish prompts', () => {
-    expect(recommendAspectRatio('a sweeping mountain landscape at dawn')?.aspectRatio).toBe('16:9');
-    expect(recommendAspectRatio('a city skyline panorama')?.aspectRatio).toBe('16:9');
-  });
+  describe('GPT-Image models (size)', () => {
+    it('recommends the matching GPT size instead of an aspect ratio', () => {
+      expect(recommendOrientation('A photorealistic portrait of a person', GPT)).toEqual({
+        label: 'portrait',
+        settingKey: 'size',
+        value: '1024x1536',
+      });
+      expect(recommendOrientation('a sweeping mountain landscape', GPT)).toEqual({
+        label: 'landscape',
+        settingKey: 'size',
+        value: '1536x1024',
+      });
+      expect(recommendOrientation('a minimalist logo', GPT)).toEqual({
+        label: 'square',
+        settingKey: 'size',
+        value: '1024x1024',
+      });
+    });
 
-  it('recommends 1:1 for square-ish prompts', () => {
-    expect(recommendAspectRatio('a minimalist logo')?.aspectRatio).toBe('1:1');
-    expect(recommendAspectRatio('a profile picture avatar')?.aspectRatio).toBe('1:1');
+    it('recognizes versioned GPT-Image ids (e.g. gpt-image-2 snapshots)', () => {
+      expect(recommendOrientation('a portrait', 'gpt-image-2-2026-04-21')?.settingKey).toBe('size');
+    });
   });
 
   it('returns null when nothing matches or the prompt is empty', () => {
-    expect(recommendAspectRatio('a cat wearing a hat')).toBeNull();
-    expect(recommendAspectRatio('   ')).toBeNull();
+    expect(recommendOrientation('a cat wearing a hat', FLUX)).toBeNull();
+    expect(recommendOrientation('a cat wearing a hat', GPT)).toBeNull();
+    expect(recommendOrientation('   ', FLUX)).toBeNull();
   });
 
   it('matches whole words only (no firing inside other words)', () => {
-    expect(recommendAspectRatio('an iconic moment')).toBeNull(); // 'icon' must not match 'iconic'
-    expect(recommendAspectRatio('a deep understanding of physics')).toBeNull(); // 'standing' not in 'understanding'
-    expect(recommendAspectRatio('a tall lighthouse')?.aspectRatio).toBe('3:4'); // 'tall' as a real word still matches
+    expect(recommendOrientation('an iconic moment', FLUX)).toBeNull(); // 'icon' must not match 'iconic'
+    expect(recommendOrientation('a deep understanding of physics', FLUX)).toBeNull(); // 'standing' not in 'understanding'
+    expect(recommendOrientation('a tall lighthouse', FLUX)?.value).toBe('3:4'); // 'tall' as a real word still matches
   });
 });

--- a/apps/client/app/components/Session/PromptBuilder/recommendations.ts
+++ b/apps/client/app/components/Session/PromptBuilder/recommendations.ts
@@ -1,30 +1,45 @@
+import { isGPTImageModel } from '@bike4mind/common';
+
 /**
  * M3 - client-side parameter recommendations from prompt keywords. Cheap keyword
  * heuristics (no model call): if the prompt reads like a portrait / landscape /
- * square, suggest a matching aspect ratio. Returns null when nothing matches or
- * the prompt is empty.
+ * square, suggest a matching orientation setting. Returns null when nothing
+ * matches or the prompt is empty.
+ *
+ * Model-aware: GPT-Image models steer orientation through `size` (they ignore
+ * `aspect_ratio` entirely - see the OpenAI branch in ImageGeneration), every
+ * other image model through `aspect_ratio`. So the same detected orientation maps
+ * to a different setting depending on the selected model.
  */
-export interface AspectRatioRecommendation {
-  /** Aspect-ratio value matching the ImageSettings options (e.g. '3:4'). */
-  aspectRatio: string;
-  /** Human label for the detected orientation. */
+export interface OrientationRecommendation {
+  /** Detected orientation: 'portrait' | 'landscape' | 'square'. */
   label: string;
+  /** Which image setting this recommendation applies to (model-dependent). */
+  settingKey: 'aspect_ratio' | 'size';
+  /** Recommended value for that setting (e.g. '3:4' or '1024x1536'). */
+  value: string;
 }
 
-const RULES: { keywords: string[]; aspectRatio: string; label: string }[] = [
+// Each orientation carries both the aspect-ratio value (Flux/Gemini/etc.) and the
+// GPT-Image size value. The three GPT sizes below are valid for both gpt-image-1
+// and gpt-image-2 (they appear in IMAGE_SIZE_CONSTRAINTS for each).
+const RULES: { keywords: string[]; label: string; aspectRatio: string; gptSize: string }[] = [
   {
     label: 'portrait',
     aspectRatio: '3:4',
+    gptSize: '1024x1536',
     keywords: ['portrait', 'headshot', 'full-body', 'standing', 'tall', 'vertical'],
   },
   {
     label: 'landscape',
     aspectRatio: '16:9',
+    gptSize: '1536x1024',
     keywords: ['landscape', 'scenery', 'panorama', 'vista', 'skyline', 'horizon', 'wide shot', 'cityscape'],
   },
   {
     label: 'square',
     aspectRatio: '1:1',
+    gptSize: '1024x1024',
     keywords: ['square', 'logo', 'icon', 'avatar', 'profile picture', 'sticker', 'album cover'],
   },
 ];
@@ -35,12 +50,16 @@ const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 // in "iconic", 'standing' in "understanding", 'tall' in "install").
 const matchesWord = (text: string, keyword: string) => new RegExp(`\\b${escapeRegExp(keyword)}\\b`, 'i').test(text);
 
-export function recommendAspectRatio(prompt: string): AspectRatioRecommendation | null {
+/**
+ * Recommend an orientation setting from prompt keywords for the given model.
+ * Returns the setting to change (`aspect_ratio` for most models, `size` for
+ * GPT-Image) and the value to use, or null when nothing matches.
+ */
+export function recommendOrientation(prompt: string, model: string): OrientationRecommendation | null {
   if (!prompt.trim()) return null;
-  for (const rule of RULES) {
-    if (rule.keywords.some(k => matchesWord(prompt, k))) {
-      return { aspectRatio: rule.aspectRatio, label: rule.label };
-    }
-  }
-  return null;
+  const rule = RULES.find(r => r.keywords.some(k => matchesWord(prompt, k)));
+  if (!rule) return null;
+  return isGPTImageModel(model)
+    ? { label: rule.label, settingKey: 'size', value: rule.gptSize }
+    : { label: rule.label, settingKey: 'aspect_ratio', value: rule.aspectRatio };
 }


### PR DESCRIPTION
## Description

Closes #756. Follow-up from the Prompt Builder review.

The Prompt Builder's orientation recommendation (portrait/landscape/square detected from prompt keywords) always suggested an **aspect ratio**. That works for Flux and Gemini, but on **GPT-Image** models it was a no-op: GPT-Image ignores `aspect_ratio` and steers orientation through `size`, so clicking "Use 3:4" changed a setting the model never reads.

This makes the recommendation **model-aware**:

- **GPT-Image models** get a **size** suggestion (portrait -> `1024x1536`, landscape -> `1536x1024`, square -> `1024x1024`).
- **Every other image model** keeps the **aspect-ratio** suggestion (portrait -> `3:4`, landscape -> `16:9`, square -> `1:1`).

The recommendation banner adapts its wording and applies to whichever setting the current model actually uses, so the suggestion now always lands.

## Changes

- **`PromptBuilder/recommendations.ts`** — replaced `recommendAspectRatio(prompt)` with `recommendOrientation(prompt, model)`. Each orientation rule now carries both an aspect-ratio value and a GPT size; the function returns `{ label, settingKey, value }` where `settingKey` is `'size'` for GPT-Image (detected via the shared `isGPTImageModel`, so versioned ids like `gpt-image-2-...` work) and `'aspect_ratio'` otherwise. The chosen GPT sizes are valid for both gpt-image-1 and gpt-image-2.
- **`PromptBuilder/PromptBuilderModal.tsx`** — reads the current `model` and `size` alongside `aspect_ratio`; the banner compares against the relevant setting, adapts its label ("Set the **size** to 1024x1536?" vs "Set the **aspect ratio** to 3:4?"), and applies via `setLLM({ [settingKey]: value })`. Recommendation button testid renamed to `prompt-builder-apply-recommendation-btn`.
- **Tests** — `recommendations.test.ts` covers both paths (aspect-ratio for Flux, size for GPT-Image, versioned-id handling, and the retained whole-word matching guards); `PromptBuilderModal.test.tsx` adds a GPT-Image case asserting `size` is set and `aspect_ratio` is left untouched.

## Guide for Testers

**Setup:** enable the `EnablePromptBuilder` admin flag (Admin Settings -> Experimental -> "Enable Prompt Builder"), start a session.

### GPT-Image: size recommendation (the new behavior)

1. Select a **GPT-Image** model (e.g. `gpt-image-1`) as the session's image model.
2. Open the **Prompt Builder** (sparkle icon in the composer settings bar).
3. In the Subject group, click the chip **`a portrait of a person`**.
4. **Expected:** a recommendation banner appears reading roughly "This looks like a portrait image. Set the **size** to 1024x1536?" (note it says _size_, not aspect ratio).
5. Click **Use 1024x1536**.
6. **Expected:** the banner disappears; the model's **Image Size** setting is now `1024x1536` and the Aspect Ratio setting is unchanged. (Open the model settings dialog to confirm the size updated.)

   <img width="635" height="707" alt="image" src="https://github.com/user-attachments/assets/24dd3d73-2bfa-4c8c-b598-19cd38427775" />

### Non-GPT model: aspect-ratio recommendation (unchanged)

1. Switch the image model to a **Flux** model (e.g. FLUX Pro 1.1).
2. Open the Prompt Builder and click **`a portrait of a person`** again.
3. **Expected:** the banner now reads "Set the **aspect ratio** to 3:4?"; clicking **Use 3:4** sets Aspect Ratio to `3:4`, exactly as before this PR.

   <img width="635" height="707" alt="image" src="https://github.com/user-attachments/assets/ebf6d0b9-c430-4496-be08-1d537b376f68" />

### Regression Checks

- Landscape and square prompts recommend correctly on both model types (e.g. a scene with "skyline"/"panorama" -> 16:9 on Flux, 1536x1024 on GPT-Image; "logo"/"avatar" -> 1:1 / 1024x1024).
- The banner only appears when the recommended value differs from the model's current setting, and disappears once applied.
- Everything else in the builder (chips, preview, Extra details, Add to prompt, Clear) is unchanged.

### What NOT to test

- **No need to actually send/generate an image** — this PR only changes which client-side setting the recommendation writes (`size` vs `aspect_ratio`). Verifying the setting updates in the UI is sufficient; the downstream generation flow is unchanged and already consumes those settings.
- Custom/non-preset GPT-Image-2 sizes are out of scope — the heuristic only suggests the three standard portrait/landscape/square presets.

## Developer Notes

- **Model-aware recommendation shape.** `recommendOrientation` returns a `settingKey` + `value` rather than a fixed field, so the same keyword rules drive different settings per model family. Adding another model-specific mapping (or another keyword rule) is a table edit in `recommendations.ts`.
- **Reuses the shared `isGPTImageModel`** from `@bike4mind/common` for the GPT-Image branch, so versioned model ids are handled consistently with the rest of the app.
