### PR TITLE
fix(cli): stop the thinking frame from wiping terminal scrollback

### DIFF
--- a/packages/cli/src/components/App.scrollback.test.tsx
+++ b/packages/cli/src/components/App.scrollback.test.tsx
@@ -2,34 +2,40 @@
  * Regression guard for the real defect: Ink repaints the live frame in place
  * only while it fits the viewport. Any taller frame goes through
  * `ansiEscapes.clearTerminal`, which includes ESC[3J ("erase scrollback"), so a
- * spinner ticking over an overflowing frame wipes scrollback ~12x/sec and the
- * terminal can never stay scrolled up.
+ * frame that overflows wipes scrollback on every repaint and the terminal can
+ * never stay scrolled up.
  *
  * These tests drive the real Ink renderer against a fake TTY and assert the
- * escape never reaches stdout while the agent is thinking. The last case is a
- * control: it renders a deliberately overflowing frame to prove the assertion
- * has teeth.
+ * escape never reaches stdout while the agent is thinking. Frames are driven by
+ * store updates rather than by waiting on the spinner: a fixed sleep is both
+ * flaky and dangerous here, because a run that produces only one frame can
+ * never clear and would pass vacuously. The last case is a control that renders
+ * a deliberately overflowing frame to prove the assertion has teeth.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import React from 'react';
 import { render, Box, Text } from 'ink';
-import Spinner from 'ink-spinner';
 import { App } from './App';
 import { useCliStore } from '../store';
 import type { Message } from '../storage';
 import type { AgentStep } from '@bike4mind/agents';
 
-const COLUMNS = 100;
 const ROWS = 24;
-const ERASE_SCROLLBACK = '[3J';
+const COLUMNS = 100;
+const ERASE_SCROLLBACK = '\u001b[3J';
 
 class FakeTtyStdout extends EventEmitter {
   isTTY = true;
-  columns = COLUMNS;
-  rows = ROWS;
   writes: string[] = [];
+
+  constructor(
+    public columns = COLUMNS,
+    public rows = ROWS
+  ) {
+    super();
+  }
 
   write(chunk: string) {
     this.writes.push(chunk);
@@ -75,8 +81,10 @@ const renderWithFakeTty = (node: React.ReactElement) =>
     patchConsole: false,
   });
 
-/** Long enough for several ink-spinner frames (80ms each) to be written. */
-const letTheSpinnerTick = () => new Promise(resolve => setTimeout(resolve, 300));
+/** Waits for Ink to write at least one more frame than it had. */
+const nextFrame = async (before: number) => {
+  await vi.waitFor(() => expect(stdout.writes.length).toBeGreaterThan(before), { timeout: 10_000, interval: 10 });
+};
 
 const thoughtStep = (i: number): AgentStep => ({
   type: 'thought',
@@ -91,6 +99,15 @@ const pendingMessage = (stepCount: number): Message => ({
   timestamp: new Date(0).toISOString(),
   metadata: { steps: Array.from({ length: stepCount }, (_, i) => thoughtStep(i)) },
 });
+
+/** Grows the pending trace step by step, the way a real turn does. */
+async function runTurn(stepCounts: number[]) {
+  for (const count of stepCounts) {
+    const before = stdout.writes.length;
+    useCliStore.setState({ pendingMessages: [pendingMessage(count)], isThinking: true });
+    await nextFrame(before);
+  }
+}
 
 const noop = () => {};
 const asyncNoop = async () => {};
@@ -108,37 +125,59 @@ function renderApp() {
   );
 }
 
+const GROWING_TURN = [1, 5, 10, 20, 40, 80];
+
 describe('App does not clobber scrollback while thinking', () => {
   beforeEach(() => {
     stdout = new FakeTtyStdout();
     stdin = new FakeTtyStdin();
+    useCliStore.setState({ pendingMessages: [], isThinking: true, messageQueue: [] });
   });
 
   afterEach(() => {
     useCliStore.setState({ pendingMessages: [], isThinking: false, messageQueue: [] });
-    vi.unstubAllEnvs();
   });
 
-  it('never erases scrollback for a long step trace', async () => {
-    useCliStore.setState({ pendingMessages: [pendingMessage(80)], isThinking: true });
+  it('never erases scrollback as the step trace grows', async () => {
+    const instance = renderApp();
+    await runTurn(GROWING_TURN);
+    // Ink clears once at teardown for a frame that filled the viewport; the
+    // defect is the wipe on every repaint, so measure the writes made before
+    // unmount.
+    const duringRun = stdout.all;
+    instance.unmount();
+
+    expect(stdout.writes.length).toBeGreaterThan(GROWING_TURN.length);
+    expect(duringRun).not.toContain(ERASE_SCROLLBACK);
+  });
+
+  it('never erases scrollback on a short terminal', async () => {
+    stdout.rows = 12;
 
     const instance = renderApp();
-    await letTheSpinnerTick();
-    // Ink clears once at teardown for a frame that filled the viewport; the
-    // defect is the per-frame wipe while the spinner runs, so measure the writes
-    // made before unmount.
+    await runTurn(GROWING_TURN);
     const duringRun = stdout.all;
     instance.unmount();
 
     expect(duringRun).not.toContain(ERASE_SCROLLBACK);
   });
 
-  it('never erases scrollback on a short terminal', async () => {
-    stdout.rows = 12;
-    useCliStore.setState({ pendingMessages: [pendingMessage(80)], isThinking: true });
+  it('never erases scrollback on a narrow terminal', async () => {
+    stdout.columns = 40;
 
     const instance = renderApp();
-    await letTheSpinnerTick();
+    await runTurn(GROWING_TURN);
+    const duringRun = stdout.all;
+    instance.unmount();
+
+    expect(duringRun).not.toContain(ERASE_SCROLLBACK);
+  });
+
+  it('never erases scrollback with queued messages taking rows', async () => {
+    useCliStore.setState({ messageQueue: ['first queued message', 'second queued message'] });
+
+    const instance = renderApp();
+    await runTurn(GROWING_TURN);
     const duringRun = stdout.all;
     instance.unmount();
 
@@ -146,19 +185,20 @@ describe('App does not clobber scrollback while thinking', () => {
   });
 
   it('control: an overflowing live frame does erase scrollback', async () => {
-    const Overflowing = () => (
+    const Overflowing = ({ rows }: { rows: number }) => (
       <Box flexDirection="column">
-        {Array.from({ length: ROWS * 2 }, (_, i) => (
+        {Array.from({ length: rows }, (_, i) => (
           <Text key={i}>{`row ${i}`}</Text>
         ))}
-        <Text>
-          <Spinner type="dots" />
-        </Text>
       </Box>
     );
 
-    const instance = renderWithFakeTty(<Overflowing />);
-    await letTheSpinnerTick();
+    const instance = renderWithFakeTty(<Overflowing rows={ROWS * 2} />);
+    // A second overflowing frame is what triggers the clear - the first has no
+    // previous frame to erase.
+    const before = stdout.writes.length;
+    instance.rerender(<Overflowing rows={ROWS * 2 + 1} />);
+    await nextFrame(before);
     instance.unmount();
 
     expect(stdout.all).toContain(ERASE_SCROLLBACK);

--- a/packages/cli/src/components/App.scrollback.test.tsx
+++ b/packages/cli/src/components/App.scrollback.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Regression guard for the real defect: Ink repaints the live frame in place
+ * only while it fits the viewport. Any taller frame goes through
+ * `ansiEscapes.clearTerminal`, which includes ESC[3J ("erase scrollback"), so a
+ * spinner ticking over an overflowing frame wipes scrollback ~12x/sec and the
+ * terminal can never stay scrolled up.
+ *
+ * These tests drive the real Ink renderer against a fake TTY and assert the
+ * escape never reaches stdout while the agent is thinking. The last case is a
+ * control: it renders a deliberately overflowing frame to prove the assertion
+ * has teeth.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import React from 'react';
+import { render, Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
+import { App } from './App';
+import { useCliStore } from '../store';
+import type { Message } from '../storage';
+import type { AgentStep } from '@bike4mind/agents';
+
+const COLUMNS = 100;
+const ROWS = 24;
+const ERASE_SCROLLBACK = '[3J';
+
+class FakeTtyStdout extends EventEmitter {
+  isTTY = true;
+  columns = COLUMNS;
+  rows = ROWS;
+  writes: string[] = [];
+
+  write(chunk: string) {
+    this.writes.push(chunk);
+    return true;
+  }
+
+  get all() {
+    return this.writes.join('');
+  }
+}
+
+class FakeTtyStdin extends EventEmitter {
+  isTTY = true;
+  setRawMode() {
+    return this;
+  }
+  setEncoding() {
+    return this;
+  }
+  resume() {
+    return this;
+  }
+  pause() {
+    return this;
+  }
+  read() {
+    return null;
+  }
+  ref() {}
+  unref() {}
+}
+
+let stdout: FakeTtyStdout;
+let stdin: FakeTtyStdin;
+
+const renderWithFakeTty = (node: React.ReactElement) =>
+  render(node, {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stdout: stdout as any, // any: fake TTY stream, only the bits Ink touches
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stdin: stdin as any, // any: same, for the stdin side
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+/** Long enough for several ink-spinner frames (80ms each) to be written. */
+const letTheSpinnerTick = () => new Promise(resolve => setTimeout(resolve, 300));
+
+const thoughtStep = (i: number): AgentStep => ({
+  type: 'thought',
+  content: `considering option ${i} in some detail`,
+  metadata: { timestamp: 0 },
+});
+
+const pendingMessage = (stepCount: number): Message => ({
+  id: 'pending-1',
+  role: 'assistant',
+  content: '...',
+  timestamp: new Date(0).toISOString(),
+  metadata: { steps: Array.from({ length: stepCount }, (_, i) => thoughtStep(i)) },
+});
+
+const noop = () => {};
+const asyncNoop = async () => {};
+
+function renderApp() {
+  return renderWithFakeTty(
+    <App
+      onMessage={asyncNoop}
+      onCommand={asyncNoop}
+      onBashCommand={noop}
+      onPermissionResponse={noop}
+      onUserQuestionResponse={noop}
+      onReviewGateResponse={noop}
+    />
+  );
+}
+
+describe('App does not clobber scrollback while thinking', () => {
+  beforeEach(() => {
+    stdout = new FakeTtyStdout();
+    stdin = new FakeTtyStdin();
+  });
+
+  afterEach(() => {
+    useCliStore.setState({ pendingMessages: [], isThinking: false, messageQueue: [] });
+    vi.unstubAllEnvs();
+  });
+
+  it('never erases scrollback for a long step trace', async () => {
+    useCliStore.setState({ pendingMessages: [pendingMessage(80)], isThinking: true });
+
+    const instance = renderApp();
+    await letTheSpinnerTick();
+    // Ink clears once at teardown for a frame that filled the viewport; the
+    // defect is the per-frame wipe while the spinner runs, so measure the writes
+    // made before unmount.
+    const duringRun = stdout.all;
+    instance.unmount();
+
+    expect(duringRun).not.toContain(ERASE_SCROLLBACK);
+  });
+
+  it('never erases scrollback on a short terminal', async () => {
+    stdout.rows = 12;
+    useCliStore.setState({ pendingMessages: [pendingMessage(80)], isThinking: true });
+
+    const instance = renderApp();
+    await letTheSpinnerTick();
+    const duringRun = stdout.all;
+    instance.unmount();
+
+    expect(duringRun).not.toContain(ERASE_SCROLLBACK);
+  });
+
+  it('control: an overflowing live frame does erase scrollback', async () => {
+    const Overflowing = () => (
+      <Box flexDirection="column">
+        {Array.from({ length: ROWS * 2 }, (_, i) => (
+          <Text key={i}>{`row ${i}`}</Text>
+        ))}
+        <Text>
+          <Spinner type="dots" />
+        </Text>
+      </Box>
+    );
+
+    const instance = renderWithFakeTty(<Overflowing />);
+    await letTheSpinnerTick();
+    instance.unmount();
+
+    expect(stdout.all).toContain(ERASE_SCROLLBACK);
+  });
+});

--- a/packages/cli/src/components/App.scrollback.test.tsx
+++ b/packages/cli/src/components/App.scrollback.test.tsx
@@ -79,6 +79,13 @@ const renderWithFakeTty = (node: React.ReactElement) =>
     stdin: stdin as any, // any: same, for the stdin side
     exitOnCtrlC: false,
     patchConsole: false,
+    // Required, not a nicety: Ink resolves interactive mode as
+    // `!isInCi && stdout.isTTY`, and a non-interactive run "disables ANSI erase
+    // sequences... writing only the final frame at unmount". Under CI=true these
+    // tests would then observe no repaints at all and could never see the erase
+    // they exist to forbid. Forcing it keeps them measuring the same path a real
+    // terminal takes.
+    interactive: true,
   });
 
 /** Waits for Ink to write at least one more frame than it had. */

--- a/packages/cli/src/components/App.tsx
+++ b/packages/cli/src/components/App.tsx
@@ -24,6 +24,10 @@ import type { McpManager } from '../utils/mcpAdapter';
 import { processFileReferences, hasFileReferences } from '../utils/processFileReferences.js';
 import type { CommandDefinition } from '../config/commands.js';
 import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
+import { MIN_TRACE_ROWS } from './liveStepWindow.js';
+
+/** Live-frame rows reserved for chrome below the step trace. Deliberately generous. */
+const LIVE_CHROME_ROWS = 12;
 
 interface AppProps {
   onMessage: (message: string) => Promise<void>;
@@ -124,7 +128,14 @@ export function App({
   // color fills the entire row (same pattern as the sent user-prompt
   // highlight in MessageItem.tsx). Subscribes to resize so the live frame
   // repaints at the new width instead of keeping the stale startup width.
-  const [terminalCols] = useStdoutDimensions();
+  const [terminalCols, terminalRows] = useStdoutDimensions();
+
+  // Rows the live frame spends on everything other than the step trace: the
+  // thinking line, background agent/shell status, the queued rows, the bordered
+  // input box and the status bar. Ink wipes and rebuilds scrollback on every
+  // frame taller than the viewport (see liveStepWindow.ts), so the trace only
+  // gets what is left over.
+  const liveTraceRows = Math.max(MIN_TRACE_ROWS, terminalRows - LIVE_CHROME_ROWS - messageQueue.length);
 
   const handleSubmit = React.useCallback(
     async (input: string) => {
@@ -220,7 +231,7 @@ export function App({
             <Box flexDirection="column">
               {pendingMessages.map(message => (
                 <Box key={message.id} flexDirection="column">
-                  <MessageItem message={message} showThoughts={showThoughts} />
+                  <MessageItem message={message} showThoughts={showThoughts} liveTraceRows={liveTraceRows} />
                 </Box>
               ))}
             </Box>

--- a/packages/cli/src/components/App.tsx
+++ b/packages/cli/src/components/App.tsx
@@ -24,10 +24,12 @@ import type { McpManager } from '../utils/mcpAdapter';
 import { processFileReferences, hasFileReferences } from '../utils/processFileReferences.js';
 import type { CommandDefinition } from '../config/commands.js';
 import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
-import { MIN_TRACE_ROWS } from './liveStepWindow.js';
-
-/** Live-frame rows reserved for chrome below the step trace. Deliberately generous. */
-const LIVE_CHROME_ROWS = 12;
+/**
+ * Live-frame rows reserved for everything outside the step trace: the thinking
+ * line and its margin, the bordered input box and the status bar come to six,
+ * and the rest is headroom for the background agent/shell status blocks.
+ */
+const LIVE_CHROME_ROWS = 10;
 
 interface AppProps {
   onMessage: (message: string) => Promise<void>;
@@ -130,12 +132,11 @@ export function App({
   // repaints at the new width instead of keeping the stale startup width.
   const [terminalCols, terminalRows] = useStdoutDimensions();
 
-  // Rows the live frame spends on everything other than the step trace: the
-  // thinking line, background agent/shell status, the queued rows, the bordered
-  // input box and the status bar. Ink wipes and rebuilds scrollback on every
-  // frame taller than the viewport (see liveStepWindow.ts), so the trace only
-  // gets what is left over.
-  const liveTraceRows = Math.max(MIN_TRACE_ROWS, terminalRows - LIVE_CHROME_ROWS - messageQueue.length);
+  // Ink wipes and rebuilds scrollback on every frame taller than the viewport
+  // (see liveStepWindow.ts), so the trace only gets the rows left over. On a
+  // terminal too short to have any left over it drops out entirely - keeping
+  // scrollback usable matters more than a two-line trace.
+  const liveTraceRows = Math.max(0, terminalRows - LIVE_CHROME_ROWS - messageQueue.length);
 
   const handleSubmit = React.useCallback(
     async (input: string) => {

--- a/packages/cli/src/components/MessageItem.liveTrace.test.tsx
+++ b/packages/cli/src/components/MessageItem.liveTrace.test.tsx
@@ -2,36 +2,77 @@
  * The live (non-<Static>) frame must stay shorter than the terminal viewport:
  * Ink falls back to clearTerminal - which erases scrollback - for every frame
  * that overflows, so a growing step trace makes it impossible to scroll up
- * while the agent is thinking. These tests pin the bound on the trace height.
+ * while the agent is thinking.
+ *
+ * liveStepWindow.test.ts pins the selection logic against its row model - two
+ * rows per step, three for an action with a result. That model is only exact
+ * because this component truncates every live line and collapses whitespace, so
+ * these tests render through real Ink and pin the rendering side of that
+ * contract at widths narrow enough to break it.
+ *
+ * Note: ink-testing-library hardcodes a 100-column stdout and ignores any
+ * columns option, so the width sweep drives Ink's own render() against a fake
+ * stream we control instead. Rendering through ink-testing-library would silently
+ * measure every case at 100 columns.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import React from 'react';
-import { render } from 'ink-testing-library';
+import { render } from 'ink';
 import { MessageItem } from './MessageItem';
 import type { Message } from '../storage';
 import type { AgentStep } from '@bike4mind/agents';
 
-// ink-testing-library renders at 100 columns; match it so the wrap estimate in
-// liveStepWindow lines up with what Ink actually prints.
-const COLUMNS = 100;
 const ROWS = 24;
 
 class FakeStdout extends EventEmitter {
-  columns: number | undefined = COLUMNS;
-  rows: number | undefined = ROWS;
+  isTTY = false;
+  writes: string[] = [];
+
+  constructor(
+    public columns: number,
+    public rows: number = ROWS
+  ) {
+    super();
+  }
+
+  write(chunk: string) {
+    this.writes.push(chunk);
+    return true;
+  }
 }
 
-const fakeStdout = new FakeStdout();
+let activeStdout = new FakeStdout(100);
 
 vi.mock('ink', async importOriginal => {
   const actual = await importOriginal<typeof import('ink')>();
   return {
     ...actual,
-    useStdout: () => ({ stdout: fakeStdout, write: () => {} }),
+    useStdout: () => ({ stdout: activeStdout, write: () => {} }),
   };
 });
+
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (value: string) => value.replace(/\[[0-9;]*[A-Za-z]/g, '');
+
+/**
+ * Renders through real Ink at an exact terminal width and returns the height of
+ * the frame Ink actually wrote.
+ */
+function renderedHeight(node: React.ReactElement, columns: number): number {
+  activeStdout = new FakeStdout(columns);
+  const instance = render(node, {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stdout: activeStdout as any, // any: fake stream, only the bits Ink touches
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+  instance.unmount();
+
+  const frame = activeStdout.writes.join('');
+  return stripAnsi(frame).replace(/\n+$/, '').split('\n').length;
+}
 
 const thoughtStep = (i: number): AgentStep => ({
   type: 'thought',
@@ -47,43 +88,129 @@ const pendingMessage = (steps: AgentStep[]): Message => ({
   metadata: { steps },
 });
 
-const frameHeight = (frame: string | undefined) => (frame ?? '').split('\n').length;
+const manyThoughts = Array.from({ length: 60 }, (_, i) => thoughtStep(i));
+
+const frameText = (node: React.ReactElement, columns: number): string => {
+  activeStdout = new FakeStdout(columns);
+  const instance = render(node, {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stdout: activeStdout as any, // any: fake stream, only the bits Ink touches
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+  instance.unmount();
+  return stripAnsi(activeStdout.writes.join(''));
+};
+
+afterEach(() => {
+  activeStdout = new FakeStdout(100);
+});
 
 describe('MessageItem live trace', () => {
   it('keeps a long trace within the row budget', () => {
-    const message = pendingMessage(Array.from({ length: 60 }, (_, i) => thoughtStep(i)));
-
-    const { lastFrame } = render(<MessageItem message={message} liveTraceRows={12} />);
-
-    expect(frameHeight(lastFrame())).toBeLessThanOrEqual(12);
-    // The newest step is the one that stays visible.
-    expect(lastFrame()).toContain('option 59');
-    expect(lastFrame()).not.toContain('option 0 ');
+    expect(
+      renderedHeight(<MessageItem message={pendingMessage(manyThoughts)} liveTraceRows={12} />, 100)
+    ).toBeLessThanOrEqual(12);
   });
 
-  it('tells the user the earlier steps are not lost', () => {
-    const message = pendingMessage(Array.from({ length: 60 }, (_, i) => thoughtStep(i)));
+  it('shows the newest steps, not the oldest', () => {
+    const text = frameText(<MessageItem message={pendingMessage(manyThoughts)} liveTraceRows={12} />, 100);
 
-    const { lastFrame } = render(<MessageItem message={message} liveTraceRows={12} />);
-
-    expect(lastFrame()).toMatch(/\.\.\. \d+ earlier steps - full trace prints when the turn ends/);
+    expect(text).toContain('option 59');
+    expect(text).not.toContain('option 0 ');
   });
 
-  it('stays bounded even when a single thought is longer than the viewport', () => {
-    const message = pendingMessage([{ type: 'thought', content: 'x'.repeat(20_000), metadata: { timestamp: 0 } }]);
+  it('says how many steps are hidden', () => {
+    const text = frameText(<MessageItem message={pendingMessage(manyThoughts)} liveTraceRows={12} />, 100);
 
-    const { lastFrame } = render(<MessageItem message={message} liveTraceRows={12} />);
-
-    expect(frameHeight(lastFrame())).toBeLessThanOrEqual(12);
+    expect(text).toMatch(/\.\.\. \d+ earlier steps hidden/);
   });
 
   it('renders the complete trace when no budget is given (<Static> history)', () => {
-    const message = pendingMessage(Array.from({ length: 60 }, (_, i) => thoughtStep(i)));
+    const text = frameText(<MessageItem message={pendingMessage(manyThoughts)} />, 100);
 
-    const { lastFrame } = render(<MessageItem message={message} />);
-
-    expect(lastFrame()).toContain('option 0 ');
-    expect(lastFrame()).toContain('option 59');
-    expect(frameHeight(lastFrame())).toBeGreaterThan(ROWS);
+    expect(text).toContain('option 0 ');
+    expect(text).toContain('option 59');
+    expect(renderedHeight(<MessageItem message={pendingMessage(manyThoughts)} />, 100)).toBeGreaterThan(ROWS);
   });
+});
+
+/**
+ * Sweep of trace shapes chosen to break a fixed rows-per-step model: text that
+ * wraps on word boundaries, words wider than the terminal, embedded newlines,
+ * long unbroken paths, results that dwarf their action, and budgets too small to
+ * fit even one step.
+ */
+describe('MessageItem live trace height bound', () => {
+  const shapes: Record<string, AgentStep[]> = {
+    'short thoughts': manyThoughts,
+    'word-wrapping thoughts': Array.from({ length: 12 }, (_, i) => ({
+      type: 'thought' as const,
+      content: `${i} ` + 'deliberation '.repeat(40),
+      metadata: { timestamp: 0 },
+    })),
+    // Words just over half the wrap width are the worst case for greedy word
+    // wrap: one word per line, where chars/width predicts two.
+    'half-width words': Array.from({ length: 12 }, (_, i) => ({
+      type: 'thought' as const,
+      content: `${i} ` + `${'a'.repeat(38)} `.repeat(12),
+      metadata: { timestamp: 0 },
+    })),
+    'one huge thought': [{ type: 'thought' as const, content: 'x'.repeat(20_000), metadata: { timestamp: 0 } }],
+    // Truncation alone does not bound these - embedded newlines still start new
+    // rows - so the live path has to collapse whitespace as well.
+    'thoughts with newlines': Array.from({ length: 12 }, (_, i) => ({
+      type: 'thought' as const,
+      content: `plan ${i}:\nfirst do this\nthen that\nthen the other thing`,
+      metadata: { timestamp: 0 },
+    })),
+    'results with newlines': Array.from({ length: 12 }, (_, i) => [
+      {
+        type: 'action' as const,
+        content: 'bash_execute',
+        metadata: { timestamp: 0, toolName: 'bash_execute', toolInput: { command: `ls /dir${i}` } },
+      },
+      {
+        type: 'observation' as const,
+        content: `one.txt\ntwo.txt\nthree.txt\nfour.txt\nfive.txt`,
+        metadata: { timestamp: 0 },
+      },
+    ]).flat(),
+    'actions with long paths': Array.from({ length: 16 }, (_, i) => [
+      {
+        type: 'action' as const,
+        content: 'read_local_file',
+        metadata: {
+          timestamp: 0,
+          toolName: 'read_local_file',
+          toolInput: { path: `/Users/someone/work/repo/packages/cli/src/components/SomeFairlyLongName${i}.tsx` },
+        },
+      },
+      {
+        type: 'observation' as const,
+        content: `Read SomeFairlyLongName${i}.tsx (240 lines) ` + 'and more detail '.repeat(20),
+        metadata: { timestamp: 0 },
+      },
+    ]).flat(),
+    'actions still running': Array.from({ length: 16 }, (_, i) => ({
+      type: 'action' as const,
+      content: 'bash_execute',
+      metadata: { timestamp: 0, toolName: 'bash_execute', toolInput: { command: `pnpm --filter pkg-${i} test` } },
+    })),
+  };
+
+  for (const [name, steps] of Object.entries(shapes)) {
+    for (const columns of [40, 80, 120]) {
+      it(`renders within the budget: ${name} at ${columns} cols`, () => {
+        for (const budget of [0, 1, 2, 3, 5, 8, 12, 20]) {
+          const height = renderedHeight(
+            <MessageItem message={pendingMessage(steps)} liveTraceRows={budget} />,
+            columns
+          );
+          // An empty render still reports one (blank) line.
+          expect(height, `${name} at ${columns} cols with budget ${budget}`).toBeLessThanOrEqual(Math.max(1, budget));
+        }
+      });
+    }
+  }
 });

--- a/packages/cli/src/components/MessageItem.liveTrace.test.tsx
+++ b/packages/cli/src/components/MessageItem.liveTrace.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * The live (non-<Static>) frame must stay shorter than the terminal viewport:
+ * Ink falls back to clearTerminal - which erases scrollback - for every frame
+ * that overflows, so a growing step trace makes it impossible to scroll up
+ * while the agent is thinking. These tests pin the bound on the trace height.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { MessageItem } from './MessageItem';
+import type { Message } from '../storage';
+import type { AgentStep } from '@bike4mind/agents';
+
+// ink-testing-library renders at 100 columns; match it so the wrap estimate in
+// liveStepWindow lines up with what Ink actually prints.
+const COLUMNS = 100;
+const ROWS = 24;
+
+class FakeStdout extends EventEmitter {
+  columns: number | undefined = COLUMNS;
+  rows: number | undefined = ROWS;
+}
+
+const fakeStdout = new FakeStdout();
+
+vi.mock('ink', async importOriginal => {
+  const actual = await importOriginal<typeof import('ink')>();
+  return {
+    ...actual,
+    useStdout: () => ({ stdout: fakeStdout, write: () => {} }),
+  };
+});
+
+const thoughtStep = (i: number): AgentStep => ({
+  type: 'thought',
+  content: `considering option ${i} in some detail`,
+  metadata: { timestamp: 0 },
+});
+
+const pendingMessage = (steps: AgentStep[]): Message => ({
+  id: 'pending-1',
+  role: 'assistant',
+  content: '...',
+  timestamp: new Date(0).toISOString(),
+  metadata: { steps },
+});
+
+const frameHeight = (frame: string | undefined) => (frame ?? '').split('\n').length;
+
+describe('MessageItem live trace', () => {
+  it('keeps a long trace within the row budget', () => {
+    const message = pendingMessage(Array.from({ length: 60 }, (_, i) => thoughtStep(i)));
+
+    const { lastFrame } = render(<MessageItem message={message} liveTraceRows={12} />);
+
+    expect(frameHeight(lastFrame())).toBeLessThanOrEqual(12);
+    // The newest step is the one that stays visible.
+    expect(lastFrame()).toContain('option 59');
+    expect(lastFrame()).not.toContain('option 0 ');
+  });
+
+  it('tells the user the earlier steps are not lost', () => {
+    const message = pendingMessage(Array.from({ length: 60 }, (_, i) => thoughtStep(i)));
+
+    const { lastFrame } = render(<MessageItem message={message} liveTraceRows={12} />);
+
+    expect(lastFrame()).toMatch(/\.\.\. \d+ earlier steps - full trace prints when the turn ends/);
+  });
+
+  it('stays bounded even when a single thought is longer than the viewport', () => {
+    const message = pendingMessage([{ type: 'thought', content: 'x'.repeat(20_000), metadata: { timestamp: 0 } }]);
+
+    const { lastFrame } = render(<MessageItem message={message} liveTraceRows={12} />);
+
+    expect(frameHeight(lastFrame())).toBeLessThanOrEqual(12);
+  });
+
+  it('renders the complete trace when no budget is given (<Static> history)', () => {
+    const message = pendingMessage(Array.from({ length: 60 }, (_, i) => thoughtStep(i)));
+
+    const { lastFrame } = render(<MessageItem message={message} />);
+
+    expect(lastFrame()).toContain('option 0 ');
+    expect(lastFrame()).toContain('option 59');
+    expect(frameHeight(lastFrame())).toBeGreaterThan(ROWS);
+  });
+});

--- a/packages/cli/src/components/MessageItem.liveTrace.test.tsx
+++ b/packages/cli/src/components/MessageItem.liveTrace.test.tsx
@@ -67,6 +67,10 @@ function renderedHeight(node: React.ReactElement, columns: number): number {
     stdout: activeStdout as any, // any: fake stream, only the bits Ink touches
     patchConsole: false,
     exitOnCtrlC: false,
+    // Pinned so the frame is written the same way locally and under CI=true;
+    // Ink's automatic detection keys off is-in-ci. Non-interactive writes the
+    // final frame at unmount, which is exactly what these helpers read.
+    interactive: false,
   });
   instance.unmount();
 
@@ -97,6 +101,10 @@ const frameText = (node: React.ReactElement, columns: number): string => {
     stdout: activeStdout as any, // any: fake stream, only the bits Ink touches
     patchConsole: false,
     exitOnCtrlC: false,
+    // Pinned so the frame is written the same way locally and under CI=true;
+    // Ink's automatic detection keys off is-in-ci. Non-interactive writes the
+    // final frame at unmount, which is exactly what these helpers read.
+    interactive: false,
   });
   instance.unmount();
   return stripAnsi(activeStdout.writes.join(''));

--- a/packages/cli/src/components/MessageItem.liveTrace.test.tsx
+++ b/packages/cli/src/components/MessageItem.liveTrace.test.tsx
@@ -54,7 +54,7 @@ vi.mock('ink', async importOriginal => {
 });
 
 // eslint-disable-next-line no-control-regex
-const stripAnsi = (value: string) => value.replace(/\[[0-9;]*[A-Za-z]/g, '');
+const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
 
 /**
  * Renders through real Ink at an exact terminal width and returns the height of

--- a/packages/cli/src/components/MessageItem.tsx
+++ b/packages/cli/src/components/MessageItem.tsx
@@ -38,12 +38,19 @@ export const MessageItem = React.memo(function MessageItem({
   const isUser = message.role === 'user';
   const [terminalCols] = useStdoutDimensions();
 
+  // Live frame: every trace line is truncated to one row and whitespace-collapsed
+  // so the window's row budget is exact. See liveStepWindow.ts - the height bound
+  // depends on this, and relaxing it reintroduces the scrollback wipe.
+  const isLive = liveTraceRows !== undefined;
+  const traceWrap = isLive ? 'truncate-end' : 'wrap';
+  const oneLine = (text: string) => (isLive ? text.replace(/\s+/g, ' ') : text);
+
   const allSteps = message.metadata?.steps;
   const { steps: traceSteps, hiddenSteps }: LiveTraceWindow = React.useMemo(() => {
     if (!allSteps) return { steps: [], hiddenSteps: 0 };
     if (liveTraceRows === undefined) return { steps: allSteps, hiddenSteps: 0 };
-    return windowLiveTrace(allSteps, { rows: liveTraceRows, columns: terminalCols, showThoughts });
-  }, [allSteps, liveTraceRows, terminalCols, showThoughts]);
+    return windowLiveTrace(allSteps, { rows: liveTraceRows, showThoughts });
+  }, [allSteps, liveTraceRows, showThoughts]);
 
   const visibleTraceSteps = traceSteps.filter(
     s => (showThoughts && s.type === 'thought') || s.type === 'action'
@@ -74,8 +81,10 @@ export const MessageItem = React.memo(function MessageItem({
       {!isUser && (visibleTraceSteps > 0 || hiddenSteps > 0) && (
         <Box paddingLeft={2} flexDirection="column" marginBottom={1}>
           {hiddenSteps > 0 && (
-            <Text dimColor>
-              {`... ${hiddenSteps} earlier ${hiddenSteps === 1 ? 'step' : 'steps'} - full trace prints when the turn ends`}
+            <Text dimColor wrap="truncate-end">
+              {/* Deliberately does not promise the trace later: a turn the user
+                  aborts with ESC discards its steps instead of printing them. */}
+              {`... ${hiddenSteps} earlier ${hiddenSteps === 1 ? 'step' : 'steps'} hidden`}
             </Text>
           )}
           {traceSteps
@@ -84,7 +93,7 @@ export const MessageItem = React.memo(function MessageItem({
                 if (!showThoughts) return null;
                 return (
                   <Box key={idx} marginTop={1} flexDirection="column">
-                    <Text dimColor>{`💭 ${step.content}`}</Text>
+                    <Text dimColor wrap={traceWrap}>{`💭 ${oneLine(step.content)}`}</Text>
                   </Box>
                 );
               }
@@ -103,15 +112,20 @@ export const MessageItem = React.memo(function MessageItem({
 
                 return (
                   <Box key={idx} marginTop={1} flexDirection="column">
-                    <Box>
+                    {/* Name and args share one <Text> so the live frame can hold
+                        the pair to a single row; nested <Text> keeps the colours. */}
+                    <Text wrap={traceWrap}>
                       <Text color="yellow">{formattedToolName}</Text>
                       {toolInput && !hideArgs && (
-                        <Text dimColor>{` • ${truncateValue(toolInput, ACTION_ARG_LIMIT)}`}</Text>
+                        <Text dimColor>{` • ${oneLine(truncateValue(toolInput, ACTION_ARG_LIMIT))}`}</Text>
                       )}
-                    </Box>
+                    </Text>
                     {result && (
                       <Box paddingLeft={2}>
-                        <Text dimColor>{`Result: ${truncateValue(result, OBSERVATION_LIMIT)}`}</Text>
+                        <Text
+                          dimColor
+                          wrap={traceWrap}
+                        >{`Result: ${oneLine(truncateValue(result, OBSERVATION_LIMIT))}`}</Text>
                       </Box>
                     )}
                   </Box>

--- a/packages/cli/src/components/MessageItem.tsx
+++ b/packages/cli/src/components/MessageItem.tsx
@@ -4,23 +4,25 @@ import type { Message } from '../storage';
 import type { AgentStep } from '@bike4mind/agents';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
-
-/**
- * Truncates a value to maxLength, converting objects to JSON strings.
- * Appends '...' if truncated.
- */
-function truncateValue(value: unknown, maxLength: number): string {
-  const str = typeof value === 'string' ? value : JSON.stringify(value);
-  if (str.length <= maxLength) {
-    return str;
-  }
-  return str.slice(0, maxLength) + '...';
-}
+import {
+  windowLiveTrace,
+  truncateValue,
+  ACTION_ARG_LIMIT,
+  OBSERVATION_LIMIT,
+  type LiveTraceWindow,
+} from './liveStepWindow.js';
 
 interface MessageItemProps {
   message: Message;
   /** When false, the agent's thought steps are suppressed in the action trace. Defaults to true. */
   showThoughts?: boolean;
+  /**
+   * Row budget for the step trace, set only for the pending message rendered in
+   * Ink's live frame. Omit it for <Static> history, which must render the whole
+   * trace into scrollback. See liveStepWindow.ts for why the live frame has to
+   * stay shorter than the viewport.
+   */
+  liveTraceRows?: number;
 }
 
 // Tools whose arguments are noisy (large old_string/new_string diffs etc.)
@@ -28,9 +30,24 @@ interface MessageItemProps {
 // already shows whether the edit succeeded.
 const TOOLS_WITH_HIDDEN_ARGS = new Set(['edit_local_file']);
 
-export const MessageItem = React.memo(function MessageItem({ message, showThoughts = true }: MessageItemProps) {
+export const MessageItem = React.memo(function MessageItem({
+  message,
+  showThoughts = true,
+  liveTraceRows,
+}: MessageItemProps) {
   const isUser = message.role === 'user';
   const [terminalCols] = useStdoutDimensions();
+
+  const allSteps = message.metadata?.steps;
+  const { steps: traceSteps, hiddenSteps }: LiveTraceWindow = React.useMemo(() => {
+    if (!allSteps) return { steps: [], hiddenSteps: 0 };
+    if (liveTraceRows === undefined) return { steps: allSteps, hiddenSteps: 0 };
+    return windowLiveTrace(allSteps, { rows: liveTraceRows, columns: terminalCols, showThoughts });
+  }, [allSteps, liveTraceRows, terminalCols, showThoughts]);
+
+  const visibleTraceSteps = traceSteps.filter(
+    s => (showThoughts && s.type === 'thought') || s.type === 'action'
+  ).length;
 
   // User-message highlight needs to fill the full row. We tried Yoga
   // `width="100%"` + Box backgroundColor - works in <Static> but not in
@@ -54,54 +71,58 @@ export const MessageItem = React.memo(function MessageItem({ message, showThough
 
       {/* Show detailed tool execution history FIRST (before final answer) */}
       {/* Show for both pending and completed messages */}
-      {!isUser &&
-        message.metadata?.steps &&
-        message.metadata.steps.filter(s => (showThoughts && s.type === 'thought') || s.type === 'action').length >
-          0 && (
-          <Box paddingLeft={2} flexDirection="column" marginBottom={1}>
-            {message.metadata.steps
-              .map((step: AgentStep, idx: number) => {
-                if (step.type === 'thought') {
-                  if (!showThoughts) return null;
-                  return (
-                    <Box key={idx} marginTop={1} flexDirection="column">
-                      <Text dimColor>{`💭 ${step.content}`}</Text>
-                    </Box>
-                  );
-                }
+      {!isUser && (visibleTraceSteps > 0 || hiddenSteps > 0) && (
+        <Box paddingLeft={2} flexDirection="column" marginBottom={1}>
+          {hiddenSteps > 0 && (
+            <Text dimColor>
+              {`... ${hiddenSteps} earlier ${hiddenSteps === 1 ? 'step' : 'steps'} - full trace prints when the turn ends`}
+            </Text>
+          )}
+          {traceSteps
+            .map((step: AgentStep, idx: number) => {
+              if (step.type === 'thought') {
+                if (!showThoughts) return null;
+                return (
+                  <Box key={idx} marginTop={1} flexDirection="column">
+                    <Text dimColor>{`💭 ${step.content}`}</Text>
+                  </Box>
+                );
+              }
 
-                if (step.type === 'action') {
-                  const toolName = step.metadata?.toolName || 'unknown';
-                  // Convert snake_case to Title Case (e.g., edit_local_file -> Edit Local File)
-                  const formattedToolName = toolName
-                    .split('_')
-                    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-                    .join(' ');
-                  const toolInput = step.metadata?.toolInput;
-                  const hideArgs = TOOLS_WITH_HIDDEN_ARGS.has(toolName);
-                  const observationStep = message.metadata?.steps?.[idx + 1];
-                  const result = observationStep?.type === 'observation' ? observationStep.content : null;
+              if (step.type === 'action') {
+                const toolName = step.metadata?.toolName || 'unknown';
+                // Convert snake_case to Title Case (e.g., edit_local_file -> Edit Local File)
+                const formattedToolName = toolName
+                  .split('_')
+                  .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                  .join(' ');
+                const toolInput = step.metadata?.toolInput;
+                const hideArgs = TOOLS_WITH_HIDDEN_ARGS.has(toolName);
+                const observationStep = traceSteps[idx + 1];
+                const result = observationStep?.type === 'observation' ? observationStep.content : null;
 
-                  return (
-                    <Box key={idx} marginTop={1} flexDirection="column">
-                      <Box>
-                        <Text color="yellow">{formattedToolName}</Text>
-                        {toolInput && !hideArgs && <Text dimColor>{` • ${truncateValue(toolInput, 100)}`}</Text>}
-                      </Box>
-                      {result && (
-                        <Box paddingLeft={2}>
-                          <Text dimColor>{`Result: ${truncateValue(result, 200)}`}</Text>
-                        </Box>
+                return (
+                  <Box key={idx} marginTop={1} flexDirection="column">
+                    <Box>
+                      <Text color="yellow">{formattedToolName}</Text>
+                      {toolInput && !hideArgs && (
+                        <Text dimColor>{` • ${truncateValue(toolInput, ACTION_ARG_LIMIT)}`}</Text>
                       )}
                     </Box>
-                  );
-                }
+                    {result && (
+                      <Box paddingLeft={2}>
+                        <Text dimColor>{`Result: ${truncateValue(result, OBSERVATION_LIMIT)}`}</Text>
+                      </Box>
+                    )}
+                  </Box>
+                );
+              }
 
-                return null;
-              })
-              .filter(Boolean)}
-          </Box>
-        )}
+              return null;
+            })
+            .filter(Boolean)}
+        </Box>
+      )}
 
       {/* Final answer / message content (shown AFTER reasoning trace) */}
       {/* Don't show '...' for pending messages, and don't show for user messages (handled above) */}

--- a/packages/cli/src/components/liveStepWindow.test.ts
+++ b/packages/cli/src/components/liveStepWindow.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentStep } from '@bike4mind/agents';
+import { windowLiveTrace, MIN_TRACE_ROWS } from './liveStepWindow';
+
+const thought = (content: string): AgentStep => ({
+  type: 'thought',
+  content,
+  metadata: { timestamp: 0 },
+});
+
+const action = (toolName: string, toolInput?: unknown): AgentStep => ({
+  type: 'action',
+  content: toolName,
+  metadata: { timestamp: 0, toolName, toolInput },
+});
+
+const observation = (content: string): AgentStep => ({
+  type: 'observation',
+  content,
+  metadata: { timestamp: 0 },
+});
+
+describe('windowLiveTrace', () => {
+  it('returns the whole trace when it fits the budget', () => {
+    const steps = [thought('one'), action('read_local_file'), observation('ok')];
+
+    const result = windowLiveTrace(steps, { rows: 40, columns: 100 });
+
+    expect(result.steps).toEqual(steps);
+    expect(result.hiddenSteps).toBe(0);
+  });
+
+  it('keeps the newest steps and reports how many were dropped', () => {
+    // Each thought renders as a blank margin row plus one wrapped row, and one
+    // row of the 10 is held back for the "earlier steps" hint.
+    const steps = Array.from({ length: 20 }, (_, i) => thought(`step ${i}`));
+
+    const result = windowLiveTrace(steps, { rows: 10, columns: 100 });
+
+    expect(result.steps).toHaveLength(4);
+    expect(result.steps[0].content).toBe('step 16');
+    expect(result.steps[result.steps.length - 1].content).toBe('step 19');
+    expect(result.hiddenSteps).toBe(16);
+  });
+
+  it('keeps the slice contiguous so each action keeps its observation', () => {
+    const steps = [
+      action('a', { path: 'one' }),
+      observation('first result'),
+      action('b', { path: 'two' }),
+      observation('second result'),
+      action('c', { path: 'three' }),
+      observation('third result'),
+    ];
+
+    const result = windowLiveTrace(steps, { rows: 8, columns: 100 });
+
+    expect(result.steps.map(s => s.type)).toEqual(['action', 'observation', 'action', 'observation']);
+    expect(result.steps[0].content).toBe('b');
+    expect(result.hiddenSteps).toBe(1);
+  });
+
+  it('counts wrapped rows, not step count, against the budget', () => {
+    const steps = [thought('a'.repeat(500)), thought('b'.repeat(500)), thought('short')];
+
+    const result = windowLiveTrace(steps, { rows: 12, columns: 100 });
+
+    // Each long thought needs ~1 margin + 6 wrapped rows, so only the last
+    // long thought plus the short one fit in 12 rows.
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0].content.startsWith('b')).toBe(true);
+    expect(result.hiddenSteps).toBe(1);
+  });
+
+  it('clamps a single step that is taller than the whole budget', () => {
+    const steps = [thought('old'), thought('x'.repeat(5000))];
+
+    const result = windowLiveTrace(steps, { rows: 8, columns: 80 });
+
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0].content.endsWith('...')).toBe(true);
+    // 7 usable rows (the 8th is the blank margin) at 80 - 4 indent - 3 glyph.
+    expect(result.steps[0].content.length).toBeLessThanOrEqual(7 * 73);
+    expect(result.hiddenSteps).toBe(1);
+  });
+
+  it('does not spend budget on thoughts that are configured off', () => {
+    const steps = [...Array.from({ length: 10 }, (_, i) => thought(`noise ${i}`)), action('read_local_file')];
+
+    const result = windowLiveTrace(steps, { rows: MIN_TRACE_ROWS, columns: 100, showThoughts: false });
+
+    expect(result.steps[result.steps.length - 1].type).toBe('action');
+    // Hidden thoughts are not advertised when the user has them turned off.
+    expect(result.hiddenSteps).toBe(0);
+  });
+
+  it('never reports a budget below the floor', () => {
+    const steps = Array.from({ length: 5 }, (_, i) => thought(`step ${i}`));
+
+    const result = windowLiveTrace(steps, { rows: 0, columns: 100 });
+
+    expect(result.steps.length).toBeGreaterThan(0);
+    expect(result.steps[result.steps.length - 1].content).toBe('step 4');
+  });
+
+  it('handles an empty trace', () => {
+    expect(windowLiveTrace([], { rows: 20, columns: 100 })).toEqual({ steps: [], hiddenSteps: 0 });
+  });
+});

--- a/packages/cli/src/components/liveStepWindow.test.ts
+++ b/packages/cli/src/components/liveStepWindow.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { AgentStep } from '@bike4mind/agents';
-import { windowLiveTrace, MIN_TRACE_ROWS } from './liveStepWindow';
+import { windowLiveTrace, measureTraceRows } from './liveStepWindow';
 
 const thought = (content: string): AgentStep => ({
   type: 'thought',
@@ -24,23 +24,23 @@ describe('windowLiveTrace', () => {
   it('returns the whole trace when it fits the budget', () => {
     const steps = [thought('one'), action('read_local_file'), observation('ok')];
 
-    const result = windowLiveTrace(steps, { rows: 40, columns: 100 });
+    const result = windowLiveTrace(steps, { rows: 40 });
 
     expect(result.steps).toEqual(steps);
     expect(result.hiddenSteps).toBe(0);
   });
 
   it('keeps the newest steps and reports how many were dropped', () => {
-    // Each thought renders as a blank margin row plus one wrapped row, and one
-    // row of the 10 is held back for the "earlier steps" hint.
+    // A thought costs a blank margin row plus its one truncated line, and two of
+    // the 12 rows go to the hint line and the box's bottom margin.
     const steps = Array.from({ length: 20 }, (_, i) => thought(`step ${i}`));
 
-    const result = windowLiveTrace(steps, { rows: 10, columns: 100 });
+    const result = windowLiveTrace(steps, { rows: 12 });
 
-    expect(result.steps).toHaveLength(4);
-    expect(result.steps[0].content).toBe('step 16');
+    expect(result.steps).toHaveLength(5);
+    expect(result.steps[0].content).toBe('step 15');
     expect(result.steps[result.steps.length - 1].content).toBe('step 19');
-    expect(result.hiddenSteps).toBe(16);
+    expect(result.hiddenSteps).toBe(15);
   });
 
   it('keeps the slice contiguous so each action keeps its observation', () => {
@@ -53,57 +53,95 @@ describe('windowLiveTrace', () => {
       observation('third result'),
     ];
 
-    const result = windowLiveTrace(steps, { rows: 8, columns: 100 });
+    const result = windowLiveTrace(steps, { rows: 10 });
 
     expect(result.steps.map(s => s.type)).toEqual(['action', 'observation', 'action', 'observation']);
     expect(result.steps[0].content).toBe('b');
     expect(result.hiddenSteps).toBe(1);
   });
 
-  it('counts wrapped rows, not step count, against the budget', () => {
-    const steps = [thought('a'.repeat(500)), thought('b'.repeat(500)), thought('short')];
+  it('charges the same rows however long a step is, since live lines truncate', () => {
+    const short = Array.from({ length: 6 }, (_, i) => thought(`step ${i}`));
+    const long = Array.from({ length: 6 }, (_, i) => thought(`step ${i} ` + 'x'.repeat(5000)));
 
-    const result = windowLiveTrace(steps, { rows: 12, columns: 100 });
+    const fromShort = windowLiveTrace(short, { rows: 10 });
+    const fromLong = windowLiveTrace(long, { rows: 10 });
 
-    // Each long thought needs ~1 margin + 6 wrapped rows, so only the last
-    // long thought plus the short one fit in 12 rows.
-    expect(result.steps).toHaveLength(2);
-    expect(result.steps[0].content.startsWith('b')).toBe(true);
+    expect(fromLong.steps).toHaveLength(fromShort.steps.length);
+    expect(fromLong.hiddenSteps).toBe(fromShort.hiddenSteps);
+  });
+
+  it('drops the Result line when an action plus its result does not fit', () => {
+    const steps = [thought('earlier'), action('read_local_file', { path: '/some/file.tsx' }), observation('done')];
+
+    // Budget of two rows: enough for the action's margin and header, not for the
+    // third row its result would take.
+    const result = windowLiveTrace(steps, { rows: 4 });
+
+    expect(result.steps.map(s => s.type)).toEqual(['action']);
     expect(result.hiddenSteps).toBe(1);
   });
 
-  it('clamps a single step that is taller than the whole budget', () => {
-    const steps = [thought('old'), thought('x'.repeat(5000))];
+  it('shows nothing rather than overflow when there is no room at all', () => {
+    const steps = [action('read_local_file', { path: '/some/path/file.tsx' }), observation('done')];
 
-    const result = windowLiveTrace(steps, { rows: 8, columns: 80 });
-
-    expect(result.steps).toHaveLength(1);
-    expect(result.steps[0].content.endsWith('...')).toBe(true);
-    // 7 usable rows (the 8th is the blank margin) at 80 - 4 indent - 3 glyph.
-    expect(result.steps[0].content.length).toBeLessThanOrEqual(7 * 73);
-    expect(result.hiddenSteps).toBe(1);
+    expect(windowLiveTrace(steps, { rows: 3 })).toEqual({ steps: [], hiddenSteps: 0 });
+    expect(windowLiveTrace(steps, { rows: 2 })).toEqual({ steps: [], hiddenSteps: 0 });
+    expect(windowLiveTrace(steps, { rows: 0 })).toEqual({ steps: [], hiddenSteps: 0 });
+    expect(windowLiveTrace(steps, { rows: -5 })).toEqual({ steps: [], hiddenSteps: 0 });
   });
 
   it('does not spend budget on thoughts that are configured off', () => {
     const steps = [...Array.from({ length: 10 }, (_, i) => thought(`noise ${i}`)), action('read_local_file')];
 
-    const result = windowLiveTrace(steps, { rows: MIN_TRACE_ROWS, columns: 100, showThoughts: false });
+    const result = windowLiveTrace(steps, { rows: 6, showThoughts: false });
 
     expect(result.steps[result.steps.length - 1].type).toBe('action');
     // Hidden thoughts are not advertised when the user has them turned off.
     expect(result.hiddenSteps).toBe(0);
   });
 
-  it('never reports a budget below the floor', () => {
-    const steps = Array.from({ length: 5 }, (_, i) => thought(`step ${i}`));
-
-    const result = windowLiveTrace(steps, { rows: 0, columns: 100 });
-
-    expect(result.steps.length).toBeGreaterThan(0);
-    expect(result.steps[result.steps.length - 1].content).toBe('step 4');
-  });
-
   it('handles an empty trace', () => {
-    expect(windowLiveTrace([], { rows: 20, columns: 100 })).toEqual({ steps: [], hiddenSteps: 0 });
+    expect(windowLiveTrace([], { rows: 20 })).toEqual({ steps: [], hiddenSteps: 0 });
   });
+});
+
+/**
+ * The module exists to bound rendered height, so sweep the budget across trace
+ * shapes and assert the bound holds. This pins the selection logic against the
+ * row model; MessageItem.liveTrace.test.tsx pins the row model itself against
+ * real Ink output at real terminal widths.
+ */
+describe('windowLiveTrace height bound', () => {
+  const shapes: Record<string, AgentStep[]> = {
+    'short thoughts': Array.from({ length: 40 }, (_, i) => thought(`step ${i}`)),
+    'long thoughts': Array.from({ length: 10 }, (_, i) => thought(`${i} `.repeat(400))),
+    'one huge thought': [thought('x'.repeat(20_000))],
+    'actions with long paths': Array.from({ length: 20 }, (_, i) => [
+      action('read_local_file', { path: `/Users/someone/work/repo/packages/cli/src/components/File${i}.tsx` }),
+      observation(`Read File${i}.tsx (240 lines) ${'detail '.repeat(30)}`),
+    ]).flat(),
+    'actions without results': Array.from({ length: 20 }, (_, i) =>
+      action('bash_execute', { command: `ls -la /${i}` })
+    ),
+    'orphan observations': [observation('stray'), observation('stray two')],
+  };
+
+  /** Mirrors TRACE_BOX_CHROME_ROWS in liveStepWindow.ts. */
+  const TRACE_BOX_CHROME_ROWS = 2;
+
+  for (const [name, steps] of Object.entries(shapes)) {
+    for (const showThoughts of [true, false]) {
+      it(`stays within budget: ${name}, thoughts ${showThoughts ? 'on' : 'off'}`, () => {
+        for (let rows = -2; rows <= 30; rows++) {
+          const result = windowLiveTrace(steps, { rows, showThoughts });
+          const rendered = measureTraceRows(result.steps, { showThoughts });
+          const allowance = result.steps.length > 0 ? rows - TRACE_BOX_CHROME_ROWS : rows;
+          expect(rendered, `${name}, ${rows} rows, thoughts ${showThoughts}`).toBeLessThanOrEqual(
+            Math.max(0, allowance)
+          );
+        }
+      });
+    }
+  }
 });

--- a/packages/cli/src/components/liveStepWindow.ts
+++ b/packages/cli/src/components/liveStepWindow.ts
@@ -1,0 +1,150 @@
+import type { AgentStep } from '@bike4mind/agents';
+
+/**
+ * Bounds the height of the agent step trace while it is being rendered in
+ * Ink's live frame.
+ *
+ * Ink 7 repaints the live frame in place (cursor-up + erase) only while the
+ * frame fits the viewport. For any frame taller than `stdout.rows` it falls
+ * back to `ansiEscapes.clearTerminal` - which includes ESC[3J, "erase
+ * scrollback" - and then re-dumps every <Static> line written so far
+ * (`shouldClearTerminalForFrame` in ink/build/ink.js). With the thinking
+ * spinner ticking every 80ms that means scrollback is destroyed and rebuilt
+ * ~12x/sec, so the terminal is pinned to the bottom and scrolling up during a
+ * turn is impossible. Keeping the live trace short keeps Ink on the in-place
+ * path.
+ *
+ * Nothing is lost by windowing: the complete step trace is committed to
+ * session.messages when the turn ends and rendered once through <Static>,
+ * which is what actually lands in terminal scrollback.
+ */
+
+/** Floor for the trace budget so a very short terminal still shows something. */
+export const MIN_TRACE_ROWS = 4;
+
+/** paddingLeft on the trace Box (2) plus the nested result Box (2). */
+const TRACE_INDENT = 4;
+
+/** Columns the thought bubble glyph plus its trailing space occupy. */
+const THOUGHT_PREFIX_COLS = 3;
+
+/** Row held back for the "N earlier steps" hint so the total stays within `rows`. */
+const HINT_ROWS = 1;
+
+/** Character caps MessageItem applies to tool args and tool results. */
+export const ACTION_ARG_LIMIT = 100;
+export const OBSERVATION_LIMIT = 200;
+
+/**
+ * Truncates a value to maxLength, converting objects to JSON strings.
+ * Appends '...' if truncated.
+ */
+export function truncateValue(value: unknown, maxLength: number): string {
+  const str = typeof value === 'string' ? value : JSON.stringify(value);
+  if (str.length <= maxLength) {
+    return str;
+  }
+  return str.slice(0, maxLength) + '...';
+}
+
+const wrappedRows = (text: string, width: number): number =>
+  text.split('\n').reduce((rows, line) => rows + Math.max(1, Math.ceil(line.length / width)), 0);
+
+const isRenderable = (step: AgentStep, showThoughts: boolean): boolean =>
+  step.type === 'action' || (step.type === 'thought' && showThoughts);
+
+/**
+ * Rows `MessageItem` will spend on `steps[index]`, including the blank
+ * marginTop row and - for actions - the trailing observation rendered as the
+ * "Result:" line. Steps that render nothing cost 0.
+ */
+function stepRows(steps: AgentStep[], index: number, width: number, showThoughts: boolean): number {
+  const step = steps[index];
+
+  if (step.type === 'thought') {
+    return showThoughts ? 1 + wrappedRows(step.content, Math.max(1, width - THOUGHT_PREFIX_COLS)) : 0;
+  }
+
+  if (step.type !== 'action') {
+    return 0;
+  }
+
+  const toolName = step.metadata?.toolName || 'unknown';
+  const args = step.metadata?.toolInput ? ` - ${truncateValue(step.metadata.toolInput, ACTION_ARG_LIMIT)}` : '';
+  let rows = 1 + wrappedRows(`${toolName}${args}`, width);
+
+  const observation = steps[index + 1];
+  if (observation?.type === 'observation') {
+    rows += wrappedRows(`Result: ${truncateValue(observation.content, OBSERVATION_LIMIT)}`, width);
+  }
+
+  return rows;
+}
+
+const countRenderable = (steps: AgentStep[], showThoughts: boolean): number =>
+  steps.filter(step => isRenderable(step, showThoughts)).length;
+
+/** Shortens an oversized step so it alone cannot overflow the row budget. */
+function clampContent(step: AgentStep, rows: number, traceWidth: number): AgentStep {
+  // Must match the width stepRows() charges this step type, or the clamped copy
+  // wraps to more rows than the budget allows.
+  const width = step.type === 'thought' ? Math.max(1, traceWidth - THOUGHT_PREFIX_COLS) : traceWidth;
+  const maxChars = Math.max(width, (rows - 1) * width);
+  if (step.content.length <= maxChars) {
+    return step;
+  }
+  return { ...step, content: step.content.slice(0, Math.max(0, maxChars - 3)) + '...' };
+}
+
+export interface LiveTraceWindow {
+  /** Contiguous tail of the trace that fits the budget. */
+  steps: AgentStep[];
+  /** Renderable steps dropped off the head, for the "earlier steps" hint. */
+  hiddenSteps: number;
+}
+
+/**
+ * Picks the newest slice of `steps` that renders within `rows`. The slice stays
+ * contiguous so each action keeps the observation that follows it.
+ */
+export function windowLiveTrace(
+  steps: AgentStep[],
+  { rows, columns, showThoughts = true }: { rows: number; columns: number; showThoughts?: boolean }
+): LiveTraceWindow {
+  const budget = Math.max(MIN_TRACE_ROWS, Math.floor(rows) - HINT_ROWS);
+  const width = Math.max(1, columns - TRACE_INDENT);
+
+  let used = 0;
+  let start = steps.length;
+  for (let i = steps.length - 1; i >= 0; i--) {
+    const height = stepRows(steps, i, width, showThoughts);
+    if (height > 0 && used + height > budget) break;
+    used += height;
+    start = i;
+  }
+
+  if (start < steps.length) {
+    // Zero-height steps are free, so the walk can stop on an observation whose
+    // action fell outside the window. It renders nothing - drop it.
+    while (start < steps.length && stepRows(steps, start, width, showThoughts) === 0) start++;
+    return { steps: steps.slice(start), hiddenSteps: countRenderable(steps.slice(0, start), showThoughts) };
+  }
+
+  // The newest step alone overflows the budget (a long thought). Show a
+  // clamped copy rather than an empty trace.
+  let newest = -1;
+  for (let i = steps.length - 1; i >= 0; i--) {
+    if (isRenderable(steps[i], showThoughts)) {
+      newest = i;
+      break;
+    }
+  }
+  if (newest < 0) {
+    return { steps: [], hiddenSteps: 0 };
+  }
+
+  return {
+    steps: steps.slice(newest).map((step, idx) => (idx === 0 ? clampContent(step, budget, width) : step)),
+    hiddenSteps: countRenderable(steps.slice(0, newest), showThoughts),
+  };
+}

--- a/packages/cli/src/components/liveStepWindow.ts
+++ b/packages/cli/src/components/liveStepWindow.ts
@@ -17,19 +17,19 @@ import type { AgentStep } from '@bike4mind/agents';
  * Nothing is lost by windowing: the complete step trace is committed to
  * session.messages when the turn ends and rendered once through <Static>,
  * which is what actually lands in terminal scrollback.
+ *
+ * Heights here are exact rather than estimated, and that is load-bearing:
+ * MessageItem renders every live trace line with `wrap="truncate-end"` and
+ * collapses whitespace, so a step occupies a fixed number of rows no matter how
+ * long its text or how narrow the terminal. Estimating wrapped rows instead
+ * looks reasonable and is wrong - Ink wraps with `wrapAnsi(trim: false, hard:
+ * true)`, whose word-boundary waste compounds per line, so any chars/width
+ * estimate runs short exactly when the terminal is narrow. If the truncation in
+ * MessageItem is ever relaxed, this module has to go back to measuring.
  */
 
-/** Floor for the trace budget so a very short terminal still shows something. */
-export const MIN_TRACE_ROWS = 4;
-
-/** paddingLeft on the trace Box (2) plus the nested result Box (2). */
-const TRACE_INDENT = 4;
-
-/** Columns the thought bubble glyph plus its trailing space occupy. */
-const THOUGHT_PREFIX_COLS = 3;
-
-/** Row held back for the "N earlier steps" hint so the total stays within `rows`. */
-const HINT_ROWS = 1;
+/** Rows the trace Box spends on the "N earlier steps" hint and its bottom margin. */
+const TRACE_BOX_CHROME_ROWS = 2;
 
 /** Character caps MessageItem applies to tool args and tool results. */
 export const ACTION_ARG_LIMIT = 100;
@@ -47,54 +47,34 @@ export function truncateValue(value: unknown, maxLength: number): string {
   return str.slice(0, maxLength) + '...';
 }
 
-const wrappedRows = (text: string, width: number): number =>
-  text.split('\n').reduce((rows, line) => rows + Math.max(1, Math.ceil(line.length / width)), 0);
-
 const isRenderable = (step: AgentStep, showThoughts: boolean): boolean =>
   step.type === 'action' || (step.type === 'thought' && showThoughts);
 
 /**
- * Rows `MessageItem` will spend on `steps[index]`, including the blank
- * marginTop row and - for actions - the trailing observation rendered as the
- * "Result:" line. Steps that render nothing cost 0.
+ * Rows `MessageItem` spends on `steps[index]` in the live frame: a blank
+ * marginTop row, one truncated line, and - for an action - one more line for the
+ * observation that follows it. Steps that render nothing cost 0.
  */
-function stepRows(steps: AgentStep[], index: number, width: number, showThoughts: boolean): number {
+function stepRows(steps: AgentStep[], index: number, showThoughts: boolean): number {
   const step = steps[index];
-
   if (step.type === 'thought') {
-    return showThoughts ? 1 + wrappedRows(step.content, Math.max(1, width - THOUGHT_PREFIX_COLS)) : 0;
+    return showThoughts ? 2 : 0;
   }
-
   if (step.type !== 'action') {
     return 0;
   }
+  return steps[index + 1]?.type === 'observation' ? 3 : 2;
+}
 
-  const toolName = step.metadata?.toolName || 'unknown';
-  const args = step.metadata?.toolInput ? ` - ${truncateValue(step.metadata.toolInput, ACTION_ARG_LIMIT)}` : '';
-  let rows = 1 + wrappedRows(`${toolName}${args}`, width);
-
-  const observation = steps[index + 1];
-  if (observation?.type === 'observation') {
-    rows += wrappedRows(`Result: ${truncateValue(observation.content, OBSERVATION_LIMIT)}`, width);
-  }
-
+/** Rows a whole window occupies, excluding the trace Box chrome. */
+export function measureTraceRows(steps: AgentStep[], { showThoughts = true }: { showThoughts?: boolean } = {}): number {
+  let rows = 0;
+  for (let i = 0; i < steps.length; i++) rows += stepRows(steps, i, showThoughts);
   return rows;
 }
 
 const countRenderable = (steps: AgentStep[], showThoughts: boolean): number =>
   steps.filter(step => isRenderable(step, showThoughts)).length;
-
-/** Shortens an oversized step so it alone cannot overflow the row budget. */
-function clampContent(step: AgentStep, rows: number, traceWidth: number): AgentStep {
-  // Must match the width stepRows() charges this step type, or the clamped copy
-  // wraps to more rows than the budget allows.
-  const width = step.type === 'thought' ? Math.max(1, traceWidth - THOUGHT_PREFIX_COLS) : traceWidth;
-  const maxChars = Math.max(width, (rows - 1) * width);
-  if (step.content.length <= maxChars) {
-    return step;
-  }
-  return { ...step, content: step.content.slice(0, Math.max(0, maxChars - 3)) + '...' };
-}
 
 export interface LiveTraceWindow {
   /** Contiguous tail of the trace that fits the budget. */
@@ -103,21 +83,27 @@ export interface LiveTraceWindow {
   hiddenSteps: number;
 }
 
+const EMPTY_WINDOW: LiveTraceWindow = { steps: [], hiddenSteps: 0 };
+
 /**
- * Picks the newest slice of `steps` that renders within `rows`. The slice stays
- * contiguous so each action keeps the observation that follows it.
+ * Picks the newest slice of `steps` that renders within `rows`, which is the
+ * total height the trace Box may occupy - the hint line and bottom margin are
+ * charged against it. The slice stays contiguous so each action keeps the
+ * observation that follows it.
  */
 export function windowLiveTrace(
   steps: AgentStep[],
-  { rows, columns, showThoughts = true }: { rows: number; columns: number; showThoughts?: boolean }
+  { rows, showThoughts = true }: { rows: number; showThoughts?: boolean }
 ): LiveTraceWindow {
-  const budget = Math.max(MIN_TRACE_ROWS, Math.floor(rows) - HINT_ROWS);
-  const width = Math.max(1, columns - TRACE_INDENT);
+  const budget = Math.floor(rows) - TRACE_BOX_CHROME_ROWS;
+  if (budget <= 0 || steps.length === 0) {
+    return EMPTY_WINDOW;
+  }
 
   let used = 0;
   let start = steps.length;
   for (let i = steps.length - 1; i >= 0; i--) {
-    const height = stepRows(steps, i, width, showThoughts);
+    const height = stepRows(steps, i, showThoughts);
     if (height > 0 && used + height > budget) break;
     used += height;
     start = i;
@@ -126,12 +112,14 @@ export function windowLiveTrace(
   if (start < steps.length) {
     // Zero-height steps are free, so the walk can stop on an observation whose
     // action fell outside the window. It renders nothing - drop it.
-    while (start < steps.length && stepRows(steps, start, width, showThoughts) === 0) start++;
-    return { steps: steps.slice(start), hiddenSteps: countRenderable(steps.slice(0, start), showThoughts) };
+    while (start < steps.length && stepRows(steps, start, showThoughts) === 0) start++;
+    if (start < steps.length) {
+      return { steps: steps.slice(start), hiddenSteps: countRenderable(steps.slice(0, start), showThoughts) };
+    }
   }
 
-  // The newest step alone overflows the budget (a long thought). Show a
-  // clamped copy rather than an empty trace.
+  // Nothing fit whole. Only an action can be trimmed further, by dropping the
+  // "Result:" line that its observation renders (3 rows down to 2).
   let newest = -1;
   for (let i = steps.length - 1; i >= 0; i--) {
     if (isRenderable(steps[i], showThoughts)) {
@@ -139,12 +127,9 @@ export function windowLiveTrace(
       break;
     }
   }
-  if (newest < 0) {
-    return { steps: [], hiddenSteps: 0 };
+  if (newest < 0 || budget < 2) {
+    return EMPTY_WINDOW;
   }
 
-  return {
-    steps: steps.slice(newest).map((step, idx) => (idx === 0 ? clampContent(step, budget, width) : step)),
-    hiddenSteps: countRenderable(steps.slice(0, newest), showThoughts),
-  };
+  return { steps: [steps[newest]], hiddenSteps: countRenderable(steps.slice(0, newest), showThoughts) };
 }


### PR DESCRIPTION
# Pull Request

## Description

**Bug:** while the CLI is thinking, you cannot scroll up to read earlier output. Every refresh of the thinking animation yanks the view back to the bottom of the terminal.

**Root cause is not the spinner.** Ink repaints its live frame in place - cursor-up, erase, rewrite - but *only while that frame fits the viewport*. For any frame taller than `stdout.rows` it falls back to `ansiEscapes.clearTerminal`, which is `ESC[2J ESC[3J ESC[H`. The `ESC[3J` is "erase scrollback". Ink then re-dumps every `<Static>` line it has ever written to rebuild the screen. See `shouldClearTerminalForFrame` in `ink/build/ink.js`.

The agent step trace is rendered from `pendingMessages`, which lives in that live frame and grows unbounded for the whole turn. So any turn past a handful of steps pushes the frame over the viewport, and the 80ms `ink-spinner` tick means scrollback is destroyed and rebuilt about 12 times a second. Hence the snap-to-bottom, and a lot of wasted terminal I/O.

**Fix:** bound the live trace to the rows actually available. `App` derives a row budget from `stdout.rows` minus the chrome below the trace and passes it to the *pending* `MessageItem` only. `<Static>` history is untouched and still renders the complete trace, which is what lands in real scrollback when the turn ends.

**The height bound is exact, not estimated - and that is the load-bearing part.** The first version of this PR estimated wrapped rows as chars/width. That is wrong: Ink wraps with `wrapAnsi(trim: false, hard: true)`, whose word-boundary waste compounds per wrapped line, so the estimate runs short exactly when the terminal is narrow (reproduced at 40 columns with words wider than the wrap width). Instead of chasing Ink's wrapping with a better estimate, the live frame now renders every trace line with `wrap="truncate-end"` and collapsed whitespace. A step therefore occupies exactly two rows - three for an action with a result - at any width, and the window arithmetic is integer-exact. If that truncation is ever relaxed, the module has to go back to measuring; the header comment says so.

Trade-off worth naming: while the agent is working, each thought/tool call is one truncated line rather than wrapped multi-line text. The complete, untruncated trace prints to scrollback when the turn finishes.

## Changes

- `liveStepWindow.ts` (new) - `windowLiveTrace()` picks the newest contiguous slice of the trace that fits a row budget. Contiguous so every action keeps the observation that renders as its `Result:` line. When even one step will not fit, it drops an action's `Result:` line first, and shows nothing at all rather than overflow. `truncateValue` and the arg/result character caps moved here so the row model and the renderer cannot drift apart.
- `MessageItem.tsx` - new optional `liveTraceRows` prop. When set, the trace is windowed, every line is truncated to one row with whitespace collapsed, and a dim `... N earlier steps hidden` heads the list. When omitted (`<Static>` history), rendering is unchanged. Tool name and args now share one `<Text>` (nested `<Text>` keeps the colours) so the pair can be held to a single row.
- `App.tsx` - computes `liveTraceRows` from the live terminal rows (already resize-aware via `useStdoutDimensions`) and passes it to pending messages only. A terminal too short to fit any trace drops it entirely: keeping scrollback usable matters more than two lines of trace.

### Tests

- `liveStepWindow.test.ts` - the windowing rules, plus a sweep asserting the height bound holds for budgets -2..30 across six trace shapes with thoughts on and off.
- `MessageItem.liveTrace.test.tsx` - renders through **real Ink at real widths** (40/80/120) over shapes built to break a fixed rows-per-step model: word wrapping, words wider than the terminal, embedded newlines, long paths, results that dwarf their action, and budgets too small for one step. It drives Ink's own `render()` against a controlled fake stream because `ink-testing-library` hardcodes a 100-column stdout and silently ignores a `columns` option - measuring through it is how the first version's narrow-width assertions passed vacuously.
- `App.scrollback.test.tsx` - drives the real Ink renderer against a fake TTY and asserts `ESC[3J` never reaches stdout while thinking, on tall, short, narrow, and queued-message layouts. A control case renders a deliberately overflowing frame and asserts the escape *does* appear, so the assertion cannot rot into a no-op.

Verification that the guards have teeth, rather than just being green:

| Change reverted | Result (measured under `CI=true`) |
|---|---|
| the `liveTraceRows` prop | 4 scrollback cases fail, control still passes |
| `wrap="truncate-end"` | 16 height cases fail |
| whitespace collapse | 6 height cases fail |

Both suites pass Ink's `interactive` option explicitly instead of inheriting its CI detection. This is not tidiness: Ink resolves interactive mode as `!isInCi && stdout.isTTY`, and a non-interactive run "disables ANSI erase sequences... writing only the final frame at unmount". Under CI the scrollback tests were therefore watching a renderer that could never emit the escape they forbid - they would have proven nothing on every CI run. The frame-count guard is what turned that into a visible failure rather than silence.

## Guide for Testers

Terminal-only change - no web UI involved.

1. Check out this branch and run `pnpm --filter @bike4mind/cli dev` in a terminal window roughly 30-40 rows tall.
2. Ask the agent something that will run many tool calls, e.g. `explore this repo and summarize how the CLI renders messages`.
3. While it is still thinking (spinner visible), scroll up with the mouse wheel or trackpad. **Expected:** the view stays where you put it and earlier output is readable. On `main`, the view snaps back to the bottom within ~80ms and earlier scrollback is gone.
4. Keep watching the live trace as steps accumulate. **Expected:** each step is a single line, the trace stops growing once it fills the space above the input box, and a dim `... N earlier steps hidden` line sits at the top of it.
5. Let the turn finish. **Expected:** the complete step trace - every step that was hidden while running, with full untruncated text - prints into scrollback above the input box, and scrolling back through it works normally.
6. Resize the terminal shorter, taller, and narrower mid-turn. **Expected:** the live trace adjusts, and step 3 still holds at each size. At around 12 rows or fewer the trace disappears while the agent works and returns in full when the turn ends.

### Regression Checks

7. Turn thoughts off (`showThoughts` preference) and repeat step 2. **Expected:** only tool actions and results appear, and no hidden-step count is shown for thoughts alone.
8. Trigger a tool that needs approval. **Expected:** the permission prompt renders as before and the thinking indicator hides while it is up.
9. Queue a couple of messages while the agent is working. **Expected:** queued rows still render above the input box with a full-width gray background, and step 3 still holds.
10. Scroll back through completed turns after several messages. **Expected:** history is complete and unduplicated, with full wrapped text (truncation applies only to the live frame).
11. Press ESC mid-turn to abort. **Expected:** the cancellation message appears. Note the aborted turn's step trace is discarded rather than printed - pre-existing behaviour, which is why the hint deliberately does not promise the trace later.

### What NOT to test

Nothing server-side, no API, no database, no client web app - this only touches CLI rendering.

## Additional Information

Known limits, stated rather than hidden:

- The reserve for chrome below the trace (`LIVE_CHROME_ROWS = 10`) is a constant, not a measurement: six rows are accounted for (thinking line and margin, bordered input box, status bar) and the rest is headroom for the background agent/shell status blocks, which vary. If enough of those stack up at once the frame could still overflow; `App.scrollback.test.tsx` is where to pin that case.
- Ink clears once at teardown for a frame that filled the viewport. That is a one-off at unmount, not the per-repaint wipe this fixes, so the tests measure writes made before unmount.
- An aborted turn loses its step trace (`turnController` builds the cancellation message without steps). Pre-existing, out of scope here, and a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
