### PR TITLE
test(agents): assert parallel tool execution by log ordering, not wall clock

### DIFF
--- a/b4m-core/agents/src/ReActAgent.parallel.test.ts
+++ b/b4m-core/agents/src/ReActAgent.parallel.test.ts
@@ -109,20 +109,26 @@ describe('ReActAgent Parallel Execution Integration', () => {
 
       const agent = new ReActAgent(context);
 
-      const startTime = Date.now();
       const result = await agent.run('Test query', {
         parallelExecution: true,
       });
-      const duration = Date.now() - startTime;
 
       // All tools should have been called
       expect(tool1.toolFn).toHaveBeenCalledTimes(1);
       expect(tool2.toolFn).toHaveBeenCalledTimes(1);
       expect(tool3.toolFn).toHaveBeenCalledTimes(1);
 
-      // Parallel execution should be faster than sequential
-      // Sequential would take ~150ms (3 * 50ms), parallel should be ~50-60ms
-      expect(duration).toBeLessThan(TOOL_DELAY * 2.5);
+      // Concurrency means every tool starts before any of them finishes; sequential
+      // execution interleaves start/end pairs instead. Asserted on executionLog order
+      // (as the sibling tests below do) rather than elapsed time: a wall-clock threshold
+      // has to separate ~50ms from ~150ms, which CI contention routinely erases, and it
+      // cannot distinguish real concurrency from tools that merely ran fast.
+      const firstEndIndex = executionLog.findIndex(entry => entry.startsWith('end:'));
+      // Guard the -1 miss explicitly: slice(0, -1) would silently mean "all but the last
+      // entry" and the count below would then fail for the wrong reason.
+      expect(firstEndIndex).toBeGreaterThan(-1);
+      const startsBeforeFirstEnd = executionLog.slice(0, firstEndIndex).filter(e => e.startsWith('start:'));
+      expect(startsBeforeFirstEnd).toHaveLength(3);
 
       expect(result.finalAnswer).toBe('Done');
       expect(result.completionInfo.toolCalls).toBe(3);

--- a/b4m-core/agents/src/toolParallelizer.test.ts
+++ b/b4m-core/agents/src/toolParallelizer.test.ts
@@ -435,12 +435,16 @@ describe('toolParallelizer (agents package)', () => {
     });
   });
 
