### PR TITLE
fix(client): refresh nav gears status on data lake creation (#833)

### DIFF
--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -15,6 +15,7 @@ import { useDataLakeWizardStore, type UploadProgress } from '@client/app/stores/
 import { activeOrgId } from '@client/app/hooks/data/dataLakes';
 import type { WizardFile } from '@client/app/utils/folderTreeParser';
 import { computeFileHash } from '@client/app/utils/folderTreeParser';
+import { invalidateGearsStatusWhileLocked } from '@client/app/hooks/useGearsStatus';
 import axios from 'axios';
 
 /**
@@ -513,6 +514,9 @@ export function useBatchUpload() {
         });
 
         queryClient.invalidateQueries({ queryKey: ['data-lakes'] });
+        // First lake unlocks the 'datalakes' nav slot; first file unlocks 'files'.
+        // Reveal them without waiting out the gears/status staleTime (#833).
+        invalidateGearsStatusWhileLocked(queryClient, ['datalakes', 'files']);
 
         return { dataLakeId, batchId, uploadedCount, failedCount };
       } catch (err) {

--- a/apps/client/app/hooks/data/dataLakes.ts
+++ b/apps/client/app/hooks/data/dataLakes.ts
@@ -4,6 +4,7 @@ import { api } from '@client/app/contexts/ApiContext';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
+import { invalidateGearsStatusWhileLocked } from '@client/app/hooks/useGearsStatus';
 
 const DATA_LAKES_KEY = ['data-lakes'];
 
@@ -49,6 +50,9 @@ export function useCreateDataLake(options?: { onSuccess?: (data: DataLakeConfig)
     },
     onSuccess: data => {
       queryClient.invalidateQueries({ queryKey: DATA_LAKES_KEY });
+      // Reveal the 'datalakes' nav slot immediately rather than after the
+      // gears/status staleTime elapses (#833).
+      invalidateGearsStatusWhileLocked(queryClient, ['datalakes']);
       toast.success(`Data lake "${data.name}" created`);
       options?.onSuccess?.(data);
     },

--- a/apps/client/app/hooks/useGearsStatus.test.ts
+++ b/apps/client/app/hooks/useGearsStatus.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: vi.fn() },
+}));
+
+import {
+  invalidateGearsStatusWhileLocked,
+  type GearKey,
+  type GearStatus,
+  type GearsStatusResponse,
+} from './useGearsStatus';
+
+const gear = (key: GearKey, unlocked: boolean): GearStatus => ({
+  key,
+  kind: 'destination',
+  unlocked,
+  credits: 0,
+  title: key,
+  tagline: '',
+  intro: '',
+  cta: '',
+  ctaAction: '',
+});
+
+const seed = (queryClient: QueryClient, gears: GearStatus[]) => {
+  const response: GearsStatusResponse = {
+    gears,
+    totalUnlocked: gears.filter(g => g.unlocked).length,
+  };
+  queryClient.setQueryData(['gears', 'status'], response);
+};
+
+describe('invalidateGearsStatusWhileLocked', () => {
+  let queryClient: QueryClient;
+  let invalidateSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue();
+  });
+
+  it('invalidates when the target gear is cached and still locked', () => {
+    seed(queryClient, [gear('datalakes', false)]);
+    invalidateGearsStatusWhileLocked(queryClient, ['datalakes']);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['gears', 'status'] });
+  });
+
+  it('does not invalidate once the target gear is already unlocked', () => {
+    seed(queryClient, [gear('datalakes', true)]);
+    invalidateGearsStatusWhileLocked(queryClient, ['datalakes']);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no status is cached (no observers to update)', () => {
+    invalidateGearsStatusWhileLocked(queryClient, ['datalakes']);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('invalidates when any one of several gears is still locked', () => {
+    seed(queryClient, [gear('datalakes', true), gear('files', false)]);
+    invalidateGearsStatusWhileLocked(queryClient, ['datalakes', 'files']);
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invalidate when every listed gear is unlocked', () => {
+    seed(queryClient, [gear('datalakes', true), gear('files', true)]);
+    invalidateGearsStatusWhileLocked(queryClient, ['datalakes', 'files']);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate when the listed gear is absent from the cached status', () => {
+    seed(queryClient, [gear('files', true)]);
+    invalidateGearsStatusWhileLocked(queryClient, ['datalakes']);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/hooks/useGearsStatus.ts
+++ b/apps/client/app/hooks/useGearsStatus.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type QueryClient } from '@tanstack/react-query';
 import { api } from '@client/app/contexts/ApiContext';
 
 /**
@@ -72,6 +72,25 @@ export function useGearsStatus() {
     // picked up on the next visit) - keep the nav from refetching on every mount.
     staleTime: 5 * 60_000,
   });
+}
+
+/**
+ * Invalidate the gears/status query after a creation, but only while at least one
+ * of the given destination gears is still locked in the cache. A creation unlocks
+ * its gear server-side, yet the 5-minute staleTime would otherwise keep the newly
+ * earned nav slot (and Gears CTA) hidden until a reload. Skipping the refetch once
+ * the gear is already unlocked keeps routine creates from refetching every time.
+ * No cached status means no observers to update, so there is nothing to invalidate.
+ * Mirrors the inline pattern in SessionFilePond for the 'files' gear.
+ */
+export function invalidateGearsStatusWhileLocked(queryClient: QueryClient, keys: GearKey[]): void {
+  const status = queryClient.getQueryData<GearsStatusResponse>(['gears', 'status']);
+  if (!status) return;
+  const anyStillLocked = keys.some(key => {
+    const gear = status.gears.find(g => g.key === key);
+    return gear && !gear.unlocked;
+  });
+  if (anyStillLocked) void queryClient.invalidateQueries({ queryKey: ['gears', 'status'] });
 }
 
 /** Convenience map: key -> unlocked. `undefined` while loading (callers choose their fallback). */


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video


https://github.com/user-attachments/assets/05040fa3-51b8-4687-84eb-d52c929668a3



## Description

Closes #833. Creating a Data Lake did not invalidate the `['gears', 'status']`
react-query cache (which has a 5-minute `staleTime`), so the "Data Lakes" nav
slot only appeared after a manual page reload.

Gears are the earned-nav progression state: unlocking the `datalakes` gear
server-side (by owning at least one lake) is what reveals the sidebar slot, but
the client kept serving the stale cached status until it expired. This PR
invalidates the gears/status query on lake and file creation so the slot appears
immediately.

The invalidation is gated: it only refetches while the relevant gear is still
locked in the cache, so routine creates by an already-unlocked user do not
trigger an extra request. This mirrors the existing pattern already used for the
`files` gear in `SessionFilePond`.

## Changes

- Add `invalidateGearsStatusWhileLocked(queryClient, keys)` to `useGearsStatus.ts`:
  reads the cached gears status and invalidates `['gears', 'status']` only when
  one of the given gears is present and still locked (no-op when the status is
  not cached, since there are no observers to update).
- Call it from `useBatchUpload` (the live wizard create/upload path) with
  `['datalakes', 'files']` - covers both first-lake creation and first-file
  upload, including append-mode uploads into an existing lake.
- Call it from `useCreateDataLake.onSuccess` with `['datalakes']` for consistency.
- Add co-located unit tests for the helper (`useGearsStatus.test.ts`).

## Guide for Testers

Requires a fresh account (or one that has never created a Data Lake), so the
`datalakes` gear starts locked and its nav slot is hidden.

1. Open the preview link and sign in with an account that has no Data Lakes.
2. Confirm the left sidebar does NOT show a "Data Lakes" slot yet.
3. Open the Data Lake wizard and create a new lake with at least one supported
   file (for example a small `.txt` or `.md` file).
4. Wait for the upload to complete (the wizard reports success).
5. Without reloading the page, confirm the "Data Lakes" slot now appears in the
   sidebar. Expected: it shows within a couple of seconds, no manual refresh.
6. Open the newly created lake from the sidebar and confirm it lists the file(s)
   you uploaded.

### Regression Checks

1. As the same (now unlocked) user, create a second Data Lake.
2. Confirm creation still succeeds and the second lake appears in the Data Lakes
   list. The nav slot should stay visible throughout (no flicker or disappearance).
3. Attach a file to a normal chat session (unrelated `files`-gear path) and
   confirm that flow is unchanged.

### What NOT to test

- No API/server behavior changed; gear unlock rules and the `/api/gears/status`
  response are untouched.
- No visual/styling changes to the wizard or the nav.

## Additional Information

Tests: `useGearsStatus.test.ts` covers the helper's gating - invalidate when a
gear is cached and locked, no-op when it is already unlocked, no-op when no
status is cached, invalidate when any one of several gears is still locked,
no-op when every listed gear is unlocked, and no-op when the listed gear is
absent from the cached status.

Verified locally: `@bike4mind/client` typecheck clean, ESLint clean on the
changed files, and all new plus existing affected tests pass.

## Developer Notes (Optional)

- `invalidateGearsStatusWhileLocked` is a reusable building block for any future
  creation flow that earns a destination gear (for example `projects` or
  `published`): call it in the mutation success path with the relevant gear
  key(s) to reveal the nav slot without waiting out the status `staleTime`. It
  replaces the previously inlined, per-call-site invalidation with a single
  shared, tested helper.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
