### PR TITLE
chore(models): align OpenAI catalog with deprecation notice and migrate retired defaults

### DIFF
--- a/apps/client/app/hooks/useAccessibleModels.ts
+++ b/apps/client/app/hooks/useAccessibleModels.ts
@@ -7,7 +7,7 @@ import { useEntitlements } from '@client/app/hooks/data/entitlements';
 // @bike4mind/common. Access is any-of: admin OR (allowedUserTags intersect
 // userTags) OR (allowedEntitlements intersect entitlementKeys); empty keys
 // means tag-only.
-import { isModelAccessible } from '@bike4mind/common';
+import { isModelAccessible, isModelDeprecated } from '@bike4mind/common';
 
 /**
  * Hook that returns only the models that the current user can access
@@ -41,21 +41,24 @@ export function useAccessibleModels() {
     return modelConfigs.filter(model => isModelAccessible(model, userTags, isAdmin, entitlementKeys));
   }, [modelConfigs, userTags, isAdmin, entitlementKeys]);
 
-  // Also provide helpers for specific model types
+  // Type-specific lists feed the model pickers, so they also drop retired models
+  // (deprecationDate reached). The raw `accessibleModels` is intentionally left
+  // unfiltered: it backs validation, default resolution, and fallback, where a
+  // session/agent still pinned to a just-retired model must remain recognized.
   const accessibleTextModels = useMemo(() => {
-    return accessibleModels.filter(model => model.type === 'text');
+    return accessibleModels.filter(model => model.type === 'text' && !isModelDeprecated(model));
   }, [accessibleModels]);
 
   const accessibleImageModels = useMemo(() => {
-    return accessibleModels.filter(model => model.type === 'image');
+    return accessibleModels.filter(model => model.type === 'image' && !isModelDeprecated(model));
   }, [accessibleModels]);
 
   const accessibleSpeechModels = useMemo(() => {
-    return accessibleModels.filter(model => model.type === 'speech-to-text');
+    return accessibleModels.filter(model => model.type === 'speech-to-text' && !isModelDeprecated(model));
   }, [accessibleModels]);
 
   const accessibleVideoModels = useMemo(() => {
-    return accessibleModels.filter(model => model.type === 'video');
+    return accessibleModels.filter(model => model.type === 'video' && !isModelDeprecated(model));
   }, [accessibleModels]);
 
   return {

--- a/apps/client/server/utils/modelResolvers.ts
+++ b/apps/client/server/utils/modelResolvers.ts
@@ -48,11 +48,11 @@ export const getApiKeyTypeFromBackend = (backend: ModelBackend): ApiKeyType | nu
  * Get default image model with fallback priority
  */
 export function getDefaultImageModel(models: ModelInfo[]): ModelInfo | undefined {
-  // Priority order: FLUX_PRO_1_1 -> FLUX_KONTEXT_PRO -> GPT_IMAGE_1 -> any image model
+  // Priority order: FLUX_PRO_1_1 -> FLUX_KONTEXT_PRO -> GPT_IMAGE_2 -> any image model
   return (
     models.find(m => m.id === 'flux-pro-1.1') ||
     models.find(m => m.id === 'flux-kontext-pro') ||
-    models.find(m => m.id === 'gpt-image-1') ||
+    models.find(m => m.id === 'gpt-image-2') ||
     models.find(m => m.type === 'image')
   );
 }

--- a/b4m-core/common/src/schemas/openai.test.ts
+++ b/b4m-core/common/src/schemas/openai.test.ts
@@ -15,9 +15,9 @@ describe('OpenAIImageGenerationInput legacy model remapping', () => {
     }
   });
 
