### PR TITLE
fix(llm-adapters): give OpenAI reasoning models output headroom too

### DIFF
--- a/b4m-core/common/src/schemas/openai.ts
+++ b/b4m-core/common/src/schemas/openai.ts
@@ -14,9 +14,9 @@ export const ChatCompletionCreateInputSchema = z.object({
   /**
    * Optional so "the caller expressed no output budget" stays distinguishable from
    * "the caller asked for exactly N". ChatCompletionProcess resolves the absent case
-   * against the resolved model, which is the only layer that knows whether it is an
-   * adaptive reasoning model (those need a larger default - see
-   * ADAPTIVE_THINKING_MAX_TOKENS_FLOOR). A number here is treated as deliberate.
+   * against the resolved model, which is the only layer that knows whether it reasons
+   * inside the output budget (those need a larger default - see
+   * reasonsWithinOutputBudget). A number here is treated as deliberate.
    */
   max_tokens: z.number().optional(),
   presence_penalty: z.number().min(-2).max(2).optional(),

--- a/b4m-core/llm-adapters/src/thinkingParams.test.ts
+++ b/b4m-core/llm-adapters/src/thinkingParams.test.ts
@@ -15,6 +15,26 @@ const baseModelInfo: ModelInfo = {
 };
 
 const legacyModel: ModelInfo = { ...baseModelInfo };
+
+/** GPT-5.6 Sol: a hardcoded OpenAI reasoning model, so REASONING_SUPPORTED_MODELS knows it. */
+const openAiReasoningModel: ModelInfo = {
+  ...baseModelInfo,
+  id: ChatModels.GPT5_6_SOL,
+  name: 'GPT-5.6 Sol',
+  backend: ModelBackend.OpenAI,
+  thinkingStyle: undefined,
+};
+
+/** The same shape, but an id no hardcoded set lists - only the dispatch profile identifies it. */
+const catalogOnlyReasoningModel: ModelInfo = {
+  ...baseModelInfo,
+  id: 'some-unlisted-reasoning-model' as ModelInfo['id'],
+  name: 'Unlisted reasoning model',
+  backend: ModelBackend.OpenAI,
+  thinkingStyle: undefined,
+  can_think: true,
+  dispatchProfile: { maxTokensParam: 'max_completion_tokens', toolTransport: 'chat' },
+};
 const adaptiveModel: ModelInfo = {
   ...baseModelInfo,
   id: ChatModels.CLAUDE_4_7_OPUS,
@@ -92,7 +112,7 @@ describe('resolveOutputMaxTokens', () => {
     resolveOutputMaxTokens({
       requested,
       fallback: 4096,
-      thinkingStyle: modelInfo.thinkingStyle,
+      modelInfo,
       modelMaxOutputTokens: modelInfo.max_tokens,
     });
 
@@ -111,6 +131,10 @@ describe('resolveOutputMaxTokens', () => {
     it('honors a budget on a legacy model', () => {
       expect(resolve(16_000, legacyModel)).toBe(16_000);
     });
+
+    it('honors a budget on an OpenAI reasoning model', () => {
+      expect(resolve(16_000, openAiReasoningModel)).toBe(16_000);
+    });
   });
 
   describe('absence is sized for the model', () => {
@@ -120,6 +144,24 @@ describe('resolveOutputMaxTokens', () => {
 
     it('defaults a legacy model to the caller-supplied fallback', () => {
       expect(resolve(undefined, legacyModel)).toBe(4096);
+    });
+
+    // The starvation this fixes: OpenAI spends reasoning inside max_completion_tokens,
+    // so a 4096 default was consumed entirely by reasoning and the turn came back empty.
+    it('defaults an OpenAI reasoning model to the shared floor', () => {
+      expect(resolve(undefined, openAiReasoningModel)).toBe(ADAPTIVE_THINKING_MAX_TOKENS_FLOOR);
+    });
+
+    // Catalog-only reasoning models are not in any hardcoded set, so the reasoning-shaped
+    // max-tokens param plus can_think has to carry them.
+    it('defaults an unlisted but reasoning-shaped catalog model to the shared floor', () => {
+      expect(resolve(undefined, catalogOnlyReasoningModel)).toBe(ADAPTIVE_THINKING_MAX_TOKENS_FLOOR);
+    });
+
+    // can_think alone must not trigger headroom: legacy thinking is opt-in and
+    // separately budgeted, so these models would pay for room they never use.
+    it('does not give a non-reasoning-shaped model the floor merely for can_think', () => {
+      expect(resolve(undefined, { ...legacyModel, can_think: true })).toBe(4096);
     });
   });
 

--- a/b4m-core/llm-adapters/src/thinkingParams.ts
+++ b/b4m-core/llm-adapters/src/thinkingParams.ts
@@ -1,4 +1,4 @@
-import { NO_TEMPERATURE_MODELS, type ModelInfo } from '@bike4mind/common';
+import { NO_TEMPERATURE_MODELS, REASONING_SUPPORTED_MODELS, type ModelInfo } from '@bike4mind/common';
 
 /**
  * Thinking parameter shapes for the Anthropic Messages API.
@@ -22,7 +22,28 @@ export type ThinkingConfig =
 export const ADAPTIVE_THINKING_MAX_TOKENS_FLOOR = 64_000;
 
 /**
- * Resolves the output budget to send as max_tokens.
+ * Whether the model spends reasoning tokens inside its output budget on every turn,
+ * which is what makes a small budget produce an empty visible reply rather than a
+ * short one. Provider-agnostic on purpose: the trap is identical whether the tokens
+ * are Anthropic extended thinking inside max_tokens or OpenAI reasoning inside
+ * max_completion_tokens.
+ *
+ * Deliberately NOT keyed on can_think alone. Anthropic legacy models set it too, but
+ * their thinking is opt-in and separately budgeted, so they do not starve at a small
+ * default and should not pay for headroom they will not use.
+ *
+ * The last clause is the catalog-only case: a reasoning-shaped model we never
+ * hardcoded still declares a reasoning-shaped max-tokens param, which openaiBackend
+ * already pairs with can_think for the same "not in our tables" reason.
+ */
+export function reasonsWithinOutputBudget(modelInfo: ModelInfo): boolean {
+  if (modelInfo.thinkingStyle === 'adaptive') return true;
+  if (REASONING_SUPPORTED_MODELS.has(modelInfo.id)) return true;
+  return modelInfo.dispatchProfile?.maxTokensParam === 'max_completion_tokens' && modelInfo.can_think === true;
+}
+
+/**
+ * Resolves the output budget to send as the model's max-tokens param.
  *
  * The distinction that matters: `requested` being undefined means the caller
  * expressed no preference, which is the only case we are free to size for the
@@ -32,23 +53,23 @@ export const ADAPTIVE_THINKING_MAX_TOKENS_FLOOR = 64_000;
  * bump is neither harmless nor invisible. Explicit values are still clamped down
  * to the model's own cap, since over-requesting 400s the whole turn.
  *
- * Adaptive reasoning models default to ADAPTIVE_THINKING_MAX_TOKENS_FLOOR because
- * they spend extended-thinking tokens inside max_tokens: a small default can be
- * consumed entirely by reasoning, leaving an empty visible reply.
+ * Models that reason inside the output budget default to
+ * ADAPTIVE_THINKING_MAX_TOKENS_FLOOR: a small default can be consumed entirely by
+ * reasoning, leaving an empty visible reply.
  */
 export function resolveOutputMaxTokens({
   requested,
   fallback,
-  thinkingStyle,
+  modelInfo,
   modelMaxOutputTokens,
 }: {
   requested: number | undefined;
   /** Default for models that do not reason inside the output budget. */
   fallback: number;
-  thinkingStyle: ModelInfo['thinkingStyle'];
+  modelInfo: ModelInfo;
   modelMaxOutputTokens: number;
 }): number {
-  const preferred = requested ?? (thinkingStyle === 'adaptive' ? ADAPTIVE_THINKING_MAX_TOKENS_FLOOR : fallback);
+  const preferred = requested ?? (reasonsWithinOutputBudget(modelInfo) ? ADAPTIVE_THINKING_MAX_TOKENS_FLOOR : fallback);
   return Math.min(preferred, modelMaxOutputTokens);
 }
 

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -1540,7 +1540,19 @@ export class ChatCompletionProcess {
       // model (a context window smaller than its own reserved output). Clamping there would
       // silently restore the empty payload that guard exists to catch.
       const modelMaxOutput = modelInfo.max_tokens ?? 16384;
-      const safeInputTokens = Math.max(0, safeInputWindow(modelInfo, params.max_tokens ?? modelMaxOutput));
+      // Resolved here, above its first use, because BOTH safeInputWindow callers have to
+      // reserve the same output or the window drifts - which is exactly what the note
+      // above promises cannot happen. Falling back to the model's full output cap was
+      // that drift: once an absent max_tokens became representable, this reserved the
+      // whole cap while assembly reserved the resolved default, and verbatim history
+      // compacted far sooner than the turn actually required.
+      const safeMaxTokens = resolveOutputMaxTokens({
+        requested: params.max_tokens,
+        fallback: DEFAULT_OUTPUT_MAX_TOKENS,
+        modelInfo,
+        modelMaxOutputTokens: modelMaxOutput,
+      });
+      const safeInputTokens = Math.max(0, safeInputWindow(modelInfo, safeMaxTokens));
       // Reserve the non-history overhead that shares this budget before applying the
       // fraction, so heavier-payload turns (more tools, a longer running summary, a
       // large prompt) compact SOONER rather than overflowing first - this is the
@@ -1625,17 +1637,10 @@ export class ChatCompletionProcess {
       // Input-window limits, needed BEFORE building messages because the amount of
       // attached-file content we extract has to be derived from them.
       const contextLimit = modelInfo.contextWindow ?? 200000;
-      const modelMaxOutputTokens = modelInfo.max_tokens ?? 16384;
-
-      // An explicit caller budget is honored as-is; only its absence is sized for the
-      // model. See resolveOutputMaxTokens for why raising an explicit value is not a
-      // free action (it feeds the credit pre-reservation and maxSafeInputTokens below).
-      const safeMaxTokens = resolveOutputMaxTokens({
-        requested: maxTokens,
-        fallback: DEFAULT_OUTPUT_MAX_TOKENS,
-        modelInfo,
-        modelMaxOutputTokens,
-      });
+      // safeMaxTokens is resolved once further up, where the verbatim-history window
+      // needs it too. An explicit caller budget is honored as-is; only its absence is
+      // sized for the model. See resolveOutputMaxTokens for why raising an explicit
+      // value is not free (it feeds the credit pre-reservation and the window below).
 
       // Fetch buffer for URL/file content. Deliberately NOT safeMaxTokens: this is a
       // *content* budget, unrelated to the output cap (same confusion called out for

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -193,10 +193,11 @@ function assertNeverElisionSignal(signal: never): never {
 
 /**
  * Output budget used when a caller supplies no max_tokens. Within supported output
- * limits for every configured non-reasoning model; adaptive reasoning models default
- * to ADAPTIVE_THINKING_MAX_TOKENS_FLOOR instead, since they spend thinking tokens
- * inside this budget. Distinct from the catalog's DEFAULT_MAX_OUTPUT_TOKENS, which
- * fills in a model's *capability* when its record omits one.
+ * limits for every configured non-reasoning model; models that reason inside the
+ * output budget default to ADAPTIVE_THINKING_MAX_TOKENS_FLOOR instead, since their
+ * reasoning would otherwise consume this whole budget. Distinct from the catalog's
+ * DEFAULT_MAX_OUTPUT_TOKENS, which fills in a model's *capability* when its record
+ * omits one.
  */
 const DEFAULT_OUTPUT_MAX_TOKENS = 4096;
 
@@ -1632,7 +1633,7 @@ export class ChatCompletionProcess {
       const safeMaxTokens = resolveOutputMaxTokens({
         requested: maxTokens,
         fallback: DEFAULT_OUTPUT_MAX_TOKENS,
-        thinkingStyle: modelInfo.thinkingStyle,
+        modelInfo,
         modelMaxOutputTokens,
       });
 


### PR DESCRIPTION
Fixes #1289

## What

`resolveOutputMaxTokens` now sizes the no-budget default using a provider-agnostic predicate, `reasonsWithinOutputBudget`, instead of the Anthropic-only `thinkingStyle === 'adaptive'` check.

## Why

OpenAI reasoning models (GPT-5.x, including the GPT-5.6 Sol/Luna/Terra family) spend reasoning tokens *inside* `max_completion_tokens`. With the plain 4096 default, the reasoning pass alone exhausted the budget and the turn returned no visible content - `finish_reason: 'length'`, 0 visible output tokens.

#1209 gave that headroom only to Anthropic adaptive models, because `ModelInfo.thinkingStyle` deliberately encodes just the two Anthropic request shapes: `modelCatalog.toThinkingStyle` maps `openai-effort` to `undefined` so a backend is never handed a wrong request shape. Correct as a request-shape signal, but it meant OpenAI reasoning models stayed on the starving fallback.

The trap is identical across providers, so the predicate is too.

## Choosing the signal

- **Not `can_think` alone.** Anthropic legacy models set it, but their thinking is opt-in and separately budgeted, so they do not starve at 4096 and should not pay for headroom they never use. There is a test pinning this.
- **Hardcoded ids via `REASONING_SUPPORTED_MODELS`**, which is already the set `openaiBackend` uses to decide `supportsReasoning`.
- **Catalog-only models** via `dispatchProfile.maxTokensParam === 'max_completion_tokens'` paired with `can_think` - the same pairing `openaiBackend` already uses to catch reasoning-shaped models missing from its hardcoded sets.

An explicit caller budget is still honored as-is and still clamped to the model's own output cap; only the absent case changed.

## Testing

`thinkingParams.test.ts` covers the OpenAI reasoning default, the catalog-only reasoning default, the `can_think`-alone case that must NOT get headroom, and explicit budgets surviving on an OpenAI reasoning model. The two new default cases were verified failing without the predicate change and passing with it.

`llm-adapters` 606, `services` 3105, `common` 1389 tests pass. `turbo:typecheck` clean except a pre-existing `@bike4mind/scripts` failure on `@aws-sdk/s3-request-presigner`, which reproduces on unmodified main. `lint:check` shows only the 4 pre-existing premium-overlay errors.

## Related

Independent of #1288 (the non-streaming Anthropic `max_tokens` clamp); these touch different providers and do not interact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)