### PR TITLE
feat(client): flip API reference to live OpenAPI docs (3/3)

### DIFF
--- a/apps/client/app/components/admin/ApiReferenceTab.test.tsx
+++ b/apps/client/app/components/admin/ApiReferenceTab.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import ApiReferenceTab from './ApiReferenceTab';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+describe('ApiReferenceTab', () => {
+  it('links to the interactive docs at /api/v1/docs in a new tab', () => {
+    render(<ApiReferenceTab />, { wrapper: TestWrapper });
+    const link = screen.getByTestId('api-reference-docs-link');
+    expect(link).toHaveAttribute('href', '/api/v1/docs');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('offers a download of the raw OpenAPI spec at /api/v1/openapi.json', () => {
+    render(<ApiReferenceTab />, { wrapper: TestWrapper });
+    const link = screen.getByTestId('api-reference-download-spec-link');
+    expect(link).toHaveAttribute('href', '/api/v1/openapi.json');
+    expect(link).toHaveAttribute('download', 'openapi.json');
+  });
+});

--- a/apps/client/app/components/admin/ApiReferenceTab.test.tsx
+++ b/apps/client/app/components/admin/ApiReferenceTab.test.tsx
@@ -13,7 +13,7 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => (
 describe('ApiReferenceTab', () => {
   it('links to the interactive docs at /api/v1/docs in a new tab', () => {
     render(<ApiReferenceTab />, { wrapper: TestWrapper });
-    const link = screen.getByTestId('api-reference-docs-link');
+    const link = screen.getByTestId('api-reference-open-docs-btn');
     expect(link).toHaveAttribute('href', '/api/v1/docs');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
@@ -21,7 +21,7 @@ describe('ApiReferenceTab', () => {
 
   it('offers a download of the raw OpenAPI spec at /api/v1/openapi.json', () => {
     render(<ApiReferenceTab />, { wrapper: TestWrapper });
-    const link = screen.getByTestId('api-reference-download-spec-link');
+    const link = screen.getByTestId('api-reference-download-spec-btn');
     expect(link).toHaveAttribute('href', '/api/v1/openapi.json');
     expect(link).toHaveAttribute('download', 'openapi.json');
   });

--- a/apps/client/app/components/admin/ApiReferenceTab.tsx
+++ b/apps/client/app/components/admin/ApiReferenceTab.tsx
@@ -74,7 +74,7 @@ const ApiReferenceTab = () => {
             variant="outlined"
             color="neutral"
             size="sm"
-            data-testid="api-reference-docs-link"
+            data-testid="api-reference-open-docs-btn"
           >
             Interactive Docs
           </Button>
@@ -86,7 +86,7 @@ const ApiReferenceTab = () => {
             variant="outlined"
             color="neutral"
             size="sm"
-            data-testid="api-reference-download-spec-link"
+            data-testid="api-reference-download-spec-btn"
           >
             Download OpenAPI Spec
           </Button>

--- a/apps/client/app/components/admin/ApiReferenceTab.tsx
+++ b/apps/client/app/components/admin/ApiReferenceTab.tsx
@@ -1,4 +1,4 @@
-import { Box, Sheet, Typography } from '@mui/joy';
+import { Box, Button, Divider, Sheet, Typography } from '@mui/joy';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useState } from 'react';
@@ -65,7 +65,32 @@ const ApiReferenceTab = () => {
     <Box sx={{ p: 3, height: '100%', overflow: 'auto' }}>
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
         <Typography level="h3">API Reference</Typography>
-        <Box sx={{ display: 'flex', gap: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Button
+            component="a"
+            href="/api/v1/docs"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="outlined"
+            color="neutral"
+            size="sm"
+            data-testid="api-reference-docs-link"
+          >
+            Interactive Docs
+          </Button>
+          <Button
+            component="a"
+            href="/api/v1/openapi.json"
+            // Same-origin, so the browser saves rather than navigates.
+            download="openapi.json"
+            variant="outlined"
+            color="neutral"
+            size="sm"
+            data-testid="api-reference-download-spec-link"
+          >
+            Download OpenAPI Spec
+          </Button>
+          <Divider orientation="vertical" />
           <Sheet
             variant={view === 'full' ? 'solid' : 'outlined'}
             color={view === 'full' ? 'primary' : 'neutral'}

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -644,6 +644,19 @@ read \`files\` (see [Poll Quest Status](#poll-quest-status)).
 }
 \`\`\`
 
+#### v1 API (OpenAPI 3.1)
+
+The versioned \`/api/ai/v1/*\` endpoints (\`/api/ai/v1/completions\` and \`/api/ai/v1/tools\`) publish a machine-readable OpenAPI 3.1 contract generated directly from the request-validation schemas, so the documentation never drifts from the running code.
+
+| Resource | Path | Description |
+|----------|------|-------------|
+| Interactive docs | \`/api/v1/docs\` | Browse and try the v1 endpoints in your browser |
+| OpenAPI spec | \`/api/v1/openapi.json\` | Raw OpenAPI 3.1 document (JSON) for SDK codegen |
+
+The spec is public and served with permissive CORS, and it rewrites its \`servers\` URL to the deployment you fetch it from, so a generated SDK targets the right origin. Point any OpenAPI generator (openapi-generator, openapi-typescript, and similar) at \`/api/v1/openapi.json\` to build a typed client.
+
+Note: \`/api/ai/v1/completions\` streams a custom SSE contract and is not OpenAI-compatible; the spec models both the completion event stream and the tools endpoint in full.
+
 #### AI Endpoints Summary
 
 | Method | Endpoint | Description |

--- a/apps/client/pages/api/v1/__tests__/openapi.json.test.ts
+++ b/apps/client/pages/api/v1/__tests__/openapi.json.test.ts
@@ -106,6 +106,13 @@ describe('GET /api/v1/openapi.json', () => {
     expect(spec.servers[0].url).not.toContain('a"b');
   });
 
+  it('accepts an underscore in the Host (non-RFC but JSON-safe) and rewrites the origin', () => {
+    const { res, getBody } = makeRes();
+    handler(makeReq('GET', { host: 'my_host.local:3000', 'x-forwarded-proto': 'http' }), res);
+    const spec = JSON.parse(getBody()) as { servers: Array<{ url: string }> };
+    expect(spec.servers[0].url).toBe('http://my_host.local:3000');
+  });
+
   it('serves the committed spec unchanged when no Host header is present', () => {
     const { res, getBody } = makeRes();
     handler(makeReq('GET'), res);

--- a/apps/client/pages/api/v1/__tests__/openapi.json.test.ts
+++ b/apps/client/pages/api/v1/__tests__/openapi.json.test.ts
@@ -94,6 +94,18 @@ describe('GET /api/v1/openapi.json', () => {
     expect(spec.servers[0].url).toBe('https://api.example.test');
   });
 
+  it('falls back to the committed spec for a malformed Host (no JSON injection)', () => {
+    const { res, getStatus, getBody } = makeRes();
+    // A Host carrying a JSON-breaking char must not be spliced into the spec;
+    // the charset allowlist rejects it, so the body stays valid and the served
+    // contract falls back to the committed placeholder URL instead of 5xx.
+    handler(makeReq('GET', { host: 'a"b', 'x-forwarded-proto': 'https' }), res);
+    expect(getStatus()).toBe(200);
+    const spec = JSON.parse(getBody()) as { openapi?: string; servers: Array<{ url: string }> };
+    expect(spec.openapi).toBe('3.1.0');
+    expect(spec.servers[0].url).not.toContain('a"b');
+  });
+
   it('serves the committed spec unchanged when no Host header is present', () => {
     const { res, getBody } = makeRes();
     handler(makeReq('GET'), res);

--- a/apps/client/pages/api/v1/openapi.json.ts
+++ b/apps/client/pages/api/v1/openapi.json.ts
@@ -33,9 +33,19 @@ const SPEC_JSON = JSON.stringify(openapiSpec);
 // the code samples and contact URL, so replacing it everywhere is sufficient.
 const PLACEHOLDER_URL = (openapiSpec as { servers?: Array<{ url?: string }> }).servers?.[0]?.url ?? '';
 
+// A valid HTTP authority is a hostname (optionally :port) or a bracketed IPv6
+// literal - every character of which is in this set. A direct-to-origin request
+// can carry an arbitrary Host, so anything outside the set is rejected below.
+const HOST_CHARSET = /^[A-Za-z0-9.\-:[\]]+$/;
+
 function specForRequest(req: NextApiRequest): string {
   const host = req.headers.host;
   if (!host || !PLACEHOLDER_URL) return SPEC_JSON;
+  // Allowlist the Host charset before splicing it into the serialized JSON: a
+  // malformed direct-to-origin Host (a quote/backslash/control char) would
+  // otherwise break the JSON.parse below and 5xx. Same reasoning as the proto
+  // allowlist - fall back to the committed spec rather than risk an injection.
+  if (!HOST_CHARSET.test(host)) return SPEC_JSON;
   const xfProto = req.headers['x-forwarded-proto'];
   const rawProto = (Array.isArray(xfProto) ? xfProto[0] : xfProto)?.split(',')[0]?.trim();
   // Allowlist the scheme: origin is spliced into the serialized JSON before it

--- a/apps/client/pages/api/v1/openapi.json.ts
+++ b/apps/client/pages/api/v1/openapi.json.ts
@@ -34,9 +34,11 @@ const SPEC_JSON = JSON.stringify(openapiSpec);
 const PLACEHOLDER_URL = (openapiSpec as { servers?: Array<{ url?: string }> }).servers?.[0]?.url ?? '';
 
 // A valid HTTP authority is a hostname (optionally :port) or a bracketed IPv6
-// literal - every character of which is in this set. A direct-to-origin request
-// can carry an arbitrary Host, so anything outside the set is rejected below.
-const HOST_CHARSET = /^[A-Za-z0-9.\-:[\]]+$/;
+// literal; underscore is tolerated too (non-RFC, but seen in internal hostnames).
+// Every allowed char is JSON-safe, so a value passing this test cannot break the
+// JSON.parse below. A direct-to-origin request can carry an arbitrary Host, so
+// anything outside the set is rejected (falls back to the committed spec).
+const HOST_CHARSET = /^[A-Za-z0-9._\-:[\]]+$/;
 
 function specForRequest(req: NextApiRequest): string {
   const host = req.headers.host;


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

**1. API Reference flip (Admin UI)**

Admin -> API Reference: the header now links the interactive docs and the downloadable spec, and
AI Services gains a "v1 API (OpenAPI 3.1)" section linking `/api/v1/docs` and `/api/v1/openapi.json`.

<img width="3588" height="2006" alt="image" src="https://github.com/user-attachments/assets/57bbf6d4-4d3b-4491-88fe-5d864428df49" />

<img width="3584" height="2002" alt="image" src="https://github.com/user-attachments/assets/872acc46-e761-424c-a084-f99ccddc622e" />



**2. Interactive Docs button**

Clicking "Interactive Docs" opens `/api/v1/docs`; the Scalar reference renders with the AI
operations and the Server panel set to the preview origin.


https://github.com/user-attachments/assets/8c0d9796-4783-427f-91ca-c19a4967f749



**3. Download OpenAPI Spec button**

Clicking "Download OpenAPI Spec" saves `openapi.json` for local codegen.


https://github.com/user-attachments/assets/b3507ebe-fc99-4577-90a3-760afdec48ab



**4. Spec endpoint still serves**

`GET /api/v1/openapi.json` on the preview: OpenAPI 3.1, `servers` rewritten to the preview origin,
open CORS, and OPTIONS preflight 204.

<img width="3600" height="2044" alt="image" src="https://github.com/user-attachments/assets/a1deced8-68bc-4809-ade1-a01d59772ab3" />

## Description

Third and final PR for #39 (OpenAPI 3.1 spec from Zod). PR 1 (#789) generated the spec; PR 2
(#882) served it and added the CI drift gate, but landed DORMANT (nothing user-facing linked to
it). This PR flips the switch: it links the interactive docs + downloadable spec from the admin
API Reference, and hardens the spec route's Host handling before it starts taking real traffic.

Closes #39.

What lands here:

- Guard the `Host` header in the spec route so a malformed direct-to-origin `Host` can no longer
  reach `JSON.parse` (the one carry-over from PR 2's approval, to fix before the docs go live).
- Add a "v1 API (OpenAPI 3.1)" section to the admin API Reference that links to the interactive
  docs (`/api/v1/docs`) and the raw spec (`/api/v1/openapi.json`).
- Add "Interactive Docs" and "Download OpenAPI Spec" buttons to the API Reference tab header.

## Changes

- `apps/client/pages/api/v1/openapi.json.ts` - allowlist the `Host` charset before splicing it into
  the serialized spec. A direct-to-origin request can carry an arbitrary `Host`; a value with a
  JSON-breaking char (quote/backslash/control) would otherwise break the `JSON.parse` of the
  origin-rewritten spec and 5xx. Anything outside a hostname/`:port`/bracketed-IPv6 charset now
  falls back to the committed spec instead, mirroring the existing `x-forwarded-proto` allowlist.
- `apps/client/app/components/admin/content/apiReferenceContent.ts` - new "v1 API (OpenAPI 3.1)"
  section under AI Services: a short prose intro plus a table linking to `/api/v1/docs` (browse and
  try) and `/api/v1/openapi.json` (raw spec for SDK codegen), and a note that `/api/ai/v1/completions`
  is a custom SSE contract (not OpenAI-compatible).
- `apps/client/app/components/admin/ApiReferenceTab.tsx` - two link buttons in the tab header:
  "Interactive Docs" (opens `/api/v1/docs` in a new tab, `rel="noopener noreferrer"`) and
  "Download OpenAPI Spec" (`/api/v1/openapi.json` with a `download` attribute; same-origin, so the
  browser saves rather than navigates), separated from the existing view toggles by a divider.

Tests:

- `apps/client/pages/api/v1/__tests__/openapi.json.test.ts` - a malformed-`Host` case asserting the
  route stays `200` and falls back to the committed spec (no JSON injection, no 5xx).
- `apps/client/app/components/admin/ApiReferenceTab.test.tsx` - the two header links resolve to the
  correct paths, the docs link opens in a new tab with `noopener`, and the spec link carries the
  `download` attribute.

## Guide for Testers

Open the preview link and sign in as an admin.

### A. API Reference content and links

1. Go to Admin -> API Reference (the "Full API Reference" view).
2. In the header, confirm two buttons appear to the left of the "Full API Reference" /
   "Claude Code Quickstart" toggles: "Interactive Docs" and "Download OpenAPI Spec".
3. Scroll to Core API Domains -> AI Services.
   Expected: a new "v1 API (OpenAPI 3.1)" section with a table linking `/api/v1/docs` and
   `/api/v1/openapi.json`, above the "AI Endpoints Summary" table.
4. Click "Interactive Docs".
   Expected: a new browser tab opens `/api/v1/docs` and the Scalar reference renders (title
   "Bike4Mind API", a sidebar, and the `AI` operations).
5. Click "Download OpenAPI Spec".
   Expected: the browser downloads a file named `openapi.json` (a valid OpenAPI 3.1 document).

### B. Spec route still serves correctly

6. In a terminal, run:
   `curl -s <the preview link>/api/v1/openapi.json | jq '.openapi, (.servers|length), .servers[0].url'`
   Expected: `"3.1.0"`, then `1`, then the preview origin (NOT `your-deployment.example.com`).

### Regression Checks

- The "Full API Reference" / "Claude Code Quickstart" view toggle still switches content as before.
- The rest of the API Reference content is unchanged.

### What NOT to test

- No behavior change to the request path: `/v1/completions` and `/v1/tools` are untouched.
- The `Host`-guard fallback is a direct-to-origin edge case; on the preview every request arrives
  through CloudFront with a well-formed `Host`, so it is covered by the unit test rather than a
  manual step.

## Additional Information

- Final PR of a 3-PR gated rollout for #39: PR 1 generate the spec (merged #789), PR 2 serve the
  spec + docs + CI gate (merged #882, dormant), PR 3 flip live (this).
- The `Host` guard was raised as a non-blocking observation on PR 2's approval and deferred to this
  PR, since it only matters once the docs start driving traffic to the spec endpoint.
- Known deviations from the #39 acceptance criteria (both deliberate):
  - Contract-diff PR comment (CI / Quality Gates) is deferred. The drift gate already forces the
    regenerated `openapi.json` into the PR file diff, so consumer-visible contract changes are
    reviewable today; the drift gate is the load-bearing correctness half, and a rendered
    breaking-vs-additive comment (e.g. `oasdiff`) is a follow-up worth building once the spec grows
    past the current two operations.
  - Scope vocabulary documents the real `ApiKeyScope` enum (`ai:generate`, `ai:chat`, ...) rather
    than the aspirational `ai.completions:write` vocab, because renaming scopes would break live
    keys and scope checks. The `resource:action` convention is documented; an aspirational rename
    would be a separate migration issue.

## Developer Notes (Optional)

- The spec route now allowlists both request-derived inputs it splices into the served JSON
  (`x-forwarded-proto` scheme and `Host` charset), so no header value can break the per-request
  origin rewrite.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (n/a)
- [x] I have made the UI/UX feel good (buttons, spacing, responsive)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation (this PR is the docs flip)
- [ ] Adding/modifying telemetry fields (n/a)
