### PR TITLE
refactor(organizations): group-list route behind a service fn + correct the index comment (#1225, #1229)

### DIFF
--- a/apps/client/pages/api/organizations/[id]/groups/__tests__/index.test.ts
+++ b/apps/client/pages/api/organizations/[id]/groups/__tests__/index.test.ts
@@ -2,14 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 
 /**
- * GET /api/organizations/[id]/groups returns each group's member ids, so it is gated on the
- * MANAGE predicate rather than Permission.read: every org member holds read (addMember writes
- * `permissions: [read]`), and user ids resolve to names through the public profile route, so a
- * read gate would make group membership enumerable by any member.
- *
- * These tests pin the wiring, not the predicate - assertCanManageOrgGroups has its own coverage in
- * organizationService/groupMembership.test.ts. What is asserted here is that this handler calls it,
- * propagates its rejection, and derives memberCount from the ids it actually returns.
+ * GET /api/organizations/[id]/groups now delegates to organizationService.listOrganizationGroups,
+ * which owns the org fetch, the MANAGE authorization, and the member assembly (org-groups #1225).
+ * These tests pin only the route wiring - extract the id, delegate with the acting user, return the
+ * result, and 404 before delegating when the id is absent. The authorization and assembly behaviour
+ * is covered in organizationService/groupMembership.test.ts.
  */
 
 const mockRefs = vi.hoisted(() => ({
@@ -30,78 +27,52 @@ vi.mock('@server/middlewares/baseApi', () => {
   return { baseApi: () => chain };
 });
 
-const findById = vi.hoisted(() => vi.fn());
-const assertCanManageOrgGroups = vi.hoisted(() => vi.fn());
-const findByOrganization = vi.hoisted(() => vi.fn());
-const findUserIdsByGroupIds = vi.hoisted(() => vi.fn());
-
-vi.mock('@bike4mind/database/infra', () => ({ Organization: { findById } }));
-vi.mock('@bike4mind/database/social', () => ({ groupRepository: { findByOrganization } }));
-vi.mock('@bike4mind/database/auth', () => ({ userRepository: { findUserIdsByGroupIds } }));
-vi.mock('@bike4mind/services', () => ({ organizationService: { assertCanManageOrgGroups } }));
+const listOrganizationGroups = vi.hoisted(() => vi.fn());
+vi.mock('@bike4mind/database', () => ({ organizationRepository: {} }));
+vi.mock('@bike4mind/database/social', () => ({ groupRepository: {} }));
+vi.mock('@bike4mind/database/auth', () => ({ userRepository: {} }));
+vi.mock('@bike4mind/services', () => ({ organizationService: { listOrganizationGroups } }));
 
 import '@pages/api/organizations/[id]/groups/index';
 
-const ORG = { id: 'org1', userId: 'owner1', adminUserIds: [], users: [{ userId: 'u1' }] };
+const RESULT = [{ id: 'g1', name: 'Sales', type: 'sales', memberIds: ['u1', 'u2'], memberCount: 2 }];
 
-const call = (user: unknown) => {
-  const { req, res } = createMocks({ method: 'GET', query: { id: 'org1' } });
+// `null` = omit the id entirely (passing `undefined` would trigger the default and send 'org1').
+const call = (user: unknown, id: string | null = 'org1') => {
+  const { req, res } = createMocks({ method: 'GET', query: id === null ? {} : { id } });
   (req as any).user = user;
   return { res, promise: mockRefs.getHandler!(req, res) };
 };
 
 describe('GET /api/organizations/[id]/groups', () => {
   beforeEach(() => {
-    findById.mockReset().mockResolvedValue(ORG);
-    assertCanManageOrgGroups.mockReset();
-    findByOrganization.mockReset().mockResolvedValue([{ id: 'g1', name: 'Sales', type: 'sales' }]);
-    findUserIdsByGroupIds.mockReset().mockResolvedValue({ g1: ['u1', 'u2'] });
+    listOrganizationGroups.mockReset().mockResolvedValue(RESULT);
   });
 
-  it('authorizes through the manage predicate, passing the acting user and the org', async () => {
-    const { res, promise } = call({ id: 'owner1', isAdmin: false });
+  it('delegates to organizationService.listOrganizationGroups with the acting user and org id', async () => {
+    const user = { id: 'owner1', isAdmin: false };
+    const { res, promise } = call(user);
     await promise;
 
-    expect(assertCanManageOrgGroups).toHaveBeenCalledWith({ id: 'owner1', isAdmin: false }, ORG);
+    expect(listOrganizationGroups).toHaveBeenCalledWith(
+      user,
+      { organizationId: 'org1' },
+      expect.objectContaining({ db: expect.anything() })
+    );
     expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().groups).toEqual(RESULT);
   });
 
-  it('propagates the predicate rejection instead of returning groups', async () => {
-    assertCanManageOrgGroups.mockImplementation(() => {
-      throw new Error('Not authorized to manage this org');
-    });
+  it('propagates a service rejection (e.g. the authorization failure) instead of returning groups', async () => {
+    listOrganizationGroups.mockRejectedValue(new Error('Not authorized to manage this organization'));
 
     const { promise } = call({ id: 'plainmember', isAdmin: false });
     await expect(promise).rejects.toThrow(/Not authorized/);
-    expect(findByOrganization).not.toHaveBeenCalled();
   });
 
-  it('does not authorize or query when the organization does not exist', async () => {
-    findById.mockResolvedValue(null);
-
-    const { promise } = call({ id: 'owner1' });
+  it('404s without delegating when the id is missing', async () => {
+    const { promise } = call({ id: 'owner1' }, null);
     await expect(promise).rejects.toThrow(/Organization not found/);
-    expect(assertCanManageOrgGroups).not.toHaveBeenCalled();
-    expect(findByOrganization).not.toHaveBeenCalled();
-  });
-
-  it('derives memberCount from the ids it returns, so the two cannot disagree', async () => {
-    const { res, promise } = call({ id: 'owner1' });
-    await promise;
-
-    const [group] = res._getJSONData().groups;
-    expect(group.memberIds).toEqual(['u1', 'u2']);
-    expect(group.memberCount).toBe(2);
-  });
-
-  it('reports zero members for a group nobody is in', async () => {
-    findUserIdsByGroupIds.mockResolvedValue({});
-
-    const { res, promise } = call({ id: 'owner1' });
-    await promise;
-
-    const [group] = res._getJSONData().groups;
-    expect(group.memberIds).toEqual([]);
-    expect(group.memberCount).toBe(0);
+    expect(listOrganizationGroups).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/pages/api/organizations/[id]/groups/index.ts
+++ b/apps/client/pages/api/organizations/[id]/groups/index.ts
@@ -1,9 +1,9 @@
 // GET /api/organizations/:id/groups
 // List an organization's groups, each with its current members.
 
+import { organizationRepository } from '@bike4mind/database';
 import { groupRepository } from '@bike4mind/database/social';
 import { userRepository } from '@bike4mind/database/auth';
-import { Organization } from '@bike4mind/database/infra';
 import { organizationService } from '@bike4mind/services';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
@@ -12,27 +12,18 @@ import { NotFoundError } from '@server/utils/errors';
 const handler = baseApi().get(
   asyncHandler<{}, unknown, unknown, { id?: string }>(async (req, res) => {
     const organizationId = req.query.id;
-    const organization = organizationId && (await Organization.findById(organizationId));
-    if (!organization) throw new NotFoundError('Organization not found');
-    // The MANAGE predicate, not Permission.read: this route returns memberIds, and every org
-    // member holds read (addMember writes permissions: [read]), so a read gate would let any
-    // member enumerate who is in which group - resolvable to names via the public profile route.
-    // Shares the single predicate with the group write routes rather than re-deriving it here.
-    organizationService.assertCanManageOrgGroups(req.user, organization);
+    if (!organizationId) throw new NotFoundError('Organization not found');
 
-    const groups = await groupRepository.findByOrganization(organizationId as string);
-    // Members per group in a single aggregation (org-groups #1172, Phase 4) - one pass keyed by
-    // group id, backed by the user_groups index (no N+1 of per-group reads). The management UI
-    // needs the member ids, not just a count, to render and unassign current members - the
-    // safe-user shape carries no groups[] field, so this route is the only place that membership
-    // surfaces. memberCount is derived from the ids so the two can never disagree.
-    const membersByGroup = await userRepository.findUserIdsByGroupIds(groups.map(group => group.id));
-    const withMembers = groups.map(group => {
-      const memberIds = membersByGroup[group.id] ?? [];
-      return { ...group, memberIds, memberCount: memberIds.length };
-    });
+    // The org fetch, the MANAGE authorization (not Permission.read - the result exposes who is in
+    // which group), and the member assembly all live in the service alongside the sibling group
+    // actions (org-groups #1225). The route only extracts params and delegates.
+    const groups = await organizationService.listOrganizationGroups(
+      req.user,
+      { organizationId },
+      { db: { organizations: organizationRepository, groups: groupRepository, users: userRepository } }
+    );
 
-    return res.status(200).json({ groups: withMembers });
+    return res.status(200).json({ groups });
   })
 );
 

--- a/b4m-core/services/src/organizationService/groupMembership.test.ts
+++ b/b4m-core/services/src/organizationService/groupMembership.test.ts
@@ -1,4 +1,4 @@
-import { assignUserToGroup, removeUserFromGroup, renameGroup } from './groupMembership';
+import { assignUserToGroup, removeUserFromGroup, renameGroup, listOrganizationGroups } from './groupMembership';
 import { BadRequestError, ForbiddenError, NotFoundError } from '@bike4mind/utils';
 import { IUserDocument } from '@bike4mind/common';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -132,5 +132,53 @@ describe('group membership (assign / remove)', () => {
       await expect(rename(billingOwner)).rejects.toThrow(NotFoundError);
       expect(db.groups.update).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('listOrganizationGroups', () => {
+  const ORG = 'org-1';
+  const owner = { id: 'owner-1', isAdmin: false } as IUserDocument;
+  const outsider = { id: 'stranger-1', isAdmin: false } as IUserDocument;
+
+  const org = (over: Record<string, unknown> = {}) => ({
+    id: ORG,
+    userId: 'owner-1',
+    adminUserIds: [],
+    users: [{ userId: 'owner-1' }],
+    ...over,
+  });
+  const group = (id: string, type: string) => ({ id, type, organizationId: ORG, name: type });
+
+  let db: any;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = {
+      organizations: { findById: vi.fn().mockResolvedValue(org()) },
+      groups: {
+        findByOrganization: vi.fn().mockResolvedValue([group('g-sales', 'sales'), group('g-research', 'research')]),
+      },
+      users: { findUserIdsByGroupIds: vi.fn().mockResolvedValue({ 'g-sales': ['u1', 'u2'] }) },
+    };
+  });
+
+  it('returns each group with its member ids and a count derived from those ids', async () => {
+    const result = await listOrganizationGroups(owner, { organizationId: ORG }, { db });
+
+    expect(result).toEqual([
+      { id: 'g-sales', type: 'sales', organizationId: ORG, name: 'sales', memberIds: ['u1', 'u2'], memberCount: 2 },
+      { id: 'g-research', type: 'research', organizationId: ORG, name: 'research', memberIds: [], memberCount: 0 },
+    ]);
+    expect(db.users.findUserIdsByGroupIds).toHaveBeenCalledWith(['g-sales', 'g-research']);
+  });
+
+  it('throws NotFound when the org does not exist, before any authz or group read', async () => {
+    db.organizations.findById.mockResolvedValue(null);
+    await expect(listOrganizationGroups(owner, { organizationId: ORG }, { db })).rejects.toThrow(NotFoundError);
+    expect(db.groups.findByOrganization).not.toHaveBeenCalled();
+  });
+
+  it('rejects a caller who cannot manage the org (the MANAGE gate, not read)', async () => {
+    await expect(listOrganizationGroups(outsider, { organizationId: ORG }, { db })).rejects.toThrow(ForbiddenError);
+    expect(db.groups.findByOrganization).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/organizationService/groupMembership.ts
+++ b/b4m-core/services/src/organizationService/groupMembership.ts
@@ -22,6 +22,17 @@ interface RenameGroupAdapters {
   };
 }
 
+interface ListGroupsAdapters {
+  db: {
+    organizations: Pick<IOrganizationRepository, 'findById'>;
+    groups: Pick<IGroupRepository, 'findByOrganization'>;
+    users: Pick<IUserRepository, 'findUserIdsByGroupIds'>;
+  };
+}
+
+/** A group instance plus its current membership, for the org-admin management UI. */
+export type OrganizationGroupWithMembers = IGroupDocument & { memberIds: string[]; memberCount: number };
+
 // The org+group resolution/authorization that every group action shares. groups.update is only
 // needed by rename, so it lives on that action's adapter, not this shared subset.
 type AuthorizeAdapters = {
@@ -123,4 +134,34 @@ export async function renameGroup(
 ): Promise<IGroupDocument | null> {
   await authorizeAndValidate(actingUser, { organizationId, groupId }, adapters, false);
   return adapters.db.groups.update({ id: groupId, name });
+}
+
+/**
+ * List an org's groups, each with its current member ids + count.
+ *
+ * Gated on the MANAGE predicate, NOT `Permission.read`: the result exposes who is in which group,
+ * and every org member holds read (`addMember` writes `permissions: [read]`), so a read gate would
+ * let any member enumerate membership (resolvable to names via the public profile route). Moved off
+ * the route (#1225) so the fetch + authz + member assembly live behind the service alongside the
+ * sibling group actions, and the route is param-extraction + delegation. Fetches the org through
+ * the repository (a full document, so `assertCanManageOrgGroups` always sees `users[]`), not the
+ * raw model.
+ */
+export async function listOrganizationGroups(
+  actingUser: IUserDocument,
+  { organizationId }: { organizationId: string },
+  adapters: ListGroupsAdapters
+): Promise<OrganizationGroupWithMembers[]> {
+  const organization = await adapters.db.organizations.findById(organizationId);
+  if (!organization) throw new NotFoundError('Organization not found');
+  assertCanManageOrgGroups(actingUser, organization);
+
+  const groups = await adapters.db.groups.findByOrganization(organizationId);
+  // Member ids per group in a single aggregation (backed by the user_groups index), not an N+1 of
+  // per-group reads. memberCount is derived from the ids so the two can never disagree.
+  const membersByGroup = await adapters.db.users.findUserIdsByGroupIds(groups.map(group => group.id));
+  return groups.map(group => {
+    const memberIds = membersByGroup[group.id] ?? [];
+    return { ...group, memberIds, memberCount: memberIds.length };
+  });
 }

--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -14,7 +14,13 @@ import { listPendingUsers } from './listPendingUsers';
 import { revokeAccess } from './revokeAccess';
 import { leave } from './leave';
 import { setOrganizationGroupTypes } from './setOrganizationGroupTypes';
-import { assignUserToGroup, removeUserFromGroup, renameGroup, assertCanManageOrgGroups } from './groupMembership';
+import {
+  assignUserToGroup,
+  removeUserFromGroup,
+  renameGroup,
+  assertCanManageOrgGroups,
+  listOrganizationGroups,
+} from './groupMembership';
 import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
 import { resolveCapabilitiesForUser, userHasCapability } from './resolveCapabilitiesForUser';
 
@@ -40,6 +46,7 @@ export {
   assertCanManageOrgGroups,
   removeUserFromGroup,
   renameGroup,
+  listOrganizationGroups,
   resolveGroupTypesForUser,
   resolveCapabilitiesForUser,
   userHasCapability,

--- a/packages/database/src/models/social/GroupModel.ts
+++ b/packages/database/src/models/social/GroupModel.ts
@@ -32,7 +32,14 @@ GroupSchema.plugin(softDeletePlugin);
 
 // One LIVE group per (organization, type) - the epic's "one group per type per org in v1"
 // invariant. The partial filter scopes uniqueness to live rows so revoke (soft-delete) then
-// re-grant of the same type still works. Also serves findByOrganization (organizationId prefix).
+// re-grant of the same type still works.
+//
+// This is PARTIAL, so it does NOT serve `findByOrganization`'s `{ organizationId }` query: the
+// planner only uses a partial index for a query it can prove is a subset of the partial filter,
+// and a bare `{ organizationId }` carries no `deletedAt`/`$type` predicates, so that read is a
+// COLLSCAN (org-groups #1229). Acceptable at current volume - the collection is effectively empty
+// and org group counts are tiny by design (one per type). Add a plain `{ organizationId: 1 }`
+// index here if group usage ever grows; do NOT assume this one covers it.
 //
 // The `$type: 'string'` guards are load-bearing, not cosmetic: legacy Group rows predate both
 // `type` and `organizationId` (strict mode dropped organizationId before it was in the schema),


### PR DESCRIPTION
## Description

Two low-risk group-layer hygiene fixes from the #1172 follow-up review, batched (same area, no correctness change).

### #1225 — move the group-list route behind a service function
`GET /api/organizations/[id]/groups` fetched the raw `Organization` model, called `assertCanManageOrgGroups` inline, and did its own `findByOrganization` + member merge — unlike every sibling group action, which takes `(actingUser, params, adapters)` and delegates. Consequences (none urgent): it forced `assertCanManageOrgGroups` onto the public barrel for one caller (a footgun — it reads `organization.users`, so a projected fetch would silently fail an appointed org admin), bypassed the repository abstraction, and invited the raw-model idiom to spread.

Added `listOrganizationGroups(actingUser, { organizationId }, adapters)` mirroring `renameGroup`: fetch the org via the **repository** (full document, so the predicate always sees `users[]`), authorize with the **MANAGE** predicate (not `Permission.read` — the result exposes who's in which group), and assemble `memberIds`/`memberCount`. The route is now param-extraction + delegation, and the behaviour picks up service-level coverage in `groupMembership.test.ts` alongside its siblings.

### #1229 — correct a misleading index comment
`group_org_type_live` is **partial**, so it cannot serve `findByOrganization`'s bare `{ organizationId }` query (no `deletedAt`/`$type` predicates to prove the subset) — that read is a COLLSCAN, not the indexed lookup the comment claimed. Corrected the comment (option 2 from the issue: fix the comment, don't add an index — acceptable at current volume; the collection is effectively empty and per-org group counts are tiny). Left a note on when to add a plain `{ organizationId: 1 }` index.

## Changes
- `groupMembership.ts` — new `listOrganizationGroups` + `OrganizationGroupWithMembers` type; exported from `organizationService`.
- `pages/api/organizations/[id]/groups/index.ts` — delegates to the service; route test rewritten to pin the delegation wiring.
- `groupMembership.test.ts` — service-level coverage (member assembly, org-missing → NotFound before authz, MANAGE-gate rejection).
- `GroupModel.ts` — index comment corrected (#1229).

## Guide for Testers
Backend/refactor only; no user-visible change.
1. `pnpm --filter @bike4mind/services exec vitest run src/organizationService/groupMembership.test.ts` → 14 pass (incl. the 3 new `listOrganizationGroups` cases).
2. `pnpm --filter @bike4mind/client exec vitest run "pages/api/organizations/[id]/groups/__tests__/index.test.ts"` → 3 pass (delegation, error propagation, missing-id 404).
3. Typecheck: `pnpm --filter @bike4mind/services run typecheck:fast`, `pnpm --filter @bike4mind/database run typecheck` → no errors.

### Regression Checks
- `GET /api/organizations/[id]/groups` returns the same `{ groups: [{ …group, memberIds, memberCount }] }` shape, still MANAGE-gated (owner / org admin / platform admin; a plain member is rejected).
- No behaviour change to the query itself (#1229 is comment-only).

### What NOT to test
- No index was added; `findByOrganization` performance is unchanged (still a collscan, fine at current volume).

Closes #1225
Closes #1229
Part of #1172.
