### PR TITLE
docs(selfhost): document hostdev worker + webhook routing for chunking

### DIFF
--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -99,6 +99,42 @@ curl -s -o /dev/null -w '%{http_code}\n' localhost:3000         # expect 200
 docker compose -f compose.selfhost.yaml logs -f app             # follow app logs (Ctrl-C to stop)
 ```
 
+### Frontend dev mode (host `next dev`)
+
+Want hot reload on the Next app while the backing services keep running in compose? Run the app on your host with `next dev` and point it at the compose services over their published `localhost` ports. The one wrinkle is chunking - read the note at the end before you upload files.
+
+Stop the compose `app` (it binds host port 3000, which `next dev` wants) and leave everything else up:
+
+```bash
+docker compose -f compose.selfhost.yaml --env-file .env.selfhost stop app
+```
+
+Keep the `worker` running. It is the piece that ingests uploads (queue consumers plus the safety-net scan), so chunking still happens even though the app itself now runs on your host.
+
+`next dev` reads `apps/client/.env.local` (gitignored), so create that file from your `.env.selfhost`, rewriting each compose service hostname to `localhost` and its published port:
+
+```bash
+B4M_SELF_HOST=true
+# directConnection avoids replica-set discovery, which would advertise the internal `mongo` host
+MONGODB_URI=mongodb://localhost:27017/bike4mind?replicaSet=rs0&directConnection=true
+AWS_ENDPOINT_URL_S3=http://localhost:9000       # was http://minio:9000
+AWS_ENDPOINT_URL_SQS=http://localhost:9324      # was http://sqs:9324
+# every *_QUEUE url: swap the `sqs` host for `localhost`, keep the path
+FAB_FILE_CHUNK_QUEUE=http://localhost:9324/000000000000/fabFileChunkQueue
+# ...the other *_QUEUE vars the same way
+# copy the rest verbatim from .env.selfhost: the three secrets, AWS creds, bucket names, LLM keys
+```
+
+Then start the app from the repo root:
+
+```bash
+pnpm --filter client dev      # http://localhost:3000
+```
+
+> **Match your published ports.** The values above use the compose defaults. If you set `MONGO_HOST_PORT` / `MINIO_HOST_PORT` / `SQS_HOST_PORT` in `.env.selfhost` (for example to dodge a port already in use on your host), use those host ports here instead.
+
+**Chunking in this mode.** MinIO's ObjectCreated webhook is wired to the compose `app` (`http://app:3000/...`), which your host `next dev` is not - so that notification dead-ends and never enqueues chunking. You do not have to fix this: the host upload route marks each file complete on its own, and the `worker`'s safety-net scan re-enqueues any complete-but-unchunked file once it is a couple of minutes old, so uploads still chunk (and become searchable) within a few minutes. To make chunking fire instantly instead, re-point the webhook at your host: set `MINIO_NOTIFY_WEBHOOK_ENDPOINT_primary=http://host.docker.internal:3000/api/internal/s3/object-created` (via a compose override file), then recreate MinIO with `docker compose -f compose.selfhost.yaml -f <override>.yaml --env-file .env.selfhost up -d minio`. On Linux, also add `extra_hosts: ["host.docker.internal:host-gateway"]` to the `minio` service.
+
 ## 4. Sign in
 
 Bike4Mind signs you in with a one-time code sent by email. In the self-host stack, all outgoing mail is caught by the bundled **Mailpit** - nothing leaves your machine:
@@ -399,6 +435,8 @@ The worker reuses the chatCompletion image and connects to Mongo, ElasticMQ, Min
 
 > **Run a single `worker` replica.** The scheduler and safety-net scan are not leader-guarded, so scaling `worker` to multiple replicas would double-run them (duplicate scheduled tasks and duplicate chunk enqueues). Queue consumers are safe to scale, but the bundled compose runs one `worker`; keep it that way.
 
+Running the app on your host with `next dev` instead of the compose `app`? Keep this `worker` up and see [Frontend dev mode](#frontend-dev-mode-host-next-dev) for pointing the app at the compose services - and for why uploads still chunk when the MinIO webhook can't reach your host app.
+
 ## Troubleshooting
 
 - **`docker pull` fails with `unauthorized` / `manifest unknown`** - the prebuilt image isn't available to your account (or isn't published yet). Build it from source instead - see "Building from source" in step 3.
