### PR TITLE
fix(admin): surface revoked API keys in the management lists

### DIFF
--- a/apps/client/app/components/admin/EmbedKeysTab.test.tsx
+++ b/apps/client/app/components/admin/EmbedKeysTab.test.tsx
@@ -95,4 +95,16 @@ describe('EmbedKeysTab', () => {
     expect('branding' in arg).toBe(false);
     expect('agentId' in arg).toBe(false);
   });
+
+  // The list route now returns disabled keys (#776); before that this row could
+  // never render and the Revoked branch was dead code.
+  it('renders a revoked key as Revoked with its actions disabled', () => {
+    h.keys = [{ ...embedKey, id: 'key-3', status: 'disabled' }];
+    renderTab();
+
+    const row = screen.getByTestId('embed-key-row-key-3');
+    expect(row).toHaveTextContent('Revoked');
+    expect(screen.getByTestId('embed-key-configure-key-3')).toBeDisabled();
+    expect(screen.getByTestId('embed-key-revoke-key-3')).toBeDisabled();
+  });
 });

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -50,7 +50,7 @@ Authorization: ApiKey b4m_live_xxxxx
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | /api/user-api-keys | List your API keys |
+| GET | /api/user-api-keys | List your active API keys (add \`?includeDisabled=true\` to also return revoked ones) |
 | POST | /api/api-keys/create | Create a new API key |
 | POST | /api/user-api-keys/[id]/rotate | Rotate an existing key |
 | POST | /api/user-api-keys/[id]/revoke | Revoke a key |

--- a/apps/client/app/hooks/data/userApiKeys.ts
+++ b/apps/client/app/hooks/data/userApiKeys.ts
@@ -80,11 +80,16 @@ export interface RotateUserApiKeyResponse {
   key: string; // Only returned once during rotation
 }
 
+/**
+ * Includes revoked (`disabled`) keys - the management tables render them as a
+ * `Revoked` row with the actions disabled, so revocation stays visible instead
+ * of the key silently dropping out of the list.
+ */
 export function useGetUserApiKeys() {
   return useQuery<IUserApiKeyDocument[]>({
     queryKey: ['user-api-keys'],
     queryFn: async () => {
-      const response = await api.get('/api/user-api-keys');
+      const response = await api.get('/api/user-api-keys', { params: { includeDisabled: true } });
       return response.data;
     },
   });

--- a/apps/client/pages/api/user-api-keys/__tests__/index.test.ts
+++ b/apps/client/pages/api/user-api-keys/__tests__/index.test.ts
@@ -13,11 +13,17 @@ vi.hoisted(() => {
   process.env.SERVER_DOMAIN = 'bike4mind.com';
 });
 
-const mockRefs = vi.hoisted(() => ({ postHandler: null as null | ((req: any, res: any) => unknown) }));
+const mockRefs = vi.hoisted(() => ({
+  postHandler: null as null | ((req: any, res: any) => unknown),
+  getHandler: null as null | ((req: any, res: any) => unknown),
+}));
 
 vi.mock('@server/middlewares/baseApi', () => {
   const chain: any = {
-    get: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
     post: (fn: any) => {
       mockRefs.postHandler = fn;
       return chain;
@@ -36,13 +42,14 @@ const createUserApiKey = vi.hoisted(() =>
     ...(params ?? {}),
   }))
 );
+const listUserApiKeys = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+const listOrganizationApiKeys = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+const findIdsAdministeredBy = vi.hoisted(() => vi.fn().mockResolvedValue([]));
 vi.mock('@bike4mind/services', () => ({
-  userApiKeyService: { createUserApiKey, listUserApiKeys: vi.fn(), listOrganizationApiKeys: vi.fn() },
+  userApiKeyService: { createUserApiKey, listUserApiKeys, listOrganizationApiKeys },
 }));
 vi.mock('@bike4mind/database/auth', () => ({ userApiKeyRepository: {} }));
-vi.mock('@bike4mind/database', () => ({
-  organizationRepository: { findIdsAdministeredBy: vi.fn().mockResolvedValue([]) },
-}));
+vi.mock('@bike4mind/database', () => ({ organizationRepository: { findIdsAdministeredBy } }));
 vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
 
 import '@pages/api/user-api-keys/index';
@@ -140,5 +147,41 @@ describe('POST /api/user-api-keys - embed-key minting', () => {
     });
     await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/must be an array/i);
     expect(createUserApiKey).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * List route: revoked keys must stay visible in the management UIs (#776). The
+ * `includeDisabled` flag has to reach BOTH list calls - personal and org-billed -
+ * or an org admin's revoked keys still vanish from the table.
+ */
+describe('GET /api/user-api-keys - revoked-key visibility', () => {
+  beforeEach(() => {
+    listUserApiKeys.mockClear();
+    listOrganizationApiKeys.mockClear();
+    findIdsAdministeredBy.mockResolvedValue(['org-1']);
+  });
+
+  function get(query: Record<string, string> = {}) {
+    const { req, res } = createMocks({ method: 'GET', query });
+    (req as any).user = { id: 'u1' };
+    (res as any).json = vi.fn();
+    return { req, res };
+  }
+
+  it('(a) threads includeDisabled=true to both the personal and org list calls', async () => {
+    const { req, res } = get({ includeDisabled: 'true' });
+    await mockRefs.getHandler!(req, res);
+
+    expect(listUserApiKeys).toHaveBeenCalledWith('u1', expect.anything(), { includeDisabled: true });
+    expect(listOrganizationApiKeys).toHaveBeenCalledWith('org-1', expect.anything(), { includeDisabled: true });
+  });
+
+  it('(b) defaults to active-only so the documented public API is unchanged', async () => {
+    const { req, res } = get();
+    await mockRefs.getHandler!(req, res);
+
+    expect(listUserApiKeys).toHaveBeenCalledWith('u1', expect.anything(), { includeDisabled: false });
+    expect(listOrganizationApiKeys).toHaveBeenCalledWith('org-1', expect.anything(), { includeDisabled: false });
   });
 });

--- a/apps/client/pages/api/user-api-keys/index.ts
+++ b/apps/client/pages/api/user-api-keys/index.ts
@@ -46,16 +46,20 @@ const handler = baseApi()
   .get(async (req, res) => {
     const userId = req.user?.id;
 
+    // Opt-in so the documented public API keeps its active-only default; the
+    // management UIs pass it to render revoked keys as `Revoked` rows.
+    const listOptions = { includeDisabled: req.query.includeDisabled === 'true' };
+
     // Personal keys (minted by this user) plus every key billed to an org this
     // user administers - so any org admin sees the org's keys, not just the minter.
     const [personalKeys, administeredOrgIds] = await Promise.all([
-      userApiKeyService.listUserApiKeys(userId, { db: { userApiKeys: userApiKeyRepository } }),
+      userApiKeyService.listUserApiKeys(userId, { db: { userApiKeys: userApiKeyRepository } }, listOptions),
       organizationRepository.findIdsAdministeredBy(userId),
     ]);
 
     const orgKeyLists = await Promise.all(
       administeredOrgIds.map(orgId =>
-        userApiKeyService.listOrganizationApiKeys(orgId, { db: { userApiKeys: userApiKeyRepository } })
+        userApiKeyService.listOrganizationApiKeys(orgId, { db: { userApiKeys: userApiKeyRepository } }, listOptions)
       )
     );
 


### PR DESCRIPTION
## Description

**Closes:** #776

`EmbedKeysTab` and `UserApiKeysTab` both render a revoked key as a `Revoked` / `Disabled` status chip with the row's actions greyed out. Neither branch could ever execute.

`GET /api/user-api-keys` called `listUserApiKeys` and `listOrganizationApiKeys` with no options. Both service functions default to `includeDisabled: false` and filter down to `status === 'active'`, so a revoked key dropped out of the response entirely: the row vanished from the table instead of flipping to `Revoked`, the Status column always read `Active`, and there was no post-revoke visibility in the UI.

This threads an opt-in `includeDisabled` query param through the route into **both** list calls, and has the client hook request it. Revoked keys now stay in the table as a non-actionable `Revoked` row (issue #776, option 1 - the choice that preserves an audit trail), while the documented public API keeps its active-only default for existing consumers.

The org-billed path matters as much as the personal one here: an org administrator sees keys billed to orgs they administer, so passing the flag to only `listUserApiKeys` would have left their revoked keys just as invisible. Both call sites are covered by a test.

## Changes

- `apps/client/pages/api/user-api-keys/index.ts` - GET reads `?includeDisabled=true` and passes `{ includeDisabled }` to both `listUserApiKeys` and `listOrganizationApiKeys`. Opt-in, so the default response is unchanged for API consumers.
- `apps/client/app/hooks/data/userApiKeys.ts` - `useGetUserApiKeys` sends `includeDisabled: true`, which is what lights up the existing `Revoked` / `Disabled` branches in both management tables.
- `apps/client/app/components/admin/content/apiReferenceContent.ts` - documents the new query param in the in-app API reference.
- Tests: route-level coverage that the flag reaches both list calls and that the default stays active-only; component coverage that a `status: 'disabled'` embed key renders as `Revoked` with Configure/Revoke disabled.

No schema, service, or data changes - `listUserApiKeys` / `listOrganizationApiKeys` already accepted `ListUserApiKeysOptions`; the route simply never passed it.

## Guide for Testers

Preconditions: an account that can reach Admin, with at least one existing embed key (or create one in step 3). Test on this PR's preview env at `app.pr805.preview.bike4mind.com`.

### Admin embed keys

1. Go to `app.pr805.preview.bike4mind.com` and sign in.
2. Navigate: Sidebar -> Admin -> AI & Agents -> Embed Keys. The embed keys table loads.
3. If the table is empty, click **Create Embed Key**, give it the name `Revoke test`, pick any agent, add the origin `example.com`, and save. A new row named `Revoke test` appears with a green `Active` status chip.
4. On the `Revoke test` row, click the red revoke (trash) icon in the Actions column. A `Embed key revoked` toast appears.
5. **Expected (this is the fix):** the row stays in the table. Its Status chip flips from a green `Active` to a red `Revoked`. Before this PR the row disappeared and, with only one key present, the table fell back to the "No embed keys yet" empty state.

   <img width="1245" height="101" alt="image" src="https://github.com/user-attachments/assets/14e6687d-02bd-402e-b364-c42938bceee9" />

6. On that same revoked row, confirm the Configure (gear), Rotate, and Revoke buttons are all greyed out and do nothing when clicked.
7. Click the refresh icon at the top right of the tab. The revoked row is still listed as `Revoked` - it persists across reloads, not just in local state.
8. Reload the browser page and return to Admin -> Embed Keys. The revoked row is still present with the `Revoked` chip.

### Profile API keys (same endpoint, second surface)

9. Open the profile modal -> **API** tab -> **User API Keys** section.
10. Revoke any key listed there.
11. **Expected:** the row remains with a red `Disabled` status chip and its Rotate/Revoke buttons greyed out, instead of vanishing from the list.

   <img width="1116" height="365" alt="image" src="https://github.com/user-attachments/assets/0a0a886e-55ab-470d-9b8d-5342c01a38e2" />

### Public API default (backwards compatibility)

12. With an API key minted on this preview env, run: `curl -H "X-API-Key: b4m_live_xxxxx" "https://app.pr805.preview.bike4mind.com/api/user-api-keys"` (keep the URL quoted - `?` is a glob character in zsh and an unquoted URL fails with `no matches found` before curl ever runs).
13. **Expected:** only active keys are returned - the revoked key from step 4 is absent. This confirms the change is opt-in and does not alter the documented API response.
14. Repeat with `"https://app.pr805.preview.bike4mind.com/api/user-api-keys?includeDisabled=true"`.
15. **Expected:** the revoked key from step 4 now appears in the JSON with `"status": "disabled"`.

### Regression Checks

16. Creating a new embed key still works and the new key appears as `Active` (step 3).
17. Rotating an active key still returns a new secret and shows the one-time reveal modal.
18. Configure on an **active** embed key still opens the modal, and saving an origin change still persists (branding and agent binding untouched).
19. An org administrator who did not mint an org-billed key still sees that key in the list - the org path was changed too, so this must not regress.

### What NOT to test

- Revoke reason / revoked-at timestamps. The revoke service records neither today (see Additional Information); a revoked row shows the status only, with no "when" or "why".
- Key authentication behavior. Revoked keys were already rejected at auth time; this PR only changes what the list endpoint returns.

## Additional Information

Two adjacent gaps surfaced while fixing this. Both are pre-existing and deliberately out of scope; both are now filed:

1. **No revoke metadata** - #813. `revokeUserApiKey` sets `status = DISABLED` and nothing else: no `revokedAt`, no `revokedBy`. A revoked row can show _that_ it was revoked but not when or by whom (`updatedAt` is the only proxy, and it is bumped by any write). The `reason` is not lost - the route forwards it to `logEvent` - but it is never joined back to the key, so no UI can surface it.
2. **Org admins cannot mutate org-billed keys they did not mint** - #814. `revoke`, `rotate`, `updateEmbedKey`, and the spend-cap update all resolve the key via `findByUserIdAndId`, so a non-minting org administrator gets a 404 from every one of them. Fully pre-existing and unchanged by this PR - `listOrganizationApiKeys` was already being called, so those active org rows were already visible and already un-mutable; revoked rows have their action buttons disabled either way.

On the strict `req.query.includeDisabled === 'true'` check: that is the repo-wide convention for boolean query params (`admin/team-members.ts`, `artifacts/[id]/index.ts`, `organizations/[id]/webhooks/github.ts` all do the same). Unexpected inputs - `1`, `TRUE`, or a repeated param that arrives as an array - all fail closed to the active-only default, so this route stays consistent with the others rather than growing a bespoke parser.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
