### PR TITLE
fix(husky): load the repo gitleaks config in the pre-commit hook

### DIFF
--- a/.github/workflows/gitleaks-config-guard.yml
+++ b/.github/workflows/gitleaks-config-guard.yml
@@ -1,0 +1,54 @@
+name: Gitleaks Config Guard
+
+# Asserts that .gitleaks.toml actually detects, rather than merely loading.
+#
+# The config previously ended in a `[useBuiltinRules]` table, which is not gitleaks
+# config syntax. It parsed as an empty table, so every builtin rule was disabled and
+# both CI and the pre-commit hook scanned with only the domain rules below it.
+# Nothing failed and nothing caught an AWS key.
+#
+# The Secrets Security (Scan) workflow cannot catch that: it is workflow_dispatch
+# only, and it runs gitleaks with --exit-code=0 so it reports to a dashboard rather
+# than failing. This is the always-on gate. See
+# scripts/gitleaks-config-selftest.sh for what is asserted.
+#
+# gitleaks is pinned to the same version secrets-scan.yml installs. The two MUST
+# stay in sync: config forms that load on one version are silently ignored by
+# another, so a guard on a different version proves nothing about the real scan.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.gitleaks.toml'
+      - '.gitleaksignore'
+      - '.husky/gitleaks-pre-commit.sh'
+      - 'scripts/gitleaks-config-selftest.sh'
+      - '.github/workflows/gitleaks-config-guard.yml'
+      - '.github/workflows/secrets-scan.yml'
+  # Also run on the merge queue so the check reports there if it later becomes a
+  # required branch-protection check (see semantic-pr-title.yml for why a required
+  # check must run on merge_group).
+  merge_group:
+    branches: [main]
+
+jobs:
+  check:
+    if: github.repository == (vars.CANONICAL_REPO || 'MillionOnMars/lumina5')
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install gitleaks CLI
+        env:
+          # Keep in sync with secrets-scan.yml.
+          GITLEAKS_VERSION: 8.24.3
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Verify the gitleaks config detects what it must
+        env:
+          GITLEAKS_REQUIRED: '1'
+        run: sh scripts/gitleaks-config-selftest.sh

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -44,6 +44,17 @@ jobs:
             | tar -xz -C /usr/local/bin gitleaks
           gitleaks version
 
+      # Runs before the scan and is allowed to fail the job. The scan itself uses
+      # --exit-code=0 and reports to a dashboard, so it cannot catch a config that
+      # loads cleanly while detecting nothing - which is exactly what
+      # [useBuiltinRules] did. This asserts the config still detects a planted
+      # credential shape, still stays quiet on the known false positive, and still
+      # honors its path exclusions on the pinned gitleaks version above.
+      - name: Verify gitleaks config actually detects
+        env:
+          GITLEAKS_REQUIRED: '1'
+        run: sh scripts/gitleaks-config-selftest.sh
+
       - name: Run secrets scan with gitleaks
         # GITLEAKS_LICENSE is available as an org secret; the CLI does not
         # currently require it, but we pass it through for future compatibility.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -16,17 +16,17 @@ paths = [
   ".*\\.bundle\\.js$",
   ".*build/.*",
   ".*dist/.*",
-  # Test fixtures and test files — strings here are by definition not live credentials
+  # Test fixtures and test files - strings here are by definition not live credentials
   ".*/__fixtures__/.*",
   ".*/__mocks__/.*",
   ".*\\.test\\.[tj]sx?$",
   ".*\\.spec\\.[tj]sx?$",
   ".*/__tests__/.*",
-  # Documentation — placeholder strings are expected here
+  # Documentation - placeholder strings are expected here
   ".*docs/.*",
   ".*docs-site/.*",
   ".*README\\.md$",
-  # Environment example files — values here are intentional placeholders
+  # Environment example files - values here are intentional placeholders
   "\\.env\\.example$",
   "\\.env\\..*\\.example$"
 ]
