### PR TITLE
fix(client): stop mfaPending 401 console spam on MFA login

### DIFF
--- a/apps/client/app/contexts/ApiContext.test.tsx
+++ b/apps/client/app/contexts/ApiContext.test.tsx
@@ -17,6 +17,17 @@ const make401 = (config: InternalAxiosRequestConfig): AxiosError =>
     config,
   } as AxiosResponse);
 
+// A mfaPending 401: the full-auth middleware rejects every non-allowlisted request
+// during the login mfaPending window with this exact { mfaPending: true } marker.
+const makeMfaPending401 = (config: InternalAxiosRequestConfig): AxiosError =>
+  new AxiosError('Unauthorized', 'ERR_BAD_REQUEST', config, {}, {
+    status: 401,
+    statusText: 'Unauthorized',
+    data: { error: 'MFA setup or verification required.', mfaPending: true },
+    headers: {},
+    config,
+  } as AxiosResponse);
+
 const ok = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse =>
   ({ data, status: 200, statusText: 'OK', headers: {}, config }) as AxiosResponse;
 
@@ -230,6 +241,32 @@ describe('ApiProvider 401 interceptor -> login redirect', () => {
     expect(replace).not.toHaveBeenCalled();
     // No forced teardown either - mfaPending session state must be left alone.
     expect(useAccessToken.getState().mfaPending).toBe(true);
+  });
+
+  it('does NOT console-log a mfaPending 401 (expected mid-MFA rejection), but still logs a normal 401 (#804)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // mfaPending session: token present, no refresh token - the interceptor's 401
+    // branch no-ops the redirect, and the logging block must stay silent.
+    useAccessToken.setState({
+      expired: false,
+      expiredReason: null,
+      accessToken: 'mfa-token',
+      refreshToken: null,
+      mfaPending: true,
+    });
+    api.defaults.adapter = ((config: InternalAxiosRequestConfig) =>
+      Promise.reject(makeMfaPending401(config))) as AxiosAdapter;
+
+    await expect(api.get('/api/agents')).rejects.toBeTruthy();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    // A plain 401 (no mfaPending marker) is a real error and must still be logged.
+    useAccessToken.setState({ accessToken: null, refreshToken: null, expired: true, mfaPending: false });
+    api.defaults.adapter = ((config: InternalAxiosRequestConfig) => Promise.reject(make401(config))) as AxiosAdapter;
+    await expect(api.get('/api/agents')).rejects.toBeTruthy();
+    expect(errorSpy).toHaveBeenCalledWith('Axios Error:', expect.anything());
+
+    errorSpy.mockRestore();
   });
 
   it('fires exactly one redirect when a burst of concurrent 401s are all unrecoverable', async () => {

--- a/apps/client/app/contexts/ApiContext.tsx
+++ b/apps/client/app/contexts/ApiContext.tsx
@@ -140,9 +140,20 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
+    // A 401 during the login mfaPending window is expected, not an error: the
+    // server rejects every non-allowlisted request while mid-MFA with
+    // { mfaPending: true } (see server/auth/auth.ts). The app shell fires its
+    // data queries before MFA completes, so logging these would spam ~40 lines
+    // per login and bury real errors (#804). Skip logging them; still let the
+    // 401 handling below run (it already no-ops the redirect for mfaPending).
+    const isMfaPending401 =
+      isAxiosError(error) && error.response?.status === 401 && error.response?.data?.mfaPending === true;
+
     // TODO: have graceful toasters for customers vs developers
     // For now just a console.log
-    if (isAxiosError(error)) {
+    if (isMfaPending401) {
+      // expected mid-MFA rejection - intentionally not logged
+    } else if (isAxiosError(error)) {
       if (error.code === 'ERR_NETWORK' || error.message === 'Network Error') {
         console.error('Network Error: Backend may not be running. Check that SST is started.');
       } else {

--- a/apps/client/app/contexts/ApiContext.tsx
+++ b/apps/client/app/contexts/ApiContext.tsx
@@ -149,18 +149,19 @@ api.interceptors.response.use(
     const isMfaPending401 =
       isAxiosError(error) && error.response?.status === 401 && error.response?.data?.mfaPending === true;
 
+    // Suppress logging for the expected mid-MFA rejection; log everything else.
     // TODO: have graceful toasters for customers vs developers
     // For now just a console.log
-    if (isMfaPending401) {
-      // expected mid-MFA rejection - intentionally not logged
-    } else if (isAxiosError(error)) {
-      if (error.code === 'ERR_NETWORK' || error.message === 'Network Error') {
-        console.error('Network Error: Backend may not be running. Check that SST is started.');
+    if (!isMfaPending401) {
+      if (isAxiosError(error)) {
+        if (error.code === 'ERR_NETWORK' || error.message === 'Network Error') {
+          console.error('Network Error: Backend may not be running. Check that SST is started.');
+        } else {
+          console.error('Axios Error:', error.response?.data || error.message);
+        }
       } else {
-        console.error('Axios Error:', error.response?.data || error.message);
+        console.log('Axios Error', error);
       }
-    } else {
-      console.log('Axios Error', error);
     }
     /*
         toast.error(

--- a/apps/client/app/hooks/data/agents.ts
+++ b/apps/client/app/hooks/data/agents.ts
@@ -2,16 +2,20 @@ import { useQuery } from '@tanstack/react-query';
 import { api } from '@client/app/contexts/ApiContext';
 import { IAgent } from '@bike4mind/common';
 import useSessionLayout from '@client/app/hooks/useSessionLayout';
+import { useIsFullyAuthenticated } from '@client/app/hooks/useAccessToken';
 import { isOptimisticId } from '@client/app/utils/llm';
 
 export const useGetAgents = (enabled: boolean = true) => {
+  // Gate on the fully-authenticated state so this doesn't fire during the login
+  // mfaPending window, where it would 401 (#804).
+  const isFullyAuthenticated = useIsFullyAuthenticated();
   return useQuery({
     queryKey: ['agents'],
     queryFn: async (): Promise<IAgent[]> => {
       const response = await api.get<{ data: IAgent[]; hasMore: boolean; total: number }>('/api/agents');
       return response.data.data;
     },
-    enabled,
+    enabled: enabled && isFullyAuthenticated,
     staleTime: 5 * 60 * 1000, // 5 minutes - only refetch when agents actually change
     refetchOnWindowFocus: false, // Prevent refetch when switching tabs/windows
     refetchOnReconnect: false, // Prevent refetch on network reconnection

--- a/apps/client/app/hooks/data/entitlements.ts
+++ b/apps/client/app/hooks/data/entitlements.ts
@@ -1,4 +1,5 @@
 import { api } from '@client/app/contexts/ApiContext';
+import { useIsFullyAuthenticated } from '@client/app/hooks/useAccessToken';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 /**
@@ -19,6 +20,9 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
  */
 export const useEntitlements = (options: { enabled?: boolean } = {}) => {
   const { enabled = true } = options;
+  // Gate on the fully-authenticated state so this doesn't fire during the login
+  // mfaPending window, where it would 401 (#804).
+  const isFullyAuthenticated = useIsFullyAuthenticated();
 
   return useQuery({
     queryKey: ['entitlements'],
@@ -29,7 +33,7 @@ export const useEntitlements = (options: { enabled?: boolean } = {}) => {
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: true,
     placeholderData: keepPreviousData,
-    enabled,
+    enabled: enabled && isFullyAuthenticated,
   });
 };
 

--- a/apps/client/app/hooks/data/settings.ts
+++ b/apps/client/app/hooks/data/settings.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import type { ServerConfig } from '@pages/api/settings/serverConfig';
 import type { ServerConfigPublic } from '@pages/api/settings/serverConfigPublic';
 import { ADMIN_SETTINGS_QUERY_KEY, ADMIN_SETTINGS_ARRAY_QUERY_KEY, BRANDING_SETTINGS_QUERY_KEY } from './queryKeys';
-import { useAccessToken } from '../useAccessToken';
+import { useAccessToken, useIsFullyAuthenticated } from '../useAccessToken';
 
 export function useUpdateSettings() {
   const queryClient = useQueryClient();
@@ -152,7 +152,7 @@ export function usePublicConfig() {
 }
 
 export function useConfig() {
-  const accessToken = useAccessToken(s => s.accessToken);
+  const isFullyAuthenticated = useIsFullyAuthenticated();
 
   return useQuery({
     queryKey: ['server-config'],
@@ -163,10 +163,12 @@ export function useConfig() {
     },
     staleTime: 1000 * 60 * 5, // 5 minutes
     refetchOnWindowFocus: false,
-    // Only fetch when authenticated - prevents a 401 race on first login where
+    // Only fetch when fully authenticated - prevents a 401 race on first login where
     // useConfig fires before setAccessToken runs, permanently erroring the query
-    // and leaving the WebSocket URL undefined (stuck on "pending").
-    enabled: !!accessToken,
+    // and leaving the WebSocket URL undefined (stuck on "pending"). Gating on the
+    // fully-authenticated state (not just a token) also keeps it quiet during the
+    // mfaPending window (#804), where a token exists but every request 401s.
+    enabled: isFullyAuthenticated,
     // Override global retry: false - this query provides the WebSocket URL,
     // so transient failures should not permanently block the connection.
     // Skip retries on 401 (unauthenticated) to avoid spurious console errors on login page.

--- a/apps/client/app/hooks/data/settings.ts
+++ b/apps/client/app/hooks/data/settings.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import type { ServerConfig } from '@pages/api/settings/serverConfig';
 import type { ServerConfigPublic } from '@pages/api/settings/serverConfigPublic';
 import { ADMIN_SETTINGS_QUERY_KEY, ADMIN_SETTINGS_ARRAY_QUERY_KEY, BRANDING_SETTINGS_QUERY_KEY } from './queryKeys';
-import { useAccessToken, useIsFullyAuthenticated } from '../useAccessToken';
+import { useAccessToken, useIsFullyAuthenticated } from '@client/app/hooks/useAccessToken';
 
 export function useUpdateSettings() {
   const queryClient = useQueryClient();

--- a/apps/client/app/hooks/data/useModelInfo.ts
+++ b/apps/client/app/hooks/data/useModelInfo.ts
@@ -1,12 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { getModels } from '@client/app/utils/llm';
+import { useIsFullyAuthenticated } from '@client/app/hooks/useAccessToken';
 
 export function useModelInfo() {
+  // Gate on the fully-authenticated state so this doesn't fire during the login
+  // mfaPending window, where /api/models would 401 (#804).
+  const isFullyAuthenticated = useIsFullyAuthenticated();
   return useQuery({
     queryKey: ['llm', 'models'],
     queryFn: getModels,
     staleTime: 60 * 60 * 1000, // 1 hour
-    enabled: true,
+    enabled: isFullyAuthenticated,
     retry: false,
   });
 }

--- a/apps/client/app/hooks/useAccessToken.test.ts
+++ b/apps/client/app/hooks/useAccessToken.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useAccessToken } from './useAccessToken';
+import { renderHook, act } from '@testing-library/react';
+import { useAccessToken, useIsFullyAuthenticated } from './useAccessToken';
 
 describe('useAccessToken store', () => {
   beforeEach(() => {
@@ -96,6 +97,29 @@ describe('useAccessToken store', () => {
       unsubscribe();
 
       expect(writes).toBe(1);
+    });
+  });
+
+  describe('useIsFullyAuthenticated', () => {
+    it('is false during the mfaPending window even though an access token is present', () => {
+      useAccessToken.setState({ accessToken: 'mfa-token', mfaPending: true });
+      const { result } = renderHook(() => useIsFullyAuthenticated());
+      expect(result.current).toBe(false);
+    });
+
+    it('is false with no access token', () => {
+      useAccessToken.setState({ accessToken: null, mfaPending: false });
+      const { result } = renderHook(() => useIsFullyAuthenticated());
+      expect(result.current).toBe(false);
+    });
+
+    it('flips to true the instant MFA verification clears mfaPending (gated queries auto-run)', () => {
+      useAccessToken.setState({ accessToken: 'mfa-token', mfaPending: true });
+      const { result } = renderHook(() => useIsFullyAuthenticated());
+      expect(result.current).toBe(false);
+
+      act(() => useAccessToken.getState().setVerifiedTokens('verified-token', 'refresh'));
+      expect(result.current).toBe(true);
     });
   });
 

--- a/apps/client/app/hooks/useAccessToken.ts
+++ b/apps/client/app/hooks/useAccessToken.ts
@@ -160,3 +160,14 @@ export const useAccessToken = create<{
     }
   )
 );
+
+/**
+ * True only when a fully-verified session is active: an access token is present
+ * AND the session is not mid-MFA. App-shell data queries gate their `enabled` on
+ * this so they don't fire the doomed 401 storm during the login mfaPending window
+ * (#804) - the server rejects every non-allowlisted request while mfaPending
+ * (see server/auth/auth.ts). A mfaPending login DOES carry an access token, so a
+ * bare `!!accessToken` check is not enough. Reactive: flips true the instant MFA
+ * verification clears mfaPending, so gated queries auto-run with no manual refetch.
+ */
+export const useIsFullyAuthenticated = (): boolean => useAccessToken(s => !!s.accessToken && !s.mfaPending);


### PR DESCRIPTION
# Pull Request

Closes #804

## Optional Screenshot/Video

**Before (staging, released build):** during the login mfaPending window (after the email one-time code, before TOTP), the console logs `GET /api/settings/serverConfig 401` plus its paired `Axios Error: {error:'MFA setup or verification required.', mfaPending: true}`. On a browser with a cached prior session the burst is larger (~20 failed fetches / ~40 lines).


https://github.com/user-attachments/assets/b09b1a48-79c4-46d8-802d-c05eb52af7d1



**After (this branch, preview):** the same MFA login flow produces zero `MFA setup or verification required` 401s in the console.


https://github.com/user-attachments/assets/c9405e30-7d79-40b5-a2b6-277529ad6873



## Description

During the login `mfaPending` window (after the email one-time-code verify, before TOTP verify) the authenticated app shell fires its data queries even though the session is not fully authenticated yet. The server's full-auth middleware rejects every non-allowlisted request while mfaPending with `401 {error:'MFA setup or verification required.', mfaPending: true}`, so each failed request plus its Axios error is logged to the console. Net effect: console-error spam on every MFA login that buries real errors and looks alarming during demos and screen-shares.

It was always harmless - once MFA completes, everything loads normally and a fully authenticated reload is quiet - so this is a noise fix, not a functional bug. This PR makes the MFA login console-quiet with no behavior change once verified.

The fix has two parts:

1. **Source reduction** - a new `useIsFullyAuthenticated` selector (`!!accessToken && !mfaPending`) gates the always-on app-shell queries so they don't fire during the mfaPending window. A mfaPending login does carry an access token, so the pre-existing `!!accessToken` gates were not enough. The selector is reactive, so gated queries auto-run the instant MFA verification clears `mfaPending` - no manual refetch.

2. **Comprehensive guarantee** - the shared Axios error handler no longer logs a `mfaPending: true` 401. This is keyed on the server response marker (ground truth), so it covers every such 401 regardless of which query fired, mirroring the expected-mfaPending-401 handling already present in `accept-policies.tsx` and the interceptor's redirect skip.

Scope note: the source gating targets the always-on shell hooks (`config`, `models`, `agents`, `entitlements`). Other shell queries are gated on `!!currentUser`/`!!userId`; because `currentUser` is persisted to localStorage and is not cleared during mfaPending, those can still fire on a same-machine relogin - they are no longer logged as errors (part 2), but they are not fully suppressed at the source. Eliminating the console spam is the goal here; further reducing the wasted requests for the cached-session case is a possible follow-up.

## Changes

- `useAccessToken.ts` - add `useIsFullyAuthenticated()` reactive selector (`!!accessToken && !mfaPending`).
- `ApiContext.tsx` - skip logging a `{ mfaPending: true }` 401 in the shared response interceptor; the existing 401 handling (including the mfaPending redirect skip) is unchanged.
- `settings.ts` (`useConfig`) - gate on `useIsFullyAuthenticated` instead of `!!accessToken` (strictly stronger; still guards the first-login WebSocket-URL race).
- `entitlements.ts` (`useEntitlements`), `agents.ts` (`useGetAgents`), `useModelInfo.ts` - AND the fully-authenticated gate into their `enabled`.
- Tests: `useAccessToken.test.ts` covers the selector (false while mfaPending, false with no token, flips true on verify); `ApiContext.test.tsx` asserts a mfaPending 401 is not console-logged while a normal 401 still is.

## Guide for Testers

Preconditions: an account with TOTP MFA enabled (or an account that will be forced through MFA setup at login).

1. Open the preview link in an incognito/private window so you start signed out.
2. Open DevTools -> Console and enable "Preserve log".
3. (optional) In the console filter box, type `MFA setup or verification` to isolate the relevant lines.
4. Enter your email and submit, then enter the emailed one-time code and submit.
5. Observe: you are now on the "Multi-Factor Authentication Required" step (the mfaPending window). Expected: the console shows NO `MFA setup or verification required` 401 errors during this window.
6. Enter your TOTP code and complete login. Expected: the app loads normally - sessions, agents, models, entitlements, and all shell data are present.

### Regression Checks

1. Non-MFA login (account without MFA, MFA not enforced): sign in and confirm the app loads normally with no new console errors.
2. Post-MFA data load: after completing TOTP, confirm the model list, agents, entitlements, and server config (WebSocket connectivity) all resolve - i.e. the gated queries re-enable once verified.
3. Session expiry / normal 401: trigger an expired-session 401 (non-mfaPending) and confirm it is still logged and still redirects to /login as before.

### What NOT to test

- The server-side allowlist behavior is unchanged; no API or auth-middleware changes in this PR.
- No UI/layout changes - this is console-noise and query-gating only.

## Additional Information

The mfaPending signal already existed client-side (`UserContext` decodes the JWT claim; `useAccessToken` exposes the flag); this PR reuses it rather than introducing new state. The Axios suppression keys on the server response body (`error.response.data.mfaPending === true`) rather than client store state, so it stays correct regardless of store/timing skew.

## Developer Notes (Optional)

- `useIsFullyAuthenticated()` (in `useAccessToken.ts`) is a reusable gate for any query that must not run until a session is fully verified - prefer it over a bare `!!accessToken` check anywhere a mfaPending token would otherwise pass.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - no UI change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
