### PR TITLE
fix(publish): correctness bugs in the published-artifact comment widget

### DIFF
--- a/apps/client/pages/api/publish/__tests__/widget.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import handler from '../widget';
+
+/**
+ * The comment overlay is served as a plain JS string, so these tests drive the handler to get
+ * the real payload and then execute it in jsdom.
+ *
+ * Focus: the launcher/panel must clear the wrapper's bottom livery bar (.b4m-bar), which is
+ * fixed at z-index 2147483647 - the maximum - so the widget cannot stack above it and has to
+ * sit clear of it instead. jsdom does no layout, so we assert the offset MECHANISM (the
+ * --b4m-chrome custom property and the rules that consume it) rather than pixel geometry.
+ */
+function getWidgetJs(): string {
+  let body = '';
+  const res = {
+    setHeader: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+    send: vi.fn((b: string) => {
+      body = b;
+    }),
+  };
+  handler({} as never, res as never);
+  return body;
+}
+
+/** Give an element a non-zero height; jsdom's own getBoundingClientRect is all zeros. */
+function stubHeight(el: Element, height: number): void {
+  el.getBoundingClientRect = () => ({ height }) as DOMRect;
+}
+
+function runWidget(): void {
+  new Function(getWidgetJs())();
+}
+
+function chromeVar(): string {
+  return document.documentElement.style.getPropertyValue('--b4m-chrome');
+}
+
+describe('publish comment widget', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ annotations: [], canComment: false }),
+        })
+      )
+    );
+    document.head.innerHTML = '';
+    document.documentElement.style.removeProperty('--b4m-chrome');
+    document.body.innerHTML =
+      '<iframe></iframe>' +
+      '<div id="b4m-annotate-root" data-public-id="abc123" data-comment-policy="open" data-title="T"></div>';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('offsets the launcher and panel by the livery-bar height instead of a bare 20px', () => {
+    const css = getWidgetJs();
+    // Both must consume --b4m-chrome; a regression to `bottom:20px` buries them under the bar.
+    expect(css).toContain('#b4m-ov{position:fixed;z-index:2147483000;bottom:calc(20px + var(--b4m-chrome,0px))');
+    expect(css).toContain('#b4m-panel{position:fixed;z-index:2147483000;bottom:calc(20px + var(--b4m-chrome,0px))');
+    // The panel must also shrink by the bar height, else a full thread overflows past the top.
+    expect(css).toContain('max-height:min(640px,calc(100vh - 40px - var(--b4m-chrome,0px)))');
+  });
+
+  it('measures the livery bar and exposes it as --b4m-chrome', () => {
+    const bar = document.createElement('div');
+    bar.className = 'b4m-bar';
+    document.body.appendChild(bar);
+    stubHeight(bar, 52);
+
+    runWidget();
+
+    expect(chromeVar()).toBe('52px');
+  });
+
+  it('falls back to a zero offset when the page renders no livery bar', () => {
+    runWidget();
+
+    expect(chromeVar()).toBe('0px');
+  });
+
+  it('re-measures on resize, since the bar wraps taller on narrow viewports', () => {
+    const bar = document.createElement('div');
+    bar.className = 'b4m-bar';
+    document.body.appendChild(bar);
+    stubHeight(bar, 52);
+
+    runWidget();
+    expect(chromeVar()).toBe('52px');
+
+    stubHeight(bar, 84);
+    window.dispatchEvent(new Event('resize'));
+
+    expect(chromeVar()).toBe('84px');
+  });
+
+  it('mounts the launcher and panel', () => {
+    runWidget();
+
+    expect(document.getElementById('b4m-ov')).not.toBeNull();
+    expect(document.getElementById('b4m-panel')).not.toBeNull();
+  });
+});

--- a/apps/client/pages/api/publish/__tests__/widget.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.test.ts
@@ -102,6 +102,17 @@ describe('publish comment widget', () => {
     expect(chromeVar()).toBe('84px');
   });
 
+  it('bypasses the HTTP cache on the initial list load but not on polls', () => {
+    runWidget();
+
+    const listCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+      c => !String(c[0]).endsWith('/can-comment')
+    );
+    // A reload wipes the in-memory justPostedId guard, so a cached pre-comment body
+    // would make the viewer's own fresh comment appear to vanish.
+    expect(listCall?.[1]).toMatchObject({ cache: 'no-store' });
+  });
+
   it('mounts the launcher and panel', () => {
     runWidget();
 

--- a/apps/client/pages/api/publish/__tests__/widget.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.test.ts
@@ -108,7 +108,7 @@ describe('publish comment widget', () => {
     const listCall = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
       c => !String(c[0]).endsWith('/can-comment')
     );
-    // A reload wipes the in-memory justPostedId guard, so a cached pre-comment body
+    // A reload wipes the in-memory justPosted guard, so a cached pre-comment body
     // would make the viewer's own fresh comment appear to vanish.
     expect(listCall?.[1]).toMatchObject({ cache: 'no-store' });
   });

--- a/apps/client/pages/api/publish/__tests__/widget.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.test.ts
@@ -120,3 +120,171 @@ describe('publish comment widget', () => {
     expect(document.getElementById('b4m-panel')).not.toBeNull();
   });
 });
