### PR TITLE
fix(datalake): exclude incomplete uploads from content-hash dedup

### DIFF
--- a/packages/database/src/models/content/FabFileModel.findByContentHashes.test.ts
+++ b/packages/database/src/models/content/FabFileModel.findByContentHashes.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+import { KnowledgeType } from '@bike4mind/common';
+import { createMongoServer } from '../../__test__/createMongoServer';
+import { FabFile, fabFileRepository } from './FabFileModel';
+
+let server: Awaited<ReturnType<typeof createMongoServer>>;
+
+beforeAll(async () => {
+  server = await createMongoServer();
+  await mongoose.connect(server.getUri());
+});
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server.stop();
+});
+beforeEach(async () => {
+  await FabFile.deleteMany({});
+});
+
+// Regression guard for the dedup bug: an orphaned upload (record created with the
+// contentHash but never completed -> status 'pending') must NOT count as an existing
+// duplicate, or a legit re-upload after a prior failed upload gets wrongly skipped.
+describe('FabFile dedup excludes incomplete uploads', () => {
+  const userId = 'u-dedup';
+
+  describe('findByContentHashes', () => {
+    it('returns completed records but excludes pending orphans', async () => {
+      await FabFile.create({
+        userId,
+        fileName: 'done.txt',
+        mimeType: 'text/plain',
+        type: KnowledgeType.FILE,
+        filePath: 'done.txt',
+        contentHash: 'hash-complete',
+        status: 'complete',
+      });
+      await FabFile.create({
+        userId,
+        fileName: 'orphan.txt',
+        mimeType: 'text/plain',
+        type: KnowledgeType.FILE,
+        filePath: 'orphan.txt',
+        contentHash: 'hash-pending',
+        status: 'pending',
+      });
+
+      const result = await fabFileRepository.findByContentHashes(userId, ['hash-complete', 'hash-pending']);
+
+      const hashes = result.map(f => f.contentHash);
+      expect(hashes).toContain('hash-complete'); // genuine completed duplicate still skipped
+      expect(hashes).not.toContain('hash-pending'); // orphan no longer blocks a re-upload
+    });
+
+    // $ne 'pending' (not === 'complete') is intentional so records predating the status
+    // field (undefined status) keep counting as duplicates - only known-incomplete drops out.
+    it('still returns a legacy record that has no status set', async () => {
+      await FabFile.collection.insertOne({
+        userId,
+        fileName: 'legacy.txt',
+        mimeType: 'text/plain',
+        type: KnowledgeType.FILE,
+        filePath: 'legacy.txt',
+        contentHash: 'hash-legacy',
+        deletedAt: null,
+      });
+
+      const result = await fabFileRepository.findByContentHashes(userId, ['hash-legacy']);
+      expect(result.map(f => f.contentHash)).toContain('hash-legacy');
+    });
+  });
+
+  describe('findByContentHashesInDataLake', () => {
+    const datalakeTag = 'datalake:test-lake';
+
+    it('returns completed records but excludes pending orphans in the lake', async () => {
+      await FabFile.create({
+        userId,
+        fileName: 'done.txt',
+        mimeType: 'text/plain',
+        type: KnowledgeType.FILE,
+        filePath: 'done.txt',
+        contentHash: 'lake-complete',
+        status: 'complete',
+        tags: [{ name: datalakeTag, strength: 1.0 }],
+      });
+      await FabFile.create({
+        userId,
+        fileName: 'orphan.txt',
+        mimeType: 'text/plain',
+        type: KnowledgeType.FILE,
+        filePath: 'orphan.txt',
+        contentHash: 'lake-pending',
+        status: 'pending',
+        tags: [{ name: datalakeTag, strength: 1.0 }],
+      });
+
+      const result = await fabFileRepository.findByContentHashesInDataLake(
+        ['lake-complete', 'lake-pending'],
+        datalakeTag
+      );
+
+      const hashes = result.map(f => f.contentHash);
+      expect(hashes).toContain('lake-complete');
+      expect(hashes).not.toContain('lake-pending');
+    });
+
+    // This variant is cross-user by contract (shared-lake dedup), not scoped to userId.
+    it('matches a completed record owned by a different user in the same lake', async () => {
+      await FabFile.create({
+        userId: 'other-user',
+        fileName: 'shared.txt',
+        mimeType: 'text/plain',
+        type: KnowledgeType.FILE,
+        filePath: 'shared.txt',
+        contentHash: 'lake-shared',
+        status: 'complete',
+        tags: [{ name: datalakeTag, strength: 1.0 }],
+      });
+
+      const result = await fabFileRepository.findByContentHashesInDataLake(['lake-shared'], datalakeTag);
+      expect(result.map(f => f.contentHash)).toContain('lake-shared');
+    });
+  });
+});

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -482,6 +482,11 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
       userId,
       contentHash: { $in: hashes },
       deletedAt: null,
+      // Exclude incomplete/orphan uploads: a record is created with the hash before the
+      // upload lands and stays 'pending' if it never completes, so a failed prior upload
+      // would otherwise block a legit re-upload. $ne (not === 'complete') is deliberate -
+      // it drops only the known-incomplete state and preserves legacy/undefined-status rows.
+      status: { $ne: 'pending' },
     });
     return result.map(d => d.toJSON());
   }
