### PR TITLE
fix(client): unblock self-host browser upload via server proxy URL + authed PUT

### DIFF
--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -16,6 +16,7 @@ import { activeOrgId } from '@client/app/hooks/data/dataLakes';
 import type { WizardFile } from '@client/app/utils/folderTreeParser';
 import { computeFileHash } from '@client/app/utils/folderTreeParser';
 import axios from 'axios';
+import { uploadFileToUrl } from '@client/app/utils/uploadFileToUrl';
 
 /**
  * Derive a single tag for a file from its immediate parent folder, so each file
@@ -279,12 +280,12 @@ function slugify(text: string): string {
 }
 
 /**
- * Upload a single file to S3 using a presigned URL.
+ * Upload one file to the URL the server returned - a same-origin proxy (self-host) or an
+ * S3 presigned URL (hosted). The auth routing (authenticated api client vs raw axios) lives
+ * in uploadFileToUrl so this and the single-file path stay in sync.
  */
 async function uploadFileToS3(url: string, file: File): Promise<void> {
-  await axios.put(url, file, {
-    headers: { 'Content-Type': file.type || 'application/octet-stream' },
-  });
+  await uploadFileToUrl(url, file, file.type);
 }
 
 /**

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -21,7 +21,7 @@ import { getContentFromFabfile as getContentFromFabfileInString } from '@client/
 import { isOptimisticId } from '@client/app/utils/llm';
 import { getErrorMessage } from '@client/app/utils/error';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
+import { uploadFileToUrl } from '@client/app/utils/uploadFileToUrl';
 import { ActualFileObject } from 'filepond';
 import { toast } from 'sonner';
 
@@ -118,11 +118,7 @@ export function useCreateFabFileWithUpload(options?: {
       const newFabFile = await createFabFileOnServer(formData);
       // If the file has a presigned URL, upload it to the bucket
       if (newFabFile.presignedUrl) {
-        await axios.put(newFabFile.presignedUrl, file, {
-          headers: {
-            'Content-Type': file.type,
-          },
-        });
+        await uploadFileToUrl(newFabFile.presignedUrl, file, file.type);
       }
 
       // Optimistically add to the first page of fab files queries

--- a/apps/client/app/utils/filesAPICalls.ts
+++ b/apps/client/app/utils/filesAPICalls.ts
@@ -10,6 +10,7 @@ import axios from 'axios';
 import { ActualFileObject } from 'filepond';
 import type { fabFilesService } from '@bike4mind/services';
 import { resizeImageFile, isImageFile } from './imageResizer';
+import { uploadFileToUrl } from './uploadFileToUrl';
 
 export const getFabFilesFromServer = async (args?: fabFilesService.SearchFabFilesParameters) => {
   console.log('getFabFilesFromServer', args);
@@ -89,10 +90,9 @@ export const createFabFileOnServerWithUpload = async (
 
     // If the a file has a presigned URL, upload the file to the bucket
     if (newFabFile.presignedUrl) {
-      const putConfig = {
-        headers: {
-          'Content-Type': fileToUpload.type,
-        },
+      // Shared helper routes the self-host proxy path through the authed `api` client and the
+      // hosted S3 presign through raw axios, so this call-site can't drift from the others.
+      await uploadFileToUrl(newFabFile.presignedUrl, fileToUpload, fileToUpload.type, {
         signal: abortSignal,
         onUploadProgress: onProgress
           ? (progressEvent: { total?: number; loaded: number }) => {
@@ -101,15 +101,7 @@ export const createFabFileOnServerWithUpload = async (
               onProgress(loaded, total);
             }
           : undefined,
-      };
-      // Self-host returns a same-origin proxy path (leading '/') that needs the app's auth;
-      // the hosted S3 presign is an absolute, self-authenticating URL. Route the proxy through
-      // the authenticated `api` client, the S3 presign through raw axios (no app auth/cookies).
-      if (newFabFile.presignedUrl.startsWith('/')) {
-        await api.put(newFabFile.presignedUrl, fileToUpload, putConfig);
-      } else {
-        await axios.put(newFabFile.presignedUrl, fileToUpload, putConfig);
-      }
+      });
 
       // Check abort before presigned URL generation
       if (abortSignal?.aborted) {

--- a/apps/client/app/utils/uploadFileToUrl.test.ts
+++ b/apps/client/app/utils/uploadFileToUrl.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { axiosPut, apiPut } = vi.hoisted(() => ({ axiosPut: vi.fn(), apiPut: vi.fn() }));
+vi.mock('axios', () => ({ default: { put: axiosPut } }));
+vi.mock('@client/app/contexts/ApiContext', () => ({ api: { put: apiPut } }));
+
+import { uploadFileToUrl } from './uploadFileToUrl';
+
+describe('uploadFileToUrl', () => {
+  afterEach(() => vi.clearAllMocks());
+  const file = new Blob(['hello']);
+
+  it('uses the authenticated api client for a same-origin proxy path (self-host)', async () => {
+    await uploadFileToUrl('/api/files/abc123/upload', file, 'text/markdown');
+    expect(apiPut).toHaveBeenCalledTimes(1);
+    expect(axiosPut).not.toHaveBeenCalled();
+    expect(apiPut.mock.calls[0][0]).toBe('/api/files/abc123/upload');
+  });
+
+  it('uses raw axios (no app auth) for an absolute S3 presigned URL (hosted)', async () => {
+    const s3 = 'https://bucket.s3.us-east-2.amazonaws.com/key.md?sig=x';
+    await uploadFileToUrl(s3, file, 'text/markdown');
+    expect(axiosPut).toHaveBeenCalledTimes(1);
+    expect(apiPut).not.toHaveBeenCalled();
+    expect(axiosPut.mock.calls[0][0]).toBe(s3);
+  });
+});

--- a/apps/client/app/utils/uploadFileToUrl.test.ts
+++ b/apps/client/app/utils/uploadFileToUrl.test.ts
@@ -24,4 +24,21 @@ describe('uploadFileToUrl', () => {
     expect(apiPut).not.toHaveBeenCalled();
     expect(axiosPut.mock.calls[0][0]).toBe(s3);
   });
+
+  it('sends protocol-relative URLs through raw axios, never the authed api client', async () => {
+    // '//host/...' passes startsWith('/'); guard it so the Bearer never reaches a foreign origin.
+    await uploadFileToUrl('//evil.example.com/key.md', file, 'text/markdown');
+    expect(axiosPut).toHaveBeenCalledTimes(1);
+    expect(apiPut).not.toHaveBeenCalled();
+  });
+
+  it('forwards request config (signal, onUploadProgress) and Content-Type to the put call', async () => {
+    const signal = new AbortController().signal;
+    const onUploadProgress = vi.fn();
+    await uploadFileToUrl('/api/files/abc/upload', file, 'text/markdown', { signal, onUploadProgress });
+    const cfg = apiPut.mock.calls[0][2];
+    expect(cfg.signal).toBe(signal);
+    expect(cfg.onUploadProgress).toBe(onUploadProgress);
+    expect(cfg.headers['Content-Type']).toBe('text/markdown');
+  });
 });

--- a/apps/client/app/utils/uploadFileToUrl.ts
+++ b/apps/client/app/utils/uploadFileToUrl.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { type AxiosRequestConfig } from 'axios';
 import { api } from '@client/app/contexts/ApiContext';
 
 /**
@@ -9,15 +9,27 @@ import { api } from '@client/app/contexts/ApiContext';
  * - Same-origin proxy path (self-host, starts with '/'): the authenticated `api` client, because
  *   pages/api/files/[id]/upload.ts is a normal baseApi route that needs the Bearer token.
  *
- * Shared by the single-file (fabFiles) and batch/data-lake (dataLakeWizard) upload paths so the
- * two can't diverge - they did, and self-host uploads 401'd against the proxy.
- * Pairs with the server-side resolveBrowserUploadUrl, which decides which URL shape to return.
+ * Shared by the single-file (fabFiles), batch/data-lake (dataLakeWizard), and generic
+ * (filesAPICalls) upload paths so they can't diverge - they did, and self-host uploads 401'd
+ * against the proxy. Pairs with the server-side resolveBrowserUploadUrl, which decides the URL
+ * shape. `config` forwards axios options (signal, onUploadProgress); Content-Type is always set here.
  */
