### PR TITLE
feat(client): Tools dropdown fixes & polish

### DIFF
--- a/apps/client/app/components/Session/AISettings/AgentsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/AgentsSection.tsx
@@ -190,23 +190,11 @@ const AgentsSection: React.FC<AgentsSectionProps> = ({ onClose, showMobileHeader
           zIndex: 1,
         }}
       >
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: { xs: 'flex-start', sm: 'space-between' },
-            flex: 1,
-            width: '100%',
-            gap: 1,
-          }}
-        >
-          <Typography sx={{ color: 'text.primary', fontSize: '14px' }}>Agents</Typography>
+        <Typography sx={{ color: 'text.primary', fontSize: '14px' }}>Agents</Typography>
 
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           <ContextHelpButton helpId="features/agents" tooltipText="Learn about Agents" size="sm" />
-        </Box>
-
-        {onClose && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {onClose && (
             <IconButton
               variant="plain"
               size="sm"
@@ -219,8 +207,8 @@ const AgentsSection: React.FC<AgentsSectionProps> = ({ onClose, showMobileHeader
             >
               <CloseIcon sx={{ fontSize: '16px', color: 'text.primary50', cursor: 'pointer' }} />
             </IconButton>
-          </Box>
-        )}
+          )}
+        </Box>
       </Box>
 
       <Box

--- a/apps/client/app/components/Session/AISettings/AgentsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/AgentsSection.tsx
@@ -14,6 +14,7 @@ import { agentAvatarFallbackSx } from '@client/app/components/Agent/AgentAvatar'
 import AgentProactiveMessagingModal from './AgentProactiveMessagingModal';
 import { useGetSessionAgentConfigs } from '@client/app/hooks/data/agentProactiveMessaging';
 import ContextHelpButton from '@client/app/components/help/ContextHelpButton';
+import { HEADER_ICON_BUTTON_SX } from './headerIconButtonSx';
 
 const ToolContainer = ({ children }: PropsWithChildren) => {
   return (
@@ -192,20 +193,16 @@ const AgentsSection: React.FC<AgentsSectionProps> = ({ onClose, showMobileHeader
       >
         <Typography sx={{ color: 'text.primary', fontSize: '14px' }}>Agents</Typography>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <ContextHelpButton helpId="features/agents" tooltipText="Learn about Agents" size="sm" />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <ContextHelpButton
+            helpId="features/agents"
+            tooltipText="Learn about Agents"
+            size="sm"
+            sx={HEADER_ICON_BUTTON_SX}
+          />
           {onClose && (
-            <IconButton
-              variant="plain"
-              size="sm"
-              onClick={onClose}
-              sx={{
-                '&:hover': {
-                  backgroundColor: 'background.level1',
-                },
-              }}
-            >
-              <CloseIcon sx={{ fontSize: '16px', color: 'text.primary50', cursor: 'pointer' }} />
+            <IconButton variant="plain" size="sm" onClick={onClose} sx={HEADER_ICON_BUTTON_SX}>
+              <CloseIcon sx={{ fontSize: '16px' }} />
             </IconButton>
           )}
         </Box>

--- a/apps/client/app/components/Session/AISettings/ToolsButton.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsButton.tsx
@@ -1,7 +1,7 @@
 import { FC, useMemo, useRef, useState } from 'react';
 import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
 import { Box, Dropdown, IconButton, Menu, MenuButton, Modal, ModalDialog, Typography } from '@mui/joy';
-import { Construction as ConstructionIcon, Close as CloseIcon } from '@mui/icons-material';
+import { Construction as ConstructionIcon } from '@mui/icons-material';
 import { B4MLLMTools } from '@bike4mind/common';
 import ToolsSection from './ToolsSection';
 import ToolIndicators from '../../common/ToolIndicators';
@@ -58,6 +58,7 @@ const ToolsButton: FC<ToolsButtonProps> = ({
     onRollDice,
     columns: 1 as const,
     onModalOpenChange: setIsDeepResearchModalOpen,
+    onClose: () => setOpen(false),
     toolContainerSx: {
       backgroundColor: (theme: { palette: { background: { surface2: string } } }) => theme.palette.background.surface2,
       padding: '12px',
@@ -98,21 +99,9 @@ const ToolsButton: FC<ToolsButtonProps> = ({
               height: '90dvh',
               border: 'none',
               backgroundColor: 'background.body',
+              overflow: 'auto',
             }}
           >
-            <IconButton
-              onClick={() => setOpen(false)}
-              size="sm"
-              variant="plain"
-              color="neutral"
-              sx={{
-                zIndex: 1,
-                alignSelf: 'flex-end',
-              }}
-              data-testid="tools-modal-close-btn"
-            >
-              <CloseIcon sx={{ fontSize: 20 }} />
-            </IconButton>
             <ToolsSection {...toolsSectionProps} />
           </ModalDialog>
         </Modal>

--- a/apps/client/app/components/Session/AISettings/ToolsButton.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsButton.tsx
@@ -152,13 +152,18 @@ const ToolsButton: FC<ToolsButtonProps> = ({
               </Typography>
             )}
           </Box>
-          <ToolIndicators
-            activePrimaryTools={activePrimaryTools}
-            isThinkingActive={isThinkingActive}
-            otherActiveToolsCount={otherActiveToolsCount}
-            enabledMcpServers={enabledMcpServers}
-            availableMcpServers={availableMcpServers}
-          />
+          {/* Fast mode sends no tools, so nothing is actually active - hide all
+              indicators (tool icons, count, and thinking). Selections persist and
+              reappear when switching back to Smart. */}
+          {toolMode !== 'fast' && (
+            <ToolIndicators
+              activePrimaryTools={activePrimaryTools}
+              isThinkingActive={isThinkingActive}
+              otherActiveToolsCount={otherActiveToolsCount}
+              enabledMcpServers={enabledMcpServers}
+              availableMcpServers={availableMcpServers}
+            />
+          )}
         </Box>
       </MenuButton>
 

--- a/apps/client/app/components/Session/AISettings/ToolsButton.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsButton.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useRef, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { scrollbarStyles } from '@client/app/utils/scrollbarStyles';
 import { Box, Dropdown, IconButton, Menu, MenuButton, Modal, ModalDialog, Typography } from '@mui/joy';
 import { Construction as ConstructionIcon } from '@mui/icons-material';
@@ -45,6 +45,21 @@ const ToolsButton: FC<ToolsButtonProps> = ({
   const [open, setOpen] = useState(false);
   const [isDeepResearchModalOpen, setIsDeepResearchModalOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  // Mobile: show a bottom fade while there's more to scroll, so it's obvious the
+  // panel scrolls (custom scrollbars are unreliable on touch). Hidden at the end.
+  const mobileScrollRef = useRef<HTMLDivElement>(null);
+  const [showBottomFade, setShowBottomFade] = useState(false);
+  const updateBottomFade = useCallback(() => {
+    const el = mobileScrollRef.current;
+    if (!el) return;
+    const scrollable = el.scrollHeight > el.clientHeight;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
+    setShowBottomFade(scrollable && !atBottom);
+  }, []);
+  useEffect(() => {
+    if (open) updateBottomFade();
+  }, [open, updateBottomFade]);
   const { data: modelInfoRepo } = useModelInfo();
   const modelSupportsTools = useMemo(
     () => modelInfoRepo?.find(m => m.id === model)?.supportsTools ?? true,
@@ -94,15 +109,36 @@ const ToolsButton: FC<ToolsButtonProps> = ({
         <Modal open={open} onClose={() => !isDeepResearchModalOpen && setOpen(false)}>
           <ModalDialog
             sx={{
-              p: 1,
+              p: 0,
               width: '90dvw',
               height: '90dvh',
               border: 'none',
               backgroundColor: 'background.body',
-              overflow: 'auto',
+              overflow: 'hidden',
+              position: 'relative',
             }}
           >
-            <ToolsSection {...toolsSectionProps} />
+            <Box
+              ref={mobileScrollRef}
+              onScroll={updateBottomFade}
+              sx={{ height: '100%', overflow: 'auto', p: 1, ...scrollbarStyles }}
+            >
+              <ToolsSection {...toolsSectionProps} />
+            </Box>
+            {/* Scroll affordance: fades content at the bottom edge while more is below. */}
+            <Box
+              sx={{
+                position: 'absolute',
+                left: 0,
+                right: 0,
+                bottom: 0,
+                height: '48px',
+                pointerEvents: 'none',
+                opacity: showBottomFade ? 1 : 0,
+                transition: 'opacity 0.2s',
+                background: theme => `linear-gradient(to bottom, transparent, ${theme.vars.palette.background.body})`,
+              }}
+            />
           </ModalDialog>
         </Modal>
       </>

--- a/apps/client/app/components/Session/AISettings/ToolsButton.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsButton.tsx
@@ -169,7 +169,7 @@ const ToolsButton: FC<ToolsButtonProps> = ({
         sx={{
           zIndex: 1400,
           ...(modelSupportsTools
-            ? { minWidth: '400px', maxWidth: '400px', p: '8px' }
+            ? { minWidth: '500px', maxWidth: '500px', p: '8px' }
             : { minWidth: 'auto', maxWidth: 'auto', p: '16px' }),
           backgroundColor: theme => theme.palette.background.body,
           border: theme => `1px solid ${theme.vars.palette.neutral.outlinedBorder}`,

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -205,6 +205,20 @@ const ToolLabel = ({ name, description, dim = false, agentOnlyNote }: ToolLabelP
 const AGENT_ONLY_MCP_SERVERS = ['github', 'atlassian'];
 const AGENT_ONLY_MCP_NOTE = 'Agent mode only - mention an @agent to use it in chat';
 
+// Tools rendered under the "Fun & Novelty" section. They count toward that section's
+// own pinned tally, not the Individual tools one. Must stay in sync with the tools
+// rendered in that section below.
+const FUN_NOVELTY_TOOLS: string[] = [
+  'chess_engine',
+  'dice_roll',
+  'iss_tracker',
+  'moon_phase',
+  'planet_visibility',
+  'sunrise_sunset',
+  'weather_info',
+  'wikipedia_on_this_day',
+];
+
 interface ToolsSectionProps {
   tools?: B4MLLMTools[];
   setTools?: (tools: B4MLLMTools[]) => void;
@@ -557,7 +571,10 @@ const ToolsSection = ({
     (isQuestMasterFeatureEnabled && isQuestMasterEnabled ? 1 : 0) +
     (isAgentsFeatureEnabled && isAgentsEnabled ? 1 : 0) +
     (isLatticeFeatureEnabled && isLatticeEnabled ? 1 : 0);
-  const pinnedCount = tools.length + enabledMcpServerCount + specialToolsCount;
+  // Fun & Novelty tools count toward their own section's tally, not Individual tools.
+  const funPinnedCount = tools.filter(t => FUN_NOVELTY_TOOLS.includes(t)).length;
+  const individualToolsCount = tools.length - funPinnedCount;
+  const pinnedCount = individualToolsCount + enabledMcpServerCount + specialToolsCount;
 
   // Second line appended to the Smart tools description in Smart mode, only when Agent-mode
   // routing would ignore the Smart Tools below; null otherwise so it stays a single line.
@@ -587,7 +604,7 @@ const ToolsSection = ({
             p: '8px 12px',
             mx: '-8px',
             mt: '-8px',
-            mb: '12px',
+            mb: '20px',
             borderBottom: '1px solid',
             borderColor: 'border.soft',
             position: 'sticky',
@@ -648,7 +665,7 @@ const ToolsSection = ({
           alignItems: { xs: 'flex-start', sm: 'center' },
           justifyContent: 'space-between',
           gap: '24px',
-          mb: '12px',
+          mb: '20px',
           px: '4px',
         }}
       >
@@ -715,21 +732,25 @@ const ToolsSection = ({
           py: 0.5,
           mb: showIndividualTools ? 1 : 0,
           userSelect: 'none',
-          '&:hover': { opacity: 0.8 },
+          '&:hover .tools-collapsible-title': { color: 'text.primary' },
         }}
       >
+        <Typography
+          className="tools-collapsible-title"
+          level="body-xs"
+          sx={{ fontSize: '13px', color: 'text.tertiary', transition: 'color 0.3s', ml: '4px' }}
+        >
+          Individual tools{pinnedCount > 0 ? ` (${pinnedCount} pinned)` : ''}
+        </Typography>
         <ExpandMoreIcon
           sx={{
             fontSize: '1rem',
             transition: 'transform 0.2s',
-            transform: showIndividualTools ? 'rotate(0deg)' : 'rotate(-90deg)',
+            transform: showIndividualTools ? 'rotate(180deg)' : 'rotate(0deg)',
             color: 'text.secondary',
-            mr: 0.5,
+            ml: '8px',
           }}
         />
-        <Typography level="body-xs" sx={{ color: 'text.secondary', flex: 1 }}>
-          Individual tools{pinnedCount > 0 ? ` (${pinnedCount} pinned)` : ''}
-        </Typography>
       </Box>
 
       {/* Tool grid (collapsible). Per-tool availability (Fast/Agent mode) is
@@ -1323,223 +1344,223 @@ const ToolsSection = ({
         </Box>
       </ToolGateContext.Provider>
 
-      {/* Collapsible Fun & Novelty tools section (hidden by default for FTUE) */}
-      {showIndividualTools && (
-        <>
-          <Box
-            role="button"
-            tabIndex={0}
-            aria-expanded={showFunTools}
-            data-testid="tools-fun-toggle"
-            onClick={toggleFunTools}
-            onKeyDown={e => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                toggleFunTools();
-              }
-            }}
+      {/* Collapsible Fun & Novelty section - independent of the Individual tools collapse,
+          so collapsing one no longer hides the other. */}
+      <>
+        <Box
+          role="button"
+          tabIndex={0}
+          aria-expanded={showFunTools}
+          data-testid="tools-fun-toggle"
+          onClick={toggleFunTools}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              toggleFunTools();
+            }
+          }}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            cursor: 'pointer',
+            py: 0.5,
+            mt: '12px',
+            mb: showFunTools ? 1 : 0,
+            userSelect: 'none',
+            '&:hover .tools-collapsible-title': { color: 'text.primary' },
+          }}
+        >
+          <Typography
+            className="tools-collapsible-title"
+            level="body-xs"
+            sx={{ fontSize: '13px', color: 'text.tertiary', transition: 'color 0.3s', ml: '4px' }}
+          >
+            Fun & Novelty{funPinnedCount > 0 ? ` (${funPinnedCount} pinned)` : ''}
+          </Typography>
+          <ExpandMoreIcon
             sx={{
-              display: 'flex',
-              alignItems: 'center',
-              cursor: 'pointer',
-              py: 0.5,
-              mt: 1,
-              mb: showFunTools ? 1 : 0,
-              userSelect: 'none',
-              '&:hover': { opacity: 0.8 },
+              fontSize: '1rem',
+              transition: 'transform 0.2s',
+              transform: showFunTools ? 'rotate(180deg)' : 'rotate(0deg)',
+              color: 'text.secondary',
+              ml: '8px',
+            }}
+          />
+        </Box>
+
+        <ToolGateContext.Provider value={getToolGate}>
+          <Box
+            className="tools-section-fun-grid"
+            sx={{
+              display: showFunTools ? 'grid' : 'none',
+              gridTemplateColumns: `repeat(${columns}, 1fr)`,
+              gap: columns,
+              width: '100%',
+              overflow: { xs: 'auto', sm: 'initial' },
             }}
           >
-            <ExpandMoreIcon
-              sx={{
-                fontSize: '1rem',
-                transition: 'transform 0.2s',
-                transform: showFunTools ? 'rotate(0deg)' : 'rotate(-90deg)',
-                color: 'text.secondary',
-                mr: 0.5,
-              }}
-            />
-            <Typography level="body-xs" sx={{ color: 'text.secondary', flex: 1 }}>
-              Fun & Novelty
-            </Typography>
+            {/* Chess Engine */}
+            <Grid xs={12} className="tool-item tool-item-chess-engine">
+              <ToolContainer sx={toolContainerSx} toolId="chess_engine">
+                <Box
+                  className="tool-content"
+                  sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                >
+                  <ChessIcon
+                    sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                  />
+                  <ToolLabel
+                    name={getToolDisplayName('chess_engine')}
+                    description={getToolDescription('chess_engine')}
+                  />
+                </Box>
+                <SquareSlideToggle
+                  onChange={() => handleToggleTool('chess_engine')}
+                  checked={tools.includes('chess_engine')}
+                />
+              </ToolContainer>
+            </Grid>
+            {/* Dice Roll */}
+            <Grid xs={12} className="tool-item tool-item-dice">
+              <ToolContainer sx={toolContainerSx} toolId="dice_roll">
+                <Box
+                  className="tool-content"
+                  sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                >
+                  <DiceIcon
+                    sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                  />
+                  <ToolLabel name={getToolDisplayName('dice_roll')} description={getToolDescription('dice_roll')} />
+                </Box>
+                <SquareSlideToggle
+                  onChange={() => handleToggleTool('dice_roll')}
+                  checked={tools.includes('dice_roll')}
+                />
+              </ToolContainer>
+            </Grid>
+            {/* Weather Info */}
+            <Grid xs={12} className="tool-item tool-item-weather">
+              <ToolContainer sx={toolContainerSx} toolId="weather_info">
+                <Box
+                  className="tool-content"
+                  sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                >
+                  <WeatherIcon
+                    sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                  />
+                  <ToolLabel
+                    name={getToolDisplayName('weather_info')}
+                    description={getToolDescription('weather_info')}
+                  />
+                </Box>
+                <SquareSlideToggle
+                  onChange={() => handleToggleTool('weather_info')}
+                  checked={tools.includes('weather_info')}
+                />
+              </ToolContainer>
+            </Grid>
+            {/* On This Day (Wikipedia) */}
+            <Grid xs={12} className="tool-item tool-item-wikipedia-on-this-day">
+              <ToolContainer sx={toolContainerSx} toolId="wikipedia_on_this_day">
+                <Box
+                  className="tool-content"
+                  sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                >
+                  <HistoryIcon
+                    sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                  />
+                  <ToolLabel
+                    name={getToolDisplayName('wikipedia_on_this_day')}
+                    description={getToolDescription('wikipedia_on_this_day')}
+                  />
+                </Box>
+                <SquareSlideToggle
+                  onChange={() => handleToggleTool('wikipedia_on_this_day')}
+                  checked={tools.includes('wikipedia_on_this_day')}
+                />
+              </ToolContainer>
+            </Grid>
+            {/* ISS Tracker */}
+            <Grid xs={12} className="tool-item tool-item-iss-tracker">
+              <ToolContainer sx={toolContainerSx} toolId="iss_tracker">
+                <Box
+                  className="tool-content"
+                  sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                >
+                  <SatelliteIcon
+                    sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                  />
+                  <ToolLabel name={getToolDisplayName('iss_tracker')} description={getToolDescription('iss_tracker')} />
+                </Box>
+                <SquareSlideToggle
+                  onChange={() => handleToggleTool('iss_tracker')}
+                  checked={tools.includes('iss_tracker')}
+                />
+              </ToolContainer>
+            </Grid>
+            {/* Sunrise/Sunset */}
+            <Grid xs={12} className="tool-item tool-item-sunrise-sunset">
+              <ToolContainer sx={toolContainerSx} toolId="sunrise_sunset">
+                <Box
+                  className="tool-content"
+                  sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                >
+                  <SunriseIcon
+                    sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                  />
+                  <ToolLabel
+                    name={getToolDisplayName('sunrise_sunset')}
+                    description={getToolDescription('sunrise_sunset')}
+                  />
+                </Box>
+                <SquareSlideToggle
+                  onChange={() => handleToggleTool('sunrise_sunset')}
+                  checked={tools.includes('sunrise_sunset')}
+                />
+              </ToolContainer>
+            </Grid>
+            {/* Moon Phase */}
+            <Grid xs={12} className="tool-item tool-item-moon-phase">
+              <ToolContainer sx={toolContainerSx} toolId="moon_phase">
+                <Box
+                  className="tool-content"
+                  sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                >
+                  <MoonIcon
+                    sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                  />
+                  <ToolLabel name={getToolDisplayName('moon_phase')} description={getToolDescription('moon_phase')} />
+                </Box>
+                <SquareSlideToggle
+                  onChange={() => handleToggleTool('moon_phase')}
+                  checked={tools.includes('moon_phase')}
+                />
+              </ToolContainer>
+            </Grid>
+            {/* Planet Visibility */}
+            <Grid xs={12} className="tool-item tool-item-planet-visibility">
+              <ToolContainer sx={toolContainerSx} toolId="planet_visibility">
+                <Box
+                  className="tool-content"
+                  sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
+                >
+                  <PlanetIcon
+                    sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
+                  />
+                  <ToolLabel
+                    name={getToolDisplayName('planet_visibility')}
+                    description={getToolDescription('planet_visibility')}
+                  />
+                </Box>
+                <SquareSlideToggle
+                  onChange={() => handleToggleTool('planet_visibility')}
+                  checked={tools.includes('planet_visibility')}
+                />
+              </ToolContainer>
+            </Grid>
           </Box>
-
-          <ToolGateContext.Provider value={getToolGate}>
-            <Box
-              className="tools-section-fun-grid"
-              sx={{
-                display: showFunTools ? 'grid' : 'none',
-                gridTemplateColumns: `repeat(${columns}, 1fr)`,
-                gap: columns,
-                width: '100%',
-                overflow: { xs: 'auto', sm: 'initial' },
-              }}
-            >
-              {/* Chess Engine */}
-              <Grid xs={12} className="tool-item tool-item-chess-engine">
-                <ToolContainer sx={toolContainerSx} toolId="chess_engine">
-                  <Box
-                    className="tool-content"
-                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-                  >
-                    <ChessIcon
-                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                    />
-                    <ToolLabel
-                      name={getToolDisplayName('chess_engine')}
-                      description={getToolDescription('chess_engine')}
-                    />
-                  </Box>
-                  <SquareSlideToggle
-                    onChange={() => handleToggleTool('chess_engine')}
-                    checked={tools.includes('chess_engine')}
-                  />
-                </ToolContainer>
-              </Grid>
-              {/* Dice Roll */}
-              <Grid xs={12} className="tool-item tool-item-dice">
-                <ToolContainer sx={toolContainerSx} toolId="dice_roll">
-                  <Box
-                    className="tool-content"
-                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-                  >
-                    <DiceIcon
-                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                    />
-                    <ToolLabel name={getToolDisplayName('dice_roll')} description={getToolDescription('dice_roll')} />
-                  </Box>
-                  <SquareSlideToggle
-                    onChange={() => handleToggleTool('dice_roll')}
-                    checked={tools.includes('dice_roll')}
-                  />
-                </ToolContainer>
-              </Grid>
-              {/* Weather Info */}
-              <Grid xs={12} className="tool-item tool-item-weather">
-                <ToolContainer sx={toolContainerSx} toolId="weather_info">
-                  <Box
-                    className="tool-content"
-                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-                  >
-                    <WeatherIcon
-                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                    />
-                    <ToolLabel
-                      name={getToolDisplayName('weather_info')}
-                      description={getToolDescription('weather_info')}
-                    />
-                  </Box>
-                  <SquareSlideToggle
-                    onChange={() => handleToggleTool('weather_info')}
-                    checked={tools.includes('weather_info')}
-                  />
-                </ToolContainer>
-              </Grid>
-              {/* On This Day (Wikipedia) */}
-              <Grid xs={12} className="tool-item tool-item-wikipedia-on-this-day">
-                <ToolContainer sx={toolContainerSx} toolId="wikipedia_on_this_day">
-                  <Box
-                    className="tool-content"
-                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-                  >
-                    <HistoryIcon
-                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                    />
-                    <ToolLabel
-                      name={getToolDisplayName('wikipedia_on_this_day')}
-                      description={getToolDescription('wikipedia_on_this_day')}
-                    />
-                  </Box>
-                  <SquareSlideToggle
-                    onChange={() => handleToggleTool('wikipedia_on_this_day')}
-                    checked={tools.includes('wikipedia_on_this_day')}
-                  />
-                </ToolContainer>
-              </Grid>
-              {/* ISS Tracker */}
-              <Grid xs={12} className="tool-item tool-item-iss-tracker">
-                <ToolContainer sx={toolContainerSx} toolId="iss_tracker">
-                  <Box
-                    className="tool-content"
-                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-                  >
-                    <SatelliteIcon
-                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                    />
-                    <ToolLabel
-                      name={getToolDisplayName('iss_tracker')}
-                      description={getToolDescription('iss_tracker')}
-                    />
-                  </Box>
-                  <SquareSlideToggle
-                    onChange={() => handleToggleTool('iss_tracker')}
-                    checked={tools.includes('iss_tracker')}
-                  />
-                </ToolContainer>
-              </Grid>
-              {/* Sunrise/Sunset */}
-              <Grid xs={12} className="tool-item tool-item-sunrise-sunset">
-                <ToolContainer sx={toolContainerSx} toolId="sunrise_sunset">
-                  <Box
-                    className="tool-content"
-                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-                  >
-                    <SunriseIcon
-                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                    />
-                    <ToolLabel
-                      name={getToolDisplayName('sunrise_sunset')}
-                      description={getToolDescription('sunrise_sunset')}
-                    />
-                  </Box>
-                  <SquareSlideToggle
-                    onChange={() => handleToggleTool('sunrise_sunset')}
-                    checked={tools.includes('sunrise_sunset')}
-                  />
-                </ToolContainer>
-              </Grid>
-              {/* Moon Phase */}
-              <Grid xs={12} className="tool-item tool-item-moon-phase">
-                <ToolContainer sx={toolContainerSx} toolId="moon_phase">
-                  <Box
-                    className="tool-content"
-                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-                  >
-                    <MoonIcon
-                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                    />
-                    <ToolLabel name={getToolDisplayName('moon_phase')} description={getToolDescription('moon_phase')} />
-                  </Box>
-                  <SquareSlideToggle
-                    onChange={() => handleToggleTool('moon_phase')}
-                    checked={tools.includes('moon_phase')}
-                  />
-                </ToolContainer>
-              </Grid>
-              {/* Planet Visibility */}
-              <Grid xs={12} className="tool-item tool-item-planet-visibility">
-                <ToolContainer sx={toolContainerSx} toolId="planet_visibility">
-                  <Box
-                    className="tool-content"
-                    sx={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: 0 }}
-                  >
-                    <PlanetIcon
-                      sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
-                    />
-                    <ToolLabel
-                      name={getToolDisplayName('planet_visibility')}
-                      description={getToolDescription('planet_visibility')}
-                    />
-                  </Box>
-                  <SquareSlideToggle
-                    onChange={() => handleToggleTool('planet_visibility')}
-                    checked={tools.includes('planet_visibility')}
-                  />
-                </ToolContainer>
-              </Grid>
-            </Box>
-          </ToolGateContext.Provider>
-        </>
-      )}
+        </ToolGateContext.Provider>
+      </>
 
       {/* Deep Research Config Modal */}
       <DeepResearchConfigModal open={deepResearchConfigOpen} onClose={() => setDeepResearchConfigOpen(false)} />

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -153,11 +153,13 @@ interface ToolLabelProps {
   name: string;
   description: string;
   dim?: boolean;
+  // Blue accent line under the description, e.g. to flag an agent-only integration.
+  agentOnlyNote?: string;
 }
 
 // Two-line label (name + inline description) used in place of the old
 // name-plus-(i)-tooltip pattern, so users can read what a tool does without hovering.
-const ToolLabel = ({ name, description, dim = false }: ToolLabelProps) => (
+const ToolLabel = ({ name, description, dim = false, agentOnlyNote }: ToolLabelProps) => (
   <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
     <Typography
       level="body-sm"
@@ -183,8 +185,23 @@ const ToolLabel = ({ name, description, dim = false }: ToolLabelProps) => (
     >
       {description}
     </Typography>
+    {agentOnlyNote && (
+      <Typography
+        level="body-xs"
+        data-testid="tool-agent-only-note"
+        sx={{ color: 'primary.500', fontSize: '0.7rem', lineHeight: 1.3, mt: 0.25 }}
+      >
+        {agentOnlyNote}
+      </Typography>
+    )}
   </Box>
 );
+
+// MCP servers reachable only through agent delegation, not plain chat. Must stay in
+// sync with the built-in agents that claim them via exclusiveMcpServers:
+// GithubManagerAgent ('github') and ProjectManagerAgent ('atlassian').
+const AGENT_ONLY_MCP_SERVERS = ['github', 'atlassian'];
+const AGENT_ONLY_MCP_NOTE = 'Agent mode only - mention an @agent to use it in chat';
 
 interface ToolsSectionProps {
   tools?: B4MLLMTools[];
@@ -738,7 +755,11 @@ const ToolsSection = ({
                       sx={{ color: theme => `${theme.palette.text.primary}80`, fontSize: '1.25rem', flexShrink: 0 }}
                     />
                   )}
-                  <ToolLabel name={getMcpServerLabel(server.name)} description={getMcpServerDescription(server.name)} />
+                  <ToolLabel
+                    name={getMcpServerLabel(server.name)}
+                    description={getMcpServerDescription(server.name)}
+                    agentOnlyNote={AGENT_ONLY_MCP_SERVERS.includes(server.name) ? AGENT_ONLY_MCP_NOTE : undefined}
+                  />
                 </Box>
                 <SquareSlideToggle
                   onChange={() => toggleMcpServer(server.name)}

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -33,6 +33,7 @@ import { Box, Grid, Input, Tooltip, Typography, IconButton } from '@mui/joy';
 import type { BoxProps } from '@mui/joy';
 import SwitchSelector from '@client/app/components/common/fields/SwitchSelector';
 import ContextHelpButton from '@client/app/components/help/ContextHelpButton';
+import { HEADER_ICON_BUTTON_SX } from './headerIconButtonSx';
 import { PropsWithChildren, useEffect, useMemo, useState, useCallback, createContext, useContext } from 'react';
 import { B4MLLMTools, IMcpServerDocument, classifyQueryComplexity } from '@bike4mind/common';
 import SquareSlideToggle from '@client/app/components/SquareSlideToggle';
@@ -615,21 +616,22 @@ const ToolsSection = ({
           }}
         >
           <Typography sx={{ color: 'text.primary', fontSize: '14px' }}>Tools</Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             <ContextHelpButton
               helpId="features/smart-tools"
               tooltipText="Learn about Smart Tools"
               data-testid="help-button-smart-tools"
               size="sm"
+              sx={HEADER_ICON_BUTTON_SX}
             />
             <IconButton
               variant="plain"
               size="sm"
               onClick={onClose}
               data-testid="tools-header-close-btn"
-              sx={{ '&:hover': { backgroundColor: 'background.level1' } }}
+              sx={HEADER_ICON_BUTTON_SX}
             >
-              <CloseIcon sx={{ fontSize: '16px', color: 'text.primary50', cursor: 'pointer' }} />
+              <CloseIcon sx={{ fontSize: '16px' }} />
             </IconButton>
           </Box>
         </Box>
@@ -666,11 +668,12 @@ const ToolsSection = ({
           justifyContent: 'space-between',
           gap: '24px',
           mb: '20px',
-          px: '4px',
+          pl: '4px',
+          pr: '12px',
         }}
       >
         <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
-          <Typography level="body-sm" sx={{ color: 'text.primary', lineHeight: 1.2, mb: 0.5 }}>
+          <Typography level="body-sm" sx={{ color: 'text.primary', lineHeight: 1.2, mb: 0.5, fontWeight: 600 }}>
             Smart tools
           </Typography>
           {toolMode === 'fast' ? (
@@ -728,11 +731,12 @@ const ToolsSection = ({
         sx={{
           display: 'flex',
           alignItems: 'center',
+          width: 'fit-content',
           cursor: 'pointer',
           py: 0.5,
           mb: showIndividualTools ? 1 : 0,
           userSelect: 'none',
-          '&:hover .tools-collapsible-title': { color: 'text.primary' },
+          '&:hover .tools-collapsible-title, &:hover .tools-collapsible-chevron': { color: 'text.primary' },
         }}
       >
         <Typography
@@ -743,11 +747,12 @@ const ToolsSection = ({
           Individual tools{pinnedCount > 0 ? ` (${pinnedCount} pinned)` : ''}
         </Typography>
         <ExpandMoreIcon
+          className="tools-collapsible-chevron"
           sx={{
             fontSize: '1rem',
-            transition: 'transform 0.2s',
+            transition: 'transform 0.2s, color 0.3s',
             transform: showIndividualTools ? 'rotate(180deg)' : 'rotate(0deg)',
-            color: 'text.secondary',
+            color: 'text.tertiary',
             ml: '8px',
           }}
         />
@@ -1362,12 +1367,13 @@ const ToolsSection = ({
           sx={{
             display: 'flex',
             alignItems: 'center',
+            width: 'fit-content',
             cursor: 'pointer',
             py: 0.5,
-            mt: '12px',
-            mb: showFunTools ? 1 : 0,
+            mt: '20px',
+            mb: showFunTools ? 1 : '12px',
             userSelect: 'none',
-            '&:hover .tools-collapsible-title': { color: 'text.primary' },
+            '&:hover .tools-collapsible-title, &:hover .tools-collapsible-chevron': { color: 'text.primary' },
           }}
         >
           <Typography
@@ -1378,11 +1384,12 @@ const ToolsSection = ({
             Fun & Novelty{funPinnedCount > 0 ? ` (${funPinnedCount} pinned)` : ''}
           </Typography>
           <ExpandMoreIcon
+            className="tools-collapsible-chevron"
             sx={{
               fontSize: '1rem',
-              transition: 'transform 0.2s',
+              transition: 'transform 0.2s, color 0.3s',
               transform: showFunTools ? 'rotate(180deg)' : 'rotate(0deg)',
-              color: 'text.secondary',
+              color: 'text.tertiary',
               ml: '8px',
             }}
           />

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -1082,7 +1082,9 @@ const ToolsSection = ({
             </ToolContainer>
           </Grid>
           <Grid xs={12} className="tool-item tool-item-thinking">
-            <ToolContainer sx={toolContainerSx}>
+            {/* flexWrap + responsive order let the budget input drop to its own line on
+                mobile (so it stops cropping the description) while staying inline on desktop. */}
+            <ToolContainer sx={{ ...(toolContainerSx as object | undefined), flexWrap: 'wrap', rowGap: '12px' }}>
               <Box
                 className="tool-content"
                 sx={{
@@ -1111,47 +1113,62 @@ const ToolsSection = ({
                 />
               </Box>
               {(thinking?.enabled ?? true) && modelSupportsThinking && (
-                <Tooltip title="Number of tokens allocated for thinking">
-                  <Input
-                    sx={commonInputStyles}
-                    size="sm"
-                    variant="outlined"
-                    color="primary"
-                    type="number"
-                    value={thinking?.budget_tokens ?? 16000}
-                    onChange={e => {
-                      const newValue = parseInt(e.target.value);
-                      if (newValue >= 1000 && newValue <= 32000) {
-                        setLLM({
-                          thinking: {
-                            enabled: thinking?.enabled ?? true,
-                            budget_tokens: newValue,
-                          },
-                        });
-                      }
-                    }}
-                    slotProps={{
-                      input: {
-                        min: 1000,
-                        max: 32000,
-                        step: 1000,
-                      },
-                    }}
-                  />
-                </Tooltip>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    // Mobile: order after the toggle + full basis => wraps to its own line.
+                    // Desktop: sits inline between the label and the toggle.
+                    order: { xs: 2, sm: 1 },
+                    flexBasis: { xs: '100%', sm: 'auto' },
+                    // Indent under the label on mobile (icon width 25 + 12 gap) so title,
+                    // description and input line up together.
+                    ml: { xs: '37px', sm: 0 },
+                  }}
+                >
+                  <Tooltip title="Number of tokens allocated for thinking">
+                    <Input
+                      sx={commonInputStyles}
+                      size="sm"
+                      variant="outlined"
+                      color="primary"
+                      type="number"
+                      value={thinking?.budget_tokens ?? 16000}
+                      onChange={e => {
+                        const newValue = parseInt(e.target.value);
+                        if (newValue >= 1000 && newValue <= 32000) {
+                          setLLM({
+                            thinking: {
+                              enabled: thinking?.enabled ?? true,
+                              budget_tokens: newValue,
+                            },
+                          });
+                        }
+                      }}
+                      slotProps={{
+                        input: {
+                          min: 1000,
+                          max: 32000,
+                          step: 1000,
+                        },
+                      }}
+                    />
+                  </Tooltip>
+                </Box>
               )}
-              <SquareSlideToggle
-                onChange={e =>
-                  setLLM({
-                    thinking: {
-                      enabled: e.target.checked,
-                      budget_tokens: thinking?.budget_tokens ?? 16000,
-                    },
-                  })
-                }
-                checked={thinking?.enabled ?? false}
-                disabled={!modelSupportsThinking}
-              />
+              <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0, order: { xs: 1, sm: 2 } }}>
+                <SquareSlideToggle
+                  onChange={e =>
+                    setLLM({
+                      thinking: {
+                        enabled: e.target.checked,
+                        budget_tokens: thinking?.budget_tokens ?? 16000,
+                      },
+                    })
+                  }
+                  checked={thinking?.enabled ?? false}
+                  disabled={!modelSupportsThinking}
+                />
+              </Box>
             </ToolContainer>
           </Grid>
           {/* Quest Master */}

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -27,6 +27,7 @@ import {
   Functions as WolframIcon,
   TableChart as ExcelIcon,
   ShowChart as FinanceIcon,
+  Close as CloseIcon,
 } from '@mui/icons-material';
 import { Box, Grid, Input, Tooltip, Typography, IconButton } from '@mui/joy';
 import type { BoxProps } from '@mui/joy';
@@ -211,6 +212,7 @@ interface ToolsSectionProps {
   columns?: number;
   onModalOpenChange?: (isOpen: boolean) => void;
   toolContainerSx?: BoxProps['sx'];
+  onClose?: () => void;
 }
 
 const ToolsSection = ({
@@ -219,6 +221,7 @@ const ToolsSection = ({
   columns = 2,
   onModalOpenChange,
   toolContainerSx,
+  onClose,
 }: ToolsSectionProps = {}) => {
   // Use props if provided, otherwise use context
   const contextTools = useLLM(state => state.tools);
@@ -557,7 +560,54 @@ const ToolsSection = ({
 
   return (
     <>
-      {/* Top descriptor + help link */}
+      {/* Sticky header (dropdown only): title + help on the left, close on the right.
+          Mirrors AgentsSection's header so the two dropdowns stay visually consistent.
+          The -8px margins break out of the container's 8px padding (same convention as
+          the unsupported-model message above) so the bottom border runs edge to edge.
+          Only rendered when onClose is provided (the dropdown); the AdvancedAIModal
+          embed omits it and keeps the inline help button below instead. */}
+      {onClose && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 1,
+            p: '8px 12px',
+            mx: '-8px',
+            mt: '-8px',
+            mb: 1,
+            borderBottom: '1px solid',
+            borderColor: 'border.soft',
+            position: 'sticky',
+            top: '-8px',
+            backgroundColor: theme => theme.palette.background.body,
+            // Above SwitchSelector's internal z-index (1/2) so scrolling tabs pass under it.
+            zIndex: 10,
+          }}
+        >
+          <Typography sx={{ color: 'text.primary', fontSize: '14px' }}>Tools</Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <ContextHelpButton
+              helpId="features/smart-tools"
+              tooltipText="Learn about Smart Tools"
+              data-testid="help-button-smart-tools"
+              size="sm"
+            />
+            <IconButton
+              variant="plain"
+              size="sm"
+              onClick={onClose}
+              data-testid="tools-header-close-btn"
+              sx={{ '&:hover': { backgroundColor: 'background.level1' } }}
+            >
+              <CloseIcon sx={{ fontSize: '16px', color: 'text.primary50', cursor: 'pointer' }} />
+            </IconButton>
+          </Box>
+        </Box>
+      )}
+
+      {/* Top descriptor. When there's no header (modal embed), keep the inline help button. */}
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
         <Typography
           level="body-xs"
@@ -566,11 +616,13 @@ const ToolsSection = ({
         >
           Enable tools the AI can use during this conversation.
         </Typography>
-        <ContextHelpButton
-          helpId="features/smart-tools"
-          tooltipText="Learn about Smart Tools"
-          data-testid="help-button-smart-tools"
-        />
+        {!onClose && (
+          <ContextHelpButton
+            helpId="features/smart-tools"
+            tooltipText="Learn about Smart Tools"
+            data-testid="help-button-smart-tools"
+          />
+        )}
       </Box>
 
       {/* Fast / Smart mode tabs */}

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -542,7 +542,18 @@ const ToolsSection = ({
     );
   }
 
-  const pinnedCount = tools.length;
+  // Enabled MCP servers (integrations) count toward the pinned tally like any other
+  // tool. Agent-only ones (see AGENT_ONLY_MCP_SERVERS) are labeled per-row rather
+  // than excluded here, so the number reflects everything the user has toggled on.
+  const enabledMcpServerCount = visibleMcpServers.filter(server => isMcpServerEnabled(server.name)).length;
+  // Feature-gated switches that live outside the `tools` array (each has its own LLM
+  // state flag) but appear in this panel, so they count like any other tool. Must stay
+  // in sync with the same tally in AdvancedAISettings' otherActiveToolsCount.
+  const specialToolsCount =
+    (isQuestMasterFeatureEnabled && isQuestMasterEnabled ? 1 : 0) +
+    (isAgentsFeatureEnabled && isAgentsEnabled ? 1 : 0) +
+    (isLatticeFeatureEnabled && isLatticeEnabled ? 1 : 0);
+  const pinnedCount = tools.length + enabledMcpServerCount + specialToolsCount;
 
   return (
     <>

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -770,7 +770,6 @@ const ToolsSection = ({
             gridTemplateColumns: `repeat(${columns}, 1fr)`,
             gap: columns,
             width: '100%',
-            overflow: { xs: 'auto', sm: 'initial' },
           }}
         >
           {/* Web Search */}
@@ -1403,7 +1402,6 @@ const ToolsSection = ({
               gridTemplateColumns: `repeat(${columns}, 1fr)`,
               gap: columns,
               width: '100%',
-              overflow: { xs: 'auto', sm: 'initial' },
             }}
           >
             {/* Chess Engine */}

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -559,6 +559,16 @@ const ToolsSection = ({
     (isLatticeFeatureEnabled && isLatticeEnabled ? 1 : 0);
   const pinnedCount = tools.length + enabledMcpServerCount + specialToolsCount;
 
+  // Second line appended to the Smart tools description in Smart mode, only when Agent-mode
+  // routing would ignore the Smart Tools below; null otherwise so it stays a single line.
+  // (Fast mode has its own dedicated two-line description - see the master switch below.)
+  const agentModeNote =
+    toolMode === 'smart' && agentWillRunFixedToolset
+      ? agentModeActive
+        ? 'Agent mode is on. It runs a fixed toolset; greyed-out Smart Tools below are ignored while Agent mode is active.'
+        : 'This request may auto-route to Agent mode, which runs a fixed toolset. Greyed-out Smart Tools below would then be ignored.'
+      : null;
+
   return (
     <>
       {/* Sticky header (dropdown only): title + help on the left, close on the right.
@@ -577,7 +587,7 @@ const ToolsSection = ({
             p: '8px 12px',
             mx: '-8px',
             mt: '-8px',
-            mb: 1,
+            mb: '12px',
             borderBottom: '1px solid',
             borderColor: 'border.soft',
             position: 'sticky',
@@ -608,51 +618,82 @@ const ToolsSection = ({
         </Box>
       )}
 
-      {/* Top descriptor. When there's no header (modal embed), keep the inline help button. */}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
-        <Typography
-          level="body-xs"
-          sx={{ color: 'text.primary50', flex: 1, lineHeight: 1.3 }}
-          data-testid="smart-tools-descriptor"
-        >
-          Enable tools the AI can use during this conversation.
-        </Typography>
-        {!onClose && (
+      {/* Modal embed (no header) keeps a descriptor + inline help; the dropdown drops
+          it in favor of the header's help button. */}
+      {!onClose && (
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
+          <Typography
+            level="body-xs"
+            sx={{ color: 'text.primary50', flex: 1, lineHeight: 1.3 }}
+            data-testid="smart-tools-descriptor"
+          >
+            Enable tools the AI can use during this conversation.
+          </Typography>
           <ContextHelpButton
             helpId="features/smart-tools"
             tooltipText="Learn about Smart Tools"
             data-testid="help-button-smart-tools"
           />
-        )}
-      </Box>
+        </Box>
+      )}
 
-      {/* Fast / Smart mode tabs */}
-      <Box sx={{ mb: 0.5 }}>
-        <SwitchSelector
-          options={[
-            { value: 'smart', label: 'Smart', tooltip: 'AI picks the right tools as needed' },
-            { value: 'fast', label: 'Fast', tooltip: 'No tools — fastest possible response' },
-          ]}
-          value={toolMode}
-          onChange={value => setLLM({ toolMode: value as 'fast' | 'smart' })}
-          width="100%"
+      {/* Smart tools master switch. On = Smart (enabled tools + prompt-based auto-recommend),
+          Off = Fast (no tools). No surface2 frame so it reads as a master control, not a tool.
+          The description gains a second line only when there's non-obvious context to add
+          (Fast mode, or Agent-mode routing that would ignore the Smart Tools below). */}
+      <Box
+        sx={{
+          display: 'flex',
+          // Center the toggle against the multi-line text on desktop; keep it top-aligned on mobile.
+          alignItems: { xs: 'flex-start', sm: 'center' },
+          justifyContent: 'space-between',
+          gap: '24px',
+          mb: '12px',
+          px: '4px',
+        }}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 }}>
+          <Typography level="body-sm" sx={{ color: 'text.primary', lineHeight: 1.2, mb: 0.5 }}>
+            Smart tools
+          </Typography>
+          {toolMode === 'fast' ? (
+            <>
+              <Typography
+                level="body-xs"
+                data-testid="tool-mode-caption-fast"
+                sx={{ color: 'primary.500', fontSize: '0.7rem', lineHeight: 1.3 }}
+              >
+                No tools are currently used. AI replies are as quick as possible.
+              </Typography>
+              <Typography
+                level="body-xs"
+                sx={{ color: 'text.primary50', fontSize: '0.7rem', lineHeight: 1.3, mt: 0.25 }}
+              >
+                Turn on Smart tools to let the AI use your enabled tools.
+              </Typography>
+            </>
+          ) : (
+            <Typography
+              level="body-xs"
+              sx={{ color: 'text.primary50', fontSize: '0.7rem', lineHeight: 1.3 }}
+              data-testid={agentModeNote ? 'tool-mode-caption-smart' : undefined}
+            >
+              AI uses enabled tools as needed. Turn off for the fastest reply.
+              {agentModeNote && (
+                <>
+                  <br />
+                  {agentModeNote}
+                </>
+              )}
+            </Typography>
+          )}
+        </Box>
+        <SquareSlideToggle
+          onChange={() => setLLM({ toolMode: toolMode === 'smart' ? 'fast' : 'smart' })}
+          checked={toolMode === 'smart'}
+          data-testid="tool-mode-toggle"
         />
       </Box>
-
-      {/* Mode caption: explains what each mode does and resolves the Smart-mode toggle ambiguity */}
-      <Typography
-        level="body-xs"
-        sx={{ color: 'text.secondary', mb: 1, lineHeight: 1.35 }}
-        data-testid={`tool-mode-caption-${toolMode}`}
-      >
-        {toolMode === 'smart'
-          ? agentWillRunFixedToolset
-            ? agentModeActive
-              ? 'Agent mode is on. It runs a fixed toolset; greyed-out Smart Tools below are ignored while Agent mode is active.'
-              : 'This request may auto-route to Agent mode, which runs a fixed toolset. Greyed-out Smart Tools below would then be ignored.'
-            : 'AI uses any enabled tools as needed. Toggle one off to disallow it.'
-          : 'No tools are used. AI replies as quickly as possible.'}
-      </Typography>
 
       {/* Collapsible individual tools header (default expanded; collapse state persisted per-user) */}
       <Box

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -168,6 +168,7 @@ const ToolLabel = ({ name, description, dim = false, agentOnlyNote }: ToolLabelP
       sx={{
         color: theme => (dim ? theme.palette.text.secondary : theme.palette.text.primary),
         lineHeight: 1.2,
+        mb: 0.5, // match the agent name -> tags gap
       }}
     >
       {name}
@@ -175,7 +176,7 @@ const ToolLabel = ({ name, description, dim = false, agentOnlyNote }: ToolLabelP
     <Typography
       level="body-xs"
       sx={{
-        color: 'text.tertiary',
+        color: 'text.primary50', // match the agent tags color
         fontSize: '0.7rem',
         lineHeight: 1.3,
         display: '-webkit-box',
@@ -190,7 +191,7 @@ const ToolLabel = ({ name, description, dim = false, agentOnlyNote }: ToolLabelP
       <Typography
         level="body-xs"
         data-testid="tool-agent-only-note"
-        sx={{ color: 'primary.500', fontSize: '0.7rem', lineHeight: 1.3, mt: 0.25 }}
+        sx={{ color: 'primary.500', fontSize: '0.7rem', lineHeight: 1.3, mt: '12px' }}
       >
         {agentOnlyNote}
       </Typography>
@@ -611,7 +612,7 @@ const ToolsSection = ({
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 1 }}>
         <Typography
           level="body-xs"
-          sx={{ color: 'text.secondary', flex: 1, lineHeight: 1.3 }}
+          sx={{ color: 'text.primary50', flex: 1, lineHeight: 1.3 }}
           data-testid="smart-tools-descriptor"
         >
           Enable tools the AI can use during this conversation.

--- a/apps/client/app/components/Session/AISettings/headerIconButtonSx.ts
+++ b/apps/client/app/components/Session/AISettings/headerIconButtonSx.ts
@@ -1,0 +1,11 @@
+// Shared style for the AI-settings dropdown header buttons (help + close) in both the
+// Tools and Agents dropdowns: 28x28 frame, tertiary icon that brightens to primary on
+// hover with no background change. `--Icon-color: currentColor` makes the Joy icon
+// follow the button's `color` (otherwise the variant color wins).
+export const HEADER_ICON_BUTTON_SX = {
+  '--IconButton-size': '28px',
+  '--Icon-color': 'currentColor',
+  color: 'text.tertiary',
+  transition: 'color 0.3s',
+  '&:hover': { backgroundColor: 'transparent', color: 'text.primary' },
+} as const;

--- a/apps/client/app/components/Session/AdvancedAISettings.tsx
+++ b/apps/client/app/components/Session/AdvancedAISettings.tsx
@@ -17,6 +17,7 @@ import { isImageModel } from '@client/app/utils/commands';
 import { keyframes } from '@mui/system';
 import { useFeatureEnabled } from '@client/app/hooks/useFeatureEnabled';
 import ToolsButton from './AISettings/ToolsButton';
+import { ICONED_MCP_SERVERS } from '../common/ToolIndicators';
 import AgentsButton from './AISettings/AgentsButton';
 import BriefcaseButton from './AISettings/BriefcaseButton';
 import ResearchModeIndicator from './AISettings/ResearchModeIndicator';
@@ -56,6 +57,8 @@ const AISettings: FC<AISettingsProps> = ({
 
   const { isFeatureEnabled, isAdminFeatureEnabled } = useFeatureEnabled();
   const isAgentsFeatureEnabled = isFeatureEnabled('enableAgents');
+  const isQuestMasterFeatureEnabled = isFeatureEnabled('enableQuestMaster');
+  const isLatticeFeatureEnabled = isFeatureEnabled('enableLattice');
   const isBriefcaseEnabled = isFeatureEnabled('enableBriefcase');
   const isImageTemplatesEnabled = isAdminFeatureEnabled('EnableImageTemplates');
 
@@ -71,6 +74,9 @@ const AISettings: FC<AISettingsProps> = ({
   const { data: sessionAgents = [] } = useGetSessionAgents(currentSessionId);
   const activeAgentsCount = currentSessionId ? sessionAgents.length : workBenchAgents.length;
 
+  const isLatticeEnabled = useLLM(state => state.isLatticeEnabled);
+  const isAgentsEnabled = useLLM(state => state.isAgentsEnabled);
+
   const [model, isQuestMasterEnabled, thinking, quality, n] = useLLM(
     useShallow(s => [s.model, s.isQuestMasterEnabled, s.thinking, s.quality, s.n])
   );
@@ -85,10 +91,24 @@ const AISettings: FC<AISettingsProps> = ({
   const primaryTools = ['web_search', 'web_fetch', 'image_generation'] as const;
   const activePrimaryTools = primaryTools.filter(tool => tools.includes(tool as unknown as (typeof tools)[number]));
   const isThinkingActive = thinking?.enabled ?? false;
+  // Enabled integrations without their own icon (e.g. linkedin, notion) roll into the
+  // "+N" badge; iconed ones (ICONED_MCP_SERVERS) are shown as icons and excluded here
+  // so they aren't double-counted. Mirrors ToolIndicators' shouldShowMcpServer logic.
+  const enabledNonIconMcpCount = availableMcpServers.filter(
+    name => !ICONED_MCP_SERVERS.includes(name) && (enabledMcpServers === null || enabledMcpServers.includes(name))
+  ).length;
+  // Feature-gated switches outside the `tools` array (Quest Master, Agent Detection,
+  // Lattice). Must stay in sync with pinnedCount's specialToolsCount in ToolsSection.
+  const specialToolsCount =
+    (isQuestMasterFeatureEnabled && isQuestMasterEnabled ? 1 : 0) +
+    (isAgentsFeatureEnabled && isAgentsEnabled ? 1 : 0) +
+    (isLatticeFeatureEnabled && isLatticeEnabled ? 1 : 0);
   const otherActiveToolsCount =
     tools.filter(
       tool => !primaryTools.includes(tool as unknown as (typeof primaryTools)[number]) && tool !== 'dice_roll'
-    ).length + (isQuestMasterEnabled ? 1 : 0);
+    ).length +
+    specialToolsCount +
+    enabledNonIconMcpCount;
 
   const isMobile = useIsMobile();
   const isTablet = useIsTablet();

--- a/apps/client/app/components/common/ToolIndicators.tsx
+++ b/apps/client/app/components/common/ToolIndicators.tsx
@@ -10,6 +10,11 @@ import SupportsToolsIcon from '../svgs/SupportsToolsIcon';
 import CountBadge from './CountBadge';
 import { green } from '../../utils/themes/colors';
 
+// MCP servers that render as their own icon here. Enabled servers NOT in this set
+// (e.g. linkedin, notion) have no icon, so they fall into the "+N" count badge
+// instead. Callers computing that count must exclude these to avoid double-counting.
+export const ICONED_MCP_SERVERS = ['github', 'atlassian'];
+
 interface ToolIndicatorsProps {
   activePrimaryTools: string[];
   isThinkingActive: boolean;
@@ -42,7 +47,7 @@ const ToolIndicators = ({
   isThinkingActive,
   otherActiveToolsCount,
   enabledMcpServers = null,
-  availableMcpServers = ['github', 'atlassian'], // Default to all known servers
+  availableMcpServers = ICONED_MCP_SERVERS, // Default to the servers that have icons
   activeColor = green[800],
   iconSize = '16px',
   gap = '8px',
@@ -153,7 +158,7 @@ const ToolIndicators = ({
     indicators.push(
       <CountBadge
         key="count"
-        prefix=""
+        prefix="+"
         count={otherActiveToolsCount}
         color={activeColor}
         margin={iconMargins.counter || '0px 0px 0 0px'}

--- a/apps/client/app/components/help/ContextHelpButton.tsx
+++ b/apps/client/app/components/help/ContextHelpButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { IconButton, Tooltip } from '@mui/joy';
+import type { SxProps } from '@mui/joy/styles/types';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { openHelpPanel } from '@client/app/hooks/useHelpPanel';
 
@@ -18,6 +19,8 @@ interface ContextHelpButtonProps {
   color?: 'primary' | 'neutral' | 'danger' | 'success' | 'warning';
   /** Additional className */
   className?: string;
+  /** Extra styles merged into the IconButton (e.g. custom color/hover) */
+  sx?: SxProps;
   /** Data test ID for testing */
   'data-testid'?: string;
 }
@@ -42,6 +45,7 @@ const ContextHelpButton: React.FC<ContextHelpButtonProps> = ({
   variant = 'plain',
   color = 'neutral',
   className,
+  sx,
   'data-testid': dataTestId,
 }) => {
   const handleClick = () => {
@@ -59,6 +63,7 @@ const ContextHelpButton: React.FC<ContextHelpButtonProps> = ({
         data-testid={dataTestId || `help-button-${helpId.replace(/\//g, '-')}`}
         sx={{
           '--IconButton-size': size === 'sm' ? '28px' : size === 'md' ? '36px' : '44px',
+          ...sx,
         }}
       >
         <HelpOutlineIcon sx={{ fontSize: size === 'sm' ? 16 : size === 'md' ? 20 : 24 }} />


### PR DESCRIPTION
## Summary
Overhauls the chat Tools dropdown for clarity and consistency (desktop + mobile),
and fixes the long-standing confusion around the GitHub and Atlassian integration
toggles (#460).

## Highlight: GitHub / Atlassian toggles are no longer misleading (#460)
Previously, enabling the GitHub or Atlassian toggle did nothing in a normal chat,
and they weren't counted like other tools, so there was no way to tell if they were
active. These integrations are agent-only by design: their tools are reachable only
through agent delegation, not direct chat. Now:
- Each toggle shows a clear "Agent mode only - mention an @agent to use it in chat"
  note, so it explains exactly how to actually use the integration.
- They count toward the tool tally like every other tool, so the UI is consistent.

## Other changes
- Replaced the Smart/Fast tabs with a single "Smart tools" master toggle
  (off = fastest reply, no tools). In Fast mode the button no longer shows
  active-tool indicators, since nothing is active.
- New dropdown header (title + help + close), shared and consistent between the
  Tools and Agents dropdowns.
- "Individual tools" and "Fun & Novelty" are now independently collapsible, each
  with its own pinned count.
- Counting fixes: enabled integrations plus Quest Master / Agent Detection / Lattice
  now count; Fun & Novelty counted separately from Individual tools.
- Mobile: the whole panel scrolls with only the header sticky, the Thinking token
  input drops to its own line (no more cropped description), and a bottom scroll
  fade makes it obvious there's more to scroll.
- Assorted spacing, color, and typography polish.

--- 

<img width="2086" height="1380" alt="image" src="https://github.com/user-attachments/assets/b8515a6e-ceda-48be-82bb-8e39ef30daa8" />

---

<img width="2176" height="1368" alt="image" src="https://github.com/user-attachments/assets/7afbc816-d12b-47bc-9c69-d3d3498ddc78" />

--- 

<img width="820" height="786" alt="Group 28" src="https://github.com/user-attachments/assets/61c738d8-cd71-4e1c-ad69-e2c194352e0e" />

---

<img width="430" height="361" alt="Group 29" src="https://github.com/user-attachments/assets/29315a45-c3ef-4b1e-9afa-0b5e6e47ee02" />



