### PR TITLE
test(organizations): exercise dormant user.groups consumers (Phase 2b)

### DIFF
--- a/apps/client/server/auth/__tests__/ability.test.ts
+++ b/apps/client/server/auth/__tests__/ability.test.ts
@@ -31,7 +31,7 @@ vi.mock('@server/models/Subscription', () => ({
 }));
 
 import defineAbilitiesFor from '../ability';
-import { Prompt } from '@bike4mind/database';
+import { Prompt, FabFile } from '@bike4mind/database';
 
 const makeUser = (overrides: Partial<IUserDocument> = {}): IUserDocument =>
   ({
@@ -88,5 +88,62 @@ describe('defineAbilitiesFor - Prompt library permissions', () => {
     const ability = defineAbilitiesFor(undefined);
     expect(ability.can('read', Prompt)).toBe(false);
     expect(ability.can('create', Prompt)).toBe(false);
+  });
+});
+
+// Org Groups Phase 2b (#1174): exercise the dormant `user.groups` consumer in the
+// CASL access gate with a NON-empty groups array. `groups[]` on a shareable doc pairs a
+// groupId with the permissions that group is granted; access requires the user to be a
+// member of a group whose entry carries the requested permission.
+describe('defineAbilitiesFor - group-shared document access', () => {
+  type GroupShare = { groupId: string; permissions: string[] };
+  const sharedWithGroups = (groups: GroupShare[]) =>
+    Object.assign(new FabFile(), { userId: 'owner', users: [], groups });
+
+  it('grants read to a member of a group the doc shares read with', () => {
+    const ability = defineAbilitiesFor(makeUser({ groups: ['g1'] }));
+    const doc = sharedWithGroups([{ groupId: 'g1', permissions: ['read'] }]);
+    expect(ability.can('read', doc)).toBe(true);
+  });
+
+  it('denies a non-member (no overlapping group id)', () => {
+    const ability = defineAbilitiesFor(makeUser({ groups: ['g-other'] }));
+    const doc = sharedWithGroups([{ groupId: 'g1', permissions: ['read'] }]);
+    expect(ability.can('read', doc)).toBe(false);
+  });
+
+  it('denies when the matched group lacks the requested permission', () => {
+    const ability = defineAbilitiesFor(makeUser({ groups: ['g1'] }));
+    const doc = sharedWithGroups([{ groupId: 'g1', permissions: ['share'] }]);
+    expect(ability.can('read', doc)).toBe(false);
+    expect(ability.can('share', doc)).toBe(true);
+  });
+
+  it('denies when the user has no groups (empty array is the prod no-op)', () => {
+    const ability = defineAbilitiesFor(makeUser({ groups: [] }));
+    const doc = sharedWithGroups([{ groupId: 'g1', permissions: ['read'] }]);
+    expect(ability.can('read', doc)).toBe(false);
+  });
+
+  // The over-broad-grant guard: groupId and permission must hold on the SAME entry.
+  // The user is in g1 (granted only `share`); `read` is granted to g2, which they are
+  // NOT in. A dotted filter would satisfy the two conditions across the two entries and
+  // leak read; $elemMatch keeps them denied.
+  it('does not leak a permission granted to a different group (no cross-element match)', () => {
+    const ability = defineAbilitiesFor(makeUser({ groups: ['g1'] }));
+    const doc = sharedWithGroups([
+      { groupId: 'g1', permissions: ['share'] },
+      { groupId: 'g2', permissions: ['read'] },
+    ]);
+    expect(ability.can('read', doc)).toBe(false);
+  });
+
+  it('resolves the right entry when a doc is shared with several groups', () => {
+    const ability = defineAbilitiesFor(makeUser({ groups: ['g2'] }));
+    const doc = sharedWithGroups([
+      { groupId: 'g1', permissions: ['read'] },
+      { groupId: 'g2', permissions: ['read', 'update'] },
+    ]);
+    expect(ability.can('update', doc)).toBe(true);
   });
 });

--- a/apps/client/server/auth/ability.ts
+++ b/apps/client/server/auth/ability.ts
@@ -94,9 +94,14 @@ function defineAbilitiesFor(user: IUserDocument | undefined) {
           'users.userId': user.id,
           'users.permissions': permission,
         };
