### PR TITLE
fix(client): show Data Lakes nav whenever the feature is enabled

### DIFF
--- a/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
@@ -153,7 +153,11 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
     // It opens the user's own lakes (browse + manage) at /data-lakes, so a non-Opti
     // user with the feature can reach their lakes too (was previously elided when
     // Opti was off, and pointed at the Opti static-registry explorer when on).
-    ...(isDataLakesEnabled && gearOpen('datalakes')
+    // Gated ONLY on the EnableDataLakes admin flag, deliberately NOT earned-nav: an
+    // admin explicitly turns this feature on, so it must be discoverable immediately.
+    // Earned-nav here was a bootstrapping trap - the row only appeared AFTER a lake
+    // existed, yet the row is how a first-time user reaches the create/manage UI.
+    ...(isDataLakesEnabled
       ? [
           {
             key: 'datalakes',


### PR DESCRIPTION
## Description

The sidebar "Data Lakes" entry was gated behind the earned-nav gear, which only unlocks after a lake exists - a bootstrapping trap, since that entry is how a first-time user reaches the create/manage UI. Gate it on the `EnableDataLakes` admin flag only, so an admin who turns the feature on can find it immediately.

Part of #850 (Data Lake: discoverability & first-run).

## Changes

- `SidenavNav.tsx`: gate the Data Lakes row on `isDataLakesEnabled` only (drop the `gearOpen('datalakes')` earned-nav condition), with a comment explaining why it is deliberately not earned-nav.

## Guide for Testers

1. As an admin, enable the `EnableDataLakes` admin setting (with no Data Lakes created yet).
2. Reload the app.
3. Expected: the "Data Lakes" entry is visible in the sidebar immediately (previously it appeared only after creating the first lake and reloading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
