### PR TITLE
ci: auto-assign PRs to their author

### DIFF
--- a/.github/workflows/auto-assign-pr-author.yml
+++ b/.github/workflows/auto-assign-pr-author.yml
@@ -1,0 +1,59 @@
+name: Auto-Assign PR Author
+
+# Every PR should have an assignee; default it to whoever opened it.
+#
+# pull_request_target (not pull_request) because this repo is public: a fork PR
+# under pull_request gets a read-only GITHUB_TOKEN and the assignment 403s.
+# This is the safe use of pull_request_target: the job never checks out the head
+# ref and never runs PR-controlled code, it only reads event metadata and calls
+# the assignees API. Do not add actions/checkout to this workflow.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    name: Assign PR Author
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            if (pr.assignees?.length) {
+              core.info(`PR #${pr.number} already assigned; leaving it alone`);
+              return;
+            }
+
+            // GitHub silently drops bot accounts from an assignees request, so
+            // skip explicitly rather than logging a no-op success. Covers
+            // dependabot[bot] and changeset-release "Version Packages" PRs.
+            if (pr.user.type === 'Bot') {
+              core.info(`PR #${pr.number} authored by bot ${author}; not assignable`);
+              return;
+            }
+
+            const { data } = await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              assignees: [author],
+            });
+
+            // The API also silently ignores assignees who lack repo access,
+            // the common case for an outside contributor here. Warn rather than
+            // fail their PR over something they can't fix.
+            if (data.assignees?.some((a) => a.login === author)) {
+              core.info(`Assigned PR #${pr.number} to ${author}`);
+            } else {
+              core.warning(
+                `Could not assign PR #${pr.number} to ${author}: GitHub ignored the assignee, ` +
+                  `which usually means they lack access to this repository.`
+              );
+            }


### PR DESCRIPTION
# Pull Request

## Description

Every PR should have an assignee, and it should default to whoever opened it. Nothing set one before, so PR lists and review-queue tooling had no owner to filter on. This adds a small workflow that assigns the author on `opened` and `reopened`.

## Changes

- New `.github/workflows/auto-assign-pr-author.yml`. Inline `actions/github-script`, matching the existing pattern in `remove-stale-label.yml` rather than taking a marketplace dependency for ~20 lines of API call.
- Uses `pull_request_target` rather than `pull_request` because this repo is public: a fork PR under `pull_request` gets a read-only `GITHUB_TOKEN` and the assignment call 403s. This is the safe use of that trigger, the job never checks out the head ref and never runs PR-controlled code, it only reads event metadata and calls the assignees API. There is a comment in the file saying not to add `actions/checkout` to it.
- Skips PRs that already have an assignee, so it never overrides a manual assignment.
- Skips bot authors. The assignees API silently drops bot accounts, so attempting it is an invisible no-op; skipping explicitly makes that behavior readable in the logs. Covers dependabot and the `changeset-release/*` Version Packages PRs.
- Warns instead of failing when GitHub silently ignores the assignee. That happens when the author lacks repo access, which is the realistic case for an outside contributor here, and it is not something they can fix by editing their PR.

An identical workflow, differing only in the runner label, is going into our other application repo.

## Guide for Testers

This is a CI-only change with no application surface. There is nothing to exercise in the app.

1. Merge this PR.
2. Open any new PR against `main` from a branch in this repo.
3. Expected: within about a minute the PR shows its author in the Assignees field, and Actions shows a successful `Auto-Assign PR Author` run.
4. Open a PR, manually set a different assignee, close it, then reopen it.
5. Expected: the manual assignee is preserved. The run logs `already assigned; leaving it alone`.
6. Check the next dependabot PR.
7. Expected: no assignee, and the run logs `authored by bot ... not assignable`.

### What NOT to test

No app behavior, no API, no UI. Do not look for changes in staging.

## Additional Information

Behavior was verified locally by extracting the embedded script from the YAML and executing it against a mocked Octokit through the same async wrapper `github-script` uses, across five cases: normal human author, already-assigned PR, bot author, author without repo access, and a payload with no `assignees` field. All five behaved as intended.

Scope note: this assigns on open, it does not enforce. Nothing stops someone removing the assignee later. A hard guarantee would need a separate required status check, which seems like more machinery than the problem warrants, since the actual gap is that nobody assigns in the first place.

Existing open unassigned PRs are being backfilled once from the CLI rather than by a workflow.

