### PR TITLE
test(client): warm the AI completion path in e2e warmup to de-flake the credits gate

### DIFF
--- a/apps/client/e2e/constants.ts
+++ b/apps/client/e2e/constants.ts
@@ -1,6 +1,14 @@
 /** Debounce margin for model search input (ModelSelection.tsx uses a 500ms debounce). */
 export const MODEL_SEARCH_DEBOUNCE_MS = 600;
 
+/**
+ * Text models the credits/timing spec measures. Also warmed by warmup.setup.ts so the
+ * measured runs hit a warm ChatCompletion backend instead of eating its cold start.
+ * Single source of truth - keep both consumers in sync by importing from here. Names must
+ * match the model selector exactly.
+ */
+export const MONITORED_MODELS = ['Claude 4.7 Opus', 'GPT-5.5'] as const;
+
 /** Centralized timeout constants for E2E tests (in milliseconds). */
 export const TIMEOUTS = {
   /** Short UI transitions and state settling */

--- a/apps/client/e2e/notebook.spec.ts
+++ b/apps/client/e2e/notebook.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from './fixtures';
-import { TIMEOUTS } from './constants';
+import { TIMEOUTS, MONITORED_MODELS } from './constants';
 import { type ModelCreditsData } from './helpers/slack';
 import { writeCreditsData } from './helpers/credits-store';
 import { apiCreateSession, apiDeleteSession, apiRenameSession } from './helpers/api';
 import { getTestUsers } from './helpers/test-users';
 
-// Update these when monitored models change - names must match the model selector exactly
-const CREDITS_MODELS = ['Claude 4.7 Opus', 'GPT-5.5'];
+// Shared with warmup.setup.ts (which warms these before the measured runs). See constants.ts.
+const CREDITS_MODELS = MONITORED_MODELS;
 const RUNS_PER_MODEL = 2;
 const CREDITS_PROMPT = 'What is the capital of France?';
 

--- a/apps/client/e2e/warmup.setup.ts
+++ b/apps/client/e2e/warmup.setup.ts
@@ -1,6 +1,14 @@
 import { test as setup } from '@playwright/test';
+import { TIMEOUTS, MONITORED_MODELS } from './constants';
+import { BasePage } from './pages/BasePage';
+import { ChatPage } from './pages/ChatPage';
+import { ModelSelectorPage } from './pages/ModelSelectorPage';
 
-const WARMUP_TIMEOUT = 90_000;
+// The AI-completion warm (Tier 3) can pay a full ChatCompletion Fargate cold start per
+// model, so the overall budget must cover that - not the 90s that only Tier 1/2 needed.
+// Sized so warmAiModel's own fail-soft handles a dead backend; this ceiling only trips if
+// every model warm hangs, and warmup failing would skip every dependent project.
+const WARMUP_TIMEOUT = 600_000;
 const RETRY_DELAY = 2_000;
 const MAX_RETRIES = 3;
 
@@ -65,5 +73,48 @@ setup('warm up server endpoints', async ({ request, page }) => {
     }, `GET ${route} (SSR)`);
   }
 
+  // Tier 3: AI completion path - the ChatCompletion Fargate container + each provider
+  // connection. This is the most expensive cold start in the system and the one the
+  // credits/timing specs gate on within AI_RESPONSE (120s); a freshly deployed staging
+  // serves the first completion cold and blows that budget. Drive one real round-trip per
+  // monitored model here so the container/provider are warm before the measured runs - the
+  // first model boots the container (slow), later models reuse it (fast). Fail-soft like the
+  // rest of warmup: a slow/broken backend must never block the suite (the specs still assert).
+  const basePage = new BasePage(page);
+  const chatPage = new ChatPage(page);
+  const modelSelector = new ModelSelectorPage(page);
+  for (const model of MONITORED_MODELS) {
+    // Two attempts, each with a full AI_RESPONSE window: if attempt 1 times out because the
+    // Fargate task is still booting, that boot completes during it, so attempt 2 lands warm.
+    // Two 120s windows cover a ~4-min cold boot - enough headroom without letting a truly
+    // dead backend burn the whole WARMUP_TIMEOUT.
+    await warmAiModel(async () => {
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await basePage.dismissModals();
+      await modelSelector.selectTextModel(model);
+      const response = await chatPage.sendMessageAndWaitForResponse('Warmup ping - reply OK.', TIMEOUTS.AI_RESPONSE);
+      return response.length > 0;
+    }, model);
+  }
+
   console.log('Warmup complete.');
 });
