### PR TITLE
fix(cli): stop the Hearth hook disclosing the OS username and MCP server names

### DIFF
--- a/packages/cli/bin/hearth-hook.mjs
+++ b/packages/cli/bin/hearth-hook.mjs
@@ -16,10 +16,16 @@
 // forwarded field set is an explicit tier rather than "whatever the hook
 // happened to receive". B4M_HEARTH_DISCLOSURE selects it:
 //   0 - event name, session id, session slug. Zero environment disclosure.
-//   1 - adds the workspace BASENAME (the repo name, never a full path).
-//   2 - adds non-sensitive activity state: a closed-set reason code, tool name,
-//       permission mode, effort level, tool duration, subagent type, and a
-//       background-task count. Default.
+//   1 - adds the workspace BASENAME (the repo name, never a full path), except
+//       when that basename would BE the OS username - the home directory is
+//       omitted rather than sent, since `/Users/<user>` basenames to <user>.
+//   2 - adds non-sensitive activity state: a reason code checked against the
+//       known set, a tool name that is either a plain identifier or the bare
+//       kind `mcp` (an mcp__<server>__<tool> name would otherwise disclose the
+//       configured integration), permission mode, effort level, tool duration,
+//       subagent type, and a background-task count. Default.
+// Values are VALIDATED, not merely selected: a field documented as a closed set
+// but forwarded unchecked is only a closed set until upstream adds a value.
 // No tier forwards a field the hook docs mark as content-bearing: prompt,
 // tool_input, tool_response, last_assistant_message, compact_summary,
 // custom_instructions, transcript_path, the full cwd, or the raw notification
@@ -30,7 +36,8 @@
 // newly added field cannot silently escape its tier.
 // Shipped standalone and run under bare `node`, so it stays dependency-free.
 
-import { basename } from 'node:path';
+import { basename, resolve } from 'node:path';
+import { homedir } from 'node:os';
 
 const { B4M_API_URL, B4M_API_KEY, B4M_HEARTH_CHANNEL, B4M_HEARTH_LABEL, B4M_HEARTH_DISCLOSURE } = process.env;
 
