### PR TITLE
feat(analytics): platform-wide usage aggregation backend

### DIFF
--- a/apps/client/pages/api/admin/platform-usage.ts
+++ b/apps/client/pages/api/admin/platform-usage.ts
@@ -1,0 +1,120 @@
+import { baseApi } from '@server/middlewares/baseApi';
+import { usageEventRepository, apiKeyUsageLogRepository, userApiKeyRepository } from '@bike4mind/database';
+import { organizationRepository } from '@bike4mind/database/infra';
+import {
+  COMPLETION_SOURCES,
+  CreditHolderType,
+  type IPlatformEndpointUsage,
+  type IPlatformUsageDashboardResponse,
+  type NamedPlatformConsumerUsage,
+} from '@bike4mind/common';
+import { ForbiddenError } from '@server/utils/errors';
+import { resolveUserNames } from '@server/utils/resolveUserNames';
+import { z } from 'zod';
+
+/** Guards the id casts in the $in lookups below from a BSONError 500 (see resolveUserNames). */
+const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
+
+/** ApiKeyUsageLog's 90-day TTL: no endpoint data exists beyond this. */
+const ENDPOINT_TTL_DAYS = 90;
+
+const QuerySchema = z.object({
+  // Trailing window in days, clamped so a stray value can't turn this into a
+  // full-collection scan.
+  days: z.coerce.number().int().min(1).max(365).optional(),
+  // Optional filters, applied as the same kind of $match addition (not separate
+  // query paths). Omit either to span all sources / all owner types.
+  source: z.enum(COMPLETION_SOURCES).optional(),
+  ownerType: z.enum([CreditHolderType.User, CreditHolderType.Organization]).optional(),
+});
+
+/**
+ * GET /api/admin/platform-usage - platform-wide usage for the admin consumer
+ * view. Two intentionally distinct sections:
+ *  - UsageEvent-derived (feature/COGS/credits/tokens), source- and
+ *    ownerType-filterable, with API-key consumers resolved to key/owner labels.
+ *  - ApiKeyUsageLog-derived endpoint/latency (request counts only, no credits).
+ * Admin-only.
+ */
+const handler = baseApi().get(async (req, res) => {
+  if (!req.user) {
+    throw new ForbiddenError('Authentication required');
+  }
+  if (!req.user.isAdmin) {
+    throw new ForbiddenError('Admin access required');
+  }
+
+  const { days = 30, source, ownerType } = QuerySchema.parse(req.query);
+
+  // ApiKeyUsageLog logs only api/cli (API-key) traffic; a web/agent/system filter
+  // has no endpoint data by construction, so skip that section rather than imply
+  // it's empty for a real reason. Window is clamped to the collection's TTL.
+  const endpointSourceApplies = !source || source === 'api' || source === 'cli';
+  const endpointWindowDays = Math.min(days, ENDPOINT_TTL_DAYS);
+
+  const [summary, endpoints] = await Promise.all([
+    usageEventRepository.platformUsageSummary({ days, source, ownerType }),
+    endpointSourceApplies
+      ? apiKeyUsageLogRepository.platformEndpointUsage({ days: endpointWindowDays })
+      : Promise.resolve<IPlatformEndpointUsage | null>(null),
+  ]);
+
+  // Resolve each consumer's apiKeyId -> key name/prefix + owner (user or org) name.
+  const consumerKeyIds = [...new Set(summary.byConsumer.map(c => c.apiKeyId))].filter(id => OBJECT_ID_RE.test(id));
+  const keys = consumerKeyIds.length ? await userApiKeyRepository.find({ _id: { $in: consumerKeyIds } }) : [];
+
+  const keyById = new Map(
+    keys.map(k => {
+      // Org-billed keys attribute to the org pool; personal keys to the user.
+      const billsOrg = k.billingOwnerType === CreditHolderType.Organization && !!k.organizationId;
+      return [
+        String(k.id),
+        {
+          keyName: k.name,
+          keyPrefix: k.keyPrefix,
+          ownerId: billsOrg ? (k.organizationId as string) : k.userId,
+          ownerType: billsOrg ? CreditHolderType.Organization : CreditHolderType.User,
+        },
+      ] as const;
+    })
+  );
+
+  const owners = [...keyById.values()];
+  const userOwnerIds = owners.filter(o => o.ownerType === CreditHolderType.User).map(o => o.ownerId);
+  const orgOwnerIds = [
+    ...new Set(owners.filter(o => o.ownerType === CreditHolderType.Organization).map(o => o.ownerId)),
+  ].filter(id => OBJECT_ID_RE.test(id));
+
+  const [userNames, orgs] = await Promise.all([
+    resolveUserNames(userOwnerIds),
+    orgOwnerIds.length ? organizationRepository.find({ _id: { $in: orgOwnerIds } }) : Promise.resolve([]),
+  ]);
+  const orgNameById = new Map(orgs.map(o => [String(o.id), o.name]));
+
+  const byConsumer: NamedPlatformConsumerUsage[] = summary.byConsumer.map(c => {
+    const meta = keyById.get(c.apiKeyId);
+    const ownerName = meta
+      ? meta.ownerType === CreditHolderType.Organization
+        ? orgNameById.get(meta.ownerId)
+        : userNames.get(meta.ownerId)
+      : undefined;
+    return { ...c, ...meta, ownerName };
+  });
+
+  const response: IPlatformUsageDashboardResponse = {
+    days,
+    source,
+    ownerType,
+    overTime: summary.overTime,
+    byFeature: summary.byFeature,
+    byConsumer,
+    byModel: summary.byModel,
+    totals: summary.totals,
+    endpoints,
+    endpointWindowDays,
+  };
+
+  return res.json(response);
+});
+
+export default handler;

