### PR TITLE
feat(admin): list user API keys with per-key rate-limit reset

### DIFF
--- a/apps/client/app/components/admin/Users/Details/AdminApiKeysModal.test.tsx
+++ b/apps/client/app/components/admin/Users/Details/AdminApiKeysModal.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import AdminApiKeysModal from './AdminApiKeysModal';
+import { toast } from 'sonner';
+
+const h = vi.hoisted(() => ({
+  keys: [] as Record<string, unknown>[],
+  liveUsage: {} as Record<string, { minute: number; day: number }>,
+  resetMutate: vi.fn(),
+  // Auto-invokes onOk so the confirm-then-mutate flow runs synchronously;
+  // individual tests override the implementation to model a dismissal.
+  confirmRun: vi.fn((opts: { onOk?: () => void | Promise<void> }) => opts.onOk?.()),
+}));
+
+vi.mock('@client/app/hooks/data/userApiKeys', () => ({
+  useAdminGetUserApiKeys: () => ({
+    data: { apiKeys: h.keys, liveUsage: h.liveUsage },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useAdminResetApiKeyRateLimit: () => ({ mutate: h.resetMutate, isPending: false }),
+}));
+
+vi.mock('@client/app/hooks/useConfirmation', () => ({
+  useConfirmation: () => h.confirmRun,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const USER = { id: 'u1', username: 'target-user' } as never;
+
+const renderModal = () =>
+  render(
+    <CssVarsProvider theme={appTheme}>
+      <AdminApiKeysModal open onClose={vi.fn()} user={USER} />
+    </CssVarsProvider>
+  );
+
+const KEY = {
+  id: 'k1',
+  name: 'pipeline key',
+  keyPrefix: 'b4m_live_abc',
+  scopes: ['chat'],
+  status: 'active',
+  rateLimit: { requestsPerMinute: 60, requestsPerDay: 1000 },
+};
+
+beforeEach(() => {
+  h.keys = [];
+  h.liveUsage = {};
+  h.resetMutate.mockReset();
+  h.confirmRun.mockClear();
+  h.confirmRun.mockImplementation((opts: { onOk?: () => void | Promise<void> }) => opts.onOk?.());
+});
+
+describe('AdminApiKeysModal', () => {
+  it('renders each key with its live counters', () => {
+    h.keys = [KEY, { ...KEY, id: 'k2', name: 'idle key', status: 'disabled' }];
+    h.liveUsage = { k1: { minute: 3, day: 42 }, k2: { minute: 0, day: 0 } };
+    renderModal();
+
+    expect(screen.getByTestId('admin-api-key-row-k1')).toBeTruthy();
+    expect(screen.getByTestId('admin-api-key-row-k2')).toBeTruthy();
+    expect(screen.getByTestId('admin-api-key-usage-k1').textContent).toContain('3/60 per min');
+    expect(screen.getByTestId('admin-api-key-usage-k1').textContent).toContain('42/1000 per day');
+    expect(screen.getByTestId('admin-api-key-status-k1').textContent).toBe('Active');
+    expect(screen.getByTestId('admin-api-key-status-k2').textContent).toBe('Disabled');
+  });
+
+  it('flags an active key whose live counter sits at its limit as rate limited', () => {
+    h.keys = [KEY];
+    h.liveUsage = { k1: { minute: 60, day: 500 } };
+    renderModal();
+
+    expect(screen.getByTestId('admin-api-key-status-k1').textContent).toBe('Rate limited');
+  });
+
+  it('confirms with a danger dialog and resets the right key on OK', () => {
+    h.keys = [KEY];
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('admin-api-key-reset-rate-limit-btn-k1'));
+
+    expect(h.confirmRun).toHaveBeenCalledWith(expect.objectContaining({ type: 'danger' }));
+    expect(h.resetMutate).toHaveBeenCalledTimes(1);
+    expect(h.resetMutate.mock.calls[0][0]).toBe('k1');
+  });
+
+  it('shows a success toast when the reset lands', () => {
+    h.keys = [KEY];
+    h.resetMutate.mockImplementation((_id: string, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.());
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('admin-api-key-reset-rate-limit-btn-k1'));
+
+    expect(vi.mocked(toast.success)).toHaveBeenCalled();
+  });
+
+  it('does not reset when the confirmation is dismissed', () => {
+    h.keys = [KEY];
+    h.confirmRun.mockImplementation(() => undefined);
+    renderModal();
+
+    fireEvent.click(screen.getByTestId('admin-api-key-reset-rate-limit-btn-k1'));
+
+    expect(h.confirmRun).toHaveBeenCalled();
+    expect(h.resetMutate).not.toHaveBeenCalled();
+  });
+
+  it('shows the empty state for a user with no keys', () => {
+    renderModal();
+
+    expect(screen.getByTestId('admin-api-keys-empty')).toBeTruthy();
+    expect(screen.queryByTestId('admin-api-key-row-k1')).toBeNull();
+  });
+});

--- a/apps/client/app/components/admin/Users/Details/AdminApiKeysModal.tsx
+++ b/apps/client/app/components/admin/Users/Details/AdminApiKeysModal.tsx
@@ -68,7 +68,9 @@ export default function AdminApiKeysModal({ open, onClose, user }: AdminApiKeysM
         setResettingKeyId(key.id);
         resetMutation.mutate(key.id, {
           onSuccess: () => toast.success(`Rate limit reset for "${key.name}"`),
-          onSettled: () => setResettingKeyId(null),
+          // Clear only our own row: a later reset on another row may already
+          // own the spinner when this settle lands.
+          onSettled: () => setResettingKeyId(prev => (prev === key.id ? null : prev)),
         });
       },
     });

--- a/apps/client/app/components/admin/Users/Details/AdminApiKeysModal.tsx
+++ b/apps/client/app/components/admin/Users/Details/AdminApiKeysModal.tsx
@@ -1,0 +1,159 @@
+import { useAdminGetUserApiKeys, useAdminResetApiKeyRateLimit } from '@client/app/hooks/data/userApiKeys';
+import { useConfirmation } from '@client/app/hooks/useConfirmation';
+import { ApiKeyStatus, IUserApiKeyDocument, IUserDocument } from '@bike4mind/common';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Modal,
+  ModalDialog,
+  Table,
+  Tooltip,
+  Typography,
+} from '@mui/joy';
+import { tableHeaderSx } from '@client/app/components/ProfileModal/settingsStyles';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
+
+interface AdminApiKeysModalProps {
+  open: boolean;
+  onClose: () => void;
+  user: IUserDocument;
+}
+
+const STATUS_CHIP: Record<ApiKeyStatus, { color: 'success' | 'neutral' | 'warning' | 'danger'; label: string }> = {
+  [ApiKeyStatus.ACTIVE]: { color: 'success', label: 'Active' },
+  [ApiKeyStatus.DISABLED]: { color: 'danger', label: 'Disabled' },
+  [ApiKeyStatus.EXPIRED]: { color: 'neutral', label: 'Expired' },
+  [ApiKeyStatus.RATE_LIMITED]: { color: 'warning', label: 'Rate limited' },
+};
+
+export default function AdminApiKeysModal({ open, onClose, user }: AdminApiKeysModalProps) {
+  const { data, isLoading, error, refetch } = useAdminGetUserApiKeys(open ? user.id : undefined);
+  const resetMutation = useAdminResetApiKeyRateLimit();
+  const confirm = useConfirmation();
+  const [resettingKeyId, setResettingKeyId] = useState<string | null>(null);
+
+  const usageFor = (key: IUserApiKeyDocument) => data?.liveUsage[key.id] ?? { minute: 0, day: 0 };
+
+  // The rate_limited status value is never persisted on key docs; a wedged key
+  // is detected from the live cache counters sitting at their ceiling.
+  const isWedged = (key: IUserApiKeyDocument) => {
+    const usage = usageFor(key);
+    return usage.minute >= key.rateLimit.requestsPerMinute || usage.day >= key.rateLimit.requestsPerDay;
+  };
+
+  const statusChip = (key: IUserApiKeyDocument) => {
+    if (key.status === ApiKeyStatus.ACTIVE && isWedged(key)) {
+      return STATUS_CHIP[ApiKeyStatus.RATE_LIMITED];
+    }
+    return STATUS_CHIP[key.status] ?? { color: 'neutral' as const, label: key.status };
+  };
+
+  const handleReset = (key: IUserApiKeyDocument) => {
+    confirm({
+      title: 'Reset rate limit',
+      description: `Reset the minute and day rate-limit counters for "${key.name}"? The next request opens a fresh window.`,
+      type: 'danger',
+      onOk: () => {
+        setResettingKeyId(key.id);
+        resetMutation.mutate(key.id, {
+          onSuccess: () => toast.success(`Rate limit reset for "${key.name}"`),
+          onSettled: () => setResettingKeyId(null),
+        });
+      },
+    });
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <ModalDialog size="lg" sx={{ width: '900px', maxWidth: '95vw', maxHeight: '90vh', overflow: 'auto' }}>
+        <Typography level="h4">API Keys for {user.username}</Typography>
+
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress data-testid="admin-api-keys-loading" />
+          </Box>
+        ) : error ? (
+          <Alert color="danger" data-testid="admin-api-keys-error">
+            Failed to load API keys.
+            <Button size="sm" variant="outlined" color="danger" onClick={() => refetch()}>
+              Retry
+            </Button>
+          </Alert>
+        ) : !data || data.apiKeys.length === 0 ? (
+          <Alert color="neutral" startDecorator={<InfoOutlinedIcon />} data-testid="admin-api-keys-empty">
+            This user has no API keys.
+          </Alert>
+        ) : (
+          <Table stickyHeader hoverRow sx={{ '& thead th': tableHeaderSx }}>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Key Prefix</th>
+                <th>Scopes</th>
+                <th>Status</th>
+                <th>Rate limit</th>
+                <th>Last Used</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.apiKeys.map(key => {
+                const usage = usageFor(key);
+                const chip = statusChip(key);
+                return (
+                  <tr key={key.id} data-testid={`admin-api-key-row-${key.id}`}>
+                    <td>{key.name}</td>
+                    <td>
+                      <Typography level="body-xs" sx={{ fontFamily: 'monospace' }}>
+                        {key.keyPrefix}
+                      </Typography>
+                    </td>
+                    <td>{key.scopes.join(', ')}</td>
+                    <td>
+                      <Chip variant="soft" color={chip.color} data-testid={`admin-api-key-status-${key.id}`}>
+                        {chip.label}
+                      </Chip>
+                    </td>
+                    <td data-testid={`admin-api-key-usage-${key.id}`}>
+                      <Typography level="body-xs">
+                        {usage.minute}/{key.rateLimit.requestsPerMinute} per min
+                      </Typography>
+                      <Typography level="body-xs">
+                        {usage.day}/{key.rateLimit.requestsPerDay} per day
+                      </Typography>
+                    </td>
+                    <td>{key.lastUsedAt ? dayjs(key.lastUsedAt).fromNow() : 'Never'}</td>
+                    <td>
+                      <Tooltip title="Reset rate limit">
+                        <IconButton
+                          size="sm"
+                          variant="outlined"
+                          onClick={() => handleReset(key)}
+                          loading={resetMutation.isPending && resettingKeyId === key.id}
+                          data-testid={`admin-api-key-reset-rate-limit-btn-${key.id}`}
+                        >
+                          <RestartAltIcon />
+                        </IconButton>
+                      </Tooltip>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        )}
+      </ModalDialog>
+    </Modal>
+  );
+}

--- a/apps/client/app/components/admin/Users/Details/UserDetails.tsx
+++ b/apps/client/app/components/admin/Users/Details/UserDetails.tsx
@@ -2,6 +2,7 @@ import { EditedFieldsState } from '@client/app/components/admin/Users/Views/Full
 
 import GrantSubscriptionModal from './GrantSubscriptionModal';
 import AdminGenerateApiKeyModal from './AdminGenerateApiKeyModal';
+import AdminApiKeysModal from './AdminApiKeysModal';
 import MFAStatusBadge from '../MFAStatusBadge';
 import { useForceResetMFA } from '@client/app/hooks/data/mfa';
 import { useConfirmation } from '@client/app/hooks/useConfirmation';
@@ -28,6 +29,7 @@ const UserDetails: React.FC<UserDetailsProps> = ({ user, editedFields, onFieldCh
   const [organizationName, setOrganizationName] = useState<string | null>(user.organizationId?.name ?? null);
   const [isGrantSubscriptionModalOpen, setIsGrantSubscriptionModalOpen] = useState(false);
   const [isGenerateApiKeyModalOpen, setIsGenerateApiKeyModalOpen] = useState(false);
+  const [isApiKeysModalOpen, setIsApiKeysModalOpen] = useState(false);
   const queryClient = useQueryClient();
 
   const forceResetMFA = useForceResetMFA();
@@ -371,6 +373,16 @@ const UserDetails: React.FC<UserDetailsProps> = ({ user, editedFields, onFieldCh
             Generate API Key
           </Button>
 
+          <Button
+            startDecorator={<KeyIcon />}
+            color="neutral"
+            variant="outlined"
+            onClick={() => setIsApiKeysModalOpen(true)}
+            data-testid="admin-api-keys-btn"
+          >
+            View API Keys
+          </Button>
+
           {user.mfa && user.mfa.totpEnabled && (
             <Alert color="neutral" size="sm">
               User has MFA enabled since {new Date(user.mfa.setupAt).toLocaleDateString()}
@@ -391,6 +403,8 @@ const UserDetails: React.FC<UserDetailsProps> = ({ user, editedFields, onFieldCh
         open={isGenerateApiKeyModalOpen}
         onClose={() => setIsGenerateApiKeyModalOpen(false)}
       />
+
+      <AdminApiKeysModal user={user} open={isApiKeysModalOpen} onClose={() => setIsApiKeysModalOpen(false)} />
     </>
   );
 };

--- a/apps/client/app/hooks/data/userApiKeys.ts
+++ b/apps/client/app/hooks/data/userApiKeys.ts
@@ -155,13 +155,54 @@ export function useUpdateEmbedKey({ onSuccess }: { onSuccess?: () => void } = {}
 }
 
 export function useAdminGenerateApiKey({ onSuccess }: { onSuccess?: (result: CreateUserApiKeyResponse) => void } = {}) {
+  const queryClient = useQueryClient();
+
   return useMutation<CreateUserApiKeyResponse, Error, { userId: string; data: CreateUserApiKeyRequest }>({
     mutationFn: async ({ userId, data }) => {
       const response = await api.post(`/api/admin/users/${userId}/generate-api-key`, data);
       return response.data;
     },
     onSuccess: result => {
+      // Keep the admin key list coherent when both modals are in play.
+      queryClient.invalidateQueries({ queryKey: ['admin', 'user-api-keys'] });
       if (onSuccess) onSuccess(result);
+    },
+    onError: (error: Error) => {
+      toast.error(parseValidationError(error));
+    },
+  });
+}
+
+/** Response of GET /api/admin/users/[userId]/user-api-keys: the user's keys plus
+ * each key's live minute/day rate-limit counters (keyed by key id) - the
+ * usage fields on the key doc itself are not maintained. */
+export interface AdminUserApiKeysResponse {
+  apiKeys: IUserApiKeyDocument[];
+  liveUsage: Record<string, { minute: number; day: number }>;
+}
+
+export function useAdminGetUserApiKeys(userId: string | undefined) {
+  return useQuery<AdminUserApiKeysResponse>({
+    queryKey: ['admin', 'user-api-keys', userId],
+    queryFn: async () => {
+      const response = await api.get(`/api/admin/users/${userId}/user-api-keys`);
+      return response.data;
+    },
+    enabled: typeof userId === 'string' && userId.length > 0,
+  });
+}
+
+export function useAdminResetApiKeyRateLimit({ onSuccess }: { onSuccess?: () => void } = {}) {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ success: boolean; id: string }, Error, string>({
+    mutationFn: async keyId => {
+      const response = await api.post(`/api/admin/user-api-keys/${keyId}/reset-rate-limit`);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'user-api-keys'] });
+      if (onSuccess) onSuccess();
     },
     onError: (error: Error) => {
       toast.error(parseValidationError(error));

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/user-api-keys.e2e.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/user-api-keys.e2e.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../../../../../packages/database/src/__test__/createMongoServer';
+import { userApiKeyRepository } from '@bike4mind/database/auth';
+import { checkApiKeyRateLimit } from '@server/utils/apiKeyRateLimitCheck';
+import { ApiKeyScope } from '@bike4mind/common';
+
+/**
+ * Agreement test for the admin key list, driving the REAL repository, model,
+ * and cache against createMongoServer. The unit test mocks the service, so
+ * only this test proves the serialization invariant the route depends on:
+ * hydrated docs pass through the model's toJSON transform and keyHash never
+ * reaches the wire (a .lean()/POJO regression on any layer of this path would
+ * fail here). It also pins liveUsage against the real enforcer's counters.
+ * Consumes the built dist, so `pnpm turbo:core:build` must be current.
+ */
+
+const { mockUserFind } = vi.hoisted(() => ({ mockUserFind: vi.fn() }));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
+      {
+        use: () => chain,
+        get: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.GET = fns[fns.length - 1]), chain),
+      }
+    );
+    return chain;
+  },
+}));
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: (req: unknown, res: unknown) => unknown) => fn,
+}));
+
+// Keep the real package (cacheRepository backs the live counters); stub only
+// the user lookup so no User doc fixture is needed.
+vi.mock('@bike4mind/database', async importOriginal => {
+  const actual = await importOriginal<typeof import('@bike4mind/database')>();
+  return { ...actual, userRepository: { findById: (...a: unknown[]) => mockUserFind(...a) } };
+});
+
+import handler from '../user-api-keys';
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 30000);
+afterEach(async () => {
+  await mongoose.connection.dropDatabase();
+  mockUserFind.mockReset();
+});
+
+const run = (userId: string) => {
+  const { req, res } = createMocks({ method: 'GET', query: { userId } });
+  (req as Record<string, unknown>).user = { id: 'admin1', isAdmin: true };
+  return { res, promise: (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res) };
+};
+
+describe('GET /api/admin/users/:userId/user-api-keys (end-to-end, real model + Mongo)', () => {
+  it('serializes real key docs without keyHash and reports the enforcer-visible counters', async () => {
+    mockUserFind.mockResolvedValue({ id: 'target-user' });
+    const created = await userApiKeyRepository.create({
+      userId: 'target-user',
+      name: 'wedgeable key',
+      keyHash: '$2b$12$abcdefghijklmnopqrstuv',
+      keyPrefix: 'b4m_live_e2e00001',
+      scopes: [ApiKeyScope.AI_CHAT],
+      metadata: { createdFrom: 'dashboard' },
+    });
+
+    // Real traffic through the real enforcer: two requests land on the counters.
+    await checkApiKeyRateLimit(created.id, { requestsPerMinute: 5, requestsPerDay: 100 });
+    await checkApiKeyRateLimit(created.id, { requestsPerMinute: 5, requestsPerDay: 100 });
+
+    const { res, promise } = run('target-user');
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    // Reproduce the wire format: real res.json serializes via JSON.stringify,
+    // which is what applies the model's toJSON transform.
+    const body = JSON.parse(JSON.stringify(res._getJSONData()));
+
+    expect(body.apiKeys).toHaveLength(1);
+    const [key] = body.apiKeys;
+    expect(key.keyPrefix).toBe('b4m_live_e2e00001');
+    expect(key.keyHash).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain('$2b$12$');
+
+    expect(body.liveUsage[created.id]).toEqual({ minute: 2, day: 2 });
+  });
+});

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/user-api-keys.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/user-api-keys.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+const { mockUserFind, mockListKeys, mockGetUsage } = vi.hoisted(() => ({
+  mockUserFind: vi.fn(),
+  mockListKeys: vi.fn(),
+  mockGetUsage: vi.fn(),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
+      {
+        use: () => chain,
+        get: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.GET = fns[fns.length - 1]), chain),
+      }
+    );
+    return chain;
+  },
+}));
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: (req: unknown, res: unknown) => unknown) => fn,
+}));
+
+vi.mock('@server/utils/errors', () => ({
+  ForbiddenError: class ForbiddenError extends Error {},
+}));
+
+vi.mock('@bike4mind/utils', () => ({
+  BadRequestError: class BadRequestError extends Error {},
+  NotFoundError: class NotFoundError extends Error {},
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  userRepository: { findById: (...a: unknown[]) => mockUserFind(...a) },
+}));
+
+// The repository is only handed through as the service's db adapter, so an
+// identity object is enough to pin the wiring.
+vi.mock('@bike4mind/database/auth', () => ({
+  userApiKeyRepository: { __marker: 'userApiKeyRepository' },
+}));
+
+vi.mock('@bike4mind/services', () => ({
+  userApiKeyService: { listUserApiKeys: (...a: unknown[]) => mockListKeys(...a) },
+}));
+
+vi.mock('@server/utils/apiKeyRateLimitCheck', () => ({
+  getApiKeyRateLimitUsage: (...a: unknown[]) => mockGetUsage(...a),
+}));
+
+import handler from '../user-api-keys';
+
+const ADMIN = { id: 'admin1', isAdmin: true };
+
+const run = ({ user, userId = 'u1' }: { user?: unknown; userId?: string | string[] } = {}) => {
+  const { req, res } = createMocks({ method: 'GET', query: { userId } });
+  if (user) (req as Record<string, unknown>).user = user;
+  return { res, promise: (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res) };
+};
+
+beforeEach(() => {
+  mockUserFind.mockReset();
+  mockListKeys.mockReset();
+  mockGetUsage.mockReset().mockResolvedValue({ minute: 0, day: 0 });
+});
+
+describe('GET /api/admin/users/:userId/user-api-keys', () => {
+  it('rejects non-admins before touching any data source', async () => {
+    const { promise } = run({ user: { id: 'u2', isAdmin: false } });
+    await expect(promise).rejects.toThrow();
+    expect(mockUserFind).not.toHaveBeenCalled();
+    expect(mockListKeys).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unauthenticated request (no req.user)', async () => {
+    const { promise } = run();
+    await expect(promise).rejects.toThrow();
+    expect(mockUserFind).not.toHaveBeenCalled();
+    expect(mockListKeys).not.toHaveBeenCalled();
+  });
+
+  it('rejects a userId that arrives as an array', async () => {
+    const { promise } = run({ user: ADMIN, userId: ['a', 'b'] });
+    await expect(promise).rejects.toThrow('Invalid user ID');
+    expect(mockUserFind).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty-string userId', async () => {
+    const { promise } = run({ user: ADMIN, userId: '' });
+    await expect(promise).rejects.toThrow('Invalid user ID');
+    expect(mockUserFind).not.toHaveBeenCalled();
+  });
+
+  it('404s when the target user does not exist, without listing keys', async () => {
+    mockUserFind.mockResolvedValue(null);
+    const { promise } = run({ user: ADMIN });
+    await expect(promise).rejects.toThrow('User not found');
+    expect(mockListKeys).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list (200, not 404) for a user with no keys', async () => {
+    mockUserFind.mockResolvedValue({ id: 'u1' });
+    mockListKeys.mockResolvedValue([]);
+    const { res, promise } = run({ user: ADMIN });
+    await promise;
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ apiKeys: [], liveUsage: {} });
+    expect(mockGetUsage).not.toHaveBeenCalled();
+  });
+
+  it('lists all statuses (includeDisabled) and maps live usage per key id', async () => {
+    const keys = [
+      { id: 'k1', name: 'wedged', status: 'active' },
+      { id: 'k2', name: 'old', status: 'disabled' },
+    ];
+    mockUserFind.mockResolvedValue({ id: 'u1' });
+    mockListKeys.mockResolvedValue(keys);
+    mockGetUsage.mockResolvedValueOnce({ minute: 60, day: 300 }).mockResolvedValueOnce({ minute: 0, day: 0 });
+
+    const { res, promise } = run({ user: ADMIN });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    // The body is a passthrough of what the service returned; keyHash
+    // redaction is the model toJSON transform's job (pinned in
+    // UserApiKeyModel.embed.test.ts), not this route's.
+    expect(res._getJSONData()).toEqual({
+      apiKeys: keys,
+      liveUsage: { k1: { minute: 60, day: 300 }, k2: { minute: 0, day: 0 } },
+    });
+    expect(mockListKeys).toHaveBeenCalledWith(
+      'u1',
+      { db: { userApiKeys: { __marker: 'userApiKeyRepository' } } },
+      { includeDisabled: true }
+    );
+    expect(mockGetUsage).toHaveBeenCalledWith('k1');
+    expect(mockGetUsage).toHaveBeenCalledWith('k2');
+  });
+});

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/user-api-keys.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/user-api-keys.test.ts
@@ -53,6 +53,10 @@ vi.mock('@server/utils/apiKeyRateLimitCheck', () => ({
 }));
 
 import handler from '../user-api-keys';
