### PR TITLE
feat(datalake): make the standalone surface brand-agnostic (#842)

### DIFF
--- a/apps/client/app/components/datalake/DataLakeArticle.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeArticle.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
 import DataLakeArticle from './DataLakeArticle';
+import { DEFAULT_DATA_LAKE_SURFACE_TOKENS } from './surfaceTokens';
 
 // The content hook hits react-query; stub it so the empty state renders without a provider.
 vi.mock('@client/app/hooks/data/fabFiles', () => ({
@@ -39,6 +40,6 @@ describe('DataLakeArticle - create-first empty state (#837)', () => {
     );
 
     expect(screen.queryByTestId('datalake-empty-create-btn')).not.toBeInTheDocument();
-    expect(screen.getByText(/sonar idle/i)).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_DATA_LAKE_SURFACE_TOKENS.copy.emptyTitle)).toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/datalake/DataLakeArticle.tsx
+++ b/apps/client/app/components/datalake/DataLakeArticle.tsx
@@ -2,10 +2,10 @@ import { Box, Button, Chip, Skeleton, Typography, useTheme } from '@mui/joy';
 import { alpha } from '@mui/system';
 import AddIcon from '@mui/icons-material/Add';
 import ChatIcon from '@mui/icons-material/Chat';
-import RecordVoiceOverIcon from '@mui/icons-material/RecordVoiceOver';
 import MarkdownViewer from '@client/app/components/Knowledge/MarkdownViewer';
-import { DATA_LAKE } from '@client/app/components/datalake/dataLakeBranding';
-import { HUES, REDUCED_MOTION_OFF, driftFloat, inkFor, sonarPing } from '@client/app/components/datalake/deckChrome';
+import { REDUCED_MOTION_OFF, driftFloat, inkFor, ringPing } from '@client/app/components/datalake/surfaceChrome';
+import { useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
+import type { DataLakeSurfaceCopy, DataLakeSurfaceTheme } from '@client/app/components/datalake/surfaceTokens';
 import { useGetFabFileContent } from '@client/app/hooks/data/fabFiles';
 import type { IFabFileDocument } from '@bike4mind/common';
 
@@ -41,29 +41,40 @@ function humanizeDive(segment: string): string {
   return segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' ');
 }
 
-/* Drifting "bioluminescent" motes for the sonar empty state */
-const MOTES: { left: string; top: string; size: number; hue: 'cyan' | 'violet'; duration: number; delay: number }[] = [
-  { left: '22%', top: '30%', size: 5, hue: 'cyan', duration: 9, delay: 0 },
-  { left: '70%', top: '24%', size: 4, hue: 'violet', duration: 11, delay: 1.2 },
-  { left: '34%', top: '68%', size: 6, hue: 'cyan', duration: 10, delay: 0.6 },
-  { left: '78%', top: '62%', size: 4, hue: 'cyan', duration: 12, delay: 2 },
-  { left: '14%', top: '52%', size: 3, hue: 'violet', duration: 8, delay: 1.6 },
-  { left: '58%', top: '78%', size: 5, hue: 'violet', duration: 13, delay: 0.3 },
-  { left: '48%', top: '18%', size: 3, hue: 'cyan', duration: 9.5, delay: 2.4 },
+/* Drifting motes behind the empty state; `hue` picks which token ink each one takes. */
+const MOTES: {
+  left: string;
+  top: string;
+  size: number;
+  hue: 'accent' | 'secondary';
+  duration: number;
+  delay: number;
+}[] = [
+  { left: '22%', top: '30%', size: 5, hue: 'accent', duration: 9, delay: 0 },
+  { left: '70%', top: '24%', size: 4, hue: 'secondary', duration: 11, delay: 1.2 },
+  { left: '34%', top: '68%', size: 6, hue: 'accent', duration: 10, delay: 0.6 },
+  { left: '78%', top: '62%', size: 4, hue: 'accent', duration: 12, delay: 2 },
+  { left: '14%', top: '52%', size: 3, hue: 'secondary', duration: 8, delay: 1.6 },
+  { left: '58%', top: '78%', size: 5, hue: 'secondary', duration: 13, delay: 0.3 },
+  { left: '48%', top: '18%', size: 3, hue: 'accent', duration: 9.5, delay: 2.4 },
 ];
 
-function SonarEmptyState({
+function EmptyState({
   isDark,
   quickDives,
   onDive,
   onCreate,
+  theme,
+  copy,
 }: {
   isDark: boolean;
   quickDives: QuickDive[];
   onDive?: (path: string[]) => void;
   onCreate?: () => void;
+  theme: DataLakeSurfaceTheme;
+  copy: DataLakeSurfaceCopy;
 }) {
-  const cyan = inkFor(HUES.cyan, isDark);
+  const accent = inkFor(theme.accent, isDark);
   return (
     <Box
       data-testid="datalake-article-empty"
@@ -81,7 +92,7 @@ function SonarEmptyState({
     >
       {/* Drifting motes */}
       {MOTES.map((mote, i) => {
-        const glow = inkFor(HUES[mote.hue], isDark);
+        const glow = inkFor(theme[mote.hue], isDark);
         return (
           <Box
             key={i}
@@ -102,7 +113,7 @@ function SonarEmptyState({
         );
       })}
 
-      {/* Sonar emitter */}
+      {/* Pinging emitter */}
       <Box sx={{ position: 'relative', width: 120, height: 120, flexShrink: 0 }}>
         {[0, 1, 2].map(ring => (
           <Box
@@ -113,8 +124,8 @@ function SonarEmptyState({
               inset: 0,
               borderRadius: '50%',
               border: '1.5px solid',
-              borderColor: alpha(cyan, 0.6),
-              animation: `${sonarPing} 3.6s cubic-bezier(0.2, 0.6, 0.4, 1) ${ring * 1.2}s infinite`,
+              borderColor: alpha(accent, 0.6),
+              animation: `${ringPing} 3.6s cubic-bezier(0.2, 0.6, 0.4, 1) ${ring * 1.2}s infinite`,
               ...REDUCED_MOTION_OFF,
             }}
           />
@@ -128,8 +139,8 @@ function SonarEmptyState({
             width: 14,
             height: 14,
             borderRadius: '50%',
-            background: `radial-gradient(circle at 35% 35%, #FFFFFF, ${cyan})`,
-            boxShadow: `0 0 18px 4px ${alpha(cyan, 0.55)}`,
+            background: `radial-gradient(circle at 35% 35%, #FFFFFF, ${accent})`,
+            boxShadow: `0 0 18px 4px ${alpha(accent, 0.55)}`,
           }}
         />
       </Box>
@@ -139,12 +150,10 @@ function SonarEmptyState({
           level="title-lg"
           sx={{ fontWeight: 700, letterSpacing: '0.02em', color: 'text.secondary', mb: 0.5 }}
         >
-          {onCreate ? 'Nothing on the scope yet' : 'Sonar idle — nothing on the scope'}
+          {onCreate ? copy.zeroTitle : copy.emptyTitle}
         </Typography>
         <Typography level="body-sm" sx={{ color: 'text.tertiary', maxWidth: 380 }}>
-          {onCreate
-            ? `Create your first ${DATA_LAKE.toLowerCase()} to turn your files into searchable knowledge.`
-            : 'Pick a branch from the tree, or drop into one of the richest currents below.'}
+          {onCreate ? copy.zeroHint : copy.emptyHint}
         </Typography>
       </Box>
 
@@ -158,7 +167,7 @@ function SonarEmptyState({
           onClick={onCreate}
           sx={{ zIndex: 1 }}
         >
-          Create {DATA_LAKE.toLowerCase()}
+          {copy.createLabel}
         </Button>
       )}
 
@@ -182,8 +191,8 @@ function SonarEmptyState({
                 transition: 'transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease',
                 '&:hover': {
                   transform: 'translateY(-2px)',
-                  borderColor: cyan,
-                  boxShadow: `0 4px 14px -4px ${alpha(cyan, 0.4)}`,
+                  borderColor: accent,
+                  boxShadow: `0 4px 14px -4px ${alpha(accent, 0.4)}`,
                 },
               }}
             >
@@ -196,19 +205,37 @@ function SonarEmptyState({
   );
 }
 
-export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onDive, onCreate }: DataLakeArticleProps) {
-  const theme = useTheme();
-  const isDark = theme.palette.mode === 'dark';
+export default function DataLakeArticle({
+  file,
+  onAskAbout,
+  quickDives = [],
+  onDive,
+  onCreate,
+}: DataLakeArticleProps) {
+  const muiTheme = useTheme();
+  const isDark = muiTheme.palette.mode === 'dark';
+  const { theme, copy, icons } = useDataLakeSurface();
+  const { secondaryActionLabel, secondaryActionPrompt } = copy;
+  const SecondaryActionIcon = icons.secondaryAction;
   const { data: content, isLoading } = useGetFabFileContent(file);
 
   if (!file) {
-    return <SonarEmptyState isDark={isDark} quickDives={quickDives} onDive={onDive} onCreate={onCreate} />;
+    return (
+      <EmptyState
+        isDark={isDark}
+        quickDives={quickDives}
+        onDive={onDive}
+        onCreate={onCreate}
+        theme={theme}
+        copy={copy}
+      />
+    );
   }
 
   const title = cleanFileName(file.fileName);
   const tags = getMeaningfulTags(file);
-  const cyan = inkFor(HUES.cyan, isDark);
-  const violet = inkFor(HUES.violet, isDark);
+  const accent = inkFor(theme.accent, isDark);
+  const secondary = inkFor(theme.secondary, isDark);
 
   return (
     <Box
@@ -229,7 +256,7 @@ export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onD
           pb: 1.5,
           borderBottom: '1px solid',
           borderColor: 'divider',
-          background: `linear-gradient(180deg, ${alpha(cyan, isDark ? 0.05 : 0.035)}, transparent)`,
+          background: `linear-gradient(180deg, ${alpha(accent, isDark ? 0.05 : 0.035)}, transparent)`,
         }}
       >
         <Box
@@ -238,7 +265,7 @@ export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onD
             height: 3,
             borderRadius: 2,
             mb: 1,
-            background: `linear-gradient(90deg, ${cyan}, ${violet})`,
+            background: `linear-gradient(90deg, ${accent}, ${secondary})`,
           }}
         />
         <Typography level="h4" sx={{ mb: 1 }}>
@@ -254,8 +281,8 @@ export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onD
                 sx={{
                   fontSize: '11px',
                   fontFamily: 'monospace',
-                  color: alpha(cyan, 0.9),
-                  borderColor: alpha(cyan, 0.35),
+                  color: alpha(accent, 0.9),
+                  borderColor: alpha(accent, 0.35),
                 }}
               >
                 {tag}
@@ -291,30 +318,28 @@ export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onD
           variant="soft"
           color="primary"
           startDecorator={<ChatIcon sx={{ fontSize: 16 }} />}
-          onClick={() => onAskAbout(`Tell me about this article: ${title}`)}
+          onClick={() => onAskAbout(copy.askAboutPrompt(title))}
           data-testid="datalake-ask-about"
           sx={{ fontSize: '13px' }}
         >
-          Ask about this article
+          {copy.askAboutLabel}
         </Button>
-        <Button
-          size="sm"
-          variant="outlined"
-          color="neutral"
-          startDecorator={<RecordVoiceOverIcon sx={{ fontSize: 16 }} />}
-          onClick={() =>
-            onAskAbout(
-              `Turn the article "${title}" into a customer-ready talking track: the three points that matter most, one analogy a non-physicist will get, and a closing question that moves the conversation forward.`
-            )
-          }
-          data-testid="datalake-talking-track"
-          sx={{
-            fontSize: '13px',
-            '&:hover': { borderColor: violet, color: violet },
-          }}
-        >
-          Turn into a talking track
-        </Button>
+        {secondaryActionLabel && secondaryActionPrompt && (
+          <Button
+            size="sm"
+            variant="outlined"
+            color="neutral"
+            startDecorator={<SecondaryActionIcon sx={{ fontSize: 16 }} />}
+            onClick={() => onAskAbout(secondaryActionPrompt(title))}
+            data-testid="datalake-secondary-action"
+            sx={{
+              fontSize: '13px',
+              '&:hover': { borderColor: secondary, color: secondary },
+            }}
+          >
+            {secondaryActionLabel}
+          </Button>
+        )}
       </Box>
     </Box>
   );

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -4,16 +4,17 @@ import AddIcon from '@mui/icons-material/Add';
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import TravelExploreIcon from '@mui/icons-material/TravelExplore';
-import { OptiModeBreadcrumb } from '@client/app/components/datalake/OptiModeBreadcrumb';
+import { SurfaceBreadcrumb } from '@client/app/components/datalake/SurfaceBreadcrumb';
 import DataLakeTree from './DataLakeTree';
 import DataLakeArticle from './DataLakeArticle';
-import { TelemetryTicker, deckBackground } from '@client/app/components/datalake/deckChrome';
+import { StatTicker, surfaceBackground } from '@client/app/components/datalake/surfaceChrome';
+import { useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
 import { useGetDataLakeArticles, useGetDataLakeTagCounts } from '@client/app/hooks/data/fabFiles';
 import type { DataLakeBrowseSource } from '@client/app/hooks/data/fabFiles';
 import { buildTagTree, getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import DataLakeIngestPickerModal from '@client/app/components/DataLakeWizard/DataLakeIngestPickerModal';
 import { readDroppedItems } from '@client/app/utils/dropReader';
-import { DATA_LAKE, DATA_LAKES } from '@client/app/components/datalake/dataLakeBranding';
+import { DATA_LAKES } from '@client/app/components/datalake/dataLakeBranding';
 import { toast } from 'sonner';
 import FieldTooltip from '@client/app/components/help/FieldTooltip';
 import { FIELD_TOOLTIPS } from '@client/app/components/help/fieldTooltips';
@@ -24,10 +25,11 @@ interface DataLakeExplorerProps {
   onAskAbout: (prompt: string) => void;
   /** When set (from URL param), auto-select and display this article on mount. */
   articleId?: string | null;
-  /** Which browse backend to read (default 'opti'). The standalone Data Lakes home
-   *  passes 'datalakes' so non-Opti users can browse their own lakes. */
+  /** Which browse backend to read. Only the react-query cache key differs; a branded
+   *  surface passes its own value to keep its cache separate from the standalone home. */
   source?: DataLakeBrowseSource;
-  /** Root breadcrumb crumb label + handler (defaults to the Mission Hub crumb). */
+  /** Overrides the root breadcrumb crumb (which is wired to `onBack`); defaults to
+   *  the surface token, so a branded surface can set it once via the provider. */
   rootLabel?: string;
   /** When provided, renders a "Manage" button that opens the lake management panel. */
   onManage?: () => void;
@@ -46,14 +48,15 @@ export default function DataLakeExplorer({
   onBack,
   onAskAbout,
   articleId,
-  source = 'opti',
-  rootLabel = '⛩ Mission Hub',
+  source = 'datalakes',
+  rootLabel,
   onManage,
   onDiscover,
   onCreate,
 }: DataLakeExplorerProps) {
-  const theme = useTheme();
-  const isDark = theme.palette.mode === 'dark';
+  const muiTheme = useTheme();
+  const isDark = muiTheme.palette.mode === 'dark';
+  const { theme, copy } = useDataLakeSurface();
   const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
   const [userSelectedFile, setUserSelectedFile] = useState<IFabFileDocument | null>(null);
 
@@ -161,7 +164,7 @@ export default function DataLakeExplorer({
 
   return (
     <Box
-      data-testid="opti-datalake-explorer"
+      data-testid="datalake-explorer"
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
@@ -171,12 +174,12 @@ export default function DataLakeExplorer({
         display: 'flex',
         flexDirection: 'column',
         height: '100%',
-        background: deckBackground(isDark),
+        background: surfaceBackground(isDark, theme.accent, theme.secondary),
       }}
     >
       {isDragging && (
         <Box
-          data-testid="opti-datalake-dropzone"
+          data-testid="datalake-dropzone"
           sx={{
             position: 'absolute',
             inset: 12,
@@ -196,15 +199,17 @@ export default function DataLakeExplorer({
         >
           <CloudUploadIcon sx={{ fontSize: 56, color: 'primary.300' }} />
           <Typography level="h4" sx={{ color: 'common.white' }}>
-            Drop to add to a data lake
+            {copy.dropTitle}
           </Typography>
           <Typography level="body-sm" sx={{ color: 'rgba(255,255,255,0.7)' }}>
-            Files or folders — you&apos;ll pick the destination next
+            {copy.dropHint}
           </Typography>
         </Box>
       )}
       <Box sx={{ px: 3, pt: 2, display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-        <OptiModeBreadcrumb segments={[{ label: rootLabel, onClick: onBack }, { label: `${DATA_LAKE} Explorer` }]} />
+        <SurfaceBreadcrumb
+          segments={[{ label: rootLabel ?? copy.rootLabel, onClick: onBack }, { label: copy.explorerTitle }]}
+        />
         {/* mb:2 matches the breadcrumb's own mb so this icon's center lines up with the
             breadcrumb text in the center-aligned header row (breadcrumb carries mb:2). */}
         <FieldTooltip
@@ -224,7 +229,7 @@ export default function DataLakeExplorer({
             onClick={onCreate}
             sx={{ mb: 2 }}
           >
-            Create {DATA_LAKE.toLowerCase()}
+            {copy.createLabel}
           </Button>
         )}
         {onManage && (
@@ -254,14 +259,14 @@ export default function DataLakeExplorer({
           </Button>
         )}
         <Box sx={{ ml: 'auto', mb: 2 }}>
-          <TelemetryTicker
+          <StatTicker
             stats={[
-              { label: 'Articles', value: String(totalArticles || '—') },
-              { label: 'Branches', value: String(branchCount || '—') },
+              { label: copy.statArticlesLabel, value: String(totalArticles || '-') },
+              { label: copy.statBranchesLabel, value: String(branchCount || '-') },
               {
-                label: 'Depth',
+                label: copy.statDepthLabel,
                 value: String(breadcrumb.length),
-                sub: breadcrumb.length === 0 ? 'surface' : breadcrumb.join(' : '),
+                sub: breadcrumb.length === 0 ? copy.depthRootLabel : breadcrumb.join(' : '),
               },
             ]}
             isDark={isDark}

--- a/apps/client/app/components/datalake/DataLakeTree.tsx
+++ b/apps/client/app/components/datalake/DataLakeTree.tsx
@@ -16,46 +16,18 @@ import {
 import { alpha } from '@mui/system';
 import SearchIcon from '@mui/icons-material/Search';
 import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
-import FolderIcon from '@mui/icons-material/Folder';
-import FolderOpenIcon from '@mui/icons-material/FolderOpen';
-import ArticleIcon from '@mui/icons-material/Article';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import type { TagNode } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import { getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
-import { HUES, inkFor } from '@client/app/components/datalake/deckChrome';
-import type { Hue } from '@client/app/components/datalake/deckChrome';
+import { inkFor } from '@client/app/components/datalake/surfaceChrome';
+import type { Hue } from '@client/app/components/datalake/surfaceChrome';
+import { humanizeSegment, useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
+import type { DataLakeSurfaceTheme } from '@client/app/components/datalake/surfaceTokens';
 import type { IFabFileDocument } from '@bike4mind/common';
 
-const PREFIX_LABELS: Record<string, string> = {
-  opti: 'Optimization Knowledge',
-};
-
-/** Hue-code branches by their top-level prefix so depth reads at a glance. */
-const PREFIX_HUES: Record<string, Hue> = {
-  opti: HUES.emerald,
-};
-
-const hueForBranch = (segment: string, breadcrumb: string[]): Hue =>
-  PREFIX_HUES[breadcrumb[0] ?? segment] ?? HUES.amber;
-
-const CATEGORY_LABELS: Record<string, string> = {
-  offering: 'Offering Lines',
-  type: 'Content Type',
-  vertical: 'Customer Verticals',
-  competitor: 'Competitors',
-  stage: 'Sales Stage',
-  content: 'Content Type',
-  family: 'Pattern Families',
-  solver: 'Solvers',
-  level: 'Difficulty Level',
-  industry: 'Industries',
-};
-
-function humanizeSegment(segment: string, depth: number): string {
-  if (depth === 0 && PREFIX_LABELS[segment]) return PREFIX_LABELS[segment];
-  if (depth === 1 && CATEGORY_LABELS[segment]) return CATEGORY_LABELS[segment];
-  return segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' ');
-}
+/** Branch ink comes from the top-level prefix, so a whole subtree reads as one color. */
+const hueForBranch = (segment: string, breadcrumb: string[], theme: DataLakeSurfaceTheme): Hue =>
+  theme.branchHues[breadcrumb[0] ?? segment] ?? theme.branchDefault;
 
 interface DataLakeTreeProps {
   tree: TagNode[];
@@ -79,8 +51,10 @@ export default function DataLakeTree({
   isLoading,
   isError,
 }: DataLakeTreeProps) {
-  const theme = useTheme();
-  const isDark = theme.palette.mode === 'dark';
+  const muiTheme = useTheme();
+  const isDark = muiTheme.palette.mode === 'dark';
+  const { theme, copy, icons, taxonomy } = useDataLakeSurface();
+  const { article: ArticleGlyph, branch: BranchGlyph, leafBranch: LeafBranchGlyph } = icons;
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<'count' | 'alpha'>('count');
 
@@ -159,8 +133,8 @@ export default function DataLakeTree({
           <ArrowBackIcon sx={{ fontSize: 16, color: 'text.tertiary' }} />
           <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
             {breadcrumb.length === 1
-              ? 'All Categories'
-              : humanizeSegment(breadcrumb[breadcrumb.length - 2], breadcrumb.length - 2)}
+              ? copy.allCategoriesLabel
+              : humanizeSegment(breadcrumb[breadcrumb.length - 2], breadcrumb.length - 2, taxonomy)}
           </Typography>
         </ListItemButton>
       )}
@@ -197,10 +171,10 @@ export default function DataLakeTree({
                     sx={{ borderRadius: 'sm', gap: 1 }}
                     data-testid={`datalake-file-${file.id}`}
                   >
-                    <ArticleIcon
+                    <ArticleGlyph
                       sx={{
                         fontSize: 16,
-                        color: selectedFileId === file.id ? inkFor(HUES.cyan, isDark) : 'text.tertiary',
+                        color: selectedFileId === file.id ? inkFor(theme.accent, isDark) : 'text.tertiary',
                         flexShrink: 0,
                       }}
                     />
@@ -229,7 +203,7 @@ export default function DataLakeTree({
               </Box>
             ) : (
               filteredNodes.map(node => {
-                const branchInk = inkFor(hueForBranch(node.segment, breadcrumb), isDark);
+                const branchInk = inkFor(hueForBranch(node.segment, breadcrumb, theme), isDark);
                 return (
                   <ListItem key={node.segment}>
                     <ListItemButton
@@ -242,13 +216,13 @@ export default function DataLakeTree({
                       data-testid={`datalake-node-${node.segment}`}
                     >
                       {node.children.length > 0 ? (
-                        <FolderIcon sx={{ fontSize: 18, color: branchInk }} />
+                        <BranchGlyph sx={{ fontSize: 18, color: branchInk }} />
                       ) : (
-                        <FolderOpenIcon sx={{ fontSize: 18, color: alpha(branchInk, 0.7) }} />
+                        <LeafBranchGlyph sx={{ fontSize: 18, color: alpha(branchInk, 0.7) }} />
                       )}
                       <ListItemContent>
                         <Typography level="body-sm" sx={{ fontWeight: 'md' }}>
-                          {humanizeSegment(node.segment, breadcrumb.length)}
+                          {humanizeSegment(node.segment, breadcrumb.length, taxonomy)}
                         </Typography>
                       </ListItemContent>
                       <Chip

--- a/apps/client/app/components/datalake/OptiModeBreadcrumb.tsx
+++ b/apps/client/app/components/datalake/OptiModeBreadcrumb.tsx
@@ -1,40 +1,6 @@
-import { Breadcrumbs, Link, Typography } from '@mui/joy';
-
 /**
- * Shared breadcrumb used by each /opti mode sub-view AND the open Data Lakes
- * home. Lives in the open datalake namespace (extracted from the private hub)
- * so the open surface does not depend on the premium one.
+ * Historical name for the shared mode breadcrumb, kept so the premium /opti mode
+ * sub-views keep their import path. The implementation is the brand-agnostic
+ * `SurfaceBreadcrumb`; new callers should import that directly.
  */
-
-interface OptiModeBreadcrumbProps {
-  segments: { label: string; onClick?: () => void }[];
-}
-
-export function OptiModeBreadcrumb({ segments }: OptiModeBreadcrumbProps) {
-  return (
-    <Breadcrumbs size="sm" sx={{ px: 0, mb: 2 }}>
-      {segments.map((seg, i) => {
-        const isLast = i === segments.length - 1;
-        if (isLast || !seg.onClick) {
-          return (
-            <Typography key={seg.label} level="body-sm" fontWeight={isLast ? 'lg' : undefined}>
-              {seg.label}
-            </Typography>
-          );
-        }
-        return (
-          <Link
-            key={seg.label}
-            component="button"
-            level="body-sm"
-            color="neutral"
-            onClick={seg.onClick}
-            sx={{ cursor: 'pointer' }}
-          >
-            {seg.label}
-          </Link>
-        );
-      })}
-    </Breadcrumbs>
-  );
-}
+export { SurfaceBreadcrumb as OptiModeBreadcrumb } from '@client/app/components/datalake/SurfaceBreadcrumb';

--- a/apps/client/app/components/datalake/SurfaceBreadcrumb.tsx
+++ b/apps/client/app/components/datalake/SurfaceBreadcrumb.tsx
@@ -1,0 +1,42 @@
+import { Breadcrumbs, Link, Typography } from '@mui/joy';
+
+/**
+ * Brand-agnostic breadcrumb for the Data Lake surface and any sibling mode
+ * sub-view: crumb labels and handlers are entirely caller-supplied.
+ *
+ * `OptiModeBreadcrumb.tsx` re-exports this under its historical name for the
+ * premium mode sub-views.
+ */
+
+interface SurfaceBreadcrumbProps {
+  segments: { label: string; onClick?: () => void }[];
+}
+
+export function SurfaceBreadcrumb({ segments }: SurfaceBreadcrumbProps) {
+  return (
+    <Breadcrumbs size="sm" sx={{ px: 0, mb: 2 }}>
+      {segments.map((seg, i) => {
+        const isLast = i === segments.length - 1;
+        if (isLast || !seg.onClick) {
+          return (
+            <Typography key={seg.label} level="body-sm" fontWeight={isLast ? 'lg' : undefined}>
+              {seg.label}
+            </Typography>
+          );
+        }
+        return (
+          <Link
+            key={seg.label}
+            component="button"
+            level="body-sm"
+            color="neutral"
+            onClick={seg.onClick}
+            sx={{ cursor: 'pointer' }}
+          >
+            {seg.label}
+          </Link>
+        );
+      })}
+    </Breadcrumbs>
+  );
+}

--- a/apps/client/app/components/datalake/deckChrome.tsx
+++ b/apps/client/app/components/datalake/deckChrome.tsx
@@ -1,9 +1,15 @@
 /**
  * deckChrome - shared visual language for the OptiHashi "command deck" surfaces
  *
- * Houses the hue palette, keyframe animations, the animated ion-trap hero
- * field, section headers, and card glow helpers used by SalesCommandDeck,
- * OptiHub, and any future deck-styled mission surface.
+ * Houses the animated ion-trap hero field, section headers, the active-brief card,
+ * and card glow helpers used by SalesCommandDeck, OptiHub, and any future
+ * deck-styled mission surface.
+ *
+ * The brand-agnostic primitives (palette, `inkFor`, generic animations, the stat
+ * ticker) live in `surfaceChrome.tsx` and are re-exported here under their
+ * historical deck names - import, never copy, so the two cannot drift. The open
+ * Data Lake surface reads them from `surfaceChrome`/`surfaceTokens` instead, so
+ * nothing in this file is on its dependency path.
  */
 
 import { Box, Card, Chip, Typography } from '@mui/joy';
@@ -11,25 +17,25 @@ import { alpha, keyframes } from '@mui/system';
 import CenterFocusStrongIcon from '@mui/icons-material/CenterFocusStrong';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import { memo, type ReactNode } from 'react';
+import {
+  SURFACE_HUES as HUES,
+  inkFor,
+  surfaceBackground,
+  REDUCED_MOTION_OFF,
+  type Hue,
+} from '@client/app/components/datalake/surfaceChrome';
 
-/* Palette */
-
-/** Each hue carries a bright variant (dark mode ink) and a deep variant (light mode ink). */
-export const HUES = {
-  cyan: { base: '#5CE1FF', deep: '#0277A8' },
-  violet: { base: '#8B7CFF', deep: '#5B4BD6' },
-  magenta: { base: '#FF6FD8', deep: '#B81E90' },
-  amber: { base: '#FFC857', deep: '#A36F00' },
-  emerald: { base: '#4ADE80', deep: '#15803D' },
-  blue: { base: '#6FA8FF', deep: '#2563EB' },
-  red: { base: '#FF7A6B', deep: '#C2271A' },
-  slate: { base: '#9FB3C8', deep: '#52677D' },
-} as const;
-
-export type Hue = (typeof HUES)[keyof typeof HUES];
-
-/** Resolve a hue to readable ink for the current color scheme. */
-export const inkFor = (hue: Hue, isDark: boolean) => (isDark ? hue.base : hue.deep);
+export {
+  SURFACE_HUES as HUES,
+  inkFor,
+  REDUCED_MOTION_OFF,
+  cursorBlink,
+  driftFloat,
+  /** Historical name for the generic expanding-ring animation. */
+  ringPing as sonarPing,
+  StatTicker as TelemetryTicker,
+} from '@client/app/components/datalake/surfaceChrome';
+export type { Hue, TickerStat } from '@client/app/components/datalake/surfaceChrome';
 
 /** Map a Q/Work job status to a telemetry dot color + pulse flag. */
 export function statusDot(status: string | undefined, isDark: boolean): { color: string; pulse: boolean } {
@@ -86,42 +92,16 @@ export const arcFlow = keyframes`
   to { stroke-dashoffset: 0; }
 `;
 
-export const cursorBlink = keyframes`
-  0%, 49% { opacity: 1; }
-  50%, 100% { opacity: 0.15; }
-`;
-
 /** Deal-in flip for encounter cards - they land on the table like dealt cards. */
 export const cardDeal = keyframes`
   0% { opacity: 0; transform: translateY(20px) rotate(-1.5deg) scale(0.97); }
   100% { opacity: 1; transform: translateY(0) rotate(0deg) scale(1); }
 `;
 
-export const sonarPing = keyframes`
-  0% { transform: scale(0.3); opacity: 0.7; }
-  100% { transform: scale(1); opacity: 0; }
-`;
-
-export const driftFloat = keyframes`
-  0%, 100% { transform: translate(0, 0); }
-  25% { transform: translate(6px, -10px); }
-  50% { transform: translate(-4px, -16px); }
-  75% { transform: translate(-8px, -6px); }
-`;
-
-export const REDUCED_MOTION_OFF = {
-  '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
-} as const;
-
 /* Page background */
 
-/** Ambient radial washes behind a deck surface. */
-export const deckBackground = (isDark: boolean) =>
-  isDark
-    ? `radial-gradient(ellipse 80% 45% at 50% -8%, ${alpha(HUES.cyan.base, 0.1)}, transparent 65%),
-       radial-gradient(ellipse 60% 40% at 88% 108%, ${alpha(HUES.violet.base, 0.07)}, transparent 60%)`
-    : `radial-gradient(ellipse 80% 45% at 50% -8%, ${alpha(HUES.cyan.deep, 0.07)}, transparent 65%),
-       radial-gradient(ellipse 60% 40% at 88% 108%, ${alpha(HUES.violet.deep, 0.05)}, transparent 60%)`;
+/** Ambient radial washes behind a deck surface (the deck's cyan/violet tint). */
+export const deckBackground = (isDark: boolean) => surfaceBackground(isDark, HUES.cyan, HUES.violet);
 
 /* Card glow */
 
@@ -262,62 +242,6 @@ export function DeckSectionHeader({ label, hint }: { label: string; hint?: strin
           {hint}
         </Typography>
       )}
-    </Box>
-  );
-}
-
-/* Telemetry ticker */
-
-export interface TickerStat {
-  label: string;
-  value: string;
-  sub?: string;
-}
-
-export function TelemetryTicker({ stats, isDark }: { stats: TickerStat[]; isDark: boolean }) {
-  return (
-    <Box
-      sx={{
-        display: 'flex',
-        justifyContent: 'center',
-        flexWrap: 'wrap',
-        columnGap: 3,
-        rowGap: 0.5,
-      }}
-    >
-      {stats.map(stat => (
-        <Box key={stat.label} sx={{ display: 'flex', alignItems: 'baseline', gap: 0.6 }}>
-          <Box
-            sx={{
-              width: 5,
-              height: 5,
-              borderRadius: '50%',
-              bgcolor: inkFor(HUES.emerald, isDark),
-              animation: `${cursorBlink} 2.4s steps(1) infinite`,
-              ...REDUCED_MOTION_OFF,
-            }}
-          />
-          <Typography
-            level="body-xs"
-            sx={{
-              fontFamily: 'monospace',
-              letterSpacing: '0.08em',
-              textTransform: 'uppercase',
-              color: 'text.tertiary',
-            }}
-          >
-            {stat.label}
-          </Typography>
-          <Typography level="body-xs" sx={{ fontFamily: 'monospace', fontWeight: 700, color: 'text.primary' }}>
-            {stat.value}
-          </Typography>
-          {stat.sub && (
-            <Typography level="body-xs" sx={{ fontFamily: 'monospace', color: 'text.tertiary' }}>
-              {stat.sub}
-            </Typography>
-          )}
-        </Box>
-      ))}
     </Box>
   );
 }

--- a/apps/client/app/components/datalake/surfaceChrome.tsx
+++ b/apps/client/app/components/datalake/surfaceChrome.tsx
@@ -1,0 +1,130 @@
+/**
+ * surfaceChrome - brand-agnostic visual primitives for the standalone Data Lake
+ * surface (tree, article, explorer header).
+ *
+ * Nothing here may carry product flavor: hues are named after colors rather than
+ * concepts and every string is caller-supplied. Branded surfaces layer their own
+ * look on top by overriding the `theme` half of the surface tokens - see
+ * `DataLakeSurfaceProvider` in `surfaceTokens.tsx`.
+ *
+ * `deckChrome.tsx` re-exports these primitives under its historical names so the
+ * premium deck surfaces keep their import paths - it imports from here rather than
+ * duplicating, so the palette and animations cannot drift between the two.
+ */
+
+import { Box, Typography } from '@mui/joy';
+import { alpha, keyframes } from '@mui/system';
+
+/** A single ink, with a bright variant for dark mode and a deep variant for light mode. */
+export interface Hue {
+  base: string;
+  deep: string;
+}
+
+export const SURFACE_HUES = {
+  cyan: { base: '#5CE1FF', deep: '#0277A8' },
+  violet: { base: '#8B7CFF', deep: '#5B4BD6' },
+  magenta: { base: '#FF6FD8', deep: '#B81E90' },
+  amber: { base: '#FFC857', deep: '#A36F00' },
+  emerald: { base: '#4ADE80', deep: '#15803D' },
+  blue: { base: '#6FA8FF', deep: '#2563EB' },
+  red: { base: '#FF7A6B', deep: '#C2271A' },
+  slate: { base: '#9FB3C8', deep: '#52677D' },
+} as const satisfies Record<string, Hue>;
+
+/** Resolve a hue to readable ink for the current color scheme. */
+export const inkFor = (hue: Hue, isDark: boolean) => (isDark ? hue.base : hue.deep);
+
+export const REDUCED_MOTION_OFF = {
+  '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+} as const;
+
+/** Expanding ring, used by the article empty state's emitter. */
+export const ringPing = keyframes`
+  0% { transform: scale(0.3); opacity: 0.7; }
+  100% { transform: scale(1); opacity: 0; }
+`;
+
+/** Slow ambient wander for decorative background motes. */
+export const driftFloat = keyframes`
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(6px, -10px); }
+  50% { transform: translate(-4px, -16px); }
+  75% { transform: translate(-8px, -6px); }
+`;
+
+export const cursorBlink = keyframes`
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0.15; }
+`;
+
+/** Ambient radial washes behind a surface, tinted by the caller's two lead hues. */
+export const surfaceBackground = (isDark: boolean, accent: Hue, secondary: Hue) =>
+  isDark
+    ? `radial-gradient(ellipse 80% 45% at 50% -8%, ${alpha(accent.base, 0.1)}, transparent 65%),
+       radial-gradient(ellipse 60% 40% at 88% 108%, ${alpha(secondary.base, 0.07)}, transparent 60%)`
+    : `radial-gradient(ellipse 80% 45% at 50% -8%, ${alpha(accent.deep, 0.07)}, transparent 65%),
+       radial-gradient(ellipse 60% 40% at 88% 108%, ${alpha(secondary.deep, 0.05)}, transparent 60%)`;
+
+export interface TickerStat {
+  label: string;
+  value: string;
+  sub?: string;
+}
+
+/** Compact monospace stat row for a surface header. */
+export function StatTicker({
+  stats,
+  isDark,
+  dotHue = SURFACE_HUES.emerald,
+}: {
+  stats: TickerStat[];
+  isDark: boolean;
+  dotHue?: Hue;
+}) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        columnGap: 3,
+        rowGap: 0.5,
+      }}
+    >
+      {stats.map(stat => (
+        <Box key={stat.label} sx={{ display: 'flex', alignItems: 'baseline', gap: 0.6 }}>
+          <Box
+            sx={{
+              width: 5,
+              height: 5,
+              borderRadius: '50%',
+              bgcolor: inkFor(dotHue, isDark),
+              animation: `${cursorBlink} 2.4s steps(1) infinite`,
+              ...REDUCED_MOTION_OFF,
+            }}
+          />
+          <Typography
+            level="body-xs"
+            sx={{
+              fontFamily: 'monospace',
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: 'text.tertiary',
+            }}
+          >
+            {stat.label}
+          </Typography>
+          <Typography level="body-xs" sx={{ fontFamily: 'monospace', fontWeight: 700, color: 'text.primary' }}>
+            {stat.value}
+          </Typography>
+          {stat.sub && (
+            <Typography level="body-xs" sx={{ fontFamily: 'monospace', color: 'text.tertiary' }}>
+              {stat.sub}
+            </Typography>
+          )}
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/apps/client/app/components/datalake/surfaceTokens.test.tsx
+++ b/apps/client/app/components/datalake/surfaceTokens.test.tsx
@@ -1,0 +1,144 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import DataLakeArticle from './DataLakeArticle';
+import DataLakeTree from './DataLakeTree';
+import { SURFACE_HUES } from './surfaceChrome';
+import { DataLakeSurfaceProvider } from './surfaceTokens';
+import type { DataLakeSurfaceOverrides } from './surfaceTokens';
+import type { IFabFileDocument } from '@bike4mind/common';
+
+vi.mock('@client/app/hooks/data/fabFiles', () => ({
+  useGetFabFileContent: () => ({ data: undefined, isLoading: false }),
+}));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children, tokens }: { children: ReactNode; tokens?: DataLakeSurfaceOverrides }) => (
+  <CssVarsProvider theme={appTheme}>
+    {tokens ? <DataLakeSurfaceProvider tokens={tokens}>{children}</DataLakeSurfaceProvider> : children}
+  </CssVarsProvider>
+);
+
+const treeProps = {
+  tree: [
+    { segment: 'opti', fullPath: 'opti', fileCount: 3, children: [] },
+    { segment: 'shared-notes', fullPath: 'shared-notes', fileCount: 1, children: [] },
+  ],
+  articles: [],
+  breadcrumb: [],
+  onNavigate: vi.fn(),
+  selectedFileId: null,
+  onSelectFile: vi.fn(),
+  isLoading: false,
+};
+
+const FILE = { id: 'f1', fileName: 'Ion traps.md', tags: [] } as unknown as IFabFileDocument;
+
+const StubLeafIcon = () => <span data-testid="stub-leaf-icon" />;
+
+/** Product-flavored wording the shared surface must never render on its own. */
+const BRANDED = /sonar|on the scope|currents|talking track|mission hub|optimization knowledge/i;
+
+describe('Data Lake surface - brand-agnostic defaults (#842)', () => {
+  it('renders neutral empty-state copy with no product flavor', () => {
+    render(
+      <Wrapper>
+        <DataLakeArticle file={null} onAskAbout={vi.fn()} />
+      </Wrapper>
+    );
+
+    const empty = screen.getByTestId('datalake-article-empty');
+    expect(empty).toHaveTextContent('Nothing selected yet');
+    expect(empty.textContent ?? '').not.toMatch(BRANDED);
+  });
+
+  it('sends a neutral prompt from the article actions', () => {
+    const onAskAbout = vi.fn();
+    render(
+      <Wrapper>
+        <DataLakeArticle file={FILE} onAskAbout={onAskAbout} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('datalake-secondary-action'));
+    expect(onAskAbout).toHaveBeenCalledWith(expect.stringContaining('Summarize the key points of "Ion traps"'));
+    expect(onAskAbout.mock.calls[0][0]).not.toMatch(BRANDED);
+  });
+
+  it('labels tree branches from the raw segment when no taxonomy is injected', () => {
+    render(
+      <Wrapper>
+        <DataLakeTree {...treeProps} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('datalake-node-opti')).toHaveTextContent('Opti');
+    expect(screen.getByTestId('datalake-node-opti').textContent ?? '').not.toMatch(BRANDED);
+    // De-slugged in place, not looked up in a product taxonomy.
+    expect(screen.getByTestId('datalake-node-shared-notes')).toHaveTextContent('Shared notes');
+  });
+});
+
+describe('Data Lake surface - injected tokens (#842)', () => {
+  it('takes empty-state copy from the provider', () => {
+    render(
+      <Wrapper tokens={{ copy: { emptyTitle: 'Sonar idle', emptyHint: 'Drop into the richest currents.' } }}>
+        <DataLakeArticle file={null} onAskAbout={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('datalake-article-empty')).toHaveTextContent('Sonar idle');
+  });
+
+  it('takes the article secondary action label and prompt from the provider', () => {
+    const onAskAbout = vi.fn();
+    render(
+      <Wrapper
+        tokens={{
+          copy: {
+            secondaryActionLabel: 'Turn into a talking track',
+            secondaryActionPrompt: title => `Talking track for ${title}`,
+          },
+        }}
+      >
+        <DataLakeArticle file={FILE} onAskAbout={onAskAbout} />
+      </Wrapper>
+    );
+
+    const action = screen.getByTestId('datalake-secondary-action');
+    expect(action).toHaveTextContent('Turn into a talking track');
+    fireEvent.click(action);
+    expect(onAskAbout).toHaveBeenCalledWith('Talking track for Ion traps');
+  });
+
+  it('drops the secondary action when its copy is cleared', () => {
+    render(
+      <Wrapper tokens={{ copy: { secondaryActionLabel: undefined, secondaryActionPrompt: undefined } }}>
+        <DataLakeArticle file={FILE} onAskAbout={vi.fn()} />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('datalake-ask-about')).toBeInTheDocument();
+    expect(screen.queryByTestId('datalake-secondary-action')).not.toBeInTheDocument();
+  });
+
+  it('takes tree labels, branch hues, and icons from the provider', () => {
+    render(
+      <Wrapper
+        tokens={{
+          taxonomy: { prefixLabels: { opti: 'Optimization Knowledge' } },
+          theme: { branchHues: { opti: SURFACE_HUES.emerald } },
+          icons: { leafBranch: StubLeafIcon },
+        }}
+      >
+        <DataLakeTree {...treeProps} />
+      </Wrapper>
+    );
+
+    const node = screen.getByTestId('datalake-node-opti');
+    expect(node).toHaveTextContent('Optimization Knowledge');
+    expect(node.querySelector('[data-testid="stub-leaf-icon"]')).not.toBeNull();
+  });
+});

--- a/apps/client/app/components/datalake/surfaceTokens.tsx
+++ b/apps/client/app/components/datalake/surfaceTokens.tsx
@@ -1,0 +1,165 @@
+/**
+ * surfaceTokens - the injection seam that keeps the standalone Data Lake surface
+ * (`/data-lakes`, rendered by `DataLakeExplorer`) brand-agnostic.
+ *
+ * Theme (hues), copy (labels, empty state, chat prompts), icons, and the tag
+ * taxonomy labels all live here with NEUTRAL defaults. A branded surface wraps the
+ * explorer in `DataLakeSurfaceProvider` and overrides only what it needs, so no
+ * product-specific string, hue, or glyph ever has to be edited into the shared
+ * components. Anything added to the shared components that reads as product flavor
+ * belongs in this file as a token instead.
+ */
+
+import ArticleIcon from '@mui/icons-material/Article';
+import FolderIcon from '@mui/icons-material/Folder';
+import FolderOpenIcon from '@mui/icons-material/FolderOpen';
+import SummarizeOutlinedIcon from '@mui/icons-material/SummarizeOutlined';
+import { createContext, useContext, useMemo, type ComponentType, type ReactNode } from 'react';
+import { SURFACE_HUES, type Hue } from '@client/app/components/datalake/surfaceChrome';
+import { DATA_LAKE, DATA_LAKES } from '@client/app/components/datalake/dataLakeBranding';
+
+/** Any MUI icon component - only `sx` is passed by the surface. */
+type SurfaceIcon = ComponentType<{ sx?: Record<string, unknown> }>;
+
+export interface DataLakeSurfaceTheme {
+  /** Lead ink: selection, header rule, empty-state emitter, hover glow. */
+  accent: Hue;
+  /** Gradient partner for the accent and hover ink for the secondary action. */
+  secondary: Hue;
+  /** Ink for a branch whose top-level prefix has no entry in `branchHues`. */
+  branchDefault: Hue;
+  /** Top-level tag prefix -> ink, so depth reads at a glance. */
+  branchHues: Record<string, Hue>;
+}
+
+export interface DataLakeSurfaceCopy {
+  /** Trailing breadcrumb crumb for the explorer itself. */
+  explorerTitle: string;
+  /** Leading breadcrumb crumb, wired to the explorer's `onBack`. */
+  rootLabel: string;
+  dropTitle: string;
+  dropHint: string;
+  emptyTitle: string;
+  emptyHint: string;
+  /** Zero-state variants, shown instead of `empty*` when the create-first CTA is offered. */
+  zeroTitle: string;
+  zeroHint: string;
+  createLabel: string;
+  askAboutLabel: string;
+  askAboutPrompt: (title: string) => string;
+  /** Optional second action under an article; omit to render only "ask about". */
+  secondaryActionLabel?: string;
+  secondaryActionPrompt?: (title: string) => string;
+  statArticlesLabel: string;
+  statBranchesLabel: string;
+  statDepthLabel: string;
+  /** Shown as the depth stat's sub-value while at the root of the tree. */
+  depthRootLabel: string;
+  /** Back-crumb label shown when stepping out of a first-level branch. */
+  allCategoriesLabel: string;
+}
+
+export interface DataLakeSurfaceIcons {
+  /** A single document in the tree's leaf list. */
+  article: SurfaceIcon;
+  /** A branch with children. */
+  branch: SurfaceIcon;
+  /** A branch whose children are documents. */
+  leafBranch: SurfaceIcon;
+  /** Decorator for the article's secondary action button. */
+  secondaryAction: SurfaceIcon;
+}
+
+/** Human labels for raw tag segments, keyed by segment. Depth 0 = prefix, depth 1 = category. */
+export interface DataLakeSurfaceTaxonomy {
+  prefixLabels: Record<string, string>;
+  categoryLabels: Record<string, string>;
+}
+
+export interface DataLakeSurfaceTokens {
+  theme: DataLakeSurfaceTheme;
+  copy: DataLakeSurfaceCopy;
+  icons: DataLakeSurfaceIcons;
+  taxonomy: DataLakeSurfaceTaxonomy;
+}
+
+export interface DataLakeSurfaceOverrides {
+  theme?: Partial<DataLakeSurfaceTheme>;
+  copy?: Partial<DataLakeSurfaceCopy>;
+  icons?: Partial<DataLakeSurfaceIcons>;
+  taxonomy?: Partial<DataLakeSurfaceTaxonomy>;
+}
+
+export const DEFAULT_DATA_LAKE_SURFACE_TOKENS: DataLakeSurfaceTokens = {
+  theme: {
+    accent: SURFACE_HUES.blue,
+    secondary: SURFACE_HUES.violet,
+    branchDefault: SURFACE_HUES.slate,
+    branchHues: {},
+  },
+  copy: {
+    explorerTitle: `${DATA_LAKE} Explorer`,
+    rootLabel: DATA_LAKES,
+    dropTitle: `Drop to add to a ${DATA_LAKE.toLowerCase()}`,
+    dropHint: "Files or folders - you'll pick the destination next",
+    emptyTitle: 'Nothing selected yet',
+    emptyHint: 'Pick a branch from the tree, or jump into one of the largest categories below.',
+    zeroTitle: 'Nothing here yet',
+    zeroHint: `Create your first ${DATA_LAKE.toLowerCase()} to turn your files into searchable knowledge.`,
+    createLabel: `Create ${DATA_LAKE.toLowerCase()}`,
+    askAboutLabel: 'Ask about this document',
+    askAboutPrompt: title => `Tell me about this document: ${title}`,
+    secondaryActionLabel: 'Summarize the key points',
+    secondaryActionPrompt: title => `Summarize the key points of "${title}" in a few short bullets.`,
+    statArticlesLabel: 'Documents',
+    statBranchesLabel: 'Branches',
+    statDepthLabel: 'Depth',
+    depthRootLabel: 'top',
+    allCategoriesLabel: 'All Categories',
+  },
+  icons: {
+    article: ArticleIcon,
+    branch: FolderIcon,
+    leafBranch: FolderOpenIcon,
+    secondaryAction: SummarizeOutlinedIcon,
+  },
+  taxonomy: {
+    prefixLabels: {},
+    categoryLabels: {},
+  },
+};
+
+const DataLakeSurfaceContext = createContext<DataLakeSurfaceTokens>(DEFAULT_DATA_LAKE_SURFACE_TOKENS);
+
+/**
+ * Overrides are merged one level deep (per section), so a caller can replace a
+ * single string or hue without restating the rest of the section.
+ */
+export function DataLakeSurfaceProvider({
+  tokens,
+  children,
+}: {
+  tokens: DataLakeSurfaceOverrides;
+  children: ReactNode;
+}) {
+  const merged = useMemo<DataLakeSurfaceTokens>(
+    () => ({
+      theme: { ...DEFAULT_DATA_LAKE_SURFACE_TOKENS.theme, ...tokens.theme },
+      copy: { ...DEFAULT_DATA_LAKE_SURFACE_TOKENS.copy, ...tokens.copy },
+      icons: { ...DEFAULT_DATA_LAKE_SURFACE_TOKENS.icons, ...tokens.icons },
+      taxonomy: { ...DEFAULT_DATA_LAKE_SURFACE_TOKENS.taxonomy, ...tokens.taxonomy },
+    }),
+    [tokens]
+  );
+  return <DataLakeSurfaceContext.Provider value={merged}>{children}</DataLakeSurfaceContext.Provider>;
+}
+
+/** Tokens for the current surface; the neutral defaults when no provider is mounted. */
+export const useDataLakeSurface = () => useContext(DataLakeSurfaceContext);
+
+/** Human label for a tag segment at `depth`, falling back to a de-slugged segment. */
+export function humanizeSegment(segment: string, depth: number, taxonomy: DataLakeSurfaceTaxonomy): string {
+  if (depth === 0 && taxonomy.prefixLabels[segment]) return taxonomy.prefixLabels[segment];
+  if (depth === 1 && taxonomy.categoryLabels[segment]) return taxonomy.categoryLabels[segment];
+  return segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' ');
+}

--- a/apps/client/app/routes/data-lakes.tsx
+++ b/apps/client/app/routes/data-lakes.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import DataLakeExplorer from '@client/app/components/datalake/DataLakeExplorer';
-import { DATA_LAKES } from '@client/app/components/datalake/dataLakeBranding';
 import { useDataLakeWizardStore } from '@client/app/stores/useDataLakeWizardStore';
 import { useChatInput } from '@client/app/hooks/useChatInput';
 
@@ -35,7 +34,6 @@ export default function DataLakesHome() {
   return (
     <DataLakeExplorer
       source="datalakes"
-      rootLabel={DATA_LAKES}
       articleId={article ?? null}
       onBack={() => navigate({ to: '/new' })}
       onAskAbout={handleAskAbout}

--- a/apps/client/e2e/pages/DataLakePage.ts
+++ b/apps/client/e2e/pages/DataLakePage.ts
@@ -83,7 +83,7 @@ export class DataLakePage extends BasePage {
     // is the real readiness gate, so we don't need to block navigation on full 'load'.
     await this.page.goto('/data-lakes', { waitUntil: 'domcontentloaded' });
     await this.dismissModals();
-    await expect(this.page.getByTestId('opti-datalake-explorer')).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+    await expect(this.page.getByTestId('datalake-explorer')).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
   }
 
   /** From the explorer, open the management panel (list of lakes + lifecycle). */


### PR DESCRIPTION
# Pull Request

Closes #842.

## Description

The generic `/data-lakes` surface carried product-flavored theme, copy, and icons baked
straight into the shared components: the OptiHashi `deckChrome` palette/animations, an
`OptiModeBreadcrumb`, a `Mission Hub` root crumb, an `opti` tag taxonomy, and empty-state /
action copy ("Sonar idle - nothing on the scope", "the richest currents", "turn into a
customer-ready talking track ... a non-physicist"). That blocked reusing the surface for
another blueprint without editing shared files.

Theme, copy, icons, and the tag-taxonomy labels are now injectable tokens with neutral
defaults. A branded surface wraps the explorer in `DataLakeSurfaceProvider` and overrides
only what it needs; nothing product-specific renders by default.

## Changes

New, in `apps/client/app/components/datalake/`:

- `surfaceChrome.tsx` - brand-agnostic primitives: `SURFACE_HUES`, `inkFor`,
  `REDUCED_MOTION_OFF`, generic animations (`ringPing`, `driftFloat`, `cursorBlink`),
  `surfaceBackground(isDark, accent, secondary)`, `StatTicker`.
- `surfaceTokens.tsx` - `DataLakeSurfaceTokens` (theme / copy / icons / taxonomy),
  neutral `DEFAULT_DATA_LAKE_SURFACE_TOKENS`, `DataLakeSurfaceProvider` (per-section
  shallow merge), `useDataLakeSurface`, taxonomy-aware `humanizeSegment`.
- `SurfaceBreadcrumb.tsx` - the breadcrumb, de-branded.
- `surfaceTokens.test.tsx` - asserts the defaults render no product wording, and that
  injected copy, prompts, branch hues, icons, and taxonomy labels all take effect
  (including dropping the article's secondary action when its copy is cleared).

De-branded:

- `DataLakeArticle` - empty-state copy, both action labels, and both chat prompts come
  from tokens; the secondary action is optional and its icon is a token. Hues are
  `theme.accent` / `theme.secondary`. Testid `datalake-talking-track` ->
  `datalake-secondary-action`.
- `DataLakeTree` - the `opti` prefix label, the sales category-label map, and the
  hardcoded prefix hues moved out to tokens; folder/article icons injectable.
- `DataLakeExplorer` - breadcrumb, root crumb, drop-zone copy, and stat labels come from
  tokens. `source` default flipped `'opti'` -> `'datalakes'` (react-query cache key only;
  both read `/api/data-lakes`). Testids `opti-datalake-explorer` / `opti-datalake-dropzone`
  -> `datalake-explorer` / `datalake-dropzone`, with the e2e page object updated.
- `deckChrome.tsx` keeps its deck-specific pieces and now imports the shared primitives
  from `surfaceChrome`, re-exporting them under their historical names (`HUES`,
  `sonarPing`, `TelemetryTicker`, ...) so existing callers keep their import paths and the
  palette cannot drift. `OptiModeBreadcrumb.tsx` is a re-export of `SurfaceBreadcrumb`.
  Nothing on the open surface's dependency path touches `deckChrome` anymore.

## Guide for Testers

1. Go to `app.staging.bike4mind.com/data-lakes` (needs the `EnableDataLakes` admin flag).
   Expected: the explorer loads. Breadcrumb reads `Data Lakes > Data Lake Explorer` - no
   `Mission Hub` crumb and no torii glyph.
2. Look at the header stat row on the right. Expected: `DOCUMENTS`, `BRANCHES`, `DEPTH`,
   with `DEPTH 0 top` at the root (previously `ARTICLES / BRANCHES / DEPTH 0 surface`).
3. Without selecting anything, read the center pane. Expected: `Nothing selected yet` and
   `Pick a branch from the tree, or jump into one of the largest categories below.` No
   "Sonar idle", no "richest currents". The ring/mote animation still plays.
4. Click one of the category chips in that empty state. Expected: the tree navigates into
   that category.
5. Click a branch in the left tree, then a document at the leaf. Expected: the article
   renders with its title, tags, and content.
6. Look at the buttons under the article. Expected: `Ask about this document` and
   `Summarize the key points`. There is no "Turn into a talking track" button.
7. Click `Summarize the key points`. Expected: you land in a new chat with the composer
   prefilled `Summarize the key points of "<document title>" in a few short bullets.`
8. Go back to `/data-lakes` and click `Ask about this document` on any article. Expected:
   composer prefilled `Tell me about this document: <title>`.
9. Drag a file from your desktop over the explorer (do not drop yet). Expected: the dashed
   overlay reads `Drop to add to a data lake` / `Files or folders - you'll pick the
   destination next`.
10. Drop it. Expected: the destination-lake picker opens as before.
11. Click `Manage lakes`, then `Discover`. Expected: both panels open as before.
12. Toggle light/dark mode on the explorer. Expected: text and branch inks stay readable in
    both; the accent is now blue/violet rather than cyan/violet.

### Regression Checks

13. In the left tree, type in `Filter...` and toggle the A-Z/count sort button. Expected:
    filtering and sorting behave as before.
14. Navigate two levels deep, then use the back row at the top of the tree. Expected: one
    level up each click; at depth 1 the row reads `All Categories`.
15. Open a deep link `/data-lakes?article=<id>`. Expected: that article is selected on load.
16. Hover the info icon next to the breadcrumb. Expected: the RAG explanation tooltip still
    appears.

### What NOT to test

- No API, schema, or ingestion-pipeline behavior changed - this is presentation-layer only.
- The premium `/opti` deck surfaces are unchanged by this PR but have not yet adopted the
  provider (see below); do not treat their current Data Lake styling as the target state.

## Additional Information

Follow-up needed in the premium overlay repo (private, not touchable from here): the `/opti`
deck previously got its Data Lake labels and hues from these shared files, so to keep its
look it must wrap `DataLakeExplorer` in `DataLakeSurfaceProvider` with its own tokens (cyan
accent, emerald `opti` branch hue, its prefix/category labels, its root crumb, its
talking-track action). Overlay e2e specs referencing `opti-datalake-explorer` /
`opti-datalake-dropzone` need the testid rename as well. That adoption is epic #853 work,
not this PR.

Verified locally: `@bike4mind/client` 709 test files / 7169 tests pass,
`@bike4mind/database` 81 files / 847 tests pass, `pnpm turbo:typecheck` 40/40,
`pnpm lint:check` clean.

## Developer Notes

- **New extension point**: `DataLakeSurfaceProvider` / `useDataLakeSurface`. Any surface
  embedding `DataLakeExplorer` can restyle and reword it without touching shared code.
  Overrides merge one level deep per section, so a caller can replace a single string or
  hue. Rule of thumb for future work: anything that reads as product flavor belongs in
  `surfaceTokens.tsx` as a token, not in the components.
- **Reusable pattern**: `surfaceChrome.tsx` owns the primitives and `deckChrome.tsx`
  re-exports them under its historical names - a way to de-brand a shared module without
  breaking out-of-tree callers or forking the palette.
- **Icon tokens** are plain `ComponentType<{ sx? }>` values, so a blueprint can pass any MUI
  icon (or its own SVG component) for the article, branch, leaf-branch, and secondary-action
  glyphs.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (N/A)
- [ ] I have made corresponding changes to the documentation (N/A)
