### PR TITLE
fix(client): correct the Hearth roster's failure states, growth bounds, and gear gate

### DIFF
--- a/apps/client/app/components/hearth/HearthChannelsView.test.tsx
+++ b/apps/client/app/components/hearth/HearthChannelsView.test.tsx
@@ -220,4 +220,58 @@ describe('HearthChannelsView', () => {
       expect(screen.getAllByText('posted!')).toHaveLength(1);
     });
   });
+  // The `hearth` gear unlocks on owning >= 1 channel, so THIS request is what
+  // earns the reveal - but useGearsStatus caches for 5 minutes, so without an
+  // explicit invalidation the sidenav row the user just earned stays hidden for
+  // up to that long. Now that the row fails closed, hidden is the default.
+  it('invalidates the gears status after creating a channel, so the reveal is not stale', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // The helper only invalidates while the gear is still LOCKED, so the cache
+    // has to hold that state or the call correctly no-ops and proves nothing.
+    queryClient.setQueryData(['gears', 'status'], { gears: [{ key: 'hearth', unlocked: false }] });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    render(
+      <CssVarsProvider theme={appTheme}>
+        <QueryClientProvider client={queryClient}>
+          <HearthChannelsView />
+        </QueryClientProvider>
+      </CssVarsProvider>
+    );
+
+    apiPostMock.mockResolvedValueOnce({ data: { channel: { id: 'ch-2', name: 'ops2' } } });
+    // Joy Input renders the testid on a wrapper; the native input is inside it.
+    const nameInput = (await screen.findByTestId('hearth-new-channel-input')).querySelector('input');
+    fireEvent.change(nameInput!, { target: { value: 'ops2' } });
+    fireEvent.click(screen.getByTestId('hearth-create-channel-btn'));
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/api/hearth/channels', { name: 'ops2' }));
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: ['gears', 'status'] }))
+    );
+  });
+
+  it('does not invalidate the gears status once the gear is already unlocked', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['gears', 'status'], { gears: [{ key: 'hearth', unlocked: true }] });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    render(
+      <CssVarsProvider theme={appTheme}>
+        <QueryClientProvider client={queryClient}>
+          <HearthChannelsView />
+        </QueryClientProvider>
+      </CssVarsProvider>
+    );
+
+    apiPostMock.mockResolvedValueOnce({ data: { channel: { id: 'ch-2', name: 'ops2' } } });
+    // Joy Input renders the testid on a wrapper; the native input is inside it.
+    const nameInput = (await screen.findByTestId('hearth-new-channel-input')).querySelector('input');
+    fireEvent.change(nameInput!, { target: { value: 'ops2' } });
+    fireEvent.click(screen.getByTestId('hearth-create-channel-btn'));
+
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalledWith('/api/hearth/channels', { name: 'ops2' }));
+    // Every subsequent channel would otherwise re-fetch the whole gears catalog.
+    expect(invalidateSpy).not.toHaveBeenCalledWith(expect.objectContaining({ queryKey: ['gears', 'status'] }));
+  });
 });

--- a/apps/client/app/components/hearth/HearthChannelsView.tsx
+++ b/apps/client/app/components/hearth/HearthChannelsView.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { IHearthEventAction } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
 import { useWebsocket } from '@client/app/contexts/WebsocketContext';
+import { invalidateGearsStatusWhileLocked } from '@client/app/hooks/useGearsStatus';
 import { useActorColor } from './actorColors';
 import HearthPresencePanel from './HearthPresencePanel';
 
@@ -91,6 +92,13 @@ export default function HearthChannelsView() {
     onSuccess: () => {
       setNewChannelName('');
       queryClient.invalidateQueries({ queryKey: ['hearth', 'channels'] });
+      // The `hearth` gear unlocks on owning >=1 channel, so this request is what
+      // earns it - but useGearsStatus has staleTime: 5 * 60_000, so without this
+      // the reveal the user just paid for is invisible for up to five minutes
+      // (and now that the sidenav row fails CLOSED, so is the row). The helper
+      // no-ops once the gear is already unlocked, so this costs nothing after
+      // the first channel.
+      invalidateGearsStatusWhileLocked(queryClient, ['hearth']);
     },
   });
 

