### PR TITLE
fix(publish): scroll same-page # links in sandboxed artifacts instead of re-prompting the passphrase

### DIFF
--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -21,6 +21,7 @@ import {
 } from '@server/services/publish';
 import { getClientIp } from '@server/utils/ip';
 import { parsePublishPath } from '@server/services/publish/parsePublishPath';
+import { HASH_BRIDGE_JS } from '@server/services/publish/fragmentNav';
 import { requestHasGateProof } from '@server/services/publish/publishGateToken';
 import { renderPassphraseShell } from '@server/services/publish/renderPassphraseShell';
 import { PUBLISH_HOST } from '@server/services/publish/validateBundle';
@@ -558,6 +559,11 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     visibility: effectiveVisibility,
     assetMode: isShare ? (artifact.accessGate ? 'inline' : 'base') : undefined,
     assets: inlineAssets,
+    // Same-page fragment links must scroll in place, not re-navigate the sandboxed
+    // iframe (an opaque-origin navigation drops the SameSite proof cookie and
+    // dead-ends a gated bundle at its prompt shell). Both the canonical /p path and
+    // the path this render is reached at (share token / isolated alias) count.
+    pagePaths: [urlBase, canonicalPath],
   });
 
   // Comment-pin bridge: when comments are enabled, inject a tiny trusted script INTO the
