### PR TITLE
fix(services): honor the per-request memory opt-out for Mementos V2

### DIFF
--- a/apps/client/app/contexts/LLMContext.tsx
+++ b/apps/client/app/contexts/LLMContext.tsx
@@ -371,7 +371,7 @@ export function getDefaultMaxTokens(modelInfo: ModelInfo): number {
 
 export const LLMProvider: React.FC = () => {
   const { setState } = useLLM;
-  const { settings } = useUserSettings();
+  const { settings, isHydrated: settingsHydrated } = useUserSettings();
   const { isFeatureEnabled, isLoading: areFeaturesLoading } = useFeatureEnabled();
   const { accessibleModels, isModelAccessible, getFallbackModel } = useAccessibleModels();
   const { data: modelInfoRepo } = useModelInfo();
@@ -388,9 +388,12 @@ export const LLMProvider: React.FC = () => {
   // Tri-state (#1319): true = V1 toggle on; undefined = V2-only user (the server resolves
   // memory from the account opt-in; an explicit false would revoke it per-request);
   // false = no memory feature enabled, so requests opt out of both pipelines.
+  // Guarded on prefs hydration: settings.experimentalFeatures starts as merged defaults
+  // (both toggles false), so deriving before hydration would stamp an explicit false and
+  // opt a cold-load first send out of V2 - the same window isArtifactsEnabled guards.
   const enableMementosV1 = settings.experimentalFeatures?.enableMementos ?? false;
   const enableMementosV2 = settings.experimentalFeatures?.enableMementosV2 ?? false;
-  const enableMementos = enableMementosV1 ? true : enableMementosV2 ? undefined : false;
+  const enableMementos = !settingsHydrated ? undefined : enableMementosV1 ? true : enableMementosV2 ? undefined : false;
   // Left undefined until both signals resolve - see isArtifactsEnabled on the state type.
   const enableArtifacts = areFeaturesLoading ? undefined : isFeatureEnabled('enableArtifacts');
   const enableAgents = isFeatureEnabled('enableAgents');

--- a/apps/client/app/contexts/LLMContext.tsx
+++ b/apps/client/app/contexts/LLMContext.tsx
@@ -69,7 +69,13 @@ export interface LLMContextProps {
   resetSettings: () => void;
   updateLLMParams: () => void;
   isQuestMasterEnabled: boolean;
-  isMementosEnabled: boolean;
+  /**
+   * Tri-state request flag for user memory (#1319). `true` = V1 mementos explicitly on;
+   * `undefined` = no V1 intent, defer to the server-side Mementos V2 account opt-in
+   * (an explicit `false` on the wire now revokes V2 for the request too, so a V2-only
+   * user must NOT send one); `false` = no memory feature enabled, requests opt out.
+   */
+  isMementosEnabled: boolean | undefined;
   /**
    * `undefined` until admin settings and user prefs have both hydrated. The server reads an
    * explicit `false` on the request as "this caller has no artifact surface" and drops the
@@ -157,7 +163,9 @@ const DEFAULTS = {
   },
   organizationId: null,
   isQuestMasterEnabled: false,
-  isMementosEnabled: false,
+  // undefined pre-hydration for the same reason as isArtifactsEnabled below: an explicit
+  // false would opt a cold-load first prompt out of V2 memory before prefs have loaded.
+  isMementosEnabled: undefined,
   isArtifactsEnabled: undefined,
   isAgentsEnabled: false, // Default controlled by user settings
   isLatticeEnabled: false, // Default controlled by user settings
@@ -377,7 +385,12 @@ export const LLMProvider: React.FC = () => {
 
   // Extract primitive booleans so the effect dep array contains stable values
   // rather than the experimentalFeatures object reference (recreated on every settings update)
-  const enableMementos = settings.experimentalFeatures?.enableMementos ?? false;
+  // Tri-state (#1319): true = V1 toggle on; undefined = V2-only user (the server resolves
+  // memory from the account opt-in; an explicit false would revoke it per-request);
+  // false = no memory feature enabled, so requests opt out of both pipelines.
+  const enableMementosV1 = settings.experimentalFeatures?.enableMementos ?? false;
+  const enableMementosV2 = settings.experimentalFeatures?.enableMementosV2 ?? false;
+  const enableMementos = enableMementosV1 ? true : enableMementosV2 ? undefined : false;
   // Left undefined until both signals resolve - see isArtifactsEnabled on the state type.
   const enableArtifacts = areFeaturesLoading ? undefined : isFeatureEnabled('enableArtifacts');
   const enableAgents = isFeatureEnabled('enableAgents');

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -128,6 +128,7 @@ import {
 import type { ToolTelemetry, ToolErrorCategory, SystemPromptDetail } from '@bike4mind/common';
 import { buildAlwaysOnFloorDetails } from './systemPromptFloorTelemetry';
 import { resolveArtifactsEnabled } from './artifactGating';
+import { resolveMementoGates } from './mementoGating';
 import {
   ContextTelemetryAlertsSchema,
   detectAgentMentions,
@@ -1203,7 +1204,9 @@ export class ChatCompletionProcess {
       await this.buildOptimizedFeatures(
         defaultAdminSettings,
         enableQuestMaster || false,
-        enableMementos || false,
+        // Tri-state, deliberately NOT coerced: explicit false is the caller's memory
+        // opt-out and must stay distinguishable from absence (#1319, resolveMementoGates).
+        enableMementos,
         enableAgents || false,
         projectId,
         optimizedFeatureList,
@@ -4740,7 +4743,7 @@ When using tools that require file IDs (like edit_image), use the ID shown above
   private async buildOptimizedFeatures(
     adminSettings: Record<string, string>,
     enableQuestMaster: boolean,
-    enableMementos: boolean,
+    enableMementos: boolean | undefined,
     enableAgents: boolean,
     projectId?: string,
     optimizedFeatureList: featureNames[] = [],
@@ -4772,29 +4775,30 @@ When using tools that require file IDs (like edit_image), use the ID shown above
       this.features.set('contextSummarization', new ContextSummarizationFeature(this));
     }
 
-    // Conditional features - only build if requested AND enabled. Mementos runs when V1 is on
-    // (admin + request flag) OR when the user has opted into V2, so V2 works independently of V1
-    // (the two are mutually exclusive at inject time - MementoFeature picks which).
+    // Conditional features - only build if requested AND enabled. Memento gating for BOTH
+    // pipelines lives in resolveMementoGates (#1319): V1 needs explicit request intent plus
+    // the admin setting; V2 rides the per-user opt-in but an explicit `enableMementos: false`
+    // from the caller now disables it too - on the read side (the feature is never registered,
+    // so nothing injects) and the write side (the flags below never fire). The two remain
+    // mutually exclusive at inject time - MementoFeature picks which.
     //
     // MUST go through isExperimentalFeatureEnabled: `preferences.experimentalFeatures` is a Mongoose
     // Map at runtime, so reading it with dot access silently yields undefined and the feature never
     // runs. That is exactly the bug this line used to have - V2 memory was never injected into a
     // prompt even for a user who had opted in.
     const enableMementosV2 = isExperimentalFeatureEnabled(this.user, 'enableMementosV2');
-    if (
-      optimizedFeatureList.includes('mementos') &&
-      ((enableMementos && adminSettingsEnableMementos) || enableMementosV2)
-    ) {
-      this.logger.log(`  - Enabling Mementos feature${enableMementosV2 ? ' (V2 opt-in)' : ''}`);
-      // Resolve the WRITE gates here, where both the admin setting and the per-user opt-in are in
-      // scope, and hand them to the feature. V1 writes only when it is fully on (request flag AND admin
-      // setting); V2 writes on the opt-in. Without this, the completion event carried no flags and the
-      // subscriber defaulted V1 on - so chat kept writing V1 mementos for a V2 user even with V1 off.
+    const mementoGates = resolveMementoGates(enableMementos, Boolean(adminSettingsEnableMementos), enableMementosV2);
+    if (optimizedFeatureList.includes('mementos') && (mementoGates.v1 || mementoGates.v2)) {
+      this.logger.log(`  - Enabling Mementos feature${mementoGates.v2 ? ' (V2 opt-in)' : ''}`);
+      // Resolve the WRITE gates here, where the request flag, admin setting, and per-user opt-in
+      // are all in scope, and hand them to the feature. Without explicit flags, the completion
+      // event carried none and the subscriber defaulted V1 on - so chat kept writing V1 mementos
+      // for a V2 user even with V1 off.
       this.features.set(
         'mementos',
         new MementoFeature(this, {
-          writeV1: Boolean(enableMementos && adminSettingsEnableMementos),
-          writeV2: enableMementosV2,
+          writeV1: mementoGates.v1,
+          writeV2: mementoGates.v2,
         })
       );
     }

--- a/b4m-core/services/src/llm/mementoGating.test.ts
+++ b/b4m-core/services/src/llm/mementoGating.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMementoGates } from './mementoGating';
+
+describe('resolveMementoGates (#1319)', () => {
+  describe('explicit false - the per-request opt-out', () => {
+    it('disables BOTH pipelines regardless of admin setting and V2 opt-in', () => {
+      expect(resolveMementoGates(false, true, true)).toEqual({ v1: false, v2: false });
+      expect(resolveMementoGates(false, true, false)).toEqual({ v1: false, v2: false });
+      expect(resolveMementoGates(false, false, true)).toEqual({ v1: false, v2: false });
+      expect(resolveMementoGates(false, false, false)).toEqual({ v1: false, v2: false });
+    });
+  });
+
+  describe('undefined - no preference expressed', () => {
+    it('keeps V1 off (V1 requires explicit intent)', () => {
+      expect(resolveMementoGates(undefined, true, false)).toEqual({ v1: false, v2: false });
+    });
+
+    it('lets V2 ride on the account-level opt-in (current-behavior preservation)', () => {
+      expect(resolveMementoGates(undefined, true, true)).toEqual({ v1: false, v2: true });
+      expect(resolveMementoGates(undefined, false, true)).toEqual({ v1: false, v2: true });
+    });
+  });
+
+  describe('explicit true - V1 intent', () => {
+    it('enables V1 only when the admin setting allows it', () => {
+      expect(resolveMementoGates(true, true, false)).toEqual({ v1: true, v2: false });
+      expect(resolveMementoGates(true, false, false)).toEqual({ v1: false, v2: false });
+    });
+
+    it('keeps V2 alongside V1 for a dual-opted user (inject side picks one, writes both)', () => {
+      expect(resolveMementoGates(true, true, true)).toEqual({ v1: true, v2: true });
+    });
+  });
+
+  it('V2 never consults the V1 admin setting - only the opt-in and the request flag', () => {
+    expect(resolveMementoGates(undefined, false, true).v2).toBe(true);
+    expect(resolveMementoGates(true, false, true).v2).toBe(true);
+    expect(resolveMementoGates(false, false, true).v2).toBe(false);
+  });
+});

--- a/b4m-core/services/src/llm/mementoGating.ts
+++ b/b4m-core/services/src/llm/mementoGating.ts
@@ -1,0 +1,42 @@
+/**
+ * Which memento pipelines are live for one chat completion - resolved from the caller's
+ * per-request flag, the deployment admin setting, and the user's V2 opt-in. Within
+ * ChatCompletionProcess these gates control BOTH sides of each pipeline: whether
+ * MementoFeature is registered at all (injection) and the write flags it forwards on
+ * completion (distillation), so a request can never read memory it was told not to use,
+ * or write memory from a turn that opted out.
+ *
+ * The request flag is a TRI-STATE and the distinction is load-bearing (#1319):
+ * - `false`  - explicit opt-out. No memory, either version, read or write. This is what
+ *              /api/chat resolves for toolMode 'fast'/'smart', what the voice proxy and
+ *              Slack senders hard-code, and what the browser sends when the user has no
+ *              memory feature enabled. V2 previously ignored it on both sides, which
+ *              leaked context across sessions on the same account with no off-switch
+ *              below the account level.
+ * - `undefined` - no preference expressed. V1 stays off (it requires explicit intent),
+ *              V2 rides on the user's account-level opt-in - the browser sends this for
+ *              V2-only users so the opt-in keeps working (see sessionsAPICalls).
+ * - `true`   - V1 intent. V1 runs when the admin setting also allows it; V2 (if opted
+ *              in) runs as well and wins at inject time (MementoFeature picks one).
+ *
+ * V2 deliberately does NOT consult the EnableMementos admin setting: the V1 setting
+ * predates V2 and gates a different pipeline; V2's gate is the per-user experimental
+ * opt-in. Only the caller's explicit `false` overrides that opt-in, per request.
+ */
+export interface MementoGates {
+  /** Inject V1 recall and write V1 mementos this turn. */
+  v1: boolean;
+  /** Inject V2 recall and write V2 beliefs this turn. */
+  v2: boolean;
+}
+
+export function resolveMementoGates(
+  requestEnableMementos: boolean | undefined,
+  adminEnabled: boolean,
+  v2OptIn: boolean
+): MementoGates {
+  return {
+    v1: requestEnableMementos === true && adminEnabled,
+    v2: v2OptIn && requestEnableMementos !== false,
+  };
+}


### PR DESCRIPTION
## Summary

Implements proposal 1 of #1319: an explicit `enableMementos: false` on a chat completion now disables Mementos V2 on **both sides** - injection (the feature is never registered, so no recall enters the prompt) and writes (no belief distillation from the turn; the write event only fires from `MementoFeature.onComplete`, so not registering the feature closes both). Previously V2 rode the account-level opt-in unconditionally, so opted-out API traffic (`/api/chat` fast/smart, the voice proxy, Slack) still read and wrote user memory - the cross-session leakage documented in #1319.

## Semantics (tri-state, resolved in one place)

New `resolveMementoGates` (`b4m-core/services/src/llm/mementoGating.ts`, mirroring `artifactGating.ts`):

| `enableMementos` on the request | V1 | V2 |
|---|---|---|
| `false` (explicit opt-out) | off | **off (read + write)** |
| `undefined` (no preference) | off | rides the account opt-in *(previous behavior preserved)* |
| `true` | on if admin setting allows | rides the account opt-in |

V2 still deliberately does not consult the V1 `EnableMementos` admin setting - its gate is the per-user opt-in; only an explicit caller `false` overrides it, per request.

## The paired client fix (load-bearing)

The browser always sent an explicit boolean, so a V2-only user (V1 toggle off) sent `false` on every turn - under the new gate that would have revoked their own opt-in. `LLMContext` now derives the tri-state from both feature toggles (`true` = V1 on / `undefined` = V2-only, defer to server / `false` = no memory feature), and initializes `undefined` pre-hydration for the same reason `isArtifactsEnabled` does. Every hop on the send path (`useSendMessage` -> `handleCommand` -> `LLMCommand` -> `/api/ai/llm`) already types the flag optional, so `undefined` serializes to an absent field.

## Surfaces that change behavior (all in the direction the flag already claimed)

- `/api/chat` `toolMode: 'fast'`/`'smart'` (resolve `false` unless the caller passes `true`): no more V2 injection or writes - the #1319 eval-contamination and memory-pollution scenario.
- Voice proxy and Slack (hard-code `false`): now actually memory-free.
- Browser UI, all user classes (V1-only, V2-only, dual, neither): behavior byte-identical to today by construction of the tri-state.

## Verification

- `mementoGating.test.ts`: full matrix, 6 tests
- `ChatCompletion.test.ts`: 71 passed
- `pnpm --filter @bike4mind/services typecheck` (tsc): clean; full `tsc --noEmit` on `apps/client`: clean; `pnpm lint:check`: clean

## Out of scope (still open on #1319)

Disclosure of memory injection in response metadata (partial today via `promptMeta.context.mementoCount`), a V2 belief list/purge API, and the session-scoped-by-default design question.

Closes #1319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)