### PR TITLE
feat(cli): add generate_sound_effect MCP tool

### DIFF
--- a/BIKE4MIND_CLI.md
+++ b/BIKE4MIND_CLI.md
@@ -138,6 +138,7 @@ Some built-in tools (weather, web search, deep research) need provider keys, and
 | `search_knowledge_base` | Semantic search across your notebooks | `notebooks:read` |
 | `list_files` | Search your files | `files:read` |
 | `get_file` | File metadata plus a signed download URL | `files:read` |
+| `generate_sound_effect` | Generate a sound effect from a text description | `ai:generate` |
 
 It also exposes four resource templates, each with a working `list` and `read` that return `application/json`:
 

--- a/apps/client/pages/api/ai/__tests__/sound-effects.test.ts
+++ b/apps/client/pages/api/ai/__tests__/sound-effects.test.ts
@@ -13,6 +13,7 @@ const {
   userIncrement,
   orgIncrement,
   recordUsage,
+  persistGeneratedAudio,
 } = vi.hoisted(() => ({
   getEffectiveApiKey: vi.fn(),
   deductCredits: vi.fn(),
@@ -24,6 +25,7 @@ const {
   userIncrement: vi.fn(),
   orgIncrement: vi.fn(),
   recordUsage: vi.fn(),
+  persistGeneratedAudio: vi.fn(),
 }));
 
 // baseApi mock: routes by req.method; a thrown ZodError maps to 422 (mirroring
@@ -84,6 +86,9 @@ vi.mock('@bike4mind/utils', () => ({
   getSettingsMap: vi.fn(async () => ({})),
   getSettingsValue: (...a: unknown[]) => getSettingsValue(...a),
 }));
+vi.mock('@server/utils/persistGeneratedAudio', () => ({
+  persistGeneratedAudio: (...a: unknown[]) => persistGeneratedAudio(...a),
+}));
 
 import handler from '../sound-effects';
 
@@ -111,8 +116,12 @@ beforeEach(() => {
     userIncrement,
     orgIncrement,
     recordUsage,
+    persistGeneratedAudio,
   ].forEach(m => m.mockReset());
   recordUsage.mockResolvedValue(undefined);
+  // Default: persistence is a no-op that reports "not saved", so tests not
+  // exercising the save path see no persisted-file headers.
+  persistGeneratedAudio.mockResolvedValue({ saved: false, reason: 'error' });
   getEffectiveApiKey.mockResolvedValue('eleven-key');
   generate.mockResolvedValue({ audio: Buffer.from('boom'), contentType: 'audio/mpeg' });
   findById.mockResolvedValue({ id: 'u1', currentCredits: 100 });
@@ -203,16 +212,57 @@ describe('POST /api/ai/sound-effects', () => {
     expect(recordUsage).not.toHaveBeenCalled();
   });
 
-  it('returns 401 when no provider key resolves (no reservation)', async () => {
+  it('returns 503 (not 401) when no provider key resolves (no reservation)', async () => {
     getEffectiveApiKey.mockResolvedValue(null);
 
     const { res, promise } = run({ text: 'rain' });
     await promise;
 
-    expect(res._getStatusCode()).toBe(401);
+    // A missing provider key is a capability gap, not an auth failure - a 401 would
+    // wrongly tell an API-key caller to re-authenticate.
+    expect(res._getStatusCode()).toBe(503);
+    expect(res._getJSONData()).toMatchObject({ error: 'No elevenlabs API key configured' });
     expect(userIncrement).not.toHaveBeenCalled();
     expect(generate).not.toHaveBeenCalled();
     expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  it('forwards the persisted-file id, name, and signed URL as response headers', async () => {
+    getSettingsValue.mockReturnValue(false);
+    estimateSoundCredits.mockReturnValue({ requiredCredits: 0, usdCost: 0, billedSeconds: 3 });
+    persistGeneratedAudio.mockResolvedValue({
+      saved: true,
+      fabFileId: 'fab1',
+      fileName: 'sound-effect-rain.mp3',
+      fileUrl: 'https://signed.example/audio.mp3',
+    });
+
+    const { res, promise } = run({ text: 'rain', durationSeconds: 3 });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    // The signed URL must ride the header: the CLI cannot re-resolve one via
+    // GET /api/files/:id until the async moderation scan flips the file to 'clean'.
+    expect(res.getHeader('X-B4M-Audio-Saved')).toBe('true');
+    expect(res.getHeader('X-B4M-Audio-Fab-File-Id')).toBe('fab1');
+    expect(res.getHeader('X-B4M-Audio-File-Name')).toBe('sound-effect-rain.mp3');
+    expect(res.getHeader('X-B4M-Audio-File-Url')).toBe('https://signed.example/audio.mp3');
+  });
+
+  it('reports not-saved and forwards no file headers when persistence fails', async () => {
+    getSettingsValue.mockReturnValue(false);
+    estimateSoundCredits.mockReturnValue({ requiredCredits: 0, usdCost: 0, billedSeconds: 3 });
+    persistGeneratedAudio.mockResolvedValue({ saved: false, reason: 'storage_limit' });
+
+    const { res, promise } = run({ text: 'rain', durationSeconds: 3 });
+    await promise;
+
+    // Persist failure never blocks the audio the caller was billed for.
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData().toString()).toBe('boom');
+    expect(res.getHeader('X-B4M-Audio-Saved')).toBe('false');
+    expect(res.getHeader('X-B4M-Audio-Fab-File-Id')).toBeUndefined();
+    expect(res.getHeader('X-B4M-Audio-File-Url')).toBeUndefined();
   });
 
   it('rejects an invalid body (422) without resolving a key', async () => {

--- a/apps/client/pages/api/ai/sound-effects.ts
+++ b/apps/client/pages/api/ai/sound-effects.ts
@@ -50,7 +50,11 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(asyn
   );
 
   if (!apiKey) {
-    return res.status(401).json({ error: `No ${provider} API key configured` });
+    // 503, not 401: the caller IS authenticated - the provider key is a server-side
+    // capability gap. A 401 would tell an API-key caller to re-authenticate, which
+    // never fixes a missing ElevenLabs key. The message survives to the CLI via the
+    // arraybuffer error decode + mapApiError's server-message fallback.
+    return res.status(503).json({ error: `No ${provider} API key configured` });
   }
 
   const settings = await getSettingsMap({ adminSettings: adminSettingsRepository }, { names: ['enforceCredits'] });
@@ -218,7 +222,16 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(asyn
       logger: req.logger,
     });
     res.setHeader('X-B4M-Audio-Saved', String(save.saved));
-    if (save.saved) res.setHeader('X-B4M-Audio-Fab-File-Id', save.fabFileId);
+    if (save.saved) {
+      res.setHeader('X-B4M-Audio-Fab-File-Id', save.fabFileId);
+      res.setHeader('X-B4M-Audio-File-Name', save.fileName);
+      // Forward the signed URL minted at creation. Non-image audio gets a working URL
+      // immediately (createFabFile), whereas re-resolving it via GET /api/files/:id
+      // fails closed until the async moderation scan flips moderationStatus to 'clean'
+      // (isImageServeable gates every mime type) - so callers must use this URL, not
+      // re-fetch one. Absent only in the rare case createFabFile minted no URL.
+      if (save.fileUrl) res.setHeader('X-B4M-Audio-File-Url', save.fileUrl);
+    }
   }
 
   res.setHeader('Content-Type', contentType);

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -392,7 +392,7 @@ You can also run any MCP server via npx or custom executables:
 
 #### Serve Bike4Mind itself as an MCP server (`b4m mcp serve`)
 
-The reverse of adding a server: `b4m mcp serve` exposes your Bike4Mind backend to any MCP client (Claude Desktop, editors, other agents). It advertises seven tools (`list_notebooks`, `get_notebook`, `create_notebook`, `send_message`, `search_knowledge_base`, `list_files`, `get_file`) plus four resource templates (`b4m://notebook/{id}`, `b4m://file/{id}`, `b4m://project/{id}`, `b4m://artifact/{id}`), each listable and readable as JSON.
+The reverse of adding a server: `b4m mcp serve` exposes your Bike4Mind backend to any MCP client (Claude Desktop, editors, other agents). It advertises eight tools (`list_notebooks`, `get_notebook`, `create_notebook`, `send_message`, `search_knowledge_base`, `list_files`, `get_file`, `generate_sound_effect`) plus four resource templates (`b4m://notebook/{id}`, `b4m://file/{id}`, `b4m://project/{id}`, `b4m://artifact/{id}`), each listable and readable as JSON.
 
 ```bash
 b4m mcp serve                        # stdio (default) - for local clients that spawn the process

--- a/packages/cli/src/mcp/b4mApiClient.test.ts
+++ b/packages/cli/src/mcp/b4mApiClient.test.ts
@@ -127,7 +127,13 @@ describe('B4mApiClient', () => {
   it('generates a sound effect, requesting bytes and reading the persisted-file headers', async () => {
     mockAxiosPost.mockResolvedValue({
       data: Buffer.from('audio-bytes'),
-      headers: { 'content-type': 'audio/mpeg', 'x-b4m-audio-saved': 'true', 'x-b4m-audio-fab-file-id': 'fab1' },
+      headers: {
+        'content-type': 'audio/mpeg',
+        'x-b4m-audio-saved': 'true',
+        'x-b4m-audio-fab-file-id': 'fab1',
+        'x-b4m-audio-file-name': 'sound-effect-thunderclap.mp3',
+        'x-b4m-audio-file-url': 'https://signed.example/audio.mp3',
+      },
     });
 
     const result = await client.generateSoundEffect({
@@ -149,12 +155,37 @@ describe('B4mApiClient', () => {
       },
       { responseType: 'arraybuffer' }
     );
+    // The signed URL comes straight off the header, not a re-fetch, so the CLI never
+    // hits the moderation race that GET /api/files/:id would on a just-created file.
     expect(result).toEqual({
       audio: Buffer.from('audio-bytes'),
       contentType: 'audio/mpeg',
       saved: true,
       fabFileId: 'fab1',
+      fileName: 'sound-effect-thunderclap.mp3',
+      fileUrl: 'https://signed.example/audio.mp3',
     });
+  });
+
+  it('drops the persisted-file headers when the save header is not "true"', async () => {
+    // A duplicated header arrives as an array; only the scalar string form is kept,
+    // and none of the file headers are read at all unless the save actually succeeded.
+    mockAxiosPost.mockResolvedValue({
+      data: Buffer.from('audio-bytes'),
+      headers: {
+        'content-type': 'audio/mpeg',
+        'x-b4m-audio-saved': 'false',
+        'x-b4m-audio-fab-file-id': ['fab1', 'fab2'],
+        'x-b4m-audio-file-url': 'https://signed.example/audio.mp3',
+      },
+    });
+
+    const result = await client.generateSoundEffect({ provider: 'elevenlabs', text: 'wind' });
+
+    expect(result.saved).toBe(false);
+    expect(result.fabFileId).toBeUndefined();
+    expect(result.fileName).toBeUndefined();
+    expect(result.fileUrl).toBeUndefined();
   });
 
   it('omits optional sound-effect fields and reports not-saved when no fab-file header is set', async () => {
@@ -180,6 +211,16 @@ describe('B4mApiClient', () => {
 
     await expect(client.generateSoundEffect({ provider: 'elevenlabs', text: 'x' })).rejects.toMatchObject({
       response: { data: { error: 'Sound generation failed' } },
+    });
+  });
+
+  it('decodes an already-stringified error body (non-Node adapter shape)', async () => {
+    mockAxiosPost.mockRejectedValue(
+      axiosError(503, { data: JSON.stringify({ error: 'No elevenlabs API key configured' }) })
+    );
+
+    await expect(client.generateSoundEffect({ provider: 'elevenlabs', text: 'x' })).rejects.toMatchObject({
+      response: { data: { error: 'No elevenlabs API key configured' } },
     });
   });
 

--- a/packages/cli/src/mcp/b4mApiClient.test.ts
+++ b/packages/cli/src/mcp/b4mApiClient.test.ts
@@ -3,10 +3,12 @@ import { AxiosError, type AxiosResponse, type InternalAxiosRequestConfig } from 
 
 const mockGet = vi.fn();
 const mockPost = vi.fn();
+const mockAxiosPost = vi.fn();
 vi.mock('../auth/ApiClient', () => ({
   ApiClient: class {
     get = mockGet;
     post = mockPost;
+    getAxiosInstance = () => ({ post: mockAxiosPost });
   },
 }));
 
@@ -120,6 +122,65 @@ describe('B4mApiClient', () => {
     mockGet.mockResolvedValue({ id: 'f1' });
     await client.getFile('f1');
     expect(mockGet).toHaveBeenCalledWith('/api/files/f1');
+  });
+
+  it('generates a sound effect, requesting bytes and reading the persisted-file headers', async () => {
+    mockAxiosPost.mockResolvedValue({
+      data: Buffer.from('audio-bytes'),
+      headers: { 'content-type': 'audio/mpeg', 'x-b4m-audio-saved': 'true', 'x-b4m-audio-fab-file-id': 'fab1' },
+    });
+
+    const result = await client.generateSoundEffect({
+      provider: 'elevenlabs',
+      text: 'thunderclap',
+      durationSeconds: 3,
+      promptInfluence: 0.5,
+      format: 'mp3_44100_128',
+    });
+
+    expect(mockAxiosPost).toHaveBeenCalledWith(
+      '/api/ai/sound-effects',
+      {
+        provider: 'elevenlabs',
+        text: 'thunderclap',
+        durationSeconds: 3,
+        promptInfluence: 0.5,
+        format: 'mp3_44100_128',
+      },
+      { responseType: 'arraybuffer' }
+    );
+    expect(result).toEqual({
+      audio: Buffer.from('audio-bytes'),
+      contentType: 'audio/mpeg',
+      saved: true,
+      fabFileId: 'fab1',
+    });
+  });
+
+  it('omits optional sound-effect fields and reports not-saved when no fab-file header is set', async () => {
+    mockAxiosPost.mockResolvedValue({
+      data: Buffer.from('bytes'),
+      headers: { 'content-type': 'audio/mpeg' },
+    });
+
+    const result = await client.generateSoundEffect({ provider: 'elevenlabs', text: 'wind' });
+
+    expect(mockAxiosPost).toHaveBeenCalledWith(
+      '/api/ai/sound-effects',
+      { provider: 'elevenlabs', text: 'wind' },
+      { responseType: 'arraybuffer' }
+    );
+    expect(result.saved).toBe(false);
+    expect(result.fabFileId).toBeUndefined();
+  });
+
+  it('decodes an arraybuffer error body so mapApiError can read the server message', async () => {
+    const bodyBytes = Buffer.from(JSON.stringify({ error: 'Sound generation failed' }));
+    mockAxiosPost.mockRejectedValue(axiosError(502, { data: bodyBytes }));
+
+    await expect(client.generateSoundEffect({ provider: 'elevenlabs', text: 'x' })).rejects.toMatchObject({
+      response: { data: { error: 'Sound generation failed' } },
+    });
   });
 
   it('lists projects with nested pagination and normalizes the envelope', async () => {

--- a/packages/cli/src/mcp/b4mApiClient.ts
+++ b/packages/cli/src/mcp/b4mApiClient.ts
@@ -75,14 +75,19 @@ export interface SoundEffectArgs {
 
 /**
  * Raw result of a sound-effects generation. The route answers with binary audio
- * plus side-channel headers reporting whether it also persisted a browsable copy:
- * `fabFileId` is set only when `saved` is true (see persistGeneratedAudio).
+ * plus side-channel headers reporting whether it also persisted a browsable copy.
+ * `fabFileId`, `fileName`, and `fileUrl` are set only when `saved` is true (see
+ * persistGeneratedAudio). `fileUrl` is the signed download URL the route minted at
+ * upload; callers must use it as-is rather than re-resolving via GET /api/files/:id,
+ * which fails closed until the async moderation scan completes.
  */
 export interface GeneratedSound {
   audio: Buffer;
   contentType: string;
   saved: boolean;
   fabFileId?: string;
+  fileName?: string;
+  fileUrl?: string;
 }
 
 export interface RawProject {
@@ -209,7 +214,7 @@ export class B4mApiClient {
    */
   async generateSoundEffect(args: SoundEffectArgs): Promise<GeneratedSound> {
     try {
-      const response = await this.client.getAxiosInstance().post(
+      const response = await this.client.getAxiosInstance().post<ArrayBuffer>(
         '/api/ai/sound-effects',
         {
           provider: args.provider,
@@ -221,13 +226,16 @@ export class B4mApiClient {
         { responseType: 'arraybuffer' }
       );
 
+      // Node duplicates a repeated header into an array; keep only the scalar string form.
+      const headerString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
       const saved = String(response.headers['x-b4m-audio-saved'] ?? '') === 'true';
-      const fabFileId = response.headers['x-b4m-audio-fab-file-id'];
       return {
         audio: Buffer.from(response.data),
         contentType: String(response.headers['content-type'] ?? 'application/octet-stream'),
         saved,
-        fabFileId: saved && typeof fabFileId === 'string' ? fabFileId : undefined,
+        fabFileId: saved ? headerString(response.headers['x-b4m-audio-fab-file-id']) : undefined,
+        fileName: saved ? headerString(response.headers['x-b4m-audio-file-name']) : undefined,
+        fileUrl: saved ? headerString(response.headers['x-b4m-audio-file-url']) : undefined,
       };
     } catch (error) {
       throw decodeArrayBufferErrorBody(error);
@@ -330,6 +338,16 @@ export function mapApiError(error: unknown, baseURL: string, scope?: string): st
 function decodeArrayBufferErrorBody(error: unknown): unknown {
   if (!isAxiosError(error) || !error.response) return error;
   const { data } = error.response;
+  // A non-Node axios adapter may hand back an already-decoded string body; parse it
+  // directly so the server message survives without going through the byte path.
+  if (typeof data === 'string') {
+    try {
+      error.response.data = JSON.parse(data);
+    } catch {
+      // Non-JSON string body; leave it for mapApiError's fallback.
+    }
+    return error;
+  }
   const bytes = Buffer.isBuffer(data)
     ? data
     : data instanceof ArrayBuffer

--- a/packages/cli/src/mcp/b4mApiClient.ts
+++ b/packages/cli/src/mcp/b4mApiClient.ts
@@ -64,6 +64,27 @@ export interface RawFile {
   [key: string]: unknown;
 }
 
+/** Arguments for POST /api/ai/sound-effects; mirrors `soundEffectsRequestSchema`. */
+export interface SoundEffectArgs {
+  provider: string;
+  text: string;
+  durationSeconds?: number;
+  promptInfluence?: number;
+  format?: string;
+}
+
+/**
+ * Raw result of a sound-effects generation. The route answers with binary audio
+ * plus side-channel headers reporting whether it also persisted a browsable copy:
+ * `fabFileId` is set only when `saved` is true (see persistGeneratedAudio).
+ */
+export interface GeneratedSound {
+  audio: Buffer;
+  contentType: string;
+  saved: boolean;
+  fabFileId?: string;
+}
+
 export interface RawProject {
   id: string;
   name?: string;
@@ -179,6 +200,40 @@ export class B4mApiClient {
     return this.client.get<RawFile>(`/api/files/${encodeURIComponent(fileId)}`);
   }
 
+  /**
+   * Generate a sound effect. Unlike the JSON routes, this one streams raw audio
+   * bytes, so it goes through the axios instance directly to read the response
+   * headers (content type + the persisted-FabFile side channel). On failure the
+   * error body arrives as bytes; {@link decodeArrayBufferErrorBody} restores the
+   * JSON shape so {@link mapApiError} can surface the server's message.
+   */
+  async generateSoundEffect(args: SoundEffectArgs): Promise<GeneratedSound> {
+    try {
+      const response = await this.client.getAxiosInstance().post(
+        '/api/ai/sound-effects',
+        {
+          provider: args.provider,
+          text: args.text,
+          ...(args.durationSeconds !== undefined ? { durationSeconds: args.durationSeconds } : {}),
+          ...(args.promptInfluence !== undefined ? { promptInfluence: args.promptInfluence } : {}),
+          ...(args.format ? { format: args.format } : {}),
+        },
+        { responseType: 'arraybuffer' }
+      );
+
+      const saved = String(response.headers['x-b4m-audio-saved'] ?? '') === 'true';
+      const fabFileId = response.headers['x-b4m-audio-fab-file-id'];
+      return {
+        audio: Buffer.from(response.data),
+        contentType: String(response.headers['content-type'] ?? 'application/octet-stream'),
+        saved,
+        fabFileId: saved && typeof fabFileId === 'string' ? fabFileId : undefined,
+      };
+    } catch (error) {
+      throw decodeArrayBufferErrorBody(error);
+    }
+  }
+
   async listProjects(args: {
     search?: string;
     limit: number;
@@ -264,6 +319,31 @@ export function mapApiError(error: unknown, baseURL: string, scope?: string): st
     return error.message;
   }
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * A request made with `responseType: 'arraybuffer'` also decodes its error body
+ * as bytes, so a JSON `{ error }` payload reaches us as a Buffer that
+ * {@link mapApiError} can't read. Decode it back to a parsed object in place so
+ * the server's message survives; leave a non-JSON body untouched.
+ */
+function decodeArrayBufferErrorBody(error: unknown): unknown {
+  if (!isAxiosError(error) || !error.response) return error;
+  const { data } = error.response;
+  const bytes = Buffer.isBuffer(data)
+    ? data
+    : data instanceof ArrayBuffer
+      ? Buffer.from(data)
+      : ArrayBuffer.isView(data)
+        ? Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+        : undefined;
+  if (!bytes) return error;
+  try {
+    error.response.data = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    // Non-JSON body (e.g. an HTML error page); leave it for mapApiError's fallback.
+  }
+  return error;
 }
 
 /**

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -12,7 +12,7 @@ export interface BuildServerOptions {
 }
 
 /**
- * Build a fully-configured Bike4Mind MCP server: the 7 tools plus the four
+ * Build a fully-configured Bike4Mind MCP server: the tools plus the four
  * resource templates (`b4m://notebook/{id}`, `b4m://file/{id}`,
  * `b4m://project/{id}`, `b4m://artifact/{id}`), backed by a {@link B4mApiClient}
  * bound to the given endpoint and credentials. Tool listing never touches the

--- a/packages/cli/src/mcp/tools.test.ts
+++ b/packages/cli/src/mcp/tools.test.ts
@@ -137,18 +137,25 @@ describe('tool handlers', () => {
     expect(result).toEqual({ results: [{ sessionId: 's1', maxSimilarity: 0.9, matchingMessages: 1 }] });
   });
 
-  it('generate_sound_effect resolves a persisted FabFile to a file reference (signed URL)', async () => {
-    const getFile = vi.fn().mockResolvedValue({ id: 'fab1', fileName: 'sound-effect.mp3', fileUrl: 'https://signed' });
+  it('generate_sound_effect surfaces a persisted FabFile via the forwarded signed URL (no re-fetch)', async () => {
+    const getFile = vi.fn();
     const client = mockClient({
-      generateSoundEffect: vi
-        .fn()
-        .mockResolvedValue({ audio: Buffer.from('abc'), contentType: 'audio/mpeg', saved: true, fabFileId: 'fab1' }),
+      generateSoundEffect: vi.fn().mockResolvedValue({
+        audio: Buffer.from('abc'),
+        contentType: 'audio/mpeg',
+        saved: true,
+        fabFileId: 'fab1',
+        fileName: 'sound-effect.mp3',
+        fileUrl: 'https://signed',
+      }),
       getFile,
     });
 
     const result = await generateSoundEffect(client, { text: 'thunder', provider: 'elevenlabs' });
 
-    expect(getFile).toHaveBeenCalledWith('fab1');
+    // The URL comes off the response header, so no GET /api/files/:id round-trip is
+    // made - that re-fetch would fail closed until the async moderation scan runs.
+    expect(getFile).not.toHaveBeenCalled();
     expect(result).toEqual({
       saved: true,
       provider: 'elevenlabs',
@@ -158,18 +165,34 @@ describe('tool handlers', () => {
     });
   });
 
-  it('generate_sound_effect returns the audio inline (base64) when it was not persisted', async () => {
-    const getFile = vi.fn();
+  it('generate_sound_effect falls back to inline audio when a save yields no usable URL', async () => {
     const client = mockClient({
       generateSoundEffect: vi
         .fn()
-        .mockResolvedValue({ audio: Buffer.from('abc'), contentType: 'audio/mpeg', saved: false }),
-      getFile,
+        .mockResolvedValue({ audio: Buffer.from('abc'), contentType: 'audio/mpeg', saved: true, fabFileId: 'fab1' }),
     });
 
     const result = await generateSoundEffect(client, { text: 'thunder', provider: 'elevenlabs' });
 
-    expect(getFile).not.toHaveBeenCalled();
+    // Persisted but no fileUrl: hand back the bytes the caller was already billed for.
+    expect(result).toEqual({
+      saved: false,
+      provider: 'elevenlabs',
+      contentType: 'audio/mpeg',
+      byteLength: 3,
+      audioBase64: Buffer.from('abc').toString('base64'),
+    });
+  });
+
+  it('generate_sound_effect returns the audio inline (base64) when it was not persisted', async () => {
+    const client = mockClient({
+      generateSoundEffect: vi
+        .fn()
+        .mockResolvedValue({ audio: Buffer.from('abc'), contentType: 'audio/mpeg', saved: false }),
+    });
+
+    const result = await generateSoundEffect(client, { text: 'thunder', provider: 'elevenlabs' });
+
     expect(result).toEqual({
       saved: false,
       provider: 'elevenlabs',
@@ -227,10 +250,14 @@ describe('registerTools', () => {
   it('generate_sound_effect surfaces a persisted file as a JSON result with the signed URL', async () => {
     const tools = collectTools(
       mockClient({
-        generateSoundEffect: vi
-          .fn()
-          .mockResolvedValue({ audio: Buffer.from('abc'), contentType: 'audio/mpeg', saved: true, fabFileId: 'fab1' }),
-        getFile: vi.fn().mockResolvedValue({ id: 'fab1', fileUrl: 'https://signed' }),
+        generateSoundEffect: vi.fn().mockResolvedValue({
+          audio: Buffer.from('abc'),
+          contentType: 'audio/mpeg',
+          saved: true,
+          fabFileId: 'fab1',
+          fileName: 'sound-effect.mp3',
+          fileUrl: 'https://signed',
+        }),
       })
     );
 

--- a/packages/cli/src/mcp/tools.test.ts
+++ b/packages/cli/src/mcp/tools.test.ts
@@ -11,13 +11,14 @@ import {
   createNotebook,
   sendMessage,
   searchKnowledgeBase,
+  generateSoundEffect,
 } from './tools';
 
 const mockClient = (overrides: Partial<Record<keyof B4mApiClient, unknown>>): B4mApiClient =>
   ({ baseURL: 'http://localhost:3000', ...overrides }) as unknown as B4mApiClient;
 
 describe('TOOL_NAMES', () => {
-  it('exposes exactly the seven v1 tools', () => {
+  it('exposes exactly the registered tools', () => {
     expect(TOOL_NAMES).toEqual([
       'list_notebooks',
       'get_notebook',
@@ -26,6 +27,7 @@ describe('TOOL_NAMES', () => {
       'search_knowledge_base',
       'list_files',
       'get_file',
+      'generate_sound_effect',
     ]);
   });
 });
@@ -134,6 +136,48 @@ describe('tool handlers', () => {
 
     expect(result).toEqual({ results: [{ sessionId: 's1', maxSimilarity: 0.9, matchingMessages: 1 }] });
   });
+
+  it('generate_sound_effect resolves a persisted FabFile to a file reference (signed URL)', async () => {
+    const getFile = vi.fn().mockResolvedValue({ id: 'fab1', fileName: 'sound-effect.mp3', fileUrl: 'https://signed' });
+    const client = mockClient({
+      generateSoundEffect: vi
+        .fn()
+        .mockResolvedValue({ audio: Buffer.from('abc'), contentType: 'audio/mpeg', saved: true, fabFileId: 'fab1' }),
+      getFile,
+    });
+
+    const result = await generateSoundEffect(client, { text: 'thunder', provider: 'elevenlabs' });
+
+    expect(getFile).toHaveBeenCalledWith('fab1');
+    expect(result).toEqual({
+      saved: true,
+      provider: 'elevenlabs',
+      contentType: 'audio/mpeg',
+      byteLength: 3,
+      file: { id: 'fab1', fileName: 'sound-effect.mp3', fileUrl: 'https://signed' },
+    });
+  });
+
+  it('generate_sound_effect returns the audio inline (base64) when it was not persisted', async () => {
+    const getFile = vi.fn();
+    const client = mockClient({
+      generateSoundEffect: vi
+        .fn()
+        .mockResolvedValue({ audio: Buffer.from('abc'), contentType: 'audio/mpeg', saved: false }),
+      getFile,
+    });
+
+    const result = await generateSoundEffect(client, { text: 'thunder', provider: 'elevenlabs' });
+
+    expect(getFile).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      saved: false,
+      provider: 'elevenlabs',
+      contentType: 'audio/mpeg',
+      byteLength: 3,
+      audioBase64: Buffer.from('abc').toString('base64'),
+    });
+  });
 });
 
 describe('registerTools', () => {
@@ -148,7 +192,7 @@ describe('registerTools', () => {
     return tools;
   };
 
-  it('registers all seven tools', () => {
+  it('registers every tool in TOOL_NAMES', () => {
     const tools = collectTools(mockClient({}));
     expect([...tools.keys()]).toEqual(TOOL_NAMES);
   });
@@ -177,6 +221,68 @@ describe('registerTools', () => {
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: "API key forbidden: check the key's scopes and account access (recommended scope: files:read)",
+    });
+  });
+
+  it('generate_sound_effect surfaces a persisted file as a JSON result with the signed URL', async () => {
+    const tools = collectTools(
+      mockClient({
+        generateSoundEffect: vi
+          .fn()
+          .mockResolvedValue({ audio: Buffer.from('abc'), contentType: 'audio/mpeg', saved: true, fabFileId: 'fab1' }),
+        getFile: vi.fn().mockResolvedValue({ id: 'fab1', fileUrl: 'https://signed' }),
+      })
+    );
+
+    const result = await tools.get('generate_sound_effect')!({ text: 'rain', provider: 'elevenlabs' });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({ saved: true, file: { id: 'fab1', fileUrl: 'https://signed' } });
+    expect(result.content.some(c => c.type === 'audio')).toBe(false);
+  });
+
+  it('generate_sound_effect returns an audio content block when the bytes were not persisted', async () => {
+    const tools = collectTools(
+      mockClient({
+        generateSoundEffect: vi
+          .fn()
+          .mockResolvedValue({ audio: Buffer.from('abc'), contentType: 'audio/mpeg', saved: false }),
+      })
+    );
+
+    const result = await tools.get('generate_sound_effect')!({ text: 'rain', provider: 'elevenlabs' });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContainEqual({
+      type: 'audio',
+      data: Buffer.from('abc').toString('base64'),
+      mimeType: 'audio/mpeg',
+    });
+    // The base64 payload stays out of structuredContent to avoid duplicating it.
+    expect(result.structuredContent).toEqual({
+      saved: false,
+      provider: 'elevenlabs',
+      contentType: 'audio/mpeg',
+      byteLength: 3,
+    });
+  });
+
+  it('generate_sound_effect maps an API failure to a structured isError naming ai:generate', async () => {
+    const forbidden = new AxiosError('forbidden', undefined, {} as InternalAxiosRequestConfig, {}, {
+      status: 403,
+      statusText: '',
+      data: {},
+      headers: {},
+      config: {} as InternalAxiosRequestConfig,
+    } as AxiosResponse);
+    const tools = collectTools(mockClient({ generateSoundEffect: vi.fn().mockRejectedValue(forbidden) }));
+
+    const result = await tools.get('generate_sound_effect')!({ text: 'rain', provider: 'elevenlabs' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({
+      type: 'text',
+      text: "API key forbidden: check the key's scopes and account access (recommended scope: ai:generate)",
     });
   });
 });

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { B4mApiClient, mapApiError, type RawFile, type RawNotebook } from './b4mApiClient.js';
+import { B4mApiClient, mapApiError, type RawNotebook } from './b4mApiClient.js';
 
 /** Static metadata for each tool, used for registration and the `mcp serve` help text. */
 export interface ToolMeta {
@@ -189,26 +189,35 @@ export async function getFile(client: B4mApiClient, args: { fileId: string }) {
 
 /**
  * Outcome of a sound-effects generation, in the two shapes the route can yield:
- * a persisted FabFile (resolved to metadata + a signed download URL, like
- * {@link getFile}) when the caller keeps generated audio, or the raw bytes when
- * it does not - so a caller who opted out of persistence still receives what it
+ * a persisted FabFile (id + name + a working signed download URL) when the caller
+ * keeps generated audio, or the raw bytes when it does not - so a caller who opted
+ * out of persistence, or whose save produced no usable URL, still receives what it
  * was billed for.
  */
 export type SoundEffectOutcome =
-  | { saved: true; provider: string; contentType: string; byteLength: number; file: RawFile }
+  | {
+      saved: true;
+      provider: string;
+      contentType: string;
+      byteLength: number;
+      file: { id: string; fileName?: string; fileUrl: string };
+    }
   | { saved: false; provider: string; contentType: string; byteLength: number; audioBase64: string };
 
 export async function generateSoundEffect(
   client: B4mApiClient,
   args: { text: string; provider: string; durationSeconds?: number; promptInfluence?: number; format?: string }
 ): Promise<SoundEffectOutcome> {
-  const { audio, contentType, saved, fabFileId } = await client.generateSoundEffect(args);
+  const { audio, contentType, saved, fabFileId, fileName, fileUrl } = await client.generateSoundEffect(args);
   const base = { provider: args.provider, contentType, byteLength: audio.length };
 
-  // Prefer the persisted-file reference (signed URL) over inlining bytes, mirroring
-  // get_file; the route already uploaded it, so we only resolve the download URL.
-  if (saved && fabFileId) {
-    return { ...base, saved: true, file: await client.getFile(fabFileId) };
+  // Prefer the persisted-file reference over inlining bytes (mirrors get_file). The
+  // route forwards the signed URL it minted at upload, so we use it directly rather
+  // than re-resolving via getFile, which fails closed on the just-created file until
+  // the async moderation scan runs. If persistence yielded no usable URL, fall back
+  // to inlining the bytes the caller was already billed for, so audio is never lost.
+  if (saved && fabFileId && fileUrl) {
+    return { ...base, saved: true, file: { id: fabFileId, fileName, fileUrl } };
   }
   return { ...base, saved: false, audioBase64: audio.toString('base64') };
 }

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { B4mApiClient, mapApiError, type RawNotebook } from './b4mApiClient.js';
+import { B4mApiClient, mapApiError, type RawFile, type RawNotebook } from './b4mApiClient.js';
 
 /** Static metadata for each tool, used for registration and the `mcp serve` help text. */
 export interface ToolMeta {
@@ -51,6 +51,13 @@ export const TOOL_META: ToolMeta[] = [
     description: "Fetch a file's metadata and a signed download URL.",
     scope: 'files:read',
   },
+  {
+    name: 'generate_sound_effect',
+    title: 'Generate sound effect',
+    description:
+      'Generate a sound effect from a text description. Returns the saved audio file (with a signed download URL) when the caller keeps generated audio, otherwise the audio inline.',
+    scope: 'ai:generate',
+  },
 ];
 
 export const TOOL_NAMES = TOOL_META.map(t => t.name);
@@ -90,6 +97,26 @@ const listFilesShape = {
 
 const getFileShape = {
   fileId: z.string().describe('The file id'),
+};
+
+// Bounds mirror `soundEffectsRequestSchema` (@bike4mind/common) and the ElevenLabs
+// sound-generation limits; keep in sync with the route's parse.
+const generateSoundEffectShape = {
+  text: z.string().min(1).max(1000).describe('Text description of the sound effect to generate'),
+  provider: z.enum(['elevenlabs']).default('elevenlabs').describe('Sound-generation provider'),
+  durationSeconds: z
+    .number()
+    .min(0.5)
+    .max(30)
+    .optional()
+    .describe('Length of the sound in seconds (0.5-30); omit to let the provider choose'),
+  promptInfluence: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe('How strictly to follow the prompt (0 = loose, 1 = strict)'),
+  format: z.string().optional().describe('Provider output encoding token, e.g. mp3_44100_128'),
 };
 
 function notebookSummary(n: RawNotebook) {
@@ -160,6 +187,32 @@ export async function getFile(client: B4mApiClient, args: { fileId: string }) {
   return client.getFile(args.fileId);
 }
 
+/**
+ * Outcome of a sound-effects generation, in the two shapes the route can yield:
+ * a persisted FabFile (resolved to metadata + a signed download URL, like
+ * {@link getFile}) when the caller keeps generated audio, or the raw bytes when
+ * it does not - so a caller who opted out of persistence still receives what it
+ * was billed for.
+ */
+export type SoundEffectOutcome =
+  | { saved: true; provider: string; contentType: string; byteLength: number; file: RawFile }
+  | { saved: false; provider: string; contentType: string; byteLength: number; audioBase64: string };
+
+export async function generateSoundEffect(
+  client: B4mApiClient,
+  args: { text: string; provider: string; durationSeconds?: number; promptInfluence?: number; format?: string }
+): Promise<SoundEffectOutcome> {
+  const { audio, contentType, saved, fabFileId } = await client.generateSoundEffect(args);
+  const base = { provider: args.provider, contentType, byteLength: audio.length };
+
+  // Prefer the persisted-file reference (signed URL) over inlining bytes, mirroring
+  // get_file; the route already uploaded it, so we only resolve the download URL.
+  if (saved && fabFileId) {
+    return { ...base, saved: true, file: await client.getFile(fabFileId) };
+  }
+  return { ...base, saved: false, audioBase64: audio.toString('base64') };
+}
+
 function toResult(value: unknown): CallToolResult {
   const structuredContent =
     value && typeof value === 'object' && !Array.isArray(value)
@@ -176,7 +229,34 @@ function errorResult(message: string): CallToolResult {
 }
 
 /**
- * Register the seven Bike4Mind tools on `server`. Each handler is wrapped so an
+ * Render a {@link SoundEffectOutcome} as an MCP result. A persisted file becomes
+ * a JSON metadata result (carrying the signed URL), exactly like get_file. When
+ * the audio was not persisted, it is returned inline as an `audio` content block
+ * so the bytes are not lost; the base64 is kept out of structuredContent to avoid
+ * duplicating a potentially large payload.
+ */
+function soundEffectResult(outcome: SoundEffectOutcome): CallToolResult {
+  if (outcome.saved) {
+    return toResult({
+      saved: true,
+      provider: outcome.provider,
+      contentType: outcome.contentType,
+      byteLength: outcome.byteLength,
+      file: outcome.file,
+    });
+  }
+  const { audioBase64, ...meta } = outcome;
+  return {
+    content: [
+      { type: 'text', text: JSON.stringify(meta, null, 2) },
+      { type: 'audio', data: audioBase64, mimeType: outcome.contentType },
+    ],
+    structuredContent: meta,
+  };
+}
+
+/**
+ * Register the Bike4Mind MCP tools on `server`. Each handler is wrapped so an
  * API failure becomes a structured `isError` result carrying a friendly message
  * (see {@link mapApiError}) rather than throwing across the transport.
  */
@@ -244,5 +324,21 @@ export function registerTools(server: McpServer, client: B4mApiClient): void {
     'get_file',
     { title: meta('get_file').title, description: meta('get_file').description, inputSchema: getFileShape },
     args => run('files:read', () => getFile(client, args))
+  );
+
+  server.registerTool(
+    'generate_sound_effect',
+    {
+      title: meta('generate_sound_effect').title,
+      description: meta('generate_sound_effect').description,
+      inputSchema: generateSoundEffectShape,
+    },
+    async args => {
+      try {
+        return soundEffectResult(await generateSoundEffect(client, args));
+      } catch (err) {
+        return errorResult(mapApiError(err, baseURL, 'ai:generate'));
+      }
+    }
   );
 }


### PR DESCRIPTION
## Description

Adds a `generate_sound_effect` MCP tool to `b4m mcp serve`, backed by `POST /api/ai/sound-effects` (provider-agnostic sound generation, ElevenLabs today). This closes a gap from the MCP capability-expansion epic: the sound-effects route shipped after the original tool set was defined, so it was authorized but unexposed. Same `ai:generate` scope as image generation.

**How the binary response is surfaced.** The route already persists generated audio as a browsable FabFile and now forwards its id, name, and signed download URL via `X-B4M-Audio-*` response headers, so the tool does not re-upload anything or re-resolve the URL:

- **Persisted (default path):** return the forwarded FabFile reference (id, name, signed URL) as JSON, so a potentially large payload stays out of the JSON-RPC response. The URL rides the header because re-resolving it via `get_file` would fail closed until the async moderation scan marks the file `clean` (`isImageServeable` gates every mime type).
- **Not persisted (caller's `saveGeneratedAudio` off, over storage quota, or no usable URL):** fall back to an inline MCP `audio` content block so the paid-for bytes are never silently lost. The base64 is kept out of `structuredContent` to avoid duplicating a large payload.

A missing provider key returns `503` (not `401`), so a caller with a valid `ai:generate` key but no ElevenLabs key configured gets the real "No elevenlabs API key configured" message instead of being told to re-authenticate.

The route reserves credits before generating and settles/refunds after, so a failed generation never leaves a stray charge; no special handling is needed on the MCP side beyond normal error mapping.

Closes #919

## Changes

- `packages/cli/src/mcp/b4mApiClient.ts`: new `generateSoundEffect()` that goes through the axios instance directly (to read response headers and request `arraybuffer`), reads the forwarded `X-B4M-Audio-*` headers (saved / id / name / signed URL), plus `decodeArrayBufferErrorBody()` so a byte- or string-encoded JSON error body still yields a readable server message via `mapApiError`.
- `packages/cli/src/mcp/tools.ts`: `TOOL_META` entry, input shape (bounds mirror `soundEffectsRequestSchema`), the handler, a `soundEffectResult` mapper (forwarded file reference vs inline audio), and registration.
- `apps/client/pages/api/ai/sound-effects.ts`: forward the persisted file's signed URL + name as response headers; return `503` for a missing provider key.
- Tests: persisted -> forwarded-URL file reference, save-without-URL -> inline fallback, not-persisted -> audio content block, API failure -> `ai:generate` scope, header parsing/forwarding (route + CLI), and arraybuffer/string error decode.
- Docs: `BIKE4MIND_CLI.md` tool table and `packages/cli/README.md` tool list updated (7 -> 8 tools).

## Guide for Testers

This is a CLI/MCP-server change with no web UI. Verify via the MCP server the CLI exposes.

1. From the repo root, build the CLI: `pnpm --filter @bike4mind/cli build`.
2. Ensure you have an instance API key with the `ai:generate` scope. Export it: `export B4M_API_KEY=<your-key>` and set `export B4M_API_URL=https://app.staging.bike4mind.com` (or your backend).
3. List the advertised tools by connecting an MCP client to the stdio server. With the MCP Inspector: `npx @modelcontextprotocol/inspector pnpm --filter @bike4mind/cli exec b4m mcp serve` (or add `b4m mcp serve` to Claude Desktop's MCP config). Expected: on the `tools/list` handshake, eight tools are listed, including `generate_sound_effect` with scope `ai:generate`. (There is no `--list-tools` flag; the tool list comes from the MCP handshake.)
4. Call `generate_sound_effect` with `text` = `a heavy wooden door slamming shut`, `durationSeconds` = `3`. Expected: a JSON result with `saved: true`, `provider: "elevenlabs"`, `contentType` (e.g. `audio/mpeg`), `byteLength`, and a `file` object containing `id`, `fileName`, and a signed download URL (`fileUrl`).
5. Open the returned signed URL in a browser. Expected: the generated audio downloads/plays. (It should work immediately, on the first response, without retrying.)
6. In the Bike4Mind web app, go to Files. Expected: a new browsable audio FabFile named like `sound-effect-a-heavy-wooden-door-slamming-shut-<timestamp>.mp3` is present.
7. Negative case (missing scope): repeat step 4 with an API key that lacks `ai:generate`. Expected: an `isError` result reading `API key forbidden: check the key's scopes and account access (recommended scope: ai:generate)`.
8. Inline-audio fallback (optional): in the web app disable the "save generated audio" preference, then repeat step 4. Expected: the result carries an inline `audio` content block (base64) with the correct `mimeType` instead of a `file` reference; `saved` is `false`.

### Regression Checks

1. Confirm the other seven tools still register and respond: call `list_notebooks` and `get_file` and verify they return as before (this PR only adds a tool and shares the existing error-mapping wrapper).

### What NOT to test

- No web UI, routing, or styling changes.
- No billing-logic changes; credit reservation/settlement lives entirely in the pre-existing route and is unchanged by this PR.

## Additional Information

Follow-ons noted in the issue (`generate_video`, `text_to_speech`, and a shared "media generation" registration grouping once `generate_image` also lands) are intentionally out of scope here.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
