### PR TITLE
fix(client): register bob_runs Dexie table for the Bob reading screen

### DIFF
--- a/apps/client/app/utils/dexie.ts
+++ b/apps/client/app/utils/dexie.ts
@@ -49,7 +49,7 @@ export class DexieStore extends Dexie {
     super('Bike4Mind');
     // DID YOU BUMP THE VERSION NUMBER?
     // JUST GO AHEAD AND BUMP THE VERSION NUMBER
-    this.version(20).stores({
+    this.version(21).stores({
       users: '_id, &id',
       sessionmodels: '_id, &id, userId, lastUpdated',
       toolmodels: '_id, &id, userId',
@@ -63,6 +63,12 @@ export class DexieStore extends Dexie {
       questmasterplans: '_id, &id, notebookId',
       artifacts: '_id, &id, userId, type, status, sessionId, projectId',
       artifact_versions: '_id, &id, artifactId, version, createdBy',
+
+      // premium-bob async run docs; the reading screen live-queries this by _id via
+      // useCollectionQuery('bob_runs', {_id}). Must stay in sync with the bob_runs entry in
+      // dataSubscribeRequest.ts (the WS subscribe allow-list). Without it Dexie throws
+      // "Table bob_runs does not exist" when the Bob reading screen mounts.
+      bob_runs: '_id, &id, userId',
 
       adminsettings: '_id, &id, &name',
     });


### PR DESCRIPTION
Fixes the crash behind Bob's "Something went wrong" reading screen (found running the Bob async e2e on staging). Refs Bike4Mind/b4m-bob#65 (Finding 1, host half).

## Root cause
The Bob reading screen live-queries the run doc via `useCollectionQuery('bob_runs', { _id })`, which resolves `dexie.table('bob_runs')`. The client Dexie schema (`apps/client/app/utils/dexie.ts`) never registered `bob_runs`, so Dexie throws **"Table bob_runs does not exist"** the moment the reading screen mounts. The WS *server* allow-list (#907) landed; the matching *client* table did not.

## Change
- Register `bob_runs: '_id, &id, userId'` in `.stores()` (matches the sibling collections; `_id` primary is the index the `{_id: runId}` query uses).
- Bump the store version 20 -> 21 (required when adding a table).
- Stays in sync with the `bob_runs` entry in `dataSubscribeRequest.ts` per the schema comment.

## Verification status — NOT yet verified end-to-end
- The Bearer half of the crash (Finding 2, overlay) is a separate PR on b4m-bob.
- This fix will be **confirmed by re-running the `/bob` UI e2e on staging once this + the overlay fix deploy** — I have not claimed it works yet. The root cause is code-confirmed (bob_runs absent from the schema; `dexie.table` resolves by name), but I will only call it fixed after the live e2e passes.

Host repo -> needs a dev approval.