-export async function uploadFileToUrl(url: string, file: File | Blob, contentType?: string): Promise<void> {
-  const headers = { 'Content-Type': contentType || (file as File).type || 'application/octet-stream' };
-  if (url.startsWith('/')) {
-    await api.put(url, file, { headers });
+export async function uploadFileToUrl(
+  url: string,
+  file: File | Blob,
+  contentType?: string,
+  config?: AxiosRequestConfig
+): Promise<void> {
+  const putConfig: AxiosRequestConfig = {
+    ...config,
+    headers: { 'Content-Type': contentType || file.type || 'application/octet-stream' },
+  };
+  // Same-origin proxy path (self-host) needs the app's Bearer via `api`; an absolute S3 presign
+  // authorizes via its own signature and must use raw axios. Exclude protocol-relative '//host/...'
+  // (also passes startsWith('/')) so the Bearer can never be sent to a foreign origin.
+  if (url.startsWith('/') && !url.startsWith('//')) {
+    await api.put(url, file, putConfig);
   } else {
-    await axios.put(url, file, { headers });
+    await axios.put(url, file, putConfig);
   }
 }

--- a/apps/client/app/utils/uploadFileToUrl.ts
+++ b/apps/client/app/utils/uploadFileToUrl.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { api } from '@client/app/contexts/ApiContext';
+
+/**
+ * PUT a new file's bytes to the upload URL the server handed back.
+ *
+ * - Absolute S3 presigned URL (hosted): raw `axios`, with NO app auth - S3 authorizes via the
+ *   signature baked into the URL and rejects unexpected auth headers.
+ * - Same-origin proxy path (self-host, starts with '/'): the authenticated `api` client, because
+ *   pages/api/files/[id]/upload.ts is a normal baseApi route that needs the Bearer token.
+ *
+ * Shared by the single-file (fabFiles) and batch/data-lake (dataLakeWizard) upload paths so the
+ * two can't diverge - they did, and self-host uploads 401'd against the proxy.
+ * Pairs with the server-side resolveBrowserUploadUrl, which decides which URL shape to return.
+ */
+export async function uploadFileToUrl(url: string, file: File | Blob, contentType?: string): Promise<void> {
+  const headers = { 'Content-Type': contentType || (file as File).type || 'application/octet-stream' };
+  if (url.startsWith('/')) {
+    await api.put(url, file, { headers });
+  } else {
+    await axios.put(url, file, { headers });
+  }
+}

--- a/apps/client/pages/api/files/createFabFile.ts
+++ b/apps/client/pages/api/files/createFabFile.ts
@@ -6,6 +6,7 @@ import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { BadRequestError } from '@server/utils/errors';
 import { getFilesStorage } from '@server/utils/storage';
+import { resolveBrowserUploadUrl } from '@server/utils/browserUploadUrl';
 
 const createFabFileSchema = fabFilesService.createFabFileSchema;
 
@@ -59,13 +60,11 @@ const handler = baseApi()
         { ability: req.ability }
       );
 
-      // Self-host: the direct S3 presign targets the internal MinIO host (unreachable from a
-      // browser and blocked by CSP connect-src). Hand back a same-origin proxy URL instead;
-      // it streams the PUT to storage server-side (pages/api/files/[id]/upload.ts) and writes
-      // the same key, so the MinIO webhook + ingestion pipeline fire unchanged. Hosted keeps
-      // the direct presign (byte-identical).
-      if (process.env.B4M_SELF_HOST === 'true' && result.presignedUrl) {
-        result.presignedUrl = `/api/files/${result.id}/upload`;
+      // Route the browser's upload via the shared resolver: hosted keeps the direct S3 presign;
+      // self-host returns a same-origin proxy (S3/MinIO isn't browser-reachable). Shared with the
+      // batch path (generate-presigned-urls-batch) so the two upload entry points can't diverge.
+      if (result.presignedUrl) {
+        result.presignedUrl = resolveBrowserUploadUrl(result.id, result.presignedUrl);
       }
 
       return res.json(result);

--- a/apps/client/pages/api/files/generate-presigned-urls-batch.ts
+++ b/apps/client/pages/api/files/generate-presigned-urls-batch.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Request } from 'express';
 import { Resource } from 'sst';
 import { toAccessContext } from '@server/dataLakes/toAccessContext';
+import { resolveBrowserUploadUrl } from '@server/utils/browserUploadUrl';
 
 const s3Client = new S3Client();
 const EXPIRES = 600; // 10 minutes
@@ -132,7 +133,11 @@ const handler = baseApi().post(async (req: Request, res) => {
         Key: fileKey,
       });
 
-      const url = await getSignedUrl(s3Client, command, { expiresIn: EXPIRES });
+      // Hosted returns the direct S3 presign; self-host returns a same-origin proxy URL
+      // (S3/MinIO isn't browser-reachable). Shared with the single-file path (createFabFile)
+      // so the two upload entry points can't diverge.
+      const presignedUrl = await getSignedUrl(s3Client, command, { expiresIn: EXPIRES });
+      const url = resolveBrowserUploadUrl(file.id, presignedUrl);
 
       return {
         fileId: file.id,

--- a/apps/client/server/utils/browserUploadUrl.test.ts
+++ b/apps/client/server/utils/browserUploadUrl.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveBrowserUploadUrl } from './browserUploadUrl';
+
+describe('resolveBrowserUploadUrl', () => {
+  afterEach(() => {
+    delete process.env.B4M_SELF_HOST;
+  });
+
+  it('returns the same-origin proxy route in self-host (S3/MinIO is not browser-reachable)', () => {
+    process.env.B4M_SELF_HOST = 'true';
+    expect(resolveBrowserUploadUrl('abc123', 'http://b4m-fab-file.localhost:9000/key.md?sig=x')).toBe(
+      '/api/files/abc123/upload'
+    );
+  });
+
+  it('returns the direct S3 presigned URL when hosted', () => {
+    process.env.B4M_SELF_HOST = 'false';
+    const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/key.md?sig=x';
+    expect(resolveBrowserUploadUrl('abc123', presigned)).toBe(presigned);
+  });
+
+  it('treats an unset B4M_SELF_HOST as hosted (returns the presign unchanged)', () => {
+    delete process.env.B4M_SELF_HOST;
+    const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/key.md?sig=x';
+    expect(resolveBrowserUploadUrl('abc123', presigned)).toBe(presigned);
+  });
+});

--- a/apps/client/server/utils/browserUploadUrl.ts
+++ b/apps/client/server/utils/browserUploadUrl.ts
@@ -1,0 +1,16 @@
+/**
+ * The URL a browser should PUT a new file's bytes to.
+ *
+ * Hosted (AWS): the direct S3 presigned URL - the browser uploads straight to S3.
+ * Self-host: S3 (MinIO) is not browser-reachable and the presign is blocked by the CSP
+ * connect-src allow-list, so return a same-origin proxy route (pages/api/files/[id]/upload.ts)
+ * that streams the PUT to storage server-side under the same key - the MinIO ObjectCreated
+ * webhook + chunk/vectorize pipeline fire unchanged.
+ *
+ * Both upload entry points - single-file (createFabFile) and batch
+ * (generate-presigned-urls-batch, the data-lake wizard path) - MUST route through this so the
+ * two can't diverge. They did: the batch path was missing the rewrite, so every self-host
+ * data-lake upload hit the CSP-blocked MinIO host and failed.
+ */
+export const resolveBrowserUploadUrl = (fileId: string, directPresignedUrl: string): string =>
+  process.env.B4M_SELF_HOST === 'true' ? `/api/files/${fileId}/upload` : directPresignedUrl;


### PR DESCRIPTION
## Description

Self-host has no browser-reachable object store, so the browser's direct presigned PUT to storage is blocked by CSP and Data Lake (and any direct) uploads fail. This routes uploads through the same-origin server proxy on self-host, while keeping S3 presigned direct uploads unchanged on hosted deployments.

Part of #848 (Data Lake: correctness & self-host unblock).

## Changes

- Add `resolveBrowserUploadUrl` (server): self-host -> same-origin `/api/files/{id}/upload`; hosted -> the S3 presigned URL. Wired into `generate-presigned-urls-batch.ts` (the missing self-host branch = the root cause) and `createFabFile.ts`.
- Add `uploadFileToUrl` (client): same-origin proxy PUT via the authenticated `api` client (Bearer); absolute S3 URL via raw axios. Wired into `dataLakeWizard.ts` (batch upload) and `fabFiles.ts` (single-file upload). Fixes the 401 on the proxy path.
- Unit tests for both helpers.

## Guide for Testers

1. Run the stack in self-host mode (`B4M_SELF_HOST=true`).
2. As an admin, enable the `EnableDataLakes` admin setting.
3. Navigate to `/data-lakes` and create a lake, uploading a few small files.
4. Expected: uploads complete with no CSP/console errors and the files reach `complete` status.
5. Regression (hosted): on a normal cloud deploy, uploads continue to use S3 presigned URLs unchanged.

## What NOT to test

- The chunking/vectorization pipeline (separate concern; needs the background worker running and a real embedding key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
