### PR TITLE
docs(help): add Data Lakes and OptiHashi help articles

### DIFF
--- a/docs-site/docs/features/data-lakes.md
+++ b/docs-site/docs/features/data-lakes.md
@@ -1,0 +1,62 @@
+---
+title: Data Lakes
+description: Curated knowledge collections for AI-powered retrieval
+sidebar_position: 17
+---
+
+# Data Lakes
+
+Data Lakes are curated collections of documents that power AI retrieval in Bike4Mind. They provide structured, scoped access to knowledge bases so the AI can search and reference domain-specific content during conversations.
+
+## How It Works
+
+A Data Lake groups files under a common tag prefix and makes them available to AI tools like knowledge base search and retrieval. Each Data Lake has:
+
+- **Name and slug** -- a human-readable identifier
+- **File tag prefix** -- scopes which uploaded files belong to the lake
+- **Access controls** -- user tags and entitlement gates determine who can query the lake
+- **Organization scoping** -- lakes can be scoped to a specific organization
+
+## Access Control
+
+Data Lakes support two layers of access control:
+
+1. **User tags** -- users with the required tag can access the lake's content
+2. **Entitlements** -- subscription-level or role-based entitlement keys provide an additional gate
+
+When an AI tool performs a knowledge base search, it automatically resolves which Data Lakes the current user can access based on their tags and entitlements.
+
+## Lifecycle
+
+Data Lakes follow a lifecycle with these statuses:
+
+| Status | Description |
+|--------|-------------|
+| Draft | Being configured, not yet active |
+| Active | Available for AI retrieval |
+| Archiving | Being moved to cold storage |
+| Archived | In cold storage, not searchable |
+| Restoring | Being brought back from archive |
+| Deleting | Removal in progress |
+
+## Use Cases
+
+- **Domain-specific knowledge** -- upload medical literature, legal documents, or technical manuals and scope retrieval to authorized users
+- **Organization knowledge bases** -- each org can maintain its own curated content
+- **Product documentation** -- give AI access to internal docs for support workflows
+
+## FAQ
+
+**How do I create a Data Lake?**
+Data Lakes are created and managed by administrators. Contact your admin to set up a new lake with the appropriate tag prefix and access controls.
+
+**Can I query multiple Data Lakes at once?**
+Yes. The AI retrieval tools automatically search across all Data Lakes you have access to based on your user tags and entitlements.
+
+**How are files added to a Data Lake?**
+Files are tagged with the lake's file tag prefix when uploaded. The lake tracks file count and total size automatically.
+
+## Related
+
+- [Knowledge Management](./knowledge-management.md) -- uploading and managing files
+- [Smart Tools](./smart-tools.md) -- AI tools that query Data Lakes

--- a/docs-site/docs/features/optihashi.md
+++ b/docs-site/docs/features/optihashi.md
@@ -1,0 +1,56 @@
+---
+title: OptiHashi
+description: AI-driven optimization engine for scheduling and resource allocation
+sidebar_position: 18
+---
+
+# OptiHashi
+
+OptiHashi is Bike4Mind's optimization engine. It provides AI-driven schedule optimization and resource allocation using a range of advanced solvers, accessible both through the sidebar dashboard and as smart tools within notebooks.
+
+## Features
+
+### Schedule Optimization
+
+Run optimization solvers on scheduling problems to find optimal or near-optimal solutions. OptiHashi supports a variety of solver backends and can handle complex constraints including:
+
+- Resource availability windows
+- Task dependencies and ordering
+- Capacity limits
+- Multi-objective trade-offs
+
+### Problem Formulation
+
+Describe your scheduling problem in plain English and the AI will convert it into structured input that the optimization engine can solve. No need to manually define variables and constraints.
+
+### Dashboard
+
+Access the OptiHashi dashboard from the sidebar to:
+
+- View and manage optimization runs
+- Inspect solver results and schedules
+- Compare alternative solutions
+- Export optimized schedules
+
+## Smart Tools Integration
+
+OptiHashi exposes optimization capabilities as smart tools within notebooks:
+
+- **Schedule Optimization** -- submit and solve scheduling problems directly from chat
+- **Problem Formulation** -- convert natural language descriptions into solver-ready input
+
+## FAQ
+
+**How do I access OptiHashi?**
+OptiHashi appears in the sidebar when enabled for your account. You can also use the optimization smart tools directly in any notebook.
+
+**What types of problems can OptiHashi solve?**
+OptiHashi specializes in scheduling and resource allocation problems -- shift scheduling, project planning, task assignment, and similar combinatorial optimization challenges.
+
+**How long does an optimization run take?**
+Run time depends on problem complexity. Simple problems solve in seconds; larger problems with many constraints may take longer. The dashboard shows progress in real time.
+
+## Related
+
+- [Smart Tools](./smart-tools.md) -- using optimization tools in notebooks
+- [Profile Settings](./profile-settings.md) -- enabling OptiHashi

