### PR TITLE
fix(agent-executor): honor the session tool contract on the agent path

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.firstIterationQuery.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.firstIterationQuery.ts
@@ -30,7 +30,7 @@ export const MAX_PREAMBLE_FILES = 25;
  * agent path does not union `session.enabledTools`, so the omission is invisible from here
  * without the caller passing its resolved tool names in.
  */
-const CONTENT_READ_TOOL = 'retrieve_knowledge_content';
+export const CONTENT_READ_TOOL = 'retrieve_knowledge_content';
 
 /** Discovery tool for files trimmed by `MAX_PREAMBLE_FILES`; also optional in a profile. */
 const CONTENT_SEARCH_TOOL = 'search_knowledge_base';

--- a/apps/client/server/queueHandlers/agentExecutor.sessionToolPolicy.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.sessionToolPolicy.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  applySessionToolPolicy,
+  runHasAttachments,
+  DELEGATION_TOOLS,
+  type SessionToolPolicyInput,
+} from './agentExecutor.sessionToolPolicy';
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+// A representative agent toolbelt: a couple of surface tools plus the always-appended
+// mission tools, with no content reader - the shape that made an attachment unreadable.
+const TOOLBELT = ['optihashi_solve', 'web_search', 'create_mission', 'mission_status'];
+
+describe('applySessionToolPolicy', () => {
+  it('returns the toolbelt unchanged when the session carries no contract and nothing is attached', () => {
+    const result = applySessionToolPolicy({
+      toolNames: TOOLBELT,
+      session: {},
+      hasAttachments: false,
+    });
+
+    expect(result).toEqual(TOOLBELT);
+  });
+
+  it('does not union session.enabledTools', () => {
+    // Deliberate: an orchestration profile narrows the toolbelt on purpose, and a curated
+    // surface's session typically names its whole chat toolset, so unioning it back in would
+    // dissolve every profile. Asserted so a future "parity" change has to argue with this test.
+    // The input type has no `enabledTools` field at all; the cast stands in for a real session
+    // document that does carry one, proving nothing here consumes it.
+    const sessionWithEnabledTools = {
+      enabledTools: ['image_generation', 'deep_research'],
+    } as unknown as SessionToolPolicyInput['session'];
+
+    const result = applySessionToolPolicy({
+      toolNames: TOOLBELT,
+      session: sessionWithEnabledTools,
+      hasAttachments: false,
+    });
+
+    expect(result).not.toContain('image_generation');
+    expect(result).not.toContain('deep_research');
+  });
+
+  describe('session.disabledTools (denylist)', () => {
+    it('strips tools the session forbids', () => {
+      const result = applySessionToolPolicy({
+        toolNames: TOOLBELT,
+        session: { disabledTools: ['web_search'] },
+        hasAttachments: false,
+      });
+
+      expect(result).not.toContain('web_search');
+      expect(result).toContain('optihashi_solve');
+    });
+
+    it('strips a forbidden tool even when the profile allowed it', () => {
+      // The session contract is applied last on the chat path; this is that precedence.
+      const result = applySessionToolPolicy({
+        toolNames: ['web_search', 'optihashi_solve'],
+        session: { disabledTools: ['web_search'] },
+        profileDeniedTools: [],
+        hasAttachments: false,
+      });
+
+      expect(result).toEqual(['optihashi_solve']);
+    });
+
+    it('strips the always-appended mission tools when the session forbids them', () => {
+      // Mission tools are appended unconditionally upstream, so the denylist has to run after
+      // that append or a "curated sources only" session cannot actually exclude them.
+      const result = applySessionToolPolicy({
+        toolNames: TOOLBELT,
+        session: { disabledTools: ['create_mission', 'mission_status'] },
+        hasAttachments: false,
+      });
+
+      expect(result).toEqual(['optihashi_solve', 'web_search']);
+    });
+  });
+
+  describe('session.disableUserIntegrations', () => {
+    it('denies the delegation tools so the loop cannot fan out on its own', () => {
+      const result = applySessionToolPolicy({
+        toolNames: [...TOOLBELT, ...DELEGATION_TOOLS],
+        session: { disableUserIntegrations: true },
+        hasAttachments: false,
+      });
+
+      for (const tool of DELEGATION_TOOLS) expect(result).not.toContain(tool);
+      expect(result).toContain('optihashi_solve');
+    });
+
+    it('leaves delegation in place when the session does not suppress integrations', () => {
+      const result = applySessionToolPolicy({
+        toolNames: [...TOOLBELT, 'delegate_to_agent'],
+        session: { disableUserIntegrations: false },
+        hasAttachments: false,
+      });
+
+      expect(result).toContain('delegate_to_agent');
+    });
+  });
+
+  describe('attachment-driven reader guarantee', () => {
+    it('adds the content reader when the run carries attachments and the toolbelt lacks it', () => {
+      const logger = makeLogger();
+
+      const result = applySessionToolPolicy({
+        toolNames: TOOLBELT,
+        session: {},
+        hasAttachments: true,
+        logger,
+      });
+
+      expect(result).toContain('retrieve_knowledge_content');
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Added the content reader'),
+        expect.objectContaining({ tool: 'retrieve_knowledge_content' })
+      );
+    });
+
+    it('does not add the reader when nothing is attached', () => {
+      const result = applySessionToolPolicy({
+        toolNames: TOOLBELT,
+        session: {},
+        hasAttachments: false,
+      });
+
+      expect(result).not.toContain('retrieve_knowledge_content');
+    });
+
+    it('does not duplicate a reader the toolbelt already has', () => {
+      const result = applySessionToolPolicy({
+        toolNames: [...TOOLBELT, 'retrieve_knowledge_content'],
+        session: {},
+        hasAttachments: true,
+      });
+
+      expect(result.filter(t => t === 'retrieve_knowledge_content')).toHaveLength(1);
+    });
+
+    it('respects a profile that explicitly denies the reader, and does not log an addition', () => {
+      // Explicit denial wins over the implicit add - the honest "cannot read them" preamble in
+      // buildFirstIterationQuery is the intended outcome, not a silent re-add.
+      const logger = makeLogger();
+
+      const result = applySessionToolPolicy({
+        toolNames: TOOLBELT,
+        session: {},
+        profileDeniedTools: ['retrieve_knowledge_content'],
+        hasAttachments: true,
+        logger,
+      });
+
+      expect(result).not.toContain('retrieve_knowledge_content');
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+
+    it('respects a session that explicitly denies the reader, and does not log an addition', () => {
+      const logger = makeLogger();
+
+      const result = applySessionToolPolicy({
+        toolNames: TOOLBELT,
+        session: { disabledTools: ['retrieve_knowledge_content'] },
+        hasAttachments: true,
+        logger,
+      });
+
+      expect(result).not.toContain('retrieve_knowledge_content');
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+  });
+
+  it('preserves input order so the toolbelt stays stable across iterations', () => {
+    const result = applySessionToolPolicy({
+      toolNames: TOOLBELT,
+      session: { disabledTools: ['web_search'] },
+      hasAttachments: true,
+    });
+
+    // Original relative order kept, guaranteed reader appended at the end.
+    expect(result).toEqual(['optihashi_solve', 'create_mission', 'mission_status', 'retrieve_knowledge_content']);
+  });
+});
+
+describe('runHasAttachments', () => {
+  it('is false when no ids are present anywhere', () => {
+    expect(runHasAttachments({}, [])).toBe(false);
+    expect(runHasAttachments({ messageFileIds: [], sessionFabFileIds: [] }, undefined)).toBe(false);
+    expect(runHasAttachments({ messageFileIds: null, sessionFabFileIds: null }, null)).toBe(false);
+  });
+
+  it('is true for any single source', () => {
+    expect(runHasAttachments({ messageFileIds: ['f1'] }, [])).toBe(true);
+    expect(runHasAttachments({ sessionFabFileIds: ['f1'] }, [])).toBe(true);
+    // Session knowledge alone counts: it is how a file attached to the notebook (rather than to
+    // this message) reaches the agent, and it is the case that first surfaced this bug.
+    expect(runHasAttachments({}, ['f1'])).toBe(true);
+  });
+});

--- a/apps/client/server/queueHandlers/agentExecutor.sessionToolPolicy.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.sessionToolPolicy.ts
@@ -1,0 +1,113 @@
+import { CONTENT_READ_TOOL } from './agentExecutor.firstIterationQuery';
+
+/**
+ * Session-scoped tool policy for the agent_executor path.
+ *
+ * `chat_completion` applies the session's tool contract to every request
+ * (`ChatCompletionProcess`: union `enabledTools`, subtract `disabledTools`, honor
+ * `disableUserIntegrations`). The agent path historically applied NONE of it - it resolved tools
+ * purely from the orchestration profile / start payload - so a product surface's curated session
+ * meant one thing in chat and something else the moment the routing classifier upgraded the same
+ * send to Agent mode.
+ *
+ * This module closes the subtractive half of that gap, and guarantees an attached file is
+ * readable. It deliberately does NOT union `session.enabledTools`: an orchestration profile is a
+ * narrowing of the toolbelt on purpose, and unioning the session's chat toolset back in would
+ * dissolve every profile (a curated surface's session typically names its whole chat toolset, so
+ * the profile's allowedTools would stop meaning anything). Additive session semantics stay a
+ * chat-path concept; the agent path gets its additions from its profile.
+ *
+ * Extracted as a pure function so the policy is unit-testable without agentExecutor's server-only
+ * dependency graph - same reason `agentExecutor.firstIterationQuery.ts` and
+ * `agentExecutor.optiProfile.ts` are separate modules.
+ */
+
+/**
+ * Tools that reach the user's own agent roster. `session.disableUserIntegrations` promises "no
+ * user MCP servers, no agent delegation" (see `IDataLakeSession.disableUserIntegrations` in
+ * SessionTypes), and the chat path enforces the delegation half by refusing to build an
+ * agentStore. The agent path uses its agentStore for run-as-agent resolution too, so it enforces
+ * the same contract by denying the delegation TOOLS rather than by tearing down the store: an
+ * explicit `@agent` run stays possible, but the loop cannot fan out on its own.
+ */
+export const DELEGATION_TOOLS = ['delegate_to_agent', 'coordinate_task'] as const;
+
+interface PolicyLogger {
+  info: (message: string, meta?: Record<string, unknown>) => void;
+}
+
+export interface SessionToolPolicyInput {
+  /** The run's resolved toolbelt before session policy (profile + mission + lattice names). */
+  toolNames: readonly string[];
+  session: {
+    disabledTools?: string[] | null;
+    disableUserIntegrations?: boolean | null;
+  };
+  /**
+   * The orchestration profile's explicit denials. A profile that deliberately denies the content
+   * reader keeps it denied even for a run carrying attachments - the honest "cannot read them"
+   * preamble in `buildFirstIterationQuery` is the outcome there, not a silent re-add.
+   */
+  profileDeniedTools?: readonly string[];
+  /**
+   * Whether this run carries any attached file (per-message, workbench, or session knowledge).
+   * Attachments imply the ability to read them: the preamble hands the agent a fabFileId and
+   * tells it to fetch content, so a toolbelt without the reader turns an attachment into a dead
+   * end the user experiences as "the agent can't see my file".
+   */
+  hasAttachments: boolean;
+  logger?: PolicyLogger;
+}
+
+/**
+ * Returns the final tool-name list for the run. Input order is preserved; a guaranteed reader is
+ * appended. Removals always win over the attachment-driven addition, so an explicit denial - from
+ * either the profile or the session - is never silently overridden.
+ */
+export function applySessionToolPolicy(input: SessionToolPolicyInput): string[] {
+  const { toolNames, session, profileDeniedTools = [], hasAttachments, logger } = input;
+
+  const sessionDenied = new Set(session.disabledTools ?? []);
+  const profileDenied = new Set(profileDeniedTools);
+  const result = [...toolNames];
+
+  // Attachment-driven reader guarantee. Checked BEFORE the removals rather than added blindly and
+  // stripped after, so the log line can't claim an addition that the next step deletes.
+  if (
+    hasAttachments &&
+    !result.includes(CONTENT_READ_TOOL) &&
+    !profileDenied.has(CONTENT_READ_TOOL) &&
+    !sessionDenied.has(CONTENT_READ_TOOL)
+  ) {
+    result.push(CONTENT_READ_TOOL);
+    logger?.info('[SessionToolPolicy] Added the content reader for a run carrying attachments', {
+      tool: CONTENT_READ_TOOL,
+    });
+  }
+
+  const denied = new Set(sessionDenied);
+  if (session.disableUserIntegrations) {
+    for (const tool of DELEGATION_TOOLS) denied.add(tool);
+  }
+  if (denied.size === 0) return result;
+
+  return result.filter(tool => !denied.has(tool));
+}
+
+/**
+ * Whether the run carries any attached file. Reads the ids the dispatch forwarded plus the
+ * session's live knowledge pool - the same three sources `buildFirstIterationQuery` merges - so
+ * the two agree on what "has attachments" means without this having to hit the database.
+ * Ids that turn out to be inaccessible still count here; the preamble builder resolves them and
+ * is the one that reports a partial resolution.
+ */
+export function runHasAttachments(
+  execution: { messageFileIds?: string[] | null; sessionFabFileIds?: string[] | null },
+  sessionKnowledgeIds: readonly string[] | null | undefined
+): boolean {
+  return (
+    (execution.messageFileIds?.length ?? 0) > 0 ||
+    (execution.sessionFabFileIds?.length ?? 0) > 0 ||
+    (sessionKnowledgeIds?.length ?? 0) > 0
+  );
+}

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -558,6 +558,30 @@ async function loadMcpToolsSafe(userId: string, logger: Logger): Promise<AgentMc
   }
 }
 
+/**
+ * `loadMcpToolsSafe` gated on the session's integration-isolation contract.
+ *
+ * A session with `disableUserIntegrations` promises "no user MCP servers, no agent delegation";
+ * the chat path keeps it by emptying `mcpServers`. EVERY agent-path entry point that loads MCP
+ * tools must go through here, not `loadMcpToolsSafe` directly - the top level and the subagent
+ * re-dispatch each run in their own Lambda and load independently, so a guard on only one of them
+ * lets an isolated session regain every personal MCP server through the other.
+ *
+ * Skipping beats emptying afterwards: it also drops the settings read and the server round-trip.
+ * The returned shape matches the failure path above, so downstream consumers are unchanged.
+ */
+async function loadMcpToolsForSession(
+  session: { disableUserIntegrations?: boolean | null },
+  userId: string,
+  logger: Logger
+): Promise<AgentMcpTools> {
+  if (session.disableUserIntegrations) {
+    logger.info('[AgentExecutor][MCP] Session suppresses user integrations - skipping MCP tool load', { userId });
+    return { mcpToolsByServer: {}, serverAgentConfig: {} };
+  }
+  return loadMcpToolsSafe(userId, logger);
+}
+
 async function processExecution(
   executionId: string,
   connectionId: string,
@@ -835,23 +859,19 @@ async function processExecution(
     // NO MCP wiring, so exclusive-MCP subagents spawned with 0 tools and the
     // model fabricated results. Mirrors ChatCompletionProcess's buildMcpTools.
     //
-    // A session that suppresses user integrations skips the load entirely: the chat path empties
-    // `mcpServers` for such a session, and without this the same curated surface silently
-    // regained every personal MCP server the moment the routing classifier upgraded a send to
-    // Agent mode. Skipping rather than emptying afterwards also avoids the network round-trip.
-    // The empty shape matches what `loadMcpToolsSafe` already returns when a load fails, so
-    // every downstream consumer is on a supported path.
-    const { mcpToolsByServer, serverAgentConfig } = session.disableUserIntegrations
-      ? { mcpToolsByServer: {}, serverAgentConfig: {} }
-      : await loadMcpToolsSafe(execution.userId, logger);
-    if (session.disableUserIntegrations) {
-      logger.info('[AgentExecutor][MCP] Session suppresses user integrations - skipping MCP tool load');
-    }
+    // Gated on the session's isolation contract - see `loadMcpToolsForSession`.
+    const { mcpToolsByServer, serverAgentConfig } = await loadMcpToolsForSession(session, execution.userId, logger);
     const agentStore = new ServerAgentStore(serverAgentConfig, { userAgents, orgAgents });
     // MCP servers claimed exclusively by an agent (e.g. atlassian by
     // project_manager). Withheld from the parent LLM's tool list; reach the
     // delegated subagent via buildSharedTools' internal parentTools closure.
-    const agentOnlyMcpServers = agentStore.getExclusiveMcpServers();
+    //
+    // An isolated session has no MCP at all, so there is nothing to claim exclusively. Empty here
+    // rather than downstream: a built-in agent claims a server unconditionally, so carrying its
+    // claim into a run with no loaded tools would make the `missingExclusive` check below warn
+    // "spawned empty-handed" on every isolated run - reporting a deliberate skip as the load
+    // failure that check exists to catch.
+    const agentOnlyMcpServers = session.disableUserIntegrations ? [] : agentStore.getExclusiveMcpServers();
     // An agent that EXCLUSIVELY claims a server spawns with 0 tools if that server produced none
     // (disabled / no cached schemas / load failed) - the exact failure this fix targets. Surface it
     // by server name so it is not a silent fabrication again.
@@ -2462,7 +2482,10 @@ async function processSubagentDispatch(
     }
     // Rebuild MCP tools on THIS invocation - a re-dispatched subagent runs in its
     // own Lambda, so the top-level path's load does not carry over. See Task 3.
-    const { mcpToolsByServer, serverAgentConfig } = await loadMcpToolsSafe(child.userId, logger);
+    // Gated on the same session isolation contract as the top-level load: this dispatch runs in
+    // its own Lambda, so an unguarded load here would hand a subagent every personal MCP server
+    // in a session whose whole point is not having them.
+    const { mcpToolsByServer, serverAgentConfig } = await loadMcpToolsForSession(session, child.userId, logger);
     const agentStore = new ServerAgentStore(serverAgentConfig, { userAgents, orgAgents });
     const agentDef = agentStore.getAgent(agentName);
     if (!agentDef) {

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -95,6 +95,7 @@ import type { DagHandoffSignal } from '@bike4mind/services';
 // (Mongo, AWS SDK, ReActAgent, etc.). `maybeBuildFirstIterationQuery` wraps
 // it with the new-execution/iteration-0 gate so the gate is testable too.
 import { maybeBuildFirstIterationQuery } from './agentExecutor.firstIterationQuery';
+import { applySessionToolPolicy, runHasAttachments } from './agentExecutor.sessionToolPolicy';
 import { toUserFacingFailureMessage } from './agentExecutor.failureMessage';
 import { buildReActAgentRuntimeConfig } from './agentExecutor.reActAgentConfig';
 // Per-iteration billing (delta math + #657 context-window guard + tool-internal
@@ -833,7 +834,19 @@ async function processExecution(
     // (e.g. project_manager -> atlassian) actually receive them. Agent Mode had
     // NO MCP wiring, so exclusive-MCP subagents spawned with 0 tools and the
     // model fabricated results. Mirrors ChatCompletionProcess's buildMcpTools.
-    const { mcpToolsByServer, serverAgentConfig } = await loadMcpToolsSafe(execution.userId, logger);
+    //
+    // A session that suppresses user integrations skips the load entirely: the chat path empties
+    // `mcpServers` for such a session, and without this the same curated surface silently
+    // regained every personal MCP server the moment the routing classifier upgraded a send to
+    // Agent mode. Skipping rather than emptying afterwards also avoids the network round-trip.
+    // The empty shape matches what `loadMcpToolsSafe` already returns when a load fails, so
+    // every downstream consumer is on a supported path.
+    const { mcpToolsByServer, serverAgentConfig } = session.disableUserIntegrations
+      ? { mcpToolsByServer: {}, serverAgentConfig: {} }
+      : await loadMcpToolsSafe(execution.userId, logger);
+    if (session.disableUserIntegrations) {
+      logger.info('[AgentExecutor][MCP] Session suppresses user integrations - skipping MCP tool load');
+    }
     const agentStore = new ServerAgentStore(serverAgentConfig, { userAgents, orgAgents });
     // MCP servers claimed exclusively by an agent (e.g. atlassian by
     // project_manager). Withheld from the parent LLM's tool list; reach the
@@ -1295,9 +1308,18 @@ async function processExecution(
     // Named rather than inlined because the `[ATTACHED FILES]` preamble below has to know
     // whether this run can actually read a file - buildSharedTools only surfaces tools named
     // here, so this array IS the run's toolbelt.
-    const resolvedToolNames = [
-      ...new Set([...profileEnabledTools, ...MISSION_CHAT_TOOL_NAMES, ...latticeEnabledTools]),
-    ];
+    //
+    // The session's tool contract is applied LAST so it wins over the profile, the start payload,
+    // and the unconditional mission/lattice appends above - the same precedence
+    // `chat_completion` gives it. See `agentExecutor.sessionToolPolicy.ts` for why
+    // `session.enabledTools` is deliberately not unioned here.
+    const resolvedToolNames = applySessionToolPolicy({
+      toolNames: [...new Set([...profileEnabledTools, ...MISSION_CHAT_TOOL_NAMES, ...latticeEnabledTools])],
+      session,
+      profileDeniedTools: orchestrationProfile?.deniedTools,
+      hasAttachments: runHasAttachments(execution, session.knowledgeIds),
+      logger,
+    });
 
     const tools = buildSharedTools({ ...toolDeps, optInTools: subagentLatticeTools }, toolCallbacks, {
       enabledTools: resolvedToolNames,


### PR DESCRIPTION
# Pull Request

## Description

Follow-ups 3 and 4 from #1293, building on the `resolvedToolNames` seam added in #1294 (now
merged).

`chat_completion` applies a session's tool contract to every request: it unions
`session.enabledTools`, subtracts `session.disabledTools`, and honors
`session.disableUserIntegrations` (`ChatCompletionProcess.ts:1081-1106`). The agent path applied
**none** of it - tools came purely from the orchestration profile and the start payload. So a
product surface's curated session meant one thing in chat and something else entirely the moment
the routing classifier upgraded the same send to Agent mode.

The most serious case is an isolation contract, not a UX bug: a session setting
`disableUserIntegrations: true` to guarantee "no user MCP servers, no agent delegation" silently
regained every personal MCP server in Agent mode, because `loadMcpToolsSafe` was called
unconditionally.

## Changes

New `agentExecutor.sessionToolPolicy.ts` - a pure, unit-tested function applied to the resolved
toolbelt, matching how `firstIterationQuery` / `optiProfile` are extracted for testability.

- **`session.disabledTools` is now a final denylist**, applied after the profile, the start
  payload, and the unconditional mission/lattice appends - the same precedence chat gives it.
  Previously a "curated sources only" session could not exclude anything from an agent run. The
  ordering matters: mission tools are appended unconditionally upstream, so a denylist that ran
  earlier could not touch them.
- **`session.disableUserIntegrations` now suppresses user MCP servers** (the load is skipped
  outright, which also drops a network round-trip; the empty shape matches what
  `loadMcpToolsSafe` already returns on failure, so every consumer stays on a supported path)
  **and denies the delegation tools**. Enforced by denying the tools rather than by tearing down
  the `agentStore` - the agent path also uses that store for run-as-agent resolution, so an
  explicit `@agent` run still works while the loop cannot fan out on its own.
- **A run carrying attachments is guaranteed a content reader**, unless the profile or the
  session explicitly denies it. This is #1293 item 4, implemented where the information actually
  exists rather than as a client-side routing heuristic: the client cannot know which profile the
  server will pick, but the executor knows both the toolbelt and whether files are attached. An
  explicit denial still yields the honest "cannot read them" preamble from #1294.

### Deliberately not done

`session.enabledTools` is **not** unioned. An orchestration profile narrows the toolbelt on
purpose, and a curated surface's session typically names its whole chat toolset - unioning it
back in would dissolve every profile (the Optimizer profile, for instance, would silently regain
the entire chat toolset it was written to exclude). #1293 listed this as "consider"; on reading
the two paths, the additive half is a chat-path concept and the agent path should get its
additions from its profile. The decision is pinned by a test so a future "parity" change has to
argue with it rather than silently flip it.

## Guide for Testers

Backend behaviour on the agent execution path. A session with a curated toolset is needed - the
Optimizer surface has one.

1. Go to `app.staging.bike4mind.com/opti` and start a new chat.
2. Attach a small `.txt` file, then send `Analyze the attached file and summarize it.`
3. Expect: the reply analyzes the real contents. It must not ask you to paste the file in.
4. Send `Delegate this to another agent to double-check.` Expect: the agent does the work itself
   and does not spawn or claim to spawn a subagent (the Optimizer session sets
   `disableUserIntegrations`).
5. If you have personal MCP servers configured, confirm none of their tools are used or offered
   in an Optimizer agent run. Expect: none.

Regression checks:

6. In a normal (non-Optimizer) notebook with Agent mode on, confirm delegation still works: send
   a prompt that would normally fan out to a subagent. Expect: unchanged behaviour, because that
   session does not set `disableUserIntegrations`.
7. In a normal notebook with personal MCP servers configured, confirm MCP tools still load and
   are usable in Agent mode. Expect: unchanged.
8. In an Optimizer chat with no attachment, send `Route 20 delivery vans across 40 cities to
   minimize distance.` Expect: the formulate/solve ladder runs as before.

What NOT to test: no UI changed, and nothing here alters the chat (non-agent) path.

## Additional Information

Verified locally: `pnpm --filter @bike4mind/client typecheck` clean (0 errors), eslint clean on
all changed files, and all 42 test files under `apps/client/server/queueHandlers/` pass (406
tests, up from 391 - the new policy module adds 15).

PR title scope is `agent-executor` rather than `agents` on purpose: the auto-changeset workflow
maps a title scope onto a publishable package, and `agents` would generate a bogus
`@bike4mind/agents` changeset for a PR that touches only `apps/client` (see the discussion on
#1294).
