### PR TITLE
feat(admin): partner signup rules can auto-add verified signups to an organization

### DIFF
--- a/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
+++ b/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
@@ -27,6 +27,7 @@ import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import HandshakeIcon from '@mui/icons-material/Handshake';
+import GroupAddIcon from '@mui/icons-material/GroupAdd';
 import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -38,6 +39,11 @@ import {
   createPartnerSignupRule,
   updatePartnerSignupRule,
   deletePartnerSignupRule,
+  searchOrganizations,
+  fetchOrganizationById,
+  previewPartnerRuleBackfill,
+  runPartnerRuleBackfill,
+  type OrganizationOption,
 } from '@client/app/utils/partnerSignupRuleAPICalls';
 
 // Options for the entitlements picker; spread to a mutable array for Joy Autocomplete.
@@ -53,6 +59,10 @@ type FormState = {
   signupCredits: string;
   notes: string;
   enabled: boolean;
+  // `organizationId` is the value persisted; `organization` carries the name so the picker can
+  // render the current selection (seeded async when editing a rule that already has an org).
+  organizationId: string | null;
+  organization: OrganizationOption | null;
 };
 
 const emptyForm: FormState = {
@@ -62,6 +72,8 @@ const emptyForm: FormState = {
   signupCredits: '0',
   notes: '',
   enabled: true,
+  organizationId: null,
+  organization: null,
 };
 
 const ruleToForm = (rule: IPartnerSignupRuleDocument): FormState => ({
@@ -71,6 +83,8 @@ const ruleToForm = (rule: IPartnerSignupRuleDocument): FormState => ({
   signupCredits: String(rule.signupCredits ?? 0),
   notes: rule.notes ?? '',
   enabled: rule.enabled,
+  organizationId: rule.organizationId ?? null,
+  organization: null,
 });
 
 export default function PartnerSignupRulesTab() {
@@ -105,6 +119,9 @@ export default function PartnerSignupRulesTab() {
         label: form.label.trim(),
         notes: form.notes.trim(),
         enabled: form.enabled,
+        // Send null (not undefined) so clearing the org association is a real update - the API
+        // $sets keys it receives, and JSON drops undefined, so undefined would be un-clearable.
+        organizationId: form.organizationId,
       };
       if (editing) {
         return updatePartnerSignupRule(editing.id, payload);
@@ -140,6 +157,36 @@ export default function PartnerSignupRulesTab() {
     onError: (error: unknown) => toast.error(extractApiError(error)),
   });
 
+  // Org picker: debounced name search, only queried while the modal is open. The Autocomplete
+  // input stays uncontrolled so it shows the selected org's label; onInputChange feeds the search.
+  const { debouncedValue: orgSearch, setValue: setOrgSearchInput } = useDebounceValue('');
+  const { data: orgOptions = [], isFetching: orgOptionsLoading } = useQuery({
+    queryKey: ['org-search', orgSearch],
+    queryFn: () => searchOrganizations(orgSearch),
+    enabled: modalOpen,
+  });
+
+  // Backfill: the rule whose existing users we're sweeping into its org (null = closed).
+  const [backfillTarget, setBackfillTarget] = useState<IPartnerSignupRuleDocument | null>(null);
+  const { data: backfillPreview, isPending: backfillPreviewLoading } = useQuery({
+    queryKey: ['partner-rule-backfill-preview', backfillTarget?.id],
+    queryFn: () => previewPartnerRuleBackfill(backfillTarget!.id),
+    enabled: !!backfillTarget,
+  });
+  const backfillMutation = useMutation({
+    mutationFn: (rule: IPartnerSignupRuleDocument) => runPartnerRuleBackfill(rule.id),
+    onSuccess: result => {
+      setBackfillTarget(null);
+      toast.success(
+        `Backfill complete: ${result.added} added` +
+          (result.alreadyMember ? `, ${result.alreadyMember} already members` : '') +
+          (result.atCapacity ? `, ${result.atCapacity} skipped (org full)` : '') +
+          (result.failed ? `, ${result.failed} failed` : '')
+      );
+    },
+    onError: (error: unknown) => toast.error(extractApiError(error)),
+  });
+
   const openCreate = () => {
     setEditing(null);
     setForm(emptyForm);
@@ -152,6 +199,17 @@ export default function PartnerSignupRulesTab() {
     setForm(ruleToForm(rule));
     setFormError(null);
     setModalOpen(true);
+    // Seed the picker's selected label. The rule stores only the id, so fetch the org name;
+    // guard against a since-deleted org (fetch returns null) by leaving the picker empty.
+    if (rule.organizationId) {
+      fetchOrganizationById(rule.organizationId)
+        .then(org => {
+          if (org) setForm(f => (f.organizationId === org.id ? { ...f, organization: org } : f));
+        })
+        .catch(() => {
+          /* non-fatal: the id still saves; only the display label is missing */
+        });
+    }
   };
 
   const rules = data?.data ?? [];
@@ -172,8 +230,9 @@ export default function PartnerSignupRulesTab() {
             )}
           </Stack>
           <Typography level="body-sm" sx={{ color: 'text.tertiary', maxWidth: 620 }}>
-            Auto-grant entitlements and a one-time signup-credit bonus to anyone who registers with a verified email on
-            a partner domain. Applied at email verification; disabled rules confer nothing.
+            Auto-grant entitlements, a one-time signup-credit bonus, and optional organization membership to anyone who
+            registers with a verified email on a partner domain. Applied at email verification; disabled rules confer
+            nothing.
           </Typography>
         </Box>
         <Button startDecorator={<AddIcon />} onClick={openCreate} data-testid="partner-rule-add-btn">
@@ -234,8 +293,9 @@ export default function PartnerSignupRulesTab() {
                 <th>Label</th>
                 <th>Entitlements</th>
                 <th style={{ width: 140, textAlign: 'right' }}>Signup credits</th>
+                <th style={{ width: 90, textAlign: 'center' }}>Org</th>
                 <th style={{ width: 90, textAlign: 'center' }}>Enabled</th>
-                <th style={{ width: 110, textAlign: 'right' }}>Actions</th>
+                <th style={{ width: 150, textAlign: 'right' }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -284,6 +344,24 @@ export default function PartnerSignupRulesTab() {
                       )}
                     </td>
                     <td style={{ textAlign: 'center' }}>
+                      {rule.organizationId ? (
+                        <Tooltip title="Verified signups on this domain are auto-added to an organization">
+                          <Chip
+                            size="sm"
+                            variant="soft"
+                            color="success"
+                            data-testid={`partner-rule-org-${rule.domain}`}
+                          >
+                            linked
+                          </Chip>
+                        </Tooltip>
+                      ) : (
+                        <Typography level="body-xs" sx={{ color: 'neutral.400' }}>
+                          -
+                        </Typography>
+                      )}
+                    </td>
+                    <td style={{ textAlign: 'center' }}>
                       <Tooltip title={rule.enabled ? 'Enabled - click to disable' : 'Disabled - click to enable'}>
                         <Switch
                           size="sm"
@@ -297,6 +375,19 @@ export default function PartnerSignupRulesTab() {
                     </td>
                     <td style={{ textAlign: 'right' }}>
                       <Stack direction="row" spacing={0.5} justifyContent="flex-end">
+                        {rule.organizationId && (
+                          <Tooltip title="Backfill existing verified users into the organization">
+                            <IconButton
+                              size="sm"
+                              variant="plain"
+                              color="success"
+                              onClick={() => setBackfillTarget(rule)}
+                              data-testid={`partner-rule-backfill-${rule.domain}`}
+                            >
+                              <GroupAddIcon />
+                            </IconButton>
+                          </Tooltip>
+                        )}
                         <Tooltip title="Edit">
                           <IconButton
                             size="sm"
@@ -410,6 +501,27 @@ export default function PartnerSignupRulesTab() {
             </FormControl>
 
             <FormControl>
+              <FormLabel>Organization</FormLabel>
+              <Autocomplete
+                placeholder="Search organizations by name..."
+                options={orgOptions}
+                value={form.organization}
+                loading={orgOptionsLoading}
+                getOptionLabel={option => option.name}
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+                onInputChange={(_event, value) => setOrgSearchInput(value)}
+                onChange={(_event, value) =>
+                  setForm(f => ({ ...f, organization: value, organizationId: value?.id ?? null }))
+                }
+                data-testid="partner-rule-org-input"
+              />
+              <FormHelperText>
+                Optional. Verified signups on this domain are auto-added to this organization as members. Existing users
+                are not touched - use the backfill action for those. Leave empty for no org.
+              </FormHelperText>
+            </FormControl>
+
+            <FormControl>
               <FormLabel>Notes</FormLabel>
               <Textarea
                 minRows={2}
@@ -490,6 +602,69 @@ export default function PartnerSignupRulesTab() {
               data-testid="partner-rule-delete-confirm-btn"
             >
               Delete rule
+            </Button>
+          </Stack>
+        </ModalDialog>
+      </Modal>
+
+      {/* Backfill: preview (dry-run) then confirm */}
+      <Modal open={!!backfillTarget} onClose={() => setBackfillTarget(null)}>
+        <ModalDialog sx={{ minWidth: 440, maxWidth: 540 }} data-testid="partner-rule-backfill-modal">
+          <ModalClose />
+          <Typography level="h4" startDecorator={<GroupAddIcon />}>
+            Backfill into organization
+          </Typography>
+          <Divider sx={{ my: 1 }} />
+          <Typography level="body-sm">
+            Add existing <b>verified</b> users on <b>{backfillTarget?.domain}</b> to this rule&apos;s organization.
+            Users already in the org are skipped, and no one is ever removed.
+          </Typography>
+
+          {backfillPreviewLoading ? (
+            <LinearProgress sx={{ my: 2 }} />
+          ) : (
+            <Sheet
+              variant="soft"
+              sx={{ borderRadius: 'sm', p: 2, my: 1.5 }}
+              data-testid="partner-rule-backfill-preview"
+            >
+              <Typography level="title-md">
+                {backfillPreview?.matched ?? 0} user{(backfillPreview?.matched ?? 0) === 1 ? '' : 's'} will be added
+              </Typography>
+              {!!backfillPreview?.sample.length && (
+                <Stack spacing={0.25} sx={{ mt: 1, maxHeight: 180, overflow: 'auto' }}>
+                  {backfillPreview.sample.map(user => (
+                    <Typography key={user.id} level="body-xs" sx={{ color: 'text.tertiary' }}>
+                      {user.email || user.name}
+                    </Typography>
+                  ))}
+                  {backfillPreview.matched > backfillPreview.sample.length && (
+                    <Typography level="body-xs" sx={{ color: 'neutral.400' }}>
+                      + {backfillPreview.matched - backfillPreview.sample.length} more
+                    </Typography>
+                  )}
+                </Stack>
+              )}
+            </Sheet>
+          )}
+
+          <Stack direction="row" justifyContent="flex-end" spacing={1} sx={{ mt: 1 }}>
+            <Button
+              variant="plain"
+              color="neutral"
+              onClick={() => setBackfillTarget(null)}
+              data-testid="partner-rule-backfill-cancel-btn"
+            >
+              Cancel
+            </Button>
+            <Button
+              color="success"
+              loading={backfillMutation.isPending}
+              disabled={backfillPreviewLoading || !backfillPreview?.matched}
+              onClick={() => backfillTarget && backfillMutation.mutate(backfillTarget)}
+              data-testid="partner-rule-backfill-confirm-btn"
+            >
+              Add {backfillPreview?.matched ?? 0} user{(backfillPreview?.matched ?? 0) === 1 ? '' : 's'}
             </Button>
           </Stack>
         </ModalDialog>

--- a/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
+++ b/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
@@ -616,8 +616,9 @@ export default function PartnerSignupRulesTab() {
           </Typography>
           <Divider sx={{ my: 1 }} />
           <Typography level="body-sm">
-            Add existing <b>verified</b> users on <b>{backfillTarget?.domain}</b> to this rule&apos;s organization.
-            Users already in the org are skipped, and no one is ever removed.
+            Add existing <b>verified</b> users on <b>{backfillTarget?.domain}</b>
+            {' to '}
+            this rule&apos;s organization. Users already in the org are skipped, and no one is ever removed.
           </Typography>
 
           {backfillPreviewLoading ? (

--- a/apps/client/app/utils/partnerSignupRuleAPICalls.ts
+++ b/apps/client/app/utils/partnerSignupRuleAPICalls.ts
@@ -27,3 +27,54 @@ export const deletePartnerSignupRule = async (id: string) => {
   const response = await api.delete<{ success: boolean }>(`${BASE}/${id}`);
   return response.data;
 };
+
+/** Minimal org shape the rule form needs: an id to store, a name to display. */
+export type OrganizationOption = { id: string; name: string };
+
+/** Search organizations by name for the rule's org picker (admin-scoped list endpoint). */
+export const searchOrganizations = async (query: string): Promise<OrganizationOption[]> => {
+  const response = await api.get<{ data: OrganizationOption[] }>('/api/organizations', {
+    params: { query, pagination: { page: 1, limit: 20 } },
+  });
+  return response.data.data.map(({ id, name }) => ({ id, name }));
+};
+
+/** Fetch a single org (to seed the picker's selected label when editing a rule with an org). */
+export const fetchOrganizationById = async (id: string): Promise<OrganizationOption | null> => {
+  const response = await api.get<OrganizationOption>(`/api/organizations/${id}`);
+  return response.data ? { id: response.data.id, name: response.data.name } : null;
+};
+
+export type BackfillPreview = {
+  dryRun: true;
+  organizationId: string;
+  domain: string;
+  matched: number;
+  sample: Array<{ id: string; email?: string; name: string }>;
+};
+
+export type BackfillResult = {
+  dryRun: false;
+  organizationId: string;
+  domain: string;
+  matched: number;
+  added: number;
+  alreadyMember: number;
+  atCapacity: number;
+  unverified: number;
+  failed: number;
+};
+
+const BACKFILL = `${BASE}/backfill`;
+
+/** Preview (dry-run) which existing verified-domain users would be added to the rule's org. */
+export const previewPartnerRuleBackfill = async (id: string): Promise<BackfillPreview> => {
+  const response = await api.post<BackfillPreview>(BACKFILL, { id, commit: false });
+  return response.data;
+};
+
+/** Commit the backfill: add the matched users to the rule's org. */
+export const runPartnerRuleBackfill = async (id: string): Promise<BackfillResult> => {
+  const response = await api.post<BackfillResult>(BACKFILL, { id, commit: true });
+  return response.data;
+};

--- a/apps/client/pages/api/admin/partner-signup-rules/[id].ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/[id].ts
@@ -5,6 +5,7 @@ import { NotFoundError } from '@bike4mind/utils';
 import { partnerSignupRuleRepository } from '@bike4mind/database';
 import { updatePartnerSignupRuleSchema } from '@bike4mind/common';
 import { invalidatePartnerRuleCache, assertKnownEntitlements } from '@server/entitlements/partnerRules';
+import { assertOrganizationExists } from '@server/entitlements/assertOrganizationExists';
 import { z } from 'zod';
 
 interface RequestQuery {
@@ -29,6 +30,8 @@ const handler = baseApi()
       }
       // Only present on a partial update that touches entitlements.
       if (data.entitlements) assertKnownEntitlements(data.entitlements);
+      // Present (and non-null) only when the update sets/changes the org association.
+      if (data.organizationId) await assertOrganizationExists(data.organizationId);
 
       const updated = await partnerSignupRuleRepository.update({ id, ...data });
       // Null => the row was deleted between check and write (or never existed). 404 rather

--- a/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
@@ -1,0 +1,107 @@
+import { baseApi } from '@server/middlewares/baseApi';
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { BadRequestError, ensureAdmin } from '@server/utils/errors';
+import { NotFoundError } from '@bike4mind/utils';
+import { partnerSignupRuleRepository, userRepository, organizationRepository } from '@bike4mind/database';
+import { organizationService } from '@bike4mind/services';
+import { assertOrganizationExists } from '@server/entitlements/assertOrganizationExists';
+import { escapeRegex } from '@bike4mind/utils/escapeRegex';
+import { z } from 'zod';
+
+/**
+ * Backfill existing verified users on a rule's domain into its associated organization.
+ *
+ * Dry-run by default (`commit: false`): returns the count + a sample of who WOULD be added,
+ * so the admin previews the blast radius before committing - a bulk membership mutation is
+ * not a one-click action. `commit: true` runs the same resolution and adds each candidate via
+ * the shared `applyPartnerRuleMembership` (idempotent, seat-aware, additive). Re-runnable.
+ */
+const backfillSchema = z.object({
+  id: z.string().min(1),
+  commit: z.boolean().default(false),
+});
+
+const SAMPLE_LIMIT = 25;
+
+const handler = baseApi().post(
+  asyncHandler(async (req, res) => {
+    ensureAdmin(req.user?.isAdmin);
+
+    let body: z.infer<typeof backfillSchema>;
+    try {
+      body = backfillSchema.parse(req.body);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new BadRequestError(error.issues.map(e => `${e.path.join('.') || 'value'}: ${e.message}`).join('; '));
+      }
+      throw error;
+    }
+
+    const rule = await partnerSignupRuleRepository.findById(body.id);
+    if (!rule) throw new NotFoundError('Partner signup rule not found');
+    if (!rule.organizationId) {
+      throw new BadRequestError('This rule has no associated organization to backfill into');
+    }
+    await assertOrganizationExists(rule.organizationId);
+
+    // Verified users whose email ends in @<domain>. Anchored + escaped so `partner.com`
+    // can't match `notpartner.com` or a `partner.com.evil.co` substring.
+    const domainPattern = `@${escapeRegex(rule.domain)}$`;
+    const domainUsers = await userRepository.find({
+      email: { $regex: domainPattern, $options: 'i' },
+      emailVerified: true,
+    });
+
+    // Membership truth is the org's users[] ACL. Anyone already there is skipped up front so
+    // the preview count reflects only real additions.
+    const organization = await organizationRepository.findById(rule.organizationId);
+    const memberIds = new Set((organization?.users ?? []).map(u => u.userId));
+    const candidates = domainUsers.filter(u => !memberIds.has(u.id));
+
+    if (!body.commit) {
+      return res.status(200).json({
+        dryRun: true,
+        organizationId: rule.organizationId,
+        domain: rule.domain,
+        matched: candidates.length,
+        sample: candidates.slice(0, SAMPLE_LIMIT).map(u => ({ id: u.id, email: u.email, name: u.name })),
+      });
+    }
+
+    const tally = { added: 0, alreadyMember: 0, atCapacity: 0, unverified: 0, failed: 0 };
+    for (const candidate of candidates) {
+      try {
+        const result = await organizationService.applyPartnerRuleMembership(
+          { userId: candidate.id, organizationId: rule.organizationId },
+          { db: { users: userRepository, organizations: organizationRepository }, logger: req.logger }
+        );
+        if (result.added) tally.added += 1;
+        else if (result.reason === 'already-member') tally.alreadyMember += 1;
+        else if (result.reason === 'at-capacity') tally.atCapacity += 1;
+        else tally.unverified += 1; // 'unverified' | 'org-missing' | 'user-missing' - candidate was verified, so effectively a skip
+      } catch (error) {
+        tally.failed += 1;
+        req.logger.error(
+          `Partner-rule backfill failed for user ${candidate.id} into org ${rule.organizationId}`,
+          error
+        );
+      }
+    }
+
+    return res.status(200).json({
+      dryRun: false,
+      organizationId: rule.organizationId,
+      domain: rule.domain,
+      matched: candidates.length,
+      ...tally,
+    });
+  })
+);
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/apps/client/pages/api/admin/partner-signup-rules/index.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/index.ts
@@ -4,6 +4,7 @@ import { BadRequestError, ensureAdmin } from '@server/utils/errors';
 import { partnerSignupRuleRepository } from '@bike4mind/database';
 import { createPartnerSignupRuleSchema } from '@bike4mind/common';
 import { invalidatePartnerRuleCache, assertKnownEntitlements } from '@server/entitlements/partnerRules';
+import { assertOrganizationExists } from '@server/entitlements/assertOrganizationExists';
 import { z } from 'zod';
 
 const listQuerySchema = z.object({
@@ -44,6 +45,7 @@ const handler = baseApi()
         toBadRequest(error);
       }
       assertKnownEntitlements(data.entitlements);
+      await assertOrganizationExists(data.organizationId);
 
       // Fast, friendly duplicate check. This is a TOCTOU pre-check, not the guarantee - the
       // unique domain index is (see the create catch below).

--- a/apps/client/pages/api/email/verify.ts
+++ b/apps/client/pages/api/email/verify.ts
@@ -5,9 +5,10 @@ import {
   adminSettingsRepository,
   creditLotRepository,
   creditTransactionRepository,
+  organizationRepository,
 } from '@bike4mind/database';
 import { baseApi } from '@server/middlewares/baseApi';
-import { userService, creditService } from '@bike4mind/services';
+import { userService, creditService, organizationService } from '@bike4mind/services';
 import { CreditHolderType, PENDING_FREE_CREDITS_TAG, settingsMap } from '@bike4mind/common';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { csrfProtection } from '@server/middlewares/csrfProtection';
@@ -140,11 +141,15 @@ const handler = baseApi({ auth: false })
       // with 0 bonus credits without falling through to the env amount.
       let domainGrantKeys = new Set<string>();
       let signupCredits = 0;
+      // Only a DB-backed PartnerSignupRule can confer org membership (the env registry has
+      // no org concept), so this stays null unless a rule matched with an organizationId.
+      let partnerOrganizationId: string | null = null;
       if (userBeforeVerify) {
         const partnerGrant = await partnerSignupGrantForEmail(userBeforeVerify.email, true);
         if (partnerGrant.matched) {
           domainGrantKeys = partnerGrant.entitlements;
           signupCredits = partnerGrant.signupCredits;
+          partnerOrganizationId = partnerGrant.organizationId;
         } else {
           domainGrantKeys = entitlementsForEmail(userBeforeVerify.email, true);
           signupCredits = signupCreditsForKeys(domainGrantKeys);
@@ -188,6 +193,37 @@ const handler = baseApi({ auth: false })
           // Deliberately swallow: verification succeeded; re-throwing would show the user
           // "Verification Failed" despite the success. The stable transactionId lets an
           // admin/maintenance flow retry the grant without re-issuing an email token.
+        }
+      }
+
+      // Phase 2c: auto-add to the partner rule's organization. A DB rule may point a
+      // verified domain at an org; membership is derive-on-write (unlike entitlements),
+      // so it happens here, right after verification proves the email. applyPartnerRuleMembership
+      // re-reads the now-verified user, is idempotent, and never removes anyone. Own try/catch
+      // so a failure can't skip the audit below or 500 an already-successful verification.
+      if (userBeforeVerify && partnerOrganizationId) {
+        try {
+          const result = await organizationService.applyPartnerRuleMembership(
+            { userId: userBeforeVerify.id, organizationId: partnerOrganizationId },
+            { db: { users: userRepository, organizations: organizationRepository }, logger: req.logger }
+          );
+          if (result.added) {
+            req.logger.info(
+              `Partner-rule org membership: added verified user ${userBeforeVerify.id} to org ${partnerOrganizationId}`
+            );
+          } else if (result.reason === 'org-missing' || result.reason === 'at-capacity') {
+            // Surfaces a misconfiguration (dangling org ref / full org) without failing verification.
+            req.logger.warn(
+              `Partner-rule org membership not applied for user ${userBeforeVerify.id} ` +
+                `(org ${partnerOrganizationId}): ${result.reason}`
+            );
+          }
+        } catch (membershipError) {
+          req.logger.error(
+            `Email verified for user ${userBeforeVerify.id} but partner-rule org auto-add failed ` +
+              `(org ${partnerOrganizationId}); membership is idempotent so a retry is safe`,
+            membershipError
+          );
         }
       }
 

--- a/apps/client/pages/api/organizations/[id]/index.ts
+++ b/apps/client/pages/api/organizations/[id]/index.ts
@@ -1,6 +1,8 @@
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { organizationRepository } from '@bike4mind/database/infra';
+import { partnerSignupRuleRepository } from '@bike4mind/database';
+import { invalidatePartnerRuleCache } from '@server/entitlements/partnerRules';
 import { organizationService } from '@bike4mind/services';
 import { toSafeOrganization } from '@bike4mind/common';
 import { Request } from 'express';
@@ -68,6 +70,12 @@ const handler = baseApi()
         },
       }
     );
+
+    // Clear the dangling reference from any partner signup rule that pointed at this org, so
+    // no future signup resolves to a deleted org. The rule survives (its entitlements/credits
+    // still apply); only the org association is dropped. Cache invalidation makes it immediate.
+    await partnerSignupRuleRepository.updateMany({ organizationId: id }, { organizationId: null });
+    invalidatePartnerRuleCache();
 
     return res.json({ id });
   });

--- a/apps/client/pages/api/otc/verify.ts
+++ b/apps/client/pages/api/otc/verify.ts
@@ -13,8 +13,9 @@ import {
   subscriberRepository,
   creditTransactionRepository,
   pendingOtcTokenRepository,
+  organizationRepository,
 } from '@bike4mind/database';
-import { creditService, userService } from '@bike4mind/services';
+import { creditService, userService, organizationService } from '@bike4mind/services';
 import { entitlementsForEmail, signupCreditsForKeys } from '@client/lib/entitlements/registry';
 import { partnerSignupGrantForEmail } from '@server/entitlements/partnerRules';
 import { baseApi } from '@server/middlewares/baseApi';
@@ -331,8 +332,10 @@ const handler = baseApi({ auth: false })
     // Wrapped whole (resolve + grant) so a failure can't 500 a completed registration: the
     // account exists and the client already holds a token, the same post-rotation invariant as
     // the analytics call below. The stable transactionId makes an admin/maintenance retry safe.
+    let partnerOrganizationId: string | null = null;
     try {
       const partnerGrant = await partnerSignupGrantForEmail(normalizedEmail, true);
+      partnerOrganizationId = partnerGrant.matched ? partnerGrant.organizationId : null;
       const signupCredits = partnerGrant.matched
         ? partnerGrant.signupCredits
         : signupCreditsForKeys(entitlementsForEmail(normalizedEmail, true));
@@ -360,6 +363,35 @@ const handler = baseApi({ auth: false })
           `idempotent transactionId domain-grant-credits:${newUser.id} makes a retry safe`,
         grantError
       );
+    }
+
+    // Partner-rule org auto-add (mirrors /api/email/verify Phase 2c). registerViaOTC set
+    // emailVerified=true, so a DB rule may place this signup into an org. Idempotent, additive,
+    // and never removes anyone. Wrapped so a failure can't 500 a completed registration; the
+    // membership write is safe to retry. Reflect the join on the returned user so the client
+    // sees the org immediately.
+    if (partnerOrganizationId) {
+      try {
+        const result = await organizationService.applyPartnerRuleMembership(
+          { userId: newUser.id, organizationId: partnerOrganizationId },
+          { db: { users: userRepository, organizations: organizationRepository }, logger: req.logger }
+        );
+        if (result.added) {
+          newUser.organizationId = partnerOrganizationId;
+          req.logger.info(`Partner-rule org membership: added OTC user ${newUser.id} to org ${partnerOrganizationId}`);
+        } else if (result.reason === 'org-missing' || result.reason === 'at-capacity') {
+          req.logger.warn(
+            `Partner-rule org membership not applied for OTC user ${newUser.id} ` +
+              `(org ${partnerOrganizationId}): ${result.reason}`
+          );
+        }
+      } catch (membershipError) {
+        req.logger.error(
+          `OTC registration succeeded for user ${newUser.id} but partner-rule org auto-add failed ` +
+            `(org ${partnerOrganizationId}); membership is idempotent so a retry is safe`,
+          membershipError
+        );
+      }
     }
 
     // Analytics only - the account already exists, so a counter-write failure must not 500 a

--- a/apps/client/server/entitlements/assertOrganizationExists.ts
+++ b/apps/client/server/entitlements/assertOrganizationExists.ts
@@ -1,0 +1,16 @@
+import { organizationRepository } from '@bike4mind/database';
+import { BadRequestError } from '@server/utils/errors';
+
+/**
+ * Guard for the admin partner-signup-rule routes: a rule may only reference an org that
+ * exists. Zod validates the id SHAPE; this is the DB existence check it can't do. A `null`
+ * id (clearing the association) is always allowed. Shared by create, update, and backfill so
+ * the check can't drift between them.
+ */
+export async function assertOrganizationExists(organizationId: string | null | undefined): Promise<void> {
+  if (!organizationId) return;
+  const organization = await organizationRepository.findById(organizationId);
+  if (!organization) {
+    throw new BadRequestError(`Organization ${organizationId} not found`);
+  }
+}

--- a/apps/client/server/entitlements/partnerRules.test.ts
+++ b/apps/client/server/entitlements/partnerRules.test.ts
@@ -53,6 +53,16 @@ describe('partnerRules resolver', () => {
     const grant = await partnerSignupGrantForEmail('a@other.com', true);
     expect(grant.matched).toBe(false);
     expect(grant.signupCredits).toBe(0);
+    expect(grant.organizationId).toBeNull();
+  });
+
+  it('signup grant carries the rule organizationId when set, and null when absent', async () => {
+    mockFindActiveRules.mockResolvedValue([{ ...RULE, organizationId: 'org-123' }]);
+    expect((await partnerSignupGrantForEmail('a@partner.com', true)).organizationId).toBe('org-123');
+
+    invalidatePartnerRuleCache();
+    mockFindActiveRules.mockResolvedValue([RULE]); // no organizationId on the rule
+    expect((await partnerSignupGrantForEmail('a@partner.com', true)).organizationId).toBeNull();
   });
 
   it('caches the rule set so repeated resolutions hit the DB once', async () => {

--- a/apps/client/server/entitlements/partnerRules.ts
+++ b/apps/client/server/entitlements/partnerRules.ts
@@ -24,6 +24,8 @@ import { BadRequestError } from '@server/utils/errors';
 type ResolvedRule = {
   entitlements: EntitlementKey[];
   signupCredits: number;
+  /** Org a verified signup on this domain is auto-added to, or null. */
+  organizationId: string | null;
 };
 
 /** How long a loaded rule set is trusted before a refresh (ms). */
@@ -47,6 +49,7 @@ async function loadRules(): Promise<Map<string, ResolvedRule>> {
     map.set(domain, {
       entitlements: rule.entitlements.map(normalizeTag).filter(Boolean),
       signupCredits: rule.signupCredits ?? 0,
+      organizationId: rule.organizationId ?? null,
     });
   }
   cache = { rules: map, loadedAt: Date.now() };
@@ -138,12 +141,18 @@ export async function partnerEntitlementsForEmail(
 export async function partnerSignupGrantForEmail(
   email: string | null | undefined,
   emailVerified: boolean | null | undefined
-): Promise<{ matched: boolean; entitlements: Set<EntitlementKey>; signupCredits: number }> {
+): Promise<{
+  matched: boolean;
+  entitlements: Set<EntitlementKey>;
+  signupCredits: number;
+  organizationId: string | null;
+}> {
   const rule = await ruleForEmail(email, emailVerified);
-  if (!rule) return { matched: false, entitlements: new Set(), signupCredits: 0 };
+  if (!rule) return { matched: false, entitlements: new Set(), signupCredits: 0, organizationId: null };
   return {
     matched: true,
     entitlements: new Set(rule.entitlements),
     signupCredits: rule.signupCredits,
+    organizationId: rule.organizationId,
   };
 }

--- a/b4m-core/common/src/schemas/partnerSignupRule.test.ts
+++ b/b4m-core/common/src/schemas/partnerSignupRule.test.ts
@@ -56,6 +56,16 @@ describe('createPartnerSignupRuleSchema', () => {
   it('allows a credits-only rule with no entitlements', () => {
     expect(createPartnerSignupRuleSchema.safeParse({ ...base, entitlements: [] }).success).toBe(true);
   });
+
+  it('accepts a 24-char hex organizationId and allows null to clear it', () => {
+    expect(createPartnerSignupRuleSchema.safeParse({ ...base, organizationId: 'a'.repeat(24) }).success).toBe(true);
+    expect(createPartnerSignupRuleSchema.safeParse({ ...base, organizationId: null }).success).toBe(true);
+  });
+
+  it('rejects a malformed organizationId', () => {
+    expect(createPartnerSignupRuleSchema.safeParse({ ...base, organizationId: 'not-an-id' }).success).toBe(false);
+    expect(createPartnerSignupRuleSchema.safeParse({ ...base, organizationId: 'z'.repeat(24) }).success).toBe(false);
+  });
 });
 
 describe('updatePartnerSignupRuleSchema', () => {

--- a/b4m-core/common/src/schemas/partnerSignupRule.ts
+++ b/b4m-core/common/src/schemas/partnerSignupRule.ts
@@ -64,6 +64,17 @@ const labelSchema = z.string().trim().max(120);
 const notesSchema = z.string().trim().max(2000);
 
 /**
+ * Optional org to auto-add verified signups to. A 24-char hex ObjectId, or `null` to
+ * clear the association. Shape only - that the org EXISTS is checked server-side (the
+ * admin route fetches it) since Zod can't reach the DB.
+ */
+const organizationIdSchema = z
+  .string()
+  .trim()
+  .regex(/^[a-f0-9]{24}$/i, 'Organization id must be a 24-character hex id')
+  .nullable();
+
+/**
  * Create payload for a partner signup rule. `enabled` defaults to true so a
  * newly-created rule is live immediately (the common case); an admin toggles
  * it off explicitly to stage a rule.
@@ -72,6 +83,7 @@ export const createPartnerSignupRuleSchema = z.object({
   domain: domainSchema,
   entitlements: entitlementsSchema,
   signupCredits: signupCreditsSchema,
+  organizationId: organizationIdSchema.optional(),
   enabled: z.boolean().default(true),
   label: labelSchema.optional(),
   notes: notesSchema.optional(),
@@ -86,6 +98,7 @@ export const updatePartnerSignupRuleSchema = z
   .object({
     entitlements: entitlementsSchema.optional(),
     signupCredits: signupCreditsSchema.optional(),
+    organizationId: organizationIdSchema.optional(),
     enabled: z.boolean().optional(),
     label: labelSchema.optional(),
     notes: notesSchema.optional(),

--- a/b4m-core/common/src/types/entities/PartnerSignupRuleTypes.ts
+++ b/b4m-core/common/src/types/entities/PartnerSignupRuleTypes.ts
@@ -19,6 +19,13 @@ export interface IPartnerSignupRule {
   entitlements: string[];
   /** One-time signup credits granted once at email verification. */
   signupCredits: number;
+  /**
+   * Optional organization a verified signup on this domain is auto-added to (as a
+   * read-permission member - the same shape `organizationService.addMember` writes).
+   * `null`/absent = no org auto-join. Members are added, never removed: disabling or
+   * deleting the rule stops future auto-adds but never evicts existing members.
+   */
+  organizationId?: string | null;
   /** Soft on/off without deleting the row. Disabled rules confer nothing. */
   enabled: boolean;
   /** Admin-facing display name (e.g. the partner's name). */

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
@@ -1,0 +1,99 @@
+import { applyPartnerRuleMembership } from './applyPartnerRuleMembership';
+import { Permission } from '@bike4mind/common';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cloneDeep } from 'lodash';
+
+describe('applyPartnerRuleMembership', () => {
+  const verifiedUser = { id: 'user-id', name: 'Test User', email: 'test@partner.com', emailVerified: true };
+  const org = { id: 'org-id', name: 'Partner Org', seats: 5, users: [] as Array<{ userId: string }> };
+
+  let db: any;
+  let logger: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = {
+      users: { findById: vi.fn(), update: vi.fn() },
+      organizations: { findById: vi.fn(), update: vi.fn() },
+    };
+    logger = { info: vi.fn() };
+  });
+
+  const run = () => applyPartnerRuleMembership({ userId: 'user-id', organizationId: 'org-id' }, { db, logger });
+
+  it('adds a verified user to the org as a read-permission member and sets organizationId', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    db.organizations.findById.mockResolvedValue(cloneDeep(org));
+
+    const result = await run();
+
+    expect(result).toEqual({ added: true, reason: 'added' });
+    expect(db.organizations.update).toHaveBeenCalledWith(
+      expect.objectContaining({ users: [{ userId: 'user-id', permissions: [Permission.read] }] })
+    );
+    expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
+  });
+
+  it('refuses to add an unverified user (security gate) and writes nothing', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, emailVerified: false });
+
+    const result = await run();
+
+    expect(result).toEqual({ added: false, reason: 'unverified' });
+    expect(db.organizations.findById).not.toHaveBeenCalled();
+    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.users.update).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the user is missing', async () => {
+    db.users.findById.mockResolvedValue(null);
+    expect(await run()).toEqual({ added: false, reason: 'user-missing' });
+    expect(db.organizations.update).not.toHaveBeenCalled();
+  });
+
+  it('fails safe when the org is missing (e.g. soft-deleted)', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser });
+    db.organizations.findById.mockResolvedValue(null);
+
+    expect(await run()).toEqual({ added: false, reason: 'org-missing' });
+    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.users.update).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: an existing member is not duplicated', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: 'org-id' });
+    db.organizations.findById.mockResolvedValue({ ...cloneDeep(org), users: [{ userId: 'user-id' }] });
+
+    const result = await run();
+
+    expect(result).toEqual({ added: false, reason: 'already-member' });
+    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.users.update).not.toHaveBeenCalled();
+  });
+
+  it('repairs a half-set membership: in users[] but organizationId unset', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    db.organizations.findById.mockResolvedValue({ ...cloneDeep(org), users: [{ userId: 'user-id' }] });
+
+    const result = await run();
+
+    expect(result).toEqual({ added: false, reason: 'already-member' });
+    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
+  });
+
+  it('does not overfill an at-capacity org (no silent seat overflow)', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser });
+    db.organizations.findById.mockResolvedValue({
+      ...cloneDeep(org),
+      seats: 2,
+      users: [{ userId: 'a' }, { userId: 'b' }],
+    });
+
+    const result = await run();
+
+    expect(result).toEqual({ added: false, reason: 'at-capacity' });
+    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.users.update).not.toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
@@ -1,0 +1,81 @@
+import { IOrganizationRepository, IUserDocument, IUserRepository, Permission } from '@bike4mind/common';
+
+/**
+ * Why the auto-add did or didn't happen - returned (not thrown) so the signup paths can
+ * log the outcome without a failure here ever breaking verification, and so the backfill
+ * route can tally results.
+ */
+export type ApplyPartnerRuleMembershipResult = {
+  added: boolean;
+  reason: 'added' | 'unverified' | 'user-missing' | 'org-missing' | 'already-member' | 'at-capacity';
+};
+
+interface ApplyPartnerRuleMembershipParams {
+  userId: string;
+  organizationId: string;
+}
+
+interface ApplyPartnerRuleMembershipAdapters {
+  db: {
+    users: IUserRepository;
+    organizations: IOrganizationRepository;
+  };
+  logger?: { info: (message: string) => void };
+}
+
+/**
+ * Add a user to an organization as the effect of a matched PartnerSignupRule - a SYSTEM
+ * action with no acting admin, so it deliberately does not go through `addMember`'s
+ * shareable-access gate. The membership shape it writes (a `users[]` read-permission entry
+ * plus `user.organizationId`) MUST stay in sync with `addMember` / `leave`.
+ *
+ * Loads the user fresh by id rather than trusting a caller-supplied doc: the verify path
+ * holds a pre-verification user object, and a full-doc write of that stale copy would revert
+ * `emailVerified`. Gating on the freshly-read `emailVerified` also closes the hole where an
+ * unverified address could land inside a partner's private org.
+ *
+ * Idempotent and additive: an existing member is never duplicated, and this never removes
+ * anyone. Respects the org's seat cap (no silent overfill); at capacity it no-ops and the
+ * caller logs, rather than forcing a billing change the admin didn't consent to per-signup.
+ */
+export async function applyPartnerRuleMembership(
+  { userId, organizationId }: ApplyPartnerRuleMembershipParams,
+  adapters: ApplyPartnerRuleMembershipAdapters
+): Promise<ApplyPartnerRuleMembershipResult> {
+  const { db, logger } = adapters;
+
+  const user = await db.users.findById(userId);
+  if (!user) return { added: false, reason: 'user-missing' };
+  if (user.emailVerified !== true) return { added: false, reason: 'unverified' };
+
+  // findById filters soft-deleted orgs, so a deleted org resolves to null here and fails
+  // safe - no crash, no membership, the caller logs the dangling reference.
+  const organization = await db.organizations.findById(organizationId);
+  if (!organization) return { added: false, reason: 'org-missing' };
+
+  const alreadyMember = organization.users.some(u => u.userId === userId);
+  if (alreadyMember) {
+    // Repair a half-set membership (in the ACL but organizationId never set) without
+    // touching the org. Partial update so no other user field is disturbed.
+    if (user.organizationId !== organizationId) {
+      await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
+    }
+    return { added: false, reason: 'already-member' };
+  }
+
+  if (organization.users.length >= organization.seats) {
+    logger?.info(
+      `Partner-rule auto-add skipped: organization ${organizationId} is at capacity (${organization.seats} seats)`
+    );
+    return { added: false, reason: 'at-capacity' };
+  }
+
+  organization.users.push({ userId, permissions: [Permission.read] });
+  await db.organizations.update(organization);
+
+  // Partial update - see the stale-doc note above.
+  await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
+
+  logger?.info(`Partner-rule auto-added user ${userId} to organization ${organizationId}`);
+  return { added: true, reason: 'added' };
+}

