### PR TITLE
refactor(data-lake): collapse wizard Upload Folder + Select Files into one Upload control

### DIFF
--- a/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/SourceSelectionStep.tsx
@@ -1,7 +1,20 @@
-import { Box, Button, CircularProgress, Stack, Tooltip, Typography } from '@mui/joy';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dropdown,
+  ListItemDecorator,
+  Menu,
+  MenuButton,
+  MenuItem,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/joy';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import CloudIcon from '@mui/icons-material/Cloud';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { useTheme } from '@mui/joy/styles';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
@@ -111,7 +124,7 @@ export default function SourceSelectionStep() {
           transition: 'all 0.2s',
           cursor: 'pointer',
         }}
-        onClick={() => !isScanning && folderInputRef.current?.click()}
+        onClick={() => !isScanning && fileInputRef.current?.click()}
       >
         {isScanning ? (
           <>
@@ -127,46 +140,86 @@ export default function SourceSelectionStep() {
           <>
             <CloudUploadIcon sx={{ fontSize: 56, color: isDragging ? 'primary.500' : 'neutral.400' }} />
             <Typography level="title-lg" textAlign="center">
-              Drop a folder here
+              Drop files or a folder here
             </Typography>
             <Typography level="body-sm" color="neutral" textAlign="center">
-              Or use the buttons below to select files
+              Or use the Upload button below
             </Typography>
           </>
         )}
       </Box>
 
-      {/* Action buttons */}
+      {/* Action buttons. A single Upload split-button covers both files and folder selection:
+          a browser file input can only be in one mode at a time (webkitdirectory forces folder-only),
+          so the two modes live behind one control instead of two top-level buttons. */}
       <Stack direction="row" gap={2} justifyContent="center" flexWrap="wrap">
-        {supportsWebkitDirectory ? (
+        {/* Joined split-button built from a flex wrapper rather than ButtonGroup: ButtonGroup's
+            child-radius CSS keys off data-first/last-child markers, which the Dropdown wrapper
+            around the caret swallows, so it can't round the caret correctly. We square the shared
+            edge and round the two outer edges by hand. */}
+        <Box sx={{ display: 'inline-flex' }}>
           <Button
-            data-testid="wizard-upload-folder-btn"
+            data-testid="wizard-upload-btn"
             variant="solid"
             color="primary"
             startDecorator={<CloudUploadIcon />}
-            onClick={() => folderInputRef.current?.click()}
+            onClick={() => fileInputRef.current?.click()}
+            sx={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
           >
-            Upload Folder
+            Upload
           </Button>
-        ) : (
-          <Tooltip title="Folder upload is not supported in this browser. Please use Chrome, Edge, or Safari.">
-            <span>
-              <Button variant="solid" color="primary" startDecorator={<CloudUploadIcon />} disabled>
-                Upload Folder
-              </Button>
-            </span>
-          </Tooltip>
-        )}
-
-        <Button
-          data-testid="wizard-select-files-btn"
-          variant="outlined"
-          color="neutral"
-          startDecorator={<InsertDriveFileIcon />}
-          onClick={() => fileInputRef.current?.click()}
-        >
-          Select Files
-        </Button>
+          <Dropdown>
+            <MenuButton
+              data-testid="wizard-upload-menu-btn"
+              aria-label="Upload options"
+              slots={{ root: Button }}
+              slotProps={{
+                root: {
+                  variant: 'solid',
+                  color: 'primary',
+                  sx: {
+                    px: 1,
+                    minWidth: 0,
+                    borderTopLeftRadius: 0,
+                    borderBottomLeftRadius: 0,
+                    borderLeft: '1px solid',
+                    borderLeftColor: 'primary.700', // subtle divider between the two halves
+                  },
+                },
+              }}
+            >
+              <KeyboardArrowDownIcon />
+            </MenuButton>
+            {/* zIndex above the wizard Modal (1300) so the menu isn't hidden behind it */}
+            <Menu placement="bottom-end" sx={{ zIndex: 1400 }}>
+              <MenuItem data-testid="wizard-upload-files-item" onClick={() => fileInputRef.current?.click()}>
+                <ListItemDecorator>
+                  <InsertDriveFileIcon />
+                </ListItemDecorator>
+                Upload Files&hellip;
+              </MenuItem>
+              {supportsWebkitDirectory ? (
+                <MenuItem data-testid="wizard-upload-folder-item" onClick={() => folderInputRef.current?.click()}>
+                  <ListItemDecorator>
+                    <CloudUploadIcon />
+                  </ListItemDecorator>
+                  Upload Folder&hellip;
+                </MenuItem>
+              ) : (
+                <Tooltip title="Folder upload is not supported in this browser. Please use Chrome, Edge, or Safari.">
+                  <span>
+                    <MenuItem data-testid="wizard-upload-folder-item" disabled>
+                      <ListItemDecorator>
+                        <CloudUploadIcon />
+                      </ListItemDecorator>
+                      Upload Folder&hellip;
+                    </MenuItem>
+                  </span>
+                </Tooltip>
+              )}
+            </Menu>
+          </Dropdown>
+        </Box>
 
         <Tooltip title="Coming soon">
           <span>


### PR DESCRIPTION
## Description

Closes #825

The Data Lake wizard's Select Source step exposed two separate top-level buttons for one intent ("add content") -- an **Upload Folder** picker and a **Select Files** picker -- which was redundant and confusing.

This collapses them into a single **Upload** split-button. The main button opens the multi-file picker (works in every browser); an attached caret opens a menu offering **Upload Files...** and **Upload Folder...**. Folder support is preserved exactly where the browser supports `webkitdirectory` (the menu item is disabled with an explanatory tooltip otherwise).

A browser file input can only be in one mode at a time (`webkitdirectory` forces folder-only selection), so the two modes have to live behind one control rather than being selectable inside a single OS dialog. The drag-and-drop zone still accepts files or a folder in one gesture, unchanged.

## Changes

- Replaced the **Upload Folder** + **Select Files** buttons with one **Upload** split-button (Joy `Dropdown` + `MenuButton` + `Menu`).
- Caret menu items: **Upload Files...** (all browsers) and **Upload Folder...** (disabled + tooltip where `webkitdirectory` is unsupported).
- Drop zone copy updated to "Drop files or a folder here / Or use the Upload button below"; clicking the zone now opens the files picker (the default action) instead of the folder picker.
- Menu `zIndex: 1400` so it renders above the wizard modal (Joy popup default `1000` sits below the modal's `1300`).
- Split-button built with a flex `Box` wrapper (not `ButtonGroup`) and hand-set corner radii, because the `Dropdown` around the caret swallows ButtonGroup's `data-*-child` markers and left the caret unrounded.
- Both hidden file inputs keep their order (folder first, files last), so the e2e selectors and drag-drop handler are unaffected.

## Guide for Testers

1. Open the app and go to **Sidebar -> Data Lakes**.
2. Start the create/upload wizard so the **Select Source** step is shown. Expected: one primary **Upload** button with a small caret on its right, plus a disabled **Connect Google Drive** button.
3. Click the main **Upload** button. Expected: the OS file picker opens in file-selection mode; selecting one or more files advances the wizard to the **Preview** step.
4. Reopen the wizard to the **Select Source** step. Click the **caret** on the right of the Upload button. Expected: a menu opens (on top of the modal, not hidden behind it) with **Upload Files...** and **Upload Folder...**.

   <img width="605" height="165" alt="image" src="https://github.com/user-attachments/assets/65ba5f25-dc0a-4ff0-88a5-a07566afacad" />

5. Click **Upload Files...**. Expected: same file picker as step 3; selecting files advances to **Preview**.
6. Reopen the menu and click **Upload Folder...** (in Chrome, Edge, or Safari). Expected: the OS picker opens in folder-selection mode; choosing a folder scans its contents and advances to **Preview**.
7. Drag a folder from your file system onto the drop zone. Expected: "Scanning folder contents..." appears, then the wizard advances to **Preview** with the folder's files listed.
8. Drag one or more loose files onto the drop zone. Expected: the wizard advances to **Preview** with those files.

### Regression Checks

- Folder upload still works in a `webkitdirectory`-capable browser (Chrome/Edge/Safari).
- In a browser without `webkitdirectory`, the **Upload Folder...** menu item is disabled and shows the "not supported in this browser" tooltip, while **Upload Files...** and the main Upload button still work.
- Drag-and-drop of both files and folders still resolves to the same **Preview** step as before.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
