### PR TITLE
fix(api): harden refineText endpoint (scope gate, caching, output cap, POST)

### DIFF
--- a/apps/client/app/hooks/useRefineText.ts
+++ b/apps/client/app/hooks/useRefineText.ts
@@ -4,9 +4,7 @@ import { api } from '../contexts/ApiContext';
 const useRefineText = (callbacks?: { onSuccess?: (text: string) => void }) => {
   return useMutation({
     mutationFn: async (values: { text: string; context?: string }) => {
-      const response = await api.get<{ text: string }>('/api/ai/refineText', {
-        params: values,
-      });
+      const response = await api.post<{ text: string }>('/api/ai/refineText', values);
 
       return response.data;
     },

--- a/apps/client/pages/api/ai/__tests__/refineText.test.ts
+++ b/apps/client/pages/api/ai/__tests__/refineText.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { z } from 'zod';
+import { ApiKeyScope } from '@bike4mind/common';
+
+// Capture the options baseApi() is constructed with so we can assert the scope
+// gate. Middleware is stripped so the raw handler runs directly (same pattern as
+// pages/api/email/__tests__/verify.test.ts). Hoisted because baseApi() runs at
+// module-eval, before top-level consts initialize.
+const { mockBaseApiArgs } = vi.hoisted(() => ({ mockBaseApiArgs: [] as any[] }));
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: (opts: any) => {
+    mockBaseApiArgs.push(opts);
+    const chain: any = { use: () => chain, post: (fn: any) => fn, get: (fn: any) => fn };
+    return chain;
+  },
+}));
+vi.mock('@server/middlewares/asyncHandler', () => ({ asyncHandler: (fn: any) => fn }));
+
+const mockGetCachedData = vi.fn();
+const mockRefineText = vi.fn();
+vi.mock('@bike4mind/services', () => ({
+  refineText: (...a: any[]) => mockRefineText(...a),
+  // Real schema so validation + ZodError behave exactly as in production.
+  refineTextLLMSchema: z.object({ text: z.string(), context: z.string().optional() }),
+  cacheService: { getCachedData: (...a: any[]) => mockGetCachedData(...a) },
+}));
+vi.mock('@bike4mind/database', () => ({ cacheRepository: { findByKey: vi.fn(), createOrUpdate: vi.fn() } }));
+
+const mockGetOperationsModel = vi.fn();
+vi.mock('@client/services/operationsModelService', () => ({
+  OperationsModelService: { getOperationsModel: (...a: any[]) => mockGetOperationsModel(...a) },
+}));
+
+import handler from '@pages/api/ai/refineText';
+
+describe('POST /api/ai/refineText', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('gates the route to the ai:generate scope', () => {
+    // Populated at module-eval when baseApi({...}) runs.
+    expect(mockBaseApiArgs[0]).toEqual({ requiredScopes: [ApiKeyScope.AI_GENERATE] });
+  });
+
+  it('rejects an invalid body with a 400 and never calls the LLM/cache', async () => {
+    const { req, res } = createMocks({ method: 'POST', body: {} }); // missing `text`
+
+    await expect(handler(req as any, res as any)).rejects.toMatchObject({ statusCode: 400 });
+    expect(mockGetCachedData).not.toHaveBeenCalled();
+    expect(mockGetOperationsModel).not.toHaveBeenCalled();
+  });
+
+  it('refines text on a cache miss via a bounded LLM call', async () => {
+    // Cache miss: run the producer.
+    mockGetCachedData.mockImplementation(async (_key: string, cb: () => Promise<string>) => cb());
+    const complete = vi.fn(async (_modelId, _messages, _opts, cb) => {
+      await cb(['refined output']);
+    });
+    mockGetOperationsModel.mockResolvedValue({ modelId: 'ops-model', llm: { complete } });
+    mockRefineText.mockImplementation(async (_params: unknown, adapters: any) => {
+      let out: string | undefined;
+      await adapters.llm.complete([{ role: 'user', content: 'x' }], async (v: string) => {
+        out = v;
+      });
+      return out;
+    });
+
+    const { req, res } = createMocks({ method: 'POST', body: { text: 'hello', context: 'ctx' } });
+    await handler(req as any, res as any);
+
+    expect(mockGetCachedData).toHaveBeenCalledTimes(1);
+    const [key, , opts] = mockGetCachedData.mock.calls[0];
+    expect(key).toMatch(/^refine-text:/); // hashed, stable per (text, context)
+    expect(opts.expiry).toBe(5 * 60 * 1000);
+    // maxTokens is finite (not Infinity) - the whole point of the hardening.
+    expect(complete.mock.calls[0][2].maxTokens).toBe(800);
+    expect(res._getJSONData()).toEqual({ text: 'refined output' });
+  });
+
+  it('serves a cached refinement without recomputing', async () => {
+    mockGetCachedData.mockResolvedValue('cached refined');
+
+    const { req, res } = createMocks({ method: 'POST', body: { text: 'hello' } });
+    await handler(req as any, res as any);
+
+    expect(res._getJSONData()).toEqual({ text: 'cached refined' });
+    expect(mockGetOperationsModel).not.toHaveBeenCalled();
+    expect(mockRefineText).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/ai/refineText.ts
+++ b/apps/client/pages/api/ai/refineText.ts
@@ -1,33 +1,64 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
-import { refineText } from '@bike4mind/services';
-import { IMessage } from '@bike4mind/common';
+import { refineText, refineTextLLMSchema, cacheService } from '@bike4mind/services';
+import { IMessage, ApiKeyScope } from '@bike4mind/common';
+import { cacheRepository } from '@bike4mind/database';
+import { BadRequestError } from '@server/utils/errors';
 import { OperationsModelService } from '@client/services/operationsModelService';
+import { CacheKeys } from '@server/utils/cacheKeys';
+import { z } from 'zod';
 
-const handler = baseApi().get(
+// Identical (text, context) refinements are common (users re-clicking refine),
+// and every miss is a paid operations-model call - cache briefly.
+const REFINE_TEXT_CACHE_MS = 5 * 60 * 1000;
+// Cap output so one refine can't run away; refined text is short by nature.
+const REFINE_TEXT_MAX_TOKENS = 800;
+
+// POST (not GET): this triggers an LLM completion, so it isn't a safe/idempotent
+// read. Gated to ai:generate so an under-scoped API key can't drive LLM cost.
+const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(
   asyncHandler(async (req, res) => {
-    const { text, context } = req.query as any;
-    const { modelId, llm } = await OperationsModelService.getOperationsModel();
-
-    if (!llm) {
-      throw new Error('Failed to initialize LLM');
+    let params: z.infer<typeof refineTextLLMSchema>;
+    try {
+      params = refineTextLLMSchema.parse(req.body);
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        throw new BadRequestError(err.issues[0]?.message ?? 'Invalid request body');
+      }
+      throw err;
     }
+    const { text, context } = params;
 
-    const enhancedText = await refineText(
-      { text, context },
+    const enhancedText = await cacheService.getCachedData(
+      CacheKeys.refineText(text, context),
+      async () => {
+        const { modelId, llm } = await OperationsModelService.getOperationsModel();
+        if (!llm) {
+          throw new Error('Failed to initialize LLM');
+        }
+
+        return refineText(
+          { text, context },
+          {
+            llm: {
+              complete: async (messages, callback) => {
+                await llm.complete(
+                  modelId,
+                  messages as unknown as IMessage[],
+                  { stream: false, maxTokens: REFINE_TEXT_MAX_TOKENS },
+                  async chunks => {
+                    await callback(chunks[0]);
+                  }
+                );
+              },
+            },
+          }
+        );
+      },
       {
-        llm: {
-          complete: async (messages, callback) => {
-            await llm.complete(
-              modelId,
-              messages as unknown as IMessage[],
-              { stream: false, maxTokens: Infinity },
-              async text => {
-                await callback(text[0]);
-              }
-            );
-          },
-        },
+        db: { caches: cacheRepository },
+        expiry: REFINE_TEXT_CACHE_MS,
+        logger: req.logger,
       }
     );
 

--- a/apps/client/server/utils/cacheKeys.ts
+++ b/apps/client/server/utils/cacheKeys.ts
@@ -83,4 +83,10 @@ export const CacheKeys = {
   modelStats: () => 'model-stats',
 
   modelList: (userId: string) => `model-list:${userId}`,
+
+  refineText: (text: string, context?: string) => {
+    const material = JSON.stringify({ text, context: context ?? '' });
+    const hash = crypto.createHash('sha256').update(material).digest('hex').substring(0, 16);
+    return `refine-text:${hash}`;
+  },
 };


### PR DESCRIPTION
# Pull Request

## Description

`/api/ai/refineText` (an operations-model text-refinement helper) had a few hardening gaps: it was a GET that triggered an LLM completion (a safe method should be side-effect-free), it applied no API-key scope gate (any valid key of any scope could call it), it did no caching, and it passed `maxTokens: Infinity`. This tightens it to standard practice for our LLM endpoints.

## Changes

- `pages/api/ai/refineText.ts`:
  - Converted GET -> POST (the operation has an LLM side effect; the input now travels in the body). The published API reference already documented this route as POST, so this aligns the implementation with the docs.
  - Added a scope gate: `baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] })`.
  - Validate the body with the exported `refineTextLLMSchema` (removes a `req.query as any`).
  - Wrapped the call in the standard read-through cache (`cacheService.getCachedData`) keyed on a hash of `{ text, context }`, 5-minute TTL.
  - Capped output at `maxTokens: 800` (was `Infinity`).
- `app/hooks/useRefineText.ts`: switched the single in-app caller from `api.get(..., { params })` to `api.post(..., values)`.
- `server/utils/cacheKeys.ts`: added `CacheKeys.refineText(text, context)`.
- Added `pages/api/ai/__tests__/refineText.test.ts` (scope-gate wiring, 400 on invalid body, bounded LLM call on cache miss, cache hit skips recompute).

## Guide for Testers

The only in-app caller is the Research Tasks form. Test in the browser plus a scope check via curl.

> API-key auth header: pass the key via `X-API-Key: <KEY>` (or `Authorization: ApiKey <KEY>`). `Authorization: Bearer ...` is reserved for the app JWT and will return 401 for an API key.

1. Sign in at `app.staging.bike4mind.com`.
2. Open a Research Task form that has the "refine"/enhance text action (Sidebar -> Research Tasks -> open/create a task; the text field with the refine button).
3. Type `make this text better plz` in the text field and click the refine/enhance button. Expected: within a few seconds the text is replaced with a cleaned-up version, no error toast.
4. Click refine again on the exact same text within 5 minutes. Expected: same result, returned faster (served from cache).
5. Scope gate (API key): create an API key WITHOUT the `ai:generate` scope (e.g. only `notebooks:read`). Run: `curl -si -X POST https://app.staging.bike4mind.com/api/ai/refineText -H "X-API-Key: <KEY>" -H "Content-Type: application/json" -d '{"text":"hello"}'`. Expected: 403 (under-scoped). Repeat with a key that HAS `ai:generate`. Expected: 200 with `{ "text": "..." }`.
6. Invalid body: `curl -si -X POST .../api/ai/refineText -H "X-API-Key: <ai:generate KEY>" -H "Content-Type: application/json" -d '{}'`. Expected: 400.

### Regression Checks

- The in-app refine action in Research Tasks still works end-to-end (it now POSTs instead of GETs).
- No other feature calls this endpoint (verified: `useRefineText` is the sole caller).

### What NOT to test

- No UI layout changes; only the network method behind the existing refine button changed.

## Additional Information

Standard-practice hardening of an LLM helper endpoint (scope gate + caching + output cap + correct HTTP method). No functional change to the refined-text output.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
