### PR TITLE
fix(files): pass session as an option to deleteMany, not chained

### DIFF
--- a/apps/client/pages/api/files/__tests__/index.test.ts
+++ b/apps/client/pages/api/files/__tests__/index.test.ts
@@ -8,33 +8,58 @@ import { createMocks } from 'node-mocks-http';
  * that a query string cannot acquire one.
  */
 
-// Collapse the baseApi().get().delete() chain and capture the GET handler.
+// Collapse the baseApi().get().delete() chain and capture both handlers.
 const mockRefs = vi.hoisted(() => ({
   getHandler: null as null | ((req: any, res: any) => unknown),
+  deleteHandler: null as null | ((req: any, res: any) => unknown),
   searchArgs: undefined as unknown[] | undefined,
+  deleteManyArgs: undefined as unknown[] | undefined,
 }));
 
 vi.mock('@server/middlewares/baseApi', () => {
   const chain: any = {
     use: () => chain,
-    delete: () => chain,
     get: (fn: any) => {
       mockRefs.getHandler = fn;
+      return chain;
+    },
+    delete: (fn: any) => {
+      mockRefs.deleteHandler = fn;
       return chain;
     },
   };
   return { baseApi: () => chain };
 });
 
-vi.mock('@bike4mind/database', () => ({
-  FabFile: class FabFile {},
-  User: class User {},
-  fabFileRepository: { __repo: 'fabFiles' },
-  userRepository: { __repo: 'users' },
-  projectRepository: { __repo: 'projects' },
-  adminSettingsRepository: { __repo: 'adminSettings' },
-  withTransaction: vi.fn(),
-}));
+const fabFileDocs = vi.hoisted(() => [{ filePath: 'a/one.png' }, { filePath: 'b/two.png' }]);
+
+vi.mock('@bike4mind/database', () => {
+  class FabFile {
+    static find = () => ({ select: () => ({ session: async () => fabFileDocs }) });
+    // Mirrors the real soft-delete plugin static: it settles to a plain Promise, not a
+    // chainable Query, so calling `.session()` on the return value throws in production
+    // (see softDeletePlugin in b4m-core/db-core/src/utils/mongo.ts). Session must be
+    // passed as an options argument instead.
+    static deleteMany = (...args: unknown[]) => {
+      mockRefs.deleteManyArgs = args;
+      return Promise.resolve({ deletedCount: fabFileDocs.length });
+    };
+  }
+  class User {
+    static findById = () => ({
+      session: async () => ({ save: vi.fn().mockResolvedValue(undefined), currentStorageSize: 0 }),
+    });
+  }
+  return {
+    FabFile,
+    User,
+    fabFileRepository: { __repo: 'fabFiles' },
+    userRepository: { __repo: 'users' },
+    projectRepository: { __repo: 'projects' },
+    adminSettingsRepository: { __repo: 'adminSettings' },
+    withTransaction: vi.fn((fn: (session: unknown) => unknown) => fn({ __fakeSession: true })),
+  };
+});
 
 vi.mock('@bike4mind/services', () => ({
   fabFilesService: {
@@ -102,5 +127,40 @@ describe('GET /api/files', () => {
     expect(params.search).toBe('invoice');
     expect(params.filters).toEqual({ type: 'pdf' });
     expect(params.pagination).toEqual({ page: '2' });
+  });
+});
+
+function invokeDelete() {
+  const { req, res } = createMocks({ method: 'DELETE', url: '/api/files' });
+  (req as any).user = { id: 'user-1' };
+  (req as any).ability = { can: () => true };
+  (req as any).logger = { error: vi.fn() };
+  return { req, res };
+}
+
+describe('DELETE /api/files', () => {
+  beforeEach(() => {
+    mockRefs.deleteManyArgs = undefined;
+  });
+
+  // Regression for the TypeError that fired in production: FabFile.deleteMany() comes from the
+  // soft-delete plugin, which resolves to a plain Promise rather than a Query, so chaining
+  // `.session(session)` onto it throws `.session is not a function`. Passing session as an
+  // options object is the only shape that both works and keeps the delete inside the transaction.
+  it('passes the session as an option to deleteMany instead of chaining it', async () => {
+    expect(mockRefs.deleteHandler).toBeTypeOf('function');
+    const { req, res } = invokeDelete();
+
+    await mockRefs.deleteHandler!(req, res);
+
+    expect(mockRefs.deleteManyArgs?.[1]).toEqual({ session: { __fakeSession: true } });
+  });
+
+  it('completes the request without throwing', async () => {
+    const { req, res } = invokeDelete();
+
+    await mockRefs.deleteHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(204);
   });
 });

--- a/apps/client/pages/api/files/__tests__/index.test.ts
+++ b/apps/client/pages/api/files/__tests__/index.test.ts
@@ -40,9 +40,12 @@ vi.mock('@bike4mind/database', () => {
     // chainable Query, so calling `.session()` on the return value throws in production
     // (see softDeletePlugin in b4m-core/db-core/src/utils/mongo.ts). Session must be
     // passed as an options argument instead.
-    static deleteMany = (...args: unknown[]) => {
-      mockRefs.deleteManyArgs = args;
-      return Promise.resolve({ deletedCount: fabFileDocs.length });
+    static deleteMany = (filter: unknown, ...rest: unknown[]) => {
+      mockRefs.deleteManyArgs = [filter, ...rest];
+      // Only the CASL-scoped accessible filter should ever reach here - a wrong/widened filter
+      // (e.g. {}) resolves 0, which the test below can tell apart from the real filter.
+      const deletedCount = filter === accessibleFilter ? fabFileDocs.length : 0;
+      return Promise.resolve({ deletedCount });
     };
   }
   class User {
@@ -72,7 +75,8 @@ vi.mock('@bike4mind/services', () => ({
 
 vi.mock('@server/utils/storage', () => ({ getFilesStorage: () => ({ getSignedUrl: vi.fn(), delete: vi.fn() }) }));
 vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn() }));
-vi.mock('@casl/mongoose', () => ({ accessibleBy: () => ({ ofType: () => ({}) }) }));
+const accessibleFilter = vi.hoisted(() => ({ __accessibleFilter: true }));
+vi.mock('@casl/mongoose', () => ({ accessibleBy: () => ({ ofType: () => accessibleFilter }) }));
 
 // Import after mocks are registered so the chain capture runs.
 import '@pages/api/files';
@@ -153,6 +157,10 @@ describe('DELETE /api/files', () => {
 
     await mockRefs.deleteHandler!(req, res);
 
+    // Both the CASL-scoped filter and the session must reach deleteMany unchanged - checking only
+    // the session option would let a widened/wrong filter (e.g. {}, matching every user's files)
+    // pass unnoticed.
+    expect(mockRefs.deleteManyArgs?.[0]).toBe(accessibleFilter);
     expect(mockRefs.deleteManyArgs?.[1]).toEqual({ session: { __fakeSession: true } });
   });
 

--- a/apps/client/pages/api/files/index.ts
+++ b/apps/client/pages/api/files/index.ts
@@ -76,7 +76,7 @@ const handler = baseApi()
 
           user.currentStorageSize = 0;
 
-          await Promise.all([user.save({ session }), FabFile.deleteMany(accessible).session(session)]);
+          await Promise.all([user.save({ session }), FabFile.deleteMany(accessible, { session })]);
 
           await Promise.all(
             filePaths.map(async filePath => {

--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -84,7 +84,7 @@ const processNotebookImport = async (
             return Quest.bulkWrite(bulkOps, { session });
           },
           deleteMany: async (filter: any) => {
-            return Quest.deleteMany(filter).session(session);
+            return Quest.deleteMany(filter, { session });
           },
         },
         knowledgeRepository: {


### PR DESCRIPTION
## Description

Closes #1232

Two call sites chained `.session(session)` onto a soft-delete-plugin `deleteMany` static, which resolves to a plain `Promise`, not a Mongoose `Query`. `Promise.prototype.session` does not exist, so both threw `TypeError: ...session is not a function` at runtime.

- `apps/client/pages/api/files/index.ts`: `FabFile.deleteMany(accessible).session(session)`, inside the `DELETE /api/files` handler (delete-all-files). **User-facing** - this operation could not previously succeed.
- `apps/client/server/s3/notebookImportComplete.ts`: `Quest.deleteMany(filter).session(session)`, in the notebook-import adapter's cleanup path.

`softDeletePlugin`'s `deleteOne`/`deleteMany` statics (`b4m-core/db-core/src/utils/mongo.ts:383-417`) both return a Promise in every branch - `BaseModel.delete`'s own comment already documents the hazard ("Pass session as an option since softDeletePlugin returns a Promise, not a Query"), so the constraint was known; these two sites predated or missed it.

A repo-wide sweep for other `.deleteMany(...).session(...)` / `.deleteOne(...).session(...)` chains on soft-delete-plugin models found no other unfixed instances.

## Changes

- Pass `session` as an options argument instead of chaining, matching the pattern already established in `BaseModel.delete`:
  - `FabFile.deleteMany(accessible, { session })`
  - `Quest.deleteMany(filter, { session })`
- Added regression coverage in `apps/client/pages/api/files/__tests__/index.test.ts` for `DELETE /api/files`:
  - Asserts the CASL-scoped `accessible` filter and the session both reach `deleteMany` unchanged (checking only the session option would let a widened/wrong filter pass unnoticed).
  - Asserts the request completes with `204` instead of throwing.
  - Verified these tests reproduce the exact production `TypeError` when the fix is reverted.

`notebookImportComplete.ts` has no existing test scaffolding (it's a full S3-event `dispatch` handler with no test file at all); adding coverage there was judged disproportionate to this one-line adapter fix and left out of scope.

## Guide for Testers

1. As a user with at least one uploaded file, open the **Profile menu > Settings**.
2. Go to the **General** tab.
3. On the **Knowledge Files** card, click the kebab (**more**, three-dot) menu.
4. Click **Delete All Files** (danger-colored item).

   <img width="1155" height="374" alt="image" src="https://github.com/user-attachments/assets/14a7cc15-2af9-4126-8e80-ad9fd3e3eb05" />

5. Confirm in the **Delete All Files** confirmation modal.
6. Expected: the modal closes and the files are gone from the list - not a `500`/`TypeError`. Before this fix, step 5 always failed with `TypeError: ...session is not a function`.

   <img width="506" height="171" alt="image" src="https://github.com/user-attachments/assets/63784d83-1dce-49d7-8427-d96b4e1d625e" />

### Regression Checks

- Other delete paths on soft-delete-plugin models (e.g. single-file delete) are unaffected - not touched by this change.
- `find`/`findOne`/`findById` chains on the same models are unaffected - the plugin only overrides `deleteOne`/`deleteMany`, so `.session()` chaining there remains valid.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