+        // $elemMatch so groupId and permission must hold on the SAME group entry.
+        // A dotted `{ 'groups.groupId': ..., 'groups.permissions': ... }` lets the two
+        // conditions be satisfied by different array elements - a doc shared with
+        // group A (some other permission) and group B (this permission) would grant
+        // access to an A-member, a cross-group over-grant. Mirrors the $elemMatch the
+        // fabFile search query already uses (packages/database fabFileSearchQuery.ts).
         const groupWithPermissions: MongoQuery = {
-          'groups.groupId': { $in: user.groups },
-          'groups.permissions': permission,
+          groups: { $elemMatch: { groupId: { $in: user.groups }, permissions: permission } },
         };
         allow(permission, resource, userWithPermissions);
 

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseRetrieve/index.test.ts
@@ -260,3 +260,59 @@ describe('retrieve_knowledge_content agent kbScope enforcement', () => {
     expect(getDynamicDataLakeAccessMock).toHaveBeenCalled();
   });
 });
+
+// Org Groups Phase 2b (#1174): exercise the dormant `user.groups` consumer in the by-id
+// (Path A) in-memory access guard with a NON-empty array. A file is group-accessible only
+// when the user is a member of a group whose entry on the file grants read or write - the
+// same per-entry semantics the $elemMatch query enforces, checked here in memory.
+describe('retrieve_knowledge_content - group-shared access (Path A)', () => {
+  type GroupShare = { groupId: string; permissions: string[] };
+  const sharedFileCtx = (userGroups: string[], fileGroups: GroupShare[]) => {
+    const ctx = makeContext({ retrievalFilter: undefined, user: { id: 'u1', groups: userGroups } as never });
+    (ctx.db.fabfiles!.findByIdAndUserId as ReturnType<typeof vi.fn>).mockResolvedValue(null); // not owned
+    (ctx.db.fabfiles!.findById as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeFile({ fileName: 'Group Shared.pdf', groups: fileGroups })
+    );
+    return ctx;
+  };
+
+  it('a member of a group granted read retrieves the file', async () => {
+    const out = await runById(sharedFileCtx(['g1'], [{ groupId: 'g1', permissions: ['read'] }]));
+    expect(out).toContain('Retrieved content from');
+  });
+
+  it('a member of a group granted write also retrieves the file', async () => {
+    const out = await runById(sharedFileCtx(['g1'], [{ groupId: 'g1', permissions: ['write'] }]));
+    expect(out).toContain('Retrieved content from');
+  });
+
+  it('a non-member is denied (reads as not-found)', async () => {
+    const out = await runById(sharedFileCtx(['g-other'], [{ groupId: 'g1', permissions: ['read'] }]));
+    expect(out).toContain(`No document found with ID "${FILE_ID}"`);
+  });
+
+  it('a member whose group grants neither read nor write is denied', async () => {
+    const out = await runById(sharedFileCtx(['g1'], [{ groupId: 'g1', permissions: ['share'] }]));
+    expect(out).toContain(`No document found with ID "${FILE_ID}"`);
+  });
+
+  // g1 (the user's group) grants only `share`; `read` is granted to g2, which the user is
+  // NOT in. The per-entry `.some()` must not combine them into a grant.
+  it('does not leak read granted to a different group (no cross-entry match)', async () => {
+    const out = await runById(
+      sharedFileCtx(
+        ['g1'],
+        [
+          { groupId: 'g1', permissions: ['share'] },
+          { groupId: 'g2', permissions: ['read'] },
+        ]
+      )
+    );
+    expect(out).toContain(`No document found with ID "${FILE_ID}"`);
+  });
+
+  it('a user with no groups is denied (empty array is the prod no-op)', async () => {
+    const out = await runById(sharedFileCtx([], [{ groupId: 'g1', permissions: ['read'] }]));
+    expect(out).toContain(`No document found with ID "${FILE_ID}"`);
+  });
+});

