### PR TITLE
fix(scripts): generate premium migration glue with a relative import

### DIFF
--- a/apps/client/scripts/generate-premium-glue.mjs
+++ b/apps/client/scripts/generate-premium-glue.mjs
@@ -21,7 +21,7 @@
  */
 
 import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, renameSync } from 'node:fs';
-import { resolve, dirname, join, sep, basename } from 'node:path';
+import { resolve, dirname, join, sep, basename, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -464,11 +464,15 @@ function generateLlmTools(packages) {
 // unlike every other glue file here): both consumers of AvailableMigrations - the
 // DatabaseMigrator Lambda's MigrationManager and the `pnpm migrate` CLI - live in
 // @bike4mind/scripts, which cannot import from apps/client (wrong dependency direction).
-// Bare specifier (like llmTools / serverHandlerStubs), NOT the infra glue's relative-import
-// workaround below - that workaround exists only because esbuild externalises symlinked
-// workspace packages when bundling sst.config.ts. The migrator is a normal Lambda handler
-// referenced by string path (infra/database.ts), so a bare specifier bundles fine - the same
-// path serverHandlerStubs already proves out for real Lambda handlers.
+//
+// RELATIVE import to the overlay source (same as the infra glue below), NOT a bare
+// @bike4mind/premium-* specifier. The bare-specifier stubs (llmTools / serverHandlerStubs)
+// resolve only because they live under apps/client, where the overlay package is linked into
+// the resolution scope. This file lives under packages/scripts, which declares only
+// @bike4mind/database - the overlay is NOT resolvable from its node_modules, so a bare
+// specifier fails to bundle ("Could not resolve @bike4mind/premium-optihashi/server/migrations"
+// when SST esbuild-bundles the DatabaseMigrator Lambda). A relative .ts source import resolves
+// by filesystem path regardless of linking, and esbuild/vitest transpile it inline.
 function generateMigrations(packages) {
   const outPath = join(REPO_ROOT, 'packages/scripts/migrate/migrations/premium.generated.ts');
   const typeImport = `import type { MigrationFile } from '@bike4mind/database';`;
@@ -485,8 +489,25 @@ function generateMigrations(packages) {
 
   contributors.forEach(p => assertModuleSpecifier(p.contributions.migrationsExport, p.name, 'migrationsExport'));
 
-  const imports = contributors
-    .map((p, i) => `import { migrations as migrations${i} } from '${p.contributions.migrationsExport}';`)
+  // Resolve each overlay's declared migrationsExport subpath (via its own exports map) to the
+  // real source file, then rewrite it as a relative import from this generated file's dir.
+  const relSpecs = contributors.map(p => {
+    const sourceFile = resolveExportFromToSourceFile(p, p.contributions.migrationsExport);
+    if (!sourceFile) {
+      throw new Error(
+        `[codegen] cannot resolve migrationsExport ${JSON.stringify(p.contributions.migrationsExport)} ` +
+          `from package "${p.name}" to a source file (check its package.json "exports" map). ` +
+          `A bare specifier can't be used here - see generateMigrations().`
+      );
+    }
+    // Strip the .ts extension and normalise to a forward-slash relative specifier.
+    let rel = relative(dirname(outPath), sourceFile).split(sep).join('/').replace(/\.ts$/, '');
+    if (!rel.startsWith('.')) rel = `./${rel}`;
+    return rel;
+  });
+
+  const imports = relSpecs
+    .map((spec, i) => `import { migrations as migrations${i} } from '${spec}';`)
     .join('\n');
 
   const spreads = contributors.map((_, i) => `  ...migrations${i}`).join(',\n');


### PR DESCRIPTION
## Description

A regression on `main` (from #948, which added the premium-overlay migration seam) fails the deploy pipeline when SST bundles the `DatabaseMigrator` Lambda:

```
Could not resolve "@bike4mind/premium-optihashi/server/migrations"
  packages/scripts/migrate/migrations/premium.generated.ts:6:42
```

**Root cause.** The premium migration glue is generated into `packages/scripts` (`@bike4mind/scripts`) rather than `apps/client`, because both consumers of `AvailableMigrations` (the migrator Lambda and the `pnpm migrate` CLI) live there and can't import from `apps/client` (wrong dependency direction). Every other overlay glue file emits a **bare** `@bike4mind/premium-*` specifier, which resolves only from `apps/client`'s resolution scope, where the overlay package is linked. `packages/scripts`'s `node_modules` carries only its one declared dep (`@bike4mind/database`) — the overlay is not linked there — so the bare specifier fails to bundle. The original code assumed "serverHandlerStubs prove bare specifiers bundle fine," but those stubs live under `apps/client`, a different scope. This was the first time `packages/scripts` imported an overlay package.

**Fix.** Emit a **relative import** to the resolved overlay source instead — the same approach `generateInfraGlue` already uses for `infra/premium-generated/`. A relative path resolves by filesystem regardless of `node_modules` linking. The generator reuses the existing `resolveExportFromToSourceFile` helper to turn the declared export subpath into an on-disk path, and fails loud if it can't. The open-core empty form (no overlay -> empty array, no import) is unchanged.

## Changes

- `apps/client/scripts/generate-premium-glue.mjs`: `generateMigrations` now emits a relative import to the overlay migration source rather than a bare package specifier; adds `relative` to the `node:path` import; updates the explanatory comment.

## Guide for Testers

This is a build-time codegen fix; there is no UI. Verify at the codegen + bundle layer.

**With an overlay hydrated (mirrors the deploy pipeline):**
1. Hydrate a premium overlay into `packages/premium/<name>` and run `pnpm install` (or `pnpm codegen`).
2. Open `packages/scripts/migrate/migrations/premium.generated.ts`. Expected: the overlay migrations are imported via a **relative** path (e.g. `../../../premium/<name>/src/server/migrations/index`), not a bare `@bike4mind/premium-*` specifier.
3. Run `pnpm --filter @bike4mind/scripts test migrate/migrations/index.test`. Expected: all tests pass and the suite loads the overlay migrations (more assertions than the no-overlay run).
4. Bundle the migrator graph with esbuild. Expected: no `Could not resolve "@bike4mind/premium-*..."` error.

**Open-core / no overlay:**
5. With `packages/premium/` empty, run `pnpm codegen`. Expected: `premium.generated.ts` is `export const premiumMigrations: MigrationFile[] = [];` with no overlay import.

### Regression Checks
- Confirm the four other apps/client-scoped glue files (routes, nav, api stubs, serverHandlerStubs, llmTools) are unchanged and still emit bare specifiers — only the migration glue changed.
- `scripts/check-no-overlay-lockfile.sh` still passes (no overlay paths leak into the tracked lockfile).

### What NOT to test
- No runtime/UI behavior changes. No DB migration logic changed — only how the glue module imports overlay migrations.

## Additional Information

Verified locally with an overlay hydrated: migrations test suite passes (100 vs 96 without the overlay), and an esbuild bundle of the migrator graph resolves cleanly. Lockfile churn from the transient install was reverted; only the codegen script is committed.