### PR TITLE
ci(e2e): bump global job timeout to 60m to absorb staging deploy wait

### DIFF
--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -49,7 +49,7 @@ jobs:
       status_context:     'e2e/core'
       suite_name:         'Core'
       artifact_suffix:    'core'
-      timeout_minutes:    25
+      timeout_minutes:    60
       stamp_promotable:   ${{ inputs.pr_number == '' }}
       wait_for_deploy:    ${{ inputs.pr_number == '' }}
       show_credits:       false

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -143,7 +143,7 @@ jobs:
       status_context:     'e2e/smoke'
       suite_name:         ''
       artifact_suffix:    ''
-      timeout_minutes:    35
+      timeout_minutes:    60
       stamp_promotable:   ${{ needs.prep.outputs.stamp_promotable == 'true' }}
       wait_for_deploy:    ${{ github.event_name == 'schedule' || inputs.pr_number == '' }}
       show_credits:       ${{ needs.prep.outputs.show_credits == 'true' }}


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description
A scheduled full-suite E2E run was cancelled at the 35m global job cap. Root cause: the run's fixed time budget was being eaten by the pre-test deploy wait before the suite could finish. In the failing run the test execution itself took ~23m, but waiting for the staging deploy to settle consumed ~10m, so the suite hit the 35m ceiling and GitHub cancelled it.

Per DevOps, staging deploys realistically take ~20-25m, which the previous timeouts did not account for: the full/smoke suite was capped at 35m and the Core gate at 25m. When a deploy is in flight at the start of an E2E run, that leaves too little of the budget for the actual test run.

This PR raises the job-level `timeout_minutes` for both E2E suites to 60m, giving enough headroom for the deploy-settle wait plus the test run without the job being cancelled at the cap. The value flows into the shared reusable workflow's `jobs.e2e-run.timeout-minutes` (`.github/workflows/e2e-run.yml:38`), which reads the `timeout_minutes` input from each caller.

## Changes

- `e2e-manual.yml` -- full/smoke suite (`e2e/smoke`): `timeout_minutes` 35 -> 60.
- `e2e-core.yml` -- Core prod-promotion gate (`e2e/core`): `timeout_minutes` 25 -> 60.
- CI-config-only change -- no production/app code, tests, deps, or schema touched.

## Guide for Testers

This is a CI-configuration change; verify it by observing job behavior on GitHub Actions -- no local setup or app clicking required.

1. Go to the repo on GitHub -> **Actions** tab -> **E2E Tests (Manual)** workflow.
2. Click **Run workflow**, select branch `test/bump-e2e-global-timeout`, set **Target environment** to `dev`, leave PR number / Tester ID blank, `gate_run` = `false`.
3. Open the run and confirm the job's configured timeout now shows **60 minutes** (the job is no longer cancelled at 35m even if the "Wait for staging deploy to settle" step runs its full ~10m). Expected: the run completes on its own conclusion (pass/fail from the tests), not a "cancelled -- timeout" from the job cap.
4. (Core gate) Trigger / observe an `e2e/core` run the same way; confirm its configured timeout is now 60 minutes rather than 25.

### Regression Checks

- Both suites still run the same steps in the same order; only the outer job time budget changed.
- The deploy-settle wait and `/api/ping` health probe are unchanged and still gate the run.
- A genuinely failing suite still fails (the timeout bump does not mask test failures).

### What NOT to test

- No application/UI behavior changed -- no need to manually exercise the app.
- No need to validate individual specs; this only affects the job's maximum wall-clock.

## Additional Information

- No new dependencies, no app config changes, no schema/index changes.
- The value is passed per caller into the reusable `e2e-run.yml` (`inputs.timeout_minutes` -> `jobs.e2e-run.timeout-minutes`, default 35).

## Developer Notes

- Known follow-up (intentionally out of scope here): the timeout bump treats the symptom. The pre-test guards in the shared `e2e-run.yml` are shorter than a 20-25m deploy:
  - "Wait for staging deploy to settle" (`e2e-run.yml:158-185`) is capped at ~10m (`30 attempts x 20s`), then warns and proceeds (`continue-on-error: true`).
  - "Wait for deployment to be healthy" (`e2e-run.yml:187-205`) is capped at ~5m (`30 attempts x 10s`), then hard-fails the job (`exit 1`).
- Combined, those cover only ~15m from when they start, so a full 20-25m deploy can still trip the health-probe failure before the 60m job cap matters. Fully absorbing a 25m deploy would additionally require extending those loop iteration counts. Decision for this PR was to ship the global-timeout bump only.



## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
