### PR TITLE
fix(admin): stop misreporting embed white-label as held via bypass

### DIFF
--- a/apps/client/lib/entitlements/registry.test.ts
+++ b/apps/client/lib/entitlements/registry.test.ts
@@ -11,6 +11,9 @@ import {
   signupCreditsForEmail,
   KNOWN_ENTITLEMENT_KEYS,
   unknownEntitlementKeys,
+  BYPASS_EXEMPT_ENTITLEMENTS,
+  isBypassExemptEntitlement,
+  EMBED_WHITELABEL_ENTITLEMENT_KEY,
 } from './registry';
 
 // Behavior tests are table-driven over the real registry rows (no product
@@ -349,5 +352,31 @@ describe('KNOWN_ENTITLEMENT_KEYS / unknownEntitlementKeys', () => {
   it('treats a known key as known regardless of case/whitespace', () => {
     const known = KNOWN_ENTITLEMENT_KEYS[0];
     expect(unknownEntitlementKeys([` ${known.toUpperCase()} `])).toEqual([]);
+  });
+});
+
+describe('BYPASS_EXEMPT_ENTITLEMENTS / isBypassExemptEntitlement', () => {
+  it('reports the embed white-label key as bypass-exempt', () => {
+    expect(isBypassExemptEntitlement(EMBED_WHITELABEL_ENTITLEMENT_KEY)).toBe(true);
+  });
+
+  it('normalizes the input before testing membership (case/whitespace insensitive)', () => {
+    expect(isBypassExemptEntitlement(` ${EMBED_WHITELABEL_ENTITLEMENT_KEY.toUpperCase()} `)).toBe(true);
+  });
+
+  it('reports a non-exempt known key as not bypass-exempt', () => {
+    const nonExempt = KNOWN_ENTITLEMENT_KEYS.find(k => k !== EMBED_WHITELABEL_ENTITLEMENT_KEY);
+    if (!nonExempt) throw new Error('fixture assumption: registry has a non-exempt key besides embed white-label');
+    expect(isBypassExemptEntitlement(nonExempt)).toBe(false);
+  });
+
+  it('has exactly one member - a new exemption is a deliberate test change, not a silent add', () => {
+    expect(BYPASS_EXEMPT_ENTITLEMENTS.size).toBe(1);
+  });
+
+  it('every exempt key is a real known entitlement (guards a typo that would never match)', () => {
+    for (const key of BYPASS_EXEMPT_ENTITLEMENTS) {
+      expect(KNOWN_ENTITLEMENT_KEYS).toContain(key);
+    }
   });
 });

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -48,6 +48,24 @@ export const BASE_ENTITLEMENT_KEY = 'base';
 export const EMBED_WHITELABEL_ENTITLEMENT_KEY: EntitlementKey = 'embed:whitelabel';
 
 /**
+ * Entitlements whose real enforcement is OWNER-scoped through the raw
+ * `getUserEntitlements` resolver and so honors NEITHER the admin nor the
+ * developer gate bypass - a literal grant (tag / subscription / domain) is
+ * required. The admin Product Access resolver must therefore NOT attribute
+ * these to `admin-bypass` / `developer-bypass`, or it reports access the gate
+ * won't actually confer. Must stay in sync with the enforcement side
+ * (`server/entitlements/embedKeyEntitlement.ts` -> `embedKeyOwnerHasEntitlement`).
+ * `embed:whitelabel` is the only such key today; the OptiHashi/Overwatch/Bob/Pi
+ * gates deliberately DO honor the bypass, so they are not members.
+ */
+export const BYPASS_EXEMPT_ENTITLEMENTS: ReadonlySet<EntitlementKey> = new Set([EMBED_WHITELABEL_ENTITLEMENT_KEY]);
+
+/** Whether `key` is bypass-exempt (see `BYPASS_EXEMPT_ENTITLEMENTS`). Normalizes first. */
+export function isBypassExemptEntitlement(key: EntitlementKey): boolean {
+  return BYPASS_EXEMPT_ENTITLEMENTS.has(normalizeTag(key));
+}
+
+/**
  * A product's Stripe price ids, authored per-stage and captured BEFORE the
  * `isTestMode` resolution. The ternary resolves to ONE id at module load
  * (test-mode in CI), which would hide the inactive stage's id from the

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -56,7 +56,9 @@ export const EMBED_WHITELABEL_ENTITLEMENT_KEY: EntitlementKey = 'embed:whitelabe
  * won't actually confer. Must stay in sync with the enforcement side
  * (`server/entitlements/embedKeyEntitlement.ts` -> `embedKeyOwnerHasEntitlement`).
  * `embed:whitelabel` is the only such key today; the OptiHashi/Overwatch/Bob/Pi
- * gates deliberately DO honor the bypass, so they are not members.
+ * entitlements are gated caller-scoped (via `requestHasEntitlement` / the client
+ * gate, which DO bypass for admin/developer), so reporting the bypass for them is
+ * correct and they are not members.
  */
 export const BYPASS_EXEMPT_ENTITLEMENTS: ReadonlySet<EntitlementKey> = new Set([EMBED_WHITELABEL_ENTITLEMENT_KEY]);
 

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/entitlements.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/entitlements.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
-import { allKnownEntitlementKeys, grantTagForEntitlement, PRICE_ENTITLEMENTS } from '@client/lib/entitlements/registry';
+import {
+  allKnownEntitlementKeys,
+  grantTagForEntitlement,
+  isBypassExemptEntitlement,
+  resolveEntitlements,
+  EMBED_WHITELABEL_ENTITLEMENT_KEY,
+  PRICE_ENTITLEMENTS,
+} from '@client/lib/entitlements/registry';
 
 const { mockUserFind, mockSubs, mockPartnerKeys } = vi.hoisted(() => ({
   mockUserFind: vi.fn(),
@@ -119,19 +126,32 @@ describe('GET /api/admin/users/:userId/entitlements', () => {
     expect(row.grantTag).toBeUndefined();
   });
 
-  it('sets admin-bypass as a source and held=true for every key when the target user isAdmin', async () => {
+  it('sets admin-bypass as a source and held=true for every NON-exempt key when the target user isAdmin', async () => {
     mockUserFind.mockResolvedValue({ id: 'u1', tags: [], isAdmin: true, email: null, emailVerified: false });
     const { res, promise } = run({ user: ADMIN });
     await promise;
     const body = res._getJSONData();
-    expect(body.entitlements.length).toBeGreaterThan(0);
-    for (const row of body.entitlements) {
+    const nonExempt = body.entitlements.filter((r: { key: string }) => !isBypassExemptEntitlement(r.key));
+    expect(nonExempt.length).toBeGreaterThan(0);
+    for (const row of nonExempt) {
       expect(row.held).toBe(true);
       expect(row.sources).toEqual(expect.arrayContaining([{ type: 'admin-bypass', detail: 'Super Admin' }]));
     }
   });
 
-  it('sets developer-bypass as a source and held=true for every key when the target user has a developer tag', async () => {
+  it('does NOT attribute a bypass-exempt key (embed white-label) to admin-bypass, even for an admin', async () => {
+    mockUserFind.mockResolvedValue({ id: 'u1', tags: [], isAdmin: true, email: null, emailVerified: false });
+    const { res, promise } = run({ user: ADMIN });
+    await promise;
+    const row = res
+      ._getJSONData()
+      .entitlements.find((r: { key: string }) => r.key === EMBED_WHITELABEL_ENTITLEMENT_KEY);
+    expect(row).toBeDefined();
+    expect(row.held).toBe(false);
+    expect(row.sources).toEqual([]);
+  });
+
+  it('sets developer-bypass as a source and held=true for every NON-exempt key when the target user has a developer tag', async () => {
     mockUserFind.mockResolvedValue({
       id: 'u1',
       tags: ['Developer'],
@@ -142,9 +162,87 @@ describe('GET /api/admin/users/:userId/entitlements', () => {
     const { res, promise } = run({ user: ADMIN });
     await promise;
     const body = res._getJSONData();
-    for (const row of body.entitlements) {
+    const nonExempt = body.entitlements.filter((r: { key: string }) => !isBypassExemptEntitlement(r.key));
+    expect(nonExempt.length).toBeGreaterThan(0);
+    for (const row of nonExempt) {
       expect(row.held).toBe(true);
       expect(row.sources).toEqual(expect.arrayContaining([{ type: 'developer-bypass', detail: 'Developer tag' }]));
+    }
+  });
+
+  it('does NOT attribute embed white-label to developer-bypass; a developer-tagged user holds it only via the literal tag', async () => {
+    // The reported bug: a Developer-tagged user without the embed comp tag was shown
+    // "Held / Developer tag" while the embed gate (owner-scoped, no bypass) denies it.
+    mockUserFind.mockResolvedValue({
+      id: 'u1',
+      tags: ['Developer'],
+      isAdmin: false,
+      email: null,
+      emailVerified: false,
+    });
+    const { res, promise } = run({ user: ADMIN });
+    await promise;
+    const body = res._getJSONData();
+    const embedRow = body.entitlements.find((r: { key: string }) => r.key === EMBED_WHITELABEL_ENTITLEMENT_KEY);
+    expect(embedRow.held).toBe(false);
+    expect(embedRow.sources).toEqual([]);
+    // Targeted, not blanket: a non-exempt key for the SAME user still reports developer-bypass.
+    const other = body.entitlements.find((r: { key: string }) => !isBypassExemptEntitlement(r.key));
+    expect(other.sources).toEqual(expect.arrayContaining([{ type: 'developer-bypass', detail: 'Developer tag' }]));
+  });
+
+  it('reports embed white-label held via the literal tag only (no bypass noise) even for a developer admin', async () => {
+    const grantTag = grantTagForEntitlement(EMBED_WHITELABEL_ENTITLEMENT_KEY);
+    if (!grantTag) throw new Error('fixture assumption: embed white-label has a granting comp tag');
+    mockUserFind.mockResolvedValue({
+      id: 'u1',
+      tags: [grantTag, 'Developer'],
+      isAdmin: true,
+      email: null,
+      emailVerified: false,
+    });
+    const { res, promise } = run({ user: ADMIN });
+    await promise;
+    const embedRow = res
+      ._getJSONData()
+      .entitlements.find((r: { key: string }) => r.key === EMBED_WHITELABEL_ENTITLEMENT_KEY);
+    expect(embedRow.held).toBe(true);
+    // Only the tag source - no admin-/developer-bypass, so the client's "revoking
+    // the tag alone will not remove access" warning does not fire.
+    expect(embedRow.sources).toEqual([{ type: 'tag', detail: grantTag }]);
+  });
+
+  it('panel-matches-the-gate: reported embed white-label held equals the owner-scoped gate for every user shape', async () => {
+    const grantTag = grantTagForEntitlement(EMBED_WHITELABEL_ENTITLEMENT_KEY)!;
+    const matrix = [
+      { label: 'plain', tags: [], isAdmin: false },
+      { label: 'developer', tags: ['Developer'], isAdmin: false },
+      { label: 'admin', tags: [], isAdmin: true },
+      { label: 'embed-whitelabel', tags: [grantTag], isAdmin: false },
+      { label: 'embed-whitelabel+developer', tags: [grantTag, 'Developer'], isAdmin: false },
+    ];
+    for (const shape of matrix) {
+      mockUserFind.mockResolvedValue({
+        id: 'u1',
+        tags: shape.tags,
+        isAdmin: shape.isAdmin,
+        email: null,
+        emailVerified: false,
+      });
+      const { res, promise } = run({ user: ADMIN });
+      await promise;
+      const embedRow = res
+        ._getJSONData()
+        .entitlements.find((r: { key: string }) => r.key === EMBED_WHITELABEL_ENTITLEMENT_KEY);
+      // The owner-scoped embed gate reduces to getUserEntitlements(owner) -> resolveEntitlements(...).
+      const gateHolds = resolveEntitlements({ tags: shape.tags, activePriceIds: [] }).includes(
+        EMBED_WHITELABEL_ENTITLEMENT_KEY
+      );
+      expect(embedRow.held, `held mismatch for ${shape.label}`).toBe(gateHolds);
+      expect(
+        embedRow.sources.every((s: { type: string }) => s.type !== 'admin-bypass' && s.type !== 'developer-bypass'),
+        `bypass source leaked for ${shape.label}`
+      ).toBe(true);
     }
   });
 

--- a/apps/client/pages/api/admin/users/[userId]/entitlements.ts
+++ b/apps/client/pages/api/admin/users/[userId]/entitlements.ts
@@ -11,6 +11,7 @@ import {
   TAG_GRANTS,
   allKnownEntitlementKeys,
   grantTagForEntitlement,
+  isBypassExemptEntitlement,
   normalizeTag,
 } from '@client/lib/entitlements/registry';
 import { partnerEntitlementsForEmail } from '@server/entitlements/partnerRules';
@@ -39,7 +40,12 @@ interface EntitlementRow {
  * `getUserEntitlements` (which returns only the held key set for gating),
  * this walks EVERY known product key and records every contributing source
  * -tag / domain / subscription / admin bypass / developer-tag bypass - so an
- * admin can see and revoke a phantom grant instead of guessing at it.
+ * admin can see and revoke a phantom grant instead of guessing at it. The two
+ * bypass sources are suppressed for bypass-exempt keys (see
+ * `isBypassExemptEntitlement`), whose enforcement honors neither bypass, so the
+ * report matches the gate for them. Note this reports on the VIEWED user; a
+ * feature gated on a different principal (e.g. an org-billed embed key resolves
+ * the org billing owner) matches only when that principal is the viewed user.
  */
 const handler = baseApi().get(
   asyncHandler(async (req, res) => {
@@ -97,11 +103,17 @@ const handler = baseApi().get(
         }
       }
 
-      if (user.isAdmin) {
-        sources.push({ type: 'admin-bypass', detail: 'Super Admin' });
-      }
-      if (isDeveloper) {
-        sources.push({ type: 'developer-bypass', detail: 'Developer tag' });
+      // Bypass-exempt keys (e.g. embed white-label) are enforced against the
+      // owner's literal grant and honor NEITHER bypass - reporting a bypass
+      // source for them would claim access the gate won't confer. Suppress both
+      // so held/sources match `getUserEntitlements` (the enforcement resolver).
+      if (!isBypassExemptEntitlement(key)) {
+        if (user.isAdmin) {
+          sources.push({ type: 'admin-bypass', detail: 'Super Admin' });
+        }
+        if (isDeveloper) {
+          sources.push({ type: 'developer-bypass', detail: 'Developer tag' });
+        }
       }
 
       return {


### PR DESCRIPTION
## Optional Screenshot/Video

<img width="816" height="1742" alt="embed-whitelabel-product-access" src="https://github.com/user-attachments/assets/8fd705a0-4659-4838-bdb7-53d64919982b" />

*Figure: admin Product Access for a `Developer`-tagged user, captured live on the pr896 preview. Every product (optihashi/overwatch/pi/tavern/bob/libreoncology) shows Held via a "Developer tag" source; `embed:whitelabel` alone shows None with no "Developer tag" chip and no "revoking the tag alone will not remove access" warning - now matching the owner-scoped embed gate.*

## Description
The admin Product Access panel reported `embed:whitelabel` as "Held" via a "Developer tag" source for any Developer-tagged user, and warned that revoking the comp tag would not remove access. That is the opposite of how the embed white-label feature actually behaves: its read-time gate is owner-scoped and honors neither the admin nor the developer bypass, so it requires the key owner's literal `embed-whitelabel` grant. A Developer-tagged user with no such grant cannot hide the footer, and removing the grant does restore it.

The reporting route was key-agnostic: it attached an `admin-bypass`/`developer-bypass` source to every known entitlement for an admin/Developer-tagged user, with no notion that some entitlements are enforced strictly against a literal grant. This PR gives the registry that notion and has the reporting route honor it, so the panel's held/sources for such keys match what the gate computes.

Closes #892.

## Changes
- Add `BYPASS_EXEMPT_ENTITLEMENTS` + `isBypassExemptEntitlement()` to the entitlements registry: entitlements whose enforcement is owner-scoped and honors neither bypass. `embed:whitelabel` is the only member today; the OptiHashi/Overwatch/Bob/Pi keys are gated caller-scoped (which do bypass for admin/developer), so reporting the bypass for them stays correct.
- In `GET /api/admin/users/{id}/entitlements`, suppress both the `admin-bypass` and `developer-bypass` sources for bypass-exempt keys. Tag/domain/subscription/partner sources are untouched, so a genuine grant still reports as Held.
- Tests: registry membership/normalization/size-lock/known-key invariants; route cases for the developer-only, admin-only, and literal-tag paths, plus a matrix test asserting the reported `held` equals `resolveEntitlements(...)` (the owner-scoped gate) for every user shape.

## Guide for Testers
Prerequisites: an admin account, plus a target user carrying the `Developer` tag and NOT the `embed-whitelabel` comp tag.

1. As an admin, go to Admin -> Users and open the Developer-tagged target user.
2. Open the Product Access section.
3. Find the `embed:whitelabel` row. Expected: it shows "None" (not "Held"), with no "Developer tag" source chip and no "revoking the tag alone will not remove access" warning.
4. Check a different product in the same panel (for example `optihashi:pro`). Expected: it STILL shows "Held" with the "Developer tag" source for the same user. This confirms the change is specific to embed white-label, not a blanket removal.
5. Click Grant on the `embed:whitelabel` row (adds the `embed-whitelabel` tag) and Save. Expected: the row now shows "Held" with only a "Tag" source, and still no bypass warning.

API-level assertion (same behavior, no browser): `GET /api/admin/users/{id}/entitlements` for the Developer-tagged user returns the `embed:whitelabel` entry with `held: false` and no `{ type: "developer-bypass" }` source, while a non-exempt key (e.g. `optihashi:pro`) still lists `developer-bypass`.

Regression checks: other products' held/source reporting is unchanged; `admin-bypass` still appears for non-exempt keys when the target user is an admin.

What NOT to test: embed white-label ENFORCEMENT (footer hiding at serve time) is not changed by this PR; the widget gate was already correct. Also out of scope: the embed-key hide-branding toggle in the Embed Keys admin tab still offers the switch to admin/developer key owners even though the save is stripped server-side (a documented, fail-safe asymmetry) - that is not a Product Access reporting surface and is left as-is.

## Additional Information
The reporting route (`entitlements.ts`) and the enforcement gate (`embedKeyOwnerHasEntitlement` -> `getUserEntitlements`) had diverged: the former treated the developer/admin tag as conferring every entitlement, the latter honors neither for embed white-label. This aligns the report with the gate for bypass-exempt keys. Note the panel reports on the VIEWED user; a feature gated on a different principal (an org-billed embed key resolves the org billing owner) matches only when that principal is the user being viewed - a pre-existing property of a per-user panel, not changed here.

## Developer Notes (Optional)
- `BYPASS_EXEMPT_ENTITLEMENTS` is the extension point for any future entitlement whose enforcement is owner-scoped/no-bypass: add the key there and the admin report stops attributing it to a bypass. It must stay in sync with the enforcement side (`server/entitlements/embedKeyEntitlement.ts`).

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