@@ -492,6 +497,10 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
       deletedAt: null,
       archivedAt: null,
       tags: { $elemMatch: { name: datalakeTag } },
+      // Same incomplete-upload exclusion as findByContentHashes: an orphan 'pending' record
+      // must not count as a live match, or sync-delta skips a legit re-upload and the restore
+      // paths (un/archive, un/delete) would discard the good copy in favor of the orphan.
+      status: { $ne: 'pending' },
     });
     return result.map(d => d.toJSON());
   }


### PR DESCRIPTION
## Optional Screenshot/Video
<img width="2010" height="944" alt="Deployed pr928 check-duplicates returns an empty duplicates list for a pending orphan" src="https://github.com/user-attachments/assets/a4f69741-0e4c-4e7f-8491-40d65b01dd10" />

*Figure: run against the deployed pr928 preview. A pending orphan was created through the real batch-presign and never uploaded, then check-duplicates was called with its hash. The 200 response is an empty duplicates list, so the orphan does not block a re-upload (AC1). Before the fix, the same endpoint returned the orphan hash and the re-upload was skipped.*

## Description
Closes #817.

A FabFile record gets its `contentHash` written before the upload actually lands, and the record stays `status: 'pending'` until an upload-complete event flips it to `'complete'`. When an upload fails, that record is orphaned in the `pending` state.

The content-hash dedup queries matched any non-deleted record regardless of `status`, so an orphan counted as an existing duplicate. The result: after a failed upload, re-uploading the same content was flagged "already exists" and skipped, with no way to recover short of deleting the orphan by hand.

The fix excludes incomplete records from the dedup set. Both dedup query methods now require `status: { $ne: 'pending' }`.

Using `$ne 'pending'` rather than an `=== 'complete'` equality is deliberate: it drops only the known-incomplete state, so records that predate the `status` field (undefined status) keep counting as duplicates, and it never lets an orphan win over a real file in the restore paths.

## Changes
- `findByContentHashes` (the wizard's duplicate check, via `/api/files/check-duplicates`) now excludes `pending` records, so a failed prior upload no longer blocks a legit re-upload.
- `findByContentHashesInDataLake` gets the same guard. It backs three callers: sync-delta classification (`/api/data-lakes/compute-sync-delta`) and the un-archive / un-delete restore dedup passes. For the restore paths this also closes a data-loss edge where an orphan `pending` live record would cause the good archived/deleted copy to be discarded in its favor.
- Added a real-DB test (`createMongoServer`) covering both methods: a `pending` orphan is excluded, a genuine `complete` duplicate is still returned, and a legacy record with no `status` set is still returned.

## Guide for Testers
End-to-end on a preview env, no DB access needed. The orphaned `pending` record that triggers the bug is created naturally by interrupting an upload: the wizard's Config step computes each file's `contentHash` and calls `check-duplicates` before uploading, while the `pending` record itself is written by `generate-presigned-urls-batch` just before the S3 upload. Interrupt the upload after the presign but before the S3 PUT completes, and the record is stranded in `pending`.

Preview URL: `app.pr928.preview.bike4mind.com`.

1. Open a Data Lake and start the upload wizard. Add one file (any small file, e.g. `report.pdf`).
2. Open DevTools -> Network. Proceed to the upload step, and either toggle **Offline** the instant the upload starts, or right-click the storage upload (S3/MinIO PUT) request and **Block request URL**. Goal: the presign request succeeds (creating the `pending` record) but the S3 PUT fails. Let the upload fail / close the wizard.
3. Turn the network back on / unblock. Start the wizard again and add the **same file**.
4. At the Config step, watch the duplicate-check result:
   - Expected (fixed): toast **"No duplicate files found"** and the file is NOT marked as a duplicate, so the re-upload proceeds.
   - Before this fix: toast **"Found 1 duplicate files"** and the file is marked duplicate / skipped, blocked by the orphan.
5. Regression check: upload a file and let it **finish successfully**, then start the wizard again with the same content. Expected: it IS flagged as a duplicate (unchanged behavior - genuine completed duplicates are still caught).

Automated coverage (model layer): `pnpm --filter @bike4mind/database test` runs `FabFileModel.findByContentHashes.test.ts`, which seeds a `pending` + a `complete` record (plus a legacy no-status record) and asserts only the completed hash is returned, for both `findByContentHashes` and `findByContentHashesInDataLake`. This is coverage, not a substitute for the preview run above.

### What NOT to test
- Moderation is out of scope. A `moderationStatus: 'blocked'` file can still be `status: 'complete'` and is still returned by dedup; that is pre-existing and intended (the S3 object exists). This PR only excludes incomplete uploads.
- #816 (records created before upload succeeds) is a separate ticket. This guard hardens the dedup path regardless of #816.

## Additional Information
The `status` enum is exactly `['pending', 'complete']`, and `'complete'` is only ever set after a real S3 object exists (`objectCreated`, the proxy upload handler, and the app-file upload-complete handler). So `pending` is the only incomplete state, which is why a single `$ne 'pending'` clause is sufficient.

## Developer Notes (Optional)
The two dedup query methods now share one contract: only real, completed content counts as a live match. Worth keeping in sync if a third dedup entry point is added.

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
