### PR TITLE
feat(publish)!: make search-engine indexing an explicit opt-in

### DIFF
--- a/apps/client/app/components/common/DiscoverableToggle.test.tsx
+++ b/apps/client/app/components/common/DiscoverableToggle.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes/themePrimitives';
+import { DiscoverableToggle } from './DiscoverableToggle';
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn().mockResolvedValue({ data: {} }), delete: vi.fn() },
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() } }));
+
+import { api } from '@client/app/contexts/ApiContext';
+const apiPatch = api.patch as unknown as ReturnType<typeof vi.fn>;
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const renderToggle = (props: Partial<React.ComponentProps<typeof DiscoverableToggle>> = {}) =>
+  render(
+    <Wrapper>
+      <DiscoverableToggle publicId="pub-1" initialDiscoverable={false} isOpenPublic {...props} />
+    </Wrapper>
+  );
+
+const toggle = () => screen.getByTestId('discoverable-toggle') as HTMLInputElement;
+
+beforeEach(() => {
+  apiPatch.mockReset().mockResolvedValue({ data: {} });
+});
+
+describe('DiscoverableToggle', () => {
+  it('renders nothing when the artifact is not open-public', () => {
+    renderToggle({ isOpenPublic: false });
+    expect(screen.queryByTestId('discoverable-toggle')).toBeNull();
+  });
+
+  it('reflects the stored value', () => {
+    renderToggle({ initialDiscoverable: true });
+    expect(toggle().checked).toBe(true);
+  });
+
+  it('PATCHes discoverable:true when switched on', async () => {
+    renderToggle();
+    fireEvent.click(toggle());
+    await waitFor(() => expect(apiPatch).toHaveBeenCalledWith('/api/publish/artifacts/pub-1', { discoverable: true }));
+  });
+
+  it('PATCHes discoverable:false when switched off', async () => {
+    renderToggle({ initialDiscoverable: true });
+    fireEvent.click(toggle());
+    await waitFor(() => expect(apiPatch).toHaveBeenCalledWith('/api/publish/artifacts/pub-1', { discoverable: false }));
+  });
+
+  it('rolls back to OFF when the opt-in request fails', async () => {
+    // The dangerous direction: the UI must never show "listed" (or stay showing a
+    // state the server did not accept) on a failed write.
+    apiPatch.mockRejectedValueOnce(new Error('nope'));
+    renderToggle();
+    fireEvent.click(toggle());
+    await waitFor(() => expect(toggle().checked).toBe(false));
+  });
+
+  it('rolls back to ON when the opt-OUT request fails, rather than claiming it is hidden', async () => {
+    apiPatch.mockRejectedValueOnce(new Error('nope'));
+    renderToggle({ initialDiscoverable: true });
+    fireEvent.click(toggle());
+    await waitFor(() => expect(toggle().checked).toBe(true));
+  });
+});

--- a/apps/client/app/components/common/DiscoverableToggle.tsx
+++ b/apps/client/app/components/common/DiscoverableToggle.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, FormControl, FormLabel, Switch, Typography } from '@mui/joy';
+import { Box, FormControl, FormHelperText, FormLabel, Switch } from '@mui/joy';
 import TravelExploreIcon from '@mui/icons-material/TravelExplore';
 import { toast } from 'sonner';
 import { updatePublishedDiscoverable } from '@client/app/utils/publishApi';
