### PR TITLE
fix(hygiene): block premium overlay paths from entering the tracked lockfile

### DIFF
--- a/.github/workflows/lockfile-integrity.yml
+++ b/.github/workflows/lockfile-integrity.yml
@@ -9,6 +9,9 @@ name: Lockfile Integrity
 #   3. bare tarball, no integrity, no commit pin: {tarball: ...} <- the hole
 # The grep below matches only shape 3, where `tarball` is the first (and
 # only) key in the resolution flow-map.
+#
+# A second step blocks premium-overlay paths from the lockfile (see
+# scripts/check-no-overlay-lockfile.sh).
 
 on:
   pull_request:

--- a/.github/workflows/lockfile-integrity.yml
+++ b/.github/workflows/lockfile-integrity.yml
@@ -33,3 +33,9 @@ jobs:
             echo "Regenerate the lockfile under pnpm >=10.34.1 so a sha512 integrity hash is written."
             exit 1
           fi
+
+      # A pnpm install with a premium overlay hydrated writes the overlay's
+      # importer blocks into the tracked lockfile; committing that publishes
+      # private overlay structure to this public repo.
+      - name: Check for premium overlay paths in pnpm-lock.yaml
+        run: bash scripts/check-no-overlay-lockfile.sh

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -68,6 +68,12 @@ if ! bash scripts/check-no-account-ids.sh; then
   FINAL_EXIT_CODE=1
 fi
 
+# Check the staged lockfile for premium overlay leakage
+echo "Running overlay lockfile check..."
+if ! bash scripts/check-no-overlay-lockfile.sh --staged; then
+  FINAL_EXIT_CODE=1
+fi
+
 # Run gitleaks to check for secrets
 echo "Running gitleaks check..."
 if ! sh "$(dirname -- "$0")/gitleaks-pre-commit.sh"; then

--- a/scripts/check-no-overlay-lockfile.sh
+++ b/scripts/check-no-overlay-lockfile.sh
@@ -22,9 +22,16 @@ if [ "${1:-}" = "--staged" ]; then
 fi
 
 if [ "$MODE" = "staged" ]; then
-  # Only relevant when the commit actually touches the lockfile.
-  if ! git diff --cached --name-only | grep -qx "$LOCKFILE"; then
+  # Only relevant when the commit actually touches the lockfile. --quiet exits
+  # nonzero when staged changes exist; unlike piping --name-only into grep -q,
+  # it cannot be flipped by an early-exit SIGPIPE under pipefail.
+  if git diff --cached --quiet -- "$LOCKFILE"; then
     echo "✅ Lockfile not staged; overlay lockfile check skipped."
+    exit 0
+  fi
+  # A staged deletion leaves no index blob to scan (git show would die).
+  if ! git ls-files --error-unmatch --cached "$LOCKFILE" >/dev/null 2>&1; then
+    echo "✅ Lockfile staged for deletion; nothing to scan."
     exit 0
   fi
   matches=$(git show ":$LOCKFILE" | grep -n "packages/premium/" || true)

--- a/scripts/check-no-overlay-lockfile.sh
+++ b/scripts/check-no-overlay-lockfile.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Fails if pnpm-lock.yaml references any packages/premium/ path.
+#
+# The premium overlay dirs are gitignored, but pnpm-workspace.yaml globs them as
+# workspace members, so a plain `pnpm install` on a machine with an overlay
+# hydrated writes the overlay's importer blocks (package names + dependency
+# sets) into the TRACKED lockfile. Committing that publishes private overlay
+# structure to this public repo, disguised as ordinary lockfile churn.
+#
+# The tracked lockfile must always be generated with packages/premium/ empty.
+# Run in CI on every PR (lockfile-integrity.yml) and locally via husky
+# pre-commit (--staged mode, which checks the staged copy of the lockfile).
+#
+# Usage: check-no-overlay-lockfile.sh [--staged]
+
+set -euo pipefail
+
+LOCKFILE="pnpm-lock.yaml"
+MODE="worktree"
+if [ "${1:-}" = "--staged" ]; then
+  MODE="staged"
+fi
+
+if [ "$MODE" = "staged" ]; then
+  # Only relevant when the commit actually touches the lockfile.
+  if ! git diff --cached --name-only | grep -qx "$LOCKFILE"; then
+    echo "✅ Lockfile not staged; overlay lockfile check skipped."
+    exit 0
+  fi
+  matches=$(git show ":$LOCKFILE" | grep -n "packages/premium/" || true)
+else
+  matches=$(grep -n "packages/premium/" "$LOCKFILE" || true)
+fi
+
+if [ -n "$matches" ]; then
+  echo "❌ ERROR: $LOCKFILE references premium overlay packages:"
+  echo ""
+  echo "$matches" | head -10 | sed 's/^/  /'
+  echo ""
+  echo "The tracked lockfile must be generated WITHOUT overlays hydrated."
+  echo "Fix options:"
+  echo "  1. Restore the committed lockfile: git checkout origin/main -- $LOCKFILE"
+  echo "  2. Or empty packages/premium/ and re-run: pnpm install"
+  exit 1
+fi
+
+echo "✅ No premium overlay paths in $LOCKFILE."


### PR DESCRIPTION
Addresses asks 1 and 2 of #963 (the CI guard and the pre-commit guard). Asks 3 and 4 (documenting the intended overlay install mechanism, gating the workspace globs) and the glue-codegen typecheck problem are deliberately not in scope here; the issue should stay open for those.

## What changed

- **`scripts/check-no-overlay-lockfile.sh`**: fails if `pnpm-lock.yaml` contains any `packages/premium/` path. Deterministic string match, no dependency on which overlays exist. `--staged` mode checks the staged copy of the lockfile and skips entirely when the commit does not touch it, so unrelated commits stay fast even with a dirty local lockfile.
- **`.github/workflows/lockfile-integrity.yml`**: new step running the script on every PR and merge-group build. This is the enforcement that works regardless of local state.
- **`.husky/pre-commit`**: runs the script in `--staged` mode alongside the other guard scripts, so the mistake is caught before the commit exists.

## Verification

All four paths exercised locally:

| Case | Result |
|---|---|
| Clean tracked lockfile, worktree mode | passes |
| Lockfile not staged, staged mode | skips (fast path) |
| Lockfile containing a `packages/premium/*` importer, worktree mode | fails, prints offending lines |
| Same content staged, staged mode | fails, prints offending lines |

The guard was confirmed to actually fail (not just pass) before the offending content was removed.