--- a/apps/client/pages/api/ai/sound-effects.ts
+++ b/apps/client/pages/api/ai/sound-effects.ts
@@ -139,6 +139,8 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(asyn
         feature: 'sound_effects',
         provider,
         model: provider,
+        // Matches this call's ledger write (deductCreditsWithOrgSupport, source: 'api').
+        source: 'api',
         inputTokens: 0,
         outputTokens: 0,
         cachedInputTokens: 0,

--- a/b4m-core/common/src/types/analytics.ts
+++ b/b4m-core/common/src/types/analytics.ts
@@ -40,6 +40,38 @@ export interface UsageBySourceResponse {
 }
 
 /**
+ * One endpoint+method's request/latency rollup from the API-key usage log
+ * (ApiKeyUsageLog). Request counts and latency only - this collection carries no
+ * credits/COGS/feature, so this section must stay distinct from the UsageEvent
+ * (COGS/credits) cuts and never imply COGS-per-endpoint.
+ */
+export interface IEndpointUsageBucket {
+  endpoint: string;
+  method: string;
+  requests: number;
+  avgResponseTimeMs: number;
+  p95ResponseTimeMs: number;
+  /** Fraction 0..1 of requests with statusCode >= 400. */
+  errorRate: number;
+}
+
+/** Endpoint request count for one UTC day (over-time chart point). */
+export interface IEndpointUsageDay {
+  day: string; // YYYY-MM-DD (UTC)
+  requests: number;
+}
+
+/**
+ * Endpoint-level platform usage from ApiKeyUsageLog. This collection logs only
+ * API-key-authed requests and has a 90-day TTL, so windows beyond 90d degrade to
+ * credit/feature (UsageEvent) data only.
+ */
+export interface IPlatformEndpointUsage {
+  byEndpoint: IEndpointUsageBucket[];
+  overTime: IEndpointUsageDay[];
+}
+
+/**
  * Resolves source for the /api/ai/v1/completions endpoint. This endpoint is
  * called only by CLI and 3rd-party API users (never by web chat - that uses a
  * different pipeline). We distinguish CLI from raw API by the `b4m-cli/`

--- a/b4m-core/common/src/types/entities/UsageEventTypes.ts
+++ b/b4m-core/common/src/types/entities/UsageEventTypes.ts
@@ -3,6 +3,7 @@ import { IBaseRepository } from './BaseTypes';
 import { IMongoDocument } from './common';
 import { CreditHolderType } from './CreditHolderTypes';
 import { NamedApiKeyUsage, ISourceUsage } from './CreditTransactionTypes';
+import { COMPLETION_SOURCES, CompletionSource, IPlatformEndpointUsage } from '../analytics';
 
 /**
  * Which product surface generated the provider call.
@@ -81,6 +82,18 @@ export const UsageEvent = z.object({
 
   status: z.enum(USAGE_EVENT_STATUSES).default('ok'),
   latencyMs: z.number().optional(),
+
+  // Denormalized origin, copied from the same call's ledger write so a single
+  // UsageEvent aggregation can co-slice by feature AND source AND consumer with
+  // frozen COGS. Invariant: these must match the paired CreditTransaction's
+  // source/apiKeyId. Both optional: recorders whose ledger write carries no
+  // source leave them unset, and those rows fall into the UNCLASSIFIED_SOURCE
+  // bucket in aggregation (mirrors the ledger).
+  /** Originating surface (web/cli/api/agent/system); unset => unclassified. */
+  source: z.enum(COMPLETION_SOURCES).optional(),
+  /** API key that authed the call; present only for API-key-authed usage. */
+  apiKeyId: z.string().optional(),
+
   createdAt: z.date(),
   updatedAt: z.date(),
 });
