### PR TITLE
feat(organizations): group membership assign/unassign + write-path invariant (Phase 4 core, WIP)

### DIFF
--- a/apps/client/pages/api/organizations/[id]/groups/[groupId]/members/[userId]/index.ts
+++ b/apps/client/pages/api/organizations/[id]/groups/[groupId]/members/[userId]/index.ts
@@ -1,0 +1,38 @@
+import { baseApi } from '@server/middlewares/baseApi';
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { BadRequestError } from '@server/utils/errors';
+import { organizationRepository } from '@bike4mind/database';
+import { groupRepository } from '@bike4mind/database/social';
+import { userRepository } from '@bike4mind/database/auth';
+import { organizationService } from '@bike4mind/services';
+
+/**
+ * DELETE /api/organizations/[id]/groups/[groupId]/members/[userId] - unassign a user from a group.
+ * Authorization + the "group belongs to this org" invariant are enforced in `removeUserFromGroup`.
+ */
+const handler = baseApi().delete(
+  asyncHandler<{}, unknown, unknown, { id?: string; groupId?: string; userId?: string }>(async (req, res) => {
+    const organizationId = req.query.id;
+    const groupId = req.query.groupId;
+    const userId = req.query.userId;
+    if (!organizationId || !groupId || !userId) {
+      throw new BadRequestError('Organization id, group id, and user id are required');
+    }
+
+    await organizationService.removeUserFromGroup(
+      req.user!,
+      { organizationId, groupId, userId },
+      { db: { organizations: organizationRepository, groups: groupRepository, users: userRepository } }
+    );
+
+    res.status(200).json({ success: true });
+  })
+);
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/apps/client/pages/api/organizations/[id]/groups/[groupId]/members/index.ts
+++ b/apps/client/pages/api/organizations/[id]/groups/[groupId]/members/index.ts
@@ -1,0 +1,47 @@
+import { baseApi } from '@server/middlewares/baseApi';
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { BadRequestError } from '@server/utils/errors';
+import { organizationRepository } from '@bike4mind/database';
+import { groupRepository } from '@bike4mind/database/social';
+import { userRepository } from '@bike4mind/database/auth';
+import { organizationService } from '@bike4mind/services';
+import { z } from 'zod';
+
+/**
+ * POST /api/organizations/[id]/groups/[groupId]/members - assign a user to a group.
+ * Authorization (billing owner / org admin / platform admin) AND the write-path invariant
+ * (group belongs to this org, target user is a member) are enforced in `assignUserToGroup`.
+ */
+const bodySchema = z.object({ userId: z.string().min(1) });
+
+const handler = baseApi().post(
+  asyncHandler<{}, unknown, unknown, { id?: string; groupId?: string }>(async (req, res) => {
+    const organizationId = req.query.id;
+    const groupId = req.query.groupId;
+    if (!organizationId || !groupId) throw new BadRequestError('Organization id and group id are required');
+
+    let userId: string;
+    try {
+      ({ userId } = bodySchema.parse(req.body));
+    } catch (error) {
+      if (error instanceof z.ZodError) throw new BadRequestError('A userId is required');
+      throw error;
+    }
+
+    await organizationService.assignUserToGroup(
+      req.user!,
+      { organizationId, groupId, userId },
+      { db: { organizations: organizationRepository, groups: groupRepository, users: userRepository } }
+    );
+
+    res.status(200).json({ success: true });
+  })
+);
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/b4m-core/common/src/types/entities/UserTypes.ts
+++ b/b4m-core/common/src/types/entities/UserTypes.ts
@@ -595,6 +595,10 @@ export interface IUserRepository extends IBaseRepository<IUserDocument>, ICredit
   findByEmail: (email: string) => Promise<IUserDocument | null>;
   /** Remove the given group ids from every user's `groups[]` (used when a group is revoked/deleted). */
   pullGroups: (groupIds: string[]) => Promise<void>;
