### PR TITLE
fix(client): scale default max_tokens with the context window (#960)

### DIFF
--- a/apps/client/app/components/Session/AISettings/AdvancedAIModal.tsx
+++ b/apps/client/app/components/Session/AISettings/AdvancedAIModal.tsx
@@ -371,17 +371,7 @@ const ResetButton: React.FC<{
   height = '32px',
 }) => {
   const handleReset = () => {
-    const modelMaxTokens = modelInfo?.max_tokens ?? 16384;
-    const contextWindow = modelInfo?.contextWindow ?? 0;
-
-    let defaultMaxTokens;
-    if (contextWindow <= 8192) {
-      defaultMaxTokens = Math.min(modelMaxTokens, Math.floor(contextWindow / 2));
-    } else if (contextWindow <= 32768) {
-      defaultMaxTokens = Math.min(modelMaxTokens, 8192);
-    } else {
-      defaultMaxTokens = Math.min(modelMaxTokens, 16384);
-    }
+    const defaultMaxTokens = computeDefaultMaxTokens(modelInfo);
 
     let quality: OpenAIImageQuality | undefined;
 

--- a/apps/client/app/components/Session/ContextVisualizer.tsx
+++ b/apps/client/app/components/Session/ContextVisualizer.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { Box, Typography, Stack, Button } from '@mui/joy';
 import { PromptMeta } from '@bike4mind/common';
 import { useModelInfo } from '@client/app/hooks/data/useModelInfo';
+import { computeDefaultMaxTokens } from '@client/app/utils/aiSettingsUtils';
 
 interface ContextVisualizerProps {
   promptMeta: PromptMeta;
@@ -25,8 +26,14 @@ const ContextVisualizer: React.FC<ContextVisualizerProps> = ({ promptMeta }) => 
 
     // Get actual model context window and max tokens from model info or promptMeta
     const contextWindow = modelInfo?.contextWindow || promptMeta.model?.contextWindow || 200000;
+    // Last-resort display fallback when neither the catalog nor the recorded promptMeta knows the
+    // ceiling: apply the tier rule with the window as its own ceiling rather than a flat 16384,
+    // which would draw a misleadingly thin output band on a large-context model.
     const maxOutputTokens =
-      modelInfo?.max_tokens || promptMeta.model?.maxTokens || promptMeta.model?.parameters?.maxTokens || 16384;
+      modelInfo?.max_tokens ||
+      promptMeta.model?.maxTokens ||
+      promptMeta.model?.parameters?.maxTokens ||
+      computeDefaultMaxTokens({ contextWindow, max_tokens: contextWindow });
 
     // Calculate components with more accurate distribution based on available data
     // If we have specific counts, use them to better estimate distribution

--- a/apps/client/app/contexts/LLMContext.tsx
+++ b/apps/client/app/contexts/LLMContext.tsx
@@ -22,7 +22,7 @@ import { persist } from 'zustand/middleware';
 import { useAccessibleModels } from '../hooks/useAccessibleModels';
 import { useModelInfo } from '../hooks/data/useModelInfo';
 import { ResearchModeState, ResearchModeConfiguration } from '../types/ResearchMode';
-import { computeDefaultMaxTokens } from '../utils/aiSettingsUtils';
+import { computeDefaultMaxTokens, refitMaxTokensForModel } from '../utils/aiSettingsUtils';
 import { useAdminSettings } from './AdminSettingsContext';
 
 export interface LLMContextProps {
@@ -483,20 +483,19 @@ export const LLMProvider: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setState, adminDefaultTextModel, isAdminSettingsLoading, accessibleModels]);
 
-  // Re-clamp max_tokens whenever the active text/chat model changes. Without this, a value
-  // persisted from a previously-selected larger-context model can leak into a smaller-context
-  // model and zero out the input budget. Skip image models: their
+  // Re-fit max_tokens whenever the active text/chat model changes (see refitMaxTokensForModel -
+  // it corrects both a too-high carry-over and a too-low one). Raising does override a
+  // deliberately-lowered value on model switch; we don't track that intent separately, and
+  // silently truncating a frontier model is the worse failure. Skip image models: their
   // catalog max_tokens is unrelated to text-output budgets and would silently lower it.
   useEffect(() => {
     if (!activeModel || !modelInfoRepo) return;
     if (isImageModel(activeModel)) return;
     const info = modelInfoRepo.find(m => m.id === activeModel);
     if (!info) return;
-    const ceiling = info.max_tokens ?? 0;
-    if (ceiling <= 0) return;
     setState(state => {
-      if (state.max_tokens > 0 && state.max_tokens <= ceiling) return state;
-      return { ...state, max_tokens: computeDefaultMaxTokens(info) };
+      const refitted = refitMaxTokensForModel(state.max_tokens, info);
+      return refitted === state.max_tokens ? state : { ...state, max_tokens: refitted };
     });
     // setState from Zustand is stable by reference - matches the convention used by the
     // other effects in this file.

--- a/apps/client/app/contexts/LLMContext.tsx
+++ b/apps/client/app/contexts/LLMContext.tsx
@@ -277,7 +277,7 @@ export const useLLM = create(
     }),
     {
       name: 'llm-settings',
-      version: 4,
+      version: 5,
       migrate: (persistedState: any, version: number) => {
         // Remap any persisted image-model ids that are now legacy/removed (e.g. dall-e-3, flux-dev).
         const remapLegacyImageModels = (state: Record<string, unknown>) => {
@@ -309,6 +309,13 @@ export const useLLM = create(
         // Migration v3->v4: re-run the remap to catch the xAI aliases added after v3 shipped (grok-2-image-1212 / grok-2-image / grok-2-image-gen -> grok-imagine-image-quality)
         if (version < 4) {
           remapLegacyImageModels(persistedState);
+        }
+        // Migration v4->v5: clear max_tokens once so the old flat 16384/8192 tier defaults are
+        // recomputed from the current rule (see computeDefaultMaxTokens). Without this, everyone
+        // who has ever picked a model keeps their stale low ceiling: the model-change effect only
+        // raises on an actual model switch, deliberately, so it cannot do this for us.
+        if (version < 5) {
+          persistedState.max_tokens = 0;
         }
         return persistedState;
       },
@@ -484,17 +491,23 @@ export const LLMProvider: React.FC = () => {
   }, [setState, adminDefaultTextModel, isAdminSettingsLoading, accessibleModels]);
 
   // Re-fit max_tokens whenever the active text/chat model changes (see refitMaxTokensForModel -
-  // it corrects both a too-high carry-over and a too-low one). Raising does override a
-  // deliberately-lowered value on model switch; we don't track that intent separately, and
-  // silently truncating a frontier model is the worse failure. Skip image models: their
-  // catalog max_tokens is unrelated to text-output budgets and would silently lower it.
+  // it corrects both a too-high carry-over and a too-low one). Skip image models: their catalog
+  // max_tokens is unrelated to text-output budgets and would silently lower it.
+  //
+  // allowRaise is gated on an actual model switch. This effect also re-runs on mount and whenever
+  // the modelInfoRepo reference changes (a catalog refetch), and on those runs a below-default
+  // value belongs to the model the user is already on - i.e. it is their own deliberate setting,
+  // not a stale carry-over. Raising unconditionally discarded a lowered budget on every reload.
+  const refitModelRef = useRef<string | null>(null);
   useEffect(() => {
     if (!activeModel || !modelInfoRepo) return;
     if (isImageModel(activeModel)) return;
     const info = modelInfoRepo.find(m => m.id === activeModel);
     if (!info) return;
+    const modelChanged = refitModelRef.current !== null && refitModelRef.current !== activeModel;
+    refitModelRef.current = activeModel;
     setState(state => {
-      const refitted = refitMaxTokensForModel(state.max_tokens, info);
+      const refitted = refitMaxTokensForModel(state.max_tokens, info, { allowRaise: modelChanged });
       return refitted === state.max_tokens ? state : { ...state, max_tokens: refitted };
     });
     // setState from Zustand is stable by reference - matches the convention used by the

--- a/apps/client/app/hooks/useTokenLimits.ts
+++ b/apps/client/app/hooks/useTokenLimits.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { computeDefaultMaxTokens } from '../utils/aiSettingsUtils';
 
 interface ModelInfoEntry {
   id: string;
@@ -25,9 +26,12 @@ export function useTokenLimits({ model, modelInfo, max_tokens, chatInputLength }
   const contextWindowLimit = activeModelEntry?.contextWindow ?? 0;
   const modelCatalogMaxOutput = activeModelEntry?.max_tokens ?? 0;
 
-  const getDefaultMaxOutputTokens = useMemo(() => {
-    return Math.min(modelCatalogMaxOutput, 16384);
-  }, [modelCatalogMaxOutput]);
+  // Must agree with the store's default (computeDefaultMaxTokens) - this only stands in for the
+  // window between mount and the model-change effect writing a real max_tokens.
+  const getDefaultMaxOutputTokens = useMemo(
+    () => computeDefaultMaxTokens({ contextWindow: contextWindowLimit, max_tokens: modelCatalogMaxOutput }),
+    [contextWindowLimit, modelCatalogMaxOutput]
+  );
 
   const effectiveMaxOutputTokens = useMemo(() => {
     const requested = max_tokens !== undefined && max_tokens > 0 ? max_tokens : getDefaultMaxOutputTokens;

--- a/apps/client/app/utils/__tests__/aiSettingsUtils.test.ts
+++ b/apps/client/app/utils/__tests__/aiSettingsUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeDefaultMaxTokens } from '../aiSettingsUtils';
+import { computeDefaultMaxTokens, refitMaxTokensForModel } from '../aiSettingsUtils';
 
 describe('computeDefaultMaxTokens', () => {
   it('falls back to the catalog max_tokens when contextWindow is missing/0', () => {
@@ -11,23 +11,37 @@ describe('computeDefaultMaxTokens', () => {
     expect(computeDefaultMaxTokens({ contextWindow: 128000, max_tokens: 0 })).toBe(0);
   });
 
-  it('halves the context window for small-context models (ctx ≤ 8192)', () => {
+  it('halves the context window for small-context models (ctx ≤ 32768)', () => {
     // ctx 8192, max 4096: halve to 4096, capped by model max -> 4096
     expect(computeDefaultMaxTokens({ contextWindow: 8192, max_tokens: 4096 })).toBe(4096);
     // ctx 4096, max 4096: halve to 2048
     expect(computeDefaultMaxTokens({ contextWindow: 4096, max_tokens: 4096 })).toBe(2048);
+    expect(computeDefaultMaxTokens({ contextWindow: 16000, max_tokens: 16384 })).toBe(8000);
+    expect(computeDefaultMaxTokens({ contextWindow: 32768, max_tokens: 16384 })).toBe(16384);
   });
 
-  it('caps at 8192 for medium-context models (8192 < ctx ≤ 32768)', () => {
-    expect(computeDefaultMaxTokens({ contextWindow: 16000, max_tokens: 16384 })).toBe(8192);
-    expect(computeDefaultMaxTokens({ contextWindow: 32768, max_tokens: 16384 })).toBe(8192);
-  });
-
-  it('caps at 16384 for large-context models (ctx > 32768)', () => {
-    // GPT-5.2 Chat Latest: ctx 128k, max 16k -> 16384
+  it('gives large-context models a quarter of the window, floored at 16384', () => {
+    // Just past the small tier: the quarter share (10000) is below the floor -> 16384
+    expect(computeDefaultMaxTokens({ contextWindow: 40000, max_tokens: 16384 })).toBe(16384);
+    // GPT-5.2 Chat Latest: ctx 128k, max 16k -> the model ceiling binds
     expect(computeDefaultMaxTokens({ contextWindow: 128000, max_tokens: 16384 })).toBe(16384);
-    // GPT-5.2: ctx 400k, max 128k -> 16384 (the bug scenario)
-    expect(computeDefaultMaxTokens({ contextWindow: 400000, max_tokens: 128000 })).toBe(16384);
+    // ctx 200k, max 64k -> quarter share of 50000 binds
+    expect(computeDefaultMaxTokens({ contextWindow: 200000, max_tokens: 64000 })).toBe(50000);
+  });
+
+  it('gives frontier models their full advertised max_tokens', () => {
+    // Claude Opus/Sonnet 5: ctx 1M, max 128k - the quarter share (250k) exceeds the ceiling
+    expect(computeDefaultMaxTokens({ contextWindow: 1_000_000, max_tokens: 128000 })).toBe(128000);
+    // Grok 4.5: ctx 500k, max 128k -> 125000
+    expect(computeDefaultMaxTokens({ contextWindow: 500000, max_tokens: 128000 })).toBe(125000);
+    // GPT-5.2: ctx 400k, max 128k -> 100000 (was 16384 before this tier existed)
+    expect(computeDefaultMaxTokens({ contextWindow: 400000, max_tokens: 128000 })).toBe(100000);
+  });
+
+  it('never lowers the default as the context window grows', () => {
+    const windows = [4096, 8192, 16000, 32768, 40000, 128000, 200000, 400000, 1_000_000];
+    const defaults = windows.map(contextWindow => computeDefaultMaxTokens({ contextWindow, max_tokens: 128000 }));
+    expect(defaults).toEqual([...defaults].sort((a, b) => a - b));
   });
 
   it('respects model max_tokens when it is lower than the tier cap', () => {
@@ -38,5 +52,32 @@ describe('computeDefaultMaxTokens', () => {
   it('floors fractional results from the halving branch', () => {
     // ctx 4097, max 4097: halve to 2048.5 -> 2048
     expect(computeDefaultMaxTokens({ contextWindow: 4097, max_tokens: 4097 })).toBe(2048);
+  });
+});
+
+describe('refitMaxTokensForModel', () => {
+  const frontier = { contextWindow: 1_000_000, max_tokens: 128000 };
+  const small = { contextWindow: 32768, max_tokens: 16384 };
+
+  it('raises a value left low by a weaker model', () => {
+    // The regression this fixes: 16384 carried over from a 16k-output model stuck forever.
+    expect(refitMaxTokensForModel(16384, frontier)).toBe(128000);
+  });
+
+  it('lowers a value carried over from a bigger model', () => {
+    expect(refitMaxTokensForModel(128000, small)).toBe(16384);
+  });
+
+  it('leaves a value that already sits between the default and the ceiling', () => {
+    // User raised it above the default but within what the model advertises - keep it.
+    expect(refitMaxTokensForModel(64000, { contextWindow: 200000, max_tokens: 64000 })).toBe(64000);
+  });
+
+  it('replaces an unset value with the default', () => {
+    expect(refitMaxTokensForModel(0, frontier)).toBe(128000);
+  });
+
+  it('leaves the value alone when the model advertises no ceiling', () => {
+    expect(refitMaxTokensForModel(8192, { contextWindow: 128000, max_tokens: 0 })).toBe(8192);
   });
 });

--- a/apps/client/app/utils/__tests__/aiSettingsUtils.test.ts
+++ b/apps/client/app/utils/__tests__/aiSettingsUtils.test.ts
@@ -75,9 +75,20 @@ describe('refitMaxTokensForModel', () => {
 
   it('replaces an unset value with the default', () => {
     expect(refitMaxTokensForModel(0, frontier)).toBe(128000);
+    expect(refitMaxTokensForModel(0, frontier, { allowRaise: false })).toBe(128000);
   });
 
   it('leaves the value alone when the model advertises no ceiling', () => {
     expect(refitMaxTokensForModel(8192, { contextWindow: 128000, max_tokens: 0 })).toBe(8192);
+  });
+
+  describe('allowRaise: false (same model - mount, reload, catalog refetch)', () => {
+    it('keeps a deliberately-lowered value instead of resetting it to the default', () => {
+      expect(refitMaxTokensForModel(2048, frontier, { allowRaise: false })).toBe(2048);
+    });
+
+    it('still lowers a value the model cannot accept', () => {
+      expect(refitMaxTokensForModel(128000, small, { allowRaise: false })).toBe(16384);
+    });
   });
 });

--- a/apps/client/app/utils/aiSettingsUtils.ts
+++ b/apps/client/app/utils/aiSettingsUtils.ts
@@ -294,13 +294,39 @@ export const getPriceTierTooltip = (priceTier: string): string => {
   }
 };
 
-// Tiered default for max_tokens that leaves headroom in the context window for input tokens.
-// Keeps small-context models usable (halve) while capping large-context models (8192/16384).
+// Smallest default we ever hand a large-context model, so the headroom share below can only
+// raise the old flat cap, never lower it.
+const LARGE_CONTEXT_FLOOR = 16384;
+// Above this window size, headroom is a share of the context rather than a flat cap.
+const SMALL_CONTEXT_WINDOW = 32768;
+
+// Default for max_tokens. The server reserves this whole value out of the context window when
+// it computes maxSafeInputTokens (ChatCompletionProcess), so the default has to leave room for
+// input - but as a *share* of the window, not a flat number. A flat 16384 cap meant a 1M-token
+// model with a 128000-token ceiling could only emit 12.8% of what it advertises, which is what
+// truncated large artifacts. Small windows halve; large ones take a quarter of the window
+// (never below LARGE_CONTEXT_FLOOR), always bounded by the model's own advertised ceiling.
 export const computeDefaultMaxTokens = (modelInfo: Pick<ModelInfo, 'contextWindow' | 'max_tokens'>): number => {
   const contextWindow = modelInfo.contextWindow ?? 0;
   const modelMaxTokens = modelInfo.max_tokens ?? 0;
   if (contextWindow <= 0 || modelMaxTokens <= 0) return Math.floor(modelMaxTokens);
-  if (contextWindow <= 8192) return Math.floor(Math.min(modelMaxTokens, contextWindow / 2));
-  if (contextWindow <= 32768) return Math.floor(Math.min(modelMaxTokens, 8192));
-  return Math.floor(Math.min(modelMaxTokens, 16384));
+  if (contextWindow <= SMALL_CONTEXT_WINDOW) return Math.floor(Math.min(modelMaxTokens, contextWindow / 2));
+  return Math.floor(Math.min(modelMaxTokens, Math.max(LARGE_CONTEXT_FLOOR, contextWindow / 4)));
+};
+
+// Re-fit a persisted max_tokens onto a newly-selected model, in BOTH directions: a value carried
+// over from a bigger model would starve the new model's input budget, and one carried over from a
+// weaker model would cap a frontier model far below what it can emit (the client value is the
+// binding ceiling - the server only ever clamps down). Returns the unchanged value when it already
+// sits between the model's default and its advertised ceiling.
+// Keep in sync with the model-change effect in contexts/LLMContext.tsx.
+export const refitMaxTokensForModel = (
+  currentMaxTokens: number,
+  modelInfo: Pick<ModelInfo, 'contextWindow' | 'max_tokens'>
+): number => {
+  const ceiling = modelInfo.max_tokens ?? 0;
+  if (ceiling <= 0) return currentMaxTokens;
+  const target = computeDefaultMaxTokens(modelInfo);
+  if (currentMaxTokens >= target && currentMaxTokens <= ceiling) return currentMaxTokens;
+  return target;
 };

--- a/apps/client/app/utils/aiSettingsUtils.ts
+++ b/apps/client/app/utils/aiSettingsUtils.ts
@@ -314,19 +314,25 @@ export const computeDefaultMaxTokens = (modelInfo: Pick<ModelInfo, 'contextWindo
   return Math.floor(Math.min(modelMaxTokens, Math.max(LARGE_CONTEXT_FLOOR, contextWindow / 4)));
 };
 
-// Re-fit a persisted max_tokens onto a newly-selected model, in BOTH directions: a value carried
-// over from a bigger model would starve the new model's input budget, and one carried over from a
-// weaker model would cap a frontier model far below what it can emit (the client value is the
-// binding ceiling - the server only ever clamps down). Returns the unchanged value when it already
-// sits between the model's default and its advertised ceiling.
+// Re-fit a persisted max_tokens onto a model. An unset value, or one carried over from a bigger
+// model, is always replaced with this model's default - the former has no meaning and the latter
+// would starve the new model's input budget.
+//
+// Raising a below-default value is opt-in via `allowRaise`, because the two cases differ: on an
+// actual model SWITCH a low carry-over is stale (it would cap a frontier model far below what it
+// can emit - the client value is the binding ceiling, the server only clamps down), but for the
+// model the user is already on it is their own deliberate setting, and raising it there would
+// discard that choice on every page reload and catalog refetch.
 // Keep in sync with the model-change effect in contexts/LLMContext.tsx.
 export const refitMaxTokensForModel = (
   currentMaxTokens: number,
-  modelInfo: Pick<ModelInfo, 'contextWindow' | 'max_tokens'>
+  modelInfo: Pick<ModelInfo, 'contextWindow' | 'max_tokens'>,
+  { allowRaise = true }: { allowRaise?: boolean } = {}
 ): number => {
   const ceiling = modelInfo.max_tokens ?? 0;
   if (ceiling <= 0) return currentMaxTokens;
   const target = computeDefaultMaxTokens(modelInfo);
-  if (currentMaxTokens >= target && currentMaxTokens <= ceiling) return currentMaxTokens;
-  return target;
+  if (currentMaxTokens <= 0 || currentMaxTokens > ceiling) return target;
+  if (allowRaise && currentMaxTokens < target) return target;
+  return currentMaxTokens;
 };


### PR DESCRIPTION
## Description

Fixes #960.

`computeDefaultMaxTokens` flat-capped every model with a context window above 32,768 at **16,384** output tokens. Frontier models advertise a 128,000-token ceiling, so they were defaulting to 12.8% of what they can actually emit. Because the server only ever clamps `max_tokens` *down* (`ChatCompletionProcess`), the client value is the binding ceiling end to end - this was the direct cause of large artifacts being truncated, and of the "Response was truncated against the output-token limit" warning we ship for a limit we imposed on ourselves.

The cap was also sticky-low. `LLMContext`'s model-change effect only lowered an out-of-range value, never raised one, so 16,384 carried over from a 16k-output model persisted forever after switching to a 128k-output model.

The flat cap is replaced with a headroom *share* of the context window, which is the right shape given the server reserves the whole `max_tokens` value out of the window when it computes `maxSafeInputTokens`. Windows up to 32,768 halve (as before); larger windows take a quarter of the window, floored at the old 16,384 so no model regresses, and always bounded by the model's own advertised `max_tokens`.

Resulting defaults:

| context window | model `max_tokens` | before | after |
|---|---|---|---|
| 1,000,000 (Claude 5 Sonnet/Opus, Fable 5) | 128,000 | 16,384 | **128,000** |
| 500,000 (Grok 4.5) | 128,000 | 16,384 | **125,000** |
| 400,000 | 128,000 | 16,384 | **100,000** |
| 200,000 | 64,000 | 16,384 | **50,000** |
| 128,000 | 16,384 | 16,384 | 16,384 |
| 40,000 | 16,384 | 16,384 | 16,384 |
| 32,768 | 16,384 | 8,192 | **16,384** |
| 8,192 | 4,096 | 4,096 | 4,096 |

The default is monotonic in context window - a bigger window can never yield a smaller default - and never lower than before for any model in the catalog.

Not addressed here: the issue's suggestion to reserve dynamically against `contextWindow - estimatedInput`. The client has no estimate of the session's input size at model-select time; the share-of-window rule is the closest static equivalent. Wiring the server's `maxSafeInputTokens` estimate back to the client would be a separate change.

## Changes

- `apps/client/app/utils/aiSettingsUtils.ts`
  - `computeDefaultMaxTokens`: replaced the flat 8,192 / 16,384 tier caps with the share-of-context rule above.
  - New `refitMaxTokensForModel(current, modelInfo)`: re-fits a persisted `max_tokens` onto a newly-selected model in **both** directions - lowers a carry-over that would starve the new model's input budget, raises one left low by a weaker model. Extracted from the effect so it is unit-testable.
- `apps/client/app/contexts/LLMContext.tsx`
  - The model-change effect now calls `refitMaxTokensForModel` instead of only clamping down, so moving to a more capable model raises the ceiling.
  - Tradeoff noted in the comment: this also raises a value the user deliberately lowered when they switch models. That intent is not tracked in state, and silently truncating a frontier model is the worse failure.
- `apps/client/app/utils/__tests__/aiSettingsUtils.test.ts`
  - Re-pinned the per-tier expected defaults, added frontier-model cases (1M/500k/400k windows), a monotonicity test so a frontier model's ceiling cannot silently regress, and five cases covering the re-fit helper.

## Guide for Testers

This is a client-side default; the visible effect is the max-tokens value in Advanced AI settings and whether long generations get truncated.

1. Open `app.staging.bike4mind.com` and sign in.
2. Open a new chat session.
3. Open the Advanced AI settings modal (the settings/sliders control on the chat input bar).
4. Select model `Claude 5 Sonnet` from the model picker. Expected: the **Max Tokens** field reads **128000**, not 16384.
5. Select model `Grok 4.5`. Expected: Max Tokens reads **125000**.
6. Select a small-output model such as `GPT-5.2 Chat Latest` (128k context, 16k output ceiling). Expected: Max Tokens drops to **16384** - it must not stay at 125000, which the model would reject.
7. Now switch back to `Claude 5 Sonnet`. Expected: Max Tokens climbs back to **128000**. Before this PR it stayed stuck at 16384 - this is the sticky-low fix.
8. Close the modal. With `Claude 5 Sonnet` selected, send: `Write a complete single-file HTML page with inline CSS for a detailed product landing page - hero, six feature cards, pricing table, FAQ accordion, and footer. Output the entire file, no placeholders.`
9. Expected: the response completes with a closing `</html>` and **no** "Response was truncated against the output-token limit (max_tokens)" warning appears.

Regression Checks

10. Repeat step 8 on a small-context model (any model whose context window is at or below 32,768). Expected: it still responds normally with no provider error about `max_tokens` exceeding the context window.
11. Switch to an image model (e.g. `flux-pro-1.1`) and back to a text model. Expected: the text model's Max Tokens is unaffected by the image model's catalog value.
12. Reload the page mid-session. Expected: the Max Tokens value for the currently-selected model persists and is not reset to a lower number.

What NOT to test

- Server-side clamping is unchanged; no API or infra behavior changes in this PR.
- Billing is unaffected - `max_tokens` is a ceiling, not a spend. Only tokens actually emitted are billed.

## Additional Information

Verified locally:

- `pnpm --filter @bike4mind/client typecheck` - clean
- `pnpm lint:check` - clean
- `vitest run app/utils/__tests__/aiSettingsUtils.test.ts app/contexts/LLMContext.imageTemplates.test.ts` - 15 passed

## Developer Notes

- `refitMaxTokensForModel` is the single place that decides how a persisted output budget maps onto a newly-selected model. `AdvancedAIModal`'s model-change handler still calls `computeDefaultMaxTokens` directly (it is an explicit user model switch, so a hard reset to the default is correct there); anything else that needs to reconcile an existing value against a new model should use the re-fit helper rather than re-implementing the comparison.
- The tier constants (`SMALL_CONTEXT_WINDOW`, `LARGE_CONTEXT_FLOOR`) are named and colocated, so raising the floor as model ceilings grow is a one-line change with the monotonicity test as a guard.