--- a/docs/architecture/org-groups-consumer-verification.md
+++ b/docs/architecture/org-groups-consumer-verification.md
@@ -1,0 +1,89 @@
+# Org Groups: `user.groups` consumer verification (Phase 2b)
+
+The `Group` collection is empty in production, so every consumer that branches on
+`user.groups` has only ever seen an empty array. Turning groups on lights them all up at
+once, and the first use gates confidential data. This is the deliberate pass that exercises
+each consumer with a **non-empty** `user.groups` **before** any real group is provisioned,
+so Phase 3 does not discover behavior through a real customer.
+
+## The shared invariant
+
+Every consumer matches `user.groups` (a flat array of group ids, no org qualifier) against
+a shared document's `groups[]`, where each entry pairs a `groupId` with the `permissions`
+that group is granted. Access requires **membership in a group whose entry carries the
+requested permission** - the groupId and the permission must be on the **same** entry. Two
+failure modes to keep out:
+
+1. **Crash / no-op break** - the filter shape breaks on non-empty input.
+2. **Over-broad grant** - the match leaks beyond the intended group + permission (e.g. a
+   permission granted to one group bleeds to a member of a different group on the same doc).
+
+## Consumers map to three implementations
+
+The five consumers collapse to three distinct group-matching implementations. Verifying
+those three covers all five.
+
+| Consumer | Implementation | Notes |
+|---|---|---|
+| CASL ability resolution (`apps/client/server/auth/ability.ts`) | **A. CASL `$elemMatch`** | The access gate. Compiled to a Mongo query via `accessibleBy`. |
+| Data lakes (`apps/client/server/dataLakes/index.ts`, both call sites) | **B. `buildOwnershipConditions` `$elemMatch`** | Thin pass-through of `user.groups ?? []` into `fabfiles.search`. |
+| `ChatCompletionFeatures.ts` forced retrieval | **B** | Pass-through into `db.fabfiles.search`. |
+| `knowledgeBaseSearch` (semantic + keyword) | **B** | Semantic path funnels through `collectScopedFiles` -> `fabfiles.search`; keyword path calls `fabfiles.search` directly. |
+| `knowledgeBaseRetrieve` Path B (tag/query search) | **B** | Same `fabfiles.search` funnel. |
+| `knowledgeBaseRetrieve` Path A (deep link by id) | **C. in-memory `.some()`** | Per-entry check `userGroups.includes(g.groupId) && g.permissions.some(read/write)`. |
+
+Implementation **B** (`buildOwnershipConditions` in
+`packages/database/src/queries/fabFileSearchQuery.ts`) is the single chokepoint for four of
+the five consumers.
+
+## Verification results
+
+Each implementation is now locked with unit tests asserting **grant for the right member,
+deny for a non-member, deny on the wrong permission, no-op on an empty array, and no
+cross-group over-grant**.
+
+- **A. CASL ability** - `apps/client/server/auth/__tests__/ability.test.ts`
+  (`group-shared document access`). Member with the granted permission is allowed; a
+  non-member, a member whose entry lacks the permission, and an empty `user.groups` are all
+  denied; a permission granted to a different group on the same doc does not leak.
+- **B. `buildOwnershipConditions`** - `packages/database/src/queries/fabFileSearchQuery.group.test.ts`.
+  A non-empty `userGroups` adds exactly one `$elemMatch` arm scoped to those ids and
+  `read`/`write`; an empty/absent `userGroups` adds no group arm; `restrictToDataLake` drops
+  the broad ownership arms (incl. groups) as designed.
+- **C. KB retrieve Path A** - `knowledgeBaseRetrieve/index.test.ts`
+  (`group-shared access (Path A)`). Same grant/deny matrix, checked through the tool's
+  by-id retrieval.
+
+### Defect found and fixed as part of this pass
+
+The CASL group arm (implementation A) was built with a **dotted** filter,
+`{ 'groups.groupId': { $in: user.groups }, 'groups.permissions': permission }`. Compiled to
+Mongo, the two conditions can be satisfied by **different** array elements: a doc shared
+with group G (some other permission) and group X (this permission) would grant access to a
+G-member. That is the over-broad grant this phase exists to prevent, on the highest-priority
+access gate. It never mattered while `user.groups` was always empty, but it would have
+mattered on the first real group.
+
+Fixed to `$elemMatch` so the groupId and permission must hold on the same entry, matching
+the pattern implementations B and C already use. Groups are dormant (empty collection), so
+this is a forward-only correctness fix with no migration or behavior change for existing
+data.
+
+### Known sibling to evaluate separately
+
+The **explicit-user** arm directly above the group arm in `ability.ts`
+(`{ 'users.userId': user.id, 'users.permissions': permission }`) has the same dotted,
+non-`$elemMatch` shape. It is live production behavior for user-to-user sharing (not dormant),
+so it was left untouched here; in practice a doc lists a given `userId` once, so the
+cross-entry match does not trigger. Worth a separate, deliberately-scoped look rather than
+folding a live-behavior change into this dormant-path pass.
+
+## Sign-off
+
+- [x] CASL ability resolution behaves correctly with a non-empty `user.groups`.
+- [x] `dataLakes/index.ts` (both call sites) - verified via implementation B.
+- [x] `ChatCompletionFeatures.ts` - verified via implementation B.
+- [x] `knowledgeBaseRetrieve` (Path A in-memory + Path B search) - verified via C and B.
+- [x] `knowledgeBaseSearch` (semantic + keyword) - verified via implementation B.
+- [x] No crash on non-empty input; no over-broad grant (CASL over-match fixed).
+- [x] Documented as a repeatable checklist (this file + the tests above).