+
+/**
+ * Behavioural tests that need the panel actually open and rendered, driven through the
+ * real DOM the widget builds. The fetch mock below is scriptable per test so a poll can
+ * be made to return a STALE list (the state that exposes the pending-comment bug) and
+ * responses can carry a Date header (which drives the clock-skew correction).
+ */
+interface StubResponse {
+  ok: boolean;
+  status: number;
+  headers: { get: (k: string) => string | null };
+  json: () => Promise<unknown>;
+}
+
+function jsonRes(body: unknown, status = 200, dateMs?: number): StubResponse {
+  return {
+    ok: status < 400,
+    status,
+    headers: {
+      get: (k: string) => (k.toLowerCase() === 'date' && dateMs != null ? new Date(dateMs).toUTCString() : null),
+    },
+    json: () => Promise.resolve(body),
+  };
+}
+
+interface Comment {
+  id: string;
+  authorDisplayName: string;
+  body: string;
+  createdAt: string;
+  resolvedAt: string | null;
+}
+
+function installFetch(opts: {
+  list: () => Comment[];
+  canComment: boolean;
+  serverDateMs?: number;
+  onPost?: () => Comment;
+}): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: unknown, init?: { method?: string }) => {
+      const u = String(url);
+      if (u.endsWith('/can-comment')) {
+        return Promise.resolve(jsonRes({ commentPolicy: 'open', canComment: opts.canComment }));
+      }
+      if (init?.method === 'POST') return Promise.resolve(jsonRes(opts.onPost!(), 201));
+      return Promise.resolve(jsonRes({ annotations: opts.list(), commentPolicy: 'open' }, 200, opts.serverDateMs));
+    })
+  );
+}
+
+/** Let the widget's fetch chains settle. */
+const flush = () => vi.advanceTimersByTimeAsync(0);
+
+const click = (id: string) => (document.getElementById(id) as HTMLElement).click();
+const listText = () => document.getElementById('b4m-list')?.textContent ?? '';
+
+// The boot call to loop() schedules the first poll while the panel is still closed, so
+// it lands at the 60s (closed) cadence even if the panel is opened immediately after.
+const FIRST_POLL_MS = 60000;
+
+describe('publish comment widget - rendered behaviour', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.head.innerHTML = '';
+    document.documentElement.style.removeProperty('--b4m-chrome');
+    document.body.innerHTML =
+      '<iframe></iframe>' +
+      '<div id="b4m-annotate-root" data-public-id="abc123" data-comment-policy="open" data-title="T"></div>';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps every just-posted comment when a poll returns a list that predates them', async () => {
+    vi.setSystemTime(Date.parse('2026-01-01T00:00:00.000Z'));
+    let posted = 0;
+    installFetch({
+      // The server list never catches up - exactly what a cached/stale poll looks like.
+      list: () => [],
+      canComment: true,
+      onPost: () => {
+        posted += 1;
+        return {
+          id: 'c' + posted,
+          authorDisplayName: 'Me',
+          body: 'body ' + posted,
+          createdAt: new Date().toISOString(),
+          resolvedAt: null,
+        };
+      },
+    });
+
+    runWidget();
+    await flush();
+    click('b4m-launch');
+    await flush();
+
+    // Two comments inside one poll window. A single-slot guard protects only the second.
+    for (const text of ['first', 'second']) {
+      (document.getElementById('b4m-ta') as HTMLTextAreaElement).value = text;
+      click('b4m-send');
+      await flush();
+    }
+
+    await vi.advanceTimersByTimeAsync(FIRST_POLL_MS);
+
+    expect(listText()).toContain('body 1');
+    expect(listText()).toContain('body 2');
+  });
+
+  it('stops protecting a posted comment once it ages out', async () => {
+    vi.setSystemTime(Date.parse('2026-01-01T00:00:00.000Z'));
+    installFetch({
+      list: () => [],
+      canComment: true,
+      onPost: () => ({
+        id: 'c1',
+        authorDisplayName: 'Me',
+        body: 'orphan',
+        createdAt: new Date().toISOString(),
+        resolvedAt: null,
+      }),
+    });
+
+    runWidget();
+    await flush();
+    click('b4m-launch');
+    await flush();
+    (document.getElementById('b4m-ta') as HTMLTextAreaElement).value = 'orphan';
+    click('b4m-send');
+    await flush();
+
+    // Still held over the first poll - it may legitimately just be a stale list.
+    await vi.advanceTimersByTimeAsync(FIRST_POLL_MS);
+    expect(listText()).toContain('orphan');
+
+    // Past PENDING_TTL_MS with the server list still empty: the local copy is dropped
+    // rather than resurrected forever (e.g. it was deleted before it ever appeared).
+    await vi.advanceTimersByTimeAsync(300000);
+    expect(listText()).not.toContain('orphan');
+  });
+
+  it('renders ages against the server clock, not a skewed client clock', async () => {
+    const clientNow = Date.parse('2026-01-01T00:00:00.000Z');
+    vi.setSystemTime(clientNow);
+    const serverNow = clientNow + 3 * 3600_000; // the browser's clock runs 3h behind
+    const twoHoursOld = new Date(serverNow - 2 * 3600_000).toISOString();
+
+    installFetch({
+      list: () => [{ id: 'a1', authorDisplayName: 'Bob', body: 'hi', createdAt: twoHoursOld, resolvedAt: null }],
+      canComment: false,
+      serverDateMs: serverNow,
+    });
+
+    runWidget();
+    await flush();
+    click('b4m-launch');
+    await flush();
+
+    // Uncorrected, client-now minus createdAt is negative and clamps to "just now".
+    expect(listText()).toContain('2h ago');
+    expect(listText()).not.toContain('just now');
+  });
+});

