### PR TITLE
feat(data-lakes): warn on duplicate lake name in the wizard config step

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
@@ -24,6 +24,11 @@ vi.mock('@client/app/hooks/data/dataLakeWizard', () => ({
   useComputeHashes: () => ({ mutate: vi.fn(), isPending: false }),
   useCheckDuplicates: () => ({ mutate: vi.fn(), isPending: false }),
 }));
+// ConfigStep reads the lake list for its duplicate-name hint; stub it so this test
+// needs no QueryClientProvider.
+vi.mock('@client/app/hooks/data/dataLakes', () => ({
+  useGetDataLakes: () => ({ data: [] }),
+}));
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const TestWrapper = ({ children }: { children: ReactNode }) => (

--- a/apps/client/app/components/DataLakeWizard/steps/ConfigStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/ConfigStep.test.tsx
@@ -1,0 +1,133 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import ConfigStep from './ConfigStep';
+
+/**
+ * The duplicate-name hint has to match the scope the create will actually land in:
+ * the server disambiguates slugs per-org, so a same-named lake in another org is not
+ * a collision and must not warn.
+ */
+
+const { lakes, selectedAccount } = vi.hoisted(() => ({
+  lakes: { current: [] as { id: string; name: string; organizationId?: string }[] },
+  selectedAccount: { current: { id: 'me', personal: true } as { id: string; personal: boolean } | null },
+}));
+
+vi.mock('@client/app/hooks/data/dataLakeWizard', () => ({
+  useComputeHashes: () => ({ mutate: vi.fn(), isPending: false }),
+  useCheckDuplicates: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('@client/app/hooks/data/dataLakes', () => ({
+  useGetDataLakes: () => ({ data: lakes.current }),
+}));
+vi.mock('@client/app/components/Credits/AccountSelector', () => ({
+  useSelectedAccount: (selector: (s: { selectedAccount: unknown }) => unknown) =>
+    selector({ selectedAccount: selectedAccount.current }),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const setName = (name: string) => {
+  useDataLakeWizardStore.setState({
+    step: 'config',
+    targetLake: null,
+    allFiles: [],
+    config: {
+      name,
+      description: '',
+      tagPrefix: 'test:',
+      requiredUserTag: '',
+      requiredEntitlement: '',
+      conflictResolution: 'skip',
+    },
+  });
+};
+
+const WARNING = 'config-name-duplicate-warning';
+
+describe('ConfigStep - duplicate lake name warning', () => {
+  beforeEach(() => {
+    lakes.current = [];
+    selectedAccount.current = { id: 'me', personal: true };
+  });
+
+  afterEach(() => {
+    useDataLakeWizardStore.getState().resetWizard();
+  });
+
+  it('warns when a personal lake already uses the name, ignoring case and padding', () => {
+    lakes.current = [{ id: 'lake-1', name: 'Niche' }];
+    setName('  niche ');
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(screen.getByTestId(WARNING)).toHaveTextContent('Niche');
+  });
+
+  it('stays silent when no name matches', () => {
+    lakes.current = [{ id: 'lake-1', name: 'Other Lake' }];
+    setName('Niche');
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(screen.queryByTestId(WARNING)).toBeNull();
+  });
+
+  it('stays silent for a same-named lake outside the active scope', () => {
+    lakes.current = [{ id: 'lake-1', name: 'Niche', organizationId: 'org-a' }];
+    setName('Niche');
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(screen.queryByTestId(WARNING)).toBeNull();
+  });
+
+  it('warns on a same-named lake in the active org when an org is selected', () => {
+    lakes.current = [{ id: 'lake-1', name: 'Niche', organizationId: 'org-a' }];
+    selectedAccount.current = { id: 'org-a', personal: false };
+    setName('Niche');
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(screen.getByTestId(WARNING)).toBeInTheDocument();
+  });
+
+  it('stays silent in append mode, where the name is locked to the target lake', () => {
+    lakes.current = [{ id: 'lake-1', name: 'Niche' }];
+    setName('Niche');
+    useDataLakeWizardStore.setState({
+      targetLake: { id: 'lake-1', name: 'Niche', slug: 'niche', fileTagPrefix: 'niche:' },
+    });
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(screen.queryByTestId(WARNING)).toBeNull();
+  });
+});

--- a/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
@@ -48,7 +48,10 @@ export default function ConfigStep() {
 
   // Duplicate-name hint. The visible lake list spans every lake the user can read, but a
   // create only ever collides inside its own org scope (the server disambiguates the slug
-  // per-org), so narrow it to the account-switcher scope the create will land in.
+  // per-org), so narrow it to the account-switcher scope the create will land in. Must stay
+  // in sync with activeOrgId() in hooks/data/dataLakes.ts, which the create path reads at
+  // mutation time - matching it on a null selection too is what keeps the hint from ever
+  // naming a scope the lake won't land in.
   const { data: allLakes } = useGetDataLakes();
   const selectedAccount = useSelectedAccount(s => s.selectedAccount);
   const scopeOrgId = selectedAccount && !selectedAccount.personal ? selectedAccount.id : undefined;

--- a/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
@@ -18,6 +18,8 @@ import { useTheme } from '@mui/joy/styles';
 import { useEffect, useRef } from 'react';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import { useComputeHashes, useCheckDuplicates } from '@client/app/hooks/data/dataLakeWizard';
+import { useGetDataLakes } from '@client/app/hooks/data/dataLakes';
+import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
 
 function slugify(text: string): string {
   return text
@@ -25,6 +27,10 @@ function slugify(text: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '')
     .slice(0, 60);
+}
+
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
 export default function ConfigStep() {
@@ -39,6 +45,20 @@ export default function ConfigStep() {
 
   const computeHashes = useComputeHashes();
   const checkDuplicates = useCheckDuplicates();
+
+  // Duplicate-name hint. The visible lake list spans every lake the user can read, but a
+  // create only ever collides inside its own org scope (the server disambiguates the slug
+  // per-org), so narrow it to the account-switcher scope the create will land in.
+  const { data: allLakes } = useGetDataLakes();
+  const selectedAccount = useSelectedAccount(s => s.selectedAccount);
+  const scopeOrgId = selectedAccount && !selectedAccount.personal ? selectedAccount.id : undefined;
+  const duplicateNameLake =
+    targetLake || !config.name.trim()
+      ? undefined
+      : allLakes?.find(
+          lake =>
+            (lake.organizationId || undefined) === scopeOrgId && normalizeName(lake.name) === normalizeName(config.name)
+        );
 
   const autoTriggered = useRef(false);
 
@@ -111,6 +131,12 @@ export default function ConfigStep() {
           <FormHelperText>
             Slug: <code>{slugify(config.name) || '...'}</code>
           </FormHelperText>
+          {duplicateNameLake && (
+            <FormHelperText data-testid="config-name-duplicate-warning" sx={{ color: 'warning.plainColor' }}>
+              A data lake named &ldquo;{duplicateNameLake.name}&rdquo; already exists here. You can still continue -
+              both will appear under the same name, with different slugs.
+            </FormHelperText>
+          )}
         </FormControl>
 
         {/* Description */}


### PR DESCRIPTION
## Description

Closes #831

Two data lakes could silently end up with the same display name. The create path never compares names: `createDataLake` only de-duplicates the **slug**, via `disambiguateSlug()`, which appends `-1`, `-2`, ... within the lake's org scope because the join meta-tag `datalake:<org>:<slug>` is the real uniqueness key. So creating "Niche" twice returns 201 both times and produces two lakes, slugs `niche` and `niche-1`, that render identically in the manager list with no signal to the user.

This adds a non-blocking warning in the wizard's Config step: when the typed name matches an existing lake in the scope the create will actually land in, an amber hint appears under the slug preview explaining that both lakes will show the same name with different slugs. The user can rename or continue - Next stays enabled, matching the issue's "option to proceed or rename".

The warning is deliberately scoped to avoid false alarms. The lake list the client can see spans every lake the user can read (own + org + public), but a create only ever collides inside its own org scope. Warning on a same-named lake in a different org would be noise about a collision that cannot happen, so the check filters to the current account-switcher scope (Personal -> no `organizationId`), using the same derivation the create itself uses.

Scope note: this is the client-side guard only. Creating a duplicate name by calling `POST /api/data-lakes` directly still succeeds silently. Closing that would mean a 409 plus an explicit override flag on the create contract - a behavior change for existing callers, intentionally left out of this PR.

## Changes

- `apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx`
  - Reads the visible lake list (`useGetDataLakes`) and the active account scope (`useSelectedAccount`) to derive `duplicateNameLake`.
  - Renders a `FormHelperText` in `warning.plainColor` under the existing slug preview when a match is found (`data-testid="config-name-duplicate-warning"`).
  - Match is scoped to the create's org scope, normalized on trim + case + internal whitespace, and skipped entirely in append mode (the name field is locked to the target lake there).
- `apps/client/app/components/DataLakeWizard/steps/ConfigStep.test.tsx` (new) - 5 cases: case/whitespace-insensitive personal match warns; no match stays silent; same-named lake in another org stays silent; match inside the selected org warns; append mode stays silent.
- `apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx` - stubs `useGetDataLakes`. That test renders `ConfigStep` at step `config`, so it began failing with "No QueryClient set" once the component gained a query.

No server, schema, or API-contract changes. No new dependencies.

## Guide for Testers

**Environment:** the PR preview env, `pr<N>.preview.bike4mind.com` (substitute this PR's number). Previews are created on demand by a maintainer - when one is triggered, a bot comment with the exact URL appears on this PR. Previews are torn down when the PR closes or after 3 days without a redeploy, so if the URL 404s, ask a maintainer to redeploy rather than treating it as a test failure.

**Prerequisite:** the `EnableDataLakes` admin feature flag must be on for the test account in that environment. Every step below assumes it is; if the **Data Lakes** sidebar entry is missing, the flag is off and the guide cannot proceed.

**Setup - create the first lake (skip if the account already has one)**

1. Go to `pr<N>.preview.bike4mind.com` and sign in.
2. In the sidebar, click **Data Lakes**.
3. Click **Manage** to open the Data Lakes panel.
4. Click **Create**. The wizard opens on the Source step.
5. Click **Select Files** and pick 2-3 small `.txt` or `.md` files.
6. Click **Next** through the Preview and Taxonomy steps until the Config step appears.
7. In **Data Lake Name**, type `QA Duplicate Test`. Expected: the helper text below shows `Slug: qa-duplicate-test`, and **no** amber warning appears.
8. In **Tag Prefix**, type `qatest:`.
9. Click **Start Upload** and wait for the upload to finish. Expected: the lake `QA Duplicate Test` now appears in the Data Lakes panel.

**The actual check - duplicate name warns**

10. Reopen the Data Lakes panel and click **Create** again.
11. Click **Select Files**, pick 2-3 small files, and click **Next** to the Config step.
12. In **Data Lake Name**, type `QA Duplicate Test` (exactly the same name). Expected: an amber warning appears directly under the slug helper text, reading `A data lake named "QA Duplicate Test" already exists here. You can still continue - both will appear under the same name, with different slugs.`

   <img width="605" height="165" alt="image" src="https://github.com/user-attachments/assets/ce863726-118c-4879-b470-fefa898e89b3" />

13. Confirm the **Next** button is still enabled. Expected: the warning does not block progress.
14. Clear the name and retype it as ` qa duplicate TEST` (leading space, mixed case). Expected: the same warning still appears - the match ignores case and surrounding whitespace.
15. Change the name to `QA Duplicate Test 2`. Expected: the warning disappears immediately.
16. Click the wizard's close (x) to abandon this second lake.

**Org scoping - a same-named lake in another scope must NOT warn**

Needs an account that belongs to at least one organization. Skip if unavailable.

17. Using the account switcher, switch to an **organization** account.
18. Open the Data Lakes panel, click **Create**, select files, and go to the Config step.
19. Type `QA Duplicate Test` (the name of the lake created under Personal in step 7). Expected: **no** warning appears - a personal lake is not a collision for an org-scoped create.
20. Close the wizard, switch back to **Personal**, and repeat step 12. Expected: the warning appears again.

**Append mode - the warning must stay hidden**

21. In the Data Lakes panel, find `QA Duplicate Test` and click its blue **+** icon button (tooltip: "Add files").
22. Select 1-2 files and click **Next** to the Config step. Expected: a blue "Adding files to QA Duplicate Test" banner is shown, the Name field is disabled, and **no** duplicate warning appears even though the name matches an existing lake (it matches itself).

**Regression Checks**

23. Complete one normal create with a brand-new unique name end to end. Expected: upload succeeds and the lake appears in the list, unchanged from before this PR.
24. On the Config step, confirm the pre-existing behavior still works: the slug preview updates as you type, and the duplicate-**file** handling radio group (Skip / Re-upload / Upload as new copies) still appears when uploaded files are already in the knowledge base. That feature is unrelated to this change despite the similar name.

**What NOT to test**

- Server-side rejection of duplicate names. There is none by design in this PR - the API still accepts a duplicate name and still auto-suffixes the slug.
- Renaming an existing lake to a duplicate name from the manager panel. Out of scope; not guarded here.

## Additional Information

The warning text says "already exists here" rather than "you already have" on purpose: the matched lake may be an org or public lake the user can read but does not own, so claiming ownership would be wrong.

Ties into #840 (manager list readability at scale) - this reduces how often identically-named lakes get created in the first place, but does not change how the list renders them.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
