### PR TITLE
fix(e2e): stop anchoring chat waits and credits reads on saturating counts

### DIFF
--- a/apps/client/e2e/pages/ChatPage.ts
+++ b/apps/client/e2e/pages/ChatPage.ts
@@ -6,8 +6,16 @@ export class ChatPage extends BasePage {
   readonly chatInput = this.page.getByTestId('lexical-chat-input-container');
   readonly sendButton = this.page.getByTestId('send-message-btn');
   readonly aiResponse = this.page.getByTestId('ai-response');
-  readonly creditsUsed = this.page.getByTestId('credits-used');
   readonly aiResponseRoot = this.page.getByTestId('ai-response-root-container');
+
+  /**
+   * One wrapper per AI message (MessageContent's root, `message-<id>`), holding both the reply
+   * container and the footer that carries the credits chip. The `has` filter is what makes the
+   * prefix match precise: `message-actions-menu-btn` and friends also start with `message-`.
+   */
+  private readonly aiMessage = this.page
+    .locator('[data-testid^="message-"]')
+    .filter({ has: this.page.getByTestId('ai-response-root-container') });
 
   /**
    * Text of the newest mounted reply, or '' when none is mounted.
@@ -178,21 +186,21 @@ export class ChatPage extends BasePage {
   }
 
   /**
-   * Returns the numeric credit count for the newest AI response chip, or null if not shown.
+   * Returns the numeric credit count for the newest AI reply's chip, or null if it never renders.
    *
-   * The per-message credits chip only renders once the server populates
-   * `messageData.creditsUsed`, which lags behind streaming visually completing. Reading
-   * `.last()` too early therefore returns the PREVIOUS message's already-rendered chip -
-   * a stale value that repeats across runs/models. `minCount` (the chip count captured
-   * before sending) is required so we wait for a brand-new chip to appear before reading it -
-   * a zero-arg call would silently reintroduce the stale-read bug this method exists to fix.
+   * Scoped to the newest message wrapper, NOT read off a global chip count. The chip renders in
+   * MessageContent's footer once the server populates `messageData.creditsUsed`, which lags
+   * behind streaming visually completing - so a bare `creditsUsed.last()` can return the PREVIOUS
+   * message's already-rendered chip, a stale value that repeats across runs/models. The old guard
+   * ("wait for one more chip than before sending") cannot work here: the chat list is virtualized,
+   * so the mounted chip count saturates and a later turn never exceeds the pre-send count, leaving
+   * a real measurement unread. Scoping to `aiMessage.last()` fixes both - it resolves to THIS
+   * message's chip or to nothing, with no dependence on how many chips are mounted.
    */
-  async getCreditsUsed(minCount: number): Promise<number | null> {
+  async getCreditsUsed(): Promise<number | null> {
     try {
-      // Wait for a new credits chip (beyond those present before sending) to render.
-      await expect.poll(() => this.creditsUsed.count(), { timeout: 15_000 }).toBeGreaterThan(minCount);
-      const chip = this.creditsUsed.last();
-      await chip.waitFor({ state: 'visible', timeout: 10_000 });
+      const chip = this.aiMessage.last().getByTestId('credits-used');
+      await chip.waitFor({ state: 'visible', timeout: 15_000 });
       const text = await chip.innerText();
       const match = text.match(/\d+/);
       return match ? parseInt(match[0]) : null;
@@ -210,13 +218,10 @@ export class ChatPage extends BasePage {
     text: string,
     timeout: number = TIMEOUTS.AI_RESPONSE
   ): Promise<{ responseText: string; durationSecs: number; credits: number | null }> {
-    // Capture how many credits chips exist before sending so getCreditsUsed can wait for
-    // THIS message's chip to render, rather than reading a stale prior-message value.
-    const creditsBefore = await this.creditsUsed.count();
     const startMs = Date.now();
     const responseText = await this.sendMessageAndWaitForResponse(text, timeout);
     const durationSecs = (Date.now() - startMs) / 1000;
-    const credits = await this.getCreditsUsed(creditsBefore);
+    const credits = await this.getCreditsUsed();
     return { responseText, durationSecs, credits };
   }
 

--- a/apps/client/e2e/pages/ChatPage.ts
+++ b/apps/client/e2e/pages/ChatPage.ts
@@ -9,6 +9,22 @@ export class ChatPage extends BasePage {
   readonly creditsUsed = this.page.getByTestId('credits-used');
   readonly aiResponseRoot = this.page.getByTestId('ai-response-root-container');
 
+  /**
+   * Text of the newest mounted reply, or '' when none is mounted.
+   *
+   * The count() guard is load-bearing: the config sets no `actionTimeout`, so a bare
+   * `aiResponse.last().innerText()` on an empty chat auto-waits with NO timeout and blocks
+   * until the test times out. count() never waits; the bounded innerText then covers
+   * Virtuoso unmounting the reply between the two calls.
+   */
+  private async newestResponseText(): Promise<string> {
+    if ((await this.aiResponse.count()) === 0) return '';
+    return this.aiResponse
+      .last()
+      .innerText({ timeout: TIMEOUTS.ELEMENT_STATE })
+      .catch(() => '');
+  }
+
   async sendMessage(text: string) {
     await this.typeAndWaitForSendReady(text);
     await this.page.keyboard.press('Enter');
@@ -42,22 +58,26 @@ export class ChatPage extends BasePage {
   async sendMessageAndWaitForResponse(text: string, timeout: number = TIMEOUTS.AI_RESPONSE) {
     const maxAttempts = 2;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      // Track response count before sending so we can wait for the NEW response
-      const responsesBeforeSend = await this.aiResponseRoot.count();
+      // Never anchor on a pre-send index. ChatHistory renders the reply list through
+      // react-virtuoso, so only the replies near the viewport stay mounted (3 at 1280x720):
+      // a new reply evicts the oldest instead of growing the count, and
+      // `.nth(countBeforeSend)` waits forever on an index that can never mount. Anchor on
+      // `.last()` (as waitForImageResponse does, for a different reason) and use the newest
+      // reply's pre-send text as the baseline that proves what we read back is new.
+      const previousResponse = await this.newestResponseText();
 
       await this.typeAndWaitForSendReady(text);
       await this.page.keyboard.press('Enter');
 
-      // Wait for a new ai-response element to appear (beyond those already present)
-      await expect(this.aiResponseRoot.nth(responsesBeforeSend)).toBeVisible({ timeout });
+      // Waits for the first container to mount in a fresh chat; in a resumed chat the prior
+      // turn's container already satisfies it. Newness is proven by the streaming lifecycle
+      // plus the text baseline, not by this gate.
+      await expect(this.aiResponseRoot.last()).toBeVisible({ timeout });
 
       // Wait for streaming to complete by watching for "Stop Generation" button to disappear
-      await this.waitForStreamingComplete(timeout);
+      await this.waitForStreamingComplete(timeout, previousResponse);
 
-      const responseText = await this.aiResponse
-        .last()
-        .innerText()
-        .catch(() => '');
+      const responseText = await this.newestResponseText();
 
       // Retry once if the server timed out
       if (attempt < maxAttempts && responseText.includes('request timed out')) {
@@ -69,7 +89,15 @@ export class ChatPage extends BasePage {
     return '';
   }
 
-  private async waitForStreamingComplete(timeout: number = TIMEOUTS.AI_RESPONSE) {
+  /**
+   * Waits out the stop-generation lifecycle for the message just sent.
+   *
+   * `previousResponse` is the newest reply's text captured before sending. It exists only
+   * for the "stop button never appeared" fallback: chats are resumed across tests, so a
+   * prior turn's reply is normally already mounted and a bare `aiResponse.count() > 0`
+   * check would return immediately without this turn having produced anything.
+   */
+  private async waitForStreamingComplete(timeout: number = TIMEOUTS.AI_RESPONSE, previousResponse = '') {
     const stopButton = this.page.getByTestId('stop-generation-btn');
 
     // First, wait for the stop button to appear (streaming started)
@@ -82,10 +110,10 @@ export class ChatPage extends BasePage {
       // Guard the entire block - the page may have been closed by the time we get here
       // (e.g. test timeout / context teardown), in which case all locator calls throw.
       try {
-        const hasResponse = await this.aiResponse.count();
-        if (hasResponse > 0) return;
+        const currentResponse = await this.newestResponseText();
+        if (currentResponse !== '' && currentResponse !== previousResponse) return;
 
-        // No response yet - Smart Tools likely still processing. Wait for either
+        // No new response yet - Smart Tools likely still processing. Wait for either
         // the Stop button to eventually appear or an ai-response element to show up.
         await Promise.race([
           expect(stopButton)
@@ -112,16 +140,10 @@ export class ChatPage extends BasePage {
       await expect(stopButton).toBeHidden({ timeout });
     } catch {
       // Stop button still visible - check if the response text has stabilised
-      const text1 = await this.aiResponse
-        .last()
-        .innerText()
-        .catch(() => '');
+      const text1 = await this.newestResponseText();
       if (text1.length > 0) {
         await this.page.waitForTimeout(TIMEOUTS.POST_ACTION);
-        const text2 = await this.aiResponse
-          .last()
-          .innerText()
-          .catch(() => '');
+        const text2 = await this.newestResponseText();
         if (text1 === text2) {
           // Response hasn't changed - streaming is effectively done
           return;


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="660" height="348" alt="Screenshot 2026-07-30 at 12 02 33 PM" src="https://github.com/user-attachments/assets/1fc1e800-269c-4819-b946-a035472a4f2d" />


## Description

`notebook.spec.ts:47` ("Notebook - AI Credits and Timing > Model: GPT-5.5 > run 2") has been failing intermittently on `main` with:

```
Error: expect(locator).toBeVisible() failed
Locator: getByTestId('ai-response-root-container').nth(3)
Expected: visible
Timeout: 120000ms
Error: element(s) not found
  at pages/ChatPage.ts:52
```

This is a test-harness bug, not an app regression. Every request in the trace is 200 and the reply plus its credits chip render correctly; the harness waits on a DOM index that can never exist.

The chain:

1. **All four credits runs share one notebook, by design.** The test measures the same prompt twice against each of two models within a single chat session, so `page.goto('/')` resuming the existing session (trace console: `Session resumption decision: Resume`) is intended: replies accumulate across `Claude 4.7 Opus run 1 -> run 2 -> GPT-5.5 run 1 -> run 2`. That is the comparison the test exists to make, and this PR preserves it.
2. **`ChatPage` assumed mounted count == total replies.** It captured `await this.aiResponseRoot.count()` before sending, then waited for `.nth(thatCount)` to become visible.
3. **The reply list is virtualized.** `app/components/Session/ChatHistory.tsx` renders history through react-virtuoso (`Virtuoso`, `followOutput="auto"`, plus `hooks/useVirtuosoPagination.ts`), so only replies near the viewport stay mounted - 3 containers at 1280x720. From the trace, immediately before the failing send:
   ```
   queryCount [data-testid="credits-used"]               => {"value": 3}
   queryCount [data-testid="ai-response-root-container"] => {"value": 3}
   ```
   while the session genuinely held 4 replies (`/chat?pagination[limit]=10 -> 200`).
4. **So `.nth(3)` never appears.** A new reply evicts the oldest rather than growing the list, the count stays at 3 (indices 0-2), and the assertion burns its full 120s budget.

**Why it flaps rather than always failing:** for a frame or two after a reply is appended, 4 containers can be mounted before Virtuoso evicts the oldest. If Playwright's poll lands inside that window the run passes. Runs 30448522172, 30445189577 and 30436066535 all failed on exactly `.nth(3)`; others passed, with no code change in between.

**Why it sits exactly on the boundary:** `RUNS_PER_MODEL = 2` x 2 models = 4 turns in one notebook. Turns 1-3 pass because indices 0/1/2 are inside the mounted window; turn 4 is the first that needs index 3. Retries cannot recover either, because a retry resumes the same (now longer) session. With `test.describe.configure({ mode: 'serial' })`, every later test in the group then reports "did not run".

Virtualization has been present since the initial open-core release (`473a271e`), so this is a long-standing latent harness bug that surfaces whenever the shared notebook reaches 4 turns, not a regression from a recent commit.

### The same bug, silently, in the credits read

`getCreditsUsed` gated on `expect.poll(() => this.creditsUsed.count()).toBeGreaterThan(minCount)`, where `minCount` was the chip count captured before sending - the identical pre-send-count pattern, one method over. The chip count saturates for the same reason, so a later turn can never exceed it:

| | Reply wait | Credits read |
|---|---|---|
| Pre-send capture | `aiResponseRoot.count()` | `creditsUsed.count()` |
| Gate | `.nth(count)` becomes visible | `poll(count).toBeGreaterThan(count)` |
| Under saturation | never satisfied -> 120s timeout, test **fails** | never satisfied -> 15s timeout, returns **`null`** |
| Visibility | loud | **silent** |

The credits variant was the more dangerous of the two: the suite stayed green while dropping a data point. Turn 4's credits were `null` on every run, and `buildCreditsSummary` still produced a non-null `avgCredits` from the other run, so the `afterAll` soft assertion never fired. Because the shared session is intentional, this was permanent rather than intermittent - the window is always saturated by turn 4.

This PR fixes both so they work within the shared session the test needs, rather than avoiding the shared session.

## Changes

All in `apps/client/e2e/pages/ChatPage.ts` (+43 / -21 and +22 / -17). No app code touched.

**The reply wait (`572a7939`)**

- **`sendMessageAndWaitForResponse` no longer anchors on a pre-send index.** `.nth(responsesBeforeSend)` is replaced by `aiResponseRoot.last()`, and the newest reply's pre-send text is captured as the "this reply is new" baseline instead of a pre-send `count()`.
- **The `.last()` gate is documented for what it actually proves.** In a fresh chat it waits for the first container to mount; in a resumed chat the prior turn's container already satisfies it. Newness comes from the streaming lifecycle plus the text baseline, not from that gate.
- **`waitForStreamingComplete` takes the baseline as a second argument.** Its "stop button never appeared" fallback used to early-return on `aiResponse.count() > 0`, which is always true in a resumed chat - it would have returned without this turn having produced anything. It now returns early only when the newest reply's text differs from the pre-send value. Identical consecutive answers fall through to the existing stop-button/first-response race, which resolves immediately, so no new hang path is introduced. The image path (`sendImageMessageAndWaitForResponse`) passes no baseline and keeps its previous behavior.
- **New private helper `newestResponseText()`** returns the newest mounted reply's text or `''`. It guards with `count()` before calling `innerText({ timeout: TIMEOUTS.ELEMENT_STATE })`, because this suite sets no `actionTimeout` (see Additional Information). Also applied to the two pre-existing reads in the stabilization fallback, which carried the same hazard.
- **Comments name react-virtuoso explicitly** and cross-reference `waitForImageResponse`, which already documents the `.last()` rule for a different reason ("a count captured before sending is not reliably zero"), so the index pattern does not come back.

**The credits read (`7e483eb4`)**

- **New private `aiMessage` locator** - `[data-testid^="message-"]` filtered by `has: ai-response-root-container`. One wrapper per AI message, holding both the reply container and the footer that carries the chip. The `has` filter is load-bearing: `message-actions-menu-btn`, `message-send-to-datalake` and `message-share-reply` also prefix-match `message-`, and only real message wrappers contain a reply container.
- **`getCreditsUsed()` takes no argument.** It waits for `aiMessage.last().getByTestId('credits-used')` to become visible (15s) and parses it; the `expect.poll` count gate is gone. Scoping keeps the stale-read guarantee `minCount` existed for - the chip lags streaming completion, so a bare `creditsUsed.last()` can return the previous message's chip - while removing the dependence on how many chips are mounted.
- **`sendMessageAndMeasure` no longer captures `creditsBefore`.**
- **Removed the unused public `creditsUsed` locator.** A global `credits-used` locator invites exactly the `.last()` stale read the scoping prevents. No spec referenced it.

No app change was needed for this: `MessageContent.tsx:488` already tags each message root `data-testid="message-<id>"`, and `ChatHistory.tsx:142` already sets `data-message-id` on the outer wrapper (added for scroll-to-message highlighting, `utils/chatScroll.ts:43`). Both wrap the reply container **and** the footer chip. `ChatHistory.tsx:120` also compares `messageData.id === activeStreamingQuestId`, so the streaming message carries its real id - the anchor is stable from the moment a reply mounts, not only after it completes.

## Guide for Testers

Environment: `https://app.staging.bike4mind.com` (or a PR preview). E2E harness change only - there is nothing to click through in the app.

### A. The reported failure

1. From the repo root, run: `pnpm --filter @bike4mind/client test:e2e e2e/notebook.spec.ts`
   Expected: the run completes with all `notebook.spec.ts` tests passing.
2. In the output, find the four lines of the "Notebook - AI Credits and Timing" group: `Model: Claude 4.7 Opus > run 1`, `run 2`, `Model: GPT-5.5 > run 1`, `run 2`.
   Expected: all four pass. **`GPT-5.5 > run 2` is the one that used to fail** - it is the first turn needing index 3.
3. Search the output for `nth(`.
   Expected: no match. That locator no longer exists in the harness, so any `element(s) not found` on an `ai-response-root-container` index means the fix did not take effect.
4. Check for "did not run" entries in that group, and for the soft assertion `Used Credit chip is missing for Claude 4.7 Opus!` / `... for GPT-5.5!` in `afterAll`.
   Expected: neither appears. Both were cascade effects of the primary failure.
5. Read the four per-run console lines, formatted `[<model>] Run N: <secs>s, credits: <n>`.
   Expected: four lines, **each with a numeric `credits:` value**. Before this PR the 4th read `credits: n/a`; that line is the headline result of the credits fix. Report any `n/a`.
6. Check the `afterAll` output for `Used Credit chip is missing for <model>!`.
   Expected: absent, and each model now averages **two** runs rather than one.
7. If you have a previous run to compare against, note the total time.
   Expected: roughly 15s faster - the old credits gate burned its full 15s timeout on turn 4 before giving up.

**If credits still come back `n/a`,** check the chip's render gate before filing a bug. `MessageContent.tsx:735-738` renders it only when **all** of these hold: `adminSettings.enforceCredits`, `currentUser?.showCreditsUsed`, `!isProcessingPrompt`, and `messageData.creditsUsed !== undefined`. On a stage with `enforceCredits` off, or for a user with `showCreditsUsed` off, `null` is correct behaviour and not this bug.

### B. Regression Checks

8. In the same run, confirm "Notebook CRUD > should create, rename, tag, and delete a notebook" passes.
   Why it matters: it calls `navigateToNewChat()` first, so its send happens with **zero** replies mounted - the opposite condition from A. Expected: the reply arrives and "Paris" verifies. A hang to the test timeout here is the regression signature for the reply-wait change.
9. Run: `pnpm --filter @bike4mind/client test:e2e e2e/prompts.spec.ts`
   Expected: unchanged pass. This spec sends multiple messages in one chat, exercising the multi-turn path.
10. Run: `pnpm --filter @bike4mind/client test:e2e e2e/agents.spec.ts e2e/projects.spec.ts`
    Expected: unchanged pass. Both send a single message in a fresh chat.
11. Run any spec that generates an image (the `waitForImageResponse` path).
    Expected: unchanged pass. That method was not modified, and the image send path passes no text baseline.
12. Compare the four credits values and durations from step 5 against each other.
    Expected: they differ run to run. Two runs reporting byte-identical credits **and** duration would suggest a stale read of the previous turn's reply and is worth reporting.
13. Confirm no spec fails to compile on `chatPage.creditsUsed`.
    Expected: none - that locator was removed and no spec referenced it. A TypeScript error naming it would mean a caller was missed.

### What NOT to test

- Any product surface. This PR changes only `apps/client/e2e/pages/ChatPage.ts`; no app file is touched.
- Whether the credits chip renders. It was never broken - the failing run's screenshot shows chip 40 rendered correctly at the moment of timeout.
- Whether the four credits runs share one notebook. They do, deliberately - the test compares the same prompt across two models in one chat session. A reviewer or agent "fixing" that would remove the measurement the test exists to make.

## Additional Information

**A defect found in self-review, worth reading before reviewing the diff**

`apps/client/playwright.config.ts` sets no `actionTimeout`, so locator action calls default to **no timeout** - `expect` gets 10s and the test gets `TIMEOUTS.TEST`, but `innerText()` gets neither. The first version of this fix used a bare `this.aiResponse.last().innerText().catch(() => '')` for the baseline. On a chat with zero replies that auto-waits forever and the `.catch()` never fires, because nothing ever throws. It would have hung every first turn in a fresh chat (`notebook.spec.ts:95`, `prompts.spec.ts:28`, `projects.spec.ts:129`, `agents.spec.ts:119`, `ai-latency-suite-factory.ts:56`) - trading a `.nth(3)` hang for a much broader one. The second edit had the same defect in the "stop button never appeared" fallback, where "no response yet" is precisely the case being handled; the original `count()` there was load-bearing.

That is what `newestResponseText()` exists for, and why its docstring spells out the reason: the `count()` guard reads like dead weight otherwise.

**Verification**

- Local fixture harness (not committed): a page whose reply list evicts the oldest container as a new one mounts (cap 3), with a stop-generation lifecycle, streamed text, and the real DOM shape around each message (`data-message-id` wrapper -> `message-<id>` root -> `[ai-response-root-container, message-footer[credits-used, message-actions-menu-btn]]`, chip appended 250ms after streaming ends). The prefix-colliding menu button is there on purpose, so a sloppy selector fails. Its config mirrors `playwright.config.ts` in the way that matters - test/expect timeouts, deliberately no `actionTimeout`. **9/9 pass** with both changes.
- Controls against the real file, all three run by stashing one change at a time:

  | Harness test | Pre-fix | Guard removed | Credits fix stashed | Both applied |
  |---|---|---|---|---|
  | old `.nth(countBeforeSend)` at saturation | pass (documents it) | pass | pass | pass |
  | `sendMessageAndWaitForResponse` at saturation | **fail** | pass | pass | pass |
  | 4 turns in one chat | **fail** | **fail** (60s) | pass | pass |
  | fresh chat, zero mounted replies | pass | **fail** (60s) | pass | pass |
  | unguarded `innerText` never resolves | pass | pass | pass | pass |
  | identical consecutive answers | **fail** | pass | pass | pass |
  | credits read for THIS turn at saturation | - | - | **fail** (`Expected: 40, Received: null`) | pass |
  | old count-based credits gate cannot pass | - | - | pass (documents it) | pass |
  | credits per turn across 4 turns | - | - | **fail** (`[10,20,30,null]`) | pass (`[10,20,30,40]`) |

  The pre-fix control reproduces the exact CI signature (`expect(locator).toBeVisible() failed ... Error: element(s) not found`) and fails the 4-turn case at turn 4, matching the boundary above. The credits controls log the exact cause (`[getCreditsUsed] credits chip not found: expect(received).toBeGreaterThan(expected) / Expected: > 3 / Received: 3`) and run 16.4s and 19.1s against 1.1s and 4.1s with the fix - the 15s the old poll wasted. The guard-removed control confirms the self-review defect was real rather than theoretical.
- `tsc --noEmit -p e2e/tsconfig.json`: no errors in `ChatPage.ts`. Four pre-existing `Resource.E2E_CLEANUP_SECRET` errors remain in `global-setup.ts`, `global-teardown.ts` and `helpers/api.ts` - unrelated to this change.
- `eslint` and `prettier --check` on the changed file: clean. `playwright test --list e2e/notebook.spec.ts`: all 9 tests enumerate.
- QA reports the change passing in a real Playwright run. <!-- paste the run URL here -->

**Not verified**

- The real Virtuoso window size was not measured; the mounted count of 3 comes from the trace and is hard-coded in the fixture. A different viewport or `overscan` changes that number but not the fix - `.last()` has no dependency on the window size.
- The chip's real render lag is unmeasured. The fixture models it as 250ms; the 15s budget is inherited from the previous implementation and was not re-derived from observed timing.
- The `has:`-filtered prefix selector has not run against the real DOM. It is correct by construction against `MessageContent.tsx:488`, but only a real run proves no other `message-*` testid wraps a reply container.

**Known limitations, accepted deliberately**

- `.last()` assumes the list stays bottom-anchored. `followOutput="auto"` only follows when the viewport is already at the bottom, so a spec that scrolls up mid-test and then sends would read the wrong container. Pre-existing assumption - `responseText`, `getCreditsUsed` and `waitForImageResponse` already rely on it - and no new exposure is added.
- Identical consecutive replies are indistinguishable by text, and the credits suite sends the same prompt repeatedly on purpose. That case resolves correctly (covered by the harness), but via the stop-button lifecycle rather than the baseline. See the follow-up below for what would make it provable.
- `getCreditsUsed` still returns `null` rather than throwing when the chip never renders, so a future breakage stays quiet. Deliberate - it preserves existing behaviour, and the `afterAll` soft assertion is the intended alarm - but that alarm only fires when *every* run for a model is null.

**Follow-up, not in this PR**

- **Anchor the reply wait on the message id too, not just the credits read.** Capture the last `data-message-id` before sending, wait for a different one, then scope the reply text to that specific message. Newness becomes provable by identity rather than inferred from a text change plus the stop-button lifecycle - which matters here because the suite sends the same prompt twice per model on purpose, so reply text can legitimately repeat. Left out deliberately: it would rewrite the reply wait a second time, and the current one is already verified passing. No app change is needed for it either - the ids are already in the DOM.

**Unrelated flake seen in the same run**

`auth.spec.ts:52` "logs in via the full OTC flow" failed on `not.toHaveURL(/.*login.*/)` and passed on retry #1. Not addressed here.

## Developer Notes (Optional)

- **A pre-send count means nothing against a virtualized list.** `count()` returns *mounted* elements, not list length, so both `count()` -> `.nth(count)` and `count()` -> "wait for more than count" are latent failures that only fire once the list outgrows the window. This PR removes both instances; worth grepping for others.
- **A saturating counter fails twice: loudly and silently.** The same pattern produced a 120s timeout in the reply wait and a quiet `null` in the credits read. The quiet one survived longer precisely because the suite stayed green.
- **Scope to the owning element instead of counting siblings.** "Wait for one more than before" needs a stable total; a windowed list has none. "Read the chip inside this message" needs no total at all.
- **Check for an existing anchor before proposing a new attribute.** The original triage recommended adding `data-message-id` to the reply container; the app had already shipped both that attribute (`ChatHistory.tsx:142`) and a `message-<id>` testid (`MessageContent.tsx:488`). Cheap to check, and it turned a proposed app change into a harness-only one.
- **Prefix selectors need a containment filter.** `[data-testid^="message-"]` also matches three button testids in the same subtree; `filter({ has: ... })` is what makes it precise.
- **Prefer `.last()` plus a lifecycle signal over positional anchors.** `waitForImageResponse` had already reached this conclusion for an unrelated reason; the second, stronger reason is now recorded next to it in both places.
- **Locator reads are unbounded in this suite.** With no `actionTimeout`, a read on a missing element waits forever instead of throwing, so a `.catch()` fallback is dead code and the "safe" path becomes a hang. `count()` is the only read that returns immediately on an empty set. `newestResponseText()` is the reusable shape for "read the newest reply, tolerate none".
- **When removing a check, account for what it was proving.** The old index gate was weak, but it was the only thing proving newness; dropping it silently moved that burden onto a fallback that early-returned on "any reply exists" - true in every resumed chat.


## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no settings added
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, no doc-visible behavior change
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry change
