### PR TITLE
feat(jupyter): execute notebooks directly from the browser without CLI

### DIFF
--- a/apps/client/app/components/ProfileModal/SettingsTabContent/JupyterIntegrationSection.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/JupyterIntegrationSection.tsx
@@ -1,22 +1,81 @@
-import { Typography, Box, Stack, Alert, Chip, Accordion, AccordionSummary, AccordionDetails } from '@mui/joy';
+import {
+  Typography,
+  Box,
+  Stack,
+  Alert,
+  Chip,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Input,
+  Button,
+} from '@mui/joy';
 import {
   Science as JupyterIcon,
-  Terminal,
   PlayArrow,
   CheckCircle,
   ExpandMore,
   Code,
   Storage,
   Settings,
+  LinkOff,
 } from '@mui/icons-material';
+import { useState, useCallback } from 'react';
 import SectionContainer from '../SectionContainer';
 import { gray } from '../../../utils/themes/colors';
+import {
+  JupyterBrowserClient,
+  getStoredJupyterConfig,
+  setStoredJupyterConfig,
+  clearStoredJupyterConfig,
+} from '../../../utils/jupyterBrowserClient';
 
 /**
- * Setup guide for executing AI-generated Jupyter notebooks on the user's local
- * Jupyter server via the B4M CLI.
+ * Setup guide and configuration for executing AI-generated Jupyter notebooks
+ * on the user's local Jupyter server directly from the browser.
  */
 const JupyterIntegrationSection = () => {
+  const initialConfig = getStoredJupyterConfig();
+  const [serverUrl, setServerUrl] = useState(() => initialConfig?.serverUrl || '');
+  const [token, setToken] = useState(() => initialConfig?.token || '');
+  const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+  const [testError, setTestError] = useState('');
+  const [isConfigured, setIsConfigured] = useState(() => !!initialConfig);
+
+  const handleSave = useCallback(() => {
+    if (!serverUrl.trim()) return;
+    setStoredJupyterConfig({ serverUrl: serverUrl.trim(), token: token.trim() });
+    setIsConfigured(true);
+  }, [serverUrl, token]);
+
+  const handleDisconnect = useCallback(() => {
+    clearStoredJupyterConfig();
+    setServerUrl('');
+    setToken('');
+    setIsConfigured(false);
+    setTestStatus('idle');
+  }, []);
+
+  const handleTestConnection = useCallback(async () => {
+    if (!serverUrl.trim()) return;
+    setTestStatus('testing');
+    setTestError('');
+
+    try {
+      const client = new JupyterBrowserClient({
+        serverUrl: serverUrl.trim(),
+        token: token.trim() || undefined,
+      });
+      await client.checkStatus();
+      setTestStatus('success');
+      // Auto-save on successful test
+      handleSave();
+    } catch (err) {
+      setTestStatus('error');
+      setTestError(err instanceof Error ? err.message : 'Connection failed');
+    }
+  }, [serverUrl, token, handleSave]);
+
   return (
     <SectionContainer
       title={
@@ -27,12 +86,101 @@ const JupyterIntegrationSection = () => {
       }
       subtitle="Execute AI-generated Python notebooks on your local Jupyter server directly from the chat interface."
       action={
-        <Chip size="sm" variant="soft" color="primary" startDecorator={<Terminal sx={{ fontSize: 14 }} />}>
-          CLI Required
+        <Chip
+          size="sm"
+          variant="soft"
+          color={isConfigured ? 'success' : 'neutral'}
+          startDecorator={isConfigured ? <CheckCircle sx={{ fontSize: 14 }} /> : <LinkOff sx={{ fontSize: 14 }} />}
+        >
+          {isConfigured ? 'Connected' : 'Not configured'}
         </Chip>
       }
     >
       <Stack spacing={3}>
+        {/* Connection Config */}
+        <Box
+          sx={theme => ({
+            backgroundColor: theme.palette.mode === 'light' ? '#F7F9FB' : gray[850],
+            p: 2.5,
+            borderRadius: 'sm',
+          })}
+        >
+          <Typography level="title-sm" sx={{ mb: 2 }}>
+            Jupyter Server Connection
+          </Typography>
+          <Stack spacing={2}>
+            <Box>
+              <Typography level="body-xs" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+                Server URL
+              </Typography>
+              <Input
+                size="sm"
+                placeholder="http://localhost:8888"
+                value={serverUrl}
+                onChange={e => {
+                  setServerUrl(e.target.value);
+                  setTestStatus('idle');
+                }}
+                sx={{ fontFamily: 'monospace' }}
+                data-testid="jupyter-server-url-input"
+              />
+            </Box>
+            <Box>
+              <Typography level="body-xs" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+                Token (optional)
+              </Typography>
+              <Input
+                size="sm"
+                type="password"
+                placeholder="Leave empty if auth is disabled"
+                value={token}
+                onChange={e => {
+                  setToken(e.target.value);
+                  setTestStatus('idle');
+                }}
+                sx={{ fontFamily: 'monospace' }}
+                data-testid="jupyter-token-input"
+              />
+            </Box>
+
+            {testStatus === 'success' && (
+              <Alert variant="soft" color="success" size="sm">
+                Connected successfully
+              </Alert>
+            )}
+            {testStatus === 'error' && (
+              <Alert variant="soft" color="danger" size="sm">
+                {testError || 'Connection failed'}
+              </Alert>
+            )}
+
+            <Stack direction="row" spacing={1}>
+              <Button
+                size="sm"
+                variant="solid"
+                color="primary"
+                onClick={handleTestConnection}
+                loading={testStatus === 'testing'}
+                disabled={!serverUrl.trim()}
+                data-testid="jupyter-test-connection-btn"
+              >
+                Test & Save
+              </Button>
+              {isConfigured && (
+                <Button
+                  size="sm"
+                  variant="outlined"
+                  color="danger"
+                  onClick={handleDisconnect}
+                  data-testid="jupyter-disconnect-btn"
+                >
+                  Disconnect
+                </Button>
+              )}
+            </Stack>
+          </Stack>
+        </Box>
+
         {/* Feature Overview */}
         <Box
           sx={theme => ({
@@ -56,15 +204,14 @@ const JupyterIntegrationSection = () => {
               <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
                 <CheckCircle sx={{ fontSize: 16, color: 'success.500', mt: 0.25 }} />
                 <Typography level="body-sm">
-                  <strong>One-click execution</strong> — Run generated notebooks with a single click using the &quot;Run
-                  Notebook&quot; button
+                  <strong>One-click execution</strong> — Run generated notebooks directly from the browser with a single
+                  click
                 </Typography>
               </Box>
               <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
                 <CheckCircle sx={{ fontSize: 16, color: 'success.500', mt: 0.25 }} />
                 <Typography level="body-sm">
-                  <strong>Real-time progress</strong> — Watch cell execution progress with live updates streamed to your
-                  browser
+                  <strong>Real-time progress</strong> — Watch cell execution progress with live updates
                 </Typography>
               </Box>
               <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
@@ -77,31 +224,6 @@ const JupyterIntegrationSection = () => {
             </Stack>
           </Stack>
         </Box>
-
-        {/* Requirements */}
-        <Alert
-          variant="soft"
-          color="neutral"
-          sx={{ borderRadius: 'sm' }}
-          startDecorator={<Settings sx={{ fontSize: 20 }} />}
-        >
-          <Box>
-            <Typography level="title-sm" sx={{ mb: 1 }}>
-              Requirements
-            </Typography>
-            <Stack spacing={0.5}>
-              <Typography level="body-xs">
-                <strong>1.</strong> B4M CLI installed and running on your machine
-              </Typography>
-              <Typography level="body-xs">
-                <strong>2.</strong> Jupyter server (JupyterLab or Jupyter Notebook) running locally
-              </Typography>
-              <Typography level="body-xs">
-                <strong>3.</strong> Python environment with your desired packages installed
-              </Typography>
-            </Stack>
-          </Box>
-        </Alert>
 
         {/* Setup Instructions */}
         <Accordion defaultExpanded sx={{ backgroundColor: 'transparent', boxShadow: 'none' }}>
@@ -132,7 +254,7 @@ const JupyterIntegrationSection = () => {
                 })}
               >
                 <Typography level="title-sm" sx={{ mb: 1 }}>
-                  Step 1: Start your Jupyter server
+                  Step 1: Start your Jupyter server with CORS enabled
                 </Typography>
                 <Box
                   component="pre"
@@ -146,19 +268,21 @@ const JupyterIntegrationSection = () => {
                     m: 0,
                   })}
                 >
-                  {`# Start JupyterLab (recommended)
-jupyter lab --NotebookApp.token='' --NotebookApp.password=''
+                  {`# JupyterLab (recommended)
+jupyter lab --ServerApp.allow_origin='*' \\
+  --ServerApp.token='' --ServerApp.password=''
 
-# Or use classic Jupyter Notebook
-jupyter notebook --NotebookApp.token='' --NotebookApp.password=''`}
+# Or classic Jupyter Notebook
+jupyter notebook --NotebookApp.allow_origin='*' \\
+  --NotebookApp.token='' --NotebookApp.password=''`}
                 </Box>
                 <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 1 }}>
-                  Disabling token/password allows the CLI to connect without authentication. For secure environments,
-                  configure a static token instead.
+                  The <code>allow_origin</code> flag lets the browser connect to your local Jupyter server. For secure
+                  environments, set a token and enter it above.
                 </Typography>
               </Box>
 
-              {/* Step 2: Configure CLI */}
+              {/* Step 2: Configure */}
               <Box
                 sx={theme => ({
                   backgroundColor: theme.palette.mode === 'light' ? '#F7F9FB' : gray[850],
@@ -169,35 +293,14 @@ jupyter notebook --NotebookApp.token='' --NotebookApp.password=''`}
                 })}
               >
                 <Typography level="title-sm" sx={{ mb: 1 }}>
-                  Step 2: Configure the B4M CLI
+                  Step 2: Enter your server URL above and click &quot;Test &amp; Save&quot;
                 </Typography>
-                <Typography level="body-sm" sx={{ mb: 1.5 }}>
-                  Set the following environment variables before starting the CLI:
+                <Typography level="body-sm">
+                  The default URL is <code>http://localhost:8888</code>. If you changed the port, update it accordingly.
                 </Typography>
-                <Box
-                  component="pre"
-                  sx={theme => ({
-                    backgroundColor: theme.palette.mode === 'light' ? gray[100] : gray[900],
-                    p: 1.5,
-                    borderRadius: 'xs',
-                    overflow: 'auto',
-                    fontSize: '0.75rem',
-                    fontFamily: 'monospace',
-                    m: 0,
-                  })}
-                >
-                  {`# Required: Jupyter server port (default: 8888)
-export JUPYTER_PORT=8888
-
-# Optional: Jupyter server host (default: localhost)
-export JUPYTER_HOST=localhost
-
-# Optional: Authentication token (if your server requires one)
-export JUPYTER_TOKEN=your-token-here`}
-                </Box>
               </Box>
 
-              {/* Step 3: Run CLI */}
+              {/* Step 3: Use */}
               <Box
                 sx={theme => ({
                   backgroundColor: theme.palette.mode === 'light' ? '#F7F9FB' : gray[850],
@@ -208,26 +311,11 @@ export JUPYTER_TOKEN=your-token-here`}
                 })}
               >
                 <Typography level="title-sm" sx={{ mb: 1 }}>
-                  Step 3: Start the B4M CLI
+                  Step 3: Generate and run notebooks from the chat
                 </Typography>
-                <Box
-                  component="pre"
-                  sx={theme => ({
-                    backgroundColor: theme.palette.mode === 'light' ? gray[100] : gray[900],
-                    p: 1.5,
-                    borderRadius: 'xs',
-                    overflow: 'auto',
-                    fontSize: '0.75rem',
-                    fontFamily: 'monospace',
-                    m: 0,
-                  })}
-                >
-                  {`# Start the CLI with Jupyter configured
-JUPYTER_PORT=8888 b4m
-
-# Or add to your shell profile for persistence
-echo 'export JUPYTER_PORT=8888' >> ~/.bashrc`}
-                </Box>
+                <Typography level="body-sm">
+                  Ask B4M to create a Python notebook, then click &quot;Execute Locally&quot; to run it on your machine.
+                </Typography>
               </Box>
             </Stack>
           </AccordionDetails>
@@ -277,13 +365,12 @@ echo 'export JUPYTER_PORT=8888' >> ~/.bashrc`}
                   </Box>
 
                   <Typography level="body-sm">
-                    <strong>2. Click &quot;Run Notebook&quot;</strong> — After B4M generates the notebook, you&apos;ll
-                    see a &quot;Run Notebook&quot; button below the code block.
+                    <strong>2. Click &quot;Execute Locally&quot;</strong> — After B4M generates the notebook, click the
+                    button below the code block to run it.
                   </Typography>
 
                   <Typography level="body-sm">
                     <strong>3. Monitor progress</strong> — Watch the progress indicator as each cell executes.
-                    You&apos;ll see the cell count and completion percentage.
                   </Typography>
 
                   <Typography level="body-sm">
@@ -292,13 +379,6 @@ echo 'export JUPYTER_PORT=8888' >> ~/.bashrc`}
                   </Typography>
                 </Stack>
               </Box>
