### PR TITLE
test(client): re-login for a fresh token in logout e2e tests

### DIFF
--- a/apps/client/e2e/auth.spec.ts
+++ b/apps/client/e2e/auth.spec.ts
@@ -1,8 +1,34 @@
+import { type APIRequestContext } from '@playwright/test';
 import { test, expect } from './fixtures';
 import { TIMEOUTS } from './constants';
-import { getTestUsers } from './helpers/test-users';
+import { getTestUsers, getTestRunId, getE2ETestId } from './helpers/test-users';
 import { seedAuthOnPage } from './helpers/auth-seed';
-import { apiGetOtcCode } from './helpers/api';
+import { apiCreateTestUser, apiGetOtcCode, apiLoginViaOtc } from './helpers/api';
+
+/**
+ * Mint a dedicated throwaway account for a test that logs out. Logout revokes every token
+ * the user holds (tokenVersion bump), so a test that logs out MUST NOT use a shared spec user -
+ * it would kill that user's session for every parallel spec. The email mirrors the setup
+ * convention (`...-<id>-e2e@test.com`) so global-teardown's cleanup sweep matches and removes it.
+ */
+async function createLogoutUser(request: APIRequestContext, label: string) {
+  const e2eId = getE2ETestId();
+  const idSuffix = e2eId ? `${e2eId}-${getTestRunId()}` : getTestRunId();
+  const email = `auth-${label}-${idSuffix}-e2e@test.com`;
+  const result = await apiCreateTestUser(request, {
+    username: `auth-${label}-${idSuffix}`,
+    email,
+    name: `Auth ${label} ${idSuffix}`,
+    password: `E2eAuth${label}Pass123!`,
+    isAdmin: false,
+  });
+  return {
+    email,
+    userId: (result.user.id || result.user._id) as string,
+    accessToken: result.accessToken,
+    refreshToken: result.refreshToken,
+  };
+}
 
 test.describe('Authentication', () => {
   test('authenticated session loads the app', async ({ basePage, page }) => {
@@ -56,8 +82,9 @@ test.describe('Authentication', () => {
     await expect(page).toHaveURL(/.*login.*/);
   });
 
-  test('should logout successfully', async ({ basePage, navigationPage, page }) => {
-    const { user } = getTestUsers();
+  test('should logout successfully', async ({ basePage, navigationPage, page, request }) => {
+    // Dedicated user: logout revokes all of the user's tokens, so we must not log out a shared one.
+    const user = await createLogoutUser(request, 'logout');
     await basePage.clearAllStorage();
     await seedAuthOnPage(page, { accessToken: user.accessToken, refreshToken: user.refreshToken });
     await page.goto('/');
@@ -69,8 +96,8 @@ test.describe('Authentication', () => {
   });
 
   // Skipped: indexedDB is not cleared after logout. Covered by a manual test; re-enable once the fix lands.
-  test.skip('should clear IndexedDB caches on logout', async ({ basePage, navigationPage, page }) => {
-    const { user } = getTestUsers();
+  test.skip('should clear IndexedDB caches on logout', async ({ basePage, navigationPage, page, request }) => {
+    const user = await createLogoutUser(request, 'cachelogout');
     await basePage.clearAllStorage();
     await seedAuthOnPage(page, { accessToken: user.accessToken, refreshToken: user.refreshToken });
     await basePage.dismissModals();
@@ -217,9 +244,15 @@ test.describe('Authentication', () => {
     }
   });
 
-  test('should load fresh data after re-login (no stale cache)', async ({ basePage, navigationPage, page }) => {
+  test('should load fresh data after re-login (no stale cache)', async ({
+    basePage,
+    navigationPage,
+    page,
+    request,
+  }) => {
     test.slow();
-    const { user } = getTestUsers();
+    // Dedicated user: logout revokes the seeded token, so we re-login below for a fresh one.
+    const user = await createLogoutUser(request, 'relogin');
     await basePage.clearAllStorage();
     // Seed auth, navigate to populate cache, then logout
     await seedAuthOnPage(page, { accessToken: user.accessToken, refreshToken: user.refreshToken });
@@ -237,8 +270,10 @@ test.describe('Authentication', () => {
       { timeout: TIMEOUTS.ACTION }
     );
 
-    // Re-seed auth and verify notebooks load from server (not stale cache)
-    await seedAuthOnPage(page, { accessToken: user.accessToken, refreshToken: user.refreshToken });
+    // Logout revoked the seeded token (all tokens for the user are killed), so re-login for a
+    // fresh session before re-seeding - otherwise /api/identify rejects the dead token with 401.
+    const fresh = await apiLoginViaOtc(request, user.email);
+    await seedAuthOnPage(page, { accessToken: fresh.accessToken, refreshToken: fresh.refreshToken });
     await basePage.dismissModals();
 
     // Navigate to notebooks to trigger the quest-plans fetch

--- a/apps/client/e2e/auth.spec.ts
+++ b/apps/client/e2e/auth.spec.ts
@@ -10,13 +10,20 @@ import { apiCreateTestUser, apiGetOtcCode, apiLoginViaOtc } from './helpers/api'
  * the user holds (tokenVersion bump), so a test that logs out MUST NOT use a shared spec user -
  * it would kill that user's session for every parallel spec. The email mirrors the setup
  * convention (`...-<id>-e2e@test.com`) so global-teardown's cleanup sweep matches and removes it.
+ *
+ * The retry index is baked into the identity: attempt 0 already created (and logged out)
+ * `auth-<label>0-...`, and createUser rejects a duplicate username OR email, so without this a
+ * retry would die inside apiCreateTestUser instead of re-running the test - defeating the retry
+ * safety net for exactly these tests. The marker stays BEFORE the `<id>-<runId>` tail so both
+ * cleanup regexes in pages/api/test/cleanup.ts still match.
  */
 async function createLogoutUser(request: APIRequestContext, label: string) {
   const e2eId = getE2ETestId();
   const idSuffix = e2eId ? `${e2eId}-${getTestRunId()}` : getTestRunId();
-  const email = `auth-${label}-${idSuffix}-e2e@test.com`;
+  const slug = `auth-${label}${test.info().retry}`;
+  const email = `${slug}-${idSuffix}-e2e@test.com`;
   const result = await apiCreateTestUser(request, {
-    username: `auth-${label}-${idSuffix}`,
+    username: `${slug}-${idSuffix}`,
     email,
     name: `Auth ${label} ${idSuffix}`,
     password: `E2eAuth${label}Pass123!`,

--- a/apps/client/e2e/helpers/api.ts
+++ b/apps/client/e2e/helpers/api.ts
@@ -190,7 +190,15 @@ export async function apiLoginViaOtc(
   if (!verifyResponse.ok()) {
     throw new Error(`OTC verify failed: ${verifyResponse.status()} ${verifyResponse.statusText()}`);
   }
-  const body = (await verifyResponse.json()) as { accessToken: string; refreshToken: string };
+  // /api/otc/verify returns 200 without tokens in some envs (MFA-enforced ->
+  // mfaRequired/mfaSetupRequired; registrationRequired -> no tokens). Fail loud and local
+  // here instead of returning undefined tokens that surface later as an opaque auth-seed 401.
+  const body = (await verifyResponse.json()) as { accessToken?: string; refreshToken?: string };
+  if (!body.accessToken || !body.refreshToken) {
+    throw new Error(
+      `OTC verify returned no tokens (mfaRequired/registrationRequired?): keys=${Object.keys(body).join(',')}`
+    );
+  }
   return { accessToken: body.accessToken, refreshToken: body.refreshToken };
 }
 

--- a/apps/client/e2e/helpers/api.ts
+++ b/apps/client/e2e/helpers/api.ts
@@ -162,6 +162,38 @@ export async function apiGetOtcCode(request: APIRequestContext, email: string): 
   return body.code;
 }
 
+/**
+ * Full passwordless re-login for an existing test account: /api/otc/send to mint a pending token,
+ * read the emailed code back via the non-prod test endpoint, then /api/otc/verify for fresh tokens.
+ * Use when a test needs a genuinely NEW session - e.g. after logout, which revokes every prior
+ * token for the user (tokenVersion bump), so reusing a seeded token would 401. Non-prod only
+ * (same gating as apiGetOtcCode).
+ */
+export async function apiLoginViaOtc(
+  request: APIRequestContext,
+  email: string
+): Promise<{ accessToken: string; refreshToken: string }> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const normalizedEmail = email.toLowerCase().trim();
+
+  const sendResponse = await request.post(`${baseURL}/api/otc/send`, { data: { email: normalizedEmail } });
+  if (!sendResponse.ok()) {
+    throw new Error(`OTC send failed: ${sendResponse.status()} ${sendResponse.statusText()}`);
+  }
+  const { pendingToken } = (await sendResponse.json()) as { pendingToken: string };
+
+  const code = await apiGetOtcCode(request, normalizedEmail);
+
+  const verifyResponse = await request.post(`${baseURL}/api/otc/verify`, {
+    data: { email: normalizedEmail, code, pendingToken },
+  });
+  if (!verifyResponse.ok()) {
+    throw new Error(`OTC verify failed: ${verifyResponse.status()} ${verifyResponse.statusText()}`);
+  }
+  const body = (await verifyResponse.json()) as { accessToken: string; refreshToken: string };
+  return { accessToken: body.accessToken, refreshToken: body.refreshToken };
+}
+
 export async function apiCreateFile(
   request: APIRequestContext,
   token: string,


### PR DESCRIPTION
## Description

The `main` E2E (Core) gate has been red since ~2026-07-28 16:56 UTC, blocking prod deploys. Root cause is a stale assumption in the auth E2E suite, not a product regression.

`feat(auth): revoke sessions on logout (#788)` changed logout from a client-only token clear to a server-side `tokenVersion` bump, which invalidates **every** token the user holds. Two auth specs still assumed the pre-#788 behavior:

1. `should load fresh data after re-login (no stale cache)` logs out, then re-seeds the app with the **same** access token to simulate re-login. That token is now dead, so `/api/identify` returns 401 during auth-seed and the test fails on all retries (the deterministic gate failure).
2. Several logout specs used the **shared** `getTestUsers().user` (the `projects` spec user). Logging that user out now revokes its session for every parallel spec - harmless in the Core shard (which doesn't run `projects`) but a latent landmine for the full suite.

## Changes

- **`helpers/api.ts`** - add `apiLoginViaOtc(request, email)`: a full passwordless re-login (`/api/otc/send` -> read code via the non-prod `/api/test/otc-code` -> `/api/otc/verify`) that returns fresh tokens. Mirrors the app's real login flow.
- **`auth.spec.ts`** - add `createLogoutUser(request, label)` so every logout test mints its **own** throwaway account instead of revoking a shared spec user. Emails follow the setup convention (`...-<id>-e2e@test.com`) so global-teardown's cleanup sweep removes them.
- **`auth.spec.ts`** - `should load fresh data after re-login` now re-logs-in for a fresh token before re-seeding, instead of reusing the revoked one.
- Applied the same dedicated-user fix to `should logout successfully` and the (skipped) `should clear IndexedDB caches on logout`.

## Guide for Testers

This is an E2E-test-only change; the E2E gate itself is the test. It runs against `app.staging.bike4mind.com`.

1. Wait for the `e2e/core` check on this PR to complete (triggered via the deployer, runs `--project=unauthenticated --project=notebook --project=prompts`).
2. Confirm the check is green. Expected: `Core e2e subset passed (24/24)`, with `0 failed`.
3. In the Playwright output, confirm `[unauthenticated] > e2e/auth.spec.ts:... > should load fresh data after re-login (no stale cache)` **passes** (previously failed with `auth-seed: /api/identify returned 401 for the provided token`).
4. Confirm `should logout successfully` still passes.

### Regression Checks
- The `unauthenticated`, `notebook`, and `prompts` projects all stay green - no shared-user session was revoked out from under a parallel spec.
- `logs in via the full OTC flow` still passes (shares the same OTC send/verify path the new `apiLoginViaOtc` helper exercises).

### What NOT to test
- No product/runtime code changed - only files under `apps/client/e2e/`. No UI, API, or behavior change ships to users.

## Additional Information

- Typecheck (`tsgo --noEmit`) and ESLint both pass locally on the changed files.
- Bisected the red/green boundary to `886d4082` (#788) via the E2E Core run history.
