### PR TITLE
fix(client): render agent-run credit chip in-session on completion

### DIFF
--- a/apps/client/app/hooks/useAgentExecution.ts
+++ b/apps/client/app/hooks/useAgentExecution.ts
@@ -258,12 +258,20 @@ export function useAgentExecutionSubscriptions(): void {
         // optimistic entry; without this patch there's a visible gap between
         // the iteration stream unmounting (on terminal status) and the real
         // Quest arriving (seconds via change-stream).
-        // mementoIds are forwarded so MementoIndicator renders now instead of
-        // waiting for the change-stream (which is silently dropped when the
-        // client-clock-set updatedAt is ahead of the server's value).
+        // mementoIds and totalCreditsUsed are forwarded so the MementoIndicator
+        // and credits chip render now instead of waiting for the change-stream
+        // (which is silently dropped when the client-clock-set updatedAt is
+        // ahead of the server's value).
         const sessionId = store().executions[msg.executionId]?.sessionId;
         if (sessionId && msg.answer) {
-          appendReplyToLatestOptimisticBubble(queryClient, sessionId, msg.answer, msg.executionId, msg.mementoIds);
+          appendReplyToLatestOptimisticBubble(
+            queryClient,
+            sessionId,
+            msg.answer,
+            msg.executionId,
+            msg.mementoIds,
+            msg.totalCreditsUsed
+          );
         }
         // Refresh the Knowledge Base so files a tool generated this run (images, Excel -
         // persisted as FabFiles during the run) appear without a manual reload. The agent

--- a/apps/client/app/utils/llm.test.ts
+++ b/apps/client/app/utils/llm.test.ts
@@ -64,6 +64,29 @@ describe('createOptimisticPromptBubble routingSource (live badge)', () => {
   });
 });
 