-
-              <Alert variant="soft" color="primary" sx={{ borderRadius: 'sm' }}>
-                <Typography level="body-xs">
-                  <strong>Tip:</strong> Keep your Jupyter server running in the background. The CLI will automatically
-                  connect when you click &quot;Run Notebook&quot;.
-                </Typography>
-              </Alert>
             </Stack>
           </AccordionDetails>
         </Accordion>
@@ -331,21 +411,22 @@ echo 'export JUPYTER_PORT=8888' >> ~/.bashrc`}
                 <Stack spacing={2}>
                   <Box>
                     <Typography level="body-sm" fontWeight="bold" sx={{ mb: 0.5 }}>
-                      &quot;No active connections available&quot;
+                      &quot;WebSocket connection failed&quot; or CORS errors
                     </Typography>
                     <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                      The B4M CLI is not running or not connected. Start the CLI and ensure it shows &quot;Connected to
-                      B4M&quot;.
+                      Make sure you started Jupyter with <code>--ServerApp.allow_origin=&apos;*&apos;</code> (or{' '}
+                      <code>--NotebookApp.allow_origin=&apos;*&apos;</code> for classic Notebook). This allows the
+                      browser to connect.
                     </Typography>
                   </Box>
 
                   <Box>
                     <Typography level="body-sm" fontWeight="bold" sx={{ mb: 0.5 }}>
-                      &quot;Jupyter server not responding&quot;
+                      &quot;Jupyter API error: 403&quot;
                     </Typography>
                     <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                      Check that your Jupyter server is running and the JUPYTER_PORT matches. Verify with: curl
-                      http://localhost:8888/api
+                      Your Jupyter server requires a token. Either disable the token (
+                      <code>--ServerApp.token=&apos;&apos;</code>) or enter your token in the settings above.
                     </Typography>
                   </Box>
 
@@ -361,11 +442,11 @@ echo 'export JUPYTER_PORT=8888' >> ~/.bashrc`}
 
                   <Box>
                     <Typography level="body-sm" fontWeight="bold" sx={{ mb: 0.5 }}>
-                      &quot;Authentication required&quot;
+                      Connection times out
                     </Typography>
                     <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-                      Your Jupyter server requires a token. Set the JUPYTER_TOKEN environment variable in your CLI
-                      session.
+                      Verify your Jupyter server is running: open the server URL in a new browser tab. You should see
+                      the Jupyter interface.
                     </Typography>
                   </Box>
                 </Stack>

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/JupyterIntegrationSection.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/JupyterIntegrationSection.tsx
@@ -35,12 +35,11 @@ import {
  * on the user's local Jupyter server directly from the browser.
  */
 const JupyterIntegrationSection = () => {
-  const initialConfig = getStoredJupyterConfig();
-  const [serverUrl, setServerUrl] = useState(() => initialConfig?.serverUrl || '');
-  const [token, setToken] = useState(() => initialConfig?.token || '');
+  const [serverUrl, setServerUrl] = useState(() => getStoredJupyterConfig()?.serverUrl || '');
+  const [token, setToken] = useState(() => getStoredJupyterConfig()?.token || '');
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
   const [testError, setTestError] = useState('');
-  const [isConfigured, setIsConfigured] = useState(() => !!initialConfig);
+  const [isConfigured, setIsConfigured] = useState(() => !!getStoredJupyterConfig());
 
   const handleSave = useCallback(() => {
     if (!serverUrl.trim()) return;
@@ -269,12 +268,16 @@ const JupyterIntegrationSection = () => {
                   })}
                 >
                   {`# JupyterLab (recommended)
-jupyter lab --ServerApp.allow_origin='*' \\
+jupyter lab \\
+  --ServerApp.allow_origin='https://app.bike4mind.com' \\
   --ServerApp.token='' --ServerApp.password=''
 
 # Or classic Jupyter Notebook
-jupyter notebook --NotebookApp.allow_origin='*' \\
-  --NotebookApp.token='' --NotebookApp.password=''`}
+jupyter notebook \\
+  --NotebookApp.allow_origin='https://app.bike4mind.com' \\
+  --NotebookApp.token='' --NotebookApp.password=''
+
+# For local dev, use allow_origin='*' instead`}
                 </Box>
                 <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 1 }}>
                   The <code>allow_origin</code> flag lets the browser connect to your local Jupyter server. For secure
@@ -374,8 +377,8 @@ jupyter notebook --NotebookApp.allow_origin='*' \\
                   </Typography>
 
                   <Typography level="body-sm">
-                    <strong>4. View results</strong> — Once complete, you can download the executed notebook with all
-                    outputs, or view the results in your local Jupyter server.
+                    <strong>4. View results</strong> — Once complete, execution status is shown inline. You can also
+                    view outputs in your local Jupyter server.
                   </Typography>
                 </Stack>
               </Box>

