### PR TITLE
feat(client): apply reviewed data-lake taxonomy tags and make the step skippable

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
@@ -123,8 +123,8 @@ describe('DataLakeWizardModal — handleStartUpload offline pre-check', () => {
  * the wizard with a dead Next button. Inference is optional by design (the endpoint itself
  * returns an empty taxonomy when no API key is configured), so it must never block.
  */
-describe('DataLakeWizardModal — taxonomy step is optional', () => {
-  const renderAtTaxonomyStep = (tags: TaxonomyTag[]) => {
+describe('DataLakeWizardModal - taxonomy step is optional', () => {
+  const renderAtTaxonomyStep = (tags: TaxonomyTag[], analyzing = false) => {
     useDataLakeWizardStore.setState({
       isOpen: true,
       step: 'taxonomy',
@@ -135,8 +135,8 @@ describe('DataLakeWizardModal — taxonomy step is optional', () => {
         suggestedName: '',
         tags,
         fileAssignments: [],
-        attempted: true,
-        analyzing: false,
+        attempted: !analyzing,
+        analyzing,
       },
     });
     render(
@@ -157,6 +157,16 @@ describe('DataLakeWizardModal — taxonomy step is optional', () => {
     expect(next.disabled).toBe(false);
     expect(next.textContent).toContain('Skip');
     expect(screen.getByTestId('taxonomy-empty-state')).toBeTruthy();
+  });
+
+  it('holds the user on the step while inference is still in flight', () => {
+    // Inference's result overwrites config.name and config.tagPrefix, so advancing mid-flight
+    // would clobber what the user then types on Config. "Skip" would also be a lie here: tags
+    // landing after the click are still applied at upload.
+    const next = renderAtTaxonomyStep([], true);
+
+    expect(next.disabled).toBe(true);
+    expect(next.textContent).toContain('Next');
   });
 
   it('labels the button Next once there are tags to apply', () => {

--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
@@ -131,7 +131,6 @@ describe('DataLakeWizardModal - taxonomy step is optional', () => {
       targetLake: null,
       taxonomy: {
         prefix: 'test:',
-        sourcePrefix: 'test:',
         suggestedName: '',
         tags,
         fileAssignments: [],
@@ -172,7 +171,7 @@ describe('DataLakeWizardModal - taxonomy step is optional', () => {
   it('labels the button Next once there are tags to apply', () => {
     const next = renderAtTaxonomyStep([
       {
-        name: 'test:type:contract',
+        suffix: 'type:contract',
         originalName: 'test:type:contract',
         strength: 0.9,
         source: 'ai',

--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
+import { useDataLakeWizardStore, type TaxonomyTag } from '@client/app/stores/useDataLakeWizardStore';
 import DataLakeWizardModal from './DataLakeWizardModal';
 
 /**
@@ -25,6 +25,7 @@ vi.mock('@client/app/hooks/data/dataLakeWizard', () => ({
   useBatchUpload: () => ({ mutate: batchUploadMutate, isPending: false }),
   useComputeHashes: () => ({ mutate: vi.fn(), isPending: false }),
   useCheckDuplicates: () => ({ mutate: vi.fn(), isPending: false }),
+  useInferTaxonomy: () => ({ mutate: vi.fn(), isPending: false }),
   OFFLINE_MESSAGE: 'No internet connection. Check your network and try again.',
 }));
 // ConfigStep reads the lake list for its duplicate-name hint; stub it so this test
@@ -113,5 +114,64 @@ describe('DataLakeWizardModal — handleStartUpload offline pre-check', () => {
     expect(btn).toBeDisabled();
     btn.click();
     expect(batchUploadMutate).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regression coverage: the taxonomy step gated Next on a successful inference run, so an
+ * empty result - or a failed one, which never set the flag at all - stranded the user in
+ * the wizard with a dead Next button. Inference is optional by design (the endpoint itself
+ * returns an empty taxonomy when no API key is configured), so it must never block.
+ */
+describe('DataLakeWizardModal — taxonomy step is optional', () => {
+  const renderAtTaxonomyStep = (tags: TaxonomyTag[]) => {
+    useDataLakeWizardStore.setState({
+      isOpen: true,
+      step: 'taxonomy',
+      targetLake: null,
+      taxonomy: {
+        prefix: 'test:',
+        sourcePrefix: 'test:',
+        suggestedName: '',
+        tags,
+        fileAssignments: [],
+        attempted: true,
+        analyzing: false,
+      },
+    });
+    render(
+      <TestWrapper>
+        <DataLakeWizardModal />
+      </TestWrapper>
+    );
+    return screen.getByTestId('wizard-next-btn') as HTMLButtonElement;
+  };
+
+  afterEach(() => {
+    useDataLakeWizardStore.getState().resetWizard();
+  });
+
+  it('lets the user continue past an empty result, labelling the button Skip', () => {
+    const next = renderAtTaxonomyStep([]);
+
+    expect(next.disabled).toBe(false);
+    expect(next.textContent).toContain('Skip');
+    expect(screen.getByTestId('taxonomy-empty-state')).toBeTruthy();
+  });
+
+  it('labels the button Next once there are tags to apply', () => {
+    const next = renderAtTaxonomyStep([
+      {
+        name: 'test:type:contract',
+        originalName: 'test:type:contract',
+        strength: 0.9,
+        source: 'ai',
+        matchingFolders: ['legal'],
+        deleted: false,
+      },
+    ]);
+
+    expect(next.disabled).toBe(false);
+    expect(next.textContent).toContain('Next');
   });
 });

--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.tsx
@@ -36,8 +36,10 @@ export default function DataLakeWizardModal() {
   const canGoBack = currentIndex > 0 && step !== 'upload';
 
   // Nothing to review means nothing to apply, so the step is a pass-through - say so on
-  // the button rather than making the user guess whether Next loses anything.
-  const nextLabel = step === 'taxonomy' && !taxonomy.tags.some(t => !t.deleted) ? 'Skip' : 'Next';
+  // the button rather than making the user guess whether Next loses anything. Never while
+  // analyzing: tags that land after the click would still be applied, so "Skip" would lie.
+  const nextLabel =
+    step === 'taxonomy' && !taxonomy.analyzing && !taxonomy.tags.some(t => !t.deleted) ? 'Skip' : 'Next';
 
   const canGoNext = (() => {
     switch (step) {
@@ -46,10 +48,12 @@ export default function DataLakeWizardModal() {
       case 'preview':
         return allFiles.some(f => !f.excluded);
       case 'taxonomy':
-        // Never gated: inference is optional (the endpoint itself degrades to an empty
-        // taxonomy when it has no API key), and a failed or empty run used to strand the
+        // Gated only while inference is in flight - its result overwrites config.name and
+        // config.tagPrefix, so advancing early would clobber what the user types on Config.
+        // An empty or failed run never blocks: inference is optional (the endpoint itself
+        // degrades to an empty taxonomy when it has no API key), and it used to strand the
         // user here with no way forward.
-        return true;
+        return !taxonomy.analyzing;
       case 'config':
         // Append mode reuses the target lake's (already valid) slug; create mode must
         // produce a slug the server will accept (slug.min(2)) before Start Upload enables.

--- a/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeWizardModal.tsx
@@ -35,6 +35,10 @@ export default function DataLakeWizardModal() {
 
   const canGoBack = currentIndex > 0 && step !== 'upload';
 
+  // Nothing to review means nothing to apply, so the step is a pass-through - say so on
+  // the button rather than making the user guess whether Next loses anything.
+  const nextLabel = step === 'taxonomy' && !taxonomy.tags.some(t => !t.deleted) ? 'Skip' : 'Next';
+
   const canGoNext = (() => {
     switch (step) {
       case 'source':
@@ -42,7 +46,10 @@ export default function DataLakeWizardModal() {
       case 'preview':
         return allFiles.some(f => !f.excluded);
       case 'taxonomy':
-        return taxonomy.analyzed;
+        // Never gated: inference is optional (the endpoint itself degrades to an empty
+        // taxonomy when it has no API key), and a failed or empty run used to strand the
+        // user here with no way forward.
+        return true;
       case 'config':
         // Append mode reuses the target lake's (already valid) slug; create mode must
         // produce a slug the server will accept (slug.min(2)) before Start Upload enables.
@@ -181,7 +188,7 @@ export default function DataLakeWizardModal() {
                 disabled={!canGoNext}
                 onClick={handleNext}
               >
-                Next
+                {nextLabel}
               </Button>
             ) : null}
           </Stack>

--- a/apps/client/app/components/DataLakeWizard/steps/ConfigStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/ConfigStep.test.tsx
@@ -200,3 +200,83 @@ describe('ConfigStep - slug validation hint', () => {
     expect(screen.queryByTestId(SLUG_ERROR)).toBeNull();
   });
 });
+
+/**
+ * Reconciliation of #829 (taxonomy applies tags -> prefix is meaningful there) with #826
+ * (Tag Prefix de-duped to a single home). The single editable home is now the taxonomy
+ * step, so Config shows the prefix read-only - except the empty-prefix dead-end, where a
+ * skippable/empty taxonomy would otherwise strand the user at Config's tagPrefix>=2 gate.
+ */
+describe('ConfigStep - Tag Prefix single home + empty-prefix fallback', () => {
+  const seedConfig = (over: { tagPrefix: string; targetLake?: unknown }) =>
+    useDataLakeWizardStore.setState({
+      step: 'config',
+      targetLake: (over.targetLake ?? null) as never,
+      allFiles: [],
+      config: {
+        name: 'My Lake',
+        description: '',
+        tagPrefix: over.tagPrefix,
+        requiredUserTag: '',
+        requiredEntitlement: '',
+        conflictResolution: 'skip',
+      },
+    });
+
+  const prefixInput = () => screen.getByTestId('config-tag-prefix-input').querySelector('input') as HTMLInputElement;
+
+  beforeEach(() => {
+    lakes.current = [];
+    selectedAccount.current = { id: 'me', personal: true };
+  });
+
+  afterEach(() => {
+    useDataLakeWizardStore.getState().resetWizard();
+  });
+
+  it('shows the prefix read-only in create mode when the taxonomy step already set one', () => {
+    seedConfig({ tagPrefix: 'acme:' });
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(prefixInput().disabled).toBe(true);
+    expect(prefixInput().value).toBe('acme:');
+    expect(screen.getByText(/Set on the AI Taxonomy step/i)).toBeInTheDocument();
+  });
+
+  it('falls back to an editable prefix when create mode arrives with an empty prefix', () => {
+    // Taxonomy skipped or inference returned no prefix: without this the user hits the
+    // tagPrefix>=2 gate on Start Upload with no field to fix it.
+    seedConfig({ tagPrefix: '' });
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(prefixInput().disabled).toBe(false);
+    expect(screen.getByText(/No taxonomy prefix was set/i)).toBeInTheDocument();
+  });
+
+  it('locks the prefix to the target lake in append mode (taxonomy step is skipped there)', () => {
+    seedConfig({
+      tagPrefix: 'niche:',
+      targetLake: { id: 'l1', name: 'Niche', slug: 'niche', fileTagPrefix: 'niche:' },
+    });
+
+    render(
+      <TestWrapper>
+        <ConfigStep />
+      </TestWrapper>
+    );
+
+    expect(prefixInput().disabled).toBe(true);
+    expect(prefixInput().value).toBe('niche:');
+    expect(screen.getByText(/Inherited from the existing data lake/i)).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/ConfigStep.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '@mui/joy';
 import { useTheme } from '@mui/joy/styles';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import { DATA_LAKE } from '@client/app/components/datalake/dataLakeBranding';
 import { useComputeHashes, useCheckDuplicates } from '@client/app/hooks/data/dataLakeWizard';
@@ -31,6 +31,7 @@ export default function ConfigStep() {
   const theme = useTheme();
   const config = useDataLakeWizardStore(s => s.config);
   const setConfig = useDataLakeWizardStore(s => s.setConfig);
+  const setTagPrefix = useDataLakeWizardStore(s => s.setTagPrefix);
   const targetLake = useDataLakeWizardStore(s => s.targetLake);
   const taxonomy = useDataLakeWizardStore(s => s.taxonomy);
   const allFiles = useDataLakeWizardStore(s => s.allFiles);
@@ -64,6 +65,14 @@ export default function ConfigStep() {
   // and only gate creates.
   const slug = targetLake ? targetLake.slug : slugifyDataLakeName(config.name);
   const slugTooShort = !targetLake && config.name.trim().length > 0 && slug.length < MIN_DATA_LAKE_SLUG_LENGTH;
+
+  // Tag Prefix's editable home is the taxonomy step (#829). Config only shows it read-only,
+  // EXCEPT the empty-prefix dead-end: the taxonomy step is skippable and inference can yield
+  // an empty prefix (e.g. no API key), yet Start Upload still gates on tagPrefix >= 2 chars.
+  // When create mode lands here with no usable prefix, fall back to an editable field so the
+  // user isn't stranded. Captured once via lazy init so typing in the fallback can't flip it
+  // read-only mid-edit; navigating back to taxonomy remounts this step and re-evaluates.
+  const [prefixEditable] = useState(() => !targetLake && config.tagPrefix.trim().length < MIN_DATA_LAKE_SLUG_LENGTH);
 
   const autoTriggered = useRef(false);
 
@@ -162,23 +171,31 @@ export default function ConfigStep() {
           />
         </FormControl>
 
-        {/* Tag Prefix */}
-        <FormControl required>
+        {/* Tag Prefix - read-only here (its editable home is the taxonomy step in create
+            mode, or the target lake in append mode), unless the empty-prefix fallback applies. */}
+        <FormControl required={prefixEditable}>
           <FormLabel>Tag Prefix</FormLabel>
           <Input
+            data-testid="config-tag-prefix-input"
             value={config.tagPrefix}
-            onChange={e => setConfig({ tagPrefix: e.target.value })}
+            onChange={e => setTagPrefix(e.target.value)}
             onBlur={e => {
               const v = e.target.value.trim();
               if (v && !v.endsWith(':')) {
-                setConfig({ tagPrefix: v + ':' });
+                setTagPrefix(v + ':');
               }
             }}
             placeholder="e.g. legal:"
             sx={{ fontFamily: 'monospace' }}
-            disabled={!!targetLake}
+            disabled={!prefixEditable}
           />
-          <FormHelperText>All tags will be prefixed with this (must end with &quot;:&quot;)</FormHelperText>
+          <FormHelperText>
+            {prefixEditable
+              ? 'All tags will be prefixed with this (must end with ":"). No taxonomy prefix was set, so add one here.'
+              : targetLake
+                ? 'Inherited from the existing data lake.'
+                : 'Set on the AI Taxonomy step. Go back there to change it.'}
+          </FormHelperText>
         </FormControl>
 
         {/* Required User Tag */}

--- a/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.test.tsx
@@ -1,0 +1,118 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { useDataLakeWizardStore, type TaxonomyTag } from '@client/app/stores/useDataLakeWizardStore';
+import TaxonomyReviewStep from './TaxonomyReviewStep';
+
+/**
+ * The prefix is a single shared value (taxonomy.prefix); each card renders `prefix + suffix`.
+ * So editing a tag can only change its suffix (never inject a second namespace), and editing
+ * the one prefix input re-namespaces every card at once. These pin that contract plus the two
+ * guards: an empty suffix can't be saved, and an empty/short prefix shows the required error.
+ */
+
+// Inference auto-triggers on mount unless already attempted; stub it so the step is inert.
+vi.mock('@client/app/hooks/data/dataLakeWizard', () => ({
+  useInferTaxonomy: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const mkTag = (over: Partial<TaxonomyTag> & { suffix: string }): TaxonomyTag => ({
+  originalName: `acme:${over.suffix}`,
+  strength: 0.95,
+  source: 'ai',
+  matchingFolders: ['legal'],
+  deleted: false,
+  ...over,
+});
+
+const seed = (prefix: string, tags: TaxonomyTag[]) =>
+  useDataLakeWizardStore.setState({
+    isOpen: true,
+    step: 'taxonomy',
+    targetLake: null,
+    taxonomy: { prefix, suggestedName: 'Acme', tags, fileAssignments: [], attempted: true, analyzing: false },
+  });
+
+const renderStep = () =>
+  render(
+    <TestWrapper>
+      <TaxonomyReviewStep />
+    </TestWrapper>
+  );
+
+const suffixInput = () => screen.getByTestId('taxonomy-tag-suffix-input').querySelector('input') as HTMLInputElement;
+const prefixInput = () => screen.getByTestId('taxonomy-tag-prefix-input').querySelector('input') as HTMLInputElement;
+
+describe('TaxonomyReviewStep - prefix + suffix', () => {
+  beforeEach(() => useDataLakeWizardStore.getState().resetWizard());
+  afterEach(() => useDataLakeWizardStore.getState().resetWizard());
+
+  it('renders each card as the shared prefix followed by its suffix', () => {
+    seed('acme:', [mkTag({ suffix: 'type:report' })]);
+    renderStep();
+
+    expect(screen.getByTestId('taxonomy-tag-card').textContent).toContain('acme:type:report');
+  });
+
+  it('re-namespaces every card when the shared prefix changes', () => {
+    seed('acme:', [mkTag({ suffix: 'type:report' }), mkTag({ suffix: 'topic:finance' })]);
+    renderStep();
+
+    fireEvent.change(prefixInput(), { target: { value: 'zzz:' } });
+
+    const cards = screen.getAllByTestId('taxonomy-tag-card');
+    expect(cards[0].textContent).toContain('zzz:type:report');
+    expect(cards[1].textContent).toContain('zzz:topic:finance');
+    // The store's single prefix moved, not any per-tag copy.
+    expect(useDataLakeWizardStore.getState().taxonomy.prefix).toBe('zzz:');
+  });
+
+  it('edits only the suffix and writes it back to the store', () => {
+    seed('acme:', [mkTag({ suffix: 'type:report' })]);
+    renderStep();
+
+    fireEvent.click(screen.getByTestId('taxonomy-tag-edit'));
+    // The editable field holds only the suffix, not the prefix.
+    expect(suffixInput().value).toBe('type:report');
+
+    fireEvent.change(suffixInput(), { target: { value: 'type:renamed' } });
+    fireEvent.click(screen.getByTestId('taxonomy-tag-save'));
+
+    expect(useDataLakeWizardStore.getState().taxonomy.tags[0].suffix).toBe('type:renamed');
+    expect(screen.getByTestId('taxonomy-tag-card').textContent).toContain('acme:type:renamed');
+  });
+
+  it('blocks saving an empty suffix (stays in edit mode, store unchanged)', () => {
+    seed('acme:', [mkTag({ suffix: 'type:report' })]);
+    renderStep();
+
+    fireEvent.click(screen.getByTestId('taxonomy-tag-edit'));
+    fireEvent.change(suffixInput(), { target: { value: '   ' } });
+
+    const save =
+      screen.getByTestId('taxonomy-tag-save').querySelector('button') ?? screen.getByTestId('taxonomy-tag-save');
+    expect((save as HTMLButtonElement).disabled).toBe(true);
+
+    // Enter must not save either; still editing, suffix unchanged.
+    fireEvent.keyDown(suffixInput(), { key: 'Enter' });
+    expect(screen.queryByTestId('taxonomy-tag-suffix-input')).not.toBeNull();
+    expect(useDataLakeWizardStore.getState().taxonomy.tags[0].suffix).toBe('type:report');
+  });
+
+  it('shows the required error when the prefix is empty or too short', () => {
+    seed('a', [mkTag({ suffix: 'type:report' })]);
+    renderStep();
+
+    expect(screen.getByTestId('taxonomy-tag-prefix-error')).toBeTruthy();
+
+    fireEvent.change(prefixInput(), { target: { value: 'acme:' } });
+    expect(screen.queryByTestId('taxonomy-tag-prefix-error')).toBeNull();
+  });
+});

--- a/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
@@ -44,8 +44,8 @@ function getTierLabel(tier: 'high' | 'medium' | 'low'): string {
 
 interface TagCardProps {
   tag: TaxonomyTag;
-  onUpdate: (tagName: string, updates: Partial<TaxonomyTag>) => void;
-  onDelete: (tagName: string) => void;
+  onUpdate: (originalName: string, updates: Partial<TaxonomyTag>) => void;
+  onDelete: (originalName: string) => void;
 }
 
 const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps) {
@@ -54,7 +54,7 @@ const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps)
 
   const handleSave = () => {
     if (editName.trim() && editName !== tag.name) {
-      onUpdate(tag.name, { name: editName.trim() });
+      onUpdate(tag.originalName, { name: editName.trim() });
     }
     setIsEditing(false);
   };
@@ -147,7 +147,7 @@ const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps)
             variant="plain"
             color="danger"
             data-testid="taxonomy-tag-delete"
-            onClick={() => onDelete(tag.name)}
+            onClick={() => onDelete(tag.originalName)}
           >
             <DeleteOutlineIcon sx={{ fontSize: 14 }} />
           </IconButton>
@@ -167,9 +167,11 @@ export default function TaxonomyReviewStep() {
   const deleteTag = useDataLakeWizardStore(s => s.deleteTag);
   const inferTaxonomy = useInferTaxonomy();
 
+  // Pass the prefix the user may have edited above, so re-analyzing returns tags in their
+  // namespace instead of silently reverting to whatever the model picks on its own.
   const handleReanalyze = useCallback(() => {
-    inferTaxonomy.mutate({});
-  }, [inferTaxonomy]);
+    inferTaxonomy.mutate({ existingPrefix: taxonomy.prefix || undefined });
+  }, [inferTaxonomy, taxonomy.prefix]);
 
   // Auto-trigger inference on first mount if not yet attempted
   const [autoTriggered, setAutoTriggered] = useState(false);
@@ -287,7 +289,7 @@ export default function TaxonomyReviewStep() {
             }}
           >
             {tags.map(tag => (
-              <TagCard key={tag.name} tag={tag} onUpdate={updateTag} onDelete={deleteTag} />
+              <TagCard key={tag.originalName} tag={tag} onUpdate={updateTag} onDelete={deleteTag} />
             ))}
           </Box>
         </Box>

--- a/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Chip, CircularProgress, IconButton, Input, Stack, Typography } from '@mui/joy';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditIcon from '@mui/icons-material/Edit';
 import RefreshIcon from '@mui/icons-material/Refresh';
@@ -122,10 +123,10 @@ const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps)
         {tag.source === 'ai' ? 'AI' : 'folder'}
       </Chip>
 
-      {/* Sample folders/files */}
-      {tag.sampleFileNames.length > 0 && (
+      {/* Folders this tag will be applied to */}
+      {tag.matchingFolders.length > 0 && (
         <Typography level="body-xs" color="neutral" sx={{ maxWidth: 200 }} noWrap>
-          {tag.sampleFileNames.join(', ')}
+          {tag.matchingFolders.join(', ')}
         </Typography>
       )}
 
@@ -161,6 +162,7 @@ const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps)
 export default function TaxonomyReviewStep() {
   const theme = useTheme();
   const taxonomy = useDataLakeWizardStore(s => s.taxonomy);
+  const setTagPrefix = useDataLakeWizardStore(s => s.setTagPrefix);
   const updateTag = useDataLakeWizardStore(s => s.updateTag);
   const deleteTag = useDataLakeWizardStore(s => s.deleteTag);
   const inferTaxonomy = useInferTaxonomy();
@@ -169,9 +171,9 @@ export default function TaxonomyReviewStep() {
     inferTaxonomy.mutate({});
   }, [inferTaxonomy]);
 
-  // Auto-trigger inference on first mount if not yet analyzed
+  // Auto-trigger inference on first mount if not yet attempted
   const [autoTriggered, setAutoTriggered] = useState(false);
-  if (!taxonomy.analyzed && !taxonomy.analyzing && !autoTriggered) {
+  if (!taxonomy.attempted && !taxonomy.analyzing && !autoTriggered) {
     setAutoTriggered(true);
     // Use setTimeout to avoid setState during render
     setTimeout(() => inferTaxonomy.mutate({}), 0);
@@ -216,15 +218,30 @@ export default function TaxonomyReviewStep() {
       data-testid="wizard-taxonomy-step"
       sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, p: 2, overflow: 'auto' }}
     >
-      {/* Header row: suggested name + re-analyze button. Tag Prefix is edited on the
-          Config step (its single home) - it drives the submitted fileTagPrefix, so
-          duplicating an editable copy here only invited the two to drift out of sync. */}
+      {/* Header row: Tag Prefix input + re-analyze button. Tag Prefix's single editable home
+          is HERE (#829): the prefix is embedded in every applied tag name and consumed by
+          Re-analyze, so this is where it drives behavior. The Config step shows it read-only
+          (append mode) rather than as a second editable copy that could drift out of sync. */}
       <Stack direction="row" gap={2} alignItems="flex-end" flexWrap="wrap">
+        <Box sx={{ flex: 1, minWidth: 200 }}>
+          <Typography level="body-xs" fontWeight="bold" sx={{ mb: 0.5 }}>
+            Tag Prefix
+          </Typography>
+          <Input
+            size="sm"
+            data-testid="taxonomy-tag-prefix-input"
+            value={taxonomy.prefix}
+            onChange={e => setTagPrefix(e.target.value)}
+            placeholder="e.g. acme:"
+            startDecorator={<AutoAwesomeIcon sx={{ fontSize: 16 }} />}
+            sx={{ fontFamily: 'monospace' }}
+          />
+        </Box>
         <Box sx={{ flex: 1, minWidth: 200 }}>
           <Typography level="body-xs" fontWeight="bold" sx={{ mb: 0.5 }}>
             Suggested Name
           </Typography>
-          <Typography level="body-sm">{taxonomy.suggestedName || '—'}</Typography>
+          <Typography level="body-sm">{taxonomy.suggestedName || '-'}</Typography>
         </Box>
         <Button
           size="sm"
@@ -240,8 +257,9 @@ export default function TaxonomyReviewStep() {
 
       {/* Summary */}
       <Typography level="body-sm" color="neutral">
-        {activeTags.length} tag categor{activeTags.length === 1 ? 'y' : 'ies'} suggested
+        {activeTags.length} tag categor{activeTags.length === 1 ? 'y' : 'ies'} will be applied to matching files
         {taxonomy.tags.filter(t => t.deleted).length > 0 && ` (${taxonomy.tags.filter(t => t.deleted).length} removed)`}
+        . This step is optional - you can skip it and keep folder-based tags only.
       </Typography>
 
       {/* Tags grouped by confidence tier */}
@@ -276,10 +294,11 @@ export default function TaxonomyReviewStep() {
       ))}
 
       {/* Empty state */}
-      {activeTags.length === 0 && taxonomy.analyzed && (
-        <Box sx={{ textAlign: 'center', py: 4 }}>
+      {activeTags.length === 0 && taxonomy.attempted && (
+        <Box data-testid="taxonomy-empty-state" sx={{ textAlign: 'center', py: 4 }}>
           <Typography color="neutral">
-            No tag categories found. Try re-analyzing with different files or adding context.
+            No tag categories suggested. Files will still be tagged by their source folder - continue, or re-analyze
+            with different files or added context.
           </Typography>
           <Button size="sm" variant="soft" sx={{ mt: 1 }} onClick={handleReanalyze}>
             Re-analyze

--- a/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
+++ b/apps/client/app/components/DataLakeWizard/steps/TaxonomyReviewStep.tsx
@@ -1,4 +1,16 @@
-import { Box, Button, Chip, CircularProgress, IconButton, Input, Stack, Typography } from '@mui/joy';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  IconButton,
+  Input,
+  Stack,
+  Typography,
+} from '@mui/joy';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditIcon from '@mui/icons-material/Edit';
@@ -44,23 +56,31 @@ function getTierLabel(tier: 'high' | 'medium' | 'low'): string {
 
 interface TagCardProps {
   tag: TaxonomyTag;
+  /** Shared tag prefix (taxonomy.prefix); fixed in the card, editable only on the header input. */
+  prefix: string;
   onUpdate: (originalName: string, updates: Partial<TaxonomyTag>) => void;
   onDelete: (originalName: string) => void;
 }
 
-const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps) {
+const TagCard = memo(function TagCard({ tag, prefix, onUpdate, onDelete }: TagCardProps) {
   const [isEditing, setIsEditing] = useState(false);
-  const [editName, setEditName] = useState(tag.name);
+  const [editSuffix, setEditSuffix] = useState(tag.suffix);
+
+  // Only the suffix is editable; the prefix is fixed, so a rename can never inject a second
+  // namespace. An empty suffix is invalid - block save (and exit) until it has a value.
+  const trimmedSuffix = editSuffix.trim();
+  const canSave = trimmedSuffix.length > 0;
 
   const handleSave = () => {
-    if (editName.trim() && editName !== tag.name) {
-      onUpdate(tag.originalName, { name: editName.trim() });
+    if (!canSave) return;
+    if (trimmedSuffix !== tag.suffix) {
+      onUpdate(tag.originalName, { suffix: trimmedSuffix });
     }
     setIsEditing(false);
   };
 
   const handleCancel = () => {
-    setEditName(tag.name);
+    setEditSuffix(tag.suffix);
     setIsEditing(false);
   };
 
@@ -86,21 +106,35 @@ const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps)
         {Math.round(tag.strength * 100)}%
       </Chip>
 
-      {/* Tag name (editable) */}
+      {/* Tag suffix (editable); the prefix is fixed and shared across all cards */}
       {isEditing ? (
         <Stack direction="row" gap={0.5} sx={{ flex: 1 }}>
           <Input
             size="sm"
-            value={editName}
-            onChange={e => setEditName(e.target.value)}
+            data-testid="taxonomy-tag-suffix-input"
+            value={editSuffix}
+            error={!canSave}
+            onChange={e => setEditSuffix(e.target.value)}
             onKeyDown={e => {
               if (e.key === 'Enter') handleSave();
               if (e.key === 'Escape') handleCancel();
             }}
+            startDecorator={
+              <Box component="span" sx={{ fontFamily: 'monospace', color: 'text.tertiary' }}>
+                {prefix}
+              </Box>
+            }
             autoFocus
-            sx={{ flex: 1 }}
+            sx={{ flex: 1, fontFamily: 'monospace' }}
           />
-          <IconButton size="sm" variant="soft" color="success" onClick={handleSave}>
+          <IconButton
+            size="sm"
+            variant="soft"
+            color="success"
+            disabled={!canSave}
+            data-testid="taxonomy-tag-save"
+            onClick={handleSave}
+          >
             <CheckIcon sx={{ fontSize: 14 }} />
           </IconButton>
           <IconButton size="sm" variant="soft" color="neutral" onClick={handleCancel}>
@@ -114,7 +148,10 @@ const TagCard = memo(function TagCard({ tag, onUpdate, onDelete }: TagCardProps)
           sx={{ flex: 1, cursor: 'pointer' }}
           onClick={() => setIsEditing(true)}
         >
-          {tag.name}
+          <Box component="span" sx={{ color: 'text.tertiary' }}>
+            {prefix}
+          </Box>
+          {tag.suffix}
         </Typography>
       )}
 
@@ -173,6 +210,10 @@ export default function TaxonomyReviewStep() {
     inferTaxonomy.mutate({ existingPrefix: taxonomy.prefix || undefined });
   }, [inferTaxonomy, taxonomy.prefix]);
 
+  // Tag Prefix is required: Config gates Start Upload on length >= 2. Warn here early, since
+  // this is its editable home, so the user isn't surprised by a blocked gate two steps later.
+  const prefixInvalid = taxonomy.prefix.trim().length < 2;
+
   // Auto-trigger inference on first mount if not yet attempted
   const [autoTriggered, setAutoTriggered] = useState(false);
   if (!taxonomy.attempted && !taxonomy.analyzing && !autoTriggered) {
@@ -221,24 +262,31 @@ export default function TaxonomyReviewStep() {
       sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, p: 2, overflow: 'auto' }}
     >
       {/* Header row: Tag Prefix input + re-analyze button. Tag Prefix's single editable home
-          is HERE (#829): the prefix is embedded in every applied tag name and consumed by
-          Re-analyze, so this is where it drives behavior. The Config step shows it read-only
-          (append mode) rather than as a second editable copy that could drift out of sync. */}
-      <Stack direction="row" gap={2} alignItems="flex-end" flexWrap="wrap">
-        <Box sx={{ flex: 1, minWidth: 200 }}>
-          <Typography level="body-xs" fontWeight="bold" sx={{ mb: 0.5 }}>
-            Tag Prefix
-          </Typography>
+          is HERE (#829): every card renders `prefix + suffix`, so editing this one value
+          re-namespaces them all. The Config step shows it read-only (create) / locked
+          (append) rather than as a second editable copy that could drift out of sync. */}
+      <Stack direction="row" gap={2} alignItems="flex-start" flexWrap="wrap">
+        <FormControl error={prefixInvalid} sx={{ flex: 1, minWidth: 200 }}>
+          <FormLabel>Tag Prefix</FormLabel>
           <Input
             size="sm"
             data-testid="taxonomy-tag-prefix-input"
             value={taxonomy.prefix}
             onChange={e => setTagPrefix(e.target.value)}
+            onBlur={e => {
+              const v = e.target.value.trim();
+              if (v && !v.endsWith(':')) setTagPrefix(v + ':');
+            }}
             placeholder="e.g. acme:"
             startDecorator={<AutoAwesomeIcon sx={{ fontSize: 16 }} />}
             sx={{ fontFamily: 'monospace' }}
           />
-        </Box>
+          {prefixInvalid && (
+            <FormHelperText data-testid="taxonomy-tag-prefix-error">
+              A tag prefix is required (at least 2 characters). It is applied to every tag.
+            </FormHelperText>
+          )}
+        </FormControl>
         <Box sx={{ flex: 1, minWidth: 200 }}>
           <Typography level="body-xs" fontWeight="bold" sx={{ mb: 0.5 }}>
             Suggested Name
@@ -289,7 +337,13 @@ export default function TaxonomyReviewStep() {
             }}
           >
             {tags.map(tag => (
-              <TagCard key={tag.originalName} tag={tag} onUpdate={updateTag} onDelete={deleteTag} />
+              <TagCard
+                key={tag.originalName}
+                tag={tag}
+                prefix={taxonomy.prefix}
+                onUpdate={updateTag}
+                onDelete={deleteTag}
+              />
             ))}
           </Box>
         </Box>

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -616,6 +616,30 @@ describe('useInferTaxonomy response handling', () => {
     expect(useDataLakeWizardStore.getState().taxonomy.tags).toHaveLength(1);
   });
 
+  it('trims a padded relativePath so per-file assignments still match at upload', async () => {
+    // tagsForFile matches assignments by strict path equality; a padded path would miss.
+    apiPost.mockResolvedValue({
+      data: {
+        suggestedPrefix: 'acme:',
+        suggestedName: 'Acme',
+        categories: [{ tagName: 'acme:type:x', confidence: 0.9, matchingFolders: ['legal'] }],
+        fileAssignments: [
+          { relativePath: '  root/legal/a.txt  ', suggestedTags: [{ name: 'acme:type:x', strength: 1 }] },
+        ],
+      },
+    });
+    seedFolderTree();
+
+    const { result } = mountHook(useInferTaxonomy);
+    act(() => {
+      result.current.mutate({});
+    });
+
+    await waitFor(() => expect(useDataLakeWizardStore.getState().taxonomy.attempted).toBe(true));
+
+    expect(useDataLakeWizardStore.getState().taxonomy.fileAssignments[0].relativePath).toBe('root/legal/a.txt');
+  });
+
   it('does not overwrite a name or prefix the user already typed', async () => {
     // Re-analyze after the user set these on Config must not clobber them.
     apiPost.mockResolvedValue({

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -268,6 +268,68 @@ describe('useBatchUpload onError', () => {
     );
   });
 
+  it('sends the reviewed taxonomy tags with each file, honoring renames and deletes', async () => {
+    // Regression: the Taxonomy step's edits used to be discarded entirely - every file
+    // got only a folder slug, so reviewing tags changed nothing about the upload.
+    apiPost.mockImplementation((url: string) => {
+      if (url === '/api/files/generate-presigned-urls-batch') return Promise.resolve({ data: { files: [] } });
+      return Promise.resolve({ data: { id: 'id-1' } });
+    });
+    seedWizardFile();
+    useDataLakeWizardStore.setState({
+      allFiles: [
+        {
+          file: new File(['contents'], 'vendor.pdf', { type: 'application/pdf' }),
+          relativePath: 'root/legal/vendor.pdf',
+          size: 8,
+          type: 'application/pdf',
+          excluded: false,
+          isDuplicate: false,
+        },
+      ],
+      taxonomy: {
+        prefix: 'test:',
+        sourcePrefix: 'acme:',
+        suggestedName: 'Acme',
+        attempted: true,
+        analyzing: false,
+        fileAssignments: [],
+        tags: [
+          {
+            name: 'acme:type:agreement',
+            originalName: 'acme:type:contract',
+            strength: 0.95,
+            source: 'ai',
+            matchingFolders: ['legal'],
+            deleted: false,
+          },
+          {
+            name: 'acme:topic:hr',
+            originalName: 'acme:topic:hr',
+            strength: 0.8,
+            source: 'ai',
+            matchingFolders: ['legal'],
+            deleted: true,
+          },
+        ],
+      },
+    });
+
+    const { result } = mountBatchUpload();
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith('/api/files/generate-presigned-urls-batch', expect.anything())
+    );
+
+    const presign = apiPost.mock.calls.find(([url]) => url === '/api/files/generate-presigned-urls-batch');
+    const tagNames = (presign?.[1] as { files: { tags: { name: string }[] }[] }).files[0].tags.map(t => t.name).sort();
+    // Renamed tag applied under the user's config prefix; deleted tag gone; folder tag kept.
+    expect(tagNames).toEqual(['test:legal', 'test:type:agreement']);
+  });
+
   it('retrying via the toast action re-invokes the upload', async () => {
     apiPost.mockRejectedValue({ isAxiosError: true, code: 'ERR_NETWORK', message: 'Network Error' });
     seedWizardFile();

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -32,15 +32,17 @@ vi.mock('@client/app/contexts/WebsocketContext', () => ({
 vi.mock('@client/app/hooks/data/dataLakes', () => ({ activeOrgId: () => undefined }));
 vi.mock('@client/app/hooks/useGearsStatus', () => ({ invalidateGearsStatusWhileLocked: () => {} }));
 
-import { useBatchUpload } from './dataLakeWizard';
+import { useBatchUpload, useInferTaxonomy } from './dataLakeWizard';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 
-const mountBatchUpload = () => {
+const mountHook = <T>(hook: () => T) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
-  return renderHook(() => useBatchUpload(), { wrapper });
+  return renderHook(hook, { wrapper });
 };
+
+const mountBatchUpload = () => mountHook(useBatchUpload);
 
 const seedWizardFile = () =>
   useDataLakeWizardStore.setState({
@@ -500,6 +502,93 @@ describe('useBatchUpload rollback (#816)', () => {
 
     expect(deleteCalledWith('/api/data-lakes/lake1')).toBe(true);
     expect(putCall('/api/data-lakes/batches/batch1')?.[1]).toMatchObject({ status: 'failed' });
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The infer-taxonomy endpoint validates only suggestedPrefix + categories-is-an-array and
+ * otherwise returns the model's raw JSON. Since the taxonomy now feeds the upload path -
+ * which runs after the lake record exists - a malformed payload reaching tagsForFile would
+ * throw mid-upload and trigger the lake rollback. It has to be sanitized on the way in.
+ */
+describe('useInferTaxonomy response handling', () => {
+  const seedFolderTree = () =>
+    useDataLakeWizardStore.setState({
+      folderTree: { name: 'root', path: 'root', type: 'folder', children: [], excluded: false },
+      allFiles: [
+        {
+          file: new File(['contents'], 'a.txt', { type: 'text/plain' }),
+          relativePath: 'root/legal/a.txt',
+          size: 8,
+          type: 'text/plain',
+          excluded: false,
+          isDuplicate: false,
+        },
+      ],
+    });
+
+  beforeEach(() => {
+    apiPost.mockReset();
+    toastMock.success.mockClear();
+    useDataLakeWizardStore.getState().resetWizard();
+  });
+
+  it('drops malformed categories and assignments instead of storing unusable tags', async () => {
+    apiPost.mockResolvedValue({
+      data: {
+        suggestedPrefix: 'acme:',
+        suggestedName: 'Acme',
+        categories: [
+          { tagName: 'acme:type:contract', confidence: 0.9, matchingFolders: ['legal'] },
+          { confidence: 0.8, matchingFolders: ['finance'] }, // no tagName
+          { tagName: '  ', confidence: 0.8 }, // blank tagName
+        ],
+        fileAssignments: { nope: true }, // not an array
+      },
+    });
+    seedFolderTree();
+
+    const { result } = mountHook(useInferTaxonomy);
+    act(() => {
+      result.current.mutate({});
+    });
+
+    await waitFor(() => expect(useDataLakeWizardStore.getState().taxonomy.attempted).toBe(true));
+
+    const { taxonomy } = useDataLakeWizardStore.getState();
+    expect(taxonomy.tags.map(t => t.name)).toEqual(['acme:type:contract']);
+    expect(taxonomy.tags[0].originalName).toBe('acme:type:contract');
+    expect(taxonomy.fileAssignments).toEqual([]);
+    // The toast must reflect what was kept, not what the model claimed to send.
+    expect(toastMock.success).toHaveBeenCalledWith('AI suggested 1 tag categories');
+  });
+
+  it('keeps the existing prefix when the endpoint returns an empty taxonomy', async () => {
+    // No API key configured -> emptyTaxonomy with a blank suggestedPrefix. Blanking
+    // sourcePrefix would make reprefixTag prepend, yielding "mine:acme:type:contract".
+    apiPost.mockResolvedValue({
+      data: { suggestedPrefix: '', suggestedName: '', categories: [], fileAssignments: [] },
+    });
+    seedFolderTree();
+    useDataLakeWizardStore.setState({
+      taxonomy: {
+        ...useDataLakeWizardStore.getState().taxonomy,
+        prefix: 'mine:',
+        sourcePrefix: 'acme:',
+      },
+    });
+
+    const { result } = mountHook(useInferTaxonomy);
+    act(() => {
+      result.current.mutate({});
+    });
+
+    await waitFor(() => expect(useDataLakeWizardStore.getState().taxonomy.attempted).toBe(true));
+
+    const { taxonomy } = useDataLakeWizardStore.getState();
+    expect(taxonomy.prefix).toBe('mine:');
+    expect(taxonomy.sourcePrefix).toBe('acme:');
     expect(toastMock.success).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -590,4 +590,79 @@ describe('useInferTaxonomy response handling', () => {
     expect(useDataLakeWizardStore.getState().taxonomy.prefix).toBe('mine:');
     expect(toastMock.success).not.toHaveBeenCalled();
   });
+
+  it('dedups repeated category names so one card edit cannot hit two tags', async () => {
+    apiPost.mockResolvedValue({
+      data: {
+        suggestedPrefix: 'acme:',
+        suggestedName: 'Acme',
+        categories: [
+          { tagName: 'acme:type:contract', confidence: 0.9, matchingFolders: ['legal'] },
+          { tagName: 'acme:type:contract', confidence: 0.8, matchingFolders: ['legal2'] }, // dup
+        ],
+        fileAssignments: [],
+      },
+    });
+    seedFolderTree();
+
+    const { result } = mountHook(useInferTaxonomy);
+    act(() => {
+      result.current.mutate({});
+    });
+
+    await waitFor(() => expect(useDataLakeWizardStore.getState().taxonomy.attempted).toBe(true));
+
+    // originalName is the React key + the update/delete/merge key, so it must be unique.
+    expect(useDataLakeWizardStore.getState().taxonomy.tags).toHaveLength(1);
+  });
+
+  it('does not overwrite a name or prefix the user already typed', async () => {
+    // Re-analyze after the user set these on Config must not clobber them.
+    apiPost.mockResolvedValue({
+      data: {
+        suggestedPrefix: 'ai:',
+        suggestedName: 'AI Suggested Name',
+        categories: [{ tagName: 'ai:type:x', confidence: 0.9, matchingFolders: ['legal'] }],
+        fileAssignments: [],
+      },
+    });
+    seedFolderTree();
+    useDataLakeWizardStore.getState().setConfig({ name: 'My Lake', tagPrefix: 'mine:' });
+
+    const { result } = mountHook(useInferTaxonomy);
+    act(() => {
+      result.current.mutate({});
+    });
+
+    await waitFor(() => expect(useDataLakeWizardStore.getState().taxonomy.attempted).toBe(true));
+
+    const { config } = useDataLakeWizardStore.getState();
+    expect(config.name).toBe('My Lake');
+    expect(config.tagPrefix).toBe('mine:');
+  });
+
+  it('marks analyzing before the content-sampling await, closing the advance-mid-inference gap', async () => {
+    // Regression: analyzing was set only after sampling files (hundreds of ms), leaving the
+    // step's !analyzing gate open during that window so a user could advance and have onSuccess
+    // clobber their config. Stall sampling (Blob.text never resolves) and prove analyzing is
+    // already true while sampling is still pending and the network call has not fired.
+    const originalText = Blob.prototype.text;
+    Blob.prototype.text = () => new Promise<string>(() => {});
+    try {
+      apiPost.mockResolvedValue({
+        data: { suggestedPrefix: 'acme:', suggestedName: '', categories: [], fileAssignments: [] },
+      });
+      seedFolderTree(); // seeded file is text/plain, so it gets content-sampled
+
+      const { result } = mountHook(useInferTaxonomy);
+      act(() => {
+        result.current.mutate({});
+      });
+
+      await waitFor(() => expect(useDataLakeWizardStore.getState().taxonomy.analyzing).toBe(true));
+      expect(apiPost).not.toHaveBeenCalled();
+    } finally {
+      Blob.prototype.text = originalText;
+    }
+  });
 });

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -291,14 +291,14 @@ describe('useBatchUpload onError', () => {
       ],
       taxonomy: {
         prefix: 'test:',
-        sourcePrefix: 'acme:',
         suggestedName: 'Acme',
         attempted: true,
         analyzing: false,
         fileAssignments: [],
         tags: [
           {
-            name: 'acme:type:agreement',
+            // User edited the suffix to "type:agreement"; originalName stays the inference id.
+            suffix: 'type:agreement',
             originalName: 'acme:type:contract',
             strength: 0.95,
             source: 'ai',
@@ -306,7 +306,7 @@ describe('useBatchUpload onError', () => {
             deleted: false,
           },
           {
-            name: 'acme:topic:hr',
+            suffix: 'topic:hr',
             originalName: 'acme:topic:hr',
             strength: 0.8,
             source: 'ai',
@@ -328,7 +328,7 @@ describe('useBatchUpload onError', () => {
 
     const presign = apiPost.mock.calls.find(([url]) => url === '/api/files/generate-presigned-urls-batch');
     const tagNames = (presign?.[1] as { files: { tags: { name: string }[] }[] }).files[0].tags.map(t => t.name).sort();
-    // Renamed tag applied under the user's config prefix; deleted tag gone; folder tag kept.
+    // Applied tag = prefix + edited suffix; deleted tag gone; folder tag kept.
     expect(tagNames).toEqual(['test:legal', 'test:type:agreement']);
   });
 
@@ -534,15 +534,17 @@ describe('useInferTaxonomy response handling', () => {
     useDataLakeWizardStore.getState().resetWizard();
   });
 
-  it('drops malformed categories and assignments instead of storing unusable tags', async () => {
+  it('splits each category into a stable originalName and an editable suffix, dropping malformed ones', async () => {
     apiPost.mockResolvedValue({
       data: {
         suggestedPrefix: 'acme:',
         suggestedName: 'Acme',
         categories: [
-          { tagName: 'acme:type:contract', confidence: 0.9, matchingFolders: ['legal'] },
+          { tagName: 'acme:type:contract', confidence: 0.9, matchingFolders: ['legal'] }, // carries prefix
+          { tagName: 'topic:finance', confidence: 0.85, matchingFolders: ['finance'] }, // no prefix -> whole name is suffix
           { confidence: 0.8, matchingFolders: ['finance'] }, // no tagName
           { tagName: '  ', confidence: 0.8 }, // blank tagName
+          { tagName: 'acme:', confidence: 0.8 }, // nothing but the prefix -> empty suffix, dropped
         ],
         fileAssignments: { nope: true }, // not an array
       },
@@ -557,26 +559,25 @@ describe('useInferTaxonomy response handling', () => {
     await waitFor(() => expect(useDataLakeWizardStore.getState().taxonomy.attempted).toBe(true));
 
     const { taxonomy } = useDataLakeWizardStore.getState();
-    expect(taxonomy.tags.map(t => t.name)).toEqual(['acme:type:contract']);
-    expect(taxonomy.tags[0].originalName).toBe('acme:type:contract');
+    expect(taxonomy.prefix).toBe('acme:');
+    // Prefix stripped into suffix; a category without the prefix keeps its whole name as suffix.
+    expect(taxonomy.tags.map(t => t.suffix)).toEqual(['type:contract', 'topic:finance']);
+    // originalName stays the full inferred name (the per-file-assignment join key).
+    expect(taxonomy.tags.map(t => t.originalName)).toEqual(['acme:type:contract', 'topic:finance']);
     expect(taxonomy.fileAssignments).toEqual([]);
     // The toast must reflect what was kept, not what the model claimed to send.
-    expect(toastMock.success).toHaveBeenCalledWith('AI suggested 1 tag categories');
+    expect(toastMock.success).toHaveBeenCalledWith('AI suggested 2 tag categories');
   });
 
   it('keeps the existing prefix when the endpoint returns an empty taxonomy', async () => {
-    // No API key configured -> emptyTaxonomy with a blank suggestedPrefix. Blanking
-    // sourcePrefix would make reprefixTag prepend, yielding "mine:acme:type:contract".
+    // No API key configured -> emptyTaxonomy with a blank suggestedPrefix. It must not blank
+    // a prefix the user already has, or Config's tagPrefix>=2 gate would strand them.
     apiPost.mockResolvedValue({
       data: { suggestedPrefix: '', suggestedName: '', categories: [], fileAssignments: [] },
     });
     seedFolderTree();
     useDataLakeWizardStore.setState({
-      taxonomy: {
-        ...useDataLakeWizardStore.getState().taxonomy,
-        prefix: 'mine:',
-        sourcePrefix: 'acme:',
-      },
+      taxonomy: { ...useDataLakeWizardStore.getState().taxonomy, prefix: 'mine:' },
     });
 
     const { result } = mountHook(useInferTaxonomy);
@@ -586,9 +587,7 @@ describe('useInferTaxonomy response handling', () => {
 
     await waitFor(() => expect(useDataLakeWizardStore.getState().taxonomy.attempted).toBe(true));
 
-    const { taxonomy } = useDataLakeWizardStore.getState();
-    expect(taxonomy.prefix).toBe('mine:');
-    expect(taxonomy.sourcePrefix).toBe('acme:');
+    expect(useDataLakeWizardStore.getState().taxonomy.prefix).toBe('mine:');
     expect(toastMock.success).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -88,6 +88,9 @@ const deriveSuffix = (fullName: string, sourcePrefix: string): string => {
  */
 function sanitizeCategories(categories: InferTaxonomyResponse['categories'], sourcePrefix: string): TaxonomyTag[] {
   if (!Array.isArray(categories)) return [];
+  // originalName is the React key and the sole key for update/delete/merge, so it must be
+  // unique: a model that repeats a tagName would otherwise make one card's edit hit both.
+  const seen = new Set<string>();
   return categories
     .filter(cat => cat && isNonEmptyString(cat.tagName))
     .map(cat => {
@@ -101,7 +104,13 @@ function sanitizeCategories(categories: InferTaxonomyResponse['categories'], sou
         deleted: false,
       };
     })
-    .filter(t => t.suffix.length > 0);
+    .filter(t => {
+      if (t.suffix.length === 0) return false;
+      const key = t.originalName.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
 }
 
 function sanitizeFileAssignments(assignments: InferTaxonomyResponse['fileAssignments']): TaxonomyFileAssignment[] {
@@ -135,6 +144,11 @@ export function useInferTaxonomy() {
       const included = allFiles.filter(f => !f.excluded);
       if (included.length === 0) throw new Error('No files included');
 
+      // Set BEFORE the content-sampling await below: that read can take hundreds of ms, and
+      // until analyzing flips true the step's Next/Skip gate (`!taxonomy.analyzing`) stays
+      // open, letting the user advance mid-inference and have onSuccess clobber their config.
+      setTaxonomyAnalyzing(true);
+
       const sampled = sampleFiles(included);
 
       // Build folder entries with optional content samples
@@ -156,8 +170,6 @@ export function useInferTaxonomy() {
           };
         })
       );
-
-      setTaxonomyAnalyzing(true);
 
       const response = await api.post<InferTaxonomyResponse>('/api/data-lakes/infer-taxonomy', {
         folderTree: folderEntries,

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -69,19 +69,39 @@ const isNonEmptyString = (value: unknown): value is string => typeof value === '
 const clampStrength = (value: unknown, fallback: number): number =>
   typeof value === 'number' && Number.isFinite(value) ? Math.min(Math.max(value, 0), 1) : fallback;
 
-/** Drop categories the model returned without a usable tag name; they can't be applied or reviewed. */
-function sanitizeCategories(categories: InferTaxonomyResponse['categories']): TaxonomyTag[] {
+/**
+ * The editable suffix is the tag name with its inferred prefix stripped, so the prefix is
+ * never stored per-tag (it lives once in taxonomy.prefix). A name that does not carry the
+ * inferred prefix keeps its whole text as the suffix.
+ */
+const deriveSuffix = (fullName: string, sourcePrefix: string): string => {
+  const trimmed = fullName.trim();
+  if (!sourcePrefix) return trimmed;
+  const p = sourcePrefix.endsWith(':') ? sourcePrefix : `${sourcePrefix}:`;
+  return trimmed.toLowerCase().startsWith(p.toLowerCase()) ? trimmed.slice(p.length) : trimmed;
+};
+
+/**
+ * Split each inferred category into its stable full name (originalName, the join key for
+ * per-file assignments) and its editable suffix. Drops entries the model returned without a
+ * usable tag name, or that reduce to an empty suffix (the tag was nothing but the prefix).
+ */
+function sanitizeCategories(categories: InferTaxonomyResponse['categories'], sourcePrefix: string): TaxonomyTag[] {
   if (!Array.isArray(categories)) return [];
   return categories
     .filter(cat => cat && isNonEmptyString(cat.tagName))
-    .map(cat => ({
-      name: cat.tagName.trim(),
-      originalName: cat.tagName.trim(),
-      strength: clampStrength(cat.confidence, 0.7),
-      source: 'ai' as const,
-      matchingFolders: Array.isArray(cat.matchingFolders) ? cat.matchingFolders.filter(isNonEmptyString) : [],
-      deleted: false,
-    }));
+    .map(cat => {
+      const originalName = cat.tagName.trim();
+      return {
+        suffix: deriveSuffix(originalName, sourcePrefix),
+        originalName,
+        strength: clampStrength(cat.confidence, 0.7),
+        source: 'ai' as const,
+        matchingFolders: Array.isArray(cat.matchingFolders) ? cat.matchingFolders.filter(isNonEmptyString) : [],
+        deleted: false,
+      };
+    })
+    .filter(t => t.suffix.length > 0);
 }
 
 function sanitizeFileAssignments(assignments: InferTaxonomyResponse['fileAssignments']): TaxonomyFileAssignment[] {
@@ -153,15 +173,15 @@ export function useInferTaxonomy() {
       // returns the model's raw JSON, so everything below is sanitized HERE, at the single
       // boundary where inference enters the store. Downstream (tagsForFile) runs mid-upload,
       // after the lake exists - a TypeError there would roll back a real upload.
-      const tags = sanitizeCategories(data.categories);
+      // Strip the inferred prefix off each tag into its suffix so the prefix is stored only
+      // once (in `prefix`); the cards render `prefix + suffix`.
+      const tags = sanitizeCategories(data.categories, data.suggestedPrefix || '');
       // An empty response (no API key configured) must not blank a prefix the user already
-      // has: config.tagPrefix keeps its old value regardless, and a blank sourcePrefix would
-      // make reprefixTag prepend instead of rewrite, producing "mine:acme:type:contract".
+      // has: config.tagPrefix keeps its old value regardless.
       const prefix = data.suggestedPrefix || previous.prefix;
 
       setTaxonomy({
         prefix,
-        sourcePrefix: data.suggestedPrefix || previous.sourcePrefix,
         suggestedName: typeof data.suggestedName === 'string' ? data.suggestedName : '',
         tags,
         fileAssignments: sanitizeFileAssignments(data.fileAssignments),

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -118,7 +118,9 @@ function sanitizeFileAssignments(assignments: InferTaxonomyResponse['fileAssignm
   return assignments
     .filter(entry => entry && isNonEmptyString(entry.relativePath))
     .map(entry => ({
-      relativePath: entry.relativePath,
+      // Trim on write to match how categories are stored: tagsForFile matches assignments by
+      // strict path equality, so a padded path would otherwise miss its per-file suggestions.
+      relativePath: entry.relativePath.trim(),
       suggestedTags: Array.isArray(entry.suggestedTags)
         ? entry.suggestedTags
             .filter(tag => tag && isNonEmptyString(tag.name))

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -4,6 +4,7 @@ import type {
   InferTaxonomyRequestInputType,
   IMessageDataToClient,
   IFabFileDocument,
+  TaxonomyFileAssignment,
 } from '@bike4mind/common';
 import { isSupportedFabFileMimeType } from '@bike4mind/common';
 import type { CreateDataLakeRequestInputType } from '@bike4mind/common';
@@ -13,6 +14,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
   useDataLakeWizardStore,
+  type TaxonomyTag,
   type UploadProgress,
   type UploadErrorKind,
 } from '@client/app/stores/useDataLakeWizardStore';
@@ -60,6 +62,40 @@ async function readContentSample(file: File, maxBytes = 500): Promise<string> {
   } catch {
     return '';
   }
+}
+
+const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
+
+const clampStrength = (value: unknown, fallback: number): number =>
+  typeof value === 'number' && Number.isFinite(value) ? Math.min(Math.max(value, 0), 1) : fallback;
+
+/** Drop categories the model returned without a usable tag name; they can't be applied or reviewed. */
+function sanitizeCategories(categories: InferTaxonomyResponse['categories']): TaxonomyTag[] {
+  if (!Array.isArray(categories)) return [];
+  return categories
+    .filter(cat => cat && isNonEmptyString(cat.tagName))
+    .map(cat => ({
+      name: cat.tagName.trim(),
+      originalName: cat.tagName.trim(),
+      strength: clampStrength(cat.confidence, 0.7),
+      source: 'ai' as const,
+      matchingFolders: Array.isArray(cat.matchingFolders) ? cat.matchingFolders.filter(isNonEmptyString) : [],
+      deleted: false,
+    }));
+}
+
+function sanitizeFileAssignments(assignments: InferTaxonomyResponse['fileAssignments']): TaxonomyFileAssignment[] {
+  if (!Array.isArray(assignments)) return [];
+  return assignments
+    .filter(entry => entry && isNonEmptyString(entry.relativePath))
+    .map(entry => ({
+      relativePath: entry.relativePath,
+      suggestedTags: Array.isArray(entry.suggestedTags)
+        ? entry.suggestedTags
+            .filter(tag => tag && isNonEmptyString(tag.name))
+            .map(tag => ({ name: tag.name.trim(), strength: clampStrength(tag.strength, 0.7) }))
+        : [],
+    }));
 }
 
 /**
@@ -112,26 +148,28 @@ export function useInferTaxonomy() {
       return response.data;
     },
     onSuccess: data => {
+      const previous = useDataLakeWizardStore.getState().taxonomy;
+      // The endpoint validates only suggestedPrefix + categories-is-an-array and otherwise
+      // returns the model's raw JSON, so everything below is sanitized HERE, at the single
+      // boundary where inference enters the store. Downstream (tagsForFile) runs mid-upload,
+      // after the lake exists - a TypeError there would roll back a real upload.
+      const tags = sanitizeCategories(data.categories);
+      // An empty response (no API key configured) must not blank a prefix the user already
+      // has: config.tagPrefix keeps its old value regardless, and a blank sourcePrefix would
+      // make reprefixTag prepend instead of rewrite, producing "mine:acme:type:contract".
+      const prefix = data.suggestedPrefix || previous.prefix;
+
       setTaxonomy({
-        prefix: data.suggestedPrefix,
-        sourcePrefix: data.suggestedPrefix,
-        suggestedName: data.suggestedName,
-        tags: data.categories.map(cat => ({
-          name: cat.tagName,
-          originalName: cat.tagName,
-          strength: cat.confidence,
-          source: 'ai' as const,
-          matchingFolders: cat.matchingFolders ?? [],
-          deleted: false,
-        })),
-        // The endpoint degrades to an empty taxonomy on any failure, so treat every
-        // field as optional rather than trusting the happy-path shape.
-        fileAssignments: data.fileAssignments ?? [],
+        prefix,
+        sourcePrefix: data.suggestedPrefix || previous.sourcePrefix,
+        suggestedName: typeof data.suggestedName === 'string' ? data.suggestedName : '',
+        tags,
+        fileAssignments: sanitizeFileAssignments(data.fileAssignments),
         attempted: true,
         analyzing: false,
       });
-      if (data.categories.length > 0) {
-        toast.success(`AI suggested ${data.categories.length} tag categories`);
+      if (tags.length > 0) {
+        toast.success(`AI suggested ${tags.length} tag categories`);
       }
     },
     onError: (error: Error) => {

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -20,28 +20,10 @@ import { activeOrgId } from '@client/app/hooks/data/dataLakes';
 import { slugifyDataLakeName, MIN_DATA_LAKE_SLUG_LENGTH } from '@client/app/hooks/data/dataLakeSlug';
 import type { WizardFile } from '@client/app/utils/folderTreeParser';
 import { computeFileHash } from '@client/app/utils/folderTreeParser';
+import { appliedTagsForBatch, tagsForFile } from '@client/app/utils/dataLakeTaxonomy';
 import { invalidateGearsStatusWhileLocked } from '@client/app/hooks/useGearsStatus';
 import axios from 'axios';
 import { uploadFileToUrl } from '@client/app/utils/uploadFileToUrl';
-
-/**
- * Derive a single tag for a file from its immediate parent folder, so each file
- * is tagged by its source folder (e.g. a disease site) rather than getting every
- * taxonomy category. Returns [] for root-level files (they get only the lake
- * meta-tag). Uses underscores to match the AI taxonomy's folder-slug style.
- */
-function folderTagForFile(relativePath: string, tagPrefix: string): { name: string; strength: number }[] {
-  const segments = relativePath.split('/').filter(Boolean);
-  const parent = segments.length >= 2 ? segments[segments.length - 2] : undefined;
-  if (!parent) return [];
-  const slug = parent
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
-  if (!slug) return [];
-  const prefix = tagPrefix.endsWith(':') ? tagPrefix : `${tagPrefix}:`;
-  return [{ name: `${prefix}${slug}`, strength: 1.0 }];
-}
 
 /**
  * Stratified sampling: pick up to `maxPerFolder` files from each unique folder path,
@@ -88,6 +70,7 @@ export function useInferTaxonomy() {
   const allFiles = useDataLakeWizardStore(s => s.allFiles);
   const setTaxonomy = useDataLakeWizardStore(s => s.setTaxonomy);
   const setTaxonomyAnalyzing = useDataLakeWizardStore(s => s.setTaxonomyAnalyzing);
+  const markTaxonomyAttempted = useDataLakeWizardStore(s => s.markTaxonomyAttempted);
 
   return useMutation({
     mutationFn: async (options?: { context?: string; existingPrefix?: string }) => {
@@ -131,21 +114,28 @@ export function useInferTaxonomy() {
     onSuccess: data => {
       setTaxonomy({
         prefix: data.suggestedPrefix,
+        sourcePrefix: data.suggestedPrefix,
         suggestedName: data.suggestedName,
         tags: data.categories.map(cat => ({
           name: cat.tagName,
+          originalName: cat.tagName,
           strength: cat.confidence,
           source: 'ai' as const,
-          sampleFileNames: cat.matchingFolders,
+          matchingFolders: cat.matchingFolders ?? [],
           deleted: false,
         })),
-        analyzed: true,
+        // The endpoint degrades to an empty taxonomy on any failure, so treat every
+        // field as optional rather than trusting the happy-path shape.
+        fileAssignments: data.fileAssignments ?? [],
+        attempted: true,
         analyzing: false,
       });
-      toast.success(`AI suggested ${data.categories.length} tag categories`);
+      if (data.categories.length > 0) {
+        toast.success(`AI suggested ${data.categories.length} tag categories`);
+      }
     },
     onError: (error: Error) => {
-      setTaxonomyAnalyzing(false);
+      markTaxonomyAttempted();
       toast.error(error.message || 'Failed to infer taxonomy');
     },
   });
@@ -399,7 +389,7 @@ export function useBatchUpload() {
 
       // Read from store at mutation time to avoid stale closure
       // (same pattern as useComputeHashes)
-      const { config, allFiles, targetLake } = useDataLakeWizardStore.getState();
+      const { config, allFiles, targetLake, taxonomy } = useDataLakeWizardStore.getState();
       let included = allFiles.filter(f => !f.excluded);
       if (included.length === 0) throw new Error('No files to upload');
 
@@ -479,12 +469,10 @@ export function useBatchUpload() {
       try {
         const totalSizeBytes = included.reduce((sum, f) => sum + f.size, 0);
 
-        // Per-file tags derived from each file's source folder (one tag = its
-        // folder/disease), so disease folders stay meaningful instead of every
-        // file carrying every taxonomy tag. The lake meta-tag is added server-side.
-        const appliedTags = Array.from(
-          new Set(included.flatMap(f => folderTagForFile(f.relativePath, tagPrefix).map(t => t.name)))
-        ).map(name => ({ name, strength: 1.0 }));
+        // Per-file tags: each file's source folder plus the taxonomy categories the
+        // user reviewed (append mode has no taxonomy step, so it stays folder-only).
+        // The lake meta-tag is added server-side.
+        const appliedTags = appliedTagsForBatch(included, taxonomy, tagPrefix);
 
         // Step 2: Create batch record
         const batchRes = await api.post<{ id: string }>('/api/data-lakes/batches', {
@@ -531,7 +519,9 @@ export function useBatchUpload() {
                 fileSize: f.size,
                 relativePath: f.relativePath,
                 ...(f.contentHash && { contentHash: f.contentHash }),
-                tags: folderTagForFile(f.relativePath, tagPrefix),
+                // Each file's source folder plus the reviewed taxonomy categories covering
+                // it (append mode has an empty taxonomy, so this stays folder-only).
+                tags: tagsForFile(f.relativePath, taxonomy, tagPrefix),
               })),
               dataLakeSlug: slug,
               // Correlate every uploaded file to its batch so the pipeline

--- a/apps/client/app/stores/useDataLakeWizardStore.test.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { useDataLakeWizardStore } from './useDataLakeWizardStore';
+import type { WizardFile } from '../utils/folderTreeParser';
+
+/**
+ * Opening the wizard must start a genuinely clean create session. taxonomy.prefix and
+ * config.tagPrefix are a synced pair now (the taxonomy step drives the applied tags), so a
+ * partial reset that blanked taxonomy but kept a prior config.tagPrefix would upload files
+ * with a prefix the user never sees on the review step.
+ */
+
+const staleFile = (): WizardFile => ({
+  file: new File(['x'], 'a.txt', { type: 'text/plain' }),
+  relativePath: 'old/a.txt',
+  size: 1,
+  type: 'text/plain',
+  excluded: false,
+  isDuplicate: false,
+});
+
+const seedStaleSession = () =>
+  useDataLakeWizardStore.setState({
+    allFiles: [staleFile()],
+    config: {
+      name: 'Old Lake',
+      description: 'old',
+      tagPrefix: 'old:',
+      requiredUserTag: 'x',
+      requiredEntitlement: 'y',
+      conflictResolution: 'skip',
+    },
+    taxonomy: {
+      prefix: 'old:',
+      suggestedName: 'Old',
+      tags: [
+        {
+          suffix: 'type:x',
+          originalName: 'old:type:x',
+          strength: 0.9,
+          source: 'ai',
+          matchingFolders: [],
+          deleted: false,
+        },
+      ],
+      fileAssignments: [],
+      attempted: true,
+      analyzing: false,
+    },
+  });
+
+describe('useDataLakeWizardStore - open starts a clean session', () => {
+  afterEach(() => useDataLakeWizardStore.getState().resetWizard());
+
+  it('openWizard clears a prior session (no config/prefix/files leak)', () => {
+    seedStaleSession();
+
+    useDataLakeWizardStore.getState().openWizard();
+
+    const s = useDataLakeWizardStore.getState();
+    expect(s.isOpen).toBe(true);
+    expect(s.step).toBe('source');
+    expect(s.targetLake).toBeNull();
+    expect(s.allFiles).toEqual([]);
+    expect(s.config.name).toBe('');
+    // The desync guard: taxonomy.prefix and config.tagPrefix both reset together.
+    expect(s.config.tagPrefix).toBe('');
+    expect(s.taxonomy.prefix).toBe('');
+    expect(s.taxonomy.tags).toEqual([]);
+    expect(s.taxonomy.attempted).toBe(false);
+  });
+
+  it('openWizardForLake clears a prior session and preseeds config from the lake only', () => {
+    seedStaleSession();
+
+    useDataLakeWizardStore.getState().openWizardForLake({
+      id: 'l1',
+      slug: 'niche',
+      name: 'Niche',
+      fileTagPrefix: 'niche:',
+    });
+
+    const s = useDataLakeWizardStore.getState();
+    expect(s.targetLake?.id).toBe('l1');
+    expect(s.allFiles).toEqual([]);
+    expect(s.config.name).toBe('Niche');
+    expect(s.config.tagPrefix).toBe('niche:');
+    // Stale fields from the prior session don't survive.
+    expect(s.config.description).toBe('');
+    expect(s.config.requiredUserTag).toBe('');
+    expect(s.taxonomy.tags).toEqual([]);
+  });
+});

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { TaxonomyFileAssignment } from '@bike4mind/common';
 import type { FolderTreeNode, WizardFile } from '../utils/folderTreeParser';
 import {
   parseFilesToTree,
@@ -16,23 +17,34 @@ export type WizardStep = 'source' | 'preview' | 'taxonomy' | 'config' | 'upload'
 export type ManagerTab = 'mine' | 'discover';
 
 export interface TaxonomyTag {
-  /** Full tag name, e.g. "acme:type:contract" */
+  /** Full tag name, e.g. "acme:type:contract"; editable by the user */
   name: string;
+  /**
+   * The name inference assigned, kept stable across user renames. Per-file assignments
+   * reference it, so it is the join key when applying tags at upload time.
+   */
+  originalName: string;
   /** Confidence/relevance score 0.0-1.0 */
   strength: number;
   /** How this tag was inferred */
   source: 'folder' | 'ai';
-  /** Sample file names for review */
-  sampleFileNames: string[];
+  /** Folder paths this tag covers; drives both the review preview and which files get it */
+  matchingFolders: string[];
   /** Whether this tag has been soft-deleted by the user */
   deleted: boolean;
 }
 
 export interface TaxonomyResult {
+  /** Tag prefix, editable by the user (kept in sync with config.tagPrefix) */
   prefix: string;
+  /** Prefix as inference returned it; tag names embed it, so rewriting needs it unedited */
+  sourcePrefix: string;
   suggestedName: string;
   tags: TaxonomyTag[];
-  analyzed: boolean;
+  /** Per-file tag suggestions for the sampled files (inference only samples a subset) */
+  fileAssignments: TaxonomyFileAssignment[];
+  /** Inference has been run - success OR failure. Never gates progression; the step is optional. */
+  attempted: boolean;
   analyzing: boolean;
 }
 
@@ -71,9 +83,11 @@ export interface UploadProgress {
 
 const DEFAULT_TAXONOMY: TaxonomyResult = {
   prefix: '',
+  sourcePrefix: '',
   suggestedName: '',
   tags: [],
-  analyzed: false,
+  fileAssignments: [],
+  attempted: false,
   analyzing: false,
 };
 
@@ -149,9 +163,11 @@ interface DataLakeWizardStore {
   // Taxonomy step
   setTaxonomy: (result: TaxonomyResult) => void;
   setTaxonomyAnalyzing: (analyzing: boolean) => void;
+  markTaxonomyAttempted: () => void;
   updateTag: (tagName: string, updates: Partial<TaxonomyTag>) => void;
   mergeTags: (sourceTagName: string, targetTagName: string) => void;
   deleteTag: (tagName: string) => void;
+  setTagPrefix: (prefix: string) => void;
 
   // Config step
   setConfig: (config: Partial<DataLakeFormValues>) => void;
@@ -189,7 +205,9 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
 
   // ── Navigation ──────────────────────────────────────────────────────────
 
-  openWizard: () => set({ isOpen: true, step: 'source', targetLake: null }),
+  // Taxonomy is cleared on every open: it now drives the tags files are actually
+  // uploaded with, so a previous run's categories must never leak into this one.
+  openWizard: () => set({ isOpen: true, step: 'source', targetLake: null, taxonomy: { ...DEFAULT_TAXONOMY } }),
 
   // Management panel (list lakes, add files, lifecycle). Its internal "Create"
   // button calls openWizard, which stacks the wizard on top and returns here on close.
@@ -204,6 +222,7 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
       isOpen: true,
       step: 'source',
       targetLake: lake,
+      taxonomy: { ...DEFAULT_TAXONOMY },
       config: {
         ...state.config,
         name: lake.name,
@@ -260,6 +279,10 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
 
   setTaxonomyAnalyzing: analyzing => set(state => ({ taxonomy: { ...state.taxonomy, analyzing } })),
 
+  // Failure path: inference is optional, so a failed run still counts as attempted -
+  // otherwise the step shows a blank pane instead of its empty state + Re-analyze.
+  markTaxonomyAttempted: () => set(state => ({ taxonomy: { ...state.taxonomy, attempted: true, analyzing: false } })),
+
   updateTag: (tagName, updates) =>
     set(state => ({
       taxonomy: {
@@ -281,7 +304,7 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
             if (t.name === targetTagName) {
               return {
                 ...t,
-                sampleFileNames: [...new Set([...t.sampleFileNames, ...sourceTag.sampleFileNames])],
+                matchingFolders: [...new Set([...t.matchingFolders, ...sourceTag.matchingFolders])],
                 strength: Math.max(t.strength, sourceTag.strength),
               };
             }
@@ -300,6 +323,15 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
         ...state.taxonomy,
         tags: state.taxonomy.tags.map(t => (t.name === tagName ? { ...t, deleted: true } : t)),
       },
+    })),
+
+  // The Tag Prefix's single editable home is the taxonomy step (#829): the prefix is
+  // embedded in every applied tag name there and consumed by Re-analyze. Kept in sync with
+  // config.tagPrefix so the Config gate and append-mode display read one value.
+  setTagPrefix: prefix =>
+    set(state => ({
+      taxonomy: { ...state.taxonomy, prefix },
+      config: { ...state.config, tagPrefix: prefix },
     })),
 
   // ── Config Step ─────────────────────────────────────────────────────────

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -114,6 +114,25 @@ const DEFAULT_UPLOAD_PROGRESS: UploadProgress = {
   status: 'idle',
 };
 
+/**
+ * A clean create-session's worth of state (everything except isOpen). Shared by openWizard,
+ * openWizardForLake, and resetWizard so opening the wizard can never inherit a prior session's
+ * files, config, or taxonomy - the fields are a synced set (e.g. taxonomy.prefix <-> config
+ * .tagPrefix), so resetting only some of them would desync them.
+ */
+const freshSession = () => ({
+  step: 'source' as WizardStep,
+  folderTree: null,
+  allFiles: [] as WizardFile[],
+  excludedPatterns: [...DEFAULT_EXCLUDED_PATTERNS],
+  taxonomy: { ...DEFAULT_TAXONOMY },
+  config: { ...DEFAULT_CONFIG },
+  duplicateCheckResults: null,
+  uploadProgress: { ...DEFAULT_UPLOAD_PROGRESS },
+  hashingProgress: { total: 0, completed: 0, status: 'idle' as const },
+  targetLake: null as WizardTargetLake | null,
+});
+
 // ── Store ───────────────────────────────────────────────────────────────────
 
 /**
@@ -209,9 +228,9 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
 
   // ── Navigation ──────────────────────────────────────────────────────────
 
-  // Taxonomy is cleared on every open: it now drives the tags files are actually
-  // uploaded with, so a previous run's categories must never leak into this one.
-  openWizard: () => set({ isOpen: true, step: 'source', targetLake: null, taxonomy: { ...DEFAULT_TAXONOMY } }),
+  // Always a clean session: taxonomy now drives the tags files are uploaded with, and config
+  // .tagPrefix is synced to taxonomy.prefix, so a stale prior session must not leak in.
+  openWizard: () => set({ isOpen: true, ...freshSession() }),
 
   // Management panel (list lakes, add files, lifecycle). Its internal "Create"
   // button calls openWizard, which stacks the wizard on top and returns here on close.
@@ -222,19 +241,18 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
   // Append mode: upload into an existing lake. Preseeds config from the lake so
   // the (locked) Config step shows the right values; taxonomy is skipped.
   openWizardForLake: lake =>
-    set(state => ({
+    set({
       isOpen: true,
-      step: 'source',
+      ...freshSession(),
       targetLake: lake,
-      taxonomy: { ...DEFAULT_TAXONOMY },
       config: {
-        ...state.config,
+        ...DEFAULT_CONFIG,
         name: lake.name,
         tagPrefix: lake.fileTagPrefix,
         requiredUserTag: lake.requiredUserTag ?? '',
         requiredEntitlement: lake.requiredEntitlement ?? '',
       },
-    })),
+    }),
 
   closeWizard: () => set({ isOpen: false }),
 
@@ -273,11 +291,12 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
   setTaxonomy: result =>
     set({
       taxonomy: result,
-      // Auto-fill config from taxonomy suggestion
+      // Auto-fill config from the suggestion, but a value the user already typed wins - else
+      // a Re-analyze would silently overwrite the name/prefix they set on the Config step.
       config: {
         ...get().config,
-        name: result.suggestedName || get().config.name,
-        tagPrefix: result.prefix || get().config.tagPrefix,
+        name: get().config.name || result.suggestedName,
+        tagPrefix: get().config.tagPrefix || result.prefix,
       },
     }),
 
@@ -384,18 +403,5 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
 
   // ── Reset ───────────────────────────────────────────────────────────────
 
-  resetWizard: () =>
-    set({
-      isOpen: false,
-      step: 'source',
-      folderTree: null,
-      allFiles: [],
-      excludedPatterns: [...DEFAULT_EXCLUDED_PATTERNS],
-      taxonomy: { ...DEFAULT_TAXONOMY },
-      config: { ...DEFAULT_CONFIG },
-      duplicateCheckResults: null,
-      uploadProgress: { ...DEFAULT_UPLOAD_PROGRESS },
-      hashingProgress: { total: 0, completed: 0, status: 'idle' as const },
-      targetLake: null,
-    }),
+  resetWizard: () => set({ isOpen: false, ...freshSession() }),
 }));

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -164,9 +164,9 @@ interface DataLakeWizardStore {
   setTaxonomy: (result: TaxonomyResult) => void;
   setTaxonomyAnalyzing: (analyzing: boolean) => void;
   markTaxonomyAttempted: () => void;
-  updateTag: (tagName: string, updates: Partial<TaxonomyTag>) => void;
-  mergeTags: (sourceTagName: string, targetTagName: string) => void;
-  deleteTag: (tagName: string) => void;
+  updateTag: (originalName: string, updates: Partial<TaxonomyTag>) => void;
+  mergeTags: (sourceOriginalName: string, targetOriginalName: string) => void;
+  deleteTag: (originalName: string) => void;
   setTagPrefix: (prefix: string) => void;
 
   // Config step
@@ -283,32 +283,34 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
   // otherwise the step shows a blank pane instead of its empty state + Re-analyze.
   markTaxonomyAttempted: () => set(state => ({ taxonomy: { ...state.taxonomy, attempted: true, analyzing: false } })),
 
-  updateTag: (tagName, updates) =>
+  // All three mutators key on originalName, never the user-editable name: renaming one tag
+  // onto another's name would otherwise make a single edit or delete hit both.
+  updateTag: (originalName, updates) =>
     set(state => ({
       taxonomy: {
         ...state.taxonomy,
-        tags: state.taxonomy.tags.map(t => (t.name === tagName ? { ...t, ...updates } : t)),
+        tags: state.taxonomy.tags.map(t => (t.originalName === originalName ? { ...t, ...updates } : t)),
       },
     })),
 
-  mergeTags: (sourceTagName, targetTagName) =>
+  mergeTags: (sourceOriginalName, targetOriginalName) =>
     set(state => {
-      const sourceTag = state.taxonomy.tags.find(t => t.name === sourceTagName);
-      const targetTag = state.taxonomy.tags.find(t => t.name === targetTagName);
+      const sourceTag = state.taxonomy.tags.find(t => t.originalName === sourceOriginalName);
+      const targetTag = state.taxonomy.tags.find(t => t.originalName === targetOriginalName);
       if (!sourceTag || !targetTag) return state;
 
       return {
         taxonomy: {
           ...state.taxonomy,
           tags: state.taxonomy.tags.map(t => {
-            if (t.name === targetTagName) {
+            if (t.originalName === targetOriginalName) {
               return {
                 ...t,
                 matchingFolders: [...new Set([...t.matchingFolders, ...sourceTag.matchingFolders])],
                 strength: Math.max(t.strength, sourceTag.strength),
               };
             }
-            if (t.name === sourceTagName) {
+            if (t.originalName === sourceOriginalName) {
               return { ...t, deleted: true };
             }
             return t;
@@ -317,11 +319,11 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
       };
     }),
 
-  deleteTag: tagName =>
+  deleteTag: originalName =>
     set(state => ({
       taxonomy: {
         ...state.taxonomy,
-        tags: state.taxonomy.tags.map(t => (t.name === tagName ? { ...t, deleted: true } : t)),
+        tags: state.taxonomy.tags.map(t => (t.originalName === originalName ? { ...t, deleted: true } : t)),
       },
     })),
 

--- a/apps/client/app/stores/useDataLakeWizardStore.ts
+++ b/apps/client/app/stores/useDataLakeWizardStore.ts
@@ -17,11 +17,15 @@ export type WizardStep = 'source' | 'preview' | 'taxonomy' | 'config' | 'upload'
 export type ManagerTab = 'mine' | 'discover';
 
 export interface TaxonomyTag {
-  /** Full tag name, e.g. "acme:type:contract"; editable by the user */
-  name: string;
   /**
-   * The name inference assigned, kept stable across user renames. Per-file assignments
-   * reference it, so it is the join key when applying tags at upload time.
+   * The editable part of the tag AFTER the shared prefix, e.g. "type:contract". The full
+   * applied tag is `taxonomy.prefix + suffix`, so the prefix lives in exactly one place
+   * (taxonomy.prefix) and can never be duplicated or drift into a tag's own text.
+   */
+  suffix: string;
+  /**
+   * The full name inference assigned (incl. its original prefix), kept stable across user
+   * edits. Per-file assignments reference it, so it is the join key at upload time.
    */
   originalName: string;
   /** Confidence/relevance score 0.0-1.0 */
@@ -35,10 +39,11 @@ export interface TaxonomyTag {
 }
 
 export interface TaxonomyResult {
-  /** Tag prefix, editable by the user (kept in sync with config.tagPrefix) */
+  /**
+   * The single shared tag prefix (kept in sync with config.tagPrefix). Every tag is
+   * `prefix + tag.suffix`, so editing this one value re-namespaces every card at once.
+   */
   prefix: string;
-  /** Prefix as inference returned it; tag names embed it, so rewriting needs it unedited */
-  sourcePrefix: string;
   suggestedName: string;
   tags: TaxonomyTag[];
   /** Per-file tag suggestions for the sampled files (inference only samples a subset) */
@@ -83,7 +88,6 @@ export interface UploadProgress {
 
 const DEFAULT_TAXONOMY: TaxonomyResult = {
   prefix: '',
-  sourcePrefix: '',
   suggestedName: '',
   tags: [],
   fileAssignments: [],
@@ -283,8 +287,8 @@ export const useDataLakeWizardStore = create<DataLakeWizardStore>((set, get) => 
   // otherwise the step shows a blank pane instead of its empty state + Re-analyze.
   markTaxonomyAttempted: () => set(state => ({ taxonomy: { ...state.taxonomy, attempted: true, analyzing: false } })),
 
-  // All three mutators key on originalName, never the user-editable name: renaming one tag
-  // onto another's name would otherwise make a single edit or delete hit both.
+  // All three mutators key on originalName (stable inference id), never the editable suffix:
+  // editing one tag's suffix to match another's would otherwise make a delete hit both.
   updateTag: (originalName, updates) =>
     set(state => ({
       taxonomy: {

--- a/apps/client/app/utils/dataLakeTaxonomy.test.ts
+++ b/apps/client/app/utils/dataLakeTaxonomy.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import type { TaxonomyResult, TaxonomyTag } from '@client/app/stores/useDataLakeWizardStore';
+import { appliedTagsForBatch, folderMatches, reprefixTag, tagsForFile } from './dataLakeTaxonomy';
+
+/**
+ * Regression coverage: the Taxonomy step used to be pure theater - inference returned
+ * categories and per-file assignments, the user edited them, and the upload path threw
+ * all of it away in favor of a folder slug. These tests pin the review edits (rename,
+ * delete) to what actually ships in the presigned-URL request.
+ */
+
+const tag = (overrides: Partial<TaxonomyTag> & { name: string }): TaxonomyTag => ({
+  originalName: overrides.name,
+  strength: 0.9,
+  source: 'ai',
+  matchingFolders: [],
+  deleted: false,
+  ...overrides,
+});
+
+const taxonomy = (overrides: Partial<TaxonomyResult> = {}): TaxonomyResult => ({
+  prefix: 'acme:',
+  sourcePrefix: 'acme:',
+  suggestedName: 'Acme',
+  tags: [],
+  fileAssignments: [],
+  attempted: true,
+  analyzing: false,
+  ...overrides,
+});
+
+const names = (tags: { name: string }[]) => tags.map(t => t.name).sort();
+
+describe('folderMatches', () => {
+  it('matches a multi-segment folder path anywhere in the file path', () => {
+    expect(folderMatches(['root', 'legal', 'agreements', '2024'], 'legal/agreements')).toBe(true);
+  });
+
+  it('does not match segments that are merely adjacent out of order', () => {
+    expect(folderMatches(['root', 'agreements', 'legal'], 'legal/agreements')).toBe(false);
+  });
+
+  it('ignores case, surrounding slashes, and empty entries', () => {
+    expect(folderMatches(['root', 'legal'], '/Legal/')).toBe(true);
+    expect(folderMatches(['root', 'legal'], '')).toBe(false);
+  });
+});
+
+describe('reprefixTag', () => {
+  it('swaps the inferred prefix for the one the user settled on', () => {
+    expect(reprefixTag('acme:type:contract', 'acme:', 'lake:')).toBe('lake:type:contract');
+  });
+
+  it('tolerates prefixes given without the trailing colon', () => {
+    expect(reprefixTag('acme:type:contract', 'acme', 'lake')).toBe('lake:type:contract');
+  });
+
+  it('prefixes rather than rewrites a tag that does not carry the inferred prefix', () => {
+    // Dropping the leading segment here would silently turn "type:contract" into
+    // "lake:contract" and lose the dimension.
+    expect(reprefixTag('type:contract', 'acme:', 'lake:')).toBe('lake:type:contract');
+  });
+
+  it('leaves an already-correct tag untouched', () => {
+    expect(reprefixTag('lake:type:contract', '', 'lake:')).toBe('lake:type:contract');
+  });
+});
+
+describe('tagsForFile', () => {
+  it('falls back to the folder tag when there is no taxonomy', () => {
+    expect(tagsForFile('root/reports/q1.pdf', taxonomy(), 'lake:')).toEqual([{ name: 'lake:reports', strength: 1.0 }]);
+  });
+
+  it('applies categories whose folders cover the file, alongside the folder tag', () => {
+    const result = tagsForFile(
+      'root/legal/agreements/vendor.pdf',
+      taxonomy({
+        tags: [
+          tag({ name: 'acme:type:contract', matchingFolders: ['legal/agreements'] }),
+          tag({ name: 'acme:topic:finance', matchingFolders: ['finance'] }),
+        ],
+      }),
+      'acme:'
+    );
+    expect(names(result)).toEqual(['acme:agreements', 'acme:type:contract']);
+  });
+
+  it('drops categories the user deleted', () => {
+    const result = tagsForFile(
+      'root/legal/vendor.pdf',
+      taxonomy({ tags: [tag({ name: 'acme:type:contract', matchingFolders: ['legal'], deleted: true })] }),
+      'acme:'
+    );
+    expect(names(result)).toEqual(['acme:legal']);
+  });
+
+  it('honors a rename, including for per-file assignments that reference the original name', () => {
+    const result = tagsForFile(
+      'root/legal/vendor.pdf',
+      taxonomy({
+        tags: [tag({ name: 'acme:type:agreement', originalName: 'acme:type:contract', matchingFolders: ['legal'] })],
+        fileAssignments: [
+          { relativePath: 'root/legal/vendor.pdf', suggestedTags: [{ name: 'acme:type:contract', strength: 0.95 }] },
+        ],
+      }),
+      'acme:'
+    );
+    expect(names(result)).toEqual(['acme:legal', 'acme:type:agreement']);
+    expect(result.find(t => t.name === 'acme:type:agreement')?.strength).toBe(0.95);
+  });
+
+  it('ignores assignments for tags that were never declared as categories', () => {
+    const result = tagsForFile(
+      'root/legal/vendor.pdf',
+      taxonomy({
+        fileAssignments: [
+          { relativePath: 'root/legal/vendor.pdf', suggestedTags: [{ name: 'acme:invented', strength: 1 }] },
+        ],
+      }),
+      'acme:'
+    );
+    expect(names(result)).toEqual(['acme:legal']);
+  });
+
+  it('rewrites taxonomy tags to the final prefix so a lake never mixes namespaces', () => {
+    const result = tagsForFile(
+      'root/legal/vendor.pdf',
+      taxonomy({ tags: [tag({ name: 'acme:type:contract', matchingFolders: ['legal'] })] }),
+      'renamed:'
+    );
+    expect(names(result)).toEqual(['renamed:legal', 'renamed:type:contract']);
+  });
+
+  it('caps how many categories a single file can accumulate, keeping the strongest', () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      tag({ name: `acme:cat${i}`, matchingFolders: ['legal'], strength: i / 12 })
+    );
+    const result = tagsForFile('root/legal/vendor.pdf', taxonomy({ tags: many }), 'acme:');
+    expect(result).toHaveLength(9); // 8 taxonomy tags + the folder tag
+    expect(result.map(t => t.name)).toContain('acme:cat11');
+    expect(result.map(t => t.name)).not.toContain('acme:cat0');
+  });
+
+  it('does not duplicate a taxonomy tag that equals the folder tag', () => {
+    const result = tagsForFile(
+      'root/legal/vendor.pdf',
+      taxonomy({ tags: [tag({ name: 'acme:legal', matchingFolders: ['legal'] })] }),
+      'acme:'
+    );
+    expect(names(result)).toEqual(['acme:legal']);
+  });
+
+  it('returns nothing for a root-level file no category covers (it gets the lake meta-tag server-side)', () => {
+    expect(tagsForFile('readme.md', taxonomy(), 'acme:')).toEqual([]);
+  });
+});
+
+describe('appliedTagsForBatch', () => {
+  it('unions every tag the batch will apply', () => {
+    const result = appliedTagsForBatch(
+      [{ relativePath: 'root/legal/a.pdf' }, { relativePath: 'root/finance/b.pdf' }],
+      taxonomy({ tags: [tag({ name: 'acme:type:contract', matchingFolders: ['legal'] })] }),
+      'acme:'
+    );
+    expect(names(result)).toEqual(['acme:finance', 'acme:legal', 'acme:type:contract']);
+  });
+});

--- a/apps/client/app/utils/dataLakeTaxonomy.test.ts
+++ b/apps/client/app/utils/dataLakeTaxonomy.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import type { TaxonomyResult, TaxonomyTag } from '@client/app/stores/useDataLakeWizardStore';
-import { appliedTagsForBatch, folderMatches, reprefixTag, tagsForFile } from './dataLakeTaxonomy';
+import { appliedTagsForBatch, folderMatches, tagsForFile } from './dataLakeTaxonomy';
 
 /**
  * Regression coverage: the Taxonomy step used to be pure theater - inference returned
  * categories and per-file assignments, the user edited them, and the upload path threw
- * all of it away in favor of a folder slug. These tests pin the review edits (rename,
- * delete) to what actually ships in the presigned-URL request.
+ * all of it away in favor of a folder slug. These tests pin the review edits (edit, delete)
+ * to what actually ships in the presigned-URL request. The applied tag is `prefix + suffix`,
+ * so the prefix lives once (in taxonomy.prefix / the passed tagPrefix), never per-tag.
  */
 
-const tag = (overrides: Partial<TaxonomyTag> & { name: string }): TaxonomyTag => ({
-  originalName: overrides.name,
+const tag = (overrides: Partial<TaxonomyTag> & { suffix: string }): TaxonomyTag => ({
+  originalName: `acme:${overrides.suffix}`,
   strength: 0.9,
   source: 'ai',
   matchingFolders: [],
@@ -20,7 +21,6 @@ const tag = (overrides: Partial<TaxonomyTag> & { name: string }): TaxonomyTag =>
 
 const taxonomy = (overrides: Partial<TaxonomyResult> = {}): TaxonomyResult => ({
   prefix: 'acme:',
-  sourcePrefix: 'acme:',
   suggestedName: 'Acme',
   tags: [],
   fileAssignments: [],
@@ -51,37 +51,6 @@ describe('folderMatches', () => {
   });
 });
 
-describe('reprefixTag', () => {
-  it('swaps the inferred prefix for the one the user settled on', () => {
-    expect(reprefixTag('acme:type:contract', 'acme:', 'lake:')).toBe('lake:type:contract');
-  });
-
-  it('tolerates prefixes given without the trailing colon', () => {
-    expect(reprefixTag('acme:type:contract', 'acme', 'lake')).toBe('lake:type:contract');
-  });
-
-  it('prefixes rather than rewrites a tag that does not carry the inferred prefix', () => {
-    // Dropping the leading segment here would silently turn "type:contract" into
-    // "lake:contract" and lose the dimension.
-    expect(reprefixTag('type:contract', 'acme:', 'lake:')).toBe('lake:type:contract');
-  });
-
-  it('leaves an already-correct tag untouched', () => {
-    expect(reprefixTag('lake:type:contract', '', 'lake:')).toBe('lake:type:contract');
-  });
-
-  it('moves a bare-prefix tag into the final namespace', () => {
-    // A user can rename a tag down to just the prefix; returning it verbatim would leave
-    // the lake with the mixed namespaces this function exists to prevent.
-    expect(reprefixTag('acme:', 'acme:', 'lake:')).toBe('lake:');
-  });
-
-  it('normalizes the casing of a tag that already carries the final prefix', () => {
-    // Left uppercased, it would not match the lake's fileTagPrefix for filtering.
-    expect(reprefixTag('ACME:type:contract', '', 'acme:')).toBe('acme:type:contract');
-  });
-});
-
 describe('tagsForFile', () => {
   it('falls back to the folder tag when there is no taxonomy', () => {
     expect(tagsForFile('root/reports/q1.pdf', taxonomy(), 'lake:')).toEqual([{ name: 'lake:reports', strength: 1.0 }]);
@@ -92,8 +61,8 @@ describe('tagsForFile', () => {
       'root/legal/agreements/vendor.pdf',
       taxonomy({
         tags: [
-          tag({ name: 'acme:type:contract', matchingFolders: ['legal/agreements'] }),
-          tag({ name: 'acme:topic:finance', matchingFolders: ['finance'] }),
+          tag({ suffix: 'type:contract', matchingFolders: ['legal/agreements'] }),
+          tag({ suffix: 'topic:finance', matchingFolders: ['finance'] }),
         ],
       }),
       'acme:'
@@ -104,17 +73,18 @@ describe('tagsForFile', () => {
   it('drops categories the user deleted', () => {
     const result = tagsForFile(
       'root/legal/vendor.pdf',
-      taxonomy({ tags: [tag({ name: 'acme:type:contract', matchingFolders: ['legal'], deleted: true })] }),
+      taxonomy({ tags: [tag({ suffix: 'type:contract', matchingFolders: ['legal'], deleted: true })] }),
       'acme:'
     );
     expect(names(result)).toEqual(['acme:legal']);
   });
 
-  it('honors a rename, including for per-file assignments that reference the original name', () => {
+  it('honors an edited suffix, including for per-file assignments that reference the original name', () => {
     const result = tagsForFile(
       'root/legal/vendor.pdf',
       taxonomy({
-        tags: [tag({ name: 'acme:type:agreement', originalName: 'acme:type:contract', matchingFolders: ['legal'] })],
+        // originalName stays the inference id; the user edited the suffix to "type:agreement".
+        tags: [tag({ suffix: 'type:agreement', originalName: 'acme:type:contract', matchingFolders: ['legal'] })],
         fileAssignments: [
           { relativePath: 'root/legal/vendor.pdf', suggestedTags: [{ name: 'acme:type:contract', strength: 0.95 }] },
         ],
@@ -138,18 +108,29 @@ describe('tagsForFile', () => {
     expect(names(result)).toEqual(['acme:legal']);
   });
 
-  it('rewrites taxonomy tags to the final prefix so a lake never mixes namespaces', () => {
+  it('applies the passed prefix to every suffix so a lake never mixes namespaces', () => {
     const result = tagsForFile(
       'root/legal/vendor.pdf',
-      taxonomy({ tags: [tag({ name: 'acme:type:contract', matchingFolders: ['legal'] })] }),
+      taxonomy({ tags: [tag({ suffix: 'type:contract', matchingFolders: ['legal'] })] }),
       'renamed:'
     );
     expect(names(result)).toEqual(['renamed:legal', 'renamed:type:contract']);
   });
 
+  it('applies the same prefix to folder tags and category tags even when it is bare', () => {
+    // Empty prefix is gated in the UI, but the pure fn must at least be consistent: folder
+    // tag and category tag both go through ensureColon, so both get the same leading colon.
+    const result = tagsForFile(
+      'root/legal/vendor.pdf',
+      taxonomy({ tags: [tag({ suffix: 'type:contract', matchingFolders: ['legal'] })] }),
+      ''
+    );
+    expect(names(result)).toEqual([':legal', ':type:contract']);
+  });
+
   it('caps how many categories a single file can accumulate, keeping the strongest', () => {
     const many = Array.from({ length: 12 }, (_, i) =>
-      tag({ name: `acme:cat${i}`, matchingFolders: ['legal'], strength: i / 12 })
+      tag({ suffix: `cat${i}`, matchingFolders: ['legal'], strength: i / 12 })
     );
     const result = tagsForFile('root/legal/vendor.pdf', taxonomy({ tags: many }), 'acme:');
     expect(result).toHaveLength(9); // 8 taxonomy tags + the folder tag
@@ -160,7 +141,7 @@ describe('tagsForFile', () => {
   it('does not duplicate a taxonomy tag that equals the folder tag', () => {
     const result = tagsForFile(
       'root/legal/vendor.pdf',
-      taxonomy({ tags: [tag({ name: 'acme:legal', matchingFolders: ['legal'] })] }),
+      taxonomy({ tags: [tag({ suffix: 'legal', matchingFolders: ['legal'] })] }),
       'acme:'
     );
     expect(names(result)).toEqual(['acme:legal']);
@@ -175,7 +156,7 @@ describe('tagsForFile', () => {
     // compared raw segments, so any folder with a space silently lost its taxonomy tags.
     const result = tagsForFile(
       'root/Legal Docs/vendor.pdf',
-      taxonomy({ tags: [tag({ name: 'acme:type:contract', matchingFolders: ['Legal Docs'] })] }),
+      taxonomy({ tags: [tag({ suffix: 'type:contract', matchingFolders: ['Legal Docs'] })] }),
       'acme:'
     );
     expect(names(result)).toEqual(['acme:legal_docs', 'acme:type:contract']);
@@ -186,7 +167,7 @@ describe('appliedTagsForBatch', () => {
   it('unions every tag the batch will apply', () => {
     const result = appliedTagsForBatch(
       [{ relativePath: 'root/legal/a.pdf' }, { relativePath: 'root/finance/b.pdf' }],
-      taxonomy({ tags: [tag({ name: 'acme:type:contract', matchingFolders: ['legal'] })] }),
+      taxonomy({ tags: [tag({ suffix: 'type:contract', matchingFolders: ['legal'] })] }),
       'acme:'
     );
     expect(names(result)).toEqual(['acme:finance', 'acme:legal', 'acme:type:contract']);

--- a/apps/client/app/utils/dataLakeTaxonomy.test.ts
+++ b/apps/client/app/utils/dataLakeTaxonomy.test.ts
@@ -44,6 +44,11 @@ describe('folderMatches', () => {
     expect(folderMatches(['root', 'legal'], '/Legal/')).toBe(true);
     expect(folderMatches(['root', 'legal'], '')).toBe(false);
   });
+
+  it('matches slugified and raw spellings of the same folder', () => {
+    expect(folderMatches(['root', 'legal_docs'], 'Legal Docs')).toBe(true);
+    expect(folderMatches(['root', 'legal_docs'], 'legal-docs')).toBe(true);
+  });
 });
 
 describe('reprefixTag', () => {
@@ -63,6 +68,17 @@ describe('reprefixTag', () => {
 
   it('leaves an already-correct tag untouched', () => {
     expect(reprefixTag('lake:type:contract', '', 'lake:')).toBe('lake:type:contract');
+  });
+
+  it('moves a bare-prefix tag into the final namespace', () => {
+    // A user can rename a tag down to just the prefix; returning it verbatim would leave
+    // the lake with the mixed namespaces this function exists to prevent.
+    expect(reprefixTag('acme:', 'acme:', 'lake:')).toBe('lake:');
+  });
+
+  it('normalizes the casing of a tag that already carries the final prefix', () => {
+    // Left uppercased, it would not match the lake's fileTagPrefix for filtering.
+    expect(reprefixTag('ACME:type:contract', '', 'acme:')).toBe('acme:type:contract');
   });
 });
 
@@ -152,6 +168,17 @@ describe('tagsForFile', () => {
 
   it('returns nothing for a root-level file no category covers (it gets the lake meta-tag server-side)', () => {
     expect(tagsForFile('readme.md', taxonomy(), 'acme:')).toEqual([]);
+  });
+
+  it('applies a category to a folder whose name needed slugifying', () => {
+    // Regression: the folder tag slugified ("Legal Docs" -> legal_docs) while matching
+    // compared raw segments, so any folder with a space silently lost its taxonomy tags.
+    const result = tagsForFile(
+      'root/Legal Docs/vendor.pdf',
+      taxonomy({ tags: [tag({ name: 'acme:type:contract', matchingFolders: ['Legal Docs'] })] }),
+      'acme:'
+    );
+    expect(names(result)).toEqual(['acme:legal_docs', 'acme:type:contract']);
   });
 });
 

--- a/apps/client/app/utils/dataLakeTaxonomy.ts
+++ b/apps/client/app/utils/dataLakeTaxonomy.ts
@@ -8,7 +8,8 @@ export interface AppliedTag {
 /**
  * A single file can pick up a tag from every category whose folders it sits under.
  * Cap it so a pathological inference result (every category matching the root) can't
- * bury a file under dozens of tags; the highest-strength ones win.
+ * bury a file under dozens of tags; the highest-strength ones win. Caps taxonomy tags
+ * only - the folder tag is added on top, so a file can carry this many + 1.
  */
 const MAX_TAXONOMY_TAGS_PER_FILE = 8;
 

--- a/apps/client/app/utils/dataLakeTaxonomy.ts
+++ b/apps/client/app/utils/dataLakeTaxonomy.ts
@@ -57,40 +57,19 @@ export function folderMatches(fileFolderSegments: string[], matchingFolder: stri
 }
 
 /**
- * Inference embeds its own suggested prefix in every tag name, but the user can still
- * change the prefix on the Config step. Swap the inferred prefix for the final one so
- * a lake never ships two namespaces. Anything that doesn't carry the inferred prefix is
- * prefixed rather than rewritten - never drop a segment we can't confidently identify.
- */
-export function reprefixTag(tagName: string, sourcePrefix: string, finalPrefix: string): string {
-  if (!finalPrefix) return tagName;
-  const target = ensureColon(finalPrefix);
-  const source = sourcePrefix ? ensureColon(sourcePrefix) : '';
-
-  if (source && tagName.toLowerCase().startsWith(source.toLowerCase())) {
-    // A tag that is nothing but the prefix still has to end up in the final namespace.
-    return `${target}${tagName.slice(source.length)}`;
-  }
-  // Case-insensitive check, but rewrite rather than return as-is: "ACME:type:x" under final
-  // prefix "acme:" must come back lowercased, or it won't match the lake's fileTagPrefix.
-  if (tagName.toLowerCase().startsWith(target.toLowerCase())) {
-    return `${target}${tagName.slice(target.length)}`;
-  }
-  return `${target}${tagName}`;
-}
-
-/**
  * Tags to apply to one file at upload time: the folder tag (always, so folder structure
  * stays queryable and every nested file gets at least one tag) plus the reviewed taxonomy
  * categories covering it. This is what makes the Taxonomy step's edits/deletes real -
- * deleted categories are dropped and renames are honored via each tag's originalName,
- * which is also what inference's per-file assignments reference.
+ * deleted categories are dropped, and each category's applied name is `prefix + suffix`, so
+ * the shared prefix (also the folder tag's) guarantees one namespace per lake. Per-file
+ * assignments are matched via each tag's originalName (the inference join key).
  */
 export function tagsForFile(relativePath: string, taxonomy: TaxonomyResult, tagPrefix: string): AppliedTag[] {
   const folderTags = folderTagForFile(relativePath, tagPrefix);
   const active = taxonomy.tags.filter(t => !t.deleted);
   if (active.length === 0) return folderTags;
 
+  const prefix = ensureColon(tagPrefix);
   const byOriginalName = new Map(active.map(t => [t.originalName.toLowerCase(), t]));
   const fileFolderSegments = normalizeSegments(relativePath.split('/').slice(0, -1).join('/'));
   const strongest = new Map<string, number>();
@@ -106,12 +85,12 @@ export function tagsForFile(relativePath: string, taxonomy: TaxonomyResult, tagP
   for (const suggested of assignment?.suggestedTags ?? []) {
     const tag = byOriginalName.get(suggested.name.toLowerCase());
     if (!tag) continue; // deleted by the user, or a tag the model never declared as a category
-    add(reprefixTag(tag.name, taxonomy.sourcePrefix, tagPrefix), suggested.strength);
+    add(`${prefix}${tag.suffix}`, suggested.strength);
   }
 
   for (const tag of active) {
     if (tag.matchingFolders.some(folder => folderMatches(fileFolderSegments, folder))) {
-      add(reprefixTag(tag.name, taxonomy.sourcePrefix, tagPrefix), tag.strength);
+      add(`${prefix}${tag.suffix}`, tag.strength);
     }
   }
 

--- a/apps/client/app/utils/dataLakeTaxonomy.ts
+++ b/apps/client/app/utils/dataLakeTaxonomy.ts
@@ -14,11 +14,18 @@ const MAX_TAXONOMY_TAGS_PER_FILE = 8;
 
 const ensureColon = (prefix: string): string => (prefix.endsWith(':') ? prefix : `${prefix}:`);
 
-const normalizeSegments = (path: string): string[] =>
-  path
-    .split('/')
-    .map(s => s.trim().toLowerCase())
-    .filter(Boolean);
+/**
+ * One normalization shared by the folder tag and folder matching. Both sides must agree:
+ * a folder named "Legal Docs" is tagged `prefix:legal_docs`, so a category listing it as
+ * either "Legal Docs" or "legal_docs" has to match the same file.
+ */
+const slugifySegment = (segment: string): string =>
+  segment
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+const normalizeSegments = (path: string): string[] => path.split('/').map(slugifySegment).filter(Boolean);
 
 /**
  * Derive a single tag for a file from its immediate parent folder, so each file
@@ -30,10 +37,7 @@ export function folderTagForFile(relativePath: string, tagPrefix: string): Appli
   const segments = relativePath.split('/').filter(Boolean);
   const parent = segments.length >= 2 ? segments[segments.length - 2] : undefined;
   if (!parent) return [];
-  const slug = parent
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
+  const slug = slugifySegment(parent);
   if (!slug) return [];
   return [{ name: `${ensureColon(tagPrefix)}${slug}`, strength: 1.0 }];
 }
@@ -64,10 +68,14 @@ export function reprefixTag(tagName: string, sourcePrefix: string, finalPrefix: 
   const source = sourcePrefix ? ensureColon(sourcePrefix) : '';
 
   if (source && tagName.toLowerCase().startsWith(source.toLowerCase())) {
-    const rest = tagName.slice(source.length);
-    return rest ? `${target}${rest}` : tagName;
+    // A tag that is nothing but the prefix still has to end up in the final namespace.
+    return `${target}${tagName.slice(source.length)}`;
   }
-  if (tagName.toLowerCase().startsWith(target.toLowerCase())) return tagName;
+  // Case-insensitive check, but rewrite rather than return as-is: "ACME:type:x" under final
+  // prefix "acme:" must come back lowercased, or it won't match the lake's fileTagPrefix.
+  if (tagName.toLowerCase().startsWith(target.toLowerCase())) {
+    return `${target}${tagName.slice(target.length)}`;
+  }
   return `${target}${tagName}`;
 }
 

--- a/apps/client/app/utils/dataLakeTaxonomy.ts
+++ b/apps/client/app/utils/dataLakeTaxonomy.ts
@@ -1,0 +1,132 @@
+import type { TaxonomyResult } from '@client/app/stores/useDataLakeWizardStore';
+
+export interface AppliedTag {
+  name: string;
+  strength: number;
+}
+
+/**
+ * A single file can pick up a tag from every category whose folders it sits under.
+ * Cap it so a pathological inference result (every category matching the root) can't
+ * bury a file under dozens of tags; the highest-strength ones win.
+ */
+const MAX_TAXONOMY_TAGS_PER_FILE = 8;
+
+const ensureColon = (prefix: string): string => (prefix.endsWith(':') ? prefix : `${prefix}:`);
+
+const normalizeSegments = (path: string): string[] =>
+  path
+    .split('/')
+    .map(s => s.trim().toLowerCase())
+    .filter(Boolean);
+
+/**
+ * Derive a single tag for a file from its immediate parent folder, so each file
+ * is tagged by its source folder rather than getting every taxonomy category.
+ * Returns [] for root-level files (they get only the lake meta-tag). Uses
+ * underscores to match the AI taxonomy's folder-slug style.
+ */
+export function folderTagForFile(relativePath: string, tagPrefix: string): AppliedTag[] {
+  const segments = relativePath.split('/').filter(Boolean);
+  const parent = segments.length >= 2 ? segments[segments.length - 2] : undefined;
+  if (!parent) return [];
+  const slug = parent
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (!slug) return [];
+  return [{ name: `${ensureColon(tagPrefix)}${slug}`, strength: 1.0 }];
+}
+
+/**
+ * Inference returns folder paths ("legal/agreements"), not bare folder names, and a
+ * category covers everything beneath its folders. So match the entry as a contiguous
+ * run of segments anywhere in the file's folder path.
+ */
+export function folderMatches(fileFolderSegments: string[], matchingFolder: string): boolean {
+  const target = normalizeSegments(matchingFolder);
+  if (target.length === 0) return false;
+  for (let i = 0; i + target.length <= fileFolderSegments.length; i++) {
+    if (target.every((seg, j) => fileFolderSegments[i + j] === seg)) return true;
+  }
+  return false;
+}
+
+/**
+ * Inference embeds its own suggested prefix in every tag name, but the user can still
+ * change the prefix on the Config step. Swap the inferred prefix for the final one so
+ * a lake never ships two namespaces. Anything that doesn't carry the inferred prefix is
+ * prefixed rather than rewritten - never drop a segment we can't confidently identify.
+ */
+export function reprefixTag(tagName: string, sourcePrefix: string, finalPrefix: string): string {
+  if (!finalPrefix) return tagName;
+  const target = ensureColon(finalPrefix);
+  const source = sourcePrefix ? ensureColon(sourcePrefix) : '';
+
+  if (source && tagName.toLowerCase().startsWith(source.toLowerCase())) {
+    const rest = tagName.slice(source.length);
+    return rest ? `${target}${rest}` : tagName;
+  }
+  if (tagName.toLowerCase().startsWith(target.toLowerCase())) return tagName;
+  return `${target}${tagName}`;
+}
+
+/**
+ * Tags to apply to one file at upload time: the folder tag (always, so folder structure
+ * stays queryable and every nested file gets at least one tag) plus the reviewed taxonomy
+ * categories covering it. This is what makes the Taxonomy step's edits/deletes real -
+ * deleted categories are dropped and renames are honored via each tag's originalName,
+ * which is also what inference's per-file assignments reference.
+ */
+export function tagsForFile(relativePath: string, taxonomy: TaxonomyResult, tagPrefix: string): AppliedTag[] {
+  const folderTags = folderTagForFile(relativePath, tagPrefix);
+  const active = taxonomy.tags.filter(t => !t.deleted);
+  if (active.length === 0) return folderTags;
+
+  const byOriginalName = new Map(active.map(t => [t.originalName.toLowerCase(), t]));
+  const fileFolderSegments = normalizeSegments(relativePath.split('/').slice(0, -1).join('/'));
+  const strongest = new Map<string, number>();
+
+  const add = (name: string, strength: number) => {
+    const current = strongest.get(name);
+    if (current === undefined || strength > current) strongest.set(name, strength);
+  };
+
+  // Per-file assignments are richer than folder matching but only cover the sampled
+  // files, so they layer on top rather than replacing the folder pass below.
+  const assignment = taxonomy.fileAssignments.find(a => a.relativePath === relativePath);
+  for (const suggested of assignment?.suggestedTags ?? []) {
+    const tag = byOriginalName.get(suggested.name.toLowerCase());
+    if (!tag) continue; // deleted by the user, or a tag the model never declared as a category
+    add(reprefixTag(tag.name, taxonomy.sourcePrefix, tagPrefix), suggested.strength);
+  }
+
+  for (const tag of active) {
+    if (tag.matchingFolders.some(folder => folderMatches(fileFolderSegments, folder))) {
+      add(reprefixTag(tag.name, taxonomy.sourcePrefix, tagPrefix), tag.strength);
+    }
+  }
+
+  const taxonomyTags = Array.from(strongest, ([name, strength]) => ({ name, strength }))
+    .sort((a, b) => b.strength - a.strength)
+    .slice(0, MAX_TAXONOMY_TAGS_PER_FILE);
+
+  const seen = new Set(taxonomyTags.map(t => t.name));
+  return [...taxonomyTags, ...folderTags.filter(t => !seen.has(t.name))];
+}
+
+/** Union of every tag the batch will apply, for the batch record's appliedTags summary. */
+export function appliedTagsForBatch(
+  files: { relativePath: string }[],
+  taxonomy: TaxonomyResult,
+  tagPrefix: string
+): AppliedTag[] {
+  const strongest = new Map<string, number>();
+  for (const file of files) {
+    for (const tag of tagsForFile(file.relativePath, taxonomy, tagPrefix)) {
+      const current = strongest.get(tag.name);
+      if (current === undefined || tag.strength > current) strongest.set(tag.name, tag.strength);
+    }
+  }
+  return Array.from(strongest, ([name, strength]) => ({ name, strength }));
+}


### PR DESCRIPTION
## Description

Closes #829

The Data Lake wizard's AI Taxonomy step suggested per-file tags and let the user rename, delete, and re-analyze them, but none of it was applied - the upload path tagged every file with a single folder-slug derived from its parent folder, so the review UI was cosmetic. The step also blocked progression until inference succeeded, which stranded users whenever inference returned nothing (for example, no OpenAI key configured).

This makes the reviewed taxonomy real and makes the step optional:

- Files are tagged at upload with their source-folder tag **plus** every reviewed category whose folders cover them. Deletes, edits, and re-analyze now change what actually ships.
- The step never blocks on an empty or failed result. It only holds the user while inference is in flight (so a late result can't overwrite what they type next). An empty result shows an empty state with Re-analyze and a "Skip" affordance.

It also reconciles the Tag Prefix with #994 (which had de-duplicated Tag Prefix to a single home on the Config step). Because the prefix is now meaningful on the taxonomy step (it namespaces every applied tag), the single editable home moves there.

## Changes

**Applying the taxonomy**
- New `app/utils/dataLakeTaxonomy.ts`: pure helpers (`tagsForFile`, `appliedTagsForBatch`, `folderTagForFile`, `folderMatches`) that derive a file's tags from the reviewed taxonomy. Each file gets its folder tag plus any category whose `matchingFolders` cover it (matched by path segment, case- and slug-insensitive, so `Legal Docs`, `legal_docs`, and `legal-docs` all match). Category count per file is capped, keeping the strongest.
- The upload path (`dataLakeWizard.ts`) now sends these per-file tags to the presign endpoint and the batch summary, instead of a folder-slug-only tag.

**Tag Prefix: one shared value, per-tag suffixes**
- A tag is stored as a `suffix` (the part after the prefix) plus a stable `originalName` (the inference join key). The applied tag is always `prefix + suffix`, so the prefix lives in exactly one place (`taxonomy.prefix`, kept in sync with `config.tagPrefix`).
- On the taxonomy step, editing the one Tag Prefix input re-namespaces every card at once. Editing a card changes only its suffix - the prefix is fixed, so a rename can't inject a second namespace. An empty suffix can't be saved, and an empty/short prefix shows a required-field error.
- The Config step shows the prefix read-only in create mode (its home is the taxonomy step), locked in append mode, and offers an editable fallback only if a create-mode user reaches Config with no prefix set - so the taxonomy step staying skippable can't dead-end them at Config's prefix gate.

**Robustness**
- Inference responses are sanitized at the store boundary: malformed entries are dropped and confidences clamped, so a bad model payload can't throw mid-upload. Repeated category names are de-duplicated (the name is a React/update/delete key and must be unique).
- `analyzing` is set before the content-sampling step, closing a window where the user could advance mid-inference.
- Re-analyze no longer overwrites a name or prefix the user already typed.
- Opening the wizard always starts a clean session, so a prior session's files, config, or taxonomy can't leak in.

## Guide for Testers

Steps 3-8 need an OpenAI API key configured for your user (Settings -> API Keys). Without one, inference returns empty - that path is step 9.

1. Prepare a folder with a couple of nested subfolders and a few files each, e.g. `corpus/legal/a.txt`, `corpus/legal/b.txt`, `corpus/finance/c.txt`.
2. Go to **Sidebar -> Data Lakes**, click **Create**, upload the `corpus` folder, and advance through **Preview** to the **AI Taxonomy** step.
3. Expected: a brief "Analyzing..." state, then suggested categories grouped by confidence. Each card shows the shared prefix followed by its own suffix (e.g. `acme:type:contract`). The summary says the step is optional.

   <img width="1048" height="729" alt="image" src="https://github.com/user-attachments/assets/3b2f1bbb-13ae-46f7-b49f-bb12e38a08d8" />

4. Change the **Tag Prefix** input at the top from `acme:` to `zzz:`. Expected: every card updates to `zzz:...` at once.

   <img width="1048" height="729" alt="image" src="https://github.com/user-attachments/assets/044fcbc1-3163-4105-afdc-a177123f2c9f" />

5. Click the edit (pencil) on a card. Expected: only the suffix is editable; the `zzz:` prefix is fixed. Clear the field. Expected: you cannot save (save disabled, Enter does nothing) until you type a value.

   <img width="1048" height="576" alt="image" src="https://github.com/user-attachments/assets/be45f1d9-476e-4c46-b05c-5611c5ddf0ef" />

6. Rename one card's suffix (e.g. to `type:renamed`) and save. Delete a different card.

   <img width="1048" height="576" alt="image" src="https://github.com/user-attachments/assets/f921ad45-adb0-4fbe-a6d9-d2f758b58308" />

7. Clear the **Tag Prefix** input entirely. Expected: a "tag prefix is required" error appears.
8. Set the prefix back to `zzz:`, click **Next**, set a **Name**, click **Start Upload**, then open the new lake and inspect a file's tags. Expected: files under `legal/` carry `zzz:legal` (folder tag) plus the categories covering that folder, the renamed one under its new suffix, the deleted one on no file, and every tag under `zzz:` (no mixed namespaces).

   <img width="1169" height="216" alt="image" src="https://github.com/user-attachments/assets/6915c37d-dda3-4f3e-b6a5-4ce96e147287" />
   
   <img width="1169" height="216" alt="image" src="https://github.com/user-attachments/assets/2cd124c8-62f3-4631-8cd5-501cee44f722" />

9. Repeat from an account with no OpenAI key. On the **AI Taxonomy** step, expected: an empty state with a working **Re-analyze** button and an enabled **Skip** button. Skip and finish the upload; files are tagged by their source folder.

### Regression Checks

- Append mode (Data Lakes -> existing lake -> add files) skips the taxonomy step and tags by folder only, with the Tag Prefix locked to the lake's prefix on Config.
- A name that slugifies too short still blocks Start Upload with the inline hint (unchanged from #994).
- Closing and reopening the wizard starts clean - no files, name, or prefix carried over.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