--- a/packages/database/src/queries/fabFileSearchQuery.group.test.ts
+++ b/packages/database/src/queries/fabFileSearchQuery.group.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { buildOwnershipConditions } from './fabFileSearchQuery';
+
+/**
+ * Org Groups Phase 2b (#1174): exercise the dormant `userGroups` consumer in the shared
+ * fabFile ownership filter with a NON-empty array. This one builder is the group-matching
+ * chokepoint for four of the five consumers - data lakes, ChatCompletionFeatures forced
+ * retrieval, knowledgeBaseSearch (semantic + keyword), and knowledgeBaseRetrieve Path B -
+ * since they all funnel their `user.groups` through `fabfiles.search`.
+ *
+ * The invariant: group access is an $elemMatch, so a doc's groupId and the granted
+ * permission must live on the SAME group entry (no cross-element over-grant), and the arm
+ * is added ONLY when the user actually has groups (empty array stays the prod no-op).
+ */
+const findGroupArm = (conditions: object[]) =>
+  conditions.find((c): c is { groups: { $elemMatch: unknown } } => 'groups' in c);
+
+describe('buildOwnershipConditions - group-level sharing (userGroups)', () => {
+  it('adds an $elemMatch group arm scoped to the user groups and read/write', () => {
+    const conditions = buildOwnershipConditions('u1', { userGroups: ['g1', 'g2'] });
+
+    expect(findGroupArm(conditions)).toEqual({
+      groups: {
+        $elemMatch: {
+          groupId: { $in: ['g1', 'g2'] },
+          permissions: { $in: ['read', 'write'] },
+        },
+      },
+    });
+  });
+
+  it('omits the group arm entirely when the user has no groups', () => {
+    expect(findGroupArm(buildOwnershipConditions('u1', { userGroups: [] }))).toBeUndefined();
+    expect(findGroupArm(buildOwnershipConditions('u1', {}))).toBeUndefined();
+    expect(findGroupArm(buildOwnershipConditions('u1'))).toBeUndefined();
+  });
+
+  it('keeps the owner + explicit-user arms alongside the group arm', () => {
+    const conditions = buildOwnershipConditions('u1', { userGroups: ['g1'] });
+
+    expect(conditions).toContainEqual({ userId: 'u1' });
+    expect(conditions).toContainEqual({
+      users: { $elemMatch: { userId: 'u1', permissions: { $in: ['read', 'write'] } } },
+    });
+    expect(findGroupArm(conditions)).toBeDefined();
+  });
+
+  it('drops the broad ownership arms (incl. groups) in restrictToDataLake mode', () => {
+    const conditions = buildOwnershipConditions('u1', {
+      userGroups: ['g1'],
+      restrictToDataLake: true,
+      dataLakeTags: ['datalake:acme:kb'],
+    });
+
+    expect(findGroupArm(conditions)).toBeUndefined();
+    expect(conditions).not.toContainEqual({ userId: 'u1' });
+  });
+});


### PR DESCRIPTION
## Description

