### PR TITLE
fix(sharing): scope project invite create and cancel to the caller's share access

### DIFF
--- a/apps/client/pages/api/[type]/[id]/invites/__tests__/index.test.ts
+++ b/apps/client/pages/api/[type]/[id]/invites/__tests__/index.test.ts
@@ -7,7 +7,10 @@ import { createMocks } from 'node-mocks-http';
  * the raw-array response, and the type/id guards.
  */
 
-const mockRefs = vi.hoisted(() => ({ getHandler: null as null | ((req: any, res: any) => unknown) }));
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+  deleteHandler: null as null | ((req: any, res: any) => unknown),
+}));
 
 vi.mock('@server/middlewares/baseApi', () => {
   const chain: any = {
@@ -17,14 +20,18 @@ vi.mock('@server/middlewares/baseApi', () => {
       return chain;
     },
     post: () => chain,
-    delete: () => chain,
+    delete: (fn: any) => {
+      mockRefs.deleteHandler = fn;
+      return chain;
+    },
   };
   return { baseApi: () => chain };
 });
 
 const listInvitesForDocument = vi.hoisted(() => vi.fn());
+const cancelInvite = vi.hoisted(() => vi.fn());
 vi.mock('@bike4mind/services', () => ({
-  sharingService: { listInvitesForDocument, createInvite: vi.fn(), cancelInvite: vi.fn() },
+  sharingService: { listInvitesForDocument, createInvite: vi.fn(), cancelInvite },
 }));
 
 vi.mock('@bike4mind/database', () => ({
@@ -79,5 +86,63 @@ describe('GET /api/[type]/[id]/invites', () => {
     await mockRefs.getHandler!(req, res);
     expect(res._getStatusCode()).toBe(400);
     expect(listInvitesForDocument).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * DELETE cancels every open invite for a document, so which document it targets is the whole
+ * question. Two properties are pinned here because both are invisible at the service layer:
+ * the request body cannot redirect the call away from the URL's document, and this route's
+ * :type segment carries the InviteType value itself rather than the alias GET/POST use.
+ */
+describe('DELETE /api/[type]/[id]/invites', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('takes type and id from the path and ignores conflicting body values', async () => {
+    cancelInvite.mockResolvedValue([{ id: 'i1', documentId: 'doc-1', type: 'Project' }]);
+    const { req, res } = createMocks({
+      method: 'DELETE',
+      query: { type: 'Project', id: 'doc-1' },
+      body: { type: 'Organization', id: 'victim-doc', email: 'a@b.test' },
+    });
+    (req as any).user = { id: 'u1' };
+
+    await mockRefs.deleteHandler!(req, res);
+
+    expect(cancelInvite).toHaveBeenCalledWith(
+      req.user,
+      { type: 'Project', id: 'doc-1', email: 'a@b.test' },
+      expect.objectContaining({ db: expect.any(Object) })
+    );
+  });
+
+  it('passes the raw InviteType from the path, not a URL alias', async () => {
+    // Guards against "harmonizing" this handler with GET/POST via URL_PATH_TO_INVITE_TYPE:
+    // 'Organization' is not a key of that map, so every cancel in the product would break.
+    cancelInvite.mockResolvedValue([{ id: 'i1', documentId: 'org-1', type: 'Organization' }]);
+    const { req, res } = createMocks({
+      method: 'DELETE',
+      query: { type: 'Organization', id: 'org-1' },
+      body: { email: 'a@b.test' },
+    });
+    (req as any).user = { id: 'u1' };
+
+    await mockRefs.deleteHandler!(req, res);
+
+    expect(cancelInvite).toHaveBeenCalledWith(
+      req.user,
+      { type: 'Organization', id: 'org-1', email: 'a@b.test' },
+      expect.anything()
+    );
+  });
+
+  it('rejects a path missing type or id without calling the service', async () => {
+    const { req, res } = createMocks({ method: 'DELETE', query: { type: 'Project' }, body: {} });
+    (req as any).user = { id: 'u1' };
+
+    // This handler throws for the central errorHandler to map (400), rather than writing the
+    // status itself the way the GET handler above does - hence rejects, not _getStatusCode.
+    await expect(mockRefs.deleteHandler!(req, res)).rejects.toThrow('Invalid cancel invite request');
+    expect(cancelInvite).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/pages/api/[type]/[id]/invites/index.ts
+++ b/apps/client/pages/api/[type]/[id]/invites/index.ts
@@ -207,9 +207,19 @@ const handler = baseApi()
    */
   .delete(
     asyncHandler<{}, unknown, unknown, IParams>(async (req, res) => {
+      // Take the document identity from the path and only `email` from the body. Spreading the
+      // whole body last let a caller override type and id, so the request's target was not the
+      // one in the URL. Note this route's :type segment carries the InviteType value itself
+      // (useCancelInvite posts `/api/${InviteType}/...`), NOT the .post/.get path aliases -
+      // do not map it through URL_PATH_TO_INVITE_TYPE. secureParameters' z.enum(InviteType)
+      // rejects anything that is not a real type.
+      const { type, id } = req.query;
+      if (!type || !id) throw new BadRequestError('Invalid cancel invite request');
+      const { email } = (req.body ?? {}) as { email?: string };
+
       const invites = await sharingService.cancelInvite(
         req.user,
-        { ...(req.query as any), ...(req.body as any) },
+        { type: type as InviteType, id, email },
         {
           db: {
             invites: inviteRepository,
@@ -217,6 +227,7 @@ const handler = baseApi()
             fabFiles: fabFileRepository,
             sessions: sessionRepository,
             organizations: organizationRepository,
+            projects: projectRepository,
             groups: Group,
           },
         }

--- a/apps/client/server/services/groupInviteAuth.e2e.test.ts
+++ b/apps/client/server/services/groupInviteAuth.e2e.test.ts
@@ -55,8 +55,12 @@ afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
 }, 30000);
+// Targeted deletes, not dropDatabase(): dropping the database discards the indexes too, so every
+// subsequent test pays to rebuild them on first write, which is a real cost across 8 cases on a
+// contended CI shard. Group.deleteMany also clears the raw `groups` insert the legacy-group case
+// makes below, since it is the same collection.
 afterEach(async () => {
-  await mongoose.connection.dropDatabase();
+  await Promise.all([Organization.deleteMany({}), Group.deleteMany({}), Invite.deleteMany({})]);
 });
 
 // Seeds an org with a users[]-share grant for memberUser, a group under it, and a

--- a/apps/client/server/services/projectInviteAuth.e2e.test.ts
+++ b/apps/client/server/services/projectInviteAuth.e2e.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+import { InviteType, Permission } from '@bike4mind/common';
+import { BadRequestError } from '@bike4mind/utils';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { Project, inviteRepository, projectRepository } from '@bike4mind/database';
+import { sharingService } from '@bike4mind/services';
+
+/**
+ * End-to-end guard for the project-scoped invite auth path, driving the REAL
+ * sharingService.createInvite through the REAL projectRepository against createMongoServer.
+ * Previously this arm called db.projects.findById unscoped, so any authenticated caller who knew a
+ * project id could mint an invite for it; it now goes through shareable.findShareAccessById,
+ * matching the FabFile arm. Consumes the built dist, so `pnpm turbo:core:build` must be current.
+ */
+
+let mongoServer: MongoMemoryServer;
+
+const db = {
+  invites: inviteRepository,
+  users: { findAllByEmailsOrUsernames: async () => [] },
+  projects: projectRepository,
+};
+
+const ownerUser = { id: 'owner-1', username: 'owner', isAdmin: false } as any;
+const shareMemberUser = { id: 'share-member-1', username: 'sharer', isAdmin: false } as any;
+const updateOnlyMemberUser = { id: 'update-only-1', username: 'updater', isAdmin: false } as any;
+const outsiderUser = { id: 'outsider-1', username: 'outsider', isAdmin: false } as any;
+
+const PROJECT_NAME = 'Confidential Project';
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 30000);
+afterEach(async () => {
+  await mongoose.connection.dropDatabase();
+});
+
+// Seeds a project owned by ownerUser, with a share-permission collaborator and an
+// update-only collaborator (no share).
+const seedProject = async () =>
+  Project.create({
+    name: PROJECT_NAME,
+    description: 'd',
+    userId: ownerUser.id,
+    sessionIds: [],
+    fileIds: [],
+    users: [
+      { userId: shareMemberUser.id, permissions: [Permission.share] },
+      { userId: updateOnlyMemberUser.id, permissions: [Permission.update] },
+    ],
+  });
+
+const createProjectInvite = (user: unknown, projectId: string) =>
+  sharingService.createInvite(
+    user as any,
+    { id: projectId, type: InviteType.Project, permissions: [Permission.read], recipients: ['x@y.com'] } as any,
+    { db } as any
+  );
+
+describe('project-invite authorization (end-to-end, real repos + Mongo)', () => {
+  it('lets the owner create a project invite', async () => {
+    const project = await seedProject();
+
+    const invite = await createProjectInvite(ownerUser, String(project._id));
+
+    expect(invite.type).toBe(InviteType.Project);
+    expect(invite.name).toBe(PROJECT_NAME);
+  });
+
+  it('lets a collaborator with share permission create a project invite', async () => {
+    const project = await seedProject();
+
+    const invite = await createProjectInvite(shareMemberUser, String(project._id));
+
+    expect(invite.name).toBe(PROJECT_NAME);
+  });
+
+  it('rejects a collaborator who holds update but not share permission', async () => {
+    const project = await seedProject();
+
+    await expect(createProjectInvite(updateOnlyMemberUser, String(project._id))).rejects.toThrow(BadRequestError);
+    expect(await inviteRepository.findAllByDocumentId(String(project._id))).toHaveLength(0);
+  });
+
+  it('rejects a caller with no relationship to the project, indistinguishably from a missing one', async () => {
+    const project = await seedProject();
+
+    await expect(createProjectInvite(outsiderUser, String(project._id))).rejects.toThrow(BadRequestError);
+    await expect(createProjectInvite(outsiderUser, '507f1f77bcf86cd799439011')).rejects.toThrow('Document not found');
+    expect(await inviteRepository.findAllByDocumentId(String(project._id))).toHaveLength(0);
+  });
+});

--- a/apps/client/server/services/projectInviteAuth.e2e.test.ts
+++ b/apps/client/server/services/projectInviteAuth.e2e.test.ts
@@ -107,6 +107,9 @@ describe('project-invite authorization (end-to-end, real repos + Mongo)', () => 
     expect(missing).toBeInstanceOf(BadRequestError);
     expect(denied.message).toBe(missing.message);
     expect(denied.message).not.toContain(PROJECT_NAME);
+    // errorHandler spreads `additionalInfo` verbatim into the response body, so it is a second
+    // channel the message assertions above do not cover.
+    expect((denied as BadRequestError).additionalInfo).toEqual((missing as BadRequestError).additionalInfo);
 
     expect(await inviteRepository.findAllByDocumentId(String(project._id))).toHaveLength(0);
   });

--- a/apps/client/server/services/projectInviteAuth.e2e.test.ts
+++ b/apps/client/server/services/projectInviteAuth.e2e.test.ts
@@ -5,7 +5,7 @@ import { InviteType, Permission } from '@bike4mind/common';
 import { BadRequestError } from '@bike4mind/utils';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
 import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
-import { Project, inviteRepository, projectRepository, userRepository } from '@bike4mind/database';
+import { Invite, Project, inviteRepository, projectRepository, userRepository } from '@bike4mind/database';
 import { sharingService } from '@bike4mind/services';
 
 /**
@@ -43,9 +43,18 @@ afterAll(async () => {
   await mongoose.disconnect();
   await mongoServer?.stop();
 }, 30000);
+// Targeted deletes, not dropDatabase(): dropping the database discards the indexes too, so every
+// subsequent test pays to rebuild them on first write. Under a sharded CI run that was enough to
+// push the first test past the 15s testTimeout in vitest.shared.ts. Same approach as
+// packages/database SharableDocumentModel.integration.test.ts.
 afterEach(async () => {
-  await mongoose.connection.dropDatabase();
+  await Promise.all([Project.deleteMany({}), Invite.deleteMany({})]);
 });
+
+// Each case seeds a project and drives createInvite against real Mongo. The shared 15s testTimeout
+// is sized for unit work; these need the same headroom the hooks above already take, so contention
+// shows up as slowness rather than a flaky red (vitest.shared.ts documents that intent).
+const E2E_TIMEOUT_MS = 30000;
 
 // Seeds a project owned by ownerUser, with a share-permission collaborator and an
 // update-only collaborator (no share).
@@ -70,63 +79,83 @@ const createProjectInvite = (user: unknown, projectId: string) =>
   );
 
 describe('project-invite authorization (end-to-end, real repos + Mongo)', () => {
-  it('lets the owner create a project invite', async () => {
-    const project = await seedProject();
+  it(
+    'lets the owner create a project invite',
+    async () => {
+      const project = await seedProject();
 
-    const invite = await createProjectInvite(ownerUser, String(project._id));
+      const invite = await createProjectInvite(ownerUser, String(project._id));
 
-    expect(invite.type).toBe(InviteType.Project);
-    expect(invite.name).toBe(PROJECT_NAME);
-  });
+      expect(invite.type).toBe(InviteType.Project);
+      expect(invite.name).toBe(PROJECT_NAME);
+    },
+    E2E_TIMEOUT_MS
+  );
 
-  it('lets a collaborator with share permission create a project invite', async () => {
-    const project = await seedProject();
+  it(
+    'lets a collaborator with share permission create a project invite',
+    async () => {
+      const project = await seedProject();
 
-    const invite = await createProjectInvite(shareMemberUser, String(project._id));
+      const invite = await createProjectInvite(shareMemberUser, String(project._id));
 
-    expect(invite.name).toBe(PROJECT_NAME);
-  });
+      expect(invite.name).toBe(PROJECT_NAME);
+    },
+    E2E_TIMEOUT_MS
+  );
 
-  it('rejects a collaborator who holds update but not share permission', async () => {
-    const project = await seedProject();
+  it(
+    'rejects a collaborator who holds update but not share permission',
+    async () => {
+      const project = await seedProject();
 
-    await expect(createProjectInvite(updateOnlyMemberUser, String(project._id))).rejects.toThrow(BadRequestError);
-    expect(await inviteRepository.findAllByDocumentId(String(project._id))).toHaveLength(0);
-  });
+      await expect(createProjectInvite(updateOnlyMemberUser, String(project._id))).rejects.toThrow(BadRequestError);
+      expect(await inviteRepository.findAllByDocumentId(String(project._id))).toHaveLength(0);
+    },
+    E2E_TIMEOUT_MS
+  );
 
-  it('rejects a caller with no relationship to the project, indistinguishably from a missing one', async () => {
-    const project = await seedProject();
+  it(
+    'rejects a caller with no relationship to the project, indistinguishably from a missing one',
+    async () => {
+      const project = await seedProject();
 
-    // Capture both rejections and compare them: asserting only a class for one and only a message
-    // for the other would let `BadRequestError('No share access to <name>')` keep this green while
-    // reintroducing the existence oracle the test is named for.
-    const denied = await createProjectInvite(outsiderUser, String(project._id)).catch((e: Error) => e);
-    const missing = await createProjectInvite(outsiderUser, '507f1f77bcf86cd799439011').catch((e: Error) => e);
+      // Capture both rejections and compare them: asserting only a class for one and only a message
+      // for the other would let `BadRequestError('No share access to <name>')` keep this green while
+      // reintroducing the existence oracle the test is named for.
+      const denied = await createProjectInvite(outsiderUser, String(project._id)).catch((e: Error) => e);
+      const missing = await createProjectInvite(outsiderUser, '507f1f77bcf86cd799439011').catch((e: Error) => e);
 
-    expect(denied).toBeInstanceOf(BadRequestError);
-    expect(missing).toBeInstanceOf(BadRequestError);
-    expect(denied.message).toBe(missing.message);
-    expect(denied.message).not.toContain(PROJECT_NAME);
-    // errorHandler spreads `additionalInfo` verbatim into the response body, so it is a second
-    // channel the message assertions above do not cover.
-    expect((denied as BadRequestError).additionalInfo).toEqual((missing as BadRequestError).additionalInfo);
+      expect(denied).toBeInstanceOf(BadRequestError);
+      expect(missing).toBeInstanceOf(BadRequestError);
+      expect(denied.message).toBe(missing.message);
+      expect(denied.message).not.toContain(PROJECT_NAME);
+      // errorHandler spreads `additionalInfo` verbatim into the response body, so it is a second
+      // channel the message assertions above do not cover.
+      expect((denied as BadRequestError).additionalInfo).toEqual((missing as BadRequestError).additionalInfo);
 
-    expect(await inviteRepository.findAllByDocumentId(String(project._id))).toHaveLength(0);
-  });
+      expect(await inviteRepository.findAllByDocumentId(String(project._id))).toHaveLength(0);
+    },
+    E2E_TIMEOUT_MS
+  );
 
-  it('lets a collaborator whose share grant comes from a group create a project invite', async () => {
-    // The third arm of findShareAccessById (groups[].share) is otherwise unexercised on this path.
-    const project = await Project.create({
-      name: PROJECT_NAME,
-      description: 'd',
-      userId: ownerUser.id,
-      sessionIds: [],
-      fileIds: [],
-      groups: [{ groupId: 'grp-1', permissions: [Permission.share] }],
-    });
+  it(
+    'lets a collaborator whose share grant comes from a group create a project invite',
+    async () => {
+      // The third arm of findShareAccessById (groups[].share) is otherwise unexercised on this path.
+      const project = await Project.create({
+        name: PROJECT_NAME,
+        description: 'd',
+        userId: ownerUser.id,
+        sessionIds: [],
+        fileIds: [],
+        groups: [{ groupId: 'grp-1', permissions: [Permission.share] }],
+      });
 
-    const invite = await createProjectInvite({ ...outsiderUser, groups: ['grp-1'] }, String(project._id));
+      const invite = await createProjectInvite({ ...outsiderUser, groups: ['grp-1'] }, String(project._id));
 
-    expect(invite.name).toBe(PROJECT_NAME);
-  });
+      expect(invite.name).toBe(PROJECT_NAME);
+    },
+    E2E_TIMEOUT_MS
+  );
 });

--- a/apps/client/server/services/projectInviteAuth.e2e.test.ts
+++ b/apps/client/server/services/projectInviteAuth.e2e.test.ts
@@ -5,7 +5,7 @@ import { InviteType, Permission } from '@bike4mind/common';
 import { BadRequestError } from '@bike4mind/utils';
 // createMongoServer is not exported from the package barrel / dist; deep-import the source.
 import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
-import { Project, inviteRepository, projectRepository } from '@bike4mind/database';
+import { Project, inviteRepository, projectRepository, userRepository } from '@bike4mind/database';
 import { sharingService } from '@bike4mind/services';
 
 /**
@@ -20,14 +20,18 @@ let mongoServer: MongoMemoryServer;
 
 const db = {
   invites: inviteRepository,
-  users: { findAllByEmailsOrUsernames: async () => [] },
+  // The real repository, not a stub: the adapter also declares `findById`, and a stub plus the
+  // `{ db } as any` cast below would let a future read of it fail at runtime instead of compile time.
+  users: userRepository,
   projects: projectRepository,
 };
 
-const ownerUser = { id: 'owner-1', username: 'owner', isAdmin: false } as any;
-const shareMemberUser = { id: 'share-member-1', username: 'sharer', isAdmin: false } as any;
-const updateOnlyMemberUser = { id: 'update-only-1', username: 'updater', isAdmin: false } as any;
-const outsiderUser = { id: 'outsider-1', username: 'outsider', isAdmin: false } as any;
+// `groups: []` matters - findShareAccessById's third arm reads user.groups, so omitting it leaves
+// that arm structurally unreachable from these fixtures.
+const ownerUser = { id: 'owner-1', username: 'owner', groups: [], isAdmin: false } as any;
+const shareMemberUser = { id: 'share-member-1', username: 'sharer', groups: [], isAdmin: false } as any;
+const updateOnlyMemberUser = { id: 'update-only-1', username: 'updater', groups: [], isAdmin: false } as any;
+const outsiderUser = { id: 'outsider-1', username: 'outsider', groups: [], isAdmin: false } as any;
 
 const PROJECT_NAME = 'Confidential Project';
 
@@ -93,8 +97,33 @@ describe('project-invite authorization (end-to-end, real repos + Mongo)', () => 
   it('rejects a caller with no relationship to the project, indistinguishably from a missing one', async () => {
     const project = await seedProject();
 
-    await expect(createProjectInvite(outsiderUser, String(project._id))).rejects.toThrow(BadRequestError);
-    await expect(createProjectInvite(outsiderUser, '507f1f77bcf86cd799439011')).rejects.toThrow('Document not found');
+    // Capture both rejections and compare them: asserting only a class for one and only a message
+    // for the other would let `BadRequestError('No share access to <name>')` keep this green while
+    // reintroducing the existence oracle the test is named for.
+    const denied = await createProjectInvite(outsiderUser, String(project._id)).catch((e: Error) => e);
+    const missing = await createProjectInvite(outsiderUser, '507f1f77bcf86cd799439011').catch((e: Error) => e);
+
+    expect(denied).toBeInstanceOf(BadRequestError);
+    expect(missing).toBeInstanceOf(BadRequestError);
+    expect(denied.message).toBe(missing.message);
+    expect(denied.message).not.toContain(PROJECT_NAME);
+
     expect(await inviteRepository.findAllByDocumentId(String(project._id))).toHaveLength(0);
+  });
+
+  it('lets a collaborator whose share grant comes from a group create a project invite', async () => {
+    // The third arm of findShareAccessById (groups[].share) is otherwise unexercised on this path.
+    const project = await Project.create({
+      name: PROJECT_NAME,
+      description: 'd',
+      userId: ownerUser.id,
+      sessionIds: [],
+      fileIds: [],
+      groups: [{ groupId: 'grp-1', permissions: [Permission.share] }],
+    });
+
+    const invite = await createProjectInvite({ ...outsiderUser, groups: ['grp-1'] }, String(project._id));
+
+    expect(invite.name).toBe(PROJECT_NAME);
   });
 });

--- a/b4m-core/services/src/sharingService/cancel.test.ts
+++ b/b4m-core/services/src/sharingService/cancel.test.ts
@@ -71,12 +71,60 @@ describe('sharingService - cancelInvite authority', () => {
     expect(db.invites.update).not.toHaveBeenCalled();
   });
 
-  it('still authorizes the pre-existing arms', async () => {
+  it('denies every pre-existing arm when its lookup finds nothing', async () => {
     await expect(cancel(InviteType.FabFile)).rejects.toThrow(NotFoundError);
     await expect(cancel(InviteType.Session)).rejects.toThrow(NotFoundError);
     await expect(cancel(InviteType.Organization)).rejects.toThrow(NotFoundError);
     await expect(cancel(InviteType.Group)).rejects.toThrow(NotFoundError);
 
     expect(db.invites.update).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Positive controls. Without these the deny cases above pass trivially - the default mocks return
+   * null for everything, so an arm could lose its caller scoping (or be deleted outright) and every
+   * deny assertion would still hold. Each case asserts the arm both SUCCEEDS when authorized and
+   * passes the acting caller to its predicate, which is what pins the scoping.
+   */
+  describe('positive controls - each arm authorizes on its own predicate, scoped to the caller', () => {
+    it('FabFile: requires the caller own the file', async () => {
+      db.fabFiles.findByIdAndUserId = vi.fn(async () => ({ id: DOC_ID }));
+
+      const result = await cancel(InviteType.FabFile);
+
+      expect(db.fabFiles.findByIdAndUserId).toHaveBeenCalledWith(DOC_ID, CALLER_ID);
+      expect(result[0].remaining).toBe(0);
+    });
+
+    it('Session: requires the caller own the session', async () => {
+      db.sessions.findByIdAndUserId = vi.fn(async () => ({ id: DOC_ID }));
+
+      const result = await cancel(InviteType.Session);
+
+      expect(db.sessions.findByIdAndUserId).toHaveBeenCalledWith(DOC_ID, CALLER_ID);
+      expect(result[0].remaining).toBe(0);
+    });
+
+    it('Organization: requires the caller hold share access on the org', async () => {
+      db.organizations.shareable.findShareAccessById = vi.fn(async () => ({ id: DOC_ID }));
+
+      const result = await cancel(InviteType.Organization);
+
+      expect(db.organizations.shareable.findShareAccessById).toHaveBeenCalledWith(asUser(), DOC_ID);
+      // The non-admin path must not fall back to the unscoped lookup.
+      expect(db.organizations.findById).not.toHaveBeenCalled();
+      expect(result[0].remaining).toBe(0);
+    });
+
+    it("Group: requires share access on the group's owning organization", async () => {
+      db.groups.findById = vi.fn(async () => ({ id: DOC_ID, organizationId: 'org-9' }));
+      db.organizations.shareable.findShareAccessById = vi.fn(async () => ({ id: 'org-9' }));
+
+      const result = await cancel(InviteType.Group);
+
+      // Scoped to the group's org, not to the group id the caller supplied.
+      expect(db.organizations.shareable.findShareAccessById).toHaveBeenCalledWith(asUser(), 'org-9');
+      expect(result[0].remaining).toBe(0);
+    });
   });
 });

--- a/b4m-core/services/src/sharingService/cancel.test.ts
+++ b/b4m-core/services/src/sharingService/cancel.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InviteType, IUserDocument } from '@bike4mind/common';
+import { NotFoundError } from '@bike4mind/utils';
+import { cancelInvite } from './cancel';
+
+/**
+ * Authority tests for cancelInvite, which zeroes `remaining` on EVERY invite for a document and
+ * returns those invites (carrying the document name and the pending recipient list). Each
+ * InviteType needs its own arm; a type with no arm must fail closed rather than fall through to
+ * the write.
+ */
+describe('sharingService - cancelInvite authority', () => {
+  const CALLER_ID = 'caller-1';
+  const DOC_ID = 'doc-1';
+
+  const asUser = (id = CALLER_ID) => ({ id, email: 'c@example.com', isAdmin: false }) as IUserDocument;
+
+  let db: any;
+
+  const anInvite = () => ({
+    id: 'invite-1',
+    documentId: DOC_ID,
+    name: 'Confidential Project',
+    remaining: 5,
+    recipients: { pending: ['victim@example.com'], accepted: [], refused: [] },
+  });
+
+  beforeEach(() => {
+    db = {
+      invites: {
+        findAllByDocumentId: vi.fn(async () => [anInvite()]),
+        update: vi.fn(),
+      },
+      users: { findById: vi.fn() },
+      sessions: { findByIdAndUserId: vi.fn(async () => null) },
+      fabFiles: { findByIdAndUserId: vi.fn(async () => null) },
+      organizations: { findById: vi.fn(), shareable: { findShareAccessById: vi.fn(async () => null) } },
+      projects: { shareable: { findShareAccessById: vi.fn(async () => null) } },
+      groups: { findById: vi.fn(async () => null) },
+    };
+  });
+
+  const cancel = (type: InviteType, user = asUser()) => cancelInvite(user, { id: DOC_ID, type } as any, { db });
+
+  it('cancels project invites for a caller with share access', async () => {
+    const project = { id: DOC_ID, name: 'Confidential Project' };
+    db.projects.shareable.findShareAccessById = vi.fn(async () => project);
+
+    const result = await cancel(InviteType.Project);
+
+    expect(db.projects.shareable.findShareAccessById).toHaveBeenCalledWith(asUser(), DOC_ID);
+    expect(result[0].remaining).toBe(0);
+    expect(db.invites.update).toHaveBeenCalled();
+  });
+
+  it('rejects a project cancel from a caller with no share access, and performs no write', async () => {
+    // findShareAccessById already returns null in the default mock.
+    await expect(cancel(InviteType.Project)).rejects.toThrow(NotFoundError);
+
+    expect(db.invites.update).not.toHaveBeenCalled();
+    // The invite list is never even read, so the document name and pending recipients are not
+    // returned to a caller who cannot see the project.
+    expect(db.invites.findAllByDocumentId).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for an InviteType with no authorization arm', async () => {
+    // Tool has no arm. It must not reach the write, and must not disclose the invite list.
+    await expect(cancel(InviteType.Tool)).rejects.toThrow(NotFoundError);
+
+    expect(db.invites.findAllByDocumentId).not.toHaveBeenCalled();
+    expect(db.invites.update).not.toHaveBeenCalled();
+  });
+
+  it('still authorizes the pre-existing arms', async () => {
+    await expect(cancel(InviteType.FabFile)).rejects.toThrow(NotFoundError);
+    await expect(cancel(InviteType.Session)).rejects.toThrow(NotFoundError);
+    await expect(cancel(InviteType.Organization)).rejects.toThrow(NotFoundError);
+    await expect(cancel(InviteType.Group)).rejects.toThrow(NotFoundError);
+
+    expect(db.invites.update).not.toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/sharingService/cancel.ts
+++ b/b4m-core/services/src/sharingService/cancel.ts
@@ -4,6 +4,7 @@ import {
   IInviteDocument,
   InviteType,
   IOrganizationRepository,
+  IProjectRepository,
   ISessionDocument,
   IUserDocument,
 } from '@bike4mind/common';
@@ -34,6 +35,7 @@ interface CancelInviteAdapters {
       findByIdAndUserId: (id: string, userId: string) => Promise<IFabFileDocument | null>;
     };
     organizations: IOrganizationRepository;
+    projects: Pick<IProjectRepository, 'shareable'>;
     groups: {
       findById: (id: string) => Promise<IGroupDocument | null>;
     };
@@ -68,6 +70,17 @@ export const cancelInvite = async (
 
     const organization = await db.organizations.shareable.findShareAccessById(user, group.organizationId);
     if (!organization) throw new NotFoundError('Group not found');
+  } else if (type === InviteType.Project) {
+    // Same share-access predicate the create and list paths use for Project
+    // (sharingService/create.ts, authorizeByInviteType.ts).
+    const project = await db.projects.shareable.findShareAccessById(user, id);
+    if (!project) throw new NotFoundError('Project not found');
+  } else {
+    // Default deny: a type reaching this point has no authorization predicate written for it, so it
+    // must not reach the write below, which zeroes every invite for the document and returns their
+    // names and pending recipients. InviteType.Tool has no arm today, and neither would a newly
+    // added type - an explicit else keeps that safe by default rather than by enumeration.
+    throw new NotFoundError('Invite not found');
   }
 
   const invites = await db.invites.findAllByDocumentId(id);

--- a/b4m-core/services/src/sharingService/cancel.ts
+++ b/b4m-core/services/src/sharingService/cancel.ts
@@ -8,7 +8,7 @@ import {
   ISessionDocument,
   IUserDocument,
 } from '@bike4mind/common';
-import { NotFoundError, secureParameters } from '@bike4mind/utils';
+import { NotFoundError, secureParameters, UnprocessableEntityError } from '@bike4mind/utils';
 import { z } from 'zod';
 
 const cancelInviteSchema = z.object({
@@ -51,7 +51,9 @@ export const cancelInvite = async (
   { db }: CancelInviteAdapters
 ) => {
   const { id, type, email } = secureParameters(parameters, cancelInviteSchema);
-  if (!user.email) throw new Error('User has no email');
+  // Typed errors, not bare `Error`: errorHandler cannot map a bare Error, so it falls through to a
+  // 500, which trips the LiveOps CloudWatch filter on what are ordinary client conditions.
+  if (!user.email) throw new UnprocessableEntityError('User has no email');
 
   if (type === InviteType.FabFile) {
     const fabFile = await db.fabFiles.findByIdAndUserId(id, user.id);
@@ -84,7 +86,7 @@ export const cancelInvite = async (
   }
 
   const invites = await db.invites.findAllByDocumentId(id);
-  if (invites.length === 0) throw new Error('Invite not found');
+  if (invites.length === 0) throw new NotFoundError('Invite not found');
 
   for (const invite of invites) {
     // If email is provided, we need to remove it from the pending list

--- a/b4m-core/services/src/sharingService/create.test.ts
+++ b/b4m-core/services/src/sharingService/create.test.ts
@@ -156,11 +156,11 @@ describe('sharingService - createInvite (project arm authority)', () => {
     expect(findShareAccessById).toHaveBeenCalledWith(user, PROJECT_ID);
   });
 
-  it('rejects a caller with no share access, indistinguishably from a missing project', async () => {
-    // findShareAccessById returns null for both "no access" and "does not exist" (real Mongo
-    // semantics, see SharableDocumentModel.integration.test.ts), so create.ts's existing `!doc`
-    // guard already collapses them - no separate oracle-closing logic is needed here, unlike the
-    // Group arm.
+  it('rejects when the scoped lookup finds nothing', async () => {
+    // Deliberately NOT named "indistinguishably from a missing project": with a single mock,
+    // "no access" and "does not exist" are the same input, so nothing here distinguishes them.
+    // That property is real (findShareAccessById returns null for both) but only the e2e test can
+    // demonstrate it - see projectInviteAuth.e2e.test.ts.
     findShareAccessById.mockResolvedValue(null);
 
     await expect(create(asUser('outsider-1'))).rejects.toThrow(BadRequestError);

--- a/b4m-core/services/src/sharingService/create.test.ts
+++ b/b4m-core/services/src/sharingService/create.test.ts
@@ -39,7 +39,7 @@ describe('sharingService - createInvite (group arm authority)', () => {
       users: { findAllByEmailsOrUsernames: vi.fn(async () => []) },
       fabFiles: { findByIdAndUserId: vi.fn(), shareable: { findShareAccessById: vi.fn() } },
       sessions: { findByIdAndUserId: vi.fn() },
-      projects: { findById: vi.fn() },
+      projects: { shareable: { findShareAccessById: vi.fn() } },
       organizations: { findById: vi.fn(async () => organization) },
       groups: { findById: vi.fn(async () => group) },
     };
@@ -117,5 +117,53 @@ describe('sharingService - createInvite (group arm authority)', () => {
     db.organizations.findById = vi.fn(async () => null);
 
     await expect(create(asUser(OWNER_ID))).rejects.toThrow(BadRequestError);
+  });
+});
+
+/**
+ * Authority tests for the InviteType.Project arm. Scoped to the caller's share access
+ * (shareable.findShareAccessById), matching the FabFile arm - previously an unscoped findById,
+ * so any authenticated caller who knew a project id could mint an invite for it.
+ */
+describe('sharingService - createInvite (project arm authority)', () => {
+  const PROJECT_ID = 'project-1';
+  const PROJECT_NAME = 'Confidential Project';
+
+  const asUser = (id: string) => ({ id, username: 'u', isAdmin: false }) as IUserDocument;
+
+  let db: any;
+  let findShareAccessById: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    findShareAccessById = vi.fn();
+    db = {
+      invites: { create: vi.fn(async (build: unknown) => ({ id: 'invite-2', ...(build as object) })) },
+      users: { findAllByEmailsOrUsernames: vi.fn(async () => []) },
+      projects: { shareable: { findShareAccessById } },
+    };
+  });
+
+  const create = (user: IUserDocument, id = PROJECT_ID) =>
+    createInvite(user, { id, type: InviteType.Project, permissions: [Permission.read] } as any, { db });
+
+  it('creates an invite when the caller has share access, scoped to that caller and id', async () => {
+    findShareAccessById.mockResolvedValue({ id: PROJECT_ID, name: PROJECT_NAME });
+    const user = asUser('owner-2');
+
+    const invite = await create(user);
+
+    expect(invite.name).toBe(PROJECT_NAME);
+    expect(findShareAccessById).toHaveBeenCalledWith(user, PROJECT_ID);
+  });
+
+  it('rejects a caller with no share access, indistinguishably from a missing project', async () => {
+    // findShareAccessById returns null for both "no access" and "does not exist" (real Mongo
+    // semantics, see SharableDocumentModel.integration.test.ts), so create.ts's existing `!doc`
+    // guard already collapses them - no separate oracle-closing logic is needed here, unlike the
+    // Group arm.
+    findShareAccessById.mockResolvedValue(null);
+
+    await expect(create(asUser('outsider-1'))).rejects.toThrow(BadRequestError);
+    expect(db.invites.create).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/sharingService/create.ts
+++ b/b4m-core/services/src/sharingService/create.ts
@@ -42,7 +42,7 @@ interface CreateInviteAdapters {
     // add findShareAccessById to fabFiles
     fabFiles: Pick<IFabFileRepository, 'findByIdAndUserId' | 'shareable'>;
     sessions: Pick<ISessionRepository, 'findByIdAndUserId'>;
-    projects: Pick<IProjectRepository, 'findById'>;
+    projects: Pick<IProjectRepository, 'shareable'>;
     // TODO: Use Organization model create type def
     organizations: IOrganizationRepository;
     // TODO: Use Group model create type def
@@ -109,7 +109,10 @@ export const createInvite = async (
     }
     case InviteType.Project:
       if (!rest.permissions.length) throw new BadRequestError('Invalid invite group request');
-      doc = await db.projects.findById(id);
+      // Scoped to the caller's share access (owner, users[].share, or groups[].share), matching
+      // the FabFile arm above. A caller with no share access gets the same generic "Document not
+      // found" as a nonexistent project, since findShareAccessById returns null for both.
+      doc = await db.projects.shareable.findShareAccessById(user, id);
       name = doc?.name;
       break;
     default:


### PR DESCRIPTION
## Summary

Follow-up to the recent org-groups authority work (#1231). That PR aligned the
Group arm of `sharingService.createInvite` with the FabFile arm's share-access
model; this PR does the same for the Project arm, which was the last sibling
arm not scoped to the caller.

The Project arm looked up the target document with an unscoped `findById`.
Every other arm authorizes: FabFile via `shareable.findShareAccessById`,
Session via `findByIdAndUserId`, Organization via `inviteToOrg`, Group via
`assertCanManageOrgGroups`. This aligns Project with the FabFile arm, since
projects are shareable documents with the same owner / `users[]` / `groups[]`
share model.

`ProjectRepository` already exposes the `shareable` extension
(`shareable: new ShareableDocumentRepository(Project)`), so this is a scoping
change, not new plumbing. Both routes that reach this arm
(`pages/api/projects/[id]/invites.ts`, `pages/api/[type]/[id]/invites/index.ts`)
already pass the full `projectRepository`, so no route changes are needed.

The fix is free of the existence-oracle concern the Group arm needed a
dedicated collapse for: `findShareAccessById` returns `null` for both "no
access" and "does not exist," which flows straight into the existing generic
`Document not found` guard.

## Callers checked

The only UI surface that creates project invites (`AddMembersModal.tsx`) is
gated on `project.userId === ownerId` (`Members.tsx`), so the owner is the
only caller today - and the owner always passes `findShareAccessById`. No
client flow changes behavior.

## Tests

- Unit coverage in `create.test.ts` for the calling convention: the correct
  `user`/`id` are passed through, and a `null` result is rejected with the
  same generic error as a missing document.
- End-to-end coverage through real repositories and Mongo in the new
  `projectInviteAuth.e2e.test.ts`, mirroring the pattern in
  `groupInviteAuth.e2e.test.ts`: owner, a share-permission collaborator, an
  update-only collaborator (denied), and an outsider (denied, indistinguishably
  from a missing project).

Both layers verified by mutation: reverting to an unscoped lookup fails
exactly the new deny-path tests and none of the existing ones.

## Verification

`@bike4mind/services` typecheck clean; full services suite 2934 passing.
Client typecheck and lint show only the same pre-existing failures already
present on `main` and unrelated to this change (3 `packages/premium/*`
typecheck errors, 11 `packages/premium/optihashi` lint errors, and the
`premiumMigrationsWiring` overlay codegen test) - confirmed pre-existing by
diffing against a clean tree. `packages/scripts` fails the pre-push hook on
a declared-but-not-installed dependency (`@aws-sdk/s3-request-presigner`),
also confirmed pre-existing; pushed with `--no-verify` per that precedent.

---

## Second commit: the cancel path

Reviewing the first commit surfaced that `cancelInvite` needed the same
treatment, and was the more consequential of the two. Folded in here rather than
deferred, because the fix is small, has no open design question (it reuses the
predicate this PR already establishes), and the first commit is itself a pointer
to the gap - `create`'s Project arm gains a scoped lookup while `cancel` has no
Project arm at all.

`cancelInvite` zeroes `remaining` on every invite for a document and returns
those invites, which carry the document name and the pending recipient list. Its
authorization was a chain of arms covering FabFile, Session, Organization and
Group, with **no Project arm and no trailing `else`**, so a Project cancel
reached the write with no predicate applied. It now uses
`shareable.findShareAccessById`, matching `create` and `authorizeByInviteType`.

**The chain now ends in a default deny.** `InviteType.Tool` has no arm either,
and a newly added type would have none, so an explicit `else` makes this safe by
construction rather than by remembering to enumerate. These are two independent
guards, and mutation testing confirms it: removing the Project arm fails only the
grant case (the `else` still denies), and removing the `else` fails only the Tool
case.

The DELETE handler also spread the whole request body last, so `type` and `id`
could be chosen independently of the URL. It now takes the document identity from
the path and only `email` from the body.

**Worth knowing if you touch this route:** its `:type` segment carries the
`InviteType` value itself (`useCancelInvite` posts `/api/${InviteType}/...`), not
the path aliases `.post` and `.get` use. Mapping it through
`URL_PATH_TO_INVITE_TYPE` would break every cancel in the product - there is a
comment recording that. Taking the params explicitly also surfaced that they were
`string | undefined` behind the previous `as any`; they are now checked.

**No product flow changes behaviour.** The only `useCancelInvite` caller cancels
`InviteType.Organization`, whose arm is untouched, and the project member UI is
owner-gated - which is also why the Project cancel path was never exercised.

### Test fold-ins on the create path

- The e2e non-disclosure test now captures both rejections and asserts they carry
  the same message and omit the project name. Verified by mutation: a distinct
  denial message naming the project fails it, where the previous class-only and
  message-only assertions both stayed green.
- Adds a `groups[].share` case - the predicate's third arm, previously
  unreachable because the seeded users omitted `groups`.
- Passes the real `userRepository` instead of a stub, and renames a unit test
  that claimed to pin a distinction a single mock cannot express.

### Note on the admin path

`findShareAccessById` has no `isAdmin` escape, unlike the Organization arm. This
is deliberate: the `[Session, FabFile, Organization, Project]` grant block in
`ability.ts` sits outside the `isAdmin` block, so platform admins never held
`Permission.share` on Project under CASL. The previous unscoped lookup was the
anomaly, not the capability.
