### PR TITLE
fix(client): hydrate session model by id so a refetch cannot revert the picker (#958)

### DIFF
--- a/apps/client/app/components/Session/AISettings/useHydrateSessionModel.test.ts
+++ b/apps/client/app/components/Session/AISettings/useHydrateSessionModel.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ISessionDocument } from '@bike4mind/common';
+import { useHydrateSessionModel } from './useHydrateSessionModel';
+
+const session = (id: string, lastUsedModel: string | null): ISessionDocument =>
+  ({ id, lastUsedModel }) as ISessionDocument;
+
+describe('useHydrateSessionModel', () => {
+  it('hydrates the model when a session first loads', () => {
+    const setModel = vi.fn();
+    const { rerender } = renderHook(({ s }) => useHydrateSessionModel(s, setModel), {
+      initialProps: { s: null as ISessionDocument | null },
+    });
+
+    rerender({ s: session('a', 'claude-opus-5') });
+
+    expect(setModel).toHaveBeenCalledExactlyOnceWith('claude-opus-5');
+  });
+
+  // The #958 regression: the server rewrites lastUsedModel to the model that ran, then the
+  // session refetches with a new object identity. That must NOT clobber the user's pick.
+  it('does not re-hydrate on a refetch of the same session, even if lastUsedModel changed', () => {
+    const setModel = vi.fn();
+    const { rerender } = renderHook(({ s }) => useHydrateSessionModel(s, setModel), {
+      initialProps: { s: session('a', 'claude-sonnet-5') },
+    });
+    expect(setModel).toHaveBeenCalledExactlyOnceWith('claude-sonnet-5');
+    setModel.mockClear();
+
+    // New object identity, same id, server-rewritten model -> ignored.
+    rerender({ s: session('a', 'grok-3') });
+
+    expect(setModel).not.toHaveBeenCalled();
+  });
+
+  it('hydrates again when a genuinely different session loads', () => {
+    const setModel = vi.fn();
+    const { rerender } = renderHook(({ s }) => useHydrateSessionModel(s, setModel), {
+      initialProps: { s: session('a', 'claude-sonnet-5') },
+    });
+    setModel.mockClear();
+
+    rerender({ s: session('b', 'grok-4.5') });
+
+    expect(setModel).toHaveBeenCalledExactlyOnceWith('grok-4.5');
+  });
+
+  it('does nothing when the loaded session has no saved model', () => {
+    const setModel = vi.fn();
+    renderHook(() => useHydrateSessionModel(session('a', null), setModel));
+
+    expect(setModel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/Session/AISettings/useHydrateSessionModel.ts
+++ b/apps/client/app/components/Session/AISettings/useHydrateSessionModel.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+
+import type { ISessionDocument } from '@bike4mind/common';
+
+/**
+ * Hydrate the model picker from a session's saved `lastUsedModel`, but only when a
+ * *different* session is loaded -- keyed on the session id, not the `currentSession`
+ * object identity.
+ *
+ * Keying on the object re-fired on every refetch and clobbered a model the user had
+ * just picked (#958): the server rewrites `lastUsedModel` to the model that actually
+ * ran, the session refetches with a new object identity, and the picker reverted --
+ * a self-reinforcing loop that pinned users to the old model. Guarding on the id means
+ * a refetch of the same session never overrides the user's in-session selection.
+ */
+export function useHydrateSessionModel(
+  currentSession: Pick<ISessionDocument, 'id' | 'lastUsedModel'> | null,
+  setModel: (model: string) => void
+): void {
+  const hydratedSessionIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const sessionId = currentSession?.id ?? null;
+    if (sessionId === hydratedSessionIdRef.current) return;
+    hydratedSessionIdRef.current = sessionId;
+    if (currentSession?.lastUsedModel) {
+      setModel(currentSession.lastUsedModel);
+    }
+  }, [currentSession, setModel]);
+}

--- a/apps/client/app/components/Session/AdvancedAISettings.tsx
+++ b/apps/client/app/components/Session/AdvancedAISettings.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useEffect, useState } from 'react';
+import { ChangeEvent, FC, useCallback, useEffect, useState } from 'react';
 
 import { Badge, Box, IconButton, Input, Tooltip } from '@mui/joy';
 
@@ -26,6 +26,7 @@ import { PromptBuilderModal } from './PromptBuilder/PromptBuilderModal';
 import { isImageGenerationModel } from './PromptBuilder/models';
 import { usePromptBuilderFirstRun } from './PromptBuilder/usePromptBuilderFirstRun';
 import { AutoAwesome as PromptBuilderIcon } from '@mui/icons-material';
+import { useHydrateSessionModel } from './AISettings/useHydrateSessionModel';
 
 // Re-export store for consumers that import from this file
 export { useAdvancedAISettings } from './AISettings/useAdvancedAISettingsStore';
@@ -129,12 +130,10 @@ const AISettings: FC<AISettingsProps> = ({
     onRollDice();
   };
 
-  // Update the model when a session is loaded
-  useEffect(() => {
-    if (currentSession?.lastUsedModel) {
-      setLLM({ model: currentSession.lastUsedModel });
-    }
-  }, [currentSession, setLLM]);
+  // Hydrate the picker from the session's saved model only when a different session
+  // loads -- guarding on session id so a refetch never clobbers the user's pick (#958).
+  const setModel = useCallback((newModel: string) => setLLM({ model: newModel }), [setLLM]);
+  useHydrateSessionModel(currentSession, setModel);
 
   // Reset QuestMaster to disabled when model changes
   useEffect(() => {


### PR DESCRIPTION
## Description

Fixes #958. Selecting a different model in a notebook did not reliably take effect: the picker visibly snapped back to the session's previous model, and the request ran on the old model.

Root cause was in `AdvancedAISettings.tsx`. The effect that hydrates the picker from `currentSession.lastUsedModel` was keyed on the whole `currentSession` **object**. That object gets a fresh identity on every refetch, so the effect re-fired on every refetch and overwrote whatever model the user had just picked. It was self-reinforcing: once a turn ran on the old model, the server rewrote `lastUsedModel` back to it (`ChatCompletionInvoke.ts`), the session refetched, the effect fired, and the picker reverted again. Escaping the pinned model required winning a race.

The fix hydrates the picker **only when a genuinely different session loads**, keyed on the session id rather than object identity. A refetch of the same session no longer clobbers the user's in-session selection, which breaks the loop. With the id guard in place, the existing fire-and-forget persistence in `AdvancedAIModal` is safe as-is, so no optimistic-cache change was needed.

## Changes

- Extract the hydration logic into a new `useHydrateSessionModel` hook that guards on `currentSession.id` via a ref, so a same-session refetch never re-hydrates.
- Wire it into `AdvancedAISettings` (replacing the object-keyed effect); pass a stable `setModel` callback.
- Add `useHydrateSessionModel.test.ts` covering first-load hydration, the #958 regression (same-id refetch with a server-rewritten `lastUsedModel` must not revert the pick), switching to a different session, and the no-saved-model case.

## Guide for Testers

1. Open a notebook that has run at least one turn on some model (so `lastUsedModel` is set).
2. Open the AI settings and select a **different** model than the one shown.
   - Expected: the picker shows the newly selected model and stays there.
3. Send a message so a turn runs and the session refetches.
   - Expected: the picker still shows the model you selected; it does not snap back to the previous one.
4. Send a second message.
   - Expected: the request runs on the model you selected (not the old one).

### Regression Checks
1. Open a different notebook.
   - Expected: its own last-used model is loaded into the picker.
2. Switch back to the first notebook.
   - Expected: it loads its saved model as before.

### What NOT to test
- No API/backend changes; server-side model persistence is unchanged.

## Additional Information

Related model-quality issues filed alongside this (e.g. staleness checks in #951, output-token caps in #960) are separate and not addressed here. This PR fixes only the silent revert.
