### PR TITLE
fix(client): emit absent premium glue when a hydrated overlay is not linked

### DIFF
--- a/apps/client/__tests__/premiumGlueLinking.test.ts
+++ b/apps/client/__tests__/premiumGlueLinking.test.ts
@@ -29,6 +29,19 @@ function runCodegen() {
   return result;
 }
 
+// Explicit per-scenario link state, so neither describe depends on the other
+// having run first. Mirrors a pnpm workspace link: a real package dir (with
+// package.json) reachable from apps/client's node_modules chain.
+function linkOverlay() {
+  const pkgDir = join(clientRoot, 'node_modules', PKG_NAME);
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: PKG_NAME }));
+}
+
+function unlinkOverlay() {
+  rmSync(join(clientRoot, 'node_modules'), { recursive: true, force: true });
+}
+
 beforeAll(() => {
   sandbox = mkdtempSync(join(tmpdir(), 'b4m-glue-test-'));
   clientRoot = join(sandbox, 'apps/client');
@@ -69,11 +82,14 @@ afterAll(() => {
 });
 
 describe('hydrated but UNLINKED overlay', () => {
+  beforeAll(() => {
+    unlinkOverlay();
+  });
+
   it('emits the absent form for bare-specifier glue and warns', () => {
     const { stderr } = runCodegen();
 
-    expect(stderr).toContain('not');
-    expect(stderr).toContain('resolvable from apps/client');
+    expect(stderr).toContain('is not resolvable from apps/client');
 
     const routes = readFileSync(join(clientRoot, 'app/premium-generated/premiumRoutes.generated.ts'), 'utf8');
     expect(routes).not.toContain(PKG_NAME);
@@ -95,14 +111,12 @@ describe('hydrated but UNLINKED overlay', () => {
 
 describe('hydrated AND linked overlay', () => {
   beforeAll(() => {
-    // A plain directory is enough: the script checks resolvability by presence in
-    // the node_modules chain, exactly where pnpm would place the workspace link.
-    mkdirSync(join(clientRoot, 'node_modules', PKG_NAME), { recursive: true });
+    linkOverlay();
   });
 
   it('emits real imports and no warning', () => {
     const { stderr } = runCodegen();
-    expect(stderr).not.toContain('resolvable from apps/client');
+    expect(stderr).not.toContain('is not resolvable from apps/client');
 
     const routes = readFileSync(join(clientRoot, 'app/premium-generated/premiumRoutes.generated.ts'), 'utf8');
     expect(routes).toContain(`from '${PKG_NAME}/routes'`);

--- a/apps/client/__tests__/premiumGlueLinking.test.ts
+++ b/apps/client/__tests__/premiumGlueLinking.test.ts
@@ -57,10 +57,15 @@ beforeAll(() => {
     join(overlayDir, 'package.json'),
     JSON.stringify({
       name: PKG_NAME,
+      exports: {
+        './server/migrations': './src/server/migrations.ts',
+      },
       b4mContributions: {
         spaRoutesExport: `${PKG_NAME}/routes`,
         navItemsExport: `${PKG_NAME}/nav`,
+        notebookSidenavExport: `${PKG_NAME}/sidenav`,
         llmToolsExport: `${PKG_NAME}/tools`,
+        migrationsExport: `${PKG_NAME}/server/migrations`,
         apiRouteStubs: [{ generatedPath: 'pages/api/premium-fakeoverlay/ping.ts', exportFrom: `${PKG_NAME}/api/ping` }],
         serverHandlerStubs: [
           { generatedPath: 'server/premium-generated/fakeoverlay.ts', exportFrom: `${PKG_NAME}/handlers` },
@@ -70,6 +75,8 @@ beforeAll(() => {
     })
   );
   writeFileSync(join(overlayDir, 'src/infra.ts'), 'export function contributeInfra() {}\n');
+  mkdirSync(join(overlayDir, 'src/server'), { recursive: true });
+  writeFileSync(join(overlayDir, 'src/server/migrations.ts'), 'export const migrations = [];\n');
 
   writeFileSync(
     join(sandbox, 'sst.config.ts'),
@@ -98,14 +105,26 @@ describe('hydrated but UNLINKED overlay', () => {
     const tools = readFileSync(join(clientRoot, 'server/premium-generated/premiumLlmTools.generated.ts'), 'utf8');
     expect(tools).not.toContain(PKG_NAME);
 
+    const nav = readFileSync(join(clientRoot, 'app/premium-generated/premiumNavItems.generated.ts'), 'utf8');
+    expect(nav).not.toContain(PKG_NAME);
+    expect(nav).toContain('premiumNavItems: PremiumNavDescriptor[] = []');
+
+    const sidenav = readFileSync(join(clientRoot, 'app/premium-generated/premiumNotebookSidenav.generated.ts'), 'utf8');
+    expect(sidenav).not.toContain(PKG_NAME);
+    expect(sidenav).toContain('premiumNotebookSidenav: PremiumNotebookSidenav = null');
+
     expect(existsSync(join(clientRoot, 'pages/api/premium-fakeoverlay'))).toBe(false);
     expect(existsSync(join(clientRoot, 'server/premium-generated/fakeoverlay.ts'))).toBe(false);
   });
 
-  it('still emits the PRESENT infra glue (relative import needs no link)', () => {
+  it('still emits the PRESENT relative-import glue (infra + migrations need no link)', () => {
     runCodegen();
     const infra = readFileSync(join(sandbox, 'infra/premium-generated/fakeoverlay-infra.generated.ts'), 'utf8');
     expect(infra).toContain(`from '../../packages/premium/fakeoverlay/src/infra'`);
+
+    const migrations = readFileSync(join(sandbox, 'packages/scripts/migrate/migrations/premium.generated.ts'), 'utf8');
+    expect(migrations).toContain('premium/fakeoverlay/src/server/migrations');
+    expect(migrations).not.toContain(PKG_NAME);
   });
 });
 
@@ -120,6 +139,12 @@ describe('hydrated AND linked overlay', () => {
 
     const routes = readFileSync(join(clientRoot, 'app/premium-generated/premiumRoutes.generated.ts'), 'utf8');
     expect(routes).toContain(`from '${PKG_NAME}/routes'`);
+
+    const nav = readFileSync(join(clientRoot, 'app/premium-generated/premiumNavItems.generated.ts'), 'utf8');
+    expect(nav).toContain(`from '${PKG_NAME}/nav'`);
+
+    const sidenav = readFileSync(join(clientRoot, 'app/premium-generated/premiumNotebookSidenav.generated.ts'), 'utf8');
+    expect(sidenav).toContain(`import('${PKG_NAME}/sidenav')`);
 
     const stub = readFileSync(join(clientRoot, 'pages/api/premium-fakeoverlay/ping.ts'), 'utf8');
     expect(stub).toContain(`export { default } from '${PKG_NAME}/api/ping'`);

--- a/apps/client/__tests__/premiumGlueLinking.test.ts
+++ b/apps/client/__tests__/premiumGlueLinking.test.ts
@@ -24,7 +24,10 @@ let script: string;
 let clientRoot: string;
 
 function runCodegen() {
-  const result = spawnSync(process.execPath, [script], { encoding: 'utf8' });
+  // CI is forced off: the script hard-fails a hydrated-but-unlinked tree when
+  // CI === 'true' (pinned by its own test below), and this suite runs the
+  // unlinked scenarios on CI runners where CI=true is ambient.
+  const result = spawnSync(process.execPath, [script], { encoding: 'utf8', env: { ...process.env, CI: '' } });
   expect(result.status, result.stderr).toBe(0);
   return result;
 }
@@ -125,6 +128,12 @@ describe('hydrated but UNLINKED overlay', () => {
     const migrations = readFileSync(join(sandbox, 'packages/scripts/migrate/migrations/premium.generated.ts'), 'utf8');
     expect(migrations).toContain('premium/fakeoverlay/src/server/migrations');
     expect(migrations).not.toContain(PKG_NAME);
+  });
+
+  it('refuses the hydrated-but-unlinked state outright when CI=true', () => {
+    const result = spawnSync(process.execPath, [script], { encoding: 'utf8', env: { ...process.env, CI: 'true' } });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('refusing to emit absent glue');
   });
 });
 

--- a/apps/client/__tests__/premiumGlueLinking.test.ts
+++ b/apps/client/__tests__/premiumGlueLinking.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * End-to-end guard for the codegen's linked/unlinked split.
+ *
+ * A hydrated overlay whose package is NOT linked into node_modules must get the
+ * ABSENT form for all bare-specifier glue (emitting real imports would fail every
+ * typecheck/build with cannot-find-module errors), while infra glue keeps the
+ * PRESENT form (it imports overlay source relatively and needs no link).
+ *
+ * Runs the real script inside a sandbox tree, since its paths derive from its own
+ * location: sandbox/apps/client/scripts/ next to sandbox/packages/premium/.
+ */
+
+const REAL_SCRIPT = join(__dirname, '../scripts/generate-premium-glue.mjs');
+const PKG_NAME = '@bike4mind/premium-fakeoverlay';
+
+let sandbox: string;
+let script: string;
+let clientRoot: string;
+
+function runCodegen() {
+  const result = spawnSync(process.execPath, [script], { encoding: 'utf8' });
+  expect(result.status, result.stderr).toBe(0);
+  return result;
+}
+
+beforeAll(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'b4m-glue-test-'));
+  clientRoot = join(sandbox, 'apps/client');
+  script = join(clientRoot, 'scripts/generate-premium-glue.mjs');
+
+  mkdirSync(join(clientRoot, 'scripts'), { recursive: true });
+  cpSync(REAL_SCRIPT, script);
+  mkdirSync(join(clientRoot, 'pages/api'), { recursive: true });
+
+  const overlayDir = join(sandbox, 'packages/premium/fakeoverlay');
+  mkdirSync(join(overlayDir, 'src'), { recursive: true });
+  writeFileSync(
+    join(overlayDir, 'package.json'),
+    JSON.stringify({
+      name: PKG_NAME,
+      b4mContributions: {
+        spaRoutesExport: `${PKG_NAME}/routes`,
+        navItemsExport: `${PKG_NAME}/nav`,
+        llmToolsExport: `${PKG_NAME}/tools`,
+        apiRouteStubs: [{ generatedPath: 'pages/api/premium-fakeoverlay/ping.ts', exportFrom: `${PKG_NAME}/api/ping` }],
+        serverHandlerStubs: [
+          { generatedPath: 'server/premium-generated/fakeoverlay.ts', exportFrom: `${PKG_NAME}/handlers` },
+        ],
+        infra: true,
+      },
+    })
+  );
+  writeFileSync(join(overlayDir, 'src/infra.ts'), 'export function contributeInfra() {}\n');
+
+  writeFileSync(
+    join(sandbox, 'sst.config.ts'),
+    `await import('./infra/premium-generated/fakeoverlay-infra.generated');\n`
+  );
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe('hydrated but UNLINKED overlay', () => {
+  it('emits the absent form for bare-specifier glue and warns', () => {
+    const { stderr } = runCodegen();
+
+    expect(stderr).toContain('not');
+    expect(stderr).toContain('resolvable from apps/client');
+
+    const routes = readFileSync(join(clientRoot, 'app/premium-generated/premiumRoutes.generated.ts'), 'utf8');
+    expect(routes).not.toContain(PKG_NAME);
+    expect(routes).toContain('premiumRoutes: PremiumRouteDescriptor[] = []');
+
+    const tools = readFileSync(join(clientRoot, 'server/premium-generated/premiumLlmTools.generated.ts'), 'utf8');
+    expect(tools).not.toContain(PKG_NAME);
+
+    expect(existsSync(join(clientRoot, 'pages/api/premium-fakeoverlay'))).toBe(false);
+    expect(existsSync(join(clientRoot, 'server/premium-generated/fakeoverlay.ts'))).toBe(false);
+  });
+
+  it('still emits the PRESENT infra glue (relative import needs no link)', () => {
+    runCodegen();
+    const infra = readFileSync(join(sandbox, 'infra/premium-generated/fakeoverlay-infra.generated.ts'), 'utf8');
+    expect(infra).toContain(`from '../../packages/premium/fakeoverlay/src/infra'`);
+  });
+});
+
+describe('hydrated AND linked overlay', () => {
+  beforeAll(() => {
+    // A plain directory is enough: the script checks resolvability by presence in
+    // the node_modules chain, exactly where pnpm would place the workspace link.
+    mkdirSync(join(clientRoot, 'node_modules', PKG_NAME), { recursive: true });
+  });
+
+  it('emits real imports and no warning', () => {
+    const { stderr } = runCodegen();
+    expect(stderr).not.toContain('resolvable from apps/client');
+
+    const routes = readFileSync(join(clientRoot, 'app/premium-generated/premiumRoutes.generated.ts'), 'utf8');
+    expect(routes).toContain(`from '${PKG_NAME}/routes'`);
+
+    const stub = readFileSync(join(clientRoot, 'pages/api/premium-fakeoverlay/ping.ts'), 'utf8');
+    expect(stub).toContain(`export { default } from '${PKG_NAME}/api/ping'`);
+
+    expect(existsSync(join(clientRoot, 'server/premium-generated/fakeoverlay.ts'))).toBe(true);
+  });
+});

--- a/apps/client/__tests__/premiumMigrationsCodegenNoSources.test.ts
+++ b/apps/client/__tests__/premiumMigrationsCodegenNoSources.test.ts
@@ -34,12 +34,15 @@ let root: string;
 
 function runCodegen(): { ok: boolean; output: string } {
   try {
+    // CI forced off: this suite's overlays are hydrated but never linked, the
+    // state the script hard-fails when CI === 'true' (ambient on CI runners).
     return {
       ok: true,
       output: execFileSync('node', [join(root, 'apps/client/scripts/generate-premium-glue.mjs')], {
         cwd: root,
         encoding: 'utf8',
         stdio: 'pipe',
+        env: { ...process.env, CI: '' },
       }),
     };
   } catch (e) {

--- a/apps/client/scripts/generate-premium-glue.mjs
+++ b/apps/client/scripts/generate-premium-glue.mjs
@@ -16,7 +16,21 @@
  *   SPA/nav   -> emit the file with an empty exported array
  *   API/handler stubs -> emit ZERO files (no file = no import of absent package)
  *
+ * A package that is hydrated but NOT resolvable from apps/client (no node_modules
+ * link) gets the ABSENT form for all bare-specifier glue, with a warning. Emitting
+ * real imports for an unlinked package fails typecheck/build repo-wide, which is
+ * worse than the overlay's features being un-wired until it is linked.
+ *
+ * Relative-import glue (infra + migrations) is exempt: it imports overlay source by
+ * relative path and needs no link. Note: infra glue itself is link-independent, but
+ * the handler stubs it references (from generateServerHandlerStubs) are bare-specifier
+ * and therefore omitted in the unlinked case. This is caught at deploy/bundle time
+ * rather than silently, and CI builds are always linked.
+ *
  * Run by: pnpm codegen (or automatically via predev/prebuild scripts)
+ * The turbo codegen task is cache:false - output depends on node_modules link state,
+ * which no turbo input glob can capture. codegen itself always re-runs; dependents
+ * are unaffected because both link states typecheck clean.
  * Turbo cache key: packages/premium/*\/package.json
  */
 
@@ -51,6 +65,15 @@ function discoverPremiumPackages() {
     }
   }
   return packages;
+}
+
+// Node resolves a bare specifier from apps/client by walking node_modules up the
+// tree, so the package must be linked at one of these roots. Being hydrated under
+// packages/premium/ is not enough: pnpm only links workspace packages somewhere a
+// package.json declares them.
+function isLinkedIntoClient(pkgName) {
+  const segments = pkgName.split('/');
+  return [CLIENT_ROOT, REPO_ROOT].some(root => existsSync(join(root, 'node_modules', ...segments)));
 }
 
 // --- Generate helpers ---
@@ -638,13 +661,39 @@ export function contributeInfra(_params: Record<string, unknown>): void {}
 const packages = discoverPremiumPackages();
 console.log(`[codegen] found ${packages.length} premium package(s): ${packages.map(p => p.name).join(', ') || '(none)'}`);
 
+// Bare-specifier glue only for packages that will actually resolve. Unlinked
+// packages get the absent form so a hydrated-but-unlinked tree still typechecks,
+// instead of failing every build with cannot-find-module errors.
+const linkedPackages = [];
+for (const pkg of packages) {
+  if (isLinkedIntoClient(pkg.name)) { linkedPackages.push(pkg); continue; }
+  console.warn(
+    `[codegen] WARNING: packages/premium/${pkg.dir} is hydrated but "${pkg.name}" is not ` +
+      `resolvable from apps/client (no node_modules link). Emitting the ABSENT form for its ` +
+      `route/nav/API/tool glue so typecheck and builds stay green - its features will NOT be ` +
+      `wired. Link it (declare it in apps/client dependencies, or symlink packages/premium/` +
+      `${pkg.dir} to node_modules/${pkg.name}) and re-run: pnpm codegen`
+  );
+}
+
+// In CI, a hydrated-but-unlinked overlay means the pipeline would ship with features
+// silently un-wired (console.warn inside a turbo/Actions log is not a control).
+// Fail hard so the link breakage surfaces as a red pipeline, not a quiet regression.
+if (linkedPackages.length < packages.length && process.env.CI === 'true') {
+  console.error('[codegen] refusing to emit absent glue for a hydrated-but-unlinked overlay in CI');
+  process.exit(1);
+}
+
 ensureDir(GENERATED_DIR);
-generateSpaRoutes(packages);
-generateNavItems(packages);
-generateNotebookSidenav(packages);
-generateApiStubs(packages);
-generateServerHandlerStubs(packages);
-generateLlmTools(packages);
+// Bare-specifier glue: linked packages only (an unresolvable import fails every build).
+generateSpaRoutes(linkedPackages);
+generateNavItems(linkedPackages);
+generateNotebookSidenav(linkedPackages);
+generateApiStubs(linkedPackages);
+generateServerHandlerStubs(linkedPackages);
+generateLlmTools(linkedPackages);
+// Relative-import glue: needs no node_modules link, so it gets the full list.
+// Any NEW generator goes in whichever group matches how it imports the overlay.
 generateMigrations(packages);
 generateInfraGlue(packages);
 

--- a/apps/client/scripts/generate-premium-glue.mjs
+++ b/apps/client/scripts/generate-premium-glue.mjs
@@ -31,7 +31,6 @@
  * The turbo codegen task is cache:false - output depends on node_modules link state,
  * which no turbo input glob can capture. codegen itself always re-runs; dependents
  * are unaffected because both link states typecheck clean.
- * Turbo cache key: packages/premium/*\/package.json
  */
 
 import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, renameSync } from 'node:fs';
@@ -73,7 +72,11 @@ function discoverPremiumPackages() {
 // package.json declares them.
 function isLinkedIntoClient(pkgName) {
   const segments = pkgName.split('/');
-  return [CLIENT_ROOT, REPO_ROOT].some(root => existsSync(join(root, 'node_modules', ...segments)));
+  // Check for package.json, not just the dir: an empty/broken dir would satisfy
+  // existsSync while still failing real module resolution.
+  return [CLIENT_ROOT, REPO_ROOT].some(root =>
+    existsSync(join(root, 'node_modules', ...segments, 'package.json'))
+  );
 }
 
 // --- Generate helpers ---

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,10 @@
   "globalPassThroughEnv": ["NODE_OPTIONS"],
   "tasks": {
     "codegen": {
+      // Not cacheable: output depends on node_modules link state (which overlay
+      // packages resolve), which no input glob can capture. A cache replay would
+      // restore glue for the WRONG link state. The script is sub-second.
+      "cache": false,
       "inputs": [
         "scripts/generate-premium-glue.mjs",
         "../../packages/premium/*/package.json",


### PR DESCRIPTION
Addresses the second-order problem in #963: a hydrated overlay whose package is not linked into node_modules made the premium glue emit real bare-specifier imports that cannot resolve, producing repo-wide cannot-find-module typecheck errors that fail the pre-push hook and block pushing unrelated work. The documented workaround was a manual symlink a contributor has to discover.

## What changed

`generate-premium-glue.mjs` now checks, per discovered overlay package, whether its bare specifier is actually resolvable from apps/client (a node_modules link at the client or repo root, exactly where Node's resolution walks). The split:

- **Linked** (the working state, including official CI): behavior is byte-for-byte unchanged.
- **Hydrated but unlinked** (the broken state): the six bare-specifier generators (SPA routes, nav items, notebook sidenav, API stubs, server handler stubs, LLM tools) emit their ABSENT form, and the script prints one loud warning per package saying the overlay's features are not wired and exactly how to link it. Typecheck and builds stay green.
- **Infra glue is exempt** and keeps the full package list: it imports overlay source by relative path (the esbuild symlink workaround already in place), so it works without a link.

The rationale lives in the script header: real imports for an unlinked package fail every build in the tree, which is strictly worse than the overlay being un-wired until linked.

## Verification

- New end-to-end test (`__tests__/premiumGlueLinking.test.ts`) runs the real script inside a sandbox tree with a fake hydrated overlay: unlinked asserts absent-form glue + warning + present-form infra glue; linked asserts real imports, API stub emission, and no warning. 3/3 passing.
- Existing infra drift guard: 13/13 passing.
- Ran the script on this (unhydrated) checkout: output identical to before, `found 0 premium package(s)`.
- eslint clean on both files.

## Not in this PR

The remaining #963 asks: hydration-mechanism documentation, the workspace-glob gating decision, and a tracked-file CI guard for `packages/premium/` paths. The lockfile guard itself already landed in #992.