@@ -188,6 +201,50 @@ export interface IOwnerUsageSummary {
 export type NamedOwnerSpendMember = IOwnerSpendMember & { userName?: string };
 
 /**
+ * Platform-wide spend attributed to one API-key consumer. Only completion_api
+ * events carry an apiKeyId, so this is the programmatic-consumer cut with frozen
+ * COGS the ledger alone cannot give (the ledger has the key but not COGS/feature).
+ */
+export interface IPlatformConsumerUsage extends IUsageSpendBucket {
+  apiKeyId: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/** A consumer bucket with the API key + owner resolved to display labels by the API. */
+export type NamedPlatformConsumerUsage = IPlatformConsumerUsage & {
+  keyName?: string;
+  keyPrefix?: string;
+  ownerId?: string;
+  ownerType?: CreditHolderType;
+  ownerName?: string;
+};
+
+/**
+ * Optional platform-summary filters. `source` and `ownerType` are applied as the
+ * same kind of $match addition - not separate query paths - so omitting either
+ * spans all sources / all owner types.
+ */
+export interface IPlatformUsageParams {
+  days?: number;
+  source?: CompletionSource;
+  ownerType?: CreditHolderType;
+}
+
+/**
+ * Cross-owner platform usage rolled up every way the admin view needs it, in a
+ * single pass so all cuts reconcile against the same event set. `overTime` is
+ * ascending by day; breakdowns are descending by creditsCharged.
+ */
+export interface IPlatformUsageSummary {
+  overTime: IOwnerSpendDay[];
+  byFeature: IOwnerSpendFeature[];
+  byConsumer: IPlatformConsumerUsage[];
+  byModel: IOwnerSpendModel[];
+  totals: IUsageSpendBucket;
+}
+
+/**
  * Owners the usage dashboard serves. Agent-held credit pools have no dashboard,
  * so the wire contract narrows to the two owners a human can view.
  */
@@ -218,6 +275,35 @@ export interface IUsageDashboardResponse {
    */
   bySource: ISourceUsage[];
   totals: IUsageSpendBucket;
+}
+
+/**
+ * Wire shape of GET /api/admin/platform-usage: the platform-wide usage summary
+ * (feature/COGS/credits from UsageEvent, source- and ownerType-filterable) with
+ * consumers resolved to key/owner labels, plus a distinct endpoint/latency
+ * section (request counts only, from ApiKeyUsageLog). The two sections are kept
+ * separate on purpose so the frontend never implies COGS-per-endpoint.
+ */
+export interface IPlatformUsageDashboardResponse {
+  /** Trailing window the UsageEvent summary covers. */
+  days: number;
+  /** Echo of the source filter, if any (default: all sources). */
+  source?: CompletionSource;
+  /** Echo of the ownerType filter, if any (default: all owner types). */
+  ownerType?: CreditHolderType;
+  overTime: IOwnerSpendDay[];
+  byFeature: IOwnerSpendFeature[];
+  byConsumer: NamedPlatformConsumerUsage[];
+  byModel: IOwnerSpendModel[];
+  totals: IUsageSpendBucket;
+  /**
+   * Endpoint/latency section from ApiKeyUsageLog (request counts only, no
+   * COGS/credits). Null when the source filter excludes API-key traffic (only
+   * api/cli requests are logged there). `endpointWindowDays` is clamped to the
+   * collection's 90-day TTL.
+   */
+  endpoints: IPlatformEndpointUsage | null;
+  endpointWindowDays: number;
 }
 
 /** A spend bucket that also carries token quantities, for session-level detail. */
@@ -302,6 +388,15 @@ export interface IUsageEventRepository extends IBaseRepository<IUsageEventDocume
    * aggregation. Powers the per-org usage dashboard.
    */
   ownerUsageSummary(ownerId: string, ownerType: CreditHolderType, days?: number): Promise<IOwnerUsageSummary>;
+
+  /**
+   * Cross-owner platform-wide usage over the trailing N days (default 30),
+   * rolled up by day, feature, API-key consumer, and model in a single
+   * aggregation. `source` and `ownerType` are optional $match filters applied
+   * the same way (not separate query paths); omitting them spans all
+   * sources / all owner types. Admin-only surface.
+   */
+  platformUsageSummary(params?: IPlatformUsageParams): Promise<IPlatformUsageSummary>;
 
   /**
    * One session's usage rolled up by quest and by model. Defaults to all events

--- a/b4m-core/services/src/billing/recordOperationalUsage.ts
+++ b/b4m-core/services/src/billing/recordOperationalUsage.ts
@@ -138,6 +138,8 @@ export async function recordOperationalUsage(
     creditsCharged,
     status: 'ok',
     latencyMs: params.latencyMs,
+    // Same origin as this call's ledger write above (params.source ?? 'system').
+    source: params.source ?? 'system',
   };
 
   await db.usageEvents

--- a/b4m-core/services/src/cliCompletions.embedMetering.test.ts
+++ b/b4m-core/services/src/cliCompletions.embedMetering.test.ts
@@ -76,8 +76,16 @@ describe('executeCompletion - unconditional usage metering (alwaysRecordUsage)',
     await executeCompletion({ ...baseParams, db, alwaysRecordUsage: true });
 
     expect(usageEvents.record).toHaveBeenCalledTimes(1);
+    // Denormalized origin rides along: source defaults to 'api' and apiKeyId is
+    // the authing key, so the platform consumer view can attribute this spend.
     expect(usageEvents.record).toHaveBeenCalledWith(
-      expect.objectContaining({ ownerId: 'org1', ownerType: CreditHolderType.Organization, creditsCharged: 10 })
+      expect.objectContaining({
+        ownerId: 'org1',
+        ownerType: CreditHolderType.Organization,
+        creditsCharged: 10,
+        source: 'api',
+        apiKeyId: 'k1',
+      })
     );
   });
 

--- a/b4m-core/services/src/cliCompletions.ts
+++ b/b4m-core/services/src/cliCompletions.ts
@@ -460,6 +460,10 @@ export async function executeCompletion(params: CompletionParams): Promise<void>
         feature: 'completion_api',
         provider: modelInfo!.backend,
         model,
+        // Denormalized origin, kept in lockstep with this call's ledger write
+        // (subtractCredits above). apiKeyId is present for API-key auth, undefined for JWT.
+        source,
+        apiKeyId: apiKeyInfo?.keyId,
         inputTokens: finalInputTokens,
         outputTokens: finalOutputTokens,
         cachedInputTokens: finalCacheReadTokens,

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -3776,6 +3776,9 @@ export class ChatCompletionProcess {
               feature: 'chat',
               provider: currentModel.backend,
               model: currentModel.id,
+              // 'web' covers all callers of ChatCompletionProcess today (matches
+              // the paired ledger writes below); no API-key auth on this path.
+              source: 'web',
               // inputTokens/outputTokens are ALWAYS the local estimate and the
               // provider* fields ALWAYS the provider counts, so drift and invoice
               // reconciliation stay comparable across rows; settledBasis says

--- a/packages/database/src/__test__/apiKeyUsageLog.test.ts
+++ b/packages/database/src/__test__/apiKeyUsageLog.test.ts
@@ -60,3 +60,79 @@ describe('ApiKeyUsageLogRepository.countRequestsByKeyForUser', () => {
     expect(counts).toEqual({});
   });
 });
+
+describe('ApiKeyUsageLogRepository.platformEndpointUsage', () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await connectTestDB();
+  }, 30000);
+
+  afterAll(async () => {
+    await disconnectTestDB(mongoServer);
+  }, 30000);
+
+  beforeEach(async () => {
+    await ApiKeyUsageLog.deleteMany({});
+  });
+
+  const log = (overrides: Partial<Record<string, unknown>> = {}) =>
+    apiKeyUsageLogRepository.create({
+      userId: 'user-1',
+      keyId: 'keyA',
+      ipAddress: '203.0.113.1',
+      endpoint: '/api/ai/v1/completions',
+      method: 'POST',
+      responseTime: 10,
+      statusCode: 200,
+      timestamp: new Date(),
+      ...overrides,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test seed: partial log doc
+    } as any);
+
+  it('groups by endpoint+method with request count, avg + p95 latency, and error rate', async () => {
+    // /a POST: 5 ok requests, latencies 10..50 -> avg 30, p95 (nearest-rank) 50.
+    for (const rt of [10, 20, 30, 40, 50]) {
+      await log({ endpoint: '/a', method: 'POST', responseTime: rt, statusCode: 200 });
+    }
+    // /b GET: 2 requests, one server error -> errorRate 0.5.
+    await log({ endpoint: '/b', method: 'GET', responseTime: 5, statusCode: 200 });
+    await log({ endpoint: '/b', method: 'GET', responseTime: 7, statusCode: 500 });
+
+    const { byEndpoint } = await apiKeyUsageLogRepository.platformEndpointUsage({ days: 30 });
+
+    // Ordered by request count desc.
+    expect(byEndpoint).toMatchObject([
+      { endpoint: '/a', method: 'POST', requests: 5, errorRate: 0 },
+      { endpoint: '/b', method: 'GET', requests: 2 },
+    ]);
+    expect(byEndpoint[0].avgResponseTimeMs).toBeCloseTo(30, 10);
+    expect(byEndpoint[0].p95ResponseTimeMs).toBe(50);
+    expect(byEndpoint[1].errorRate).toBeCloseTo(0.5, 10);
+  });
+
+  it('rolls up over-time request counts by UTC day', async () => {
+    await log({ responseTime: 10 });
+    await log({ responseTime: 20 });
+
+    const { overTime } = await apiKeyUsageLogRepository.platformEndpointUsage({ days: 30 });
+    expect(overTime).toHaveLength(1);
+    expect(overTime[0]).toMatchObject({ requests: 2 });
+    expect(overTime[0].day).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('excludes requests outside the trailing window', async () => {
+    await log({ timestamp: new Date('2020-01-01') });
+    const result = await apiKeyUsageLogRepository.platformEndpointUsage({ days: 30 });
+    expect(result.byEndpoint).toHaveLength(0);
+    expect(result.overTime).toHaveLength(0);
+  });
+
+  it('supports an hours window', async () => {
+    await log({ timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000) }); // 2h ago
+    const oneHour = await apiKeyUsageLogRepository.platformEndpointUsage({ hours: 1 });
+    expect(oneHour.byEndpoint).toHaveLength(0);
+    const threeHours = await apiKeyUsageLogRepository.platformEndpointUsage({ hours: 3 });
+    expect(threeHours.byEndpoint).toHaveLength(1);
+  });
+});

--- a/packages/database/src/models/auth/ApiKeyUsageLogModel.ts
+++ b/packages/database/src/models/auth/ApiKeyUsageLogModel.ts
@@ -1,4 +1,4 @@
-import { IMongoDocument } from '@bike4mind/common';
+import { IEndpointUsageBucket, IEndpointUsageDay, IMongoDocument, IPlatformEndpointUsage } from '@bike4mind/common';
 import mongoose, { Model } from 'mongoose';
 import BaseRepository from '@bike4mind/db-core';
 
@@ -158,6 +158,89 @@ export class ApiKeyUsageLogRepository extends BaseRepository<IApiKeyUsageLogDocu
       acc[row._id] = { totalRequests: row.totalRequests, requestsToday: row.requestsToday };
       return acc;
     }, {});
+  }
+
+  /**
+   * Platform-wide endpoint/latency rollup over a trailing window (default 30
+   * days; pass `hours` for finer windows). Every row here is API-key-authed
+   * traffic - this collection logs nothing else - so there is no source
+   * dimension to filter on (the handler decides whether the endpoint section
+   * applies given the user's source filter). Beyond the collection's 90-day TTL
+   * there is simply no data; callers should clamp the window accordingly.
+   *
+   * `byEndpoint` groups by endpoint+method with request count, avg + p95 latency
+   * (nearest-rank), and error rate (statusCode >= 400). `overTime` is daily
+   * request counts. Request counts only - no credits/COGS live here.
+   */
+  async platformEndpointUsage(params: { hours?: number; days?: number } = {}): Promise<IPlatformEndpointUsage> {
+    const { hours, days = 30 } = params;
+    const windowMs = hours != null ? hours * 60 * 60 * 1000 : days * 24 * 60 * 60 * 1000;
+    const from = new Date(Date.now() - windowMs);
+
+    const [result] = await this.model.aggregate<{
+      byEndpoint: IEndpointUsageBucket[];
+      overTime: IEndpointUsageDay[];
+    }>([
+      { $match: { timestamp: { $gte: from } } },
+      {
+        $facet: {
+          byEndpoint: [
+            {
+              $group: {
+                _id: { endpoint: '$endpoint', method: '$method' },
+                requests: { $sum: 1 },
+                totalResponseTime: { $sum: '$responseTime' },
+                errors: { $sum: { $cond: [{ $gte: ['$statusCode', 400] }, 1, 0] } },
+                responseTimes: { $push: '$responseTime' },
+              },
+            },
+            {
+              // Nearest-rank p95: sort ascending, take element ceil(0.95 * n) - 1,
+              // clamped into range. $sortArray keeps this in-pipeline (no $unwind).
+              $addFields: {
+                p95Index: {
+                  $min: [
+                    { $subtract: [{ $size: '$responseTimes' }, 1] },
+                    { $max: [0, { $subtract: [{ $ceil: { $multiply: [0.95, { $size: '$responseTimes' }] } }, 1] }] },
+                  ],
+                },
+              },
+            },
+            {
+              $project: {
+                _id: 0,
+                endpoint: '$_id.endpoint',
+                method: '$_id.method',
+                requests: 1,
+                avgResponseTimeMs: {
+                  $cond: [{ $gt: ['$requests', 0] }, { $divide: ['$totalResponseTime', '$requests'] }, 0],
+                },
+                p95ResponseTimeMs: {
+                  $arrayElemAt: [{ $sortArray: { input: '$responseTimes', sortBy: 1 } }, '$p95Index'],
+                },
+                errorRate: { $cond: [{ $gt: ['$requests', 0] }, { $divide: ['$errors', '$requests'] }, 0] },
+              },
+            },
+            { $sort: { requests: -1 } },
+          ],
+          overTime: [
+            {
+              $group: {
+                _id: { $dateToString: { format: '%Y-%m-%d', date: '$timestamp', timezone: 'UTC' } },
+                requests: { $sum: 1 },
+              },
+            },
+            { $project: { _id: 0, day: '$_id', requests: 1 } },
+            { $sort: { day: 1 } },
+          ],
+        },
+      },
+    ]);
+
+    return {
+      byEndpoint: result?.byEndpoint ?? [],
+      overTime: result?.overTime ?? [],
+    };
   }
 }
 

--- a/packages/database/src/models/billing/UsageEventModel.test.ts
+++ b/packages/database/src/models/billing/UsageEventModel.test.ts
@@ -59,6 +59,18 @@ describe('UsageEventRepository', () => {
       expect(doc!.createdAt).toBeInstanceOf(Date);
     });
 
+    it('persists denormalized origin (source + apiKeyId) when provided', async () => {
+      const doc = await record({ source: 'api', apiKeyId: 'key-123' });
+      expect(doc!.source).toBe('api');
+      expect(doc!.apiKeyId).toBe('key-123');
+    });
+
+    it('leaves origin unset when omitted (unclassified)', async () => {
+      const doc = await record();
+      expect(doc!.source).toBeUndefined();
+      expect(doc!.apiKeyId).toBeUndefined();
+    });
+
     it('rejects an unknown feature', async () => {
       await expect(record({ feature: 'nonsense' as IUsageEventInput['feature'] })).rejects.toThrow();
     });
@@ -299,6 +311,119 @@ describe('UsageEventRepository', () => {
         byMember: [],
         byModel: [],
         byFeature: [],
+        totals: { requests: 0, cogsUsd: 0, creditsCharged: 0 },
+      });
+    });
+  });
+
+  describe('platformUsageSummary', () => {
+    it('rolls up across owners by day, feature, consumer, and model', async () => {
+      await record({
+        ownerId: 'u1',
+        ownerType: CreditHolderType.User,
+        feature: 'chat',
+        source: 'web',
+        costUsd: 0.01,
+        creditsCharged: 50,
+      });
+      await record({
+        ownerId: 'o1',
+        ownerType: CreditHolderType.Organization,
+        feature: 'completion_api',
+        source: 'api',
+        apiKeyId: 'k1',
+        inputTokens: 100,
+        outputTokens: 40,
+        costUsd: 0.02,
+        creditsCharged: 100,
+      });
+      await record({
+        ownerId: 'o1',
+        ownerType: CreditHolderType.Organization,
+        feature: 'completion_api',
+        source: 'api',
+        apiKeyId: 'k1',
+        inputTokens: 200,
+        outputTokens: 60,
+        costUsd: 0.03,
+        creditsCharged: 150,
+      });
+      await record({
+        ownerId: 'u2',
+        ownerType: CreditHolderType.User,
+        feature: 'completion_api',
+        source: 'api',
+        apiKeyId: 'k2',
+        costUsd: 0.005,
+        creditsCharged: 25,
+      });
+
+      const summary = await usageEventRepository.platformUsageSummary();
+
+      expect(summary.totals).toMatchObject({ requests: 4, creditsCharged: 325 });
+      expect(summary.totals.cogsUsd).toBeCloseTo(0.065, 10);
+
+      // byConsumer covers only key-authed events, biggest spender first, with tokens.
+      expect(summary.byConsumer).toMatchObject([
+        { apiKeyId: 'k1', requests: 2, creditsCharged: 250, inputTokens: 300, outputTokens: 100 },
+        { apiKeyId: 'k2', requests: 1, creditsCharged: 25 },
+      ]);
+      expect(summary.byFeature).toMatchObject([
+        { feature: 'completion_api', creditsCharged: 275 },
+        { feature: 'chat', creditsCharged: 50 },
+      ]);
+      expect(summary.overTime).toHaveLength(1);
+      expect(summary.overTime[0]).toMatchObject({ requests: 4, creditsCharged: 325 });
+    });
+
+    it('applies the source filter as an extra $match (default: all sources)', async () => {
+      await record({ source: 'web', creditsCharged: 50 });
+      await record({ source: 'api', apiKeyId: 'k1', creditsCharged: 100 });
+
+      const all = await usageEventRepository.platformUsageSummary();
+      expect(all.totals.requests).toBe(2);
+
+      const apiOnly = await usageEventRepository.platformUsageSummary({ source: 'api' });
+      expect(apiOnly.totals).toMatchObject({ requests: 1, creditsCharged: 100 });
+      expect(apiOnly.byConsumer).toMatchObject([{ apiKeyId: 'k1' }]);
+    });
+
+    it('applies the ownerType filter the same way as source', async () => {
+      await record({ ownerId: 'u1', ownerType: CreditHolderType.User, creditsCharged: 10 });
+      await record({ ownerId: 'o1', ownerType: CreditHolderType.Organization, creditsCharged: 20 });
+
+      const users = await usageEventRepository.platformUsageSummary({ ownerType: CreditHolderType.User });
+      expect(users.totals).toMatchObject({ requests: 1, creditsCharged: 10 });
+
+      const orgs = await usageEventRepository.platformUsageSummary({ ownerType: CreditHolderType.Organization });
+      expect(orgs.totals).toMatchObject({ requests: 1, creditsCharged: 20 });
+    });
+
+    it('excludes events without an apiKeyId from byConsumer', async () => {
+      await record({ source: 'web', creditsCharged: 50 });
+      await record({ source: 'api', apiKeyId: 'k1', creditsCharged: 100 });
+
+      const summary = await usageEventRepository.platformUsageSummary();
+      expect(summary.byConsumer).toHaveLength(1);
+      expect(summary.byConsumer).toMatchObject([{ apiKeyId: 'k1' }]);
+    });
+
+    it('excludes events outside the trailing window', async () => {
+      await record({ source: 'api', apiKeyId: 'k1', creditsCharged: 100 });
+      await UsageEvent.collection.updateMany({}, { $set: { createdAt: new Date('2020-01-01') } });
+
+      const summary = await usageEventRepository.platformUsageSummary({ days: 30 });
+      expect(summary.totals).toEqual({ requests: 0, cogsUsd: 0, creditsCharged: 0 });
+      expect(summary.byConsumer).toHaveLength(0);
+    });
+
+    it('returns zeroed totals when there are no events', async () => {
+      const summary = await usageEventRepository.platformUsageSummary();
+      expect(summary).toEqual({
+        overTime: [],
+        byFeature: [],
+        byConsumer: [],
+        byModel: [],
         totals: { requests: 0, cogsUsd: 0, creditsCharged: 0 },
       });
     });

--- a/packages/database/src/models/billing/UsageEventModel.ts
+++ b/packages/database/src/models/billing/UsageEventModel.ts
@@ -1,6 +1,7 @@
 import mongoose, { Model, Schema, model } from 'mongoose';
 import BaseRepository from '@bike4mind/db-core';
 import {
+  COMPLETION_SOURCES,
   CreditHolderType,
   IMongoDocument,
   IModelDayMargin,
@@ -9,6 +10,9 @@ import {
   IOwnerSpendMember,
   IOwnerSpendModel,
   IOwnerUsageSummary,
+  IPlatformConsumerUsage,
+  IPlatformUsageParams,
+  IPlatformUsageSummary,
   IProviderMonthCogs,
   ISessionModelUsage,
   ISessionQuestUsage,
@@ -57,6 +61,13 @@ const UsageEventSchema = new Schema<IUsageEventDocument>(
 
     status: { type: String, required: true, enum: [...USAGE_EVENT_STATUSES], default: 'ok' },
     latencyMs: { type: Number, required: false },
+
+    // Denormalized origin, copied from the same call's ledger write (see
+    // UsageEventTypes). Both optional; rows written before this change (or by a
+    // recorder whose ledger write carries no source) leave them unset and fall
+    // into the UNCLASSIFIED_SOURCE bucket in aggregation.
+    source: { type: String, required: false, enum: [...COMPLETION_SOURCES] },
+    apiKeyId: { type: String, required: false },
   },
   {
     timestamps: true,
@@ -74,6 +85,10 @@ UsageEventSchema.index({ createdAt: -1, settledBasis: 1 });
 UsageEventSchema.index({ ownerId: 1, ownerType: 1, createdAt: -1 });
 // Supports sessionUsageSummary()'s $match on sessionId (per-session usage detail).
 UsageEventSchema.index({ sessionId: 1, createdAt: -1 });
+// Supports platformUsageSummary()'s optional source filter over a time window.
+UsageEventSchema.index({ source: 1, createdAt: -1 });
+// Supports platformUsageSummary()'s byConsumer cut ($match apiKeyId present).
+UsageEventSchema.index({ apiKeyId: 1, createdAt: -1 });
 
 export type IUsageEventModel = Model<IUsageEventDocument>;
 
@@ -290,6 +305,84 @@ export class UsageEventRepository extends BaseRepository<IUsageEventDocument> im
       byModel: result?.byModel ?? [],
       byFeature: result?.byFeature ?? [],
       // $facet yields totals as a 0- or 1-element array; unwrap to a scalar bucket.
+      totals: result?.totals?.[0] ?? emptyTotals,
+    };
+  }
+
+  async platformUsageSummary(params: IPlatformUsageParams = {}): Promise<IPlatformUsageSummary> {
+    const { days = 30, source, ownerType } = params;
+    const from = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+    // Shared across every day/feature/model cut.
+    const spendSums = {
+      requests: { $sum: 1 },
+      cogsUsd: { $sum: '$costUsd' },
+      creditsCharged: { $sum: '$creditsCharged' },
+    } as const;
+    const spendFields = { requests: 1, cogsUsd: 1, creditsCharged: 1 } as const;
+
+    // source and ownerType are optional filters applied the same way - extra
+    // $match predicates, never a separate query path. Omitting either spans all.
+    const match: Record<string, unknown> = { createdAt: { $gte: from } };
+    if (source) match.source = source;
+    if (ownerType) match.ownerType = ownerType;
+
+    const [result] = await this.model.aggregate<{
+      overTime: IOwnerSpendDay[];
+      byFeature: IOwnerSpendFeature[];
+      byConsumer: IPlatformConsumerUsage[];
+      byModel: IOwnerSpendModel[];
+      totals: IUsageSpendBucket[];
+    }>([
+      { $match: match },
+      {
+        $facet: {
+          overTime: [
+            {
+              $group: {
+                _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt', timezone: 'UTC' } },
+                ...spendSums,
+              },
+            },
+            { $project: { _id: 0, day: '$_id', ...spendFields } },
+            { $sort: { day: 1 } },
+          ],
+          byFeature: [
+            { $group: { _id: '$feature', ...spendSums } },
+            { $project: { _id: 0, feature: '$_id', ...spendFields } },
+            { $sort: { creditsCharged: -1 } },
+          ],
+          // Consumers are API-key holders; only key-authed events carry apiKeyId.
+          // Tokens ride along so the admin view shows per-consumer input/output.
+          byConsumer: [
+            { $match: { apiKeyId: { $exists: true, $ne: null } } },
+            {
+              $group: {
+                _id: '$apiKeyId',
+                ...spendSums,
+                inputTokens: { $sum: '$inputTokens' },
+                outputTokens: { $sum: '$outputTokens' },
+              },
+            },
+            { $project: { _id: 0, apiKeyId: '$_id', ...spendFields, inputTokens: 1, outputTokens: 1 } },
+            { $sort: { creditsCharged: -1 } },
+          ],
+          byModel: [
+            { $group: { _id: { provider: '$provider', model: '$model' }, ...spendSums } },
+            { $project: { _id: 0, provider: '$_id.provider', model: '$_id.model', ...spendFields } },
+            { $sort: { creditsCharged: -1 } },
+          ],
+          totals: [{ $group: { _id: null, ...spendSums } }, { $project: { _id: 0, ...spendFields } }],
+        },
+      },
+    ]);
+
+    const emptyTotals: IUsageSpendBucket = { requests: 0, cogsUsd: 0, creditsCharged: 0 };
+    return {
+      overTime: result?.overTime ?? [],
+      byFeature: result?.byFeature ?? [],
+      byConsumer: result?.byConsumer ?? [],
+      byModel: result?.byModel ?? [],
       totals: result?.totals?.[0] ?? emptyTotals,
     };
   }


### PR DESCRIPTION
## Description

Backend for the platform-admin usage view (epic #921, child 2). Adds cross-owner, platform-wide usage aggregation with a special focus on external/programmatic (`source=api`) consumers, plus the small denormalization enabler that makes a single-collection roll-up possible.

Existing aggregations are all owner-scoped and the data is split across three collections with no per-row join key (`feature`+COGS on `UsageEvent`, `source`+`apiKeyId`+credits on the ledger, `endpoint` on `ApiKeyUsageLog`). This denormalizes `source`+`apiKeyId` onto `UsageEvent` at record time so one aggregation can co-slice by feature AND source AND consumer with frozen COGS.

**Design invariant:** `UsageEvent.source` mirrors the same call's ledger (`CreditTransaction`) source. Recorders whose ledger write already carries a source are wired; those that don't leave it unset and fall into the `unclassified` bucket (same pattern as the ledger's `UNCLASSIFIED_SOURCE`). No guessed/hardcoded values that could misattribute the external-consumer analytics this feature exists to report.

## Changes

- **Denormalization:** optional `source` + `apiKeyId` on `UsageEventModel` (schema + `IUsageEventInput`), plus `{source,createdAt}` and `{apiKeyId,createdAt}` compound indexes.
- **Recorders wired** (source mirrors the paired ledger write): `completion_api` (`source` + `apiKeyId`), `chat` (`web`), `sound_effects` (`api`), `operations` (`source` param). Media/tool/agent paths whose ledger write sets no source remain unclassified by design.
- **`usageEventRepository.platformUsageSummary({ days, source?, ownerType? })`** -> `overTime / byFeature / byConsumer (apiKeyId + tokens/COGS/credits) / byModel / totals`. `source` and `ownerType` are optional `$match` filters (not separate query paths).
- **`apiKeyUsageLogRepository.platformEndpointUsage({ hours?, days? })`** -> `byEndpoint` (requests, avg + nearest-rank p95 latency, error rate) + daily `overTime`.
- **`GET /api/admin/platform-usage`** (admin-gated, `days` clamped 1..365): wires both repo methods, resolves each consumer's `apiKeyId` -> key name/prefix + owner (user/org) name, and keeps the UsageEvent (COGS/credits) and ApiKeyUsageLog (request-counts-only) sections distinct. Endpoint window clamped to the collection's 90-day TTL.
- Tests for both repo methods, field persistence, and the `completion_api` recorder wiring.

## Guide for Testers

Backend-only. Test the new admin endpoint on the PR preview. You need a platform-admin account's JWT (from `localStorage` after logging into the preview) as a `Bearer` token.

1. Log into `app.pr<N>.preview.bike4mind.com` as a platform admin.
2. `GET https://app.pr<N>.preview.bike4mind.com/api/admin/platform-usage` with header `Authorization: Bearer <admin-jwt>`. Expect `200` and a JSON body with keys: `days` (30), `overTime`, `byFeature`, `byConsumer`, `byModel`, `totals`, `endpoints`, `endpointWindowDays`.
3. Repeat step 2 with a **non-admin** JWT. Expect `403` ("Admin access required").
4. Repeat step 2 with no `Authorization` header. Expect `403` ("Authentication required").
5. Add `?source=api`. Expect only `source=api` usage in `totals`/`byFeature`/`byConsumer`, and `endpoints` populated (api is API-key traffic).
6. Add `?source=web`. Expect the UsageEvent cuts filtered to web, and `endpoints: null` (web is not API-key traffic, so there is no endpoint data by construction).
7. Add `?ownerType=User` then `?ownerType=Organization`. Expect `totals` to change to only user-owned / only org-owned usage respectively; the response shape is identical (filter, not a fork).
8. Add `?days=1`, then `?days=95`, then `?days=400`. Expect: `days=1` echoes `days: 1`; `days=95` echoes `days: 95` but `endpointWindowDays: 90` (clamped to the 90-day TTL); `days=400` is rejected with `422` (validation, allowed range is 1..365).
9. In `byConsumer`, confirm each entry has `apiKeyId` and, where the key resolves, `keyName` / `keyPrefix` / `ownerName`.

To generate data if the preview is empty: make a few completion calls via an API key (source=api) and some web-chat turns, then re-query.

### What NOT to test
- No UI — the admin dashboard is the frontend child (#924); there is no page yet.
- No billing/credit behavior changes: `UsageEvent.record` is analytics-only and fire-and-forget; the ledger/credit paths are untouched.

## Additional Information

- One deviation from the issue: `platformEndpointUsage` does not take a `source?` param — `ApiKeyUsageLog` has no `source` column, and every row is API-key traffic by construction. Source-awareness for the endpoint section lives in the handler (it skips the section for `web`/`agent`/`system` filters). Flagged so it isn't read as an omission.
- Extension point: to classify a currently-unclassified path (e.g. `agent_execution` -> `agent`), set `source` on BOTH that path's ledger write and its adjacent UsageEvent recorder together, preserving the invariant.
- Verified live on the PR preview: admin gate (401 unauth / 403 non-admin), the full response shape, `source`/`ownerType` filters, and `days` handling all behave as intended, and `byConsumer` populates + resolves key/owner labels from real `source=api` completions. The `endpoints` section (from `ApiKeyUsageLog`) can read empty even after real API-key traffic because that log is written fire-and-forget in `apiKeyAuth`'s `res.on('finish')` handler, which Lambda often freezes before the write lands - a pre-existing write-side quirk, orthogonal to this PR (the aggregation itself is covered by tests).

## Developer Notes

- **Data model:** `UsageEvent` now carries `source` + `apiKeyId` — a per-row join key that lets any future report co-slice feature/COGS by originating surface and API-key consumer without stitching collections.
- **Pattern:** `platformUsageSummary` shows the "optional filter as a `$match` addition, single `$facet`" approach — new platform dimensions are added as another `$match` predicate, never a parallel query path.

Closes #923

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — n/a
- [ ] I have made the UI/UX feel good — n/a (backend-only)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) — n/a
