### PR TITLE
ci: pre-warm the mongodb-memory-server binary before the test shards (#1098)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,28 @@ jobs:
         env:
           CI: 'true'
 
+      # Persist the downloaded mongod binary across runs so the pre-warm below is usually a
+      # no-op restore. restore-keys lets a lockfile bump reuse the prior binary (the pre-warm
+      # then tops up any new version) instead of a cold download every time.
+      - name: Cache mongodb-memory-server binary
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: ${{ runner.os }}-mongodb-binaries-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-mongodb-binaries-
+
+      # Resolve (download if absent) the mongod binary in a dedicated step, OUTSIDE any test's
+      # beforeAll hook budget. Under CI load a cold download + createMongoServer's port-retry
+      # loop can blow that budget, timing out the hook and silently skipping the whole file -
+      # the #1 flake in #1098. Fail-soft: tests still download on demand if this misses. Uses
+      # the same package + default version as createMongoServer, so the same binary is cached.
+      - name: Pre-warm mongodb-memory-server binary
+        continue-on-error: true
+        run: >-
+          pnpm --filter @bike4mind/database exec node -e
+          "require('mongodb-memory-server').MongoBinary.getPath({}).then(p => console.log('mongod binary ready:', p)).catch(e => console.warn('prewarm skipped:', e.message))"
+
       - name: Run Tests (${{ matrix.shard.name }})
         run: pnpm --recursive --workspace-concurrency=4 ${{ matrix.shard.filter }} test
         env:


### PR DESCRIPTION
## Description

Fixes flake **#1** from #1098 (`artifactModels.test.ts` — `Hook timed out in 60000ms` in `createMongoServer`'s `beforeAll`).

A cold `mongodb-memory-server` start under CI load = binary download + `createMongoServer`'s port-collision retry loop, which can exceed the hook budget. When it dies in `beforeAll`, **nothing in the file runs** — a coverage gap surfacing as a red. #785 already bumped that hook 30s→60s and #1098 shows it *still* blew past 60s, so raising the timeout again only moves the threshold (the issue says as much).

## Fix

Move the binary resolution **out of the per-hook budget** into a dedicated `test-shards` step, and cache it across runs:

- **Pre-warm step** — `MongoBinary.getPath({})` via `@bike4mind/database` (same package + default mongod version as `createMongoServer`, so it caches the exact binary the tests use). Runs before `Run Tests`; `continue-on-error` so a hiccup can't fail the shard (tests still download on demand as a backstop).
- **Cache step** — persists `~/.cache/mongodb-binaries` keyed on the lockfile hash, with a `restore-keys` fallback so a lockfile bump reuses the prior binary instead of a cold download. On the common path the pre-warm is a ~instant restore.

`mongodb-memory-server` is in `ignoredBuiltDependencies`, so its download-on-postinstall is skipped — which is exactly why the binary was being fetched lazily (cold) inside the test hook. This step restores that download to a controlled, budget-free moment.

## Guide for Testers

1. Open any PR and watch a `Run Tests (data)` / `Run Tests (client)` shard. Confirm the new **Pre-warm mongodb-memory-server binary** step logs `mongod binary ready: <path>` and the **Run Tests** step no longer hits `Hook timed out ... createMongoServer`.
2. First run after this merges downloads once (out of the hook budget); subsequent runs restore from cache in seconds.

### Regression Checks
- All shards still pass; the pre-warm is fail-soft so a download miss never fails a shard.

### What NOT to test
- CI-workflow-only change; no product/runtime or test-source change.

## Scope

Closes only **#1** of the three flakes in #1098. #3 (rate-limit window) is fixed in #1127; #2 (OTC cooldown CAS at `cooldownMs=0`) is a real `tryReserveSlot` edge left for its owner.

Refs #1098
