### PR TITLE
test(database): make OTC cooldown tests robust to legal schedulings

### DIFF
--- a/packages/database/src/__tests__/pending-otc-cooldown.test.ts
+++ b/packages/database/src/__tests__/pending-otc-cooldown.test.ts
@@ -86,12 +86,22 @@ describe('PendingOtcToken.tryReserveSlot — atomic cooldown enforcement', () =>
   });
 
   describe('cooldownMs = 0 (E2E bypass)', () => {
+    // Even at cooldownMs = 0, a resend in the SAME millisecond as the previous
+    // reservation is blocked (`existing.createdAt >= threshold` compares at ms
+    // resolution), so tests that reserve twice must let the clock tick first.
+    const clockTickPast = async (previous: Date) => {
+      while (Date.now() <= previous.getTime()) {
+        await new Promise(resolve => setTimeout(resolve, 1));
+      }
+    };
+
     it('allows repeated sequential resends to the same email, each overwriting the last nonce', async () => {
       const first = await pendingOtcTokenRepository.tryReserveSlot(EMAIL, 0);
       expect(first.allowed).toBe(true);
       if (!first.allowed) throw new Error('unreachable');
       expect(await pendingOtcTokenRepository.confirmReservation(EMAIL, first.reservedAt, 'nonce-1')).toBe(true);
 
+      await clockTickPast(first.reservedAt);
       const second = await pendingOtcTokenRepository.tryReserveSlot(EMAIL, 0);
       expect(second.allowed).toBe(true);
       if (!second.allowed) throw new Error('unreachable');
@@ -102,7 +112,7 @@ describe('PendingOtcToken.tryReserveSlot — atomic cooldown enforcement', () =>
       expect(await PendingOtcTokenModel.countDocuments({ email: EMAIL })).toBe(1);
     });
 
-    it('concurrent reservations on an already-existing record: exactly one wins (the createdAt < now bug this closes)', async () => {
+    it('concurrent reservations on an already-existing record: winners form a strict supersession chain (the createdAt < now bug this closes)', async () => {
       // Seed an existing record so every racer takes the "reclaim" branch, not the
       // brand-new-email "create" branch (that one was already protected by the
       // unique index, tested separately above).
@@ -112,13 +122,39 @@ describe('PendingOtcToken.tryReserveSlot — atomic cooldown enforcement', () =>
         Array.from({ length: 5 }, () => pendingOtcTokenRepository.tryReserveSlot(EMAIL, 0))
       );
 
-      const allowed = results.filter(r => r.allowed);
-      const blocked = results.filter(r => !r.allowed);
-      // Before the fix, a bare `createdAt < now` filter matched for every racer
-      // (any prior write is always "in the past" relative to a later `now`), so
-      // all 5 would win here and each would silently overwrite the last one's nonce.
-      expect(allowed).toHaveLength(1);
-      expect(blocked).toHaveLength(4);
+      // The winner COUNT is scheduling-dependent, so don't assert it. At cooldownMs = 0
+      // there is no cooldown window: a racer whose read lands after a sibling's claim is
+      // a legitimate NEW winner, exactly like the sequential-resend case above. Promise.all
+      // gives no barrier between one racer's write and another's read, so under CI load
+      // more than one generation can occur (this flaked in CI expecting exactly 1).
+      //
+      // What the CAS does guarantee, under any scheduling:
+      //   - at least one racer wins
+      //   - winners supersede each other: strictly increasing, DISTINCT reservedAt values.
+      //     The pre-fix bare `createdAt < now` filter let every racer win off the same
+      //     stale snapshot (any prior write is always "in the past" relative to a later
+      //     `now`), which shows up here as duplicate reservedAt values.
+      //   - the record is updated in place, never duplicated
+      //   - only the LAST winner holds a confirmable reservation; superseded winners fail
+      const winners = results.filter((r): r is { allowed: true; reservedAt: Date } => r.allowed);
+      expect(winners.length).toBeGreaterThanOrEqual(1);
+
+      const times = winners.map(w => w.reservedAt.getTime()).sort((a, b) => a - b);
+      for (let i = 1; i < times.length; i++) {
+        expect(times[i]).toBeGreaterThan(times[i - 1]);
+      }
+
+      expect(await PendingOtcTokenModel.countDocuments({ email: EMAIL })).toBe(1);
+
+      const latest = winners.reduce((a, b) => (a.reservedAt > b.reservedAt ? a : b));
+      for (const w of winners) {
+        const confirmed = await pendingOtcTokenRepository.confirmReservation(
+          EMAIL,
+          w.reservedAt,
+          `nonce-${w.reservedAt.getTime()}`
+        );
+        expect(confirmed).toBe(w === latest);
+      }
     });
 
     it('confirmReservation fails for a reservation a newer one has since superseded, instead of silently succeeding', async () => {
@@ -129,6 +165,7 @@ describe('PendingOtcToken.tryReserveSlot — atomic cooldown enforcement', () =>
       // A second, later reservation for the same email lands before the first confirms
       // - e.g. a genuinely concurrent resend that arrived just after the first claimed
       // its slot but before it finished generating/sending its code.
+      await clockTickPast(first.reservedAt);
       const second = await pendingOtcTokenRepository.tryReserveSlot(EMAIL, 0);
       expect(second.allowed).toBe(true);
       if (!second.allowed) throw new Error('unreachable');

--- a/packages/database/src/__tests__/pending-otc-cooldown.test.ts
+++ b/packages/database/src/__tests__/pending-otc-cooldown.test.ts
@@ -67,6 +67,29 @@ describe('PendingOtcToken.tryReserveSlot — atomic cooldown enforcement', () =>
     expect(blocked).toHaveLength(4);
   });
 
+  it('concurrent reclaims of a stale record: exactly one wins inside the new cooldown window', async () => {
+    // Reclaim-branch counterpart of the create-branch race above. Seed a record
+    // older than the cooldown so every racer tries to reclaim it. Unlike the
+    // cooldownMs = 0 race below, the winner count here IS deterministic: a racer
+    // that read the seed loses the CAS to the winner, and a racer that read the
+    // winner's fresh createdAt is inside the window and blocked. This is the
+    // suite's anti-spam guard for the reclaim path: a non-atomic reclaim would
+    // let several concurrent requests each send an OTC email within the cooldown.
+    await PendingOtcTokenModel.create({
+      email: EMAIL,
+      nonce: 'seed-nonce',
+      createdAt: new Date(Date.now() - COOLDOWN_MS - 1000),
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => pendingOtcTokenRepository.tryReserveSlot(EMAIL, COOLDOWN_MS))
+    );
+
+    expect(results.filter(r => r.allowed)).toHaveLength(1);
+    expect(results.filter(r => !r.allowed)).toHaveLength(4);
+    expect(await PendingOtcTokenModel.countDocuments({ email: EMAIL })).toBe(1);
+  });
+
   it('confirmReservation after a successful reserve persists the real nonce', async () => {
     const reservation = await pendingOtcTokenRepository.tryReserveSlot(EMAIL, COOLDOWN_MS);
     expect(reservation.allowed).toBe(true);
@@ -130,12 +153,15 @@ describe('PendingOtcToken.tryReserveSlot — atomic cooldown enforcement', () =>
       //
       // What the CAS does guarantee, under any scheduling:
       //   - at least one racer wins
-      //   - winners supersede each other: strictly increasing, DISTINCT reservedAt values.
-      //     The pre-fix bare `createdAt < now` filter let every racer win off the same
-      //     stale snapshot (any prior write is always "in the past" relative to a later
-      //     `now`), which shows up here as duplicate reservedAt values.
+      //   - winners supersede each other: strictly increasing, DISTINCT reservedAt values
+      //     (duplicates would mean two same-millisecond wins, the old non-atomic
+      //     check-then-act shape described in the file header)
       //   - the record is updated in place, never duplicated
       //   - only the LAST winner holds a confirmable reservation; superseded winners fail
+      //
+      // A non-atomic reclaim regression is NOT reliably observable at cooldown 0 (a
+      // stale-snapshot win looks like a legitimate resend); the deterministic guard for
+      // that is the stale-record reclaim race test in the outer describe.
       const winners = results.filter((r): r is { allowed: true; reservedAt: Date } => r.allowed);
       expect(winners.length).toBeGreaterThanOrEqual(1);
 


### PR DESCRIPTION
## Description

`packages/database/src/__tests__/pending-otc-cooldown.test.ts` has two timing-dependent assertions that fail intermittently on correct production code. One flaked in CI on PR #993 ("Run Tests (data)" leg, unrelated change; a plain rerun went green). The other reproduced locally at roughly 1 in 15 runs on a fast machine.

Both flakes come from properties `tryReserveSlot` never actually guaranteed at `cooldownMs = 0`:

1. **"Exactly one racer wins" is scheduling-dependent.** With no cooldown window, a racer whose read lands after a sibling's claim is a legitimate new winner (the sequential-resend test in the same file explicitly allows this). `Promise.all` provides no barrier between one racer's write and another's read, so a loaded CI runner can serialize racers and produce 2+ valid winners.
2. **A same-millisecond resend is blocked.** The cooldown check (`existing.createdAt >= threshold`) compares at ms resolution, so two sequential reservations landing in the same millisecond block the second one, even at cooldown 0. Fast machines occasionally do exactly that.

The fix is test-only; production semantics are untouched. The race test now asserts the invariants the CAS does guarantee under any scheduling: at least one winner, winners form a strict supersession chain (strictly increasing, distinct `reservedAt`), exactly one document remains, and only the last winner can confirm. The two sequential tests wait for the clock to tick past the previous reservation before reserving again.

Review of the first commit surfaced a real gap: dropping the exact-count assertion left the suite with no concurrent regression guard on the reclaim path (the existing nonzero-cooldown race test only covers the brand-new-email create branch), and a non-atomic reclaim regression is not reliably observable at cooldown 0 at all. The second commit adds the guard where the winner count IS deterministic: a stale-record reclaim race at `COOLDOWN_MS`, where a late reader is blocked by the cooldown window and a stale reader is blocked by the CAS under every interleaving. It also corrects an in-test comment that overclaimed what the distinct-`reservedAt` assertion catches.

## Changes

- `packages/database/src/__tests__/pending-otc-cooldown.test.ts`
  - Race test at cooldown 0: replaced the exact winner/loser counts with the scheduling-independent invariants above, plus a supersession check (`confirmReservation` succeeds only for the latest winner).
  - Added a `clockTickPast` helper and used it in the two tests that reserve twice at cooldown 0, removing the same-millisecond block hazard.
  - Added a deterministic stale-record reclaim race test at `COOLDOWN_MS` (exactly one of 5 concurrent reclaims wins) as the anti-spam regression guard for the reclaim CAS.

## Guide for Testers

Backend test-only change; nothing to test in the app.

**What NOT to test:** no runtime code changed. OTC send behavior, cooldowns, and E2E bypass are unaffected.

Repro/verification for reviewers:

1. `cd packages/database`
2. `for i in $(seq 1 25); do pnpm vitest run src/__tests__/pending-otc-cooldown.test.ts 2>&1 | grep "Tests "; done`
3. Expected: `9 passed` on every run. Before this change, the superseded-reservation test failed intermittently at this repetition count on a fast machine.

## Additional Information

Verification summary: 25/25 consecutive local runs of the file pass, full `@bike4mind/database` suite passes, package `pnpm typecheck` is clean, and a mutation check (temporarily removing the reclaim CAS filter locally) makes both race tests fail, confirming the regression guards actually fire.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
