### PR TITLE
feat(organizations): resolve a user's group types within an organization (#1235)

### DIFF
--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -15,6 +15,7 @@ import { revokeAccess } from './revokeAccess';
 import { leave } from './leave';
 import { setOrganizationGroupTypes } from './setOrganizationGroupTypes';
 import { assignUserToGroup, removeUserFromGroup, renameGroup, assertCanManageOrgGroups } from './groupMembership';
+import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
 
 export {
   search,
@@ -38,6 +39,7 @@ export {
   assertCanManageOrgGroups,
   removeUserFromGroup,
   renameGroup,
+  resolveGroupTypesForUser,
 };
 
 export type { SearchParameters };

--- a/b4m-core/services/src/organizationService/resolveGroupTypesForUser.test.ts
+++ b/b4m-core/services/src/organizationService/resolveGroupTypesForUser.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { IGroupDocument, IUserDocument } from '@bike4mind/common';
+import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
+
+const ORG = 'org-1';
+
+// Minimal live-group shape as findByOrganization returns it (plain objects with the `id` virtual).
+const group = (id: string, type: string, organizationId = ORG): IGroupDocument =>
+  ({ id, type, organizationId, name: type, description: '' }) as unknown as IGroupDocument;
+
+const user = (groups: string[] | null): Pick<IUserDocument, 'groups'> => ({ groups });
+
+function makeAdapters(orgGroups: IGroupDocument[]) {
+  const findByOrganization = vi.fn().mockResolvedValue(orgGroups);
+  return { adapters: { db: { groups: { findByOrganization } } }, findByOrganization };
+}
+
+describe('resolveGroupTypesForUser (#1235)', () => {
+  it('returns [] and never queries when the user has no groups', async () => {
+    const { adapters, findByOrganization } = makeAdapters([]);
+    await expect(resolveGroupTypesForUser({ user: user([]), organizationId: ORG }, adapters)).resolves.toEqual([]);
+    await expect(resolveGroupTypesForUser({ user: user(null), organizationId: ORG }, adapters)).resolves.toEqual([]);
+    expect(findByOrganization).not.toHaveBeenCalled();
+  });
+
+  it("maps the user's group ids to the catalog type keys of the org's live groups", async () => {
+    const { adapters } = makeAdapters([group('g-sales', 'sales'), group('g-research', 'research')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-sales', 'g-research']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['sales', 'research']);
+  });
+
+  it('sorts by catalog priority (lower first), not membership order', async () => {
+    // customer=30, sales=10 -> sales must come first regardless of the order held.
+    const { adapters } = makeAdapters([group('g-customer', 'customer'), group('g-sales', 'sales')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-customer', 'g-sales']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['sales', 'customer']);
+  });
+
+  it('excludes group ids the user holds that do not belong to this org (cross-tenant / stale)', async () => {
+    // The org only has the sales group; the user also carries a foreign id not returned by this org.
+    const { adapters } = makeAdapters([group('g-sales', 'sales')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-sales', 'g-other-org']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['sales']);
+  });
+
+  it('drops a group whose type is not in the catalog (e.g. a retired type)', async () => {
+    const { adapters } = makeAdapters([group('g-sales', 'sales'), group('g-legacy', 'optihashi:compute')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-sales', 'g-legacy']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['sales']);
+  });
+
+  it('returns membership only for groups the user is actually in', async () => {
+    // Org has both types, but the user is only in research.
+    const { adapters } = makeAdapters([group('g-sales', 'sales'), group('g-research', 'research')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-research']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['research']);
+  });
+});

--- a/b4m-core/services/src/organizationService/resolveGroupTypesForUser.ts
+++ b/b4m-core/services/src/organizationService/resolveGroupTypesForUser.ts
@@ -1,0 +1,48 @@
+import { IGroupRepository, IUserDocument, getGroupType, isKnownGroupType } from '@bike4mind/common';
+
+interface ResolveGroupTypesAdapters {
+  db: {
+    groups: Pick<IGroupRepository, 'findByOrganization'>;
+  };
+}
+
+/**
+ * Resolve which GROUP-TYPE keys a user holds WITHIN one organization (org-groups #1235).
+ *
+ * `user.groups[]` stores bare Group ids with no type or org qualifier, so a consumer that wants
+ * "is this user in the org's `sales` group" cannot answer from the user doc alone. This is the
+ * single primitive the epic promises core will supply: it loads the org's LIVE groups
+ * (`findByOrganization` excludes soft-deleted rows) and maps the user's membership to catalog
+ * type keys. Scoping through the org's own groups is what makes the result org-qualified - a user
+ * carrying another tenant's group ids in `user.groups` contributes nothing here.
+ *
+ * Returns the DISTINCT known type keys, sorted by catalog `priority` (lower first) - the order a
+ * multi-type landing card menu uses (#137). Unknown keys (a `Group.type` not in GROUP_TYPE_CATALOG,
+ * e.g. a retired type) are dropped, so the result is always a valid subset of the catalog.
+ *
+ * Membership only, and deliberately side-effect-free: it confers nothing by itself. Capability
+ * resolution and the billing-owner implicit-hold are layered on top in #1234, NOT here, so this
+ * mirrors the hardened write-path invariant's org scoping without duplicating its authorization.
+ */
+export async function resolveGroupTypesForUser(
+  { user, organizationId }: { user: Pick<IUserDocument, 'groups'>; organizationId: string },
+  adapters: ResolveGroupTypesAdapters
+): Promise<string[]> {
+  const memberGroupIds = new Set(user.groups ?? []);
+  if (memberGroupIds.size === 0) return [];
+
+  const orgGroups = await adapters.db.groups.findByOrganization(organizationId);
+
+  const types = new Set<string>();
+  for (const group of orgGroups) {
+    if (memberGroupIds.has(group.id) && isKnownGroupType(group.type)) {
+      types.add(group.type);
+    }
+  }
+
+  return [...types].sort((a, b) => {
+    const pa = getGroupType(a)?.priority ?? Number.MAX_SAFE_INTEGER;
+    const pb = getGroupType(b)?.priority ?? Number.MAX_SAFE_INTEGER;
+    return pa - pb || a.localeCompare(b);
+  });
+}


### PR DESCRIPTION
## Description

Part of the Org Groups epic (#1172). `user.groups[]` stores bare `Group` ids with no type or organization qualifier, so nothing downstream can answer "does this user hold the org's `sales` group type?" from the user document alone. This adds the single core primitive the epic promises: `resolveGroupTypesForUser`.

It loads the org's **live** groups (`groupRepository.findByOrganization`, which excludes soft-deleted rows) and maps the user's membership to `GROUP_TYPE_CATALOG` type keys. Scoping through the org's own groups is what makes the result organization-qualified — a user carrying another tenant's group ids contributes nothing.

Design decisions baked in:
- **Membership only, side-effect-free.** It confers nothing by itself. Capability resolution and the billing-owner implicit-hold are layered on top in the follow-up (#1234), deliberately *not* here — so this mirrors the hardened write-path invariant's org scoping without duplicating its authorization.
- **Sorted by catalog `priority`** (lower first), the order a multi-type landing card menu consumes.
- **Unknown keys dropped** — a `Group.type` not in the catalog (e.g. a retired type) is excluded, so the result is always a valid subset of the catalog.

Unblocks #1234 (capability resolution) and the downstream persona/surface work.

## Changes

- Add `b4m-core/services/src/organizationService/resolveGroupTypesForUser.ts` — `resolveGroupTypesForUser({ user, organizationId }, { db: { groups } })` returning distinct, priority-sorted known type keys.
- Export it from `organizationService/index.ts`.
- Unit tests covering the mapping, priority ordering, cross-tenant/stale-id exclusion, unknown-type drop, partial membership, and the empty-groups short-circuit (no repo query).

## Guide for Testers

This is a pure resolver with **no runtime caller yet** — its first consumers are #1234 and the persona work — so there is no UI or endpoint to exercise. Coverage is the unit suite:

1. From the repo root, run: `pnpm --filter @bike4mind/services exec vitest run src/organizationService/resolveGroupTypesForUser.test.ts`
2. Expected: `Test Files 1 passed`, `Tests 6 passed`.
3. Typecheck: `pnpm --filter @bike4mind/services typecheck:fast` → no errors.

### Regression Checks
- `pnpm --filter @bike4mind/services exec vitest run src/organizationService/` → all `organizationService` suites still green (the only shared file touched is `index.ts`, which gains one export).

### What NOT to test
- Capability resolution / what a group type confers — not in this PR (#1234).
- Any UI or `/opti` surface behaviour — nothing wires this resolver yet.

## Additional Information

Depends on the Org Groups Phase 2-4 backend (#1181): `GROUP_TYPE_CATALOG`, `Group.type`, and `groupRepository.findByOrganization`.

## Developer Notes

- **New Extension Point**: `resolveGroupTypesForUser` is the seam #1234 builds capability resolution on. Its adapter is `{ db: { groups: Pick<IGroupRepository, 'findByOrganization'> } }` — the minimal repo subset, matching the sibling group-service signatures.

Closes #1235
