### PR TITLE
refactor(services): remove any from artifactExtractor

### DIFF
--- a/b4m-core/services/src/notebookCurationService/artifactExtractor.test.ts
+++ b/b4m-core/services/src/notebookCurationService/artifactExtractor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { CurationArtifactType } from '@bike4mind/common';
-import { extractArtifactsFromMessage, mapMimeTypeToArtifactType } from './artifactExtractor';
+import { CurationArtifactType, type CurationOptions } from '@bike4mind/common';
+import { extractArtifactsFromMessage, mapMimeTypeToArtifactType, type CurationMessage } from './artifactExtractor';
 
 // The curation extractor used to carry its own copy of the MIME-to-type table. It now
 // delegates parsing to the shared @bike4mind/common mapper and only bridges the shared
@@ -49,14 +49,14 @@ describe('extractArtifactsFromMessage - attribute values containing quotes', () 
     includeCode: true,
     includeDiagrams: true,
     includeDataViz: true,
-  } as Parameters<typeof extractArtifactsFromMessage>[1];
+  } as CurationOptions;
 
   it('keeps an apostrophe inside a double-quoted title', () => {
     const artifacts = extractArtifactsFromMessage(
       {
         id: 'm1',
         reply: `<artifact identifier="bobs-app" type="text/html" title="Bob's App"><p>hi</p></artifact>`,
-      },
+      } as CurationMessage,
       options
     );
     const html = artifacts.find(a => a.type === CurationArtifactType.HTML);

--- a/b4m-core/services/src/notebookCurationService/artifactExtractor.ts
+++ b/b4m-core/services/src/notebookCurationService/artifactExtractor.ts
@@ -2,8 +2,16 @@ import {
   ExtractedArtifact,
   CurationArtifactType as ArtifactType,
   CurationOptions,
+  IChatHistoryItem,
   mapMimeTypeToArtifactType as mapMimeTypeToSharedArtifactType,
 } from '@bike4mind/common';
+
+/**
+ * The loaded `IChatHistoryItem` plus the mongo `_id` that document/lean-form items
+ * carry but the interface omits (used only as an id fallback). Also the input type of
+ * computeCurationContentHash in ./index - see there for which fields the hash covers.
+ */
+export type CurationMessage = IChatHistoryItem & { _id?: { toString(): string } };
 
 /**
  * Extracts code, diagrams, and other artifacts from conversation messages.
@@ -20,7 +28,7 @@ const CODE_BLOCK_REGEX = /```(\w+)?\s*([\s\S]*?)```/g;
 /**
  * Extract artifacts from a single message
  */
-export function extractArtifactsFromMessage(message: any, options: CurationOptions): ExtractedArtifact[] {
+export function extractArtifactsFromMessage(message: CurationMessage, options: CurationOptions): ExtractedArtifact[] {
   const artifacts: ExtractedArtifact[] = [];
   const messageId = message.id || message._id?.toString() || 'unknown';
   const timestamp = message.timestamp ? new Date(message.timestamp) : new Date();
@@ -84,7 +92,7 @@ export function extractArtifactsFromMessage(message: any, options: CurationOptio
 
   // 5. Extract images
   if (options.includeImages && message.images && message.images.length > 0) {
-    message.images.forEach((imagePath: string, index: number) => {
+    message.images.forEach((imagePath, index) => {
       artifacts.push({
         type: ArtifactType.IMAGE,
         content: imagePath,

--- a/b4m-core/services/src/notebookCurationService/index.ts
+++ b/b4m-core/services/src/notebookCurationService/index.ts
@@ -15,15 +15,19 @@ import {
   IUserDocument,
 } from '@bike4mind/common';
 import type { CurationTokenUsage, LLMContext } from './llmMarkdownGenerator';
+import type { CurationMessage } from './artifactExtractor';
 import { createFabFile, CreateFabFileAdapters } from '../fabFileService/create';
 import { FormatConverter } from './formatConverter';
 import { createHash } from 'crypto';
 
 interface ChatHistorySource {
+  // CurationMessage, not IChatHistoryItem: repositories return toObject() output, which
+  // carries the mongo `_id` the interface omits. Without it the `_id` id-fallback in the
+  // hash and the artifact extractor would look like dead code at every call site.
   find(
     filter: Record<string, unknown>,
     options: { skip: number; limit: number; sort: Record<string, 1 | -1> }
-  ): Promise<IChatHistoryItem[]>;
+  ): Promise<CurationMessage[]>;
 }
 
 export interface NotebookCurationAdapters {
@@ -49,13 +53,6 @@ export interface NotebookCurationAdapters {
 const CURATION_HASH_VERSION = 'v1';
 
 /**
- * The loaded `IChatHistoryItem` plus the mongo `_id` that document/lean-form
- * items carry but the interface omits (used only as an id fallback in the hash).
- * Every other field the hash reads already lives on `IChatHistoryItem`.
- */
-type CurationHashMessage = IChatHistoryItem & { _id?: { toString(): string } };
-
-/**
  * Stable hash of everything that determines the curated output: the hash version,
  * the curation type, the include/format options, and the conversation content. An
  * unchanged re-curation produces the same hash, letting curateNotebook reuse the
@@ -65,8 +62,10 @@ type CurationHashMessage = IChatHistoryItem & { _id?: { toString(): string } };
  * - options.tokenBudget: affects only the base credit deduction, not the document.
  * - session.name: curation is a point-in-time snapshot, so a rename alone should
  *   not force a full (paid) re-curation just to refresh the header title.
+ * - message.timestamp: the extractor reads it for artifact metadata, but it is fixed
+ *   at message creation, so it cannot change without prompt/reply changing too.
  */
-export function computeCurationContentHash(messages: CurationHashMessage[], options: CurationOptions): string {
+export function computeCurationContentHash(messages: CurationMessage[], options: CurationOptions): string {
   const hash = createHash('sha256');
   hash.update(`ver:${CURATION_HASH_VERSION}`);
   hash.update(`|type:${options.curationType || 'transcript'}`);


### PR DESCRIPTION
Part of #175 (reduce `any` in top offenders).

Types the last `any` in `artifactExtractor.ts`: `extractArtifactsFromMessage(message: any, ...)`.

The type it needed already existed one file over. `index.ts` declared `CurationHashMessage = IChatHistoryItem & { _id?: { toString(): string } }` for `computeCurationContentHash`, because loaded messages carry a mongo `_id` that `IChatHistoryItem` omits and both functions use it as an id fallback. Since the extractor and the hash read the same message fields, the type moves into the leaf as the exported `CurationMessage` and `index.ts` imports it rather than keeping a second copy.

Two smaller changes come with it:

- The local `ChatHistorySource.find()` is narrowed to `CurationMessage[]`. Without that, `_id` is statically absent at every call site, so the `_id` fallback reads as dead code even though repositories return `toObject()` output that does carry `_id`.
- `message.timestamp` is added to `computeCurationContentHash`'s existing "Intentionally NOT hashed" list. The extractor reads it, but it is fixed at message creation and so cannot change without `prompt`/`reply` changing too - documenting it stops a future reader treating the omission as a bug.

No behavior change: the emitted JavaScript is identical.

## Verification

The hash gates the curation cache, so a perturbed hash would silently re-curate every previously curated notebook and re-charge credits. That was the main thing worth proving:

- **All 16 content hashes are byte-identical to `main`** (same fixtures run on both branches and diffed).
- 23/23 tests pass; `@bike4mind/services` typecheck and prettier clean; 0 `any` in the file.
- The `_id` fallback was exercised directly: a message with only `_id` resolves `messageId` from `_id.toString()` and still extracts its artifacts.
- End-to-end against a real Mongo, driven through the UI (notebook menu -> Curate -> Raw Transcript -> markdown): `POST /api/notebooks/curate` returns 202, the worker extracts `{ code: 1, html: 1, mermaid: 1 }` from a seeded conversation containing exactly those three artifacts, and writes the curated file.
- Re-running the identical curation logs `Curation cache hit - reusing existing file, skipping LLM and credit charge` with `tokensDeducted: 0` and leaves the credit balance unchanged - confirming the hash still matches.
- Confirmed on the `pr1275` preview against real data - a conversation whose reply contained a fenced `typescript` code block, curated as Raw Transcript / Markdown. The first run reported **100 credits used**; re-running the identical curation reported **0 credits used**, reused the same `curatedNotebookFileId`, and left `curationContentHash` and `curatedAt` unchanged. The hash still matched, so the stored file was served instead of re-curating.

## Testing guide

Preview: open a notebook that has some conversation content.

1. Hover the notebook in the sidebar, open its menu, choose **Curate**.
2. Keep **Raw Transcript** and format **Markdown** (Raw Transcript costs 100 credits and uses no LLM).
3. Click **Start Curation** and wait for it to finish, then download the result.
4. Confirm the curated document contains the code blocks / diagrams from the conversation.
5. **Run the exact same curation again.** It should finish almost immediately and report **0 credits used** - the second run is served from cache and must not charge.

Step 5 is the important one; a regression here would show up as a second credit deduction.

