### PR TITLE
test(data-lakes): guard public-browse offset paging

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeDiscoverPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeDiscoverPanel.test.tsx
@@ -137,12 +137,13 @@ describe('DataLakeDiscoverPanel', () => {
     expect(useBrowsePublicDataLakes).toHaveBeenLastCalledWith('sales');
   });
 
-  it('fetches the next page on Load more only while there is one, and never grows the request', async () => {
+  it('calls fetchNextPage once when Load more is clicked, passing only the search term to the hook', async () => {
     mockHook({ hasNextPage: true });
     render(<DataLakeDiscoverPanel />, { wrapper: TestWrapper });
 
-    // The hook is always called with just the search term - Load more advances offset internally,
-    // so a deep load-more can never push `limit` past the route cap (the bug this guards against).
+    // The browse hook is mocked in this file, so limit/offset are not observable here - this
+    // asserts only the panel's half of the contract: search term in, one fetchNextPage out.
+    // The fixed-limit offset paging itself is guarded in app/hooks/data/dataLakes.test.ts.
     expect(useBrowsePublicDataLakes).toHaveBeenLastCalledWith('');
     await userEvent.click(screen.getByTestId('datalake-discover-load-more'));
     expect(fetchNextPage).toHaveBeenCalledTimes(1);

--- a/apps/client/app/hooks/data/dataLakes.test.ts
+++ b/apps/client/app/hooks/data/dataLakes.test.ts
@@ -116,11 +116,11 @@ describe('useBrowsePublicDataLakes', () => {
     const limits = requestedUrls().map(url => paramsOf(url).get('limit'));
     const offsets = requestedUrls().map(url => paramsOf(url).get('offset'));
 
-    expect(limits).toEqual(['24', '24', '24']);
     // The old bug summed the page size into `limit` (24 -> 48 -> 72), so the THIRD load-more blew
-    // past the route's max of 60. Assert the cap itself, not just equality, so the failure names
-    // the real consequence.
+    // past the route's max of 60 (public.ts:12). Assert the cap itself, before the exact-equality
+    // check below, so a regression fails on the real consequence rather than on equality alone.
     limits.forEach(limit => expect(Number(limit)).toBeLessThanOrEqual(60));
+    expect(limits).toEqual(['24', '24', '24']);
     expect(offsets).toEqual(['0', '24', '48']);
   });
 

--- a/apps/client/app/hooks/data/dataLakes.test.ts
+++ b/apps/client/app/hooks/data/dataLakes.test.ts
@@ -1,0 +1,149 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { BrowsePublicDataLakesResult, PublicDataLakeSummary } from '@bike4mind/common';
+
+/**
+ * Offset paging for the public-lake discovery catalog. The regression this guards: `limit` used
+ * to grow with each load-more (24 -> 48 -> 72), so the third click exceeded the route's max-limit
+ * cap of 60 (pages/api/data-lakes/public.ts) and 422'd. `limit` must stay fixed and `offset` must
+ * be what advances. 24 and 60 are deliberately literal here rather than imported from the hook /
+ * the route - a self-referential assertion could not observe the regression.
+ */
+
+const apiGet = vi.fn();
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: (...args: unknown[]) => apiGet(...args) },
+}));
+// dataLakes.ts value-imports these at module load for its OTHER hooks; the browse hook touches
+// none of them, and AccountSelector alone would pull in MUI Joy plus two React contexts.
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() } }));
+vi.mock('@client/app/components/Credits/AccountSelector', () => ({
+  useSelectedAccount: { getState: () => ({ selectedAccount: undefined }) },
+}));
+vi.mock('@client/app/hooks/useGearsStatus', () => ({ invalidateGearsStatusWhileLocked: () => {} }));
+
+import { useBrowsePublicDataLakes } from './dataLakes';
+
+const PAGE_SIZE = 24;
+
+const summary = (id: string): PublicDataLakeSummary => ({
+  id,
+  slug: `lake-${id}`,
+  name: `Lake ${id}`,
+  fileTagPrefix: 'lake:',
+  fileCount: 0,
+  totalSizeBytes: 0,
+  isOwn: false,
+  canManage: false,
+});
+
+// api.get is axios-shaped, so the payload is double-nested: { data: { data, total } }.
+const pageResponse = (count: number, total: number, startAt = 0): { data: BrowsePublicDataLakesResult } => ({
+  data: {
+    data: Array.from({ length: count }, (_, i) => summary(`lk${startAt + i}`)),
+    total,
+  },
+});
+
+const mountBrowse = (initialSearch = '') => {
+  // A fresh client per mount - a shared one would serve the next test from cache and fire no request.
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return renderHook(({ search }: { search: string }) => useBrowsePublicDataLakes(search), {
+    wrapper,
+    initialProps: { search: initialSearch },
+  });
+};
+
+const requestedUrls = (): string[] => apiGet.mock.calls.map(call => call[0] as string);
+const paramsOf = (url: string) => new URL(url, 'http://test.local').searchParams;
+
+describe('useBrowsePublicDataLakes', () => {
+  beforeEach(() => {
+    // mockReset (not mockClear) so a previous test's mockResolvedValueOnce queue cannot leak.
+    apiGet.mockReset();
+    apiGet.mockResolvedValue(pageResponse(PAGE_SIZE, 100));
+  });
+
+  it('requests the first page at a fixed limit and offset 0', async () => {
+    const { result } = mountBrowse('');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(requestedUrls()).toEqual(['/api/data-lakes/public?limit=24&offset=0']);
+  });
+
+  it('trims the search term and sends it as q', async () => {
+    const { result } = mountBrowse('  sales  ');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(requestedUrls()[0]).toBe('/api/data-lakes/public?q=sales&limit=24&offset=0');
+  });
+
+  it('omits q entirely for a whitespace-only search', async () => {
+    const { result } = mountBrowse('   ');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(paramsOf(requestedUrls()[0]).has('q')).toBe(false);
+  });
+
+  it('advances offset, not limit, on the second page', async () => {
+    const { result } = mountBrowse('');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(2));
+    expect(requestedUrls()[1]).toBe('/api/data-lakes/public?limit=24&offset=24');
+  });
+
+  it('keeps limit fixed across a deep load-more', async () => {
+    apiGet
+      .mockResolvedValueOnce(pageResponse(PAGE_SIZE, 100, 0))
+      .mockResolvedValueOnce(pageResponse(PAGE_SIZE, 100, 24))
+      .mockResolvedValueOnce(pageResponse(PAGE_SIZE, 100, 48));
+
+    const { result } = mountBrowse('');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(3));
+
+    const limits = requestedUrls().map(url => paramsOf(url).get('limit'));
+    const offsets = requestedUrls().map(url => paramsOf(url).get('offset'));
+
+    expect(limits).toEqual(['24', '24', '24']);
+    // The old bug summed the page size into `limit` (24 -> 48 -> 72), so the THIRD load-more blew
+    // past the route's max of 60. Assert the cap itself, not just equality, so the failure names
+    // the real consequence.
+    limits.forEach(limit => expect(Number(limit)).toBeLessThanOrEqual(60));
+    expect(offsets).toEqual(['0', '24', '48']);
+  });
+
+  it('stops paging once the loaded count reaches the total', async () => {
+    apiGet.mockResolvedValue(pageResponse(10, 10));
+    const { result } = mountBrowse('');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.hasNextPage).toBe(false);
+    expect(apiGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('restarts at offset 0 when the search term changes', async () => {
+    const { result, rerender } = mountBrowse('');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(2));
+
+    rerender({ search: 'sales' });
+    // keepPreviousData holds the prior pages for a tick, so gate on the recorded request rather
+    // than on result.current.data.
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(3));
+    expect(requestedUrls()[2]).toBe('/api/data-lakes/public?q=sales&limit=24&offset=0');
+  });
+});

