### PR TITLE
fix(admin): show subscription owner instead of "Unknown User"

### DIFF
--- a/apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.test.tsx
+++ b/apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CssVarsProvider } from '@mui/joy/styles';
+import SubscriptionTable from './SubscriptionTable';
+import { SubscriptionData } from '../types';
+
+// Force the desktop table branch (deterministic; avoids matchMedia in jsdom).
+vi.mock('@client/app/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+
+const baseSub = (over: Partial<SubscriptionData>): SubscriptionData => ({
+  id: 'sub_1',
+  userId: 'u1',
+  priceId: 'price_1',
+  status: 'active',
+  canceledAt: null,
+  periodStartsAt: new Date('2026-01-01'),
+  periodEndsAt: new Date('2026-02-01'),
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  ...over,
+});
+
+const renderTable = (subscriptions: SubscriptionData[]) =>
+  render(
+    <CssVarsProvider>
+      <SubscriptionTable subscriptions={subscriptions} planMap={{}} />
+    </CssVarsProvider>
+  );
+
+describe('SubscriptionTable — user column (regression for #1264)', () => {
+  it("renders the owner's username/email from the API `owner` field", () => {
+    renderTable([
+      baseSub({
+        id: 'sub_a',
+        owner: { username: 'alice', email: 'alice@example.com', name: 'Alice', _id: 'u1' },
+      }),
+    ]);
+
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.queryByText('Unknown User')).not.toBeInTheDocument();
+  });
+
+  it('falls back to "Unknown User" only when the owner is absent', () => {
+    renderTable([baseSub({ id: 'sub_b', owner: undefined })]);
+
+    expect(screen.getByText('Unknown User')).toBeInTheDocument();
+  });
+});

--- a/apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.test.tsx
+++ b/apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.test.tsx
@@ -1,12 +1,20 @@
+/**
+ * Locks the User column onto the API's `owner` field. Both layouts are covered
+ * because the mobile card and desktop table read the owner independently.
+ */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { CssVarsProvider } from '@mui/joy/styles';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
 import SubscriptionTable from './SubscriptionTable';
 import { SubscriptionData } from '../types';
 