--- a/apps/client/pages/api/publish/__tests__/widget.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.test.ts
@@ -119,6 +119,16 @@ describe('publish comment widget', () => {
     expect(document.getElementById('b4m-ov')).not.toBeNull();
     expect(document.getElementById('b4m-panel')).not.toBeNull();
   });
+
+  it('scopes the sans-serif font to the panel, which is appended to body not #b4m-ov', () => {
+    const css = getWidgetJs();
+    // The panel and hint live outside #b4m-ov, so the font rule must name them or they
+    // fall back to the host page's default serif (buttons hide it via a UA sans default).
+    const fontRule = css.split('\n').find(line => line.includes('font-family:ui-sans-serif'));
+    expect(fontRule).toBeDefined();
+    expect(fontRule).toContain('#b4m-panel');
+    expect(fontRule).toContain('#b4m-panel *');
+  });
 });
 
 /**

--- a/apps/client/pages/api/publish/annotations/[publicId].ts
+++ b/apps/client/pages/api/publish/annotations/[publicId].ts
@@ -104,8 +104,12 @@ const handler = baseApi({ auth: false })
     // Only OPEN-public (ungated) may be shared-cached: a gated artifact's list is
     // authorized per viewer, so it keeps the no-store default even though its
     // visibility is still 'public'.
+    // No stale-while-revalidate: it let a viewer who had just commented be served the
+    // pre-comment body for up to a further 60s, so a fresh comment appeared to vanish
+    // on reload. A short shared TTL still collapses the polling fan-out. The widget
+    // additionally sends `cache: 'no-store'` on its FIRST load for the same reason.
     if (isOpenPublic(artifact)) {
-      res.setHeader('Cache-Control', 'public, max-age=5, s-maxage=15, stale-while-revalidate=60');
+      res.setHeader('Cache-Control', 'public, max-age=5, s-maxage=5');
     }
     return res.status(200).json(response);
   })

--- a/apps/client/pages/api/publish/annotations/[publicId].ts
+++ b/apps/client/pages/api/publish/annotations/[publicId].ts
@@ -151,7 +151,12 @@ const handler = baseApi({ auth: false })
         createdAt: { $gte: new Date(Date.now() - COMMENT_RATE_WINDOW_MS) },
       });
       if (recent >= COMMENT_RATE_MAX) {
-        return res.status(429).json({ error: 'You are commenting too quickly - please slow down' });
+        // Names the account-wide window explicitly: it counts across ALL artifacts, so
+        // a message about "this artifact" would misdirect when it fires somewhere the
+        // author has not commented.
+        return res.status(429).json({
+          error: 'You have posted too many comments across your account recently - please slow down',
+        });
       }
     }
 

--- a/apps/client/pages/api/publish/annotations/__tests__/list-cache.test.ts
+++ b/apps/client/pages/api/publish/annotations/__tests__/list-cache.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * GET /api/publish/annotations/[publicId] - cache posture of the annotation list.
+ *
+ * The list is deliberately shared-cacheable so the widget's polling fan-out collapses
+ * at the CDN, which makes its exact Cache-Control a correctness concern: it previously
+ * carried `stale-while-revalidate=60`, so a viewer who had just commented could be
+ * served the pre-comment body for another minute and their comment appeared to vanish
+ * on reload. Only OPEN-public (public AND ungated) may be cached at all.
+ */
+
+const dbMocks = vi.hoisted(() => ({
+  artifactLean: vi.fn(),
+  annotationLean: vi.fn(),
+}));
+
+// The route chains .get(...).post(...), so .get must return the GET handler with a
+// .post that swallows the write handler and hands the GET one back - the default
+// export is then the GET handler itself.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const chain: Record<string, unknown> = {};
+    Object.assign(chain, {
+      use: () => chain,
+      get: (fn: object) => Object.assign(fn, { post: () => fn }),
+    });
+    return chain;
+  },
+}));
+vi.mock('@server/middlewares/optionalAuth', () => ({ optionalAuth: () => {} }));
+vi.mock('@bike4mind/database', () => ({
+  PublishedArtifact: { findOne: () => ({ select: () => ({ lean: dbMocks.artifactLean }) }) },
+  Annotation: { find: () => ({ sort: () => ({ lean: dbMocks.annotationLean }) }) },
+}));
+vi.mock('@server/services/publish', () => ({
+  checkVisibility: vi.fn(async () => ({ ok: true })),
+  canAnnotate: () => false,
+  toPublishUser: () => undefined,
+  authorDisplayName: () => 'User',
+  toAnnotationDto: (a: unknown) => a,
+  requestHasGateProof: () => false,
+}));
+
+import handler from '../[publicId]';
+
+type Res = {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  setHeader: (k: string, v: string) => void;
+  status: (c: number) => Res;
+  json: (o: unknown) => Res;
+};
+
+function makeRes(): Res {
+  const res = { statusCode: 0, headers: {}, body: undefined } as unknown as Res;
+  res.setHeader = (k, v) => {
+    res.headers[k] = v;
+  };
+  res.status = c => {
+    res.statusCode = c;
+    return res;
+  };
+  res.json = o => {
+    res.body = o;
+    return res;
+  };
+  return res;
+}
+
+const run = (): Promise<Res> => {
+  const res = makeRes();
+  const req = { query: { publicId: 'pub1' }, user: undefined, headers: {}, cookies: {} };
+  return (handler as unknown as (q: unknown, s: unknown) => Promise<void>)(req, res).then(() => res);
+};
+
+const cacheControl = (res: Res) => res.headers['Cache-Control'];
+
+describe('GET annotations list - cache posture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.annotationLean.mockResolvedValue([]);
+  });
+
+  it('shared-caches an open-public list briefly, with no stale-while-revalidate', async () => {
+    dbMocks.artifactLean.mockResolvedValue({
+      publicId: 'pub1',
+      visibility: 'public',
+      ownerId: 'o1',
+      scopeId: 's1',
+      commentPolicy: 'open',
+      accessGate: null,
+    });
+
+    const res = await run();
+
+    expect(res.statusCode).toBe(200);
+    expect(cacheControl(res)).toBe('public, max-age=5, s-maxage=5');
+    // A fresh comment must never be maskable by a stale body served from cache.
+    expect(cacheControl(res)).not.toContain('stale-while-revalidate');
+  });
+
+  it('never caches a gated artifact, even though its visibility is still public', async () => {
+    dbMocks.artifactLean.mockResolvedValue({
+      publicId: 'pub1',
+      visibility: 'public',
+      ownerId: 'o1',
+      scopeId: 's1',
+      commentPolicy: 'open',
+      accessGate: { kind: 'passphrase' },
+    });
+
+    const res = await run();
+
+    expect(res.statusCode).toBe(200);
+    expect(cacheControl(res)).toBe('private, no-store');
+  });
+
+  it('never caches a private artifact', async () => {
+    dbMocks.artifactLean.mockResolvedValue({
+      publicId: 'pub1',
+      visibility: 'private',
+      ownerId: 'o1',
+      scopeId: 's1',
+      commentPolicy: 'open',
+      accessGate: null,
+    });
+
+    const res = await run();
+
+    expect(res.statusCode).toBe(200);
+    expect(cacheControl(res)).toBe('private, no-store');
+  });
+
+  it('leaves a 404 non-cacheable so it cannot poison the shared key', async () => {
+    dbMocks.artifactLean.mockResolvedValue(null);
+
+    const res = await run();
+
+    expect(res.statusCode).toBe(404);
+    expect(cacheControl(res)).toBe('private, no-store');
+  });
+});

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -30,7 +30,15 @@ const WIDGET_JS = String.raw`(function () {
   var origin = window.location.origin;
   var API = origin + '/api/publish/annotations/' + encodeURIComponent(publicId);
 
-  var state = { comments: [], canComment: false, open: false, pinMode: false, pendingAnchor: null, draft: '', justPostedId: null };
+  // justPosted holds EVERY comment of ours the server list has not caught up to yet,
+  // as [{id, at}] - a single slot would leave an earlier comment unprotected as soon
+  // as a second one was posted, and the next stale poll would drop it. Entries expire
+  // after PENDING_TTL_MS so a comment deleted before it ever appeared in the list
+  // cannot be resurrected indefinitely. Must stay well above the poll cadence (60s
+  // closed / 15s open) and the list's cache staleness, or a comment would be dropped
+  // while it is still legitimately waiting to show up.
+  var PENDING_TTL_MS = 300000;
+  var state = { comments: [], canComment: false, open: false, pinMode: false, pendingAnchor: null, draft: '', justPosted: [] };
 
   function getToken() {
     try {
@@ -47,8 +55,22 @@ const WIDGET_JS = String.raw`(function () {
     if (t) h['Authorization'] = 'Bearer ' + t;
     return h;
   }
+  // Server clock minus client clock, learned from the initial list response's Date
+  // header. Timestamps come from the server but were being compared against the
+  // browser's clock, so a viewer whose clock ran behind saw every comment as "just
+  // now". Only the FIRST load is sampled: it is sent no-store, so its Date header is
+  // genuinely fresh, whereas a cached response's Date is older by its cache age.
+  var serverSkewMs = 0;
+  function noteServerClock(r) {
+    try {
+      var d = r.headers && r.headers.get && r.headers.get('date');
+      if (!d) return;
+      var t = new Date(d).getTime();
+      if (!isNaN(t)) serverSkewMs = t - Date.now();
+    } catch (e) { /* header unreadable - leave the skew at 0 */ }
+  }
   function timeAgo(iso) {
-    var s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+    var s = Math.max(0, (Date.now() + serverSkewMs - new Date(iso).getTime()) / 1000);
     if (s < 60) return 'just now';
     if (s < 3600) return Math.floor(s / 60) + 'm ago';
     if (s < 86400) return Math.floor(s / 3600) + 'h ago';
@@ -301,11 +323,10 @@ const WIDGET_JS = String.raw`(function () {
     // in-memory justPostedId guard below cannot help here - a reload wipes it.
     // Polls keep the default cache mode, so the fan-out collapse is preserved.
     return fetch(API, { headers: headers(false), credentials: 'omit', cache: 'no-store' })
-      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+      .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); noteServerClock(r); return r.json(); })
       .then(function (data) {
         state.comments = data.annotations || [];
         policy = data.commentPolicy || policy;
-        lastSig = sig(state.comments); // seed so the first poll doesn't re-render identical data
         render();
       })
       .catch(function () { /* artifact may be private to this viewer; stay quiet */ render(); });
@@ -337,7 +358,11 @@ const WIDGET_JS = String.raw`(function () {
         if (!r.ok) return r.json().then(function (j) { throw new Error(j.error || ('HTTP ' + r.status)); });
         return r.json();
       })
-      .then(function (created) { state.comments.push(created); state.justPostedId = created.id; render(); });
+      .then(function (created) {
+        state.comments.push(created);
+        state.justPosted.push({ id: created.id, at: Date.now() });
+        render();
+      });
   }
 
   // ---- smart polling: pick up other users' comments without a reload ----
@@ -348,7 +373,6 @@ const WIDGET_JS = String.raw`(function () {
   function sig(list) {
     return list.length + ':' + list.map(function (c) { return c.id + (c.resolvedAt ? 'R' : ''); }).join(',');
   }
-  var lastSig = '';
   var lastCanComment = null;
   function poll() {
     if (document.visibilityState !== 'visible') return;
@@ -359,17 +383,26 @@ const WIDGET_JS = String.raw`(function () {
       .then(function (data) {
         if (!data) return;
         var incoming = data.annotations || [];
-        // Don't let a poll whose fetch predated your just-posted comment drop it from
-        // the list (it self-heals next cycle, but the blink is avoidable). Keep the
-        // local copy until the server's list reflects it. Only protects YOUR fresh
-        // post — never resurrects others' deletes.
-        if (state.justPostedId) {
-          if (incoming.some(function (c) { return c.id === state.justPostedId; })) state.justPostedId = null;
-          else incoming = incoming.concat(state.comments.filter(function (c) { return c.id === state.justPostedId; }));
+        // Don't let a poll whose fetch predated your just-posted comments drop them
+        // from the list (it self-heals next cycle, but the blink is avoidable). Keep
+        // the local copies until the server's list reflects them. Only protects YOUR
+        // fresh posts — never resurrects others' deletes.
+        if (state.justPosted.length) {
+          var now = Date.now();
+          // Retire an entry once the server list carries it, or once it ages out.
+          state.justPosted = state.justPosted.filter(function (p) {
+            return now - p.at < PENDING_TTL_MS && !incoming.some(function (c) { return c.id === p.id; });
+          });
+          var pending = state.comments.filter(function (c) {
+            return state.justPosted.some(function (p) { return p.id === c.id; });
+          });
+          if (pending.length) incoming = incoming.concat(pending);
         }
-        var s = sig(incoming);
-        if (s === lastSig) return; // nothing changed
-        lastSig = s;
+        // Compare against what is actually on screen rather than a remembered
+        // signature: an optimistic local copy can diverge from the last server
+        // response, and a remembered signature would then early-return forever and
+        // never reconcile it away.
+        if (sig(incoming) === sig(state.comments)) return; // nothing changed
         state.comments = incoming;
         render();
       })

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -295,7 +295,12 @@ const WIDGET_JS = String.raw`(function () {
   var CAN_API = API + '/can-comment';
 
   function loadList() {
-    return fetch(API, { headers: headers(false), credentials: 'omit' })
+    // no-store on the INITIAL load only: the list is deliberately cacheable for the
+    // polling fan-out, but a reader who just posted (or reloaded right after someone
+    // else did) would otherwise be served their own stale pre-comment copy. The
+    // in-memory justPostedId guard below cannot help here - a reload wipes it.
+    // Polls keep the default cache mode, so the fan-out collapse is preserved.
+    return fetch(API, { headers: headers(false), credentials: 'omit', cache: 'no-store' })
       .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(function (data) {
         state.comments = data.annotations || [];

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -80,7 +80,10 @@ const WIDGET_JS = String.raw`(function () {
   // ---- styles (style-src allows 'unsafe-inline') ----
   var css = document.createElement('style');
   css.textContent = [
-    '#b4m-ov,#b4m-ov *{box-sizing:border-box;font-family:ui-sans-serif,system-ui,-apple-system,sans-serif}',
+    // Cover all three widget roots, not just #b4m-ov: the panel and the hint toast are
+    // appended to <body> (not inside #b4m-ov), so without this they inherit the host
+    // page's default serif. Buttons masked the bug by defaulting to a UA sans-serif.
+    '#b4m-ov,#b4m-ov *,#b4m-panel,#b4m-panel *,#b4m-hint{box-sizing:border-box;font-family:ui-sans-serif,system-ui,-apple-system,sans-serif}',
     // --b4m-chrome is the height of the wrapper's bottom livery bar (.b4m-bar), measured at
     // boot. That bar is fixed at z-index 2147483647 (the max), so we cannot stack above it -
     // the launcher and panel must sit clear of it instead. Must stay in sync with the bar in

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -59,11 +59,15 @@ const WIDGET_JS = String.raw`(function () {
   var css = document.createElement('style');
   css.textContent = [
     '#b4m-ov,#b4m-ov *{box-sizing:border-box;font-family:ui-sans-serif,system-ui,-apple-system,sans-serif}',
-    '#b4m-ov{position:fixed;z-index:2147483000;bottom:20px;right:20px}',
+    // --b4m-chrome is the height of the wrapper's bottom livery bar (.b4m-bar), measured at
+    // boot. That bar is fixed at z-index 2147483647 (the max), so we cannot stack above it -
+    // the launcher and panel must sit clear of it instead. Must stay in sync with the bar in
+    // renderBundleWrapper (pages/api/publish/serve/[...path].ts).
+    '#b4m-ov{position:fixed;z-index:2147483000;bottom:calc(20px + var(--b4m-chrome,0px));right:20px}',
     '#b4m-launch{display:flex;align-items:center;gap:8px;background:#1a1a2e;color:#fff;border:0;border-radius:999px;padding:11px 16px;font-size:14px;font-weight:600;cursor:pointer;box-shadow:0 6px 24px rgba(0,0,0,.28)}',
     '#b4m-launch:hover{background:#2a2a44}',
     '#b4m-launch .dot{background:#8ab4ff;color:#0f0f1a;border-radius:999px;min-width:20px;height:20px;display:inline-flex;align-items:center;justify-content:center;font-size:12px;padding:0 5px}',
-    '#b4m-panel{position:fixed;bottom:20px;right:20px;width:360px;max-width:calc(100vw - 32px);max-height:min(640px,calc(100vh - 40px));background:#fff;color:#1a1a2e;border-radius:14px;box-shadow:0 12px 48px rgba(0,0,0,.32);display:none;flex-direction:column;overflow:hidden}',
+    '#b4m-panel{position:fixed;z-index:2147483000;bottom:calc(20px + var(--b4m-chrome,0px));right:20px;width:360px;max-width:calc(100vw - 32px);max-height:min(640px,calc(100vh - 40px - var(--b4m-chrome,0px)));background:#fff;color:#1a1a2e;border-radius:14px;box-shadow:0 12px 48px rgba(0,0,0,.32);display:none;flex-direction:column;overflow:hidden}',
     '#b4m-panel.b4m-open{display:flex}',
     '#b4m-head{display:flex;align-items:center;justify-content:space-between;padding:13px 15px;border-bottom:1px solid #ececf3}',
     '#b4m-head b{font-size:15px}',
@@ -127,6 +131,16 @@ const WIDGET_JS = String.raw`(function () {
   panel.id = 'b4m-panel';
   document.body.appendChild(ov);
   document.body.appendChild(panel);
+
+  // The bottom livery bar is present only on own-tab open-public renders, and its height
+  // grows when its contents wrap on narrow viewports - so measure rather than hardcode 52px.
+  function syncChrome() {
+    var bar = document.querySelector('.b4m-bar');
+    var h = bar ? bar.getBoundingClientRect().height : 0;
+    document.documentElement.style.setProperty('--b4m-chrome', h + 'px');
+  }
+  syncChrome();
+  window.addEventListener('resize', syncChrome);
 
   function el(tag, cls, text) { var e = document.createElement(tag); if (cls) e.className = cls; if (text != null) e.textContent = text; return e; }
 

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -320,7 +320,7 @@ const WIDGET_JS = String.raw`(function () {
     // no-store on the INITIAL load only: the list is deliberately cacheable for the
     // polling fan-out, but a reader who just posted (or reloaded right after someone
     // else did) would otherwise be served their own stale pre-comment copy. The
-    // in-memory justPostedId guard below cannot help here - a reload wipes it.
+    // in-memory justPosted guard below cannot help here - a reload wipes it.
     // Polls keep the default cache mode, so the fan-out collapse is preserved.
     return fetch(API, { headers: headers(false), credentials: 'omit', cache: 'no-store' })
       .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); noteServerClock(r); return r.json(); })

--- a/scripts/no-baseapi-allowlist.txt
+++ b/scripts/no-baseapi-allowlist.txt
@@ -18,6 +18,7 @@ apps/client/pages/api/__tests__/react-artifact-sandbox.test.ts # Test file for t
 apps/client/pages/api/__tests__/sessionRedactionGuard.test.ts # Static-analysis guard test (#9405); reads route source via fs, not an API route
 apps/client/pages/api/feedback/[id]/__tests__/update.ability.test.ts # Pure CASL unit test (class-vs-instance); no HTTP route, no baseApi
 apps/client/pages/api/publish/widget.ts                 # Static first-party comment-overlay JS; intentionally public, no user data, no DB
+apps/client/pages/api/publish/__tests__/widget.test.ts  # Test file for the handler above (script greps by path, not export)
 apps/client/pages/api/embed/widget.ts                   # Static first-party embed-loader JS; intentionally public, no user data, no DB (epic #41 Phase C)
 apps/client/pages/api/embed/__tests__/widget.test.ts    # Test file for the handler above (script greps by path, not export)
 


### PR DESCRIPTION
## Description

The comment overlay on published artifacts had a cluster of correctness bugs. Individually most were small; together they were why the feature read as unreliable. This closes all five items in #886.

The most visible ones:

**The launcher and panel were painted over by the livery bar.** The wrapper's bottom brand bar is `position:fixed` at `z-index:2147483647` (the maximum) and 52px tall. The comment overlay sat at `bottom:20px`, so the bar covered roughly 32 of the launcher's 39 pixels and it read as absent. The panel was worse: its bottom 32px are exactly where the textarea, pin toggle, and **Comment** button live, so the composer could not be clicked at all. Only own-tab open-public renders draw the bar, which is why private, gated, and embedded artifacts looked fine and the bug seemed intermittent. The iframe had already been shortened to `calc(100vh - 52px)` to make room for the bar; the `position:fixed` overlay never got the same treatment.

**A fresh comment vanished on reload.** The annotation list carried `stale-while-revalidate=60`, and nothing invalidated it on write, so for up to ~65s after commenting a viewer could be handed the pre-comment body straight from cache. The widget's in-memory guard covers this while the page stays open, but a reload wipes it -- so it covered every case except the one users hit.

**The panel text rendered in the host page's serif font** (found during QA, not part of #886). The font rule targeted `#b4m-ov` and its descendants, but the panel and hint toast are appended to `<body>`, not inside `#b4m-ov`, so their text fell back to the default serif. The buttons masked it by defaulting to a UA sans-serif, leaving comment bodies and author names mismatched against them.

The remaining three from #886 are conditional: a second comment posted inside one poll window could drop the first, comment ages were computed against the browser's clock, and the throttle message implied a per-artifact limit when the window is account-wide.

## Changes

- **Livery bar overlap.** Stacking above the bar is impossible at max z-index, so the launcher and panel are offset by its height instead, via a `--b4m-chrome` custom property measured at boot and on resize (the bar wraps taller on narrow viewports, so it is measured rather than hardcoded to 52px). The panel's `max-height` subtracts the same value, and the panel gained an explicit `z-index` -- it previously had none.
- **Reload staleness.** Dropped `stale-while-revalidate` and cut `s-maxage` from 15 to 5 on the list response, and the widget now sends `cache: 'no-store'` on its **first** list load only, so the polling fan-out stays collapsible at the CDN.
- **Pending comments.** `state.justPostedId` held a single id, so posting a second comment left the first unguarded. It now tracks every unconfirmed post, retiring each when the server list carries it or after a TTL, so a comment deleted before it ever appeared cannot be resurrected indefinitely.
- **Comment ages.** `timeAgo` compared server-issued `createdAt` values against the browser's clock. The offset is now learned from the `Date` header on the initial list response and applied. Only the first load is sampled: it is sent `no-store`, so its `Date` is fresh, whereas a cached response's `Date` trails by its cache age.
- **Throttle copy.** Reworded to name the account-wide window. Wording only; the window is unchanged.
- **Panel font (not in #886).** Named all three body-appended widget roots (`#b4m-ov`, `#b4m-panel` + descendants, `#b4m-hint`) in the font rule so the panel matches the sans-serif buttons instead of inheriting the host page's serif.
- **CI allowlist.** Added the new `widget.test.ts` to `scripts/no-baseapi-allowlist.txt` -- the `check-no-baseapi` script greps every file under `pages/api` by path, and this test drives a handler that (like its already-allowlisted `widget.ts`) intentionally skips `baseApi`. Mirrors the existing `embed/__tests__/widget.test.ts` entry.
- **Poll loop (please read -- not implied by the issue).** `poll()` compared the incoming list against a _remembered_ signature. An optimistic local copy can diverge from the last server response, and the remembered signature would then early-return forever and never reconcile it away. It now compares against what is actually rendered. This is a real behavioural change to the poll loop, and it is what made the pending-comment TTL above reachable at all.

## Guide for Testers

Requires an artifact published as **public** with comments enabled, opened in its own tab (not an embed) -- the bugs only appear on that render.

**Setup**

1. In a notebook session, prompt the assistant for a single-page HTML artifact. It renders in the Knowledge Viewer panel on the right.
2. Click the publish icon in the Knowledge Viewer tab toolbar (tooltip "Publish", testid `knowledgeviewer-publish-btn`). Note: this button is admin-only.
3. In the publish modal, set visibility to **Public** and confirm the **Allow comments** toggle is on (testid `publish-share-comments-toggle`; it defaults on).
4. Click Create (testid `publish-share-create`) and copy the URL from `publish-share-url`. It looks like `/p/u/<userId>/<slug>`.
5. Open that URL in a new tab. Expected: the artifact renders, with an orange "Try the app" bar pinned across the bottom.

**Bug 1 -- launcher and composer are reachable**

6. Look at the bottom-right corner. Expected: a dark "Comments 0" pill sits fully visible **above** the orange bar, not clipped by it.
7. Click the pill. Expected: the comment panel opens.
8. Scroll to the bottom of the panel. Expected: the text area, the "drop a pin" button, and the "Comment" button are all fully visible and clickable -- none sit underneath the orange bar.
9. Narrow the browser window until the orange bar's contents wrap onto two lines. Expected: the launcher and panel move up to stay clear of the taller bar.
10. With the panel open, read the header ("Comments"), an author name, and a comment body. Expected: they render in the same sans-serif font as the "Comment" button -- not a serif (Times-like) font.

**Bug 2 -- a fresh comment survives a reload**

11. With the panel open, type `first comment` in the text area and click **Comment**. Expected: it appears in the list immediately.
12. Reload the page within about 5 seconds (Cmd-R / F5).
13. Open the comment panel again. Expected: `first comment` is still listed. Before this fix it disappeared for up to a minute.

**Bug 3 -- two quick comments both survive**

14. With the panel open, post `comment A`, then immediately post `comment B` (within about 15 seconds of each other).
15. Wait 60 seconds without reloading, leaving the panel open.
16. Expected: **both** `comment A` and `comment B` are still listed. Before this fix, `comment A` disappeared at the first poll.

**Bug 4 -- comment ages (optional, needs a clock change)**

17. Note the timestamp on an existing comment, e.g. "2h ago".
18. Set the machine clock back one hour, then reload the page and reopen the panel.
19. Expected: the comment still reads "2h ago", not "just now".
20. Restore the machine clock.

**Bug 5 -- throttle copy (code-only; not practical to test by hand)**

Triggering it needs a non-admin account posting 30 comments within 60 seconds via the API (admins are exempt). The change is wording only -- no behaviour change -- so verifying the string in the diff is sufficient.

**Regression Checks**

21. With two browsers signed in as different users on the same artifact, post a comment as user A. Expected: it appears for user B within about 60 seconds without a reload.
22. Start typing a comment and leave the text area focused for 60+ seconds while a poll fires. Expected: your draft text and cursor position are preserved, and a pending pin stays put.
23. Delete a comment via the API and wait for a poll. Expected: it disappears and does not come back.
24. Open a **private** artifact's published page. Expected: the comment widget still loads and behaves normally (no livery bar renders there).
25. Open an artifact with comments disabled. Expected: no comment launcher appears at all.

**What NOT to test**

Reply shares (`/p/r/...`), fabfile shares (`/p/f/...`), and embedded renders never carry the comment overlay. Nothing changed there.

## Additional Information

**The widget JS is itself cached for up to ~24h.** `/api/publish/widget` is served with `public, max-age=300, s-maxage=3600, stale-while-revalidate=86400`, so after deploy a returning viewer can keep running the _old_ widget for as long as a day. The server-side half of the staleness fix (the `Cache-Control` change) applies immediately; the client-side fixes (bugs 1, 3, 4) do not. Worth accounting for when verifying on staging -- use a hard reload, or a fresh profile.

**Known pre-existing, not touched here.** The poll cadence comment in `widget.ts` says "45s" where the code uses 60000. Left alone to keep the diff scoped to #886.

**Test results.** 6710 passed. 5 failures, all Mongo-backed e2e tests timing out at 15s under parallel load (`user-api-keys.e2e`, `embedSpendCap.e2e`, `groupInviteAuth.e2e`, `apiKeyRateLimitReset.e2e`) -- none in `pages/api/publish/**`, and a baseline run on `main` fails a different set, confirming they are load-flaky rather than caused by this branch. `pnpm --filter @bike4mind/client typecheck` has 6 pre-existing errors (TTS, auth, premium overlay), none in the files touched here.

New coverage: 10 tests in `pages/api/publish/__tests__/widget.test.ts` (bar measurement, cache bypass, pending-comment retention and expiry, clock skew, panel font scope) and 4 in `pages/api/publish/annotations/__tests__/list-cache.test.ts` (cache posture per visibility, including that the 404 stays non-cacheable).

**Scope note.** Two changes here go beyond #886 -- the panel serif font (QA-found) and the poll-loop signature comparison (see Changes). Both are comment-widget correctness in files this PR already touches; called out so the diff is honest about covering slightly more than the issue.

## Developer Notes (Optional)

- **`--b4m-chrome`** is a general hook for the published-page chrome height. Any future fixed-position affordance on the wrapper can offset by it rather than re-deriving the bar's size.
- **Sampling the server clock from a response header** avoids adding a field to the annotation DTO, which matters because that body is deliberately shared-cacheable and must stay viewer-invariant.
- **The widget's behavioural tests now drive the real DOM** (open the panel, type, click Comment, advance the poll timer) with a scriptable `fetch` stub. That harness is reusable for any future widget behaviour, which previously had no test coverage at all.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings

Closes #886