### PR TITLE
test(client): freeze the clock in the api-key rate-limit reset e2e test (#1098)

### DIFF
--- a/apps/client/server/utils/apiKeyRateLimitReset.e2e.test.ts
+++ b/apps/client/server/utils/apiKeyRateLimitReset.e2e.test.ts
@@ -38,9 +38,12 @@ describe('resetApiKeyRateLimit (end-to-end, real cache repo + Mongo)', () => {
     // fixed wall-clock window can't roll over mid-test. On a starved CI runner the three
     // sequential awaits below could otherwise span >60s, expiring the window and letting the
     // "blocked" call through - a false red in the runner, not the code. All calls must see one
-    // window; time is only advanced deliberately to test the roll-over-after-reset path.
+    // window. The frozen instant must be in the real-clock FUTURE: the cache collection has a
+    // TTL index on expiresAt, and mongod's sweeper runs on its own real clock (not the faked
+    // Date), so a past instant would make the window doc immediately TTL-eligible and delete it
+    // mid-test - the same starved-runner flake, reintroduced via TTL.
     vi.useFakeTimers({ toFake: ['Date'] });
-    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'));
     try {
       // Drive the enforcer to the minute ceiling: 2 allowed, 3rd rejected.
       expect((await checkApiKeyRateLimit(keyId, rateLimit)).allowed).toBe(true);

--- a/apps/client/server/utils/apiKeyRateLimitReset.e2e.test.ts
+++ b/apps/client/server/utils/apiKeyRateLimitReset.e2e.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import type { MongoMemoryServer } from 'mongodb-memory-server';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
@@ -34,20 +34,31 @@ afterEach(async () => {
 
 describe('resetApiKeyRateLimit (end-to-end, real cache repo + Mongo)', () => {
   it('unblocks a key that genuinely hit its ceiling, opening a fresh window', async () => {
-    // Drive the enforcer to the minute ceiling: 2 allowed, 3rd rejected.
-    expect((await checkApiKeyRateLimit(keyId, rateLimit)).allowed).toBe(true);
-    expect((await checkApiKeyRateLimit(keyId, rateLimit)).allowed).toBe(true);
-    const blocked = await checkApiKeyRateLimit(keyId, rateLimit);
-    expect(blocked.allowed).toBe(false);
-    expect(blocked.limitType).toBe('minute');
+    // Freeze the clock (Date only - Mongo's real timers/IO are untouched) so the enforcer's
+    // fixed wall-clock window can't roll over mid-test. On a starved CI runner the three
+    // sequential awaits below could otherwise span >60s, expiring the window and letting the
+    // "blocked" call through - a false red in the runner, not the code. All calls must see one
+    // window; time is only advanced deliberately to test the roll-over-after-reset path.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    try {
+      // Drive the enforcer to the minute ceiling: 2 allowed, 3rd rejected.
+      expect((await checkApiKeyRateLimit(keyId, rateLimit)).allowed).toBe(true);
+      expect((await checkApiKeyRateLimit(keyId, rateLimit)).allowed).toBe(true);
+      const blocked = await checkApiKeyRateLimit(keyId, rateLimit);
+      expect(blocked.allowed).toBe(false);
+      expect(blocked.limitType).toBe('minute');
 
-    await resetApiKeyRateLimit(keyId);
+      await resetApiKeyRateLimit(keyId);
 
-    // Fresh window: allowed again, counter restarted at 1.
-    const afterReset = await checkApiKeyRateLimit(keyId, rateLimit);
-    expect(afterReset.allowed).toBe(true);
-    expect(afterReset.headers['X-RateLimit-Remaining-Minute']).toBe(rateLimit.requestsPerMinute - 1);
-    expect(afterReset.headers['X-RateLimit-Remaining-Day']).toBe(rateLimit.requestsPerDay - 1);
+      // Fresh window: allowed again, counter restarted at 1.
+      const afterReset = await checkApiKeyRateLimit(keyId, rateLimit);
+      expect(afterReset.allowed).toBe(true);
+      expect(afterReset.headers['X-RateLimit-Remaining-Minute']).toBe(rateLimit.requestsPerMinute - 1);
+      expect(afterReset.headers['X-RateLimit-Remaining-Day']).toBe(rateLimit.requestsPerDay - 1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('clears both window docs for the target key only; unrelated cache keys survive', async () => {


### PR DESCRIPTION
## Description

Fixes failure **#3** from #1098 (`apiKeyRateLimitReset.e2e.test.ts` — `expect(blocked.allowed).toBe(false)` intermittently gets `true`).

The limiter is a **wall-clock fixed window**: `cacheRepository.tryIncrementWithinLimitFixedWindow` opens the window at `new Date()` with `expiresAt = now + 60_000`, and treats a doc whose `expiresAt` has passed as count 0. The failing test makes three sequential `checkApiKeyRateLimit` calls and expects the third to be blocked. On a starved CI runner (the `client` shard took ~11 min in the failing run), >60s of real time can elapse between the second and third `await`, so the window legitimately rolls over and the third call is correctly allowed — the **assertion breaks, not the code**.

## Fix

Freeze the clock for that one test with `vi.useFakeTimers({ toFake: ['Date'] })` + `vi.setSystemTime(...)`, so all three calls fall in a single window and the outcome is deterministic regardless of runner load. Real timers restored in `finally`.

- **`toFake: ['Date']` only** — `setTimeout`/`setInterval` stay real, so the Mongo driver's timers and async IO are untouched (no hang).
- Verified the limiter computes the window in JS (`const now = new Date()`, `expiresAt: { $gt: now }`), so freezing `Date` fully controls the boundary.
- No timeout bump, no added retries, nothing skipped — the fix removes the time dependency the assertion never should have had.

## Guide for Testers

1. `cd apps/client && npx vitest run server/utils/apiKeyRateLimitReset.e2e.test.ts` — expect `3 passed` (requires current core dist; run `pnpm turbo:core:build` first if stale).
2. The behavior under test is unchanged: 2 allowed → 3rd blocked → reset → allowed again.

### What NOT to test
- Test-only change; no product/runtime code touched.

## Scope

This closes **only #3** of the three flakes in #1098:
- **#2** (OTC cooldown `exactly one wins`) is **not** a test artifact — the winner-count is the production invariant guarding #598's CAS, and the flake reflects a real edge in `tryReserveSlot` that only manifests at the test-only `cooldownMs=0`. Left to the CAS owner (@jjmarfa) — changing that assertion would mask the signal.
- **#1** (Mongo setup-hook timeout) wants the `mongodb-memory-server` binary pre-warmed in the workflow, a separate CI change.

Refs #1098