+  /** Add a single group id to one user's `groups[]` (idempotent; used when assigning a member). */
+  addGroupToUser: (userId: string, groupId: string) => Promise<void>;
+  /** Remove a single group id from one user's `groups[]` (used when unassigning a member). */
+  removeGroupFromUser: (userId: string, groupId: string) => Promise<void>;
   findByEmailVerificationToken: (token: string) => Promise<IUserDocument | null>;
   findByPendingEmailToken: (token: string) => Promise<IUserDocument | null>;
   findByIdWithPassword: (id: string) => Promise<IUserDocument | null>;

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -129,6 +129,8 @@ export const createMockUserRepository = (): MockedObject<IUserRepository> =>
     ...createMockRepository<IUserDocument>(),
     findByEmail: vi.fn(),
     pullGroups: vi.fn(),
+    addGroupToUser: vi.fn(),
+    removeGroupFromUser: vi.fn(),
     findByIds: vi.fn(),
     findByUsernameOrEmail: vi.fn(),
     findByIdWithPassword: vi.fn(),

--- a/b4m-core/services/src/organizationService/groupMembership.test.ts
+++ b/b4m-core/services/src/organizationService/groupMembership.test.ts
@@ -1,0 +1,93 @@
+import { assignUserToGroup, removeUserFromGroup } from './groupMembership';
+import { BadRequestError, ForbiddenError, NotFoundError } from '@bike4mind/utils';
+import { IUserDocument } from '@bike4mind/common';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('group membership (assign / remove)', () => {
+  const ORG = 'org-1';
+  const GROUP = 'group-1';
+  const TARGET = 'target-user';
+
+  const billingOwner = { id: 'owner-1', isAdmin: false } as IUserDocument;
+  const orgAdmin = { id: 'orgadmin-1', isAdmin: false } as IUserDocument;
+  const platformAdmin = { id: 'admin-1', isAdmin: true } as IUserDocument;
+  const outsiderAdmin = { id: 'stranger-1', isAdmin: false } as IUserDocument;
+
+  let db: any;
+
+  const org = (over: Record<string, unknown> = {}) => ({
+    id: ORG,
+    userId: 'owner-1',
+    adminUserIds: ['orgadmin-1'],
+    users: [{ userId: TARGET }, { userId: 'owner-1' }],
+    ...over,
+  });
+  const group = (over: Record<string, unknown> = {}) => ({ id: GROUP, organizationId: ORG, type: 'sales', ...over });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = {
+      organizations: { findById: vi.fn().mockResolvedValue(org()) },
+      groups: { findById: vi.fn().mockResolvedValue(group()) },
+      users: { addGroupToUser: vi.fn(), removeGroupFromUser: vi.fn() },
+    };
+  });
+
+  const assign = (actor: IUserDocument) =>
+    assignUserToGroup(actor, { organizationId: ORG, groupId: GROUP, userId: TARGET }, { db });
+
+  it('assigns a member to a group for the billing owner, org admin, and platform admin', async () => {
+    for (const actor of [billingOwner, orgAdmin, platformAdmin]) {
+      await assign(actor);
+    }
+    expect(db.users.addGroupToUser).toHaveBeenCalledTimes(3);
+    expect(db.users.addGroupToUser).toHaveBeenCalledWith(TARGET, GROUP);
+  });
+
+  it('forbids a plain member / non-admin from assigning', async () => {
+    await expect(assign(outsiderAdmin)).rejects.toThrow(ForbiddenError);
+    expect(db.users.addGroupToUser).not.toHaveBeenCalled();
+  });
+
+  // Write-path invariant, negative A: cannot attach an OUTSIDER (fails condition 2).
+  it('rejects assigning a user who is not a member of the organization', async () => {
+    db.organizations.findById.mockResolvedValue(org({ users: [{ userId: 'someone-else' }] }));
+    await expect(assign(billingOwner)).rejects.toThrow(BadRequestError);
+    expect(db.users.addGroupToUser).not.toHaveBeenCalled();
+  });
+
+  // Write-path invariant, negative B: cannot attach a member to ANOTHER TENANT's group (fails condition 1).
+  it('rejects assigning to a group that belongs to a different organization', async () => {
+    db.groups.findById.mockResolvedValue(group({ organizationId: 'other-org' }));
+    await expect(assign(billingOwner)).rejects.toThrow(BadRequestError);
+    expect(db.users.addGroupToUser).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFound when the org or group is missing', async () => {
+    db.organizations.findById.mockResolvedValue(null);
+    await expect(assign(billingOwner)).rejects.toThrow(NotFoundError);
+
+    db.organizations.findById.mockResolvedValue(org());
+    db.groups.findById.mockResolvedValue(null);
+    await expect(assign(billingOwner)).rejects.toThrow(NotFoundError);
+  });
+
+  it('removes a member from a group (invariant 1 enforced, membership not required)', async () => {
+    // even a user no longer in users[] can be unassigned (cleanup), as long as the group is this org's
+    db.organizations.findById.mockResolvedValue(org({ users: [] }));
+    await removeUserFromGroup(billingOwner, { organizationId: ORG, groupId: GROUP, userId: TARGET }, { db });
+    expect(db.users.removeGroupFromUser).toHaveBeenCalledWith(TARGET, GROUP);
+  });
+
+  it("remove still rejects another tenant's group and unauthorized actors", async () => {
+    db.groups.findById.mockResolvedValue(group({ organizationId: 'other-org' }));
+    await expect(
+      removeUserFromGroup(billingOwner, { organizationId: ORG, groupId: GROUP, userId: TARGET }, { db })
+    ).rejects.toThrow(BadRequestError);
+
+    db.groups.findById.mockResolvedValue(group());
+    await expect(
+      removeUserFromGroup(outsiderAdmin, { organizationId: ORG, groupId: GROUP, userId: TARGET }, { db })
+    ).rejects.toThrow(ForbiddenError);
+  });
+});