@@ -418,7 +456,7 @@ The worker reuses the chatCompletion image and connects to Mongo, ElasticMQ, Min
 - **Changed `SECRET_ENCRYPTION_KEY` and now secrets fail to decrypt** - restore the original key; it cannot be rotated in place.
 - **Notebook auto-naming / summaries / mementos never happen** - background enrichment runs on the `worker` service via the event queue. Check the worker is up (`docker compose -f compose.selfhost.yaml ps worker`) and that `SELF_HOST_EVENT_QUEUE` is set in `.env.selfhost` (the app warns and drops enrichment events when it's unset). Watch `docker compose -f compose.selfhost.yaml logs -f worker`.
 - **Research/deep-research tasks never complete** - the `worker` consumes the research queue. Confirm it's running and check its logs; a task that keeps failing is left for a few retries, then dropped with an error log (ElasticMQ has no dead-letter queue).
-- **Uploaded files never chunk or become searchable** - ingestion is triggered by a MinIO -> app webhook. Verify `INTERNAL_S3_WEBHOOK_SECRET` is set (identical value reaches both the `app` and `minio` services via `.env.selfhost`), that `createbuckets` ran the `mc event add` on the fab-file bucket (`docker compose -f compose.selfhost.yaml logs createbuckets`), and that a local embedder is configured (see "Offline RAG"). Even if the webhook is missed, the worker's 60s safety-net scan re-enqueues un-chunked files - so also check the `worker` logs.
+- **Uploaded files never chunk or become searchable** - ingestion is triggered by a MinIO -> app webhook. Verify `INTERNAL_S3_WEBHOOK_SECRET` is set (identical value reaches both the `app` and `minio` services via `.env.selfhost`), that `createbuckets` ran the `mc event add` on the fab-file bucket (`docker compose -f compose.selfhost.yaml logs createbuckets`), and that a local embedder is configured (see "Offline RAG"). Even if the webhook is missed, the worker's 60s safety-net scan re-enqueues un-chunked files - so also check the `worker` logs. Running the app on your host with `next dev`? The webhook (aimed at the compose `app`) can't reach it at all - that is expected, and the safety-net scan still chunks within a few minutes. See [Frontend dev mode](#frontend-dev-mode-host-next-dev).
 
 ## Security notes
 

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -101,15 +101,23 @@ docker compose -f compose.selfhost.yaml logs -f app             # follow app log
 
 ### Frontend dev mode (host `next dev`)
 
-Want hot reload on the Next app while the backing services keep running in compose? Run the app on your host with `next dev` and point it at the compose services over their published `localhost` ports. The one wrinkle is chunking - read the note at the end before you upload files.
+Want hot reload on the Next app while the backing services keep running in compose? Run the app on your host with `next dev` and point it at the compose services over their published `localhost` ports. Two things need attention here - letting the host app reach Mailpit for sign-in, and how uploads get chunked - both covered below.
 
-Stop the compose `app` (it binds host port 3000, which `next dev` wants) and leave everything else up:
+**First, let the host app reach Mailpit for sign-in.** Sign-in emails a one-time code, and the app sends it over SMTP to `MAIL_HOST:MAIL_PORT`. In compose that host is the internal `mail` service and only Mailpit's web UI port (8025) is published, so a host-run app can't reach its SMTP port (1025) and no code is sent. Publish it with a small compose override (`compose.hostdev.yaml`):
 
-```bash
-docker compose -f compose.selfhost.yaml --env-file .env.selfhost stop app
+```yaml
+services:
+  mail:
+    ports:
+      - '127.0.0.1:1025:1025'
 ```
 
-Keep the `worker` running. It is the piece that ingests uploads (queue consumers plus the safety-net scan), so chunking still happens even though the app itself now runs on your host.
+Bring the stack up with the override, then stop the compose `app` - it binds host port 3000, which `next dev` wants. Keep the `worker` running: it ingests uploads (queue consumers plus the safety-net scan), so chunking still happens even though the app now runs on your host.
+
+```bash
+docker compose -f compose.selfhost.yaml -f compose.hostdev.yaml --env-file .env.selfhost up -d
+docker compose -f compose.selfhost.yaml --env-file .env.selfhost stop app
+```
 
 `next dev` reads `apps/client/.env.local` (gitignored), so create that file from your `.env.selfhost`, rewriting each compose service hostname to `localhost` and its published port:
 
@@ -119,6 +127,7 @@ B4M_SELF_HOST=true
 MONGODB_URI=mongodb://localhost:27017/bike4mind?replicaSet=rs0&directConnection=true
 AWS_ENDPOINT_URL_S3=http://localhost:9000       # was http://minio:9000
 AWS_ENDPOINT_URL_SQS=http://localhost:9324      # was http://sqs:9324
+MAIL_HOST=localhost                             # was mail (so sign-in codes reach Mailpit)
 # every *_QUEUE url: swap the `sqs` host for `localhost`, keep the path
 FAB_FILE_CHUNK_QUEUE=http://localhost:9324/000000000000/fabFileChunkQueue
 # ...the other *_QUEUE vars the same way
@@ -131,9 +140,11 @@ Then start the app from the repo root:
 pnpm --filter client dev      # http://localhost:3000
 ```
 
+Open http://localhost:3000 and sign in - the code lands in Mailpit at http://localhost:8025 (see [4. Sign in](#4-sign-in)).
+
 > **Match your published ports.** The values above use the compose defaults. If you set `MONGO_HOST_PORT` / `MINIO_HOST_PORT` / `SQS_HOST_PORT` in `.env.selfhost` (for example to dodge a port already in use on your host), use those host ports here instead.
 
-**Chunking in this mode.** MinIO's ObjectCreated webhook is wired to the compose `app` (`http://app:3000/...`), which your host `next dev` is not - so that notification dead-ends and never enqueues chunking. You do not have to fix this: the host upload route marks each file complete on its own, and the `worker`'s safety-net scan re-enqueues any complete-but-unchunked file once it is a couple of minutes old, so uploads still chunk (and become searchable) within a few minutes. To make chunking fire instantly instead, re-point the webhook at your host: set `MINIO_NOTIFY_WEBHOOK_ENDPOINT_primary=http://host.docker.internal:3000/api/internal/s3/object-created` (via a compose override file), then recreate MinIO with `docker compose -f compose.selfhost.yaml -f <override>.yaml --env-file .env.selfhost up -d minio`. On Linux, also add `extra_hosts: ["host.docker.internal:host-gateway"]` to the `minio` service.
+**Chunking in this mode.** MinIO's ObjectCreated webhook is wired to the compose `app` (`http://app:3000/...`), which your host `next dev` is not - so that notification dead-ends and never enqueues chunking. You do not have to fix this: the host upload route marks each file complete on its own, and the `worker`'s safety-net scan re-enqueues any complete-but-unchunked file once it is a couple of minutes old, so uploads still chunk (and become searchable) within a few minutes. To make chunking fire instantly instead, re-point the webhook at your host by adding MinIO to the same `compose.hostdev.yaml` override - set `MINIO_NOTIFY_WEBHOOK_ENDPOINT_primary` to `http://host.docker.internal:3000/api/internal/s3/object-created`, then recreate MinIO with `docker compose -f compose.selfhost.yaml -f compose.hostdev.yaml --env-file .env.selfhost up -d minio`. On Linux, also add `extra_hosts: ["host.docker.internal:host-gateway"]` to the `minio` service.
 
 ## 4. Sign in
 


### PR DESCRIPTION
## Optional Screenshot/Video

<img width="2368" height="1640" alt="hostdev-ui-freshdev" src="https://github.com/user-attachments/assets/3d2ae7a8-a25e-4ee1-a27b-b89ac6c2eec2" />
*Fresh-dev flow in hostdev: signed in through the host `next dev` UI (one-time code via Mailpit), uploaded a file via Files -> Upload Files, and the FabFile went 0 -> 5 chunks via the worker safety-net scan with the compose `app` stopped.*

## Description
Closes #822.

In self-host "hostdev" mode (the Next app running on your host via `next dev`, backends running in docker compose), uploaded Data Lake files silently never chunk, so search returns nothing. The cause is an ops/docs gap, not a code bug: the piece that chunks is the compose `worker` (its queue consumers plus a 60s safety-net scan), and MinIO's ObjectCreated webhook is wired to the compose `app` (`http://app:3000/...`), which a host-run `next dev` is not. Nothing in `SELF_HOST.md` explained how to run this mode, so a fresh dev had no way to get upload to chunking working.

This documents the mode. It is docs-only: the worker, the safety-net scan, and the webhook handler already exist and work. Note the ticket referenced a `compose.selfhost.hostdev.yaml` that does not exist anywhere in the repo; rather than add a maintained compose file, this documents a manual recipe (the scope agreed at assessment).

The docs also cover the sign-in step this mode needs: the host app emails the one-time code over SMTP, so a fresh dev has to publish Mailpit's SMTP port and set `MAIL_HOST=localhost`, or sign-in silently fails before they ever reach an upload.

Scope is chunking only (`chunkCount > 0`). Vectorize/search additionally needs a real embedding key, which is tracked separately in #823.

## Changes
- `SELF_HOST.md`: new "Frontend dev mode (host `next dev`)" subsection under "3. Bring up the stack" covering the app/compose split, the port-3000 conflict, the host `apps/client/.env.local` pointed at the compose services over `localhost` ports, and the two chunking options (rely on the worker's safety-net scan, or re-point the MinIO webhook at `host.docker.internal`).
- Documented the hostdev sign-in requirement: publish Mailpit's SMTP port (1025) via a small `compose.hostdev.yaml` override and set `MAIL_HOST=localhost`, so the host app can deliver the one-time sign-in code.
- Cross-linked the new subsection from the "Background worker" section.
- Extended the "Uploaded files never chunk or become searchable" Troubleshooting bullet with the hostdev caveat.

## Guide for Testers
Verified end to end on a local self-host stack, including a fresh-dev browser run (sign in -> upload -> chunk). First create a compose override `compose.hostdev.yaml` that publishes Mailpit's SMTP port so the host app can send sign-in codes:

```yaml
services:
  mail:
    ports:
      - '127.0.0.1:1025:1025'
```

Then:
1. Bring the stack up with the override, then stop the compose `app` (it binds host port 3000, which `next dev` wants; leave `mongo`/`minio`/`sqs`/`mail`/`worker` up): `docker compose -f compose.selfhost.yaml -f compose.hostdev.yaml --env-file .env.selfhost up -d` then `docker compose -f compose.selfhost.yaml --env-file .env.selfhost stop app`.
2. Create `apps/client/.env.local` from `.env.selfhost`, rewriting each compose hostname to `localhost` and its published port: Mongo needs `&directConnection=true`; `AWS_ENDPOINT_URL_S3=http://localhost:9000`; `AWS_ENDPOINT_URL_SQS=http://localhost:9324`; `MAIL_HOST=localhost`; each `*_QUEUE` swaps `sqs` for `localhost`; keep `B4M_SELF_HOST=true` and copy secrets/creds/bucket names verbatim.
3. Start the app on your host: `pnpm --filter client dev` (http://localhost:3000).
4. Open the app, sign in with the code from Mailpit (http://localhost:8025), then upload a file via Files -> Upload Files.
5. Confirm chunking: within a few minutes the file's `chunkCount` goes above 0 (worker log shows `[fabFileChunkScan] enqueued ... un-chunked file(s)` then `Completed chunking file into N chunks`). With the compose app stopped the MinIO webhook dead-ends, and the worker safety-net scan is what rescues it.

## Additional Information
Docs-only diff (a single markdown file), so no forced preview gate. Vectorize/search is out of scope here (#823).

## Developer Notes (Optional)
The recipe leans on an existing invariant worth knowing: the self-host upload proxy (`pages/api/files/[id]/upload.ts`) marks the FabFile `complete` itself, not only via the webhook. That is exactly what lets `worker/chunkScan.ts` recover a file whose webhook never arrived, since the scan only rescues `status: 'complete'` files.

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
