### PR TITLE
fix(e2e): scope test-user cleanup per run to stop cross-run deletes

### DIFF
--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -18,7 +18,7 @@ on:
         type: string
         required: false
       e2e_test_id:
-        description: 'Tester ID for user isolation (e.g. alice)'
+        description: 'Optional extra tester prefix for test user isolation (e.g. alice). Leave blank - e2e-run always appends a per-run id, so runs are already isolated from each other.'
         type: string
         required: false
       gate_run:

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -40,7 +40,7 @@ on:
         type: string
         required: false
       e2e_test_id:
-        description: 'Tester ID for user isolation (e.g. alice)'
+        description: 'Optional extra tester prefix for test user isolation (e.g. alice). Leave blank - e2e-run always appends a per-run id, so runs are already isolated from each other.'
         type: string
         required: false
       gate_run:

--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -206,13 +206,38 @@ jobs:
           echo "Deployment did not become healthy within 300s"
           exit 1
 
+      - name: Resolve E2E test ID
+        id: testid
+        env:
+          E2E_TEST_ID_INPUT: ${{ inputs.e2e_test_id }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          # NEVER let this be empty. An empty E2E_TEST_ID makes global-setup fall back to the
+          # unscoped sweep, which hard-deletes every -<digits>-e2e@test.com user on the target
+          # stage - including the live users of any suite running concurrently against it, which
+          # then 401s and dies mid-test with unrelated-looking timeouts.
+          # See apps/client/e2e/global-setup.ts + pages/api/test/cleanup.ts.
+
+          # Same alphanumeric strip the TS side applies (e2e/helpers/test-users.ts
+          # getE2ETestId); also stops a dispatch value smuggling a newline into GITHUB_OUTPUT.
+          SAFE_INPUT=$(printf '%s' "$E2E_TEST_ID_INPUT" | tr -cd 'a-zA-Z0-9')
+
+          # Unique per Actions run and traceable straight back to it. A re-run reuses the id
+          # deliberately, so its pre-run cleanup collects its own earlier attempt's leftovers.
+          TEST_ID="gh${RUN_ID}"
+          if [ -n "$SAFE_INPUT" ]; then
+            TEST_ID="${SAFE_INPUT}-${TEST_ID}"
+          fi
+          echo "test_id=$TEST_ID" >> "$GITHUB_OUTPUT"
+          echo "Scoping e2e users and cleanup to testId=$TEST_ID"
+
       - name: Run E2E tests
         id: e2e
         env:
           API_URL: ${{ steps.config.outputs.api_url }}
           # E2E_CLEANUP_SECRET is read from SST (Resource.E2E_CLEANUP_SECRET.value) via the
           # `sst shell` wrapper below — no GitHub-secret env override (issue #251).
-          E2E_TEST_ID: ${{ inputs.e2e_test_id }}
+          E2E_TEST_ID: ${{ steps.testid.outputs.test_id }}
           # Only wire the credits webhook for suites that report credits (show_credits).
           # Core runs the notebook project too, but must NOT post the in-process AI
           # Credits report (global-teardown -> notifyCreditsReport) to the slow-responses

--- a/apps/client/.env.e2e.example
+++ b/apps/client/.env.e2e.example
@@ -5,7 +5,10 @@
 API_URL=http://localhost:3000
 
 # Optional prefix for test user isolation (e.g. your name or initials)
-# Prevents test data collisions when multiple testers share the same environment
+# Prevents test data collisions when multiple testers share the same environment.
+# Set this whenever you run against a SHARED stage: left empty, cleanup runs unscoped and
+# hard-deletes every ephemeral e2e user on that stage, including other people's live runs.
+# CI never relies on this - e2e-run.yml always derives a per-run id.
 E2E_TEST_ID=
 
 # Secret used by the test cleanup API to remove stale e2e test data

--- a/apps/client/e2e/README.md
+++ b/apps/client/e2e/README.md
@@ -88,7 +88,7 @@ Copy `.env.e2e.example` to `.env.e2e` and fill in the values:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `API_URL` | Yes | Base URL of the app (default: `http://localhost:3000`) |
-| `E2E_TEST_ID` | No | Optional prefix for test user isolation (e.g., `alice`). Use when multiple testers run on shared preview builds. |
+| `E2E_TEST_ID` | No* | Prefix for test user isolation (e.g., `alice`). **Required in practice on any shared stage:** when empty, cleanup runs unscoped and hard-deletes every ephemeral `-e2e@test.com` user on the target stage, including the live users of anyone else's in-flight run. CI does not depend on this variable — `e2e-run.yml` always appends a per-run `gh<run_id>` scope. |
 | `E2E_CLEANUP_SECRET` | Yes* | Shared secret for the `/api/test/*` endpoints (create-user, cleanup, otc-code). **Same value on every stage** (previews, staging, production) — each deploy writes the deployer's `E2E_CLEANUP_SECRET` GitHub secret into that stage's SST secret, so it does not change between deploys. Required when running without SST context (staging/preview); falls back to the SST Resource if unset. Get the value from the team secret store, or read it per-stage: `./for-env bike4mind-previews npx sst secret list --stage pr<N> \| grep E2E_CLEANUP_SECRET`. Never commit the literal value. |
 | `PW_WORKERS` | No | Number of parallel workers (default: 1) |
 
@@ -172,6 +172,17 @@ a live page and navigates to `/` to bootstrap the authenticated app. An agent
 by a password/OTC UI round-trip.
 
 Before setup runs, `global-setup.ts` calls `/api/test/cleanup` to remove stale test users from prior runs. After all tests, `global-teardown.ts` does the same.
+
+Both calls are **scoped to this run's `E2E_TEST_ID`**, so a run can only ever delete its own
+users. Every CI workflow supplies a non-empty id (`e2e-run.yml` derives `gh<run_id>`;
+`e2e-ai-latency.yml` derives one per matrix cell), because an unscoped sweep deletes every
+ephemeral e2e user on the stage and will kill a concurrent suite mid-test — its users vanish,
+the app 401s, and the tests fail with unrelated-looking timeouts.
+
+Because a per-run scope never matches a previous run's leftovers, `global-setup` also passes
+`staleMinutes` to sweep users orphaned by runs that died before their own teardown. The endpoint
+floors that window (see `server/utils/e2eCleanupScope.ts`), so it can only reach runs that are
+long finished — never one still in flight.
 
 ### Completing an OTC login/registration in a test (no mailbox needed)
 

--- a/apps/client/e2e/global-setup.ts
+++ b/apps/client/e2e/global-setup.ts
@@ -2,6 +2,10 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { Resource } from 'sst';
 
+// Age cutoff for the orphan sweep, in minutes. 6h is far above the longest CI run
+// (ai-latency cells allow 90 min) so a concurrent suite is never in range.
+const STALE_SWEEP_MINUTES = 360;
+
 /**
  * Cleans up stale e2e data from runs that failed before global-teardown ran,
  * so `-e2e@test.com` users don't accumulate over time.
@@ -21,12 +25,17 @@ export default async function globalSetup() {
     );
   }
 
-  // Scope to this run's testId so concurrent matrix cells don't wipe each other's freshly-created
-  // users. Empty testId (local dev) keeps the unscoped behavior - every -e2e@test.com user is cleared.
+  // Scope to this run's testId so concurrent runs don't wipe each other's freshly-created users.
+  // CI always sets a per-run id (.github/workflows/e2e-run.yml); an empty testId is the local-dev
+  // fallback only, and there it keeps the unscoped behavior - every -e2e@test.com user is cleared.
   const testId = (process.env.E2E_TEST_ID ?? '').replace(/[^a-zA-Z0-9]/g, '');
-  const cleanupUrl = testId
-    ? `${baseURL}/api/test/cleanup?testId=${encodeURIComponent(testId)}`
-    : `${baseURL}/api/test/cleanup`;
+  const params = new URLSearchParams();
+  if (testId) params.set('testId', testId);
+  // A per-run scope never matches a previous run's leftovers, so also ask for the aged sweep to
+  // collect users orphaned by runs that died before teardown. The endpoint floors the window well
+  // above the longest possible run, so this can never touch a suite that is still going.
+  params.set('staleMinutes', String(STALE_SWEEP_MINUTES));
+  const cleanupUrl = `${baseURL}/api/test/cleanup?${params.toString()}`;
 
   const response = await fetch(cleanupUrl, {
     method: 'DELETE',

--- a/apps/client/pages/api/test/cleanup.ts
+++ b/apps/client/pages/api/test/cleanup.ts
@@ -47,7 +47,10 @@ const handler = baseApi({ auth: false }).delete(
     // Scope cleanup to one run's users (multi-tester isolation, and in CI a per-run id so
     // concurrent suites never delete each other's live users - see .github/workflows/e2e-run.yml).
     // Unscoped is the local-dev fallback only: it matches EVERY ephemeral e2e user on the stage.
-    const testId = sanitizeTestId(req.query.testId);
+    // Cast because baseApi types req.query as unknown; both values are re-validated below
+    // (sanitizeTestId / resolveStaleSweepMinutes tolerate arrays and non-strings).
+    const { testId: rawTestId, staleMinutes } = req.query as { testId?: string; staleMinutes?: string };
+    const testId = sanitizeTestId(rawTestId);
     const emailPattern = buildE2EEmailPattern(testId);
 
     const scoped = await User.find({ email: { $regex: emailPattern } }, { _id: 1 }).lean();
@@ -61,8 +64,8 @@ const handler = baseApi({ auth: false }).delete(
     // The window is floored server-side, so this only ever sees runs that are long finished,
     // and a doc with no createdAt is skipped rather than assumed old.
     let staleSwept = 0;
-    if (req.query.staleMinutes !== undefined) {
-      const cutoff = new Date(Date.now() - resolveStaleSweepMinutes(req.query.staleMinutes) * 60_000);
+    if (staleMinutes !== undefined) {
+      const cutoff = new Date(Date.now() - resolveStaleSweepMinutes(staleMinutes) * 60_000);
       const orphans = await User.find(
         { email: { $regex: BASE_E2E_EMAIL_PATTERN }, createdAt: { $lt: cutoff } },
         { _id: 1 }

--- a/apps/client/pages/api/test/cleanup.ts
+++ b/apps/client/pages/api/test/cleanup.ts
@@ -23,13 +23,12 @@ import {
   Organization,
 } from '@bike4mind/database';
 import mongoose from 'mongoose';
-
-// Only sweep EPHEMERAL test users, which always carry a numeric timestamp segment
-// (e.g. setup-admin-12345678-e2e@test.com - see e2e/core.setup.ts + apiCreateTestUser).
-// Standing seeded QA accounts (qa-admin-e2e@test.com / qa-user-e2e@test.com from
-// UserSeeder) deliberately omit the timestamp so this cleanup never deletes them -
-// otherwise every Playwright/CI run would wipe the accounts QA logs in with.
-const BASE_E2E_EMAIL_PATTERN = /-\d+-e2e@test\.com$/i;
+import {
+  BASE_E2E_EMAIL_PATTERN,
+  buildE2EEmailPattern,
+  resolveStaleSweepMinutes,
+  sanitizeTestId,
+} from '@server/utils/e2eCleanupScope';
 
 const handler = baseApi({ auth: false }).delete(
   asyncHandler(async (req, res) => {
@@ -45,13 +44,39 @@ const handler = baseApi({ auth: false }).delete(
       return res.status(401).json({ error: 'Invalid cleanup secret' });
     }
 
-    // Optional: scope cleanup to a specific test ID (for multi-tester isolation on shared preview builds)
-    const { testId } = req.query as { testId?: string };
-    const emailPattern = testId ? new RegExp(`${testId}-[0-9]+-e2e@test\\.com$`, 'i') : BASE_E2E_EMAIL_PATTERN;
+    // Scope cleanup to one run's users (multi-tester isolation, and in CI a per-run id so
+    // concurrent suites never delete each other's live users - see .github/workflows/e2e-run.yml).
+    // Unscoped is the local-dev fallback only: it matches EVERY ephemeral e2e user on the stage.
+    const testId = sanitizeTestId(req.query.testId);
+    const emailPattern = buildE2EEmailPattern(testId);
 
-    const users = await User.find({ email: { $regex: emailPattern } }, { _id: 1 }).lean();
-    const userIds = users.map(u => u._id);
-    const userIdStrings = userIds.map(id => id.toString());
+    const scoped = await User.find({ email: { $regex: emailPattern } }, { _id: 1 }).lean();
+    const byId = new Map(scoped.map(u => [u._id.toString(), u._id] as const));
+
+    // Aged sweep: reclaims users orphaned by runs that died before their own teardown
+    // (cancelled job, runner timeout). Necessary because a per-run testId scope never matches
+    // a previous run's leftovers, so nothing else would ever collect them - and it is also the
+    // only thing that reaches specs whose emails carry no testId at all (mfa/admin/signup).
+    // Age is createdAt, not the email's digits: those are a truncated clock, not a real time.
+    // The window is floored server-side, so this only ever sees runs that are long finished,
+    // and a doc with no createdAt is skipped rather than assumed old.
+    let staleSwept = 0;
+    if (req.query.staleMinutes !== undefined) {
+      const cutoff = new Date(Date.now() - resolveStaleSweepMinutes(req.query.staleMinutes) * 60_000);
+      const orphans = await User.find(
+        { email: { $regex: BASE_E2E_EMAIL_PATTERN }, createdAt: { $lt: cutoff } },
+        { _id: 1 }
+      ).lean();
+      for (const orphan of orphans) {
+        const key = orphan._id.toString();
+        if (byId.has(key)) continue;
+        byId.set(key, orphan._id);
+        staleSwept++;
+      }
+    }
+
+    const userIds = [...byId.values()];
+    const userIdStrings = [...byId.keys()];
 
     if (userIds.length === 0) {
       return res.json({ success: true, cleaned: { users: 0 }, message: 'No e2e test users found' });
@@ -133,6 +158,7 @@ const handler = baseApi({ auth: false }).delete(
       success: true,
       cleaned: {
         users: userIds.length,
+        staleSwept,
         sessions: sessionIds.length,
         files: counts.files || 0,
         agents: counts.agents || 0,

--- a/apps/client/server/utils/e2eCleanupScope.test.ts
+++ b/apps/client/server/utils/e2eCleanupScope.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BASE_E2E_EMAIL_PATTERN,
+  DEFAULT_STALE_SWEEP_MINUTES,
+  MIN_STALE_SWEEP_MINUTES,
+  buildE2EEmailPattern,
+  resolveStaleSweepMinutes,
+  sanitizeTestId,
+} from './e2eCleanupScope';
+
+describe('buildE2EEmailPattern', () => {
+  it('matches only the run that owns the testId', () => {
+    const pattern = buildE2EEmailPattern('gh30421366842');
+    expect(pattern.test('setup-admin-gh30421366842-1769000000000-e2e@test.com')).toBe(true);
+    expect(pattern.test('setup-admin-gh30327348536-1769000000000-e2e@test.com')).toBe(false);
+  });
+
+  it('does not match a longer testId that ends with it', () => {
+    const pattern = buildE2EEmailPattern('gh12');
+    expect(pattern.test('setup-admin-alicegh12-1769000000000-e2e@test.com')).toBe(false);
+    expect(pattern.test('setup-admin-gh12-1769000000000-e2e@test.com')).toBe(true);
+  });
+
+  it('matches the retry-marker emails auth.spec builds', () => {
+    const pattern = buildE2EEmailPattern('gh99');
+    expect(pattern.test('auth-logout0-gh99-1769000000000-e2e@test.com')).toBe(true);
+  });
+
+  it('falls back to the unscoped base pattern when no testId is given', () => {
+    expect(buildE2EEmailPattern('')).toBe(BASE_E2E_EMAIL_PATTERN);
+  });
+
+  it('never matches the standing seeded QA accounts', () => {
+    for (const pattern of [buildE2EEmailPattern(''), buildE2EEmailPattern('gh1')]) {
+      expect(pattern.test('qa-admin-e2e@test.com')).toBe(false);
+      expect(pattern.test('qa-user-e2e@test.com')).toBe(false);
+    }
+  });
+});
+
+describe('sanitizeTestId', () => {
+  it('strips everything outside the alphanumeric class, matching getE2ETestId', () => {
+    expect(sanitizeTestId('alice-gh30421366842')).toBe('alicegh30421366842');
+  });
+
+  it('neutralizes regex metacharacters so the id cannot alter the pattern', () => {
+    expect(sanitizeTestId('.*')).toBe('');
+    const pattern = buildE2EEmailPattern(sanitizeTestId('a.*b'));
+    expect(pattern.test('setup-admin-aXXb-1769000000000-e2e@test.com')).toBe(false);
+    expect(pattern.test('setup-admin-ab-1769000000000-e2e@test.com')).toBe(true);
+  });
+
+  it('returns empty for non-string input', () => {
+    expect(sanitizeTestId(undefined)).toBe('');
+    expect(sanitizeTestId(['a', 'b'])).toBe('');
+  });
+});
+
+describe('base pattern coverage', () => {
+  // The aged sweep is the only thing that reaches these: they carry no testId segment, so no
+  // scoped pattern matches them and nothing else would ever collect them.
+  it('matches the spec emails that carry no testId segment', () => {
+    for (const email of [
+      'mfa-signin-1769000000000-e2e@test.com',
+      'admin-1769000000000-e2e@test.com',
+      'signup-1769000000000-e2e@test.com',
+      'inline-signup-1769000000000-e2e@test.com',
+    ]) {
+      expect(BASE_E2E_EMAIL_PATTERN.test(email)).toBe(true);
+      expect(buildE2EEmailPattern('gh30421366842').test(email)).toBe(false);
+    }
+  });
+
+  it('matches the truncated run ids core.setup and the specs actually produce', () => {
+    // core.setup.ts uses Date.now().slice(-8), other specs slice(-6) - short, not epoch ms.
+    expect(BASE_E2E_EMAIL_PATTERN.test('setup-admin-51900411-e2e@test.com')).toBe(true);
+    expect(BASE_E2E_EMAIL_PATTERN.test('setup-agents-004119-e2e@test.com')).toBe(true);
+  });
+});
+
+describe('resolveStaleSweepMinutes', () => {
+  it('defaults when the caller sends nothing usable', () => {
+    expect(resolveStaleSweepMinutes(undefined)).toBe(DEFAULT_STALE_SWEEP_MINUTES);
+    expect(resolveStaleSweepMinutes('not-a-number')).toBe(DEFAULT_STALE_SWEEP_MINUTES);
+  });
+
+  it('honors a window at or above the floor', () => {
+    expect(resolveStaleSweepMinutes('720')).toBe(720);
+    expect(resolveStaleSweepMinutes(String(MIN_STALE_SWEEP_MINUTES))).toBe(MIN_STALE_SWEEP_MINUTES);
+  });
+
+  it('clamps up so a small window cannot reach a live run', () => {
+    expect(resolveStaleSweepMinutes('0')).toBe(MIN_STALE_SWEEP_MINUTES);
+    expect(resolveStaleSweepMinutes('-1')).toBe(MIN_STALE_SWEEP_MINUTES);
+    expect(resolveStaleSweepMinutes('5')).toBe(MIN_STALE_SWEEP_MINUTES);
+  });
+
+  it('keeps the floor above the longest allowed CI run', () => {
+    expect(MIN_STALE_SWEEP_MINUTES).toBeGreaterThan(90);
+  });
+});

--- a/apps/client/server/utils/e2eCleanupScope.ts
+++ b/apps/client/server/utils/e2eCleanupScope.ts
@@ -1,0 +1,44 @@
+/**
+ * Selection rules for the gated E2E cleanup endpoint (pages/api/test/cleanup.ts).
+ * Kept out of the route module so they can be unit-tested without Next/SST/Mongo.
+ * Must stay in sync with the client-side id handling in e2e/helpers/test-users.ts
+ * (getE2ETestId) - both strip the same character class.
+ */
+
+// Only sweep EPHEMERAL test users, which always carry a numeric timestamp segment
+// (e.g. setup-admin-12345678-e2e@test.com - see e2e/core.setup.ts + apiCreateTestUser).
+// Standing seeded QA accounts (qa-admin-e2e@test.com / qa-user-e2e@test.com from
+// UserSeeder) deliberately omit the timestamp so this cleanup never deletes them -
+// otherwise every Playwright/CI run would wipe the accounts QA logs in with.
+export const BASE_E2E_EMAIL_PATTERN = /-\d+-e2e@test\.com$/i;
+
+// Floor for the aged sweep. Must stay well above the longest allowed run (ai-latency
+// matrix cells get 90 min) so an in-flight suite's users can never fall in range.
+// Age comes from the User doc's createdAt, NOT from the email: the digits in the email
+// tail are a truncated clock (core.setup.ts uses Date.now().slice(-8), other specs
+// slice(-6)), so they are unique-ish but say nothing about absolute age.
+export const MIN_STALE_SWEEP_MINUTES = 120;
+export const DEFAULT_STALE_SWEEP_MINUTES = 360;
+
+export function sanitizeTestId(raw: unknown): string {
+  return typeof raw === 'string' ? raw.replace(/[^a-zA-Z0-9]/g, '') : '';
+}
+
+/**
+ * Scoped pattern for a single run's users. Anchored on the leading '-' so one testId can
+ * never match a longer one that merely ends with it (e.g. 'gh12' vs 'alicegh12'). Falls
+ * back to the unscoped base pattern only when no testId is supplied (local dev).
+ */
+export function buildE2EEmailPattern(testId: string): RegExp {
+  return testId ? new RegExp(`-${testId}-[0-9]+-e2e@test\\.com$`, 'i') : BASE_E2E_EMAIL_PATTERN;
+}
+
+/**
+ * Clamps a caller-supplied window up to the floor, so `staleMinutes=0` can never turn the
+ * aged sweep back into the delete-every-e2e-user sweep that used to break concurrent runs.
+ */
+export function resolveStaleSweepMinutes(raw: unknown): number {
+  const requested = Number(Array.isArray(raw) ? raw[0] : raw);
+  if (!Number.isFinite(requested)) return DEFAULT_STALE_SWEEP_MINUTES;
+  return Math.max(requested, MIN_STALE_SWEEP_MINUTES);
+}


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Verdict

A scheduled or bot-dispatched E2E run left `E2E_TEST_ID` empty, which made its pre-run cleanup delete **every** ephemeral `-e2e@test.com` user on the target stage — including the live users of any other suite running against it. Both nightly schedules sit inside each other's blast radius, and per the triage **7 of the last 12 scheduled runs failed** this way, burning ~2.5h of runner time per occurrence on tests that could not pass.

Every CI path that goes through `e2e-run.yml` (the Core promote-gate and the manual/nightly suite) is now scoped to a per-run id. Because a per-run scope can never match a *previous* run's leftovers, an age-gated orphan sweep replaces what the unscoped sweep used to collect.

---

## Description

### The symptom

Job `ai-latency-short-answers — GPT-5.6 Sol`, spec user `6a697e298f9bdd9b1adafb1b`:

| Time | Event |
|---|---|
| 04:14:33 | spec user created + authenticated (JWT `iat` 04:14:33, `exp` 2026-08-05 — 7-day TTL) |
| 04:14:38–04:15:35 | prompts 1 & 2 pass (28.7s, 28.4s) |
| ~04:15:36 | prompt 3 "Name the 5 planets closest to the Sun in order" starts |
| **04:18:52** | **user deleted by a concurrent Core run's unscoped cleanup** |
| 04:20:35 | 300s test timeout — response never rendered |
| 04:20:36 / 04:25:41 | retries #1/#2 time out on the first click |

The reported error at `ai-latency-suite-factory.ts:59` (`locator.allInnerTexts: Target page, context or browser has been closed`) is a post-timeout artifact. The real failure is that the app 401'd and bounced to `/login`, so the AI response never arrived.

Confirmed from the retry-1 trace (`0-trace.network`): **19 x HTTP 401** starting 04:20:38, including `POST /api/auth/refreshToken` -> 401. The token was still cryptographically valid for another 7 days, so this was not expiry — **the user record was gone**. Both retry screenshots and attempt 1's screenshot show the "Welcome to Bike4Mind" login page, which is why `getByTestId('sidenav-nav-new-chat')` never resolved.

Corroborating evidence:

- The killer: `E2E Tests (Core)` run [30421366842](https://github.com/Bike4Mind/bike4mind/actions/runs/30421366842) (workflow_dispatch on `main`) started Playwright at 04:18:43. Its `globalSetup` pre-run cleanup fired at 04:18:52 with `E2E_TEST_ID` empty and hard-deleted 12 users:
  ```
  04:18:52  Pre-run cleanup removed stale e2e data: { users: 12, sessions: 9, registrationInvites: 4, ... }
  ```
- Both failing cells' own teardowns reported `E2E cleanup: { users: 0 }` — their users were already gone.
- The four cells that **passed** all finished before 04:18:52 (teardowns at 04:16:10 / 04:16:25 / 04:17:00 / 04:18:03) and each cleaned up its own scoped users.
- Collateral in the same run: `ai-latency-tool-prompts — GPT-5.6 Sol` (1h3m, 2 failed) and `ai-latency-intermediate-tools — GPT-5.6 Sol` (1h30m), same signature.
- **Not model-specific.** Run [30327348536](https://github.com/Bike4Mind/bike4mind/actions/runs/30327348536) (2026-07-28) has the identical shape on Claude 5 Opus. Whichever cell is still running when another E2E run starts is the one that dies.

### Root cause — three links

1. **`e2e-run.yml:213` (pre-fix)** passed the dispatch input straight through: `E2E_TEST_ID: ${{ inputs.e2e_test_id }}`. On a `schedule` event GitHub populates no `inputs`, so this resolved to `''`; a bot dispatch that leaves the field blank does the same.
2. **`global-setup.ts:25-29` (pre-fix)** treated an empty id as "local dev" and fell back to the unscoped sweep.
3. **`cleanup.ts:52` (pre-fix)** then matched `BASE_E2E_EMAIL_PATTERN` = `/-\d+-e2e@test\.com$/i` — every ephemeral e2e user on the stage, regardless of which run owned it — and hard-deleted across ~20 collections via the native driver (bypassing the soft-delete plugin).

The "local dev only" unscoped path was therefore running against shared staging on every scheduled and gate run.

### Why the two nightlies are inside each other's blast radius

| Workflow | Cron (UTC) | Per-run timeout | Scoped pre-fix? |
|---|---|---|---|
| `e2e-ai-latency` | 1am, 11am | **90 min per matrix cell** (`:234`) | Yes — per-cell id (`:266-272`) |
| `e2e-manual` | 2am, 12pm | 60 min | **No** — empty on schedule |

One hour between the schedules against a 90-minute allowance. `e2e-ai-latency.yml:263-265` already documented the hazard for its own matrix ("Without this, the cleanup endpoint (no testId) deletes ALL e2e users globally, causing the first-finishing cell to wipe data for the rest") — but its careful per-cell scoping cannot protect it, because **an unscoped sweep from any other workflow overrides it**. The per-cell `concurrency` group (`:241-243`) only serializes ai-latency against itself; `e2e-manual` sits in `e2e-manual-dev`, a different group entirely.

**This was never only a CI-hygiene problem.** A red `e2e/core` gate blocks prod promotion, and a nightly `e2e/smoke` that fails for this reason is indistinguishable at a glance from a real regression.

---

## Changes

**CI — the actual fix**

- `.github/workflows/e2e-run.yml:209-232` — new `Resolve E2E test ID` step. `E2E_TEST_ID` (`:240`) is now `steps.testid.outputs.test_id` and can never be empty:

  | Dispatch input | Resolved id |
  |---|---|
  | `''` (cron / bot dispatch) | `gh30421366842` |
  | `alice` | `alice-gh30421366842` |
  | `bad-id!@#` | `badid-gh30421366842` |

  Fixed at the shared reusable workflow rather than duplicated in both callers, since `e2e-core.yml:46` and `e2e-manual.yml:141` are thin passthroughs. `github.run_id` inside a reusable workflow is the **caller's** run id, so the value is the number in the Actions URL, identical across `e2e-manual`'s `prep` and `run` jobs, and unique per run — which makes any orphaned user traceable straight back to the run that made it (the lookup this triage had to do by hand). A re-run reuses the id deliberately, so its pre-run cleanup collects its own earlier attempt's leftovers. The tester prefix is stripped with `tr -cd 'a-zA-Z0-9'` — the same character class `getE2ETestId` applies, `a-zA-Z0-9` rather than `[:alnum:]` because the latter is locale-dependent under UTF-8 — which also stops a dispatch value smuggling a newline into `$GITHUB_OUTPUT`.
- `.github/workflows/e2e-core.yml` / `e2e-manual.yml` — `e2e_test_id` description now states it is an optional *extra* prefix and that isolation is automatic, so leaving it blank cannot reintroduce this.

**API — cleanup endpoint**

- `apps/client/pages/api/test/cleanup.ts:52-54` — `testId` is sanitized server-side before it reaches a `RegExp` (it was interpolated raw), and the scoped pattern is built via `buildE2EEmailPattern`.
- `cleanup.ts:66-79` — **aged orphan sweep**, opt-in via `?staleMinutes=N`. Age comes from the User doc's `createdAt` (`:70`), floored server-side. Union'd with the scoped set through a `Map` keyed on `_id.toString()`, so a user matched by both paths is deleted once. `staleSwept` is reported separately in the response (`:164`).
- `apps/client/server/utils/e2eCleanupScope.ts` (new, 44 lines) — the selection rules, extracted so they are unit-testable without Next/SST/Mongo:
  - `BASE_E2E_EMAIL_PATTERN` — unchanged; still excludes the standing seeded QA accounts (`qa-admin-e2e@test.com` / `qa-user-e2e@test.com`), which deliberately omit the timestamp segment.
  - `sanitizeTestId` — strips to `[a-zA-Z0-9]`, matching `getE2ETestId`; neutralizes regex metacharacters as a side effect.
  - `buildE2EEmailPattern` — **anchored on the leading `-`**, so `gh12` can no longer match `alicegh12`. Falls back to the base pattern only for an empty id.
  - `MIN_STALE_SWEEP_MINUTES = 120`, `DEFAULT_STALE_SWEEP_MINUTES = 360`, `resolveStaleSweepMinutes` — clamps **up**, so `staleMinutes=0` cannot turn the aged sweep back into a delete-everything sweep.

**E2E harness**

- `apps/client/e2e/global-setup.ts:7,33-38` — builds the URL via `URLSearchParams` and always requests `staleMinutes=360`. 6h is far above the longest CI run (90 min), so a concurrent suite is never in range. `e2e-ai-latency` picks this up for free, since it drives the same `globalSetup`.

**Tests**

- `apps/client/server/utils/e2eCleanupScope.test.ts` (new, 101 lines, 14 tests) — scoped-vs-unscoped matching, the suffix-collision case, `auth.spec`'s retry-marker email shape, seeded-QA-account exclusion, metacharacter neutralization, floor clamping, and the two regressions found in self-review (below).

**Docs**

- `apps/client/e2e/README.md` — `E2E_TEST_ID` is now `No*` rather than `No`, spelling out that an empty value deletes every ephemeral e2e user on the target stage including other people's in-flight runs; plus a paragraph on why every CI workflow supplies a non-empty id and what `staleMinutes` is for.
- `apps/client/.env.e2e.example` — same warning at the variable.

---

## Two defects found in self-review

Both were in this change, not pre-existing. Worth reading before reviewing the diff, because the first would have been **worse than the bug being fixed**.

### Defect A — the aged sweep read a truncated clock (critical)

The first implementation parsed the digits out of the email and treated them as epoch milliseconds. They are not:

```
core.setup.ts:23    const TEST_RUN_ID = Date.now().toString().slice(-8);
agents.spec.ts:4    const TEST_RUN_ID = Date.now().toString().slice(-6);
```

(also `skills.spec.ts:18`, `search.setup.ts:4`, `projects.spec.ts:6`)

Unique-ish, but meaningless as an absolute time. An 8-digit value is at most ~1e8 while the cutoff is ~1.77e12, so `ts < cutoff` was **always true** — every ephemeral user would be classified as a 6-hour-old orphan and deleted on every `global-setup`. That fires on *every* run including ai-latency, not only when someone dispatched Core.

Fixed by filtering on the document instead: `{ email: { $regex: BASE }, createdAt: { $lt: cutoff } }`. `UserSchema` has `timestamps: true` (`UserModel.ts:780`) and `/api/test/create-user` persists via `userService.createUser` -> `userRepository` -> mongoose, so `createdAt` is always written. It also **fails closed**: a doc with no `createdAt` does not match, so the worst case is a lingering orphan, never a deleted live user. `e2eEmailTimestamp` was deleted entirely and the sweep became one query instead of a full scan plus JS filter.

Note the original passing check was a false positive — it fed the helper a synthetic 13-digit timestamp instead of the 8-digit value the code actually produces, i.e. it validated the assumption against itself.

### Defect B — specs whose emails carry no test id

Several specs build emails with no `testId` segment at all:

```
mfa.spec.ts:22,47,79,92    `mfa-signin-${Date.now()}-e2e@test.com`
admin.spec.ts:10           `admin-${Date.now()}-e2e@test.com`
signup.spec.ts:38,64       `signup-${Date.now()}-e2e@test.com`
```

No scoped pattern can ever match these (true before this PR too). The unscoped nightly sweep was the **only** thing collecting them — so scoping every CI run would have made them accumulate forever. The `createdAt` sweep matches them via the base pattern, which closes it. Both cases now have explicit tests.

---

## Guide for Testers

There is no user-facing surface here. Verification is (a) that concurrent runs stop killing each other and (b) that nothing regressed in normal cleanup.

### A. The concurrency case — the point of the PR

1. Dispatch **E2E Tests (AI Latency)** against `dev` with `run_all_specs` checked (long-running cells).
2. While it is still running, dispatch **E2E Tests (Core)** against `dev`, leaving **Tester ID blank** — the exact condition that broke.
3. In the Core run's log, open the `Resolve E2E test ID` step. Expected: `Scoping e2e users and cleanup to testId=gh<run_id>`, never empty.
4. In the Core run's Playwright output, find the pre-run cleanup line. Expected: it reports only its own users — typically `{ users: 0 }` on a clean stage, and **never** the double-digit `users:` count seen at 04:18:52 in the incident.
5. Expected: the AI-latency cells keep passing. No HTTP 401 burst, no `/login` screenshots, no `E2E cleanup: { users: 0 }` in a cell whose users should still exist.

### B. Scoping did not break normal cleanup

6. Let a normal **E2E Tests (Manual)** run finish. Expected in teardown: `E2E cleanup: { users: N }` with `N` > 0 — it still deletes its own users. A run that leaks its users would show `users: 0` here.
7. On the target stage, confirm `qa-admin-e2e@test.com` and `qa-user-e2e@test.com` **still exist** after any run. These are the standing seeded QA accounts and no sweep may ever touch them.

### C. The orphan sweep

8. Create an orphan deliberately: start a run, let `globalSetup` finish creating users, then cancel the job so teardown never runs.
9. Wait >6h (or temporarily lower `STALE_SWEEP_MINUTES` in `global-setup.ts:7` for a local run — the endpoint floor of 120 min still applies), then start another run.
10. Expected: the new run's pre-run cleanup reports a non-zero `staleSwept` and the orphan is gone.
11. Expected in the same log: `staleSwept` is **0** when nothing is older than the window — the sweep must not be picking up fresh users.

### D. Tester-prefix behavior

12. Dispatch **E2E Tests (Manual)** with **Tester ID** = `alice`. Expected in the resolve step: `alice-gh<run_id>`. Two runs by the same tester no longer collide, since the run id is always appended.

### What NOT to test

- Any product surface. This PR touches only CI workflow wiring, the gated `/api/test/cleanup` endpoint, and the E2E harness.
- The cascade delete itself (which collections get cleared for a matched user) — unchanged. Only *which users match* changed.
- `e2e-ai-latency.yml` — deliberately unmodified; it already derived a non-empty per-cell id.

---

## Additional Information

**Verification performed**

- `pnpm run pre-push` (the exact husky gate: `turbo typecheck:fast` + `typecheck:infra:local`): **exit 0**, 37/37 tasks.
- `vitest run server/utils/e2eCleanupScope.test.ts`: **14/14 pass**.
- `eslint` on all four changed/added TS files: 0 errors.
- All three workflow YAMLs parse; the new step is confirmed ordered *before* `Run E2E tests`, and `bash -n` on the step body is clean.
- Resolved-id simulation for empty / `alice` / `bad-id!@#` inputs — see the table under Changes.
- Incident replay against the new logic:
  ```
  core sweep hits live ai-latency user : false (must be false)
  core sweep hits its own user         : true  (must be true)
  core sweep hits seeded QA account    : false (must be false)
  aged sweep takes a 3-min-old user    : false (must be false)
  aged sweep takes a 24h-old orphan    : true  (must be true)
  staleMinutes=0 clamps to             : 120
  ```
- No non-ASCII introduced in any changed code file (all hits are pre-existing lines).
- Confirmed no vitest test imports `cleanup.ts` or `global-setup.ts`, so the 98 pre-existing failures in the full client suite (e.g. `serverConfig.test.ts` `search_knowledge_base`) are unrelated to this change.

**Not verified**

- **No live CI run yet.** Section A above has not been executed; the fix is verified by simulation and unit tests only. This is the main gap and the reason to run A before merging.
- **The aged sweep has not run against a real database.** The `createdAt` filter is typechecked and reasoned about; nobody has watched it delete an actual orphan. Section C covers it.
- **`staleSwept` in the response shape** — no consumer asserts on it; `global-setup` only logs `cleaned.users`.

**Known limitations, accepted deliberately**

- **Local runs against a shared stage are still unscoped.** An empty `E2E_TEST_ID` remains the documented local-dev fallback, so a laptop run against dev/staging can still cause exactly this incident. Only the docs were strengthened. If QA runs against shared stages from laptops, the safer follow-up is to have `global-setup` refuse the unscoped sweep whenever `API_URL` is not localhost.
- **`e2e-on-label.yml` is the one CI path still unscoped** (`:108` runs the full suite with no `E2E_TEST_ID`). Contained rather than fixed: it is hard-pinned to `stage=pr<N>` (`:32`), `MONGODB_URI` is a per-stage SST secret templated with a `%STAGE%` placeholder so each preview has its own database, and same-PR runs are serialized by `concurrency: e2e-label-<pr>` with `cancel-in-progress: true`. Same one-step fix applies if wanted.
- **Soft-deleted orphans are unreachable.** Both queries go through the soft-delete plugin, so a soft-deleted user is invisible to them and never hard-deleted. Pre-existing for the scoped path; the sweep inherits it.
- **The 120-minute floor is coupled to workflow timeouts by convention only.** The test asserts `MIN_STALE_SWEEP_MINUTES > 90`, but nothing would catch someone raising `timeout-minutes` past 120. The effective window is 360, so there is 4x margin.
- **ai-latency's ids carry no run id** (`<model>-<spec>`), so its cross-run safety comes from the per-cell `concurrency` group serializing same-cell runs, not from unique ids. Pre-existing and still sound, but it is a different guarantee from the one this PR gives `e2e-run.yml`.

**Out of scope, noticed during triage**

- **`packages/database/src/models/auth/UserModel.ts` contains a literal NUL byte** (~offset 31600), which makes plain `grep`/`rg` silently skip the file and return empty output. This produced one false "clean" verification during this work (a `tsc | grep` check that reported nothing because grep had switched to binary mode). Anyone searching that file will be misled; worth a separate look.
- A harness-level E2E failure still reports as an empty green run — with no `pw-results.json` the parse step emits all zeros and Slack posts "0 passed, 0 failed". Unrelated to this PR but it is why an incident like this can look benign in Slack.

**Commit hygiene note**

The branch has **two commits with the identical subject** (`e95a78a9`, `4133cc09`) — the second is only the `req.query` cast that unblocked the pre-push typecheck. Worth squashing, or rewording the second, before opening the PR. CI validates the PR *title*, which drives the automatic changeset; `fix(...)` yields a patch bump either way.

---

## Developer Notes

- **An unscoped delete overrides every scoped one.** ai-latency did the careful thing — a distinct id per matrix cell, with a comment explaining why — and it made no difference, because safety here is a property of *all* participants, not of one. Any shared-stage cleanup has to be scoped everywhere or it is scoped nowhere.
- **Derive the isolation key in CI; do not accept it as optional input.** The old design put the burden on whoever clicked Run, and a blank field silently selected the most destructive behavior. Deriving `gh<run_id>` makes the safe path the only path, and encoding the run id buys traceability for free.
- **Never infer time from an id that was truncated for readability.** `Date.now().toString().slice(-8)` is a uniqueness token, not a clock. `createdAt` is the only trustworthy age signal, and it has the right failure direction: absent data means "skip", not "assume ancient".
- **Clamp destructive windows upward.** `resolveStaleSweepMinutes` raises anything below the floor rather than honoring it, so no caller — including a future one — can pass `staleMinutes=0` and resurrect the original bug through the new parameter.
- **Anchor scoped patterns.** `${testId}-[0-9]+-...` unanchored means any id that is a suffix of another matches it. One leading `-` removes the whole class of collision.
- **`grep` goes silent on binary input.** A NUL byte anywhere in the stream makes GNU grep switch to binary mode and suppress matches, so `command | grep -E "pattern"` returning nothing is not evidence of success. Check exit codes when verifying a gate.


## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
