### PR TITLE
feat(ai): background music generation via ElevenLabs (/api/ai/music)

### DIFF
--- a/apps/client/app/components/Files/Browser/Item.tsx
+++ b/apps/client/app/components/Files/Browser/Item.tsx
@@ -50,7 +50,7 @@ const ImageThumbnail: FC<{ url: string; fileName: string; size: number }> = ({ u
   );
 };
 
-/** Inline audio player for generated TTS / sound-effect files. Stops click
+/** Inline audio player for generated audio files (TTS, sound-effect, music). Stops click
  *  propagation so using the transport controls doesn't toggle row selection. */
 const AudioPlayer: FC<{ url: string }> = ({ url }) => (
   <Box
@@ -453,7 +453,7 @@ const ListItem: FC<Omit<IFileBrowserItemProps, 'viewType'>> = ({ file, tags = []
             </Typography>
           </Box>
 
-          {/* Inline audio player for generated TTS / sound-effect files */}
+          {/* Inline audio player for generated audio files (TTS, sound-effect, music) */}
           {isAudioMimeType(file.mimeType) && (file.fileUrl || file.presignedUrl) && (
             <Box sx={{ width: '100%', maxWidth: 320 }}>
               <AudioPlayer url={(file.fileUrl || file.presignedUrl)!} />
@@ -789,7 +789,7 @@ const GridItem: FC<Omit<IFileBrowserItemProps, 'viewType'>> = ({ file, tags = []
             })}
           </Typography>
 
-          {/* Inline audio player for generated TTS / sound-effect files */}
+          {/* Inline audio player for generated audio files (TTS, sound-effect, music) */}
           {isAudioMimeType(file.mimeType) && (file.fileUrl || file.presignedUrl) && (
             <Box sx={{ width: '100%', px: 1, mt: 1 }}>
               <AudioPlayer url={(file.fileUrl || file.presignedUrl)!} />

--- a/apps/client/app/components/ProfileModal/CreditAnalyticsTabContent.tsx
+++ b/apps/client/app/components/ProfileModal/CreditAnalyticsTabContent.tsx
@@ -119,6 +119,7 @@ const CreditAnalyticsTabContent: React.FC = () => {
     const speechToTextUsageTransactions = sortedTransactions.filter(t => t.type === 'speech_to_text_usage');
     const textToSpeechUsageTransactions = sortedTransactions.filter(t => t.type === 'text_to_speech_usage');
     const soundEffectsUsageTransactions = sortedTransactions.filter(t => t.type === 'sound_effects_usage');
+    const musicUsageTransactions = sortedTransactions.filter(t => t.type === 'music_generation_usage');
 
     // Combined deduct transactions for burn rate calculation
     const allDeductTransactions = [
@@ -132,6 +133,7 @@ const CreditAnalyticsTabContent: React.FC = () => {
       ...speechToTextUsageTransactions,
       ...textToSpeechUsageTransactions,
       ...soundEffectsUsageTransactions,
+      ...musicUsageTransactions,
     ];
 
     // Calculate burn rate (average daily usage)
@@ -217,6 +219,7 @@ const CreditAnalyticsTabContent: React.FC = () => {
     const speechToTextUsageDailyData = new Map<string, { x: string; y: number }>();
     const textToSpeechUsageDailyData = new Map<string, { x: string; y: number }>();
     const soundEffectsUsageDailyData = new Map<string, { x: string; y: number }>();
+    const musicUsageDailyData = new Map<string, { x: string; y: number }>();
     const creditsAddedDailyData = new Map<string, { x: string; y: number }>(); // Combined purchases, subscriptions, and generic adds
     const allUsageDailyData = new Map<string, { x: string; y: number }>(); // Combined all usage types including generic deducts
 
@@ -250,6 +253,7 @@ const CreditAnalyticsTabContent: React.FC = () => {
     processTransactionType(speechToTextUsageTransactions, speechToTextUsageDailyData);
     processTransactionType(textToSpeechUsageTransactions, textToSpeechUsageDailyData);
     processTransactionType(soundEffectsUsageTransactions, soundEffectsUsageDailyData);
+    processTransactionType(musicUsageTransactions, musicUsageDailyData);
 
     // Create combined credits added (purchases + subscriptions + generic adds)
     [...purchaseTransactions, ...subscriptionTransactions, ...genericAddTransactions].forEach(transaction => {
@@ -273,6 +277,7 @@ const CreditAnalyticsTabContent: React.FC = () => {
       ...speechToTextUsageTransactions,
       ...textToSpeechUsageTransactions,
       ...soundEffectsUsageTransactions,
+      ...musicUsageTransactions,
     ].forEach(transaction => {
       const day = dayjs(transaction.createdAt).format('YYYY-MM-DD');
       if (!allUsageDailyData.has(day)) {
@@ -301,6 +306,7 @@ const CreditAnalyticsTabContent: React.FC = () => {
         speechToTextUsageDailyData,
         textToSpeechUsageDailyData,
         soundEffectsUsageDailyData,
+        musicUsageDailyData,
         creditsAddedDailyData,
         allUsageDailyData,
       ].forEach(dataMap => {
@@ -329,6 +335,7 @@ const CreditAnalyticsTabContent: React.FC = () => {
     const speechToTextUsageDataPoints = sortDataPoints(speechToTextUsageDailyData);
     const textToSpeechUsageDataPoints = sortDataPoints(textToSpeechUsageDailyData);
     const soundEffectsUsageDataPoints = sortDataPoints(soundEffectsUsageDailyData);
+    const musicUsageDataPoints = sortDataPoints(musicUsageDailyData);
     const creditsAddedDataPoints = sortDataPoints(creditsAddedDailyData);
     const allUsageDataPoints = sortDataPoints(allUsageDailyData);
 
@@ -457,6 +464,14 @@ const CreditAnalyticsTabContent: React.FC = () => {
           id: 'sound_effects_usage',
           data: soundEffectsUsageDataPoints,
           color: theme.palette.warning[400],
+        });
+      }
+
+      if (musicUsageDataPoints.some(p => p.y > 0)) {
+        lines.push({
+          id: 'music_generation_usage',
+          data: musicUsageDataPoints,
+          color: theme.palette.success[400],
         });
       }
 
@@ -969,6 +984,8 @@ const CreditAnalyticsTabContent: React.FC = () => {
                       return 'Text to Speech';
                     case 'sound_effects_usage':
                       return 'Sound Effects';
+                    case 'music_generation_usage':
+                      return 'Music Generation';
                     case 'usage':
                       return t('credits.credits_used');
                     case 'credits_added':

--- a/apps/client/app/components/ProfileModal/CreditAnalyticsTabContent.tsx
+++ b/apps/client/app/components/ProfileModal/CreditAnalyticsTabContent.tsx
@@ -471,7 +471,10 @@ const CreditAnalyticsTabContent: React.FC = () => {
         lines.push({
           id: 'music_generation_usage',
           data: musicUsageDataPoints,
-          color: theme.palette.success[400],
+          // Adjacent to sound_effects_usage (both audio) and unused elsewhere in
+          // this chart - success[400] already belongs to the subscriptions series,
+          // and the chart has no legend to disambiguate a collision.
+          color: theme.palette.warning[300],
         });
       }
 

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/GeneralSettingsTab.tsx
@@ -681,8 +681,8 @@ const GeneralSettingsTab = () => {
                   Save Generated Audio
                 </Typography>
                 <Typography level="body-sm" sx={{ mt: 0.5 }}>
-                  Keep text-to-speech and sound-effect audio in your files so you can browse and replay it. Counts
-                  toward your storage limit.
+                  Keep text-to-speech, sound-effect, and music audio in your files so you can browse and replay it.
+                  Counts toward your storage limit.
                 </Typography>
               </Box>
               <Switch

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -54,7 +54,7 @@ export interface UserSettings {
   /** Layer-2 Agent-mode preference. Default `'off'` per `IUserPreferences`. */
   agentModeDefault: 'off' | 'auto' | 'on';
   showFunTools: boolean;
-  /** Whether generated TTS / sound-effect audio is saved as a browsable FabFile. Default: true. */
+  /** Whether generated audio (TTS, sound-effect, music) is saved as a browsable FabFile. Default: true. */
   saveGeneratedAudio: boolean;
 }
 

--- a/apps/client/pages/api/ai/__tests__/music.test.ts
+++ b/apps/client/pages/api/ai/__tests__/music.test.ts
@@ -169,6 +169,8 @@ describe('POST /api/ai/music', () => {
         feature: 'music_generation',
         provider: 'elevenlabs',
         model: 'music_v1',
+        // Must match the ledger write's source or the two analytics surfaces disagree.
+        source: 'api',
         ownerId: 'u1',
         ownerType: CreditHolderType.User,
         creditsCharged: 150,
@@ -177,6 +179,40 @@ describe('POST /api/ai/music', () => {
         status: 'ok',
       })
     );
+  });
+
+  it('forwards caller-supplied forceInstrumental and format to the provider and to persistence', async () => {
+    getSettingsValue.mockReturnValue(false);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 0, usdCost: 0, billedSeconds: 30 });
+    generate.mockResolvedValue({ audio: Buffer.from('pcm'), contentType: 'audio/L16' });
+    persistGeneratedAudio.mockResolvedValue({ saved: true, fabFileId: 'fab1', fileName: 'music-x.pcm_44100' });
+
+    const { res, promise } = run({
+      prompt: 'instrumental study loop',
+      lengthMs: 30000,
+      forceInstrumental: true,
+      format: 'pcm_44100',
+    });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    // Real values, not `undefined`: toHaveBeenCalledWith uses toEqual semantics, so
+    // asserting `undefined` can't tell "forwarded" from "silently dropped". Dropping
+    // either field here means a caller asking for an instrumental PCM track quietly
+    // gets vocals in mp3.
+    expect(generate).toHaveBeenCalledWith('instrumental study loop', {
+      lengthMs: 30000,
+      forceInstrumental: true,
+      modelId: 'music_v1',
+      format: 'pcm_44100',
+    });
+    // format is also the persisted file's extension fallback when the content type
+    // is unmapped, so it must survive the hand-off to persistence too.
+    expect(persistGeneratedAudio).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'music', format: 'pcm_44100', contentType: 'audio/L16' })
+    );
+    expect(res.getHeader('Content-Type')).toBe('audio/L16');
+    expect(res.getHeader('Content-Length')).toBe(3);
   });
 
   it('does NOT reserve or charge when enforceCredits is off, but still records analytics (COGS, 0 credits)', async () => {

--- a/apps/client/pages/api/ai/__tests__/music.test.ts
+++ b/apps/client/pages/api/ai/__tests__/music.test.ts
@@ -1,0 +1,406 @@
+import { CreditHolderType, isZodError } from '@bike4mind/common';
+import { createMocks } from 'node-mocks-http';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getEffectiveApiKey,
+  deductCredits,
+  estimateMusicCredits,
+  generate,
+  getSettingsValue,
+  findById,
+  orgFindById,
+  userIncrement,
+  orgIncrement,
+  recordUsage,
+  persistGeneratedAudio,
+} = vi.hoisted(() => ({
+  getEffectiveApiKey: vi.fn(),
+  deductCredits: vi.fn(),
+  estimateMusicCredits: vi.fn(),
+  generate: vi.fn(),
+  getSettingsValue: vi.fn(),
+  findById: vi.fn(),
+  orgFindById: vi.fn(),
+  userIncrement: vi.fn(),
+  orgIncrement: vi.fn(),
+  recordUsage: vi.fn(),
+  persistGeneratedAudio: vi.fn(),
+}));
+
+// baseApi mock: routes by req.method; a thrown ZodError maps to 422 (mirroring
+// the real errorHandler), any other thrown error to its statusCode or 500.
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      async (req: unknown, res: unknown) => {
+        try {
+          return await h[(req as { method?: string }).method ?? 'GET']?.(req, res);
+        } catch (err) {
+          const status = isZodError(err)
+            ? 422
+            : typeof (err as { statusCode?: number })?.statusCode === 'number'
+              ? (err as { statusCode: number }).statusCode
+              : 500;
+          (res as { status: (n: number) => { json: (b: unknown) => void } })
+            .status(status)
+            .json({ error: (err as Error)?.message });
+        }
+      },
+      {
+        use: () => chain,
+        post: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.POST = fns[fns.length - 1]), chain),
+      }
+    );
+    return chain;
+  },
+}));
+
+vi.mock('@server/utils/errors', () => ({
+  BadRequestError: class BadRequestError extends Error {
+    statusCode = 400;
+  },
+}));
+vi.mock('@bike4mind/database', () => ({
+  apiKeyRepository: {},
+  adminSettingsRepository: {},
+  creditTransactionRepository: {},
+  organizationRepository: {
+    findById: (...a: unknown[]) => orgFindById(...a),
+    incrementCredits: (...a: unknown[]) => orgIncrement(...a),
+  },
+  usageEventRepository: { record: (...a: unknown[]) => recordUsage(...a) },
+  userRepository: {
+    findById: (...a: unknown[]) => findById(...a),
+    incrementCredits: (...a: unknown[]) => userIncrement(...a),
+  },
+}));
+vi.mock('@bike4mind/services', () => ({
+  apiKeyService: { getEffectiveApiKey: (...a: unknown[]) => getEffectiveApiKey(...a) },
+  creditService: { deductCreditsWithOrgSupport: (...a: unknown[]) => deductCredits(...a) },
+  estimateMusicCredits: (...a: unknown[]) => estimateMusicCredits(...a),
+}));
+vi.mock('@bike4mind/utils', () => ({
+  aiMusicService: () => ({ generate: (...a: unknown[]) => generate(...a) }),
+  getSettingsMap: vi.fn(async () => ({})),
+  getSettingsValue: (...a: unknown[]) => getSettingsValue(...a),
+}));
+vi.mock('@server/utils/persistGeneratedAudio', () => ({
+  persistGeneratedAudio: (...a: unknown[]) => persistGeneratedAudio(...a),
+}));
+
+import handler from '../music';
+
+type Handler = (req: unknown, res: unknown) => Promise<void>;
+
+const run = (body: unknown, apiKeyInfo?: unknown, userOrganizationId?: string) => {
+  const { req, res } = createMocks({ method: 'POST', body });
+  Object.assign(req, {
+    user: { id: 'u1', organizationId: userOrganizationId ?? null },
+    apiKeyInfo,
+    logger: { error: vi.fn(), warn: vi.fn() },
+  });
+  return { res, promise: (handler as Handler)(req, res) };
+};
+
+beforeEach(() => {
+  [
+    getEffectiveApiKey,
+    deductCredits,
+    estimateMusicCredits,
+    generate,
+    getSettingsValue,
+    findById,
+    orgFindById,
+    userIncrement,
+    orgIncrement,
+    recordUsage,
+    persistGeneratedAudio,
+  ].forEach(m => m.mockReset());
+  recordUsage.mockResolvedValue(undefined);
+  // Default: persistence is a no-op that reports "not saved", so tests not
+  // exercising the save path see no persisted-file headers.
+  persistGeneratedAudio.mockResolvedValue({ saved: false, reason: 'error' });
+  getEffectiveApiKey.mockResolvedValue('eleven-key');
+  generate.mockResolvedValue({ audio: Buffer.from('song'), contentType: 'audio/mpeg' });
+  findById.mockResolvedValue({ id: 'u1', currentCredits: 1000 });
+  // Default reservation results (post-decrement balance, non-negative == funded).
+  userIncrement.mockResolvedValue({ currentCredits: 850 });
+  orgIncrement.mockResolvedValue({ currentCredits: 9000 });
+});
+
+describe('POST /api/ai/music', () => {
+  it('reserves then settles the user charge on a successful generation (enforceCredits on)', async () => {
+    getSettingsValue.mockReturnValue(true);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 150, usdCost: 0.075, billedSeconds: 30 });
+
+    const { res, promise } = run({ prompt: 'lofi beat', lengthMs: 30000 });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData().toString()).toBe('song');
+    // Reserved up front (single call: funded, no rollback), then settled.
+    expect(userIncrement).toHaveBeenCalledTimes(1);
+    expect(userIncrement).toHaveBeenCalledWith('u1', -150);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    const [params, , options] = deductCredits.mock.calls[0];
+    // No API key -> personal billing: user pool, no organization.
+    expect(params).toMatchObject({
+      type: 'music_generation_usage',
+      credits: 150,
+      organization: null,
+      model: 'music_v1',
+    });
+    expect(params.user).toMatchObject({ id: 'u1' });
+    // Balance already moved at reservation -> settlement only writes the ledger row.
+    expect(options).toMatchObject({ skipBalanceUpdate: true });
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feature: 'music_generation',
+        provider: 'elevenlabs',
+        model: 'music_v1',
+        ownerId: 'u1',
+        ownerType: CreditHolderType.User,
+        creditsCharged: 150,
+        costUsd: 0.075,
+        units: 30,
+        status: 'ok',
+      })
+    );
+  });
+
+  it('does NOT reserve or charge when enforceCredits is off, but still records analytics (COGS, 0 credits)', async () => {
+    getSettingsValue.mockReturnValue(false);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 150, usdCost: 0.075, billedSeconds: 30 });
+
+    const { res, promise } = run({ prompt: 'ambient pad', lengthMs: 30000 });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(userIncrement).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+    // Analytics is decoupled from billing: the event still fires with the true
+    // provider COGS and zero credits charged.
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ feature: 'music_generation', creditsCharged: 0, costUsd: 0.075, status: 'ok' })
+    );
+  });
+
+  it('records the billed length as units', async () => {
+    getSettingsValue.mockReturnValue(true);
+    // Length defaulted by the schema when omitted; the estimator bills that
+    // length and units must follow the billed value.
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 50, usdCost: 0.025, billedSeconds: 10 });
+
+    const { res, promise } = run({ prompt: 'background music' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(recordUsage).toHaveBeenCalledWith(expect.objectContaining({ feature: 'music_generation', units: 10 }));
+  });
+
+  it('rejects (422) and rolls back the reservation before generating when the balance is short', async () => {
+    getSettingsValue.mockReturnValue(true);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 300, usdCost: 0.15, billedSeconds: 60 });
+    // Reserve overdraws: route must roll back and reject.
+    userIncrement.mockResolvedValue({ currentCredits: -40 });
+
+    const { res, promise } = run({ prompt: 'epic orchestral', lengthMs: 60000 });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(422);
+    // Reserve (-300) then immediate rollback (+300); nothing generated or settled.
+    expect(userIncrement).toHaveBeenCalledTimes(2);
+    expect(userIncrement).toHaveBeenNthCalledWith(1, 'u1', -300);
+    expect(userIncrement).toHaveBeenNthCalledWith(2, 'u1', 300);
+    expect(generate).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(recordUsage).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 (not 401) when no provider key resolves (no reservation)', async () => {
+    getEffectiveApiKey.mockResolvedValue(null);
+
+    const { res, promise } = run({ prompt: 'jazz', lengthMs: 30000 });
+    await promise;
+
+    // A missing provider key is a capability gap, not an auth failure - a 401 would
+    // wrongly tell an API-key caller to re-authenticate.
+    expect(res._getStatusCode()).toBe(503);
+    expect(res._getJSONData()).toMatchObject({ error: 'No elevenlabs API key configured' });
+    expect(userIncrement).not.toHaveBeenCalled();
+    expect(generate).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  it('forwards the persisted-file id, name, and signed URL as response headers', async () => {
+    getSettingsValue.mockReturnValue(false);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 0, usdCost: 0, billedSeconds: 30 });
+    persistGeneratedAudio.mockResolvedValue({
+      saved: true,
+      fabFileId: 'fab1',
+      fileName: 'music-lofi-beat.mp3',
+      fileUrl: 'https://signed.example/music.mp3',
+    });
+
+    const { res, promise } = run({ prompt: 'lofi beat', lengthMs: 30000 });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    // The signed URL must ride the header: the CLI cannot re-resolve one via
+    // GET /api/files/:id until the async moderation scan flips the file to 'clean'.
+    expect(res.getHeader('X-B4M-Audio-Saved')).toBe('true');
+    expect(res.getHeader('X-B4M-Audio-Fab-File-Id')).toBe('fab1');
+    expect(res.getHeader('X-B4M-Audio-File-Name')).toBe('music-lofi-beat.mp3');
+    expect(res.getHeader('X-B4M-Audio-File-Url')).toBe('https://signed.example/music.mp3');
+  });
+
+  it('rejects an invalid body (422) without resolving a key', async () => {
+    const { res, promise } = run({ prompt: '' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(422);
+    expect(getEffectiveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects an out-of-range length (422) without resolving a key', async () => {
+    // Below the 3s ElevenLabs minimum.
+    const { res, promise } = run({ prompt: 'blip', lengthMs: 500 });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(422);
+    expect(getEffectiveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('maps an upstream provider failure to 502 and refunds the reservation', async () => {
+    getSettingsValue.mockReturnValue(true);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 150, usdCost: 0.075, billedSeconds: 30 });
+    generate.mockRejectedValue(new Error('ElevenLabs music generation failed: 429'));
+
+    const { res, promise } = run({ prompt: 'thunder score', lengthMs: 30000 });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(502);
+    // Reserved (-150), then refunded (+150) because generation failed; never settled.
+    expect(userIncrement).toHaveBeenCalledTimes(2);
+    expect(userIncrement).toHaveBeenNthCalledWith(1, 'u1', -150);
+    expect(userIncrement).toHaveBeenNthCalledWith(2, 'u1', 150);
+    expect(deductCredits).not.toHaveBeenCalled();
+    // A failed generation still logs an analytics event, as an error with no cost.
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ feature: 'music_generation', status: 'error', creditsCharged: 0, costUsd: 0 })
+    );
+  });
+
+  it('still reports the charge (creditsCharged) when the settlement ledger write fails', async () => {
+    getSettingsValue.mockReturnValue(true);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 150, usdCost: 0.075, billedSeconds: 30 });
+    // Balance already moved at reservation; a settlement failure must NOT free the audio.
+    deductCredits.mockRejectedValue(new Error('mongo down'));
+
+    const { res, promise } = run({ prompt: 'lofi beat', lengthMs: 30000 });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData().toString()).toBe('song');
+    // No refund: the customer was charged at reservation; only the ledger row is missing.
+    expect(userIncrement).toHaveBeenCalledTimes(1);
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ feature: 'music_generation', status: 'ok', creditsCharged: 150 })
+    );
+  });
+
+  const orgKey = { billingOwnerType: CreditHolderType.Organization, organizationId: 'org1' };
+
+  it('reserves and settles against the org pool for an org-billed API key (user stays the actor)', async () => {
+    getSettingsValue.mockReturnValue(true);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 200, usdCost: 0.1, billedSeconds: 40 });
+    // Personal pool is empty on purpose: an org-billed key must draw from the org.
+    findById.mockResolvedValue({ id: 'u1', currentCredits: 0 });
+    orgFindById.mockResolvedValue({ id: 'org1', currentCredits: 10000, userDetails: [] });
+
+    const { res, promise } = run({ prompt: 'orchestral', lengthMs: 40000 }, orgKey);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    // Reserved against the org, not the user.
+    expect(orgIncrement).toHaveBeenCalledWith('org1', -200);
+    expect(userIncrement).not.toHaveBeenCalled();
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    const [params] = deductCredits.mock.calls[0];
+    expect(params).toMatchObject({ type: 'music_generation_usage', credits: 200 });
+    expect(params.organization).toMatchObject({ id: 'org1' });
+    expect(params.user).toMatchObject({ id: 'u1' });
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerId: 'org1',
+        ownerType: CreditHolderType.Organization,
+        userId: 'u1',
+        creditsCharged: 200,
+      })
+    );
+  });
+
+  it('bills the org seat of a browser/JWT member (organizationId from the user)', async () => {
+    getSettingsValue.mockReturnValue(true);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 100, usdCost: 0.05, billedSeconds: 20 });
+    orgFindById.mockResolvedValue({ id: 'orgSeat', currentCredits: 5000, userDetails: [] });
+
+    // No API key: JWT session whose user belongs to an org.
+    const { res, promise } = run({ prompt: 'chime melody', lengthMs: 20000 }, undefined, 'orgSeat');
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(orgFindById).toHaveBeenCalledWith('orgSeat');
+    expect(orgIncrement).toHaveBeenCalledWith('orgSeat', -100);
+    expect(userIncrement).not.toHaveBeenCalled();
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerId: 'orgSeat', ownerType: CreditHolderType.Organization, userId: 'u1' })
+    );
+  });
+
+  it('rejects (422) before reserving when the org per-member cap is reached', async () => {
+    getSettingsValue.mockReturnValue(true);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 300, usdCost: 0.15, billedSeconds: 60 });
+    // Pool is flush, but the member's usage + this request exceeds maxCreditsPerMember (100 + 300 > 200).
+    orgFindById.mockResolvedValue({
+      id: 'org1',
+      currentCredits: 100000,
+      maxCreditsPerMember: 200,
+      userDetails: [{ id: 'u1', usedCredits: 100 }],
+    });
+
+    const { res, promise } = run({ prompt: 'anthem', lengthMs: 60000 }, orgKey);
+    await promise;
+
+    expect(res._getStatusCode()).toBe(422);
+    // Cap is enforced before touching the pool.
+    expect(orgIncrement).not.toHaveBeenCalled();
+    expect(generate).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  it('bills the user pool for a user-billed API key (billingOwnerType User), ignoring the org seat', async () => {
+    getSettingsValue.mockReturnValue(true);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 150, usdCost: 0.075, billedSeconds: 30 });
+
+    // User-billed key even though the user has an org seat: bill the user.
+    const { res, promise } = run(
+      { prompt: 'rainy jazz', lengthMs: 30000 },
+      { billingOwnerType: CreditHolderType.User },
+      'orgSeat'
+    );
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(orgFindById).not.toHaveBeenCalled();
+    expect(orgIncrement).not.toHaveBeenCalled();
+    expect(userIncrement).toHaveBeenCalledWith('u1', -150);
+    const [params] = deductCredits.mock.calls[0];
+    expect(params.organization).toBeNull();
+    expect(recordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerId: 'u1', ownerType: CreditHolderType.User })
+    );
+  });
+});

