### PR TITLE
fix(client): stop unavailable tools reading as enabled in the picker

### DIFF
--- a/apps/client/app/components/Session/AISettings/ToolsSection.gating.test.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.gating.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
 
@@ -111,6 +111,8 @@ const gated = (container: HTMLElement, toolClass: string) =>
   container.querySelector(`.${toolClass} [data-tool-disabled="true"]`);
 
 beforeEach(() => {
+  mocks.state.tools = [];
+  mocks.useLLM.setState.mockClear();
   mocks.state.isAgentsEnabled = false;
   mocks.state.toolMode = 'smart';
   mocks.state.agentMode = { enabled: true, source: 'toggle' };
@@ -276,6 +278,130 @@ describe('ToolsSection missing-key gating', () => {
     mocks.toolAvailability.value = { search_knowledge_base: true };
     const { container: enabled } = render(<ToolsSection />, { wrapper: Wrapper });
     expect(gated(enabled, 'tool-item-knowledge-base')).toBeFalsy();
+  });
+});
+
+/**
+ * A tool enabled while its key was present keeps its stored preference after the key
+ * goes away, so it restores when a valid key returns. Until then it must not READ as
+ * enabled: greyed-out-but-on is a control that claims to be usable while refusing to
+ * be used, and the pinned tallies agree with it.
+ *
+ * Switches are found by their authored `.tool-item-*` class rather than getByRole:
+ * the Fun & Novelty grid renders with `display: none` (the useUserSettings mock omits
+ * `showFunTools`), which excludes it from the a11y tree.
+ */
+describe('ToolsSection unavailable-tool display', () => {
+  const switchFor = (container: HTMLElement, toolClass: string) =>
+    container.querySelector(`.${toolClass} [role="switch"]`);
+  const tallyFor = (container: HTMLElement, section: string) =>
+    Array.from(container.querySelectorAll('.tools-collapsible-title')).find(el =>
+      el.textContent?.startsWith(section)
+    )?.textContent;
+  const setToolsPayloads = () =>
+    mocks.useLLM.setState.mock.calls.filter((call: unknown[]) => {
+      const payload = call[0];
+      return !!payload && typeof payload === 'object' && 'tools' in payload;
+    });
+
+  it('renders an unavailable tool off and drops it from the pinned tally', () => {
+    mocks.state.tools = ['web_search', 'math_evaluate'];
+    mocks.toolAvailability.value = { web_search: false };
+    const { container } = render(<ToolsSection />, { wrapper: Wrapper });
+    expect(switchFor(container, 'tool-item-web-search')?.getAttribute('aria-checked')).toBe('false');
+    expect(switchFor(container, 'tool-item-math')?.getAttribute('aria-checked')).toBe('true');
+    expect(tallyFor(container, 'Individual tools')).toBe('Individual tools (1 pinned)');
+  });
+
+  // Control: proves the assertion above tracks availability rather than always reading off.
+  it('leaves the switch on and counted when the key is present', () => {
+    mocks.state.tools = ['web_search', 'math_evaluate'];
+    mocks.toolAvailability.value = { web_search: true };
+    const { container } = render(<ToolsSection />, { wrapper: Wrapper });
+    expect(switchFor(container, 'tool-item-web-search')?.getAttribute('aria-checked')).toBe('true');
+    expect(tallyFor(container, 'Individual tools')).toBe('Individual tools (2 pinned)');
+  });
+
+  // Control against an over-fix (`=== true`): availability is undefined until
+  // /serverConfig resolves, and treating that as missing would blank the panel on
+  // first paint.
+  it('leaves everything on while availability is still loading', () => {
+    mocks.state.tools = ['web_search'];
+    mocks.toolAvailability.value = undefined;
+    const { container } = render(<ToolsSection />, { wrapper: Wrapper });
+    expect(switchFor(container, 'tool-item-web-search')?.getAttribute('aria-checked')).toBe('true');
+    expect(tallyFor(container, 'Individual tools')).toBe('Individual tools (1 pinned)');
+  });
+
+  // The tally is `pinnedCount > 0 ? ... : ''`, so zero renders no parenthetical at all
+  // rather than "(0 pinned)".
+  it('renders no tally when the only enabled tool is unavailable', () => {
+    mocks.state.tools = ['web_search'];
+    mocks.toolAvailability.value = { web_search: false };
+    const { container } = render(<ToolsSection />, { wrapper: Wrapper });
+    expect(tallyFor(container, 'Individual tools')).toBe('Individual tools');
+  });
+
+  it('drops an unavailable Fun tool from the Fun tally without disturbing Individual tools', () => {
+    mocks.state.tools = ['weather_info', 'math_evaluate'];
+    mocks.toolAvailability.value = { weather_info: false };
+    const { container } = render(<ToolsSection />, { wrapper: Wrapper });
+    expect(switchFor(container, 'tool-item-weather')?.getAttribute('aria-checked')).toBe('false');
+    expect(tallyFor(container, 'Fun & Novelty')).toBe('Fun & Novelty');
+    expect(tallyFor(container, 'Individual tools')).toBe('Individual tools (1 pinned)');
+  });
+
+  // Mode gating dims a row without contradicting it: the preference is still honored
+  // the moment the mode changes, so the switch must stay on. Only a missing key -
+  // which nothing the user does in this panel can fix - reads as off.
+  it('does not flip a switch for Fast-mode dimming', () => {
+    mocks.state.tools = ['web_search'];
+    mocks.state.toolMode = 'fast';
+    const { container } = render(<ToolsSection />, { wrapper: Wrapper });
+    expect(gated(container, 'tool-item-web-search')).toBeTruthy();
+    expect(switchFor(container, 'tool-item-web-search')?.getAttribute('aria-checked')).toBe('true');
+    expect(tallyFor(container, 'Individual tools')).toBe('Individual tools (1 pinned)');
+  });
+
+  it('does not flip a switch for Agent-mode dimming', () => {
+    mocks.state.tools = ['wolfram_alpha'];
+    mocks.agentModeFeatureFlag.value = true; // bolt is on via beforeEach
+    const { container } = render(<ToolsSection />, { wrapper: Wrapper });
+    expect(gated(container, 'tool-item-wolfram-alpha')).toBeTruthy();
+    expect(switchFor(container, 'tool-item-wolfram-alpha')?.getAttribute('aria-checked')).toBe('true');
+    expect(tallyFor(container, 'Individual tools')).toBe('Individual tools (1 pinned)');
+  });
+
+  it('keeps the stored preference for an unavailable tool', () => {
+    mocks.adminFeatureFlags.value = { EnableKnowledgeBaseSearch: true };
+    mocks.state.tools = ['search_knowledge_base'];
+    mocks.toolAvailability.value = { search_knowledge_base: false };
+    render(<ToolsSection />, { wrapper: Wrapper });
+    expect(mocks.state.tools).toContain('search_knowledge_base');
+    expect(setToolsPayloads()).toHaveLength(0);
+  });
+
+  // ToolContainer only kills pointer events, so the greyed switch stays a focusable
+  // button. Without a guard in handleToggleTool, Enter/Space would erase the stored
+  // preference while the switch already reads off - a silent edit with no feedback.
+  it('refuses to toggle a key-gated switch', () => {
+    mocks.adminFeatureFlags.value = { EnableKnowledgeBaseSearch: true };
+    mocks.state.tools = ['search_knowledge_base'];
+    mocks.toolAvailability.value = { search_knowledge_base: false };
+    const { container } = render(<ToolsSection />, { wrapper: Wrapper });
+    fireEvent.click(switchFor(container, 'tool-item-knowledge-base') as Element);
+    expect(setToolsPayloads()).toHaveLength(0);
+  });
+
+  // Control: the same click DOES reach handleToggleTool once the key is present, so
+  // the assertion above is about the guard and not about an unclickable element.
+  it('still toggles that switch when the key is present', () => {
+    mocks.adminFeatureFlags.value = { EnableKnowledgeBaseSearch: true };
+    mocks.state.tools = ['search_knowledge_base'];
+    mocks.toolAvailability.value = { search_knowledge_base: true };
+    const { container } = render(<ToolsSection />, { wrapper: Wrapper });
+    fireEvent.click(switchFor(container, 'tool-item-knowledge-base') as Element);
+    expect(setToolsPayloads()).toEqual([[{ tools: [] }]]);
   });
 });
 

