### PR TITLE
feat(e2e): bound remaining unbounded retry-loop 

### DIFF
--- a/apps/client/e2e/pages/AdminPage.ts
+++ b/apps/client/e2e/pages/AdminPage.ts
@@ -18,8 +18,10 @@ export class AdminPage extends BasePage {
     // Menu items can be detached by React re-renders (WebSocket/polling).
     // Retry: re-open the menu if the click fails due to detachment or visibility.
     for (let attempt = 1; attempt <= 3; attempt++) {
-      await this.page.getByTestId('profile-menu-card').click();
       try {
+        // Bound the click so a stuck menu-open (unbounded stability check) fails fast into the
+        // retry rather than hanging; keeping it inside the try lets a throw retry too.
+        await this.page.getByTestId('profile-menu-card').click({ timeout: TIMEOUTS.ELEMENT_STATE });
         await this.page.getByTestId('profile-menu-admin').click({ timeout: TIMEOUTS.ELEMENT_STATE });
         break;
       } catch {
@@ -92,8 +94,10 @@ export class AdminPage extends BasePage {
     const testId = option === 'name' ? 'sort-option-name' : 'sort-option-created-at';
     // Dropdown options can be detached by React re-renders. Retry: re-open the dropdown.
     for (let attempt = 1; attempt <= 3; attempt++) {
-      await this.page.getByTestId('admin-sort-by-select').click();
       try {
+        // Bound the click so a stuck dropdown-open (unbounded stability check) fails fast into
+        // the retry rather than hanging; keeping it inside the try lets a throw retry too.
+        await this.page.getByTestId('admin-sort-by-select').click({ timeout: TIMEOUTS.ELEMENT_STATE });
         await this.page.getByTestId(testId).click({ timeout: TIMEOUTS.ELEMENT_STATE });
         break;
       } catch {

--- a/apps/client/e2e/pages/ChatPage.ts
+++ b/apps/client/e2e/pages/ChatPage.ts
@@ -22,9 +22,13 @@ export class ChatPage extends BasePage {
    */
   private async typeAndWaitForSendReady(text: string) {
     for (let attempt = 1; attempt <= 3; attempt++) {
-      await this.chatInput.click();
-      await this.page.keyboard.insertText(text);
       try {
+        // Bound the click: with no suite-level actionTimeout an unbounded click would hang on
+        // the actionability/stability check (background refetch re-rendering the input) instead
+        // of throwing, starving this retry loop. Keeping it inside the try also lets a real
+        // click failure fall through to the reload-and-retry path.
+        await this.chatInput.click({ timeout: TIMEOUTS.ELEMENT_STATE });
+        await this.page.keyboard.insertText(text);
         await expect(this.sendButton).toBeEnabled({ timeout: TIMEOUTS.NAVIGATION });
         return;
       } catch {


### PR DESCRIPTION

# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description

Follow-up to PR 796, which fixed this class of bug in the file-browser page object (`selectFileRow` / `renameFile`). Issue #865 tracked the two remaining page objects that still had the same latent pattern.

The suite sets no `use.actionTimeout` in `playwright.config.ts`, so Playwright's default of `0` (wait forever) applies to every action. An unbounded `.click()` placed **outside** the `try` block of a retry loop has two failure modes:

- **Hang:** if a background React refetch keeps re-rendering the element mid-click, the click's actionability/stability check can wait forever, defeating the retry entirely and consuming the whole `test.slow()` budget (the ~2.7m hang PR 796 fixed).
- **Throw skips the retry:** because the click sat above the `try`, a real click exception incremented `attempt` but was never caught, so the retry loop provided no protection.

This PR mirrors the PR 796 fix in the three remaining spots: move each outer click **inside** its `try` block and bound it with `{ timeout: TIMEOUTS.ELEMENT_STATE }` (5s) so a stuck click fails fast and the retry loop can actually fire.

## Changes

- `ChatPage.ts` -- `typeAndWaitForSendReady`: `chatInput.click()` moved inside the `try` and bounded with `TIMEOUTS.ELEMENT_STATE`. The dependent `keyboard.insertText(text)` moved in with it (it relies on the click having placed focus); order is preserved.
- `AdminPage.ts` -- `navigateToAdmin`: `profile-menu-card.click()` moved inside the `try` and bounded. The inner `profile-menu-admin` click was already bounded.
- `AdminPage.ts` -- `setSortBy`: `admin-sort-by-select.click()` moved inside the `try` and bounded. The inner option click was already bounded.
- Added inline comments explaining why every click in these retry loops must carry an explicit timeout (no suite-level `actionTimeout`).
- Test-only change -- no production/app code touched.

## Guide for Testers

This is an e2e-harness fix; verify it by running the affected specs on CI via the manual E2E workflow -- no local setup or manual app clicking required.

1. Go to the repo on GitHub -> **Actions** tab -> select the **E2E Tests (Manual)** workflow in the left sidebar.
2. Click **Run workflow** (top-right).
3. In the **Use workflow from** branch dropdown, select `feat/e2e-865-bound-remaining-unbound-retry-loop-click`.
4. Set **Target environment** to `dev`.
5. Run the specs that exercise these page objects (the chat send flow and the admin navigation/sort flows). Leave **PR number** and **Tester ID** blank, and leave `gate_run` as `false`.
6. Click the green **Run workflow** button.
   Expected: a new "E2E Tests" run appears and starts within a few seconds.
7. Open the run and wait for the job to finish.
   Expected: the job is green.
8. Open the run's uploaded **playwright-report** artifact and inspect the chat-send step and the admin navigate/sort steps. Expected: each completes in seconds -- no multi-minute hang and no `test.slow()` timeout on the affected steps.
9. (Optional, to confirm the intermittent hang is gone) Re-run the workflow 2-3 times with the same inputs.
   Expected: every run passes; no run stalls on the send/menu/dropdown clicks.

### Regression Checks

- **ChatPage:** sending a message still works -- the input receives focus, text is typed, and the send button enables and submits. The reload-and-retry path still fires when the editor is not ready.
- **AdminPage `navigateToAdmin`:** the profile menu still opens and the Admin item still navigates to the admin page.
- **AdminPage `setSortBy`:** the sort dropdown still opens and selecting name / created-at still re-sorts the user list.

### What NOT to test

- No application/UI behavior changed -- no need to manually exercise the app.
- Only specs using ChatPage/AdminPage are affected; a full-suite run is optional, not required, to validate this PR.

## Additional Information

- No new dependencies, no config changes, no schema/index changes.
- Pre-existing `E2E_CLEANUP_SECRET` typecheck errors (SST `Resource` typing in `global-setup.ts` / `global-teardown.ts` / `helpers/api.ts`) are unrelated to this change and do not touch these files.
- Happy-path behavior is unchanged; the only difference is that a stuck click now fails fast and retries instead of hanging to the test timeout.

## Developer Notes

- Reusable guardrail (same as PR 796): because this suite sets no `use.actionTimeout` (Playwright default `0` = wait forever), **every `click()`/`fill()` inside a retry loop must pass an explicit `{ timeout }`** and live **inside** the `try` -- otherwise an un-actionable element hangs instead of throwing and starves the retry. With this PR, the three page objects called out in #865 are now all consistent with the file-browser fix.


## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