--- a/apps/client/pages/api/ai/__tests__/music.test.ts
+++ b/apps/client/pages/api/ai/__tests__/music.test.ts
@@ -140,6 +140,15 @@ describe('POST /api/ai/music', () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(res._getData().toString()).toBe('song');
+    // The billed length is what's forced on the provider: the same lengthMs must
+    // drive the cost estimate AND the generate call, or billed != generated.
+    expect(estimateMusicCredits).toHaveBeenCalledWith('elevenlabs', { lengthMs: 30000 });
+    expect(generate).toHaveBeenCalledWith('lofi beat', {
+      lengthMs: 30000,
+      forceInstrumental: undefined,
+      modelId: 'music_v1',
+      format: undefined,
+    });
     // Reserved up front (single call: funded, no rollback), then settled.
     expect(userIncrement).toHaveBeenCalledTimes(1);
     expect(userIncrement).toHaveBeenCalledWith('u1', -150);
@@ -248,6 +257,9 @@ describe('POST /api/ai/music', () => {
     await promise;
 
     expect(res._getStatusCode()).toBe(200);
+    // Persisted under the 'music' source so it's tagged/named as music, not a
+    // sound effect (the two routes share persistGeneratedAudio).
+    expect(persistGeneratedAudio).toHaveBeenCalledWith(expect.objectContaining({ source: 'music' }));
     // The signed URL must ride the header: the CLI cannot re-resolve one via
     // GET /api/files/:id until the async moderation scan flips the file to 'clean'.
     expect(res.getHeader('X-B4M-Audio-Saved')).toBe('true');
@@ -291,6 +303,28 @@ describe('POST /api/ai/music', () => {
     expect(recordUsage).toHaveBeenCalledWith(
       expect.objectContaining({ feature: 'music_generation', status: 'error', creditsCharged: 0, costUsd: 0 })
     );
+  });
+
+  it('refunds the ORG pool (not the user) when an org-billed generation fails', async () => {
+    getSettingsValue.mockReturnValue(true);
+    estimateMusicCredits.mockReturnValue({ requiredCredits: 200, usdCost: 0.1, billedSeconds: 40 });
+    findById.mockResolvedValue({ id: 'u1', currentCredits: 0 });
+    orgFindById.mockResolvedValue({ id: 'org1', currentCredits: 10000, userDetails: [] });
+    generate.mockRejectedValue(new Error('ElevenLabs music generation failed: 500'));
+
+    const { res, promise } = run(
+      { prompt: 'orchestral', lengthMs: 40000 },
+      { billingOwnerType: CreditHolderType.Organization, organizationId: 'org1' }
+    );
+    await promise;
+
+    expect(res._getStatusCode()).toBe(502);
+    // The refund must go back to whoever was reserved against - the org, via
+    // holderMethods - not the user pool.
+    expect(orgIncrement).toHaveBeenNthCalledWith(1, 'org1', -200);
+    expect(orgIncrement).toHaveBeenNthCalledWith(2, 'org1', 200);
+    expect(userIncrement).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
   });
 
   it('still reports the charge (creditsCharged) when the settlement ledger write fails', async () => {

--- a/apps/client/pages/api/ai/music.ts
+++ b/apps/client/pages/api/ai/music.ts
@@ -141,6 +141,8 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(asyn
         feature: 'music_generation',
         provider,
         model: modelId,
+        // Matches this call's ledger write (deductCreditsWithOrgSupport, source: 'api').
+        source: 'api',
         inputTokens: 0,
         outputTokens: 0,
         cachedInputTokens: 0,

--- a/apps/client/pages/api/ai/music.ts
+++ b/apps/client/pages/api/ai/music.ts
@@ -1,0 +1,249 @@
+import {
+  ApiKeyScope,
+  ApiKeyType,
+  CreditHolderType,
+  ICreditHolder,
+  ICreditHolderMethods,
+  insufficientCreditsError,
+  IOrganizationDocument,
+  IUserDocument,
+  MusicGenerationVendor,
+  musicRequestSchema,
+} from '@bike4mind/common';
+import {
+  adminSettingsRepository,
+  apiKeyRepository,
+  creditTransactionRepository,
+  organizationRepository,
+  userRepository,
+  usageEventRepository,
+} from '@bike4mind/database';
+import { apiKeyService, creditService, estimateMusicCredits } from '@bike4mind/services';
+import { aiMusicService, getSettingsMap, getSettingsValue } from '@bike4mind/utils';
+import { baseApi } from '@server/middlewares/baseApi';
+import { BadRequestError } from '@server/utils/errors';
+import { persistGeneratedAudio } from '@server/utils/persistGeneratedAudio';
+
+// The stored key type each vendor needs. Resolved per-user first, then falling
+// back to the admin-configured key (getEffectiveApiKey), so the feature works
+// out of the box on platforms that provide a shared provider key.
+const PROVIDER_API_KEY_TYPE: Record<MusicGenerationVendor, ApiKeyType> = {
+  elevenlabs: ApiKeyType.elevenlabs,
+};
+
+// Provider-agnostic background-music generation. Meters usage: because the cost
+// is deterministic (the requested length is forced on the provider, so the
+// generated track always matches what we bill), it RESERVES the exact charge
+// before calling the provider and settles it on success / refunds it on failure
+// - so a charge can never fail after the audio is produced. Bills the
+// organization's shared pool for org-billed API keys and for org-seat members;
+// otherwise the user. All billing is gated on the enforceCredits admin setting,
+// so self-host / credits-off deployments run free. Scope-gated (AI_GENERATE) so
+// an under-scoped API key can't drive paid provider generation, matching
+// image/video/sound-effects. Mirrors pages/api/ai/sound-effects.ts.
+const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_GENERATE] }).post(async (req, res) => {
+  const { provider, prompt, lengthMs, forceInstrumental, modelId, format } = musicRequestSchema.parse(req.body);
+  const userId = req.user?.id;
+
+  const apiKey = await apiKeyService.getEffectiveApiKey(
+    userId,
+    { type: PROVIDER_API_KEY_TYPE[provider] },
+    { db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository } }
+  );
+
+  if (!apiKey) {
+    // 503, not 401: the caller IS authenticated - the provider key is a server-side
+    // capability gap. A 401 would tell an API-key caller to re-authenticate, which
+    // never fixes a missing ElevenLabs key. The message survives to the CLI via the
+    // arraybuffer error decode + mapApiError's server-message fallback.
+    return res.status(503).json({ error: `No ${provider} API key configured` });
+  }
+
+  const settings = await getSettingsMap({ adminSettings: adminSettingsRepository }, { names: ['enforceCredits'] });
+  const enforceCredits = getSettingsValue('enforceCredits', settings);
+
+  // Cost is deterministic from the request (length-driven), so the same estimate
+  // drives the reservation, the settlement, and the usage-event COGS - it's
+  // computed regardless of enforceCredits so analytics capture true provider
+  // cost even on credits-off / self-host deployments.
+  const { requiredCredits, usdCost, billedSeconds } = estimateMusicCredits(provider, { lengthMs });
+
+  // Billing owner, in precedence order:
+  //   1. Org-billed API key -> its organization (billingOwnerType invariant).
+  //   2. User-billed API key -> the user (explicit intent; ignore the org seat).
+  //   3. Browser/JWT caller -> the user's own organization seat if any, matching
+  //      image/video generation; otherwise the user.
+  // The user always stays the actor for attribution + per-member usage tracking.
+  const billingOrganizationId = req.apiKeyInfo
+    ? req.apiKeyInfo.billingOwnerType === CreditHolderType.Organization
+      ? req.apiKeyInfo.organizationId
+      : undefined
+    : (req.user?.organizationId?.toString() ?? undefined);
+  const creditOwnerId = billingOrganizationId ?? userId;
+  const creditOwnerType = billingOrganizationId ? CreditHolderType.Organization : CreditHolderType.User;
+  const holderMethods: ICreditHolderMethods = billingOrganizationId ? organizationRepository : userRepository;
+
+  // Holder docs are resolved under enforceCredits only (the charge settlement
+  // needs them); left null on credits-off / self-host deploys, which never bill.
+  let billingUser: IUserDocument | null = null;
+  let billingOrg: IOrganizationDocument | null = null;
+  // Set once credits are reserved; its presence drives the refund/settle below.
+  let reservedHolder: ICreditHolder | null = null;
+
+  if (enforceCredits && requiredCredits > 0) {
+    billingUser = await userRepository.findById(userId);
+    if (!billingUser) throw new BadRequestError('User not found');
+    if (billingOrganizationId) {
+      billingOrg = await organizationRepository.findById(billingOrganizationId);
+      if (!billingOrg) throw new BadRequestError('Billing organization not found');
+    }
+
+    // Org-billed: enforce the per-member cap before touching the shared pool,
+    // mirroring deductCreditsWithOrgSupport (which re-checks it at settlement).
+    if (billingOrg?.maxCreditsPerMember != null) {
+      const usedCredits = billingOrg.userDetails?.find(member => member.id === userId)?.usedCredits ?? 0;
+      if (usedCredits + requiredCredits > billingOrg.maxCreditsPerMember) {
+        throw insufficientCreditsError(
+          `Your organization member credit limit has been reached for music generation. Contact your organization administrator.`
+        );
+      }
+    }
+
+    // Reserve the deterministic cost BEFORE incurring any provider cost: the
+    // atomic decrement doubles as the balance check (closing the check-then-charge
+    // race) and guarantees the charge can never fail after the audio is produced.
+    // Rolled back immediately if it overdraws; refunded below if generation fails.
+    reservedHolder = await holderMethods.incrementCredits(creditOwnerId, -requiredCredits);
+    if (!reservedHolder || reservedHolder.currentCredits < 0) {
+      if (reservedHolder) await holderMethods.incrementCredits(creditOwnerId, requiredCredits);
+      const availableCredits = (reservedHolder?.currentCredits ?? 0) + requiredCredits;
+      throw insufficientCreditsError(
+        billingOrg
+          ? `Your organization does not have enough credits for music generation. It currently has ${availableCredits} credits and this requires approximately ${requiredCredits}.`
+          : `You do not have enough credits for music generation. You currently have ${availableCredits} credits and this requires approximately ${requiredCredits}.`
+      );
+    }
+  }
+
+  const sessionId = `music-${userId}-${Date.now()}`;
+
+  // Analytics is never part of the billing path: one usage event per provider
+  // call (ok or error), independent of enforceCredits and of whether the charge
+  // succeeds. Fire-and-forget; a logging failure never affects the response.
+  const recordUsage = (status: 'ok' | 'error', creditsCharged: number, costUsdValue: number) =>
+    usageEventRepository
+      .record({
+        requestId: sessionId,
+        userId,
+        ownerId: creditOwnerId,
+        ownerType: creditOwnerType,
+        sessionId,
+        feature: 'music_generation',
+        provider,
+        model: modelId,
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedInputTokens: 0,
+        cacheWriteTokens: 0,
+        // Billed track length in seconds; the provider generates exactly this
+        // length, so units stay consistent with costUsd.
+        units: billedSeconds,
+        costUsd: costUsdValue,
+        creditsCharged,
+        status,
+      })
+      .catch(err => req.logger.warn('Failed to record music-generation usage event', { err }));
+
+  let audio: Buffer;
+  let contentType: string;
+  try {
+    const musicService = aiMusicService(provider, apiKey, req.logger);
+    ({ audio, contentType } = await musicService.generate(prompt, { lengthMs, forceInstrumental, modelId, format }));
+  } catch (error) {
+    req.logger.error('Music generation failed', {
+      provider,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    // Refund the reserved credits - a failed generation incurs no provider cost.
+    if (reservedHolder) await holderMethods.incrementCredits(creditOwnerId, requiredCredits);
+    recordUsage('error', 0, 0);
+    return res.status(502).json({ error: 'Music generation failed' });
+  }
+
+  // Settle the reserved charge: the balance already moved at reservation, so this
+  // only writes the ledger row + per-member usage tracking (skipBalanceUpdate).
+  // If it fails, the customer was still charged (balance moved) - the audit row is
+  // just missing; log for reconciliation. Never a free generation.
+  let creditsCharged = 0;
+  if (reservedHolder) {
+    creditsCharged = requiredCredits;
+    try {
+      // billingUser is guaranteed set here: the reservation branch populated it.
+      await creditService.deductCreditsWithOrgSupport(
+        {
+          type: 'music_generation_usage',
+          user: billingUser!,
+          organization: billingOrg, // null => the user's personal pool
+          credits: requiredCredits,
+          sessionId,
+          model: modelId,
+          source: 'api',
+        },
+        {
+          db: {
+            creditTransactions: creditTransactionRepository,
+            users: userRepository,
+            organizations: organizationRepository,
+          },
+        },
+        { skipBalanceUpdate: true, currentCreditHolder: reservedHolder }
+      );
+    } catch (err) {
+      req.logger.error('Music-generation usage transaction write failed - credits charged, ledger row missing', {
+        userId,
+        organizationId: billingOrganizationId,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+  }
+
+  recordUsage('ok', creditsCharged, usdCost);
+
+  // Persist a browsable copy of the generated audio (on by default; opt out via
+  // the saveGeneratedAudio preference). Best-effort: a save failure (e.g. over
+  // quota) never blocks returning the audio the caller was already charged for.
+  if (userId && (req.user?.preferences?.saveGeneratedAudio ?? true)) {
+    const save = await persistGeneratedAudio({
+      userId,
+      audio,
+      contentType,
+      format,
+      source: 'music',
+      text: prompt,
+      logger: req.logger,
+    });
+    res.setHeader('X-B4M-Audio-Saved', String(save.saved));
+    if (save.saved) {
+      res.setHeader('X-B4M-Audio-Fab-File-Id', save.fabFileId);
+      res.setHeader('X-B4M-Audio-File-Name', save.fileName);
+      // Forward the signed URL minted at creation. Non-image audio gets a working URL
+      // immediately (createFabFile), whereas re-resolving it via GET /api/files/:id
+      // fails closed until the async moderation scan flips moderationStatus to 'clean'
+      // (isImageServeable gates every mime type) - so callers must use this URL, not
+      // re-fetch one. Absent only in the rare case createFabFile minted no URL.
+      if (save.fileUrl) res.setHeader('X-B4M-Audio-File-Url', save.fileUrl);
+    }
+  }
+
+  res.setHeader('Content-Type', contentType);
+  res.setHeader('Content-Length', audio.length);
+  return res.send(audio);
+});
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/apps/client/server/utils/persistGeneratedAudio.test.ts
+++ b/apps/client/server/utils/persistGeneratedAudio.test.ts
@@ -72,6 +72,21 @@ describe('persistGeneratedAudio', () => {
     expect(params.fileName).toMatch(/^sound-effect-\d+\.wav$/);
   });
 
+  it('tags music audio with its source', async () => {
+    h.createFabFile.mockResolvedValue({ id: 'fab-3' });
+    await persistGeneratedAudio({
+      userId: 'u1',
+      audio: Buffer.from('bytes'),
+      contentType: 'audio/mpeg',
+      source: 'music',
+      text: 'lofi beat',
+      logger,
+    });
+    const [, params] = h.createFabFile.mock.calls[0];
+    expect(params.tags).toContainEqual({ name: 'music', strength: 1 });
+    expect(params.fileName).toMatch(/^music-lofi-beat-\d+\.mp3$/);
+  });
+
   it('maps a storage-quota rejection to saved:false without throwing (audio must still be returned)', async () => {
     h.createFabFile.mockRejectedValue(new Error('File size exceeds storage limit'));
     const result = await persistGeneratedAudio({

--- a/apps/client/server/utils/persistGeneratedAudio.ts
+++ b/apps/client/server/utils/persistGeneratedAudio.ts
@@ -4,7 +4,14 @@ import { FabFile, User, adminSettingsRepository } from '@bike4mind/database';
 import { fabFilesService } from '@bike4mind/services';
 import { getFilesStorage } from '@server/utils/storage';
 
-export type GeneratedAudioSource = 'tts' | 'sound-effect';
+export type GeneratedAudioSource = 'tts' | 'sound-effect' | 'music';
+
+/** Human-friendly file-name prefix for each generated-audio source. */
+const FILE_NAME_LABELS: Record<GeneratedAudioSource, string> = {
+  tts: 'speech',
+  'sound-effect': 'sound-effect',
+  music: 'music',
+};
 
 /**
  * Outcome of trying to persist generated audio. `saved: false` is never fatal:
@@ -41,7 +48,7 @@ export async function persistGeneratedAudio(params: {
   const { userId, audio, contentType, source, text, format, logger } = params;
 
   const ext = extensionFromMimeType(contentType) || format || 'mp3';
-  const label = source === 'tts' ? 'speech' : 'sound-effect';
+  const label = FILE_NAME_LABELS[source];
   // Short, sanitized snippet of the prompt (no dots, so the appended extension
   // is the only one getFileExtension can pick up).
   const snippet = text

--- a/apps/client/server/utils/persistGeneratedAudio.ts
+++ b/apps/client/server/utils/persistGeneratedAudio.ts
@@ -24,7 +24,9 @@ export type PersistGeneratedAudioResult =
   | { saved: false; reason: 'storage_limit' | 'file_too_large' | 'error' };
 
 /**
- * Persist generated TTS / sound-effect audio as a browsable `AUDIO` FabFile.
+ * Persist generated audio (TTS, sound-effect, or music) as a browsable `AUDIO`
+ * FabFile. `source` only varies the file-name prefix and the `generated` tag;
+ * every source takes the identical storage path.
  *
  * Routes through `fabFilesService.createFabFile`, which enforces the per-user
  * storage quota (`checkStorageLimitForFile`) and the `MaxFileSize` admin

--- a/b4m-core/common/src/index.ts
+++ b/b4m-core/common/src/index.ts
@@ -15,6 +15,7 @@ export * from './voicePricing';
 export * from './videoGeneration';
 export * from './soundGeneration';
 export * from './soundPricing';
+export * from './musicGeneration';
 export * from './schemas/sora';
 export * from './schemas';
 export * from './constants/user';

--- a/b4m-core/common/src/musicGeneration.test.ts
+++ b/b4m-core/common/src/musicGeneration.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MUSIC_LENGTH_MS,
+  DEFAULT_MUSIC_MODEL_ID,
+  MAX_MUSIC_LENGTH_MS,
+  MIN_MUSIC_LENGTH_MS,
+  musicRequestSchema,
+} from './musicGeneration';
+
+describe('musicRequestSchema', () => {
+  it('defaults provider, length, and model so a prompt-only body is billable', () => {
+    // The reserve/settle path needs a deterministic length before generation, so
+    // an omitted lengthMs must resolve to a concrete number, not stay undefined.
+    expect(musicRequestSchema.parse({ prompt: 'lofi beat' })).toEqual({
+      provider: 'elevenlabs',
+      prompt: 'lofi beat',
+      lengthMs: DEFAULT_MUSIC_LENGTH_MS,
+      modelId: DEFAULT_MUSIC_MODEL_ID,
+    });
+  });
+
+  it('accepts the length bounds inclusively and rejects one step outside either', () => {
+    expect(musicRequestSchema.parse({ prompt: 'x', lengthMs: MIN_MUSIC_LENGTH_MS }).lengthMs).toBe(MIN_MUSIC_LENGTH_MS);
+    expect(musicRequestSchema.parse({ prompt: 'x', lengthMs: MAX_MUSIC_LENGTH_MS }).lengthMs).toBe(MAX_MUSIC_LENGTH_MS);
+    expect(musicRequestSchema.safeParse({ prompt: 'x', lengthMs: MIN_MUSIC_LENGTH_MS - 1 }).success).toBe(false);
+    // The cap exists so we never accept a length that would predictably outlive the
+    // provider-fetch budget; raising it silently is the regression to catch.
+    expect(musicRequestSchema.safeParse({ prompt: 'x', lengthMs: MAX_MUSIC_LENGTH_MS + 1 }).success).toBe(false);
+  });
+
+  it('caps length below the serving function budget', () => {
+    expect(MAX_MUSIC_LENGTH_MS).toBe(120_000);
+  });
+
+  it('rejects a non-integer length', () => {
+    expect(musicRequestSchema.safeParse({ prompt: 'x', lengthMs: 10_000.5 }).success).toBe(false);
+  });
+
+  it('preserves forceInstrumental: false instead of dropping it', () => {
+    // false is meaningfully different from absent: it tells the provider to allow
+    // vocals. A falsy-drop would silently change what the caller asked for.
+    expect(musicRequestSchema.parse({ prompt: 'x', forceInstrumental: false })).toMatchObject({
+      forceInstrumental: false,
+    });
+  });
+
+  it('rejects an empty or over-long prompt', () => {
+    expect(musicRequestSchema.safeParse({ prompt: '' }).success).toBe(false);
+    expect(musicRequestSchema.safeParse({ prompt: 'a'.repeat(2001) }).success).toBe(false);
+  });
+
+  it('rejects an unknown provider or model', () => {
+    expect(musicRequestSchema.safeParse({ prompt: 'x', provider: 'suno' }).success).toBe(false);
+    expect(musicRequestSchema.safeParse({ prompt: 'x', modelId: 'music_v2' }).success).toBe(false);
+  });
+});

--- a/b4m-core/common/src/musicGeneration.ts
+++ b/b4m-core/common/src/musicGeneration.ts
@@ -31,12 +31,13 @@ export const DEFAULT_MUSIC_LENGTH_MS = 10_000;
 /** ElevenLabs music length bounds, in milliseconds (`music_length_ms`). */
 export const MIN_MUSIC_LENGTH_MS = 3_000;
 /**
- * Capped well below the provider's own 600s ceiling because generation happens
- * inside a 60s-limited serving function whose provider fetch aborts at ~45s (see
- * ElevenLabsMusicGenerator). The abort makes over-budget requests fail safe
- * (reservation refunded), so this cap is purely to avoid accepting lengths that
- * would predictably time out. Conservative and provisional: raise it once real
- * ElevenLabs generation latency is measured against the fetch budget.
+ * Capped well below the provider's own 600s ceiling: generation happens inside a
+ * time-limited serving function whose provider fetch carries its own abort
+ * deadline (MUSIC_GENERATION_TIMEOUT_MS in ElevenLabsMusicGenerator). That abort
+ * is what makes an over-budget request fail safe (reservation refunded); this cap
+ * only avoids accepting lengths that would predictably hit it. Conservative and
+ * provisional: raise it once real ElevenLabs generation latency is measured.
+ * Note this bounds output length, which correlates with - but is not - wall time.
  */
 export const MAX_MUSIC_LENGTH_MS = 120_000;
 

--- a/b4m-core/common/src/musicGeneration.ts
+++ b/b4m-core/common/src/musicGeneration.ts
@@ -1,0 +1,54 @@
+import z from 'zod';
+
+/**
+ * Supported background-music generation vendors. Currently only ElevenLabs.
+ * New vendors are added here and in the `aiMusicService` factory.
+ */
+export const supportedMusicGenerationVendor = z.enum(['elevenlabs']);
+
+export type MusicGenerationVendor = z.infer<typeof supportedMusicGenerationVendor>;
+
+/**
+ * Supported ElevenLabs music models. Scoped to `music_v1` for now; `music_v2` is
+ * a deliberate follow-up (see the parent issue). Adding it here is the only
+ * change the request surface needs to accept it.
+ */
+export const supportedMusicModel = z.enum(['music_v1']);
+
+export type MusicModel = z.infer<typeof supportedMusicModel>;
+
+export const DEFAULT_MUSIC_MODEL_ID: MusicModel = 'music_v1';
+
+/**
+ * Default clip length (ms) billed and generated when the caller omits `lengthMs`.
+ * Deliberately conservative: the route forwards this exact value to the provider
+ * so the generated length always equals the billed length (deterministic
+ * reserve/settle), and a small default keeps a prompt-only call cheap. Callers
+ * that want a longer track pass `lengthMs` explicitly.
+ */
+export const DEFAULT_MUSIC_LENGTH_MS = 10_000;
+
+/** ElevenLabs music length bounds, in milliseconds (`music_length_ms`). */
+export const MIN_MUSIC_LENGTH_MS = 3_000;
+export const MAX_MUSIC_LENGTH_MS = 600_000;
+
+/**
+ * Inbound request body for `POST /api/ai/music`.
+ *
+ * `lengthMs` bounds mirror the ElevenLabs Music API (`music_length_ms`,
+ * 3s-600s). It carries a default rather than being optional so the billed
+ * length is always known up front (the reserve/settle path needs a deterministic
+ * cost before generation) and the route can force that exact length on the
+ * provider. `format` is the provider-specific output encoding token (e.g.
+ * `mp3_44100_128`).
+ */
+export const musicRequestSchema = z.object({
+  provider: supportedMusicGenerationVendor.default('elevenlabs'),
+  prompt: z.string().min(1).max(2000),
+  lengthMs: z.number().int().min(MIN_MUSIC_LENGTH_MS).max(MAX_MUSIC_LENGTH_MS).default(DEFAULT_MUSIC_LENGTH_MS),
+  forceInstrumental: z.boolean().optional(),
+  modelId: supportedMusicModel.default(DEFAULT_MUSIC_MODEL_ID),
+  format: z.string().optional(),
+});
+
+export type MusicRequest = z.infer<typeof musicRequestSchema>;

--- a/b4m-core/common/src/musicGeneration.ts
+++ b/b4m-core/common/src/musicGeneration.ts
@@ -30,13 +30,22 @@ export const DEFAULT_MUSIC_LENGTH_MS = 10_000;
 
 /** ElevenLabs music length bounds, in milliseconds (`music_length_ms`). */
 export const MIN_MUSIC_LENGTH_MS = 3_000;
-export const MAX_MUSIC_LENGTH_MS = 600_000;
+/**
+ * Capped well below the provider's own 600s ceiling because generation happens
+ * inside a 60s-limited serving function whose provider fetch aborts at ~45s (see
+ * ElevenLabsMusicGenerator). The abort makes over-budget requests fail safe
+ * (reservation refunded), so this cap is purely to avoid accepting lengths that
+ * would predictably time out. Conservative and provisional: raise it once real
+ * ElevenLabs generation latency is measured against the fetch budget.
+ */
+export const MAX_MUSIC_LENGTH_MS = 120_000;
 
 /**
  * Inbound request body for `POST /api/ai/music`.
  *
- * `lengthMs` bounds mirror the ElevenLabs Music API (`music_length_ms`,
- * 3s-600s). It carries a default rather than being optional so the billed
+ * `lengthMs` upper bound is capped below the ElevenLabs Music API ceiling to fit
+ * the serving function's time budget (see MAX_MUSIC_LENGTH_MS). It carries a
+ * default rather than being optional so the billed
  * length is always known up front (the reserve/settle path needs a deterministic
  * cost before generation) and the route can force that exact length on the
  * provider. `format` is the provider-specific output encoding token (e.g.

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -3003,7 +3003,7 @@ export const settingsMap = {
     name: 'ElevenLabs Server API Key (Voice v2)',
     defaultValue: '',
     description:
-      'Server-side ElevenLabs API key. Mints Conversational AI signed URLs for /api/voice/v2/sessions and is the org-wide fallback key for ElevenLabs text-to-speech (/api/ai/tts) and sound-effects (/api/ai/sound-effects) when a user has no personal key. A per-user ElevenLabs key still takes precedence.',
+      'Server-side ElevenLabs API key. Mints Conversational AI signed URLs for /api/voice/v2/sessions and is the org-wide fallback key for ElevenLabs text-to-speech (/api/ai/tts), sound-effects (/api/ai/sound-effects), and music generation (/api/ai/music) when a user has no personal key. A per-user ElevenLabs key still takes precedence.',
     isSensitive: true,
     category: 'AI',
     group: API_SERVICE_GROUPS.VOICE_SESSION.id,

--- a/b4m-core/common/src/types/entities/CreditTransactionTypes.ts
+++ b/b4m-core/common/src/types/entities/CreditTransactionTypes.ts
@@ -202,6 +202,12 @@ export const SoundEffectsUsageTransaction = BaseCreditTransaction.extend({
   sessionId: z.string(),
 });
 
+export const MusicGenerationUsageTransaction = BaseCreditTransaction.extend({
+  type: z.literal('music_generation_usage'),
+  model: z.string(),
+  sessionId: z.string(),
+});
+
 export const TransferCreditTransaction = BaseCreditTransaction.extend({
   type: z.literal('transfer_credit'),
   recipientId: z.string(),
@@ -234,6 +240,7 @@ export const CreditTransaction = z.discriminatedUnion('type', [
   SpeechToTextUsageTransaction,
   TextToSpeechUsageTransaction,
   SoundEffectsUsageTransaction,
+  MusicGenerationUsageTransaction,
   TransferCreditTransaction,
   ReceivedCreditTransaction,
 ]);
@@ -260,6 +267,7 @@ export type ICompletionApiUsageTransaction = z.infer<typeof CompletionApiUsageTr
 export type ISpeechToTextUsageTransaction = z.infer<typeof SpeechToTextUsageTransaction>;
 export type ITextToSpeechUsageTransaction = z.infer<typeof TextToSpeechUsageTransaction>;
 export type ISoundEffectsUsageTransaction = z.infer<typeof SoundEffectsUsageTransaction>;
+export type IMusicGenerationUsageTransaction = z.infer<typeof MusicGenerationUsageTransaction>;
 export type ITransferCreditTransaction = z.infer<typeof TransferCreditTransaction>;
 export type IReceivedCreditTransaction = z.infer<typeof ReceivedCreditTransaction>;
 
@@ -292,6 +300,7 @@ export const CREDIT_DEDUCT_TRANSACTION_TYPES: CreditTransactionType[] = [
   'speech_to_text_usage',
   'text_to_speech_usage',
   'sound_effects_usage',
+  'music_generation_usage',
   'transfer_credit',
   'generic_deduct',
 ] as const;

--- a/b4m-core/common/src/types/entities/UsageEventTypes.ts
+++ b/b4m-core/common/src/types/entities/UsageEventTypes.ts
@@ -17,6 +17,7 @@ export const USAGE_EVENT_FEATURES = [
   'transcription',
   'text_to_speech',
   'sound_effects',
+  'music_generation',
   'agent_execution',
   'completion_api',
   'tool',

--- a/b4m-core/common/src/types/entities/UserTypes.ts
+++ b/b4m-core/common/src/types/entities/UserTypes.ts
@@ -122,7 +122,7 @@ export interface IUserPreferences {
   agentModeDefault?: 'off' | 'auto' | 'on';
   /** Whether to show fun/novelty tools (chess, dice, ISS tracker, etc.) in the tools catalog. Default: false. */
   showFunTools?: boolean;
-  /** Whether generated TTS / sound-effect audio is saved to storage as a browsable FabFile. Default: true. */
+  /** Whether generated audio (TTS, sound-effect, music) is saved to storage as a browsable FabFile. Default: true. */
   saveGeneratedAudio?: boolean;
 }
 

--- a/b4m-core/services/src/creditService/deductCreditsWithOrgSupport.test.ts
+++ b/b4m-core/services/src/creditService/deductCreditsWithOrgSupport.test.ts
@@ -330,6 +330,58 @@ describe('creditService - deductCreditsWithOrgSupport', () => {
         expect.any(Object)
       );
     });
+
+    it('should handle music_generation_usage type (quest-less, questId omitted)', async () => {
+      const params: DeductCreditsParams = {
+        type: 'music_generation_usage',
+        user: mockUser,
+        organization: null,
+        credits: 150,
+        sessionId: 'session1',
+        model: 'music_v1',
+        source: 'api',
+      };
+
+      await deductCreditsWithOrgSupport(params, mockAdapters);
+
+      const [calledWith] = mockSubtractCredits.mock.calls.at(-1)!;
+      expect(calledWith).toMatchObject({
+        type: 'music_generation_usage',
+        ownerId: 'user1',
+        ownerType: CreditHolderType.User,
+        credits: 150,
+      });
+      // Quest-less: no questId key is forwarded for music generation.
+      expect('questId' in calledWith).toBe(false);
+    });
+
+    it('should bill the org pool and track userDetails for org-billed music generation', async () => {
+      const params: DeductCreditsParams = {
+        type: 'music_generation_usage',
+        user: mockUser,
+        organization: mockOrganization,
+        credits: 150,
+        sessionId: 'session1',
+        model: 'music_v1',
+        source: 'api',
+      };
+
+      await deductCreditsWithOrgSupport(params, mockAdapters);
+
+      expect(mockOrgRepo.updateUserDetails).toHaveBeenCalledWith(
+        'org1',
+        'user1',
+        expect.objectContaining({ creditsDelta: 150 })
+      );
+      expect(mockSubtractCredits).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'music_generation_usage',
+          ownerId: 'org1',
+          ownerType: CreditHolderType.Organization,
+        }),
+        expect.any(Object)
+      );
+    });
   });
 
   describe('error handling', () => {

--- a/b4m-core/services/src/creditService/deductCreditsWithOrgSupport.ts
+++ b/b4m-core/services/src/creditService/deductCreditsWithOrgSupport.ts
@@ -86,6 +86,15 @@ export interface DeductSoundEffectsCreditsParams extends DeductCreditsCommonPara
 }
 
 /**
+ * Parameters for music-generation credit deduction. Quest-less, like sound
+ * effects: music generation is a stateless API call with only a synthetic
+ * sessionId, so it extends the common base rather than the quest-scoped one.
+ */
+export interface DeductMusicGenerationCreditsParams extends DeductCreditsCommonParams {
+  type: 'music_generation_usage';
+}
+
+/**
  * Union type of all deduction parameter types
  */
 export type DeductCreditsParams =
@@ -93,7 +102,8 @@ export type DeductCreditsParams =
   | DeductImageEditCreditsParams
   | DeductVideoGenerationCreditsParams
   | DeductTextGenerationCreditsParams
-  | DeductSoundEffectsCreditsParams;
+  | DeductSoundEffectsCreditsParams
+  | DeductMusicGenerationCreditsParams;
 
 /**
  * Database adapters required for credit deduction.
@@ -196,6 +206,9 @@ export async function deductCreditsWithOrgSupport(
   } else if (type === 'sound_effects_usage') {
     // Quest-less: sound effects has no questId.
     transactionParams = { ...baseParams, type: 'sound_effects_usage' };
+  } else if (type === 'music_generation_usage') {
+    // Quest-less: music generation has no questId.
+    transactionParams = { ...baseParams, type: 'music_generation_usage' };
   } else {
     // Quest-scoped image/edit/video types; questId is guaranteed by their param shape.
     transactionParams = {

--- a/b4m-core/services/src/creditService/subtractCredits.test.ts
+++ b/b4m-core/services/src/creditService/subtractCredits.test.ts
@@ -584,4 +584,57 @@ describe('creditService - subtractCredits', () => {
       });
     });
   });
+
+  describe('music_generation_usage transactions', () => {
+    it('writes a NEGATIVE ledger row so a charge is never recorded as a credit', async () => {
+      mockCreditHolderMethods.incrementCredits.mockResolvedValue(mockUser);
+
+      const parameters: SubtractCreditsParameters = {
+        type: 'music_generation_usage',
+        ownerId: 'user1',
+        ownerType: CreditHolderType.User,
+        credits: 75,
+        model: 'music_v1',
+        sessionId: 'music-u1-1',
+        source: 'api',
+      };
+
+      await subtractCredits(parameters, mockAdapters);
+
+      // Sign is the whole point: the route already moved the balance, so a positive
+      // row here would make the ledger disagree with the balance in the customer's favour.
+      expect(mockCreditTransactionRepo.createTransaction).toHaveBeenCalledWith('music_generation_usage', {
+        ownerId: 'user1',
+        ownerType: CreditHolderType.User,
+        credits: -75,
+        description: 'Music generation usage',
+        metadata: undefined,
+        source: 'api',
+        model: 'music_v1',
+        sessionId: 'music-u1-1',
+      });
+    });
+
+    it('bills the organization pool when the owner is an organization', async () => {
+      mockCreditHolderMethods.incrementCredits.mockResolvedValue(mockOrganization);
+
+      await subtractCredits(
+        {
+          type: 'music_generation_usage',
+          ownerId: 'org1',
+          ownerType: CreditHolderType.Organization,
+          credits: 200,
+          model: 'music_v1',
+          sessionId: 'music-u1-2',
+        },
+        mockAdapters
+      );
+
+      expect(mockCreditHolderMethods.incrementCredits).toHaveBeenCalledWith('org1', -200);
+      expect(mockCreditTransactionRepo.createTransaction).toHaveBeenCalledWith(
+        'music_generation_usage',
+        expect.objectContaining({ ownerId: 'org1', ownerType: CreditHolderType.Organization, credits: -200 })
+      );
+    });
+  });
 });

--- a/b4m-core/services/src/creditService/subtractCredits.ts
+++ b/b4m-core/services/src/creditService/subtractCredits.ts
@@ -11,6 +11,7 @@ import {
   SpeechToTextUsageTransaction,
   TextToSpeechUsageTransaction,
   SoundEffectsUsageTransaction,
+  MusicGenerationUsageTransaction,
   TextGenerationUsageTransaction,
   ToolUsageTransaction,
   TransferCreditTransaction,
@@ -58,6 +59,7 @@ export const SubtractCreditsSchema = z.discriminatedUnion('type', [
   SpeechToTextUsageTransaction.omit({ createdAt: true, updatedAt: true }),
   TextToSpeechUsageTransaction.omit({ createdAt: true, updatedAt: true }),
   SoundEffectsUsageTransaction.omit({ createdAt: true, updatedAt: true }),
+  MusicGenerationUsageTransaction.omit({ createdAt: true, updatedAt: true }),
   TransferCreditTransaction.omit({ createdAt: true, updatedAt: true }),
 ]);
 
@@ -201,6 +203,17 @@ export async function subtractCredits(
       ownerType,
       credits: -Math.abs(credits),
       description: description || 'Sound effects usage',
+      metadata,
+      source,
+      model: params.model,
+      sessionId: params.sessionId,
+    });
+  } else if (type === 'music_generation_usage') {
+    await db.creditTransactions.createTransaction('music_generation_usage', {
+      ownerId,
+      ownerType,
+      credits: -Math.abs(credits),
+      description: description || 'Music generation usage',
       metadata,
       source,
       model: params.model,

--- a/b4m-core/services/src/index.ts
+++ b/b4m-core/services/src/index.ts
@@ -37,6 +37,7 @@ export * as adminSettingsService from './adminSettingsService';
 export * as creditService from './creditService';
 export * from './billing';
 export * from './soundCost';
+export * from './musicCost';
 export * as emailIngestionService from './emailIngestionService';
 export * as emailAnalysisService from './emailAnalysisService';
 export * as mementoService from './mementoService';

--- a/b4m-core/services/src/llm/musicCostCalculator/ElevenLabsMusicCostCalculator.ts
+++ b/b4m-core/services/src/llm/musicCostCalculator/ElevenLabsMusicCostCalculator.ts
@@ -1,0 +1,22 @@
+import { DEFAULT_MUSIC_LENGTH_MS } from '@bike4mind/common';
+import { MusicCost, MusicCostCalculator } from './types';
+
+/**
+ * ElevenLabs music pricing. Billed by generated track length at $0.15/minute
+ * when billed directly (vs. $0.12/min for sound effects). Because the route
+ * forces the requested length on the provider, the generated length always
+ * equals the length billed here - there is no vendor auto-duration to reconcile.
+ * See https://elevenlabs.io/pricing/api.
+ */
+const USD_PER_SECOND = 0.15 / 60; // $0.0025
+
+export interface ElevenLabsMusicCostInput {
+  lengthMs?: number;
+}
+
+export class ElevenLabsMusicCostCalculator implements MusicCostCalculator<ElevenLabsMusicCostInput> {
+  getCost(input: ElevenLabsMusicCostInput): MusicCost {
+    const billedSeconds = (input.lengthMs ?? DEFAULT_MUSIC_LENGTH_MS) / 1000;
+    return { usdCost: billedSeconds * USD_PER_SECOND, billedSeconds };
+  }
+}

--- a/b4m-core/services/src/llm/musicCostCalculator/types.ts
+++ b/b4m-core/services/src/llm/musicCostCalculator/types.ts
@@ -1,0 +1,22 @@
+import { ElevenLabsMusicCostInput } from './ElevenLabsMusicCostCalculator';
+
+export type MusicCostInput = ElevenLabsMusicCostInput;
+
+/** Raw provider cost of one music generation. */
+export interface MusicCost {
+  /** Provider cost in USD. */
+  usdCost: number;
+  /**
+   * Effective track length billed, in seconds. Drives usage-event analytics
+   * `units`, so it must match what the cost was actually computed on.
+   */
+  billedSeconds: number;
+}
+
+/**
+ * Computes the raw provider cost of a single music generation.
+ * Conversion to internal credits happens downstream via `usdToCredits`.
+ */
+export interface MusicCostCalculator<T extends MusicCostInput> {
+  getCost(input: T): MusicCost;
+}

--- a/b4m-core/services/src/musicCost/index.test.ts
+++ b/b4m-core/services/src/musicCost/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { computeMusicUsdCost, estimateMusicCredits, UnsupportedMusicVendorError } from './index';
+
+describe('computeMusicUsdCost (elevenlabs)', () => {
+  it('bills a custom length at $0.15/minute', () => {
+    // 60s => 1 min => $0.15
+    expect(computeMusicUsdCost('elevenlabs', { lengthMs: 60000 })).toBeCloseTo(0.15, 6);
+    // 30s => $0.075
+    expect(computeMusicUsdCost('elevenlabs', { lengthMs: 30000 })).toBeCloseTo(0.075, 6);
+  });
+
+  it('bills an omitted length at the default clip length (10s)', () => {
+    // 10s * $0.0025/s = $0.025
+    expect(computeMusicUsdCost('elevenlabs', {})).toBeCloseTo(10 * (0.15 / 60), 6);
+  });
+
+  it('throws for an unknown vendor', () => {
+    expect(() => computeMusicUsdCost('nope' as 'elevenlabs', {})).toThrow(UnsupportedMusicVendorError);
+  });
+});
+
+describe('estimateMusicCredits', () => {
+  it('converts USD to credits (round-up, min 1) at the platform rate', () => {
+    // $0.075 * 2000 credits/USD = 150 credits
+    expect(estimateMusicCredits('elevenlabs', { lengthMs: 30000 })).toEqual({
+      requiredCredits: 150,
+      usdCost: expect.closeTo(0.075, 6),
+      billedSeconds: 30,
+    });
+  });
+
+  it('reports the default clip length as billedSeconds when no length is given', () => {
+    // billedSeconds must match what the cost was computed on, so usage-event
+    // units stay consistent with costUsd.
+    const { billedSeconds, usdCost } = estimateMusicCredits('elevenlabs', {});
+    expect(billedSeconds).toBeCloseTo(10, 6);
+    expect(usdCost).toBeCloseTo(10 * (0.15 / 60), 6);
+  });
+
+  it('never charges below 1 credit', () => {
+    const { requiredCredits } = estimateMusicCredits('elevenlabs', { lengthMs: 3000 });
+    expect(requiredCredits).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/b4m-core/services/src/musicCost/index.test.ts
+++ b/b4m-core/services/src/musicCost/index.test.ts
@@ -37,8 +37,24 @@ describe('estimateMusicCredits', () => {
     expect(usdCost).toBeCloseTo(10 * (0.15 / 60), 6);
   });
 
+  it('rounds a fractional credit cost UP rather than down or to nearest', () => {
+    // 3050ms -> $0.0076250 -> 15.25 raw credits. The only nearby length whose raw
+    // value discriminates ceil (16) from round/floor (15), so it is what actually
+    // pins the rounding mode - every whole-second length looks identical.
+    expect(estimateMusicCredits('elevenlabs', { lengthMs: 3050 }).requiredCredits).toBe(16);
+  });
+
   it('never charges below 1 credit', () => {
+    // The shortest accepted clip must still cost something, or a caller can drive
+    // real provider spend for free.
     const { requiredCredits } = estimateMusicCredits('elevenlabs', { lengthMs: 3000 });
+    expect(requiredCredits).toBe(15);
     expect(requiredCredits).toBeGreaterThanOrEqual(1);
+  });
+
+  it('throws for an unknown vendor rather than estimating zero', () => {
+    expect(() => estimateMusicCredits('nope' as 'elevenlabs', { lengthMs: 30000 })).toThrow(
+      UnsupportedMusicVendorError
+    );
   });
 });

--- a/b4m-core/services/src/musicCost/index.ts
+++ b/b4m-core/services/src/musicCost/index.ts
@@ -1,0 +1,50 @@
+import {
+  MusicGenerationVendor,
+  UnprocessableEntityError,
+  // From common, NOT @bike4mind/utils: keep this module free of the utils
+  // barrel's server-only deps so a future client-side cost preview can import it.
+  usdToCredits,
+} from '@bike4mind/common';
+import { ElevenLabsMusicCostCalculator } from '../llm/musicCostCalculator/ElevenLabsMusicCostCalculator';
+import { MusicCost, MusicCostInput } from '../llm/musicCostCalculator/types';
+
+/** Thrown when no cost calculator exists for a vendor. */
+export class UnsupportedMusicVendorError extends Error {
+  constructor(vendor: string) {
+    super(`Music generation vendor not supported: ${vendor}`);
+    this.name = 'UnsupportedMusicVendorError';
+  }
+}
+
+/** Resolves the vendor's cost calculator and computes cost + billed length. */
+function getMusicCost(vendor: MusicGenerationVendor, input: MusicCostInput): MusicCost {
+  switch (vendor) {
+    case 'elevenlabs':
+      return new ElevenLabsMusicCostCalculator().getCost(input);
+    default:
+      throw new UnsupportedMusicVendorError(vendor);
+  }
+}
+
+/** Raw provider cost (USD) for one music generation. */
+export function computeMusicUsdCost(vendor: MusicGenerationVendor, input: MusicCostInput): number {
+  return getMusicCost(vendor, input).usdCost;
+}
+
+/**
+ * Estimates the credit cost of a music generation: provider USD cost converted
+ * to internal credits (deterministic round-up, min 1). `usdCost` and
+ * `billedSeconds` are carried through for usage-event analytics (COGS + units);
+ * billing uses `requiredCredits`.
+ */
+export function estimateMusicCredits(
+  vendor: MusicGenerationVendor,
+  input: MusicCostInput
+): { requiredCredits: number; usdCost: number; billedSeconds: number } {
+  const { usdCost, billedSeconds } = getMusicCost(vendor, input);
+  const requiredCredits = usdToCredits(usdCost);
+  if (!Number.isFinite(requiredCredits)) {
+    throw new UnprocessableEntityError(`Unable to compute credit cost for music vendor "${vendor}" (got ${usdCost}).`);
+  }
+  return { requiredCredits, usdCost, billedSeconds };
+}

--- a/b4m-core/utils/src/index.ts
+++ b/b4m-core/utils/src/index.ts
@@ -73,6 +73,7 @@ export type { ImageEditResponse } from './imageGeneration';
 export * from './voiceGeneration';
 export * from './videoGeneration';
 export * from './soundGeneration';
+export * from './musicGeneration';
 export * from './analytics';
 export * from './user';
 export * from './pricing';

--- a/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.test.ts
+++ b/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.test.ts
@@ -1,8 +1,18 @@
 import { Logger } from '@bike4mind/observability';
 import { describe, expect, it, vi } from 'vitest';
-import { ElevenLabsMusicGenerator } from './ElevenLabsMusicGenerator';
+import { ElevenLabsMusicGenerator, MUSIC_GENERATION_TIMEOUT_MS } from './ElevenLabsMusicGenerator';
 
 const logger = { error: vi.fn() } as unknown as Logger;
+
+// The hosted serving function's own cap (infra/web.ts). The provider deadline
+// must stay strictly under it - that ordering IS the credit-loss guarantee.
+const SERVING_FUNCTION_TIMEOUT_MS = 60_000;
+
+/** Never settles on its own; only the caller's AbortSignal can end it. */
+const hangingFetch: typeof fetch = (_url, init) =>
+  new Promise((_resolve, reject) => {
+    init?.signal?.addEventListener('abort', () => reject((init.signal as AbortSignal).reason));
+  });
 
 function mockFetch(body: string, ok = true, status = 200): typeof fetch {
   const bytes = new TextEncoder().encode(body);
@@ -52,15 +62,41 @@ describe('ElevenLabsMusicGenerator', () => {
     expect(JSON.parse(init.body)).toEqual({ prompt: 'ambient pad', model_id: 'music_v1' });
   });
 
-  it('arms an abort signal so a slow provider round-trip cannot outlive the serving function', async () => {
+  it('aborts a stalled provider round-trip so the route can refund the reservation', async () => {
+    const generator = new ElevenLabsMusicGenerator({
+      apiKey: 'secret',
+      logger,
+      fetchImpl: hangingFetch,
+      timeoutMs: 20,
+    });
+
+    // A signal that never fires (or fires after the function is dead) destroys the
+    // reservation instead of refunding it, so assert the deadline actually elapses -
+    // not merely that some AbortSignal was attached.
+    await expect(generator.generate('drone')).rejects.toMatchObject({ name: 'TimeoutError' });
+  }, // Short ceiling: the 20ms deadline should fire instantly, so a regression that
+  // disarms the signal fails fast instead of stalling the suite for the default 5s.
+  2_000);
+
+  it('arms the default deadline, and that deadline fits inside the serving function budget', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
     const fetchImpl = mockFetch('x');
     const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl });
 
     await generator.generate('drone');
 
-    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    // The route's catch/refund path only runs if the fetch can reject on timeout.
-    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(timeoutSpy).toHaveBeenCalledWith(MUSIC_GENERATION_TIMEOUT_MS);
+    // Raising the constant past the function cap silently reintroduces the
+    // charge-without-refund hole, so pin the relationship, not just the value.
+    expect(MUSIC_GENERATION_TIMEOUT_MS).toBeLessThan(SERVING_FUNCTION_TIMEOUT_MS);
+    timeoutSpy.mockRestore();
+  });
+
+  it('throws on an empty 200 body so a 0-byte track is never billed or persisted', async () => {
+    const fetchImpl = mockFetch('');
+    const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl });
+
+    await expect(generator.generate('silence')).rejects.toThrow(/returned no audio/);
   });
 
   it('maps the requested output format to the right content type', async () => {
@@ -72,6 +108,26 @@ describe('ElevenLabsMusicGenerator', () => {
     const [url] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(url).toContain('output_format=pcm_44100');
     expect(result.contentType).toBe('audio/L16');
+  });
+
+  it.each([
+    ['opus_48000_128', 'audio/opus'],
+    ['ulaw_8000', 'audio/basic'],
+    ['not_a_codec', 'application/octet-stream'],
+  ])('maps %s to %s', async (format, expected) => {
+    const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl: mockFetch('x') });
+
+    expect((await generator.generate('beep', { format })).contentType).toBe(expected);
+  });
+
+  it('forwards forceInstrumental: false rather than dropping it as falsy', async () => {
+    const fetchImpl = mockFetch('x');
+    const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl });
+
+    await generator.generate('vocal track', { forceInstrumental: false });
+
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body).force_instrumental).toBe(false);
   });
 
   it('throws with the upstream status and body on a non-ok response', async () => {

--- a/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.test.ts
+++ b/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.test.ts
@@ -1,0 +1,72 @@
+import { Logger } from '@bike4mind/observability';
+import { describe, expect, it, vi } from 'vitest';
+import { ElevenLabsMusicGenerator } from './ElevenLabsMusicGenerator';
+
+const logger = { error: vi.fn() } as unknown as Logger;
+
+function mockFetch(body: string, ok = true, status = 200): typeof fetch {
+  const bytes = new TextEncoder().encode(body);
+  return vi.fn(async () => ({
+    ok,
+    status,
+    arrayBuffer: async () => bytes.buffer,
+    text: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+describe('ElevenLabsMusicGenerator', () => {
+  it('throws when constructed without an API key', () => {
+    expect(() => new ElevenLabsMusicGenerator({ apiKey: '', logger })).toThrow(/API key is required/);
+  });
+
+  it('POSTs to the music endpoint with the api key, prompt, model, and length', async () => {
+    const fetchImpl = mockFetch('music-bytes');
+    const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl });
+
+    const result = await generator.generate('lofi hip hop beat', { lengthMs: 30000, forceInstrumental: true });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain('https://api.elevenlabs.io/v1/music');
+    expect(url).toContain('output_format=mp3_44100_128');
+    expect(init.method).toBe('POST');
+    expect(init.headers['xi-api-key']).toBe('secret');
+    expect(JSON.parse(init.body)).toEqual({
+      prompt: 'lofi hip hop beat',
+      model_id: 'music_v1',
+      music_length_ms: 30000,
+      force_instrumental: true,
+    });
+
+    expect(result.contentType).toBe('audio/mpeg');
+    expect(result.audio.toString()).toBe('music-bytes');
+  });
+
+  it('defaults the model and omits optional params when not provided', async () => {
+    const fetchImpl = mockFetch('x');
+    const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl });
+
+    await generator.generate('ambient pad');
+
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ prompt: 'ambient pad', model_id: 'music_v1' });
+  });
+
+  it('maps the requested output format to the right content type', async () => {
+    const fetchImpl = mockFetch('x');
+    const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl });
+
+    const result = await generator.generate('beep', { format: 'pcm_44100' });
+
+    const [url] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain('output_format=pcm_44100');
+    expect(result.contentType).toBe('audio/L16');
+  });
+
+  it('throws with the upstream status and body on a non-ok response', async () => {
+    const fetchImpl = mockFetch('quota exceeded', false, 401);
+    const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl });
+
+    await expect(generator.generate('boom')).rejects.toThrow(/failed: 401 quota exceeded/);
+  });
+});

