### PR TITLE
feat(questmaster): attach a node's artifacts to the node

### DIFF
--- a/apps/client/app/components/questmaster-v5/QuestGraphView.test.tsx
+++ b/apps/client/app/components/questmaster-v5/QuestGraphView.test.tsx
@@ -46,6 +46,7 @@ const makeNode = (over: Partial<QuestNode> & { id: string }): QuestNode =>
     artifactIds: [],
     isReady: true,
     isRunnable: true,
+    artifacts: [],
     run: null,
     ...over,
   }) as QuestNode;
@@ -171,6 +172,41 @@ describe('QuestGraphView', () => {
     fireEvent.keyDown(screen.getByTestId('questmaster-v5-node-row'), { key: 'Enter' });
 
     expect(screen.getByTestId('questmaster-v5-result-panel')).toBeInTheDocument();
+  });
+
+  it('renders artifact chips produced by the node', () => {
+    nodes = [
+      makeNode({
+        id: 'n1',
+        status: 'completed',
+        artifactIds: ['art-1'],
+        artifacts: [{ id: 'art-1', type: 'react', title: 'Counter' }],
+        run: {
+          executionId: 'exec-1',
+          status: 'completed',
+          answer: 'done',
+          answerTruncated: false,
+          totalIterations: 1,
+          totalCreditsUsed: 1,
+          errorMessage: null,
+        },
+      }),
+    ];
+    renderView();
+    selectGraph();
+    fireEvent.click(screen.getByTestId('questmaster-v5-node-row'));
+
+    expect(screen.getByTestId('questmaster-v5-node-artifacts')).toBeInTheDocument();
+    expect(screen.getByTestId('questmaster-v5-artifact-chip')).toHaveTextContent('Counter');
+  });
+
+  it('shows no artifact section for a node that produced none', () => {
+    nodes = [makeNode({ id: 'n1', status: 'completed', artifacts: [] })];
+    renderView();
+    selectGraph();
+    fireEvent.click(screen.getByTestId('questmaster-v5-node-row'));
+
+    expect(screen.queryByTestId('questmaster-v5-node-artifacts')).not.toBeInTheDocument();
   });
 
   it('surfaces a failed run error message', () => {

--- a/apps/client/app/components/questmaster-v5/QuestGraphView.tsx
+++ b/apps/client/app/components/questmaster-v5/QuestGraphView.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { Alert, Box, Button, Chip, Divider, Input, Sheet, Stack, Textarea, Typography } from '@mui/joy';
 import type { ColorPaletteProp } from '@mui/joy';
 import { api } from '@client/app/contexts/ApiContext';
@@ -211,7 +212,7 @@ export default function QuestGraphView() {
                 chips would still hold node ids from the previous graph. */}
             <AddNodeForm key={selectedGraphId} graphId={selectedGraphId} nodes={nodes} onError={setError} />
 
-            {selectedNode && <NodeResultPanel node={selectedNode} />}
+            {selectedNode && <NodeResultPanel node={selectedNode} sessionId={detail.data?.graph.sessionId} />}
           </Box>
         )}
       </Box>
@@ -317,7 +318,8 @@ function AddNodeForm({
   );
 }
 