Part of the Organization Groups epic (#1172). Stacked on `feat/org-groups-foundation`.

The `Group` collection is empty in production, so every consumer that branches on `user.groups` has only ever seen an empty array. Turning groups on lights them all up at once, and the first use gates confidential data. This PR exercises each dormant consumer with a **non-empty** `user.groups` **before** any real group is provisioned, so Phase 3 does not discover behavior through a real customer.

The five consumers collapse to **three** distinct group-matching implementations. Verifying those three covers all five:

- **A. CASL ability** (`apps/client/server/auth/ability.ts`) - the access gate.
- **B. `buildOwnershipConditions` `$elemMatch`** (`packages/database/.../fabFileSearchQuery.ts`) - the shared chokepoint for data lakes (both call sites), `ChatCompletionFeatures` forced retrieval, `knowledgeBaseSearch` (semantic + keyword), and `knowledgeBaseRetrieve` Path B.
- **C. `knowledgeBaseRetrieve` Path A** - the in-memory per-entry match for deep-link-by-id.

### Defect found and fixed

The CASL group arm (A) was built with a **dotted** filter, `{ 'groups.groupId': { $in }, 'groups.permissions': permission }`. Compiled to Mongo via `accessibleBy`, the two conditions can be satisfied by **different** array entries: a doc shared with group G (some other permission) and group X (this permission) would grant access to a G-member - a cross-group over-grant on the highest-priority access gate. It never mattered while `user.groups` was always empty. Fixed to `$elemMatch` (groupId and permission must hold on the same entry), matching what implementations B and C already do. Groups are dormant, so this is a forward-only correctness fix - no migration, no behavior change for existing data.

The explicit-**user** arm directly above it has the same dotted shape but is live user-to-user sharing behavior; left untouched here and flagged in the checklist doc for a separate, deliberately-scoped look.

## Changes

- `ability.ts`: group-shared grant arm switched from a dotted filter to `$elemMatch`.
- `ability.test.ts`: new `group-shared document access` block (grant, non-member deny, wrong-permission deny, empty-array no-op, cross-group leak denied, multi-group resolves the right entry).
- `fabFileSearchQuery.group.test.ts` (new): asserts the `$elemMatch` group arm shape, its absence on empty/absent `userGroups`, and that `restrictToDataLake` drops the broad ownership arms.
- `knowledgeBaseRetrieve/index.test.ts`: new `group-shared access (Path A)` block with the same grant/deny matrix.
- `docs/architecture/org-groups-consumer-verification.md` (new): the checklist run + sign-off.

## Guide for Testers

Backend/test-only PR - verification is the automated suites (no UI surface). Run from the repo root.

1. Rebuild core so the foundation's new `@bike4mind/common` exports resolve:
   `pnpm turbo:core:build` - expect `18 successful`.
2. Typecheck the touched packages:
   `pnpm --filter @bike4mind/database typecheck && pnpm --filter @bike4mind/services typecheck && pnpm --filter @bike4mind/client typecheck` - all exit 0, no output.
3. Run implementation A tests:
   `pnpm --filter @bike4mind/client exec vitest run server/auth/__tests__/ability.test.ts` - expect `13 passed`.
4. Run implementation B tests:
   `pnpm --filter @bike4mind/database exec vitest run src/queries/fabFileSearchQuery.group.test.ts` - expect `4 passed`.
5. Run implementation C tests:
   `pnpm --filter @bike4mind/services exec vitest run src/llm/tools/implementation/knowledgeBaseRetrieve/index.test.ts` - expect `22 passed`.

### Regression Checks

6. Full suites for the touched packages stay green:
   `VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/database test` (expect `1026 passed | 1 skipped`), `pnpm --filter @bike4mind/services test` (expect `2875 passed | 11 skipped`), and `pnpm --filter @bike4mind/client exec vitest run server/auth` (expect `133 passed`).

### What NOT to test

- No UI, API route, or runtime behavior changes to exercise in a browser - `user.groups` is still empty in every environment until a group is provisioned (Phase 3+).
- Do not provision a real `Group`; this PR's purpose is to prove the consumers before that happens.

## Additional Information

Closes #1174.

Depends on #1181 (foundation) - review/merge after it. Base branch is `feat/org-groups-foundation`, not `main`.

## Developer Notes

- The three-implementation map (A CASL / B `buildOwnershipConditions` / C in-memory) is the canonical reference for where group access is decided; the checklist doc records it so future group work has one place to look.
- `buildOwnershipConditions` is the single group-matching chokepoint for four of the five consumers - test coverage there transitively protects all of them.