--- a/b4m-core/services/src/organizationService/groupMembership.ts
+++ b/b4m-core/services/src/organizationService/groupMembership.ts
@@ -1,0 +1,81 @@
+import { IGroupRepository, IOrganizationRepository, IUserDocument, IUserRepository } from '@bike4mind/common';
+import { BadRequestError, ForbiddenError, NotFoundError } from '@bike4mind/utils';
+
+interface GroupMembershipAdapters {
+  db: {
+    organizations: Pick<IOrganizationRepository, 'findById'>;
+    groups: Pick<IGroupRepository, 'findById'>;
+    users: Pick<IUserRepository, 'addGroupToUser' | 'removeGroupFromUser'>;
+  };
+}
+
+interface GroupMembershipParams {
+  organizationId: string;
+  groupId: string;
+  userId: string;
+}
+
+type OrgLike = { userId: string; adminUserIds?: string[]; users: Array<{ userId: string }> };
+
+/**
+ * Who may manage an org's group memberships: a platform admin, the org's billing owner, or an
+ * appointed org admin (`adminUserIds`). A plain member has no group-management authority.
+ */
+const assertCanManageOrgGroups = (actingUser: IUserDocument, organization: OrgLike): void => {
+  const isPlatformAdmin = actingUser.isAdmin === true;
+  const isBillingOwner = organization.userId === actingUser.id;
+  const isOrgAdmin = (organization.adminUserIds ?? []).includes(actingUser.id);
+  if (!isPlatformAdmin && !isBillingOwner && !isOrgAdmin) {
+    throw new ForbiddenError("Not authorized to manage this organization's groups");
+  }
+};
+
+/**
+ * Resolve the org + group and enforce the group-membership **write-path invariant**
+ * (org-groups #1172 - the single highest-risk path). Every membership write must confirm BOTH:
+ *   (1) the target group belongs to the acting admin's organization, AND
+ *   (2) the target user is a member of that same organization.
+ * `user.groups[]` carries no org qualifier, so skipping (1) lets an admin attach their member to
+ * another tenant's group, and skipping (2) lets them attach an outsider to their own group -
+ * either omission is cross-tenant access, not a cosmetic bug. Assign requires both; unassign
+ * requires (1) only ((2) is not needed to REMOVE, and a departed member should still be cleanable).
+ */
+async function authorizeAndValidate(
+  actingUser: IUserDocument,
+  { organizationId, groupId, userId }: GroupMembershipParams,
+  adapters: GroupMembershipAdapters,
+  requireMembership: boolean
+): Promise<void> {
+  const organization = await adapters.db.organizations.findById(organizationId);
+  if (!organization) throw new NotFoundError('Organization not found');
+  assertCanManageOrgGroups(actingUser, organization);
+
+  const group = await adapters.db.groups.findById(groupId);
+  if (!group) throw new NotFoundError('Group not found');
+  if (group.organizationId !== organizationId) {
+    throw new BadRequestError('Group does not belong to this organization'); // invariant (1)
+  }
+  if (requireMembership && !organization.users.some(member => member.userId === userId)) {
+    throw new BadRequestError('User is not a member of this organization'); // invariant (2)
+  }
+}
+
+/** Assign a member to a group (idempotent). Enforces both invariant conditions. */
+export async function assignUserToGroup(
+  actingUser: IUserDocument,
+  params: GroupMembershipParams,
+  adapters: GroupMembershipAdapters
+): Promise<void> {
+  await authorizeAndValidate(actingUser, params, adapters, true);
+  await adapters.db.users.addGroupToUser(params.userId, params.groupId);
+}
+
+/** Remove a member from a group. Enforces invariant (1) so an admin can't touch another tenant's group. */
+export async function removeUserFromGroup(
+  actingUser: IUserDocument,
+  params: GroupMembershipParams,
+  adapters: GroupMembershipAdapters
+): Promise<void> {
+  await authorizeAndValidate(actingUser, params, adapters, false);
+  await adapters.db.users.removeGroupFromUser(params.userId, params.groupId);
+}

