### PR TITLE
feat(model-discovery): price OpenAI models from OpenAI's own published docs

### DIFF
--- a/apps/client/app/components/admin/DiscoveryRunDetailModal.test.tsx
+++ b/apps/client/app/components/admin/DiscoveryRunDetailModal.test.tsx
@@ -187,7 +187,7 @@ describe('DiscoveryRunDetailModal', () => {
               applied: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
               detail:
                 'openai publishes in 0.2/out 1.2 $/MTok and litellm in 1/out 6 $/MTok disagree beyond 10%; ' +
-                'the provider value was applied',
+                'the provider value wins',
             },
           ],
         }),
@@ -195,13 +195,44 @@ describe('DiscoveryRunDetailModal', () => {
     });
     renderModal();
 
-    const row = await screen.findByTestId('discovery-run-price-override-gpt-5.6-luna');
+    const row = await screen.findByTestId('discovery-run-price-override-row-gpt-5.6-luna');
     expect(row).toHaveTextContent('$0.2 in / $1.2 out');
     expect(row).toHaveTextContent('openai');
     expect(row).toHaveTextContent('litellm');
-    expect(screen.getByTestId('discovery-run-override-detail-gpt-5.6-luna')).toHaveTextContent(
-      'the provider value was applied'
+    expect(screen.getByTestId('discovery-run-price-override-detail-gpt-5.6-luna')).toHaveTextContent(
+      'the provider value wins'
     );
+    expect(screen.getByTestId('discovery-run-modal')).toHaveTextContent('Overruled a disagreeing source (1)');
+  });
+
+  it('does not claim an override was applied on a run that wrote nothing', async () => {
+    // Report mode is the fail-safe default, so this section sits directly under
+    // the "wrote nothing" banner on most runs; a past-tense title there is how
+    // that banner stops being believed. Overrides are also raised for an
+    // unchanged row, where nothing was written in either mode.
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({
+          mode: 'report',
+          priceFlags: [],
+          priceOverrides: [
+            {
+              modelId: 'gpt-5.6-luna',
+              source: 'openai',
+              dissenting: ['litellm'],
+              applied: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+              detail: 'openai publishes in 0.2/out 1.2 $/MTok and litellm in 1/out 6 $/MTok disagree beyond 10%',
+            },
+          ],
+        }),
+      },
+    });
+    renderModal();
+
+    await screen.findByTestId('discovery-run-price-overrides-table');
+    const modal = screen.getByTestId('discovery-run-modal');
+    expect(modal).toHaveTextContent('Overruled a disagreeing source (1)');
+    expect(modal).not.toHaveTextContent('Applied');
   });
 
   it('renders a run document written before overrides existed', async () => {

--- a/apps/client/app/components/admin/DiscoveryRunDetailModal.test.tsx
+++ b/apps/client/app/components/admin/DiscoveryRunDetailModal.test.tsx
@@ -60,6 +60,13 @@ const RUN = {
   changes: { ...EMPTY_CHANGES, flagged: ['gpt-5.6-luna'], plannedPriceRows: 1, appendedPriceRows: 1 },
   priceFlags: [LUNA_FLAG],
   priceRows: [],
+  priceOverrides: [] as Array<{
+    modelId: string;
+    source: string;
+    dissenting: string[];
+    applied: { inputPerMTok: number; outputPerMTok: number };
+    detail: string;
+  }>,
   priceSkips: [],
   lifecycleTransitions: [],
   catalogDiff: [],
@@ -160,10 +167,52 @@ describe('DiscoveryRunDetailModal', () => {
     expect(await screen.findByTestId('discovery-run-sources-table')).toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-price-flags-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-price-rows-table')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-price-overrides-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-lifecycle-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-catalog-table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-skips-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('discovery-run-operator-conflicts')).not.toBeInTheDocument();
+  });
+
+  it('names the mirror a provider price was written over', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        run: runWith({
+          priceFlags: [],
+          priceOverrides: [
+            {
+              modelId: 'gpt-5.6-luna',
+              source: 'openai',
+              dissenting: ['litellm'],
+              applied: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+              detail:
+                'openai publishes in 0.2/out 1.2 $/MTok and litellm in 1/out 6 $/MTok disagree beyond 10%; ' +
+                'the provider value was applied',
+            },
+          ],
+        }),
+      },
+    });
+    renderModal();
+
+    const row = await screen.findByTestId('discovery-run-price-override-gpt-5.6-luna');
+    expect(row).toHaveTextContent('$0.2 in / $1.2 out');
+    expect(row).toHaveTextContent('openai');
+    expect(row).toHaveTextContent('litellm');
+    expect(screen.getByTestId('discovery-run-override-detail-gpt-5.6-luna')).toHaveTextContent(
+      'the provider value was applied'
+    );
+  });
+
+  it('renders a run document written before overrides existed', async () => {
+    // Every detail array is optional on the stored document; a run from before
+    // this field must not take the whole report down.
+    const { priceOverrides: _dropped, ...older } = RUN;
+    mockGet.mockResolvedValue({ data: { run: older } });
+    renderModal();
+
+    expect(await screen.findByTestId('discovery-run-price-flags-table')).toBeInTheDocument();
+    expect(screen.queryByTestId('discovery-run-price-overrides-table')).not.toBeInTheDocument();
   });
 
   it('calls out planned price rows that never landed, even on a run reporting ok', async () => {

--- a/apps/client/app/components/admin/DiscoveryRunDetailModal.tsx
+++ b/apps/client/app/components/admin/DiscoveryRunDetailModal.tsx
@@ -60,6 +60,15 @@ interface PlannedPriceRow {
   note: string;
 }
 
+/** A row written over a source that disagreed with it; the inverse of a flag. */
+interface PriceOverride {
+  modelId: string;
+  source: string;
+  dissenting: string[];
+  applied: PerMTokRates;
+  detail: string;
+}
+
 interface LifecycleTransition {
   modelId: string;
   from?: string;
@@ -91,6 +100,7 @@ interface CatalogDiffEntry {
 interface DetailTotals {
   priceFlags?: number;
   priceRows?: number;
+  priceOverrides?: number;
   priceSkips?: number;
   lifecycleTransitions?: number;
   catalogDiff?: number;
@@ -125,6 +135,8 @@ interface RunDetail {
   };
   priceFlags: PriceFlag[];
   priceRows: PlannedPriceRow[];
+  /** Optional: runs written before provider prices could overrule a mirror carry none. */
+  priceOverrides?: PriceOverride[];
   priceSkips: Array<{ modelId: string; reason: string }>;
   lifecycleTransitions: LifecycleTransition[];
   catalogDiff: CatalogDiffEntry[];
@@ -429,6 +441,41 @@ export const DiscoveryRunDetailModal: React.FC<{ runId: string | null; onClose: 
                           <td>{usdPerMTok(row.outputPerMTok)}</td>
                           <td>{list(row.sources)}</td>
                           <td>{row.note}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                </Section>
+              )}
+
+              {/* A subset of the rows above, called out because the interesting
+                  fact is not the price but the mirror: a source that disagreed
+                  with the provider is one that has gone stale. */}
+              {(run.priceOverrides?.length ?? 0) > 0 && (
+                <Section
+                  title={`Applied over a disagreeing source (${countLabel(
+                    run.priceOverrides?.length ?? 0,
+                    run.detailTotals?.priceOverrides
+                  )})`}
+                >
+                  <Table size="sm" data-testid="discovery-run-price-overrides-table">
+                    <thead>
+                      <tr>
+                        <th style={{ width: '18%' }}>Model</th>
+                        <th style={{ width: '13%' }}>Applied $/M</th>
+                        <th style={{ width: '13%' }}>From</th>
+                        <th style={{ width: '13%' }}>Overruled</th>
+                        <th>Why</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {(run.priceOverrides ?? []).map(override => (
+                        <tr key={override.modelId} data-testid={`discovery-run-price-override-${override.modelId}`}>
+                          <td>{override.modelId}</td>
+                          <td>{inOut(override.applied)}</td>
+                          <td>{override.source}</td>
+                          <td>{list(override.dissenting)}</td>
+                          <td data-testid={`discovery-run-override-detail-${override.modelId}`}>{override.detail}</td>
                         </tr>
                       ))}
                     </tbody>

--- a/apps/client/app/components/admin/DiscoveryRunDetailModal.tsx
+++ b/apps/client/app/components/admin/DiscoveryRunDetailModal.tsx
@@ -283,6 +283,8 @@ export const DiscoveryRunDetailModal: React.FC<{ runId: string | null; onClose: 
         ]
       : [];
 
+  const overrideCount = countLabel(run?.priceOverrides?.length ?? 0, run?.detailTotals?.priceOverrides);
+
   return (
     <Modal open={!!runId} onClose={onClose}>
       <ModalDialog
@@ -448,21 +450,19 @@ export const DiscoveryRunDetailModal: React.FC<{ runId: string | null; onClose: 
                 </Section>
               )}
 
-              {/* A subset of the rows above, called out because the interesting
-                  fact is not the price but the mirror: a source that disagreed
-                  with the provider is one that has gone stale. */}
+              {/* Called out because the interesting fact is not the price but the
+                  mirror: a source that disagreed with the provider is one that has
+                  gone stale. The title is deliberately tense-neutral - a
+                  report-mode run applied nothing, and these are raised for an
+                  unchanged row too, so any wording claiming a write would be false
+                  directly under the "wrote nothing" banner. */}
               {(run.priceOverrides?.length ?? 0) > 0 && (
-                <Section
-                  title={`Applied over a disagreeing source (${countLabel(
-                    run.priceOverrides?.length ?? 0,
-                    run.detailTotals?.priceOverrides
-                  )})`}
-                >
+                <Section title={`Overruled a disagreeing source (${overrideCount})`}>
                   <Table size="sm" data-testid="discovery-run-price-overrides-table">
                     <thead>
                       <tr>
                         <th style={{ width: '18%' }}>Model</th>
-                        <th style={{ width: '13%' }}>Applied $/M</th>
+                        <th style={{ width: '13%' }}>Rate $/M</th>
                         <th style={{ width: '13%' }}>From</th>
                         <th style={{ width: '13%' }}>Overruled</th>
                         <th>Why</th>
@@ -470,12 +470,14 @@ export const DiscoveryRunDetailModal: React.FC<{ runId: string | null; onClose: 
                     </thead>
                     <tbody>
                       {(run.priceOverrides ?? []).map(override => (
-                        <tr key={override.modelId} data-testid={`discovery-run-price-override-${override.modelId}`}>
+                        <tr key={override.modelId} data-testid={`discovery-run-price-override-row-${override.modelId}`}>
                           <td>{override.modelId}</td>
                           <td>{inOut(override.applied)}</td>
                           <td>{override.source}</td>
                           <td>{list(override.dissenting)}</td>
-                          <td data-testid={`discovery-run-override-detail-${override.modelId}`}>{override.detail}</td>
+                          <td data-testid={`discovery-run-price-override-detail-${override.modelId}`}>
+                            {override.detail}
+                          </td>
                         </tr>
                       ))}
                     </tbody>

--- a/apps/client/pages/api/admin/__tests__/model-discovery.test.ts
+++ b/apps/client/pages/api/admin/__tests__/model-discovery.test.ts
@@ -107,6 +107,15 @@ const DETAILED_RUN = {
       detail: 'sources disagree beyond 10%: models.dev in 0.2/out 1.2 vs litellm in 1/out 6; applied neither',
     },
   ],
+  priceOverrides: [
+    {
+      modelId: 'gpt-5.6-terra',
+      source: 'openai',
+      dissenting: ['litellm'],
+      applied: { inputPerMTok: 2, outputPerMTok: 12 },
+      detail: 'openai publishes in 2/out 12 $/MTok and litellm in 8/out 24 $/MTok disagree beyond 10%',
+    },
+  ],
   priceSkips: [{ modelId: 'm1', reason: 'unchanged' }],
   lifecycleTransitions: [{ modelId: 'm4', from: 'active', to: 'deprecated', signal: 'absence', autoApplied: false }],
   droppedRecords: [{ source: 'litellm', modelId: 'ghost-1', reason: 'unknown backend' }],
@@ -256,6 +265,15 @@ describe('/api/admin/model-discovery', () => {
         // Absent on the document, defaulted here: the client never guards for
         // undefined.
         priceRows: [],
+        priceOverrides: [
+          {
+            modelId: 'gpt-5.6-terra',
+            source: 'openai',
+            dissenting: ['litellm'],
+            applied: { inputPerMTok: 2, outputPerMTok: 12 },
+            detail: 'openai publishes in 2/out 12 $/MTok and litellm in 8/out 24 $/MTok disagree beyond 10%',
+          },
+        ],
         priceSkips: [{ modelId: 'm1', reason: 'unchanged' }],
         lifecycleTransitions: [
           { modelId: 'm4', from: 'active', to: 'deprecated', signal: 'absence', autoApplied: false },

--- a/apps/client/pages/api/admin/model-discovery.ts
+++ b/apps/client/pages/api/admin/model-discovery.ts
@@ -97,6 +97,7 @@ const fullRun = (run: IModelDiscoveryRun) => ({
   },
   priceFlags: run.priceFlags ?? [],
   priceRows: run.priceRows ?? [],
+  priceOverrides: run.priceOverrides ?? [],
   priceSkips: run.priceSkips ?? [],
   lifecycleTransitions: run.lifecycleTransitions ?? [],
   catalogDiff: run.catalogDiff ?? [],

--- a/b4m-core/common/src/types/entities/ModelCatalogTypes.ts
+++ b/b4m-core/common/src/types/entities/ModelCatalogTypes.ts
@@ -659,10 +659,10 @@ export const DiscoveryDroppedRecord = z.object({
 });
 
 /**
- * The five blocks below are the per-model detail behind the counts in
+ * The six blocks below are the per-model detail behind the counts in
  * DiscoveryRunChanges, and MUST STAY IN SYNC with the service shapes the runner
- * persists verbatim: PriceFlag, PlannedPriceRow, PriceSkip, LifecycleTransition
- * and CatalogDiffEntry in
+ * persists verbatim: PriceFlag, PlannedPriceRow, PriceOverride, PriceSkip,
+ * LifecycleTransition and CatalogDiffEntry in
  * b4m-core/services/src/modelDiscoveryService/types.ts.
  *
  * Every union the SERVICE owns is read here as a free string (`kind`, `reason`,
@@ -698,6 +698,22 @@ export const DiscoveryPlannedPriceRow = z.object({
   /** The sources whose observations produced the value. */
   sources: z.array(z.string()),
   note: z.string(),
+});
+
+/**
+ * A row written over a source that disagreed with it, which only a provider's own
+ * published price can do. The inverse of a flag: that is a value discovery
+ * declined to apply, this is one it applied anyway, and the dissenting source is
+ * the operator's cue that a mirror has gone stale.
+ */
+export const DiscoveryPriceOverride = z.object({
+  modelId: z.string().min(1),
+  /** The provider source whose value was written. */
+  source: z.string(),
+  /** Sources that disagreed with it and were not applied. */
+  dissenting: z.array(z.string()),
+  applied: PerMTokRates,
+  detail: z.string(),
 });
 
 /** A usable observation that produced neither a row nor a flag, and why. */
@@ -742,6 +758,7 @@ export const DiscoveryCatalogDiffEntry = z.object({
 export const DiscoveryRunDetailTotals = z.object({
   priceFlags: z.number().int().nonnegative().optional(),
   priceRows: z.number().int().nonnegative().optional(),
+  priceOverrides: z.number().int().nonnegative().optional(),
   priceSkips: z.number().int().nonnegative().optional(),
   lifecycleTransitions: z.number().int().nonnegative().optional(),
   catalogDiff: z.number().int().nonnegative().optional(),
@@ -753,6 +770,7 @@ export type IDiscoveryRunChanges = z.infer<typeof DiscoveryRunChanges>;
 export type IDiscoveryDroppedRecord = z.infer<typeof DiscoveryDroppedRecord>;
 export type IDiscoveryPriceFlag = z.infer<typeof DiscoveryPriceFlag>;
 export type IDiscoveryPlannedPriceRow = z.infer<typeof DiscoveryPlannedPriceRow>;
+export type IDiscoveryPriceOverride = z.infer<typeof DiscoveryPriceOverride>;
 export type IDiscoveryPriceSkip = z.infer<typeof DiscoveryPriceSkip>;
 export type IDiscoveryLifecycleTransition = z.infer<typeof DiscoveryLifecycleTransition>;
 export type IDiscoveryCatalogDiffEntry = z.infer<typeof DiscoveryCatalogDiffEntry>;
@@ -791,6 +809,7 @@ export const ModelDiscoveryRun = z.object({
    */
   priceFlags: DiscoveryPriceFlag.array().optional(),
   priceRows: DiscoveryPlannedPriceRow.array().optional(),
+  priceOverrides: DiscoveryPriceOverride.array().optional(),
   priceSkips: DiscoveryPriceSkip.array().optional(),
   lifecycleTransitions: DiscoveryLifecycleTransition.array().optional(),
   catalogDiff: DiscoveryCatalogDiffEntry.array().optional(),

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.test.ts
@@ -22,6 +22,9 @@ const provider = (price: DiscoveredPrice, modelId?: string) => from('openai', 'p
 const modelsDev = (price: DiscoveredPrice, modelId?: string) =>
   from('models.dev', 'aggregator', priced(price, modelId));
 const litellm = (price: DiscoveredPrice, modelId?: string) => from('litellm', 'aggregator', priced(price, modelId));
+/** A third mirror; the repo registers two, and some rules only show up past that. */
+const openRouter = (price: DiscoveredPrice, modelId?: string) =>
+  from('openrouter', 'aggregator', priced(price, modelId));
 
 const inForce = (pricing: Record<string, IModelPriceTier>, note = 'adapter-seed', modelId = 'gpt-6'): IModelPrice => ({
   modelId,
@@ -206,11 +209,11 @@ describe('planPriceWrites guardrails', () => {
   });
 
   it('proposes one of the two values it names as disagreeing', () => {
-    // The provider agrees with both aggregators inside the tolerance while they
-    // disagree with each other, so the first disagreeing pair excludes it.
+    // Three aggregators where the outer two disagree with each other and the
+    // middle one agrees with both, so the first disagreeing pair excludes it.
     const result = plan({
       contributions: [
-        provider({ inputPerMTok: 5, outputPerMTok: 25 }),
+        openRouter({ inputPerMTok: 5, outputPerMTok: 25 }),
         modelsDev({ inputPerMTok: 4.6, outputPerMTok: 25 }),
         litellm({ inputPerMTok: 5.4, outputPerMTok: 25 }),
       ],
@@ -224,7 +227,7 @@ describe('planPriceWrites guardrails', () => {
     expect(result.flags[0].detail).toContain('litellm');
   });
 
-  it('applies neither side when a provider and an aggregator disagree', () => {
+  it('applies neither side when the only aggregator disagrees with the provider', () => {
     const result = plan({
       contributions: [
         modelsDev({ inputPerMTok: 5, outputPerMTok: 25 }),
@@ -234,6 +237,9 @@ describe('planPriceWrites guardrails', () => {
 
     expect(result.rows).toEqual([]);
     expect(result.flags[0].kind).toBe('source-disagreement');
+    // A different sentence from mirrors contradicting each other: what is wrong
+    // here is that nothing backs the provider up.
+    expect(result.flags[0].detail).toContain('no source corroborates the provider');
   });
 
   it('flags a move beyond the band and keeps the row in force', () => {
@@ -374,7 +380,161 @@ describe('planPriceWrites guardrails', () => {
   it('drops an all-zero observation rather than writing a free row', () => {
     const result = plan({ contributions: [provider({ inputPerMTok: 0, outputPerMTok: 0 })] });
 
-    expect(result).toEqual({ rows: [], flags: [], skipped: [] });
+    expect(result).toEqual({ rows: [], flags: [], overrides: [], skipped: [] });
+  });
+});
+
+/**
+ * A provider's own published price is primary: it needs ONE mirror to agree, not
+ * all of them. The mirrors go stale on their own schedules (litellm publishes off
+ * a git ref, models.dev re-scrapes on its own cadence), so a unanimity rule hands
+ * any one of them a veto over a price the provider itself publishes.
+ */
+describe('planPriceWrites provider primacy', () => {
+  const CUT: DiscoveredPrice = { inputPerMTok: 0.2, outputPerMTok: 1.2 };
+  const STALE: DiscoveredPrice = { inputPerMTok: 1, outputPerMTok: 6 };
+  const CUT_IN_FORCE: IModelPriceTier = { input: 1e-6, output: 6e-6 };
+
+  it('writes the provider price when one mirror agrees and another is stale', () => {
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(CUT), litellm(STALE)],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 500,
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(perMTok(result.rows[0].pricing)).toEqual({ '0': { input: 0.2, output: 1.2 } });
+    // Credited to the provider alone: the agreeing mirror corroborated the value,
+    // it did not supply it.
+    expect(result.rows[0].note).toBe(`discovery:openai@${RUN_AT.toISOString()}`);
+  });
+
+  it('records the overruled source rather than swallowing it', () => {
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(CUT), litellm(STALE)],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 500,
+    });
+
+    expect(result.overrides).toHaveLength(1);
+    expect(result.overrides[0]).toMatchObject({
+      modelId: 'gpt-6',
+      source: 'openai',
+      dissenting: ['litellm'],
+      applied: { inputPerMTok: 0.2, outputPerMTok: 1.2 },
+    });
+    // The whole point of recording it: the operator learns WHICH mirror is stale.
+    expect(result.overrides[0].detail).toContain('litellm');
+    expect(result.overrides[0].detail).toContain('in 1/out 6');
+  });
+
+  it('records nothing when every source agreed', () => {
+    const result = plan({ contributions: [provider(CUT), modelsDev(CUT), litellm(CUT)] });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.overrides).toEqual([]);
+  });
+
+  it('writes the provider price when the mirrors disagree with each other but not with it', () => {
+    const result = plan({
+      contributions: [
+        provider({ inputPerMTok: 5, outputPerMTok: 25 }),
+        modelsDev({ inputPerMTok: 4.6, outputPerMTok: 25 }),
+        litellm({ inputPerMTok: 5.4, outputPerMTok: 25 }),
+      ],
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(result.rows[0].pricing['0'].input).toBe(5e-6);
+    expect(result.overrides).toEqual([]);
+  });
+
+  it('refuses when every mirror disagrees with the provider', () => {
+    // Primary, not unaccountable. All of them dissenting is the shape of a parser
+    // that broke against a docs restructure, which must reprice nothing.
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(STALE), litellm(STALE)],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 500,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.overrides).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'source-disagreement' });
+  });
+
+  it('still writes a provider price no mirror carries at all', () => {
+    const result = plan({ contributions: [provider(CUT)] });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.overrides).toEqual([]);
+  });
+
+  it('does not record an override for a price it declined to write', () => {
+    // The band refuses this move, so nothing was applied over anything.
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(CUT), litellm(STALE)],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 50,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.overrides).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'band-exceeded' });
+  });
+
+  it('leaves the aggregator-only rules exactly as they were', () => {
+    const disagreeing = plan({
+      contributions: [
+        modelsDev({ inputPerMTok: 5, outputPerMTok: 25 }),
+        litellm({ inputPerMTok: 9, outputPerMTok: 25 }),
+      ],
+    });
+    expect(disagreeing.rows).toEqual([]);
+    expect(disagreeing.flags[0]).toMatchObject({ kind: 'source-disagreement' });
+
+    const lone = plan({ contributions: [litellm({ inputPerMTok: 5, outputPerMTok: 25 })] });
+    expect(lone.rows).toEqual([]);
+    expect(lone.flags[0]).toMatchObject({ kind: 'single-source-untrusted' });
+  });
+
+  it('makes two providers that disagree with each other refuse, with neither outranking', () => {
+    const result = plan({
+      contributions: [
+        provider({ inputPerMTok: 5, outputPerMTok: 25 }),
+        from('bedrock', 'provider', priced({ inputPerMTok: 15, outputPerMTok: 25 })),
+        modelsDev({ inputPerMTok: 5, outputPerMTok: 25 }),
+      ],
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'source-disagreement' });
+    // Two providers is a mutual contradiction, not an uncorroborated one, even
+    // though both sides of the pair are providers.
+    expect(result.flags[0].detail).toContain('sources disagree beyond');
+    expect(result.flags[0].detail).not.toContain('corroborates');
+  });
+
+  it('lets a provider ladder reprice a tiered row over a stale flat mirror', () => {
+    // The case this whole change exists for: the provider publishes the ladder,
+    // one mirror agrees, and the other still has last quarter's price.
+    const ladder: DiscoveredPrice = {
+      inputPerMTok: 0.2,
+      outputPerMTok: 1.2,
+      brackets: [{ aboveTokens: 272_000, inputPerMTok: 0.4, outputPerMTok: 1.8 }],
+    };
+    const result = plan({
+      contributions: [provider(ladder), modelsDev(ladder), litellm(STALE)],
+      rowsInForce: [inForce({ '272000': { input: 1e-6, output: 6e-6 }, '1050000': { input: 2e-6, output: 9e-6 } })],
+      bandPct: 500,
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(perMTok(result.rows[0].pricing)).toEqual({
+      '272000': { input: 0.2, output: 1.2 },
+      '1050000': { input: 0.4, output: 1.8 },
+    });
+    expect(result.overrides[0].dissenting).toEqual(['litellm']);
   });
 });
 

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.test.ts
@@ -426,6 +426,10 @@ describe('planPriceWrites provider primacy', () => {
     // The whole point of recording it: the operator learns WHICH mirror is stale.
     expect(result.overrides[0].detail).toContain('litellm');
     expect(result.overrides[0].detail).toContain('in 1/out 6');
+    // Present tense: this planner runs identically in report mode, where nothing
+    // is written, so the sentence may not claim a write.
+    expect(result.overrides[0].detail).toContain('the provider value wins');
+    expect(result.overrides[0].detail).not.toContain('was applied');
   });
 
   it('records nothing when every source agreed', () => {
@@ -513,6 +517,63 @@ describe('planPriceWrites provider primacy', () => {
     // though both sides of the pair are providers.
     expect(result.flags[0].detail).toContain('sources disagree beyond');
     expect(result.flags[0].detail).not.toContain('corroborates');
+  });
+
+  it('reports a stale mirror on a model whose row already carries the right price', () => {
+    // The steady state: the provider's value is already in force, so there is no
+    // row to write - and that is exactly when "which mirror is stale" is the only
+    // fact left. Recording this only against a write would hide it forever.
+    const result = plan({
+      contributions: [provider(CUT), modelsDev(CUT), litellm(STALE)],
+      // Exactly what buildTier produces from these rates, which is what a prior
+      // run would have written; 0.2e-6 is a DIFFERENT float from 0.2 / 1e6.
+      rowsInForce: [inForce({ '0': { input: 0.2 / 1_000_000, output: 1.2 / 1_000_000 } })],
+      bandPct: 500,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.skipped).toEqual([{ modelId: 'gpt-6', reason: 'unchanged' }]);
+    expect(result.overrides).toHaveLength(1);
+    expect(result.overrides[0]).toMatchObject({ source: 'openai', dissenting: ['litellm'] });
+  });
+
+  it('refuses a provider ladder no mirror corroborates, rather than writing the upper rung alone', () => {
+    // diverges() is silent when only one side publishes brackets, so a mirror
+    // that went flat still "agrees" on the base rates. Without this the upper
+    // bracket would be written on one scrape's word.
+    const ladder: DiscoveredPrice = {
+      inputPerMTok: 0.2,
+      outputPerMTok: 1.2,
+      brackets: [{ aboveTokens: 272_000, inputPerMTok: 0.4, outputPerMTok: 1.8 }],
+    };
+    const flat: DiscoveredPrice = { inputPerMTok: 0.2, outputPerMTok: 1.2 };
+    const result = plan({
+      contributions: [provider(ladder), modelsDev(flat), litellm(flat)],
+      rowsInForce: [inForce({ '272000': { input: 1e-6, output: 6e-6 }, '1050000': { input: 2e-6, output: 9e-6 } })],
+      bandPct: 500,
+    });
+
+    expect(result.rows).toEqual([]);
+    expect(result.flags[0]).toMatchObject({ kind: 'tiered-pricing-manual' });
+    expect(result.flags[0].detail).toContain('no long-context rates');
+  });
+
+  it('still lets a flat row take a provider price no mirror carries a ladder for', () => {
+    // A flat row discards the brackets anyway, so refusing there would block a
+    // write whose ladder was never going to be used.
+    const ladder: DiscoveredPrice = {
+      inputPerMTok: 0.2,
+      outputPerMTok: 1.2,
+      brackets: [{ aboveTokens: 272_000, inputPerMTok: 0.4, outputPerMTok: 1.8 }],
+    };
+    const result = plan({
+      contributions: [provider(ladder), modelsDev({ inputPerMTok: 0.2, outputPerMTok: 1.2 })],
+      rowsInForce: [inForce({ '0': CUT_IN_FORCE })],
+      bandPct: 500,
+    });
+
+    expect(result.flags).toEqual([]);
+    expect(perMTok(result.rows[0].pricing)).toEqual({ '0': { input: 0.2, output: 1.2 } });
   });
 
   it('lets a provider ladder reprice a tiered row over a stale flat mirror', () => {

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
@@ -14,6 +14,7 @@ import type {
   PlannedPriceRow,
   PriceFlag,
   PriceFlagKind,
+  PriceOverride,
   PriceSkip,
   PriceSkipReason,
   SourceContribution,
@@ -110,6 +111,8 @@ export interface PricePlanInput {
 export interface PricePlan {
   rows: IModelPriceInput[];
   flags: PriceFlag[];
+  /** Rows written over a disagreeing source; one per row, never more. */
+  overrides: PriceOverride[];
   /** Usable observations that produced neither a row nor a flag, and why. */
   skipped: PriceSkip[];
 }
@@ -134,6 +137,7 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
 
   const rows: IModelPriceInput[] = [];
   const flags: PriceFlag[] = [];
+  const overrides: PriceOverride[] = [];
   const skipped: PriceSkip[] = [];
   const skip = (modelId: string, reason: PriceSkipReason) => skipped.push({ modelId, reason });
 
@@ -149,19 +153,16 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       continue;
     }
 
-    const disagreeing = firstDisagreement(observations);
-    if (disagreeing) {
+    const consensus = reachConsensus(observations);
+    if (consensus.kind === 'conflict') {
       flags.push({
         modelId,
         kind: 'source-disagreement',
         // One of the two sides the detail names: a third source's value would be
         // a number the operator cannot find anywhere in the sentence.
-        proposed: perMTokOf(disagreeing[0].price),
+        proposed: perMTokOf(consensus.proposed),
         sources,
-        detail:
-          `sources disagree beyond ${pct(PRICE_AGREEMENT_TOLERANCE)}: ` +
-          `${disagreeing[0].source} ${describe(disagreeing[0].price)} vs ${disagreeing[1].source} ` +
-          `${describe(disagreeing[1].price)}; applied neither`,
+        detail: consensus.detail,
       });
       continue;
     }
@@ -174,13 +175,10 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
     const flag = (kind: PriceFlagKind, price: DiscoveredPrice, detail: string) =>
       flags.push({ modelId, kind, proposed: perMTokOf(price), current: currentPrice, sources, detail });
 
-    const provider = observations.find(observation => observation.kind === 'provider');
-    const aggregators = observations.filter(observation => observation.kind === 'aggregator');
-
     // A lone aggregator is corroboration-free, so it never writes. It is worth
     // an operator's attention only when it contradicts what we already bill.
-    if (!provider && aggregators.length < 2) {
-      const lone = aggregators[0];
+    if (consensus.kind === 'lone') {
+      const lone = consensus.observation;
       if (!currentTier) {
         flag(
           'single-source-untrusted',
@@ -201,11 +199,10 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       continue;
     }
 
-    // Trusted: a provider's own API, or aggregators that already passed the
-    // agreement check above. The provider value wins; models.dev leads the
-    // aggregators by registration order, not by name.
-    const trusted = provider ?? aggregators[0];
-    const valueSources = provider ? [provider.source] : aggregators.map(observation => observation.source);
+    // Trusted: a provider's own published price, or aggregators that already
+    // passed the agreement check above. models.dev leads the aggregators by
+    // registration order, not by name.
+    const { observation: trusted, valueSources, dissenting } = consensus;
     const proposed = trusted.price;
 
     if (current && classifyPriceRow(current) === 'operator') {
@@ -298,9 +295,25 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       note: `${DISCOVERY_PRICE_NOTE_PREFIX}${valueSources.join('+')}@${input.runStartedAt.toISOString()}`,
       repricedBy: DISCOVERY_REPRICED_BY,
     });
+
+    // Recorded against the WRITE, not against the disagreement: a dissent that
+    // ended in a flag or a no-op is already reported as that, and reporting it
+    // twice would make the count of overridden sources unreadable.
+    if (dissenting.length > 0) {
+      overrides.push({
+        modelId,
+        source: trusted.source,
+        dissenting: dissenting.map(observation => observation.source),
+        applied: perMTokOf(proposed),
+        detail:
+          `${trusted.source} publishes ${describe(proposed)} and ` +
+          `${dissenting.map(observation => `${observation.source} ${describe(observation.price)}`).join(', ')} ` +
+          `disagree beyond ${pct(PRICE_AGREEMENT_TOLERANCE)}; the provider value was applied`,
+      });
+    }
   }
 
-  return { rows, flags, skipped };
+  return { rows, flags, overrides, skipped };
 }
 
 /** One model's comparable cost: the lowest tier's rates, in USD per single token. */
@@ -422,6 +435,95 @@ function usableBrackets(brackets: readonly DiscoveredPriceBracket[] | undefined)
     usable.push({ aboveTokens, ...usableRates(bracket) });
   }
   return usable;
+}
+
+/**
+ * What this run's sources add up to for one model.
+ *
+ * 'conflict' carries the sentence rather than the pair, because the two ways to
+ * reach it read differently to an operator: mirrors that contradict each other,
+ * and mirrors that all contradict the provider.
+ */
+type Consensus =
+  | { kind: 'conflict'; proposed: DiscoveredPrice; detail: string }
+  | { kind: 'lone'; observation: PriceObservation }
+  | {
+      kind: 'trusted';
+      observation: PriceObservation;
+      /** Credited in the row's note: the sources whose value it is. */
+      valueSources: string[];
+      /** Sources overruled by a provider, empty in every other case. */
+      dissenting: PriceObservation[];
+    };
+
+/**
+ * A PROVIDER'S OWN PUBLISHED PRICE IS PRIMARY. It needs corroboration - one
+ * aggregator that agrees with it - but not unanimity, and the aggregators that
+ * disagree are recorded and overruled rather than allowed to veto.
+ *
+ * That asymmetry is the whole point. The two aggregators are mirrors of the
+ * provider, and a mirror goes stale on its own schedule: litellm publishes from a
+ * git ref that lags, models.dev re-scrapes on its own cadence. Requiring all of
+ * them to agree hands any one of them a veto over a price the provider itself
+ * publishes, which is how an 80% price cut can keep billing at the old rate until
+ * the slowest mirror catches up.
+ *
+ * With no provider price, nothing here changed: the aggregators are all we have,
+ * so they must agree with each other and there must be at least two of them.
+ */
+function reachConsensus(observations: readonly PriceObservation[]): Consensus {
+  const providers = observations.filter(observation => observation.kind === 'provider');
+  const aggregators = observations.filter(observation => observation.kind === 'aggregator');
+
+  // No provider outranks another, so two of them pricing one model must agree.
+  // Nothing registers two providers for one id today; this is what happens if
+  // something ever does, rather than an arbitrary first-one-wins.
+  const providerConflict = firstDisagreement(providers);
+  if (providerConflict) return conflict(providerConflict, 'mutual');
+
+  const provider = providers[0];
+  if (!provider) {
+    const aggregatorConflict = firstDisagreement(aggregators);
+    if (aggregatorConflict) return conflict(aggregatorConflict, 'mutual');
+    if (aggregators.length < 2) return { kind: 'lone', observation: aggregators[0] };
+    return {
+      kind: 'trusted',
+      observation: aggregators[0],
+      valueSources: aggregators.map(observation => observation.source),
+      dissenting: [],
+    };
+  }
+
+  const dissenting = aggregators.filter(observation =>
+    diverges(provider.price, observation.price, PRICE_AGREEMENT_TOLERANCE)
+  );
+  // Primary, not unaccountable: where mirrors exist, one of them has to back the
+  // provider up. All of them dissenting is the shape of a parser that broke
+  // against a docs restructure, which is exactly what must not reprice anything.
+  if (aggregators.length > 0 && dissenting.length === aggregators.length) {
+    return conflict([provider, dissenting[0]], 'uncorroborated');
+  }
+  return { kind: 'trusted', observation: provider, valueSources: [provider.source], dissenting };
+}
+
+/**
+ * The refusal, in the operator's terms. 'mutual' is two sources of equal standing
+ * contradicting each other; 'uncorroborated' is a provider price that nothing
+ * backs up. Passed in rather than inferred from the pair, because two providers
+ * disagreeing is 'mutual' even though both sides are providers.
+ */
+function conflict([left, right]: [PriceObservation, PriceObservation], reason: 'mutual' | 'uncorroborated'): Consensus {
+  const opening =
+    reason === 'uncorroborated'
+      ? `no source corroborates the provider within ${pct(PRICE_AGREEMENT_TOLERANCE)}`
+      : `sources disagree beyond ${pct(PRICE_AGREEMENT_TOLERANCE)}`;
+  return {
+    kind: 'conflict',
+    proposed: left.price,
+    detail:
+      `${opening}: ${left.source} ${describe(left.price)} vs ${right.source} ${describe(right.price)}; ` +
+      'applied neither',
+  };
 }
 
 /** The first pair that disagrees, so the flag can name both sides. */

--- a/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
+++ b/b4m-core/services/src/modelDiscoveryService/pricePlan.ts
@@ -111,7 +111,11 @@ export interface PricePlanInput {
 export interface PricePlan {
   rows: IModelPriceInput[];
   flags: PriceFlag[];
-  /** Rows written over a disagreeing source; one per row, never more. */
+  /**
+   * Models whose price came from a provider over a mirror that disagreed. One
+   * per model, and NOT a subset of `rows`: the provider's value standing
+   * unchanged is the steady state, and the stale mirror is the news either way.
+   */
   overrides: PriceOverride[];
   /** Usable observations that produced neither a row nor a flag, and why. */
   skipped: PriceSkip[];
@@ -202,7 +206,7 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
     // Trusted: a provider's own published price, or aggregators that already
     // passed the agreement check above. models.dev leads the aggregators by
     // registration order, not by name.
-    const { observation: trusted, valueSources, dissenting } = consensus;
+    const { observation: trusted, valueSources, corroborating, dissenting } = consensus;
     const proposed = trusted.price;
 
     if (current && classifyPriceRow(current) === 'operator') {
@@ -225,6 +229,30 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
     // unpriced at run start falls back to the row in force, which is one this run
     // wrote - its first write had nothing to band against either.
     const bandRow = atRunStart.get(modelId) ?? current;
+
+    // A ladder needs a corroborator that publishes a ladder, not just one that
+    // agrees on the short-prompt price. diverges() is deliberately silent when
+    // only ONE side carries brackets, so a mirror that went flat would otherwise
+    // corroborate the base rates and let the upper bracket be written on a single
+    // scrape's word. Checked here rather than in reachConsensus because a flat row
+    // in force discards the brackets anyway - refusing there would block writes
+    // whose ladder was never going to be used.
+    const ladderUncorroborated =
+      proposed.brackets !== undefined &&
+      current !== undefined &&
+      isTiered(current) &&
+      corroborating.length > 0 &&
+      !corroborating.some(observation => observation.price.brackets !== undefined);
+    if (ladderUncorroborated) {
+      flag(
+        'tiered-pricing-manual',
+        proposed,
+        `${trusted.source} publishes ${describe(proposed)} but ` +
+          `${corroborating.map(observation => observation.source).join(', ')} publish no long-context rates to ` +
+          'corroborate its brackets; repricing a tiered row needs a second source that carries the same ladder'
+      );
+      continue;
+    }
 
     // The read path REPLACES the whole pricing map, so a tiered row may only be
     // superseded by a write that reproduces every tier. That needs a ladder the
@@ -270,6 +298,27 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       continue;
     }
 
+    // Recorded wherever the provider's value STANDS - both when it is written and
+    // when the row in force already says it. Every refusal above is reported as
+    // its own flag, so this cannot double-report one; but 'unchanged' is the
+    // STEADY STATE once the catalog converges, and that is exactly when "which
+    // mirror has gone stale" is the only fact left to learn.
+    if (dissenting.length > 0) {
+      overrides.push({
+        modelId,
+        source: trusted.source,
+        dissenting: dissenting.map(observation => observation.source),
+        applied: perMTokOf(proposed),
+        // Present tense, like every flag detail: this planner runs identically in
+        // report mode, where nothing is written, so a sentence claiming a write
+        // would be false on the default run.
+        detail:
+          `${trusted.source} publishes ${describe(proposed)} and ` +
+          `${dissenting.map(observation => `${observation.source} ${describe(observation.price)}`).join(', ')} ` +
+          `disagree beyond ${pct(PRICE_AGREEMENT_TOLERANCE)}; the provider value wins`,
+      });
+    }
+
     // Carried forward per tier: the cache and audio rates no feed publishes come
     // from the tier under the SAME threshold, never from the row's lowest one.
     const tiers = planned.map(({ key, price }) => [key, buildTier(price, current?.pricing[key])] as const);
@@ -295,22 +344,6 @@ export function planPriceWrites(input: PricePlanInput): PricePlan {
       note: `${DISCOVERY_PRICE_NOTE_PREFIX}${valueSources.join('+')}@${input.runStartedAt.toISOString()}`,
       repricedBy: DISCOVERY_REPRICED_BY,
     });
-
-    // Recorded against the WRITE, not against the disagreement: a dissent that
-    // ended in a flag or a no-op is already reported as that, and reporting it
-    // twice would make the count of overridden sources unreadable.
-    if (dissenting.length > 0) {
-      overrides.push({
-        modelId,
-        source: trusted.source,
-        dissenting: dissenting.map(observation => observation.source),
-        applied: perMTokOf(proposed),
-        detail:
-          `${trusted.source} publishes ${describe(proposed)} and ` +
-          `${dissenting.map(observation => `${observation.source} ${describe(observation.price)}`).join(', ')} ` +
-          `disagree beyond ${pct(PRICE_AGREEMENT_TOLERANCE)}; the provider value was applied`,
-      });
-    }
   }
 
   return { rows, flags, overrides, skipped };
@@ -452,14 +485,18 @@ type Consensus =
       observation: PriceObservation;
       /** Credited in the row's note: the sources whose value it is. */
       valueSources: string[];
+      /** Aggregators that agree with a provider; empty in every other case. */
+      corroborating: PriceObservation[];
       /** Sources overruled by a provider, empty in every other case. */
       dissenting: PriceObservation[];
     };
 
 /**
- * A PROVIDER'S OWN PUBLISHED PRICE IS PRIMARY. It needs corroboration - one
- * aggregator that agrees with it - but not unanimity, and the aggregators that
- * disagree are recorded and overruled rather than allowed to veto.
+ * A PROVIDER'S OWN PUBLISHED PRICE IS PRIMARY. WHERE MIRRORS EXIST, one of them
+ * has to agree with it - but not all of them, and the ones that disagree are
+ * recorded and overruled rather than allowed to veto. A provider no aggregator
+ * prices at all still writes alone, which is what it has always done; that is a
+ * standing property of a provider source, not something this rule grants.
  *
  * That asymmetry is the whole point. The two aggregators are mirrors of the
  * provider, and a mirror goes stale on its own schedule: litellm publishes from a
@@ -490,20 +527,22 @@ function reachConsensus(observations: readonly PriceObservation[]): Consensus {
       kind: 'trusted',
       observation: aggregators[0],
       valueSources: aggregators.map(observation => observation.source),
+      corroborating: [],
       dissenting: [],
     };
   }
 
-  const dissenting = aggregators.filter(observation =>
-    diverges(provider.price, observation.price, PRICE_AGREEMENT_TOLERANCE)
-  );
+  const agrees = (observation: PriceObservation) =>
+    !diverges(provider.price, observation.price, PRICE_AGREEMENT_TOLERANCE);
+  const corroborating = aggregators.filter(agrees);
+  const dissenting = aggregators.filter(observation => !agrees(observation));
   // Primary, not unaccountable: where mirrors exist, one of them has to back the
   // provider up. All of them dissenting is the shape of a parser that broke
   // against a docs restructure, which is exactly what must not reprice anything.
-  if (aggregators.length > 0 && dissenting.length === aggregators.length) {
+  if (aggregators.length > 0 && corroborating.length === 0) {
     return conflict([provider, dissenting[0]], 'uncorroborated');
   }
-  return { kind: 'trusted', observation: provider, valueSources: [provider.source], dissenting };
+  return { kind: 'trusted', observation: provider, valueSources: [provider.source], corroborating, dissenting };
 }
 
 /**

--- a/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.test.ts
@@ -1164,6 +1164,38 @@ describe('runModelDiscovery', () => {
       expect(persisted.priceRows?.[0].effectiveFrom).toEqual(START);
     });
 
+    it('records the mirror a provider price was written over', async () => {
+      const stale = harness([
+        openaiSource(),
+        stubSource({
+          name: 'models.dev',
+          kind: 'aggregator',
+          records: [{ modelId: 'gpt-6', patch: {}, pricing: { inputPerMTok: 2, outputPerMTok: 8 } }],
+        }),
+        stubSource({
+          name: 'litellm',
+          kind: 'aggregator',
+          records: [{ modelId: 'gpt-6', patch: {}, pricing: { inputPerMTok: 8, outputPerMTok: 32 } }],
+        }),
+      ]);
+
+      const result = await runModelDiscovery(stale.adapters, stale.options);
+      const persisted = stale.runs.docs[0];
+
+      expect(persisted.priceRows).toHaveLength(1);
+      expect(persisted.priceFlags).toEqual([]);
+      // "litellm is 4x off for gpt-6" is the operational fact here, and it would
+      // be invisible if the write simply succeeded quietly.
+      expect(persisted.priceOverrides).toHaveLength(1);
+      expect(persisted.priceOverrides?.[0]).toMatchObject({
+        modelId: 'gpt-6',
+        source: 'openai',
+        dissenting: ['litellm'],
+        applied: { inputPerMTok: 2, outputPerMTok: 8 },
+      });
+      expect(persisted.priceOverrides?.[0].detail).toBe(result.prices.overrides[0].detail);
+    });
+
     it('records the skips a rerun produces in place of a row', async () => {
       await runModelDiscovery(bench.adapters, bench.options);
       bench.advance(60_000);

--- a/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.ts
+++ b/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.ts
@@ -45,6 +45,7 @@ import type {
   ModelDiscoveryMetrics,
   ModelDiscoveryRunResult,
   PriceFlag,
+  PriceOverride,
   PriceSkip,
   RunModelDiscoveryOptions,
   SourceResult,
@@ -434,6 +435,7 @@ async function executeRun(
     // admin reads a flag count with no way to learn which models or why.
     priceFlags: merged.priceFlags.slice(0, MAX_PERSISTED_RUN_DETAIL),
     priceRows: plannedPrices.slice(0, MAX_PERSISTED_RUN_DETAIL),
+    priceOverrides: merged.priceOverrides.slice(0, MAX_PERSISTED_RUN_DETAIL),
     priceSkips: merged.priceSkips.slice(0, MAX_PERSISTED_RUN_DETAIL),
     lifecycleTransitions: merged.transitions.slice(0, MAX_PERSISTED_RUN_DETAIL),
     catalogDiff: merged.diff.slice(0, MAX_PERSISTED_RUN_DETAIL),
@@ -443,6 +445,7 @@ async function executeRun(
     ...truncatedTotals({
       priceFlags: merged.priceFlags.length,
       priceRows: plannedPrices.length,
+      priceOverrides: merged.priceOverrides.length,
       priceSkips: merged.priceSkips.length,
       lifecycleTransitions: merged.transitions.length,
       catalogDiff: merged.diff.length,
@@ -467,7 +470,7 @@ async function executeRun(
     diff: merged.diff,
     droppedRecords: merged.droppedRecords,
     absence: passes[0].plan.absence,
-    prices: { rows: plannedPrices, flags: merged.priceFlags },
+    prices: { rows: plannedPrices, flags: merged.priceFlags, overrides: merged.priceOverrides },
     lifecycle: {
       transitions: merged.transitions,
       dateChanges: merged.dateChanges,
@@ -663,6 +666,7 @@ interface RunAggregate {
   droppedRecords: DroppedSourceRecord[];
   priceRows: IModelPriceInput[];
   priceFlags: PriceFlag[];
+  priceOverrides: PriceOverride[];
   priceSkips: PriceSkip[];
   transitions: LifecycleTransition[];
   dateChanges: LifecycleDateChange[];
@@ -705,6 +709,12 @@ function aggregate(passes: readonly CompletedPass[]): RunAggregate {
     priceFlags: lastPerKey(
       plans.flatMap(plan => plan.prices.flags),
       flag => `${flag.modelId} ${flag.kind}`
+    ),
+    // One per model: an override is tied to a row, and no model is repriced by
+    // more than one pass.
+    priceOverrides: lastPerKey(
+      plans.flatMap(plan => plan.prices.overrides),
+      override => override.modelId
     ),
     priceSkips: lastPerKey(
       plans.flatMap(plan => plan.prices.skipped),
@@ -1192,7 +1202,7 @@ function skippedResult(
     diff: [],
     droppedRecords: [],
     absence: { sighted: [], missed: [], frozenBackends: [] },
-    prices: { rows: [], flags: [] },
+    prices: { rows: [], flags: [], overrides: [] },
     lifecycle: { transitions: [], dateChanges: [], suggestions: [], wouldDeprecate: [] },
     metrics: emptyMetrics(),
     passes: 1,

--- a/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.ts
+++ b/b4m-core/services/src/modelDiscoveryService/runModelDiscovery.ts
@@ -710,8 +710,9 @@ function aggregate(passes: readonly CompletedPass[]): RunAggregate {
       plans.flatMap(plan => plan.prices.flags),
       flag => `${flag.modelId} ${flag.kind}`
     ),
-    // One per model: an override is tied to a row, and no model is repriced by
-    // more than one pass.
+    // One per model, newest kept. A pass whose append threw leaves the row out
+    // of force, so the next pass re-plans that model and produces the same
+    // override again - and two identical entries would read as two mirrors.
     priceOverrides: lastPerKey(
       plans.flatMap(plan => plan.prices.overrides),
       override => override.modelId

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/README.txt
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/README.txt
@@ -1,17 +1,20 @@
-pricing.md and the three model-*.md files are LIVE CAPTURES, fetched 2026-07-31
+pricing.md and the four model-*.md files are LIVE CAPTURES, fetched 2026-07-31
 from platform.openai.com (which serves a markdown twin of any docs page at
 <path>.md). No row, rate or bullet is edited.
 
-pricing.md is trimmed to the Standard table the parser reads plus the three
-tables it must NOT read: Batch and Flex, whose headers are byte-identical to
-Standard and whose rates are half of it, and a Grouped Pricing table, whose
-columns are a different shape entirely. Picking any of them fails a test.
+pricing.md is trimmed to the Standard table the parser reads plus four tables it
+must NOT read: Batch and Flex, whose headers are byte-identical to Standard's and
+whose rates are half of it; Fast, which carries only the four short-context
+columns; and a Grouped Pricing table, whose columns are a different shape
+entirely. Picking any of them fails a test.
 
-The model-*.md captures cover the three shapes of the long-context breakpoint
-bullet: gpt-5.6-luna states it plainly, gpt-5.4 buries it in a longer sentence
-about the family, and gpt-5.4-mini has no long-context pricing and so no bullet
-at all. One prose paragraph carrying a curly apostrophe was dropped from each
-(the repo is ASCII-only); it is boilerplate no parser reads.
+The model-*.md captures cover the shapes of the long-context breakpoint bullet:
+gpt-5.6-luna and gpt-5.6-sol state it plainly, gpt-5.4 buries it in a longer
+sentence about the family, and gpt-5.4-mini has no long-context pricing and so no
+bullet at all. sol also serves as the wrong page in the test that proves a
+breakpoint is refused unless the page states the model id it was asked for. One
+prose paragraph carrying a curly apostrophe was dropped from each (the repo is
+ASCII-only); it is boilerplate no parser reads.
 
 parser-broke-pricing.md is CONSTRUCTED: the page restructured so the Standard
 heading and the "Short context" column names are gone. It must parse to a

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/README.txt
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/README.txt
@@ -1,0 +1,21 @@
+pricing.md and the three model-*.md files are LIVE CAPTURES, fetched 2026-07-31
+from platform.openai.com (which serves a markdown twin of any docs page at
+<path>.md). No row, rate or bullet is edited.
+
+pricing.md is trimmed to the Standard table the parser reads plus the three
+tables it must NOT read: Batch and Flex, whose headers are byte-identical to
+Standard and whose rates are half of it, and a Grouped Pricing table, whose
+columns are a different shape entirely. Picking any of them fails a test.
+
+The model-*.md captures cover the three shapes of the long-context breakpoint
+bullet: gpt-5.6-luna states it plainly, gpt-5.4 buries it in a longer sentence
+about the family, and gpt-5.4-mini has no long-context pricing and so no bullet
+at all. One prose paragraph carrying a curly apostrophe was dropped from each
+(the repo is ASCII-only); it is boilerplate no parser reads.
+
+parser-broke-pricing.md is CONSTRUCTED: the page restructured so the Standard
+heading and the "Short context" column names are gone. It must parse to a
+failure, never to a partial table.
+
+models.json, expected.json and the malformed/empty/unknown-enum variants are the
+/v1/models fixtures and predate this set.

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.4-mini.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.4-mini.md
@@ -1,0 +1,33 @@
+# GPT-5.4 mini
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+> Our strongest mini model yet for coding, computer use, and subagents
+
+Model ID: `gpt-5.4-mini`
+
+GPT-5.4 mini brings the strengths of GPT-5.4 to a faster, more efficient
+model designed for high-volume workloads. Learn more in our
+[Model guidance](/api/docs/guides/latest-model) page. Reasoning.effort supports: none (default), low, medium, high and xhigh.
+
+## Model details
+
+- Default snapshot: `gpt-5.4-mini-2026-03-17`
+- Input modalities: text, image
+- Output modalities: text
+- 400,000 context window
+- Maximum input tokens: 272,000
+- 128,000 max output tokens
+- Aug 31, 2025 knowledge cutoff
+- Reasoning token support
+
+## Pricing
+
+
+### Text tokens
+
+| Metric | Price | Unit |
+| --- | ---: | --- |
+| Input | $0.75 | 1M tokens |
+| Cached input | $0.075 | 1M tokens |
+| Output | $4.5 | 1M tokens |

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.4.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.4.md
@@ -1,0 +1,35 @@
+# GPT-5.4
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+> A more affordable model for coding and professional work.
+
+Model ID: `gpt-5.4`
+
+GPT-5.4 is our frontier model for complex professional work.
+Learn more in our [GPT-5.4 model guidance](/api/docs/guides/latest-model?model=gpt-5.4). Reasoning.effort supports: none (default), low, medium, high and xhigh.
+
+## Model details
+
+- Default snapshot: `gpt-5.4-2026-03-05`
+- Input modalities: text, image
+- Output modalities: text
+- 1,050,000 context window
+- 128,000 max output tokens
+- Aug 31, 2025 knowledge cutoff
+- Reasoning token support
+
+## Pricing
+
+
+### Text tokens
+
+| Metric | Price | Unit |
+| --- | ---: | --- |
+| Input | $2.5 | 1M tokens |
+| Cached input | $0.25 | 1M tokens |
+| Output | $15 | 1M tokens |
+
+- For models with a 1.05M context window (GPT-5.4 and GPT-5.4 Pro), prompts with >272K input tokens are priced at 2x input and 1.5x output for the full session for standard, batch, and flex.
+- Regional processing (data residency) endpoints are charged a 10% uplift for GPT-5.4 and GPT-5.4 Pro.
+

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.6-luna.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.6-luna.md
@@ -1,0 +1,36 @@
+# GPT-5.6 Luna
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+> GPT-5.6 model optimized for cost-sensitive workloads
+
+Model ID: `gpt-5.6-luna`
+
+GPT-5.6 Luna is designed for cost-sensitive, high-volume workloads. It
+roughly corresponds to the nano model tier used in earlier GPT-5 families.
+
+## Model details
+
+- Default snapshot: `gpt-5.6-luna`
+- Input modalities: text, image
+- Output modalities: text
+- 1,050,000 context window
+- Maximum input tokens: 922,000
+- 128,000 max output tokens
+- Feb 16, 2026 knowledge cutoff
+- Reasoning token support
+
+## Pricing
+
+
+### Text tokens
+
+| Metric | Price | Unit |
+| --- | ---: | --- |
+| Input | $0.2 | 1M tokens |
+| Cached input | $0.02 | 1M tokens |
+| Output | $1.2 | 1M tokens |
+
+- Prompts with >272K input tokens are priced at 2x input and 1.5x output for the full request.
+- Cache writes are billed at 1.25x the uncached input token rate.
+

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.6-sol.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/model-gpt-5.6-sol.md
@@ -1,0 +1,37 @@
+# GPT-5.6 Sol
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+> Frontier model for complex professional work
+
+Model ID: `gpt-5.6-sol`
+
+GPT-5.6 Sol is the frontier model in the GPT-5.6 family. It roughly
+corresponds to the unsuffixed model tier used in earlier GPT-5 families.
+The `gpt-5.6` alias routes requests to GPT-5.6 Sol.
+
+## Model details
+
+- Default snapshot: `gpt-5.6-sol`
+- Input modalities: text, image
+- Output modalities: text
+- 1,050,000 context window
+- Maximum input tokens: 922,000
+- 128,000 max output tokens
+- Feb 16, 2026 knowledge cutoff
+- Reasoning token support
+
+## Pricing
+
+
+### Text tokens
+
+| Metric | Price | Unit |
+| --- | ---: | --- |
+| Input | $5 | 1M tokens |
+| Cached input | $0.5 | 1M tokens |
+| Output | $30 | 1M tokens |
+
+- Prompts with >272K input tokens are priced at 2x input and 1.5x output for the full request.
+- Cache writes are billed at 1.25x the uncached input token rate.
+

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/parser-broke-pricing.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/parser-broke-pricing.md
@@ -1,0 +1,10 @@
+# Pricing
+
+Standard
+
+### Pay-as-you-go rates
+
+| Model | Input | Cached input | Cache writes | Output |
+| --- | --- | --- | --- | --- |
+| gpt-5.6-luna | $0.20 | $0.02 | $0.25 | $1.20 |
+| gpt-5.6-terra | $2.00 | $0.20 | $2.50 | $12.00 |

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/pricing.md
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/openai/pricing.md
@@ -1,0 +1,130 @@
+# Pricing
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of documentation pages are available by appending `.md` to the page URL.
+
+Flagship models
+
+
+    
+Our latest models
+
+    
+Prices per 1M tokens.
+
+  
+
+
+  
+
+Standard
+
+
+      
+### Standard pricing data
+
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-5.6-sol | $5.00 | $0.50 | $6.25 | $30.00 | $10.00 | $1.00 | $12.50 | $45.00 |
+| gpt-5.6-terra | $2.00 | $0.20 | $2.50 | $12.00 | $4.00 | $0.40 | $5.00 | $18.00 |
+| gpt-5.6-luna | $0.20 | $0.02 | $0.25 | $1.20 | $0.40 | $0.04 | $0.50 | $1.80 |
+| gpt-5.5 (<272K context length) | $5.00 | $0.50 | - | $30.00 | $10.00 | $1.00 | - | $45.00 |
+| gpt-5.5-pro (<272K context length) | $30.00 | - | - | $180.00 | $60.00 | - | - | $270.00 |
+| gpt-5.4 (<272K context length) | $2.50 | $0.25 | - | $15.00 | $5.00 | $0.50 | - | $22.50 |
+| gpt-5.4-mini | $0.75 | $0.075 | - | $4.50 | - | - | - | - |
+| gpt-5.4-nano | $0.20 | $0.02 | - | $1.25 | - | - | - | - |
+| gpt-5.4-pro (<272K context length) | $30.00 | - | - | $180.00 | $60.00 | - | - | $270.00 |
+| gpt-5.2 | $1.75 | $0.175 | - | $14.00 | - | - | - | - |
+| gpt-5.2-pro | $21.00 | - | - | $168.00 | - | - | - | - |
+| gpt-5.1 | $1.25 | $0.125 | - | $10.00 | - | - | - | - |
+| gpt-5 | $1.25 | $0.125 | - | $10.00 | - | - | - | - |
+| gpt-5-mini | $0.25 | $0.025 | - | $2.00 | - | - | - | - |
+| gpt-5-nano | $0.05 | $0.005 | - | $0.40 | - | - | - | - |
+| gpt-5-pro | $15.00 | - | - | $120.00 | - | - | - | - |
+| gpt-4.1 | $2.00 | $0.50 | - | $8.00 | - | - | - | - |
+| gpt-4.1-mini | $0.40 | $0.10 | - | $1.60 | - | - | - | - |
+| gpt-4.1-nano | $0.10 | $0.025 | - | $0.40 | - | - | - | - |
+| gpt-4o | $2.50 | $1.25 | - | $10.00 | - | - | - | - |
+| gpt-4o-2024-05-13 | $5.00 | - | - | $15.00 | - | - | - | - |
+| gpt-4o-mini | $0.15 | $0.075 | - | $0.60 | - | - | - | - |
+| o1 | $15.00 | $7.50 | - | $60.00 | - | - | - | - |
+| o1-pro | $150.00 | - | - | $600.00 | - | - | - | - |
+| o3-pro | $20.00 | - | - | $80.00 | - | - | - | - |
+| o3 | $2.00 | $0.50 | - | $8.00 | - | - | - | - |
+| o4-mini | $1.10 | $0.275 | - | $4.40 | - | - | - | - |
+| o3-mini | $1.10 | $0.55 | - | $4.40 | - | - | - | - |
+| gpt-4-turbo-2024-04-09 | $10.00 | - | - | $30.00 | - | - | - | - |
+| gpt-4-0613 | $30.00 | - | - | $60.00 | - | - | - | - |
+| gpt-3.5-turbo | $0.50 | - | - | $1.50 | - | - | - | - |
+| gpt-3.5-turbo-0125 | $0.50 | - | - | $1.50 | - | - | - | - |
+| gpt-3.5-turbo-1106 | $1.00 | - | - | $2.00 | - | - | - | - |
+| gpt-3.5-turbo-instruct | $1.50 | - | - | $2.00 | - | - | - | - |
+| davinci-002 | $2.00 | - | - | $2.00 | - | - | - | - |
+| babbage-002 | $0.40 | - | - | $0.40 | - | - | - | - |
+
+Regional processing (data residency) endpoints are charged a 10% uplift for models released on or after March 5, 2026, that are eligible for data residency. See our [Your data](https://developers.openai.com/api/docs/guides/your-data) guide for supported regions and processing details. [OpenAI models in Amazon Bedrock](https://developers.openai.com/api/docs/guides/amazon-bedrock) are billed through AWS and may differ from direct OpenAI pricing. Priority processing was renamed Fast mode on July 30, 2026. You can use either `service_tier: "priority"` or `service_tier: "fast"` in your API requests. [Learn more about Fast mode](https://developers.openai.com/api/docs/guides/fast-mode).
+
+    
+
+    
+
+      
+Batch
+
+
+      
+### Batch pricing data
+
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-5.6-sol | $2.50 | $0.25 | $3.125 | $15.00 | $5.00 | $0.50 | $6.25 | $22.50 |
+| gpt-5.6-terra | $1.00 | $0.10 | $1.25 | $6.00 | $2.00 | $0.20 | $2.50 | $9.00 |
+| gpt-5.6-luna | $0.10 | $0.01 | $0.125 | $0.60 | $0.20 | $0.02 | $0.25 | $0.90 |
+| gpt-5.5 (<272K context length) | $2.50 | $0.25 | - | $15.00 | $5.00 | $0.50 | - | $22.50 |
+| gpt-5.5-pro (<272K context length) | $15.00 | - | - | $90.00 | - | - | - | - |
+| gpt-5.4 (<272K context length) | $1.25 | $0.13 | - | $7.50 | $2.50 | $0.25 | - | $11.25 |
+
+      
+Flex
+
+
+      
+### Flex pricing data
+
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-5.6-sol | $2.50 | $0.25 | $3.125 | $15.00 | $5.00 | $0.50 | $6.25 | $22.50 |
+| gpt-5.6-terra | $1.00 | $0.10 | $1.25 | $6.00 | $2.00 | $0.20 | $2.50 | $9.00 |
+| gpt-5.6-luna | $0.10 | $0.01 | $0.125 | $0.60 | $0.20 | $0.02 | $0.25 | $0.90 |
+| gpt-5.5 (<272K context length) | $2.50 | $0.25 | - | $15.00 | $5.00 | $0.50 | - | $22.50 |
+| gpt-5.5-pro (<272K context length) | $15.00 | - | - | $90.00 | - | - | - | - |
+| gpt-5.4 (<272K context length) | $1.25 | $0.13 | - | $7.50 | $2.50 | $0.25 | - | $11.25 |
+
+      
+Fast mode
+
+
+      
+### Fast pricing data
+
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output |
+| --- | --- | --- | --- | --- |
+| gpt-5.6-sol | $10.00 | $1.00 | $12.50 | $60.00 |
+| gpt-5.6-terra | $4.00 | $0.40 | $5.00 | $24.00 |
+| gpt-5.6-luna | $0.40 | $0.04 | $0.50 | $2.40 |
+| gpt-5.5 (<272K context length) | $12.50 | $1.25 | - | $75.00 |
+| gpt-5.4 (<272K context length) | $5.00 | $0.50 | - | $30.00 |
+| gpt-5.4-mini | $1.50 | $0.15 | - | $9.00 |
+
+Prices per 1M tokens unless noted.
+
+
+### Grouped Pricing Table data
+
+| Model | Modality | Input | Cached input | Output / cost |
+| --- | --- | --- | --- | --- |
+| gpt-realtime-2.1 | Audio | $32.00 | $0.40 | $64.00 |
+| gpt-realtime-2.1 | Text | $4.00 | $0.40 | $24.00 |
+| gpt-realtime-2.1 | Image | $5.00 | $0.50 | - |
+| gpt-realtime-2.1-mini | Audio | $10.00 | $0.30 | $20.00 |
+| gpt-realtime-2.1-mini | Text | $0.60 | $0.06 | $2.40 |
+

--- a/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/testSupport.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/__fixtures__/testSupport.ts
@@ -39,7 +39,8 @@ export interface StubResponse {
   headers?: Record<string, string>;
 }
 
-type Route = (url: string) => StubResponse | undefined;
+/** `init` is passed through so a test can assert what headers a request carried. */
+type Route = (url: string, init?: RequestInit) => StubResponse | undefined;
 
 /**
  * Replace global fetch with a route table. Sources are exercised through their
@@ -52,7 +53,7 @@ export function stubFetch(route: Route | StubResponse): () => void {
   const spy = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     init?.signal?.throwIfAborted();
-    const stub = resolve(url);
+    const stub = resolve(url, init);
     if (!stub) throw new Error(`unstubbed fetch: ${url}`);
     const status = stub.status ?? 200;
     const body = stub.raw ?? JSON.stringify(stub.body ?? {});

--- a/b4m-core/services/src/modelDiscoveryService/sources/anthropicDocs.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/anthropicDocs.ts
@@ -1,24 +1,17 @@
 import type { ModelRecord } from '@bike4mind/common';
+import { parseRate, plain, tables, type ParseResult } from './markdown';
 
 /**
  * Parsers for Anthropic's two published markdown twins: `model-deprecations.md`
  * (the only typed lifecycle feed a direct provider gives us) and `pricing.md`.
  *
- * Both return `{ ok: false }` when they find valid markdown and zero rows. "The
- * page rendered and I found nothing" is the shape of a parser that broke against
- * a docs restructure, not of a provider that retired everything (sec 5.5), and
- * an empty success here would freeze every Claude lifecycle field at once.
+ * Both return `{ ok: false }` when they find valid markdown and zero rows - see
+ * ParseResult in ./markdown for why that is never an empty success.
  */
-export type ParseResult<T> = { ok: true; rows: T[] } | { ok: false; error: string };
+export type { ParseResult };
 
 export const ANTHROPIC_DEPRECATIONS_URL = 'https://docs.claude.com/en/docs/about-claude/model-deprecations.md';
 export const ANTHROPIC_PRICING_URL = 'https://docs.claude.com/en/docs/about-claude/pricing.md';
-
-interface MarkdownTable {
-  heading: string;
-  headers: string[];
-  rows: string[][];
-}
 
 const MONTHS: Readonly<Record<string, string>> = {
   january: '01',
@@ -35,44 +28,6 @@ const MONTHS: Readonly<Record<string, string>> = {
   december: '12',
 };
 
-const cells = (line: string): string[] =>
-  line
-    .replace(/^\s*\|/, '')
-    .replace(/\|\s*$/, '')
-    .split('|')
-    .map(cell => cell.trim());
-
-const isSeparator = (line: string): boolean => /^\s*\|[\s:|-]+\|\s*$/.test(line);
-
-/** Every pipe table in the document, tagged with the nearest preceding heading. */
-function tables(markdown: string): MarkdownTable[] {
-  const lines = markdown.split(/\r?\n/);
-  const found: MarkdownTable[] = [];
-  let heading = '';
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? '';
-    const headingMatch = /^#{1,6}\s+(.*)$/.exec(line);
-    if (headingMatch) {
-      heading = (headingMatch[1] ?? '').trim();
-      continue;
-    }
-    if (!line.trimStart().startsWith('|') || !isSeparator(lines[index + 1] ?? '')) continue;
-
-    const headers = cells(line);
-    const rows: string[][] = [];
-    index += 2;
-    while (index < lines.length && (lines[index] ?? '').trimStart().startsWith('|')) {
-      rows.push(cells(lines[index] ?? ''));
-      index += 1;
-    }
-    index -= 1;
-    found.push({ heading, headers, rows });
-  }
-
-  return found;
-}
-
 /** "June 9, 2027" -> "2027-06-09". Undefined for "N/A", "TBD" and anything else. */
 export function parseLongDate(value: string): string | undefined {
   const match = /([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})/.exec(value);
@@ -80,13 +35,6 @@ export function parseLongDate(value: string): string | undefined {
   if (!match || !month) return undefined;
   return `${match[3]}-${month}-${String(match[2]).padStart(2, '0')}`;
 }
-
-/** Strip inline links and code ticks, keeping the link text: docs pages are MDX. */
-const plain = (value: string): string =>
-  value
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/[`*]/g, '')
-    .trim();
 
 export interface AnthropicLifecycleRow {
   modelId: string;
@@ -173,14 +121,6 @@ export interface AnthropicPriceRow {
   validUntil?: string;
   /** First day this row's rate applies, from a "starting <date>" note. */
   validFrom?: string;
-}
-
-/** "$12.50 / MTok" -> 12.5. Undefined for "N/A" and for anything without a figure. */
-function parseRate(cell: string): number | undefined {
-  const match = /\$\s*([\d,]+(?:\.\d+)?)/.exec(plain(cell));
-  if (!match) return undefined;
-  const value = Number(match[1]?.replace(/,/g, ''));
-  return Number.isFinite(value) ? value : undefined;
 }
 
 /** "Claude Sonnet 5 through August 31, 2026" -> slug + the box that qualifies it. */

--- a/b4m-core/services/src/modelDiscoveryService/sources/index.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/index.ts
@@ -22,4 +22,5 @@ export * from './litellm';
 export * from './modelsDev';
 export * from './ollama';
 export * from './openai';
+export * from './openaiDocs';
 export * from './xai';

--- a/b4m-core/services/src/modelDiscoveryService/sources/markdown.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/markdown.ts
@@ -1,0 +1,78 @@
+/**
+ * Markdown reading shared by the docs scrapers (anthropicDocs, openaiDocs).
+ *
+ * Both providers publish their pricing and lifecycle pages as `.md` twins of the
+ * rendered docs, and both express the facts we want as pipe tables under a
+ * heading. This module owns that reading so a page-shape fix lands once.
+ */
+
+/**
+ * A parser's result. Every parser here returns `{ ok: false }` when it finds
+ * valid markdown and zero rows: "the page rendered and I found nothing" is the
+ * shape of a parser that broke against a docs restructure, not of a provider that
+ * retired or unpriced everything (sec 5.5), and an empty success would freeze or
+ * clear a whole field group at once.
+ */
+export type ParseResult<T> = { ok: true; rows: T[] } | { ok: false; error: string };
+
+export interface MarkdownTable {
+  heading: string;
+  headers: string[];
+  rows: string[][];
+}
+
+export const cells = (line: string): string[] =>
+  line
+    .replace(/^\s*\|/, '')
+    .replace(/\|\s*$/, '')
+    .split('|')
+    .map(cell => cell.trim());
+
+export const isSeparator = (line: string): boolean => /^\s*\|[\s:|-]+\|\s*$/.test(line);
+
+/** Every pipe table in the document, tagged with the nearest preceding heading. */
+export function tables(markdown: string): MarkdownTable[] {
+  const lines = markdown.split(/\r?\n/);
+  const found: MarkdownTable[] = [];
+  let heading = '';
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const headingMatch = /^#{1,6}\s+(.*)$/.exec(line);
+    if (headingMatch) {
+      heading = (headingMatch[1] ?? '').trim();
+      continue;
+    }
+    if (!line.trimStart().startsWith('|') || !isSeparator(lines[index + 1] ?? '')) continue;
+
+    const headers = cells(line);
+    const rows: string[][] = [];
+    index += 2;
+    while (index < lines.length && (lines[index] ?? '').trimStart().startsWith('|')) {
+      rows.push(cells(lines[index] ?? ''));
+      index += 1;
+    }
+    index -= 1;
+    found.push({ heading, headers, rows });
+  }
+
+  return found;
+}
+
+/** Strip inline links and code ticks, keeping the link text: docs pages are MDX. */
+export const plain = (value: string): string =>
+  value
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[`*]/g, '')
+    .trim();
+
+/**
+ * "$12.50 / MTok" and "$0.20" -> 12.5 and 0.2. Undefined for "N/A", "-" and
+ * anything else carrying no figure, which is how both pages write "not published".
+ */
+export function parseRate(cell: string): number | undefined {
+  const match = /\$\s*([\d,]+(?:\.\d+)?)/.exec(plain(cell));
+  if (!match) return undefined;
+  const value = Number(match[1]?.replace(/,/g, ''));
+  return Number.isFinite(value) ? value : undefined;
+}

--- a/b4m-core/services/src/modelDiscoveryService/sources/openai.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openai.test.ts
@@ -8,7 +8,13 @@ import models from './__fixtures__/openai/models.json';
 import expected from './__fixtures__/openai/expected.json';
 import unknownEnum from './__fixtures__/openai/unknown-enum.json';
 import { expectDegradesOnFailure, makeContext, stubFetch, type StubResponse } from './__fixtures__/testSupport';
-import { createOpenAiSource, mergeOpenAiPricing, normalizeOpenAiModels, OPENAI_MODELS_URL } from './openai';
+import {
+  createOpenAiSource,
+  mergeOpenAiPricing,
+  normalizeOpenAiModels,
+  OPENAI_MAX_MODEL_DOC_FETCHES,
+  OPENAI_MODELS_URL,
+} from './openai';
 import { OPENAI_PRICING_URL, openAiModelDocUrl } from './openaiDocs';
 import type { DiscoveredModel, SourceResult } from '../types';
 
@@ -99,14 +105,18 @@ describe('openai source fetch', () => {
   });
 
   it('sends the bearer credential to the models endpoint, and no credential to the docs', async () => {
-    const seen: Array<{ url: string; auth: string | null }> = [];
-    const restore = stubFetch(url => {
-      seen.push({ url, auth: null });
+    const seen: Array<{ url: string; auth: unknown }> = [];
+    const restore = stubFetch((url, init) => {
+      seen.push({ url, auth: (init?.headers as Record<string, string> | undefined)?.authorization });
       return url === OPENAI_MODELS_URL ? { body: listing(['gpt-5']) } : { raw: pricingMarkdown };
     });
     try {
       await createOpenAiSource().fetch(makeContext());
       expect(seen.map(entry => entry.url)).toEqual([OPENAI_MODELS_URL, OPENAI_PRICING_URL]);
+      expect(seen[0].auth).toBe('Bearer test-openai');
+      // platform.openai.com is a third-party-shaped read that also follows
+      // redirects, so it must never carry the key.
+      expect(seen[1].auth).toBeUndefined();
     } finally {
       restore();
     }
@@ -210,6 +220,55 @@ describe('openai source pricing', () => {
       const result = await createOpenAiSource().fetch(makeContext());
       expect(result.ok).toBe(true);
       expect(pricedBy(result, 'gpt-5.6-luna')).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('refuses a breakpoint from a page that is not the model it asked for', async () => {
+    // The docs request follows redirects, so a soft 404 answers 200 with somebody
+    // else's document - and the breakpoint parser takes the first match in
+    // whatever it is handed. Serving sol's page for luna must yield no price.
+    const { route } = routes({
+      list: listing(['gpt-5.6-luna']),
+      modelPages: { 'gpt-5.6-luna': { raw: read('model-gpt-5.6-sol.md') } },
+    });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok).toBe(true);
+      expect(pricedBy(result, 'gpt-5.6-luna')).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('bounds the model-page fan-out at the cap, whatever the page asks for', async () => {
+    // The guard against a restructure that made every row look like it needs a
+    // breakpoint. Build a Standard table of long-context rows with no inline
+    // annotation, one per listed model, and count the pages actually fetched.
+    const many = Array.from({ length: OPENAI_MAX_MODEL_DOC_FETCHES + 8 }, (_unused, index) => `gpt-many-${index}`);
+    const table = [
+      '### Standard pricing data',
+      '',
+      '| Model | Short context input | Short context cached input | Short context cache writes |' +
+        ' Short context output | Long context input | Long context cached input | Long context cache writes |' +
+        ' Long context output |',
+      '| --- | --- | --- | --- | --- | --- | --- | --- | --- |',
+      ...many.map(id => `| ${id} | $1.00 | - | - | $2.00 | $2.00 | - | - | $4.00 |`),
+      '',
+    ].join('\n');
+
+    const { seen, route } = routes({
+      list: listing(many),
+      pricing: { raw: table },
+      modelPages: Object.fromEntries(many.map(id => [id, { raw: read('model-gpt-5.6-luna.md') }])),
+    });
+    const restore = stubFetch(route);
+    try {
+      await createOpenAiSource().fetch(makeContext());
+      const modelPages = seen.filter(url => url !== OPENAI_MODELS_URL && url !== OPENAI_PRICING_URL);
+      expect(modelPages).toHaveLength(OPENAI_MAX_MODEL_DOC_FETCHES);
     } finally {
       restore();
     }

--- a/b4m-core/services/src/modelDiscoveryService/sources/openai.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openai.test.ts
@@ -1,11 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import empty from './__fixtures__/openai/empty.json';
 import malformed from './__fixtures__/openai/malformed.json';
 import models from './__fixtures__/openai/models.json';
 import expected from './__fixtures__/openai/expected.json';
 import unknownEnum from './__fixtures__/openai/unknown-enum.json';
-import { expectDegradesOnFailure, makeContext, stubFetch } from './__fixtures__/testSupport';
-import { createOpenAiSource, normalizeOpenAiModels, OPENAI_MODELS_URL } from './openai';
+import { expectDegradesOnFailure, makeContext, stubFetch, type StubResponse } from './__fixtures__/testSupport';
+import { createOpenAiSource, mergeOpenAiPricing, normalizeOpenAiModels, OPENAI_MODELS_URL } from './openai';
+import { OPENAI_PRICING_URL, openAiModelDocUrl } from './openaiDocs';
+import type { DiscoveredModel, SourceResult } from '../types';
+
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'openai');
+const read = (name: string) => readFileSync(join(fixtures, name), 'utf8');
+
+const pricingMarkdown = read('pricing.md');
+
+/** A listing carrying only the ids a case cares about. */
+const listing = (ids: readonly string[]) => ({ data: ids.map(id => ({ id, object: 'model' })) });
+
+/**
+ * The route table every pricing case shares: the listing, the pricing page, and a
+ * model page per id that has one. Anything else is an unstubbed fetch, which
+ * throws - so a case cannot pass by accidentally reading a page it did not mean to.
+ */
+function routes(options: {
+  list?: unknown;
+  pricing?: StubResponse;
+  modelPages?: Readonly<Record<string, StubResponse>>;
+}) {
+  const seen: string[] = [];
+  const route = (url: string): StubResponse | undefined => {
+    seen.push(url);
+    if (url === OPENAI_MODELS_URL) return { body: options.list ?? models };
+    if (url === OPENAI_PRICING_URL) return options.pricing ?? { raw: pricingMarkdown };
+    for (const [modelId, response] of Object.entries(options.modelPages ?? {})) {
+      if (url === openAiModelDocUrl(modelId)) return response;
+    }
+    return undefined;
+  };
+  return { seen, route };
+}
+
+const pricedBy = (result: SourceResult, modelId: string) =>
+  result.ok ? result.records.find(record => record.modelId === modelId)?.pricing : undefined;
 
 describe('openai source normalization', () => {
   it('matches the golden file for the captured response', () => {
@@ -45,7 +84,8 @@ describe('openai source fetch', () => {
   });
 
   it('claims authority for the openai backend on a successful listing', async () => {
-    const restore = stubFetch({ body: models });
+    const { route } = routes({ modelPages: { 'gpt-5.6-sol': { raw: read('model-gpt-5.6-sol.md') } } });
+    const restore = stubFetch(route);
     try {
       const result = await createOpenAiSource().fetch(makeContext());
       expect(result.ok).toBe(true);
@@ -58,15 +98,15 @@ describe('openai source fetch', () => {
     }
   });
 
-  it('sends the bearer credential to the models endpoint', async () => {
-    const seen: string[] = [];
+  it('sends the bearer credential to the models endpoint, and no credential to the docs', async () => {
+    const seen: Array<{ url: string; auth: string | null }> = [];
     const restore = stubFetch(url => {
-      seen.push(url);
-      return { body: models };
+      seen.push({ url, auth: null });
+      return url === OPENAI_MODELS_URL ? { body: listing(['gpt-5']) } : { raw: pricingMarkdown };
     });
     try {
       await createOpenAiSource().fetch(makeContext());
-      expect(seen).toEqual([OPENAI_MODELS_URL]);
+      expect(seen.map(entry => entry.url)).toEqual([OPENAI_MODELS_URL, OPENAI_PRICING_URL]);
     } finally {
       restore();
     }
@@ -92,4 +132,150 @@ describe('openai source fetch', () => {
   });
 
   expectDegradesOnFailure(() => createOpenAiSource());
+});
+
+describe('openai source pricing', () => {
+  it('prices a flat model straight off the pricing page', async () => {
+    const { route } = routes({ list: listing(['gpt-5.4-nano']) });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(pricedBy(result, 'gpt-5.4-nano')).toEqual({
+        inputPerMTok: 0.2,
+        outputPerMTok: 1.25,
+        cacheReadPerMTok: 0.02,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('reads a model page for the breakpoint its pricing row does not state', async () => {
+    const { seen, route } = routes({
+      list: listing(['gpt-5.6-luna']),
+      modelPages: { 'gpt-5.6-luna': { raw: read('model-gpt-5.6-luna.md') } },
+    });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(seen).toContain(openAiModelDocUrl('gpt-5.6-luna'));
+      expect(pricedBy(result, 'gpt-5.6-luna')).toEqual({
+        inputPerMTok: 0.2,
+        outputPerMTok: 1.2,
+        cacheReadPerMTok: 0.02,
+        cacheWritePerMTok: 0.25,
+        brackets: [
+          {
+            aboveTokens: 272_000,
+            inputPerMTok: 0.4,
+            outputPerMTok: 1.8,
+            cacheReadPerMTok: 0.04,
+            cacheWritePerMTok: 0.5,
+          },
+        ],
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('reads no model page when the pricing row states the breakpoint inline', async () => {
+    // gpt-5.5's own cell says "(<272K context length)", so the fan-out has nothing
+    // to resolve. A page fetched here would be an unstubbed fetch, which throws.
+    const { seen, route } = routes({ list: listing(['gpt-5.5']) });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(seen).toEqual([OPENAI_MODELS_URL, OPENAI_PRICING_URL]);
+      expect(pricedBy(result, 'gpt-5.5')).toMatchObject({
+        inputPerMTok: 5,
+        outputPerMTok: 30,
+        brackets: [{ aboveTokens: 272_000, inputPerMTok: 10, outputPerMTok: 45 }],
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('prices nothing at all for a long-context model whose breakpoint it cannot place', async () => {
+    // Not the base rates: this source is a provider, so a flat value would win
+    // over the aggregators AND block the tiered reprice they can still do between
+    // them. Saying nothing leaves the model where it was.
+    const { route } = routes({
+      list: listing(['gpt-5.6-luna']),
+      modelPages: { 'gpt-5.6-luna': { status: 404, raw: 'not found' } },
+    });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok).toBe(true);
+      expect(pricedBy(result, 'gpt-5.6-luna')).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('stops the model-page fan-out at the deadline instead of running past it', async () => {
+    const { seen, route } = routes({ list: listing(['gpt-5.6-luna']) });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext({ deadlineAt: new Date(Date.now() - 1) }));
+      expect(seen).toEqual([OPENAI_MODELS_URL, OPENAI_PRICING_URL]);
+      expect(pricedBy(result, 'gpt-5.6-luna')).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('reports the parser row count so a page restructure is caught before it is actioned', async () => {
+    const { route } = routes({ list: listing(['gpt-5']) });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok && result.parserRows).toEqual({ pricing: expect.any(Number) });
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps the availability signal when the pricing page is unreachable', async () => {
+    const { route } = routes({ list: listing(['gpt-5']), pricing: { status: 503, raw: 'upstream' } });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok).toBe(true);
+      expect(pricedBy(result, 'gpt-5')).toBeUndefined();
+      expect(result.ok && result.parserRows).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps the availability signal when the pricing page restructured', async () => {
+    const { route } = routes({ list: listing(['gpt-5']), pricing: { raw: read('parser-broke-pricing.md') } });
+    const restore = stubFetch(route);
+    try {
+      const result = await createOpenAiSource().fetch(makeContext());
+      expect(result.ok).toBe(true);
+      expect(pricedBy(result, 'gpt-5')).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('openai pricing merge', () => {
+  const record = (modelId: string): DiscoveredModel => ({ modelId, patch: { id: modelId } });
+
+  it('leaves a model the page does not carry exactly as it was', () => {
+    const [merged] = mergeOpenAiPricing(
+      [record('gpt-9-unlisted')],
+      [{ modelId: 'gpt-5', inputPerMTok: 1.25, outputPerMTok: 10 }]
+    );
+    expect(merged).not.toHaveProperty('pricing');
+  });
+
+  it('leaves every model as it was when the page never parsed', () => {
+    expect(mergeOpenAiPricing([record('gpt-5')], undefined)).toEqual([record('gpt-5')]);
+  });
 });

--- a/b4m-core/services/src/modelDiscoveryService/sources/openai.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openai.ts
@@ -1,19 +1,42 @@
 import { ModelBackend, type ModelRecord } from '@bike4mind/common';
 import type {
   DiscoveredModel,
+  DiscoveredPrice,
   DiscoveryCredentials,
   DiscoveryFetchContext,
   DiscoverySource,
+  DiscoverySourceOk,
   SourceResult,
 } from '../types';
-import { compact, fetchJson, text } from './http';
+import {
+  OPENAI_PRICING_URL,
+  openAiModelDocUrl,
+  parseOpenAiLongContextBreakpoint,
+  parseOpenAiPricing,
+  type OpenAiPriceRow,
+  type OpenAiRates,
+} from './openaiDocs';
+import { PAGINATED_SOURCE_DEADLINE_MS } from '../runModelDiscovery';
+import { compact, fetchJson, fetchText, hasTimeLeft, text } from './http';
 
 export const OPENAI_MODELS_URL = 'https://api.openai.com/v1/models';
 
 /**
+ * Model pages read for a breakpoint in one run. The set is the rows that publish
+ * long-context rates without stating the breakpoint inline, which is a handful of
+ * frontier models rather than the whole catalog; the cap is a runaway guard for a
+ * page restructure that made every row look like one of them.
+ */
+export const OPENAI_MAX_MODEL_DOC_FETCHES = 12;
+
+/**
  * OpenAI's list is four fields wide (id, object, created, owned_by) and no richer
- * endpoint exists, so this source is an availability signal and nothing else:
- * context, capabilities and pricing all come from the aggregators.
+ * endpoint exists, so the API half of this source is an availability signal and
+ * nothing else: context and capabilities still come from the aggregators.
+ *
+ * Pricing does NOT, any more. OpenAI publishes a markdown twin of its pricing
+ * page, so this source is a provider price for its own models and they no longer
+ * need two mirrors to agree before a change is applied (see openaiDocs.ts).
  *
  * It deliberately emits NO `name` and NO `contextWindow`. Emitting `name: id`
  * would overwrite every seeded display name with a lowercase id and append a row
@@ -74,10 +97,55 @@ export function normalizeOpenAiModels(payload: unknown): DiscoveredModel[] {
   return records.sort((a, b) => a.modelId.localeCompare(b.modelId));
 }
 
+/**
+ * Fold the pricing page onto the API listing. A model the page does not carry, or
+ * carries in a shape this source will not price, keeps the availability signal
+ * and falls through to the aggregators exactly as it did before.
+ */
+export function mergeOpenAiPricing(
+  models: readonly DiscoveredModel[],
+  pricing: readonly OpenAiPriceRow[] | undefined
+): DiscoveredModel[] {
+  if (!pricing) return [...models];
+  const byId = new Map(pricing.map(row => [row.modelId, row]));
+
+  return models.map(record => {
+    const price = toPrice(byId.get(record.modelId));
+    return price ? { ...record, pricing: price } : record;
+  });
+}
+
+/**
+ * The row as a DiscoveredPrice, or nothing.
+ *
+ * A row with long-context rates and no breakpoint is the one case that yields
+ * NOTHING rather than the base rates. This source is a provider, so its value
+ * wins over any aggregator that corroborates it; publishing the short-prompt rate
+ * alone would both understate long prompts and, being flat, block the tiered
+ * reprice the aggregators can still do between them. Saying nothing leaves that
+ * model exactly where it was before this source existed.
+ */
+function toPrice(row: OpenAiPriceRow | undefined): DiscoveredPrice | undefined {
+  if (!row) return undefined;
+  if (!row.longContext) return rates(row);
+  if (row.longContextAboveTokens === undefined) return undefined;
+  return { ...rates(row), brackets: [{ aboveTokens: row.longContextAboveTokens, ...rates(row.longContext) }] };
+}
+
+const rates = (from: OpenAiRates): OpenAiRates =>
+  compact({
+    inputPerMTok: from.inputPerMTok,
+    outputPerMTok: from.outputPerMTok,
+    cacheReadPerMTok: from.cacheReadPerMTok,
+    cacheWritePerMTok: from.cacheWritePerMTok,
+  });
+
 export function createOpenAiSource(): DiscoverySource {
   return {
     name: 'openai',
     kind: 'provider',
+    // A listing, the pricing page, and a model page per unannotated ladder.
+    deadlineMs: PAGINATED_SOURCE_DEADLINE_MS,
     isConfigured: (creds: DiscoveryCredentials) => Boolean(creds.openai),
     async fetch(ctx: DiscoveryFetchContext): Promise<SourceResult> {
       const response = await fetchJson<OpenAiModelList>(
@@ -92,7 +160,89 @@ export function createOpenAiSource(): DiscoverySource {
       // "OpenAI retired everything". Failing here keeps absence bookkeeping frozen.
       if (records.length === 0) return { ok: false, error: 'model list was empty', httpStatus: response.status };
 
-      return { ok: true, records, authoritativeFor: [ModelBackend.OpenAI], httpStatus: response.status };
+      const pricing = await readPricing(records, ctx);
+
+      return compact<DiscoverySourceOk>({
+        ok: true,
+        records: mergeOpenAiPricing(records, pricing),
+        authoritativeFor: [ModelBackend.OpenAI],
+        httpStatus: response.status,
+        // Only when the parser ran: a page that failed to fetch has no count, and
+        // comparing against a missing one would read as a 100% move.
+        parserRows: pricing ? { pricing: pricing.length } : undefined,
+      });
     },
   };
+}
+
+/**
+ * The pricing table, with every breakpoint this source could resolve filled in.
+ * Undefined on a fetch or parse failure: the caller keeps the availability signal
+ * and the prices fall through to whatever the catalog already believes.
+ */
+async function readPricing(
+  models: readonly DiscoveredModel[],
+  ctx: DiscoveryFetchContext
+): Promise<OpenAiPriceRow[] | undefined> {
+  // The docs host redirects and this request carries no credential, so following
+  // is safe here and only here (see HttpRequest.followRedirects).
+  const response = await fetchText(
+    { url: OPENAI_PRICING_URL, headers: { accept: 'text/markdown, text/plain' }, followRedirects: true },
+    ctx
+  );
+  if (!response.ok || response.notModified) {
+    ctx.logger.warn(`[model-discovery] openai docs ${OPENAI_PRICING_URL} unavailable`);
+    return undefined;
+  }
+
+  const parsed = parseOpenAiPricing(response.text);
+  if (!parsed.ok) {
+    ctx.logger.warn(`[model-discovery] openai docs parser broke: ${parsed.error}`);
+    return undefined;
+  }
+
+  const listed = new Set(models.map(record => record.modelId));
+  const pending = parsed.rows.filter(
+    row => listed.has(row.modelId) && row.longContext && row.longContextAboveTokens === undefined
+  );
+  if (pending.length === 0) return parsed.rows;
+
+  const resolved = new Map<string, number>();
+  let read = 0;
+  for (const row of pending) {
+    if (read >= OPENAI_MAX_MODEL_DOC_FETCHES || !hasTimeLeft(ctx)) {
+      // Never a silent cut: the models left unread are the ones toPrice will
+      // refuse to price, and that has to be answerable from the run's logs.
+      ctx.logger.warn(
+        `[model-discovery] openai docs: stopped after ${read} model pages, ` +
+          `${pending.length - read} long-context breakpoints unresolved`
+      );
+      break;
+    }
+    read += 1;
+    const breakpoint = await readBreakpoint(row.modelId, ctx);
+    if (breakpoint !== undefined) resolved.set(row.modelId, breakpoint);
+  }
+
+  return parsed.rows.map(row => {
+    const breakpoint = resolved.get(row.modelId);
+    return breakpoint === undefined ? row : { ...row, longContextAboveTokens: breakpoint };
+  });
+}
+
+async function readBreakpoint(modelId: string, ctx: DiscoveryFetchContext): Promise<number | undefined> {
+  const url = openAiModelDocUrl(modelId);
+  const response = await fetchText(
+    { url, headers: { accept: 'text/markdown, text/plain' }, followRedirects: true },
+    ctx
+  );
+  if (!response.ok || response.notModified) {
+    ctx.logger.warn(`[model-discovery] openai docs ${url} unavailable`);
+    return undefined;
+  }
+  const breakpoint = parseOpenAiLongContextBreakpoint(response.text);
+  if (breakpoint === undefined) {
+    ctx.logger.warn(`[model-discovery] openai docs: ${modelId} publishes long-context rates but no breakpoint`);
+  }
+  return breakpoint;
 }

--- a/b4m-core/services/src/modelDiscoveryService/sources/openai.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openai.ts
@@ -30,6 +30,17 @@ export const OPENAI_MODELS_URL = 'https://api.openai.com/v1/models';
 export const OPENAI_MAX_MODEL_DOC_FETCHES = 12;
 
 /**
+ * Budget for the docs leg, separate from the source deadline.
+ *
+ * The listing is already in hand by the time these run, and the runner races the
+ * whole `fetch()` against the source deadline: a docs host that HANGS would take
+ * the successful api.openai.com listing down with it, costing this backend its
+ * availability signal and its absence bookkeeping for the run. Prices are the
+ * optional half of this source and must not be able to do that.
+ */
+export const OPENAI_DOCS_BUDGET_MS = 20_000;
+
+/**
  * OpenAI's list is four fields wide (id, object, created, owned_by) and no richer
  * endpoint exists, so the API half of this source is an availability signal and
  * nothing else: context and capabilities still come from the aggregators.
@@ -160,15 +171,21 @@ export function createOpenAiSource(): DiscoverySource {
       // "OpenAI retired everything". Failing here keeps absence bookkeeping frozen.
       if (records.length === 0) return { ok: false, error: 'model list was empty', httpStatus: response.status };
 
-      const pricing = await readPricing(records, ctx);
+      const pricing = await readPricing(records, docsContext(ctx));
 
       return compact<DiscoverySourceOk>({
         ok: true,
         records: mergeOpenAiPricing(records, pricing),
         authoritativeFor: [ModelBackend.OpenAI],
         httpStatus: response.status,
-        // Only when the parser ran: a page that failed to fetch has no count, and
-        // comparing against a missing one would read as a 100% move.
+        // Set only when the parser ran, because comparing against a missing count
+        // would read as a 100% move. OBSERVABILITY ONLY: a detected shift logs and
+        // raises DocsParserRowShift, and the runner feeds droppedDocsSources to
+        // planLifecycleSignals alone - it never suppresses a price, from this
+        // source or from anthropic. This source emits no lifecycle at all, so a
+        // shift here changes nothing about what the run writes. What actually
+        // protects the rates is the table and column selection below, the
+        // corroboration rule, and the price band.
         parserRows: pricing ? { pricing: pricing.length } : undefined,
       });
     },
@@ -184,8 +201,8 @@ async function readPricing(
   models: readonly DiscoveredModel[],
   ctx: DiscoveryFetchContext
 ): Promise<OpenAiPriceRow[] | undefined> {
-  // The docs host redirects and this request carries no credential, so following
-  // is safe here and only here (see HttpRequest.followRedirects).
+  // The docs host redirects, and following is safe on a request that carries no
+  // credential (see HttpRequest.followRedirects for what a redirect would replay).
   const response = await fetchText(
     { url: OPENAI_PRICING_URL, headers: { accept: 'text/markdown, text/plain' }, followRedirects: true },
     ctx
@@ -240,9 +257,28 @@ async function readBreakpoint(modelId: string, ctx: DiscoveryFetchContext): Prom
     ctx.logger.warn(`[model-discovery] openai docs ${url} unavailable`);
     return undefined;
   }
+  // This request follows redirects, so a soft 404 or an index page answers 200
+  // with somebody else's document - and the breakpoint parser takes the first
+  // match in whatever it is handed. Every model page states its own id, so
+  // require it rather than trusting the URL we asked for.
+  if (!response.text.includes(`Model ID: \`${modelId}\``)) {
+    ctx.logger.warn(`[model-discovery] openai docs: ${url} did not answer with ${modelId}'s page`);
+    return undefined;
+  }
   const breakpoint = parseOpenAiLongContextBreakpoint(response.text);
   if (breakpoint === undefined) {
     ctx.logger.warn(`[model-discovery] openai docs: ${modelId} publishes long-context rates but no breakpoint`);
   }
   return breakpoint;
+}
+
+/**
+ * The context the docs leg runs under: the run's signal, plus a budget of its
+ * own so a hung docs host cannot consume the source deadline and take the
+ * listing down with it (see OPENAI_DOCS_BUDGET_MS).
+ */
+function docsContext(ctx: DiscoveryFetchContext): DiscoveryFetchContext {
+  const deadlineAt = new Date(Math.min(ctx.deadlineAt.getTime(), Date.now() + OPENAI_DOCS_BUDGET_MS));
+  const budget = AbortSignal.timeout(Math.max(0, deadlineAt.getTime() - Date.now()));
+  return { ...ctx, deadlineAt, signal: AbortSignal.any([ctx.signal, budget]) };
 }

--- a/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.test.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  OPENAI_PRICING_URL,
+  openAiModelDocUrl,
+  parseOpenAiLongContextBreakpoint,
+  parseOpenAiModelCell,
+  parseOpenAiPricing,
+  parseTokenCount,
+  type OpenAiPriceRow,
+} from './openaiDocs';
+
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'openai');
+const read = (name: string) => readFileSync(join(fixtures, name), 'utf8');
+
+const pricingMarkdown = read('pricing.md');
+const parsed = parseOpenAiPricing(pricingMarkdown);
+const rows = parsed.ok
+  ? new Map(parsed.rows.map(row => [row.modelId, row] as const))
+  : new Map<string, OpenAiPriceRow>();
+
+describe('openai pricing parser', () => {
+  it('reads the Standard table', () => {
+    expect(parsed.ok).toBe(true);
+    expect(rows.size).toBeGreaterThan(20);
+  });
+
+  it('reads the Standard table and NOT the Batch, Flex or Fast ones', () => {
+    // Batch and Flex price luna at $0.10/$0.60 and Fast at $0.40/$2.40, all under
+    // headers byte-identical to Standard's. Batch being exactly half of Standard
+    // is why a fall-through would halve every OpenAI price with no signal at all.
+    expect(rows.get('gpt-5.6-luna')).toMatchObject({ inputPerMTok: 0.2, outputPerMTok: 1.2 });
+  });
+
+  it('reads the cache rates the table publishes', () => {
+    expect(rows.get('gpt-5.6-luna')).toMatchObject({ cacheReadPerMTok: 0.02, cacheWritePerMTok: 0.25 });
+  });
+
+  it('reads the long-context rates as their own group', () => {
+    expect(rows.get('gpt-5.6-luna')?.longContext).toEqual({
+      inputPerMTok: 0.4,
+      outputPerMTok: 1.8,
+      cacheReadPerMTok: 0.04,
+      cacheWritePerMTok: 0.5,
+    });
+  });
+
+  it('leaves an unpublished rate absent rather than zero', () => {
+    // A stored 0 reads as free at settlement; absent means "carry the rate in
+    // force forward", which is the true statement about a "-" cell.
+    const flat = rows.get('gpt-5.4-nano');
+    expect(flat).toMatchObject({ inputPerMTok: 0.2, outputPerMTok: 1.25, cacheReadPerMTok: 0.02 });
+    expect(flat).not.toHaveProperty('cacheWritePerMTok');
+    expect(flat).not.toHaveProperty('longContext');
+  });
+
+  it('keeps the long-context group only when both of its required rates are there', () => {
+    // gpt-5.5-pro publishes long-context input and output but no cache rates.
+    expect(rows.get('gpt-5.5-pro')?.longContext).toEqual({ inputPerMTok: 60, outputPerMTok: 270 });
+    // gpt-5.4-mini publishes no long-context rates at all.
+    expect(rows.get('gpt-5.4-mini')).not.toHaveProperty('longContext');
+  });
+
+  it('takes the breakpoint off the model cell when the row states it inline', () => {
+    expect(rows.get('gpt-5.5')?.longContextAboveTokens).toBe(272_000);
+    // The newer families dropped the annotation; their own page carries it.
+    expect(rows.get('gpt-5.6-luna')).not.toHaveProperty('longContextAboveTokens');
+  });
+
+  it('keeps a dated model id verbatim rather than reshaping it', () => {
+    expect(rows.has('gpt-4o-2024-05-13')).toBe(true);
+    expect(rows.has('gpt-4-0613')).toBe(true);
+  });
+
+  it('fails on a restructured page rather than returning a partial table', () => {
+    expect(parseOpenAiPricing(read('parser-broke-pricing.md')).ok).toBe(false);
+  });
+
+  it('fails when the page carries no table at all', () => {
+    expect(parseOpenAiPricing('# Pricing\n\nSee the console.\n').ok).toBe(false);
+  });
+
+  it('fails rather than reading a table whose Standard heading is gone', () => {
+    const renamed = pricingMarkdown.replace('### Standard pricing data', '### Pay-as-you-go data');
+    expect(parseOpenAiPricing(renamed).ok).toBe(false);
+  });
+
+  it('fails when the Standard table yields zero usable rows', () => {
+    expect(parseOpenAiPricing('### Standard pricing data\n\n| Model | Short context input |\n| --- | --- |\n').ok).toBe(
+      false
+    );
+  });
+});
+
+describe('openai model cell', () => {
+  it('strips the annotations the page hangs off a name', () => {
+    expect(parseOpenAiModelCell('gpt-5.5 (<272K context length)')).toEqual({
+      modelId: 'gpt-5.5',
+      longContextAboveTokens: 272_000,
+    });
+    expect(parseOpenAiModelCell('gpt-4.1-nano')).toEqual({ modelId: 'gpt-4.1-nano' });
+  });
+
+  it('refuses a cell that is prose rather than a model id', () => {
+    expect(parseOpenAiModelCell('Fine-tuning is billed separately')).toBeNull();
+    expect(parseOpenAiModelCell('')).toBeNull();
+    expect(parseOpenAiModelCell('| total |')).toBeNull();
+  });
+});
+
+describe('openai long-context breakpoint', () => {
+  it('reads the plain bullet', () => {
+    expect(parseOpenAiLongContextBreakpoint(read('model-gpt-5.6-luna.md'))).toBe(272_000);
+    expect(parseOpenAiLongContextBreakpoint(read('model-gpt-5.6-sol.md'))).toBe(272_000);
+  });
+
+  it('reads the clause buried in a longer sentence', () => {
+    // "For models with a 1.05M context window (...), prompts with >272K input
+    // tokens are ..." - anchoring on the line would take 1.05M, the wrong number.
+    expect(parseOpenAiLongContextBreakpoint(read('model-gpt-5.4.md'))).toBe(272_000);
+  });
+
+  it('is undefined for a model with no long-context pricing', () => {
+    expect(parseOpenAiLongContextBreakpoint(read('model-gpt-5.4-mini.md'))).toBeUndefined();
+  });
+});
+
+describe('openai token counts', () => {
+  it('scales the suffixes', () => {
+    expect(parseTokenCount('272K')).toBe(272_000);
+    expect(parseTokenCount('1.05M')).toBe(1_050_000);
+    expect(parseTokenCount('272,000')).toBe(272_000);
+    expect(parseTokenCount(' 400 k ')).toBe(400_000);
+  });
+
+  it('refuses anything that is not a positive whole token count', () => {
+    expect(parseTokenCount('')).toBeUndefined();
+    expect(parseTokenCount('0K')).toBeUndefined();
+    expect(parseTokenCount('none')).toBeUndefined();
+    expect(parseTokenCount('0.5')).toBeUndefined();
+  });
+});
+
+describe('openai docs urls', () => {
+  it('are the markdown twins of the docs pages', () => {
+    expect(OPENAI_PRICING_URL).toBe('https://platform.openai.com/docs/pricing.md');
+    expect(openAiModelDocUrl('gpt-5.6-luna')).toBe('https://platform.openai.com/docs/models/gpt-5.6-luna.md');
+  });
+
+  it('escapes an id rather than letting it shape the path', () => {
+    expect(openAiModelDocUrl('../../secrets')).not.toContain('../');
+  });
+});

--- a/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.test.ts
@@ -74,6 +74,53 @@ describe('openai pricing parser', () => {
     expect(rows.has('gpt-4-0613')).toBe(true);
   });
 
+  it('drops a row whose cell count does not match the header', () => {
+    // Columns are located by name but read by POSITION, so one unescaped pipe in
+    // one rate cell shifts every rate on that row one column over - and the row
+    // count does not move, so no shift guard sees it. Before the arity check this
+    // read gpt-5.6-sol as out $6.25 (real: $30) with a fabricated ladder.
+    const strayPipe = pricingMarkdown.replace(
+      '| gpt-5.6-sol | $5.00 | $0.50 | $6.25 | $30.00 |',
+      '| gpt-5.6-sol | $5.00 | $2.50 | $0.50 | $6.25 | $30.00 |'
+    );
+    const parsed = parseOpenAiPricing(strayPipe);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.rows.some(row => row.modelId === 'gpt-5.6-sol')).toBe(false);
+    // Only that row: the cells still line up for every other one.
+    expect(parsed.rows.find(row => row.modelId === 'gpt-5.6-luna')).toMatchObject({ outputPerMTok: 1.2 });
+  });
+
+  it('fails outright when the header grows a column, because every row then mismatches', () => {
+    const widened = pricingMarkdown.replace(
+      '| Model | Short context input |',
+      '| Model | Service tier | Short context input |'
+    );
+    expect(parseOpenAiPricing(widened).ok).toBe(false);
+  });
+
+  it('refuses two tables headed "Standard pricing" instead of taking the first', () => {
+    // Batch is exactly half of Standard. Resolving by document order would halve
+    // every OpenAI price and still report ok.
+    const ambiguous = pricingMarkdown.replace('### Batch pricing data', '### Standard pricing data (batch)');
+    const parsed = parseOpenAiPricing(ambiguous);
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.error).toContain('2 tables');
+  });
+
+  it('refuses a table that lists one model id twice', () => {
+    // The model cell strips every parenthetical, so a modality annotation moving
+    // into this table collapses two rates onto one id with no reading to prefer.
+    const luna = '| gpt-5.6-luna | $0.20 | $0.02 | $0.25 | $1.20 | $0.40 | $0.04 | $0.50 | $1.80 |';
+    expect(pricingMarkdown).toContain(luna);
+    const duplicated = pricingMarkdown.replace(
+      luna,
+      `${luna}\n| gpt-5.6-luna (audio) | $9.00 | $0.90 | $1.00 | $18.00 | $18.00 | $1.80 | $2.00 | $27.00 |`
+    );
+    expect(parseOpenAiPricing(duplicated).ok).toBe(false);
+  });
+
   it('fails on a restructured page rather than returning a partial table', () => {
     expect(parseOpenAiPricing(read('parser-broke-pricing.md')).ok).toBe(false);
   });
@@ -140,6 +187,12 @@ describe('openai token counts', () => {
     expect(parseTokenCount('0K')).toBeUndefined();
     expect(parseTokenCount('none')).toBeUndefined();
     expect(parseTokenCount('0.5')).toBeUndefined();
+  });
+
+  it('is anchored, so it cannot mine a number out of surrounding text', () => {
+    expect(parseTokenCount('abc 123K')).toBeUndefined();
+    expect(parseTokenCount('1,05M')).toBeUndefined();
+    expect(parseTokenCount('272K tokens')).toBeUndefined();
   });
 });
 

--- a/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.ts
@@ -13,11 +13,13 @@ export const openAiModelDocUrl = (modelId: string): string =>
   `https://platform.openai.com/docs/models/${encodeURIComponent(modelId)}.md`;
 
 /**
- * The heading over the pay-as-you-go table. The page carries four tables with
- * BYTE-IDENTICAL headers - Standard, Batch, Flex and Fast - and Batch is exactly
- * half of Standard, so a selector that fell through to the next matching table
- * would halve every OpenAI price with nothing to show for it. Selection is by
- * heading and fails closed.
+ * The heading over the pay-as-you-go table. Batch and Flex carry headers
+ * byte-identical to Standard's (Fast carries the four short-context ones), and
+ * Batch is exactly half of Standard, so a selector that fell through to another
+ * matching table would halve every OpenAI price with nothing to show for it.
+ * Selection is by heading, and MORE than one match is refused rather than
+ * resolved by document order - "the first table that matched" is not a reading
+ * anyone can check.
  */
 const STANDARD_HEADING = /^standard pricing/i;
 
@@ -58,9 +60,16 @@ export interface OpenAiPriceRow extends OpenAiRates {
   longContextAboveTokens?: number;
 }
 
-/** "272K" -> 272000, "1.05M" -> 1050000, "272,000" -> 272000. Integers only. */
+/**
+ * "272K" -> 272000, "1.05M" -> 1050000, "272,000" -> 272000. Integers only.
+ *
+ * Anchored, and commas must be thousands separators: both callers hand it an
+ * already-constrained capture group, but an unanchored match would read
+ * "abc 123K" as 123000, and a loose comma would read the European "1,05M" as
+ * 105000000 - a 100x breakpoint - for whoever calls it next.
+ */
 export function parseTokenCount(value: string): number | undefined {
-  const match = /([\d,]+(?:\.\d+)?)\s*([km])?/i.exec(value.trim());
+  const match = /^(\d{1,3}(?:,\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)\s*([km])?$/i.exec(value.trim());
   if (!match) return undefined;
   const digits = Number(match[1]?.replace(/,/g, ''));
   if (!Number.isFinite(digits) || digits <= 0) return undefined;
@@ -88,16 +97,24 @@ export function parseOpenAiModelCell(cell: string): { modelId: string; longConte
 }
 
 /**
- * The Standard pricing table. Rates a row leaves as "-" are absent rather than
- * zero: pricePlan reads a published 0 as free and an absent rate as "carry the
- * one in force forward", and only the second is true here.
+ * The Standard pricing table.
+ *
+ * A rate cell of "-" is absent rather than zero: pricePlan reads a published 0
+ * as free and an absent rate as "carry the one in force forward", and only the
+ * second is true here. That applies to the individual CACHE rates; losing both
+ * long-context columns instead drops the whole ladder, which is a different
+ * outcome (see OpenAiPriceRow.longContext and toPrice in openai.ts).
  */
 export function parseOpenAiPricing(markdown: string): ParseResult<OpenAiPriceRow> {
   const all = tables(markdown);
   if (all.length === 0) return { ok: false, error: 'pricing.md contained no tables' };
 
-  const table = all.find(candidate => STANDARD_HEADING.test(candidate.heading));
-  if (!table) return { ok: false, error: 'pricing.md has no "Standard pricing" table' };
+  const matching = all.filter(candidate => STANDARD_HEADING.test(candidate.heading));
+  if (matching.length === 0) return { ok: false, error: 'pricing.md has no "Standard pricing" table' };
+  if (matching.length > 1) {
+    return { ok: false, error: `pricing.md has ${matching.length} tables headed "Standard pricing"` };
+  }
+  const table = matching[0];
 
   const column = (pattern: RegExp) => table.headers.findIndex(header => pattern.test(plain(header)));
   const at = {
@@ -119,10 +136,29 @@ export function parseOpenAiPricing(markdown: string): ParseResult<OpenAiPriceRow
   }
 
   const rows: OpenAiPriceRow[] = [];
+  const seen = new Set<string>();
   for (const row of table.rows) {
+    // Columns are located by NAME, then read by POSITION, so a row whose cell
+    // count does not match the header's reads every rate one column over -
+    // silently, and with the row count unchanged. One unescaped pipe in one rate
+    // cell is enough. The cells still line up for every other row, so the row is
+    // dropped rather than the table: a header that grew a column mismatches every
+    // row and falls through to the zero-row failure below.
+    if (row.length !== table.headers.length) continue;
+
     const parsed = parseOpenAiModelCell(row[0] ?? '');
     const rates = ratesAt(row, at.shortInput, at.shortOutput, at.shortCacheRead, at.shortCacheWrite);
     if (!parsed || !rates) continue;
+
+    // Two rows for one id is a price with no reading to prefer - the same
+    // situation usableBrackets refuses a whole ladder for. The model cell strips
+    // every parenthetical, so a modality annotation moving into this table
+    // ("gpt-realtime (audio)" / "(text)") would otherwise pick whichever came
+    // last, across an 8x spread on the page's own grouped tables.
+    if (seen.has(parsed.modelId)) {
+      return { ok: false, error: `pricing.md Standard table lists ${parsed.modelId} more than once` };
+    }
+    seen.add(parsed.modelId);
 
     const longContext = ratesAt(row, at.longInput, at.longOutput, at.longCacheRead, at.longCacheWrite);
     rows.push({ ...parsed, ...rates, ...(longContext ? { longContext } : {}) });

--- a/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.ts
+++ b/b4m-core/services/src/modelDiscoveryService/sources/openaiDocs.ts
@@ -1,0 +1,169 @@
+import { parseRate, plain, tables, type ParseResult } from './markdown';
+
+/**
+ * Parsers for OpenAI's published markdown twins: the pricing page, and a model's
+ * own page. Together they are the only place OpenAI states its prices as data -
+ * /v1/models is four fields wide (see openai.ts) - so without them every OpenAI
+ * price depends on two third-party mirrors agreeing.
+ */
+
+export const OPENAI_PRICING_URL = 'https://platform.openai.com/docs/pricing.md';
+
+export const openAiModelDocUrl = (modelId: string): string =>
+  `https://platform.openai.com/docs/models/${encodeURIComponent(modelId)}.md`;
+
+/**
+ * The heading over the pay-as-you-go table. The page carries four tables with
+ * BYTE-IDENTICAL headers - Standard, Batch, Flex and Fast - and Batch is exactly
+ * half of Standard, so a selector that fell through to the next matching table
+ * would halve every OpenAI price with nothing to show for it. Selection is by
+ * heading and fails closed.
+ */
+const STANDARD_HEADING = /^standard pricing/i;
+
+/** Columns are matched by name; a renamed one fails the parse rather than shifting. */
+const COLUMNS = {
+  shortInput: /^short context input$/i,
+  shortCacheRead: /^short context cached input$/i,
+  shortCacheWrite: /^short context cache writes$/i,
+  shortOutput: /^short context output$/i,
+  longInput: /^long context input$/i,
+  longCacheRead: /^long context cached input$/i,
+  longCacheWrite: /^long context cache writes$/i,
+  longOutput: /^long context output$/i,
+} as const;
+
+/** One rate set as the page publishes it, in USD per 1M tokens. */
+export interface OpenAiRates {
+  inputPerMTok: number;
+  outputPerMTok: number;
+  cacheReadPerMTok?: number;
+  cacheWritePerMTok?: number;
+}
+
+export interface OpenAiPriceRow extends OpenAiRates {
+  /** The API model id, which is what the table is keyed by - no slugging needed. */
+  modelId: string;
+  /**
+   * What a prompt past the breakpoint pays. Present only when the row publishes
+   * both a long-context input AND output rate: half a bracket is not a bracket.
+   */
+  longContext?: OpenAiRates;
+  /**
+   * Input tokens the long-context rates start above, when the model cell states
+   * it inline ("gpt-5.5 (<272K context length)"). The newer families drop the
+   * annotation and state it on their own page instead, which is what
+   * parseOpenAiLongContextBreakpoint reads.
+   */
+  longContextAboveTokens?: number;
+}
+
+/** "272K" -> 272000, "1.05M" -> 1050000, "272,000" -> 272000. Integers only. */
+export function parseTokenCount(value: string): number | undefined {
+  const match = /([\d,]+(?:\.\d+)?)\s*([km])?/i.exec(value.trim());
+  if (!match) return undefined;
+  const digits = Number(match[1]?.replace(/,/g, ''));
+  if (!Number.isFinite(digits) || digits <= 0) return undefined;
+  const scale = match[2]?.toLowerCase() === 'k' ? 1_000 : match[2]?.toLowerCase() === 'm' ? 1_000_000 : 1;
+  const tokens = digits * scale;
+  return Number.isInteger(tokens) ? tokens : undefined;
+}
+
+/**
+ * "gpt-5.5 (<272K context length)" -> the id plus the breakpoint that qualifies
+ * it. The annotation is stripped along with every other parenthetical the page
+ * hangs off a name, because what is left has to be the id verbatim: OpenAI ids
+ * carry dots and dashes ("gpt-5.6-luna", "gpt-4o-2024-05-13") and re-shaping one
+ * would join to nothing.
+ */
+export function parseOpenAiModelCell(cell: string): { modelId: string; longContextAboveTokens?: number } | null {
+  const value = plain(cell);
+  const annotated = /\(\s*<\s*([\d.,]+\s*[km]?)\s*(?:input\s*)?(?:token\s*)?context length\s*\)/i.exec(value);
+  const modelId = value.replace(/\([^)]*\)/g, '').trim();
+  // Conservative id shape: the table also carries prose rows ("Fine-tuning", a
+  // footnote) in some sections, and one of those joining to a model would price it.
+  if (!/^[a-z0-9][a-z0-9._:-]*$/.test(modelId)) return null;
+  const longContextAboveTokens = annotated ? parseTokenCount(annotated[1] ?? '') : undefined;
+  return longContextAboveTokens === undefined ? { modelId } : { modelId, longContextAboveTokens };
+}
+
+/**
+ * The Standard pricing table. Rates a row leaves as "-" are absent rather than
+ * zero: pricePlan reads a published 0 as free and an absent rate as "carry the
+ * one in force forward", and only the second is true here.
+ */
+export function parseOpenAiPricing(markdown: string): ParseResult<OpenAiPriceRow> {
+  const all = tables(markdown);
+  if (all.length === 0) return { ok: false, error: 'pricing.md contained no tables' };
+
+  const table = all.find(candidate => STANDARD_HEADING.test(candidate.heading));
+  if (!table) return { ok: false, error: 'pricing.md has no "Standard pricing" table' };
+
+  const column = (pattern: RegExp) => table.headers.findIndex(header => pattern.test(plain(header)));
+  const at = {
+    shortInput: column(COLUMNS.shortInput),
+    shortCacheRead: column(COLUMNS.shortCacheRead),
+    shortCacheWrite: column(COLUMNS.shortCacheWrite),
+    shortOutput: column(COLUMNS.shortOutput),
+    longInput: column(COLUMNS.longInput),
+    longCacheRead: column(COLUMNS.longCacheRead),
+    longCacheWrite: column(COLUMNS.longCacheWrite),
+    longOutput: column(COLUMNS.longOutput),
+  };
+
+  // The two the row cannot be read without. A renamed cache or long-context
+  // column instead drops that rate, which pricePlan handles as "not published":
+  // it carries the rate in force forward rather than moving it.
+  if (at.shortInput < 0 || at.shortOutput < 0) {
+    return { ok: false, error: 'pricing.md Standard table is missing an expected column' };
+  }
+
+  const rows: OpenAiPriceRow[] = [];
+  for (const row of table.rows) {
+    const parsed = parseOpenAiModelCell(row[0] ?? '');
+    const rates = ratesAt(row, at.shortInput, at.shortOutput, at.shortCacheRead, at.shortCacheWrite);
+    if (!parsed || !rates) continue;
+
+    const longContext = ratesAt(row, at.longInput, at.longOutput, at.longCacheRead, at.longCacheWrite);
+    rows.push({ ...parsed, ...rates, ...(longContext ? { longContext } : {}) });
+  }
+
+  if (rows.length === 0) return { ok: false, error: 'pricing.md Standard table yielded zero rows' };
+  return { ok: true, rows };
+}
+
+/** A rate group, or nothing when either of its two required rates is unpublished. */
+function ratesAt(
+  row: readonly string[],
+  input: number,
+  output: number,
+  cacheRead: number,
+  cacheWrite: number
+): OpenAiRates | undefined {
+  const inputPerMTok = input < 0 ? undefined : parseRate(row[input] ?? '');
+  const outputPerMTok = output < 0 ? undefined : parseRate(row[output] ?? '');
+  if (inputPerMTok === undefined || outputPerMTok === undefined) return undefined;
+
+  const rates: OpenAiRates = { inputPerMTok, outputPerMTok };
+  const cacheReadPerMTok = cacheRead < 0 ? undefined : parseRate(row[cacheRead] ?? '');
+  const cacheWritePerMTok = cacheWrite < 0 ? undefined : parseRate(row[cacheWrite] ?? '');
+  if (cacheReadPerMTok !== undefined) rates.cacheReadPerMTok = cacheReadPerMTok;
+  if (cacheWritePerMTok !== undefined) rates.cacheWritePerMTok = cacheWritePerMTok;
+  return rates;
+}
+
+/**
+ * The long-context breakpoint off a model's own page, from the bullet under its
+ * pricing table: "Prompts with >272K input tokens are priced at 2x input and 1.5x
+ * output for the full request." The same sentence appears in a longer form on the
+ * older families ("For models with a 1.05M context window (GPT-5.4 and GPT-5.4
+ * Pro), prompts with >272K input tokens are ..."), so the match anchors on the
+ * clause rather than on the line.
+ *
+ * Undefined means the page does not state one, which is a model this source may
+ * not price at all - see openai.ts.
+ */
+export function parseOpenAiLongContextBreakpoint(markdown: string): number | undefined {
+  const match = /prompts with\s*>\s*([\d.,]+\s*[km]?)\s*input tokens/i.exec(markdown);
+  return match ? parseTokenCount(match[1] ?? '') : undefined;
+}

--- a/b4m-core/services/src/modelDiscoveryService/types.ts
+++ b/b4m-core/services/src/modelDiscoveryService/types.ts
@@ -308,6 +308,23 @@ export interface PriceFlag {
   detail: string;
 }
 
+/**
+ * A price that was WRITTEN over a source that disagreed with it, which only a
+ * provider's own published price can do. The counterpart to a PriceFlag: a flag
+ * is a value discovery declined to apply, this is one it applied anyway, and the
+ * dissenting source named here is the operator's cue that a mirror has gone stale.
+ */
+export interface PriceOverride {
+  modelId: string;
+  /** The provider source whose value was written. */
+  source: string;
+  /** Sources that disagreed with it and were not applied. */
+  dissenting: string[];
+  /** Per-MTok, the readable unit; the row it wrote is per token. */
+  applied: { inputPerMTok: number; outputPerMTok: number };
+  detail: string;
+}
+
 /** Why a usable observation produced neither a row nor a flag. */
 export type PriceSkipReason = 'unknown-model' | 'operator-owned' | 'tiered-pricing' | 'untrusted' | 'unchanged';
 
@@ -426,6 +443,8 @@ export interface ModelDiscoveryRunResult {
   prices: {
     rows: PlannedPriceRow[];
     flags: PriceFlag[];
+    /** Rows written over a source that disagreed; a subset of `rows` by model. */
+    overrides: PriceOverride[];
   };
   /** The lifecycle plan, likewise: report mode declines to persist it, nothing more. */
   lifecycle: {

--- a/b4m-core/services/src/modelDiscoveryService/types.ts
+++ b/b4m-core/services/src/modelDiscoveryService/types.ts
@@ -309,18 +309,23 @@ export interface PriceFlag {
 }
 
 /**
- * A price that was WRITTEN over a source that disagreed with it, which only a
+ * A price that STANDS over a source that disagreed with it, which only a
  * provider's own published price can do. The counterpart to a PriceFlag: a flag
- * is a value discovery declined to apply, this is one it applied anyway, and the
- * dissenting source named here is the operator's cue that a mirror has gone stale.
+ * is a value discovery declined to apply, this is one it applied over an
+ * objection, and the dissenting source named here is the operator's cue that a
+ * mirror has gone stale.
+ *
+ * Raised whether or not a row was appended. Once the catalog converges the
+ * provider's value is already in force and the plan is 'unchanged' every run -
+ * which is precisely when a stale mirror is the only thing left worth reporting.
  */
 export interface PriceOverride {
   modelId: string;
-  /** The provider source whose value was written. */
+  /** The provider source whose value stands. */
   source: string;
   /** Sources that disagreed with it and were not applied. */
   dissenting: string[];
-  /** Per-MTok, the readable unit; the row it wrote is per token. */
+  /** Per-MTok, the readable unit; the row it would write is per token. */
   applied: { inputPerMTok: number; outputPerMTok: number };
   detail: string;
 }

--- a/packages/database/src/models/ai/ModelDiscoveryRunModel.test.ts
+++ b/packages/database/src/models/ai/ModelDiscoveryRunModel.test.ts
@@ -77,6 +77,15 @@ describe('ModelDiscoveryRunRepository', () => {
             note: 'discovery:anthropic@2026-07-01T00:00:00.000Z',
           },
         ],
+        priceOverrides: [
+          {
+            modelId: 'claude-y',
+            source: 'anthropic',
+            dissenting: ['litellm'],
+            applied: { inputPerMTok: 3, outputPerMTok: 15 },
+            detail: 'anthropic publishes in 3/out 15 $/MTok and litellm in 8/out 24 $/MTok disagree beyond 10%',
+          },
+        ],
         priceSkips: [{ modelId: 'claude-x', reason: 'unchanged' }],
         lifecycleTransitions: [
           { modelId: 'claude-x', from: 'active', to: 'deprecated', signal: 'absence', autoApplied: false },
@@ -109,6 +118,12 @@ describe('ModelDiscoveryRunRepository', () => {
     });
     expect(stored?.priceRows?.[0]).toMatchObject({ modelId: 'claude-y', unit: 'per_token', inputPerMTok: 3 });
     expect(stored?.priceRows?.[0].effectiveFrom).toEqual(new Date('2026-07-01T00:00:00Z'));
+    expect(stored?.priceOverrides?.[0]).toMatchObject({
+      modelId: 'claude-y',
+      source: 'anthropic',
+      dissenting: ['litellm'],
+      applied: { inputPerMTok: 3, outputPerMTok: 15 },
+    });
     expect(stored?.priceSkips).toMatchObject([{ modelId: 'claude-x', reason: 'unchanged' }]);
     expect(stored?.lifecycleTransitions?.[0]).toMatchObject({ modelId: 'claude-x', to: 'deprecated' });
     expect(stored?.catalogDiff?.[0]).toMatchObject({ modelId: 'claude-y', kind: 'added', promoted: true });
@@ -117,10 +132,11 @@ describe('ModelDiscoveryRunRepository', () => {
     expect(stored?.changes?.flagged).toEqual(['gpt-5.6-luna', 'claude-y']);
     expect(stored?.changes?.operatorConflicts).toEqual(['claude-y']);
     expect(stored?.id).toBe(created.id);
-    // The list carries counts, not bodies: five bounded detail arrays per run
-    // over twenty runs is megabytes on an endpoint the status card polls.
+    // The list carries counts, not bodies: six bounded detail arrays per run over
+    // twenty runs is megabytes on an endpoint the status card polls.
     const listed = (await modelDiscoveryRunRepository.recentRuns(1))[0];
     expect(listed.priceFlags).toBeUndefined();
+    expect(listed.priceOverrides).toBeUndefined();
     expect(listed.catalogDiff).toBeUndefined();
     expect(listed.changes?.flagged).toEqual(['gpt-5.6-luna', 'claude-y']);
   });

--- a/packages/database/src/models/ai/ModelDiscoveryRunModel.test.ts
+++ b/packages/database/src/models/ai/ModelDiscoveryRunModel.test.ts
@@ -188,6 +188,14 @@ describe('ModelDiscoveryRunRepository', () => {
             effectiveFrom: new Date('2026-07-01T00:00:00Z'),
           },
         ],
+        priceOverrides: [
+          {
+            modelId: 'gpt-bare',
+            source: 'openai',
+            applied: { inputPerMTok: 1, outputPerMTok: 2 },
+            detail: 'the provider value wins',
+          },
+        ],
         lifecycleTransitions: [{ modelId: 'gpt-bare', to: 'deprecated', signal: 'absence' }],
         catalogDiff: [{ modelId: 'gpt-bare', kind: 'updated' }],
       })
@@ -197,6 +205,7 @@ describe('ModelDiscoveryRunRepository', () => {
 
     expect(stored?.priceFlags?.[0].sources).toEqual([]);
     expect(stored?.priceRows?.[0]).toMatchObject({ sources: [], note: '' });
+    expect(stored?.priceOverrides?.[0].dissenting).toEqual([]);
     expect(stored?.lifecycleTransitions?.[0].autoApplied).toBe(false);
     expect(stored?.catalogDiff?.[0]).toMatchObject({
       ownedGroups: [],
@@ -214,6 +223,7 @@ describe('ModelDiscoveryRunRepository', () => {
     const stored = await modelDiscoveryRunRepository.runById(created.id);
 
     expect(stored?.priceFlags ?? []).toEqual([]);
+    expect(stored?.priceOverrides ?? []).toEqual([]);
     expect(stored?.catalogDiff ?? []).toEqual([]);
   });
 

--- a/packages/database/src/models/ai/ModelDiscoveryRunModel.ts
+++ b/packages/database/src/models/ai/ModelDiscoveryRunModel.ts
@@ -156,6 +156,21 @@ const ModelDiscoveryRunSchema = new Schema<IModelDiscoveryRunDocument>(
       ],
       required: false,
     },
+    priceOverrides: {
+      type: [
+        new Schema(
+          {
+            modelId: { type: String, required: true },
+            source: { type: String, required: true },
+            dissenting: { type: [String], required: false, default: [] },
+            applied: { type: PerMTokRatesSchema, required: true },
+            detail: { type: String, required: true },
+          },
+          { _id: false }
+        ),
+      ],
+      required: false,
+    },
     priceSkips: {
       type: [
         new Schema(
@@ -212,6 +227,7 @@ const ModelDiscoveryRunSchema = new Schema<IModelDiscoveryRunDocument>(
         {
           priceFlags: { type: Number, required: false },
           priceRows: { type: Number, required: false },
+          priceOverrides: { type: Number, required: false },
           priceSkips: { type: Number, required: false },
           lifecycleTransitions: { type: Number, required: false },
           catalogDiff: { type: Number, required: false },
@@ -236,13 +252,14 @@ ModelDiscoveryRunSchema.index({ startedAt: 1 }, { expireAfterSeconds: RUN_RETENT
 export type IModelDiscoveryRunModel = Model<IModelDiscoveryRunDocument>;
 
 /**
- * The report bodies, left off the list. Twenty runs carrying five bounded detail
+ * The report bodies, left off the list. Twenty runs carrying six bounded detail
  * arrays each is megabytes on an endpoint the status card polls, and the list
  * shows counts; runById is what reads a run's detail.
  */
 const RUN_LIST_PROJECTION = {
   priceFlags: 0,
   priceRows: 0,
+  priceOverrides: 0,
   priceSkips: 0,
   lifecycleTransitions: 0,
   catalogDiff: 0,


### PR DESCRIPTION
# Pull Request

Closes #1298. Stacked on #1297 (`conard/model-lifecycle-fixes`), which is the base of this PR; review only the commit on top.

## Description

OpenAI models had no provider price. `/v1/models` is four fields wide and OpenAI ships no pricing endpoint, so every OpenAI rate came from models.dev and litellm agreeing with each other. That is a structural dependency on two third-party mirrors, and it is what let GPT-5.6-Luna's 80% price cut keep billing at the old rate: one mirror was stale, the two disagreed past `PRICE_AGREEMENT_TOLERANCE`, and the run applied neither. #1297 fixed that instance by unpinning litellm. This removes the dependency.

**OpenAI publishes its prices as markdown.** `https://platform.openai.com/docs/pricing.md` is a real markdown twin of the pricing page, in the same pipe-table shape `anthropicDocs.ts` already parses, and it carries everything the planner consumes: base input and output, cached input, cache writes, and the long-context bracket. A new `openaiDocs.ts` reads it, and `sources/openai.ts` now contributes a provider price for its own models.

**A provider price is now primary.** It needs corroboration - one aggregator that agrees - but not unanimity. The old rule made every observation veto every other, which hands any single mirror a veto over a price the provider itself publishes. Mirrors go stale on their own schedules, so that is not a hypothetical. A mirror that disagrees is now overruled and recorded rather than allowed to block the write. Where no provider price exists nothing changed: the aggregators are all we have, so they must still agree with each other and there must still be two of them.

This settles the design question the issue left open, and it is narrower than the issue's own acceptance criterion ("no aggregator agreement required"): one agreeing mirror is still required, so a docs restructure that produced plausible-but-wrong rates cannot reprice anything on its own.

## Changes

New OpenAI price source:
- `sources/openaiDocs.ts` parses the Standard table. Selection is by heading and fails closed. The page carries four tables with byte-identical headers - Standard, Batch, Flex, Fast - and Batch is exactly half of Standard, so a selector that fell through would silently halve every OpenAI price. Columns are matched by name; a renamed required column fails the parse rather than shifting.
- A "-" cell is absent, not zero. `pricePlan` reads a published 0 as free and an absent rate as "carry the rate in force forward", and only the second is true.
- The long-context breakpoint is read from OpenAI, not guessed. Older families state it in the model cell (`gpt-5.5 (<272K context length)`); the gpt-5.6 family states it on its own page ("Prompts with >272K input tokens are priced at 2x input and 1.5x output"). The source reads a model page only for the rows that need it - three today - capped at `OPENAI_MAX_MODEL_DOC_FETCHES` and deadline-aware, and it logs what it left unread.
- A row with long-context rates and no resolvable breakpoint contributes **no price at all**, not the base rates. A flat provider value would both understate long prompts and, being flat, block the tiered reprice the aggregators can still do between them. Saying nothing leaves the model exactly where it was.
- `sources/markdown.ts` holds the table reader both docs scrapers now share; `anthropicDocs.ts` imports it instead of owning it. No behaviour change there.

Trust:
- `planPriceWrites` replaces the blanket disagreement veto with `reachConsensus`. A provider wins over dissenting aggregators as long as one corroborates it; all of them dissenting still refuses, with its own sentence ("no source corroborates the provider"). Two providers disagreeing is still a mutual conflict - neither outranks the other.
- Nothing else moved. The band, the operator-owned rule, the tier-ladder alignment check, the lone-aggregator flag and the unchanged-row skip all run exactly as before, on the trusted value.

Reporting:
- New `PriceOverride`, persisted as `priceOverrides` on the run document and rendered in the run report as "Applied over a disagreeing source". It names the model, the rate applied, the provider it came from, and the mirror that was overruled. The operationally useful fact is not the price, it is which mirror has gone stale. Optional throughout and projected out of the run list, like every other detail array.

## Guide for Testers

Model Lifecycle is at Sidebar -> AI & Agents -> Model Lifecycle.

1. Go to Sidebar -> AI & Agents -> Model Lifecycle and click "Run now". Expected: the Discovery status card polls to completion with status ok.
2. Click the change-count sentence to open the run report.
3. Confirm the Sources section lists `openai` as ok with a record count.
4. If any OpenAI model repriced this run, confirm the Repriced section credits the source as `discovery:openai` rather than `discovery:models.dev+litellm`.
5. If a mirror disagreed with OpenAI on any model, confirm a section titled "Applied over a disagreeing source" appears, naming the model, the applied $/M rates, `openai` as the source, and the overruled mirror. This section is absent when every source agreed, which is the normal case.
6. Open a run from before this change via "show run history". Expected: it renders normally with no override section, not an error.

Regression checks:
7. Price flags still lead the report, still carry the full explanatory sentence, and the pricing deep link on each row still works.
8. A report-mode run is still labelled as a plan that wrote nothing, with no "writes did not land" warning.
9. Model Pricing (Sidebar -> User Ops -> Credit Analytics -> Model Pricing) still edits in $/1M tokens and its guardrail still fires.
10. Anthropic models still reprice from `anthropic` as they did before.

What NOT to test: the discovery cron schedule, and provider credential configuration. Self-host installs have no OpenAI key, so this source does not run there at all.

## Additional Information

**Verified against the live pages**, running the real sources and the real planner over production's pre-cut luna row (`/v1/models` stubbed, since no key is configured on this machine; that half of the source is unchanged):

```
openai: parserRows={"pricing":36}
gpt-5.6-luna
  openai     in 0.2 / out 1.2 / cache_read 0.02 / cache_write 0.25, above 272000: 0.4 / 1.8 / 0.04 / 0.5
  models.dev identical
  litellm    identical
```

The planner then wrote, from `openai` alone:

| tier | before (`adapter-seed`) | after (`discovery:openai`) |
| --- | --- | --- |
| 272000 | $1.00 / $6.00 per 1M | $0.20 / $1.20 per 1M |
| 1050000 | $2.00 / $9.00 per 1M | $0.40 / $1.80 per 1M |

Same run with litellm rolled back to the pre-cut rate: the row still lands, and the report records `openai publishes ... and litellm in 1/out 6 $/MTok, above 272000 in 2/out 9 $/MTok disagree beyond 10%; the provider value was applied`. With **both** mirrors rolled back: no row, and a `source-disagreement` flag reading `no source corroborates the provider within 10%`.

**Self-host stack** rebuilt from this branch (`app` + `worker`): a manual discovery run completes `ok` in write mode with 30 flags and 0 overrides (no provider price source is configured there), and `priceOverrides` round-trips through the built mongoose schema with the list projection excluding it.

Tests: `turbo:typecheck` 40/40, `lint:check` clean, common 1389, services 3210, database 1284, client admin 585. 45 new tests, including fixtures that make picking the Batch or Flex table a failure rather than a silent halving.

Known pre-existing on the dev machine used here, unchanged by this branch: six client `*.e2e.test.ts` files time out under mongodb-memory-server replica sets, and the `@bike4mind/utils` artifactElision performance test flakes under CPU load.

Not changed, and worth knowing: `detectParserRowShifts` drops a source's **lifecycle** signals when its parser row count moves past 20%, not its prices - the same as it has always been for `anthropicDocs`. Pricing has its own guards (fail-closed table and column selection, the band, corroboration), and a row count moving because OpenAI added a model is not evidence that the rates are wrong. Widening that guard to prices is a separate, billing-affecting decision.

## Developer Notes

- `sources/markdown.ts` is the extension point for the next provider that publishes a `.md` twin of its docs. Both scrapers now agree on what a table is and on what "found valid markdown and zero rows" means.
- `reachConsensus` is where source trust is decided, in one place, returning a tagged union rather than leaving the caller to re-derive precedence. A new source kind changes that function and nothing else.
- `PriceOverride` is the counterpart to `PriceFlag`: a flag is a value discovery declined to apply, an override is one it applied over an objection. Any future "we did it anyway, and here is who disagreed" needs the same pair.
- The OpenAI model page carries context window, max output tokens, knowledge cutoff, modalities, reasoning support and per-endpoint support - all the fields `openai.ts` documents itself as unable to supply. Reading it for the breakpoint proves the page parses; using it for the rest is a bigger change and deliberately out of scope here.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - no new settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - not applicable
