### PR TITLE
chore(premium): set b4m-overwatch overlay pin to 470754a2cabe3d1caa6663f3d905d07769e10b67

### DIFF
--- a/premium-overlay.lock.json
+++ b/premium-overlay.lock.json
@@ -1,6 +1,6 @@
 {
   "b4m-bob": "72235ca1b3fa53421917a1e7c1f244af18d2ed2b",
-  "b4m-overwatch": "4afc25e5ab5844b3bfb61cc7994310fe9c966487",
+  "b4m-overwatch": "470754a2cabe3d1caa6663f3d905d07769e10b67",
   "b4m-libreoncology": "0a81b7055fa5dba745b6f55381b528e737f8f4cf",
   "b4m-optihashi": "290df3393d87c4af533b63d678e3c05645b24f34",
   "b4m-pi": "6bc009c8b0bcc80c3688db0ee5c546e384ead133",


### PR DESCRIPTION
Overlay-pin-only change; no application source changes.