### PR TITLE
fix(llm-adapters): clamp max_tokens on non-streaming Anthropic requests

### DIFF
--- a/b4m-core/llm-adapters/src/anthropicBackend.nonStreamingMaxTokens.test.ts
+++ b/b4m-core/llm-adapters/src/anthropicBackend.nonStreamingMaxTokens.test.ts
@@ -49,9 +49,15 @@ function buildBackend() {
   return { backend, getCaptured: () => captured };
 }
 
-async function runComplete(backend: AnthropicBackend, options: Partial<ICompletionOptions>): Promise<void> {
+async function runComplete(
+  backend: AnthropicBackend,
+  options: Partial<ICompletionOptions>,
+  // Opus 5 is adaptive; the legacy-thinking cases need a model that still takes an
+  // explicit budget_tokens, which is the shape the clamp has to keep consistent.
+  model: string = ChatModels.CLAUDE_5_OPUS
+): Promise<void> {
   try {
-    await backend.complete(ChatModels.CLAUDE_5_OPUS, [{ role: 'user', content: 'hi' }], options, async () => undefined);
+    await backend.complete(model, [{ role: 'user', content: 'hi' }], options, async () => undefined);
   } catch (err) {
     if (err !== SENTINEL) throw err;
   }
@@ -84,5 +90,38 @@ describe('AnthropicBackend non-streaming max_tokens ceiling', () => {
     await runComplete(backend, { stream: true, maxTokens: 64_000 });
 
     expect(getCaptured()[0].max_tokens).toBe(64_000);
+  });
+
+  // A legacy thinking budget is spent inside max_tokens, and the API rejects a budget
+  // that is not strictly below it. Lowering only the ceiling would swap the SDK's error
+  // for a 400 - still no answer, just a more confusing one.
+  it('brings a legacy thinking budget down with the ceiling', async () => {
+    const { backend, getCaptured } = buildBackend();
+
+    await runComplete(backend, {
+      stream: false,
+      thinking: { enabled: true, budget_tokens: 30_000 },
+    } as Partial<ICompletionOptions>, ChatModels.CLAUDE_4_6_OPUS);
+
+    const sent = getCaptured()[0];
+    const maxTokens = sent.max_tokens as number;
+    const budget = (sent.thinking as { budget_tokens: number }).budget_tokens;
+    expect(budget).toBeLessThan(maxTokens);
+    expect(sdkWouldReject(maxTokens)).toBe(false);
+    // Anthropic's own floor for a thinking budget.
+    expect(budget).toBeGreaterThanOrEqual(1024);
+  });
+
+  it('leaves a legacy thinking budget alone when streaming', async () => {
+    const { backend, getCaptured } = buildBackend();
+
+    await runComplete(backend, {
+      stream: true,
+      thinking: { enabled: true, budget_tokens: 30_000 },
+    } as Partial<ICompletionOptions>, ChatModels.CLAUDE_4_6_OPUS);
+
+    const sent = getCaptured()[0];
+    expect((sent.thinking as { budget_tokens: number }).budget_tokens).toBe(30_000);
+    expect(sent.max_tokens).toBe(31_000);
   });
 });