--- a/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.test.ts
+++ b/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.test.ts
@@ -52,6 +52,17 @@ describe('ElevenLabsMusicGenerator', () => {
     expect(JSON.parse(init.body)).toEqual({ prompt: 'ambient pad', model_id: 'music_v1' });
   });
 
+  it('arms an abort signal so a slow provider round-trip cannot outlive the serving function', async () => {
+    const fetchImpl = mockFetch('x');
+    const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl });
+
+    await generator.generate('drone');
+
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    // The route's catch/refund path only runs if the fetch can reject on timeout.
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it('maps the requested output format to the right content type', async () => {
     const fetchImpl = mockFetch('x');
     const generator = new ElevenLabsMusicGenerator({ apiKey: 'secret', logger, fetchImpl });

--- a/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.ts
+++ b/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.ts
@@ -5,6 +5,13 @@ import { GeneratedMusic, MusicGenerationOptions, MusicGenerator } from './types'
 const MUSIC_GENERATION_ENDPOINT = 'https://api.elevenlabs.io/v1/music';
 const DEFAULT_OUTPUT_FORMAT = 'mp3_44100_128';
 
+// The provider round-trip runs inside a 60s-capped serving function while a
+// credit reservation is already debited. Abort with headroom (leaving room for
+// the surrounding reserve/settle/persist work) so a slow provider surfaces as a
+// rejected fetch - which the route's catch refunds - instead of the process
+// being killed mid-call with the charge applied and no refund.
+const MUSIC_GENERATION_TIMEOUT_MS = 45_000;
+
 /** Maps an ElevenLabs `output_format` token to its MIME type. */
 function contentTypeForFormat(format: string): string {
   if (format.startsWith('mp3')) return 'audio/mpeg';
@@ -59,6 +66,7 @@ export class ElevenLabsMusicGenerator implements MusicGenerator {
         ...(options.lengthMs !== undefined ? { music_length_ms: options.lengthMs } : {}),
         ...(options.forceInstrumental !== undefined ? { force_instrumental: options.forceInstrumental } : {}),
       }),
+      signal: AbortSignal.timeout(MUSIC_GENERATION_TIMEOUT_MS),
     });
 
     if (!res.ok) {

--- a/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.ts
+++ b/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.ts
@@ -1,0 +1,73 @@
+import { DEFAULT_MUSIC_MODEL_ID } from '@bike4mind/common';
+import { Logger } from '@bike4mind/observability';
+import { GeneratedMusic, MusicGenerationOptions, MusicGenerator } from './types';
+
+const MUSIC_GENERATION_ENDPOINT = 'https://api.elevenlabs.io/v1/music';
+const DEFAULT_OUTPUT_FORMAT = 'mp3_44100_128';
+
+/** Maps an ElevenLabs `output_format` token to its MIME type. */
+function contentTypeForFormat(format: string): string {
+  if (format.startsWith('mp3')) return 'audio/mpeg';
+  if (format.startsWith('opus')) return 'audio/opus';
+  if (format.startsWith('pcm')) return 'audio/L16';
+  if (format.startsWith('ulaw')) return 'audio/basic';
+  return 'application/octet-stream';
+}
+
+export interface ElevenLabsMusicGeneratorConfig {
+  apiKey: string;
+  logger: Logger;
+  /** Injectable HTTP client; defaults to the global `fetch`. Overridden in tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Generates background music via the ElevenLabs `POST /v1/music` API.
+ * See https://elevenlabs.io/docs/api-reference/music.
+ *
+ * `music_length_ms` is always sent when a length is provided so the generated
+ * track length is deterministic and matches what the caller was billed for.
+ */
+export class ElevenLabsMusicGenerator implements MusicGenerator {
+  private readonly apiKey: string;
+  private readonly logger: Logger;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: ElevenLabsMusicGeneratorConfig) {
+    if (!config.apiKey) {
+      throw new Error('ElevenLabs API key is required for music generation');
+    }
+    this.apiKey = config.apiKey;
+    this.logger = config.logger;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  async generate(prompt: string, options: MusicGenerationOptions = {}): Promise<GeneratedMusic> {
+    const format = options.format ?? DEFAULT_OUTPUT_FORMAT;
+    const url = new URL(MUSIC_GENERATION_ENDPOINT);
+    url.searchParams.set('output_format', format);
+
+    const res = await this.fetchImpl(url.toString(), {
+      method: 'POST',
+      headers: {
+        'xi-api-key': this.apiKey,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        prompt,
+        model_id: options.modelId ?? DEFAULT_MUSIC_MODEL_ID,
+        ...(options.lengthMs !== undefined ? { music_length_ms: options.lengthMs } : {}),
+        ...(options.forceInstrumental !== undefined ? { force_instrumental: options.forceInstrumental } : {}),
+      }),
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      this.logger.error('ElevenLabs music generation failed', { status: res.status, detail });
+      throw new Error(`ElevenLabs music generation failed: ${res.status} ${detail}`);
+    }
+
+    const audio = Buffer.from(await res.arrayBuffer());
+    return { audio, contentType: contentTypeForFormat(format) };
+  }
+}

--- a/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.ts
+++ b/b4m-core/utils/src/musicGeneration/ElevenLabsMusicGenerator.ts
@@ -5,12 +5,18 @@ import { GeneratedMusic, MusicGenerationOptions, MusicGenerator } from './types'
 const MUSIC_GENERATION_ENDPOINT = 'https://api.elevenlabs.io/v1/music';
 const DEFAULT_OUTPUT_FORMAT = 'mp3_44100_128';
 
-// The provider round-trip runs inside a 60s-capped serving function while a
-// credit reservation is already debited. Abort with headroom (leaving room for
-// the surrounding reserve/settle/persist work) so a slow provider surfaces as a
-// rejected fetch - which the route's catch refunds - instead of the process
-// being killed mid-call with the charge applied and no refund.
-const MUSIC_GENERATION_TIMEOUT_MS = 45_000;
+/**
+ * Default provider-fetch deadline. The round-trip runs inside a time-capped
+ * serving function (60s on hosted; see infra/web.ts) while a credit reservation
+ * is already debited. Aborting with headroom - leaving room for the surrounding
+ * reserve/settle/persist work - makes a slow provider surface as a rejected
+ * fetch, which the route's catch refunds, instead of the process being killed
+ * mid-call with the charge applied and no refund.
+ *
+ * Overridable per-instance via `timeoutMs` so a deployment without that cap
+ * (self-host) isn't bound by a hosted-infra number.
+ */
+export const MUSIC_GENERATION_TIMEOUT_MS = 45_000;
 
 /** Maps an ElevenLabs `output_format` token to its MIME type. */
 function contentTypeForFormat(format: string): string {
@@ -26,6 +32,8 @@ export interface ElevenLabsMusicGeneratorConfig {
   logger: Logger;
   /** Injectable HTTP client; defaults to the global `fetch`. Overridden in tests. */
   fetchImpl?: typeof fetch;
+  /** Provider-fetch deadline; defaults to MUSIC_GENERATION_TIMEOUT_MS. */
+  timeoutMs?: number;
 }
 
 /**
@@ -39,6 +47,7 @@ export class ElevenLabsMusicGenerator implements MusicGenerator {
   private readonly apiKey: string;
   private readonly logger: Logger;
   private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
 
   constructor(config: ElevenLabsMusicGeneratorConfig) {
     if (!config.apiKey) {
@@ -47,6 +56,7 @@ export class ElevenLabsMusicGenerator implements MusicGenerator {
     this.apiKey = config.apiKey;
     this.logger = config.logger;
     this.fetchImpl = config.fetchImpl ?? fetch;
+    this.timeoutMs = config.timeoutMs ?? MUSIC_GENERATION_TIMEOUT_MS;
   }
 
   async generate(prompt: string, options: MusicGenerationOptions = {}): Promise<GeneratedMusic> {
@@ -66,7 +76,7 @@ export class ElevenLabsMusicGenerator implements MusicGenerator {
         ...(options.lengthMs !== undefined ? { music_length_ms: options.lengthMs } : {}),
         ...(options.forceInstrumental !== undefined ? { force_instrumental: options.forceInstrumental } : {}),
       }),
-      signal: AbortSignal.timeout(MUSIC_GENERATION_TIMEOUT_MS),
+      signal: AbortSignal.timeout(this.timeoutMs),
     });
 
     if (!res.ok) {
@@ -76,6 +86,12 @@ export class ElevenLabsMusicGenerator implements MusicGenerator {
     }
 
     const audio = Buffer.from(await res.arrayBuffer());
+    // A truncated/empty 200 must fail here so the route refunds the reservation,
+    // rather than settling the full charge and persisting a 0-byte file.
+    if (audio.length === 0) {
+      this.logger.error('ElevenLabs music generation returned an empty body', { status: res.status });
+      throw new Error('ElevenLabs music generation returned no audio');
+    }
     return { audio, contentType: contentTypeForFormat(format) };
   }
 }

--- a/b4m-core/utils/src/musicGeneration/index.test.ts
+++ b/b4m-core/utils/src/musicGeneration/index.test.ts
@@ -1,0 +1,17 @@
+import { Logger } from '@bike4mind/observability';
+import { describe, expect, it, vi } from 'vitest';
+import { ElevenLabsMusicGenerator } from './ElevenLabsMusicGenerator';
+import { aiMusicService } from './index';
+
+const logger = { error: vi.fn() } as unknown as Logger;
+
+describe('aiMusicService', () => {
+  it('returns an ElevenLabs generator for the elevenlabs vendor', () => {
+    expect(aiMusicService('elevenlabs', 'key', logger)).toBeInstanceOf(ElevenLabsMusicGenerator);
+  });
+
+  it('throws for an unknown vendor', () => {
+    // Cast past the type guard to exercise the runtime default branch.
+    expect(() => aiMusicService('nope' as 'elevenlabs', 'key', logger)).toThrow(/Unknown music generation vendor/);
+  });
+});

--- a/b4m-core/utils/src/musicGeneration/index.ts
+++ b/b4m-core/utils/src/musicGeneration/index.ts
@@ -1,0 +1,32 @@
+import { MusicGenerationVendor } from '@bike4mind/common';
+import { Logger } from '@bike4mind/observability';
+import { ElevenLabsMusicGenerator } from './ElevenLabsMusicGenerator';
+import { MusicGenerator } from './types';
+
+export * from './types';
+export { ElevenLabsMusicGenerator } from './ElevenLabsMusicGenerator';
+export type { ElevenLabsMusicGeneratorConfig } from './ElevenLabsMusicGenerator';
+
+export interface MusicGeneratorOptions {
+  /** Injectable HTTP client forwarded to the vendor implementation (tests). */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Resolves the {@link MusicGenerator} for a vendor. Adding a provider means
+ * adding a case here plus a vendor entry in `supportedMusicGenerationVendor` --
+ * callers depend only on the `MusicGenerator` interface (open/closed).
+ */
+export function aiMusicService(
+  vendor: MusicGenerationVendor,
+  apiKey: string,
+  logger: Logger,
+  options: MusicGeneratorOptions = {}
+): MusicGenerator {
+  switch (vendor) {
+    case 'elevenlabs':
+      return new ElevenLabsMusicGenerator({ apiKey, logger, fetchImpl: options.fetchImpl });
+    default:
+      throw new Error(`Unknown music generation vendor: ${vendor}`);
+  }
+}

--- a/b4m-core/utils/src/musicGeneration/types.ts
+++ b/b4m-core/utils/src/musicGeneration/types.ts
@@ -1,0 +1,27 @@
+import { MusicModel } from '@bike4mind/common';
+
+export interface MusicGenerationOptions {
+  /** Target track length in ms. The provider clamps to its own 3s-600s range. */
+  lengthMs?: number;
+  /** When true, ask the provider for an instrumental (no vocals) track. */
+  forceInstrumental?: boolean;
+  /** Provider model id (e.g. ElevenLabs `music_v1`). */
+  modelId?: MusicModel;
+  /** Provider-specific output encoding token (e.g. ElevenLabs `mp3_44100_128`). */
+  format?: string;
+}
+
+export interface GeneratedMusic {
+  audio: Buffer;
+  /** MIME type of `audio`, derived from the requested output format. */
+  contentType: string;
+}
+
+/**
+ * Turns a text prompt into a background-music track. Deliberately a single
+ * method so vendors that only generate (and don't edit/stream) aren't forced
+ * to stub out methods they can't support.
+ */
+export interface MusicGenerator {
+  generate(prompt: string, options?: MusicGenerationOptions): Promise<GeneratedMusic>;
+}

--- a/b4m-core/utils/src/musicGeneration/types.ts
+++ b/b4m-core/utils/src/musicGeneration/types.ts
@@ -1,7 +1,8 @@
 import { MusicModel } from '@bike4mind/common';
 
 export interface MusicGenerationOptions {
-  /** Target track length in ms. The provider clamps to its own 3s-600s range. */
+  /** Target track length in ms. Bounded by the route to fit the serving-function
+   * budget (see MAX_MUSIC_LENGTH_MS); the provider's own range is 3s-600s. */
   lengthMs?: number;
   /** When true, ask the provider for an instrumental (no vocals) track. */
   forceInstrumental?: boolean;

--- a/b4m-core/utils/src/soundGeneration/ElevenLabsSoundGenerator.test.ts
+++ b/b4m-core/utils/src/soundGeneration/ElevenLabsSoundGenerator.test.ts
@@ -1,8 +1,18 @@
 import { Logger } from '@bike4mind/observability';
 import { describe, expect, it, vi } from 'vitest';
-import { ElevenLabsSoundGenerator } from './ElevenLabsSoundGenerator';
+import { ElevenLabsSoundGenerator, SOUND_GENERATION_TIMEOUT_MS } from './ElevenLabsSoundGenerator';
 
 const logger = { error: vi.fn() } as unknown as Logger;
+
+// The hosted serving function's own cap (infra/web.ts). The provider deadline
+// must stay strictly under it - that ordering IS the credit-loss guarantee.
+const SERVING_FUNCTION_TIMEOUT_MS = 60_000;
+
+/** Never settles on its own; only the caller's AbortSignal can end it. */
+const hangingFetch: typeof fetch = (_url, init) =>
+  new Promise((_resolve, reject) => {
+    init?.signal?.addEventListener('abort', () => reject((init.signal as AbortSignal).reason));
+  });
 
 function mockFetch(body: string, ok = true, status = 200): typeof fetch {
   const bytes = new TextEncoder().encode(body);
@@ -63,5 +73,27 @@ describe('ElevenLabsSoundGenerator', () => {
     const generator = new ElevenLabsSoundGenerator({ apiKey: 'secret', logger, fetchImpl });
 
     await expect(generator.generate('boom')).rejects.toThrow(/failed: 401 quota exceeded/);
+  });
+
+  it('aborts a stalled provider round-trip so the route can refund the reservation', async () => {
+    const generator = new ElevenLabsSoundGenerator({
+      apiKey: 'secret',
+      logger,
+      fetchImpl: hangingFetch,
+      timeoutMs: 20,
+    });
+
+    await expect(generator.generate('rain')).rejects.toMatchObject({ name: 'TimeoutError' });
+  }, 2_000);
+
+  it('arms the default deadline, and that deadline fits inside the serving function budget', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const generator = new ElevenLabsSoundGenerator({ apiKey: 'secret', logger, fetchImpl: mockFetch('x') });
+
+    await generator.generate('rain');
+
+    expect(timeoutSpy).toHaveBeenCalledWith(SOUND_GENERATION_TIMEOUT_MS);
+    expect(SOUND_GENERATION_TIMEOUT_MS).toBeLessThan(SERVING_FUNCTION_TIMEOUT_MS);
+    timeoutSpy.mockRestore();
   });
 });

--- a/b4m-core/utils/src/soundGeneration/ElevenLabsSoundGenerator.ts
+++ b/b4m-core/utils/src/soundGeneration/ElevenLabsSoundGenerator.ts
@@ -13,11 +13,22 @@ function contentTypeForFormat(format: string): string {
   return 'application/octet-stream';
 }
 
+/**
+ * Default provider-fetch deadline. Same reasoning as the music generator's
+ * MUSIC_GENERATION_TIMEOUT_MS: /api/ai/sound-effects debits a credit reservation
+ * before this call and runs inside a time-capped serving function, so without a
+ * deadline a slow provider kills the process with the charge applied and no
+ * refund. Aborting lets the route's catch refund instead.
+ */
+export const SOUND_GENERATION_TIMEOUT_MS = 45_000;
+
 export interface ElevenLabsSoundGeneratorConfig {
   apiKey: string;
   logger: Logger;
   /** Injectable HTTP client; defaults to the global `fetch`. Overridden in tests. */
   fetchImpl?: typeof fetch;
+  /** Provider-fetch deadline; defaults to SOUND_GENERATION_TIMEOUT_MS. */
+  timeoutMs?: number;
 }
 
 /**
@@ -28,6 +39,7 @@ export class ElevenLabsSoundGenerator implements SoundGenerator {
   private readonly apiKey: string;
   private readonly logger: Logger;
   private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
 
   constructor(config: ElevenLabsSoundGeneratorConfig) {
     if (!config.apiKey) {
@@ -36,6 +48,7 @@ export class ElevenLabsSoundGenerator implements SoundGenerator {
     this.apiKey = config.apiKey;
     this.logger = config.logger;
     this.fetchImpl = config.fetchImpl ?? fetch;
+    this.timeoutMs = config.timeoutMs ?? SOUND_GENERATION_TIMEOUT_MS;
   }
 
   async generate(text: string, options: SoundGenerationOptions = {}): Promise<GeneratedSound> {
@@ -54,6 +67,7 @@ export class ElevenLabsSoundGenerator implements SoundGenerator {
         ...(options.durationSeconds !== undefined ? { duration_seconds: options.durationSeconds } : {}),
         ...(options.promptInfluence !== undefined ? { prompt_influence: options.promptInfluence } : {}),
       }),
+      signal: AbortSignal.timeout(this.timeoutMs),
     });
 
     if (!res.ok) {

--- a/packages/database/src/models/billing/CreditTransactionModel.test.ts
+++ b/packages/database/src/models/billing/CreditTransactionModel.test.ts
@@ -210,6 +210,7 @@ describe('CreditTransactionRepository.sourceUsageForOwner', () => {
     'speech_to_text_usage',
     'text_to_speech_usage',
     'sound_effects_usage',
+    'music_generation_usage',
   ];
 
   it('counts every AI usage type', async () => {

--- a/packages/database/src/models/billing/CreditTransactionModel.ts
+++ b/packages/database/src/models/billing/CreditTransactionModel.ts
@@ -51,6 +51,7 @@ const CreditTransactionSchema = new Schema<ICreditTransactionDocument>(
         'speech_to_text_usage',
         'text_to_speech_usage',
         'sound_effects_usage',
+        'music_generation_usage',
         'transfer_credit',
         'received_credit',
       ],


### PR DESCRIPTION
## Description

Adds an AI **background-music generation** capability (`POST /api/ai/music`), backed by ElevenLabs' Music API, following the same provider-agnostic pattern already used for **sound-effects** and **TTS**. A user provides a text prompt (plus optional length / instrumental flags) and gets back a generated music track persisted as an `AUDIO` FabFile, with credits reserved/settled/refunded and a usage event recorded.

This is the **backend HTTP capability** only. The in-chat / agent `music_generation` LLM tool is the follow-up (#1161) and now has everything it needs to call.

Closes #1160

## Changes

**Provider-agnostic core**
- `b4m-core/common/src/musicGeneration.ts` — `supportedMusicGenerationVendor`, `musicRequestSchema` (`prompt`, `lengthMs` 3s–120s, `forceInstrumental?`, `modelId?`, `format?`), `DEFAULT_MUSIC_LENGTH_MS`
- `b4m-core/utils/src/musicGeneration/` — `MusicGenerator` interface, `aiMusicService()` factory, `ElevenLabsMusicGenerator` (`POST /v1/music`)

**Credits & analytics**
- New `music_generation_usage` credit transaction type + `music_generation` usage feature, wired through every sync surface (credit-transaction union + `CREDIT_DEDUCT_TRANSACTION_TYPES`, DB model enum + model test, `subtractCredits`, `deductCreditsWithOrgSupport`, `CreditAnalyticsTabContent`)
- `b4m-core/services/src/musicCost/` + `ElevenLabsMusicCostCalculator` — bills by generated length at **$0.15/min** (confirmed against ElevenLabs' API pricing page), converted to credits via `usdToCredits`

**Route & persistence**
- `apps/client/pages/api/ai/music.ts` — reserve → generate → settle → refund-on-failure → record usage → persist. Scope-gated `AI_GENERATE`; org-vs-user billing precedence identical to sound-effects; returns `X-B4M-Audio-*` headers
- `persistGeneratedAudio` gains a `'music'` source (`KnowledgeType.AUDIO`)

## Guide for Testers

Backend-only; the natural way to exercise it is the HTTP route. Requires an ElevenLabs API key configured (user key or admin fallback).

1. Obtain a JWT for a test user (log in to `app.staging.bike4mind.com`, copy the token from `localStorage`).
2. Ensure an ElevenLabs key is configured: **Sidebar → Settings → API Keys** (or an admin-level ElevenLabs key). Without one, step 4 should return **HTTP 503** `No elevenlabs API key configured`.
3. POST a generation request:
   ```
   curl -X POST https://app.staging.bike4mind.com/api/ai/music \
     -H "Authorization: Bearer <JWT>" \
     -H "Content-Type: application/json" \
     -d '{"prompt":"calm lofi hip hop for studying","lengthMs":15000}' \
     --output music.mp3 -D headers.txt
   ```
   Expected: **HTTP 200**, `music.mp3` is a playable ~15s track, and `headers.txt` contains `X-B4M-Audio-Saved: true` plus `X-B4M-Audio-Fab-File-Id` / `X-B4M-Audio-File-Url`.
4. Confirm the track is browsable: **Sidebar → Knowledge** — a new generated audio file named like `music-calm-lofi-...mp3` appears and plays.
5. Confirm billing (with `enforceCredits` on): **Profile → Credits/Analytics** shows a **Music Generation** deduction, and the ledger has a `music_generation_usage` row. A 15s track at $0.15/min ≈ $0.0375 ≈ ~75 credits.
6. Validation: POST `{"prompt":"x","lengthMs":500}` → **HTTP 422** (below the 3s minimum). POST `{"prompt":"x","lengthMs":120001}` → **HTTP 422** (above the 120s cap). POST `{"prompt":""}` → **HTTP 422**.

### Regression Checks
1. `POST /api/ai/sound-effects` and `POST /api/ai/tts` still generate, persist, and bill correctly (shared `persistGeneratedAudio` + credit-deduction paths were touched).
2. **Profile → Credits/Analytics** still renders every existing usage series (a new "Music Generation" line only appears once music usage exists).

### What NOT to test
- No UI surface for triggering music generation ships in this PR (that's #1161) — only the HTTP route, persistence, credits, and analytics wiring.
- Provider-side audio quality / prompt fidelity is ElevenLabs' concern, not this PR's.

## Additional Information

Billing note: `lengthMs` is defaulted at the schema boundary and **forced on the provider**, so the generated track length always equals the reserved/settled charge — deterministic reserve/settle with no vendor auto-duration to reconcile (sound-effects, which lets ElevenLabs auto-pick, back-bills a default instead). Cost is computed regardless of `enforceCredits` so analytics capture true COGS on credits-off / self-host deploys.

Length cap: `lengthMs` tops out at **120s**, not the provider's own 600s ceiling. Generation runs inside a time-capped serving function whose provider fetch carries a 45s abort deadline, so the cap only avoids accepting lengths that would predictably hit that abort. The abort - not the cap - is what makes an over-budget request fail safe (reservation refunded). Conservative and provisional: worth raising once real ElevenLabs generation latency is measured. Both generators (music and sound-effects) take an injectable `timeoutMs`, so a self-host deploy without the function cap is not bound by the hosted number.

## Developer Notes

- `aiMusicService(vendor, apiKey, logger)` is the open/closed factory boundary — a second provider drops in with one `case` + one vendor enum entry, no changes past the `MusicGenerator` interface.
- `music_generation_usage` follows the quest-less deduction shape (`DeductMusicGenerationCreditsParams`), reusable by the #1161 tool path.
- Usage-event/ledger rows record `provider: 'elevenlabs'` + `model: 'music_v1'` (a real model id), unlike sound-effects which conflates the two.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made the UI/UX feel good (N/A — backend-only)
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (N/A — no new AdminSettings)

