### PR TITLE
fix(tags): keep file tag names in step when a tag is renamed or deleted

### DIFF
--- a/apps/client/app/hooks/data/tag.test.tsx
+++ b/apps/client/app/hooks/data/tag.test.tsx
@@ -6,11 +6,13 @@ import type { IFileTag, ITag } from '@bike4mind/common';
 
 const mockPut = vi.fn();
 const mockPost = vi.fn();
+const mockDelete = vi.fn();
 
 vi.mock('@client/app/contexts/ApiContext', () => ({
   api: {
     put: (...args: unknown[]) => mockPut(...args),
     post: (...args: unknown[]) => mockPost(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
   },
 }));
 
@@ -18,7 +20,7 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 
-import { useCreateFileTag, useUpdateFileTag } from './tag';
+import { useCreateFileTag, useDeleteFileTag, useUpdateFileTag } from './tag';
 
 const CACHED_TAG = { id: 'tag-1', name: 'invoices', color: 'blue', fileCount: 7 } as IFileTag;
 
@@ -36,6 +38,7 @@ describe('file tag mutations', () => {
   beforeEach(() => {
     mockPut.mockReset();
     mockPost.mockReset();
+    mockDelete.mockReset();
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     queryClient.setQueryData(['file-tags'], [CACHED_TAG]);
     invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
@@ -79,6 +82,34 @@ describe('file tag mutations', () => {
 
       await waitFor(() => expect(cachedTags()[0].name).toBe('renamed'));
       expect(cachedTags()[1]).toEqual(other);
+    });
+  });
+
+  describe('useDeleteFileTag', () => {
+    const remove = async () => {
+      const { result } = renderHook(() => useDeleteFileTag(), { wrapper });
+      await act(async () => {
+        await result.current.mutateAsync('tag-1');
+      });
+    };
+
+    it('invalidates the tag list', async () => {
+      mockDelete.mockResolvedValueOnce({});
+
+      await remove();
+
+      expect(invalidatedKeys()).toContainEqual(['file-tags']);
+    });
+
+    // Deleting a tag now strips the name off the files as well, so a cached file row still carries
+    // a tag the server has removed. Without this the chips stay on screen until something else
+    // happens to refetch.
+    it('invalidates the file list, because the delete retags the files', async () => {
+      mockDelete.mockResolvedValueOnce({});
+
+      await remove();
+
+      expect(invalidatedKeys()).toContainEqual(['fabFiles']);
     });
   });
 

--- a/apps/client/app/hooks/data/tag.test.tsx
+++ b/apps/client/app/hooks/data/tag.test.tsx
@@ -62,8 +62,8 @@ describe('file tag mutations', () => {
       expect(cachedTags()[0].color).toBe('blue');
     });
 
-    // A rename does not retag the files, so the cached count is optimistic at best and flatly
-    // wrong at worst. Invalidating the bare prefix is what makes the server-derived count win;
+    // A rename retags the files and can merge two tags into one, so the cached count and the
+    // cached row set are both guesses. Invalidating the bare prefix is what makes the server win;
     // invalidating only ['file-tags','counts'] leaves the longer key matched and the list stale.
     it('invalidates the tag list so the derived count is refetched, not trusted', async () => {
       mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'receipts' } });
@@ -71,6 +71,16 @@ describe('file tag mutations', () => {
       await rename();
 
       expect(invalidatedKeys()).toContainEqual(['file-tags']);
+    });
+
+    // The rename rewrites the tag names stored on the files, so a cached file row still shows the
+    // old name until something refetches it.
+    it('invalidates the file list, because the rename retags the files', async () => {
+      mockPut.mockResolvedValueOnce({ data: { id: 'tag-1', name: 'receipts' } });
+
+      await rename();
+
+      expect(invalidatedKeys()).toContainEqual(['fabFiles']);
     });
 
     it('leaves other cached tags untouched', async () => {

--- a/apps/client/app/hooks/data/tag.ts
+++ b/apps/client/app/hooks/data/tag.ts
@@ -58,14 +58,17 @@ export const useUpdateFileTag = () => {
     onSuccess: data => {
       // Merge rather than replace so the edited fields show immediately: PUT /api/files/tags/[id]
       // echoes back only what tagUpdateSchema accepted, and a wholesale swap would blank the rest
-      // of the row. This is optimistic only - fileCount is derived from the files that carry the
-      // tag, and a rename does not retag them, so the invalidation below is what settles it.
+      // of the row. This is optimistic only - a rename retags the files and can merge two tags into
+      // one, so fileCount here is a guess and the invalidation below is what settles it.
       queryClient.setQueryData(['file-tags'], (prev: IFileTag[]) =>
         prev.map(t => (t.id === data.id ? { ...t, ...data } : t))
       );
       // The bare prefix: invalidating ['file-tags','counts'] alone leaves the longer key matched
-      // and the list itself - which is what carries fileCount - stale.
+      // and the list itself - which is what carries fileCount - stale. A merge also removes the
+      // collided row entirely, which only a refetch of the list can reflect.
       queryClient.invalidateQueries({ queryKey: ['file-tags'] });
+      // A rename rewrites the tag names stored on the files, so cached file rows are stale too.
+      queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
       toast.success('Tag updated successfully');
     },
     onError: () => {

--- a/apps/client/app/hooks/data/tag.ts
+++ b/apps/client/app/hooks/data/tag.ts
@@ -82,6 +82,9 @@ export const useDeleteFileTag = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['file-tags'] });
+      // Deleting a tag now strips its name off the files too, so cached file rows carry tags the
+      // server has already removed.
+      queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
     },
     onError: () => {
       toast.error('Failed to delete tag');

--- a/apps/client/pages/api/files/tags/[id].ts
+++ b/apps/client/pages/api/files/tags/[id].ts
@@ -3,7 +3,7 @@ import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ForbiddenError } from '@server/utils/errors';
 import { tagService } from '@bike4mind/services';
-import { fileTagRepository } from '@bike4mind/database';
+import { fabFileRepository, fileTagRepository } from '@bike4mind/database';
 
 const handler = baseApi()
   .put(
@@ -42,6 +42,7 @@ const handler = baseApi()
         {
           db: {
             tags: fileTagRepository,
+            fabFiles: fabFileRepository,
           },
         }
       );

--- a/apps/client/pages/api/files/tags/[id].ts
+++ b/apps/client/pages/api/files/tags/[id].ts
@@ -21,6 +21,7 @@ const handler = baseApi()
         {
           db: {
             tags: fileTagRepository as unknown as ITagRepository,
+            fabFiles: fabFileRepository,
           },
         }
       );

--- a/apps/client/pages/api/files/tags/__tests__/[id].test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/[id].test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Route-layer coverage for PUT/DELETE /api/files/tags/[id]. The service decides HOW to keep a
+ * tag rename or delete in step with the names stored on files; the route decides WHETHER it can
+ * at all, by putting a fabFiles repository in scope. That was the actual defect - the service had
+ * no fabFiles adapter to reach, so no service-level test could have caught it.
+ */
+
+const h = vi.hoisted(() => ({
+  update: vi.fn().mockResolvedValue({ id: 't1' }),
+  remove: vi.fn().mockResolvedValue({ id: 't1', name: 'invoices', filesUpdated: 2 }),
+}));
+
+// baseApi mock: callable chain routed by req.method (same shape as the sibling toggle test).
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const routes: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign((req: { method?: string }, res: unknown) => routes[req.method ?? 'PUT']?.(req, res), {
+      use: () => chain,
+      put: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((routes.PUT = fns[fns.length - 1]), chain),
+      delete: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((routes.DELETE = fns[fns.length - 1]), chain),
+    });
+    return chain;
+  },
+}));
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: (req: unknown, res: unknown) => unknown) => fn,
+}));
+vi.mock('@bike4mind/services', () => ({
+  tagService: { update: h.update, remove: h.remove },
+}));
+vi.mock('@bike4mind/database', () => ({
+  fabFileRepository: { __repo: 'fabFiles' },
+  fileTagRepository: { __repo: 'fileTags' },
+}));
+
+import handler from '../[id]';
+
+const makeRes = () => {
+  const json = vi.fn();
+  return { res: { json, status: vi.fn(() => ({ json })) } as never, json };
+};
+const call = (r: unknown, res: unknown) => (handler as (req: unknown, res: unknown) => Promise<void>)(r, res);
+
+describe('PUT /api/files/tags/[id]', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('acts as the authenticated user, never a userId supplied in the body', async () => {
+    const { res } = makeRes();
+
+    await call(
+      {
+        method: 'PUT',
+        query: { id: 't1' },
+        body: { id: 't1', name: 'receipts', userId: 'someone-else' },
+        user: { id: 'u1' },
+      },
+      res
+    );
+
+    const [actorId] = h.update.mock.calls[0];
+    expect(actorId).toBe('u1');
+  });
+
+  it('rejects an unauthenticated request before reaching the service', async () => {
+    const { res } = makeRes();
+
+    await expect(call({ method: 'PUT', query: { id: 't1' }, body: {}, user: {} }, res)).rejects.toThrow('Unauthorized');
+    expect(h.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/files/tags/[id]', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('puts a fabFiles repository in scope so the delete can untag the files', async () => {
+    const { res } = makeRes();
+
+    await call({ method: 'DELETE', query: { id: 't1' }, user: { id: 'u1' } }, res);
+
+    const [, , adapters] = h.remove.mock.calls[0];
+    expect(adapters.db.fabFiles).toEqual({ __repo: 'fabFiles' });
+    expect(adapters.db.tags).toEqual({ __repo: 'fileTags' });
+  });
+
+  it('takes the tag id from the query string', async () => {
+    const { res } = makeRes();
+
+    await call({ method: 'DELETE', query: { id: 't1' }, user: { id: 'u1' } }, res);
+
+    const [actorId, params] = h.remove.mock.calls[0];
+    expect(actorId).toBe('u1');
+    expect(params).toMatchObject({ id: 't1' });
+  });
+
+  it('rejects an unauthenticated request before reaching the service', async () => {
+    const { res } = makeRes();
+
+    await expect(call({ method: 'DELETE', query: { id: 't1' }, user: {} }, res)).rejects.toThrow('Unauthorized');
+    expect(h.remove).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/files/tags/__tests__/[id].test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/[id].test.ts
@@ -46,6 +46,16 @@ const call = (r: unknown, res: unknown) => (handler as (req: unknown, res: unkno
 describe('PUT /api/files/tags/[id]', () => {
   beforeEach(() => vi.clearAllMocks());
 
+  it('puts a fabFiles repository in scope so a rename can retag the files', async () => {
+    const { res } = makeRes();
+
+    await call({ method: 'PUT', query: { id: 't1' }, body: { id: 't1', name: 'receipts' }, user: { id: 'u1' } }, res);
+
+    const [, , adapters] = h.update.mock.calls[0];
+    expect(adapters.db.fabFiles).toEqual({ __repo: 'fabFiles' });
+    expect(adapters.db.tags).toEqual({ __repo: 'fileTags' });
+  });
+
   it('acts as the authenticated user, never a userId supplied in the body', async () => {
     const { res } = makeRes();
 

--- a/apps/client/server/services/tagDelete.e2e.test.ts
+++ b/apps/client/server/services/tagDelete.e2e.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+import { KnowledgeType } from '@bike4mind/common';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { FabFile, fabFileRepository, fileTagRepository } from '@bike4mind/database';
+import { tagService } from '@bike4mind/services';
+
+/**
+ * End-to-end guard that deleting a tag leaves the three surfaces AGREEING: the tag documents, the
+ * tag-name strings on the files, and the aggregate the Workspaces tag counts read. Deleting the
+ * document alone satisfied the first two by accident - chips stopped rendering because they
+ * intersect documents with strings - while the aggregate kept counting the orphaned string.
+ *
+ * Drives the REAL tagService.remove through the REAL repositories. Consumes the built dist, so
+ * `pnpm turbo:core:build` must be current.
+ */
+
+let mongoServer: MongoMemoryServer;
+
+const USER = 'lifecycle-user';
+const OTHER_USER = 'someone-else';
+const SCOPE = { userGroups: [], dataLakeTags: [] };
+
+const db = { tags: fileTagRepository, fabFiles: fabFileRepository };
+
+// The Tag model is registered by importing @bike4mind/database but is not exported from it.
+const TagModel = () => mongoose.model('Tag');
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 30000);
+afterEach(async () => {
+  await Promise.all([FabFile.deleteMany({}), TagModel().deleteMany({})]);
+});
+
+const seedFile = async (tags: string[], overrides: Record<string, unknown> = {}) => {
+  const doc = await FabFile.create({
+    userId: USER,
+    fileName: 'seed.txt',
+    type: KnowledgeType.FILE,
+    mimeType: 'text/plain',
+    tags: tags.map(name => ({ name, strength: 1 })),
+    ...overrides,
+  });
+  return doc.id as string;
+};
+
+const rawTagsOf = async (id: string): Promise<string[]> => {
+  const raw = await FabFile.collection.findOne({ _id: new mongoose.Types.ObjectId(id) });
+  return ((raw?.tags ?? []) as { name: string }[]).map(t => t.name);
+};
+
+const countOf = async (tag: string): Promise<number> => {
+  const counts = await fabFileRepository.countFilesByTagForUser(USER, SCOPE);
+  return counts.find(c => c.tag === tag)?.count ?? 0;
+};
+
+describe('tagService.remove keeps tag documents, file tags and the count aggregate in agreement', () => {
+  it('strips the name everywhere, including a soft-deleted file an undelete would revive', async () => {
+    const invoices = await fileTagRepository.findOrCreateByNameAndUserId('invoices', USER, {});
+    await fileTagRepository.findOrCreateByNameAndUserId('receipts', USER, {});
+    await fileTagRepository.findOrCreateByNameAndUserId('invoices-2024', USER, {});
+
+    const both = await seedFile(['invoices', 'receipts']);
+    const casingVariant = await seedFile(['Invoices']);
+    const duplicated = await seedFile(['invoices', 'invoices']);
+    const softDeleted = await seedFile(['invoices', 'receipts'], { deletedAt: new Date() });
+    const substringNeighbour = await seedFile(['invoices-2024']);
+    const otherUsersFile = await FabFile.create({
+      userId: OTHER_USER,
+      fileName: 'theirs.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: [{ name: 'invoices', strength: 1 }],
+    });
+
+    // Sanity: the aggregate really does see the orphan-prone rows before the delete, so a later
+    // "no invoices bucket" assertion cannot pass just because the fixture never counted.
+    expect(await countOf('invoices')).toBe(3);
+
+    await tagService.remove(USER, { id: invoices.id }, { db });
+
+    // 1. The tag document is gone, and the untouched ones survive.
+    expect(await fileTagRepository.findByIdAndUserId(invoices.id, USER)).toBeNull();
+    const remaining = (await fileTagRepository.findAllByUserId(USER)).map(t => t.name).sort();
+    expect(remaining).toEqual(['invoices-2024', 'receipts']);
+
+    // 2. No file of this user carries any casing of the name - soft-deleted included.
+    expect(await rawTagsOf(both)).toEqual(['receipts']);
+    expect(await rawTagsOf(casingVariant)).toEqual([]);
+    expect(await rawTagsOf(duplicated)).toEqual([]);
+    expect(await rawTagsOf(softDeleted)).toEqual(['receipts']);
+    // The substring neighbour is a different tag and must survive.
+    expect(await rawTagsOf(substringNeighbour)).toEqual(['invoices-2024']);
+    // One user's tag edit must not rewrite another user's file.
+    expect(await rawTagsOf(otherUsersFile.id as string)).toEqual(['invoices']);
+
+    // 3. The aggregate agrees: no bucket for the deleted name in any casing.
+    expect(await countOf('invoices')).toBe(0);
+    expect(await countOf('Invoices')).toBe(0);
+    expect(await countOf('receipts')).toBe(1);
+    expect(await countOf('invoices-2024')).toBe(1);
+
+    // 4. listFileTags never reports a count for a name no file carries.
+    const rows = await tagService.listFileTags(USER, SCOPE, {
+      db: { fileTags: fileTagRepository, fabFiles: fabFileRepository },
+    });
+    expect(rows.map(r => r.name).sort()).toEqual(['invoices-2024', 'receipts']);
+    expect(rows.find(r => r.name === 'receipts')?.fileCount).toBe(1);
+
+    // 5. The assertion the old code fails: undeleting must not bring the dead tag back.
+    await FabFile.collection.updateOne(
+      { _id: new mongoose.Types.ObjectId(softDeleted) },
+      { $unset: { deletedAt: '' } }
+    );
+    expect(await countOf('invoices')).toBe(0);
+    expect(await countOf('receipts')).toBe(2);
+  }, 30000);
+});

--- a/apps/client/server/services/tagRename.e2e.test.ts
+++ b/apps/client/server/services/tagRename.e2e.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+import { KnowledgeType } from '@bike4mind/common';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { FabFile, fabFileRepository, fileTagRepository } from '@bike4mind/database';
+import { tagService } from '@bike4mind/services';
+
+/**
+ * End-to-end guard that renaming a tag - INTO a name the user already has, with duplicates, a
+ * casing variant, a substring neighbour and a soft-deleted file all in play - leaves the tag
+ * documents, the tag names stored on the files, and the count aggregate all telling the same
+ * story. Renaming the document alone left the old name on every file, and the first-positional
+ * update this replaces would leave a duplicated name half-renamed.
+ *
+ * Drives the REAL tagService.update through the REAL repositories. Consumes the built dist, so
+ * `pnpm turbo:core:build` must be current.
+ */
+
+let mongoServer: MongoMemoryServer;
+
+const USER = 'rename-lifecycle-user';
+const OTHER_USER = 'someone-else';
+const SCOPE = { userGroups: [], dataLakeTags: [] };
+
+const db = { tags: fileTagRepository, fabFiles: fabFileRepository };
+
+// The Tag model is registered by importing @bike4mind/database but is not exported from it.
+const TagModel = () => mongoose.model('Tag');
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 30000);
+afterEach(async () => {
+  await Promise.all([FabFile.deleteMany({}), TagModel().deleteMany({})]);
+});
+
+const seedFile = async (tags: string[], overrides: Record<string, unknown> = {}) => {
+  const doc = await FabFile.create({
+    userId: USER,
+    fileName: 'seed.txt',
+    type: KnowledgeType.FILE,
+    mimeType: 'text/plain',
+    tags: tags.map(name => ({ name, strength: 1 })),
+    ...overrides,
+  });
+  return doc.id as string;
+};
+
+const rawTagsOf = async (id: string): Promise<string[]> => {
+  const raw = await FabFile.collection.findOne({ _id: new mongoose.Types.ObjectId(id) });
+  return ((raw?.tags ?? []) as { name: string }[]).map(t => t.name);
+};
+
+const countOf = async (tag: string): Promise<number> => {
+  const counts = await fabFileRepository.countFilesByTagForUser(USER, SCOPE);
+  return counts.find(c => c.tag === tag)?.count ?? 0;
+};
+
+describe('tagService.update keeps tag documents, file tags and the count aggregate in agreement', () => {
+  it('merges a rename onto an existing tag without leaving duplicates or orphans', async () => {
+    const invoices = await fileTagRepository.findOrCreateByNameAndUserId('invoices', USER, {});
+    const receipts = await fileTagRepository.findOrCreateByNameAndUserId('Receipts', USER, {});
+    await fileTagRepository.findOrCreateByNameAndUserId('invoices-2024', USER, {});
+
+    const plain = await seedFile(['invoices', 'misc']);
+    const casingVariant = await seedFile(['Invoices']);
+    const duplicated = await seedFile(['invoices', 'invoices']);
+    const alreadyHasTarget = await seedFile(['invoices', 'Receipts']);
+    const substringNeighbour = await seedFile(['invoices-2024']);
+    const softDeleted = await seedFile(['invoices'], { deletedAt: new Date() });
+    const otherUsersFile = await FabFile.create({
+      userId: OTHER_USER,
+      fileName: 'theirs.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: [{ name: 'invoices', strength: 1 }],
+    });
+
+    // Sanity: the fixture really does carry the pre-rename shape, so the assertions below cannot
+    // pass just because nothing was ever there.
+    expect(await countOf('invoices')).toBe(4);
+
+    await tagService.update(USER, { id: invoices.id, name: 'Receipts' }, { db });
+
+    // 1. Exactly one document folds to the target, it is the one that was renamed, and the
+    //    collider is gone.
+    const docs = await fileTagRepository.findAllByUserId(USER);
+    const folded = docs.filter(t => t.name.toLowerCase() === 'receipts');
+    expect(folded).toHaveLength(1);
+    expect(folded[0].id).toBe(invoices.id);
+    expect(folded[0].name).toBe('Receipts');
+    expect(await fileTagRepository.findByIdAndUserId(receipts.id, USER)).toBeNull();
+    expect(docs.map(t => t.name).sort()).toEqual(['Receipts', 'invoices-2024']);
+
+    // 2. Every file carries the new name exactly once - including the one that already had it.
+    expect(await rawTagsOf(plain)).toEqual(['Receipts', 'misc']);
+    expect(await rawTagsOf(casingVariant)).toEqual(['Receipts']);
+    expect(await rawTagsOf(duplicated)).toEqual(['Receipts']);
+    expect(await rawTagsOf(alreadyHasTarget)).toEqual(['Receipts']);
+    // A different tag that merely contains the old name must survive untouched.
+    expect(await rawTagsOf(substringNeighbour)).toEqual(['invoices-2024']);
+    expect(await rawTagsOf(softDeleted)).toEqual(['Receipts']);
+    // One user's rename must not rewrite another user's file.
+    expect(await rawTagsOf(otherUsersFile.id as string)).toEqual(['invoices']);
+
+    // 3. The aggregate agrees. Four live files carry it (the soft-deleted one is excluded); the
+    //    number is pinned so a future $unwind change cannot quietly double-count the two files
+    //    that briefly held the name twice.
+    expect(await countOf('invoices')).toBe(0);
+    expect(await countOf('Invoices')).toBe(0);
+    expect(await countOf('Receipts')).toBe(4);
+    expect(await countOf('invoices-2024')).toBe(1);
+
+    // 4. listFileTags reports the same number, and no row names a tag no file carries.
+    const rows = await tagService.listFileTags(USER, SCOPE, {
+      db: { fileTags: fileTagRepository, fabFiles: fabFileRepository },
+    });
+    expect(rows.map(r => r.name).sort()).toEqual(['Receipts', 'invoices-2024']);
+    expect(rows.find(r => r.name === 'Receipts')?.fileCount).toBe(4);
+
+    // 5. Re-running the identical request changes nothing, which is what makes the retry path in
+    //    the service safe.
+    await tagService.update(USER, { id: invoices.id, name: 'Receipts' }, { db });
+    expect(await rawTagsOf(duplicated)).toEqual(['Receipts']);
+    expect(await rawTagsOf(alreadyHasTarget)).toEqual(['Receipts']);
+    expect(await countOf('Receipts')).toBe(4);
+  }, 30000);
+});

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -486,12 +486,30 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   removeTagByUserId(userId: string, tag: string): Promise<number>;
 
   /**
-   * Update the tags for a user's files.
-   * @param userId - The ID of the user.
-   * @param tag - The tag to update.
-   * @returns A promise that resolves to the number of files.
+   * Rename one tag on every file a user owns, so renaming a tag document cannot leave the old name
+   * orphaned on the files that carried it. Matches the WHOLE name, case-insensitively, and renames
+   * EVERY occurrence in a file's tags array rather than only the first. Includes soft-deleted files
+   * and carries `primaryTag` across, for the same reasons as `removeTagByUserId`.
+   *
+   * May leave a file carrying `newTag` twice - once from the rename and once because it already
+   * had that tag. The caller resolves it with `dedupeTagByUserId`; doing both in one write would
+   * mean rewriting the whole array and losing the element-level concurrency this buys.
+   *
+   * @returns files modified by the rename (not the `primaryTag` sweep).
    */
   updateTagsByUserId(userId: string, tag: string, newTag: string): Promise<number>;
+
+  /**
+   * Collapse a repeated tag name to a single entry on every file of a user's that carries it more
+   * than once, normalizing the survivor to `name`'s casing. Keeps the FIRST occurrence and its
+   * other fields (`strength`, and anything this schemaless array happens to hold).
+   *
+   * The companion to `updateTagsByUserId`: renaming in place is what creates the duplicate, when a
+   * file already carried the target name.
+   *
+   * @returns the number of files that actually had a duplicate to collapse.
+   */
+  dedupeTagByUserId(userId: string, name: string): Promise<number>;
 
   /**
    * Atomically remove every tag matching one of `tagNames` (exact names) from one file's

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -401,10 +401,9 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   ) => Promise<{ data: IFabFileDocument[]; hasMore: boolean; total: number }>;
 
   /**
-   * Count the number of files by user id and tag.
-   * @param userId - The ID of the user.
-   * @param tag - The tag to count.
-   * @returns A promise that resolves to the number of files.
+   * Count a user's live files carrying one tag. Matches the WHOLE name, case-insensitively - a
+   * `test` tag does not count files tagged `testing`. Excludes soft-deleted files, unlike the
+   * write paths that keep tag names in step.
    */
   countByUserIdAndTag(userId: string, tag: string): Promise<number>;
 

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -469,10 +469,19 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   ): Promise<{ namespace: string; fileCount: number }[]>;
 
   /**
-   * Remove a tag from a user's files.
-   * @param userId - The ID of the user.
-   * @param tag - The tag to remove.
-   * @returns A promise that resolves to the number of files.
+   * Strip one tag name off every file a user owns, so deleting a tag document cannot leave the
+   * name orphaned on the files that carried it. Matches the WHOLE name, case-insensitively, and
+   * removes every occurrence - including a name a file carries twice.
+   *
+   * Includes SOFT-DELETED files, unlike most reads here: a soft-deleted file that kept the name
+   * would resurrect a tag that no longer exists the moment it is undeleted. Also clears
+   * `primaryTag` where it named the removed tag.
+   *
+   * Scoped to files the user OWNS. A file shared to them but owned by someone else keeps the
+   * name, which is correct - one user's tag edit must not rewrite another user's file.
+   *
+   * @returns files modified by the tag removal (not tags removed, and not counting the
+   * `primaryTag` sweep).
    */
   removeTagByUserId(userId: string, tag: string): Promise<number>;
 

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -74,6 +74,7 @@ export const createMockFabFileRepository = (): IFabFileRepository => ({
   countUniqueFilesByNamespaceForUser: vi.fn(),
   removeTagByUserId: vi.fn(),
   updateTagsByUserId: vi.fn(),
+  dedupeTagByUserId: vi.fn(),
   pullTagsByFabFileId: vi.fn(),
   pushTagsByFabFileId: vi.fn(),
   bulkUpdateTags: vi.fn(),

--- a/b4m-core/services/src/tagService/remove.test.ts
+++ b/b4m-core/services/src/tagService/remove.test.ts
@@ -144,4 +144,20 @@ describe('tagService - remove', () => {
     expect(mockFabFileRepo.removeTagByUserId).not.toHaveBeenCalled();
     expect(mockTagRepo.delete).not.toHaveBeenCalled();
   });
+
+  // The strip matches names case-insensitively, so a case-sensitive guard was walkable: create a
+  // `DATALAKE:acme` document (nothing refuses that at create time), delete it, and the strip pulls
+  // the real `datalake:acme` membership off every file the caller owns.
+  it.each(['DATALAKE:acme', 'DataLake:acme', '  datalake:acme'])(
+    'refuses the membership namespace spelled as %s',
+    async name => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc(name));
+
+      await expect(remove(userId, { id: existingTagId }, adapters)).rejects.toThrow(
+        'a data lake membership tag cannot be deleted here'
+      );
+      expect(mockFabFileRepo.removeTagByUserId).not.toHaveBeenCalled();
+      expect(mockTagRepo.delete).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/b4m-core/services/src/tagService/remove.test.ts
+++ b/b4m-core/services/src/tagService/remove.test.ts
@@ -1,21 +1,41 @@
 import { describe, it, expect, beforeEach, Mock, vi } from 'vitest';
 import { remove } from './remove';
-import { ITagRepository } from '@bike4mind/common';
+import { IFabFileRepository, ITagRepository } from '@bike4mind/common';
 
 describe('tagService - remove', () => {
   const userId = 'test-user-123';
   const existingTagId = 'existing-tag-123';
   let mockTagRepo: Pick<ITagRepository, 'findByIdAndUserId' | 'delete'>;
-  let adapters: { db: { tags: Pick<ITagRepository, 'findByIdAndUserId' | 'delete'> } };
+  let mockFabFileRepo: Pick<IFabFileRepository, 'removeTagByUserId'>;
+  let adapters: {
+    db: {
+      tags: Pick<ITagRepository, 'findByIdAndUserId' | 'delete'>;
+      fabFiles: Pick<IFabFileRepository, 'removeTagByUserId'>;
+    };
+  };
+
+  const tagDoc = (name: string) => ({
+    id: existingTagId,
+    userId,
+    name,
+    fileCount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActivityAt: new Date(),
+  });
 
   beforeEach(() => {
     mockTagRepo = {
       delete: vi.fn(),
       findByIdAndUserId: vi.fn(),
     };
+    mockFabFileRepo = {
+      removeTagByUserId: vi.fn().mockResolvedValue(0),
+    };
     adapters = {
       db: {
         tags: mockTagRepo,
+        fabFiles: mockFabFileRepo,
       },
     };
   });
@@ -26,17 +46,7 @@ describe('tagService - remove', () => {
       id: existingTagId,
     };
 
-    const existingTag = {
-      id: existingTagId,
-      userId,
-      name: 'Test Tag',
-      fileCount: 0,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      lastActivityAt: new Date(),
-    };
-
-    (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(existingTag);
+    (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc('Test Tag'));
     (mockTagRepo.delete as Mock).mockResolvedValueOnce(undefined);
 
     // Act
@@ -77,22 +87,61 @@ describe('tagService - remove', () => {
       id: existingTagId,
     };
 
-    const existingTag = {
-      id: existingTagId,
-      userId,
-      name: 'Test Tag',
-      fileCount: 0,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      lastActivityAt: new Date(),
-    };
-
-    (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(existingTag);
+    (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc('Test Tag'));
     (mockTagRepo.delete as Mock).mockRejectedValueOnce(new Error('Database error'));
 
     // Act & Assert
     await expect(remove(userId, params, adapters)).rejects.toThrow('Database error');
     expect(mockTagRepo.findByIdAndUserId).toHaveBeenCalledWith(existingTagId, userId);
     expect(mockTagRepo.delete).toHaveBeenCalledWith(existingTagId);
+  });
+
+  it('strips the name off the files, using the STORED name rather than anything from the request', async () => {
+    (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc('Invoices'));
+    (mockFabFileRepo.removeTagByUserId as Mock).mockResolvedValueOnce(4);
+
+    const result = await remove(userId, { id: existingTagId }, adapters);
+
+    expect(mockFabFileRepo.removeTagByUserId).toHaveBeenCalledWith(userId, 'Invoices');
+    expect(result).toEqual({ id: existingTagId, name: 'Invoices', filesUpdated: 4 });
+  });
+
+  // The order is the correctness argument: deleting the document first strands the files, because
+  // the name that would locate them is gone.
+  it('strips the files BEFORE deleting the tag document', async () => {
+    (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc('Invoices'));
+
+    await remove(userId, { id: existingTagId }, adapters);
+
+    const stripOrder = (mockFabFileRepo.removeTagByUserId as Mock).mock.invocationCallOrder[0];
+    const deleteOrder = (mockTagRepo.delete as Mock).mock.invocationCallOrder[0];
+    expect(stripOrder).toBeLessThan(deleteOrder);
+  });
+
+  it('leaves the tag document in place when the file strip fails, so the delete can be retried', async () => {
+    (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc('Invoices'));
+    (mockFabFileRepo.removeTagByUserId as Mock).mockRejectedValueOnce(new Error('Database error'));
+
+    await expect(remove(userId, { id: existingTagId }, adapters)).rejects.toThrow('Database error');
+    expect(mockTagRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it('does not strip files when the tag is not found', async () => {
+    (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(null);
+
+    await expect(remove(userId, { id: 'missing' }, adapters)).rejects.toThrow();
+    expect(mockFabFileRepo.removeTagByUserId).not.toHaveBeenCalled();
+  });
+
+  // Lake membership IS the tag string on the file, so stripping one would evict every file from
+  // the lake. Such a document is reachable: accepting an invite to a shared lake file mints one.
+  it('refuses a data lake membership tag before touching anything', async () => {
+    (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc('datalake:quarterly-reports'));
+
+    await expect(remove(userId, { id: existingTagId }, adapters)).rejects.toThrow(
+      'a data lake membership tag cannot be deleted here'
+    );
+    expect(mockFabFileRepo.removeTagByUserId).not.toHaveBeenCalled();
+    expect(mockTagRepo.delete).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/tagService/remove.ts
+++ b/b4m-core/services/src/tagService/remove.ts
@@ -1,6 +1,7 @@
 import { secureParameters, BadRequestError } from '@bike4mind/utils';
-import { IFabFileRepository, ITagRepository, isReservedTagPrefix } from '@bike4mind/common';
+import { IFabFileRepository, ITagRepository } from '@bike4mind/common';
 import { z } from 'zod';
+import { isDataLakeTagName } from './tagName';
 
 const tagRemoveSchema = z.object({
   id: z.string(),
@@ -35,7 +36,7 @@ export const remove = async (userId: string, params: TagRemoveParams, adapters: 
     throw new Error('Tag Service - Delete: Tag not found');
   }
 
-  if (isReservedTagPrefix(tag.name)) {
+  if (isDataLakeTagName(tag.name)) {
     throw new BadRequestError('Tag Service - Delete: a data lake membership tag cannot be deleted here');
   }
 

--- a/b4m-core/services/src/tagService/remove.ts
+++ b/b4m-core/services/src/tagService/remove.ts
@@ -1,5 +1,5 @@
-import { secureParameters } from '@bike4mind/utils';
-import { ITagRepository } from '@bike4mind/common';
+import { secureParameters, BadRequestError } from '@bike4mind/utils';
+import { IFabFileRepository, ITagRepository, isReservedTagPrefix } from '@bike4mind/common';
 import { z } from 'zod';
 
 const tagRemoveSchema = z.object({
@@ -9,9 +9,22 @@ const tagRemoveSchema = z.object({
 type TagRemoveParams = z.infer<typeof tagRemoveSchema>;
 
 interface TagRemoveAdapters {
-  db: { tags: Pick<ITagRepository, 'findByIdAndUserId' | 'delete'> };
+  db: {
+    tags: Pick<ITagRepository, 'findByIdAndUserId' | 'delete'>;
+    fabFiles: Pick<IFabFileRepository, 'removeTagByUserId'>;
+  };
 }
 
+/**
+ * Delete a tag document AND strip its name off every file that carried it. Deleting the document
+ * alone left the name orphaned: chips stopped rendering (they intersect tag documents with the
+ * file's strings) while the Workspaces tag counts, which read the strings, kept counting it.
+ *
+ * A `datalake:` name is refused. Membership in a lake IS that string on the file, so stripping one
+ * would silently evict every file from the lake. Such a document is reachable - accepting an
+ * invite to a shared lake file mints one for the invitee - so this is a real path, not a
+ * theoretical one.
+ */
 export const remove = async (userId: string, params: TagRemoveParams, adapters: TagRemoveAdapters) => {
   const { db } = adapters;
   const { id } = secureParameters(params, tagRemoveSchema);
@@ -22,5 +35,16 @@ export const remove = async (userId: string, params: TagRemoveParams, adapters: 
     throw new Error('Tag Service - Delete: Tag not found');
   }
 
+  if (isReservedTagPrefix(tag.name)) {
+    throw new BadRequestError('Tag Service - Delete: a data lake membership tag cannot be deleted here');
+  }
+
+  // Files first, tag document second. This order converges under retry: if the delete below fails,
+  // the document still names the tag, so re-running the same request finds the stragglers. The
+  // reverse order strands them - the name is gone from the only record that could locate them.
+  const filesUpdated = await db.fabFiles.removeTagByUserId(userId, tag.name);
+
   await db.tags.delete(tag.id);
+
+  return { id: tag.id, name: tag.name, filesUpdated };
 };

--- a/b4m-core/services/src/tagService/tagName.test.ts
+++ b/b4m-core/services/src/tagService/tagName.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { foldTagName, normalizeTagName } from './tagName';
+import { foldTagName, isDataLakeTagName, normalizeTagName } from './tagName';
 
 describe('tagName', () => {
   describe('normalizeTagName', () => {
@@ -36,6 +36,32 @@ describe('tagName', () => {
     it('uses locale-independent folding', () => {
       expect(foldTagName('INVOICES')).toBe('invoices');
       expect(foldTagName('I')).toBe('i');
+    });
+  });
+
+  describe('isDataLakeTagName', () => {
+    it('recognizes a membership tag', () => {
+      expect(isDataLakeTagName('datalake:acme')).toBe(true);
+    });
+
+    // The guard must fold, because the writes it gates match names case-insensitively. A
+    // case-sensitive guard would pass `DATALAKE:acme` through and then strip the real
+    // `datalake:acme` membership off every file the caller owns.
+    it('recognizes casing variants, which a case-sensitive check would let through', () => {
+      expect(isDataLakeTagName('DATALAKE:acme')).toBe(true);
+      expect(isDataLakeTagName('DataLake:acme')).toBe(true);
+      expect(isDataLakeTagName('dAtAlAkE:acme')).toBe(true);
+    });
+
+    it('sees through surrounding whitespace', () => {
+      expect(isDataLakeTagName('  datalake:acme  ')).toBe(true);
+      expect(isDataLakeTagName('\tDATALAKE:acme')).toBe(true);
+    });
+
+    it('leaves ordinary tags alone, including one that merely mentions the word', () => {
+      expect(isDataLakeTagName('invoices')).toBe(false);
+      expect(isDataLakeTagName('my-datalake:acme')).toBe(false);
+      expect(isDataLakeTagName('datalake')).toBe(false);
     });
   });
 });

--- a/b4m-core/services/src/tagService/tagName.test.ts
+++ b/b4m-core/services/src/tagService/tagName.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { foldTagName, normalizeTagName } from './tagName';
+
+describe('tagName', () => {
+  describe('normalizeTagName', () => {
+    it('trims surrounding whitespace', () => {
+      expect(normalizeTagName('  invoices  ')).toBe('invoices');
+    });
+
+    // Tag documents keep the casing they were created with, and a rename writes what the caller
+    // typed. Lowercasing here would silently rewrite every renamed tag.
+    it('preserves casing', () => {
+      expect(normalizeTagName('Invoices')).toBe('Invoices');
+      expect(normalizeTagName('INVOICES')).toBe('INVOICES');
+    });
+  });
+
+  describe('foldTagName', () => {
+    it('folds casing so two spellings of one tag compare equal', () => {
+      expect(foldTagName('Invoices')).toBe(foldTagName('invoices'));
+      expect(foldTagName('INVOICES')).toBe(foldTagName('invoices'));
+    });
+
+    it('trims before folding, so a padded name still collides', () => {
+      expect(foldTagName('  Invoices ')).toBe(foldTagName('invoices'));
+    });
+
+    it('keeps genuinely different names distinct', () => {
+      expect(foldTagName('invoices')).not.toBe(foldTagName('invoices-2024'));
+    });
+
+    // The fold must agree with listFileTags (which folds unclaimed aggregate buckets onto tag
+    // documents) and with the chip match in ItemActions. toLocaleLowerCase's dotless-i mapping
+    // varies by runtime locale, so a Turkish-locale server would fold `I` to a different
+    // codepoint than the browser and the two would stop agreeing on what one tag is.
+    it('uses locale-independent folding', () => {
+      expect(foldTagName('INVOICES')).toBe('invoices');
+      expect(foldTagName('I')).toBe('i');
+    });
+  });
+});

--- a/b4m-core/services/src/tagService/tagName.ts
+++ b/b4m-core/services/src/tagService/tagName.ts
@@ -17,7 +17,7 @@ export const normalizeTagName = (raw: string): string => raw.trim();
  * toLowerCase and not toLocaleLowerCase, whose dotless-i mapping varies by runtime locale - the
  * same reasoning listFileTags spells out where it folds bucket names.
  */
-export const foldTagName = (raw: string): string => raw.trim().toLowerCase();
+export const foldTagName = (raw: string): string => normalizeTagName(raw).toLowerCase();
 
 /**
  * True when a tag NAME sits in the lake-membership namespace. Folds case, because the writes this

--- a/b4m-core/services/src/tagService/tagName.ts
+++ b/b4m-core/services/src/tagService/tagName.ts
@@ -1,3 +1,5 @@
+import { DATALAKE_TAG_PREFIX } from '@bike4mind/common';
+
 /**
  * One definition of "the same tag", shared by every path that has to decide whether two tag names
  * collide. Must stay in sync with tagService/listFileTags (which folds unclaimed aggregate buckets
@@ -16,3 +18,14 @@ export const normalizeTagName = (raw: string): string => raw.trim();
  * same reasoning listFileTags spells out where it folds bucket names.
  */
 export const foldTagName = (raw: string): string => raw.trim().toLowerCase();
+
+/**
+ * True when a tag NAME sits in the lake-membership namespace. Folds case, because the writes this
+ * guards match names case-insensitively - a case-sensitive guard would let a `DATALAKE:acme`
+ * document through and then strip the real `datalake:acme` membership off every file.
+ *
+ * Deliberately NOT `isReservedTagPrefix`, which takes a lake's configured tag PREFIX and folds no
+ * case on purpose (see the note in dataLakeService/fallbackLakeTags). Same rule as the local
+ * `isDataLakeTag` in fabFileService/toggleTags; keep the two in sync.
+ */
+export const isDataLakeTagName = (raw: string): boolean => foldTagName(raw).startsWith(DATALAKE_TAG_PREFIX);

--- a/b4m-core/services/src/tagService/tagName.ts
+++ b/b4m-core/services/src/tagService/tagName.ts
@@ -1,0 +1,18 @@
+/**
+ * One definition of "the same tag", shared by every path that has to decide whether two tag names
+ * collide. Must stay in sync with tagService/listFileTags (which folds unclaimed aggregate buckets
+ * onto tag documents) and the chip match in Files/Browser/ItemActions - if the three disagree, a
+ * rename can merge two documents the UI still draws as separate, or leave two the UI draws as one.
+ */
+
+/**
+ * Trim only. Casing is deliberately preserved: tag documents keep whatever casing they were
+ * created with, and a rename writes the name as the caller spelled it.
+ */
+export const normalizeTagName = (raw: string): string => raw.trim();
+
+/**
+ * toLowerCase and not toLocaleLowerCase, whose dotless-i mapping varies by runtime locale - the
+ * same reasoning listFileTags spells out where it folds bucket names.
+ */
+export const foldTagName = (raw: string): string => raw.trim().toLowerCase();

--- a/b4m-core/services/src/tagService/update.test.ts
+++ b/b4m-core/services/src/tagService/update.test.ts
@@ -1,39 +1,52 @@
 import { describe, it, expect, beforeEach, Mock, vi } from 'vitest';
 import { update } from './update';
-import { ITagRepository } from '@bike4mind/common';
+import { IFabFileRepository, ITagRepository } from '@bike4mind/common';
 
 describe('tagService - update', () => {
   const userId = 'test-user-123';
   const existingTagId = 'existing-tag-123';
-  let mockTagRepo: Pick<ITagRepository, 'update' | 'findByIdAndUserId'>;
-  let adapters: { db: { tags: Pick<ITagRepository, 'update' | 'findByIdAndUserId'> } };
+  type TagRepo = Pick<ITagRepository, 'update' | 'findByIdAndUserId' | 'findAllByUserId' | 'delete'>;
+  type FabFileRepo = Pick<IFabFileRepository, 'updateTagsByUserId' | 'dedupeTagByUserId'>;
+  let mockTagRepo: TagRepo;
+  let mockFabFileRepo: FabFileRepo;
+  let adapters: { db: { tags: TagRepo; fabFiles: FabFileRepo } };
+
+  const tagDoc = (overrides: Record<string, unknown> = {}) => ({
+    id: existingTagId,
+    userId,
+    name: 'Original Name',
+    icon: 'folder',
+    description: 'Original Description',
+    color: '#000000',
+    fileCount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActivityAt: new Date(),
+    ...overrides,
+  });
 
   beforeEach(() => {
     mockTagRepo = {
       update: vi.fn(),
       findByIdAndUserId: vi.fn(),
+      findAllByUserId: vi.fn().mockResolvedValue([]),
+      delete: vi.fn(),
+    };
+    mockFabFileRepo = {
+      updateTagsByUserId: vi.fn().mockResolvedValue(0),
+      dedupeTagByUserId: vi.fn().mockResolvedValue(0),
     };
     adapters = {
       db: {
         tags: mockTagRepo,
+        fabFiles: mockFabFileRepo,
       },
     };
   });
 
   it('should update a tag with partial parameters', async () => {
     // Arrange
-    const existingTag = {
-      id: existingTagId,
-      userId,
-      name: 'Original Name',
-      icon: '📁',
-      description: 'Original Description',
-      color: '#000000',
-      fileCount: 0,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      lastActivityAt: new Date(),
-    };
+    const existingTag = tagDoc();
 
     const params = {
       id: existingTagId,
@@ -75,27 +88,17 @@ describe('tagService - update', () => {
     // Act & Assert
     await expect(update(userId, params, adapters)).rejects.toThrow('Tag Service - Update: Tag not found');
     expect(mockTagRepo.update).not.toHaveBeenCalled();
+    expect(mockFabFileRepo.updateTagsByUserId).not.toHaveBeenCalled();
   });
 
   it('should update a tag with all optional parameters', async () => {
     // Arrange
-    const existingTag = {
-      id: existingTagId,
-      userId,
-      name: 'Original Name',
-      icon: '📁',
-      description: 'Original Description',
-      color: '#000000',
-      fileCount: 0,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      lastActivityAt: new Date(),
-    };
+    const existingTag = tagDoc();
 
     const params = {
       id: existingTagId,
       name: 'Updated Name',
-      icon: '📂',
+      icon: 'folder-open',
       description: 'Updated Description',
       color: '#FF0000',
     };
@@ -111,7 +114,7 @@ describe('tagService - update', () => {
     expect(mockTagRepo.update).toHaveBeenCalledWith({
       id: existingTagId,
       name: 'Updated Name',
-      icon: '📂',
+      icon: 'folder-open',
       description: 'Updated Description',
       color: '#FF0000',
       updatedAt: expect.any(Date),
@@ -119,7 +122,7 @@ describe('tagService - update', () => {
     expect(result).toEqual({
       id: existingTagId,
       name: 'Updated Name',
-      icon: '📂',
+      icon: 'folder-open',
       description: 'Updated Description',
       color: '#FF0000',
       updatedAt: expect.any(Date),
@@ -136,5 +139,194 @@ describe('tagService - update', () => {
     // Act & Assert
     // @ts-expect-error Testing invalid types
     await expect(update(userId, params, adapters)).rejects.toThrow('Invalid input: expected string, received number');
+  });
+
+  describe('carrying the rename onto the files', () => {
+    it('renames the tag on the files, from the stored name to the new one', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+
+      await update(userId, { id: existingTagId, name: 'receipts' }, adapters);
+
+      expect(mockFabFileRepo.updateTagsByUserId).toHaveBeenCalledWith(userId, 'invoices', 'receipts');
+    });
+
+    // The client PUTs the whole tag, so `name` is present even on a colour-only edit. Touching
+    // files on every such request would rewrite the whole collection for a palette change.
+    it('touches no files when only the colour changes', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+
+      await update(userId, { id: existingTagId, name: 'invoices', color: '#FF0000' }, adapters);
+
+      expect(mockFabFileRepo.updateTagsByUserId).not.toHaveBeenCalled();
+      expect(mockFabFileRepo.dedupeTagByUserId).not.toHaveBeenCalled();
+      expect(mockTagRepo.update).toHaveBeenCalled();
+    });
+
+    // The files store the old casing, so this IS a rename even though the names fold equal.
+    it('rewrites the files for a case-only rename', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+
+      await update(userId, { id: existingTagId, name: 'Invoices' }, adapters);
+
+      expect(mockFabFileRepo.updateTagsByUserId).toHaveBeenCalledWith(userId, 'invoices', 'Invoices');
+    });
+
+    it('trims the incoming name before comparing, so padding alone is not a rename', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+
+      await update(userId, { id: existingTagId, name: '  invoices  ' }, adapters);
+
+      expect(mockFabFileRepo.updateTagsByUserId).not.toHaveBeenCalled();
+      expect(mockTagRepo.update).toHaveBeenCalledWith(expect.objectContaining({ name: 'invoices' }));
+    });
+
+    // Renaming in place leaves two identical entries on any file that already had the target name,
+    // whether or not a tag document collided.
+    it('de-dupes whenever files moved, even with no colliding tag document', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+      (mockFabFileRepo.updateTagsByUserId as Mock).mockResolvedValueOnce(3);
+
+      await update(userId, { id: existingTagId, name: 'receipts' }, adapters);
+
+      expect(mockFabFileRepo.dedupeTagByUserId).toHaveBeenCalledWith(userId, 'receipts');
+    });
+
+    it('skips the de-dupe when the rename moved no files', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+      (mockFabFileRepo.updateTagsByUserId as Mock).mockResolvedValueOnce(0);
+
+      await update(userId, { id: existingTagId, name: 'receipts' }, adapters);
+
+      expect(mockFabFileRepo.dedupeTagByUserId).not.toHaveBeenCalled();
+    });
+
+    // Retry-convergence: if the document write fails, the source still names the old tag, so the
+    // same request re-run can still find the stragglers.
+    it('rewrites the files BEFORE writing the tag document', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+      (mockFabFileRepo.updateTagsByUserId as Mock).mockResolvedValueOnce(1);
+
+      await update(userId, { id: existingTagId, name: 'receipts' }, adapters);
+
+      const renameOrder = (mockFabFileRepo.updateTagsByUserId as Mock).mock.invocationCallOrder[0];
+      const dedupeOrder = (mockFabFileRepo.dedupeTagByUserId as Mock).mock.invocationCallOrder[0];
+      const writeOrder = (mockTagRepo.update as Mock).mock.invocationCallOrder[0];
+      expect(renameOrder).toBeLessThan(dedupeOrder);
+      expect(dedupeOrder).toBeLessThan(writeOrder);
+    });
+
+    it('leaves the tag document naming the old tag when the file rename fails', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+      (mockFabFileRepo.updateTagsByUserId as Mock).mockRejectedValueOnce(new Error('Database error'));
+
+      await expect(update(userId, { id: existingTagId, name: 'receipts' }, adapters)).rejects.toThrow('Database error');
+      expect(mockTagRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('merging onto an existing tag', () => {
+    const collider = (id: string, name: string) => ({ ...tagDoc({ name }), id });
+
+    it('deletes the colliding document and keeps the renamed one', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+      (mockTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([
+        tagDoc({ name: 'invoices' }),
+        collider('other-tag', 'receipts'),
+      ]);
+
+      const result = await update(userId, { id: existingTagId, name: 'receipts' }, adapters);
+
+      expect(mockTagRepo.delete).toHaveBeenCalledWith('other-tag');
+      expect(mockTagRepo.delete).toHaveBeenCalledTimes(1);
+      // The surviving row keeps the requested id, which is what the client's optimistic update
+      // matches on.
+      expect(result.id).toBe(existingTagId);
+      expect(result.name).toBe('receipts');
+    });
+
+    it('collides case-insensitively, matching how the UI decides two tags are the same', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+      (mockTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([collider('other-tag', 'RECEIPTS')]);
+
+      await update(userId, { id: existingTagId, name: 'receipts' }, adapters);
+
+      expect(mockTagRepo.delete).toHaveBeenCalledWith('other-tag');
+    });
+
+    // The unique index has no collation, so `Foo` and `FOO` are two legitimate documents and both
+    // must go.
+    it('deletes every collider, not just the first', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+      (mockTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([
+        collider('tag-a', 'Receipts'),
+        collider('tag-b', 'RECEIPTS'),
+      ]);
+
+      await update(userId, { id: existingTagId, name: 'receipts' }, adapters);
+
+      expect(mockTagRepo.delete).toHaveBeenCalledWith('tag-a');
+      expect(mockTagRepo.delete).toHaveBeenCalledWith('tag-b');
+    });
+
+    it('never deletes the tag being renamed', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+      (mockTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([tagDoc({ name: 'Invoices' })]);
+
+      await update(userId, { id: existingTagId, name: 'Invoices' }, adapters);
+
+      expect(mockTagRepo.delete).not.toHaveBeenCalled();
+    });
+
+    // The unique index would reject the rename while the collider still exists.
+    it('deletes the collider BEFORE writing the renamed document', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+      (mockTagRepo.findAllByUserId as Mock).mockResolvedValueOnce([collider('other-tag', 'receipts')]);
+
+      await update(userId, { id: existingTagId, name: 'receipts' }, adapters);
+
+      const deleteOrder = (mockTagRepo.delete as Mock).mock.invocationCallOrder[0];
+      const writeOrder = (mockTagRepo.update as Mock).mock.invocationCallOrder[0];
+      expect(deleteOrder).toBeLessThan(writeOrder);
+    });
+
+    it('does not look for colliders when nothing is being renamed', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+
+      await update(userId, { id: existingTagId, color: '#FF0000' }, adapters);
+
+      expect(mockTagRepo.findAllByUserId).not.toHaveBeenCalled();
+      expect(mockTagRepo.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('guards', () => {
+    it('rejects an empty name before touching anything', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
+
+      await expect(update(userId, { id: existingTagId, name: '   ' }, adapters)).rejects.toThrow();
+      expect(mockFabFileRepo.updateTagsByUserId).not.toHaveBeenCalled();
+      expect(mockTagRepo.update).not.toHaveBeenCalled();
+    });
+
+    // Lake membership IS the tag string on the file, so renaming one would evict every file.
+    it('refuses to rename a data lake membership tag', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'datalake:reports' }));
+
+      await expect(update(userId, { id: existingTagId, name: 'reports' }, adapters)).rejects.toThrow(
+        'a data lake membership tag cannot be renamed here'
+      );
+      expect(mockFabFileRepo.updateTagsByUserId).not.toHaveBeenCalled();
+      expect(mockTagRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('refuses to rename an ordinary tag INTO the data lake namespace', async () => {
+      (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'reports' }));
+
+      await expect(update(userId, { id: existingTagId, name: 'datalake:reports' }, adapters)).rejects.toThrow(
+        'a data lake membership tag cannot be renamed here'
+      );
+      expect(mockFabFileRepo.updateTagsByUserId).not.toHaveBeenCalled();
+      expect(mockTagRepo.update).not.toHaveBeenCalled();
+    });
   });
 });

--- a/b4m-core/services/src/tagService/update.test.ts
+++ b/b4m-core/services/src/tagService/update.test.ts
@@ -328,5 +328,34 @@ describe('tagService - update', () => {
       expect(mockFabFileRepo.updateTagsByUserId).not.toHaveBeenCalled();
       expect(mockTagRepo.update).not.toHaveBeenCalled();
     });
+
+    // The rename matches names case-insensitively, so a case-sensitive guard was walkable in both
+    // directions: renaming a `DATALAKE:acme` document rewrites the real membership tag, and
+    // renaming an ordinary tag to `DATALAKE:acme` injects files into the lake.
+    it.each(['DATALAKE:acme', 'DataLake:acme', '  datalake:acme'])(
+      'refuses the membership namespace spelled as %s on the stored name',
+      async name => {
+        (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name }));
+
+        await expect(update(userId, { id: existingTagId, name: 'harmless' }, adapters)).rejects.toThrow(
+          'a data lake membership tag cannot be renamed here'
+        );
+        expect(mockFabFileRepo.updateTagsByUserId).not.toHaveBeenCalled();
+        expect(mockTagRepo.update).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each(['DATALAKE:acme', 'DataLake:acme'])(
+      'refuses the membership namespace spelled as %s on the new name',
+      async name => {
+        (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'reports' }));
+
+        await expect(update(userId, { id: existingTagId, name }, adapters)).rejects.toThrow(
+          'a data lake membership tag cannot be renamed here'
+        );
+        expect(mockFabFileRepo.updateTagsByUserId).not.toHaveBeenCalled();
+        expect(mockTagRepo.update).not.toHaveBeenCalled();
+      }
+    );
   });
 });

--- a/b4m-core/services/src/tagService/update.test.ts
+++ b/b4m-core/services/src/tagService/update.test.ts
@@ -191,13 +191,16 @@ describe('tagService - update', () => {
       expect(mockFabFileRepo.dedupeTagByUserId).toHaveBeenCalledWith(userId, 'receipts');
     });
 
-    it('skips the de-dupe when the rename moved no files', async () => {
+    // Deliberately NOT gated on this call's file count. A previous attempt may have renamed the
+    // files and died before de-duping; the retry's rename then matches nothing, and a count-gated
+    // de-dupe would skip the duplicate it left behind.
+    it('de-dupes even when the rename moved no files, so a retry still clears a stranded duplicate', async () => {
       (mockTagRepo.findByIdAndUserId as Mock).mockResolvedValueOnce(tagDoc({ name: 'invoices' }));
       (mockFabFileRepo.updateTagsByUserId as Mock).mockResolvedValueOnce(0);
 
       await update(userId, { id: existingTagId, name: 'receipts' }, adapters);
 
-      expect(mockFabFileRepo.dedupeTagByUserId).not.toHaveBeenCalled();
+      expect(mockFabFileRepo.dedupeTagByUserId).toHaveBeenCalledWith(userId, 'receipts');
     });
 
     // Retry-convergence: if the document write fails, the source still names the old tag, so the

--- a/b4m-core/services/src/tagService/update.ts
+++ b/b4m-core/services/src/tagService/update.ts
@@ -1,7 +1,7 @@
-import { IFabFileRepository, ITagRepository, isReservedTagPrefix } from '@bike4mind/common';
+import { IFabFileRepository, ITagRepository } from '@bike4mind/common';
 import { secureParameters, BadRequestError } from '@bike4mind/utils';
 import { z } from 'zod';
-import { foldTagName, normalizeTagName } from './tagName';
+import { foldTagName, isDataLakeTagName, normalizeTagName } from './tagName';
 
 const tagUpdateSchema = z.object({
   id: z.string(),
@@ -44,7 +44,7 @@ export const update = async (userId: string, params: TagUpdateParams, adapters: 
 
   const newName = rest.name === undefined ? undefined : normalizeTagName(rest.name);
 
-  if (isReservedTagPrefix(tag.name) || (newName !== undefined && isReservedTagPrefix(newName))) {
+  if (isDataLakeTagName(tag.name) || (newName !== undefined && isDataLakeTagName(newName))) {
     throw new BadRequestError('Tag Service - Update: a data lake membership tag cannot be renamed here');
   }
 

--- a/b4m-core/services/src/tagService/update.ts
+++ b/b4m-core/services/src/tagService/update.ts
@@ -63,13 +63,14 @@ export const update = async (userId: string, params: TagUpdateParams, adapters: 
     // Renaming the document first strands them - the next attempt reads the new name and has
     // nothing left to search for. Not wrapped in a transaction: the rename can touch thousands of
     // files and would hold locks against the 16MB/60s ceiling, and every write here is idempotent.
-    const filesUpdated = await db.fabFiles.updateTagsByUserId(userId, tag.name, newName);
+    await db.fabFiles.updateTagsByUserId(userId, tag.name, newName);
 
     // Renaming in place is what creates a duplicate, on any file that already carried the target
-    // name - so this runs whenever files moved, not only when a tag document collided.
-    if (filesUpdated > 0) {
-      await db.fabFiles.dedupeTagByUserId(userId, newName);
-    }
+    // name. Deliberately NOT gated on the rename having moved files this time: if a previous
+    // attempt renamed the files and then died here, the retry's rename matches nothing and a
+    // count-gated dedupe would skip the duplicate it left behind, stranding it. Its own $expr
+    // prefilter makes the no-duplicate case an empty write, so running it every rename is cheap.
+    await db.fabFiles.dedupeTagByUserId(userId, newName);
 
     // Before the update below, not after: the unique index on { userId, name } has no collation, so
     // an exactly-colliding document makes that write fail while this one still exists. There can be

--- a/b4m-core/services/src/tagService/update.ts
+++ b/b4m-core/services/src/tagService/update.ts
@@ -1,10 +1,11 @@
-import { ITagRepository } from '@bike4mind/common';
-import { secureParameters } from '@bike4mind/utils';
+import { IFabFileRepository, ITagRepository, isReservedTagPrefix } from '@bike4mind/common';
+import { secureParameters, BadRequestError } from '@bike4mind/utils';
 import { z } from 'zod';
+import { foldTagName, normalizeTagName } from './tagName';
 
 const tagUpdateSchema = z.object({
   id: z.string(),
-  name: z.string().optional(),
+  name: z.string().trim().min(1).optional(),
   icon: z.string().optional(),
   description: z.string().optional(),
   color: z.string().optional(),
@@ -14,10 +15,23 @@ export type TagUpdateParams = z.infer<typeof tagUpdateSchema>;
 
 interface TagUpdateAdapters {
   db: {
-    tags: Pick<ITagRepository, 'update' | 'findByIdAndUserId'>;
+    tags: Pick<ITagRepository, 'update' | 'findByIdAndUserId' | 'findAllByUserId' | 'delete'>;
+    fabFiles: Pick<IFabFileRepository, 'updateTagsByUserId' | 'dedupeTagByUserId'>;
   };
 }
 
+/**
+ * Update a tag document AND, when the name changes, carry the rename onto every file that stored
+ * the old name. Writing the document alone left the old string on the files, so the tag read zero
+ * files while the Workspaces counts still showed the orphan under its old name.
+ *
+ * Renaming ONTO a name the user already has merges the two: the renamed document survives (it
+ * carries the caller's intended icon/colour/description, and keeping its id is what lets the
+ * client's optimistic row update match), and the colliding documents are deleted. A file that
+ * carried both names ends up with one entry, not two.
+ *
+ * A `datalake:` name is refused on either side - see tagService/remove.
+ */
 export const update = async (userId: string, params: TagUpdateParams, adapters: TagUpdateAdapters) => {
   const { db } = adapters;
   const { id, ...rest } = secureParameters(params, tagUpdateSchema);
@@ -28,9 +42,47 @@ export const update = async (userId: string, params: TagUpdateParams, adapters: 
     throw new Error('Tag Service - Update: Tag not found');
   }
 
+  const newName = rest.name === undefined ? undefined : normalizeTagName(rest.name);
+
+  if (isReservedTagPrefix(tag.name) || (newName !== undefined && isReservedTagPrefix(newName))) {
+    throw new BadRequestError('Tag Service - Update: a data lake membership tag cannot be renamed here');
+  }
+
+  // Exact comparison, deliberately. The client PUTs the whole tag, so an icon-only or colour-only
+  // edit still carries `name` and must not touch a single file; but `foo` -> `Foo` is a real
+  // rename, because the files store the old casing.
+  const renaming = newName !== undefined && newName !== tag.name;
+
+  if (renaming) {
+    const colliders = (await db.tags.findAllByUserId(userId)).filter(
+      t => t.id !== tag.id && foldTagName(t.name) === foldTagName(newName)
+    );
+
+    // Files before documents. This order converges under retry: if a write below fails, the source
+    // document still holds the old name, so re-running the same request finds any straggler.
+    // Renaming the document first strands them - the next attempt reads the new name and has
+    // nothing left to search for. Not wrapped in a transaction: the rename can touch thousands of
+    // files and would hold locks against the 16MB/60s ceiling, and every write here is idempotent.
+    const filesUpdated = await db.fabFiles.updateTagsByUserId(userId, tag.name, newName);
+
+    // Renaming in place is what creates a duplicate, on any file that already carried the target
+    // name - so this runs whenever files moved, not only when a tag document collided.
+    if (filesUpdated > 0) {
+      await db.fabFiles.dedupeTagByUserId(userId, newName);
+    }
+
+    // Before the update below, not after: the unique index on { userId, name } has no collation, so
+    // an exactly-colliding document makes that write fail while this one still exists. There can be
+    // more than one collider, for the same reason - `Foo` and `FOO` are separate documents.
+    for (const collider of colliders) {
+      await db.tags.delete(collider.id);
+    }
+  }
+
   const buildData = {
     id,
     ...rest,
+    ...(newName === undefined ? {} : { name: newName }),
     updatedAt: new Date(),
   };
 

--- a/packages/database/src/__tests__/fabFileDedupeTagByUserId.test.ts
+++ b/packages/database/src/__tests__/fabFileDedupeTagByUserId.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+import { FabFile, fabFileRepository } from '../models/content/FabFileModel';
+import { setupMongoTest } from '../__test__/utils';
+import { KnowledgeType } from '@bike4mind/common';
+
+/**
+ * Real Mongo: this method is an aggregation-pipeline update, so what it actually does to a stored
+ * array is the only thing worth asserting. Renaming with `$[elem]` collapses two distinct names
+ * onto one, and this is what removes the resulting duplicate - the issue's "a file carrying the
+ * old name twice ends up fully updated".
+ */
+setupMongoTest();
+
+describe('FabFileRepository.dedupeTagByUserId', () => {
+  const userId = 'dedupe-tag-user';
+  const otherUserId = 'someone-else';
+
+  const seedRaw = async (tags: Record<string, unknown>[]): Promise<string> => {
+    const doc = await FabFile.create({
+      userId,
+      fileName: 'seed.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags,
+    });
+    return doc.id as string;
+  };
+  const seed = (names: string[]) => seedRaw(names.map(name => ({ name, strength: 1 })));
+
+  const rawOf = async (id: string) => FabFile.collection.findOne({ _id: new mongoose.Types.ObjectId(id) });
+  const rawTagsOf = async (id: string) => ((await rawOf(id))?.tags ?? []) as Record<string, unknown>[];
+  const namesOf = async (id: string) => (await rawTagsOf(id)).map(t => t.name);
+
+  beforeEach(async () => {
+    await FabFile.deleteMany({});
+  });
+
+  it('collapses a repeated name to a single entry', async () => {
+    const file = await seed(['receipts', 'misc', 'receipts']);
+
+    const modified = await fabFileRepository.dedupeTagByUserId(userId, 'receipts');
+
+    expect(modified).toBe(1);
+    expect(await namesOf(file)).toEqual(['receipts', 'misc']);
+  });
+
+  it('keeps the FIRST occurrence, with its strength and any undeclared fields', async () => {
+    const file = await seedRaw([
+      { name: 'receipts', strength: 9, source: 'import' },
+      { name: 'misc', strength: 2 },
+      { name: 'receipts', strength: 1 },
+    ]);
+
+    await fabFileRepository.dedupeTagByUserId(userId, 'receipts');
+
+    expect(await rawTagsOf(file)).toEqual([
+      { name: 'receipts', strength: 9, source: 'import' },
+      { name: 'misc', strength: 2 },
+    ]);
+  });
+
+  it('collapses casing variants and normalizes the survivor to the passed casing', async () => {
+    const file = await seed(['Receipts', 'misc', 'RECEIPTS']);
+
+    await fabFileRepository.dedupeTagByUserId(userId, 'Receipts');
+
+    expect(await namesOf(file)).toEqual(['Receipts', 'misc']);
+  });
+
+  it('leaves the relative order of the other tags intact', async () => {
+    const file = await seed(['a', 'receipts', 'b', 'receipts', 'c']);
+
+    await fabFileRepository.dedupeTagByUserId(userId, 'receipts');
+
+    expect(await namesOf(file)).toEqual(['a', 'receipts', 'b', 'c']);
+  });
+
+  it('does not rewrite a file that carries the name only once', async () => {
+    const file = await seed(['receipts', 'misc']);
+    const before = await rawTagsOf(file);
+
+    const modified = await fabFileRepository.dedupeTagByUserId(userId, 'receipts');
+
+    expect(modified).toBe(0);
+    expect(await rawTagsOf(file)).toEqual(before);
+  });
+
+  // `tags` is [Object] with no sub-schema, so legacy rows really do carry elements with a missing
+  // or non-string name. One of those must not decide the outcome for the whole user.
+  it('survives a malformed tag element and still de-dupes the rest', async () => {
+    const file = await seedRaw([
+      { name: 'receipts', strength: 1 },
+      { strength: 4 },
+      { name: 42 },
+      { name: 'receipts', strength: 1 },
+    ]);
+
+    const modified = await fabFileRepository.dedupeTagByUserId(userId, 'receipts');
+
+    expect(modified).toBe(1);
+    expect(await namesOf(file)).toEqual(['receipts', undefined, 42]);
+  });
+
+  it('treats regex metacharacters in the name literally', async () => {
+    const file = await seed(['.*', 'misc', '.*']);
+    const neighbour = await seed(['literal', 'literal']);
+
+    await fabFileRepository.dedupeTagByUserId(userId, '.*');
+
+    expect(await namesOf(file)).toEqual(['.*', 'misc']);
+    // A match-everything regex would have collapsed this file too.
+    expect(await namesOf(neighbour)).toEqual(['literal', 'literal']);
+  });
+
+  it("leaves another user's files alone", async () => {
+    const theirs = await FabFile.create({
+      userId: otherUserId,
+      fileName: 'theirs.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: [
+        { name: 'receipts', strength: 1 },
+        { name: 'receipts', strength: 1 },
+      ],
+    });
+
+    const modified = await fabFileRepository.dedupeTagByUserId(userId, 'receipts');
+
+    expect(modified).toBe(0);
+    expect(await namesOf(theirs.id as string)).toEqual(['receipts', 'receipts']);
+  });
+
+  it('reports zero for an empty name rather than matching everything', async () => {
+    const file = await seed(['receipts', 'receipts']);
+
+    expect(await fabFileRepository.dedupeTagByUserId(userId, '')).toBe(0);
+    expect(await namesOf(file)).toEqual(['receipts', 'receipts']);
+  });
+});

--- a/packages/database/src/__tests__/fabFileRemoveTagByUserId.test.ts
+++ b/packages/database/src/__tests__/fabFileRemoveTagByUserId.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FabFile, fabFileRepository } from '../models/content/FabFileModel';
+import { setupMongoTest } from '../__test__/utils';
+import { KnowledgeType } from '@bike4mind/common';
+
+/**
+ * Real Mongo, not a mock: every fact here is about what the $pull actually does to a stored array,
+ * which a mock can only assert by restating the implementation. Two of them are the bugs this
+ * method shipped with - an unanchored regex that ate neighbouring tag names, and a `deletedAt`
+ * filter that let an undelete resurrect a deleted tag.
+ */
+setupMongoTest();
+
+describe('FabFileRepository.removeTagByUserId', () => {
+  const userId = 'remove-tag-user';
+  const otherUserId = 'someone-else';
+
+  const seed = async (tags: string[], overrides: Record<string, unknown> = {}): Promise<string> => {
+    const doc = await FabFile.create({
+      userId,
+      fileName: 'seed.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: tags.map(name => ({ name, strength: 1 })),
+      ...overrides,
+    });
+    return doc.id as string;
+  };
+
+  // Reads straight from the collection: a soft-deleted document is invisible to the model's
+  // find hooks, so asserting through FabFile.findById would pass whether or not the tag was
+  // actually stripped.
+  const rawTagsOf = async (id: string): Promise<string[]> => {
+    const raw = await FabFile.collection.findOne({ _id: FabFile.base.Types.ObjectId.createFromHexString(id) });
+    return ((raw?.tags ?? []) as { name: string }[]).map(t => t.name);
+  };
+
+  beforeEach(async () => {
+    await FabFile.deleteMany({});
+  });
+
+  it('removes the tag from every file that carries it', async () => {
+    const a = await seed(['invoices', 'receipts']);
+    const b = await seed(['invoices']);
+    const untouched = await seed(['receipts']);
+
+    const modified = await fabFileRepository.removeTagByUserId(userId, 'invoices');
+
+    expect(modified).toBe(2);
+    expect(await rawTagsOf(a)).toEqual(['receipts']);
+    expect(await rawTagsOf(b)).toEqual([]);
+    expect(await rawTagsOf(untouched)).toEqual(['receipts']);
+  });
+
+  it('strips a soft-deleted file too, so an undelete cannot resurrect the tag', async () => {
+    const deleted = await seed(['invoices', 'receipts'], { deletedAt: new Date() });
+
+    await fabFileRepository.removeTagByUserId(userId, 'invoices');
+
+    expect(await rawTagsOf(deleted)).toEqual(['receipts']);
+  });
+
+  it('matches the whole name, so a tag is not removed by a neighbour that contains it', async () => {
+    const neighbours = await seed(['test', 'testing', 'unit-test']);
+
+    await fabFileRepository.removeTagByUserId(userId, 'test');
+
+    expect(await rawTagsOf(neighbours)).toEqual(['testing', 'unit-test']);
+  });
+
+  it('treats regex metacharacters in the name literally', async () => {
+    const file = await seed(['.*', 'invoices']);
+
+    const modified = await fabFileRepository.removeTagByUserId(userId, '.*');
+
+    expect(modified).toBe(1);
+    expect(await rawTagsOf(file)).toEqual(['invoices']);
+  });
+
+  it('removes every occurrence when one file carries the name more than once', async () => {
+    const dup = await seed(['invoices', 'misc', 'invoices']);
+
+    await fabFileRepository.removeTagByUserId(userId, 'invoices');
+
+    expect(await rawTagsOf(dup)).toEqual(['misc']);
+  });
+
+  it('removes casing variants, matching how the UI decides two tags are the same', async () => {
+    const mixed = await seed(['Invoices', 'invoices', 'misc']);
+
+    await fabFileRepository.removeTagByUserId(userId, 'INVOICES');
+
+    expect(await rawTagsOf(mixed)).toEqual(['misc']);
+  });
+
+  it("leaves another user's files alone", async () => {
+    const theirs = await FabFile.create({
+      userId: otherUserId,
+      fileName: 'theirs.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: [{ name: 'invoices', strength: 1 }],
+    });
+
+    const modified = await fabFileRepository.removeTagByUserId(userId, 'invoices');
+
+    expect(modified).toBe(0);
+    expect(await rawTagsOf(theirs.id as string)).toEqual(['invoices']);
+  });
+
+  it('clears primaryTag only on the files where it named the removed tag', async () => {
+    const pointed = await seed(['invoices'], { primaryTag: 'invoices' });
+    const other = await seed(['invoices', 'receipts'], { primaryTag: 'receipts' });
+
+    await fabFileRepository.removeTagByUserId(userId, 'invoices');
+
+    const pointedRaw = await FabFile.collection.findOne({
+      _id: FabFile.base.Types.ObjectId.createFromHexString(pointed),
+    });
+    const otherRaw = await FabFile.collection.findOne({
+      _id: FabFile.base.Types.ObjectId.createFromHexString(other),
+    });
+    expect(pointedRaw?.primaryTag).toBeUndefined();
+    expect(otherRaw?.primaryTag).toBe('receipts');
+  });
+
+  it('reports zero and writes nothing when no file carries the tag', async () => {
+    const file = await seed(['receipts']);
+
+    const modified = await fabFileRepository.removeTagByUserId(userId, 'invoices');
+
+    expect(modified).toBe(0);
+    expect(await rawTagsOf(file)).toEqual(['receipts']);
+  });
+
+  it('reports zero for an empty name rather than building a match-everything regex', async () => {
+    const file = await seed(['invoices']);
+
+    const modified = await fabFileRepository.removeTagByUserId(userId, '');
+
+    expect(modified).toBe(0);
+    expect(await rawTagsOf(file)).toEqual(['invoices']);
+  });
+});

--- a/packages/database/src/__tests__/fabFileSearchQuery.test.ts
+++ b/packages/database/src/__tests__/fabFileSearchQuery.test.ts
@@ -523,6 +523,34 @@ describe('buildFabFileSearchQuery', () => {
       expect(patterns[0].test('Research')).toBe(true);
       expect(patterns[1].test('Robotics')).toBe(true);
     });
+
+    // These are whole tag names picked from the tag list, not a search term. Unanchored, the list
+    // covered files the count aggregate - which groups on the exact stored name - does not.
+    it('matches the whole tag name, not a neighbour that merely contains it', () => {
+      const result = buildFabFileSearchQuery(makeParams({ filters: { tags: ['test'] } }));
+      const andConditions = result.filter.$and as Record<string, unknown>[];
+      const tagCondition = andConditions.find(
+        c => 'tags' in c && JSON.stringify(c).includes('$elemMatch') && JSON.stringify(c).includes('$in')
+      ) as { tags: { $elemMatch: { name: { $in: RegExp[] } } } };
+
+      const pattern = tagCondition.tags.$elemMatch.name.$in[0];
+      expect(pattern.test('test')).toBe(true);
+      expect(pattern.test('TEST')).toBe(true);
+      expect(pattern.test('testing')).toBe(false);
+      expect(pattern.test('unit-test')).toBe(false);
+    });
+
+    it('treats regex metacharacters in a tag name literally', () => {
+      const result = buildFabFileSearchQuery(makeParams({ filters: { tags: ['.*'] } }));
+      const andConditions = result.filter.$and as Record<string, unknown>[];
+      const tagCondition = andConditions.find(
+        c => 'tags' in c && JSON.stringify(c).includes('$elemMatch') && JSON.stringify(c).includes('$in')
+      ) as { tags: { $elemMatch: { name: { $in: RegExp[] } } } };
+
+      const pattern = tagCondition.tags.$elemMatch.name.$in[0];
+      expect(pattern.test('.*')).toBe(true);
+      expect(pattern.test('anything')).toBe(false);
+    });
   });
 
   // ── 14. fileIds exclusion ─────────────────────────────────────────

--- a/packages/database/src/__tests__/fabFileTagCounts.test.ts
+++ b/packages/database/src/__tests__/fabFileTagCounts.test.ts
@@ -247,3 +247,63 @@ describe('FabFileRepository.countUniqueFilesByNamespaceForUser', () => {
     expect(await countOf('clients')).toBe(0);
   });
 });
+
+/**
+ * The single-tag counterpart. It queries the same `tags.name` data as the tag-lifecycle writes and
+ * carried the same unescaped, unanchored regex they did, so it is pinned here rather than left to
+ * re-seed the bug for its first caller - it has none yet.
+ */
+describe('FabFileRepository.countByUserIdAndTag', () => {
+  const userId = 'single-tag-count-user';
+
+  const seedFor = async (owner: string, tags: string[], overrides: Record<string, unknown> = {}) => {
+    await FabFile.create({
+      userId: owner,
+      fileName: 'seed.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: tags.map(name => ({ name, strength: 1 })),
+      ...overrides,
+    });
+  };
+
+  beforeEach(async () => {
+    await FabFile.deleteMany({});
+  });
+
+  it('counts only files carrying the whole name, not a neighbour containing it', async () => {
+    await seedFor(userId, ['test']);
+    await seedFor(userId, ['testing']);
+    await seedFor(userId, ['unit-test']);
+
+    expect(await fabFileRepository.countByUserIdAndTag(userId, 'test')).toBe(1);
+  });
+
+  it('counts casing variants as the same tag', async () => {
+    await seedFor(userId, ['Invoices']);
+    await seedFor(userId, ['invoices']);
+
+    expect(await fabFileRepository.countByUserIdAndTag(userId, 'INVOICES')).toBe(2);
+  });
+
+  it('treats regex metacharacters literally', async () => {
+    await seedFor(userId, ['.*']);
+    await seedFor(userId, ['anything']);
+
+    expect(await fabFileRepository.countByUserIdAndTag(userId, '.*')).toBe(1);
+  });
+
+  it('excludes soft-deleted files and other users', async () => {
+    await seedFor(userId, ['invoices']);
+    await seedFor(userId, ['invoices'], { deletedAt: new Date() });
+    await seedFor('someone-else', ['invoices']);
+
+    expect(await fabFileRepository.countByUserIdAndTag(userId, 'invoices')).toBe(1);
+  });
+
+  it('reports zero for an empty name rather than counting everything', async () => {
+    await seedFor(userId, ['invoices']);
+
+    expect(await fabFileRepository.countByUserIdAndTag(userId, '')).toBe(0);
+  });
+});

--- a/packages/database/src/__tests__/fabFileUpdateTagsByUserId.test.ts
+++ b/packages/database/src/__tests__/fabFileUpdateTagsByUserId.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+import { FabFile, fabFileRepository } from '../models/content/FabFileModel';
+import { setupMongoTest } from '../__test__/utils';
+import { KnowledgeType } from '@bike4mind/common';
+
+/**
+ * Real Mongo, not a mock: the central fact here is that the update reaches EVERY matching element
+ * of a stored array, which is exactly what the first-positional `tags.$.name` operator this method
+ * shipped with got wrong. `tags` has no sub-schema, so this also pins that Mongoose can cast the
+ * arrayFilters path at all.
+ */
+setupMongoTest();
+
+describe('FabFileRepository.updateTagsByUserId', () => {
+  const userId = 'rename-tag-user';
+  const otherUserId = 'someone-else';
+
+  const seed = async (tags: string[], overrides: Record<string, unknown> = {}): Promise<string> => {
+    const doc = await FabFile.create({
+      userId,
+      fileName: 'seed.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: tags.map(name => ({ name, strength: 1 })),
+      ...overrides,
+    });
+    return doc.id as string;
+  };
+
+  // Straight from the collection: a soft-deleted document is invisible to the model's find hooks,
+  // so asserting through findById would pass whether or not the rename landed.
+  const rawOf = async (id: string) => FabFile.collection.findOne({ _id: new mongoose.Types.ObjectId(id) });
+  const rawTagsOf = async (id: string): Promise<string[]> =>
+    (((await rawOf(id))?.tags ?? []) as { name: string }[]).map(t => t.name);
+
+  beforeEach(async () => {
+    await FabFile.deleteMany({});
+  });
+
+  // The assertion the first-positional `tags.$.name` cannot satisfy: it renames `foo` and stops.
+  it('renames EVERY occurrence within one document, not just the first', async () => {
+    const file = await seed(['foo', 'bar', 'Foo']);
+
+    await fabFileRepository.updateTagsByUserId(userId, 'foo', 'renamed');
+
+    expect(await rawTagsOf(file)).toEqual(['renamed', 'bar', 'renamed']);
+  });
+
+  it('preserves the position and the other fields of each renamed element', async () => {
+    const doc = await FabFile.create({
+      userId,
+      fileName: 'seed.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: [
+        { name: 'keep', strength: 3 },
+        { name: 'foo', strength: 7 },
+      ],
+    });
+
+    await fabFileRepository.updateTagsByUserId(userId, 'foo', 'renamed');
+
+    const tags = ((await rawOf(doc.id as string))?.tags ?? []) as { name: string; strength: number }[];
+    expect(tags).toEqual([
+      { name: 'keep', strength: 3 },
+      { name: 'renamed', strength: 7 },
+    ]);
+  });
+
+  it('renames across files and reports how many it touched', async () => {
+    const a = await seed(['invoices']);
+    const b = await seed(['invoices', 'misc']);
+    const untouched = await seed(['misc']);
+
+    const modified = await fabFileRepository.updateTagsByUserId(userId, 'invoices', 'receipts');
+
+    expect(modified).toBe(2);
+    expect(await rawTagsOf(a)).toEqual(['receipts']);
+    expect(await rawTagsOf(b)).toEqual(['receipts', 'misc']);
+    expect(await rawTagsOf(untouched)).toEqual(['misc']);
+  });
+
+  it('renames on a soft-deleted file, so an undelete cannot revive the old name', async () => {
+    const deleted = await seed(['invoices'], { deletedAt: new Date() });
+
+    await fabFileRepository.updateTagsByUserId(userId, 'invoices', 'receipts');
+
+    expect(await rawTagsOf(deleted)).toEqual(['receipts']);
+  });
+
+  it('matches the whole name, so a neighbour containing it is not renamed', async () => {
+    const file = await seed(['q1', 'q1-draft']);
+
+    await fabFileRepository.updateTagsByUserId(userId, 'q1', 'quarter-one');
+
+    expect(await rawTagsOf(file)).toEqual(['quarter-one', 'q1-draft']);
+  });
+
+  it('treats regex metacharacters in the old name literally', async () => {
+    const file = await seed(['.*', 'invoices']);
+
+    const modified = await fabFileRepository.updateTagsByUserId(userId, '.*', 'literal');
+
+    expect(modified).toBe(1);
+    expect(await rawTagsOf(file)).toEqual(['literal', 'invoices']);
+  });
+
+  it("leaves another user's files alone", async () => {
+    const theirs = await FabFile.create({
+      userId: otherUserId,
+      fileName: 'theirs.txt',
+      type: KnowledgeType.FILE,
+      mimeType: 'text/plain',
+      tags: [{ name: 'invoices', strength: 1 }],
+    });
+
+    const modified = await fabFileRepository.updateTagsByUserId(userId, 'invoices', 'receipts');
+
+    expect(modified).toBe(0);
+    expect(await rawTagsOf(theirs.id as string)).toEqual(['invoices']);
+  });
+
+  it('renames primaryTag only where it named the renamed tag', async () => {
+    const pointed = await seed(['invoices'], { primaryTag: 'invoices' });
+    const other = await seed(['invoices', 'misc'], { primaryTag: 'misc' });
+
+    await fabFileRepository.updateTagsByUserId(userId, 'invoices', 'receipts');
+
+    expect((await rawOf(pointed))?.primaryTag).toBe('receipts');
+    expect((await rawOf(other))?.primaryTag).toBe('misc');
+  });
+
+  it('reports zero for an empty name rather than building a match-everything regex', async () => {
+    const file = await seed(['invoices']);
+
+    expect(await fabFileRepository.updateTagsByUserId(userId, '', 'receipts')).toBe(0);
+    expect(await fabFileRepository.updateTagsByUserId(userId, 'invoices', '')).toBe(0);
+    expect(await rawTagsOf(file)).toEqual(['invoices']);
+  });
+});

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -812,17 +812,96 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
   }
 
   async updateTagsByUserId(userId: string, tag: string, newTag: string): Promise<number> {
+    if (!tag || !newTag) return 0;
+    // Anchored and escaped for the same reason as removeTagByUserId: unanchored, renaming `q1`
+    // also rewrote `q1-draft`.
+    const nameRegex = new RegExp(`^${escapeRegex(tag)}$`, 'i');
+    // `$[elem]` and not `$`: the first-positional operator updates only the FIRST matching element
+    // per document, so a file carrying the name twice kept one stale copy.
+    // No deletedAt conjunct - see removeTagByUserId; an undelete must not revive the old name.
     const result = await this.fabFileModel.updateMany(
       {
         userId,
-        deletedAt: null,
-        'tags.name': { $regex: new RegExp(tag, 'i') },
+        'tags.name': nameRegex,
       },
       {
         $set: {
-          'tags.$.name': newTag,
+          'tags.$[elem].name': newTag,
         },
-      }
+      },
+      { arrayFilters: [{ 'elem.name': nameRegex }] }
+    );
+    // Renamed rather than cleared: unlike a delete, the tag still exists under its new name, so
+    // the file's primary label should follow it.
+    await this.fabFileModel.updateMany({ userId, primaryTag: nameRegex }, { $set: { primaryTag: newTag } });
+    return result.modifiedCount;
+  }
+
+  async dedupeTagByUserId(userId: string, name: string): Promise<number> {
+    if (!name) return 0;
+    const folded = name.toLowerCase();
+    // An aggregation-pipeline update, which is NOT the read-modify-write that pullTagsByFabFileId
+    // rejects: the array is rebuilt from the document's own value server-side inside one atomic
+    // per-document write, so there is no snapshot round trip for a concurrent writer to lose.
+    // Same mechanism as StockPortfolioRepository.executeBuy.
+    //
+    // `$ifNull` guards throughout: `tags` is declared as [Object] with no sub-schema, and legacy
+    // rows carry elements with a missing or non-string `name` - six other call sites defend the
+    // same shape. Without the guard one bad element decides the whole user's dedupe.
+    const isMatch = (expr: unknown) => ({ $eq: [{ $toLower: { $ifNull: [expr, ''] } }, folded] });
+    const result = await this.fabFileModel.updateMany(
+      {
+        userId,
+        // Index-eligible prefilter first, then the $expr narrows to documents that genuinely carry
+        // the name more than once, so the write set stays small.
+        'tags.name': new RegExp(`^${escapeRegex(name)}$`, 'i'),
+        $expr: {
+          $gt: [
+            {
+              $size: {
+                $filter: {
+                  input: { $ifNull: ['$tags', []] },
+                  as: 't',
+                  cond: isMatch('$$t.name'),
+                },
+              },
+            },
+            1,
+          ],
+        },
+      },
+      [
+        {
+          $set: {
+            tags: {
+              $reduce: {
+                input: { $ifNull: ['$tags', []] },
+                initialValue: [],
+                in: {
+                  $cond: {
+                    if: isMatch('$$this.name'),
+                    // Keep the FIRST match, normalized to the passed casing, and drop later ones.
+                    // $mergeObjects rather than a rebuilt {name, strength} so `strength` and any
+                    // field this schema does not declare survive.
+                    then: {
+                      $cond: {
+                        if: {
+                          $anyElementTrue: {
+                            $map: { input: '$$value', as: 'kept', in: isMatch('$$kept.name') },
+                          },
+                        },
+                        then: '$$value',
+                        else: { $concatArrays: ['$$value', [{ $mergeObjects: ['$$this', { name }] }]] },
+                      },
+                    },
+                    else: { $concatArrays: ['$$value', ['$$this']] },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ]
     );
     return result.modifiedCount;
   }

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -356,12 +356,15 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
   }
 
   async countByUserIdAndTag(userId: string, tag: string): Promise<number> {
+    if (!tag) return 0;
+    // Anchored and escaped for the same reason as removeTagByUserId, which queries this same
+    // tags.name data: unanchored, `test` counted every file carrying `testing` too.
     const result = await this.fabFileModel.countDocuments({
       userId,
       deletedAt: null,
       tags: {
         $elemMatch: {
-          name: { $regex: new RegExp(tag, 'i') },
+          name: new RegExp(`^${escapeRegex(tag)}$`, 'i'),
         },
       },
     });
@@ -606,24 +609,34 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
   }
 
   async removeTagByUserId(userId: string, tag: string): Promise<number> {
+    if (!tag) return 0;
+    // Anchored, not a substring match: unanchored, removing `test` also stripped `testing` and
+    // `unit-test` off every file. Escaped because a tag name is user-chosen and can carry regex
+    // metacharacters. Case-insensitive so a `Foo` document also clears files carrying `foo`.
+    const nameRegex = new RegExp(`^${escapeRegex(tag)}$`, 'i');
+    // No deletedAt conjunct, unlike most reads here: a soft-deleted file that kept the name would
+    // resurrect a tag document that no longer exists the moment it is undeleted.
     const result = await this.fabFileModel.updateMany(
       {
         userId,
-        deletedAt: null,
         tags: {
           $elemMatch: {
-            name: { $regex: new RegExp(tag, 'i') },
+            name: nameRegex,
           },
         },
       },
       {
         $pull: {
           tags: {
-            name: { $regex: new RegExp(tag, 'i') },
+            name: nameRegex,
           },
         },
       }
     );
+    // Same reasoning as pullTagsByFabFileId: a primaryTag naming a tag the file no longer carries
+    // later fails the data-lake write gate on PUT /api/files/[id]. Separate filtered write because
+    // a plain update cannot clear a field conditionally on its own value.
+    await this.fabFileModel.updateMany({ userId, primaryTag: nameRegex }, { $unset: { primaryTag: '' } });
     return result.modifiedCount;
   }
 

--- a/packages/database/src/queries/fabFileSearchQuery.ts
+++ b/packages/database/src/queries/fabFileSearchQuery.ts
@@ -379,10 +379,15 @@ export function buildFabFileSearchQuery(params: FabFileSearchParams): FabFileSea
     }
   }
 
-  // Tag filter
+  // Tag filter. Anchored: these are whole tag names picked from the user's tag list, not a search
+  // term, so filtering by `test` must not also return files tagged `testing`. Unanchored, this
+  // disagreed with countFilesByTagForUser, which groups on the exact stored name - so the badge and
+  // the list it is compared against could cover different files.
   if (filters.tags && filters.tags.length > 0) {
     andConditions.push({
-      tags: { $elemMatch: { name: { $in: filters.tags.map(tag => new RegExp(escapeRegex(String(tag)), 'i')) } } },
+      tags: {
+        $elemMatch: { name: { $in: filters.tags.map(tag => new RegExp(`^${escapeRegex(String(tag))}$`, 'i')) } },
+      },
     });
   }
 


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="2700" height="1712" alt="3-tag-manager-after-delete" src="https://github.com/user-attachments/assets/959ffe37-2b82-4475-b3c5-9d904c29a2ff" />

Tag Manager immediately after deleting the `invoices` tag: the tag document is gone. This half always worked.

<img width="2700" height="1712" alt="4-workspaces-after-delete" src="https://github.com/user-attachments/assets/3bcf6b6c-9d78-40ad-bba3-612c39e52080" />

The same moment in the file browser Overview: `invoices` is gone from WORKSPACES instead of lingering as an orphaned count. `receipts` is untouched at 1. Before this change the row stayed here, still counting 2 files.


## Description

Closes #1137

Renaming or deleting a file tag wrote the `Tag` document and nothing else, leaving the old name on every file that carried it. Delete looked like it worked because the chips are drawn by intersecting tag documents with the file's strings, so the chip vanished while the Workspaces tag counts, which read the strings, kept counting the orphan.

Helpers existed for both paths and neither had a caller. Wiring them up meant fixing them first: the regexes were unescaped and, more damagingly, unanchored, so deleting `test` would have stripped `testing` off every file; soft-deleted files were skipped, so an undelete resurrected a dead tag; and the rename used the first-positional operator, which updates one array element per document.

Files are rewritten before either document is touched - the only order that converges under retry.

## Changes

- `removeTagByUserId` / `updateTagsByUserId`: anchored + escaped matching, soft-deleted files included, `primaryTag` carried across. The rename now uses `$[elem]` so every occurrence in one file updates.
- New `dedupeTagByUserId`: an aggregation-pipeline `$reduce` collapsing the duplicate that renaming in place creates on a file that already had the target name.
- `tagService/remove` + `update` take a `fabFiles` adapter; the route injects `fabFileRepository` on PUT and DELETE.
- Renaming onto an existing tag merges instead of failing the unique index - the renamed document survives, colliders are deleted first.
- A data-lake membership tag is refused on both paths, matched case-insensitively because the writes it gates are.
- Anchored the file-browser tag filter, which listed files the count aggregate does not count.
- `countByUserIdAndTag`: same regex treatment, plus the tests it never had.
- Both tag mutations invalidate `['fabFiles']`, since file rows now change.

## Guide for Testers

Preview URL is in the internal deploys channel (the deploy bot posts it there, not on this PR).

**Setup**

1. Open the file browser (Files in the left sidenav). It opens on the **Overview** tab.
2. Upload three small text files - `Upload Files`, top right. A fresh preview account has no files at all, so this step is required, not optional.
3. Switch to the **List** tab. The Tag Manager button only exists on List and Grid, not Overview.
4. Click the tag-icon button labelled **Tag Manager**, at the top left of the list. A panel slides in from the left.
5. In that panel, click the blue **+** button (tooltip "Create a new tag") and create `invoices`. Repeat for `invoices-2024` and `receipts`.
6. Close the panel (click outside it or the X).
7. Tick the checkboxes on the first two files, then click the **Tag** button in the action bar that appears above the list, and apply `invoices`. The Tag button only appears once at least one file is selected.
8. Repeat for the third file with `invoices-2024`.
9. Select the FIRST file only and also apply `receipts` to it. That file now carries both `invoices` and `receipts` - this is the case the merge has to collapse.

**Rename, including the merge**

Note before you start: the Edit Tag dialog's preview chip always reads "0 files" regardless of the real count. That is a separate known bug (#1154), not something this PR changes - read the count off the Tag Manager row instead.

10. Open the Tag Manager again. Expected: `invoices (2)`, `invoices-2024 (1)`, `receipts (1)`.
11. Hover the `invoices` row - a three-dot menu appears at its right edge. Click it and choose **Edit**.
12. Change the **Tag Name** field to `receipts` and click **Update Tag**. The dialog requires an
    Icon and a Colour; tags you created in step 5 already have both (the create form fills them in at
    random). A tag created by some other flow has neither, and the dialog will refuse to save until you
    pick them - that is pre-existing behaviour, not part of this change.
13. Expected: `invoices` is gone from the panel and only ONE `receipts` row remains - the two tags merged. It reads **receipts (2)**, not (3): the first file carried both names and is counted once, not twice.
14. Expected: `invoices-2024 (1)` is unchanged. It contains the string "invoices" and must NOT have been renamed.
15. Go to the **Overview** tab and look at the **WORKSPACES** list. Note it renders at most SIX
    entries, so on an account with lots of tags the row you want may simply not be shown - use the
    **Tags** tab in step 16 instead of concluding the row is missing. Expected: a `receipts` row showing **2**, and no `invoices` row at all. This is the surface that was broken - the old code left `invoices` here after the rename.
16. Also check the **Tags** tab. Expected: same story - `receipts`, no `invoices`. (This tab reads "No tagged files found" until at least one file carries a tag, so check it after step 9, not before.)
17. Back on the **List** tab, expected: the first two files show a `receipts` chip and no `invoices` chip, with no page reload.

**Delete**

18. Open the Tag Manager, hover the `invoices-2024` row, three-dot menu, **Delete**. The confirmation dialog's button is labelled **Ok**.
19. Expected: the tag disappears from the Tag Manager AND the chip disappears from the third file's row.
20. Go to **Overview** -> **WORKSPACES**. Expected: no `invoices-2024` row. **This is the headline fix.** Previously the chip vanished here while WORKSPACES kept listing the tag and counting its file - the two surfaces disagreed.

**Regression checks**

21. Edit a tag and change only its colour, leaving the name untouched. Expected: the colour updates and the file count is unchanged. A colour-only edit must not rewrite any file.
22. Rename `receipts` to `Receipts` (letter case only). Expected: the chips on the file rows show the new casing - a case-only change IS a real rename.
23. On the List tab, filter the file list by a tag. Expected: only files carrying that exact tag appear. In particular filtering by `receipts` must not also return files tagged `receipts-archive` if you create one.

**What NOT to test**

- Data-lake membership tags (`datalake:...`). Rename and delete deliberately refuse these; covered by unit tests.
- Files shared to you but owned by someone else. Their tags are deliberately not rewritten - one user's tag edit must not modify another user's file.
- Historical orphaned tag names already in the database. This fixes the write paths going forward; there is no backfill.

## Additional Information

An earlier commit on this branch had the `datalake:` guard case-sensitive while the writes it gates match case-insensitively, so `DATALAKE:acme` walked it. Caught by `/security-review` and fixed here. Both repository methods were dead code before this PR, so the bypass never existed in a deployed build.

## Developer Notes

`dedupeTagByUserId` is the first array-collapsing pipeline update in `FabFileModel`. It rebuilds the array server-side in one atomic write, so it avoids the lost-update risk `pullTagsByFabFileId` documents for a read-modify-write `$set: { tags }`.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc





