### PR TITLE
fix(tags): recompute file-tag counts instead of a drifting counter

### DIFF
--- a/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.test.tsx
@@ -127,6 +127,33 @@ describe('SendToDataLakeModal', () => {
     await waitFor(() => expect(createFabFileOnServerWithUpload).toHaveBeenCalledTimes(2));
   });
 
+  // The send writes the lake's tags onto the new file, and the tag list's fileCount is derived
+  // from the files carrying each tag - so without this the sidebar badge misses the new file.
+  it('invalidates the tag surfaces after tagging the uploaded file', async () => {
+    createFabFileOnServerWithUpload.mockResolvedValue({ id: 'file-1' });
+    updateFabFileOnServer.mockResolvedValue({});
+
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CssVarsProvider theme={appTheme}>
+          <SendToDataLakeModal />
+        </CssVarsProvider>
+      </QueryClientProvider>
+    );
+
+    const user = userEvent.setup({ delay: null });
+    await user.click(screen.getByTestId('send-to-datalake-option-lake-1'));
+    screen.getByTestId('send-to-datalake-confirm-btn').click();
+
+    await waitFor(() => expect(updateFabFileOnServer).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      const keys = invalidate.mock.calls.map(call => JSON.stringify((call[0] as { queryKey: unknown[] })?.queryKey));
+      expect(keys).toContain(JSON.stringify(['file-tags']));
+    });
+  });
+
   it('excludes lakes the caller cannot manage (read-only public lakes are not send targets)', () => {
     render(
       <TestWrapper>

--- a/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.tsx
+++ b/apps/client/app/components/DataLakeWizard/SendToDataLakeModal.tsx
@@ -79,6 +79,8 @@ export default function SendToDataLakeModal() {
       });
       queryClient.invalidateQueries({ queryKey: ['dataLakeFiles', lake.id] });
       queryClient.invalidateQueries({ queryKey: ['data-lakes'] });
+      // The tag write above lands on the file, so every per-tag file count is now stale.
+      queryClient.invalidateQueries({ queryKey: ['file-tags'] });
       toast.success(`Saved ${sourceLabel} to “${lake.name}”. It'll be searchable once processing finishes.`);
       setSelectedId(null);
       closeStore();

--- a/apps/client/app/hooks/data/dataLakeWizard.test.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.test.ts
@@ -712,6 +712,9 @@ describe('useRemoveFileFromDataLake cache invalidation', () => {
     // a fully-specified key would refresh only one of the two surfaces.
     expect(keys).toContain(JSON.stringify(['dataLakeTagCounts']));
     expect(keys).toContain(JSON.stringify(['dataLakeArticles']));
-    expect(keys).toContain(JSON.stringify(['file-tags', 'counts']));
+    // The bare file-tags prefix, not ['file-tags','counts']: the tag list itself now carries a
+    // fileCount derived from the files holding each tag, and invalidating only the longer key
+    // leaves that list stale. Prefix matching covers the counts endpoint too.
+    expect(keys).toContain(JSON.stringify(['file-tags']));
   });
 });

--- a/apps/client/app/hooks/data/dataLakeWizard.ts
+++ b/apps/client/app/hooks/data/dataLakeWizard.ts
@@ -940,7 +940,9 @@ export function useRemoveFileFromDataLake(dataLakeId: string | null) {
       // source discriminator, and a fully-specified key would refresh only one surface.
       queryClient.invalidateQueries({ queryKey: ['dataLakeTagCounts'] });
       queryClient.invalidateQueries({ queryKey: ['dataLakeArticles'] });
-      queryClient.invalidateQueries({ queryKey: ['file-tags', 'counts'] });
+      // Bare prefix: the tag list carries a fileCount derived from the files that hold each tag,
+      // so dropping tags here staled the list too, not only the counts endpoint.
+      queryClient.invalidateQueries({ queryKey: ['file-tags'] });
     },
     onError: (error: Error) => {
       toast.error(error.message || 'Failed to remove file from data lake');

--- a/apps/client/app/hooks/data/fabFiles.test.tsx
+++ b/apps/client/app/hooks/data/fabFiles.test.tsx
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
-import { useGetFabFilesBySessionId, useGetFabFilesByQuestId } from './fabFiles';
+import { act } from '@testing-library/react';
+import { useGetFabFilesBySessionId, useGetFabFilesByQuestId, useUpdateFabFile } from './fabFiles';
 
 // Mock the axios-backed api context - we only care that the GET is (or isn't) fired.
 const apiGet = vi.fn();
@@ -10,6 +11,11 @@ vi.mock('@client/app/contexts/ApiContext', () => ({
   api: {
     get: (...args: unknown[]) => apiGet(...args),
   },
+}));
+
+const updateFabFileOnServer = vi.fn();
+vi.mock('@client/app/utils/filesAPICalls', () => ({
+  updateFabFileOnServer: (...args: unknown[]) => updateFabFileOnServer(...args),
 }));
 
 const makeWrapper = () => {
@@ -82,5 +88,33 @@ describe('useGetFabFilesByQuestId', () => {
   it('respects the caller-supplied enabled=false', () => {
     renderQuest('507f1f77bcf86cd799439012', false);
     expect(apiGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('useUpdateFabFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // PUT /api/files/[id] replaces the whole tags array, and the tag list's fileCount is derived
+  // from the files that carry each tag - so this route going through without refreshing the tag
+  // surfaces leaves every per-tag count stale. The bare prefix also covers ['file-tags','counts'].
+  it('invalidates the tag surfaces, whose counts this route can change', async () => {
+    updateFabFileOnServer.mockResolvedValue({ id: 'f1' });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    Wrapper.displayName = 'TestQueryClientWrapper';
+
+    const { result } = renderHook(() => useUpdateFabFile(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'f1', tags: [{ name: 'invoices', strength: 1 }] });
+    });
+
+    const keys = invalidate.mock.calls.map(call => JSON.stringify((call[0] as { queryKey: unknown[] })?.queryKey));
+    expect(keys).toContain(JSON.stringify(['file-tags']));
   });
 });

--- a/apps/client/app/hooks/data/fabFiles.test.tsx
+++ b/apps/client/app/hooks/data/fabFiles.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
-import { act } from '@testing-library/react';
 import { useGetFabFilesBySessionId, useGetFabFilesByQuestId, useUpdateFabFile } from './fabFiles';
 
 // Mock the axios-backed api context - we only care that the GET is (or isn't) fired.

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -141,6 +141,10 @@ export function useCreateFabFileWithUpload(options?: {
       });
 
       queryClient.invalidateQueries({ queryKey: ['fabFiles'], exact: false });
+      // A created file can carry tags, and per-tag counts are derived from the files holding each
+      // tag. This hook has no callers today; the invalidation is here so wiring it up later cannot
+      // silently reintroduce the stale-count bug the other write paths were fixed for.
+      queryClient.invalidateQueries({ queryKey: ['file-tags'] });
       options?.onSuccess?.(newFabFile);
       return newFabFile;
     } catch (err) {

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -583,6 +583,9 @@ export function useUpdateFabFile(callback?: { onSuccess?: () => void }) {
       queryClient.invalidateQueries({ queryKey: ['fabFiles'], exact: false });
       // Invalidate and force refetch system prompt files (they have long staleTime)
       queryClient.invalidateQueries({ queryKey: ['system-prompt-files'], exact: false, refetchType: 'all' });
+      // This route replaces the whole tags array, so any tag surface showing a per-tag file count
+      // is stale afterwards. The bare prefix also covers ['file-tags','counts'].
+      queryClient.invalidateQueries({ queryKey: ['file-tags'] });
       callback?.onSuccess?.();
     },
   });

--- a/apps/client/app/hooks/data/tag.test.tsx
+++ b/apps/client/app/hooks/data/tag.test.tsx
@@ -5,70 +5,98 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { IFileTag, ITag } from '@bike4mind/common';
 
 const mockPut = vi.fn();
+const mockPost = vi.fn();
 
 vi.mock('@client/app/contexts/ApiContext', () => ({
-  api: { put: (...args: unknown[]) => mockPut(...args) },
+  api: {
+    put: (...args: unknown[]) => mockPut(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
 }));
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 
-import { useUpdateFileTag } from './tag';
+import { useCreateFileTag, useUpdateFileTag } from './tag';
 
-const CACHED_TAG = { id: 'tag-1', name: 'invoices', fileCount: 7 } as IFileTag;
+const CACHED_TAG = { id: 'tag-1', name: 'invoices', color: 'blue', fileCount: 7 } as IFileTag;
 
-describe('useUpdateFileTag', () => {
+describe('file tag mutations', () => {
   let queryClient: QueryClient;
+  let invalidateSpy: ReturnType<typeof vi.spyOn>;
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 
   const cachedTags = () => queryClient.getQueryData<IFileTag[]>(['file-tags']) ?? [];
+  const invalidatedKeys = () => invalidateSpy.mock.calls.map(([arg]) => (arg as { queryKey: unknown[] }).queryKey);
 
   beforeEach(() => {
     mockPut.mockReset();
+    mockPost.mockReset();
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     queryClient.setQueryData(['file-tags'], [CACHED_TAG]);
+    invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
   });
 
-  // PUT /api/files/tags/[id] returns only the fields tagUpdateSchema accepts, so replacing the
-  // cached entry wholesale drops the recomputed fileCount and the sidebar badge reads (0).
-  it('keeps the recomputed fileCount when the response omits it', async () => {
-    mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'receipts', updatedAt: new Date() } });
+  describe('useUpdateFileTag', () => {
+    const rename = async () => {
+      const { result } = renderHook(() => useUpdateFileTag(), { wrapper });
+      await act(async () => {
+        await result.current.mutateAsync({ id: 'tag-1', name: 'receipts' } as ITag);
+      });
+    };
 
-    const { result } = renderHook(() => useUpdateFileTag(), { wrapper });
-    await act(async () => {
-      await result.current.mutateAsync({ id: 'tag-1', name: 'receipts' } as ITag);
+    it('merges the response instead of replacing the cached row', async () => {
+      mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'receipts' } });
+
+      await rename();
+
+      await waitFor(() => expect(cachedTags()[0].name).toBe('receipts'));
+      // tagUpdateSchema echoes back only what it accepted, so a wholesale swap would drop these.
+      expect(cachedTags()[0].color).toBe('blue');
     });
 
-    await waitFor(() => expect(cachedTags()[0].name).toBe('receipts'));
-    expect(cachedTags()[0].fileCount).toBe(7);
+    // A rename does not retag the files, so the cached count is optimistic at best and flatly
+    // wrong at worst. Invalidating the bare prefix is what makes the server-derived count win;
+    // invalidating only ['file-tags','counts'] leaves the longer key matched and the list stale.
+    it('invalidates the tag list so the derived count is refetched, not trusted', async () => {
+      mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'receipts' } });
+
+      await rename();
+
+      expect(invalidatedKeys()).toContainEqual(['file-tags']);
+    });
+
+    it('leaves other cached tags untouched', async () => {
+      const other = { id: 'tag-2', name: 'receipts', fileCount: 2 } as IFileTag;
+      queryClient.setQueryData(['file-tags'], [CACHED_TAG, other]);
+      mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'renamed' } });
+
+      await rename();
+
+      await waitFor(() => expect(cachedTags()[0].name).toBe('renamed'));
+      expect(cachedTags()[1]).toEqual(other);
+    });
   });
 
-  it('lets the response win for fields it does return', async () => {
-    mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'receipts', fileCount: 3 } });
+  describe('useCreateFileTag', () => {
+    // create seeds fileCount at 0, which is wrong whenever files already carry the name - tag
+    // documents get auto-created by name elsewhere, and deleting one never untags the files.
+    it('invalidates the tag list rather than trusting the seeded zero', async () => {
+      mockPost.mockResolvedValueOnce({ data: { id: 'tag-9', name: 'archive', fileCount: 0 } });
 
-    const { result } = renderHook(() => useUpdateFileTag(), { wrapper });
-    await act(async () => {
-      await result.current.mutateAsync({ id: 'tag-1', name: 'receipts' } as ITag);
+      const { result } = renderHook(() => useCreateFileTag(), { wrapper });
+      await act(async () => {
+        await result.current.mutateAsync({ name: 'archive' } as Omit<
+          ITag,
+          'id' | 'userId' | 'createdAt' | 'updatedAt' | 'type'
+        >);
+      });
+
+      expect(invalidatedKeys()).toContainEqual(['file-tags']);
     });
-
-    await waitFor(() => expect(cachedTags()[0].fileCount).toBe(3));
-  });
-
-  it('leaves other cached tags untouched', async () => {
-    const other = { id: 'tag-2', name: 'receipts', fileCount: 2 } as IFileTag;
-    queryClient.setQueryData(['file-tags'], [CACHED_TAG, other]);
-    mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'renamed' } });
-
-    const { result } = renderHook(() => useUpdateFileTag(), { wrapper });
-    await act(async () => {
-      await result.current.mutateAsync({ id: 'tag-1', name: 'renamed' } as ITag);
-    });
-
-    await waitFor(() => expect(cachedTags()[0].name).toBe('renamed'));
-    expect(cachedTags()[1]).toEqual(other);
   });
 });

