### PR TITLE
feat(datalake): persistent info tooltip on Data Lakes header (#834)

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeListPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeListPanel.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
@@ -218,6 +218,33 @@ describe('DataLakeListPanel - EnableDataLakes gating', () => {
     // is a dead end - so the panel must not render at all, mirroring
     // SendToDataLakeModal's render guard.
     expect(screen.queryByTestId('datalake-list-panel')).not.toBeInTheDocument();
+  });
+});
+
+describe('DataLakeListPanel - persistent Data Lakes info tooltip (#834)', () => {
+  beforeEach(() => {
+    isFeatureEnabled.mockReset();
+    isFeatureEnabled.mockReturnValue(true);
+    useDataLakes.mockReset();
+    useDataLakes.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it('shows a persistent info icon next to the header that reveals the RAG explanation on hover', async () => {
+    render(
+      <Wrapper>
+        <DataLakeListPanel />
+      </Wrapper>
+    );
+
+    // Always present next to the header - not a one-time dismissable callout.
+    const trigger = screen.getByTestId('field-tooltip-data-lake-panel');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-label', 'Help: Data Lakes');
+
+    fireEvent.mouseOver(trigger);
+    expect(
+      await screen.findByText(/curated knowledge base the AI grounds its answers in \(RAG\)/i)
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/client/app/components/DataLakeWizard/DataLakeListPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeListPanel.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within, fireEvent } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
@@ -230,6 +230,7 @@ describe('DataLakeListPanel - persistent Data Lakes info tooltip (#834)', () => 
   });
 
   it('shows a persistent info icon next to the header that reveals the RAG explanation on hover', async () => {
+    const user = userEvent.setup();
     render(
       <Wrapper>
         <DataLakeListPanel />
@@ -241,7 +242,7 @@ describe('DataLakeListPanel - persistent Data Lakes info tooltip (#834)', () => 
     expect(trigger).toBeInTheDocument();
     expect(trigger).toHaveAttribute('aria-label', 'Help: Data Lakes');
 
-    fireEvent.mouseOver(trigger);
+    await user.hover(trigger);
     expect(
       await screen.findByText(/curated knowledge base the AI grounds its answers in \(RAG\)/i)
     ).toBeInTheDocument();

--- a/apps/client/app/components/DataLakeWizard/DataLakeListPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeListPanel.tsx
@@ -49,6 +49,8 @@ import { useAccounts } from '@client/app/components/Credits/AccountSelector';
 import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import { toast } from 'sonner';
 import DataLakeViewer from './DataLakeViewer';
+import FieldTooltip from '@client/app/components/help/FieldTooltip';
+import { FIELD_TOOLTIPS } from '@client/app/components/help/fieldTooltips';
 
 export default function DataLakeListPanel() {
   const { data: dataLakes, isLoading } = useDataLakes();
@@ -107,7 +109,18 @@ export default function DataLakeListPanel() {
         {/* pr clears the modal's absolutely-positioned ModalClose (top-right) so the
             Create button doesn't collide with the × when this panel is shown in a modal. */}
         <Stack direction="row" justifyContent="space-between" alignItems="center" gap={1} sx={{ mb: 2, pr: 5 }}>
-          <Typography level="title-md" startDecorator={<StorageIcon />}>
+          <Typography
+            level="title-md"
+            startDecorator={<StorageIcon />}
+            endDecorator={
+              <FieldTooltip
+                content={FIELD_TOOLTIPS.dataLake}
+                placement="bottom"
+                ariaLabel="Help: Data Lakes"
+                data-testid="field-tooltip-data-lake-panel"
+              />
+            }
+          >
             Data Lakes
           </Typography>
           <Button size="sm" variant="soft" color="primary" startDecorator={<AddIcon />} onClick={openWizard}>

--- a/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import DataLakeExplorer from './DataLakeExplorer';
+
+// The browse hooks hit react-query; stub them to an empty, non-loading result so the
+// explorer renders its header without a QueryClientProvider.
+vi.mock('@client/app/hooks/data/fabFiles', () => ({
+  useGetDataLakeTagCounts: () => ({ data: undefined, isLoading: false, isError: false }),
+  useGetDataLakeArticles: () => ({ data: undefined }),
+}));
+
+// Heavy children are irrelevant to the header assertion - keep them inert.
+vi.mock('./DataLakeTree', () => ({ default: () => null }));
+vi.mock('./DataLakeArticle', () => ({ default: () => null }));
+vi.mock('@client/app/components/DataLakeWizard/DataLakeIngestPickerModal', () => ({ default: () => null }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+describe('DataLakeExplorer - persistent Data Lakes info tooltip (#834)', () => {
+  it('shows a persistent info icon next to the header that reveals the RAG explanation on hover', async () => {
+    render(
+      <Wrapper>
+        <DataLakeExplorer onBack={vi.fn()} onAskAbout={vi.fn()} />
+      </Wrapper>
+    );
+
+    const trigger = screen.getByTestId('field-tooltip-data-lake-explorer');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-label', 'Help: Data Lakes');
+
+    fireEvent.mouseOver(trigger);
+    expect(
+      await screen.findByText(/curated knowledge base the AI grounds its answers in \(RAG\)/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -12,6 +12,8 @@ import { buildTagTree, getNodesAtPath } from '@client/app/components/Files/Brows
 import DataLakeIngestPickerModal from '@client/app/components/DataLakeWizard/DataLakeIngestPickerModal';
 import { readDroppedItems } from '@client/app/utils/dropReader';
 import { toast } from 'sonner';
+import FieldTooltip from '@client/app/components/help/FieldTooltip';
+import { FIELD_TOOLTIPS } from '@client/app/components/help/fieldTooltips';
 import type { IFabFileDocument } from '@bike4mind/common';
 
 interface DataLakeExplorerProps {
@@ -188,6 +190,16 @@ export default function DataLakeExplorer({
       )}
       <Box sx={{ px: 3, pt: 2, display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
         <OptiModeBreadcrumb segments={[{ label: rootLabel, onClick: onBack }, { label: 'Data Lake Explorer' }]} />
+        {/* Match the breadcrumb's own mb so this icon's center lines up with the
+            breadcrumb text in the center-aligned header row (breadcrumb carries mb:2). */}
+        <Box sx={{ display: 'inline-flex', mb: 2 }}>
+          <FieldTooltip
+            content={FIELD_TOOLTIPS.dataLake}
+            placement="bottom"
+            ariaLabel="Help: Data Lakes"
+            data-testid="field-tooltip-data-lake-explorer"
+          />
+        </Box>
         {onManage && (
           <Button
             data-testid="datalake-manage-btn"

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -190,16 +190,15 @@ export default function DataLakeExplorer({
       )}
       <Box sx={{ px: 3, pt: 2, display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
         <OptiModeBreadcrumb segments={[{ label: rootLabel, onClick: onBack }, { label: 'Data Lake Explorer' }]} />
-        {/* Match the breadcrumb's own mb so this icon's center lines up with the
+        {/* mb:2 matches the breadcrumb's own mb so this icon's center lines up with the
             breadcrumb text in the center-aligned header row (breadcrumb carries mb:2). */}
-        <Box sx={{ display: 'inline-flex', mb: 2 }}>
-          <FieldTooltip
-            content={FIELD_TOOLTIPS.dataLake}
-            placement="bottom"
-            ariaLabel="Help: Data Lakes"
-            data-testid="field-tooltip-data-lake-explorer"
-          />
-        </Box>
+        <FieldTooltip
+          content={FIELD_TOOLTIPS.dataLake}
+          placement="bottom"
+          ariaLabel="Help: Data Lakes"
+          data-testid="field-tooltip-data-lake-explorer"
+          sx={{ mb: 2 }}
+        />
         {onManage && (
           <Button
             data-testid="datalake-manage-btn"

--- a/apps/client/app/components/help/FieldTooltip.test.tsx
+++ b/apps/client/app/components/help/FieldTooltip.test.tsx
@@ -104,4 +104,16 @@ describe('FieldTooltip', () => {
 
     expect(screen.getByTestId('field-tooltip-credits')).toBeInTheDocument();
   });
+
+  it('merges a call-site sx into the wrapper (e.g. layout margin)', () => {
+    render(
+      <TestWrapper>
+        <FieldTooltip content="Help" data-testid="field-tooltip-sx" sx={{ marginBottom: '16px' }} />
+      </TestWrapper>
+    );
+
+    // The wrapper span is the trigger's parent; the sx margin must land on it.
+    const wrapper = screen.getByTestId('field-tooltip-sx').parentElement as HTMLElement;
+    expect(wrapper).toHaveStyle({ marginBottom: '16px' });
+  });
 });

--- a/apps/client/app/components/help/FieldTooltip.tsx
+++ b/apps/client/app/components/help/FieldTooltip.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Tooltip, Typography, Box } from '@mui/joy';
 import type { TooltipProps } from '@mui/joy';
+import type { SxProps } from '@mui/joy/styles/types';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 export interface FieldTooltipProps {
@@ -20,6 +21,8 @@ export interface FieldTooltipProps {
   'data-testid'?: string;
   /** Optional className applied to the wrapper Box. */
   className?: string;
+  /** Extra styles merged into the wrapper Box (e.g. layout margins at a call site). */
+  sx?: SxProps;
 }
 
 /**
@@ -53,6 +56,7 @@ const FieldTooltip: React.FC<FieldTooltipProps> = ({
   ariaLabel,
   'data-testid': dataTestId,
   className,
+  sx,
 }) => {
   const effectiveAriaLabel = ariaLabel ?? (typeof label === 'string' ? `Help: ${label}` : 'Help');
   const tooltipId = React.useId();
@@ -107,7 +111,7 @@ const FieldTooltip: React.FC<FieldTooltipProps> = ({
     <Box
       component="span"
       className={className}
-      sx={{ display: 'inline-flex', alignItems: 'center', gap: hasLabel ? 0.5 : 0 }}
+      sx={{ display: 'inline-flex', alignItems: 'center', gap: hasLabel ? 0.5 : 0, ...sx }}
     >
       {hasLabel &&
         (typeof label === 'string' ? (

--- a/apps/client/app/components/help/fieldTooltips.ts
+++ b/apps/client/app/components/help/fieldTooltips.ts
@@ -4,6 +4,8 @@
  * sentences. For deeper documentation, link out via `ContextHelpButton`.
  */
 export const FIELD_TOOLTIPS = {
+  dataLake:
+    'A Data Lake is a curated knowledge base the AI grounds its answers in (RAG). It gives you better, sourced answers without having to recall the exact document.',
   credits: 'AI operations consume credits. Your balance updates after each request.',
   burnRate:
     'Average credits consumed per day over your recent activity. Use this to estimate how long your balance will last.',


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video


https://github.com/user-attachments/assets/92f7f6ec-afe1-47ca-ab15-b470ec0dfe49



## Description

Closes #834.

Opening the Data Lakes surface gave no always-available explanation of what a Data Lake is or why to use it, so first-time and returning users could not quickly find out what it does. This PR adds a persistent info icon next to the "Data Lakes" header on both surfaces that reveals a short tooltip on hover or keyboard focus: what a Data Lake is (a curated RAG knowledge base) plus the benefit (better, sourced answers without recalling the exact document).

It reuses the app's existing `FieldTooltip` component (InfoOutlined + MUI Joy Tooltip) with a single shared copy string, so the explanation is permanently available (not a one-time dismissable callout) and stays identical across both surfaces.

## Changes

- Add a `dataLake` entry to the shared `FIELD_TOOLTIPS` registry (`fieldTooltips.ts`) so the copy lives in one place and both surfaces stay in sync.
- Render `FieldTooltip` next to the "Data Lakes" title in the management panel (`DataLakeListPanel.tsx`) as the title's `endDecorator`.
- Render `FieldTooltip` next to the header in the Data Lake Explorer (`DataLakeExplorer.tsx`), wrapped to match the breadcrumb's bottom margin so the icon lines up with the header text.
- Use repo-standard `ariaLabel` ("Help: Data Lakes") and per-surface `data-testid`s (`field-tooltip-data-lake-panel`, `field-tooltip-data-lake-explorer`).

## Tests

- `DataLakeListPanel.test.tsx`: new case asserting the info icon is present next to the panel header, carries the correct aria-label, and reveals the RAG copy on hover.
- `DataLakeExplorer.test.tsx`: new file asserting the same for the explorer header (mocks the browse hooks and heavy children so the header renders in isolation).

## Guide for Testers

Requires the `EnableDataLakes` feature flag to be on for your user/org.

1. Open the preview link and sign in.
2. In the left sidebar, click `Data Lakes`. The Data Lake Explorer opens.
3. Confirm a small info icon (i) appears immediately after the "Data Lakes / Data Lake Explorer" breadcrumb, before the "Manage lakes" button, and is vertically aligned with the header text.
4. Hover the info icon. Expected: a tooltip appears reading "A Data Lake is a curated knowledge base the AI grounds its answers in (RAG). It gives you better, sourced answers without having to recall the exact document."
5. Move the mouse away, then press Tab until the info icon is focused. Expected: the same tooltip appears on keyboard focus.
6. In the left sidebar, click `Files Manager` to open the file browser.
7. Open the `Upload Files` menu and choose `Data Lakes`. The Data Lakes management panel opens in a modal.
8. Confirm a small info icon (i) appears immediately after the "Data Lakes" title, before the `Create` button.
9. Hover the info icon. Expected: the same tooltip copy as step 4 appears.
10. Reload the page and repeat step 9. Expected: the icon and tooltip are still present (the explanation is permanent, not dismissed after first view).

### What NOT to test
- Data Lake creation, browsing, ingestion, or management behavior is unchanged by this PR.

## Additional Information

We deliberately used `FieldTooltip` (the (i) info icon) rather than `ContextHelpButton` (the (?) icon seen next to some admin headers): the (?) button opens the Help Center and would require a dedicated Data Lakes help article that does not exist, whereas the issue asks for a short inline explanation available on hover/focus. A full Data Lakes Help Center article with a (?) button would be a clean follow-up.

## Developer Notes (Optional)

- `FIELD_TOOLTIPS.dataLake` is a new shared copy key; reuse it anywhere the Data Lake concept needs a one-line explainer so the wording never drifts.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no settings added
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry changes
