### PR TITLE
feat(client): create-first data lake affordance for zero-lake browse surfaces

### DIFF
--- a/apps/client/app/components/datalake/DataLakeArticle.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeArticle.test.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import DataLakeArticle from './DataLakeArticle';
+
+// The content hook hits react-query; stub it so the empty state renders without a provider.
+vi.mock('@client/app/hooks/data/fabFiles', () => ({
+  useGetFabFileContent: () => ({ data: undefined, isLoading: false }),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+describe('DataLakeArticle - create-first empty state (#837)', () => {
+  it('renders a create CTA in the empty state when onCreate is provided and invokes it', () => {
+    const onCreate = vi.fn();
+    render(
+      <Wrapper>
+        <DataLakeArticle file={null} onAskAbout={vi.fn()} onCreate={onCreate} />
+      </Wrapper>
+    );
+
+    const cta = screen.getByTestId('datalake-empty-create-btn');
+    expect(cta).toBeInTheDocument();
+
+    fireEvent.click(cta);
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the default idle copy and no CTA when onCreate is absent', () => {
+    render(
+      <Wrapper>
+        <DataLakeArticle file={null} onAskAbout={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('datalake-empty-create-btn')).not.toBeInTheDocument();
+    expect(screen.getByText(/sonar idle/i)).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/datalake/DataLakeArticle.tsx
+++ b/apps/client/app/components/datalake/DataLakeArticle.tsx
@@ -1,8 +1,10 @@
 import { Box, Button, Chip, Skeleton, Typography, useTheme } from '@mui/joy';
 import { alpha } from '@mui/system';
+import AddIcon from '@mui/icons-material/Add';
 import ChatIcon from '@mui/icons-material/Chat';
 import RecordVoiceOverIcon from '@mui/icons-material/RecordVoiceOver';
 import MarkdownViewer from '@client/app/components/Knowledge/MarkdownViewer';
+import { DATA_LAKE } from '@client/app/components/datalake/dataLakeBranding';
 import { HUES, REDUCED_MOTION_OFF, driftFloat, inkFor, sonarPing } from '@client/app/components/datalake/deckChrome';
 import { useGetFabFileContent } from '@client/app/hooks/data/fabFiles';
 import type { IFabFileDocument } from '@bike4mind/common';
@@ -19,6 +21,9 @@ interface DataLakeArticleProps {
   /** Richest categories, surfaced as one-click dives in the empty state. */
   quickDives?: QuickDive[];
   onDive?: (path: string[]) => void;
+  /** When set, the empty state offers a create-first CTA (zero-lake bootstrap, #837).
+   *  The caller only passes this in the true zero-state, so its presence is the signal. */
+  onCreate?: () => void;
 }
 
 function cleanFileName(fileName: string): string {
@@ -51,10 +56,12 @@ function SonarEmptyState({
   isDark,
   quickDives,
   onDive,
+  onCreate,
 }: {
   isDark: boolean;
   quickDives: QuickDive[];
   onDive?: (path: string[]) => void;
+  onCreate?: () => void;
 }) {
   const cyan = inkFor(HUES.cyan, isDark);
   return (
@@ -132,12 +139,28 @@ function SonarEmptyState({
           level="title-lg"
           sx={{ fontWeight: 700, letterSpacing: '0.02em', color: 'text.secondary', mb: 0.5 }}
         >
-          Sonar idle — nothing on the scope
+          {onCreate ? 'Nothing on the scope yet' : 'Sonar idle — nothing on the scope'}
         </Typography>
         <Typography level="body-sm" sx={{ color: 'text.tertiary', maxWidth: 380 }}>
-          Pick a branch from the tree, or drop into one of the richest currents below.
+          {onCreate
+            ? `Create your first ${DATA_LAKE.toLowerCase()} to turn your files into searchable knowledge.`
+            : 'Pick a branch from the tree, or drop into one of the richest currents below.'}
         </Typography>
       </Box>
+
+      {/* Create-first CTA: only shown in the true zero-lake state (caller passes onCreate). */}
+      {onCreate && (
+        <Button
+          data-testid="datalake-empty-create-btn"
+          variant="solid"
+          color="primary"
+          startDecorator={<AddIcon />}
+          onClick={onCreate}
+          sx={{ zIndex: 1 }}
+        >
+          Create {DATA_LAKE.toLowerCase()}
+        </Button>
+      )}
 
       {/* Quick dives */}
       {quickDives.length > 0 && onDive && (
@@ -173,13 +196,13 @@ function SonarEmptyState({
   );
 }
 
-export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onDive }: DataLakeArticleProps) {
+export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onDive, onCreate }: DataLakeArticleProps) {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
   const { data: content, isLoading } = useGetFabFileContent(file);
 
   if (!file) {
-    return <SonarEmptyState isDark={isDark} quickDives={quickDives} onDive={onDive} />;
+    return <SonarEmptyState isDark={isDark} quickDives={quickDives} onDive={onDive} onCreate={onCreate} />;
   }
 
   const title = cleanFileName(file.fileName);

--- a/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
@@ -41,3 +41,30 @@ describe('DataLakeExplorer - persistent Data Lakes info tooltip (#834)', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('DataLakeExplorer - create-first affordance (#837)', () => {
+  it('renders a header Create button when onCreate is provided and invokes it on click', () => {
+    const onCreate = vi.fn();
+    render(
+      <Wrapper>
+        <DataLakeExplorer onBack={vi.fn()} onAskAbout={vi.fn()} onCreate={onCreate} />
+      </Wrapper>
+    );
+
+    const createBtn = screen.getByTestId('datalake-create-btn');
+    expect(createBtn).toBeInTheDocument();
+
+    fireEvent.click(createBtn);
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the create affordance entirely when no onCreate is provided', () => {
+    render(
+      <Wrapper>
+        <DataLakeExplorer onBack={vi.fn()} onAskAbout={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.queryByTestId('datalake-create-btn')).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { Box, Button, Typography, useTheme } from '@mui/joy';
+import AddIcon from '@mui/icons-material/Add';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import TravelExploreIcon from '@mui/icons-material/TravelExplore';
@@ -32,6 +33,10 @@ interface DataLakeExplorerProps {
   onManage?: () => void;
   /** When provided, renders a "Discover" button that opens the public-lake browse catalog. */
   onDiscover?: () => void;
+  /** When provided, renders a "Create" affordance (header button + zero-state call to
+   *  action) that starts the new-lake wizard. Independent of `onManage` so a browse-only
+   *  surface can still let a user create the FIRST lake in place (#837). */
+  onCreate?: () => void;
 }
 
 /** True only for drags carrying real files (not text/image-from-page drags). */
@@ -45,6 +50,7 @@ export default function DataLakeExplorer({
   rootLabel = '⛩ Mission Hub',
   onManage,
   onDiscover,
+  onCreate,
 }: DataLakeExplorerProps) {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
@@ -133,6 +139,10 @@ export default function DataLakeExplorer({
   const totalArticles = tagCountsData?.uniqueArticleCounts?.total ?? 0;
   const branchCount = useMemo(() => tree.reduce((sum, node) => sum + Math.max(node.children.length, 1), 0), [tree]);
 
+  // Zero-state: nothing to browse yet. Drives the create-first affordance so the first
+  // lake can be created in place instead of dead-ending on an empty scope (#837).
+  const isEmpty = !tagCountsLoading && !tagCountsError && totalArticles === 0 && tree.length === 0;
+
   // Quick dives for the empty state: richest second-level categories across prefixes
   const quickDives = useMemo(
     () =>
@@ -204,6 +214,19 @@ export default function DataLakeExplorer({
           data-testid="field-tooltip-data-lake-explorer"
           sx={{ mb: 2 }}
         />
+        {onCreate && (
+          <Button
+            data-testid="datalake-create-btn"
+            size="sm"
+            variant="soft"
+            color="primary"
+            startDecorator={<AddIcon sx={{ fontSize: 16 }} />}
+            onClick={onCreate}
+            sx={{ mb: 2 }}
+          >
+            Create {DATA_LAKE.toLowerCase()}
+          </Button>
+        )}
         {onManage && (
           <Button
             data-testid="datalake-manage-btn"
@@ -212,7 +235,7 @@ export default function DataLakeExplorer({
             color="neutral"
             startDecorator={<SettingsOutlinedIcon sx={{ fontSize: 16 }} />}
             onClick={onManage}
-            sx={{ mb: 2 }}
+            sx={{ mb: 2, ml: 1 }}
           >
             Manage lakes
           </Button>
@@ -256,7 +279,13 @@ export default function DataLakeExplorer({
           isLoading={tagCountsLoading || (!!leafTag && leafLoading)}
           isError={tagCountsError}
         />
-        <DataLakeArticle file={selectedFile} onAskAbout={onAskAbout} quickDives={quickDives} onDive={handleNavigate} />
+        <DataLakeArticle
+          file={selectedFile}
+          onAskAbout={onAskAbout}
+          quickDives={quickDives}
+          onDive={handleNavigate}
+          onCreate={isEmpty ? onCreate : undefined}
+        />
       </Box>
 
       {/* Drag-to-ingest: pick a destination lake, then the append wizard takes over.

--- a/apps/client/app/routes/data-lakes.tsx
+++ b/apps/client/app/routes/data-lakes.tsx
@@ -20,6 +20,7 @@ export default function DataLakesHome() {
   const navigate = useNavigate();
   const { article } = useSearch({ strict: false }) as { article?: string };
   const openManager = useDataLakeWizardStore(s => s.openManager);
+  const openWizard = useDataLakeWizardStore(s => s.openWizard);
 
   // No docked chat on this surface - "Ask about this article" prefills the composer
   // and drops the user into a fresh chat to send it.
@@ -40,6 +41,7 @@ export default function DataLakesHome() {
       onAskAbout={handleAskAbout}
       onManage={openManager}
       onDiscover={() => openManager('discover')}
+      onCreate={openWizard}
     />
   );
 }


### PR DESCRIPTION
## Description

`DataLakeExplorer` only exposed lake management through `onManage` (which opens the manager panel, where the Create button lives). A browse-only surface that does not pass `onManage` therefore had no create affordance at all, and with zero lakes there was no way to create the FIRST lake from that screen -- a bootstrapping dead-end (same shape as #856).

This adds a dedicated, `onManage`-independent create affordance to the shared `DataLakeExplorer` so any browse surface -- including browse-only ones -- can let a user create the first lake in place.

## Changes

- `DataLakeExplorer.tsx`: new `onCreate?` prop. Renders a persistent header "Create data lake" button whenever it is set, and computes a zero-state signal (`!loading && !error && no articles && empty tree`) that surfaces a create-first CTA in the article pane only when there is truly nothing to browse.
- `DataLakeArticle.tsx`: the sonar empty state now shows a prominent "Create data lake" CTA and switches its copy to a create-first message when `onCreate` is provided; non-empty behavior (quick dives, idle copy) is unchanged.
- `routes/data-lakes.tsx`: wires `onCreate` to the new-lake wizard (`openWizard`).
- Labels use the shared `DATA_LAKE` branding constant so premium overlays stay consistent.
- Tests: new `DataLakeArticle.test.tsx` (empty-state CTA) and extended `DataLakeExplorer.test.tsx` (header create button present/absent + click).

Closes #837.

## Guide for Testers

1. Sign in as a user with the **EnableDataLakes** admin flag enabled.
2. Navigate to the standalone **Data Lakes** destination (`/data-lakes`).
3. With **no data lakes created yet**, confirm the header shows a **Create data lake** button (to the left of "Manage lakes").
   - Expected: the button is visible and labeled "Create data lake".
4. Confirm the main article pane shows the empty state with the heading **"Nothing on the scope yet"** and body text prompting you to create your first data lake, plus a solid **Create data lake** button.
5. Click either **Create data lake** button.
   - Expected: the new-lake creation wizard opens.
6. Create a lake and add at least one file, then return to `/data-lakes`.
   - Expected: the empty-state create CTA in the article pane is gone (content now browsable); the header **Create data lake** button remains available.

### Regression Checks

7. With at least one lake present, before selecting an article the article pane shows the original idle copy ("Sonar idle -- nothing on the scope") and quick-dive chips -- not the create CTA.
8. "Manage lakes" and "Discover" buttons still open the manager panel on their respective tabs.

### What NOT to test

- Overlay (OptiHashi) wiring -- that is a separate overlay PR; this PR only adds the shared-core capability.

## Developer Notes

- `DataLakeExplorer` now accepts an `onCreate` prop that is independent of `onManage`, so a browse-only surface can offer first-lake creation without exposing the full manage panel. The Explorer decides zero-state internally and only threads `onCreate` into the empty article view when there is nothing to browse, keeping `DataLakeArticle`'s contract simple (presence of `onCreate` in the empty state IS the zero-state signal).