--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -13,6 +13,7 @@ import { listPendingUsers } from './listPendingUsers';
 import { revokeAccess } from './revokeAccess';
 import { leave } from './leave';
 import { setOrganizationGroupTypes } from './setOrganizationGroupTypes';
+import { assignUserToGroup, removeUserFromGroup } from './groupMembership';
 
 export {
   search,
@@ -31,6 +32,8 @@ export {
   revokeAccess,
   leave,
   setOrganizationGroupTypes,
+  assignUserToGroup,
+  removeUserFromGroup,
 };
 
 export type { SearchParameters };

--- a/packages/database/src/models/auth/UserModel.ts
+++ b/packages/database/src/models/auth/UserModel.ts
@@ -252,6 +252,16 @@ export class UserRepository extends BaseRepository<IUserDocument> implements IUs
     await this.model.updateMany({ groups: { $in: groupIds } }, { $pull: { groups: { $in: groupIds } } });
   }
 
+  /** Add one group id to one user (idempotent via $addToSet). */
+  async addGroupToUser(userId: string, groupId: string): Promise<void> {
+    await this.model.updateOne({ _id: userId }, { $addToSet: { groups: groupId } });
+  }
+
+  /** Remove one group id from one user. */
+  async removeGroupFromUser(userId: string, groupId: string): Promise<void> {
+    await this.model.updateOne({ _id: userId }, { $pull: { groups: groupId } });
+  }
+
   async findAllByEmailsOrUsernames(emails: string[], usernames: string[]) {
     const result = await this.model.find({
       $or: [{ email: { $in: emails } }, { username: { $in: usernames } }],


### PR DESCRIPTION
**Draft - stacked on #1181 (foundation: Phases 2 + 2b + 3).** Base is the foundation branch, so this diff shows only Phase 4. Part of #1176.

## What's here (the demo-unblocking core)
The missing link for demoing group-gated content: the ability to **put a user into / take them out of a group**, with the security-critical write-path invariant.

- **`assignUserToGroup` / `removeUserFromGroup`** service (adapter-injected, **unit-tested - 8 cases**):
  - **Actor authorization**: billing owner / org admin (`adminUserIds`) / platform admin. A plain member is forbidden.
  - **Write-path invariant** (the single highest-risk path in the epic): a membership write must confirm BOTH (1) the group belongs to the acting org, AND (2) the target user is a member of that org. `user.groups[]` has no org qualifier, so skipping either is cross-tenant access - **both cross-tenant negatives are tested directly**. (Unassign enforces (1) only - a departed member should still be cleanable.)
- **`userRepository.addGroupToUser`** (`$addToSet`, idempotent) + **`removeGroupFromUser`** (`$pull`) + testUtils mocks.
- Routes: `POST .../groups/[groupId]/members` (assign), `DELETE .../groups/[groupId]/members/[userId]` (unassign).

## Guide for Testers

This is a backend/API PR - there is **no group-management UI yet** (routes only; UI is Phase 5). Drive it with authenticated API calls. The bearer token lives in `localStorage` (not a cookie), so send `Authorization: Bearer <jwt>`. Base URL on the preview: `https://app.pr1192.preview.bike4mind.com`.

**Setup (record the ids as you go):**
- Platform-admin token `ADMIN_JWT`.
- An organization `ORG` with a billing-owner user `OWNER`.
- A user `MEMBER` who is in `ORG`, and a user `OUTSIDER` who is **not**.
- A second org `ORG2` (any) for the cross-tenant negative.

**Happy path**
1. **Grant a group type to the org** (platform admin):
   `PUT /api/admin/organizations/{ORG}/group-types` with body `{"allowedGroupTypes":["sales"]}`.
   Expect `200`. A follow-up `GET /api/organizations/{ORG}` shows `allowedGroupTypes: ["sales"]`.
2. **Provision a group instance:**
   `POST /api/organizations/{ORG}/groups/create` with body `{"name":"Sales East","type":"sales"}`.
   Expect `200` and a group in the response - record its id as `GROUP`.
3. **Assign the member:**
   `POST /api/organizations/{ORG}/groups/{GROUP}/members` with body `{"userId":"{MEMBER}"}`.
   Expect `200 {"success":true}`. `MEMBER`'s `user.groups` now contains `GROUP`.
4. **Consumer gating (the payoff):** share a document with the group by setting `groups: [{ "groupId": "{GROUP}", "permissions": ["read"] }]` on a FabFile (via the sharing path; until the share-with-group UI lands this may require an admin/DB write).
   - As `MEMBER`: `GET /api/data-lakes/...` (or ask the `retrieve_knowledge_content` tool for that file) -> the file is **visible / retrievable**.
   - As `OUTSIDER`: the same request -> the file is **absent / not-found** (no leak).
5. **Unassign:** `DELETE /api/organizations/{ORG}/groups/{GROUP}/members/{MEMBER}`.
   Expect `200`. `MEMBER`'s `user.groups` no longer contains `GROUP`, and access from step 4 is revoked.

**Negatives (must all be rejected)**
6. Assign `OUTSIDER` (not a member of `ORG`) to `GROUP` -> `400` "User is not a member of this organization" (invariant 2).
7. Assign `MEMBER` to a group that belongs to `ORG2` -> `400` "Group does not belong to this organization" (invariant 1).
8. As `MEMBER` (a plain member, not owner/admin) call the assign route -> `403` Forbidden.
9. Create a group with `{"type":"bogus"}` -> `400` "Unknown group type"; with a type the org was not granted -> `400` "not allowed the group type".

### Regression Checks
10. Assigning the same member twice (repeat step 3) still returns `200` and leaves a single membership (`$addToSet` idempotency).
11. Group assignment does not alter `ORG.users[]` / `userDetails[]` (org membership is unchanged).
12. Leaving the org still purges that org's group ids from `user.groups` (foundation behavior; `organizationService/leave`).

### What NOT to test
- Any group-management **UI** - there isn't one yet (Phase 5).
- **Capability** behavior - `capabilities[]` is stored but read by nothing (Phases 6+).
- Real-customer provisioning - keep this to internal/test orgs.

## Verified
Core build, `tsc` (common/database/services/client), eslint 0 errors, services suite green incl. the 8 `groupMembership` tests (3 authorized roles, forbidden non-admin, both cross-tenant negatives, not-found, remove-still-guards).

## Order note
Foundation (#1181) now includes **2b (#1174)** - the dormant `user.groups` consumers are exercised and a CASL over-grant was fixed - so this branch, rebased onto that foundation, gates through the corrected access path. Do not provision groups to a real customer ahead of the epic's rollout plan.