-  describe('timing verification', () => {
-    it('should complete parallel execution faster than sequential would', async () => {
+  describe('concurrency verification', () => {
+    it('should overlap the parallel batch rather than serializing it', async () => {
       const TOOL_DELAY = 50;
+      const TOOL_NAMES = ['tool_a', 'tool_b', 'tool_c'];
+      const executionLog: string[] = [];
 
-      const executor = vi.fn(async () => {
+      const executor = vi.fn(async (tool: ToolUseInfo) => {
+        executionLog.push(`start:${tool.name}`);
         await new Promise(r => setTimeout(r, TOOL_DELAY));
+        executionLog.push(`end:${tool.name}`);
         return 'result';
       });
 
@@ -454,12 +458,13 @@ describe('toolParallelizer (agents package)', () => {
         originalOrder: ['tool_a_"{}"', 'tool_b_"{}"', 'tool_c_"{}"'],
       };
 
-      const start = Date.now();
       await executeToolsInParallel(plan, executor);
-      const duration = Date.now() - start;
 
-      // Sequential would be ~150ms, parallel should be ~50ms
-      expect(duration).toBeLessThan(TOOL_DELAY * 2);
+      // Every tool starts before any finishes; a serialized batch would log start/end
+      // in pairs. Asserting the ordering keeps this immune to loaded-runner jitter.
+      const lastStart = Math.max(...TOOL_NAMES.map(name => executionLog.indexOf(`start:${name}`)));
+      const firstEnd = Math.min(...TOOL_NAMES.map(name => executionLog.indexOf(`end:${name}`)));
+      expect(lastStart).toBeLessThan(firstEnd);
     });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Closes #1011, which documents the problem in full - this takes its **preferred** option ("assert interleaving, not duration").

`ReActAgent.parallel.test.ts:125` asserted parallel execution by wall clock: `expect(duration).toBeLessThan(TOOL_DELAY * 2.5)` (125ms). As #1011 notes, `duration` spans the whole `agent.run()` call, not just the 50ms tool phase, so runner jitter eats the headroom and the test fails while execution genuinely was parallel.

Two additions from digging into the CI history, since they change how the fix should be judged:

**1. There is no threshold that works.** Not "the budget is too tight" - the measurement itself is unusable:

- Observed parallel-under-contention reaches **234ms** (run 30242366030). Sequential-unloaded measures **~154ms** locally. The ranges overlap, so any budget loose enough to stop flaking (>234ms) would also pass a fully sequential implementation, making the test vacuous.
- Failure does not correlate with slowness. The same file's duration on **passing** runs: 725/754/762/767/769/808/**813**/**833**ms. On **failing** runs: **779**/**787**/**803**/839/871/879ms. Passing runs are often slower than failing ones, so this is momentary jitter inside the measured window, not a slow environment. Nothing tunable.

This rules out option 2 in #1011 (a tighter phase-scoped bound) on evidence rather than preference.

**2. It happens more than the failure list suggests - 8 known occurrences.** Re-running a failed job flips the run's conclusion to `success`, which hides the original flake:

| Run | Event | Assertion |
|---|---|---|
| 30237310309 | pull_request (#979) | expected 131 to be less than 125 |
| 30237255800 | **merge_group** | expected 131 to be less than 125 |
| 30242366030 | push main | expected 234 to be less than 125 |
| 30242721707 | pull_request | expected 139 to be less than 125 |
| 30243728787 | pull_request (#977) | expected 144 to be less than 125 |
| 30253919211 | push main | expected 129 to be less than 125 |
| 30255825127 | pull_request | expected 135 to be less than 125 |
| 30257740677 **attempt 1** | pull_request | expected 131 to be less than 125 (hidden - attempt 2 went green) |

That is **33% of all CI failures** in the last 120 runs, and a floor rather than a rate, since any other re-run-to-green is invisible the same way. Two consequences worth naming:

- The `merge_group` hit **ejected PR #764 from the merge queue** - an unrelated Slack `any`-removal refactor, approved and CLEAN. `github-merge-queue[bot]` removed it 14 minutes after it was queued.
- It reds `main` directly (two occurrences above).

Earliest sighting I found is @jjmarfa on #807 (2026-07-24), correctly dismissing it as "an unrelated flaky timing assertion... not attributed to this PR" - three days before it was filed as an issue. That is exactly the re-run reflex #1011 warns about.

## Changes

- `ReActAgent.parallel.test.ts` - replace the wall-clock assertion with an `executionLog` ordering assertion: under real concurrency all three tools log `start` before any logs `end`; sequential execution interleaves `start`/`end` pairs. This is the pattern the sibling tests in this file already use (`:207-212`, `:250`, `:329`, `:360`, `:414`), so the file is now internally consistent.
- Explicit `expect(firstEndIndex).toBeGreaterThan(-1)` guard. Without it, a `findIndex` miss makes `slice(0, -1)` mean "all but the last entry" and the count fails for the wrong reason - correct outcome, wrong reason, which is not good enough for a test whose job is precision.

**Answering the open question in #1011** ("the second wall-clock assertion around line 177 should get the same treatment if it has one"): checked, and there isn't one. I read all 1075 lines and grepped every `Date.now` / `duration` / `toBeLessThan` / `setTimeout` occurrence. The `TOOL_DELAY = 30` block at `:177` already asserts via `executionLog` indices at `:207-212`. Line 125 was the only wall-clock assertion in the file, so this one-place change covers it.

## Guide for Testers

No product behavior changes - this is a test-only change to a test that was failing on noise. Nothing to exercise in a browser or preview.

Verification is CI itself:

1. Confirm all checks pass on this PR, in particular **Run Tests (misc)**.
2. Confirm `b4m-core/agents` reports **411 passed**.

Regression check (optional, local):

1. `pnpm turbo:core:build`
2. `cd b4m-core/agents && npx vitest run src/ReActAgent.parallel.test.ts`
3. Expected: **23 passed**, including `should execute multiple read-only tools in parallel`.

### What NOT to test

- No UI, API, or runtime path is touched. The only changed file is a `.test.ts`.
- Do not try to reproduce the original flake locally - I could not, and that is expected (see below).

## Additional Information

**Verification performed:**

- Empirical log ordering, 8/8 runs identical: parallel produces `start,start,start,end,end,end`; sequential produces `start,end,start,end,start,end`. The new assertion reads 3 vs 1.
- **Mutation-tested against the real implementation.** Serializing the parallel batch in `toolParallelizer.ts` (awaiting `executor` inline) **fails** the test; forcing `shouldUseParallelExecution` to return false **fails** it. So the assertion still guards real concurrency, not just the option flag.
- One mutant deliberately survives and should: collecting already-in-flight promises serially (`Promise.allSettled` -> a loop) keeps genuine concurrency, because `.map(async ...)` starts all three eagerly. The test constrains concurrency, not the collection mechanism - correct scope.
- `b4m-core/agents` 411/411 across 5 runs (incl. `VITEST_MAX_WORKERS=2`), `pnpm turbo:typecheck` 40/40, `pnpm lint:check` exit 0. `TOOL_DELAY` is still used by `createTimedTool`, so no unused-variable break.

**Why the new assertion cannot flake:** it depends on macrotask ordering, not elapsed time. All three `start:` pushes happen in one synchronous `.map()` pass before any 50ms timer callback can run, so a late timer cannot reorder start-before-end. Any condition capable of breaking it would also have broken the old assertion - strictly more robust, never less.

**Not verified:** I could not reproduce the original flake locally - not under 22x CPU saturation (40/40 passed, 50-52ms), not across 4 constrained full-suite rounds, and not with the exact `misc`-shard command. That shard runs **12 packages** at `workspace-concurrency=4` x `workers: 25%` on a 4-core hosted runner; an 11-core dev box has too much headroom. So confidence rests on the 8 CI occurrences plus the mechanism, not on a local repro.

## Developer Notes (Optional)

- **Pattern:** prefer asserting the observable *property* (ordering, causality) over a timing proxy. The `executionLog` `start:`/`end:` convention in this file already supports it and is immune to runner contention.
- **Reviewer heuristic this surfaced:** a wall-clock assertion is only sound when the pass and fail populations cannot overlap. Here parallel-under-load (234ms) exceeded sequential-unloaded (154ms), so no bound could separate them - worth checking before adding or loosening any duration assertion.
- **Out of scope, worth a follow-up:** the sibling ordering assertions use `indexOf`, which returns `-1` when a tool never ran, so `expect(-1).toBeLessThan(5)` passes vacuously (`:207-212`, `:250`, `:329`, `:360`, `:414`). Same class as the guard added here. Happy to file it separately rather than widen this PR.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
