### PR TITLE
feat(models): parse Kimi native tool-call tokens on Bedrock, re-enable tools

### DIFF
--- a/b4m-core/llm-adapters/src/bedrockBackend/kimiNativeTools.test.ts
+++ b/b4m-core/llm-adapters/src/bedrockBackend/kimiNativeTools.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { hasNativeToolMarker, parseNativeToolSection, KimiNativeToolStream } from './kimiNativeTools';
+
+// Fixtures are reasoning-stripped captures from live moonshot.kimi-k2-thinking (Bedrock).
+const TWO_TOOL_SECTION =
+  '<|tool_call_begin|> functions.math_evaluate:0 <|tool_call_argument_begin|> {"expression": "12*15"} <|tool_call_end|> ' +
+  '<|tool_call_begin|> functions.get_weather:1 <|tool_call_argument_begin|> {"city": "Paris"} <|tool_call_end|>';
+
+describe('parseNativeToolSection', () => {
+  it('extracts name, index and args for parallel calls, stripping the functions. prefix', () => {
+    expect(parseNativeToolSection(TWO_TOOL_SECTION)).toEqual([
+      { id: 'functions.math_evaluate:0', name: 'math_evaluate', index: 0, arguments: '{"expression": "12*15"}' },
+      { id: 'functions.get_weather:1', name: 'get_weather', index: 1, arguments: '{"city": "Paris"}' },
+    ]);
+  });
+
+  it('falls back to positional index when the id carries none', () => {
+    const calls = parseNativeToolSection(
+      '<|tool_call_begin|> search <|tool_call_argument_begin|> {"q":"x"} <|tool_call_end|>'
+    );
+    expect(calls).toEqual([{ id: 'search', name: 'search', index: 0, arguments: '{"q":"x"}' }]);
+  });
+});
+
+describe('hasNativeToolMarker', () => {
+  it('detects the section and call markers, ignores plain text', () => {
+    expect(hasNativeToolMarker('just reasoning about the answer')).toBe(false);
+    expect(hasNativeToolMarker('...<|tool_calls_section_begin|>...')).toBe(true);
+    expect(hasNativeToolMarker('...<|tool_call_begin|>...')).toBe(true);
+  });
+});
+
+describe('KimiNativeToolStream', () => {
+  it('surfaces the pre-section reasoning and yields tool calls, never leaking a raw token', () => {
+    const s = new KimiNativeToolStream();
+    const full =
+      'I will call the tools. <|tool_calls_section_begin|> ' + TWO_TOOL_SECTION + ' <|tool_calls_section_end|>';
+    const { text, toolCalls } = s.push(full);
+    expect(text).toBe('I will call the tools. ');
+    expect(text).not.toContain('<|');
+    expect(toolCalls.map(c => c.name)).toEqual(['math_evaluate', 'get_weather']);
+    expect(toolCalls[1].arguments).toBe('{"city": "Paris"}');
+  });
+
+  it('handles a section split across the exact deltas Bedrock streamed', () => {
+    // Reasoning-stripped inner text of the three real content deltas, in order.
+    const deltas = [
+      " I'll compute the math problem and get the weather for Paris for you. <|tool_calls_section_begin|> <|tool_call_begin|> functions.math_evaluate:0 <|tool_call_argument_begin|>",
+      ' {"expression": "12*15"} <|tool_call_end|> <|tool_call_begin|> functions.get_weather:1 <|tool_call_argument_begin|> {"city": "Paris',
+      '"} <|tool_call_end|> <|tool_calls_section_end|>',
+    ];
+    const s = new KimiNativeToolStream();
+    let text = '';
+    const calls = [];
+    for (const d of deltas) {
+      const r = s.push(d);
+      text += r.text;
+      calls.push(...r.toolCalls);
+    }
+    text += s.flush();
+    expect(text).toBe(" I'll compute the math problem and get the weather for Paris for you. ");
+    expect(text).not.toContain('<|');
+    expect(calls.map(c => c.name)).toEqual(['math_evaluate', 'get_weather']);
+    expect(calls[0].arguments).toBe('{"expression": "12*15"}');
+    expect(calls[1].arguments).toBe('{"city": "Paris"}');
+  });
+
+  it('passes ordinary reasoning through unchanged, chunk by chunk', () => {
+    const s = new KimiNativeToolStream();
+    const a = s.push('The user wants 17 x 24. ');
+    const b = s.push('That is 408.');
+    expect(a.text + b.text).toBe('The user wants 17 x 24. That is 408.');
+    expect(a.toolCalls.length + b.toolCalls.length).toBe(0);
+  });
+
+  it('holds back a section-begin marker split across a chunk boundary', () => {
+    const s = new KimiNativeToolStream();
+    const a = s.push('go <|tool_calls_sec');
+    expect(a.text).toBe('go '); // partial marker withheld
+    const b = s.push(
+      'tion_begin|> <|tool_call_begin|> x <|tool_call_argument_begin|> {} <|tool_call_end|> <|tool_calls_section_end|>'
+    );
+    expect(b.text).toBe('');
+    expect(b.toolCalls).toEqual([{ id: 'x', name: 'x', index: 0, arguments: '{}' }]);
+    expect(a.text + b.text).not.toContain('<|');
+  });
+
+  it('flush surfaces a held-back tail that turned out not to be a marker', () => {
+    const s = new KimiNativeToolStream();
+    const a = s.push('trailing <|');
+    expect(a.text).toBe('trailing ');
+    expect(s.flush()).toBe('<|');
+  });
+});

