### PR TITLE
fix(artifacts): stop deleted artifacts reappearing in the gallery

### DIFF
--- a/apps/client/app/components/artifacts/ArtifactGallery.test.tsx
+++ b/apps/client/app/components/artifacts/ArtifactGallery.test.tsx
@@ -25,10 +25,11 @@ const mocks = vi.hoisted(() => ({
   buildArtifactPublishWiring: vi.fn(() => ({ resolveExisting: vi.fn(), publish: vi.fn() })),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
+  apiDelete: vi.fn(),
 }));
 
 vi.mock('@client/app/contexts/ApiContext', () => ({
-  api: { get: mocks.apiGet, post: vi.fn(), delete: vi.fn() },
+  api: { get: mocks.apiGet, post: vi.fn(), delete: mocks.apiDelete },
 }));
 vi.mock('sonner', () => ({
   toast: { error: mocks.toastError, success: mocks.toastSuccess },
@@ -194,5 +195,53 @@ describe('ArtifactGallery - Share hydrates content (#147)', () => {
     // Let the first flow finish so it publishes exactly once and no pending work leaks.
     resolveFetch({ data: { content: { content: '<h1>hydrated</h1>' } } });
     await waitFor(() => expect(mocks.publishAndShare).toHaveBeenCalledTimes(1));
+  });
+});
+
+/**
+ * The category tabs count the local `artifacts` array, but the All tab renders the server's
+ * `pagination.total`. handleDelete only filtered the local array, so after a delete All kept
+ * counting the removed artifact while the category tab decremented - the two badges disagreed
+ * until an unrelated refetch.
+ */
+describe('ArtifactGallery - All badge decrements on delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('decrements the All total, not just the category list, when an artifact is deleted', async () => {
+    // Two artifacts on purpose, so the count lands on a visible 1 rather than 0: Joy's Badge
+    // defaults to showZero=false, so at zero it renders nothing and any negative assertion would
+    // pass simply because the badge vanished.
+    const second = { ...LIST_RESPONSE.artifacts[0], id: 'artifact_html_demo_456', title: 'Second Artifact' };
+    mocks.apiGet.mockImplementation((url: string) => {
+      if (url.startsWith('/api/artifacts/types')) return Promise.resolve({ data: TYPES_RESPONSE });
+      if (url.includes('includeContent=true')) return Promise.resolve({ data: {} });
+      if (url.startsWith('/api/artifacts')) {
+        return Promise.resolve({
+          data: { ...LIST_RESPONSE, artifacts: [...LIST_RESPONSE.artifacts, second], pagination: { total: 2 } },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    mocks.apiDelete.mockResolvedValue({ data: { success: true } });
+    const user = userEvent.setup();
+    render(
+      <TestWrapper>
+        <ArtifactGallery />
+      </TestWrapper>
+    );
+
+    const allTab = (await screen.findAllByRole('tab'))[0];
+    await screen.findByText('My Demo Artifact');
+    expect(allTab.textContent).toContain('2');
+
+    await user.click((await screen.findAllByTestId('artifact-card-menu-btn'))[0]);
+    await user.click(await screen.findByRole('menuitem', { name: 'Delete' }));
+
+    await waitFor(() => expect(mocks.apiDelete).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByText('My Demo Artifact')).not.toBeInTheDocument());
+    // Positive assertion on a visible number: without the setTotal fix this stays at 2.
+    await waitFor(() => expect(allTab.textContent).toContain('1'));
   });
 });

--- a/apps/client/app/components/artifacts/ArtifactGallery.tsx
+++ b/apps/client/app/components/artifacts/ArtifactGallery.tsx
@@ -264,8 +264,10 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
         if (projectId) params.append('projectId', projectId);
         if (sessionId) params.append('sessionId', sessionId);
 
-        const endpoint = searchQuery ? '/api/artifacts/search' : '/api/artifacts';
-        const response = await api.get<ArtifactListResponse>(`${endpoint}?${params}`);
+        // /api/artifacts handles `search` itself. The dedicated search route wants the term as `q`
+        // and hardcodes its own sort, so routing there both failed to parse and discarded the sort
+        // the user picked.
+        const response = await api.get<ArtifactListResponse>(`/api/artifacts?${params}`);
 
         if (reset) {
           setArtifacts(response.data.artifacts);
@@ -351,6 +353,9 @@ export const ArtifactGallery: React.FC<ArtifactGalleryProps> = ({
     try {
       await api.delete(`/api/artifacts/${artifactId}`);
       setArtifacts(prev => prev.filter(a => a.id !== artifactId));
+      // The category tabs count the local list, but the All tab shows the server's
+      // pagination total - without this it keeps counting the artifact just deleted.
+      setTotal(prev => Math.max(0, prev - 1));
       toast.success('Artifact deleted successfully');
     } catch (error: any) {
       toast.error(error.message || 'Failed to delete artifact');

--- a/apps/client/pages/api/artifacts/__tests__/index.test.ts
+++ b/apps/client/pages/api/artifacts/__tests__/index.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import '../index';
+
+/**
+ * The parser itself is pinned where `queryBool` is defined. These pin the plumbing: the bug
+ * travelled qs.parse -> schema -> service, and only the last hop decides whether soft-deleted rows
+ * are filtered, so a route that parsed correctly and then forwarded the raw query would still ship
+ * it.
+ */
+
+// Collapse the baseApi().get().post() chain and capture the GET handler.
+const mockRefs = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
+  listArgs: undefined as unknown[] | undefined,
+}));
+
+vi.mock('@server/middlewares/baseApi', () => {
+  const chain: any = {
+    get: (fn: any) => {
+      mockRefs.getHandler = fn;
+      return chain;
+    },
+    post: () => chain,
+  };
+  return { baseApi: () => chain };
+});
+
+vi.mock('@bike4mind/database', () => ({
+  artifactRepository: { __repo: 'artifacts' },
+  artifactContentRepository: { __repo: 'artifactContents' },
+  artifactVersionRepository: { __repo: 'artifactVersions' },
+}));
+
+vi.mock('@bike4mind/services', () => ({
+  artifactService: {
+    list: (...args: unknown[]) => {
+      mockRefs.listArgs = args;
+      return Promise.resolve({ artifacts: [], pagination: { total: 0 } });
+    },
+  },
+}));
+
+function invokeGet(query: Record<string, unknown>) {
+  const { req, res } = createMocks({ method: 'GET', url: '/api/artifacts', query: query as any });
+  (req as any).user = { id: 'user-1' };
+  return { req, res };
+}
+
+const includeDeletedArg = () => (mockRefs.listArgs?.[1] as { includeDeleted?: unknown } | undefined)?.includeDeleted;
+
+describe('GET /api/artifacts', () => {
+  it('hands the service a real boolean false for ?includeDeleted=false', async () => {
+    expect(mockRefs.getHandler).toBeTypeOf('function');
+    const { req, res } = invokeGet({ includeDeleted: 'false' });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(includeDeletedArg()).toBe(false);
+  });
+
+  it('hands the service true for ?includeDeleted=true', async () => {
+    const { req, res } = invokeGet({ includeDeleted: 'true' });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(includeDeletedArg()).toBe(true);
+  });
+
+  it('defaults to false when the caller omits the param', async () => {
+    const { req, res } = invokeGet({});
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(includeDeletedArg()).toBe(false);
+  });
+});

--- a/apps/client/pages/api/artifacts/index.ts
+++ b/apps/client/pages/api/artifacts/index.ts
@@ -1,4 +1,4 @@
-import { ArtifactTypeSchema } from '@bike4mind/common';
+import { ArtifactTypeSchema, queryBool } from '@bike4mind/common';
 import { artifactService } from '@bike4mind/services';
 import { artifactRepository, artifactContentRepository, artifactVersionRepository } from '@bike4mind/database';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
@@ -11,7 +11,7 @@ const ListArtifactsSchema = z.object({
   offset: z.coerce.number().min(0).prefault(0),
   sortBy: z.enum(['type', 'title', 'createdAt', 'updatedAt']).prefault('createdAt'),
   sortOrder: z.enum(['asc', 'desc']).prefault('desc'),
-  includeDeleted: z.coerce.boolean().prefault(false),
+  includeDeleted: queryBool,
   type: z.string().optional(),
   status: z.enum(['draft', 'review', 'published', 'archived']).optional(),
   visibility: z.enum(['private', 'project', 'organization', 'public']).optional(),
@@ -64,7 +64,8 @@ const handler = baseApi()
 
       const result = await artifactService.list(userId, validatedParams, {
         db: {
-          artifacts: artifactRepository as any,        },
+          artifacts: artifactRepository as any,
+        },
       });
 
       return res.json(result);
@@ -85,7 +86,10 @@ const handler = baseApi()
 
       const result = await artifactService.create(userId, validatedData, {
         db: {
-          artifacts: artifactRepository as any,          artifactContents: artifactContentRepository as any,          artifactVersions: artifactVersionRepository as any,        },
+          artifacts: artifactRepository as any,
+          artifactContents: artifactContentRepository as any,
+          artifactVersions: artifactVersionRepository as any,
+        },
       });
 
       return res.status(201).json(result);

--- a/apps/client/pages/api/sessions/[id]/chat/index.ts
+++ b/apps/client/pages/api/sessions/[id]/chat/index.ts
@@ -5,6 +5,7 @@ import { NotFoundError } from '@server/utils/errors';
 import { z } from 'zod';
 import qs from 'qs';
 import { secureParameters } from '@bike4mind/utils';
+import { queryBool } from '@bike4mind/common';
 
 const searchSchema = z.object({
   search: z.string().optional(),
@@ -14,7 +15,7 @@ const searchSchema = z.object({
       page: z.coerce.number().positive().int().prefault(1),
     })
     .optional(),
-  all: z.coerce.boolean().prefault(false),
+  all: queryBool,
   sort: z.enum(['asc', 'desc']).prefault('asc'),
 });
 

--- a/b4m-core/common/src/schemas/query.test.ts
+++ b/b4m-core/common/src/schemas/query.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { queryBool } from './query';
+
+/**
+ * `z.coerce.boolean()` is `Boolean(input)`, so on a query string - where every value is a string -
+ * `'false'` becomes TRUE. These pin the parse for the shapes `qs.parse` can hand a route, including
+ * the repeated-param array that must resolve rather than surface as a 422.
+ */
+describe('queryBool', () => {
+  const schema = z.object({ flag: queryBool });
+  const parse = (flag?: unknown) => schema.parse(flag === undefined ? {} : { flag }).flag;
+
+  it.each([
+    ['true', true],
+    ['TRUE', true],
+    ['1', true],
+    ['false', false],
+    ['False', false],
+    ['0', false],
+    ['', false],
+    ['yes', false],
+  ])('parses the string %j as %s', (input, expected) => {
+    expect(parse(input)).toBe(expected);
+  });
+
+  it('defaults to false when the param is absent', () => {
+    expect(parse()).toBe(false);
+  });
+
+  it('accepts a real boolean, so the helper is safe off the wire too', () => {
+    expect(parse(true)).toBe(true);
+    expect(parse(false)).toBe(false);
+  });
+
+  it('takes the last value of a repeated param instead of rejecting the request', () => {
+    // qs turns ?flag=true&flag=false into an array. Collapsing that to the default would silently
+    // ignore a caller who asked twice for true; a bare union would 422 the whole request.
+    expect(parse(['true', 'false'])).toBe(false);
+    expect(parse(['false', 'true'])).toBe(true);
+    expect(parse(['true'])).toBe(true);
+  });
+
+  it('falls back to the default for a value it cannot read, rather than 422ing', () => {
+    expect(parse({ nested: 'true' })).toBe(false);
+    expect(parse(null)).toBe(false);
+  });
+});

--- a/b4m-core/common/src/schemas/query.ts
+++ b/b4m-core/common/src/schemas/query.ts
@@ -26,3 +26,19 @@ export const TableQuery = QueryPaginate.extend({
 
 export const QueryComplexity = z.enum(['simple', 'contextual', 'complex']);
 export type QueryComplexityType = z.infer<typeof QueryComplexity>;
+
+/**
+ * Boolean query parameter. Not `z.coerce.boolean()`: that is `Boolean(input)`, and query params
+ * arrive as strings, so `'false'` would parse as TRUE. Accepts `true`/`'true'`/`'1'`
+ * case-insensitively.
+ *
+ * A repeated param (`?flag=true&flag=true`) arrives from `qs` as an array; the last value wins,
+ * matching how servers usually treat duplicates. Collapsing it to the default instead would be
+ * wrong in the other direction - a caller who asked twice for `all=true` would silently get one
+ * truncated page. `.catch` is the final guard so a malformed value cannot 422 the whole request.
+ */
+export const queryBool = z
+  .preprocess(v => (Array.isArray(v) ? v.at(-1) : v), z.union([z.boolean(), z.string()]))
+  .prefault(false)
+  .transform(v => ['true', '1'].includes(String(v).toLowerCase()))
+  .catch(false);

--- a/b4m-core/common/src/types/entities/ArtifactRepositoryTypes.ts
+++ b/b4m-core/common/src/types/entities/ArtifactRepositoryTypes.ts
@@ -48,7 +48,11 @@ export interface IArtifactRepository extends IBaseRepository<IArtifactDocument> 
   findActive(filter?: Record<string, unknown>): Promise<IArtifactDocument[]>;
   findByStatus(status: string, filter?: Record<string, unknown>): Promise<IArtifactDocument[]>;
   findByVisibility(visibility: string, filter?: Record<string, unknown>): Promise<IArtifactDocument[]>;
-  searchByText(searchTerm: string, filter?: Record<string, unknown>): Promise<IArtifactDocument[]>;
+  searchByText(
+    searchTerm: string,
+    filter?: Record<string, unknown>,
+    includeDeleted?: boolean
+  ): Promise<IArtifactDocument[]>;
   findDuplicatesByHash(contentHash: string): Promise<IArtifactDocument[]>;
 
   // Permission-based queries

--- a/b4m-core/services/src/artifactService/list.test.ts
+++ b/b4m-core/services/src/artifactService/list.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { list } from './list';
+import { IArtifactRepository } from '@bike4mind/common';
+
+/**
+ * `includeDeleted` is the only thing standing between a caller and a soft-deleted artifact: the
+ * Mongoose ArtifactSchema registers no soft-delete plugin, so there is no `pre('find')` backstop
+ * the way Group/Organization/FabFile have. These assert the filter the service actually hands the
+ * repository, on both the plain-find and text-search paths.
+ */
+describe('artifactService - list includeDeleted', () => {
+  const makeAdapters = () => {
+    const find = vi.fn().mockResolvedValue([]);
+    const searchByText = vi.fn().mockResolvedValue([]);
+    const count = vi.fn().mockResolvedValue(0);
+    return {
+      adapters: { db: { artifacts: { find, searchByText, count } as unknown as IArtifactRepository } },
+      find,
+      searchByText,
+    };
+  };
+
+  const params = (over: Partial<Parameters<typeof list>[1]> = {}): Parameters<typeof list>[1] => ({
+    limit: 20,
+    offset: 0,
+    sortBy: 'updatedAt',
+    sortOrder: 'desc',
+    includeDeleted: false,
+    ...over,
+  });
+
+  it('excludes soft-deleted rows by default', async () => {
+    const { adapters, find } = makeAdapters();
+
+    await list('user-1', params(), adapters);
+
+    expect(find).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-1', deletedAt: null }));
+  });
+
+  it('omits the deletedAt filter when includeDeleted is true', async () => {
+    const { adapters, find } = makeAdapters();
+
+    await list('user-1', params({ includeDeleted: true }), adapters);
+
+    const filter = find.mock.calls[0][0] as Record<string, unknown>;
+    expect(filter).not.toHaveProperty('deletedAt');
+  });
+
+  it('passes includeDeleted through to the text search rather than letting it default', async () => {
+    // searchByText applies its own live-only default, so the flag has to be handed over explicitly
+    // or a search silently ignores it.
+    const { adapters, searchByText, find } = makeAdapters();
+
+    await list('user-1', params({ includeDeleted: true, search: 'needle' }), adapters);
+
+    expect(find).not.toHaveBeenCalled();
+    expect(searchByText).toHaveBeenCalledWith('needle', expect.any(Object), true);
+  });
+
+  it('tells the text search to exclude deleted rows by default', async () => {
+    const { adapters, searchByText } = makeAdapters();
+
+    await list('user-1', params({ search: 'needle' }), adapters);
+
+    expect(searchByText).toHaveBeenCalledWith('needle', expect.objectContaining({ deletedAt: null }), false);
+  });
+});

--- a/b4m-core/services/src/artifactService/list.ts
+++ b/b4m-core/services/src/artifactService/list.ts
@@ -68,7 +68,9 @@ export const list = async (userId: string, parameters: ListArtifactsParameters, 
   // Get artifacts with filtering
   let artifacts;
   if (search) {
-    artifacts = await db.artifacts.searchByText(search, filter);
+    // Passed explicitly: the text search applies its own live-only default otherwise, which
+    // would ignore includeDeleted on this path.
+    artifacts = await db.artifacts.searchByText(search, filter, includeDeleted);
   } else {
     artifacts = await db.artifacts.find(filter);
   }

--- a/packages/database/src/models/content/ArtifactModel.ts
+++ b/packages/database/src/models/content/ArtifactModel.ts
@@ -310,10 +310,13 @@ export class ArtifactRepository extends BaseRepository<IArtifactDocument> {
     return this.find({ ...filter, visibility, deletedAt: null });
   }
 
-  async searchByText(searchTerm: string, filter: Record<string, unknown> = {}) {
+  // Defaults to live rows only. `includeDeleted` is an explicit opt-in because this used to write
+  // `deletedAt: null` after spreading the caller's filter, which silently overrode a caller that
+  // had deliberately left it off - so a text search ignored an includeDeleted request.
+  async searchByText(searchTerm: string, filter: Record<string, unknown> = {}, includeDeleted = false) {
     return this.find({
       ...filter,
-      deletedAt: null,
+      ...(includeDeleted ? {} : { deletedAt: null }),
       $text: { $search: searchTerm },
     });
   }


### PR DESCRIPTION
Fixes #1270 - the list endpoint returning soft-deleted artifacts, the stale All tab badge, and
(as a consequence of the first) deleted cards rendering in the gallery.

## The coercion bug

`includeDeleted` was parsed with `z.coerce.boolean()`, which is `Boolean(input)`. Query params arrive as strings, and `Boolean('false') === true` - so `?includeDeleted=false` and `?includeDeleted=true` returned identical results, both including soft-deleted rows. Omitting the param happened to work, but the gallery sends it explicitly on load, which is why deleting an artifact looked successful and then undid itself on the next reload.

The parser now lives in `@bike4mind/common` as `queryBool`, alongside the other shared query-param schemas, rather than in the route that first needed it, so the service layer can share it - `b4m-core` cannot import from `apps/client`. It reads the literal case-insensitively, takes the last value of a repeated param (how servers usually treat duplicates), and falls back to the default rather than rejecting input it cannot read: a 422 on a malformed boolean is a worse failure than ignoring it. The session chat endpoint parsed `all` the same broken way and now shares the helper.

`searchByText` wrote `deletedAt: null` *after* spreading the caller's filter, silently overriding a caller that had deliberately left it off - so a text search ignored `includeDeleted` entirely. The caller now states the constraint and the service passes the flag through.

## Two client fixes on the search path

The gallery routed searches to `/api/artifacts/search` with the term as `search`, but that schema requires `q` - so **every keystroke returned 422** and the grid only ever showed "Failed to load artifacts". `/api/artifacts` already handles `search` itself, and the dedicated route merely forwards to the same service while hardcoding its own sort, so it also discarded the sort the user picked. Dropping the endpoint switch fixes both.

The category tabs count the local `artifacts` array while the All tab renders the server's `pagination.total`, and `handleDelete` only filtered the local array - so the two badges disagreed after a delete. It now decrements the total as well.

## Verification

Local run against a seeded DB: 4 live artifacts + 1 soft-deleted (`GHOST`), instrumented with temporary logs at the parse site, the repository filter, and the `searchByText` call.

| query | parsed | filter | rows | GHOST |
|---|---|---|---|---|
| omitted | `false` | `deletedAt: null` | 4 | absent |
| `=false` | `false` | `deletedAt: null` | 4 | absent |
| `=true` | `true` | no `deletedAt` | 5 | present |
| `=true&=false` | `false` | `deletedAt: null` | 4 | absent |
| `=false&=true` | `true` | no `deletedAt` | 5 | present |
| `%5Ba%5D=1` (malformed) | `false` | `deletedAt: null` | 4 | absent |

Every case returned 200 - no malformed value can 422 the request. (The malformed case must be percent-encoded to reach the app: on a deployed stage API Gateway rejects a literal unencoded `[` with a 400 of its own, before any application code runs.) Search path: `?search=needle&includeDeleted=false` returned 2 rows without GHOST, `=true` returned 3 with it.

Sort is genuinely preserved now: `?search=needle&sortBy=title&sortOrder=asc` returns `alpha | charlie`, against the relevance order `charlie | alpha` the old route forced regardless of what was asked.

In the browser: typing in the gallery search box issues `/api/artifacts?...&search=needle` and returns 200 (the old path 422'd). Deleting an artifact takes the badge from 4 to 3, and the row stays gone across a refetch.

Tests: 12 parser cases in `common`, 4 service-layer filter cases, 3 route-plumbing cases, plus the gallery badge test. Mutation-checked - restoring `z.coerce.boolean()` fails the parser cases, and dropping the `searchByText` pass-through fails the service cases.

One incidental note: the diff includes two whitespace hunks in the `db:` object literals - prettier repairing pre-existing mangled one-liners via the pre-commit hook, not deliberate edits.