--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -2,6 +2,7 @@ import { search, searchSchema } from './search';
 import type { SearchParameters } from './search';
 import { get } from './get';
 import { addMember } from './addMember';
+import { applyPartnerRuleMembership } from './applyPartnerRuleMembership';
 import { assignManager } from './assignManager';
 import { removeManager } from './removeManager';
 import getUsers from './getUsers';
@@ -18,6 +19,7 @@ export {
   searchSchema,
   get,
   addMember,
+  applyPartnerRuleMembership,
   assignManager,
   removeManager,
   getUsers,

--- a/packages/database/src/models/auth/PartnerSignupRuleModel.ts
+++ b/packages/database/src/models/auth/PartnerSignupRuleModel.ts
@@ -61,6 +61,9 @@ export const PartnerSignupRuleSchema = new Schema<IPartnerSignupRuleDocument, IP
     domain: { type: String, required: true, unique: true, set: normalizeSignupRuleDomain },
     entitlements: { type: [String], default: [] },
     signupCredits: { type: Number, default: 0 },
+    // Stored as a plain string id (like createdBy) so toJSON yields a string matching
+    // IPartnerSignupRule.organizationId; existence is validated in the admin route, not here.
+    organizationId: { type: String, default: null },
     enabled: { type: Boolean, default: true },
     label: { type: String, default: null },
     notes: { type: String, default: null },
@@ -79,6 +82,8 @@ export const PartnerSignupRuleSchema = new Schema<IPartnerSignupRuleDocument, IP
 
 // Performance indexes (unique domain is declared on the field as a data constraint).
 PartnerSignupRuleSchema.index({ enabled: 1 });
+// Backs the org-delete cleanup sweep (updateMany by organizationId) and backfill lookups.
+PartnerSignupRuleSchema.index({ organizationId: 1 });
 
 export const PartnerSignupRule =
   (mongoose.models.PartnerSignupRule as unknown as IPartnerSignupRuleModel) ??


### PR DESCRIPTION
## Description

Partner signup rules currently map a verified email domain to entitlements + one-time signup credits. This adds an **optional organization** to a rule: when a user registers with a verified email on the rule's domain, they are automatically added to that organization as a member. It also adds an admin **backfill** action to place existing verified-domain users into the org.

Closes #1157

Design decisions (the "why"):
- **Verified email only.** Org membership grants access to shared org resources, so auto-add fires only on a verified email - the same hook where signup credits are granted. An unverified address never lands in a partner's org.
- **Additive, never destructive.** Disabling or deleting a rule stops future auto-adds but never removes existing members. Deleting the org clears the rule's reference (fail-safe; a soft-deleted org also resolves to a no-op).
- **Member-level only.** Auto-add writes the same read-permission membership `addMember` writes. There is deliberately no configurable role - a self-serve signup path must never mint org admins, and the membership model has no member-level admin role anyway (org admin = billing owner / manager).
- **One shared primitive.** `organizationService.applyPartnerRuleMembership` (verified-gated, idempotent, seat-aware) is used by both signup paths and the backfill, so behavior can't drift.

## Changes

- `PartnerSignupRule.organizationId` (optional) across type, Zod schema (24-hex or null), and model; index for the cleanup/backfill queries.
- `organizationService.applyPartnerRuleMembership`: loads the user fresh (avoids reverting just-committed `emailVerified`), gates on verified, idempotent, additive, seat-aware; membership shape mirrors `addMember`.
- Wired into `email/verify` (Phase 2c) and `otc/verify`.
- Admin routes validate the org exists on create/update (shared `assertOrganizationExists`); org delete clears the rule reference + invalidates cache.
- New `POST /api/admin/partner-signup-rules/backfill` (dry-run preview + commit), reusing the shared function.
- Admin UI: org picker on the rule form, an "Org" column, and a backfill dry-run/confirm modal.

## Guide for Testers

Prereq: log in as an **admin**. Navigate to **Sidebar -> Admin -> Partner Signup Rules**.

1. Click **Add rule**. Enter domain `partnerco.test`, pick an **Organization** from the new picker, set Signup credits `0`, click **Create rule**. Expected: toast "Created signup rule for partnerco.test"; the row shows a green **linked** chip in the Org column.
2. Register a brand-new user with a verified email on that domain (e.g. via the OTC "Register now" flow with `someone@partnerco.test`, completing email verification). Expected: after verification the user is a member of the chosen org.
3. Open that org (Admin/Org members view) and confirm the new user appears as a member.
4. Back on Partner Signup Rules, click the **group-add** icon on the rule row (appears only when an org is linked). Expected: a modal previews "N users will be added" with a sample list (dry-run - nothing written yet).
5. Click **Add N users**. Expected: toast "Backfill complete: X added..."; those existing verified-domain users are now org members. Re-running shows them as "already members" (idempotent, no duplicates).
6. Edit the rule and clear the Organization (open picker, remove selection), Save. Expected: the linked chip disappears; new signups on the domain are no longer auto-added. Existing members remain (nothing removed).

Expected negatives:
- An **unverified** signup on the domain is NOT added to the org.
- Deleting the linked org, then registering on the domain: no crash; the user just isn't org-added (rule reference is cleared).

## Regression Checks

- Existing partner rules with no org behave exactly as before (entitlements + signup credits unchanged on both verify and OTC paths).
- Creating/editing a rule without touching the org picker does not add/clear an org association.
- Adding a member via the normal org members UI is unaffected (`addMember` untouched).

## What NOT to test

- Non-org partner-rule behavior (entitlement/credit grants) is unchanged - covered by existing tests.

## Additional Information

Verification: `turbo:core:build`, `tsc` typecheck (common/services/database/client), `tsgo` (CI-parity, clean), eslint (0 errors), and full unit suites green - services (+ new `applyPartnerRuleMembership` tests), common (schema), and client (resolver + admin routes + verify/otc paths).

## Developer Notes

- **New reusable primitive:** `organizationService.applyPartnerRuleMembership({ userId, organizationId }, adapters)` - a system-context, verified-gated, idempotent, seat-aware org-join. Any future "auto-join by domain" path (e.g. an org-owned verified-domain allowlist) can reuse it instead of reimplementing membership writes.
- **Data model:** `PartnerSignupRule.organizationId` moves org association into runtime data.
- **Future direction (not in scope):** org-owned domain auto-join managed by the org admin, decoupled from platform partner perks - would layer on the same primitive.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
