### PR TITLE
test(ci): de-flake embed metering assertion + Mongo setup hook timeout

### DIFF
--- a/apps/client/server/chatCompletion/external/embedRoute.integration.test.ts
+++ b/apps/client/server/chatCompletion/external/embedRoute.integration.test.ts
@@ -365,10 +365,18 @@ describe('embed tool loop (real executeCompletion + real KB tools + real Mongo)'
 
     await post('usage metered to the org across the tool loop');
 
-    // Scope to THIS test's org: a prior test's fire-and-forget usage write can land
+    // The route writes the UsageEvent fire-and-forget (not awaited on the response
+    // path), so poll until it lands instead of reading once and racing the write.
+    // Scope to THIS test's org: a prior test's fire-and-forget write can also land
     // after its own dropDatabase, so filter rather than asserting a global count.
-    const events = await UsageEvent.find({ feature: 'completion_api', ownerId: org.id }).lean();
-    expect(events).toHaveLength(1);
+    const events = await vi.waitFor(
+      async () => {
+        const found = await UsageEvent.find({ feature: 'completion_api', ownerId: org.id }).lean();
+        expect(found).toHaveLength(1);
+        return found;
+      },
+      { timeout: 5000, interval: 50 }
+    );
     expect(String(events[0].ownerId)).toBe(org.id);
     expect(events[0].ownerType).toBe('Organization');
     expect(String(events[0].userId)).toBe(owner.id);

--- a/packages/database/src/__test__/utils.ts
+++ b/packages/database/src/__test__/utils.ts
@@ -49,7 +49,10 @@ export async function setupMongoTest() {
 
     // Force the models to be registered by accessing them
     await Promise.resolve([researchTaskRepository, taskScheduleRepository, researchAgentRepository]);
-  }, 30000); // Increase timeout for index creation and MongoDB startup
+    // 60s (not 30s): under parallel shards a cold mongodb-memory-server start - binary
+    // resolution plus the port-collision retry loop in createMongoServer - can exceed
+    // 30s and time the hook out (a transient red, not a real failure).
+  }, 60000);
 
   afterAll(async () => {
     if (mongoServer) {


### PR DESCRIPTION
## Problem

Two production-CI reds on `main` that are transient, not code regressions:

- `apps/client` shard . `embedRoute.integration.test.ts:371` "meters the multi-turn tool run against the owner org" . `expect(events).toHaveLength(1)` intermittently gets `0`.
- `packages/database` shard . `artifactModels.test.ts` . `setupMongoTest` beforeAll fails with "Hook timed out in 30000ms."

Both reproduced on two different SHAs (`758f406`, `ec18fc8`) with green runs on both sides, including on commits newer than the failures. The failing test and the metering route are byte-identical across the passing and failing SHAs (both last touched by #733, which merged green), so there is no version skew . the only variable is runtime timing. These are flakes.

## Root causes

1. The embed route writes the `UsageEvent` fire-and-forget (not awaited on the response path). The test did `await post(...)` then read `UsageEvent.find(...)` once, immediately, so it raced the async write and occasionally saw `0`. The test's own comment already flagged the fire-and-forget hazard (in the other direction).
2. `setupMongoTest`'s beforeAll had a 30s cap. Under parallel shards a cold `mongodb-memory-server` start . binary resolution plus the port-collision retry loop in `createMongoServer` . can exceed 30s and time the hook out.

## Fix

1. Poll for the metering event with `vi.waitFor` (5s timeout, 50ms interval) instead of a single immediate read. This matches the fire-and-forget reality: the assertion retries until the write lands, and still fails fast on a genuine miss. Field assertions are unchanged.
2. Raise the `setupMongoTest` beforeAll timeout from 30s to 60s.

Test-only; no product code touched.

## Verification

This integration test needs the built core `dist` + `mongodb-memory-server`, so it runs in CI rather than locally. Watching this PR's `Run Tests (client)` and `Run Tests (data)` shards to confirm both go green.
