### PR TITLE
fix(model-discovery): apply real price changes and make every run reviewable

### DIFF
--- a/apps/client/app/components/admin/AdminPage.tsx
+++ b/apps/client/app/components/admin/AdminPage.tsx
@@ -66,15 +66,9 @@ import SystemSecretsTab from './SystemSecretsTab';
 import MenuIcon from '@mui/icons-material/Menu';
 import ApiReferenceTab from './ApiReferenceTab';
 import ApiCookbookTab from './ApiCookbookTab';
-import {
-  AdminTab,
-  SIDEBAR_SECTIONS,
-  SIDEBAR_EXPANDED_STORAGE_KEY,
-  findSectionKeyForTab,
-  type SidebarGate,
-  type SidebarItem,
-} from './adminSidebarConfig';
+import { AdminTab, SIDEBAR_SECTIONS, type SidebarGate, type SidebarItem } from './adminSidebarConfig';
 import { useAdminModal } from './useAdminModal';
+import { useAdminSidebarSections } from './useAdminSidebarSections';
 
 export { AdminTab } from './adminSidebarConfig';
 
@@ -137,38 +131,7 @@ const SidebarNav = ({
 }: SidebarNavProps) => {
   const activeTab = useAdminModal(state => state.activeTab);
 
-  // Expand state keyed by section. On mount, restore the user's last choice from
-  // localStorage; otherwise expand only the section containing the active tab so
-  // the sidebar opens scannable instead of fully expanded.
-  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(() => {
-    if (typeof window !== 'undefined') {
-      try {
-        const stored = window.localStorage.getItem(SIDEBAR_EXPANDED_STORAGE_KEY);
-        if (stored) {
-          const parsed = JSON.parse(stored) as Record<string, boolean>;
-          return Object.fromEntries(SIDEBAR_SECTIONS.map(s => [s.key, parsed[s.key] ?? false]));
-        }
-      } catch {
-        // Ignore malformed storage and fall through to active-section default.
-      }
-    }
-    const activeKey = findSectionKeyForTab(activeTab);
-    return Object.fromEntries(SIDEBAR_SECTIONS.map(s => [s.key, s.key === activeKey]));
-  });
-
-  const toggleSection = (key: string) => {
-    setExpandedSections(prev => {
-      const next = { ...prev, [key]: !prev[key] };
-      if (typeof window !== 'undefined') {
-        try {
-          window.localStorage.setItem(SIDEBAR_EXPANDED_STORAGE_KEY, JSON.stringify(next));
-        } catch {
-          // Persistence is best-effort; ignore quota/serialization failures.
-        }
-      }
-      return next;
-    });
-  };
+  const { isExpanded, toggleSection } = useAdminSidebarSections(activeTab);
 
   const gates: Record<SidebarGate, boolean> = {
     userMigration: !!enableUserMigration,
@@ -223,11 +186,7 @@ const SidebarNav = ({
         const { Icon: SectionIcon } = section;
         const visibleItems = section.items.filter(item => !item.gate || gates[item.gate]);
         return (
-          <Accordion
-            key={section.key}
-            expanded={expandedSections[section.key] ?? false}
-            onChange={() => toggleSection(section.key)}
-          >
+          <Accordion key={section.key} expanded={isExpanded(section.key)} onChange={() => toggleSection(section.key)}>
             <AccordionSummary>
               <SectionIcon color="primary" />
               <Typography color="primary" level="body-md">

--- a/apps/client/app/components/admin/AdminSettingInputField.test.tsx
+++ b/apps/client/app/components/admin/AdminSettingInputField.test.tsx
@@ -5,8 +5,10 @@ import { getThemeConfig } from '@client/app/utils/themes';
 import { SENSITIVE_SETTING_MASK, settingsMap } from '@bike4mind/common';
 
 const mutate = vi.fn();
+// Read at render time, so a test can put the mutation into its rejected state.
+let updateError: unknown;
 vi.mock('@client/app/hooks/data/settings', () => ({
-  useUpdateSettings: () => ({ mutate, isPending: false }),
+  useUpdateSettings: () => ({ mutate, isPending: false, error: updateError }),
 }));
 
 import AdminSettingInputField from './AdminSettingInputField';
@@ -34,6 +36,7 @@ const saveButton = () => screen.getByTestId('admin-setting-anthropicDemoKey-save
 describe('AdminSettingInputField sensitive setting', () => {
   beforeEach(() => {
     mutate.mockReset();
+    updateError = undefined;
   });
 
   it('shows the server mask and reveals nothing on focus', () => {
@@ -116,5 +119,65 @@ describe('AdminSettingInputField sensitive setting', () => {
     const { onSuccess } = mutate.mock.calls[0][1];
     act(() => onSuccess({ settingName: 'anthropicDemoKey', settingValue: `${SENSITIVE_SETTING_MASK}resh` }));
     expect(input().value).toBe(`${SENSITIVE_SETTING_MASK}resh`);
+  });
+});
+
+// modelDiscoveryPriceBandPct is the bounded case: makeNumberSetting gives its schema
+// min 0 / max 500, and the update route parses with that schema.
+const bandSetting = settingsMap.modelDiscoveryPriceBandPct;
+
+const renderBandField = (defaultValue: number) =>
+  render(
+    <TestWrapper>
+      <AdminSettingInputField setting={bandSetting} index={0} defaultValue={defaultValue} />
+    </TestWrapper>
+  );
+
+const bandInput = () => screen.getByTestId('admin-setting-modelDiscoveryPriceBandPct-input') as HTMLInputElement;
+const bandSaveButton = () => screen.getByTestId('admin-setting-modelDiscoveryPriceBandPct-save-btn');
+const bandHelperText = () => screen.getByTestId('admin-setting-modelDiscoveryPriceBandPct-helper');
+
+describe('AdminSettingInputField number setting', () => {
+  beforeEach(() => {
+    mutate.mockReset();
+    updateError = undefined;
+  });
+
+  it('carries the schema bounds the server enforces', () => {
+    renderBandField(50);
+
+    expect(bandInput()).toHaveAttribute('min', '0');
+    expect(bandInput()).toHaveAttribute('max', '500');
+  });
+
+  it('explains an out-of-range value rather than letting the save do nothing', () => {
+    renderBandField(50);
+    fireEvent.change(bandInput(), { target: { value: '600' } });
+
+    // The reported bug: the schema rejects 600 server-side, so a field that submitted it
+    // would look like a no-op save with no reason given anywhere.
+    expect(bandHelperText()).toHaveTextContent('Enter a number between 0 and 500.');
+    expect(bandSaveButton()).toBeDisabled();
+
+    fireEvent.click(bandSaveButton());
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it('saves a value inside the range and keeps showing the description', () => {
+    renderBandField(50);
+    fireEvent.change(bandInput(), { target: { value: '200' } });
+
+    expect(bandHelperText()).toHaveTextContent(bandSetting.description);
+    fireEvent.click(bandSaveButton());
+
+    expect(mutate).toHaveBeenCalledWith({ key: 'modelDiscoveryPriceBandPct', value: 200 }, expect.anything());
+  });
+
+  it('surfaces the server reason when a write is rejected anyway', () => {
+    updateError = { isAxiosError: true, response: { status: 400, data: { message: 'Number must be <= 500' } } };
+
+    renderBandField(50);
+
+    expect(bandHelperText()).toHaveTextContent('Number must be <= 500');
   });
 });

--- a/apps/client/app/components/admin/AdminSettingInputField.tsx
+++ b/apps/client/app/components/admin/AdminSettingInputField.tsx
@@ -1,4 +1,5 @@
 import { useUpdateSettings } from '@client/app/hooks/data/settings';
+import { getErrorMessage } from '@client/app/utils/error';
 import { isMaskedSensitiveSettingValue, settingsMap } from '@bike4mind/common';
 import SaveIcon from '@mui/icons-material/Save';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -78,6 +79,21 @@ const SubSettingToggle = ({ setting, defaultValue }: SubSetting) => {
   );
 };
 
+/**
+ * Why the server would refuse this number, in the words the field shows. The setting's own
+ * schema carries the same bounds (makeNumberSetting in @bike4mind/common), and the update
+ * route parses with it directly, so an out-of-range value comes back as an untranslated
+ * ZodError: without this the admin sees Save do nothing and is told nothing.
+ */
+const rangeMessage = (value: number, min?: number, max?: number): string | undefined => {
+  const inRange = (min === undefined || value >= min) && (max === undefined || value <= max);
+  if (!Number.isNaN(value) && inRange) return undefined;
+  if (min !== undefined && max !== undefined) return `Enter a number between ${min} and ${max}.`;
+  if (min !== undefined) return `Enter a number of ${min} or more.`;
+  if (max !== undefined) return `Enter a number of ${max} or less.`;
+  return 'Enter a number.';
+};
+
 const AdminSettingInputField = ({
   setting,
   index,
@@ -108,6 +124,18 @@ const AdminSettingInputField = ({
   const showsStoredSecretMask = setting.isSensitive === true && isMaskedSensitiveSettingValue(value);
   const isEmbeddingModelSetting = setting.key === 'defaultEmbeddingModel';
 
+  // Only number settings declare bounds, and only some of those, so they are read through
+  // the type discriminant rather than off the union.
+  const bounds: { min?: number; max?: number } = setting.type === 'number' ? setting : {};
+  const rangeError =
+    setting.type === 'number' && value !== null
+      ? rangeMessage(typeof value === 'number' ? value : Number(value), bounds.min, bounds.max)
+      : undefined;
+  // A rejected write is otherwise silent: the mutation surfaces nothing of its own and the
+  // Save button simply stops spinning.
+  const saveError = updateSettings.error ? getErrorMessage(updateSettings.error) : undefined;
+  const fieldError = rangeError ?? saveError;
+
   const saveValue = (next: string | number | boolean) => {
     // Backstop, intentionally unreachable while isDirty excludes the untouched-empty state
     // above: focusing a sensitive field clears the mask, and a click is not guaranteed to
@@ -132,7 +160,7 @@ const AdminSettingInputField = ({
   };
 
   const handleSaveSetting = () => {
-    if (value === null) return;
+    if (value === null || rangeError) return;
 
     // Show warning for embedding model changes
     if (isEmbeddingModelSetting && isDirty) {
@@ -158,7 +186,7 @@ const AdminSettingInputField = ({
       >
         <Grid container spacing={2}>
           <Grid xs={12} md={6}>
-            <FormControl sx={{ width: '100%' }}>
+            <FormControl error={Boolean(fieldError)} sx={{ width: '100%' }}>
               <FormLabel>{setting.name}</FormLabel>
 
               {setting.type === 'boolean' ? (
@@ -169,6 +197,15 @@ const AdminSettingInputField = ({
                 />
               ) : setting.type === 'number' ? (
                 <Input
+                  // The schema's own bounds, so the browser offers the same range the server
+                  // will accept rather than leaving the field unbounded.
+                  slotProps={{
+                    input: {
+                      'data-testid': `admin-setting-${setting.key}-input`,
+                      min: bounds.min,
+                      max: bounds.max,
+                    },
+                  }}
                   type="number"
                   value={typeof value === 'number' ? value : Number(value)}
                   onChange={e => setValue(Number(e.target.value))}
@@ -212,7 +249,9 @@ const AdminSettingInputField = ({
                 )
               ) : null}
 
-              <FormHelperText>{setting.description}</FormHelperText>
+              <FormHelperText data-testid={`admin-setting-${setting.key}-helper`}>
+                {fieldError ?? setting.description}
+              </FormHelperText>
             </FormControl>
           </Grid>
 
@@ -225,7 +264,7 @@ const AdminSettingInputField = ({
                 type="button"
                 loading={updateSettings.isPending}
                 onClick={handleSaveSetting}
-                disabled={!isDirty}
+                disabled={!isDirty || Boolean(rangeError)}
               >
                 <SaveIcon sx={{ marginX: 1 }} />
               </Button>

--- a/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.test.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.test.tsx
@@ -11,6 +11,7 @@ vi.mock('@client/app/contexts/ApiContext', () => ({
 }));
 
 import { ModelPricingCatalog } from './ModelPricingCatalog';
+import { useCreditAnalysisStore } from '../store';
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -56,6 +57,7 @@ describe('ModelPricingCatalog', () => {
     vi.clearAllMocks();
     mockGet.mockResolvedValue({ data: { rows: ROWS } });
     mockPost.mockResolvedValue({ data: { row: {} } });
+    useCreditAnalysisStore.setState({ activeTab: 'pricing', pricingModelId: null });
   });
 
   it('renders in-force rows with seed/operator source chips', async () => {
@@ -116,7 +118,8 @@ describe('ModelPricingCatalog', () => {
     expect(save).toHaveAttribute('disabled');
     expect(mockPost).not.toHaveBeenCalled();
 
-    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '0.000005' } });
+    // Entered in the displayed unit ($/1M), posted as the stored per-token rate.
+    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '5' } });
     fireEvent.change(screen.getByTestId('reprice-note-input'), { target: { value: 'openai price page 2026-07' } });
     fireEvent.click(screen.getByTestId('reprice-save-btn'));
 
@@ -126,8 +129,198 @@ describe('ModelPricingCatalog', () => {
     expect(body).toMatchObject({
       modelId: 'gpt-x',
       note: 'openai price page 2026-07',
-      pricing: { '0': { input: 0.000005, output: 16e-6 } },
+      pricing: { '0': { input: 5e-6, output: 16e-6 } },
     });
+    // The markup is never written; the row stays raw provider cost.
+    expect(body).not.toHaveProperty('confirm');
+  });
+
+  it('edits token rates in the displayed unit: a stored 3e-6 opens as 3 and a saved 0.2 posts 2e-7', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        rows: [
+          {
+            modelId: 'gpt-cheap',
+            unit: 'per_token',
+            pricing: { '0': { input: 3e-6, output: 12e-6 } },
+            effectiveFrom: '2026-07-01T00:00:00.000Z',
+            note: 'adapter-seed',
+          },
+        ],
+      },
+    });
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-cheap-per_token'));
+
+    // What the table shows ($3.00) is what the editor seeds.
+    expect(screen.getByTestId('reprice-rate-0-input')).toHaveValue('3');
+    expect(screen.getByTestId('reprice-rate-0-output')).toHaveValue('12');
+
+    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '0.2' } });
+    fireEvent.change(screen.getByTestId('reprice-note-input'), { target: { value: 'provider price page' } });
+    fireEvent.click(screen.getByTestId('reprice-save-btn'));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    const body = mockPost.mock.calls[0][1] as { pricing: Record<string, Record<string, number>> };
+    // Exactly 2e-7: the division's float noise is trimmed, not stored.
+    expect(body.pricing['0'].input).toBe(2e-7);
+    expect(body.pricing['0'].output).toBe(12e-6);
+  });
+
+  it('presents a stored rate carrying 1e6 round-trip float noise as its readable value', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        rows: [
+          {
+            modelId: 'gpt-noisy',
+            unit: 'per_token',
+            // Real production value: 15 $/1M that survived a 1e6 round trip.
+            pricing: { '0': { input: 1.4999999999999999e-5, output: 6e-5 } },
+            effectiveFrom: '2026-07-01T00:00:00.000Z',
+            note: 'adapter-seed',
+          },
+        ],
+      },
+    });
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-noisy-per_token'));
+    expect(screen.getByTestId('reprice-rate-0-input')).toHaveValue('15');
+    expect(screen.getByTestId('reprice-rate-0-input')).not.toHaveValue('14.999999999999998');
+  });
+
+  it('leaves a per_minute row unscaled in both directions (no x1M on open, no /1M on save)', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        rows: [
+          {
+            modelId: 'voice-conversational',
+            unit: 'per_minute',
+            pricing: { '0': { input: 0.06, output: 0 } },
+            effectiveFrom: '2026-07-01T00:00:00.000Z',
+            note: 'adapter-seed',
+          },
+        ],
+      },
+    });
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-voice-conversational-per_minute'));
+    expect(screen.getByTestId('reprice-rate-0-input')).toHaveValue('0.06');
+
+    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '0.09' } });
+    fireEvent.change(screen.getByTestId('reprice-note-input'), { target: { value: 'realtime price page' } });
+    fireEvent.click(screen.getByTestId('reprice-save-btn'));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    expect(mockPost.mock.calls[0][1]).toMatchObject({
+      unit: 'per_minute',
+      pricing: { '0': { input: 0.09, output: 0 } },
+    });
+  });
+
+  it('shows what a user pays at the published markup as a read-only derived line', async () => {
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-x-per_token'));
+    // gpt-x stores 4e-6 / 16e-6 -> $4 and $16 per 1M cost, x1.2 default markup.
+    const derived = screen.getByTestId('reprice-markup-0');
+    expect(derived).toHaveTextContent('$4.8');
+    expect(derived).toHaveTextContent('$19.2');
+    expect(derived).toHaveTextContent('markup');
+    // Editing the cost re-derives it without changing what gets posted.
+    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '10' } });
+    expect(screen.getByTestId('reprice-markup-0')).toHaveTextContent('$12');
+    expect(screen.getByTestId('reprice-rate-0-input')).toHaveValue('10');
+  });
+
+  it('offers a confirm path that echoes the waiver token the server issued', async () => {
+    mockPost.mockRejectedValueOnce({
+      message: 'Request failed with status code 400',
+      response: {
+        data: {
+          code: 'manual-reprice-over-band',
+          confirmToken: 'a1b2c3d4e5f60718',
+          error: 'gpt-x input: $4 -> $4000 per 1M tokens is a 1000x move, beyond the 10x manual reprice band',
+        },
+      },
+    });
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-x-per_token'));
+    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '4000' } });
+    fireEvent.change(screen.getByTestId('reprice-note-input'), { target: { value: 'provider price page' } });
+    fireEvent.click(screen.getByTestId('reprice-save-btn'));
+
+    expect(await screen.findByTestId('reprice-modal-error')).toHaveTextContent('1000x move');
+    expect(mockPost.mock.calls[0][1]).not.toHaveProperty('confirm');
+
+    fireEvent.click(screen.getByTestId('reprice-confirm-band-btn'));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(2));
+    expect(mockPost.mock.calls[1][1]).toMatchObject({
+      modelId: 'gpt-x',
+      // The exact token, not a boolean: the server re-derives it from this draft.
+      confirm: 'a1b2c3d4e5f60718',
+      pricing: { '0': { input: 4e-3 } },
+    });
+  });
+
+  it('surfaces EVERY enumerated violation, not just the first line of the rejection', async () => {
+    mockPost.mockRejectedValueOnce({
+      response: {
+        data: {
+          code: 'manual-reprice-over-band',
+          confirmToken: 'deadbeefdeadbeef',
+          error:
+            'gpt-x (per_token): 2 changes need confirmation before they can settle calls:\n' +
+            '- gpt-x input (tier 0): $4 -> $120 per 1M tokens is a 30x move, beyond the 10x manual reprice band\n' +
+            '- gpt-x output (tier 0): $16 -> $16000000 per 1M tokens is a 1000000x move, beyond the 10x manual reprice band\n' +
+            'review every line, then resubmit with confirm set to the confirmToken in this response.',
+        },
+      },
+    });
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-x-per_token'));
+    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '120' } });
+    fireEvent.change(screen.getByTestId('reprice-rate-0-output'), { target: { value: '16000000' } });
+    fireEvent.change(screen.getByTestId('reprice-note-input'), { target: { value: 'provider price page' } });
+    fireEvent.click(screen.getByTestId('reprice-save-btn'));
+
+    const alert = await screen.findByTestId('reprice-modal-error');
+    expect(alert).toHaveTextContent('input (tier 0): $4 -> $120 per 1M tokens is a 30x move');
+    expect(alert).toHaveTextContent('output (tier 0): $16 -> $16000000 per 1M tokens is a 1000000x move');
+    // Newlines must survive into the Alert or the lines run together.
+    expect(alert).toHaveStyle({ whiteSpace: 'pre-line' });
+  });
+
+  it('withdraws the over-band confirm once the rejected rate is edited', async () => {
+    mockPost.mockRejectedValueOnce({
+      response: {
+        data: {
+          code: 'manual-reprice-over-band',
+          confirmToken: 'a1b2c3d4e5f60718',
+          error: 'beyond the 10x manual reprice band',
+        },
+      },
+    });
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-x-per_token'));
+    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '4000' } });
+    fireEvent.change(screen.getByTestId('reprice-note-input'), { target: { value: 'provider price page' } });
+    fireEvent.click(screen.getByTestId('reprice-save-btn'));
+    await screen.findByTestId('reprice-confirm-band-btn');
+
+    fireEvent.change(screen.getByTestId('reprice-rate-0-input'), { target: { value: '4.5' } });
+    expect(screen.queryByTestId('reprice-confirm-band-btn')).toBeNull();
+  });
+
+  it('offers no waiver for a rejection that carries no token (nothing to confirm)', async () => {
+    mockPost.mockRejectedValueOnce({
+      response: { data: { error: "tier key '0200000' has a leading zero" } },
+    });
+    renderCatalog();
+    fireEvent.click(await screen.findByTestId('model-pricing-reprice-gpt-x-per_token'));
+    fireEvent.change(screen.getByTestId('reprice-note-input'), { target: { value: 'provider price page' } });
+    fireEvent.click(screen.getByTestId('reprice-save-btn'));
+
+    expect(await screen.findByTestId('reprice-modal-error')).toHaveTextContent('leading zero');
+    expect(screen.queryByTestId('reprice-confirm-band-btn')).toBeNull();
   });
 
   it('revert-to-seed is offered only on operator rows and posts the action after confirm', async () => {
@@ -316,6 +509,28 @@ describe('ModelPricingCatalog', () => {
     });
     await waitFor(() => expect(screen.getByTestId('history-drawer')).toHaveTextContent('gpt-y'));
     expect(screen.getByTestId('history-drawer')).not.toHaveTextContent('stale gpt-x row');
+  });
+
+  it('filters the catalog by model id', async () => {
+    renderCatalog();
+    await screen.findByTestId('model-pricing-row-gpt-x-per_token');
+
+    fireEvent.change(screen.getByTestId('model-pricing-filter-input'), { target: { value: 'gpt-y' } });
+
+    expect(screen.getByTestId('model-pricing-row-gpt-y-per_token')).toBeInTheDocument();
+    expect(screen.queryByTestId('model-pricing-row-gpt-x-per_token')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('model-pricing-filter-input'), { target: { value: 'nothing-like-this' } });
+    expect(screen.getByTestId('model-pricing-filter-empty')).toBeInTheDocument();
+  });
+
+  it('seeds the filter from a cross-surface jump and consumes the focus so a later visit is not stuck', async () => {
+    useCreditAnalysisStore.setState({ pricingModelId: 'gpt-y' });
+    renderCatalog();
+
+    await waitFor(() => expect(screen.getByTestId('model-pricing-filter-input')).toHaveValue('gpt-y'));
+    expect(screen.queryByTestId('model-pricing-row-gpt-x-per_token')).not.toBeInTheDocument();
+    expect(useCreditAnalysisStore.getState().pricingModelId).toBeNull();
   });
 
   it('history drawer fetches and lists the audit trail for one model', async () => {

--- a/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/ModelPricingCatalog.tsx
@@ -23,8 +23,11 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import EditIcon from '@mui/icons-material/Edit';
 import HistoryIcon from '@mui/icons-material/History';
 import ReplayIcon from '@mui/icons-material/Replay';
-import type { IModelPriceTier } from '@bike4mind/common';
+// getPriceMargin is read-only here: markup is applied when calls settle, so it
+// informs the editor's derived line and never reaches a stored rate.
+import { getPriceMargin, type IModelPriceTier } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
+import { useCreditAnalysisStore } from '../store';
 
 /** Wire shape of a catalog row (dates arrive as ISO strings). */
 interface PriceRow {
@@ -42,9 +45,9 @@ const SEED_NOTE = 'adapter-seed';
 const isSeedRow = (row: PriceRow) => row.note === SEED_NOTE;
 
 // Mirrors DISCOVERY_PRICE_NOTE_PREFIX in @bike4mind/common; discovery stamps
-// notes as 'discovery:<source>@<iso-date>'. Duplicated because every
-// @bike4mind import in this file is type-only, and a runtime one would drag
-// server code into the client bundle. Pinned by the model-prices API test.
+// notes as 'discovery:<source>@<iso-date>'. Kept as a literal so the whole note
+// vocabulary this file classifies on reads in one place, next to SEED_NOTE,
+// which cannot be imported at all. Pinned by the model-prices API test.
 const DISCOVERY_NOTE_PREFIX = 'discovery:';
 const isDiscoveryRow = (row: PriceRow) => row.note?.startsWith(DISCOVERY_NOTE_PREFIX) === true;
 
@@ -96,12 +99,50 @@ const UNIT_SUFFIX: Record<string, string> = {
   per_image: 'per image',
 };
 
+/** Compact form for the narrow editor inputs; the modal states the full unit. */
+const UNIT_FIELD_SUFFIX: Record<string, string> = {
+  per_token: '$/M',
+  per_minute: '$/min',
+  per_image: '$/img',
+};
+
+// The one place the token scale lives: display, editing, and submission all go
+// through it, because a scaling applied in one direction and missed in the
+// other is a 1e6 mispricing that takes effect the instant the row is appended.
+const TOKENS_PER_MILLION = 1_000_000;
+
 // per_token rates are USD per single token and read best scaled to 1M; other
 // units are already human-scale and must NOT be inflated.
 const formatRate = (unit: string, value: number | undefined) => {
   if (value === undefined) return '-';
-  const scaled = unit === 'per_token' ? value * 1_000_000 : value;
+  const scaled = unit === 'per_token' ? value * TOKENS_PER_MILLION : value;
   return `$${scaled.toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
+};
+
+// Both directions trim to 10 significant digits: the 1e6 round trip leaves
+// float noise at either end (stored 1.4999999999999999e-05 must present as 15,
+// and an entered 0.2 must store as 2e-7, not 2.0000000000000002e-7, or the
+// API's idempotency compare sees a change that isn't one). Same choice as
+// readable() in b4m-core/services/src/modelDiscoveryService/pricePlan.ts.
+const trimRoundTripNoise = (value: number) => Number(value.toPrecision(10));
+
+/** Stored per-single-token rate -> the value the editor shows and edits. */
+const toDisplayedRate = (unit: string, stored: number) =>
+  trimRoundTripNoise(unit === 'per_token' ? stored * TOKENS_PER_MILLION : stored);
+
+/** Inverse of toDisplayedRate: the edited value back to the stored wire rate. */
+const toStoredRate = (unit: string, displayed: number) =>
+  trimRoundTripNoise(unit === 'per_token' ? displayed / TOKENS_PER_MILLION : displayed);
+
+/**
+ * What a user pays for a rate the editor is showing. Display only: the markup
+ * is applied when calls settle (usdToCredits), so it must never reach the wire
+ * or the catalog would carry cost times markup and be marked up again on read.
+ */
+const markedUpRate = (displayed: string | undefined) => {
+  const value = Number(displayed);
+  if (displayed === undefined || !Number.isFinite(value)) return '-';
+  return `$${(value * getPriceMargin()).toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
 };
 
 const firstTier = (row: PriceRow): IModelPriceTier => Object.values(row.pricing)[0] ?? { input: 0, output: 0 };
@@ -110,26 +151,54 @@ const numberCell = { fontVariantNumeric: 'tabular-nums' } as const;
 
 // Axios errors carry the server's validation reason in response.data, while
 // err.message is the useless generic 'Request failed with status code 400'.
+// The envelope names it 'error' (server/middlewares/errorHandler.ts); 'message'
+// stays as a fallback for endpoints that answer outside that envelope.
 const apiErrorMessage = (err: unknown, fallback: string) => {
-  const e = err as { response?: { data?: { message?: string } }; message?: string };
-  return e?.response?.data?.message || e?.message || fallback;
+  const e = err as { response?: { data?: { error?: string; message?: string } }; message?: string };
+  return e?.response?.data?.error || e?.response?.data?.message || e?.message || fallback;
+};
+
+// Mirrors MANUAL_REPRICE_BAND_ERROR_CODE in pages/api/admin/model-prices.ts
+// (importing an API route here would drag the server into the SPA bundle);
+// pinned by that route's test. It marks the one rejection an operator may waive,
+// so a magnitude slip costs a second, deliberate click instead of nothing.
+const BAND_ERROR_CODE = 'manual-reprice-over-band';
+
+/**
+ * The waiver token from a guardrail rejection, or null when the failure was
+ * anything else. It is echoed back verbatim as `confirm`: the server recomputes
+ * it from the resubmitted draft, so it can only ever waive the exact values
+ * this rejection enumerated.
+ */
+const bandConfirmToken = (err: unknown): string | null => {
+  const data = (err as { response?: { data?: { code?: string; confirmToken?: string } } })?.response?.data;
+  return data?.code === BAND_ERROR_CODE && typeof data.confirmToken === 'string' ? data.confirmToken : null;
 };
 
 /**
  * Admin manager for the versioned model price catalog. Rates are provider
- * cost beliefs in USD (shown per 1M tokens); what users pay is always this
- * cost times the published uniform markup, so nothing here touches markup.
+ * cost beliefs in USD (shown AND edited per 1M tokens, stored per token); what
+ * users pay is always this cost times the published uniform markup, so nothing
+ * here writes markup.
  * All writes are append-only rows via /api/admin/model-prices.
  */
 export const ModelPricingCatalog: React.FC = () => {
   const [rows, setRows] = useState<PriceRow[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
+
+  const pricingModelId = useCreditAnalysisStore(state => state.pricingModelId);
+  const clearPricingModelId = useCreditAnalysisStore(state => state.clearPricingModelId);
 
   const [repriceTarget, setRepriceTarget] = useState<PriceRow | null>(null);
   const [draftRates, setDraftRates] = useState<Record<string, Record<string, string>>>({});
   const [note, setNote] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+  // Waiver token from the server's guardrails; cleared on any edit so a confirm
+  // can only ever waive the exact values the server rejected (the server also
+  // re-derives the token, so a stale one is refused there too).
+  const [confirmToken, setConfirmToken] = useState<string | null>(null);
 
   const [revertTarget, setRevertTarget] = useState<PriceRow | null>(null);
   const [historyModel, setHistoryModel] = useState<string | null>(null);
@@ -155,22 +224,38 @@ export const ModelPricingCatalog: React.FC = () => {
     void fetchRows();
   }, [fetchRows]);
 
+  // A cross-surface jump (a discovery price flag) names one model out of ~110
+  // rows. Consumed once so a later manual visit does not open still filtered.
+  useEffect(() => {
+    if (!pricingModelId) return;
+    setFilter(pricingModelId);
+    clearPricingModelId();
+  }, [pricingModelId, clearPricingModelId]);
+
+  // Drafts are held in the DISPLAYED unit (per 1M for token rows), so what the
+  // editor shows always matches the table it was opened from.
   const openReprice = (row: PriceRow) => {
     const drafts: Record<string, Record<string, string>> = {};
     for (const [threshold, tier] of Object.entries(row.pricing)) {
       drafts[threshold] = {};
       for (const field of RATE_FIELDS) {
         const value = tier[field];
-        if (value !== undefined) drafts[threshold][field] = String(value);
+        if (value !== undefined) drafts[threshold][field] = String(toDisplayedRate(row.unit, value));
       }
     }
     setDraftRates(drafts);
     setNote('');
     setError(null);
+    setConfirmToken(null);
     setRepriceTarget(row);
   };
 
-  const submitReprice = async () => {
+  const editRate = (threshold: string, field: string, value: string) => {
+    setConfirmToken(null);
+    setDraftRates(prev => ({ ...prev, [threshold]: { ...prev[threshold], [field]: value } }));
+  };
+
+  const submitReprice = async (waiver?: string) => {
     if (!repriceTarget) return;
     setIsSaving(true);
     setError(null);
@@ -179,7 +264,7 @@ export const ModelPricingCatalog: React.FC = () => {
       for (const [threshold, fields] of Object.entries(draftRates)) {
         pricing[threshold] = {};
         for (const [field, raw] of Object.entries(fields)) {
-          pricing[threshold][field] = Number(raw);
+          pricing[threshold][field] = toStoredRate(repriceTarget.unit, Number(raw));
         }
       }
       await api.post('/api/admin/model-prices', {
@@ -187,11 +272,14 @@ export const ModelPricingCatalog: React.FC = () => {
         unit: repriceTarget.unit,
         pricing,
         note: note.trim(),
+        ...(waiver ? { confirm: waiver } : {}),
       });
       setRepriceTarget(null);
+      setConfirmToken(null);
       await fetchRows();
     } catch (err) {
       setError(apiErrorMessage(err, 'Reprice failed'));
+      setConfirmToken(bandConfirmToken(err));
     } finally {
       setIsSaving(false);
     }
@@ -233,6 +321,14 @@ export const ModelPricingCatalog: React.FC = () => {
     }
   };
 
+  const repriceUnit = repriceTarget?.unit ?? '';
+  const repriceUnitLabel = UNIT_SUFFIX[repriceUnit] ?? repriceUnit;
+
+  const visibleRows = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    return needle ? rows.filter(row => row.modelId.toLowerCase().includes(needle)) : rows;
+  }, [rows, filter]);
+
   const draftInvalid = useMemo(
     () =>
       Object.values(draftRates).some(fields =>
@@ -251,15 +347,25 @@ export const ModelPricingCatalog: React.FC = () => {
             edited.
           </Typography>
         </Box>
-        <IconButton
-          size="sm"
-          onClick={fetchRows}
-          disabled={isLoading}
-          aria-label="Refresh the price catalog"
-          data-testid="model-pricing-refresh-btn"
-        >
-          <RefreshIcon />
-        </IconButton>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Input
+            size="sm"
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            placeholder="Filter by model id"
+            sx={{ width: 220 }}
+            slotProps={{ input: { 'data-testid': 'model-pricing-filter-input', 'aria-label': 'Filter by model id' } }}
+          />
+          <IconButton
+            size="sm"
+            onClick={fetchRows}
+            disabled={isLoading}
+            aria-label="Refresh the price catalog"
+            data-testid="model-pricing-refresh-btn"
+          >
+            <RefreshIcon />
+          </IconButton>
+        </Stack>
       </Stack>
 
       {error && (
@@ -288,7 +394,16 @@ export const ModelPricingCatalog: React.FC = () => {
               </tr>
             </thead>
             <tbody>
-              {rows.map(row => {
+              {visibleRows.length === 0 && rows.length > 0 && (
+                <tr>
+                  <td colSpan={9}>
+                    <Typography level="body-sm" color="neutral" data-testid="model-pricing-filter-empty">
+                      No model id matches &quot;{filter}&quot;.
+                    </Typography>
+                  </td>
+                </tr>
+              )}
+              {visibleRows.map(row => {
                 const tier = firstTier(row);
                 const provenance = provenanceOf(row);
                 const source = discoverySource(row);
@@ -366,13 +481,15 @@ export const ModelPricingCatalog: React.FC = () => {
         <ModalDialog sx={{ minWidth: 420 }} data-testid="reprice-modal">
           <Typography level="title-md">Reprice {repriceTarget?.modelId}</Typography>
           {error && (
-            <Alert color="danger" size="sm" data-testid="reprice-modal-error">
+            // pre-line: a guardrail rejection enumerates one violation per
+            // line, and every line has to be readable before "Apply anyway".
+            <Alert color="danger" size="sm" sx={{ whiteSpace: 'pre-line' }} data-testid="reprice-modal-error">
               {error}
             </Alert>
           )}
-          <Typography level="body-sm" color="neutral">
-            USD per token. This appends a new operator row taking effect immediately; seeding will no longer manage this
-            model until reverted.
+          <Typography level="body-sm" color="neutral" data-testid="reprice-unit-help">
+            Raw provider cost in USD {repriceUnitLabel}, as providers publish it. This appends a new operator row taking
+            effect immediately; seeding will no longer manage this model until reverted.
           </Typography>
           <Stack spacing={1} sx={{ mt: 1 }}>
             {Object.entries(draftRates).map(([threshold, fields]) => (
@@ -385,21 +502,22 @@ export const ModelPricingCatalog: React.FC = () => {
                 <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
                   {Object.entries(fields).map(([field, raw]) => (
                     <FormControl key={field} sx={{ width: 130 }}>
-                      <FormLabel>{RATE_LABELS[field as RateField]}</FormLabel>
+                      <FormLabel>
+                        {RATE_LABELS[field as RateField]} {UNIT_FIELD_SUFFIX[repriceUnit] ?? repriceUnit}
+                      </FormLabel>
                       <Input
                         size="sm"
                         value={raw}
-                        onChange={e =>
-                          setDraftRates(prev => ({
-                            ...prev,
-                            [threshold]: { ...prev[threshold], [field]: e.target.value },
-                          }))
-                        }
+                        onChange={e => editRate(threshold, field, e.target.value)}
                         slotProps={{ input: { 'data-testid': `reprice-rate-${threshold}-${field}` } }}
                       />
                     </FormControl>
                   ))}
                 </Stack>
+                <Typography level="body-xs" color="neutral" data-testid={`reprice-markup-${threshold}`}>
+                  At the published {getPriceMargin()}x markup a user pays about {markedUpRate(fields.input)} in /{' '}
+                  {markedUpRate(fields.output)} out {repriceUnitLabel}. Entered rates stay raw cost.
+                </Typography>
               </Box>
             ))}
             <FormControl required>
@@ -418,11 +536,22 @@ export const ModelPricingCatalog: React.FC = () => {
               <Button
                 disabled={note.trim() === '' || draftInvalid || isSaving}
                 loading={isSaving}
-                onClick={submitReprice}
+                onClick={() => submitReprice()}
                 data-testid="reprice-save-btn"
               >
                 Append price row
               </Button>
+              {confirmToken !== null && (
+                <Button
+                  color="danger"
+                  disabled={note.trim() === '' || draftInvalid || isSaving}
+                  loading={isSaving}
+                  onClick={() => submitReprice(confirmToken)}
+                  data-testid="reprice-confirm-band-btn"
+                >
+                  Apply anyway
+                </Button>
+              )}
             </Stack>
           </Stack>
         </ModalDialog>

--- a/apps/client/app/components/admin/CreditAnalysis/index.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Box, Tabs, TabList, Tab, TabPanel } from '@mui/joy';
 import PeopleIcon from '@mui/icons-material/People';
 import InsightsIcon from '@mui/icons-material/Insights';
@@ -15,13 +15,17 @@ import { CreditAdjustmentsLog } from './components/CreditAdjustmentsLog';
 import { UserCreditsManager } from './components/UserCreditsManager';
 import AdminProfileModal from '../AdminProfileModal';
 import ContextHelpButton from '@client/app/components/help/ContextHelpButton';
+import { useCreditAnalysisStore, type CreditAnalysisTab } from './store';
 
 export const CreditAnalyticsTab: React.FC = () => {
-  const [activeTab, setActiveTab] = useState<string>('users');
+  // Held in the store rather than locally so another admin tab can land the
+  // operator on a specific inner tab (Model Lifecycle -> Model Pricing).
+  const activeTab = useCreditAnalysisStore(state => state.activeTab);
+  const setActiveTab = useCreditAnalysisStore(state => state.setActiveTab);
 
   return (
     <Box sx={{ height: '100%', overflow: 'auto', px: 2, py: 1 }}>
-      <Tabs value={activeTab} onChange={(_, value) => setActiveTab(value as string)} sx={{ mb: 2 }}>
+      <Tabs value={activeTab} onChange={(_, value) => setActiveTab(value as CreditAnalysisTab)} sx={{ mb: 2 }}>
         <TabList sx={{ overflowX: { xs: 'auto', sm: 'visible' }, minWidth: { xs: 'max-content', sm: 'auto' } }}>
           <Tab value="users">
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/apps/client/app/components/admin/CreditAnalysis/store.ts
+++ b/apps/client/app/components/admin/CreditAnalysis/store.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+
+/** Inner tab values of the Credit Analytics tab; must match the Tab/TabPanel values in ./index.tsx. */
+export type CreditAnalysisTab = 'users' | 'pricing' | 'margins' | 'org-usage' | 'ledger' | 'adjustments';
+
+/**
+ * Inner-tab and focus state for Credit Analytics.
+ *
+ * Its own module, like RegistrationInvites/store.ts, because other admin
+ * surfaces drive it: the Model Lifecycle tab (a different sidebar section) jumps
+ * straight to Model Pricing, and a discovery price flag jumps to one model.
+ * Keep it dependency-light so importing it never drags Credit Analytics into
+ * another tab's bundle.
+ */
+export const useCreditAnalysisStore = create<{
+  /**
+   * Sticky for the whole SPA session, deliberately: it used to be component state
+   * that reset to 'users' on every mount, and a cross-section jump sets it before
+   * Credit Analytics has mounted. Leaving Credit Analytics and coming back
+   * therefore reopens the last inner tab rather than 'users'.
+   */
+  activeTab: CreditAnalysisTab;
+  /**
+   * A model the operator arrived to look at. ModelPricingCatalog seeds its filter
+   * from it and clears it, so a later manual visit does not open still filtered.
+   */
+  pricingModelId: string | null;
+  setActiveTab: (tab: CreditAnalysisTab) => void;
+  /** Open Model Pricing focused on one model (a discovery price flag's jump). */
+  focusPricingModel: (modelId: string) => void;
+  clearPricingModelId: () => void;
+}>(set => ({
+  activeTab: 'users',
+  pricingModelId: null,
+  setActiveTab: tab => set({ activeTab: tab }),
+  focusPricingModel: modelId => set({ activeTab: 'pricing', pricingModelId: modelId }),
+  clearPricingModelId: () => set({ pricingModelId: null }),
+}));

--- a/apps/client/app/components/admin/DiscoveryRunDetailModal.test.tsx
+++ b/apps/client/app/components/admin/DiscoveryRunDetailModal.test.tsx
@@ -1,0 +1,413 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: (...a: unknown[]) => mockGet(...a), post: (...a: unknown[]) => mockPost(...a) },
+}));
+
+import { DiscoveryRunDetailModal } from './DiscoveryRunDetailModal';
+import { AdminTab } from './adminSidebarConfig';
+import { useAdminModal } from './useAdminModal';
+import { useCreditAnalysisStore } from './CreditAnalysis/store';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+/** The production flag that had no explanation anywhere but a log line. */
+const LUNA_FLAG = {
+  modelId: 'gpt-5.6-luna',
+  kind: 'source-disagreement',
+  proposed: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+  current: { inputPerMTok: 1, outputPerMTok: 6 },
+  sources: ['models.dev', 'litellm'],
+  detail: 'sources disagree beyond 10%: models.dev in 0.2/out 1.2 vs litellm in 1/out 6; applied neither',
+};
+
+const EMPTY_CHANGES = {
+  added: [],
+  promoted: [],
+  deprecated: [],
+  repriced: [],
+  flagged: [],
+  operatorConflicts: [],
+  plannedRows: 0,
+  appendedRows: 0,
+  plannedPriceRows: 0,
+  appendedPriceRows: 0,
+};
+
+const RUN = {
+  id: 'run-1',
+  startedAt: '2026-07-30T12:00:00.000Z',
+  finishedAt: '2026-07-30T12:03:00.000Z',
+  trigger: 'cron',
+  host: 'hosted',
+  status: 'ok',
+  mode: 'write' as 'write' | 'report' | undefined,
+  passes: 2,
+  sources: [
+    { name: 'models.dev', ok: true, durationMs: 120, httpStatus: 200, recordCount: 113 },
+    { name: 'litellm', ok: false, durationMs: 900, error: 'ETIMEDOUT' },
+  ],
+  joinCoverage: [{ aggregator: 'models.dev', matched: 84, total: 113 }],
+  changes: { ...EMPTY_CHANGES, flagged: ['gpt-5.6-luna'], plannedPriceRows: 1, appendedPriceRows: 1 },
+  priceFlags: [LUNA_FLAG],
+  priceRows: [],
+  priceSkips: [],
+  lifecycleTransitions: [],
+  catalogDiff: [],
+  detailTotals: {} as Record<string, number>,
+  unmatchedIds: [],
+  droppedRecords: [],
+};
+
+type Run = typeof RUN;
+const runWith = (over: Partial<Run>): Run => ({ ...RUN, ...over });
+
+const renderModal = (runId: string | null = 'run-1', onClose = vi.fn()) =>
+  render(
+    <TestWrapper>
+      <DiscoveryRunDetailModal runId={runId} onClose={onClose} />
+    </TestWrapper>
+  );
+
+describe('DiscoveryRunDetailModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ data: { run: RUN } });
+    useAdminModal.setState({ activeTab: AdminTab.ModelLifecycle });
+    useCreditAnalysisStore.setState({ activeTab: 'users', pricingModelId: null });
+  });
+
+  it('fetches the chosen run and leads with the price flags', async () => {
+    renderModal();
+
+    expect(await screen.findByTestId('discovery-run-price-flags-table')).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith('/api/admin/model-discovery?runId=run-1');
+    expect(screen.getByTestId('discovery-run-status-chip')).toHaveTextContent('ok');
+    expect(screen.getByTestId('discovery-run-header')).toHaveTextContent('cron on hosted');
+  });
+
+  it('renders the whole detail sentence, untruncated: it is the explanation the operator came for', async () => {
+    renderModal();
+
+    const detail = await screen.findByTestId('discovery-run-flag-detail-gpt-5.6-luna');
+    expect(detail).toHaveTextContent(
+      'sources disagree beyond 10%: models.dev in 0.2/out 1.2 vs litellm in 1/out 6; applied neither'
+    );
+  });
+
+  it('shows the proposed rates against the row in force, and names both sources', async () => {
+    renderModal();
+
+    const row = await screen.findByTestId('discovery-run-flag-row-gpt-5.6-luna');
+    expect(row).toHaveTextContent('$0.2 in / $1.2 out');
+    expect(row).toHaveTextContent('$1 in / $6 out');
+    expect(row).toHaveTextContent('models.dev, litellm');
+    expect(row).toHaveTextContent('source-disagreement');
+  });
+
+  it('renders a 404 as an error rather than a blank modal', async () => {
+    // The envelope from server/middlewares/errorHandler.ts: the reason is in
+    // `error`, and err.message is the useless axios sentence.
+    mockGet.mockRejectedValue({
+      message: 'Request failed with status code 404',
+      response: { data: { name: 'NotFoundError', error: 'Discovery run not found' } },
+    });
+    renderModal('gone');
+
+    expect(await screen.findByTestId('discovery-run-error')).toHaveTextContent('Discovery run not found');
+    expect(screen.getByTestId('discovery-run-modal')).toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-price-flags-table')).not.toBeInTheDocument();
+  });
+
+  it('shows the reason a 403 gives rather than the axios status sentence', async () => {
+    mockGet.mockRejectedValue({
+      message: 'Request failed with status code 403',
+      response: { data: { name: 'ForbiddenError', error: 'Admin access required' } },
+    });
+    renderModal('run-1');
+
+    expect(await screen.findByTestId('discovery-run-error')).toHaveTextContent('Admin access required');
+  });
+
+  it('falls back to a message-shaped body for endpoints outside that envelope', async () => {
+    mockGet.mockRejectedValue({
+      message: 'Request failed with status code 503',
+      response: { data: { message: 'Discovery is unavailable on this deployment' } },
+    });
+    renderModal('run-1');
+
+    expect(await screen.findByTestId('discovery-run-error')).toHaveTextContent(
+      'Discovery is unavailable on this deployment'
+    );
+  });
+
+  it('hides every section that has no rows', async () => {
+    mockGet.mockResolvedValue({
+      data: { run: runWith({ priceFlags: [], changes: EMPTY_CHANGES }) },
+    });
+    renderModal();
+
+    // Mechanics always renders, so the modal is never blank.
+    expect(await screen.findByTestId('discovery-run-sources-table')).toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-price-flags-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-price-rows-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-lifecycle-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-catalog-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-skips-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-operator-conflicts')).not.toBeInTheDocument();
+  });
+
+  it('calls out planned price rows that never landed, even on a run reporting ok', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({ mode: 'write', changes: { ...EMPTY_CHANGES, plannedPriceRows: 32, appendedPriceRows: 0 } }),
+      },
+    });
+    renderModal();
+
+    const warning = await screen.findByTestId('discovery-run-write-gap');
+    expect(warning).toHaveTextContent('32 price rows planned, 0 appended');
+    expect(screen.getByTestId('discovery-run-counters')).toHaveTextContent('price rows 0/32 appended');
+  });
+
+  it('says nothing about write gaps when every planned row landed', async () => {
+    renderModal();
+
+    await screen.findByTestId('discovery-run-price-flags-table');
+    expect(screen.queryByTestId('discovery-run-write-gap')).not.toBeInTheDocument();
+  });
+
+  it('reads a report-mode run as a plan that wrote nothing, not as lost writes', async () => {
+    // Report mode is the default, and it plans rows and writes none BY DESIGN.
+    // Warning here is how the warning stops meaning anything: production has runs
+    // recording 32 planned / 0 appended with status ok.
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({
+          mode: 'report',
+          changes: { ...EMPTY_CHANGES, plannedPriceRows: 32, appendedPriceRows: 0 },
+          priceRows: [
+            {
+              modelId: 'gpt-cheap',
+              unit: 'per_token',
+              inputPerMTok: 0.5,
+              outputPerMTok: 1.5,
+              effectiveFrom: '2026-07-30T12:00:00.000Z',
+              sources: ['openrouter'],
+              note: 'discovery:openrouter@2026-07-30',
+            },
+          ],
+        }),
+      },
+    });
+    renderModal();
+
+    expect(await screen.findByTestId('discovery-run-report-mode')).toHaveTextContent('wrote nothing');
+    expect(screen.queryByTestId('discovery-run-write-gap')).not.toBeInTheDocument();
+    // And the section may not claim a model was repriced on a run that wrote none.
+    const modal = screen.getByTestId('discovery-run-modal');
+    expect(modal).toHaveTextContent('Price rows planned (1)');
+    expect(modal).not.toHaveTextContent('Repriced (1)');
+  });
+
+  it('stays silent about the mode on a run document written before the field existed', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({ mode: undefined, changes: { ...EMPTY_CHANGES, plannedPriceRows: 32, appendedPriceRows: 0 } }),
+      },
+    });
+    renderModal();
+
+    await screen.findByTestId('discovery-run-price-flags-table');
+    // Neither claim can be made: an absent mode is not evidence of either one.
+    expect(screen.queryByTestId('discovery-run-report-mode')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-write-gap')).not.toBeInTheDocument();
+  });
+
+  it('says which sections are showing only the first 200 rows of a wider run', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({
+          changes: { ...EMPTY_CHANGES, flagged: ['gpt-5.6-luna'] },
+          detailTotals: { priceFlags: 260 },
+        }),
+      },
+    });
+    renderModal();
+
+    await screen.findByTestId('discovery-run-price-flags-table');
+    // 260 flagged in the header against 1 stored flag: without the marker the
+    // missing 259 could include the one price that actually moved.
+    expect(screen.getByTestId('discovery-run-modal')).toHaveTextContent('Price flags (first 1 of 260)');
+  });
+
+  it('keeps the low-signal not-repriced list collapsed until asked for', async () => {
+    mockGet.mockResolvedValue({
+      data: { run: runWith({ priceSkips: [{ modelId: 'gpt-quiet', reason: 'unchanged' }] }) },
+    });
+    renderModal();
+
+    const toggle = await screen.findByTestId('discovery-run-skips-toggle');
+    expect(screen.queryByTestId('discovery-run-skips-table')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('discovery-run-skips-table')).toHaveTextContent('gpt-quiet');
+  });
+
+  it('shows operator conflicts as their own work item, not merged into the price flags', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({
+          changes: { ...EMPTY_CHANGES, flagged: ['gpt-5.6-luna'], operatorConflicts: ['gpt-operator-owned'] },
+        }),
+      },
+    });
+    renderModal();
+
+    const conflicts = await screen.findByTestId('discovery-run-operator-conflicts');
+    expect(conflicts).toHaveTextContent('gpt-operator-owned');
+    // The flag means "an operator-owned catalog row exists", nothing about a value
+    // diverging and nothing about prices: operatorOwned in the service's
+    // CatalogDiffEntry is exactly that one fact.
+    expect(conflicts).toHaveTextContent('An operator catalog row exists');
+    expect(conflicts).not.toHaveTextContent('different value');
+    expect(screen.getByTestId('discovery-run-price-flags-table')).not.toHaveTextContent('gpt-operator-owned');
+  });
+
+  it('jumps a flagged model to Model Pricing: admin tab, pricing sub-tab and the model in focus', async () => {
+    const onClose = vi.fn();
+    renderModal('run-1', onClose);
+
+    const jump = await screen.findByTestId('discovery-run-flag-pricing-gpt-5.6-luna');
+    // A Joy Link with an onClick and no href renders an <a> with no href: not
+    // focusable, not announced, unreachable by keyboard.
+    expect(jump.tagName).toBe('BUTTON');
+
+    fireEvent.click(jump);
+
+    expect(useAdminModal.getState().activeTab).toBe(AdminTab.CreditAnalytics);
+    expect(useCreditAnalysisStore.getState().activeTab).toBe('pricing');
+    expect(useCreditAnalysisStore.getState().pricingModelId).toBe('gpt-5.6-luna');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders the lifecycle, repriced and catalog sections when the run carries them', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({
+          priceRows: [
+            {
+              modelId: 'gpt-cheap',
+              unit: 'per_token',
+              inputPerMTok: 0.5,
+              outputPerMTok: 1.5,
+              effectiveFrom: '2026-07-30T12:00:00.000Z',
+              sources: ['openrouter'],
+              note: 'discovery:openrouter@2026-07-30',
+            },
+          ],
+          lifecycleTransitions: [
+            {
+              modelId: 'gpt-sunset',
+              from: 'active',
+              to: 'deprecated',
+              signal: 'typed',
+              deprecationDate: '2026-08-01',
+              replacedBy: 'gpt-live',
+              autoApplied: false,
+            },
+          ],
+          catalogDiff: [
+            {
+              modelId: 'gpt-new',
+              kind: 'added',
+              ownedGroups: ['identity'],
+              changedKeys: ['contextWindow'],
+              lifecycleStatus: 'active',
+              promoted: false,
+              blockedBy: ['no-price'],
+              operatorOwned: false,
+            },
+          ],
+        }),
+      },
+    });
+    renderModal();
+
+    expect(await screen.findByTestId('discovery-run-price-row-gpt-cheap-0')).toHaveTextContent('$0.5');
+    const lifecycle = screen.getByTestId('discovery-run-lifecycle-row-gpt-sunset-0');
+    expect(lifecycle).toHaveTextContent('active -> deprecated');
+    expect(lifecycle).toHaveTextContent('suggestion');
+    const catalog = screen.getByTestId('discovery-run-catalog-row-gpt-new');
+    expect(catalog).toHaveTextContent('contextWindow');
+    expect(catalog).toHaveTextContent('no-price');
+  });
+
+  it('renders two passes of the same model as two rows, with distinct keys and testids', async () => {
+    // priceRows and lifecycleTransitions are plain flatMaps across convergence
+    // passes (aggregate() in runModelDiscovery.ts collapses every other array), so
+    // one modelId+unit twice in one run is legitimate.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const row = (inputPerMTok: number) => ({
+      modelId: 'gpt-twice',
+      unit: 'per_token',
+      inputPerMTok,
+      outputPerMTok: 4,
+      effectiveFrom: '2026-07-30T12:00:00.000Z',
+      sources: ['openai'],
+      note: 'discovery:openai@2026-07-30',
+    });
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({
+          priceRows: [row(1), row(2)],
+          lifecycleTransitions: [
+            { modelId: 'gpt-sunset', to: 'deprecated', signal: 'absence', autoApplied: false },
+            { modelId: 'gpt-sunset', to: 'retired', signal: 'typed', autoApplied: true },
+          ],
+        }),
+      },
+    });
+    renderModal();
+
+    expect(await screen.findByTestId('discovery-run-price-row-gpt-twice-0')).toHaveTextContent('$1');
+    expect(screen.getByTestId('discovery-run-price-row-gpt-twice-1')).toHaveTextContent('$2');
+    expect(screen.getByTestId('discovery-run-lifecycle-row-gpt-sunset-0')).toHaveTextContent('deprecated');
+    expect(screen.getByTestId('discovery-run-lifecycle-row-gpt-sunset-1')).toHaveTextContent('retired');
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('same key');
+    consoleError.mockRestore();
+  });
+
+  it('fetches nothing until a run is chosen', () => {
+    renderModal(null);
+
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('discovery-run-modal')).not.toBeInTheDocument();
+  });
+
+  it('ignores a slow response for a run the operator already navigated away from', async () => {
+    let resolveSlow: (value: unknown) => void = () => {};
+    mockGet.mockReturnValueOnce(new Promise(resolve => (resolveSlow = resolve)));
+    const { rerender } = renderModal('run-slow');
+
+    mockGet.mockResolvedValueOnce({ data: { run: runWith({ id: 'run-2', trigger: 'manual' }) } });
+    rerender(
+      <TestWrapper>
+        <DiscoveryRunDetailModal runId="run-2" onClose={vi.fn()} />
+      </TestWrapper>
+    );
+    await waitFor(() => expect(screen.getByTestId('discovery-run-header')).toHaveTextContent('manual on hosted'));
+
+    resolveSlow({ data: { run: runWith({ id: 'run-slow', trigger: 'stale' }) } });
+    await waitFor(() => expect(screen.getByTestId('discovery-run-header')).not.toHaveTextContent('stale'));
+  });
+});

--- a/apps/client/app/components/admin/DiscoveryRunDetailModal.test.tsx
+++ b/apps/client/app/components/admin/DiscoveryRunDetailModal.test.tsx
@@ -60,6 +60,13 @@ const RUN = {
   changes: { ...EMPTY_CHANGES, flagged: ['gpt-5.6-luna'], plannedPriceRows: 1, appendedPriceRows: 1 },
   priceFlags: [LUNA_FLAG],
   priceRows: [],
+  priceOverrides: [] as Array<{
+    modelId: string;
+    source: string;
+    dissenting: string[];
+    applied: { inputPerMTok: number; outputPerMTok: number };
+    detail: string;
+  }>,
   priceSkips: [],
   lifecycleTransitions: [],
   catalogDiff: [],
@@ -160,10 +167,83 @@ describe('DiscoveryRunDetailModal', () => {
     expect(await screen.findByTestId('discovery-run-sources-table')).toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-price-flags-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-price-rows-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-price-overrides-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-lifecycle-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-catalog-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-skips-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-operator-conflicts')).not.toBeInTheDocument();
+  });
+
+  it('names the mirror a provider price was written over', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({
+          priceFlags: [],
+          priceOverrides: [
+            {
+              modelId: 'gpt-5.6-luna',
+              source: 'openai',
+              dissenting: ['litellm'],
+              applied: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+              detail:
+                'openai publishes in 0.2/out 1.2 $/MTok and litellm in 1/out 6 $/MTok disagree beyond 10%; ' +
+                'the provider value wins',
+            },
+          ],
+        }),
+      },
+    });
+    renderModal();
+
+    const row = await screen.findByTestId('discovery-run-price-override-row-gpt-5.6-luna');
+    expect(row).toHaveTextContent('$0.2 in / $1.2 out');
+    expect(row).toHaveTextContent('openai');
+    expect(row).toHaveTextContent('litellm');
+    expect(screen.getByTestId('discovery-run-price-override-detail-gpt-5.6-luna')).toHaveTextContent(
+      'the provider value wins'
+    );
+    expect(screen.getByTestId('discovery-run-modal')).toHaveTextContent('Overruled a disagreeing source (1)');
+  });
+
+  it('does not claim an override was applied on a run that wrote nothing', async () => {
+    // Report mode is the fail-safe default, so this section sits directly under
+    // the "wrote nothing" banner on most runs; a past-tense title there is how
+    // that banner stops being believed. Overrides are also raised for an
+    // unchanged row, where nothing was written in either mode.
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({
+          mode: 'report',
+          priceFlags: [],
+          priceOverrides: [
+            {
+              modelId: 'gpt-5.6-luna',
+              source: 'openai',
+              dissenting: ['litellm'],
+              applied: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+              detail: 'openai publishes in 0.2/out 1.2 $/MTok and litellm in 1/out 6 $/MTok disagree beyond 10%',
+            },
+          ],
+        }),
+      },
+    });
+    renderModal();
+
+    await screen.findByTestId('discovery-run-price-overrides-table');
+    const modal = screen.getByTestId('discovery-run-modal');
+    expect(modal).toHaveTextContent('Overruled a disagreeing source (1)');
+    expect(modal).not.toHaveTextContent('Applied');
+  });
+
+  it('renders a run document written before overrides existed', async () => {
+    // Every detail array is optional on the stored document; a run from before
+    // this field must not take the whole report down.
+    const { priceOverrides: _dropped, ...older } = RUN;
+    mockGet.mockResolvedValue({ data: { run: older } });
+    renderModal();
+
+    expect(await screen.findByTestId('discovery-run-price-flags-table')).toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-price-overrides-table')).not.toBeInTheDocument();
   });
 
   it('calls out planned price rows that never landed, even on a run reporting ok', async () => {

--- a/apps/client/app/components/admin/DiscoveryRunDetailModal.tsx
+++ b/apps/client/app/components/admin/DiscoveryRunDetailModal.tsx
@@ -60,6 +60,15 @@ interface PlannedPriceRow {
   note: string;
 }
 
+/** A row written over a source that disagreed with it; the inverse of a flag. */
+interface PriceOverride {
+  modelId: string;
+  source: string;
+  dissenting: string[];
+  applied: PerMTokRates;
+  detail: string;
+}
+
 interface LifecycleTransition {
   modelId: string;
   from?: string;
@@ -91,6 +100,7 @@ interface CatalogDiffEntry {
 interface DetailTotals {
   priceFlags?: number;
   priceRows?: number;
+  priceOverrides?: number;
   priceSkips?: number;
   lifecycleTransitions?: number;
   catalogDiff?: number;
@@ -125,6 +135,8 @@ interface RunDetail {
   };
   priceFlags: PriceFlag[];
   priceRows: PlannedPriceRow[];
+  /** Optional: runs written before provider prices could overrule a mirror carry none. */
+  priceOverrides?: PriceOverride[];
   priceSkips: Array<{ modelId: string; reason: string }>;
   lifecycleTransitions: LifecycleTransition[];
   catalogDiff: CatalogDiffEntry[];
@@ -270,6 +282,8 @@ export const DiscoveryRunDetailModal: React.FC<{ runId: string | null; onClose: 
             : []),
         ]
       : [];
+
+  const overrideCount = countLabel(run?.priceOverrides?.length ?? 0, run?.detailTotals?.priceOverrides);
 
   return (
     <Modal open={!!runId} onClose={onClose}>
@@ -429,6 +443,41 @@ export const DiscoveryRunDetailModal: React.FC<{ runId: string | null; onClose: 
                           <td>{usdPerMTok(row.outputPerMTok)}</td>
                           <td>{list(row.sources)}</td>
                           <td>{row.note}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                </Section>
+              )}
+
+              {/* Called out because the interesting fact is not the price but the
+                  mirror: a source that disagreed with the provider is one that has
+                  gone stale. The title is deliberately tense-neutral - a
+                  report-mode run applied nothing, and these are raised for an
+                  unchanged row too, so any wording claiming a write would be false
+                  directly under the "wrote nothing" banner. */}
+              {(run.priceOverrides?.length ?? 0) > 0 && (
+                <Section title={`Overruled a disagreeing source (${overrideCount})`}>
+                  <Table size="sm" data-testid="discovery-run-price-overrides-table">
+                    <thead>
+                      <tr>
+                        <th style={{ width: '18%' }}>Model</th>
+                        <th style={{ width: '13%' }}>Rate $/M</th>
+                        <th style={{ width: '13%' }}>From</th>
+                        <th style={{ width: '13%' }}>Overruled</th>
+                        <th>Why</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {(run.priceOverrides ?? []).map(override => (
+                        <tr key={override.modelId} data-testid={`discovery-run-price-override-row-${override.modelId}`}>
+                          <td>{override.modelId}</td>
+                          <td>{inOut(override.applied)}</td>
+                          <td>{override.source}</td>
+                          <td>{list(override.dissenting)}</td>
+                          <td data-testid={`discovery-run-price-override-detail-${override.modelId}`}>
+                            {override.detail}
+                          </td>
                         </tr>
                       ))}
                     </tbody>

--- a/apps/client/app/components/admin/DiscoveryRunDetailModal.tsx
+++ b/apps/client/app/components/admin/DiscoveryRunDetailModal.tsx
@@ -1,0 +1,634 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Link,
+  Modal,
+  ModalClose,
+  ModalDialog,
+  Sheet,
+  Stack,
+  Table,
+  Typography,
+} from '@mui/joy';
+import type { ColorPaletteProp } from '@mui/joy/styles';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { api } from '@client/app/contexts/ApiContext';
+import { AdminTab } from './adminSidebarConfig';
+import { useAdminModal } from './useAdminModal';
+import { useCreditAnalysisStore } from './CreditAnalysis/store';
+
+/**
+ * Wire shapes of GET /api/admin/model-discovery?runId= (dates arrive as strings).
+ * Mirrors fullRun() in pages/api/admin/model-discovery.ts, which defaults every
+ * top-level array; the nested arrays come off stored subdocuments, so `list()`
+ * still tolerates a missing one.
+ */
+interface RunSource {
+  name: string;
+  ok: boolean;
+  durationMs: number;
+  httpStatus?: number;
+  recordCount?: number;
+  error?: string;
+}
+
+interface PerMTokRates {
+  inputPerMTok: number;
+  outputPerMTok: number;
+}
+
+interface PriceFlag {
+  modelId: string;
+  /** A service-owned union read as a free string; a new kind must still render. */
+  kind: string;
+  proposed: PerMTokRates;
+  current?: PerMTokRates;
+  sources: string[];
+  detail: string;
+}
+
+interface PlannedPriceRow {
+  modelId: string;
+  unit: string;
+  inputPerMTok: number;
+  outputPerMTok: number;
+  effectiveFrom: string;
+  sources: string[];
+  note: string;
+}
+
+interface LifecycleTransition {
+  modelId: string;
+  from?: string;
+  to: string;
+  signal: string;
+  deprecationDate?: string;
+  retirementDate?: string;
+  replacedBy?: string;
+  autoApplied: boolean;
+}
+
+interface CatalogDiffEntry {
+  modelId: string;
+  kind: string;
+  ownedGroups: string[];
+  changedKeys: string[];
+  lifecycleStatus: string;
+  promoted: boolean;
+  blockedBy: string[];
+  operatorOwned: boolean;
+}
+
+/**
+ * How much each capped detail array was cut from, present per array only when the
+ * runner truncated it (MAX_PERSISTED_RUN_DETAIL). The `changes.*` id arrays the
+ * sections explain are uncapped, so without these a wide run reads "260 flagged"
+ * in the header and "Price flags (200)" below it with nothing saying why.
+ */
+interface DetailTotals {
+  priceFlags?: number;
+  priceRows?: number;
+  priceSkips?: number;
+  lifecycleTransitions?: number;
+  catalogDiff?: number;
+}
+
+interface RunDetail {
+  id: string;
+  startedAt: string;
+  finishedAt?: string | null;
+  trigger: string;
+  host: string;
+  status: 'ok' | 'partial' | 'failed';
+  /**
+   * What the run was allowed to do, as it ran. Absent on runs written before the
+   * field existed, which is why nothing here infers 'write' from its absence.
+   */
+  mode?: 'report' | 'write';
+  passes: number;
+  sources: RunSource[];
+  joinCoverage: Array<{ aggregator: string; matched: number; total: number }>;
+  changes: {
+    added: string[];
+    promoted: string[];
+    deprecated: string[];
+    repriced: string[];
+    flagged: string[];
+    operatorConflicts: string[];
+    plannedRows: number;
+    appendedRows: number;
+    plannedPriceRows: number;
+    appendedPriceRows: number;
+  };
+  priceFlags: PriceFlag[];
+  priceRows: PlannedPriceRow[];
+  priceSkips: Array<{ modelId: string; reason: string }>;
+  lifecycleTransitions: LifecycleTransition[];
+  catalogDiff: CatalogDiffEntry[];
+  /** Absent per array (and, on an older run document, entirely) when nothing was cut. */
+  detailTotals?: DetailTotals;
+  unmatchedIds: string[];
+  droppedRecords: Array<{ source: string; modelId: string; reason: string }>;
+}
+
+const STATUS_COLOR: Record<RunDetail['status'], ColorPaletteProp> = {
+  ok: 'success',
+  partial: 'warning',
+  failed: 'danger',
+};
+
+/**
+ * PriceFlagKind in b4m-core/services/src/modelDiscoveryService/types.ts. A kind
+ * added there renders neutral rather than crashing, but the two guardrails an
+ * operator acts on most are coloured apart deliberately.
+ */
+const FLAG_KIND_COLOR: Record<string, ColorPaletteProp> = {
+  'band-exceeded': 'danger',
+  'source-disagreement': 'warning',
+  'single-source-untrusted': 'primary',
+  'operator-owned-divergence': 'primary',
+  'tiered-pricing-manual': 'neutral',
+};
+
+// The envelope names it 'error' (server/middlewares/errorHandler.ts); 'message'
+// stays as a fallback for endpoints that answer outside that envelope. Reading
+// only 'message' left every 403 and 500 as axios's useless
+// 'Request failed with status code 403'.
+const apiErrorMessage = (err: unknown, fallback: string) => {
+  const e = err as { response?: { data?: { error?: string; message?: string } }; message?: string };
+  return e?.response?.data?.error || e?.response?.data?.message || e?.message || fallback;
+};
+
+const formatTime = (iso: string | null | undefined) => (iso ? new Date(iso).toLocaleString() : '-');
+
+/** Rates arrive already per 1M tokens, the unit an operator reads prices in. */
+const usdPerMTok = (value: number | undefined) =>
+  value === undefined ? '-' : `$${value.toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
+
+const inOut = (rates: PerMTokRates | undefined) =>
+  rates ? `${usdPerMTok(rates.inputPerMTok)} in / ${usdPerMTok(rates.outputPerMTok)} out` : '-';
+
+/** Undefined is tolerated: a subdoc written before its path existed has no array. */
+const list = (values: string[] | undefined) => (values && values.length > 0 ? values.join(', ') : '-');
+
+/**
+ * A section's count, which may not pass a truncated slice off as the whole set:
+ * the run document caps each detail array, and the ids in `changes` do not.
+ */
+const countLabel = (shown: number, total: number | undefined) =>
+  total !== undefined && total > shown ? `first ${shown} of ${total}` : `${shown}`;
+
+/** A labelled Sheet + Table section, the idiom ModelLifecycleTab uses. */
+const Section: React.FC<{ title: string; children: React.ReactNode; sx?: object }> = ({ title, children, sx }) => (
+  <Sheet variant="outlined" sx={{ p: 1, borderRadius: 'sm', ...sx }}>
+    <Typography level="title-sm" sx={{ mb: 0.5 }}>
+      {title}
+    </Typography>
+    {children}
+  </Sheet>
+);
+
+/**
+ * One discovery run as the report behind the status card's change counts: which
+ * models were flagged and, above all, WHY - the flag detail sentence used to
+ * reach only a log line, leaving an operator a count like "34 flagged" and no
+ * way to act on it. Price flags come first because they are the work queue.
+ *
+ * Fetches on open; the run id is captured by the caller, so the status card's
+ * poll cannot swap out what is on screen. See GET /api/admin/model-discovery.
+ */
+export const DiscoveryRunDetailModal: React.FC<{ runId: string | null; onClose: () => void }> = ({
+  runId,
+  onClose,
+}) => {
+  const [run, setRun] = useState<RunDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showSkips, setShowSkips] = useState(false);
+
+  const setAdminTab = useAdminModal(state => state.setActiveTab);
+  const focusPricingModel = useCreditAnalysisStore(state => state.focusPricingModel);
+
+  const unmounted = useRef(false);
+  useEffect(() => {
+    // Reset on mount, not just set on unmount: React can remount the same
+    // instance (StrictMode does it deliberately), and a ref left true discards
+    // every post-await state write, leaving the modal spinning forever.
+    unmounted.current = false;
+    return () => {
+      unmounted.current = true;
+    };
+  }, []);
+
+  // Latest requested run; a slower earlier response must not overwrite the run
+  // currently displayed, the same guard ModelPricingCatalog's history uses.
+  const requestedRunId = useRef<string | null>(null);
+
+  useEffect(() => {
+    requestedRunId.current = runId;
+    if (!runId) return;
+    setRun(null);
+    setError(null);
+    setShowSkips(false);
+    setIsLoading(true);
+    void (async () => {
+      try {
+        const res = await api.get<{ run: RunDetail }>(`/api/admin/model-discovery?runId=${encodeURIComponent(runId)}`);
+        if (unmounted.current || requestedRunId.current !== runId) return;
+        setRun(res.data.run);
+      } catch (err) {
+        if (unmounted.current || requestedRunId.current !== runId) return;
+        setError(apiErrorMessage(err, 'Failed to load the discovery run'));
+      } finally {
+        if (!unmounted.current && requestedRunId.current === runId) setIsLoading(false);
+      }
+    })();
+  }, [runId]);
+
+  const jumpToPricing = (modelId: string) => {
+    focusPricingModel(modelId);
+    setAdminTab(AdminTab.CreditAnalytics);
+    onClose();
+  };
+
+  const changes = run?.changes;
+  // The plan is reported identically in both modes, so a write-mode run whose
+  // appends all threw looks clean everywhere except here. Write mode ONLY: report
+  // mode plans rows and writes none by design, and warning about that on every
+  // report run (the default mode) is how the warning stops meaning anything.
+  const writeGaps =
+    changes && run?.mode === 'write'
+      ? [
+          ...(changes.plannedPriceRows > changes.appendedPriceRows
+            ? [`${changes.plannedPriceRows} price rows planned, ${changes.appendedPriceRows} appended`]
+            : []),
+          ...(changes.plannedRows > changes.appendedRows
+            ? [`${changes.plannedRows} catalog rows planned, ${changes.appendedRows} appended`]
+            : []),
+        ]
+      : [];
+
+  return (
+    <Modal open={!!runId} onClose={onClose}>
+      <ModalDialog
+        sx={{ width: 'min(1100px, 96vw)', maxHeight: '90vh', overflow: 'auto' }}
+        data-testid="discovery-run-modal"
+      >
+        <ModalClose />
+        <Typography level="title-md" sx={{ pr: 4 }}>
+          Discovery run
+        </Typography>
+        <Typography level="body-xs" sx={{ fontFamily: 'monospace', color: 'neutral.500', mb: 1 }}>
+          {runId}
+        </Typography>
+
+        {error && (
+          <Alert color="danger" size="sm" sx={{ mb: 1 }} data-testid="discovery-run-error">
+            {error}
+          </Alert>
+        )}
+
+        {isLoading && !run ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+            <CircularProgress data-testid="discovery-run-loading" />
+          </Box>
+        ) : (
+          run && (
+            <Stack spacing={1.5}>
+              <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap>
+                <Chip size="sm" color={STATUS_COLOR[run.status] ?? 'neutral'} data-testid="discovery-run-status-chip">
+                  {run.status}
+                </Chip>
+                <Typography level="body-xs" data-testid="discovery-run-header">
+                  {run.trigger} on {run.host}, started {formatTime(run.startedAt)}
+                  {run.finishedAt ? `, finished ${formatTime(run.finishedAt)}` : ', still running'}
+                </Typography>
+                <Typography level="body-xs" color="neutral" data-testid="discovery-run-change-counts">
+                  {run.changes.added.length} added, {run.changes.promoted.length} promoted,{' '}
+                  {run.changes.deprecated.length} deprecated, {run.changes.repriced.length} repriced,{' '}
+                  {run.changes.flagged.length} flagged
+                </Typography>
+              </Stack>
+
+              {run.mode === 'report' && (
+                <Alert color="primary" size="sm" data-testid="discovery-run-report-mode">
+                  Report mode: this run computed the plan below and wrote nothing. Every count is what it would have
+                  changed, not what changed.
+                </Alert>
+              )}
+
+              {writeGaps.length > 0 && (
+                <Alert color="warning" size="sm" data-testid="discovery-run-write-gap">
+                  Writes were planned and did not land: {writeGaps.join('; ')}. The run still reports {run.status}.
+                </Alert>
+              )}
+
+              {run.priceFlags.length > 0 && (
+                <Section
+                  title={`Price flags (${countLabel(run.priceFlags.length, run.detailTotals?.priceFlags)}) - discovered prices this run refused to write`}
+                  sx={{ borderColor: 'warning.400', borderWidth: 2 }}
+                >
+                  <Table size="sm" data-testid="discovery-run-price-flags-table">
+                    <thead>
+                      <tr>
+                        <th style={{ width: '18%' }}>Model</th>
+                        <th style={{ width: '13%' }}>Kind</th>
+                        <th style={{ width: '13%' }}>Proposed $/M</th>
+                        <th style={{ width: '13%' }}>In force $/M</th>
+                        <th style={{ width: '11%' }}>Sources</th>
+                        <th>Why</th>
+                        <th style={{ width: '8%' }} aria-label="actions" />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {run.priceFlags.map(flag => (
+                        <tr key={`${flag.modelId}|${flag.kind}`} data-testid={`discovery-run-flag-row-${flag.modelId}`}>
+                          <td>{flag.modelId}</td>
+                          <td>
+                            <Chip size="sm" variant="soft" color={FLAG_KIND_COLOR[flag.kind] ?? 'neutral'}>
+                              {flag.kind}
+                            </Chip>
+                          </td>
+                          <td>{inOut(flag.proposed)}</td>
+                          <td>{inOut(flag.current)}</td>
+                          <td>{list(flag.sources)}</td>
+                          {/* Never truncated: this sentence is what the operator came for. */}
+                          <td data-testid={`discovery-run-flag-detail-${flag.modelId}`}>{flag.detail}</td>
+                          <td>
+                            {/* component="button": a Joy Link with an onClick and no
+                                href renders an <a> with no href, which no keyboard
+                                can reach. Same as DiscoveryStatusCard's links. */}
+                            <Link
+                              level="body-xs"
+                              component="button"
+                              startDecorator={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                              onClick={() => jumpToPricing(flag.modelId)}
+                              data-testid={`discovery-run-flag-pricing-${flag.modelId}`}
+                            >
+                              pricing
+                            </Link>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                </Section>
+              )}
+
+              {/* operatorOwned in b4m-core/services/src/modelDiscoveryService/types.ts
+                  is "an operator-owned CATALOG row exists for this model" and nothing
+                  more: not a divergence, not a value comparison, and nothing to do
+                  with prices (a price the operator owns is flagged above as
+                  operator-owned-divergence instead). */}
+              {run.changes.operatorConflicts.length > 0 && (
+                <Section
+                  title={`Operator-owned models this run planned a catalog change for (${run.changes.operatorConflicts.length})`}
+                >
+                  <Typography level="body-xs" color="neutral" data-testid="discovery-run-operator-conflicts">
+                    An operator catalog row exists for these {run.changes.operatorConflicts.length} models, so the
+                    groups it owns keep winning the merge and some of what discovery planned will not show up in the
+                    catalog: {list(run.changes.operatorConflicts)}
+                  </Typography>
+                </Section>
+              )}
+
+              {run.priceRows.length > 0 && (
+                <Section
+                  title={
+                    // Nothing was repriced on a run that wrote nothing, and an older
+                    // run carries no mode to claim either way.
+                    run.mode === 'write'
+                      ? `Repriced (${countLabel(run.priceRows.length, run.detailTotals?.priceRows)})`
+                      : `Price rows planned (${countLabel(run.priceRows.length, run.detailTotals?.priceRows)})`
+                  }
+                >
+                  <Table size="sm" data-testid="discovery-run-price-rows-table">
+                    <thead>
+                      <tr>
+                        <th>Model</th>
+                        <th>$/M in</th>
+                        <th>$/M out</th>
+                        <th>Sources</th>
+                        <th>Note</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {/* Keyed by index as well: priceRows is a plain flatMap across
+                          convergence passes (see aggregate() in runModelDiscovery.ts),
+                          so two rows for one modelId+unit are legitimate. */}
+                      {run.priceRows.map((row, index) => (
+                        <tr
+                          key={`${row.modelId}|${row.unit}|${index}`}
+                          data-testid={`discovery-run-price-row-${row.modelId}-${index}`}
+                        >
+                          <td>{row.modelId}</td>
+                          <td>{usdPerMTok(row.inputPerMTok)}</td>
+                          <td>{usdPerMTok(row.outputPerMTok)}</td>
+                          <td>{list(row.sources)}</td>
+                          <td>{row.note}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                </Section>
+              )}
+
+              {run.lifecycleTransitions.length > 0 && (
+                <Section
+                  title={`Lifecycle transitions (${countLabel(
+                    run.lifecycleTransitions.length,
+                    run.detailTotals?.lifecycleTransitions
+                  )})`}
+                >
+                  <Table size="sm" data-testid="discovery-run-lifecycle-table">
+                    <thead>
+                      <tr>
+                        <th>Model</th>
+                        <th>Change</th>
+                        <th>Signal</th>
+                        <th>Deprecation</th>
+                        <th>Retirement</th>
+                        <th>Successor</th>
+                        <th>Applied</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {/* Indexed for the same reason as the price rows: transitions are
+                          flatMapped across passes, not collapsed per model. */}
+                      {run.lifecycleTransitions.map((transition, index) => (
+                        <tr
+                          key={`${transition.modelId}|${index}`}
+                          data-testid={`discovery-run-lifecycle-row-${transition.modelId}-${index}`}
+                        >
+                          <td>{transition.modelId}</td>
+                          <td>
+                            {transition.from ?? 'none'} {'->'} {transition.to}
+                          </td>
+                          <td>{transition.signal}</td>
+                          <td>{transition.deprecationDate ?? '-'}</td>
+                          <td>{transition.retirementDate ?? '-'}</td>
+                          <td>{transition.replacedBy ?? '-'}</td>
+                          <td>
+                            <Chip size="sm" variant="soft" color={transition.autoApplied ? 'success' : 'neutral'}>
+                              {transition.autoApplied ? 'auto-applied' : 'suggestion'}
+                            </Chip>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                </Section>
+              )}
+
+              {run.catalogDiff.length > 0 && (
+                <Section
+                  title={`Catalog changes (${countLabel(run.catalogDiff.length, run.detailTotals?.catalogDiff)})`}
+                >
+                  <Table size="sm" data-testid="discovery-run-catalog-table">
+                    <thead>
+                      <tr>
+                        <th>Model</th>
+                        <th>Kind</th>
+                        <th>Changed keys</th>
+                        <th>Lifecycle</th>
+                        <th>Promoted</th>
+                        <th>Blocked by</th>
+                        <th>Operator owned</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {run.catalogDiff.map(entry => (
+                        <tr key={entry.modelId} data-testid={`discovery-run-catalog-row-${entry.modelId}`}>
+                          <td>{entry.modelId}</td>
+                          <td>{entry.kind}</td>
+                          <td>{list(entry.changedKeys)}</td>
+                          <td>{entry.lifecycleStatus}</td>
+                          <td>{entry.promoted ? 'yes' : 'no'}</td>
+                          <td>{list(entry.blockedBy)}</td>
+                          <td>{entry.operatorOwned ? 'yes' : 'no'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                </Section>
+              )}
+
+              {run.priceSkips.length > 0 && (
+                <Section title={`Not repriced (${countLabel(run.priceSkips.length, run.detailTotals?.priceSkips)})`}>
+                  <Link
+                    level="body-xs"
+                    component="button"
+                    onClick={() => setShowSkips(v => !v)}
+                    data-testid="discovery-run-skips-toggle"
+                  >
+                    {showSkips ? 'hide' : 'show'} the observations that produced neither a row nor a flag
+                  </Link>
+                  {showSkips && (
+                    <Table size="sm" data-testid="discovery-run-skips-table">
+                      <thead>
+                        <tr>
+                          <th style={{ width: '40%' }}>Model</th>
+                          <th>Reason</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {run.priceSkips.map(skip => (
+                          <tr key={`${skip.modelId}|${skip.reason}`}>
+                            <td>{skip.modelId}</td>
+                            <td>{skip.reason}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </Table>
+                  )}
+                </Section>
+              )}
+
+              <Section title="Run mechanics">
+                <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 0.5 }}>
+                  <Chip size="sm" variant="outlined" data-testid="discovery-run-passes">
+                    {run.passes} passes
+                  </Chip>
+                  {run.joinCoverage.map(coverage => (
+                    <Chip
+                      key={coverage.aggregator}
+                      size="sm"
+                      variant="outlined"
+                      data-testid={`discovery-run-coverage-${coverage.aggregator}`}
+                    >
+                      {coverage.aggregator} {coverage.matched}/{coverage.total}
+                    </Chip>
+                  ))}
+                  <Typography level="body-xs" color="neutral" data-testid="discovery-run-counters">
+                    catalog rows {run.changes.appendedRows}/{run.changes.plannedRows} appended, price rows{' '}
+                    {run.changes.appendedPriceRows}/{run.changes.plannedPriceRows} appended
+                  </Typography>
+                </Stack>
+                {run.sources.length > 0 && (
+                  <Table size="sm" data-testid="discovery-run-sources-table">
+                    <thead>
+                      <tr>
+                        <th>Source</th>
+                        <th>Ok</th>
+                        <th>ms</th>
+                        <th>HTTP</th>
+                        <th>Records</th>
+                        <th>Error</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {run.sources.map(source => (
+                        <tr key={source.name} data-testid={`discovery-run-source-row-${source.name}`}>
+                          <td>{source.name}</td>
+                          <td>
+                            <Chip size="sm" variant="soft" color={source.ok ? 'success' : 'danger'}>
+                              {source.ok ? 'ok' : 'failed'}
+                            </Chip>
+                          </td>
+                          <td>{source.durationMs}</td>
+                          <td>{source.httpStatus ?? '-'}</td>
+                          <td>{source.recordCount ?? '-'}</td>
+                          <td>{source.error ?? '-'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                )}
+                {run.unmatchedIds.length > 0 && (
+                  <Typography level="body-xs" color="neutral" sx={{ mt: 0.5 }} data-testid="discovery-run-unmatched">
+                    Unmatched by every aggregator ({run.unmatchedIds.length}): {list(run.unmatchedIds)}
+                  </Typography>
+                )}
+                {run.droppedRecords.length > 0 && (
+                  <Table size="sm" sx={{ mt: 0.5 }} data-testid="discovery-run-dropped-table">
+                    <thead>
+                      <tr>
+                        <th>Dropped record</th>
+                        <th>Source</th>
+                        <th>Reason</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {run.droppedRecords.map(dropped => (
+                        <tr key={`${dropped.source}|${dropped.modelId}|${dropped.reason}`}>
+                          <td>{dropped.modelId}</td>
+                          <td>{dropped.source}</td>
+                          <td>{dropped.reason}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                )}
+              </Section>
+            </Stack>
+          )
+        )}
+      </ModalDialog>
+    </Modal>
+  );
+};
+
+export default DiscoveryRunDetailModal;

--- a/apps/client/app/components/admin/DiscoveryStatusCard.test.tsx
+++ b/apps/client/app/components/admin/DiscoveryStatusCard.test.tsx
@@ -18,6 +18,7 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 const CRON_RUN = {
+  id: 'run-1',
   startedAt: '2026-07-26T12:00:00.000Z',
   finishedAt: '2026-07-26T12:03:00.000Z',
   trigger: 'cron',
@@ -32,8 +33,22 @@ const CRON_RUN = {
   changes: { added: 2, promoted: 1, deprecated: 0, repriced: 0, flagged: 0 },
 };
 
+type Run = typeof CRON_RUN;
+
+/** The run as the polled list carries it: counts, no per-model detail. */
+const listOf = (run: Run) => ({
+  id: run.id,
+  startedAt: run.startedAt,
+  finishedAt: run.finishedAt,
+  trigger: run.trigger,
+  host: run.host,
+  status: run.status,
+  changes: run.changes,
+});
+
 const STATUS = {
   lastRun: CRON_RUN,
+  runs: [listOf(CRON_RUN)],
   lastSuccessfulRunAt: '2026-07-26T06:00:00.000Z',
   enabled: true,
   mode: 'report',
@@ -41,9 +56,68 @@ const STATUS = {
   selfHost: false,
 };
 
-type Run = typeof CRON_RUN;
 const runLike = (over: Partial<Run>): Run => ({ ...CRON_RUN, ...over });
-const statusWith = (lastRun: Run | null, over: Partial<typeof STATUS> = {}) => ({ ...STATUS, lastRun, ...over });
+const statusWith = (lastRun: Run | null, over: Partial<typeof STATUS> = {}) => ({
+  ...STATUS,
+  lastRun,
+  // runs[0] is lastRun by construction server-side; keep the fixture honest.
+  runs: lastRun ? [listOf(lastRun)] : [],
+  ...over,
+});
+
+/** One run in full, as GET ?runId= answers it. */
+const RUN_DETAIL = {
+  id: 'run-1',
+  startedAt: CRON_RUN.startedAt,
+  finishedAt: CRON_RUN.finishedAt,
+  trigger: 'cron',
+  host: 'hosted',
+  status: 'partial',
+  passes: 1,
+  sources: [],
+  joinCoverage: [],
+  changes: {
+    added: [],
+    promoted: [],
+    deprecated: [],
+    repriced: [],
+    flagged: ['gpt-5.6-luna'],
+    operatorConflicts: [],
+    plannedRows: 0,
+    appendedRows: 0,
+    plannedPriceRows: 0,
+    appendedPriceRows: 0,
+  },
+  priceFlags: [
+    {
+      modelId: 'gpt-5.6-luna',
+      kind: 'source-disagreement',
+      proposed: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+      current: { inputPerMTok: 1, outputPerMTok: 6 },
+      sources: ['models.dev', 'litellm'],
+      detail: 'sources disagree beyond 10%; applied neither',
+    },
+  ],
+  priceRows: [],
+  priceSkips: [],
+  lifecycleTransitions: [],
+  catalogDiff: [],
+  unmatchedIds: [],
+  droppedRecords: [],
+};
+
+/**
+ * Route the two GETs this card can trigger: its own status, and the detail modal's
+ * run report (echoing back whichever run id was asked for).
+ */
+const routeGets = (status: unknown = STATUS) =>
+  mockGet.mockImplementation((url: string) =>
+    Promise.resolve(
+      url.includes('runId=')
+        ? { data: { run: { ...RUN_DETAIL, id: decodeURIComponent(url.split('runId=')[1]) } } }
+        : { data: status }
+    )
+  );
 
 const renderCard = () =>
   render(
@@ -107,6 +181,71 @@ describe('DiscoveryStatusCard', () => {
 
     expect(await screen.findByTestId('discovery-status-error')).toHaveTextContent('turned off');
     expect(screen.queryByTestId('discovery-status-notice')).not.toBeInTheDocument();
+  });
+
+  it('states the retention window, so an operator knows how far back runs go', async () => {
+    renderCard();
+
+    expect(await screen.findByTestId('discovery-status-retention')).toHaveTextContent('90 days');
+  });
+});
+
+const OLDER_RUNS = [
+  listOf(CRON_RUN),
+  listOf(
+    runLike({
+      id: 'run-0',
+      startedAt: '2026-07-26T06:00:00.000Z',
+      finishedAt: '2026-07-26T06:02:00.000Z',
+      trigger: 'manual',
+      status: 'ok',
+      changes: { added: 0, promoted: 0, deprecated: 0, repriced: 3, flagged: 34 },
+    })
+  ),
+];
+
+describe('DiscoveryStatusCard run history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeGets();
+    mockPost.mockResolvedValue({ data: { dispatched: 'lambda' } });
+  });
+
+  it('opens the last run report from the change-count sentence', async () => {
+    renderCard();
+
+    fireEvent.click(await screen.findByTestId('discovery-status-changes'));
+
+    expect(await screen.findByTestId('discovery-run-modal')).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith('/api/admin/model-discovery?runId=run-1');
+    // The counts sentence led straight to the model and the reason behind it.
+    expect(screen.getByTestId('discovery-run-flag-detail-gpt-5.6-luna')).toHaveTextContent('applied neither');
+  });
+
+  it('lists the recent runs with their trigger, status and counts, and opens a prior one', async () => {
+    routeGets({ ...STATUS, runs: OLDER_RUNS });
+    renderCard();
+
+    fireEvent.click(await screen.findByTestId('discovery-status-history-toggle'));
+
+    const list = screen.getByTestId('discovery-status-history-list');
+    expect(list).toHaveTextContent('cron');
+    const prior = screen.getByTestId('discovery-status-history-run-run-0');
+    expect(prior).toHaveTextContent('manual');
+    expect(prior).toHaveTextContent('ok');
+    expect(prior).toHaveTextContent('3 repriced, 34 flagged');
+
+    fireEvent.click(prior);
+
+    expect(await screen.findByTestId('discovery-run-modal')).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith('/api/admin/model-discovery?runId=run-0');
+  });
+
+  it('offers no history toggle when the only run is the one already on the card', async () => {
+    renderCard();
+
+    await screen.findByTestId('discovery-status-changes');
+    expect(screen.queryByTestId('discovery-status-history-toggle')).not.toBeInTheDocument();
   });
 });
 
@@ -274,6 +413,42 @@ describe('DiscoveryStatusCard run now', () => {
 
     expect(screen.getByTestId('discovery-status-error')).toHaveTextContent('Network Error');
     expect(runNowButton()).not.toHaveAttribute('disabled');
+  });
+
+  it('keeps an open run report on the run the operator chose while the card polls underneath it', async () => {
+    const newerManual = runLike({
+      id: 'run-2',
+      startedAt: '2026-07-26T12:10:00.000Z',
+      finishedAt: '2026-07-26T12:11:00.000Z',
+      trigger: 'manual',
+      status: 'ok',
+    });
+    let latest: unknown = STATUS;
+    mockGet.mockImplementation((url: string) =>
+      Promise.resolve(
+        url.includes('runId=')
+          ? { data: { run: { ...RUN_DETAIL, id: decodeURIComponent(url.split('runId=')[1]) } } }
+          : { data: latest }
+      )
+    );
+
+    renderCard();
+    await tick();
+    fireEvent.click(screen.getByTestId('discovery-status-changes'));
+    await tick();
+    expect(screen.getByTestId('discovery-run-modal')).toHaveTextContent('run-1');
+
+    fireEvent.click(runNowButton());
+    await tick();
+    latest = statusWith(newerManual);
+    await tick(POLL_INTERVAL_MS);
+    await tick(POLL_INTERVAL_MS);
+
+    // The card moved on to the newer run; the report being read did not, and the
+    // poll never re-fetched it.
+    expect(screen.getByTestId('discovery-status-notice')).toHaveTextContent('Run finished: ok.');
+    expect(screen.getByTestId('discovery-run-modal')).toHaveTextContent('run-1');
+    expect(mockGet.mock.calls.filter(([url]) => String(url).includes('runId=')).length).toBe(1);
   });
 
   it('leaves no timer behind when the tab closes mid-poll', async () => {

--- a/apps/client/app/components/admin/DiscoveryStatusCard.tsx
+++ b/apps/client/app/components/admin/DiscoveryStatusCard.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, Box, Button, Chip, CircularProgress, Link, Sheet, Stack, Tooltip, Typography } from '@mui/joy';
 import type { ColorPaletteProp } from '@mui/joy/styles';
 import { api } from '@client/app/contexts/ApiContext';
+import { DiscoveryRunDetailModal } from './DiscoveryRunDetailModal';
 
 /** Wire shapes of /api/admin/model-discovery (dates arrive as strings). */
 interface DiscoverySource {
@@ -17,19 +18,34 @@ interface DiscoveryJoinCoverage {
   total: number;
 }
 
-interface DiscoveryRunSummary {
+interface DiscoveryChangeCounts {
+  added: number;
+  promoted: number;
+  deprecated: number;
+  repriced: number;
+  flagged: number;
+}
+
+/** A run on the history list: counts only, since this response is polled. */
+interface DiscoveryRunListItem {
+  id: string;
   startedAt: string;
   finishedAt?: string | null;
   trigger: string;
   host: string;
   status: 'ok' | 'partial' | 'failed';
+  changes: DiscoveryChangeCounts;
+}
+
+interface DiscoveryRunSummary extends DiscoveryRunListItem {
   sources: DiscoverySource[];
   joinCoverage: DiscoveryJoinCoverage[];
-  changes: { added: number; promoted: number; deprecated: number; repriced: number; flagged: number };
 }
 
 interface DiscoveryStatus {
   lastRun: DiscoveryRunSummary | null;
+  /** Newest first; runs[0] is the same run as lastRun. */
+  runs: DiscoveryRunListItem[];
   lastSuccessfulRunAt: string | null;
   enabled: boolean;
   mode: string;
@@ -60,7 +76,10 @@ const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, m
 
 const formatTime = (iso: string | null | undefined) => (iso ? new Date(iso).toLocaleString() : '-');
 
-const changeSummary = (changes: DiscoveryRunSummary['changes']) => {
+/** Matches the run document's TTL in packages/database ModelDiscoveryRunModel. */
+const RUN_RETENTION_NOTE = 'Runs are kept for 90 days.';
+
+const changeSummary = (changes: DiscoveryChangeCounts) => {
   const parts = Object.entries(changes)
     .filter(([, count]) => count > 0)
     .map(([name, count]) => `${count} ${name}`);
@@ -91,6 +110,10 @@ const giveUpMessage = (sawNewRun: boolean, enabled: boolean) => {
  * polling for a run document newer than the one on screen when the button was
  * clicked. A run that never appears is usually the lease: a run already in
  * flight makes the manual trigger a deliberate no-op.
+ *
+ * The change counts and the run history are entry points into
+ * DiscoveryRunDetailModal: the counts alone ("34 flagged") name no model and no
+ * reason, and the 6h cron would otherwise erase whatever run was being read.
  */
 export const DiscoveryStatusCard: React.FC = () => {
   const [status, setStatus] = useState<DiscoveryStatus | null>(null);
@@ -99,6 +122,10 @@ export const DiscoveryStatusCard: React.FC = () => {
   const [isDispatching, setIsDispatching] = useState(false);
   const [isWaiting, setIsWaiting] = useState(false);
   const [showFailures, setShowFailures] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+  // The run being read, captured by id: a poll refreshes `status` underneath it
+  // and must never swap out the report the operator has open.
+  const [detailRunId, setDetailRunId] = useState<string | null>(null);
 
   // The poll loop outlives a fast unmount (2 minutes of it), so every state
   // write past an await is gated on this.
@@ -177,6 +204,7 @@ export const DiscoveryStatusCard: React.FC = () => {
   };
 
   const lastRun = status?.lastRun ?? null;
+  const runs = status?.runs ?? [];
   const failedSources = lastRun?.sources.filter(source => !source.ok) ?? [];
   const discoveryDisabled = status?.enabled === false;
   // One in-flight window covers dispatch plus the poll that follows it, so a
@@ -282,9 +310,21 @@ export const DiscoveryStatusCard: React.FC = () => {
                 {coverage.aggregator} {coverage.matched}/{coverage.total}
               </Chip>
             ))}
-            <Typography level="body-xs" color="neutral" data-testid="discovery-status-changes">
-              {changeSummary(lastRun.changes)}
-            </Typography>
+            {/* No id means there is no report to open, so it stays a sentence. */}
+            {lastRun.id ? (
+              <Link
+                level="body-xs"
+                component="button"
+                onClick={() => setDetailRunId(lastRun.id)}
+                data-testid="discovery-status-changes"
+              >
+                {changeSummary(lastRun.changes)}
+              </Link>
+            ) : (
+              <Typography level="body-xs" color="neutral" data-testid="discovery-status-changes">
+                {changeSummary(lastRun.changes)}
+              </Typography>
+            )}
           </Stack>
           {showFailures &&
             failedSources.map(source => (
@@ -297,15 +337,48 @@ export const DiscoveryStatusCard: React.FC = () => {
                 {source.name}: {source.error ?? 'failed'}
               </Typography>
             ))}
-          <Typography level="body-xs" color="neutral" sx={{ mt: 0.5 }}>
-            Last success: {formatTime(status?.lastSuccessfulRunAt)}
-          </Typography>
+          <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" sx={{ mt: 0.5 }}>
+            <Typography level="body-xs" color="neutral">
+              Last success: {formatTime(status?.lastSuccessfulRunAt)}
+            </Typography>
+            {runs.length > 1 && (
+              <Link
+                level="body-xs"
+                component="button"
+                onClick={() => setShowHistory(v => !v)}
+                data-testid="discovery-status-history-toggle"
+              >
+                {showHistory ? 'hide' : 'show'} run history ({runs.length})
+              </Link>
+            )}
+            <Typography level="body-xs" color="neutral" data-testid="discovery-status-retention">
+              {RUN_RETENTION_NOTE}
+            </Typography>
+          </Stack>
+          {showHistory && (
+            <Stack spacing={0.25} sx={{ mt: 0.5 }} data-testid="discovery-status-history-list">
+              {runs.map(run => (
+                <Link
+                  key={run.id}
+                  level="body-xs"
+                  component="button"
+                  onClick={() => setDetailRunId(run.id)}
+                  sx={{ display: 'block', textAlign: 'left' }}
+                  data-testid={`discovery-status-history-run-${run.id}`}
+                >
+                  {formatTime(run.startedAt)} - {run.trigger} - {run.status} - {changeSummary(run.changes)}
+                </Link>
+              ))}
+            </Stack>
+          )}
         </Box>
       ) : (
         <Typography level="body-xs" color="neutral" sx={{ mt: 1 }} data-testid="discovery-status-never-run">
           Discovery has not run yet.
         </Typography>
       )}
+
+      <DiscoveryRunDetailModal runId={detailRunId} onClose={() => setDetailRunId(null)} />
     </Sheet>
   );
 };

--- a/apps/client/app/components/admin/ModelLifecycleTab.test.tsx
+++ b/apps/client/app/components/admin/ModelLifecycleTab.test.tsx
@@ -17,6 +17,9 @@ vi.mock('./DiscoveryStatusCard', () => ({
 }));
 
 import { ModelLifecycleTab } from './ModelLifecycleTab';
+import { AdminTab } from './adminSidebarConfig';
+import { useAdminModal } from './useAdminModal';
+import { useCreditAnalysisStore } from './CreditAnalysis/store';
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -59,6 +62,8 @@ describe('ModelLifecycleTab', () => {
     vi.clearAllMocks();
     mockGet.mockResolvedValue({ data: STATUS });
     mockPost.mockResolvedValue({ data: {} });
+    useAdminModal.setState({ activeTab: AdminTab.ModelLifecycle });
+    useCreditAnalysisStore.setState({ activeTab: 'users', pricingModelId: null });
   });
 
   it('renders the queue, the horizon and the stale references from one fetch', async () => {
@@ -253,6 +258,22 @@ describe('ModelLifecycleTab', () => {
     expect(screen.getByRole('button', { name: 'Refresh model lifecycle status' })).toBe(
       screen.getByTestId('model-lifecycle-refresh-btn')
     );
+  });
+
+  it('links to Model Pricing, landing on the pricing sub-tab of another sidebar section', async () => {
+    renderTab();
+    await screen.findByTestId('model-lifecycle-queue-row-gpt-sunset');
+
+    const link = screen.getByTestId('model-lifecycle-model-pricing-link');
+    // A Joy Link with an onClick and no href renders an <a> with no href: not
+    // focusable, not announced, unreachable by keyboard.
+    expect(link.tagName).toBe('BUTTON');
+    fireEvent.click(link);
+
+    expect(useAdminModal.getState().activeTab).toBe(AdminTab.CreditAnalytics);
+    expect(useCreditAnalysisStore.getState().activeTab).toBe('pricing');
+    // The header link is not about one model, so nothing is put in focus.
+    expect(useCreditAnalysisStore.getState().pricingModelId).toBeNull();
   });
 
   it('says so when nothing is awaiting a decision', async () => {

--- a/apps/client/app/components/admin/ModelLifecycleTab.tsx
+++ b/apps/client/app/components/admin/ModelLifecycleTab.tsx
@@ -9,6 +9,7 @@ import {
   FormLabel,
   IconButton,
   Input,
+  Link,
   Modal,
   ModalDialog,
   Sheet,
@@ -19,8 +20,12 @@ import {
 } from '@mui/joy';
 import type { ColorPaletteProp } from '@mui/joy/styles';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { api } from '@client/app/contexts/ApiContext';
 import { DiscoveryStatusCard } from './DiscoveryStatusCard';
+import { AdminTab } from './adminSidebarConfig';
+import { useAdminModal } from './useAdminModal';
+import { useCreditAnalysisStore } from './CreditAnalysis/store';
 
 /** Wire shapes of /api/admin/model-deprecation-status (dates arrive as strings). */
 interface QueueItem {
@@ -144,6 +149,9 @@ export const ModelLifecycleTab: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [pendingDismissId, setPendingDismissId] = useState<string | null>(null);
 
+  const setAdminTab = useAdminModal(state => state.setActiveTab);
+  const setCreditAnalysisTab = useCreditAnalysisStore(state => state.setActiveTab);
+
   const fetchStatus = useCallback(async () => {
     setIsLoading(true);
     setError(null);
@@ -238,6 +246,23 @@ export const ModelLifecycleTab: React.FC = () => {
             Detected deprecations awaiting a verdict. Accepting appends an operator catalog row; the stale-reference
             list is a report - those chains live in code.
           </Typography>
+          {/* Prices live in a different sidebar section, so settling a flagged
+              price meant hunting for it. Already inside /admin: setting the tab
+              is the whole navigation. component="button" because a Joy Link with
+              an onClick and no href renders an <a> with no href, which is not
+              focusable and unreachable by keyboard. */}
+          <Link
+            level="body-sm"
+            component="button"
+            startDecorator={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+            onClick={() => {
+              setCreditAnalysisTab('pricing');
+              setAdminTab(AdminTab.CreditAnalytics);
+            }}
+            data-testid="model-lifecycle-model-pricing-link"
+          >
+            Model pricing catalog
+          </Link>
         </Box>
         <IconButton
           size="sm"

--- a/apps/client/app/components/admin/useAdminSidebarSections.test.ts
+++ b/apps/client/app/components/admin/useAdminSidebarSections.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { AdminTab, SIDEBAR_EXPANDED_STORAGE_KEY } from './adminSidebarConfig';
+import { useAdminSidebarSections } from './useAdminSidebarSections';
+
+/** The cross-section jump this hook exists for: aiAgents -> userOps. */
+const LIFECYCLE_SECTION = 'aiAgents';
+const PRICING_SECTION = 'userOps';
+
+const stored = () => JSON.parse(window.localStorage.getItem(SIDEBAR_EXPANDED_STORAGE_KEY) ?? 'null');
+
+describe('useAdminSidebarSections', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('opens only the active tab section when the admin has no stored preference', () => {
+    const { result } = renderHook(() => useAdminSidebarSections(AdminTab.ModelLifecycle));
+
+    expect(result.current.isExpanded(LIFECYCLE_SECTION)).toBe(true);
+    expect(result.current.isExpanded(PRICING_SECTION)).toBe(false);
+    // Nothing is written until the admin actually chooses something.
+    expect(stored()).toBeNull();
+  });
+
+  it('honours a stored collapse of the active tab section, rather than forcing it open on mount', () => {
+    window.localStorage.setItem(SIDEBAR_EXPANDED_STORAGE_KEY, JSON.stringify({ [LIFECYCLE_SECTION]: false }));
+
+    const { result } = renderHook(() => useAdminSidebarSections(AdminTab.ModelLifecycle));
+
+    expect(result.current.isExpanded(LIFECYCLE_SECTION)).toBe(false);
+  });
+
+  it('force-expands the section a cross-section jump lands in', () => {
+    window.localStorage.setItem(SIDEBAR_EXPANDED_STORAGE_KEY, JSON.stringify({ [LIFECYCLE_SECTION]: true }));
+    const { result, rerender } = renderHook(tab => useAdminSidebarSections(tab), {
+      initialProps: AdminTab.ModelLifecycle,
+    });
+    expect(result.current.isExpanded(PRICING_SECTION)).toBe(false);
+
+    rerender(AdminTab.CreditAnalytics);
+
+    expect(result.current.isExpanded(PRICING_SECTION)).toBe(true);
+  });
+
+  it('never persists a forced expansion, so the next unrelated toggle cannot make it permanent', () => {
+    window.localStorage.setItem(SIDEBAR_EXPANDED_STORAGE_KEY, JSON.stringify({ [PRICING_SECTION]: false }));
+    const { result, rerender } = renderHook(tab => useAdminSidebarSections(tab), {
+      initialProps: AdminTab.ModelLifecycle,
+    });
+
+    rerender(AdminTab.CreditAnalytics);
+    expect(result.current.isExpanded(PRICING_SECTION)).toBe(true);
+    // An unrelated section toggled after the jump used to serialize the whole map,
+    // writing the forced expansion out over the admin's own collapse choice.
+    act(() => result.current.toggleSection('docs'));
+
+    expect(stored()).toMatchObject({ [PRICING_SECTION]: false, docs: true });
+  });
+
+  it('collapses a force-expanded section on click instead of toggling hidden state', () => {
+    const { result, rerender } = renderHook(tab => useAdminSidebarSections(tab), {
+      initialProps: AdminTab.ModelLifecycle,
+    });
+    rerender(AdminTab.CreditAnalytics);
+
+    act(() => result.current.toggleSection(PRICING_SECTION));
+
+    expect(result.current.isExpanded(PRICING_SECTION)).toBe(false);
+    expect(stored()).toMatchObject({ [PRICING_SECTION]: false });
+  });
+
+  it("persists the admin's own toggle", () => {
+    const { result } = renderHook(() => useAdminSidebarSections(AdminTab.ModelLifecycle));
+
+    act(() => result.current.toggleSection(PRICING_SECTION));
+    expect(stored()).toMatchObject({ [PRICING_SECTION]: true, [LIFECYCLE_SECTION]: true });
+
+    act(() => result.current.toggleSection(LIFECYCLE_SECTION));
+    expect(stored()).toMatchObject({ [PRICING_SECTION]: true, [LIFECYCLE_SECTION]: false });
+  });
+});

--- a/apps/client/app/components/admin/useAdminSidebarSections.ts
+++ b/apps/client/app/components/admin/useAdminSidebarSections.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react';
+import { AdminTab, SIDEBAR_SECTIONS, SIDEBAR_EXPANDED_STORAGE_KEY, findSectionKeyForTab } from './adminSidebarConfig';
+
+const readStored = (): Record<string, boolean> | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = window.localStorage.getItem(SIDEBAR_EXPANDED_STORAGE_KEY);
+    return stored ? (JSON.parse(stored) as Record<string, boolean>) : null;
+  } catch {
+    // Malformed storage reads as no preference at all.
+    return null;
+  }
+};
+
+const persist = (sections: Record<string, boolean>) => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(SIDEBAR_EXPANDED_STORAGE_KEY, JSON.stringify(sections));
+  } catch {
+    // Persistence is best-effort; ignore quota/serialization failures.
+  }
+};
+
+/**
+ * Which admin sidebar sections are open: the user's own choice, persisted, plus a
+ * transient force-expand so a cross-section tab jump (Model Lifecycle in aiAgents
+ * linking to Credit Analytics in userOps) does not land on a collapsed section.
+ *
+ * The two are held in SEPARATE state on purpose. toggleSection persists the whole
+ * map, so a forced expansion folded into it would be written out by the next
+ * unrelated toggle and permanently overwrite a section the admin deliberately
+ * collapsed. The force also fires only on a tab CHANGE: on mount the stored
+ * preference is the answer, whatever tab is active.
+ */
+export function useAdminSidebarSections(activeTab: AdminTab | string | null): {
+  isExpanded: (key: string) => boolean;
+  toggleSection: (key: string) => void;
+} {
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(() => {
+    const stored = readStored();
+    if (stored) return Object.fromEntries(SIDEBAR_SECTIONS.map(s => [s.key, stored[s.key] ?? false]));
+    // No preference yet: open only the active tab's section so the sidebar opens
+    // scannable instead of fully expanded.
+    const activeKey = findSectionKeyForTab(activeTab);
+    return Object.fromEntries(SIDEBAR_SECTIONS.map(s => [s.key, s.key === activeKey]));
+  });
+
+  // Navigation, not a preference: never persisted, and at most one at a time.
+  const [forcedSection, setForcedSection] = useState<string | null>(null);
+  const lastTab = useRef(activeTab);
+
+  useEffect(() => {
+    if (activeTab === lastTab.current) return;
+    lastTab.current = activeTab;
+    setForcedSection(findSectionKeyForTab(activeTab) ?? null);
+  }, [activeTab]);
+
+  const isExpanded = (key: string) => expandedSections[key] === true || forcedSection === key;
+
+  const toggleSection = (key: string) => {
+    // Read off what is on screen, so clicking a force-expanded section collapses
+    // it (and drops the force) instead of toggling invisible state underneath it.
+    const open = isExpanded(key);
+    if (forcedSection === key) setForcedSection(null);
+    setExpandedSections(prev => {
+      const next = { ...prev, [key]: !open };
+      persist(next);
+      return next;
+    });
+  };
+
+  return { isExpanded, toggleSection };
+}

--- a/apps/client/pages/api/admin/__tests__/model-discovery.test.ts
+++ b/apps/client/pages/api/admin/__tests__/model-discovery.test.ts
@@ -107,6 +107,15 @@ const DETAILED_RUN = {
       detail: 'sources disagree beyond 10%: models.dev in 0.2/out 1.2 vs litellm in 1/out 6; applied neither',
     },
   ],
+  priceOverrides: [
+    {
+      modelId: 'gpt-5.6-terra',
+      source: 'openai',
+      dissenting: ['litellm'],
+      applied: { inputPerMTok: 2, outputPerMTok: 12 },
+      detail: 'openai publishes in 2/out 12 $/MTok and litellm in 8/out 24 $/MTok disagree beyond 10%',
+    },
+  ],
   priceSkips: [{ modelId: 'm1', reason: 'unchanged' }],
   lifecycleTransitions: [{ modelId: 'm4', from: 'active', to: 'deprecated', signal: 'absence', autoApplied: false }],
   droppedRecords: [{ source: 'litellm', modelId: 'ghost-1', reason: 'unknown backend' }],
@@ -256,6 +265,15 @@ describe('/api/admin/model-discovery', () => {
         // Absent on the document, defaulted here: the client never guards for
         // undefined.
         priceRows: [],
+        priceOverrides: [
+          {
+            modelId: 'gpt-5.6-terra',
+            source: 'openai',
+            dissenting: ['litellm'],
+            applied: { inputPerMTok: 2, outputPerMTok: 12 },
+            detail: 'openai publishes in 2/out 12 $/MTok and litellm in 8/out 24 $/MTok disagree beyond 10%',
+          },
+        ],
         priceSkips: [{ modelId: 'm1', reason: 'unchanged' }],
         lifecycleTransitions: [
           { modelId: 'm4', from: 'active', to: 'deprecated', signal: 'absence', autoApplied: false },

--- a/apps/client/pages/api/admin/__tests__/model-discovery.test.ts
+++ b/apps/client/pages/api/admin/__tests__/model-discovery.test.ts
@@ -21,9 +21,10 @@ vi.mock('@server/middlewares/baseApi', () => ({
   },
 }));
 
-const { latestRun, lastSuccessfulRun, getSettingsValue, lambdaSend, runScheduledDiscovery, resource } = vi.hoisted(
-  () => ({
-    latestRun: vi.fn(),
+const { recentRuns, runById, lastSuccessfulRun, getSettingsValue, lambdaSend, runScheduledDiscovery, resource } =
+  vi.hoisted(() => ({
+    recentRuns: vi.fn(),
+    runById: vi.fn(),
     lastSuccessfulRun: vi.fn(),
     getSettingsValue: vi.fn(),
     lambdaSend: vi.fn(async () => ({ StatusCode: 202 })),
@@ -31,11 +32,10 @@ const { latestRun, lastSuccessfulRun, getSettingsValue, lambdaSend, runScheduled
     resource: { lambdaFunctionNames: { modelDiscovery: 'dev-model-discovery-fn' } } as {
       lambdaFunctionNames?: Record<string, string | undefined>;
     },
-  })
-);
+  }));
 
 vi.mock('@bike4mind/database', () => ({
-  modelDiscoveryRunRepository: { latestRun, lastSuccessfulRun },
+  modelDiscoveryRunRepository: { recentRuns, runById, lastSuccessfulRun },
   adminSettingsRepository: { getSettingsValue },
 }));
 vi.mock('@bike4mind/observability', () => ({
@@ -82,8 +82,43 @@ const RUN = {
   updatedAt: FINISHED_AT,
 };
 
-function call(options: { method: 'GET' | 'POST'; isAdmin?: boolean }) {
-  const { req, res } = createMocks({ method: options.method });
+/** The same run as the report reads it: the detail behind every count. */
+const DETAILED_RUN = {
+  ...RUN,
+  passes: 3,
+  sources: [
+    { name: 'openai', ok: true, durationMs: 120, httpStatus: 200, recordCount: 61, etag: 'W/"abc"' },
+    { name: 'models.dev', ok: false, durationMs: 900, error: 'ETIMEDOUT', parserRows: { pricing: 30 } },
+  ],
+  changes: {
+    added: ['m1', 'm2'],
+    promoted: ['m1'],
+    flagged: ['m3', 'gpt-5.6-luna'],
+    operatorConflicts: ['m3'],
+    plannedRows: 4,
+    appendedRows: 4,
+  },
+  priceFlags: [
+    {
+      modelId: 'gpt-5.6-luna',
+      kind: 'source-disagreement',
+      proposed: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+      sources: ['models.dev', 'litellm'],
+      detail: 'sources disagree beyond 10%: models.dev in 0.2/out 1.2 vs litellm in 1/out 6; applied neither',
+    },
+  ],
+  priceSkips: [{ modelId: 'm1', reason: 'unchanged' }],
+  lifecycleTransitions: [{ modelId: 'm4', from: 'active', to: 'deprecated', signal: 'absence', autoApplied: false }],
+  droppedRecords: [{ source: 'litellm', modelId: 'ghost-1', reason: 'unknown backend' }],
+};
+
+function call(options: {
+  method: 'GET' | 'POST';
+  isAdmin?: boolean;
+  // string[] covers a repeated query parameter, which is a request the route rejects.
+  query?: Record<string, string | string[]>;
+}) {
+  const { req, res } = createMocks({ method: options.method, query: options.query });
   (req as unknown as { user: { isAdmin: boolean; id: string } }).user = {
     isAdmin: options.isAdmin ?? true,
     id: 'admin-1',
@@ -100,7 +135,8 @@ describe('/api/admin/model-discovery', () => {
     resource.lambdaFunctionNames = { modelDiscovery: 'dev-model-discovery-fn' };
     delete process.env.B4M_SELF_HOST;
     process.env.B4M_DISCOVERY_DRIVER = 'true';
-    latestRun.mockResolvedValue(RUN);
+    recentRuns.mockResolvedValue([RUN]);
+    runById.mockResolvedValue(DETAILED_RUN);
     lastSuccessfulRun.mockResolvedValue({ ...RUN, startedAt: new Date('2026-07-26T06:00:00Z'), status: 'ok' });
     getSettingsValue.mockImplementation(async (key: string) => (key === 'modelDiscoveryMode' ? 'write' : 'manual'));
   });
@@ -117,34 +153,48 @@ describe('/api/admin/model-discovery', () => {
     await expect(run()).rejects.toThrow('Admin access required');
   });
 
-  it('returns the trimmed last run, the settings and the deployment kind', async () => {
+  it('rejects a non-admin asking for one run by id', async () => {
+    const { run } = call({ method: 'GET', isAdmin: false, query: { runId: 'run-1' } });
+    await expect(run()).rejects.toThrow('Admin access required');
+    expect(runById).not.toHaveBeenCalled();
+  });
+
+  it('returns the trimmed last run, the run list, the settings and the deployment kind', async () => {
     const { run, res } = call({ method: 'GET' });
     await run();
 
+    const listed = {
+      id: 'run-1',
+      startedAt: STARTED_AT.toISOString(),
+      finishedAt: FINISHED_AT.toISOString(),
+      trigger: 'cron',
+      host: 'hosted',
+      status: 'partial',
+      changes: { added: 2, promoted: 1, deprecated: 0, repriced: 0, flagged: 0 },
+    };
     expect(res._getJSONData()).toEqual({
       lastRun: {
-        startedAt: STARTED_AT.toISOString(),
-        finishedAt: FINISHED_AT.toISOString(),
-        trigger: 'cron',
-        host: 'hosted',
-        status: 'partial',
+        ...listed,
         sources: [
           { name: 'openai', ok: true, durationMs: 120 },
           { name: 'models.dev', ok: false, durationMs: 900, error: 'ETIMEDOUT' },
         ],
         joinCoverage: [{ aggregator: 'models.dev', matched: 84, total: 113 }],
-        changes: { added: 2, promoted: 1, deprecated: 0, repriced: 0, flagged: 0 },
       },
+      // The head of the list is the run the card shows, and the id is what the
+      // client opens the report with.
+      runs: [listed],
       lastSuccessfulRunAt: '2026-07-26T06:00:00.000Z',
       enabled: true,
       mode: 'write',
       autoEnable: 'manual',
       selfHost: false,
     });
+    expect(recentRuns).toHaveBeenCalledWith(20);
   });
 
-  it('reports the setting defaults and a null run before discovery has ever run', async () => {
-    latestRun.mockResolvedValue(null);
+  it('reports the setting defaults, a null run and an empty list before discovery has ever run', async () => {
+    recentRuns.mockResolvedValue([]);
     lastSuccessfulRun.mockResolvedValue(null);
     getSettingsValue.mockResolvedValue(undefined);
 
@@ -153,11 +203,119 @@ describe('/api/admin/model-discovery', () => {
 
     expect(res._getJSONData()).toMatchObject({
       lastRun: null,
+      runs: [],
       lastSuccessfulRunAt: null,
       enabled: true,
       mode: 'report',
       autoEnable: 'priced',
     });
+  });
+
+  it('returns one run in full, with the change ids rather than their counts', async () => {
+    const { run, res } = call({ method: 'GET', query: { runId: 'run-1' } });
+    await run();
+
+    expect(runById).toHaveBeenCalledWith('run-1');
+    expect(res._getJSONData()).toEqual({
+      run: {
+        id: 'run-1',
+        startedAt: STARTED_AT.toISOString(),
+        finishedAt: FINISHED_AT.toISOString(),
+        trigger: 'cron',
+        host: 'hosted',
+        status: 'partial',
+        passes: 3,
+        // No etag, contentHash or parserRows: those belong to the run-over-run
+        // parser-shift guard, not to an operator.
+        sources: [
+          { name: 'openai', ok: true, durationMs: 120, httpStatus: 200, recordCount: 61 },
+          { name: 'models.dev', ok: false, durationMs: 900, error: 'ETIMEDOUT' },
+        ],
+        joinCoverage: [{ aggregator: 'models.dev', matched: 84, total: 113 }],
+        changes: {
+          added: ['m1', 'm2'],
+          promoted: ['m1'],
+          deprecated: [],
+          repriced: [],
+          flagged: ['m3', 'gpt-5.6-luna'],
+          operatorConflicts: ['m3'],
+          plannedRows: 4,
+          appendedRows: 4,
+          plannedPriceRows: 0,
+          appendedPriceRows: 0,
+        },
+        priceFlags: [
+          {
+            modelId: 'gpt-5.6-luna',
+            kind: 'source-disagreement',
+            proposed: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+            sources: ['models.dev', 'litellm'],
+            detail: 'sources disagree beyond 10%: models.dev in 0.2/out 1.2 vs litellm in 1/out 6; applied neither',
+          },
+        ],
+        // Absent on the document, defaulted here: the client never guards for
+        // undefined.
+        priceRows: [],
+        priceSkips: [{ modelId: 'm1', reason: 'unchanged' }],
+        lifecycleTransitions: [
+          { modelId: 'm4', from: 'active', to: 'deprecated', signal: 'absence', autoApplied: false },
+        ],
+        catalogDiff: [],
+        // Empty because this run truncated nothing; a total appears per array only
+        // when the runner cut it.
+        detailTotals: {},
+        unmatchedIds: ['a', 'b', 'c'],
+        droppedRecords: [{ source: 'litellm', modelId: 'ghost-1', reason: 'unknown backend' }],
+      },
+    });
+  });
+
+  it('reports the mode each run itself ran in, not the mode the setting holds now', async () => {
+    // The setting says 'write' (see beforeEach) while these runs ran in report
+    // mode. Reading the setting instead would tell the report that a plan nobody
+    // wrote should have landed.
+    runById.mockResolvedValue({ ...DETAILED_RUN, mode: 'report' });
+    recentRuns.mockResolvedValue([{ ...RUN, mode: 'report' }]);
+
+    const detail = call({ method: 'GET', query: { runId: 'run-1' } });
+    await detail.run();
+    expect(detail.res._getJSONData().run.mode).toBe('report');
+
+    const list = call({ method: 'GET' });
+    await list.run();
+    const listed = list.res._getJSONData();
+    expect(listed.lastRun.mode).toBe('report');
+    expect(listed.runs[0].mode).toBe('report');
+    expect(listed.mode).toBe('write');
+  });
+
+  it('passes the truncation totals through so a section can say it shows the first 200 of N', async () => {
+    runById.mockResolvedValue({ ...DETAILED_RUN, detailTotals: { priceFlags: 260, catalogDiff: 301 } });
+
+    const { run, res } = call({ method: 'GET', query: { runId: 'run-1' } });
+    await run();
+
+    expect(res._getJSONData().run.detailTotals).toEqual({ priceFlags: 260, catalogDiff: 301 });
+  });
+
+  it('answers 404 for a run id that matches nothing', async () => {
+    runById.mockResolvedValue(null);
+
+    // NotFoundError so the standard envelope answers it (name/error/request_id),
+    // which is the shape every client here already reads.
+    const { run } = call({ method: 'GET', query: { runId: 'nope' } });
+    await expect(run()).rejects.toThrow(/not found/i);
+    expect(recentRuns).not.toHaveBeenCalled();
+  });
+
+  it('rejects a repeated runId instead of quietly answering the status list', async () => {
+    // ?runId=a&runId=b arrives as an array; falling through to the list would look
+    // like a successful report fetch.
+    const { run } = call({ method: 'GET', query: { runId: ['a', 'b'] } });
+
+    await expect(run()).rejects.toThrow(/single value/i);
+    expect(runById).not.toHaveBeenCalled();
+    expect(recentRuns).not.toHaveBeenCalled();
   });
 
   it('reports the master switch as off so the card can say why nothing will run', async () => {

--- a/apps/client/pages/api/admin/__tests__/model-prices.test.ts
+++ b/apps/client/pages/api/admin/__tests__/model-prices.test.ts
@@ -35,9 +35,39 @@ vi.mock('@bike4mind/database', () => ({
   SEED_NOTE: 'adapter-seed',
 }));
 
-import handler from '../model-prices';
+import handler, {
+  MANUAL_REPRICE_BAND_ERROR_CODE,
+  MANUAL_REPRICE_MAX_FACTOR,
+  MANUAL_REPRICE_MAX_PER_TOKEN_USD,
+} from '../model-prices';
 
 const TIER = { input: 4e-6, output: 16e-6 };
+
+/** The in-force row the magnitude band compares a submitted reprice against. */
+const inForceRow = { modelId: 'gpt-x', unit: 'per_token', pricing: { '0': TIER }, note: 'invoice A' };
+
+/** grok-4.5's real production shape: a single long-context tier. */
+const grokInForce = {
+  modelId: 'grok-4.5',
+  unit: 'per_token',
+  pricing: { '200000': { input: 2e-6, output: 6e-6 } },
+  note: 'invoice B',
+};
+
+/** A tiered ladder like the four in production; dropping a rung reprices the
+ * most expensive traffic sold. */
+const ladderInForce = {
+  modelId: 'gpt-5.6-sol',
+  unit: 'per_token',
+  pricing: { '272000': { input: 1.25e-6, output: 10e-6 }, '1050000': { input: 2.5e-6, output: 15e-6 } },
+  note: 'invoice C',
+};
+
+interface GuardrailError {
+  statusCode: number;
+  message: string;
+  additionalInfo?: { code?: string; confirmToken?: string };
+}
 
 function call(options: { method: 'GET' | 'POST'; isAdmin?: boolean; query?: object; body?: object }) {
   const { req, res } = createMocks({ method: options.method, query: options.query ?? {}, body: options.body });
@@ -46,6 +76,22 @@ function call(options: { method: 'GET' | 'POST'; isAdmin?: boolean; query?: obje
     id: 'admin-1',
   };
   return { req, res, run: () => (handler as unknown as (rq: unknown, rs: unknown) => Promise<unknown>)(req, res) };
+}
+
+const post = async (body: object): Promise<GuardrailError> =>
+  (await call({ method: 'POST', body })
+    .run()
+    .catch((e: GuardrailError) => e)) as GuardrailError;
+
+/** Posts a draft expected to trip the guardrails and returns the rejection,
+ * whose confirmToken is the waiver an operator would echo back. */
+async function expectGuardrail(body: object): Promise<GuardrailError> {
+  const err = await post(body);
+  expect(err.statusCode).toBe(400);
+  expect(err.additionalInfo?.code).toBe(MANUAL_REPRICE_BAND_ERROR_CODE);
+  expect(typeof err.additionalInfo?.confirmToken).toBe('string');
+  expect(mockAppend).not.toHaveBeenCalled();
+  return err;
 }
 
 describe('GET /api/admin/model-prices', () => {
@@ -204,6 +250,297 @@ describe('POST /api/admin/model-prices', () => {
 
     await call({ method: 'POST', body: { modelId: 'gpt-x', unit: 'per_token', action: 'revert-to-seed' } }).run();
     expect(mockAppend.mock.calls[1][0].repricedBy).toBe('admin-1');
+  });
+
+  it('rejects a reprice beyond the magnitude band, naming the model, field, both values and the factor', async () => {
+    expect(MANUAL_REPRICE_MAX_FACTOR).toBe(10);
+    mockRowsInForce.mockResolvedValue([inForceRow]);
+    // A $/1M figure typed into a per-token field: 1e6 off, in force immediately.
+    const err = await expectGuardrail({
+      modelId: 'gpt-x',
+      unit: 'per_token',
+      pricing: { '0': { input: 4, output: 16 } },
+      note: 'unit slip',
+    });
+    expect(err.message).toContain('gpt-x input');
+    expect(err.message).toContain('$4 -> $4000000 per 1M tokens');
+    expect(err.message).toContain('1000000x move');
+    expect(err.message).toContain(`${MANUAL_REPRICE_MAX_FACTOR}x manual reprice band`);
+  });
+
+  it('measures the move symmetrically: a 1e6 cut is rejected the same as a 1e6 raise', async () => {
+    mockRowsInForce.mockResolvedValue([inForceRow]);
+    const err = await expectGuardrail({
+      modelId: 'gpt-x',
+      unit: 'per_token',
+      pricing: { '0': { input: 4e-12, output: 16e-6 } },
+      note: 'slip',
+    });
+    expect(err.message).toContain('1000000x move');
+  });
+
+  it('enumerates EVERY violation in one rejection, so a confirm cannot waive one the operator never saw', async () => {
+    mockRowsInForce.mockResolvedValue([grokInForce]);
+    // A deliberate 30x input raise alongside a fat-fingered output ($6000000/1M).
+    const err = await expectGuardrail({
+      modelId: 'grok-4.5',
+      unit: 'per_token',
+      pricing: { '200000': { input: 6e-5, output: 6 } },
+      note: 'negotiated input rate',
+    });
+    expect(err.message).toContain('2 changes need confirmation');
+    expect(err.message).toContain('grok-4.5 input (tier 200000): $2 -> $60 per 1M tokens is a 30x move');
+    expect(err.message).toContain('grok-4.5 output (tier 200000): $6 -> $6000000 per 1M tokens is a 1000000x move');
+  });
+
+  it('applies an over-band reprice when the body echoes the rejection confirmToken', async () => {
+    mockRowsInForce.mockResolvedValue([inForceRow]);
+    const draft = { modelId: 'gpt-x', unit: 'per_token', pricing: { '0': { input: 4, output: 16 } } };
+    const err = await expectGuardrail({ ...draft, note: 'unit slip, reviewed' });
+
+    await call({
+      method: 'POST',
+      body: { ...draft, note: 'unit slip, reviewed', confirm: err.additionalInfo?.confirmToken },
+    }).run();
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    expect(mockAppend.mock.calls[0][0]).toMatchObject({ pricing: { '0': { input: 4, output: 16 } } });
+  });
+
+  it('refuses a blanket boolean confirm: a waiver has to name the values it waives', async () => {
+    mockRowsInForce.mockResolvedValue([inForceRow]);
+    const err = await post({
+      modelId: 'gpt-x',
+      unit: 'per_token',
+      pricing: { '0': { input: 4, output: 16 } },
+      note: 'unit slip',
+      confirm: true,
+    });
+    expect(err.statusCode).toBe(400);
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('withdraws a waiver server-side once any rate changes, then honors the token reissued for the fix', async () => {
+    mockRowsInForce.mockResolvedValue([grokInForce]);
+    const rejected = await expectGuardrail({
+      modelId: 'grok-4.5',
+      unit: 'per_token',
+      pricing: { '200000': { input: 6e-5, output: 6 } },
+      note: 'negotiated input rate',
+    });
+
+    // Output typo fixed, waiver from the previous draft reused: the digest no
+    // longer matches, so the 30x input move is NOT applied unseen.
+    const fixed = { input: 6e-5, output: 6e-5 };
+    const stale = await post({
+      modelId: 'grok-4.5',
+      unit: 'per_token',
+      pricing: { '200000': fixed },
+      note: 'negotiated input rate',
+      confirm: rejected.additionalInfo?.confirmToken,
+    });
+    expect(stale.message).toContain('does not match this draft');
+    expect(stale.additionalInfo?.confirmToken).not.toBe(rejected.additionalInfo?.confirmToken);
+    expect(mockAppend).not.toHaveBeenCalled();
+
+    await call({
+      method: 'POST',
+      body: {
+        modelId: 'grok-4.5',
+        unit: 'per_token',
+        pricing: { '200000': fixed },
+        note: 'negotiated input rate',
+        confirm: stale.additionalInfo?.confirmToken,
+      },
+    }).run();
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    expect(mockAppend.mock.calls[0][0]).toMatchObject({ pricing: { '200000': fixed } });
+  });
+
+  it('compares a rate field the row in force lacks against the seed rather than skipping it', async () => {
+    mockRowsInForce.mockResolvedValue([
+      {
+        modelId: 'claude-3-5-sonnet-20241022',
+        unit: 'per_token',
+        pricing: { '200000': { input: 3e-6, output: 15e-6 } },
+      },
+    ]);
+    mockGenerateSeed.mockResolvedValue([
+      {
+        modelId: 'claude-3-5-sonnet-20241022',
+        unit: 'per_token',
+        pricing: { '200000': { input: 3e-6, output: 15e-6, cache_write: 3.75e-6 } },
+      },
+    ]);
+    const err = await expectGuardrail({
+      modelId: 'claude-3-5-sonnet-20241022',
+      unit: 'per_token',
+      // $3.75/1M typed raw into a per-token field.
+      pricing: { '200000': { input: 3e-6, output: 15e-6, cache_write: 3.75 } },
+      note: 'cache pricing',
+    });
+    expect(err.message).toContain('cache_write (tier 200000): $3.75 -> $3750000 per 1M tokens is a 1000000x move');
+  });
+
+  it('catches a rate field with no baseline in force AND none in the seed via the absolute ceiling', async () => {
+    expect(MANUAL_REPRICE_MAX_PER_TOKEN_USD).toBe(1e-2);
+    mockRowsInForce.mockResolvedValue([
+      {
+        modelId: 'claude-3-5-sonnet-20241022',
+        unit: 'per_token',
+        pricing: { '200000': { input: 3e-6, output: 15e-6 } },
+      },
+    ]);
+    mockGenerateSeed.mockResolvedValue([
+      {
+        modelId: 'claude-3-5-sonnet-20241022',
+        unit: 'per_token',
+        pricing: { '200000': { input: 3e-6, output: 15e-6 } },
+      },
+    ]);
+    const err = await expectGuardrail({
+      modelId: 'claude-3-5-sonnet-20241022',
+      unit: 'per_token',
+      pricing: { '200000': { input: 3e-6, output: 15e-6, cache_write: 3.75 } },
+      note: 'cache pricing',
+    });
+    expect(err.message).toContain('cache_write (tier 200000)');
+    expect(err.message).toContain('$3750000 per 1M tokens has no rate in force and none in the seed');
+    expect(err.message).toContain('$10000 per 1M tokens absolute ceiling');
+  });
+
+  it('catches a 1e6 slip on a model with nothing in force and nothing in the seed to compare against', async () => {
+    // Known only because a row exists; that row predates the pricing map, so no
+    // baseline exists anywhere and only the ceiling stands between it and $4/token.
+    mockRowsInForce.mockResolvedValue([{ modelId: 'legacy-model', unit: 'per_token' }]);
+    mockGenerateSeed.mockResolvedValue([]);
+    const err = await expectGuardrail({
+      modelId: 'legacy-model',
+      unit: 'per_token',
+      pricing: { '0': { input: 4, output: 16 } },
+      note: 'first priced row',
+    });
+    expect(err.message).toContain('2 changes need confirmation');
+    expect(err.message).toContain('$4000000 per 1M tokens has no rate in force and none in the seed');
+    expect(err.message).toContain('$16000000 per 1M tokens has no rate in force and none in the seed');
+  });
+
+  it('needs confirmation for a brand-new tier inside an existing row, naming the tier and the ceiling breach', async () => {
+    mockRowsInForce.mockResolvedValue([ladderInForce]);
+    const err = await expectGuardrail({
+      modelId: 'gpt-5.6-sol',
+      unit: 'per_token',
+      pricing: { ...ladderInForce.pricing, '1000': { input: 2, output: 6 } },
+      note: 'add a short-prompt tier',
+    });
+    expect(err.message).toContain('gpt-5.6-sol tier ladder: adding tier 1000');
+    expect(err.message).toContain('gpt-5.6-sol input (tier 1000)');
+    expect(err.message).toContain('absolute ceiling');
+  });
+
+  it('needs confirmation when a tier disappears from a ladder, and applies the drop with the token', async () => {
+    mockRowsInForce.mockResolvedValue([ladderInForce]);
+    const draft = {
+      modelId: 'gpt-5.6-sol',
+      unit: 'per_token',
+      pricing: { '272000': ladderInForce.pricing['272000'] },
+      note: 'consolidate tiers',
+    };
+    const err = await expectGuardrail(draft);
+    expect(err.message).toContain('gpt-5.6-sol tier ladder: dropping tier 1050000');
+
+    await call({ method: 'POST', body: { ...draft, confirm: err.additionalInfo?.confirmToken } }).run();
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    expect(Object.keys(mockAppend.mock.calls[0][0].pricing)).toEqual(['272000']);
+  });
+
+  it('rejects a leading-zero tier key: one threshold must have exactly one spelling in the map', async () => {
+    mockRowsInForce.mockResolvedValue([grokInForce]);
+    const err = await post({
+      modelId: 'grok-4.5',
+      unit: 'per_token',
+      pricing: { '0200000': { input: 2e-6, output: 6e-6 } },
+      note: 'respelled tier',
+    });
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toContain('leading zero');
+    expect(err.additionalInfo?.code).toBeUndefined();
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('matches tiers numerically, so a legacy leading-zero key in force still supplies the baseline', async () => {
+    mockRowsInForce.mockResolvedValue([
+      { modelId: 'grok-4.5', unit: 'per_token', pricing: { '0200000': { input: 2e-6, output: 6e-6 } }, note: 'legacy' },
+    ]);
+    const err = await expectGuardrail({
+      modelId: 'grok-4.5',
+      unit: 'per_token',
+      pricing: { '200000': { input: 2, output: 6e-6 } },
+      note: 'unit slip',
+    });
+    expect(err.message).toContain('$2 -> $2000000 per 1M tokens is a 1000000x move');
+    // The respelled key is the same tier, so the ladder is unchanged.
+    expect(err.message).not.toContain('tier ladder');
+  });
+
+  it('leaves a within-band reprice alone (a 5x move needs no confirm)', async () => {
+    mockRowsInForce.mockResolvedValue([inForceRow]);
+    const { run } = call({
+      method: 'POST',
+      body: {
+        modelId: 'gpt-x',
+        unit: 'per_token',
+        pricing: { '0': { input: 2e-5, output: 8e-5 } },
+        note: 'provider raised prices',
+      },
+    });
+    await run();
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+  });
+
+  it('round-trips a tier ladder through an ordinary within-band edit', async () => {
+    mockRowsInForce.mockResolvedValue([ladderInForce]);
+    const pricing = {
+      '272000': { input: 1.25e-6, output: 12e-6 },
+      '1050000': { input: 2.5e-6, output: 18e-6 },
+    };
+    await call({
+      method: 'POST',
+      body: { modelId: 'gpt-5.6-sol', unit: 'per_token', pricing, note: 'provider price page' },
+    }).run();
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    expect(mockAppend.mock.calls[0][0].pricing).toEqual(pricing);
+  });
+
+  it('still requires confirmation for a large-but-real move, and applies it with the token', async () => {
+    mockRowsInForce.mockResolvedValue([
+      { modelId: 'gpt-x', unit: 'per_token', pricing: { '0': { input: 3e-6, output: 16e-6 } }, note: 'invoice A' },
+    ]);
+    const draft = {
+      modelId: 'gpt-x',
+      unit: 'per_token',
+      // $3/1M -> $60/1M: real, but 20x, so it is shown before it settles calls.
+      pricing: { '0': { input: 6e-5, output: 16e-6 } },
+      note: 'provider raised the input rate',
+    };
+    const err = await expectGuardrail(draft);
+    expect(err.message).toContain('$3 -> $60 per 1M tokens is a 20x move');
+    expect(err.message).not.toContain('absolute ceiling');
+
+    await call({ method: 'POST', body: { ...draft, confirm: err.additionalInfo?.confirmToken } }).run();
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+    expect(mockAppend.mock.calls[0][0]).toMatchObject({ pricing: { '0': { input: 6e-5, output: 16e-6 } } });
+  });
+
+  it('honors the seed baseline when nothing is in force: a first-ever row is not a free pass', async () => {
+    mockRowsInForce.mockResolvedValue([]);
+    const err = await expectGuardrail({
+      modelId: 'gpt-x',
+      unit: 'per_token',
+      pricing: { '0': { input: 4, output: 16 } },
+      note: 'first row',
+    });
+    expect(err.message).toContain('gpt-x input (tier 0): $4 -> $4000000 per 1M tokens is a 1000000x move');
+    expect(err.message).toContain('gpt-x output (tier 0): $16 -> $16000000 per 1M tokens is a 1000000x move');
   });
 
   it('rejects revert for a model the seed does not manage', async () => {

--- a/apps/client/pages/api/admin/model-discovery.ts
+++ b/apps/client/pages/api/admin/model-discovery.ts
@@ -2,23 +2,29 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { adminSettingsRepository, modelDiscoveryRunRepository } from '@bike4mind/database';
 import type { IModelDiscoveryRun } from '@bike4mind/common';
 import { Logger } from '@bike4mind/observability';
-import { ForbiddenError } from '@server/utils/errors';
+import { BadRequestError, ForbiddenError, NotFoundError } from '@server/utils/errors';
 import { DiscoveryDispatchUnavailableError, dispatchDiscoveryRunNow } from '@server/modelDiscovery/runNow';
 
 /**
- * Discovery status card and its "Run now" (spec sec 7).
+ * Discovery status card, its run history and its "Run now" (spec sec 7).
  *
- * GET  -> the last run's outcome plus the settings that decide whether a run
- *         happens at all and what it is allowed to do, so an operator can read
- *         "did it work, and would it have written anything" off one card.
- * POST -> trigger a run on whichever driver this deployment has.
+ * GET          -> the last run's outcome plus the settings that decide whether a
+ *                 run happens at all and what it is allowed to do, so an operator
+ *                 can read "did it work, and would it have written anything" off
+ *                 one card, plus the recent runs the 6h cron would otherwise
+ *                 erase from view.
+ * GET ?runId=  -> that one run in full.
+ * POST         -> trigger a run on whichever driver this deployment has.
  *
- * The run document is trimmed here rather than in the card: the full document
+ * The listed runs are trimmed here rather than in the card: the full document
  * carries every changed model id and every unmatched id, which is a report, not
- * a status line.
+ * a status line. The runId branch is that report.
  */
 
 const logger = new Logger({ metadata: { service: 'model-discovery-admin' } });
+
+/** Runs on the list, newest first. Enough to cover several days of the 6h cron. */
+const RUN_LIST_LIMIT = 20;
 
 /** Change ids are counted, not listed - the card shows scale, the run doc has the detail. */
 const countChanges = (changes: IModelDiscoveryRun['changes']) => ({
@@ -29,12 +35,22 @@ const countChanges = (changes: IModelDiscoveryRun['changes']) => ({
   flagged: changes?.flagged?.length ?? 0,
 });
 
-const trimRun = (run: IModelDiscoveryRun) => ({
+const listRun = (run: IModelDiscoveryRun) => ({
+  id: run.id,
   startedAt: run.startedAt,
   finishedAt: run.finishedAt,
   trigger: run.trigger,
   host: run.host,
   status: run.status,
+  // The run's OWN mode, not the modelDiscoveryMode setting below: the setting can
+  // change between the run and this read, and a report-mode run's counts are a
+  // plan it deliberately did not write. Undefined on runs written before it existed.
+  mode: run.mode,
+  changes: countChanges(run.changes),
+});
+
+const trimRun = (run: IModelDiscoveryRun) => ({
+  ...listRun(run),
   sources: (run.sources ?? []).map(source => ({
     name: source.name,
     ok: source.ok,
@@ -42,23 +58,83 @@ const trimRun = (run: IModelDiscoveryRun) => ({
     ...(source.error ? { error: source.error } : {}),
   })),
   joinCoverage: run.joinCoverage ?? [],
-  changes: countChanges(run.changes),
+});
+
+/**
+ * One run as the report. Every array is defaulted so the client never guards for
+ * undefined, and the source validators (etag, contentHash, parserRows) stay off
+ * it: they are the run-over-run parser-shift guard's data, not an operator's.
+ */
+const fullRun = (run: IModelDiscoveryRun) => ({
+  id: run.id,
+  startedAt: run.startedAt,
+  finishedAt: run.finishedAt,
+  trigger: run.trigger,
+  host: run.host,
+  status: run.status,
+  mode: run.mode,
+  passes: run.passes ?? 0,
+  sources: (run.sources ?? []).map(source => ({
+    name: source.name,
+    ok: source.ok,
+    durationMs: source.durationMs,
+    ...(source.httpStatus === undefined ? {} : { httpStatus: source.httpStatus }),
+    ...(source.recordCount === undefined ? {} : { recordCount: source.recordCount }),
+    ...(source.error ? { error: source.error } : {}),
+  })),
+  joinCoverage: run.joinCoverage ?? [],
+  changes: {
+    added: run.changes?.added ?? [],
+    promoted: run.changes?.promoted ?? [],
+    deprecated: run.changes?.deprecated ?? [],
+    repriced: run.changes?.repriced ?? [],
+    flagged: run.changes?.flagged ?? [],
+    operatorConflicts: run.changes?.operatorConflicts ?? [],
+    plannedRows: run.changes?.plannedRows ?? 0,
+    appendedRows: run.changes?.appendedRows ?? 0,
+    plannedPriceRows: run.changes?.plannedPriceRows ?? 0,
+    appendedPriceRows: run.changes?.appendedPriceRows ?? 0,
+  },
+  priceFlags: run.priceFlags ?? [],
+  priceRows: run.priceRows ?? [],
+  priceSkips: run.priceSkips ?? [],
+  lifecycleTransitions: run.lifecycleTransitions ?? [],
+  catalogDiff: run.catalogDiff ?? [],
+  // Only the arrays the runner truncated carry a total; a missing one means the
+  // stored array is complete.
+  detailTotals: run.detailTotals ?? {},
+  unmatchedIds: run.unmatchedIds ?? [],
+  droppedRecords: run.droppedRecords ?? [],
 });
 
 const handler = baseApi()
   .get(async (req, res) => {
     if (!req.user?.isAdmin) throw new ForbiddenError('Admin access required');
 
-    const [lastRun, lastSuccessful, enabled, mode, autoEnable] = await Promise.all([
-      modelDiscoveryRunRepository.latestRun(),
+    const runId = req.query.runId;
+    // ?runId=a&runId=b arrives as an array: answering the status list for it would
+    // look like a successful report fetch to the caller.
+    if (Array.isArray(runId)) throw new BadRequestError('runId must be a single value');
+    if (typeof runId === 'string' && runId.length > 0) {
+      const run = await modelDiscoveryRunRepository.runById(runId);
+      if (!run) throw new NotFoundError('Discovery run not found');
+      return res.json({ run: fullRun(run) });
+    }
+
+    const [runs, lastSuccessful, enabled, mode, autoEnable] = await Promise.all([
+      modelDiscoveryRunRepository.recentRuns(RUN_LIST_LIMIT),
       modelDiscoveryRunRepository.lastSuccessfulRun(),
       adminSettingsRepository.getSettingsValue('enableModelDiscovery'),
       adminSettingsRepository.getSettingsValue('modelDiscoveryMode'),
       adminSettingsRepository.getSettingsValue('modelDiscoveryAutoEnable'),
     ]);
+    // The newest run is the head of the list by construction, so the card and the
+    // list can never disagree about what the last run was.
+    const lastRun = runs[0] ?? null;
 
     return res.json({
       lastRun: lastRun ? trimRun(lastRun) : null,
+      runs: runs.map(listRun),
       lastSuccessfulRunAt: lastSuccessful?.startedAt ?? null,
       // Same defaulting as the service's readMode: unset means on.
       enabled: enabled !== false,

--- a/apps/client/pages/api/admin/model-discovery.ts
+++ b/apps/client/pages/api/admin/model-discovery.ts
@@ -97,6 +97,7 @@ const fullRun = (run: IModelDiscoveryRun) => ({
   },
   priceFlags: run.priceFlags ?? [],
   priceRows: run.priceRows ?? [],
+  priceOverrides: run.priceOverrides ?? [],
   priceSkips: run.priceSkips ?? [],
   lifecycleTransitions: run.lifecycleTransitions ?? [],
   catalogDiff: run.catalogDiff ?? [],

--- a/apps/client/pages/api/admin/model-prices.ts
+++ b/apps/client/pages/api/admin/model-prices.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { z } from 'zod';
 import { baseApi } from '@server/middlewares/baseApi';
 import { generateModelPriceSeed, modelPriceRepository, SEED_NOTE } from '@bike4mind/database';
@@ -12,7 +13,8 @@ import { ForbiddenError, BadRequestError } from '@server/utils/errors';
  *
  * GET                       -> { rows } in force
  * GET ?history=<modelId>    -> { history } (audit trail, newest first)
- * POST { modelId, unit, pricing, note }        -> operator reprice
+ * POST { modelId, unit, pricing, note, confirm? } -> operator reprice
+ *   (confirm is the token from a prior guardrail rejection; see confirmTokenFor)
  * POST { modelId, unit, action: 'revert-to-seed' } -> hand the model back to
  *   seed management: appends the adapter literal's CURRENT rates (computed
  *   server-side) under the seed note, so boot seeding resumes versioning it.
@@ -24,7 +26,67 @@ const RepriceBody = z.object({
   // (a rate the schema does not know yet must fail loudly, not vanish with 200).
   pricing: z.record(z.string().regex(/^\d+$/, 'tier keys must be numeric token thresholds'), ModelPriceTier.strict()),
   note: z.string(),
+  /**
+   * Waiver token echoed back from a prior rejection's `confirmToken`. A string,
+   * not a boolean: a blanket "yes" would waive every violation in the draft
+   * while the operator was shown only the ones the rejection enumerated.
+   */
+  confirm: z.string().min(1).optional(),
 });
+
+/**
+ * Largest fold-change a single manual reprice may apply to a rate's baseline
+ * (the tier field in force, else the seed literal's) without an explicit
+ * confirm. This editor is the only unguarded write
+ * path into the billing catalog - discovery clamps its own moves
+ * (modelDiscoveryPriceBandPct) and boot seeding only writes adapter literals -
+ * and its failure mode is a magnitude slip: a $/1M figure typed into what is
+ * stored as a per-single-token rate is 1e6 off, settles calls at that rate
+ * immediately, and (being an operator row) is then immune to correction by
+ * either automation.
+ */
+export const MANUAL_REPRICE_MAX_FACTOR = 10;
+
+/**
+ * Absolute ceiling, in USD per SINGLE token, on any per_token rate - the layer
+ * that catches a magnitude slip with no baseline to compare against (a model
+ * with nothing in force and nothing in the seed, a tier key the row does not
+ * have yet, a rate field neither source carries).
+ * The window it sits in: the priciest real rate in the catalog is $150 per 1M
+ * ($1.5e-4 per token) and the cheapest is $0.0375 per 1M, whose 1e6 unit slip
+ * lands at $37,500 per 1M. $10,000 per 1M (1e-2 per token) is therefore ~66x
+ * above any real price yet ~3.75x below the smallest slip this endpoint can be
+ * handed, so no real reprice trips it and every $/1M-typed-as-per-token slip
+ * does. Non-token units are excluded: their rates are already per-unit human
+ * scale, with no shared ceiling to pick.
+ */
+export const MANUAL_REPRICE_MAX_PER_TOKEN_USD = 1e-2;
+
+/** Marks a guardrail rejection so the admin UI can offer a confirm affordance. */
+export const MANUAL_REPRICE_BAND_ERROR_CODE = 'manual-reprice-over-band';
+
+const TOKENS_PER_MILLION = 1_000_000;
+
+const UNIT_LABEL: Record<string, string> = {
+  per_token: 'per 1M tokens',
+  per_minute: 'per minute',
+  per_image: 'per image',
+};
+
+/** Symmetric fold-change, so a 10x raise and a 10x cut both read as 10; a move
+ * from or to zero is unbounded (no ratio exists). */
+const moveFactor = (a: number, b: number): number => {
+  if (a === b) return 1;
+  const lo = Math.min(a, b);
+  return lo <= 0 ? Infinity : Math.max(a, b) / lo;
+};
+
+/** Locale-independent, so the rejection message reads the same everywhere. */
+const readable = (value: number): string =>
+  Number.isFinite(value) ? String(Number(value.toPrecision(4))) : 'unbounded';
+
+/** Rates are quoted per 1M tokens; the other units are already per-unit. */
+const forDisplay = (unit: string, rate: number): number => (unit === 'per_token' ? rate * TOKENS_PER_MILLION : rate);
 
 /** Stable serialization for idempotency comparison (mirrors the seeder's normalizePricing). */
 function normalizePricing(pricing: Record<string, Record<string, number | undefined>>): string {
@@ -38,6 +100,50 @@ function normalizePricing(pricing: Record<string, Record<string, number | undefi
     out[key] = normalized;
   }
   return JSON.stringify(out);
+}
+
+type TierRates = Record<string, number | undefined>;
+
+/**
+ * Re-keys a tier map by the NUMERIC threshold. getTextModelCost selects a tier
+ * through Number(key), so '0200000' and '200000' are one tier at read time and
+ * must compare as one tier here - keyed by the raw string, a respelled key
+ * silently misses its own baseline.
+ */
+function byNumericThreshold(pricing: Record<string, TierRates | undefined> | undefined): Map<number, TierRates> {
+  const out = new Map<number, TierRates>();
+  for (const [key, tier] of Object.entries(pricing ?? {})) {
+    const threshold = Number(key);
+    if (!Number.isFinite(threshold) || !tier) continue;
+    out.set(threshold, tier);
+  }
+  return out;
+}
+
+/** One guardrail violation: `key` identifies the exact values shown to the
+ * operator (it is what the confirm token digests), `message` is the line the
+ * rejection enumerates. */
+interface Finding {
+  key: string;
+  message: string;
+}
+
+/**
+ * Binds a waiver to the exact draft the operator was shown. The digest covers
+ * the whole submitted map plus every finding (each carrying its baseline), so
+ * editing any rate - or the row in force moving underneath the operator -
+ * makes the token stop matching here, not merely in the client. Not a secret
+ * and not authentication (an admin can recompute it); it exists so one "apply
+ * anyway" click cannot waive a violation that was never displayed.
+ */
+function confirmTokenFor(
+  modelId: string,
+  unit: string,
+  pricing: Record<string, TierRates>,
+  findings: Finding[]
+): string {
+  const canonical = [modelId, unit, normalizePricing(pricing), ...findings.map(f => f.key).sort()].join('\n');
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 16);
 }
 
 const FAR_FUTURE = new Date('9999-01-01T00:00:00Z');
@@ -61,6 +167,11 @@ const handler = baseApi()
   .post(async (req, res) => {
     if (!req.user?.isAdmin) throw new ForbiddenError('Admin access required');
 
+    // Deliberately ahead of, and exempt from, the reprice guardrails below:
+    // the rates written here are the adapter literals computed server-side, so
+    // a client cannot smuggle a magnitude slip through this branch, and a
+    // literal that legitimately moved by more than the band must still be
+    // revertible to.
     if ((req.body as { action?: string })?.action === 'revert-to-seed') {
       const parsed = RevertBody.safeParse(req.body);
       if (!parsed.success) throw new BadRequestError(parsed.error.issues[0]?.message ?? 'invalid revert request');
@@ -103,6 +214,16 @@ const handler = baseApi()
     if (Object.keys(pricing).length === 0 || !hasNonzeroTier) {
       throw new BadRequestError('all-zero or empty pricing would settle calls free; mark the model freeToRun instead');
     }
+    // Two spellings of one threshold ('0200000' and '200000') are one tier at
+    // read time (Number()) but two independent keys in the stored map: the
+    // respelled one dodges its baseline here and then shadows the real tier.
+    const leadingZeroTier = Object.keys(pricing).find(key => key.length > 1 && key.startsWith('0'));
+    if (leadingZeroTier) {
+      throw new BadRequestError(
+        `tier key '${leadingZeroTier}' has a leading zero; write the threshold as '${Number(leadingZeroTier)}' ` +
+          'so one threshold has exactly one spelling in the map'
+      );
+    }
 
     // Only models the catalog already knows (seeded or previously priced) can
     // be repriced: a typoed modelId must not mint a phantom in-force row.
@@ -110,9 +231,8 @@ const handler = baseApi()
       generateModelPriceSeed(),
       modelPriceRepository.rowsInForce(FAR_FUTURE),
     ]);
-    const knownModel =
-      seedEntries.some(e => e.modelId === modelId && e.unit === unit) ||
-      newestRows.some(r => r.modelId === modelId && r.unit === unit);
+    const seedEntry = seedEntries.find(e => e.modelId === modelId && e.unit === unit);
+    const knownModel = seedEntry !== undefined || newestRows.some(r => r.modelId === modelId && r.unit === unit);
     if (!knownModel) {
       throw new BadRequestError(`unknown model ${modelId} (${unit}): reprice targets an existing catalog model`);
     }
@@ -123,6 +243,102 @@ const handler = baseApi()
     const newest = newestRows.find(r => r.modelId === modelId && r.unit === unit);
     if (newest && newest.note === note && normalizePricing(newest.pricing) === normalizePricing(pricing)) {
       return res.json({ row: newest });
+    }
+
+    // Write guardrails. Three layers, because this is the only unguarded
+    // operator write into the billing catalog and its rows are immune to
+    // correction by discovery or by boot seeding:
+    //   1. magnitude band against a baseline rate - the tier field in force,
+    //      else the same model+unit's seed (adapter literal) tier field, so a
+    //      field or a row that has never been priced still has a comparison;
+    //   2. an absolute per-token ceiling, for a rate with no baseline anywhere;
+    //   3. tier-ladder equality, since tierForTokens re-settles traffic onto a
+    //      neighboring threshold when a tier appears or disappears.
+    // Every layer reports rather than throws, so ONE rejection enumerates ALL
+    // violations and the confirm token can cover exactly what was enumerated.
+    // Tier maps are keyed numerically on both sides (see byNumericThreshold).
+    // Tolerates a row that predates the pricing map rather than 500ing on it.
+    const inForceTiers = byNumericThreshold(newest?.pricing);
+    const seedTiers = byNumericThreshold(seedEntry?.pricing);
+    const submittedTiers = byNumericThreshold(pricing);
+    const findings: Finding[] = [];
+
+    const baselineLadder = inForceTiers.size > 0 ? inForceTiers : seedTiers;
+    if (baselineLadder.size > 0) {
+      const added = [...submittedTiers.keys()].filter(t => !baselineLadder.has(t)).sort((a, b) => a - b);
+      const dropped = [...baselineLadder.keys()].filter(t => !submittedTiers.has(t)).sort((a, b) => a - b);
+      if (added.length > 0 || dropped.length > 0) {
+        const parts = [
+          added.length > 0 ? `adding tier ${added.join(', ')}` : '',
+          dropped.length > 0 ? `dropping tier ${dropped.join(', ')}` : '',
+        ].filter(Boolean);
+        findings.push({
+          key: `ladder|${added.join(',')}|${dropped.join(',')}`,
+          message:
+            `${modelId} tier ladder: ${parts.join(' and ')} - a prompt settles on the nearest remaining ` +
+            'threshold, so traffic no rate in this draft touched gets repriced',
+        });
+      }
+    }
+
+    const ceilingLabel = `$${readable(forDisplay('per_token', MANUAL_REPRICE_MAX_PER_TOKEN_USD))} ${UNIT_LABEL.per_token}`;
+    for (const [threshold, tier] of [...submittedTiers.entries()].sort((a, b) => a[0] - b[0])) {
+      for (const field of Object.keys(tier).sort()) {
+        const value = tier[field];
+        if (typeof value !== 'number') continue;
+        const baseline = inForceTiers.get(threshold)?.[field] ?? seedTiers.get(threshold)?.[field];
+        const reasons: string[] = [];
+        const keys: string[] = [];
+
+        if (typeof baseline === 'number') {
+          const factor = moveFactor(baseline, value);
+          if (factor > MANUAL_REPRICE_MAX_FACTOR) {
+            const move = Number.isFinite(factor)
+              ? `is a ${readable(factor)}x move`
+              : 'is an unbounded move (a zero rate has no ratio)';
+            reasons.push(
+              `$${readable(forDisplay(unit, baseline))} -> $${readable(forDisplay(unit, value))} ` +
+                `${UNIT_LABEL[unit] ?? unit} ${move}, beyond the ${MANUAL_REPRICE_MAX_FACTOR}x manual reprice band`
+            );
+            keys.push(`band|${threshold}|${field}|${baseline}|${value}`);
+          }
+        }
+
+        if (unit === 'per_token' && value > MANUAL_REPRICE_MAX_PER_TOKEN_USD) {
+          reasons.push(
+            typeof baseline === 'number'
+              ? `it exceeds the ${ceilingLabel} absolute ceiling`
+              : `$${readable(forDisplay(unit, value))} ${UNIT_LABEL[unit] ?? unit} has no rate in force and none in ` +
+                  `the seed to compare against, and exceeds the ${ceilingLabel} absolute ceiling`
+          );
+          keys.push(`ceiling|${threshold}|${field}|${value}`);
+        }
+
+        if (reasons.length === 0) continue;
+        findings.push({
+          key: keys.join('+'),
+          message: `${modelId} ${field} (tier ${threshold}): ${reasons.join(', and ')}`,
+        });
+      }
+    }
+
+    if (findings.length > 0) {
+      const confirmToken = confirmTokenFor(modelId, unit, pricing, findings);
+      if (parsed.data.confirm !== confirmToken) {
+        const stale = parsed.data.confirm !== undefined;
+        const lines = findings.map(f => `- ${f.message}`).join('\n');
+        throw new BadRequestError(
+          (stale
+            ? 'the confirm token does not match this draft (a rate here, or the row in force, changed since the ' +
+              'token was issued), so nothing was applied. '
+            : '') +
+            `${modelId} (${unit}): ${findings.length === 1 ? '1 change needs' : `${findings.length} changes need`} ` +
+            `confirmation before it can settle calls:\n${lines}\n` +
+            'review every line, then resubmit with confirm set to the confirmToken in this response to apply ' +
+            'exactly these values.',
+          { code: MANUAL_REPRICE_BAND_ERROR_CODE, confirmToken }
+        );
+      }
     }
 
     const row = await modelPriceRepository.append({

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -3611,7 +3611,7 @@ export const settingsMap = {
     name: 'Model Discovery Price Band (%)',
     defaultValue: 50,
     description:
-      'The largest price move discovery applies without a human, in either direction, measured against the rate in the row it would supersede - so 200 passes anything up to a 3x change. A bigger move is flagged with both sources shown and the existing price keeps billing. 0 flags every move.',
+      'The largest price move discovery applies without a human, measured as the ratio between the new rate and the rate in the row it would supersede - so 200 passes anything up to a 3x change, and 500, the highest this accepts, passes up to 6x. Both read the same in either direction: a 3x cut is the same 200% as a 3x rise. A bigger move is flagged with both sources shown and the existing price keeps billing. 0 flags every move.',
     min: 0,
     max: 500,
     category: 'AI',

--- a/b4m-core/common/src/types/entities/ModelCatalogTypes.ts
+++ b/b4m-core/common/src/types/entities/ModelCatalogTypes.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { ModelBackend, ModelInfo } from '../../models';
 import { IBaseRepository } from './BaseTypes';
 import { IMongoDocument } from './common';
+import { MODEL_PRICE_UNITS } from './ModelPriceTypes';
 
 /**
  * Stamped on every ModelCatalog append. Bump ONLY when the record shape grows,
@@ -585,10 +586,14 @@ export const DISCOVERY_RUN_TRIGGERS = ['cron', 'startup', 'manual'] as const;
 export const DISCOVERY_RUN_HOSTS = ['hosted', 'selfhost'] as const;
 /** 'partial' commits what it verified and does not advance lastSuccessfulRun. */
 export const DISCOVERY_RUN_STATUSES = ['ok', 'partial', 'failed'] as const;
+/** 'report' computes the whole plan and writes nothing but the run document. */
+export const DISCOVERY_RUN_MODES = ['report', 'write'] as const;
 
 export type DiscoveryRunTrigger = (typeof DISCOVERY_RUN_TRIGGERS)[number];
 export type DiscoveryRunHost = (typeof DISCOVERY_RUN_HOSTS)[number];
 export type DiscoveryRunStatus = (typeof DISCOVERY_RUN_STATUSES)[number];
+/** DiscoveryMode in b4m-core/services/src/modelDiscoveryService/types.ts aliases this. */
+export type DiscoveryRunMode = (typeof DISCOVERY_RUN_MODES)[number];
 
 export const DiscoverySourceReport = z.object({
   name: z.string().min(1),
@@ -628,6 +633,13 @@ export const DiscoveryRunChanges = z.object({
   repriced: z.array(z.string()).optional(),
   flagged: z.array(z.string()).optional(),
   /**
+   * The operator overlaps `flagged` merges in with the price flags. Kept apart
+   * because the two want different verdicts from the operator, and `flagged`
+   * itself may not change shape: the status card counts it and every run already
+   * persisted holds the merged array.
+   */
+  operatorConflicts: z.array(z.string()).optional(),
+  /**
    * Rows the run PLANNED against rows that actually landed. Everything above is
    * the plan, deliberately, so report and write mode report identically - which
    * leaves a write-mode run whose appends all threw indistinguishable from a
@@ -646,10 +658,105 @@ export const DiscoveryDroppedRecord = z.object({
   reason: z.string(),
 });
 
+/**
+ * The five blocks below are the per-model detail behind the counts in
+ * DiscoveryRunChanges, and MUST STAY IN SYNC with the service shapes the runner
+ * persists verbatim: PriceFlag, PlannedPriceRow, PriceSkip, LifecycleTransition
+ * and CatalogDiffEntry in
+ * b4m-core/services/src/modelDiscoveryService/types.ts.
+ *
+ * Every union the SERVICE owns is read here as a free string (`kind`, `reason`,
+ * `signal`, `blockedBy`). Adding a value there is normal, and a stored run that
+ * stopped parsing over one would take the whole report down with it - the same
+ * read-compat rule the catalog rows above follow.
+ */
+const PerMTokRates = z.object({ inputPerMTok: z.number(), outputPerMTok: z.number() });
+
+export const DiscoveryPriceFlag = z.object({
+  modelId: z.string().min(1),
+  kind: z.string(),
+  /** Per-MTok, the readable unit; the row it would have written is per token. */
+  proposed: PerMTokRates,
+  /** The row in force, when there was one. */
+  current: PerMTokRates.optional(),
+  /** Every source that priced this model, so a disagreement names both sides. */
+  sources: z.array(z.string()),
+  /**
+   * The sentence that explains the flag, and the whole reason the flags are
+   * persisted: it used to reach only logger.warn, leaving the admin card with a
+   * flag count and nowhere to learn what it stood for.
+   */
+  detail: z.string(),
+});
+
+export const DiscoveryPlannedPriceRow = z.object({
+  modelId: z.string().min(1),
+  unit: z.enum(MODEL_PRICE_UNITS),
+  inputPerMTok: z.number(),
+  outputPerMTok: z.number(),
+  effectiveFrom: z.date(),
+  /** The sources whose observations produced the value. */
+  sources: z.array(z.string()),
+  note: z.string(),
+});
+
+/** A usable observation that produced neither a row nor a flag, and why. */
+export const DiscoveryPriceSkip = z.object({
+  modelId: z.string().min(1),
+  reason: z.string(),
+});
+
+export const DiscoveryLifecycleTransition = z.object({
+  modelId: z.string().min(1),
+  /** Absent when no row in force carried a lifecycle for this model. */
+  from: z.string().optional(),
+  to: z.string(),
+  signal: z.string(),
+  deprecationDate: z.string().optional(),
+  retirementDate: z.string().optional(),
+  /** Present only when auto-remap applied it; otherwise the successor is a suggestion. */
+  replacedBy: z.string().optional(),
+  autoApplied: z.boolean(),
+});
+
+export const DiscoveryCatalogDiffEntry = z.object({
+  modelId: z.string().min(1),
+  /** 'added' is a model with no catalog row at all; 'updated' is a changed merged view. */
+  kind: z.string(),
+  ownedGroups: z.array(z.string()),
+  changedKeys: z.array(z.string()),
+  lifecycleStatus: z.string(),
+  promoted: z.boolean(),
+  /** Promotion denials, one per failed clause; empty on a promoted model. */
+  blockedBy: z.array(z.string()),
+  operatorOwned: z.boolean(),
+});
+
+/**
+ * Totals behind the capped detail arrays (MAX_PERSISTED_RUN_DETAIL in the
+ * runner). Written only when a slice was actually truncated, so a reader can say
+ * "the first 200 of 260" instead of passing the cap off as the whole set: the
+ * `changes.*` id arrays these explain are NOT capped, so a wide run otherwise
+ * reports 260 flagged in the header and 200 in the section with no marker.
+ */
+export const DiscoveryRunDetailTotals = z.object({
+  priceFlags: z.number().int().nonnegative().optional(),
+  priceRows: z.number().int().nonnegative().optional(),
+  priceSkips: z.number().int().nonnegative().optional(),
+  lifecycleTransitions: z.number().int().nonnegative().optional(),
+  catalogDiff: z.number().int().nonnegative().optional(),
+});
+
 export type IDiscoverySourceReport = z.infer<typeof DiscoverySourceReport>;
 export type IDiscoveryJoinCoverage = z.infer<typeof DiscoveryJoinCoverage>;
 export type IDiscoveryRunChanges = z.infer<typeof DiscoveryRunChanges>;
 export type IDiscoveryDroppedRecord = z.infer<typeof DiscoveryDroppedRecord>;
+export type IDiscoveryPriceFlag = z.infer<typeof DiscoveryPriceFlag>;
+export type IDiscoveryPlannedPriceRow = z.infer<typeof DiscoveryPlannedPriceRow>;
+export type IDiscoveryPriceSkip = z.infer<typeof DiscoveryPriceSkip>;
+export type IDiscoveryLifecycleTransition = z.infer<typeof DiscoveryLifecycleTransition>;
+export type IDiscoveryCatalogDiffEntry = z.infer<typeof DiscoveryCatalogDiffEntry>;
+export type IDiscoveryRunDetailTotals = z.infer<typeof DiscoveryRunDetailTotals>;
 
 export const ModelDiscoveryRun = z.object({
   id: z.string().optional(),
@@ -658,6 +765,15 @@ export const ModelDiscoveryRun = z.object({
   trigger: z.enum(DISCOVERY_RUN_TRIGGERS),
   host: z.enum(DISCOVERY_RUN_HOSTS),
   status: z.enum(DISCOVERY_RUN_STATUSES),
+  /**
+   * What this run was allowed to do, recorded as it ran. A reader may NOT
+   * substitute the modelDiscoveryMode setting for it: the setting can change
+   * between the run and the read, and a 'report' run plans writes and lands none
+   * BY DESIGN - without this, that is indistinguishable from a write run whose
+   * appends all threw, which is the case the plan-vs-appended counters exist for.
+   * Optional: runs written before it existed carry none.
+   */
+  mode: z.enum(DISCOVERY_RUN_MODES).optional(),
   sources: z.array(DiscoverySourceReport).optional(),
   joinCoverage: z.array(DiscoveryJoinCoverage).optional(),
   /** Ids no aggregator matched: a work item, not a log line. */
@@ -667,6 +783,19 @@ export const ModelDiscoveryRun = z.object({
   passes: z.number().int().nonnegative().optional(),
   /** Bounded: the whole point is a trace, and a pathological run can drop thousands. */
   droppedRecords: z.array(DiscoveryDroppedRecord).optional(),
+  /**
+   * The run's own detail, bounded the same way droppedRecords is (see
+   * MAX_PERSISTED_RUN_DETAIL). Optional throughout: every run written before
+   * these existed has to keep parsing, and a run that never reached its final
+   * update has none of them.
+   */
+  priceFlags: DiscoveryPriceFlag.array().optional(),
+  priceRows: DiscoveryPlannedPriceRow.array().optional(),
+  priceSkips: DiscoveryPriceSkip.array().optional(),
+  lifecycleTransitions: DiscoveryLifecycleTransition.array().optional(),
+  catalogDiff: DiscoveryCatalogDiffEntry.array().optional(),
+  /** Present only when one of the arrays above was truncated. */
+  detailTotals: DiscoveryRunDetailTotals.optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
@@ -688,4 +817,16 @@ export interface IModelDiscoveryRunRepository extends IBaseRepository<IModelDisc
    * is the exact condition for the "FALLBACK SEED" catalog banner.
    */
   lastSuccessfulRun(host?: DiscoveryRunHost): Promise<IModelDiscoveryRun | null>;
+
+  /**
+   * Newest runs first, for the admin run list. Without it the 6h cron erases
+   * whatever the operator was reading, since only the newest run is reachable.
+   *
+   * A LIST view: the implementation projects the per-model detail arrays out, so
+   * read a run's detail with runById rather than from here.
+   */
+  recentRuns(limit: number, host?: DiscoveryRunHost): Promise<IModelDiscoveryRun[]>;
+
+  /** One run in full (the report). Null for an unknown or malformed id. */
+  runById(id: string): Promise<IModelDiscoveryRun | null>;
 }

--- a/b4m-core/common/src/types/entities/ModelCatalogTypes.ts
+++ b/b4m-core/common/src/types/entities/ModelCatalogTypes.ts
@@ -659,10 +659,10 @@ export const DiscoveryDroppedRecord = z.object({
 });
 
 /**
- * The five blocks below are the per-model detail behind the counts in
+ * The six blocks below are the per-model detail behind the counts in
  * DiscoveryRunChanges, and MUST STAY IN SYNC with the service shapes the runner
- * persists verbatim: PriceFlag, PlannedPriceRow, PriceSkip, LifecycleTransition
- * and CatalogDiffEntry in
+ * persists verbatim: PriceFlag, PlannedPriceRow, PriceOverride, PriceSkip,
+ * LifecycleTransition and CatalogDiffEntry in
  * b4m-core/services/src/modelDiscoveryService/types.ts.
  *
  * Every union the SERVICE owns is read here as a free string (`kind`, `reason`,
@@ -698,6 +698,22 @@ export const DiscoveryPlannedPriceRow = z.object({
   /** The sources whose observations produced the value. */
   sources: z.array(z.string()),
   note: z.string(),
+});
+
+/**
+ * A row written over a source that disagreed with it, which only a provider's own
+ * published price can do. The inverse of a flag: that is a value discovery
+ * declined to apply, this is one it applied anyway, and the dissenting source is
+ * the operator's cue that a mirror has gone stale.
+ */
+export const DiscoveryPriceOverride = z.object({
+  modelId: z.string().min(1),
+  /** The provider source whose value was written. */
+  source: z.string(),
+  /** Sources that disagreed with it and were not applied. */
+  dissenting: z.array(z.string()),
+  applied: PerMTokRates,
+  detail: z.string(),
 });
 
 /** A usable observation that produced neither a row nor a flag, and why. */
@@ -742,6 +758,7 @@ export const DiscoveryCatalogDiffEntry = z.object({
 export const DiscoveryRunDetailTotals = z.object({
   priceFlags: z.number().int().nonnegative().optional(),
   priceRows: z.number().int().nonnegative().optional(),
+  priceOverrides: z.number().int().nonnegative().optional(),
   priceSkips: z.number().int().nonnegative().optional(),
   lifecycleTransitions: z.number().int().nonnegative().optional(),
   catalogDiff: z.number().int().nonnegative().optional(),
@@ -753,6 +770,7 @@ export type IDiscoveryRunChanges = z.infer<typeof DiscoveryRunChanges>;
 export type IDiscoveryDroppedRecord = z.infer<typeof DiscoveryDroppedRecord>;
 export type IDiscoveryPriceFlag = z.infer<typeof DiscoveryPriceFlag>;
 export type IDiscoveryPlannedPriceRow = z.infer<typeof DiscoveryPlannedPriceRow>;
+export type IDiscoveryPriceOverride = z.infer<typeof DiscoveryPriceOverride>;
 export type IDiscoveryPriceSkip = z.infer<typeof DiscoveryPriceSkip>;
 export type IDiscoveryLifecycleTransition = z.infer<typeof DiscoveryLifecycleTransition>;
 export type IDiscoveryCatalogDiffEntry = z.infer<typeof DiscoveryCatalogDiffEntry>;
@@ -791,6 +809,7 @@ export const ModelDiscoveryRun = z.object({
    */
   priceFlags: DiscoveryPriceFlag.array().optional(),
   priceRows: DiscoveryPlannedPriceRow.array().optional(),
+  priceOverrides: DiscoveryPriceOverride.array().optional(),
   priceSkips: DiscoveryPriceSkip.array().optional(),
   lifecycleTransitions: DiscoveryLifecycleTransition.array().optional(),
   catalogDiff: DiscoveryCatalogDiffEntry.array().optional(),

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.test.ts
@@ -22,6 +22,9 @@ const provider = (price: DiscoveredPrice, modelId?: string) => from('openai', 'p
 const modelsDev = (price: DiscoveredPrice, modelId?: string) =>
   from('models.dev', 'aggregator', priced(price, modelId));
 const litellm = (price: DiscoveredPrice, modelId?: string) => from('litellm', 'aggregator', priced(price, modelId));
+/** A third mirror; the repo registers two, and some rules only show up past that. */
+const openRouter = (price: DiscoveredPrice, modelId?: string) =>
+  from('openrouter', 'aggregator', priced(price, modelId));
 
 const inForce = (pricing: Record<string, IModelPriceTier>, note = 'adapter-seed', modelId = 'gpt-6'): IModelPrice => ({
   modelId,
@@ -206,11 +209,11 @@ describe('planPriceWrites guardrails', () => {
   });
 
   it('proposes one of the two values it names as disagreeing', () => {
-    // The provider agrees with both aggregators inside the tolerance while they
-    // disagree with each other, so the first disagreeing pair excludes it.
+    // Three aggregators where the outer two disagree with each other and the
+    // middle one agrees with both, so the first disagreeing pair excludes it.
     const result = plan({
       contributions: [
-        provider({ inputPerMTok: 5, outputPerMTok: 25 }),
+        openRouter({ inputPerMTok: 5, outputPerMTok: 25 }),
         modelsDev({ inputPerMTok: 4.6, outputPerMTok: 25 }),
         litellm({ inputPerMTok: 5.4, outputPerMTok: 25 }),
       ],
@@ -224,7 +227,7 @@ describe('planPriceWrites guardrails', () => {
     expect(result.flags[0].detail).toContain('litellm');
   });
 
-  it('applies neither side when a provider and an aggregator disagree', () => {
+  it('applies neither side when the only aggregator disagrees with the provider', () => {
     const result = plan({
       contributions: [
         modelsDev({ inputPerMTok: 5, outputPerMTok: 25 }),
@@ -234,6 +237,9 @@ describe('planPriceWrites guardrails', () => {
 
     expect(result.rows).toEqual([]);
     expect(result.flags[0].kind).toBe('source-disagreement');
+    // A different sentence from mirrors contradicting each other: what is wrong
+    // here is that nothing backs the provider up.
+    expect(result.flags[0].detail).toContain('no source corroborates the provider');
   });
 
   it('flags a move beyond the band and keeps the row in force', () => {
@@ -374,7 +380,222 @@ describe('planPriceWrites guardrails', () => {
   it('drops an all-zero observation rather than writing a free row', () => {
     const result = plan({ contributions: [provider({ inputPerMTok: 0, outputPerMTok: 0 })] });
 
-    expect(result).toEqual({ rows: [], flags: [], skipped: [] });
+    expect(result).toEqual({ rows: [], flags: [], overrides: [], skipped: [] });
+  });
+});
+
+/**
+ * A provider's own published price is primary: it needs ONE mirror to agree, not
+ * all of them. The mirrors go stale on their own schedules (litellm publishes off
+ * a git ref, models.dev re-scrapes on its own cadence), so a unanimity rule hands
+ * any one of them a veto over a price the provider itself publishes.
+ */
+describe('planPriceWrites provider primacy', () => {
+  const CUT: DiscoveredPrice = { inputPerMTok: 0.2, outputPerMTok: 1.2 };
+  const STALE: DiscoveredPrice = { inputPerMTok: 1, outputPerMTok: 6 };
+  const CUT_IN_FORCE: IModelPriceTier = { input: 1e-6, output: 6e-6 };
+
+  it('writes the provider price when one mirror agrees and another is stale', () => {
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(CUT), litellm(STALE)],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 500,
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(perMTok(result.rows[0].pricing)).toEqual({ '0': { input: 0.2, output: 1.2 } });
+    // Credited to the provider alone: the agreeing mirror corroborated the value,
+    // it did not supply it.
+    expect(result.rows[0].note).toBe(`discovery:openai@${RUN_AT.toISOString()}`);
+  });
+
+  it('records the overruled source rather than swallowing it', () => {
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(CUT), litellm(STALE)],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 500,
+    });
+
+    expect(result.overrides).toHaveLength(1);
+    expect(result.overrides[0]).toMatchObject({
+      modelId: 'gpt-6',
+      source: 'openai',
+      dissenting: ['litellm'],
+      applied: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+    });
+    // The whole point of recording it: the operator learns WHICH mirror is stale.
+    expect(result.overrides[0].detail).toContain('litellm');
+    expect(result.overrides[0].detail).toContain('in 1/out 6');
+    // Present tense: this planner runs identically in report mode, where nothing
+    // is written, so the sentence may not claim a write.
+    expect(result.overrides[0].detail).toContain('the provider value wins');
+    expect(result.overrides[0].detail).not.toContain('was applied');
+  });
+
+  it('records nothing when every source agreed', () => {
+    const result = plan({ contributions: [provider(CUT), modelsDev(CUT), litellm(CUT)] });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.overrides).toEqual([]);
+  });
+
+  it('writes the provider price when the mirrors disagree with each other but not with it', () => {
+    const result = plan({
+      contributions: [
+        provider({ inputPerMTok: 5, outputPerMTok: 25 }),
+        modelsDev({ inputPerMTok: 4.6, outputPerMTok: 25 }),
+        litellm({ inputPerMTok: 5.4, outputPerMTok: 25 }),
+      ],
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(result.rows[0].pricing['0'].input).toBe(5e-6);
+    expect(result.overrides).toEqual([]);
+  });
+
+  it('refuses when every mirror disagrees with the provider', () => {
+    // Primary, not unaccountable. All of them dissenting is the shape of a parser
+    // that broke against a docs restructure, which must reprice nothing.
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(STALE), litellm(STALE)],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 500,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.overrides).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'source-disagreement' });
+  });
+
+  it('still writes a provider price no mirror carries at all', () => {
+    const result = plan({ contributions: [provider(CUT)] });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.overrides).toEqual([]);
+  });
+
+  it('does not record an override for a price it declined to write', () => {
+    // The band refuses this move, so nothing was applied over anything.
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(CUT), litellm(STALE)],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 50,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.overrides).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'band-exceeded' });
+  });
+
+  it('leaves the aggregator-only rules exactly as they were', () => {
+    const disagreeing = plan({
+      contributions: [
+        modelsDev({ inputPerMTok: 5, outputPerMTok: 25 }),
+        litellm({ inputPerMTok: 9, outputPerMTok: 25 }),
+      ],
+    });
+    expect(disagreeing.rows).toEqual([]);
+    expect(disagreeing.flags[0]).toMatchObject({ kind: 'source-disagreement' });
+
+    const lone = plan({ contributions: [litellm({ inputPerMTok: 5, outputPerMTok: 25 })] });
+    expect(lone.rows).toEqual([]);
+    expect(lone.flags[0]).toMatchObject({ kind: 'single-source-untrusted' });
+  });
+
+  it('makes two providers that disagree with each other refuse, with neither outranking', () => {
+    const result = plan({
+      contributions: [
+        provider({ inputPerMTok: 5, outputPerMTok: 25 }),
+        from('bedrock', 'provider', priced({ inputPerMTok: 15, outputPerMTok: 25 })),
+        modelsDev({ inputPerMTok: 5, outputPerMTok: 25 }),
+      ],
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'source-disagreement' });
+    // Two providers is a mutual contradiction, not an uncorroborated one, even
+    // though both sides of the pair are providers.
+    expect(result.flags[0].detail).toContain('sources disagree beyond');
+    expect(result.flags[0].detail).not.toContain('corroborates');
+  });
+
+  it('reports a stale mirror on a model whose row already carries the right price', () => {
+    // The steady state: the provider's value is already in force, so there is no
+    // row to write - and that is exactly when "which mirror is stale" is the only
+    // fact left. Recording this only against a write would hide it forever.
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(CUT), litellm(STALE)],
+      // Exactly what buildTier produces from these rates, which is what a prior
+      // run would have written; 0.2e-6 is a DIFFERENT float from 0.2 / 1e6.
+      rowsInForce: [inForce({ '0': { input: 0.2 / 1_000_000, output: 1.2 / 1_000_000 } })],
+      bandPct: 500,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.skipped).toEqual([{ modelId: 'gpt-6', reason: 'unchanged' }]);
+    expect(result.overrides).toHaveLength(1);
+    expect(result.overrides[0]).toMatchObject({ source: 'openai', dissenting: ['litellm'] });
+  });
+
+  it('refuses a provider ladder no mirror corroborates, rather than writing the upper rung alone', () => {
+    // diverges() is silent when only one side publishes brackets, so a mirror
+    // that went flat still "agrees" on the base rates. Without this the upper
+    // bracket would be written on one scrape's word.
+    const ladder: DiscoveredPrice = {
+      inputPerMTok: 0.2,
+      outputPerMTok: 1.2,
+      brackets: [{ aboveTokens: 272_000, inputPerMTok: 0.4, outputPerMTok: 1.8 }],
+    };
+    const flat: DiscoveredPrice = { inputPerMTok: 0.2, outputPerMTok: 1.2 };
+    const result = plan({
+      contributions: [provider(ladder), modelsDev(flat), litellm(flat)],
+      rowsInForce: [inForce({ '272000': { input: 1e-6, output: 6e-6 }, '1050000': { input: 2e-6, output: 9e-6 } })],
+      bandPct: 500,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'tiered-pricing-manual' });
+    expect(result.flags[0].detail).toContain('no long-context rates');
+  });
+
+  it('still lets a flat row take a provider price no mirror carries a ladder for', () => {
+    // A flat row discards the brackets anyway, so refusing there would block a
+    // write whose ladder was never going to be used.
+    const ladder: DiscoveredPrice = {
+      inputPerMTok: 0.2,
+      outputPerMTok: 1.2,
+      brackets: [{ aboveTokens: 272_000, inputPerMTok: 0.4, outputPerMTok: 1.8 }],
+    };
+    const result = plan({
+      contributions: [provider(ladder), modelsDev({ inputPerMTok: 0.2, outputPerMTok: 1.2 })],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 500,
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(perMTok(result.rows[0].pricing)).toEqual({ '0': { input: 0.2, output: 1.2 } });
+  });
+
+  it('lets a provider ladder reprice a tiered row over a stale flat mirror', () => {
+    // The case this whole change exists for: the provider publishes the ladder,
+    // one mirror agrees, and the other still has last quarter's price.
+    const ladder: DiscoveredPrice = {
+      inputPerMTok: 0.2,
+      outputPerMTok: 1.2,
+      brackets: [{ aboveTokens: 272_000, inputPerMTok: 0.4, outputPerMTok: 1.8 }],
+    };
+    const result = plan({
+      contributions: [provider(ladder), modelsDev(ladder), litellm(STALE)],
+      rowsInForce: [inForce({ '272000': { input: 1e-6, output: 6e-6 }, '1050000': { input: 2e-6, output: 9e-6 } })],
+      bandPct: 500,
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(perMTok(result.rows[0].pricing)).toEqual({
+      '272000': { input: 0.2, output: 1.2 },
+      '1050000': { input: 0.4, output: 1.8 },
+    });
+    expect(result.overrides[0].dissenting).toEqual(['litellm']);
   });
 });
 

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.test.ts
@@ -36,6 +36,21 @@ const inForce = (pricing: Record<string, IModelPriceTier>, note = 'adapter-seed'
 /** $5/$25 per MTok as the collection stores it: USD per single token. */
 const FIVE_AND_TWENTY_FIVE: IModelPriceTier = { input: 5e-6, output: 25e-6 };
 
+/**
+ * A stored pricing map read back in $/MTok, which is the unit the sources quote
+ * and the one these expectations are legible in. Rounded like the run report's
+ * own numbers: a rate that crosses 1e6 and back picks up float noise
+ * (0.2 -> 2.0000000000000002e-7), and that noise is not what any of these
+ * assertions are about.
+ */
+const perMTok = (pricing: Record<string, IModelPriceTier>): Record<string, Record<string, number>> =>
+  Object.fromEntries(
+    Object.entries(pricing).map(([threshold, tier]) => [
+      threshold,
+      Object.fromEntries(Object.entries(tier).map(([rate, value]) => [rate, Number((value * 1e6).toPrecision(10))])),
+    ])
+  );
+
 const plan = (overrides: Partial<PricePlanInput> = {}) =>
   planPriceWrites({
     contributions: [],
@@ -236,7 +251,7 @@ describe('planPriceWrites guardrails', () => {
   });
 
   it('applies the same move once the band is widened past it', () => {
-    // The band is a multiple of the rate in force, so 200% passes anything up to
+    // The band is the ratio between the two rates, so 200% passes anything up to
     // 3x: $5 -> $12 is a 140% move.
     const result = plan({
       contributions: [provider({ inputPerMTok: 12, outputPerMTok: 25 })],
@@ -249,8 +264,6 @@ describe('planPriceWrites guardrails', () => {
   });
 
   it('still flags a 10x move against a widened band', () => {
-    // A symmetric distance saturates at 100%, which would make every band of 100
-    // or more a no-op; against the rate in force this is a 900% move.
     const result = plan({
       contributions: [provider({ inputPerMTok: 50, outputPerMTok: 25 })],
       rowsInForce: [inForce({ '0': FIVE_AND_TWENTY_FIVE })],
@@ -259,6 +272,77 @@ describe('planPriceWrites guardrails', () => {
 
     expect(result.rows).toEqual([]);
     expect(result.flags[0]).toMatchObject({ kind: 'band-exceeded', proposed: { inputPerMTok: 50 } });
+  });
+
+  it('scores a 5x cut as 400%, the same multiple as the matching rise', () => {
+    // $1/MTok down to $0.20 is the shape a provider price drop actually arrives
+    // in. Measured as a fraction of the rate in force it would score 80% and no
+    // band of 100 or more could ever flag a cut at all.
+    const banded = (bandPct: number) =>
+      plan({
+        contributions: [provider({ inputPerMTok: 0.2, outputPerMTok: 25 })],
+        rowsInForce: [inForce({ '0': { input: 1e-6, output: 25e-6 } })],
+        bandPct,
+      });
+
+    const flagged = banded(50);
+    expect(flagged.rows).toEqual([]);
+    expect(flagged.flags[0]).toMatchObject({ kind: 'band-exceeded', proposed: { inputPerMTok: 0.2 } });
+    expect(flagged.flags[0].detail).toContain('input 400%');
+
+    // 500 is the setting's cap, and 400% is inside it.
+    const wide = banded(500);
+    expect(wide.flags).toEqual([]);
+    expect(wide.rows).toHaveLength(1);
+  });
+
+  it.each([
+    ['rise', 18],
+    ['cut', 2],
+  ])('passes a 3x %s at a band of 200 and flags it at 150', (_label, observed) => {
+    const banded = (bandPct: number) =>
+      plan({
+        contributions: [provider({ inputPerMTok: observed, outputPerMTok: 25 })],
+        rowsInForce: [inForce({ '0': { input: 6e-6, output: 25e-6 } })],
+        bandPct,
+      });
+
+    // What the setting's own description promises: 200 passes up to a 3x change
+    // in EITHER direction, and both directions score the same 200%.
+    expect(banded(200).flags).toEqual([]);
+    expect(banded(200).rows).toHaveLength(1);
+
+    const tight = banded(150);
+    expect(tight.rows).toEqual([]);
+    expect(tight.flags[0]).toMatchObject({ kind: 'band-exceeded' });
+    expect(tight.flags[0].detail).toContain('input 200%');
+  });
+
+  it('reads a move off a zero rate as unbounded, which no band passes', () => {
+    const result = plan({
+      contributions: [provider({ inputPerMTok: 5, outputPerMTok: 25 })],
+      rowsInForce: [inForce({ '0': { input: 0, output: 25e-6 } })],
+      bandPct: 500,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'band-exceeded' });
+    expect(result.flags[0].detail).toContain('input unbounded');
+  });
+
+  it('fails the band closed when the row it bands against carries an unusable rate', () => {
+    // The discovered side cannot reach this (isUsable requires a finite rate), so
+    // this is the stored side. NaN > band is false, which would wave the move
+    // through as if it were inside the band.
+    const result = plan({
+      contributions: [provider({ inputPerMTok: 5, outputPerMTok: 25 })],
+      rowsInForce: [inForce({ '0': { input: Number.NaN, output: 25e-6 } })],
+      bandPct: 500,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'band-exceeded' });
+    expect(result.flags[0].detail).toContain('input unbounded');
   });
 
   it('measures the band against the run-start row, not the one an earlier pass wrote', () => {
@@ -381,6 +465,258 @@ describe('planPriceWrites provenance', () => {
   });
 });
 
+describe('planPriceWrites tier ladders', () => {
+  const LUNA = 'gpt-5.6-luna';
+
+  /**
+   * The row in force as production holds it: a two-tier ladder whose keys are the
+   * UPPER bound of each bracket (tierForTokens picks the first threshold >= the
+   * prompt), so 272000 is the up-to-272k rate and 1050000 the rest of the window.
+   */
+  const LUNA_ROW: Record<string, IModelPriceTier> = {
+    '272000': { input: 1e-6, output: 6e-6 },
+    '1050000': { input: 2e-6, output: 9e-6 },
+  };
+
+  /** models.dev after the 80% cut: a base rate plus one bracket above 272k. */
+  const LUNA_MODELS_DEV: DiscoveredPrice = {
+    inputPerMTok: 0.2,
+    outputPerMTok: 1.2,
+    cacheReadPerMTok: 0.02,
+    cacheWritePerMTok: 0.25,
+    brackets: [
+      {
+        aboveTokens: 272_000,
+        inputPerMTok: 0.4,
+        outputPerMTok: 1.8,
+        cacheReadPerMTok: 0.04,
+        cacheWritePerMTok: 0.5,
+      },
+    ],
+  };
+
+  /** The same rates off litellm, whose per-token quotes pick up 1e6 float noise. */
+  const LUNA_LITELLM: DiscoveredPrice = {
+    inputPerMTok: 2e-7 * 1e6,
+    outputPerMTok: 1.2e-6 * 1e6,
+    cacheReadPerMTok: 2e-8 * 1e6,
+    cacheWritePerMTok: 2.5e-7 * 1e6,
+    brackets: [
+      {
+        aboveTokens: 272_000,
+        inputPerMTok: 4e-7 * 1e6,
+        outputPerMTok: 1.8e-6 * 1e6,
+        cacheReadPerMTok: 4e-8 * 1e6,
+        cacheWritePerMTok: 5e-7 * 1e6,
+      },
+    ],
+  };
+
+  const lunaPlan = (overrides: Partial<PricePlanInput> = {}) =>
+    plan({
+      knownModelIds: new Set([LUNA]),
+      rowsInForce: [inForce(LUNA_ROW, 'adapter-seed', LUNA)],
+      // An 80% cut is a 5x move, so the default 50% band would flag it. The band
+      // is a separate guardrail and has its own cases below.
+      bandPct: 500,
+      ...overrides,
+    });
+
+  it('rewrites both tiers of the row in force from the brackets both aggregators publish', () => {
+    const result = lunaPlan({
+      contributions: [modelsDev(LUNA_MODELS_DEV, LUNA), litellm(LUNA_LITELLM, LUNA)],
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.rows).toHaveLength(1);
+    // The keys are the row's own, untouched: re-deriving a threshold would move
+    // where the long-context rate starts.
+    expect(Object.keys(result.rows[0].pricing)).toEqual(['272000', '1050000']);
+    expect(perMTok(result.rows[0].pricing)).toEqual({
+      '272000': { input: 0.2, output: 1.2, cache_read: 0.02, cache_write: 0.25 },
+      '1050000': { input: 0.4, output: 1.8, cache_read: 0.04, cache_write: 0.5 },
+    });
+    // Stored per SINGLE token, the same 1e6 crossing a flat row makes.
+    expect(result.rows[0].pricing['1050000'].input).toBeLessThan(1e-6);
+    expect(result.rows[0].note).toBe(`discovery:models.dev+litellm@${RUN_AT.toISOString()}`);
+    expect(result.rows[0].repricedBy).toBe('model-discovery');
+  });
+
+  it('applies neither side when the two sources agree on the base and differ on the bracket', () => {
+    const disagreeing: DiscoveredPrice = {
+      ...LUNA_MODELS_DEV,
+      brackets: [{ aboveTokens: 272_000, inputPerMTok: 0.9, outputPerMTok: 1.8 }],
+    };
+    const result = lunaPlan({ contributions: [modelsDev(LUNA_MODELS_DEV, LUNA), litellm(disagreeing, LUNA)] });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'source-disagreement', sources: ['models.dev', 'litellm'] });
+    // Both upper rates on the line: the base rates are identical, so a detail
+    // without the brackets would show two equal prices "disagreeing".
+    expect(result.flags[0].detail).toContain('above 272000 in 0.4');
+    expect(result.flags[0].detail).toContain('above 272000 in 0.9');
+  });
+
+  it('applies neither side when only one source publishes a breakpoint the other does not', () => {
+    const shifted: DiscoveredPrice = {
+      ...LUNA_MODELS_DEV,
+      brackets: [{ aboveTokens: 200_000, inputPerMTok: 0.4, outputPerMTok: 1.8 }],
+    };
+    const result = lunaPlan({ contributions: [modelsDev(LUNA_MODELS_DEV, LUNA), litellm(shifted, LUNA)] });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'source-disagreement' });
+  });
+
+  it('still refuses a ladder whose breakpoints do not line up with the row', () => {
+    const misaligned: DiscoveredPrice = {
+      ...LUNA_MODELS_DEV,
+      brackets: [{ aboveTokens: 200_000, inputPerMTok: 0.4, outputPerMTok: 1.8 }],
+    };
+    const result = lunaPlan({ contributions: [modelsDev(misaligned, LUNA), litellm(misaligned, LUNA)] });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'tiered-pricing-manual' });
+    // The flag has to say WHY it could not be mapped, not only that it wasn't.
+    expect(result.flags[0].detail).toContain('272000, 1050000');
+    expect(result.flags[0].detail).toContain('brackets above 200000 do not line up');
+  });
+
+  it('still refuses a flat observation against a tiered row, and says so', () => {
+    const flat: DiscoveredPrice = { inputPerMTok: 0.2, outputPerMTok: 1.2 };
+    const result = lunaPlan({ contributions: [modelsDev(flat, LUNA), litellm(flat, LUNA)] });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'tiered-pricing-manual' });
+    expect(result.flags[0].detail).toContain('the sources publish one flat rate');
+  });
+
+  it('flags the ladder when only its upper tier leaves the band', () => {
+    // The base rate barely moves and the 1050000 tier goes up 10x. Banding on the
+    // lowest tier alone would write that upper rate unattended.
+    const runaway: DiscoveredPrice = {
+      inputPerMTok: 1.02,
+      outputPerMTok: 6,
+      brackets: [{ aboveTokens: 272_000, inputPerMTok: 20, outputPerMTok: 9 }],
+    };
+    const result = lunaPlan({
+      contributions: [modelsDev(runaway, LUNA), litellm(runaway, LUNA)],
+      bandPct: 200,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'band-exceeded' });
+    // Named per tier, or 'input' alone would not say which rung moved.
+    expect(result.flags[0].detail).toContain('input@1050000 900%');
+    expect(result.flags[0].detail).toContain('above 272000 in 2');
+  });
+
+  it.each([
+    ['carries an unusable rate', [{ aboveTokens: 272_000, inputPerMTok: Number.NaN, outputPerMTok: 1.8 }]],
+    ['is free above the breakpoint', [{ aboveTokens: 272_000, inputPerMTok: 0, outputPerMTok: 0 }]],
+    [
+      'quotes one breakpoint twice',
+      [
+        { aboveTokens: 272_000, inputPerMTok: 0.4, outputPerMTok: 1.8 },
+        { aboveTokens: 272_000, inputPerMTok: 0.9, outputPerMTok: 1.8 },
+      ],
+    ],
+  ])('refuses the whole ladder when a bracket %s', (_label, brackets) => {
+    const broken: DiscoveredPrice = { ...LUNA_MODELS_DEV, brackets };
+    const result = lunaPlan({ contributions: [modelsDev(broken, LUNA), litellm(broken, LUNA)] });
+
+    // A ladder we cannot read is a flat observation, which a tiered row refuses.
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'tiered-pricing-manual' });
+    expect(result.flags[0].detail).toContain('the sources publish one flat rate');
+  });
+
+  it('appends nothing when the same ladder is observed again', () => {
+    const contributions = [modelsDev(LUNA_MODELS_DEV, LUNA), litellm(LUNA_LITELLM, LUNA)];
+    const first = lunaPlan({ contributions });
+
+    const second = lunaPlan({
+      contributions,
+      rowsInForce: [
+        {
+          ...inForce(LUNA_ROW, `discovery:models.dev+litellm@${RUN_AT.toISOString()}`, LUNA),
+          pricing: first.rows[0].pricing,
+        },
+      ],
+    });
+
+    expect(second.rows).toEqual([]);
+    expect(second.flags).toEqual([]);
+    expect(second.skipped).toEqual([{ modelId: LUNA, reason: 'unchanged' }]);
+  });
+
+  it('carries a cache rate forward per tier, from the tier under the same threshold', () => {
+    // grok-4.5's shape: a 200k breakpoint with cache_read in both tiers, and an
+    // audio rate no feed publishes that only survives by being carried.
+    const GROK = 'grok-4.5';
+    const observed: DiscoveredPrice = {
+      inputPerMTok: 2.2,
+      outputPerMTok: 6,
+      cacheReadPerMTok: 0.33,
+      brackets: [{ aboveTokens: 200_000, inputPerMTok: 4.4, outputPerMTok: 12 }],
+    };
+    const result = plan({
+      knownModelIds: new Set([GROK]),
+      contributions: [modelsDev(observed, GROK), litellm(observed, GROK)],
+      rowsInForce: [
+        inForce(
+          {
+            '200000': { input: 2e-6, output: 6e-6, cache_read: 0.3e-6, audio_input: 40e-6 },
+            '500000': { input: 4e-6, output: 12e-6, cache_read: 0.6e-6 },
+          },
+          'adapter-seed',
+          GROK
+        ),
+      ],
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(perMTok(result.rows[0].pricing)).toEqual({
+      // The observed cache rate wins in the tier that quotes one; the upper tier
+      // keeps its own 0.6 rather than inheriting the base tier's.
+      '200000': { input: 2.2, output: 6, cache_read: 0.33, audio_input: 40 },
+      '500000': { input: 4.4, output: 12, cache_read: 0.6 },
+    });
+  });
+
+  it('leaves a flat row flat even when the sources publish a ladder', () => {
+    const result = plan({
+      contributions: [
+        provider({ inputPerMTok: 6, outputPerMTok: 25 }),
+        modelsDev({
+          inputPerMTok: 6,
+          outputPerMTok: 25,
+          brackets: [{ aboveTokens: 200_000, inputPerMTok: 12, outputPerMTok: 50 }],
+        }),
+      ],
+      rowsInForce: [inForce({ '1000000': FIVE_AND_TWENTY_FIVE })],
+    });
+
+    // Inventing a second threshold would bill long prompts at a rate that was
+    // never in a row, so the base rate lands alone under the row's own key.
+    expect(result.rows[0].pricing).toEqual({ '1000000': { input: 6e-6, output: 25e-6 } });
+  });
+
+  it('refuses the ladder when the run-start row has no tier to band the upper one against', () => {
+    // Pass 2 of a run whose pass 1 wrote a differently keyed row: the upper tier
+    // would go in unbanded, which is the one thing the band exists to prevent.
+    const result = lunaPlan({
+      contributions: [modelsDev(LUNA_MODELS_DEV, LUNA), litellm(LUNA_LITELLM, LUNA)],
+      baselineRowsInForce: [inForce({ '272000': { input: 1e-6, output: 6e-6 } }, 'adapter-seed', LUNA)],
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'tiered-pricing-manual' });
+    expect(result.flags[0].detail).toContain('no tier at 1050000');
+  });
+});
+
 describe('planPriceWrites idempotence and carry-forward', () => {
   const asInForce = (row: {
     modelId: string;
@@ -439,11 +775,13 @@ describe('planPriceWrites idempotence and carry-forward', () => {
   });
 
   it('prefers an observed cache rate over the carried one', () => {
+    // The cache rates here are a fifth apart on purpose: halving one is a 100%
+    // move against the band, and these carry-forward cases are not about the band.
     const result = plan({
       contributions: [provider({ inputPerMTok: 5, outputPerMTok: 25, cacheReadPerMTok: 0.25, cacheWritePerMTok: 5 })],
       rowsInForce: [
         inForce(
-          { '0': { ...FIVE_AND_TWENTY_FIVE, cache_read: 0.5e-6, cache_write: 6.25e-6 } },
+          { '0': { ...FIVE_AND_TWENTY_FIVE, cache_read: 0.3e-6, cache_write: 6.25e-6 } },
           'discovery:openai@2026-01-01T00:00:00.000Z'
         ),
       ],
@@ -493,7 +831,7 @@ describe('planPriceWrites idempotence and carry-forward', () => {
       contributions: [provider({ inputPerMTok: 5, outputPerMTok: 25, cacheReadPerMTok: 0.25 })],
       rowsInForce: [
         inForce(
-          { '0': { ...FIVE_AND_TWENTY_FIVE, cache_read: 0.5e-6, cache_write: 6.25e-6 } },
+          { '0': { ...FIVE_AND_TWENTY_FIVE, cache_read: 0.3e-6, cache_write: 6.25e-6 } },
           'discovery:openai@2026-01-01T00:00:00.000Z'
         ),
       ],
@@ -539,7 +877,7 @@ describe('planPriceWrites idempotence and carry-forward', () => {
     const result = plan({
       contributions,
       rowsInForce: [
-        inForce({ '0': { ...FIVE_AND_TWENTY_FIVE, cache_read: 0.5e-6 } }, 'discovery:openai@2026-01-01T00:00:00.000Z'),
+        inForce({ '0': { ...FIVE_AND_TWENTY_FIVE, cache_read: 0.3e-6 } }, 'discovery:openai@2026-01-01T00:00:00.000Z'),
       ],
     });
 

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
@@ -8,6 +8,8 @@ import isEqual from 'lodash/isEqual.js';
 import { PRICE_AGREEMENT_TOLERANCE, relativeGap } from './catalogWrite';
 import type {
   DiscoveredPrice,
+  DiscoveredPriceBracket,
+  DiscoveredRates,
   DiscoverySourceKind,
   PlannedPriceRow,
   PriceFlag,
@@ -165,6 +167,7 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
     }
 
     const current = inForce.get(modelId);
+    const currentThresholds = current ? thresholdsOf(current) : [];
     const currentEntry = current ? lowestTierEntry(current) : undefined;
     const currentTier = currentEntry?.[1];
     const currentPrice = currentTier ? perMTokOf(tierAsPrice(currentTier)) : undefined;
@@ -219,16 +222,25 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       continue;
     }
 
-    // A single observed rate cannot express a tier ladder, and the read path
-    // REPLACES the whole pricing map, so writing one would delete the ladder.
-    if (current && isTiered(current)) {
+    // Banded against the run's opening position, not the row the previous pass of
+    // this same run wrote: the band is what one unattended run may move a price
+    // by, and a per-pass measurement would multiply it by the pass count. A model
+    // unpriced at run start falls back to the row in force, which is one this run
+    // wrote - its first write had nothing to band against either.
+    const bandRow = atRunStart.get(modelId) ?? current;
+
+    // The read path REPLACES the whole pricing map, so a tiered row may only be
+    // superseded by a write that reproduces every tier. That needs a ladder the
+    // sources published and this row's own thresholds to map it onto.
+    const ladder = current && isTiered(current) ? planLadder(current, proposed, bandRow) : undefined;
+    if (ladder && 'blocked' in ladder) {
       if (currentTier && diverges(proposed, tierAsPrice(currentTier), PRICE_AGREEMENT_TOLERANCE)) {
         flag(
           'tiered-pricing-manual',
           proposed,
-          `the row in force is tiered (${Object.keys(current.pricing).sort().join(', ')}) and its lowest tier ` +
+          `the row in force is tiered (${currentThresholds.join(', ')}) and its lowest tier ` +
             `${describe(tierAsPrice(currentTier))} differs from ${valueSources.join('+')} ${describe(proposed)}; ` +
-            'repricing a tier ladder is a manual edit'
+            `repricing it needs a ladder that maps onto those thresholds, and ${ladder.blocked}`
         );
       } else {
         skip(modelId, 'tiered-pricing');
@@ -236,30 +248,41 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       continue;
     }
 
-    // Measured against the run's opening position, not the row the previous pass
-    // of this same run wrote: the band is what one unattended run may move a
-    // price by, and a per-pass measurement would multiply it by the pass count.
-    // A model unpriced at run start falls back to the row in force, which is one
-    // this run wrote - its first write had nothing to band against either.
-    const openingRow = atRunStart.get(modelId);
-    const bandBaseline = (openingRow ? lowestTier(openingRow) : undefined) ?? currentTier;
-    if (bandBaseline) {
-      const band = input.bandPct / 100;
-      const moves = bandMoves(proposed, bandBaseline);
-      if (moves.some(move => move.move > band)) {
-        flag(
-          'band-exceeded',
-          proposed,
-          `${valueSources.join('+')} moves ${moves.map(move => `${move.rate} ${pct(move.move)}`).join(', ')} against ` +
-            `the row this run started from (band ${pct(band)}): ${describe(tierAsPrice(bandBaseline))} -> ` +
-            `${describe(proposed)}`
-        );
-        continue;
-      }
+    // A flat row stays flat even when the sources publish a ladder: inventing a
+    // second threshold would bill long prompts at a rate nobody signed off on.
+    const planned: PlannedTier[] = ladder?.tiers ?? [
+      { key: currentEntry?.[0] ?? '0', price: proposed, baseline: bandRow ? lowestTier(bandRow) : undefined },
+    ];
+
+    const band = input.bandPct / 100;
+    // Per tier, because a ladder whose upper bracket moves 10x while its base
+    // holds steady is exactly the move an operator has to see. The rate name
+    // carries its threshold only for a ladder, so a flat row reads as it always did.
+    const moves = planned.flatMap(tier =>
+      tier.baseline ? bandMoves(tier.price, tier.baseline, planned.length > 1 ? tier.key : undefined) : []
+    );
+    const bandBaseline = baselineAsPrice(planned);
+    if (bandBaseline && moves.some(move => move.move > band)) {
+      flag(
+        'band-exceeded',
+        proposed,
+        `${valueSources.join('+')} moves ${moves.map(move => `${move.rate} ${pct(move.move)}`).join(', ')} against ` +
+          `the row this run started from (band ${pct(band)}): ${describe(bandBaseline)} -> ` +
+          `${describe(proposed)}`
+      );
+      continue;
     }
 
-    const tier = buildTier(proposed, currentTier);
-    if (currentTier && isEqual(rateFields(tier), rateFields(currentTier))) {
+    // Carried forward per tier: the cache and audio rates no feed publishes come
+    // from the tier under the SAME threshold, never from the row's lowest one.
+    const tiers = planned.map(({ key, price }) => [key, buildTier(price, current?.pricing[key])] as const);
+    const unchanged =
+      current !== undefined &&
+      tiers.every(([key, tier]) => {
+        const held = current.pricing[key];
+        return held !== undefined && isEqual(rateFields(tier), rateFields(held));
+      });
+    if (unchanged) {
       skip(modelId, 'unchanged');
       continue;
     }
@@ -270,7 +293,7 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       // Keyed like the row it supersedes: the seed keys its single tier at the
       // model's context window, and re-keying it to '0' would churn a threshold
       // convention this planner has no way to re-derive.
-      pricing: { [currentEntry?.[0] ?? '0']: tier },
+      pricing: Object.fromEntries(tiers),
       effectiveFrom: input.runStartedAt,
       note: `${DISCOVERY_PRICE_NOTE_PREFIX}${valueSources.join('+')}@${input.runStartedAt.toISOString()}`,
       repricedBy: DISCOVERY_REPRICED_BY,
@@ -336,7 +359,7 @@ function collectObservations(contributions: readonly SourceContribution[]): Map<
       const observation = {
         source: contribution.name,
         kind: contribution.kind,
-        price: withUsableCacheRates(record.pricing),
+        price: usableObservation(record.pricing),
       };
       if (existing) existing.push(observation);
       else observed.set(modelId, [observation]);
@@ -350,7 +373,7 @@ function collectObservations(contributions: readonly SourceContribution[]): Map<
  * rejects it anyway, and a model that genuinely costs nothing is a catalog
  * flag, not a $0 row that would settle every call free.
  */
-function isUsable(price: DiscoveredPrice): boolean {
+function isUsable(price: DiscoveredRates): boolean {
   const rates = [price.inputPerMTok, price.outputPerMTok];
   if (!rates.every(rate => Number.isFinite(rate) && rate >= 0)) return false;
   return rates.some(rate => rate > 0);
@@ -362,12 +385,42 @@ function isUsable(price: DiscoveredPrice): boolean {
  * force is carried forward instead. Zero is a claim no feed gets to make - see
  * perToken for what a stored 0 would do to settlement.
  */
-function withUsableCacheRates(price: DiscoveredPrice): DiscoveredPrice {
-  const usable: DiscoveredPrice = { inputPerMTok: price.inputPerMTok, outputPerMTok: price.outputPerMTok };
-  const cacheRead = positiveRate(price.cacheReadPerMTok);
-  const cacheWrite = positiveRate(price.cacheWritePerMTok);
+function usableObservation(price: DiscoveredPrice): DiscoveredPrice {
+  const usable: DiscoveredPrice = usableRates(price);
+  const brackets = usableBrackets(price.brackets);
+  if (brackets) usable.brackets = brackets;
+  return usable;
+}
+
+function usableRates(rates: DiscoveredRates): DiscoveredRates {
+  const usable: DiscoveredRates = { inputPerMTok: rates.inputPerMTok, outputPerMTok: rates.outputPerMTok };
+  const cacheRead = positiveRate(rates.cacheReadPerMTok);
+  const cacheWrite = positiveRate(rates.cacheWritePerMTok);
   if (cacheRead !== undefined) usable.cacheReadPerMTok = cacheRead;
   if (cacheWrite !== undefined) usable.cacheWritePerMTok = cacheWrite;
+  return usable;
+}
+
+/**
+ * The ladder as the guardrails read it, ascending by breakpoint. All or nothing:
+ * one unusable bracket drops the whole ladder, because a ladder missing a rung
+ * would bill that rung's prompts at the rate below it. A source publishing no
+ * usable ladder reads as flat, which is how every source read before ladders
+ * existed.
+ */
+function usableBrackets(brackets: readonly DiscoveredPriceBracket[] | undefined): DiscoveredPriceBracket[] | undefined {
+  if (!brackets?.length) return undefined;
+  const ascending = [...brackets].sort((a, b) => a.aboveTokens - b.aboveTokens);
+
+  const usable: DiscoveredPriceBracket[] = [];
+  for (const bracket of ascending) {
+    // A stored tier key is a positive integer, and two rates for one breakpoint is
+    // a ladder with no reading to prefer.
+    const { aboveTokens } = bracket;
+    if (!Number.isInteger(aboveTokens) || aboveTokens <= 0 || !isUsable(bracket)) return undefined;
+    if (usable.some(kept => kept.aboveTokens === aboveTokens)) return undefined;
+    usable.push({ aboveTokens, ...usableRates(bracket) });
+  }
   return usable;
 }
 
@@ -384,11 +437,28 @@ function firstDisagreement(observations: readonly PriceObservation[]): [PriceObs
 }
 
 /**
- * Disagreement over any rate BOTH sides publish. A rate only one of them carries
- * is silence rather than a contradiction: models.dev quoting cache_read where
- * litellm does not is the ordinary case and may not read as a conflict.
+ * Disagreement over any rate BOTH sides publish, in the base rates or in a
+ * long-context bracket. A rate only one of them carries is silence rather than a
+ * contradiction: models.dev quoting cache_read where litellm does not is the
+ * ordinary case and may not read as a conflict.
+ *
+ * Two sides that BOTH publish a ladder must describe the SAME one, down to the
+ * breakpoints. Comparing only the base rates would let two sources that agree on
+ * the short-prompt price write one of their upper rates with no corroboration.
  */
 function diverges(a: DiscoveredPrice, b: DiscoveredPrice, tolerance: number): boolean {
+  if (ratesDiverge(a, b, tolerance)) return true;
+  const left = a.brackets;
+  const right = b.brackets;
+  if (!left || !right) return false;
+  if (left.length !== right.length) return true;
+  return left.some(
+    (bracket, index) =>
+      bracket.aboveTokens !== right[index].aboveTokens || ratesDiverge(bracket, right[index], tolerance)
+  );
+}
+
+function ratesDiverge(a: DiscoveredRates, b: DiscoveredRates, tolerance: number): boolean {
   return OBSERVED_RATES.some(([rate]) => {
     const left = a[rate];
     const right = b[rate];
@@ -403,11 +473,15 @@ function diverges(a: DiscoveredPrice, b: DiscoveredPrice, tolerance: number): bo
  * supersedes this one.
  */
 function lowestTierEntry(row: Pick<IModelPrice, 'pricing'>): [string, IModelPriceTier] | undefined {
-  const [threshold] = Object.keys(row.pricing).sort((a, b) => Number(a) - Number(b));
+  const [threshold] = thresholdsOf(row);
   return threshold === undefined ? undefined : [threshold, row.pricing[threshold]];
 }
 
 const lowestTier = (row: Pick<IModelPrice, 'pricing'>): IModelPriceTier | undefined => lowestTierEntry(row)?.[1];
+
+/** The row's thresholds in NUMERIC order; the keys are stringified numbers, so a plain sort() would put 1050000 before 272000. */
+const thresholdsOf = (row: Pick<IModelPrice, 'pricing'>): string[] =>
+  Object.keys(row.pricing).sort((a, b) => Number(a) - Number(b));
 
 /**
  * A ladder discovery must not flatten: more than one threshold. A single tier is
@@ -417,28 +491,117 @@ const lowestTier = (row: Pick<IModelPrice, 'pricing'>): IModelPriceTier | undefi
  */
 const isTiered = (row: IModelPrice): boolean => Object.keys(row.pricing).length !== 1;
 
+/** One tier of a planned row: where it is stored, what it would say, and what the band measures it against. */
+interface PlannedTier {
+  /** Threshold key in the stored pricing map. */
+  key: string;
+  price: DiscoveredRates;
+  /** The run-start row's tier under the same key; absent when there is nothing to band against. */
+  baseline?: IModelPriceTier;
+}
+
+type LadderPlan = { tiers: PlannedTier[] } | { blocked: string };
+
+/**
+ * Map a bracketed observation onto the ladder the row in force already carries,
+ * or say why it cannot be mapped (`blocked` completes the flag's sentence).
+ *
+ * Our tier keys are bracket UPPER bounds - tierForTokens in common/src/models.ts
+ * picks the first threshold >= the prompt's input tokens - while both feeds
+ * publish a base rate plus "above N tokens" rates. So the base rate belongs to the
+ * LOWEST key and each bracket to the key above its own breakpoint, which lines up
+ * only when the row's thresholds except its highest ARE the breakpoints. For a
+ * 272k/1050000 row against one bracket above 272k: [272000] == [272000], so the
+ * base is the up-to-272k tier and the bracket is the up-to-1050000 one.
+ *
+ * Any other shape would need a threshold we invented, and an invented threshold
+ * bills long prompts at the wrong end of the ladder.
+ */
+function planLadder(row: IModelPrice, observed: DiscoveredPrice, bandRow: IModelPrice | undefined): LadderPlan {
+  const brackets = observed.brackets;
+  if (!brackets?.length) return { blocked: 'the sources publish one flat rate' };
+
+  const thresholds = thresholdsOf(row);
+  const breakpoints = brackets.map(bracket => bracket.aboveTokens);
+  const aligned =
+    thresholds.length === brackets.length + 1 &&
+    thresholds.slice(0, -1).every((threshold, index) => Number(threshold) === breakpoints[index]);
+  if (!aligned) {
+    return { blocked: `the sources' brackets above ${breakpoints.join(', ')} do not line up with them` };
+  }
+
+  const tiers = thresholds.map((key, index) => ({
+    key,
+    price: index === 0 ? observed : brackets[index - 1],
+    baseline: bandRow?.pricing[key],
+  }));
+  // Per-tier banding is what makes an unattended ladder write safe, so a tier with
+  // no run-start counterpart is not one this planner may write.
+  const unbanded = tiers.filter(tier => !tier.baseline).map(tier => tier.key);
+  if (unbanded.length > 0) {
+    return { blocked: `the row this run started from has no tier at ${unbanded.join(', ')} to band against` };
+  }
+  return { tiers };
+}
+
+/**
+ * The tiers being superseded, in the shape describe() prints: the lowest tier's
+ * rates plus one bracket per tier above it, each keyed by the threshold BELOW it,
+ * which is the token count its rates start applying at.
+ */
+function baselineAsPrice(planned: readonly PlannedTier[]): DiscoveredPrice | undefined {
+  const base = planned[0]?.baseline;
+  if (!base) return undefined;
+
+  const price: DiscoveredPrice = tierAsPrice(base);
+  const brackets: DiscoveredPriceBracket[] = [];
+  for (const [index, tier] of planned.slice(1).entries()) {
+    if (tier.baseline) brackets.push({ aboveTokens: Number(planned[index].key), ...tierAsPrice(tier.baseline) });
+  }
+  if (brackets.length > 0) price.brackets = brackets;
+  return price;
+}
+
 /**
  * Every rate the band applies to: the two text rates, plus a cache rate when the
- * row in force carries it AND this observation quotes it. Each move is measured
- * against the CURRENT rate rather than symmetrically, so the setting reads as a
- * multiple of what we bill today (200% is "up to 3x") instead of saturating at
- * 100%, where relativeGap would silently disable the band.
+ * row in force carries it AND this observation quotes it. Each move is a ratio of
+ * the two rates rather than a fraction of either one, so the setting means the
+ * same multiple whichever way the price went (200% is "up to 3x", up or down).
+ *
+ * `tierKey` qualifies the rate names for a multi-tier plan, where 'input' alone
+ * would not say which tier of the ladder moved.
  */
-function bandMoves(proposed: DiscoveredPrice, current: IModelPriceTier): Array<{ rate: string; move: number }> {
+function bandMoves(
+  proposed: DiscoveredRates,
+  current: IModelPriceTier,
+  tierKey?: string
+): Array<{ rate: string; move: number }> {
   const moves: Array<{ rate: string; move: number }> = [];
   for (const [observed, field] of OBSERVED_RATES) {
     const next = proposed[observed];
     const held = current[field];
     if (next === undefined || held === undefined) continue;
-    moves.push({ rate: field, move: baselineMove(next, held * TOKENS_PER_MTOK) });
+    moves.push({ rate: tierKey ? `${field}@${tierKey}` : field, move: baselineMove(next, held * TOKENS_PER_MTOK) });
   }
   return moves;
 }
 
-/** Leaving a zero rate for a real one exceeds any band: nothing is a multiple of 0. */
+/**
+ * How far apart two rates are, as the larger over the smaller minus one: a 3x move
+ * is 200% whether the price tripled or fell to a third. A fraction of the current
+ * rate would instead saturate at 100% for any cut, which is every band of 100 or
+ * more silently disabled in that direction.
+ *
+ * Leaving OR reaching a zero rate exceeds any band: nothing is a multiple of 0. A
+ * negative rate cannot reach this point, and fails the band the same way if it ever does.
+ */
 const baselineMove = (proposed: number, current: number): number => {
+  // NaN compares false against any band, so an unusable rate would pass it.
+  if (!Number.isFinite(proposed) || !Number.isFinite(current)) return Number.POSITIVE_INFINITY;
   if (proposed === current) return 0;
-  return current === 0 ? Number.POSITIVE_INFINITY : Math.abs(proposed - current) / current;
+  const smaller = Math.min(proposed, current);
+  const larger = Math.max(proposed, current);
+  return smaller <= 0 ? Number.POSITIVE_INFINITY : larger / smaller - 1;
 };
 
 /**
@@ -447,7 +610,7 @@ const baselineMove = (proposed: number, current: number): number => {
  * silently move cached reads and voice minutes onto the text rate, which is a
  * billing change nobody asked for.
  */
-function buildTier(price: DiscoveredPrice, carry: IModelPriceTier | undefined): IModelPriceTier {
+function buildTier(price: DiscoveredRates, carry: IModelPriceTier | undefined): IModelPriceTier {
   const tier: IModelPriceTier = {
     input: price.inputPerMTok / TOKENS_PER_MTOK,
     output: price.outputPerMTok / TOKENS_PER_MTOK,
@@ -486,8 +649,8 @@ function rateFields(tier: IModelPriceTier): Record<string, number> {
   return out;
 }
 
-const tierAsPrice = (tier: IModelPriceTier): DiscoveredPrice => {
-  const price: DiscoveredPrice = {
+const tierAsPrice = (tier: IModelPriceTier): DiscoveredRates => {
+  const price: DiscoveredRates = {
     inputPerMTok: tier.input * TOKENS_PER_MTOK,
     outputPerMTok: tier.output * TOKENS_PER_MTOK,
   };
@@ -505,15 +668,21 @@ const perMTokOf = (price: DiscoveredPrice): { inputPerMTok: number; outputPerMTo
 const readable = (rate: number): number => Number(rate.toPrecision(10));
 
 /**
- * Every rate the observation carries, cache rates included: a disagreement can
- * live entirely in cache_read, and a detail line that only prints input and
- * output would then show two identical prices "disagreeing" - the opposite of
- * the explainable-line-by-line contract the flags exist to meet.
+ * Every rate the observation carries, cache rates and long-context brackets
+ * included: a disagreement can live entirely in cache_read or in an upper bracket,
+ * and a detail line that only prints the base input and output would then show two
+ * identical prices "disagreeing" - the opposite of the explainable-line-by-line
+ * contract the flags exist to meet.
  */
-const describe = (price: DiscoveredPrice): string => {
-  const parts = [`in ${readable(price.inputPerMTok)}`, `out ${readable(price.outputPerMTok)}`];
-  if (price.cacheReadPerMTok !== undefined) parts.push(`cache_read ${readable(price.cacheReadPerMTok)}`);
-  if (price.cacheWritePerMTok !== undefined) parts.push(`cache_write ${readable(price.cacheWritePerMTok)}`);
+const describe = (price: DiscoveredPrice): string =>
+  [rateList(price), ...(price.brackets ?? []).map(bracket => `above ${bracket.aboveTokens} ${rateList(bracket)}`)].join(
+    ', '
+  );
+
+const rateList = (rates: DiscoveredRates): string => {
+  const parts = [`in ${readable(rates.inputPerMTok)}`, `out ${readable(rates.outputPerMTok)}`];
+  if (rates.cacheReadPerMTok !== undefined) parts.push(`cache_read ${readable(rates.cacheReadPerMTok)}`);
+  if (rates.cacheWritePerMTok !== undefined) parts.push(`cache_write ${readable(rates.cacheWritePerMTok)}`);
   return `${parts.join('/')} $/MTok`;
 };
 

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
@@ -14,6 +14,7 @@ import type {
   PlannedPriceRow,
   PriceFlag,
   PriceFlagKind,
+  PriceOverride,
   PriceSkip,
   PriceSkipReason,
   SourceContribution,
@@ -110,6 +111,12 @@ export interface PricePlanInput {
 export interface PricePlan {
   rows: IModelPriceInput[];
   flags: PriceFlag[];
+  /**
+   * Models whose price came from a provider over a mirror that disagreed. One
+   * per model, and NOT a subset of `rows`: the provider's value standing
+   * unchanged is the steady state, and the stale mirror is the news either way.
+   */
+  overrides: PriceOverride[];
   /** Usable observations that produced neither a row nor a flag, and why. */
   skipped: PriceSkip[];
 }
@@ -134,6 +141,7 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
 
   const rows: IModelPriceInput[] = [];
   const flags: PriceFlag[] = [];
+  const overrides: PriceOverride[] = [];
   const skipped: PriceSkip[] = [];
   const skip = (modelId: string, reason: PriceSkipReason) => skipped.push({ modelId, reason });
 
@@ -149,19 +157,16 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       continue;
     }
 
-    const disagreeing = firstDisagreement(observations);
-    if (disagreeing) {
+    const consensus = reachConsensus(observations);
+    if (consensus.kind === 'conflict') {
       flags.push({
         modelId,
         kind: 'source-disagreement',
         // One of the two sides the detail names: a third source's value would be
         // a number the operator cannot find anywhere in the sentence.
-        proposed: perMTokOf(disagreeing[0].price),
+        proposed: perMTokOf(consensus.proposed),
         sources,
-        detail:
-          `sources disagree beyond ${pct(PRICE_AGREEMENT_TOLERANCE)}: ` +
-          `${disagreeing[0].source} ${describe(disagreeing[0].price)} vs ${disagreeing[1].source} ` +
-          `${describe(disagreeing[1].price)}; applied neither`,
+        detail: consensus.detail,
       });
       continue;
     }
@@ -174,13 +179,10 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
     const flag = (kind: PriceFlagKind, price: DiscoveredPrice, detail: string) =>
       flags.push({ modelId, kind, proposed: perMTokOf(price), current: currentPrice, sources, detail });
 
-    const provider = observations.find(observation => observation.kind === 'provider');
-    const aggregators = observations.filter(observation => observation.kind === 'aggregator');
-
     // A lone aggregator is corroboration-free, so it never writes. It is worth
     // an operator's attention only when it contradicts what we already bill.
-    if (!provider && aggregators.length < 2) {
-      const lone = aggregators[0];
+    if (consensus.kind === 'lone') {
+      const lone = consensus.observation;
       if (!currentTier) {
         flag(
           'single-source-untrusted',
@@ -201,11 +203,10 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       continue;
     }
 
-    // Trusted: a provider's own API, or aggregators that already passed the
-    // agreement check above. The provider value wins; models.dev leads the
-    // aggregators by registration order, not by name.
-    const trusted = provider ?? aggregators[0];
-    const valueSources = provider ? [provider.source] : aggregators.map(observation => observation.source);
+    // Trusted: a provider's own published price, or aggregators that already
+    // passed the agreement check above. models.dev leads the aggregators by
+    // registration order, not by name.
+    const { observation: trusted, valueSources, corroborating, dissenting } = consensus;
     const proposed = trusted.price;
 
     if (current && classifyPriceRow(current) === 'operator') {
@@ -228,6 +229,30 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
     // unpriced at run start falls back to the row in force, which is one this run
     // wrote - its first write had nothing to band against either.
     const bandRow = atRunStart.get(modelId) ?? current;
+
+    // A ladder needs a corroborator that publishes a ladder, not just one that
+    // agrees on the short-prompt price. diverges() is deliberately silent when
+    // only ONE side carries brackets, so a mirror that went flat would otherwise
+    // corroborate the base rates and let the upper bracket be written on a single
+    // scrape's word. Checked here rather than in reachConsensus because a flat row
+    // in force discards the brackets anyway - refusing there would block writes
+    // whose ladder was never going to be used.
+    const ladderUncorroborated =
+      proposed.brackets !== undefined &&
+      current !== undefined &&
+      isTiered(current) &&
+      corroborating.length > 0 &&
+      !corroborating.some(observation => observation.price.brackets !== undefined);
+    if (ladderUncorroborated) {
+      flag(
+        'tiered-pricing-manual',
+        proposed,
+        `${trusted.source} publishes ${describe(proposed)} but ` +
+          `${corroborating.map(observation => observation.source).join(', ')} publish no long-context rates to ` +
+          'corroborate its brackets; repricing a tiered row needs a second source that carries the same ladder'
+      );
+      continue;
+    }
 
     // The read path REPLACES the whole pricing map, so a tiered row may only be
     // superseded by a write that reproduces every tier. That needs a ladder the
@@ -273,6 +298,27 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       continue;
     }
 
+    // Recorded wherever the provider's value STANDS - both when it is written and
+    // when the row in force already says it. Every refusal above is reported as
+    // its own flag, so this cannot double-report one; but 'unchanged' is the
+    // STEADY STATE once the catalog converges, and that is exactly when "which
+    // mirror has gone stale" is the only fact left to learn.
+    if (dissenting.length > 0) {
+      overrides.push({
+        modelId,
+        source: trusted.source,
+        dissenting: dissenting.map(observation => observation.source),
+        applied: perMTokOf(proposed),
+        // Present tense, like every flag detail: this planner runs identically in
+        // report mode, where nothing is written, so a sentence claiming a write
+        // would be false on the default run.
+        detail:
+          `${trusted.source} publishes ${describe(proposed)} and ` +
+          `${dissenting.map(observation => `${observation.source} ${describe(observation.price)}`).join(', ')} ` +
+          `disagree beyond ${pct(PRICE_AGREEMENT_TOLERANCE)}; the provider value wins`,
+      });
+    }
+
     // Carried forward per tier: the cache and audio rates no feed publishes come
     // from the tier under the SAME threshold, never from the row's lowest one.
     const tiers = planned.map(({ key, price }) => [key, buildTier(price, current?.pricing[key])] as const);
@@ -300,7 +346,7 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
     });
   }
 
-  return { rows, flags, skipped };
+  return { rows, flags, overrides, skipped };
 }
 
 /** One model's comparable cost: the lowest tier's rates, in USD per single token. */
@@ -422,6 +468,101 @@ function usableBrackets(brackets: readonly DiscoveredPriceBracket[] | undefined)
     usable.push({ aboveTokens, ...usableRates(bracket) });
   }
   return usable;
+}
+
+/**
+ * What this run's sources add up to for one model.
+ *
+ * 'conflict' carries the sentence rather than the pair, because the two ways to
+ * reach it read differently to an operator: mirrors that contradict each other,
+ * and mirrors that all contradict the provider.
+ */
+type Consensus =
+  | { kind: 'conflict'; proposed: DiscoveredPrice; detail: string }
+  | { kind: 'lone'; observation: PriceObservation }
+  | {
+      kind: 'trusted';
+      observation: PriceObservation;
+      /** Credited in the row's note: the sources whose value it is. */
+      valueSources: string[];
+      /** Aggregators that agree with a provider; empty in every other case. */
+      corroborating: PriceObservation[];
+      /** Sources overruled by a provider, empty in every other case. */
+      dissenting: PriceObservation[];
+    };
+
+/**
+ * A PROVIDER'S OWN PUBLISHED PRICE IS PRIMARY. WHERE MIRRORS EXIST, one of them
+ * has to agree with it - but not all of them, and the ones that disagree are
+ * recorded and overruled rather than allowed to veto. A provider no aggregator
+ * prices at all still writes alone, which is what it has always done; that is a
+ * standing property of a provider source, not something this rule grants.
+ *
+ * That asymmetry is the whole point. The two aggregators are mirrors of the
+ * provider, and a mirror goes stale on its own schedule: litellm publishes from a
+ * git ref that lags, models.dev re-scrapes on its own cadence. Requiring all of
+ * them to agree hands any one of them a veto over a price the provider itself
+ * publishes, which is how an 80% price cut can keep billing at the old rate until
+ * the slowest mirror catches up.
+ *
+ * With no provider price, nothing here changed: the aggregators are all we have,
+ * so they must agree with each other and there must be at least two of them.
+ */
+function reachConsensus(observations: readonly PriceObservation[]): Consensus {
+  const providers = observations.filter(observation => observation.kind === 'provider');
+  const aggregators = observations.filter(observation => observation.kind === 'aggregator');
+
+  // No provider outranks another, so two of them pricing one model must agree.
+  // Nothing registers two providers for one id today; this is what happens if
+  // something ever does, rather than an arbitrary first-one-wins.
+  const providerConflict = firstDisagreement(providers);
+  if (providerConflict) return conflict(providerConflict, 'mutual');
+
+  const provider = providers[0];
+  if (!provider) {
+    const aggregatorConflict = firstDisagreement(aggregators);
+    if (aggregatorConflict) return conflict(aggregatorConflict, 'mutual');
+    if (aggregators.length < 2) return { kind: 'lone', observation: aggregators[0] };
+    return {
+      kind: 'trusted',
+      observation: aggregators[0],
+      valueSources: aggregators.map(observation => observation.source),
+      corroborating: [],
+      dissenting: [],
+    };
+  }
+
+  const agrees = (observation: PriceObservation) =>
+    !diverges(provider.price, observation.price, PRICE_AGREEMENT_TOLERANCE);
+  const corroborating = aggregators.filter(agrees);
+  const dissenting = aggregators.filter(observation => !agrees(observation));
+  // Primary, not unaccountable: where mirrors exist, one of them has to back the
+  // provider up. All of them dissenting is the shape of a parser that broke
+  // against a docs restructure, which is exactly what must not reprice anything.
+  if (aggregators.length > 0 && corroborating.length === 0) {
+    return conflict([provider, dissenting[0]], 'uncorroborated');
+  }
+  return { kind: 'trusted', observation: provider, valueSources: [provider.source], corroborating, dissenting };
+}
+
+/**
+ * The refusal, in the operator's terms. 'mutual' is two sources of equal standing
+ * contradicting each other; 'uncorroborated' is a provider price that nothing
+ * backs up. Passed in rather than inferred from the pair, because two providers
+ * disagreeing is 'mutual' even though both sides are providers.
+ */
+function conflict([left, right]: [PriceObservation, PriceObservation], reason: 'mutual' | 'uncorroborated'): Consensus {
+  const opening =
+    reason === 'uncorroborated'
+      ? `no source corroborates the provider within ${pct(PRICE_AGREEMENT_TOLERANCE)}`
+      : `sources disagree beyond ${pct(PRICE_AGREEMENT_TOLERANCE)}`;
+  return {
+    kind: 'conflict',
+    proposed: left.price,
+    detail:
+      `${opening}: ${left.source} ${describe(left.price)} vs ${right.source} ${describe(right.price)}; ` +
+      'applied neither',
+  };
 }
 
 /** The first pair that disagrees, so the flag can name both sides. */

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
@@ -589,13 +589,14 @@ function firstDisagreement(observations: readonly PriceObservation[]): [PriceObs
  */
 function diverges(a: DiscoveredPrice, b: DiscoveredPrice, tolerance: number): boolean {
   if (ratesDiverge(a, b, tolerance)) return true;
-  const left = a.brackets;
-  const right = b.brackets;
-  if (!left || !right) return false;
-  if (left.length !== right.length) return true;
+
+  const left = a.brackets ?? [];
+  const right = b.brackets ?? [];
+  // Brackets change the priced shape; a ladder observed by only one side is not corroborated.
+  if (left.length !== right.length) return left.length > 0 || right.length > 0;
+
   return left.some(
-    (bracket, index) =>
-      bracket.aboveTokens !== right[index].aboveTokens || ratesDiverge(bracket, right[index], tolerance)
+    (bracket, index) => bracket.aboveTokens !== right[index].aboveTokens || ratesDiverge(bracket, right[index], tolerance)
   );
 }
 

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
@@ -590,10 +590,16 @@ function firstDisagreement(observations: readonly PriceObservation[]): [PriceObs
 function diverges(a: DiscoveredPrice, b: DiscoveredPrice, tolerance: number): boolean {
   if (ratesDiverge(a, b, tolerance)) return true;
 
-  const left = a.brackets ?? [];
-  const right = b.brackets ?? [];
-  // Brackets change the priced shape; a ladder observed by only one side is not corroborated.
-  if (left.length !== right.length) return left.length > 0 || right.length > 0;
+  const left = a.brackets;
+  const right = b.brackets;
+  // A ladder only one side publishes is silence, NOT divergence - deliberately, and it is
+  // load-bearing. An uncorroborated ladder is refused by the ladderUncorroborated check in
+  // planPriceWrites, which fires only when the row in force is already tiered. Repeating that
+  // judgement here would also block a FLAT row from taking the base rates, a write whose
+  // brackets get discarded anyway. Both are covered by tests; if a static analyzer suggests
+  // treating a one-sided ladder as divergence, that is the case it is missing.
+  if (!left || !right) return false;
+  if (left.length !== right.length) return true;
 
   return left.some(
     (bracket, index) => bracket.aboveTokens !== right[index].aboveTokens || ratesDiverge(bracket, right[index], tolerance)

--- a/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.test.ts
@@ -12,7 +12,12 @@ import {
   testCredentials,
   testRecord,
 } from './__fixtures__/fakes';
-import { DISCOVERY_LEASE_KEY, MAX_DISCOVERY_PASSES, runModelDiscovery } from './runModelDiscovery';
+import {
+  DISCOVERY_LEASE_KEY,
+  MAX_DISCOVERY_PASSES,
+  MAX_PERSISTED_RUN_DETAIL,
+  runModelDiscovery,
+} from './runModelDiscovery';
 import type {
   DiscoveredModel,
   DiscoveryLogger,
@@ -153,6 +158,19 @@ describe('runModelDiscovery', () => {
     expect(result.diff[0]).toMatchObject({ modelId: 'gpt-6', kind: 'added', promoted: true });
     // The run report itself is always written: it is how the diff is read.
     expect(reporting.runs.docs).toHaveLength(1);
+    // On the document, not inferred from the setting at read time: the plan below
+    // it counts rows this run deliberately did not write, and a reader with no
+    // mode cannot tell that from a write run whose appends all threw.
+    expect(reporting.runs.docs[0]).toMatchObject({ mode: 'report', changes: { plannedPriceRows: 1 } });
+    expect(reporting.runs.docs[0].changes?.appendedPriceRows).toBe(0);
+  });
+
+  it('records the mode it ran in from the moment the run document exists', async () => {
+    // Written at creation rather than at the final update, so a run killed
+    // mid-flight still says what it was allowed to do.
+    await runModelDiscovery(bench.adapters, bench.options);
+
+    expect(bench.runs.docs[0].mode).toBe('write');
   });
 
   it('defaults to report mode when the setting is unset', async () => {
@@ -432,6 +450,18 @@ describe('runModelDiscovery', () => {
         expect(result.lifecycle.wouldDeprecate).toEqual(['gpt-6']);
         expect(result.metrics.ModelsDeprecated).toBe(1);
         expect(bench.runs.docs[3].changes?.deprecated).toEqual(['gpt-6']);
+        // The count says one model moved; only the transition says from what, on
+        // what signal, and with which dates.
+        expect(bench.runs.docs[3].lifecycleTransitions).toEqual([
+          {
+            modelId: 'gpt-6',
+            from: 'active',
+            to: 'deprecated',
+            signal: 'absence',
+            deprecationDate: '2026-07-29',
+            autoApplied: false,
+          },
+        ]);
         expect(bench.catalog.rows).toHaveLength(2);
         expect(bench.catalog.rows[1].patch).toMatchObject({
           id: 'gpt-6',
@@ -711,8 +741,8 @@ describe('runModelDiscovery', () => {
     });
 
     it('flags a move beyond the band under its own log prefix and applies nothing', async () => {
-      // $8/MTok in force against the $2 the source reports: a 75% cut, past
-      // the 50% default band.
+      // $8/MTok in force against the $2 the source reports: a 4x cut, which the
+      // band scores as 300%, past the 50% default.
       await seedPrice(bench, { input: 8e-6, output: 8e-6 });
 
       const result = await runModelDiscovery(bench.adapters, bench.options);
@@ -725,7 +755,8 @@ describe('runModelDiscovery', () => {
     });
 
     it('honors a widened band from the admin setting', async () => {
-      const wide = harness([openaiSource()], { modelDiscoveryPriceBandPct: 90 });
+      // The same 4x cut, applied unattended only by a band that admits 4x.
+      const wide = harness([openaiSource()], { modelDiscoveryPriceBandPct: 400 });
       await seedPrice(wide, { input: 8e-6, output: 8e-6 });
 
       const result = await runModelDiscovery(wide.adapters, wide.options);
@@ -1065,6 +1096,122 @@ describe('runModelDiscovery', () => {
       expect(hung.catalog.rows).toHaveLength(1);
       expect(result.passes).toBe(1);
       expect(result.outcome).toBe('partial');
+    });
+  });
+
+  describe('the persisted run report', () => {
+    const gpt6mini: DiscoveredModel = {
+      ...gpt6,
+      modelId: 'gpt-6-mini',
+      patch: { ...gpt6.patch, id: 'gpt-6-mini', name: 'GPT-6 mini' },
+    };
+
+    /** An operator row for the model, which is what makes the run report a conflict. */
+    const pinByOperator = (harnessed: Harness, modelId: string) =>
+      harnessed.catalog.append({
+        modelId,
+        source: 'operator',
+        patch: { rank: 5 },
+        ownedGroups: ['presentation'],
+        note: 'pinned by an operator',
+        effectiveFrom: new Date(START.getTime() - 60_000),
+      });
+
+    it('carries the sentence behind each price flag, and the operator overlaps apart from them', async () => {
+      const reported = harness([openaiSource([gpt6, gpt6mini])]);
+      await pinByOperator(reported, 'gpt-6-mini');
+      // $8/MTok in force against the $2 the source reports: past the 50% band.
+      await reported.prices.append({
+        modelId: 'gpt-6',
+        unit: 'per_token',
+        pricing: { '0': { input: 8e-6, output: 8e-6 } },
+        effectiveFrom: new Date(START.getTime() - 60_000),
+        note: 'adapter-seed',
+      });
+
+      const result = await runModelDiscovery(reported.adapters, reported.options);
+      const persisted = reported.runs.docs[0];
+
+      expect(persisted.priceFlags).toHaveLength(1);
+      expect(persisted.priceFlags?.[0]).toMatchObject({
+        modelId: 'gpt-6',
+        kind: 'band-exceeded',
+        proposed: { inputPerMTok: 2, outputPerMTok: 8 },
+        current: { inputPerMTok: 8, outputPerMTok: 8 },
+        sources: ['openai'],
+      });
+      // The explanation is what the flags are persisted for: it used to reach
+      // logger.warn and nowhere else, leaving "1 flagged" unanswerable.
+      expect(persisted.priceFlags?.[0].detail).toBe(result.prices.flags[0].detail);
+      expect(persisted.priceFlags?.[0].detail).toContain('band 50%');
+      // One queue for the operator, but the merged array cannot say which half of
+      // it a model came from.
+      expect(persisted.changes?.flagged).toEqual(['gpt-6-mini', 'gpt-6']);
+      expect(persisted.changes?.operatorConflicts).toEqual(['gpt-6-mini']);
+      expect(persisted.catalogDiff?.find(entry => entry.modelId === 'gpt-6-mini')).toMatchObject({
+        kind: 'added',
+        operatorOwned: true,
+      });
+      // A planned row keeps its Date across the boundary; the schema stores a date.
+      expect(persisted.priceRows).toHaveLength(1);
+      expect(persisted.priceRows?.[0]).toMatchObject({
+        modelId: 'gpt-6-mini',
+        unit: 'per_token',
+        inputPerMTok: 2,
+        outputPerMTok: 8,
+        sources: ['openai'],
+      });
+      expect(persisted.priceRows?.[0].effectiveFrom).toEqual(START);
+    });
+
+    it('records the skips a rerun produces in place of a row', async () => {
+      await runModelDiscovery(bench.adapters, bench.options);
+      bench.advance(60_000);
+
+      await runModelDiscovery(bench.adapters, bench.options);
+
+      // A run that planned no price row reads exactly like a run that saw no
+      // price at all until the skip says which model and why.
+      expect(bench.runs.docs[1].priceRows).toEqual([]);
+      expect(bench.runs.docs[1].priceSkips).toEqual([{ modelId: 'gpt-6', reason: 'unchanged' }]);
+    });
+
+    it('bounds every detail array, so one wide run cannot grow the document without limit', async () => {
+      const overflow = MAX_PERSISTED_RUN_DETAIL + 50;
+      const many: DiscoveredModel[] = Array.from({ length: overflow }, (_unused, index) => ({
+        ...gpt6,
+        modelId: `gpt-6-${index}`,
+        patch: { ...gpt6.patch, id: `gpt-6-${index}`, name: `GPT-6 ${index}` },
+      }));
+      const wide = harness([openaiSource(many)]);
+
+      const result = await runModelDiscovery(wide.adapters, wide.options);
+      const persisted = wide.runs.docs[0];
+
+      // The result is the caller's, unbounded; the document the admin reads whole
+      // is not.
+      expect(result.diff).toHaveLength(overflow);
+      expect(result.prices.rows).toHaveLength(overflow);
+      expect(persisted.catalogDiff).toHaveLength(MAX_PERSISTED_RUN_DETAIL);
+      expect(persisted.priceRows).toHaveLength(MAX_PERSISTED_RUN_DETAIL);
+      // The convergence pass re-read the prices it wrote and skipped every one.
+      expect(persisted.priceSkips).toHaveLength(MAX_PERSISTED_RUN_DETAIL);
+      // What each slice was cut from. The `changes` ids are uncapped, so without
+      // these the report shows 250 flagged in the header and 200 in the section.
+      expect(persisted.detailTotals).toEqual({
+        catalogDiff: overflow,
+        priceRows: overflow,
+        priceSkips: overflow,
+      });
+      // Only the truncated arrays: an untouched one would report a total equal to
+      // what is stored, which says nothing.
+      expect(persisted.detailTotals?.priceFlags).toBeUndefined();
+    });
+
+    it('leaves the totals off entirely when every detail array fit', async () => {
+      await runModelDiscovery(bench.adapters, bench.options);
+
+      expect(bench.runs.docs[0].detailTotals).toBeUndefined();
     });
   });
 

--- a/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.test.ts
@@ -1164,6 +1164,38 @@ describe('runModelDiscovery', () => {
       expect(persisted.priceRows?.[0].effectiveFrom).toEqual(START);
     });
 
+    it('records the mirror a provider price was written over', async () => {
+      const stale = harness([
+        openaiSource(),
+        stubSource({
+          name: 'models.dev',
+          kind: 'aggregator',
+          records: [{ modelId: 'gpt-6', patch: {}, pricing: { inputPerMTok: 2, outputPerMTok: 8 } }],
+        }),
+        stubSource({
+          name: 'litellm',
+          kind: 'aggregator',
+          records: [{ modelId: 'gpt-6', patch: {}, pricing: { inputPerMTok: 8, outputPerMTok: 32 } }],
+        }),
+      ]);
+
+      const result = await runModelDiscovery(stale.adapters, stale.options);
+      const persisted = stale.runs.docs[0];
+
+      expect(persisted.priceRows).toHaveLength(1);
+      expect(persisted.priceFlags).toEqual([]);
+      // "litellm is 4x off for gpt-6" is the operational fact here, and it would
+      // be invisible if the write simply succeeded quietly.
+      expect(persisted.priceOverrides).toHaveLength(1);
+      expect(persisted.priceOverrides?.[0]).toMatchObject({
+        modelId: 'gpt-6',
+        source: 'openai',
+        dissenting: ['litellm'],
+        applied: { inputPerMTok: 2, outputPerMTok: 8 },
+      });
+      expect(persisted.priceOverrides?.[0].detail).toBe(result.prices.overrides[0].detail);
+    });
+
     it('records the skips a rerun produces in place of a row', async () => {
       await runModelDiscovery(bench.adapters, bench.options);
       bench.advance(60_000);

--- a/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.ts
+++ b/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.ts
@@ -4,6 +4,7 @@ import {
   type FieldGroup,
   type ICatalogContributor,
   type IDiscoveryJoinCoverage,
+  type IDiscoveryRunDetailTotals,
   type IDiscoverySourceReport,
   type IModelDiscoveryRun,
   type IModelDiscoveryRunDocument,
@@ -44,6 +45,7 @@ import type {
   ModelDiscoveryMetrics,
   ModelDiscoveryRunResult,
   PriceFlag,
+  PriceSkip,
   RunModelDiscoveryOptions,
   SourceResult,
   SourceSkipReason,
@@ -103,6 +105,13 @@ const LOG_PREFIX = '[model-discovery]';
  * would put an unbounded array on a document the admin card reads whole.
  */
 export const MAX_PERSISTED_DROPPED_RECORDS = 200;
+
+/**
+ * Per-model detail kept on the run document, for the same reason: it is a
+ * bounded trace on a document the admin reads whole, and a run that touches
+ * every model would otherwise put thousands of entries on it.
+ */
+export const MAX_PERSISTED_RUN_DETAIL = 200;
 
 /** Its own prefix (sec 10) so a flagged price move alarms without a log filter. */
 const PRICE_BAND_PREFIX = '[PRICE_BAND]';
@@ -213,12 +222,15 @@ async function executeRun(
 
   // The run document is created up front because every appended row carries its
   // id. 'failed' is the pessimistic placeholder: a run that never reaches the
-  // final update must not read as ok or partial.
+  // final update must not read as ok or partial. `mode` is written here too: a
+  // report-mode run plans writes and lands none by design, so a reader with no
+  // mode on the document cannot tell it from a write run whose appends threw.
   const run = await db.discoveryRuns.create({
     startedAt,
     trigger: options.trigger,
     host: options.host,
     status: 'failed',
+    mode: ctx.mode,
   } as Omit<IModelDiscoveryRunDocument, 'id' | 'createdAt' | 'updatedAt'>);
   const runId = run.id;
 
@@ -387,6 +399,7 @@ async function executeRun(
   const deprecated = [...new Set(merged.transitions.map(transition => transition.modelId))];
   const sourceReports = [...results.values()].map(entry => entry.report);
   const finishedAt = ctx.now();
+  const plannedPrices = describePriceRows(merged.priceRows);
 
   logPriceFlags(merged.priceFlags, logger);
   logLifecycle(merged, logger);
@@ -407,6 +420,9 @@ async function executeRun(
       // Operator overlaps and price flags are one queue: both are "a human has
       // to look at this model", which is what report mode exists to surface.
       flagged: [...new Set([...summary.operatorConflicts, ...merged.priceFlags.map(flag => flag.modelId)])],
+      // The same overlaps on their own, because the merged array cannot say which
+      // half of the queue a model came from.
+      operatorConflicts: [...new Set(summary.operatorConflicts)],
       plannedRows: merged.plannedRows,
       appendedRows: merged.appended,
       plannedPriceRows: merged.plannedPriceRows,
@@ -414,6 +430,23 @@ async function executeRun(
     },
     passes: passes.length,
     droppedRecords: merged.droppedRecords.slice(0, MAX_PERSISTED_DROPPED_RECORDS),
+    // The detail behind the counts above, every array bounded. Without it the
+    // admin reads a flag count with no way to learn which models or why.
+    priceFlags: merged.priceFlags.slice(0, MAX_PERSISTED_RUN_DETAIL),
+    priceRows: plannedPrices.slice(0, MAX_PERSISTED_RUN_DETAIL),
+    priceSkips: merged.priceSkips.slice(0, MAX_PERSISTED_RUN_DETAIL),
+    lifecycleTransitions: merged.transitions.slice(0, MAX_PERSISTED_RUN_DETAIL),
+    catalogDiff: merged.diff.slice(0, MAX_PERSISTED_RUN_DETAIL),
+    // What those slices were cut from, so a reader shows "the first 200 of 260"
+    // instead of a cap that looks like the whole set. The change-id arrays above
+    // are uncapped, so the two would otherwise disagree with no marker anywhere.
+    ...truncatedTotals({
+      priceFlags: merged.priceFlags.length,
+      priceRows: plannedPrices.length,
+      priceSkips: merged.priceSkips.length,
+      lifecycleTransitions: merged.transitions.length,
+      catalogDiff: merged.diff.length,
+    }),
   } as Partial<IModelDiscoveryRunDocument>);
 
   logger.info(
@@ -434,7 +467,7 @@ async function executeRun(
     diff: merged.diff,
     droppedRecords: merged.droppedRecords,
     absence: passes[0].plan.absence,
-    prices: { rows: describePriceRows(merged.priceRows), flags: merged.priceFlags },
+    prices: { rows: plannedPrices, flags: merged.priceFlags },
     lifecycle: {
       transitions: merged.transitions,
       dateChanges: merged.dateChanges,
@@ -630,6 +663,7 @@ interface RunAggregate {
   droppedRecords: DroppedSourceRecord[];
   priceRows: IModelPriceInput[];
   priceFlags: PriceFlag[];
+  priceSkips: PriceSkip[];
   transitions: LifecycleTransition[];
   dateChanges: LifecycleDateChange[];
   suggestions: LifecycleSuggestion[];
@@ -671,6 +705,10 @@ function aggregate(passes: readonly CompletedPass[]): RunAggregate {
     priceFlags: lastPerKey(
       plans.flatMap(plan => plan.prices.flags),
       flag => `${flag.modelId} ${flag.kind}`
+    ),
+    priceSkips: lastPerKey(
+      plans.flatMap(plan => plan.prices.skipped),
+      skip => `${skip.modelId} ${skip.reason}`
     ),
     transitions: plans.flatMap(plan => plan.lifecycle.transitions),
     dateChanges: plans.flatMap(plan => plan.lifecycle.dateChanges),
@@ -722,6 +760,19 @@ function lastPerKey<T>(items: readonly T[], keyOf: (item: T) => string): T[] {
   const byKey = new Map<string, T>();
   for (const item of items) byKey.set(keyOf(item), item);
   return [...byKey.values()];
+}
+
+/**
+ * The `detailTotals` patch, or nothing when every array fit inside the cap. Only
+ * the truncated ones are recorded: a total equal to what is stored says nothing,
+ * and omitting the field keeps an ordinary run's document as it was.
+ */
+function truncatedTotals(counts: Required<IDiscoveryRunDetailTotals>): { detailTotals?: IDiscoveryRunDetailTotals } {
+  const totals: IDiscoveryRunDetailTotals = {};
+  for (const [key, total] of Object.entries(counts) as Array<[keyof IDiscoveryRunDetailTotals, number]>) {
+    if (total > MAX_PERSISTED_RUN_DETAIL) totals[key] = total;
+  }
+  return Object.keys(totals).length > 0 ? { detailTotals: totals } : {};
 }
 
 async function appendRows(

--- a/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.ts
+++ b/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.ts
@@ -45,6 +45,7 @@ import type {
   ModelDiscoveryMetrics,
   ModelDiscoveryRunResult,
   PriceFlag,
+  PriceOverride,
   PriceSkip,
   RunModelDiscoveryOptions,
   SourceResult,
@@ -434,6 +435,7 @@ async function executeRun(
     // admin reads a flag count with no way to learn which models or why.
     priceFlags: merged.priceFlags.slice(0, MAX_PERSISTED_RUN_DETAIL),
     priceRows: plannedPrices.slice(0, MAX_PERSISTED_RUN_DETAIL),
+    priceOverrides: merged.priceOverrides.slice(0, MAX_PERSISTED_RUN_DETAIL),
     priceSkips: merged.priceSkips.slice(0, MAX_PERSISTED_RUN_DETAIL),
     lifecycleTransitions: merged.transitions.slice(0, MAX_PERSISTED_RUN_DETAIL),
     catalogDiff: merged.diff.slice(0, MAX_PERSISTED_RUN_DETAIL),
@@ -443,6 +445,7 @@ async function executeRun(
     ...truncatedTotals({
       priceFlags: merged.priceFlags.length,
       priceRows: plannedPrices.length,
+      priceOverrides: merged.priceOverrides.length,
       priceSkips: merged.priceSkips.length,
       lifecycleTransitions: merged.transitions.length,
       catalogDiff: merged.diff.length,
@@ -467,7 +470,7 @@ async function executeRun(
     diff: merged.diff,
     droppedRecords: merged.droppedRecords,
     absence: passes[0].plan.absence,
-    prices: { rows: plannedPrices, flags: merged.priceFlags },
+    prices: { rows: plannedPrices, flags: merged.priceFlags, overrides: merged.priceOverrides },
     lifecycle: {
       transitions: merged.transitions,
       dateChanges: merged.dateChanges,
@@ -663,6 +666,7 @@ interface RunAggregate {
   droppedRecords: DroppedSourceRecord[];
   priceRows: IModelPriceInput[];
   priceFlags: PriceFlag[];
+  priceOverrides: PriceOverride[];
   priceSkips: PriceSkip[];
   transitions: LifecycleTransition[];
   dateChanges: LifecycleDateChange[];
@@ -705,6 +709,13 @@ function aggregate(passes: readonly CompletedPass[]): RunAggregate {
     priceFlags: lastPerKey(
       plans.flatMap(plan => plan.prices.flags),
       flag => `${flag.modelId} ${flag.kind}`
+    ),
+    // One per model, newest kept. A pass whose append threw leaves the row out
+    // of force, so the next pass re-plans that model and produces the same
+    // override again - and two identical entries would read as two mirrors.
+    priceOverrides: lastPerKey(
+      plans.flatMap(plan => plan.prices.overrides),
+      override => override.modelId
     ),
     priceSkips: lastPerKey(
       plans.flatMap(plan => plan.prices.skipped),
@@ -1192,7 +1203,7 @@ function skippedResult(
     diff: [],
     droppedRecords: [],
     absence: { sighted: [], missed: [], frozenBackends: [] },
-    prices: { rows: [], flags: [] },
+    prices: { rows: [], flags: [], overrides: [] },
     lifecycle: { transitions: [], dateChanges: [], suggestions: [], wouldDeprecate: [] },
     metrics: emptyMetrics(),
     passes: 1,

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/litellm/expected.json
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/litellm/expected.json
@@ -112,7 +112,16 @@
     "pricing": {
       "inputPerMTok": 2,
       "outputPerMTok": 12,
-      "cacheReadPerMTok": 0.19999999999999998
+      "cacheReadPerMTok": 0.19999999999999998,
+      "brackets": [
+        {
+          "aboveTokens": 200000,
+          "inputPerMTok": 4,
+          "outputPerMTok": 18,
+          "cacheReadPerMTok": 0.39999999999999997,
+          "cacheWritePerMTok": 0.25
+        }
+      ]
     }
   },
   {
@@ -201,7 +210,15 @@
     "pricing": {
       "inputPerMTok": 2,
       "outputPerMTok": 6,
-      "cacheReadPerMTok": 0.5
+      "cacheReadPerMTok": 0.5,
+      "brackets": [
+        {
+          "aboveTokens": 200000,
+          "inputPerMTok": 4,
+          "outputPerMTok": 12,
+          "cacheReadPerMTok": 1
+        }
+      ]
     }
   },
   {

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/modelsDev/expected.json
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/modelsDev/expected.json
@@ -76,7 +76,15 @@
     "pricing": {
       "inputPerMTok": 1.25,
       "outputPerMTok": 10,
-      "cacheReadPerMTok": 0.125
+      "cacheReadPerMTok": 0.125,
+      "brackets": [
+        {
+          "aboveTokens": 200000,
+          "inputPerMTok": 2.5,
+          "outputPerMTok": 15,
+          "cacheReadPerMTok": 0.25
+        }
+      ]
     }
   },
   {
@@ -99,7 +107,15 @@
     "pricing": {
       "inputPerMTok": 2,
       "outputPerMTok": 12,
-      "cacheReadPerMTok": 0.2
+      "cacheReadPerMTok": 0.2,
+      "brackets": [
+        {
+          "aboveTokens": 200000,
+          "inputPerMTok": 4,
+          "outputPerMTok": 18,
+          "cacheReadPerMTok": 0.4
+        }
+      ]
     }
   },
   {
@@ -177,7 +193,15 @@
     "pricing": {
       "inputPerMTok": 2,
       "outputPerMTok": 6,
-      "cacheReadPerMTok": 0.3
+      "cacheReadPerMTok": 0.3,
+      "brackets": [
+        {
+          "aboveTokens": 200000,
+          "inputPerMTok": 4,
+          "outputPerMTok": 12,
+          "cacheReadPerMTok": 1
+        }
+      ]
     }
   },
   {

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/README.txt
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/README.txt
@@ -1,0 +1,24 @@
+pricing.md and the four model-*.md files are LIVE CAPTURES, fetched 2026-07-31
+from platform.openai.com (which serves a markdown twin of any docs page at
+<path>.md). No row, rate or bullet is edited.
+
+pricing.md is trimmed to the Standard table the parser reads plus four tables it
+must NOT read: Batch and Flex, whose headers are byte-identical to Standard's and
+whose rates are half of it; Fast, which carries only the four short-context
+columns; and a Grouped Pricing table, whose columns are a different shape
+entirely. Picking any of them fails a test.
+
+The model-*.md captures cover the shapes of the long-context breakpoint bullet:
+gpt-5.6-luna and gpt-5.6-sol state it plainly, gpt-5.4 buries it in a longer
+sentence about the family, and gpt-5.4-mini has no long-context pricing and so no
+bullet at all. sol also serves as the wrong page in the test that proves a
+breakpoint is refused unless the page states the model id it was asked for. One
+prose paragraph carrying a curly apostrophe was dropped from each (the repo is
+ASCII-only); it is boilerplate no parser reads.
+
+parser-broke-pricing.md is CONSTRUCTED: the page restructured so the Standard
+heading and the "Short context" column names are gone. It must parse to a
+failure, never to a partial table.
+
+models.json, expected.json and the malformed/empty/unknown-enum variants are the
+/v1/models fixtures and predate this set.

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.4-mini.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.4-mini.md
@@ -1,0 +1,33 @@
+# GPT-5.4 mini
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+> Our strongest mini model yet for coding, computer use, and subagents
+
+Model ID: `gpt-5.4-mini`
+
+GPT-5.4 mini brings the strengths of GPT-5.4 to a faster, more efficient
+model designed for high-volume workloads. Learn more in our
+[Model guidance](/api/docs/guides/latest-model) page. Reasoning.effort supports: none (default), low, medium, high and xhigh.
+
+## Model details
+
+- Default snapshot: `gpt-5.4-mini-2026-03-17`
+- Input modalities: text, image
+- Output modalities: text
+- 400,000 context window
+- Maximum input tokens: 272,000
+- 128,000 max output tokens
+- Aug 31, 2025 knowledge cutoff
+- Reasoning token support
+
+## Pricing
+
+
+### Text tokens
+
+| Metric | Price | Unit |
+| --- | ---: | --- |
+| Input | $0.75 | 1M tokens |
+| Cached input | $0.075 | 1M tokens |
+| Output | $4.5 | 1M tokens |

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.4.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.4.md
@@ -1,0 +1,35 @@
+# GPT-5.4
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+> A more affordable model for coding and professional work.
+
+Model ID: `gpt-5.4`
+
+GPT-5.4 is our frontier model for complex professional work.
+Learn more in our [GPT-5.4 model guidance](/api/docs/guides/latest-model?model=gpt-5.4). Reasoning.effort supports: none (default), low, medium, high and xhigh.
+
+## Model details
+
+- Default snapshot: `gpt-5.4-2026-03-05`
+- Input modalities: text, image
+- Output modalities: text
+- 1,050,000 context window
+- 128,000 max output tokens
+- Aug 31, 2025 knowledge cutoff
+- Reasoning token support
+
+## Pricing
+
+
+### Text tokens
+
+| Metric | Price | Unit |
+| --- | ---: | --- |
+| Input | $2.5 | 1M tokens |
+| Cached input | $0.25 | 1M tokens |
+| Output | $15 | 1M tokens |
+
+- For models with a 1.05M context window (GPT-5.4 and GPT-5.4 Pro), prompts with >272K input tokens are priced at 2x input and 1.5x output for the full session for standard, batch, and flex.
+- Regional processing (data residency) endpoints are charged a 10% uplift for GPT-5.4 and GPT-5.4 Pro.
+

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.6-luna.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.6-luna.md
@@ -1,0 +1,36 @@
+# GPT-5.6 Luna
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+> GPT-5.6 model optimized for cost-sensitive workloads
+
+Model ID: `gpt-5.6-luna`
+
+GPT-5.6 Luna is designed for cost-sensitive, high-volume workloads. It
+roughly corresponds to the nano model tier used in earlier GPT-5 families.
+
+## Model details
+
+- Default snapshot: `gpt-5.6-luna`
+- Input modalities: text, image
+- Output modalities: text
+- 1,050,000 context window
+- Maximum input tokens: 922,000
+- 128,000 max output tokens
+- Feb 16, 2026 knowledge cutoff
+- Reasoning token support
+
+## Pricing
+
+
+### Text tokens
+
+| Metric | Price | Unit |
+| --- | ---: | --- |
+| Input | $0.2 | 1M tokens |
+| Cached input | $0.02 | 1M tokens |
+| Output | $1.2 | 1M tokens |
+
+- Prompts with >272K input tokens are priced at 2x input and 1.5x output for the full request.
+- Cache writes are billed at 1.25x the uncached input token rate.
+

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.6-sol.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.6-sol.md
@@ -1,0 +1,37 @@
+# GPT-5.6 Sol
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+> Frontier model for complex professional work
+
+Model ID: `gpt-5.6-sol`
+
+GPT-5.6 Sol is the frontier model in the GPT-5.6 family. It roughly
+corresponds to the unsuffixed model tier used in earlier GPT-5 families.
+The `gpt-5.6` alias routes requests to GPT-5.6 Sol.
+
+## Model details
+
+- Default snapshot: `gpt-5.6-sol`
+- Input modalities: text, image
+- Output modalities: text
+- 1,050,000 context window
+- Maximum input tokens: 922,000
+- 128,000 max output tokens
+- Feb 16, 2026 knowledge cutoff
+- Reasoning token support
+
+## Pricing
+
+
+### Text tokens
+
+| Metric | Price | Unit |
+| --- | ---: | --- |
+| Input | $5 | 1M tokens |
+| Cached input | $0.5 | 1M tokens |
+| Output | $30 | 1M tokens |
+
+- Prompts with >272K input tokens are priced at 2x input and 1.5x output for the full request.
+- Cache writes are billed at 1.25x the uncached input token rate.
+

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/parser-broke-pricing.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/parser-broke-pricing.md
@@ -1,0 +1,10 @@
+# Pricing
+
+Standard
+
+### Pay-as-you-go rates
+
+| Model | Input | Cached input | Cache writes | Output |
+| --- | --- | --- | --- | --- |
+| gpt-5.6-luna | $0.20 | $0.02 | $0.25 | $1.20 |
+| gpt-5.6-terra | $2.00 | $0.20 | $2.50 | $12.00 |

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/pricing.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/pricing.md
@@ -1,0 +1,130 @@
+# Pricing
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+Flagship models
+
+
+    
+Our latest models
+
+    
+Prices per 1M tokens.
+
+  
+
+
+  
+
+Standard
+
+
+      
+### Standard pricing data
+
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-5.6-sol | $5.00 | $0.50 | $6.25 | $30.00 | $10.00 | $1.00 | $12.50 | $45.00 |
+| gpt-5.6-terra | $2.00 | $0.20 | $2.50 | $12.00 | $4.00 | $0.40 | $5.00 | $18.00 |
+| gpt-5.6-luna | $0.20 | $0.02 | $0.25 | $1.20 | $0.40 | $0.04 | $0.50 | $1.80 |
+| gpt-5.5 (<272K context length) | $5.00 | $0.50 | - | $30.00 | $10.00 | $1.00 | - | $45.00 |
+| gpt-5.5-pro (<272K context length) | $30.00 | - | - | $180.00 | $60.00 | - | - | $270.00 |
+| gpt-5.4 (<272K context length) | $2.50 | $0.25 | - | $15.00 | $5.00 | $0.50 | - | $22.50 |
+| gpt-5.4-mini | $0.75 | $0.075 | - | $4.50 | - | - | - | - |
+| gpt-5.4-nano | $0.20 | $0.02 | - | $1.25 | - | - | - | - |
+| gpt-5.4-pro (<272K context length) | $30.00 | - | - | $180.00 | $60.00 | - | - | $270.00 |
+| gpt-5.2 | $1.75 | $0.175 | - | $14.00 | - | - | - | - |
+| gpt-5.2-pro | $21.00 | - | - | $168.00 | - | - | - | - |
+| gpt-5.1 | $1.25 | $0.125 | - | $10.00 | - | - | - | - |
+| gpt-5 | $1.25 | $0.125 | - | $10.00 | - | - | - | - |
+| gpt-5-mini | $0.25 | $0.025 | - | $2.00 | - | - | - | - |
+| gpt-5-nano | $0.05 | $0.005 | - | $0.40 | - | - | - | - |
+| gpt-5-pro | $15.00 | - | - | $120.00 | - | - | - | - |
+| gpt-4.1 | $2.00 | $0.50 | - | $8.00 | - | - | - | - |
+| gpt-4.1-mini | $0.40 | $0.10 | - | $1.60 | - | - | - | - |
+| gpt-4.1-nano | $0.10 | $0.025 | - | $0.40 | - | - | - | - |
+| gpt-4o | $2.50 | $1.25 | - | $10.00 | - | - | - | - |
+| gpt-4o-2024-05-13 | $5.00 | - | - | $15.00 | - | - | - | - |
+| gpt-4o-mini | $0.15 | $0.075 | - | $0.60 | - | - | - | - |
+| o1 | $15.00 | $7.50 | - | $60.00 | - | - | - | - |
+| o1-pro | $150.00 | - | - | $600.00 | - | - | - | - |
+| o3-pro | $20.00 | - | - | $80.00 | - | - | - | - |
+| o3 | $2.00 | $0.50 | - | $8.00 | - | - | - | - |
+| o4-mini | $1.10 | $0.275 | - | $4.40 | - | - | - | - |
+| o3-mini | $1.10 | $0.55 | - | $4.40 | - | - | - | - |
+| gpt-4-turbo-2024-04-09 | $10.00 | - | - | $30.00 | - | - | - | - |
+| gpt-4-0613 | $30.00 | - | - | $60.00 | - | - | - | - |
+| gpt-3.5-turbo | $0.50 | - | - | $1.50 | - | - | - | - |
+| gpt-3.5-turbo-0125 | $0.50 | - | - | $1.50 | - | - | - | - |
+| gpt-3.5-turbo-1106 | $1.00 | - | - | $2.00 | - | - | - | - |
+| gpt-3.5-turbo-instruct | $1.50 | - | - | $2.00 | - | - | - | - |
+| davinci-002 | $2.00 | - | - | $2.00 | - | - | - | - |
+| babbage-002 | $0.40 | - | - | $0.40 | - | - | - | - |
+
+Regional processing (data residency) endpoints are charged a 10% uplift for models released on or after March 5, 2026, that are eligible for data residency. See our [Your data](https://developers.openai.com/api/docs/guides/your-data) guide for supported regions and processing details. [OpenAI models in Amazon Bedrock](https://developers.openai.com/api/docs/guides/amazon-bedrock) are billed through AWS and may differ from direct OpenAI pricing. Priority processing was renamed Fast mode on July 30, 2026. You can use either `service_tier: "priority"` or `service_tier: "fast"` in your API requests. [Learn more about Fast mode](https://developers.openai.com/api/docs/guides/fast-mode).
+
+    
+
+    
+
+      
+Batch
+
+
+      
+### Batch pricing data
+
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-5.6-sol | $2.50 | $0.25 | $3.125 | $15.00 | $5.00 | $0.50 | $6.25 | $22.50 |
+| gpt-5.6-terra | $1.00 | $0.10 | $1.25 | $6.00 | $2.00 | $0.20 | $2.50 | $9.00 |
+| gpt-5.6-luna | $0.10 | $0.01 | $0.125 | $0.60 | $0.20 | $0.02 | $0.25 | $0.90 |
+| gpt-5.5 (<272K context length) | $2.50 | $0.25 | - | $15.00 | $5.00 | $0.50 | - | $22.50 |
+| gpt-5.5-pro (<272K context length) | $15.00 | - | - | $90.00 | - | - | - | - |
+| gpt-5.4 (<272K context length) | $1.25 | $0.13 | - | $7.50 | $2.50 | $0.25 | - | $11.25 |
+
+      
+Flex
+
+
+      
+### Flex pricing data
+
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-5.6-sol | $2.50 | $0.25 | $3.125 | $15.00 | $5.00 | $0.50 | $6.25 | $22.50 |
+| gpt-5.6-terra | $1.00 | $0.10 | $1.25 | $6.00 | $2.00 | $0.20 | $2.50 | $9.00 |
+| gpt-5.6-luna | $0.10 | $0.01 | $0.125 | $0.60 | $0.20 | $0.02 | $0.25 | $0.90 |
+| gpt-5.5 (<272K context length) | $2.50 | $0.25 | - | $15.00 | $5.00 | $0.50 | - | $22.50 |
+| gpt-5.5-pro (<272K context length) | $15.00 | - | - | $90.00 | - | - | - | - |
+| gpt-5.4 (<272K context length) | $1.25 | $0.13 | - | $7.50 | $2.50 | $0.25 | - | $11.25 |
+
+      
+Fast mode
+
+
+      
+### Fast pricing data
+
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output |
+| --- | --- | --- | --- | --- |
+| gpt-5.6-sol | $10.00 | $1.00 | $12.50 | $60.00 |
+| gpt-5.6-terra | $4.00 | $0.40 | $5.00 | $24.00 |
+| gpt-5.6-luna | $0.40 | $0.04 | $0.50 | $2.40 |
+| gpt-5.5 (<272K context length) | $12.50 | $1.25 | - | $75.00 |
+| gpt-5.4 (<272K context length) | $5.00 | $0.50 | - | $30.00 |
+| gpt-5.4-mini | $1.50 | $0.15 | - | $9.00 |
+
+Prices per 1M tokens unless noted.
+
+
+### Grouped Pricing Table data
+
+| Model | Modality | Input | Cached input | Output / cost |
+| --- | --- | --- | --- | --- |
+| gpt-realtime-2.1 | Audio | $32.00 | $0.40 | $64.00 |
+| gpt-realtime-2.1 | Text | $4.00 | $0.40 | $24.00 |
+| gpt-realtime-2.1 | Image | $5.00 | $0.50 | - |
+| gpt-realtime-2.1-mini | Audio | $10.00 | $0.30 | $20.00 |
+| gpt-realtime-2.1-mini | Text | $0.60 | $0.06 | $2.40 |
+

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/testSupport.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/testSupport.ts
@@ -39,7 +39,8 @@ export interface StubResponse {
   headers?: Record<string, string>;
 }
 
-type Route = (url: string) => StubResponse | undefined;
+/** `init` is passed through so a test can assert what headers a request carried. */
+type Route = (url: string, init?: RequestInit) => StubResponse | undefined;
 
 /**
  * Replace global fetch with a route table. Sources are exercised through their
@@ -52,7 +53,7 @@ export function stubFetch(route: Route | StubResponse): () => void {
   const spy = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     init?.signal?.throwIfAborted();
-    const stub = resolve(url);
+    const stub = resolve(url, init);
     if (!stub) throw new Error(`unstubbed fetch: ${url}`);
     const status = stub.status ?? 200;
     const body = stub.raw ?? JSON.stringify(stub.body ?? {});

--- a/b4m-core/services/src/modelDiscoveryService/sources/anthropicDocs.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/anthropicDocs.ts
@@ -1,24 +1,17 @@
 import type { ModelRecord } from '@bike4mind/common';
+import { parseRate, plain, tables, type ParseResult } from './markdown';
 
 /**
  * Parsers for Anthropic's two published markdown twins: `model-deprecations.md`
  * (the only typed lifecycle feed a direct provider gives us) and `pricing.md`.
  *
- * Both return `{ ok: false }` when they find valid markdown and zero rows. "The
- * page rendered and I found nothing" is the shape of a parser that broke against
- * a docs restructure, not of a provider that retired everything (sec 5.5), and
- * an empty success here would freeze every Claude lifecycle field at once.
+ * Both return `{ ok: false }` when they find valid markdown and zero rows - see
+ * ParseResult in ./markdown for why that is never an empty success.
  */
-export type ParseResult<T> = { ok: true; rows: T[] } | { ok: false; error: string };
+export type { ParseResult };
 
 export const ANTHROPIC_DEPRECATIONS_URL = 'https://docs.claude.com/en/docs/about-claude/model-deprecations.md';
 export const ANTHROPIC_PRICING_URL = 'https://docs.claude.com/en/docs/about-claude/pricing.md';
-
-interface MarkdownTable {
-  heading: string;
-  headers: string[];
-  rows: string[][];
-}
 
 const MONTHS: Readonly<Record<string, string>> = {
   january: '01',
@@ -35,44 +28,6 @@ const MONTHS: Readonly<Record<string, string>> = {
   december: '12',
 };
 
-const cells = (line: string): string[] =>
-  line
-    .replace(/^\s*\|/, '')
-    .replace(/\|\s*$/, '')
-    .split('|')
-    .map(cell => cell.trim());
-
-const isSeparator = (line: string): boolean => /^\s*\|[\s:|-]+\|\s*$/.test(line);
-
-/** Every pipe table in the document, tagged with the nearest preceding heading. */
-function tables(markdown: string): MarkdownTable[] {
-  const lines = markdown.split(/\r?\n/);
-  const found: MarkdownTable[] = [];
-  let heading = '';
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? '';
-    const headingMatch = /^#{1,6}\s+(.*)$/.exec(line);
-    if (headingMatch) {
-      heading = (headingMatch[1] ?? '').trim();
-      continue;
-    }
-    if (!line.trimStart().startsWith('|') || !isSeparator(lines[index + 1] ?? '')) continue;
-
-    const headers = cells(line);
-    const rows: string[][] = [];
-    index += 2;
-    while (index < lines.length && (lines[index] ?? '').trimStart().startsWith('|')) {
-      rows.push(cells(lines[index] ?? ''));
-      index += 1;
-    }
-    index -= 1;
-    found.push({ heading, headers, rows });
-  }
-
-  return found;
-}
-
 /** "June 9, 2027" -> "2027-06-09". Undefined for "N/A", "TBD" and anything else. */
 export function parseLongDate(value: string): string | undefined {
   const match = /([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})/.exec(value);
@@ -80,13 +35,6 @@ export function parseLongDate(value: string): string | undefined {
   if (!match || !month) return undefined;
   return `${match[3]}-${month}-${String(match[2]).padStart(2, '0')}`;
 }
-
-/** Strip inline links and code ticks, keeping the link text: docs pages are MDX. */
-const plain = (value: string): string =>
-  value
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/[`*]/g, '')
-    .trim();
 
 export interface AnthropicLifecycleRow {
   modelId: string;
@@ -173,14 +121,6 @@ export interface AnthropicPriceRow {
   validUntil?: string;
   /** First day this row's rate applies, from a "starting <date>" note. */
   validFrom?: string;
-}
-
-/** "$12.50 / MTok" -> 12.5. Undefined for "N/A" and for anything without a figure. */
-function parseRate(cell: string): number | undefined {
-  const match = /\$\s*([\d,]+(?:\.\d+)?)/.exec(plain(cell));
-  if (!match) return undefined;
-  const value = Number(match[1]?.replace(/,/g, ''));
-  return Number.isFinite(value) ? value : undefined;
 }
 
 /** "Claude Sonnet 5 through August 31, 2026" -> slug + the box that qualifies it. */

--- a/b4m-core/services/src/modelDiscoveryService/sources/index.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/index.ts
@@ -22,4 +22,5 @@ export * from './litellm';
 export * from './modelsDev';
 export * from './ollama';
 export * from './openai';
+export * from './openaiDocs';
 export * from './xai';

--- a/b4m-core/services/src/modelDiscoveryService/sources/litellm.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/litellm.test.ts
@@ -11,8 +11,9 @@ import {
   createLiteLlmSource,
   indexLiteLlm,
   LITELLM_PRICES_URL,
-  LITELLM_RELEASE_TAG,
+  LITELLM_REF,
   normalizeLiteLlm,
+  parseBracketField,
   TOKENS_PER_MTOK,
 } from './litellm';
 
@@ -39,12 +40,51 @@ const byId = (records: ReturnType<typeof normalizeLiteLlm>['records']) =>
   new Map(records.map(record => [record.modelId, record]));
 
 describe('litellm supply chain', () => {
-  it('is pinned to a release tag, never a moving branch', () => {
-    expect(LITELLM_RELEASE_TAG).toMatch(/^v\d+\.\d+\.\d+$/);
-    expect(LITELLM_PRICES_URL).toContain(`/${LITELLM_RELEASE_TAG}/`);
-    for (const moving of ['/main/', '/master/', '/HEAD/', '/refs/heads/']) {
-      expect(LITELLM_PRICES_URL).not.toContain(moving);
-    }
+  it('reads a moving ref, because a snapshot reports the price a provider used to charge', () => {
+    // A release tag froze this feed weeks behind models.dev. The two then disagreed
+    // about every repriced model, the agreement check applied neither, and the old
+    // rate kept billing - so the ref moves and the guardrails do the protecting.
+    expect(LITELLM_REF).toBe('main');
+    expect(LITELLM_PRICES_URL).toContain(`/${LITELLM_REF}/`);
+  });
+
+  it('builds the url from the one constant, so re-pinning is a single edit', () => {
+    expect(LITELLM_PRICES_URL.split('/').filter(Boolean)).toContain(LITELLM_REF);
+    expect(LITELLM_PRICES_URL.endsWith('/model_prices_and_context_window.json')).toBe(true);
+  });
+});
+
+describe('litellm long-context bracket field names', () => {
+  it.each([
+    ['input_cost_per_token_above_272k_tokens', 'inputPerMTok', 272_000],
+    ['output_cost_per_token_above_272k_tokens', 'outputPerMTok', 272_000],
+    ['cache_read_input_token_cost_above_272k_tokens', 'cacheReadPerMTok', 272_000],
+    ['cache_creation_input_token_cost_above_272k_tokens', 'cacheWritePerMTok', 272_000],
+    ['input_cost_per_token_above_128k_tokens', 'inputPerMTok', 128_000],
+    ['output_cost_per_token_above_512k_tokens', 'outputPerMTok', 512_000],
+  ])('reads %s as the %s rate above %i tokens', (field, rate, aboveTokens) => {
+    // The breakpoint comes from the name: 272k here is data, not a constant.
+    expect(parseBracketField(field)).toEqual({ rate, aboveTokens });
+  });
+
+  it.each([
+    // Service tiers of the same bracket, not brackets: pricing one of them as the
+    // long-context rate would overcharge or undercharge every long prompt.
+    'input_cost_per_token_above_272k_tokens_priority',
+    'output_cost_per_token_above_272k_tokens_flex',
+    'cache_read_input_token_cost_above_200k_tokens_priority',
+    // A cache-TTL lane, and a compound of a TTL lane with a bracket.
+    'cache_creation_input_token_cost_above_1hr',
+    'cache_creation_input_token_cost_above_1hr_above_200k_tokens',
+    // Units DiscoveredPrice cannot express, bracketed or not.
+    'input_cost_per_character_above_128k_tokens',
+    'input_cost_per_video_per_second_above_15s_interval',
+    // The flat rates themselves, and a breakpoint of zero.
+    'input_cost_per_token',
+    'input_cost_per_token_flex',
+    'input_cost_per_token_above_0k_tokens',
+  ])('rejects %s', field => {
+    expect(parseBracketField(field)).toBeNull();
   });
 });
 
@@ -74,6 +114,61 @@ describe('litellm normalization', () => {
       outputPerMTok: 10,
       cacheReadPerMTok: 0.125,
     });
+  });
+
+  it('carries the long-context bracket, cache rates and all', () => {
+    // xai/grok-4.5 prices above 200k at double its base rate, cache_read included.
+    expect(byId(result.records).get('grok-4.5')?.pricing?.brackets).toEqual([
+      { aboveTokens: 200_000, inputPerMTok: 4, outputPerMTok: 12, cacheReadPerMTok: 1 },
+    ]);
+  });
+
+  it('never mistakes a priority or flex lane for a context bracket', () => {
+    // The fixture's gemini-3-pro-preview carries _above_200k_tokens_priority
+    // variants at double the standard bracket; one bracket is the right answer.
+    const brackets = byId(result.records).get('gemini-3-pro-preview')?.pricing?.brackets;
+    expect(brackets).toHaveLength(1);
+    expect(brackets?.[0]).toMatchObject({ aboveTokens: 200_000, inputPerMTok: 4, outputPerMTok: 18 });
+  });
+
+  it('leaves an entry with no bracket fields flat', () => {
+    expect(byId(result.records).get('gpt-5')?.pricing).not.toHaveProperty('brackets');
+    // claude-opus-4-5 carries cache_creation_input_token_cost_above_1hr, which is a
+    // cache TTL and not a context bracket.
+    expect(byId(result.records).get('claude-opus-4-5-20251101')?.pricing).not.toHaveProperty('brackets');
+  });
+
+  it('drops the whole ladder when a bracket prices only one direction', () => {
+    // Upstream really does this: gemini/gemini-1.5-flash publishes an above-128k
+    // input rate and no output rate. Half a ladder would bill long prompts at the
+    // short-prompt output rate, so the observation goes out flat instead.
+    const half = {
+      'claude-half-ladder': {
+        input_cost_per_token: 1e-6,
+        output_cost_per_token: 5e-6,
+        input_cost_per_token_above_200k_tokens: 2e-6,
+      },
+    };
+    const records = normalizeLiteLlm(half, [{ modelId: 'claude-half-ladder', backend: 'anthropic' }], RUN_AT).records;
+    expect(records[0]?.pricing).toEqual({ inputPerMTok: 1, outputPerMTok: 5 });
+  });
+
+  it('sorts brackets ascending whatever order the fields arrive in', () => {
+    const ladder = {
+      'claude-two-rungs': {
+        input_cost_per_token: 1e-6,
+        output_cost_per_token: 5e-6,
+        input_cost_per_token_above_512k_tokens: 4e-6,
+        output_cost_per_token_above_512k_tokens: 20e-6,
+        input_cost_per_token_above_200k_tokens: 2e-6,
+        output_cost_per_token_above_200k_tokens: 10e-6,
+      },
+    };
+    const records = normalizeLiteLlm(ladder, [{ modelId: 'claude-two-rungs', backend: 'anthropic' }], RUN_AT).records;
+    expect(records[0]?.pricing?.brackets).toEqual([
+      { aboveTokens: 200_000, inputPerMTok: 2, outputPerMTok: 10 },
+      { aboveTokens: 512_000, inputPerMTok: 4, outputPerMTok: 20 },
+    ]);
   });
 
   it('joins FLUX and Whisper but carries no price, because theirs is not per token', () => {
@@ -173,7 +268,7 @@ describe('litellm source fetch', () => {
     expect(createLiteLlmSource({ targets }).isConfigured({} as never, {})).toBe(true);
   });
 
-  it('fetches the pinned tag and records a content hash', async () => {
+  it('fetches the ref and records the content hash that is its audit trail', async () => {
     const calls: string[] = [];
     const restore = stubFetch(url => {
       calls.push(url);

--- a/b4m-core/services/src/modelDiscoveryService/sources/litellm.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/litellm.ts
@@ -2,6 +2,7 @@ import type {
   DiscoveredModel,
   DiscoveredPatch,
   DiscoveredPrice,
+  DiscoveredPriceBracket,
   DiscoveryFetchContext,
   DiscoverySource,
   SourceResult,
@@ -10,14 +11,27 @@ import { isEmptyDocument, joinTargets, logCoverage, type AggregatorSourceOptions
 import { boolean, compact, contentHashOf, count, fetchJson } from './http';
 
 /**
- * PINNED TO A RELEASE TAG, NEVER `main` (sec 6.5). This file is third-party data
- * fetched on a schedule and turned into prices; reading it from a moving branch
- * would mean an unreviewed upstream commit can reprice the catalog between two
- * runs. Bumping this constant is the review.
+ * The git ref the price blob is read from. A MOVING ref on purpose: a release tag
+ * is an immutable snapshot, and a snapshot that is weeks behind reports the price
+ * a provider used to charge. Two feeds then disagree about the same model, the
+ * agreement check applies neither, and the stale rate keeps billing - which is
+ * exactly the failure this constant used to cause.
+ *
+ * What protects the catalog is not the ref: no single aggregator can write a price
+ * (a lone one only ever raises a flag), the two aggregators must agree within
+ * PRICE_AGREEMENT_TOLERANCE, any move past modelDiscoveryPriceBandPct is flagged
+ * rather than applied, operator-owned rows are untouchable, and anything else
+ * suspicious keeps the row in force billing. The tradeoff accepted here is that
+ * upstream data can change between two runs, which is the point of a live
+ * registry; the source report records the body's `contentHash`, so "the
+ * aggregator changed under us" stays answerable after the fact.
+ *
+ * Single constant so re-pinning to a tag is one edit if upstream ever ships a
+ * commit worth pinning away from.
  */
-export const LITELLM_RELEASE_TAG = 'v1.93.0';
+export const LITELLM_REF = 'main';
 
-export const LITELLM_PRICES_URL = `https://raw.githubusercontent.com/BerriAI/litellm/${LITELLM_RELEASE_TAG}/model_prices_and_context_window.json`;
+export const LITELLM_PRICES_URL = `https://raw.githubusercontent.com/BerriAI/litellm/${LITELLM_REF}/model_prices_and_context_window.json`;
 
 /** The document's own self-describing template row, not a model. */
 const SAMPLE_SPEC_KEY = 'sample_spec';
@@ -52,19 +66,81 @@ export const TOKENS_PER_MTOK = 1_000_000;
 const perMTok = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value * TOKENS_PER_MTOK : undefined;
 
+/** litellm's field-name prefix for each rate, and the DiscoveredRates key it lands in. */
+const BRACKET_RATE_BY_PREFIX = {
+  input_cost_per_token: 'inputPerMTok',
+  output_cost_per_token: 'outputPerMTok',
+  cache_read_input_token_cost: 'cacheReadPerMTok',
+  cache_creation_input_token_cost: 'cacheWritePerMTok',
+} as const satisfies Record<string, keyof DiscoveredPriceBracket>;
+
+type BracketRateKey = (typeof BRACKET_RATE_BY_PREFIX)[keyof typeof BRACKET_RATE_BY_PREFIX];
+
+/**
+ * litellm spells a long-context bracket as a field-name family, so the breakpoint
+ * is read off the NAME - nothing here knows 272k. Anchored at both ends on
+ * purpose: `_above_272k_tokens_priority`, `_flex`, `_batches` and
+ * `cache_creation_input_token_cost_above_1hr_above_200k_tokens` are different
+ * service or cache-TTL lanes, and pricing one of them as the long-context rate
+ * would overcharge every long prompt.
+ */
+const BRACKET_FIELD = new RegExp(`^(${Object.keys(BRACKET_RATE_BY_PREFIX).join('|')})_above_(\\d+)k_tokens$`);
+
+/** The rate and breakpoint a litellm field name declares, or null when it is not a context bracket. */
+export function parseBracketField(field: string): { rate: BracketRateKey; aboveTokens: number } | null {
+  const match = BRACKET_FIELD.exec(field);
+  if (!match) return null;
+  const rate = BRACKET_RATE_BY_PREFIX[match[1] as keyof typeof BRACKET_RATE_BY_PREFIX];
+  const thousands = Number(match[2]);
+  return thousands > 0 ? { rate, aboveTokens: thousands * 1000 } : null;
+}
+
+/**
+ * The entry's context brackets, ascending by breakpoint. A bracket missing either
+ * text rate, or carrying an unreadable one, drops the WHOLE ladder rather than
+ * part of it (gemini-1.5-flash publishes an above-128k input rate and no output
+ * rate): a half ladder would leave the tier we dropped billing at the rate below
+ * it, and the price planner treats a ladderless observation as flat, which is what
+ * this feed has always been read as.
+ */
+function bracketsOf(entry: LiteLlmEntry): DiscoveredPriceBracket[] | undefined {
+  const byBreakpoint = new Map<number, Partial<Record<BracketRateKey, number>>>();
+  for (const [field, value] of Object.entries(entry as Record<string, unknown>)) {
+    const parsed = parseBracketField(field);
+    if (!parsed) continue;
+    const rate = perMTok(value);
+    if (rate === undefined) return undefined;
+    const rates = byBreakpoint.get(parsed.aboveTokens) ?? {};
+    rates[parsed.rate] = rate;
+    byBreakpoint.set(parsed.aboveTokens, rates);
+  }
+  if (byBreakpoint.size === 0) return undefined;
+
+  const brackets: DiscoveredPriceBracket[] = [];
+  for (const [aboveTokens, rates] of [...byBreakpoint.entries()].sort(([a], [b]) => a - b)) {
+    const { inputPerMTok, outputPerMTok, cacheReadPerMTok, cacheWritePerMTok } = rates;
+    if (inputPerMTok === undefined || outputPerMTok === undefined) return undefined;
+    brackets.push(
+      compact<DiscoveredPriceBracket>({ aboveTokens, inputPerMTok, outputPerMTok, cacheReadPerMTok, cacheWritePerMTok })
+    );
+  }
+  return brackets;
+}
+
 function priceOf(entry: LiteLlmEntry): DiscoveredPrice | undefined {
   const inputPerMTok = perMTok(entry.input_cost_per_token);
   const outputPerMTok = perMTok(entry.output_cost_per_token);
   if (inputPerMTok === undefined || outputPerMTok === undefined) return undefined;
   if (inputPerMTok === 0 && outputPerMTok === 0) return undefined;
-  // The `_above_*_tokens` and `_priority` variants are deliberately ignored:
-  // DiscoveredPrice is one flat rate, and picking one of them would quote a
-  // long-context or priority-lane price as if it were the standard one.
+  // The `_priority`, `_flex` and `_batches` variants stay ignored: those are
+  // service tiers of the same context bracket, not brackets, and quoting one
+  // would price the standard lane at a lane nobody is on.
   return compact({
     inputPerMTok,
     outputPerMTok,
     cacheReadPerMTok: perMTok(entry.cache_read_input_token_cost),
     cacheWritePerMTok: perMTok(entry.cache_creation_input_token_cost),
+    brackets: bracketsOf(entry),
   });
 }
 
@@ -153,11 +229,12 @@ export function createLiteLlmSource(options: AggregatorSourceOptions): Discovery
     kind: 'aggregator',
     isConfigured: () => true,
     async fetch(ctx: DiscoveryFetchContext): Promise<SourceResult> {
-      // No conditional GET: a tagged file is immutable, so a validator would
-      // only ever answer a question the tag already answers.
+      // No conditional GET: a 304 carries no body, the join needs the body on
+      // every run, and contentHash already answers "did this change since last
+      // run" - so a validator would only buy an extra round trip.
       const response = await fetchJson<LiteLlmDocument>({ url: LITELLM_PRICES_URL, followRedirects: true }, ctx);
       if (!response.ok) return { ok: false, error: response.error, httpStatus: response.status };
-      if (response.notModified) return { ok: false, error: 'unexpected 304 from a pinned tag', httpStatus: 304 };
+      if (response.notModified) return { ok: false, error: 'unexpected 304 without a validator', httpStatus: 304 };
       // Same contract every provider source honors (types.ts:154-158): a
       // valid-but-empty body is a failed fetch, not a run on which every price
       // happened to vanish. Checked on the document, not the join.

--- a/b4m-core/services/src/modelDiscoveryService/sources/markdown.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/markdown.ts
@@ -1,0 +1,78 @@
+/**
+ * Markdown reading shared by the docs scrapers (anthropicDocs, openaiDocs).
+ *
+ * Both providers publish their pricing and lifecycle pages as `.md` twins of the
+ * rendered docs, and both express the facts we want as pipe tables under a
+ * heading. This module owns that reading so a page-shape fix lands once.
+ */
+
+/**
+ * A parser's result. Every parser here returns `{ ok: false }` when it finds
+ * valid markdown and zero rows: "the page rendered and I found nothing" is the
+ * shape of a parser that broke against a docs restructure, not of a provider that
+ * retired or unpriced everything (sec 5.5), and an empty success would freeze or
+ * clear a whole field group at once.
+ */
+export type ParseResult<T> = { ok: true; rows: T[] } | { ok: false; error: string };
+
+export interface MarkdownTable {
+  heading: string;
+  headers: string[];
+  rows: string[][];
+}
+
+export const cells = (line: string): string[] =>
+  line
+    .replace(/^\s*\|/, '')
+    .replace(/\|\s*$/, '')
+    .split('|')
+    .map(cell => cell.trim());
+
+export const isSeparator = (line: string): boolean => /^\s*\|[\s:|-]+\|\s*$/.test(line);
+
+/** Every pipe table in the document, tagged with the nearest preceding heading. */
+export function tables(markdown: string): MarkdownTable[] {
+  const lines = markdown.split(/\r?\n/);
+  const found: MarkdownTable[] = [];
+  let heading = '';
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const headingMatch = /^#{1,6}\s+(.*)$/.exec(line);
+    if (headingMatch) {
+      heading = (headingMatch[1] ?? '').trim();
+      continue;
+    }
+    if (!line.trimStart().startsWith('|') || !isSeparator(lines[index + 1] ?? '')) continue;
+
+    const headers = cells(line);
+    const rows: string[][] = [];
+    index += 2;
+    while (index < lines.length && (lines[index] ?? '').trimStart().startsWith('|')) {
+      rows.push(cells(lines[index] ?? ''));
+      index += 1;
+    }
+    index -= 1;
+    found.push({ heading, headers, rows });
+  }
+
+  return found;
+}
+
+/** Strip inline links and code ticks, keeping the link text: docs pages are MDX. */
+export const plain = (value: string): string =>
+  value
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[`*]/g, '')
+    .trim();
+
+/**
+ * "$12.50 / MTok" and "$0.20" -> 12.5 and 0.2. Undefined for "N/A", "-" and
+ * anything else carrying no figure, which is how both pages write "not published".
+ */
+export function parseRate(cell: string): number | undefined {
+  const match = /\$\s*([\d,]+(?:\.\d+)?)/.exec(plain(cell));
+  if (!match) return undefined;
+  const value = Number(match[1]?.replace(/,/g, ''));
+  return Number.isFinite(value) ? value : undefined;
+}

--- a/b4m-core/services/src/modelDiscoveryService/sources/modelsDev.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/modelsDev.test.ts
@@ -58,11 +58,81 @@ describe('models.dev normalization', () => {
   it('leaves a cache rate the entry does not carry unset', () => {
     // grok-4.5 publishes cache_read and no cache_write. An invented rate would
     // overwrite the one the price row in force already carries.
-    expect(byId(result.records).get('grok-4.5')?.pricing).toEqual({
+    expect(byId(result.records).get('grok-4.5')?.pricing).toMatchObject({
       inputPerMTok: 2,
       outputPerMTok: 6,
       cacheReadPerMTok: 0.3,
     });
+    expect(byId(result.records).get('grok-4.5')?.pricing).not.toHaveProperty('cacheWritePerMTok');
+  });
+
+  it('reads cost.tiers[] as long-context brackets, cache rates included', () => {
+    expect(byId(result.records).get('grok-4.5')?.pricing?.brackets).toEqual([
+      { aboveTokens: 200_000, inputPerMTok: 4, outputPerMTok: 12, cacheReadPerMTok: 1 },
+    ]);
+  });
+
+  it('leaves a model with no tiers flat', () => {
+    expect(byId(result.records).get('claude-opus-5')?.pricing).not.toHaveProperty('brackets');
+  });
+
+  it('takes the breakpoint from tier.size, never from the context_over_200k key', () => {
+    // The legacy key's NAME is fixed while the real breakpoint is not: upstream
+    // ships context_over_200k next to a tier of size 272000. Reading the name
+    // would start the long-context rate 72k tokens early.
+    const document = {
+      openai: {
+        models: {
+          'gpt-luna': {
+            cost: {
+              input: 0.2,
+              output: 1.2,
+              tiers: [{ input: 0.4, output: 1.8, tier: { type: 'context', size: 272_000 } }],
+              context_over_200k: { input: 0.4, output: 1.8 },
+            },
+          },
+        },
+      },
+    };
+    const records = normalizeModelsDev(document, [{ modelId: 'gpt-luna', backend: 'openai' }]).records;
+    expect(records[0]?.pricing?.brackets).toEqual([{ aboveTokens: 272_000, inputPerMTok: 0.4, outputPerMTok: 1.8 }]);
+  });
+
+  it('sorts a two-rung ladder ascending and ignores a tier that is not a context bracket', () => {
+    const document = {
+      openai: {
+        models: {
+          'gpt-rungs': {
+            cost: {
+              input: 1,
+              output: 5,
+              tiers: [
+                { input: 4, output: 20, tier: { type: 'context', size: 512_000 } },
+                { input: 9, output: 9, tier: { type: 'service', size: 200_000 } },
+                { input: 2, output: 10, tier: { type: 'context', size: 200_000 } },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const records = normalizeModelsDev(document, [{ modelId: 'gpt-rungs', backend: 'openai' }]).records;
+    expect(records[0]?.pricing?.brackets).toEqual([
+      { aboveTokens: 200_000, inputPerMTok: 2, outputPerMTok: 10 },
+      { aboveTokens: 512_000, inputPerMTok: 4, outputPerMTok: 20 },
+    ]);
+  });
+
+  it.each([
+    ['prices only one direction', { input: 4, tier: { type: 'context', size: 200_000 } }],
+    ['has no breakpoint', { input: 4, output: 20, tier: { type: 'context' } }],
+    ['has a zero breakpoint', { input: 4, output: 20, tier: { type: 'context', size: 0 } }],
+  ])('drops the whole ladder when a context tier %s', (_label, tier) => {
+    // Half a ladder would leave the rung we dropped billing at the rate below it,
+    // so the observation goes out flat and the tiered row stays a manual edit.
+    const document = { openai: { models: { 'gpt-broken': { cost: { input: 1, output: 5, tiers: [tier] } } } } };
+    const records = normalizeModelsDev(document, [{ modelId: 'gpt-broken', backend: 'openai' }]).records;
+    expect(records[0]?.pricing).toEqual({ inputPerMTok: 1, outputPerMTok: 5 });
   });
 
   it('fills the AWS pricing hole for Bedrock', () => {

--- a/b4m-core/services/src/modelDiscoveryService/sources/modelsDev.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/modelsDev.ts
@@ -1,5 +1,12 @@
 import { MODELS_DEV_PROVIDER_BY_BACKEND, type ModelRecord } from '@bike4mind/common';
-import type { DiscoveredModel, DiscoveredPrice, DiscoveryFetchContext, DiscoverySource, SourceResult } from '../types';
+import type {
+  DiscoveredModel,
+  DiscoveredPrice,
+  DiscoveredPriceBracket,
+  DiscoveryFetchContext,
+  DiscoverySource,
+  SourceResult,
+} from '../types';
 import { isEmptyDocument, joinTargets, logCoverage, type AggregatorSourceOptions, type JoinTarget } from './aggregator';
 import { boolean, compact, contentHashOf, count, fetchJson } from './http';
 
@@ -16,6 +23,23 @@ interface ModelsDevCost {
   output?: unknown;
   cache_read?: unknown;
   cache_write?: unknown;
+  tiers?: unknown;
+  /**
+   * Legacy duplicate of the `tiers[]` entry, kept by models.dev for the models
+   * whose breakpoint used to be 200k. Its NAME is fixed while the real breakpoint
+   * is not (gpt-5.6-luna carries context_over_200k with a tier size of 272000),
+   * so reading it would price a 272k bracket as if it started at 200k.
+   */
+  context_over_200k?: unknown;
+}
+
+interface ModelsDevTier {
+  input?: unknown;
+  output?: unknown;
+  cache_read?: unknown;
+  cache_write?: unknown;
+  /** 'context' is the only type published today; a size is the breakpoint in input tokens. */
+  tier?: { type?: unknown; size?: unknown };
 }
 
 interface ModelsDevModel {
@@ -71,6 +95,35 @@ export function indexModelsDev(document: unknown, backends: Iterable<string>): M
 const rate = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
 
+/**
+ * The context brackets in `cost.tiers[]`, ascending by breakpoint. A tier of any
+ * other type is not a long-context bracket and is skipped; a context tier we
+ * cannot read whole drops the WHOLE ladder rather than part of it, because the
+ * bracket we dropped would leave its prompts billed at the rate below it.
+ */
+function bracketsOf(cost: ModelsDevCost | undefined): DiscoveredPriceBracket[] | undefined {
+  if (!Array.isArray(cost?.tiers)) return undefined;
+
+  const brackets: DiscoveredPriceBracket[] = [];
+  for (const entry of cost.tiers as ModelsDevTier[]) {
+    if (!entry || typeof entry !== 'object' || entry.tier?.type !== 'context') continue;
+    const aboveTokens = count(entry.tier.size);
+    const inputPerMTok = rate(entry.input);
+    const outputPerMTok = rate(entry.output);
+    if (!aboveTokens || inputPerMTok === undefined || outputPerMTok === undefined) return undefined;
+    brackets.push(
+      compact<DiscoveredPriceBracket>({
+        aboveTokens,
+        inputPerMTok,
+        outputPerMTok,
+        cacheReadPerMTok: rate(entry.cache_read),
+        cacheWritePerMTok: rate(entry.cache_write),
+      })
+    );
+  }
+  return brackets.length > 0 ? brackets.sort((a, b) => a.aboveTokens - b.aboveTokens) : undefined;
+}
+
 /** models.dev already quotes $/MTok, so there is no unit conversion to get wrong. */
 function priceOf(cost: ModelsDevCost | undefined): DiscoveredPrice | undefined {
   const inputPerMTok = rate(cost?.input);
@@ -82,6 +135,7 @@ function priceOf(cost: ModelsDevCost | undefined): DiscoveredPrice | undefined {
     outputPerMTok,
     cacheReadPerMTok: rate(cost?.cache_read),
     cacheWritePerMTok: rate(cost?.cache_write),
+    brackets: bracketsOf(cost),
   });
 }
 

--- a/b4m-core/services/src/modelDiscoveryService/sources/openai.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openai.test.ts
@@ -1,11 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import empty from './__fixtures__/openai/empty.json';
 import malformed from './__fixtures__/openai/malformed.json';
 import models from './__fixtures__/openai/models.json';
 import expected from './__fixtures__/openai/expected.json';
 import unknownEnum from './__fixtures__/openai/unknown-enum.json';
-import { expectDegradesOnFailure, makeContext, stubFetch } from './__fixtures__/testSupport';
-import { createOpenAiSource, normalizeOpenAiModels, OPENAI_MODELS_URL } from './openai';
+import { expectDegradesOnFailure, makeContext, stubFetch, type StubResponse } from './__fixtures__/testSupport';
+import {
+  createOpenAiSource,
+  mergeOpenAiPricing,
+  normalizeOpenAiModels,
+  OPENAI_MAX_MODEL_DOC_FETCHES,
+  OPENAI_MODELS_URL,
+} from './openai';
+import { OPENAI_PRICING_URL, openAiModelDocUrl } from './openaiDocs';
+import type { DiscoveredModel, SourceResult } from '../types';
+
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'openai');
+const read = (name: string) => readFileSync(join(fixtures, name), 'utf8');
+
+const pricingMarkdown = read('pricing.md');
+
+/** A listing carrying only the ids a case cares about. */
+const listing = (ids: readonly string[]) => ({ data: ids.map(id => ({ id, object: 'model' })) });
+
+/**
+ * The route table every pricing case shares: the listing, the pricing page, and a
+ * model page per id that has one. Anything else is an unstubbed fetch, which
+ * throws - so a case cannot pass by accidentally reading a page it did not mean to.
+ */
+function routes(options: {
+  list?: unknown;
+  pricing?: StubResponse;
+  modelPages?: Readonly<Record<string, StubResponse>>;
+}) {
+  const seen: string[] = [];
+  const route = (url: string): StubResponse | undefined => {
+    seen.push(url);
+    if (url === OPENAI_MODELS_URL) return { body: options.list ?? models };
+    if (url === OPENAI_PRICING_URL) return options.pricing ?? { raw: pricingMarkdown };
+    for (const [modelId, response] of Object.entries(options.modelPages ?? {})) {
+      if (url === openAiModelDocUrl(modelId)) return response;
+    }
+    return undefined;
+  };
+  return { seen, route };
+}
+
+const pricedBy = (result: SourceResult, modelId: string) =>
+  result.ok ? result.records.find(record => record.modelId === modelId)?.pricing : undefined;
 
 describe('openai source normalization', () => {
   it('matches the golden file for the captured response', () => {
@@ -45,7 +90,8 @@ describe('openai source fetch', () => {
   });
 
   it('claims authority for the openai backend on a successful listing', async () => {
-    const restore = stubFetch({ body: models });
+    const { route } = routes({ modelPages: { 'gpt-5.6-sol': { raw: read('model-gpt-5.6-sol.md') } } });
+    const restore = stubFetch(route);
     try {
       const result = await createOpenAiSource().fetch(makeContext());
       expect(result.ok).toBe(true);
@@ -58,15 +104,19 @@ describe('openai source fetch', () => {
     }
   });
 
-  it('sends the bearer credential to the models endpoint', async () => {
-    const seen: string[] = [];
-    const restore = stubFetch(url => {
-      seen.push(url);
-      return { body: models };
+  it('sends the bearer credential to the models endpoint, and no credential to the docs', async () => {
+    const seen: Array<{ url: string; auth: unknown }> = [];
+    const restore = stubFetch((url, init) => {
+      seen.push({ url, auth: (init?.headers as Record<string, string> | undefined)?.authorization });
+      return url === OPENAI_MODELS_URL ? { body: listing(['gpt-5']) } : { raw: pricingMarkdown };
     });
     try {
       await createOpenAiSource().fetch(makeContext());
-      expect(seen).toEqual([OPENAI_MODELS_URL]);
+      expect(seen.map(entry => entry.url)).toEqual([OPENAI_MODELS_URL, OPENAI_PRICING_URL]);
+      expect(seen[0].auth).toBe('Bearer test-openai');
+      // platform.openai.com is a third-party-shaped read that also follows
+      // redirects, so it must never carry the key.
+      expect(seen[1].auth).toBeUndefined();
     } finally {
       restore();
     }
@@ -92,4 +142,199 @@ describe('openai source fetch', () => {
   });
 
   expectDegradesOnFailure(() => createOpenAiSource());
+});
+
+describe('openai source pricing', () => {
+  it('prices a flat model straight off the pricing page', async () => {
+    const { route } = routes({ list: listing(['gpt-5.4-nano']) });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(pricedBy(result, 'gpt-5.4-nano')).toEqual({
+        inputPerMTok: 0.2,
+        outputPerMTok: 1.25,
+        cacheReadPerMTok: 0.02,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('reads a model page for the breakpoint its pricing row does not state', async () => {
+    const { seen, route } = routes({
+      list: listing(['gpt-5.6-luna']),
+      modelPages: { 'gpt-5.6-luna': { raw: read('model-gpt-5.6-luna.md') } },
+    });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(seen).toContain(openAiModelDocUrl('gpt-5.6-luna'));
+      expect(pricedBy(result, 'gpt-5.6-luna')).toEqual({
+        inputPerMTok: 0.2,
+        outputPerMTok: 1.2,
+        cacheReadPerMTok: 0.02,
+        cacheWritePerMTok: 0.25,
+        brackets: [
+          {
+            aboveTokens: 272_000,
+            inputPerMTok: 0.4,
+            outputPerMTok: 1.8,
+            cacheReadPerMTok: 0.04,
+            cacheWritePerMTok: 0.5,
+          },
+        ],
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('reads no model page when the pricing row states the breakpoint inline', async () => {
+    // gpt-5.5's own cell says "(<272K context length)", so the fan-out has nothing
+    // to resolve. A page fetched here would be an unstubbed fetch, which throws.
+    const { seen, route } = routes({ list: listing(['gpt-5.5']) });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(seen).toEqual([OPENAI_MODELS_URL, OPENAI_PRICING_URL]);
+      expect(pricedBy(result, 'gpt-5.5')).toMatchObject({
+        inputPerMTok: 5,
+        outputPerMTok: 30,
+        brackets: [{ aboveTokens: 272_000, inputPerMTok: 10, outputPerMTok: 45 }],
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('prices nothing at all for a long-context model whose breakpoint it cannot place', async () => {
+    // Not the base rates: this source is a provider, so a flat value would win
+    // over the aggregators AND block the tiered reprice they can still do between
+    // them. Saying nothing leaves the model where it was.
+    const { route } = routes({
+      list: listing(['gpt-5.6-luna']),
+      modelPages: { 'gpt-5.6-luna': { status: 404, raw: 'not found' } },
+    });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok).toBe(true);
+      expect(pricedBy(result, 'gpt-5.6-luna')).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('refuses a breakpoint from a page that is not the model it asked for', async () => {
+    // The docs request follows redirects, so a soft 404 answers 200 with somebody
+    // else's document - and the breakpoint parser takes the first match in
+    // whatever it is handed. Serving sol's page for luna must yield no price.
+    const { route } = routes({
+      list: listing(['gpt-5.6-luna']),
+      modelPages: { 'gpt-5.6-luna': { raw: read('model-gpt-5.6-sol.md') } },
+    });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok).toBe(true);
+      expect(pricedBy(result, 'gpt-5.6-luna')).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('bounds the model-page fan-out at the cap, whatever the page asks for', async () => {
+    // The guard against a restructure that made every row look like it needs a
+    // breakpoint. Build a Standard table of long-context rows with no inline
+    // annotation, one per listed model, and count the pages actually fetched.
+    const many = Array.from({ length: OPENAI_MAX_MODEL_DOC_FETCHES + 8 }, (_unused, index) => `gpt-many-${index}`);
+    const table = [
+      '### Standard pricing data',
+      '',
+      '| Model | Short context input | Short context cached input | Short context cache writes |' +
+        ' Short context output | Long context input | Long context cached input | Long context cache writes |' +
+        ' Long context output |',
+      '| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
+      ...many.map(id => `| ${id} | $1.00 | - | - | $2.00 | $2.00 | - | - | $4.00 |`),
+      '',
+    ].join('\n');
+
+    const { seen, route } = routes({
+      list: listing(many),
+      pricing: { raw: table },
+      modelPages: Object.fromEntries(many.map(id => [id, { raw: read('model-gpt-5.6-luna.md') }])),
+    });
+    const restore = stubFetch(route);
+    try {
+      await createOpenAiSource().fetch(makeContext());
+      const modelPages = seen.filter(url => url !== OPENAI_MODELS_URL && url !== OPENAI_PRICING_URL);
+      expect(modelPages).toHaveLength(OPENAI_MAX_MODEL_DOC_FETCHES);
+    } finally {
+      restore();
+    }
+  });
+
+  it('stops the model-page fan-out at the deadline instead of running past it', async () => {
+    const { seen, route } = routes({ list: listing(['gpt-5.6-luna']) });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext({ deadlineAt: new Date(Date.now() - 1) }));
+      expect(seen).toEqual([OPENAI_MODELS_URL, OPENAI_PRICING_URL]);
+      expect(pricedBy(result, 'gpt-5.6-luna')).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('reports the parser row count so a page restructure is caught before it is actioned', async () => {
+    const { route } = routes({ list: listing(['gpt-5']) });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok && result.parserRows).toEqual({ pricing: expect.any(Number) });
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps the availability signal when the pricing page is unreachable', async () => {
+    const { route } = routes({ list: listing(['gpt-5']), pricing: { status: 503, raw: 'upstream' } });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok).toBe(true);
+      expect(pricedBy(result, 'gpt-5')).toBeUndefined();
+      expect(result.ok && result.parserRows).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps the availability signal when the pricing page restructured', async () => {
+    const { route } = routes({ list: listing(['gpt-5']), pricing: { raw: read('parser-broke-pricing.md') } });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok).toBe(true);
+      expect(pricedBy(result, 'gpt-5')).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('openai pricing merge', () => {
+  const record = (modelId: string): DiscoveredModel => ({ modelId, patch: { id: modelId } });
+
+  it('leaves a model the page does not carry exactly as it was', () => {
+    const [merged] = mergeOpenAiPricing(
+      [record('gpt-9-unlisted')],
+      [{ modelId: 'gpt-5', inputPerMTok: 1.25, outputPerMTok: 10 }]
+    );
+    expect(merged).not.toHaveProperty('pricing');
+  });
+
+  it('leaves every model as it was when the page never parsed', () => {
+    expect(mergeOpenAiPricing([record('gpt-5')], undefined)).toEqual([record('gpt-5')]);
+  });
 });

--- a/b4m-core/services/src/modelDiscoveryService/sources/openai.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openai.ts
@@ -1,19 +1,53 @@
 import { ModelBackend, type ModelRecord } from '@bike4mind/common';
 import type {
   DiscoveredModel,
+  DiscoveredPrice,
   DiscoveryCredentials,
   DiscoveryFetchContext,
   DiscoverySource,
+  DiscoverySourceOk,
   SourceResult,
 } from '../types';
-import { compact, fetchJson, text } from './http';
+import {
+  OPENAI_PRICING_URL,
+  openAiModelDocUrl,
+  parseOpenAiLongContextBreakpoint,
+  parseOpenAiPricing,
+  type OpenAiPriceRow,
+  type OpenAiRates,
+} from './openaiDocs';
+import { PAGINATED_SOURCE_DEADLINE_MS } from '../runModelDiscovery';
+import { compact, fetchJson, fetchText, hasTimeLeft, text } from './http';
 
 export const OPENAI_MODELS_URL = 'https://api.openai.com/v1/models';
 
 /**
+ * Model pages read for a breakpoint in one run. The set is the rows that publish
+ * long-context rates without stating the breakpoint inline, which is a handful of
+ * frontier models rather than the whole catalog; the cap is a runaway guard for a
+ * page restructure that made every row look like one of them.
+ */
+export const OPENAI_MAX_MODEL_DOC_FETCHES = 12;
+
+/**
+ * Budget for the docs leg, separate from the source deadline.
+ *
+ * The listing is already in hand by the time these run, and the runner races the
+ * whole `fetch()` against the source deadline: a docs host that HANGS would take
+ * the successful api.openai.com listing down with it, costing this backend its
+ * availability signal and its absence bookkeeping for the run. Prices are the
+ * optional half of this source and must not be able to do that.
+ */
+export const OPENAI_DOCS_BUDGET_MS = 20_000;
+
+/**
  * OpenAI's list is four fields wide (id, object, created, owned_by) and no richer
- * endpoint exists, so this source is an availability signal and nothing else:
- * context, capabilities and pricing all come from the aggregators.
+ * endpoint exists, so the API half of this source is an availability signal and
+ * nothing else: context and capabilities still come from the aggregators.
+ *
+ * Pricing does NOT, any more. OpenAI publishes a markdown twin of its pricing
+ * page, so this source is a provider price for its own models and they no longer
+ * need two mirrors to agree before a change is applied (see openaiDocs.ts).
  *
  * It deliberately emits NO `name` and NO `contextWindow`. Emitting `name: id`
  * would overwrite every seeded display name with a lowercase id and append a row
@@ -74,10 +108,55 @@ export function normalizeOpenAiModels(payload: unknown): DiscoveredModel[] {
   return records.sort((a, b) => a.modelId.localeCompare(b.modelId));
 }
 
+/**
+ * Fold the pricing page onto the API listing. A model the page does not carry, or
+ * carries in a shape this source will not price, keeps the availability signal
+ * and falls through to the aggregators exactly as it did before.
+ */
+export function mergeOpenAiPricing(
+  models: readonly DiscoveredModel[],
+  pricing: readonly OpenAiPriceRow[] | undefined
+): DiscoveredModel[] {
+  if (!pricing) return [...models];
+  const byId = new Map(pricing.map(row => [row.modelId, row]));
+
+  return models.map(record => {
+    const price = toPrice(byId.get(record.modelId));
+    return price ? { ...record, pricing: price } : record;
+  });
+}
+
+/**
+ * The row as a DiscoveredPrice, or nothing.
+ *
+ * A row with long-context rates and no breakpoint is the one case that yields
+ * NOTHING rather than the base rates. This source is a provider, so its value
+ * wins over any aggregator that corroborates it; publishing the short-prompt rate
+ * alone would both understate long prompts and, being flat, block the tiered
+ * reprice the aggregators can still do between them. Saying nothing leaves that
+ * model exactly where it was before this source existed.
+ */
+function toPrice(row: OpenAiPriceRow | undefined): DiscoveredPrice | undefined {
+  if (!row) return undefined;
+  if (!row.longContext) return rates(row);
+  if (row.longContextAboveTokens === undefined) return undefined;
+  return { ...rates(row), brackets: [{ aboveTokens: row.longContextAboveTokens, ...rates(row.longContext) }] };
+}
+
+const rates = (from: OpenAiRates): OpenAiRates =>
+  compact({
+    inputPerMTok: from.inputPerMTok,
+    outputPerMTok: from.outputPerMTok,
+    cacheReadPerMTok: from.cacheReadPerMTok,
+    cacheWritePerMTok: from.cacheWritePerMTok,
+  });
+
 export function createOpenAiSource(): DiscoverySource {
   return {
     name: 'openai',
     kind: 'provider',
+    // A listing, the pricing page, and a model page per unannotated ladder.
+    deadlineMs: PAGINATED_SOURCE_DEADLINE_MS,
     isConfigured: (creds: DiscoveryCredentials) => Boolean(creds.openai),
     async fetch(ctx: DiscoveryFetchContext): Promise<SourceResult> {
       const response = await fetchJson<OpenAiModelList>(
@@ -92,7 +171,114 @@ export function createOpenAiSource(): DiscoverySource {
       // "OpenAI retired everything". Failing here keeps absence bookkeeping frozen.
       if (records.length === 0) return { ok: false, error: 'model list was empty', httpStatus: response.status };
 
-      return { ok: true, records, authoritativeFor: [ModelBackend.OpenAI], httpStatus: response.status };
+      const pricing = await readPricing(records, docsContext(ctx));
+
+      return compact<DiscoverySourceOk>({
+        ok: true,
+        records: mergeOpenAiPricing(records, pricing),
+        authoritativeFor: [ModelBackend.OpenAI],
+        httpStatus: response.status,
+        // Set only when the parser ran, because comparing against a missing count
+        // would read as a 100% move. OBSERVABILITY ONLY: a detected shift logs and
+        // raises DocsParserRowShift, and the runner feeds droppedDocsSources to
+        // planLifecycleSignals alone - it never suppresses a price, from this
+        // source or from anthropic. This source emits no lifecycle at all, so a
+        // shift here changes nothing about what the run writes. What actually
+        // protects the rates is the table and column selection below, the
+        // corroboration rule, and the price band.
+        parserRows: pricing ? { pricing: pricing.length } : undefined,
+      });
     },
   };
+}
+
+/**
+ * The pricing table, with every breakpoint this source could resolve filled in.
+ * Undefined on a fetch or parse failure: the caller keeps the availability signal
+ * and the prices fall through to whatever the catalog already believes.
+ */
+async function readPricing(
+  models: readonly DiscoveredModel[],
+  ctx: DiscoveryFetchContext
+): Promise<OpenAiPriceRow[] | undefined> {
+  // The docs host redirects, and following is safe on a request that carries no
+  // credential (see HttpRequest.followRedirects for what a redirect would replay).
+  const response = await fetchText(
+    { url: OPENAI_PRICING_URL, headers: { accept: 'text/markdown, text/plain' }, followRedirects: true },
+    ctx
+  );
+  if (!response.ok || response.notModified) {
+    ctx.logger.warn(`[model-discovery] openai docs ${OPENAI_PRICING_URL} unavailable`);
+    return undefined;
+  }
+
+  const parsed = parseOpenAiPricing(response.text);
+  if (!parsed.ok) {
+    ctx.logger.warn(`[model-discovery] openai docs parser broke: ${parsed.error}`);
+    return undefined;
+  }
+
+  const listed = new Set(models.map(record => record.modelId));
+  const pending = parsed.rows.filter(
+    row => listed.has(row.modelId) && row.longContext && row.longContextAboveTokens === undefined
+  );
+  if (pending.length === 0) return parsed.rows;
+
+  const resolved = new Map<string, number>();
+  let read = 0;
+  for (const row of pending) {
+    if (read >= OPENAI_MAX_MODEL_DOC_FETCHES || !hasTimeLeft(ctx)) {
+      // Never a silent cut: the models left unread are the ones toPrice will
+      // refuse to price, and that has to be answerable from the run's logs.
+      ctx.logger.warn(
+        `[model-discovery] openai docs: stopped after ${read} model pages, ` +
+          `${pending.length - read} long-context breakpoints unresolved`
+      );
+      break;
+    }
+    read += 1;
+    const breakpoint = await readBreakpoint(row.modelId, ctx);
+    if (breakpoint !== undefined) resolved.set(row.modelId, breakpoint);
+  }
+
+  return parsed.rows.map(row => {
+    const breakpoint = resolved.get(row.modelId);
+    return breakpoint === undefined ? row : { ...row, longContextAboveTokens: breakpoint };
+  });
+}
+
+async function readBreakpoint(modelId: string, ctx: DiscoveryFetchContext): Promise<number | undefined> {
+  const url = openAiModelDocUrl(modelId);
+  const response = await fetchText(
+    { url, headers: { accept: 'text/markdown, text/plain' }, followRedirects: true },
+    ctx
+  );
+  if (!response.ok || response.notModified) {
+    ctx.logger.warn(`[model-discovery] openai docs ${url} unavailable`);
+    return undefined;
+  }
+  // This request follows redirects, so a soft 404 or an index page answers 200
+  // with somebody else's document - and the breakpoint parser takes the first
+  // match in whatever it is handed. Every model page states its own id, so
+  // require it rather than trusting the URL we asked for.
+  if (!response.text.includes(`Model ID: \`${modelId}\``)) {
+    ctx.logger.warn(`[model-discovery] openai docs: ${url} did not answer with ${modelId}'s page`);
+    return undefined;
+  }
+  const breakpoint = parseOpenAiLongContextBreakpoint(response.text);
+  if (breakpoint === undefined) {
+    ctx.logger.warn(`[model-discovery] openai docs: ${modelId} publishes long-context rates but no breakpoint`);
+  }
+  return breakpoint;
+}
+
+/**
+ * The context the docs leg runs under: the run's signal, plus a budget of its
+ * own so a hung docs host cannot consume the source deadline and take the
+ * listing down with it (see OPENAI_DOCS_BUDGET_MS).
+ */
+function docsContext(ctx: DiscoveryFetchContext): DiscoveryFetchContext {
+  const deadlineAt = new Date(Math.min(ctx.deadlineAt.getTime(), Date.now() + OPENAI_DOCS_BUDGET_MS));
+  const budget = AbortSignal.timeout(Math.max(0, deadlineAt.getTime() - Date.now()));
+  return { ...ctx, deadlineAt, signal: AbortSignal.any([ctx.signal, budget]) };
 }

--- a/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.test.ts
@@ -1,0 +1,208 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OPENAI_PRICING_URL,
+  openAiModelDocUrl,
+  parseOpenAiLongContextBreakpoint,
+  parseOpenAiModelCell,
+  parseOpenAiPricing,
+  parseTokenCount,
+  type OpenAiPriceRow,
+} from './openaiDocs';
+
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'openai');
+const read = (name: string) => readFileSync(join(fixtures, name), 'utf8');
+
+const pricingMarkdown = read('pricing.md');
+const parsed = parseOpenAiPricing(pricingMarkdown);
+const rows = parsed.ok
+  ? new Map(parsed.rows.map(row => [row.modelId, row] as const))
+  : new Map<string, OpenAiPriceRow>();
+
+describe('openai pricing parser', () => {
+  it('reads the Standard table', () => {
+    expect(parsed.ok).toBe(true);
+    expect(rows.size).toBeGreaterThan(20);
+  });
+
+  it('reads the Standard table and NOT the Batch, Flex or Fast ones', () => {
+    // Batch and Flex price luna at $0.10/$0.60 and Fast at $0.40/$2.40, all under
+    // headers byte-identical to Standard's. Batch being exactly half of Standard
+    // is why a fall-through would halve every OpenAI price with no signal at all.
+    expect(rows.get('gpt-5.6-luna')).toMatchObject({ inputPerMTok: 0.2, outputPerMTok: 1.2 });
+  });
+
+  it('reads the cache rates the table publishes', () => {
+    expect(rows.get('gpt-5.6-luna')).toMatchObject({ cacheReadPerMTok: 0.02, cacheWritePerMTok: 0.25 });
+  });
+
+  it('reads the long-context rates as their own group', () => {
+    expect(rows.get('gpt-5.6-luna')?.longContext).toEqual({
+      inputPerMTok: 0.4,
+      outputPerMTok: 1.8,
+      cacheReadPerMTok: 0.04,
+      cacheWritePerMTok: 0.5,
+    });
+  });
+
+  it('leaves an unpublished rate absent rather than zero', () => {
+    // A stored 0 reads as free at settlement; absent means "carry the rate in
+    // force forward", which is the true statement about a "-" cell.
+    const flat = rows.get('gpt-5.4-nano');
+    expect(flat).toMatchObject({ inputPerMTok: 0.2, outputPerMTok: 1.25, cacheReadPerMTok: 0.02 });
+    expect(flat).not.toHaveProperty('cacheWritePerMTok');
+    expect(flat).not.toHaveProperty('longContext');
+  });
+
+  it('keeps the long-context group only when both of its required rates are there', () => {
+    // gpt-5.5-pro publishes long-context input and output but no cache rates.
+    expect(rows.get('gpt-5.5-pro')?.longContext).toEqual({ inputPerMTok: 60, outputPerMTok: 270 });
+    // gpt-5.4-mini publishes no long-context rates at all.
+    expect(rows.get('gpt-5.4-mini')).not.toHaveProperty('longContext');
+  });
+
+  it('takes the breakpoint off the model cell when the row states it inline', () => {
+    expect(rows.get('gpt-5.5')?.longContextAboveTokens).toBe(272_000);
+    // The newer families dropped the annotation; their own page carries it.
+    expect(rows.get('gpt-5.6-luna')).not.toHaveProperty('longContextAboveTokens');
+  });
+
+  it('keeps a dated model id verbatim rather than reshaping it', () => {
+    expect(rows.has('gpt-4o-2024-05-13')).toBe(true);
+    expect(rows.has('gpt-4-0613')).toBe(true);
+  });
+
+  it('drops a row whose cell count does not match the header', () => {
+    // Columns are located by name but read by POSITION, so one unescaped pipe in
+    // one rate cell shifts every rate on that row one column over - and the row
+    // count does not move, so no shift guard sees it. Before the arity check this
+    // read gpt-5.6-sol as out $6.25 (real: $30) with a fabricated ladder.
+    const strayPipe = pricingMarkdown.replace(
+      '| gpt-5.6-sol | $5.00 | $0.50 | $6.25 | $30.00 |',
+      '| gpt-5.6-sol | $5.00 | $2.50 | $0.50 | $6.25 | $30.00 |'
+    );
+    const parsed = parseOpenAiPricing(strayPipe);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.rows.some(row => row.modelId === 'gpt-5.6-sol')).toBe(false);
+    // Only that row: the cells still line up for every other one.
+    expect(parsed.rows.find(row => row.modelId === 'gpt-5.6-luna')).toMatchObject({ outputPerMTok: 1.2 });
+  });
+
+  it('fails outright when the header grows a column, because every row then mismatches', () => {
+    const widened = pricingMarkdown.replace(
+      '| Model | Short context input |',
+      '| Model | Service tier | Short context input |'
+    );
+    expect(parseOpenAiPricing(widened).ok).toBe(false);
+  });
+
+  it('refuses two tables headed "Standard pricing" instead of taking the first', () => {
+    // Batch is exactly half of Standard. Resolving by document order would halve
+    // every OpenAI price and still report ok.
+    const ambiguous = pricingMarkdown.replace('### Batch pricing data', '### Standard pricing data (batch)');
+    const parsed = parseOpenAiPricing(ambiguous);
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.error).toContain('2 tables');
+  });
+
+  it('refuses a table that lists one model id twice', () => {
+    // The model cell strips every parenthetical, so a modality annotation moving
+    // into this table collapses two rates onto one id with no reading to prefer.
+    const luna = '| gpt-5.6-luna | $0.20 | $0.02 | $0.25 | $1.20 | $0.40 | $0.04 | $0.50 | $1.80 |';
+    expect(pricingMarkdown).toContain(luna);
+    const duplicated = pricingMarkdown.replace(
+      luna,
+      `${luna}\n| gpt-5.6-luna (audio) | $9.00 | $0.90 | $1.00 | $18.00 | $18.00 | $1.80 | $2.00 | $27.00 |`
+    );
+    expect(parseOpenAiPricing(duplicated).ok).toBe(false);
+  });
+
+  it('fails on a restructured page rather than returning a partial table', () => {
+    expect(parseOpenAiPricing(read('parser-broke-pricing.md')).ok).toBe(false);
+  });
+
+  it('fails when the page carries no table at all', () => {
+    expect(parseOpenAiPricing('# Pricing\n\nSee the console.\n').ok).toBe(false);
+  });
+
+  it('fails rather than reading a table whose Standard heading is gone', () => {
+    const renamed = pricingMarkdown.replace('### Standard pricing data', '### Pay-as-you-go data');
+    expect(parseOpenAiPricing(renamed).ok).toBe(false);
+  });
+
+  it('fails when the Standard table yields zero usable rows', () => {
+    expect(parseOpenAiPricing('### Standard pricing data\n\n| Model | Short context input |\n| --- | --- |\n').ok).toBe(
+      false
+    );
+  });
+});
+
+describe('openai model cell', () => {
+  it('strips the annotations the page hangs off a name', () => {
+    expect(parseOpenAiModelCell('gpt-5.5 (<272K context length)')).toEqual({
+      modelId: 'gpt-5.5',
+      longContextAboveTokens: 272_000,
+    });
+    expect(parseOpenAiModelCell('gpt-4.1-nano')).toEqual({ modelId: 'gpt-4.1-nano' });
+  });
+
+  it('refuses a cell that is prose rather than a model id', () => {
+    expect(parseOpenAiModelCell('Fine-tuning is billed separately')).toBeNull();
+    expect(parseOpenAiModelCell('')).toBeNull();
+    expect(parseOpenAiModelCell('| total |')).toBeNull();
+  });
+});
+
+describe('openai long-context breakpoint', () => {
+  it('reads the plain bullet', () => {
+    expect(parseOpenAiLongContextBreakpoint(read('model-gpt-5.6-luna.md'))).toBe(272_000);
+    expect(parseOpenAiLongContextBreakpoint(read('model-gpt-5.6-sol.md'))).toBe(272_000);
+  });
+
+  it('reads the clause buried in a longer sentence', () => {
+    // "For models with a 1.05M context window (...), prompts with >272K input
+    // tokens are ..." - anchoring on the line would take 1.05M, the wrong number.
+    expect(parseOpenAiLongContextBreakpoint(read('model-gpt-5.4.md'))).toBe(272_000);
+  });
+
+  it('is undefined for a model with no long-context pricing', () => {
+    expect(parseOpenAiLongContextBreakpoint(read('model-gpt-5.4-mini.md'))).toBeUndefined();
+  });
+});
+
+describe('openai token counts', () => {
+  it('scales the suffixes', () => {
+    expect(parseTokenCount('272K')).toBe(272_000);
+    expect(parseTokenCount('1.05M')).toBe(1_050_000);
+    expect(parseTokenCount('272,000')).toBe(272_000);
+    expect(parseTokenCount(' 400 k ')).toBe(400_000);
+  });
+
+  it('refuses anything that is not a positive whole token count', () => {
+    expect(parseTokenCount('')).toBeUndefined();
+    expect(parseTokenCount('0K')).toBeUndefined();
+    expect(parseTokenCount('none')).toBeUndefined();
+    expect(parseTokenCount('0.5')).toBeUndefined();
+  });
+
+  it('is anchored, so it cannot mine a number out of surrounding text', () => {
+    expect(parseTokenCount('abc 123K')).toBeUndefined();
+    expect(parseTokenCount('1,05M')).toBeUndefined();
+    expect(parseTokenCount('272K tokens')).toBeUndefined();
+  });
+});
+
+describe('openai docs urls', () => {
+  it('are the markdown twins of the docs pages', () => {
+    expect(OPENAI_PRICING_URL).toBe('https://platform.openai.com/docs/pricing.md');
+    expect(openAiModelDocUrl('gpt-5.6-luna')).toBe('https://platform.openai.com/docs/models/gpt-5.6-luna.md');
+  });
+
+  it('escapes an id rather than letting it shape the path', () => {
+    expect(openAiModelDocUrl('../../secrets')).not.toContain('../');
+  });
+});

--- a/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.ts
@@ -1,0 +1,205 @@
+import { parseRate, plain, tables, type ParseResult } from './markdown';
+
+/**
+ * Parsers for OpenAI's published markdown twins: the pricing page, and a model's
+ * own page. Together they are the only place OpenAI states its prices as data -
+ * /v1/models is four fields wide (see openai.ts) - so without them every OpenAI
+ * price depends on two third-party mirrors agreeing.
+ */
+
+export const OPENAI_PRICING_URL = 'https://platform.openai.com/docs/pricing.md';
+
+export const openAiModelDocUrl = (modelId: string): string =>
+  `https://platform.openai.com/docs/models/${encodeURIComponent(modelId)}.md`;
+
+/**
+ * The heading over the pay-as-you-go table. Batch and Flex carry headers
+ * byte-identical to Standard's (Fast carries the four short-context ones), and
+ * Batch is exactly half of Standard, so a selector that fell through to another
+ * matching table would halve every OpenAI price with nothing to show for it.
+ * Selection is by heading, and MORE than one match is refused rather than
+ * resolved by document order - "the first table that matched" is not a reading
+ * anyone can check.
+ */
+const STANDARD_HEADING = /^standard pricing/i;
+
+/** Columns are matched by name; a renamed one fails the parse rather than shifting. */
+const COLUMNS = {
+  shortInput: /^short context input$/i,
+  shortCacheRead: /^short context cached input$/i,
+  shortCacheWrite: /^short context cache writes$/i,
+  shortOutput: /^short context output$/i,
+  longInput: /^long context input$/i,
+  longCacheRead: /^long context cached input$/i,
+  longCacheWrite: /^long context cache writes$/i,
+  longOutput: /^long context output$/i,
+} as const;
+
+/** One rate set as the page publishes it, in USD per 1M tokens. */
+export interface OpenAiRates {
+  inputPerMTok: number;
+  outputPerMTok: number;
+  cacheReadPerMTok?: number;
+  cacheWritePerMTok?: number;
+}
+
+export interface OpenAiPriceRow extends OpenAiRates {
+  /** The API model id, which is what the table is keyed by - no slugging needed. */
+  modelId: string;
+  /**
+   * What a prompt past the breakpoint pays. Present only when the row publishes
+   * both a long-context input AND output rate: half a bracket is not a bracket.
+   */
+  longContext?: OpenAiRates;
+  /**
+   * Input tokens the long-context rates start above, when the model cell states
+   * it inline ("gpt-5.5 (<272K context length)"). The newer families drop the
+   * annotation and state it on their own page instead, which is what
+   * parseOpenAiLongContextBreakpoint reads.
+   */
+  longContextAboveTokens?: number;
+}
+
+/**
+ * "272K" -> 272000, "1.05M" -> 1050000, "272,000" -> 272000. Integers only.
+ *
+ * Anchored, and commas must be thousands separators: both callers hand it an
+ * already-constrained capture group, but an unanchored match would read
+ * "abc 123K" as 123000, and a loose comma would read the European "1,05M" as
+ * 105000000 - a 100x breakpoint - for whoever calls it next.
+ */
+export function parseTokenCount(value: string): number | undefined {
+  const match = /^(\d{1,3}(?:,\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)\s*([km])?$/i.exec(value.trim());
+  if (!match) return undefined;
+  const digits = Number(match[1]?.replace(/,/g, ''));
+  if (!Number.isFinite(digits) || digits <= 0) return undefined;
+  const scale = match[2]?.toLowerCase() === 'k' ? 1_000 : match[2]?.toLowerCase() === 'm' ? 1_000_000 : 1;
+  const tokens = digits * scale;
+  return Number.isInteger(tokens) ? tokens : undefined;
+}
+
+/**
+ * "gpt-5.5 (<272K context length)" -> the id plus the breakpoint that qualifies
+ * it. The annotation is stripped along with every other parenthetical the page
+ * hangs off a name, because what is left has to be the id verbatim: OpenAI ids
+ * carry dots and dashes ("gpt-5.6-luna", "gpt-4o-2024-05-13") and re-shaping one
+ * would join to nothing.
+ */
+export function parseOpenAiModelCell(cell: string): { modelId: string; longContextAboveTokens?: number } | null {
+  const value = plain(cell);
+  const annotated = /\(\s*<\s*([\d.,]+\s*[km]?)\s*(?:input\s*)?(?:token\s*)?context length\s*\)/i.exec(value);
+  const modelId = value.replace(/\([^)]*\)/g, '').trim();
+  // Conservative id shape: the table also carries prose rows ("Fine-tuning", a
+  // footnote) in some sections, and one of those joining to a model would price it.
+  if (!/^[a-z0-9][a-z0-9._:-]*$/.test(modelId)) return null;
+  const longContextAboveTokens = annotated ? parseTokenCount(annotated[1] ?? '') : undefined;
+  return longContextAboveTokens === undefined ? { modelId } : { modelId, longContextAboveTokens };
+}
+
+/**
+ * The Standard pricing table.
+ *
+ * A rate cell of "-" is absent rather than zero: pricePlan reads a published 0
+ * as free and an absent rate as "carry the one in force forward", and only the
+ * second is true here. That applies to the individual CACHE rates; losing both
+ * long-context columns instead drops the whole ladder, which is a different
+ * outcome (see OpenAiPriceRow.longContext and toPrice in openai.ts).
+ */
+export function parseOpenAiPricing(markdown: string): ParseResult<OpenAiPriceRow> {
+  const all = tables(markdown);
+  if (all.length === 0) return { ok: false, error: 'pricing.md contained no tables' };
+
+  const matching = all.filter(candidate => STANDARD_HEADING.test(candidate.heading));
+  if (matching.length === 0) return { ok: false, error: 'pricing.md has no "Standard pricing" table' };
+  if (matching.length > 1) {
+    return { ok: false, error: `pricing.md has ${matching.length} tables headed "Standard pricing"` };
+  }
+  const table = matching[0];
+
+  const column = (pattern: RegExp) => table.headers.findIndex(header => pattern.test(plain(header)));
+  const at = {
+    shortInput: column(COLUMNS.shortInput),
+    shortCacheRead: column(COLUMNS.shortCacheRead),
+    shortCacheWrite: column(COLUMNS.shortCacheWrite),
+    shortOutput: column(COLUMNS.shortOutput),
+    longInput: column(COLUMNS.longInput),
+    longCacheRead: column(COLUMNS.longCacheRead),
+    longCacheWrite: column(COLUMNS.longCacheWrite),
+    longOutput: column(COLUMNS.longOutput),
+  };
+
+  // The two the row cannot be read without. A renamed cache or long-context
+  // column instead drops that rate, which pricePlan handles as "not published":
+  // it carries the rate in force forward rather than moving it.
+  if (at.shortInput < 0 || at.shortOutput < 0) {
+    return { ok: false, error: 'pricing.md Standard table is missing an expected column' };
+  }
+
+  const rows: OpenAiPriceRow[] = [];
+  const seen = new Set<string>();
+  for (const row of table.rows) {
+    // Columns are located by NAME, then read by POSITION, so a row whose cell
+    // count does not match the header's reads every rate one column over -
+    // silently, and with the row count unchanged. One unescaped pipe in one rate
+    // cell is enough. The cells still line up for every other row, so the row is
+    // dropped rather than the table: a header that grew a column mismatches every
+    // row and falls through to the zero-row failure below.
+    if (row.length !== table.headers.length) continue;
+
+    const parsed = parseOpenAiModelCell(row[0] ?? '');
+    const rates = ratesAt(row, at.shortInput, at.shortOutput, at.shortCacheRead, at.shortCacheWrite);
+    if (!parsed || !rates) continue;
+
+    // Two rows for one id is a price with no reading to prefer - the same
+    // situation usableBrackets refuses a whole ladder for. The model cell strips
+    // every parenthetical, so a modality annotation moving into this table
+    // ("gpt-realtime (audio)" / "(text)") would otherwise pick whichever came
+    // last, across an 8x spread on the page's own grouped tables.
+    if (seen.has(parsed.modelId)) {
+      return { ok: false, error: `pricing.md Standard table lists ${parsed.modelId} more than once` };
+    }
+    seen.add(parsed.modelId);
+
+    const longContext = ratesAt(row, at.longInput, at.longOutput, at.longCacheRead, at.longCacheWrite);
+    rows.push({ ...parsed, ...rates, ...(longContext ? { longContext } : {}) });
+  }
+
+  if (rows.length === 0) return { ok: false, error: 'pricing.md Standard table yielded zero rows' };
+  return { ok: true, rows };
+}
+
+/** A rate group, or nothing when either of its two required rates is unpublished. */
+function ratesAt(
+  row: readonly string[],
+  input: number,
+  output: number,
+  cacheRead: number,
+  cacheWrite: number
+): OpenAiRates | undefined {
+  const inputPerMTok = input < 0 ? undefined : parseRate(row[input] ?? '');
+  const outputPerMTok = output < 0 ? undefined : parseRate(row[output] ?? '');
+  if (inputPerMTok === undefined || outputPerMTok === undefined) return undefined;
+
+  const rates: OpenAiRates = { inputPerMTok, outputPerMTok };
+  const cacheReadPerMTok = cacheRead < 0 ? undefined : parseRate(row[cacheRead] ?? '');
+  const cacheWritePerMTok = cacheWrite < 0 ? undefined : parseRate(row[cacheWrite] ?? '');
+  if (cacheReadPerMTok !== undefined) rates.cacheReadPerMTok = cacheReadPerMTok;
+  if (cacheWritePerMTok !== undefined) rates.cacheWritePerMTok = cacheWritePerMTok;
+  return rates;
+}
+
+/**
+ * The long-context breakpoint off a model's own page, from the bullet under its
+ * pricing table: "Prompts with >272K input tokens are priced at 2x input and 1.5x
+ * output for the full request." The same sentence appears in a longer form on the
+ * older families ("For models with a 1.05M context window (GPT-5.4 and GPT-5.4
+ * Pro), prompts with >272K input tokens are ..."), so the match anchors on the
+ * clause rather than on the line.
+ *
+ * Undefined means the page does not state one, which is a model this source may
+ * not price at all - see openai.ts.
+ */
+export function parseOpenAiLongContextBreakpoint(markdown: string): number | undefined {
+  const match = /prompts with\s*>\s*([\d.,]+\s*[km]?)\s*input tokens/i.exec(markdown);
+  return match ? parseTokenCount(match[1] ?? '') : undefined;
+}

--- a/b4m-core/services/src/modelDiscoveryService/types.ts
+++ b/b4m-core/services/src/modelDiscoveryService/types.ts
@@ -1,5 +1,6 @@
 import type {
   DiscoveryRunHost,
+  DiscoveryRunMode,
   DiscoveryRunStatus,
   DiscoveryRunTrigger,
   IAdminSettingsRepository,
@@ -61,12 +62,12 @@ export interface DiscoveryCredentials {
 export type DiscoverySourceKind = 'provider' | 'aggregator';
 
 /**
- * A price a source observed, in the one unit the promotion predicate compares
- * and the price planner reasons in. ModelPrice tier rates are USD per SINGLE
- * token, so pricePlan divides by 1e6 at the write boundary - crossing the two
- * is a 1e6 billing error.
+ * One set of rates, in the one unit the promotion predicate compares and the
+ * price planner reasons in. ModelPrice tier rates are USD per SINGLE token, so
+ * pricePlan divides by 1e6 at the write boundary - crossing the two is a 1e6
+ * billing error.
  */
-export interface DiscoveredPrice {
+export interface DiscoveredRates {
   /** USD per 1M input tokens. */
   inputPerMTok: number;
   /** USD per 1M output tokens. */
@@ -75,6 +76,30 @@ export interface DiscoveredPrice {
   cacheReadPerMTok?: number;
   /** USD per 1M cache-write input tokens, when the source publishes it. */
   cacheWritePerMTok?: number;
+}
+
+/**
+ * The rates that take over once a prompt is LONGER than `aboveTokens` input
+ * tokens, which is how both aggregators express a long-context ladder (models.dev
+ * `cost.tiers[]`, litellm `*_above_<N>k_tokens`).
+ *
+ * The stored ModelPrice map instead keys each tier by its UPPER bound -
+ * tierForTokens in common/src/models.ts picks the first threshold >= the prompt -
+ * so pricePlan maps a bracket onto the threshold ABOVE its own breakpoint, never
+ * onto a key of its own.
+ */
+export interface DiscoveredPriceBracket extends DiscoveredRates {
+  aboveTokens: number;
+}
+
+/** A price a source observed: the rates a short prompt pays, plus any ladder above them. */
+export interface DiscoveredPrice extends DiscoveredRates {
+  /**
+   * Long-context brackets, ascending by `aboveTokens` and in the same $/MTok unit
+   * as the base rates. Absent means the source published one flat rate, which is
+   * the ordinary case and the only one a non-tiered row can be repriced from.
+   */
+  brackets?: DiscoveredPriceBracket[];
 }
 
 /**
@@ -208,8 +233,11 @@ export interface DiscoverySource {
  */
 export type DispatchResolver = (record: ModelRecord) => Pick<ModelRecord, 'adapterFamily' | 'dispatchProfile'> | null;
 
-/** 'report' writes no catalog rows and no bookkeeping; it only reports the diff. */
-export type DiscoveryMode = 'report' | 'write';
+/**
+ * 'report' writes no catalog rows and no bookkeeping; it only reports the diff.
+ * Aliased from common because the run document persists it (DISCOVERY_RUN_MODES).
+ */
+export type DiscoveryMode = DiscoveryRunMode;
 
 export type DiscoveryAutoEnablePolicy = 'priced' | 'manual' | 'all';
 

--- a/b4m-core/services/src/modelDiscoveryService/types.ts
+++ b/b4m-core/services/src/modelDiscoveryService/types.ts
@@ -308,6 +308,28 @@ export interface PriceFlag {
   detail: string;
 }
 
+/**
+ * A price that STANDS over a source that disagreed with it, which only a
+ * provider's own published price can do. The counterpart to a PriceFlag: a flag
+ * is a value discovery declined to apply, this is one it applied over an
+ * objection, and the dissenting source named here is the operator's cue that a
+ * mirror has gone stale.
+ *
+ * Raised whether or not a row was appended. Once the catalog converges the
+ * provider's value is already in force and the plan is 'unchanged' every run -
+ * which is precisely when a stale mirror is the only thing left worth reporting.
+ */
+export interface PriceOverride {
+  modelId: string;
+  /** The provider source whose value stands. */
+  source: string;
+  /** Sources that disagreed with it and were not applied. */
+  dissenting: string[];
+  /** Per-MTok, the readable unit; the row it would write is per token. */
+  applied: { inputPerMTok: number; outputPerMTok: number };
+  detail: string;
+}
+
 /** Why a usable observation produced neither a row nor a flag. */
 export type PriceSkipReason = 'unknown-model' | 'operator-owned' | 'tiered-pricing' | 'untrusted' | 'unchanged';
 
@@ -426,6 +448,8 @@ export interface ModelDiscoveryRunResult {
   prices: {
     rows: PlannedPriceRow[];
     flags: PriceFlag[];
+    /** Rows written over a source that disagreed; a subset of `rows` by model. */
+    overrides: PriceOverride[];
   };
   /** The lifecycle plan, likewise: report mode declines to persist it, nothing more. */
   lifecycle: {

--- a/packages/database/src/models/ai/ModelDiscoveryRunModel.test.ts
+++ b/packages/database/src/models/ai/ModelDiscoveryRunModel.test.ts
@@ -77,6 +77,15 @@ describe('ModelDiscoveryRunRepository', () => {
             note: 'discovery:anthropic@2026-07-01T00:00:00.000Z',
           },
         ],
+        priceOverrides: [
+          {
+            modelId: 'claude-y',
+            source: 'anthropic',
+            dissenting: ['litellm'],
+            applied: { inputPerMTok: 3, outputPerMTok: 15 },
+            detail: 'anthropic publishes in 3/out 15 $/MTok and litellm in 8/out 24 $/MTok disagree beyond 10%',
+          },
+        ],
         priceSkips: [{ modelId: 'claude-x', reason: 'unchanged' }],
         lifecycleTransitions: [
           { modelId: 'claude-x', from: 'active', to: 'deprecated', signal: 'absence', autoApplied: false },
@@ -109,6 +118,12 @@ describe('ModelDiscoveryRunRepository', () => {
     });
     expect(stored?.priceRows?.[0]).toMatchObject({ modelId: 'claude-y', unit: 'per_token', inputPerMTok: 3 });
     expect(stored?.priceRows?.[0].effectiveFrom).toEqual(new Date('2026-07-01T00:00:00Z'));
+    expect(stored?.priceOverrides?.[0]).toMatchObject({
+      modelId: 'claude-y',
+      source: 'anthropic',
+      dissenting: ['litellm'],
+      applied: { inputPerMTok: 3, outputPerMTok: 15 },
+    });
     expect(stored?.priceSkips).toMatchObject([{ modelId: 'claude-x', reason: 'unchanged' }]);
     expect(stored?.lifecycleTransitions?.[0]).toMatchObject({ modelId: 'claude-x', to: 'deprecated' });
     expect(stored?.catalogDiff?.[0]).toMatchObject({ modelId: 'claude-y', kind: 'added', promoted: true });
@@ -117,10 +132,11 @@ describe('ModelDiscoveryRunRepository', () => {
     expect(stored?.changes?.flagged).toEqual(['gpt-5.6-luna', 'claude-y']);
     expect(stored?.changes?.operatorConflicts).toEqual(['claude-y']);
     expect(stored?.id).toBe(created.id);
-    // The list carries counts, not bodies: five bounded detail arrays per run
-    // over twenty runs is megabytes on an endpoint the status card polls.
+    // The list carries counts, not bodies: six bounded detail arrays per run over
+    // twenty runs is megabytes on an endpoint the status card polls.
     const listed = (await modelDiscoveryRunRepository.recentRuns(1))[0];
     expect(listed.priceFlags).toBeUndefined();
+    expect(listed.priceOverrides).toBeUndefined();
     expect(listed.catalogDiff).toBeUndefined();
     expect(listed.changes?.flagged).toEqual(['gpt-5.6-luna', 'claude-y']);
   });
@@ -172,6 +188,14 @@ describe('ModelDiscoveryRunRepository', () => {
             effectiveFrom: new Date('2026-07-01T00:00:00Z'),
           },
         ],
+        priceOverrides: [
+          {
+            modelId: 'gpt-bare',
+            source: 'openai',
+            applied: { inputPerMTok: 1, outputPerMTok: 2 },
+            detail: 'the provider value wins',
+          },
+        ],
         lifecycleTransitions: [{ modelId: 'gpt-bare', to: 'deprecated', signal: 'absence' }],
         catalogDiff: [{ modelId: 'gpt-bare', kind: 'updated' }],
       })
@@ -181,6 +205,7 @@ describe('ModelDiscoveryRunRepository', () => {
 
     expect(stored?.priceFlags?.[0].sources).toEqual([]);
     expect(stored?.priceRows?.[0]).toMatchObject({ sources: [], note: '' });
+    expect(stored?.priceOverrides?.[0].dissenting).toEqual([]);
     expect(stored?.lifecycleTransitions?.[0].autoApplied).toBe(false);
     expect(stored?.catalogDiff?.[0]).toMatchObject({
       ownedGroups: [],
@@ -198,6 +223,7 @@ describe('ModelDiscoveryRunRepository', () => {
     const stored = await modelDiscoveryRunRepository.runById(created.id);
 
     expect(stored?.priceFlags ?? []).toEqual([]);
+    expect(stored?.priceOverrides ?? []).toEqual([]);
     expect(stored?.catalogDiff ?? []).toEqual([]);
   });
 

--- a/packages/database/src/models/ai/ModelDiscoveryRunModel.test.ts
+++ b/packages/database/src/models/ai/ModelDiscoveryRunModel.test.ts
@@ -52,6 +52,184 @@ describe('ModelDiscoveryRunRepository', () => {
     expect(await modelDiscoveryRunRepository.lastSuccessfulRun()).toBeNull();
   });
 
+  it('round-trips the per-model detail the report is read for', async () => {
+    const created = await ModelDiscoveryRun.create(
+      run({
+        changes: { added: ['claude-y'], flagged: ['gpt-5.6-luna', 'claude-y'], operatorConflicts: ['claude-y'] },
+        priceFlags: [
+          {
+            modelId: 'gpt-5.6-luna',
+            kind: 'source-disagreement',
+            proposed: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+            current: { inputPerMTok: 1, outputPerMTok: 6 },
+            sources: ['models.dev', 'litellm'],
+            detail: 'sources disagree beyond 10%: models.dev in 0.2/out 1.2 vs litellm in 1/out 6; applied neither',
+          },
+        ],
+        priceRows: [
+          {
+            modelId: 'claude-y',
+            unit: 'per_token',
+            inputPerMTok: 3,
+            outputPerMTok: 15,
+            effectiveFrom: new Date('2026-07-01T00:00:00Z'),
+            sources: ['anthropic'],
+            note: 'discovery:anthropic@2026-07-01T00:00:00.000Z',
+          },
+        ],
+        priceSkips: [{ modelId: 'claude-x', reason: 'unchanged' }],
+        lifecycleTransitions: [
+          { modelId: 'claude-x', from: 'active', to: 'deprecated', signal: 'absence', autoApplied: false },
+        ],
+        catalogDiff: [
+          {
+            modelId: 'claude-y',
+            kind: 'added',
+            ownedGroups: ['identity', 'limits'],
+            changedKeys: ['contextWindow'],
+            lifecycleStatus: 'active',
+            promoted: true,
+            blockedBy: [],
+            operatorOwned: false,
+          },
+        ],
+      })
+    );
+
+    const stored = await modelDiscoveryRunRepository.runById(created.id);
+
+    // The sentence is the whole point: it used to reach only logger.warn, which
+    // left the admin card saying "flagged" with nowhere to learn why.
+    expect(stored?.priceFlags?.[0]).toMatchObject({
+      modelId: 'gpt-5.6-luna',
+      kind: 'source-disagreement',
+      proposed: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+      current: { inputPerMTok: 1, outputPerMTok: 6 },
+      detail: 'sources disagree beyond 10%: models.dev in 0.2/out 1.2 vs litellm in 1/out 6; applied neither',
+    });
+    expect(stored?.priceRows?.[0]).toMatchObject({ modelId: 'claude-y', unit: 'per_token', inputPerMTok: 3 });
+    expect(stored?.priceRows?.[0].effectiveFrom).toEqual(new Date('2026-07-01T00:00:00Z'));
+    expect(stored?.priceSkips).toMatchObject([{ modelId: 'claude-x', reason: 'unchanged' }]);
+    expect(stored?.lifecycleTransitions?.[0]).toMatchObject({ modelId: 'claude-x', to: 'deprecated' });
+    expect(stored?.catalogDiff?.[0]).toMatchObject({ modelId: 'claude-y', kind: 'added', promoted: true });
+    // Both halves of the queue: the merged array the card counts, and the operator
+    // overlaps on their own.
+    expect(stored?.changes?.flagged).toEqual(['gpt-5.6-luna', 'claude-y']);
+    expect(stored?.changes?.operatorConflicts).toEqual(['claude-y']);
+    expect(stored?.id).toBe(created.id);
+    // The list carries counts, not bodies: five bounded detail arrays per run
+    // over twenty runs is megabytes on an endpoint the status card polls.
+    const listed = (await modelDiscoveryRunRepository.recentRuns(1))[0];
+    expect(listed.priceFlags).toBeUndefined();
+    expect(listed.catalogDiff).toBeUndefined();
+    expect(listed.changes?.flagged).toEqual(['gpt-5.6-luna', 'claude-y']);
+  });
+
+  it('records the mode the run was allowed to act in', async () => {
+    // The report is read long after the run, and modelDiscoveryMode can change in
+    // between: a report-mode run plans rows and writes none by design, so only the
+    // stored mode separates that from a write run whose appends threw.
+    const reported = await ModelDiscoveryRun.create(run({ mode: 'report' }));
+    const written = await ModelDiscoveryRun.create(run({ mode: 'write', startedAt: new Date('2026-07-02T00:00:00Z') }));
+
+    expect((await modelDiscoveryRunRepository.runById(reported.id))?.mode).toBe('report');
+    expect((await modelDiscoveryRunRepository.runById(written.id))?.mode).toBe('write');
+    // The list carries it too: the run history picker labels each entry.
+    expect((await modelDiscoveryRunRepository.recentRuns(2)).map(entry => entry.mode)).toEqual(['write', 'report']);
+  });
+
+  it('records what a truncated detail array was cut from, and nothing when nothing was cut', async () => {
+    const cut = await ModelDiscoveryRun.create(run({ detailTotals: { priceFlags: 260, catalogDiff: 301 } }));
+    const whole = await ModelDiscoveryRun.create(run({ startedAt: new Date('2026-07-02T00:00:00Z') }));
+
+    expect((await modelDiscoveryRunRepository.runById(cut.id))?.detailTotals).toMatchObject({
+      priceFlags: 260,
+      catalogDiff: 301,
+    });
+    expect((await modelDiscoveryRunRepository.runById(whole.id))?.detailTotals).toBeUndefined();
+  });
+
+  it('defaults every detail path the type declares non-optional', async () => {
+    // lean() skips defaults for paths a document does not carry, so a subdoc
+    // written without one would come back undefined while IModelDiscoveryRun
+    // promises a value - and the report reads these arrays without guarding.
+    const created = await ModelDiscoveryRun.create(
+      run({
+        priceFlags: [
+          {
+            modelId: 'gpt-bare',
+            kind: 'band-exceeded',
+            proposed: { inputPerMTok: 1, outputPerMTok: 2 },
+            detail: 'moved beyond the band',
+          },
+        ],
+        priceRows: [
+          {
+            modelId: 'gpt-bare',
+            unit: 'per_token',
+            inputPerMTok: 1,
+            outputPerMTok: 2,
+            effectiveFrom: new Date('2026-07-01T00:00:00Z'),
+          },
+        ],
+        lifecycleTransitions: [{ modelId: 'gpt-bare', to: 'deprecated', signal: 'absence' }],
+        catalogDiff: [{ modelId: 'gpt-bare', kind: 'updated' }],
+      })
+    );
+
+    const stored = await modelDiscoveryRunRepository.runById(created.id);
+
+    expect(stored?.priceFlags?.[0].sources).toEqual([]);
+    expect(stored?.priceRows?.[0]).toMatchObject({ sources: [], note: '' });
+    expect(stored?.lifecycleTransitions?.[0].autoApplied).toBe(false);
+    expect(stored?.catalogDiff?.[0]).toMatchObject({
+      ownedGroups: [],
+      changedKeys: [],
+      blockedBy: [],
+      promoted: false,
+      operatorOwned: false,
+      lifecycleStatus: 'unknown',
+    });
+  });
+
+  it('keeps parsing a run written before the detail fields existed', async () => {
+    const created = await ModelDiscoveryRun.create(run());
+
+    const stored = await modelDiscoveryRunRepository.runById(created.id);
+
+    expect(stored?.priceFlags ?? []).toEqual([]);
+    expect(stored?.catalogDiff ?? []).toEqual([]);
+  });
+
+  it('lists the newest runs first, up to the limit', async () => {
+    for (const day of ['01', '02', '03']) {
+      await ModelDiscoveryRun.create(run({ startedAt: new Date(`2026-07-${day}T00:00:00Z`) }));
+    }
+    await ModelDiscoveryRun.create(run({ startedAt: new Date('2026-07-04T00:00:00Z'), host: 'selfhost' }));
+
+    const recent = await modelDiscoveryRunRepository.recentRuns(2);
+    expect(recent.map(entry => entry.startedAt)).toEqual([
+      new Date('2026-07-04T00:00:00Z'),
+      new Date('2026-07-03T00:00:00Z'),
+    ]);
+    // The list is addressed by id, so a run without one is a run nobody can open.
+    expect(recent.every(entry => typeof entry.id === 'string' && entry.id.length > 0)).toBe(true);
+    expect((await modelDiscoveryRunRepository.recentRuns(20, 'hosted')).map(entry => entry.host)).toEqual([
+      'hosted',
+      'hosted',
+      'hosted',
+    ]);
+    // The head of the list is the run the status card reads.
+    expect(recent[0].startedAt).toEqual((await modelDiscoveryRunRepository.latestRun())?.startedAt);
+  });
+
+  it('has no run to open for an unknown or malformed id', async () => {
+    // A runId out of a query string is whatever the caller typed: a CastError
+    // here would be a 500 on what is really a 404.
+    expect(await modelDiscoveryRunRepository.runById('not-an-object-id')).toBeNull();
+    expect(await modelDiscoveryRunRepository.runById('68000000000000000000000a')).toBeNull();
+  });
+
   it('expires run reports after 90 days', () => {
     const ttl = ModelDiscoveryRun.schema.indexes().find(([, options]) => options.expireAfterSeconds !== undefined);
     expect(ttl?.[0]).toEqual({ startedAt: 1 });

--- a/packages/database/src/models/ai/ModelDiscoveryRunModel.ts
+++ b/packages/database/src/models/ai/ModelDiscoveryRunModel.ts
@@ -156,6 +156,21 @@ const ModelDiscoveryRunSchema = new Schema<IModelDiscoveryRunDocument>(
       ],
       required: false,
     },
+    priceOverrides: {
+      type: [
+        new Schema(
+          {
+            modelId: { type: String, required: true },
+            source: { type: String, required: true },
+            dissenting: { type: [String], required: false, default: [] },
+            applied: { type: PerMTokRatesSchema, required: true },
+            detail: { type: String, required: true },
+          },
+          { _id: false }
+        ),
+      ],
+      required: false,
+    },
     priceSkips: {
       type: [
         new Schema(
@@ -212,6 +227,7 @@ const ModelDiscoveryRunSchema = new Schema<IModelDiscoveryRunDocument>(
         {
           priceFlags: { type: Number, required: false },
           priceRows: { type: Number, required: false },
+          priceOverrides: { type: Number, required: false },
           priceSkips: { type: Number, required: false },
           lifecycleTransitions: { type: Number, required: false },
           catalogDiff: { type: Number, required: false },
@@ -236,13 +252,14 @@ ModelDiscoveryRunSchema.index({ startedAt: 1 }, { expireAfterSeconds: RUN_RETENT
 export type IModelDiscoveryRunModel = Model<IModelDiscoveryRunDocument>;
 
 /**
- * The report bodies, left off the list. Twenty runs carrying five bounded detail
+ * The report bodies, left off the list. Twenty runs carrying six bounded detail
  * arrays each is megabytes on an endpoint the status card polls, and the list
  * shows counts; runById is what reads a run's detail.
  */
 const RUN_LIST_PROJECTION = {
   priceFlags: 0,
   priceRows: 0,
+  priceOverrides: 0,
   priceSkips: 0,
   lifecycleTransitions: 0,
   catalogDiff: 0,

--- a/packages/database/src/models/ai/ModelDiscoveryRunModel.ts
+++ b/packages/database/src/models/ai/ModelDiscoveryRunModel.ts
@@ -2,6 +2,7 @@ import mongoose, { Model, Schema, model } from 'mongoose';
 import BaseRepository from '@bike4mind/db-core';
 import {
   DISCOVERY_RUN_HOSTS,
+  DISCOVERY_RUN_MODES,
   DISCOVERY_RUN_STATUSES,
   DISCOVERY_RUN_TRIGGERS,
   DiscoveryRunHost,
@@ -12,6 +13,12 @@ import {
 
 /** 90 days: long enough to answer "when did this model change and why". */
 const RUN_RETENTION_SECONDS = 90 * 24 * 60 * 60;
+
+/** Per-MTok, the readable unit; the price row a flag declined to write is per token. */
+const PerMTokRatesSchema = new Schema(
+  { inputPerMTok: { type: Number, required: true }, outputPerMTok: { type: Number, required: true } },
+  { _id: false }
+);
 
 /**
  * One discovery run report: what each source returned, how well the aggregator
@@ -27,6 +34,11 @@ const ModelDiscoveryRunSchema = new Schema<IModelDiscoveryRunDocument>(
     // 'partial' commits what it verified and does not advance lastSuccessfulRun,
     // so a flaky provider degrades to "no new information".
     status: { type: String, required: true, enum: [...DISCOVERY_RUN_STATUSES] },
+    // What the run was allowed to do, as it ran: a 'report' run plans writes and
+    // lands none by design, and the current modelDiscoveryMode setting cannot
+    // stand in for it - it can change between the run and the read. Optional
+    // because runs written before this field existed have none.
+    mode: { type: String, required: false, enum: [...DISCOVERY_RUN_MODES] },
     sources: {
       type: [
         new Schema(
@@ -71,6 +83,9 @@ const ModelDiscoveryRunSchema = new Schema<IModelDiscoveryRunDocument>(
           deprecated: { type: [String], required: false },
           repriced: { type: [String], required: false },
           flagged: { type: [String], required: false },
+          // The operator overlaps `flagged` merges in with the price flags. Both
+          // arrays are kept: `flagged` is what the status card counts.
+          operatorConflicts: { type: [String], required: false },
           // Everything above is the PLAN, identically in both modes. These four
           // are what actually happened, and they are the only way a write-mode
           // run whose appends all failed reads differently from a clean one.
@@ -97,6 +112,114 @@ const ModelDiscoveryRunSchema = new Schema<IModelDiscoveryRunDocument>(
       ],
       required: false,
     },
+    // The detail behind the counts in `changes`, and the reason a run document is
+    // worth reading whole. Nothing here may become required: the collection holds
+    // runs written before these fields existed. The service-owned enumerations
+    // (`kind`, `reason`, `signal`, `blockedBy`) are stored as free strings so a
+    // new value there cannot make an already-written run unreadable.
+    //
+    // Every path the zod shapes declare non-optional carries a `default` instead:
+    // .lean() skips defaults, so a subdoc written without one would come back
+    // undefined while IModelDiscoveryRun promises a value, and the report reads
+    // these arrays without guarding.
+    priceFlags: {
+      type: [
+        new Schema(
+          {
+            modelId: { type: String, required: true },
+            kind: { type: String, required: true },
+            proposed: { type: PerMTokRatesSchema, required: true },
+            current: { type: PerMTokRatesSchema, required: false },
+            sources: { type: [String], required: false, default: [] },
+            // The sentence explaining the flag, which used to reach only the log.
+            detail: { type: String, required: true },
+          },
+          { _id: false }
+        ),
+      ],
+      required: false,
+    },
+    priceRows: {
+      type: [
+        new Schema(
+          {
+            modelId: { type: String, required: true },
+            unit: { type: String, required: true },
+            inputPerMTok: { type: Number, required: true },
+            outputPerMTok: { type: Number, required: true },
+            effectiveFrom: { type: Date, required: true },
+            sources: { type: [String], required: false, default: [] },
+            note: { type: String, required: false, default: '' },
+          },
+          { _id: false }
+        ),
+      ],
+      required: false,
+    },
+    priceSkips: {
+      type: [
+        new Schema(
+          {
+            modelId: { type: String, required: true },
+            reason: { type: String, required: true },
+          },
+          { _id: false }
+        ),
+      ],
+      required: false,
+    },
+    lifecycleTransitions: {
+      type: [
+        new Schema(
+          {
+            modelId: { type: String, required: true },
+            from: { type: String, required: false },
+            to: { type: String, required: true },
+            signal: { type: String, required: true },
+            deprecationDate: { type: String, required: false },
+            retirementDate: { type: String, required: false },
+            replacedBy: { type: String, required: false },
+            autoApplied: { type: Boolean, required: false, default: false },
+          },
+          { _id: false }
+        ),
+      ],
+      required: false,
+    },
+    catalogDiff: {
+      type: [
+        new Schema(
+          {
+            modelId: { type: String, required: true },
+            kind: { type: String, required: true },
+            ownedGroups: { type: [String], required: false, default: [] },
+            changedKeys: { type: [String], required: false, default: [] },
+            // 'unknown' rather than '' so the report shows a word, not a blank cell.
+            lifecycleStatus: { type: String, required: false, default: 'unknown' },
+            promoted: { type: Boolean, required: false, default: false },
+            blockedBy: { type: [String], required: false, default: [] },
+            operatorOwned: { type: Boolean, required: false, default: false },
+          },
+          { _id: false }
+        ),
+      ],
+      required: false,
+    },
+    // Written only when a detail array above was truncated, so an absent object
+    // means "nothing was cut" rather than "totals unknown".
+    detailTotals: {
+      type: new Schema(
+        {
+          priceFlags: { type: Number, required: false },
+          priceRows: { type: Number, required: false },
+          priceSkips: { type: Number, required: false },
+          lifecycleTransitions: { type: Number, required: false },
+          catalogDiff: { type: Number, required: false },
+        },
+        { _id: false }
+      ),
+      required: false,
+    },
   },
   {
     timestamps: true,
@@ -111,6 +234,30 @@ const ModelDiscoveryRunSchema = new Schema<IModelDiscoveryRunDocument>(
 ModelDiscoveryRunSchema.index({ startedAt: 1 }, { expireAfterSeconds: RUN_RETENTION_SECONDS });
 
 export type IModelDiscoveryRunModel = Model<IModelDiscoveryRunDocument>;
+
+/**
+ * The report bodies, left off the list. Twenty runs carrying five bounded detail
+ * arrays each is megabytes on an endpoint the status card polls, and the list
+ * shows counts; runById is what reads a run's detail.
+ */
+const RUN_LIST_PROJECTION = {
+  priceFlags: 0,
+  priceRows: 0,
+  priceSkips: 0,
+  lifecycleTransitions: 0,
+  catalogDiff: 0,
+  droppedRecords: 0,
+  unmatchedIds: 0,
+} as const;
+
+/**
+ * lean() skips the `id` virtual, and the admin run list is addressed by it: the
+ * detail fetch is `?runId=`, so a run with no id is a run nobody can open.
+ */
+const withId = (doc: IModelDiscoveryRun & { _id?: unknown }): IModelDiscoveryRun => ({
+  ...doc,
+  id: String(doc._id),
+});
 
 export class ModelDiscoveryRunRepository
   extends BaseRepository<IModelDiscoveryRunDocument>
@@ -134,6 +281,23 @@ export class ModelDiscoveryRunRepository
       .sort({ startedAt: -1 })
       .lean();
     return doc as IModelDiscoveryRun | null;
+  }
+
+  async recentRuns(limit: number, host?: DiscoveryRunHost): Promise<IModelDiscoveryRun[]> {
+    const docs = await this.model
+      .find(host ? { host } : {}, RUN_LIST_PROJECTION)
+      .sort({ startedAt: -1 })
+      .limit(limit)
+      .lean();
+    return docs.map(doc => withId(doc as IModelDiscoveryRun & { _id?: unknown }));
+  }
+
+  async runById(id: string): Promise<IModelDiscoveryRun | null> {
+    // An id out of a URL is whatever the caller typed; findById would throw a
+    // CastError on it, and "no such run" is a 404 rather than a 500.
+    if (!mongoose.isValidObjectId(id)) return null;
+    const doc = await this.model.findById(id).lean();
+    return doc ? withId(doc as IModelDiscoveryRun & { _id?: unknown }) : null;
   }
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Model price changes were being discovered and then silently thrown away, and the admin UI gave no way to find out. A production model took an 80% price cut and kept billing at the old rate for a day.

Three separate faults, each verified against production data before fixing.

**1. Discovery could not apply the price cut.** Two walls, both hit before anything is written:

- `litellm` was pinned to release tag `v1.93.0`, an immutable snapshot that still reported the pre-cut rate. models.dev (live) reported the new one. The gap exceeded `PRICE_AGREEMENT_TOLERANCE` (a hard 0.1), so the run flagged `source-disagreement` and applied neither, leaving the old price billing. Since litellm and models.dev are the only two price-bearing aggregators and OpenAI models have no provider price, any real move above 10% deadlocked until someone bumped a constant. A pinned mirror can only ever report what was true at deploy time, which defeats the point of a 6h discovery cron. Release `v1.94.0` still carries the stale rate, so bumping the tag would not have helped; the ref is now `main`.
- Discovery refused to reprice any tier ladder, on the premise that a single observed rate cannot express one. That premise was false: models.dev publishes `cost.tiers[]` and litellm publishes `*_above_<N>k_tokens`. Both are now parsed into `DiscoveredPrice.brackets`, and a multi-tier row is written when the source breakpoints line up with the row's own thresholds. Shapes that do not line up still flag for a human.

The price band had its own bug. `baselineMove` measured a cut as a fraction of the current rate, which saturates at 100%, so any band of 100 or more could never flag a price cut in either half of its range. It is now a symmetric ratio, so 200 means up to 3x in both directions as the setting always claimed.

**2. A run reported counts and nothing else.** The run document stored bare model-id arrays, so the admin card could say "34 flagged" but not which models or why. The sentence explaining each refusal was computed and sent only to a log. Prior runs were unreachable, so a 6h cron erased whatever an operator was looking at. Runs are retained 90 days and were already queryable; nothing surfaced them.

**3. The Model Pricing editor was a unit trap.** The table displayed token rates scaled to per-1M while the reprice modal edited the raw per-single-token value, so the same rate read as `$3.00` in one place and `0.000003` in the other. Typing the displayed number stored a 1e6 overcharge, in force immediately, on a row that becomes operator-owned and is therefore immune to correction by both discovery and boot seeding. Nothing checked the magnitude of a manual reprice. The tab also sits under Credit Analytics, in a different sidebar section from Model Lifecycle, with no link between them.

Stored rates stay raw provider cost. The markup is applied at settlement and is only surfaced in the editor as a read-only derived line; writing a marked-up value would double it to 1.44x and break the margin dashboard and discovery's own comparisons.

## Changes

Discovery engine:
- `litellm` reads a moving ref (`LITELLM_REF`) instead of a pinned tag; the doc comment now states what actually protects the catalog (two-source agreement, the price band, operator-owned rows, flag-and-keep-billing) and that `contentHash` is the audit trail.
- `DiscoveredPrice.brackets` carries context-tier ladders; models.dev parses `cost.tiers[]`, litellm derives breakpoints from the `_above_<N>k_tokens` field names. Service-lane variants (`_flex`, `_batches`, `_priority`) stay ignored. A partial ladder is refused whole rather than written half-parsed.
- `planPriceWrites` writes multi-tier rows when breakpoints align, bands every rate in every tier against the run-start row, compares brackets in the source-agreement check, and carries cache and audio rates forward per tier. Flat rows behave exactly as before.
- `baselineMove` is a symmetric ratio and fails closed on non-finite input.

Run reporting:
- Run documents persist `mode`, `priceFlags` (kind, proposed and in-force rates, sources, the explanatory sentence), `priceRows`, `priceSkips`, `lifecycleTransitions`, `catalogDiff`, and `changes.operatorConflicts` separately from `changes.flagged`. All optional, so existing documents still read. Detail arrays are capped at 200 with a per-array total recorded when truncated.
- `GET /api/admin/model-discovery` gains the 20 most recent runs; `?runId=` serves the full report. Detail arrays are projected out of the polled list response.
- New run report modal, a run history picker, and the count sentence is now a button. A report-mode run is labelled as a plan that wrote nothing, so the "writes did not land" warning only fires in write mode.

Model pricing:
- The reprice modal reads and writes $/1M tokens through one shared constant, leaves per-minute and per-image rows unscaled, trims 1e6 round-trip float noise, and shows the derived user-facing rate read-only.
- `POST /api/admin/model-prices` gains a guardrail: a symmetric 10x band against the row in force falling back to the seed entry, an absolute per-token ceiling for rates with no baseline anywhere, tier-ladder equality so a rung cannot silently vanish, and rejection of leading-zero tier keys. All violations are enumerated in one response, and the confirm waiver is a server-recomputed digest of the exact draft, so editing any rate invalidates it.
- A filter box on the pricing table, and deep links to it from the Model Lifecycle header and from each price-flag row.

Settings and navigation:
- The price band setting documents its 500 cap and the ratio meaning; the number input carries min and max, shows a range message, and surfaces a rejected write instead of silently doing nothing.
- Sidebar section expansion follows a cross-section jump without persisting the forced expansion over a user's own collapse choice.

## Guide for Testers

Model Lifecycle is at Sidebar -> AI & Agents -> Model Lifecycle. Model Pricing is at Sidebar -> User Ops -> Credit Analytics -> Model Pricing.

Run report and history:
1. Go to Sidebar -> AI & Agents -> Model Lifecycle. The Discovery status card appears at the top.
2. Click the change-count sentence (for example `3 repriced, 1 flagged`). Expected: a Discovery run modal opens.
3. Confirm the Price flags section is first and each row shows the model, a kind chip, proposed and in-force rates in $/M, the contributing sources, and a full sentence explaining the refusal.
4. If the run was in report mode, confirm a banner says the run computed a plan and wrote nothing, and that no "writes did not land" warning appears.
5. Close the modal, click `show run history`. Expected: a list of recent runs with timestamp, trigger, status and counts.
6. Click a run other than the newest. Expected: the modal opens showing that run's detail, not the newest run's.
7. Leave the modal open for 15 seconds. Expected: the card's background poll does not swap out what the modal is showing.

Pricing editor units:
8. From a price-flag row, click the pricing link. Expected: you land on Credit Analytics -> Model Pricing, the User Ops sidebar section is expanded, and the filter is pre-set to that model.
9. Note the Input value in the table, for example `$3`.
10. Click the edit (pencil) action on that row. Expected: the modal shows `3`, matching the table, and the helper text says USD per 1M tokens.
11. Confirm a read-only line shows the marked-up rate a user pays.
12. Type `0.2` in Input, enter a note, and save. Expected: the row's Input reads `$0.2` and the Source chip reads `operator`.
13. Click the history action on that row. Expected: a drawer shows the previous value against the new one.

Pricing guardrail:
14. Edit the same row and type `4000000` in Input. Enter a note and save. Expected: an error names the model, field, both values in $/M, and the factor, and an "Apply anyway" button appears. The save does not go through.
15. Without dismissing the error, change the Input value. Expected: the "Apply anyway" button disappears.
16. Set Input back to `4000000` and save, then click "Apply anyway". Expected: it now saves. Use the history action and revert-to-seed to undo.
17. On a model with more than one tier (`gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`, `grok-4.5`), open the editor and confirm every tier is listed and editable, and that saving an unchanged draft does not create a new row.

Band setting:
18. Go to Sidebar -> General Ops -> Admin Settings and find `Model Discovery Price Band (%)`.
19. Confirm the description states the 500 cap and that the number reads the same for a rise and a cut.
20. Type `600`. Expected: a range message appears and Save is disabled. Previously this silently did nothing.

Regression checks:
21. Model Lifecycle's deprecation queue, expired/expiring table and stale references table all still load and their accept and dismiss actions still work.
22. The Discovery status card's "Run now" button still dispatches and the card still polls to completion.
23. Model Pricing revert-to-seed still restores the adapter literal.
24. Credit Analytics still opens on the Users tab on a first visit in a session.

What NOT to test: the discovery cron schedule itself, and any provider credential configuration.

## Additional Information

Verified end to end in the self-host docker stack, rebuilt from this branch, with write mode on and the band at 500. `gpt-5.6-luna` moved in a single run:

| tier | before (`adapter-seed`) | after (`discovery:models.dev+litellm`) |
| --- | --- | --- |
| 272000 | $1.00 / $6.00 per 1M | $0.20 / $1.20 per 1M |
| 1050000 | $2.00 / $9.00 per 1M | $0.40 / $1.80 per 1M |

Both rungs repriced, tier keys preserved, cache rates picked up. The same run persisted 55 price rows, all appended, and 30 price flags with full explanations where the card previously showed a bare number.

Tests: `turbo:typecheck` 40/40, `lint:check` clean, common 1389, services 3154, database 1283, mcp 439, admin client 480. Two independent reviews were run against the branch; their confirmed findings are fixed in this PR, including a confirm token that waived violations it never displayed, four band-bypass paths on the reprice endpoint, and a false "writes did not land" warning on every report-mode run.

Known pre-existing on the dev machine used here, failing identically on a clean checkout of `main`: six client `*.e2e.test.ts` files time out at 15000ms under mongodb-memory-server replica sets, and the `@bike4mind/utils` artifactElision performance test flakes under CPU load. Neither is touched by this branch.

Not included, and worth deciding separately: OpenAI's `/v1/models` returns four fields and no pricing, and OpenAI ships no pricing endpoint, so OpenAI models still depend on two agreeing aggregators. Anthropic avoids this only because `anthropicDocs.ts` scrapes its docs pricing page and registers as a provider source, which wins outright. An equivalent OpenAI pricing scraper would remove the dependency entirely.

## Developer Notes

- `DiscoveredPrice.brackets` is the extension point for tier ladders. It is keyed by `aboveTokens` (the lower bound, as both feeds publish it) while `ModelPrice` keys by the upper bound; the one shift between them lives in the price planner so a single place can get it wrong.
- `DiscoveredRates` was extracted so the band, the tier builder and the usability check operate on a base rate or a bracket unchanged, which means no guardrail can know about one and not the other.
- Run documents carry service-owned unions (`kind`, `reason`, `signal`) as plain strings rather than enums, so a new value cannot make a stored document fail to read.
- The confirm-token pattern on the reprice endpoint (digest the submitted payload plus every finding, verify server-side on resubmit) is reusable anywhere a destructive override needs to be scoped to exactly what the operator saw.
- `useAdminSidebarSections` separates the persisted user preference from a transient navigation-forced expansion; reuse it for any future cross-section deep link.
- `CreditAnalysis/store.ts` follows the per-feature zustand store precedent and is what makes the inner pricing tab addressable from another admin tab.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - no new settings; `modelDiscoveryPriceBandPct` only gained description text and input validation
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - not applicable, no telemetry fields changed
