### PR TITLE
perf(db): index ModelPrice.effectiveFrom for the rowsInForce hot path

### DIFF
--- a/packages/database/src/models/billing/ModelPriceModel.test.ts
+++ b/packages/database/src/models/billing/ModelPriceModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { ModelPrice, modelPriceRepository } from './ModelPriceModel';
+import { ModelPrice, modelPriceRepository, rowsInForcePipeline } from './ModelPriceModel';
 import { SEED_NOTE } from '../../seeds/seedModelPrices';
 import { setupMongoTest } from '../../__test__/utils';
 
@@ -81,6 +81,25 @@ describe('ModelPriceRepository', () => {
     const history = await modelPriceRepository.historyForModel('gpt-x');
     expect(history).toHaveLength(2);
     expect(history[0].effectiveFrom.toISOString()).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('serves rowsInForce from an index with no blocking in-memory sort', async () => {
+    // Without a dedicated { effectiveFrom: -1 } index this read COLLSCANs and sorts in
+    // memory on every model-list cache rebuild and on every voice settlement.
+    const base = { modelId: 'gpt-x', unit: 'per_token' as const, pricing: { '200000': tier } };
+    await modelPriceRepository.append({ ...base, effectiveFrom: new Date('2026-06-01T00:00:00Z') });
+    await modelPriceRepository.append({ ...base, effectiveFrom: new Date('2026-07-01T00:00:00Z') });
+    await ModelPrice.ensureIndexes();
+
+    const plan = await ModelPrice.collection
+      .aggregate(rowsInForcePipeline(new Date('2026-07-15T00:00:00Z')))
+      .explain('queryPlanner');
+
+    const planned = JSON.stringify(plan);
+    // Naming the index matters: asserting IXSCAN alone would also pass on the compound
+    // unique index, which cannot serve an effectiveFrom-only range or sort.
+    expect(planned).toContain('"indexName":"effectiveFrom_-1"');
+    expect(planned).not.toContain('"stage":"SORT"');
   });
 
   it('rejects units outside the enum', async () => {

--- a/packages/database/src/models/billing/ModelPriceModel.ts
+++ b/packages/database/src/models/billing/ModelPriceModel.ts
@@ -1,4 +1,4 @@
-import mongoose, { Model, Schema, model } from 'mongoose';
+import mongoose, { Model, PipelineStage, Schema, model } from 'mongoose';
 import BaseRepository from '@bike4mind/db-core';
 import {
   IModelPrice,
@@ -56,8 +56,28 @@ const ModelPriceSchema = new Schema<IModelPriceDocument>(
 // deterministic seed epoch instead of double-inserting; reprices use a fresh
 // effectiveFrom and never conflict.
 ModelPriceSchema.index({ modelId: 1, unit: 1, effectiveFrom: -1 }, { unique: true });
+// rowsInForce() filters and sorts on effectiveFrom alone, which cannot use the
+// compound index above (effectiveFrom is not its prefix). Mirrors the same index
+// on ModelCatalog, whose rowsInForce has the identical query shape.
+ModelPriceSchema.index({ effectiveFrom: -1 });
 
 export type IModelPriceModel = Model<IModelPriceDocument>;
+
+/**
+ * The newest-row-per-(model, unit) read. Exported so the index test can explain()
+ * the exact pipeline the hot path runs.
+ */
+export const rowsInForcePipeline = (at: Date): PipelineStage[] => [
+  { $match: { effectiveFrom: { $lte: at } } },
+  { $sort: { effectiveFrom: -1 } },
+  {
+    $group: {
+      _id: { modelId: '$modelId', unit: '$unit' },
+      doc: { $first: '$$ROOT' },
+    },
+  },
+  { $replaceRoot: { newRoot: '$doc' } },
+];
 
 export class ModelPriceRepository extends BaseRepository<IModelPriceDocument> implements IModelPriceRepository {
   constructor(model: IModelPriceModel) {
@@ -80,17 +100,7 @@ export class ModelPriceRepository extends BaseRepository<IModelPriceDocument> im
   }
 
   async rowsInForce(at: Date = new Date()): Promise<IModelPrice[]> {
-    const docs = await this.model.aggregate<IModelPriceDocument>([
-      { $match: { effectiveFrom: { $lte: at } } },
-      { $sort: { effectiveFrom: -1 } },
-      {
-        $group: {
-          _id: { modelId: '$modelId', unit: '$unit' },
-          doc: { $first: '$$ROOT' },
-        },
-      },
-      { $replaceRoot: { newRoot: '$doc' } },
-    ]);
+    const docs = await this.model.aggregate<IModelPriceDocument>(rowsInForcePipeline(at));
     // Aggregation bypasses Mongoose casting; Map fields come back as plain objects.
     return docs.map(doc => ({ ...doc, pricing: doc.pricing }) as IModelPrice);
   }


### PR DESCRIPTION
# Pull Request

## Description

Closes #1071.

`ModelPriceRepository.rowsInForce()` is a hot read - it backs every `getAvailableModels`
cache rebuild and the voice settlement path in `voiceSessionEnded` (which bypasses the
5-minute cache) - but it ran a full collection scan plus a blocking in-memory sort.

The pipeline is `$match { effectiveFrom: { $lte } }` -> `$sort { effectiveFrom: -1 }` ->
`$group`. The only index on the collection was the compound unique
`{ modelId: 1, unit: 1, effectiveFrom: -1 }`, and `effectiveFrom` is not its prefix, so it
could serve neither the range match nor the sort: COLLSCAN + in-memory SORT on every
rebuild. The sibling `ModelCatalog` schema has the identical query shape and already
carries a dedicated `{ effectiveFrom: -1 }` index; `ModelPrice` never got the parallel one.

Cheap today because the price collection is small, but it degrades linearly as reprices
accumulate.

## Changes

- `ModelPriceModel.ts`: add `ModelPriceSchema.index({ effectiveFrom: -1 })`, declared with
  the other performance indexes at the bottom of the schema, mirroring `ModelCatalog`.
- `ModelPriceModel.ts`: extract the `rowsInForce` aggregation into an exported
  `rowsInForcePipeline(at)` so the regression test can `explain()` the exact pipeline the
  hot path runs (same approach as `PENDING_SUGGESTIONS_QUERY` in `ModelDiscoveryStateModel`).
- `ModelPriceModel.test.ts`: new test asserting the plan uses `indexName "effectiveFrom_-1"`
  and contains no `"stage":"SORT"`. It names the index rather than just asserting IXSCAN,
  because an IXSCAN-only assertion would also pass on the compound unique index.

Not included: the issue's optional second item (reusing the cached price rows in
`voiceSessionEnded` instead of the raw aggregation). The index removes the scan on that
path, and putting a 5-minute cache in front of a billing settlement read changes freshness
semantics - worth its own discussion.

## Guide for Testers

Backend-only index change; there is no UI surface.

1. Run `pnpm --filter @bike4mind/database test` (or
   `npx vitest run src/models/billing/ModelPriceModel.test.ts` inside `packages/database`).
   Expected: all tests pass, including
   "serves rowsInForce from an index with no blocking in-memory sort".
2. To confirm the test is not vacuous: comment out the
   `ModelPriceSchema.index({ effectiveFrom: -1 })` line and re-run.
   Expected: the new test fails with
   `expected '...' to contain '"indexName":"effectiveFrom_-1"'`. Restore the line.

### Regression Checks

3. Open the model picker in a chat and confirm the model list loads with prices as before
   (this is the `getAvailableModels` cache rebuild path).
4. Start and end a voice session and confirm credits settle as before (the
   `voiceSessionEnded` settlement path).

### What NOT to test

No UI, API contract, or pricing-value changes. Query results are unchanged - only the
execution plan is.

## Additional Information

The index is created by Mongoose `autoIndex`/`ensureIndexes` like every other index in this
package; the collection is small, so the build is not a concern on existing deployments.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
