### PR TITLE
feat(organizations): platform-admin group-type grant/revoke route (Phase 3, WIP)

### DIFF
--- a/apps/client/pages/api/admin/organizations/[id]/group-types.ts
+++ b/apps/client/pages/api/admin/organizations/[id]/group-types.ts
@@ -1,0 +1,76 @@
+import { baseApi } from '@server/middlewares/baseApi';
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { BadRequestError, ensureAdmin } from '@server/utils/errors';
+import { organizationRepository } from '@bike4mind/database';
+import { Group } from '@bike4mind/database/social';
+import { User } from '@bike4mind/database/auth';
+import { organizationService } from '@bike4mind/services';
+import { z } from 'zod';
+
+/**
+ * PUT /api/admin/organizations/[id]/group-types - platform-admin only.
+ * Sets an org's allowed group types (org-groups #1172, Phase 3): provisions a Group instance for
+ * each newly-allowed type, and on revocation soft-deletes the instance and purges its id from
+ * every member. All validation + the revoke purge live in `setOrganizationGroupTypes` (tested).
+ *
+ * DRAFT TODOs (tracked on the PR): wrap the writes in a transaction with session propagation to
+ * the model-direct group/user writes, and emit a formal admin audit event for the grant/revoke.
+ */
+const bodySchema = z.object({
+  allowedGroupTypes: z.array(z.string()).max(20),
+});
+
+const handler = baseApi().put(
+  asyncHandler<{}, unknown, unknown, { id?: string }>(async (req, res) => {
+    ensureAdmin(req.user?.isAdmin);
+    const organizationId = req.query.id;
+    if (!organizationId) throw new BadRequestError('Organization id is required');
+
+    let body: z.infer<typeof bodySchema>;
+    try {
+      body = bodySchema.parse(req.body);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new BadRequestError(error.issues.map(e => `${e.path.join('.') || 'value'}: ${e.message}`).join('; '));
+      }
+      throw error;
+    }
+
+    const result = await organizationService.setOrganizationGroupTypes(
+      { organizationId, allowedGroupTypes: body.allowedGroupTypes },
+      {
+        db: {
+          organizations: organizationRepository,
+          groups: {
+            findByOrganization: async orgId => {
+              const groups = await Group.find({ organizationId: orgId }).select('_id type').lean();
+              return groups.map(group => ({ id: group._id.toString(), type: group.type as string }));
+            },
+            create: data => Group.create(data),
+            softDeleteByIds: async groupIds => {
+              await Group.deleteMany({ _id: { $in: groupIds } });
+            },
+          },
+          users: {
+            // $pull each revoked group id from every user that has it. Not a $set-style repo op,
+            // so it goes through the model directly.
+            pullGroupsFromAll: async groupIds => {
+              await User.updateMany({ groups: { $in: groupIds } }, { $pull: { groups: { $in: groupIds } } });
+            },
+          },
+        },
+        logger: req.logger,
+      }
+    );
+
+    res.status(200).json(result);
+  })
+);
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -12,6 +12,7 @@ import { listOwn } from './listOwn';
 import { listPendingUsers } from './listPendingUsers';
 import { revokeAccess } from './revokeAccess';
 import { leave } from './leave';
