### PR TITLE
chore(security): gitignore arnold overlay and harden lockfile integrity check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,11 @@ packages/premium/bob/
 # PUBLIC repo. Same near-miss the optihashi and bob entries above record.
 packages/premium/interactive-meetings/
 
+# Premium overlay snapshot for b4m-arnold — hydrated at the pinned ref by the deploy
+# pipeline before pnpm install. Without this entry a local clone leaves private overlay
+# source untracked, one bulk `git add` away from publishing it.
+packages/premium/arnold/
+
 # Docusaurus
 docs-site/build/
 docs-site/.docusaurus/

--- a/scripts/check-no-overlay-lockfile.sh
+++ b/scripts/check-no-overlay-lockfile.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
-# Fails if pnpm-lock.yaml references any packages/premium/ path.
+# Fails if pnpm-lock.yaml references any packages/premium/ path OR any
+# dependency from a private MillionOnMars GitHub repo.
 #
-# The premium overlay dirs are gitignored, but pnpm-workspace.yaml globs them as
-# workspace members, so a plain `pnpm install` on a machine with an overlay
-# hydrated writes the overlay's importer blocks (package names + dependency
-# sets) into the TRACKED lockfile. Committing that publishes private overlay
-# structure to this public repo, disguised as ordinary lockfile churn.
+# TWO classes of leak are blocked:
+#
+#   1. packages/premium/ importer blocks — pnpm-workspace.yaml globs the
+#      premium dirs, so `pnpm install` with an overlay hydrated writes the
+#      overlay's importer block (package names + dependency sets) into the
+#      TRACKED lockfile, publishing private overlay structure.
+#
+#   2. @milliononmars/ scoped packages (e.g. @milliononmars/hydra) — overlay
+#      packages can depend on private scoped packages in this org. Those git
+#      resolutions appear in a separate section of the lockfile that contains
+#      no "packages/premium/" string, so check (1) alone does not catch them.
+#      Grep (2) closes that gap. Note: unscoped MillionOnMars tarball forks
+#      (e.g. react-use-websocket) are already in the public lockfile and are
+#      intentionally excluded from this check — only @milliononmars/ scoped
+#      packages are private.
 #
 # The tracked lockfile must always be generated with packages/premium/ empty.
 # Run in CI on every PR (lockfile-integrity.yml) and locally via husky
@@ -34,13 +45,14 @@ if [ "$MODE" = "staged" ]; then
     echo "✅ Lockfile staged for deletion; nothing to scan."
     exit 0
   fi
-  matches=$(git show ":$LOCKFILE" | grep -n "packages/premium/" || true)
+  CONTENT=$(git show ":$LOCKFILE")
+  matches=$(echo "$CONTENT" | grep -in "packages/premium/\|@milliononmars/" || true)
 else
-  matches=$(grep -n "packages/premium/" "$LOCKFILE" || true)
+  matches=$(grep -in "packages/premium/\|@milliononmars/" "$LOCKFILE" || true)
 fi
 
 if [ -n "$matches" ]; then
-  echo "❌ ERROR: $LOCKFILE references premium overlay packages:"
+  echo "❌ ERROR: $LOCKFILE references premium overlay packages or private dependencies:"
   echo ""
   echo "$matches" | head -10 | sed 's/^/  /'
   echo ""
@@ -51,4 +63,4 @@ if [ -n "$matches" ]; then
   exit 1
 fi
 
-echo "✅ No premium overlay paths in $LOCKFILE."
+echo "✅ No premium overlay paths or private dependencies in $LOCKFILE."


### PR DESCRIPTION
## Summary

- Adds `packages/premium/arnold/` to `.gitignore` so a local clone of the private `b4m-arnold` overlay is never one bulk `git add` away from being published — same pattern as Bob, Overwatch, Tavern, etc.
- Extends `scripts/check-no-overlay-lockfile.sh` to also block `@milliononmars/` scoped packages from the lockfile. Git resolutions for private scoped deps appear in a separate lockfile section that contains no `packages/premium/` string, so the previous check had a gap.

## Test plan

- [ ] CI lockfile integrity check passes
- [ ] CI typecheck passes