--- a/apps/client/app/components/Session/NotebookExecutionButtons.tsx
+++ b/apps/client/app/components/Session/NotebookExecutionButtons.tsx
@@ -7,7 +7,7 @@
 
 import { Box, Button, CircularProgress, Typography } from '@mui/joy';
 import { CheckCircleOutline, ErrorOutline, PlayArrow } from '@mui/icons-material';
-import { FC, useState, useEffect, useRef } from 'react';
+import { FC, useState, useEffect } from 'react';
 import { isAxiosError } from 'axios';
 import { api } from '@client/app/contexts/ApiContext';
 import { useWebsocket } from '@client/app/contexts/WebsocketContext';
@@ -69,7 +69,6 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
   const [isExecuting, setIsExecuting] = useState(false);
   const [executionStarted, setExecutionStarted] = useState(() => parsedData?.started || false);
   const [error, setError] = useState<string | null>(() => parsedData?.error || null);
-  const abortRef = useRef(false);
 
   const [liveProgress, setLiveProgress] = useState<{
     status?: string;
@@ -144,7 +143,6 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
     setIsExecuting(true);
     setExecutionStarted(true);
     setError(null);
-    abortRef.current = false;
 
     if (storageKey) {
       sessionStorage.setItem(storageKey, JSON.stringify({ started: true }));
@@ -190,8 +188,6 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
       let cellsFailed = 0;
 
       for (let ci = 0; ci < codeCells.length; ci++) {
-        if (abortRef.current) break;
-
         const { cell } = codeCells[ci];
         const code = getCellSource(cell);
 
@@ -229,7 +225,7 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
         }
       }
 
-      if (cellsFailed === 0 && !abortRef.current) {
+      if (cellsFailed === 0) {
         setLiveProgress({ status: 'completed', cellIndex: totalCodeCells - 1, totalCells: totalCodeCells });
         await reportProgress('completed', totalCodeCells - 1, totalCodeCells);
         if (storageKey) {
@@ -256,6 +252,12 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
         } catch {
           // Ignore cleanup errors
         }
+      }
+      // Clean up the temp notebook file created on the Jupyter server
+      try {
+        await client.deleteContents(notebookPath);
+      } catch {
+        // Ignore cleanup errors
       }
       setIsExecuting(false);
     }
@@ -297,9 +299,10 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
     }
   };
 