@@ -757,6 +763,12 @@ function renderBundleWrapper(
   const iframeTag = isolatedSrc
     ? `<iframe sandbox="allow-scripts allow-same-origin" title="${titleHtml}" src="${escapeHtml(isolatedSrc)}"></iframe>`
     : `<iframe sandbox="allow-scripts" title="${titleHtml}" srcdoc="${srcdocAttr}"></iframe>`;
+  // Hash bridge (srcdoc mode only): forwards the page fragment into the sandboxed
+  // bundle (initial deep link + hashchange) and mirrors in-bundle fragment jumps
+  // back into the address bar. Approach B's wrapper CSP drops 'unsafe-inline', so
+  // isolated embeds skip it - in-bundle # clicks still scroll via the injected
+  // helper (fragmentNav.ts); only address-bar deep links stay a known gap there.
+  const hashBridge = isolatedSrc ? '' : `\n<script>${HASH_BRIDGE_JS}</script>`;
   // The comment overlay lives in this trusted wrapper (app origin), floating over the
   // sandboxed iframe - never inside it (the opaque-origin bundle can't read the token).
   const overlay = buildAnnotateOverlayHtml(artifact);
@@ -836,7 +848,7 @@ function renderBundleWrapper(
 .b4m-ver .b4m-vd{opacity:.4}</style>
 </head>
 <body>
-${iframeTag}${chromeBody}${brandBadge}${floatingReport}${bar}
+${iframeTag}${hashBridge}${chromeBody}${brandBadge}${floatingReport}${bar}
 ${noscriptBody}
 </body>
 </html>`;

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -133,6 +133,7 @@ describe('GET /api/publish/serve - sandboxed bundle', () => {
     // Wrapper has no inline scripts / bundle libs in Approach B -> tightened script-src.
     expect(csp).not.toContain("script-src 'unsafe-inline'");
     expect(csp).toContain('/api/publish/widget'); // only the external overlay widget
+    expect(data).not.toContain("b4m:'hash'"); // no inline hash bridge - the CSP would block it
   });
 
   it('falls back to the same-origin srcdoc when the wrapper is NOT served from an app host', async () => {
@@ -153,6 +154,8 @@ describe('GET /api/publish/serve - sandboxed bundle', () => {
     expect(data).not.toContain('usercontent.app.bike4mind.com'); // no cross-origin embed attempted
     const csp = res.getHeader('Content-Security-Policy') as string;
     expect(csp).toContain("script-src 'unsafe-inline'"); // srcdoc inherits -> must permit bundle inline JS
+    expect(data).toContain("b4m:'hash'"); // srcdoc mode carries the wrapper hash bridge
+    expect(data).toContain("b4m:'fragment'"); // and the srcdoc carries the fragment-nav helper
   });
 
   it('isolated origin serves the bundle AS the page with inline JS + unsafe-inline CSP', async () => {
@@ -169,6 +172,8 @@ describe('GET /api/publish/serve - sandboxed bundle', () => {
     expect(data).toContain('console.log(42)'); // author inline JS runs on the isolated origin
     expect(data).toContain('<base href='); // public tier <base> -> assets stay on the isolated origin
     expect(data).not.toContain('<iframe'); // it IS the page, not a wrapper
+    // Fragment-nav helper knows BOTH the /uc alias it is served at and the canonical /p path.
+    expect(data).toContain('"paths":["/uc/u/scope123/my-slug","/p/u/scope123/my-slug"]');
     const csp = res.getHeader('Content-Security-Policy') as string;
     expect(csp).toContain("script-src 'unsafe-inline'"); // inline allowed - isolation is the origin, not stripping
     // frame-ancestors is the EXACT app wrapper host, no wildcard. Since usercontent
@@ -330,6 +335,7 @@ describe('GET /api/publish/serve - gated-bundle loader shell', () => {
     const csp = res.getHeader('Content-Security-Policy') as string;
     expect(csp).toContain("script-src 'unsafe-inline'");
     expect(csp).toContain('connect-src https://app.bike4mind.com');
+    expect(data).toContain("b4m:'hash'"); // hash bridge feeds deep links into the injected srcdoc
     // Shell carries no secret - no index download happens.
     expect(mockDownload).not.toHaveBeenCalled();
   });
@@ -1386,6 +1392,10 @@ describe('GET /api/publish/serve - access gates (issue #383)', () => {
     const csp = res.getHeader('Content-Security-Policy') as string;
     expect(csp).toContain("frame-ancestors 'self'");
     expect(csp).toContain("form-action 'self'");
+    // Framed fallback: inside a sandboxed iframe the form cannot submit, so the
+    // shell script swaps it for open-in-own-tab guidance instead of a dead end.
+    expect(data).toContain('window.top !== window.self');
+    expect(data).toContain('cannot be unlocked inside an embedded view');
   });
 
   it('a valid per-artifact proof cookie unlocks the gated bundle - served like a gated (non-public) page', async () => {
@@ -1403,6 +1413,11 @@ describe('GET /api/publish/serve - access gates (issue #383)', () => {
     expect(res.getHeader('Cache-Control')).toBe('private, no-store, must-revalidate');
     const data = res._getData() as string;
     expect(data).not.toContain('usercontent.app.bike4mind.com');
+    // Same-page # links must scroll in place: an iframe re-navigation would drop the
+    // SameSite proof cookie and dead-end at the prompt shell inside the sandbox.
+    expect(data).toContain("b4m:'fragment'"); // helper inside the srcdoc
+    expect(data).toContain("b4m:'hash'"); // bridge in the wrapper
+    expect(data).toContain('&quot;paths&quot;:[&quot;/p/u/scope123/my-slug&quot;]'); // config, srcdoc-attr escaped
   });
 
   it('a proof for a DIFFERENT artifact does not unlock (re-prompts instead)', async () => {

--- a/apps/client/server/services/publish/fragmentNav.test.ts
+++ b/apps/client/server/services/publish/fragmentNav.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { buildFragmentNavScriptTag, HASH_BRIDGE_JS } from './fragmentNav';
+
+describe('buildFragmentNavScriptTag', () => {
+  it('serializes origins and trailing-slash-normalized, deduped paths into the config', () => {
+    const tag = buildFragmentNavScriptTag({
+      origins: ['https://app.example.com', '', 'https://app.example.com'],
+      paths: ['/p/u/scope/slug/', '/p/u/scope/slug', '/a/tok123'],
+    });
+    expect(tag).toContain('"origins":["https://app.example.com"]');
+    expect(tag).toContain('"paths":["/p/u/scope/slug","/a/tok123"]');
+    expect(tag).not.toContain('__B4M_FRAGMENT_CFG__');
+  });
+
+  it('escapes < in config values so a crafted path cannot close the script tag', () => {
+    const tag = buildFragmentNavScriptTag({
+      origins: ['https://app.example.com'],
+      paths: ['/p/u/scope/</script><script>alert(1)'],
+    });
+    expect(tag.indexOf('</script>')).toBe(tag.length - '</script>'.length);
+    expect(tag).toContain('\\u003c/script>');
+  });
+
+  it('neither script contains a literal </script> of its own', () => {
+    const tag = buildFragmentNavScriptTag({ origins: ['https://a.b'], paths: ['/p/u/x/y'] });
+    const inner = tag.slice('<script>'.length, -'</script>'.length);
+    expect(inner).not.toContain('</script>');
+    expect(HASH_BRIDGE_JS).not.toContain('</script>');
+  });
+});

--- a/apps/client/server/services/publish/fragmentNav.ts
+++ b/apps/client/server/services/publish/fragmentNav.ts
@@ -1,0 +1,113 @@
+/**
+ * Publish - same-page fragment navigation for sandboxed bundles.
+ *
+ * A bundle document inside the sandboxed viewer iframe cannot fragment-navigate
+ * natively: a srcdoc document's URL is `about:srcdoc` (its base URL is inherited
+ * from the wrapper), and a directly-served bundle carries an injected trailing-slash
+ * `<base>` for asset resolution - either way `#tldr` (or an absolute link to the
+ * artifact's own URL plus a fragment) resolves to a URL that differs from the
+ * document URL, so a click triggers a full CROSS-DOCUMENT iframe navigation instead
+ * of an in-page scroll. Worse, that navigation is issued from the sandbox's opaque
+ * origin, which strips SameSite cookies: a passphrase-gated artifact re-serves its
+ * prompt shell INTO the sandboxed frame, where the form cannot submit (the sandbox
+ * has no `allow-forms` and suppresses the submit event entirely) and fetch would be
+ * uncredentialed - a dead end the viewer can only escape by reloading.
+ *
+ * Two cooperating scripts restore in-page semantics:
+ *   - FRAGMENT_NAV: injected INTO the sandboxed bundle (renderSandboxedBundle). It
+ *     intercepts clicks on links that identify THIS page (raw `#...` hrefs, or
+ *     absolute URLs whose origin+path match the bundle's own), scrolls to the
+ *     fragment target, and notifies the parent so the address bar can follow:
+ *       iframe -> parent : { b4m: 'fragment', hash: '#...' | '' }
+ *     It also accepts the page hash from the parent (initial deep link + hashchange):
+ *       parent -> iframe : { b4m: 'hash', hash: '#...' }
+ *   - HASH_BRIDGE_JS: inlined in the app-origin wrapper / loader shell (srcdoc mode
+ *     only - the Approach B wrapper CSP has no 'unsafe-inline', so deep-link scroll
+ *     is a known gap there). Forwards location.hash into the iframe and mirrors
+ *     in-bundle jumps back via history.replaceState (fragment-only, validated).
+ *
+ * Both scripts run on the opaque origin / app origin respectively and exchange only
+ * the fragment string. Message types must stay disjoint from the pin bridge's
+ * ('pinmode'/'pins'/'scrollto'/'ready'/'pin-dropped'/'pin-activate') - both sides
+ * ignore unknown types. Neither script may contain a literal `</script>`.
+ */
+
+export interface FragmentNavConfig {
+  /** Origins whose absolute links may identify this page (doc origin + app host). */
+  origins: string[];
+  /** URL paths that identify this page (canonical /p path, /a/<token>, /uc alias). */
+  paths: string[];
+}
+
+const FRAGMENT_NAV_JS = String.raw`(function(){
+  'use strict';
+  var CFG=__B4M_FRAGMENT_CFG__;
+  function norm(p){return p.length>1?p.replace(/\/+$/,''):p;}
+  function targetFor(hash){var id;try{id=decodeURIComponent(hash.slice(1));}catch(e){id=hash.slice(1);}
+    if(!id){return null;}
+    var el=document.getElementById(id);if(el){return el;}
+    var named=document.getElementsByName(id);return named&&named[0]?named[0]:null;}
+  function jump(hash,notify){
+    var el=hash?targetFor(hash):null;
+    if(el){el.scrollIntoView();}
+    else if(!hash||hash==='#'||hash==='#top'){window.scrollTo(0,0);}
+    if(notify){try{window.parent.postMessage({b4m:'fragment',hash:hash&&hash!=='#'?hash:''},'*');}catch(e){}}
+  }
+  document.addEventListener('click',function(e){
+    if(e.defaultPrevented||e.button!==0||e.metaKey||e.ctrlKey||e.shiftKey||e.altKey){return;}
+    var a=e.target&&e.target.closest?e.target.closest('a[href]'):null;
+    if(!a){return;}
+    var raw=a.getAttribute('href')||'';
+    var hash;
+    if(raw.charAt(0)==='#'){hash=raw;}
+    else{
+      var u;try{u=new URL(String(a.href));}catch(err){return;}
+      if(CFG.origins.indexOf(u.origin)===-1){return;}
+      if(CFG.paths.indexOf(norm(u.pathname))===-1){return;}
+      hash=u.hash;
+    }
+    e.preventDefault();
+    jump(hash,true);
+  });
+  window.addEventListener('message',function(e){
+    if(e.source!==window.parent){return;}
+    var d=e.data||{};
+    if(d.b4m==='hash'&&typeof d.hash==='string'&&d.hash){jump(d.hash,false);}
+  });
+})();`;
+
+/**
+ * Build the fragment-nav <script> tag for injection into a sandboxed bundle.
+ * The config is serialized with `<` escaped so no author-influenced path (slug,
+ * share token) can close the script tag.
+ */
+export function buildFragmentNavScriptTag(config: FragmentNavConfig): string {
+  const cfg = {
+    origins: [...new Set(config.origins.filter(Boolean))],
+    paths: [...new Set(config.paths.filter(Boolean).map(p => (p.length > 1 ? p.replace(/\/+$/, '') : p)))],
+  };
+  const json = JSON.stringify(cfg).replace(/</g, '\\u003c');
+  return `<script>${FRAGMENT_NAV_JS.replace('__B4M_FRAGMENT_CFG__', json)}</script>`;
+}
+
+/**
+ * Parent-side hash bridge for the wrapper page and the loader shell (srcdoc mode).
+ * Sends the page hash on every iframe load (covers the loader shell's late srcdoc
+ * injection) and on hashchange; accepts fragment updates back and mirrors them into
+ * the address bar. Incoming hashes are fragment-only by construction (regex-gated
+ * `#...` or empty), so replaceState can never change path or query.
+ */
+export const HASH_BRIDGE_JS = String.raw`(function(){
+  var frame=document.querySelector('iframe');
+  if(!frame){return;}
+  function send(){try{frame.contentWindow.postMessage({b4m:'hash',hash:location.hash||''},'*');}catch(e){}}
+  frame.addEventListener('load',send);
+  window.addEventListener('hashchange',send);
+  window.addEventListener('message',function(e){
+    if(e.source!==frame.contentWindow){return;}
+    var d=e.data||{};
+    if(d.b4m!=='fragment'||typeof d.hash!=='string'){return;}
+    if(d.hash!==''&&!/^#\S{1,512}$/.test(d.hash)){return;}
+    try{history.replaceState(null,'',location.pathname+location.search+d.hash);}catch(err){}
+  });
+})();`;

--- a/apps/client/server/services/publish/renderBundleLoaderShell.ts
+++ b/apps/client/server/services/publish/renderBundleLoaderShell.ts
@@ -21,6 +21,8 @@
  * only appears once the authenticated `?raw=1` srcdoc renders. The login URL is built
  * from `location.*` at runtime. No server interpolation -> no injection surface.
  */
+import { HASH_BRIDGE_JS } from './fragmentNav';
+
 export function renderBundleLoaderShell(): string {
   // Bootstrap script: no server-interpolated values. The localStorage key mirrors
   // ACCESS_TOKEN_STORAGE_KEY in app/hooks/useAccessToken.ts.
@@ -95,6 +97,7 @@ export function renderBundleLoaderShell(): string {
 <div id="b4m-msg"></div>
 <noscript><div style="max-width:540px;margin:18vh auto 0;padding:0 1.25rem;text-align:center;font-family:system-ui,sans-serif">This is a private item. <a href="/login">Sign in</a> to view it.</div></noscript>
 <script>${bootstrap}</script>
+<script>${HASH_BRIDGE_JS}</script>
 </body>
 </html>`;
 }

--- a/apps/client/server/services/publish/renderPassphraseShell.ts
+++ b/apps/client/server/services/publish/renderPassphraseShell.ts
@@ -13,6 +13,11 @@
  * interpolation -> no injection surface. The passphrase travels only in the
  * POST body over HTTPS and is never persisted client-side; the proof cookie
  * (not the passphrase) is what future requests carry.
+ *
+ * Framed render: when this shell lands inside an iframe (a sandboxed bundle
+ * navigated to a gated path after its proof cookie was dropped/expired), the
+ * form cannot function - the sandbox suppresses form submission and strips
+ * credentials - so the script swaps it for open-in-own-tab guidance instead.
  */
 export function renderPassphraseShell(): string {
   const bootstrap = `(function () {
@@ -21,6 +26,21 @@ export function renderPassphraseShell(): string {
   var btn = document.getElementById('b4m-pp-btn');
   var msg = document.getElementById('b4m-pp-msg');
   function note(text) { msg.textContent = text; }
+  if (window.top !== window.self) {
+    // Framed render (e.g. a sandboxed bundle iframe navigated here after its
+    // proof cookie was dropped/expired): the form CANNOT work - the sandbox has
+    // no allow-forms (the submit event is suppressed before it fires) and a
+    // fetch from the opaque origin would be uncredentialed. Swap to guidance
+    // instead of a dead-end form. textContent only - no injection surface.
+    form.parentNode.removeChild(form);
+    var p = document.getElementById('b4m-pp-hint');
+    p.textContent = 'It cannot be unlocked inside an embedded view. Open this link in its own tab to enter the passphrase:';
+    var url = document.createElement('code');
+    url.id = 'b4m-pp-url';
+    url.textContent = location.href;
+    msg.parentNode.insertBefore(url, msg);
+    return;
+  }
   form.addEventListener('submit', function (ev) {
     ev.preventDefault();
     var passphrase = input.value;
@@ -76,13 +96,15 @@ export function renderPassphraseShell(): string {
          font-size:14px;font-weight:600;cursor:pointer}
   button:disabled{opacity:.6;cursor:default}
   #b4m-pp-msg{font-size:12.5px;color:#8b98a5;min-height:18px;margin-top:12px}
+  #b4m-pp-url{display:block;word-break:break-all;font-size:12px;text-align:left;color:#e6edf3;
+              background:#0f1216;border:1px solid #2a3138;border-radius:8px;padding:10px 12px;user-select:all}
 </style>
 </head>
 <body>
   <div class="card">
     <div class="lock" aria-hidden="true">&#128274;</div>
     <h1>This shared item is passphrase-protected</h1>
-    <p>Enter the passphrase you were given to view it.</p>
+    <p id="b4m-pp-hint">Enter the passphrase you were given to view it.</p>
     <form id="b4m-pp-form">
       <input id="b4m-pp-input" type="password" autocomplete="off" aria-label="Passphrase">
       <button id="b4m-pp-btn" type="submit">Unlock</button>

--- a/apps/client/server/services/publish/renderSandboxedBundle.test.ts
+++ b/apps/client/server/services/publish/renderSandboxedBundle.test.ts
@@ -188,4 +188,33 @@ describe('renderSandboxedBundle', () => {
       expect(priv.srcdoc).not.toContain('<base');
     });
   });
+
+  describe('fragment-nav helper', () => {
+    const html = `<html><head></head><body><a href="#tldr">jump</a></body></html>`;
+
+    it('injects the helper with the doc origin and page paths when pagePaths is set', () => {
+      const { srcdoc } = renderSandboxedBundle({
+        indexHtml: html,
+        urlBase: URL_BASE,
+        origin: ORIGIN,
+        visibility: 'private',
+        assets: new Map(),
+        pagePaths: [URL_BASE, '/a/tok123'],
+      });
+      expect(srcdoc).toContain(`"paths":["${URL_BASE}","/a/tok123"]`);
+      expect(srcdoc).toContain(`"origins":["${ORIGIN}"`);
+      expect(srcdoc).toContain(`b4m:'fragment'`);
+    });
+
+    it('does not inject the helper when pagePaths is omitted (?a= sub-documents)', () => {
+      const { srcdoc } = renderSandboxedBundle({
+        indexHtml: html,
+        urlBase: '',
+        origin: ORIGIN,
+        visibility: 'public',
+        assetMode: 'inline',
+      });
+      expect(srcdoc).not.toContain(`b4m:'fragment'`);
+    });
+  });
 });

--- a/apps/client/server/services/publish/renderSandboxedBundle.ts
+++ b/apps/client/server/services/publish/renderSandboxedBundle.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import type { PublishVisibility } from '@bike4mind/common';
-import { BLESSED_SCRIPT_PATHS } from './validateBundle';
+import { BLESSED_SCRIPT_PATHS, PUBLISH_HOST } from './validateBundle';
+import { buildFragmentNavScriptTag } from './fragmentNav';
 
 /**
  * Publish - sandboxed-bundle serializer.
@@ -62,6 +63,15 @@ export interface RenderSandboxedBundleInput {
    * `assetMode` resolves to `inline`; ignored for `base`.
    */
   assets?: Map<string, SandboxAsset>;
+  /**
+   * URL paths that identify THIS page (canonical /p path plus the /a/<token> or /uc
+   * alias it was reached at). When set, the fragment-nav helper (see fragmentNav.ts)
+   * is injected so same-page `#fragment` links scroll in place instead of triggering
+   * a cross-document iframe navigation that drops the sandbox's cookies and
+   * dead-ends a gated bundle at its prompt shell. Leave unset for self-contained
+   * sub-documents (`?a=` reply artifacts), whose real URL fragment-navigates natively.
+   */
+  pagePaths?: string[];
 }
 
 export interface RenderSandboxedBundleResult {
@@ -133,6 +143,18 @@ export function renderSandboxedBundle(input: RenderSandboxedBundleInput): Render
         $(el).attr(attr, toDataUri(asset));
       });
     }
+  }
+
+  if (input.pagePaths?.length) {
+    // After author content so author click handlers run first (the helper skips
+    // defaultPrevented events); the pin bridge appends after this, order-independent.
+    const tag = buildFragmentNavScriptTag({
+      origins: [origin, PUBLISH_HOST ? `https://${PUBLISH_HOST}` : ''],
+      paths: input.pagePaths,
+    });
+    const body = $('body');
+    if (body.length) body.append(tag);
+    else $.root().append(tag);
   }
 
   return { srcdoc: $.html(), droppedAssets };


### PR DESCRIPTION
## Description

Fragment links inside a published artifact (`/p/u/{scope}/{slug}#tldr` style, or a bare `#tldr` href) were a dead end on passphrase-gated artifacts. The bundle renders in a sandboxed srcdoc iframe whose document has no URL of its own, so a fragment click resolved against the inherited page URL and triggered a full cross-document iframe navigation instead of an in-page scroll. That navigation comes from the sandbox's opaque origin, which strips the SameSite=Lax proof cookie, so the serve route re-gated the request and rendered the passphrase prompt inside the sandboxed frame - where the sandbox suppresses form submission entirely (no `allow-forms`; the submit event never fires, hence the "Blocked form submission" console error) and a fetch would be uncredentialed anyway. Public/base-mode and isolated-origin bundles had the same fragment breakage via the trailing-slash `<base>`.

## Changes

- New `fragmentNav.ts`: a helper script injected into every sandboxed bundle srcdoc that intercepts clicks on same-page links (raw `#...` hrefs, or absolute URLs matching the artifact's own origin+path) and scrolls to the target in place, plus a wrapper-side hash bridge that forwards `location.hash` into the iframe (deep links, hashchange) and mirrors in-bundle jumps back into the address bar via fragment-only `history.replaceState`.
- `renderSandboxedBundle` gains an optional `pagePaths` input that triggers the helper injection; the serve route passes the canonical `/p` path plus the `/a/<token>` or `/uc` alias the render is reached at. Reply `?a=` sub-documents are left alone (their real URL fragment-navigates natively).
- The bundle wrapper and the loader shell inline the hash bridge (srcdoc mode only; the Approach B wrapper CSP has no `unsafe-inline`, so address-bar deep links remain a known gap there while in-bundle clicks still work via the injected helper).
- `renderPassphraseShell` detects a framed render (`window.top !== window.self`) and swaps the form - which cannot function inside a sandboxed frame - for open-in-own-tab guidance showing the URL. Still fully static, no server interpolation.

## Guide for Testers

1. Publish an artifact containing links like `<a href="#section2">` and a full `https://app.../p/u/{scope}/{slug}#section2` link, set a passphrase gate on it.
2. Open the artifact URL in a fresh session, enter the passphrase. Expected: artifact renders.
3. Click a `#` link inside the artifact. Expected: the page scrolls to that section, the address bar updates to `...#section2`, and NO passphrase prompt appears.
4. Copy the `...#section2` URL into a new tab (same session). Expected: after the gate passes, the page loads scrolled to that section.
5. In an artifact that links to a different passphrase-gated artifact, click that link. Expected: the framed prompt shows "open this link in its own tab" guidance with the URL instead of a passphrase form; opening that URL in a new tab shows the working form.

Regression checks: public (ungated) artifacts still render and their `#` links scroll; share links (`/a/<token>`) unaffected; comment pins still work (pin bridge and fragment helper coexist).

## Additional Information

Root cause verified end-to-end with a local harness serving the real renderer output into a Chromium session: reproduced the exact "Blocked form submission to ''" error pre-fix, and confirmed scroll/deep-link/guidance behavior post-fix. The proof-cookie flow is unchanged; the helper and bridge exchange only fragment strings over postMessage with source checks, and message types stay disjoint from the pin bridge protocol.