### PR TITLE
chore: set b4m-bob overlay pin to 71d63553a19f8a5b8cf46025e9cc298fdfa253d6

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,5 +1,5 @@
 {
-  "b4m-bob": "72235ca1b3fa53421917a1e7c1f244af18d2ed2b",
+  "b4m-bob": "71d63553a19f8a5b8cf46025e9cc298fdfa253d6",
   "b4m-overwatch": "4afc25e5ab5844b3bfb61cc7994310fe9c966487",
   "b4m-libreoncology": "0a81b7055fa5dba745b6f55381b528e737f8f4cf",
   "b4m-optihashi": "b1412baeaecbb5ade49ad75e19588f61beecad4f",


### PR DESCRIPTION
Sets the b4m-bob overlay pin to 71d63553a19f8a5b8cf46025e9cc298fdfa253d6. Overlay-pin-only change; no application source changes.

**Preview-only — not for merge.** Opened to spin up a preview environment; please do not merge (staging should stay on the current pin until the planned convergence bump).
