### PR TITLE
fix(chat): keep context meter below composer popovers

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -591,7 +591,10 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
                         sx={{
                           position: 'absolute',
                           mr: 20,
-                          zIndex: 2000,
+                          // Passive readout: must stay below composer popovers (attach
+                          // menu zIndex 1000 in AttachFileButton.tsx, slash/mention
+                          // suggestions), or it intercepts their clicks.
+                          zIndex: 1,
                           backgroundColor: 'background.surface',
                           borderRadius: '6px',
                           padding: '4px 8px',


### PR DESCRIPTION
# Pull Request

## Description

Fixes #1167

Once a notebook crosses the 70% context band, the composer's context meter pill rendered at `zIndex: 2000` — above the attach menu (`zIndex: 1000`), which opens upward into the same band. Neither element is portaled, so the meter painted over the open menu and intercepted its clicks: "Upload from Computer" was dead, and clicks near the meter closed the menu via the outside-click handler.

The meter is a passive readout and only needs to sit above the editor's in-flow content, so it drops to `zIndex: 1`. Fixing the meter side (instead of raising the menu above 2000) avoids a z-index arms race and resolves the same conflict for every composer popover under 2000. The `zIndex: 2000` predates the meter feature — #995 just made it visible often enough to collide.

## Changes

- `SessionBottom.tsx`: context meter pill `zIndex` 2000 → 1, with a comment documenting the stacking invariant.

## Guide for Testers

1. Open a notebook where the context meter pill (`74% of <model> context`) shows at the bottom of the input — e.g. send long messages on a small-context model like Llama 4 Maverick 17B Instruct (8K window) until it appears. If it vanishes right after a response streams in, reload the page (known pre-existing quirk, unrelated to this fix).
2. Click the paperclip (Attach Files) button. Expected: the menu renders fully on top of the meter.
3. Click **Upload from Computer** (`data-testid="upload-from-device-btn"`). Expected: the OS file picker opens.
4. Regression: with menus closed, the meter is still visible and its hover tooltip still works; slash (`/`) and @-mention suggestions still render above the input.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