--- a/apps/client/app/components/hearth/HearthPresencePanel.test.tsx
+++ b/apps/client/app/components/hearth/HearthPresencePanel.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
@@ -126,5 +126,75 @@ describe('HearthPresencePanel', () => {
     await pushWs({ action: 'hearth_event', event: { channelId: 'ch-1', kind: 'message' } });
 
     await waitFor(() => expect(apiGetMock).toHaveBeenCalledTimes(1));
+  });
+  // The four cases below all carry comments in the component asserting they
+  // matter, and none of them were exercised.
+
+  it('a failed load says so, and never claims the channel is empty', async () => {
+    apiGetMock.mockRejectedValue(new Error('boom'));
+    renderPanel();
+
+    expect(await screen.findByTestId('hearth-presence-error')).toBeInTheDocument();
+    // The distinction is the whole point: "nobody is here" is a claim about the
+    // world, and a 500 is not evidence for it. With retry: false and no refetch
+    // on focus, that wrong claim used to be permanent.
+    expect(screen.queryByTestId('hearth-presence-empty')).not.toBeInTheDocument();
+  });
+
+  it('a failed load can be retried, since nothing else will', async () => {
+    apiGetMock.mockRejectedValueOnce(new Error('boom'));
+    renderPanel();
+
+    const retry = await screen.findByTestId('hearth-presence-retry-btn');
+    apiGetMock.mockResolvedValue(respondWith([row('busy', 'running')]));
+    fireEvent.click(retry);
+
+    await screen.findByText('Working');
+    expect(screen.queryByTestId('hearth-presence-error')).not.toBeInTheDocument();
+  });
+
+  it('an unknown state falls back to Working rather than to the top of the roster', async () => {
+    apiGetMock.mockResolvedValue(respondWith([row('mystery', 'ascended')]));
+    renderPanel();
+
+    // Guessing at a state must never escalate: an unrecognized value renders as
+    // the neutral working case, not as a claim on the human's attention.
+    expect(await screen.findByTestId('hearth-presence-state-chip')).toHaveTextContent('Working');
+  });
+
+  it('dims a stale row without dimming the timestamp that explains why', async () => {
+    apiGetMock.mockResolvedValue(
+      respondWith([
+        // staleAfterMs is 300000, so this row is well past it.
+        row('old', 'idle', { lastSeen: new Date(Date.now() - 45 * 60 * 1000).toISOString() }),
+      ])
+    );
+    renderPanel();
+
+    const rowEl = await screen.findByTestId('hearth-presence-row');
+    expect(rowEl).toHaveStyle({ opacity: '0.7' });
+    // Not 0.6: multiplied by the row's dim that gave ~0.36, below AA, on the one
+    // element carrying the staleness information.
+    expect(screen.getByTestId('hearth-presence-last-seen')).toHaveStyle({ opacity: '1' });
+    expect(screen.getByTestId('hearth-presence-last-seen')).toHaveTextContent('45m ago');
+  });
+
+  it('a fresh row leaves the timestamp de-emphasized', async () => {
+    apiGetMock.mockResolvedValue(respondWith([row('busy', 'running')]));
+    renderPanel();
+
+    await screen.findByText('Working');
+    expect(screen.getByTestId('hearth-presence-row')).toHaveStyle({ opacity: '1' });
+    expect(screen.getByTestId('hearth-presence-last-seen')).toHaveStyle({ opacity: '0.6' });
+  });
+
+  it('caps its own height so the roster cannot crowd out the composer', async () => {
+    renderPanel();
+    // Rows are permanent and per-session, so without this the panel grows without
+    // bound and the event stream - the only shrinkable child of the column -
+    // absorbs all of it until the composer is clipped out of the viewport.
+    const panel = await screen.findByTestId('hearth-presence-panel');
+    expect(panel).toHaveStyle({ overflowY: 'auto' });
+    expect(getComputedStyle(panel).maxHeight).toBe('30dvh');
   });
 });

