### PR TITLE
refactor(services): remove any from processIngestedEmail

### DIFF
--- a/b4m-core/services/src/emailIngestionService/processIngestedEmail.test.ts
+++ b/b4m-core/services/src/emailIngestionService/processIngestedEmail.test.ts
@@ -178,6 +178,29 @@ describe('emailIngestionService - processIngestedEmail', () => {
       expect(result.emailId).toBe('existing123');
       expect(mockAdapters.db.ingestedEmails.create).not.toHaveBeenCalled();
     });
+
+    it('should collapse a null fabFileId to undefined when returning stored attachments', async () => {
+      const existingEmail = {
+        id: 'existing123',
+        messageId: '<msg123@example.com>',
+        threadId: 'thread123',
+        attachments: [
+          { filename: 'no-fabfile.pdf', mimeType: 'application/pdf', size: 1000, fabFileId: null },
+          { filename: 'ok.png', mimeType: 'image/png', size: 22, fabFileId: 'fab456' },
+        ],
+        bodyFabFileId: 'fab123',
+      };
+
+      vi.mocked(mockAdapters.db.ingestedEmails.findByMessageId).mockResolvedValue(existingEmail as any);
+      vi.mocked(mockAdapters.db.ingestedEmails.findById).mockResolvedValue(existingEmail as any);
+
+      const result = await processIngestedEmail(mockParsedEmail, 's3://bucket/email.eml', mockAdapters);
+
+      expect(result.attachments).toEqual([
+        { filename: 'no-fabfile.pdf', mimeType: 'application/pdf', size: 1000, fabFileId: undefined },
+        { filename: 'ok.png', mimeType: 'image/png', size: 22, fabFileId: 'fab456' },
+      ]);
+    });
   });
 
   describe('Thread ID Generation', () => {

--- a/b4m-core/services/src/emailIngestionService/processIngestedEmail.ts
+++ b/b4m-core/services/src/emailIngestionService/processIngestedEmail.ts
@@ -4,10 +4,12 @@ import { UnauthorizedError } from '@bike4mind/utils';
 import { validateSenderAuthorization, extractEmails } from './validateSender';
 import { processAttachments } from './processAttachments';
 import { processEmailBody } from './processEmailBody';
+import type { IIngestedEmailDocument } from '@bike4mind/common';
 import {
   ParsedEmailObject,
   EmailIngestionAdapters,
   IngestedEmailResult,
+  ProcessedAttachment,
   ValidatedSender,
   processIngestedEmailSchema,
 } from './types';
@@ -156,12 +158,14 @@ export async function processIngestedEmail(
   const alreadyProcessed =
     existingEmail && ((existingEmail.attachments?.length ?? 0) > 0 || existingEmail.bodyFabFileId);
 
-  let processedAttachments: any[] = [];
+  let processedAttachments: ProcessedAttachment[] = [];
   let bodyFabFileCreated = false;
 
   if (alreadyProcessed && existingEmail) {
     Logger.info('Email already processed (from previous attempt), skipping attachment/body processing');
-    processedAttachments = existingEmail.attachments || [];
+    // IEmailAttachment types fabFileId as string | null but nothing ever writes null,
+    // so collapse it here rather than widening the exported ProcessedAttachment.
+    processedAttachments = (existingEmail.attachments ?? []).map(a => ({ ...a, fabFileId: a.fabFileId ?? undefined }));
     bodyFabFileCreated = !!existingEmail.bodyFabFileId;
   } else {
     // 3. Process attachments and upload to fabFiles
@@ -201,7 +205,7 @@ export async function processIngestedEmail(
 
     // 5. Update email with fabFile information
     Logger.info('Updating email with fabFile references...');
-    const updateData: any = {
+    const updateData: Partial<IIngestedEmailDocument> = {
       attachments: processedAttachments,
     };
 


### PR DESCRIPTION
Part of #175 (reduce `any` in top offenders).

Removes the two `any` annotations in the email ingestion orchestrator:

- `processedAttachments: any[]` -> `ProcessedAttachment[]`
- `updateData: any` -> `Partial<IIngestedEmailDocument>` (the type the repository's own `update(data: Partial<T>)` expects)

Typing the first one surfaced a real mismatch: the already-processed retry path assigns `existingEmail.attachments` into a value that is returned as `ProcessedAttachment[]`. Those are two different types -- `IEmailAttachment` declares `fabFileId` as `string | null`, `ProcessedAttachment` as `string`. Nothing in the repo ever writes null (the upload-failure path omits the field, and the Mongoose schema has no `default: null`), so rather than widen the exported `ProcessedAttachment` to admit a state that never occurs, the DB's declared nullability is collapsed at the read boundary.

That one line is a genuine (tiny) runtime addition; the other two changes are type-only and erase at compile time.

## Verification
- `@bike4mind/services` typecheck clean; prettier clean; 0 `any` in the file.
- Existing suites pass: 5 files, 82 tests.
- Instrumented run confirmed the retry-path map is an identity transform on real data (same length, same keys, same values), that a forced `fabFileId: null` fixture collapses to `undefined`, and that `updateData` still carries every key it did before (`attachments`, `bodyMarkdown`, `bodyFabFileId`).
- Exercised both branches against a real Mongoose `IngestedEmail` model on an in-memory Mongo:
  - **retry path** -- a seeded row with `fabFileId: null` returns `undefined` while every other field survives, and the stored document is not rewritten.
  - **fresh path** -- real `create()` then real `update()`; read-back confirms `attachments` and `bodyMarkdown` persisted.

No preview verification: inbound email ingestion is an SQS-triggered Lambda with no HTTP or UI entry point, and the SES receipt rule is only created for the `production` and `dev` stages (`infra/emailIngestion.ts`), so no email can reach a preview stage.
