### PR TITLE
feat(session-types): add populateScheduleRace UI side-effect type

### DIFF
--- a/b4m-core/common/src/types/entities/SessionTypes.ts
+++ b/b4m-core/common/src/types/entities/SessionTypes.ts
@@ -49,11 +49,20 @@ export type PopulatedSolveOutputs = {
 
 export type UiSideEffect =
   | {
+      // A BARE scheduling problem populated by a formulate/edit tool. A solve tool's problem +
+      // race rides `populateScheduleRace` (below), NOT this type, so this payload is never a
+      // wrapper — a client bundle that predates the race feature reads it as the bare problem
+      // and stays correct.
       type: 'populateProblem';
-      // Either the bare scheduling problem (a formulate/edit tool) or that problem nested
-      // under `problem` with optional solve outputs (a solve tool). Consumers must handle
-      // both arms and must not assume the payload IS the problem.
-      payload: SchedulingProblemPayload | ({ problem: SchedulingProblemPayload } & PopulatedSolveOutputs);
+      payload: SchedulingProblemPayload;
+    }
+  | {
+      // A solve tool's scheduling problem WRAPPED with its solver-run outputs. Deliberately a
+      // distinct type from populateProblem: routing a wrapper through populateProblem would let
+      // an older client persist the wrapper as the active brief. A client that predates this
+      // type ignores it (its handler has no case) instead of mis-applying it.
+      type: 'populateScheduleRace';
+      payload: { problem: SchedulingProblemPayload } & PopulatedSolveOutputs;
     }
   | {
       // The unified families carry their familyId alongside the family-specific problem

--- a/b4m-core/services/src/llm/sharedToolBuilder.ts
+++ b/b4m-core/services/src/llm/sharedToolBuilder.ts
@@ -198,7 +198,15 @@ export interface BuildSharedToolsOptions {
 // payload is dispatched via onUiSideEffect (and the terse displayMessage replaces
 // the model-visible result) rather than echoed back to the model.
 // `populateDecomposition` loads a decomposed multi-step plan's first sub-problem.
-const VALID_SIDE_EFFECT_TYPES = new Set(['populateProblem', 'populateFamilyProblem', 'populateDecomposition']);
+// `populateScheduleRace` carries a solve tool's scheduling problem + its bounded race under a
+// type distinct from `populateProblem`, so a client predating it ignores the race rather than
+// persisting the wrapper as the brief (allowlisting it here is what lets the frame through).
+const VALID_SIDE_EFFECT_TYPES = new Set([
+  'populateProblem',
+  'populateScheduleRace',
+  'populateFamilyProblem',
+  'populateDecomposition',
+]);
 const TOOL_ARTIFACT_RE = /<artifact\s+([^>]*)>([\s\S]*?)<\/artifact>/gi;
 // Value is anchored to its own quote kind so a double-quoted value can contain
 // apostrophes (title="Bob's App") and vice versa. Group 2 is the double-quoted


### PR DESCRIPTION
## Description

Adds a new `populateScheduleRace` UI side-effect type so a solve tool can hand the client its solved problem **plus** the solver run that produced it, without overloading `populateProblem` (whose payload is a **bare** problem). Routing a wrapped payload through `populateProblem` would let a client on an older bundle read the wrapper as the problem and persist it as the active brief. A distinct type means a client that predates it has no handler case and simply ignores it.

Follow-up to the `UiSideEffect` widening in #1009. Pure type + allowlist change; no runtime behavior change for existing side-effects.

## Changes

- `b4m-core/common` `SessionTypes.ts`: add the `populateScheduleRace` variant to the `UiSideEffect` union (`{ problem: SchedulingProblemPayload } & PopulatedSolveOutputs`), and narrow `populateProblem` back to the bare `SchedulingProblemPayload` now that the wrapped shape has its own type.
- `b4m-core/services` `sharedToolBuilder.ts`: allowlist `populateScheduleRace` in `VALID_SIDE_EFFECT_TYPES` so its frame is dispatched (with its terse `displayMessage` replacing the model-visible result) instead of dropped server-side.

## Guide for Testers

Type-definition + allowlist PR with **no user-facing UI surface**. Verify mechanically:

1. Check out this branch.
2. Run `pnpm --filter @bike4mind/common typecheck` — expected: exits clean, 0 errors.
3. Grep the union: `grep -n "populateScheduleRace" b4m-core/common/src/types/entities/SessionTypes.ts b4m-core/services/src/llm/sharedToolBuilder.ts` — expected: the type appears in both the union and `VALID_SIDE_EFFECT_TYPES`.

**Regression Checks**
- `populateProblem` / `populateFamilyProblem` / `populateDecomposition` are unchanged in `VALID_SIDE_EFFECT_TYPES` (only an addition).
- No consumer reads a `populateScheduleRace` payload in this repo (it is produced/consumed by a private overlay); the only structural reader of `populate*` payloads here is `briefContextInjector`, which is untouched and gated to non-solve tools.

**What NOT to test**
- No UI changes, no settings, no API endpoints, no telemetry.

## Additional Information

The wrapped race shape is produced and consumed by an optimization solve tool in a private overlay; this host change only teaches the shared envelope contract about the new type so an older client degrades to ignoring the race rather than mis-applying it.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script — N/A
- [ ] I have made the UI/UX feel good — N/A (no UI)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields — N/A