--- a/b4m-core/llm-adapters/src/bedrockBackend/kimiNativeTools.ts
+++ b/b4m-core/llm-adapters/src/bedrockBackend/kimiNativeTools.ts
@@ -1,0 +1,128 @@
+/**
+ * Kimi (Moonshot) on Bedrock non-deterministically returns tool calls two ways:
+ * as structured `tool_calls` deltas (handled directly in the backend), OR as its
+ * NATIVE special-token format emitted inline in the content/reasoning stream:
+ *
+ *   <|tool_calls_section_begin|>
+ *     <|tool_call_begin|> functions.<name>:<index> <|tool_call_argument_begin|> {json} <|tool_call_end|>
+ *     ...more calls...
+ *   <|tool_calls_section_end|>
+ *
+ * Nothing downstream parses that, so the tokens would leak into the answer as text
+ * and the tool would never run. This module extracts the native section and yields
+ * structured tool calls, so both provider shapes converge on the same execution path.
+ *
+ * Verified against live Bedrock captures (moonshot.kimi-k2-thinking, us-east-2):
+ * the section is emitted WITHIN the model's reasoning, its markers span content
+ * deltas, and a section can carry several parallel calls.
+ */
+
+export type ParsedNativeToolCall = { id: string; name: string; index: number; arguments: string };
+
+const SECTION_BEGIN = '<|tool_calls_section_begin|>';
+const SECTION_END = '<|tool_calls_section_end|>';
+
+/** Cheap gate: is there any native tool-call marker in this text at all? */
+export function hasNativeToolMarker(text: string): boolean {
+  return text.includes(SECTION_BEGIN) || text.includes('<|tool_call_begin|>');
+}
+
+/** `functions.math_evaluate:0` -> { name: 'math_evaluate', index: 0 }. */
+function splitNativeToolId(rawId: string, fallbackIndex: number): { name: string; index: number } {
+  const withoutPrefix = rawId.startsWith('functions.') ? rawId.slice('functions.'.length) : rawId;
+  const colon = withoutPrefix.lastIndexOf(':');
+  if (colon >= 0) {
+    const parsed = Number.parseInt(withoutPrefix.slice(colon + 1), 10);
+    return { name: withoutPrefix.slice(0, colon), index: Number.isNaN(parsed) ? fallbackIndex : parsed };
+  }
+  return { name: withoutPrefix, index: fallbackIndex };
+}
+
+/**
+ * Parse the calls out of one section's inner text (between the section markers, or a
+ * whole string that contains them - the per-call regex ignores the section markers).
+ */
+export function parseNativeToolSection(section: string): ParsedNativeToolCall[] {
+  const calls: ParsedNativeToolCall[] = [];
+  const re = /<\|tool_call_begin\|>\s*([\s\S]+?)\s*<\|tool_call_argument_begin\|>\s*([\s\S]*?)\s*<\|tool_call_end\|>/g;
+  let match: RegExpExecArray | null;
+  let fallbackIndex = 0;
+  while ((match = re.exec(section)) !== null) {
+    const rawId = match[1].trim();
+    const args = match[2].trim();
+    const { name, index } = splitNativeToolId(rawId, fallbackIndex);
+    if (name) calls.push({ id: rawId, name, index, arguments: args });
+    fallbackIndex++;
+  }
+  return calls;
+}
+
+/** Length of the longest suffix of `buf` that is a proper prefix of `marker`. */
+function partialMarkerTail(buf: string, marker: string): number {
+  const max = Math.min(buf.length, marker.length - 1);
+  for (let n = max; n > 0; n--) {
+    if (marker.startsWith(buf.slice(buf.length - n))) return n;
+  }
+  return 0;
+}
+
+/**
+ * Stateful streaming filter. Feed reasoning/content text chunk by chunk; get back
+ * the text that is safe to surface (everything outside a tool-call section) plus any
+ * tool calls whose section completed in this push. Text that begins a section, or
+ * that could be a partial section-begin marker split across chunks, is held back so
+ * a raw `<|tool_call...|>` token never reaches the user. One instance per request.
+ */
+export class KimiNativeToolStream {
+  private buffer = '';
+  private inSection = false;
+
+  push(chunk: string): { text: string; toolCalls: ParsedNativeToolCall[] } {
+    this.buffer += chunk;
+    let text = '';
+    const toolCalls: ParsedNativeToolCall[] = [];
+
+    for (;;) {
+      if (!this.inSection) {
+        const start = this.buffer.indexOf(SECTION_BEGIN);
+        if (start >= 0) {
+          text += this.buffer.slice(0, start);
+          this.buffer = this.buffer.slice(start + SECTION_BEGIN.length);
+          this.inSection = true;
+          continue;
+        }
+        // No section start in view: surface everything except a tail that might be a
+        // section-begin marker split across the next chunk.
+        const hold = partialMarkerTail(this.buffer, SECTION_BEGIN);
+        text += this.buffer.slice(0, this.buffer.length - hold);
+        this.buffer = hold > 0 ? this.buffer.slice(this.buffer.length - hold) : '';
+        break;
+      }
+
+      const end = this.buffer.indexOf(SECTION_END);
+      if (end >= 0) {
+        toolCalls.push(...parseNativeToolSection(this.buffer.slice(0, end)));
+        this.buffer = this.buffer.slice(end + SECTION_END.length);
+        this.inSection = false;
+        continue;
+      }
+      // Section still open: keep buffering, surface nothing.
+      break;
+    }
+
+    return { text, toolCalls };
+  }
+
+  /**
+   * Surface any held-back tail at end of stream. Non-empty only when a section-begin
+   * prefix was held but never completed (i.e. it was ordinary text ending in `<|...`),
+   * so it is safe to emit. A genuinely unterminated section is dropped rather than
+   * leaked.
+   */
+  flush(): string {
+    if (this.inSection) return '';
+    const remaining = this.buffer;
+    this.buffer = '';
+    return remaining;
+  }
+}