-  it('remaps legacy dall-e ids to gpt-image-1', () => {
-    expect(OpenAIImageGenerationInput.parse({ prompt: 'x', model: 'dall-e-3' }).model).toBe(ImageModels.GPT_IMAGE_1);
-    expect(OpenAIImageGenerationInput.parse({ prompt: 'x', model: 'dall-e-2' }).model).toBe(ImageModels.GPT_IMAGE_1);
+  it('remaps legacy dall-e ids to gpt-image-2', () => {
+    expect(OpenAIImageGenerationInput.parse({ prompt: 'x', model: 'dall-e-3' }).model).toBe(ImageModels.GPT_IMAGE_2);
+    expect(OpenAIImageGenerationInput.parse({ prompt: 'x', model: 'dall-e-2' }).model).toBe(ImageModels.GPT_IMAGE_2);
   });
 
   it('passes supported models through unchanged', () => {

--- a/b4m-core/common/src/schemas/openai.ts
+++ b/b4m-core/common/src/schemas/openai.ts
@@ -107,8 +107,8 @@ export type OpenAIImageStyle = z.infer<typeof OpenAIImageStyleSchema>;
  * same-provider, same-modality replacement.
  */
 export const LEGACY_IMAGE_MODEL_MAP: Record<string, (typeof ALL_IMAGE_MODELS)[number]> = {
-  'dall-e-3': ImageModels.GPT_IMAGE_1,
-  'dall-e-2': ImageModels.GPT_IMAGE_1,
+  'dall-e-3': ImageModels.GPT_IMAGE_2,
+  'dall-e-2': ImageModels.GPT_IMAGE_2,
   'flux-dev': ImageModels.FLUX_PRO_1_1, // removed model -> live BFL standard
   'grok-2-image-1212': ImageModels.GROK_IMAGINE_IMAGE_QUALITY, // original xAI image id -> current id
   'grok-2-image': ImageModels.GROK_IMAGINE_IMAGE_QUALITY, // intermediate xAI image id -> current id

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -333,7 +333,7 @@ export const IntentClassifierConfigSchema = z.object({
   enabled: z.boolean().default(true),
   shadowMode: z.boolean().default(true),
   primaryModel: z.string().default('claude-haiku-4-5-20251001'),
-  fallbackModels: z.array(z.string()).default(['gemini-2.5-flash-lite', 'gpt-4.1-nano-2025-04-14']),
+  fallbackModels: z.array(z.string()).default(['gemini-2.5-flash-lite', 'gpt-5.4-nano']),
 });
 
 export type IntentClassifierConfig = z.infer<typeof IntentClassifierConfigSchema>;

--- a/b4m-core/llm-adapters/src/openaiBackend.ts
+++ b/b4m-core/llm-adapters/src/openaiBackend.ts
@@ -177,6 +177,7 @@ export class OpenAIBackend implements ICompletionBackend {
         logoFile: 'OpenAI_Logo.svg',
         rank: 0,
         trainingCutoff: '2024-06-01',
+        deprecationDate: '2026-10-23', // Deprecated as per https://platform.openai.com/docs/deprecations
         description:
           'Designed for high-volume, low-cost processing with rapid response times, ideal for budget-conscious applications.',
       },
@@ -239,6 +240,7 @@ export class OpenAIBackend implements ICompletionBackend {
         logoFile: 'OpenAI_Logo.svg',
         rank: 0,
         trainingCutoff: '2024-06-01',
+        deprecationDate: '2026-12-11', // Deprecated as per https://platform.openai.com/docs/deprecations
         description:
           "OpenAI's O3 reasoning model with broad capabilities and up-to-date training data. Superseded by O4 Mini for most use cases.",
         isSlowModel: true,
@@ -324,6 +326,7 @@ export class OpenAIBackend implements ICompletionBackend {
         logoFile: 'OpenAI_Logo.svg',
         rank: 10,
         trainingCutoff: '2025-04-01',
+        deprecationDate: '2026-10-23', // Deprecated as per https://platform.openai.com/docs/deprecations
         description:
           "OpenAI's compact reasoning model optimized for fast, cost-efficient performance with strong multimodal and agentic capabilities. Excellent for STEM tasks and coding.",
         isSlowModel: true,
@@ -536,6 +539,7 @@ export class OpenAIBackend implements ICompletionBackend {
         rank: 1,
         trainingCutoff: '2024-09-30',
         releaseDate: '2025-11-13',
+        deprecationDate: '2026-08-10', // Deprecated as per https://platform.openai.com/docs/deprecations
         description: 'Latest GPT-5.2 model version. Automatically updated with improvements and optimizations.',
       },
 
@@ -582,6 +586,7 @@ export class OpenAIBackend implements ICompletionBackend {
         rank: 1,
         trainingCutoff: '2024-09-30',
         releaseDate: '2025-11-13',
+        deprecationDate: '2026-07-23', // Deprecated as per https://platform.openai.com/docs/deprecations
         description:
           'Continuously updated GPT-5.1 chat model with advanced conversational abilities and vision support, ideal for dynamic, real-time applications.',
       },
@@ -674,6 +679,7 @@ export class OpenAIBackend implements ICompletionBackend {
         rank: 3,
         trainingCutoff: '2024-09-30',
         releaseDate: '2025-08-07',
+        deprecationDate: '2026-07-23', // Deprecated as per https://platform.openai.com/docs/deprecations
         description:
           'Continuously updated GPT-5 chat model with advanced conversational abilities and vision support, ideal for dynamic, real-time applications.',
       },
@@ -731,6 +737,7 @@ export class OpenAIBackend implements ICompletionBackend {
         logoFile: 'OpenAI_Logo.svg',
         rank: 10,
         supportsTools: true,
+        deprecationDate: '2026-10-23', // Deprecated as per https://platform.openai.com/docs/deprecations
         description:
           'Delivers fast, efficient text generation with advanced reasoning, a large context window, and integrated vision and tool capabilities.',
       },
@@ -750,6 +757,7 @@ export class OpenAIBackend implements ICompletionBackend {
         logoFile: 'OpenAI_Logo.svg',
         rank: 11,
         supportsTools: false,
+        deprecationDate: '2026-10-23', // Deprecated as per https://platform.openai.com/docs/deprecations
         description:
           "OpenAI's original GPT-4 model. Legacy model good for basic tasks and content generation, but newer models offer better capabilities.",
       },
@@ -768,6 +776,7 @@ export class OpenAIBackend implements ICompletionBackend {
         description:
           'OpenAI GPT-Image-1 - Advanced multimodal image generation with text integration, supporting up to 2048x2048 resolution and image editing capabilities.',
         rank: 10,
+        deprecationDate: '2026-10-23', // Deprecated as per https://platform.openai.com/docs/deprecations
       },
       {
         id: ImageModels.GPT_IMAGE_1_5,
@@ -783,6 +792,7 @@ export class OpenAIBackend implements ICompletionBackend {
         description:
           'OpenAI GPT-Image-1.5 - Enhanced version of GPT-Image-1 with improved image generation quality and text integration, supporting up to 2048x2048 resolution and image editing capabilities.',
         rank: 9,
+        deprecationDate: '2026-12-01', // Deprecated as per https://platform.openai.com/docs/deprecations
       },
       {
         id: ImageModels.GPT_IMAGE_2,
@@ -814,6 +824,7 @@ export class OpenAIBackend implements ICompletionBackend {
         description:
           'OpenAI GPT-Image-1 Mini - Faster, cost-effective version of GPT-Image-1 with good quality image generation and text integration, supporting up to 2048x2048 resolution and image editing capabilities.',
         rank: 11,
+        deprecationDate: '2026-12-01', // Deprecated as per https://platform.openai.com/docs/deprecations
       },
       // OpenAI Speech-to-Text Models
       {
@@ -854,6 +865,8 @@ export class OpenAIBackend implements ICompletionBackend {
         supportsImageVariation: false,
         logoFile: 'OpenAI_Logo.svg',
         rank: 1,
+        // Sora 2 and the Videos API are being removed with no OpenAI replacement. https://platform.openai.com/docs/deprecations
+        deprecationDate: '2026-09-24',
         description:
           "OpenAI's Sora video generation model. Creates high-quality videos from text prompts with durations of 4, 8, or 12 seconds.",
       },
@@ -874,6 +887,8 @@ export class OpenAIBackend implements ICompletionBackend {
         supportsImageVariation: false,
         logoFile: 'OpenAI_Logo.svg',
         rank: 0,
+        // Sora 2 Pro and the Videos API are being removed with no OpenAI replacement. https://platform.openai.com/docs/deprecations
+        deprecationDate: '2026-09-24',
         description:
           "OpenAI's premium Sora video generation model. Produces the highest quality videos with enhanced detail, coherence, and visual fidelity.",
       },

--- a/b4m-core/llm-adapters/src/resolveDeprecatedModel.ts
+++ b/b4m-core/llm-adapters/src/resolveDeprecatedModel.ts
@@ -22,6 +22,13 @@ const DEPRECATED_MODEL_MAP: Record<string, string> = {
   'claude-sonnet-4-20250514': 'claude-sonnet-4-6',
   'claude-3-opus-20240229': 'claude-opus-4-8',
   'claude-3-haiku-20240307': 'claude-haiku-4-5-20251001',
+  // OpenAI-hosted models retired from the API (https://platform.openai.com/docs/deprecations).
+  // These are past their shutdown date and 404 upstream, so a session/agent still pinned to
+  // one must be upgraded here to avoid a hard API failure. Models with a future shutdown date
+  // keep their real ID (they still resolve) and are only hidden from the picker via
+  // deprecationDate in the catalog.
+  'gpt-5-chat-latest': 'gpt-5.5',
+  'gpt-5.1-chat-latest': 'gpt-5.5',
 };
 
 export function resolveDeprecatedModelId(modelId: string, context?: string): string {

--- a/b4m-core/utils/src/adminSettings/fallback.ts
+++ b/b4m-core/utils/src/adminSettings/fallback.ts
@@ -268,8 +268,8 @@ function findAutomaticFallback(
     'us.anthropic.claude-3-7-sonnet-20250219-v1:0': ['global.anthropic.claude-sonnet-4-6', 'gpt-4o'],
 
     // GPT models fallback to Claude
-    'gpt-4o': ['claude-sonnet-4-6', 'claude-opus-4-6', 'gpt-4-turbo'],
-    'gpt-4o-mini': ['claude-haiku-4-5-20251001', 'gpt-3.5-turbo'],
+    'gpt-4o': ['claude-sonnet-4-6', 'claude-opus-4-6', 'gpt-5.5'],
+    'gpt-4o-mini': ['claude-haiku-4-5-20251001', 'gpt-5.4-mini'],
   };
 
   // Get preference list for this model


### PR DESCRIPTION
## Description

Cross-references our OpenAI models against the latest OpenAI [deprecation notice](https://platform.openai.com/docs/deprecations) and reflects every announced retirement that touches our catalog. `deprecationDate` only hides a model from the pickers on/after its date (via `isModelDeprecated`) — it does not block server-side completions, so future-dated flags keep a model fully usable until OpenAI actually retires it, then auto-hide.

This also migrates the handful of **defaults and fallback chains** that pointed at soon-retired models (those would have silently broken at the shutdown date rather than just disappearing from a picker), using OpenAI's own recommended replacements.

## Changes

**Catalog flags (`openaiBackend.ts`)** — added `deprecationDate` to 13 entries:

| Model | Date |
|---|---|
| `gpt-5-chat-latest`, `gpt-5.1-chat-latest` | 2026-07-23 |
| `gpt-5.2-chat-latest` | 2026-08-10 |
| `sora-2`, `sora-2-pro` | 2026-09-24 (Videos API removed, no replacement) |
| `gpt-4.1-nano`, `o4-mini`, `gpt-4-turbo`, `gpt-4`, `gpt-image-1` | 2026-10-23 |
| `gpt-image-1.5`, `gpt-image-1-mini` | 2026-12-01 |
| `o3` | 2026-12-11 |

**Runtime remaps (`resolveDeprecatedModel.ts`)** — the two snapshots retired *today* (`gpt-5-chat-latest`, `gpt-5.1-chat-latest`) map to `gpt-5.5` so any pinned session/agent is upgraded instead of 404-ing upstream. Future-dated models keep their real ID (they still resolve).

**Defaults / fallbacks migrated off retiring models:**
- Intent-classifier `fallbackModels` default: `gpt-4.1-nano-2025-04-14` → `gpt-5.4-nano` (`settings.ts`)
- Fallback chains: `gpt-4-turbo` → `gpt-5.5`, dead `gpt-3.5-turbo` → `gpt-5.4-mini` (`fallback.ts`)
- Default image model + `dall-e-*` legacy remap targets: `gpt-image-1` → `gpt-image-2` (`modelResolvers.ts`, `openai.ts`). `gpt-image-1` was intentionally **not** added to `LEGACY_IMAGE_MODEL_MAP` — that map coerces at request time, so doing so would force-migrate live gpt-image-1 traffic three months early. It follows the chat-model pattern: selectable until its Oct 23 flag fires.

**Picker consistency (`useAccessibleModels.ts`)** — the typed lists (`accessibleTextModels` / `Image` / `Speech` / `Video`) now drop deprecated models, so retired image/video models no longer leak into the agent-config, orchestration, and research pickers (previously only the main `ModelSelection` filtered them). The raw `accessibleModels` stays unfiltered so validation and default resolution still recognize an already-pinned model.

## Guide for Testers

This is a backend/metadata + config change; behavior is verified by the automated suite. To sanity-check in the app:

1. Open a chat session and click the model picker (Sidebar → chat input → model dropdown).
2. Confirm the retired-today snapshots **GPT-5 Chat Latest** and **GPT-5.1 Chat Latest** are **not** listed.
3. Confirm current models (GPT-5.5, GPT-5.6 Sol/Luna/Terra, GPT-5.4 family) still appear and are selectable.
4. Switch the picker to image mode; confirm **GPT-Image-2** appears and is selectable, and image generation with it succeeds.
5. Confirm GPT-Image-1 / 1.5 / 1-mini still appear (their flags are future-dated) — they are only hidden on/after their shutdown dates.

### Regression Checks
1. Send a normal chat message on GPT-5.5 → response streams with no errors.
2. Generate an image with the default image model → succeeds (default now resolves to GPT-Image-2).
3. In an Agent config, open the text-model and image-model dropdowns → they populate and no retired model is listed.

### What NOT to test
- No API contract, schema, or migration changes; no DB/AdminSettings changes.
- The catalog flags with future dates do not change current availability — they only take effect on their listed shutdown dates.

## Additional Information

`sora-2` / `sora-2-pro` have **no** OpenAI replacement — the Videos API is being removed entirely on 2026-09-24. This PR flags them (they auto-hide on that date and degrade cleanly to "no video models"); whether to proactively disable/communicate the video feature ahead of time is a separate product decision, not handled here.

Verified: core build; `common` (1114), `utils` (450), `services` (2166), `llm-adapters` (314) tests; full client suite (6702, 0 fail); typecheck on client + all touched core packages.