--- a/apps/client/pages/api/data-lakes/__tests__/public.test.ts
+++ b/apps/client/pages/api/data-lakes/__tests__/public.test.ts
@@ -141,7 +141,8 @@ describe('GET /api/data-lakes/public - search and pass-through', () => {
 
   it('passes the repositories through by identity', async () => {
     await route(makeReq({}), makeRes());
-    expect(browseArgs()[2]).toEqual({ db: { dataLakes: LAKES_REPO, users: USERS_REPO } });
+    expect(browseArgs()[2].db.dataLakes).toBe(LAKES_REPO);
+    expect(browseArgs()[2].db.users).toBe(USERS_REPO);
   });
 
   it('returns the service result as JSON', async () => {

--- a/apps/client/pages/api/data-lakes/__tests__/public.test.ts
+++ b/apps/client/pages/api/data-lakes/__tests__/public.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Query-validation bounds for GET /api/data-lakes/public. The route parses with
+ * BrowseQuery.parse, so a bad query REJECTS the handler promise; turning that into a 422 is
+ * errorHandler's job (server/middlewares/errorHandler.ts), and the baseApi mock below replaces
+ * the chain that wires it, so no status is observable here. What this pins at this seam: a
+ * rejected query never reaches the service, and an accepted one arrives coerced.
+ */
+
+const { mockBrowse, LAKES_REPO, USERS_REPO } = vi.hoisted(() => ({
+  mockBrowse: vi.fn(),
+  // Distinguishable sentinels so the adapter case can assert identity pass-through.
+  LAKES_REPO: { __tag: 'dataLakeRepository' },
+  USERS_REPO: { __tag: 'userRepository' },
+}));
+
+// The route is baseApi().use(...).get(fn), so `use` must return the chain and `get` returns the
+// raw handler - which makes the module's default export the handler itself.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const chain: Record<string, unknown> = {};
+    chain.use = () => chain;
+    chain.get = (fn: unknown) => fn;
+    return chain;
+  },
+}));
+vi.mock('@server/middlewares/featureFlag', () => ({
+  requireFeatureEnabled: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock('@bike4mind/services', () => ({ dataLakeService: { browsePublicDataLakes: mockBrowse } }));
+vi.mock('@bike4mind/database', () => ({ dataLakeRepository: LAKES_REPO, userRepository: USERS_REPO }));
+
+import handler from '@pages/api/data-lakes/public';
+
+type RouteHandler = (req: unknown, res: unknown) => Promise<unknown>;
+const route = handler as unknown as RouteHandler;
+
+const EMPTY_RESULT = { data: [], total: 0 };
+
+// `query` is always passed, even when empty: BrowseQuery.parse(undefined) throws its own
+// invalid_type error, which would satisfy a rejection assertion for the wrong reason.
+const makeReq = (query: Record<string, string | string[]>, user: Record<string, unknown> = { id: 'u1' }) => ({
+  query,
+  user,
+});
+
+const makeRes = () => {
+  const res: Record<string, unknown> = {};
+  res.json = vi.fn(() => res);
+  return res as { json: ReturnType<typeof vi.fn> };
+};
+
+/** The three positional args the route passes to browsePublicDataLakes: (actor, opts, adapters). */
+const browseArgs = () => mockBrowse.mock.calls[0];
+const browseOpts = () => browseArgs()[1] as { search?: unknown; limit?: unknown; offset?: unknown };
+
+const expectRejected = async (query: Record<string, string | string[]>, field: string) => {
+  await expect(route(makeReq(query), makeRes())).rejects.toMatchObject({
+    name: 'ZodError',
+    issues: expect.arrayContaining([expect.objectContaining({ path: [field] })]),
+  });
+  expect(mockBrowse).not.toHaveBeenCalled();
+};
+
+describe('GET /api/data-lakes/public - query bounds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBrowse.mockResolvedValue(EMPTY_RESULT);
+  });
+
+  it('rejects a limit above the cap', () => expectRejected({ limit: '61' }, 'limit'));
+
+  // Number('abc') is NaN, so zod's base number gate rejects it before .int()/.min()/.max() run.
+  it('rejects a non-numeric limit', () => expectRejected({ limit: 'abc' }, 'limit'));
+
+  it('rejects a limit below the minimum', () => expectRejected({ limit: '0' }, 'limit'));
+
+  it('rejects a fractional limit', () => expectRejected({ limit: '10.5' }, 'limit'));
+
+  it('rejects a negative offset', () => expectRejected({ offset: '-1' }, 'offset'));
+
+  it('rejects a search term over the length cap', () => expectRejected({ q: 'x'.repeat(201) }, 'q'));
+
+  it('accepts the cap itself - the bound is inclusive', async () => {
+    await route(makeReq({ limit: '60', offset: '0' }), makeRes());
+    expect(browseOpts()).toEqual({ search: undefined, limit: 60, offset: 0 });
+  });
+
+  // .optional() short-circuits on undefined before coercion runs, so an absent limit stays
+  // undefined rather than becoming Number(undefined) === NaN.
+  it('leaves absent paging params undefined rather than coercing them', async () => {
+    await route(makeReq({}), makeRes());
+    expect(browseOpts().limit).toBeUndefined();
+    expect(browseOpts().offset).toBeUndefined();
+  });
+
+  it('coerces query strings to numbers', async () => {
+    await route(makeReq({ limit: '24', offset: '24' }), makeRes());
+    expect(browseOpts()).toEqual({ search: undefined, limit: 24, offset: 24 });
+    expect(typeof browseOpts().limit).toBe('number');
+    expect(typeof browseOpts().offset).toBe('number');
+  });
+
+  // Number('') is 0, which clears .min(0) - asymmetric with an empty limit, which fails .min(1).
+  it('accepts an empty offset as 0', async () => {
+    await route(makeReq({ offset: '' }), makeRes());
+    expect(browseOpts().offset).toBe(0);
+  });
+});
+
+describe('GET /api/data-lakes/public - search and pass-through', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBrowse.mockResolvedValue(EMPTY_RESULT);
+  });
+
+  it('trims the search term', async () => {
+    await route(makeReq({ q: '  sales  ' }), makeRes());
+    expect(browseOpts().search).toBe('sales');
+  });
+
+  it('forwards an absent q as undefined', async () => {
+    await route(makeReq({}), makeRes());
+    expect(browseOpts().search).toBeUndefined();
+  });
+
+  // An empty q is a valid string here, so the route forwards ''. The empty search is dropped
+  // downstream at the repository (packages/database/src/models/ai/DataLakeModel.ts, where a
+  // falsy trimmed search adds no regex clause), not in this file.
+  it('forwards an empty q as an empty string', async () => {
+    await route(makeReq({ q: '' }), makeRes());
+    expect(browseOpts().search).toBe('');
+  });
+
+  it('passes a non-admin caller through as isAdmin false, not undefined', async () => {
+    await route(makeReq({}, { id: 'u1' }), makeRes());
+    expect(browseArgs()[0]).toEqual({ userId: 'u1', isAdmin: false });
+  });
+
+  it('passes the repositories through by identity', async () => {
+    await route(makeReq({}), makeRes());
+    expect(browseArgs()[2]).toEqual({ db: { dataLakes: LAKES_REPO, users: USERS_REPO } });
+  });
+
+  it('returns the service result as JSON', async () => {
+    const result = { data: [], total: 7 };
+    mockBrowse.mockResolvedValue(result);
+    const res = makeRes();
+    await route(makeReq({}), res);
+    expect(res.json).toHaveBeenCalledWith(result);
+  });
+});


### PR DESCRIPTION
## Summary

- Add hook coverage for `useBrowsePublicDataLakes` that pins the fixed-`limit` / growing-`offset` paging contract and reproduces the original regression (limit summing into the page size) if it recurs.
- Add route coverage for `GET /api/data-lakes/public` query-validation bounds (`limit`/`offset`/`q` min/max/coercion, and pass-through to the service).
- Retitle one panel test and rewrite its comment where it claimed to observe something the mocked hook makes unobservable.

Test-only change; no production code touched.

## Test plan

- [x] `pnpm --filter @bike4mind/client test` - full client suite green
- [x] `pnpm turbo:typecheck` - clean (new `*.test.ts` files are outside `tsc`'s scope; the suite run is the real correctness gate on them)
- [x] `pnpm lint:check` - clean
- [x] Reverted `useBrowsePublicDataLakes`'s paging fix locally, confirmed the new hook tests go red, restored the file