--- a/apps/client/app/hooks/data/tag.test.tsx
+++ b/apps/client/app/hooks/data/tag.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { IFileTag, ITag } from '@bike4mind/common';
+
+const mockPut = vi.fn();
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { put: (...args: unknown[]) => mockPut(...args) },
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+import { useUpdateFileTag } from './tag';
+
+const CACHED_TAG = { id: 'tag-1', name: 'invoices', fileCount: 7 } as IFileTag;
+
+describe('useUpdateFileTag', () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  const cachedTags = () => queryClient.getQueryData<IFileTag[]>(['file-tags']) ?? [];
+
+  beforeEach(() => {
+    mockPut.mockReset();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['file-tags'], [CACHED_TAG]);
+  });
+
+  // PUT /api/files/tags/[id] returns only the fields tagUpdateSchema accepts, so replacing the
+  // cached entry wholesale drops the recomputed fileCount and the sidebar badge reads (0).
+  it('keeps the recomputed fileCount when the response omits it', async () => {
+    mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'receipts', updatedAt: new Date() } });
+
+    const { result } = renderHook(() => useUpdateFileTag(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'tag-1', name: 'receipts' } as ITag);
+    });
+
+    await waitFor(() => expect(cachedTags()[0].name).toBe('receipts'));
+    expect(cachedTags()[0].fileCount).toBe(7);
+  });
+
+  it('lets the response win for fields it does return', async () => {
+    mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'receipts', fileCount: 3 } });
+
+    const { result } = renderHook(() => useUpdateFileTag(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'tag-1', name: 'receipts' } as ITag);
+    });
+
+    await waitFor(() => expect(cachedTags()[0].fileCount).toBe(3));
+  });
+
+  it('leaves other cached tags untouched', async () => {
+    const other = { id: 'tag-2', name: 'receipts', fileCount: 2 } as IFileTag;
+    queryClient.setQueryData(['file-tags'], [CACHED_TAG, other]);
+    mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'renamed' } });
+
+    const { result } = renderHook(() => useUpdateFileTag(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'tag-1', name: 'renamed' } as ITag);
+    });
+
+    await waitFor(() => expect(cachedTags()[0].name).toBe('renamed'));
+    expect(cachedTags()[1]).toEqual(other);
+  });
+});

