### PR TITLE
fix(client): stop the model picker reverting to the session's previous model

### DIFF
--- a/apps/client/app/components/Session/AISettings/useHydrateModelFromSession.test.ts
+++ b/apps/client/app/components/Session/AISettings/useHydrateModelFromSession.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ISessionDocument } from '@bike4mind/common';
+import { useHydrateModelFromSession } from './useHydrateModelFromSession';
+
+type SessionArg = Pick<ISessionDocument, 'id' | 'lastUsedModel'> | null;
+
+const session = (id: string, lastUsedModel: string | null): SessionArg => ({ id, lastUsedModel }) as SessionArg;
+
+/** Renders the hook with a stable applyModel spy, mirroring the component's useCallback. */
+function setup(initial: SessionArg) {
+  const applyModel = vi.fn();
+  const view = renderHook(({ s }: { s: SessionArg }) => useHydrateModelFromSession(s, applyModel), {
+    initialProps: { s: initial },
+  });
+  return { applyModel, view };
+}
+
+describe('useHydrateModelFromSession', () => {
+  it('adopts the session pinned model on first load', () => {
+    const { applyModel } = setup(session('sess-1', 'grok-3'));
+    expect(applyModel).toHaveBeenCalledExactlyOnceWith('grok-3');
+  });
+
+  /**
+   * The actual production bug. SessionsContext bumps lastUpdated/updatedAt in the send path,
+   * producing a NEW session object that still carries the OLD lastUsedModel. The old effect
+   * re-fired on that identity change and clobbered the user's pick, so the turn ran on the
+   * previous model. Observed live: Claude 5 Sonnet selected twice, zero Sonnet requests billed.
+   */
+  it('does NOT re-apply when the session object identity changes but the id does not', () => {
+    const { applyModel, view } = setup(session('sess-1', 'grok-3'));
+    applyModel.mockClear();
+
+    // User picks a different model in the picker (local LLM state, not yet persisted),
+    // then sends -- which bumps the timestamp and hands us a fresh object carrying the
+    // stale lastUsedModel.
+    view.rerender({ s: { id: 'sess-1', lastUsedModel: 'grok-3' } as SessionArg });
+    view.rerender({ s: { id: 'sess-1', lastUsedModel: 'grok-3' } as SessionArg });
+
+    expect(applyModel).not.toHaveBeenCalled();
+  });
+
+  it('does not re-apply even if the server later reports a different pinned model', () => {
+    // The server writes lastUsedModel from the model that actually ran, which is what made
+    // the old revert self-reinforcing. A mid-session change must not seize the picker.
+    const { applyModel, view } = setup(session('sess-1', 'grok-3'));
+    applyModel.mockClear();
+
+    view.rerender({ s: session('sess-1', 'claude-opus-5') });
+
+    expect(applyModel).not.toHaveBeenCalled();
+  });
+
+  it('hydrates again when the user switches to a different session', () => {
+    const { applyModel, view } = setup(session('sess-1', 'grok-3'));
+    applyModel.mockClear();
+
+    view.rerender({ s: session('sess-2', 'claude-opus-5') });
+
+    expect(applyModel).toHaveBeenCalledExactlyOnceWith('claude-opus-5');
+  });
+
+  it('re-hydrates a session revisited after being cleared', () => {
+    const { applyModel, view } = setup(session('sess-1', 'grok-3'));
+    applyModel.mockClear();
+
+    view.rerender({ s: null }); // notebook closed
+    view.rerender({ s: session('sess-1', 'grok-3') }); // reopened
+
+    expect(applyModel).toHaveBeenCalledExactlyOnceWith('grok-3');
+  });
+
+  it('stays eligible when the session arrives before its pinned model', () => {
+    // Guards the ref bookkeeping: recording a session as hydrated before a model was
+    // actually applied would strand the picker on whatever it defaulted to.
+    const { applyModel, view } = setup(session('sess-1', null));
+    expect(applyModel).not.toHaveBeenCalled();
+
+    view.rerender({ s: session('sess-1', 'claude-opus-5') });
+
+    expect(applyModel).toHaveBeenCalledExactlyOnceWith('claude-opus-5');
+  });
+
+  it('does nothing when there is no session', () => {
+    const { applyModel } = setup(null);
+    expect(applyModel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/Session/AISettings/useHydrateModelFromSession.ts
+++ b/apps/client/app/components/Session/AISettings/useHydrateModelFromSession.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import type { ISessionDocument } from '@bike4mind/common';
+
+/**
+ * Hydrates the model picker from a session's pinned `lastUsedModel` -- exactly ONCE per
+ * session, never again for the life of that session.
+ *
+ * The "once" is the whole point. This used to be a plain effect keyed on the session object:
+ *
+ *   useEffect(() => {
+ *     if (currentSession?.lastUsedModel) setLLM({ model: currentSession.lastUsedModel });
+ *   }, [currentSession, setLLM]);
+ *
+ * `currentSession` is React state that gets a FRESH OBJECT IDENTITY on every optimistic
+ * update -- most importantly the `lastUpdated`/`updatedAt` bump that SessionsContext applies
+ * in the message-send path. That new object still carries the OLD `lastUsedModel`, because
+ * persisting a model change is a separate fire-and-forget PUT that has usually not landed yet.
+ *
+ * So picking a new model and hitting send went: user selects B -> send bumps the timestamp ->
+ * effect re-fires with the stale object -> picker snaps back to A -> the turn runs on A.
+ * Users could not change models at all, and the reverted-to model was billed. Worse, the
+ * server writes `lastUsedModel` from the model that actually RAN, so A got re-pinned and the
+ * revert became self-reinforcing.
+ *
+ * Tracking the hydrated session id in a ref (rather than narrowing the dep array) keeps the
+ * effect honest about what it reads while making the body idempotent. It also handles a
+ * session object that arrives before its `lastUsedModel` does: no hydration is recorded until
+ * a model is actually applied, so a later arrival still hydrates.
+ *
+ * @param currentSession the active session, or null when none is loaded
+ * @param applyModel called with the model id to select; must be referentially stable
+ */
+export function useHydrateModelFromSession(
+  currentSession: Pick<ISessionDocument, 'id' | 'lastUsedModel'> | null | undefined,
+  applyModel: (model: string) => void
+): void {
+  // Session id this hook has already hydrated. Survives re-renders; never triggers one.
+  const hydratedSessionIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const sessionId = currentSession?.id ?? null;
+    if (!sessionId) {
+      // Session closed/cleared: allow a future re-open to hydrate again.
+      hydratedSessionIdRef.current = null;
+      return;
+    }
+
+    if (hydratedSessionIdRef.current === sessionId) return;
+
+    const pinnedModel = currentSession?.lastUsedModel;
+    if (!pinnedModel) return; // Not hydrated yet -- stay eligible for a later arrival.
+
+    hydratedSessionIdRef.current = sessionId;
+    applyModel(pinnedModel);
+  }, [currentSession, applyModel]);
+}

--- a/apps/client/app/components/Session/AdvancedAISettings.tsx
+++ b/apps/client/app/components/Session/AdvancedAISettings.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useEffect, useState } from 'react';
+import { ChangeEvent, FC, useCallback, useEffect, useState } from 'react';
 
 import { Badge, Box, IconButton, Input, Tooltip } from '@mui/joy';
 
@@ -13,6 +13,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useModelInfo } from '../../hooks/data/useModelInfo';
 import InspectableSettingsButton from './AISettings/InspectableSettingsButton';
 import { AdvancedAIModal } from './AISettings/AdvancedAIModal';
+import { useHydrateModelFromSession } from './AISettings/useHydrateModelFromSession';
 import { isImageModel } from '@client/app/utils/commands';
 import { keyframes } from '@mui/system';
 import { useFeatureEnabled } from '@client/app/hooks/useFeatureEnabled';
@@ -129,12 +130,11 @@ const AISettings: FC<AISettingsProps> = ({
     onRollDice();
   };
 
-  // Update the model when a session is loaded
-  useEffect(() => {
-    if (currentSession?.lastUsedModel) {
-      setLLM({ model: currentSession.lastUsedModel });
-    }
-  }, [currentSession, setLLM]);
+  // Adopt the session's pinned model once per session. Must NOT re-run on every
+  // `currentSession` identity change -- see useHydrateModelFromSession for why that
+  // silently reverted the user's model selection on send.
+  const applyModelFromSession = useCallback((nextModel: string) => setLLM({ model: nextModel }), [setLLM]);
+  useHydrateModelFromSession(currentSession, applyModelFromSession);
 
   // Reset QuestMaster to disabled when model changes
   useEffect(() => {


### PR DESCRIPTION
Closes #958

## The bug

Selecting a different model in a notebook did not reliably take effect. The picker visibly snapped back, and the turn ran on -- and was billed as -- the **old** model.

Reproduced live during a support investigation. An operator selected Claude 5 Sonnet twice; the session's billing ledger recorded **zero** Sonnet requests:

| provider | model | requests |
|---|---|---|
| anthropic | `claude-opus-5` | 4 |
| xai | `grok-3` | 11 |
| anthropic | `claude-sonnet-5` | **0** |

## Root cause

`AdvancedAISettings.tsx` hydrated the picker with an effect keyed on the session **object**:

```ts
// Update the model when a session is loaded
useEffect(() => {
  if (currentSession?.lastUsedModel) setLLM({ model: currentSession.lastUsedModel });
}, [currentSession, setLLM]);
```

The comment says "when a session is loaded." The dependency is the whole object, and `currentSession` is `useState` in `SessionsContext` that gets a **fresh identity on every optimistic update**. The decisive one is in the message-send path:

```ts
setCurrentSession(prev =>
  prev && prev.id === message.sessionId
    ? { ...prev, lastUpdated: optimisticTimestamp, updatedAt: optimisticTimestamp }
    : prev
);
```

That new object still carries the **old** `lastUsedModel`, because persisting a model change is a separate fire-and-forget PUT that has usually not landed yet.

So the sequence was:

1. User picks model B -> local LLM state updates, async PUT fires.
2. User hits send -> `lastUpdated` bump produces a new `currentSession` identity carrying stale `lastUsedModel: A`.
3. Effect re-fires -> `setLLM({ model: A })` -> picker snaps back.
4. Request goes out as **A**.

Then it compounds: the server writes `lastUsedModel` from the model that **actually ran** (`ChatCompletionInvoke.ts`), re-pinning A. So the revert was **self-reinforcing** -- escaping a pinned model required winning a race against your own send.

## Fix

Extracted into `useHydrateModelFromSession`, which adopts a session's pinned model **exactly once per session**, tracking the hydrated session id in a ref.

A ref rather than a narrowed dep array, deliberately: it keeps the effect honest about everything it reads (no `exhaustive-deps` suppression) while making the body idempotent. It also handles a session object that arrives before its `lastUsedModel` -- nothing is recorded as hydrated until a model is actually applied, so a later arrival still hydrates rather than stranding the picker on a default.

**Deliberately unchanged:** the `startTransition` and the fire-and-forget PUT in `handleModelSelection`. A transition defers an update but does not lose it, so neither was the clobber. Fixing them is not required and would widen the blast radius.

**Known residual, not addressed here:** `currentSession.lastUsedModel` stays stale until the PUT round-trips. With this fix that no longer causes a revert, but switching away and back to a session before the PUT lands would hydrate the old value. Narrow, self-correcting, and separable -- an optimistic cache write in `handleModelSelection` is the fix if it ever bites.

## Tests

`useHydrateModelFromSession.test.ts`, 7 cases: first load, session switch, re-open after close, pinned-model-arrives-late, no session, plus the two that encode the bug:

- session object identity changes with the same id (the send-path timestamp bump)
- server later reports a different pinned model mid-session (the self-reinforcing half)

**Verified the test is targeted at the defect, not the refactor.** Restoring the original implementation fails exactly those two and passes the other five:

```
× does NOT re-apply when the session object identity changes but the id does not
× does not re-apply even if the server later reports a different pinned model
  Tests  2 failed | 5 passed (7)
```

## Verification

- `useHydrateModelFromSession`: 7/7
- All `app/components/Session` tests: 62 files, 425 passed / 35 skipped
- `turbo typecheck:fast`: 41/41
- `eslint` on all three files: 0 problems
- ASCII-only confirmed on new files and the diff

## Note on scope

This is the delivery mechanism behind the model-pinning family. #962 stops `grok-3` specifically from being served (it now resolves to `grok-4.5`), which reduced the damage; this makes the control itself work, for every model. #951 (warn on open when a pinned model is stale) is still open and is the remaining piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)