### PR TITLE
ci(e2e): fix preview e2e by injecting E2E_CLEANUP_SECRET instead of cross-account sst shell

### DIFF
--- a/.github/workflows/e2e-on-label.yml
+++ b/.github/workflows/e2e-on-label.yml
@@ -98,14 +98,21 @@ jobs:
         id: e2e
         env:
           API_URL: ${{ steps.config.outputs.api_url }}
-          # E2E_CLEANUP_SECRET is read from SST (Resource.E2E_CLEANUP_SECRET.value) via the
-          # `sst shell` wrapper below — no GitHub-secret env override (issue #251).
+          # Preview stacks live in a SEPARATE AWS account the dev role can't `sst shell`
+          # into, so inject E2E_CLEANUP_SECRET (the only SST value the suite needs) directly
+          # from this repo secret. It must match the stable value the deployer seeds onto
+          # every stage (bike4mind-deployer _tier-deploy.yml).
+          E2E_CLEANUP_SECRET: ${{ secrets.E2E_CLEANUP_SECRET }}
           AI_LATENCY_RUN: 'false'
           PW_WORKERS: '1'
           CI: 'true'
         run: |
           set -o pipefail
-          pnpm sst shell --stage ${{ steps.config.outputs.stage }} -- pnpm --filter client exec playwright test 2>&1 | tee apps/client/playwright-output.txt
+          if [ -z "${E2E_CLEANUP_SECRET:-}" ]; then
+            echo "::error::E2E_CLEANUP_SECRET repo secret is required for preview runs"
+            exit 1
+          fi
+          pnpm --filter client exec playwright test 2>&1 | tee apps/client/playwright-output.txt
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -235,8 +235,13 @@ jobs:
         id: e2e
         env:
           API_URL: ${{ steps.config.outputs.api_url }}
-          # E2E_CLEANUP_SECRET is read from SST (Resource.E2E_CLEANUP_SECRET.value) via the
-          # `sst shell` wrapper below — no GitHub-secret env override (issue #251).
+          # dev/staging read E2E_CLEANUP_SECRET from SST via the `sst shell` wrapper
+          # below (same-account). Preview stacks live in a SEPARATE AWS account the
+          # dev role can't `sst shell` into, so for pr<N> runs we inject the secret
+          # directly from this repo secret instead. It must match the stable value the
+          # deployer seeds onto every stage (bike4mind-deployer _tier-deploy.yml).
+          # E2E_CLEANUP_SECRET is the ONLY SST value the suite needs.
+          E2E_CLEANUP_SECRET: ${{ secrets.E2E_CLEANUP_SECRET }}
           E2E_TEST_ID: ${{ steps.testid.outputs.test_id }}
           # Only wire the credits webhook for suites that report credits (show_credits).
           # Core runs the notebook project too, but must NOT post the in-process AI
@@ -251,7 +256,17 @@ jobs:
         run: |
           set -o pipefail
           [ -n "$PLAYWRIGHT_ARGS" ] && echo "Running: playwright test $PLAYWRIGHT_ARGS" || echo "Running full suite"
-          pnpm sst shell --stage ${{ steps.config.outputs.stage }} -- pnpm --filter client exec playwright test $PLAYWRIGHT_ARGS 2>&1 | tee apps/client/playwright-output.txt
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            # Preview (cross-account): E2E_CLEANUP_SECRET is injected from the repo secret above.
+            if [ -z "${E2E_CLEANUP_SECRET:-}" ]; then
+              echo "::error::E2E_CLEANUP_SECRET repo secret is required for preview runs"
+              exit 1
+            fi
+            pnpm --filter client exec playwright test $PLAYWRIGHT_ARGS 2>&1 | tee apps/client/playwright-output.txt
+          else
+            # dev/staging (same account): resolve the secret from SST.
+            pnpm sst shell --stage ${{ steps.config.outputs.stage }} -- pnpm --filter client exec playwright test $PLAYWRIGHT_ARGS 2>&1 | tee apps/client/playwright-output.txt
+          fi
 
       - name: Upload Playwright report
         if: always()


### PR DESCRIPTION
## Description

Preview E2E runs (`E2E Tests (Core)` with `pr_number`, and `E2E Tests (on label)`) fail before a single test executes: the `Run E2E tests` step calls `pnpm sst shell --stage pr<N> -- playwright test`, but `pr<N>` stacks deploy into a **separate AWS account** the dev role (`AWS_DEV_ROLE_ARN`) can't `sst shell` into. `sst shell` errors with `✕ Unexpected error occurred` and the suite reports 0 tests. (The `dev`/staging gate is unaffected - dev role + `--stage dev` are the same account.)

`E2E_CLEANUP_SECRET` is the **only** SST value the entire e2e suite reads (`grep -rE 'Resource\.' apps/client/e2e` → just `Resource.E2E_CLEANUP_SECRET`), and the tests already prefer `process.env.E2E_CLEANUP_SECRET`. So for preview runs we inject that secret from a repo secret and skip `sst shell` entirely - no cross-account IAM needed.

## Changes

- **`e2e-run.yml`** - when `pr_number` is set, inject `E2E_CLEANUP_SECRET` (repo secret) and run Playwright directly; otherwise keep the existing same-account `sst shell` path for dev/staging. Fails loudly if the secret is missing on a preview run.
- **`e2e-on-label.yml`** - always a preview run, so drop `sst shell` unconditionally and inject the secret the same way.

## Required before this works (maintainer)

1. Add a repo secret **`E2E_CLEANUP_SECRET`** to `Bike4Mind/bike4mind`, set to the **same stable value** the deployer seeds onto stages (`bike4mind-deployer` repo secret `E2E_CLEANUP_SECRET`).
2. Land the companion deployer change so **preview** stacks are seeded with that stable value instead of a per-deploy random (`bike4mind-deployer` `_tier-deploy.yml`). Existing previews must be redeployed to pick it up.

## Guide for Testers

1. After the maintainer steps above, trigger a preview deploy for any open PR, then dispatch `E2E Tests (Core)` with `pr_number=<that PR>`.
2. Expected: the `Run E2E tests` step runs the suite (no `sst shell` error), and the `unauthenticated`/`notebook`/`prompts` projects execute against `app.pr<N>.preview.bike4mind.com`.
3. Confirm the summary shows real counts (e.g. `24/24`), not `Total: 0`.

### Regression Checks
- The `dev` gate (`E2E Tests (Core)` with no `pr_number`) still runs via `sst shell --stage dev` - unchanged. Confirm it stays green.

### What NOT to test
- No product/runtime code changes - CI workflow only.

## Additional Information

- Note: the `Configure AWS credentials` step is now unused for preview-only runs (its sole consumer was `sst shell`); left in place to keep this change focused. Could be dropped from `e2e-on-label.yml` in a follow-up.