--- a/b4m-core/llm-adapters/src/anthropicBackend.nonStreamingMaxTokens.test.ts
+++ b/b4m-core/llm-adapters/src/anthropicBackend.nonStreamingMaxTokens.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The Anthropic SDK refuses a non-streaming request whose max_tokens implies it could
+ * run past its 10-minute ceiling, throwing before any HTTP call is made:
+ *
+ *   _calculateNonstreamingTimeout(maxTokens):
+ *     expectedTimeout = 60min * maxTokens / 128000
+ *     if (expectedTimeout > 10min) throw AnthropicError('Streaming is required ...')
+ *
+ * which puts the real limit at 128000 * 10 / 60 = 21333 tokens.
+ *
+ * That made a large budget plus stream:false an unconditional failure rather than a
+ * long request. It surfaced when adaptive models started defaulting to the 64K
+ * ADAPTIVE_THINKING_MAX_TOKENS_FLOOR: every non-streaming Opus 5 turn died with a
+ * generic error and no output tokens. The same trap predates that default via
+ * buildThinkingParams, which sizes adaptive max_tokens at the same floor whenever
+ * thinking is enabled.
+ *
+ * These cases pin the clamp: non-streaming requests are trimmed to a budget the SDK
+ * will accept, and streaming requests keep the full budget.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ChatModels } from '@bike4mind/common';
+import { AnthropicBackend } from './anthropicBackend';
+import type { ICompletionOptions } from './backend';
+
+const SENTINEL = new Error('captured-params-sentinel');
+
+/** Mirrors the SDK guard, so the assertions fail if its formula is ever retuned. */
+function sdkWouldReject(maxTokens: number): boolean {
+  return (60 * 60 * maxTokens) / 128_000 > 10 * 60;
+}
+
+function buildBackend() {
+  const backend = new AnthropicBackend('test-key');
+  const captured: Record<string, unknown>[] = [];
+  (backend as unknown as { _api: unknown })._api = {
+    messages: {
+      create: async (apiParams: Record<string, unknown>) => {
+        captured.push(apiParams);
+        throw SENTINEL;
+      },
+      stream: (apiParams: Record<string, unknown>) => {
+        captured.push(apiParams);
+        throw SENTINEL;
+      },
+    },
+  };
+  return { backend, getCaptured: () => captured };
+}
+
+async function runComplete(backend: AnthropicBackend, options: Partial<ICompletionOptions>): Promise<void> {
+  try {
+    await backend.complete(ChatModels.CLAUDE_5_OPUS, [{ role: 'user', content: 'hi' }], options, async () => undefined);
+  } catch (err) {
+    if (err !== SENTINEL) throw err;
+  }
+}
+
+describe('AnthropicBackend non-streaming max_tokens ceiling', () => {
+  it('clamps a 64K budget on a non-streaming request to something the SDK accepts', async () => {
+    const { backend, getCaptured } = buildBackend();
+
+    await runComplete(backend, { stream: false, maxTokens: 64_000 });
+
+    const sent = getCaptured()[0].max_tokens as number;
+    expect(sent).toBeLessThan(64_000);
+    expect(sdkWouldReject(sent)).toBe(false);
+  });
+
+  it('leaves a modest non-streaming budget untouched', async () => {
+    const { backend, getCaptured } = buildBackend();
+
+    await runComplete(backend, { stream: false, maxTokens: 4096 });
+
+    expect(getCaptured()[0].max_tokens).toBe(4096);
+  });
+
+  // The clamp is a workaround for a non-streaming-only limit; streaming has no such
+  // ceiling, so the full budget must survive or adaptive models lose their headroom.
+  it('preserves the full budget when streaming', async () => {
+    const { backend, getCaptured } = buildBackend();
+
+    await runComplete(backend, { stream: true, maxTokens: 64_000 });
+
+    expect(getCaptured()[0].max_tokens).toBe(64_000);
+  });
+});

--- a/b4m-core/llm-adapters/src/anthropicBackend.nonStreamingMaxTokens.test.ts
+++ b/b4m-core/llm-adapters/src/anthropicBackend.nonStreamingMaxTokens.test.ts
@@ -112,6 +112,23 @@ describe('AnthropicBackend non-streaming max_tokens ceiling', () => {
     expect(budget).toBeGreaterThanOrEqual(1024);
   });
 
