### PR TITLE
fix(e2e): keep previous file-browser results while a new search loads

### DIFF
--- a/apps/client/app/components/Files/Browser/Actions.tsx
+++ b/apps/client/app/components/Files/Browser/Actions.tsx
@@ -30,6 +30,7 @@ interface FileBrowserActionsProps {
   currentPage?: number;
   totalPages?: number;
   onPageChange?: (page: number) => void;
+  /** True while a page change is in flight; pass the same signal as Browser/List.tsx's `isChangingPage`. */
   isLoadingPage?: boolean;
 }
 

--- a/apps/client/app/components/Files/Browser/Content.embedded.test.tsx
+++ b/apps/client/app/components/Files/Browser/Content.embedded.test.tsx
@@ -31,7 +31,11 @@ const bulkDeleteMutate = vi.fn();
 const confirmRun = vi.fn((opts: { onOk?: () => void | Promise<void> }) => opts.onOk?.());
 
 vi.mock('@client/app/hooks/data/fabFiles', () => ({
-  usePaginatedSearchFabFiles: () => ({ data: { data: [testFile], total: 1 }, isLoading: false, isFetching: false }),
+  usePaginatedSearchFabFiles: () => ({
+    data: { data: [testFile], total: 1 },
+    isLoading: false,
+    isPlaceholderData: false,
+  }),
   useSearchFabFiles: () => ({ data: { data: [], total: 0 }, isLoading: false }),
   useBulkDeleteFiles: () => ({ mutateAsync: bulkDeleteMutate }),
   useCreateFabFile: () => ({ mutate: vi.fn(), isPending: false }),

--- a/apps/client/app/components/Files/Browser/Content.searchRemount.test.tsx
+++ b/apps/client/app/components/Files/Browser/Content.searchRemount.test.tsx
@@ -1,0 +1,182 @@
+import { type ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { IFabFileDocument } from '@bike4mind/common';
+
+/**
+ * Guards the file browser's single list render site. Content used to host FileBrowserList in two
+ * mutually-exclusive branches switched on hasFilters; since React reconciles children by position,
+ * the first committed search term unmounted the whole list subtree and mounted a fresh one, wiping
+ * every row's local state - an open inline rename included. keepPreviousData keeps the rows' DATA
+ * across that refetch, so the blank-list symptom disappeared while the lost-rename one did not.
+ *
+ * Real Filter (debounce and all) and real List; the row is stubbed with the smallest thing that
+ * behaves like Item.tsx's `editMode` - useState that survives re-render and dies on unmount.
+ */
+
+const { rowMounts } = vi.hoisted(() => ({ rowMounts: new Map<string, number>() }));
+
+const testFiles = [
+  { id: 'f1', fileName: 'cat.png', fileSize: 100, userId: 'u1', mimeType: 'image/png', type: 'file' },
+  { id: 'f2', fileName: 'dog.png', fileSize: 200, userId: 'u1', mimeType: 'image/png', type: 'file' },
+  { id: 'f3', fileName: 'notes.txt', fileSize: 300, userId: 'u1', mimeType: 'text/plain', type: 'file' },
+] as unknown as IFabFileDocument[];
+
+// Every search term the hook is asked for, in order - the observable signal that the debounced
+// filter change has reached the query, so the test never has to sleep on the 500ms debounce.
+const searchParams: (string | undefined)[] = [];
+
+vi.mock('./Item', async () => {
+  const { useState, useEffect } = await import('react');
+  const StubRow = ({ file }: { file: IFabFileDocument }) => {
+    const [editing, setEditing] = useState(false);
+    useEffect(() => {
+      rowMounts.set(file.id, (rowMounts.get(file.id) ?? 0) + 1);
+    }, [file.id]);
+    return (
+      <div data-testid={`row-${file.id}`}>
+        {file.fileName}
+        <button data-testid={`row-edit-${file.id}`} onClick={() => setEditing(true)}>
+          edit
+        </button>
+        {editing && <span data-testid={`row-editing-${file.id}`} />}
+      </div>
+    );
+  };
+  return { default: StubRow };
+});
+
+vi.mock('@client/app/hooks/data/fabFiles', () => ({
+  usePaginatedSearchFabFiles: (params?: { search?: string }) => {
+    searchParams.push(params?.search);
+    // Mirrors keepPreviousData: the previous rows stay put while a new term is in flight.
+    return { data: { data: testFiles, total: testFiles.length }, isLoading: false, isPlaceholderData: false };
+  },
+  useSearchFabFiles: () => ({ data: { data: [], total: 0 }, isLoading: false }),
+  useBulkDeleteFiles: () => ({ mutateAsync: vi.fn() }),
+  useCreateFabFile: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateFabFile: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@client/app/hooks/data/tag', () => ({
+  useGetFileTags: () => ({ data: [] }),
+  useToggleTagToFiles: () => ({ mutateAsync: vi.fn() }),
+  useCreateFileTag: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@client/app/hooks/data/sessions', () => ({ useUpdateSession: () => ({ mutate: vi.fn() }) }));
+vi.mock('@client/app/hooks/data/useModelInfo', () => ({ useModelInfo: () => ({ data: [] }) }));
+vi.mock('@client/app/hooks/useConfirmation', () => ({ useConfirmation: () => vi.fn() }));
+vi.mock('@client/app/contexts/UserContext', () => ({ useUser: () => ({ currentUser: { id: 'u1' } }) }));
+vi.mock('@client/app/contexts/LLMContext', () => ({
+  useLLM: (selector: (s: { model: string }) => unknown) => selector({ model: 'gpt' }),
+}));
+vi.mock('@client/app/contexts/SessionsContext', () => ({
+  useSessions: () => ({ currentSessionId: 's1', currentSession: null }),
+  useWorkBenchFiles: () => [],
+  useWorkBenchStore: { getState: () => ({ setWorkBenchFiles: vi.fn() }) },
+}));
+vi.mock('@client/app/contexts/WebsocketContext', () => ({
+  useWebsocket: () => ({ subscribeToAction: () => () => {} }),
+}));
+vi.mock('@client/app/hooks/useAdminSettingsCache', () => ({
+  useAdminSettingsCache: () => ({ isFeatureEnabled: () => false }),
+}));
+vi.mock('@client/app/hooks/useFeatureEnabled', () => ({
+  useFeatureEnabled: () => ({ isFeatureEnabled: () => false }),
+}));
+vi.mock('@client/app/stores/useDataLakeWizardStore', () => ({
+  useDataLakeWizardStore: (selector: (s: { openManager: () => void }) => unknown) => selector({ openManager: vi.fn() }),
+}));
+vi.mock('../../Knowledge/KnowledgeModal', () => {
+  const state = { setOpen: vi.fn(), setSelectedFabFileId: vi.fn(), setViewOnly: vi.fn() };
+  return { useKnowledgeModal: (selector: (s: typeof state) => unknown) => selector(state) };
+});
+
+// Heavy children not under test - Filter and List are deliberately NOT mocked.
+// The browser opens on the Overview tab, which renders no paginated list; this stub is just a
+// switch into List view (the real ViewActions pulls in chrome this test does not exercise).
+vi.mock('./ViewActions', () => ({
+  default: ({ value, onChange }: { value: { viewMode?: string }; onChange: (v: { viewMode: string }) => void }) => (
+    <button data-testid="stub-view-mode-list" onClick={() => onChange({ ...value, viewMode: 'list' })}>
+      list view
+    </button>
+  ),
+}));
+vi.mock('./TagSidebar', () => ({ default: () => null }));
+vi.mock('./TagView', () => ({ TagViewPanel: () => null }));
+vi.mock('./HomeView', () => ({ HomeViewPanel: () => null }));
+vi.mock('./MobileSearchFilter', () => ({ MobileSearchFilter: () => null }));
+vi.mock('./UploadActionsSelect', () => ({ UploadActionsSelect: () => null }));
+vi.mock('../../common/FileStorageBar', () => ({ default: () => null }));
+vi.mock('../../common/ShareModal', () => ({ default: () => null }));
+vi.mock('../../Knowledge/CreateKnowledgeFromUrl', () => ({ default: () => null }));
+vi.mock('../../Tag/Form', () => ({ default: () => null }));
+vi.mock('../../ResarchEngine/Modal', () => ({ default: () => null }));
+vi.mock('@client/app/components/MobileTopBar', () => ({ MobileTopBar: () => null }));
+vi.mock('@client/app/components/help', () => ({ FieldTooltip: () => null }));
+
+import FileBrowserContent from './Content';
+import { FileBrowserInstanceProvider, FileBrowserInstanceValue } from './instanceContext';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+const renderContent = () => {
+  const value: FileBrowserInstanceValue = {
+    selectedIds: new Set(),
+    setSelectedIds: vi.fn(),
+    open: true,
+    setOpen: vi.fn(),
+    fileToShare: null,
+    setFileToShare: vi.fn(),
+    config: {},
+  };
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={new QueryClient()}>
+      <CssVarsProvider theme={appTheme}>
+        <FileBrowserInstanceProvider value={value}>{children}</FileBrowserInstanceProvider>
+      </CssVarsProvider>
+    </QueryClientProvider>
+  );
+  render(<FileBrowserContent />, { wrapper });
+  // Content renders the view switcher twice (mobile + desktop); either one drives the same state.
+  fireEvent.click(screen.getAllByTestId('stub-view-mode-list')[0]);
+};
+
+/** Type a term and wait for the debounced filter change to reach the query. */
+const search = async (term: string) => {
+  const input = screen.getByTestId('file-browser-search-input').querySelector('input');
+  fireEvent.change(input as HTMLInputElement, { target: { value: term } });
+  await waitFor(() => expect(searchParams).toContain(term), { timeout: 2_000 });
+};
+
+describe('FileBrowserContent - list survives the unfiltered/filtered switch', () => {
+  beforeEach(() => {
+    rowMounts.clear();
+    searchParams.length = 0;
+  });
+
+  it('keeps per-row state (an open inline rename) when a search term commits', async () => {
+    renderContent();
+
+    fireEvent.click(screen.getByTestId('row-edit-f1'));
+    expect(screen.getByTestId('row-editing-f1')).toBeInTheDocument();
+
+    await search('ca');
+
+    expect(screen.getByTestId('row-editing-f1')).toBeInTheDocument();
+  });
+
+  it('does not remount rows when the search term commits or changes', async () => {
+    renderContent();
+    expect(rowMounts.get('f1')).toBe(1);
+
+    await search('ca');
+    await search('cat');
+    // Back to the unfiltered view - the reverse crossing of the same boundary.
+    await search('');
+
+    expect(rowMounts.get('f1')).toBe(1);
+  });
+});

--- a/apps/client/app/components/Files/Browser/Content.tsx
+++ b/apps/client/app/components/Files/Browser/Content.tsx
@@ -111,6 +111,7 @@ const FileBrowserContent = () => {
     data,
     isLoading: isLoadingAllFiles,
     isFetching,
+    isPlaceholderData,
   } = usePaginatedSearchFabFiles({
     ...filter,
     order: { by: sortField, direction: sortDirection },
@@ -703,7 +704,7 @@ const FileBrowserContent = () => {
                   sortDirection={sortDirection}
                   onSortChange={handleSortChange}
                   isLoading={isLoading}
-                  isFetching={isFetching}
+                  isPlaceholderData={isPlaceholderData}
                   fileFilterType={
                     filter.filters?.shared === true ? 'shared' : filter.filters?.curated === true ? 'curated' : 'all'
                   }
@@ -759,7 +760,7 @@ const FileBrowserContent = () => {
                   sortDirection={sortDirection}
                   onSortChange={handleSortChange}
                   isLoading={isLoading}
-                  isFetching={isFetching}
+                  isPlaceholderData={isPlaceholderData}
                   fileFilterType={
                     filter.filters?.shared === true ? 'shared' : filter.filters?.curated === true ? 'curated' : 'all'
                   }

--- a/apps/client/app/components/Files/Browser/Content.tsx
+++ b/apps/client/app/components/Files/Browser/Content.tsx
@@ -31,7 +31,7 @@ import TagForm from '../../Tag/Form';
 import { useFileBrowserInstance } from './instanceContext';
 import FileBrowserActions from './Actions';
 import FileBrowserFilter from './Filter';
-import FileBrowserList from './List';
+import FileBrowserList, { type FileBrowserListProps } from './List';
 import ResearchEngineModal from '../../ResarchEngine/Modal';
 import FileBrowserViewActions, { ViewMode } from './ViewActions';
 import TagSidebar from './TagSidebar';
@@ -110,7 +110,6 @@ const FileBrowserContent = () => {
   const {
     data,
     isLoading: isLoadingAllFiles,
-    isFetching,
     isPlaceholderData,
   } = usePaginatedSearchFabFiles({
     ...filter,
@@ -132,7 +131,7 @@ const FileBrowserContent = () => {
 
   const availableOptions = fileTags?.filter(tag => !filter.filters?.tags?.includes(tag.name)) || [];
 
-  const hasFilters = filter.search || filter.filters?.tags?.length || filter.filters?.type;
+  const hasFilters = Boolean(filter.search || filter.filters?.tags?.length || filter.filters?.type);
 
   const allFiles = data?.data || [];
   const totalFiles = data?.total || 0;
@@ -391,6 +390,12 @@ const FileBrowserContent = () => {
 
   const isLoading = isLoadingAllFiles;
 
+  // Must stay in sync with `isChangingPage` in Browser/List.tsx so the bottom-bar Prev/Next and
+  // the list-view Prev/Next disable on the same signal. keepPreviousData leaves isLoading false
+  // mid-page-change, and isFetching would also trip on the background WebSocket-driven
+  // ['fabFiles'] refetches below, which leave the visible page current.
+  const isChangingPage = isLoading || isPlaceholderData;
+
   // Add handler for tag sidebar actions
   const handleTagSidebarClick = (tagName: string) => {
     const currentTags = filter.filters?.tags || [];
@@ -427,6 +432,20 @@ const FileBrowserContent = () => {
       },
     });
   };
+
+  // The tag-filter row belongs to the filtered view only, and List renders it only when all four
+  // props are supplied - so gate the props, not the list's render site (see the note at the list).
+  const tagFilterProps: Pick<
+    FileBrowserListProps,
+    'availableTagOptions' | 'selectedTags' | 'onTagsChange' | 'onClearAll'
+  > = hasFilters
+    ? {
+        availableTagOptions: availableOptions,
+        selectedTags: filter.filters?.tags || [],
+        onTagsChange: tags => handleFilterChange({ ...filter, filters: { ...(filter.filters || {}), tags } }),
+        onClearAll: handleClearAllTags,
+      }
+    : {};
 
   const handleAddTagToFiles = async (tagId: string, fileIds: string[]) => {
     try {
@@ -692,39 +711,21 @@ const FileBrowserContent = () => {
             />
           )}
 
-          {viewAction.viewMode !== 'tags' && viewAction.viewMode !== 'home' && !hasFilters && (
-            <>
-              <Stack sx={{ display: 'flex', flexDirection: 'column', height: '100%', mb: 2 }}>
-                <FileBrowserList
-                  files={allFiles}
-                  fileTags={fileTags}
-                  viewType={viewAction.viewMode as 'list' | 'grid'}
-                  emptyDescription="You have no files"
-                  sortField={sortField}
-                  sortDirection={sortDirection}
-                  onSortChange={handleSortChange}
-                  isLoading={isLoading}
-                  isPlaceholderData={isPlaceholderData}
-                  fileFilterType={
-                    filter.filters?.shared === true ? 'shared' : filter.filters?.curated === true ? 'curated' : 'all'
-                  }
-                  onFileFilterChange={handleFileFilterChange}
-                  onOpenTagManager={() => setIsTagSidebarOpen(!isTagSidebarOpen)}
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  onPageChange={setCurrentPage}
-                />
-              </Stack>
-            </>
-          )}
-
-          {viewAction.viewMode !== 'tags' && viewAction.viewMode !== 'home' && hasFilters && (
+          {/* Filtered and unfiltered share ONE list render site. React reconciles children by
+              position, so hosting the list in two sibling branches switched on hasFilters made the
+              first committed search keystroke unmount the whole subtree and mount a fresh one -
+              wiping per-row local state, including an open inline rename (Item.tsx `editMode`).
+              keepPreviousData in usePaginatedSearchFabFiles preserves the rows' data, not the
+              components holding that state, so the single render site is what keeps rename alive.
+              Anything added here must stay position-stable across the hasFilters flip: gate props
+              and siblings on it, never which branch renders the list. */}
+          {viewAction.viewMode !== 'tags' && viewAction.viewMode !== 'home' && (
             <Stack
               direction="column"
               gap={{ xs: '16px', md: '20px' }}
               sx={{ flex: 1, minHeight: 0, height: '100%', mb: 2 }}
             >
-              {navigatedFromTags && (
+              {hasFilters && navigatedFromTags && (
                 <Chip
                   data-testid="back-to-tags-chip"
                   variant="soft"
@@ -766,18 +767,7 @@ const FileBrowserContent = () => {
                   }
                   onFileFilterChange={handleFileFilterChange}
                   onOpenTagManager={() => setIsTagSidebarOpen(!isTagSidebarOpen)}
-                  availableTagOptions={availableOptions}
-                  selectedTags={filter.filters?.tags || []}
-                  onTagsChange={t => {
-                    handleFilterChange({
-                      ...filter,
-                      filters: {
-                        ...(filter.filters || {}),
-                        tags: t,
-                      },
-                    });
-                  }}
-                  onClearAll={handleClearAllTags}
+                  {...tagFilterProps}
                   currentPage={currentPage}
                   totalPages={totalPages}
                   onPageChange={setCurrentPage}
@@ -842,7 +832,7 @@ const FileBrowserContent = () => {
             currentPage={currentPage}
             totalPages={totalPages}
             onPageChange={viewAction.viewMode === 'home' ? undefined : setCurrentPage}
-            isLoadingPage={isFetching}
+            isLoadingPage={isChangingPage}
           />
         </Box>
 

--- a/apps/client/app/components/Files/Browser/List.tsx
+++ b/apps/client/app/components/Files/Browser/List.tsx
@@ -67,6 +67,7 @@ const FileBrowserList: FC<FileBrowserListProps> = ({
   // isPlaceholderData rather than isFetching: background refetches (the WebSocket-driven
   // ['fabFiles'] invalidations in Content.tsx) leave the visible page current, and disabling
   // Prev/Next through those would flicker the controls for no reason.
+  // Must stay in sync with Content.tsx's `isChangingPage`, which feeds the bottom-bar Prev/Next.
   const isChangingPage = isLoading || isPlaceholderData;
 
   function getTags(file: IFabFileDocument): IFileTag[] | undefined {

--- a/apps/client/app/components/Files/Browser/List.tsx
+++ b/apps/client/app/components/Files/Browser/List.tsx
@@ -20,7 +20,8 @@ export interface FileBrowserListProps {
   sortDirection?: 'asc' | 'desc';
   onSortChange?: (field: 'fileName' | 'fileSize' | 'createdAt', direction: 'asc' | 'desc') => void;
   isLoading?: boolean;
-  isFetching?: boolean;
+  /** True while the rows on screen are the previous page/search standing in for a not-yet-loaded one. */
+  isPlaceholderData?: boolean;
   // Pagination props
   currentPage?: number;
   totalPages?: number;
@@ -47,7 +48,7 @@ const FileBrowserList: FC<FileBrowserListProps> = ({
   sortDirection = 'asc',
   onSortChange,
   isLoading = false,
-  isFetching = false,
+  isPlaceholderData = false,
   currentPage = 1,
   totalPages = 1,
   onPageChange,
@@ -60,6 +61,13 @@ const FileBrowserList: FC<FileBrowserListProps> = ({
   onClearAll,
 }) => {
   const { t } = useTranslation();
+
+  // The query keeps the previous rows while a new page/search loads (see
+  // usePaginatedSearchFabFiles), so isLoading alone is false during a page change. Latch on
+  // isPlaceholderData rather than isFetching: background refetches (the WebSocket-driven
+  // ['fabFiles'] invalidations in Content.tsx) leave the visible page current, and disabling
+  // Prev/Next through those would flicker the controls for no reason.
+  const isChangingPage = isLoading || isPlaceholderData;
 
   function getTags(file: IFabFileDocument): IFileTag[] | undefined {
     // For shared files, show all tags from the file itself
@@ -349,7 +357,7 @@ const FileBrowserList: FC<FileBrowserListProps> = ({
           >
             <Button
               variant="outlined"
-              disabled={currentPage === 1 || isLoading}
+              disabled={currentPage === 1 || isChangingPage}
               onClick={() => onPageChange(currentPage - 1)}
               size="sm"
             >
@@ -360,7 +368,7 @@ const FileBrowserList: FC<FileBrowserListProps> = ({
             </Typography>
             <Button
               variant="outlined"
-              disabled={currentPage === totalPages || isLoading}
+              disabled={currentPage === totalPages || isChangingPage}
               onClick={() => onPageChange(currentPage + 1)}
               size="sm"
             >
@@ -434,7 +442,7 @@ const FileBrowserList: FC<FileBrowserListProps> = ({
         >
           <Button
             variant="outlined"
-            disabled={currentPage === 1 || isLoading}
+            disabled={currentPage === 1 || isChangingPage}
             onClick={() => onPageChange(currentPage - 1)}
             size="sm"
           >
@@ -445,7 +453,7 @@ const FileBrowserList: FC<FileBrowserListProps> = ({
           </Typography>
           <Button
             variant="outlined"
-            disabled={currentPage === totalPages || isLoading}
+            disabled={currentPage === totalPages || isChangingPage}
             onClick={() => onPageChange(currentPage + 1)}
             size="sm"
           >

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -20,7 +20,7 @@ import {
 import { getContentFromFabfile as getContentFromFabfileInString } from '@client/app/utils/fabFileUtils';
 import { isOptimisticId } from '@client/app/utils/llm';
 import { getErrorMessage } from '@client/app/utils/error';
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { uploadFileToUrl } from '@client/app/utils/uploadFileToUrl';
 import { ActualFileObject } from 'filepond';
 import { toast } from 'sonner';
@@ -558,6 +558,11 @@ export function usePaginatedSearchFabFiles(parameters?: ISearchFabFilesParams & 
     },
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 5, // Cache results for 5 minutes
+    // Search text and page number are part of the query key, so without this every
+    // keystroke or page change would drop `data` to undefined and unmount every row.
+    // That flickers the list and destroys per-row local state mid-interaction (an
+    // in-progress inline rename loses its edit mode - see Browser/Item.tsx ToggleRename).
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/apps/client/e2e/pages/FileUploadPage.ts
+++ b/apps/client/e2e/pages/FileUploadPage.ts
@@ -145,6 +145,10 @@ export class FileUploadPage extends BasePage {
     const renameInput = this.page.getByTestId('file-browser-rename-input');
     const renameItem = this.page.getByTestId('file-browser-rename-item');
     const saveBtn = this.page.getByTestId('file-browser-rename-save-btn');
+    const successToast = this.page
+      .locator('[data-sonner-toast]')
+      .filter({ hasText: /renamed/i })
+      .first();
 
     // Menu items can be detached by React re-renders, or the click may not register.
     // Retry the whole open-menu -> rename -> type -> save sequence, not just entering rename
@@ -166,6 +170,16 @@ export class FileUploadPage extends BasePage {
         await saveBtn.click({ timeout: TIMEOUTS.ELEMENT_STATE });
         break;
       } catch {
+        // The throw can land after the rename already went through - a save click that registered
+        // but whose actionability re-check then timed out on the re-rendering row. Retrying from
+        // there searches for a row that no longer carries the old name and would report a false
+        // failure, so treat the success toast as done. Bounded wait, not an instant check: the
+        // PUT may still be in flight when the click times out.
+        const renamed = await successToast
+          .waitFor({ state: 'visible', timeout: TIMEOUTS.POST_ACTION })
+          .then(() => true)
+          .catch(() => false);
+        if (renamed) break;
         if (attempt === 3) throw new Error('Failed to rename file after retries');
         await this.page.keyboard.press('Escape').catch(() => {});
       }
@@ -177,9 +191,7 @@ export class FileUploadPage extends BasePage {
       () => expect(renameInput).toBeHidden({ timeout: TIMEOUTS.ACTION })
     );
     // Wait for success toast to confirm rename completed and file list refreshed
-    await expect(this.page.locator('[data-sonner-toast]').filter({ hasText: /renamed/i })).toBeVisible({
-      timeout: TIMEOUTS.VISIBLE,
-    });
+    await expect(successToast).toBeVisible({ timeout: TIMEOUTS.VISIBLE });
   }
 
   async deleteFile(filename: string) {

--- a/apps/client/e2e/pages/FileUploadPage.ts
+++ b/apps/client/e2e/pages/FileUploadPage.ts
@@ -76,7 +76,25 @@ export class FileUploadPage extends BasePage {
   async findFile(filename: string) {
     await this.waitForLoaderToDisappear('file-browser-loader');
     const searchInput = this.page.getByTestId('file-browser-search-input').getByRole('textbox');
+    // The search box debounces 500ms (app/components/Files/Browser/Filter.tsx), so filling it
+    // starts no request synchronously: the loader wait below would resolve against the
+    // pre-search list and the real results would then land mid-interaction, remounting rows
+    // under whatever the caller does next. Arm the wait BEFORE filling so the response can't
+    // be missed, and match on the decoded `search` param so a still-in-flight response for a
+    // previous term (e.g. "cat.png" while searching "cat") can't satisfy it.
+    // Bounded and swallowed: react-query serves an already-cached term without a request, and
+    // then there is nothing to wait for.
+    const searchApplied = this.page
+      .waitForResponse(
+        response =>
+          response.url().includes('/api/files/search') &&
+          response.ok() &&
+          new URL(response.url()).searchParams.get('search') === filename,
+        { timeout: TIMEOUTS.VISIBLE }
+      )
+      .catch(() => null);
     await searchInput.fill(filename);
+    await searchApplied;
     await this.waitForLoaderToDisappear('file-browser-loader');
     const file = this.page
       .getByTestId('file-browser-dialog')
@@ -126,9 +144,13 @@ export class FileUploadPage extends BasePage {
     const menuButton = row.getByTestId('file-browser-actions-menu-btn');
     const renameInput = this.page.getByTestId('file-browser-rename-input');
     const renameItem = this.page.getByTestId('file-browser-rename-item');
+    const saveBtn = this.page.getByTestId('file-browser-rename-save-btn');
 
     // Menu items can be detached by React re-renders, or the click may not register.
-    // Retry the full open-menu -> click-rename -> wait-for-input sequence.
+    // Retry the whole open-menu -> rename -> type -> save sequence, not just entering rename
+    // mode: rename mode is per-row local state (Browser/Item.tsx `useCommon`), so anything that
+    // remounts the row drops out of it and the input plus Save button never come back - a retry
+    // scoped to menu-opening alone would leave the typing and save steps to fail unrecoverably.
     // Every click MUST carry an explicit timeout: the suite sets no `actionTimeout`, so an
     // unbounded click() waits forever for actionability. If a background list refetch re-renders
     // the row mid-click, the stability check never resolves and the click hangs until the whole
@@ -138,17 +160,16 @@ export class FileUploadPage extends BasePage {
         await menuButton.click({ timeout: TIMEOUTS.ELEMENT_STATE });
         await renameItem.click({ timeout: TIMEOUTS.ELEMENT_STATE });
         await expect(renameInput).toBeVisible({ timeout: TIMEOUTS.POST_ACTION });
+        const renameTextbox = renameInput.getByRole('textbox');
+        await renameTextbox.clear({ timeout: TIMEOUTS.ELEMENT_STATE });
+        await renameTextbox.fill(newName, { timeout: TIMEOUTS.ELEMENT_STATE });
+        await saveBtn.click({ timeout: TIMEOUTS.ELEMENT_STATE });
         break;
       } catch {
-        if (attempt === 3) throw new Error('Failed to enter rename mode after retries');
+        if (attempt === 3) throw new Error('Failed to rename file after retries');
         await this.page.keyboard.press('Escape').catch(() => {});
       }
     }
-
-    const renameTextbox = renameInput.getByRole('textbox');
-    await renameTextbox.clear({ timeout: TIMEOUTS.ELEMENT_STATE });
-    await renameTextbox.fill(newName, { timeout: TIMEOUTS.ELEMENT_STATE });
-    await this.page.getByTestId('file-browser-rename-save-btn').click({ timeout: TIMEOUTS.ELEMENT_STATE });
     // Wait for rename API or the inline input to disappear (rename complete)
     await this.waitForResponseOrUI(
       response =>


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1911" height="1071" alt="Screenshot 2026-07-27 at 10 24 32 PM" src="https://github.com/user-attachments/assets/1abce9bc-a64a-40c4-8a80-152199213f57" />


## Description

The E2E suite failed on `notebook-files.spec.ts` -> step `rename a file`, on all three attempts (20.5s / 29.8s / 19.5s):

```
TimeoutError: locator.click: Timeout 5000ms exceeded.
  at pages/FileUploadPage.ts:151   getByTestId('file-browser-rename-save-btn').click(...)
  - locator resolved to <button aria-label="Save" data-testid=...>
  - element is not stable      -> retry
  - element was detached from the DOM, retrying
```

The Save button existed, then moved, then vanished for good. There are **two independent defects** behind that, and rev 1 only fixed the first.

### Defect 1 — the query dropped its data on every keystroke (fixed in rev 1)

1. The search box debounces 500ms (`Browser/Filter.tsx:14`). `findFile()` fills the box and then waits for the loader, but no request has started yet, and `waitForLoaderToDisappear` treats a not-yet-attached loader as already hidden (`BasePage.ts:240-247`). The trace confirms it: Fill 10ms, loader wait 2ms, `toBeVisible` 2ms — all passing against the *unfiltered* list.
2. ~500ms later the debounce commits, changing the react-query key in `usePaginatedSearchFabFiles`. That hook had no `placeholderData`, so `data` dropped to `undefined` -> `allFiles = []` -> zero rows, and `isLoading` flipped true, inserting the ~19px loader bar above the list.
3. Those two effects are the two log lines: the inserted loader bar shifts the row (*not stable*), then the row unmounts (*detached*).

### Defect 2 — the list was rendered from two places (fixed in rev 2)

`Content.tsx` hosted `FileBrowserList` in **two mutually-exclusive sibling branches** switched on `hasFilters` (`filter.search || filters.tags?.length || filters.type`) — one for the unfiltered view, one for the filtered view, each inside a different wrapper tree.

React reconciles children by position. When the debounced term committed and `hasFilters` flipped, the list moved to a different child index: React unmounted the entire subtree and mounted a fresh one. Every row's local state died with it, including the `editMode` at `Item.tsx:193` that holds the inline rename open.

`keepPreviousData` preserves the rows' **data** across a refetch; it cannot preserve components that get unmounted. That is exactly why QA saw section A pass and section B fail, and why the rename vanished *at the moment the term committed* — in one reproduction while the four placeholder rows were still on screen, before any new data had arrived.

**Neither defect was only a test problem.** In the product, every search keystroke blanked the file list (defect 1) and destroyed any in-progress inline rename (defect 2).

Why only `rename` broke while `delete` survived the same `findFile`: `selectFileRow` retries its click 3x and tolerates the remount, whereas `renameFile`'s clear/fill/save was unguarded — and no retry could have recovered it once `editMode` was wiped.

---

## Changes

**App**

- `app/hooks/data/fabFiles.ts` — `usePaginatedSearchFabFiles` sets `placeholderData: keepPreviousData`. Previous rows stay on screen while a new search/page loads. Uses the `keepPreviousData` helper to match sibling files in the same directory (`toolDefinitions.ts`, `entitlements.ts`).
- `app/components/Files/Browser/Content.tsx:714-774` — **the list now renders from a single site** instead of two branches switched on `hasFilters`. The wrapper is unconditional; only props and siblings vary:
  - `hasFilters` is now `Boolean(...)` (`:134`) since it feeds a ternary.
  - Tag-filter props are gated through `tagFilterProps` (`:438`), so the unfiltered view still renders no tag-filter row (`List` only renders that row when all four props are supplied).
  - The "Back to Tags" chip is gated `hasFilters && navigatedFromTags` (`:728`) — same behavior as before. A conditional at a fixed JSX child index does not shift the list's position, so this is safe; swapping *which branch renders the list* is not.
  - A comment at the render site states the invariant: anything added here must stay position-stable across the `hasFilters` flip.
- `app/components/Files/Browser/List.tsx` — pagination Prev/Next gate on `isChangingPage = isLoading || isPlaceholderData` (`:71`). With previous data retained, `isLoading` stays false during a page change, so guarding on it alone would leave the buttons clickable mid-fetch. The declared-but-unread `isFetching` prop was renamed to `isPlaceholderData`.
- `app/components/Files/Browser/Content.tsx:397, :835` — the **bottom action bar's** Prev/Next now take the same signal (`isChangingPage`), not `isFetching`. Previously the toolbar pair and the list-view pair latched on different signals, so one could stay clickable while the other was disabled. `isFetching` is no longer read anywhere in the file.
- `app/components/Files/Browser/Actions.tsx:33` — doc comment on `isLoadingPage` pointing at `List`'s `isChangingPage`, since the two definitions must stay in sync.

`isPlaceholderData` deliberately over `isFetching`: `Content.tsx` invalidates `['fabFiles']` on two WebSocket subscriptions (chunk/vector status, image moderation), which fire throughout any upload. Gating on `isFetching` would blink the pagination controls to disabled during those background refetches, when the visible page is perfectly current.

**E2E**

- `e2e/pages/FileUploadPage.ts` -> `findFile()` arms a `waitForResponse` *before* filling the search box and awaits it after, matching on `new URL(response.url()).searchParams.get('search') === filename`. Exact-param matching matters: a substring check would let an in-flight `search=cat.png` response satisfy a wait for `cat`. Bounded at 10s and swallowed, because a term react-query already has cached fresh never hits the network.
- `e2e/pages/FileUploadPage.ts` -> `renameFile()`'s retry loop wraps clear/fill/save, not just menu-opening.
- `e2e/pages/FileUploadPage.ts:178` — that retry now **exits early when the success toast is already visible**. Without it, a save click that registered and then threw on the immediately-following detach would send attempts 2-3 hunting for a row that now carries the *new* name, and the loop would report `Failed to rename file after retries` over a rename that actually worked. Bounded `waitFor` rather than an instant `isVisible()` check, because the PUT can still be in flight when the click times out (and Playwright ignores `timeout` on `isVisible()`). The toast locator is hoisted and reused for the end-of-method assertion.

With defect 2 fixed, the E2E hardening is belt-and-braces rather than load-bearing: the row no longer remounts under the rename in the first place.

**Tests**

- `app/components/Files/Browser/Content.searchRemount.test.tsx` (new) — real `Filter` (real 500ms debounce) and real `List`, with the row stubbed as the minimal `useState` analogue of `editMode`. Two cases: per-row state survives a committed search term, and rows do not remount across `'' -> 'ca' -> 'cat' -> ''`. **Against the pre-fix `Content.tsx` both fail** — the rename marker is gone and row `f1` mounts 3 times instead of 1 — so it reproduces the QA finding rather than merely asserting current behavior.
- `app/components/Files/Browser/Content.embedded.test.tsx:33` — mock returns `isPlaceholderData` instead of the no-longer-existing `isFetching`.

---

## Guide for Testers

Env: any deployed environment with the file browser (e.g. `app.staging.bike4mind.com`, or the `pr1012` preview). Account: a normal user with **at least 25 files** so pagination appears (page size is 20). Have one file whose name contains a distinctive substring, e.g. `cat.png`.

> **Note on the 2026-07-28 QA run:** section A passed and section B failed on the `282c7b2e` preview. Section B is the reason `03cf2a3f` exists, so **B must be re-run on a preview built from `03cf2a3f` or later** — a run against the older build will fail exactly as before. Sections C9/C10/C12 were not reached for lack of a >=25-file account; that account is still the main coverage gap, and it now matters more because both pagination control sets changed.

### A. Search no longer blanks the list (defect 1)

1. Sign in and open the file browser: Sidebar -> **Files**.
2. Click the **List** view toggle. Expected: files render as rows.
3. Click into the **Search files...** box and type `ca` (do not press Enter). Watch the list area closely while typing.
   - Expected: the existing rows stay on screen until the filtered results arrive, then the list updates in place. No moment where the list goes empty, and no loading bar pushing the rows down.
   - Before this fix: the list blanked for a few hundred ms and a thin progress bar appeared under the header.
4. Clear the search box. Expected: full list returns, again without a blank flash.

*Verified 2026-07-28 on the `pr1012` preview: row count polled at 50ms went `4,4,4,4,4 -> 1,1,1,1,1`, never 0.*

### B. Inline rename survives a filter change (defect 2)

The boundary under test is `hasFilters` flipping — search text, a tag filter, or the file-type dropdown going from empty to set, or back. The list used to be rendered from two different branches on either side of that flip, so crossing it remounted every row and silently dropped rename mode. Search is just the easiest way to cross it.

5. In List view, hover the row for `cat.png` and click its **three-dot** actions menu -> **Rename**.
   - Expected: the row becomes an inline text input with a green check (Save) and a red X (Cancel).
6. Type `catRenamed` in the inline input. Do **not** save.
7. Click into **Search files...** and type `ca`, then wait ~2 seconds.
   - **Use a term that still matches the file.** `ca` and `png` both keep `cat.png` in the results. Searching `dog` legitimately removes the row, and losing the rename there is correct behavior, not this bug.
   - Expected: the inline input is still open, still contains `catRenamed`, and the green Save is still clickable.
   - Before this fix: the input vanished and the row reverted to display mode — the edit was silently lost, and the file was not renamed.
8. Clear the search box entirely and wait ~2 seconds.
   - Expected: the rename is still open. This is the reverse crossing of the same boundary and used to remount just as hard.
9. Click the green **Save** check.
   - Expected: a "File renamed successfully" toast and the row shows the new name.
10. Repeat 5-9 crossing the boundary with the **File Type** dropdown instead of Search, and again with a **tag filter**. Same expectation each time.
11. Repeat 5-9 in **Grid** view.

### C. Regression checks

12. **Pagination advances correctly, on both control sets.** With >20 files there are **two** Prev/Next pairs: one in the bottom action bar (`file-browser-prev-page-btn` / `file-browser-next-page-btn`) and one in the pagination row under the list. Click Next on each in turn.
    - Expected: the page indicator advances, rows update, and **both pairs disable together** while the new page loads. Before rev 2 the toolbar pair latched on `isFetching` while the list pair latched on `isPlaceholderData`, so they could disagree.
    - Expected: no blank list between pages.
13. **Neither pair flickers during background refetches.** Start a file upload (or trigger vectorization on a file) and watch both pairs for ~15 seconds without clicking.
    - Expected: both stay enabled the whole time. Disabled flicker here would mean a guard latched on `isFetching` again.
14. **Default list layout is unchanged.** With no search or filter active, compare the list and the grid against `main` at a desktop width and at ~430px: row spacing, the gap under the header, and that the list scrolls inside its own area with the bottom bar staying put.
    - Why this is on the list: the unfiltered view now renders through the same wrapper the filtered view always used, one level deeper than before (`flex: 1; min-height: 0` instead of a bare `height: 100%`). Behavior should be identical — this is the check that it is. The wrapper itself is the one QA already exercised at 1440px and 430px in the filtered view.
15. **Tag-filter row appears only when filtering.** With no filters, there is no tag-filter chip row above the list. Apply a tag filter: the row appears. Clear it: the row goes away.
16. **"Back to Tags" chip.** Tags view -> filter by a tag -> the chip appears above the list and returns you to Tags view. Clear the tag filter: the chip disappears.
17. **Empty state still works.** Search for a term that matches nothing, e.g. `zzzqqq`.
    - Expected: after the results arrive, the list shows "You have no files" rather than continuing to show the previous rows.
18. **Grid view parity.** Switch to **Grid** and repeat steps 3 and 12.
19. **Delete still works.** Select a file's row, click **Delete**, confirm. Expected: "deleted" toast, row disappears.
20. **Add-to-notebook still works.** Open a notebook, open the file browser over it, search a file, select its row, click **Add**. Expected: the file is attached.
21. **Selection clears on filter change (unchanged behavior).** Select two rows, then type a search term. Expected: the selection resets — `handleFilterChange` clears it deliberately, and that is not what this PR changed.

### D. E2E — `notebook-files.spec.ts` (the spec that failed)

This is the primary regression gate. The spec is one test, `Notebook File Operations > should upload, browse, rename, and delete a file`, with four `test.step`s: upload a file to notebook -> add file to notebook via file browser -> **rename a file** (the step that failed) -> delete a file. It uploads `e2e/fixtures/uploads/cat.png`, then searches `cat.png`, `cat`, and `RenamedFile` in turn — three different search terms, which is what made the debounce race land on the rename step.

The spec has its own Playwright project, `notebook-files`, with its own seeded test user (`e2e/notebook-files.setup.ts` -> `setupSpecUser`). Selecting the project runs its dependency chain: `setup-core` -> `warmup` -> `setup-notebook-files` -> `notebook-files`. Do not run the spec file without the project — the auth storage state comes from the setup.

> **Run it locally against a preview or staging — not through CI.** CI cannot run this suite against a preview environment right now; see D4.

#### D1. Prerequisites (local run against a deployed env)

22. Ensure `apps/client/.env.e2e` exists. First-time setup:
    ```
    cd apps/client
    pnpm test:e2e:setup          # installs Chromium, creates .env.e2e interactively
    ```
23. Set these in `.env.e2e`:
    - `API_URL` — the environment under test, e.g. `https://app.staging.bike4mind.com` or `https://app.pr<N>.preview.bike4mind.com`. Defaults to `http://localhost:3000` if unset.
    - `E2E_CLEANUP_SECRET` — required outside SST context. Retrieve it per stage with the `get-e2e-cleanup-secret` skill. Never commit the literal value.
    - Expected: a missing secret fails fast with "E2E_CLEANUP_SECRET must be set" rather than a confusing test failure.

#### D2. Run it — PASSED at `282c7b2e`, RE-RUN NEEDED at `03cf2a3f`

24. Run the project:
    ```
    cd apps/client
    pnpm test:e2e -- --project=notebook-files
    ```
    - Expected: 1 passed. The list reporter prints `[notebook-files] > notebook-files.spec.ts:4:3 > Notebook File Operations > should upload, browse, rename, and delete a file`.
    - Note: local `retries` is 1 (CI uses 2), so a pass reported as **flaky** means it still failed once and retried — for this PR that counts as not fixed (see D3).
    - **Status:** one clean local pass against the `pr1012` preview at head `282c7b2e` (not flaky, no retry consumed). **That run predates `03cf2a3f`**, which restructured `Content.tsx` and changed `renameFile()`, so it is no longer the verification of record. Re-run against a preview built from `03cf2a3f`.
25. Open the report and inspect the step tree:
    ```
    pnpm test:e2e:report
    ```
    - Expected in the `rename a file` step: `Click getByTestId('file-browser-rename-save-btn')` completes in tens of milliseconds. In the failing run it sat at **5.0s** and then threw.
    - Expected: no `TimeoutError: locator.click`, no "element is not stable", no "element was detached from the DOM" anywhere in the run.
    - Expected: the `rename a file` step total drops well under its previous 5.7s.
    - Artifacts on failure: `apps/client/playwright-report/` (HTML), `apps/client/e2e/test-results/` (screenshots, traces).

#### D3. Confirm the flake is actually gone — OUTSTANDING (optional)

Only one clean local run was performed, and against the older head. The repetition below has not been done. Optional rather than blocking: the original failure was deterministic within its CI run (all three attempts, not one in three), and both root causes are removed at the source rather than retried around.

26. Run the project several times with retries disabled, so a single race shows up as red instead of being hidden by a retry:
    ```
    cd apps/client
    for i in 1 2 3 4 5; do
      pnpm test:e2e -- --project=notebook-files --retries=0 || { echo "FAILED on run $i"; break; }
    done
    ```
    - Expected: 5 consecutive passes, no "FAILED on run" line.
    - Rationale: the failure was load-sensitive (it hit at worker #18 under full parallel CI load). A quiet local run exercises a friendlier timing profile, so repetition raises confidence.
    - Note: each iteration reruns the setup chain and seeds a **fresh test user** on the target environment. Five runs means five users' worth of seed data — fine on a preview, worth knowing if anyone is watching cleanup.
27. Optional — prove which fix carries the spec. `git stash` only the `e2e/pages/FileUploadPage.ts` changes, keep the app changes, rerun step 26: expected still green, because the app fixes remove the unmount entirely. Then keep only the E2E changes: also green, because the test no longer races the debounce. Both close the failure; they are kept together because each covers a different weakness.
28. Optional — capture a trace on a clean run: add `--trace=on` (the config only traces `on-first-retry`, so a first-attempt pass produces none).

#### D4. CI on a preview environment — BLOCKED (known infra issue, unrelated to this PR)

**Do not use CI to verify this PR against the preview. It cannot work today.** The per-preview `E2E_CLEANUP_SECRET` is rotated — each `pr<N>` stage self-provisions a fresh random value at deploy time, and it is deliberately not a GitHub secret (`e2e/README.md`, issue #251). CI's only way to read it is inside `sst shell`, and that wrapper currently cannot resolve the SST context for a preview stage: `e2e-run.yml:111` always assumes `secrets.AWS_DEV_ROLE_ARN`, then line 227 runs a bare `pnpm sst shell --stage pr<N>`, with no equivalent of the private `./for-env <stage>` wrapper that resolves the AWS/app context for a preview stage's app.

Observed on this PR — two dispatches, both dead in ~7 seconds before Playwright started:

| Run | Time | Outcome |
|---|---|---|
| [30270010156](https://github.com/Bike4Mind/bike4mind/actions/runs/30270010156) | 13:22:53Z | `sst shell --stage pr1012` -> "Unexpected error occurred" |
| [30270681405](https://github.com/Bike4Mind/bike4mind/actions/runs/30270681405) | 13:31:33Z | identical |

The preview itself was fine: the deployer run deployed `282c7b2e` successfully (12:57:46 -> 13:21:55), the PR carries `preview-deployed`, and the workflow's own health gate got HTTP 200 from `/api/ping`. Both dispatches started after the deploy finished, so it was not a state-lock overlap. Zero tests ran in either.

Two things to know when reading those runs:

- Both dispatches left **Test project** unset, so `PLAYWRIGHT_ARGS` was empty and the log says "Running full suite" — the scoped `--project=notebook-files` was never passed. Irrelevant to the outcome (it died before Playwright), but do not read those runs as a scoped attempt.
- A harness-level failure **reports as an empty green run**: with no `pw-results.json`, the parse step (`e2e-run.yml:242-252`) emits all zeros and Slack posted ":white_check_mark: 0 passed :x: 0 failed ... Total: 0", while "Fail if E2E tests failed" was *skipped* because `real_failed=0`. Only the job's red X reveals anything went wrong. Do not read that Slack line as "nothing failed."

29. If you want a CI signal anyway, dispatch **E2E Tests (Manual)** with **Test project** = `Notebook Files` against `staging` or `dev` (those stages work — every recent successful run used `--stage dev`).
    - Caveat that makes this weak: Playwright runs from the *branch checkout* while the app under test comes from `API_URL`. Against staging, this branch's updated spec runs against **main's app code**, which has neither fix. A pass there exercises only the E2E half. It cannot validate the app half — only the preview has that code.
30. `notebook-files` is **not** in the Core set (`CORE_PROJECTS` in `e2e-core.yml` is `unauthenticated`, `notebook`, `prompts`), so this PR does not touch a required gate and no merge-blocking check depends on the run above. Once the spec holds green for 5+ consecutive runs it becomes a candidate for Core promotion per the README's criteria.

**Follow-ups this exposed** (separate PRs): pass `--print-logs` or upload `.sst/log/sst.log` on failure so an SST-level error is diagnosable at all; give the E2E workflow preview-stage AWS/app context; and make the results parser distinguish "harness failed, 0 tests ran" from a clean run. The label-triggered path (`e2e-on-label.yml`) has the same bare `sst shell --stage pr<N>` pattern and its last 100 runs are all `skipped`, so the preview path has no recent successful precedent.

#### D5. If it still fails

31. Check which failure mode appears in the report:
    - **"element was detached from the DOM"** on `file-browser-rename-save-btn` -> the row is still remounting. Two possible causes now: the query lost `placeholderData`, or something reintroduced a second list render site in `Content.tsx` (the list must render from exactly one place regardless of `hasFilters`). The unit test `Content.searchRemount.test.tsx` catches the second cause without a browser.
    - **"Failed to rename file after retries"** -> all 3 attempts failed *and* no success toast appeared. Unlike rev 1, this message no longer fires after a rename that actually worked, so treat it as a real failure.
    - **A ~10s gap inside `findFile` with no request in the network tab** -> the search term was already cached, so the response wait timed out and was swallowed. Harmless, but it is the wall-clock cost noted under Known limitations.

### What NOT to test

- Server-side file search, ranking, or the `/api/files/search` response shape — untouched. This PR only changes how the client holds onto results it already has, and where the list is mounted.
- File upload, chunking, or vectorization pipelines — untouched.
- Any file browser surface outside the paginated list/grid. The Overview tab's "Recent" list uses a different hook (`useSearchFabFiles`) and is unchanged; the Tags view is unchanged.

---

## Additional Information

**Verification performed (at `03cf2a3f`)**

- **`Content.searchRemount.test.tsx` against the pre-fix `Content.tsx`: both cases fail** — `row-editing-f1` absent, and row `f1` mounts 3 times instead of 1. The test reproduces the QA finding, so it is a real guard rather than a restatement of current behavior. Against the fix: both pass.
- `vitest run app/components/Files`: 7 files, 47 tests, all pass.
- `vitest run` on the other `FileBrowser` consumers (`SendToDataLakeModal.test.tsx`, `SessionToolbar.test.tsx`): 2 files, 6 tests, pass.
- `pnpm --filter @bike4mind/client typecheck` (`tsc --noEmit`): **clean**. (Rev 1 recorded 18 pre-existing errors from stale `@bike4mind/common` dist output; with core packages built they do not appear. Either way, none were in these files.)
- `eslint --quiet` on all changed files: 0 errors. Remaining warnings in `Content.tsx` are pre-existing lines (exhaustive-deps at 126/136, `any` at 545); `lint:check` runs `--quiet`, so warnings do not gate.
- `prettier --check` on all changed files: clean.
- Hands-on QA via Playwright MCP on the `pr1012` preview, 2026-07-28, at head `282c7b2e`: **section A passed** (rows never hit 0), **section B failed** (4 reproductions, including real keystrokes), layout fine at 1440px and 430px, one transient WebSocket console error. Sections C9/C10/C12 not reached — the account had 4 files, and pagination needs >=25.

**Not verified**

- **The E2E spec at `03cf2a3f`.** The recorded pass was at `282c7b2e`. Needs a re-run against a preview built from the new head — see D2.
- **Section B on a build containing the fix.** The unit test covers the invariant; nobody has watched the rename survive a search in a browser yet.
- **Sections C12/C13/C18 (pagination).** Still blocked on a >=25-file account. This now covers two control sets rather than one.
- **The unfiltered view's layout after the wrapper change (C14).** Reasoned about, not seen. The wrapper is the one the filtered view already used and QA verified at both widths, and `List`'s root supplies its own `flex: 1; min-height: 0; overflow: hidden`, so scrolling should be unchanged.
- **CI E2E against the preview: impossible today**, and not because of this PR. See D4.
- **Repeat runs (D3): not done.**

**Known limitations, accepted deliberately**

- `findFile`'s response wait can silently spend up to 10s when no network request fires — i.e. the search term is already cached fresh within the hook's 5-minute `staleTime`. Correctness is unaffected (no request means the cached rows are already correct and there is no unmount to race), but it is invisible wall-clock. Guard if it ever bites: skip the wait when `await searchInput.inputValue() === filename`. The current spec searches a distinct term each time, so it does not hit this path.
- The rename-retry false-failure from rev 1 is **fixed**, not accepted. One residual: the early-exit reads the `/renamed/i` toast, so a caller that renames the same file twice inside one test could satisfy it against a stale toast. The only caller (`notebook-files.spec.ts:25`) renames once.
- `isChangingPage` is now computed in two places (`Content.tsx:397` for the toolbar, `List.tsx:71` for the list controls) with cross-referencing comments. Passing one value down would need a third prop on `List`, which already takes `isLoading` and `isPlaceholderData` for its own loader and empty state.

**Out of scope, noticed during triage**

- `Browser/Filter.tsx:14` declares `debounce` at module scope, so the 500ms timer is shared across every mounted `FileBrowserFilter` instance (global browser plus embedded pickers). Typing in one cancels another's pending commit. Unrelated to this failure; deserves its own change.
- `BasePage.handleWhatsNewModal` spends the full `TIMEOUTS.VISIBLE` (10s) in Before Hooks whenever no announcement is live, paid per test across the suite. Deliberate and documented (`BasePage.ts:40-58`), but a large fixed cost if chasing the E2E job's wall-clock.

**Review status**

`claude[bot]` approved `282c7b2e` on 2026-07-27 with three non-blocking follow-ups. All three are addressed in `03cf2a3f`: the `Actions.tsx` pagination signal, the rename-retry false-failure, and the `Content.embedded.test.tsx` mock field.

**PR title:** the commits are scoped `fix(e2e)` then `fix(files)`. The user-facing defects are the search flicker and the lost inline rename, both in the app; `fix(files): keep file-browser rows mounted across search and pagination` describes the branch more accurately in the changelog. Either scope produces a patch bump.

---

## Developer Notes

- **React reconciles by position — the lesson from defect 2.** Rendering the same component from two mutually-exclusive branches is not equivalent to rendering it once with different props. Any state below the switch is destroyed on every flip, silently, and no amount of react-query caching prevents it. If a component holds interactive local state, it needs exactly one render site; gate props and siblings on the condition instead. `Content.tsx:714` carries this as an in-code invariant.
- **`FileBrowserList` prop change:** `isFetching` -> `isPlaceholderData`. The old prop was declared but never read, so nothing was lost. Any future caller wanting a "page/search swap in flight" signal should pass `isPlaceholderData`, not `isFetching`.
- **Which react-query flag gates what:** in a list that keeps previous data, `isLoading` is only the very first load, `isPlaceholderData` means "the rows you see belong to a different key," and `isFetching` is any refetch including background invalidations. Gating interactive controls on `isFetching` in a component whose query is invalidated by WebSocket traffic produces disabled-flicker; this file browser has two such subscriptions.
- **E2E waits against debounced inputs:** filling a debounced input starts no request, so a loader-based wait resolves against pre-filter state. Arm `waitForResponse` before the fill, and match on the decoded query param rather than a URL substring so an in-flight response for a prefix term cannot satisfy the wait.
- **Playwright retry loops around mutations:** widening a retry to cover the mutating action means the loop can re-run something that already succeeded. Check for the success signal before retrying, and use a bounded `waitFor` rather than `isVisible()` (which ignores its `timeout` option) since the request may still be in flight when the click throws.
- **Constraint worth remembering:** any per-row local state in the file browser (rename edit mode, and anything added later) is destroyed by a row remount. Keeping list identity stable across refetches *and* across filter-state changes is what makes such state usable at all.


## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
