### PR TITLE
fix(admin): make User Credits sort/search span all users and repair activity columns

### DIFF
--- a/apps/client/app/components/admin/CreditAnalysis/components/CreditAdjustmentModal.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/CreditAdjustmentModal.tsx
@@ -55,7 +55,7 @@ export const CreditAdjustmentModal: React.FC<CreditAdjustmentModalProps> = ({
         {selectedUser && (
           <>
             <Typography level="body-md">
-              User: <strong>{selectedUser.fullName || selectedUser.email}</strong>
+              User: <strong>{selectedUser.name || selectedUser.email}</strong>
             </Typography>
 
             <Typography level="body-md" mb={1}>

--- a/apps/client/app/components/admin/CreditAnalysis/components/UserCreditsManager.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/UserCreditsManager.tsx
@@ -28,11 +28,12 @@ import { CreditAdjustmentModal } from './CreditAdjustmentModal';
 
 interface AdminUser {
   id: string;
-  fullName?: string;
+  name?: string;
   email?: string;
   currentCredits?: number;
-  lastLoginAt?: string;
-  isActive?: boolean;
+  loginRecords?: Array<{ loginTime?: string | Date }> | null;
+  lastActiveAt?: string | Date;
+  isOnline?: boolean;
   isAdmin?: boolean;
   createdAt: string;
 }
@@ -40,6 +41,30 @@ interface AdminUser {
 interface UserCreditsManagerProps {
   onRefresh?: () => void;
 }
+
+// A user with no websocket activity within this window is shown as Inactive.
+const ACTIVE_WITHIN_DAYS = 30;
+
+// Most recent explicit login (loginRecords, as the Admin > Users view uses); falls back
+// to the websocket-tracked lastActiveAt for users with no recorded login yet.
+const getLastLoginDate = (user: AdminUser): Date | null => {
+  const latest = user.loginRecords?.reduce<string | Date | undefined>((acc, record) => {
+    const t = record?.loginTime;
+    if (!t) return acc;
+    return !acc || new Date(t) > new Date(acc) ? t : acc;
+  }, undefined);
+  const source = latest ?? user.lastActiveAt;
+  return source ? new Date(source) : null;
+};
+
+const getActivityStatus = (user: AdminUser): { label: string; color: 'success' | 'neutral' } => {
+  if (user.isOnline) return { label: 'Online', color: 'success' };
+  if (user.lastActiveAt) {
+    const daysSince = (Date.now() - new Date(user.lastActiveAt).getTime()) / 86_400_000;
+    if (daysSince <= ACTIVE_WITHIN_DAYS) return { label: 'Active', color: 'success' };
+  }
+  return { label: 'Inactive', color: 'neutral' };
+};
 
 export const UserCreditsManager: React.FC<UserCreditsManagerProps> = ({ onRefresh }) => {
   const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
@@ -139,56 +164,60 @@ export const UserCreditsManager: React.FC<UserCreditsManagerProps> = ({ onRefres
         </Alert>
       ) : isMobile ? (
         <Stack spacing={1}>
-          {(paginatedUsers as AdminUser[]).map(user => (
-            <Card key={user.id} variant="outlined" sx={{ p: 1, gap: 0 }}>
-              {/* Row 1: name + status chips */}
-              <Stack direction="row" justifyContent="space-between" alignItems="center">
-                <Typography level="body-sm" fontWeight="lg">
-                  {user.fullName || 'No Name'}
-                </Typography>
-                <Stack direction="row" spacing={0.5}>
-                  <Chip color={user.isActive ? 'success' : 'neutral'} size="sm">
-                    {user.isActive ? 'Active' : 'Inactive'}
-                  </Chip>
-                  {user.isAdmin && (
-                    <Chip color="warning" size="sm">
-                      Admin
+          {(paginatedUsers as AdminUser[]).map(user => {
+            const lastLogin = getLastLoginDate(user);
+            const status = getActivityStatus(user);
+            return (
+              <Card key={user.id} variant="outlined" sx={{ p: 1, gap: 0 }}>
+                {/* Row 1: name + status chips */}
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Typography level="body-sm" fontWeight="lg">
+                    {user.name || 'No Name'}
+                  </Typography>
+                  <Stack direction="row" spacing={0.5}>
+                    <Chip color={status.color} size="sm">
+                      {status.label}
                     </Chip>
-                  )}
+                    {user.isAdmin && (
+                      <Chip color="warning" size="sm">
+                        Admin
+                      </Chip>
+                    )}
+                  </Stack>
                 </Stack>
-              </Stack>
 
-              {/* Row 2: email */}
-              <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                {user.email || 'No Email'}
-              </Typography>
-
-              {/* Row 3: credits + last login */}
-              <Stack direction="row" spacing={2} sx={{ mt: 0.5 }}>
-                <Typography level="body-xs">
-                  Credits: <strong>{(user.currentCredits || 0).toLocaleString()}</strong>
+                {/* Row 2: email */}
+                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                  {user.email || 'No Email'}
                 </Typography>
-                <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                  Login: {user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString() : 'Never'}
-                </Typography>
-              </Stack>
 
-              {/* Row 4: actions */}
-              <Stack direction="row" spacing={1} sx={{ mt: 0.75 }}>
-                <ViewUserProfile userId={user.id} size="sm" />
-                <Button
-                  size="sm"
-                  variant="outlined"
-                  color="primary"
-                  startDecorator={<CreditCardIcon />}
-                  onClick={() => openCreditsModal(user)}
-                  sx={{ flex: 1 }}
-                >
-                  Adjust Credits
-                </Button>
-              </Stack>
-            </Card>
-          ))}
+                {/* Row 3: credits + last login */}
+                <Stack direction="row" spacing={2} sx={{ mt: 0.5 }}>
+                  <Typography level="body-xs">
+                    Credits: <strong>{(user.currentCredits || 0).toLocaleString()}</strong>
+                  </Typography>
+                  <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
+                    Login: {lastLogin ? lastLogin.toLocaleDateString() : 'Never'}
+                  </Typography>
+                </Stack>
+
+                {/* Row 4: actions */}
+                <Stack direction="row" spacing={1} sx={{ mt: 0.75 }}>
+                  <ViewUserProfile userId={user.id} size="sm" />
+                  <Button
+                    size="sm"
+                    variant="outlined"
+                    color="primary"
+                    startDecorator={<CreditCardIcon />}
+                    onClick={() => openCreditsModal(user)}
+                    sx={{ flex: 1 }}
+                  >
+                    Adjust Credits
+                  </Button>
+                </Stack>
+              </Card>
+            );
+          })}
         </Stack>
       ) : (
         <Sheet sx={{ borderRadius: 'md', overflow: 'auto' }}>
@@ -204,59 +233,61 @@ export const UserCreditsManager: React.FC<UserCreditsManagerProps> = ({ onRefres
               </tr>
             </thead>
             <tbody>
-              {(paginatedUsers as AdminUser[]).map(user => (
-                <tr key={user.id}>
-                  <td>
-                    <Stack>
-                      <Typography level="body-sm" fontWeight="lg">
-                        {user.fullName || 'No Name'}
+              {(paginatedUsers as AdminUser[]).map(user => {
+                const lastLogin = getLastLoginDate(user);
+                const status = getActivityStatus(user);
+                return (
+                  <tr key={user.id}>
+                    <td>
+                      <Stack>
+                        <Typography level="body-sm" fontWeight="lg">
+                          {user.name || 'No Name'}
+                        </Typography>
+                        <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                          {user.email || 'No Email'}
+                        </Typography>
+                      </Stack>
+                    </td>
+                    <td>
+                      <Typography level="body-sm" fontWeight="lg" color="primary">
+                        {(user.currentCredits || 0).toLocaleString()}
                       </Typography>
-                      <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                        {user.email || 'No Email'}
-                      </Typography>
-                    </Stack>
-                  </td>
-                  <td>
-                    <Typography level="body-sm" fontWeight="lg" color="primary">
-                      {(user.currentCredits || 0).toLocaleString()}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Typography level="body-xs">
-                      {user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString() : 'Never'}
-                    </Typography>
-                  </td>
-                  <td>
-                    <Stack direction="row" spacing={1}>
-                      <Chip color={user.isActive ? 'success' : 'neutral'} size="sm">
-                        {user.isActive ? 'Active' : 'Inactive'}
-                      </Chip>
-                      {user.isAdmin && (
-                        <Chip color="warning" size="sm">
-                          Admin
+                    </td>
+                    <td>
+                      <Typography level="body-xs">{lastLogin ? lastLogin.toLocaleDateString() : 'Never'}</Typography>
+                    </td>
+                    <td>
+                      <Stack direction="row" spacing={1}>
+                        <Chip color={status.color} size="sm">
+                          {status.label}
                         </Chip>
-                      )}
-                    </Stack>
-                  </td>
-                  <td>
-                    <Typography level="body-xs">{new Date(user.createdAt).toLocaleDateString()}</Typography>
-                  </td>
-                  <td>
-                    <Stack direction="row" spacing={1}>
-                      <ViewUserProfile userId={user.id} size="sm" />
-                      <Button
-                        size="sm"
-                        variant="outlined"
-                        color="primary"
-                        startDecorator={<CreditCardIcon />}
-                        onClick={() => openCreditsModal(user)}
-                      >
-                        Credits
-                      </Button>
-                    </Stack>
-                  </td>
-                </tr>
-              ))}
+                        {user.isAdmin && (
+                          <Chip color="warning" size="sm">
+                            Admin
+                          </Chip>
+                        )}
+                      </Stack>
+                    </td>
+                    <td>
+                      <Typography level="body-xs">{new Date(user.createdAt).toLocaleDateString()}</Typography>
+                    </td>
+                    <td>
+                      <Stack direction="row" spacing={1}>
+                        <ViewUserProfile userId={user.id} size="sm" />
+                        <Button
+                          size="sm"
+                          variant="outlined"
+                          color="primary"
+                          startDecorator={<CreditCardIcon />}
+                          onClick={() => openCreditsModal(user)}
+                        >
+                          Credits
+                        </Button>
+                      </Stack>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </Table>
         </Sheet>

--- a/apps/client/app/components/admin/CreditAnalysis/hooks/useUserCreditsManager.test.ts
+++ b/apps/client/app/components/admin/CreditAnalysis/hooks/useUserCreditsManager.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const mockUseGetUsers = vi.fn();
+
+vi.mock('@client/app/hooks/data/user', () => ({
+  useGetUsers: (...args: unknown[]) => mockUseGetUsers(...args),
+}));
+vi.mock('./useUpdateUserCredits', () => ({
+  useUpdateUserCredits: () => ({ mutateAsync: vi.fn() }),
+}));
+
+import { useUserCreditsManager } from './useUserCreditsManager';
+
+const lastParams = () => mockUseGetUsers.mock.calls.at(-1)?.[0];
+
+describe('useUserCreditsManager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockUseGetUsers.mockReturnValue({
+      data: { users: [], totalUsers: 373, totalPages: 19 },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('requests server-side sort by currentCredits (default highest first)', () => {
+    renderHook(() => useUserCreditsManager());
+    expect(lastParams()).toMatchObject({ sortField: 'currentCredits', sortOrder: 'desc' });
+  });
+
+  it('pushes the sort direction to the server and returns to page 1', () => {
+    const { result } = renderHook(() => useUserCreditsManager());
+
+    act(() => result.current.setCurrentPage(5));
+    expect(result.current.currentPage).toBe(5);
+
+    act(() => result.current.setSortDirection('asc'));
+
+    expect(result.current.currentPage).toBe(1);
+    expect(lastParams()).toMatchObject({ sortField: 'currentCredits', sortOrder: 'asc', page: 1 });
+  });
+
+  it('passes the search term to the server (debounced) and returns to page 1', () => {
+    const { result } = renderHook(() => useUserCreditsManager());
+
+    act(() => result.current.setCurrentPage(5));
+    act(() => result.current.setSearchQuery('ada'));
+
+    // Input reflects the term immediately and the page resets, but the query waits for debounce.
+    expect(result.current.searchQuery).toBe('ada');
+    expect(result.current.currentPage).toBe(1);
+    expect(lastParams()?.search).toBeUndefined();
+
+    act(() => vi.advanceTimersByTime(300));
+
+    expect(lastParams()?.search).toBe('ada');
+  });
+});

--- a/apps/client/app/components/admin/CreditAnalysis/hooks/useUserCreditsManager.ts
+++ b/apps/client/app/components/admin/CreditAnalysis/hooks/useUserCreditsManager.ts
@@ -1,10 +1,11 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useGetUsers } from '@client/app/hooks/data/user';
+import { useDebounceValue } from '@client/app/hooks/useDebouncedValue';
 import { useUpdateUserCredits } from './useUpdateUserCredits';
 import { NotificationState } from '../types';
 
 export function useUserCreditsManager(onRefresh?: () => void) {
-  const [searchQuery, setSearchQuery] = useState('');
+  const { value: searchQuery, debouncedValue: debouncedSearch, setValue: setSearchValue } = useDebounceValue('');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const [pageSize, setPageSize] = useState(20);
   const [currentPage, setCurrentPage] = useState(1);
@@ -14,11 +15,32 @@ export function useUserCreditsManager(onRefresh?: () => void) {
     color: 'neutral',
   });
 
-  const allUsers = useGetUsers({ page: currentPage, limit: pageSize });
+  // Search + sort are pushed to the server so they span the full dataset, not just
+  // the current page (issue #883). The API sorts/filters before $skip/$limit, so the
+  // returned page is already globally ordered.
+  const allUsers = useGetUsers({
+    page: currentPage,
+    limit: pageSize,
+    search: debouncedSearch.trim() || undefined,
+    sortField: 'currentCredits',
+    sortOrder: sortDirection,
+  });
   const updateUserCreditsMutation = useUpdateUserCredits();
 
+  // A new search or sort produces a different result set, so return to page 1 rather
+  // than stranding the user on a page index that may no longer exist.
+  const handleSearchChange = (query: string) => {
+    setSearchValue(query);
+    setCurrentPage(1);
+  };
+
+  const handleSortDirectionChange = (direction: 'asc' | 'desc') => {
+    setSortDirection(direction);
+    setCurrentPage(1);
+  };
+
   const toggleSortDirection = () => {
-    setSortDirection(prev => (prev === 'asc' ? 'desc' : 'asc'));
+    handleSortDirectionChange(sortDirection === 'asc' ? 'desc' : 'asc');
   };
 
   const handleRefresh = () => {
@@ -26,28 +48,7 @@ export function useUserCreditsManager(onRefresh?: () => void) {
     onRefresh?.();
   };
 
-  // Filter and sort users
-  const filteredAndSortedUsers = useMemo(() => {
-    if (!allUsers.data?.users) return [];
-
-    const users = allUsers.data.users as any[];
-    let filtered = users;
-
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = users.filter(
-        (user: any) =>
-          (user.email && user.email.toLowerCase().includes(query)) ||
-          (user.fullName && user.fullName.toLowerCase().includes(query))
-      );
-    }
-
-    return [...filtered].sort((a: any, b: any) => {
-      const aCredits = a.currentCredits || 0;
-      const bCredits = b.currentCredits || 0;
-      return sortDirection === 'asc' ? aCredits - bCredits : bCredits - aCredits;
-    });
-  }, [allUsers.data?.users, searchQuery, sortDirection]);
+  const users = (allUsers.data?.users ?? []) as any[];
 
   const handleCreditAdjustment = async (userId: string, currentCredits: number, adjustment: number) => {
     const newCredits = Math.max(0, currentCredits + adjustment);
@@ -72,12 +73,6 @@ export function useUserCreditsManager(onRefresh?: () => void) {
     }
   };
 
-  // Reset to first page when search changes
-  const handleSearchChange = (query: string) => {
-    setSearchQuery(query);
-    setCurrentPage(1);
-  };
-
   // Reset to first page when page size changes
   const handlePageSizeChange = (size: number) => {
     setPageSize(size);
@@ -87,13 +82,12 @@ export function useUserCreditsManager(onRefresh?: () => void) {
   // Calculate pagination values from server response
   const totalUsers = allUsers.data?.totalUsers || 0;
   const totalPages = allUsers.data?.totalPages || 0;
-  const paginatedUsers = filteredAndSortedUsers;
 
   return {
     searchQuery,
     setSearchQuery: handleSearchChange,
     sortDirection,
-    setSortDirection: (direction: 'asc' | 'desc') => setSortDirection(direction),
+    setSortDirection: handleSortDirectionChange,
     pageSize,
     setPageSize: handlePageSizeChange,
     currentPage,
@@ -103,8 +97,8 @@ export function useUserCreditsManager(onRefresh?: () => void) {
     notification,
     setNotification,
     allUsers,
-    filteredAndSortedUsers,
-    paginatedUsers,
+    filteredAndSortedUsers: users,
+    paginatedUsers: users,
     toggleSortDirection,
     handleRefresh,
     handleCreditAdjustment,


### PR DESCRIPTION
## Screenshots

<img width="1659" height="873" alt="Screenshot 2026-07-23 at 12 37 55 pm" src="https://github.com/user-attachments/assets/c5d8b96e-3819-44db-b7b8-cbf895f5b7f9" />
<img width="1714" height="897" alt="Screenshot 2026-07-23 at 12 37 47 pm" src="https://github.com/user-attachments/assets/e2de2059-4012-4697-91da-0741b414cde1" />
<img width="1691" height="444" alt="Screenshot 2026-07-23 at 12 37 39 pm" src="https://github.com/user-attachments/assets/c64cfbdb-d6f4-4d1d-a019-a78a7bcb8948" />


## Description

On the admin **Credit Analysis -> User Credits** tab, "Sort by Credits" and the search box only operated on the ~20 rows of the current page instead of the full set of users. Page 2 could show higher credit values than page 1, and searching only matched users already on the visible page.

While fixing that, the Last Login, Status, and Name columns turned out to be reading fields the users API never returns (`lastLoginAt`, `isActive`, `fullName`), so every row showed `Never` / `Inactive` / `No Name`. Those are mapped to the real fields the endpoint already provides.

Closes #883.

## Changes

- **Server-side sort/search** (`useUserCreditsManager.ts`): pass `sortField: 'currentCredits'` + `sortOrder` and the debounced `search` term into `useGetUsers`. The API already sorts/filters the full dataset before `$skip`/`$limit`. Removed the client-side `.sort()`/`.filter()` and reset to page 1 on any search or sort change. Search is debounced (via the existing `useDebounceValue`) so it doesn't fire a request per keystroke.
- **Last Login column**: derived from the most recent `loginRecords[].loginTime` (same source as the Admin > Users view), falling back to `lastActiveAt`.
- **Status column**: filled from recent activity - `Online` when `isOnline`, `Active` when active within the last 30 days (`lastActiveAt`), otherwise `Inactive`.
- **Name**: `fullName` -> `name` in the table, mobile card, and the credit-adjustment modal (was showing "No Name" for every user).
- Added `useUserCreditsManager.test.ts` covering default server sort params, sort-direction change -> server param + page reset, and debounced search -> query + page reset.

## Guide for Testers

1. Log in as an admin on `app.staging.bike4mind.com`.
2. Navigate: Sidebar -> Admin -> Credit Analysis -> User Credits tab.
3. Set "Sort by Credits" to "Highest First". Expected: the top rows have the highest credit balances across ALL users.
4. Click to page 2, then page 3. Expected: credit values keep descending across page boundaries (page 2 values are all <= the lowest value on page 1).
5. Switch "Sort by Credits" to "Lowest First". Expected: the list flips to ascending and jumps back to page 1.
6. Type a partial name or email into the search box. Expected: results reflect matches across the whole dataset (not just the previously visible page), the total count updates, and the view returns to page 1.
7. Inspect any row's **Last Login** column. Expected: a real date for users who have logged in (not "Never" for everyone).
8. Inspect the **Status** column. Expected: `Online` / `Active` / `Inactive` reflecting recent activity, not "Inactive" for everyone.
9. Inspect the **User** column and open "Credits" on a row. Expected: the user's actual name shows (not "No Name").

### Regression Checks

- Pagination controls (page size 10/20/50/100, page navigation) still work and totals are correct.
- Adjusting a user's credits still succeeds and refreshes the list.

## Additional Information

Backend was already capable of full-dataset sort/search; this PR is frontend-only (no API or schema changes). The 30-day window for "Active" is a display heuristic and easy to tune.