@@ -63,10 +63,13 @@ export function DiscoverableToggle({
         <TravelExploreIcon fontSize="small" />
         <Box>
           <FormLabel sx={{ mb: 0 }}>List in search engines</FormLabel>
-          <Typography level="body-xs" sx={{ opacity: 0.75 }}>
+          {/* FormHelperText, not Typography: only a FormHelperText child registers itself into
+              Joy's FormControl context and lands in the switch's aria-describedby, so a screen-
+              reader user actually hears this caveat instead of just the label. */}
+          <FormHelperText sx={{ opacity: 0.75 }}>
             Off by default. When off, the link still works for anyone you send it to - it just won&apos;t show up in
             Google. Link previews in chat apps work either way.
-          </Typography>
+          </FormHelperText>
         </Box>
       </Box>
       <Switch

--- a/apps/client/app/components/common/DiscoverableToggle.tsx
+++ b/apps/client/app/components/common/DiscoverableToggle.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { Box, FormControl, FormLabel, Switch, Typography } from '@mui/joy';
+import TravelExploreIcon from '@mui/icons-material/TravelExplore';
+import { toast } from 'sonner';
+import { updatePublishedDiscoverable } from '@client/app/utils/publishApi';
+
+export interface DiscoverableToggleProps {
+  publicId: string;
+  /** Current stored value, seeded from the live record. */
+  initialDiscoverable: boolean;
+  /** Rendered only when true - the server ANDs `discoverable` with open-public, so
+   *  offering it on a gated or non-public item would promise a no-op. */
+  isOpenPublic: boolean;
+  testIdPrefix?: string;
+}
+
+/**
+ * Search-engine opt-in for an already-published artifact. Publishing publicly means
+ * "anyone with the link may view", never "listed in Google" - so indexing is a separate
+ * switch that starts OFF, and this is where an owner turns it on.
+ *
+ * Optimistic with rollback: the switch reflects the request's outcome, never just the
+ * click, so a failed PATCH can't leave the UI claiming a page is hidden when it isn't.
+ */
+export function DiscoverableToggle({
+  publicId,
+  initialDiscoverable,
+  isOpenPublic,
+  testIdPrefix = 'discoverable',
+}: DiscoverableToggleProps) {
+  const [discoverable, setDiscoverable] = useState(initialDiscoverable);
+  const [busy, setBusy] = useState(false);
+
+  if (!isOpenPublic) return null;
+
+  const onToggle = async (next: boolean) => {
+    if (busy) return;
+    const prev = discoverable;
+    setDiscoverable(next);
+    setBusy(true);
+    try {
+      await updatePublishedDiscoverable(publicId, next);
+      toast.success(
+        next
+          ? 'Search engines may now list this page'
+          : 'Hidden from search engines - the link still works for anyone you send it to'
+      );
+    } catch {
+      setDiscoverable(prev);
+      toast.error('Failed to update search listing');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <FormControl
+      orientation="horizontal"
+      sx={{ justifyContent: 'space-between', alignItems: 'center', gap: 1 }}
+      data-testid={`${testIdPrefix}-control`}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <TravelExploreIcon fontSize="small" />
+        <Box>
+          <FormLabel sx={{ mb: 0 }}>List in search engines</FormLabel>
+          <Typography level="body-xs" sx={{ opacity: 0.75 }}>
+            Off by default. When off, the link still works for anyone you send it to - it just won&apos;t show up in
+            Google. Link previews in chat apps work either way.
+          </Typography>
+        </Box>
+      </Box>
+      <Switch
+        checked={discoverable}
+        disabled={busy}
+        onChange={e => void onToggle(e.target.checked)}
+        // On the INPUT slot, not the root: Joy spreads bare props to the root span,
+        // where a test can't read `.checked`.
+        slotProps={{ input: { 'data-testid': `${testIdPrefix}-toggle` } }}
+      />
+    </FormControl>
+  );
+}
+
+export default DiscoverableToggle;

--- a/apps/client/app/components/common/ManageSharingPanel.test.tsx
+++ b/apps/client/app/components/common/ManageSharingPanel.test.tsx
@@ -56,3 +56,41 @@ describe('ManageSharingPanel', () => {
     await waitFor(() => expect(screen.getByTestId('manage-gate-needs-public')).not.toBeNull());
   });
 });
+
+describe('ManageSharingPanel — search-listing toggle', () => {
+  it('seeds the toggle ON from a listed artifact', async () => {
+    // Pins setInitialDiscoverable: without it the switch renders OFF for an artifact
+    // that is genuinely listed, and the owner sees a state that is not the truth.
+    await renderPanel({
+      visibility: 'public',
+      accessGate: null,
+      embedOrigins: [],
+      commentPolicy: 'none',
+      discoverable: true,
+    });
+    const toggle = screen.getByTestId('manage-discoverable-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+  });
+
+  it('seeds the toggle OFF for an artifact that never opted in', async () => {
+    await renderPanel({ visibility: 'public', accessGate: null, embedOrigins: [], commentPolicy: 'none' });
+    const toggle = screen.getByTestId('manage-discoverable-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+  });
+
+  it('hides the toggle for a gated artifact (it could never take effect)', async () => {
+    await renderPanel({
+      visibility: 'public',
+      accessGate: { kind: 'passphrase' },
+      embedOrigins: [],
+      commentPolicy: 'none',
+      discoverable: true,
+    });
+    expect(screen.queryByTestId('manage-discoverable-toggle')).toBeNull();
+  });
+
+  it('hides the toggle for a private artifact', async () => {
+    await renderPanel({ visibility: 'private', accessGate: null, embedOrigins: [], commentPolicy: 'none' }, 'private');
+    expect(screen.queryByTestId('manage-discoverable-toggle')).toBeNull();
+  });
+});

--- a/apps/client/app/components/common/ManageSharingPanel.tsx
+++ b/apps/client/app/components/common/ManageSharingPanel.tsx
@@ -3,6 +3,7 @@ import { Box, CircularProgress, Divider } from '@mui/joy';
 import { ShareActions } from './ShareActions';
 import { AccessGateEditor } from './AccessGateEditor';
 import { EmbedAllowlistEditor } from './EmbedAllowlistEditor';
+import { DiscoverableToggle } from './DiscoverableToggle';
 import { getPublishedManageState, type PublishAccessGateRead } from '@client/app/utils/publishApi';
 
 export interface ManageSharingPanelProps {
@@ -24,6 +25,7 @@ export function ManageSharingPanel({ publicId, title, shareUrl, visibility }: Ma
   const [loading, setLoading] = useState(true);
   const [gate, setGate] = useState<PublishAccessGateRead>(null);
   const [initialOrigins, setInitialOrigins] = useState<string[]>([]);
+  const [initialDiscoverable, setInitialDiscoverable] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -33,6 +35,7 @@ export function ManageSharingPanel({ publicId, title, shareUrl, visibility }: Ma
         if (!active) return;
         setGate(state.accessGate);
         setInitialOrigins(state.embedOrigins);
+        setInitialDiscoverable(state.discoverable);
       })
       .finally(() => {
         if (active) setLoading(false);
@@ -57,6 +60,13 @@ export function ManageSharingPanel({ publicId, title, shareUrl, visibility }: Ma
       <ShareActions title={title} url={shareUrl} />
       <Divider />
       <AccessGateEditor publicId={publicId} visibility={visibility} initialGate={gate} onGateChange={setGate} />
+      {isOpenPublic && <Divider />}
+      <DiscoverableToggle
+        publicId={publicId}
+        initialDiscoverable={initialDiscoverable}
+        isOpenPublic={isOpenPublic}
+        testIdPrefix="manage-discoverable"
+      />
       {isOpenPublic && <Divider />}
       <EmbedAllowlistEditor
         publicId={publicId}

--- a/apps/client/app/components/common/PublishShareModal.test.tsx
+++ b/apps/client/app/components/common/PublishShareModal.test.tsx
@@ -65,7 +65,7 @@ describe('PublishShareModal — update seeds controls from the prior publication
     // The regression: without seeding, this would be 'public' + comments on.
     expect(radio('private')?.checked).toBe(true);
     expect(radio('public')?.checked).toBe(false);
-    expect((screen.getByRole('switch') as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByTestId('publish-share-comments-toggle') as HTMLInputElement).checked).toBe(false);
   });
 
   it('carries a PUBLIC, comments-open publication through unchanged', async () => {
@@ -94,7 +94,7 @@ describe('PublishShareModal — update seeds controls from the prior publication
 
     expect(radio('public')?.checked).toBe(true);
     expect(radio('private')?.checked).toBe(false);
-    expect((screen.getByRole('switch') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('publish-share-comments-toggle') as HTMLInputElement).checked).toBe(true);
   });
 });
 
@@ -134,7 +134,7 @@ describe('PublishShareModal — update re-asserts the PRESERVED comment policy',
 
     await screen.findByTestId('publish-share-mode-update');
     // Seeded on because 'restricted' still allows comments.
-    expect((screen.getByRole('switch') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('publish-share-comments-toggle') as HTMLInputElement).checked).toBe(true);
 
     fireEvent.click(screen.getByTestId('publish-share-create'));
 
@@ -158,7 +158,7 @@ describe('PublishShareModal — update re-asserts the PRESERVED comment policy',
 
     await screen.findByTestId('publish-share-mode-update');
     // Seeded off because the prior policy was 'none'.
-    expect((screen.getByRole('switch') as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByTestId('publish-share-comments-toggle') as HTMLInputElement).checked).toBe(false);
 
     fireEvent.click(screen.getByTestId('publish-share-create'));
 
@@ -443,5 +443,68 @@ describe('PublishShareModal - embed allowlist', () => {
     await renderShared({ accessGate: { kind: 'domain', allowedDomains: ['milliononmars.com'] } });
     await waitFor(() => expect(apiGet).toHaveBeenCalled());
     expect(screen.queryByTestId('publish-share-embed-section')).toBeNull();
+  });
+});
+
+describe('PublishShareModal — search-engine listing is opt-in', () => {
+  const renderModal = (props: Partial<React.ComponentProps<typeof PublishShareModal>> = {}) =>
+    render(
+      <Wrapper>
+        <PublishShareModal
+          open
+          onClose={() => {}}
+          publish={noopPublish}
+          title="My artifact"
+          defaultVisibility="public"
+          {...props}
+        />
+      </Wrapper>
+    );
+
+  it('defaults the search-listing toggle to OFF for a fresh public publish', () => {
+    renderModal();
+    const toggle = screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+  });
+
+  it('tells the user a public link stays out of search engines by default', () => {
+    renderModal();
+    // The public warning must say what "public" does NOT mean - this is the exact
+    // expectation gap that made "anyone with the link" read as "unlisted".
+    expect(screen.getByText(/stays out of search engines unless you turn on/i)).toBeTruthy();
+    expect(screen.getByText(/won't show up in Google/i)).toBeTruthy();
+  });
+
+  it('hides the toggle for a private item - it could never take effect there', () => {
+    renderModal({ defaultVisibility: 'private' });
+    expect(screen.queryByTestId('publish-share-discoverable-toggle')).toBeNull();
+  });
+
+  it('seeds the toggle ON from a prior publication that opted in', async () => {
+    renderModal({
+      resolveExisting: () =>
+        Promise.resolve({
+          title: 'My artifact',
+          versionsCount: 1,
+          slug: 's',
+          visibility: 'public',
+          commentPolicy: 'none',
+          discoverable: true,
+        }),
+    });
+    await waitFor(() => {
+      const toggle = screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement;
+      expect(toggle.checked).toBe(true);
+    });
+  });
+
+  it('does not PATCH discoverable while still staging a fresh publish', () => {
+    apiPatch.mockClear();
+    renderModal();
+    fireEvent.click(screen.getByTestId('publish-share-discoverable-toggle'));
+    // Nothing exists to PATCH yet; the choice is applied after publish succeeds.
+    expect(apiPatch).not.toHaveBeenCalledWith(expect.stringContaining('/api/publish/artifacts/'), {
+      discoverable: true,
+    });
   });
 });

--- a/apps/client/app/components/common/PublishShareModal.test.tsx
+++ b/apps/client/app/components/common/PublishShareModal.test.tsx
@@ -513,16 +513,100 @@ describe('PublishShareModal — search-engine listing is opt-in', () => {
     expect((screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement).checked).toBe(false);
   });
 
-  it('drops a staged listing choice when the user adds a gate', () => {
+  it('keeps the staged listing choice consistent with storage across a gate round-trip', () => {
+    // Review point (c): resetting on a gate PICK was local-only, because a gate is not
+    // persisted until "Update access". That made the switch read OFF while storage still
+    // said true. The switch now holds its value; what stops a gated artifact from being
+    // persisted as listed is the publish-time guard (covered separately below).
     renderModal();
     fireEvent.click(screen.getByTestId('publish-share-discoverable-toggle'));
-    // Click the underlying input: Joy puts the testid on the Radio root, which does not
-    // forward a click to the control.
+
     fireEvent.click(radio('passphrase')!);
     expect(screen.queryByTestId('publish-share-discoverable-toggle')).toBeNull();
 
     fireEvent.click(radio('none')!);
-    expect((screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement).checked).toBe(true);
+  });
+
+  const publishAndWait = async (props: Partial<React.ComponentProps<typeof PublishShareModal>> = {}) => {
+    const publish = vi.fn().mockResolvedValue({ publicId: 'pub-1', url: '/p/u/me/s', tier: 'user' });
+    render(
+      <Wrapper>
+        <PublishShareModal
+          open
+          onClose={() => {}}
+          publish={publish}
+          title="My artifact"
+          defaultVisibility="public"
+          {...props}
+        />
+      </Wrapper>
+    );
+    return publish;
+  };
+
+  it('PATCHes discoverable:true after publishing when the switch was staged ON', async () => {
+    // The feature's primary happy path: stage ON, publish, artifact becomes discoverable.
+    apiPatch.mockClear().mockResolvedValue({ data: {} });
+    await publishAndWait();
+    fireEvent.click(screen.getByTestId('publish-share-discoverable-toggle'));
+    fireEvent.click(screen.getByTestId('publish-share-create'));
+
+    await waitFor(() => expect(apiPatch).toHaveBeenCalledWith('/api/publish/artifacts/pub-1', { discoverable: true }));
+  });
+
+  it('does NOT PATCH discoverable:true when a gate was staged alongside it', async () => {
+    // The `gateKind === 'none'` conjunct is load-bearing: persisting true on a gated
+    // artifact would arm a silent opt-in for whenever the gate is later removed.
+    apiPatch.mockClear().mockResolvedValue({ data: {} });
+    await publishAndWait();
+    fireEvent.click(screen.getByTestId('publish-share-discoverable-toggle'));
+    fireEvent.click(radio('passphrase')!);
+    // The gate radio and the passphrase Input share this testid, so query by input type.
+    fireEvent.change(document.querySelector('input[type="password"]')!, {
+      target: { value: 'a-long-enough-passphrase' },
+    });
+    fireEvent.click(screen.getByTestId('publish-share-create'));
+
+    await waitFor(() => expect(screen.queryByTestId('publish-share-url')).not.toBeNull());
+    expect(apiPatch).not.toHaveBeenCalledWith('/api/publish/artifacts/pub-1', { discoverable: true });
+  });
+
+  it('PATCHes discoverable:false to DE-LIST a previously-listed artifact', async () => {
+    // finalize does not $set discoverable, so a re-publish preserves it - the OFF
+    // direction has to be written explicitly or the dialog can never turn it off.
+    apiPatch.mockClear().mockResolvedValue({ data: {} });
+    await publishAndWait({
+      resolveExisting: () =>
+        Promise.resolve({
+          title: 'My artifact',
+          versionsCount: 1,
+          slug: 's',
+          visibility: 'public',
+          commentPolicy: 'none',
+          discoverable: true,
+        }),
+    });
+    // Wait for seeding, then switch it off before publishing.
+    await waitFor(() =>
+      expect((screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement).checked).toBe(true)
+    );
+    fireEvent.click(screen.getByTestId('publish-share-discoverable-toggle'));
+    fireEvent.click(screen.getByTestId('publish-share-create'));
+
+    await waitFor(() => expect(apiPatch).toHaveBeenCalledWith('/api/publish/artifacts/pub-1', { discoverable: false }));
+  });
+
+  it('rolls the live toggle back when the PATCH fails', async () => {
+    await publishAndWait();
+    fireEvent.click(screen.getByTestId('publish-share-create'));
+    await screen.findByTestId('publish-share-url');
+
+    apiPatch.mockClear().mockRejectedValueOnce(new Error('nope'));
+    fireEvent.click(screen.getByTestId('publish-share-discoverable-toggle'));
+    await waitFor(() =>
+      expect((screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement).checked).toBe(false)
+    );
   });
 
   it('does not PATCH discoverable while still staging a fresh publish', () => {

--- a/apps/client/app/components/common/PublishShareModal.test.tsx
+++ b/apps/client/app/components/common/PublishShareModal.test.tsx
@@ -498,6 +498,33 @@ describe('PublishShareModal — search-engine listing is opt-in', () => {
     });
   });
 
+  it('drops a staged listing choice when the user switches away from Public', () => {
+    // Otherwise the flag is parked on a hidden control and silently arms itself the
+    // next time someone widens the artifact back to public.
+    renderModal();
+    fireEvent.click(screen.getByTestId('publish-share-discoverable-toggle'));
+    expect((screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(screen.getByTestId('publish-share-visibility-private'));
+    expect(screen.queryByTestId('publish-share-discoverable-toggle')).toBeNull();
+
+    // Back to Public: starts from OFF, not from the stale staged choice.
+    fireEvent.click(screen.getByTestId('publish-share-visibility-public'));
+    expect((screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('drops a staged listing choice when the user adds a gate', () => {
+    renderModal();
+    fireEvent.click(screen.getByTestId('publish-share-discoverable-toggle'));
+    // Click the underlying input: Joy puts the testid on the Radio root, which does not
+    // forward a click to the control.
+    fireEvent.click(radio('passphrase')!);
+    expect(screen.queryByTestId('publish-share-discoverable-toggle')).toBeNull();
+
+    fireEvent.click(radio('none')!);
+    expect((screen.getByTestId('publish-share-discoverable-toggle') as HTMLInputElement).checked).toBe(false);
+  });
+
   it('does not PATCH discoverable while still staging a fresh publish', () => {
     apiPatch.mockClear();
     renderModal();

--- a/apps/client/app/components/common/PublishShareModal.tsx
+++ b/apps/client/app/components/common/PublishShareModal.tsx
@@ -13,6 +13,7 @@ import {
   Radio,
   FormControl,
   FormLabel,
+  FormHelperText,
   Switch,
 } from '@mui/joy';
 import PublicIcon from '@mui/icons-material/Public';
@@ -351,14 +352,20 @@ export function PublishShareModal({
           toast.warning('Published, but enabling comments failed - you can toggle them below.');
         });
       }
-      // Only ever PATCHed when ON, and only when the artifact actually published as
-      // open-public. Staging the toggle ON and then picking Private (or adding a gate)
-      // hides the switch but leaves the flag set - persisting it there would arm a
-      // silent opt-in that fires later, the moment someone widens the artifact back to
-      // public. The server default is already false, so a failed call here leaves the
-      // artifact non-indexable: the safe direction.
-      if (discoverableOn && visibility === 'public' && gateKind === 'none') {
-        await updatePublishedDiscoverable(r.publicId, true).catch(() => {
+      // Search listing. `finalize` does not $set `discoverable` (unlike commentPolicy), so
+      // a re-publish PRESERVES whatever was stored - which means the OFF direction has to
+      // be written explicitly too, or a listed artifact can never be de-listed from this
+      // dialog. Hence "on change", not "when on": `wanted` is what the user is asking for,
+      // `existing?.discoverable` is what storage currently holds.
+      //
+      // The visibility/gate guard forces `wanted` to false rather than skipping the call:
+      // staging the switch ON and then picking Private (or adding a gate) hides the
+      // control, and persisting `true` there would arm a silent opt-in that fires the
+      // moment someone widens the artifact back to public. A failed call leaves the
+      // artifact at its stored value, and the server de-arms on any downgrade anyway.
+      const wanted = discoverableOn && visibility === 'public' && gateKind === 'none';
+      if (wanted !== !!existing?.discoverable) {
+        await updatePublishedDiscoverable(r.publicId, wanted).catch(() => {
           toast.warning('Published, but the search-listing setting failed - you can toggle it below.');
         });
       }
@@ -493,6 +500,10 @@ export function PublishShareModal({
       // Embedding is open-public only, so hide the embed editor the moment a gate
       // goes on (and reveal it again when the gate is cleared) - matches the server rule.
       setEmbedGated(gate !== null);
+      // The PATCH above left open-public, so the server de-armed `discoverable`. Mirror
+      // that here rather than leaving the switch showing a value storage no longer holds.
+      // Clearing a gate does NOT restore it - re-opting-in is an explicit choice.
+      if (gate !== null) setDiscoverableOn(false);
       toast.success(
         gate === null
           ? 'Link is open to anyone again'
@@ -509,9 +520,12 @@ export function PublishShareModal({
 
   const onPickGate = (next: GateKind) => {
     if (busy) return;
-    // Same reasoning as onPick: adding a gate hides the listing switch, so retire the
-    // staged choice instead of leaving it set behind a control the user can't see.
-    if (next !== 'none') setDiscoverableOn(false);
+    // Deliberately does NOT touch discoverableOn. Unlike a visibility pick, a gate pick is
+    // not persisted here - it waits for the explicit "Update access" button - so resetting
+    // now would make the switch disagree with storage the moment the user picks `none`
+    // again. applyGateLive does the reset, once the gate is actually live and the server
+    // has de-armed the flag. While gated the switch is hidden anyway, and the staged-
+    // publish path forces `wanted` to false independently.
     setGateKind(next);
     setGateTouched(true);
   };
@@ -727,10 +741,13 @@ export function PublishShareModal({
               <TravelExploreIcon fontSize="small" />
               <Box>
                 <FormLabel sx={{ mb: 0 }}>List in search engines</FormLabel>
-                <Typography level="body-xs" sx={{ opacity: 0.75 }}>
+                {/* FormHelperText, not Typography: only a FormHelperText child registers itself into
+                    Joy's FormControl context and lands in the switch's aria-describedby, so a screen-
+                    reader user actually hears this caveat instead of just the label. */}
+                <FormHelperText sx={{ opacity: 0.75 }}>
                   Off by default. When off, the link still works for anyone you send it to - it just won&apos;t show up
                   in Google. Link previews in chat apps work either way.
-                </Typography>
+                </FormHelperText>
               </Box>
             </Box>
             <Switch

--- a/apps/client/app/components/common/PublishShareModal.tsx
+++ b/apps/client/app/components/common/PublishShareModal.tsx
@@ -351,9 +351,13 @@ export function PublishShareModal({
           toast.warning('Published, but enabling comments failed - you can toggle them below.');
         });
       }
-      // Only ever PATCHed when ON. The server default is already false, so a failed
-      // call here leaves the artifact non-indexable - the safe direction.
-      if (discoverableOn) {
+      // Only ever PATCHed when ON, and only when the artifact actually published as
+      // open-public. Staging the toggle ON and then picking Private (or adding a gate)
+      // hides the switch but leaves the flag set - persisting it there would arm a
+      // silent opt-in that fires later, the moment someone widens the artifact back to
+      // public. The server default is already false, so a failed call here leaves the
+      // artifact non-indexable: the safe direction.
+      if (discoverableOn && visibility === 'public' && gateKind === 'none') {
         await updatePublishedDiscoverable(r.publicId, true).catch(() => {
           toast.warning('Published, but the search-listing setting failed - you can toggle it below.');
         });
@@ -432,6 +436,10 @@ export function PublishShareModal({
 
   const onPick = (next: PublishVisibility) => {
     if (busy) return;
+    // Leaving public retires a staged search-listing choice rather than parking it on a
+    // hidden control. Re-picking Public starts from off, so listing is always a choice
+    // made against the exposure the artifact actually has.
+    if (next !== 'public') setDiscoverableOn(false);
     if (phase === 'shared') void changeVisibilityLive(next);
     else setVisibility(next);
   };
@@ -501,6 +509,9 @@ export function PublishShareModal({
 
   const onPickGate = (next: GateKind) => {
     if (busy) return;
+    // Same reasoning as onPick: adding a gate hides the listing switch, so retire the
+    // staged choice instead of leaving it set behind a control the user can't see.
+    if (next !== 'none') setDiscoverableOn(false);
     setGateKind(next);
     setGateTouched(true);
   };

--- a/apps/client/app/components/common/PublishShareModal.tsx
+++ b/apps/client/app/components/common/PublishShareModal.tsx
@@ -22,6 +22,7 @@ import LinkIcon from '@mui/icons-material/Link';
 import KeyIcon from '@mui/icons-material/Key';
 import DomainIcon from '@mui/icons-material/Domain';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import TravelExploreIcon from '@mui/icons-material/TravelExplore';
 import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
 import type { CommentPolicy, PublishResult, PublishVisibility } from '@bike4mind/common';
@@ -36,6 +37,7 @@ import {
   revokeShareToken,
   updatePublishedVisibility,
   updatePublishedCommentPolicy,
+  updatePublishedDiscoverable,
   updatePublishedAccessGate,
   getPublishedEmbedState,
   type PublishAccessGateInput,
@@ -72,6 +74,8 @@ export interface PublishShareModalProps {
     // one-click re-publish can't silently widen visibility or re-enable comments.
     visibility: PublishVisibility;
     commentPolicy?: CommentPolicy;
+    /** Whether the prior publication opted into search-engine indexing. */
+    discoverable?: boolean;
   } | null>;
   /**
    * When set, offers a "Team" (organization) visibility choice, publishing an org-scoped
@@ -164,6 +168,9 @@ export function PublishShareModal({
 }: PublishShareModalProps) {
   const [visibility, setVisibility] = useState<PublishVisibility>(defaultVisibility);
   const [commentsOn, setCommentsOn] = useState(true);
+  // Search-engine opt-IN, off by default. Publishing publicly must never imply
+  // "list this in Google" - that has to be a deliberate click.
+  const [discoverableOn, setDiscoverableOn] = useState(false);
   const [result, setResult] = useState<PublishResult | null>(null);
   const [busy, setBusy] = useState(false);
   // A prior publication of this artifact, resolved asynchronously after the dialog opens.
@@ -175,6 +182,7 @@ export function PublishShareModal({
     versionsCount: number;
     slug: string;
     commentPolicy?: CommentPolicy;
+    discoverable?: boolean;
   } | null>(null);
   const [mode, setMode] = useState<PublishMode>('new');
   // The opt-in no-sign-in (`/a/<token>`) share link, minted lazily only when the owner asks.
@@ -197,6 +205,7 @@ export function PublishShareModal({
       setResult(null);
       setVisibility(defaultVisibility);
       setCommentsOn(true);
+      setDiscoverableOn(false);
       setBusy(false);
       setExisting(null);
       setMode('new');
@@ -244,6 +253,7 @@ export function PublishShareModal({
           versionsCount: found.versionsCount || 1,
           slug: found.slug,
           commentPolicy: found.commentPolicy,
+          discoverable: found.discoverable,
         });
         setMode('update');
         // Carry the existing publication's exposure into the (now default) "update" action.
@@ -252,6 +262,10 @@ export function PublishShareModal({
         // the owner had turned off - on a plain "add a new version".
         setVisibility(found.visibility);
         setCommentsOn(found.commentPolicy === 'open' || found.commentPolicy === 'restricted');
+        // Unlike visibility/commentPolicy, finalize does NOT $set discoverable, so an
+        // update can't widen it. Seeded anyway so the toggle shows the artifact's real
+        // current state instead of a misleading "off".
+        setDiscoverableOn(!!found.discoverable);
       })
       .catch(() => {
         /* lookup failure -> no choice shown; publishes as new */
@@ -337,6 +351,13 @@ export function PublishShareModal({
           toast.warning('Published, but enabling comments failed - you can toggle them below.');
         });
       }
+      // Only ever PATCHed when ON. The server default is already false, so a failed
+      // call here leaves the artifact non-indexable - the safe direction.
+      if (discoverableOn) {
+        await updatePublishedDiscoverable(r.publicId, true).catch(() => {
+          toast.warning('Published, but the search-listing setting failed - you can toggle it below.');
+        });
+      }
       setResult(r);
       toast.success('Share link ready', { id });
     } catch (err) {
@@ -362,6 +383,31 @@ export function PublishShareModal({
     } catch {
       setCommentsOn(prev);
       toast.error('Failed to update comments');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Toggle search-engine listing. Live-PATCH once published; otherwise stage the choice.
+  const onToggleDiscoverable = async (next: boolean) => {
+    if (busy) return;
+    if (phase !== 'shared' || !result) {
+      setDiscoverableOn(next);
+      return;
+    }
+    const prev = discoverableOn;
+    setDiscoverableOn(next);
+    setBusy(true);
+    try {
+      await updatePublishedDiscoverable(result.publicId, next);
+      toast.success(
+        next
+          ? 'Search engines may now list this page'
+          : 'Hidden from search engines - the link still works for anyone you send it to'
+      );
+    } catch {
+      setDiscoverableOn(prev);
+      toast.error('Failed to update search listing');
     } finally {
       setBusy(false);
     }
@@ -562,7 +608,8 @@ export function PublishShareModal({
               Access note below tells the truth instead. */}
           {isPublic && gateKind === 'none' && !existing && !gateTouched && (
             <Typography level="body-xs" sx={{ mt: 0.75, color: AMBER }}>
-              ⚠ Public: anyone with the link will be able to view this.
+              ⚠ Public: anyone with the link will be able to view this. It stays out of search engines unless you turn
+              on &quot;List in search engines&quot; below.
             </Typography>
           )}
         </FormControl>
@@ -657,6 +704,35 @@ export function PublishShareModal({
           </FormControl>
         )}
 
+        {/* Search listing. Offered ONLY for an ungated public item, matching the server
+            rule (discoverable is ANDed with isOpenPublic on every request) - showing it
+            for a private or gated item would promise something that never takes effect. */}
+        {isPublic && gateKind === 'none' && (
+          <FormControl
+            orientation="horizontal"
+            sx={{ mb: 2, justifyContent: 'space-between', alignItems: 'center', gap: 1 }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <TravelExploreIcon fontSize="small" />
+              <Box>
+                <FormLabel sx={{ mb: 0 }}>List in search engines</FormLabel>
+                <Typography level="body-xs" sx={{ opacity: 0.75 }}>
+                  Off by default. When off, the link still works for anyone you send it to - it just won&apos;t show up
+                  in Google. Link previews in chat apps work either way.
+                </Typography>
+              </Box>
+            </Box>
+            <Switch
+              checked={discoverableOn}
+              disabled={busy}
+              onChange={e => void onToggleDiscoverable(e.target.checked)}
+              // On the INPUT slot, not the root: Joy spreads bare props to the root span,
+              // where a test can't read `.checked`.
+              slotProps={{ input: { 'data-testid': 'publish-share-discoverable-toggle' } }}
+            />
+          </FormControl>
+        )}
+
         <FormControl
           orientation="horizontal"
           sx={{ mb: 2, justifyContent: 'space-between', alignItems: 'center', gap: 1 }}
@@ -674,7 +750,7 @@ export function PublishShareModal({
             checked={commentsOn}
             disabled={busy}
             onChange={e => void onToggleComments(e.target.checked)}
-            data-testid="publish-share-comments-toggle"
+            slotProps={{ input: { 'data-testid': 'publish-share-comments-toggle' } }}
           />
         </FormControl>
 

--- a/apps/client/app/generated/help-index.json
+++ b/apps/client/app/generated/help-index.json
@@ -8712,6 +8712,11 @@
         },
         {
           "level": 2,
+          "text": "Search engines",
+          "anchor": "search-engines"
+        },
+        {
+          "level": 2,
           "text": "Managing what you've published",
           "anchor": "managing-what-youve-published"
         },
@@ -18144,6 +18149,11 @@
             },
             {
               "level": 2,
+              "text": "Search engines",
+              "anchor": "search-engines"
+            },
+            {
+              "level": 2,
               "text": "Managing what you've published",
               "anchor": "managing-what-youve-published"
             },
@@ -18855,5 +18865,5 @@
       "accessLevel": "public"
     }
   ],
-  "version": "2026-07-15T14:34:12.156Z"
+  "version": "2026-07-29T01:24:45.816Z"
 }

--- a/apps/client/app/generated/help-index.json
+++ b/apps/client/app/generated/help-index.json
@@ -3215,63 +3215,6 @@
       "accessLevel": "public"
     },
     {
-      "slug": "features/tavern",
-      "title": "The Tavern",
-      "description": "Autonomous AI agent simulation in Bike4Mind",
-      "category": "features",
-      "sidebarPosition": 1,
-      "tags": [],
-      "headings": [
-        {
-          "level": 1,
-          "text": "The Tavern",
-          "anchor": "the-tavern"
-        },
-        {
-          "level": 2,
-          "text": "How It Works",
-          "anchor": "how-it-works"
-        },
-        {
-          "level": 3,
-          "text": "Agents",
-          "anchor": "agents"
-        },
-        {
-          "level": 3,
-          "text": "Heartbeats",
-          "anchor": "heartbeats"
-        },
-        {
-          "level": 3,
-          "text": "Quest Board",
-          "anchor": "quest-board"
-        },
-        {
-          "level": 3,
-          "text": "Confidence Gates",
-          "anchor": "confidence-gates"
-        },
-        {
-          "level": 3,
-          "text": "Agent-to-Agent Communication",
-          "anchor": "agent-to-agent-communication"
-        },
-        {
-          "level": 2,
-          "text": "Interfaces",
-          "anchor": "interfaces"
-        },
-        {
-          "level": 2,
-          "text": "Creating Agents",
-          "anchor": "creating-agents"
-        }
-      ],
-      "filePath": "features/tavern/index.md",
-      "accessLevel": "public"
-    },
-    {
       "slug": "features/integrations/slack-integration",
       "title": "Slack Integration",
       "description": "Use AI agents in Slack with @mentions, thread intelligence, and natural language commands for GitHub, Jira, and Confluence",
@@ -3806,6 +3749,63 @@
       "accessLevel": "public"
     },
     {
+      "slug": "features/tavern",
+      "title": "The Tavern",
+      "description": "Autonomous AI agent simulation in Bike4Mind",
+      "category": "features",
+      "sidebarPosition": 1,
+      "tags": [],
+      "headings": [
+        {
+          "level": 1,
+          "text": "The Tavern",
+          "anchor": "the-tavern"
+        },
+        {
+          "level": 2,
+          "text": "How It Works",
+          "anchor": "how-it-works"
+        },
+        {
+          "level": 3,
+          "text": "Agents",
+          "anchor": "agents"
+        },
+        {
+          "level": 3,
+          "text": "Heartbeats",
+          "anchor": "heartbeats"
+        },
+        {
+          "level": 3,
+          "text": "Quest Board",
+          "anchor": "quest-board"
+        },
+        {
+          "level": 3,
+          "text": "Confidence Gates",
+          "anchor": "confidence-gates"
+        },
+        {
+          "level": 3,
+          "text": "Agent-to-Agent Communication",
+          "anchor": "agent-to-agent-communication"
+        },
+        {
+          "level": 2,
+          "text": "Interfaces",
+          "anchor": "interfaces"
+        },
+        {
+          "level": 2,
+          "text": "Creating Agents",
+          "anchor": "creating-agents"
+        }
+      ],
+      "filePath": "features/tavern/index.md",
+      "accessLevel": "public"
+    },
+    {
       "slug": "features/notebooks",
       "title": "Notebooks - AI Chat Sessions",
       "description": "Complete guide to Bike4Mind's notebook chat interface - your workspace for AI conversations",
@@ -4289,88 +4289,6 @@
       "accessLevel": "public"
     },
     {
-      "slug": "features/tavern/cli",
-      "title": "CLI Integration",
-      "description": "Interact with Tavern agents from the B4M CLI",
-      "category": "features",
-      "sidebarPosition": 2,
-      "tags": [],
-      "headings": [
-        {
-          "level": 1,
-          "text": "Tavern CLI Integration",
-          "anchor": "tavern-cli-integration"
-        },
-        {
-          "level": 2,
-          "text": "Enabling Tavern",
-          "anchor": "enabling-tavern"
-        },
-        {
-          "level": 2,
-          "text": "Usage",
-          "anchor": "usage"
-        },
-        {
-          "level": 3,
-          "text": "Discovering Agents",
-          "anchor": "discovering-agents"
-        },
-        {
-          "level": 3,
-          "text": "Creating Agents",
-          "anchor": "creating-agents"
-        },
-        {
-          "level": 3,
-          "text": "Editing and Deleting Agents",
-          "anchor": "editing-and-deleting-agents"
-        },
-        {
-          "level": 3,
-          "text": "Talking to Agents",
-          "anchor": "talking-to-agents"
-        },
-        {
-          "level": 3,
-          "text": "Quest Board",
-          "anchor": "quest-board"
-        },
-        {
-          "level": 3,
-          "text": "Agent Notebooks",
-          "anchor": "agent-notebooks"
-        },
-        {
-          "level": 3,
-          "text": "Confidence Gates",
-          "anchor": "confidence-gates"
-        },
-        {
-          "level": 3,
-          "text": "Heartbeat Control",
-          "anchor": "heartbeat-control"
-        },
-        {
-          "level": 2,
-          "text": "Tools Reference",
-          "anchor": "tools-reference"
-        },
-        {
-          "level": 2,
-          "text": "Activity Stream",
-          "anchor": "activity-stream"
-        },
-        {
-          "level": 2,
-          "text": "Disabling Tavern",
-          "anchor": "disabling-tavern"
-        }
-      ],
-      "filePath": "features/tavern/cli.md",
-      "accessLevel": "public"
-    },
-    {
       "slug": "features/integrations/slack-admin-guide",
       "title": "Slack Admin Guide",
       "description": "Set up and manage the Bike4Mind Slack app for your workspace with manifest-based configuration",
@@ -4806,6 +4724,88 @@
         }
       ],
       "filePath": "features/integrations/confluence-mcp-tools.md",
+      "accessLevel": "public"
+    },
+    {
+      "slug": "features/tavern/cli",
+      "title": "CLI Integration",
+      "description": "Interact with Tavern agents from the B4M CLI",
+      "category": "features",
+      "sidebarPosition": 2,
+      "tags": [],
+      "headings": [
+        {
+          "level": 1,
+          "text": "Tavern CLI Integration",
+          "anchor": "tavern-cli-integration"
+        },
+        {
+          "level": 2,
+          "text": "Enabling Tavern",
+          "anchor": "enabling-tavern"
+        },
+        {
+          "level": 2,
+          "text": "Usage",
+          "anchor": "usage"
+        },
+        {
+          "level": 3,
+          "text": "Discovering Agents",
+          "anchor": "discovering-agents"
+        },
+        {
+          "level": 3,
+          "text": "Creating Agents",
+          "anchor": "creating-agents"
+        },
+        {
+          "level": 3,
+          "text": "Editing and Deleting Agents",
+          "anchor": "editing-and-deleting-agents"
+        },
+        {
+          "level": 3,
+          "text": "Talking to Agents",
+          "anchor": "talking-to-agents"
+        },
+        {
+          "level": 3,
+          "text": "Quest Board",
+          "anchor": "quest-board"
+        },
+        {
+          "level": 3,
+          "text": "Agent Notebooks",
+          "anchor": "agent-notebooks"
+        },
+        {
+          "level": 3,
+          "text": "Confidence Gates",
+          "anchor": "confidence-gates"
+        },
+        {
+          "level": 3,
+          "text": "Heartbeat Control",
+          "anchor": "heartbeat-control"
+        },
+        {
+          "level": 2,
+          "text": "Tools Reference",
+          "anchor": "tools-reference"
+        },
+        {
+          "level": 2,
+          "text": "Activity Stream",
+          "anchor": "activity-stream"
+        },
+        {
+          "level": 2,
+          "text": "Disabling Tavern",
+          "anchor": "disabling-tavern"
+        }
+      ],
+      "filePath": "features/tavern/cli.md",
       "accessLevel": "public"
     },
     {
@@ -12652,63 +12652,6 @@
           "accessLevel": "public"
         },
         {
-          "slug": "features/tavern",
-          "title": "The Tavern",
-          "description": "Autonomous AI agent simulation in Bike4Mind",
-          "category": "features",
-          "sidebarPosition": 1,
-          "tags": [],
-          "headings": [
-            {
-              "level": 1,
-              "text": "The Tavern",
-              "anchor": "the-tavern"
-            },
-            {
-              "level": 2,
-              "text": "How It Works",
-              "anchor": "how-it-works"
-            },
-            {
-              "level": 3,
-              "text": "Agents",
-              "anchor": "agents"
-            },
-            {
-              "level": 3,
-              "text": "Heartbeats",
-              "anchor": "heartbeats"
-            },
-            {
-              "level": 3,
-              "text": "Quest Board",
-              "anchor": "quest-board"
-            },
-            {
-              "level": 3,
-              "text": "Confidence Gates",
-              "anchor": "confidence-gates"
-            },
-            {
-              "level": 3,
-              "text": "Agent-to-Agent Communication",
-              "anchor": "agent-to-agent-communication"
-            },
-            {
-              "level": 2,
-              "text": "Interfaces",
-              "anchor": "interfaces"
-            },
-            {
-              "level": 2,
-              "text": "Creating Agents",
-              "anchor": "creating-agents"
-            }
-          ],
-          "filePath": "features/tavern/index.md",
-          "accessLevel": "public"
-        },
-        {
           "slug": "features/integrations/slack-integration",
           "title": "Slack Integration",
           "description": "Use AI agents in Slack with @mentions, thread intelligence, and natural language commands for GitHub, Jira, and Confluence",
@@ -13243,6 +13186,63 @@
           "accessLevel": "public"
         },
         {
+          "slug": "features/tavern",
+          "title": "The Tavern",
+          "description": "Autonomous AI agent simulation in Bike4Mind",
+          "category": "features",
+          "sidebarPosition": 1,
+          "tags": [],
+          "headings": [
+            {
+              "level": 1,
+              "text": "The Tavern",
+              "anchor": "the-tavern"
+            },
+            {
+              "level": 2,
+              "text": "How It Works",
+              "anchor": "how-it-works"
+            },
+            {
+              "level": 3,
+              "text": "Agents",
+              "anchor": "agents"
+            },
+            {
+              "level": 3,
+              "text": "Heartbeats",
+              "anchor": "heartbeats"
+            },
+            {
+              "level": 3,
+              "text": "Quest Board",
+              "anchor": "quest-board"
+            },
+            {
+              "level": 3,
+              "text": "Confidence Gates",
+              "anchor": "confidence-gates"
+            },
+            {
+              "level": 3,
+              "text": "Agent-to-Agent Communication",
+              "anchor": "agent-to-agent-communication"
+            },
+            {
+              "level": 2,
+              "text": "Interfaces",
+              "anchor": "interfaces"
+            },
+            {
+              "level": 2,
+              "text": "Creating Agents",
+              "anchor": "creating-agents"
+            }
+          ],
+          "filePath": "features/tavern/index.md",
+          "accessLevel": "public"
+        },
+        {
           "slug": "features/notebooks",
           "title": "Notebooks - AI Chat Sessions",
           "description": "Complete guide to Bike4Mind's notebook chat interface - your workspace for AI conversations",
@@ -13726,88 +13726,6 @@
           "accessLevel": "public"
         },
         {
-          "slug": "features/tavern/cli",
-          "title": "CLI Integration",
-          "description": "Interact with Tavern agents from the B4M CLI",
-          "category": "features",
-          "sidebarPosition": 2,
-          "tags": [],
-          "headings": [
-            {
-              "level": 1,
-              "text": "Tavern CLI Integration",
-              "anchor": "tavern-cli-integration"
-            },
-            {
-              "level": 2,
-              "text": "Enabling Tavern",
-              "anchor": "enabling-tavern"
-            },
-            {
-              "level": 2,
-              "text": "Usage",
-              "anchor": "usage"
-            },
-            {
-              "level": 3,
-              "text": "Discovering Agents",
-              "anchor": "discovering-agents"
-            },
-            {
-              "level": 3,
-              "text": "Creating Agents",
-              "anchor": "creating-agents"
-            },
-            {
-              "level": 3,
-              "text": "Editing and Deleting Agents",
-              "anchor": "editing-and-deleting-agents"
-            },
-            {
-              "level": 3,
-              "text": "Talking to Agents",
-              "anchor": "talking-to-agents"
-            },
-            {
-              "level": 3,
-              "text": "Quest Board",
-              "anchor": "quest-board"
-            },
-            {
-              "level": 3,
-              "text": "Agent Notebooks",
-              "anchor": "agent-notebooks"
-            },
-            {
-              "level": 3,
-              "text": "Confidence Gates",
-              "anchor": "confidence-gates"
-            },
-            {
-              "level": 3,
-              "text": "Heartbeat Control",
-              "anchor": "heartbeat-control"
-            },
-            {
-              "level": 2,
-              "text": "Tools Reference",
-              "anchor": "tools-reference"
-            },
-            {
-              "level": 2,
-              "text": "Activity Stream",
-              "anchor": "activity-stream"
-            },
-            {
-              "level": 2,
-              "text": "Disabling Tavern",
-              "anchor": "disabling-tavern"
-            }
-          ],
-          "filePath": "features/tavern/cli.md",
-          "accessLevel": "public"
-        },
-        {
           "slug": "features/integrations/slack-admin-guide",
           "title": "Slack Admin Guide",
           "description": "Set up and manage the Bike4Mind Slack app for your workspace with manifest-based configuration",
@@ -14243,6 +14161,88 @@
             }
           ],
           "filePath": "features/integrations/confluence-mcp-tools.md",
+          "accessLevel": "public"
+        },
+        {
+          "slug": "features/tavern/cli",
+          "title": "CLI Integration",
+          "description": "Interact with Tavern agents from the B4M CLI",
+          "category": "features",
+          "sidebarPosition": 2,
+          "tags": [],
+          "headings": [
+            {
+              "level": 1,
+              "text": "Tavern CLI Integration",
+              "anchor": "tavern-cli-integration"
+            },
+            {
+              "level": 2,
+              "text": "Enabling Tavern",
+              "anchor": "enabling-tavern"
+            },
+            {
+              "level": 2,
+              "text": "Usage",
+              "anchor": "usage"
+            },
+            {
+              "level": 3,
+              "text": "Discovering Agents",
+              "anchor": "discovering-agents"
+            },
+            {
+              "level": 3,
+              "text": "Creating Agents",
+              "anchor": "creating-agents"
+            },
+            {
+              "level": 3,
+              "text": "Editing and Deleting Agents",
+              "anchor": "editing-and-deleting-agents"
+            },
+            {
+              "level": 3,
+              "text": "Talking to Agents",
+              "anchor": "talking-to-agents"
+            },
+            {
+              "level": 3,
+              "text": "Quest Board",
+              "anchor": "quest-board"
+            },
+            {
+              "level": 3,
+              "text": "Agent Notebooks",
+              "anchor": "agent-notebooks"
+            },
+            {
+              "level": 3,
+              "text": "Confidence Gates",
+              "anchor": "confidence-gates"
+            },
+            {
+              "level": 3,
+              "text": "Heartbeat Control",
+              "anchor": "heartbeat-control"
+            },
+            {
+              "level": 2,
+              "text": "Tools Reference",
+              "anchor": "tools-reference"
+            },
+            {
+              "level": 2,
+              "text": "Activity Stream",
+              "anchor": "activity-stream"
+            },
+            {
+              "level": 2,
+              "text": "Disabling Tavern",
+              "anchor": "disabling-tavern"
+            }
+          ],
+          "filePath": "features/tavern/cli.md",
           "accessLevel": "public"
         },
         {
@@ -18865,5 +18865,5 @@
       "accessLevel": "public"
     }
   ],
-  "version": "2026-07-29T01:24:45.816Z"
+  "version": "2026-07-29T13:14:08.393Z"
 }

--- a/apps/client/app/hooks/usePublishShare.tsx
+++ b/apps/client/app/hooks/usePublishShare.tsx
@@ -13,6 +13,9 @@ export interface ExistingPublication {
    *  one-click re-publish can't silently widen visibility or re-enable comments. */
   visibility: PublishVisibility;
   commentPolicy?: CommentPolicy;
+  /** Whether the prior publication opted into search-engine listing. Seeds the dialog's
+   *  switch, so it must stay in the list endpoint's $project to be non-null in practice. */
+  discoverable?: boolean;
 }
 
 interface ShareState {

--- a/apps/client/app/utils/publishApi.ts
+++ b/apps/client/app/utils/publishApi.ts
@@ -20,6 +20,8 @@ export interface ManagedArtifact {
   description?: string;
   visibility: PublishVisibility;
   commentPolicy?: CommentPolicy;
+  /** Owner opt-in to search-engine indexing; absent/false means the page is served noindex. */
+  discoverable?: boolean;
   source: { kind: 'bundle' | 'reply' | 'fabfile'; artifactId?: string };
   size?: { totalBytes: number; fileCount: number };
   viewCount?: number;
@@ -185,6 +187,16 @@ export async function updatePublishedCommentPolicy(publicId: string, commentPoli
   await api.patch(`/api/publish/artifacts/${publicId}`, { commentPolicy });
 }
 
+/**
+ * Opt a published item in or out of search-engine indexing (owner/admin). Off by
+ * default: publishing publicly means "anyone with the link can view", never "listed
+ * in Google". Only takes effect while the item is open-public; link previews in chat
+ * apps are unaffected either way.
+ */
+export async function updatePublishedDiscoverable(publicId: string, discoverable: boolean): Promise<void> {
+  await api.patch(`/api/publish/artifacts/${publicId}`, { discoverable });
+}
+
 /** Access gate on top of `visibility: 'public'` - see issue #383. */
 export type PublishAccessGateInput =
   { kind: 'passphrase'; passphrase: string } | { kind: 'domain'; allowedDomains: string[] } | null;
@@ -228,6 +240,7 @@ export interface PublishedManageState {
   accessGate: PublishAccessGateRead;
   embedOrigins: string[];
   commentPolicy: CommentPolicy;
+  discoverable: boolean;
 }
 
 export async function getPublishedManageState(publicId: string): Promise<PublishedManageState> {
@@ -238,6 +251,9 @@ export async function getPublishedManageState(publicId: string): Promise<Publish
     accessGate: a.accessGate ?? null,
     embedOrigins: a.embedOrigins ?? [],
     commentPolicy: a.commentPolicy ?? 'none',
+    // Absent on rows predating the field -> false. Matches the server default: an
+    // artifact is not search-discoverable until its owner says so.
+    discoverable: a.discoverable ?? false,
   };
 }
 

--- a/apps/client/pages/api/publish/artifacts/[id].ts
+++ b/apps/client/pages/api/publish/artifacts/[id].ts
@@ -173,16 +173,27 @@ const handler = baseApi()
       });
     }
     if (parsed.data.commentPolicy !== undefined) artifact.commentPolicy = parsed.data.commentPolicy;
-    // Tracked for the CDN purge below: this flag changes the served X-Robots-Tag AND
-    // the in-document robots <meta>, both of which are part of the cached public bytes.
-    const discoverableChanged =
-      parsed.data.discoverable !== undefined && parsed.data.discoverable !== !!artifact.discoverable;
+    const discoverableBefore = !!artifact.discoverable;
     if (parsed.data.discoverable !== undefined) artifact.discoverable = parsed.data.discoverable;
 
     // Embed allowlist. Validated against the artifact's FINAL open-public state
     // (after any visibility/gate change above), so a gate + embed grant in the
     // same PATCH is rejected as a pair rather than by apply order.
     const isOpenPublicNow = artifact.visibility === 'public' && !artifact.accessGate;
+
+    // DE-ARM on leaving open-public. `discoverable` only has an effect while an artifact
+    // is public AND ungated, so a downgrade or a new gate leaves it set but inert - and
+    // widening the artifact again later would silently re-arm indexing that nobody chose
+    // in that context. Clearing it here (the authoritative layer) means the flag never
+    // outlives the exposure it was granted against, and the client's optimistic reset
+    // when the user picks Private / adds a gate becomes a truthful view of storage
+    // rather than local-only state. The owner re-opts-in explicitly if they want it back.
+    if (!isOpenPublicNow && artifact.discoverable) artifact.discoverable = false;
+
+    // Tracked for the CDN purge below: this flag changes the served X-Robots-Tag AND the
+    // in-document robots <meta>, both of which are part of the cached public bytes.
+    // Compared against the pre-PATCH value so an implicit de-arm counts as a change too.
+    const discoverableChanged = !!artifact.discoverable !== discoverableBefore;
     let embedOriginsChanged = false;
     if (parsed.data.embedOrigins !== undefined) {
       const check = validateEmbedOrigins(parsed.data.embedOrigins, { isOpenPublic: isOpenPublicNow });

--- a/apps/client/pages/api/publish/artifacts/[id].ts
+++ b/apps/client/pages/api/publish/artifacts/[id].ts
@@ -43,6 +43,10 @@ const PatchSchema = z.object({
   description: z.string().max(1000).optional(),
   visibility: VisibilitySchema.optional(),
   commentPolicy: CommentPolicySchema.optional(),
+  // Search-engine opt-in. Accepted at any visibility (owners commonly set it before
+  // flipping to public), but only has an effect while the artifact is open-public -
+  // the serve route ANDs it with isOpenPublic on every request.
+  discoverable: z.boolean().optional(),
   accessGate: AccessGatePatchSchema.optional(),
   // Raw strings; validateEmbedOrigins normalizes and applies the host/open-public
   // rules server-side. `[]` clears the allowlist. Bounded here so a huge payload
@@ -169,6 +173,11 @@ const handler = baseApi()
       });
     }
     if (parsed.data.commentPolicy !== undefined) artifact.commentPolicy = parsed.data.commentPolicy;
+    // Tracked for the CDN purge below: this flag changes the served X-Robots-Tag AND
+    // the in-document robots <meta>, both of which are part of the cached public bytes.
+    const discoverableChanged =
+      parsed.data.discoverable !== undefined && parsed.data.discoverable !== !!artifact.discoverable;
+    if (parsed.data.discoverable !== undefined) artifact.discoverable = parsed.data.discoverable;
 
     // Embed allowlist. Validated against the artifact's FINAL open-public state
     // (after any visibility/gate change above), so a gate + embed grant in the
@@ -189,11 +198,13 @@ const handler = baseApi()
     await artifact.save();
 
     // Any change that alters the CACHED public response must purge the CDN, or the
-    // stale copy keeps serving up to its TTL. Two triggers: (a) leaving open-public
+    // stale copy keeps serving up to its TTL. Three triggers: (a) leaving open-public
     // (downgrade OR newly-gated) removes the page from cache-eligibility; (b) the
     // embed allowlist changed while still open-public - the served frame-ancestors
-    // CSP header is part of the cached bytes. Fire-and-forget, best-effort.
-    if ((wasOpenPublic && !isOpenPublicNow) || (isOpenPublicNow && embedOriginsChanged)) {
+    // CSP header is part of the cached bytes; (c) discoverability changed - the robots
+    // header and <meta> are cached too, and an owner turning discovery OFF must not
+    // keep serving an indexable copy for up to an hour. Fire-and-forget, best-effort.
+    if ((wasOpenPublic && !isOpenPublicNow) || (isOpenPublicNow && (embedOriginsChanged || discoverableChanged))) {
       void invalidatePublishCdn(toCacheTarget(artifact), req.logger);
     }
     const json = artifact.toJSON() as Record<string, unknown> & {

--- a/apps/client/pages/api/publish/artifacts/__tests__/[id].test.ts
+++ b/apps/client/pages/api/publish/artifacts/__tests__/[id].test.ts
@@ -249,3 +249,82 @@ describe('PATCH /api/publish/artifacts/[id] - discoverable (search-engine opt-in
     expect(invalidatePublishCdn).not.toHaveBeenCalled();
   });
 });
+
+describe('PATCH /api/publish/artifacts/[id] - discoverable de-arms on leaving open-public', () => {
+  async function patchBody(body: Record<string, unknown>, artifact = makeArtifact()) {
+    findOne.mockResolvedValue(artifact);
+    const { req, res } = createMocks({ method: 'PATCH' });
+    (req as unknown as { query: unknown }).query = { id: 'pub-1' };
+    (req as unknown as { user?: unknown }).user = { id: OWNER };
+    (req as unknown as { body: unknown }).body = body;
+    (req as unknown as { logger: unknown }).logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    await (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res);
+    return { res, artifact };
+  }
+
+  /** A listed, open-public artifact. */
+  function listedArtifact() {
+    const a = makeArtifact();
+    (a as unknown as { discoverable?: boolean }).discoverable = true;
+    return a;
+  }
+
+  const isDiscoverable = (a: unknown) => (a as { discoverable?: boolean }).discoverable;
+
+  it('clears discoverable when visibility drops to private', async () => {
+    // Otherwise the flag survives inert and silently re-arms indexing whenever the
+    // artifact is widened back to public - nobody chose that in context.
+    const { res, artifact } = await patchBody({ visibility: 'private' }, listedArtifact());
+    expect(res._getStatusCode()).toBe(200);
+    expect(isDiscoverable(artifact)).toBe(false);
+  });
+
+  it('clears discoverable when a passphrase gate is added', async () => {
+    const { res, artifact } = await patchBody(
+      { accessGate: { kind: 'passphrase', passphrase: 'a-long-passphrase' } },
+      listedArtifact()
+    );
+    expect(res._getStatusCode()).toBe(200);
+    expect(isDiscoverable(artifact)).toBe(false);
+  });
+
+  it('clears discoverable when a domain gate is added', async () => {
+    const { res, artifact } = await patchBody(
+      { accessGate: { kind: 'domain', allowedDomains: ['acme.com'] } },
+      listedArtifact()
+    );
+    expect(res._getStatusCode()).toBe(200);
+    expect(isDiscoverable(artifact)).toBe(false);
+  });
+
+  it('rejects discoverable:true in the SAME patch that adds a gate', async () => {
+    // Apply-order independence: the de-arm runs against the final open-public state.
+    const { artifact } = await patchBody({
+      discoverable: true,
+      accessGate: { kind: 'passphrase', passphrase: 'a-long-passphrase' },
+    });
+    expect(isDiscoverable(artifact)).toBe(false);
+  });
+
+  it('leaves discoverable alone while the artifact stays open-public', async () => {
+    const { artifact } = await patchBody({ title: 'Renamed' }, listedArtifact());
+    expect(isDiscoverable(artifact)).toBe(true);
+  });
+
+  it('purges the CDN on an implicit de-arm, not just an explicit toggle', async () => {
+    // The robots header is cached bytes; a de-arm that skipped the purge would keep
+    // serving an indexable copy for up to s-maxage.
+    const { invalidatePublishCdn } = await import('@server/services/publish');
+    vi.mocked(invalidatePublishCdn).mockClear();
+    await patchBody({ visibility: 'private' }, listedArtifact());
+    expect(invalidatePublishCdn).toHaveBeenCalled();
+  });
+
+  it('does not re-list an artifact when a gate is later cleared', async () => {
+    const a = makeArtifact();
+    (a as unknown as { discoverable?: boolean }).discoverable = false;
+    (a as unknown as { accessGate: unknown }).accessGate = { kind: 'passphrase' };
+    const { artifact } = await patchBody({ accessGate: null }, a);
+    expect(isDiscoverable(artifact)).toBe(false);
+  });
+});

--- a/apps/client/pages/api/publish/artifacts/__tests__/[id].test.ts
+++ b/apps/client/pages/api/publish/artifacts/__tests__/[id].test.ts
@@ -194,3 +194,58 @@ describe('PATCH domain access gate - stored as entered, validated', () => {
     expect(artifact.accessGate).toEqual({ kind: 'domain', allowedDomains: ['acme.onmicrosoft.com'] });
   });
 });
+
+describe('PATCH /api/publish/artifacts/[id] - discoverable (search-engine opt-in)', () => {
+  async function patchBody(body: Record<string, unknown>, artifact = makeArtifact()) {
+    findOne.mockResolvedValue(artifact);
+    const { req, res } = createMocks({ method: 'PATCH' });
+    (req as unknown as { query: unknown }).query = { id: 'pub-1' };
+    (req as unknown as { user?: unknown }).user = { id: OWNER };
+    (req as unknown as { body: unknown }).body = body;
+    (req as unknown as { logger: unknown }).logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    await (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res);
+    return { res, artifact };
+  }
+
+  it('sets discoverable when the owner opts in', async () => {
+    const { res, artifact } = await patchBody({ discoverable: true });
+    expect(res._getStatusCode()).toBe(200);
+    expect((artifact as unknown as { discoverable?: boolean }).discoverable).toBe(true);
+  });
+
+  it('clears discoverable when the owner opts back out', async () => {
+    const artifact = makeArtifact();
+    (artifact as unknown as { discoverable?: boolean }).discoverable = true;
+    const { res } = await patchBody({ discoverable: false }, artifact);
+    expect(res._getStatusCode()).toBe(200);
+    expect((artifact as unknown as { discoverable?: boolean }).discoverable).toBe(false);
+  });
+
+  it('leaves discoverable untouched when the field is absent from the patch', async () => {
+    const artifact = makeArtifact();
+    (artifact as unknown as { discoverable?: boolean }).discoverable = true;
+    await patchBody({ title: 'Renamed' }, artifact);
+    expect((artifact as unknown as { discoverable?: boolean }).discoverable).toBe(true);
+  });
+
+  it('rejects a non-boolean discoverable', async () => {
+    const { res } = await patchBody({ discoverable: 'yes' });
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('purges the CDN when discoverability changes - the robots header is cached', async () => {
+    const { invalidatePublishCdn } = await import('@server/services/publish');
+    vi.mocked(invalidatePublishCdn).mockClear();
+    await patchBody({ discoverable: true });
+    expect(invalidatePublishCdn).toHaveBeenCalled();
+  });
+
+  it('does NOT purge when discoverable is re-sent unchanged', async () => {
+    const { invalidatePublishCdn } = await import('@server/services/publish');
+    vi.mocked(invalidatePublishCdn).mockClear();
+    const artifact = makeArtifact();
+    (artifact as unknown as { discoverable?: boolean }).discoverable = true;
+    await patchBody({ discoverable: true }, artifact);
+    expect(invalidatePublishCdn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/publish/artifacts/index.ts
+++ b/apps/client/pages/api/publish/artifacts/index.ts
@@ -65,6 +65,10 @@ const handler = baseApi().get(async (req, res) => {
         description: 1,
         visibility: 1,
         commentPolicy: 1,
+        // Needed by the share dialog to seed its "List in search engines" switch. Without
+        // it the control renders OFF for an artifact that is genuinely listed, and the
+        // owner has no way to turn it off from that dialog.
+        discoverable: 1,
         source: 1,
         size: 1,
         publishedAt: 1,

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -151,13 +151,22 @@ const ASSET_CSP = [
 // Share links are served same-origin, sandboxed, and must never be cached: no-store
 // is what makes a token rotation/revoke take effect immediately (no stale CDN/browser copy).
 const SHARE_CACHE_CONTROL = 'private, no-store, must-revalidate';
-// In-document belt-and-suspenders for the X-Robots-Tag / Referrer-Policy headers, for
-// UAs that honor the <meta> but not the header (and vice versa). Emitted on every page
-// that is not opted into discovery (see `searchIndexable`). The two directives travel
-// together on purpose: a page we keep out of the search index is one whose URL is
-// effectively unlisted, so it must not leak via the Referer header on an outbound link
-// the author included either.
-const NOINDEX_META = '<meta name="robots" content="noindex,nofollow">\n<meta name="referrer" content="no-referrer">';
+// In-document belt-and-suspenders for the X-Robots-Tag header, for UAs that honor the
+// <meta> but not the header (and vice versa). Emitted on every page that is not opted
+// into discovery (see `searchIndexable`).
+const NOINDEX_META = '<meta name="robots" content="noindex,nofollow">';
+// Referrer suppression, kept SEPARATE from NOINDEX_META and scoped to share links only.
+// These two are independent decisions that must not ride along with each other:
+//   - noindex applies to the default state of every public page.
+//   - no-referrer exists to stop a /a/<shareToken> CAPABILITY leaking to third parties
+//     via the Referer header on an outbound link the artifact author included.
+// Applying no-referrer to all public pages would silently kill outbound referral
+// attribution for every author, and would blank `document.referrer` inside the isolated
+// bundle - which makes PIN_BRIDGE_JS fall back to `PO = '*'` and skip its inbound
+// `e.origin` check. Pairing it with the noindex meta is what made that the DEFAULT
+// configuration rather than a deliberate choice. Emitted alongside the matching
+// Referrer-Policy header, so meta and header always agree.
+const NO_REFERRER_META = '<meta name="referrer" content="no-referrer">';
 
 const handler = baseApi({ auth: false }).get(async (req: Request, res: Response) => {
   // Optional-auth shims populate req.user from a Bearer JWT or X-API-Key; anonymous
@@ -266,20 +275,39 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
   // the noindex it was blocked from seeing. Allowing the crawl and serving noindex is
   // the combination that actually keeps a page out of the index; disallow-without-
   // noindex is the misconfiguration that has burned several LLM share features.
-  // Opting in makes exactly ONE url indexable: the canonical `/p/...` page. The three
-  // exclusions below are each load-bearing, not redundant with isOpenPublic:
-  //  - isShare:    a /a/<token> link can resolve to an artifact that is ALSO open-public
-  //                and opted in. Possession of the token is the grant; a search result
-  //                would hand that grant to everyone.
-  //  - isIsolated: the `{publicId}.usercontent...` origin serves the BARE bundle with no
-  //                wrapper, branding, or canonical link. Indexing it would compete with
-  //                the real page and land visitors on an implementation-detail host.
-  //  - embed=1:    the embed render is meant to be framed inside someone else's page,
-  //                not to stand alone as a search result.
+  // Opting in makes exactly ONE url indexable: the artifact's canonical `/p/...` page.
+  // `isCanonicalDoc` below is that page and nothing else. Every other surface this route
+  // can serve is a duplicate, a fragment, or a superseded copy of it, and each would
+  // compete with the real page in results while lacking its wrapper, branding, and (for
+  // the non-HTML ones) any way to carry a canonical link at all:
+  //  - isShare:      a /a/<token> link can resolve to an artifact that is ALSO open-public
+  //                  and opted in. Possession of the token is the grant; a search result
+  //                  would hand that grant to everyone.
+  //  - isIsolated:   the `{publicId}.usercontent...` origin serves the BARE bundle.
+  //  - embed=1:      built to be framed inside someone else's page, not to stand alone.
+  //  - ?v=<sha>:     a SUPERSEDED version. The version switcher emits real crawlable
+  //                  <a> anchors, so a replaced v1 is reachable and would otherwise be
+  //                  indexed alongside the v2 that replaced it. rel=canonical is a hint,
+  //                  not a guarantee - this is the one that actually bites.
+  //  - ?format=raw:  text/plain, so it can carry NEITHER a robots meta nor a canonical
+  //                  tag - the header here is its only control. Advertised to crawlers
+  //                  via rel="alternate" on the page that just became indexable.
+  //  - ?raw=1:       the loader shell's internal srcdoc fetch, not a page.
+  //  - ?a=<N>:       one embedded sub-artifact as a bare srcdoc document.
+  //  - assetPath:    an individual bundle file. A bundle may ship .html assets, which
+  //                  would otherwise be standalone indexable pages with no wrapper.
   // Read `embed` off the query directly: the `isEmbed` binding is computed further down,
   // after several response branches that must already carry the right header.
-  const searchIndexable =
-    !isShare && !isIsolated && req.query.embed !== '1' && isOpenPublic && artifact.discoverable === true;
+  const isCanonicalDoc =
+    !isShare &&
+    !isIsolated &&
+    !isRaw &&
+    !isFormatRaw &&
+    req.query.embed !== '1' &&
+    !req.query.v &&
+    !req.query.a &&
+    !(resolved.kind === 'bundle' && resolved.assetPath);
+  const searchIndexable = isCanonicalDoc && isOpenPublic && artifact.discoverable === true;
   if (!searchIndexable) {
     res.setHeader('X-Robots-Tag', 'noindex, nofollow');
   }
@@ -457,7 +485,7 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     // an iframe navigation cannot send - so it would dead-end at a nested loader shell. For those
     // we render the placeholder card instead of a frame that can never load.
     const canFrameArtifacts = isOpenPublic || isShare || passphraseVerified;
-    const page = renderViewerPage(artifact, !searchIndexable, selfPath, canFrameArtifacts);
+    const page = renderViewerPage(artifact, !searchIndexable, isShare, selfPath, canFrameArtifacts);
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     // The page itself stays script-free (`script-src 'none'` neutralizes any markup that
     // slipped past the sanitizer); embedded artifacts run only inside their own sandboxed
@@ -737,6 +765,7 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     isolatedSrc,
     shareMeta,
     !searchIndexable,
+    isShare,
     isEmbed,
     pillHref,
     barHref,
@@ -788,6 +817,8 @@ function renderBundleWrapper(
   isolatedSrc: string,
   shareMeta: { metaTags: string; noscriptBody: string; alternateLink: string } | null,
   noindex: boolean,
+  /** Share links only - suppresses Referer so the capability token can't leak outbound. */
+  noReferrer: boolean,
   embed = false,
   pillHref = '',
   barHref = '',
@@ -823,7 +854,7 @@ function renderBundleWrapper(
   const reportHref = `/report/${encodeURIComponent(artifact.publicId)}`;
   const versionBar = buildVersionSwitcherHtml(artifact, requestedVersion);
   const metaHead = shareMeta ? `\n${shareMeta.metaTags}\n${shareMeta.alternateLink}` : '';
-  const noindexHead = noindex ? `\n${NOINDEX_META}` : '';
+  const noindexHead = `${noindex ? `\n${NOINDEX_META}` : ''}${noReferrer ? `\n${NO_REFERRER_META}` : ''}`;
   const noscriptBody = shareMeta ? `\n${shareMeta.noscriptBody}` : '';
   // Embedded render drops the interactive chrome (version switcher + comment
   // overlay) so the widget is just the content. The canonical link back to the
@@ -1261,6 +1292,8 @@ function renderArtifactBlock(artifact: ParsedArtifact, index: number, selfPath: 
 function renderViewerPage(
   artifact: PublishedArtifactLean,
   noindex: boolean,
+  /** Share links only - see NO_REFERRER_META. */
+  noReferrer: boolean,
   selfPath = '',
   canFrameArtifacts = false
 ): string {
@@ -1299,7 +1332,7 @@ function renderViewerPage(
     displayTitle = cleanViewerTitle(artifact.title, artifacts);
   }
   const titleHtml = escapeHtml(displayTitle);
-  const noindexHead = noindex ? `\n${NOINDEX_META}` : '';
+  const noindexHead = `${noindex ? `\n${NOINDEX_META}` : ''}${noReferrer ? `\n${NO_REFERRER_META}` : ''}`;
 
   return `<!doctype html>
 <html lang="en">

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -152,9 +152,12 @@ const ASSET_CSP = [
 // is what makes a token rotation/revoke take effect immediately (no stale CDN/browser copy).
 const SHARE_CACHE_CONTROL = 'private, no-store, must-revalidate';
 // In-document belt-and-suspenders for the X-Robots-Tag / Referrer-Policy headers, for
-// UAs that honor the <meta> but not the header (and vice versa).
-const SHARE_NOINDEX_META =
-  '<meta name="robots" content="noindex,nofollow">\n<meta name="referrer" content="no-referrer">';
+// UAs that honor the <meta> but not the header (and vice versa). Emitted on every page
+// that is not opted into discovery (see `searchIndexable`). The two directives travel
+// together on purpose: a page we keep out of the search index is one whose URL is
+// effectively unlisted, so it must not leak via the Referer header on an outbound link
+// the author included either.
+const NOINDEX_META = '<meta name="robots" content="noindex,nofollow">\n<meta name="referrer" content="no-referrer">';
 
 const handler = baseApi({ auth: false }).get(async (req: Request, res: Response) => {
   // Optional-auth shims populate req.user from a Bearer JWT or X-API-Key; anonymous
@@ -246,6 +249,33 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
   // Share links have their own always-no-store policy and are handled by kind.
   const isOpenPublic = artifact.visibility === 'public' && !artifact.accessGate;
 
+  // Search-engine indexability is an explicit owner opt-in (`discoverable`), NOT a
+  // side effect of being public. "Anyone with the link may view" and "listed in every
+  // search engine" are different promises, and owners reliably read the first as the
+  // second; defaulting to noindex means the surprising outcome requires a deliberate
+  // choice. Everything not opted in - gated, private, share-token links, and public
+  // artifacts whose owner never asked for it - is noindexed at BOTH layers (this
+  // header and the in-document <meta>), since a UA may honor one and not the other.
+  //
+  // Set ONCE here, before any response branch below, so a new branch inherits the safe
+  // default instead of having to remember the header. Only an opted-in open-public
+  // artifact skips it.
+  //
+  // Deliberately NOT paired with a robots.txt Disallow. A crawler blocked from FETCHING
+  // a page can still index the URL from a link it found elsewhere, and will never read
+  // the noindex it was blocked from seeing. Allowing the crawl and serving noindex is
+  // the combination that actually keeps a page out of the index; disallow-without-
+  // noindex is the misconfiguration that has burned several LLM share features.
+  // `!isShare` is load-bearing, not redundant with isOpenPublic: a /a/<token> link can
+  // resolve to an artifact that is ALSO open-public and opted in, and an unlisted
+  // capability URL must stay out of the index no matter what the owner chose for the
+  // canonical /p page. Possession of the token is the grant; a search result would
+  // hand that grant to everyone.
+  const searchIndexable = !isShare && isOpenPublic && artifact.discoverable === true;
+  if (!searchIndexable) {
+    res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+  }
+
   // The isolated `/uc` origin is an OPEN-public-only surface (a distinct SOP
   // partition with no /api routes and an app-host-scoped proof cookie). If an
   // artifact was embedded open-public and later GAINED a gate, existing /uc
@@ -299,7 +329,7 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
       );
       res.setHeader('Cache-Control', 'no-store');
       res.setHeader('X-Content-Type-Options', 'nosniff');
-      res.setHeader('X-Robots-Tag', 'noindex');
+      // X-Robots-Tag already set above: a gated artifact is never searchIndexable.
       if (isShare) res.setHeader('Referrer-Policy', 'no-referrer');
       return res.status(200).send(renderPassphraseShell());
     }
@@ -348,11 +378,12 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
       : undefined;
 
   if (isShare) {
-    // No-sign-in links are unlisted capabilities: keep them out of search indexes,
-    // and stop the token leaking to third parties via the Referer header on any
-    // outbound link the artifact author included. Set once here so every share
-    // response below (viewer page, asset, wrapper) inherits them.
-    res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+    // No-sign-in links are unlisted capabilities: stop the token leaking to third
+    // parties via the Referer header on any outbound link the artifact author
+    // included. Set once here so every share response below (viewer page, asset,
+    // wrapper) inherits it. The matching X-Robots-Tag is already set above - a share
+    // link resolves through the token, never through `discoverable`, so it can never
+    // be searchIndexable.
     res.setHeader('Referrer-Policy', 'no-referrer');
   }
 
@@ -418,7 +449,7 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     // an iframe navigation cannot send - so it would dead-end at a nested loader shell. For those
     // we render the placeholder card instead of a frame that can never load.
     const canFrameArtifacts = isOpenPublic || isShare || passphraseVerified;
-    const page = renderViewerPage(artifact, isShare, selfPath, canFrameArtifacts);
+    const page = renderViewerPage(artifact, !searchIndexable, selfPath, canFrameArtifacts);
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     // The page itself stays script-free (`script-src 'none'` neutralizes any markup that
     // slipped past the sanitizer); embedded artifacts run only inside their own sandboxed
@@ -663,6 +694,12 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
   // more than the JS shell. Gated shares (access gate OR non-public) deliberately do
   // not - the pre-auth shells carry no artifact data, and even post-auth renders skip
   // the SEO surface so a gate regression can never leak meta to crawlers.
+  //
+  // Intentionally keyed on isOpenPublic and NOT on `discoverable`: unfurling and search
+  // indexing are different things. Pasting a link into Slack should still produce a
+  // title card for a non-discoverable artifact - unfurlers read OG tags and ignore
+  // robots directives, while search crawlers honor the noindex above. Owners who opt
+  // out of discovery are opting out of the index, not out of link previews.
   const shareMeta =
     !isShare && isOpenPublic
       ? prepareShareMeta({
@@ -691,7 +728,7 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     requestedVersion,
     isolatedSrc,
     shareMeta,
-    isShare,
+    !searchIndexable,
     isEmbed,
     pillHref,
     barHref,
@@ -778,7 +815,7 @@ function renderBundleWrapper(
   const reportHref = `/report/${encodeURIComponent(artifact.publicId)}`;
   const versionBar = buildVersionSwitcherHtml(artifact, requestedVersion);
   const metaHead = shareMeta ? `\n${shareMeta.metaTags}\n${shareMeta.alternateLink}` : '';
-  const noindexHead = noindex ? `\n${SHARE_NOINDEX_META}` : '';
+  const noindexHead = noindex ? `\n${NOINDEX_META}` : '';
   const noscriptBody = shareMeta ? `\n${shareMeta.noscriptBody}` : '';
   // Embedded render drops the interactive chrome (version switcher + comment
   // overlay) so the widget is just the content. The canonical link back to the
@@ -1033,6 +1070,9 @@ interface PublishedArtifactLean {
    *  Appended to frame-ancestors on both the wrapper and the isolated bundle. */
   embedOrigins?: string[];
   commentPolicy?: 'none' | 'open' | 'restricted';
+  /** Owner opt-in to search-engine indexing. Absent on rows predating the field,
+   *  which reads as false - the safe direction (see the model's field comment). */
+  discoverable?: boolean;
   ownerId: string;
   storageKeyPrefix: string;
   manifest: Array<{ path: string; mimeType: string }>;
@@ -1251,7 +1291,7 @@ function renderViewerPage(
     displayTitle = cleanViewerTitle(artifact.title, artifacts);
   }
   const titleHtml = escapeHtml(displayTitle);
-  const noindexHead = noindex ? `\n${SHARE_NOINDEX_META}` : '';
+  const noindexHead = noindex ? `\n${NOINDEX_META}` : '';
 
   return `<!doctype html>
 <html lang="en">

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -266,12 +266,20 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
   // the noindex it was blocked from seeing. Allowing the crawl and serving noindex is
   // the combination that actually keeps a page out of the index; disallow-without-
   // noindex is the misconfiguration that has burned several LLM share features.
-  // `!isShare` is load-bearing, not redundant with isOpenPublic: a /a/<token> link can
-  // resolve to an artifact that is ALSO open-public and opted in, and an unlisted
-  // capability URL must stay out of the index no matter what the owner chose for the
-  // canonical /p page. Possession of the token is the grant; a search result would
-  // hand that grant to everyone.
-  const searchIndexable = !isShare && isOpenPublic && artifact.discoverable === true;
+  // Opting in makes exactly ONE url indexable: the canonical `/p/...` page. The three
+  // exclusions below are each load-bearing, not redundant with isOpenPublic:
+  //  - isShare:    a /a/<token> link can resolve to an artifact that is ALSO open-public
+  //                and opted in. Possession of the token is the grant; a search result
+  //                would hand that grant to everyone.
+  //  - isIsolated: the `{publicId}.usercontent...` origin serves the BARE bundle with no
+  //                wrapper, branding, or canonical link. Indexing it would compete with
+  //                the real page and land visitors on an implementation-detail host.
+  //  - embed=1:    the embed render is meant to be framed inside someone else's page,
+  //                not to stand alone as a search result.
+  // Read `embed` off the query directly: the `isEmbed` binding is computed further down,
+  // after several response branches that must already carry the right header.
+  const searchIndexable =
+    !isShare && !isIsolated && req.query.embed !== '1' && isOpenPublic && artifact.discoverable === true;
   if (!searchIndexable) {
     res.setHeader('X-Robots-Tag', 'noindex, nofollow');
   }

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -1387,7 +1387,7 @@ describe('GET /api/publish/serve - access gates (issue #383)', () => {
     expect(data).not.toContain('My Artifact');
     expect(data).not.toContain('pub1');
     expect(res.getHeader('Cache-Control')).toBe('no-store');
-    expect(res.getHeader('X-Robots-Tag')).toBe('noindex');
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
     // The credential-input page must not be frame-able (clickjacking).
     const csp = res.getHeader('Content-Security-Policy') as string;
     expect(csp).toContain("frame-ancestors 'self'");
@@ -1747,5 +1747,102 @@ describe('GET /api/publish/serve - embed allowlist', () => {
       else process.env.NEXT_PUBLIC_SHARE_BUILTIN_LOGO = prev;
       vi.resetModules();
     }
+  });
+});
+
+describe('GET /api/publish/serve - search-engine discoverability is opt-in', () => {
+  const ROBOTS_META = '<meta name="robots" content="noindex,nofollow">';
+
+  it('a public bundle is NOT indexable by default (no `discoverable` on the record)', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle());
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+    expect(res._getData() as string).toContain(ROBOTS_META);
+  });
+
+  it('an explicitly non-discoverable public bundle is noindexed', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle({ discoverable: false }));
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug']);
+    await promise;
+
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+    expect(res._getData() as string).toContain(ROBOTS_META);
+  });
+
+  it('opting in drops BOTH the robots header and the meta - the only indexable case', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle({ discoverable: true }));
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('X-Robots-Tag')).toBeUndefined();
+    expect(res._getData() as string).not.toContain('name="robots"');
+  });
+
+  it('opting in does NOT survive a gate: discoverable + accessGate is still noindexed', async () => {
+    // The serve route ANDs `discoverable` with isOpenPublic, so a stale opt-in left on a
+    // newly-gated artifact can never re-expose it to crawlers.
+    mockArtifactFindOne.mockReturnValue(bundle({ discoverable: true, accessGate: { kind: 'passphrase' } }));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug']);
+    await promise;
+
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+
+  it('opting in does NOT survive a visibility downgrade: discoverable + private is noindexed', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle({ discoverable: true, visibility: 'private' }));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { user: { id: 'owner1' } });
+    await promise;
+
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+
+  it('a share-token link is noindexed even when the artifact opted in', async () => {
+    // Possession of the token is the capability; an unlisted link must never be
+    // reachable from a search result regardless of the owner's discovery choice.
+    mockArtifactFindOne.mockReturnValue(bundle({ discoverable: true }));
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['a', 'tok123']);
+    await promise;
+
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+    expect(res._getData() as string).toContain(ROBOTS_META);
+  });
+
+  it('keeps OG/unfurl meta on a non-discoverable public page - previews are not indexing', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle({ description: 'A thing' }));
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain(ROBOTS_META);
+    // Unfurlers read OG tags and ignore robots directives, so a link pasted into a chat
+    // app still renders a card while the page stays out of the search index.
+    expect(data).toContain('og:title');
+  });
+
+  it('the ?format=raw plain-text surface is noindexed unless opted in', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle());
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { format: 'raw' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
   });
 });

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -1835,6 +1835,32 @@ describe('GET /api/publish/serve - search-engine discoverability is opt-in', () 
     expect(data).toContain('og:title');
   });
 
+  it('does NOT index the isolated usercontent origin, even when opted in', async () => {
+    // The /uc origin serves the bare bundle with no wrapper, branding, or canonical
+    // link. Opting in must make exactly one URL indexable: the canonical /p page.
+    mockArtifactFindOne.mockReturnValue(bundle({ discoverable: true }));
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { uc: 'pub1' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+
+  it('does NOT index the embed render, even when opted in', async () => {
+    // An embed is meant to be framed inside someone else's page, not to stand alone
+    // as a search result competing with the canonical page.
+    mockArtifactFindOne.mockReturnValue(bundle({ discoverable: true }));
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { embed: true });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+
   it('the ?format=raw plain-text surface is noindexed unless opted in', async () => {
     mockArtifactFindOne.mockReturnValue(bundle());
     mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -1835,6 +1835,129 @@ describe('GET /api/publish/serve - search-engine discoverability is opt-in', () 
     expect(data).toContain('og:title');
   });
 
+  // The reply/fabfile viewer page is a SEPARATE render path from the bundle wrapper
+  // (renderViewerPage vs renderBundleWrapper), and it is where most published LLM output
+  // lands. Reverting just that call site to `isShare` must not pass.
+  const publicReply = (over: Record<string, unknown> = {}) => ({
+    publicId: 'rep1',
+    title: 'My Reply',
+    visibility: 'public',
+    ownerId: 'owner1',
+    source: { kind: 'reply' },
+    renderedBody: '# Hello',
+    storageKeyPrefix: '',
+    manifest: [],
+    tier: 'user',
+    scopeId: 'scope123',
+    slug: 'r-pub',
+    ...over,
+  });
+
+  it('noindexes a public REPLY viewer page by default', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply());
+
+    const { res, promise } = run(['r', 'rep1']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+    expect(res._getData() as string).toContain(ROBOTS_META);
+  });
+
+  it('drops the robots meta from a REPLY viewer page once opted in', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply({ discoverable: true }));
+
+    const { res, promise } = run(['r', 'rep1']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('X-Robots-Tag')).toBeUndefined();
+    expect(res._getData() as string).not.toContain('name="robots"');
+  });
+
+  it('noindexes a public FABFILE viewer page by default', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply({ source: { kind: 'fabfile' }, publicId: 'fab1' }));
+
+    const { res, promise } = run(['f', 'fab1']);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData() as string).toContain(ROBOTS_META);
+  });
+
+  it('noindexes a superseded ?v=<sha> render even when opted in', async () => {
+    // The version switcher emits real crawlable anchors, so a replaced v1 stays
+    // reachable; rel=canonical is a hint, not a guarantee.
+    mockArtifactFindOne.mockReturnValue(
+      bundle({ discoverable: true, sha256Index: 'shaCURRENT', versions: [{ sha256Index: 'shaOLD' }] })
+    );
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Old</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { v: 'shaOLD' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+
+  it('noindexes ?format=raw even when opted in - text/plain cannot carry a meta tag', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle({ discoverable: true }));
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { format: 'raw' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+
+  it('noindexes an individual bundle ASSET even when opted in', async () => {
+    mockArtifactFindOne.mockReturnValue(
+      bundle({
+        discoverable: true,
+        manifest: [
+          { path: 'index.html', mimeType: 'text/html' },
+          { path: 'page2.html', mimeType: 'text/html' },
+        ],
+      })
+    );
+    mockDownload.mockResolvedValue(Buffer.from('<html><body>two</body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug', 'page2.html']);
+    await promise;
+
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+
+  it('keeps no-referrer scoped to share links, not every noindexed public page', async () => {
+    // no-referrer exists to stop a share TOKEN leaking via Referer. Riding it along with
+    // the robots meta would make it the default for every public page - killing outbound
+    // referral attribution and blanking document.referrer inside the isolated bundle.
+    mockArtifactFindOne.mockReturnValue(bundle());
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain(ROBOTS_META);
+    expect(data).not.toContain('name="referrer"');
+    expect(res.getHeader('Referrer-Policy')).toBeUndefined();
+  });
+
+  it('still emits BOTH robots and referrer meta on a share link', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle());
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+
+    const { res, promise } = run(['a', 'tok123']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain(ROBOTS_META);
+    expect(data).toContain('<meta name="referrer" content="no-referrer">');
+    expect(res.getHeader('Referrer-Policy')).toBe('no-referrer');
+  });
+
   it('does NOT index the isolated usercontent origin, even when opted in', async () => {
     // The /uc origin serves the bare bundle with no wrapper, branding, or canonical
     // link. Opting in must make exactly one URL indexable: the canonical /p page.

--- a/apps/client/server/services/publish/invalidatePublishCdn.test.ts
+++ b/apps/client/server/services/publish/invalidatePublishCdn.test.ts
@@ -47,7 +47,16 @@ describe('publishCachePaths', () => {
   it('maps a bundle to its index + asset glob on BOTH the /p and /uc (isolated) origins', () => {
     expect(
       publishCachePaths({ publicId: 'p1', tier: 'user', scopeId: 'u1', slug: 'my-page', sourceKind: 'bundle' })
-    ).toEqual(['/p/u/u1/my-page', '/p/u/u1/my-page/*', '/uc/u/u1/my-page', '/uc/u/u1/my-page/*']);
+    ).toEqual([
+      '/p/u/u1/my-page',
+      // Bare wildcard clears query-string variants (?format=raw, ?embed=1, ?v=), which a
+      // slash-wildcard cannot reach - it matches further path segments only.
+      '/p/u/u1/my-page*',
+      '/p/u/u1/my-page/*',
+      '/uc/u/u1/my-page',
+      '/uc/u/u1/my-page*',
+      '/uc/u/u1/my-page/*',
+    ]);
   });
 
   it('uses the org/project url prefixes for bundles', () => {
@@ -70,11 +79,13 @@ describe('invalidatePublishCdn', () => {
     expect(cmd.input.DistributionId).toBe(DIST_ID);
     expect(cmd.input.InvalidationBatch.Paths.Items).toEqual([
       '/p/u/u1/my-page',
+      '/p/u/u1/my-page*',
       '/p/u/u1/my-page/*',
       '/uc/u/u1/my-page',
+      '/uc/u/u1/my-page*',
       '/uc/u/u1/my-page/*',
     ]);
-    expect(cmd.input.InvalidationBatch.Paths.Quantity).toBe(4);
+    expect(cmd.input.InvalidationBatch.Paths.Quantity).toBe(6);
   });
 
   it('skips (no send) when the Router distribution id is not configured', async () => {

--- a/apps/client/server/services/publish/invalidatePublishCdn.ts
+++ b/apps/client/server/services/publish/invalidatePublishCdn.ts
@@ -52,7 +52,15 @@ export function publishCachePaths(t: PublishCacheTarget): string[] {
   if (t.sourceKind === 'fabfile') return [`/p/f/${t.publicId}`];
   const base = buildPublishUrlPath(t.tier, t.scopeId, t.slug); // /p/{prefix}/{scopeId}/{slug}
   const ucBase = base.replace(/^\/p\b/, '/uc'); // isolated-origin path (mirrors the serve handler)
-  return [base, `${base}/*`, ucBase, `${ucBase}/*`]; // /p + /uc, index + every asset under each
+  // `${base}*` (no slash) in addition to `${base}/*`: a slash-wildcard matches further path
+  // SEGMENTS, so it does not clear query-string variants (`?format=raw`, `?embed=1`, `?v=`).
+  // If the distribution's cache policy keys on query string - it is supplied by id via
+  // PROD_CACHE_POLICY_ID, so this cannot be settled from the repo - those variants would
+  // otherwise keep serving stale bytes for a full s-maxage after a takedown, a visibility
+  // downgrade, or a search-listing opt-out. The bare-wildcard form covers them either way.
+  // Cost of the belt: it can also match a SIBLING slug sharing this prefix, whose only
+  // consequence is an extra cache miss.
+  return [base, `${base}*`, `${base}/*`, ucBase, `${ucBase}*`, `${ucBase}/*`];
 }
 
 /**

--- a/apps/client/server/services/publish/renderBundleLoaderShell.ts
+++ b/apps/client/server/services/publish/renderBundleLoaderShell.ts
@@ -20,6 +20,11 @@
  * pre-PR 401 disclosed nothing), so the shell shows a constant title and the real title
  * only appears once the authenticated `?raw=1` srcdoc renders. The login URL is built
  * from `location.*` at runtime. No server interpolation -> no injection surface.
+ *
+ * Carries `noindex` unconditionally: this shell is only ever returned for a GATED
+ * artifact, so it is by definition not search-discoverable. It holds no artifact data,
+ * so an indexed copy would leak nothing - but a gated artifact's URL still has no
+ * business in a search index. Mirrors the header the serve route already sets.
  */
 import { HASH_BRIDGE_JS } from './fragmentNav';
 
@@ -82,6 +87,8 @@ export function renderBundleLoaderShell(): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<meta name="referrer" content="no-referrer">
 <title>${sharedTitle}</title>
 <style>
   html,body{margin:0;padding:0;height:100%}

--- a/apps/client/server/services/publish/renderPassphraseShell.ts
+++ b/apps/client/server/services/publish/renderPassphraseShell.ts
@@ -79,7 +79,8 @@ export function renderPassphraseShell(): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="robots" content="noindex">
+<meta name="robots" content="noindex,nofollow">
+<meta name="referrer" content="no-referrer">
 <title>Passphrase required</title>
 <style>
   body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;

--- a/b4m-core/common/src/schemas/publishedArtifact.ts
+++ b/b4m-core/common/src/schemas/publishedArtifact.ts
@@ -336,6 +336,15 @@ export const PublishedArtifactSchema = z.object({
    *  `visibility`. Defaults to `none` (read-only) until the owner opts in. */
   commentPolicy: CommentPolicySchema.prefault('none'),
 
+  /** Search-engine opt-IN. `visibility: 'public'` means "anyone with the link may
+   *  view"; it does NOT mean "list this in Google". Those are different promises and
+   *  owners consistently read the first as the second, so indexability is a separate
+   *  explicit choice that defaults OFF: every viewer surface is served `noindex`
+   *  unless the owner turns this on for an open-public artifact.
+   *  Independent of social unfurling - OG/Twitter cards still render either way, so a
+   *  non-discoverable link previews correctly in chat without entering a search index. */
+  discoverable: z.boolean().prefault(false),
+
   /** Exact external origins permitted to embed this artifact (frame-ancestors
    *  grants). Publication-level; empty/absent means app host only. Uses the same
    *  normalizing/deduping EmbedOriginsSchema as the write path so the stored

--- a/docs-site/docs/features/publish-and-share.md
+++ b/docs-site/docs/features/publish-and-share.md
@@ -72,7 +72,7 @@ Never rely on a URL being hard to guess. If content shouldn't be seen by everyon
 ## Safety notes
 
 - **Public means public.** Anyone with a public link can view it — don't publish anything you wouldn't post openly. Being absent from search results is not protection; see [Search engines](#search-engines).
-- **Published artifact bundles run sandboxed.** A bundle is served inside an `<iframe sandbox="allow-scripts">` with no `allow-same-origin`, so author JavaScript executes on an opaque origin: it cannot read the app origin's cookies or localStorage, or call `/api/*` with your credentials. Open-public bundles additionally get their own per-artifact origin (`{id}.usercontent.app.<domain>`) for artifact-vs-artifact isolation.
+- **Published artifact bundles run on a separate origin.** Author JavaScript does execute, but never on the app's origin. On a normal deployment each artifact is framed from **its own per-artifact origin** (`{id}.usercontent.app.<domain>`) — that separate origin *is* the isolation boundary, and it also isolates artifacts from each other. Because it is cross-origin to the app, code in the bundle cannot read the app's cookies or `localStorage`, and cannot call `/api/*` with your credentials. (Where that per-artifact host isn't provisioned, the bundle falls back to a same-origin `<iframe sandbox="allow-scripts">` `srcdoc` with **no** `allow-same-origin`, which puts it on an opaque origin instead. Both paths keep the app origin out of reach; they differ in mechanism.)
 - Bundles are validated at publish time: no `iframe`s, no `eval`/`new Function`/`document.write`, and assets/scripts must come from an allowlist.
 
 ## API reference (power users)

--- a/docs-site/docs/features/publish-and-share.md
+++ b/docs-site/docs/features/publish-and-share.md
@@ -43,6 +43,26 @@ Defaults depend on where you publish (your **user** space defaults to *private*;
 A **public** link works for anyone, even logged out. A **private/project/organization** link requires the viewer to be signed in and authorized — anonymous visitors get a 401.
 :::
 
+## Search engines
+
+**Public does not mean listed in Google.** These are two different promises, and Bike4Mind keeps them separate:
+
+- **"Anyone with the link can view"** — what *public* means. The page loads for anyone you send the URL to, signed in or not.
+- **"Findable by searching"** — a *separate* opt-in, off by default.
+
+Every published page is served with `noindex, nofollow` (as both an `X-Robots-Tag` header and an in-page `<meta name="robots">`) unless you explicitly turn on **List in search engines** in the share dialog. That switch appears only for a public, ungated item, because it can't do anything otherwise.
+
+What the opt-out does *not* affect:
+
+- **Link previews still work.** Pasting the URL into Slack, Discord, iMessage, or a social post still renders a title/description card. Unfurlers read Open Graph tags and ignore robots directives; search crawlers honor them.
+- **The link still works.** Anyone you send it to can open it. Not being indexed is not access control.
+
+Turning the switch back off purges the CDN copy immediately, so the page stops being served as indexable right away. Note that removing a page from a search index that already crawled it is up to the search engine — use the gates below if the content is actually sensitive.
+
+:::warning
+Never rely on a URL being hard to guess. If content shouldn't be seen by everyone, use a **passphrase**, a **domain restriction**, or a non-public visibility tier — not the absence of a search listing.
+:::
+
 ## Managing what you've published
 
 - **List:** `GET /api/publish/artifacts` returns everything you can see (yours + anything shared with you).
@@ -51,8 +71,8 @@ A **public** link works for anyone, even logged out. A **private/project/organiz
 
 ## Safety notes
 
-- **Public means public.** Anyone with a public link can view it — don't publish anything you wouldn't post openly.
-- **Published artifact bundles are static.** For security, author-supplied inline JavaScript is **not executed** when a bundle is served from the app origin — inline scripts are stripped and the page renders without them. Interactive (JS-driven) artifacts will be supported once bundles are served from an isolated sandbox origin (tracked separately). Today, lean on HTML/CSS and SVG for rich visual artifacts.
+- **Public means public.** Anyone with a public link can view it — don't publish anything you wouldn't post openly. Being absent from search results is not protection; see [Search engines](#search-engines).
+- **Published artifact bundles run sandboxed.** A bundle is served inside an `<iframe sandbox="allow-scripts">` with no `allow-same-origin`, so author JavaScript executes on an opaque origin: it cannot read the app origin's cookies or localStorage, or call `/api/*` with your credentials. Open-public bundles additionally get their own per-artifact origin (`{id}.usercontent.app.<domain>`) for artifact-vs-artifact isolation.
 - Bundles are validated at publish time: no `iframe`s, no `eval`/`new Function`/`document.write`, and assets/scripts must come from an allowlist.
 
 ## API reference (power users)
@@ -67,5 +87,5 @@ All publish endpoints require auth (`x-api-key` or a bearer token). See the [Pub
 | `POST /api/publish/artifact/finalize` | Step 3: validate + publish the uploaded bundle |
 | `GET /api/publish/artifacts` | List artifacts you can see |
 | `GET /api/publish/artifacts/{publicId}` | Fetch one |
-| `PATCH /api/publish/artifacts/{publicId}` | Update title/description/visibility |
+| `PATCH /api/publish/artifacts/{publicId}` | Update title/description/visibility, or `{"discoverable": true\|false}` to change the search listing |
 | `DELETE /api/publish/artifacts/{publicId}` | Unpublish (soft-delete) |

--- a/packages/database/src/models/content/PublishedArtifactModel.ts
+++ b/packages/database/src/models/content/PublishedArtifactModel.ts
@@ -137,6 +137,16 @@ const PublishedArtifactSchema = new Schema(
       default: 'none',
     },
 
+    /** Search-engine opt-IN, orthogonal to `visibility` (who may view) the same way
+     *  `commentPolicy` is. Default false means EVERY viewer surface is served
+     *  `noindex` until the owner explicitly asks to be discoverable, and only ever
+     *  takes effect while the artifact is open-public (public AND ungated).
+     *  Backfill is deliberately omitted: an absent field reads as falsy, so every
+     *  existing row becomes non-indexable on deploy. That is the safe direction -
+     *  artifacts published under the old always-indexable behavior opt back IN
+     *  rather than staying silently exposed. */
+    discoverable: { type: Boolean, default: false },
+
     ownerId: { type: String, required: true },
     lastPublishedBy: { type: String },
 


### PR DESCRIPTION
## Description

**Publishing something publicly no longer means handing it to Google.** Search-engine indexing becomes an explicit, per-artifact opt-in that defaults to **off**.

### Why: the industry lesson

In late July 2026, publicly-shared Claude conversations and Artifacts were found indexed in Google and Bing. A Reddit user demonstrated that `site:claude.ai/share` returned hundreds of live results. The indexed pages reportedly included API keys, crypto wallet keys, patient health records, internal employee reviews, resumes, and clinical trial data. Anthropic shipped a Google-side fix within ~2 days; Bing results and third-party scrapes remained.

Two things went wrong, and the second one is the interesting one:

1. **The mechanism.** Crawlers were blocked in `robots.txt`, but the pages carried no `noindex`. These are different controls. `robots.txt` says *don't crawl*; it does **not** say *don't index* — Google will index a URL it was disallowed from crawling if it discovers the link anywhere else (a public Slack, a tweet, a scraper). And because crawling was blocked, Googlebot could never *read* a `noindex` even if one had been added. Disallow-without-noindex is the worst of both worlds.

2. **The expectation gap.** Users read "anyone with the link" as "unlisted." It is not. That misreading is the actual root cause; the missing header just made it costly.

Public reporting: [VentureBeat](https://venturebeat.com/technology/uh-oh-some-claude-shared-conversations-and-artifacts-appear-to-be-indexed-and-publicly-accessible-on-google-search) · [Cybernews](https://cybernews.com/ai-news/claude-chats-artifacts-indexed-google/) · [Android Headlines](https://www.androidheadlines.com/2026/07/google-indexes-shared-claude-ai-chats-privacy-leak.html)

### What our audit found

I traced every `X-Robots-Tag` and robots `<meta>` through `pages/api/publish/serve/[...path].ts`. **We did not have Anthropic's bug.** Our gated surfaces were already correct, at both layers:

| Surface | Header | In-document meta | Status before this PR |
|---|---|---|---|
| `/a/<shareToken>` no-sign-in links | `noindex, nofollow` | yes | correct |
| Passphrase prompt shell | `noindex` | yes | correct |
| Gated bundle loader shell | via route | **no** | gap (carried no artifact data, so nothing leaked) |
| **Open-public `/p/*`** | **none** | **none** | **indexable by design** |

The public tier was not an oversight — it was built to be indexed. `renderViewerPage` and `renderBundleWrapper` both take a `noindex` parameter, and at every call site that argument was literally `isShare`. On top of that, `prepareShareMeta()` emitted OG/Twitter cards, a canonical URL, a `<noscript>` body, and a `?format=raw` plain-text alternate, with a comment stating the intent: *"so unfurlers, LLM URL fetchers, and non-JS crawlers see more than the JS shell."* Cached `public, max-age=60, s-maxage=3600`.

There is also **no `robots.txt` in the repo**, so nothing was disallowed either — meaning we never had the specific misconfiguration above, just the outcome pointed the other way.

Meanwhile our UI called the public tier **"Anyone with the link"** in five places, and the docs said the same. That is the exact phrase that burned Claude users, paired with a page we were actively feeding to crawlers.

So: not a vulnerability, a **default**. This PR changes the default.

### Design decisions worth reviewing

- **Opt-in, not opt-out.** `discoverable` defaults `false`, so the surprising outcome requires a deliberate click.
- **No backfill migration — intentional.** An absent field reads falsy, so every existing row becomes non-indexable on deploy. Artifacts published under the old always-indexable behavior opt back *in*; they do not stay silently exposed. That is the safe direction, and it is the whole point of the PR.
- **One decision point.** `searchIndexable` is computed once, before any response branch, so a future branch inherits the safe default rather than having to remember a header.
- **`!isShare` is load-bearing.** A `/a/<token>` link can resolve to an artifact that is *also* open-public and opted in. A test I wrote caught exactly this regression in my first draft — the token link had become indexable. Possession of the token is the grant; a search result would hand that grant to everyone.
- **Indexing != unfurling.** OG tags still render for non-discoverable pages. Unfurlers read OG and ignore robots directives; search crawlers honor them. Pasting a private-ish link into Slack still gives you a title card. Opting out of discovery is not opting out of link previews.
- **Still no `robots.txt` Disallow, deliberately.** Per the lesson above, blocking the crawl would prevent Google from ever *reading* our `noindex`. Allow the crawl, serve the header. Also, indexability is now per-artifact, which `robots.txt` cannot express.
- **CDN purge on toggle.** The robots header and meta are part of the cached bytes; turning discovery off has to take effect now, not in an hour.

## Changes

**Contract + storage**
- `discoverable: boolean` (default `false`) on `PublishedArtifactSchema` (`@bike4mind/common`) and the Mongoose model.

**Serve path** (`pages/api/publish/serve/[...path].ts`)
- Single `searchIndexable = !isShare && isOpenPublic && discoverable`, evaluated before every response branch; sets `X-Robots-Tag: noindex, nofollow` unless opted in.
- `renderViewerPage` / `renderBundleWrapper` now receive `!searchIndexable` instead of `isShare`.
- Removed two now-redundant per-branch header writes (one of which set a *weaker* `noindex` without `nofollow`).
- `SHARE_NOINDEX_META` → `NOINDEX_META`; it is no longer share-specific.

**Shells**
- `renderBundleLoaderShell` gains in-document `noindex` + `no-referrer` (closes the table gap above).
- `renderPassphraseShell` upgraded `noindex` → `noindex,nofollow` + `no-referrer` for consistency.

**API** (`pages/api/publish/artifacts/[id].ts`)
- `PATCH` accepts `discoverable`; change triggers a CDN invalidation.

**UI**
- New `DiscoverableToggle` (optimistic with rollback) wired into `ManageSharingPanel` for already-published items.
- Same toggle in `PublishShareModal`, rendered only for a public + ungated item (matching the server rule).
- Public warning copy now reads: *"anyone with the link will be able to view this. It stays out of search engines unless you turn on 'List in search engines' below."*

**Docs** — new "Search engines" section; also corrected two stale claims (bundles are sandboxed now, not script-stripped).

**Test hygiene** — moved two Joy `Switch` testids onto the input slot; adding a second switch made `getByRole('switch')` ambiguous and broke three pre-existing tests.

## Guide for Testers

Setup: sign in at `app.staging.bike4mind.com`.

**A. A new public artifact is not indexable by default**
1. Open any notebook and generate an HTML artifact.
2. Open the Artifacts gallery, click the `⋮` menu on that artifact, choose **Share**.
3. Select visibility **Public**. Expect the amber warning to read "anyone with the link will be able to view this. It stays out of search engines unless you turn on 'List in search engines' below."
4. Expect a **List in search engines** switch below, and expect it to be **off**.
5. Click **Publish**. Copy the `/p/u/...` URL.
6. In a terminal: `curl -sI "<the URL>" | grep -i x-robots-tag`. Expect exactly `x-robots-tag: noindex, nofollow`.
7. `curl -s "<the URL>" | grep -i 'name="robots"'`. Expect `<meta name="robots" content="noindex,nofollow">`.

**B. Opting in makes it indexable**
8. In the still-open share dialog, switch **List in search engines** on. Expect the toast "Search engines may now list this page".
9. Re-run step 6. Expect **no** `x-robots-tag` header at all.
10. Re-run step 7. Expect **no** robots meta tag.

**C. Opting back out**
11. Switch it off. Expect the toast "Hidden from search engines - the link still works for anyone you send it to".
12. Re-run step 6. Expect `noindex, nofollow` to be back.
13. Open the URL in a logged-out/incognito window. Expect the page to **still load** — this is the key point: not indexed is not access-controlled.

**D. Link previews survive the opt-out**
14. With the toggle **off**, paste the `/p/...` URL into a Slack channel.
15. Expect a normal unfurl card with the artifact's title. (Unfurl caching may require a not-recently-pasted URL.)

**E. A gate always wins over the opt-in**
16. Turn **List in search engines** on, then set **Access** to **Passphrase**, enter `test-passphrase-123`, click **Update access**.
17. Re-run step 6. Expect `noindex, nofollow` despite the toggle being on.

**F. Share-token links are never indexable**
18. In the dialog, create a **no-sign-in link** (`/a/<token>`).
19. `curl -sI "<the /a/ URL>" | grep -i -E 'x-robots-tag|referrer-policy'`. Expect `noindex, nofollow` and `no-referrer`.

**G. Existing artifacts (the migration path)**
20. Go to Profile → Published Artifacts, expand an artifact published *before* this deploy.
21. Expect a **List in search engines** switch, defaulted **off**.
22. `curl -sI` its `/p/` URL. Expect `noindex, nofollow` — i.e. it was silently de-indexed by the deploy, as intended.

**Regression checks**
23. A **private** artifact's `/p/` URL still 401s / shows the sign-in loader for a logged-out viewer.
24. A passphrase-gated artifact still prompts, and the correct passphrase still grants access.
25. The **Allow comments** switch still works (its testid moved to the input slot).
26. Embed allowlist editing still works for an open-public artifact.

**What NOT to test**
- Whether Google actually de-indexes anything — that is the search engine's timeline, not ours.
- `robots.txt` — we intentionally do not ship one; see the design notes.

## Additional Information

**Verification**
- `pnpm --filter @bike4mind/client typecheck` — clean except a pre-existing `packages/scripts/migrate/migrations/index.ts` → `./premium.generated` error, confirmed present on a clean `main` checkout (premium-overlay artifact, unrelated).
- Publish-surface tests: **589 passed / 51 files**, including 8 new serve-route cases, 6 new PATCH cases, and 6 new `DiscoverableToggle` cases.
- `pnpm --filter @bike4mind/database test` — 955 passed.
- `pnpm lint:check` — 4 errors, all in `packages/premium/optihashi`, pre-existing and unrelated; the changed files lint clean.

**Not done here**
- `help-embeddings.json` was not regenerated (needs `OPENAI_API_KEY`). `help-index.json` is updated and committed.
- Retroactive de-indexing of anything already crawled would need Search Console removal requests. Worth checking whether we have live `/p/` URLs in Google today.

**Follow-up worth considering**
- A stale comment in `app/utils/publishApi.ts` still says inline scripts are stripped at serve time; left alone to keep this diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
