### PR TITLE
fix(client): validate data-lake slug client-side and de-dup Tag Prefix

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
@@ -19,6 +19,8 @@ const { toastMock, batchUploadMutate } = vi.hoisted(() => ({
 }));
 
 vi.mock('sonner', () => ({ toast: toastMock }));
+// Stub only the hooks; isValidDataLakeSlug comes from the unmocked dataLakeSlug
+// module so the config gate is checked against the real validation logic.
 vi.mock('@client/app/hooks/data/dataLakeWizard', () => ({
   useBatchUpload: () => ({ mutate: batchUploadMutate, isPending: false }),
   useComputeHashes: () => ({ mutate: vi.fn(), isPending: false }),
@@ -95,5 +97,21 @@ describe('DataLakeWizardModal — handleStartUpload offline pre-check', () => {
 
     expect(batchUploadMutate).toHaveBeenCalledTimes(1);
     expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it('disables Start Upload when the name slugifies too short, and clicking it is a no-op', () => {
+    // "!!" slugifies to an empty string - shorter than the server's slug.min(2), which
+    // would otherwise be rejected only at the final upload step.
+    useDataLakeWizardStore.setState(state => ({ config: { ...state.config, name: '!!' } }));
+
+    render(
+      <TestWrapper>
+        <DataLakeWizardModal />
+      </TestWrapper>
+    );
+    const btn = screen.getByTestId('wizard-start-upload-btn') as HTMLButtonElement;
+    expect(btn).toBeDisabled();
+    btn.click();
+    expect(batchUploadMutate).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.tsx
@@ -3,6 +3,7 @@ import { useTheme } from '@mui/joy/styles';
 import { toast } from 'sonner';
 import { useDataLakeWizardStore, type WizardStep } from '@client/app/stores/useDataLakeWizardStore';
 import { useBatchUpload, OFFLINE_MESSAGE } from '@client/app/hooks/data/dataLakeWizard';
+import { isValidDataLakeSlug } from '@client/app/hooks/data/dataLakeSlug';
 import WizardStepIndicator from './WizardStepIndicator';
 import SourceSelectionStep from './steps/SourceSelectionStep';
 import PreviewStep from './steps/PreviewStep';
@@ -43,7 +44,9 @@ export default function DataLakeWizardModal() {
       case 'taxonomy':
         return taxonomy.analyzed;
       case 'config':
-        return config.name.trim().length > 0 && config.tagPrefix.trim().length >= 2;
+        // Append mode reuses the target lake's (already valid) slug; create mode must
+        // produce a slug the server will accept (slug.min(2)) before Start Upload enables.
+        return (!!targetLake || isValidDataLakeSlug(config.name)) && config.tagPrefix.trim().length >= 2;
       case 'upload':
         return false; // No "next" on last step
     }

--- a/apps/client/app/components/DataLakeWizard/steps/ConfigStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/ConfigStep.test.tsx
@@ -182,10 +182,12 @@ describe('ConfigStep - slug validation hint', () => {
     expect(screen.queryByTestId(SLUG_ERROR)).toBeNull();
   });
 
-  it('stays silent in append mode, where the slug comes from the target lake', () => {
-    setName('!!');
+  it('shows the target lake real slug in append mode, not what the name slugifies to', () => {
+    // The lake's stored slug can be disambiguated (e.g. "niche-2") and differ from
+    // slugify(name); the preview must show the real appended slug, and never flag it.
+    setName('Niche');
     useDataLakeWizardStore.setState({
-      targetLake: { id: 'lake-1', name: '!!', slug: 'niche', fileTagPrefix: 'niche:' },
+      targetLake: { id: 'lake-1', name: 'Niche', slug: 'niche-2', fileTagPrefix: 'niche:' },
     });
 
     render(
@@ -194,6 +196,7 @@ describe('ConfigStep - slug validation hint', () => {
       </TestWrapper>
     );
 
+    expect(screen.getByText('niche-2')).toBeInTheDocument();
     expect(screen.queryByTestId(SLUG_ERROR)).toBeNull();
   });
 });

--- a/apps/client/app/components/DataLakeWizard/steps/ConfigStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/ConfigStep.test.tsx
@@ -17,6 +17,8 @@ const { lakes, selectedAccount } = vi.hoisted(() => ({
   selectedAccount: { current: { id: 'me', personal: true } as { id: string; personal: boolean } | null },
 }));
 
+// Stub only the hooks; the pure slug helpers live in the unmocked dataLakeSlug
+// module so this test exercises the real slugify/validation logic.
 vi.mock('@client/app/hooks/data/dataLakeWizard', () => ({
   useComputeHashes: () => ({ mutate: vi.fn(), isPending: false }),
   useCheckDuplicates: () => ({ mutate: vi.fn(), isPending: false }),
@@ -129,5 +131,69 @@ describe('ConfigStep - duplicate lake name warning', () => {
     );
 
     expect(screen.queryByTestId(WARNING)).toBeNull();
+  });
+});
+
+const SLUG_ERROR = 'config-name-slug-error';
+
+describe('ConfigStep - slug validation hint', () => {
+  beforeEach(() => {
+    lakes.current = [];
+    selectedAccount.current = { id: 'me', personal: true };
+  });
+
+  afterEach(() => {
+    useDataLakeWizardStore.getState().resetWizard();
+  });
+
+  it('flags a name that slugifies too short (below the server 2-char minimum)', () => {
+    setName('!!');
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(screen.getByTestId(SLUG_ERROR)).toBeInTheDocument();
+  });
+
+  it('stays silent for a name that yields a valid slug', () => {
+    setName('Legal Contracts');
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(screen.queryByTestId(SLUG_ERROR)).toBeNull();
+  });
+
+  it('stays silent for an empty name (no nagging before the user types)', () => {
+    setName('');
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(screen.queryByTestId(SLUG_ERROR)).toBeNull();
+  });
+
+  it('stays silent in append mode, where the slug comes from the target lake', () => {
+    setName('!!');
+    useDataLakeWizardStore.setState({
+      targetLake: { id: 'lake-1', name: '!!', slug: 'niche', fileTagPrefix: 'niche:' },
+    });
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(screen.queryByTestId(SLUG_ERROR)).toBeNull();
   });
 });

--- a/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
@@ -19,16 +19,9 @@ import { useEffect, useRef } from 'react';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import { DATA_LAKE } from '@client/app/components/datalake/dataLakeBranding';
 import { useComputeHashes, useCheckDuplicates } from '@client/app/hooks/data/dataLakeWizard';
+import { slugifyDataLakeName, MIN_DATA_LAKE_SLUG_LENGTH } from '@client/app/hooks/data/dataLakeSlug';
 import { useGetDataLakes } from '@client/app/hooks/data/dataLakes';
 import { useSelectedAccount } from '@client/app/components/Credits/AccountSelector';
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 60);
-}
 
 function normalizeName(name: string): string {
   return name.trim().toLowerCase().replace(/\s+/g, ' ');
@@ -63,6 +56,12 @@ export default function ConfigStep() {
           lake =>
             (lake.organizationId || undefined) === scopeOrgId && normalizeName(lake.name) === normalizeName(config.name)
         );
+
+  // Client mirror of the server's slug.min(2) rule so a name that slugifies to
+  // empty/too-short is caught here instead of failing at the final upload step.
+  // Append mode reuses the target lake's (already valid) slug, so only gate creates.
+  const slug = slugifyDataLakeName(config.name);
+  const slugTooShort = !targetLake && config.name.trim().length > 0 && slug.length < MIN_DATA_LAKE_SLUG_LENGTH;
 
   const autoTriggered = useRef(false);
 
@@ -123,7 +122,7 @@ export default function ConfigStep() {
         )}
 
         {/* Name */}
-        <FormControl required>
+        <FormControl required error={slugTooShort}>
           <FormLabel>{DATA_LAKE} Name</FormLabel>
           <Input
             data-testid="config-name-input"
@@ -133,8 +132,14 @@ export default function ConfigStep() {
             disabled={!!targetLake}
           />
           <FormHelperText>
-            Slug: <code>{slugify(config.name) || '...'}</code>
+            Slug: <code>{slug || '...'}</code>
           </FormHelperText>
+          {slugTooShort && (
+            <FormHelperText data-testid="config-name-slug-error">
+              This name needs at least {MIN_DATA_LAKE_SLUG_LENGTH} letters or numbers - it currently makes an invalid
+              URL slug.
+            </FormHelperText>
+          )}
           {duplicateNameLake && (
             <FormHelperText data-testid="config-name-duplicate-warning" sx={{ color: 'warning.plainColor' }}>
               A data lake named &ldquo;{duplicateNameLake.name}&rdquo; already exists here. You can still continue -

--- a/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
@@ -59,8 +59,10 @@ export default function ConfigStep() {
 
   // Client mirror of the server's slug.min(2) rule so a name that slugifies to
   // empty/too-short is caught here instead of failing at the final upload step.
-  // Append mode reuses the target lake's (already valid) slug, so only gate creates.
-  const slug = slugifyDataLakeName(config.name);
+  // Append mode reuses the target lake's real slug (which may be disambiguated,
+  // e.g. "niche-2"), so show that rather than what the locked name slugifies to,
+  // and only gate creates.
+  const slug = targetLake ? targetLake.slug : slugifyDataLakeName(config.name);
   const slugTooShort = !targetLake && config.name.trim().length > 0 && slug.length < MIN_DATA_LAKE_SLUG_LENGTH;
 
   const autoTriggered = useRef(false);

--- a/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
@@ -1,5 +1,4 @@
 import { Box, Button, Chip, CircularProgress, IconButton, Input, Stack, Typography } from '@mui/joy';
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditIcon from '@mui/icons-material/Edit';
 import RefreshIcon from '@mui/icons-material/Refresh';
@@ -162,7 +161,6 @@ const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps)
 export default function TaxonomyReviewStep() {
   const theme = useTheme();
   const taxonomy = useDataLakeWizardStore(s => s.taxonomy);
-  const setTagPrefix = useDataLakeWizardStore(s => s.setTagPrefix);
   const updateTag = useDataLakeWizardStore(s => s.updateTag);
   const deleteTag = useDataLakeWizardStore(s => s.deleteTag);
   const inferTaxonomy = useInferTaxonomy();
@@ -218,21 +216,10 @@ export default function TaxonomyReviewStep() {
       data-testid="wizard-taxonomy-step"
       sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, p: 2, overflow: 'auto' }}
     >
-      {/* Header row: prefix input + re-analyze button */}
+      {/* Header row: suggested name + re-analyze button. Tag Prefix is edited on the
+          Config step (its single home) - it drives the submitted fileTagPrefix, so
+          duplicating an editable copy here only invited the two to drift out of sync. */}
       <Stack direction="row" gap={2} alignItems="flex-end" flexWrap="wrap">
-        <Box sx={{ flex: 1, minWidth: 200 }}>
-          <Typography level="body-xs" fontWeight="bold" sx={{ mb: 0.5 }}>
-            Tag Prefix
-          </Typography>
-          <Input
-            size="sm"
-            value={taxonomy.prefix}
-            onChange={e => setTagPrefix(e.target.value)}
-            placeholder="e.g. acme:"
-            startDecorator={<AutoAwesomeIcon sx={{ fontSize: 16 }} />}
-            sx={{ fontFamily: 'monospace' }}
-          />
-        </Box>
         <Box sx={{ flex: 1, minWidth: 200 }}>
           <Typography level="body-xs" fontWeight="bold" sx={{ mb: 0.5 }}>
             Suggested Name

--- a/apps/client/app/hooks/data/dataLakeSlug.test.ts
+++ b/apps/client/app/hooks/data/dataLakeSlug.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { slugifyDataLakeName, isValidDataLakeSlug } from './dataLakeSlug';
+
+// The server validates the slug with slug.min(2) AND slugRegex
+// (/^[a-z0-9][a-z0-9-]*[a-z0-9]$/). isValidDataLakeSlug is the client gate that
+// must agree with both, so a name never passes here only to be rejected server-side.
+const slugRegex = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+describe('slugifyDataLakeName', () => {
+  it('lowercases and hyphenates runs of non-alphanumerics', () => {
+    expect(slugifyDataLakeName('Legal Contracts KB')).toBe('legal-contracts-kb');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(slugifyDataLakeName('  ...Hello!!  ')).toBe('hello');
+  });
+
+  it('yields an empty string when nothing alphanumeric remains', () => {
+    expect(slugifyDataLakeName('!!')).toBe('');
+  });
+
+  it('never leaves a trailing hyphen when truncation lands mid-word', () => {
+    // 59 letters + a space would put the collapsed hyphen at index 59; a naive
+    // trim-then-slice would keep it, producing a slug the server's slugRegex rejects.
+    const slug = slugifyDataLakeName('x'.repeat(59) + ' extra');
+    expect(slug).toBe('x'.repeat(59));
+    expect(slug.length).toBeLessThanOrEqual(60);
+    expect(slug).toMatch(slugRegex);
+  });
+});
+
+describe('isValidDataLakeSlug', () => {
+  it('rejects a name that slugifies below the 2-char minimum', () => {
+    expect(isValidDataLakeSlug('!!')).toBe(false);
+    expect(isValidDataLakeSlug('a')).toBe(false);
+  });
+
+  it('accepts a name that yields a server-valid slug', () => {
+    expect(isValidDataLakeSlug('Legal Contracts')).toBe(true);
+  });
+
+  it('only returns true for slugs the server slugRegex also accepts', () => {
+    for (const name of ['ab', 'Legal Contracts', 'x'.repeat(59) + ' extra', 'A-B']) {
+      if (isValidDataLakeSlug(name)) {
+        expect(slugifyDataLakeName(name)).toMatch(slugRegex);
+      }
+    }
+  });
+});

--- a/apps/client/app/hooks/data/dataLakeSlug.ts
+++ b/apps/client/app/hooks/data/dataLakeSlug.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure slug helpers for the Data Lake wizard, kept dependency-free (no hooks,
+ * axios, or store) so the client gate and its tests exercise the same logic the
+ * server validates against. Mirrors slug.min(2) + slugRegex in common/schemas/dataLake.
+ */
+
+/**
+ * Minimum length the server enforces on a lake slug (see slug.min(2) in
+ * common/schemas/dataLake). A name that slugifies shorter than this is rejected
+ * server-side, so the wizard gates on it client-side too.
+ */
+export const MIN_DATA_LAKE_SLUG_LENGTH = 2;
+
+/** Max slug length the server accepts (slug.max(60)); we truncate to it here. */
+const MAX_DATA_LAKE_SLUG_LENGTH = 60;
+
+/**
+ * Slugify a string for use as a data lake slug. Trimming the leading/trailing
+ * hyphen AFTER truncating is deliberate: truncation can land mid-word and leave a
+ * dangling '-' (e.g. a >60-char name), which slugRegex (`[a-z0-9]$`) would reject.
+ * With that, the output always satisfies slugRegex, so length is the only gate left
+ * (see isValidDataLakeSlug).
+ */
+export function slugifyDataLakeName(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .slice(0, MAX_DATA_LAKE_SLUG_LENGTH)
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Whether a name slugifies to a server-acceptable slug (>= MIN_DATA_LAKE_SLUG_LENGTH chars). */
+export function isValidDataLakeSlug(name: string): boolean {
+  return slugifyDataLakeName(name).length >= MIN_DATA_LAKE_SLUG_LENGTH;
+}

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -17,6 +17,7 @@ import {
   type UploadErrorKind,
 } from '@client/app/stores/useDataLakeWizardStore';
 import { activeOrgId } from '@client/app/hooks/data/dataLakes';
+import { slugifyDataLakeName, MIN_DATA_LAKE_SLUG_LENGTH } from '@client/app/hooks/data/dataLakeSlug';
 import type { WizardFile } from '@client/app/utils/folderTreeParser';
 import { computeFileHash } from '@client/app/utils/folderTreeParser';
 import { invalidateGearsStatusWhileLocked } from '@client/app/hooks/useGearsStatus';
@@ -281,17 +282,6 @@ const BATCH_CHUNK_SIZE = 100; // Max files per presigned URL request
 export const OFFLINE_MESSAGE = 'No internet connection. Check your network and try again.';
 
 /**
- * Slugify a string for use as a data lake slug.
- */
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 60);
-}
-
-/**
  * Translate an upload/create failure into a distinct kind + human message. The lake
  * config validates server-side with zod, whose raw text (e.g. "Too small: expected
  * string to have >=2 characters at 'slug'") must never reach the UI - so a 422 is
@@ -314,8 +304,8 @@ function classifyUploadError(error: unknown): { kind: UploadErrorKind; message: 
   // rather than surfacing the raw validator string.
   if (status === 422) {
     const { config, targetLake } = useDataLakeWizardStore.getState();
-    const slug = targetLake ? targetLake.slug : slugify(config.name);
-    if (slug.length < 2) {
+    const slug = targetLake ? targetLake.slug : slugifyDataLakeName(config.name);
+    if (slug.length < MIN_DATA_LAKE_SLUG_LENGTH) {
       return {
         kind: 'validation',
         message: 'The data lake name is too short. Use a name with at least 2 letters or numbers.',
@@ -440,7 +430,7 @@ export function useBatchUpload() {
       // Ensure tag prefix ends with ':'
       const tagPrefix = config.tagPrefix.endsWith(':') ? config.tagPrefix : config.tagPrefix + ':';
       // Append mode reuses the target lake's slug; create mode derives it from the name.
-      const slug = targetLake ? targetLake.slug : slugify(config.name);
+      const slug = targetLake ? targetLake.slug : slugifyDataLakeName(config.name);
 
       // Step 1: Create the data lake; skipped in append mode (upload into the existing lake).
       let dataLakeId: string;

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -147,7 +147,6 @@ interface DataLakeWizardStore {
   updateTag: (tagName: string, updates: Partial<TaxonomyTag>) => void;
   mergeTags: (sourceTagName: string, targetTagName: string) => void;
   deleteTag: (tagName: string) => void;
-  setTagPrefix: (prefix: string) => void;
 
   // Config step
   setConfig: (config: Partial<DataLakeFormValues>) => void;
@@ -294,12 +293,6 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
         ...state.taxonomy,
         tags: state.taxonomy.tags.map(t => (t.name === tagName ? { ...t, deleted: true } : t)),
       },
-    })),
-
-  setTagPrefix: prefix =>
-    set(state => ({
-      taxonomy: { ...state.taxonomy, prefix },
-      config: { ...state.config, tagPrefix: prefix },
     })),
 
   // ── Config Step ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Closes #826

The Data Lake wizard's "Start Upload" button enabled as soon as a Name was present, but the server rejects any slug shorter than 2 characters. A name that slugifies to empty or a single character (e.g. `!!`) passed the client gate and only failed at the final create call, surfacing as a generic error.

Separately, the Tag Prefix field was editable on two steps (Config and the AI Taxonomy review), which was duplicative and let the two copies drift.

This PR validates the slug client-side with the same rule as the server (`>= 2` chars), blocking Start Upload with an inline hint until it is valid, and gives Tag Prefix a single home on the Config step.

## Changes

- Extracted the slug helpers into a dependency-free `dataLakeSlug.ts` module (`slugifyDataLakeName`, `isValidDataLakeSlug`, `MIN_DATA_LAKE_SLUG_LENGTH`), replacing two duplicate local `slugify` copies with one shared implementation.
- Gated "Start Upload" on `isValidDataLakeSlug(config.name)` (append mode still passes, reusing the target lake's already-valid slug).
- Added an inline error under the Config-step Name field when a typed name slugifies below the 2-char minimum.
- Fixed a slug edge case: the leading/trailing hyphen trim now runs after truncating to 60 chars, so a >60-char name can no longer yield a trailing-hyphen slug that passes the length check but fails the server's slug regex.
- Removed the duplicate Tag Prefix input from the Taxonomy step; kept it on the Config step (the submitted `fileTagPrefix`, present in both create and append flows). Removed the now-unused `setTagPrefix` store action and its selector.

## Guide for Testers

1. Open the Create Data Lake wizard and add a folder of files on the Source step.
2. Advance through Preview and Taxonomy to the Config step.
3. On the Config step, confirm the Tag Prefix field is present here (it should no longer appear on the earlier Taxonomy step).
4. In the Name field, type `!!`. Expected: a slug preview of `...`, an inline error stating the name needs at least 2 letters or numbers, and the "Start Upload" button is disabled.

   <img width="1048" height="729" alt="image" src="https://github.com/user-attachments/assets/18878f4d-517c-4cc0-9046-070261c0c098" />

5. Change the Name to `Legal Contracts`. Expected: the slug preview updates to `legal-contracts`, the inline error disappears, and "Start Upload" enables (assuming a Tag Prefix of 2+ chars is set).
6. Click "Start Upload". Expected: the upload proceeds and the server no longer rejects the request with a slug validation error.

### Regression Checks

1. Create a lake with a normal name (e.g. `Legal Contracts`) and verify it uploads and appears with the expected slug.
2. Add files to an existing lake (append mode) and verify the Config step's Name and Tag Prefix are locked to the existing lake and Start Upload works.
3. On the Taxonomy step, edit/re-analyze tags and confirm the suggested prefix still flows into the Config step's Tag Prefix.

## Developer Notes (Optional)

- `dataLakeSlug.ts` is a dependency-free module (`slugifyDataLakeName`, `isValidDataLakeSlug`, `MIN_DATA_LAKE_SLUG_LENGTH`) that mirrors the server's `slug.min(2)` + slug-regex rules, so the client gate and the server stay in sync from one source of truth.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
