### PR TITLE
docs(settings): correct the empty-write backstop rationale

### DIFF
--- a/apps/client/app/components/admin/AdminSettingInputField.tsx
+++ b/apps/client/app/components/admin/AdminSettingInputField.tsx
@@ -110,10 +110,12 @@ const AdminSettingInputField = ({
 
   const saveValue = (next: string | number | boolean) => {
     // Backstop, intentionally unreachable while isDirty excludes the untouched-empty state
-    // above: focusing a sensitive field clears the mask, and a click is not guaranteed to
-    // blur the input first (macOS Safari and Firefox do not focus buttons on click). If the
-    // dirty logic is ever loosened, this still stops '' overwriting a stored key. Kept
-    // deliberately - do not delete it as redundant.
+    // above. Kept because it does not depend on event ordering: the dirty check protects the
+    // button, this protects the write, so loosening one cannot silently expose ''.
+    // Do not delete as redundant. The original rationale cited macOS Safari and Firefox not
+    // blurring the input before a save click; that was measured and is wrong - both do blur
+    // on the button's mousedown and restore the mask. No browser is known to skip the blur,
+    // but nothing in the DOM contract guarantees it either.
     if (setting.isSensitive && next === '' && !secretEdited) return;
 
     updateSettings.mutate(


### PR DESCRIPTION
## Description

Follow-up to #1054, which is now merged. Comment-only, no behaviour change.

The backstop in `AdminSettingInputField.saveValue` that refuses to write `''` over a stored sensitive setting justified itself with a browser behaviour that turns out not to exist. It claimed macOS Safari and Firefox do not blur the input before a save click, which would make that guard the load-bearing protection on those browsers.

The QA run on #1054 measured it with native mouse input on Safari 18.3 and Firefox 152. Half the claim holds: neither browser moves focus to the button. The other half does not: mousedown on Save blurs the field in both, which restores the mask before any click handler could run. So the scenario the comment names does not arise on either browser it names.

## Why bother, given the guard is staying

A wrong justification is worse than no justification. The next person to touch this reads that comment, tries to reproduce the no-blur case on the two browsers it cites, cannot, and concludes the guard is dead code. The guard is not dead code, so the comment needs to say something true.

What actually earns it a place is independence from event ordering. The dirty check protects the button and this protects the write, so loosening either one cannot silently expose an empty write on its own. That reason holds regardless of what any particular browser does with focus, which is also why it is the reason worth writing down.

## Changes

Rewrote the comment above the `setting.isSensitive && next === '' && !secretEdited` early return. Records the measured result, keeps the do-not-delete note, and states the ordering-independence rationale instead of the browser claim. The line it documents is untouched.

## Test Plan

Nothing to exercise. The diff is six comment lines; no statement, expression, or type changed. `git diff --stat` is one file, six insertions, four deletions, all inside a comment block.

For a reviewer wanting to confirm the underlying claim rather than take it on trust, the measurements are in the QA report on #1054: per-browser tables sampled from inside in-page focus and blur listeners, showing the blur firing on the Save button's mousedown in both browsers, and the save button reporting disabled in every sample including the focused-and-empty window.

## Additional Information

Not verified with typecheck or lint. The change is inside a comment block, lines are 93 characters at the widest against a printWidth of 120, and prettier does not reflow comments, so there is nothing for either to report. Flagging it rather than implying a run that did not happen.

Branched off `main` after #1054 landed at `67c107ae`, not off the feature branch, so this carries exactly one commit.
