### PR TITLE
test(billing): pin organization credit balance as a hard stop (#1238)

### DIFF
--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -1994,6 +1994,36 @@ describe('computeSettlementDelta (zero-balance shortfall clamp)', () => {
   it('treats a negative balance snapshot as zero', () => {
     expect(computeSettlementDelta(100, 130, -50)).toEqual({ delta: 0, writtenOffCredits: 30 });
   });
+
+  // #1238: the org-wide balance is a HARD STOP - the settlement true-up must never drive it
+  // negative. Pin the invariant across a swept input range, not just the examples above, so a
+  // future refactor of the clamp can't quietly reintroduce a negative-balance path.
+  it('never drives the settled balance below zero, and conserves the shortfall (hard-stop invariant)', () => {
+    for (let reserved = 0; reserved <= 200; reserved += 25) {
+      for (let used = 0; used <= 300; used += 25) {
+        for (let available = 0; available <= 300; available += 25) {
+          const { delta, writtenOffCredits } = computeSettlementDelta(reserved, used, available);
+          // The balance already moved by `reserved` at reservation; settlement applies `delta`.
+          // Post-settlement balance = available + delta and must never be negative.
+          expect(available + delta).toBeGreaterThanOrEqual(0);
+          expect(writtenOffCredits).toBeGreaterThanOrEqual(0);
+          if (used <= reserved) {
+            // Over- or exactly-reserved: pure refund/no-op, nothing written off.
+            expect(writtenOffCredits).toBe(0);
+            expect(delta).toBe(reserved - used);
+          } else {
+            // Under-reserved: the shortfall is either collected (via -delta) or written off,
+            // and the collected part is clamped to what the balance can actually cover.
+            const shortfall = used - reserved;
+            // delta <= 0 here (a shortfall debit); Math.abs avoids a -0 vs +0 Object.is mismatch.
+            const collected = Math.abs(delta);
+            expect(collected + writtenOffCredits).toBe(shortfall);
+            expect(collected).toBe(Math.min(shortfall, available));
+          }
+        }
+      }
+    }
+  });
 });
 
 describe('clampFraction (verbatim window fraction admin setting)', () => {

--- a/docs/architecture/org-credit-hard-stop.md
+++ b/docs/architecture/org-credit-hard-stop.md
@@ -1,0 +1,75 @@
+# Organization credit balance: hard stop verification (#1238)
+
+**Question:** Is an organization's `currentCredits` balance a hard stop (a real floor that
+rejects spend at zero), or a soft limit that can be pushed negative?
+
+**Verdict: it is a hard stop.** An org's balance floors at zero on every metered spend path; it is
+never driven negative in the single-request path. The one residual soft edge is concurrent
+settlement (best-effort, already documented in code), and the whole floor is gated on the
+`enforceCredits` admin setting by design (except the embed path, which is settings-free).
+
+This matters because org-wide balance is the only bound on *aggregate* spend. The per-member cap
+(`maxCreditsPerMember`) limits any single member but scales with headcount; once orgs self-serve
+which members reach the expensive execution paths (#1237), the balance is what caps total exposure.
+
+## Where the floor is enforced (evidence)
+
+Three independent layers, all keyed on the org balance when the request is org-billed:
+
+1. **Atomic pre-flight reservation** (primary, race-safe). Bare `$inc(-required)` then reject +
+   roll back if the returned `currentCredits < 0`. Because the check reads the value *returned by*
+   the atomic decrement, it closes the check-then-act race.
+   - chat: `b4m-core/services/src/llm/ChatCompletionProcess.ts` (reservation ~2445-2457, holder is
+     the org when org-billed ~2422-2426)
+   - CLI: `b4m-core/services/src/cliCompletions.ts` (~280-293)
+   - sound-effects: `apps/client/pages/api/ai/sound-effects.ts` (~114-123)
+
+2. **Settlement true-up clamp** (never-negative reconciliation). Pre-reservation runs on a local
+   *estimate*; provider-basis settlement can exceed it. `computeSettlementDelta`
+   (`ChatCompletionProcess.ts:539-550`) clamps the shortfall debit to the available balance and
+   reports the remainder as `writtenOffCredits` (uncollected revenue surfaced on the usage event
+   for margin reporting). The balance floors at zero; the platform eats the overrun rather than
+   pushing the customer negative. A `[BILLING_SHORTFALL_CLAMP]` warn fires when it triggers
+   (`ChatCompletionProcess.ts:3758-3767`).
+
+3. **Embed pre-gate** (settings-free). `assertOwnerHasCredits`
+   (`b4m-core/services/src/billing/assertOwnerHasCredits.ts`) refuses a broke owner *regardless* of
+   `enforceCredits`, so an anonymous embed end-user can never spend an org into the negative even on
+   a credits-off stage. Used by `apps/client/server/chatCompletion/external/embedRoute.ts:384`.
+
+## Consistency across spend paths
+
+- The atomic reservation is enforced identically in the three text/audio paths above, but it is
+  **inline-triplicated** rather than a shared helper. Currently consistent; a shared
+  `reserveOrReject` seam would prevent drift (suggested follow-up, deliberately not done here to
+  avoid refactoring hot billing paths under a "confirm" task).
+- The image/video/tool paths validate through the shared `validateUserCredits`
+  (`b4m-core/services/src/llm/tools/base/utils.ts`), which is a **check-then-act** comparison
+  against `organization.currentCredits` (not an atomic reserve). A concurrent-request window can
+  momentarily let two tool calls both pass the check, but the settlement clamp (layer 2) bounds the
+  aggregate so the balance still cannot end up negative. In-stream, the reserved balance is written
+  back to `organization.currentCredits` so mid-stream tool validation sees the reduced figure
+  (`ChatCompletionProcess.ts:2460-2461`).
+
+## Where it is (deliberately) soft
+
+- **`enforceCredits` toggle.** Layers 1 and 2 only run when the `enforceCredits` admin setting is
+  on. When off (self-host / credits-off deployments) nothing is reserved or floored - intentional.
+  Layer 3 (embed) is the exception and is settings-free.
+- **Concurrent settlement.** The settlement clamp is computed against a balance *snapshot* taken at
+  reservation time (`computeSettlementDelta` docstring). Under simultaneous settlements the snapshot
+  can be stale, so the never-negative guarantee is exact per single request and best-effort under
+  concurrency. Making it exact would require a conditional atomic decrement (`$inc` guarded by
+  `balance >= amount`) - out of scope for this confirmation; flag if concurrency-driven negatives
+  are observed.
+- **Per-member cap** (`maxCreditsPerMember`) is a documented check-then-act TOCTOU (off-by-one under
+  concurrency: `deductCreditsWithOrgSupport.ts:155`). That is the *per-member* axis, not the
+  org-wide balance, and does not affect the balance floor.
+
+## Regression coverage
+
+- `computeSettlementDelta` example cases and a swept **hard-stop invariant** (`available + delta >= 0`
+  for all inputs; shortfall conserved between collected and written-off) live in
+  `b4m-core/services/src/llm/ChatCompletion.test.ts`.
+- `assertOwnerHasCredits` (embed floor) is pinned in
+  `b4m-core/services/src/billing/assertOwnerHasCredits.test.ts`.


### PR DESCRIPTION
## Description

Confirms the org-wide `Organization.currentCredits` balance is a **hard stop** (a real floor that rejects spend at zero), not a soft limit that can be pushed negative (#1238). **No production change was needed** - the behavior is already correct across the metered spend paths; this PR records the evidence and pins the invariant so it can't silently regress.

Why it matters: org-wide balance is the only bound on *aggregate* spend. The per-member cap limits any single member but scales with headcount; once orgs self-serve which members reach the expensive execution paths (#1237), the balance is what caps total exposure.

### Verdict: hard stop. Enforced in three layers (evidence in the doc)

1. **Atomic pre-flight reservation** (race-safe) - bare `$inc(-required)` then reject + rollback if the returned `currentCredits < 0`. chat (`ChatCompletionProcess.ts`), CLI (`cliCompletions.ts`), sound-effects (`ai/sound-effects.ts`).
2. **Settlement true-up clamp** - `computeSettlementDelta` clamps an under-estimate shortfall to the available balance and writes off the remainder (`writtenOffCredits`); the balance floors at zero, the platform eats the overrun.
3. **Embed pre-gate** - `assertOwnerHasCredits` is settings-free, so an anonymous embed user can't spend an org negative even with `enforceCredits` off.

### Deliberately-soft edges (documented, not bugs)

- `enforceCredits` toggle gates layers 1-2 (self-host / credits-off runs free by design; the embed gate is the settings-free exception).
- Concurrent settlement is best-effort (the clamp uses a balance snapshot; already noted in code).
- The per-member cap TOCTOU is a *different* axis and does not affect the balance floor.

## Changes

- `docs/architecture/org-credit-hard-stop.md` - the verification write-up with file:line evidence, the consistency analysis across spend paths, and the soft edges.
- `b4m-core/services/src/llm/ChatCompletion.test.ts` - a swept **hard-stop invariant** test on `computeSettlementDelta`: for all inputs the settled balance `available + delta >= 0` and the shortfall is conserved between collected and written-off.

## Guide for Testers

Backend/verification-only PR - no UI, no runtime behavior change. Verify via the unit suite and the doc.

1. From the repo root, run: `pnpm --filter @bike4mind/services exec vitest run src/llm/ChatCompletion.test.ts -t "computeSettlementDelta"`
2. Expected: 7 passed (the 6 existing example cases + the new swept `hard-stop invariant`).
3. Type check: `pnpm --filter @bike4mind/services typecheck:fast` -> no errors.
4. Read `docs/architecture/org-credit-hard-stop.md` and spot-check two of the cited call sites resolve to a `currentCredits < 0` rejection (`cliCompletions.ts` reservation) and the clamp (`computeSettlementDelta`).

### Regression Checks

- The 6 pre-existing `computeSettlementDelta` example tests still pass unchanged; the new test is additive.
- No production source changed, so no spend-path behavior should differ - confirm the diff is doc + test only.

### What NOT to test

- No live billing run is required (and none should be started against prod). The invariant is a pure-function property; the reservation-floor rejection is exercised by the existing billing integration tests, not this PR.

## Additional Information

Follow-up worth considering (intentionally not done here to avoid refactoring hot billing paths under a confirmation task): the atomic reservation is inline-triplicated across chat/CLI/sound-effects; a shared `reserveOrReject` seam would prevent drift. And making the never-negative guarantee exact under concurrent settlement would need a conditional atomic decrement (`$inc` guarded by `balance >= amount`).

Part of #1172. Related: #1237 (which is unblocked once this lands).

Closes #1238
