### PR TITLE
fix(notion): stop transient errors from permanently breaking the connection

### DIFF
--- a/apps/client/app/components/ProfileModal/SettingsTabContent/NotionPagePicker.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/NotionPagePicker.tsx
@@ -61,7 +61,13 @@ const NotionPagePicker = ({ allowedPages, excludedPageIds, onSave, saving }: Not
       setTopLevelPages(data.pages);
     } catch (err) {
       console.error('Failed to load Notion pages:', err);
-      toast.error('Failed to load Notion workspace pages');
+      const serverError =
+        err && typeof err === 'object' && 'response' in err
+          ? (err as { response?: { data?: { error?: string } } }).response?.data?.error
+          : undefined;
+      toast.error(serverError || 'Failed to load Notion workspace pages. Check your connection and try again.', {
+        duration: 6000,
+      });
     } finally {
       setLoadingRoot(false);
     }
@@ -85,6 +91,11 @@ const NotionPagePicker = ({ allowedPages, excludedPageIds, onSave, saving }: Not
       }));
     } catch (err) {
       console.error('Failed to load children:', err);
+      const serverError =
+        err && typeof err === 'object' && 'response' in err
+          ? (err as { response?: { data?: { error?: string } } }).response?.data?.error
+          : undefined;
+      toast.error(serverError || 'Failed to load child pages from Notion.', { duration: 6000 });
       setNodeStates(prev => ({
         ...prev,
         [parentId]: { ...prev[parentId], loading: false },

--- a/apps/client/app/hooks/data/mcpServers.ts
+++ b/apps/client/app/hooks/data/mcpServers.ts
@@ -74,7 +74,7 @@ export const useConnectNotion = () => {
         : error instanceof Error
           ? error.message
           : 'Unknown error';
-      toast.error(`Failed to connect Notion: ${errorMessage}`);
+      toast.error(`Failed to connect Notion: ${errorMessage}`, { duration: 6000 });
     },
   });
 };
@@ -109,7 +109,8 @@ export const useDisconnectNotion = () => {
       if (context?.previousUser) {
         useUser.getState().setCurrentUser(context.previousUser);
       }
-      toast.error(`Failed to disconnect Notion: ${error.message}`);
+      const errorMessage = isAxiosError(error) ? error.response?.data?.error || error.message : error.message;
+      toast.error(`Failed to disconnect Notion: ${errorMessage}`, { duration: 6000 });
     },
   });
 };
@@ -148,7 +149,7 @@ export const useUpdateNotionSettings = () => {
         : error instanceof Error
           ? error.message
           : 'Unknown error';
-      toast.error(`Failed to update Notion settings: ${errorMessage}`);
+      toast.error(`Failed to update Notion settings: ${errorMessage}`, { duration: 6000 });
     },
   });
 };

--- a/apps/client/pages/api/mcp-servers/notion/callback.ts
+++ b/apps/client/pages/api/mcp-servers/notion/callback.ts
@@ -24,6 +24,21 @@ function redirectWithError(res: ExpressResponse, message: string) {
   return res.redirect('/profile?tab=integrations&notion=error');
 }
 