--- a/apps/client/app/hooks/data/tag.ts
+++ b/apps/client/app/hooks/data/tag.ts
@@ -35,7 +35,10 @@ export const useCreateFileTag = () => {
     },
     onSuccess: data => {
       queryClient.setQueryData(['file-tags'], (prev: IFileTag[]) => [...prev, data]);
-      queryClient.invalidateQueries({ queryKey: ['file-tags', 'counts'] });
+      // The create response carries the seeded fileCount of 0, which is wrong the moment the name
+      // matches files that already exist - tag documents are auto-created by name elsewhere, and
+      // deleting one never untags the files. Invalidate the list, not just the counts endpoint.
+      queryClient.invalidateQueries({ queryKey: ['file-tags'] });
       toast.success('Tag created successfully');
     },
     onError: () => {
@@ -53,13 +56,16 @@ export const useUpdateFileTag = () => {
       return result.data;
     },
     onSuccess: data => {
-      // Merge rather than replace: PUT /api/files/tags/[id] echoes back only the fields it
-      // accepted, so a wholesale swap drops fileCount and the sidebar badge reads (0) until the
-      // next refetch.
+      // Merge rather than replace so the edited fields show immediately: PUT /api/files/tags/[id]
+      // echoes back only what tagUpdateSchema accepted, and a wholesale swap would blank the rest
+      // of the row. This is optimistic only - fileCount is derived from the files that carry the
+      // tag, and a rename does not retag them, so the invalidation below is what settles it.
       queryClient.setQueryData(['file-tags'], (prev: IFileTag[]) =>
         prev.map(t => (t.id === data.id ? { ...t, ...data } : t))
       );
-      queryClient.invalidateQueries({ queryKey: ['file-tags', 'counts'] });
+      // The bare prefix: invalidating ['file-tags','counts'] alone leaves the longer key matched
+      // and the list itself - which is what carries fileCount - stale.
+      queryClient.invalidateQueries({ queryKey: ['file-tags'] });
       toast.success('Tag updated successfully');
     },
     onError: () => {

--- a/apps/client/app/hooks/data/tag.ts
+++ b/apps/client/app/hooks/data/tag.ts
@@ -53,7 +53,12 @@ export const useUpdateFileTag = () => {
       return result.data;
     },
     onSuccess: data => {
-      queryClient.setQueryData(['file-tags'], (prev: IFileTag[]) => prev.map(t => (t.id === data.id ? data : t)));
+      // Merge rather than replace: PUT /api/files/tags/[id] echoes back only the fields it
+      // accepted, so a wholesale swap drops fileCount and the sidebar badge reads (0) until the
+      // next refetch.
+      queryClient.setQueryData(['file-tags'], (prev: IFileTag[]) =>
+        prev.map(t => (t.id === data.id ? { ...t, ...data } : t))
+      );
       queryClient.invalidateQueries({ queryKey: ['file-tags', 'counts'] });
       toast.success('Tag updated successfully');
     },

--- a/apps/client/pages/api/files/tags/__tests__/index.test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/index.test.ts
@@ -45,7 +45,10 @@ vi.mock('@bike4mind/services', () => ({
 // Import after mocks are registered so the chain capture runs.
 import '@pages/api/files/tags/index';
 
-const USER_TAGS = ['beta-tester', 'some-arbitrary-tag'];
+// `Opti` is the requiredUserTag of the only lake in the DATA_LAKES registry, so getDataLakeTags
+// resolves to a non-empty set here. Without it every assertion below passes vacuously on [].
+const USER_TAGS = ['Opti', 'some-arbitrary-tag'];
+const GRANTED_LAKE_TAG = 'datalake:opti-knowledge';
 
 function invokeGet(user: Record<string, unknown>) {
   const { req, res } = createMocks({ method: 'GET', url: '/api/files/tags' });
@@ -77,8 +80,19 @@ describe('GET /api/files/tags', () => {
     await mockRefs.getHandler!(req, res);
 
     const { dataLakeTags } = mockRefs.listArgs?.[1] as { dataLakeTags: string[] };
+    expect(dataLakeTags).toContain(GRANTED_LAKE_TAG);
     expect(dataLakeTags).not.toContain('some-arbitrary-tag');
-    expect(dataLakeTags.every(tag => tag.startsWith('datalake:'))).toBe(true);
+    expect(dataLakeTags).not.toContain('Opti');
+  });
+
+  // dataLakeTags is an ownership-bypass arm in buildOwnershipConditions, so a caller who holds no
+  // lake-granting tag must widen the count scope by nothing at all.
+  it('grants no lake scope to a caller without the gating tag', async () => {
+    const { req, res } = invokeGet({ id: 'user-1', groups: [], tags: ['some-arbitrary-tag'] });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect((mockRefs.listArgs?.[1] as { dataLakeTags: string[] }).dataLakeTags).toEqual([]);
   });
 
   it('passes both repositories the service needs to recompute counts', async () => {

--- a/apps/client/pages/api/files/tags/__tests__/index.test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/index.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { getDataLakeTags } from '@bike4mind/common';
+
+/**
+ * Route-layer coverage for GET /api/files/tags. The service decides how to fold counts into tags;
+ * the route decides what scope to hand it, and getting that wrong (owner-only counts, or raw user
+ * tags forwarded as data-lake tags) makes the sidebar badge disagree with the tag tree. Only a
+ * route-level test can catch that, so this asserts the wiring matches the sibling counts.ts.
+ */
+
+// Collapse the baseApi().post().get() chain and capture the GET handler.
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+  listArgs: undefined as unknown[] | undefined,
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    post: () => chain,
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@bike4mind/database', () => ({
+  fileTagRepository: { __repo: 'fileTags' },
+  fabFileRepository: { __repo: 'fabFiles' },
+}));
+
+vi.mock('@bike4mind/services', () => ({
+  tagService: {
+    create: vi.fn(),
+    listFileTags: (...args: unknown[]) => {
+      mockRefs.listArgs = args;
+      return Promise.resolve([]);
+    },
+  },
+}));
+
+// Import after mocks are registered so the chain capture runs.
+import '@pages/api/files/tags/index';
+
+const USER_TAGS = ['beta-tester', 'some-arbitrary-tag'];
+
+function invokeGet(user: Record<string, unknown>) {
+  const { req, res } = createMocks({ method: 'GET', url: '/api/files/tags' });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('GET /api/files/tags', () => {
+  beforeEach(() => {
+    mockRefs.listArgs = undefined;
+  });
+
+  it('scopes counts to the caller groups and their accessible data lakes', async () => {
+    expect(mockRefs.getHandler).toBeTypeOf('function');
+    const { req, res } = invokeGet({ id: 'user-1', groups: ['group-a'], tags: USER_TAGS });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(mockRefs.listArgs?.[0]).toBe('user-1');
+    expect(mockRefs.listArgs?.[1]).toEqual({
+      userGroups: ['group-a'],
+      dataLakeTags: getDataLakeTags(USER_TAGS),
+    });
+  });
+
+  it('derives data-lake tags rather than forwarding the raw user tags', async () => {
+    const { req, res } = invokeGet({ id: 'user-1', groups: [], tags: USER_TAGS });
+
+    await mockRefs.getHandler!(req, res);
+
+    const { dataLakeTags } = mockRefs.listArgs?.[1] as { dataLakeTags: string[] };
+    expect(dataLakeTags).not.toContain('some-arbitrary-tag');
+    expect(dataLakeTags.every(tag => tag.startsWith('datalake:'))).toBe(true);
+  });
+
+  it('passes both repositories the service needs to recompute counts', async () => {
+    const { req, res } = invokeGet({ id: 'user-1', groups: ['group-a'], tags: USER_TAGS });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(mockRefs.listArgs?.[2]).toEqual({
+      db: { fileTags: { __repo: 'fileTags' }, fabFiles: { __repo: 'fabFiles' } },
+    });
+  });
+
+  it('defaults missing groups and tags to empty rather than passing undefined', async () => {
+    const { req, res } = invokeGet({ id: 'user-1' });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(mockRefs.listArgs?.[1]).toEqual({ userGroups: [], dataLakeTags: getDataLakeTags([]) });
+  });
+
+  it('rejects an unauthenticated caller before touching the service', async () => {
+    const { req, res } = invokeGet({});
+
+    await expect(mockRefs.getHandler!(req, res)).rejects.toThrow();
+    expect(mockRefs.listArgs).toBeUndefined();
+  });
+});

--- a/apps/client/pages/api/files/tags/counts.ts
+++ b/apps/client/pages/api/files/tags/counts.ts
@@ -1,7 +1,7 @@
-import { getDataLakeTags } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ForbiddenError } from '@server/utils/errors';
+import { buildTagCountScope } from '@server/utils/tagCountScope';
 import { fabFileRepository } from '@bike4mind/database';
 
 const handler = baseApi().get(
@@ -11,10 +11,8 @@ const handler = baseApi().get(
     }
 
     const [tagCounts, namespaceCounts] = await Promise.all([
-      fabFileRepository.countFilesByTagForUser(req.user.id, {
-        userGroups: req.user.groups ?? [],
-        dataLakeTags: getDataLakeTags(req.user.tags ?? []),
-      }),
+      // Shared with the tag list in ./index.ts; the two must count the same files.
+      fabFileRepository.countFilesByTagForUser(req.user.id, buildTagCountScope(req.user)),
       fabFileRepository.countUniqueFilesByNamespaceForUser(req.user.id),
     ]);
 

--- a/apps/client/pages/api/files/tags/index.ts
+++ b/apps/client/pages/api/files/tags/index.ts
@@ -1,7 +1,8 @@
-import { TagType, getDataLakeTags } from '@bike4mind/common';
+import { TagType } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ForbiddenError } from '@server/utils/errors';
+import { buildTagCountScope } from '@server/utils/tagCountScope';
 import { tagService } from '@bike4mind/services';
 import { fabFileRepository, fileTagRepository } from '@bike4mind/database';
 
@@ -34,21 +35,13 @@ const handler = baseApi()
         throw new ForbiddenError('Unauthorized');
       }
 
-      // Same scoping as the sibling counts.ts, so the sidebar badge and the tag tree count the
-      // same set of files.
-      const result = await tagService.listFileTags(
-        req.user.id,
-        {
-          userGroups: req.user.groups ?? [],
-          dataLakeTags: getDataLakeTags(req.user.tags ?? []),
+      // Shared with counts.ts so the sidebar badge and the tag tree always count the same files.
+      const result = await tagService.listFileTags(req.user.id, buildTagCountScope(req.user), {
+        db: {
+          fileTags: fileTagRepository,
+          fabFiles: fabFileRepository,
         },
-        {
-          db: {
-            fileTags: fileTagRepository,
-            fabFiles: fabFileRepository,
-          },
-        }
-      );
+      });
 
       return res.json(result);
     })

--- a/apps/client/pages/api/files/tags/index.ts
+++ b/apps/client/pages/api/files/tags/index.ts
@@ -1,9 +1,9 @@
-import { TagType } from '@bike4mind/common';
+import { TagType, getDataLakeTags } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ForbiddenError } from '@server/utils/errors';
 import { tagService } from '@bike4mind/services';
-import { fileTagRepository } from '@bike4mind/database';
+import { fabFileRepository, fileTagRepository } from '@bike4mind/database';
 
 const handler = baseApi()
   .post(
@@ -34,11 +34,21 @@ const handler = baseApi()
         throw new ForbiddenError('Unauthorized');
       }
 
-      const result = await tagService.listFileTags(req.user.id, {
-        db: {
-          fileTags: fileTagRepository,
+      // Same scoping as the sibling counts.ts, so the sidebar badge and the tag tree count the
+      // same set of files.
+      const result = await tagService.listFileTags(
+        req.user.id,
+        {
+          userGroups: req.user.groups ?? [],
+          dataLakeTags: getDataLakeTags(req.user.tags ?? []),
         },
-      });
+        {
+          db: {
+            fileTags: fileTagRepository,
+            fabFiles: fabFileRepository,
+          },
+        }
+      );
 
       return res.json(result);
     })

--- a/apps/client/server/utils/tagCountScope.test.ts
+++ b/apps/client/server/utils/tagCountScope.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { getDataLakeTags } from '@bike4mind/common';
+import { buildTagCountScope } from './tagCountScope';
+
+// `Opti` is the requiredUserTag of the only lake in the DATA_LAKES registry; without it the
+// derived set is empty and every assertion here would pass vacuously.
+const GRANTING_TAG = 'Opti';
+const GRANTED_LAKE_TAG = 'datalake:opti-knowledge';
+
+describe('buildTagCountScope', () => {
+  it('derives lake tags from the registry rather than forwarding the raw user tags', () => {
+    const scope = buildTagCountScope({ groups: [], tags: [GRANTING_TAG, 'some-arbitrary-tag'] });
+
+    expect(scope.dataLakeTags).toContain(GRANTED_LAKE_TAG);
+    expect(scope.dataLakeTags).not.toContain('some-arbitrary-tag');
+    expect(scope.dataLakeTags).not.toContain(GRANTING_TAG);
+  });
+
+  // dataLakeTags is an ownership-bypass arm downstream, so a caller holding no gating tag must
+  // widen the counted set by nothing at all.
+  it('grants no lake scope to a caller without the gating tag', () => {
+    expect(buildTagCountScope({ groups: [], tags: ['some-arbitrary-tag'] }).dataLakeTags).toEqual([]);
+  });
+
+  it('passes the caller groups through', () => {
+    expect(buildTagCountScope({ groups: ['group-a', 'group-b'], tags: [] }).userGroups).toEqual(['group-a', 'group-b']);
+  });
+
+  it('defaults absent groups and tags to empty rather than undefined', () => {
+    expect(buildTagCountScope({})).toEqual({ userGroups: [], dataLakeTags: getDataLakeTags([]) });
+  });
+
+  // IUserDocument types both fields as nullable, and a persisted record really can hold null.
+  it('treats an explicit null the same as absent', () => {
+    expect(buildTagCountScope({ groups: null, tags: null })).toEqual({
+      userGroups: [],
+      dataLakeTags: getDataLakeTags([]),
+    });
+  });
+});

--- a/apps/client/server/utils/tagCountScope.ts
+++ b/apps/client/server/utils/tagCountScope.ts
@@ -1,0 +1,25 @@
+import { getDataLakeTags } from '@bike4mind/common';
+
+/**
+ * The file set a per-tag count is taken over.
+ *
+ * Two endpoints report per-tag counts and MUST agree: GET /api/files/tags, whose `fileCount` is
+ * derived per tag document, and GET /api/files/tags/counts, which backs the tag tree. Passing
+ * different scopes makes the sidebar badge and the tag card disagree for the same tag, which is
+ * exactly the class of bug deriving the count was meant to end. Building the scope in one place
+ * means a future edit cannot drift one caller without the other.
+ *
+ * `dataLakeTags` reaches an ownership-bypass arm in buildOwnershipConditions, so it must stay the
+ * registry-derived set for lakes this user can reach - never the user's raw tags.
+ */
+// `groups` and `tags` are nullable on IUserDocument, not merely optional - a user record can hold
+// an explicit null, so the parameter has to admit it rather than only `undefined`.
+export function buildTagCountScope(user: { groups?: string[] | null; tags?: string[] | null }): {
+  userGroups: string[];
+  dataLakeTags: string[];
+} {
+  return {
+    userGroups: user.groups ?? [],
+    dataLakeTags: getDataLakeTags(user.tags ?? []),
+  };
+}

--- a/b4m-core/services/src/tagService/listFileTags.test.ts
+++ b/b4m-core/services/src/tagService/listFileTags.test.ts
@@ -43,17 +43,57 @@ describe('tagService - listFileTags', () => {
     expect(result[0].fileCount).toBe(2);
   });
 
-  it('sums aggregate buckets that differ only in case', async () => {
+  // toggleTags lowercases what it writes onto files, tagService/create keeps the casing the user
+  // typed, so the common shape is a capitalised document over lowercase file tags.
+  it('matches case-insensitively when no document claims the bucket exactly', async () => {
     (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([tag('Invoices', 0)]);
     (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([
       { tag: 'invoices', count: 2 },
-      { tag: 'Invoices', count: 3 },
       { tag: 'INVOICES', count: 1 },
     ]);
 
     const result = await listFileTags(userId, params, adapters);
 
-    expect(result[0].fileCount).toBe(6);
+    expect(result[0].fileCount).toBe(3);
+  });
+
+  // The unique index is { userId, name } with no collation, so these are two real documents.
+  // Folding them together would credit each with the other's files and double-count the surface.
+  it('keeps documents that differ only in case on their own exact counts', async () => {
+    (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([tag('Invoices', 0), tag('invoices', 0)]);
+    (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([
+      { tag: 'Invoices', count: 3 },
+      { tag: 'invoices', count: 2 },
+    ]);
+
+    const result = await listFileTags(userId, params, adapters);
+
+    expect(result.map(t => t.fileCount)).toEqual([3, 2]);
+  });
+
+  it('drops a bucket it cannot attribute rather than crediting both candidates', async () => {
+    (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([tag('Invoices', 0), tag('invoices', 0)]);
+    (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([
+      { tag: 'Invoices', count: 3 },
+      { tag: 'invoices', count: 2 },
+      { tag: 'INVOICES', count: 9 },
+    ]);
+
+    const result = await listFileTags(userId, params, adapters);
+
+    expect(result.map(t => t.fileCount)).toEqual([3, 2]);
+  });
+
+  it('adds unclaimed case variants to the single document that folds to them', async () => {
+    (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([tag('invoices', 0)]);
+    (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([
+      { tag: 'invoices', count: 2 },
+      { tag: 'Invoices', count: 3 },
+    ]);
+
+    const result = await listFileTags(userId, params, adapters);
+
+    expect(result[0].fileCount).toBe(5);
   });
 
   it('reports zero for a tag no live file carries', async () => {

--- a/b4m-core/services/src/tagService/listFileTags.test.ts
+++ b/b4m-core/services/src/tagService/listFileTags.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, Mock, vi } from 'vitest';
+import { listFileTags } from './listFileTags';
+import { IFabFileRepository, IFileTag, IFileTagRepository, TagType } from '@bike4mind/common';
+
+describe('tagService - listFileTags', () => {
+  const userId = 'test-user-123';
+  const params = { userGroups: ['group-a'], dataLakeTags: ['datalake:org:mylake'] };
+
+  let mockFileTagRepo: Pick<IFileTagRepository, 'findAllByUserId'>;
+  let mockFabFileRepo: Pick<IFabFileRepository, 'countFilesByTagForUser'>;
+  let adapters: {
+    db: {
+      fileTags: Pick<IFileTagRepository, 'findAllByUserId'>;
+      fabFiles: Pick<IFabFileRepository, 'countFilesByTagForUser'>;
+    };
+  };
+
+  // `fileCount` is deliberately wrong on every fixture tag: that stale value is exactly what the
+  // unmaintained write paths leave behind, so a test asserting on it would pass against the bug.
+  const tag = (name: string, storedFileCount: number): IFileTag =>
+    ({
+      id: `tag-${name}`,
+      userId,
+      name,
+      type: TagType.FILE,
+      fileCount: storedFileCount,
+      lastActivityAt: new Date(),
+    }) as IFileTag;
+
+  beforeEach(() => {
+    mockFileTagRepo = { findAllByUserId: vi.fn() };
+    mockFabFileRepo = { countFilesByTagForUser: vi.fn() };
+    adapters = { db: { fileTags: mockFileTagRepo, fabFiles: mockFabFileRepo } };
+  });
+
+  it('returns the live aggregate count, not the drifted stored counter', async () => {
+    (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([tag('invoices', 99)]);
+    (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([{ tag: 'invoices', count: 2 }]);
+
+    const result = await listFileTags(userId, params, adapters);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].fileCount).toBe(2);
+  });
+
+  it('sums aggregate buckets that differ only in case', async () => {
+    (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([tag('Invoices', 0)]);
+    (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([
+      { tag: 'invoices', count: 2 },
+      { tag: 'Invoices', count: 3 },
+      { tag: 'INVOICES', count: 1 },
+    ]);
+
+    const result = await listFileTags(userId, params, adapters);
+
+    expect(result[0].fileCount).toBe(6);
+  });
+
+  it('reports zero for a tag no live file carries', async () => {
+    (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([tag('orphaned', 7)]);
+    (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([{ tag: 'something-else', count: 4 }]);
+
+    const result = await listFileTags(userId, params, adapters);
+
+    expect(result[0].fileCount).toBe(0);
+  });
+
+  it('preserves the rest of the tag document', async () => {
+    const stored = tag('invoices', 99);
+    (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([stored]);
+    (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([{ tag: 'invoices', count: 2 }]);
+
+    const result = await listFileTags(userId, params, adapters);
+
+    expect(result[0]).toEqual({ ...stored, fileCount: 2 });
+  });
+
+  it('scopes the aggregate to the caller and their shared/data-lake reach', async () => {
+    (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([]);
+    (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([]);
+
+    await listFileTags(userId, params, adapters);
+
+    expect(mockFabFileRepo.countFilesByTagForUser).toHaveBeenCalledWith(userId, {
+      userGroups: ['group-a'],
+      dataLakeTags: ['datalake:org:mylake'],
+    });
+  });
+
+  it('returns an empty list when the user has no tags', async () => {
+    (mockFileTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([]);
+    (mockFabFileRepo.countFilesByTagForUser as Mock).mockResolvedValueOnce([{ tag: 'invoices', count: 2 }]);
+
+    await expect(listFileTags(userId, params, adapters)).resolves.toEqual([]);
+  });
+});

--- a/b4m-core/services/src/tagService/listFileTags.ts
+++ b/b4m-core/services/src/tagService/listFileTags.ts
@@ -1,15 +1,51 @@
-import { IFileTagRepository } from '@bike4mind/common';
+import { IFabFileRepository, IFileTagRepository } from '@bike4mind/common';
+
+interface TagListFileTagsParams {
+  userGroups: string[];
+  dataLakeTags: string[];
+}
 
 interface TagListFileTagsAdapters {
   db: {
     fileTags: Pick<IFileTagRepository, 'findAllByUserId'>;
+    fabFiles: Pick<IFabFileRepository, 'countFilesByTagForUser'>;
   };
 }
 
-export const listFileTags = async (userId: string, adapters: TagListFileTagsAdapters) => {
+/**
+ * Lists a user's file tags with `fileCount` recomputed from live `FabFile.tags` rather than read
+ * off the tag document. The stored counter is only maintained by fabFileService/toggleTags and the
+ * file-delete routes, so every other writer (the `$pull` removal path, a whole-array tags replace
+ * on PUT /api/files/[id], tags set at creation) leaves it permanently drifted.
+ *
+ * Uses the same aggregate and the same options as GET /api/files/tags/counts, which backs the tag
+ * tree - the two surfaces must stay in sync or the sidebar badge and the tag card disagree for the
+ * same tag. Counting live files means soft-deleted files drop out, as does anything attached to a
+ * session (the aggregate's own filter).
+ */
+export const listFileTags = async (
+  userId: string,
+  params: TagListFileTagsParams,
+  adapters: TagListFileTagsAdapters
+) => {
   const { db } = adapters;
 
-  const fileTags = await db.fileTags.findAllByUserId(userId);
+  const [fileTags, tagCounts] = await Promise.all([
+    db.fileTags.findAllByUserId(userId),
+    db.fabFiles.countFilesByTagForUser(userId, {
+      userGroups: params.userGroups,
+      dataLakeTags: params.dataLakeTags,
+    }),
+  ]);
 
-  return fileTags;
+  // The aggregate groups on the exact stored `tags.name`, so one tag document can match several
+  // buckets differing only in case; sum them instead of letting the last one win. toLowerCase and
+  // not toLocaleLowerCase, whose dotless-i mapping varies by runtime locale.
+  const countsByName = new Map<string, number>();
+  for (const { tag, count } of tagCounts) {
+    const key = tag.toLowerCase();
+    countsByName.set(key, (countsByName.get(key) ?? 0) + count);
+  }
+
+  return fileTags.map(tag => ({ ...tag, fileCount: countsByName.get(tag.name.toLowerCase()) ?? 0 }));
 };

--- a/b4m-core/services/src/tagService/listFileTags.ts
+++ b/b4m-core/services/src/tagService/listFileTags.ts
@@ -38,14 +38,39 @@ export const listFileTags = async (
     }),
   ]);
 
-  // The aggregate groups on the exact stored `tags.name`, so one tag document can match several
-  // buckets differing only in case; sum them instead of letting the last one win. toLowerCase and
-  // not toLocaleLowerCase, whose dotless-i mapping varies by runtime locale.
-  const countsByName = new Map<string, number>();
-  for (const { tag, count } of tagCounts) {
-    const key = tag.toLowerCase();
-    countsByName.set(key, (countsByName.get(key) ?? 0) + count);
+  // Attribute each aggregate bucket to a tag document. An exact name match wins. A bucket that no
+  // document claims exactly is matched case-insensitively, because fabFileService/toggleTags
+  // lowercases what it writes onto files while tagService/create keeps whatever casing the tag
+  // document was created with - without the fallback, an `Invoices` document over `invoices` files
+  // would read zero.
+  //
+  // The fold cannot be unconditional: TagSchema's unique index is { userId, name } with no
+  // collation, so `Invoices` and `invoices` are two legitimate documents, and crediting both with
+  // the combined total would count the same file twice. An unclaimed bucket is therefore only
+  // credited when exactly one document folds to its name; when several do it is unattributable and
+  // dropped, which under-reports rather than inventing files. toLowerCase and not
+  // toLocaleLowerCase, whose dotless-i mapping varies by runtime locale.
+  const exactNames = new Set(fileTags.map(t => t.name));
+  const documentsPerFoldedName = new Map<string, number>();
+  for (const { name } of fileTags) {
+    const key = name.toLowerCase();
+    documentsPerFoldedName.set(key, (documentsPerFoldedName.get(key) ?? 0) + 1);
   }
 
-  return fileTags.map(tag => ({ ...tag, fileCount: countsByName.get(tag.name.toLowerCase()) ?? 0 }));
+  const exactCounts = new Map<string, number>();
+  const unclaimedCounts = new Map<string, number>();
+  for (const { tag, count } of tagCounts) {
+    if (exactNames.has(tag)) {
+      exactCounts.set(tag, count);
+    } else {
+      const key = tag.toLowerCase();
+      unclaimedCounts.set(key, (unclaimedCounts.get(key) ?? 0) + count);
+    }
+  }
+
+  return fileTags.map(tag => {
+    const folded = tag.name.toLowerCase();
+    const unclaimed = documentsPerFoldedName.get(folded) === 1 ? (unclaimedCounts.get(folded) ?? 0) : 0;
+    return { ...tag, fileCount: (exactCounts.get(tag.name) ?? 0) + unclaimed };
+  });
 };

--- a/packages/database/src/__tests__/fabFileTagCounts.test.ts
+++ b/packages/database/src/__tests__/fabFileTagCounts.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FabFile, fabFileRepository } from '../models/content/FabFileModel';
+import { setupMongoTest } from '../__test__/utils';
+import { KnowledgeType } from '@bike4mind/common';
+
+/**
+ * Real-Mongo coverage for the aggregate that tagService/listFileTags serves as `fileCount`.
+ * A mock cannot prove what the $unwind/$group actually returns, and two of the facts pinned here
+ * are load-bearing for the caller: that a tag removed by $pull immediately stops counting (the
+ * whole point of recomputing instead of maintaining a stored counter), and that names differing
+ * only in case come back as SEPARATE buckets, which is why listFileTags sums them.
+ */
+describe('FabFileRepository.countFilesByTagForUser', () => {
+  setupMongoTest();
+
+  const userId = 'tag-counts-user';
+  const otherUserId = 'someone-else';
+  const OPTIONS = { userGroups: [], dataLakeTags: [] };
+
+  const seed = async (tags: string[], overrides: Record<string, unknown> = {}): Promise<string> => {
+    const doc = await FabFile.create({
+      userId,
+      fileName: 'seed.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: tags.map(name => ({ name, strength: 1 })),
+      ...overrides,
+    });
+    return doc.id as string;
+  };
+
+  const countOf = async (tag: string, options?: Parameters<typeof fabFileRepository.countFilesByTagForUser>[1]) => {
+    const counts = await fabFileRepository.countFilesByTagForUser(userId, options);
+    return counts.find(c => c.tag === tag)?.count ?? 0;
+  };
+
+  beforeEach(async () => {
+    await FabFile.deleteMany({});
+  });
+
+  // The acceptance criterion for the drift this replaces: the $pull removal path never touched
+  // the stored counter, so a tag removed that way stayed one too high forever.
+  it('drops a tag removed by pullTagsByFabFileId on the very next read', async () => {
+    const first = await seed(['invoices']);
+    await seed(['invoices']);
+    await seed(['invoices']);
+    expect(await countOf('invoices', OPTIONS)).toBe(3);
+
+    await fabFileRepository.pullTagsByFabFileId(first, ['invoices']);
+
+    expect(await countOf('invoices', OPTIONS)).toBe(2);
+  });
+
+  it('stops counting a soft-deleted file', async () => {
+    const id = await seed(['invoices']);
+    await seed(['invoices']);
+
+    await FabFile.updateOne({ _id: id }, { $set: { deletedAt: new Date() } });
+
+    expect(await countOf('invoices', OPTIONS)).toBe(1);
+  });
+
+  it('returns names differing only in case as separate buckets', async () => {
+    await seed(['Invoices']);
+    await seed(['invoices']);
+
+    const counts = await fabFileRepository.countFilesByTagForUser(userId, OPTIONS);
+    const invoiceBuckets = counts.filter(c => c.tag.toLowerCase() === 'invoices');
+
+    expect(invoiceBuckets).toHaveLength(2);
+    expect(invoiceBuckets.reduce((sum, c) => sum + c.count, 0)).toBe(2);
+  });
+
+  it('counts a file once however many tags it carries', async () => {
+    await seed(['invoices', 'receipts', 'invoices-archive']);
+
+    expect(await countOf('invoices', OPTIONS)).toBe(1);
+    expect(await countOf('receipts', OPTIONS)).toBe(1);
+  });
+
+  it('excludes session-attached files unless they are curated notebooks', async () => {
+    await seed(['invoices'], { sessionId: 'session-1' });
+    expect(await countOf('invoices', OPTIONS)).toBe(0);
+
+    await seed(['invoices', 'curated-notebook'], { sessionId: 'session-2' });
+    expect(await countOf('invoices', OPTIONS)).toBe(1);
+  });
+
+  it('still counts the caller own files when scoping options are supplied', async () => {
+    await seed(['invoices']);
+
+    expect(await countOf('invoices')).toBe(1);
+    expect(await countOf('invoices', OPTIONS)).toBe(1);
+  });
+
+  it('ignores files belonging to another user', async () => {
+    await seed(['invoices'], { userId: otherUserId });
+
+    expect(await countOf('invoices', OPTIONS)).toBe(0);
+  });
+
+  it('omits a tag no live file carries rather than reporting it as zero', async () => {
+    await seed(['invoices']);
+
+    const counts = await fabFileRepository.countFilesByTagForUser(userId, OPTIONS);
+
+    expect(counts.some(c => c.tag === 'never-used')).toBe(false);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1440" height="900" alt="before-drifted" src="https://github.com/user-attachments/assets/4ba784fe-ae99-474b-949f-9afed181e5fb" />

*Before, on main: the Tag Manager reads the stored counters, showing `invoices (5)` and `receipts (9)`.*

<img width="1440" height="900" alt="after-fixed" src="https://github.com/user-attachments/assets/8a73c33d-76ca-4faa-b276-7363807ca10a" />

*After, on this branch: the same panel, same database, same seeded state, now reading `invoices (2)` and `receipts (0)` - the number of live files that actually carry each tag. The stored counters in Mongo are untouched at 5 and 9.*

## Description

Closes #1036

`FileTag` documents carry a stored `fileCount`. Only two paths ever kept it honest: `fabFileService/toggleTags` and the file-delete routes. Every other writer left it drifted, including the `$pull` removal path the issue names, a whole-array `tags` replace on `PUT /api/files/[id]`, and tags applied at file creation. Nothing ever reconciled the difference, so the error was permanent.

The issue calls this cosmetic on the grounds that nothing user-facing reads the stored value. That turned out to be wrong. Two live surfaces read it: the tag sidebar renders the `(N)` badge from it and buckets tags into frequent/moderate/light by it, and the tag-management dialog renders "N files" from it. A drifted counter puts a tag in the wrong bucket, not just off by one.

Rather than teach a fourth and fifth writer to maintain the counter, this takes the issue's second option and stops maintaining one. `listFileTags` now derives `fileCount` from `countFilesByTagForUser`, the aggregate that already backs the tag tree, with the same scoping the sibling `counts.ts` uses. Both surfaces become correct with no component changes, and no future tag writer can drift the number because nothing depends on being told about it.

Two consequences are deliberate: soft-deleted files stop counting, which is what the acceptance criterion asks for, and session-attached files are excluded unless tagged `curated-notebook`, which is the aggregate's existing filter and what the tag tree already does.

## Changes

Server
- `tagService/listFileTags` takes `{ userGroups, dataLakeTags }` and a `fabFiles` adapter, and computes `fileCount` per tag instead of returning the stored field.
- Attribution is exact-name-first: a bucket no document claims exactly falls back to a case-insensitive match, but only when a single document folds to that name. `toggleTags` lowercases what it writes onto files while `tagService/create` keeps the user's casing, so the fallback is needed; the unique index is `{ userId, name }` with no collation, so `Invoices` and `invoices` are two real documents and folding them together would count the same file twice.
- `GET /api/files/tags` passes `req.user.groups` and `getDataLakeTags(req.user.tags)`, mirroring `counts.ts` argument for argument.

Client cache
- Every tag-affecting mutation now invalidates the bare `['file-tags']` prefix. Invalidating `['file-tags','counts']` does not match the shorter key, so the list that actually carries `fileCount` was left stale.
- `useUpdateFabFile` and the send-to-lake upload write a file's tags and previously refreshed no tag surface at all; both now do.
- `useUpdateFileTag` keeps its optimistic merge so an edit shows immediately, but no longer replaces the cached row wholesale, and defers the count to the refetch.

Tests
- `listFileTags.test.ts`: the fixture carries a deliberately stale stored count, so a test asserting on it would pass against the bug. Covers the exact/folded attribution rules and the unattributable case.
- `pages/api/files/tags/__tests__/index.test.ts`: route-level, since the route decides the scope. Includes the negative case, a caller with no lake-granting tag gets an empty set.
- `packages/database/src/__tests__/fabFileTagCounts.test.ts`: real Mongo. `countFilesByTagForUser` had no coverage and this change makes it authoritative.
- Invalidation coverage for both file-write paths.

## Guide for Testers

Environment: the PR preview at `pr<N>.preview.bike4mind.com` (a maintainer triggers it; the bot posts the URL on this PR).

Prerequisites: an account with at least four files, and one file tag applied to two or more of them.
Note on a fresh account: the sidebar "Files Manager" entry is not rendered while the account has zero
files, so upload one first, or reach the same modal from the chat composer paperclip -> file browser.

1. In the left sidebar, click "Files Manager" (see the prerequisites note if it is absent). Expected: the file browser opens as a modal on the "Overview" tab.
2. Click the "List" tab along the top of the modal. Expected: the paginated file list renders.
3. In the toolbar above the file list, click the "Tag Manager" button. Expected: a panel headed "Tag Manager" slides in from the left, listing your tags as `name (N)`. This panel is the surface the fix changes; it is not visible until this step, so do not look for it on the Overview tab.
4. Note the `(N)` beside one tag. Expected: a number, not blank.
5. Close the Tag Manager, then click that same tag to filter the list, and count the files shown. Expected: the number of files listed equals the `(N)` from step 4. This is the core assertion; before this change the two could disagree by any amount. Caveat: this does not hold if two of your tags differ only by letter case - see the known gap below.
6. Open the row menu (three dots) on any file and choose Manage Tags. Find the same tag under "Available tags". Expected: it reads "N files", the same N as step 4.
7. Close the dialog and click the "Tags" tab. Find the same tag's card. Expected: the same N again. All four numbers agree.
8. Upload a new file and apply that same tag to it, then reopen the Tag Manager. Expected: the panel, the dialog and the tag card all move to N+1 together, with no page refresh.
9. Delete one file carrying the tag. Expected: all three numbers drop together.

Regression Checks
- Tag create, rename, recolor and delete still work from the Tag Manager panel, and the list reflects each change.
- Sending a file to a data lake, then removing it from that lake, still succeeds and leaves the tag surfaces consistent.
- The tag tree's grouping and its namespace rollups are unchanged.

What NOT to test
- The Overview tab's "Workspaces" row already read from the recomputed aggregate before this change, so it was always correct and is not evidence either way. The Tag Manager panel in step 3 is the surface that was wrong.
- Known gap, pre-existing and not fixed here: two tags whose names differ only by letter case. Counting is case-sensitive while filtering and writing are case-insensitive, so the variant reads 0 while its filter returns the other tag's files, and applying it collapses onto the existing tag. The mismatch predates this change - the stored counter was also wrong against the filter - so only the displayed number moved. Being tracked separately.
- Do not try to reproduce the original drift through the Manage Tags dialog. That dialog routes through `toggleTags`, the one path that always did maintain the counter, so it never exhibited the bug and passing there proves nothing about this fix. The invariant checks in steps 5 to 7 are what actually cover it.
- Renaming a tag is expected to leave it reading 0 files. Renaming a tag document does not retag the files carrying the old name, so 0 is the truthful count. That is a separate pre-existing bug, not a regression here; before this change the stale stored counter hid it by continuing to show the old number. A follow-up issue is pending.
- No infrastructure, schema or migration changes; nothing to verify on the deploy side.

## Additional Information

The persisted `fileCount` column is now written but never read. Removing it means dropping the field from `FileTagSchema` and `IFileTag`, deleting `incrementFileCountBy` and `incrementFileCountByIds` with their call sites, adding an unset migration, and editing a frozen historical migration that calls the removed method. That is roughly fifteen files of pure cleanup with no behavioural change, so it is deliberately not in this PR.

The scope here matches the sibling `counts.ts` exactly, so the data-lake ownership-bypass arm in `buildOwnershipConditions` is reached with the same inputs it already was. `req.user.tags` is a persisted server-side field and `getDataLakeTags` returns constants from the hardcoded registry, so a caller cannot widen their own count scope.

## Developer Notes (Optional)

- A derived-on-read field is a reasonable answer whenever a stored counter has more writers than any one of them can be trusted to remember. The aggregate already existed here; the work was routing the read through it and making sure every mutation invalidates the surface.
- The React Query prefix trap is worth remembering: `invalidateQueries({ queryKey: ['a','b'] })` does not invalidate `['a']`. Matching runs prefix-first, so invalidating the shorter key covers the longer one and not the reverse. Four sites in this repo had the narrow version.
- `countFilesByTagForUser` now has real-Mongo coverage, including the fact that names differing only in case come back as separate aggregate buckets. That is what the aggregate does, not a property the rest of the app honours: the file-list filter (`fabFileSearchQuery.ts:365`) and the tag write path (`toggleTags.ts:45-49`) are both case-insensitive, and the latter stores names lowercased.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc



