### PR TITLE
fix(llm): gate the artifact prompt on the request flag; abstain when retrieval grounds nothing

### DIFF
--- a/apps/client/app/contexts/LLMContext.tsx
+++ b/apps/client/app/contexts/LLMContext.tsx
@@ -70,7 +70,13 @@ export interface LLMContextProps {
   updateLLMParams: () => void;
   isQuestMasterEnabled: boolean;
   isMementosEnabled: boolean;
-  isArtifactsEnabled: boolean;
+  /**
+   * `undefined` until admin settings and user prefs have both hydrated. The server reads an
+   * explicit `false` on the request as "this caller has no artifact surface" and drops the
+   * artifact prompt and extraction for the turn, so a pre-hydration `false` would silently
+   * cost the first prompt of a cold load its artifacts. Absent means "no preference".
+   */
+  isArtifactsEnabled: boolean | undefined;
   isAgentsEnabled: boolean;
   isLatticeEnabled: boolean;
   toolMode: 'fast' | 'smart';
@@ -152,7 +158,7 @@ const DEFAULTS = {
   organizationId: null,
   isQuestMasterEnabled: false,
   isMementosEnabled: false,
-  isArtifactsEnabled: false,
+  isArtifactsEnabled: undefined,
   isAgentsEnabled: false, // Default controlled by user settings
   isLatticeEnabled: false, // Default controlled by user settings
   toolMode: 'smart' as const,
@@ -358,7 +364,7 @@ export function getDefaultMaxTokens(modelInfo: ModelInfo): number {
 export const LLMProvider: React.FC = () => {
   const { setState } = useLLM;
   const { settings } = useUserSettings();
-  const { isFeatureEnabled } = useFeatureEnabled();
+  const { isFeatureEnabled, isLoading: areFeaturesLoading } = useFeatureEnabled();
   const { accessibleModels, isModelAccessible, getFallbackModel } = useAccessibleModels();
   const { data: modelInfoRepo } = useModelInfo();
   const activeModel = useLLM(s => s.model);
@@ -372,7 +378,8 @@ export const LLMProvider: React.FC = () => {
   // Extract primitive booleans so the effect dep array contains stable values
   // rather than the experimentalFeatures object reference (recreated on every settings update)
   const enableMementos = settings.experimentalFeatures?.enableMementos ?? false;
-  const enableArtifacts = isFeatureEnabled('enableArtifacts');
+  // Left undefined until both signals resolve - see isArtifactsEnabled on the state type.
+  const enableArtifacts = areFeaturesLoading ? undefined : isFeatureEnabled('enableArtifacts');
   const enableAgents = isFeatureEnabled('enableAgents');
   const enableLattice = settings.experimentalFeatures?.enableLattice ?? false;
 

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -24,9 +24,23 @@ import { SecopsTriageConfigSchema } from '../types/entities/SecopsTriageTypes';
  * nobody checks for; the reverse means the detector flags wording the prompt never warned against.
  * Because this text is live-editable per environment, that drift is silent - an admin edit cannot
  * update the detector. Prefer changing both in one commit.
+ *
+ * The SCOPE paragraph is load-bearing, not throat-clearing. This block lands as an undifferentiated
+ * system message alongside org/lake/session prompts, so without it the "never deliver less than the
+ * complete artifact" mandate below reads as a general instruction on turns where no artifact is
+ * possible - biasing the model against "I do not have enough to answer that" on exactly the
+ * retrieval-grounded questions where abstention is the correct answer. Keep any edit to the
+ * completeness rules bounded to artifact bodies.
+ *
+ * Live-editability cuts both ways: an environment whose `ArtifactEmissionPrompt` row holds a saved
+ * copy of an older default keeps that copy and silently misses every fix made here. Behavioural
+ * changes to this text therefore need the stored values checked (or cleared) per environment - the
+ * code change alone does not ship them.
  */
 export const ARTIFACT_EMISSION_PROMPT = `ARTIFACT OUTPUT:
-When asked to create something substantial and self-contained - a complete HTML page, an interactive visualization, a React component, an SVG, a Mermaid diagram, or a long code file/document - emit it inside an <artifact> tag, never as raw inline markup. The body between the opening and closing tags MUST be the complete file you generate - the entire document, top to bottom. NEVER put an ellipsis (...), a stand-in, or a "code here" comment as the body; write the real, full content and close the document before </artifact>. Shape (replace the body with your actual complete file):
+SCOPE: everything below is about artifacts - when to emit one, and what must go inside it once you do. The COMPLETENESS and NEVER ABBREVIATE rules bind the BODY of an artifact you have chosen to emit; they are not a general instruction to always produce a deliverable, and nothing below decides WHETHER to answer or how much of an answer you owe. When a question is underspecified, rests on a premise you cannot verify, or asks for something your sources do not cover, say so and name what is missing. "I do not have enough to answer that" and "that is not in the material I can see" are correct, high-value answers, and no completeness rule below outranks them. Never invent facts about the user, their business, or their data in order to have something complete to put in an artifact.
+
+When asked to create something substantial and self-contained - a complete HTML page, an interactive visualization, a React component, an SVG, a Mermaid diagram, or a long code file/document - emit it inside an <artifact> tag, never as raw inline markup - never paste large raw HTML or code into the chat body outside an <artifact> tag. The body between the opening and closing tags MUST be the complete file you generate - the entire document, top to bottom. NEVER put an ellipsis (...), a stand-in, or a "code here" comment as the body; write the real, full content and close the document before </artifact>. Shape (replace the body with your actual complete file):
 <artifact identifier="kebab-case-id" type="text/html" title="Short Title">THE FULL FILE, WRITTEN OUT IN FULL</artifact>
 Types: text/html, application/vnd.ant.react, image/svg+xml, application/vnd.ant.mermaid, application/vnd.ant.python, application/vnd.ant.code.
 
@@ -69,10 +83,10 @@ SHARING A REACT ARTIFACT (publishing to a /p/ link): the in-chat preview is perm
 - File downloads are sandbox-blocked on the published page (no allow-downloads) - \`XLSX.writeFile\`/save-to-disk buttons won't fire; render results in the page (a table, inline preview) instead of offering a download.
 - Only the importable packages above publish; importing anything else fails the publish with a clear "not publishable yet" error.
 
-COMPLETENESS: Deliver the full artifact - favor completeness over brevity; trim only genuine bloat (boilerplate, dead code, repetition), never requested scope. Only when a deliverable is genuinely too large for one response, build it incrementally: ship a complete first version, then expand under the SAME identifier rather than letting it get cut off mid-tag. Always emit the closing </artifact>. Never paste large raw HTML or code into the chat body outside an <artifact> tag.
+COMPLETENESS (artifact bodies only - see SCOPE): Deliver the full artifact - favor completeness over brevity; trim only genuine bloat (boilerplate, dead code, repetition), never requested scope. Only when a deliverable is genuinely too large for one response, build it incrementally: ship a complete first version, then expand under the SAME identifier rather than letting it get cut off mid-tag. Always emit the closing </artifact>.
 
 NEVER ABBREVIATE THE BODY - THIS IS THE MOST DAMAGING FAILURE YOU CAN PRODUCE HERE: every function the artifact needs must be written out in full, every time, even when you already wrote it in an earlier turn. An artifact whose logic is replaced by a summary comment still parses and still renders a complete-looking UI whose controls silently do nothing - the user cannot see the difference, ships it, and only finds out when a teammate clicks a dead button. That is far worse than an obviously unfinished artifact. Specifically FORBIDDEN as artifact body content, in any comment form: "same as above", "same as before", "identical to previous", "from the previous version", "for brevity" and any padded variant of it ("for the sake of brevity", "in the interest of brevity"), "omitted", "unchanged", "rest of the ...", "<rest of the code>", "code goes here", "implementation here", "[...]", or any comment that stands in for code you wrote previously or intend the reader to copy from elsewhere. Equally forbidden inside the artifact: anything addressed to the reader rather than to the runtime - asking them to reply "CONTINUE", pointing at a "next response", or promising in the first person what you are about to write ("I will include the remaining 84 entries"). The artifact is a standalone document; it has no next turn. Re-emitting the same 300 lines verbatim is CORRECT and expected; referring to them is not.
-If the full deliverable genuinely will not fit, do NOT stub the difference. REDUCE SCOPE EXPLICITLY: build fewer features, completely and working, then say in the chat body (outside the artifact) which features you left out and offer to add them in a follow-up under the same identifier. A working artifact with three of five features plus an honest note beats five features where two are hollow.`;
+If the full deliverable genuinely will not fit, do NOT stub the difference. REDUCE SCOPE EXPLICITLY: build fewer features, completely and working, then say in the chat body (outside the artifact) which features you left out and offer to add them in a follow-up under the same identifier. A working artifact with three of five features plus an honest note beats five features where two are hollow. And where the request itself is the thing that will not hold - too little given, a premise you cannot check, a corpus that does not cover it - saying so and asking for what is missing beats any artifact built on details you invented on the user's behalf.`;
 
 /**
  * Default text for the help-center nudge system prompt. Single source of truth used BOTH as the
@@ -1827,7 +1841,9 @@ export const settingsMap = {
   EnableArtifactsDefault: makeBooleanSetting({
     key: 'EnableArtifactsDefault',
     name: 'Artifacts: On by default for users',
-    defaultValue: false,
+    // The completion pipeline honors this flag, so false would withdraw artifacts from every
+    // never-toggled user rather than merely leaving them un-surfaced.
+    defaultValue: true,
     description: 'When enabled, the Artifacts feature is active for users who have never explicitly toggled it.',
     category: 'Experimental',
     group: API_SERVICE_GROUPS.EXPERIMENTAL.id,
@@ -1973,7 +1989,7 @@ export const settingsMap = {
     name: 'Artifact Emission Prompt',
     defaultValue: ARTIFACT_EMISSION_PROMPT,
     description:
-      'System prompt instructing the model how to emit <artifact> tags (HTML/React/SVG/Mermaid/etc.). Live-editable; clearing it reverts to the built-in default. Only injected when the Enable Artifacts feature is on. (The sandbox runtime that renders artifacts is intentionally NOT editable — it is a security boundary.)',
+      'System prompt instructing the model how to emit <artifact> tags (HTML/React/SVG/Mermaid/etc.). Injected only when the Enable Artifacts feature is on AND the request did not disable artifacts. Live-editable; clearing it reverts to the built-in default. After an upgrade, diff a saved copy against that default: a saved copy pins the wording from whenever it was saved and will not pick up fixes made since. (The sandbox runtime that renders artifacts is intentionally NOT editable — it is a security boundary.)',
     category: 'AI',
     order: 9,
   }),

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.test.ts
@@ -712,8 +712,12 @@ describe('KnowledgeRetrievalFeature bounded scan + coverage reporting', () => {
     const ctx = makeCtx({
       rows: () => [{ id: 'c1', fabFileId: 'fileA', text: 'x', vector: [1, 0, 0] }],
     });
-    const { quest, messages } = await run(ctx);
-    expect(messages).toEqual([]);
+    const { quest, messages, content } = await run(ctx);
+    expect(messages).toHaveLength(1);
+    // Nothing was ever scored against the query, so the abstention block must NOT tell the user
+    // the library lacks coverage - that is a claim this turn did not earn.
+    expect(content).toContain('could not be searched');
+    expect(content).not.toContain('does not cover this');
     const warn = (ctx.logger as unknown as { warn: ReturnType<typeof vi.fn> }).warn;
     // Reported through the SAME path as every other coverage gap - previously this call site sat
     // before reportCoverage ever ran, so a fully-mismatched library warned to the operator log
@@ -725,13 +729,39 @@ describe('KnowledgeRetrievalFeature bounded scan + coverage reporting', () => {
     expect(logs).not.toContain('no vectorized chunks');
   });
 
-  it('genuinely unvectorized files keep the original message and do not warn', async () => {
+  it('genuinely unvectorized files abstain as unsearchable and do not warn', async () => {
     const ctx = makeCtx({ rows: () => [] });
-    const { messages } = await run(ctx);
-    expect(messages).toEqual([]);
+    const { messages, content } = await run(ctx);
+    expect(messages).toHaveLength(1);
+    expect(content).toContain('could not be searched');
     const logs = (ctx.logger as unknown as { log: ReturnType<typeof vi.fn> }).log.mock.calls.flat().join(' ');
     expect(logs).toContain('no vectorized chunks');
     expect((ctx.logger as unknown as { warn: ReturnType<typeof vi.fn> }).warn).not.toHaveBeenCalled();
+  });
+
+  it('a real search that matches nothing says the library does not cover it', async () => {
+    // Orthogonal to the [1,0] query, so the chunk IS scored and simply falls under the floor -
+    // the production-dominant abstention path, and the only one where a flat "not covered" is honest.
+    const ctx = makeCtx({ rows: () => [{ id: 'c1', fabFileId: 'fileA', text: 'off topic', vector: [0, 1] }] });
+    const { quest, content } = await run(ctx);
+    expect(content).toContain('does not cover this');
+    expect(content).not.toContain('the search was incomplete');
+    const logs = (ctx.logger as unknown as { log: ReturnType<typeof vi.fn> }).log.mock.calls.flat().join(' ');
+    expect(logs).toContain('no chunk cleared the similarity floor');
+    expect((quest.promptMeta as { warnings?: string[] } | undefined)?.warnings).toBeUndefined();
+  });
+
+  it('a no-match over a PARTIALLY scanned library must not harden into "no coverage"', async () => {
+    // Same miss, but the candidate cap cut the search short. Claiming the library has nothing on
+    // the topic here is the misleading outcome reportCoverage exists to prevent.
+    const ctx = makeCtx({
+      hasMore: true,
+      rows: () => [{ id: 'c1', fabFileId: 'fileA', text: 'off topic', vector: [0, 1] }],
+    });
+    const { quest, content } = await run(ctx);
+    expect(content).toContain('the search was incomplete');
+    expect(content).not.toContain('does not cover this');
+    expect((quest.promptMeta as { warnings?: string[] }).warnings).toHaveLength(1);
   });
 
   it('citation [N] numbering is stable when the reader returns rows in a different order', async () => {
@@ -835,8 +865,12 @@ describe('KnowledgeRetrievalFeature bounded scan + coverage reporting', () => {
   it('grounds nothing when the projected reader is missing, rather than falling back', async () => {
     const ctx = makeCtx({});
     (ctx.db.fabfilechunks as { findVectorsByFabFileIds?: unknown }).findVectorsByFabFileIds = undefined;
-    const { messages } = await run(ctx);
-    expect(messages).toEqual([]);
+    const { messages, content } = await run(ctx);
+    // Ungrounded, but not silent: the abstention block stands in for the retrieved context. A
+    // missing repository is an outage, so it must read as "could not consult", not "not covered".
+    expect(messages).toHaveLength(1);
+    expect(content).toContain('could not be searched');
+    expect(content).not.toContain('does not cover this');
     expect(ctx.db.fabfilechunks.findByFabFileId).not.toHaveBeenCalled();
   });
 
@@ -932,8 +966,9 @@ describe('KnowledgeRetrievalFeature bounded scan + coverage reporting', () => {
       // any content the mock can return, so the run below still forces the partition to load them.
       rows: () => [{ id: 'c1', fabFileId: 'foreign', text: 'cross-space noise', vector: [1, 0] }],
     });
-    const { quest, messages } = await run(ctx);
-    expect(messages).toEqual([]);
+    const { quest, messages, content } = await run(ctx);
+    expect(messages).toHaveLength(1);
+    expect(content).toContain('could not be searched');
     // The foreign file's id must never reach the chunk query at all.
     const calledIds = (ctx.db.fabfilechunks.findVectorsByFabFileIds as ReturnType<typeof vi.fn>).mock.calls.flatMap(
       c => c[0] as string[]
@@ -949,6 +984,74 @@ describe('KnowledgeRetrievalFeature bounded scan + coverage reporting', () => {
     });
     const { content } = await run(ctx);
     expect((content.match(/z/g) ?? []).length).toBe(12000);
+  });
+});
+
+/**
+ * A forced-retrieval turn that grounds nothing must SAY so. Returning an empty array leaves the
+ * model answering from parametric knowledge with no notice, which on a citation-enforced surface
+ * reads to the user as a library-backed answer.
+ */
+describe('KnowledgeRetrievalFeature abstention when nothing is retrieved', () => {
+  const embeddingFactory = {
+    createEmbeddingService: () => ({ generateEmbedding: vi.fn().mockResolvedValue([1, 0]) }),
+    getDefaultEmbeddingModel: () => 'text-embedding-ada-002',
+  };
+
+  const makeCtx = (overrides: { search?: unknown } = {}) => ({
+    logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger,
+    user: { id: 'u1', tags: [], groups: [] },
+    db: {
+      fabfiles: {
+        search: overrides.search ?? vi.fn().mockResolvedValue({ data: [], hasMore: false, total: 0 }),
+      },
+      fabfilechunks: { findByFabFileId: vi.fn(), findVectorsByFabFileIds: vi.fn().mockResolvedValue([]) },
+      adminSettings: { getSettingsValue: vi.fn().mockResolvedValue(undefined) },
+    },
+    resolveEntitlementKeys: vi.fn().mockResolvedValue([]),
+    sendStatusUpdate: vi.fn().mockResolvedValue(undefined),
+  });
+
+  const run = async (ctx: ReturnType<typeof makeCtx>, quest = makeQuest()) => {
+    const feature = new KnowledgeRetrievalFeature(
+      ctx as unknown as ConstructorParameters<typeof KnowledgeRetrievalFeature>[0]
+    );
+    const messages = await feature.getContextMessages(
+      quest,
+      embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1],
+      'what does the library say about X'
+    );
+    return { messages, content: messages[0]?.content ?? '' };
+  };
+
+  it('a lake with no readable documents gets the abstention block, not silence', async () => {
+    const { messages, content } = await run(makeCtx());
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('system');
+    // Nothing to search is an access/config state, so it must not be reported as a coverage gap.
+    expect(content).toContain('could not be searched');
+    expect(content).not.toContain('does not cover this');
+    expect(content).toContain('never invent sources, citations, or figures');
+  });
+
+  it('a thrown search reads as an outage, never as the library lacking coverage', async () => {
+    const ctx = makeCtx({ search: vi.fn().mockRejectedValue(new Error('search backend down')) });
+    const { content } = await run(ctx);
+    expect(content).toContain('could not be searched');
+    // The regression this guards: an outage relayed to the user as "that document is not in here".
+    expect(content).not.toContain('does not cover this');
+    expect((ctx.logger as unknown as { error: ReturnType<typeof vi.fn> }).error).toHaveBeenCalled();
+  });
+
+  it('stays silent on the two non-failures: an empty prompt and a turn with attached files', async () => {
+    const feature = new KnowledgeRetrievalFeature(
+      makeCtx() as unknown as ConstructorParameters<typeof KnowledgeRetrievalFeature>[0]
+    );
+    const factory = embeddingFactory as unknown as Parameters<typeof feature.getContextMessages>[1];
+    expect(await feature.getContextMessages(makeQuest(), factory, '   ')).toEqual([]);
+    // An attachment IS the source for this turn; skipping lake retrieval is intended, not a gap.
+    const withFiles = makeQuest({ fabFileIds: ['f1'] } as Partial<IChatHistoryItemDocument>);
+    expect(await feature.getContextMessages(withFiles, factory, 'summarize the attached figure')).toEqual([]);
   });
 });
 

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -1303,8 +1303,56 @@ const FORCED_RETRIEVAL_MAX_SCORED_CHUNKS = 256;
 // Total characters of retrieved chunk text injected into the prompt.
 const FORCED_RETRIEVAL_CHAR_BUDGET = 12000;
 // Minimum cosine similarity (ada-002) for a chunk to count as relevant. Below this,
-// nothing is injected so the model refuses rather than grounding in off-topic content.
+// no chunk is injected and the turn falls back to forcedRetrievalNoContextPrompt.
 const FORCED_RETRIEVAL_MIN_SIMILARITY = 0.75;
+
+/**
+ * Common to all three findings below. Every instruction here and in the finding bodies is
+ * conditional on the request actually depending on the library - forced retrieval is a per-session
+ * toggle on ordinary chats, so a greeting or a "make that shorter" must not become a refusal.
+ */
+const FORCED_RETRIEVAL_NO_CONTEXT_RULES =
+  'For any part of the answer that depends on that library, do not fill the gap from general knowledge or ' +
+  'from assumptions about the user, their organization, or their data, and never invent sources, citations, ' +
+  'or figures. If answering needs information you do not have, say what is missing and ask for it - here ' +
+  'that is a correct and useful answer, not a failure to deliver.';
+
+/**
+ * The abstention block that replaces retrieved context when a forced-retrieval turn grounds nothing.
+ * Returning an empty array used to be read as "the model will refuse", but nothing ever told it to:
+ * with no context and no instruction, a grounded surface answers from parametric knowledge and
+ * fills the gaps with assumptions about the caller - the worst outcome a citation-enforced product
+ * has.
+ *
+ * Three findings, because the model relays this to the user as fact and only one of the three
+ * supports "the library does not cover this":
+ * - `unavailable` - nothing was searchable (repo missing, search threw, no readable documents, no
+ *   vectorized chunks). Saying the library lacks coverage here is a claim the turn never earned;
+ *   an outage would read to the user as a missing document.
+ * - `no_match_partial` - a real search ran but coverage was cut short (candidate cap, chunk budget,
+ *   embedding-model mismatch), so "nothing matched" must not harden into "nothing exists". Mirrors
+ *   the coverageNote hedge on the success path.
+ * - `no_match` - the whole accessible library was searched and nothing cleared the relevance floor.
+ *   Only here is a flat "not covered" honest.
+ *
+ * Deliberately NOT emitted for the two non-failures: an empty prompt, and a turn carrying attached
+ * files (where skipping lake retrieval is the intended behaviour and the attachment is the source).
+ */
+function forcedRetrievalNoContextPrompt(finding: 'unavailable' | 'no_match_partial' | 'no_match'): string {
+  const body =
+    finding === 'unavailable'
+      ? 'The curated library could not be searched for this question - it is unavailable, or it holds no ' +
+        'documents that could be searched for you on this turn. If the request depends on that library, say ' +
+        'it could not be consulted. Do NOT say or imply the library lacks coverage of the topic; this turn ' +
+        'established no such thing.'
+      : finding === 'no_match_partial'
+        ? 'Only part of the curated library could be searched for this question, and nothing in the part that ' +
+          'was searched matched. If the request depends on that library, say the search turned up nothing. Do ' +
+          'NOT state or imply the library has no coverage of the topic - the search was incomplete.'
+        : 'The curated library was searched for this question and returned nothing relevant. If the request ' +
+          'depends on that library, say plainly that it does not cover this.';
+  return `[Knowledge Base - No Retrieved Context]\n${body} ${FORCED_RETRIEVAL_NO_CONTEXT_RULES}`;
+}
 
 /** An above-floor candidate. The vector is dropped so each batch can be freed after scoring. */
 interface ForcedRetrievalCandidate {
@@ -1498,6 +1546,10 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
     return factoryDefault;
   }
 
+  private noContextMessages(finding: 'unavailable' | 'no_match_partial' | 'no_match'): IMessage[] {
+    return [{ role: 'system' as const, content: forcedRetrievalNoContextPrompt(finding) }];
+  }
+
   async getContextMessages(
     quest: IChatHistoryItemDocument,
     embeddingFactory: EmbeddingFactory,
@@ -1521,7 +1573,7 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
     // a host missing it should ground nothing, not quietly reintroduce the corpus-sized load.
     if (!db.fabfiles || !db.fabfilechunks || typeof db.fabfilechunks.findVectorsByFabFileIds !== 'function') {
       this.logger.warn('🔒 Forced retrieval: fabfiles/fabfilechunks repository unavailable — skipping');
-      return [];
+      return this.noContextMessages('unavailable');
     }
 
     try {
@@ -1557,8 +1609,9 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
       // exclusion in memory so correctness never depends on the DB regex engine or fileNameLower.
       const files = filterRetrievalExcluded(fileResults.data, this.retrievalFilter);
       if (files.length === 0) {
+        // No readable documents is an access/config state, not evidence about the topic.
         this.logger.log('🔒 Forced retrieval: no accessible data-lake files');
-        return [];
+        return this.noContextMessages('unavailable');
       }
       const fileById = new Map(files.map(f => [f.id, f]));
       // Fixed scan order so batching, the model pick, and any truncation are all reproducible;
@@ -1708,13 +1761,15 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
         if (!reported) {
           this.logger.log('🔒 Forced retrieval: candidate files have no vectorized chunks');
         }
-        return [];
+        // Zero chunks SCORED, so no comparison against the query ever happened - whether the cause
+        // is an unvectorized corpus or a wholly mismatched one, the library was not searched.
+        return this.noContextMessages('unavailable');
       }
       const scored = pool.sort(compareForcedRetrievalCandidates);
 
       // 4. Inject the most-similar chunks (above the relevance floor) up to the budget.
-      //    If nothing clears the floor, inject nothing so the model refuses rather than
-      //    grounding in off-topic content.
+      //    If nothing clears the floor, inject the abstention block instead of off-topic
+      //    content, hedged by whether the scan was complete.
       let used = 0;
       const sections: string[] = [];
       const sourceFileIds: string[] = [];
@@ -1742,10 +1797,11 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
 
       if (sections.length === 0) {
         // Report coverage first: a refusal grounded on a partially-scanned library is the most
-        // misleading outcome there is, because it reads as "the library has nothing on this".
-        this.reportCoverage(quest, coverage, embeddingModel);
+        // misleading outcome there is, because it reads as "the library has nothing on this". The
+        // return value is what keeps the abstention block from making exactly that claim.
+        const partial = this.reportCoverage(quest, coverage, embeddingModel);
         this.logger.log(`🔒 Forced retrieval: no chunk cleared the similarity floor (top=${topScore.toFixed(3)})`);
-        return [];
+        return this.noContextMessages(partial ? 'no_match_partial' : 'no_match');
       }
       const partialCoverage = this.reportCoverage(quest, coverage, embeddingModel);
 
@@ -1834,8 +1890,12 @@ export class KnowledgeRetrievalFeature implements ChatCompletionFeature {
             'cite documents by name. If it does not address the question, say so rather than relying on outside knowledge.\n\n';
       return [{ role: 'system' as const, content: header + coverageNote + sections.join('\n\n---\n\n') }];
     } catch (error) {
+      // A failed search still leaves the turn ungrounded, so it gets the abstention block for the
+      // same reason an empty one does - silently answering from parametric knowledge is the failure.
+      // 'unavailable', not 'no_match': an outage must never be reported to the user as a gap in the
+      // library's coverage.
       this.logger.error('🔒 Forced retrieval failed:', error);
-      return [];
+      return this.noContextMessages('unavailable');
     }
   }
 

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -128,6 +128,7 @@ import {
 } from '../telemetry';
 import type { ToolTelemetry, ToolErrorCategory, SystemPromptDetail } from '@bike4mind/common';
 import { buildAlwaysOnFloorDetails } from './systemPromptFloorTelemetry';
+import { resolveArtifactsEnabled } from './artifactGating';
 import {
   ContextTelemetryAlertsSchema,
   detectAgentMentions,
@@ -1947,7 +1948,14 @@ export class ChatCompletionProcess {
       // Always-on system-prompt floor. Resolved once here (pure settings reads with
       // built-in fallbacks) so the assembly below and the telemetry itemization further
       // down measure the exact same content - see buildAlwaysOnFloorDetails.
-      const artifactEmissionEnabled = Boolean(getSettingsValue('EnableArtifacts', defaultAdminSettings));
+      //
+      // Admin setting AND the caller's request flag - see resolveArtifactsEnabled for why
+      // `undefined` leaves the admin setting as the only gate. Gates the emission prompt here and
+      // the extraction pass after streaming, so the two can never disagree.
+      const artifactsEnabled = resolveArtifactsEnabled(
+        Boolean(getSettingsValue('EnableArtifacts', defaultAdminSettings)),
+        parsedBody.enableArtifacts
+      );
       // Admin-editable via the `ArtifactEmissionPrompt` setting (general AI settings); falls back
       // to the built-in ARTIFACT_EMISSION_PROMPT default when unset/cleared, so a blank value can
       // never strip artifact guidance from completions.
@@ -1967,8 +1975,9 @@ export class ChatCompletionProcess {
         ...extraContextMessages, // Add extra context messages from external sources at the top
         // Artifact emission guidance. Without this, correct <artifact> usage
         // is left to the model's defaults and large HTML/code can leak into the chat
-        // body as raw markup. Gated on the same EnableArtifacts flag as extraction.
-        ...(artifactEmissionEnabled ? [{ role: 'system' as const, content: artifactEmissionContent }] : []),
+        // body as raw markup. Gated on the same effective flag as extraction, so a turn is
+        // never told to emit artifacts that the post-processing below will not extract.
+        ...(artifactsEnabled ? [{ role: 'system' as const, content: artifactEmissionContent }] : []),
         // Help-center awareness. Makes the model aware of the in-app
         // Help Center so a user who types a how-to question ("how do I add to my data lake?")
         // gets pointed to it instead of an ungrounded guess. Skipped for local models (lean prompt).
@@ -2333,7 +2342,7 @@ export class ChatCompletionProcess {
           // the fixed prompt cost is auditable in the Context Inspector (#810).
           systemPromptDetails.push(
             ...(await buildAlwaysOnFloorDetails(
-              { artifactEmissionEnabled, artifactEmissionContent, isLocalModel, helpCenterContent },
+              { artifactEmissionEnabled: artifactsEnabled, artifactEmissionContent, isLocalModel, helpCenterContent },
               content => calculateTotalTokenLength([{ role: 'system' as const, content }], tokenCalcOptions)
             ))
           );
@@ -3332,8 +3341,11 @@ export class ChatCompletionProcess {
 
         timer.phase('post_process');
 
-        // Process artifacts if enabled
-        if (getSettingsValue('EnableArtifacts', defaultAdminSettings)) {
+        // Process artifacts if enabled. Same effective gate as the guidance prompt above:
+        // convertCodeBlocksToArtifacts REWRITES the reply, so a caller that passed
+        // enableArtifacts:false previously got <artifact> markup spliced into a response it had
+        // explicitly asked to keep artifact-free.
+        if (artifactsEnabled) {
           // The barrel is the only export path for these two; there is no artifactParser subpath
           // that carries them, so this import stays as-is.
           const { parseArtifacts, convertCodeBlocksToArtifacts } = await import('@bike4mind/utils');

--- a/b4m-core/services/src/llm/artifactGating.test.ts
+++ b/b4m-core/services/src/llm/artifactGating.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { resolveArtifactsEnabled } from './artifactGating';
+
+describe('resolveArtifactsEnabled', () => {
+  it('requires the admin setting: no request flag can turn artifacts back on', () => {
+    expect(resolveArtifactsEnabled(false, true)).toBe(false);
+    expect(resolveArtifactsEnabled(false, false)).toBe(false);
+    expect(resolveArtifactsEnabled(false, undefined)).toBe(false);
+  });
+
+  it('honours an explicit opt-out from the caller', () => {
+    expect(resolveArtifactsEnabled(true, false)).toBe(false);
+  });
+
+  it('leaves the admin setting as the only gate when the caller says nothing', () => {
+    // Regression lock: most internal callers never set the flag. Reading absence as "off" would
+    // silently strip artifacts from every one of them.
+    expect(resolveArtifactsEnabled(true, undefined)).toBe(true);
+  });
+
+  it('is on when both agree', () => {
+    expect(resolveArtifactsEnabled(true, true)).toBe(true);
+  });
+});

--- a/b4m-core/services/src/llm/artifactGating.ts
+++ b/b4m-core/services/src/llm/artifactGating.ts
@@ -1,0 +1,19 @@
+/**
+ * Whether artifacts are live for one chat completion: the deployment-wide admin setting AND the
+ * caller's per-request flag. Within ChatCompletionProcess this gates BOTH the artifact-emission
+ * system prompt and the post-stream extraction, so a turn is never told to emit artifacts that
+ * nothing will extract, and never has artifacts spliced into a reply whose caller asked for none.
+ *
+ * Scope is the chat pipeline only. The agent-execution surface injects the same prompt off the
+ * admin setting alone; its payload carries no per-request artifact flag, so there is no caller
+ * intent for this to honour there.
+ *
+ * `undefined` means the caller expressed no preference and leaves the admin setting as the only
+ * gate. That asymmetry is deliberate and load-bearing: most internal callers never set the flag,
+ * and reading absence as "off" would silently strip artifacts from all of them. Only an explicit
+ * `false` - the external /api/chat surface, the voice proxy, Slack - opts out. Clients that cannot
+ * yet resolve the user's preference must therefore send nothing, not `false`.
+ */
+export function resolveArtifactsEnabled(adminEnabled: boolean, requestedByCaller: boolean | undefined): boolean {
+  return adminEnabled && requestedByCaller !== false;
+}

--- a/b4m-core/services/src/llm/systemPromptFloorTelemetry.ts
+++ b/b4m-core/services/src/llm/systemPromptFloorTelemetry.ts
@@ -7,7 +7,7 @@ import type { SystemPromptDetail } from '@bike4mind/common';
  * assembly sends is what gets measured - no re-derivation, no drift.
  */
 export type AlwaysOnFloorInput = {
-  /** getSettingsValue('EnableArtifacts'); artifact-emission guidance is gated on it. */
+  /** The effective artifact gate (admin setting AND request flag) - see resolveArtifactsEnabled. */
   artifactEmissionEnabled: boolean;
   /** Resolved ArtifactEmissionPrompt (or its default). */
   artifactEmissionContent: string;


### PR DESCRIPTION
# Pull Request

## Description

The artifact-emission system prompt (~2,780 tokens) shipped on **every** chat completion, gated only on the deployment-wide `EnableArtifacts` admin setting. The per-request `enableArtifacts` flag was parsed, threaded all the way through `ChatCompletionInvoke` into `ChatCompletionProcess`, and then never read. Callers that explicitly pass `enableArtifacts: false` -- the external `POST /api/chat` surface, the voice LLM proxy, and every Slack entry point -- paid for the block anyway.

The token cost is the smaller half. That prompt's thesis is *never deliver less than the complete artifact*, with `NEVER ABBREVIATE THE BODY - THIS IS THE MOST DAMAGING FAILURE YOU CAN PRODUCE HERE` and a blacklist of hedging phrases. It arrives as an undifferentiated system message alongside org, data-lake, and session prompts, so on a turn where no artifact is possible it reads as a general instruction: *withholding a deliverable is the worst thing you can do.* On a retrieval-grounded question that argues directly against "I don't have enough to answer that" -- which is the answer a knowledge product needs. An internal A/B over the same model, same question, with and without the B4M prompt layer, measured a grounded-honesty score fall from **0.95 to 0.48**, the low arm inventing details about the asker's situation to fill the gaps.

The same defect had a mirror in forced retrieval. `KnowledgeRetrievalFeature` returns an empty array whenever a grounded turn finds nothing, and a code comment asserted this made "the model refuse" -- but nothing ever told it to. With no context and no instruction, the model answered from parametric knowledge, and on a citation-enforced surface that reads to the user as a library-backed answer.

Three changes: honor the request flag, scope the completeness mandate to artifact bodies, and make an ungrounded retrieval turn say so.

## Changes

**Honor the per-request flag** (`b4m-core/services/src/llm/artifactGating.ts`, new)

- `resolveArtifactsEnabled(adminEnabled, requestedByCaller)` = `adminEnabled && requestedByCaller !== false`. One resolved boolean now gates the emission prompt, the post-stream extraction pass, and the Context Inspector's floor telemetry, so those three can't disagree.
- `undefined` deliberately does **not** mean off. Most internal callers never set the flag; reading absence as "off" would silently strip artifacts from all of them. Only an explicit `false` opts out.
- Gating extraction fixes a second bug on its own: `convertCodeBlocksToArtifacts` rewrites `quest.replies`, so a caller that asked for no artifacts was getting `<artifact>` markup spliced into the response body it received back. Tool-extracted artifacts (`source: 'tool_result'`) are written in `ToolBuilder` outside this block and are unaffected.

**Scope the prompt** (`b4m-core/common/src/schemas/settings.ts`)

- A leading `SCOPE:` paragraph binds `COMPLETENESS` and `NEVER ABBREVIATE` to the body of an artifact already chosen, states that nothing in the block decides *whether* to answer, and names abstention as a correct, high-value response. `COMPLETENESS` carries a matching `(artifact bodies only - see SCOPE)` anchor, and the closing paragraph ends on the same note instead of on "never withhold".
- The "never paste large raw HTML or code into the chat body" rule moved up into the when-to-emit paragraph, where it isn't covered by the artifact-bodies-only label.
- No change to the forbidden-phrase list, which must stay in sync with `PLACEHOLDER_PATTERNS` in `@bike4mind/utils/artifactElision`.

**Abstain instead of guessing** (`b4m-core/services/src/llm/ChatCompletionFeatures.ts`)

The five paths where a forced-retrieval turn grounds nothing now inject an abstention block instead of returning nothing. It carries one of three findings, because the model relays this to the user as fact and only one of the three earns "the library does not cover this":

| Finding | When | What it says |
|---|---|---|
| `unavailable` | repository missing, search threw, no readable documents, no chunk ever scored | the library could not be consulted -- explicitly forbids claiming a coverage gap |
| `no_match_partial` | a real search ran but the candidate cap / chunk budget / an embedding-model mismatch cut it short | the search turned up nothing, and must not harden into "nothing exists" |
| `no_match` | the whole accessible library was searched, nothing cleared the relevance floor | plainly, it does not cover this |

An outage must never reach the user as "that document isn't in here", so the `reportCoverage` return value at the below-floor path is now threaded into the finding rather than discarded. Every instruction is conditional on the request actually depending on the library -- forced retrieval is a per-session toggle on ordinary chats, so a greeting or a "make that shorter" must not become a refusal. The two non-failures stay silent: an empty prompt, and a turn carrying attached files (there the attachment *is* the source, and skipping lake retrieval is intended).

## Deliberate behaviour changes -- please read before approving

**1. `EnableArtifactsDefault` now defaults to `true`.**

This is load-bearing, not incidental. Because the pipeline ignored the request flag, a user who never touched the Profile artifacts toggle received artifacts regardless of this setting -- the client sends `isFeatureEnabled('enableArtifacts')`, which resolves to this default. Honoring the flag while leaving the default `false` would silently withdraw a working feature from the entire never-toggled population on any deployment that never expressed an opinion. Flipping it keeps today's effective server-side behaviour and makes the setting describe reality.

A deployment that has explicitly stored `false` keeps its choice, and now gets it enforced end to end for the first time.

One visible consequence for that population: `ArtifactPreviewCard` seeds its expanded state from `!artifactsEnabled`, so artifact cards will now render **collapsed** by default rather than expanded. That is the designed presentation for artifact-enabled users. The other consumers of the flag are benign -- the "Artifact" option appears in the recharts display selector, the Profile toggle renders on, and recharts mode is no longer force-pinned to inline (it still defaults to inline).

**2. A client that hasn't resolved the user's preference now sends nothing, not `false`.**

`LLMContext.isArtifactsEnabled` widened to `boolean | undefined` and stays `undefined` until admin settings and user prefs have both hydrated. Without this, the first prompt of a cold page load would send a pre-hydration `false`, which under the new semantics reads as a deliberate opt-out and would silently cost that turn its artifacts. The window is small behind CDN-seeded public settings and larger on self-host, where that artifact 404s.

**3. `ArtifactEmissionPrompt` is a live-editable admin string.**

Any environment whose row holds a saved copy of an older default keeps that copy and gets **none** of the scoping fix -- the honesty regression would still reproduce there with no signal. The code change alone does not ship the prompt change. Stored values need checking per environment; clearing the field reverts to the maintained default. The setting description and the constant's docstring now say so.

## Guide for Testers

Prerequisite: an admin account, and a session you can attach a data lake to.

### A. The artifact prompt no longer ships to API callers

1. Sign in as an admin and go to `Sidebar -> Admin -> Settings`. Confirm `Enable Artifacts` is ON.
2. Open a normal chat session. Type `Build me a small interactive HTML dashboard with three stat tiles.` and send.
3. Expected: the reply produces an artifact card (collapsed by default) with a working preview. Artifacts still work for normal chat.
4. Now call the external API directly with an account API key, with no artifact flag:
   ```
   curl -X POST https://<your-host>/api/chat \
     -H "Authorization: Bearer <API_KEY>" -H "Content-Type: application/json" \
     -d '{"sessionId":"<SESSION_ID>","message":"Write a Python function that reverses a string.","toolMode":"fast"}'
   ```
5. Expected: the response body contains a normal fenced markdown code block. It must **not** contain an `<artifact ...>` tag. Before this change it could.
6. Open the same session in the UI and use the Context Inspector on that quest. Expected: the `artifact_emission` row shows `0` tokens and is marked excluded.

### B. Abstention on a grounded turn that finds nothing

7. Create a data-lake session and attach a lake that contains documents on a narrow topic (or use the header Data Lake toggle on a normal chat).
8. Ask something the corpus plainly does not contain, e.g. `What does the corpus say about next year's regional staffing plan?`
9. Expected: the model says the library does not cover this and asks for what is missing. It must **not** invent an answer, a source, or details about your organization.
10. Ask a deliberately underspecified question with no corpus support: `We have a lot of data about our supply chain and we know there is inefficiency in it. Formalize the optimization problem for us.`
11. Expected: the reply pushes back on the premise and enumerates what it needs (objective, decision variables, constraints, data). It must **not** assert facts about your business ("you are running at least three distinct operations") to complete the formulation.
12. On the same grounded session, send `hi` and then `make that shorter`.
13. Expected: both behave normally. Neither turns into a refusal or a "the library does not cover this" notice.

### C. Data Lake mode with nothing to search

14. Turn on Data Lake mode on a chat with no accessible lake documents.
15. Send `hi`.
16. Expected: a normal greeting. No coverage-gap announcement.
17. Ask a substantive question that would need the lake.
18. Expected: the model says the library could not be consulted. It must **not** claim the library "does not cover" the topic -- there was nothing to search.

### Regression Checks

19. Voice: start a voice session and ask a question that would normally produce code. Expected: a spoken answer, no artifact markup leaking into the transcript.
20. Slack: mention the bot with `write me a short python script`. Expected: a normal code block in the Slack reply, unchanged from today.
21. Agents: run an agent whose steps produce a chart or an HTML document. Expected: artifacts still persist and render. The agent surface is untouched by this PR.
22. Profile toggle: `Profile -> Experimental Features -> Artifacts`. Expected: shows ON by default. Turn it OFF, send the prompt from step 2. Expected: a plain code block, no artifact card. Turn it back ON, resend. Expected: the artifact card returns.
23. Citations: on a grounded session ask something the corpus **does** cover. Expected: a cited answer with the Sources chip, exactly as before.

### What NOT to test

- Artifact rendering internals, the publish/share pipeline, and the sandbox CSP. This PR changes only *whether* the emission prompt and the extraction pass run, never how an artifact renders or publishes.
- The agent-execution surface. It injects the same prompt off the admin setting alone; its payload carries no per-request artifact flag, so there is no caller intent to honor there. Making that surface capability-conditional is follow-up work.

## Additional Information

Verified: `@bike4mind/services` 3114 tests pass, `@bike4mind/common` 1389 pass, client contexts/hooks/Session suites 564 pass, `turbo:typecheck` clean across `services`, `common`, and `client`, and `eslint` clean on every changed file. `apps/client`'s full suite has 43 failures on this branch and the identical 43 on `main` (Mongo e2e plus `server/modelDiscovery/adapters.test.ts`); `packages/scripts` fails `typecheck:fast` on `main` too, on a missing `@aws-sdk/s3-request-presigner`. Neither is related to this change.

The eval that produced the 0.95 -> 0.48 number ran against a bare provider call as the control arm, so it isolates the prompt layer but does not prove the artifact block is the sole cause -- org- and session-level prompts stored in the DB could contribute. This PR is the cheap decisive test: re-run the same question through `POST /api/chat` with `toolMode: 'fast'`, where the block is now absent, and see whether the grounded-honesty score moves toward the control.

Two follow-ups deliberately left out of scope: making the emission prompt capability-conditional more broadly (skip it when no artifact-capable surface is attached, on the agent path as well as chat), and auditing `HELP_CENTER_PROMPT`, the other always-on floor block. That one is ~197 tokens, already narrowly scoped to "how do I do X in the app" questions, and already pro-abstention ("if unsure, say so ... rather than guessing"), so it was left alone.

## Developer Notes

- `resolveArtifactsEnabled` establishes the pattern for the other request-level feature flags: an admin gate that can only turn a feature off, a request flag that can only opt out, and `undefined` reserved for "no preference" so absence is never mistaken for refusal. `enableAgents` and `enableMementos` are read directly off the parsed body today and have the same pre-hydration race the client fix here addresses for artifacts.
- `forcedRetrievalNoContextPrompt` makes the *provenance* of an empty result part of what the model is told, not just the emptiness. Any future retrieval arm that can fail for more than one reason wants this shape: an outage, a truncated scan, and a genuine miss are three different statements to a user, and collapsing them is how a knowledge product loses trust.
- Prompt text that ships on every turn should carry its own scope statement. This block reads as an instruction about the whole turn precisely because it never said what it governed.
