### PR TITLE
fix(scripts): derive the migration glue path without probing for sources

### DIFF
--- a/apps/client/__tests__/premiumMigrationsCodegenNoSources.test.ts
+++ b/apps/client/__tests__/premiumMigrationsCodegenNoSources.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Regression guard: the migrations codegen must not require overlay SOURCE files to
+ * exist - only the paths their package.json declares.
+ *
+ * Dockerfile.chatcompletion builds in this order:
+ *
+ *   COPY --parents **\/package.json ./          <- package.json files only
+ *   COPY apps/client/scripts ./apps/client/scripts
+ *   RUN pnpm install --frozen-lockfile ...      <- postinstall runs the codegen HERE
+ *   COPY . .                                    <- overlay sources arrive AFTER
+ *
+ * So at codegen time inside the image, every overlay's package.json is present and none
+ * of its .ts source is. A generator that probes the filesystem to build an import path
+ * therefore explodes in the image while working perfectly everywhere else. That is
+ * exactly what happened on 2026-07-28: the first overlay to declare migrationsExport
+ * turned every `Build & push server image(s)` step red with
+ * "[codegen] cannot resolve migrationsExport", after the preceding fix had already made
+ * the SST bundle work. The generated path is identical either way, so nothing is lost by
+ * deriving it from package.json alone.
+ *
+ * Runs the real script against a throwaway tree rather than the repo, which also keeps it
+ * clear of the codegen/test races the sibling premium* tests document.
+ */
+
+const SCRIPT = join(__dirname, '../scripts/generate-premium-glue.mjs');
+
+let root: string;
+
+function runCodegen(): { ok: boolean; output: string } {
+  try {
+    return { ok: true, output: execFileSync('node', [join(root, 'apps/client/scripts/generate-premium-glue.mjs')], { cwd: root, encoding: 'utf8', stdio: 'pipe' }) };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string };
+    return { ok: false, output: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'premium-codegen-'));
+  mkdirSync(join(root, 'apps/client/scripts'), { recursive: true });
+  copyFileSync(SCRIPT, join(root, 'apps/client/scripts/generate-premium-glue.mjs'));
+
+  // An overlay that declares migrations, with its package.json present and its source
+  // absent - the Docker install layer, reproduced exactly.
+  const overlay = join(root, 'packages/premium/fixtureoverlay');
+  mkdirSync(overlay, { recursive: true });
+  writeFileSync(
+    join(overlay, 'package.json'),
+    JSON.stringify({
+      name: '@bike4mind/premium-fixtureoverlay',
+      exports: { './server/migrations': './src/server/migrations/index.ts' },
+      b4mContributions: { migrationsExport: '@bike4mind/premium-fixtureoverlay/server/migrations' },
+    }) + '\n'
+  );
+});
+
+afterAll(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe('premium migrations codegen with overlay sources absent', () => {
+  it('succeeds when only package.json is on disk', () => {
+    const { ok, output } = runCodegen();
+    expect(output).not.toContain('cannot resolve migrationsExport');
+    expect(ok).toBe(true);
+  });
+
+  it('emits a relative import to the declared source path', () => {
+    runCodegen();
+    const generated = join(root, 'packages/scripts/migrate/migrations/premium.generated.ts');
+    expect(existsSync(generated)).toBe(true);
+
+    const content = readFileSync(generated, 'utf8');
+    // Relative, extensionless, and pointing at the path package.json declared. A bare
+    // @bike4mind/premium-* specifier here would not resolve from packages/scripts.
+    expect(content).toContain(
+      "import { migrations as migrations0 } from '../../../premium/fixtureoverlay/src/server/migrations/index';"
+    );
+    expect(content).not.toContain("from '@bike4mind/premium-fixtureoverlay");
+  });
+});

--- a/apps/client/scripts/generate-premium-glue.mjs
+++ b/apps/client/scripts/generate-premium-glue.mjs
@@ -229,7 +229,18 @@ export const premiumNotebookSidenav: PremiumNotebookSidenav = dynamic(
 // `exports` map in its package.json - so we can inspect the source without executing it.
 // Returns null (never throws) for any shape this doesn't confidently recognize;
 // callers treat null as "no config to re-export", which is the pre-existing behavior.
-function resolveExportFromToSourceFile(pkg, exportFrom) {
+// Resolve a validated bare specifier to the path its package.json DECLARES for it,
+// without requiring that path to exist on disk yet.
+//
+// That distinction is load-bearing during the Docker image build. Dockerfile.chatcompletion
+// copies `**/package.json` and apps/client/scripts, runs `pnpm install` (whose postinstall
+// runs THIS script), and only then does `COPY . .` bring in the sources. So at codegen time
+// inside the image every overlay's package.json is present but none of its .ts source is.
+// A generator that only needs to WRITE a path must therefore not probe the filesystem;
+// one that needs to READ the source (extractConfigLiteral) legitimately must.
+//
+// Returns null (never throws) for any shape this doesn't confidently recognize.
+function resolveExportToDeclaredPath(pkg, exportFrom) {
   let subpath;
   if (exportFrom === pkg.name) subpath = '.';
   else if (exportFrom.startsWith(`${pkg.name}/`)) subpath = `.${exportFrom.slice(pkg.name.length)}`;
@@ -266,7 +277,14 @@ function resolveExportFromToSourceFile(pkg, exportFrom) {
   const resolved = resolve(join(PREMIUM_DIR, pkg.dir, target));
   if (resolved !== pkgRoot && !resolved.startsWith(pkgRoot + sep)) return null;
 
-  return existsSync(resolved) ? resolved : null;
+  return resolved;
+}
+
+// As above, but additionally requires the source file to be present, because every
+// caller of this one goes on to READ it. Unchanged behaviour for those callers.
+function resolveExportFromToSourceFile(pkg, exportFrom) {
+  const resolved = resolveExportToDeclaredPath(pkg, exportFrom);
+  return resolved !== null && existsSync(resolved) ? resolved : null;
 }
 
 // Next.js's Pages Router requires `export const config = {...}` to be a literal,
@@ -490,14 +508,24 @@ function generateMigrations(packages) {
   contributors.forEach(p => assertModuleSpecifier(p.contributions.migrationsExport, p.name, 'migrationsExport'));
 
   // Resolve each overlay's declared migrationsExport subpath (via its own exports map) to the
-  // real source file, then rewrite it as a relative import from this generated file's dir.
+  // path that package.json DECLARES, then rewrite it as a relative import from this generated
+  // file's dir.
+  //
+  // Declared path, NOT an on-disk one: this must not require the overlay source to exist yet.
+  // Dockerfile.chatcompletion copies `**/package.json` and apps/client/scripts, runs
+  // `pnpm install` - whose postinstall runs this script - and only then `COPY . .`. Probing the
+  // filesystem here made the image build die with "cannot resolve migrationsExport" the moment
+  // an overlay declared one, even though the very same import resolves fine at build time, once
+  // the sources are in place. The generated path is identical either way.
   const relSpecs = contributors.map(p => {
-    const sourceFile = resolveExportFromToSourceFile(p, p.contributions.migrationsExport);
+    const sourceFile = resolveExportToDeclaredPath(p, p.contributions.migrationsExport);
     if (!sourceFile) {
       throw new Error(
         `[codegen] cannot resolve migrationsExport ${JSON.stringify(p.contributions.migrationsExport)} ` +
-          `from package "${p.name}" to a source file (check its package.json "exports" map). ` +
-          `A bare specifier can't be used here - see generateMigrations().`
+          `from package "${p.name}" to a declared path - its package.json "exports" map has no ` +
+          `plain-string entry for that subpath. A bare specifier can't be used here - see ` +
+          `generateMigrations(). Note this checks only what package.json DECLARES; the source ` +
+          `file itself is deliberately not required to exist yet.`
       );
     }
     // Strip the .ts extension and normalise to a forward-slash relative specifier.


### PR DESCRIPTION
Follow-up to #1048. Staging is red again, and production promotion is still blocked . the failure just moved from `Deploy to AWS` to `Build & push server image(s)`.

## What broke

#1048 was the right call: a relative import is what makes the glue resolve from `packages/scripts`, and it fixed the SST bundle of the `DatabaseMigrator` Lambda. But it derived the path with `resolveExportFromToSourceFile`, which ends in

```js
return existsSync(resolved) ? resolved : null;
```

and then throws on `null`.

That probe cannot be satisfied during the Docker image build. `Dockerfile.chatcompletion` uses the standard layer-caching order:

```dockerfile
COPY --parents **/package.json ./            # package.json files ONLY
COPY apps/client/scripts ./apps/client/scripts
RUN pnpm install --frozen-lockfile ...       # postinstall runs the codegen HERE
COPY . .                                     # overlay sources arrive AFTER
```

So at codegen time inside the image, every overlay's `package.json` is present and none of its `.ts` source is. The overlays are discovered fine and every other glue file writes correctly . only this one generator needs a file on disk. The moment `b4m-optihashi` declared `migrationsExport`, every image build started dying with `[codegen] cannot resolve migrationsExport`.

Worth noting: `generateInfraGlue`, cited in #1048 as the precedent for the relative-import approach, has never hit this because it builds its path by string convention and never touches the filesystem.

```js
const relSource = `../../packages/premium/${dir}/src/infra`;
```

## The fix

The exports-map value is already a path, so the relative specifier can be derived from `package.json` alone. `resolveExportToDeclaredPath` is split out of `resolveExportFromToSourceFile`: same subpath parsing, same non-string warning, same containment guard, no existence check. `generateMigrations` uses the declared-path form.

The config-literal callers keep the existence check, because they go on to actually READ the file . that requirement is real for them and unchanged.

**The emitted path is byte-identical either way**, so nothing about the generated output changes; only the precondition for producing it does.

I kept the exports-map lookup rather than copying `generateInfraGlue`'s hardcoded `src/infra` convention, since honouring what the overlay declares is the better of the two behaviours.

## Verification

Reproduced the Docker install layer directly . a tree with the overlay's `package.json` and no sources . and ran the real script against it:

- **script as merged in `c14bd9f`**: throws `[codegen] cannot resolve migrationsExport`, non-zero exit
- **with this change**: exits 0 and emits `import { migrations as migrations0 } from '../../../premium/<name>/src/server/migrations/index';`

That is the same specifier it produces when the sources are present, which is the point.

Added as a regression test (`premiumMigrationsCodegenNoSources.test.ts`) that runs the real script against a throwaway tmp tree, so it cannot race the sibling `premium*` codegen tests the way re-invoking the script in-repo would.

**One caveat, stated plainly:** I could not run vitest locally . this clone has no workspace install, so loading the repo tsconfig fails before collection. I validated all five assertions by executing the identical fixture and checks in plain node (all pass). CI on this PR is the first real run of the test file itself; if it fails there, it is the harness, not the finding . the underlying reproduction above is solid either way.

## Why nothing caught it

#1048 never got a preview deploy, and previews are the only opt-in gate that builds the image. Host CI has no overlays at all, so the code path with a real contributor never executes there. Bike4Mind/workflow-templates#10 adds an overlay-CI gate for the sibling class of bug, but it typechecks rather than image-builds, so it would not have caught this one either . a preview on #1048 would have, in about twenty minutes.
