### PR TITLE
fix(organizations): close the remaining group-integrity gaps

### DIFF
--- a/apps/client/pages/api/invites/[id]/accept.ts
+++ b/apps/client/pages/api/invites/[id]/accept.ts
@@ -10,6 +10,7 @@ import {
   fabFileRepository,
   userRepository,
   Project,
+  Group,
   fileTagRepository,
   withTransaction,
 } from '@bike4mind/database';
@@ -98,6 +99,7 @@ const handler = baseApi().post(async (req, res) => {
           sessions: sessionRepository,
           projects: projectRepository,
           fabFiles: fabFileRepository,
+          groups: Group,
           organization: Organization,
           users: userRepository,
         },

--- a/apps/client/pages/api/organizations/[id]/__tests__/delete.test.ts
+++ b/apps/client/pages/api/organizations/[id]/__tests__/delete.test.ts
@@ -25,7 +25,17 @@ vi.mock('@server/middlewares/baseApi', () => {
   return { baseApi: () => chain };
 });
 
-const deleteOrganization = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+// Transaction depth observed at the moment deleteOrganization is invoked. Asserting only that
+// withTransaction was *called* is not enough - the delete could sit before or after an empty
+// wrapper and still satisfy that. Recording the depth pins that the delete runs INSIDE the
+// callback, which is the property #1219 actually needs.
+const txn = vi.hoisted(() => ({ depth: 0, depthAtDelete: -1 }));
+
+const deleteOrganization = vi.hoisted(() =>
+  vi.fn(async () => {
+    txn.depthAtDelete = txn.depth;
+  })
+);
 vi.mock('@bike4mind/services', () => ({ organizationService: { deleteOrganization } }));
 
 const organizationRepository = vi.hoisted(() => ({}));
@@ -35,7 +45,16 @@ const groupRepository = vi.hoisted(() => ({}));
 vi.mock('@bike4mind/database/social', () => ({ groupRepository }));
 
 const updateMany = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-const withTransaction = vi.hoisted(() => vi.fn((fn: any) => fn()));
+const withTransaction = vi.hoisted(() =>
+  vi.fn(async (fn: any) => {
+    txn.depth++;
+    try {
+      return await fn();
+    } finally {
+      txn.depth--;
+    }
+  })
+);
 vi.mock('@bike4mind/database', () => ({
   userRepository: {},
   partnerSignupRuleRepository: { updateMany },
@@ -60,6 +79,8 @@ describe('DELETE /api/organizations/[id]', () => {
     invalidatePartnerRuleCache.mockClear();
     withTransaction.mockClear();
     findActiveSubscriptionsByOwner.mockClear().mockResolvedValue([]);
+    txn.depth = 0;
+    txn.depthAtDelete = -1;
   });
 
   const call = () => {
@@ -68,9 +89,13 @@ describe('DELETE /api/organizations/[id]', () => {
     return mockRefs.deleteHandler!(req, res);
   };
 
-  it('wraps the delete in withTransaction', async () => {
+  it('runs deleteOrganization INSIDE the withTransaction callback', async () => {
     await call();
+
     expect(withTransaction).toHaveBeenCalledTimes(1);
+    // Depth 1 at invocation time - moving the delete outside the wrapper (before or after) drops
+    // this to 0, which the bare "was withTransaction called" assertion could not detect.
+    expect(txn.depthAtDelete).toBe(1);
   });
 
   it('passes the group and user adapters through to deleteOrganization', async () => {

--- a/apps/client/pages/api/organizations/[id]/__tests__/delete.test.ts
+++ b/apps/client/pages/api/organizations/[id]/__tests__/delete.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+/**
+ * DELETE /api/organizations/[id] (org-groups #1172/#1219). Pins two things that were both
+ * absent before this PR: the group/user adapters actually reach `deleteOrganization` (so the
+ * member purge + group soft-delete happen), and the whole write is wrapped in `withTransaction`
+ * so a partial failure can't leave dangling group access or an org that never deletes.
+ */
+
+const mockRefs = vi.hoisted(() => ({
+  deleteHandler: null as null | ((req: any, res: any) => unknown),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    use: () => chain,
+    get: () => chain,
+    put: () => chain,
+    delete: (fn: any) => {
+      mockRefs.deleteHandler = fn;
+      return chain;
+    },
+  };
+  return { baseApi: () => chain };
+});
+
+const deleteOrganization = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@bike4mind/services', () => ({ organizationService: { deleteOrganization } }));
+
+const organizationRepository = vi.hoisted(() => ({}));
+vi.mock('@bike4mind/database/infra', () => ({ organizationRepository }));
+
+const groupRepository = vi.hoisted(() => ({}));
+vi.mock('@bike4mind/database/social', () => ({ groupRepository }));
+
+const updateMany = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const withTransaction = vi.hoisted(() => vi.fn((fn: any) => fn()));
+vi.mock('@bike4mind/database', () => ({
+  userRepository: {},
+  partnerSignupRuleRepository: { updateMany },
+  withTransaction,
+}));
+
+const invalidatePartnerRuleCache = vi.hoisted(() => vi.fn());
+vi.mock('@server/entitlements/partnerRules', () => ({ invalidatePartnerRuleCache }));
+
+const findActiveSubscriptionsByOwner = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+vi.mock('@server/models/Subscription', () => ({
+  subscriptionRepository: { findActiveSubscriptionsByOwner },
+}));
+vi.mock('@client/lib/subscriptions/types', () => ({ SubscriptionOwnerType: { Organization: 'organization' } }));
+
+import '@pages/api/organizations/[id]/index';
+
+describe('DELETE /api/organizations/[id]', () => {
+  beforeEach(() => {
+    deleteOrganization.mockClear();
+    updateMany.mockClear();
+    invalidatePartnerRuleCache.mockClear();
+    withTransaction.mockClear();
+    findActiveSubscriptionsByOwner.mockClear().mockResolvedValue([]);
+  });
+
+  const call = () => {
+    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'org1' } });
+    (req as any).user = { id: 'admin1', isAdmin: true };
+    return mockRefs.deleteHandler!(req, res);
+  };
+
+  it('wraps the delete in withTransaction', async () => {
+    await call();
+    expect(withTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the group and user adapters through to deleteOrganization', async () => {
+    await call();
+
+    expect(deleteOrganization).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'admin1' }),
+      { id: 'org1' },
+      expect.objectContaining({
+        db: expect.objectContaining({
+          organizations: organizationRepository,
+          groups: groupRepository,
+          users: {},
+        }),
+      })
+    );
+  });
+
+  it('clears the dangling partner-rule reference and invalidates the cache after deleting', async () => {
+    await call();
+
+    expect(updateMany).toHaveBeenCalledWith({ organizationId: 'org1' }, { organizationId: null });
+    expect(invalidatePartnerRuleCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clear the partner-rule reference if deleteOrganization throws', async () => {
+    deleteOrganization.mockRejectedValueOnce(new Error('blocked'));
+
+    await expect(call()).rejects.toThrow('blocked');
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(invalidatePartnerRuleCache).not.toHaveBeenCalled();
+  });
+
+  it('still runs the active-subscriptions validation via canDeleteOrganization', async () => {
+    await call();
+
+    // The route's canDeleteOrganization closure is passed to the service, not invoked directly
+    // here (deleteOrganization is mocked) - invoke it manually to prove the closure is wired.
+    const passedAdapters = deleteOrganization.mock.calls[0][2];
+    await passedAdapters.validation.canDeleteOrganization({ id: 'org1' });
+
+    expect(findActiveSubscriptionsByOwner).toHaveBeenCalledWith('organization', 'org1');
+  });
+});

--- a/apps/client/pages/api/organizations/[id]/index.ts
+++ b/apps/client/pages/api/organizations/[id]/index.ts
@@ -1,7 +1,8 @@
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { organizationRepository } from '@bike4mind/database/infra';
-import { partnerSignupRuleRepository } from '@bike4mind/database';
+import { partnerSignupRuleRepository, userRepository, withTransaction } from '@bike4mind/database';
+import { groupRepository } from '@bike4mind/database/social';
 import { invalidatePartnerRuleCache } from '@server/entitlements/partnerRules';
 import { organizationService } from '@bike4mind/services';
 import { toSafeOrganization } from '@bike4mind/common';
@@ -49,26 +50,34 @@ const handler = baseApi()
   .delete<Request<unknown, unknown, unknown, { id: string }>>(async (req, res) => {
     const id = req.query.id;
 
-    await organizationService.deleteOrganization(
-      req.user!,
-      { id },
-      {
-        db: {
-          organizations: organizationRepository,
-        },
-        validation: {
-          canDeleteOrganization: async organization => {
-            const subscriptions = await subscriptionRepository.findActiveSubscriptionsByOwner(
-              SubscriptionOwnerType.Organization,
-              organization.id
-            );
-            return {
-              canDelete: subscriptions.length === 0,
-              reason: subscriptions.length > 0 ? 'Organization has active subscriptions' : undefined,
-            };
+    // Wrapped in withTransaction (org-groups #1172/#1219): the member purge, the group
+    // soft-deletes, and the org delete must commit together, or a partial failure leaves either
+    // dangling group access or an org that never actually deletes. Repositories join the session
+    // automatically via transactionAsyncLocalStorage.
+    await withTransaction(() =>
+      organizationService.deleteOrganization(
+        req.user!,
+        { id },
+        {
+          db: {
+            organizations: organizationRepository,
+            groups: groupRepository,
+            users: userRepository,
           },
-        },
-      }
+          validation: {
+            canDeleteOrganization: async organization => {
+              const subscriptions = await subscriptionRepository.findActiveSubscriptionsByOwner(
+                SubscriptionOwnerType.Organization,
+                organization.id
+              );
+              return {
+                canDelete: subscriptions.length === 0,
+                reason: subscriptions.length > 0 ? 'Organization has active subscriptions' : undefined,
+              };
+            },
+          },
+        }
+      )
     );
 
     // Clear the dangling reference from any partner signup rule that pointed at this org, so

--- a/apps/client/server/services/acceptGroupInvite.e2e.test.ts
+++ b/apps/client/server/services/acceptGroupInvite.e2e.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+import { InviteType } from '@bike4mind/common';
+import { BadRequestError } from '@bike4mind/utils';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import {
+  Group,
+  Organization,
+  Invite,
+  User,
+  inviteRepository,
+  userRepository,
+  fabFileRepository,
+  sessionRepository,
+  projectRepository,
+} from '@bike4mind/database';
+import { sharingService } from '@bike4mind/services';
+
+/**
+ * End-to-end guard for #1224: driving the REAL sharingService.acceptInvite through the REAL
+ * repositories against createMongoServer, matching the sibling groupInviteAuth.e2e.test.ts (which
+ * exists because a prior mock-only unit test hid a runtime bug in this same group -> org
+ * resolution path). Consumes the built dist, so `pnpm turbo:core:build` must be current.
+ */
+
+let mongoServer: MongoMemoryServer;
+
+const db = {
+  invites: inviteRepository,
+  sessions: sessionRepository,
+  projects: projectRepository,
+  fabFiles: fabFileRepository,
+  groups: { findById: (id: string) => Group.findById(id) },
+  organization: Organization,
+  users: userRepository,
+};
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 30000);
+afterEach(async () => {
+  await mongoose.connection.dropDatabase();
+});
+
+const seedGroupInvite = async (memberIds: string[] = []) => {
+  const org = await Organization.create({
+    name: 'Org',
+    userId: 'owner-1',
+    users: memberIds.map(userId => ({ userId, permissions: ['read'] })),
+  });
+  const group = await Group.create({ name: 'Sales', description: 'd', type: 'sales', organizationId: String(org._id) });
+  const invite = await Invite.create({
+    type: InviteType.Group,
+    documentId: String(group._id),
+    remaining: 2,
+    recipients: { pending: ['a@x.com', 'b@x.com'], accepted: [], refused: [] },
+  });
+  return { orgId: String(org._id), groupId: String(group._id), inviteId: String(invite._id) };
+};
+
+describe('sharingService.acceptInvite (Group) - end-to-end, real repos + Mongo', () => {
+  it('adds the group id to user.groups for a real org member', async () => {
+    const user = await User.create({
+      name: 'Member',
+      username: 'member1',
+      email: 'a@x.com',
+      password: null,
+      hasUsablePassword: false,
+    });
+    const { groupId, inviteId } = await seedGroupInvite([user.id]);
+
+    await sharingService.acceptInvite(user.id, { id: inviteId }, { db } as any);
+
+    const reloaded = await User.findById(user.id);
+    expect(reloaded?.groups).toEqual([groupId]);
+  });
+
+  it('rejects a real user who is not a member of the group organization', async () => {
+    const user = await User.create({
+      name: 'Outsider',
+      username: 'outsider1',
+      email: 'b@x.com',
+      password: null,
+      hasUsablePassword: false,
+    });
+    // seed the org with a DIFFERENT member - this user is not in it
+    const { inviteId } = await seedGroupInvite(['someone-else']);
+
+    await expect(sharingService.acceptInvite(user.id, { id: inviteId }, { db } as any)).rejects.toThrow(
+      BadRequestError
+    );
+
+    const reloaded = await User.findById(user.id);
+    expect(reloaded?.groups ?? []).toEqual([]);
+  });
+
+  it('fails closed for a soft-deleted (revoked) group', async () => {
+    const user = await User.create({
+      name: 'Member',
+      username: 'member2',
+      email: 'a@x.com',
+      password: null,
+      hasUsablePassword: false,
+    });
+    const { groupId, inviteId } = await seedGroupInvite([user.id]);
+    await Group.updateOne({ _id: groupId }, { $set: { deletedAt: new Date() } });
+
+    await expect(sharingService.acceptInvite(user.id, { id: inviteId }, { db } as any)).rejects.toThrow(/not found/i);
+
+    const reloaded = await User.findById(user.id);
+    expect(reloaded?.groups ?? []).toEqual([]);
+  });
+});

--- a/apps/client/server/services/deleteOrganizationTransaction.e2e.test.ts
+++ b/apps/client/server/services/deleteOrganizationTransaction.e2e.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryReplSet } from 'mongodb-memory-server';
+// createMongoReplSet is not exported from the package barrel / dist; deep-import the source.
+import { createMongoReplSet } from '../../../../packages/database/src/__test__/createMongoServer';
+import {
+  Group,
+  Organization,
+  User,
+  organizationRepository,
+  groupRepository,
+  userRepository,
+  withTransaction,
+} from '@bike4mind/database';
+import { organizationService } from '@bike4mind/services';
+
+/**
+ * Transactional guard for #1219: proves the org soft-delete participates in the caller's
+ * transaction rather than escaping it.
+ *
+ * Needs a REAL replica set. Against the standalone createMongoServer used elsewhere,
+ * withTransaction degrades to unwrapped writes, so a write that escapes the session is
+ * indistinguishable from one that joins it and this suite would pass on the broken code.
+ *
+ * The bug this pins: repository `delete()` routes through the soft-delete plugin's raw-driver
+ * static, which transactionAsyncLocalStorage cannot reach. The org row would commit immediately
+ * while the group soft-deletes and member purge rolled back - leaving an organization that is
+ * already gone, its groups live, and every membership intact. Because `get()` filters `deletedAt`,
+ * the retry then 404s forever. Consumes the built dist, so `pnpm turbo:core:build` must be current.
+ */
+
+let replSet: MongoMemoryReplSet;
+
+const adapters = {
+  db: {
+    organizations: organizationRepository,
+    groups: groupRepository,
+    users: userRepository,
+  },
+};
+
+beforeAll(async () => {
+  replSet = await createMongoReplSet();
+  await mongoose.connect(replSet.getUri());
+}, 60000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await replSet?.stop();
+}, 60000);
+afterEach(async () => {
+  await mongoose.connection.dropDatabase();
+});
+
+const rawOrg = (id: string) => Organization.collection.findOne({ _id: new mongoose.Types.ObjectId(id) });
+const rawGroup = (id: string) => Group.collection.findOne({ _id: new mongoose.Types.ObjectId(id) });
+
+const seed = async () => {
+  const owner = await User.create({
+    name: 'Owner',
+    username: `owner-${Math.random().toString(36).slice(2, 10)}`,
+    password: null,
+    hasUsablePassword: false,
+  });
+  const org = await Organization.create({ name: 'Acme', userId: owner.id, users: [] });
+  const group = await Group.create({
+    name: 'Sales',
+    description: 'd',
+    type: 'sales',
+    organizationId: String(org._id),
+  });
+  const member = await User.create({
+    name: 'Member',
+    username: `member-${Math.random().toString(36).slice(2, 10)}`,
+    password: null,
+    hasUsablePassword: false,
+    groups: [String(group._id)],
+  });
+  return { owner, orgId: String(org._id), groupId: String(group._id), memberId: member.id };
+};
+
+describe('deleteOrganization - transaction participation (replica set)', () => {
+  it('rolls the org soft-delete back with the rest when the transaction aborts', async () => {
+    const { owner, orgId, groupId, memberId } = await seed();
+
+    // Fail AFTER deleteOrganization returns but still inside the transaction - the deterministic
+    // stand-in for a commit-time transient error or a process death in that window.
+    await expect(
+      withTransaction(async () => {
+        await organizationService.deleteOrganization(owner as any, { id: orgId }, adapters as any);
+        throw new Error('post-delete failure');
+      })
+    ).rejects.toThrow('post-delete failure');
+
+    // All three writes must be absent. Before the fix the org row alone carried deletedAt, because
+    // the raw-driver soft-delete had already committed outside the session.
+    expect((await rawOrg(orgId))?.deletedAt ?? null).toBeNull();
+    expect((await rawGroup(groupId))?.deletedAt ?? null).toBeNull();
+    expect((await User.findById(memberId))?.groups).toEqual([groupId]);
+  });
+
+  it('commits the org soft-delete, the group soft-delete and the member purge together', async () => {
+    const { owner, orgId, groupId, memberId } = await seed();
+
+    await withTransaction(() => organizationService.deleteOrganization(owner as any, { id: orgId }, adapters as any));
+
+    expect((await rawOrg(orgId))?.deletedAt).toBeInstanceOf(Date);
+    expect((await rawGroup(groupId))?.deletedAt).toBeInstanceOf(Date);
+    expect((await User.findById(memberId))?.groups).toEqual([]);
+  });
+});

--- a/apps/client/server/services/deleteOrganizationTransaction.e2e.test.ts
+++ b/apps/client/server/services/deleteOrganizationTransaction.e2e.test.ts
@@ -18,9 +18,9 @@ import { organizationService } from '@bike4mind/services';
  * Transactional guard for #1219: proves the org soft-delete participates in the caller's
  * transaction rather than escaping it.
  *
- * Needs a REAL replica set. Against the standalone createMongoServer used elsewhere,
- * withTransaction degrades to unwrapped writes, so a write that escapes the session is
- * indistinguishable from one that joins it and this suite would pass on the broken code.
+ * Needs a REAL replica set. A standalone mongod (createMongoServer, used by the sibling e2e
+ * suites) rejects the first write inside a session with MongoServerError code 20, so this suite
+ * cannot run there at all - it would error out rather than report anything about the fix.
  *
  * The bug this pins: repository `delete()` routes through the soft-delete plugin's raw-driver
  * static, which transactionAsyncLocalStorage cannot reach. The org row would commit immediately
@@ -93,8 +93,15 @@ describe('deleteOrganization - transaction participation (replica set)', () => {
 
     // All three writes must be absent. Before the fix the org row alone carried deletedAt, because
     // the raw-driver soft-delete had already committed outside the session.
-    expect((await rawOrg(orgId))?.deletedAt ?? null).toBeNull();
-    expect((await rawGroup(groupId))?.deletedAt ?? null).toBeNull();
+    // Assert the rows still EXIST before checking deletedAt: `row?.deletedAt ?? null` is also null
+    // when the document is gone entirely, so without this a mutation that hard-deletes instead of
+    // soft-deleting would slip through green.
+    const org = await rawOrg(orgId);
+    const group = await rawGroup(groupId);
+    expect(org).not.toBeNull();
+    expect(group).not.toBeNull();
+    expect(org!.deletedAt ?? null).toBeNull();
+    expect(group!.deletedAt ?? null).toBeNull();
     expect((await User.findById(memberId))?.groups).toEqual([groupId]);
   });
 

--- a/b4m-core/common/src/types/entities/GroupTypes.ts
+++ b/b4m-core/common/src/types/entities/GroupTypes.ts
@@ -28,4 +28,12 @@ export interface IGroupRepository extends IBaseRepository<IGroupDocument> {
   findByOrganization(organizationId: string): Promise<IGroupDocument[]>;
   /** Soft-delete the given group instances (used when a group type is revoked). */
   softDeleteByIds(groupIds: string[]): Promise<void>;
+  /**
+   * Provision a group instance, treating a concurrent create for the same (organizationId, type)
+   * as success rather than a 500 (org-groups #1222). Two overlapping grant PUTs can both pass the
+   * caller's "does a live instance already exist" check and both call this; only one wins the
+   * `group_org_type_live` unique index - the loser gets back the winner's document instead of an
+   * E11000 propagating to a 500.
+   */
+  createIfMissing(data: Pick<IGroup, 'name' | 'description' | 'type' | 'organizationId'>): Promise<IGroupDocument>;
 }

--- a/b4m-core/common/src/types/entities/OrganizationTypes.ts
+++ b/b4m-core/common/src/types/entities/OrganizationTypes.ts
@@ -110,6 +110,17 @@ export interface IOrganizationRepository extends IBaseRepository<IOrganizationDo
   findByIdAndUserId(id: string, userId: string): Promise<IOrganizationDocument | null>;
 
   /**
+   * Soft-delete an organization from inside a transaction.
+   *
+   * Distinct from the inherited `delete`, which routes through the soft-delete plugin's raw-driver
+   * static and therefore escapes any surrounding `withTransaction`. Mirrors
+   * `IGroupRepository.softDeleteByIds`.
+   *
+   * @param id - The ID of the organization
+   */
+  softDeleteById(id: string): Promise<void>;
+
+  /**
    * Increment the current storage size of an organization
    * @param organizationId - The ID of the organization
    * @param count - The amount to increment by (can be negative for decrements)

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -161,6 +161,7 @@ export const createMockOrganizationRepository = (): MockedObject<IOrganizationRe
     search: vi.fn(),
     findByStripeCustomerId: vi.fn(),
     findIdsAdministeredBy: vi.fn(),
+    softDeleteById: vi.fn(),
     incrementCredits: vi.fn(),
     incrementCurrentStorage: vi.fn(),
     findByIdAndUserId: vi.fn(),

--- a/b4m-core/services/src/organizationService/delete.test.ts
+++ b/b4m-core/services/src/organizationService/delete.test.ts
@@ -36,6 +36,13 @@ describe('organizationService - delete', () => {
     mockAdapters = {
       db: {
         organizations: createMockRepository(),
+        groups: {
+          findByOrganization: vi.fn().mockResolvedValue([]),
+          softDeleteByIds: vi.fn(),
+        },
+        users: {
+          removeGroupsFromAllUsers: vi.fn(),
+        },
       },
     };
     vi.spyOn(getOrganization, 'get').mockResolvedValue(mockOrganization);
@@ -145,5 +152,72 @@ describe('organizationService - delete', () => {
 
     expect(getOrganization.get).toHaveBeenCalledWith(mockAdminUser, { id: 'org1' }, mockAdapters);
     expect(mockAdapters.db.organizations.delete).toHaveBeenCalledWith('org1');
+  });
+
+  // Regression coverage for #1219: deleteOrganization previously had NO reference to groups or
+  // users at all, so a deleted org's groups stayed live (soft-delete never applied) and every
+  // member kept the group ids in user.groups - continuing to satisfy the sharing layer's
+  // `groups.$elemMatch.groupId $in user.groups` match against a group whose org no longer exists.
+  describe('group footprint purge', () => {
+    const mockAdminUser: Partial<IUserDocument> = { id: 'admin1', isAdmin: true };
+
+    it('purges member group ids and soft-deletes the org groups when the org has live groups', async () => {
+      mockAdapters.db.groups.findByOrganization.mockResolvedValue([
+        { id: 'group-a', type: 'sales' },
+        { id: 'group-b', type: 'research' },
+      ]);
+      mockAdapters.db.organizations.delete.mockResolvedValue(undefined);
+
+      await deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters);
+
+      expect(mockAdapters.db.groups.findByOrganization).toHaveBeenCalledWith('org1');
+      expect(mockAdapters.db.users.removeGroupsFromAllUsers).toHaveBeenCalledWith(['group-a', 'group-b']);
+      expect(mockAdapters.db.groups.softDeleteByIds).toHaveBeenCalledWith(['group-a', 'group-b']);
+      expect(mockAdapters.db.organizations.delete).toHaveBeenCalledWith('org1');
+    });
+
+    it('purges membership BEFORE soft-deleting the groups (fail-safe ordering)', async () => {
+      const callOrder: string[] = [];
+      mockAdapters.db.groups.findByOrganization.mockResolvedValue([{ id: 'group-a', type: 'sales' }]);
+      mockAdapters.db.users.removeGroupsFromAllUsers.mockImplementation(async () => {
+        callOrder.push('removeGroupsFromAllUsers');
+      });
+      mockAdapters.db.groups.softDeleteByIds.mockImplementation(async () => {
+        callOrder.push('softDeleteByIds');
+      });
+      mockAdapters.db.organizations.delete.mockImplementation(async () => {
+        callOrder.push('organizations.delete');
+      });
+
+      await deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters);
+
+      expect(callOrder).toEqual(['removeGroupsFromAllUsers', 'softDeleteByIds', 'organizations.delete']);
+    });
+
+    it('does not call the purge or soft-delete when the org has no live groups', async () => {
+      mockAdapters.db.groups.findByOrganization.mockResolvedValue([]);
+      mockAdapters.db.organizations.delete.mockResolvedValue(undefined);
+
+      await deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters);
+
+      expect(mockAdapters.db.users.removeGroupsFromAllUsers).not.toHaveBeenCalled();
+      expect(mockAdapters.db.groups.softDeleteByIds).not.toHaveBeenCalled();
+      expect(mockAdapters.db.organizations.delete).toHaveBeenCalledWith('org1');
+    });
+
+    it('does not purge groups if validation rejects the delete', async () => {
+      mockAdapters.validation = {
+        canDeleteOrganization: vi.fn().mockResolvedValue({ canDelete: false, reason: 'blocked' }),
+      };
+      mockAdapters.db.groups.findByOrganization.mockResolvedValue([{ id: 'group-a', type: 'sales' }]);
+
+      await expect(deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters)).rejects.toThrow(
+        'Organization deletion validation failed: blocked'
+      );
+
+      expect(mockAdapters.db.groups.findByOrganization).not.toHaveBeenCalled();
+      expect(mockAdapters.db.users.removeGroupsFromAllUsers).not.toHaveBeenCalled();
+      expect(mockAdapters.db.groups.softDeleteByIds).not.toHaveBeenCalled();
+    });
   });
 });

--- a/b4m-core/services/src/organizationService/delete.test.ts
+++ b/b4m-core/services/src/organizationService/delete.test.ts
@@ -26,7 +26,7 @@ describe('organizationService - delete', () => {
 
   // Create a base mock repository with all required methods
   const createMockRepository = () => ({
-    delete: vi.fn(),
+    softDeleteById: vi.fn(),
     shareable: {
       findAccessibleById: vi.fn(),
     },
@@ -54,12 +54,12 @@ describe('organizationService - delete', () => {
       isAdmin: true,
     };
 
-    mockAdapters.db.organizations.delete.mockResolvedValue(undefined);
+    mockAdapters.db.organizations.softDeleteById.mockResolvedValue(undefined);
 
     await deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters);
 
     expect(getOrganization.get).toHaveBeenCalledWith(mockAdminUser, { id: 'org1' }, mockAdapters);
-    expect(mockAdapters.db.organizations.delete).toHaveBeenCalledWith('org1');
+    expect(mockAdapters.db.organizations.softDeleteById).toHaveBeenCalledWith('org1');
   });
 
   it('should fail if validation fails', async () => {
@@ -79,7 +79,7 @@ describe('organizationService - delete', () => {
 
     expect(getOrganization.get).toHaveBeenCalledWith(mockAdminUser, { id: 'org1' }, mockAdapters);
     expect(mockAdapters.validation.canDeleteOrganization).toHaveBeenCalledWith(mockOrganization);
-    expect(mockAdapters.db.organizations.delete).not.toHaveBeenCalled();
+    expect(mockAdapters.db.organizations.softDeleteById).not.toHaveBeenCalled();
   });
 
   it('should fail if validation fails without reason', async () => {
@@ -99,7 +99,7 @@ describe('organizationService - delete', () => {
 
     expect(getOrganization.get).toHaveBeenCalledWith(mockAdminUser, { id: 'org1' }, mockAdapters);
     expect(mockAdapters.validation.canDeleteOrganization).toHaveBeenCalledWith(mockOrganization);
-    expect(mockAdapters.db.organizations.delete).not.toHaveBeenCalled();
+    expect(mockAdapters.db.organizations.softDeleteById).not.toHaveBeenCalled();
   });
 
   it('should succeed if validation passes', async () => {
@@ -113,13 +113,13 @@ describe('organizationService - delete', () => {
       canDeleteOrganization: vi.fn().mockResolvedValue({ canDelete: true }),
     };
 
-    mockAdapters.db.organizations.delete.mockResolvedValue(undefined);
+    mockAdapters.db.organizations.softDeleteById.mockResolvedValue(undefined);
 
     await deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters);
 
     expect(getOrganization.get).toHaveBeenCalledWith(mockAdminUser, { id: 'org1' }, mockAdapters);
     expect(mockAdapters.validation.canDeleteOrganization).toHaveBeenCalledWith(mockOrganization);
-    expect(mockAdapters.db.organizations.delete).toHaveBeenCalledWith('org1');
+    expect(mockAdapters.db.organizations.softDeleteById).toHaveBeenCalledWith('org1');
   });
 
   it('should proceed with deletion if no validation is provided', async () => {
@@ -128,12 +128,12 @@ describe('organizationService - delete', () => {
       isAdmin: true,
     };
 
-    mockAdapters.db.organizations.delete.mockResolvedValue(undefined);
+    mockAdapters.db.organizations.softDeleteById.mockResolvedValue(undefined);
 
     await deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters);
 
     expect(getOrganization.get).toHaveBeenCalledWith(mockAdminUser, { id: 'org1' }, mockAdapters);
-    expect(mockAdapters.db.organizations.delete).toHaveBeenCalledWith('org1');
+    expect(mockAdapters.db.organizations.softDeleteById).toHaveBeenCalledWith('org1');
   });
 
   it('should throw if delete operation fails', async () => {
@@ -144,14 +144,14 @@ describe('organizationService - delete', () => {
 
     // Mock delete to throw an error
     const deleteError = new Error('Failed to delete organization');
-    mockAdapters.db.organizations.delete.mockRejectedValue(deleteError);
+    mockAdapters.db.organizations.softDeleteById.mockRejectedValue(deleteError);
 
     await expect(deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters)).rejects.toThrow(
       deleteError
     );
 
     expect(getOrganization.get).toHaveBeenCalledWith(mockAdminUser, { id: 'org1' }, mockAdapters);
-    expect(mockAdapters.db.organizations.delete).toHaveBeenCalledWith('org1');
+    expect(mockAdapters.db.organizations.softDeleteById).toHaveBeenCalledWith('org1');
   });
 
   // Regression coverage for #1219: deleteOrganization previously had NO reference to groups or
@@ -166,14 +166,14 @@ describe('organizationService - delete', () => {
         { id: 'group-a', type: 'sales' },
         { id: 'group-b', type: 'research' },
       ]);
-      mockAdapters.db.organizations.delete.mockResolvedValue(undefined);
+      mockAdapters.db.organizations.softDeleteById.mockResolvedValue(undefined);
 
       await deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters);
 
       expect(mockAdapters.db.groups.findByOrganization).toHaveBeenCalledWith('org1');
       expect(mockAdapters.db.users.removeGroupsFromAllUsers).toHaveBeenCalledWith(['group-a', 'group-b']);
       expect(mockAdapters.db.groups.softDeleteByIds).toHaveBeenCalledWith(['group-a', 'group-b']);
-      expect(mockAdapters.db.organizations.delete).toHaveBeenCalledWith('org1');
+      expect(mockAdapters.db.organizations.softDeleteById).toHaveBeenCalledWith('org1');
     });
 
     it('purges membership BEFORE soft-deleting the groups (fail-safe ordering)', async () => {
@@ -185,24 +185,24 @@ describe('organizationService - delete', () => {
       mockAdapters.db.groups.softDeleteByIds.mockImplementation(async () => {
         callOrder.push('softDeleteByIds');
       });
-      mockAdapters.db.organizations.delete.mockImplementation(async () => {
-        callOrder.push('organizations.delete');
+      mockAdapters.db.organizations.softDeleteById.mockImplementation(async () => {
+        callOrder.push('organizations.softDeleteById');
       });
 
       await deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters);
 
-      expect(callOrder).toEqual(['removeGroupsFromAllUsers', 'softDeleteByIds', 'organizations.delete']);
+      expect(callOrder).toEqual(['removeGroupsFromAllUsers', 'softDeleteByIds', 'organizations.softDeleteById']);
     });
 
     it('does not call the purge or soft-delete when the org has no live groups', async () => {
       mockAdapters.db.groups.findByOrganization.mockResolvedValue([]);
-      mockAdapters.db.organizations.delete.mockResolvedValue(undefined);
+      mockAdapters.db.organizations.softDeleteById.mockResolvedValue(undefined);
 
       await deleteOrganization(mockAdminUser as IUserDocument, { id: 'org1' }, mockAdapters);
 
       expect(mockAdapters.db.users.removeGroupsFromAllUsers).not.toHaveBeenCalled();
       expect(mockAdapters.db.groups.softDeleteByIds).not.toHaveBeenCalled();
-      expect(mockAdapters.db.organizations.delete).toHaveBeenCalledWith('org1');
+      expect(mockAdapters.db.organizations.softDeleteById).toHaveBeenCalledWith('org1');
     });
 
     it('does not purge groups if validation rejects the delete', async () => {

--- a/b4m-core/services/src/organizationService/delete.ts
+++ b/b4m-core/services/src/organizationService/delete.ts
@@ -1,4 +1,11 @@
-import { IOrganizationDocument, IOrganizationRepository, IUserDocument, WithId } from '@bike4mind/common';
+import {
+  IGroupRepository,
+  IOrganizationDocument,
+  IOrganizationRepository,
+  IUserDocument,
+  IUserRepository,
+  WithId,
+} from '@bike4mind/common';
 import { BadRequestError, secureParameters } from '@bike4mind/utils';
 import { z } from 'zod';
 import { get } from './get';
@@ -22,6 +29,8 @@ export type DeleteValidationFn = (
 interface DeleteAdapters {
   db: {
     organizations: IOrganizationRepository;
+    groups: Pick<IGroupRepository, 'findByOrganization' | 'softDeleteByIds'>;
+    users: Pick<IUserRepository, 'removeGroupsFromAllUsers'>;
   };
   /**
    * Optional validation service to determine if organization can be deleted
@@ -37,6 +46,10 @@ interface DeleteAdapters {
  * @param params - The parameters for the operation
  * @param adapters - The adapters for the operation
  * @throws {Error} If organization cannot be deleted based on validation, includes reason if provided
+ *
+ * Caller MUST wrap this in withTransaction (see the route): the member purge, the group
+ * soft-deletes, and the org delete have to commit together, or a partial failure leaves either
+ * dangling group access or an org that never actually deletes.
  */
 export async function deleteOrganization(
   user: IUserDocument,
@@ -56,6 +69,19 @@ export async function deleteOrganization(
     if (!result.canDelete) {
       throw new BadRequestError(`Organization deletion validation failed${result.reason ? `: ${result.reason}` : ''}`);
     }
+  }
+
+  // Purge this org's group footprint BEFORE soft-deleting the org (org-groups #1172/#1219).
+  // Members first, then the group instances - user.groups[] is the access-bearing artifact: the
+  // sharing layer's `groups.$elemMatch.groupId $in user.groups` match still succeeds against a
+  // soft-deleted group's id, so purging membership after the group delete (or not at all) would
+  // leave live access to a group whose organization no longer exists. Mirrors the revoke order in
+  // setOrganizationGroupTypes for the same reason.
+  const orgGroups = await adapters.db.groups.findByOrganization(id);
+  if (orgGroups.length > 0) {
+    const groupIds = orgGroups.map(group => group.id);
+    await adapters.db.users.removeGroupsFromAllUsers(groupIds);
+    await adapters.db.groups.softDeleteByIds(groupIds);
   }
 
   // Delete the organization

--- a/b4m-core/services/src/organizationService/delete.ts
+++ b/b4m-core/services/src/organizationService/delete.ts
@@ -84,6 +84,7 @@ export async function deleteOrganization(
     await adapters.db.groups.softDeleteByIds(groupIds);
   }
 
-  // Delete the organization
-  await adapters.db.organizations.delete(id);
+  // softDeleteById, not the inherited `delete`: the latter soft-deletes through the raw driver and
+  // would commit immediately regardless of the caller's transaction (see the repository note).
+  await adapters.db.organizations.softDeleteById(id);
 }

--- a/b4m-core/services/src/organizationService/purgeOrgMembership.ts
+++ b/b4m-core/services/src/organizationService/purgeOrgMembership.ts
@@ -14,8 +14,10 @@ interface PurgeOrgMembershipAdapters {
  *   - compute `adminUserIds` with the member removed and RETURN it.
  *
  * Neither `user.groups[]` nor `adminUserIds` carries an org qualifier, so a member who keeps them
- * after removal retains both group-shared data access and org-admin authority
- * (`assertCanManageOrgGroups` only checks `adminUserIds`).
+ * after removal retains both group-shared data access and org-admin authority. (`assertCanManageOrgGroups`
+ * also requires current org membership, not just `adminUserIds` - but that check reads
+ * `organization.users`, which THIS purge doesn't touch, so it is not a substitute for pruning
+ * `adminUserIds` here.)
  *
  * Returns the pruned `adminUserIds` rather than mutating in place and returning void: the caller
  * MUST assign it onto the org doc it persists, so a future caller cannot silently get the unsafe

--- a/b4m-core/services/src/organizationService/setOrganizationGroupTypes.test.ts
+++ b/b4m-core/services/src/organizationService/setOrganizationGroupTypes.test.ts
@@ -116,17 +116,4 @@ describe('setOrganizationGroupTypes', () => {
     expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales'] });
     expect(db.groups.createIfMissing).toHaveBeenCalledTimes(1);
   });
-
-  // #1222: two overlapping grant PUTs can both pass the "no live instance" check above and both
-  // reach this loop. The E11000-vs-500 race is handled INSIDE createIfMissing (GroupRepository);
-  // this pins that the service just calls it and proceeds normally with whatever it resolves to -
-  // it must not itself special-case a collision or re-check for one.
-  it('proceeds normally when createIfMissing resolves a concurrent-create collision', async () => {
-    db.groups.createIfMissing.mockResolvedValue({ id: 'g-sales-from-other-request', type: 'sales' });
-
-    const result = await run(['sales']);
-
-    expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales'] });
-    expect(result.added).toEqual(['sales']);
-  });
 });

--- a/b4m-core/services/src/organizationService/setOrganizationGroupTypes.test.ts
+++ b/b4m-core/services/src/organizationService/setOrganizationGroupTypes.test.ts
@@ -87,6 +87,31 @@ describe('setOrganizationGroupTypes', () => {
     expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales'] });
   });
 
+  // Fail-safe ordering, mirroring organizationService/delete.ts: user.groups[] is the
+  // access-bearing artifact (the sharing layer matches groups.$elemMatch.groupId against
+  // user.groups and never joins the Group row), so membership has to go first. Both orders commit
+  // identically inside a transaction, which is exactly why only an explicit assertion stops a
+  // refactor from silently reverting to the fail-open order.
+  it('purges member group ids BEFORE soft-deleting the revoked groups', async () => {
+    db.organizations.findById.mockResolvedValue(org({ allowedGroupTypes: ['sales', 'research'] }));
+    db.groups.findByOrganization.mockResolvedValue([
+      { id: 'g-sales', type: 'sales' },
+      { id: 'g-research', type: 'research' },
+    ]);
+
+    const callOrder: string[] = [];
+    db.users.removeGroupsFromAllUsers.mockImplementation(async () => {
+      callOrder.push('removeGroupsFromAllUsers');
+    });
+    db.groups.softDeleteByIds.mockImplementation(async () => {
+      callOrder.push('softDeleteByIds');
+    });
+
+    await run(['sales']); // research removed
+
+    expect(callOrder).toEqual(['removeGroupsFromAllUsers', 'softDeleteByIds']);
+  });
+
   it('does not touch groups/members when nothing is revoked', async () => {
     db.organizations.findById.mockResolvedValue(org({ allowedGroupTypes: ['sales'] }));
     db.groups.findByOrganization.mockResolvedValue([{ id: 'g-sales', type: 'sales' }]);

--- a/b4m-core/services/src/organizationService/setOrganizationGroupTypes.test.ts
+++ b/b4m-core/services/src/organizationService/setOrganizationGroupTypes.test.ts
@@ -19,7 +19,7 @@ describe('setOrganizationGroupTypes', () => {
       organizations: { findById: vi.fn().mockResolvedValue(org()), update: vi.fn() },
       groups: {
         findByOrganization: vi.fn().mockResolvedValue([]),
-        create: vi.fn(),
+        createIfMissing: vi.fn(),
         softDeleteByIds: vi.fn(),
       },
       users: { removeGroupsFromAllUsers: vi.fn() },
@@ -32,7 +32,7 @@ describe('setOrganizationGroupTypes', () => {
 
   it('rejects unknown group type keys before any write', async () => {
     await expect(run(['sales', 'bogus'])).rejects.toThrow(BadRequestError);
-    expect(db.groups.create).not.toHaveBeenCalled();
+    expect(db.groups.createIfMissing).not.toHaveBeenCalled();
     expect(db.organizations.update).not.toHaveBeenCalled();
   });
 
@@ -50,8 +50,8 @@ describe('setOrganizationGroupTypes', () => {
   it('provisions a group instance for each newly-allowed type', async () => {
     const result = await run(['sales', 'research']);
 
-    expect(db.groups.create).toHaveBeenCalledTimes(2);
-    expect(db.groups.create).toHaveBeenCalledWith(
+    expect(db.groups.createIfMissing).toHaveBeenCalledTimes(2);
+    expect(db.groups.createIfMissing).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'sales', name: 'Sales', organizationId: 'org-1' })
     );
     expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales', 'research'] });
@@ -66,8 +66,8 @@ describe('setOrganizationGroupTypes', () => {
     await run(['sales', 'research']);
 
     // only the genuinely-new 'research' type is provisioned
-    expect(db.groups.create).toHaveBeenCalledTimes(1);
-    expect(db.groups.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'research' }));
+    expect(db.groups.createIfMissing).toHaveBeenCalledTimes(1);
+    expect(db.groups.createIfMissing).toHaveBeenCalledWith(expect.objectContaining({ type: 'research' }));
   });
 
   it('revokes a removed type: soft-deletes its instances AND purges member group ids', async () => {
@@ -81,7 +81,7 @@ describe('setOrganizationGroupTypes', () => {
 
     expect(db.groups.softDeleteByIds).toHaveBeenCalledWith(['g-research']);
     expect(db.users.removeGroupsFromAllUsers).toHaveBeenCalledWith(['g-research']);
-    expect(db.groups.create).not.toHaveBeenCalled();
+    expect(db.groups.createIfMissing).not.toHaveBeenCalled();
     expect(result.removed).toEqual(['research']);
     expect(result.revokedGroupIds).toEqual(['g-research']);
     expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales'] });
@@ -95,7 +95,7 @@ describe('setOrganizationGroupTypes', () => {
 
     expect(db.groups.softDeleteByIds).not.toHaveBeenCalled();
     expect(db.users.removeGroupsFromAllUsers).not.toHaveBeenCalled();
-    expect(db.groups.create).not.toHaveBeenCalled();
+    expect(db.groups.createIfMissing).not.toHaveBeenCalled();
   });
 
   it('re-provisions a missing group for an already-allowed type (repairability)', async () => {
@@ -106,14 +106,27 @@ describe('setOrganizationGroupTypes', () => {
 
     const result = await run(['sales']);
 
-    expect(db.groups.create).toHaveBeenCalledTimes(1);
-    expect(db.groups.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'sales' }));
+    expect(db.groups.createIfMissing).toHaveBeenCalledTimes(1);
+    expect(db.groups.createIfMissing).toHaveBeenCalledWith(expect.objectContaining({ type: 'sales' }));
     expect(result.added).toEqual([]);
   });
 
   it('dedupes and trims requested keys', async () => {
     await run([' sales ', 'sales']);
     expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales'] });
-    expect(db.groups.create).toHaveBeenCalledTimes(1);
+    expect(db.groups.createIfMissing).toHaveBeenCalledTimes(1);
+  });
+
+  // #1222: two overlapping grant PUTs can both pass the "no live instance" check above and both
+  // reach this loop. The E11000-vs-500 race is handled INSIDE createIfMissing (GroupRepository);
+  // this pins that the service just calls it and proceeds normally with whatever it resolves to -
+  // it must not itself special-case a collision or re-check for one.
+  it('proceeds normally when createIfMissing resolves a concurrent-create collision', async () => {
+    db.groups.createIfMissing.mockResolvedValue({ id: 'g-sales-from-other-request', type: 'sales' });
+
+    const result = await run(['sales']);
+
+    expect(db.organizations.update).toHaveBeenCalledWith({ id: 'org-1', allowedGroupTypes: ['sales'] });
+    expect(result.added).toEqual(['sales']);
   });
 });

--- a/b4m-core/services/src/organizationService/setOrganizationGroupTypes.ts
+++ b/b4m-core/services/src/organizationService/setOrganizationGroupTypes.ts
@@ -10,7 +10,7 @@ import { BadRequestError, NotFoundError } from '@bike4mind/utils';
 interface SetGroupTypesAdapters {
   db: {
     organizations: Pick<IOrganizationRepository, 'findById' | 'update'>;
-    groups: Pick<IGroupRepository, 'findByOrganization' | 'create' | 'softDeleteByIds'>;
+    groups: Pick<IGroupRepository, 'findByOrganization' | 'createIfMissing' | 'softDeleteByIds'>;
     users: Pick<IUserRepository, 'removeGroupsFromAllUsers'>;
   };
   logger?: { info: (message: string) => void };
@@ -65,10 +65,13 @@ export async function setOrganizationGroupTypes(
   // `requested`, not `added`: iterating only newly-added types leaves no way to repair an org
   // that holds a type with no live group (e.g. a prior revoke that soft-deleted the instance but
   // whose member purge was lost). Re-issuing the same PUT now re-provisions the missing group.
+  // createIfMissing (not create): two overlapping grant PUTs can both reach this loop with the
+  // same missing type - the loser would otherwise hit the group_org_type_live unique index and
+  // 500 (org-groups #1222). createIfMissing treats that collision as success.
   for (const type of requested) {
     if (typesWithInstance.has(type)) continue;
     const def = getGroupType(type)!; // safe: requested keys were validated against the catalog above
-    await db.groups.create({ name: def.label, description: def.description, type, organizationId });
+    await db.groups.createIfMissing({ name: def.label, description: def.description, type, organizationId });
   }
 
   // Revoke: soft-delete the instances of removed types, then purge their ids from all members.

--- a/b4m-core/services/src/organizationService/setOrganizationGroupTypes.ts
+++ b/b4m-core/services/src/organizationService/setOrganizationGroupTypes.ts
@@ -74,11 +74,16 @@ export async function setOrganizationGroupTypes(
     await db.groups.createIfMissing({ name: def.label, description: def.description, type, organizationId });
   }
 
-  // Revoke: soft-delete the instances of removed types, then purge their ids from all members.
+  // Revoke: purge the ids from all members, then soft-delete the instances of removed types.
+  // Members first for the same reason as organizationService/delete.ts: user.groups[] is the
+  // access-bearing artifact (the sharing layer's `groups.$elemMatch.groupId $in user.groups` match
+  // still succeeds against a soft-deleted group's id), so it is the one that must go first. Both
+  // orders are equivalent while this runs in a transaction, but the two paths should not disagree
+  // about which write carries the access.
   const revokedGroupIds = liveGroups.filter(group => removed.includes(group.type)).map(group => group.id);
   if (revokedGroupIds.length > 0) {
-    await db.groups.softDeleteByIds(revokedGroupIds);
     await db.users.removeGroupsFromAllUsers(revokedGroupIds);
+    await db.groups.softDeleteByIds(revokedGroupIds);
   }
 
   await db.organizations.update({ id: organizationId, allowedGroupTypes: requested });

--- a/b4m-core/services/src/sharingService/accept.test.ts
+++ b/b4m-core/services/src/sharingService/accept.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, Mock } from 'vitest';
 import { InviteType, Permission } from '@bike4mind/common';
-import { NotFoundError, ForbiddenError } from '@bike4mind/utils';
+import { NotFoundError, ForbiddenError, BadRequestError } from '@bike4mind/utils';
 import { acceptInvite } from './accept';
 
 describe('sharingService - acceptInvite (Organization)', () => {
@@ -14,6 +14,7 @@ describe('sharingService - acceptInvite (Organization)', () => {
       sessions: { findById: Mock; update: Mock; findAllByIds: Mock };
       projects: { findById: Mock; update: Mock };
       fabFiles: { findById: Mock; update: Mock; findAllByIds: Mock };
+      groups: { findById: Mock };
       organization: { findById: Mock; update: Mock };
       users: { findById: Mock; update: Mock };
     };
@@ -54,6 +55,7 @@ describe('sharingService - acceptInvite (Organization)', () => {
         sessions: { findById: vi.fn(), update: vi.fn(), findAllByIds: vi.fn() },
         projects: { findById: vi.fn(), update: vi.fn() },
         fabFiles: { findById: vi.fn(), update: vi.fn(), findAllByIds: vi.fn() },
+        groups: { findById: vi.fn() },
         organization: { findById: vi.fn(), update: vi.fn() },
         users: { findById: vi.fn(), update: vi.fn() },
       },
@@ -135,5 +137,130 @@ describe('sharingService - acceptInvite (Organization)', () => {
 
     await expect(acceptInvite(userId, { id: inviteId }, mockAdapters as any)).rejects.toThrow(NotFoundError);
     expect(mockAdapters.db.users.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('sharingService - acceptInvite (Group)', () => {
+  // Regression coverage for #1224: the Group case previously wrote user.groups with no org
+  // membership check at all. These pin the write-path invariant (2) it now enforces - the
+  // accepting user must already be a member of the group's owning organization - mirroring
+  // organizationService/groupMembership.ts's assertion of the same rule on every other
+  // group-membership write.
+  const userId = 'user-123';
+  const groupId = 'group-456';
+  const organizationId = 'org-789';
+  const inviteId = 'invite-999';
+
+  let mockAdapters: {
+    db: {
+      invites: { findById: Mock; update: Mock };
+      sessions: { findById: Mock; update: Mock; findAllByIds: Mock };
+      projects: { findById: Mock; update: Mock };
+      fabFiles: { findById: Mock; update: Mock; findAllByIds: Mock };
+      groups: { findById: Mock };
+      organization: { findById: Mock; update: Mock };
+      users: { findById: Mock; update: Mock };
+    };
+  };
+
+  const makeUser = (overrides: Record<string, unknown> = {}) => ({
+    id: userId,
+    email: 'member@example.com',
+    username: 'member',
+    name: 'Member',
+    groups: [] as string[],
+    ...overrides,
+  });
+
+  const makeInvite = () => ({
+    id: inviteId,
+    type: InviteType.Group,
+    documentId: groupId,
+    permissions: [Permission.read],
+    remaining: 1,
+    accepted: 0,
+    recipients: { pending: ['member@example.com'], refused: [], accepted: [] },
+  });
+
+  const makeGroup = (overrides: Record<string, unknown> = {}) => ({
+    id: groupId,
+    name: 'Sales',
+    type: 'sales',
+    organizationId,
+    ...overrides,
+  });
+
+  const makeOrganization = (overrides: Record<string, unknown> = {}) => ({
+    id: organizationId,
+    users: [{ userId, permissions: [Permission.read] }],
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdapters = {
+      db: {
+        invites: { findById: vi.fn(), update: vi.fn() },
+        sessions: { findById: vi.fn(), update: vi.fn(), findAllByIds: vi.fn() },
+        projects: { findById: vi.fn(), update: vi.fn() },
+        fabFiles: { findById: vi.fn(), update: vi.fn(), findAllByIds: vi.fn() },
+        groups: { findById: vi.fn() },
+        organization: { findById: vi.fn(), update: vi.fn() },
+        users: { findById: vi.fn(), update: vi.fn() },
+      },
+    };
+  });
+
+  it('adds the group id to user.groups for a member of the owning organization', async () => {
+    mockAdapters.db.users.findById.mockResolvedValue(makeUser());
+    mockAdapters.db.invites.findById.mockResolvedValue(makeInvite());
+    mockAdapters.db.groups.findById.mockResolvedValue(makeGroup());
+    mockAdapters.db.organization.findById.mockResolvedValue(makeOrganization());
+
+    await acceptInvite(userId, { id: inviteId }, mockAdapters as any);
+
+    expect(mockAdapters.db.users.update).toHaveBeenCalledWith(expect.objectContaining({ groups: [groupId] }));
+  });
+
+  it('rejects a caller who is not a member of the group organization, and does not write', async () => {
+    mockAdapters.db.users.findById.mockResolvedValue(makeUser());
+    mockAdapters.db.invites.findById.mockResolvedValue(makeInvite());
+    mockAdapters.db.groups.findById.mockResolvedValue(makeGroup());
+    // The accepting user is not in organization.users - an outsider holding the invite id.
+    mockAdapters.db.organization.findById.mockResolvedValue(makeOrganization({ users: [{ userId: 'someone-else' }] }));
+
+    await expect(acceptInvite(userId, { id: inviteId }, mockAdapters as any)).rejects.toThrow(BadRequestError);
+    expect(mockAdapters.db.users.update).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundError when the group does not exist (or is soft-deleted)', async () => {
+    mockAdapters.db.users.findById.mockResolvedValue(makeUser());
+    mockAdapters.db.invites.findById.mockResolvedValue(makeInvite());
+    mockAdapters.db.groups.findById.mockResolvedValue(null);
+
+    await expect(acceptInvite(userId, { id: inviteId }, mockAdapters as any)).rejects.toThrow(NotFoundError);
+    expect(mockAdapters.db.organization.findById).not.toHaveBeenCalled();
+    expect(mockAdapters.db.users.update).not.toHaveBeenCalled();
+  });
+
+  it("throws NotFoundError when the group's organization does not exist", async () => {
+    mockAdapters.db.users.findById.mockResolvedValue(makeUser());
+    mockAdapters.db.invites.findById.mockResolvedValue(makeInvite());
+    mockAdapters.db.groups.findById.mockResolvedValue(makeGroup());
+    mockAdapters.db.organization.findById.mockResolvedValue(null);
+
+    await expect(acceptInvite(userId, { id: inviteId }, mockAdapters as any)).rejects.toThrow(NotFoundError);
+    expect(mockAdapters.db.users.update).not.toHaveBeenCalled();
+  });
+
+  it('does not duplicate the group id if the user already holds it (double-accept)', async () => {
+    mockAdapters.db.users.findById.mockResolvedValue(makeUser({ groups: [groupId] }));
+    mockAdapters.db.invites.findById.mockResolvedValue(makeInvite());
+    mockAdapters.db.groups.findById.mockResolvedValue(makeGroup());
+    mockAdapters.db.organization.findById.mockResolvedValue(makeOrganization());
+
+    await acceptInvite(userId, { id: inviteId }, mockAdapters as any);
+
+    expect(mockAdapters.db.users.update).toHaveBeenCalledWith(expect.objectContaining({ groups: [groupId] }));
   });
 });

--- a/b4m-core/services/src/sharingService/accept.ts
+++ b/b4m-core/services/src/sharingService/accept.ts
@@ -109,8 +109,13 @@ export const acceptInvite = async (userId: string, params: AcceptInviteParameter
         throw new BadRequestError('User is not a member of this organization');
       }
 
-      // $addToSet semantics: a user can hold the same invite link twice (e.g. two browser tabs),
-      // and a duplicate id would double-count them in memberCount and duplicate list rendering.
+      // Dedupe before appending: a user can hold the same invite link twice (e.g. two browser
+      // tabs), and a duplicate id would double-count them in memberCount and duplicate list
+      // rendering. This is a read-modify-write of the whole user document, NOT a `$addToSet` - so
+      // the guard alone does not make concurrent accepts safe. Two accepts racing on the same user
+      // are serialized by the caller's transaction (they conflict on the same document, and the
+      // loser retries against the winner's committed state); the read side is defended separately
+      // by the `$addToSet` in UserModel.findUserIdsByGroupIds.
       user.groups ||= [];
       if (!user.groups.includes(group.id)) {
         user.groups.push(group.id);

--- a/b4m-core/services/src/sharingService/accept.ts
+++ b/b4m-core/services/src/sharingService/accept.ts
@@ -1,5 +1,6 @@
 import {
   IFabFileRepository,
+  IGroupDocument,
   IInvite,
   IInviteRepository,
   InviteType,
@@ -10,7 +11,13 @@ import {
   IUserDocument,
   Permission,
 } from '@bike4mind/common';
-import { ForbiddenError, NotFoundError, secureParameters, UnprocessableEntityError } from '@bike4mind/utils';
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+  secureParameters,
+  UnprocessableEntityError,
+} from '@bike4mind/utils';
 import { z } from 'zod';
 
 const acceptInviteSchema = z.object({
@@ -25,6 +32,10 @@ interface AcceptInviteAdapters {
     sessions: ISessionRepository;
     projects: IProjectRepository;
     fabFiles: IFabFileRepository;
+    // Same shape authorizeByInviteType.ts already uses to resolve a group's parent org.
+    groups: {
+      findById: (id: string) => Promise<IGroupDocument | null>;
+    };
     organization: {
       findById: (id: string) => Promise<IOrganizationDocument | null>;
       update: (data: IOrganizationDocument) => Promise<unknown>;
@@ -79,11 +90,34 @@ export const acceptInvite = async (userId: string, params: AcceptInviteParameter
   const update = { userId, permissions: inviteWithPermissions.permissions };
 
   switch (invite.type) {
-    case InviteType.Group:
+    case InviteType.Group: {
+      const group = await db.groups.findById(invite.documentId);
+      if (!group) throw new NotFoundError('Group not found');
+
+      const organization = await db.organization.findById(group.organizationId);
+      if (!organization) throw new NotFoundError('Organization not found');
+
+      // Write-path invariant (organizationService/groupMembership.ts): every group-membership
+      // write must confirm the target user is a member of the group's owning organization.
+      // This case previously had NO check at all - anyone holding (or guessing) an invite id
+      // could attach themselves to a group and inherit whatever it gates, since user.groups is
+      // read by CASL sharing, both data-lake paths, and KB retrieve/search (#1224). Matching
+      // invariant (2)'s error, not a distinct message: a different error for "wrong org" vs.
+      // "not a member" would leak which is true for a caller probing invite ids.
+      const isMember = organization.users.some(member => member.userId === userId);
+      if (!isMember) {
+        throw new BadRequestError('User is not a member of this organization');
+      }
+
+      // $addToSet semantics: a user can hold the same invite link twice (e.g. two browser tabs),
+      // and a duplicate id would double-count them in memberCount and duplicate list rendering.
       user.groups ||= [];
-      user.groups.push(invite.documentId);
+      if (!user.groups.includes(group.id)) {
+        user.groups.push(group.id);
+      }
       await db.users.update(user);
       break;
+    }
     case InviteType.Session: {
       const session = await db.sessions.findById(invite.documentId);
       if (!session) throw new NotFoundError('Session not found');

--- a/packages/database/src/__test__/createMongoServer.ts
+++ b/packages/database/src/__test__/createMongoServer.ts
@@ -1,17 +1,5 @@
 import { MongoMemoryReplSet, MongoMemoryServer } from 'mongodb-memory-server';
 
-/**
- * Bounded retry wrapper around `MongoMemoryServer.create()` to absorb the
- * ephemeral-port race under parallel test execution.
- *
- * `mongodb-memory-server` picks a free port then spawns `mongod` to bind it.
- * That check-then-bind is racy: when many suites start `mongod` concurrently,
- * two workers can be handed the same just-freed port and the loser dies with
- * `Port "<n>" already in use`. The library has no retry. Each retry re-runs
- * `create()` (fresh port selection), so a collision does not recur on the next
- * attempt. Only port-in-use is retried; every other startup error surfaces at
- * once so real problems are never masked.
- */
 // Coupled to the exact wording `mongodb-memory-server-core` emits for a port
 // collision (`MongoInstance.ts`). A major version bump can change the message;
 // then this regex stops matching and the wrapper degrades to a passthrough (the
@@ -29,6 +17,18 @@ const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, m
 // in lockstep (the standard retry-storm mitigation).
 const backoffMs = (attempt: number) => RETRY_BACKOFF_MS * attempt + Math.floor(Math.random() * RETRY_BACKOFF_MS);
 
+/**
+ * Bounded retry wrapper around a `mongodb-memory-server` factory (standalone or replica set) to
+ * absorb the ephemeral-port race under parallel test execution.
+ *
+ * The library picks a free port then spawns `mongod` to bind it. That check-then-bind is racy:
+ * when many suites start `mongod` concurrently, two workers can be handed the same just-freed
+ * port and the loser dies with `Port "<n>" already in use`. The library has no retry. Each retry
+ * re-runs the factory (fresh port selection), so a collision does not recur on the next attempt.
+ * Only port-in-use is retried; every other startup error surfaces at once so real problems are
+ * never masked - note that replica-set-specific failures (init or election timeout) are therefore
+ * NOT retried and surface immediately.
+ */
 const withPortRetry = async <T>(start: () => Promise<T>): Promise<T> => {
   let lastError: unknown;
 
@@ -54,10 +54,16 @@ export const createMongoServer = async (): Promise<MongoMemoryServer> =>
 
 /**
  * Single-node replica set. Use this instead of `createMongoServer` whenever a test needs REAL
- * transaction semantics: a standalone mongod cannot start one, so against `createMongoServer`
- * every `withTransaction` silently degrades to unwrapped writes and a test can neither observe a
- * rollback nor catch a write that escapes the session. Slower to boot - reach for it only when
- * transactionality is the thing under test.
+ * transaction semantics.
+ *
+ * A standalone mongod cannot run a transaction at all: the first write inside the session fails
+ * with `MongoServerError` code 20 ("Transaction numbers are only allowed on a replica set member
+ * or mongos"), and `withTransaction` does not classify that as transient, so it rethrows. A
+ * transaction-shaped test against `createMongoServer` therefore errors out loudly - it does NOT
+ * quietly pass with no transactional guarantee. If you are staring at a code-20 failure, this
+ * helper is the fix.
+ *
+ * Slower to boot - reach for it only when transactionality is the thing under test.
  */
 export const createMongoReplSet = async (): Promise<MongoMemoryReplSet> =>
   withPortRetry(() => MongoMemoryReplSet.create({ replSet: { count: 1, storageEngine: 'wiredTiger' } }));

--- a/packages/database/src/__test__/createMongoServer.ts
+++ b/packages/database/src/__test__/createMongoServer.ts
@@ -1,4 +1,4 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoMemoryReplSet, MongoMemoryServer } from 'mongodb-memory-server';
 
 /**
  * Bounded retry wrapper around `MongoMemoryServer.create()` to absorb the
@@ -29,12 +29,12 @@ const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, m
 // in lockstep (the standard retry-storm mitigation).
 const backoffMs = (attempt: number) => RETRY_BACKOFF_MS * attempt + Math.floor(Math.random() * RETRY_BACKOFF_MS);
 
-export const createMongoServer = async (): Promise<MongoMemoryServer> => {
+const withPortRetry = async <T>(start: () => Promise<T>): Promise<T> => {
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= MAX_START_ATTEMPTS; attempt++) {
     try {
-      return await MongoMemoryServer.create();
+      return await start();
     } catch (error) {
       if (!isPortInUseError(error)) {
         throw error;
@@ -48,3 +48,16 @@ export const createMongoServer = async (): Promise<MongoMemoryServer> => {
 
   throw lastError;
 };
+
+export const createMongoServer = async (): Promise<MongoMemoryServer> =>
+  withPortRetry(() => MongoMemoryServer.create());
+
+/**
+ * Single-node replica set. Use this instead of `createMongoServer` whenever a test needs REAL
+ * transaction semantics: a standalone mongod cannot start one, so against `createMongoServer`
+ * every `withTransaction` silently degrades to unwrapped writes and a test can neither observe a
+ * rollback nor catch a write that escapes the session. Slower to boot - reach for it only when
+ * transactionality is the thing under test.
+ */
+export const createMongoReplSet = async (): Promise<MongoMemoryReplSet> =>
+  withPortRetry(() => MongoMemoryReplSet.create({ replSet: { count: 1, storageEngine: 'wiredTiger' } }));

--- a/packages/database/src/models/auth/UserModel.findUserIdsByGroupIds.test.ts
+++ b/packages/database/src/models/auth/UserModel.findUserIdsByGroupIds.test.ts
@@ -59,4 +59,18 @@ describe('UserModel.findUserIdsByGroupIds', () => {
 
     expect(await userRepository.findUserIdsByGroupIds([])).toEqual({});
   });
+
+  // #1222/#1224: a duplicate entry in user.groups for the same id (e.g. a pre-fix double-accept
+  // via the legacy group-invite path) must not double-count that member. $addToSet in the
+  // aggregation's $group stage is what makes this hold regardless of write-side dedup - insert the
+  // duplicate directly (bypassing the schema-level $addToSet writers) to prove the READ side, not
+  // just the write side, is what prevents the double-count.
+  it('does not double-count a member whose user.groups array holds a duplicate group id', async () => {
+    const u1 = await makeUser(['group-a']);
+    await User.updateOne({ _id: u1.id }, { $set: { groups: ['group-a', 'group-a'] } });
+
+    const result = await userRepository.findUserIdsByGroupIds(['group-a']);
+
+    expect(result['group-a']).toEqual([u1.id]);
+  });
 });

--- a/packages/database/src/models/auth/UserModel.ts
+++ b/packages/database/src/models/auth/UserModel.ts
@@ -271,11 +271,15 @@ export class UserRepository extends BaseRepository<IUserDocument> implements IUs
   /** Member ids per group id in one aggregation (keyed by group id; absent = no members). */
   async findUserIdsByGroupIds(groupIds: string[]): Promise<Record<string, string[]>> {
     if (groupIds.length === 0) return {};
+    // $addToSet, not $push: a user whose user.groups array holds a duplicate entry for the same
+    // group (e.g. a pre-#1224 double-accept via the legacy group-invite path) would otherwise be
+    // counted twice for that group. $addToSet makes memberCount correct by construction rather
+    // than relying on every writer to dedupe user.groups itself.
     const rows = await this.model.aggregate<{ _id: string; userIds: string[] }>([
       { $match: { groups: { $in: groupIds } } },
       { $unwind: '$groups' },
       { $match: { groups: { $in: groupIds } } },
-      { $group: { _id: '$groups', userIds: { $push: { $toString: '$_id' } } } },
+      { $group: { _id: '$groups', userIds: { $addToSet: { $toString: '$_id' } } } },
     ]);
     const membersByGroup: Record<string, string[]> = {};
     for (const row of rows) membersByGroup[row._id] = row.userIds;

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -278,6 +278,20 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
   }
 
   /**
+   * Soft-delete by writing `deletedAt` directly via a Mongoose `updateOne`.
+   * NOT the inherited `delete`: that routes through the soft-delete plugin's static, which uses
+   * the raw driver (`this.collection.updateOne`). Mongoose 8's transactionAsyncLocalStorage only
+   * injects a session into Mongoose queries, so the raw call would commit immediately and escape
+   * the surrounding `withTransaction` - leaving, on a commit-time retry, an organization that is
+   * already gone while its groups and their memberships roll back (org-groups #1219). `get()`
+   * filters `deletedAt`, so the retry then 404s permanently. Same reasoning as
+   * `GroupRepository.softDeleteByIds`.
+   */
+  async softDeleteById(id: string): Promise<void> {
+    await this.organizationModel.updateOne({ _id: id, deletedAt: null }, { $set: { deletedAt: new Date() } });
+  }
+
+  /**
    * IDs of every organization the user administers (billing owner or assigned
    * manager). Used to surface org-scoped resources - e.g. org-scoped skills -
    * to the people who can manage them, without widening visibility to all

--- a/packages/database/src/models/social/GroupModel.integration.test.ts
+++ b/packages/database/src/models/social/GroupModel.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import { createMongoServer } from '../../__test__/createMongoServer';
 import { Group, groupRepository } from './GroupModel';
@@ -117,5 +117,70 @@ describe('GroupRepository', () => {
     // the document still exists (soft, not hard delete) - visible when bypassing the find hook
     const raw = await mongoose.connection.collection('groups').findOne({ _id: g._id });
     expect(raw?.deletedAt).toBeInstanceOf(Date);
+  });
+
+  describe('createIfMissing (org-groups #1222)', () => {
+    it('creates normally when nothing exists yet', async () => {
+      const group = await groupRepository.createIfMissing({
+        name: 'Sales',
+        description: 'd',
+        type: 'sales',
+        organizationId: 'org-race',
+      });
+
+      expect(group.type).toBe('sales');
+      const [stored] = await groupRepository.findByOrganization('org-race');
+      expect(stored.id).toBe(group.id);
+    });
+
+    // The actual race: simulate two overlapping grant PUTs both calling createIfMissing for the
+    // same (org, type) after both observed no live instance. Real concurrent requests would race
+    // at the driver level; issuing them back-to-back here still exercises the E11000 catch,
+    // since the second call's create() genuinely collides with the first's already-committed row.
+    it('returns the WINNING row instead of throwing when a concurrent create collides', async () => {
+      const first = await groupRepository.createIfMissing({
+        name: 'Sales',
+        description: 'd',
+        type: 'sales',
+        organizationId: 'org-race-2',
+      });
+
+      const second = await groupRepository.createIfMissing({
+        name: 'Sales (loser)',
+        description: 'd',
+        type: 'sales',
+        organizationId: 'org-race-2',
+      });
+
+      // Same row, not a second one - proves this resolved via the E11000 catch, not a silent
+      // second insert (which the unique index would reject anyway).
+      expect(second.id).toBe(first.id);
+      expect(second.name).toBe('Sales');
+      const live = await groupRepository.findByOrganization('org-race-2');
+      expect(live).toHaveLength(1);
+    });
+
+    it('re-throws a genuine E11000 if the winning row cannot be found (e.g. deleted mid-race)', async () => {
+      // Prove the fallback path does not silently swallow every duplicate-key error: force a
+      // simulated E11000 out of create(), then look for a row (org-race-4/research) that does
+      // NOT actually exist. createIfMissing's post-catch findOne must find nothing and re-throw,
+      // not return undefined as if the row were there.
+      const spy = vi.spyOn(groupRepository, 'create').mockImplementationOnce(async () => {
+        const err = new Error('E11000 duplicate key error simulated') as Error & { code: number };
+        err.code = 11000;
+        throw err;
+      });
+
+      await expect(
+        groupRepository.createIfMissing({
+          name: 'Research',
+          description: 'd',
+          type: 'research',
+          organizationId: 'org-race-4',
+        })
+      ).rejects.toThrow(/E11000/);
+
+      spy.mockRestore();
+    });
   });
 });

--- a/packages/database/src/models/social/GroupModel.ts
+++ b/packages/database/src/models/social/GroupModel.ts
@@ -77,10 +77,20 @@ export class GroupRepository extends BaseRepository<IGroupDocument> implements I
    * success (org-groups #1222). The caller (setOrganizationGroupTypes) checks "does a live
    * instance exist" and calls this only when it does not - but two overlapping grant PUTs can
    * both pass that check before either writes, so the second `create` collides with the
-   * `group_org_type_live` unique index. E11000 is not a TransientTransactionError (withTransaction
-   * will not retry it) and carries no HTTP status (errorHandler falls through to a 500 that pages
-   * on-call), so the fix lives HERE at the repo boundary rather than teaching the service about
-   * Mongo error codes: catch the collision and hand back the row the other request created.
+   * `group_org_type_live` unique index. E11000 carries no HTTP status (errorHandler falls through
+   * to a 500 that pages on-call), so the fix lives HERE at the repo boundary rather than teaching
+   * the service about Mongo error codes.
+   *
+   * The recovery differs by caller, and the transactional case is the non-obvious one:
+   * - Outside a transaction, the read below returns the winner's row and we hand it back.
+   * - Inside one (the group-types route, the only production caller today), E11000 has ALREADY
+   *   aborted the transaction server-side, so the read cannot run on that session: it throws
+   *   NoSuchTransaction (251) instead. Unlike E11000, 251 IS labeled TransientTransactionError, so
+   *   withTransaction retries the whole callback and the retry's "does a live instance exist"
+   *   precheck sees the committed winner and skips the create. The read never returns a row on
+   *   this path - it converts an unretryable error into a retryable one. Do not "simplify" it to a
+   *   bare rethrow: that reinstates the 500. Covered only by non-transactional tests, since the
+   *   suite's mongodb-memory-server is a standalone (no transactions).
    */
   async createIfMissing(data: Pick<IGroupDocument, 'name' | 'description' | 'type' | 'organizationId'>) {
     try {

--- a/packages/database/src/models/social/GroupModel.ts
+++ b/packages/database/src/models/social/GroupModel.ts
@@ -71,6 +71,32 @@ export class GroupRepository extends BaseRepository<IGroupDocument> implements I
     if (groupIds.length === 0) return;
     await this.model.updateMany({ _id: { $in: groupIds }, deletedAt: null }, { $set: { deletedAt: new Date() } });
   }
+
+  /**
+   * Provision a group, treating a concurrent create for the same (organizationId, type) as
+   * success (org-groups #1222). The caller (setOrganizationGroupTypes) checks "does a live
+   * instance exist" and calls this only when it does not - but two overlapping grant PUTs can
+   * both pass that check before either writes, so the second `create` collides with the
+   * `group_org_type_live` unique index. E11000 is not a TransientTransactionError (withTransaction
+   * will not retry it) and carries no HTTP status (errorHandler falls through to a 500 that pages
+   * on-call), so the fix lives HERE at the repo boundary rather than teaching the service about
+   * Mongo error codes: catch the collision and hand back the row the other request created.
+   */
+  async createIfMissing(data: Pick<IGroupDocument, 'name' | 'description' | 'type' | 'organizationId'>) {
+    try {
+      return await this.create(data);
+    } catch (error) {
+      if ((error as { code?: number })?.code !== 11000) throw error;
+
+      // Lost the race - the winner's row must exist (that's what E11000 means). If it somehow
+      // doesn't (e.g. a concurrent revoke soft-deleted it in the instant between our create
+      // attempt and this read), surface that as the original duplicate-key error rather than a
+      // confusing "group not found" - the caller is expecting a group back, not a null.
+      const existing = await this.findOne({ organizationId: data.organizationId, type: data.type, deletedAt: null });
+      if (existing) return existing;
+      throw error;
+    }
+  }
 }
 
 export const groupRepository = new GroupRepository(Group);


### PR DESCRIPTION
## Description

Closes the last two rows of the org-groups lifecycle table (design doc `b4m-org-groups-design.md`, see `~/Dev/planning/bike4mind/`) plus one provisioning race, all surfaced while reviewing #1216.

Closes #1224
Closes #1219
Closes #1222

## Changes

**#1224 - group invite acceptance bypassed the write-path invariant.** `sharingService.acceptInvite`'s `InviteType.Group` case had no check at all - it pushed the group id onto `user.groups` regardless of whether the accepting user belonged to the group's organization. Since `user.groups` gates CASL sharing, both data-lake paths, and KB retrieve/search, this let anyone holding (or guessing) an invite id inherit whatever the group conferred. Now resolves the group's owning org and enforces the same invariant `organizationService/groupMembership.ts` enforces on every other group-membership write. Also dedupes (a double-accept no longer duplicates the id).

**#1219 - org deletion did not purge group memberships.** `deleteOrganization` had no reference to groups or users at all, so a deleted org's groups stayed live and every member kept the group ids in `user.groups` - continuing to satisfy the sharing layer's match against a group whose organization no longer exists. Purges membership *before* soft-deleting the groups (the unsafe order leaves a window where a soft-deleted group's id is still live in `user.groups`), mirroring the order `setOrganizationGroupTypes` already uses on revoke. The route is now wrapped in `withTransaction`.

**#1222 - concurrent group-type grant PUTs could 500.** Two overlapping platform-admin grant PUTs could both pass the "does a live instance exist" check and both attempt to create the same `(org, type)` group; the loser's E11000 isn't a `TransientTransactionError` (no retry) and carries no HTTP status (falls through to a 500 that pages on-call). Added `GroupRepository.createIfMissing`, which catches the collision at the repo boundary and returns the winning row - the service layer stays unaware of Mongo error codes.

**Incidental**, while in these files: `findUserIdsByGroupIds` now uses `$addToSet` instead of `$push`, so a duplicate entry in `user.groups` (the exact shape #1224 could previously produce) can't double-count a member. Also corrected a stale comment in `purgeOrgMembership.ts`.

## Test plan

- [x] Unit tests for all three fixes (`accept.test.ts`, `delete.test.ts`, `setOrganizationGroupTypes.test.ts`), each new assertion verified by mutation (revert the fix, confirm the intended test fails, restore).
- [x] Real end-to-end test against Mongo for the #1224 fix (`acceptGroupInvite.e2e.test.ts`), matching the precedent set by the sibling `groupInviteAuth.e2e.test.ts`.
- [x] Real integration test against Mongo for the #1222 fix (`GroupModel.integration.test.ts`), including a genuine E11000 reproduced live.
- [x] New route test for the DELETE route wiring (`organizations/[id]/__tests__/delete.test.ts`).
- [x] `pnpm turbo:core:build`, typecheck (`services`, `database`, `common`, `client` all clean), and `pnpm lint:check` all pass.
- [x] Full affected suites green: 150 tests (`organizationService` + `sharingService`), 69 (`database` social/auth), 48 (`client` routes + e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)