--- a/docs-site/docs/features/tavern/_category_.json
+++ b/docs-site/docs/features/tavern/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Tavern",
-  "position": 30,
+  "position": 80,
   "link": {
     "type": "doc",
     "id": "features/tavern/index"


### PR DESCRIPTION
## Description

The Data Lakes and OptiHashi help articles, split out of #283 where they were
unrelated to the splash-card toggle they shipped alongside. Also moves Tavern
help content to the bottom of the help-center ordering.

**Draft: needs a `help-embeddings.json` regen before it can merge.** See below.

## Changes

- Add `docs-site/docs/features/data-lakes.md`
- Add `docs-site/docs/features/optihashi.md`
- Move Tavern to sidebar position 80 (was 30)

## Blocked on: help embeddings

This branch intentionally does **not** include a regenerated
`apps/client/app/generated/help-index.json`.

The index and `help-embeddings.json` are both tracked, and
`.husky/check-help-content.sh` hard-fails any commit whose index contains a slug
with no matching embedding chunk. That guard exists because an index entry
without an embedding means the Help AI chat cannot answer questions about the
article - it appears in the sidebar but is invisible to search.

That is exactly what #283 shipped: 85 index entries against 83 embedded slugs.
It passed CI because **this check is pre-commit only and has no CI equivalent**,
so a `--no-verify` commit walks straight past it. Once the mismatch is on a
branch the hook blocks *every* subsequent commit in the clone, including
unrelated ones, because it compares files on disk rather than the staged diff.

Committing a stale index here would reintroduce that, so the generated files are
left for whoever has an OpenAI key. To finish this PR:

```
pnpm --filter @bike4mind/scripts help:build-index
pnpm --filter @bike4mind/scripts help:bundle-content
OPENAI_API_KEY=sk-... pnpm --filter @bike4mind/scripts help:vectorize
```

Then stage both `help-index.json` and `help-embeddings.json`, confirm the counts
match, and mark ready for review. `help:regenerate` runs all three.

## Guide for Testers

1. Go to the deployed docs site / in-app Help center.
2. Search for `Data Lakes`. **Expected:** the article opens and renders, with
   working links and images.
3. Search for `OptiHashi`. **Expected:** same.
4. Open the Help AI chat and ask `What is a Data Lake?`.
   **Expected:** it answers from the new article. *This step only passes once
   the embeddings above have been regenerated - it is the reason this PR is a
   draft.*
5. Check the help sidebar ordering. **Expected:** Tavern content now sorts to
   the bottom.

### What NOT to test

No application code changes here - no need to exercise notebooks, settings, or
any runtime behavior beyond the Help center itself.

## Additional Information

`pnpm --filter @bike4mind/scripts help:validate` passes on both articles (no
broken links, anchors, images, or frontmatter issues).

Worth considering separately: promoting the index/embeddings sync check into CI,
so this class of mismatch cannot reach `main` behind a `--no-verify`.
