### PR TITLE
fix(client): open Gear external CTAs in a new tab, not a popup window

### DIFF
--- a/apps/client/app/routes/gears/index.tsx
+++ b/apps/client/app/routes/gears/index.tsx
@@ -40,6 +40,7 @@ import { useFeatureEnabled } from '@client/app/hooks/useFeatureEnabled';
 import { useAdminSettingsCache } from '@client/app/hooks/useAdminSettingsCache';
 import { useFileBrowser } from '@client/app/components/Files/Browser';
 import { DataLakeIcon } from '@client/app/components/datalake/dataLakeBranding';
+import { openInNewTab } from '@client/app/utils/externalLinks';
 
 /**
  * Gears - the earned-nav progression page.
@@ -137,7 +138,7 @@ const GearsPage = () => {
       return;
     }
     if (action.startsWith('external:')) {
-      window.open(action.slice('external:'.length), '_blank', 'noopener');
+      openInNewTab(action.slice('external:'.length));
       claimStamp();
       return;
     }


### PR DESCRIPTION
## Description

Closes #1185

A Gear CTA with an `external:<url>` action opened the URL in a popup **window** instead of a **tab**. Passing any feature string to `window.open` - even just `'noopener'` - forces a popup window regardless of the `'_blank'` target; this is already documented at `apps/client/app/utils/externalLinks.ts:39-41` and contradicts the grammar documented at `apps/client/lib/gears/presentation.ts:7`, which specifies `external:<url>` as "window.open in a new tab."

A sweep of all `window.open` call sites in `apps/client` (plus `b4m-core`, `packages/premium`, `packages/cli`) found this was the only site passing a feature string - the other eleven already pass just `'_blank'` and open tabs correctly.

## Changes

- `apps/client/app/routes/gears/index.tsx`: replaced the inline `window.open(url, '_blank', 'noopener')` call with the existing `openInNewTab` helper from `app/utils/externalLinks.ts`. The helper opens a tab via a transient anchor click and applies `noopener noreferrer` at open time - strictly stronger than `window.open`'s `'noopener'`, which can't suppress the referrer without also forcing a window.

No new code was needed; this is a one-line swap to an existing, already-tested helper.

## Guide for Testers

`clidocs` ("Meet the CLI") is currently the only Gear with an `external:` CTA, so it's the one to exercise:

1. Go to **Sidebar -> Gears** (`/gears`).
2. Find the **Meet the CLI** card. Click its CTA button (`data-testid="gear-cta-clidocs"`) - labeled **Open the CLI docs** if locked, or **Open** if you've already unlocked it; either state runs the same `external:` action.
3. Expected: the docs URL (`docs.bike4mind.com/cli`) opens in a new **tab** in the same browser window, not a separate popup window.
4. In the opened tab's console, run `window.opener`. Expected: `null` (opener protection retained).

### Regression Checks

- Other Gear CTA types (`files:`, `navigate:`) are unaffected - untouched code paths.
- The other eleven `window.open` call sites in the app are unaffected - not touched by this change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings