### PR TITLE
feat(organizations): platform-admin resolution override for group types (#1236)

### DIFF
--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -1998,6 +1998,10 @@ describe('computeSettlementDelta (zero-balance shortfall clamp)', () => {
   // #1238: the org-wide balance is a HARD STOP - the settlement true-up must never drive it
   // negative. Pin the invariant across a swept input range, not just the examples above, so a
   // future refactor of the clamp can't quietly reintroduce a negative-balance path.
+  // The grid below is deliberately coarse non-negative INTEGERS so the conservation assertion can use
+  // exact equality. Real credits are token-derived floats, where `collected + writtenOff === shortfall`
+  // is not exact - hence the separate fractional case, which asserts the floor exactly (it is a
+  // comparison, not a sum) and conservation approximately.
   it('never drives the settled balance below zero, and conserves the shortfall (hard-stop invariant)', () => {
     for (let reserved = 0; reserved <= 200; reserved += 25) {
       for (let used = 0; used <= 300; used += 25) {
@@ -2021,6 +2025,25 @@ describe('computeSettlementDelta (zero-balance shortfall clamp)', () => {
             expect(collected).toBe(Math.min(shortfall, available));
           }
         }
+      }
+    }
+  });
+
+  it('holds the floor for fractional credits (token-derived costs are not integers)', () => {
+    const fractional: Array<[number, number, number]> = [
+      [0.1, 0.30000000000000004, 0.15], // shortfall the balance only partly covers
+      [1.7, 2.9, 0.05],
+      [0.25, 0.25, 0.1], // exact settlement on a fractional basis
+      [0.2, 0.7, 0], // whole shortfall written off at zero balance
+      [3.3, 1.1, 0.5], // over-reserved: fractional refund
+    ];
+    for (const [reserved, used, available] of fractional) {
+      const { delta, writtenOffCredits } = computeSettlementDelta(reserved, used, available);
+      expect(available + delta).toBeGreaterThanOrEqual(0);
+      expect(writtenOffCredits).toBeGreaterThanOrEqual(0);
+      if (used > reserved) {
+        // Conservation only up to FP error here; its exact form is pinned by the integer sweep above.
+        expect(Math.abs(delta) + writtenOffCredits).toBeCloseTo(used - reserved, 10);
       }
     }
   });

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -1994,6 +1994,36 @@ describe('computeSettlementDelta (zero-balance shortfall clamp)', () => {
   it('treats a negative balance snapshot as zero', () => {
     expect(computeSettlementDelta(100, 130, -50)).toEqual({ delta: 0, writtenOffCredits: 30 });
   });
+
+  // #1238: the org-wide balance is a HARD STOP - the settlement true-up must never drive it
+  // negative. Pin the invariant across a swept input range, not just the examples above, so a
+  // future refactor of the clamp can't quietly reintroduce a negative-balance path.
+  it('never drives the settled balance below zero, and conserves the shortfall (hard-stop invariant)', () => {
+    for (let reserved = 0; reserved <= 200; reserved += 25) {
+      for (let used = 0; used <= 300; used += 25) {
+        for (let available = 0; available <= 300; available += 25) {
+          const { delta, writtenOffCredits } = computeSettlementDelta(reserved, used, available);
+          // The balance already moved by `reserved` at reservation; settlement applies `delta`.
+          // Post-settlement balance = available + delta and must never be negative.
+          expect(available + delta).toBeGreaterThanOrEqual(0);
+          expect(writtenOffCredits).toBeGreaterThanOrEqual(0);
+          if (used <= reserved) {
+            // Over- or exactly-reserved: pure refund/no-op, nothing written off.
+            expect(writtenOffCredits).toBe(0);
+            expect(delta).toBe(reserved - used);
+          } else {
+            // Under-reserved: the shortfall is either collected (via -delta) or written off,
+            // and the collected part is clamped to what the balance can actually cover.
+            const shortfall = used - reserved;
+            // delta <= 0 here (a shortfall debit); Math.abs avoids a -0 vs +0 Object.is mismatch.
+            const collected = Math.abs(delta);
+            expect(collected + writtenOffCredits).toBe(shortfall);
+            expect(collected).toBe(Math.min(shortfall, available));
+          }
+        }
+      }
+    }
+  });
 });
 
 describe('clampFraction (verbatim window fraction admin setting)', () => {

--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -22,6 +22,7 @@ import {
   listOrganizationGroups,
 } from './groupMembership';
 import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
+import type { GroupTypeResolutionOverride } from './resolveGroupTypesForUser';
 import { resolveCapabilitiesForUser, userHasCapability } from './resolveCapabilitiesForUser';
 
 export {
@@ -53,3 +54,4 @@ export {
 };
 
 export type { SearchParameters };
+export type { GroupTypeResolutionOverride };

--- a/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.test.ts
+++ b/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.test.ts
@@ -36,6 +36,11 @@ const group = (id: string, type: string): IGroupDocument =>
   ({ id, type, organizationId: ORG, name: type, description: '' }) as unknown as IGroupDocument;
 
 const user = (id: string, groups: string[] | null): Pick<IUserDocument, 'id' | 'groups'> => ({ id, groups });
+const admin = (id: string, groups: string[] | null): Pick<IUserDocument, 'id' | 'groups'> & { isAdmin: boolean } => ({
+  id,
+  groups,
+  isAdmin: true,
+});
 
 const org = (over: Partial<{ userId: string; allowedGroupTypes: string[] }> = {}): IOrganizationDocument =>
   ({
@@ -115,6 +120,50 @@ describe('resolveCapabilitiesForUser (#1234)', () => {
       await expect(
         resolveCapabilitiesForUser({ user: user('member-1', []), organizationId: ORG }, adapters)
       ).resolves.toEqual([]);
+    });
+  });
+
+  describe('platform-admin override (#1236)', () => {
+    it('reflects the override persona capabilities for an admin in no group', async () => {
+      // Admin holds no groups; override -> resolves as sales+research, so caps are their union.
+      const { adapters, findByOrganization } = makeAdapters(org(), []);
+      await expect(
+        resolveCapabilitiesForUser(
+          {
+            user: admin('admin-1', []),
+            organizationId: ORG,
+            override: { organizationId: ORG, groupTypes: ['sales', 'research'] },
+          },
+          adapters
+        )
+      ).resolves.toEqual(['crm:read', 'qwork:submit', 'sales:brief']);
+      // Override short-circuits the membership read entirely.
+      expect(findByOrganization).not.toHaveBeenCalled();
+    });
+
+    it('is ignored for a non-admin, who still resolves from real membership', async () => {
+      const { adapters } = makeAdapters(org(), [group('g-sales', 'sales')]);
+      await expect(
+        resolveCapabilitiesForUser(
+          {
+            user: user('member-1', ['g-sales']),
+            organizationId: ORG,
+            override: { organizationId: ORG, groupTypes: ['research'] },
+          },
+          adapters
+        )
+      ).resolves.toEqual(['crm:read', 'sales:brief']);
+    });
+
+    it('gates userHasCapability off the overridden persona', async () => {
+      const { adapters } = makeAdapters(org(), []);
+      const params = {
+        user: admin('admin-1', []),
+        organizationId: ORG,
+        override: { organizationId: ORG, groupTypes: ['research'] },
+      };
+      await expect(userHasCapability({ ...params, capability: 'qwork:submit' }, adapters)).resolves.toBe(true);
+      await expect(userHasCapability({ ...params, capability: 'sales:brief' }, adapters)).resolves.toBe(false);
     });
   });
 

--- a/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.test.ts
+++ b/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.test.ts
@@ -155,6 +155,58 @@ describe('resolveCapabilitiesForUser (#1234)', () => {
       ).resolves.toEqual(['crm:read', 'sales:brief']);
     });
 
+    it('forwards the logger so an override resolved through the capability layer is still recorded', async () => {
+      const { adapters } = makeAdapters(org(), []);
+      const info = vi.fn();
+      await resolveCapabilitiesForUser(
+        {
+          user: admin('admin-1', []),
+          organizationId: ORG,
+          override: { organizationId: ORG, groupTypes: ['sales'] },
+        },
+        { ...adapters, logger: { info } }
+      );
+      expect(info).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT union the billing-owner implicit hold when the overriding admin IS the org owner', async () => {
+      // The likely shape for this affordance: the admin who created the demo org is its `userId`.
+      // Unioned, the preview would report sales caps the `customer` persona does not hold.
+      const { adapters } = makeAdapters(org({ userId: 'admin-1', allowedGroupTypes: ['sales', 'research'] }), []);
+      await expect(
+        resolveCapabilitiesForUser(
+          {
+            user: admin('admin-1', []),
+            organizationId: ORG,
+            override: { organizationId: ORG, groupTypes: ['customer'] },
+          },
+          adapters
+        )
+      ).resolves.toEqual([]); // customer confers nothing; owner's sales/research must NOT leak in
+    });
+
+    it('still gives an owner-admin their implicit hold when they pass NO override', async () => {
+      // Guards the fix above from over-reaching: skipping the union is override-scoped, not admin-scoped.
+      const { adapters } = makeAdapters(org({ userId: 'admin-1', allowedGroupTypes: ['sales'] }), []);
+      await expect(
+        resolveCapabilitiesForUser({ user: admin('admin-1', []), organizationId: ORG }, adapters)
+      ).resolves.toEqual(['crm:read', 'sales:brief']);
+    });
+
+    it('keeps the billing-owner hold when the override is ignored (wrong org)', async () => {
+      const { adapters } = makeAdapters(org({ userId: 'admin-1', allowedGroupTypes: ['sales'] }), []);
+      await expect(
+        resolveCapabilitiesForUser(
+          {
+            user: admin('admin-1', []),
+            organizationId: ORG,
+            override: { organizationId: 'org-other', groupTypes: ['research'] },
+          },
+          adapters
+        )
+      ).resolves.toEqual(['crm:read', 'sales:brief']);
+    });
+
     it('gates userHasCapability off the overridden persona', async () => {
       const { adapters } = makeAdapters(org(), []);
       const params = {

--- a/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.ts
+++ b/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.ts
@@ -5,13 +5,19 @@ import {
   getGroupType,
   isKnownGroupType,
 } from '@bike4mind/common';
-import { resolveGroupTypesForUser, type GroupTypeResolutionOverride } from './resolveGroupTypesForUser';
+import {
+  resolveGroupTypesForUser,
+  isGroupTypeOverrideActive,
+  type GroupTypeResolutionOverride,
+} from './resolveGroupTypesForUser';
 
 interface CapabilityAdapters {
   db: {
     organizations: Pick<IOrganizationRepository, 'findById'>;
     groups: Pick<IGroupRepository, 'findByOrganization'>;
   };
+  /** Forwarded to the type resolver, which logs an applied override (#1236). */
+  logger?: { info: (message: string) => void };
 }
 
 type CapabilityUser = Pick<IUserDocument, 'id' | 'groups'> & { isAdmin?: boolean };
@@ -34,6 +40,7 @@ type CapabilityUser = Pick<IUserDocument, 'id' | 'groups'> & { isAdmin?: boolean
  * would otherwise be locked out of their own org's capabilities. `organization.userId === user.id`
  * implicitly holds every type the org is GRANTED (`allowedGroupTypes`) - not the whole catalog. This
  * is a resolution-layer read only; it does NOT relax `groupMembership.ts` invariant (2) (#1227/#1231).
+ * It does not apply under an active resolution override (#1236) - see the branch comment below.
  *
  * Keys stay generic (never a customer name) per GROUP_TYPE_CATALOG - product-specific keys live in
  * the consuming overlay. Returns a sorted, de-duplicated array (a serialisable shape for a client seam).
@@ -49,15 +56,23 @@ export async function resolveCapabilitiesForUser(
   const organization = await adapters.db.organizations.findById(organizationId);
   if (!organization) return [];
 
-  // Forward the platform-admin override (#1236) so capabilities reflect the persona being operated
-  // as. The billing-owner branch below can't fire for an overriding admin (they are not the org's
-  // `userId`), so the override cleanly yields exactly that persona's capabilities.
+  // Forward the platform-admin override (#1236) so capabilities reflect the persona being operated as.
+  const overridden = isGroupTypeOverrideActive(override, user, organizationId);
   const effectiveTypes = new Set(
-    await resolveGroupTypesForUser({ user, organizationId, override }, { db: { groups: adapters.db.groups } })
+    await resolveGroupTypesForUser(
+      { user, organizationId, override },
+      { db: { groups: adapters.db.groups }, logger: adapters.logger }
+    )
   );
 
   // Billing-owner implicit hold: every GRANTED type (allowedGroupTypes), not the whole catalog.
-  if (organization.userId === user.id) {
+  // SKIPPED under an active override: `isAdmin` (the override gate) and `organization.userId ===
+  // user.id` (this branch) are independent, and an admin who created the demo org IS its userId - the
+  // likely shape for this affordance. Unioned, the preview would report capabilities the persona does
+  // not hold, a false positive in exactly the "does this persona see X?" check the override exists to
+  // answer. The admin loses nothing: their own capabilities are what they resolve to without an
+  // override, and the override is opt-in per call.
+  if (!overridden && organization.userId === user.id) {
     for (const type of organization.allowedGroupTypes ?? []) {
       if (isKnownGroupType(type)) effectiveTypes.add(type);
     }

--- a/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.ts
+++ b/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.ts
@@ -5,7 +5,7 @@ import {
   getGroupType,
   isKnownGroupType,
 } from '@bike4mind/common';
-import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
+import { resolveGroupTypesForUser, type GroupTypeResolutionOverride } from './resolveGroupTypesForUser';
 
 interface CapabilityAdapters {
   db: {
@@ -14,7 +14,7 @@ interface CapabilityAdapters {
   };
 }
 
-type CapabilityUser = Pick<IUserDocument, 'id' | 'groups'>;
+type CapabilityUser = Pick<IUserDocument, 'id' | 'groups'> & { isAdmin?: boolean };
 
 /**
  * Resolve the CAPABILITY set a user holds within an organization (org-groups #1234).
@@ -39,14 +39,21 @@ type CapabilityUser = Pick<IUserDocument, 'id' | 'groups'>;
  * the consuming overlay. Returns a sorted, de-duplicated array (a serialisable shape for a client seam).
  */
 export async function resolveCapabilitiesForUser(
-  { user, organizationId }: { user: CapabilityUser; organizationId: string },
+  {
+    user,
+    organizationId,
+    override,
+  }: { user: CapabilityUser; organizationId: string; override?: GroupTypeResolutionOverride },
   adapters: CapabilityAdapters
 ): Promise<string[]> {
   const organization = await adapters.db.organizations.findById(organizationId);
   if (!organization) return [];
 
+  // Forward the platform-admin override (#1236) so capabilities reflect the persona being operated
+  // as. The billing-owner branch below can't fire for an overriding admin (they are not the org's
+  // `userId`), so the override cleanly yields exactly that persona's capabilities.
   const effectiveTypes = new Set(
-    await resolveGroupTypesForUser({ user, organizationId }, { db: { groups: adapters.db.groups } })
+    await resolveGroupTypesForUser({ user, organizationId, override }, { db: { groups: adapters.db.groups } })
   );
 
   // Billing-owner implicit hold: every GRANTED type (allowedGroupTypes), not the whole catalog.
@@ -71,9 +78,14 @@ export async function resolveCapabilitiesForUser(
  * authorization check rather than an array-membership test.
  */
 export async function userHasCapability(
-  { user, organizationId, capability }: { user: CapabilityUser; organizationId: string; capability: string },
+  {
+    user,
+    organizationId,
+    capability,
+    override,
+  }: { user: CapabilityUser; organizationId: string; capability: string; override?: GroupTypeResolutionOverride },
   adapters: CapabilityAdapters
 ): Promise<boolean> {
-  const capabilities = await resolveCapabilitiesForUser({ user, organizationId }, adapters);
+  const capabilities = await resolveCapabilitiesForUser({ user, organizationId, override }, adapters);
   return capabilities.includes(capability);
 }

--- a/b4m-core/services/src/organizationService/resolveGroupTypesForUser.test.ts
+++ b/b4m-core/services/src/organizationService/resolveGroupTypesForUser.test.ts
@@ -106,6 +106,42 @@ describe('resolveGroupTypesForUser (#1235)', () => {
       ).resolves.toEqual(['research']);
     });
 
+    it('logs the applied override, naming the org and the resolved types', async () => {
+      // The return type is a bare string[], so the log line is the only downstream evidence that a
+      // resolution came from an override rather than from real membership.
+      const { adapters } = makeAdapters([]);
+      const info = vi.fn();
+      await resolveGroupTypesForUser(
+        { user: admin([]), organizationId: ORG, override: { organizationId: ORG, groupTypes: ['sales'] } },
+        { ...adapters, logger: { info } }
+      );
+      expect(info).toHaveBeenCalledTimes(1);
+      expect(info.mock.calls[0][0]).toContain(ORG);
+      expect(info.mock.calls[0][0]).toContain('[sales]');
+    });
+
+    it('names dropped unknown keys in the log line so a typo is not silent', async () => {
+      const { adapters } = makeAdapters([]);
+      const info = vi.fn();
+      await expect(
+        resolveGroupTypesForUser(
+          { user: admin([]), organizationId: ORG, override: { organizationId: ORG, groupTypes: ['saels'] } },
+          { ...adapters, logger: { info } }
+        )
+      ).resolves.toEqual([]);
+      expect(info.mock.calls[0][0]).toContain('saels');
+    });
+
+    it('logs nothing when the override is ignored', async () => {
+      const { adapters } = makeAdapters([group('g-research', 'research')]);
+      const info = vi.fn();
+      await resolveGroupTypesForUser(
+        { user: user(['g-research']), organizationId: ORG, override: { organizationId: ORG, groupTypes: ['sales'] } },
+        { ...adapters, logger: { info } }
+      );
+      expect(info).not.toHaveBeenCalled();
+    });
+
     it('ignores an override scoped to a different org, falling back to real membership', async () => {
       const { adapters } = makeAdapters([group('g-research', 'research')]);
       await expect(

--- a/b4m-core/services/src/organizationService/resolveGroupTypesForUser.test.ts
+++ b/b4m-core/services/src/organizationService/resolveGroupTypesForUser.test.ts
@@ -9,6 +9,10 @@ const group = (id: string, type: string, organizationId = ORG): IGroupDocument =
   ({ id, type, organizationId, name: type, description: '' }) as unknown as IGroupDocument;
 
 const user = (groups: string[] | null): Pick<IUserDocument, 'groups'> => ({ groups });
+const admin = (groups: string[] | null): Pick<IUserDocument, 'groups'> & { isAdmin: boolean } => ({
+  groups,
+  isAdmin: true,
+});
 
 function makeAdapters(orgGroups: IGroupDocument[]) {
   const findByOrganization = vi.fn().mockResolvedValue(orgGroups);
@@ -59,5 +63,61 @@ describe('resolveGroupTypesForUser (#1235)', () => {
     await expect(
       resolveGroupTypesForUser({ user: user(['g-research']), organizationId: ORG }, adapters)
     ).resolves.toEqual(['research']);
+  });
+
+  describe('platform-admin override (#1236)', () => {
+    it('resolves AS the override types without a membership read when an admin overrides their own target org', async () => {
+      // Admin holds no groups; the override alone confers the types, and priority sort still applies.
+      const { adapters, findByOrganization } = makeAdapters([]);
+      await expect(
+        resolveGroupTypesForUser(
+          {
+            user: admin([]),
+            organizationId: ORG,
+            override: { organizationId: ORG, groupTypes: ['customer', 'sales'] },
+          },
+          adapters
+        )
+      ).resolves.toEqual(['sales', 'customer']);
+      expect(findByOrganization).not.toHaveBeenCalled();
+    });
+
+    it('drops unknown override keys and de-duplicates', async () => {
+      const { adapters } = makeAdapters([]);
+      await expect(
+        resolveGroupTypesForUser(
+          {
+            user: admin([]),
+            organizationId: ORG,
+            override: { organizationId: ORG, groupTypes: ['sales', 'sales', 'not-a-real-type'] },
+          },
+          adapters
+        )
+      ).resolves.toEqual(['sales']);
+    });
+
+    it('ignores the override for a non-admin, falling back to real membership', async () => {
+      const { adapters } = makeAdapters([group('g-research', 'research')]);
+      await expect(
+        resolveGroupTypesForUser(
+          { user: user(['g-research']), organizationId: ORG, override: { organizationId: ORG, groupTypes: ['sales'] } },
+          adapters
+        )
+      ).resolves.toEqual(['research']);
+    });
+
+    it('ignores an override scoped to a different org, falling back to real membership', async () => {
+      const { adapters } = makeAdapters([group('g-research', 'research')]);
+      await expect(
+        resolveGroupTypesForUser(
+          {
+            user: admin(['g-research']),
+            organizationId: ORG,
+            override: { organizationId: 'org-other', groupTypes: ['sales'] },
+          },
+          adapters
+        )
+      ).resolves.toEqual(['research']);
+    });
   });
 });

--- a/b4m-core/services/src/organizationService/resolveGroupTypesForUser.ts
+++ b/b4m-core/services/src/organizationService/resolveGroupTypesForUser.ts
@@ -7,6 +7,26 @@ interface ResolveGroupTypesAdapters {
 }
 
 /**
+ * Platform-admin resolution override (org-groups #1236): "resolve AS these group types in this org".
+ * Lets an admin exercise a persona for testing/demo WITHOUT being written into the org's `users[]`.
+ * The caller (overlay #139) owns making it opt-in, non-sticky, and logged; the resolver just applies
+ * it, gated on `isAdmin` and scoped to `organizationId`.
+ */
+export interface GroupTypeResolutionOverride {
+  /** The org the admin is operating in - the override applies ONLY when resolving this org. */
+  organizationId: string;
+  /** Group-type keys to resolve as (validated against GROUP_TYPE_CATALOG; unknown keys dropped). */
+  groupTypes: string[];
+}
+
+/** Catalog-priority order (lower first), stable by key - shared by the membership and override paths. */
+const byCatalogPriority = (a: string, b: string): number => {
+  const pa = getGroupType(a)?.priority ?? Number.MAX_SAFE_INTEGER;
+  const pb = getGroupType(b)?.priority ?? Number.MAX_SAFE_INTEGER;
+  return pa - pb || a.localeCompare(b);
+};
+
+/**
  * Resolve which GROUP-TYPE keys a user holds WITHIN one organization (org-groups #1235).
  *
  * `user.groups[]` stores bare Group ids with no type or org qualifier, so a consumer that wants
@@ -25,9 +45,25 @@ interface ResolveGroupTypesAdapters {
  * mirrors the hardened write-path invariant's org scoping without duplicating its authorization.
  */
 export async function resolveGroupTypesForUser(
-  { user, organizationId }: { user: Pick<IUserDocument, 'groups'>; organizationId: string },
+  {
+    user,
+    organizationId,
+    override,
+  }: {
+    user: Pick<IUserDocument, 'groups'> & { isAdmin?: boolean };
+    organizationId: string;
+    override?: GroupTypeResolutionOverride;
+  },
   adapters: ResolveGroupTypesAdapters
 ): Promise<string[]> {
+  // Platform-admin override (#1236): resolve AS the given types, no membership read. isAdmin-only and
+  // scoped to the override's org, so it can never widen a non-admin or bleed into another org. This
+  // changes only what is RESOLVED, never what is written - the write-path invariant (#1227/#1231) is
+  // untouched. Unknown keys are dropped just like the membership path.
+  if (override && user.isAdmin === true && override.organizationId === organizationId) {
+    return [...new Set(override.groupTypes.filter(isKnownGroupType))].sort(byCatalogPriority);
+  }
+
   const memberGroupIds = new Set(user.groups ?? []);
   if (memberGroupIds.size === 0) return [];
 
@@ -40,9 +76,5 @@ export async function resolveGroupTypesForUser(
     }
   }
 
-  return [...types].sort((a, b) => {
-    const pa = getGroupType(a)?.priority ?? Number.MAX_SAFE_INTEGER;
-    const pb = getGroupType(b)?.priority ?? Number.MAX_SAFE_INTEGER;
-    return pa - pb || a.localeCompare(b);
-  });
+  return [...types].sort(byCatalogPriority);
 }

--- a/b4m-core/services/src/organizationService/resolveGroupTypesForUser.ts
+++ b/b4m-core/services/src/organizationService/resolveGroupTypesForUser.ts
@@ -4,19 +4,48 @@ interface ResolveGroupTypesAdapters {
   db: {
     groups: Pick<IGroupRepository, 'findByOrganization'>;
   };
+  /**
+   * Optional audit sink (same shape as setOrganizationGroupTypes'). Both resolvers return a bare
+   * `string[]`/`boolean`, so an override-derived resolution is otherwise indistinguishable
+   * downstream from real membership - only this function knows the branch was taken (#1236).
+   */
+  logger?: { info: (message: string) => void };
 }
 
 /**
  * Platform-admin resolution override (org-groups #1236): "resolve AS these group types in this org".
  * Lets an admin exercise a persona for testing/demo WITHOUT being written into the org's `users[]`.
- * The caller (overlay #139) owns making it opt-in, non-sticky, and logged; the resolver just applies
- * it, gated on `isAdmin` and scoped to `organizationId`.
+ * The caller (overlay #139) owns making it opt-in and non-sticky; the resolver applies it gated on
+ * `isAdmin` and scoped to `organizationId`, and logs when it fires if given a logger.
+ *
+ * Bounded by the CATALOG, not by the org's `allowedGroupTypes` - a deliberate decision, not an
+ * oversight. The membership path is implicitly bounded by grants (Group rows exist only where
+ * `setOrganizationGroupTypes` provisioned them), so the override can resolve a persona the org was
+ * never granted: previewing a type before its grant lands is a real pre-sales/demo use case, and the
+ * affordance is admin-only and read-only. Intersecting with `allowedGroupTypes` would remove that.
+ * This widened reach is why the branch is logged.
  */
 export interface GroupTypeResolutionOverride {
   /** The org the admin is operating in - the override applies ONLY when resolving this org. */
   organizationId: string;
   /** Group-type keys to resolve as (validated against GROUP_TYPE_CATALOG; unknown keys dropped). */
   groupTypes: string[];
+}
+
+/**
+ * Does the override apply for this user resolving this org? isAdmin-only and scoped to the override's
+ * org, so it can never widen a non-admin or bleed across tenants.
+ *
+ * Shared so the two resolvers cannot drift: this one APPLIES the override, while
+ * `resolveCapabilitiesForUser` must know it fired in order to skip the billing-owner union that would
+ * otherwise pollute the persona being previewed.
+ */
+export function isGroupTypeOverrideActive(
+  override: GroupTypeResolutionOverride | undefined,
+  user: { isAdmin?: boolean },
+  organizationId: string
+): override is GroupTypeResolutionOverride {
+  return override !== undefined && user.isAdmin === true && override.organizationId === organizationId;
 }
 
 /** Catalog-priority order (lower first), stable by key - shared by the membership and override paths. */
@@ -43,6 +72,12 @@ const byCatalogPriority = (a: string, b: string): number => {
  * Membership only, and deliberately side-effect-free: it confers nothing by itself. Capability
  * resolution and the billing-owner implicit-hold are layered on top in #1234, NOT here, so this
  * mirrors the hardened write-path invariant's org scoping without duplicating its authorization.
+ *
+ * OVERRIDE TRUST BOUNDARY (#1236): the CALLER is the trust boundary for both `user.isAdmin` and
+ * `override`. The `user` param is a structural type and is never re-read from the database, so a
+ * caller that hand-builds `{ groups, isAdmin: true }` - or forwards an unvalidated request body -
+ * defeats the gate. Callers must take `isAdmin` from the persisted user document and validate that
+ * `override.groupTypes` is an array of strings (a non-array throws inside this authorization path).
  */
 export async function resolveGroupTypesForUser(
   {
@@ -56,12 +91,19 @@ export async function resolveGroupTypesForUser(
   },
   adapters: ResolveGroupTypesAdapters
 ): Promise<string[]> {
-  // Platform-admin override (#1236): resolve AS the given types, no membership read. isAdmin-only and
-  // scoped to the override's org, so it can never widen a non-admin or bleed into another org. This
-  // changes only what is RESOLVED, never what is written - the write-path invariant (#1227/#1231) is
-  // untouched. Unknown keys are dropped just like the membership path.
-  if (override && user.isAdmin === true && override.organizationId === organizationId) {
-    return [...new Set(override.groupTypes.filter(isKnownGroupType))].sort(byCatalogPriority);
+  // Platform-admin override (#1236): resolve AS the given types, no membership read. This changes
+  // only what is RESOLVED, never what is written - the write-path invariant (#1227/#1231) is
+  // untouched. Unknown keys are dropped just like the membership path, but named in the log line:
+  // a typo'd persona key otherwise resolves silently to [] and looks like a deliberate empty set.
+  if (isGroupTypeOverrideActive(override, user, organizationId)) {
+    const resolved = [...new Set(override.groupTypes.filter(isKnownGroupType))].sort(byCatalogPriority);
+    const dropped = [...new Set(override.groupTypes.filter(key => !isKnownGroupType(key)))];
+    adapters.logger?.info(
+      `Group-type resolution override applied in organization ${organizationId}: ` +
+        `resolved as [${resolved.join(', ')}]` +
+        (dropped.length > 0 ? `; dropped unknown key(s): [${dropped.join(', ')}]` : '')
+    );
+    return resolved;
   }
 
   const memberGroupIds = new Set(user.groups ?? []);

--- a/docs/architecture/org-credit-hard-stop.md
+++ b/docs/architecture/org-credit-hard-stop.md
@@ -3,10 +3,11 @@
 **Question:** Is an organization's `currentCredits` balance a hard stop (a real floor that
 rejects spend at zero), or a soft limit that can be pushed negative?
 
-**Verdict: it is a hard stop.** An org's balance floors at zero on every metered spend path; it is
-never driven negative in the single-request path. The one residual soft edge is concurrent
-settlement (best-effort, already documented in code), and the whole floor is gated on the
-`enforceCredits` admin setting by design (except the embed path, which is settings-free).
+**Verdict: it is a hard stop per single request.** An org's balance floors at zero on every metered
+spend path and is never driven negative by one request. The residual soft edges are both
+concurrency-shaped - concurrent settlement of a chat stream, and concurrent standalone image/video
+deducts (both below) - and the whole floor is gated on the `enforceCredits` admin setting by design
+(except the embed path, which is settings-free).
 
 This matters because org-wide balance is the only bound on *aggregate* spend. The per-member cap
 (`maxCreditsPerMember`) limits any single member but scales with headcount; once orgs self-serve
@@ -43,13 +44,26 @@ Three independent layers, all keyed on the org balance when the request is org-b
   **inline-triplicated** rather than a shared helper. Currently consistent; a shared
   `reserveOrReject` seam would prevent drift (suggested follow-up, deliberately not done here to
   avoid refactoring hot billing paths under a "confirm" task).
-- The image/video/tool paths validate through the shared `validateUserCredits`
-  (`b4m-core/services/src/llm/tools/base/utils.ts`), which is a **check-then-act** comparison
-  against `organization.currentCredits` (not an atomic reserve). A concurrent-request window can
-  momentarily let two tool calls both pass the check, but the settlement clamp (layer 2) bounds the
-  aggregate so the balance still cannot end up negative. In-stream, the reserved balance is written
-  back to `organization.currentCredits` so mid-stream tool validation sees the reduced figure
-  (`ChatCompletionProcess.ts:2460-2461`).
+- The image/video/tool paths do a **check-then-act** comparison against `organization.currentCredits`
+  rather than an atomic reserve, so a concurrent-request window can momentarily let two requests both
+  pass the check. How that window is bounded differs by path, and the distinction matters:
+  - **In-stream tool calls** validate through the shared `validateUserCredits`
+    (`b4m-core/services/src/llm/tools/base/utils.ts`) inside an already-reserved chat completion. The
+    reserved balance is written back to `organization.currentCredits` so mid-stream validation sees
+    the reduced figure (`ChatCompletionProcess.ts:2460-2461`), and the settlement clamp (layer 2)
+    trues the whole stream up without going negative.
+  - **Standalone image/video generation** is bounded by the check-then-act *only* - layer 2 does not
+    reach it. `ImageGeneration.ts` has its own private `validateUserCredits` (`credits <
+    requiredCredits`, ~line 450) and never touches `ChatCompletionProcess` or
+    `computeSettlementDelta`; it deducts post-generation via `deductCreditsWithOrgSupport` (~line
+    1278) with no `skipBalanceUpdate`, so it reaches the bare `$inc` in
+    `subtractCredits.ts:242` -> `incrementCredits`
+    (`packages/database/src/models/infra/admin/OrganizationModel.ts:186-192`), which has no floor
+    guard. Two concurrent standalone image requests against a near-zero org balance can therefore
+    both pass the check and both deduct, with nothing downstream to clamp or refund. This inherits
+    the same concurrency softness recorded under "Concurrent settlement" below; the per-single-request
+    verdict is unaffected. Making it exact needs the same fix: a conditional atomic decrement, or
+    routing these paths through a shared `reserveOrReject`.
 
 ## Where it is (deliberately) soft
 
@@ -62,6 +76,9 @@ Three independent layers, all keyed on the org balance when the request is org-b
   concurrency. Making it exact would require a conditional atomic decrement (`$inc` guarded by
   `balance >= amount`) - out of scope for this confirmation; flag if concurrency-driven negatives
   are observed.
+- **Concurrent standalone image/video generation.** Check-then-act with no atomic reserve and no
+  settlement clamp downstream (see "Consistency across spend paths"). Pre-existing and unchanged;
+  called out here so the clamp is not read as covering it.
 - **Per-member cap** (`maxCreditsPerMember`) is a documented check-then-act TOCTOU (off-by-one under
   concurrency: `deductCreditsWithOrgSupport.ts:155`). That is the *per-member* axis, not the
   org-wide balance, and does not affect the balance floor.
@@ -70,6 +87,11 @@ Three independent layers, all keyed on the org balance when the request is org-b
 
 - `computeSettlementDelta` example cases and a swept **hard-stop invariant** (`available + delta >= 0`
   for all inputs; shortfall conserved between collected and written-off) live in
-  `b4m-core/services/src/llm/ChatCompletion.test.ts`.
+  `b4m-core/services/src/llm/ChatCompletion.test.ts`, with a fractional-credit case alongside the
+  integer sweep (real credits are token-derived floats).
+  Scope: that is a unit test on one pure function. It pins the arithmetic of the clamp, **not** that
+  any given spend path calls it - the standalone image/video path does not. The cross-path claims in
+  this document rest on code reading, which is what a "confirm" task can establish; do not cite this
+  test as broader proof.
 - `assertOwnerHasCredits` (embed floor) is pinned in
   `b4m-core/services/src/billing/assertOwnerHasCredits.test.ts`.

--- a/docs/architecture/org-credit-hard-stop.md
+++ b/docs/architecture/org-credit-hard-stop.md
@@ -1,0 +1,75 @@
+# Organization credit balance: hard stop verification (#1238)
+
+**Question:** Is an organization's `currentCredits` balance a hard stop (a real floor that
+rejects spend at zero), or a soft limit that can be pushed negative?
+
+**Verdict: it is a hard stop.** An org's balance floors at zero on every metered spend path; it is
+never driven negative in the single-request path. The one residual soft edge is concurrent
+settlement (best-effort, already documented in code), and the whole floor is gated on the
+`enforceCredits` admin setting by design (except the embed path, which is settings-free).
+
+This matters because org-wide balance is the only bound on *aggregate* spend. The per-member cap
+(`maxCreditsPerMember`) limits any single member but scales with headcount; once orgs self-serve
+which members reach the expensive execution paths (#1237), the balance is what caps total exposure.
+
+## Where the floor is enforced (evidence)
+
+Three independent layers, all keyed on the org balance when the request is org-billed:
+
+1. **Atomic pre-flight reservation** (primary, race-safe). Bare `$inc(-required)` then reject +
+   roll back if the returned `currentCredits < 0`. Because the check reads the value *returned by*
+   the atomic decrement, it closes the check-then-act race.
+   - chat: `b4m-core/services/src/llm/ChatCompletionProcess.ts` (reservation ~2445-2457, holder is
+     the org when org-billed ~2422-2426)
+   - CLI: `b4m-core/services/src/cliCompletions.ts` (~280-293)
+   - sound-effects: `apps/client/pages/api/ai/sound-effects.ts` (~114-123)
+
+2. **Settlement true-up clamp** (never-negative reconciliation). Pre-reservation runs on a local
+   *estimate*; provider-basis settlement can exceed it. `computeSettlementDelta`
+   (`ChatCompletionProcess.ts:539-550`) clamps the shortfall debit to the available balance and
+   reports the remainder as `writtenOffCredits` (uncollected revenue surfaced on the usage event
+   for margin reporting). The balance floors at zero; the platform eats the overrun rather than
+   pushing the customer negative. A `[BILLING_SHORTFALL_CLAMP]` warn fires when it triggers
+   (`ChatCompletionProcess.ts:3758-3767`).
+
+3. **Embed pre-gate** (settings-free). `assertOwnerHasCredits`
+   (`b4m-core/services/src/billing/assertOwnerHasCredits.ts`) refuses a broke owner *regardless* of
+   `enforceCredits`, so an anonymous embed end-user can never spend an org into the negative even on
+   a credits-off stage. Used by `apps/client/server/chatCompletion/external/embedRoute.ts:384`.
+
+## Consistency across spend paths
+
+- The atomic reservation is enforced identically in the three text/audio paths above, but it is
+  **inline-triplicated** rather than a shared helper. Currently consistent; a shared
+  `reserveOrReject` seam would prevent drift (suggested follow-up, deliberately not done here to
+  avoid refactoring hot billing paths under a "confirm" task).
+- The image/video/tool paths validate through the shared `validateUserCredits`
+  (`b4m-core/services/src/llm/tools/base/utils.ts`), which is a **check-then-act** comparison
+  against `organization.currentCredits` (not an atomic reserve). A concurrent-request window can
+  momentarily let two tool calls both pass the check, but the settlement clamp (layer 2) bounds the
+  aggregate so the balance still cannot end up negative. In-stream, the reserved balance is written
+  back to `organization.currentCredits` so mid-stream tool validation sees the reduced figure
+  (`ChatCompletionProcess.ts:2460-2461`).
+
+## Where it is (deliberately) soft
+
+- **`enforceCredits` toggle.** Layers 1 and 2 only run when the `enforceCredits` admin setting is
+  on. When off (self-host / credits-off deployments) nothing is reserved or floored - intentional.
+  Layer 3 (embed) is the exception and is settings-free.
+- **Concurrent settlement.** The settlement clamp is computed against a balance *snapshot* taken at
+  reservation time (`computeSettlementDelta` docstring). Under simultaneous settlements the snapshot
+  can be stale, so the never-negative guarantee is exact per single request and best-effort under
+  concurrency. Making it exact would require a conditional atomic decrement (`$inc` guarded by
+  `balance >= amount`) - out of scope for this confirmation; flag if concurrency-driven negatives
+  are observed.
+- **Per-member cap** (`maxCreditsPerMember`) is a documented check-then-act TOCTOU (off-by-one under
+  concurrency: `deductCreditsWithOrgSupport.ts:155`). That is the *per-member* axis, not the
+  org-wide balance, and does not affect the balance floor.
+
+## Regression coverage
+
+- `computeSettlementDelta` example cases and a swept **hard-stop invariant** (`available + delta >= 0`
+  for all inputs; shortfall conserved between collected and written-off) live in
+  `b4m-core/services/src/llm/ChatCompletion.test.ts`.
+- `assertOwnerHasCredits` (embed floor) is pinned in
+  `b4m-core/services/src/billing/assertOwnerHasCredits.test.ts`.


### PR DESCRIPTION
## Description

Adds a platform-admin **resolution override** to the org-groups capability spine (#1236). It lets a platform admin resolve group types (and the capabilities layered on them) AS an arbitrary set of an organization's group types *without being written into that organization's `users[]`*. This is the read-side primitive a downstream consumer needs to preview/operate-as a persona for testing and demos.

It is deliberately narrow:
- **isAdmin-only** and **scoped to the override's `organizationId`** — it can never widen a non-admin, and can never bleed into a different org.
- Changes only what is **resolved**, never what is **written** — the group write-path invariant (#1227/#1231) is untouched. The override takes no membership read and performs no mutation.
- Unknown keys are dropped and results de-duplicated + priority-sorted, exactly like the membership path, so the result is always a valid subset of the catalog.

## Changes

- `resolveGroupTypesForUser`: new optional `override` param + `GroupTypeResolutionOverride` type; when an admin overrides their target org, resolves AS the given types with no `findByOrganization` read. Extracted a shared `byCatalogPriority` comparator used by both the membership and override paths.
- `resolveCapabilitiesForUser` / `userHasCapability`: forward the optional `override` through to the type resolver so capabilities reflect the operated-as persona. The billing-owner implicit hold is **skipped** while an override is active (see review follow-ups below), so the override yields exactly that persona's capabilities even when the admin is also the org's `userId`.
- Both resolvers take an optional `logger` adapter (same shape as `setOrganizationGroupTypes`'). The override branch logs the org, the resolved types, and any dropped unknown keys - the only downstream evidence an override fired, since both functions return bare values.
- `organizationService/index.ts`: export the `GroupTypeResolutionOverride` type.
- Tests: 14 new cases across the two resolvers (admin override resolves without a membership read; unknown keys dropped + deduped; non-admin ignored; wrong-org ignored; capabilities/`userHasCapability` reflect the override; admin-is-owner in both directions; logger assertions). All prior spine tests still pass unchanged.

## Guide for Testers

This is a **backend, pure-function** change to the capability-resolution layer with no UI and no new endpoint. Verify via the unit suite.

1. From the repo root, run: `pnpm --filter @bike4mind/services exec vitest run src/organizationService/resolveGroupTypesForUser.test.ts src/organizationService/resolveCapabilitiesForUser.test.ts`
2. Expected result: all tests pass (30 total across the two files), including the new `platform-admin override (#1236)` describe blocks.
3. Type check: run `pnpm --filter @bike4mind/services typecheck:fast`. Expected: no errors.

### Regression Checks

- The existing `resolveGroupTypesForUser (#1235)` and `resolveCapabilitiesForUser (#1234)` cases (membership mapping, fail-closed, billing-owner implicit-hold) must still pass unchanged — the override is purely additive via an optional param.
- Confirm no caller is forced to pass `override`: it is optional and omitting it is the pre-existing behavior.

### What NOT to test

- No UI, route, or DB migration ships here. Do not look for a screen or endpoint. The operator affordance that *sets* the override (opt-in, non-sticky) is a separate downstream change and is not part of this PR. The resolver-side audit line for an applied override does ship here.

## Developer Notes

- **New extension point**: `resolveGroupTypesForUser`, `resolveCapabilitiesForUser`, and `userHasCapability` now accept an optional `{ override?: GroupTypeResolutionOverride }`. A consumer can resolve-as a set of an org's group types for an admin without mutating membership.
- **Reusable pattern**: the override is applied at the resolution layer only and gated on `isAdmin` + org scope, keeping the write-path invariant as the single source of truth for what is persisted. Read-side "operate-as" never touches the persisted graph.

Part of #1236 - deliberately not `Closes`. This ships the read-side primitive; the operator affordance that sets an override has zero production callers yet, so the issue stays open to track it and the call-site logging that goes with it.

## Review follow-ups (round 1)

- **The billing-owner claim was false.** The override gates on `isAdmin`; the implicit hold gates on `organization.userId === user.id`. They are independent, and an admin who created a demo org *is* that `userId` - the likely shape here. Unioned, a preview reported capabilities the persona does not hold: a false positive in the exact "does this persona see X?" check the affordance exists to answer. Fixed by skipping the hold under an active override, via a shared `isGroupTypeOverrideActive` predicate so the two resolvers cannot drift. Covered both ways: an owner-admin *with* an override gets only the persona, *without* one still gets their implicit hold.
- **Observability** (the unmet #1236 criterion): optional `logger` adapter, logged in the override branch. Also names dropped unknown keys, so a typo'd persona key no longer resolves silently to `[]`.
- **Docstrings**: the caller is the trust boundary for both `isAdmin` and `override` (the `user` param is structural and never re-read from the DB); and the override is deliberately catalog-bounded rather than intersected with the org's `allowedGroupTypes`, since previewing a type before its grant lands is a real use case.
- **Credit doc**: narrowed the layer-2 justification. The settlement clamp covers in-stream tool calls; standalone image/video generation never reaches `computeSettlementDelta` and deducts through a bare `$inc` with no floor guard, so it is bounded by check-then-act only and inherits the concurrency softness the doc already records. The verdict (hard stop per single request) is unchanged, and the regression section now says plainly that the unit test pins the clamp's arithmetic, not that any path calls it.
- **`computeSettlementDelta` sweep**: added a fractional-credit case; the integer grid stays because its conservation assertion uses exact equality.


---

## Also folded in: #1238 - organization credit balance is a hard stop (verification)

Combined here to keep it to one core review (both are #1172 follow-ups). This part is **doc + test only, no production change** - it confirms `Organization.currentCredits` is already a hard stop (a real floor, never driven negative) across the metered spend paths.

- `docs/architecture/org-credit-hard-stop.md` - evidence for the three enforcement layers (atomic pre-flight reservation, the never-negative settlement clamp `computeSettlementDelta`, and the settings-free embed pre-gate `assertOwnerHasCredits`) plus the deliberately-soft edges (`enforceCredits` toggle, best-effort concurrent settlement, per-member TOCTOU).
- `b4m-core/services/src/llm/ChatCompletion.test.ts` - a swept hard-stop invariant on `computeSettlementDelta`: settled balance `available + delta >= 0` for all inputs, shortfall conserved between collected and written-off.

Verify: `pnpm --filter @bike4mind/services exec vitest run src/llm/ChatCompletion.test.ts -t "computeSettlementDelta"` (7 pass). Merging this unblocks #1237 and #1178.

Closes #1238