-function NodeResultPanel({ node }: { node: QuestNode }) {
+function NodeResultPanel({ node, sessionId }: { node: QuestNode; sessionId?: string }) {
+  const navigate = useNavigate();
   return (
     <Sheet variant="soft" sx={{ mt: 2, p: 2, borderRadius: 'sm' }} data-testid="questmaster-v5-result-panel">
       <Typography level="title-sm">{node.title}</Typography>
@@ -347,6 +349,32 @@ function NodeResultPanel({ node }: { node: QuestNode }) {
         <Alert color="danger" size="sm" sx={{ mt: 1 }} data-testid="questmaster-v5-run-error">
           {node.run.errorMessage}
         </Alert>
+      )}
+
+      {node.artifacts.length > 0 && (
+        <Box sx={{ mt: 1.5 }} data-testid="questmaster-v5-node-artifacts">
+          <Typography level="body-xs" sx={{ mb: 0.5 }}>
+            Artifacts from this node
+          </Typography>
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+            {node.artifacts.map(artifact => (
+              <Chip
+                key={artifact.id}
+                size="sm"
+                variant="outlined"
+                // The notebook, not the artifact: there is no /artifacts/:id
+                // route - artifacts render inline in chat via ArtifactRenderer.
+                // Phase 5's graph view is where per-node inspection belongs;
+                // until then this at least lands you where the artifact is.
+                {...(sessionId ? { onClick: () => navigate({ to: '/notebooks/$id', params: { id: sessionId } }) } : {})}
+                sx={sessionId ? { cursor: 'pointer' } : undefined}
+                data-testid="questmaster-v5-artifact-chip"
+              >
+                {artifact.type}: {artifact.title}
+              </Chip>
+            ))}
+          </Stack>
+        </Box>
       )}
 
       {node.run?.answer && (

--- a/apps/client/app/hooks/data/questGraphs.test.ts
+++ b/apps/client/app/hooks/data/questGraphs.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { shouldPollForSettlingArtifacts } from './questGraphs';
+
+const NOW = new Date('2026-08-01T12:00:00.000Z').getTime();
+const secondsAgo = (s: number) => new Date(NOW - s * 1000).toISOString();
+
+// `completedAt` is typed as a Date by z.infer but arrives as an ISO string over
+// the wire; the predicate reads whatever JSON gave it.
+const node = (over: Record<string, unknown> = {}) =>
+  ({
+    status: 'completed',
+    artifacts: [],
+    completedAt: secondsAgo(5),
+    ...over,
+  }) as never;
+
+describe('shouldPollForSettlingArtifacts', () => {
+  it('polls for a node that just completed with no artifacts yet', () => {
+    expect(shouldPollForSettlingArtifacts([node()], NOW)).toBe(true);
+  });
+
+  it('stops once the artifacts have landed', () => {
+    expect(shouldPollForSettlingArtifacts([node({ artifacts: [{ id: 'a', type: 'react', title: 'A' }] })], NOW)).toBe(
+      false
+    );
+  });
+
+  // Otherwise a run that genuinely produces nothing would poll forever.
+  it('stops once the settle window has passed', () => {
+    expect(shouldPollForSettlingArtifacts([node({ completedAt: secondsAgo(120) })], NOW)).toBe(false);
+  });
+
+  it('ignores nodes that never ran', () => {
+    expect(shouldPollForSettlingArtifacts([node({ status: 'pending', completedAt: undefined })], NOW)).toBe(false);
+  });
+
+  // The regression this predicate exists for: an earlier version gated on the
+  // run having a non-empty answer, so a completed run with a null or empty
+  // answer stopped polling immediately and could never pick its artifacts up.
+  it('polls regardless of whether the run produced an answer', () => {
+    expect(shouldPollForSettlingArtifacts([node({ run: null })], NOW)).toBe(true);
+    expect(shouldPollForSettlingArtifacts([node({ run: { answer: '' } })], NOW)).toBe(true);
+    expect(shouldPollForSettlingArtifacts([node({ run: { answer: null } })], NOW)).toBe(true);
+  });
+
+  it('polls when any one node of several is still settling', () => {
+    const settled = node({ artifacts: [{ id: 'a', type: 'react', title: 'A' }] });
+    expect(shouldPollForSettlingArtifacts([settled, node()], NOW)).toBe(true);
+  });
+
+  it('does not poll for an empty graph', () => {
+    expect(shouldPollForSettlingArtifacts([], NOW)).toBe(false);
+  });
+});

--- a/apps/client/app/hooks/data/questGraphs.ts
+++ b/apps/client/app/hooks/data/questGraphs.ts
@@ -32,6 +32,35 @@ const RUNNING_POLL_MS = 3_000;
  */
 const ARTIFACT_SETTLE_WINDOW_MS = 30_000;
 
+/**
+ * Whether to keep polling after every node has stopped running.
+ *
+ * The executor calls `markComplete` BEFORE `persistRunAsQuest` writes the
+ * artifacts, so the poll that first observes `completed` can legitimately
+ * precede them. Stop there and the node looks artifact-less until something
+ * else happens to refetch.
+ *
+ * Deliberately does NOT gate on the run having an answer. An earlier version
+ * did, which meant a completed run with a null or empty answer stopped polling
+ * immediately and could never pick its artifacts up. Whether an answer exists
+ * says nothing about whether artifacts are still landing.
+ *
+ * Bounded by `completedAt` so a run that genuinely emits no artifacts stops
+ * once the window passes instead of polling forever.
+ */
+export function shouldPollForSettlingArtifacts(
+  nodes: Pick<QuestNodeWire, 'status' | 'artifacts' | 'completedAt'>[],
+  now = Date.now()
+): boolean {
+  return nodes.some(
+    n =>
+      n.status === 'completed' &&
+      n.artifacts.length === 0 &&
+      Boolean(n.completedAt) &&
+      now - new Date(n.completedAt as unknown as string).getTime() < ARTIFACT_SETTLE_WINDOW_MS
+  );
+}
+
 export const questGraphKeys = {
   all: ['questGraphs'] as const,
   detail: (id: string) => ['questGraphs', id] as const,
@@ -60,21 +89,7 @@ export function useQuestGraph(graphId: string | null) {
       const nodes = query.state.data?.nodes;
       if (!nodes) return false;
       if (nodes.some(n => n.status === 'in_progress')) return RUNNING_POLL_MS;
-      // Keep polling briefly after a run finishes. The executor calls
-      // markComplete BEFORE persistRunAsQuest writes the artifacts, so the very
-      // poll that first sees `completed` can legitimately precede them - stop
-      // there and the node looks artifact-less until something else refetches.
-      // Bounded by completedAt so a run that genuinely emits no artifacts stops
-      // polling once the window passes, rather than spinning forever.
-      const settling = nodes.some(
-        n =>
-          n.status === 'completed' &&
-          n.run?.answer &&
-          n.artifacts.length === 0 &&
-          n.completedAt &&
-          Date.now() - new Date(n.completedAt).getTime() < ARTIFACT_SETTLE_WINDOW_MS
-      );
-      return settling ? RUNNING_POLL_MS : false;
+      return shouldPollForSettlingArtifacts(nodes) ? RUNNING_POLL_MS : false;
     },
   });
 }

--- a/apps/client/app/hooks/data/questGraphs.ts
+++ b/apps/client/app/hooks/data/questGraphs.ts
@@ -26,6 +26,12 @@ type QuestGraphList = z.infer<typeof QuestGraphListResponseSchema>;
  */
 const RUNNING_POLL_MS = 3_000;
 
+/**
+ * How long after a node completes we keep re-reading to pick up artifacts the
+ * terminal write had not landed yet. See the refetchInterval comment.
+ */
+const ARTIFACT_SETTLE_WINDOW_MS = 30_000;
+
 export const questGraphKeys = {
   all: ['questGraphs'] as const,
   detail: (id: string) => ['questGraphs', id] as const,
@@ -52,7 +58,23 @@ export function useQuestGraph(graphId: string | null) {
     enabled: Boolean(graphId),
     refetchInterval: query => {
       const nodes = query.state.data?.nodes;
-      return nodes?.some(n => n.status === 'in_progress') ? RUNNING_POLL_MS : false;
+      if (!nodes) return false;
+      if (nodes.some(n => n.status === 'in_progress')) return RUNNING_POLL_MS;
+      // Keep polling briefly after a run finishes. The executor calls
+      // markComplete BEFORE persistRunAsQuest writes the artifacts, so the very
+      // poll that first sees `completed` can legitimately precede them - stop
+      // there and the node looks artifact-less until something else refetches.
+      // Bounded by completedAt so a run that genuinely emits no artifacts stops
+      // polling once the window passes, rather than spinning forever.
+      const settling = nodes.some(
+        n =>
+          n.status === 'completed' &&
+          n.run?.answer &&
+          n.artifacts.length === 0 &&
+          n.completedAt &&
+          Date.now() - new Date(n.completedAt).getTime() < ARTIFACT_SETTLE_WINDOW_MS
+      );
+      return settling ? RUNNING_POLL_MS : false;
     },
   });
 }

--- a/apps/client/server/questmaster/v5/linkNodeArtifacts.test.ts
+++ b/apps/client/server/questmaster/v5/linkNodeArtifacts.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IQuestNodeDocument } from '@bike4mind/common';
+
+const findByQuestIds = vi.fn();
+const linkArtifacts = vi.fn();
+
+vi.mock('@bike4mind/database', () => ({
+  artifactRepository: { findByQuestIds: (...a: unknown[]) => findByQuestIds(...a) },
+  questNodeRepository: { linkArtifacts: (...a: unknown[]) => linkArtifacts(...a) },
+}));
+
+const { linkNodeArtifacts } = await import('./linkNodeArtifacts');
+
+const logger = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+const node = (over: Partial<IQuestNodeDocument> & { id: string }): IQuestNodeDocument =>
+  ({
+    graphId: 'g1',
+    dependsOn: [],
+    order: 0,
+    depth: 0,
+    kind: 'task',
+    title: 't',
+    task: 'do it',
+    status: 'completed',
+    enabledTools: [],
+    artifactIds: [],
+    execution: { agentExecutionId: 'exec-1' },
+    ...over,
+  }) as IQuestNodeDocument;
+
+type Runs = Parameters<typeof linkNodeArtifacts>[1];
+const runs = (entries: Array<[string, string | null]>): Runs =>
+  new Map(
+    entries.map(([execId, questId]) => [
+      execId,
+      {
+        id: execId,
+        questId,
+        status: 'completed',
+        answer: 'a',
+        totalIterations: 1,
+        totalCreditsUsed: 1,
+        errorMessage: null,
+        completedAt: null,
+      },
+    ])
+  ) as Runs;
+
+const artifact = (id: string, sourceQuestId: string) => ({ id, type: 'react', title: id, sourceQuestId });
+
+describe('linkNodeArtifacts', () => {
+  beforeEach(() => {
+    findByQuestIds.mockReset().mockResolvedValue([]);
+    linkArtifacts.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('does not query when no node has a run', async () => {
+    await linkNodeArtifacts([node({ id: 'n1', execution: undefined })], runs([]), logger);
+    expect(findByQuestIds).not.toHaveBeenCalled();
+  });
+
+  it('attaches a run artifact to its node and returns it for display', async () => {
+    findByQuestIds.mockResolvedValue([artifact('art-1', 'quest-1')]);
+
+    const result = await linkNodeArtifacts([node({ id: 'n1' })], runs([['exec-1', 'quest-1']]), logger);
+
+    expect(linkArtifacts).toHaveBeenCalledWith('n1', ['art-1']);
+    expect(result.get('n1')).toEqual([{ id: 'art-1', type: 'react', title: 'art-1' }]);
+  });
+
+  // One batched query for the whole graph: this runs on a polled endpoint, so a
+  // per-node lookup would be an N+1.
+  it('queries once for the whole graph, de-duplicating quest ids', async () => {
+    await linkNodeArtifacts(
+      [
+        node({ id: 'n1', execution: { agentExecutionId: 'exec-1' } }),
+        node({ id: 'n2', execution: { agentExecutionId: 'exec-2' } }),
+      ],
+      runs([
+        ['exec-1', 'quest-1'],
+        ['exec-2', 'quest-1'],
+      ]),
+      logger
+    );
+
+    expect(findByQuestIds).toHaveBeenCalledTimes(1);
+    expect(findByQuestIds).toHaveBeenCalledWith(['quest-1']);
+  });
+
+  it('writes nothing when the node already carries the artifact', async () => {
+    findByQuestIds.mockResolvedValue([artifact('art-1', 'quest-1')]);
+
+    const result = await linkNodeArtifacts(
+      [node({ id: 'n1', artifactIds: ['art-1'] })],
+      runs([['exec-1', 'quest-1']]),
+      logger
+    );
+
+    expect(linkArtifacts).not.toHaveBeenCalled();
+    expect(result.get('n1')).toHaveLength(1); // still rendered
+  });
+
+  it('adds only the artifacts the node is missing', async () => {
+    findByQuestIds.mockResolvedValue([artifact('art-1', 'quest-1'), artifact('art-2', 'quest-1')]);
+
+    await linkNodeArtifacts([node({ id: 'n1', artifactIds: ['art-1'] })], runs([['exec-1', 'quest-1']]), logger);
+
+    expect(linkArtifacts).toHaveBeenCalledWith('n1', ['art-2']);
+  });
+
+  // Artifacts are an enrichment; the graph must stay readable without them.
+  it('returns empty and does not throw when the lookup fails', async () => {
+    findByQuestIds.mockRejectedValue(new Error('mongo down'));
+
+    const result = await linkNodeArtifacts([node({ id: 'n1' })], runs([['exec-1', 'quest-1']]), logger);
+
+    expect(result.size).toBe(0);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('still renders the artifact when only the node write fails', async () => {
+    findByQuestIds.mockResolvedValue([artifact('art-1', 'quest-1')]);
+    linkArtifacts.mockRejectedValue(new Error('write failed'));
+
+    const result = await linkNodeArtifacts([node({ id: 'n1' })], runs([['exec-1', 'quest-1']]), logger);
+
+    expect(result.get('n1')).toHaveLength(1);
+  });
+
+  // The run reached a terminal state before persistRunAsQuest wrote anything.
+  it('is a no-op when the run has no quest id yet', async () => {
+    await linkNodeArtifacts([node({ id: 'n1' })], runs([['exec-1', null]]), logger);
+    expect(findByQuestIds).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/server/questmaster/v5/linkNodeArtifacts.ts
+++ b/apps/client/server/questmaster/v5/linkNodeArtifacts.ts
@@ -1,0 +1,90 @@
+import { artifactRepository, questNodeRepository } from '@bike4mind/database';
+import type { IQuestNodeDocument } from '@bike4mind/common';
+import type { Logger } from '@bike4mind/observability';
+import type { NodeRunSummary } from './reconcileQuestNodes';
+
+/** What the graph view needs to render an artifact chip - never the body. */
+export interface NodeArtifact {
+  id: string;
+  type: string;
+  title: string;
+}
+
+/**
+ * Attach each node's run artifacts to the node, and return them for the wire.
+ *
+ * The join is `artifact.sourceQuestId === run.questId`: `persistAgentArtifacts`
+ * stamps every row it writes with the Quest the run produced, and a v5 node
+ * knows that Quest through its execution. Nothing about this is v5-specific on
+ * the write side, which is why the node link had to wait for server-side
+ * artifact persistence to land.
+ *
+ * Runs on every graph read rather than only at the completed-transition,
+ * deliberately. The executor calls `markComplete` BEFORE `persistRunAsQuest`
+ * writes the artifacts, so a node can legitimately reach `completed` a moment
+ * before its artifacts exist. Linking only on transition would lose that race
+ * permanently; re-deriving on read makes it self-healing, and `linkArtifacts`
+ * uses `$addToSet` so repeats are free.
+ *
+ * One batched query for the whole graph, projected to id/type/title - a
+ * per-node lookup would be an N+1 on a polled endpoint, and the full document
+ * carries the artifact body.
+ *
+ * Best-effort by contract: artifacts are an enrichment, so a failure here
+ * returns an empty map and leaves the graph perfectly readable.
+ */
+export async function linkNodeArtifacts(
+  nodes: IQuestNodeDocument[],
+  runs: Map<string, NodeRunSummary>,
+  logger: Logger
+): Promise<Map<string, NodeArtifact[]>> {
+  const byNode = new Map<string, NodeArtifact[]>();
+
+  const questIdByNode = new Map<string, string>();
+  for (const node of nodes) {
+    const executionId = node.execution?.agentExecutionId;
+    const questId = executionId ? runs.get(executionId)?.questId : undefined;
+    if (questId) questIdByNode.set(node.id, questId);
+  }
+  if (!questIdByNode.size) return byNode;
+
+  try {
+    const rows = await artifactRepository.findByQuestIds([...new Set(questIdByNode.values())]);
+    if (!rows.length) return byNode;
+
+    const byQuest = new Map<string, NodeArtifact[]>();
+    for (const row of rows) {
+      const list = byQuest.get(row.sourceQuestId) ?? [];
+      list.push({ id: row.id, type: row.type, title: row.title });
+      byQuest.set(row.sourceQuestId, list);
+    }
+
+    await Promise.all(
+      nodes.map(async node => {
+        const questId = questIdByNode.get(node.id);
+        const artifacts = questId ? byQuest.get(questId) : undefined;
+        if (!artifacts?.length) return;
+        byNode.set(node.id, artifacts);
+
+        // Persist only what the node does not already carry, so a steady-state
+        // read does no writes at all.
+        const missing = artifacts.map(a => a.id).filter(id => !node.artifactIds.includes(id));
+        if (!missing.length) return;
+        try {
+          await questNodeRepository.linkArtifacts(node.id, missing);
+        } catch (err) {
+          logger.warn('[questmaster-v5] could not attach artifacts to node - they still render', {
+            nodeId: node.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      })
+    );
+  } catch (err) {
+    logger.warn('[questmaster-v5] artifact lookup failed - rendering the graph without artifacts', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return byNode;
+}

--- a/apps/client/server/questmaster/v5/loadGraphDetail.ts
+++ b/apps/client/server/questmaster/v5/loadGraphDetail.ts
@@ -2,6 +2,7 @@ import { agentExecutionRepository, isNodeReady, isNodeRunnable, questNodeReposit
 import type { IQuestGraphDocument, NodeStatus } from '@bike4mind/common';
 import type { Logger } from '@bike4mind/observability';
 import { reconcileQuestNodes, type NodeRunSummary } from './reconcileQuestNodes';
+import { linkNodeArtifacts } from './linkNodeArtifacts';
 import { toQuestGraphWire, toQuestNodeWire, type QuestNodeRunWire } from './wire';
 
 /**
@@ -31,6 +32,7 @@ export async function loadGraphDetail(graph: IQuestGraphDocument, logger: Logger
 
   const nodes = await reconcileQuestNodes(stored, runs, logger);
   const statusById = new Map<string, NodeStatus>(nodes.map(n => [n.id, n.status]));
+  const artifactsByNode = await linkNodeArtifacts(nodes, runs, logger);
 
   return {
     graph: toQuestGraphWire(graph),
@@ -41,6 +43,7 @@ export async function loadGraphDetail(graph: IQuestGraphDocument, logger: Logger
         isReady: isNodeReady(node, statusById),
         isRunnable: isNodeRunnable(node, statusById),
         run: run ? toRunWire(executionId!, run) : null,
+        artifacts: artifactsByNode.get(node.id) ?? [],
       });
     }),
   };

--- a/apps/client/server/questmaster/v5/reconcileQuestNodes.ts
+++ b/apps/client/server/questmaster/v5/reconcileQuestNodes.ts
@@ -6,6 +6,8 @@ import { nodeStatusFromExecution } from './nodeStatusFromExecution';
 /** The projected slice of an AgentExecution a node needs to reconcile and render. */
 export interface NodeRunSummary {
   id: string;
+  /** The Quest this run wrote; artifacts carry it as `sourceQuestId`. */
+  questId: string | null;
   status: AgentExecutionStatus;
   answer: string | null;
   totalIterations: number | null;

--- a/apps/client/server/questmaster/v5/verifyArtifactLink.integration.ts
+++ b/apps/client/server/questmaster/v5/verifyArtifactLink.integration.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env npx tsx
+/**
+ * Integration verification for the node -> artifact link, against REAL Mongo.
+ *
+ * The unit tests mock the repositories, so they prove the control flow and
+ * nothing about the join itself: that `artifact.sourceQuestId` really matches
+ * `run.questId`, that the projection returns the fields the wire needs, that
+ * `linkArtifacts` actually persists, and that a second read writes nothing.
+ * Those are properties of the schema and the query, so they need the database.
+ *
+ * Needs no deploy - it drives the module directly, so it works on a stage whose
+ * stack is behind (which is the situation this was written in).
+ *
+ *   ./for-env local npx sst shell --stage <stage> -- \
+ *     sh -c 'cd apps/client && npx tsx server/questmaster/v5/verifyArtifactLink.integration.ts'
+ *
+ * Writes only rows tagged with a unique run id and removes them in a finally.
+ */
+
+import { connectDB, Artifact, QuestGraph, QuestNode, questNodeRepository } from '@bike4mind/database';
+import { Config } from '@server/utils/config';
+import { linkNodeArtifacts } from './linkNodeArtifacts';
+import type { NodeRunSummary } from './reconcileQuestNodes';
+import mongoose from 'mongoose';
+
+const RUN = `alink-${Date.now().toString(36)}`;
+const QUEST_ID = `${RUN}-quest`;
+const EXEC_ID = new mongoose.Types.ObjectId().toString();
+
+const logs: string[] = [];
+const logger = {
+  info: (m: string) => logs.push(m),
+  warn: (m: string) => logs.push(m),
+  error: (m: string) => logs.push(m),
+  debug: () => {},
+} as never;
+
+let failures = 0;
+const check = (label: string, cond: boolean, detail = '') => {
+  console.log(`  ${cond ? 'PASS' : 'FAIL'}  ${label}${!cond && detail ? ` -- ${detail}` : ''}`);
+  if (!cond) failures++;
+};
+
+const runs = (questId: string | null): Map<string, NodeRunSummary> =>
+  new Map([
+    [
+      EXEC_ID,
+      {
+        id: EXEC_ID,
+        questId,
+        status: 'completed',
+        answer: null, // deliberately null: the settle path must not depend on it
+        totalIterations: 1,
+        totalCreditsUsed: 1,
+        errorMessage: null,
+        completedAt: new Date(),
+      },
+    ],
+  ]);
+
+async function run() {
+  await connectDB(Config.MONGODB_URI.replace('%STAGE%', Config.STAGE));
+  console.log(`connected to stage '${Config.STAGE}'. run ${RUN}\n`);
+
+  const graph = await QuestGraph.create({ goal: `${RUN} goal`, userId: `${RUN}-user` });
+  const node = await questNodeRepository.addNode({ graphId: graph.id, title: 'n', task: 'do it' });
+  await questNodeRepository.setExecution(node.id, { agentExecutionId: EXEC_ID });
+
+  // Two artifacts shaped exactly as persistAgentArtifacts writes them.
+  const artifactFixture = (id: string, type: string, title: string) => ({
+    id,
+    type,
+    title,
+    sourceQuestId: QUEST_ID,
+    userId: `${RUN}-user`,
+    version: 1,
+    // Required by the schema; the join under test touches none of them.
+    contentId: new mongoose.Types.ObjectId(),
+    contentHash: 'fixture',
+    contentSize: 1,
+    permissions: { canRead: [], canWrite: [], canDelete: [], isPublic: false, inheritFromProject: true },
+  });
+  await Artifact.create([
+    artifactFixture(`${RUN}-art-1`, 'react', 'Counter'),
+    artifactFixture(`${RUN}-art-2`, 'code', 'Helper'),
+  ]);
+
+  console.log('1. the run -> artifact join resolves against real rows');
+  const fresh = (await questNodeRepository.getNode(node.id))!;
+  const first = await linkNodeArtifacts([fresh], runs(QUEST_ID), logger);
+  const found = first.get(node.id) ?? [];
+  check('both artifacts found for the node', found.length === 2, `got ${found.length}`);
+  check('projection carries type and title', Boolean(found[0]?.type && found[0]?.title), JSON.stringify(found[0]));
+
+  console.log('\n2. the ids are persisted onto the node');
+  const linked = (await questNodeRepository.getNode(node.id))!;
+  check('artifactIds written', linked.artifactIds.length === 2, `got ${linked.artifactIds.length}`);
+
+  console.log('\n3. a second read writes nothing but still renders');
+  const before = (await QuestNode.findById(node.id).lean<{ updatedAt: Date }>())!.updatedAt.getTime();
+  const second = await linkNodeArtifacts([linked], runs(QUEST_ID), logger);
+  const after = (await QuestNode.findById(node.id).lean<{ updatedAt: Date }>())!.updatedAt.getTime();
+  check('still returns them for display', (second.get(node.id) ?? []).length === 2);
+  check('no write on a steady-state read', before === after, 'updatedAt moved');
+
+  console.log('\n4. a run with no quest id is a no-op');
+  const none = await linkNodeArtifacts([linked], runs(null), logger);
+  check('nothing returned', none.size === 0);
+
+  console.log('\n5. the index the join relies on exists');
+  const idx = await Artifact.collection.indexes();
+  check(
+    'sourceQuestId is indexed exactly once',
+    idx.filter(i => JSON.stringify(i.key) === JSON.stringify({ sourceQuestId: 1 })).length === 1,
+    JSON.stringify(idx.map(i => i.key))
+  );
+}
+
+async function cleanup() {
+  // Scoped to THIS run's graph. An earlier version filtered on `{ title: 'n' }`,
+  // which would have matched any node anyone else had named the same - never
+  // write a cleanup filter that is not keyed to the run's own ids.
+  await Artifact.deleteMany({ sourceQuestId: QUEST_ID });
+  const graphs = await QuestGraph.find({ goal: `${RUN} goal` }, { _id: 1 }).lean<Array<{ _id: unknown }>>();
+  const graphIds = graphs.map(g => String(g._id));
+  if (graphIds.length) await QuestNode.deleteMany({ graphId: { $in: graphIds } });
+  await QuestGraph.deleteMany({ goal: `${RUN} goal` });
+  console.log('\ncleaned up');
+}
+
+run()
+  .catch(err => {
+    failures++;
+    console.error('\nERROR:', err instanceof Error ? err.message : String(err));
+  })
+  .finally(async () => {
+    await cleanup().catch(e => console.error('cleanup failed:', e));
+    await mongoose.disconnect();
+    console.log(failures === 0 ? '\nALL CHECKS PASSED\n' : `\n${failures} CHECK(S) FAILED\n`);
+    process.exit(failures === 0 ? 0 : 1);
+  });

--- a/apps/client/server/questmaster/v5/wire.ts
+++ b/apps/client/server/questmaster/v5/wire.ts
@@ -51,6 +51,13 @@ export const QuestNodeRunWireSchema = z.object({
   errorMessage: z.string().nullable(),
 });
 
+/** Enough to render an artifact chip and open it; never the body. */
+export const QuestNodeArtifactWireSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  title: z.string(),
+});
+
 export const QuestNodeWireSchema = z.object({
   id: z.string(),
   graphId: z.string(),
@@ -67,6 +74,8 @@ export const QuestNodeWireSchema = z.object({
   reviewVerdict: z.enum(REVIEW_VERDICT_VALUES).nullable().optional(),
   enabledTools: z.array(z.string()),
   artifactIds: z.array(z.string()),
+  /** Resolved from artifactIds for display - empty until the run persists them. */
+  artifacts: z.array(QuestNodeArtifactWireSchema),
   isReady: z.boolean(),
   /** Dependencies met AND the status allows a manual dispatch (includes `failed`, which is retryable). */
   isRunnable: z.boolean(),
@@ -90,6 +99,7 @@ export const QuestNodeRunResponseSchema = z.object({
 export type QuestGraphWire = z.infer<typeof QuestGraphWireSchema>;
 export type QuestNodeWire = z.infer<typeof QuestNodeWireSchema>;
 export type QuestNodeRunWire = z.infer<typeof QuestNodeRunWireSchema>;
+export type QuestNodeArtifact = z.infer<typeof QuestNodeArtifactWireSchema>;
 
 export function toQuestGraphWire(graph: IQuestGraphDocument): QuestGraphWire {
   return {
@@ -113,7 +123,7 @@ export function toQuestGraphWire(graph: IQuestGraphDocument): QuestGraphWire {
 
 export function toQuestNodeWire(
   node: IQuestNodeDocument,
-  extras: { isReady: boolean; isRunnable: boolean; run: QuestNodeRunWire | null }
+  extras: { isReady: boolean; isRunnable: boolean; run: QuestNodeRunWire | null; artifacts?: QuestNodeArtifact[] }
 ): QuestNodeWire {
   return {
     id: node.id,
@@ -131,6 +141,7 @@ export function toQuestNodeWire(
     reviewVerdict: node.reviewVerdict,
     enabledTools: node.enabledTools,
     artifactIds: node.artifactIds,
+    artifacts: extras.artifacts ?? [],
     isReady: extras.isReady,
     isRunnable: extras.isRunnable,
     run: extras.run,

--- a/apps/client/server/questmaster/v5/wire.ts
+++ b/apps/client/server/questmaster/v5/wire.ts
@@ -74,7 +74,12 @@ export const QuestNodeWireSchema = z.object({
   reviewVerdict: z.enum(REVIEW_VERDICT_VALUES).nullable().optional(),
   enabledTools: z.array(z.string()),
   artifactIds: z.array(z.string()),
-  /** Resolved from artifactIds for display - empty until the run persists them. */
+  /**
+   * The artifacts this node's run produced, joined on
+   * `run.questId === artifact.sourceQuestId`. This is the source of truth for
+   * display; `artifactIds` above is a best-effort backfill written FROM this,
+   * not the other way round.
+   */
   artifacts: z.array(QuestNodeArtifactWireSchema),
   isReady: z.boolean(),
   /** Dependencies met AND the status allows a manual dispatch (includes `failed`, which is retryable). */

--- a/packages/database/src/models/billing/AgentExecutionModel.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.ts
@@ -1612,6 +1612,7 @@ class AgentExecutionRepository extends BaseRepository<IAgentExecution> {
   async findRunSummariesByIds(ids: string[]): Promise<
     Array<{
       id: string;
+      questId: string | null;
       status: AgentExecutionStatus;
       answer: string | null;
       totalIterations: number | null;
@@ -1628,6 +1629,7 @@ class AgentExecutionRepository extends BaseRepository<IAgentExecution> {
         { _id: { $in: valid.map(id => new mongoose.Types.ObjectId(id)) } },
         {
           _id: 1,
+          questId: 1,
           status: 1,
           'result.answer': 1,
           'result.totalIterations': 1,
@@ -1639,6 +1641,7 @@ class AgentExecutionRepository extends BaseRepository<IAgentExecution> {
       .lean<
         Array<{
           _id: mongoose.Types.ObjectId;
+          questId?: string;
           status: AgentExecutionStatus;
           result?: { answer?: string; totalIterations?: number };
           totalCreditsUsed?: number;
@@ -1649,6 +1652,9 @@ class AgentExecutionRepository extends BaseRepository<IAgentExecution> {
 
     return docs.map(doc => ({
       id: String(doc._id),
+      // The Quest this run wrote. QuestMaster v5 joins a node's artifacts on it -
+      // persistAgentArtifacts stamps `sourceQuestId` with the same value.
+      questId: doc.questId ?? null,
       status: doc.status,
       answer: typeof doc.result?.answer === 'string' ? doc.result.answer : null,
       totalIterations: typeof doc.result?.totalIterations === 'number' ? doc.result.totalIterations : null,

--- a/packages/database/src/models/content/ArtifactModel.ts
+++ b/packages/database/src/models/content/ArtifactModel.ts
@@ -112,7 +112,6 @@ const ArtifactSchema = new Schema(
     // Relationships
     sourceQuestId: {
       type: String,
-      index: true,
     },
     sessionId: {
       type: String,
@@ -183,6 +182,12 @@ ArtifactSchema.index({ createdAt: -1, status: 1 }); // Recent artifacts
 ArtifactSchema.index({ updatedAt: -1, status: 1 }); // Recently updated
 ArtifactSchema.index({ contentHash: 1 }); // Content deduplication
 ArtifactSchema.index({ deletedAt: 1 }); // Soft delete queries
+// Artifacts produced by one agent run, looked up by the Quest that run wrote.
+// Read by QuestMaster v5 to attach a run's artifacts to its node, and by
+// persistAgentArtifacts' quest-level idempotency gate. Moved off the field's
+// `index: true` (see CLAUDE.md) - declaring it in both places is what produced
+// a duplicate-index warning at model load.
+ArtifactSchema.index({ sourceQuestId: 1 });
 
 // Text search index for title and description
 ArtifactSchema.index(
@@ -346,6 +351,25 @@ export class ArtifactRepository extends BaseRepository<IArtifactDocument> {
 
   async findDeleted(filter: Record<string, unknown> = {}) {
     return this.find({ ...filter, deletedAt: { $ne: null } });
+  }
+
+  /**
+   * The artifacts a set of agent runs produced, keyed by the Quest each run
+   * wrote. Projected and batched: QuestMaster v5 calls this once per graph read
+   * to attach a node's artifacts, so it must not be an N+1 and must not drag
+   * `content` (which is the whole artifact body) across for a chip label.
+   */
+  async findByQuestIds(
+    questIds: string[]
+  ): Promise<Array<{ id: string; type: string; title: string; sourceQuestId: string }>> {
+    if (!questIds.length) return [];
+    return this.model
+      .find(
+        { sourceQuestId: { $in: questIds }, deletedAt: null },
+        { _id: 0, id: 1, type: 1, title: 1, sourceQuestId: 1 }
+      )
+      .sort({ createdAt: 1 })
+      .lean<Array<{ id: string; type: string; title: string; sourceQuestId: string }>>();
   }
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Closes the gap Phase 1 (#1147) deliberately left open: `node.artifactIds` was always empty, because nothing wrote it. Server-side agent artifact persistence (#286) landed today, so the link is now possible.

**The join:** a node knows its execution, the execution knows its Quest, and `persistAgentArtifacts` stamps every row it writes with that Quest as `sourceQuestId`. Nothing about that is v5-specific on the write side, which is exactly why this had to wait for #286.

## Changes

**Derived on every graph read, not at the completed-transition.** This is the load-bearing decision. The executor calls `markComplete` **before** `persistRunAsQuest` writes the artifacts, so a node legitimately reaches `completed` a moment before its artifacts exist. Linking only on transition would lose that race permanently. Re-deriving on read makes it self-healing, and `linkArtifacts` uses `$addToSet`, so a steady-state read does no writes at all.

- `linkNodeArtifacts.ts` — one batched, projected query per graph read (`findByQuestIds`), never per node: this is a polled endpoint, and the full artifact document carries the body. Best-effort by contract; artifacts are an enrichment, so a failure leaves the graph perfectly readable.
- `AgentExecutionModel` — `questId` threaded through `findRunSummariesByIds` (it was already the natural key, just not projected).
- `ArtifactModel` — new `findByQuestIds`, projected to `id/type/title`.

**Client** keeps polling for a bounded window after a run completes, for the same race. Otherwise the poll that first sees `completed` stops and the node looks artifact-less until something else refetches. Bounded by `completedAt`, so a run that genuinely emits no artifacts stops quickly rather than spinning.

**UI** — the result panel lists a node's artifacts as chips.

## Additional Information

**Index hygiene.** `Artifact.sourceQuestId` had `index: true` on the field *and* I added a `schema.index()` declaration, which produced a duplicate-index warning at model load — caught by the new tests. Fixed per CLAUDE.md: `index: true` removed, the declaration kept with the others at the bottom. The field was already indexed; #286's quest-level idempotency gate queries the same key, so both paths benefit from it being declared once.

**The chips navigate to the notebook, not to an artifact page.** There is no `/artifacts/:id` route — artifacts render inline in chat via `ArtifactRenderer`. I checked before wiring it rather than shipping a dead link. Per-node artifact inspection is Phase 5; this at least lands you where the artifact actually is.

## Guide for Testers

Requires the **Quest Master v5** experimental flag (off by default, user-only).

1. Go to `app.staging.bike4mind.com`, Profile → Experimental Features → turn **Quest Master v5** on.
2. Sidebar → **Quests v5**.
3. Type a goal, e.g. `Artifact link check`, click **New**.
4. Add a node — Title `Make a component`, Task `Create a tiny React counter component as an artifact.`
5. Pick a model in the model picker, then click **Run**.
6. Wait for the status chip to reach `completed` (the view polls; no refresh needed).
7. Click the node row. Expected: an **"Artifacts from this node"** section with a chip like `react: Counter`, alongside the answer text.
8. Click the chip. Expected: navigates to the notebook where the artifact renders in chat.

**The race is the interesting case.** Artifacts are written just after the run reports complete, so the chip may appear a few seconds after the status flips to `completed`. That is expected and is what the settle-poll handles — it should appear without you refreshing. If it only appears after a manual refresh, that is a bug worth reporting.

**Regression checks**
9. A node whose run produces no artifact should show no artifact section at all (not an empty heading).
10. Node execution, dependency gating and failed-node retry from #1147 should be unchanged.

**What NOT to test**
- Automatic graph execution / plan generation — Phases 2a and 2b.
- Node scoring — Phase 4.
- Opening an artifact in a dedicated per-node viewer — Phase 5.

## Developer Notes

- **Derive-on-read over write-on-transition** is the pattern worth reusing anywhere state depends on another subsystem's terminal write. It converts an ordering race from a permanent data-loss bug into a transient display delay.
- `findByQuestIds` is a general "artifacts produced by these runs" query, useful to anything joining runs to artifacts.
- The bounded settle-poll keyed on `completedAt` is a cheap alternative to extra client state when you need to poll a little past a terminal condition.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings — and removed an existing duplicate-index warning
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A

Verified: client **779/779**, database **30/30**, typecheck clean, lint clean.

Follows #1147. Next in the stack: Phase 2a (goal → spine+tasks plan generation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
