### PR TITLE
fix(selfhost): route app-file, logo and photo browser uploads through the upload proxy

### DIFF
--- a/apps/client/app/components/ProfileModal/SettingsTabContent/DocxTemplateSection.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/DocxTemplateSection.tsx
@@ -10,6 +10,7 @@ import UploadFileIcon from '@mui/icons-material/UploadFile';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { VALID_DOCX_MIME_TYPES, MAX_DOCX_TEMPLATE_SIZE } from '@server/services/docxTemplateService';
+import { uploadFileToUrl } from '@client/app/utils/uploadFileToUrl';
 
 interface TemplateInfo {
   fileId: string;
@@ -52,23 +53,17 @@ const DocxTemplateSection = () => {
     mutationFn: async (file: File) => {
       if (!userId) throw new Error('User not logged in');
 
-      // Step 1: Get presigned URL for upload
-      const formData = new FormData();
-      formData.append('fileName', file.name);
-      formData.append('fileSize', file.size.toString());
-      formData.append('mimeType', file.type);
-
-      const presignedResponse = await api.post('/api/app-files/generate-presigned-url', formData);
-      const { presignedUrl, fileId } = presignedResponse.data;
-
-      // Step 2: Upload file to S3
-      await fetch(presignedUrl, {
-        method: 'PUT',
-        body: file,
-        headers: {
-          'Content-Type': file.type,
-        },
+      // Step 1: Get the upload URL. The endpoint zod-parses a JSON body and returns it as `url`.
+      const presignedResponse = await api.post('/api/app-files/generate-presigned-url', {
+        fileName: file.name,
+        fileSize: file.size,
+        mimeType: file.type,
       });
+      const { url: uploadUrl, fileId } = presignedResponse.data;
+
+      // Step 2: Upload the bytes. The shared helper handles both shapes the server can hand back:
+      // an S3 presign (hosted, raw axios) and the same-origin app-file proxy (self-host, authed api).
+      await uploadFileToUrl(uploadUrl, file, file.type);
 
       // Step 3: Set as template
       const response = await api.post(`/api/users/${userId}/docx-template`, { fileId });

--- a/apps/client/app/components/admin/AdminLogoUpload.tsx
+++ b/apps/client/app/components/admin/AdminLogoUpload.tsx
@@ -14,6 +14,7 @@ import {
   ADMIN_SETTINGS_ARRAY_QUERY_KEY,
   BRANDING_SETTINGS_QUERY_KEY,
 } from '@client/app/hooks/data/queryKeys';
+import { uploadFileToUrl } from '@client/app/utils/uploadFileToUrl';
 
 export async function compressAdminLogo(file: File, quality: number = 0.8): Promise<File | Blob> {
   return new Promise((resolve, reject) => {
@@ -169,25 +170,9 @@ const AdminLogoUpload: React.FC = () => {
         // Handle dual upload for both light and dark modes
         const { urls, logoUrls } = responseData;
 
-        const lightUploadResponse = await fetch(urls.light, {
-          method: 'PUT',
-          body: compressedFile,
-          headers: {
-            'Content-Type': compressedFile.type || file.type,
-          },
-        });
-
-        const darkUploadResponse = await fetch(urls.dark, {
-          method: 'PUT',
-          body: compressedFile,
-          headers: {
-            'Content-Type': compressedFile.type || file.type,
-          },
-        });
-
-        if (!lightUploadResponse.ok || !darkUploadResponse.ok) {
-          throw new Error('Failed to upload file to S3');
-        }
+        // uploadFileToUrl handles both URL shapes the server can hand back and throws on failure.
+        await uploadFileToUrl(urls.light, compressedFile, compressedFile.type || file.type);
+        await uploadFileToUrl(urls.dark, compressedFile, compressedFile.type || file.type);
 
         console.log('Both logos uploaded successfully:', logoUrls);
 
@@ -196,19 +181,11 @@ const AdminLogoUpload: React.FC = () => {
         setLocalDarkLogoUrl(logoUrls.dark);
       } else {
         // Handle single upload
-        const { url: presignedUrl, fileKey } = responseData;
+        const { url: uploadUrl, fileKey } = responseData;
 
-        const uploadResponse = await fetch(presignedUrl, {
-          method: 'PUT',
-          body: compressedFile,
-          headers: {
-            'Content-Type': compressedFile.type || file.type,
-          },
-        });
-
-        if (!uploadResponse.ok) {
-          throw new Error('Failed to upload file to S3');
-        }
+        // The shared helper handles both shapes the server can hand back: an S3 presign (hosted,
+        // raw axios) and the same-origin app-file upload proxy (self-host, authed api).
+        await uploadFileToUrl(uploadUrl, compressedFile, compressedFile.type || file.type);
 
         // Update with the S3 key (not full URL - will be combined with cdnUrl later)
         if (isDarkMode) {

--- a/apps/client/app/hooks/data/organizations.ts
+++ b/apps/client/app/hooks/data/organizations.ts
@@ -7,11 +7,12 @@ import {
   FileGeneratePresignedUrlResponseType,
 } from '@bike4mind/common';
 import { toast } from 'sonner';
-import axios, { AxiosResponse } from 'axios';
+import { AxiosResponse } from 'axios';
 import { updateAllQueryData } from '@client/app/utils/react-query';
 import { useGetOrganizationUsers, useGetPendingOrganizationUsers } from './user';
 import { useMemo } from 'react';
 import { getErrorMessage } from '@client/app/utils/error';
+import { uploadFileToUrl } from '@client/app/utils/uploadFileToUrl';
 
 /**
  * Hook to search organizations with pagination and filtering
@@ -231,12 +232,9 @@ export function useUploadOrganizationLogo() {
 
       const { url, fileId } = data;
 
-      // Step 2: Upload the file to the presigned URL
-      await axios.put(url, file, {
-        headers: {
-          'Content-Type': file.type,
-        },
-      });
+      // Step 2: Upload the bytes. The shared helper handles both shapes the server can hand back:
+      // an S3 presign (hosted, raw axios) and the same-origin app-file proxy (self-host, authed api).
+      await uploadFileToUrl(url, file, file.type);
 
       return fileId;
     },

--- a/apps/client/app/utils/filesAPICalls.ts
+++ b/apps/client/app/utils/filesAPICalls.ts
@@ -191,12 +191,7 @@ export const createAppFileOnServerWithUpload = async (
     formData
   );
 
-  const { url: presignedUrl, fileId } = response.data;
-  await axios.put(presignedUrl, fileToUpload, {
-    headers: {
-      'Content-Type': fileToUpload.type,
-    },
-  });
+  const { url: uploadUrl, fileId } = response.data;
 
   try {
     // Check if already aborted before starting upload
@@ -204,12 +199,10 @@ export const createAppFileOnServerWithUpload = async (
       throw new DOMException('Upload cancelled', 'AbortError');
     }
 
-    await axios.put(presignedUrl, file, {
-      headers: {
-        'Content-Type': file.type,
-      },
-      signal: abortSignal,
-    });
+    // Shared helper routes the self-host proxy path through the authed `api` client and the
+    // hosted S3 presign through raw axios, so this call-site can't drift from the others.
+    // Upload the (possibly resized) `fileToUpload`, which is what formData's fileSize describes.
+    await uploadFileToUrl(uploadUrl, fileToUpload, fileToUpload.type, { signal: abortSignal });
 
     return fileId;
   } catch (err) {

--- a/apps/client/app/utils/organizationAPICalls.tsx
+++ b/apps/client/app/utils/organizationAPICalls.tsx
@@ -10,7 +10,8 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { z } from 'zod';
-import axios, { AxiosResponse, isAxiosError } from 'axios';
+import { AxiosResponse, isAxiosError } from 'axios';
+import { uploadFileToUrl } from './uploadFileToUrl';
 
 export const fetchOrganizations = async (): Promise<IOrganizationDocument[]> => {
   try {
@@ -181,11 +182,9 @@ export function useUploadOrganizationLogo() {
 
       const { url, fileId } = data;
 
-      await axios.put(url, file, {
-        headers: {
-          'Content-Type': file.type,
-        },
-      });
+      // The shared helper handles both shapes the server can hand back: an S3 presign (hosted,
+      // raw axios) and the same-origin app-file upload proxy (self-host, authed api).
+      await uploadFileToUrl(url, file, file.type);
 
       return fileId;
     },

--- a/apps/client/app/utils/userAPICalls.tsx
+++ b/apps/client/app/utils/userAPICalls.tsx
@@ -9,6 +9,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import axios, { AxiosResponse } from 'axios';
 import { api } from '@client/app/contexts/ApiContext';
+import { uploadFileToUrl } from './uploadFileToUrl';
 
 export const updateUserToServer = async (userId: string, userData: Partial<IUser>) => {
   const { data } = await api.put(`/api/users/${userId}/update`, userData);
@@ -181,11 +182,9 @@ export function useUploadProfilePhoto() {
 
       const { url, fileId } = data;
 
-      await axios.put(url, file, {
-        headers: {
-          'Content-Type': file.type,
-        },
-      });
+      // The shared helper handles both shapes the server can hand back: an S3 presign (hosted,
+      // raw axios) and the same-origin app-file upload proxy (self-host, authed api).
+      await uploadFileToUrl(url, file, file.type);
 
       return fileId;
     },

--- a/apps/client/pages/api/admin/upload-logo.ts
+++ b/apps/client/pages/api/admin/upload-logo.ts
@@ -9,6 +9,7 @@ import { AppFile } from '@bike4mind/database/content';
 import { AdminSettings } from '@bike4mind/database/infra';
 import { S3Storage } from '@bike4mind/fab-pipeline';
 import { baseApi } from '@server/middlewares/baseApi';
+import { resolveBrowserAppFileUploadUrl } from '@server/utils/browserUploadUrl';
 import { BadRequestError, ForbiddenError } from '@server/utils/errors';
 import mime from 'mime-types';
 import { v4 as uuidv4 } from 'uuid';
@@ -143,7 +144,8 @@ const handler = baseApi()
         await updateLogoSettings(updatedSettings, session);
 
         return {
-          url: presignedUrl,
+          // Self-host swaps the (browser-unreachable) MinIO presign for the same-origin upload proxy.
+          url: resolveBrowserAppFileUploadUrl(file.id, presignedUrl),
           fileId: file.id,
           fileKey,
           logoUrl: `${process.env.NEXT_PUBLIC_CDN_URL}/admin-logos/${fileKey}`,

--- a/apps/client/pages/api/app-files/[id]/__tests__/upload.test.ts
+++ b/apps/client/pages/api/app-files/[id]/__tests__/upload.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+
+const { findByIdMock, uploadMock, getSettingsValueMock } = vi.hoisted(() => ({
+  findByIdMock: vi.fn(),
+  uploadMock: vi.fn(),
+  getSettingsValueMock: vi.fn(),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({ baseApi: () => ({ put: (h: unknown) => h }) }));
+vi.mock('@bike4mind/database', () => ({ adminSettingsRepository: {} }));
+vi.mock('@bike4mind/database/content', () => ({ AppFile: { findById: findByIdMock } }));
+vi.mock('@bike4mind/utils', () => ({
+  getSettingsMap: vi.fn(async () => ({})),
+  getSettingsValue: getSettingsValueMock,
+}));
+vi.mock('@server/utils/storage', () => ({ getAppFilesStorage: () => ({ upload: uploadMock }) }));
+
+const handler = (await import('../upload')).default as (req: Request, res: Response) => Promise<unknown>;
+
+const makeRes = () => {
+  const res = {} as Response & { statusCode: number; body: unknown };
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res;
+  }) as unknown as Response['status'];
+  res.json = vi.fn((payload: unknown) => {
+    res.body = payload;
+    return res;
+  }) as unknown as Response['json'];
+  return res;
+};
+
+const makeReq = (opts: { id?: string; userId?: string; body?: Buffer[] }) => {
+  const chunks = opts.body ?? [Buffer.from('hello')];
+  return {
+    query: { id: opts.id ?? 'af1' },
+    user: { id: opts.userId ?? 'u1' },
+    headers: { 'content-type': 'image/png' },
+    destroy: vi.fn(),
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield c;
+    },
+  } as unknown as Request;
+};
+
+const makePendingFile = () => ({
+  id: 'af1',
+  userId: 'u1',
+  status: 'pending' as string,
+  path: 'organizations/org1/logo.png',
+  mimeType: 'image/png',
+  save: vi.fn(async function (this: { status: string }) {
+    return this;
+  }),
+});
+
+describe('PUT /api/app-files/[id]/upload (self-host proxy)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.B4M_SELF_HOST = 'true';
+    getSettingsValueMock.mockReturnValue(20); // 20 MB
+    uploadMock.mockResolvedValue(undefined);
+    findByIdMock.mockResolvedValue(makePendingFile());
+  });
+  afterEach(() => {
+    delete process.env.B4M_SELF_HOST;
+  });
+
+  it('returns 404 when not in self-host mode', async () => {
+    process.env.B4M_SELF_HOST = 'false';
+    const res = makeRes();
+    await handler(makeReq({}), res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(findByIdMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the app file does not exist', async () => {
+    findByIdMock.mockResolvedValue(null);
+    const res = makeRes();
+    await handler(makeReq({}), res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the app file was created by another user', async () => {
+    findByIdMock.mockResolvedValue({ ...makePendingFile(), userId: 'someone-else' });
+    const res = makeRes();
+    await handler(makeReq({ userId: 'u1' }), res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the app file is not awaiting upload (already complete)', async () => {
+    findByIdMock.mockResolvedValue({ ...makePendingFile(), status: 'complete' });
+    const res = makeRes();
+    await handler(makeReq({}), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 and aborts mid-stream when the body exceeds the size cap', async () => {
+    getSettingsValueMock.mockReturnValue(0.00001); // ~10 bytes cap
+    const req = makeReq({ body: [Buffer.alloc(50), Buffer.alloc(50)] });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(413);
+    expect((req as unknown as { destroy: ReturnType<typeof vi.fn> }).destroy).toHaveBeenCalled();
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("writes the body to the app file's own storage key and returns 200 on success", async () => {
+    const res = makeRes();
+    await handler(makeReq({ body: [Buffer.from('hello '), Buffer.from('world')] }), res);
+
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    const [body, key, options] = uploadMock.mock.calls[0];
+    expect(Buffer.isBuffer(body)).toBe(true);
+    expect((body as Buffer).toString()).toBe('hello world');
+    expect(key).toBe('organizations/org1/logo.png');
+    expect(options).toMatchObject({ ContentType: 'image/png', ContentLength: 11 });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('marks the AppFile complete on a successful write so a lost webhook cannot strand it', async () => {
+    const appFile = makePendingFile();
+    findByIdMock.mockResolvedValue(appFile);
+    const res = makeRes();
+    await handler(makeReq({}), res);
+
+    expect(appFile.status).toBe('complete');
+    expect(appFile.save).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('does not mark complete when the write fails', async () => {
+    const appFile = makePendingFile();
+    findByIdMock.mockResolvedValue(appFile);
+    uploadMock.mockRejectedValue(new Error('storage down'));
+    const res = makeRes();
+    await expect(handler(makeReq({}), res)).rejects.toThrow('storage down');
+
+    expect(appFile.status).toBe('pending');
+    expect(appFile.save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/app-files/[id]/upload.ts
+++ b/apps/client/pages/api/app-files/[id]/upload.ts
@@ -1,0 +1,99 @@
+import { adminSettingsRepository } from '@bike4mind/database';
+import { AppFile } from '@bike4mind/database/content';
+import { getSettingsMap, getSettingsValue } from '@bike4mind/utils';
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { baseApi } from '@server/middlewares/baseApi';
+import { getAppFilesStorage } from '@server/utils/storage';
+import type { Request, Response } from 'express';
+
+/**
+ * Self-host app-file upload proxy (PUT).
+ *
+ * The AppFile twin of pages/api/files/[id]/upload.ts, for the app-files bucket: generic app files,
+ * organization logos and profile photos. In AWS the browser PUTs straight to S3 with the presign
+ * those endpoints return; self-host has no browser-reachable S3 (the presign targets the internal
+ * MinIO host, unreachable and blocked by CSP), so resolveBrowserAppFileUploadUrl hands the browser
+ * this same-origin route instead and it writes the bytes to storage server-side.
+ *
+ * Auth is normal baseApi (the logged-in user / API key), but the target AppFile must exist, have
+ * been created by the caller, and still be awaiting upload - so the presign-issuing endpoint's own
+ * authorization (org membership, self-or-admin for photos) is what gates the write. Marking the
+ * AppFile complete here mirrors server/s3/appFileUploadComplete.ts, whose ObjectCreated webhook
+ * still fires and whose status write is then an idempotent no-op.
+ *
+ * Self-host only (404 otherwise).
+ */
+
+const DEFAULT_MAX_FILE_SIZE_MB = 20; // mirror pages/api/files/[id]/upload.ts
+/** Coarse Content-Length pre-check ceiling; the exact MaxFileSize cap is enforced mid-stream. */
+const BODY_CEILING_BYTES = 512 * 1024 * 1024;
+
+const handler = baseApi({ maxBodySize: BODY_CEILING_BYTES }).put(
+  asyncHandler(async (req: Request, res: Response) => {
+    if (process.env.B4M_SELF_HOST !== 'true') {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    const appFileId = String((req.query as { id?: string }).id ?? '');
+    const appFile = await AppFile.findById(appFileId);
+    // Same 404 for missing and not-owned so the route doesn't leak which files exist.
+    if (!appFile || appFile.userId !== req.user.id) {
+      return res.status(404).json({ error: 'File not found' });
+    }
+    if (appFile.status !== 'pending') {
+      return res.status(400).json({ error: 'File is not awaiting upload' });
+    }
+    if (!appFile.path) {
+      return res.status(400).json({ error: 'File has no storage path' });
+    }
+    const filePath = appFile.path;
+
+    const maxBytes =
+      getSettingsValue(
+        'MaxFileSize',
+        await getSettingsMap({ adminSettings: adminSettingsRepository }),
+        DEFAULT_MAX_FILE_SIZE_MB
+      ) *
+      1024 *
+      1024;
+
+    // Stream with a hard mid-stream cap so a client that lies about (or omits) Content-Length
+    // can't exhaust memory: stop and 413 the moment the cap is exceeded.
+    const chunks: Buffer[] = [];
+    let received = 0;
+    for await (const chunk of req) {
+      const buf = chunk as Buffer;
+      received += buf.length;
+      if (received > maxBytes) {
+        req.destroy();
+        return res.status(413).json({ error: 'File size exceeds maximum file size', maxBytes });
+      }
+      chunks.push(buf);
+    }
+    const body = Buffer.concat(chunks);
+
+    // Write to the AppFile's own storage key (from the DB, never client-supplied) so the caller
+    // can't target an arbitrary key and the webhook fires on the expected object.
+    await getAppFilesStorage().upload(body, filePath, {
+      ContentType: appFile.mimeType || (req.headers['content-type'] as string) || 'application/octet-stream',
+      ContentLength: body.length,
+    });
+
+    // A successful write proves the object landed, so mark complete here rather than depending on
+    // the webhook; the webhook's own status write (when it arrives) is an idempotent no-op.
+    appFile.status = 'complete';
+    await appFile.save();
+
+    return res.status(200).json({ ok: true, appFileId: appFile.id });
+  })
+);
+
+// Raw stream: disable Next's body parser so we can size-cap and forward the bytes ourselves.
+export const config = {
+  api: {
+    bodyParser: false,
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/apps/client/pages/api/app-files/generate-presigned-url.ts
+++ b/apps/client/pages/api/app-files/generate-presigned-url.ts
@@ -10,6 +10,7 @@ import { AppFile } from '@bike4mind/database/content';
 import { logEvent } from '@server/utils/analyticsLog';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
+import { resolveBrowserAppFileUploadUrl } from '@server/utils/browserUploadUrl';
 import { BadRequestError } from '@server/utils/errors';
 import mime from 'mime-types';
 import { v4 as uuidv4 } from 'uuid';
@@ -56,7 +57,8 @@ const handler = baseApi().post(
         { ability: req.ability }
       );
 
-      return res.json({ url: presignedUrl, fileId: file.id, fileKey });
+      // Self-host swaps the (browser-unreachable) MinIO presign for the same-origin upload proxy.
+      return res.json({ url: resolveBrowserAppFileUploadUrl(file.id, presignedUrl), fileId: file.id, fileKey });
     }
   )
 );

--- a/apps/client/pages/api/organizations/[id]/upload-logo.ts
+++ b/apps/client/pages/api/organizations/[id]/upload-logo.ts
@@ -5,6 +5,7 @@ import { Organization } from '@bike4mind/database/infra';
 import { S3Storage } from '@bike4mind/fab-pipeline';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
+import { resolveBrowserAppFileUploadUrl } from '@server/utils/browserUploadUrl';
 import { BadRequestError, ForbiddenError, NotFoundError } from '@server/utils/errors';
 import mime from 'mime-types';
 import { v4 as uuidv4 } from 'uuid';
@@ -62,7 +63,8 @@ const handler = baseApi().post(
       // Note: ACL not needed - bucket policy grants public read for organizations/* prefix
       const presignedUrl = await storage.getSignedUrl(fileKey, 'put', { expiresIn: 600 });
 
-      return { url: presignedUrl, fileId: file.id, fileKey };
+      // Self-host swaps the (browser-unreachable) MinIO presign for the same-origin upload proxy.
+      return { url: resolveBrowserAppFileUploadUrl(file.id, presignedUrl), fileId: file.id, fileKey };
     });
 
     return res.json(result);

--- a/apps/client/pages/api/users/[id]/upload-photo.ts
+++ b/apps/client/pages/api/users/[id]/upload-photo.ts
@@ -3,6 +3,7 @@ import { AppFile } from '@bike4mind/database/content';
 import { User, withTransaction } from '@bike4mind/database';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
+import { resolveBrowserAppFileUploadUrl } from '@server/utils/browserUploadUrl';
 import { BadRequestError, NotFoundError } from '@server/utils/errors';
 import mime from 'mime-types';
 import { v4 as uuidv4 } from 'uuid';
@@ -79,7 +80,8 @@ const handler = baseApi().post(
       { ability: req.ability }
     );
 
-    return res.json({ url: presignedUrl, fileId, fileKey });
+    // Self-host swaps the (browser-unreachable) MinIO presign for the same-origin upload proxy.
+    return res.json({ url: resolveBrowserAppFileUploadUrl(fileId, presignedUrl), fileId, fileKey });
   })
 );
 

--- a/apps/client/server/utils/browserUploadUrl.test.ts
+++ b/apps/client/server/utils/browserUploadUrl.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { resolveBrowserUploadUrl } from './browserUploadUrl';
+import { resolveBrowserAppFileUploadUrl, resolveBrowserUploadUrl } from './browserUploadUrl';
 
 describe('resolveBrowserUploadUrl', () => {
   afterEach(() => {
@@ -23,5 +23,30 @@ describe('resolveBrowserUploadUrl', () => {
     delete process.env.B4M_SELF_HOST;
     const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/key.md?sig=x';
     expect(resolveBrowserUploadUrl('abc123', presigned)).toBe(presigned);
+  });
+});
+
+describe('resolveBrowserAppFileUploadUrl', () => {
+  afterEach(() => {
+    delete process.env.B4M_SELF_HOST;
+  });
+
+  it('returns the app-file proxy route in self-host (a different bucket than fab-files)', () => {
+    process.env.B4M_SELF_HOST = 'true';
+    expect(resolveBrowserAppFileUploadUrl('af1', 'http://b4m-app-files.localhost:9000/logo.png?sig=x')).toBe(
+      '/api/app-files/af1/upload'
+    );
+  });
+
+  it('returns the direct S3 presigned URL when hosted', () => {
+    process.env.B4M_SELF_HOST = 'false';
+    const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/logo.png?sig=x';
+    expect(resolveBrowserAppFileUploadUrl('af1', presigned)).toBe(presigned);
+  });
+
+  it('treats an unset B4M_SELF_HOST as hosted (returns the presign unchanged)', () => {
+    delete process.env.B4M_SELF_HOST;
+    const presigned = 'https://bucket.s3.us-east-2.amazonaws.com/logo.png?sig=x';
+    expect(resolveBrowserAppFileUploadUrl('af1', presigned)).toBe(presigned);
   });
 });

--- a/apps/client/server/utils/browserUploadUrl.ts
+++ b/apps/client/server/utils/browserUploadUrl.ts
@@ -14,3 +14,15 @@
  */
 export const resolveBrowserUploadUrl = (fileId: string, directPresignedUrl: string): string =>
   process.env.B4M_SELF_HOST === 'true' ? `/api/files/${fileId}/upload` : directPresignedUrl;
+
+/**
+ * The same rewrite for AppFile uploads (app-files, organization logos, profile photos), which
+ * live in the app-files bucket rather than the fab-file bucket and so need their own proxy route
+ * (pages/api/app-files/[id]/upload.ts).
+ *
+ * Every endpoint that hands the browser an app-files presign - app-files/generate-presigned-url,
+ * organizations/[id]/upload-logo, users/[id]/upload-photo - MUST route through this, or that
+ * upload hits the CSP-blocked MinIO host on self-host.
+ */
+export const resolveBrowserAppFileUploadUrl = (appFileId: string, directPresignedUrl: string): string =>
+  process.env.B4M_SELF_HOST === 'true' ? `/api/app-files/${appFileId}/upload` : directPresignedUrl;

--- a/apps/client/server/utils/storage/index.ts
+++ b/apps/client/server/utils/storage/index.ts
@@ -4,6 +4,7 @@ import { Resource } from 'sst';
 let _filesStorage: S3Storage | undefined;
 let _generatedImageStorage: S3Storage | undefined;
 let _publishedArtifactsStorage: S3Storage | undefined;
+let _appFilesStorage: S3Storage | undefined;
 
 export const getFilesStorage = () => {
   if (!_filesStorage) _filesStorage = new S3Storage(Resource.fabFileBucket.name);
@@ -13,6 +14,11 @@ export const getFilesStorage = () => {
 export const getGeneratedImageStorage = () => {
   if (!_generatedImageStorage) _generatedImageStorage = new S3Storage(Resource.generatedImagesBucket.name);
   return _generatedImageStorage;
+};
+
+export const getAppFilesStorage = () => {
+  if (!_appFilesStorage) _appFilesStorage = new S3Storage(Resource.appFilesBucket.name);
+  return _appFilesStorage;
 };
 
 export const getPublishedArtifactsStorage = () => {


### PR DESCRIPTION
## Description

Follow-up to #855. That PR made the Data Lake / FabFile browser uploads self-host-safe by routing them through the server-side `resolveBrowserUploadUrl` and the client-side `uploadFileToUrl`. Several other browser-upload call-sites were missed: they requested an S3 presigned URL and PUT to it directly with raw `axios`/`fetch`, with no self-host branch.

On self-host that presign targets the internal MinIO host, which is unreachable from a browser and blocked by the CSP `connect-src` allow-list — so app-file, organization-logo, profile-photo and admin-logo uploads all failed the same way BUG-1 did.

These uploads all live in the **app-files bucket** rather than the fab-file bucket, so they need their own proxy route; `/api/files/[id]/upload` is keyed to a FabFile and can't serve them. Conveniently, all four flows already create an `AppFile` record with `status: 'pending'` and a server-chosen `path`, so one AppFile-keyed proxy covers all of them.

## Changes

**Server**
- `server/utils/browserUploadUrl.ts` — new `resolveBrowserAppFileUploadUrl()`, returning `/api/app-files/<id>/upload` on self-host and the presign unchanged when hosted.
- `pages/api/app-files/[id]/upload.ts` **(new)** — the AppFile twin of `pages/api/files/[id]/upload.ts`. Normal `baseApi` auth; the target AppFile must exist, have been created by the caller, and still be `pending`; body is read as a size-capped stream (mid-stream 413, so a client lying about `Content-Length` can't exhaust memory); bytes are written to the AppFile's own DB-held storage key, never a client-supplied one; marks the AppFile `complete` so a lost ObjectCreated webhook can't strand it. 404s when not self-host.
- `server/utils/storage/index.ts` — added `getAppFilesStorage()`.
- Rewrite applied on all four endpoints issuing an app-files presign: `app-files/generate-presigned-url.ts`, `organizations/[id]/upload-logo.ts`, `users/[id]/upload-photo.ts`, `admin/upload-logo.ts`.

**Client** — every PUT to those endpoints now goes through the shared `uploadFileToUrl` (authed `api` for the same-origin proxy, raw axios for an S3 presign):
- `app/utils/filesAPICalls.ts` (`createAppFileOnServerWithUpload`)
- `app/hooks/data/organizations.ts` and `app/utils/organizationAPICalls.tsx` — both org-logo hooks
- `app/utils/userAPICalls.tsx` (`useUploadProfilePhoto`)
- `app/components/admin/AdminLogoUpload.tsx`
- `app/components/ProfileModal/SettingsTabContent/DocxTemplateSection.tsx`

**Two pre-existing bugs fixed in passing**, both in call-sites this PR had to touch anyway:
- `createAppFileOnServerWithUpload` PUT the file **twice**. The first PUT used the resized `fileToUpload` but ignored the abort signal; the second re-uploaded the *original* unresized `file` over it, defeating the client-side resize that `formData.fileSize` claims. Collapsed to a single abort-aware PUT of the resized file.
- `DocxTemplateSection` posted `FormData` to an endpoint that zod-parses a JSON body, then read `presignedUrl` from a response that returns `url`. Both wrong; the template upload could not have been working. Now posts JSON and reads `url`.

**Tests**
- `pages/api/app-files/[id]/__tests__/upload.test.ts` (new, 8 cases) — mirrors the fab-file proxy suite: non-self-host 404, missing file 404, another user's file 404, non-pending 400, oversized body 413 + stream destroyed, correct key/content-type/length on success, marks complete, and does *not* mark complete when the storage write throws.
- `resolveBrowserAppFileUploadUrl` cases added to `server/utils/browserUploadUrl.test.ts`.

## Guide for Testers

This is a self-host-only code path; on hosted/staging the behavior is unchanged (the presign is returned exactly as before). The meaningful verification is on a self-host stack.

**Regression checks (hosted — staging)**

1. Go to `app.staging.bike4mind.com` and log in.
2. Open Profile → Settings → General. Upload a profile photo (any PNG/JPG under 3 MB). Expect: upload succeeds, the new photo renders in the sidebar avatar within a few seconds, no console errors.
3. In the same Settings area, find the DOCX export template section. Upload a `.docx` file. Expect: toast `DOCX export template set successfully`, and the filename + size appear in the section. (This path was broken before this PR, so treat a success here as the fix, not a regression.)
4. As an admin, go to Admin → Branding and upload a custom logo. Expect: upload succeeds and the header logo updates.
5. Open an organization you administer and upload an organization logo. Expect: upload succeeds and the logo appears on the org.
6. Open a chat session and attach an image larger than 3 MB to a message. Expect: it uploads once, is resized client-side, and the attachment renders. Confirm in the Network tab that exactly **one** PUT is issued for the file (previously two).

**Self-host verification**

7. Bring up the self-host stack (`compose.selfhost.yaml`, `B4M_SELF_HOST=true`) and log in.
8. Repeat steps 2–5. Expect: each upload succeeds. In the Network tab each PUT goes to a **same-origin** `/api/app-files/<id>/upload` URL with an `Authorization: Bearer` header — **not** to a `*.localhost:9000` MinIO host.
9. Confirm no CSP violations appear in the browser console during any of these uploads.
10. Confirm the uploaded assets render after a page reload (proving the object actually landed in the bucket and the AppFile was marked `complete`).

**What NOT to test**

- The `useBothLogos` dual light/dark branch in `AdminLogoUpload.tsx` — the server never returns `useBothLogos` or `urls`, so that branch is unreachable dead code. It was converted for consistency only.
- Blog images, published artifacts, and LLM-history import (see Additional Information) — deliberately unchanged by this PR.

## Additional Information

**Still bypassing the proxy on self-host — out of scope here.** Three other browser-upload flows PUT direct-to-storage, but none creates an `AppFile` record, so each needs its own proxy route rather than this one. They are separate work, not covered by this PR's acceptance criteria:

- blog images — `app/utils/blogImageUpload.ts`
- published artifacts — `app/utils/publishApi.ts`
- LLM history import — `GeneralSettingsTab.tsx` → `/api/import-history/upload`

Worth a follow-up issue.

**Verification performed**
- `pnpm exec turbo typecheck:fast` — 37/37 tasks pass.
- `vitest` over `pages/api/app-files app/utils app/hooks/data/organizations server/utils/browserUploadUrl.test.ts` — 63 files, 764 tests pass.
- `vitest` over `app/components/admin app/components/ProfileModal pages/api/{users,organizations,admin}` — 70 files, 516 pass / 7 skipped.
- `eslint` on all touched files — 0 errors (10 pre-existing warnings on untouched lines).
- **Not** verified by me: an actual upload against a running self-host MinIO stack. I did not stand up the self-host environment, so steps 7–10 above are unexercised and are the main thing a reviewer should confirm.

## Developer Notes

- `resolveBrowserAppFileUploadUrl` + `/api/app-files/[id]/upload` establish the app-files-bucket counterpart to the existing fab-file pair. Any future endpoint that hands the browser an app-files presign should call the resolver and let the client PUT via `uploadFileToUrl` — that is now the complete set of primitives for a self-host-safe browser upload.
- The pattern generalizes: a browser upload is self-host-safe iff (a) an owning DB record holds the storage key, and (b) a same-origin proxy route writes under that key. The three remaining call-sites listed above fail (a), which is exactly why they need more than a one-line rewrite.
- `getAppFilesStorage()` added to `server/utils/storage` alongside the existing lazy getters, so app-files-bucket access no longer needs an ad-hoc `new S3Storage(Resource.appFilesBucket.name)` at each call-site.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — n/a, no new settings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) — n/a, no UI changes
- [ ] I have made corresponding changes to the documentation (if applicable) — n/a
- [ ] If adding/modifying telemetry fields — n/a
