### PR TITLE
fix(e2e): bound file-browser retry-loop clicks to fix notebook-files hang

### DIFF
--- a/apps/client/e2e/pages/FileUploadPage.ts
+++ b/apps/client/e2e/pages/FileUploadPage.ts
@@ -99,10 +99,12 @@ export class FileUploadPage extends BasePage {
     await expect(row).toBeVisible({ timeout: TIMEOUTS.ELEMENT_STATE });
 
     const actionBtn = this.page.getByTestId(actionBtnTestId);
-    // Retry click - row selection can fail if React re-renders between click and state update
+    // Retry click - row selection can fail if React re-renders between click and state update.
+    // Bound the click (see renameFile): with no suite-level actionTimeout an unbounded click
+    // would hang on the stability check instead of throwing, starving this retry loop.
     for (let attempt = 1; attempt <= 3; attempt++) {
-      await row.click();
       try {
+        await row.click({ timeout: TIMEOUTS.ELEMENT_STATE });
         await expect(actionBtn).toBeEnabled({ timeout: 2_000 });
         return;
       } catch {
@@ -128,9 +130,13 @@ export class FileUploadPage extends BasePage {
 
     // Menu items can be detached by React re-renders, or the click may not register.
     // Retry the full open-menu -> click-rename -> wait-for-input sequence.
+    // Every click MUST carry an explicit timeout: the suite sets no `actionTimeout`, so an
+    // unbounded click() waits forever for actionability. If a background list refetch re-renders
+    // the row mid-click, the stability check never resolves and the click hangs until the whole
+    // test times out - defeating this retry loop. A bounded click throws so the retry can fire.
     for (let attempt = 1; attempt <= 3; attempt++) {
       try {
-        await menuButton.click();
+        await menuButton.click({ timeout: TIMEOUTS.ELEMENT_STATE });
         await renameItem.click({ timeout: TIMEOUTS.ELEMENT_STATE });
         await expect(renameInput).toBeVisible({ timeout: TIMEOUTS.POST_ACTION });
         break;
@@ -141,9 +147,9 @@ export class FileUploadPage extends BasePage {
     }
 
     const renameTextbox = renameInput.getByRole('textbox');
-    await renameTextbox.clear();
-    await renameTextbox.fill(newName);
-    await this.page.getByTestId('file-browser-rename-save-btn').click();
+    await renameTextbox.clear({ timeout: TIMEOUTS.ELEMENT_STATE });
+    await renameTextbox.fill(newName, { timeout: TIMEOUTS.ELEMENT_STATE });
+    await this.page.getByTestId('file-browser-rename-save-btn').click({ timeout: TIMEOUTS.ELEMENT_STATE });
     // Wait for rename API or the inline input to disappear (rename complete)
     await this.waitForResponseOrUI(
       response =>


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="634" height="292" alt="Screenshot 2026-07-22 at 5 57 10 PM" src="https://github.com/user-attachments/assets/c9354775-6e9d-489c-89e1-d24d895d830b" />

## Description

`notebook-files.spec.ts` intermittently failed on the **"rename a file"** step. The step
hung for ~2.7 minutes, and the whole test then died at its `test.slow()` timeout
(60s x 3 = 180s). The failure screenshot showed a stable file browser with the actions menu
never opened — execution was blocked *before* the menu appeared, not during a later
assertion.

**Root cause:** the `renameFile` retry loop was written to survive transient React
re-renders of the file row, but its first action — `menuButton.click()` — carried no
explicit timeout. The suite sets no `use.actionTimeout` in `playwright.config.ts`, so
Playwright's default of `0` (wait forever) applied. When the file-browser list
background-refetches and re-renders the row mid-click, the click's actionability/stability
check never resolves — and it never *throws*, so the surrounding 3-attempt `try/catch`
retry loop never fired. One unbounded click swallowed the entire retry budget and hung until
the test-level timeout.

The same latent pattern existed in `selectFileRow` (used by the add-to-notebook and delete
steps in the same spec), whose `row.click()` was also unbounded.

## Changes

- `renameFile`: added `{ timeout: TIMEOUTS.ELEMENT_STATE }` to `menuButton.click()`,
  `renameTextbox.clear()`, `renameTextbox.fill()`, and the save-button click so a stuck
  action throws promptly and the retry loop can fire.
- `selectFileRow`: bounded `row.click()` with the same timeout and moved it *inside* the
  `try` block, so a click timeout also triggers a retry instead of throwing out of the loop
  on the first attempt.
- Added inline comments explaining why every click in these retry loops must carry an
  explicit timeout (no suite-level `actionTimeout`).
- Test-only change — no production/app code touched.

## Guide for Testers

This is an e2e-harness fix; verify it by running the **Notebook Files** spec on CI via the
manual E2E workflow — no local setup or manual app clicking required.

1. Go to the repo on GitHub -> **Actions** tab -> select the **E2E Tests (Manual)** workflow
   in the left sidebar.
2. Click **Run workflow** (top-right).
3. In the **Use workflow from** branch dropdown, select `fix/e2e-update-notebook-files-upload`.
4. Set **Target environment** to `dev`.
5. Set **Specific test to run** to `Notebook Files`.
6. Leave **PR number** and **Tester ID** blank, and leave **gate_run** as `false`.
7. Click the green **Run workflow** button.
   Expected: a new "E2E Tests" run appears and starts within a few seconds.
8. Open the run and wait for the **E2E Tests** job to finish.
   Expected: the job is green. The **notebook-files** project passes its full
   **upload -> browse -> rename -> delete** flow.
9. Open the run's uploaded **playwright-report** artifact and inspect the
   **"rename a file"** step.
   Expected: the step is green and completes in seconds — no ~2.7m entry and no
   `test.slow()` timeout on that step.
10. (Optional, to confirm the intermittent hang is gone) Re-run the workflow 2-3 times with
    the same inputs.
    Expected: every run passes; no run stalls on the rename step.

### Regression Checks

- The four sub-steps still pass in order: **upload a file to notebook**, **add file to
  notebook via file browser**, **rename a file**, **delete a file**.
- Rename still produces the "File renamed successfully" toast and the file list updates to
  the new name (`RenamedFile`).
- Delete still produces the "deleted" toast and removes the file.

### What NOT to test

- No application/UI behavior changed — no need to manually exercise the file browser in the
  running app.
- Other e2e projects are unaffected by this change; a full-suite run is optional, not
  required, to validate this PR.

## Additional Information

- No new dependencies, no config changes.
- Pre-existing `E2E_CLEANUP_SECRET` typecheck errors (SST `Resource` typing) are unrelated
  to this change and do not touch this file.
- Happy-path behavior is unchanged; the only difference is that a stuck click now fails fast
  and retries instead of hanging to the test timeout.

## Developer Notes

- Reusable guardrail: because this suite sets no `use.actionTimeout` (Playwright default
  `0` = wait forever), **every `click()`/`fill()` inside a retry loop must pass an explicit
  `{ timeout }`** — otherwise an un-actionable element hangs instead of throwing and starves
  the retry. Worth applying to any similar retry loops in other page objects.

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