@@ -128,13 +135,16 @@ function reasonForEvent(eventName) {
  * task descriptions and commands inside it are content-bearing.
  */
 function activityOf(hook) {
-  const activity = {
-    reason:
-      typeof hook.notification_type === 'string' && hook.notification_type
-        ? hook.notification_type
-        : reasonForEvent(hook.hook_event_name),
-  };
-  if (typeof hook.tool_name === 'string' && hook.tool_name) activity.tool = hook.tool_name;
+  // notification_type is forwarded ONLY if it is a reason we actually know.
+  // REASON_PHRASES already enumerates that vocabulary, so an unknown value falls
+  // back to the event-derived code instead of passing an upstream string through.
+  const notified =
+    typeof hook.notification_type === 'string' && Object.hasOwn(REASON_PHRASES, hook.notification_type)
+      ? hook.notification_type
+      : undefined;
+  const activity = { reason: notified ?? reasonForEvent(hook.hook_event_name) };
+  const tool = toolOf(hook.tool_name);
+  if (tool) activity.tool = tool;
   if (typeof hook.permission_mode === 'string' && hook.permission_mode) {
     activity.permission_mode = hook.permission_mode;
   }
@@ -143,6 +153,55 @@ function activityOf(hook) {
   if (typeof hook.agent_type === 'string' && hook.agent_type) activity.subagent = hook.agent_type;
   if (Array.isArray(hook.background_tasks)) activity.background_tasks = hook.background_tasks.length;
   return activity;
+}
+
+/**
+ * Workspace name for tier >= 1: the basename of the session's directory, or
+ * undefined when there is no name safe to send.
+ *
+ * The HOME directory is excluded because its basename IS the OS username on
+ * macOS and Linux (`/Users/<user>`, `/home/<user>`) - and starting a session in
+ * the home directory is ordinary, so this fired on real sessions at the default
+ * tier while the file header promised "the repo name, never a full path". A
+ * filesystem root has no useful name either.
+ *
+ * What this does NOT try to solve: any basename is still a directory name the
+ * user chose, so a directory named after a client or a project discloses that
+ * name. That is the acknowledged cost of tier 1 and the reason tier 0 exists.
+ */
+function workspaceOf(cwd) {
+  if (typeof cwd !== 'string' || !cwd) return undefined;
+  const absolute = resolve(cwd);
+  let home;
+  try {
+    home = homedir();
+  } catch {
+    home = undefined;
+  }
+  if (home && absolute === resolve(home)) return undefined;
+  const name = basename(absolute);
+  // basename('/') is '' and basename('/root') is a system account, not a workspace.
+  if (!name || name === 'root') return undefined;
+  return name;
+}
+
+/**
+ * Tool names that may be forwarded verbatim vs. reduced.
+ *
+ * An MCP tool is named `mcp__<server>__<tool>`, so forwarding it verbatim
+ * disclosed every configured MCP SERVER name at the default tier - the field was
+ * documented as a closed set but was `hook.tool_name` unchecked. Reducing it to
+ * a bare `mcp` keeps the signal a roster actually wants ("it is calling out to a
+ * tool") without naming the integration. Anything else unrecognized is dropped
+ * rather than guessed at, since a built-in tool name is a short identifier and a
+ * value that is not one did not come from the closed set.
+ */
+const TOOL_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]{0,39}$/;
+
+function toolOf(toolName) {
+  if (typeof toolName !== 'string' || !toolName) return undefined;
+  if (toolName.startsWith('mcp__')) return 'mcp';
+  return TOOL_NAME_PATTERN.test(toolName) ? toolName : undefined;
 }
 
 /** Phrases for the closed reason set. Anything unrecognized degrades to a
@@ -190,7 +249,7 @@ process.stdin.on('end', async () => {
     const label = B4M_HEARTH_LABEL || `Claude Code (${slug})`;
 
     const payload = { hook_event_name: eventName, session_id: sessionId, slug };
-    const workspace = typeof hook.cwd === 'string' && hook.cwd ? basename(hook.cwd) : undefined;
+    const workspace = workspaceOf(hook.cwd);
     if (tier >= 1 && workspace) payload.workspace = workspace;
     const activity = activityOf(hook);
     if (tier >= 2) payload.activity = activity;

--- a/packages/cli/src/features/hearth/__tests__/hearthHook.test.ts
+++ b/packages/cli/src/features/hearth/__tests__/hearthHook.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { homedir } from 'node:os';
+import { basename } from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
@@ -237,6 +239,121 @@ describe('bin/hearth-hook.mjs privacy contract', () => {
       expect(text).toContain('needs permission: Bash');
       expect(text).not.toContain('deploy.sh');
       expect(JSON.stringify(body)).not.toContain('secret-project');
+    } finally {
+      close();
+    }
+  }, 15000);
+
+  it('never sends the home directory as a workspace, because its basename is the username', async () => {
+    const { port, captured, close } = await startCaptureServer();
+    try {
+      // Starting a session in $HOME is ordinary, and `/Users/<user>` or
+      // `/home/<user>` basenames to the OS USERNAME - so this fired on real
+      // sessions at the DEFAULT tier while the header promised "the repo name".
+      await runHook(HOOK_ENV(port), {
+        hook_event_name: 'Stop',
+        session_id: 'sess-123',
+        cwd: homedir(),
+      });
+
+      const body = captured.current!.body;
+      const payload = (body.machine as { payload: Record<string, unknown> }).payload;
+      expect(payload.workspace).toBeUndefined();
+      // And the username must not have reached the human line either.
+      expect(JSON.stringify(body)).not.toContain(basename(homedir()));
+    } finally {
+      close();
+    }
+  }, 15000);
+
+  it('still sends a real workspace basename', async () => {
+    const { port, captured, close } = await startCaptureServer();
+    try {
+      await runHook(HOOK_ENV(port), {
+        hook_event_name: 'Stop',
+        session_id: 'sess-123',
+        cwd: '/Users/someone/parent/my-repo',
+      });
+
+      const payload = (captured.current!.body.machine as { payload: Record<string, unknown> }).payload;
+      expect(payload.workspace).toBe('my-repo');
+    } finally {
+      close();
+    }
+  }, 15000);
+
+  it('reduces an MCP tool to a bare kind, so server names stay local', async () => {
+    const { port, captured, close } = await startCaptureServer();
+    try {
+      // mcp__<server>__<tool> disclosed every configured MCP SERVER at the
+      // default tier through a field documented as a closed set.
+      await runHook(HOOK_ENV(port), {
+        hook_event_name: 'PreToolUse',
+        session_id: 'sess-123',
+        tool_name: 'mcp__acme_internal_crm__create_ticket',
+      });
+
+      const body = captured.current!.body;
+      const activity = (body.machine as { payload: { activity: Record<string, unknown> } }).payload.activity;
+      expect(activity.tool).toBe('mcp');
+      expect(JSON.stringify(body)).not.toContain('acme_internal_crm');
+      expect(JSON.stringify(body)).not.toContain('create_ticket');
+    } finally {
+      close();
+    }
+  }, 15000);
+
+  it('drops a tool name that is not a plain identifier', async () => {
+    const { port, captured, close } = await startCaptureServer();
+    try {
+      await runHook(HOOK_ENV(port), {
+        hook_event_name: 'PreToolUse',
+        session_id: 'sess-123',
+        tool_name: 'Bash /Users/someone/secret-project/deploy.sh',
+      });
+
+      const body = captured.current!.body;
+      const activity = (body.machine as { payload: { activity: Record<string, unknown> } }).payload.activity;
+      expect(activity.tool).toBeUndefined();
+      expect(JSON.stringify(body)).not.toContain('secret-project');
+    } finally {
+      close();
+    }
+  }, 15000);
+
+  it('ignores an unrecognized notification_type instead of forwarding it', async () => {
+    const { port, captured, close } = await startCaptureServer();
+    try {
+      // The field was documented as a closed set but was forwarded unchecked, so
+      // an upstream addition (or anything else) passed straight through.
+      await runHook(HOOK_ENV(port), {
+        hook_event_name: 'Stop',
+        session_id: 'sess-123',
+        notification_type: 'BAIT-unknown-classifier',
+      });
+
+      const body = captured.current!.body;
+      const activity = (body.machine as { payload: { activity: Record<string, unknown> } }).payload.activity;
+      // Falls back to the event-derived code for Stop.
+      expect(activity.reason).toBe('turn_finished');
+      expect(JSON.stringify(body)).not.toContain('BAIT-unknown-classifier');
+    } finally {
+      close();
+    }
+  }, 15000);
+
+  it('does not treat a prototype key as a known notification_type', async () => {
+    const { port, captured, close } = await startCaptureServer();
+    try {
+      await runHook(HOOK_ENV(port), {
+        hook_event_name: 'Stop',
+        session_id: 'sess-123',
+        notification_type: 'constructor',
+      });
+
+      const activity = (captured.current!.body.machine as { payload: { activity: Record<string, unknown> } }).payload
+        .activity;
+      expect(activity.reason).toBe('turn_finished');
     } finally {
       close();
     }


### PR DESCRIPTION
# Pull Request

## Description

Two tier-boundary findings from #1093. Both were fields the hook's own header described as safe, forwarded without the check that would have made the description true.

### `basename(cwd)` is the OS username in the home directory

`/Users/<user>` and `/home/<user>` both basename to `<user>`, and starting a session in `$HOME` is ordinary rather than exotic. So the hook published the OS username at tier 1 **and at the default tier 2**, against a header that promised "the workspace BASENAME (the repo name, never a full path)".

The bait model in the existing privacy test treats `/Users/someone` as a segment that must never escape — but no case ever set `cwd` **to** that directory, so the one path where the promise broke was the one path untested.

Now the home directory is omitted entirely rather than sent, along with a filesystem root and the `/root` system account. A real workspace basename still goes through unchanged.

What this deliberately does **not** try to solve: any basename is still a directory name the user chose, so a directory named after a client or a project discloses that name. That is the acknowledged cost of tier 1 and the reason tier 0 exists. It is now stated in the header instead of implied.

### `activity.tool` and `activity.reason` were unvalidated

Both were documented as closed sets and neither was checked.

- `activity.tool` was `hook.tool_name` verbatim. An MCP tool is named `mcp__<server>__<tool>`, so **every configured integration's name** was disclosed at the default tier. It now reduces to the bare kind `mcp` — which keeps the signal a roster actually wants (this session is calling out to a tool) without naming the integration — and anything that is not a plain identifier is dropped rather than guessed at.
- `activity.reason` was `hook.notification_type` verbatim. It is now checked against `REASON_PHRASES`, which already enumerated the intended vocabulary **in the same file**, and falls back to the event-derived code otherwise. The membership test uses `Object.hasOwn`, so a prototype-named value cannot pass as known either (the same class of bug as the roster's reason table in the sibling PR).

The underlying lesson is now in the header: *a field documented as a closed set but forwarded unchecked is only a closed set until upstream adds a value.*

## Changes

- `workspaceOf(cwd)` replaces the inline `basename(hook.cwd)`, excluding `$HOME`, filesystem roots, and `/root`.
- `toolOf(toolName)` reduces `mcp__*` to `mcp` and drops non-identifier values.
- `activityOf` validates `notification_type` against `REASON_PHRASES` via `Object.hasOwn`.
- Header rewritten so each tier's description matches what the code now guarantees.
- Six new assertions in the privacy suite.

## Guide for Testers

Requires `EnableHearth` and the hook wired into `.claude/settings.json`.

1. From a shell, `cd ~` (your home directory) and start a Claude Code session there.
2. Let it hit a hook event (finish a turn — the `Stop` hook fires).
3. Open the web app → Hearth → the `agents` channel. Find that session's row.
4. Expect **no workspace name** on the row, and expect your OS username to appear **only** as part of your own account name — never as a workspace/repo label. Before this PR the row read as if your username were the repo.
5. Now `cd` into a real repo directory and start a session there. Expect the row to show that directory's name (e.g. `bike4mind`).
6. In that session, invoke any MCP tool. Expect the row's tool chip to read `mcp` — **not** `mcp__<yourserver>__<tool>`. Confirm none of your configured MCP server names appear anywhere in the channel.
7. Invoke a built-in tool (e.g. ask it to run a bash command). Expect the tool chip to name it normally (`Bash`).

**Regression checks**

8. `B4M_HEARTH_DISCLOSURE=0` — expect no workspace and no activity block, exactly as before.
9. `B4M_HEARTH_DISCLOSURE=1` — expect the workspace basename but no activity block.
10. Unset it (default tier 2) — expect workspace plus activity (reason, tool, permission mode, effort).
11. Confirm the hook still never blocks a session: kill the API URL (`B4M_API_URL=http://127.0.0.1:1`) and confirm Claude Code runs normally.

**What NOT to test**

- No server, roster-ordering, or SPA changes here.
- Tool-name reduction is hook-side; existing stored rows keep whatever they were written with.

## Additional Information

- **All five new behavior assertions fail against the previous implementation** (mutation-tested by reverting each of the three checks), so they are guards rather than restatements.
- **Not fixed here, deliberately:** this suite spawns with `...process.env`, so a developer who actually uses the hook runs it against their own `B4M_HEARTH_*` config — a real `B4M_HEARTH_CHANNEL` makes the hook send `channelId` and fails the default-channel assertion locally. That fix lives in the per-session-actor PR to keep this diff to the disclosure change. CI has no such vars; locally these pass under `env -u B4M_HEARTH_CHANNEL`.
- Verified: `pnpm turbo:typecheck` (44/44), CLI hearth suites (45), `@bike4mind/hearth` (15), `eslint` clean, `node --check` on the hook.
- One behavior change worth calling out for anyone reading rosters: existing rows written before this PR keep their old `tool` values, so a historical `mcp__<server>__<tool>` string stays in the log. The log is append-only by design; this stops new ones rather than rewriting old ones. If that matters, the affected events would need deleting, which is a separate call.