+
+/**
+ * Warm a single AI model with up to two real completion round-trips. Separate from
+ * warmEndpoint (3 quick REST retries): AI warms are minutes-long, so the attempt count is
+ * kept low and explicit to stay within WARMUP_TIMEOUT. Fail-soft - logs and returns.
+ */
+async function warmAiModel(fn: () => Promise<boolean>, model: string) {
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      if (await fn()) {
+        console.log(`  ✓ AI completion (${model})`);
+        return;
+      }
+    } catch {
+      /* retry: attempt 1 likely timed out booting the container */
+    }
+  }
+  console.warn(`  ⚠ AI completion (${model}) — did not warm (continuing anyway)`);
+}


### PR DESCRIPTION
## Description

The `e2e/core` prod-promotion gate intermittently flaked on `notebook.spec.ts` "AI Credits and Timing": the first measured run timed out at 120s (`aiResponseRoot` never appeared) whenever it ran against a **freshly deployed staging**. Root cause is a warmup gap, not a test bug.

`warmup.setup.ts` primed Lambda, DB pools, and Next.js SSR — but never the **AI completion path** (the ChatCompletion Fargate container + per-provider connection). So the first `sendMessageAndWaitForResponse` in the notebook spec paid the full ChatCompletion cold start, which on a cold container exceeds the 120s `AI_RESPONSE` budget. (Same failure on the nightly; warm re-runs always pass.)

## Changes

- **`warmup.setup.ts`** — add **Tier 3**: drive one real completion per monitored model so the container + provider connections are warm before the measured runs (a "measure response time" test should measure warm steady-state, not cold start). The first model boots the container (slow), later models reuse it (fast). `warmAiModel` does two attempts per model so a slow Fargate boot is absorbed by the warm, not the spec; fail-soft so a dead backend never blocks the suite. `WARMUP_TIMEOUT` raised to cover the boot.
- **`constants.ts`** — `MONITORED_MODELS` is now the single source of truth for the models the credits spec measures *and* the warmup warms (previously duplicated as `CREDITS_MODELS` in the spec, a drift hazard).
- **`notebook.spec.ts`** — consume `MONITORED_MODELS`.

No test timeouts were bumped, no retries added, nothing skipped — the cold start is moved to where it belongs (warmup), not hidden.

## Guide for Testers

1. Trigger the Core gate: `E2E Tests (Core)` (stage `dev`), or run `apps/client` locally with `API_URL=https://app.staging.bike4mind.com` + `--project=notebook --grep "measure response time"`.
2. In the warmup step output, confirm Tier 3 runs: `✓ AI completion (Claude 4.7 Opus)` and `✓ AI completion (GPT-5.5)` before `Warmup complete.`
3. Confirm all four `Notebook - AI Credits and Timing` runs pass, and that **run 1** for each model is fast (single-digit seconds) rather than timing out — evidence the model was pre-warmed.

### Regression Checks
- Other projects still run: warmup remains fail-soft (a slow AI warm logs `⚠ ... did not warm (continuing anyway)` and never fails the setup, so dependent projects aren't skipped).
- The credits spec's Slack report still populates (avgCredits/avgDuration).

### What NOT to test
- No product/runtime code changed — only files under `apps/client/e2e/`.

## Additional Information

Verified on staging: warmup warmed both models, then all 4 credits runs passed with warm-fast run 1 (`Claude 4.7 Opus` 3.09s, `GPT-5.5` 3.16s) vs the prior cold-start 120s timeout. Typecheck + eslint clean.
