### PR TITLE
perf(client): reorder the counterLogs user lookup to run after grouping

### DIFF
--- a/apps/client/pages/api/users/__tests__/counterLogs.test.ts
+++ b/apps/client/pages/api/users/__tests__/counterLogs.test.ts
@@ -146,6 +146,37 @@ describe('GET /api/users/counterLogs (end-to-end, real model + Mongo)', () => {
     expect(orphanRow!.users[0].userEmail).toBe('');
   });
 
+  it('does not abort the aggregation when a userId is not a valid ObjectId', async () => {
+    // Distinct from the orphaned-user case above, which uses a VALID ObjectId with no matching
+    // User (that exercises preserveNullAndEmptyArrays). This covers the $convert onError: null
+    // arm: a non-ObjectId userId such as 'SYSTEM' must fail to join rather than throw. With the
+    // previous $toObjectId, one such row aborted the entire aggregation with a ConversionFailure,
+    // 500ing the whole admin analytics page.
+    await CounterLog.create({
+      userId: 'SYSTEM',
+      userName: 'System',
+      userLevel: 'System',
+      counterName: 'Session Created',
+      counterValue: 1,
+      datetime: new Date('2026-07-21T10:00:00.000Z'),
+      metadata: { sessionId: 'session-system' },
+    });
+
+    const { res, promise } = run({ startDate: '2026-07-21', endDate: '2026-07-21' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const rows = JSON.parse(JSON.stringify(res._getJSONData())).logs as Array<{
+      metadata: { sessionId: string };
+      users: Array<{ userId: string; userEmail: string }>;
+    }>;
+
+    const systemRow = rows.find(r => r.metadata.sessionId === 'session-system');
+    expect(systemRow, 'the row must still be returned, not dropped or thrown on').toBeDefined();
+    expect(systemRow!.users[0].userId).toBe('SYSTEM');
+    expect(systemRow!.users[0].userEmail).toBe('');
+  });
+
   it('builds the user $lookup with an inner $project restricted to non-secret fields', () => {
     // Asserts on the EXPORTED builder the handler calls, so deleting or widening the production
     // $project fails here. Do not inline a copy of the stages: the $lookup's projection has no

--- a/apps/client/pages/api/users/__tests__/counterLogs.test.ts
+++ b/apps/client/pages/api/users/__tests__/counterLogs.test.ts
@@ -5,14 +5,21 @@ import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
 import { createMongoServer } from '../../../../../../packages/database/src/__test__/createMongoServer';
 import { CounterLog, User } from '@bike4mind/database';
-import { SAFE_USER_LOOKUP_PROJECT } from '@bike4mind/common';
+import { SAFE_USER_LOOKUP_PROJECT, USER_SECRET_FIELDS } from '@bike4mind/common';
 
 /**
- * Agreement test for the M1 $lookup reorder (see counterlogs-phase2-payload-reduction.md):
- * drives the REAL aggregation against createMongoServer rather than mocking the pipeline, so a
- * regression in the group-then-join reshape or the inner $project fails here. The staging
- * before/after diff (13,308 rows, byte-identical once resorted, ~2x faster) is the empirical
- * parity proof; this test pins the same invariants so they can't regress silently in CI.
+ * Tests for the M1 $lookup reorder (see counterlogs-phase2-payload-reduction.md).
+ *
+ * Tests 1 and 3 are AGREEMENT tests: they drive the real handler against createMongoServer and
+ * pin the output contract, which is unchanged by the reorder. They pass against both the old and
+ * new pipeline by design - that is the point, since the PR's claim is "identical output, faster".
+ * The staging before/after diff (13,308 rows, byte-identical once resorted, ~2x faster) is the
+ * empirical parity proof.
+ *
+ * Test 2 asserts on `buildCounterLogsPipeline` - the exported builder the handler actually calls -
+ * NOT on a copy of the stages. An earlier version re-declared its own pipeline, which meant
+ * deleting the production `$project` failed nothing; it was asserting that MongoDB's `$project`
+ * works rather than that this route uses it.
  */
 
 vi.mock('@server/middlewares/baseApi', () => ({
@@ -29,15 +36,15 @@ vi.mock('@server/middlewares/baseApi', () => ({
   },
 }));
 
-import handler from '../counterLogs';
+import handler, { buildCounterLogsPipeline } from '../counterLogs';
 
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
-  // autoIndex builds in the background after connect; the aggregation's `hint: { datetime: 1 }`
-  // needs that index to exist before the first query runs, or Mongo rejects the hint outright.
+  // Ensure declared indexes exist before querying. autoIndex is fire-and-forget, so on a fresh
+  // database the first query can race the index build.
   await CounterLog.init();
 }, 30000);
 
@@ -48,8 +55,7 @@ afterAll(async () => {
 
 afterEach(async () => {
   await mongoose.connection.dropDatabase();
-  // dropDatabase wipes indexes along with the data - rebuild before the next test's aggregate
-  // runs its `hint: { datetime: 1 }`, or it hits the same "no matching index" race.
+  // dropDatabase wipes indexes along with the data - rebuild for the next test.
   await CounterLog.init();
 });
 
@@ -140,73 +146,30 @@ describe('GET /api/users/counterLogs (end-to-end, real model + Mongo)', () => {
     expect(orphanRow!.users[0].userEmail).toBe('');
   });
 
-  it('projects the joined user through the safe lookup allowlist, excluding secret fields', async () => {
-    // Password is bcrypt-hashed by a pre-save hook, and the endpoint's own outer $group/$project
-    // never forward the full `user` object to the response regardless of this stage - so a
-    // response-level string/key check on the full endpoint would pass whether or not the lookup's
-    // own inner $project exists. That made an earlier version of this test vacuous (confirmed by
-    // mutation: deleting the inner $project below did not fail it). Test the lookup's OWN output
-    // directly instead, by running the same match/group/lookup prefix the handler builds
-    // (apps/client/pages/api/users/counterLogs.ts) as its own aggregation. Keep this prefix in
-    // sync with that pipeline if the lookup stage ever changes.
-    const user = await User.create({
-      username: 'e2e-secret-check-user',
-      name: 'Secret Check User',
-      email: 'secret-check@example.com',
-      password: 'sup3rSecretHashValueXYZ',
-    });
+  it('builds the user $lookup with an inner $project restricted to non-secret fields', () => {
+    // Asserts on the EXPORTED builder the handler calls, so deleting or widening the production
+    // $project fails here. Do not inline a copy of the stages: the $lookup's projection has no
+    // effect on the HTTP response (the outer $group/$project already forward only named scalars),
+    // so an output-level assertion cannot pin it - the property is structural.
+    const stages = buildCounterLogsPipeline({ datetime: { $gte: new Date(0) } }) as Array<
+      Record<string, { pipeline?: Array<{ $project?: Record<string, unknown> }>; as?: string }>
+    >;
 
-    await CounterLog.create({
-      userId: user.id,
-      userName: 'Secret Check User',
-      userLevel: 'User',
-      counterName: 'Session Created',
-      counterValue: 1,
-      datetime: new Date('2026-07-21T10:00:00.000Z'),
-      metadata: { sessionId: 'session-secret-check' },
-    });
+    const lookup = stages.find(s => s.$lookup?.as === 'user')?.$lookup;
+    expect(lookup, 'the pipeline must contain a $lookup aliased to "user"').toBeDefined();
 
-    const rows = await CounterLog.aggregate([
-      {
-        $match: {
-          datetime: { $gte: new Date('2026-07-21T00:00:00.000Z'), $lte: new Date('2026-07-21T23:59:59.999Z') },
-        },
-      },
-      { $addFields: { dateString: { $dateToString: { format: '%Y-%m-%d', date: '$datetime', timezone: 'UTC' } } } },
-      {
-        $group: {
-          _id: { date: '$dateString', counterName: '$counterName', userId: '$userId', metadata: '$metadata' },
-          totalValue: { $sum: '$counterValue' },
-          count: { $sum: 1 },
-        },
-      },
-      { $addFields: { userObjectId: { $toObjectId: '$_id.userId' } } },
-      {
-        $lookup: {
-          from: 'users',
-          localField: 'userObjectId',
-          foreignField: '_id',
-          pipeline: [{ $project: { ...SAFE_USER_LOOKUP_PROJECT, email: 1, organization: 1 } }],
-          as: 'user',
-        },
-      },
-      { $unwind: { path: '$user', preserveNullAndEmptyArrays: true } },
-    ]);
+    const projection = lookup!.pipeline?.[0]?.$project;
+    expect(projection, 'the user $lookup must carry an inner $project').toBeDefined();
 
-    expect(rows).toHaveLength(1);
-    const joinedUser = rows[0].user;
-    expect(joinedUser).toBeDefined();
-    expect(joinedUser.email).toBe('secret-check@example.com');
-    // $project only emits fields present on the source doc, so a field with no default (e.g.
-    // lastActiveAt) may legitimately be absent - assert no UNEXPECTED key leaked through, rather
-    // than exact key equality against fields that may or may not be set.
-    const allowedKeys = new Set([...Object.keys(SAFE_USER_LOOKUP_PROJECT), 'email', 'organization']);
-    for (const key of Object.keys(joinedUser)) {
-      expect(allowedKeys.has(key), `unexpected key "${key}" leaked through the lookup projection`).toBe(true);
+    // Exact key set: an inclusion projection that gains a field is exactly the regression to catch,
+    // so assert equality rather than a subset. Secret fields are named explicitly too, so the
+    // intent survives even if SAFE_USER_LOOKUP_PROJECT itself is ever widened by mistake.
+    expect(new Set(Object.keys(projection!))).toEqual(
+      new Set([...Object.keys(SAFE_USER_LOOKUP_PROJECT), 'email', 'organization'])
+    );
+    for (const secret of USER_SECRET_FIELDS) {
+      expect(projection, `secret field "${secret}" must never be projected`).not.toHaveProperty(secret);
     }
-    expect(joinedUser.password).toBeUndefined();
-    expect(joinedUser.mfa).toBeUndefined();
-    expect(joinedUser.oauthCredentials).toBeUndefined();
   });
 
   it('keeps metadata fragments in separate groups (M1 does not change the group key)', async () => {

--- a/apps/client/pages/api/users/__tests__/counterLogs.test.ts
+++ b/apps/client/pages/api/users/__tests__/counterLogs.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../../../packages/database/src/__test__/createMongoServer';
+import { CounterLog, User } from '@bike4mind/database';
+import { SAFE_USER_LOOKUP_PROJECT } from '@bike4mind/common';
+
+/**
+ * Agreement test for the M1 $lookup reorder (see counterlogs-phase2-payload-reduction.md):
+ * drives the REAL aggregation against createMongoServer rather than mocking the pipeline, so a
+ * regression in the group-then-join reshape or the inner $project fails here. The staging
+ * before/after diff (13,308 rows, byte-identical once resorted, ~2x faster) is the empirical
+ * parity proof; this test pins the same invariants so they can't regress silently in CI.
+ */
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
+      {
+        use: () => chain,
+        get: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.GET = fns[fns.length - 1]), chain),
+      }
+    );
+    return chain;
+  },
+}));
+
+import handler from '../counterLogs';
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+  // autoIndex builds in the background after connect; the aggregation's `hint: { datetime: 1 }`
+  // needs that index to exist before the first query runs, or Mongo rejects the hint outright.
+  await CounterLog.init();
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 30000);
+
+afterEach(async () => {
+  await mongoose.connection.dropDatabase();
+  // dropDatabase wipes indexes along with the data - rebuild before the next test's aggregate
+  // runs its `hint: { datetime: 1 }`, or it hits the same "no matching index" race.
+  await CounterLog.init();
+});
+
+const stubLogger = () => {
+  const logger: Record<string, unknown> = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  logger.withMetadata = vi.fn(() => logger);
+  return logger;
+};
+
+function run(query: Record<string, string>) {
+  const { req, res } = createMocks({ method: 'GET', query });
+  (req as Record<string, unknown>).ability = { can: () => true };
+  (req as Record<string, unknown>).logger = stubLogger();
+  (req as Record<string, unknown>).headers = { 'accept-encoding': 'gzip' };
+  return { res, promise: (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res) };
+}
+
+describe('GET /api/users/counterLogs (end-to-end, real model + Mongo)', () => {
+  it('aggregates counts per user via the reordered lookup', async () => {
+    const goodUser = await User.create({
+      username: 'e2e-good-user',
+      name: 'Good User',
+      email: 'good-user@example.com',
+    });
+
+    const orphanUserId = new mongoose.Types.ObjectId().toString();
+
+    await CounterLog.create([
+      {
+        userId: goodUser.id,
+        userName: 'Good User',
+        userLevel: 'User',
+        counterName: 'Session Created',
+        counterValue: 1,
+        datetime: new Date('2026-07-21T10:00:00.000Z'),
+        metadata: { sessionId: 'session-a' },
+      },
+      {
+        // Second event for the same user/date/counterName/metadata -> should collapse into the
+        // same group and sum, exactly like the pre-reorder pipeline.
+        userId: goodUser.id,
+        userName: 'Good User',
+        userLevel: 'User',
+        counterName: 'Session Created',
+        counterValue: 1,
+        datetime: new Date('2026-07-21T11:00:00.000Z'),
+        metadata: { sessionId: 'session-a' },
+      },
+      {
+        // No matching User document - the orphaned-user path the client's $ifNull fallback
+        // exists for. Must not throw, and must resolve to an empty-string email.
+        userId: orphanUserId,
+        userName: 'Ghost User',
+        userLevel: 'User',
+        counterName: 'Session Created',
+        counterValue: 1,
+        datetime: new Date('2026-07-21T12:00:00.000Z'),
+        metadata: { sessionId: 'session-b' },
+      },
+    ]);
+
+    const { res, promise } = run({ startDate: '2026-07-21', endDate: '2026-07-21' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const body = JSON.parse(JSON.stringify(res._getJSONData()));
+    const rows = body.logs as Array<{
+      date: string;
+      counterName: string;
+      count: number;
+      totalValue: number;
+      metadata: Record<string, unknown>;
+      users: Array<{ userId: string; userEmail: string; count: number; totalValue: number }>;
+    }>;
+
+    expect(rows).toHaveLength(2);
+
+    const goodRow = rows.find(r => (r.metadata as { sessionId: string }).sessionId === 'session-a');
+    expect(goodRow).toBeDefined();
+    expect(goodRow!.count).toBe(2);
+    expect(goodRow!.totalValue).toBe(2);
+    expect(goodRow!.users).toHaveLength(1);
+    expect(goodRow!.users[0].userEmail).toBe('good-user@example.com');
+    expect(goodRow!.users[0].count).toBe(2);
+
+    const orphanRow = rows.find(r => (r.metadata as { sessionId: string }).sessionId === 'session-b');
+    expect(orphanRow).toBeDefined();
+    expect(orphanRow!.users[0].userEmail).toBe('');
+  });
+
+  it('projects the joined user through the safe lookup allowlist, excluding secret fields', async () => {
+    // Password is bcrypt-hashed by a pre-save hook, and the endpoint's own outer $group/$project
+    // never forward the full `user` object to the response regardless of this stage - so a
+    // response-level string/key check on the full endpoint would pass whether or not the lookup's
+    // own inner $project exists. That made an earlier version of this test vacuous (confirmed by
+    // mutation: deleting the inner $project below did not fail it). Test the lookup's OWN output
+    // directly instead, by running the same match/group/lookup prefix the handler builds
+    // (apps/client/pages/api/users/counterLogs.ts) as its own aggregation. Keep this prefix in
+    // sync with that pipeline if the lookup stage ever changes.
+    const user = await User.create({
+      username: 'e2e-secret-check-user',
+      name: 'Secret Check User',
+      email: 'secret-check@example.com',
+      password: 'sup3rSecretHashValueXYZ',
+    });
+
+    await CounterLog.create({
+      userId: user.id,
+      userName: 'Secret Check User',
+      userLevel: 'User',
+      counterName: 'Session Created',
+      counterValue: 1,
+      datetime: new Date('2026-07-21T10:00:00.000Z'),
+      metadata: { sessionId: 'session-secret-check' },
+    });
+
+    const rows = await CounterLog.aggregate([
+      {
+        $match: {
+          datetime: { $gte: new Date('2026-07-21T00:00:00.000Z'), $lte: new Date('2026-07-21T23:59:59.999Z') },
+        },
+      },
+      { $addFields: { dateString: { $dateToString: { format: '%Y-%m-%d', date: '$datetime', timezone: 'UTC' } } } },
+      {
+        $group: {
+          _id: { date: '$dateString', counterName: '$counterName', userId: '$userId', metadata: '$metadata' },
+          totalValue: { $sum: '$counterValue' },
+          count: { $sum: 1 },
+        },
+      },
+      { $addFields: { userObjectId: { $toObjectId: '$_id.userId' } } },
+      {
+        $lookup: {
+          from: 'users',
+          localField: 'userObjectId',
+          foreignField: '_id',
+          pipeline: [{ $project: { ...SAFE_USER_LOOKUP_PROJECT, email: 1, organization: 1 } }],
+          as: 'user',
+        },
+      },
+      { $unwind: { path: '$user', preserveNullAndEmptyArrays: true } },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    const joinedUser = rows[0].user;
+    expect(joinedUser).toBeDefined();
+    expect(joinedUser.email).toBe('secret-check@example.com');
+    // $project only emits fields present on the source doc, so a field with no default (e.g.
+    // lastActiveAt) may legitimately be absent - assert no UNEXPECTED key leaked through, rather
+    // than exact key equality against fields that may or may not be set.
+    const allowedKeys = new Set([...Object.keys(SAFE_USER_LOOKUP_PROJECT), 'email', 'organization']);
+    for (const key of Object.keys(joinedUser)) {
+      expect(allowedKeys.has(key), `unexpected key "${key}" leaked through the lookup projection`).toBe(true);
+    }
+    expect(joinedUser.password).toBeUndefined();
+    expect(joinedUser.mfa).toBeUndefined();
+    expect(joinedUser.oauthCredentials).toBeUndefined();
+  });
+
+  it('keeps metadata fragments in separate groups (M1 does not change the group key)', async () => {
+    const user = await User.create({
+      username: 'e2e-frag-user',
+      name: 'Frag User',
+      email: 'frag-user@example.com',
+    });
+
+    await CounterLog.create([
+      {
+        userId: user.id,
+        userName: 'Frag User',
+        userLevel: 'User',
+        counterName: 'Marketing Report Opened',
+        counterValue: 1,
+        datetime: new Date('2026-07-21T09:00:00.000Z'),
+        metadata: { reportId: 'report-1' },
+      },
+      {
+        userId: user.id,
+        userName: 'Frag User',
+        userLevel: 'User',
+        counterName: 'Marketing Report Opened',
+        counterValue: 1,
+        datetime: new Date('2026-07-21T09:30:00.000Z'),
+        metadata: { reportId: 'report-2' },
+      },
+    ]);
+
+    const { res, promise } = run({ startDate: '2026-07-21', endDate: '2026-07-21' });
+    await promise;
+
+    const body = JSON.parse(JSON.stringify(res._getJSONData()));
+    const rows = body.logs as Array<{ metadata: { reportId: string } }>;
+
+    // Still two rows, one per distinct reportId - the group-key collapse is M2's job, not M1's.
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map(r => r.metadata.reportId))).toEqual(new Set(['report-1', 'report-2']));
+  });
+});

--- a/apps/client/pages/api/users/counterLogs.ts
+++ b/apps/client/pages/api/users/counterLogs.ts
@@ -22,8 +22,136 @@ import { sendMaybeGzip } from '@server/utils/sendMaybeGzip';
 dayjs.extend(isSameOrBefore);
 
 // Lambda gives this route a 60s budget; leave headroom for the response to serialize/gzip
-// after the DB call returns rather than let a slow query eat the whole timeout.
+// after the DB call returns rather than let a slow query eat the whole timeout. Deliberately
+// larger than the 20s used by the overwatch services - this route's aggregation is heavier and
+// its Lambda budget is 60s, so it is sized to this route rather than copied from elsewhere.
 const AGGREGATION_MAX_TIME_MS = 45000;
+
+/**
+ * Builds the `{logs}` aggregation pipeline.
+ *
+ * Exported so the test can assert against the pipeline the handler ACTUALLY runs. An earlier
+ * version of the test re-declared its own copy of these stages, which meant deleting the
+ * `$lookup`'s inner `$project` from this file failed nothing - the test was asserting that
+ * MongoDB's `$project` works, not that this route uses it. Keep the builder as the single
+ * source of truth rather than reintroducing a replica.
+ *
+ * The user `$lookup` runs AFTER the first `$group`, not before: userEmail/userOrganization are
+ * functionally determined by userId alone, so grouping first and joining once per resulting
+ * (date, counterName, userId, metadata) row returns the same output as the old per-raw-document
+ * join while touching far fewer rows (this collection's bloat is metadata fragmentation, not
+ * user cardinality - see the Phase 2 plan). It also lets the join use the index-eligible
+ * localField/foreignField form instead of a correlated let/pipeline/$expr subquery.
+ *
+ * NOTE: `convertLookupForDocumentDB` returns early when `localField`/`foreignField` are present
+ * (b4m-core/db-core/src/utils/documentdb-compat.ts), so the inner pipeline below is passed to
+ * DocumentDB unconverted. Do not add an `$expr` in there expecting it to be rewritten.
+ */
+export const buildCounterLogsPipeline = (matchCondition: Record<string, unknown>) => [
+  {
+    $match: matchCondition,
+  },
+  {
+    $addFields: {
+      dateString: {
+        $dateToString: {
+          format: '%Y-%m-%d',
+          date: '$datetime',
+          timezone: 'UTC',
+        },
+      },
+    },
+  },
+  {
+    $group: {
+      // metadata is part of the group key; storing it again as a field would
+      // duplicate it in every user pushed below.
+      _id: {
+        date: '$dateString',
+        counterName: '$counterName',
+        userId: '$userId',
+        metadata: '$metadata',
+      },
+      totalValue: { $sum: '$counterValue' },
+      count: { $sum: 1 },
+    },
+  },
+  {
+    $addFields: {
+      // $convert (not $toObjectId) so a non-ObjectId userId such as 'SYSTEM' yields null and
+      // simply fails to join, instead of aborting the whole aggregation with a 500. Mirrors
+      // InboxModel.findByReceiverId, which documents the same hazard.
+      userObjectId: { $convert: { input: '$_id.userId', to: 'objectId', onError: null } },
+    },
+  },
+  {
+    // Aggregation $lookup bypasses Mongoose select:false, so project off the shared
+    // secret-free baseline plus the extra non-secret fields this route reads (email,
+    // organization). Never add credential/secret fields here.
+    $lookup: {
+      from: 'users',
+      localField: 'userObjectId',
+      foreignField: '_id',
+      pipeline: [
+        {
+          $project: {
+            ...SAFE_USER_LOOKUP_PROJECT,
+            email: 1,
+            organization: 1,
+          },
+        },
+      ],
+      as: 'user',
+    },
+  },
+  {
+    $unwind: {
+      path: '$user',
+      preserveNullAndEmptyArrays: true,
+    },
+  },
+  {
+    $addFields: {
+      userEmail: { $ifNull: ['$user.email', ''] },
+    },
+  },
+  {
+    $group: {
+      // Outer key includes metadata, so every user in users[] shares the parent
+      // log's metadata. Consumers read it from the parent row, not per user.
+      _id: {
+        date: '$_id.date',
+        counterName: '$_id.counterName',
+        metadata: '$_id.metadata',
+      },
+      totalValue: { $sum: '$totalValue' },
+      count: { $sum: '$count' },
+      uniqueUsers: { $addToSet: '$_id.userId' },
+      users: {
+        $push: {
+          userId: '$_id.userId',
+          userEmail: '$userEmail',
+          userOrganization: '$user.organization',
+          totalValue: '$totalValue',
+          count: '$count',
+        },
+      },
+    },
+  },
+  {
+    $project: {
+      _id: 0,
+      date: '$_id.date',
+      counterName: '$_id.counterName',
+      metadata: '$_id.metadata',
+      totalValue: 1,
+      count: 1,
+      uniqueUserCount: { $size: '$uniqueUsers' },
+      users: 1,
+    },
+  },
+  { $sort: { date: 1, counterName: 1 } },
+];
 
 const CounterLogsQuerySchema = z.object({
   startDate: z.string(),
@@ -167,122 +295,16 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
         matchCondition.userOrganization = { $nin: excludeOrgs };
       }
 
-      // For non-report requests, return the aggregated logs.
-      //
-      // The user $lookup runs AFTER the first $group, not before: userEmail/userOrganization
-      // are functionally determined by userId alone, so grouping first and joining once per
-      // resulting (date, counterName, userId, metadata) row is equivalent to the old
-      // per-raw-document join but touches far fewer rows (this collection's own bloat problem
-      // is metadata fragmentation, not user cardinality - see the Phase 2 plan). It also lets
-      // the join use the standard localField/foreignField form (an index-eligible equality
-      // join) instead of a correlated let/pipeline/$expr subquery, which is the only one of its
-      // kind on this collection - every other lookup here uses localField/foreignField.
-      const pipeline = [
-        {
-          $match: matchCondition,
-        },
-        {
-          $addFields: {
-            dateString: {
-              $dateToString: {
-                format: '%Y-%m-%d',
-                date: '$datetime',
-                timezone: 'UTC',
-              },
-            },
-          },
-        },
-        {
-          $group: {
-            // metadata is part of the group key; storing it again as a field would
-            // duplicate it in every user pushed below.
-            _id: {
-              date: '$dateString',
-              counterName: '$counterName',
-              userId: '$userId',
-              metadata: '$metadata',
-            },
-            totalValue: { $sum: '$counterValue' },
-            count: { $sum: 1 },
-          },
-        },
-        {
-          $addFields: {
-            userObjectId: { $toObjectId: '$_id.userId' },
-          },
-        },
-        {
-          // Aggregation $lookup bypasses Mongoose select:false, so project off the shared
-          // secret-free baseline plus the extra non-secret fields this route reads (email,
-          // organization). Never add credential/secret fields here.
-          $lookup: {
-            from: 'users',
-            localField: 'userObjectId',
-            foreignField: '_id',
-            pipeline: [
-              {
-                $project: {
-                  ...SAFE_USER_LOOKUP_PROJECT,
-                  email: 1,
-                  organization: 1,
-                },
-              },
-            ],
-            as: 'user',
-          },
-        },
-        {
-          $unwind: {
-            path: '$user',
-            preserveNullAndEmptyArrays: true,
-          },
-        },
-        {
-          $addFields: {
-            userEmail: { $ifNull: ['$user.email', ''] },
-          },
-        },
-        {
-          $group: {
-            // Outer key includes metadata, so every user in users[] shares the parent
-            // log's metadata. Consumers read it from the parent row, not per user.
-            _id: {
-              date: '$_id.date',
-              counterName: '$_id.counterName',
-              metadata: '$_id.metadata',
-            },
-            totalValue: { $sum: '$totalValue' },
-            count: { $sum: '$count' },
-            uniqueUsers: { $addToSet: '$_id.userId' },
-            users: {
-              $push: {
-                userId: '$_id.userId',
-                userEmail: '$userEmail',
-                userOrganization: '$user.organization',
-                totalValue: '$totalValue',
-                count: '$count',
-              },
-            },
-          },
-        },
-        {
-          $project: {
-            _id: 0,
-            date: '$_id.date',
-            counterName: '$_id.counterName',
-            metadata: '$_id.metadata',
-            totalValue: 1,
-            count: 1,
-            uniqueUserCount: { $size: '$uniqueUsers' },
-            users: 1,
-          },
-        },
-        { $sort: { date: 1, counterName: 1 } },
-      ];
+      // Pipeline lives in buildCounterLogsPipeline (exported, so the test asserts the real thing).
+      const pipeline = buildCounterLogsPipeline(matchCondition);
 
+      // No `hint`: measured with explain() on this collection's real index set, forcing
+      // { datetime: 1 } makes Mongo examine 4x the documents on the filtered shape the UI
+      // actually sends (orgs/excludeOrgs are always present), because it blocks the
+      // { datetime, counterName, userOrganization } compound index the planner would pick.
+      // A hint would also hard-fail the whole request if the index were ever absent.
       const result = await CounterLog.aggregate(convertPipelineForDocumentDB(pipeline), {
         allowDiskUse: true,
-        hint: { datetime: 1 },
         maxTimeMS: AGGREGATION_MAX_TIME_MS,
       });
 

--- a/apps/client/pages/api/users/counterLogs.ts
+++ b/apps/client/pages/api/users/counterLogs.ts
@@ -1,4 +1,4 @@
-import { Permission, dayjs, type CompletionSource } from '@bike4mind/common';
+import { Permission, dayjs, SAFE_USER_LOOKUP_PROJECT, type CompletionSource } from '@bike4mind/common';
 import {
   CounterLog,
   DailyReport,
@@ -9,7 +9,6 @@ import {
   convertPipelineForDocumentDB,
 } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
-import { User } from '@bike4mind/database';
 import { Logger } from '@bike4mind/observability';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import { counterService } from '@bike4mind/services';
@@ -21,6 +20,10 @@ import { BadRequestError, ForbiddenError } from '@server/utils/errors';
 import { sendMaybeGzip } from '@server/utils/sendMaybeGzip';
 
 dayjs.extend(isSameOrBefore);
+
+// Lambda gives this route a 60s budget; leave headroom for the response to serialize/gzip
+// after the DB call returns rather than let a slow query eat the whole timeout.
+const AGGREGATION_MAX_TIME_MS = 45000;
 
 const CounterLogsQuerySchema = z.object({
   startDate: z.string(),
@@ -164,19 +167,64 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
         matchCondition.userOrganization = { $nin: excludeOrgs };
       }
 
-      // For non-report requests, return the aggregated logs
+      // For non-report requests, return the aggregated logs.
+      //
+      // The user $lookup runs AFTER the first $group, not before: userEmail/userOrganization
+      // are functionally determined by userId alone, so grouping first and joining once per
+      // resulting (date, counterName, userId, metadata) row is equivalent to the old
+      // per-raw-document join but touches far fewer rows (this collection's own bloat problem
+      // is metadata fragmentation, not user cardinality - see the Phase 2 plan). It also lets
+      // the join use the standard localField/foreignField form (an index-eligible equality
+      // join) instead of a correlated let/pipeline/$expr subquery, which is the only one of its
+      // kind on this collection - every other lookup here uses localField/foreignField.
       const pipeline = [
         {
           $match: matchCondition,
         },
         {
+          $addFields: {
+            dateString: {
+              $dateToString: {
+                format: '%Y-%m-%d',
+                date: '$datetime',
+                timezone: 'UTC',
+              },
+            },
+          },
+        },
+        {
+          $group: {
+            // metadata is part of the group key; storing it again as a field would
+            // duplicate it in every user pushed below.
+            _id: {
+              date: '$dateString',
+              counterName: '$counterName',
+              userId: '$userId',
+              metadata: '$metadata',
+            },
+            totalValue: { $sum: '$counterValue' },
+            count: { $sum: 1 },
+          },
+        },
+        {
+          $addFields: {
+            userObjectId: { $toObjectId: '$_id.userId' },
+          },
+        },
+        {
+          // Aggregation $lookup bypasses Mongoose select:false, so project off the shared
+          // secret-free baseline plus the extra non-secret fields this route reads (email,
+          // organization). Never add credential/secret fields here.
           $lookup: {
-            from: User.collection.name,
-            let: { userId: '$userId' },
+            from: 'users',
+            localField: 'userObjectId',
+            foreignField: '_id',
             pipeline: [
               {
-                $match: {
-                  $expr: { $eq: ['$_id', { $toObjectId: '$$userId' }] },
+                $project: {
+                  ...SAFE_USER_LOOKUP_PROJECT,
+                  email: 1,
+                  organization: 1,
                 },
               },
             ],
@@ -191,30 +239,7 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
         },
         {
           $addFields: {
-            dateString: {
-              $dateToString: {
-                format: '%Y-%m-%d',
-                date: '$datetime',
-                timezone: 'UTC',
-              },
-            },
             userEmail: { $ifNull: ['$user.email', ''] },
-          },
-        },
-        {
-          $group: {
-            // metadata is part of the group key; storing it again as a field would
-            // duplicate it in every user pushed below.
-            _id: {
-              date: '$dateString',
-              counterName: '$counterName',
-              userId: '$userId',
-              userEmail: '$userEmail',
-              userOrganization: '$user.organization',
-              metadata: '$metadata',
-            },
-            totalValue: { $sum: '$counterValue' },
-            count: { $sum: 1 },
           },
         },
         {
@@ -232,8 +257,8 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
             users: {
               $push: {
                 userId: '$_id.userId',
-                userEmail: '$_id.userEmail',
-                userOrganization: '$_id.userOrganization',
+                userEmail: '$userEmail',
+                userOrganization: '$user.organization',
                 totalValue: '$totalValue',
                 count: '$count',
               },
@@ -255,7 +280,11 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
         { $sort: { date: 1, counterName: 1 } },
       ];
 
-      const result = await CounterLog.aggregate(convertPipelineForDocumentDB(pipeline));
+      const result = await CounterLog.aggregate(convertPipelineForDocumentDB(pipeline), {
+        allowDiskUse: true,
+        hint: { datetime: 1 },
+        maxTimeMS: AGGREGATION_MAX_TIME_MS,
+      });
 
       // Cache the result with 1 hour expiry
       try {


### PR DESCRIPTION
## Summary
M1 of the counterLogs Phase 2 plan (`~/Dev/planning/bike4mind/counterlogs-phase2-payload-reduction.md`).

The user `$lookup` in the `{logs}` branch of `GET /api/users/counterLogs` ran on **every raw matched document** (~46k in a 7-day staging window) using a correlated `let`/`pipeline`/`$expr` subquery, before any grouping. It now groups first (`date, counterName, userId, metadata`) and joins **once per grouped row** using the index-eligible `localField`/`foreignField` form.

Also in scope:
- **Inner `$project` on the `$lookup`** (`SAFE_USER_LOOKUP_PROJECT` + `email`/`organization`) so the join stops materializing entire user documents into the pipeline.
- `$convert … onError: null` instead of `$toObjectId`, so a non-ObjectId `userId` (e.g. `'SYSTEM'`) fails to join rather than aborting the whole aggregation with a 500.
- `allowDiskUse` + `maxTimeMS` on the aggregation.
- Pipeline extracted to an exported `buildCounterLogsPipeline` so tests can assert the real thing.

## On the projection: this is hardening, not a leak fix
To be precise, since an earlier version of this description overstated it: **there was no reachable leak on `main`.** The outer `$group` emits only `_id` plus accumulators, and the final `$project` emits only named fields, so the full user document could never reach the HTTP response. The inner `$project` is defense-in-depth plus a genuine pipeline-memory reduction.

The real security win is different and verifiable: `scripts/check-user-lookup-projection.mjs` matches a **literal** `from: 'users'`, so it previously **skipped this file entirely** (it used `from: User.collection.name`). It now inspects it — confirmed by attempted refutation: remove the `$project` and the guard exits 1.

## Why no `hint`
An earlier commit added `hint: { datetime: 1 }`, copying `CounterLogModel.ts`. That was wrong here and has been removed. Measured with `explain()` against this collection's real index set, on the filtered shape the UI actually sends (`useAnalyticsData` always sends `orgs`/`excludeOrgs`):

| | index chosen | docsExamined |
|---|---|---|
| no hint | `datetime_1_counterName_1_userOrganization_1` | 10,000 |
| `hint: {datetime:1}` | `datetime_1` | **40,000** |

The convention doesn't transfer: both hinted methods in `CounterLogModel` match on **datetime only**, where it's the sole applicable index. A hint also hard-fails the entire request if the index is ever absent, which is reachable on a fresh database since `autoIndex` is fire-and-forget.

## Verification
Re-measured against the **current** pipeline (after the review fold-ins removed the `hint` and switched to `$convert`), on real staging data over a 7-day window:

| shape | old rows | new rows | deep-equal | old | new | speedup |
|---|---|---|---|---|---|---|
| unfiltered | 13,518 | 13,518 | ✅ byte-identical | 9,866ms | 3,905ms | **2.53x** |
| **filtered** (the shape the UI sends) | 13,518 | 13,518 | ✅ byte-identical | 8,580ms | 4,119ms | **2.08x** |

The filtered shape had never been measured before — it's the one the `hint` was pessimizing, so it's now covered explicitly. Both shapes produce identical output (canonicalized; row order between same-date/same-counterName groups was never a guaranteed contract).

Independently re-verified on a fixture with an orphan `userId` and an org-less user: identical output. The mechanism is that `$group._id` *omits* missing field paths rather than storing `null`.

**Tests** (`apps/client/pages/api/users/__tests__/counterLogs.test.ts`, real `createMongoServer()`), 4 tests, each mutation-verified against the production file:
- Grouping/count correctness incl. the orphaned-user `$ifNull` path — removing `$ifNull` fails it.
- The `$lookup` projection asserted against the **exported builder the handler calls** — deleting the `$project` fails it, and widening it with `password: 1` fails it.
- Metadata fragmentation unchanged (that's M2's job).
- Non-ObjectId `userId` (`'SYSTEM'`) does not abort the aggregation — reverting `$convert` to `$toObjectId` fails it with `Failed to parse objectId 'SYSTEM'`, which is exactly the 500 the hardening prevents.

## Test plan
- [x] `Run Tests (client)` green in CI, with this file confirmed executed
- [x] `pnpm --filter client typecheck` clean on the changed files (3 pre-existing errors are in gitignored `packages/premium/*` overlay checkouts)
- [x] `eslint` clean; `check-user-lookup-projection.mjs` passes at HEAD and fails when mutated
- [x] Staging before/after: content-identical, ~2x faster

## Deferred (recorded in the plan's Follow-ups)
- `users[].userOrganization` is always absent — the User schema has `organizationId`, not `organization`. Pre-existing on `main`; fixing it inside M1 would have broken the byte-identical parity check. M2 owns it.
- `maxTimeMS` expiry surfaces as a 500 that the UI swallows into an empty dashboard — error-mapping decision, better handled with M5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
