### PR TITLE
fix(client): mark persisted identify initialData as immediately stale

### DIFF
--- a/apps/client/app/hooks/data/user.test.ts
+++ b/apps/client/app/hooks/data/user.test.ts
@@ -1,5 +1,73 @@
-import { describe, it, expect } from 'vitest';
-import { adminReturnValidationError, ADMIN_SESSION_EXPIRED, ADMIN_SESSION_VALIDATION_FAILED } from './user';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import {
+  adminReturnValidationError,
+  ADMIN_SESSION_EXPIRED,
+  ADMIN_SESSION_VALIDATION_FAILED,
+  useGetIdentify,
+} from './user';
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: vi.fn() },
+}));
+
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: vi.fn(),
+}));
+
+vi.mock('../useAccessToken', () => ({
+  useAccessToken: vi.fn(),
+}));
+
+const { useUser } = await import('@client/app/contexts/UserContext');
+const { useAccessToken } = await import('../useAccessToken');
+
+describe('useGetIdentify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return React.createElement(QueryClientProvider, { client: qc }, children);
+  };
+
+  it('treats persisted initialData as immediately stale so a background refetch fires', async () => {
+    const fakeUser = { id: 'u1', name: 'Test', preferences: {} };
+    const fakeToken = 'stale-jwt';
+
+    vi.mocked(useUser).mockImplementation((sel: any) => sel({ currentUser: fakeUser }));
+    vi.mocked(useAccessToken).mockImplementation((sel: any) => sel({ accessToken: fakeToken }));
+
+    const { result } = renderHook(() => useGetIdentify(), { wrapper });
+
+    // initialData is provided, so the query starts as success
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The data should be the persisted stub (initialData)
+    expect(result.current.data?.user).toEqual(fakeUser);
+
+    // Critical assertion: the data must be immediately stale (dataUpdatedAt === 0)
+    // so React Query fires a background refetch rather than suppressing the
+    // network call for the full staleTime window.
+    expect(result.current.isStale).toBe(true);
+  });
+
+  it('does not set initialData when the persisted user lacks preferences', () => {
+    const fakeUser = { id: 'u1', name: 'Test' };
+    const fakeToken = 'some-jwt';
+
+    vi.mocked(useUser).mockImplementation((sel: any) => sel({ currentUser: fakeUser }));
+    vi.mocked(useAccessToken).mockImplementation((sel: any) => sel({ accessToken: fakeToken }));
+
+    const { result } = renderHook(() => useGetIdentify(), { wrapper });
+
+    // No initialData -> query starts in pending state, not success
+    expect(result.current.data).toBeUndefined();
+  });
+});
 
 describe('adminReturnValidationError', () => {
   it('returns the force-logout sentinel for an auth rejection (401/403)', () => {

--- a/apps/client/app/hooks/data/user.ts
+++ b/apps/client/app/hooks/data/user.ts
@@ -40,15 +40,16 @@ export const useGetIdentify = () => {
       const response = await api.get<{ user: IUserDocument; accessToken: string }>('/api/identify');
       return response.data;
     },
-    // Only seed initialData when the cached user is a FULL record (has `preferences`).
-    // The persisted stub from UserContext (`pickPersistedFields`) deliberately omits
-    // `preferences` - and UserSettingsContext keys `isHydrated` on `'preferences' in currentUser`.
-    // Feeding the stub as initialData makes React Query treat it as fresh for the entire
-    // staleTime window and skip the /api/identify network call, so preferences never land,
-    // isHydrated never flips, and ExperimentalFeatureGate hangs forever on cold loads
-    // of gated routes (e.g. /agents).
+    // Seed initialData from the persisted user so the UI renders instantly on
+    // cold load (no loading spinner). `initialDataUpdatedAt: 0` marks it
+    // immediately stale so React Query fires a background /api/identify refetch
+    // right away. Without this, the staleTime window suppresses the network call
+    // and the identify effect feeds the stale persisted accessToken back into the
+    // store -- which can overwrite a token the 401 interceptor just refreshed,
+    // leaving data queries permanently failed (the "name shows but no data" bug).
     initialData:
       currentUser && accessToken && 'preferences' in currentUser ? { user: currentUser, accessToken } : undefined,
+    initialDataUpdatedAt: 0,
     staleTime: 1000 * 60 * 5, // 5 minutes
     // Only run query when there's an access token to avoid 401 errors for unauthenticated users
     enabled: !!accessToken,


### PR DESCRIPTION
Add `initialDataUpdatedAt: 0` to useGetIdentify so React Query treats the localStorage-cached user+token as stale on mount and fires a background /api/identify refetch right away. Without this the staleTime window suppresses the network call and the identify effect can overwrite a token the 401 interceptor just refreshed, leaving data queries permanently failed ("name shows but no data" on return visits).

This was created for this bug report:
" Same problem I had last week - can't log in.  It registers me a '[redacted]', but not models are available, and my history/files are not there.   I'm using MSFT Edge - as usual.  I'm doing the things I did last week... but still can't get in.
[11:27 AM]I have to do a full log-out, every time, now, I think.  I did that, and that re-sends the magic 6 digit code, and now I can get in.  Is that what I have to do, now, full logout every time?"


What was happening: When you closed Edge and came back, the app loaded your cached identity instantly (so your name showed), but it treated that cached data as "fresh" and skipped re-checking with the server for 5 minutes. During that window, your stale access token could get stuck in a loop where the refresh mechanism and the identity cache fought over which token to use — the result being your name shows but nothing else loads.                                                     
   
  What the fix does: The cached identity still loads instantly (no loading spinner), but the app now immediately checks with the server in the background to get a fresh, valid token. So the "close Edge, come back later" flow should just work    
  without needing to full-logout first. 

# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description
<!--
Provide a detailed description of what this PR does. Explain the problem you're solving or the feature you're adding.
-->

## Changes
<!--
List the changes you've made in this PR. This is to help the reviewers understand the impact of your changes.
- Change 1
- Change 2
- ...
-->

## Guide for Testers
<!--
Write step-by-step instructions that both human QA testers AND AI agents (e.g., Playwright) can follow without codebase knowledge.

Requirements:
- Number every step — one action per step
- Use exact navigation paths: "Sidebar → Admin → DLQ Management"
- Use exact URLs: "app.staging.bike4mind.com"
- Use exact input values: type `Hello, how are you?` in the message input
- State expected results after each step: "A response appears within 10 seconds with no errors"
- Include a "Regression Checks" section for refactors
- Include a "What NOT to test" section for infra/backend-only PRs

See CLAUDE.md → "Test Guide Standards" for full guidelines and examples.
-->

## Additional Information
<!--
Include any additional information or context that you think would be helpful for your reviewers.
-->

## Developer Notes (Optional)
<!--
Document capability unlocks, architectural improvements, and reusable patterns introduced by this PR.
This helps future developers understand what new building blocks are available.

Categories to consider:
- **New Extension Points**: Components/interfaces that accept new props, hooks, or configuration
- **Reusable Patterns**: New components, utilities, or approaches that can be applied elsewhere
- **Data Model Changes**: New fields, types, or structures that enable future features
- **Architecture Decisions**: Why something was built a certain way (not just what changed)

Example:
- `SchedulerTab` now accepts a `familyId` prop — any new pattern family automatically gets a Learn tab
- `ComingSoonPanel` component can be dropped into any tab to indicate future work
- `effectiveTab` pattern shows how to handle persisted tab state when tabs become conditionally disabled
-->

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
