### PR TITLE
fix(events): scope session summarization to the notebook owner

### DIFF
--- a/apps/client/server/events/sessionSummarization.test.ts
+++ b/apps/client/server/events/sessionSummarization.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The summary FabFile lookup is an ownership boundary: a sessionId is attacker-settable via
+ * PUT /api/files/[id], so a lookup by session id alone can hand the summarizer a stranger's
+ * document to overwrite. The `findOne` fake below honours whatever filter it is given, so
+ * dropping the owner conjunct from the handler changes which document is selected and fails
+ * these tests rather than quietly passing.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  fabFileStore: [] as Record<string, unknown>[],
+  findOne: vi.fn(),
+  updateFabFile: vi.fn(),
+  createFabFile: vi.fn(),
+  sessionUpdate: vi.fn(),
+  publishTag: vi.fn(),
+  logEvent: vi.fn(),
+  upload: vi.fn(),
+  session: {} as Record<string, unknown>,
+}));
+
+// Passthrough the wrapper so the raw handler runs without connectDB / Config.
+vi.mock('@server/events/utils', () => ({
+  withEventContext: (fn: unknown) => fn,
+}));
+
+vi.mock('@server/utils/eventBus', () => ({
+  SessionEvents: {
+    Summarize: { schema: { parse: (properties: unknown) => properties } },
+    Tag: { publish: h.publishTag },
+  },
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  Session: { findById: vi.fn(async () => h.session) },
+  User: { findById: vi.fn(async (id: string) => ({ id, isAdmin: false })) },
+  Quest: {
+    find: vi.fn(() => ({
+      sort: () => ({ limit: async () => [{ _id: 'q1', prompt: 'hello', reply: 'world' }] }),
+    })),
+  },
+  sessionRepository: { update: h.sessionUpdate },
+  fabFileRepository: { findOne: h.findOne },
+  dataLakeRepository: {},
+  adminSettingsRepository: {},
+  userRepository: {},
+  withTransaction: (fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock('@bike4mind/services', () => ({
+  fabFilesService: { updateFabFile: h.updateFabFile, createFabFile: h.createFabFile },
+}));
+
+vi.mock('@client/services/operationsModelService', () => ({
+  OperationsModelService: {
+    getOperationsModel: async () => ({
+      modelId: 'test-model',
+      modelInfo: { name: 'Test Model', backend: 'test' },
+      llm: {
+        complete: async (
+          _modelId: string,
+          _messages: unknown,
+          _options: unknown,
+          onChunk: (chunk: (string | null)[]) => Promise<void>
+        ) => {
+          await onChunk(['A summary of the session.']);
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock('@server/utils/storage', () => ({
+  getFilesStorage: () => ({ upload: h.upload, getSignedUrl: vi.fn(async () => 'https://example.test/signed') }),
+}));
+
+vi.mock('@server/utils/analyticsLog', () => ({ logEvent: h.logEvent }));
+vi.mock('@server/events/recordSessionOperationalUsage', () => ({
+  recordSessionOperationalUsage: vi.fn(),
+}));
+
+import { handler } from './sessionSummarization';
+
+const OWNER = 'user-owner';
+const STRANGER = 'user-stranger';
+const SESSION_ID = 'session-1';
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), updateMetadata: vi.fn() };
+
+const run = () =>
+  (handler as unknown as (event: unknown, logger: unknown) => Promise<void>)(
+    { event: 'session.summarize', properties: { sessionId: SESSION_ID, trigger: 'manual' } },
+    logger
+  );
+
+describe('sessionSummarization summary-file lookup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.fabFileStore.length = 0;
+    h.session = { id: SESSION_ID, _id: SESSION_ID, userId: OWNER, name: 'Notebook', tags: [] };
+    h.findOne.mockImplementation(
+      async (filter: Record<string, unknown>) =>
+        h.fabFileStore.find(doc => Object.entries(filter).every(([key, value]) => doc[key] === value)) ?? null
+    );
+    h.createFabFile.mockResolvedValue({ filePath: 'summary.txt', mimeType: 'text/plain' });
+  });
+
+  it('looks the summary file up by session id AND the session owner', async () => {
+    await run();
+
+    expect(h.findOne).toHaveBeenCalledWith({ sessionId: SESSION_ID, userId: OWNER });
+  });
+
+  it('leaves a stranger-owned file carrying the session id alone and creates its own summary', async () => {
+    h.fabFileStore.push({
+      id: 'fabfile-stranger',
+      userId: STRANGER,
+      sessionId: SESSION_ID,
+      fileName: 'Their notes.txt',
+      tags: [],
+    });
+
+    await run();
+
+    expect(h.updateFabFile).not.toHaveBeenCalled();
+    expect(h.createFabFile).toHaveBeenCalledWith(OWNER, expect.objectContaining({ userId: OWNER }), expect.anything());
+  });
+
+  it("updates the owner's existing summary file", async () => {
+    h.fabFileStore.push({
+      id: 'fabfile-owner',
+      userId: OWNER,
+      sessionId: SESSION_ID,
+      fileName: 'Notebook Summary.txt',
+      tags: [],
+    });
+
+    await run();
+
+    expect(h.createFabFile).not.toHaveBeenCalled();
+    expect(h.updateFabFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'fabfile-owner' }),
+      expect.anything()
+    );
+  });
+});

--- a/apps/client/server/events/sessionSummarization.test.ts
+++ b/apps/client/server/events/sessionSummarization.test.ts
@@ -127,6 +127,30 @@ describe('sessionSummarization summary-file lookup', () => {
     expect(h.createFabFile).toHaveBeenCalledWith(OWNER, expect.objectContaining({ userId: OWNER }), expect.anything());
   });
 
+  it('refuses to summarize an owner-less session instead of running an unscoped lookup', async () => {
+    // A missing userId would be dropped from the filter, leaving the lookup keyed on sessionId
+    // alone. The event carries its own userId here, which is what gets an owner-less session
+    // past the `!user` check on the spider and agent-run paths.
+    h.session = { id: SESSION_ID, _id: SESSION_ID, name: 'Notebook', tags: [] };
+    h.fabFileStore.push({ id: 'fabfile-stranger', userId: STRANGER, sessionId: SESSION_ID, tags: [] });
+
+    await (handler as unknown as (event: unknown, logger: unknown) => Promise<void>)(
+      { event: 'session.summarize', properties: { sessionId: SESSION_ID, userId: STRANGER, trigger: 'manual' } },
+      logger
+    );
+
+    expect(h.findOne).not.toHaveBeenCalled();
+    expect(h.updateFabFile).not.toHaveBeenCalled();
+    expect(h.createFabFile).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('has no owner'));
+  });
+
+  it('stays silent about ownership on the healthy path', async () => {
+    await run();
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it("updates the owner's existing summary file", async () => {
     h.fabFileStore.push({
       id: 'fabfile-owner',

--- a/apps/client/server/events/sessionSummarization.ts
+++ b/apps/client/server/events/sessionSummarization.ts
@@ -189,7 +189,12 @@ export const handler = withEventContext(async (event, logger) => {
   // entire summarization - the summary text is already saved on the session.
   try {
     await withTransaction(async () => {
-      const fabfile = await fabFileRepository.findOne({ sessionId: session.id });
+      // A FabFile's sessionId is not an ownership claim - any user can stamp an arbitrary one
+      // onto a file they own via PUT /api/files/[id]. Without the owner conjunct this lookup can
+      // select a stranger's document, and the update below gates on ACCESSIBLE-not-owned, so the
+      // summary would overwrite their content and tags. A miss falls through to createFabFile,
+      // which is the safe direction: a duplicate summary beats clobbering someone else's file.
+      const fabfile = await fabFileRepository.findOne({ sessionId: session.id, userId: session.userId });
       if (fabfile) {
         // Re-summarizing must not change which data lakes this file belongs to. The tags here are
         // the SESSION's, which never carry a `datalake:` meta-tag, and a whole-array tag write

--- a/apps/client/server/events/sessionSummarization.ts
+++ b/apps/client/server/events/sessionSummarization.ts
@@ -48,6 +48,16 @@ export const handler = withEventContext(async (event, logger) => {
     return;
   }
 
+  // Everything downstream keys off the session's owner: it is the conjunct that stops the
+  // summary-file lookup selecting someone else's document, and the owner createFabFile stamps.
+  // Mongoose drops an undefined value from a filter, so an owner-less session would silently
+  // restore the unscoped lookup - and the acting user comes from the event on the spider and
+  // agent-run paths, so the `!user` check below does not catch it.
+  if (!session.userId) {
+    logger.warn(`Session ${sessionId} has no owner; skipping summarization`);
+    return;
+  }
+
   const user = await User.findById(userId ?? session.userId);
   if (!user) {
     logger.error(`User not found`);
@@ -189,11 +199,11 @@ export const handler = withEventContext(async (event, logger) => {
   // entire summarization - the summary text is already saved on the session.
   try {
     await withTransaction(async () => {
-      // A FabFile's sessionId is not an ownership claim - any user can stamp an arbitrary one
-      // onto a file they own via PUT /api/files/[id]. Without the owner conjunct this lookup can
-      // select a stranger's document, and the update below gates on ACCESSIBLE-not-owned, so the
-      // summary would overwrite their content and tags. A miss falls through to createFabFile,
-      // which is the safe direction: a duplicate summary beats clobbering someone else's file.
+      // The owner conjunct is load-bearing: a sessionId is not an ownership claim (any user can
+      // stamp one on their own file via PUT /api/files/[id]) and updateFabFile below gates on
+      // findAccessibleById, which a read share satisfies. Without it, a file merely shared with
+      // the summarizing user gets its content and tags overwritten with this summary. A miss
+      // falls through to createFabFile - a duplicate beats clobbering someone else's file.
       const fabfile = await fabFileRepository.findOne({ sessionId: session.id, userId: session.userId });
       if (fabfile) {
         // Re-summarizing must not change which data lakes this file belongs to. The tags here are


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1440" height="900" alt="b-file-content-intact-after-a-summarized-after" src="https://github.com/user-attachments/assets/f27a90bd-b9e9-4a34-9309-b61858ce735f" />

*B's file, opened from its own signed content URL on the PR preview after A's notebook was summarized. It still holds B's own text rather than A's session summary. Before this fix the summarizer selected this file by session id alone and replaced its contents, name and tags.*

## Description

Closes #1328.

The session summarizer found the FabFile it was about to overwrite by session id alone. A `sessionId` is not an ownership claim: any user can stamp an arbitrary one onto a file they own via `PUT /api/files/[id]`, which passes the field straight through to `updateFabFile`. That write then gates on `shareable.findAccessibleById`, which a plain read share satisfies, so a file merely shared with the summarizing user had its `fileContent`, `fileName`, `mimeType` and `tags` replaced with that session's summary. The owner of that file got a copy of a summary they were never meant to see, which makes this a disclosure as well as an overwrite. Nothing user-facing gates the handler, since it runs as a system job from chat completion, quest processing and the admin spider.

The lookup now carries the owner conjunct the create path already assumed. A miss falls through to `createFabFile`, so the worst case is a duplicate summary rather than someone else's document.

## Changes

- `sessionSummarization.ts`: scope the summary-file lookup to `session.userId`.
- `sessionSummarization.ts`: skip an owner-less session. Mongoose drops an undefined value from a filter, so such a session would quietly fall back to the unscoped lookup, and the existing "user not found" check misses it because the spider and agent-run publishers pass their own `userId` on the event.
- `sessionSummarization.test.ts`: new coverage for the handler, including both arms of the lookup and the owner-less guard.

## Guide for Testers

Backend-only, so this is an API exercise. Two actors, both already seeded on every non-prod stage:

- **B** = `qa-admin-e2e@test.com` - owns the file that used to get clobbered, and is admin.
- **A** = `qa-user-e2e@test.com` - owns the notebook being summarized.

Set `HOST` to the preview URL from the deploy bot comment on this PR. For each actor, sign in and copy its bearer token from devtools: Application -> Local Storage -> key `access-token-storage`, field `state.accessToken`. Below, `$TOKEN_A` and `$TOKEN_B` are those two values.

**Prerequisite - do this first or nothing will summarize.** This stage's operations model is an OpenAI model, but its `OPENAI_API_KEY` slot holds a key beginning `xai-`, so every summarization job dies on a 401 before reaching the code this PR changes. That is a pre-existing environment defect, not something this PR introduces or fixes. Point the operations model at Bedrock for the duration of the test, as **B**:

```
curl "$HOST/api/admin/operations-model" -H "Authorization: Bearer $TOKEN_B"          # record this, you restore it at the end
curl -X PUT "$HOST/api/admin/operations-model" -H "Authorization: Bearer $TOKEN_B" -H "Content-Type: application/json" \
  -d '{"modelId":"global.anthropic.claude-sonnet-5","imageModelId":"<from the GET>","speechModelId":"<from the GET>"}'
```

All three ids are required; sending only `modelId` returns a 500.

1. As **A**, open a notebook and send `In one sentence, what is the capital of France?`. Note the notebook's session id from the URL as `SESSION_A`. Summarization returns early on a notebook with no exchanges, so this step is required.
2. Confirm the reply arrived before continuing: `curl "$HOST/api/sessions/SESSION_A/chat" -H "Authorization: Bearer $TOKEN_A"`. The answer lands in the `replies` array of the newest entry, not a `reply` field. It normally takes about ten seconds.
3. As **B**, create any text file. Note its id as `FILE_B`, and record its `fileName` and `fileContent` - those are what you compare against at the end.
4. As **B**, share `FILE_B` with **A**, then accept as **A**. Read access is enough; write is not needed.
   ```
   curl -X POST "$HOST/api/files/$FILE_B/invites" -H "Authorization: Bearer $TOKEN_B" -H "Content-Type: application/json" \
     -d '{"permissions":["read"],"recipients":["qa-user-e2e@test.com"]}'
   curl -X POST "$HOST/api/invites/<invite id from above>/accept" -H "Authorization: Bearer $TOKEN_A"
   ```
5. As **B**, stamp A's session id onto B's own file. This is the step that makes the file look like A's summary file:
   `curl -X PUT "$HOST/api/files/$FILE_B" -H "Authorization: Bearer $TOKEN_B" -H "Content-Type: application/json" -d '{"sessionId":"SESSION_A"}'`
   Expect `200`. This is accepted both before and after the fix - it is the setup, not the bug.
6. As **A**, trigger summarization:
   `curl -X POST "$HOST/api/sessions/SESSION_A/summary" -H "Authorization: Bearer $TOKEN_A"`
   Expect `200` with `{"message":"Summarization job queued", ...}`.
7. Wait for the job to actually finish, then check: `curl "$HOST/api/sessions/SESSION_A" -H "Authorization: Bearer $TOKEN_A"` until `summary` is non-empty (up to a couple of minutes). **Do not skip this.** If you check B's file while `summary` is still null, it will look untouched simply because the job has not run yet, and the test proves nothing.
8. As **B**, read the file back. This is the check that matters:
   `curl "$HOST/api/files/$FILE_B" -H "Authorization: Bearer $TOKEN_B"`
   **Expected on this PR:** `fileName` is exactly what you recorded in step 3, and `userId` is still B's. Before the fix, `fileName` became `<notebook name> Summary.txt` and the contents became A's session summary - so B both lost their file and received a copy of A's private summary.
9. To see it rather than read JSON, copy the `fileUrl` from that response and open it in a browser tab. It renders the file's actual bytes, which should still be your step-3 text and not a session summary.
10. Confirm summarization still worked for its rightful owner: `curl "$HOST/api/sessions/SESSION_A" -H "Authorization: Bearer $TOKEN_A"` and check `summary` is a real summary of the step-1 exchange.
11. Restore the operations model to the value you recorded in the prerequisite.

### Regression Checks

- Re-run step 6 a second time on A's notebook. The summary on A's session should be refreshed, and B's file should still be untouched by step 8's check.
- If A's notebook belongs to a data lake, confirm it still does after re-summarizing. The lake tag carry-through is untouched by this PR but shares the code path.

### Expected oddity, not a bug

After step 5, `FILE_B` disappears from B's file browser. That is pre-existing and unrelated: the library view only lists files whose `sessionId` is null or absent, and step 5 sets one. The file is still there - step 8 and step 9 both reach it. Do not read its absence from the browser as data loss.

### What NOT to test

- No UI changed. The only thing to look at is the file's own content URL in step 9.
- Existing summary files whose owner disagrees with their session are out of scope. After this change the summarizer no longer finds them and will create a fresh file instead. Counting and cleaning those up is tracked in #1331.

## Additional Information

`updateFabFile` is still called with the **acting** user (`userId ?? session.userId`), not the session owner. That is deliberate: #1128 wired `reconcileLakeTags` to gate data-lake writes on that principal, and swapping in the owner would weaken the gate. Only the lookup gained the conjunct.

## Developer Notes (Optional)

`sessionSummarization.test.ts` is the first test for this handler. It mocks the repository's `findOne` as a **filter-honoring fake** over a small seeded store rather than a fixed return value, so deleting the ownership conjunct from the handler changes which document gets selected and fails the test. Worth copying for any other lookup that is an authorization boundary - a mock that returns a canned document cannot tell the two apart.

## Security Testing (for security-labeled PRs only)

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