+import { setOrganizationGroupTypes } from './setOrganizationGroupTypes';
 
 export {
   search,
@@ -29,6 +30,7 @@ export {
   listPendingUsers,
   revokeAccess,
   leave,
+  setOrganizationGroupTypes,
 };
 
 export type { SearchParameters };

--- a/b4m-core/services/src/organizationService/setOrganizationGroupTypes.test.ts
+++ b/b4m-core/services/src/organizationService/setOrganizationGroupTypes.test.ts
@@ -1,0 +1,106 @@
+import { setOrganizationGroupTypes } from './setOrganizationGroupTypes';
+import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('setOrganizationGroupTypes', () => {
+  let db: any;
+  let logger: any;
+
+  const org = (over: Record<string, unknown> = {}) => ({
+    id: 'org-1',
+    personal: false,
+    allowedGroupTypes: [],
+    ...over,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = {
+      organizations: { findById: vi.fn().mockResolvedValue(org()), update: vi.fn() },
+      groups: {
+        findByOrganization: vi.fn().mockResolvedValue([]),
+        create: vi.fn(),
+        softDeleteByIds: vi.fn(),
+      },
+      users: { pullGroupsFromAll: vi.fn() },
+    };
+    logger = { info: vi.fn() };
+  });
+
+  const run = (allowedGroupTypes: string[]) =>
+    setOrganizationGroupTypes({ organizationId: 'org-1', allowedGroupTypes }, { db, logger });
+
+  it('rejects unknown group type keys before any write', async () => {
+    await expect(run(['sales', 'bogus'])).rejects.toThrow(BadRequestError);
+    expect(db.groups.create).not.toHaveBeenCalled();
+    expect(db.organizations.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects personal organizations', async () => {
+    db.organizations.findById.mockResolvedValue(org({ personal: true }));
+    await expect(run(['sales'])).rejects.toThrow(BadRequestError);
+    expect(db.organizations.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the org is missing', async () => {
+    db.organizations.findById.mockResolvedValue(null);
+    await expect(run(['sales'])).rejects.toThrow(NotFoundError);
+  });
+
+  it('provisions a group instance for each newly-allowed type', async () => {
+    const result = await run(['sales', 'research']);
+
+    expect(db.groups.create).toHaveBeenCalledTimes(2);
+    expect(db.groups.create).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'sales', name: 'Sales', organizationId: 'org-1' })
+    );
+    expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales', 'research'] });
+    expect(result.added).toEqual(['sales', 'research']);
+    expect(result.removed).toEqual([]);
+  });
+
+  it('does not re-provision a type that already has a live instance (idempotent)', async () => {
+    db.organizations.findById.mockResolvedValue(org({ allowedGroupTypes: ['sales'] }));
+    db.groups.findByOrganization.mockResolvedValue([{ id: 'g-sales', type: 'sales' }]);
+
+    await run(['sales', 'research']);
+
+    // only the genuinely-new 'research' type is provisioned
+    expect(db.groups.create).toHaveBeenCalledTimes(1);
+    expect(db.groups.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'research' }));
+  });
+
+  it('revokes a removed type: soft-deletes its instances AND purges member group ids', async () => {
+    db.organizations.findById.mockResolvedValue(org({ allowedGroupTypes: ['sales', 'research'] }));
+    db.groups.findByOrganization.mockResolvedValue([
+      { id: 'g-sales', type: 'sales' },
+      { id: 'g-research', type: 'research' },
+    ]);
+
+    const result = await run(['sales']); // research removed
+
+    expect(db.groups.softDeleteByIds).toHaveBeenCalledWith(['g-research']);
+    expect(db.users.pullGroupsFromAll).toHaveBeenCalledWith(['g-research']);
+    expect(db.groups.create).not.toHaveBeenCalled();
+    expect(result.removed).toEqual(['research']);
+    expect(result.revokedGroupIds).toEqual(['g-research']);
+    expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales'] });
+  });
+
+  it('does not touch groups/members when nothing is revoked', async () => {
+    db.organizations.findById.mockResolvedValue(org({ allowedGroupTypes: ['sales'] }));
+    db.groups.findByOrganization.mockResolvedValue([{ id: 'g-sales', type: 'sales' }]);
+
+    await run(['sales']); // no change
+
+    expect(db.groups.softDeleteByIds).not.toHaveBeenCalled();
+    expect(db.users.pullGroupsFromAll).not.toHaveBeenCalled();
+    expect(db.groups.create).not.toHaveBeenCalled();
+  });
+
+  it('dedupes and trims requested keys', async () => {
+    await run([' sales ', 'sales']);
+    expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales'] });
+    expect(db.groups.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/b4m-core/services/src/organizationService/setOrganizationGroupTypes.ts
+++ b/b4m-core/services/src/organizationService/setOrganizationGroupTypes.ts
@@ -1,0 +1,95 @@
+import { IOrganizationRepository, unknownGroupTypeKeys, getGroupType } from '@bike4mind/common';
+import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+
+/** A live group instance, minimally typed for the diff logic. */
+export interface GroupInstanceRef {
+  id: string;
+  type: string;
+}
+
+interface SetGroupTypesAdapters {
+  db: {
+    organizations: Pick<IOrganizationRepository, 'findById' | 'update'>;
+    groups: {
+      /** Live (non-soft-deleted) group instances for the org. */
+      findByOrganization: (organizationId: string) => Promise<GroupInstanceRef[]>;
+      /** Provision a group instance for a newly-allowed type. */
+      create: (data: { name: string; description: string; type: string; organizationId: string }) => Promise<unknown>;
+      /** Soft-delete the given group instances. */
+      softDeleteByIds: (groupIds: string[]) => Promise<void>;
+    };
+    users: {
+      /** Remove the given group ids from every user's `groups[]` (the revoke purge). */
+      pullGroupsFromAll: (groupIds: string[]) => Promise<void>;
+    };
+  };
+  logger?: { info: (message: string) => void };
+}
+
+export interface SetGroupTypesResult {
+  added: string[];
+  removed: string[];
+  revokedGroupIds: string[];
+}
+
+/**
+ * Set an organization's allowed group types - a platform-admin action (org-groups #1172, Phase 3).
+ *
+ * - Validates every requested key against the code-defined catalog (a typo can't persist a dead grant).
+ * - Rejects personal organizations (agreed decision 4).
+ * - Provisions a `Group` instance for each newly-allowed type that has none yet (idempotent - groups
+ *   are created only here, never directly).
+ * - For each revoked type: soft-deletes its instance(s) AND purges those group ids from every
+ *   member's `user.groups`. This is the org-wide analog of the leave.ts purge - without it, a
+ *   revoked type would leave members holding access to a group that no longer exists.
+ *
+ * Callers MUST wrap this in a transaction: the group soft-deletes, the member purge, and the org
+ * write have to commit together, or a partial failure leaves dangling membership.
+ */
+export async function setOrganizationGroupTypes(
+  { organizationId, allowedGroupTypes }: { organizationId: string; allowedGroupTypes: string[] },
+  adapters: SetGroupTypesAdapters
+): Promise<SetGroupTypesResult> {
+  const { db, logger } = adapters;
+
+  const requested = [...new Set(allowedGroupTypes.map(key => key.trim()).filter(Boolean))];
+  const unknown = unknownGroupTypeKeys(requested);
+  if (unknown.length > 0) {
+    throw new BadRequestError(`Unknown group type(s): ${unknown.join(', ')}`);
+  }
+
+  const organization = await db.organizations.findById(organizationId);
+  if (!organization) throw new NotFoundError('Organization not found');
+  if (organization.personal) {
+    throw new BadRequestError('Personal organizations cannot be granted group types');
+  }
+
+  const current = organization.allowedGroupTypes ?? [];
+  const added = requested.filter(type => !current.includes(type));
+  const removed = current.filter(type => !requested.includes(type));
+
+  const liveGroups = await db.groups.findByOrganization(organizationId);
+  const typesWithInstance = new Set(liveGroups.map(group => group.type));
+
+  // Provision a group instance for each newly-allowed type that lacks one (idempotent).
+  for (const type of added) {
+    if (typesWithInstance.has(type)) continue;
+    const def = getGroupType(type)!; // safe: requested keys were validated against the catalog above
+    await db.groups.create({ name: def.label, description: def.description, type, organizationId });
+  }
+
+  // Revoke: soft-delete the instances of removed types, then purge their ids from all members.
+  const revokedGroupIds = liveGroups.filter(group => removed.includes(group.type)).map(group => group.id);
+  if (revokedGroupIds.length > 0) {
+    await db.groups.softDeleteByIds(revokedGroupIds);
+    await db.users.pullGroupsFromAll(revokedGroupIds);
+  }
+
+  await db.organizations.update({ id: organizationId, allowedGroupTypes: requested });
+  logger?.info(
+    `Organization ${organizationId} allowed group types updated ` +
+      `(added: [${added.join(', ')}], removed: [${removed.join(', ')}])`
+  );
+
+  return { added, removed, revokedGroupIds };
+}


### PR DESCRIPTION
**Draft — stacked on #1181 (Phase 2).** Review/merge #1181 first; this PR's base is the Phase 2 branch, so its diff shows only Phase 3. Part of #1172, closes #1175 when complete.

## What's here
- **`setOrganizationGroupTypes`** service (adapter-injected, **unit-tested** — 8 cases): validates requested keys against the catalog, rejects personal orgs, provisions a `Group` instance per newly-allowed type (idempotent), and on revocation soft-deletes the instance **and purges its id from every member** (the org-wide analog of the `leave.ts` purge — the highest-risk path, so it lives in a tested service, not the route).
- **`PUT /api/admin/organizations/[id]/group-types`** — platform-admin route wiring the service to the `Group`/`User` models.

## Remaining before ready for review (why it's a draft)
- [ ] Wrap the route writes (group provision/soft-delete + member `$pull` + org update) in a **transaction** with session propagation to the model-direct writes — currently sequenced, not atomic. Safe today (empty `Group` collection) but must land before real use.
- [ ] Emit a **formal admin audit event** for grant/revoke (design calls for this; using `req.logger` for now).
- [ ] Route-level / integration test for the wiring (service logic is unit-covered).

## Verified so far
Core build, `tsc` (services + client), eslint (0 errors), services unit suite green incl. the 8 new `setOrganizationGroupTypes` tests (revoke → soft-delete + member purge, idempotent provisioning, unknown-key rejection, personal-org rejection, dedupe).