### PR TITLE
feat(chat): surface effective context-window usage and warn before the ceiling

### DIFF
--- a/apps/client/app/components/Session/ContextUsageWarning.test.tsx
+++ b/apps/client/app/components/Session/ContextUsageWarning.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { ContextUsageWarning } from './ContextUsageWarning';
+import type { SessionContextUsage } from '@client/app/hooks/useSessionContextUsage';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const baseUsage: SessionContextUsage = {
+  actualInputTokens: 86_000,
+  contextLimit: 131_072,
+  safeMaxInputTokens: 113_000,
+  utilizationPercentage: 76,
+  band: 'warning',
+  isApproachingLimit: true,
+  overflowDetected: false,
+  cachingIneffective: false,
+};
+
+describe('ContextUsageWarning', () => {
+  it('renders nothing when show is false', () => {
+    const { container } = render(
+      <TestWrapper>
+        <ContextUsageWarning show={false} usage={baseUsage} modelName="Grok 4" onDismiss={vi.fn()} />
+      </TestWrapper>
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the assembled size, model, and percent', () => {
+    render(
+      <TestWrapper>
+        <ContextUsageWarning show usage={baseUsage} modelName="Grok 4" onDismiss={vi.fn()} />
+      </TestWrapper>
+    );
+    const text = screen.getByTestId('context-usage-warning-text').textContent;
+    expect(text).toContain('Grok 4');
+    expect(text).toContain('86K of 113K');
+    expect(text).toContain('76%');
+  });
+
+  it('adds the caching cost note only when caching is ineffective', () => {
+    const { rerender } = render(
+      <TestWrapper>
+        <ContextUsageWarning show usage={baseUsage} modelName="Grok 4" onDismiss={vi.fn()} />
+      </TestWrapper>
+    );
+    expect(screen.queryByText(/no caching discount/i)).toBeNull();
+
+    rerender(
+      <TestWrapper>
+        <ContextUsageWarning
+          show
+          usage={{ ...baseUsage, cachingIneffective: true }}
+          modelName="Grok 4"
+          onDismiss={vi.fn()}
+        />
+      </TestWrapper>
+    );
+    expect(screen.getByText(/no caching discount/i)).toBeInTheDocument();
+  });
+
+  it('fires onDismiss when the close button is clicked', () => {
+    const onDismiss = vi.fn();
+    render(
+      <TestWrapper>
+        <ContextUsageWarning show usage={baseUsage} modelName="Grok 4" onDismiss={onDismiss} />
+      </TestWrapper>
+    );
+    fireEvent.click(screen.getByTestId('context-usage-warning-dismiss'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/client/app/components/Session/ContextUsageWarning.tsx
+++ b/apps/client/app/components/Session/ContextUsageWarning.tsx
@@ -1,0 +1,105 @@
+import { Box, IconButton, Typography, useTheme } from '@mui/joy';
+import { keyframes } from '@mui/system';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+import { formatTokenCount, type SessionContextUsage } from '@client/app/hooks/useSessionContextUsage';
+
+const fadeIn = keyframes`
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+`;
+
+interface ContextUsageWarningProps {
+  show: boolean;
+  usage: SessionContextUsage;
+  modelName: string;
+  onDismiss: () => void;
+}
+
+/**
+ * Slim, non-blocking banner shown above the composer when a session's assembled
+ * context approaches the model's ceiling. Unlike the credit warnings this does
+ * NOT cover the input - the user must be able to keep typing while it shows.
+ */
+export function ContextUsageWarning({ show, usage, modelName, onDismiss }: ContextUsageWarningProps) {
+  const theme = useTheme();
+  const isDarkMode = theme.palette.mode === 'dark';
+
+  if (!show) return null;
+
+  const isDanger = usage.band === 'danger';
+  const pct = Math.round(usage.utilizationPercentage);
+  const used = formatTokenCount(usage.actualInputTokens);
+  const max = formatTokenCount(usage.safeMaxInputTokens);
+
+  const accent = isDanger ? (isDarkMode ? '#fca5a5' : '#b91c1c') : isDarkMode ? '#fbbf24' : '#b45309';
+  const border = isDanger
+    ? isDarkMode
+      ? 'rgba(239, 68, 68, 0.5)'
+      : 'rgba(220, 38, 38, 0.4)'
+    : isDarkMode
+      ? 'rgba(234, 179, 8, 0.5)'
+      : 'rgba(202, 138, 4, 0.4)';
+  const bg = isDanger
+    ? isDarkMode
+      ? 'rgba(80, 20, 20, 0.55)'
+      : 'rgba(254, 226, 226, 0.85)'
+    : isDarkMode
+      ? 'rgba(80, 60, 15, 0.5)'
+      : 'rgba(254, 249, 195, 0.9)';
+
+  const headline = usage.overflowDetected
+    ? `Context is full for ${modelName}`
+    : isDanger
+      ? `Context nearly full for ${modelName}`
+      : `Context is filling up on ${modelName}`;
+
+  return (
+    <Box
+      data-testid="session-context-usage-warning"
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        gap: 1.5,
+        background: bg,
+        border: `1px solid ${border}`,
+        borderRadius: '8px',
+        px: 1.5,
+        py: 1,
+        mb: 1,
+        animation: `${fadeIn} 0.25s ease-out`,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+        <WarningAmberRoundedIcon sx={{ fontSize: '20px', color: accent, mt: '1px', flexShrink: 0 }} />
+        <Box>
+          <Typography
+            data-testid="context-usage-warning-text"
+            sx={{ fontSize: '13px', fontWeight: 600, color: accent }}
+          >
+            {headline} - {used} of {max} tokens ({pct}%)
+          </Typography>
+          <Typography sx={{ fontSize: '12px', color: 'text.secondary', mt: 0.25 }}>
+            {usage.overflowDetected
+              ? 'The next turn may be rejected. Start a new notebook to reset, or the oldest turns will be dropped from context.'
+              : 'As it fills, older turns get summarized or dropped and answers can lose detail. Consider starting a new notebook for a fresh topic.'}
+            {usage.cachingIneffective
+              ? ` This model applies no caching discount, so each turn re-bills the full context - long sessions cost more here.`
+              : ''}
+          </Typography>
+        </Box>
+      </Box>
+      <IconButton
+        data-testid="context-usage-warning-dismiss"
+        size="sm"
+        variant="plain"
+        onClick={onDismiss}
+        aria-label="Dismiss context warning"
+        sx={{ color: accent, flexShrink: 0, minHeight: '24px', minWidth: '24px' }}
+      >
+        <CloseRoundedIcon sx={{ fontSize: '18px' }} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -44,6 +44,12 @@ import { useChatCompletionContext } from '@client/app/contexts/ChatCompletionCon
 import { useAutoFocus } from '@client/app/hooks/useAutoFocus';
 import { useChatPaste } from '@client/app/hooks/useChatPaste';
 import { useTokenLimits } from '@client/app/hooks/useTokenLimits';
+import {
+  useSessionContextUsage,
+  formatTokenCount,
+  type ContextUsageBand,
+} from '@client/app/hooks/useSessionContextUsage';
+import { ContextUsageWarning } from '../ContextUsageWarning';
 import { buildSortedKnowledgeItems } from '@client/app/utils/knowledgeViewerSorting';
 import { deleteFileUtility, getFabFilesFromServerByIds } from '@client/app/utils/filesAPICalls';
 import { useQueryClient } from '@tanstack/react-query';
@@ -112,6 +118,8 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
   const [rephraseGlow, setRephraseGlow] = useState(false);
   const [showSlashSuggestions, setShowSlashSuggestions] = useState(false);
   const [lowCreditsWarningDismissed, setLowCreditsWarningDismissed] = useState(false);
+  // Band at which the user dismissed the context warning; re-shows on escalation.
+  const [contextWarningDismissedBand, setContextWarningDismissedBand] = useState<ContextUsageBand | null>(null);
 
   // Modal state: triggered modal, admin preview, format dialog, modal list
   const {
@@ -164,6 +172,39 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
     max_tokens,
     chatInputLength: chatInputValue.length,
   });
+
+  // Effective (assembled) context usage from the last completed turn - the real
+  // number the user is paying for, vs. isOverContextWindow which only measures
+  // the current input box against the budget.
+  const contextUsage = useSessionContextUsage(currentSessionId);
+  const modelName = useMemo(() => modelInfo?.find(m => m.id === model)?.name ?? model, [modelInfo, model]);
+  // Show the warning once usage is elevated, until dismissed at that band; a
+  // jump from warning -> danger re-surfaces it.
+  const showContextWarning =
+    !!contextUsage && contextUsage.band !== 'normal' && contextUsage.band !== contextWarningDismissedBand;
+
+  // Reset the dismissal when switching notebooks so a heavy session doesn't
+  // inherit a prior notebook's dismissed state.
+  useEffect(() => {
+    setContextWarningDismissedBand(null);
+  }, [currentSessionId]);
+
+  // Corner readout for the composer. Prefer the real assembled-context size from
+  // the last turn; before any turn completes, fall back to the current-input
+  // guard (which measures the input box against the budget, not the history).
+  const contextMeter = contextUsage
+    ? {
+        show: contextUsage.band !== 'normal',
+        danger: contextUsage.band === 'danger',
+        primary: `${formatTokenCount(contextUsage.actualInputTokens)}/${formatTokenCount(contextUsage.safeMaxInputTokens)}`,
+        secondary: `${Math.round(contextUsage.utilizationPercentage)}% of ${modelName} context`,
+      }
+    : {
+        show: isOverContextWindow,
+        danger: isOverContextWindow,
+        primary: `${chatInputValue.length}/${maxInputTokens}`,
+        secondary: `Context: ${contextWindowLimit} - Output: ${effectiveMaxOutputTokens}`,
+      };
 
   const pond = useNotebookFilepond();
   const maxFileSize = useGetSettingsValue('MaxFileSize') || 100;
@@ -411,6 +452,14 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
                 }}
               >
                 <NoModelsWarning show={!isModelsLoading && (!accessibleModels || accessibleModels.length === 0)} />
+                {contextUsage && (
+                  <ContextUsageWarning
+                    show={showContextWarning}
+                    usage={contextUsage}
+                    modelName={modelName}
+                    onDismiss={() => setContextWarningDismissedBand(contextUsage.band)}
+                  />
+                )}
                 <Stack
                   className="session-bottom-input-row"
                   direction="row"
@@ -498,7 +547,7 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
                       agents={lexicalAgents}
                     />
 
-                    {isOverContextWindow ? (
+                    {contextMeter.show ? (
                       <Box
                         sx={{
                           position: 'absolute',
@@ -509,10 +558,10 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
                           padding: '4px 8px',
                         }}
                       >
-                        <Tooltip title="Context Window">
+                        <Tooltip title="Assembled context size for this notebook (last turn)">
                           <Typography
                             sx={theme => ({
-                              color: isOverContextWindow ? 'red' : theme.palette.text.primary,
+                              color: contextMeter.danger ? 'red' : theme.palette.text.primary,
                               textAlign: 'right',
                               leadingTrim: 'both',
                               textEdge: 'cap',
@@ -528,10 +577,10 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
                             level="body-xs"
                           >
                             <Box component="span" sx={{ fontWeight: '500' }}>
-                              {chatInputValue.length}/{maxInputTokens}
+                              {contextMeter.primary}
                             </Box>
                             <Box component="span" sx={{ opacity: 0.7, fontSize: '12px', mt: 0.5 }}>
-                              Context: {contextWindowLimit} - Output: {effectiveMaxOutputTokens}
+                              {contextMeter.secondary}
                             </Box>
                           </Typography>
                         </Tooltip>

--- a/apps/client/app/hooks/useSessionContextUsage.test.ts
+++ b/apps/client/app/hooks/useSessionContextUsage.test.ts
@@ -1,0 +1,102 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSessionContextUsage } from './useSessionContextUsage';
+import { useGetSessionQuests } from '@client/app/hooks/data/sessions';
+
+vi.mock('@client/app/hooks/data/sessions', () => ({
+  useGetSessionQuests: vi.fn(),
+}));
+
+const SAFE_MAX = 100_000;
+
+type UsageOverrides = {
+  utilizationPercentage?: number;
+  actualInputTokens?: number;
+  overflowDetected?: boolean;
+  cacheReadInputTokens?: number;
+};
+
+function quest(id: string, overrides: UsageOverrides = {}) {
+  const actualInputTokens = overrides.actualInputTokens ?? 50_000;
+  return {
+    id,
+    promptMeta: {
+      tokenUsage: { cacheReadInputTokens: overrides.cacheReadInputTokens },
+      context: {
+        contextWindowUsage: {
+          contextLimit: 131_072,
+          maxOutputTokens: 16_384,
+          safeMaxInputTokens: SAFE_MAX,
+          actualInputTokens,
+          bufferTokens: 1000,
+          utilizationPercentage: overrides.utilizationPercentage ?? (actualInputTokens / SAFE_MAX) * 100,
+          overflowDetected: overrides.overflowDetected,
+        },
+      },
+    },
+  };
+}
+
+function mockPages(quests: unknown[]) {
+  (useGetSessionQuests as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    data: { pages: [{ data: quests, hasMore: false }] },
+  });
+}
+
+describe('useSessionContextUsage', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns null when no quest carries context telemetry', () => {
+    (useGetSessionQuests as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useSessionContextUsage('s1'));
+    expect(result.current).toBeNull();
+  });
+
+  it('skips optimistic/in-flight quests that have no telemetry yet', () => {
+    mockPages([{ id: 'tmp-1', promptMeta: undefined }, quest('q1', { utilizationPercentage: 40 })]);
+    const { result } = renderHook(() => useSessionContextUsage('s1'));
+    expect(result.current?.band).toBe('normal');
+  });
+
+  it('picks the newest quest (highest ObjectId) with telemetry', () => {
+    mockPages([
+      quest('q1', { utilizationPercentage: 20 }),
+      quest('q3', { utilizationPercentage: 95 }),
+      quest('q2', { utilizationPercentage: 50 }),
+    ]);
+    const { result } = renderHook(() => useSessionContextUsage('s1'));
+    expect(result.current?.utilizationPercentage).toBe(95);
+    expect(result.current?.band).toBe('danger');
+  });
+
+  it('bands normal / warning / danger at the thresholds', () => {
+    mockPages([quest('q1', { utilizationPercentage: 69 })]);
+    expect(renderHook(() => useSessionContextUsage('s1')).result.current?.band).toBe('normal');
+
+    mockPages([quest('q1', { utilizationPercentage: 70 })]);
+    const warning = renderHook(() => useSessionContextUsage('s1')).result.current;
+    expect(warning?.band).toBe('warning');
+    expect(warning?.isApproachingLimit).toBe(true);
+
+    mockPages([quest('q1', { utilizationPercentage: 90 })]);
+    expect(renderHook(() => useSessionContextUsage('s1')).result.current?.band).toBe('danger');
+  });
+
+  it('forces danger when the backend flagged an overflow', () => {
+    mockPages([quest('q1', { utilizationPercentage: 30, overflowDetected: true })]);
+    const { result } = renderHook(() => useSessionContextUsage('s1'));
+    expect(result.current?.band).toBe('danger');
+    expect(result.current?.overflowDetected).toBe(true);
+  });
+
+  it('flags cachingIneffective only for a large context with zero observed cache reads', () => {
+    mockPages([quest('q1', { actualInputTokens: 30_000, cacheReadInputTokens: 0 })]);
+    expect(renderHook(() => useSessionContextUsage('s1')).result.current?.cachingIneffective).toBe(true);
+
+    mockPages([quest('q1', { actualInputTokens: 30_000, cacheReadInputTokens: 5_000 })]);
+    expect(renderHook(() => useSessionContextUsage('s1')).result.current?.cachingIneffective).toBe(false);
+
+    mockPages([quest('q1', { actualInputTokens: 10_000, cacheReadInputTokens: 0 })]);
+    expect(renderHook(() => useSessionContextUsage('s1')).result.current?.cachingIneffective).toBe(false);
+  });
+});

--- a/apps/client/app/hooks/useSessionContextUsage.ts
+++ b/apps/client/app/hooks/useSessionContextUsage.ts
@@ -1,0 +1,100 @@
+import { useMemo } from 'react';
+import type { PromptMeta } from '@bike4mind/common';
+import { useGetSessionQuests } from '@client/app/hooks/data/sessions';
+
+type ContextWindowUsage = NonNullable<NonNullable<PromptMeta['context']>['contextWindowUsage']>;
+
+/** Utilization band thresholds, as a percent of the model's safe input budget. */
+export const CONTEXT_WARN_THRESHOLD = 70;
+export const CONTEXT_DANGER_THRESHOLD = 90;
+
+/**
+ * Minimum assembled-input size for a missing caching discount to be worth
+ * flagging. Below this the per-turn cost delta from re-billing uncached input
+ * is noise, so we stay quiet to avoid crying wolf on short conversations.
+ */
+const CACHE_NOTE_MIN_INPUT_TOKENS = 20_000;
+
+export type ContextUsageBand = 'normal' | 'warning' | 'danger';
+
+export interface SessionContextUsage {
+  /** Tokens the last completed turn actually assembled as input. */
+  actualInputTokens: number;
+  /** The model's full context window. */
+  contextLimit: number;
+  /** Input budget after reserving output + safety buffer (the real ceiling). */
+  safeMaxInputTokens: number;
+  /** actualInputTokens / safeMaxInputTokens, as a percent. */
+  utilizationPercentage: number;
+  band: ContextUsageBand;
+  isApproachingLimit: boolean;
+  overflowDetected: boolean;
+  /**
+   * The turn ran a large context but earned no cache-read discount, so it was
+   * re-billed at full input rate. Empirical (observed cache reads == 0) rather
+   * than catalog-derived, so it stays correct regardless of provider quirks.
+   */
+  cachingIneffective: boolean;
+}
+
+function bandFor(pct: number, overflow: boolean): ContextUsageBand {
+  if (overflow || pct >= CONTEXT_DANGER_THRESHOLD) return 'danger';
+  if (pct >= CONTEXT_WARN_THRESHOLD) return 'warning';
+  return 'normal';
+}
+
+/** Compact token count for display, e.g. 86000 -> "86K". */
+export function formatTokenCount(tokens: number): string {
+  return tokens >= 1000 ? `${Math.round(tokens / 1000)}K` : `${tokens}`;
+}
+
+/**
+ * Effective context-window usage for a session, read from the most recent
+ * completed turn.
+ *
+ * The source is `promptMeta.context.contextWindowUsage`, which the backend
+ * already records on every quest (ChatCompletionProcess) and the chat-history
+ * endpoint returns in full - so this adds no request. Returns null until a turn
+ * has completed with telemetry (a brand-new or still-streaming session).
+ */
+export function useSessionContextUsage(sessionId: string | null): SessionContextUsage | null {
+  const { data } = useGetSessionQuests(sessionId);
+
+  return useMemo(() => {
+    // Pick the newest quest carrying telemetry. Quest ids are Mongo ObjectIds
+    // (monotonic hex), so a lexical max is the latest turn - order-independent
+    // of how pages happen to be sorted, and optimistic/in-flight quests are
+    // skipped because they have no contextWindowUsage yet.
+    let latestId = '';
+    let latest: ContextWindowUsage | null = null;
+    let latestCacheReadTokens = 0;
+
+    for (const page of data?.pages ?? []) {
+      for (const quest of page.data) {
+        const usage = quest.promptMeta?.context?.contextWindowUsage;
+        if (!usage || !usage.safeMaxInputTokens) continue;
+        if (quest.id && quest.id > latestId) {
+          latestId = quest.id;
+          latest = usage;
+          latestCacheReadTokens = quest.promptMeta?.tokenUsage?.cacheReadInputTokens ?? 0;
+        }
+      }
+    }
+
+    if (!latest) return null;
+
+    const pct = latest.utilizationPercentage ?? (latest.actualInputTokens / latest.safeMaxInputTokens) * 100;
+    const overflowDetected = latest.overflowDetected ?? latest.actualInputTokens > latest.safeMaxInputTokens;
+
+    return {
+      actualInputTokens: latest.actualInputTokens,
+      contextLimit: latest.contextLimit,
+      safeMaxInputTokens: latest.safeMaxInputTokens,
+      utilizationPercentage: pct,
+      band: bandFor(pct, overflowDetected),
+      isApproachingLimit: pct >= CONTEXT_WARN_THRESHOLD,
+      overflowDetected,
+      cachingIneffective: latest.actualInputTokens >= CACHE_NOTE_MIN_INPUT_TOKENS && latestCacheReadTokens === 0,
+    };
+  }, [data?.pages]);
+}

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -57,6 +57,20 @@ export const PromptMetaSchema = new Schema<PromptMeta>(
         toolSchemas: { type: Number, required: false },
         userPrompt: { type: Number, required: false },
       },
+      // Assembled context-window usage for the completed turn. Like the billing
+      // audit fields above, this must be declared or Mongoose strict mode silently
+      // strips it on save (it is set in ChatCompletionProcess and read by the
+      // client's useSessionContextUsage to surface effective context size).
+      contextWindowUsage: {
+        contextLimit: { type: Number, required: false },
+        maxOutputTokens: { type: Number, required: false },
+        safeMaxInputTokens: { type: Number, required: false },
+        actualInputTokens: { type: Number, required: false },
+        bufferTokens: { type: Number, required: false },
+        utilizationPercentage: { type: Number, required: false },
+        overflowDetected: { type: Boolean, required: false },
+        overflowAmount: { type: Number, required: false },
+      },
     },
     functionCalls: [
       {


### PR DESCRIPTION
# Pull Request

<img width="1200" height="1223" alt="context-warning-71pct" src="https://github.com/user-attachments/assets/2ba63691-4508-461f-b085-7222f796fe0e" />


## Description

Long-lived notebooks re-send their accumulated history every turn, and today the only pre-send "context" indicator in the composer compares the **input-box character count** to the token budget (`useTokenLimits` -> `isOverContextWindow`), completely ignoring the accumulated history. So a user can be sitting at ~86K of a ~113K effective budget, type a short message, and get no signal at all -- they just experience answers getting worse/slower and credits draining faster, with no explanation (issue #956).

Note the backend already records the real number: `promptMeta.context.contextWindowUsage` (utilization %, assembled input tokens, limits) is persisted on every quest, and the chat-history endpoint returns it in full. It was just invisible outside the debug inspector / admin telemetry tab.

This PR surfaces the true assembled-context size in the composer and warns proactively before the ceiling. It is almost entirely a client-side read of telemetry the backend already computes -- with **one required backend fix** found during live verification: the Mongoose `PromptMetaSchema` never declared `context.contextWindowUsage`, so strict mode silently dropped it on save and the field never reached the client. Declaring it is the only backend change; no request, assembly, billing, or overflow logic is touched.

Scope note: this is the "visibility first" half of #956. Token-pressure-driven auto-compaction (making the existing summarizer fire on token load instead of message count, and telling the user when it does) is intentionally a separate follow-up because it touches the billing-critical completion path.

## Changes

- **`useSessionContextUsage` hook** -- reads the newest completed turn's `contextWindowUsage` from the `useGetSessionQuests` cache; returns assembled input tokens, safe budget, utilization %, a normal/warning/danger band, overflow flag, and `cachingIneffective` (an *empirical* signal: large context with zero observed cache reads, so it stays correct regardless of provider cache-accounting quirks). Returns null until a turn has completed.
- **Composer readout fixed** -- the corner overlay in `SessionBottom` now shows the real `usedK/maxK - N% of <model> context` from the last turn instead of `inputChars/budget`. Falls back to the old input-box guard before the first turn completes.
- **`ContextUsageWarning` banner** -- a slim, dismissible, non-blocking banner above the composer at >=70% utilization (escalates to a danger style near/at overflow). Includes a cost note when the active model earned no caching discount on a large context. Unlike the credit warnings it does not cover the input, so the user can keep typing.
- **`QuestModel` schema fix** -- declare `promptMeta.context.contextWindowUsage` on the Mongoose sub-schema so the per-turn telemetry (already set in `ChatCompletionProcess`) actually persists instead of being stripped by strict mode. This is what unblocks everything above.

## Guide for Testers

Because the banner is driven by real accumulated context, it only appears once a notebook's assembled context passes 70% of the model's effective budget. Fastest path is a model with a small context window.

1. Log in to the app (e.g. `app.staging.bike4mind.com`).
2. Sidebar -> create a **new notebook**.
3. Open the model selector and pick a model with a **small context window** (for a fast repro; any model works given enough turns).
4. In the composer, type `Summarize the history of computing in about 800 words` and send. Wait for the full response.
5. Send the follow-up `Now expand every section with more detail, keep it long` and wait. Repeat this 3-5 more times so the conversation accumulates.
6. **Expected:** once the assembled context crosses ~70% of the budget, a yellow banner appears directly above the message input reading roughly `Context is filling up on <model> - NNK of NNK tokens (NN%)`, with a sub-line about older turns being summarized/dropped. Below the input, the small corner readout shows `NNK/NNK` and `NN% of <model> context` (the accurate assembled size, not your typed character count).
7. Click the **X** on the banner. **Expected:** it dismisses and stays dismissed for that notebook while utilization stays in the same band.
8. Send another heavy turn to push utilization higher. **Expected:** as it approaches/exceeds the limit the banner returns in a **red** danger style with wording about the next turn possibly being rejected.
9. Switch to a **different notebook** and back. **Expected:** dismissal state resets per notebook (a fresh heavy notebook shows its own banner).
10. (Cost note) If you used a model whose provider caching isn't reflected (e.g. an xAI Grok model) at a large context, the banner's second line additionally states the model applies no caching discount. On a Claude model with warm cache reads, that sentence is absent.

### Regression Checks

1. Open an existing notebook with only a few short turns. **Expected:** no context banner, no corner readout (utilization is normal).
2. Start a brand-new notebook before sending anything. **Expected:** composer behaves exactly as before; if you paste a single message larger than the budget the original over-limit corner readout still appears (fallback path).
3. Confirm sending, streaming, file attach, slash commands, and the credit warnings all behave unchanged.

### What NOT to test

- The only backend change is one added Mongoose field so existing telemetry persists. Context assembly, trimming, summarization, billing, and the overflow guard are untouched -- no need to re-test those paths.

## Additional Information

Closes #956. The compaction/fork follow-up is tracked in #996.

During live preview verification I found that `contextWindowUsage` was never persisted (Mongoose strict mode dropped an undeclared field), which would have made the whole feature a silent no-op in production -- fixed here by declaring the sub-schema. Also corrects a couple of the issue's assumptions: history is not actually unbounded (there's already a model-aware window + tokenizer trimming + async summarization), and `cachedInputTokens: 0` is not caused by a missing `cache_read` price tier (that value is derived at 0.1x input) -- so the caching signal here is measured empirically rather than read from the catalog.

## Developer Notes (Optional)

- **`useSessionContextUsage(sessionId)`** is a reusable read-model over per-quest context telemetry; anything needing "how full is this session" (a header chip, an inspector, an agent guardrail) can consume it without another request.
- **Empirical caching signal**: keying "no caching discount" off observed `cacheReadInputTokens === 0` on a large context avoids hard-coding provider caching capability and survives the fact that some backends don't forward cache-read counts.
- **`ContextUsageWarning`** is a non-covering, band-driven banner pattern (dismiss re-arms on band escalation) that can be reused for other "approaching a soft limit" nudges.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- n/a, no settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) -- n/a
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc -- n/a, reads existing fields only
