### PR TITLE
chore(premium): set b4m-optihashi overlay pin to b1412baeaecbb5ade49ad75e19588f61beecad4f

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -2,7 +2,7 @@
   "b4m-bob": "72235ca1b3fa53421917a1e7c1f244af18d2ed2b",
   "b4m-overwatch": "4afc25e5ab5844b3bfb61cc7994310fe9c966487",
   "b4m-libreoncology": "0a81b7055fa5dba745b6f55381b528e737f8f4cf",
-  "b4m-optihashi": "06504a7e687c8eca3f37b3628de6138297d35952",
+  "b4m-optihashi": "b1412baeaecbb5ade49ad75e19588f61beecad4f",
   "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",
   "b4m-tavern": "2ed2ff905cb22201f90b4723147ea975bfcf955b"
 }


### PR DESCRIPTION
Sets the b4m-optihashi overlay pin to b1412baeaecbb5ade49ad75e19588f61beecad4f. Overlay-pin-only change; no application source changes.