### PR TITLE
fix(gitignore): ignore the b4m-bob premium overlay snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,14 @@ packages/premium/tavern/
 # overlay code.
 packages/premium/optihashi/
 
+# Premium overlay snapshot for b4m-bob, hydrated at the pinned ref by the deploy
+# pipeline before pnpm install. Last of the six to be listed here: bootstrap-premium.sh
+# clones every overlay in the deployer's overlay-pins.json, so without this entry a
+# local `pnpm bootstrap:premium` against this PUBLIC checkout leaves private overlay
+# source untracked, one bulk `git add` away from publishing it. Same near-miss the
+# optihashi entry above records.
+packages/premium/bob/
+
 # Docusaurus
 docs-site/build/
 docs-site/.docusaurus/


### PR DESCRIPTION
One line. All six premium overlays are hydrated into `packages/premium/<name>` by the deployer's `bootstrap-premium.sh`, which is driven by every key in `overlay-pins.json`. Five of them are ignored here; `bob` was not.

```
packages/premium/overwatch/     ignored
packages/premium/libreoncology/ ignored
packages/premium/pi/            ignored
packages/premium/tavern/        ignored
packages/premium/optihashi/     ignored
packages/premium/bob/           MISSING  <- this PR
```

So a local `pnpm bootstrap:premium` against a checkout of this **public** repo leaves private `b4m-bob` source sitting untracked, one bulk `git add` away from publishing premium overlay code into the open-core repo.

That is not hypothetical . it is the same near-miss the `optihashi` entry directly above this one was added to record, and its comment says so. `bob` is the last of the six still exposed.

**Deploys are unaffected either way**: the deploy job clears and re-hydrates `packages/premium` itself before install, so nothing about CI or a deploy changes. This closes only the local-development hole.

Held until Bike4Mind/bike4mind#949 landed, since that PR rewrote this exact region of the file.
