### PR TITLE
fix(client): close submit race condition and block send during uploads

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -489,8 +489,9 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
                         setShowSlashSuggestions(shouldShowSlashSuggestions);
                       }}
                       onSubmit={async () => {
-                        // Block Enter-to-send while a response is still streaming.
-                        if (shouldShowStopButton || submitting) return;
+                        // Block Enter-to-send while a response is still streaming
+                        // or while files are still uploading/scanning.
+                        if (shouldShowStopButton || submitting || hasActiveUploads) return;
                         await handleSendClick();
                       }}
                       onPaste={handlePaste}

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.hostCreate.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.hostCreate.test.ts
@@ -23,7 +23,7 @@ describe('useSendMessage — host-managed first-message creation (regression)', 
   it('delegates a no-session send to the host factory and short-circuits', () => {
     // The guard reads the host factory from useSessionRouter and awaits it with the prompt.
     expect(source).toContain('useSessionRouter.getState().hostCreateSession');
-    expect(source).toMatch(/await hostCreateSession\(prompt\);\s*return;/);
+    expect(source).toMatch(/await hostCreateSession\(prompt\);\s*setSubmitting\(false\);\s*return;/);
   });
 
   it('runs the delegation only when there is no active session', () => {
@@ -35,13 +35,21 @@ describe('useSendMessage — host-managed first-message creation (regression)', 
 
   it('delegates BEFORE the generic send path begins (ordering invariant)', () => {
     const delegateIdx = source.indexOf('await hostCreateSession(prompt)');
-    const firstSubmittingIdx = source.indexOf('setSubmitting(true)');
     const newOptimisticIdx = source.indexOf("location.pathname === '/new'");
 
     expect(delegateIdx).toBeGreaterThan(-1);
-    // Delegation short-circuits before the generic send turns on the submitting state...
-    expect(delegateIdx).toBeLessThan(firstSubmittingIdx);
-    // ...and before the /new optimistic-create branch that would mint a generic session.
+    // Delegation short-circuits before the /new optimistic-create branch that would mint a generic session.
     expect(delegateIdx).toBeLessThan(newOptimisticIdx);
+  });
+
+  it('resets submitting state on the host-create early-return path', () => {
+    // setSubmitting(true) is now a re-entrancy lock at the top of handleSendClick.
+    // The host-create path must call setSubmitting(false) before returning so the
+    // UI is not left stuck in a submitting state.
+    const hostReturnBlock = source.slice(
+      source.indexOf('await hostCreateSession(prompt)'),
+      source.indexOf('await hostCreateSession(prompt)') + 200
+    );
+    expect(hostReturnBlock).toContain('setSubmitting(false)');
   });
 });

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.hostCreate.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.hostCreate.test.ts
@@ -43,13 +43,15 @@ describe('useSendMessage — host-managed first-message creation (regression)', 
   });
 
   it('resets submitting state on the host-create early-return path', () => {
-    // setSubmitting(true) is now a re-entrancy lock at the top of handleSendClick.
+    // setSubmitting(true) is a re-entrancy lock at the top of handleSendClick.
     // The host-create path must call setSubmitting(false) before returning so the
     // UI is not left stuck in a submitting state.
-    const hostReturnBlock = source.slice(
-      source.indexOf('await hostCreateSession(prompt)'),
-      source.indexOf('await hostCreateSession(prompt)') + 200
-    );
-    expect(hostReturnBlock).toContain('setSubmitting(false)');
+    expect(source).toMatch(/await hostCreateSession\(prompt\);[\s\S]*?setSubmitting\(false\);[\s\S]*?return;/);
+  });
+
+  it('uses a ref-based mutex for the re-entrancy guard', () => {
+    // React state updates are batched, so the guard must check a synchronous ref
+    // rather than the closure-captured state value.
+    expect(source).toContain('submittingRef.current');
   });
 });

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -318,6 +318,10 @@ export function useSendMessage({
   ): Promise<IChatHistoryItemDocument | undefined> => {
     if (submitting) return;
 
+    // Lock out concurrent sends immediately so a second click/Enter during
+    // validation or the host-create await cannot slip through the guard above.
+    setSubmitting(true);
+
     // For editor-driven sends (newPrompt === undefined) serialize the composer to
     // markdown so inline formatting (Ctrl+B / Ctrl+I) round-trips into the rendered
     // user bubble. getSerializedValue() emits plain text unchanged when no
@@ -343,6 +347,7 @@ export function useSendMessage({
     if (errorMessage) {
       console.error(errorMessage);
       toast.error(errorMessage);
+      setSubmitting(false);
       return;
     }
 
@@ -358,11 +363,10 @@ export function useSendMessage({
       const hostCreateSession = useSessionRouter.getState().hostCreateSession;
       if (hostCreateSession) {
         await hostCreateSession(prompt);
+        setSubmitting(false);
         return;
       }
     }
-
-    setSubmitting(true);
     setSessionLayout({ selectedArtifactId: undefined, artifactData: undefined });
     const session = currentSession;
     let sessionToSend = session;

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { useShallow } from 'zustand/react/shallow';
@@ -258,7 +258,15 @@ export function useSendMessage({
   // `execution_started` event during the `/new -> /notebooks/$id` swap.
   const agentExecution = useAgentExecutionDispatch();
 
-  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [submitting, setSubmittingState] = useState<boolean>(false);
+  // Ref-based mutex: React state updates are batched, so two rapid calls can
+  // both read `submitting === false` from their closure. The ref flips
+  // synchronously, making the guard at the top of handleSendClick airtight.
+  const submittingRef = useRef(false);
+  const setSubmitting = useCallback((value: boolean) => {
+    submittingRef.current = value;
+    setSubmittingState(value);
+  }, []);
   const [stoppingMessage, setStoppingMessage] = useState<boolean>(false);
   const [pendingAutoSubmitGoal, setPendingAutoSubmitGoal] = useState<string | null>(null);
   const [enableQuestMasterOnSubmit, setEnableQuestMasterOnSubmit] = useState(false);
@@ -316,7 +324,7 @@ export function useSendMessage({
     newPrompt?: string,
     options?: { forceEnableQuestMaster?: boolean; toolsOverride?: B4MLLMTools[] }
   ): Promise<IChatHistoryItemDocument | undefined> => {
-    if (submitting) return;
+    if (submittingRef.current) return;
 
     // Lock out concurrent sends immediately so a second click/Enter during
     // validation or the host-create await cannot slip through the guard above.


### PR DESCRIPTION
Move setSubmitting(true) to immediately after the re-entrancy guard in handleSendClick so a second Enter/click cannot slip through while validation or the host-create await is in flight. Add setSubmitting(false) to the validation-failure and host-create early-return paths.

Add hasActiveUploads to the Enter-to-send guard in SessionBottom so pressing Enter while a file is still uploading does not send the message without the pending files (the Send button already enforced this).

# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description
<!--
Provide a detailed description of what this PR does. Explain the problem you're solving or the feature you're adding.
-->

## Changes
<!--
List the changes you've made in this PR. This is to help the reviewers understand the impact of your changes.
- Change 1
- Change 2
- ...
-->

## Guide for Testers
Bug A: Prompt ignored / needs double entry

  - Open a notebook with some chat history (medium-length session)
  - Type a prompt and press Enter rapidly twice in quick succession — only one message should be sent, never two
  - Type a prompt, press Enter, then immediately click the Send button — only one message should be sent
  - After a validation error (e.g. empty input somehow), the Send button and Enter should remain functional (not stuck in submitting state)
  - On a surface with hostCreateSession (e.g. /opti), send a first message — session creation should work and the composer should not get stuck

  Bug B: Stale file content when uploading .txt files

  - Drag-drop a .txt file into the chat, then immediately press Enter before the upload completes — the send should be blocked (no message sent until upload finishes)
  - Drag-drop a .txt file, wait for the thumbnail to show "complete", then press Enter — Claude should see the actual content of the uploaded file, not old/stale content
  - Drag-drop a .txt file, wait for completion, click Send — same as above, correct file content should be received
  - Upload multiple files via drag-drop, press Enter mid-upload — blocked until all uploads complete
  - Paste a large text block (>30 lines) which auto-uploads as a file, then immediately press Enter — should block until the auto-upload completes

  Regression checks

  - Normal prompt submission (no files) works as before
  - Session-level file uploads (paperclip toggle ON) still attach correctly
  - Message-level file uploads (paperclip toggle OFF) still attach correctly
  - Image uploads with content-moderation scanning still block send until scan clears
  - Slash commands (/roll, /gen_image) still work normally



## Additional Information
<!--
Include any additional information or context that you think would be helpful for your reviewers.
-->

## Developer Notes (Optional)
<!--
Document capability unlocks, architectural improvements, and reusable patterns introduced by this PR.
This helps future developers understand what new building blocks are available.

Categories to consider:
- **New Extension Points**: Components/interfaces that accept new props, hooks, or configuration
- **Reusable Patterns**: New components, utilities, or approaches that can be applied elsewhere
- **Data Model Changes**: New fields, types, or structures that enable future features
- **Architecture Decisions**: Why something was built a certain way (not just what changed)

Example:
- `SchedulerTab` now accepts a `familyId` prop — any new pattern family automatically gets a Learn tab
- `ComingSoonPanel` component can be dropped into any tab to indicate future work
- `effectiveTab` pattern shows how to handle persisted tab state when tabs become conditionally disabled
-->

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
