### PR TITLE
feat(ws): allow subscribing to bob_runs, owner-scoped

### DIFF
--- a/apps/client/server/websocket/dataSubscribeRequest.ts
+++ b/apps/client/server/websocket/dataSubscribeRequest.ts
@@ -107,6 +107,13 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
       [Subscription.collection.collectionName]: accessibleBy(userAbility).ofType(Subscription),
       [Artifact.collection.collectionName]: accessibleBy(userAbility).ofType(Artifact),
       [ArtifactVersion.collection.collectionName]: accessibleBy(userAbility).ofType(ArtifactVersion),
+      // [DELETION-FOOTPRINT] premium-bob run doc: the reading screen live-subscribes to its
+      // bob_runs doc by _id (issue #33). Owner-scoped so a user only sees their own runs. Literal
+      // string because the model lives in the overlay (not importable here); `userId` is a String
+      // field, so match the stringified id. This ownership rule (own runs only) MUST stay in sync
+      // with the GET /api/premium-bob/runs/:id polling route's read check (assertCanReadRun) so the
+      // poll can't leak what the socket wouldn't. Removed when Bob is extracted.
+      ['bob_runs']: { userId: user._id.toString() },
     }[collectionName];
   }
 


### PR DESCRIPTION
Adds `bob_runs` to the `dataSubscribeRequest` subscribe allow-list, **owner-scoped** (`{ userId }`) like `Inbox`, so the premium-bob overlay's reading screen can live-subscribe to a run's progress doc via the subscriber-fanout we already run.

## Why
Bob's reading screen shows per-persona progress during a ~60s panel run. Rather than build a new transport, it subscribes to the run's `bob_runs` doc by `_id` and rides the existing change-stream fanout (one-way, five-event progress feed). The overlay side already writes the doc (progress lifecycle) and consumes the subscription (`useBobRunDoc`). This is the one host change that mechanism needs.

**Lead-dev greenlit** (Nao): doc-subscription is the right call here — one-way progress, no new transport; Tavern's push pattern would be overkill (that's for bidirectional/live-sprite). Scope it like `Inbox`.

## The change (small + reviewable)
One entry in the scope map:
```ts
['bob_runs']: { userId: user._id.toString() },
```
- **Literal collection name** — the model lives in the premium-bob overlay, not importable here (same sanctioned-cross-boundary posture as premium literals elsewhere). `[DELETION-FOOTPRINT]` comment; removed when Bob is extracted.
- **`user._id.toString()`** — `bob_runs.userId` is a `String` field, so the id is stringified to match.
- **Owner-scoped** — a user can only subscribe to their own runs. This ownership rule must stay in sync with the forthcoming `GET /api/premium-bob/runs/:id` polling route's read check (`assertCanReadRun`) so the poll can't leak what the socket wouldn't (flagged inline).

## Safety / blast radius
Purely additive — makes `bob_runs` *subscribable*; nothing subscribes until the overlay is pinned in and the endpoint writes docs, so merging early is inert on the app. Host code, so it's fully typechecked by CI (verified locally after a core build: **0 errors in the file**). Runtime fanout behavior is exercised by the Bob e2e (issue #33, step G).

Part of the Bob URL-field entry point (issue #33, live-reading). Companion overlay work (async endpoint + GET polling route) tracked separately on the overlay repo.
