### PR TITLE
chore(ci): cut core-build artifact retention from 7 days to 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,16 @@ jobs:
           path: |
             b4m-core/*/dist
             packages/database/dist
-          retention-days: 7
+          # Intra-run handoff only: the jobs that consume this all `needs:
+          # core-build`, so it is dead weight the moment the run ends. It was on
+          # 7 days, which at ~1.8 GiB/day of CI artifacts overran the org's 2 GB
+          # Actions+Packages storage pool on 2026-07-25 and blocked EVERY deploy
+          # (staging, previews and production promotion) with "Failed to
+          # CreateArtifact: Artifact storage quota has been hit" for four days.
+          # Storage is billed regardless of repo visibility - public repos get
+          # free minutes, not free storage. Same content hash re-uploads once per
+          # run anyway, so this is not a cross-run cache and 1 day costs nothing.
+          retention-days: 1
           if-no-files-found: error
 
   typecheck:


### PR DESCRIPTION
## Why

On 2026-07-25 the org's **2 GB shared Actions + Packages storage pool** filled and blocked **every deploy path** for four days . staging, previews and production promotion all died at the same step:

```
##[error]Failed to CreateArtifact: Artifact storage quota has been hit. Unable to upload any new artifacts. Usage is recalculated every 6-12 hours.
```

This was not a billing problem and no budget increase helps, because the blocked resource is storage rather than compute. Raising the org Actions budget to $2,500 changed nothing.

Measured at the time, this repo held **7.2 GiB of live artifacts**, and `core-build` was by far the largest consumer at **3.7 GiB across 633 artifacts**. Every private repo in the org combined held 47 MiB, so this repo was effectively the whole problem.

Worth stating explicitly because it is counter-intuitive: **artifact storage is billed regardless of repository visibility.** Public repos get free Actions *minutes*, not free artifact *storage*. That is why a public repo can exhaust a pool that is otherwise mostly consumed by private ones.

## What this changes

`retention-days: 7` becomes `retention-days: 1` on the `core-build` upload.

`core-build` is an intra-run handoff: every consumer declares `needs: core-build`, so the artifact is dead the moment the run ends. Seven days of retention bought nothing. And because artifacts with the same content-hash name still upload once **per run** (27 copies of a single hash were observed), this is not a cross-run cache, so shortening retention does not cost a single rebuild.

At roughly 1.8 GiB/day of CI artifact churn against a 2 GB pool, even 1-day retention is tight . which is the real reason this needs to be 1 rather than 3 or 5.

## Already done separately

- Org-wide default artifact retention cut from 90 days to 7 (only `playwright-report-*` was still on the 90-day default; `core-build` and the e2e artifacts were already at 7)
- 6.7 GiB purged across 820 artifacts, from completed runs only
- The deployer repo's own deploy handoff moved off artifact storage entirely, so deploys no longer depend on this pool at all

## Worth a follow-up, not in this PR

`playwright-report-*` held 1.33 GiB across 59 artifacts and is the next largest. A Playwright HTML report is useful for a day or two after a failure, so it is a good candidate for the same treatment. `ai-latency-*` looks like benchmark output; if those results matter beyond debugging they probably belong somewhere durable rather than in a 2 GB CI pool.

Also note `selfhost-image.yml` uploads a digest artifact purely to pass ~70 bytes between matrix legs and the manifest-merge job. That job breaks whenever this pool is full, despite GHCR itself being free for public packages. Passing per-arch tags instead of digests would remove that dependency.