+  const hasJupyterConfig = !!getStoredJupyterConfig()?.serverUrl;
+
   const handleExecute = async () => {
-    const jupyterConfig = getStoredJupyterConfig();
-    if (jupyterConfig?.serverUrl) {
+    if (hasJupyterConfig) {
       await handleBrowserExecute();
     } else {
       await handleCliExecute();
@@ -382,8 +385,6 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
       </Box>
     );
   }
-
-  const hasJupyterConfig = !!getStoredJupyterConfig()?.serverUrl;
 
   // Show execute button
   return (

--- a/apps/client/app/components/Session/NotebookExecutionButtons.tsx
+++ b/apps/client/app/components/Session/NotebookExecutionButtons.tsx
@@ -1,14 +1,21 @@
 /**
- * NotebookExecutionButtons - Execute Jupyter notebook locally via CLI
- * Shown when a message contains generated notebook content
+ * NotebookExecutionButtons - Execute Jupyter notebooks directly from the browser
+ *
+ * Primary path: connects to the user's local Jupyter server from the browser
+ * (no CLI needed). Falls back to CLI relay if no browser Jupyter config is set.
  */
 
 import { Box, Button, CircularProgress, Typography } from '@mui/joy';
 import { CheckCircleOutline, ErrorOutline, PlayArrow } from '@mui/icons-material';
-import { FC, useState, useEffect } from 'react';
+import { FC, useState, useEffect, useRef } from 'react';
 import { isAxiosError } from 'axios';
 import { api } from '@client/app/contexts/ApiContext';
 import { useWebsocket } from '@client/app/contexts/WebsocketContext';
+import {
+  JupyterBrowserClient,
+  JupyterBrowserError,
+  getStoredJupyterConfig,
+} from '@client/app/utils/jupyterBrowserClient';
 import type { IChatHistoryItem } from '@bike4mind/common';
 
 export interface NotebookExecutionButtonsProps {
@@ -20,7 +27,6 @@ export interface NotebookExecutionButtonsProps {
 
 /**
  * Safely parse sessionStorage data with error handling.
- * Returns null if data is corrupted or unparseable.
  */
 function safeParseStoredData(
   storageKey: string | null
@@ -32,12 +38,22 @@ function safeParseStoredData(
     if (!storedData) return null;
     return JSON.parse(storedData);
   } catch {
-    // Corrupted data - clear it and return null
     if (storageKey) {
       sessionStorage.removeItem(storageKey);
     }
     return null;
   }
+}
+
+interface NotebookCell {
+  cell_type: string;
+  source: string | string[];
+  outputs?: unknown[];
+  execution_count?: number | null;
+}
+
+function getCellSource(cell: { source: string | string[] }): string {
+  return Array.isArray(cell.source) ? cell.source.join('') : cell.source;
 }
 
 export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
@@ -53,8 +69,8 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
   const [isExecuting, setIsExecuting] = useState(false);
   const [executionStarted, setExecutionStarted] = useState(() => parsedData?.started || false);
   const [error, setError] = useState<string | null>(() => parsedData?.error || null);
+  const abortRef = useRef(false);
 
-  // Live progress state updated via WebSocket
   const [liveProgress, setLiveProgress] = useState<{
     status?: string;
     cellIndex?: number;
@@ -62,12 +78,11 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
     error?: string;
   }>({});
 
-  // Subscribe to WebSocket progress updates
+  // Subscribe to WebSocket progress updates (for CLI fallback path)
   useEffect(() => {
     if (!messageId || !sessionId) return;
 
     const unsubscribe = subscribeToAction('jupyter_notebook_progress', async message => {
-      // Type guard for the message
       const progressMsg = message as {
         action: string;
         questId?: string;
@@ -78,7 +93,6 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
         error?: string;
       };
 
-      // Check if this progress update is for our message/session
       if (progressMsg.questId === messageId || progressMsg.sessionId === sessionId) {
         setLiveProgress({
           status: progressMsg.status,
@@ -87,7 +101,6 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
           error: progressMsg.error,
         });
 
-        // Update sessionStorage for persistence across refresh
         if (storageKey) {
           if (progressMsg.status === 'completed') {
             sessionStorage.setItem(storageKey, JSON.stringify({ completed: true }));
@@ -99,23 +112,156 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
     });
 
     return unsubscribe;
-    // storageKey is derived from messageId, but eslint requires it in deps
   }, [messageId, sessionId, subscribeToAction, storageKey]);
 
-  // Merge initial state with live progress
-  const status = liveProgress.status ?? initialJupyterNotebook?.status ?? (executionStarted ? 'executing' : 'pending');
-  const cellCount = liveProgress.totalCells ?? initialJupyterNotebook?.cellCount ?? 0;
-  // Use ?? to handle 0 as a valid value (|| would incorrectly treat 0 as falsy)
-  const executedCells =
-    liveProgress.cellIndex !== undefined ? liveProgress.cellIndex + 1 : (initialJupyterNotebook?.executedCells ?? 0);
-  const lastError = liveProgress.error ?? initialJupyterNotebook?.lastError ?? error;
+  const reportProgress = async (
+    status: 'executing' | 'completed' | 'failed',
+    cellIndex?: number,
+    totalCells?: number,
+    errMsg?: string
+  ) => {
+    if (!messageId || !sessionId) return;
+    try {
+      await api.post('/api/jupyter/progress', {
+        sessionId,
+        questId: messageId,
+        status,
+        cellIndex,
+        totalCells,
+        error: errMsg,
+      });
+    } catch {
+      // Non-fatal: progress reporting is best-effort
+    }
+  };
 
-  // Don't show if no notebook content to execute
-  if (!notebookContent) {
-    return null;
-  }
+  const handleBrowserExecute = async () => {
+    if (!notebookContent || !sessionId) return;
 
-  const handleExecute = async () => {
+    const jupyterConfig = getStoredJupyterConfig();
+    if (!jupyterConfig) return;
+
+    setIsExecuting(true);
+    setExecutionStarted(true);
+    setError(null);
+    abortRef.current = false;
+
+    if (storageKey) {
+      sessionStorage.setItem(storageKey, JSON.stringify({ started: true }));
+    }
+
+    let notebook: { cells: NotebookCell[]; metadata?: Record<string, unknown> };
+    try {
+      notebook = JSON.parse(notebookContent);
+      if (!notebook.cells || !Array.isArray(notebook.cells)) {
+        throw new Error('Invalid notebook: missing cells array');
+      }
+    } catch (parseErr) {
+      const msg = parseErr instanceof Error ? parseErr.message : 'Failed to parse notebook';
+      setError(msg);
+      setIsExecuting(false);
+      return;
+    }
+
+    const client = new JupyterBrowserClient({
+      serverUrl: jupyterConfig.serverUrl,
+      token: jupyterConfig.token || undefined,
+    });
+
+    const codeCells = notebook.cells
+      .map((cell, idx) => ({ cell, idx }))
+      .filter(({ cell }) => cell.cell_type === 'code' && getCellSource(cell).trim().length > 0);
+    const totalCodeCells = codeCells.length;
+
+    setLiveProgress({ status: 'executing', cellIndex: -1, totalCells: totalCodeCells });
+
+    // Report initial state to server
+    await reportProgress('executing', undefined, totalCodeCells);
+
+    const kernelName = initialJupyterNotebook?.kernelName || 'python3';
+    const notebookPath = `b4m-notebook-${Date.now()}.ipynb`;
+
+    let session: { id: string; kernel: { id: string } } | null = null;
+
+    try {
+      session = await client.startSession(notebookPath, kernelName);
+      const kernelId = session.kernel.id;
+
+      let cellsFailed = 0;
+
+      for (let ci = 0; ci < codeCells.length; ci++) {
+        if (abortRef.current) break;
+
+        const { cell } = codeCells[ci];
+        const code = getCellSource(cell);
+
+        setLiveProgress({ status: 'executing', cellIndex: ci, totalCells: totalCodeCells });
+
+        try {
+          const result = await client.executeCell(kernelId, code, 30000);
+          cell.outputs = result.outputs;
+          cell.execution_count = result.executionCount;
+
+          if (!result.success) {
+            cellsFailed++;
+            const errMsg = result.error ? `${result.error.ename}: ${result.error.evalue}` : 'Cell execution failed';
+            setLiveProgress({ status: 'error', cellIndex: ci, totalCells: totalCodeCells, error: errMsg });
+            await reportProgress('failed', ci, totalCodeCells, errMsg);
+            setError(errMsg);
+            if (storageKey) {
+              sessionStorage.setItem(storageKey, JSON.stringify({ error: errMsg }));
+            }
+            // Stop on first error to match CLI behavior
+            break;
+          }
+
+          await reportProgress('executing', ci, totalCodeCells);
+        } catch (cellErr) {
+          cellsFailed++;
+          const errMsg = cellErr instanceof Error ? cellErr.message : 'Cell execution failed';
+          setLiveProgress({ status: 'error', cellIndex: ci, totalCells: totalCodeCells, error: errMsg });
+          await reportProgress('failed', ci, totalCodeCells, errMsg);
+          setError(errMsg);
+          if (storageKey) {
+            sessionStorage.setItem(storageKey, JSON.stringify({ error: errMsg }));
+          }
+          break;
+        }
+      }
+
+      if (cellsFailed === 0 && !abortRef.current) {
+        setLiveProgress({ status: 'completed', cellIndex: totalCodeCells - 1, totalCells: totalCodeCells });
+        await reportProgress('completed', totalCodeCells - 1, totalCodeCells);
+        if (storageKey) {
+          sessionStorage.setItem(storageKey, JSON.stringify({ completed: true }));
+        }
+      }
+    } catch (err) {
+      const errMsg =
+        err instanceof JupyterBrowserError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Failed to connect to Jupyter server';
+      setError(errMsg);
+      setLiveProgress({ status: 'failed', error: errMsg });
+      await reportProgress('failed', undefined, totalCodeCells, errMsg);
+      if (storageKey) {
+        sessionStorage.setItem(storageKey, JSON.stringify({ error: errMsg }));
+      }
+    } finally {
+      if (session) {
+        try {
+          await client.stopSession(session.id);
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+      setIsExecuting(false);
+    }
+  };
+
+  const handleCliExecute = async () => {
     if (!sessionId || !notebookContent) return;
 
     setIsExecuting(true);
@@ -150,6 +296,26 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
       setIsExecuting(false);
     }
   };
+
+  const handleExecute = async () => {
+    const jupyterConfig = getStoredJupyterConfig();
+    if (jupyterConfig?.serverUrl) {
+      await handleBrowserExecute();
+    } else {
+      await handleCliExecute();
+    }
+  };
+
+  // Merge initial state with live progress
+  const status = liveProgress.status ?? initialJupyterNotebook?.status ?? (executionStarted ? 'executing' : 'pending');
+  const cellCount = liveProgress.totalCells ?? initialJupyterNotebook?.cellCount ?? 0;
+  const executedCells =
+    liveProgress.cellIndex !== undefined ? liveProgress.cellIndex + 1 : (initialJupyterNotebook?.executedCells ?? 0);
+  const lastError = liveProgress.error ?? initialJupyterNotebook?.lastError ?? error;
+
+  if (!notebookContent) {
+    return null;
+  }
 
   // Show completion state
   if (status === 'completed') {
@@ -217,6 +383,8 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
     );
   }
 
+  const hasJupyterConfig = !!getStoredJupyterConfig()?.serverUrl;
+
   // Show execute button
   return (
     <Box
@@ -232,9 +400,11 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
       <Typography level="body-sm" sx={{ mb: 1.5, fontWeight: 'md' }}>
         Run this notebook locally with Jupyter
       </Typography>
-      <Typography level="body-xs" sx={{ mb: 1.5, color: 'text.secondary' }}>
-        Requires B4M CLI connected with Jupyter server running locally
-      </Typography>
+      {!hasJupyterConfig && (
+        <Typography level="body-xs" sx={{ mb: 1.5, color: 'text.secondary' }}>
+          Configure your Jupyter server in Settings to run notebooks directly from the browser, or use the B4M CLI.
+        </Typography>
+      )}
       <Button
         size="sm"
         variant="solid"
@@ -244,7 +414,7 @@ export const NotebookExecutionButtons: FC<NotebookExecutionButtonsProps> = ({
         startDecorator={isExecuting ? <CircularProgress size="sm" /> : <PlayArrow sx={{ fontSize: 16 }} />}
         data-testid="notebook-execute-btn"
       >
-        {isExecuting ? 'Starting...' : 'Execute Locally'}
+        {isExecuting ? 'Executing...' : 'Execute Locally'}
       </Button>
     </Box>
   );

--- a/apps/client/app/components/Session/__tests__/NotebookExecutionButtons.test.tsx
+++ b/apps/client/app/components/Session/__tests__/NotebookExecutionButtons.test.tsx
@@ -5,9 +5,10 @@ import { AxiosError, AxiosHeaders } from 'axios';
 import { NotebookExecutionButtons } from '../NotebookExecutionButtons';
 
 // Mock dependencies - use vi.hoisted() to ensure these are defined before vi.mock hoisting
-const { mockSubscribeToAction, mockPost } = vi.hoisted(() => ({
+const { mockSubscribeToAction, mockPost, mockGetStoredJupyterConfig } = vi.hoisted(() => ({
   mockSubscribeToAction: vi.fn(),
   mockPost: vi.fn(),
+  mockGetStoredJupyterConfig: vi.fn(),
 }));
 
 vi.mock('@client/app/contexts/WebsocketContext', () => ({
@@ -22,6 +23,12 @@ vi.mock('@client/app/contexts/ApiContext', () => ({
   },
 }));
 
+vi.mock('@client/app/utils/jupyterBrowserClient', () => ({
+  getStoredJupyterConfig: mockGetStoredJupyterConfig,
+  JupyterBrowserClient: vi.fn(),
+  JupyterBrowserError: class extends Error {},
+}));
+
 describe('NotebookExecutionButtons', () => {
   const validNotebookContent = JSON.stringify({
     nbformat: 4,
@@ -34,6 +41,8 @@ describe('NotebookExecutionButtons', () => {
     vi.clearAllMocks();
     unsubscribeMock = vi.fn();
     mockSubscribeToAction.mockReturnValue(unsubscribeMock);
+    // Default: no browser Jupyter config, so tests use the CLI fallback path
+    mockGetStoredJupyterConfig.mockReturnValue(null);
     sessionStorage.clear();
   });
 
@@ -131,7 +140,9 @@ describe('NotebookExecutionButtons', () => {
       });
     });
 
-    it('shows error message when API call fails', async () => {
+    it('shows error message when CLI API call fails', async () => {
+      // Ensure CLI fallback path
+      mockGetStoredJupyterConfig.mockReturnValue(null);
       // Create a proper AxiosError to test isAxiosError() function correctly
       const axiosError = new AxiosError('Request failed', 'ERR_BAD_REQUEST', undefined, undefined, {
         data: {
@@ -182,7 +193,7 @@ describe('NotebookExecutionButtons', () => {
 
       // Button should show loading state
       await waitFor(() => {
-        expect(screen.getByText('Starting...')).toBeInTheDocument();
+        expect(screen.getByText('Executing...')).toBeInTheDocument();
       });
 
       resolvePost!({ data: { sent: true } });

--- a/apps/client/app/components/Session/__tests__/NotebookExecutionButtons.test.tsx
+++ b/apps/client/app/components/Session/__tests__/NotebookExecutionButtons.test.tsx
@@ -5,10 +5,22 @@ import { AxiosError, AxiosHeaders } from 'axios';
 import { NotebookExecutionButtons } from '../NotebookExecutionButtons';
 
 // Mock dependencies - use vi.hoisted() to ensure these are defined before vi.mock hoisting
-const { mockSubscribeToAction, mockPost, mockGetStoredJupyterConfig } = vi.hoisted(() => ({
+const {
+  mockSubscribeToAction,
+  mockPost,
+  mockGetStoredJupyterConfig,
+  mockStartSession,
+  mockExecuteCell,
+  mockStopSession,
+  mockDeleteContents,
+} = vi.hoisted(() => ({
   mockSubscribeToAction: vi.fn(),
   mockPost: vi.fn(),
   mockGetStoredJupyterConfig: vi.fn(),
+  mockStartSession: vi.fn(),
+  mockExecuteCell: vi.fn(),
+  mockStopSession: vi.fn(),
+  mockDeleteContents: vi.fn(),
 }));
 
 vi.mock('@client/app/contexts/WebsocketContext', () => ({
@@ -25,7 +37,12 @@ vi.mock('@client/app/contexts/ApiContext', () => ({
 
 vi.mock('@client/app/utils/jupyterBrowserClient', () => ({
   getStoredJupyterConfig: mockGetStoredJupyterConfig,
-  JupyterBrowserClient: vi.fn(),
+  JupyterBrowserClient: class {
+    startSession = mockStartSession;
+    executeCell = mockExecuteCell;
+    stopSession = mockStopSession;
+    deleteContents = mockDeleteContents;
+  },
   JupyterBrowserError: class extends Error {},
 }));
 
@@ -290,6 +307,121 @@ describe('NotebookExecutionButtons', () => {
         const stored = sessionStorage.getItem('notebook-exec-quest-123');
         expect(stored).toBe(JSON.stringify({ started: true }));
       });
+    });
+  });
+
+  describe('browser-direct execution', () => {
+    const multiCellNotebook = JSON.stringify({
+      nbformat: 4,
+      cells: [
+        { cell_type: 'markdown', source: '# Title' },
+        { cell_type: 'code', source: 'x = 1' },
+        { cell_type: 'code', source: 'print(x)' },
+      ],
+    });
+
+    beforeEach(() => {
+      // Configure browser Jupyter path
+      mockGetStoredJupyterConfig.mockReturnValue({
+        serverUrl: 'http://localhost:8888',
+        token: '',
+      });
+      mockStartSession.mockResolvedValue({ id: 's1', kernel: { id: 'k1' } });
+      mockStopSession.mockResolvedValue(undefined);
+      mockDeleteContents.mockResolvedValue(undefined);
+      // progress reporting is best-effort
+      mockPost.mockResolvedValue({ data: { ok: true } });
+    });
+
+    it('executes cells via JupyterBrowserClient when config is set', async () => {
+      mockExecuteCell.mockResolvedValue({
+        success: true,
+        outputs: [{ output_type: 'stream', text: '1\n' }],
+        executionCount: 1,
+      });
+
+      render(
+        <NotebookExecutionButtons notebookContent={multiCellNotebook} sessionId="session-1" messageId="quest-1" />
+      );
+
+      fireEvent.click(screen.getByTestId('notebook-execute-btn'));
+
+      await waitFor(() => {
+        expect(mockStartSession).toHaveBeenCalled();
+        expect(mockExecuteCell).toHaveBeenCalledTimes(2); // 2 code cells
+        expect(mockStopSession).toHaveBeenCalledWith('s1');
+        expect(mockDeleteContents).toHaveBeenCalled();
+      });
+
+      // Should show completed
+      await waitFor(() => {
+        expect(screen.getByText(/Notebook executed successfully/)).toBeInTheDocument();
+      });
+    });
+
+    it('reports progress to the server API', async () => {
+      mockExecuteCell.mockResolvedValue({
+        success: true,
+        outputs: [],
+        executionCount: 1,
+      });
+
+      render(
+        <NotebookExecutionButtons notebookContent={multiCellNotebook} sessionId="session-1" messageId="quest-1" />
+      );
+
+      fireEvent.click(screen.getByTestId('notebook-execute-btn'));
+
+      await waitFor(() => {
+        // Initial executing report + per-cell reports + completed
+        const progressCalls = mockPost.mock.calls.filter((c: unknown[]) => c[0] === '/api/jupyter/progress');
+        expect(progressCalls.length).toBeGreaterThanOrEqual(3);
+
+        // Last call should be 'completed'
+        const lastCall = progressCalls[progressCalls.length - 1];
+        expect(lastCall[1].status).toBe('completed');
+      });
+    });
+
+    it('shows error and stops on cell failure', async () => {
+      mockExecuteCell.mockResolvedValueOnce({ success: true, outputs: [], executionCount: 1 }).mockResolvedValueOnce({
+        success: false,
+        outputs: [],
+        executionCount: 2,
+        error: { ename: 'NameError', evalue: 'x is not defined', traceback: [] },
+      });
+
+      render(
+        <NotebookExecutionButtons notebookContent={multiCellNotebook} sessionId="session-1" messageId="quest-1" />
+      );
+
+      fireEvent.click(screen.getByTestId('notebook-execute-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/NameError: x is not defined/)).toBeInTheDocument();
+      });
+    });
+
+    it('handles startSession failure gracefully', async () => {
+      mockStartSession.mockRejectedValue(new Error('Jupyter server not responding'));
+
+      render(
+        <NotebookExecutionButtons notebookContent={multiCellNotebook} sessionId="session-1" messageId="quest-1" />
+      );
+
+      fireEvent.click(screen.getByTestId('notebook-execute-btn'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Jupyter server not responding/)).toBeInTheDocument();
+      });
+    });
+
+    it('does not show CLI hint when Jupyter config is set', () => {
+      render(
+        <NotebookExecutionButtons notebookContent={multiCellNotebook} sessionId="session-1" messageId="quest-1" />
+      );
+
+      expect(screen.queryByText(/Configure your Jupyter server/)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/client/app/utils/__tests__/jupyterBrowserClient.test.ts
+++ b/apps/client/app/utils/__tests__/jupyterBrowserClient.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock @bike4mind/common validators before importing the module under test
+vi.mock('@bike4mind/common', () => ({
+  validateNotebookPath: () => ({ valid: true }),
+  validateJupyterKernelName: () => ({ valid: true }),
+}));
+
+import {
+  JupyterBrowserClient,
+  JupyterBrowserError,
+  getStoredJupyterConfig,
+  setStoredJupyterConfig,
+  clearStoredJupyterConfig,
+} from '../jupyterBrowserClient';
+
+// -- Helpers for mocking WebSocket and fetch --
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  sentMessages: string[] = [];
+
+  constructor(public url: string) {
+    // Simulate async open
+    setTimeout(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.onopen?.();
+    }, 0);
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  // Test helpers
+  simulateMessage(msg: Record<string, unknown>) {
+    this.onmessage?.({ data: JSON.stringify(msg) });
+  }
+
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  simulateError() {
+    this.onerror?.();
+  }
+}
+
+let mockWsInstance: MockWebSocket | null = null;
+
+function setMockWsInstance(instance: MockWebSocket) {
+  mockWsInstance = instance;
+}
+
+describe('JupyterBrowserClient', () => {
+  const originalFetch = globalThis.fetch;
+  const originalWebSocket = globalThis.WebSocket;
+
+  beforeEach(() => {
+    mockWsInstance = null;
+    // @ts-expect-error -- replacing global WebSocket with mock
+    globalThis.WebSocket = class extends MockWebSocket {
+      constructor(url: string) {
+        super(url);
+        setMockWsInstance(this);
+      }
+    };
+    // @ts-expect-error -- static constants
+    globalThis.WebSocket.OPEN = MockWebSocket.OPEN;
+    // @ts-expect-error -- static constants
+    globalThis.WebSocket.CONNECTING = MockWebSocket.CONNECTING;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.WebSocket = originalWebSocket;
+    vi.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('rejects non-http protocols', () => {
+      expect(() => new JupyterBrowserClient({ serverUrl: 'ftp://localhost:8888' })).toThrow(JupyterBrowserError);
+    });
+
+    it('rejects invalid URLs', () => {
+      expect(() => new JupyterBrowserClient({ serverUrl: 'not-a-url' })).toThrow(JupyterBrowserError);
+    });
+
+    it('accepts http URLs', () => {
+      expect(() => new JupyterBrowserClient({ serverUrl: 'http://localhost:8888' })).not.toThrow();
+    });
+
+    it('strips trailing slash', () => {
+      const client = new JupyterBrowserClient({ serverUrl: 'http://localhost:8888/' });
+      // Verify via checkStatus call URL
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ started: '2024-01-01' }),
+      });
+      client.checkStatus();
+      expect(globalThis.fetch).toHaveBeenCalledWith('http://localhost:8888/api/status', expect.any(Object));
+    });
+  });
+
+  describe('request methods', () => {
+    let client: JupyterBrowserClient;
+
+    beforeEach(() => {
+      client = new JupyterBrowserClient({ serverUrl: 'http://localhost:8888', token: 'test-token' });
+    });
+
+    it('checkStatus sends GET /api/status with auth header', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ started: '2024-01-01', last_activity: '2024-01-01' }),
+      });
+
+      const result = await client.checkStatus();
+      expect(result.started).toBe('2024-01-01');
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'http://localhost:8888/api/status',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'token test-token' }),
+        })
+      );
+    });
+
+    it('startSession sends POST /api/sessions', async () => {
+      const mockSession = { id: 's1', path: 'test.ipynb', kernel: { id: 'k1' } };
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockSession),
+      });
+
+      const result = await client.startSession('test.ipynb', 'python3');
+      expect(result.id).toBe('s1');
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'http://localhost:8888/api/sessions',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('stopSession sends DELETE /api/sessions/:id', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+
+      await client.stopSession('s1');
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'http://localhost:8888/api/sessions/s1',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+
+    it('deleteContents sends DELETE /api/contents/:path', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+
+      await client.deleteContents('b4m-notebook-123.ipynb');
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'http://localhost:8888/api/contents/b4m-notebook-123.ipynb',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+
+    it('throws JupyterBrowserError on non-ok response', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        json: () => Promise.resolve({ message: 'Forbidden' }),
+      });
+
+      await expect(client.checkStatus()).rejects.toThrow(JupyterBrowserError);
+    });
+  });
+
+  describe('getKernelWebSocketUrl', () => {
+    it('URL-encodes the token in the query string', async () => {
+      const client = new JupyterBrowserClient({ serverUrl: 'http://localhost:8888', token: 'a+b=c&d' });
+
+      // Trigger executeCell to capture the WebSocket URL
+      const cellPromise = client.executeCell('kernel-1', 'print("hi")', 1000);
+
+      // Wait for the mock WS to be created
+      await new Promise(r => setTimeout(r, 10));
+      expect(mockWsInstance).not.toBeNull();
+      expect(mockWsInstance!.url).toBe('ws://localhost:8888/api/kernels/kernel-1/channels?token=a%2Bb%3Dc%26d');
+
+      // Clean up: simulate close to reject the promise
+      mockWsInstance!.simulateClose();
+      await expect(cellPromise).rejects.toThrow();
+    });
+  });
+
+  describe('executeCell', () => {
+    let client: JupyterBrowserClient;
+
+    beforeEach(() => {
+      client = new JupyterBrowserClient({ serverUrl: 'http://localhost:8888' });
+    });
+
+    it('resolves on successful execute_reply', async () => {
+      const cellPromise = client.executeCell('k1', 'print("hello")', 5000);
+
+      await new Promise(r => setTimeout(r, 10));
+      expect(mockWsInstance).not.toBeNull();
+
+      // Get the msg_id from the sent message
+      expect(mockWsInstance!.sentMessages.length).toBe(1);
+      const sentMsg = JSON.parse(mockWsInstance!.sentMessages[0]);
+      const msgId = sentMsg.header.msg_id;
+
+      // Simulate stream output
+      mockWsInstance!.simulateMessage({
+        parent_header: { msg_id: msgId },
+        header: { msg_type: 'stream' },
+        content: { name: 'stdout', text: 'hello\n' },
+      });
+
+      // Simulate execute_reply
+      mockWsInstance!.simulateMessage({
+        parent_header: { msg_id: msgId },
+        header: { msg_type: 'execute_reply' },
+        content: { status: 'ok', execution_count: 1 },
+      });
+
+      const result = await cellPromise;
+      expect(result.success).toBe(true);
+      expect(result.executionCount).toBe(1);
+      expect(result.outputs).toHaveLength(1);
+      expect(result.outputs[0].output_type).toBe('stream');
+    });
+
+    it('resolves with error info on execution error', async () => {
+      const cellPromise = client.executeCell('k1', 'raise ValueError("bad")', 5000);
+
+      await new Promise(r => setTimeout(r, 10));
+      const sentMsg = JSON.parse(mockWsInstance!.sentMessages[0]);
+      const msgId = sentMsg.header.msg_id;
+
+      mockWsInstance!.simulateMessage({
+        parent_header: { msg_id: msgId },
+        header: { msg_type: 'error' },
+        content: { ename: 'ValueError', evalue: 'bad', traceback: ['line 1'] },
+      });
+
+      mockWsInstance!.simulateMessage({
+        parent_header: { msg_id: msgId },
+        header: { msg_type: 'execute_reply' },
+        content: { status: 'error', execution_count: 1 },
+      });
+
+      const result = await cellPromise;
+      expect(result.success).toBe(false);
+      expect(result.error?.ename).toBe('ValueError');
+      expect(result.error?.evalue).toBe('bad');
+    });
+
+    it('rejects when WebSocket closes before execute_reply', async () => {
+      const cellPromise = client.executeCell('k1', 'print("hi")', 5000);
+
+      await new Promise(r => setTimeout(r, 10));
+
+      // Close without sending execute_reply
+      mockWsInstance!.simulateClose();
+
+      await expect(cellPromise).rejects.toThrow('WebSocket closed before execution completed');
+    });
+
+    it('rejects on timeout', async () => {
+      const cellPromise = client.executeCell('k1', 'import time; time.sleep(999)', 50);
+
+      await expect(cellPromise).rejects.toThrow('timed out after 50ms');
+    });
+
+    it('rejects on WebSocket error', async () => {
+      const cellPromise = client.executeCell('k1', 'print("hi")', 5000);
+
+      await new Promise(r => setTimeout(r, 10));
+      mockWsInstance!.simulateError();
+
+      await expect(cellPromise).rejects.toThrow('WebSocket connection failed');
+    });
+
+    it('ignores messages from other requests', async () => {
+      const cellPromise = client.executeCell('k1', 'x = 1', 5000);
+
+      await new Promise(r => setTimeout(r, 10));
+      const sentMsg = JSON.parse(mockWsInstance!.sentMessages[0]);
+      const msgId = sentMsg.header.msg_id;
+
+      // Message from a different request
+      mockWsInstance!.simulateMessage({
+        parent_header: { msg_id: 'other-msg-id' },
+        header: { msg_type: 'stream' },
+        content: { name: 'stdout', text: 'wrong' },
+      });
+
+      // Our execute_reply
+      mockWsInstance!.simulateMessage({
+        parent_header: { msg_id: msgId },
+        header: { msg_type: 'execute_reply' },
+        content: { status: 'ok', execution_count: 1 },
+      });
+
+      const result = await cellPromise;
+      expect(result.outputs).toHaveLength(0);
+    });
+
+    it('warns on binary frames instead of crashing', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const cellPromise = client.executeCell('k1', 'x = 1', 5000);
+
+      await new Promise(r => setTimeout(r, 10));
+      const sentMsg = JSON.parse(mockWsInstance!.sentMessages[0]);
+      const msgId = sentMsg.header.msg_id;
+
+      // Simulate a binary frame (non-string data)
+      mockWsInstance!.onmessage?.({ data: new ArrayBuffer(8) as unknown as string });
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('binary WebSocket frame'));
+
+      // Complete normally
+      mockWsInstance!.simulateMessage({
+        parent_header: { msg_id: msgId },
+        header: { msg_type: 'execute_reply' },
+        content: { status: 'ok', execution_count: 1 },
+      });
+
+      const result = await cellPromise;
+      expect(result.success).toBe(true);
+      warnSpy.mockRestore();
+    });
+  });
+});
+
+describe('localStorage config helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns null when no config stored', () => {
+    expect(getStoredJupyterConfig()).toBeNull();
+  });
+
+  it('round-trips config through set/get', () => {
+    setStoredJupyterConfig({ serverUrl: 'http://localhost:8888', token: 'abc' });
+    const config = getStoredJupyterConfig();
+    expect(config).toEqual({ serverUrl: 'http://localhost:8888', token: 'abc' });
+  });
+
+  it('clears config', () => {
+    setStoredJupyterConfig({ serverUrl: 'http://localhost:8888', token: '' });
+    clearStoredJupyterConfig();
+    expect(getStoredJupyterConfig()).toBeNull();
+  });
+
+  it('returns null for corrupted JSON', () => {
+    localStorage.setItem('b4m-jupyter-config', 'not-json');
+    expect(getStoredJupyterConfig()).toBeNull();
+  });
+
+  it('returns null for object missing serverUrl', () => {
+    localStorage.setItem('b4m-jupyter-config', JSON.stringify({ token: 'abc' }));
+    expect(getStoredJupyterConfig()).toBeNull();
+  });
+});

--- a/apps/client/app/utils/jupyterBrowserClient.ts
+++ b/apps/client/app/utils/jupyterBrowserClient.ts
@@ -179,12 +179,19 @@ export class JupyterBrowserClient {
     await this.request('DELETE', `/api/sessions/${sessionId}`);
   }
 
+  /**
+   * Delete a file from the Jupyter server via the Contents API.
+   */
+  async deleteContents(path: string): Promise<void> {
+    await this.request('DELETE', `/api/contents/${path}`);
+  }
+
   private getKernelWebSocketUrl(kernelId: string): string {
     const httpUrl = new URL(this.serverUrl);
     const wsProtocol = httpUrl.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = `${wsProtocol}//${httpUrl.host}/api/kernels/${kernelId}/channels`;
     if (this.token) {
-      return `${wsUrl}?token=${this.token}`;
+      return `${wsUrl}?token=${encodeURIComponent(this.token)}`;
     }
     return wsUrl;
   }
@@ -202,9 +209,12 @@ export class JupyterBrowserClient {
       let executionCount: number | null = null;
       let hasError = false;
       let errorInfo: { ename: string; evalue: string; traceback: string[] } | undefined;
+      let settled = false;
 
       const ws = new WebSocket(wsUrl);
       const timeoutHandle = setTimeout(() => {
+        if (settled) return;
+        settled = true;
         cleanup();
         reject(new JupyterBrowserError(`Cell execution timed out after ${timeoutMs}ms`));
       }, timeoutMs);
@@ -217,6 +227,8 @@ export class JupyterBrowserClient {
       };
 
       ws.onerror = () => {
+        if (settled) return;
+        settled = true;
         cleanup();
         reject(
           new JupyterBrowserError('WebSocket connection failed. Is the Jupyter server running with CORS enabled?')
@@ -252,7 +264,13 @@ export class JupyterBrowserClient {
 
       ws.onmessage = (event: MessageEvent) => {
         try {
-          const msg = JSON.parse(typeof event.data === 'string' ? event.data : '');
+          // Binary frames (Blob/ArrayBuffer) are out-of-scope; skip with a warning
+          if (typeof event.data !== 'string') {
+            console.warn('[JupyterBrowserClient] Received binary WebSocket frame; skipping');
+            return;
+          }
+
+          const msg = JSON.parse(event.data);
 
           if (msg.parent_header?.msg_id !== msgId) return;
 
@@ -305,6 +323,8 @@ export class JupyterBrowserClient {
                 if (msg.content.execution_count !== undefined) {
                   executionCount = msg.content.execution_count;
                 }
+                if (settled) return;
+                settled = true;
                 cleanup();
                 resolve({
                   success: !hasError,
@@ -322,6 +342,9 @@ export class JupyterBrowserClient {
 
       ws.onclose = () => {
         clearTimeout(timeoutHandle);
+        if (settled) return;
+        settled = true;
+        reject(new JupyterBrowserError('WebSocket closed before execution completed'));
       };
     });
   }

--- a/apps/client/app/utils/jupyterBrowserClient.ts
+++ b/apps/client/app/utils/jupyterBrowserClient.ts
@@ -1,0 +1,360 @@
+/**
+ * Browser-side Jupyter Server Client
+ *
+ * Connects directly to a user's local Jupyter server from the browser,
+ * eliminating the need for the CLI as a middleman.
+ *
+ * Uses browser-native fetch() and WebSocket APIs.
+ * Requires the Jupyter server to allow cross-origin requests:
+ *   jupyter lab --ServerApp.allow_origin='*'
+ *
+ * @see https://jupyter-server.readthedocs.io/en/latest/developers/rest-api.html
+ * @see https://jupyter-client.readthedocs.io/en/latest/messaging.html
+ */
+
+import { validateNotebookPath as validateNotebookPathBase, validateJupyterKernelName } from '@bike4mind/common';
+
+export interface JupyterBrowserConfig {
+  serverUrl: string;
+  token?: string;
+}
+
+export interface JupyterSession {
+  id: string;
+  path: string;
+  name: string;
+  type: string;
+  kernel: {
+    id: string;
+    name: string;
+    last_activity: string;
+    execution_state: string;
+    connections: number;
+  };
+}
+
+export interface CellOutput {
+  output_type: 'stream' | 'execute_result' | 'display_data' | 'error';
+  name?: string;
+  text?: string | string[];
+  data?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  execution_count?: number | null;
+  ename?: string;
+  evalue?: string;
+  traceback?: string[];
+}
+
+export interface ExecuteCellResult {
+  success: boolean;
+  outputs: CellOutput[];
+  executionCount: number | null;
+  error?: {
+    ename: string;
+    evalue: string;
+    traceback: string[];
+  };
+}
+
+export class JupyterBrowserError extends Error {
+  constructor(
+    message: string,
+    public statusCode?: number,
+    public response?: unknown
+  ) {
+    super(message);
+    this.name = 'JupyterBrowserError';
+  }
+}
+
+function validateServerUrl(url: string): void {
+  if (!url || typeof url !== 'string') {
+    throw new JupyterBrowserError('Server URL is required');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new JupyterBrowserError(`Invalid server URL: ${url}`);
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new JupyterBrowserError(`Invalid protocol: ${parsed.protocol}. Only http and https are allowed`);
+  }
+}
+
+function validateNotebookPath(path: string): void {
+  const result = validateNotebookPathBase(path);
+  if (!result.valid) {
+    throw new JupyterBrowserError(result.error || 'Invalid notebook path');
+  }
+}
+
+function validateKernelName(name: string): void {
+  const result = validateJupyterKernelName(name);
+  if (!result.valid) {
+    throw new JupyterBrowserError(result.error || 'Invalid kernel name');
+  }
+}
+
+export class JupyterBrowserClient {
+  private serverUrl: string;
+  private token?: string;
+
+  constructor(config: JupyterBrowserConfig) {
+    validateServerUrl(config.serverUrl);
+    this.serverUrl = config.serverUrl.replace(/\/$/, '');
+    this.token = config.token;
+  }
+
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.token) {
+      headers['Authorization'] = `token ${this.token}`;
+    }
+    return headers;
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${this.serverUrl}${path}`;
+    const options: RequestInit = {
+      method,
+      headers: this.getHeaders(),
+    };
+    if (body) {
+      options.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      let errorBody: unknown;
+      try {
+        errorBody = await response.json();
+      } catch {
+        errorBody = await response.text();
+      }
+      throw new JupyterBrowserError(
+        `Jupyter API error: ${response.status} ${response.statusText}`,
+        response.status,
+        errorBody
+      );
+    }
+
+    if (response.status === 204) {
+      return {} as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  async checkStatus(): Promise<{ started: string; last_activity: string }> {
+    return this.request('GET', '/api/status');
+  }
+
+  async getKernelSpecs(): Promise<{
+    default: string;
+    kernelspecs: Record<string, { name: string; spec: { display_name: string; language: string } }>;
+  }> {
+    return this.request('GET', '/api/kernelspecs');
+  }
+
+  async startSession(notebookPath: string, kernelName?: string): Promise<JupyterSession> {
+    validateNotebookPath(notebookPath);
+    const kernel = kernelName || 'python3';
+    validateKernelName(kernel);
+
+    return this.request('POST', '/api/sessions', {
+      path: notebookPath,
+      type: 'notebook',
+      name: notebookPath.split('/').pop() || 'Untitled',
+      kernel: { name: kernel },
+    });
+  }
+
+  async stopSession(sessionId: string): Promise<void> {
+    await this.request('DELETE', `/api/sessions/${sessionId}`);
+  }
+
+  private getKernelWebSocketUrl(kernelId: string): string {
+    const httpUrl = new URL(this.serverUrl);
+    const wsProtocol = httpUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${wsProtocol}//${httpUrl.host}/api/kernels/${kernelId}/channels`;
+    if (this.token) {
+      return `${wsUrl}?token=${this.token}`;
+    }
+    return wsUrl;
+  }
+
+  private generateMsgId(): string {
+    return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+  }
+
+  async executeCell(kernelId: string, code: string, timeoutMs = 30000): Promise<ExecuteCellResult> {
+    const wsUrl = this.getKernelWebSocketUrl(kernelId);
+    const msgId = this.generateMsgId();
+
+    return new Promise((resolve, reject) => {
+      const outputs: CellOutput[] = [];
+      let executionCount: number | null = null;
+      let hasError = false;
+      let errorInfo: { ename: string; evalue: string; traceback: string[] } | undefined;
+
+      const ws = new WebSocket(wsUrl);
+      const timeoutHandle = setTimeout(() => {
+        cleanup();
+        reject(new JupyterBrowserError(`Cell execution timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      const cleanup = () => {
+        clearTimeout(timeoutHandle);
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+          ws.close();
+        }
+      };
+
+      ws.onerror = () => {
+        cleanup();
+        reject(
+          new JupyterBrowserError('WebSocket connection failed. Is the Jupyter server running with CORS enabled?')
+        );
+      };
+
+      ws.onopen = () => {
+        const executeRequest = {
+          header: {
+            msg_id: msgId,
+            msg_type: 'execute_request',
+            username: 'b4m-browser',
+            session: this.generateMsgId(),
+            date: new Date().toISOString(),
+            version: '5.3',
+          },
+          parent_header: {},
+          metadata: {},
+          content: {
+            code,
+            silent: false,
+            store_history: true,
+            user_expressions: {},
+            allow_stdin: false,
+            stop_on_error: true,
+          },
+          buffers: [],
+          channel: 'shell',
+        };
+
+        ws.send(JSON.stringify(executeRequest));
+      };
+
+      ws.onmessage = (event: MessageEvent) => {
+        try {
+          const msg = JSON.parse(typeof event.data === 'string' ? event.data : '');
+
+          if (msg.parent_header?.msg_id !== msgId) return;
+
+          const msgType = msg.header?.msg_type || msg.msg_type;
+
+          switch (msgType) {
+            case 'stream':
+              outputs.push({
+                output_type: 'stream',
+                name: msg.content.name,
+                text: msg.content.text,
+              });
+              break;
+
+            case 'execute_result':
+              executionCount = msg.content.execution_count;
+              outputs.push({
+                output_type: 'execute_result',
+                data: msg.content.data,
+                execution_count: msg.content.execution_count,
+                metadata: msg.content.metadata,
+              });
+              break;
+
+            case 'display_data':
+              outputs.push({
+                output_type: 'display_data',
+                data: msg.content.data,
+                metadata: msg.content.metadata,
+              });
+              break;
+
+            case 'error':
+              hasError = true;
+              errorInfo = {
+                ename: msg.content.ename,
+                evalue: msg.content.evalue,
+                traceback: msg.content.traceback,
+              };
+              outputs.push({
+                output_type: 'error',
+                ename: msg.content.ename,
+                evalue: msg.content.evalue,
+                traceback: msg.content.traceback,
+              });
+              break;
+
+            case 'execute_reply':
+              if (msg.content.status === 'ok' || msg.content.status === 'error') {
+                if (msg.content.execution_count !== undefined) {
+                  executionCount = msg.content.execution_count;
+                }
+                cleanup();
+                resolve({
+                  success: !hasError,
+                  outputs,
+                  executionCount,
+                  error: errorInfo,
+                });
+              }
+              break;
+          }
+        } catch {
+          // Ignore malformed messages
+        }
+      };
+
+      ws.onclose = () => {
+        clearTimeout(timeoutHandle);
+      };
+    });
+  }
+}
+
+// -- Jupyter config persistence (localStorage) --
+
+const JUPYTER_CONFIG_KEY = 'b4m-jupyter-config';
+
+export interface StoredJupyterConfig {
+  serverUrl: string;
+  token: string;
+}
+
+export function getStoredJupyterConfig(): StoredJupyterConfig | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(JUPYTER_CONFIG_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed.serverUrl) return parsed as StoredJupyterConfig;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredJupyterConfig(config: StoredJupyterConfig): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(JUPYTER_CONFIG_KEY, JSON.stringify(config));
+}
+
+export function clearStoredJupyterConfig(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(JUPYTER_CONFIG_KEY);
+}

--- a/apps/client/pages/api/jupyter/progress.ts
+++ b/apps/client/pages/api/jupyter/progress.ts
@@ -13,7 +13,6 @@
  *     cellIndex?: number,
  *     totalCells?: number,
  *     error?: string,
- *     executedNotebook?: string,
  *   }
  */
 import { baseApi } from '@server/middlewares/baseApi';
@@ -27,7 +26,6 @@ const ProgressBody = z.object({
   cellIndex: z.number().optional(),
   totalCells: z.number().optional(),
   error: z.string().optional(),
-  executedNotebook: z.string().optional(),
 });
 
 const handler = baseApi({ auth: true }).post(async (req, res) => {
@@ -36,7 +34,7 @@ const handler = baseApi({ auth: true }).post(async (req, res) => {
     return res.status(400).json({ error: 'Invalid request body', details: parsed.error.flatten() });
   }
 
-  const { questId, status, cellIndex, totalCells, error: errorMsg, executedNotebook } = parsed.data;
+  const { questId, status, cellIndex, totalCells, error: errorMsg } = parsed.data;
   const userId = req.user!.id;
 
   const updateData: Record<string, unknown> = {};
@@ -48,6 +46,10 @@ const handler = baseApi({ auth: true }).post(async (req, res) => {
     }
     if (totalCells !== undefined) {
       updateData['jupyterNotebook.cellCount'] = totalCells;
+    }
+    // Set startedAt on the first executing report (when cellIndex is absent)
+    if (cellIndex === undefined) {
+      updateData['jupyterNotebook.startedAt'] = new Date();
     }
   } else if (status === 'completed') {
     updateData['jupyterNotebook.status'] = 'completed';
@@ -61,10 +63,6 @@ const handler = baseApi({ auth: true }).post(async (req, res) => {
     if (errorMsg) {
       updateData['jupyterNotebook.lastError'] = errorMsg;
     }
-  }
-
-  if (executedNotebook) {
-    updateData['jupyterNotebook.executedNotebookJson'] = executedNotebook;
   }
 
   const updated = await Quest.findOneAndUpdate({ _id: questId, userId }, { $set: updateData }, { new: true });

--- a/apps/client/pages/api/jupyter/progress.ts
+++ b/apps/client/pages/api/jupyter/progress.ts
@@ -1,0 +1,79 @@
+/**
+ * Jupyter Notebook Progress Endpoint (Browser -> Server)
+ *
+ * Reports notebook execution progress from the browser directly to the server,
+ * updating the Quest document. This replaces the CLI WebSocket relay path
+ * when executing notebooks from the browser.
+ *
+ * POST /api/jupyter/progress
+ *   Body: {
+ *     sessionId: string,
+ *     questId: string,
+ *     status: 'executing' | 'completed' | 'failed',
+ *     cellIndex?: number,
+ *     totalCells?: number,
+ *     error?: string,
+ *     executedNotebook?: string,
+ *   }
+ */
+import { baseApi } from '@server/middlewares/baseApi';
+import { Quest } from '@bike4mind/database/content';
+import { z } from 'zod';
+
+const ProgressBody = z.object({
+  sessionId: z.string().min(1),
+  questId: z.string().min(1),
+  status: z.enum(['executing', 'completed', 'failed']),
+  cellIndex: z.number().optional(),
+  totalCells: z.number().optional(),
+  error: z.string().optional(),
+  executedNotebook: z.string().optional(),
+});
+
+const handler = baseApi({ auth: true }).post(async (req, res) => {
+  const parsed = ProgressBody.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request body', details: parsed.error.flatten() });
+  }
+
+  const { questId, status, cellIndex, totalCells, error: errorMsg, executedNotebook } = parsed.data;
+  const userId = req.user!.id;
+
+  const updateData: Record<string, unknown> = {};
+
+  if (status === 'executing') {
+    updateData['jupyterNotebook.status'] = 'executing';
+    if (cellIndex !== undefined) {
+      updateData['jupyterNotebook.executedCells'] = cellIndex + 1;
+    }
+    if (totalCells !== undefined) {
+      updateData['jupyterNotebook.cellCount'] = totalCells;
+    }
+  } else if (status === 'completed') {
+    updateData['jupyterNotebook.status'] = 'completed';
+    updateData['jupyterNotebook.completedAt'] = new Date();
+    if (cellIndex !== undefined) {
+      updateData['jupyterNotebook.executedCells'] = cellIndex + 1;
+    }
+  } else if (status === 'failed') {
+    updateData['jupyterNotebook.status'] = 'failed';
+    updateData['jupyterNotebook.completedAt'] = new Date();
+    if (errorMsg) {
+      updateData['jupyterNotebook.lastError'] = errorMsg;
+    }
+  }
+
+  if (executedNotebook) {
+    updateData['jupyterNotebook.executedNotebookJson'] = executedNotebook;
+  }
+
+  const updated = await Quest.findOneAndUpdate({ _id: questId, userId }, { $set: updateData }, { new: true });
+
+  if (!updated) {
+    return res.status(403).json({ error: 'Quest not found or access denied' });
+  }
+
+  res.json({ ok: true });
+});
+
+export default handler;


### PR DESCRIPTION
Add a browser-native Jupyter client that connects directly to the user's local Jupyter server, eliminating the CLI as a required middleman for notebook execution. Users configure their server URL and token in Settings, and notebooks execute cell-by-cell from the browser with real-time progress. The CLI relay path is preserved as a fallback.

# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description
<!--
Provide a detailed description of what this PR does. Explain the problem you're solving or the feature you're adding.
-->

## Changes
<!--
List the changes you've made in this PR. This is to help the reviewers understand the impact of your changes.
- Change 1
- Change 2
- ...
-->

## Guide for Testers
<!--
Write step-by-step instructions that both human QA testers AND AI agents (e.g., Playwright) can follow without codebase knowledge.

Requirements:
- Number every step — one action per step
- Use exact navigation paths: "Sidebar → Admin → DLQ Management"
- Use exact URLs: "app.staging.bike4mind.com"
- Use exact input values: type `Hello, how are you?` in the message input
- State expected results after each step: "A response appears within 10 seconds with no errors"
- Include a "Regression Checks" section for refactors
- Include a "What NOT to test" section for infra/backend-only PRs

See CLAUDE.md → "Test Guide Standards" for full guidelines and examples.
-->

## Additional Information
<!--
Include any additional information or context that you think would be helpful for your reviewers.
-->

## Developer Notes (Optional)
<!--
Document capability unlocks, architectural improvements, and reusable patterns introduced by this PR.
This helps future developers understand what new building blocks are available.

Categories to consider:
- **New Extension Points**: Components/interfaces that accept new props, hooks, or configuration
- **Reusable Patterns**: New components, utilities, or approaches that can be applied elsewhere
- **Data Model Changes**: New fields, types, or structures that enable future features
- **Architecture Decisions**: Why something was built a certain way (not just what changed)

Example:
- `SchedulerTab` now accepts a `familyId` prop — any new pattern family automatically gets a Learn tab
- `ComingSoonPanel` component can be dropped into any tab to indicate future work
- `effectiveTab` pattern shows how to handle persisted tab state when tabs become conditionally disabled
-->

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