+  // A budget that merely squeaks under the ceiling satisfies the API but starves the
+  // answer to a token or two, which is the same empty reply the clamp exists to avoid.
+  it('claws back the answer headroom from a budget that only just fits', async () => {
+    const { backend, getCaptured } = buildBackend();
+
+    await runComplete(
+      backend,
+      { stream: false, thinking: { enabled: true, budget_tokens: 20_999 } } as Partial<ICompletionOptions>,
+      ChatModels.CLAUDE_4_6_OPUS
+    );
+
+    const sent = getCaptured()[0];
+    const maxTokens = sent.max_tokens as number;
+    const budget = (sent.thinking as { budget_tokens: number }).budget_tokens;
+    expect(maxTokens - budget).toBeGreaterThanOrEqual(1000);
+  });
+
   it('leaves a legacy thinking budget alone when streaming', async () => {
     const { backend, getCaptured } = buildBackend();
 

--- a/b4m-core/llm-adapters/src/anthropicBackend.ts
+++ b/b4m-core/llm-adapters/src/anthropicBackend.ts
@@ -33,7 +33,7 @@ import { handleToolResultStreaming } from './toolStreamingHelper';
 import { ensureToolPairingIntegrity, stripAllToolBlocks } from './toolPairingUtils';
 import { getCachingAdapter, logCacheStats } from './caching/adapters';
 import { withRetry, isUserInitiatedAbort, isRetryableError } from '@bike4mind/common';
-import { buildThinkingParams, type ThinkingConfig } from './thinkingParams';
+import { buildThinkingParams, THINKING_ANSWER_HEADROOM_TOKENS, type ThinkingConfig } from './thinkingParams';
 import { DispatchModel } from './dispatchModel';
 import { acquireSlot, releaseSlot } from './_anthropicSemaphore';
 
@@ -1022,6 +1022,15 @@ export class AnthropicBackend implements ICompletionBackend {
         { model }
       );
       apiParams.max_tokens = ANTHROPIC_NONSTREAMING_MAX_TOKENS;
+
+      // A legacy thinking budget is spent inside max_tokens and the API rejects one that
+      // is not strictly below it, so lowering the ceiling has to bring the budget down
+      // with it - otherwise the clamp trades the SDK's error for a 400 instead of a
+      // working turn. The ceiling keeps the result well above Anthropic's 1024 minimum.
+      const thinking = apiParams.thinking;
+      if (thinking?.type === 'enabled' && thinking.budget_tokens >= apiParams.max_tokens) {
+        thinking.budget_tokens = apiParams.max_tokens - THINKING_ANSWER_HEADROOM_TOKENS;
+      }
     }
 
     // Setup the actual API call with API-specific options

--- a/b4m-core/llm-adapters/src/anthropicBackend.ts
+++ b/b4m-core/llm-adapters/src/anthropicBackend.ts
@@ -66,6 +66,14 @@ const REQUEST_TIMEOUT_MS = 60000; // 60s timeout for the initial API request bef
 const SLOW_MODEL_REQUEST_TIMEOUT_MS = 120000; // 120s for slow/opus-class models that need longer to begin streaming
 
 /**
+ * Largest max_tokens the SDK will accept without streaming. It derives a projected
+ * duration of 60min * max_tokens / 128000 and throws outright once that exceeds its
+ * 10-minute non-streaming ceiling, so the real limit is 128000 * 10 / 60 = 21333.
+ * Floored to a round number for headroom against that formula being retuned.
+ */
+const ANTHROPIC_NONSTREAMING_MAX_TOKENS = 21_000;
+
+/**
  * Accumulated multi-turn cache token total. Undefined when zero so turns
  * without cache activity keep the pre-cache callback shape.
  */
@@ -999,6 +1007,21 @@ export class AnthropicBackend implements ICompletionBackend {
         cacheHistory: cacheStrategy.cacheConversationHistory,
         cacheTTL: cacheStrategy.cacheTTL,
       });
+    }
+
+    // The SDK refuses a non-streaming request whose max_tokens implies it could run
+    // past its 10-minute ceiling, throwing before any HTTP call is made (see
+    // Anthropic.calculateNonstreamingTimeout: 60min * max_tokens / 128000 > 10min).
+    // Clamping is strictly better than the alternative, which is not a shorter answer
+    // but no answer at all. Reachable from any caller that pairs a large budget with
+    // stream:false - notably an adaptive model, where both the no-budget default and
+    // buildThinkingParams size max_tokens at ADAPTIVE_THINKING_MAX_TOKENS_FLOOR (64K).
+    if (!options.stream && apiParams.max_tokens > ANTHROPIC_NONSTREAMING_MAX_TOKENS) {
+      this.logger.warn(
+        `[AnthropicBackend] max_tokens ${apiParams.max_tokens} exceeds the non-streaming ceiling; clamping to ${ANTHROPIC_NONSTREAMING_MAX_TOKENS}. Stream this request to use the full budget.`,
+        { model }
+      );
+      apiParams.max_tokens = ANTHROPIC_NONSTREAMING_MAX_TOKENS;
     }
 
     // Setup the actual API call with API-specific options

--- a/b4m-core/llm-adapters/src/anthropicBackend.ts
+++ b/b4m-core/llm-adapters/src/anthropicBackend.ts
@@ -1023,13 +1023,16 @@ export class AnthropicBackend implements ICompletionBackend {
       );
       apiParams.max_tokens = ANTHROPIC_NONSTREAMING_MAX_TOKENS;
 
-      // A legacy thinking budget is spent inside max_tokens and the API rejects one that
-      // is not strictly below it, so lowering the ceiling has to bring the budget down
-      // with it - otherwise the clamp trades the SDK's error for a 400 instead of a
-      // working turn. The ceiling keeps the result well above Anthropic's 1024 minimum.
+      // A legacy thinking budget is spent inside max_tokens, so lowering the ceiling has
+      // to bring the budget down with it. Keyed on the headroom rather than on max_tokens
+      // itself: a budget merely below the ceiling (20_999 against 21_000) satisfies the
+      // API yet leaves a single token for the visible answer, which is the same empty
+      // reply this whole clamp exists to avoid. The ceiling keeps the result well above
+      // Anthropic's 1024 minimum budget.
+      const maxThinkingBudget = apiParams.max_tokens - THINKING_ANSWER_HEADROOM_TOKENS;
       const thinking = apiParams.thinking;
