### PR TITLE
fix(release-notes): extract PR numbers from commit subjects only

### DIFF
--- a/packages/scripts/src/generateChangelog.test.ts
+++ b/packages/scripts/src/generateChangelog.test.ts
@@ -1,5 +1,49 @@
 import { describe, it, expect } from 'vitest';
-import { buildFallbackTitle } from './generateChangelog';
+import { buildFallbackTitle, extractPRNumber } from './generateChangelog';
+
+describe('extractPRNumber', () => {
+  it('reads the trailing (#N) suffix from a squash-merge subject', () => {
+    expect(extractPRNumber('feat(memory): Mementos 2.0 - unified principal-scoped memory core (#442)')).toBe(442);
+  });
+
+  it('reads a plain squash suffix even with no scope', () => {
+    expect(extractPRNumber('fix: resolve spinner (#663)')).toBe(663);
+  });
+
+  it('reads the merge-commit form', () => {
+    expect(extractPRNumber('Merge pull request #741 from Bike4Mind/ci/e2e-plumbing-extraction')).toBe(741);
+  });
+
+  it('takes the TRAILING (#N) and ignores an inner (epic #N)', () => {
+    expect(extractPRNumber('feat(agents): per-embed-key spend cap with pre-flight enforcement (epic #41) (#727)')).toBe(
+      727
+    );
+  });
+
+  it('ignores issue / epic / prose references in the body', () => {
+    const message = [
+      'feat(memory): Mementos 2.0 (#442)',
+      '',
+      'the OFF-topic "favorite color is green" ranked #1',
+      '(activation .238) while the on-topic belief ranked #3, "favorite color" down at #4.',
+      'Closes #627',
+      'Issue #471 covers the file corpus.',
+    ].join('\n');
+    expect(extractPRNumber(message)).toBe(442);
+  });
+
+  it('ignores mid-subject epic/issue references when there is no trailing PR suffix', () => {
+    expect(extractPRNumber('feat(agents): embed endpoint (epic #41 - Phase B.1)')).toBeNull();
+  });
+
+  it('does not treat a bare "Closes #N" body line as a PR', () => {
+    expect(extractPRNumber('fix(client): register auth interceptors\n\nCloses #627')).toBeNull();
+  });
+
+  it('returns null for a direct commit with no PR reference', () => {
+    expect(extractPRNumber('hotfix: bump timeout')).toBeNull();
+  });
+});
 
 describe('buildFallbackTitle', () => {
   it('uses the single change as the title, capitalized', () => {

--- a/packages/scripts/src/generateChangelog.ts
+++ b/packages/scripts/src/generateChangelog.ts
@@ -85,29 +85,49 @@ function parseConventionalCommit(message: string): ParsedCommit {
 }
 
 /**
- * Extract PR numbers from commits
- * Looks for patterns like:
- * - "Merge pull request #N"
- * - "(#N)"
- * - "PR #N"
+ * Extract the PR number a commit belongs to.
+ *
+ * Only the SUBJECT (first line) is inspected, and only the two canonical forms
+ * GitHub writes when a PR lands are matched:
+ *   - Merge-commit workflow:  "Merge pull request #N from ..."
+ *   - Squash-merge workflow:  "feat(x): thing (#N)"  (trailing "(#N)" suffix)
+ *
+ * Anything in the commit BODY is deliberately ignored. Bodies carry issue,
+ * epic, and prose references ("Closes #627", "epic #41 - Phase B.1", "ranked
+ * #1") that are NOT the PR this commit shipped under - scraping them polluted
+ * the release "Pull Requests" list with issues/epics/arbitrary numbers. The old
+ * whitespace-anchored regex also silently MISSED the "(#N)" squash suffix (the
+ * char before "#" is "(", not whitespace), dropping real PRs. Matching only the
+ * trailing "(#N)" group also ignores an inner "(epic #41)" earlier in a subject.
+ *
+ * Exported for testing.
+ */
+export function extractPRNumber(message: string): number | null {
+  const subject = message.split('\n')[0];
+
+  const mergeMatch = subject.match(/^Merge pull request #(\d+)/i);
+  if (mergeMatch) {
+    return parseInt(mergeMatch[1], 10);
+  }
+
+  const squashMatch = subject.match(/\(#(\d+)\)\s*$/);
+  if (squashMatch) {
+    return parseInt(squashMatch[1], 10);
+  }
+
+  return null;
+}
+
+/**
+ * Extract the set of PR numbers shipped by a list of commits, sorted ascending.
  */
 function extractPRNumbers(commits: GitHubCommit[]): number[] {
   const prNumbers = new Set<number>();
 
   for (const commit of commits) {
-    const message = commit.message;
-
-    // Match "Merge pull request #N"
-    const mergeMatch = message.match(/Merge pull request #(\d+)/i);
-    if (mergeMatch) {
-      prNumbers.add(parseInt(mergeMatch[1], 10));
-      continue;
-    }
-
-    // Match "(#N)" or "PR #N" or "pr: #N"
-    const prMatches = message.matchAll(/(?:^|\s|PR:?\s*)#(\d+)/gi);
-    for (const match of prMatches) {
-      prNumbers.add(parseInt(match[1], 10));
+    const prNumber = extractPRNumber(commit.message);
+    if (prNumber !== null) {
+      prNumbers.add(prNumber);
     }
   }
 


### PR DESCRIPTION
## Problem

Production release notes list PRs that were never part of the release, and drop PRs that were. Reported on two releases:

- v2026.07.19.1 → `Pull Requests: #1, #3, #4, #442, #471, #627, #698, #699, #700, #702, #705`
- v2026.07.21.1 → `Pull Requests: #41, #108, #532, #632, #635, #643, #695, #713, #715, #717, #727, #733, #741`

`#1, #3, #4` come from a commit body describing ranking results ("the OFF-topic ... ranked #1 ... belief ranked #3 ... down at #4"). `#41` is an epic ("epic #41 - Phase B.1"), `#108`/`#632` are cross-referenced issues, `#471`/`#627` are `Issue #471` / `Closes #627`. None are PRs shipped in that release.

## Root cause

`extractPRNumbers` in `generateChangelog.ts` ran one regex over the entire commit message (subject and body):

```
/(?:^|\s|PR:?\s*)#(\d+)/gi
```

That is wrong in two directions at once:

1. It matches any `#N` preceded by whitespace or "PR" anywhere in the body, so issue references, epic references, and arbitrary prose all get listed as "Pull Requests".
2. It silently misses the canonical squash-merge subject suffix `feat(x): thing (#663)`, because the character before `#` is `(`, not whitespace. Real PRs whose only reference is that suffix were dropped. The only reason any PRs showed up is the incidental `chore: auto-generate changeset for PR #N` lines that happen to match the `PR #N` branch.

The rendered list uses the raw regex output (`metadata.prNumbers`), not the SHA-validated PR groups (and that SHA grouping is itself unreliable under squash merges, since a PR's branch SHAs differ from the squashed commit on `prod`).

## Fix

Extract from the subject (first line) only, matching the two forms GitHub actually writes when a PR lands:

- Merge-commit workflow: `Merge pull request #N from ...`
- Squash-merge workflow: a trailing `(#N)` suffix

Matching only the trailing `(#N)` group also ignores an inner `(epic #41)` earlier in a subject. Direct commits with no PR reference are correctly excluded.

## Verification

Replayed both affected ranges through the old and new logic. The old-logic replay reproduces the exact buggy release output (confirming the diagnosis); the new logic is clean and complete:

| Range | Old (shipped) | New (fixed) |
| --- | --- | --- |
| →v2026.07.19.1 (12 commits) | #1, #3, #4, #442, #471, #627, #698, #699, #700, #702, #705 | #442, #663, #668, #698, #699, #700, #701, #702, #703, #704, #705, #706 |
| →v2026.07.21.1 (19 commits) | #41, #108, #532, #632, #635, #643, #695, #713, #715, #717, #727, #733, #741 | #532, #618, #635, #643, #665, #695, #711, #712, #713, #715, #717, #719, #727, #729, #731, #733, #741, #743, #746 |

Commit count equals PR count in both (12 → 12, 19 → 19), the expected one-squash-commit-per-PR result. `extractPRNumber` is exported and covered by unit tests built from the real regressions.

## Follow-up (not in this PR)

For fully authoritative accuracy across any merge strategy, a later change could map each release commit to its merged PR via `GET /repos/{owner}/{repo}/commits/{sha}/pulls` and also repair the commit→PR grouping that feeds the AI changelog prompt. This PR is the low-risk subject-parsing fix that resolves the reported output.