-// Force the desktop table branch (deterministic; avoids matchMedia in jsdom).
-vi.mock('@client/app/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+// Pick the layout branch directly; jsdom has no matchMedia for the real hook.
+const mocks = vi.hoisted(() => ({ isMobile: false }));
+vi.mock('@client/app/hooks/useIsMobile', () => ({ useIsMobile: () => mocks.isMobile }));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
 
 const baseSub = (over: Partial<SubscriptionData>): SubscriptionData => ({
   id: 'sub_1',
@@ -23,13 +31,20 @@ const baseSub = (over: Partial<SubscriptionData>): SubscriptionData => ({
 
 const renderTable = (subscriptions: SubscriptionData[]) =>
   render(
-    <CssVarsProvider>
+    <CssVarsProvider theme={appTheme}>
       <SubscriptionTable subscriptions={subscriptions} planMap={{}} />
     </CssVarsProvider>
   );
 
-describe('SubscriptionTable — user column (regression for #1264)', () => {
-  it("renders the owner's username/email from the API `owner` field", () => {
+describe.each([
+  { layout: 'desktop table', isMobile: false },
+  { layout: 'mobile card', isMobile: true },
+])('SubscriptionTable user column ($layout)', ({ isMobile }) => {
+  beforeEach(() => {
+    mocks.isMobile = isMobile;
+  });
+
+  it("renders the owner's username and email from the API `owner` field", () => {
     renderTable([
       baseSub({
         id: 'sub_a',
@@ -37,14 +52,14 @@ describe('SubscriptionTable — user column (regression for #1264)', () => {
       }),
     ]);
 
-    expect(screen.getByText('alice')).toBeInTheDocument();
-    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
-    expect(screen.queryByText('Unknown User')).not.toBeInTheDocument();
+    expect(screen.getByTestId('subscription-owner-username')).toHaveTextContent('alice');
+    expect(screen.getByTestId('subscription-owner-email')).toHaveTextContent('alice@example.com');
   });
 
   it('falls back to "Unknown User" only when the owner is absent', () => {
     renderTable([baseSub({ id: 'sub_b', owner: undefined })]);
 
-    expect(screen.getByText('Unknown User')).toBeInTheDocument();
+    expect(screen.getByTestId('subscription-owner-username')).toHaveTextContent('Unknown User');
+    expect(screen.getByTestId('subscription-owner-email')).toBeEmptyDOMElement();
   });
 });

--- a/apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.tsx
+++ b/apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.tsx
@@ -23,10 +23,16 @@ const SubscriptionTable = ({ subscriptions, planMap }: SubscriptionTableProps) =
               <CardContent sx={{ p: 1.5 }}>
                 <Stack spacing={0.75}>
                   <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-                    <Typography fontWeight="bold">{subscription.owner?.username || 'Unknown User'}</Typography>
+                    <Typography fontWeight="bold" data-testid="subscription-owner-username">
+                      {subscription.owner?.username || 'Unknown User'}
+                    </Typography>
                     <SubscriptionStatusChip subscription={subscription} />
                   </Stack>
-                  <Typography level="body-xs" sx={{ wordBreak: 'break-word', color: 'text.secondary' }}>
+                  <Typography
+                    level="body-xs"
+                    data-testid="subscription-owner-email"
+                    sx={{ wordBreak: 'break-word', color: 'text.secondary' }}
+                  >
                     {subscription.owner?.email}
                   </Typography>
                   <Divider />
@@ -73,8 +79,10 @@ const SubscriptionTable = ({ subscriptions, planMap }: SubscriptionTableProps) =
               <tr key={subscription.id || subscription.subscriptionId}>
                 <td>
                   <Stack>
-                    <Typography>{subscription.owner?.username || 'Unknown User'}</Typography>
-                    <Typography level="body-xs" sx={{ wordBreak: 'break-word' }}>
+                    <Typography data-testid="subscription-owner-username">
+                      {subscription.owner?.username || 'Unknown User'}
+                    </Typography>
+                    <Typography level="body-xs" data-testid="subscription-owner-email" sx={{ wordBreak: 'break-word' }}>
                       {subscription.owner?.email}
                     </Typography>
                   </Stack>

--- a/apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.tsx
+++ b/apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.tsx
@@ -23,11 +23,11 @@ const SubscriptionTable = ({ subscriptions, planMap }: SubscriptionTableProps) =
               <CardContent sx={{ p: 1.5 }}>
                 <Stack spacing={0.75}>
                   <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-                    <Typography fontWeight="bold">{subscription.user?.username || 'Unknown User'}</Typography>
+                    <Typography fontWeight="bold">{subscription.owner?.username || 'Unknown User'}</Typography>
                     <SubscriptionStatusChip subscription={subscription} />
                   </Stack>
                   <Typography level="body-xs" sx={{ wordBreak: 'break-word', color: 'text.secondary' }}>
-                    {subscription.user?.email}
+                    {subscription.owner?.email}
                   </Typography>
                   <Divider />
                   <Stack direction="row" justifyContent="space-between">
@@ -73,9 +73,9 @@ const SubscriptionTable = ({ subscriptions, planMap }: SubscriptionTableProps) =
               <tr key={subscription.id || subscription.subscriptionId}>
                 <td>
                   <Stack>
-                    <Typography>{subscription.user?.username || 'Unknown User'}</Typography>
+                    <Typography>{subscription.owner?.username || 'Unknown User'}</Typography>
                     <Typography level="body-xs" sx={{ wordBreak: 'break-word' }}>
-                      {subscription.user?.email}
+                      {subscription.owner?.email}
                     </Typography>
                   </Stack>
                 </td>

--- a/apps/client/app/components/admin/Subscriptions/types.ts
+++ b/apps/client/app/components/admin/Subscriptions/types.ts
@@ -10,7 +10,9 @@ export interface SubscriptionData {
   periodEndsAt: Date;
   createdAt: Date;
   updatedAt: Date;
-  user?: {
+  // The subscription owner (a User here — this admin view is User-scoped). The API
+  // (findWithOwnerDetails) projects the joined account under `owner`, not `user`.
+  owner?: {
     username: string;
     email: string;
     name: string;

--- a/apps/client/app/components/admin/Subscriptions/types.ts
+++ b/apps/client/app/components/admin/Subscriptions/types.ts
@@ -10,8 +10,9 @@ export interface SubscriptionData {
   periodEndsAt: Date;
   createdAt: Date;
   updatedAt: Date;
-  // The subscription owner (a User here — this admin view is User-scoped). The API
-  // (findWithOwnerDetails) projects the joined account under `owner`, not `user`.
+  // Must stay named `owner`: subscriptionRepository.findWithOwnerDetails projects the
+  // joined account under `owner`. Always the User shape here, since /api/subscriptions
+  // filters to SubscriptionOwnerType.User.
   owner?: {
     username: string;
     email: string;

--- a/apps/client/app/hooks/data/subscriptions.ts
+++ b/apps/client/app/hooks/data/subscriptions.ts
@@ -121,7 +121,7 @@ export const useGetAllSubscriptions = (
       };
       const response = await api.get<{
         subscriptions: Array<
-          IUserSubscription & { user: { username: string; email: string; name: string; _id: string } }
+          IUserSubscription & { owner: { username: string; email: string; name: string; _id: string } }
         >;
         pagination: {
           total: number;


### PR DESCRIPTION
## Description

Fixes #1264. In **Admin → Subscriptions**, the **User** column rendered **"Unknown User"** for every row.

**Root cause — API ↔ client field-name mismatch.** The `/api/subscriptions` handler ([`subscriptionRepository.findWithOwnerDetails`](apps/client/server/models/Subscription.ts)) projects the joined account under **`owner`** (`owner.username/name/email/_id`) and never emits a `user` field. The client, however, typed the response as `{ user }` and rendered `subscription.user?.username || 'Unknown User'` — so `subscription.user` was always `undefined` and the fallback showed for all rows. (Plan/Status/dates/price rendered fine because those are top-level fields.)

## Changes

Align the client onto the API's actual `owner` field. `findWithOwnerDetails` is generic over User/Organization owners (so `owner` is the correct contract), and this endpoint's only consumer is this admin view — so no server change is needed and there's zero blast radius.

- `SubscriptionData.user` → `owner` ([`types.ts`](apps/client/app/components/admin/Subscriptions/types.ts))
- `useGetAllSubscriptions` response type `user` → `owner` ([`subscriptions.ts`](apps/client/app/hooks/data/subscriptions.ts))
- `SubscriptionTable` reads `subscription.owner?` for username + email, in both the mobile-card and desktop-table layouts ([`SubscriptionTable.tsx`](apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.tsx))
- New regression test locking the `owner` field, parameterized over **both** layouts ([`SubscriptionTable.test.tsx`](apps/client/app/components/admin/Subscriptions/components/SubscriptionTable.test.tsx))
- `data-testid` on the owner username/email cells so the test selects the cell rather than matching page text (repo standard: select by `data-testid`)

## Guide for Testers

UI-verifiable in the admin panel; also covered by an automated test.

**Automated:**
```bash
# from apps/client
pnpm exec vitest run app/components/admin/Subscriptions/components/SubscriptionTable.test.tsx
```
Asserts the row renders the owner's username/email from the API `owner` field, and only falls back to "Unknown User" when the owner is genuinely absent. Both cases run against the desktop table and the mobile card, since each layout reads the owner independently.

**Manual (admin):**
1. Sign in as an admin and open **Admin → Subscriptions**.
2. Each row's **User** column should now show the real **username** (with email beneath) instead of **"Unknown User"**.
3. The search box (filters server-side on `owner.email` / `owner.name`) still returns matching rows.
4. Regression: pagination, plan, status, period, and price columns are unchanged.

## Verification
- Regression test: **4/4 pass** (2 assertions x 2 layouts)
- `pnpm --filter client typecheck`: **clean**
- ESLint + Prettier on changed files: **clean** (only the pre-existing `StatusDisplay.icon: any` warning in `types.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