+// These resolve to the mocked classes above, so instanceof pins which error
+// (and therefore which status) each guard maps to.
+import { ForbiddenError } from '@server/utils/errors';
+import { BadRequestError, NotFoundError } from '@bike4mind/utils';
 
 const ADMIN = { id: 'admin1', isAdmin: true };
 
@@ -69,36 +73,36 @@ beforeEach(() => {
 });
 
 describe('GET /api/admin/users/:userId/user-api-keys', () => {
-  it('rejects non-admins before touching any data source', async () => {
+  it('rejects non-admins with ForbiddenError before touching any data source', async () => {
     const { promise } = run({ user: { id: 'u2', isAdmin: false } });
-    await expect(promise).rejects.toThrow();
+    await expect(promise).rejects.toBeInstanceOf(ForbiddenError);
     expect(mockUserFind).not.toHaveBeenCalled();
     expect(mockListKeys).not.toHaveBeenCalled();
   });
 
-  it('rejects an unauthenticated request (no req.user)', async () => {
+  it('rejects an unauthenticated request (no req.user) with ForbiddenError', async () => {
     const { promise } = run();
-    await expect(promise).rejects.toThrow();
+    await expect(promise).rejects.toBeInstanceOf(ForbiddenError);
     expect(mockUserFind).not.toHaveBeenCalled();
     expect(mockListKeys).not.toHaveBeenCalled();
   });
 
   it('rejects a userId that arrives as an array', async () => {
     const { promise } = run({ user: ADMIN, userId: ['a', 'b'] });
-    await expect(promise).rejects.toThrow('Invalid user ID');
+    await expect(promise).rejects.toBeInstanceOf(BadRequestError);
     expect(mockUserFind).not.toHaveBeenCalled();
   });
 
   it('rejects an empty-string userId', async () => {
     const { promise } = run({ user: ADMIN, userId: '' });
-    await expect(promise).rejects.toThrow('Invalid user ID');
+    await expect(promise).rejects.toBeInstanceOf(BadRequestError);
     expect(mockUserFind).not.toHaveBeenCalled();
   });
 
   it('404s when the target user does not exist, without listing keys', async () => {
     mockUserFind.mockResolvedValue(null);
     const { promise } = run({ user: ADMIN });
-    await expect(promise).rejects.toThrow('User not found');
+    await expect(promise).rejects.toBeInstanceOf(NotFoundError);
     expect(mockListKeys).not.toHaveBeenCalled();
   });
 

--- a/apps/client/pages/api/admin/users/[userId]/user-api-keys.ts
+++ b/apps/client/pages/api/admin/users/[userId]/user-api-keys.ts
@@ -1,0 +1,63 @@
+import { userApiKeyService } from '@bike4mind/services';
+import { userApiKeyRepository } from '@bike4mind/database/auth';
+import { userRepository } from '@bike4mind/database';
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { baseApi } from '@server/middlewares/baseApi';
+import { ForbiddenError } from '@server/utils/errors';
+import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { getApiKeyRateLimitUsage, type RateLimitUsage } from '@server/utils/apiKeyRateLimitCheck';
+
+/**
+ * GET /api/admin/users/[userId]/user-api-keys
+ *
+ * Admin-only list of the API keys a user owns (docs whose userId is the
+ * target user - this includes org-billed keys the user minted, but not org
+ * keys minted by someone else). All statuses are returned so support can see
+ * disabled and expired keys too.
+ *
+ * liveUsage carries each key's current rate-limit counters read from the
+ * cache - the usage.* fields on the key doc itself are not maintained. A key
+ * whose counter sits at its limit is wedged; the per-key reset endpoint
+ * (/api/admin/user-api-keys/[id]/reset-rate-limit) clears it.
+ *
+ * keyHash redaction happens in UserApiKeyModel's toJSON transform, so the
+ * docs must stay hydrated - do not switch this path to .lean().
+ */
+const handler = baseApi().get(
+  asyncHandler(async (req, res) => {
+    if (!req.user?.isAdmin) {
+      throw new ForbiddenError('Unauthorized. Admin access required.');
+    }
+
+    const { userId } = req.query as { userId?: string | string[] };
+    if (typeof userId !== 'string' || !userId) {
+      throw new BadRequestError('Invalid user ID');
+    }
+
+    const targetUser = await userRepository.findById(userId);
+    if (!targetUser) {
+      throw new NotFoundError('User not found');
+    }
+
+    const apiKeys = await userApiKeyService.listUserApiKeys(
+      userId,
+      { db: { userApiKeys: userApiKeyRepository } },
+      { includeDisabled: true }
+    );
+
+    const usageEntries = await Promise.all(
+      apiKeys.map(async key => [key.id, await getApiKeyRateLimitUsage(key.id)] as const)
+    );
+    const liveUsage: Record<string, RateLimitUsage> = Object.fromEntries(usageEntries);
+
+    return res.status(200).json({ apiKeys, liveUsage });
+  })
+);
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/apps/client/server/utils/apiKeyRateLimitCheck.test.ts
+++ b/apps/client/server/utils/apiKeyRateLimitCheck.test.ts
@@ -3,6 +3,7 @@ import {
   buildRateLimitKeys,
   checkApiKeyRateLimit,
   extractApiKeyFromHeaders,
+  getApiKeyRateLimitUsage,
   resetApiKeyRateLimit,
 } from './apiKeyRateLimitCheck';
 import { cacheRepository } from '@bike4mind/database';
@@ -14,6 +15,7 @@ vi.mock('@bike4mind/database', () => ({
     tryIncrementWithinLimitFixedWindow: vi.fn(),
     decrementCounter: vi.fn(),
     deleteByKey: vi.fn(),
+    findByKey: vi.fn(),
   },
 }));
 
@@ -323,6 +325,42 @@ describe('apiKeyRateLimitCheck', () => {
         .mocked(cacheRepository.tryIncrementWithinLimitFixedWindow)
         .mock.calls.map(call => call[0]);
       expect(enforcerKeys).toEqual([minuteKey, dayKey]);
+    });
+  });
+
+  describe('getApiKeyRateLimitUsage', () => {
+    it('reads both counters by their canonical keys', async () => {
+      vi.mocked(cacheRepository.findByKey)
+        .mockResolvedValueOnce({ result: { count: 3 }, expiresAt: future(MINUTE_MS) })
+        .mockResolvedValueOnce({ result: { count: 42 }, expiresAt: future(DAY_MS) });
+
+      const usage = await getApiKeyRateLimitUsage(mockKeyId);
+
+      expect(usage).toEqual({ minute: 3, day: 42 });
+      const { minuteKey, dayKey } = buildRateLimitKeys(mockKeyId);
+      const queried = vi.mocked(cacheRepository.findByKey).mock.calls.map(call => call[0]);
+      expect(new Set(queried)).toEqual(new Set([minuteKey, dayKey]));
+    });
+
+    it('reads a missing counter doc as 0', async () => {
+      vi.mocked(cacheRepository.findByKey).mockResolvedValue(null);
+      expect(await getApiKeyRateLimitUsage(mockKeyId)).toEqual({ minute: 0, day: 0 });
+    });
+
+    it('reads an expired window (awaiting TTL cleanup) as 0', async () => {
+      vi.mocked(cacheRepository.findByKey)
+        .mockResolvedValueOnce({ result: { count: 60 }, expiresAt: new Date(Date.now() - 1) })
+        .mockResolvedValueOnce({ result: { count: 500 }, expiresAt: future(DAY_MS) });
+
+      expect(await getApiKeyRateLimitUsage(mockKeyId)).toEqual({ minute: 0, day: 500 });
+    });
+
+    it('reads a malformed counter doc as 0', async () => {
+      vi.mocked(cacheRepository.findByKey)
+        .mockResolvedValueOnce({ result: 'not-a-counter', expiresAt: future(MINUTE_MS) })
+        .mockResolvedValueOnce({ expiresAt: future(DAY_MS) });
+
+      expect(await getApiKeyRateLimitUsage(mockKeyId)).toEqual({ minute: 0, day: 0 });
     });
   });
 

--- a/apps/client/server/utils/apiKeyRateLimitCheck.ts
+++ b/apps/client/server/utils/apiKeyRateLimitCheck.ts
@@ -57,6 +57,35 @@ export async function resetApiKeyRateLimit(keyId: string): Promise<void> {
   await cacheRepository.deleteByKey(dayKey);
 }
 
+export interface RateLimitUsage {
+  minute: number;
+  day: number;
+}
+
+/**
+ * Read a key's current minute and day counter values without touching them.
+ * A missing doc, or one whose fixed window already ended (expiresAt in the
+ * past, awaiting TTL cleanup), reads as 0 - the same view the enforcer takes
+ * on the next request. The DB usage.* fields on the key doc are not
+ * maintained; these cache counters are the live source of truth.
+ */
+export async function getApiKeyRateLimitUsage(keyId: string): Promise<RateLimitUsage> {
+  const { minuteKey, dayKey } = buildRateLimitKeys(keyId);
+  const [minuteDoc, dayDoc] = await Promise.all([
+    cacheRepository.findByKey(minuteKey),
+    cacheRepository.findByKey(dayKey),
+  ]);
+  return { minute: readCounterValue(minuteDoc), day: readCounterValue(dayDoc) };
+}
+
+function readCounterValue(doc: { result?: unknown; expiresAt?: Date } | null): number {
+  if (!doc || (doc.expiresAt && doc.expiresAt.getTime() <= Date.now())) {
+    return 0;
+  }
+  const count = (doc.result as { count?: unknown } | undefined)?.count;
+  return typeof count === 'number' ? count : 0;
+}
+
 /**
  * Atomically increment a rate-limit counter ONLY if under limit, using
  * FIXED-WINDOW semantics: the window opens on the first request and closes


### PR DESCRIPTION
## Optional Screenshot/Video

[admin-api-key-rate-limit-reset.webm](https://github.com/user-attachments/assets/eda0b302-48ea-4f3f-a1ae-5864b4be6f5c)

*Figure: local stack run - the key sits wedged at 2/2 per min with a Rate limited chip (three real requests: 200, 200, 429), the admin resets it behind the confirmation dialog, and the row refreshes to Active 0/2; the same key was served a 200 in the same minute right after.*

## Description
Closes #781.

The reset endpoint from #771 gave support a way to unblock a wedged API key over the API, but the admin console had nowhere to use it: user details could only generate a new key, with no view of the keys a user already has. This PR adds that view. A "View API Keys" button on the admin user detail opens a modal listing the user's keys, and each row carries a reset action wired to the existing endpoint, behind a confirmation dialog.

One wrinkle surfaced during design: the `usage` fields on the key document are never written, and the `rate_limited` status value is never persisted. The real counters live in the cache the enforcer increments. So the list endpoint reads those cache counters (a new read-only `getApiKeyRateLimitUsage` helper) and returns them as `liveUsage` alongside the keys. The UI shows live minute/day usage against each key's limits and flags an active key sitting at its ceiling as rate limited, which also means a reset visibly drops the counters to zero on refetch.

## Changes
- New `GET /api/admin/users/[userId]/user-api-keys`: admin-only, returns all of a user's keys (every status) plus `liveUsage` per key id. Mirrors the sibling admin routes' guard order (admin check, userId validation, 404 on unknown user).
- New `getApiKeyRateLimitUsage(keyId)` in `apiKeyRateLimitCheck.ts`: reads the minute/day counter docs; missing or expired windows read as 0, matching the enforcer's view.
- New hooks in `hooks/data/userApiKeys.ts`: `useAdminGetUserApiKeys(userId)` and `useAdminResetApiKeyRateLimit()` (invalidates the admin list on success). `useAdminGenerateApiKey` now also invalidates that list so a freshly minted key appears in an open modal.
- New `AdminApiKeysModal` + "View API Keys" button in `UserDetails`: key table (name, prefix, scopes, status chip, live rate-limit usage, last used) with a per-row reset action using the standard confirmation dialog and toasts.
- Tests: route unit tests (guard triad, typed error classes, empty list, includeDisabled + liveUsage contract), a real-model agreement test pinning `keyHash` off the wire and `liveUsage` against counters the real enforcer produced, helper unit tests, and a component test covering the confirm-then-reset wiring.

## Guide for Testers
Prerequisite: an admin account.

1. Open the admin console (Sidebar -> Admin -> Users) and search for a user who has API keys. If none, open their user details and use "Generate API Key" first: name `wedge test`, scope `ai:chat`, and set the per-minute rate limit to `2`.
2. In the user's details column, click "View API Keys". Expected: a modal lists the user's keys with name, key prefix, scopes, a status chip, "Rate limit" usage like `0/2 per min` and `0/1000 per day`, and last-used.
3. Using the generated key, make 3 API requests in one minute (for example `curl -H "X-API-Key: <key>" https://<env>/api/user-api-keys` repeated 3 times). Expected: the third returns 429 with a `Retry-After` header.
4. Reopen "View API Keys". Expected: the key's usage shows `2/2 per min` and its status chip reads "Rate limited".
5. Click the reset icon on that row. Expected: a confirmation dialog names the key; Cancel does nothing.
6. Click the reset icon again and confirm. Expected: a success toast, and the row refreshes to `0/2 per min` with status "Active".
7. Repeat the request from step 3 once. Expected: 200 within the same minute (the window was reset).
8. Regression check: as a non-admin, `GET /api/admin/users/<userId>/user-api-keys` returns 403.

## Additional Information
Scope note: the list shows keys whose `userId` is the target user, which includes org-billed keys that user minted but not org keys minted by someone else. The reset endpoint itself (from #771) is unchanged.

## Developer Notes (Optional)
`getApiKeyRateLimitUsage` is the first read-only accessor for the rate-limit counters; anything else that wants to display live usage should go through it rather than touching cache keys directly (key format stays centralized in `buildRateLimitKeys`).

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