-      if (thinking?.type === 'enabled' && thinking.budget_tokens >= apiParams.max_tokens) {
-        thinking.budget_tokens = apiParams.max_tokens - THINKING_ANSWER_HEADROOM_TOKENS;
+      if (thinking?.type === 'enabled' && thinking.budget_tokens > maxThinkingBudget) {
+        thinking.budget_tokens = maxThinkingBudget;
       }
     }
 

--- a/b4m-core/llm-adapters/src/thinkingParams.ts
+++ b/b4m-core/llm-adapters/src/thinkingParams.ts
@@ -22,9 +22,10 @@ export type ThinkingConfig =
 export const ADAPTIVE_THINKING_MAX_TOKENS_FLOOR = 64_000;
 
 /**
- * Room reserved for the visible answer above a legacy thinking budget. The API rejects
- * a budget_tokens that is not strictly below max_tokens, so anything that moves either
- * value has to preserve this gap - see the non-streaming clamp in anthropicBackend.
+ * Room reserved for the visible answer above a legacy thinking budget. The API rejects a
+ * thinking budget that is not strictly below max_tokens, and a budget that merely squeaks
+ * under it starves the answer instead, so anything that moves either value has to preserve
+ * this gap - see the non-streaming clamp in anthropicBackend.
  */
 export const THINKING_ANSWER_HEADROOM_TOKENS = 1000;
 

--- a/b4m-core/llm-adapters/src/thinkingParams.ts
+++ b/b4m-core/llm-adapters/src/thinkingParams.ts
@@ -22,6 +22,13 @@ export type ThinkingConfig =
 export const ADAPTIVE_THINKING_MAX_TOKENS_FLOOR = 64_000;
 
 /**
+ * Room reserved for the visible answer above a legacy thinking budget. The API rejects
+ * a budget_tokens that is not strictly below max_tokens, so anything that moves either
+ * value has to preserve this gap - see the non-streaming clamp in anthropicBackend.
+ */
+export const THINKING_ANSWER_HEADROOM_TOKENS = 1000;
+
+/**
  * Resolves the output budget to send as max_tokens.
  *
  * The distinction that matters: `requested` being undefined means the caller
@@ -103,7 +110,7 @@ export function buildThinkingParams(
   }
 
   // Legacy models: explicit budget_tokens, inflate max_tokens to fit
-  const maxTokens = Math.max(currentMaxTokens, budgetTokens + 1000);
+  const maxTokens = Math.max(currentMaxTokens, budgetTokens + THINKING_ANSWER_HEADROOM_TOKENS);
 
   return {
     thinkingConfig: {


### PR DESCRIPTION
## What

Non-streaming Anthropic requests are now clamped to a `max_tokens` the SDK will accept. Streaming requests are untouched and keep the full budget.

## Why

The Anthropic SDK refuses a non-streaming request whose `max_tokens` implies it could run past its 10-minute ceiling, and it throws **before any HTTP call is made**:

```js
_calculateNonstreamingTimeout(maxTokens) {
  const expectedTimeout = (60 * 60 * maxTokens) / 128_000;
  if (expectedTimeout > 10 * 60) throw new AnthropicError('Streaming is required ...');
}
```

That puts the real limit at `128000 * 10 / 60` = **21,333 tokens**.

#1209 gave adaptive reasoning models a 64K default output budget. `/api/chat` defaults `stream` to `false`, so every non-streaming Opus 5 turn started failing immediately: quest `status: stopped`, no output tokens, and a generic "Something went wrong while processing your request." Reported from live use, reproduced two for two.

The same trap predates that default: `buildThinkingParams` sizes adaptive `max_tokens` at the same 64K floor whenever thinking is enabled, so any caller pairing that with `stream: false` hit it too. Fixing it in the adapter covers both, since the constraint is a property of the Anthropic non-streaming API rather than of any one caller.

Clamping is strictly better than the alternative, which is not a shorter answer but no answer at all.

## Testing

New `anthropicBackend.nonStreamingMaxTokens.test.ts` pins all three behaviors: a 64K non-streaming budget is clamped below the SDK's threshold, a modest budget is left alone, and a streaming request keeps the full 64K. The test mirrors the SDK's own formula, so it fails if that formula is ever retuned. Verified failing without the clamp and passing with it.

`llm-adapters` 605 tests and `services` 3105 tests pass; `turbo:typecheck` clean.

## Note

Not addressed here: this only restores Anthropic adaptive models. OpenAI reasoning models (e.g. GPT-5.6 Sol) still get the plain 4096 default, because `thinkingStyle` describes only the two Anthropic request shapes. Reports of those returning empty output are the original starvation bug, still unfixed for that provider - worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)