### PR TITLE
fix(client): back API-key usage counts with usage-log aggregates

### DIFF
--- a/apps/client/pages/api/security/api-usage.ts
+++ b/apps/client/pages/api/security/api-usage.ts
@@ -1,6 +1,7 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { userApiKeyRepository } from '@bike4mind/database/auth';
 import { apiKeyAlertRepository } from '@bike4mind/database/auth';
+import { apiKeyUsageLogRepository } from '@bike4mind/database/auth';
 
 const handler = baseApi().get(async (req, res) => {
   const userId = req.user?.id;
@@ -12,6 +13,13 @@ const handler = baseApi().get(async (req, res) => {
   const apiKeys = await userApiKeyRepository.findByUserId(userId);
   const activeAlerts = await apiKeyAlertRepository.findActiveByUserId(userId);
 
+  // The UserApiKey.usage counters are never written in production (#773), so the
+  // displayed request counts were always 0. Derive them from the request log, which
+  // records every API-key request. "Total" reflects the log's 90-day retention window.
+  const dayStart = new Date();
+  dayStart.setUTCHours(0, 0, 0, 0);
+  const requestCounts = await apiKeyUsageLogRepository.countRequestsByKeyForUser(userId, dayStart);
+
   const alertsByKey = activeAlerts.reduce<Record<string, typeof activeAlerts>>((acc, alert) => {
     if (!acc[alert.keyId]) {
       acc[alert.keyId] = [];
@@ -22,6 +30,7 @@ const handler = baseApi().get(async (req, res) => {
 
   const items = apiKeys.map(apiKey => {
     const alerts = alertsByKey[apiKey.id] ?? [];
+    const counts = requestCounts[apiKey.id];
     return {
       id: apiKey.id,
       name: apiKey.name,
@@ -30,7 +39,11 @@ const handler = baseApi().get(async (req, res) => {
       lastUsedAt: apiKey.lastUsedAt,
       expiresAt: apiKey.expiresAt,
       rateLimit: apiKey.rateLimit,
-      usage: apiKey.usage,
+      usage: {
+        ...apiKey.usage,
+        totalRequests: counts?.totalRequests ?? 0,
+        requestsToday: counts?.requestsToday ?? 0,
+      },
       metadata: apiKey.metadata,
       alerts: alerts.map(alert => ({
         id: alert.id,

--- a/packages/database/src/__test__/apiKeyUsageLog.test.ts
+++ b/packages/database/src/__test__/apiKeyUsageLog.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+import { connectTestDB, disconnectTestDB } from './utils';
+import { ApiKeyUsageLog, apiKeyUsageLogRepository } from '../models/auth/ApiKeyUsageLogModel';
+
+// #773: the API-key usage view now derives request counts from the usage log via
+// countRequestsByKeyForUser (the UserApiKey.usage counters are never written).
+describe('ApiKeyUsageLogRepository.countRequestsByKeyForUser', () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await connectTestDB();
+  }, 30000);
+
+  afterAll(async () => {
+    await disconnectTestDB(mongoServer);
+  }, 30000);
+
+  beforeEach(async () => {
+    await ApiKeyUsageLog.deleteMany({});
+  });
+
+  const base = {
+    ipAddress: '203.0.113.1',
+    endpoint: '/api/ai/v1/completions',
+    method: 'POST',
+    responseTime: 12,
+    statusCode: 200,
+  };
+  const logRequest = (userId: string, keyId: string, timestamp: Date) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test seed: partial log doc
+    apiKeyUsageLogRepository.create({ userId, keyId, timestamp, ...base } as any);
+
+  it('returns per-key lifetime total and today count matching the logged requests', async () => {
+    const dayStart = new Date();
+    dayStart.setUTCHours(0, 0, 0, 0);
+    const earlierToday = new Date(dayStart.getTime() + 60 * 60 * 1000); // +1h (today)
+    const beforeToday = new Date(dayStart.getTime() - 2 * 60 * 60 * 1000); // -2h (before today, still <90d)
+
+    // keyA: 2 today + 1 before today -> total 3, today 2
+    await logRequest('user-1', 'keyA', earlierToday);
+    await logRequest('user-1', 'keyA', earlierToday);
+    await logRequest('user-1', 'keyA', beforeToday);
+    // keyB: 1 today -> total 1, today 1
+    await logRequest('user-1', 'keyB', earlierToday);
+    // another user's key must NOT leak into user-1's counts
+    await logRequest('user-2', 'keyC', earlierToday);
+
+    const counts = await apiKeyUsageLogRepository.countRequestsByKeyForUser('user-1', dayStart);
+
+    expect(counts.keyA).toEqual({ totalRequests: 3, requestsToday: 2 });
+    expect(counts.keyB).toEqual({ totalRequests: 1, requestsToday: 1 });
+    expect(counts.keyC).toBeUndefined(); // user-scoped
+  });
+
+  it('returns an empty map when the user has no logged requests', async () => {
+    const dayStart = new Date();
+    dayStart.setUTCHours(0, 0, 0, 0);
+    const counts = await apiKeyUsageLogRepository.countRequestsByKeyForUser('nobody', dayStart);
+    expect(counts).toEqual({});
+  });
+});

--- a/packages/database/src/models/auth/ApiKeyUsageLogModel.ts
+++ b/packages/database/src/models/auth/ApiKeyUsageLogModel.ts
@@ -127,6 +127,38 @@ export class ApiKeyUsageLogRepository extends BaseRepository<IApiKeyUsageLogDocu
       })
       .exec();
   }
+
+  /**
+   * Count logged requests per API key for a user, in a single aggregation.
+   * Returns each key's lifetime total (bounded by this collection's 90-day TTL)
+   * and today's count (timestamp >= dayStart). Backs the API-key usage view with
+   * real request data instead of the never-written UserApiKey.usage counters (#773).
+   * Keys with no logged requests are simply absent from the result.
+   */
+  async countRequestsByKeyForUser(
+    userId: string,
+    dayStart: Date
+  ): Promise<Record<string, { totalRequests: number; requestsToday: number }>> {
+    const rows = await this.model.aggregate<{
+      _id: string;
+      totalRequests: number;
+      requestsToday: number;
+    }>([
+      { $match: { userId } },
+      {
+        $group: {
+          _id: '$keyId',
+          totalRequests: { $sum: 1 },
+          requestsToday: { $sum: { $cond: [{ $gte: ['$timestamp', dayStart] }, 1, 0] } },
+        },
+      },
+    ]);
+
+    return rows.reduce<Record<string, { totalRequests: number; requestsToday: number }>>((acc, row) => {
+      acc[row._id] = { totalRequests: row.totalRequests, requestsToday: row.requestsToday };
+      return acc;
+    }, {});
+  }
 }
 
 export const apiKeyUsageLogRepository = new ApiKeyUsageLogRepository(ApiKeyUsageLog);


### PR DESCRIPTION
## Description

The API-key status view (Profile → Security → API Keys) showed per-key request counts that were **always zero**. The `UserApiKey.usage` counters (`totalRequests`, `requestsToday`) that the view renders have **no production writer** — `updateUsage()` is only referenced in a unit test — so they stay at their schema default of `0`, even though every API-key request is recorded in the `ApiKeyUsageLog` collection. (`lastUsedAt` was already accurate, since `updateLastUsed()` *is* wired.)

This derives the displayed counts from the real request log instead of the dead counters.

## Changes

- `packages/database` — add `ApiKeyUsageLogRepository.countRequestsByKeyForUser(userId, dayStart)`: a single aggregation returning, per key, the lifetime total (bounded by the log's existing 90-day TTL) and today's count (`timestamp >= dayStart`).
- `apps/client` — `GET /api/security/api-usage` now overrides `usage.totalRequests` / `usage.requestsToday` with the aggregated values; the rest of the `usage` subdoc and all other fields are unchanged.
- Test — `packages/database/src/__test__/apiKeyUsageLog.test.ts` seeds logs across keys/timestamps/users and asserts the aggregate matches the logged requests and is user-scoped.

## Guide for Testers

1. Sign in and open **Profile → Security → API Keys** (the API Key Status view).
2. Create an API key with the `ai:chat` scope (or use an existing one).
3. Make 3 requests to `POST /api/ai/v1/completions` with the key in the `x-api-key` header (body e.g. `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`).
4. Reload the API Key Status view.
5. **Expected:** the key shows `Today: 3 requests · Total: 3` matching the requests just made. **Before this fix** it stayed `Today: 0 · Total: 0` even though the key was used (only `Last used` updated).

## Additional Information

- `Total` reflects `ApiKeyUsageLog`'s 90-day retention window (the collection has a 90-day TTL). This is accurate immediately (includes existing history) and needs no per-request write. A true lifetime counter would require wiring `updateUsage()` into the request path and would start from 0 (missing pre-existing history) — deliberately out of scope here.
- No new write on the request hot path; one aggregation per status-view load (low-traffic dashboard endpoint).

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — N/A
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) — no UI change; existing view now shows real data
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) — N/A
- [x] My changes generate no new warnings

Closes #773