### PR TITLE
fix(utils): scope the format prompt fallback to formatting only

### DIFF
--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -1980,7 +1980,8 @@ export const settingsMap = {
     key: 'FormatPromptTemplate',
     name: 'Format Prompt Template',
     defaultValue: '',
-    description: 'The template to use for formatting prompts.',
+    description:
+      'System prompt fragment injected when Use Format Prompt is on. Scope it to FORMATTING ONLY - wording that reads as general compliance ("adhere to requests") measurably degrades refusal behavior on underspecified asks (#1320). Leave empty to use the built-in scoped default. After an upgrade, diff a saved copy against that default: a saved copy pins the wording from whenever it was saved and will not pick up fixes made since.',
     category: 'AI',
     order: 4,
   }),

--- a/b4m-core/utils/src/llm/utils.test.ts
+++ b/b4m-core/utils/src/llm/utils.test.ts
@@ -7,6 +7,7 @@ import {
   getLastBuildDebugInfo,
   fetchAndProcessPreviousMessages,
   fetchAgentConversationHistory,
+  includeHardcodedSystemMessage,
   TOOL_RESULT_NOT_RECORDED,
 } from './utils';
 import { ensureToolPairingIntegrity, stripAllToolBlocks } from '@bike4mind/llm-adapters';
@@ -2627,5 +2628,27 @@ describe('unusable attachments are judged one at a time', () => {
     expect(result.some(m => typeof m.content === 'string' && (m.content as string).startsWith('bravo,col'))).toBe(
       false
     );
+  });
+});
+
+describe('includeHardcodedSystemMessage - format prompt scoping (#1320)', () => {
+  it('prepends the built-in scoped default when no template is stored', () => {
+    const result = includeHardcodedSystemMessage([], '');
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('system');
+    // The scope guard is the load-bearing part of the fix: the previous wording read as a
+    // general compliance instruction and degraded refusal behavior on underspecified asks.
+    expect(result[0].content as string).toMatch(
+      /^Formatting only - nothing here decides whether or how fully to answer/
+    );
+    expect(result[0].content as string).not.toContain('Adhere to specific formatting requests');
+  });
+
+  it('uses the stored template verbatim when provided, prepended ahead of existing messages', () => {
+    const existing: IMessage[] = [{ role: 'system', content: 'other block' }];
+    const result = includeHardcodedSystemMessage(existing, 'Custom template.');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ role: 'system', content: 'Custom template.' });
+    expect(result[1]).toEqual(existing[0]);
   });
 });

--- a/b4m-core/utils/src/llm/utils.ts
+++ b/b4m-core/utils/src/llm/utils.ts
@@ -1506,7 +1506,13 @@ export async function processFabFilesServer(
 }
 
 export function includeHardcodedSystemMessage(messages: IMessage[], formatPrompt: string): IMessage[] {
-  let format = `format replies to maintain the integrity of the requested style. Default to markdown for text-based responses. Ensure proper structuring for poems, songs, or haikus with appropriate line breaks and stanza divisions. Adhere to specific formatting requests such as TypeScript when specified by the user.`;
+  // Scoped to formatting ONLY. The previous wording ("Adhere to specific formatting
+  // requests...") read as a general compliance instruction and measurably degraded
+  // refusal behavior on underspecified asks (#1320: 81.1 -> 40.3 as the sole system
+  // content). Same failure shape as the artifact prompt's pre-SCOPE wording (#1296):
+  // any instruction that sounds like "comply with requests" bleeds into WHETHER to
+  // answer, not just how to format. Keep any future edit inside that boundary.
+  let format = `Formatting only - nothing here decides whether or how fully to answer. Format replies to maintain the integrity of the requested style; default to markdown for text. Preserve proper structure for poems, songs, or haikus. When the user specifies an output format (e.g. TypeScript), use that format for the parts you do answer.`;
   if (formatPrompt) {
     format = formatPrompt;
   }


### PR DESCRIPTION
## Summary

Change 2 from #1320: the built-in `FormatPromptTemplate` fallback in `includeHardcodedSystemMessage` told the model to "adhere to specific formatting requests", which reads as a general compliance instruction and bleeds into *whether* to answer, not just how to format. Measured effect (#1320, eval run `20260802T114444`): with the template as the sole system content, refusal quality on a deliberately underspecified ask dropped 81.1 -> 40.3, and -9.5 overall across nine questions.

Same failure shape as the artifact prompt's pre-`SCOPE:` wording (#1296).

## Changes

- **`b4m-core/utils/src/llm/utils.ts`** - reword the fallback to open with an explicit scope guard ("Formatting only - nothing here decides whether or how fully to answer..."), with a comment pinning the boundary for future editors.
- **`b4m-core/utils/src/llm/utils.test.ts`** - two tests: the fallback opens with the scope guard and no longer contains the compliance-toned phrase; a stored template still passes through verbatim.
- **`b4m-core/common/src/schemas/settings.ts`** - `FormatPromptTemplate` description now states the formatting-only constraint and warns that a saved settings row pins its wording across upgrades (mirrors the `ArtifactEmissionPrompt` description).

## What this does NOT do

- Does not change prod behavior by itself: deployments with a **stored** `FormatPromptTemplate` row keep their saved wording until an admin re-saves it (tracked in #1320, pending the A/B run on the rescoped text).
- Out-of-box deployments are unaffected in practice (`UseFormatPrompt` defaults to false); this protects any deployment that enables it without saving a template.

## Verification

- `pnpm --filter @bike4mind/utils exec vitest run src/llm/utils.test.ts` - 114 passed
- `pnpm --filter @bike4mind/utils typecheck` and `pnpm --filter @bike4mind/common typecheck` - clean
- `pnpm lint:check` - clean

Part of #1320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)