### PR TITLE
refactor(services): remove any from artifactService create

### DIFF
--- a/b4m-core/services/src/artifactService/create.test.ts
+++ b/b4m-core/services/src/artifactService/create.test.ts
@@ -94,6 +94,9 @@ describe('artifactService - create', () => {
         version: 1,
         status: 'draft',
         visibility: 'private',
+        // _ids from the content/version writes must thread into the artifact record
+        contentId: 'content-id-123',
+        currentVersionId: 'version-id-123',
       })
     );
   });

--- a/b4m-core/services/src/artifactService/create.ts
+++ b/b4m-core/services/src/artifactService/create.ts
@@ -2,6 +2,9 @@ import {
   IArtifactRepository,
   IArtifactContentRepository,
   IArtifactVersionRepository,
+  IArtifactDocument,
+  IArtifactContentDocument,
+  IArtifactVersionDocument,
   createArtifactId,
   calculateContentHash,
   calculateContentSize,
@@ -49,6 +52,12 @@ interface CreateArtifactAdapters {
   };
 }
 
+// Repo.create() input: the persisted doc minus fields absent from a create
+// payload -- the datastore-generated _id and timestamps, plus the caller-owned
+// id (supplied separately). Cast to the repo's create() param at the call site,
+// since IBaseRepository.create still lists _id as required.
+type CreateInput<T> = Omit<T, '_id' | 'id' | 'createdAt' | 'updatedAt'>;
+
 /**
  * Creates a new artifact with content and initial version
  */
@@ -92,7 +101,7 @@ export const create = async (
     contentSize,
     mimeType: getContentMimeType(type),
     encoding: 'utf8',
-  } as any);
+  } satisfies CreateInput<IArtifactContentDocument> as Parameters<IArtifactContentRepository['create']>[0]);
 
   // Create version record
   const artifactVersion = await db.artifactVersions.create({
@@ -103,13 +112,16 @@ export const create = async (
     changeDescription: 'Created artifact',
     createdBy: userId,
     isActive: true,
-  } as any);
+  } satisfies CreateInput<IArtifactVersionDocument> as Parameters<IArtifactVersionRepository['create']>[0]);
 
   // Set up permissions
   const artifactPermissions = permissions || createDefaultPermissions(userId);
 
-  // Create main artifact record
-  const artifact = {
+  // Create main artifact record. `id` is re-added because CreateInput strips it
+  // (it's caller-supplied and a distinct field from Mongo's _id). `contentId` is
+  // a denormalized pointer the Mongoose ArtifactModel persists but that isn't on
+  // the IArtifactDocument type yet, so it's typed on top of the create input.
+  const artifact: CreateInput<IArtifactDocument> & { id: string; contentId: string } = {
     id: artifactId,
     type,
     title,
@@ -117,7 +129,7 @@ export const create = async (
     version: 1,
     versionTag,
     currentVersionId: artifactVersion._id,
-    contentId: artifactContent._id, // required contentId field
+    contentId: artifactContent._id,
     userId,
     projectId,
     organizationId,
@@ -133,7 +145,11 @@ export const create = async (
     metadata,
   };
 
-  const createdArtifact = await db.artifacts.create(artifact as any);
+  // Object already validated by its annotation above; `as unknown as` just
+  // bridges the id/_id shape gap the create() param type can't express.
+  const createdArtifact = await db.artifacts.create(
+    artifact as unknown as Parameters<IArtifactRepository['create']>[0]
+  );
 
   return {
     artifact: createdArtifact,


### PR DESCRIPTION
Part of #175 (reduce `any` in top offenders).

Removes 3 `as any` casts from `artifactService/create.ts` (the repo `.create()` calls).

Root cause of the casts: `IBaseRepository.create` is typed `Omit<T,'id'|createdAt|updatedAt>`, but the artifact doc types key on `_id` (DB-generated), so the type wrongly demanded `_id` at create time. Each object is now built as `satisfies CreateInput<Doc> as Parameters<Repo['create']>[0]` -- `satisfies` fully checks every real field; the only gap is the generated `_id`.

The main artifact object additionally carries two fields that are persisted by the Mongoose `ArtifactModel` but not on the `IArtifactDocument` type, so they're typed explicitly on top of the create input:
- `id` -- caller-supplied, a distinct field from Mongo's `_id`
- `contentId` -- denormalized content pointer

No behavior change; the object literals passed to `.create()` are byte-identical.

## Verification
- `@bike4mind/services` typecheck clean; lint clean; 0 `any` in the file.
- Unit test (`create.test.ts`) passes 3/3, plus a new assertion that the content/version `_id`s thread into `contentId`/`currentVersionId` on the artifact record.
- Exercised the real code path against a real Mongoose `ArtifactModel` on an in-memory Mongo: artifact, content and version all persist, and `contentId` / `id` / `currentVersionId` round-trip through real schema validation.


## Testing guide

Preview: https://app.pr1214.preview.bike4mind.com/artifacts-demo

1. Log in and open the Artifact Gallery. Note the current count.
2. Click **Create New Artifact**.
3. Enter a title, leave Type = `React Component` and keep the prefilled content.
4. Click **Create**.

**Expected:** the artifact is created with no error, appears in the gallery as a card with the `react` chip, and is still there after a page reload.

This is a type-only change, so nothing else needs regression testing.