@@ -34,7 +34,7 @@ paths = [
 regexes = [
   # Pre-existing
   "SHORTKEY=",
-  # AWS documentation canonical fake access key — never a real credential
+  # AWS documentation canonical fake access key - never a real credential
   "AKIAIOSFODNN7EXAMPLE",
   # Slack sample workspace / channel / token patterns from Slack docs
   "T00000000",
@@ -70,9 +70,9 @@ regexes = [
   "mongodb(\\+srv)?://username:password@cluster",
   "mongodb(\\+srv)?://\\$\\{",
   "mongodb(\\+srv)?://\\{\\{",
-  # Literal ellipsis placeholder — used in console.log usage examples
+  # Literal ellipsis placeholder - used in console.log usage examples
   "mongodb(\\+srv)?://\\.\\.\\.",
-  # Documentation example in echo statements — user:pass with known placeholder hostnames only
+  # Documentation example in echo statements - user:pass with known placeholder hostnames only
   "mongodb(\\+srv)?://user:pass@(localhost|127\\.0\\.0\\.1|example\\.com|cluster\\.|docdb\\.|your-cluster)"
 ]
 
@@ -119,7 +119,7 @@ entropy = 3.5
 [rules.allowlist]
 regexTarget = "secret"
 regexes = [
-  # Redaction test fixtures — the value is input to sanitizeErrorMessage(), not a live key
+  # Redaction test fixtures - the value is input to sanitizeErrorMessage(), not a live key
   "sanitizeErrorMessage",
   "REDACTED",
   "redact",

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,7 +3,10 @@
 
 title = "Bike4Mind Gitleaks Configuration"
 
-# Global allowlist for non-sensitive patterns matching secret formats
+# Global allowlist for non-sensitive patterns matching secret formats.
+# Keep the singular [allowlist] table. The [[allowlists]] array form is accepted by
+# gitleaks 8.26 but SILENTLY IGNORED by 8.24.3, which CI pins - switching would drop
+# every exclusion below without any error, so the two must not diverge.
 [allowlist]
 description = "Global allowlist for non-sensitive patterns"
 paths = [
@@ -42,6 +45,8 @@ regexes = [
   # Generic placeholder shapes
   "your[-_]secret[-_]here",
   "your[-_]api[-_]key",
+  # Uppercase placeholder shapes in docs and demo snippets, e.g. `Bearer YOUR_TOKEN`
+  "(?i)your[-_](api[-_])?(token|key|secret)",
   "insert[-_].*[-_]here",
   "<your[-_]",
   "\\$\\{[A-Z_]+\\}",
@@ -138,5 +143,19 @@ regexes = [
   "XXXXXXXXXXXXXXXXXXXXXXXXX"
 ]
 
-# Use default builtin rules as well
-[useBuiltinRules]
+# Inherit gitleaks' builtin rules (aws-access-token, github-pat, stripe, gcp,
+# private keys, ...) on top of the domain rules above. This must stay
+# `[extend] useDefault = true`: a bare `[useBuiltinRules]` table is not gitleaks
+# config syntax, so it parsed as an empty table and left every builtin disabled.
+#
+# generic-api-key stays off. It is a pure entropy heuristic with no credential
+# shape, and it fires on ordinary camelCase identifiers - every `key: 'xEnabled'`
+# in the settings schema scores above its threshold. There is no narrower fix that
+# works on both gitleaks versions in play: a `paths` allowlist would exempt the
+# whole file from ALL rules (8.26 ignores `targetRules` and `matchCondition` on a
+# global allowlist), and secret/stopword allowlists are ignored entirely by 8.24.3.
+# Specific-shape rules (aws, github, stripe, anthropic, gemini, slack, mongodb,
+# JWT/session secrets) all remain active and are what actually catch leaks.
+[extend]
+useDefault = true
+disabledRules = ["generic-api-key"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -150,10 +150,19 @@ regexes = [
 #
 # generic-api-key stays off. It is a pure entropy heuristic with no credential
 # shape, and it fires on ordinary camelCase identifiers - every `key: 'xEnabled'`
-# in the settings schema scores above its threshold. There is no narrower fix that
-# works on both gitleaks versions in play: a `paths` allowlist would exempt the
-# whole file from ALL rules (8.26 ignores `targetRules` and `matchCondition` on a
-# global allowlist), and secret/stopword allowlists are ignored entirely by 8.24.3.
+# in the settings schema scores above its threshold.
+#
+# Allowlist-based narrowing does not work across the two gitleaks versions in play
+# (CI pins 8.24.3, brew ships 8.26.0): a `paths` allowlist exempts the file from ALL
+# rules rather than one, because 8.26 ignores `targetRules` and `matchCondition` on
+# a global allowlist, and secret/stopword allowlists are ignored outright by 8.24.3.
+#
+# Redefining the rule with a raised entropy floor DOES work on both versions, and is
+# the alternative to this line. It is not used here because it requires vendoring
+# gitleaks' builtin regex into this file, where it would silently go stale as
+# upstream tunes the rule - the same class of silent staleness as the
+# [useBuiltinRules] bug above. Revisit if generic-api-key coverage is wanted back.
+#
 # Specific-shape rules (aws, github, stripe, anthropic, gemini, slack, mongodb,
 # JWT/session secrets) all remain active and are what actually catch leaks.
 [extend]

--- a/.husky/gitleaks-pre-commit.sh
+++ b/.husky/gitleaks-pre-commit.sh
@@ -28,6 +28,11 @@ NC='\033[0m' # No Color
 echo "${YELLOW}Running gitleaks to check for secrets...${NC}"
 echo "Using: $GITLEAKS_PATH"
 
+# Pass the repo config explicitly. Staged files are scanned from a temp dir below,
+# and gitleaks only auto-discovers a config in the directory it scans - so without
+# this the hook silently runs on default rules and disagrees with CI.
+GITLEAKS_CONFIG="$(git rev-parse --show-toplevel)/.gitleaks.toml"
+
 # Get all staged files
 STAGED_FILES=$(git diff --cached --name-only)
 
@@ -52,7 +57,7 @@ done
 
 # Scan the temporary directory with the --no-git flag
 echo "Scanning staged files..."
-if "$GITLEAKS_PATH" detect --verbose --redact --no-git -s "$TEMP_DIR" 2>/dev/null; then
+if "$GITLEAKS_PATH" detect --verbose --redact --no-git --config "$GITLEAKS_CONFIG" -s "$TEMP_DIR" 2>/dev/null; then
   echo "${GREEN}No secrets detected in staged files!${NC}"
   # Clean up
   rm -rf "$TEMP_DIR"
@@ -73,7 +78,7 @@ else
     echo "${RED}ERROR: gitleaks failed with exit code $EXIT_CODE${NC}"
     echo "${YELLOW}Debugging info:${NC}"
     echo "gitleaks path: $GITLEAKS_PATH"
-    echo "Try running manually: $GITLEAKS_PATH detect --verbose --redact --no-git -s ."
+    echo "Try running manually: $GITLEAKS_PATH detect --verbose --redact --no-git --config \"$GITLEAKS_CONFIG\" -s ."
     echo "Or bypass with: git commit --no-verify -m \"your message\""
     # Clean up
     rm -rf "$TEMP_DIR"

--- a/scripts/gitleaks-config-selftest.sh
+++ b/scripts/gitleaks-config-selftest.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+set -eu
+
+# Self-test for .gitleaks.toml.
+#
+# Guards the failure mode that motivated this script: a config that loads without
+# error while detecting nothing. The repo config previously ended in a
+# `[useBuiltinRules]` table, which is not gitleaks config syntax - it parsed as an
+# empty table, so every builtin rule was disabled and both CI and the pre-commit
+# hook scanned with only the handful of domain rules below it. Nothing failed, and
+# nothing caught an AWS key.
+#
+# Two directions are asserted, because fixing either one alone regresses the other:
+#   1. A credential shape that MUST be caught is caught (builtin rules are loaded).
+#   2. A known false positive stays quiet (the settings schema still commits).
+#
+# The canary is generated at runtime and written to a temp dir. Never commit a
+# credential-shaped literal to this repo - GitHub secret scanning alerts on example
+# values in tracked files, PR descriptions and comments, and cannot tell a
+# fabricated one from a live one.
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CONFIG="$REPO_ROOT/.gitleaks.toml"
+
+GITLEAKS_PATH=$(command -v gitleaks 2>/dev/null || true)
+if [ -z "$GITLEAKS_PATH" ]; then
+  # Skipping is right for a contributor who has not installed gitleaks, but in CI a
+  # skip is indistinguishable from a pass. Callers that install gitleaks themselves
+  # set GITLEAKS_REQUIRED=1 so a broken install fails loudly instead.
+  if [ "${GITLEAKS_REQUIRED:-0}" = "1" ]; then
+    echo "FAIL: GITLEAKS_REQUIRED=1 but gitleaks is not on PATH."
+    exit 1
+  fi
+  echo "gitleaks is not installed; skipping config self-test."
+  echo "  Mac: brew install gitleaks"
+  exit 0
+fi
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+FAILED=0
+
+# --- Assertion 1: builtin rules are loaded ------------------------------------
+# An AWS-access-key shape is used because it comes from gitleaks' builtin ruleset,
+# not from the domain rules in .gitleaks.toml, so it can only match when
+# `[extend] useDefault = true` is in effect. Generated, never hardcoded. Do not
+# substitute AWS's canonical documentation key - this repo allowlists it by design.
+CANARY_SUFFIX=$(LC_ALL=C tr -dc 'A-Z0-9' < /dev/urandom | head -c 16)
+printf "const canary = 'AKIA%s';\n" "$CANARY_SUFFIX" > "$TEMP_DIR/canary.ts"
+
+if "$GITLEAKS_PATH" detect --no-git --redact --no-banner \
+    --config "$CONFIG" -s "$TEMP_DIR" >/dev/null 2>&1; then
+  echo "FAIL: builtin rules are not active - a planted AWS-key shape was not detected."
+  echo "      Check that .gitleaks.toml still contains [extend] useDefault = true."
+  FAILED=1
+else
+  echo "ok: builtin rules active (planted credential shape detected)"
+fi
+
+# --- Assertion 2: the known false positive stays quiet ------------------------
+# The settings schema is a long list of camelCase feature-flag keys; several score
+# high enough on entropy to trip the builtin generic-api-key heuristic. If this
+# starts failing, staging that file blocks every commit and people reach for
+# --no-verify, which skips the other pre-commit guards too.
+SETTINGS="b4m-core/common/src/schemas/settings.ts"
+if [ -f "$REPO_ROOT/$SETTINGS" ]; then
+  if "$GITLEAKS_PATH" detect --no-git --redact --no-banner \
+      --config "$CONFIG" -s "$REPO_ROOT/$SETTINGS" >/dev/null 2>&1; then
+    echo "ok: $SETTINGS scans clean"
+  else
+    echo "FAIL: $SETTINGS reports a finding, so staging it will block commits."
+    echo "      Re-check the generic-api-key handling in .gitleaks.toml."
+    FAILED=1
+  fi
+fi
+
+# --- Assertion 3: the global allowlist is honored -----------------------------
+# The [[allowlists]] array form loads without error on 8.26 but is silently ignored
+# by the 8.24.3 that CI pins, which would drop every path exclusion below it. That
+# is invisible to assertions 1 and 2, so probe an excluded fixture directly.
+#
+# The probe is validated before it is trusted: the fixture is first scanned with no
+# config at all, and must report something. If it does not, the fixture no longer
+# contains a credential shape and this assertion would otherwise pass for the wrong
+# reason - so say so instead of reporting a false ok.
+PROBE="apps/client/app/utils/__tests__/error.test.ts"
+if [ -f "$REPO_ROOT/$PROBE" ]; then
+  if "$GITLEAKS_PATH" detect --no-git --redact --no-banner \
+      -s "$REPO_ROOT/$PROBE" >/dev/null 2>&1; then
+    echo "WARN: probe fixture $PROBE no longer trips the default ruleset."
+    echo "      The path-allowlist assertion is now vacuous - pick another fixture."
+  elif "$GITLEAKS_PATH" detect --no-git --redact --no-banner \
+      --config "$CONFIG" -s "$REPO_ROOT/$PROBE" >/dev/null 2>&1; then
+    echo "ok: path allowlist honored (test fixture excluded)"
+  else
+    echo "FAIL: $PROBE reports a finding, so the global allowlist is being ignored."
+    echo "      Check that .gitleaks.toml still uses the singular [allowlist] table:"
+    echo "      the [[allowlists]] array form is silently ignored by gitleaks 8.24.3."
+    FAILED=1
+  fi
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo ""
+  echo "gitleaks config self-test FAILED. The config may load cleanly and still"
+  echo "detect nothing, so treat this as a secret-scanning outage, not a lint nit."
+  exit 1
+fi
+
+echo "gitleaks config self-test passed."


### PR DESCRIPTION
# Pull Request

## Description

Closes #1045.

`.husky/gitleaks-pre-commit.sh` copies staged files to a temp dir and scans there. gitleaks only auto-discovers a config in the directory it scans, so without `--config` the hook ran on gitleaks' **default** rules and disagreed with CI. Staging `b4m-core/common/src/schemas/settings.ts` therefore always failed, on `generic-api-key` firing at entropy 3.66 against the camelCase key `voiceV2Enabled`. The workaround is `--no-verify`, which also skips the other six pre-commit guards - a hook that trains people to bypass it is worse than no hook.

**Loading the config exposed a larger, latent problem.** The config ended with:

```toml
# Use default builtin rules as well
[useBuiltinRules]
```

That is not gitleaks config syntax. It parses as an empty table and is ignored, so the repo config had **every builtin rule disabled** - and CI, which auto-discovers this config from the repo root, has been scanning without them. Verified with planted fake credentials:

| Config | Planted AWS access key + GitHub PAT |
|---|---|
| Default rules (what the hook used) | **caught (2)** |
| Repo `.gitleaks.toml` (what CI uses) | **MISSED (0)** |

So the one-line fix suggested in the issue (`--config`) would have traded a false positive for a real gap: the hook would have stopped detecting AWS keys, GitHub PATs, private keys and GCP keys. Both parts have to land together.

## Changes

- **`.husky/gitleaks-pre-commit.sh`** - pass `--config "$(git rev-parse --show-toplevel)/.gitleaks.toml"` so the hook and CI share one policy. Also threaded into the manual-repro hint in the error path.
- **`.gitleaks.toml`**
  - `[useBuiltinRules]` -> `[extend] useDefault = true`, restoring builtin coverage for the hook **and** CI.
  - `disabledRules = ["generic-api-key"]` - the rule behind the false positive. It is a pure entropy heuristic with no credential shape, so it matches ordinary camelCase identifiers.
  - Allowlist uppercase placeholder shapes (`Bearer YOUR_TOKEN`), which surfaced in `packages/scripts/FORMAT_SELECTION_DEMO.md` once the builtins came back.
  - Kept the singular `[allowlist]` table, with a comment explaining why it must stay.
- **`scripts/gitleaks-config-selftest.sh`** (new) - asserts the config actually detects. See below.
- **`.github/workflows/secrets-scan.yml`** - run the self-test before the scan, as a step that is allowed to fail.

### The config is now guarded

The bug class here is "config loads cleanly and detects nothing." Nothing caught it, and nothing would have caught it coming back: no test referenced `useDefault`, and the CI scan runs `--exit-code=0` so it cannot fail on anything. `[useBuiltinRules]` had an explanatory comment above it and looked deliberate.

The self-test asserts three things on CI's pinned version:

1. A planted credential shape **is** detected (builtin rules loaded). The canary is generated at runtime - no credential-shaped literal is committed.
2. `settings.ts` stays clean (the reported false positive does not come back).
3. Path exclusions are honored (catches a `[[allowlists]]` migration, which assertions 1 and 2 cannot see).

Assertion 3 validates its own probe: it first scans the fixture with no config and requires a finding, so if that fixture is ever cleaned up the assertion warns instead of passing vacuously.

Mutation-tested - all four regressions are caught:

| Mutant | Result |
|---|---|
| Reintroduce `[useBuiltinRules]` | caught |
| Migrate to `[[allowlists]]` (on 8.24.3) | caught |
| Drop the `generic-api-key` handling | caught |
| Delete the whole `[extend]` block | caught |

### Why `generic-api-key` is disabled rather than narrowly allowlisted

Every allowlist-based narrowing fails on one of the two gitleaks versions in play (CI pins **8.24.3**, local brew installs **8.26.0**):

| Approach | 8.26.0 | 8.24.3 |
|---|---|---|
| `[[allowlists]]` + `targetRules` | ignored | ignored |
| `[[allowlists]]` + `matchCondition = "AND"` | ignored | ignored |
| `[[allowlists]]` + `regexTarget`/`stopwords` | works | **ignored** |
| Redefine the rule with a raised entropy floor | works | works |
| `[extend] disabledRules` | works | works |

`targetRules` and `matchCondition` being ignored matters: a `paths` allowlist does not silence one rule for one file, it exempts that file from **every** rule. Confirmed by probe - an allowlist with a deliberately impossible regex still allowlisted the file. That is strictly worse than dropping one heuristic.

**There is a working alternative, and it is a judgment call worth a reviewer's opinion.** Redefining `generic-api-key` with `entropy = 4.2` works on both versions: `voiceV2Enabled` scores 3.66 so it goes quiet, and planted AWS/GitHub credentials are still caught. I did not take it because it requires vendoring gitleaks' builtin regex into our config, where it silently goes stale as upstream tunes the rule - the same class of silent staleness as the `[useBuiltinRules]` bug this PR fixes. Happy to switch if you would rather keep the heuristic above a high floor than lose it.

**Tradeoff, stated plainly:** the hook loses `generic-api-key`, which it has today. Net is still clearly positive - CI gains every builtin where it had none, and the hook gains all the domain rules. Canary check: the old config caught 1 of 4 planted secrets, the new config catches 3.

## Guide for Testers

No product behavior changes. Nothing to exercise in a browser or preview - this touches a git hook and a scanner config only.

Verification is local, and needs `gitleaks` installed (`brew install gitleaks`).

1. Check out this branch and confirm the reported failure is gone:
   - `touch b4m-core/common/src/schemas/settings.ts`
   - `git add b4m-core/common/src/schemas/settings.ts`
   - `sh .husky/gitleaks-pre-commit.sh`
   - Expected: `No secrets detected in staged files!` and exit code 0. On `main` this prints `ERROR: Potential secrets detected` and exits 1.
2. Confirm the hook still blocks a real secret:
   - Generate a throwaway AWS-shaped canary so no credential-shaped literal has to live in this PR:
     `printf "const k = 'AKIA%s';\n" "$(LC_ALL=C tr -dc 'A-Z0-9' </dev/urandom | head -c 16)" > canary.ts`
     (Do not use AWS's canonical documentation example key - this repo allowlists it by design, so it will correctly report no leak and look like a broken hook.)
   - `git add canary.ts && sh .husky/gitleaks-pre-commit.sh`
   - Expected: `RuleID: aws-access-token`, `ERROR: Potential secrets detected`, exit code 1.
   - Clean up: `git reset canary.ts && rm canary.ts`
3. Confirm the working tree is clean under the new config:
   - `gitleaks detect --no-git -s . --config .gitleaks.toml --no-banner`
   - Expected: `no leaks found`.

### Regression Checks

1. Test-file exclusions still apply: `gitleaks detect --no-git -s apps/client/app/utils/__tests__/error.test.ts --config .gitleaks.toml --no-banner` -> `no leaks found`.
2. A commit touching a normal source file still runs all seven pre-commit guards and passes.

### What NOT to test

- No UI, API, or runtime path is touched. The changed files are a shell hook and a TOML config.
- Do not test via the GitHub Actions secrets-scan job alone - it runs with `--exit-code=0` and reports to a dashboard, so it cannot fail and will not demonstrate the change.

## Additional Information

**Verified on both gitleaks versions, identical results:**

| Check | 8.24.3 (CI pin) | 8.26.0 |
|---|---|---|
| `settings.ts` clean (the reported bug) | no leaks | no leaks |
| Planted AWS + GitHub PAT caught | 2 | 2 |
| Test-file exclusion still honored | no leaks | no leaks |
| Whole working tree clean | no leaks | no leaks |
| Credentials planted **inside** `settings.ts` still caught | 2 | 2 |

The last row is the one that matters for the allowlist question: the fix must not shield the file it stops false-positiving on.

**CI impact:** ran CI's exact invocation (`gitleaks detect --source=. --exit-code=0`) on 8.24.3 against both configs - **0 findings before, 0 after**. No new dashboard noise.

**Whole-repo risk check** (the issue asked for this, since restoring builtins changes which rules apply): 3 findings, all handled - 2 were the `settings.ts` false positive, 1 was the `Bearer YOUR_TOKEN` doc placeholder now allowlisted.

**Not verified:** I could not test every gitleaks version a contributor might have installed locally. The two covered are CI's pin and current brew.

## Developer Notes (Optional)

- **A scanner config needs a positive assertion, not a comment.** This is the reusable lesson: `[useBuiltinRules]` was documented, plausible, and inert. `scripts/gitleaks-config-selftest.sh` is the pattern - assert the tool detects something it must detect, and validate the probe before trusting it.
- **Version skew is the real hazard here.** CI pins 8.24.3 while contributors get whatever brew installs. Two config forms that load cleanly on one version are silently ignored by the other, with no error - `[[allowlists]]` being the dangerous one, since it would drop every exclusion. Worth pinning the local version or asserting it in the hook; I have not done either here.
- **Reviewer heuristic:** when a scanner config "works", check that its rules are actually loaded. `[useBuiltinRules]` looked deliberate, had an explanatory comment, and did nothing for as long as it has existed.
- **Out of scope, worth follow-ups:**
  - `bike4mind-mongodb-uri` never fires. A realistic Atlas SRV connection string carrying inline credentials is missed under both the old and new config, so the rule has been dead. Not introduced here; happy to file separately with the repro off-repo.
  - `.gitleaks.toml` has pre-existing em-dashes (lines 19, 25, 29, 37, 73, 75, 122) which violate the ASCII-only rule in CLAUDE.md. None are mine. Left alone to keep this diff focused.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
