### PR TITLE
docs(api): correct embed-key ownership comments and pin rate-limit as minter-only

### DIFF
--- a/apps/client/app/utils/apiKeyRevocation.ts
+++ b/apps/client/app/utils/apiKeyRevocation.ts
@@ -21,8 +21,9 @@ interface RevocationFields {
  * revocation metadata existed carry no timestamp, and `updatedAt` is not a
  * substitute (any write to the document bumps it).
  *
- * `revokedBy` is deliberately not rendered - it is a raw user id that always
- * equals the key's minter while every revoke path is minter-scoped.
+ * `revokedBy` is deliberately not rendered - it is a raw user id, and it is not
+ * necessarily the minter (an org admin can revoke a key billed to an org they
+ * administer). Surfacing it would need a username lookup this helper does not do.
  */
 export function revocationTooltip(key: RevocationFields): string | null {
   if (!key.revokedAt) return null;

--- a/apps/client/pages/api/user-api-keys/[id]/rate-limit.ts
+++ b/apps/client/pages/api/user-api-keys/[id]/rate-limit.ts
@@ -18,10 +18,12 @@ interface UpdateRateLimitRequest {
  * Change a key's request ceilings in place, so raising or lowering a limit no
  * longer means revoking and re-minting. Only the fields sent change.
  *
- * Not admin-gated: ownership-scoped self-service, same posture as the sibling
- * embed-config PATCH. `updateApiKeyRateLimit` resolves the key via
- * findByUserIdAndId, so a caller can only ever retarget their own key. Bounds
- * are the service's (shared with mint); out-of-range values come back 422.
+ * Not admin-gated: minter-scoped self-service. `updateApiKeyRateLimit` resolves
+ * the key via findByUserIdAndId, so a caller can only ever retarget their own
+ * key. Deliberately narrower than the sibling embed-config PATCH, which also
+ * resolves org-administered keys because it backs the org-wide embed-key admin
+ * table; rate limits are not on that table. Bounds are the service's (shared
+ * with mint); out-of-range values come back 422.
  *
  * csrfProtection is defense in depth rather than a live hole - a cross-site
  * PATCH carrying JSON cannot get past preflight anyway - but it costs the

--- a/b4m-core/services/src/userApiKeyService/rateLimit.test.ts
+++ b/b4m-core/services/src/userApiKeyService/rateLimit.test.ts
@@ -5,6 +5,9 @@ import { IUserApiKeyDocument, IUserApiKeyRepository } from '@bike4mind/common';
 const makeRepo = (stored: Partial<IUserApiKeyDocument> | null) =>
   ({
     findByUserIdAndId: vi.fn().mockResolvedValue(stored),
+    // Stubbed even though this surface must never reach for it, so the
+    // minter-only assertion below is a real check rather than a vacuous one.
+    findByOrganizationIdsAndId: vi.fn().mockResolvedValue(null),
     setRateLimit: vi.fn().mockResolvedValue(undefined),
   }) as unknown as IUserApiKeyRepository;
 
@@ -52,6 +55,23 @@ describe('userApiKeyService - updateApiKeyRateLimit', () => {
     await expect(
       updateApiKeyRateLimit('user2', { keyId: 'key-1', requestsPerMinute: 600 }, { db: { userApiKeys: repo } })
     ).rejects.toThrow(/API key not found/i);
+    expect(repo.setRateLimit).not.toHaveBeenCalled();
+  });
+
+  // Rate limits are not on the org-wide embed-key admin table, so this surface
+  // stays minter-only while its sibling embed-config/rotate/revoke paths resolve
+  // org-administered keys too. Pinned because broadening it would be silent -
+  // an org admin would just start succeeding, with no failing test to notice.
+  it('never falls back to the org-admin resolver for a key the caller did not mint', async () => {
+    const repo = makeRepo(null);
+    // Resolvable via the org path, so growing that fallback would make the call
+    // SUCCEED - failing the rejection assertion as well as the call assertion.
+    vi.mocked(repo.findByOrganizationIdsAndId).mockResolvedValue(storedKey() as IUserApiKeyDocument);
+
+    await expect(
+      updateApiKeyRateLimit('org-admin', { keyId: 'key-1', requestsPerMinute: 600 }, { db: { userApiKeys: repo } })
+    ).rejects.toThrow(/API key not found/i);
+    expect(repo.findByOrganizationIdsAndId).not.toHaveBeenCalled();
     expect(repo.setRateLimit).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="2360" height="1196" alt="org-admin-write-posture" src="https://github.com/user-attachments/assets/b640db3c-e22b-4199-9a9c-d89b997002eb" />

*Figure: real HTTP against the app running locally (real routes, real Mongo), seeded so OWNER administers the org while a different user minted the org-billed key. The org admin can Configure (200) and Revoke (200) a key they did not mint; the rate-limit surface stays minter-only (404), which is the invariant the new test pins; and `revokedBy` records the acting admin, not the minter - the claim the two corrected comments now make.*

## Description

#777 reported that an org admin sees other members' org-billed keys in the embed-key admin table but hits a dead end on Configure / Rotate / Revoke, because read was org-wide while write was minter-only.

That asymmetry is already gone. #940 widened all three write paths a few days after #777 was filed, so the reported symptom does not reproduce on main. #940 did leave two comments describing the old posture, and one invariant that nothing pins.

This PR is documentation and a regression lock. No runtime behavior changes.

## Changes

- `apps/client/app/utils/apiKeyRevocation.ts` - `revocationTooltip` claimed `revokedBy` "always equals the key's minter while every revoke path is minter-scoped". Both halves are now wrong: revoke resolves org-administered keys and stamps the acting caller. The field is still not rendered, so the comment now gives the real reason - a raw user id needs a username lookup to be presentable.
- `apps/client/pages/api/user-api-keys/[id]/rate-limit.ts` - the route called itself "same posture as the sibling embed-config PATCH". The sibling widened and this route deliberately did not, because rate limits are not on the org-wide embed-key admin table. The comment now states that divergence instead of pointing at a sibling that no longer matches.
- `b4m-core/services/src/userApiKeyService/rateLimit.test.ts` - pins `updateApiKeyRateLimit` as minter-only. It stubs `findByOrganizationIdsAndId` so it would resolve the key, then asserts the call still rejects and the resolver is never reached.

Both comment rewrites state the invariant rather than the change, since describing a moment in time is how the originals drifted.

## Guide for Testers

The comment changes have no runtime surface. What is worth verifying is the invariant the new test pins, and that the posture #777 asked about does hold on main. Run against the PR preview once a maintainer triggers one.

Prerequisite (internal): the per-deploy E2E secret, sent as `x-e2e-cleanup-secret` on `/api/test/*`. Test users must use `-e2e@test.com` emails.

Setup - each `create-user` call returns an `accessToken`, used as `Authorization: Bearer <token>`:

1. `POST /api/test/create-user` for `owner-e2e@test.com` with `isAdmin:false`. This is the ORG OWNER, the admin caller under test. Save OWNER_TOKEN.
2. `POST /api/test/create-user` for `minter-e2e@test.com` with `isAdmin:true` - the teammate who mints the key, admin so it may bill the org. Save MINTER_TOKEN.
3. As OWNER_TOKEN, `POST /api/organizations` with `{"name":"QA Org"}`. The caller becomes the org owner. Save the returned org `id` as ORG_ID.
4. As MINTER_TOKEN, `POST /api/user-api-keys` with `{"name":"QA widget","scopes":["embed:chat"],"agentId":"agent-qa","organizationId":"<ORG_ID>"}`. Save the returned key `id` as KEY_ID. This is a teammate's org-billed key the owner did not mint.

Verify the org-admin write posture holds (what #777 asked for):

5. As OWNER_TOKEN, `PATCH /api/user-api-keys/<KEY_ID>` with `{"branding":{"displayName":"Renamed by admin"}}`. Expected: `200`.
6. As OWNER_TOKEN, `POST /api/user-api-keys/<KEY_ID>/revoke` with `{"reason":"qa"}`. Expected: `200`, and `GET /api/user-api-keys?includeDisabled=true` shows that key disabled with `revokedBy` set to the owner's user id, not the minter's.

Verify the locked invariant - rate limits stay minter-only:

7. As OWNER_TOKEN, `PATCH /api/user-api-keys/<KEY_ID>/rate-limit` with `{"requestsPerMinute":120}`. Expected: `404`. That surface is deliberately minter-scoped even though the caller administers the org. This is the invariant the new test pins.
8. As MINTER_TOKEN, repeat step 7 against a key it minted. Expected: `200` - a minter can still set their own key's ceilings.

### Regression Checks

- A key's own minter can still configure, rotate and revoke it (repeat steps 5-6 with MINTER_TOKEN).
- Editing an unrelated branding field on a key that already stores `hideBranding: true` does not clear it.

### What NOT to test

- The org-admin write widening itself shipped in #940, not here. Steps 5-6 confirm it still holds; they do not test new code.
- Rate-limit and spend-cap staying minter-scoped is by design, not an oversight.

## Additional Information

Scope decisions:

- `spendCap` is the other deliberately minter-only service. It has no route, so no asymmetry is reachable and no comment there is wrong. Intentionally not locked here.
- #940 left the minter-then-org-admin resolution duplicated in four places, which carries a latent silent-`hideBranding`-strip risk. Filed as #998, out of scope here.
- #776, the sibling follow-up cited by #777, also appears already fixed by #805. Verified and noted on that issue; left open for a human to close.
- No preview env was requested and QA sign-off is not being solicited for this PR. The required `preview gate` check passes without one, the diff is two comments plus one test with no runtime delta, and the internal deployer declines docs/test-only PRs as non-deployable. The Guide for Testers above is reproducible on any dev or preview stage if someone wants to confirm the invariant independently.

Verification:

- `pnpm turbo:typecheck` - 40/40 tasks pass.
- `pnpm lint:check` - clean.
- `pnpm turbo:test` - one client test file failed at `VITEST_MAX_WORKERS=2`; re-running `@bike4mind/client` at one worker gives 691 files / 6993 tests passing, exit 0. Known oversubscription flake.
- The new test was mutation-checked: adding the org-admin fallback to `updateApiKeyRateLimit` makes it fail on the rejection assertion, and no pre-existing test notices.

## Developer Notes (Optional)

The two rewritten comments are a small worked example of a drift pattern worth avoiding: both originals described a moment in time ("while every revoke path is minter-scoped", "same posture as the sibling") rather than an invariant, so a later change falsified them silently. Comments phrased as invariants, with the reason for a deliberate divergence, survive the next widening.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