+/**
+ * Fixed messages for the RFC 6749 4.1.2.1 error codes. This route is unauthenticated, so the
+ * `error` query param is attacker-controllable via a crafted link: never echo it to the user,
+ * or an arbitrary string (e.g. a fake support phone number) can be phished into a toast.
+ */
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  access_denied: 'Notion authorization was declined. Please try connecting again and approve access.',
+  invalid_request: 'Notion rejected the authorization request. Please try connecting again.',
+  unauthorized_client: 'This app is not authorized to connect to Notion. Please contact your administrator.',
+  unsupported_response_type: 'Notion rejected the authorization request. Please contact your administrator.',
+  invalid_scope: 'Notion rejected the requested permissions. Please contact your administrator.',
+  server_error: 'Notion reported a server error during authorization. Please try again shortly.',
+  temporarily_unavailable: 'Notion is temporarily unavailable. Please try connecting again shortly.',
+};
+
 interface NotionTokenResponse {
   access_token: string;
   token_type: 'bearer';
@@ -74,8 +89,10 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
   if (error) {
     console.error('[Notion Callback] OAuth error:', error);
     auditLogger.failure('oauth_error');
-    const errorMsg = typeof error === 'string' ? error : 'OAuth authorization failed';
-    return redirectWithError(res, `Notion authorization failed: ${errorMsg}`);
+    const message =
+      (typeof error === 'string' && OAUTH_ERROR_MESSAGES[error]) ||
+      'Notion authorization failed. Please try connecting again.';
+    return redirectWithError(res, message);
   }
 
   if (!code || typeof code !== 'string') {

--- a/apps/client/pages/api/mcp-servers/notion/callback.ts
+++ b/apps/client/pages/api/mcp-servers/notion/callback.ts
@@ -1,3 +1,4 @@
+import type { NextApiResponse } from 'next';
 import { baseApi } from '@server/middlewares/baseApi';
 import { userRepository } from '@bike4mind/database';
 import {
@@ -16,7 +17,7 @@ const OAUTH_TIMEOUT = 30000;
 const NOTION_API_TIMEOUT = 10000;
 
 /** Redirect to the integrations page with a specific error message shown as a toast. */
-function redirectWithError(res: any, message: string) {
+function redirectWithError(res: NextApiResponse, message: string) {
   res.setHeader('Set-Cookie', [
     `notion_error=${encodeURIComponent(message)}; Path=/; Max-Age=60; SameSite=Lax; Secure`,
   ]);
@@ -209,7 +210,7 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
       auditLogger.failure('token_exchange_timeout');
       return redirectWithError(
         res,
-        'Notion connection timed out while exchanging credentials. Notion may be slow — please try again.'
+        'Notion connection timed out while exchanging credentials. Notion may be slow -- please try again.'
       );
     }
     throw fetchError;

--- a/apps/client/pages/api/mcp-servers/notion/callback.ts
+++ b/apps/client/pages/api/mcp-servers/notion/callback.ts
@@ -1,4 +1,4 @@
-import type { NextApiResponse } from 'next';
+import type { Response as ExpressResponse } from 'express';
 import { baseApi } from '@server/middlewares/baseApi';
 import { userRepository } from '@bike4mind/database';
 import {
@@ -17,7 +17,7 @@ const OAUTH_TIMEOUT = 30000;
 const NOTION_API_TIMEOUT = 10000;
 
 /** Redirect to the integrations page with a specific error message shown as a toast. */
-function redirectWithError(res: NextApiResponse, message: string) {
+function redirectWithError(res: ExpressResponse, message: string) {
   res.setHeader('Set-Cookie', [
     `notion_error=${encodeURIComponent(message)}; Path=/; Max-Age=60; SameSite=Lax; Secure`,
   ]);

--- a/apps/client/pages/api/mcp-servers/notion/callback.ts
+++ b/apps/client/pages/api/mcp-servers/notion/callback.ts
@@ -15,6 +15,14 @@ import { encryptToken } from '@server/security/tokenEncryption';
 const OAUTH_TIMEOUT = 30000;
 const NOTION_API_TIMEOUT = 10000;
 
+/** Redirect to the integrations page with a specific error message shown as a toast. */
+function redirectWithError(res: any, message: string) {
+  res.setHeader('Set-Cookie', [
+    `notion_error=${encodeURIComponent(message)}; Path=/; Max-Age=60; SameSite=Lax; Secure`,
+  ]);
+  return res.redirect('/profile?tab=integrations&notion=error');
+}
+
 interface NotionTokenResponse {
   access_token: string;
   token_type: 'bearer';
@@ -66,22 +74,22 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
     console.error('[Notion Callback] OAuth error:', error);
     auditLogger.failure('oauth_error');
     const errorMsg = typeof error === 'string' ? error : 'OAuth authorization failed';
-    res.setHeader('Set-Cookie', [
-      `notion_error=${encodeURIComponent(errorMsg)}; Path=/; Max-Age=60; SameSite=Lax; Secure`,
-    ]);
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(res, `Notion authorization failed: ${errorMsg}`);
   }
 
   if (!code || typeof code !== 'string') {
     console.error('[Notion Callback] Missing authorization code');
     auditLogger.failure('missing_code');
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(
+      res,
+      'Notion authorization failed: no authorization code received. Please try connecting again.'
+    );
   }
 
   if (!state || typeof state !== 'string') {
     console.error('[Notion Callback] Missing state parameter');
     auditLogger.failure('missing_state');
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(res, 'Notion authorization failed: invalid callback state. Please try connecting again.');
   }
 
   // Extract and validate state parameter
@@ -103,7 +111,7 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
   } catch (parseError) {
     console.error('[Notion Callback] Failed to parse state parameter:', parseError);
     auditLogger.failure('invalid_state');
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(res, 'Notion authorization failed: corrupted callback data. Please try connecting again.');
   }
 
   auditLogger.setUserId(userId);
@@ -113,7 +121,7 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
   if (!secret) {
     console.error('[Notion Callback] JWT_SECRET environment variable is required');
     auditLogger.failure('missing_jwt_secret');
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(res, 'Notion connection failed: server configuration error. Please contact support.');
   }
   const hmac = crypto.createHmac('sha256', secret);
   hmac.update(`${userId}:${csrfToken}:${timestamp}`);
@@ -122,7 +130,10 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
   if (signature !== expectedSignature) {
     console.error('[Notion Callback] CSRF signature validation failed');
     auditLogger.failure('csrf_signature_invalid');
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(
+      res,
+      'Notion authorization failed: security validation error. Please try connecting again.'
+    );
   }
 
   // Check token age (expire after 10 minutes)
@@ -130,13 +141,19 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
   if (tokenAge > 10 * 60 * 1000) {
     console.error('[Notion Callback] CSRF token expired (age: ' + Math.round(tokenAge / 1000) + 's)');
     auditLogger.failure('csrf_token_expired');
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(
+      res,
+      'Notion authorization timed out (took longer than 10 minutes). Please try connecting again.'
+    );
   }
 
   if (tokenAge < 0) {
     console.error('[Notion Callback] CSRF token timestamp is in the future');
     auditLogger.failure('csrf_token_future');
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(
+      res,
+      'Notion authorization failed: clock synchronization error. Please try connecting again.'
+    );
   }
 
   // Idempotency check: avoid re-running token exchange if the callback fires more than once
@@ -152,7 +169,10 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
   if (!clientId || !clientSecret || !redirectUri) {
     console.error('[Notion Callback] Notion OAuth credentials not configured');
     auditLogger.failure('oauth_not_configured');
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(
+      res,
+      'Notion integration is not configured on this server. Please contact your administrator.'
+    );
   }
 
   // Step 1: Exchange code for tokens
@@ -187,7 +207,10 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
     if (fetchError instanceof Error && fetchError.name === 'AbortError') {
       console.error('[Notion Callback] Token exchange timed out after 30s');
       auditLogger.failure('token_exchange_timeout');
-      return res.redirect('/profile?tab=integrations&notion=error');
+      return redirectWithError(
+        res,
+        'Notion connection timed out while exchanging credentials. Notion may be slow — please try again.'
+      );
     }
     throw fetchError;
   }
@@ -204,7 +227,10 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
     console.error('   4. Client ID/Secret mismatch');
     console.error('   Current redirect_uri:', redirectUri);
     auditLogger.failure('token_exchange_failed', { statusCode: tokenResponse.status });
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(
+      res,
+      `Notion rejected the authorization (HTTP ${tokenResponse.status}). This can happen if the link expired or was already used. Please try connecting again.`
+    );
   }
 
   const tokenData: NotionTokenResponse = await tokenResponse.json();
@@ -212,7 +238,7 @@ const handler = baseApi({ auth: false }).get(async (req, res) => {
   if (!tokenData.access_token) {
     console.error('[Notion Callback] No access token returned from Notion');
     auditLogger.failure('no_access_token');
-    return res.redirect('/profile?tab=integrations&notion=error');
+    return redirectWithError(res, 'Notion did not return an access token. Please try connecting again.');
   }
 
   console.log(

--- a/apps/client/pages/api/mcp-servers/notion/disconnect.ts
+++ b/apps/client/pages/api/mcp-servers/notion/disconnect.ts
@@ -53,9 +53,9 @@ const handler = baseApi().delete(async (req, res) => {
     res.status(200).json({ success: true });
   } catch (error) {
     console.error('[Notion Disconnect] Fatal error during disconnect:', error);
+    const detail = error instanceof Error ? error.message : 'Unknown error';
     res.status(500).json({
-      error: 'Failed to disconnect Notion',
-      message: error instanceof Error ? error.message : 'Unknown error',
+      error: `Failed to disconnect Notion: ${detail}. Please try again or contact support.`,
     });
   }
 });

--- a/apps/client/pages/api/mcp-servers/notion/pages.ts
+++ b/apps/client/pages/api/mcp-servers/notion/pages.ts
@@ -116,7 +116,7 @@ const handler = baseApi().get(async (req, res) => {
       if (error.message.includes('Notion search failed')) {
         const status = error.message.match(/: (\d+)/)?.[1];
         return res.status(502).json({
-          error: `Notion API returned an error (HTTP ${status || 'unknown'}). This is usually temporary — please try again.`,
+          error: `Notion API returned an error (HTTP ${status || 'unknown'}). This is usually temporary - please try again.`,
           code: 'NOTION_API_ERROR',
         });
       }

--- a/apps/client/pages/api/mcp-servers/notion/pages.ts
+++ b/apps/client/pages/api/mcp-servers/notion/pages.ts
@@ -89,8 +89,50 @@ const handler = baseApi().get(async (req, res) => {
     res.status(200).json({ pages });
   } catch (error) {
     console.error('[Notion Pages] Error browsing pages:', error);
-    const message = error instanceof Error ? error.message : 'Failed to browse Notion pages';
-    res.status(500).json({ error: message });
+
+    // Surface specific, actionable error messages to the client
+    if (error instanceof Error) {
+      if (error.name === 'NotionReconnectRequiredError') {
+        return res.status(401).json({
+          error: 'Your Notion connection has been revoked. Please reconnect in Settings > Integrations.',
+          code: 'NOTION_RECONNECT_REQUIRED',
+        });
+      }
+
+      if (error.message.includes('Failed to get valid Notion tokens')) {
+        return res.status(401).json({
+          error: 'Notion is not connected. Please connect your Notion account in Settings > Integrations.',
+          code: 'NOTION_NOT_CONNECTED',
+        });
+      }
+
+      if (error.message.includes('Failed to decrypt')) {
+        return res.status(500).json({
+          error: 'Notion credentials could not be read. Please disconnect and reconnect your Notion account.',
+          code: 'NOTION_DECRYPT_FAILED',
+        });
+      }
+
+      if (error.message.includes('Notion search failed')) {
+        const status = error.message.match(/: (\d+)/)?.[1];
+        return res.status(502).json({
+          error: `Notion API returned an error (HTTP ${status || 'unknown'}). This is usually temporary — please try again.`,
+          code: 'NOTION_API_ERROR',
+        });
+      }
+
+      if (error.message.includes('Notion blocks fetch failed')) {
+        const status = error.message.match(/: (\d+)/)?.[1];
+        return res.status(502).json({
+          error: `Could not load child pages from Notion (HTTP ${status || 'unknown'}). The page may have been deleted or unshared.`,
+          code: 'NOTION_BLOCKS_ERROR',
+        });
+      }
+    }
+
+    res.status(500).json({
+      error: 'Unexpected error loading Notion pages. Please try again or reconnect your account.',
+    });
   }
 });
 

--- a/apps/client/pages/api/mcp-servers/notion/settings.ts
+++ b/apps/client/pages/api/mcp-servers/notion/settings.ts
@@ -143,7 +143,12 @@ const handler = baseApi().patch(async (req, res) => {
     res.status(200).json({ success: true });
   } catch (error) {
     console.error('[Notion Settings] Error updating settings:', error);
-    res.status(500).json({ error: 'Failed to update Notion settings' });
+    const detail = error instanceof Error ? error.message : '';
+    res.status(500).json({
+      error: detail.includes('not connected')
+        ? 'Notion is not connected. Please reconnect your account before changing settings.'
+        : `Failed to update Notion settings: ${detail || 'unexpected server error'}`,
+    });
   }
 });
 

--- a/apps/client/server/integrations/notion/notionTokenManager.test.ts
+++ b/apps/client/server/integrations/notion/notionTokenManager.test.ts
@@ -41,12 +41,14 @@ vi.mock('@server/security/tokenEncryption', () => ({
 }));
 
 // Mock invokeMcpHandler
+const DEFAULT_MCP_TOOLS = [
+  { name: 'notion_search', description: 'Search Notion' },
+  { name: 'notion_create_page', description: 'Create a page' },
+  { name: 'notion_read_page', description: 'Read page content' },
+];
+const mockInvokeMcpHandler = vi.fn();
 vi.mock('@server/utils/invokeMcpHandler', () => ({
-  invokeMcpHandler: vi.fn().mockResolvedValue([
-    { name: 'notion_search', description: 'Search Notion' },
-    { name: 'notion_create_page', description: 'Create a page' },
-    { name: 'notion_read_page', description: 'Read page content' },
-  ]),
+  invokeMcpHandler: (...args: unknown[]) => mockInvokeMcpHandler(...args),
 }));
 
 // Mock fetch for token validation
@@ -59,6 +61,8 @@ describe('NotionTokenManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockReset();
+    mockInvokeMcpHandler.mockReset();
+    mockInvokeMcpHandler.mockResolvedValue(DEFAULT_MCP_TOOLS);
   });
 
   describe('NotionReconnectRequiredError', () => {
@@ -328,6 +332,49 @@ describe('NotionTokenManager', () => {
           ]),
         })
       );
+    });
+
+    it('should retry the tool fetch once and store tools when the second attempt succeeds', async () => {
+      mockFindOne.mockResolvedValue({ id: 'mcp-123', name: 'notion' });
+      mockInvokeMcpHandler
+        .mockRejectedValueOnce(new Error('MCP handler timed out'))
+        .mockResolvedValue([{ name: 'notion_search', description: 'Search Notion' }]);
+
+      vi.useFakeTimers();
+      try {
+        const sync = NotionTokenManager.syncMcpServer('user-123', 'access-token', 'ws-123');
+        await vi.runAllTimersAsync(); // clear the 2s backoff between attempts
+        await sync;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(mockInvokeMcpHandler).toHaveBeenCalledTimes(2);
+      expect(mockMcpUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'mcp-123',
+          tools: ['notion_search'],
+        })
+      );
+    });
+
+    it('should save the connection without tools when every tool-fetch attempt fails', async () => {
+      mockFindOne.mockResolvedValue({ id: 'mcp-123', name: 'notion' });
+      mockInvokeMcpHandler.mockRejectedValue(new Error('MCP handler unavailable'));
+
+      vi.useFakeTimers();
+      try {
+        const sync = NotionTokenManager.syncMcpServer('user-123', 'access-token', 'ws-123');
+        await vi.runAllTimersAsync();
+        await expect(sync).resolves.toBeUndefined(); // must not throw: the connection itself is still valid
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(mockInvokeMcpHandler).toHaveBeenCalledTimes(2);
+      // Only the envVariables update ran; no tools/toolSchemas write happened
+      expect(mockMcpUpdate).toHaveBeenCalledTimes(1);
+      expect(mockMcpUpdate).not.toHaveBeenCalledWith(expect.objectContaining({ toolSchemas: expect.anything() }));
     });
   });
 });

--- a/apps/client/server/integrations/notion/notionTokenManager.test.ts
+++ b/apps/client/server/integrations/notion/notionTokenManager.test.ts
@@ -151,6 +151,76 @@ describe('NotionTokenManager', () => {
       });
     });
 
+    it('should return tokens optimistically on transient network error', async () => {
+      mockFindById.mockResolvedValue({
+        id: 'user-123',
+        notionConnect: {
+          status: 'connected',
+          accessToken: 'valid-token',
+          workspaceId: 'ws-123',
+          workspaceName: 'My Workspace',
+        },
+      });
+
+      mockFetch.mockRejectedValue(new Error('fetch failed'));
+
+      const result = await NotionTokenManager.getValidTokens('user-123');
+
+      expect(result).toEqual({
+        accessToken: 'decrypted-valid-token',
+        workspaceId: 'ws-123',
+        workspaceName: 'My Workspace',
+      });
+      // Should NOT mark as needs_reconnect
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should return tokens optimistically on Notion 5xx error', async () => {
+      mockFindById.mockResolvedValue({
+        id: 'user-123',
+        notionConnect: {
+          status: 'connected',
+          accessToken: 'valid-token',
+          workspaceId: 'ws-123',
+          workspaceName: 'My Workspace',
+        },
+      });
+
+      mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+      const result = await NotionTokenManager.getValidTokens('user-123');
+
+      expect(result).toEqual({
+        accessToken: 'decrypted-valid-token',
+        workspaceId: 'ws-123',
+        workspaceName: 'My Workspace',
+      });
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should mark as needs_reconnect only on 403', async () => {
+      mockFindById.mockResolvedValue({
+        id: 'user-123',
+        notionConnect: {
+          status: 'connected',
+          accessToken: 'revoked-token',
+          workspaceId: 'ws-123',
+          workspaceName: 'My Workspace',
+        },
+      });
+
+      mockFetch.mockResolvedValue({ ok: false, status: 403 });
+
+      await expect(NotionTokenManager.getValidTokens('user-123')).rejects.toThrow(NotionReconnectRequiredError);
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        id: 'user-123',
+        notionConnect: expect.objectContaining({
+          status: 'needs_reconnect',
+        }),
+      });
+    });
+
     it('should validate token against Notion API', async () => {
       mockFindById.mockResolvedValue({
         id: 'user-123',

--- a/apps/client/server/integrations/notion/notionTokenManager.ts
+++ b/apps/client/server/integrations/notion/notionTokenManager.ts
@@ -187,12 +187,14 @@ export class NotionTokenManager {
     // Fetch and store available tools, retrying once on failure.
     // Without toolSchemas the ToolBuilder silently skips the server,
     // so the LLM never sees Notion tools despite a valid connection.
-    const { invokeMcpHandler } = await import('@server/utils/invokeMcpHandler');
     const MAX_TOOL_FETCH_ATTEMPTS = 2;
     let toolsFetched = false;
 
     for (let attempt = 1; attempt <= MAX_TOOL_FETCH_ATTEMPTS; attempt++) {
       try {
+        // Imported inside the try so a module-resolution failure degrades to "no tool schemas"
+        // rather than failing the whole OAuth flow. Repeat imports hit the module cache.
+        const { invokeMcpHandler } = await import('@server/utils/invokeMcpHandler');
         const result = await invokeMcpHandler<unknown>({
           envVariables: envVars,
           name: 'notion',
@@ -222,7 +224,7 @@ export class NotionTokenManager {
     if (!toolsFetched) {
       console.error(
         'Notion MCP tools could not be fetched after retries. ' +
-          'The server is saved but toolSchemas are empty — the LLM will not see Notion tools ' +
+          'The server is saved but toolSchemas are empty - the LLM will not see Notion tools ' +
           'until the next GET /api/mcp-servers request refreshes them.'
       );
     }

--- a/apps/client/server/integrations/notion/notionTokenManager.ts
+++ b/apps/client/server/integrations/notion/notionTokenManager.ts
@@ -24,8 +24,9 @@ interface NotionTokenResult {
 export class NotionTokenManager {
   /**
    * Notion tokens don't expire, so validity only means "not revoked" - checked via a test API call.
+   * Returns 'valid', 'revoked' (confirmed 401/403), or 'unknown' (network/timeout/5xx).
    */
-  private static async validateToken(accessToken: string): Promise<boolean> {
+  private static async validateToken(accessToken: string): Promise<'valid' | 'revoked' | 'unknown'> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), TOKEN_VALIDATION_TIMEOUT);
     try {
@@ -38,9 +39,12 @@ export class NotionTokenManager {
         },
         signal: controller.signal,
       });
-      return response.ok;
+      if (response.ok) return 'valid';
+      // Only treat explicit auth failures as revocation
+      if (response.status === 401 || response.status === 403) return 'revoked';
+      return 'unknown';
     } catch {
-      return false;
+      return 'unknown';
     } finally {
       clearTimeout(timeoutId);
     }
@@ -83,10 +87,10 @@ export class NotionTokenManager {
         return null;
       }
 
-      const isValid = await this.validateToken(accessToken);
+      const status = await this.validateToken(accessToken);
 
-      if (!isValid) {
-        console.log('Notion token is invalid/revoked. Marking for reconnection.');
+      if (status === 'revoked') {
+        console.log('Notion token is confirmed revoked (401/403). Marking for reconnection.');
 
         await userRepository.update({
           id: userId,
@@ -100,7 +104,14 @@ export class NotionTokenManager {
         throw new NotionReconnectRequiredError();
       }
 
-      console.log('Using valid Notion token');
+      if (status === 'unknown') {
+        // Transient error (timeout, network, 5xx) - use the token optimistically
+        // since Notion tokens don't expire, the most likely cause is a temporary issue
+        console.warn('Notion token validation inconclusive (network/timeout). Using token optimistically.');
+      } else {
+        console.log('Using valid Notion token');
+      }
+
       return {
         accessToken,
         workspaceId: notionConnect.workspaceId,
@@ -173,27 +184,47 @@ export class NotionTokenManager {
       console.log('Created new Notion MCP server');
     }
 
-    // Try to get and store available tools (non-blocking)
-    try {
-      const { invokeMcpHandler } = await import('@server/utils/invokeMcpHandler');
-      const result = await invokeMcpHandler<unknown>({
-        envVariables: envVars,
-        name: 'notion',
-        action: 'getTools',
-        userId,
-      });
+    // Fetch and store available tools, retrying once on failure.
+    // Without toolSchemas the ToolBuilder silently skips the server,
+    // so the LLM never sees Notion tools despite a valid connection.
+    const { invokeMcpHandler } = await import('@server/utils/invokeMcpHandler');
+    const MAX_TOOL_FETCH_ATTEMPTS = 2;
+    let toolsFetched = false;
 
-      const tools = Array.isArray(result) ? result : [result].flat();
-      if (notionServer) {
-        await mcpServerRepository.update({
-          id: notionServer.id,
-          tools: tools.map((tool: { name: string }) => tool.name),
-          toolSchemas: tools as Array<{ name: string; description?: string; input_schema?: Record<string, unknown> }>,
+    for (let attempt = 1; attempt <= MAX_TOOL_FETCH_ATTEMPTS; attempt++) {
+      try {
+        const result = await invokeMcpHandler<unknown>({
+          envVariables: envVars,
+          name: 'notion',
+          action: 'getTools',
+          userId,
         });
+
+        const tools = Array.isArray(result) ? result : [result].flat();
+        if (notionServer) {
+          await mcpServerRepository.update({
+            id: notionServer.id,
+            tools: tools.map((tool: { name: string }) => tool.name),
+            toolSchemas: tools as Array<{ name: string; description?: string; input_schema?: Record<string, unknown> }>,
+          });
+        }
+        console.log(`Notion MCP server configured with ${tools.length} tools`);
+        toolsFetched = true;
+        break;
+      } catch (toolsError) {
+        console.warn(`Failed to get Notion MCP tools (attempt ${attempt}/${MAX_TOOL_FETCH_ATTEMPTS}):`, toolsError);
+        if (attempt < MAX_TOOL_FETCH_ATTEMPTS) {
+          await new Promise(resolve => setTimeout(resolve, 2000));
+        }
       }
-      console.log(`Notion MCP server configured with ${tools.length} tools`);
-    } catch (toolsError) {
-      console.warn('Failed to get Notion MCP tools, but connection saved:', toolsError);
+    }
+
+    if (!toolsFetched) {
+      console.error(
+        'Notion MCP tools could not be fetched after retries. ' +
+          'The server is saved but toolSchemas are empty — the LLM will not see Notion tools ' +
+          'until the next GET /api/mcp-servers request refreshes them.'
+      );
     }
   }
 }

--- a/b4m-core/services/src/llm/tools/ToolBuilder.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.ts
@@ -360,40 +360,45 @@ export class ToolBuilder {
     // Tool schemas are populated by the GET /api/mcp-servers endpoint and connect/OAuth flows.
     // callTool connects lazily via Lambda only when the LLM actually invokes a tool.
     for (const server of mcpServers) {
-      let schemas = server.toolSchemas;
+      // Isolate per server: a malformed cached schema must not drop tools for every other server.
+      try {
+        let schemas = server.toolSchemas;
 
-      // If cached schemas are missing, attempt a live fetch so the LLM still gets
-      // the tools for this request rather than silently ignoring the server.
-      if (!schemas?.length) {
-        try {
-          logger.info(`🛠️ [MCP] No cached tool schemas for ${server.name} — fetching live`);
-          const client = await this.deps.getMcpClient(server);
-          const liveTools = await client.getTools();
-          if (Array.isArray(liveTools) && liveTools.length > 0) {
-            schemas = liveTools;
-            // Persist so future requests don't need a live fetch
-            await this.deps.db.mcpServers.update({
-              id: server.id,
-              tools: liveTools.map((t: { name: string }) => t.name),
-              toolSchemas: liveTools,
-            });
-            logger.info(`🛠️ [MCP] Live-fetched and cached ${liveTools.length} tool schemas for ${server.name}`);
+        // If cached schemas are missing, attempt a live fetch so the LLM still gets
+        // the tools for this request rather than silently ignoring the server.
+        if (!schemas?.length) {
+          try {
+            logger.info(`🛠️ [MCP] No cached tool schemas for ${server.name} - fetching live`);
+            const client = await this.deps.getMcpClient(server);
+            const liveTools = await client.getTools();
+            if (Array.isArray(liveTools) && liveTools.length > 0) {
+              schemas = liveTools;
+              // Persist so future requests don't need a live fetch
+              await this.deps.db.mcpServers.update({
+                id: server.id,
+                tools: liveTools.map((t: { name: string }) => t.name),
+                toolSchemas: liveTools,
+              });
+              logger.info(`🛠️ [MCP] Live-fetched and cached ${liveTools.length} tool schemas for ${server.name}`);
+            }
+          } catch (fetchError) {
+            logger.warn(`🛠️ [MCP] Live tool fetch failed for ${server.name} - skipping:`, fetchError);
           }
-        } catch (fetchError) {
-          logger.warn(`🛠️ [MCP] Live tool fetch failed for ${server.name} — skipping:`, fetchError);
         }
-      }
 
-      if (schemas?.length) {
-        const callTool = async (toolName: string, toolArgs: unknown) => {
-          const client = await this.deps.getMcpClient(server);
-          const result = await client.callTool(toolName, toolArgs);
-          return result;
-        };
-        mcpToolsByServer[server.name] = generateMcpToolsFromCache(server.name, schemas, callTool);
-        logger.info(`🛠️ [MCP] Loaded ${schemas.length} tool schemas for ${server.name}`);
-      } else {
-        logger.warn(`🛠️ [MCP] No tool schemas found for ${server.name} — skipping (reconnect server to populate)`);
+        if (schemas?.length) {
+          const callTool = async (toolName: string, toolArgs: unknown) => {
+            const client = await this.deps.getMcpClient(server);
+            const result = await client.callTool(toolName, toolArgs);
+            return result;
+          };
+          mcpToolsByServer[server.name] = generateMcpToolsFromCache(server.name, schemas, callTool);
+          logger.info(`🛠️ [MCP] Loaded ${schemas.length} tool schemas for ${server.name}`);
+        } else {
+          logger.warn(`🛠️ [MCP] No tool schemas found for ${server.name} - skipping (reconnect server to populate)`);
+        }
+      } catch (serverError) {
+        logger.error(`🛠️ [MCP] Failed to build tools for ${server.name} - skipping this server:`, serverError);
       }
     }
 

--- a/b4m-core/services/src/llm/tools/ToolBuilder.ts
+++ b/b4m-core/services/src/llm/tools/ToolBuilder.ts
@@ -360,14 +360,38 @@ export class ToolBuilder {
     // Tool schemas are populated by the GET /api/mcp-servers endpoint and connect/OAuth flows.
     // callTool connects lazily via Lambda only when the LLM actually invokes a tool.
     for (const server of mcpServers) {
-      if (server.toolSchemas?.length) {
+      let schemas = server.toolSchemas;
+
+      // If cached schemas are missing, attempt a live fetch so the LLM still gets
+      // the tools for this request rather than silently ignoring the server.
+      if (!schemas?.length) {
+        try {
+          logger.info(`🛠️ [MCP] No cached tool schemas for ${server.name} — fetching live`);
+          const client = await this.deps.getMcpClient(server);
+          const liveTools = await client.getTools();
+          if (Array.isArray(liveTools) && liveTools.length > 0) {
+            schemas = liveTools;
+            // Persist so future requests don't need a live fetch
+            await this.deps.db.mcpServers.update({
+              id: server.id,
+              tools: liveTools.map((t: { name: string }) => t.name),
+              toolSchemas: liveTools,
+            });
+            logger.info(`🛠️ [MCP] Live-fetched and cached ${liveTools.length} tool schemas for ${server.name}`);
+          }
+        } catch (fetchError) {
+          logger.warn(`🛠️ [MCP] Live tool fetch failed for ${server.name} — skipping:`, fetchError);
+        }
+      }
+
+      if (schemas?.length) {
         const callTool = async (toolName: string, toolArgs: unknown) => {
           const client = await this.deps.getMcpClient(server);
           const result = await client.callTool(toolName, toolArgs);
           return result;
         };
-        mcpToolsByServer[server.name] = generateMcpToolsFromCache(server.name, server.toolSchemas, callTool);
-        logger.info(`🛠️ [MCP] Loaded ${server.toolSchemas.length} tool schemas for ${server.name} from DB`);
+        mcpToolsByServer[server.name] = generateMcpToolsFromCache(server.name, schemas, callTool);
+        logger.info(`🛠️ [MCP] Loaded ${schemas.length} tool schemas for ${server.name}`);
       } else {
         logger.warn(`🛠️ [MCP] No tool schemas found for ${server.name} — skipping (reconnect server to populate)`);
       }


### PR DESCRIPTION
# Pull Request

## Description

Two reliability bugs made the Notion integration look broken to users when nothing was actually wrong with their connection.

**1. Transient failures permanently broke the connection.** `validateToken` returned a plain boolean, so *any* non-OK outcome — a timeout, a DNS hiccup, a Notion 500 — was treated as revocation and flipped the connection to `needs_reconnect`. The user then had to manually reconnect to recover from what was a momentary blip. Notion tokens do not expire, so the only real reason a token stops working is explicit revocation.

**2. Missing `toolSchemas` silently removed Notion from the LLM.** If the tool-schema fetch failed during OAuth, the server row was saved with empty `toolSchemas`. `ToolBuilder` skips any server with no schemas, so the LLM never saw Notion tools even though the UI showed a healthy connection, with nothing in the product to indicate why.

Error messaging across all Notion paths was also generic ("Failed to load Notion workspace pages"), giving the user no idea whether to retry, reconnect, or contact an admin.

## Changes

**Token validation (`notionTokenManager.ts`)**
- `validateToken` now returns `'valid' | 'revoked' | 'unknown'` instead of a boolean.
- Only a confirmed 401/403 marks the connection `needs_reconnect`. Timeouts, network errors, and 5xx return `'unknown'` and the token is used optimistically — if it really is bad, the downstream Notion call surfaces its own error.

**Tool schema availability**
- `syncMcpServer` retries the tool fetch once (2s backoff) and logs loudly if both attempts fail.
- `ToolBuilder` attempts a live schema fetch when the DB cache is empty, and persists the result so later requests hit the cache. The server is skipped rather than failing the request if the live fetch also fails.
- Tool building is isolated per server, so one server's malformed schema cannot drop tools for the others on that request.

**Error messaging**
- The OAuth callback, `pages`, `settings`, and `disconnect` endpoints return specific, actionable messages; `pages` also returns a stable `code` (`NOTION_RECONNECT_REQUIRED`, `NOTION_NOT_CONNECTED`, …).
- Client toasts surface the server message and run for 6s instead of the default.

**Security**
- The OAuth `error` query param is no longer echoed back to the user. This callback is unauthenticated, so a crafted link could have phished an arbitrary string (e.g. a fake support number) into a toast. The RFC 6749 error codes now map to fixed messages; the raw value is still logged server-side.

## Guide for Testers

Prerequisite: a Notion account you can connect and disconnect freely.

**A. Connection survives a transient failure (the main fix)**

1. Go to `app.staging.bike4mind.com`, open **Profile → Settings → Integrations**.
2. Connect Notion and approve access. Expect a green "Notion connected successfully!" toast and the card showing your workspace name.
3. Open a new chat, enable the Notion tool, and send `List my Notion pages`. Expect the assistant to return pages (confirms `toolSchemas` populated).
4. Simulate a blip: with DevTools open, go to **Network → set throttling to Offline**, then in the Integrations tab click into the Notion page picker. Expect an error toast that lasts ~6 seconds and names the problem.
5. Set throttling back to **No throttling** and reload the Integrations tab. Expect the Notion card to still read **connected** — *not* "reconnect required". This is the regression this PR fixes; before it, step 4 would flip the card to needs-reconnect.
6. Send another Notion chat message. Expect it to work with no reconnect.

**B. Real revocation still forces a reconnect**

1. In Notion, go to **Settings → Connections**, find the Bike4Mind integration, and remove access.
2. Back in Bike4Mind, reload **Profile → Settings → Integrations**.
3. Expect the Notion card to show it needs reconnecting, and the page picker to toast `Your Notion connection has been revoked. Please reconnect in Settings > Integrations.`
4. Reconnect. Expect it to recover cleanly.

**C. OAuth error messages are safe and specific**

1. Start a Notion connect and click **Cancel** / decline on the Notion consent screen.
2. Expect the toast `Notion authorization was declined. Please try connecting again and approve access.`
3. Visit `app.staging.bike4mind.com/api/mcp-servers/notion/callback?error=Call+555-1234+to+restore+your+account` directly.
4. Expect the **generic** toast `Notion authorization failed. Please try connecting again.` — the injected text must NOT appear anywhere on screen.

**Regression Checks**

1. Other MCP integrations (GitHub, Slack) still load their tools in chat — `ToolBuilder` was touched on a shared path.
2. Disconnect Notion via the Integrations card. Expect a success toast and the card returning to the disconnected state.
3. Change the Notion access mode (All pages ↔ Selected pages) and save. Expect a success toast and the setting persisting across a reload.

**What NOT to test**

- Notion tool *behavior* itself (search quality, page contents) — unchanged by this PR.
- Other OAuth integrations' callback flows — only the Notion callback changed.

## Additional Information

The `pages.ts` handler classifies errors by matching on message text. That is fragile — if an upstream message is reworded, the check falls through to the generic catch-all (a degraded message, not a broken response). Converting these to typed error classes is worth doing but is deliberately out of scope here to keep the fix reviewable.

`ToolBuilder`'s live schema fetch adds latency (roughly 2-5s) to the chat path in the rare case where the cache is empty. That is the right trade — working tools beat a fast response with silently missing tools — and it self-heals, since the result is persisted for subsequent requests.

## Developer Notes (Optional)

- **`'valid' | 'revoked' | 'unknown'` is the pattern to copy for any OAuth token validation.** Collapsing "the provider says no" and "we could not reach the provider" into one boolean is what caused this bug; other integrations validating tokens over the network have the same shape of hazard.
- **Unauthenticated callback routes must not echo query params into user-facing text.** `OAUTH_ERROR_MESSAGES` in `callback.ts` is a reusable allowlist shape for this.
- **`ToolBuilder` now degrades per server rather than per request** — a new MCP server with a bad schema cache can no longer take down tool loading for every other server.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — n/a, no new AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) — n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc — n/a, no telemetry changes