--- a/apps/client/app/components/Session/AISettings/ToolsSection.tsx
+++ b/apps/client/app/components/Session/AISettings/ToolsSection.tsx
@@ -49,7 +49,13 @@ import { green } from '@client/app/utils/themes/colors';
 import { useModelInfo } from '@client/app/hooks/data/useModelInfo';
 import DeepResearchConfigModal from './DeepResearchConfigModal';
 import ImageGenerationModelSelectionModal from './ImageGenerationModelSelectionModal';
-import { getToolDisplayName, getToolDescription, isToolAvailableInAgentMode } from '@client/app/utils/toolMapping';
+import {
+  getToolDisplayName,
+  getToolDescription,
+  isToolAvailableInAgentMode,
+  isToolKeyMissing,
+  filterToolsForDisplay,
+} from '@client/app/utils/toolMapping';
 import { useMcpServers } from '@client/app/hooks/data/mcpServers';
 import { useConfig } from '@client/app/hooks/data/settings';
 
@@ -79,10 +85,10 @@ export const MISSING_KEY_TOOLTIPS: Partial<Record<B4MLLMTools, string>> = {
 type McpServerOption = Pick<IMcpServerDocument, 'id' | 'enabled' | 'tools'> & { name: string };
 
 /**
- * Resolves, for a given tool id, why it's unavailable in the current composer
- * mode (Fast / Agent), or `null` when the tool is allowed. Provided by
- * ToolsSection so each ToolContainer can dim itself + show an explanatory
- * tooltip without prop-drilling the mode state to every row.
+ * Resolves, for a given tool id, why it's unavailable - either a missing API key
+ * or the current composer mode (Fast / Agent) - or `null` when the tool is
+ * allowed. Provided by ToolsSection so each ToolContainer can dim itself + show an
+ * explanatory tooltip without prop-drilling that state to every row.
  */
 type ToolGate = { reason: string } | null;
 const ToolGateContext = createContext<(toolId: B4MLLMTools) => ToolGate>(() => null);
@@ -90,10 +96,10 @@ const ToolGateContext = createContext<(toolId: B4MLLMTools) => ToolGate>(() => n
 interface ToolContainerProps extends PropsWithChildren {
   sx?: BoxProps['sx'];
   /**
-   * When set, this row represents a Smart Tool whose availability depends on the
-   * current mode. If the mode disallows it, the row is dimmed + made
+   * When set, this row represents a Smart Tool that can be gated by a missing API
+   * key or by the current mode. When it is, the row is dimmed + made
    * non-interactive and wrapped in a tooltip explaining why. Omit for non-tool
-   * rows (Thinking, Quest Master, MCP servers, etc.) which are never mode-gated.
+   * rows (Thinking, Quest Master, MCP servers, etc.) which are never gated.
    */
   toolId?: B4MLLMTools;
 }
@@ -137,8 +143,10 @@ const ToolContainer = ({ children, sx, toolId }: ToolContainerProps) => {
     return content;
   }
 
-  // Disallowed in the current mode: dim + disable interaction on the row itself,
-  // but keep the wrapper hoverable so the explanatory tooltip still shows.
+  // Gated: dim + disable interaction on the row itself, but keep the wrapper
+  // hoverable so the explanatory tooltip still shows. This only kills pointer
+  // events - a key-gated toggle is still keyboard-reachable, so handleToggleTool
+  // refuses it there too.
   return (
     <Tooltip title={gate.reason} variant="soft" size="sm" placement="top" arrow>
       <Box
@@ -392,6 +400,13 @@ const ToolsSection = ({
 
   const handleToggleTool = useCallback(
     (tool: B4MLLMTools) => {
+      // A key-gated tool renders as off (filterToolsForDisplay) while its stored
+      // preference is kept, so toggling has to be refused here too. ToolContainer
+      // only kills pointer events; the toggle is a real focusable <button>, so
+      // Enter/Space would otherwise erase that preference with no visible change.
+      if (isToolKeyMissing(tool, toolAvailability)) {
+        return;
+      }
       if (setTools) {
         // Use the provided setTools function
         if (tools.includes(tool)) {
@@ -406,7 +421,7 @@ const ToolsSection = ({
         });
       }
     },
-    [setLLM, setTools, tools]
+    [setLLM, setTools, tools, toolAvailability]
   );
 
   // Agent mode runs the agent executor (fixed toolset, ignoring Smart Tools) when
@@ -490,9 +505,9 @@ const ToolsSection = ({
   const getToolGate = useCallback(
     (toolId: B4MLLMTools): { reason: string } | null => {
       // A missing API key is a hard, mode-independent blocker: without it the
-      // tool silently returns nothing, so surface it first. Only gate once the
-      // availability data has loaded (=== false), never on undefined.
-      if (toolAvailability?.[toolId] === false) {
+      // tool silently returns nothing, so surface it first. isToolKeyMissing only
+      // gates once the availability data has loaded, never on undefined.
+      if (isToolKeyMissing(toolId, toolAvailability)) {
         return { reason: MISSING_KEY_TOOLTIPS[toolId] ?? 'Requires an API key that has not been configured.' };
       }
       if (toolMode === 'fast') {
@@ -562,9 +577,16 @@ const ToolsSection = ({
     );
   }
 
+  // The tools that read as ON in this panel: a key-gated tool keeps its stored
+  // preference but renders off, so both the switches and the tallies below go
+  // through this rather than the raw `tools`. Plain const, not a useMemo - the
+  // early return above means hooks cannot be called from here down.
+  const displayTools = filterToolsForDisplay(tools, toolAvailability);
   // Enabled MCP servers (integrations) count toward the pinned tally like any other
   // tool. Agent-only ones (see AGENT_ONLY_MCP_SERVERS) are labeled per-row rather
-  // than excluded here, so the number reflects everything the user has toggled on.
+  // than excluded here, so the number reflects everything the user has toggled on
+  // and can actually use. MCP servers have no toolAvailability entry, so nothing to
+  // filter for them.
   const enabledMcpServerCount = visibleMcpServers.filter(server => isMcpServerEnabled(server.name)).length;
   // Feature-gated switches that live outside the `tools` array (each has its own LLM
   // state flag) but appear in this panel, so they count like any other tool. Must stay
@@ -574,8 +596,10 @@ const ToolsSection = ({
     (isAgentsFeatureEnabled && isAgentsEnabled ? 1 : 0) +
     (isLatticeFeatureEnabled && isLatticeEnabled ? 1 : 0);
   // Fun & Novelty tools count toward their own section's tally, not Individual tools.
-  const funPinnedCount = tools.filter(t => FUN_NOVELTY_TOOLS.includes(t)).length;
-  const individualToolsCount = tools.length - funPinnedCount;
+  // Both lines must read displayTools: splitting them (one raw, one filtered) would
+  // count a filtered-out tool in the Individual total.
+  const funPinnedCount = displayTools.filter(t => FUN_NOVELTY_TOOLS.includes(t)).length;
+  const individualToolsCount = displayTools.length - funPinnedCount;
   const pinnedCount = individualToolsCount + enabledMcpServerCount + specialToolsCount;
 
   // Second line appended to the Smart tools description in Smart mode, only when Agent-mode
@@ -787,7 +811,7 @@ const ToolsSection = ({
               </Box>
               <SquareSlideToggle
                 onChange={() => handleToggleTool('web_search')}
-                checked={tools.includes('web_search')}
+                checked={displayTools.includes('web_search')}
               />
             </ToolContainer>
           </Grid>
@@ -803,7 +827,7 @@ const ToolsSection = ({
                 />
                 <ToolLabel name={getToolDisplayName('web_fetch')} description={getToolDescription('web_fetch')} />
               </Box>
-              <SquareSlideToggle onChange={() => handleToggleTool('web_fetch')} checked={tools.includes('web_fetch')} />
+              <SquareSlideToggle onChange={() => handleToggleTool('web_fetch')} checked={displayTools.includes('web_fetch')} />
             </ToolContainer>
           </Grid>
           {/* Knowledge Base Search */}
@@ -824,7 +848,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('search_knowledge_base')}
-                  checked={tools.includes('search_knowledge_base')}
+                  checked={displayTools.includes('search_knowledge_base')}
                 />
               </ToolContainer>
             </Grid>
@@ -847,7 +871,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('fmp_financial_data')}
-                  checked={tools.includes('fmp_financial_data')}
+                  checked={displayTools.includes('fmp_financial_data')}
                 />
               </ToolContainer>
             </Grid>
@@ -916,7 +940,7 @@ const ToolsSection = ({
               </Box>
               <SquareSlideToggle
                 onChange={() => handleToggleTool('prompt_enhancement')}
-                checked={tools.includes('prompt_enhancement')}
+                checked={displayTools.includes('prompt_enhancement')}
               />
             </ToolContainer>
           </Grid>
@@ -974,7 +998,7 @@ const ToolsSection = ({
                   </Tooltip>
                   <SquareSlideToggle
                     onChange={() => handleToggleTool('deep_research')}
-                    checked={tools.includes('deep_research')}
+                    checked={displayTools.includes('deep_research')}
                   />
                 </Box>
               </ToolContainer>
@@ -1034,7 +1058,7 @@ const ToolsSection = ({
                 </Tooltip>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('image_generation')}
-                  checked={tools.includes('image_generation')}
+                  checked={displayTools.includes('image_generation')}
                   data-testid="tool-toggle-image-generation"
                 />
               </Box>
@@ -1057,7 +1081,7 @@ const ToolsSection = ({
               </Box>
               <SquareSlideToggle
                 onChange={() => handleToggleTool('mermaid_chart')}
-                checked={tools.includes('mermaid_chart')}
+                checked={displayTools.includes('mermaid_chart')}
               />
             </ToolContainer>
           </Grid>
@@ -1078,7 +1102,7 @@ const ToolsSection = ({
               </Box>
               <SquareSlideToggle
                 onChange={() => handleToggleTool('excel_generation')}
-                checked={tools.includes('excel_generation')}
+                checked={displayTools.includes('excel_generation')}
               />
             </ToolContainer>
           </Grid>
@@ -1260,7 +1284,7 @@ const ToolsSection = ({
               </Box>
               <SquareSlideToggle
                 onChange={() => handleToggleTool('current_datetime')}
-                checked={tools.includes('current_datetime')}
+                checked={displayTools.includes('current_datetime')}
               />
             </ToolContainer>
           </Grid>
@@ -1281,7 +1305,7 @@ const ToolsSection = ({
               </Box>
               <SquareSlideToggle
                 onChange={() => handleToggleTool('math_evaluate')}
-                checked={tools.includes('math_evaluate')}
+                checked={displayTools.includes('math_evaluate')}
               />
             </ToolContainer>
           </Grid>
@@ -1302,7 +1326,7 @@ const ToolsSection = ({
               </Box>
               <SquareSlideToggle
                 onChange={() => handleToggleTool('wolfram_alpha')}
-                checked={tools.includes('wolfram_alpha')}
+                checked={displayTools.includes('wolfram_alpha')}
               />
             </ToolContainer>
           </Grid>
@@ -1338,7 +1362,8 @@ const ToolsSection = ({
                 />
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px', flex: 1, minWidth: 0 }}>
                   <ToolLabel name={getToolDisplayName('recharts')} description={getToolDescription('recharts')} />
-                  {tools.includes('recharts') && (
+                  {/* Sub-control follows the rendered toggle, not the raw preference. */}
+                  {displayTools.includes('recharts') && (
                     <SwitchSelector
                       options={[
                         { value: 'inline', label: 'Inline' },
@@ -1359,7 +1384,7 @@ const ToolsSection = ({
                     />
                   )}
                 </Box>
-                <SquareSlideToggle onChange={() => handleToggleTool('recharts')} checked={tools.includes('recharts')} />
+                <SquareSlideToggle onChange={() => handleToggleTool('recharts')} checked={displayTools.includes('recharts')} />
               </Box>
             </ToolContainer>
           </Grid>
@@ -1439,7 +1464,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('chess_engine')}
-                  checked={tools.includes('chess_engine')}
+                  checked={displayTools.includes('chess_engine')}
                 />
               </ToolContainer>
             </Grid>
@@ -1457,7 +1482,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('dice_roll')}
-                  checked={tools.includes('dice_roll')}
+                  checked={displayTools.includes('dice_roll')}
                 />
               </ToolContainer>
             </Grid>
@@ -1478,7 +1503,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('weather_info')}
-                  checked={tools.includes('weather_info')}
+                  checked={displayTools.includes('weather_info')}
                 />
               </ToolContainer>
             </Grid>
@@ -1499,7 +1524,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('wikipedia_on_this_day')}
-                  checked={tools.includes('wikipedia_on_this_day')}
+                  checked={displayTools.includes('wikipedia_on_this_day')}
                 />
               </ToolContainer>
             </Grid>
@@ -1517,7 +1542,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('iss_tracker')}
-                  checked={tools.includes('iss_tracker')}
+                  checked={displayTools.includes('iss_tracker')}
                 />
               </ToolContainer>
             </Grid>
@@ -1538,7 +1563,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('sunrise_sunset')}
-                  checked={tools.includes('sunrise_sunset')}
+                  checked={displayTools.includes('sunrise_sunset')}
                 />
               </ToolContainer>
             </Grid>
@@ -1556,7 +1581,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('moon_phase')}
-                  checked={tools.includes('moon_phase')}
+                  checked={displayTools.includes('moon_phase')}
                 />
               </ToolContainer>
             </Grid>
@@ -1577,7 +1602,7 @@ const ToolsSection = ({
                 </Box>
                 <SquareSlideToggle
                   onChange={() => handleToggleTool('planet_visibility')}
-                  checked={tools.includes('planet_visibility')}
+                  checked={displayTools.includes('planet_visibility')}
                 />
               </ToolContainer>
             </Grid>

--- a/apps/client/app/components/Session/AdvancedAISettings.availability.test.tsx
+++ b/apps/client/app/components/Session/AdvancedAISettings.availability.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+/**
+ * The composer's tool indicators (the green primary-tool icons and the "+N" badge)
+ * must agree with the Tools picker: a tool whose API key is missing renders off
+ * there, so it must not show an icon or inflate the badge here.
+ *
+ * Asserts on the props handed to ToolsButton rather than the rendered icons, since
+ * ToolIndicators is presentational - it draws whatever it is given, so the wiring in
+ * this component is where the two surfaces can drift apart.
+ */
+
+const mocks = vi.hoisted(() => {
+  const state: Record<string, unknown> = {
+    tools: [] as string[],
+    toolMode: 'smart',
+    enabledMcpServers: null,
+    isQuestMasterEnabled: false,
+    isAgentsEnabled: false,
+    isLatticeEnabled: false,
+    model: 'gpt-4o',
+    thinking: { enabled: false, budget_tokens: 16000 },
+    quality: 'standard',
+    n: 1,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test double for the Zustand hook (selector + setState)
+  const useLLM: any = (selector: (s: Record<string, unknown>) => unknown) => selector(state);
+  useLLM.setState = vi.fn();
+  const toolAvailability = { value: undefined as Record<string, boolean> | undefined };
+  const toolsButtonProps = { value: null as Record<string, unknown> | null };
+  return { state, useLLM, toolAvailability, toolsButtonProps };
+});
+
+vi.mock('@client/app/contexts/LLMContext', () => ({ useLLM: mocks.useLLM }));
+vi.mock('@client/app/contexts/SessionsContext', () => ({
+  useSessions: () => ({ currentSessionId: null, workBenchAgents: [] }),
+}));
+vi.mock('@client/app/hooks/data/agents', () => ({ useGetSessionAgents: () => ({ data: [] }) }));
+vi.mock('@client/app/hooks/data/mcpServers', () => ({ useMcpServers: () => ({ data: [] }) }));
+vi.mock('@client/app/hooks/data/settings', () => ({
+  useConfig: () => ({ data: { toolAvailability: mocks.toolAvailability.value } }),
+}));
+vi.mock('@client/app/hooks/data/useModelInfo', () => ({
+  useModelInfo: () => ({ data: [{ id: 'gpt-4o', name: 'GPT-4o', supportsTools: true }] }),
+}));
+vi.mock('@client/app/hooks/useIsMobile', () => ({ useIsMobile: () => false, useIsTablet: () => false }));
+vi.mock('@client/app/hooks/useFeatureEnabled', () => ({
+  useFeatureEnabled: () => ({ isFeatureEnabled: () => false, isAdminFeatureEnabled: () => false }),
+}));
+vi.mock('./AISettings/useHydrateModelFromSession', () => ({ useHydrateModelFromSession: () => {} }));
+vi.mock('./AISettings/useAdvancedAISettingsStore', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- same shape of test double as useLLM
+  useAdvancedAISettings: (selector: any) =>
+    selector({ showAdvancedSettings: false, setShowAdvancedSettings: vi.fn(), setPromptBuilderOpen: vi.fn() }),
+}));
+vi.mock('./PromptBuilder/usePromptBuilderFirstRun', () => ({
+  usePromptBuilderFirstRun: () => ({ showHint: false, markSeen: vi.fn() }),
+}));
+vi.mock('./AISettings/InspectableSettingsButton', () => ({ default: () => null }));
+vi.mock('./AISettings/AdvancedAIModal', () => ({ AdvancedAIModal: () => null }));
+vi.mock('./AISettings/AgentsButton', () => ({ default: () => null }));
+vi.mock('./AISettings/BriefcaseButton', () => ({ default: () => null }));
+vi.mock('./AISettings/ResearchModeIndicator', () => ({ default: () => null }));
+vi.mock('./ImageTemplates/ImageTemplateControls', () => ({ ImageTemplateControls: () => null }));
+vi.mock('./PromptBuilder/PromptBuilderModal', () => ({ PromptBuilderModal: () => null }));
+vi.mock('./AISettings/ToolsButton', () => ({
+  default: (props: Record<string, unknown>) => {
+    mocks.toolsButtonProps.value = props;
+    return null;
+  },
+}));
+
+import AdvancedAISettings from './AdvancedAISettings';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const renderIndicators = () => {
+  render(
+    <AdvancedAISettings
+      stream={false}
+      setStream={vi.fn()}
+      spokenWords={0}
+      setSpokenWords={vi.fn()}
+      onRollDice={vi.fn()}
+      currentSession={null}
+    />,
+    { wrapper: Wrapper }
+  );
+  const props = mocks.toolsButtonProps.value;
+  return {
+    activePrimaryTools: props?.activePrimaryTools as string[],
+    otherActiveToolsCount: props?.otherActiveToolsCount as number,
+    tools: props?.tools as string[],
+  };
+};
+
+beforeEach(() => {
+  mocks.state.tools = [];
+  mocks.toolAvailability.value = undefined;
+  mocks.toolsButtonProps.value = null;
+});
+
+describe('AdvancedAISettings tool indicators vs availability', () => {
+  it('drops an unavailable primary tool from the indicator icons', () => {
+    mocks.state.tools = ['web_search', 'web_fetch'];
+    mocks.toolAvailability.value = { web_search: false };
+    expect(renderIndicators().activePrimaryTools).toEqual(['web_fetch']);
+  });
+
+  it('drops an unavailable non-primary tool from the "+N" badge count', () => {
+    mocks.state.tools = ['search_knowledge_base', 'math_evaluate'];
+    mocks.toolAvailability.value = { search_knowledge_base: false };
+    expect(renderIndicators().otherActiveToolsCount).toBe(1);
+  });
+
+  // Control: proves the two assertions above track availability rather than always
+  // shrinking the lists.
+  it('keeps both when the keys are present', () => {
+    mocks.state.tools = ['web_search', 'search_knowledge_base'];
+    mocks.toolAvailability.value = { web_search: true, search_knowledge_base: true };
+    const indicators = renderIndicators();
+    expect(indicators.activePrimaryTools).toEqual(['web_search']);
+    expect(indicators.otherActiveToolsCount).toBe(1);
+  });
+
+  // Control against an over-fix: availability is undefined until /serverConfig
+  // resolves, and treating that as missing would blank the indicators on first paint.
+  it('keeps both while availability is still loading', () => {
+    mocks.state.tools = ['web_search', 'search_knowledge_base'];
+    mocks.toolAvailability.value = undefined;
+    const indicators = renderIndicators();
+    expect(indicators.activePrimaryTools).toEqual(['web_search']);
+    expect(indicators.otherActiveToolsCount).toBe(1);
+  });
+
+  // ToolsButton's `tools` prop becomes ToolsSection's propTools, which
+  // handleToggleTool reads and rewrites. Handing it the filtered list would drop a
+  // key-gated preference the moment any other tool is toggled.
+  it('still hands ToolsButton the unfiltered preference array', () => {
+    mocks.state.tools = ['web_search', 'search_knowledge_base'];
+    mocks.toolAvailability.value = { web_search: false, search_knowledge_base: false };
+    expect(renderIndicators().tools).toEqual(['web_search', 'search_knowledge_base']);
+  });
+});

--- a/apps/client/app/components/Session/AdvancedAISettings.tsx
+++ b/apps/client/app/components/Session/AdvancedAISettings.tsx
@@ -7,6 +7,8 @@ import { useLLM } from '@client/app/contexts/LLMContext';
 import { useSessions } from '@client/app/contexts/SessionsContext';
 import { useGetSessionAgents } from '@client/app/hooks/data/agents';
 import { useMcpServers } from '@client/app/hooks/data/mcpServers';
+import { useConfig } from '@client/app/hooks/data/settings';
+import { filterToolsForDisplay } from '@client/app/utils/toolMapping';
 import { useIsMobile, useIsTablet } from '@client/app/hooks/useIsMobile';
 import { Casino as CasinoIcon, Tag as TagIcon } from '@mui/icons-material';
 import { useShallow } from 'zustand/react/shallow';
@@ -74,6 +76,10 @@ const AISettings: FC<AISettingsProps> = ({
   const enabledMcpServers = useLLM(state => state.enabledMcpServers);
   const { setState: setLLM } = useLLM;
 
+  // Presence-only availability of key-gated tools. Already mounted app-wide by
+  // WebsocketConfigProvider with a 5-min staleTime, so this shares that cache
+  // rather than adding a request.
+  const { data: serverConfig } = useConfig();
   const { data: mcpServersData = [] } = useMcpServers();
   const availableMcpServers = mcpServersData.filter(server => server.enabled).map(server => server.name);
 
@@ -96,7 +102,12 @@ const AISettings: FC<AISettingsProps> = ({
   };
 
   const primaryTools = ['web_search', 'web_fetch', 'image_generation'] as const;
-  const activePrimaryTools = primaryTools.filter(tool => tools.includes(tool as unknown as (typeof tools)[number]));
+  // Indicators must agree with the Tools picker: a tool whose key is missing renders
+  // off there, so it must not show an icon or feed the "+N" badge here either. The
+  // raw `tools` still goes to ToolsButton below - that array is what handleToggleTool
+  // reads and rewrites, so filtering it would drop preferences on the next toggle.
+  const displayTools = filterToolsForDisplay(tools, serverConfig?.toolAvailability);
+  const activePrimaryTools = primaryTools.filter(tool => displayTools.includes(tool));
   const isThinkingActive = thinking?.enabled ?? false;
   // Enabled integrations without their own icon (e.g. linkedin, notion) roll into the
   // "+N" badge; iconed ones (ICONED_MCP_SERVERS) are shown as icons and excluded here
@@ -111,7 +122,7 @@ const AISettings: FC<AISettingsProps> = ({
     (isAgentsFeatureEnabled && isAgentsEnabled ? 1 : 0) +
     (isLatticeFeatureEnabled && isLatticeEnabled ? 1 : 0);
   const otherActiveToolsCount =
-    tools.filter(
+    displayTools.filter(
       tool => !primaryTools.includes(tool as unknown as (typeof primaryTools)[number]) && tool !== 'dice_roll'
     ).length +
     specialToolsCount +
@@ -263,7 +274,8 @@ const AISettings: FC<AISettingsProps> = ({
 
         {!isTablet && (
           <>
-            {/* Dice Roll Icon */}
+            {/* Dice Roll Icon. Raw `tools` on purpose: dice_roll needs no API key, so
+                it has no toolAvailability entry and can never be key-gated. */}
             {tools.includes('dice_roll') && (
               <Tooltip title="Roll Dice">
                 <IconButton

--- a/apps/client/app/utils/toolMapping.ts
+++ b/apps/client/app/utils/toolMapping.ts
@@ -25,6 +25,7 @@ import {
 } from '@mui/icons-material';
 import { B4MLLMTools, OrchestrationDefaultsSchema } from '@bike4mind/common';
 import type { SlackLlmTools } from '@bike4mind/services';
+import type { ToolAvailability } from '@pages/api/settings/serverConfig';
 import React from 'react';
 
 export interface ToolInfo {
@@ -298,6 +299,35 @@ export const AGENT_MODE_TOOL_IDS: ReadonlySet<string> = (() => {
 
 /** Whether a Smart Tools toggle is honored when the composer is in Agent mode. */
 export const isToolAvailableInAgentMode = (toolName: B4MLLMTools): boolean => AGENT_MODE_TOOL_IDS.has(toolName);
+
+/**
+ * Whether the server reported this tool's required API key/config as missing
+ * (`serverConfig.toolAvailability`, computed by `computeToolAvailability` in
+ * `apps/client/pages/api/settings/serverConfig.ts`).
+ *
+ * Tests `=== false` on purpose: availability is `undefined` until /serverConfig
+ * resolves, and treating that as missing would blank the picker on first paint.
+ */
+export const isToolKeyMissing = (toolName: B4MLLMTools, availability: ToolAvailability | undefined): boolean =>
+  availability?.[toolName] === false;
+
+/**
+ * The user's enabled tools minus the ones whose key is missing, for DISPLAY and
+ * interaction gating only.
+ *
+ * A tool enabled while its key was present keeps its stored preference after the key
+ * goes away, so it restores when a valid key returns. Every surface that renders that
+ * preference (toggle state, "N pinned" tallies, composer indicators) has to combine it
+ * with availability, or a greyed-out row reads as enabled.
+ *
+ * NOT for building a send payload: the stored preference is still forwarded to the
+ * model on purpose (see `resolveTools` in useLLMSettingsAssembly), and dropping a tool
+ * here would silently diverge the request from what the user chose.
+ */
+export const filterToolsForDisplay = (
+  enabledTools: readonly B4MLLMTools[],
+  availability: ToolAvailability | undefined
+): B4MLLMTools[] => enabledTools.filter(tool => !isToolKeyMissing(tool, availability));
 
 export const getToolInfo = (toolName: PublicTools): ToolInfo | undefined => {
   return TOOL_MAPPING[toolName];


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="1280" height="720" alt="Tools popover on the PR preview: Knowledge Base greyed out with its switch off, header reading Individual tools (2 pinned), composer badge reading +1" src="https://github.com/user-attachments/assets/2312452b-dd3f-4689-ac91-ddb7627b8cd3" />

*Captured on `app.pr1104.preview.bike4mind.com` with three tools enabled (`search_knowledge_base`, `web_search`, `math_evaluate`) and `toolAvailability.search_knowledge_base = false`. The Knowledge Base row is greyed with its switch OFF, the header reads `Individual tools (2 pinned)` rather than 3, and the composer badge reads `+1` rather than the `+2` reported in #1076. `Web Search` directly above stays at full contrast with its switch green, so the filter follows availability instead of dimming everything. The focus ring on the Knowledge Base switch is the keyboard-focus check: pressing Enter there left the stored preference intact.*

## Description

Closes #1076.

A tool toggled on while its API key was present kept rendering on, and kept counting toward `Individual tools (N pinned)` and the composer's `+N` badge, after the key went away. The row was correctly greyed out and pointer-dead, so the picker showed a control that claimed to be enabled while refusing to be used, with no way to clear it. The row's own tooltip said the opposite of its switch.

Switch state and every tally now come from the stored preference AND server availability (`serverConfig.toolAvailability`). The stored preference is left untouched, so it restores when a valid key returns.

This is not specific to Knowledge Base. All seven key-gated tools (`web_search`, `deep_research`, `weather_info`, `wolfram_alpha`, `fmp_financial_data`, `image_generation`, `search_knowledge_base`) had the same latent bug, so the fix is one shared predicate applied at every display site rather than a patch on the one row that was reported.

One thing rendering the switch off did not fix on its own: `ToolContainer` blocks only pointer events, and the toggle is a real focusable `<button role="switch">`, so Enter or Space still reached `handleToggleTool`. With the switch reading off, that keypress would have silently deleted the stored preference this change is trying to preserve, with no visible feedback. `handleToggleTool` now refuses a key-gated tool as well.

## Changes

Shared helper (`apps/client/app/utils/toolMapping.ts`):

- `isToolKeyMissing(toolName, availability)` - the single home for the `=== false` convention, so an availability map that has not loaded yet (`undefined`) never gates.
- `filterToolsForDisplay(enabledTools, availability)` - enabled minus key-missing. Its docstring states it is for display and interaction gating only, never for building a send payload.

Tools picker (`ToolsSection.tsx`):

- All 21 tool-row switches read `displayTools` instead of the raw preference.
- `funPinnedCount` and `individualToolsCount` both derive from `displayTools`. Moving only one of them would have counted a filtered-out tool in the Individual total, so they change together.
- `getToolGate` now calls the shared `isToolKeyMissing` instead of inlining the comparison.
- `handleToggleTool` refuses a key-gated tool, closing the keyboard path described above.
- The recharts display-mode sub-control follows the rendered toggle rather than the raw preference.
- Corrected three comments that described the gate as mode-only, and one that asserted the pinned tally "reflects everything the user has toggled on" - the invariant this change deliberately replaces.

Composer indicators (`AdvancedAISettings.tsx`):

- `activePrimaryTools` (the green icons) and `otherActiveToolsCount` (the `+N` badge) derive from the same filtered list, which is the reported `+2`.
- `ToolsButton` still receives the unfiltered array: that is what `handleToggleTool` reads and rewrites, so filtering it would drop preferences on the next toggle of any other tool.

Tests: 15 new cases across `ToolsSection.gating.test.tsx` and a new `AdvancedAISettings.availability.test.tsx`.

## Guide for Testers

Test on the PR preview env (`app.pr<N>.preview.bike4mind.com`). Precondition: no admin OpenAI or VoyageAI key is configured for the workspace, otherwise availability never drops. Sign in as a non-admin user.

1. Confirm the `EnableKnowledgeBaseSearch` admin feature flag is on for the workspace. Expected: a `Knowledge Base` row appears in step 4 below. If it does not, the flag is off and the rest of this guide cannot run.
2. Go to `Profile -> API Keys -> OpenAI -> Add New Key` and paste the working-shaped key value from the Steps-to-reproduce section of #1076 (step 2 of the issue body; the identical value also appears in #1065 step 2). Save, then click `Activate` on the row. Expected: the row shows as active. An inactive key has no effect on availability.
3. Reload the page. Expected: a genuine fresh load, because `serverConfig` is client-cached for about 5 minutes.
4. Open the composer's `Tools` button, expand `Individual tools`, and toggle `Knowledge Base` ON. Expected: the switch turns green and is interactive, the section header gains one to its `(N pinned)` count, and the composer badge next to the Tools button gains one.
5. Go to `Profile -> API Keys` and delete the key you added in step 2. Expected: no OpenAI key remains on the account.
6. Reload the page again (a genuine fresh load, not a client-side navigation), then reopen `Tools -> Individual tools`.
7. Look at the `Knowledge Base` row. Expected: the label and description are greyed out, the row is not clickable, and the switch is in the OFF position. Before this fix the switch stayed green here, which is the bug.
8. Hover the greyed `Knowledge Base` row. Expected tooltip: `Requires an embeddings API key (VoyageAI or OpenAI) in Admin > API Keys, or a self-hosted local Ollama embedder (OLLAMA_BASE_URL).`
9. Read the `Individual tools (N pinned)` header and the composer badge. Expected: both are one lower than in step 4. If Knowledge Base was your only enabled tool, the header reads exactly `Individual tools` with no parenthetical, and the badge disappears rather than showing `+0`.
10. With the keyboard, Tab to the greyed `Knowledge Base` switch and press Enter or Space. Expected: nothing changes, and no error appears. The stored preference must survive this.
11. Re-add and `Activate` the key from step 2, then reload. Expected: the `Knowledge Base` row returns to full contrast, its switch is back ON and interactive, and both counts return to their step-4 values. This proves the preference was preserved, not deleted.

### Regression Checks

12. Set the composer's tool mode to `Fast`. Expected: every **Smart Tool** row greys out, but each switch keeps the position it had in Smart mode. Mode dimming must not flip a switch, because the preference applies again as soon as the mode changes. Quest Master, Agent Detection and Lattice are not Smart Tools (they have their own state flags, not entries in `tools`), so they correctly stay full-contrast and interactive; Thinking is disabled separately by model capability.
13. Turn on Agent mode (the bolt) and reopen `Tools`. Expected: the agent-ignored rows (for example `Wolfram Alpha`) grey out with their switches unchanged.
14. Toggle a few tools that need no API key (`Web Fetch`, `Current Date/Time`, `Math`). Expected: they toggle normally and the `(N pinned)` header tracks each one. Note the header and the `+N` badge are NOT expected to be equal: `web_search`, `web_fetch` and `image_generation` render as their own icon in the composer and are deliberately excluded from `+N` so they are not shown twice. So toggling `Web Fetch` moves the header and makes a globe icon appear or disappear next to the badge, while `+N` holds steady. `Current Date/Time` and `Math` have no icon, so they move `+N` by one each.
15. Open `Advanced AI Settings` and expand its embedded `Tools` panel. Expected: it shows the same switch states and counts as the composer dropdown.

### What NOT to test

- Whether the tool is actually withheld from the model. It is not, and that is deliberately out of scope here. An unavailable tool is still sent and `search_knowledge_base` degrades to keyword search. That is tracked separately in #1103, which also covers whether the tooltip overstates the breakage.
- The dice-roll icon. `dice_roll` needs no API key, has no availability entry, and is intentionally left reading the raw preference.

## Additional Information

The `#1076` Impact section assumed the gate is enforced server-side. It is not: `computeToolAvailability` is only ever called by the `/api/settings/serverConfig` route, and nothing in `b4m-core/services` imports it. Following that up produced #1103. It is a design decision (`serverConfig.ts` documents the leniency as intentional) and it needs `computeToolAvailability` to move out of the pages/api route, so it is not folded into this P3 display fix.

Coverage here is mutation-verified rather than just green. Reverting the display derivation kills 4 tests; removing only the `handleToggleTool` guard kills 1; reverting both `AdvancedAISettings` derivation sites kills 2. Six of the new cases are labelled controls that pass under revert on purpose, because they guard the opposite mistake: treating a still-loading `undefined` availability as missing, which would blank the picker on first paint.

`useConfig()` in `AdvancedAISettings` adds no request. `WebsocketConfigProvider` already mounts that query at the app root (`providers.tsx`) with a 5-minute `staleTime`, and react-query dedupes on the `['server-config']` key, so the roughly 12 lookups noted in `computeToolAvailability` are not repeated.

## Developer Notes (Optional)

- `filterToolsForDisplay` is the reusable seam for "what the user has enabled AND can actually use". Any future surface that renders per-tool enabled state should call it rather than reading `useLLM(s => s.tools)` directly. Its docstring marks the boundary: display and interaction gating only, never the send payload.
- The display-versus-preference split is the load-bearing decision. Clearing the preference when a key vanishes would have been simpler, but it loses the user's choice permanently on a transient key problem, and the restore behaviour in step 11 is the desirable half of the current design.
- `displayTools` in `ToolsSection` is a plain const rather than a `useMemo` because the pinned-count block sits after the component's early return for models that do not support tools, where hooks cannot be called.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc



