### PR TITLE
fix(client): stop the roster's coalesce timer leaking across channels, and give it a11y

### DIFF
--- a/apps/client/app/components/hearth/HearthPresencePanel.test.tsx
+++ b/apps/client/app/components/hearth/HearthPresencePanel.test.tsx
@@ -197,4 +197,97 @@ describe('HearthPresencePanel', () => {
     expect(panel).toHaveStyle({ overflowY: 'auto' });
     expect(getComputedStyle(panel).maxHeight).toBe('30dvh');
   });
+  it('announces only the sessions that need a human, not the busy ones', async () => {
+    apiGetMock.mockResolvedValue(
+      respondWith([
+        row('blocked', 'awaiting_permission'),
+        row('asking', 'awaiting_input'),
+        row('busy', 'running'),
+        row('done', 'idle'),
+      ])
+    );
+    renderPanel();
+
+    const announcer = await screen.findByTestId('hearth-presence-announcer');
+    await waitFor(() => expect(announcer).toHaveTextContent('2 sessions need attention'));
+    expect(announcer).toHaveTextContent('blocked needs permission');
+    expect(announcer).toHaveTextContent('asking needs you');
+    // A roster of several sessions each reporting per tool call would otherwise
+    // bury the one actionable line in a stream of "is working".
+    expect(announcer).not.toHaveTextContent('busy');
+    expect(announcer).not.toHaveTextContent('done');
+  });
+
+  it('says nothing when nobody needs attention', async () => {
+    apiGetMock.mockResolvedValue(respondWith([row('busy', 'running')]));
+    renderPanel();
+
+    await screen.findByText('Working');
+    expect(screen.getByTestId('hearth-presence-announcer')).toHaveTextContent('');
+  });
+
+  it('uses singular phrasing for one session', async () => {
+    apiGetMock.mockResolvedValue(respondWith([row('blocked', 'awaiting_permission')]));
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('hearth-presence-announcer')).toHaveTextContent('1 session needs attention')
+    );
+  });
+
+  it('exposes the roster as a labelled list with a real heading', async () => {
+    apiGetMock.mockResolvedValue(respondWith([row('busy', 'running'), row('done', 'idle')]));
+    renderPanel();
+
+    // The heading renders in every state including loading, so wait for the rows
+    // before asserting the list - otherwise this races the query.
+    await waitFor(() => expect(screen.getAllByTestId('hearth-presence-row')).toHaveLength(2));
+    // Joy's title-sm maps to <p>, so the panel had no landmark to navigate to.
+    const heading = screen.getByRole('heading', { name: 'Who is here' });
+    const list = screen.getByRole('list');
+    expect(list).toHaveAttribute('aria-labelledby', heading.id);
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  // The timer leak. Arming a refresh on one channel and switching before the
+  // coalesce window closes used to invalidate the OLD key, swallowing one refresh
+  // for the channel just switched to.
+  it('does not let a pending refresh fire against the previous channel', async () => {
+    vi.useFakeTimers();
+    try {
+      apiGetMock.mockResolvedValue(respondWith([row('busy', 'running')]));
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const view = render(
+        <CssVarsProvider theme={appTheme}>
+          <QueryClientProvider client={queryClient}>
+            <HearthPresencePanel channelId="ch-1" />
+          </QueryClientProvider>
+        </CssVarsProvider>
+      );
+
+      // Two events inside the window: the first refreshes on the leading edge,
+      // the second arms the trailing timer.
+      await pushWs({ action: 'hearth_event', event: { channelId: 'ch-1', kind: 'presence' } });
+      await pushWs({ action: 'hearth_event', event: { channelId: 'ch-1', kind: 'presence' } });
+
+      invalidateSpy.mockClear();
+      view.rerender(
+        <CssVarsProvider theme={appTheme}>
+          <QueryClientProvider client={queryClient}>
+            <HearthPresencePanel channelId="ch-2" />
+          </QueryClientProvider>
+        </CssVarsProvider>
+      );
+      vi.advanceTimersByTime(2000);
+
+      const staleInvalidations = invalidateSpy.mock.calls.filter(
+        ([arg]) =>
+          JSON.stringify((arg as { queryKey: unknown }).queryKey) === JSON.stringify(['hearth', 'presence', 'ch-1'])
+      );
+      expect(staleInvalidations).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/client/app/components/hearth/HearthPresencePanel.tsx
+++ b/apps/client/app/components/hearth/HearthPresencePanel.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { IHearthEventAction, ICcAgentStatus } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
 import { useWebsocket } from '@client/app/contexts/WebsocketContext';
+import { visuallyHidden } from '@client/app/utils/a11yStyles';
 import { useActorColor } from './actorColors';
 
 // Reuses the shared code-agent status vocabulary rather than a parallel one,
@@ -72,6 +73,14 @@ const MAX_ROSTER_HEIGHT = '30dvh';
  */
 const STALE_ROW_OPACITY = 0.7;
 
+/**
+ * The states that mean a human has to do something. Announced; the rest are not,
+ * because a roster of several sessions each reporting per tool call would turn a
+ * screen reader into a stream of "is working" with the one actionable line buried
+ * in it.
+ */
+const ATTENTION_STATES: ReadonlySet<PresenceState> = new Set(['awaiting_permission', 'awaiting_input']);
+
 function useNow(): number {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -129,11 +138,18 @@ export default function HearthPresencePanel({ channelId }: { channelId: string }
     }, REFRESH_COALESCE_MS - elapsed);
   }, [queryClient, channelId]);
 
+  // Keyed on channelId, not []: a timer armed for the previous channel used to
+  // survive the switch, fire, and invalidate the OLD query key - swallowing one
+  // refresh for the channel the user had just moved to. Reads as flaky presence
+  // rather than as a bug, which is why it is worth the dependency.
   useEffect(() => {
     return () => {
-      if (pendingRef.current) clearTimeout(pendingRef.current);
+      if (pendingRef.current) {
+        clearTimeout(pendingRef.current);
+        pendingRef.current = null;
+      }
     };
-  }, []);
+  }, [channelId]);
 
   useEffect(() => {
     // Only presence events can change a roster row, so other kinds are ignored
@@ -147,6 +163,16 @@ export default function HearthPresencePanel({ channelId }: { channelId: string }
 
   const rows = roster.data?.presence ?? [];
   const staleAfterMs = roster.data?.staleAfterMs;
+  // Distinct per channel, so two mounted panels cannot both own the same id.
+  const headingId = `hearth-presence-heading-${channelId}`;
+
+  const attention = rows.filter(row => ATTENTION_STATES.has(row.state));
+  const attentionSummary =
+    attention.length === 0
+      ? ''
+      : `${attention.length} ${attention.length === 1 ? 'session needs' : 'sessions need'} attention: ${attention
+          .map(row => `${row.actorName ?? row.actorId} ${STATE_CHIPS[row.state].label.toLowerCase()}`)
+          .join(', ')}`;
 
   return (
     <Sheet
@@ -154,9 +180,21 @@ export default function HearthPresencePanel({ channelId }: { channelId: string }
       sx={{ p: 1.5, borderRadius: 0, maxHeight: MAX_ROSTER_HEIGHT, overflowY: 'auto' }}
       data-testid="hearth-presence-panel"
     >
-      <Typography level="title-sm" sx={{ mb: rows.length > 0 ? 1 : 0 }}>
+      {/* `component` so this is a real heading: Joy's title-sm maps to <p>, which
+          left the panel with no landmark to navigate to. */}
+      <Typography level="title-sm" component="h3" id={headingId} sx={{ mb: rows.length > 0 ? 1 : 0 }}>
         Who is here
       </Typography>
+      {/*
+        A transition into "Needs permission" is the one event in this feature that
+        is genuinely urgent for a human, and it was announced to nobody. Only the
+        actionable states go in the live region, and only their names - the clock
+        tick re-renders this component every 30s, and aria-live re-announces on
+        CHANGED text, so including lastSeen here would nag on a timer.
+      */}
+      <Box aria-live="polite" aria-atomic="true" sx={visuallyHidden} data-testid="hearth-presence-announcer">
+        {attentionSummary}
+      </Box>
       {/*
         Loading and failure must never render as "nobody is here". All three
         collapsed into the empty message before, and the error version was
@@ -194,7 +232,7 @@ export default function HearthPresencePanel({ channelId }: { channelId: string }
           No presence reported in this channel yet.
         </Typography>
       ) : (
-        <Stack spacing={0.75}>
+        <Stack spacing={0.75} role="list" aria-labelledby={headingId}>
           {rows.map(row => {
             // Falls back to 'running' for an unrecognized state, matching the
             // server-side default: never claim the human's attention on a guess.
@@ -209,6 +247,7 @@ export default function HearthPresencePanel({ channelId }: { channelId: string }
                 spacing={1}
                 alignItems="center"
                 flexWrap="wrap"
+                role="listitem"
                 sx={{ opacity: stale ? STALE_ROW_OPACITY : 1 }}
                 data-testid="hearth-presence-row"
               >

--- a/apps/client/pages/api/hearth/__tests__/hearthRoutes.test.ts
+++ b/apps/client/pages/api/hearth/__tests__/hearthRoutes.test.ts
@@ -498,3 +498,37 @@ describe('/api/hearth/channels', () => {
     expect((res.body as { channels: Array<{ id: string }> }).channels[0].id).toBe('ch-1');
   });
 });
+
+/**
+ * Scope declarations for EVERY hearth route, not just presence.
+ *
+ * `requiredScopes` is enforced inside baseApi, which this suite mocks, so no test
+ * here can prove enforcement - what it CAN prove is that each route asks for the
+ * right list, which is the part a refactor silently changes. Before the harness
+ * recorded the config, nothing in the suite asserted any route's scopes at all.
+ */
+describe('hearth route scope declarations', () => {
+  const READ_OR_WRITE = ['hearth:read', 'hearth:write', 'admin:*'];
+
+  it.each([
+    ['channels', () => channelsRouter, READ_OR_WRITE],
+    ['catchup', () => catchupRouter, READ_OR_WRITE],
+    ['presence', () => presenceRouter, READ_OR_WRITE],
+    // events is the asymmetric one and deliberately so: appending is a write, so
+    // a hearth:read key must NOT reach it. Pinning the difference is the point -
+    // widening this list to match its siblings would hand every read-only key the
+    // ability to append to the log.
+    ['events', () => eventsRouter, ['hearth:write', 'admin:*']],
+  ])('%s declares its scope list', (_name, router, expected) => {
+    expect(router()._config?.requiredScopes).toEqual(expected);
+  });
+
+  it('no route omits requiredScopes entirely', () => {
+    // An undefined list is the dangerous default: baseApi would apply no scope
+    // constraint at all, and every assertion above would still read as coverage.
+    for (const router of [channelsRouter, catchupRouter, presenceRouter, eventsRouter]) {
+      expect(router._config?.requiredScopes).toBeDefined();
+      expect(router._config?.requiredScopes?.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Three findings from the Hearth post-merge audit (#1093) that #1096 and #1097 unblocked by merging. All in files no open PR holds, so this is conflict-free against #1094 and #1091.

## The coalesce timer leaked across a channel switch

`HearthPresencePanel`'s cleanup effect had `[]` deps, so a refresh armed for the previous channel survived the switch, fired, and invalidated the **old** query key - swallowing one refresh for the channel the user had just moved to.

It presents as flaky presence rather than as a bug, which is what makes it worth a test: switch channels while a burst is in flight and the new channel's roster is silently one event stale until the next presence event arrives. On a quiet channel that can be a long time.

Keyed on `channelId` now, with the ref nulled on clear. The test drives two events inside the coalesce window (first refreshes on the leading edge, second arms the trailing timer), switches channel, advances timers, and asserts no invalidation lands on `['hearth','presence','ch-1']`. Reverting the deps to `[]` fails it - verified, not assumed.

## The panel had no accessibility affordances at all

- **"Who is here" was a `<p>`.** Joy's `title-sm` maps to one, so the panel had no landmark to navigate to. It is an `<h3>` now via `component`.
- **Rows were flat sibling paragraphs.** They carry `role="listitem"` inside a `role="list"` labelled by the heading.
- **A transition into "Needs permission" was announced to nobody.** That is the one event in this whole feature that is genuinely urgent for a human - a session is halted, waiting on them, and the roster exists precisely to surface it. There is now a visually-hidden `aria-live="polite"` region.

The live region carries **only** the attention states (`awaiting_permission`, `awaiting_input`) and only their names. Two deliberate constraints behind that:

- Announcing every state would turn a screen reader into a stream of "is working" with the actionable line buried in it, since presence is the bulk of Hearth traffic and several sessions each report per tool call.
- `aria-live` re-announces on *changed* text, so including `lastSeen` would nag on the 30-second clock tick even when nothing happened. The summary changes only when the set of actors needing attention changes.

`ATTENTION_STATES` is a `Set<PresenceState>` rather than a string check, so adding a presence state forces a decision about whether it announces.

## Scope declarations are asserted for all four routes, not one

#1096 taught the test harness to record the route config so `presence.ts`'s scope list could be asserted by value. This uses it for the other three, which closes the audit's "nothing in the suite asserts any route's scope list" properly rather than for a single route.

The interesting part is that the lists are **not** uniform, and pinning that is the point:

| Route | `requiredScopes` |
|---|---|
| `channels`, `catchup`, `presence` | `hearth:read`, `hearth:write`, `admin:*` |
| `events` | `hearth:write`, `admin:*` |

`events` has no read scope because appending is a write. Widening it to match its siblings - the obvious "make these consistent" refactor - would hand every read-only key the ability to append to the log. A companion case asserts no route omits `requiredScopes` entirely, since an undefined list means no scope constraint at all while every other assertion in the suite would still read as coverage.

To be explicit about what these tests do and do not prove: enforcement happens inside `baseApi`, which this suite mocks, so nothing here proves a scope is enforced. What it proves is that each route *asks* for the right list, which is the part a refactor changes silently.

## Verified

59 tests across `app/components/hearth` and `pages/api/hearth`, `tsc --noEmit -p apps/client`, eslint clean. The timer test was confirmed to fail against the bug it covers.

## Still open from #1093

The database cluster waits on **#1091**: `presenceStateForReason` reading through `Object.prototype` (a `reason` of `constructor` persists a state outside the declared enum), the E11000 insert race that drops a newer presence event, and the unbounded roster read needing `$limit`. The hook and bridge items wait on **#1094**: `basename(cwd)` publishing the OS username when the session cwd is the home directory, tier-2 activity values not being the closed set the comment claims, and the bridge's `machine.payload` not being projectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuwWCLgi8mtWjDTDMJ6XcS