--- a/apps/client/app/components/hearth/HearthPresencePanel.tsx
+++ b/apps/client/app/components/hearth/HearthPresencePanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Box, Chip, Sheet, Stack, Typography } from '@mui/joy';
+import { Box, Chip, Link, Sheet, Stack, Typography } from '@mui/joy';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { IHearthEventAction, ICcAgentStatus } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
@@ -53,6 +53,24 @@ const REFRESH_COALESCE_MS = 1000;
  * roster left open must not keep claiming an actor was seen "just now".
  */
 const CLOCK_TICK_MS = 30 * 1000;
+
+/**
+ * Caps the roster's share of the column. Rows are per-session and nothing
+ * deletes them, so an unbounded panel grows without limit; in this flex column
+ * the event stream is the only child that can shrink, so it absorbed all of it
+ * and at roughly 20 rows the composer was pushed out of a `100dvh; overflow:
+ * hidden` root - clipped rather than scrolled to, leaving no way to post.
+ */
+const MAX_ROSTER_HEIGHT = '30dvh';
+
+/**
+ * Dim for a stale row. Applied to the ROW only: it used to compound with the
+ * last-seen line's own 0.6 for an effective 0.36, roughly 2:1 on the soft
+ * background and below AA - and it landed on the one element that carries the
+ * staleness information. Since rows never expire, stale is the majority state of
+ * an aged roster, so this is the common case rather than an edge one.
+ */
+const STALE_ROW_OPACITY = 0.7;
 
 function useNow(): number {
   const [now, setNow] = useState(() => Date.now());
@@ -131,11 +149,47 @@ export default function HearthPresencePanel({ channelId }: { channelId: string }
   const staleAfterMs = roster.data?.staleAfterMs;
 
   return (
-    <Sheet variant="soft" sx={{ p: 1.5, borderRadius: 0 }} data-testid="hearth-presence-panel">
+    <Sheet
+      variant="soft"
+      sx={{ p: 1.5, borderRadius: 0, maxHeight: MAX_ROSTER_HEIGHT, overflowY: 'auto' }}
+      data-testid="hearth-presence-panel"
+    >
       <Typography level="title-sm" sx={{ mb: rows.length > 0 ? 1 : 0 }}>
         Who is here
       </Typography>
-      {rows.length === 0 ? (
+      {/*
+        Loading and failure must never render as "nobody is here". All three
+        collapsed into the empty message before, and the error version was
+        STICKY: the global query defaults are retry: false with no refetch on
+        focus or reconnect, so one 500 or one post-expiry 401 left the panel
+        asserting the channel was empty until a later presence push happened to
+        arrive - which a channel full of quiet actors never sends. A wrong claim
+        about who is present is worse than admitting we do not know yet.
+
+        Deliberately not `placeholderData: keepPreviousData`: on a channel switch
+        that would show the PREVIOUS channel's actors under the new channel's
+        heading, trading a momentary blank for a momentary lie.
+      */}
+      {roster.isPending ? (
+        <Typography level="body-xs" sx={{ opacity: 0.7 }} data-testid="hearth-presence-loading">
+          Loading presence...
+        </Typography>
+      ) : roster.isError ? (
+        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+          <Typography level="body-xs" color="danger" data-testid="hearth-presence-error">
+            Could not load presence.
+          </Typography>
+          {/* The only way back: nothing else retries this query. */}
+          <Link
+            level="body-xs"
+            component="button"
+            onClick={() => void roster.refetch()}
+            data-testid="hearth-presence-retry-btn"
+          >
+            Retry
+          </Link>
+        </Stack>
+      ) : rows.length === 0 ? (
         <Typography level="body-xs" sx={{ opacity: 0.7 }} data-testid="hearth-presence-empty">
           No presence reported in this channel yet.
         </Typography>
@@ -155,7 +209,7 @@ export default function HearthPresencePanel({ channelId }: { channelId: string }
                 spacing={1}
                 alignItems="center"
                 flexWrap="wrap"
-                sx={{ opacity: stale ? 0.6 : 1 }}
+                sx={{ opacity: stale ? STALE_ROW_OPACITY : 1 }}
                 data-testid="hearth-presence-row"
               >
                 <Box
@@ -189,7 +243,9 @@ export default function HearthPresencePanel({ channelId }: { channelId: string }
                     {row.reason}
                   </Typography>
                 )}
-                <Typography level="body-xs" sx={{ opacity: 0.6 }} data-testid="hearth-presence-last-seen">
+                {/* Full strength when stale: this is the element that explains
+                    the dim, so it must not be dimmed by it. */}
+                <Typography level="body-xs" sx={{ opacity: stale ? 1 : 0.6 }} data-testid="hearth-presence-last-seen">
                   {formatLastSeen(row.lastSeen, now)}
                 </Typography>
               </Stack>

--- a/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.test.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.test.tsx
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+/**
+ * The two gates on the Hearth nav row, which had no test at all.
+ *
+ * The row is DOUBLE gated and the two halves fail in OPPOSITE directions on
+ * purpose, which is the part worth pinning: the experimental flag fails closed
+ * (no flag, no row), and so does the gear - unlike the pre-Gears rows beside it,
+ * where an unknown gear state must not remove navigation the user already had.
+ */
+const { useFeatureEnabledMock, useGearUnlocksMock } = vi.hoisted(() => ({
+  useFeatureEnabledMock: vi.fn(),
+  useGearUnlocksMock: vi.fn(),
+}));
+
+vi.mock('@client/app/hooks/useFeatureEnabled', () => ({
+  useFeatureEnabled: () => ({ isFeatureEnabled: useFeatureEnabledMock }),
+}));
+vi.mock('@client/app/hooks/useGearsStatus', () => ({ useGearUnlocks: useGearUnlocksMock }));
+vi.mock('@client/app/hooks/useAdminSettingsCache', () => ({
+  useAdminSettingsCache: () => ({ isFeatureEnabled: () => false }),
+}));
+vi.mock('@client/app/contexts/UserContext', () => ({ useUser: () => undefined }));
+vi.mock('@client/app/hooks/data/opti', () => ({ useOptiAccess: () => false }));
+vi.mock('@client/app/components/Files/Browser', () => ({
+  useFileBrowser: () => ({ open: false, setOpen: vi.fn() }),
+}));
+vi.mock('@client/app/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+vi.mock('@client/app/hooks/useHelpPanel', () => ({
+  useHelpPanel: () => false,
+  openHelpPanel: vi.fn(),
+}));
+vi.mock('@client/app/premium-generated/premiumRoutes.generated', () => ({ premiumRoutes: [] }));
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/new', search: {} }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+vi.mock('..', () => ({ useNotebookLayout: () => vi.fn() }));
+
+import SidenavNav from './SidenavNav';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+function renderNav() {
+  return render(
+    <CssVarsProvider theme={appTheme}>
+      <SidenavNav />
+    </CssVarsProvider>
+  );
+}
+
+const hearthRow = () => screen.queryByTestId('sidenav-nav-hearth');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useFeatureEnabledMock.mockImplementation((key: string) => key === 'enableHearth');
+  useGearUnlocksMock.mockReturnValue({ hearth: true });
+});
+
+describe('SidenavNav Hearth row', () => {
+  it('shows when the flag is on and the gear is earned', () => {
+    renderNav();
+    expect(hearthRow()).toBeInTheDocument();
+  });
+
+  it('hides when the experimental flag is off, even with the gear earned', () => {
+    useFeatureEnabledMock.mockReturnValue(false);
+    renderNav();
+    expect(hearthRow()).not.toBeInTheDocument();
+  });
+
+  it('hides when the gear is explicitly unearned', () => {
+    useGearUnlocksMock.mockReturnValue({ hearth: false });
+    renderNav();
+    expect(hearthRow()).not.toBeInTheDocument();
+  });
+
+  // The three cases below are the fail-CLOSED direction, and all three used to
+  // REVEAL the row. `gearOpen` treats an unknown gear state as open so that a
+  // loading state or a renamed key cannot delete navigation that predates Gears;
+  // Hearth is net-new, so there is nothing to preserve and the reasoning inverts.
+  it('hides while the gear status is still loading', () => {
+    useGearUnlocksMock.mockReturnValue(undefined);
+    renderNav();
+    expect(hearthRow()).not.toBeInTheDocument();
+  });
+
+  it('hides when an admin disables the gear, which drops the key from the response', () => {
+    // /api/gears/status omits admin-disabled gears entirely rather than
+    // returning them as false, so "key absent" is the shape a disabled gear
+    // actually takes - and under gearOpen that made disabling it reveal the row
+    // permanently to every flag-enabled user.
+    useGearUnlocksMock.mockReturnValue({ projects: true });
+    renderNav();
+    expect(hearthRow()).not.toBeInTheDocument();
+  });
+
+  it('hides when the gear status errors', () => {
+    useGearUnlocksMock.mockReturnValue({});
+    renderNav();
+    expect(hearthRow()).not.toBeInTheDocument();
+  });
+
+  // Guards the boundary between the two helpers: switching Hearth to fail-closed
+  // must not drag the pre-Gears rows along with it.
+  it('still shows a pre-Gears row whose gear key is absent', () => {
+    useFeatureEnabledMock.mockReturnValue(true);
+    useGearUnlocksMock.mockReturnValue({});
+    renderNav();
+    expect(screen.getByTestId('sidenav-nav-files')).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/SidenavNav.tsx
@@ -82,6 +82,15 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
   // must NOT silently remove core navigation app-wide - only a key the server
   // returns as `false` (a known, genuinely-unearned gear) hides its row.
   const gearOpen = (key: GearKey) => gearUnlocks === undefined || !(key in gearUnlocks) || gearUnlocks[key] === true;
+  // Fail CLOSED, for rows that did NOT exist before Gears. The fail-open above
+  // protects navigation users already had; a net-new earned row has nothing to
+  // preserve, and its failure modes run the other way. `/api/gears/status`
+  // omits admin-disabled gears from the response entirely, so under gearOpen
+  // turning a gear OFF in Manage Gears satisfied `!(key in gearUnlocks)` and
+  // pinned the unearned row visible for every flag-enabled user - the opposite
+  // of what the admin asked for. Same on any status error. Only an explicit
+  // `true` reveals these.
+  const gearEarned = (key: GearKey) => gearUnlocks?.[key] === true;
   const helpOpen = useHelpPanel(s => s.open);
 
   const closeOnMobile = () => {
@@ -234,10 +243,12 @@ const SidenavNav = ({ section = 'all' }: { section?: 'pinned' | 'scroll' | 'all'
           },
         ]
       : []),
-    // Double-gated like the earned destinations above: the experimental flag says
-    // the feature exists for this user, the gear says they have actually used it
-    // (>=1 channel). Sits beside Tavern/Gears - the shared-log destination.
-    ...(isFeatureEnabled('enableHearth') && gearOpen('hearth')
+    // Double-gated: the experimental flag says the feature exists for this user,
+    // the gear says they have actually used it (>=1 channel). Sits beside
+    // Tavern/Gears - the shared-log destination. Uses gearEarned, not gearOpen:
+    // this row is net-new, so an unknown gear state must hide it rather than
+    // reveal it.
+    ...(isFeatureEnabled('enableHearth') && gearEarned('hearth')
       ? [
           {
             key: 'hearth',

--- a/apps/client/pages/api/hearth/__tests__/hearthRoutes.test.ts
+++ b/apps/client/pages/api/hearth/__tests__/hearthRoutes.test.ts
@@ -52,8 +52,12 @@ const {
 // of each verb (per-route middleware like csrf/rate-limit is skipped so the
 // business logic runs directly).
 vi.mock('@server/middlewares/baseApi', () => ({
-  baseApi: () => {
+  // Records the CONFIG and the full middleware chain, not just the terminal
+  // handler. Without `_config` no test could see a route's requiredScopes, so a
+  // suite that read as scope coverage would have passed with requiredScopes: [].
+  baseApi: (config?: unknown) => {
     const routes: Record<string, (req: unknown, res: unknown) => Promise<unknown>> = {};
+    const middleware: Record<string, unknown[]> = {};
     const uses: unknown[] = [];
     const chain = {
       use: (mw: unknown) => {
@@ -62,19 +66,27 @@ vi.mock('@server/middlewares/baseApi', () => ({
       },
       get: (...handlers: unknown[]) => {
         routes.get = handlers[handlers.length - 1] as (typeof routes)['get'];
+        middleware.get = handlers.slice(0, -1);
         return chain;
       },
       post: (...handlers: unknown[]) => {
         routes.post = handlers[handlers.length - 1] as (typeof routes)['post'];
+        middleware.post = handlers.slice(0, -1);
         return chain;
       },
       _routes: routes,
+      _middleware: middleware,
       _uses: uses,
+      _config: config,
     };
     return chain;
   },
 }));
-vi.mock('@server/middlewares/rateLimit', () => ({ rateLimit: () => vi.fn() }));
+// Records the options each route asks for, so a limit can be asserted by value
+// rather than by "some middleware is present".
+vi.mock('@server/middlewares/rateLimit', () => ({
+  rateLimit: (options: unknown) => Object.assign(vi.fn(), { _rateLimit: options }),
+}));
 vi.mock('@server/middlewares/csrfProtection', () => ({ csrfProtection: () => vi.fn() }));
 vi.mock('@server/middlewares/requireUser', () => ({ requireUser: vi.fn() }));
 vi.mock('@server/middlewares/featureFlag', () => ({ requireFeatureEnabled: featureGateMock }));
@@ -104,7 +116,18 @@ vi.mock('@bike4mind/hearth', async importOriginal => ({
 }));
 
 type Handler = (req: Request, res: Response) => Promise<unknown>;
-type MockedRouter = { _routes: Record<string, Handler>; _uses: unknown[] };
+type MockedRouter = {
+  _routes: Record<string, Handler>;
+  _middleware: Record<string, unknown[]>;
+  _uses: unknown[];
+  _config?: { requiredScopes?: string[] };
+};
+
+/** The rate-limit options a route registered for a verb, or undefined if none. */
+function rateLimitOptions(router: MockedRouter, verb: 'get' | 'post'): unknown {
+  const tagged = (router._middleware[verb] ?? []).find(mw => (mw as { _rateLimit?: unknown })._rateLimit);
+  return (tagged as { _rateLimit?: unknown } | undefined)?._rateLimit;
+}
 
 const eventsRouter = (await import('../events')).default as unknown as MockedRouter;
 const catchupRouter = (await import('../catchup')).default as unknown as MockedRouter;
@@ -358,14 +381,29 @@ describe('GET /api/hearth/presence', () => {
     expect(presenceForChannelMock).not.toHaveBeenCalled();
   });
 
-  it('is read-only: a key with only hearth:read may read the roster', async () => {
-    const req = makeReq({}, { channelId: 'ch-1' });
-    (req as unknown as { apiKeyInfo: { scopes: string[] } }).apiKeyInfo = { scopes: ['hearth:read'] };
-    await get()(req, makeRes());
+  // This case used to be titled "a key with only hearth:read may read the
+  // roster" while asserting nothing of the kind: scope enforcement happens in
+  // baseApi's requiredScopes, which the harness discarded, and the handler never
+  // reads apiKeyInfo - so it passed identically with no apiKeyInfo at all, and
+  // would have passed with requiredScopes: []. Split into the two claims that
+  // are actually checkable here.
+  it('declares the read scope list, so a read-only key is admitted', () => {
+    // OR semantics, matching the sibling routes: any one of these suffices.
+    expect(presenceRouter._config?.requiredScopes).toEqual(['hearth:read', 'hearth:write', 'admin:*']);
+  });
+
+  it('consumes nothing: reading a roster advances no cursor and mints no actor', async () => {
+    await get()(makeReq({}, { channelId: 'ch-1' }), makeRes());
     expect(presenceForChannelMock).toHaveBeenCalledWith('u1', 'ch-1');
-    // Reading a roster consumes nothing.
     expect(storeMock.setCursor).not.toHaveBeenCalled();
     expect(ensureActorMock).not.toHaveBeenCalled();
+  });
+
+  // Was the only hearth route with no limit at all, and it is the most expensive
+  // one: the roster aggregation sorts on an $addFields key, so no index can serve
+  // it, over a collection that grows one permanent row per session.
+  it('is rate limited on the same budget as the other reads', () => {
+    expect(rateLimitOptions(presenceRouter, 'get')).toEqual({ limit: 120, windowMs: 60000 });
   });
 
   it('returns the repository order untouched (needs-you-first, not by recency)', async () => {

--- a/apps/client/pages/api/hearth/presence.ts
+++ b/apps/client/pages/api/hearth/presence.ts
@@ -2,6 +2,7 @@ import { hearthRepository } from '@bike4mind/database';
 import { ApiKeyScope, NotFoundError, UnauthorizedError } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { requireFeatureEnabled } from '@server/middlewares/featureFlag';
+import { rateLimit } from '@server/middlewares/rateLimit';
 import { requireUser } from '@server/middlewares/requireUser';
 import { toWireHearthPresence } from '@server/utils/hearthWire';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -21,6 +22,15 @@ const GetPresenceSchema = z.object({
 const PRESENCE_STALE_AFTER_MS = 5 * 60 * 1000;
 
 /**
+ * Matches the catchup read budget. This was the one hearth route with no limit
+ * at all, and it is the most expensive: the roster aggregation sorts on an
+ * $addFields key, so no index can serve it and mongod sorts in memory, over a
+ * collection that grows one permanent row per session. The panel already
+ * refetches at up to 1 Hz on presence traffic.
+ */
+const presenceRateLimit = rateLimit({ limit: 120, windowMs: 60000 });
+
+/**
  * GET the presence roster for a channel: one row per actor, ordered
  * needs-you-first by the repository. Read-only by construction - it advances no
  * cursor and consumes nothing - so read scope is sufficient and there is no
@@ -31,7 +41,7 @@ const handler = baseApi({
 })
   .use(requireFeatureEnabled('EnableHearth'))
   .use(requireUser)
-  .get<NextApiRequest, NextApiResponse>(async (req, res) => {
+  .get<NextApiRequest, NextApiResponse>(presenceRateLimit, async (req, res) => {
     if (!req.user?.id) throw new UnauthorizedError('User required');
 
     const { channelId } = GetPresenceSchema.parse(req.query);


### PR DESCRIPTION
Six P2 findings from the post-merge audit (#1093), grouped as the client-and-gating half. Chosen as one batch because they touch files no open Hearth PR touches, so it lands without three-way conflicts against #1090 and #1091.

The two P1s from that audit are in #1094.

## Roster panel

**Loading and failure both claimed the channel was empty.** All three states collapsed into "No presence reported in this channel yet", and the error version was *sticky*: the global query defaults are `retry: false` with no refetch on focus or reconnect, so one 500 or one post-expiry 401 left the panel asserting a channel was empty until a later presence push happened to arrive - which a channel full of quiet actors never sends. Loading, failed, and empty are now distinct, and the failed state offers the retry nothing else in the app would perform.

Deliberately *not* `placeholderData: keepPreviousData`, which was the other way to kill the empty-flash on channel switch: it would render the previous channel's actors under the new channel's heading, trading a momentary blank for a momentary lie about who is present.

**The panel could push the composer out of the viewport.** No `maxHeight`, no `overflow`, and rows never expire. In the flex column the event list is the only child with an automatic minimum size of 0, so it absorbed all the shrink; at roughly 20 rows the stream is at zero height, and because the layout root is `height: 100dvh; overflow: hidden` the composer is *clipped* rather than scrolled to - no way to post. Capped at `30dvh` with `overflowY: auto`, matching the two other growable regions in the same view.

**Stale rows fell below AA.** The row dim (`0.6`) compounded with the last-seen line's own `0.6` for an effective `0.36`, roughly 2:1 on the soft Sheet background - and it landed on the exact element the code comment names as the real staleness signal. Since rows are permanent, stale is the majority state of an aged roster, so this was the common case. The row now dims to `0.7` and the timestamp explaining the dim stays at full strength.

## Gating

**The gear half of the double gate failed open, which inverted the admin control.** `gearOpen` treats an unknown gear state as open, and `/api/gears/status` omits admin-disabled gears from the response *entirely* rather than returning them as `false`. So turning Hearth off in Manage Gears satisfied `!('hearth' in gearUnlocks)` and pinned the unearned row permanently visible for every flag-enabled user - the opposite of what the admin asked for. Same on any status error.

The fail-open is right for rows that predate Gears: a loading state or a renamed key must not silently remove navigation users already had. That rationale does not transfer to a net-new earned row, which has nothing to preserve. Added `gearEarned` (explicit `true` only) and switched Hearth to it; every pre-Gears row keeps `gearOpen`.

**The reveal the user just earned was stale for five minutes.** Creating the first channel is precisely what unlocks the gear, but the mutation never invalidated `['gears','status']` against its `staleTime: 5 * 60_000`. Now calls the existing `invalidateGearsStatusWhileLocked`, which the hook documents for this case and five other sites already use; it no-ops once the gear is unlocked, so later channels cost nothing.

**`GET /api/hearth/presence` had no rate limit** - the only hearth route without one, and the most expensive of them. The roster aggregation sorts on an `$addFields` key, so no index can serve it and mongod sorts in memory, over a collection that grows one permanent row per session, with a panel refetching at up to 1 Hz. Now 120/min, matching catchup.

## Tests

Four panel branches carried comments asserting their importance and were never exercised: stale dimming (`lastSeen` was always `new Date()`), the unknown-state fallback, the error path (`apiGetMock` never rejected), and the retry that did not exist. All four are covered now, including that a fresh row keeps its timestamp de-emphasized - so the two opacity cases pin each other.

Neither gate had any test at all. `SidenavNav.test.tsx` is new and pins both directions: shown when flag and gear agree, hidden when the flag is off, hidden when the gear is explicitly false, and hidden for all three fail-open shapes (loading, key absent, empty response). One case guards the boundary - a pre-Gears row whose key is absent must still appear, so Hearth's switch to fail-closed did not drag the others with it.

It also repairs a false assurance the audit called out. `it('is read-only: a key with only hearth:read may read the roster')` asserted none of that: scope enforcement lives in `baseApi`'s `requiredScopes`, which the test harness discarded, and `presence.ts` never reads `apiKeyInfo` - so it passed identically with no `apiKeyInfo` at all, and would still have passed with `requiredScopes: []`. The harness now records the route config and the full middleware chain, so the scope list and the rate limit are both asserted by value. That closes "nothing in the suite asserts any route's scope list" for this route and gives the other three a way to do the same.

Verified: 73 tests across the affected `apps/client` suites, `tsc --noEmit -p apps/client`, eslint clean on every touched file.

## Not in this PR

The remaining P2s from #1093 are presence-state correctness (hook tier 0/1 pinned to `running`, re-register clobbering a blocked row, the E11000 insert race, `presenceStateForReason` reading through `Object.prototype`), roster growth at the store level, hook privacy (`basename(cwd)` publishing the OS username, tier-2 values not actually a closed set), and actor-identity convergence between the two reporters. Those land in files #1090/#1091/#1094 are holding, so they follow once those merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuwWCLgi8mtWjDTDMJ6XcS