+// The credits chip reads messageData.creditsUsed. On agent completion the
+// value must ride the reply-append patch so the chip renders in-session,
+// not only after the change-stream Quest replaces the optimistic bubble.
+describe('appendReplyToLatestOptimisticBubble creditsUsed (live chip)', () => {
+  it('patches creditsUsed onto the completed bubble when provided', () => {
+    const qc = seedQueryClient([makeQuest({ id: 'optimistic-quest-1', replies: [] })]);
+    appendReplyToLatestOptimisticBubble(qc, sessionId, 'the answer', 'exec_1', undefined, 42);
+    expect(readQuests(qc)[0].creditsUsed).toBe(42);
+  });
+
+  it('patches a zero total (genuinely free run) rather than dropping it', () => {
+    const qc = seedQueryClient([makeQuest({ id: 'optimistic-quest-1', replies: [] })]);
+    appendReplyToLatestOptimisticBubble(qc, sessionId, 'the answer', 'exec_1', undefined, 0);
+    expect(readQuests(qc)[0].creditsUsed).toBe(0);
+  });
+
+  it('leaves creditsUsed unset when no total is provided', () => {
+    const qc = seedQueryClient([makeQuest({ id: 'optimistic-quest-1', replies: [] })]);
+    appendReplyToLatestOptimisticBubble(qc, sessionId, 'the answer', 'exec_1');
+    expect(readQuests(qc)[0].creditsUsed).toBeUndefined();
+  });
+});
+
 describe('swapOptimisticPromptBubbleId', () => {
   it('renames the optimistic bubble to the real id when no collision exists', () => {
     const optimistic = makeQuest({ id: 'optimistic-quest-sess_abc-12345', prompt: 'do the thing' });

--- a/apps/client/app/utils/llm.ts
+++ b/apps/client/app/utils/llm.ts
@@ -155,7 +155,8 @@ export function appendReplyToLatestOptimisticBubble(
   sessionId: string,
   reply: string,
   agentExecutionId?: string,
-  mementoIds?: string[]
+  mementoIds?: string[],
+  creditsUsed?: number
 ): void {
   queryClient.setQueryData<SessionQuestPages>(['quests', 'session', sessionId], current => {
     if (!current?.pages) return current;
@@ -174,11 +175,14 @@ export function appendReplyToLatestOptimisticBubble(
       // users had to refresh to revisit the trace.
       // mementoIds are included here so MementoIndicator renders immediately
       // without waiting for the change-stream to deliver the persisted Quest.
+      // creditsUsed rides the same path so the credits chip appears on
+      // completion instead of only after the change-stream Quest lands.
       const patched: IChatHistoryItemDocument = {
         ...page.data[idx],
         replies: [reply],
         updatedAt: new Date(),
         ...(agentExecutionId ? { agentExecutionId } : {}),
+        ...(typeof creditsUsed === 'number' ? { creditsUsed } : {}),
         ...(mementoIds?.length
           ? {
               promptMeta: {


### PR DESCRIPTION
## Description

Follow-up to #661. That PR persisted an agent run's credit total onto the Quest (`creditsUsed`) so it survives into chat history — it works on reload, but the credits chip still did **not** appear in the *same* session the moment the run completed. You had to reload (or wait for the change-stream Quest replacement) to see it.

Root cause: on the `completed` WS event, `useAgentExecution.ts` calls `appendReplyToLatestOptimisticBubble(...)`, which patches the just-completed optimistic bubble with `replies`, `agentExecutionId`, and `mementoIds` so the "Show reasoning" disclosure and MementoIndicator render immediately. It did **not** patch `creditsUsed`, even though `msg.totalCreditsUsed` was already in hand (it's passed to the store's `markCompleted` on the line just above). The chip therefore relied on the change-stream Quest replacement, which is silently dropped when the client clock is ahead of the server `updatedAt`.

Fix threads `creditsUsed` through the exact same path `mementoIds` already takes. Display-only, no billing/ledger math changes.

## Changes

- `apps/client/app/utils/llm.ts` — add optional `creditsUsed?: number` param to `appendReplyToLatestOptimisticBubble`; spread `...(typeof creditsUsed === 'number' ? { creditsUsed } : {})` into the patched bubble, mirroring the existing `mementoIds` spread.
- `apps/client/app/hooks/useAgentExecution.ts` — forward `msg.totalCreditsUsed` from the `completed` handler call site.
- `apps/client/app/utils/llm.test.ts` — cover the new behavior: patches a positive total, patches a genuine `0` (free run) rather than dropping it, and leaves `creditsUsed` unset when no total is provided.

## Guide for Testers

1. Open a preview/staging environment as an admin (e.g. `app.pr<N>.preview.bike4mind.com`).
2. Enable `enforceCredits` for the org (Admin settings) and turn on "Show credits used" in chat display settings.
3. Open a session and switch to **agent mode**.
4. Send a prompt that will actually spend credits, e.g. `Summarize the history of the printing press in 5 paragraphs.` (avoid trivial prompts that round to ~0 credits).
5. Wait for the agent run to complete. **Do not reload.**
6. Expected: the `credits-used` chip appears on the completed message immediately on completion, showing the final total.
7. Reload the page.
8. Expected: the chip persists and shows the **same** value as before the reload, matching the AgentExecution's `totalCreditsUsed`.

### Regression Checks

- Non-agent (normal chat) completions still show the credits chip as before.
- "Show reasoning" disclosure and the MementoIndicator still render immediately on agent completion (same patch path).
- With "Show credits used" off, no chip appears in either mode.

### What NOT to test

- No billing/ledger math changes — this is display-only (parity with #661). Credit amounts are unchanged.
- The reload path already worked (shipped in #661); this PR is strictly the in-session immediate render.

## Additional Information

The issue's optional cosmetic parity note (`persistRunAsQuest.ts` writing `creditsUsed: ... ?? 0` unconditionally vs the chat path's conditional set) was intentionally left out of scope to keep this change surgical — the issue explicitly says do not block on it.

Closes #664