--- a/b4m-core/llm-adapters/src/bedrockBackend/moonshot.test.ts
+++ b/b4m-core/llm-adapters/src/bedrockBackend/moonshot.test.ts
@@ -330,3 +330,124 @@ describe('MoonshotBedrockBackend live Bedrock shapes', () => {
     ).toBe(false);
   });
 });
+
+// Kimi on Bedrock non-deterministically emits tool calls as native <|tool_call...|>
+// tokens inside the reasoning stream instead of structured tool_calls. These frames
+// are captured verbatim from live moonshot.kimi-k2-thinking (us-east-2). The helper
+// mirrors base.ts's streaming accumulator so we prove the tokens become an EXECUTED
+// tool call, not leaked text.
+describe('MoonshotBedrockBackend native tool-call tokens', () => {
+  // Reproduce base.ts's streaming func[] accumulation over a sequence of frames.
+  function drive(frames: Record<string, unknown>[]) {
+    const be = new MoonshotBedrockBackend();
+    be.getPayload(ChatModels.KIMI_K2_THINKING_BEDROCK, messages, {});
+    const func: { name?: string; id?: string; parameters?: string }[] = [];
+    let text = '';
+    for (const f of frames) {
+      const { chunk } = be.translateStreamChunk(ChatModels.KIMI_K2_THINKING_BEDROCK, f);
+      for (const c of chunk.choices) {
+        func[c.index] ||= {};
+        func[c.index].name ||= c.tool?.name;
+        func[c.index].id ||= c.tool?.id;
+        if (func[c.index].name && c.statusEndReason !== ChoiceEndReason.TOOL_USE) {
+          func[c.index].parameters ??= '';
+          func[c.index].parameters += c.chunkText || '';
+        }
+        if (!func.some(x => x?.name)) text += c.chunkText || '';
+      }
+    }
+    return { func: func.filter(Boolean), text };
+  }
+
+  it('streaming: parallel native tool calls become structured, args intact, no token leak', () => {
+    // The exact three content deltas Bedrock streamed for a two-tool turn.
+    const frames = [
+      {
+        choices: [
+          {
+            delta: {
+              content:
+                "<reasoning> I'll compute the math problem and get the weather for Paris for you. <|tool_calls_section_begin|> <|tool_call_begin|> functions.math_evaluate:0 <|tool_call_argument_begin|></reasoning>",
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              content:
+                '<reasoning> {"expression": "12*15"} <|tool_call_end|> <|tool_call_begin|> functions.get_weather:1 <|tool_call_argument_begin|> {"city": "Paris</reasoning>',
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: { content: '<reasoning>"} <|tool_call_end|> <|tool_calls_section_end|></reasoning>' },
+            finish_reason: 'stop',
+          },
+        ],
+        'amazon-bedrock-invocationMetrics': { inputTokenCount: 236, outputTokenCount: 49 },
+      },
+    ];
+    const { func, text } = drive(frames);
+    expect(func).toEqual([
+      { name: 'math_evaluate', id: 'functions.math_evaluate:0', parameters: '{"expression": "12*15"}' },
+      { name: 'get_weather', id: 'functions.get_weather:1', parameters: '{"city": "Paris"}' },
+    ]);
+    // The pre-call reasoning survives as a <think> block; no raw token leaks as text.
+    expect(text).toContain("I'll compute the math problem");
+    expect(text).not.toContain('<|');
+  });
+
+  it('streaming: usage still resolves from invocationMetrics on a native-token turn', () => {
+    const fresh = new MoonshotBedrockBackend();
+    fresh.getPayload(ChatModels.KIMI_K2_THINKING_BEDROCK, messages, {});
+    let usage: unknown;
+    for (const f of [
+      {
+        choices: [
+          {
+            delta: {
+              content:
+                '<reasoning> ok <|tool_calls_section_begin|> <|tool_call_begin|> functions.math_evaluate:0 <|tool_call_argument_begin|> {"expression":"1+1"} <|tool_call_end|> <|tool_calls_section_end|></reasoning>',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        'amazon-bedrock-invocationMetrics': { inputTokenCount: 40, outputTokenCount: 12 },
+      },
+    ]) {
+      const { chunk } = fresh.translateStreamChunk(ChatModels.KIMI_K2_THINKING_BEDROCK, f);
+      for (const c of chunk.choices) if (c.usage) usage = c.usage;
+    }
+    expect(usage).toEqual({ input_tokens: 40, output_tokens: 12 });
+  });
+
+  it('non-streaming: a native tool section becomes a TOOL_USE end with full args', () => {
+    const { chunk } = backend.translateChunk(ChatModels.KIMI_K2_THINKING_BEDROCK, {
+      choices: [
+        {
+          message: {
+            content:
+              '<reasoning> I will use the tool. <|tool_calls_section_begin|> <|tool_call_begin|> functions.math_evaluate:0 <|tool_call_argument_begin|> {"expression": "384*27"} <|tool_call_end|> <|tool_calls_section_end|></reasoning>',
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+      usage: { prompt_tokens: 46, completion_tokens: 30 },
+    });
+    const tool = chunk.choices.find(c => c.statusEndReason === ChoiceEndReason.TOOL_USE);
+    expect(tool?.tool).toEqual({
+      id: 'functions.math_evaluate:0',
+      name: 'math_evaluate',
+      parameters: '{"expression": "384*27"}',
+    });
+    // reasoning survives, no raw tokens leak
+    const joined = chunk.choices.map(c => ('chunkText' in c ? c.chunkText : '')).join('');
+    expect(joined).toContain('<think>');
+    expect(joined).not.toContain('<|');
+  });
+});

--- a/b4m-core/llm-adapters/src/bedrockBackend/moonshot.ts
+++ b/b4m-core/llm-adapters/src/bedrockBackend/moonshot.ts
@@ -8,6 +8,7 @@ import {
   IChoiceEndToolUse,
 } from '../backend';
 import { BaseBedrockBackend } from './base';
+import { hasNativeToolMarker, parseNativeToolSection, KimiNativeToolStream } from './kimiNativeTools';
 
 /** The assistant payload Moonshot returns, on `message` or streamed as `delta`. */
 interface MoonshotMessage {
@@ -50,6 +51,13 @@ export default class MoonshotBedrockBackend extends BaseBedrockBackend {
   /** Streaming-only: whether an unclosed `<think>` tag has been emitted. */
   private isInThinkingBlock = false;
 
+  /**
+   * Streaming-only: extracts Kimi's native `<|tool_call...|>` tokens out of the
+   * reasoning stream into structured calls. One instance per request; reset in
+   * getPayload. See kimiNativeTools.
+   */
+  private nativeToolStream = new KimiNativeToolStream();
+
   async getModelInfo(): Promise<ModelInfo[]> {
     return [
       {
@@ -71,12 +79,11 @@ export default class MoonshotBedrockBackend extends BaseBedrockBackend {
         },
         can_think: true,
         supportsVision: true,
-        // Tools disabled on the Bedrock path pending #1119: this model emits Kimi's
-        // native <|tool_call...|> token format inside the reasoning stream instead of
-        // structured tool_calls, which nothing parses (it would leak as raw text and
-        // never execute). The direct-served Kimi ids keep tools. See #1119 for the
-        // native-token parser that re-enables this.
-        supportsTools: false,
+        // This model non-deterministically emits tool calls as Kimi's native
+        // <|tool_call...|> tokens inside the reasoning stream instead of structured
+        // tool_calls; kimiNativeTools filters those into structured calls (translate),
+        // so tools work on the Bedrock path too. (#1119)
+        supportsTools: true,
         supportsImageVariation: false,
         releaseDate: '2026-01-27',
         rank: 10,
@@ -98,10 +105,9 @@ export default class MoonshotBedrockBackend extends BaseBedrockBackend {
         can_think: true,
         // Text-only on Bedrock, unlike the direct-served Kimi family.
         supportsVision: false,
-        // Tools disabled on the Bedrock path pending #1119 (native tool-call tokens
-        // are emitted in the reasoning stream, not as structured tool_calls). The
-        // direct-served Kimi ids keep tools.
-        supportsTools: false,
+        // Native <|tool_call...|> tokens in the reasoning stream are filtered into
+        // structured calls by kimiNativeTools, so tools work here too. (#1119)
+        supportsTools: true,
         supportsImageVariation: false,
         releaseDate: '2025-11-06',
         rank: 10,
@@ -170,8 +176,10 @@ export default class MoonshotBedrockBackend extends BaseBedrockBackend {
       if (options.tool_choice !== undefined) body.tool_choice = options.tool_choice;
     }
 
-    // A fresh request starts outside any thinking block; see translateStreamChunk.
+    // A fresh request starts outside any thinking block, with an empty native-tool
+    // buffer; see translateStreamChunk.
     this.isInThinkingBlock = false;
+    this.nativeToolStream = new KimiNativeToolStream();
 
     return {
       modelId: model,
@@ -288,41 +296,114 @@ export default class MoonshotBedrockBackend extends BaseBedrockBackend {
 
       const reasoning = payload.reasoning_content ?? '';
       const content = payload.content ?? '';
-
       // Bedrock Kimi does NOT populate `reasoning_content`; it inlines the monologue
       // in `content` wrapped in <reasoning>...</reasoning> -- a self-contained,
-      // balanced pair per streamed delta. Convert that envelope to the <think>
-      // convention the client renders, or the raw tags show verbatim in the answer.
-      // Per-delta conversion (rather than merging into one block via
-      // isInThinkingBlock) is deliberate: each Bedrock delta is already balanced, and
-      // a reasoning-to-tool turn would otherwise strand an open <think> the base
-      // cannot close once a tool frame appears. `reasoning_content` is still honored
-      // as a fallback spelling for any variant that emits it.
+      // balanced pair per streamed delta -- which we convert to the <think>
+      // convention the client renders. It ALSO non-deterministically emits tool
+      // calls as native <|tool_call...|> tokens INSIDE that reasoning rather than as
+      // structured tool_calls (see kimiNativeTools); those are filtered into
+      // structured calls so they execute and never leak as raw text.
+      const endReason =
+        choice.finish_reason === 'stop' || choice.finish_reason === 'length'
+          ? ChoiceEndReason.STOP
+          : ChoiceEndReason.COMPLETE;
       const convertTags = (t: string) => t.replace(/<reasoning>/g, '<think>').replace(/<\/reasoning>/g, '</think>');
 
-      let chunkText: string;
-      if (!opts.streaming) {
-        chunkText = (reasoning ? `<think>${reasoning}</think>` : '') + convertTags(content);
-      } else if (reasoning) {
-        chunkText = this.isInThinkingBlock ? reasoning : `<think>${reasoning}`;
-        this.isInThinkingBlock = true;
-      } else if (this.isInThinkingBlock && content) {
-        this.isInThinkingBlock = false;
-        chunkText = `</think>${convertTags(content)}`;
-      } else {
-        chunkText = convertTags(content);
+      if (opts.streaming) {
+        // `reasoning_content` fallback spelling: merge into one <think> block.
+        if (reasoning) {
+          const chunkText = this.isInThinkingBlock ? reasoning : `<think>${reasoning}`;
+          this.isInThinkingBlock = true;
+          choices.push({ status: ChoiceStatus.STREAM, index, chunkText, ...usageForIndex });
+          continue;
+        }
+
+        // Real Bedrock: reasoning inlined as <reasoning> tags, tool calls possibly
+        // inside it as native tokens. Filter the reasoning inner text.
+        if (content.includes('<reasoning>')) {
+          const inner = content.replace(/<\/?reasoning>/g, '');
+          const { text: safe, toolCalls: nativeCalls } = this.nativeToolStream.push(inner);
+          for (const call of nativeCalls) {
+            // Same header + plain-argument-delta contract the structured path uses,
+            // so base.ts accumulates the arguments (never TOOL_USE on the arg frame).
+            choices.push({
+              status: ChoiceStatus.STREAM,
+              index: call.index,
+              chunkText: '',
+              tool: { id: call.id, name: call.name },
+            });
+            if (call.arguments) {
+              choices.push({ status: ChoiceStatus.STREAM, index: call.index, chunkText: call.arguments });
+            }
+          }
+          const think = safe + (choice.finish_reason ? this.nativeToolStream.flush() : '');
+          choices.push({
+            status: ChoiceStatus.END,
+            statusEndReason: endReason,
+            index,
+            chunkText: think ? `<think>${think}</think>` : '',
+            ...usageForIndex,
+          });
+          continue;
+        }
+
+        // Prose, or the close of an open `reasoning_content` block.
+        if (this.isInThinkingBlock && content) {
+          this.isInThinkingBlock = false;
+          choices.push({
+            status: ChoiceStatus.END,
+            statusEndReason: endReason,
+            index,
+            chunkText: `</think>${content}`,
+            ...usageForIndex,
+          });
+          continue;
+        }
+        choices.push({
+          status: ChoiceStatus.END,
+          statusEndReason: endReason,
+          index,
+          chunkText: content,
+          ...usageForIndex,
+        });
+        continue;
       }
 
-      choices.push({
-        status: ChoiceStatus.END,
-        statusEndReason:
-          choice.finish_reason === 'stop' || choice.finish_reason === 'length'
-            ? ChoiceEndReason.STOP
-            : ChoiceEndReason.COMPLETE,
-        index,
-        chunkText,
-        ...usageForIndex,
-      });
+      // Non-streaming: the whole message is in hand. Extract a native tool section if
+      // present; otherwise convert the inline <reasoning> envelope to <think>.
+      if (hasNativeToolMarker(content)) {
+        const inner = content.replace(/<\/?reasoning>/g, '');
+        const begin = inner.indexOf('<|tool_calls_section_begin|>');
+        const before = (begin >= 0 ? inner.slice(0, begin) : inner).trim();
+        const nativeCalls = parseNativeToolSection(inner);
+        const think = [reasoning, before].filter(Boolean).join(' ').trim();
+        let usageAttached = false;
+        if (think) {
+          choices.push({
+            status: ChoiceStatus.END,
+            statusEndReason: endReason,
+            index,
+            chunkText: `<think>${think}</think>`,
+            ...usageForIndex,
+          });
+          usageAttached = true;
+        }
+        for (const call of nativeCalls) {
+          choices.push({
+            status: ChoiceStatus.END,
+            statusEndReason: ChoiceEndReason.TOOL_USE,
+            index: call.index,
+            chunkText: call.arguments,
+            tool: { id: call.id, name: call.name, parameters: call.arguments },
+            ...(usageAttached ? {} : usageForIndex),
+          });
+          usageAttached = true;
+        }
+        continue;
+      }
+
+      const chunkText = (reasoning ? `<think>${reasoning}</think>` : '') + convertTags(content);
+      choices.push({ status: ChoiceStatus.END, statusEndReason: endReason, index, chunkText, ...usageForIndex });
     }
 
     return { done: true, chunk: { model, choices } };

--- a/packages/database/src/seeds/modelCatalog.seed.json
+++ b/packages/database/src/seeds/modelCatalog.seed.json
@@ -3169,7 +3169,7 @@
           "supported": true
         },
         "supportsVision": false,
-        "supportsTools": false,
+        "supportsTools": true,
         "supportsImageVariation": false,
         "lifecycle": {
           "status": "active"
@@ -3202,7 +3202,7 @@
           "supported": true
         },
         "supportsVision": true,
-        "supportsTools": false,
+        "supportsTools": true,
         "supportsImageVariation": false,
         "lifecycle": {
           "status": "active"


### PR DESCRIPTION
## Description

Follow-up to #1089, stacked on `feat/kimi-provider`. Makes tools work on the two Bedrock-served Kimi rows and re-enables `supportsTools`.

Bedrock-served Kimi non-deterministically returns tool calls two ways: as structured `tool_calls` deltas (already handled), or as its **native special-token format** emitted inline in the reasoning stream:

```
<|tool_calls_section_begin|> <|tool_call_begin|> functions.<name>:<idx> <|tool_call_argument_begin|> {json} <|tool_call_end|> <|tool_calls_section_end|>
```

Nothing parsed the native form, so the tokens leaked into the answer as text and the tool never ran — which is why #1089 shipped with tools disabled on the Bedrock rows. This adds a parser + streaming filter so both provider shapes converge on the same execution path, and turns the flag back on.

## Changes

- **`bedrockBackend/kimiNativeTools.ts` (new):** pure `parseNativeToolSection` + a small stateful `KimiNativeToolStream` filter that pulls the section out of the reasoning stream. Handles the streaming reality: markers span content deltas and interleave with the `<reasoning>` envelope; partial section-begin markers split across a chunk are held back so a raw `<|...|>` token never reaches the user.
- **`bedrockBackend/moonshot.ts`:** `translate()` routes reasoning content through the filter (streaming) and extracts a native section one-shot (non-streaming), emitting the same header + argument-delta shape the base accumulator already reads. Structured `tool_calls`, the `reasoning_content` fallback, and plain reasoning rendering are unchanged.
- **`supportsTools` re-enabled** on both Bedrock rows (adapter `getModelInfo` + the catalog seed).
- Tests grounded in live captures from `moonshot.kimi-k2-thinking` (us-east-2): the exact streamed frames are driven through the adapter plus a base-accumulator simulation, asserting the calls execute with intact args and no `<|` token leaks.

## Guide for Testers

Target: a preview for this PR (`app.pr<N>.preview.bike4mind.com`). Bedrock Kimi is keyless, so no provider key is needed.

1. Log in and open a new chat.
2. Click the model selector (the "AI Settings" chip) → search `kimi k2 thinking` → select **Kimi K2 Thinking (Bedrock)**. Expected: the chip reads "Kimi K2 Thinking (Bedrock)".
3. Click **Tools** in the composer → enable **Math Evaluate** → close the menu. Expected: the Tools chip shows a count badge.
4. In the message box type: `Use the Math Evaluate tool to compute 384 multiplied by 27, then state the result in one sentence.` and press Enter.
5. Expected within ~15s: the answer states **10368** (or "10,368"), the reasoning shows as a clean "Thoughts" block, and there are **no** literal `<|tool_call...|>` tokens anywhere in the reply.
6. (Optional, parallel calls) New chat, same model, enable **Math Evaluate** and **Web Search**; ask a prompt that needs both. Expected: both tools run; no raw tokens leak.

### Regression Checks
- **Reasoning render (no tools):** ask `What is 17 times 24? Think briefly, then answer.` — reasoning shows as one Thoughts block, answer `408`, no `<reasoning>`/`<|` tokens.
- **Usage/billing:** a streamed Bedrock Kimi turn still settles on provider tokens (`settledBasis: "provider"`, non-zero `actualInputTokens`), not the local estimate.
- **Direct Kimi models** (kimi-k3, kimi-k2.7-code, etc.): tools continue to work as before (unchanged path; needs a Moonshot key).
- **Other Bedrock models** (Claude, DeepSeek, Llama): tool calling unchanged.

### What NOT to test
- No UI/schema changes; this is a provider-adapter change. No admin settings, no migrations.

## Additional Information

Verified live at the adapter level: fresh native-token frames from `moonshot.kimi-k2-thinking` driven through the compiled adapter + base-accumulator simulation extract both parallel calls with full args and zero token leak. The full in-app tool execution (tool runs → result → recursion → final answer) should be confirmed once a preview is deployed for this PR.

Closes #1119.
