### PR TITLE
fix(api): exempt status-poll and content reads from the per-key daily rate limit

### DIFF
--- a/apps/client/pages/api/generated-content/[ref].ts
+++ b/apps/client/pages/api/generated-content/[ref].ts
@@ -13,7 +13,10 @@ const refSchema = z
 
 const PRESIGNED_URL_EXPIRY_SECONDS = 3600;
 
-const handler = baseApi().get(
+// Fetching produced content is the final read of the async generation pipeline
+// (submit + poll + fetch); exempt these reads from the daily quota so one
+// generation costs a single daily slot. Only safe methods are exempted.
+const handler = baseApi({ exemptReadsFromDailyRateLimit: true }).get(
   asyncHandler<unknown, unknown, unknown, { ref?: string; format?: string }>(async (req, res) => {
     // Validate ref format - catch ZodError so we return 400 (not 422)
     let ref: string;

--- a/apps/client/pages/api/quests/[id]/index.ts
+++ b/apps/client/pages/api/quests/[id]/index.ts
@@ -10,6 +10,9 @@ import type { Request } from 'express';
 // a least-privilege chat key 403s on its own reply. OR / "any of" semantics.
 const handler = baseApi({
   requiredScopes: [ApiKeyScope.READ_NOTEBOOKS, ApiKeyScope.AI_CHAT, ApiKeyScope.AI_GENERATE],
+  // Quest status is the poll step of the async generation pipeline; don't let
+  // polling one job to completion burn the daily quota that meters submissions.
+  exemptReadsFromDailyRateLimit: true,
 }).get(async (req: Request<{}, {}, {}, { id: string }>, res) => {
   const { id: questId } = req.query;
   const userId = req.user?.id;

--- a/apps/client/server/middlewares/apiKeyRateLimit.ts
+++ b/apps/client/server/middlewares/apiKeyRateLimit.ts
@@ -5,6 +5,21 @@ import { emitMetric } from '@server/utils/cloudwatch';
 import { StandardUnit } from '@aws-sdk/client-cloudwatch';
 import { ApiKeyScope } from '@bike4mind/common';
 
+export interface ApiKeyRateLimitOptions {
+  /**
+   * When true, this route's SAFE (idempotent) requests - GET/HEAD/OPTIONS - do
+   * not consume the per-DAY quota; they still count toward the per-minute burst
+   * limit. Use for async job-status polls and content fetches, which would
+   * otherwise burn the daily budget meant to meter generation submissions.
+   * Defaults to false: every request counts, so unaudited routes fail safe
+   * (an expensive GET keeps its daily cap unless a route explicitly opts in).
+   */
+  exemptReadsFromDailyLimit?: boolean;
+}
+
+/** RFC 7231 safe methods: no state change, so cheap to serve and safe to exempt. */
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
 /**
  * Middleware to enforce API key-specific rate limits
  *
@@ -28,58 +43,69 @@ import { ApiKeyScope } from '@bike4mind/common';
  * - X-RateLimit-Remaining-Day: Remaining requests today
  * - X-RateLimit-Reset-Day: Unix timestamp when day limit resets
  */
-export const apiKeyRateLimit = (): RequestHandler => async (req, res, next) => {
-  // Only apply to API key authenticated requests
-  if (!req.apiKeyInfo) {
-    return next();
-  }
-
-  const { keyId, rateLimit } = req.apiKeyInfo;
-
-  try {
-    // Check rate limit with context for analytics logging
-    const result = await checkApiKeyRateLimit(keyId, rateLimit, {
-      userId: req.user?.id,
-      endpoint: req.originalUrl || req.url,
-      method: req.method,
-    });
-
-    // Add rate limit headers to response
-    res.setHeader('X-RateLimit-Limit-Minute', result.headers['X-RateLimit-Limit-Minute']);
-    res.setHeader('X-RateLimit-Remaining-Minute', result.headers['X-RateLimit-Remaining-Minute']);
-    res.setHeader('X-RateLimit-Reset-Minute', result.headers['X-RateLimit-Reset-Minute']);
-    res.setHeader('X-RateLimit-Limit-Day', result.headers['X-RateLimit-Limit-Day']);
-    res.setHeader('X-RateLimit-Remaining-Day', result.headers['X-RateLimit-Remaining-Day']);
-    res.setHeader('X-RateLimit-Reset-Day', result.headers['X-RateLimit-Reset-Day']);
-
-    // If rate limit exceeded, set Retry-After header and throw error
-    if (!result.allowed) {
-      if (result.retryAfter) {
-        res.setHeader('Retry-After', result.retryAfter);
-      }
-      // Emit per-product RateLimitHit metric for ingest keys so the Overwatch ops dashboard
-      // can surface per-product rate pressure without a separate Lambda.
-      if (req.apiKeyInfo?.scopes?.includes(ApiKeyScope.OVERWATCH_INGEST_WRITE) && req.apiKeyInfo.productId) {
-        emitMetric(
-          'Lumina5/OverwatchIngest',
-          'RateLimitHit',
-          1,
-          { productId: req.apiKeyInfo.productId },
-          StandardUnit.Count
-        ).catch(() => {});
-      }
-      throw new TooManyRequestsError(result.error || 'Rate limit exceeded');
+export const apiKeyRateLimit =
+  (options: ApiKeyRateLimitOptions = {}): RequestHandler =>
+  async (req, res, next) => {
+    // Only apply to API key authenticated requests
+    if (!req.apiKeyInfo) {
+      return next();
     }
 
-    return next();
-  } catch (error) {
-    // If it's a TooManyRequestsError, pass it through
-    if (error instanceof TooManyRequestsError) {
+    const { keyId, rateLimit } = req.apiKeyInfo;
+
+    // A route can exempt its cheap reads from the day quota; only safe methods
+    // actually qualify, so a POST on an opted-in route still counts.
+    const meterDailyLimit = !(options.exemptReadsFromDailyLimit && SAFE_METHODS.has(req.method.toUpperCase()));
+
+    try {
+      // Check rate limit with context for analytics logging
+      const result = await checkApiKeyRateLimit(
+        keyId,
+        rateLimit,
+        {
+          userId: req.user?.id,
+          endpoint: req.originalUrl || req.url,
+          method: req.method,
+        },
+        { meterDailyLimit }
+      );
+
+      // Add rate limit headers to response
+      res.setHeader('X-RateLimit-Limit-Minute', result.headers['X-RateLimit-Limit-Minute']);
+      res.setHeader('X-RateLimit-Remaining-Minute', result.headers['X-RateLimit-Remaining-Minute']);
+      res.setHeader('X-RateLimit-Reset-Minute', result.headers['X-RateLimit-Reset-Minute']);
+      res.setHeader('X-RateLimit-Limit-Day', result.headers['X-RateLimit-Limit-Day']);
+      res.setHeader('X-RateLimit-Remaining-Day', result.headers['X-RateLimit-Remaining-Day']);
+      res.setHeader('X-RateLimit-Reset-Day', result.headers['X-RateLimit-Reset-Day']);
+
+      // If rate limit exceeded, set Retry-After header and throw error
+      if (!result.allowed) {
+        if (result.retryAfter) {
+          res.setHeader('Retry-After', result.retryAfter);
+        }
+        // Emit per-product RateLimitHit metric for ingest keys so the Overwatch ops dashboard
+        // can surface per-product rate pressure without a separate Lambda.
+        if (req.apiKeyInfo?.scopes?.includes(ApiKeyScope.OVERWATCH_INGEST_WRITE) && req.apiKeyInfo.productId) {
+          emitMetric(
+            'Lumina5/OverwatchIngest',
+            'RateLimitHit',
+            1,
+            { productId: req.apiKeyInfo.productId },
+            StandardUnit.Count
+          ).catch(() => {});
+        }
+        throw new TooManyRequestsError(result.error || 'Rate limit exceeded');
+      }
+
+      return next();
+    } catch (error) {
+      // If it's a TooManyRequestsError, pass it through
+      if (error instanceof TooManyRequestsError) {
+        return next(error);
+      }
+
+      // For other errors (e.g., database connection issues), log and pass through
+      console.error('[API_KEY_RATE_LIMIT] Error checking rate limit:', error);
       return next(error);
     }
-
-    // For other errors (e.g., database connection issues), log and pass through
-    console.error('[API_KEY_RATE_LIMIT] Error checking rate limit:', error);
-    return next(error);
-  }
-};
+  };

--- a/apps/client/server/middlewares/baseApi.ts
+++ b/apps/client/server/middlewares/baseApi.ts
@@ -27,6 +27,16 @@ interface BaseAPIOptions {
    * scope gate only runs for requests authenticated by an API key.
    */
   requiredScopes?: ApiKeyScope[];
+  /**
+   * Exempt this route's SAFE (idempotent) requests - GET/HEAD/OPTIONS - from
+   * the per-DAY API-key quota. Use for async job-status polls and content
+   * fetches so one async generation (submit + N polls + 1 fetch) costs a
+   * single daily slot instead of N+2. Only safe methods are exempted, so a
+   * POST on the same route still counts. The per-minute burst limit always
+   * applies. Defaults to false (every request counts - unaudited routes fail
+   * safe).
+   */
+  exemptReadsFromDailyRateLimit?: boolean;
 }
 
 /** Default max body size: 1MB - prevents memory exhaustion from large payloads */
@@ -125,7 +135,7 @@ export function baseApi<Req extends Request = Request, Res extends Response = Re
     router.use(apiKeyAnomalyDetection());
 
     // Enforce per-API-key rate limits (skips non-API-key requests)
-    router.use(apiKeyRateLimit());
+    router.use(apiKeyRateLimit({ exemptReadsFromDailyLimit: resolvedOptions.exemptReadsFromDailyRateLimit }));
 
     // Apply JWT authentication middleware (will be skipped if already authenticated via API key)
     router.use(auth);

--- a/apps/client/server/utils/apiKeyRateLimitCheck.test.ts
+++ b/apps/client/server/utils/apiKeyRateLimitCheck.test.ts
@@ -278,6 +278,74 @@ describe('apiKeyRateLimitCheck', () => {
       expect(result.allowed).toBe(false);
     });
 
+    describe('meterDailyLimit: false (exempt reads)', () => {
+      it('should not increment the day counter and report day usage from a read', async () => {
+        // Minute increment succeeds; day counter must NOT be touched.
+        vi.mocked(cacheRepository.tryIncrementWithinLimitFixedWindow).mockResolvedValueOnce({
+          success: true,
+          count: 2,
+          expiresAt: future(MINUTE_MS),
+        });
+        // Existing day counter (from prior POST submissions) is read, not incremented.
+        vi.mocked(cacheRepository.findByKey).mockResolvedValueOnce({
+          key: `api-key-rate-limit:${mockKeyId}:day`,
+          result: { count: 40 },
+          expiresAt: future(DAY_MS),
+        } as never);
+
+        const result = await checkApiKeyRateLimit(mockKeyId, mockRateLimit, mockContext, {
+          meterDailyLimit: false,
+        });
+
+        expect(result.allowed).toBe(true);
+        // Only the minute counter was incremented (day was read, not incremented).
+        expect(cacheRepository.tryIncrementWithinLimitFixedWindow).toHaveBeenCalledTimes(1);
+        expect(cacheRepository.tryIncrementWithinLimitFixedWindow).toHaveBeenCalledWith(
+          expect.stringContaining(':minute'),
+          mockRateLimit.requestsPerMinute,
+          MINUTE_MS
+        );
+        expect(cacheRepository.findByKey).toHaveBeenCalledWith(expect.stringContaining(':day'));
+        // Day headers reflect the read value without consuming a slot.
+        expect(result.headers['X-RateLimit-Remaining-Minute']).toBe(3); // 5 - 2
+        expect(result.headers['X-RateLimit-Remaining-Day']).toBe(60); // 100 - 40, unchanged by this read
+      });
+
+      it('should report a full day quota when no day counter exists yet', async () => {
+        vi.mocked(cacheRepository.tryIncrementWithinLimitFixedWindow).mockResolvedValueOnce({
+          success: true,
+          count: 1,
+          expiresAt: future(MINUTE_MS),
+        });
+        vi.mocked(cacheRepository.findByKey).mockResolvedValueOnce(null as never);
+
+        const result = await checkApiKeyRateLimit(mockKeyId, mockRateLimit, mockContext, {
+          meterDailyLimit: false,
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.headers['X-RateLimit-Remaining-Day']).toBe(100); // full quota, nothing consumed
+      });
+
+      it('should still enforce the per-minute burst limit on exempt reads', async () => {
+        // Even exempt reads count toward the minute limit, so a runaway poll is throttled.
+        vi.mocked(cacheRepository.tryIncrementWithinLimitFixedWindow).mockResolvedValueOnce({
+          success: false,
+          count: 5,
+          expiresAt: future(MINUTE_MS),
+        });
+
+        const result = await checkApiKeyRateLimit(mockKeyId, mockRateLimit, mockContext, {
+          meterDailyLimit: false,
+        });
+
+        expect(result.allowed).toBe(false);
+        expect(result.limitType).toBe('minute');
+        // Day counter never consulted once the minute limit rejects.
+        expect(cacheRepository.findByKey).not.toHaveBeenCalled();
+      });
+    });
+
     it('should use 16-char key prefix for security', async () => {
       // Use a longer key ID to test prefix truncation
       const longKeyId = 'test-api-key-1234567890abcdef-extra';

--- a/apps/client/server/utils/apiKeyRateLimitCheck.ts
+++ b/apps/client/server/utils/apiKeyRateLimitCheck.ts
@@ -28,6 +28,18 @@ export interface RateLimitContext {
   method: string;
 }
 
+export interface RateLimitOptions {
+  /**
+   * Whether this request should consume the per-DAY quota. Defaults to true.
+   * Set false for cheap idempotent reads (async job-status polls, content
+   * fetches) so they don't burn the daily budget that meters actual generation
+   * submissions. The per-MINUTE burst limit still applies regardless, so a
+   * runaway poll loop is still throttled. The caller (middleware) owns the
+   * policy of which requests qualify; this function only honors the flag.
+   */
+  meterDailyLimit?: boolean;
+}
+
 /**
  * Single source of truth for the rate-limit cache key format. Both the
  * enforcer (checkApiKeyRateLimit) and the reset (resetApiKeyRateLimit) must
@@ -125,14 +137,17 @@ async function decrementCounter(key: string): Promise<number> {
  * @param keyId - The API key ID to check
  * @param rateLimit - The rate limit configuration from the API key
  * @param context - Optional context for analytics logging (userId, endpoint, method)
+ * @param options - Enforcement options (e.g. exempt cheap reads from the day quota)
  * @returns RateLimitResult with allowed status, headers, and error if exceeded
  */
 export async function checkApiKeyRateLimit(
   keyId: string,
   rateLimit: { requestsPerMinute: number; requestsPerDay: number },
-  context?: RateLimitContext
+  context?: RateLimitContext,
+  options: RateLimitOptions = {}
 ): Promise<RateLimitResult> {
   const { requestsPerMinute, requestsPerDay } = rateLimit;
+  const { meterDailyLimit = true } = options;
 
   try {
     const { minuteKey, dayKey } = buildRateLimitKeys(keyId);
@@ -160,6 +175,27 @@ export async function checkApiKeyRateLimit(
           requestsPerDay,
           0, // Day counter untouched on a minute-limit rejection
           Date.now() + DAY_IN_MS // Nominal; the day header is informational here
+        ),
+      };
+    }
+
+    // Step 1b: Cheap reads (status polls, content fetches) are exempt from the
+    // day quota. Don't touch the day counter - report its current value from a
+    // non-incrementing read so the day headers stay honest.
+    if (!meterDailyLimit) {
+      const dayDoc = await cacheRepository.findByKey(dayKey);
+      const dayCount = (dayDoc?.result as { count?: number } | undefined)?.count ?? 0;
+      const dayResetAt = dayDoc?.expiresAt ? dayDoc.expiresAt.getTime() : Date.now() + DAY_IN_MS;
+
+      return {
+        allowed: true,
+        headers: buildHeaders(
+          requestsPerMinute,
+          minuteResult.count,
+          minuteResetAt,
+          requestsPerDay,
+          dayCount,
+          dayResetAt
         ),
       };
     }


### PR DESCRIPTION
# Pull Request

## Description

The per-API-key daily rate limiter counted every request equally, including the cheap idempotent reads that make up the async generation pipeline. One image generation is 1 submit (POST) + N status polls (GET `/api/quests/{id}`) + 1 content fetch (GET `/api/generated-content/{ref}`), so a key with `requestsPerDay: 1000` was exhausting after roughly 80-160 real generations instead of 1000 - the daily budget was metering polling, not generations.

The fixed-window counter itself is correct (expiry is set only when a window opens, never pushed forward), so this is purely an accounting-scope fix: cheap reads should not consume the daily budget that is meant to meter generation submissions.

## Changes

- `apiKeyRateLimitCheck.ts`: new `RateLimitOptions { meterDailyLimit }`. When false, the day counter is not incremented; the day headers are reported from a non-incrementing `findByKey` read so they stay accurate.
- `apiKeyRateLimit.ts`: middleware factory takes `{ exemptReadsFromDailyLimit }`. It computes `meterDailyLimit = !(exempt && SAFE_METHODS.has(method))`, so only GET/HEAD/OPTIONS are ever exempted - a POST on an opted-in route still counts.
- `baseApi.ts`: new `exemptReadsFromDailyRateLimit` option (default false, so unaudited routes fail safe), threaded to the middleware.
- Opted in on the two pipeline reads only: `GET /api/quests/[id]` and `GET /api/generated-content/[ref]`.
- The per-minute burst limit still applies to every request (including exempt reads), so a runaway poll loop is still throttled.
- Tests: added coverage for the exempt path (no day increment; full quota when no counter exists; per-minute limit still enforced on exempt reads).

Net effect: one generation costs a single daily slot (the POST). Default behavior for every other route is unchanged.

## Guide for Testers

Backend behavior; test with an API key + curl against staging.

1. Sign in at `app.staging.bike4mind.com` and go to Profile -> API Keys.
2. Create an API key with scopes including `ai:generate`, and set `requestsPerDay` low (e.g. `20`) to make the counter easy to observe. Copy the key (starts with `b4m_`).
3. Submit a generation: `curl -si -X POST https://app.staging.bike4mind.com/api/ai/generate-image -H "Authorization: Bearer <KEY>" -H "Content-Type: application/json" -d '{"prompt":"a red bicycle"}'`. Expected: 200 with a quest object; note the `X-RateLimit-Remaining-Day` header value (call it R).
4. Poll status several times: `curl -si https://app.staging.bike4mind.com/api/quests/<questId> -H "Authorization: Bearer <KEY>"` (repeat 5-10 times). Expected: each returns 200, and `X-RateLimit-Remaining-Day` stays at R (polls do NOT decrement the day counter). `X-RateLimit-Remaining-Minute` DOES decrease.
5. Fetch the produced content once it is ready: `curl -si "https://app.staging.bike4mind.com/api/generated-content/<ref>?format=json" -H "Authorization: Bearer <KEY>"`. Expected: 200/302, `X-RateLimit-Remaining-Day` still R.
6. Submit a second generation (step 3 again). Expected: `X-RateLimit-Remaining-Day` is now R-1 (only submissions consume the daily budget).

### Regression Checks

- A normal POST endpoint (e.g. `/api/ai/generate-image`, `/api/ai/text-to-speech`) still decrements `X-RateLimit-Remaining-Day` by exactly 1 per call.
- Exceeding `requestsPerMinute` on the quest-poll GET still returns 429 with a `Retry-After` header (per-minute burst protection intact for reads).
- JWT/browser requests are unaffected (the limiter only applies to API-key requests).

### What NOT to test

- No UI changes.
- Fixed-window reset timing is unchanged; no need to re-verify the 24h window behavior.

## Additional Information

Part of the API-key rate-limit tracking epic (#770). Follow-up gaps (reset, live usage visibility, per-key limit updates) are tracked in the linked sub-issues.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
