### PR TITLE
feat(agent): durable opti plan ledger across continuation Lambdas (#680)

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -39,6 +39,7 @@ import {
   usageEventRepository,
   imageModerationIncidentRepository,
   mcpServerRepository,
+  type IOptiPlanState,
 } from '@bike4mind/database';
 import { registerLambdaErrorHandlers, getSettingsByNames, fetchAgentConversationHistory } from '@bike4mind/utils';
 import { toRetrievalFilter } from '@bike4mind/utils/retrievalExclusion';
@@ -84,7 +85,7 @@ import { resolveLatticeTools, buildSubagentLatticeToolPool } from './agentExecut
 import { selectGatedAction } from './agentExecutorUtils/toolPermissions';
 import { guardDecomposeOnce } from './agentExecutorUtils/decomposeGuard';
 import { buildTruncatedRunReply } from './agentExecutorUtils/truncatedReply';
-import { guardPlanCompletion, type PlanProgressState } from './agentExecutorUtils/planCompletionGuard';
+import { guardPlanCompletion } from './agentExecutorUtils/planCompletionGuard';
 import { injectBriefContext } from './agentExecutorUtils/briefContextInjector';
 import { buildDagResumeReport, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
 import { collectDagChildArtifactBlocks } from './agentExecutor.dagArtifacts';
@@ -1242,30 +1243,39 @@ async function processExecution(
     // `buildSubagentLatticeToolPool` and `ServerOrchestratorDeps.optInTools`.
     const subagentLatticeTools = buildSubagentLatticeToolPool(toolDeps, toolCallbacks, subagentToolConfig);
 
-    // Let optihashi_decompose run only ONCE per run (#666). The loop occasionally re-plans
-    // mid-run, which reloads step 1 (a console yank), burns an iteration, and re-sources;
-    // the guard turns any repeat into a no-op redirect that steers the agent back to
-    // advancing its existing plan. Only affects opti runs (decompose isn't offered elsewhere).
-    const decomposeGuard = { used: false };
-    // Two complementary opti-loop guards: #666 stops re-PLANNING (decompose at most once); the
-    // plan-completion guard stops re-SOLVING (once every planned step has a solver result, further
-    // formulate/solve calls redirect to "write the final summary"). Without the latter the agent
-    // -- which has no reliable memory of which steps it finished -- re-does solved families until
-    // it hits the iteration ceiling. Both are inert on non-opti runs (decompose isn't offered).
-    const planProgress: PlanProgressState = { steps: null, solved: {}, results: {} };
-    // Outermost: give the loop the real active brief in-context (#57) so it passes the exact
-    // problem to solve/edit instead of reconstructing it. Wraps the guarded tools last, so it
-    // augments real tool observations and leaves guard redirects (non-envelope strings) untouched.
+    // Durable opti plan ledger (#680): ONE state object, rehydrated from the persisted execution so
+    // the opti-loop guards survive a continuation Lambda (SQS resume / timeout self-dispatch) -- a
+    // repeat decompose or a re-solve of a finished step cannot slip through after the boundary.
+    // Seed ONLY from the persisted ledger, never from `!isNewExecution` (which would wrongly block a
+    // legitimate first decompose that lands on a continuation). Plain-object copy so the guards
+    // mutate a clean object rather than a Mongoose subdocument. Persisted alongside the checkpoint
+    // (below) so it has the same continuation durability. Inert on non-opti runs (stays empty).
+    const optiPlanState: IOptiPlanState = {
+      decomposeUsed: execution.optiPlanState?.decomposeUsed ?? false,
+      steps: (execution.optiPlanState?.steps ?? []).map(s => ({ family: s.family, title: s.title })),
+      solved: { ...(execution.optiPlanState?.solved ?? {}) },
+      results: { ...(execution.optiPlanState?.results ?? {}) },
+    };
+    // Three complementary opti-loop guards, all reading/writing the one ledger above:
+    // - #666 decompose-once: stops re-PLANNING (decompose at most once, now durable across a resume).
+    // - plan-completion: stops re-SOLVING (once every planned step has a result, formulate/solve
+    //   redirect to "write the final summary"); without it the agent -- which has no reliable memory
+    //   of which steps it finished -- re-does solved families until the iteration ceiling.
+    // - inject brief (outermost, #57): gives the loop the real active brief in-context so it passes
+    //   the exact problem to solve/edit instead of reconstructing it. Wraps last, so it augments real
+    //   tool observations and leaves guard redirects (non-envelope strings) untouched.
     const guardedPremiumTools = injectBriefContext(
       guardPlanCompletion(
-        guardDecomposeOnce(premiumLlmTools, decomposeGuard, () =>
+        guardDecomposeOnce(premiumLlmTools, optiPlanState, () =>
           logger.info('[opti] blocked a repeat optihashi_decompose call (advancing existing plan)', { executionId })
         ),
-        planProgress,
+        optiPlanState,
         () =>
           logger.info('[opti] plan complete -- all planned steps solved; steering to final summary', { executionId })
       )
     );
+    // True once the loop has a plan in flight; gates ledger persistence so non-opti runs write nothing.
+    const optiPlanActive = () => optiPlanState.decomposeUsed || optiPlanState.steps.length > 0;
 
     const tools = buildSharedTools({ ...toolDeps, optInTools: subagentLatticeTools }, toolCallbacks, {
       // Dedupe: a caller may already have enabled create_mission/mission_status;
@@ -1747,6 +1757,9 @@ async function processExecution(
       if (Date.now() - startTime > deadlineMs) {
         logger.info('[Timeout] Approaching Lambda timeout, triggering self-dispatch');
         const checkpoint = agent.toCheckpoint();
+        // Persist the opti plan ledger BEFORE flipping to `continuing` so the continuation Lambda
+        // rehydrates the latest plan state (decompose-once + solved steps), not a stale one (#680).
+        if (optiPlanActive()) await agentExecutionRepository.updateOptiPlanState(executionId, optiPlanState);
         // Atomic write: persisting checkpoint + status separately could leave the
         // doc in `running` with a fresh checkpoint if Lambda is killed between
         // calls, which would fail the continuation Lambda's CAS and orphan the
@@ -1878,6 +1891,17 @@ async function processExecution(
       //   3. The subagent-handoff path now bills the parent's deciding
       //      iteration, which previously slipped through unbilled.
       await agentExecutionRepository.updateCheckpoint(executionId, iterationResult.checkpoint);
+      // Keep the durable opti ledger fresh at the iteration boundary (#680). Fire-and-forget: the
+      // continuation-critical write is the awaited one at the self-dispatch handoff above; this just
+      // minimizes staleness within an invocation and must not add latency to every iteration.
+      if (optiPlanActive()) {
+        void agentExecutionRepository.updateOptiPlanState(executionId, optiPlanState).catch((err: unknown) => {
+          logger.warn('[opti] failed to persist plan ledger at iteration boundary', {
+            executionId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
       await billIterationIfNeeded(iterationIndex, iterationResult.checkpoint, counters);
 
       // Handoff signal: orchestrator-side polling on a sync Lambda-dispatched

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -86,7 +86,7 @@ import { guardDecomposeOnce } from './agentExecutorUtils/decomposeGuard';
 import { buildTruncatedRunReply } from './agentExecutorUtils/truncatedReply';
 import { guardPlanCompletion } from './agentExecutorUtils/planCompletionGuard';
 import { injectBriefContext } from './agentExecutorUtils/briefContextInjector';
-import { rehydrateOptiPlanState, optiPlanActive } from './agentExecutorUtils/optiPlanLedger';
+import { rehydrateOptiPlanState, ledgerForWrite } from './agentExecutorUtils/optiPlanLedger';
 import { buildDagResumeReport, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
 import { collectDagChildArtifactBlocks } from './agentExecutor.dagArtifacts';
 import type { DagHandoffSignal } from '@bike4mind/services';
@@ -1756,7 +1756,7 @@ async function processExecution(
           executionId,
           checkpoint,
           'continuing',
-          optiPlanActive(optiPlanState) ? optiPlanState : undefined
+          ledgerForWrite(optiPlanState)
         );
 
         // Publish to continuation queue
@@ -1889,7 +1889,7 @@ async function processExecution(
       await agentExecutionRepository.updateCheckpoint(
         executionId,
         iterationResult.checkpoint,
-        optiPlanActive(optiPlanState) ? optiPlanState : undefined
+        ledgerForWrite(optiPlanState)
       );
       await billIterationIfNeeded(iterationIndex, iterationResult.checkpoint, counters);
 

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -39,7 +39,6 @@ import {
   usageEventRepository,
   imageModerationIncidentRepository,
   mcpServerRepository,
-  type IOptiPlanState,
 } from '@bike4mind/database';
 import { registerLambdaErrorHandlers, getSettingsByNames, fetchAgentConversationHistory } from '@bike4mind/utils';
 import { toRetrievalFilter } from '@bike4mind/utils/retrievalExclusion';
@@ -87,6 +86,7 @@ import { guardDecomposeOnce } from './agentExecutorUtils/decomposeGuard';
 import { buildTruncatedRunReply } from './agentExecutorUtils/truncatedReply';
 import { guardPlanCompletion } from './agentExecutorUtils/planCompletionGuard';
 import { injectBriefContext } from './agentExecutorUtils/briefContextInjector';
+import { rehydrateOptiPlanState, optiPlanActive } from './agentExecutorUtils/optiPlanLedger';
 import { buildDagResumeReport, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
 import { collectDagChildArtifactBlocks } from './agentExecutor.dagArtifacts';
 import type { DagHandoffSignal } from '@bike4mind/services';
@@ -1244,18 +1244,10 @@ async function processExecution(
     const subagentLatticeTools = buildSubagentLatticeToolPool(toolDeps, toolCallbacks, subagentToolConfig);
 
     // Durable opti plan ledger (#680): ONE state object, rehydrated from the persisted execution so
-    // the opti-loop guards survive a continuation Lambda (SQS resume / timeout self-dispatch) -- a
-    // repeat decompose or a re-solve of a finished step cannot slip through after the boundary.
-    // Seed ONLY from the persisted ledger, never from `!isNewExecution` (which would wrongly block a
-    // legitimate first decompose that lands on a continuation). Plain-object copy so the guards
-    // mutate a clean object rather than a Mongoose subdocument. Persisted alongside the checkpoint
-    // (below) so it has the same continuation durability. Inert on non-opti runs (stays empty).
-    const optiPlanState: IOptiPlanState = {
-      decomposeUsed: execution.optiPlanState?.decomposeUsed ?? false,
-      steps: (execution.optiPlanState?.steps ?? []).map(s => ({ family: s.family, title: s.title })),
-      solved: { ...(execution.optiPlanState?.solved ?? {}) },
-      results: { ...(execution.optiPlanState?.results ?? {}) },
-    };
+    // the opti-loop guards survive a continuation Lambda -- a repeat decompose or a re-solve of a
+    // finished step cannot slip through after the boundary. Seeded only from the persisted ledger
+    // (see rehydrateOptiPlanState); ridden on the checkpoint writes below for continuation durability.
+    const optiPlanState = rehydrateOptiPlanState(execution.optiPlanState);
     // Three complementary opti-loop guards, all reading/writing the one ledger above:
     // - #666 decompose-once: stops re-PLANNING (decompose at most once, now durable across a resume).
     // - plan-completion: stops re-SOLVING (once every planned step has a result, formulate/solve
@@ -1274,8 +1266,6 @@ async function processExecution(
           logger.info('[opti] plan complete -- all planned steps solved; steering to final summary', { executionId })
       )
     );
-    // True once the loop has a plan in flight; gates ledger persistence so non-opti runs write nothing.
-    const optiPlanActive = () => optiPlanState.decomposeUsed || optiPlanState.steps.length > 0;
 
     const tools = buildSharedTools({ ...toolDeps, optInTools: subagentLatticeTools }, toolCallbacks, {
       // Dedupe: a caller may already have enabled create_mission/mission_status;
@@ -1757,14 +1747,17 @@ async function processExecution(
       if (Date.now() - startTime > deadlineMs) {
         logger.info('[Timeout] Approaching Lambda timeout, triggering self-dispatch');
         const checkpoint = agent.toCheckpoint();
-        // Persist the opti plan ledger BEFORE flipping to `continuing` so the continuation Lambda
-        // rehydrates the latest plan state (decompose-once + solved steps), not a stale one (#680).
-        if (optiPlanActive()) await agentExecutionRepository.updateOptiPlanState(executionId, optiPlanState);
         // Atomic write: persisting checkpoint + status separately could leave the
         // doc in `running` with a fresh checkpoint if Lambda is killed between
         // calls, which would fail the continuation Lambda's CAS and orphan the
-        // execution.
-        await agentExecutionRepository.updateCheckpointAndStatus(executionId, checkpoint, 'continuing');
+        // execution. The opti plan ledger (#680) rides the SAME write so the continuation Lambda
+        // rehydrates the latest plan state (decompose-once + solved steps), not a stale one.
+        await agentExecutionRepository.updateCheckpointAndStatus(
+          executionId,
+          checkpoint,
+          'continuing',
+          optiPlanActive() ? optiPlanState : undefined
+        );
 
         // Publish to continuation queue
         await sqsClient.send(
@@ -1890,18 +1883,14 @@ async function processExecution(
       //      reconcile with the terminal state.
       //   3. The subagent-handoff path now bills the parent's deciding
       //      iteration, which previously slipped through unbilled.
-      await agentExecutionRepository.updateCheckpoint(executionId, iterationResult.checkpoint);
-      // Keep the durable opti ledger fresh at the iteration boundary (#680). Fire-and-forget: the
-      // continuation-critical write is the awaited one at the self-dispatch handoff above; this just
-      // minimizes staleness within an invocation and must not add latency to every iteration.
-      if (optiPlanActive()) {
-        void agentExecutionRepository.updateOptiPlanState(executionId, optiPlanState).catch((err: unknown) => {
-          logger.warn('[opti] failed to persist plan ledger at iteration boundary', {
-            executionId,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
-      }
+      // The opti plan ledger (#680) rides this awaited checkpoint write in one atomic updateOne, so
+      // it is persisted with the checkpoint's durability at every iteration boundary -- covering all
+      // continuation paths (each resumes from a checkpoint) without a separate write to race or lose.
+      await agentExecutionRepository.updateCheckpoint(
+        executionId,
+        iterationResult.checkpoint,
+        optiPlanActive() ? optiPlanState : undefined
+      );
       await billIterationIfNeeded(iterationIndex, iterationResult.checkpoint, counters);
 
       // Handoff signal: orchestrator-side polling on a sync Lambda-dispatched

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -1756,7 +1756,7 @@ async function processExecution(
           executionId,
           checkpoint,
           'continuing',
-          optiPlanActive() ? optiPlanState : undefined
+          optiPlanActive(optiPlanState) ? optiPlanState : undefined
         );
 
         // Publish to continuation queue
@@ -1889,7 +1889,7 @@ async function processExecution(
       await agentExecutionRepository.updateCheckpoint(
         executionId,
         iterationResult.checkpoint,
-        optiPlanActive() ? optiPlanState : undefined
+        optiPlanActive(optiPlanState) ? optiPlanState : undefined
       );
       await billIterationIfNeeded(iterationIndex, iterationResult.checkpoint, counters);
 

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
@@ -23,17 +23,17 @@ const run = (t: ToolDefinition, params?: unknown) => t.implementation({} as neve
 describe('guardDecomposeOnce', () => {
   it('runs the real decompose on the FIRST call', async () => {
     const { tool, calls } = fakeDecompose();
-    const state = { used: false };
+    const state = { decomposeUsed: false };
     const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state);
     const out = await run(guarded.optihashi_decompose, { scenario: 'x' });
     expect(out).toBe('PLAN CREATED');
     expect(calls).toHaveLength(1);
-    expect(state.used).toBe(true);
+    expect(state.decomposeUsed).toBe(true);
   });
 
   it('blocks a SECOND call with the redirect message and does not re-run decompose', async () => {
     const { tool, calls } = fakeDecompose();
-    const state = { used: false };
+    const state = { decomposeUsed: false };
     const onBlocked = vi.fn();
     const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state, onBlocked);
     await run(guarded.optihashi_decompose); // first - runs
@@ -49,14 +49,14 @@ describe('guardDecomposeOnce', () => {
       implementation: () => ({ toolFn: async () => 'ok', toolSchema: {} }),
     } as unknown as ToolDefinition;
     const map = { web_search: other };
-    const guarded = guardDecomposeOnce(map, { used: false });
+    const guarded = guardDecomposeOnce(map, { decomposeUsed: false });
     expect(guarded).toBe(map);
   });
 
   it('does not mutate the input map', () => {
     const { tool } = fakeDecompose();
     const map = { optihashi_decompose: tool };
-    const guarded = guardDecomposeOnce(map, { used: false });
+    const guarded = guardDecomposeOnce(map, { decomposeUsed: false });
     expect(guarded).not.toBe(map);
     expect(map.optihashi_decompose).toBe(tool); // original entry untouched
   });

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
@@ -21,7 +21,7 @@ function fakeDecompose(): { tool: ToolDefinition; calls: unknown[] } {
 const run = (t: ToolDefinition, params?: unknown) => t.implementation({} as never, undefined).toolFn(params);
 // The ledger the guard shares with planCompletionGuard: `steps` is populated by the latter when a
 // decompose result parses into a plan. Start empty, like a fresh execution.
-const ledger = () => ({ decomposeUsed: false, steps: [] as unknown[] });
+const ledger = () => ({ decomposeUsed: false, steps: [] as { family: string; title: string }[] });
 
 describe('guardDecomposeOnce', () => {
   it('runs the real decompose on the FIRST call', async () => {
@@ -47,12 +47,12 @@ describe('guardDecomposeOnce', () => {
     expect(onBlocked).toHaveBeenCalledTimes(1);
   });
 
-  // #680 (F1): a first decompose that failed OR succeeded-but-unparseable latches decomposeUsed with
-  // no captured plan. Gating the block on `decomposeUsed` alone would durably poison the run; gating
-  // on a LOADED plan (steps>0) lets the agent re-decompose to recover.
+  // A first decompose that failed or succeeded-but-unparseable latches decomposeUsed with no captured
+  // plan. Gating the block on the durable flag alone would poison the run across continuations;
+  // gating on a loaded plan (steps>0) lets the agent re-decompose to recover.
   it('does NOT block a repeat when the flag latched but no plan loaded (steps empty)', async () => {
     const { tool, calls } = fakeDecompose();
-    const state = { decomposeUsed: true, steps: [] as unknown[] }; // poisoned-looking state
+    const state = { decomposeUsed: true, steps: [] as { family: string; title: string }[] }; // no plan loaded
     const onBlocked = vi.fn();
     const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state, onBlocked);
     const out = await run(guarded.optihashi_decompose);

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
@@ -60,4 +60,52 @@ describe('guardDecomposeOnce', () => {
     expect(guarded).not.toBe(map);
     expect(map.optihashi_decompose).toBe(tool); // original entry untouched
   });
+
+  // #680 regression: with the flag now DURABLE, a failed first decompose must not latch it -- else
+  // it would permanently block retries across continuations against a plan that never loaded.
+  it('does NOT latch the flag when decompose returns an Error string; a retry re-runs it', async () => {
+    const calls: unknown[] = [];
+    const tool = {
+      name: 'optihashi_decompose',
+      implementation: () => ({
+        toolFn: async (p?: unknown) => {
+          calls.push(p);
+          return calls.length === 1 ? 'Error: could not formulate step 1' : 'PLAN CREATED';
+        },
+        toolSchema: {},
+      }),
+    } as unknown as ToolDefinition;
+    const state = { decomposeUsed: false };
+    const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state);
+
+    const first = await run(guarded.optihashi_decompose);
+    expect(first).toMatch(/^Error:/);
+    expect(state.decomposeUsed).toBe(false); // failure did not latch
+
+    const second = await run(guarded.optihashi_decompose);
+    expect(second).toBe('PLAN CREATED'); // retry actually re-ran the real tool
+    expect(calls).toHaveLength(2);
+    expect(state.decomposeUsed).toBe(true); // success latches
+  });
+
+  it('does NOT latch the flag when decompose throws (error surfaces, retry still allowed)', async () => {
+    let attempts = 0;
+    const tool = {
+      name: 'optihashi_decompose',
+      implementation: () => ({
+        toolFn: async () => {
+          attempts++;
+          if (attempts === 1) throw new Error('boom');
+          return 'PLAN CREATED';
+        },
+        toolSchema: {},
+      }),
+    } as unknown as ToolDefinition;
+    const state = { decomposeUsed: false };
+    const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state);
+
+    await expect(run(guarded.optihashi_decompose)).rejects.toThrow('boom');
+    expect(state.decomposeUsed).toBe(false); // throw did not latch
+    expect(await run(guarded.optihashi_decompose)).toBe('PLAN CREATED'); // retry runs
+  });
 });

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.test.ts
@@ -19,11 +19,14 @@ function fakeDecompose(): { tool: ToolDefinition; calls: unknown[] } {
 }
 
 const run = (t: ToolDefinition, params?: unknown) => t.implementation({} as never, undefined).toolFn(params);
+// The ledger the guard shares with planCompletionGuard: `steps` is populated by the latter when a
+// decompose result parses into a plan. Start empty, like a fresh execution.
+const ledger = () => ({ decomposeUsed: false, steps: [] as unknown[] });
 
 describe('guardDecomposeOnce', () => {
   it('runs the real decompose on the FIRST call', async () => {
     const { tool, calls } = fakeDecompose();
-    const state = { decomposeUsed: false };
+    const state = ledger();
     const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state);
     const out = await run(guarded.optihashi_decompose, { scenario: 'x' });
     expect(out).toBe('PLAN CREATED');
@@ -31,16 +34,31 @@ describe('guardDecomposeOnce', () => {
     expect(state.decomposeUsed).toBe(true);
   });
 
-  it('blocks a SECOND call with the redirect message and does not re-run decompose', async () => {
+  it('blocks a repeat ONLY once a plan has loaded (steps captured)', async () => {
     const { tool, calls } = fakeDecompose();
-    const state = { decomposeUsed: false };
+    const state = ledger();
     const onBlocked = vi.fn();
     const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state, onBlocked);
-    await run(guarded.optihashi_decompose); // first - runs
-    const second = await run(guarded.optihashi_decompose); // repeat - blocked
+    await run(guarded.optihashi_decompose); // first - runs, latches decomposeUsed
+    state.steps = [{ family: 'scheduling', title: 's' }]; // planCompletionGuard captured a plan
+    const second = await run(guarded.optihashi_decompose); // repeat - now blocked
     expect(second).toBe(DECOMPOSE_ALREADY_DONE_MSG);
     expect(calls).toHaveLength(1); // real decompose ran only once
     expect(onBlocked).toHaveBeenCalledTimes(1);
+  });
+
+  // #680 (F1): a first decompose that failed OR succeeded-but-unparseable latches decomposeUsed with
+  // no captured plan. Gating the block on `decomposeUsed` alone would durably poison the run; gating
+  // on a LOADED plan (steps>0) lets the agent re-decompose to recover.
+  it('does NOT block a repeat when the flag latched but no plan loaded (steps empty)', async () => {
+    const { tool, calls } = fakeDecompose();
+    const state = { decomposeUsed: true, steps: [] as unknown[] }; // poisoned-looking state
+    const onBlocked = vi.fn();
+    const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state, onBlocked);
+    const out = await run(guarded.optihashi_decompose);
+    expect(out).toBe('PLAN CREATED'); // re-ran, not blocked
+    expect(calls).toHaveLength(1);
+    expect(onBlocked).not.toHaveBeenCalled();
   });
 
   it('returns the map unchanged when there is no optihashi_decompose (non-opti run)', () => {
@@ -49,63 +67,15 @@ describe('guardDecomposeOnce', () => {
       implementation: () => ({ toolFn: async () => 'ok', toolSchema: {} }),
     } as unknown as ToolDefinition;
     const map = { web_search: other };
-    const guarded = guardDecomposeOnce(map, { decomposeUsed: false });
+    const guarded = guardDecomposeOnce(map, ledger());
     expect(guarded).toBe(map);
   });
 
   it('does not mutate the input map', () => {
     const { tool } = fakeDecompose();
     const map = { optihashi_decompose: tool };
-    const guarded = guardDecomposeOnce(map, { decomposeUsed: false });
+    const guarded = guardDecomposeOnce(map, ledger());
     expect(guarded).not.toBe(map);
     expect(map.optihashi_decompose).toBe(tool); // original entry untouched
-  });
-
-  // #680 regression: with the flag now DURABLE, a failed first decompose must not latch it -- else
-  // it would permanently block retries across continuations against a plan that never loaded.
-  it('does NOT latch the flag when decompose returns an Error string; a retry re-runs it', async () => {
-    const calls: unknown[] = [];
-    const tool = {
-      name: 'optihashi_decompose',
-      implementation: () => ({
-        toolFn: async (p?: unknown) => {
-          calls.push(p);
-          return calls.length === 1 ? 'Error: could not formulate step 1' : 'PLAN CREATED';
-        },
-        toolSchema: {},
-      }),
-    } as unknown as ToolDefinition;
-    const state = { decomposeUsed: false };
-    const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state);
-
-    const first = await run(guarded.optihashi_decompose);
-    expect(first).toMatch(/^Error:/);
-    expect(state.decomposeUsed).toBe(false); // failure did not latch
-
-    const second = await run(guarded.optihashi_decompose);
-    expect(second).toBe('PLAN CREATED'); // retry actually re-ran the real tool
-    expect(calls).toHaveLength(2);
-    expect(state.decomposeUsed).toBe(true); // success latches
-  });
-
-  it('does NOT latch the flag when decompose throws (error surfaces, retry still allowed)', async () => {
-    let attempts = 0;
-    const tool = {
-      name: 'optihashi_decompose',
-      implementation: () => ({
-        toolFn: async () => {
-          attempts++;
-          if (attempts === 1) throw new Error('boom');
-          return 'PLAN CREATED';
-        },
-        toolSchema: {},
-      }),
-    } as unknown as ToolDefinition;
-    const state = { decomposeUsed: false };
-    const guarded = guardDecomposeOnce({ optihashi_decompose: tool }, state);
-
-    await expect(run(guarded.optihashi_decompose)).rejects.toThrow('boom');
-    expect(state.decomposeUsed).toBe(false); // throw did not latch
-    expect(await run(guarded.optihashi_decompose)).toBe('PLAN CREATED'); // retry runs
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from '@bike4mind/services';
+import type { IOptiPlanState } from '@bike4mind/database';
 
 /**
  * Message returned when the opti loop tries to decompose a second time. It tells the
@@ -24,14 +25,14 @@ export const DECOMPOSE_ALREADY_DONE_MSG =
  *
  * State is carried on the durable opti plan ledger (`AgentExecution.optiPlanState`, #680) so it is
  * rehydrated on a continuation Lambda -- a re-plan is blocked even across a self-dispatch/resume.
- * The block requires BOTH `decomposeUsed` AND `steps.length > 0`: a first decompose that fails or
- * returns an unparseable success latches `decomposeUsed` with no captured plan, and gating on that
- * alone would durably poison the run (every retry redirected to a plan that never loaded). Requiring
- * a loaded plan lets those cases re-decompose while still blocking a genuine re-plan.
+ * The effective gate is `steps.length > 0` (a plan actually loaded): `decomposeUsed` is recorded but
+ * does not gate on its own, because a first decompose that fails or returns an unparseable success
+ * latches `decomposeUsed` with no captured plan. Requiring a loaded plan lets those cases
+ * re-decompose to recover while still blocking a genuine re-plan.
  */
 export function guardDecomposeOnce(
   tools: Record<string, ToolDefinition>,
-  state: { decomposeUsed: boolean; steps: readonly unknown[] },
+  state: Pick<IOptiPlanState, 'decomposeUsed' | 'steps'>,
   onBlocked?: () => void
 ): Record<string, ToolDefinition> {
   const raw = tools['optihashi_decompose'];
@@ -47,12 +48,11 @@ export function guardDecomposeOnce(
           ...inner,
           toolFn: (parameters?: unknown, apiKey?: string) => {
             // Block a repeat decompose ONLY once a plan actually loaded (steps captured by
-            // planCompletionGuard from a parseable result). Gating on `decomposeUsed` alone would,
-            // with the durable ledger (#680), permanently poison a run whose first decompose failed
-            // OR succeeded-but-unparseable: the flag would latch with steps=[] and every retry would
-            // get redirected to advance a plan that never loaded. Requiring steps>0 lets those cases
-            // re-decompose while still blocking a genuine re-plan.
-            if (state.decomposeUsed && state.steps.length > 0) {
+            // planCompletionGuard from a parseable result). A first decompose that fails or succeeds-
+            // but-unparseable captures no steps, so it stays re-runnable -- gating on the durable
+            // `decomposeUsed` flag alone (#680) would permanently redirect every retry to a plan that
+            // never loaded. `decomposeUsed` is still recorded (below) for the ledger's active check.
+            if (state.steps.length > 0) {
               onBlocked?.();
               return Promise.resolve(DECOMPOSE_ALREADY_DONE_MSG);
             }

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
@@ -16,20 +16,22 @@ export const DECOMPOSE_ALREADY_DONE_MSG =
  *
  * The opti loop prompt says to decompose exactly once, but the model occasionally re-plans
  * mid-run -- which reloads step 1 (a visible console yank), burns an iteration, and re-sources
- * the dataset. This wraps the tool so the FIRST call runs normally and any repeat is a no-op
- * redirect (no re-plan, no populateDecomposition side-effect) that steers the agent back to
- * advancing its existing plan.
+ * the dataset. This wraps the tool so the FIRST successful call runs normally and any repeat -- once
+ * a plan has actually loaded -- is a no-op redirect that steers the agent back to advancing it.
  *
  * Returns a NEW map (never mutates the input). If the map has no optihashi_decompose (e.g. a
  * non-opti run where the overlay tool isn't present), it's returned unchanged.
  *
- * `state.decomposeUsed` is the per-execution flag, carried on the durable opti plan ledger
- * (`AgentExecution.optiPlanState`, #680) so it is rehydrated on a continuation Lambda -- a repeat
- * decompose is blocked even across a self-dispatch/resume boundary, not just within one invocation.
+ * State is carried on the durable opti plan ledger (`AgentExecution.optiPlanState`, #680) so it is
+ * rehydrated on a continuation Lambda -- a re-plan is blocked even across a self-dispatch/resume.
+ * The block requires BOTH `decomposeUsed` AND `steps.length > 0`: a first decompose that fails or
+ * returns an unparseable success latches `decomposeUsed` with no captured plan, and gating on that
+ * alone would durably poison the run (every retry redirected to a plan that never loaded). Requiring
+ * a loaded plan lets those cases re-decompose while still blocking a genuine re-plan.
  */
 export function guardDecomposeOnce(
   tools: Record<string, ToolDefinition>,
-  state: { decomposeUsed: boolean },
+  state: { decomposeUsed: boolean; steps: readonly unknown[] },
   onBlocked?: () => void
 ): Record<string, ToolDefinition> {
   const raw = tools['optihashi_decompose'];
@@ -43,20 +45,19 @@ export function guardDecomposeOnce(
         const run = inner.toolFn;
         return {
           ...inner,
-          toolFn: async (parameters?: unknown, apiKey?: string) => {
-            if (state.decomposeUsed) {
+          toolFn: (parameters?: unknown, apiKey?: string) => {
+            // Block a repeat decompose ONLY once a plan actually loaded (steps captured by
+            // planCompletionGuard from a parseable result). Gating on `decomposeUsed` alone would,
+            // with the durable ledger (#680), permanently poison a run whose first decompose failed
+            // OR succeeded-but-unparseable: the flag would latch with steps=[] and every retry would
+            // get redirected to advance a plan that never loaded. Requiring steps>0 lets those cases
+            // re-decompose while still blocking a genuine re-plan.
+            if (state.decomposeUsed && state.steps.length > 0) {
               onBlocked?.();
-              return DECOMPOSE_ALREADY_DONE_MSG;
+              return Promise.resolve(DECOMPOSE_ALREADY_DONE_MSG);
             }
-            // Latch the durable flag ONLY on a successful decompose. A throw (surfaced by
-            // ReActAgent.callTool as an "Error: ..." observation) propagates without setting it;
-            // a non-throwing "Error: ..." string return is also treated as "did not happen". Else a
-            // first-try decompose failure would permanently poison the ledger (decomposeUsed=true,
-            // steps=[]) across continuations -- redirecting every later decompose to advance a plan
-            // that never loaded. Success detection mirrors planCompletionGuard's isToolSuccess.
-            const out = await run(parameters, apiKey);
-            if (!out.trimStart().toLowerCase().startsWith('error')) state.decomposeUsed = true;
-            return out;
+            state.decomposeUsed = true;
+            return run(parameters, apiKey);
           },
         };
       },

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
@@ -23,13 +23,13 @@ export const DECOMPOSE_ALREADY_DONE_MSG =
  * Returns a NEW map (never mutates the input). If the map has no optihashi_decompose (e.g. a
  * non-opti run where the overlay tool isn't present), it's returned unchanged.
  *
- * `state.used` is the per-execution flag; keep it in the caller's execution closure so it's
- * shared across tool-map rebuilds. In-memory per Lambda invocation: a continuation Lambda
- * resets it, but a re-decompose almost always happens within a single invocation.
+ * `state.decomposeUsed` is the per-execution flag, carried on the durable opti plan ledger
+ * (`AgentExecution.optiPlanState`, #680) so it is rehydrated on a continuation Lambda -- a repeat
+ * decompose is blocked even across a self-dispatch/resume boundary, not just within one invocation.
  */
 export function guardDecomposeOnce(
   tools: Record<string, ToolDefinition>,
-  state: { used: boolean },
+  state: { decomposeUsed: boolean },
   onBlocked?: () => void
 ): Record<string, ToolDefinition> {
   const raw = tools['optihashi_decompose'];
@@ -44,11 +44,11 @@ export function guardDecomposeOnce(
         return {
           ...inner,
           toolFn: (parameters?: unknown, apiKey?: string) => {
-            if (state.used) {
+            if (state.decomposeUsed) {
               onBlocked?.();
               return Promise.resolve(DECOMPOSE_ALREADY_DONE_MSG);
             }
-            state.used = true;
+            state.decomposeUsed = true;
             return run(parameters, apiKey);
           },
         };

--- a/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/decomposeGuard.ts
@@ -43,13 +43,20 @@ export function guardDecomposeOnce(
         const run = inner.toolFn;
         return {
           ...inner,
-          toolFn: (parameters?: unknown, apiKey?: string) => {
+          toolFn: async (parameters?: unknown, apiKey?: string) => {
             if (state.decomposeUsed) {
               onBlocked?.();
-              return Promise.resolve(DECOMPOSE_ALREADY_DONE_MSG);
+              return DECOMPOSE_ALREADY_DONE_MSG;
             }
-            state.decomposeUsed = true;
-            return run(parameters, apiKey);
+            // Latch the durable flag ONLY on a successful decompose. A throw (surfaced by
+            // ReActAgent.callTool as an "Error: ..." observation) propagates without setting it;
+            // a non-throwing "Error: ..." string return is also treated as "did not happen". Else a
+            // first-try decompose failure would permanently poison the ledger (decomposeUsed=true,
+            // steps=[]) across continuations -- redirecting every later decompose to advance a plan
+            // that never loaded. Success detection mirrors planCompletionGuard's isToolSuccess.
+            const out = await run(parameters, apiKey);
+            if (!out.trimStart().toLowerCase().startsWith('error')) state.decomposeUsed = true;
+            return out;
           },
         };
       },

--- a/apps/client/server/queueHandlers/agentExecutorUtils/optiPlanLedger.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/optiPlanLedger.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { rehydrateOptiPlanState, optiPlanActive } from './optiPlanLedger';
+
+describe('rehydrateOptiPlanState', () => {
+  it('returns a fresh empty ledger when nothing is persisted', () => {
+    expect(rehydrateOptiPlanState(undefined)).toEqual({ decomposeUsed: false, steps: [], solved: {}, results: {} });
+    expect(rehydrateOptiPlanState(null)).toEqual({ decomposeUsed: false, steps: [], solved: {}, results: {} });
+  });
+
+  it('rehydrates the persisted ledger for a continuation', () => {
+    const persisted = {
+      decomposeUsed: true,
+      steps: [{ family: 'scheduling', title: 'Seq' }],
+      solved: { scheduling: 1 },
+      results: { scheduling: 'SA (makespan: 130)' },
+    };
+    expect(rehydrateOptiPlanState(persisted)).toEqual(persisted);
+  });
+
+  it('deep-copies so guard mutations do not alias the persisted doc', () => {
+    const persisted = {
+      decomposeUsed: true,
+      steps: [{ family: 'scheduling', title: 'Seq' }],
+      solved: { scheduling: 1 },
+      results: {},
+    };
+    const state = rehydrateOptiPlanState(persisted);
+    state.solved.scheduling = 99;
+    state.steps.push({ family: 'routing', title: 'Route' });
+    expect(persisted.solved.scheduling).toBe(1); // original untouched
+    expect(persisted.steps).toHaveLength(1);
+  });
+});
+
+describe('optiPlanActive', () => {
+  it('is false for a fresh ledger, true once decompose ran or a plan loaded', () => {
+    expect(optiPlanActive({ decomposeUsed: false, steps: [] })).toBe(false);
+    expect(optiPlanActive({ decomposeUsed: true, steps: [] })).toBe(true);
+    expect(optiPlanActive({ decomposeUsed: false, steps: [{ family: 'x', title: 'y' }] })).toBe(true);
+  });
+});

--- a/apps/client/server/queueHandlers/agentExecutorUtils/optiPlanLedger.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/optiPlanLedger.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { rehydrateOptiPlanState, optiPlanActive } from './optiPlanLedger';
+import { rehydrateOptiPlanState, optiPlanActive, ledgerForWrite } from './optiPlanLedger';
 
 describe('rehydrateOptiPlanState', () => {
   it('returns a fresh empty ledger when nothing is persisted', () => {
@@ -17,18 +17,33 @@ describe('rehydrateOptiPlanState', () => {
     expect(rehydrateOptiPlanState(persisted)).toEqual(persisted);
   });
 
-  it('deep-copies so guard mutations do not alias the persisted doc', () => {
+  it('deep-copies so guard mutations do not alias the persisted doc (steps + solved + results)', () => {
     const persisted = {
       decomposeUsed: true,
       steps: [{ family: 'scheduling', title: 'Seq' }],
       solved: { scheduling: 1 },
-      results: {},
+      results: { scheduling: 'SA' },
     };
     const state = rehydrateOptiPlanState(persisted);
     state.solved.scheduling = 99;
+    state.results.scheduling = 'changed';
     state.steps.push({ family: 'routing', title: 'Route' });
-    expect(persisted.solved.scheduling).toBe(1); // original untouched
+    state.steps[0].title = 'mutated';
+    expect(persisted.solved.scheduling).toBe(1); // original solved untouched
+    expect(persisted.results.scheduling).toBe('SA'); // original results untouched
     expect(persisted.steps).toHaveLength(1);
+    expect(persisted.steps[0].title).toBe('Seq'); // per-step object copied, not aliased
+  });
+
+  it('tolerates a partial persisted ledger (minimize drops empty solved/results on read)', () => {
+    // What Mongo actually returns when solved/results were {} at write time (schema minimize).
+    const partial = { decomposeUsed: true, steps: [{ family: 'scheduling', title: 'Seq' }] } as never;
+    expect(rehydrateOptiPlanState(partial)).toEqual({
+      decomposeUsed: true,
+      steps: [{ family: 'scheduling', title: 'Seq' }],
+      solved: {},
+      results: {},
+    });
   });
 });
 
@@ -37,5 +52,13 @@ describe('optiPlanActive', () => {
     expect(optiPlanActive({ decomposeUsed: false, steps: [] })).toBe(false);
     expect(optiPlanActive({ decomposeUsed: true, steps: [] })).toBe(true);
     expect(optiPlanActive({ decomposeUsed: false, steps: [{ family: 'x', title: 'y' }] })).toBe(true);
+  });
+});
+
+describe('ledgerForWrite', () => {
+  it('returns the ledger when active, undefined when there is nothing to persist', () => {
+    const active = { decomposeUsed: true, steps: [], solved: {}, results: {} };
+    expect(ledgerForWrite(active)).toBe(active);
+    expect(ledgerForWrite({ decomposeUsed: false, steps: [], solved: {}, results: {} })).toBeUndefined();
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutorUtils/optiPlanLedger.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/optiPlanLedger.ts
@@ -1,0 +1,27 @@
+import type { IOptiPlanState } from '@bike4mind/database';
+
+/**
+ * Build the in-memory opti plan ledger for an invocation from the persisted execution field (#680).
+ *
+ * A plain-object DEEP-ish copy: the guards mutate this object in place (increment `solved`, assign
+ * `steps`, flip `decomposeUsed`), so it must not be a live Mongoose subdocument, and `solved`/
+ * `results` are copied so mutation doesn't alias the persisted doc. Seeded ONLY from the persisted
+ * ledger -- never from `!isNewExecution` -- so a legitimate first decompose that lands on a
+ * continuation isn't wrongly blocked. Returns a fresh empty ledger when nothing is persisted yet.
+ */
+export function rehydrateOptiPlanState(persisted: IOptiPlanState | null | undefined): IOptiPlanState {
+  return {
+    decomposeUsed: persisted?.decomposeUsed ?? false,
+    steps: (persisted?.steps ?? []).map(s => ({ family: s.family, title: s.title })),
+    solved: { ...(persisted?.solved ?? {}) },
+    results: { ...(persisted?.results ?? {}) },
+  };
+}
+
+/**
+ * Whether the ledger holds anything worth persisting. Gates the checkpoint-ride writes so non-opti
+ * runs (which never touch these fields) write no `optiPlanState`.
+ */
+export function optiPlanActive(state: Pick<IOptiPlanState, 'decomposeUsed' | 'steps'>): boolean {
+  return state.decomposeUsed || state.steps.length > 0;
+}

--- a/apps/client/server/queueHandlers/agentExecutorUtils/optiPlanLedger.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/optiPlanLedger.ts
@@ -3,11 +3,13 @@ import type { IOptiPlanState } from '@bike4mind/database';
 /**
  * Build the in-memory opti plan ledger for an invocation from the persisted execution field (#680).
  *
- * A plain-object DEEP-ish copy: the guards mutate this object in place (increment `solved`, assign
- * `steps`, flip `decomposeUsed`), so it must not be a live Mongoose subdocument, and `solved`/
- * `results` are copied so mutation doesn't alias the persisted doc. Seeded ONLY from the persisted
- * ledger -- never from `!isNewExecution` -- so a legitimate first decompose that lands on a
- * continuation isn't wrongly blocked. Returns a fresh empty ledger when nothing is persisted yet.
+ * A plain-object copy so the guards can mutate it (increment `solved`, assign `steps`, flip
+ * `decomposeUsed`) with `solved`/`results` copied so mutation doesn't alias the persisted doc.
+ * (`BaseRepository.findById` already returns a plain object, so this is defensive, not required.)
+ * Seeded ONLY from the persisted ledger -- never from an is-new-execution heuristic -- so a
+ * legitimate first decompose that lands on a continuation isn't wrongly blocked. Note `solved`/
+ * `results` can be absent on read (the schema's `minimize` drops empty maps), hence the `?? {}`.
+ * Returns a fresh empty ledger when nothing is persisted yet.
  */
 export function rehydrateOptiPlanState(persisted: IOptiPlanState | null | undefined): IOptiPlanState {
   return {
@@ -24,4 +26,13 @@ export function rehydrateOptiPlanState(persisted: IOptiPlanState | null | undefi
  */
 export function optiPlanActive(state: Pick<IOptiPlanState, 'decomposeUsed' | 'steps'>): boolean {
   return state.decomposeUsed || state.steps.length > 0;
+}
+
+/**
+ * The ledger to write alongside a checkpoint, or `undefined` when there's nothing to persist (so a
+ * non-opti run leaves the field untouched). Keeps the persist decision in one tested place rather
+ * than duplicating the `optiPlanActive(...) ? state : undefined` ternary at each checkpoint site.
+ */
+export function ledgerForWrite(state: IOptiPlanState): IOptiPlanState | undefined {
+  return optiPlanActive(state) ? state : undefined;
 }

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.test.ts
@@ -32,14 +32,21 @@ const envelope = (displayMessage: string, familyId?: string) =>
   });
 
 const scheduleResult = envelope(
-  ['## Scheduling Results for "Sequencing"', 'Problem: 4 jobs, 4 machines', '', '### Winner: Simulated Annealing (makespan: 130)', '', '### Simulated Annealing'].join(
-    '\n'
-  )
+  [
+    '## Scheduling Results for "Sequencing"',
+    'Problem: 4 jobs, 4 machines',
+    '',
+    '### Winner: Simulated Annealing (makespan: 130)',
+    '',
+    '### Simulated Annealing',
+  ].join('\n')
 );
 const solveResultFor = (p?: unknown) => {
   const fam = (p as { problem?: { family?: string } })?.problem?.family ?? 'selection';
   return envelope(
-    [`## Results for "${fam} problem" (${fam})`, '', '### Winner: Tabu Search (score: 42)', '', '### Tabu Search'].join('\n'),
+    [`## Results for "${fam} problem" (${fam})`, '', '### Winner: Tabu Search (score: 42)', '', '### Tabu Search'].join(
+      '\n'
+    ),
     fam
   );
 };
@@ -80,7 +87,7 @@ function makeOptiTools() {
   };
 }
 
-const emptyState = (): PlanProgressState => ({ steps: null, solved: {}, results: {} });
+const emptyState = (): PlanProgressState => ({ steps: [], solved: {}, results: {} });
 
 describe('pure helpers', () => {
   it('capturePlan returns ordered steps with family + title; null for non-plan results', () => {
@@ -105,7 +112,11 @@ describe('pure helpers', () => {
     // Falls back to raw markdown for callers/strings that aren't the envelope.
     expect(extractResultDigest('### Winner: Greedy (bins: 4)')).toBe('Greedy (bins: 4)');
     // No winner line (single-solver run emits no Winner header) or an error -> null.
-    expect(extractResultDigest(envelope(['## Results for "X" (routing)', '', '### Concorde', 'tour: 88'].join('\n'), 'routing'))).toBeNull();
+    expect(
+      extractResultDigest(
+        envelope(['## Results for "X" (routing)', '', '### Concorde', 'tour: 88'].join('\n'), 'routing')
+      )
+    ).toBeNull();
     expect(extractResultDigest('Error: invalid problem')).toBeNull();
   });
 

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
@@ -12,7 +12,9 @@ export type PlanStep = { family: string; title: string };
  * Keep this in the caller's execution closure so it survives tool-map rebuilds.
  */
 export type PlanProgressState = {
-  steps: PlanStep[] | null;
+  // Empty until a plan is captured from a decompose result (was `| null`; now a plain array so it
+  // maps 1:1 onto the durable AgentExecution.optiPlanState ledger, #680).
+  steps: PlanStep[];
   solved: Record<string, number>;
   results: Record<string, string>;
 };
@@ -99,7 +101,7 @@ export function extractResultDigest(result: string): string | null {
  * one; the run is done only when the covered-step count reaches the plan length.
  */
 export function planIsComplete(state: PlanProgressState): boolean {
-  if (!state.steps) return false;
+  if (state.steps.length === 0) return false;
   const needed = neededByFamily(state.steps);
   let planSteps = 0;
   let covered = 0;
@@ -167,7 +169,7 @@ export function guardPlanCompletion(
   const decompose = tools['optihashi_decompose'];
   guarded.optihashi_decompose = wrap(decompose, run => async (parameters, apiKey) => {
     const out = await run(parameters, apiKey);
-    if (!state.steps) {
+    if (state.steps.length === 0) {
       const captured = capturePlan(out);
       if (captured) state.steps = captured;
     }

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
@@ -2,7 +2,7 @@ import type { ToolDefinition } from '@bike4mind/services';
 import type { IOptiPlanState, IOptiPlanStep } from '@bike4mind/database';
 
 /** One planned sub-problem: its family and the short title the decomposition gave it. */
-export type PlanStep = IOptiPlanStep;
+type PlanStep = IOptiPlanStep;
 
 /**
  * The slice of the durable opti plan ledger this guard reads/writes. Derived from the persisted

--- a/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/planCompletionGuard.ts
@@ -1,23 +1,19 @@
 import type { ToolDefinition } from '@bike4mind/services';
+import type { IOptiPlanState, IOptiPlanStep } from '@bike4mind/database';
 
 /** One planned sub-problem: its family and the short title the decomposition gave it. */
-export type PlanStep = { family: string; title: string };
+export type PlanStep = IOptiPlanStep;
 
 /**
- * Per-execution plan progress. `steps` is the ordered plan captured from the decompose result
- * (null until a decomposition loads, so single-problem runs are never gated). `solved` counts
- * SUCCESSFUL schedule/solve calls per family. `results` holds the first winning-result digest per
- * family, so the completion redirect can hand the agent the actual per-step results to summarize --
- * the agent's own transcript memory of earlier steps is unreliable (that's the bug we're fixing).
- * Keep this in the caller's execution closure so it survives tool-map rebuilds.
+ * The slice of the durable opti plan ledger this guard reads/writes. Derived from the persisted
+ * `IOptiPlanState` (single source of truth, #680) rather than re-declared, so a change to those
+ * fields' shapes propagates here instead of silently drifting. `steps` is the ordered plan captured
+ * from the decompose result (empty until a decomposition loads, so single-problem runs are never
+ * gated); `solved` counts SUCCESSFUL schedule/solve calls per family; `results` holds the first
+ * winning-result digest per family, so the completion redirect can hand the agent the actual per-step
+ * results to summarize (its own transcript memory of earlier steps is unreliable -- the bug we fix).
  */
-export type PlanProgressState = {
-  // Empty until a plan is captured from a decompose result (was `| null`; now a plain array so it
-  // maps 1:1 onto the durable AgentExecution.optiPlanState ledger, #680).
-  steps: PlanStep[];
-  solved: Record<string, number>;
-  results: Record<string, string>;
-};
+export type PlanProgressState = Pick<IOptiPlanState, 'steps' | 'solved' | 'results'>;
 
 type ToolFn = (parameters?: unknown, apiKey?: string) => Promise<string>;
 
@@ -118,7 +114,7 @@ export function planIsComplete(state: PlanProgressState): boolean {
  * re-deriving from its transcript (where earlier steps are buried and get forgotten/undersold).
  */
 export function buildPlanCompleteMsg(state: PlanProgressState): string {
-  const lines = (state.steps ?? []).map((step, i) => {
+  const lines = state.steps.map((step, i) => {
     const digest = state.results[step.family];
     return `${i + 1}. ${step.title}${digest ? ` -- ${digest}` : ' -- solved (see result in your history above)'}`;
   });

--- a/packages/database/src/models/billing/AgentExecutionModel.test.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.test.ts
@@ -289,6 +289,54 @@ describe('AgentExecutionRepository', () => {
     });
   });
 
+  describe('updateOptiPlanState (#680 durable plan ledger)', () => {
+    it('round-trips the plan ledger so a continuation Lambda can rehydrate it', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution({ status: 'running' }));
+      expect(exec.optiPlanState).toBeUndefined(); // absent on create (opti-only)
+
+      await agentExecutionRepository.updateOptiPlanState(exec.id, {
+        decomposeUsed: true,
+        steps: [
+          { family: 'scheduling', title: 'Sequence stations' },
+          { family: 'routing', title: 'Route vans' },
+        ],
+        solved: { scheduling: 1 },
+        results: { scheduling: 'Seq -- Simulated Annealing (makespan: 130)' },
+      });
+
+      const updated = await agentExecutionRepository.findById(exec.id);
+      expect(updated?.optiPlanState?.decomposeUsed).toBe(true);
+      expect(updated?.optiPlanState?.steps.map(s => s.family)).toEqual(['scheduling', 'routing']);
+      expect(updated?.optiPlanState?.solved).toMatchObject({ scheduling: 1 });
+      expect(updated?.optiPlanState?.results).toMatchObject({
+        scheduling: 'Seq -- Simulated Annealing (makespan: 130)',
+      });
+    });
+
+    it('overwrites the ledger on each write (whole-subdoc $set)', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution({ status: 'running' }));
+      await agentExecutionRepository.updateOptiPlanState(exec.id, {
+        decomposeUsed: true,
+        steps: [{ family: 'scheduling', title: 's' }],
+        solved: { scheduling: 1 },
+        results: {},
+      });
+      await agentExecutionRepository.updateOptiPlanState(exec.id, {
+        decomposeUsed: true,
+        steps: [
+          { family: 'scheduling', title: 's' },
+          { family: 'routing', title: 'r' },
+        ],
+        solved: { scheduling: 1, routing: 1 },
+        results: {},
+      });
+
+      const updated = await agentExecutionRepository.findById(exec.id);
+      expect(updated?.optiPlanState?.steps).toHaveLength(2);
+      expect(updated?.optiPlanState?.solved).toMatchObject({ scheduling: 1, routing: 1 });
+    });
+  });
+
   describe('setWaitingOnChild / clearWaitingOnChild', () => {
     it('atomically sets waitingOnChild + status + checkpoint', async () => {
       const exec = await agentExecutionRepository.create(makeBaseExecution({ status: 'running' }));

--- a/packages/database/src/models/billing/AgentExecutionModel.test.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import mongoose from 'mongoose';
 import AgentExecutionModel, { agentExecutionRepository, type AgentExecutionStatus } from './AgentExecutionModel';
 import { setupMongoTest } from '../../__test__/utils';
@@ -312,13 +312,36 @@ describe('AgentExecutionRepository', () => {
       expect((updated?.checkpoint as { iteration: number }).iteration).toBe(1); // checkpoint written too
       expect(updated?.optiPlanState?.decomposeUsed).toBe(true);
       expect(updated?.optiPlanState?.steps).toEqual([
-        { family: 'scheduling', title: 'Sequence stations' }, // title durability asserted (F7)
+        { family: 'scheduling', title: 'Sequence stations' }, // step titles round-trip intact
         { family: 'routing', title: 'Route vans' },
       ]);
       expect(updated?.optiPlanState?.solved).toMatchObject({ scheduling: 1 });
       expect(updated?.optiPlanState?.results).toMatchObject({
         scheduling: 'Seq -- Simulated Annealing (makespan: 130)',
       });
+    });
+
+    it('writes checkpoint + ledger in a SINGLE atomic updateOne (the refactor is a lone write)', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution({ status: 'running' }));
+      const spy = vi.spyOn(AgentExecutionModel, 'updateOne');
+      try {
+        await agentExecutionRepository.updateCheckpoint(
+          exec.id,
+          { iteration: 1 },
+          {
+            decomposeUsed: true,
+            steps: [{ family: 'scheduling', title: 's' }],
+            solved: {},
+            results: {},
+          }
+        );
+        expect(spy).toHaveBeenCalledTimes(1);
+        const set = (spy.mock.calls[0][1] as { $set: Record<string, unknown> }).$set;
+        expect(set).toHaveProperty('checkpoint');
+        expect(set).toHaveProperty('optiPlanState'); // both fields in the one $set
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it('replaces the whole ledger on each write (not a merge) so shrinking fields drop', async () => {
@@ -354,11 +377,41 @@ describe('AgentExecutionRepository', () => {
       expect(updated?.optiPlanState?.results).toEqual({ scheduling: 'new' });
     });
 
-    it('leaves optiPlanState untouched when omitted (non-opti checkpoint write)', async () => {
+    it('preserves an existing ledger across a ledger-less checkpoint write (omitted != cleared)', async () => {
       const exec = await agentExecutionRepository.create(makeBaseExecution({ status: 'running' }));
-      await agentExecutionRepository.updateCheckpoint(exec.id, { iteration: 3 });
+      // A ledger is established...
+      await agentExecutionRepository.updateCheckpoint(
+        exec.id,
+        {},
+        {
+          decomposeUsed: true,
+          steps: [{ family: 'scheduling', title: 's' }],
+          solved: { scheduling: 1 },
+          results: {},
+        }
+      );
+      // ...then a later checkpoint write with no ledger arg (a non-opti or pre-plan iteration) must
+      // NOT wipe it -- this is the assertion that actually protects the `!== undefined` guard.
+      await agentExecutionRepository.updateCheckpoint(exec.id, { iteration: 5 });
       const updated = await agentExecutionRepository.findById(exec.id);
-      expect(updated?.optiPlanState).toBeUndefined();
+      expect((updated?.checkpoint as { iteration: number }).iteration).toBe(5);
+      expect(updated?.optiPlanState?.steps).toEqual([{ family: 'scheduling', title: 's' }]);
+      expect(updated?.optiPlanState?.solved).toMatchObject({ scheduling: 1 });
+    });
+
+    it('updateCheckpointAndStatus rides the ledger + flips status atomically (timeout self-dispatch)', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution({ status: 'running' }));
+      await agentExecutionRepository.updateCheckpointAndStatus(exec.id, { iteration: 2 }, 'continuing', {
+        decomposeUsed: true,
+        steps: [{ family: 'routing', title: 'Route' }],
+        solved: { routing: 1 },
+        results: { routing: 'SA (35 km)' },
+      });
+      const updated = await agentExecutionRepository.findById(exec.id);
+      expect(updated?.status).toBe('continuing');
+      expect((updated?.checkpoint as { iteration: number }).iteration).toBe(2);
+      expect(updated?.optiPlanState?.steps).toEqual([{ family: 'routing', title: 'Route' }]);
+      expect(updated?.optiPlanState?.results).toMatchObject({ routing: 'SA (35 km)' });
     });
   });
 

--- a/packages/database/src/models/billing/AgentExecutionModel.test.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.test.ts
@@ -289,51 +289,76 @@ describe('AgentExecutionRepository', () => {
     });
   });
 
-  describe('updateOptiPlanState (#680 durable plan ledger)', () => {
-    it('round-trips the plan ledger so a continuation Lambda can rehydrate it', async () => {
+  describe('updateCheckpoint opti plan ledger (#680)', () => {
+    it('rides the ledger on the checkpoint write so a continuation Lambda rehydrates it', async () => {
       const exec = await agentExecutionRepository.create(makeBaseExecution({ status: 'running' }));
       expect(exec.optiPlanState).toBeUndefined(); // absent on create (opti-only)
 
-      await agentExecutionRepository.updateOptiPlanState(exec.id, {
-        decomposeUsed: true,
-        steps: [
-          { family: 'scheduling', title: 'Sequence stations' },
-          { family: 'routing', title: 'Route vans' },
-        ],
-        solved: { scheduling: 1 },
-        results: { scheduling: 'Seq -- Simulated Annealing (makespan: 130)' },
-      });
+      await agentExecutionRepository.updateCheckpoint(
+        exec.id,
+        { iteration: 1 },
+        {
+          decomposeUsed: true,
+          steps: [
+            { family: 'scheduling', title: 'Sequence stations' },
+            { family: 'routing', title: 'Route vans' },
+          ],
+          solved: { scheduling: 1 },
+          results: { scheduling: 'Seq -- Simulated Annealing (makespan: 130)' },
+        }
+      );
 
       const updated = await agentExecutionRepository.findById(exec.id);
+      expect((updated?.checkpoint as { iteration: number }).iteration).toBe(1); // checkpoint written too
       expect(updated?.optiPlanState?.decomposeUsed).toBe(true);
-      expect(updated?.optiPlanState?.steps.map(s => s.family)).toEqual(['scheduling', 'routing']);
+      expect(updated?.optiPlanState?.steps).toEqual([
+        { family: 'scheduling', title: 'Sequence stations' }, // title durability asserted (F7)
+        { family: 'routing', title: 'Route vans' },
+      ]);
       expect(updated?.optiPlanState?.solved).toMatchObject({ scheduling: 1 });
       expect(updated?.optiPlanState?.results).toMatchObject({
         scheduling: 'Seq -- Simulated Annealing (makespan: 130)',
       });
     });
 
-    it('overwrites the ledger on each write (whole-subdoc $set)', async () => {
+    it('replaces the whole ledger on each write (not a merge) so shrinking fields drop', async () => {
       const exec = await agentExecutionRepository.create(makeBaseExecution({ status: 'running' }));
-      await agentExecutionRepository.updateOptiPlanState(exec.id, {
-        decomposeUsed: true,
-        steps: [{ family: 'scheduling', title: 's' }],
-        solved: { scheduling: 1 },
-        results: {},
-      });
-      await agentExecutionRepository.updateOptiPlanState(exec.id, {
-        decomposeUsed: true,
-        steps: [
-          { family: 'scheduling', title: 's' },
-          { family: 'routing', title: 'r' },
-        ],
-        solved: { scheduling: 1, routing: 1 },
-        results: {},
-      });
+      await agentExecutionRepository.updateCheckpoint(
+        exec.id,
+        {},
+        {
+          decomposeUsed: true,
+          steps: [
+            { family: 'scheduling', title: 's' },
+            { family: 'routing', title: 'r' },
+          ],
+          solved: { scheduling: 1, routing: 1 },
+          results: { scheduling: 'old' },
+        }
+      );
+      // Second write carries FEWER steps + a changed result; whole-subdoc $set must replace, not merge.
+      await agentExecutionRepository.updateCheckpoint(
+        exec.id,
+        {},
+        {
+          decomposeUsed: true,
+          steps: [{ family: 'scheduling', title: 's2' }],
+          solved: { scheduling: 2 },
+          results: { scheduling: 'new' },
+        }
+      );
 
       const updated = await agentExecutionRepository.findById(exec.id);
-      expect(updated?.optiPlanState?.steps).toHaveLength(2);
-      expect(updated?.optiPlanState?.solved).toMatchObject({ scheduling: 1, routing: 1 });
+      expect(updated?.optiPlanState?.steps).toEqual([{ family: 'scheduling', title: 's2' }]); // routing gone, title updated
+      expect(updated?.optiPlanState?.solved).toEqual({ scheduling: 2 });
+      expect(updated?.optiPlanState?.results).toEqual({ scheduling: 'new' });
+    });
+
+    it('leaves optiPlanState untouched when omitted (non-opti checkpoint write)', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution({ status: 'running' }));
+      await agentExecutionRepository.updateCheckpoint(exec.id, { iteration: 3 });
+      const updated = await agentExecutionRepository.findById(exec.id);
+      expect(updated?.optiPlanState).toBeUndefined();
     });
   });
 

--- a/packages/database/src/models/billing/AgentExecutionModel.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.ts
@@ -112,7 +112,11 @@ export interface IOptiPlanStep {
  * Opti-only: absent on non-opti executions (no schema default).
  */
 export interface IOptiPlanState {
-  /** True once optihashi_decompose has run; blocks a repeat re-plan across continuations. */
+  /**
+   * True once optihashi_decompose has run (recorded for the ledger's active check). The re-plan
+   * block itself keys on a LOADED plan (`steps.length > 0`), not this flag alone -- a failed or
+   * unparseable first decompose sets this with no captured steps and must stay re-runnable.
+   */
   decomposeUsed: boolean;
   /** Ordered plan captured from the decompose result (empty until a plan loads). */
   steps: IOptiPlanStep[];
@@ -456,7 +460,10 @@ const OptiPlanStateSchema = new mongoose.Schema(
     solved: { type: mongoose.Schema.Types.Mixed, default: {} },
     results: { type: mongoose.Schema.Types.Mixed, default: {} },
   },
-  { _id: false }
+  // `minimize: false` so an empty `solved`/`results` (`{}`) still persists and reads back as `{}`,
+  // matching the non-optional type -- otherwise Mongoose drops empty objects and the read boundary
+  // would return `undefined` for a field the type says is always present.
+  { _id: false, minimize: false }
 );
 
 const WaitingOnChildSchema = new mongoose.Schema(

--- a/packages/database/src/models/billing/AgentExecutionModel.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.ts
@@ -101,10 +101,11 @@ export interface IOptiPlanStep {
 
 /**
  * Durable ledger for the autonomous optimizer loop (#680). The opti guards previously tracked this
- * in per-Lambda-invocation memory, so it reset when a run spanned a continuation (SQS resume,
- * subagent handoff, or timeout self-dispatch) -- letting a repeat decompose or re-solve slip through
- * after the boundary. Persisting it here (rehydrated per invocation) makes the decompose-once and
- * plan-completion guards durable across continuations.
+ * in per-Lambda-invocation memory, so it reset whenever a run spanned a continuation -- letting a
+ * repeat decompose or re-solve slip through after the boundary. It is persisted here, rehydrated per
+ * invocation, and written in the SAME atomic `updateOne` as the checkpoint (see updateCheckpoint /
+ * updateCheckpointAndStatus). Because every continuation path resumes from a checkpoint, riding the
+ * checkpoint write gives the ledger the checkpoint's exact durability at every boundary.
  *
  * Do NOT reconstruct this from `checkpoint.steps`: that transcript front-trims past ~4 iterations
  * (ReActAgent trimSteps), so on the long runs that actually continue the early decompose is gone.
@@ -441,7 +442,15 @@ const ConfidenceTelemetrySchema = new mongoose.Schema(
 const OptiPlanStateSchema = new mongoose.Schema(
   {
     decomposeUsed: { type: Boolean, default: false },
-    steps: { type: [new mongoose.Schema({ family: String, title: String }, { _id: false })], default: [] },
+    steps: {
+      type: [
+        new mongoose.Schema(
+          { family: { type: String, required: true }, title: { type: String, required: true } },
+          { _id: false }
+        ),
+      ],
+      default: [],
+    },
     // Mixed maps (family -> count / digest). Persisted via whole-subdoc $set on change, so Mongoose
     // deep-change tracking on Mixed is not relied upon.
     solved: { type: mongoose.Schema.Types.Mixed, default: {} },
@@ -1131,17 +1140,16 @@ class AgentExecutionRepository extends BaseRepository<IAgentExecution> {
     return result.modifiedCount > 0;
   }
 
-  async updateCheckpoint(id: string, checkpoint: unknown): Promise<void> {
-    await this.model.updateOne({ _id: id }, { $set: { checkpoint } });
-  }
-
   /**
-   * Persist the durable optimizer plan ledger (#680). Written alongside the checkpoint at
-   * iteration boundaries and continuation handoffs so it survives a continuation Lambda with the
-   * same durability guarantee as the checkpoint. Whole-subdoc `$set` (the ledger is tiny).
+   * Persist the checkpoint, optionally with the durable optimizer plan ledger (#680) in the SAME
+   * atomic `updateOne`. Riding the ledger on the already-awaited checkpoint write gives it exactly
+   * the checkpoint's continuation durability (every iteration boundary + handoff) with no separate
+   * write to race or lose. `optiPlanState` omitted (non-opti runs) leaves the field untouched.
    */
-  async updateOptiPlanState(id: string, optiPlanState: IOptiPlanState): Promise<void> {
-    await this.model.updateOne({ _id: id }, { $set: { optiPlanState } });
+  async updateCheckpoint(id: string, checkpoint: unknown, optiPlanState?: IOptiPlanState): Promise<void> {
+    const set: Record<string, unknown> = { checkpoint };
+    if (optiPlanState !== undefined) set.optiPlanState = optiPlanState;
+    await this.model.updateOne({ _id: id }, { $set: set });
   }
 
   /**
@@ -1171,8 +1179,15 @@ class AgentExecutionRepository extends BaseRepository<IAgentExecution> {
    * document with an updated checkpoint but stale `running` status (which
    * would orphan the execution by failing the continuation Lambda's CAS).
    */
-  async updateCheckpointAndStatus(id: string, checkpoint: unknown, status: AgentExecutionStatus): Promise<void> {
-    await this.model.updateOne({ _id: id }, { $set: { checkpoint, status } });
+  async updateCheckpointAndStatus(
+    id: string,
+    checkpoint: unknown,
+    status: AgentExecutionStatus,
+    optiPlanState?: IOptiPlanState
+  ): Promise<void> {
+    const set: Record<string, unknown> = { checkpoint, status };
+    if (optiPlanState !== undefined) set.optiPlanState = optiPlanState;
+    await this.model.updateOne({ _id: id }, { $set: set });
   }
 
   async updateConnectionId(id: string, connectionId: string): Promise<void> {

--- a/packages/database/src/models/billing/AgentExecutionModel.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.ts
@@ -91,6 +91,36 @@ export type ConfidenceTelemetrySummary = {
   avgConfidence: number;
 };
 
+// --- Opti Plan Ledger ---
+
+/** One planned sub-problem in an opti decomposition: its family and short title. */
+export interface IOptiPlanStep {
+  family: string;
+  title: string;
+}
+
+/**
+ * Durable ledger for the autonomous optimizer loop (#680). The opti guards previously tracked this
+ * in per-Lambda-invocation memory, so it reset when a run spanned a continuation (SQS resume,
+ * subagent handoff, or timeout self-dispatch) -- letting a repeat decompose or re-solve slip through
+ * after the boundary. Persisting it here (rehydrated per invocation) makes the decompose-once and
+ * plan-completion guards durable across continuations.
+ *
+ * Do NOT reconstruct this from `checkpoint.steps`: that transcript front-trims past ~4 iterations
+ * (ReActAgent trimSteps), so on the long runs that actually continue the early decompose is gone.
+ * Opti-only: absent on non-opti executions (no schema default).
+ */
+export interface IOptiPlanState {
+  /** True once optihashi_decompose has run; blocks a repeat re-plan across continuations. */
+  decomposeUsed: boolean;
+  /** Ordered plan captured from the decompose result (empty until a plan loads). */
+  steps: IOptiPlanStep[];
+  /** Successful schedule/solve calls per family. */
+  solved: Record<string, number>;
+  /** First winning-result digest per family, for the completion summary. */
+  results: Record<string, string>;
+}
+
 // --- Waiting On Subagent ---
 
 /**
@@ -282,6 +312,12 @@ export interface IAgentExecution {
    */
   confidenceTelemetry?: IConfidenceTelemetry;
 
+  /**
+   * Durable optimizer plan ledger (#680). Present only on opti agent runs; rehydrated each
+   * invocation so the decompose-once / plan-completion guards survive continuation Lambdas.
+   */
+  optiPlanState?: IOptiPlanState;
+
   // Billing
   iterationBilling: IIterationBilling[];
   totalCreditsUsed: number;
@@ -398,6 +434,18 @@ const ConfidenceTelemetrySchema = new mongoose.Schema(
     emittedCount: { type: Number, default: 0 },
     minConfidence: { type: Number, default: 1 },
     confidenceSum: { type: Number, default: 0 },
+  },
+  { _id: false }
+);
+
+const OptiPlanStateSchema = new mongoose.Schema(
+  {
+    decomposeUsed: { type: Boolean, default: false },
+    steps: { type: [new mongoose.Schema({ family: String, title: String }, { _id: false })], default: [] },
+    // Mixed maps (family -> count / digest). Persisted via whole-subdoc $set on change, so Mongoose
+    // deep-change tracking on Mixed is not relied upon.
+    solved: { type: mongoose.Schema.Types.Mixed, default: {} },
+    results: { type: mongoose.Schema.Types.Mixed, default: {} },
   },
   { _id: false }
 );
@@ -563,6 +611,8 @@ const AgentExecutionSchema = new mongoose.Schema(
     // the subdoc so its field defaults (evaluatedCount 0, minConfidence 1, ...)
     // apply to every new execution.
     confidenceTelemetry: { type: ConfidenceTelemetrySchema, default: () => ({}) },
+    // Opti-only; no default so non-opti executions don't carry an empty ledger.
+    optiPlanState: { type: OptiPlanStateSchema, required: false },
 
     // Billing
     iterationBilling: { type: [IterationBillingSchema], default: [] },
@@ -1083,6 +1133,15 @@ class AgentExecutionRepository extends BaseRepository<IAgentExecution> {
 
   async updateCheckpoint(id: string, checkpoint: unknown): Promise<void> {
     await this.model.updateOne({ _id: id }, { $set: { checkpoint } });
+  }
+
+  /**
+   * Persist the durable optimizer plan ledger (#680). Written alongside the checkpoint at
+   * iteration boundaries and continuation handoffs so it survives a continuation Lambda with the
+   * same durability guarantee as the checkpoint. Whole-subdoc `$set` (the ledger is tiny).
+   */
+  async updateOptiPlanState(id: string, optiPlanState: IOptiPlanState): Promise<void> {
+    await this.model.updateOne({ _id: id }, { $set: { optiPlanState } });
   }
 
   /**


### PR DESCRIPTION
Closes #680 (consolidates #673).

## Problem
The opti-loop guards (#666 decompose-once, #676 plan-completion, #57 brief/results) tracked their state in per-Lambda-invocation memory, so it reset whenever a run spanned a continuation (SQS resume / timeout self-dispatch). After the boundary a repeat decompose or a re-solve of a finished step could slip through -- and long runs are exactly the ones that continue.

## Fix -- durable ledger on the execution record, rehydrated per invocation
- **`AgentExecution.optiPlanState`** (new sub-doc): `{ decomposeUsed, steps[], solved, results }`. Opti-only (no schema default); `minimize: false` so empty maps persist and read back matching the non-optional type.
- **Rides the awaited checkpoint writes atomically.** `updateCheckpoint` / `updateCheckpointAndStatus` take an optional `optiPlanState` and write it in the SAME `updateOne`. Every continuation resumes from a checkpoint, so the ledger has the checkpoint's exact durability at every boundary -- no separate write to race or lose. `ledgerForWrite(state)` decides whether to include it, so non-opti runs write nothing.
- **Rehydrated** from `execution.optiPlanState` at run start (`rehydrateOptiPlanState`), seeded only from the persisted ledger -- never an is-new-execution heuristic. The three guards read/write the one shared object.
- **The re-plan block keys on a LOADED plan** (`steps.length > 0`), so a failed or unparseable first decompose stays re-runnable; `decomposeUsed` is a record-only field.

## Constraint (from #673)
Do not derive durable state from `checkpoint.steps` -- ReActAgent front-trims transcript history, so on the long runs that actually continue the early decompose is gone.

## Tests / verification
`agentExecutorUtils` (decompose/plan-completion/brief guards + `optiPlanLedger`: rehydrate, active, `ledgerForWrite`) and the `AgentExecutionModel` ledger tests (round-trip, replace-not-merge, existing-ledger-survives-a-ledger-less-write, single-`updateOne` atomicity, `updateCheckpointAndStatus`). `@bike4mind/database` typecheck clean. Cross-package typecheck + the DB model test run in CI (the worktree can't rebuild the tsdown-built database dist locally).

## Guide for Testers
1. Agent mode `/opti`, a multi-step scenario long enough to cross a continuation (or force a self-dispatch).
2. After the continuation, the agent must NOT re-decompose or re-solve a finished step -- `optiPlanState` rehydrates the plan.
3. The execution doc has `optiPlanState` with solved counts + per-step results; non-opti runs have no `optiPlanState`.
4. Regression: single-invocation opti runs behave exactly as before.