### PR TITLE
fix(husky): stop the pre-commit hook short-circuiting past six checks

### DIFF
--- a/.husky/check-help-content.sh
+++ b/.husky/check-help-content.sh
@@ -61,6 +61,10 @@ if [ -f "$INDEX_FILE" ] && [ -f "$EMBEDDINGS_FILE" ]; then
     echo "     OPENAI_API_KEY=sk-... pnpm --filter @bike4mind/scripts help:vectorize"
     echo "   Then stage help-embeddings.json and commit again."
     echo ""
-    return 1
+    # exit, not return: the pre-commit hook invokes this as a subprocess, so `return` at
+    # top level is an error and the non-zero status would be lost.
+    exit 1
   fi
 fi
+
+exit 0

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -14,14 +14,20 @@ npx lint-staged
 # Initialize exit code
 FINAL_EXIT_CODE=0
 
+# Every check below runs as a SUBPROCESS, never with `.` / `source`. A sourced script that
+# calls `exit` terminates this hook, taking every later check with it -- and because the
+# first one exits 0 on success, the hook silently "passed" while skipping the no-baseApi,
+# user-lookup, account-id, deprecated-model, and gitleaks checks entirely. Keep these as
+# subprocess calls, and let each script use its own shebang shell.
+
 # Check for pnpm links in package.json
 echo "Running pnpm link check..."
-if ! . "$(dirname -- "$0")/check-pnpm-links.sh"; then
+if ! bash "$(dirname -- "$0")/check-pnpm-links.sh"; then
   FINAL_EXIT_CODE=1
 fi
 
 # Check if help articles changed without regenerating index/embeddings
-if ! . "$(dirname -- "$0")/check-help-content.sh"; then
+if ! sh "$(dirname -- "$0")/check-help-content.sh"; then
   FINAL_EXIT_CODE=1
 fi
 
@@ -64,7 +70,7 @@ fi
 
 # Run gitleaks to check for secrets
 echo "Running gitleaks check..."
-if ! . "$(dirname -- "$0")/gitleaks-pre-commit.sh"; then
+if ! sh "$(dirname -- "$0")/gitleaks-pre-commit.sh"; then
   FINAL_EXIT_CODE=1
 fi
 


### PR DESCRIPTION
Closes #969

## The bug

`.husky/pre-commit` invoked three checks with `.` (source). A sourced script that calls `exit` exits the **calling** shell, and `check-pnpm-links.sh` ends with `exit $EXIT_CODE` -- so the hook terminated there on every commit. Because that script exits `0` on success, the hook reported success while never reaching:

- `check-help-content.sh` (help index/embeddings drift)
- help content validation
- `checkDeprecatedModelUsage.ts` (hardcoded deprecated model IDs)
- `check-no-baseapi.sh` (API routes missing auth middleware)
- `check-user-lookup-projection.mjs` (user `$lookup` field projections)
- `check-no-account-ids.sh` (account-tied IDs in shippable code)
- `gitleaks-pre-commit.sh` (staged secrets)

`exit` in a sourced script terminates the parent even inside an `if ! ...; then` condition, so the control flow never protected it.

## Why it hid

CI runs all of these independently, so violations were still caught -- one push later. The symptom presented as "CI failed on something the hook should have caught," which reads as flakiness rather than a dead hook. The tell was that hook output always stopped after `✅ No pnpm links found in package.json`.

I found it the direct way: a `check-no-baseapi` failure on #962 that the hook had happily let through.

## Why a partial fix would have failed

The two sourced scripts had **opposite, mutually exclusive** conventions:

| script | signals failure with | correct only when |
|---|---|---|
| `check-pnpm-links.sh` | `exit` | run as a subprocess |
| `gitleaks-pre-commit.sh` | `exit` | run as a subprocess |
| `check-help-content.sh` | `return 1` | **sourced** |

Switching to subprocesses without also fixing `check-help-content.sh` breaks that script (`return` outside a function is an error and the status is lost). Fixing it in the other direction means converting seven `exit` calls in the gitleaks script to `return`, leaving both scripts un-runnable standalone. Worth knowing if this was attempted before and reverted -- either half looks broken on its own.

## Changes

- Run all three as subprocesses, each under its own shebang shell (`bash` for `#!/bin/bash`, `sh` for the two `#!/bin/sh` scripts), so behavior is otherwise identical -- including the gitleaks script's color escapes, which still go through `sh`.
- `check-help-content.sh`: `return 1` -> `exit 1`, plus a terminating `exit 0`.
- A comment on the hook explaining why these must never be sourced, so it does not silently regress.

Deliberately minimal: no reordering, no new checks, no behavior changes beyond the checks now actually executing.

## Verification

Hook run directly, before and after:

```
BEFORE:  Running pnpm link check...
         🔍 Checking for pnpm links in root package.json...
         ✅ No pnpm links found in package.json
         (stops here, exit 0)

AFTER:   Running pnpm link check... ✅
         Running deprecated model usage check on staged files...
         Running no-baseapi check... ✅
         Running user-lookup projection check... ✅
         Running account-tied ID check... ✅
         Running gitleaks check... ✅ No secrets detected
```

**Still blocks.** Staging an API file with no `baseApi()`:

```
HOOK EXIT CODE = 1
Running no-baseapi check...
❌ ERROR: The following API files do not use baseApi() and are not on the allowlist:
  apps/client/pages/api/__hooktest_delete_me.ts
```

Previously that committed clean. Test file was removed and unstaging verified.

**No backlog.** All six checks pass against the current tree, so this should not block anyone's commits. Ran each manually to confirm before committing.

**This commit is its own proof** -- it is the first commit on this branch to run the full chain, gitleaks included.

## Follow-up

The hook is a hand-maintained list of invocations with no test. A smoke test asserting every expected check line appears in its output would have caught this on day one. Noted in #969; same shape as the drift gap in #964.