### PR TITLE
feat(organizations): group-type + capability resolution (#1235, #1234)

### DIFF
--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -16,6 +16,7 @@ import { leave } from './leave';
 import { setOrganizationGroupTypes } from './setOrganizationGroupTypes';
 import { assignUserToGroup, removeUserFromGroup, renameGroup, assertCanManageOrgGroups } from './groupMembership';
 import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
+import { resolveCapabilitiesForUser, userHasCapability } from './resolveCapabilitiesForUser';
 
 export {
   search,
@@ -40,6 +41,8 @@ export {
   removeUserFromGroup,
   renameGroup,
   resolveGroupTypesForUser,
+  resolveCapabilitiesForUser,
+  userHasCapability,
 };
 
 export type { SearchParameters };

--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -15,6 +15,7 @@ import { revokeAccess } from './revokeAccess';
 import { leave } from './leave';
 import { setOrganizationGroupTypes } from './setOrganizationGroupTypes';
 import { assignUserToGroup, removeUserFromGroup, renameGroup, assertCanManageOrgGroups } from './groupMembership';
+import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
 
 export {
   search,
@@ -38,6 +39,7 @@ export {
   assertCanManageOrgGroups,
   removeUserFromGroup,
   renameGroup,
+  resolveGroupTypesForUser,
 };
 
 export type { SearchParameters };

--- a/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.test.ts
+++ b/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { IGroupDocument, IOrganizationDocument, IUserDocument } from '@bike4mind/common';
+
+// The real GROUP_TYPE_CATALOG carries no `capabilities` (those are product-specific and live in the
+// consuming overlay, not open core), so override the lookup with generic test capabilities to
+// exercise the union logic. Keys stay generic - no customer name - per the catalog's own rule.
+vi.mock('@bike4mind/common', async importOriginal => {
+  const actual = await importOriginal<typeof import('@bike4mind/common')>();
+  const TEST_CATALOG: Record<
+    string,
+    { key: string; label: string; description: string; priority: number; capabilities?: string[] }
+  > = {
+    sales: { key: 'sales', label: 'Sales', description: '', priority: 10, capabilities: ['crm:read', 'sales:brief'] },
+    research: {
+      key: 'research',
+      label: 'Research',
+      description: '',
+      priority: 20,
+      capabilities: ['qwork:submit', 'crm:read'],
+    },
+    customer: { key: 'customer', label: 'Customer', description: '', priority: 30, capabilities: [] },
+  };
+  return {
+    ...actual,
+    getGroupType: (key: string) => TEST_CATALOG[key],
+    isKnownGroupType: (key: string) => key in TEST_CATALOG,
+  };
+});
+
+import { resolveCapabilitiesForUser, userHasCapability } from './resolveCapabilitiesForUser';
+
+const ORG = 'org-1';
+const OWNER = 'owner-1';
+
+const group = (id: string, type: string): IGroupDocument =>
+  ({ id, type, organizationId: ORG, name: type, description: '' }) as unknown as IGroupDocument;
+
+const user = (id: string, groups: string[] | null): Pick<IUserDocument, 'id' | 'groups'> => ({ id, groups });
+
+const org = (over: Partial<{ userId: string; allowedGroupTypes: string[] }> = {}): IOrganizationDocument =>
+  ({
+    id: ORG,
+    userId: over.userId ?? OWNER,
+    allowedGroupTypes: over.allowedGroupTypes ?? [],
+  }) as unknown as IOrganizationDocument;
+
+function makeAdapters(organization: IOrganizationDocument | null, orgGroups: IGroupDocument[]) {
+  const findById = vi.fn().mockResolvedValue(organization);
+  const findByOrganization = vi.fn().mockResolvedValue(orgGroups);
+  return {
+    adapters: { db: { organizations: { findById }, groups: { findByOrganization } } },
+    findById,
+    findByOrganization,
+  };
+}
+
+describe('resolveCapabilitiesForUser (#1234)', () => {
+  it('unions capabilities across the group types a member holds (deduped, sorted)', async () => {
+    const { adapters } = makeAdapters(org(), [group('g-sales', 'sales'), group('g-research', 'research')]);
+    // sales -> crm:read, sales:brief ; research -> qwork:submit, crm:read ; union deduped + sorted.
+    await expect(
+      resolveCapabilitiesForUser({ user: user('member-1', ['g-sales', 'g-research']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['crm:read', 'qwork:submit', 'sales:brief']);
+  });
+
+  it('fail-closed: a plain member in no group resolves to the empty set', async () => {
+    const { adapters } = makeAdapters(org(), [group('g-sales', 'sales')]);
+    await expect(
+      resolveCapabilitiesForUser({ user: user('member-1', []), organizationId: ORG }, adapters)
+    ).resolves.toEqual([]);
+  });
+
+  it('fail-closed: a missing / soft-deleted org resolves to empty and never queries groups', async () => {
+    const { adapters, findByOrganization } = makeAdapters(null, []);
+    await expect(
+      resolveCapabilitiesForUser({ user: user('member-1', ['g-sales']), organizationId: ORG }, adapters)
+    ).resolves.toEqual([]);
+    expect(findByOrganization).not.toHaveBeenCalled();
+  });
+
+  it('a group type conferring no capabilities contributes nothing', async () => {
+    const { adapters } = makeAdapters(org(), [group('g-customer', 'customer')]);
+    await expect(
+      resolveCapabilitiesForUser({ user: user('member-1', ['g-customer']), organizationId: ORG }, adapters)
+    ).resolves.toEqual([]);
+  });
+
+  describe('billing-owner implicit hold (#1226)', () => {
+    it("grants the union of the org's GRANTED types even when the owner is in no group", async () => {
+      // Owner is never a users[] row, so they hold no groups; they implicitly hold allowedGroupTypes.
+      const { adapters } = makeAdapters(org({ allowedGroupTypes: ['sales', 'research'] }), []);
+      await expect(
+        resolveCapabilitiesForUser({ user: user(OWNER, []), organizationId: ORG }, adapters)
+      ).resolves.toEqual(['crm:read', 'qwork:submit', 'sales:brief']);
+    });
+
+    it('is the allowedGroupTypes set, NOT the whole catalog', async () => {
+      // Granted only `sales` -> owner gets sales caps only, never research/customer.
+      const { adapters } = makeAdapters(org({ allowedGroupTypes: ['sales'] }), []);
+      await expect(
+        resolveCapabilitiesForUser({ user: user(OWNER, []), organizationId: ORG }, adapters)
+      ).resolves.toEqual(['crm:read', 'sales:brief']);
+    });
+
+    it('ignores an unknown / retired key in allowedGroupTypes', async () => {
+      const { adapters } = makeAdapters(org({ allowedGroupTypes: ['sales', 'retired:x'] }), []);
+      await expect(
+        resolveCapabilitiesForUser({ user: user(OWNER, []), organizationId: ORG }, adapters)
+      ).resolves.toEqual(['crm:read', 'sales:brief']);
+    });
+
+    it('does NOT grant the implicit set to a non-owner member', async () => {
+      // Same org, granted sales+research, but this user is neither the owner nor in any group.
+      const { adapters } = makeAdapters(org({ allowedGroupTypes: ['sales', 'research'] }), [group('g-sales', 'sales')]);
+      await expect(
+        resolveCapabilitiesForUser({ user: user('member-1', []), organizationId: ORG }, adapters)
+      ).resolves.toEqual([]);
+    });
+  });
+
+  describe('userHasCapability gate', () => {
+    it('is true for a capability the user holds and false otherwise', async () => {
+      const { adapters } = makeAdapters(org(), [group('g-sales', 'sales')]);
+      const params = { user: user('member-1', ['g-sales']), organizationId: ORG };
+      await expect(userHasCapability({ ...params, capability: 'crm:read' }, adapters)).resolves.toBe(true);
+      await expect(userHasCapability({ ...params, capability: 'qwork:submit' }, adapters)).resolves.toBe(false);
+    });
+
+    it('is false (fail-closed) for a user in no group', async () => {
+      const { adapters } = makeAdapters(org(), [group('g-sales', 'sales')]);
+      await expect(
+        userHasCapability({ user: user('member-1', []), organizationId: ORG, capability: 'crm:read' }, adapters)
+      ).resolves.toBe(false);
+    });
+  });
+});

--- a/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.ts
+++ b/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.ts
@@ -1,0 +1,79 @@
+import {
+  IGroupRepository,
+  IOrganizationRepository,
+  IUserDocument,
+  getGroupType,
+  isKnownGroupType,
+} from '@bike4mind/common';
+import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
+
+interface CapabilityAdapters {
+  db: {
+    organizations: Pick<IOrganizationRepository, 'findById'>;
+    groups: Pick<IGroupRepository, 'findByOrganization'>;
+  };
+}
+
+type CapabilityUser = Pick<IUserDocument, 'id' | 'groups'>;
+
+/**
+ * Resolve the CAPABILITY set a user holds within an organization (org-groups #1234).
+ *
+ * `GroupTypeDefinition.capabilities` is the product-behaviour axis a group type confers; until this
+ * layer, holding a type conferred nothing beyond document ACL sharing. A user's capabilities are the
+ * UNION of what each of their group types confers (decided #1234): most-permissive-wins, and
+ * monotonic - adding a group never removes access. Group assignment is already authority-gated
+ * (`assertCanManageOrgGroups`) and audited, so a mis-assignment over-granting is acceptable and
+ * debuggable, unlike a ceiling that would silently clamp.
+ *
+ * Fail-closed: a user in no group (and not the billing owner) resolves to the EMPTY set - never a
+ * default grant. A missing or soft-deleted org (findById -> null) is likewise empty.
+ *
+ * Billing-owner exception (decided #1226; lives HERE, not in the membership invariant): the owner is
+ * never a `users[]` row, so the group write-path invariant can never assign them to a group and they
+ * would otherwise be locked out of their own org's capabilities. `organization.userId === user.id`
+ * implicitly holds every type the org is GRANTED (`allowedGroupTypes`) - not the whole catalog. This
+ * is a resolution-layer read only; it does NOT relax `groupMembership.ts` invariant (2) (#1227/#1231).
+ *
+ * Keys stay generic (never a customer name) per GROUP_TYPE_CATALOG - product-specific keys live in
+ * the consuming overlay. Returns a sorted, de-duplicated array (a serialisable shape for a client seam).
+ */
+export async function resolveCapabilitiesForUser(
+  { user, organizationId }: { user: CapabilityUser; organizationId: string },
+  adapters: CapabilityAdapters
+): Promise<string[]> {
+  const organization = await adapters.db.organizations.findById(organizationId);
+  if (!organization) return [];
+
+  const effectiveTypes = new Set(
+    await resolveGroupTypesForUser({ user, organizationId }, { db: { groups: adapters.db.groups } })
+  );
+
+  // Billing-owner implicit hold: every GRANTED type (allowedGroupTypes), not the whole catalog.
+  if (organization.userId === user.id) {
+    for (const type of organization.allowedGroupTypes ?? []) {
+      if (isKnownGroupType(type)) effectiveTypes.add(type);
+    }
+  }
+
+  const capabilities = new Set<string>();
+  for (const type of effectiveTypes) {
+    for (const capability of getGroupType(type)?.capabilities ?? []) {
+      capabilities.add(capability);
+    }
+  }
+  return [...capabilities].sort();
+}
+
+/**
+ * Server-side capability gate - the stable seam a consumer calls to key behaviour off group
+ * membership. Thin boolean wrapper over `resolveCapabilitiesForUser` so call sites read as an
+ * authorization check rather than an array-membership test.
+ */
+export async function userHasCapability(
+  { user, organizationId, capability }: { user: CapabilityUser; organizationId: string; capability: string },
+  adapters: CapabilityAdapters
+): Promise<boolean> {
+  const capabilities = await resolveCapabilitiesForUser({ user, organizationId }, adapters);
+  return capabilities.includes(capability);
+}

--- a/b4m-core/services/src/organizationService/resolveGroupTypesForUser.test.ts
+++ b/b4m-core/services/src/organizationService/resolveGroupTypesForUser.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { IGroupDocument, IUserDocument } from '@bike4mind/common';
+import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
+
+const ORG = 'org-1';
+
+// Minimal live-group shape as findByOrganization returns it (plain objects with the `id` virtual).
+const group = (id: string, type: string, organizationId = ORG): IGroupDocument =>
+  ({ id, type, organizationId, name: type, description: '' }) as unknown as IGroupDocument;
+
+const user = (groups: string[] | null): Pick<IUserDocument, 'groups'> => ({ groups });
+
+function makeAdapters(orgGroups: IGroupDocument[]) {
+  const findByOrganization = vi.fn().mockResolvedValue(orgGroups);
+  return { adapters: { db: { groups: { findByOrganization } } }, findByOrganization };
+}
+
+describe('resolveGroupTypesForUser (#1235)', () => {
+  it('returns [] and never queries when the user has no groups', async () => {
+    const { adapters, findByOrganization } = makeAdapters([]);
+    await expect(resolveGroupTypesForUser({ user: user([]), organizationId: ORG }, adapters)).resolves.toEqual([]);
+    await expect(resolveGroupTypesForUser({ user: user(null), organizationId: ORG }, adapters)).resolves.toEqual([]);
+    expect(findByOrganization).not.toHaveBeenCalled();
+  });
+
+  it("maps the user's group ids to the catalog type keys of the org's live groups", async () => {
+    const { adapters } = makeAdapters([group('g-sales', 'sales'), group('g-research', 'research')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-sales', 'g-research']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['sales', 'research']);
+  });
+
+  it('sorts by catalog priority (lower first), not membership order', async () => {
+    // customer=30, sales=10 -> sales must come first regardless of the order held.
+    const { adapters } = makeAdapters([group('g-customer', 'customer'), group('g-sales', 'sales')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-customer', 'g-sales']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['sales', 'customer']);
+  });
+
+  it('excludes group ids the user holds that do not belong to this org (cross-tenant / stale)', async () => {
+    // The org only has the sales group; the user also carries a foreign id not returned by this org.
+    const { adapters } = makeAdapters([group('g-sales', 'sales')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-sales', 'g-other-org']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['sales']);
+  });
+
+  it('drops a group whose type is not in the catalog (e.g. a retired type)', async () => {
+    const { adapters } = makeAdapters([group('g-sales', 'sales'), group('g-legacy', 'optihashi:compute')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-sales', 'g-legacy']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['sales']);
+  });
+
+  it('returns membership only for groups the user is actually in', async () => {
+    // Org has both types, but the user is only in research.
+    const { adapters } = makeAdapters([group('g-sales', 'sales'), group('g-research', 'research')]);
+    await expect(
+      resolveGroupTypesForUser({ user: user(['g-research']), organizationId: ORG }, adapters)
+    ).resolves.toEqual(['research']);
+  });
+});

--- a/b4m-core/services/src/organizationService/resolveGroupTypesForUser.ts
+++ b/b4m-core/services/src/organizationService/resolveGroupTypesForUser.ts
@@ -1,0 +1,48 @@
+import { IGroupRepository, IUserDocument, getGroupType, isKnownGroupType } from '@bike4mind/common';
+
+interface ResolveGroupTypesAdapters {
+  db: {
+    groups: Pick<IGroupRepository, 'findByOrganization'>;
+  };
+}
+
+/**
+ * Resolve which GROUP-TYPE keys a user holds WITHIN one organization (org-groups #1235).
+ *
+ * `user.groups[]` stores bare Group ids with no type or org qualifier, so a consumer that wants
+ * "is this user in the org's `sales` group" cannot answer from the user doc alone. This is the
+ * single primitive the epic promises core will supply: it loads the org's LIVE groups
+ * (`findByOrganization` excludes soft-deleted rows) and maps the user's membership to catalog
+ * type keys. Scoping through the org's own groups is what makes the result org-qualified - a user
+ * carrying another tenant's group ids in `user.groups` contributes nothing here.
+ *
+ * Returns the DISTINCT known type keys, sorted by catalog `priority` (lower first) - the order a
+ * multi-type landing card menu uses (#137). Unknown keys (a `Group.type` not in GROUP_TYPE_CATALOG,
+ * e.g. a retired type) are dropped, so the result is always a valid subset of the catalog.
+ *
+ * Membership only, and deliberately side-effect-free: it confers nothing by itself. Capability
+ * resolution and the billing-owner implicit-hold are layered on top in #1234, NOT here, so this
+ * mirrors the hardened write-path invariant's org scoping without duplicating its authorization.
+ */
+export async function resolveGroupTypesForUser(
+  { user, organizationId }: { user: Pick<IUserDocument, 'groups'>; organizationId: string },
+  adapters: ResolveGroupTypesAdapters
+): Promise<string[]> {
+  const memberGroupIds = new Set(user.groups ?? []);
+  if (memberGroupIds.size === 0) return [];
+
+  const orgGroups = await adapters.db.groups.findByOrganization(organizationId);
+
+  const types = new Set<string>();
+  for (const group of orgGroups) {
+    if (memberGroupIds.has(group.id) && isKnownGroupType(group.type)) {
+      types.add(group.type);
+    }
+  }
+
+  return [...types].sort((a, b) => {
+    const pa = getGroupType(a)?.priority ?? Number.MAX_SAFE_INTEGER;
+    const pb = getGroupType(b)?.priority ?? Number.MAX_SAFE_INTEGER;
+    return pa - pb || a.localeCompare(b);
+  });
+}


### PR DESCRIPTION
## Description

The capability spine for the Org Groups epic (#1172), as one unit — two tightly-coupled commits, since the first is a primitive the second builds directly on and nothing else consumes yet.

### #1235 — `resolveGroupTypesForUser` (group-type resolution)
`user.groups[]` stores bare Group ids with no type or org qualifier, so nothing downstream can answer "is this user in the org's `sales` group". This loads the org's **live** groups (`findByOrganization` excludes soft-deleted) and maps the user's membership to `GROUP_TYPE_CATALOG` type keys — distinct, sorted by catalog `priority`, unknown/foreign keys dropped. Scoping through the org's own groups is what makes the result org-qualified. Membership only, side-effect-free.

### #1234 — `resolveCapabilitiesForUser` + `userHasCapability` (capability resolution)
`GroupTypeDefinition.capabilities` was declared and **read by nothing**. This resolves the **union** of capabilities across the group types a user holds (via the resolver above): most-permissive-wins, monotonic (adding a group never removes access — a ceiling was rejected as non-monotonic).
- **Fail-closed** — a plain member in no group, and a missing/soft-deleted org, resolve to the empty set, never a default grant.
- **Billing-owner exception (#1226), resolution-layer only** — `organization.userId === user.id` implicitly holds every **granted** type (`allowedGroupTypes`, not the whole catalog), since the owner is never a `users[]` row and the write-path invariant can't assign them a group. Does **not** relax `groupMembership.ts` invariant (2) (#1227/#1231).
- **`userHasCapability`** — the thin server-side gate seam consumers call.

Keys stay generic per `GROUP_TYPE_CATALOG`; product-specific keys live in the consuming overlay. Both resolvers return sorted, de-duplicated arrays (serialisable for a future client seam).

## Changes
- `resolveGroupTypesForUser.ts` (+ test) — group-type resolution.
- `resolveCapabilitiesForUser.ts` (+ test) — capability union, billing-owner exception, `userHasCapability`.
- Export all three from `organizationService/index.ts`.

## Guide for Testers

Pure resolution layer — **no runtime consumer yet** (the first ones are #1178 and overlay #137), so there is **no UI or endpoint to exercise and nothing to e2e here**. Verification is the unit suites:
1. `pnpm --filter @bike4mind/services exec vitest run src/organizationService/resolveGroupTypesForUser.test.ts src/organizationService/resolveCapabilitiesForUser.test.ts` → `Tests 16 passed` (6 + 10).
2. `pnpm --filter @bike4mind/services typecheck:fast` → no errors.

### Regression Checks
- `pnpm --filter @bike4mind/services exec vitest run src/organizationService/` → all suites green (the only shared file touched is `index.ts`, which gains three exports).

### What NOT to test
- Any specific capability's product meaning — keys are generic; behaviour lives in the consuming overlay.
- A browser/API flow — e2e belongs to the first consumer PR (#1178 / #137), not to these resolvers.

## Developer Notes
- **New seams:** `resolveGroupTypesForUser`, `resolveCapabilitiesForUser`, `userHasCapability` — what the persona/surface work (overlay #137), the first capability consumer (#1178), and entitlement retirement (#1237) build on. Adapters are minimal repo subsets (`Pick<…,'findById'|'findByOrganization'>`), matching sibling group services.
- The core catalog ships **no** `capabilities` by design; an overlay populates them. The #1234 test mocks the catalog lookup to exercise the union with generic placeholder keys.

Closes #1235
Closes #1234
Part of #1172.
