### PR TITLE
feat(telemetry): itemize the always-on prompt floor billed on every turn (#810)

### DIFF
--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -125,7 +125,8 @@ import {
   AnomalyAlertService,
   aggregateWebFetchContentTelemetry,
 } from '../telemetry';
-import type { ToolTelemetry, ToolErrorCategory } from '@bike4mind/common';
+import type { ToolTelemetry, ToolErrorCategory, SystemPromptDetail } from '@bike4mind/common';
+import { buildAlwaysOnFloorDetails } from './systemPromptFloorTelemetry';
 import {
   ContextTelemetryAlertsSchema,
   detectAgentMentions,
@@ -1891,6 +1892,22 @@ export class ChatCompletionProcess {
         });
       }
 
+      // Always-on system-prompt floor. Resolved once here (pure settings reads with
+      // built-in fallbacks) so the assembly below and the telemetry itemization further
+      // down measure the exact same content - see buildAlwaysOnFloorDetails.
+      const artifactEmissionEnabled = Boolean(getSettingsValue('EnableArtifacts', defaultAdminSettings));
+      // Admin-editable via the `ArtifactEmissionPrompt` setting (general AI settings); falls back
+      // to the built-in ARTIFACT_EMISSION_PROMPT default when unset/cleared, so a blank value can
+      // never strip artifact guidance from completions.
+      const artifactEmissionContent = getSettingsValue(
+        'ArtifactEmissionPrompt',
+        defaultAdminSettings,
+        ARTIFACT_EMISSION_PROMPT
+      );
+      // Admin-editable via the `HelpCenterPrompt` setting; a blank value falls back to the built-in
+      // default so the nudge can never be silently stripped.
+      const helpCenterContent = getSettingsValue('HelpCenterPrompt', defaultAdminSettings, HELP_CENTER_PROMPT);
+
       // Extracted so the overflow-guard safety net below can rebuild with a trimmed
       // history without duplicating this (long, order-sensitive) system/context block.
       const contextAndSystemMessages: IMessage[] = [
@@ -1899,30 +1916,11 @@ export class ChatCompletionProcess {
         // Artifact emission guidance. Without this, correct <artifact> usage
         // is left to the model's defaults and large HTML/code can leak into the chat
         // body as raw markup. Gated on the same EnableArtifacts flag as extraction.
-        ...(getSettingsValue('EnableArtifacts', defaultAdminSettings)
-          ? [
-              {
-                role: 'system' as const,
-                // Admin-editable via the `ArtifactEmissionPrompt` setting (general AI settings);
-                // falls back to the built-in ARTIFACT_EMISSION_PROMPT default when unset/cleared,
-                // so a blank value can never strip artifact guidance from completions.
-                content: getSettingsValue('ArtifactEmissionPrompt', defaultAdminSettings, ARTIFACT_EMISSION_PROMPT),
-              },
-            ]
-          : []),
+        ...(artifactEmissionEnabled ? [{ role: 'system' as const, content: artifactEmissionContent }] : []),
         // Help-center awareness. Makes the model aware of the in-app
         // Help Center so a user who types a how-to question ("how do I add to my data lake?")
-        // gets pointed to it instead of an ungrounded guess. Admin-editable via the
-        // `HelpCenterPrompt` setting; a blank value falls back to the built-in default so the
-        // nudge can never be silently stripped. Skipped for local models (lean prompt).
-        ...(isLocalModel
-          ? []
-          : [
-              {
-                role: 'system' as const,
-                content: getSettingsValue('HelpCenterPrompt', defaultAdminSettings, HELP_CENTER_PROMPT),
-              },
-            ]),
+        // gets pointed to it instead of an ungrounded guess. Skipped for local models (lean prompt).
+        ...(isLocalModel ? [] : [{ role: 'system' as const, content: helpCenterContent }]),
         // Inject view registry summary when navigate_view tool is enabled
         ...(enabledTools.includes('navigate_view')
           ? [
@@ -2184,12 +2182,6 @@ export class ChatCompletionProcess {
       if (telemetryBuilder) {
         try {
           // Build system prompt details for telemetry
-          type SystemPromptDetail = {
-            source: 'hardcoded' | 'admin' | 'user' | 'project' | 'session' | 'org';
-            name: string;
-            tokenCount: number;
-            wasIncluded: boolean;
-          };
           const systemPromptDetails: SystemPromptDetail[] = [];
 
           // Date/time context (hardcoded)
@@ -2275,6 +2267,16 @@ export class ChatCompletionProcess {
               wasIncluded: true,
             });
           }
+
+          // Always-on floor blocks (artifact-emission, help-center) billed on every basic
+          // turn. Previously invisible inside the systemPrompts residual; itemized here so
+          // the fixed prompt cost is auditable in the Context Inspector (#810).
+          systemPromptDetails.push(
+            ...(await buildAlwaysOnFloorDetails(
+              { artifactEmissionEnabled, artifactEmissionContent, isLocalModel, helpCenterContent },
+              content => calculateTotalTokenLength([{ role: 'system' as const, content }], tokenCalcOptions)
+            ))
+          );
 
           // Calculate total system prompt tokens
           const systemPromptTokensTotal = systemPromptDetails.reduce((sum, p) => sum + p.tokenCount, 0);

--- a/b4m-core/services/src/llm/systemPromptFloorTelemetry.test.ts
+++ b/b4m-core/services/src/llm/systemPromptFloorTelemetry.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildAlwaysOnFloorDetails, type AlwaysOnFloorInput } from './systemPromptFloorTelemetry';
+
+// Deterministic stand-in for the real tiktoken counter: token count == char length.
+const lengthCounter = (content: string) => Promise.resolve(content.length);
+
+const base: AlwaysOnFloorInput = {
+  artifactEmissionEnabled: true,
+  artifactEmissionContent: 'ARTIFACT',
+  isLocalModel: false,
+  helpCenterContent: 'HELP',
+};
+
+describe('buildAlwaysOnFloorDetails', () => {
+  it('itemizes both always-on floor blocks in stable order for a normal turn', async () => {
+    const details = await buildAlwaysOnFloorDetails(base, lengthCounter);
+    expect(details.map(d => d.name)).toEqual(['artifact_emission', 'help_center']);
+    expect(details).toEqual([
+      { source: 'admin', name: 'artifact_emission', tokenCount: 8, wasIncluded: true },
+      { source: 'admin', name: 'help_center', tokenCount: 4, wasIncluded: true },
+    ]);
+  });
+
+  it('marks artifact_emission excluded (0 tokens, disabled) when artifacts are off', async () => {
+    const details = await buildAlwaysOnFloorDetails({ ...base, artifactEmissionEnabled: false }, lengthCounter);
+    const artifact = details.find(d => d.name === 'artifact_emission');
+    expect(artifact).toEqual({
+      source: 'admin',
+      name: 'artifact_emission',
+      tokenCount: 0,
+      wasIncluded: false,
+      exclusionReason: 'disabled',
+    });
+  });
+
+  it('marks help_center excluded (0 tokens, disabled) for local models', async () => {
+    const details = await buildAlwaysOnFloorDetails({ ...base, isLocalModel: true }, lengthCounter);
+    const help = details.find(d => d.name === 'help_center');
+    expect(help).toEqual({
+      source: 'admin',
+      name: 'help_center',
+      tokenCount: 0,
+      wasIncluded: false,
+      exclusionReason: 'disabled',
+    });
+  });
+
+  it('does not count tokens for an excluded block (no wasted tokenizer work)', async () => {
+    const counter = vi.fn(lengthCounter);
+    await buildAlwaysOnFloorDetails({ ...base, artifactEmissionEnabled: false, isLocalModel: true }, counter);
+    expect(counter).not.toHaveBeenCalled();
+  });
+
+  it('counts each included block exactly once, with its own content', async () => {
+    const counter = vi.fn(lengthCounter);
+    await buildAlwaysOnFloorDetails(base, counter);
+    expect(counter).toHaveBeenCalledTimes(2);
+    expect(counter).toHaveBeenCalledWith('ARTIFACT');
+    expect(counter).toHaveBeenCalledWith('HELP');
+  });
+});

--- a/b4m-core/services/src/llm/systemPromptFloorTelemetry.ts
+++ b/b4m-core/services/src/llm/systemPromptFloorTelemetry.ts
@@ -1,0 +1,63 @@
+import type { SystemPromptDetail } from '@bike4mind/common';
+
+/**
+ * Resolved inputs for the always-on system-prompt floor. Content strings are
+ * passed in already-resolved (via getSettingsValue with its built-in fallback)
+ * so this stays a pure function of its inputs and the exact same content the
+ * assembly sends is what gets measured - no re-derivation, no drift.
+ */
+export type AlwaysOnFloorInput = {
+  /** getSettingsValue('EnableArtifacts'); artifact-emission guidance is gated on it. */
+  artifactEmissionEnabled: boolean;
+  /** Resolved ArtifactEmissionPrompt (or its default). */
+  artifactEmissionContent: string;
+  /** Ollama/local models ship a lean prompt and skip the help-center nudge. */
+  isLocalModel: boolean;
+  /** Resolved HelpCenterPrompt (or its default). */
+  helpCenterContent: string;
+};
+
+/**
+ * Itemize the always-on system-prompt blocks billed on every basic chat turn.
+ *
+ * The artifact-emission and help-center blocks are unconditional for a normal
+ * (non-local) turn, yet they were previously folded into the opaque
+ * `tokensBySource.systemPrompts` residual - hiding the largest fixed prompt
+ * cost from the Context Inspector. Breaking them out gives the per-section
+ * composition #810 needs to decide what is safe to trim. Excluded blocks are
+ * still emitted (wasIncluded=false, exclusionReason='disabled') so the floor
+ * inventory is complete regardless of settings.
+ *
+ * NOTE: this measures only content WE author. The provider-injected tool-use
+ * preamble that Anthropic adds whenever any tool is attached is not visible
+ * here; sizing that needs a provider count_tokens probe (tracked separately).
+ *
+ * @param countTokens counts one system block's content; injected so the caller
+ *   supplies the real tokenizer and tests can stay deterministic.
+ */
+export async function buildAlwaysOnFloorDetails(
+  input: AlwaysOnFloorInput,
+  countTokens: (content: string) => Promise<number>
+): Promise<SystemPromptDetail[]> {
+  const details: SystemPromptDetail[] = [];
+
+  const artifactIncluded = input.artifactEmissionEnabled;
+  details.push({
+    source: 'admin',
+    name: 'artifact_emission',
+    tokenCount: artifactIncluded ? await countTokens(input.artifactEmissionContent) : 0,
+    wasIncluded: artifactIncluded,
+    ...(artifactIncluded ? {} : { exclusionReason: 'disabled' as const }),
+  });
+
+  const helpCenterIncluded = !input.isLocalModel;
+  details.push({
+    source: 'admin',
+    name: 'help_center',
+    tokenCount: helpCenterIncluded ? await countTokens(input.helpCenterContent) : 0,
+    wasIncluded: helpCenterIncluded,
+    ...(helpCenterIncluded ? {} : { exclusionReason: 'disabled' as const }),
+  });
+
+  return details;
+}

--- a/b4m-core/services/src/userService/update.test.ts
+++ b/b4m-core/services/src/userService/update.test.ts
@@ -388,4 +388,47 @@ describe('updateUser', () => {
     const persisted = mockUserRepository.update.mock.calls[0][0] as IUserDocument;
     expect(persisted.tags).toEqual(['Customer']);
   });
+
+  it('coerces an ISO-string contextTelemetryConsentedAt on write (telemetry level is not write-once)', async () => {
+    // The settings UI echoes the whole `preferences` object back on each write, so
+    // `contextTelemetryConsentedAt` round-trips from GET /users/{id} as an ISO string.
+    // A strict z.date() rejected it with a 422 on every write after the first, stranding
+    // users on the level they first picked. z.coerce.date() must accept and coerce it.
+    const isoConsentedAt = '2026-07-31T04:40:29.874Z';
+    const user = {
+      id: 'user-telemetry',
+      username: 'telemetryuser',
+      name: 'Telemetry User',
+      email: 'telemetry@example.com',
+      password: undefined,
+      isAdmin: false,
+      tags: [],
+      level: 'DemoUser',
+      systemFiles: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as unknown as IUserDocument;
+
+    const mockUserRepository = {
+      findByIdWithPassword: vi.fn().mockResolvedValue(user),
+      update: vi.fn().mockImplementation((u: IUserDocument) => Promise.resolve(u)),
+    };
+
+    const result = await updateUser(
+      'user-telemetry',
+      {
+        preferences: {
+          contextTelemetryLevel: 'basic',
+          contextTelemetryConsentedAt: isoConsentedAt,
+        },
+      } as unknown as UpdateUserParameters,
+      { db: { users: mockUserRepository as any } }
+    );
+
+    const persisted = mockUserRepository.update.mock.calls[0][0] as IUserDocument;
+    expect(persisted.preferences?.contextTelemetryLevel).toBe('basic');
+    expect(persisted.preferences?.contextTelemetryConsentedAt).toBeInstanceOf(Date);
+    expect((persisted.preferences?.contextTelemetryConsentedAt as Date).toISOString()).toBe(isoConsentedAt);
+    expect(result.preferences?.contextTelemetryLevel).toBe('basic');
+  });
 });

--- a/b4m-core/services/src/userService/update.ts
+++ b/b4m-core/services/src/userService/update.ts
@@ -64,7 +64,9 @@ export const updateUserSchema = z.object({
       toolsCatalogCollapsed: z.boolean().optional(),
       docxTemplateFileId: z.string().nullable().optional(),
       contextTelemetryLevel: z.enum(['none', 'basic', 'enhanced']).optional(),
-      contextTelemetryConsentedAt: z.date().optional(),
+      // coerce: the settings UI echoes this back as an ISO string from GET /users/{id},
+      // so a strict z.date() 422s on every write after the first (which mints a real Date).
+      contextTelemetryConsentedAt: z.coerce.date().optional(),
       // Layer-2 Agent-mode preference. The Mongoose schema accepts it now
       // (UserModel.ts) but unknown keys never reach repo.update without being
       // listed here.


### PR DESCRIPTION
## Description

Part of #810. Before we can decide what is safe to trim from the always-on prompt, we need to *see* the per-section composition of a basic turn. Today we can't: `tokensBySource.systemPrompts` is a derived residual (total minus history/fabs/urls/mementos/user), and the per-section `SystemPromptDetail` breakdown that feeds the admin Context Inspector never itemized the two blocks that dominate a basic no-tool turn - the **artifact-emission** and **help-center** system prompts. Both are unconditional for a normal (non-local) turn, so the largest *fixed* prompt cost was invisible.

This PR itemizes those two always-on floor blocks so their token cost shows up per-section in the Context Inspector. It is instrumentation only - **it does not change what is sent to the provider.**

## Changes

- Add `b4m-core/services/src/llm/systemPromptFloorTelemetry.ts`: a pure `buildAlwaysOnFloorDetails(...)` helper that returns `SystemPromptDetail[]` for the artifact-emission and help-center blocks, with `wasIncluded` / `exclusionReason: 'disabled'` for the artifacts-off and local-model cases so the floor inventory is complete regardless of settings. Token counting is injected, so the helper is deterministic and unit-tested (`systemPromptFloorTelemetry.test.ts`).
- `ChatCompletionProcess.ts`:
  - Extract the two block contents into named consts (`artifactEmissionContent`, `helpCenterContent`, `artifactEmissionEnabled`) that the message assembly and the telemetry itemization both read - identical content, no drift. The assembled prompt is byte-for-byte unchanged (same `getSettingsValue` calls, same conditions, same order).
  - Append the floor details to `systemPromptDetails` before the telemetry total is computed.
  - Replace the local inline `SystemPromptDetail` type with the canonical exported one from `@bike4mind/common`.

## Guide for Testers

Backend telemetry change. Three ways to verify, most-reproducible first. (A) needs only the repo; (B) and (C) run against the live preview at `app.pr1126.preview.bike4mind.com`.

### A. Unit tests (deterministic, no preview) - do this first
1. `git fetch && git checkout perf/810-prompt-payload-capture`
2. `pnpm i -r && pnpm turbo:core:build`
3. `pnpm --filter @bike4mind/services exec vitest run src/llm/systemPromptFloorTelemetry.test.ts`
   - Expected: `Test Files 1 passed`, `Tests 5 passed`.
4. No-regression sweep: `pnpm --filter @bike4mind/services exec vitest run src/llm/ChatCompletion.test.ts src/llm/ChatCompletionFeatures.test.ts src/telemetry`
   - Expected: all pass (139 tests).

### B. Live, deterministic (any logged-in user) - read the turn's telemetry
`Enhanced` telemetry is required; the default `Basic` tier strips `systemPrompts`.
1. Log in at https://app.pr1126.preview.bike4mind.com (passwordless: enter your email, then the emailed 6-digit code).
2. Raise your telemetry level: top-left avatar -> **Profile** -> **Settings** tab -> **Beta Features** -> the **Telemetry** card -> select **Enhanced**.
3. **New Chat** on the default model (**Claude 5 Sonnet**) and send a trivial one-line prompt, e.g. `hello`. Wait for the reply.
4. Read that turn's telemetry via the API:
   - Token (DevTools -> Console): `JSON.parse(localStorage['access-token-storage']).state.accessToken`
   - Quest id: the 24-hex id on the assistant message element (or from the notebook's network calls).
   - `curl -s https://app.pr1126.preview.bike4mind.com/api/quests/<QUEST_ID> -H "authorization: Bearer <TOKEN>" | jq '.promptMeta.contextTelemetry.systemPrompts.prompts'`
5. Expected: the array includes rows named **`artifact_emission`** and **`help_center`**, each `wasIncluded: true` with a non-zero `tokenCount`. On a default preview: `artifact_emission` ~2190, `help_center` ~179 (exact counts depend on the admin-configured prompt text). Before this PR both rows were absent.

### C. Live, visual (admin only) - Context Inspector
1. As an admin on the preview (admin access on a fresh preview is maintainer-provisioned), with your telemetry at `Enhanced` (B.2), send a turn that earns a non-zero anomaly score so it lists in the Inspector - the HTML-artifact turn from the regression checks works (it's slower, so it scores for `Slow Response`). A trivial `hello` scores 0 and is excluded (see step 3).
2. Sidebar -> **Admin** -> **Context Inspector**.
3. IMPORTANT: the **Min Anomaly Score** filter offers only `Any (>0)`, `30+`, `50+`, `70+` - there is no "include 0" option, and score-0 turns are excluded server-side too, so a benign turn (score 0) will not appear here at all. Inspect a turn with a non-zero score (the artifact turn from step 1). To read a benign turn's floor rows instead, use the direct `GET /api/quests/<id>` route from section B.
4. In the **System Prompts** per-section breakdown, confirm `artifact_emission` and `help_center` rows appear with non-zero counts.

### Regression Checks (verified live on pr1126 - see PR comment)
- Trivial turn, HTML-artifact turn, warm follow-up, and a model switch (Sonnet 5 -> Opus 4.8) all itemize the floor identically (`artifact_emission` 2190, `help_center` 179).
- Artifact emission still works end-to-end (HTML artifact renders in its card, not leaked as raw markup) - the content extraction is byte-identical to what was sent before.
- Multi-turn chat unaffected; responses unchanged (no prompt content changed).
- `basic` / `none` telemetry tier: `systemPrompts` details remain stripped as before.

### What NOT to test
- No user-facing chat behavior, billing, or settlement changes - this only adds telemetry rows.
- Local (Ollama) models: `help_center` is intentionally `wasIncluded: false` (disabled); not testable on a preview (no local model configured).

## Additional Information

Scope note: this measures only content **we** author. The investigation on #810 found that attaching any tool also triggers a provider-injected tool-use preamble (counted in `cache_creation`) that is ~half the cold-turn prefix and is not visible in our assembly. Sizing that requires a provider `count_tokens` probe (`system` vs `system+tools` vs `no-tools`) and is a separate follow-up. This PR closes the authored-content half of the "document the real per-section composition" acceptance item.

Known adjacent gap (not touched here): the existing `session_summary` detail measures `session.summary`, while the assembled context-summary block uses `session.contextSummary` - a pre-existing mismatch worth a separate fix.

## Developer Notes (Optional)

- `buildAlwaysOnFloorDetails` establishes a pattern for itemizing always-on prompt blocks with injected token counting - other currently-residual blocks (navigate_view summary, context summary, recent-images) can be itemized the same way.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings



