### PR TITLE
feat(client): move the refresh token into an HttpOnly cookie

### DIFF
--- a/apps/client/__tests__/api/auth/refreshToken.test.ts
+++ b/apps/client/__tests__/api/auth/refreshToken.test.ts
@@ -55,6 +55,7 @@ vi.mock('@bike4mind/common', () => ({
     isAfter: () => false,
     subtract: () => ({}),
   }),
+  redactUserSecretsForSelf: (user: unknown) => user,
 }));
 
 vi.mock('@server/utils/errors', () => ({
@@ -143,5 +144,67 @@ describe('POST /api/auth/refreshToken — tokenVersion kill switch', () => {
       expect.objectContaining({ impersonatedBy: 'admin-9' }),
       expect.anything()
     );
+  });
+});
+
+describe('POST /api/auth/refreshToken — cookie vs body transport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueSession.mockResolvedValue({ accessToken: 'new_access', refreshToken: 'new_refresh', sid: 'sid' });
+    mockVerifyRefreshToken.mockReturnValue({ userId: 'user-1', tokenVersion: 0 });
+    mockFindById.mockResolvedValue({ id: 'user-1', tokenVersion: 0 });
+  });
+
+  const cookieHeader = (res: any) => String(res.getHeader('Set-Cookie') ?? '');
+
+  it('reads the token from the HttpOnly cookie when the body has none, and rotates it back there', async () => {
+    const { req, res } = createMocks({ method: 'POST', body: {}, headers: { cookie: 'b4m_rt=cookie-token' } });
+
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockVerifyRefreshToken).toHaveBeenCalledWith('cookie-token', undefined);
+    expect(cookieHeader(res)).toContain('b4m_rt=new_refresh');
+    // Never in the body: a page script must not be able to read it.
+    expect(res._getJSONData().refreshToken).toBeUndefined();
+  });
+
+  it('returns the rotated token in the BODY and sets no cookie for a CLI/OAuth caller', async () => {
+    const { req, res } = createMocks({ method: 'POST', body: { refresh_token: 'cli-token' } });
+
+    await handler(req as any, res as any);
+
+    expect(res._getJSONData().refreshToken).toBe('new_refresh');
+    expect(res.getHeader('Set-Cookie')).toBeUndefined();
+  });
+
+  it('migrates a pre-cookie browser session onto the cookie when it opts in with cookie: true', async () => {
+    // The one-shot upgrade path: the token still lives in localStorage, so it arrives in the body,
+    // but the response must move it to a cookie rather than logging the user out.
+    const { req, res } = createMocks({ method: 'POST', body: { token: 'legacy-localstorage-token', cookie: true } });
+
+    await handler(req as any, res as any);
+
+    expect(mockVerifyRefreshToken).toHaveBeenCalledWith('legacy-localstorage-token', undefined);
+    expect(cookieHeader(res)).toContain('b4m_rt=new_refresh');
+    expect(res._getJSONData().refreshToken).toBeUndefined();
+  });
+
+  it('prefers an explicit body token over the cookie (a CLI request carrying a stale browser cookie)', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { refresh_token: 'body-token' },
+      headers: { cookie: 'b4m_rt=cookie-token' },
+    });
+
+    await handler(req as any, res as any);
+
+    expect(mockVerifyRefreshToken).toHaveBeenCalledWith('body-token', undefined);
+  });
+
+  it('rejects when neither transport carries a token', async () => {
+    const { req, res } = createMocks({ method: 'POST', body: {} });
+
+    await expect(handler(req as any, res as any)).rejects.toThrow('Refresh token is required');
   });
 });

--- a/apps/client/__tests__/otc-verify.test.ts
+++ b/apps/client/__tests__/otc-verify.test.ts
@@ -124,7 +124,10 @@ describe('/api/otc/verify — enumeration resistance', () => {
     json: ReturnType<typeof vi.fn>;
     status: ReturnType<typeof vi.fn>;
     setHeader: ReturnType<typeof vi.fn>;
+    getHeader: ReturnType<typeof vi.fn>;
   };
+  // Minimal Set-Cookie accumulator so setRefreshCookie's get/append/set cycle works on the stub.
+  let sentCookies: string[];
 
   const makeReq = (body: Record<string, unknown>) => ({
     body,
@@ -139,7 +142,15 @@ describe('/api/otc/verify — enumeration resistance', () => {
     mockJwtSign.mockReturnValue('reissued-token');
     mockValidateAndRotateNonce.mockResolvedValue(true);
     mockUserHasMFA.mockReturnValue(false);
-    mockRes = { json: vi.fn().mockReturnThis(), status: vi.fn().mockReturnThis(), setHeader: vi.fn() };
+    sentCookies = [];
+    mockRes = {
+      json: vi.fn().mockReturnThis(),
+      status: vi.fn().mockReturnThis(),
+      setHeader: vi.fn((name: string, value: string | string[]) => {
+        if (name === 'Set-Cookie') sentCookies = Array.isArray(value) ? value.map(String) : [String(value)];
+      }),
+      getHeader: vi.fn((name: string) => (name === 'Set-Cookie' && sentCookies.length ? sentCookies : undefined)),
+    };
     const mod = await import('@pages/api/otc/verify');
     handler = mod.default;
   });
@@ -204,7 +215,10 @@ describe('/api/otc/verify — enumeration resistance', () => {
     expect(mockFindByEmail).toHaveBeenCalledWith('user@example.com');
     expect(mockRes.status).toHaveBeenCalledWith(200);
     const body = mockRes.json.mock.calls[0][0];
-    expect(body).toMatchObject({ id: 'u1', username: 'bob', accessToken: 'access', refreshToken: 'refresh' });
+    expect(body).toMatchObject({ id: 'u1', username: 'bob', accessToken: 'access' });
+    // The refresh token is delivered as an HttpOnly cookie, never in the JSON body.
+    expect(body.refreshToken).toBeUndefined();
+    expect(sentCookies.join(';')).toContain('b4m_rt=refresh');
     // Serialized via toJSON - no raw Mongoose internals / select:false fields.
     expect(body.password).toBeUndefined();
   });

--- a/apps/client/app/components/MultiStepLogin.test.tsx
+++ b/apps/client/app/components/MultiStepLogin.test.tsx
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
   userState: { currentUser: null as unknown },
   accessTokenState: {
     accessToken: null as string | null,
-    setVerifiedTokens: vi.fn(),
+    setVerifiedSession: vi.fn(),
     resetTokens: vi.fn(),
     setMfaPendingTokens: vi.fn(),
     forceLogoutTokens: vi.fn(),
@@ -136,16 +136,15 @@ describe('MultiStepLogin — inline registration (new-user branch)', () => {
     await waitFor(() => expect(mocks.setCurrentUser).toHaveBeenCalled());
 
     const arg = mocks.setCurrentUser.mock.calls[0][0];
-    // Regression guard: the user must be flattened, NOT the { user, accessToken, refreshToken } wrapper.
+    // Regression guard: the user must be flattened, NOT the { user, accessToken } wrapper.
     expect(arg).toMatchObject({
       id: 'new-1',
       email: 'new@test.com',
       username: 'newbie',
       accessToken: 'atk',
-      refreshToken: 'rtk',
     });
     expect(arg).not.toHaveProperty('user');
-    expect(mocks.accessTokenState.setVerifiedTokens).toHaveBeenCalledWith('atk', 'rtk');
+    expect(mocks.accessTokenState.setVerifiedSession).toHaveBeenCalledWith('atk');
     // The inline step must thread the abuse-gate fields into the verify call;
     // without them the server rejects every inline registration.
     expect(mocks.verifyOTC).toHaveBeenLastCalledWith(

--- a/apps/client/app/components/MultiStepLogin.tsx
+++ b/apps/client/app/components/MultiStepLogin.tsx
@@ -28,6 +28,7 @@ import { useSendOTC, useVerifyOTC } from '@client/app/hooks/data/auth';
 import { useVerifyMFA, useSetupMFA, useVerifyMFASetup, MFASetupResponse } from '@client/app/hooks/data/mfa';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import { resetRefreshPromise } from '@client/app/contexts/ApiContext';
+import { resetSessionBootstrap } from '@client/app/utils/sessionBootstrap';
 import { useCommonStyles } from '@client/app/hooks/useCommonStyles';
 import { useTheme } from '@mui/joy/styles';
 import MFAModal from './common/MFAModal';
@@ -265,7 +266,10 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
         result = await verifyMFA.mutateAsync({ token });
       }
       resetRefreshPromise();
-      useAccessToken.getState().setVerifiedTokens(result.accessToken, result.refreshToken);
+      // Drop the cached cold-load result: this browser just acquired a session, so the next
+      // protected navigation must not reuse the "no session" answer from before login.
+      resetSessionBootstrap();
+      useAccessToken.getState().setVerifiedSession(result.accessToken);
       setShowMFAModal(false);
       setCurrentUser(result.user);
     } catch (error: unknown) {
@@ -279,11 +283,6 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
         setMfaSetupData(null);
         toast.error((errorData.error as string) || 'Too many failed attempts. Please try again.');
         return;
-      }
-      if (errorData?.accessToken && errorData?.refreshToken) {
-        useAccessToken
-          .getState()
-          .setMfaPendingTokens(errorData.accessToken as string, errorData.refreshToken as string);
       }
       const baseError = (errorData?.error as string) || (error as Error).message || 'MFA verification failed';
       const attemptsInfo = errorData?.attemptsRemaining ? ` (${errorData.attemptsRemaining} attempts remaining)` : '';
@@ -376,7 +375,7 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
       }
 
       // Successful login
-      finishLogin(response as Record<string, unknown> & { accessToken: string; refreshToken: string });
+      finishLogin(response as Record<string, unknown> & { accessToken: string });
     } catch (error: unknown) {
       const errorMessage = (error as Error).message || 'Verification failed';
       // On a wrong code the server re-issues an attempt-tracked pending token with a rotated
@@ -391,10 +390,14 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
     }
   };
 
-  // Shared success path: persist tokens, set the user, honor ?redirectTo.
-  const finishLogin = (user: Record<string, unknown> & { accessToken: string; refreshToken: string }) => {
+  // Shared success path: store the access token, set the user, honor ?redirectTo. The refresh
+  // token is not here - the login endpoint set it as an HttpOnly cookie.
+  const finishLogin = (user: Record<string, unknown> & { accessToken: string }) => {
     resetRefreshPromise();
-    useAccessToken.getState().setVerifiedTokens(user.accessToken, user.refreshToken);
+    // Drop the cached cold-load result: this browser just acquired a session, so the next
+    // protected navigation must not reuse the "no session" answer from before login.
+    resetSessionBootstrap();
+    useAccessToken.getState().setVerifiedSession(user.accessToken);
     setCurrentUser(user as unknown as Parameters<typeof setCurrentUser>[0]);
     const searchParams = new URLSearchParams(window.location.search);
     applyRedirect(router.history, searchParams.get('redirectTo'));
@@ -473,7 +476,6 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
           ? {
               ...(response.user as unknown as Record<string, unknown>),
               accessToken: response.accessToken,
-              refreshToken: response.refreshToken,
             }
           : response;
       if ('user' in response) {
@@ -482,7 +484,7 @@ const MultiStepLogin: React.FC<MultiStepLoginProps> = ({
         // already existed, which must not double-count.
         trackSignupConversion('password');
       }
-      finishLogin(flat as Record<string, unknown> & { accessToken: string; refreshToken: string });
+      finishLogin(flat as Record<string, unknown> & { accessToken: string });
     } catch (error: unknown) {
       const errorMessage = (error as Error).message || 'Registration failed';
       // useVerifyOTC surfaces any re-issued pending token (rotated nonce) at the error

--- a/apps/client/app/components/Register.tsx
+++ b/apps/client/app/components/Register.tsx
@@ -37,6 +37,7 @@ import { gray, brand } from '@client/app/utils/themes/colors';
 import { trackSignupConversion } from '@client/app/utils/signupConversion';
 import { applyRedirect, appendRedirectTo } from '@client/app/utils/authRedirect';
 import { resetRefreshPromise } from '@client/app/contexts/ApiContext';
+import { resetSessionBootstrap } from '@client/app/utils/sessionBootstrap';
 import { CURRENT_POLICY_VERSION } from '@bike4mind/common';
 import { ExternalLinks, CHECKBOX_LABEL_LINK_SX } from '@client/app/utils/externalLinks';
 
@@ -62,7 +63,6 @@ const Register: React.FC = () => {
   const { setCurrentUser, currentUser } = useUser();
   const navigate = useNavigate();
   const router = useRouter();
-  const { setAccessToken } = useAccessToken();
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -249,7 +249,10 @@ const Register: React.FC = () => {
         result = await verifyMFA.mutateAsync({ token });
       }
       resetRefreshPromise();
-      useAccessToken.getState().setVerifiedTokens(result.accessToken, result.refreshToken);
+      // Drop the cached cold-load result: this browser just acquired a session, so the next
+      // protected navigation must not reuse the "no session" answer from before login.
+      resetSessionBootstrap();
+      useAccessToken.getState().setVerifiedSession(result.accessToken);
       setShowMFAModal(false);
       // Setting currentUser triggers the redirect effect above.
       setCurrentUser(result.user);
@@ -264,11 +267,6 @@ const Register: React.FC = () => {
         setMfaSetupData(null);
         toast.error((errorData.error as string) || 'Too many failed attempts. Please try again.');
         return;
-      }
-      if (errorData?.accessToken && errorData?.refreshToken) {
-        useAccessToken
-          .getState()
-          .setMfaPendingTokens(errorData.accessToken as string, errorData.refreshToken as string);
       }
       const baseError = (errorData?.error as string) || (error as Error).message || 'MFA verification failed';
       const attemptsInfo = errorData?.attemptsRemaining ? ` (${errorData.attemptsRemaining} attempts remaining)` : '';
@@ -351,13 +349,15 @@ const Register: React.FC = () => {
         return;
       }
 
-      // Registration successful - response may be OTCRegisterResponse ({ user, accessToken, refreshToken })
-      // or OTCVerifyResponse (user doc spread with tokens). Handle both shapes.
+      // Registration successful - response may be OTCRegisterResponse ({ user, accessToken })
+      // or OTCVerifyResponse (user doc spread with the access token). Handle both shapes.
       const result = response as Record<string, unknown>;
       const accessToken = (result.accessToken as string) || '';
-      const refreshToken = (result.refreshToken as string) || '';
       const user = result.user ?? result; // OTCRegisterResponse has .user, OTCVerifyResponse spreads it
       resetRefreshPromise();
+      // Drop the cached cold-load result: this browser just acquired a session, so the next
+      // protected navigation must not reuse the "no session" answer from before login.
+      resetSessionBootstrap();
 
       if (result.user) {
         // Ad-conversion signal (GA4 sign_up + Reddit SignUp). Fires exactly once per
@@ -368,8 +368,7 @@ const Register: React.FC = () => {
         trackSignupConversion('password');
       }
 
-      setAccessToken(accessToken);
-      useAccessToken.getState().setVerifiedTokens(accessToken, refreshToken);
+      useAccessToken.getState().setVerifiedSession(accessToken);
       setCurrentUser(user as Parameters<typeof setCurrentUser>[0]);
 
       const searchParams = new URLSearchParams(window.location.search);

--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -22,15 +22,20 @@ Authorization: Bearer <access_token>
 
 | Token Type | Lifetime | Description |
 |------------|----------|-------------|
-| Access Token | 7 days | Short-lived token for API requests |
+| Access Token | 30 minutes | Short-lived token for API requests |
 | Refresh Token | 30 days | Used to obtain new access tokens |
 
 **Obtaining tokens:**
 
 - \`POST /api/otc/send\` — request a one-time sign-in code by email (passwordless)
-- \`POST /api/otc/verify\` — verify the code to log in or register; returns both tokens
+- \`POST /api/otc/verify\` — verify the code to log in or register; returns the access token
 - \`POST /api/auth/refreshToken\` — exchange a refresh token for a new access token
-- OAuth callbacks (Google, GitHub, Okta, SAML) return tokens on successful authentication
+- OAuth callbacks (Google, GitHub, Okta, SAML) return an access token on successful authentication
+
+Browser clients never receive the refresh token in a response body: it is set as an
+\`HttpOnly; Secure; SameSite=Strict\` cookie scoped to \`/api\`, and \`POST /api/auth/refreshToken\`
+reads and rotates it from there. Non-browser clients (CLI, OAuth authorization-code and device
+flows) get the refresh token in the response body and send it back the same way.
 
 ### API Key Authentication
 
@@ -1340,7 +1345,8 @@ Admin endpoints require the \`admin:*\` scope or superuser role.
 }
 \`\`\`
 
-Use the refresh token flow to obtain a new access token:
+Use the refresh token flow to obtain a new access token. Non-browser clients pass the token in
+the body; a browser sends an empty body and the HttpOnly cookie supplies it:
 
 \`\`\`
 POST /api/auth/refreshToken
@@ -1388,7 +1394,7 @@ Real-time updates are delivered via WebSocket. Connect to the WebSocket endpoint
 
 7. **Prefer pagination over fetching all.** All list endpoints support \`page\` and \`limit\` parameters. Default page size is 20. Never fetch unbounded lists in production.
 
-8. **Token lifecycle matters.** Access tokens expire after 7 days. Use the refresh token flow (\`POST /api/auth/refreshToken\`) to get new tokens without requiring re-authentication.
+8. **Token lifecycle matters.** Access tokens expire after 30 minutes. Use the refresh token flow (\`POST /api/auth/refreshToken\`) to get new tokens without requiring re-authentication.
 
 9. **Test with the server status endpoint.** Use \`GET /api/settings/serverStatus\` as a lightweight health check. It returns server version, uptime, and configuration without requiring authentication.
 

--- a/apps/client/app/components/auth/MFAEnforcementWrapper.tsx
+++ b/apps/client/app/components/auth/MFAEnforcementWrapper.tsx
@@ -34,7 +34,7 @@ const MFAEnforcementWrapper: React.FC<MFAEnforcementWrapperProps> = ({ children 
   const mfaStatus = mfaStatusQuery.data;
   const mfaQueryFailed = mfaStatusQuery.isError;
 
-  const isImpersonating = useAccessToken(s => !!s.returnToken);
+  const isImpersonating = useAccessToken(s => s.impersonating);
 
   // MFA mutations
   const setupMFA = useSetupMFA();
@@ -157,13 +157,6 @@ const MFAEnforcementWrapper: React.FC<MFAEnforcementWrapperProps> = ({ children 
             // cross-tab background-tab UX.
             window.location.replace(buildLoginRedirectUrl('session_revoked', window.location));
             return;
-          }
-
-          // Update tokens if new attempt count provided (for next try)
-          if (errorData?.accessToken && errorData?.refreshToken) {
-            // Still mid-MFA (next attempt): keep mfaPending true via the named action so the
-            // invariant can't be dropped.
-            useAccessToken.getState().setMfaPendingTokens(errorData.accessToken, errorData.refreshToken);
           }
 
           // Show error with attempts remaining

--- a/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
+++ b/apps/client/app/components/layouts/Notebook/Sidenav/ProfileMenu.tsx
@@ -233,7 +233,7 @@ const ProfileMenu = () => {
   const logEvent = useLogEvent();
   const { data: friendRequests } = useGetFriendRequests(currentUser?.id);
   const returnToAdmin = useReturnToAdmin();
-  const hasReturnToken = useAccessToken(s => s.returnToken);
+  const hasReturnToken = useAccessToken(s => s.impersonating);
   const { mutate: logout, isPending: isPendingLogout } = useUserLogout();
   const appVersion = useAppVersion();
 

--- a/apps/client/app/components/layouts/Notebook/index.tsx
+++ b/apps/client/app/components/layouts/Notebook/index.tsx
@@ -70,7 +70,7 @@ const pulseBorder = keyframes`
 const NotebookLayout: FC<PropsWithChildren<NotebookLayoutProps>> = ({ children }) => {
   const openSideNav = useNotebookLayout(s => s.openSideNav);
   const isMobile = useIsMobile();
-  const isImpersonating = useAccessToken(s => s.returnToken);
+  const isImpersonating = useAccessToken(s => s.impersonating);
   const layout = useSessionLayout(s => s.layout);
 
   // Global keyboard shortcuts

--- a/apps/client/app/contexts/ApiContext.tsx
+++ b/apps/client/app/contexts/ApiContext.tsx
@@ -133,7 +133,7 @@ api.interceptors.request.use(config => {
 api.interceptors.response.use(
   response => response,
   async error => {
-    const { setState, getState } = useAccessToken;
+    const { getState } = useAccessToken;
 
     // Ignore cancelled requests (user-initiated abort)
     if (axios.isCancel(error) || error.code === 'ERR_CANCELED') {
@@ -177,17 +177,18 @@ api.interceptors.response.use(
         return Promise.reject(error);
       }
 
-      const { refreshToken, expired, mfaPending } = getState();
+      const { expired, mfaPending } = getState();
 
-      // Already expired or no refresh token - don't attempt refresh.
-      if (expired || !refreshToken) {
-        // During mfaPending the login stage issues no refresh token by
-        // design (see useAccessToken.ts), so a 401 on a non-allowlisted
-        // endpoint lands here for a user who is mid-MFA-setup, not
-        // actually locked out - skip the forced redirect in that case.
-        if (!mfaPending) {
-          await forceSessionExpiredRedirect();
-        }
+      // During mfaPending the login stage issues no refresh token or cookie by design (see
+      // useAccessToken.ts), so a 401 on a non-allowlisted endpoint is the expected mid-MFA
+      // rejection, not a lockout: there is nothing to refresh and nowhere to redirect.
+      if (mfaPending) {
+        return Promise.reject(error);
+      }
+
+      // Already torn down by a previous unrecoverable 401 - don't attempt refresh again.
+      if (expired) {
+        await forceSessionExpiredRedirect();
         return Promise.reject(error);
       }
 
@@ -212,9 +213,12 @@ api.interceptors.response.use(
       // This request initiates the refresh - all other 401s will queue on this promise
       refreshPromise = (async () => {
         try {
-          const response = await api.post<{ accessToken: string; refreshToken: string }>(
+          // No token in the body: the refresh token rides the HttpOnly cookie, which
+          // `withCredentials` on this axios instance sends. The rotated one comes back the
+          // same way and is never visible to this code.
+          const response = await api.post<{ accessToken: string }>(
             '/api/auth/refreshToken',
-            { token: refreshToken },
+            {},
             {
               skipAuthRefresh: true,
               // Bound the refresh attempt so a cold Lambda or hanging server
@@ -224,10 +228,7 @@ api.interceptors.response.use(
               timeout: 10000,
             }
           );
-          setState({
-            accessToken: response.data.accessToken,
-            refreshToken: response.data.refreshToken,
-          });
+          getState().setVerifiedSession(response.data.accessToken);
         } catch (e) {
           // Only the initiator runs the teardown. Distinguish a genuine
           // revocation from a transient outage by the refresh endpoint's

--- a/apps/client/app/contexts/UserContext.tsx
+++ b/apps/client/app/contexts/UserContext.tsx
@@ -8,7 +8,7 @@ import { api, isPublicPath } from '@client/app/contexts/ApiContext';
 import { buildLoginRedirectUrl } from '@client/app/utils/authRedirect';
 import ExpiredSession from '../components/ExpiredSession';
 import { useSubscribeCollection } from '../utils/react-query';
-import { useGetIdentify, useReturnTokenValidation } from '@client/app/hooks/data/user';
+import { useGetIdentify } from '@client/app/hooks/data/user';
 import { persist, PersistStorage, StorageValue } from 'zustand/middleware';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
@@ -341,7 +341,6 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
     useShallow(s => [s.setAccessToken, s.expired, s.accessToken, s.mfaPending, s.setMfaPending])
   );
   const identity = useGetIdentify();
-  useReturnTokenValidation();
   const { t } = useTranslation();
 
   // Real-time subscription updates instead of periodic polling

--- a/apps/client/app/hooks/data/auth.redirect.test.ts
+++ b/apps/client/app/hooks/data/auth.redirect.test.ts
@@ -24,7 +24,7 @@ vi.mock('@tanstack/react-query', () => ({
 }));
 vi.mock('@client/app/contexts/UserContext', () => ({ useUser: () => ({ setCurrentUser: vi.fn() }) }));
 vi.mock('@client/app/hooks/useAccessToken', () => ({
-  useAccessToken: { getState: () => ({ setVerifiedTokens: vi.fn() }) },
+  useAccessToken: { getState: () => ({ setVerifiedSession: vi.fn() }) },
 }));
 vi.mock('@client/app/contexts/ApiContext', () => ({ api: { get: vi.fn() } }));
 

--- a/apps/client/app/hooks/data/auth.ts
+++ b/apps/client/app/hooks/data/auth.ts
@@ -22,16 +22,17 @@ interface LoginError {
 
 // OTC login response: successful login, MFA required, MFA setup required, or, for an
 // email with no account, a signal to collect a username and finish registration inline.
+// The refresh token is absent from every shape: login endpoints set it as an HttpOnly cookie
+// (server/auth/refreshCookie.ts) rather than returning it.
 type OTCVerifyResponse =
-  | (IUserDocument & { accessToken: string; refreshToken: string })
-  | { mfaRequired: true; userId: string; accessToken: string; refreshToken: string }
-  | { mfaSetupRequired: true; userId: string; accessToken: string; refreshToken: string }
+  | (IUserDocument & { accessToken: string })
+  | { mfaRequired: true; userId: string; accessToken: string }
+  | { mfaSetupRequired: true; userId: string; accessToken: string }
   | { registrationRequired: true; email: string; pendingToken: string };
 
 interface OTCRegisterResponse {
   user: IUserDocument;
   accessToken: string;
-  refreshToken: string;
 }
 
 interface SendOTCData {
@@ -158,7 +159,7 @@ export const useAuthCallback = (
         if (strategy === AuthStrategy.Okta && state !== undefined) {
           params.append('state', state as string);
         }
-        const { data } = await api.get<IUserDocument & { accessToken: string; refreshToken: string }>(
+        const { data } = await api.get<IUserDocument & { accessToken: string }>(
           `/api/auth/${strategy}/callback?${params.toString()}`
         );
         return data;
@@ -174,7 +175,7 @@ export const useAuthCallback = (
   useEffect(() => {
     if (oauthCallback.data) {
       const user = oauthCallback.data;
-      useAccessToken.getState().setVerifiedTokens(user.accessToken, user.refreshToken);
+      useAccessToken.getState().setVerifiedSession(user.accessToken);
       setCurrentUser(user);
       // Route the user-controlled redirectTo through sanitizeRedirectTo so an
       // open-redirect can't ride the OAuth callback. Falls back to /new.

--- a/apps/client/app/hooks/data/user.ts
+++ b/apps/client/app/hooks/data/user.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import {
   Collection,
   CollectionType,
@@ -330,16 +329,14 @@ export function useGetUserCollections(userId: string | undefined | null, params:
 
 export function useLoginAsUser() {
   const queryClient = useQueryClient();
-  const { accessToken, refreshToken, setAccessToken, setRefreshToken, setReturnToken, setReturnRefreshToken } =
-    useAccessToken();
+  const { setVerifiedSession, setImpersonating } = useAccessToken();
   const { setCurrentUser } = useUser();
 
   return useMutation({
     mutationFn: async ({ id, mfaToken }: { id: string; mfaToken: string }) => {
-      const { data } = await api.post<{ user: IUserDocument; accessToken: string; refreshToken: string }>(
-        `/api/users/${id}/loginAs`,
-        { mfaToken }
-      );
+      const { data } = await api.post<{ user: IUserDocument; accessToken: string }>(`/api/users/${id}/loginAs`, {
+        mfaToken,
+      });
       return data;
     },
     onSuccess: async data => {
@@ -354,25 +351,12 @@ export function useLoginAsUser() {
       // null currentUser and redirects to /login (logging the admin out).
       await clearClientCaches();
 
-      // Stash BOTH of the admin's tokens so "Return to Admin" can restore a
-      // consistent session: returnToken (access) is used to validate the return,
-      // returnRefreshToken restores the admin's refresh token (the active one is
-      // about to be swapped to the impersonated user's).
-      // Read from the store (not the hook closure) so we capture the freshest
-      // admin tokens: if the loginAs request hit a 401, ApiContext rotated both
-      // tokens via /api/auth/refreshToken before the retry succeeded, leaving the
-      // closure values stale (and the old refresh token possibly invalidated).
-      // clearClientCaches() above does not touch the token store, so these are
-      // still the admin's. Fall back to the closure values defensively.
-      const { accessToken: adminAccessToken, refreshToken: adminRefreshToken } = useAccessToken.getState();
-      setReturnToken(adminAccessToken ?? accessToken);
-      setReturnRefreshToken(adminRefreshToken ?? refreshToken);
-
-      // Switch the active session to the impersonated user - full token PAIR so a
-      // later refresh keeps the impersonated identity instead of flipping to admin.
-      // Persist their identity so it survives the hard reload below.
-      setAccessToken(data.accessToken);
-      setRefreshToken(data.refreshToken);
+      // The token swap itself happened server-side: /api/users/[id]/loginAs parked the admin's
+      // refresh token in the HttpOnly return cookie and handed the primary cookie to the
+      // impersonated user. Nothing sensitive is stashed here any more - only the access token
+      // (in memory) and the impersonation flag the UI reads.
+      setVerifiedSession(data.accessToken);
+      setImpersonating(true);
       setCurrentUser(data.user);
 
       // Remove in-memory queries only AFTER the impersonated identity is active, so any
@@ -382,7 +366,7 @@ export function useLoginAsUser() {
       toast.success('Successfully logged in as user');
 
       // Wait for state to persist before redirecting
-      // This ensures the new token and user data are saved to localStorage
+      // This ensures the new user data is saved to localStorage
       setTimeout(() => {
         window.location.replace('/new');
       }, 50);
@@ -400,20 +384,21 @@ export function useLoginAsUser() {
   });
 }
 
-// Sentinel for a confirmed-dead admin return token (identify 401/403). onError matches it
-// EXACTLY (not a loose 'expired' substring) so an unrelated error can't trip force-logout.
+// Sentinel for a confirmed-dead admin return session (the return cookie is gone, expired, or
+// its token was already rotated away). onError matches it EXACTLY (not a loose 'expired'
+// substring) so an unrelated error can't trip force-logout.
 export const ADMIN_SESSION_EXPIRED = 'Admin session has expired. Please log in again.';
 
-// Customer-facing message for a transient (5xx / other non-OK) validation failure. No
-// status code (not actionable for a user), and it must NOT equal the sentinel so onError
-// leaves the session intact on flaky connectivity.
+// Customer-facing message for a transient (5xx / network) failure. No status code (not
+// actionable for a user), and it must NOT equal the sentinel so onError leaves the session
+// intact on flaky connectivity.
 export const ADMIN_SESSION_VALIDATION_FAILED = "We couldn't verify your admin session. Please try again.";
 
 /**
- * Maps a /api/identify return-token validation response to the error message to throw, or
- * null on success. Pure so the "a 5xx must not force a logout" invariant is unit-testable
- * without rendering the mutation: only 401/403 yields the force-logout sentinel; any other
- * non-OK yields a transient message that onError won't act on.
+ * Maps a /api/auth/returnToAdmin response to the error message to throw, or null on success.
+ * Pure so the "a 5xx must not force a logout" invariant is unit-testable without rendering the
+ * mutation: only 401/403 yields the force-logout sentinel; any other non-OK yields a transient
+ * message that onError won't act on.
  */
 export function adminReturnValidationError(status: number, ok: boolean): string | null {
   if (status === 401 || status === 403) {
@@ -427,43 +412,37 @@ export function adminReturnValidationError(status: number, ok: boolean): string 
 
 export function useReturnToAdmin() {
   const queryClient = useQueryClient();
-  const { returnToken, returnRefreshToken, setAccessToken, setRefreshToken, setReturnToken, setReturnRefreshToken } =
-    useAccessToken();
+  const { setVerifiedSession, setImpersonating } = useAccessToken();
   const { setCurrentUser } = useUser();
 
   return useMutation({
     mutationFn: async () => {
-      if (!returnToken) {
-        throw new Error('No admin token available');
-      }
-      // Validate the return token is still usable by calling identify with it.
-      // Use fetch directly (not the api axios instance) to bypass the request
-      // interceptor that would overwrite the Authorization header with the
-      // impersonated user's token.
+      // The admin's refresh token lives in the HttpOnly return cookie, so the whole swap is a
+      // single server round-trip: it rotates that token, hands it back as the primary refresh
+      // cookie, revokes the impersonation session and returns a fresh admin access token.
+      // Uses fetch rather than the `api` instance so the request interceptor can't attach the
+      // impersonated user's bearer token - the route authenticates on the cookie alone.
       let res: Response;
       try {
-        res = await fetch('/api/identify', {
-          headers: { Authorization: `Bearer ${returnToken}` },
-        });
+        res = await fetch('/api/auth/returnToAdmin', { method: 'POST', credentials: 'same-origin' });
       } catch (err) {
-        // Network failure (offline / DNS) - transient, like a 5xx: show the friendly
-        // message and keep the session (not the ADMIN_SESSION_EXPIRED sentinel, so onError
-        // won't force a logout) rather than a raw "Failed to fetch".
-        // Log the raw error first so genuinely broken connectivity is visible in telemetry
-        // (the friendly remap below would otherwise swallow it entirely).
-        console.warn('Return-to-admin identify request failed (network error):', err);
+        // Network failure (offline / DNS) - transient, like a 5xx: show the friendly message and
+        // keep the session (not the ADMIN_SESSION_EXPIRED sentinel, so onError won't force a
+        // logout) rather than a raw "Failed to fetch". Log the raw error first so genuinely
+        // broken connectivity is visible in telemetry.
+        console.warn('Return-to-admin request failed (network error):', err);
         throw new Error(ADMIN_SESSION_VALIDATION_FAILED);
       }
-      // Only an auth rejection (401/403) means the admin's return token is actually dead
-      // and the session must be torn down; any other non-OK (5xx) is transient and must not
-      // force a logout. adminReturnValidationError encodes that rule (and is unit-tested).
+      // Only an auth rejection (401/403) means the admin's return cookie is actually dead and the
+      // session must be torn down; any other non-OK (5xx) is transient and must not force a
+      // logout. adminReturnValidationError encodes that rule (and is unit-tested).
       const validationError = adminReturnValidationError(res.status, res.ok);
       if (validationError) {
         throw new Error(validationError);
       }
       return (await res.json()) as { user: IUserDocument; accessToken: string };
     },
-    onSuccess: async ({ user: adminUser, accessToken: freshToken }) => {
+    onSuccess: async ({ user: adminUser, accessToken }) => {
       // Cancel in-flight queries (e.g. admin-settings) BEFORE clearing caches so a
       // request dispatched under the impersonated token can't resolve and re-persist
       // impersonated data after clearClientCaches() deletes the IndexedDB blob.
@@ -475,17 +454,8 @@ export function useReturnToAdmin() {
       // redirects to /login.
       await clearClientCaches();
 
-      // Use the fresh token from identify (may have been refreshed if near expiry)
-      // and restore the admin's refresh token. In the current flow the active
-      // refresh token is the impersonated user's, so swap in returnRefreshToken.
-      // If returnRefreshToken is absent we're in a pre-upgrade session (old loginAs
-      // never stashed it) - and old loginAs also never swapped the refresh token,
-      // so the active one is still the admin's. Fall back to it rather than clearing
-      // it, which would otherwise break the restored admin session's token refresh.
-      setAccessToken(freshToken ?? returnToken);
-      setRefreshToken(returnRefreshToken ?? useAccessToken.getState().refreshToken);
-      setReturnToken(null);
-      setReturnRefreshToken(null);
+      setVerifiedSession(accessToken);
+      setImpersonating(false);
       setCurrentUser(adminUser);
 
       // Remove in-memory queries only AFTER the admin identity is restored, so any
@@ -495,7 +465,6 @@ export function useReturnToAdmin() {
       toast.success('Successfully returned to admin account');
 
       // Wait for state to persist before redirecting
-      // This ensures the token and user data are saved to localStorage
       setTimeout(() => {
         window.location.replace('/new');
       }, 50);
@@ -505,12 +474,12 @@ export function useReturnToAdmin() {
 
       toast.error(errorMessage);
 
-      // Only a confirmed-expired admin token (401/403) forces a full logout; transient
+      // Only a confirmed-dead return cookie (401/403) forces a full logout; transient
       // 5xx / network failures leave the session intact (don't log the admin out on flaky
-      // connectivity). markSessionExpired() clears every token (including the impersonation
-      // return tokens, as resetTokens() did) and stamps expiredReason: 'expired'. Redirect
-      // via session_expired so the reason reliably shows on the login page - the toast above
-      // can be lost when window.location.replace tears down the DOM before sonner paints.
+      // connectivity). markSessionExpired() clears the session and stamps
+      // expiredReason: 'expired'. Redirect via session_expired so the reason reliably shows on
+      // the login page - the toast above can be lost when window.location.replace tears down the
+      // DOM before sonner paints.
       if (errorMessage === ADMIN_SESSION_EXPIRED) {
         useAccessToken.getState().markSessionExpired();
         setCurrentUser(null);
@@ -518,26 +487,6 @@ export function useReturnToAdmin() {
       }
     },
   });
-}
-
-export function useReturnTokenValidation() {
-  useEffect(() => {
-    const { returnToken, setReturnToken, setReturnRefreshToken, accessToken } = useAccessToken.getState();
-    if (!accessToken || !returnToken) return;
-    fetch('/api/identify', { headers: { Authorization: `Bearer ${returnToken}` } })
-      .then(res => {
-        if (res.status === 401 || res.status === 403) {
-          // Admin return credential is dead - drop both halves together.
-          setReturnToken(null);
-          setReturnRefreshToken(null);
-        }
-        // Other non-ok statuses (5xx, etc.) are server errors - don't clear
-      })
-      .catch(() => {
-        // Network error - token validity is unknown; preserve it so the admin
-        // can still use "Return to Admin" once connectivity is restored
-      });
-  }, []); // [] is correct — getState() is a snapshot, not a React subscription
 }
 
 export function useGetOrganizationUsers(organizationId: string | null | undefined) {

--- a/apps/client/app/hooks/useAccessToken.test.ts
+++ b/apps/client/app/hooks/useAccessToken.test.ts
@@ -5,13 +5,11 @@ import { useAccessToken, useIsFullyAuthenticated } from './useAccessToken';
 describe('useAccessToken store', () => {
   beforeEach(() => {
     // Start each test from a populated, logged-in-and-impersonating state so a
-    // clear action has something to clear on every field (including the
-    // returnToken/returnRefreshToken impersonation tokens).
+    // clear action has something to clear on every field.
     useAccessToken.setState({
       accessToken: 'access',
-      refreshToken: 'refresh',
-      returnToken: 'return',
-      returnRefreshToken: 'return-refresh',
+      impersonating: true,
+      hasSession: true,
       mfaPending: true,
       expired: false,
       expiredReason: null,
@@ -19,14 +17,13 @@ describe('useAccessToken store', () => {
   });
 
   describe('markSessionExpired', () => {
-    it('clears every token field and sets expired: true with reason "expired"', () => {
+    it('clears the session and sets expired: true with reason "expired"', () => {
       useAccessToken.getState().markSessionExpired();
 
       expect(useAccessToken.getState()).toMatchObject({
         accessToken: null,
-        refreshToken: null,
-        returnToken: null,
-        returnRefreshToken: null,
+        impersonating: false,
+        hasSession: false,
         mfaPending: false,
         expired: true,
         expiredReason: 'expired',
@@ -61,24 +58,23 @@ describe('useAccessToken store', () => {
       expect(state.accessToken).toBeNull();
       expect(state.expired).toBe(true);
       expect(state.expiredReason).toBe('revoked');
-      // Intentionally PRESERVES the impersonation return tokens (unlike markSessionRevoked,
-      // which clears them) - lock that divergence so a refactor can't silently drop it.
-      expect(state.returnToken).toBe('return');
-      expect(state.returnRefreshToken).toBe('return-refresh');
+      // Intentionally leaves the impersonation flag alone (unlike markSessionRevoked, which
+      // clears it): an MFA lockout is the impersonated user's failure, not the admin's, and the
+      // admin's HttpOnly return cookie is still valid. Lock that divergence.
+      expect(state.impersonating).toBe(true);
     });
   });
 
   describe('markSessionRevoked', () => {
-    it('clears every token including impersonation return tokens, with reason "revoked"', () => {
-      // The hard-revocation path (server-side tokenVersion kill-switch) must not leave an
-      // admin's stashed return token behind - unlike forceLogoutTokens, which keeps it.
+    it('clears the session including the impersonation flag, with reason "revoked"', () => {
+      // The hard-revocation path (server-side tokenVersion kill-switch) must not leave the
+      // session looking like a live impersonation - unlike forceLogoutTokens, which keeps it.
       useAccessToken.getState().markSessionRevoked();
 
       expect(useAccessToken.getState()).toMatchObject({
         accessToken: null,
-        refreshToken: null,
-        returnToken: null,
-        returnRefreshToken: null,
+        impersonating: false,
+        hasSession: false,
         mfaPending: false,
         expired: true,
         expiredReason: 'revoked',
@@ -118,19 +114,19 @@ describe('useAccessToken store', () => {
       const { result } = renderHook(() => useIsFullyAuthenticated());
       expect(result.current).toBe(false);
 
-      act(() => useAccessToken.getState().setVerifiedTokens('verified-token', 'refresh'));
+      act(() => useAccessToken.getState().setVerifiedSession('verified-token'));
       expect(result.current).toBe(true);
     });
   });
 
   describe('re-auth clears a stale expiredReason', () => {
-    it('setVerifiedTokens resets expiredReason after a prior forced logout', () => {
+    it('setVerifiedSession resets expiredReason after a prior forced logout', () => {
       // Without the reset, a 'revoked' value would linger with expired: false -
       // misleading any future consumer that reads expiredReason without the gate.
       useAccessToken.getState().forceLogoutTokens();
       expect(useAccessToken.getState().expiredReason).toBe('revoked');
 
-      useAccessToken.getState().setVerifiedTokens('new-access', 'new-refresh');
+      useAccessToken.getState().setVerifiedSession('new-access');
 
       const state = useAccessToken.getState();
       expect(state.expired).toBe(false);

--- a/apps/client/app/hooks/useAccessToken.ts
+++ b/apps/client/app/hooks/useAccessToken.ts
@@ -1,8 +1,29 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-/** localStorage key used by Zustand persist - referenced by cross-tab logout listener. */
+/** localStorage key used by Zustand persist - referenced by cross-tab logout listener.
+ *  NOTE: no credential is written here any more. Only the non-sensitive session-state flags
+ *  (hasSession / expired / expiredReason) are persisted; the access token lives in memory and
+ *  the refresh token lives in an HttpOnly cookie (server/auth/refreshCookie.ts). */
 export const ACCESS_TOKEN_STORAGE_KEY = 'access-token-storage';
+
+/**
+ * One-shot carrier for a refresh token left in localStorage by a pre-cookie session.
+ *
+ * Sessions created before the refresh token moved into an HttpOnly cookie persisted it here.
+ * The persist `migrate` below strips it (that is the whole point), but dropping it outright
+ * would sign every existing user out on deploy - so it is lifted into memory on the way past
+ * and handed to the bootstrap refresh once, which exchanges it for a cookie. Read via
+ * takeLegacyRefreshToken(), which also clears it so it can never be replayed.
+ */
+let legacyRefreshToken: string | null = null;
+
+/** Consume the pre-cookie refresh token, if this browser had one. Single-use. */
+export function takeLegacyRefreshToken(): string | null {
+  const token = legacyRefreshToken;
+  legacyRefreshToken = null;
+  return token;
+}
 
 /** Why a session ended, when it ended involuntarily. 'expired' = a failed mid-session
  *  refresh; 'revoked' = a security-forced logout (e.g. 3-strike MFA lockout). null while
@@ -10,19 +31,36 @@ export const ACCESS_TOKEN_STORAGE_KEY = 'access-token-storage';
  *  message via crossTabLogout. */
 export type ExpiredSessionReason = 'expired' | 'revoked';
 
+/** Exactly what reaches localStorage - see `partialize`. No credential is a member of this
+ *  type, and none should ever become one. crossTabLogout.ts reads the same shape. */
+export interface PersistedSessionState {
+  hasSession: boolean;
+  expired: boolean;
+  expiredReason: ExpiredSessionReason | null;
+}
+
 /**
  * Global state for the access token.
  * For now, this is only used on websocket messages.
  */
 export const useAccessToken = create<{
+  /** In-memory ONLY (never persisted): a page reload re-obtains it via the bootstrap silent
+   *  refresh, which exchanges the HttpOnly refresh cookie. Kept in JS rather than a cookie
+   *  because the WebSocket lives on a different registrable domain and authenticates with
+   *  `?token=<accessToken>`, which a cookie cannot reach. */
   accessToken: string | null;
-  refreshToken: string | null;
-  returnToken: string | null;
-  /** The impersonating admin's refresh token, stashed during loginAs so
-   *  "Return to Admin" can restore a consistent admin session. The active
-   *  refreshToken is swapped to the impersonated user's, so this must be held
-   *  separately rather than relying on refreshToken staying the admin's. */
-  returnRefreshToken: string | null;
+  /** True while the active session belongs to a user an admin is impersonating. Derived from
+   *  the server (`impersonating` on the loginAs / refresh / identify responses) because the
+   *  admin's own credentials are no longer held client-side - they are parked in the HttpOnly
+   *  return cookie and restored by POST /api/auth/returnToAdmin. */
+  impersonating: boolean;
+  /** Persisted, non-sensitive: "this browser believes it has a session". The cross-tab logout
+   *  listener needs a durable flag to tell "the other tab logged out" from "the other tab is
+   *  still signed in", a job the persisted accessToken used to do. Deliberately NOT used to
+   *  decide whether to attempt the bootstrap refresh: WebKit ITP evicts localStorage after
+   *  ~7 days while leaving the server-set cookie intact, and gating on this flag would
+   *  reintroduce exactly the mobile-Safari logout this design removes. */
+  hasSession: boolean;
   /** True when the stored tokens are mfaPending (pre-MFA-verification).
    *  UserProvider gates setCurrentUser on this flag so /api/identify responses
    *  with mfaPending tokens don't populate currentUser prematurely.
@@ -30,42 +68,34 @@ export const useAccessToken = create<{
    *  Not persisted (see partialize below): it's a transient, tab-owned flag. */
   mfaPending: boolean;
   setAccessToken: (token: string | null) => void;
-  setReturnToken: (token: string | null) => void;
-  setReturnRefreshToken: (token: string | null) => void;
-  setRefreshToken: (token: string | null) => void;
+  setImpersonating: (value: boolean) => void;
   resetTokens: () => void;
-  /** Store tokens for an in-flight MFA login (pre-verification). Sets mfaPending: true so
-   *  UserProvider won't populate currentUser from /api/identify yet.
-   *  refreshToken is intentionally optional - the mfaPending stage no longer issues one
-   *  (prevents the MFA-bypass path where a refresh exchange skips the second factor). */
-  setMfaPendingTokens: (accessToken: string, refreshToken?: string | null) => void;
-  /** Store fully-verified session tokens. Clears mfaPending so UserProvider can bootstrap. */
-  setVerifiedTokens: (accessToken: string, refreshToken: string) => void;
+  /** Store the short-lived access token for an in-flight MFA login (pre-verification). Sets
+   *  mfaPending: true so UserProvider won't populate currentUser from /api/identify yet. The
+   *  mfaPending stage issues no refresh token or cookie at all (prevents the MFA-bypass path
+   *  where a refresh exchange skips the second factor). */
+  setMfaPendingTokens: (accessToken: string) => void;
+  /** Store a fully-verified session's access token. The matching refresh token was set as an
+   *  HttpOnly cookie by the login endpoint and is never seen here. Clears mfaPending so
+   *  UserProvider can bootstrap. */
+  setVerifiedSession: (accessToken: string) => void;
   /** Set just the mfaPending flag (e.g. cross-tab rehydrate where the server's identify
    *  response is authoritative - see UserContext.tsx). */
   setMfaPending: (value: boolean) => void;
-  /** Clear tokens for a forced logout (3-strike MFA lockout). Distinct from resetTokens():
+  /** Clear the session for a forced logout (3-strike MFA lockout). Distinct from resetTokens():
    *  sets expired: true (the session was revoked, not voluntarily ended) while still clearing
    *  mfaPending explicitly. Named so this clear path can't silently drop the invariant.
-   *  Deliberately PRESERVES the impersonation returnToken/returnRefreshToken: an MFA lockout is
-   *  the impersonated user's MFA failing, not the admin's, so the admin's stashed return session
-   *  is still valid and should survive. A hard revocation of the admin's own session uses
-   *  markSessionRevoked() instead, which clears those too. Keep this divergence intentional. */
+   *  The impersonating flag is deliberately left alone: an MFA lockout is the impersonated
+   *  user's MFA failing, not the admin's, and the admin's return cookie is still valid. */
   forceLogoutTokens: () => void;
-  /** Clear all tokens AND set expired: true in a single atomic write - used by the API 401
-   *  interceptor when a mid-session refresh fails. Like resetTokens() it also clears the
-   *  impersonation tokens (returnToken/returnRefreshToken), which forceLogoutTokens() leaves
-   *  intact, but unlike resetTokens() it sets expired: true. One set() = one persisted write =
-   *  one cross-tab storage event carrying the final expired: true payload, so background tabs
-   *  never observe a transient expired: false and race to a plain /login. Clearing the return
-   *  tokens is intentional: an admin whose impersonated session can't refresh is sent to /login
-   *  rather than popped back to their own session (matches the prior resetTokens behavior;
-   *  auto-popping back on a failed refresh is out of scope). */
+  /** Clear the session AND set expired: true in a single atomic write - used by the API 401
+   *  interceptor when a mid-session refresh fails. Unlike resetTokens() it sets expired: true.
+   *  One set() = one persisted write = one cross-tab storage event carrying the final
+   *  expired: true payload, so background tabs never observe a transient expired: false and
+   *  race to a plain /login. */
   markSessionExpired: () => void;
-  /** Like markSessionExpired (clears every token, including the impersonation return tokens)
-   *  but stamps expiredReason: 'revoked'. Used for a hard server-side revocation - e.g. the
-   *  tokenVersion kill-switch - where leaving an admin's stashed return token behind would be
-   *  wrong. */
+  /** Like markSessionExpired but stamps expiredReason: 'revoked'. Used for a hard server-side
+   *  revocation - e.g. the tokenVersion kill-switch. */
   markSessionRevoked: () => void;
   expired: boolean;
   /** Why the session ended, persisted so a background tab's cross-tab listener
@@ -79,53 +109,46 @@ export const useAccessToken = create<{
   persist(
     set => ({
       accessToken: null,
-      refreshToken: null,
-      returnToken: null,
-      returnRefreshToken: null,
+      impersonating: false,
+      hasSession: false,
       mfaPending: false,
       expired: true,
       expiredReason: null,
       setAccessToken: token => {
-        set({ accessToken: token, expired: false, expiredReason: null });
+        set({ accessToken: token, hasSession: !!token, expired: false, expiredReason: null });
       },
-      setReturnToken: token => {
-        set({ returnToken: token });
-      },
-      setReturnRefreshToken: token => {
-        set({ returnRefreshToken: token });
-      },
-      setRefreshToken: token => {
-        set({ refreshToken: token });
+      setImpersonating: value => {
+        set({ impersonating: value });
       },
       resetTokens: () => {
         set({
           accessToken: null,
-          refreshToken: null,
-          returnToken: null,
-          returnRefreshToken: null,
+          impersonating: false,
+          hasSession: false,
           mfaPending: false,
           expired: false,
           expiredReason: null,
         });
       },
-      setMfaPendingTokens: (accessToken, refreshToken) => {
-        set({ accessToken, refreshToken: refreshToken ?? null, expired: false, mfaPending: true, expiredReason: null });
+      setMfaPendingTokens: accessToken => {
+        // hasSession stays false: mfaPending has no refresh cookie behind it, so there is no
+        // session for another tab to converge on until the second factor clears.
+        set({ accessToken, expired: false, mfaPending: true, expiredReason: null });
       },
-      setVerifiedTokens: (accessToken, refreshToken) => {
-        set({ accessToken, refreshToken, expired: false, mfaPending: false, expiredReason: null });
+      setVerifiedSession: accessToken => {
+        set({ accessToken, hasSession: true, expired: false, mfaPending: false, expiredReason: null });
       },
       setMfaPending: value => {
         set({ mfaPending: value });
       },
       forceLogoutTokens: () => {
-        set({ accessToken: null, refreshToken: null, expired: true, mfaPending: false, expiredReason: 'revoked' });
+        set({ accessToken: null, hasSession: false, expired: true, mfaPending: false, expiredReason: 'revoked' });
       },
       markSessionExpired: () => {
         set({
           accessToken: null,
-          refreshToken: null,
-          returnToken: null,
-          returnRefreshToken: null,
+          impersonating: false,
+          hasSession: false,
           mfaPending: false,
           expired: true,
           expiredReason: 'expired',
@@ -134,9 +157,8 @@ export const useAccessToken = create<{
       markSessionRevoked: () => {
         set({
           accessToken: null,
-          refreshToken: null,
-          returnToken: null,
-          returnRefreshToken: null,
+          impersonating: false,
+          hasSession: false,
           mfaPending: false,
           expired: true,
           expiredReason: 'revoked',
@@ -145,18 +167,36 @@ export const useAccessToken = create<{
     }),
     {
       name: ACCESS_TOKEN_STORAGE_KEY,
-      // Persist only the durable token fields. mfaPending is a transient,
-      // tab-owned flag for an in-flight MFA login; if it survived a reload it
-      // would leave UserProvider permanently gating setCurrentUser (see
-      // UserContext.tsx), stranding the account in a half-bootstrapped state.
+      // NO CREDENTIAL IS PERSISTED. The access token is memory-only (a reload re-obtains it via
+      // the bootstrap silent refresh) and the refresh token is an HttpOnly cookie the page can
+      // never read. What remains are the flags the cross-tab logout listener reads
+      // (crossTabLogout.ts): whether a session is believed active, and if it ended, why.
+      // mfaPending is excluded as before: it's a transient, tab-owned flag for an in-flight MFA
+      // login; surviving a reload would leave UserProvider permanently gating setCurrentUser
+      // (see UserContext.tsx), stranding the account in a half-bootstrapped state.
       partialize: state => ({
-        accessToken: state.accessToken,
-        refreshToken: state.refreshToken,
-        returnToken: state.returnToken,
-        returnRefreshToken: state.returnRefreshToken,
+        hasSession: state.hasSession,
         expired: state.expired,
         expiredReason: state.expiredReason,
       }),
+      // v1 drops the four persisted credentials (accessToken / refreshToken / returnToken /
+      // returnRefreshToken). partialize alone is not enough: persist REHYDRATES whatever is in
+      // storage, so without this a stale access token from a pre-upgrade session would be
+      // loaded back into the store and used until the server rejected it. The refresh token is
+      // lifted out first so the bootstrap refresh can trade it for a cookie instead of the
+      // upgrade logging everyone out.
+      version: 1,
+      migrate: persisted => {
+        const state = (persisted ?? {}) as Partial<PersistedSessionState> & { refreshToken?: string | null };
+        if (typeof state.refreshToken === 'string' && state.refreshToken.length > 0) {
+          legacyRefreshToken = state.refreshToken;
+        }
+        return {
+          hasSession: state.hasSession ?? !!legacyRefreshToken,
+          expired: state.expired ?? true,
+          expiredReason: state.expiredReason ?? null,
+        };
+      },
     }
   )
 );

--- a/apps/client/app/router.tsx
+++ b/apps/client/app/router.tsx
@@ -14,6 +14,7 @@ import NotebookLayout from '@client/app/components/layouts/Notebook';
 import { useUser } from '@client/app/contexts/UserContext';
 import { buildRedirectTo } from '@client/app/utils/authRedirect';
 import { enforceConsentRedirect } from '@client/app/utils/consentGuard';
+import { bootstrapSession } from '@client/app/utils/sessionBootstrap';
 
 // Keep layout components as eager imports for optimal performance
 import RestrictedPage from './components/common/RestrictedPage';
@@ -179,7 +180,15 @@ const rootRoute = createRootRoute({
 const layoutRoute = createRoute({
   getParentRoute: () => rootRoute,
   id: 'layout',
-  beforeLoad: ({ location }) => {
+  beforeLoad: async ({ location }) => {
+    // Cold-load ordering: the access token is memory-only, so a fresh page load has no session
+    // until the HttpOnly refresh cookie is exchanged. This guard must wait for that - firing on
+    // a not-yet-populated currentUser would redirect to /login, whose on-mount
+    // clearClientCaches() + removeQueries() tears the session down before it can establish.
+    // bootstrapSession() resolves instantly once the answer is known, so only the first
+    // navigation of a page load actually waits.
+    await bootstrapSession();
+
     const { currentUser } = useUser.getState();
     if (!currentUser) {
       const redirectTo = buildRedirectTo(
@@ -196,7 +205,7 @@ const layoutRoute = createRoute({
     // P0-B abuse gate: route an authenticated-but-not-yet-consented account (in practice a
     // brand-new OAuth/SAML/OTC user) to the acceptance interstitial. Shared with the standalone
     // rootRoute children so the guard can't drift (see enforceConsentRedirect / issue #382).
-    enforceConsentRedirect(location);
+    await enforceConsentRedirect(location);
 
     // Handle redirects stored in sessionStorage to work around CloudFront Access Denied
     // on SPA routes (CloudFront can only serve "/" directly; all other paths return 403).
@@ -614,10 +623,9 @@ const authSuccessRoute = createRoute({
   ),
   validateSearch: (
     search: Record<string, unknown>
-  ): { token?: string; refreshToken?: string; error?: string; userId?: string; redirectTo?: string } => {
+  ): { token?: string; error?: string; userId?: string; redirectTo?: string } => {
     return {
       token: search.token ? String(search.token) : undefined,
-      refreshToken: search.refreshToken ? String(search.refreshToken) : undefined,
       error: search.error ? String(search.error) : undefined,
       userId: search.userId ? String(search.userId) : undefined,
       redirectTo: search.redirectTo ? String(search.redirectTo) : undefined,

--- a/apps/client/app/routes/admin-emergency.tsx
+++ b/apps/client/app/routes/admin-emergency.tsx
@@ -39,16 +39,14 @@ const AdminEmergencyPage = () => {
       if (response.data.success) {
         const userData = response.data.user;
 
-        // Extract tokens from user data (they're embedded by the backend)
-        const { accessToken, refreshToken, ...userWithoutTokens } = userData;
+        // Extract the access token from user data (embedded by the backend). The refresh token
+        // is not here - the endpoint set it as an HttpOnly cookie.
+        const { accessToken, ...userWithoutTokens } = userData;
 
-        console.log('🔐 Emergency login tokens extracted:', {
-          hasAccessToken: !!accessToken,
-          hasRefreshToken: !!refreshToken,
-        });
+        console.log('Emergency login token extracted:', { hasAccessToken: !!accessToken });
 
-        // Store tokens in useAccessToken store (CRITICAL for API calls)
-        useAccessToken.getState().setVerifiedTokens(accessToken, refreshToken);
+        // Store the access token in useAccessToken store (CRITICAL for API calls)
+        useAccessToken.getState().setVerifiedSession(accessToken);
 
         // Set user context (without embedded tokens)
         setCurrentUser(userWithoutTokens);

--- a/apps/client/app/routes/auth/success.test.tsx
+++ b/apps/client/app/routes/auth/success.test.tsx
@@ -7,8 +7,7 @@ const {
   mockNavigate,
   mockRouterHistory,
   mockSetCurrentUser,
-  mockSetAccessToken,
-  mockSetRefreshToken,
+  mockSetVerifiedSession,
   mockGetState,
   mockParseAuthParams,
   mockApplyRedirect,
@@ -16,8 +15,7 @@ const {
   mockNavigate: vi.fn(),
   mockRouterHistory: { push: vi.fn() },
   mockSetCurrentUser: vi.fn(),
-  mockSetAccessToken: vi.fn(),
-  mockSetRefreshToken: vi.fn(),
+  mockSetVerifiedSession: vi.fn(),
   mockGetState: vi.fn(() => ({ accessToken: null as string | null })),
   mockParseAuthParams: vi.fn(),
   mockApplyRedirect: vi.fn(),
@@ -38,13 +36,17 @@ vi.mock('@client/app/contexts/UserContext', () => ({
 }));
 
 vi.mock('@client/app/hooks/useAccessToken', () => ({
-  useAccessToken: Object.assign(() => ({ setAccessToken: mockSetAccessToken, setRefreshToken: mockSetRefreshToken }), {
+  useAccessToken: Object.assign(() => ({ setVerifiedSession: mockSetVerifiedSession }), {
     getState: mockGetState,
   }),
 }));
 
 vi.mock('@client/app/contexts/ApiContext', () => ({
   resetRefreshPromise: vi.fn(),
+}));
+
+vi.mock('@client/app/utils/sessionBootstrap', () => ({
+  resetSessionBootstrap: vi.fn(),
 }));
 
 vi.mock('@client/app/utils/authParams', () => ({
@@ -73,7 +75,7 @@ vi.mock('@mui/joy', () => ({
 
 import AuthSuccessPage from './success';
 
-const TOKENS = { token: 'tok', refreshToken: 'ref', userId: 'u1', error: undefined };
+const TOKENS = { token: 'tok', userId: 'u1', error: undefined };
 const USER_DATA = { id: 'u1', name: 'Test User' };
 
 beforeEach(() => {
@@ -90,8 +92,7 @@ describe('AuthSuccessPage', () => {
     render(<AuthSuccessPage />);
 
     await waitFor(() => expect(mockApplyRedirect).toHaveBeenCalledWith(mockRouterHistory, '/new'));
-    expect(mockSetAccessToken).toHaveBeenCalledWith('tok');
-    expect(mockSetRefreshToken).toHaveBeenCalledWith('ref');
+    expect(mockSetVerifiedSession).toHaveBeenCalledWith('tok');
     expect(mockSetCurrentUser).toHaveBeenCalledWith(USER_DATA);
     expect(mockNavigate).not.toHaveBeenCalled();
     // A routine login is not a signup - no conversion.

--- a/apps/client/app/routes/auth/success.tsx
+++ b/apps/client/app/routes/auth/success.tsx
@@ -4,6 +4,7 @@ import { CircularProgress, Container, Typography, Box } from '@mui/joy';
 import { useUser } from '@client/app/contexts/UserContext';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import { resetRefreshPromise } from '@client/app/contexts/ApiContext';
+import { resetSessionBootstrap } from '@client/app/utils/sessionBootstrap';
 import { parseAuthParams } from '@client/app/utils/authParams';
 import { applyRedirect } from '@client/app/utils/authRedirect';
 import { trackSignupConversion } from '@client/app/utils/signupConversion';
@@ -13,7 +14,7 @@ const AuthSuccessPage = () => {
   const router = useRouter();
   const search = useSearch({ strict: false });
   const { setCurrentUser } = useUser();
-  const { setAccessToken, setRefreshToken } = useAccessToken();
+  const { setVerifiedSession } = useAccessToken();
   const hasProcessed = useRef(false);
 
   useEffect(() => {
@@ -23,9 +24,7 @@ const AuthSuccessPage = () => {
     hasProcessed.current = true;
 
     const handleAuthSuccess = async () => {
-      const { token, refreshToken, error, userId, isNewUser, signupMethod } = parseAuthParams(
-        search as Record<string, unknown>
-      );
+      const { token, error, userId, isNewUser, signupMethod } = parseAuthParams(search as Record<string, unknown>);
 
       if (error) {
         console.error('Authentication error:', error);
@@ -33,12 +32,14 @@ const AuthSuccessPage = () => {
         return;
       }
 
-      if (token && refreshToken && userId) {
+      if (token && userId) {
         try {
-          // Set the tokens - reset any stale refresh promise first
+          // Set the access token - reset any stale refresh promise first. The matching refresh
+          // token never reaches the client: the SSO callback set it as an HttpOnly cookie, which
+          // is also why it is no longer in this page's URL fragment.
           resetRefreshPromise();
-          setAccessToken(token as string);
-          setRefreshToken(refreshToken as string);
+          resetSessionBootstrap();
+          setVerifiedSession(token as string);
 
           const response = await fetch(`/api/users/${userId}`, {
             headers: {
@@ -82,7 +83,7 @@ const AuthSuccessPage = () => {
         // component instance after the hash has already been cleared by the first
         // mount. If the access token is already in the store, auth completed
         // successfully - redirect to the destination instead of showing an error.
-        // A user with a persisted (localStorage) token who reaches this page
+        // A user who already holds an in-memory access token and reaches this page
         // with no hash/error is also redirected rather than shown missing_tokens:
         // they hold a valid session, so forwarding them is the correct outcome.
         const { accessToken } = useAccessToken.getState();
@@ -96,7 +97,7 @@ const AuthSuccessPage = () => {
 
     handleAuthSuccess();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [navigate, setCurrentUser, setAccessToken, setRefreshToken]);
+  }, [navigate, setCurrentUser, setVerifiedSession]);
 
   return (
     <Container

--- a/apps/client/app/utils/__tests__/authParams.test.ts
+++ b/apps/client/app/utils/__tests__/authParams.test.ts
@@ -4,36 +4,33 @@ import { parseHashParams, parseQueryParams, parseAuthParams } from '../authParam
 describe('authParams', () => {
   describe('parseHashParams', () => {
     it('should parse complete hash params with leading #', () => {
-      const hash = '#token=abc123&refreshToken=refresh456&userId=user789';
+      const hash = '#token=abc123&userId=user789';
       const result = parseHashParams(hash);
 
       expect(result).toEqual({
         token: 'abc123',
-        refreshToken: 'refresh456',
         userId: 'user789',
         error: undefined,
       });
     });
 
     it('should parse complete hash params without leading #', () => {
-      const hash = 'token=abc123&refreshToken=refresh456&userId=user789';
+      const hash = 'token=abc123&userId=user789';
       const result = parseHashParams(hash);
 
       expect(result).toEqual({
         token: 'abc123',
-        refreshToken: 'refresh456',
         userId: 'user789',
         error: undefined,
       });
     });
 
     it('should include error when present with complete params', () => {
-      const hash = '#token=abc&refreshToken=ref&userId=user&error=some_error';
+      const hash = '#token=abc&userId=user&error=some_error';
       const result = parseHashParams(hash);
 
       expect(result).toEqual({
         token: 'abc',
-        refreshToken: 'ref',
         userId: 'user',
         error: 'some_error',
       });
@@ -53,20 +50,19 @@ describe('authParams', () => {
 
     it('should return null for incomplete token data', () => {
       // Missing userId
-      expect(parseHashParams('#token=abc&refreshToken=ref')).toBeNull();
-      // Missing refreshToken
-      expect(parseHashParams('#token=abc&userId=user')).toBeNull();
+      expect(parseHashParams('#token=abc')).toBeNull();
       // Missing token
+      expect(parseHashParams('#userId=user')).toBeNull();
+      // A stale fragment carrying only the (now cookie-borne) refresh token is not a session
       expect(parseHashParams('#refreshToken=ref&userId=user')).toBeNull();
     });
 
     it('should handle URL-encoded values', () => {
-      const hash = '#token=abc%20123&refreshToken=ref%2B456&userId=user%40test';
+      const hash = '#token=abc%20123&userId=user%40test';
       const result = parseHashParams(hash);
 
       expect(result).toEqual({
         token: 'abc 123',
-        refreshToken: 'ref+456',
         userId: 'user@test',
         error: undefined,
       });
@@ -75,7 +71,7 @@ describe('authParams', () => {
     it('should handle JWT-like tokens', () => {
       // nosemgrep: generic.secrets.security.detected-jwt-token.detected-jwt-token
       const jwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N';
-      const hash = `#token=${jwtToken}&refreshToken=refresh&userId=123`;
+      const hash = `#token=${jwtToken}&userId=123`;
       const result = parseHashParams(hash);
 
       expect(result?.token).toBe(jwtToken);
@@ -86,14 +82,12 @@ describe('authParams', () => {
     it('should parse complete query params', () => {
       const search = {
         token: 'abc123',
-        refreshToken: 'refresh456',
         userId: 'user789',
       };
       const result = parseQueryParams(search);
 
       expect(result).toEqual({
         token: 'abc123',
-        refreshToken: 'refresh456',
         userId: 'user789',
         error: undefined,
       });
@@ -102,7 +96,6 @@ describe('authParams', () => {
     it('should include error when present', () => {
       const search = {
         token: 'abc',
-        refreshToken: 'ref',
         userId: 'user',
         error: 'some_error',
       };
@@ -110,7 +103,6 @@ describe('authParams', () => {
 
       expect(result).toEqual({
         token: 'abc',
-        refreshToken: 'ref',
         userId: 'user',
         error: 'some_error',
       });
@@ -121,7 +113,6 @@ describe('authParams', () => {
 
       expect(result).toEqual({
         token: undefined,
-        refreshToken: undefined,
         userId: undefined,
         error: undefined,
       });
@@ -130,7 +121,6 @@ describe('authParams', () => {
     it('should ignore non-string values', () => {
       const search = {
         token: 123,
-        refreshToken: ['array'],
         userId: null,
         error: undefined,
       };
@@ -138,7 +128,6 @@ describe('authParams', () => {
 
       expect(result).toEqual({
         token: undefined,
-        refreshToken: undefined,
         userId: undefined,
         error: undefined,
       });
@@ -150,7 +139,6 @@ describe('authParams', () => {
 
       expect(result).toEqual({
         token: 'abc',
-        refreshToken: undefined,
         userId: undefined,
         error: undefined,
       });
@@ -165,7 +153,7 @@ describe('authParams', () => {
     it('should prefer hash params when window has hash', () => {
       const mockWindow = {
         location: {
-          hash: '#token=hashToken&refreshToken=hashRefresh&userId=hashUser',
+          hash: '#token=hashToken&userId=hashUser',
           pathname: '/auth/success',
           search: '',
         },
@@ -176,7 +164,6 @@ describe('authParams', () => {
 
       const search = {
         token: 'queryToken',
-        refreshToken: 'queryRefresh',
         userId: 'queryUser',
       };
 
@@ -184,7 +171,6 @@ describe('authParams', () => {
 
       expect(result).toEqual({
         token: 'hashToken',
-        refreshToken: 'hashRefresh',
         userId: 'hashUser',
         error: undefined,
       });
@@ -194,7 +180,7 @@ describe('authParams', () => {
       const replaceStateMock = vi.fn();
       const mockWindow = {
         location: {
-          hash: '#token=abc&refreshToken=ref&userId=user',
+          hash: '#token=abc&userId=user',
           pathname: '/auth/success',
           search: '',
         },
@@ -222,7 +208,6 @@ describe('authParams', () => {
 
       const search = {
         token: 'queryToken',
-        refreshToken: 'queryRefresh',
         userId: 'queryUser',
       };
 
@@ -230,7 +215,6 @@ describe('authParams', () => {
 
       expect(result).toEqual({
         token: 'queryToken',
-        refreshToken: 'queryRefresh',
         userId: 'queryUser',
         error: undefined,
       });
@@ -250,7 +234,6 @@ describe('authParams', () => {
 
       const search = {
         token: 'queryToken',
-        refreshToken: 'queryRefresh',
         userId: 'queryUser',
       };
 
@@ -258,7 +241,6 @@ describe('authParams', () => {
 
       expect(result).toEqual({
         token: 'queryToken',
-        refreshToken: 'queryRefresh',
         userId: 'queryUser',
         error: undefined,
       });
@@ -285,7 +267,7 @@ describe('authParams', () => {
       const replaceStateMock = vi.fn();
       const mockWindow = {
         location: {
-          hash: '#token=abc&refreshToken=ref&userId=user',
+          hash: '#token=abc&userId=user',
           pathname: '/auth/success',
           search: '?redirectTo=%2Fnew',
         },
@@ -300,7 +282,6 @@ describe('authParams', () => {
     it('should handle undefined window (SSR)', () => {
       const search = {
         token: 'queryToken',
-        refreshToken: 'queryRefresh',
         userId: 'queryUser',
       };
 
@@ -309,7 +290,6 @@ describe('authParams', () => {
 
       expect(result).toEqual({
         token: 'queryToken',
-        refreshToken: 'queryRefresh',
         userId: 'queryUser',
         error: undefined,
       });
@@ -318,7 +298,7 @@ describe('authParams', () => {
     it('should handle window without history (edge case)', () => {
       const mockWindow = {
         location: {
-          hash: '#token=abc&refreshToken=ref&userId=user',
+          hash: '#token=abc&userId=user',
           pathname: '/auth/success',
           search: '',
         },
@@ -330,7 +310,6 @@ describe('authParams', () => {
 
       expect(result).toEqual({
         token: 'abc',
-        refreshToken: 'ref',
         userId: 'user',
         error: undefined,
       });

--- a/apps/client/app/utils/authParams.ts
+++ b/apps/client/app/utils/authParams.ts
@@ -1,17 +1,20 @@
 /**
  * Auth Parameters Parser Utility
  *
- * Parses OAuth tokens from URL - supports both query params (legacy) and hash fragments (secure)
+ * Parses the OAuth access token from the URL - supports both query params (legacy) and hash
+ * fragments (secure).
  *
  * Hash fragments are preferred because they:
  * - Are not sent to servers in Referer headers
  * - Are not logged in server access logs
  * - Provide better security for OAuth token transport
+ *
+ * The refresh token is NOT carried here any more: SSO callbacks set it as an HttpOnly cookie
+ * (server/auth/refreshCookie.ts), so the long-lived credential never touches a URL at all.
  */
 
 export interface AuthParams {
   token?: string;
-  refreshToken?: string;
   userId?: string;
   error?: string;
   /** True only when the OAuth callback just created a brand-new account. */
@@ -40,15 +43,13 @@ export function parseHashParams(hash: string): AuthParams | null {
 
   const hashParams = new URLSearchParams(hashContent);
   const token = hashParams.get('token');
-  const refreshToken = hashParams.get('refreshToken');
   const userId = hashParams.get('userId');
   const error = hashParams.get('error');
 
   // Only return hash params if we have complete token data
-  if (token && refreshToken && userId) {
+  if (token && userId) {
     return {
       token,
-      refreshToken,
       userId,
       error: error || undefined,
       isNewUser: hashParams.get('isNewUser') === '1' || undefined,
@@ -73,7 +74,6 @@ export function parseHashParams(hash: string): AuthParams | null {
 export function parseQueryParams(search: Record<string, unknown>): AuthParams {
   return {
     token: typeof search.token === 'string' ? search.token : undefined,
-    refreshToken: typeof search.refreshToken === 'string' ? search.refreshToken : undefined,
     userId: typeof search.userId === 'string' ? search.userId : undefined,
     error: typeof search.error === 'string' ? search.error : undefined,
   };

--- a/apps/client/app/utils/consentGuard.test.ts
+++ b/apps/client/app/utils/consentGuard.test.ts
@@ -20,6 +20,9 @@ vi.mock('@client/app/contexts/UserContext', () => ({
 vi.mock('@client/app/hooks/useAccessToken', () => ({
   useAccessToken: { getState: () => tokenState },
 }));
+// The guard awaits the cold-load silent refresh before reading the stores; stub it to a resolved
+// no-op so these tests exercise only the gate decision, not the network exchange.
+vi.mock('./sessionBootstrap', () => ({ bootstrapSession: () => Promise.resolve() }));
 
 import { enforceConsentRedirect } from './consentGuard';
 
@@ -32,16 +35,16 @@ describe('enforceConsentRedirect', () => {
     tokenState = { accessToken: TOKEN };
   });
 
-  it('redirects a not-yet-consented account to /accept-policies with a return path', () => {
+  it('redirects a not-yet-consented account to /accept-policies with a return path', async () => {
     userState = { currentUser: { aupAcceptedVersion: undefined }, isHydrated: true };
-    expect(() => enforceConsentRedirect(loc('/admin'))).toThrow(
+    await expect(enforceConsentRedirect(loc('/admin'))).rejects.toThrow(
       expect.objectContaining({ isRedirect: true, to: '/accept-policies', search: { redirectTo: '/admin' } })
     );
   });
 
-  it('preserves the full search string in the return path (the OAuth authorize case)', () => {
+  it('preserves the full search string in the return path (the OAuth authorize case)', async () => {
     userState = { currentUser: {}, isHydrated: true };
-    expect(() => enforceConsentRedirect(loc('/oauth/authorize', '?client_id=abc&response_type=code'))).toThrow(
+    await expect(enforceConsentRedirect(loc('/oauth/authorize', '?client_id=abc&response_type=code'))).rejects.toThrow(
       expect.objectContaining({
         to: '/accept-policies',
         search: { redirectTo: '/oauth/authorize?client_id=abc&response_type=code' },
@@ -49,31 +52,31 @@ describe('enforceConsentRedirect', () => {
     );
   });
 
-  it('omits redirectTo when the location is not worth preserving (home page)', () => {
+  it('omits redirectTo when the location is not worth preserving (home page)', async () => {
     userState = { currentUser: {}, isHydrated: true };
-    expect(() => enforceConsentRedirect(loc('/'))).toThrow(
+    await expect(enforceConsentRedirect(loc('/'))).rejects.toThrow(
       expect.objectContaining({ to: '/accept-policies', search: undefined })
     );
   });
 
-  it('does NOT redirect an already-consented account', () => {
+  it('does NOT redirect an already-consented account', async () => {
     userState = { currentUser: { aupAcceptedVersion: 'v1' }, isHydrated: true };
-    expect(() => enforceConsentRedirect(loc('/admin'))).not.toThrow();
+    await expect(enforceConsentRedirect(loc('/admin'))).resolves.toBeUndefined();
   });
 
-  it('does NOT redirect a token-less / broken session (goes to /login instead, issue #386)', () => {
+  it('does NOT redirect a token-less / broken session (goes to /login instead, issue #386)', async () => {
     userState = { currentUser: {}, isHydrated: true };
     tokenState = { accessToken: null };
-    expect(() => enforceConsentRedirect(loc('/admin'))).not.toThrow();
+    await expect(enforceConsentRedirect(loc('/admin'))).resolves.toBeUndefined();
   });
 
-  it('does NOT redirect before the server-confirmed user has hydrated', () => {
+  it('does NOT redirect before the server-confirmed user has hydrated', async () => {
     userState = { currentUser: {}, isHydrated: false };
-    expect(() => enforceConsentRedirect(loc('/admin'))).not.toThrow();
+    await expect(enforceConsentRedirect(loc('/admin'))).resolves.toBeUndefined();
   });
 
-  it('does NOT redirect when there is no user (that path bounces to /login)', () => {
+  it('does NOT redirect when there is no user (that path bounces to /login)', async () => {
     userState = { currentUser: null, isHydrated: true };
-    expect(() => enforceConsentRedirect(loc('/admin'))).not.toThrow();
+    await expect(enforceConsentRedirect(loc('/admin'))).resolves.toBeUndefined();
   });
 });

--- a/apps/client/app/utils/consentGuard.ts
+++ b/apps/client/app/utils/consentGuard.ts
@@ -2,6 +2,7 @@ import { redirect } from '@tanstack/react-router';
 import { useUser } from '@client/app/contexts/UserContext';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import { buildRedirectTo, shouldRedirectToConsent } from './authRedirect';
+import { bootstrapSession } from './sessionBootstrap';
 
 /**
  * Consent-redirect guard shared by the app-shell `layoutRoute` and every standalone
@@ -16,8 +17,18 @@ import { buildRedirectTo, shouldRedirectToConsent } from './authRedirect';
  * in a try/catch. UX only - the server consent-gate middleware (server/auth/auth.ts) is the
  * real enforcement and fails closed. See shouldRedirectToConsent for the gate rationale
  * (issues #369, #386).
+ *
+ * Awaits the cold-load silent refresh first. The access token is memory-only now, so on a fresh
+ * page load neither it nor a server-confirmed currentUser exists until the refresh cookie has
+ * been exchanged - evaluating the gate before that would read a signed-in user as signed-out.
+ * bootstrapSession() is cached, so this is a resolved microtask on every subsequent navigation.
  */
-export function enforceConsentRedirect(location: { pathname: string; searchStr: string; hash: string }): void {
+export async function enforceConsentRedirect(location: {
+  pathname: string;
+  searchStr: string;
+  hash: string;
+}): Promise<void> {
+  await bootstrapSession();
   const { currentUser, isHydrated } = useUser.getState();
   const { accessToken } = useAccessToken.getState();
   if (shouldRedirectToConsent({ currentUser, isHydrated, accessToken })) {

--- a/apps/client/app/utils/crossTabLogout.test.ts
+++ b/apps/client/app/utils/crossTabLogout.test.ts
@@ -10,15 +10,16 @@ describe('resolveCrossTabRedirect', () => {
     expect(resolveCrossTabRedirect(null, loc('/new'))).toBe('/login');
   });
 
-  it('returns null when the other tab still holds an accessToken (cross-tab refresh)', () => {
-    // A token refresh in another tab rewrites the entry with a fresh accessToken -
-    // this tab is still authenticated, so it must NOT bounce to /login.
-    expect(resolveCrossTabRedirect(payload({ accessToken: 'fresh', expired: false }), loc('/new'))).toBeNull();
+  it('returns null when the other tab still reports an active session', () => {
+    // A sign-in in another tab rewrites the entry with hasSession: true - this tab is still
+    // authenticated, so it must NOT bounce to /login. (A plain token refresh no longer touches
+    // localStorage at all, so it never even reaches here.)
+    expect(resolveCrossTabRedirect(payload({ hasSession: true, expired: false }), loc('/new'))).toBeNull();
   });
 
   it('surfaces session_expired with redirectTo on a refresh-failure expiry', () => {
     const url = resolveCrossTabRedirect(
-      payload({ accessToken: null, expired: true, expiredReason: 'expired' }),
+      payload({ hasSession: false, expired: true, expiredReason: 'expired' }),
       loc('/projects', '?a=1', '#x')
     );
     expect(url).toBe(`/login?error=session_expired&redirectTo=${encodeURIComponent('/projects?a=1#x')}`);
@@ -26,7 +27,7 @@ describe('resolveCrossTabRedirect', () => {
 
   it('surfaces session_revoked for a security-forced logout (MFA lockout)', () => {
     const url = resolveCrossTabRedirect(
-      payload({ accessToken: null, expired: true, expiredReason: 'revoked' }),
+      payload({ hasSession: false, expired: true, expiredReason: 'revoked' }),
       loc('/new')
     );
     expect(url).toBe(`/login?error=session_revoked&redirectTo=${encodeURIComponent('/new')}`);
@@ -36,21 +37,21 @@ describe('resolveCrossTabRedirect', () => {
     // A background tab mid-login / register / password-reset must not be yanked to /login
     // by another tab's session change - that would wipe an in-progress form.
     expect(
-      resolveCrossTabRedirect(payload({ accessToken: null, expired: true, expiredReason: 'expired' }), loc('/login'))
+      resolveCrossTabRedirect(payload({ hasSession: false, expired: true, expiredReason: 'expired' }), loc('/login'))
     ).toBeNull();
     expect(
-      resolveCrossTabRedirect(payload({ accessToken: null, expired: true, expiredReason: 'revoked' }), loc('/register'))
+      resolveCrossTabRedirect(payload({ hasSession: false, expired: true, expiredReason: 'revoked' }), loc('/register'))
     ).toBeNull();
     // even a plain removed-key logout is a no-op on a public path
     expect(resolveCrossTabRedirect(null, loc('/login'))).toBeNull();
   });
 
   it('uses a plain /login for a voluntary logout (expired: false)', () => {
-    expect(resolveCrossTabRedirect(payload({ accessToken: null, expired: false }), loc('/new'))).toBe('/login');
+    expect(resolveCrossTabRedirect(payload({ hasSession: false, expired: false }), loc('/new'))).toBe('/login');
   });
 
   it('uses a plain /login when expired is true but the reason is unknown', () => {
-    expect(resolveCrossTabRedirect(payload({ accessToken: null, expired: true }), loc('/new'))).toBe('/login');
+    expect(resolveCrossTabRedirect(payload({ hasSession: false, expired: true }), loc('/new'))).toBe('/login');
   });
 
   it('treats malformed JSON as a plain logout', () => {
@@ -59,7 +60,7 @@ describe('resolveCrossTabRedirect', () => {
 });
 
 describe('resolveStorageEventRedirect', () => {
-  const cleared = payload({ accessToken: null, expired: true, expiredReason: 'expired' });
+  const cleared = payload({ hasSession: false, expired: true, expiredReason: 'expired' });
 
   it('ignores storage events for any other localStorage key', () => {
     // Same payload that WOULD redirect, but under an unrelated key - must be a no-op.
@@ -73,10 +74,10 @@ describe('resolveStorageEventRedirect', () => {
     );
   });
 
-  it('returns null for the access-token key when a token is still present (delegated no-op)', () => {
+  it('returns null for the access-token key when a session is still active (delegated no-op)', () => {
     expect(
       resolveStorageEventRedirect(
-        { key: ACCESS_TOKEN_STORAGE_KEY, newValue: payload({ accessToken: 'fresh' }) },
+        { key: ACCESS_TOKEN_STORAGE_KEY, newValue: payload({ hasSession: true }) },
         loc('/new')
       )
     ).toBeNull();

--- a/apps/client/app/utils/crossTabLogout.ts
+++ b/apps/client/app/utils/crossTabLogout.ts
@@ -26,7 +26,7 @@ export interface CrossTabLocation {
  * Decide where a background tab should navigate when the access-token storage entry
  * changes in another tab (the 'storage' event only fires cross-tab). Returns the URL
  * for window.location.replace, or null when no redirect is warranted (the entry still
- * holds a valid accessToken - e.g. a cross-tab token refresh). Pure so the cross-tab
+ * reports an active session - e.g. the other tab just signed in). Pure so the cross-tab
  * logout branch can be unit-tested without rendering the provider tree.
  */
 export function resolveCrossTabRedirect(newValue: string | null, location: CrossTabLocation): string | null {
@@ -44,7 +44,7 @@ export function resolveCrossTabRedirect(newValue: string | null, location: Cross
     return '/login';
   }
 
-  let parsed: { state?: { accessToken?: string | null; expired?: boolean; expiredReason?: string | null } };
+  let parsed: { state?: { hasSession?: boolean; expired?: boolean; expiredReason?: string | null } };
   try {
     parsed = JSON.parse(newValue);
   } catch {
@@ -52,13 +52,15 @@ export function resolveCrossTabRedirect(newValue: string | null, location: Cross
     return '/login';
   }
 
-  // A truthy accessToken means the other tab is still authenticated (e.g. it just
-  // refreshed the token) - nothing to do in this tab.
-  if (parsed?.state?.accessToken) {
+  // hasSession means the other tab is still authenticated (e.g. it just signed in) - nothing to
+  // do in this tab. It replaces the persisted accessToken this used to read: no credential is
+  // written to localStorage any more, so a plain token refresh now produces no storage event at
+  // all and only genuine session-state changes reach this function.
+  if (parsed?.state?.hasSession) {
     return null;
   }
 
-  // Tokens are cleared (and we're on a protected page - public paths returned above).
+  // The session is over (and we're on a protected page - public paths returned above).
   // Only an expired: true payload with a known reason gets the tailored ?error= UX; a
   // voluntary logout (expired: false / unknown reason) gets a plain /login with no toast.
   const reason = parsed?.state?.expired === true ? parsed?.state?.expiredReason : null;

--- a/apps/client/app/utils/sessionBootstrap.ts
+++ b/apps/client/app/utils/sessionBootstrap.ts
@@ -1,0 +1,75 @@
+import { IUserDocument } from '@bike4mind/common';
+import { api } from '@client/app/contexts/ApiContext';
+import { takeLegacyRefreshToken, useAccessToken } from '@client/app/hooks/useAccessToken';
+import { useUser } from '@client/app/contexts/UserContext';
+
+/**
+ * Cold-load silent refresh.
+ *
+ * The access token is memory-only, so after any page load the app has no credential until it
+ * exchanges the HttpOnly refresh cookie for a fresh one. Every protected route awaits this in
+ * `beforeLoad` (see router.tsx): treating "no token yet" as "logged out" would bounce a cold
+ * load through /login, whose on-mount clearClientCaches() + removeQueries() tears the session
+ * down before it can be established.
+ *
+ * Deliberately unconditional - it does NOT check any localStorage flag first. WebKit ITP evicts
+ * script-writable storage after ~7 days while leaving a server-set cookie intact, and that
+ * asymmetry is the whole reason the refresh token moved into a cookie. The cost is one 401 for
+ * a genuinely signed-out visitor who lands on a protected deep link.
+ */
+
+interface RefreshResponse {
+  user?: IUserDocument;
+  accessToken: string;
+  impersonating?: boolean;
+}
+
+/** Cached for the page's lifetime: resolved OR rejected, the answer does not change until a
+ *  login/logout resets it. Without caching, every route transition would re-run the exchange. */
+let bootstrapPromise: Promise<void> | null = null;
+
+/** Drop the cached result so the next protected navigation re-derives the session. Call after
+ *  any client-side identity change (login, logout, impersonation swap). */
+export function resetSessionBootstrap(): void {
+  bootstrapPromise = null;
+}
+
+async function exchangeRefreshCookie(): Promise<void> {
+  // A pre-cookie session still holds its refresh token in localStorage; send it once with
+  // `cookie: true` so the server migrates it onto a cookie instead of logging the user out.
+  const legacy = takeLegacyRefreshToken();
+
+  try {
+    const { data } = await api.post<RefreshResponse>(
+      '/api/auth/refreshToken',
+      legacy ? { token: legacy, cookie: true } : {},
+      {
+        // skipAuthRefresh: a 401 here means "no session", not "refresh me" - letting the
+        // interceptor react would recurse and force a /login redirect on an anonymous visitor.
+        skipAuthRefresh: true,
+        // Same 10s bound as the interceptor's refresh: a cold Lambda must not hang the guard.
+        timeout: 10000,
+      }
+    );
+
+    useAccessToken.getState().setVerifiedSession(data.accessToken);
+    useAccessToken.getState().setImpersonating(!!data.impersonating);
+    if (data.user) {
+      useUser.getState().setCurrentUser(data.user);
+    }
+  } catch {
+    // No recoverable session. Leave the stores alone rather than marking the session expired:
+    // the route guard turns a null currentUser into a /login redirect with the deep link
+    // preserved, and stamping expiredReason here would show a spurious "session expired" toast
+    // to someone who was simply never signed in.
+  }
+}
+
+/** Idempotent; safe to await from every guard and from concurrent navigations. */
+export function bootstrapSession(): Promise<void> {
+  if (useAccessToken.getState().accessToken) {
+    return Promise.resolve();
+  }
+  bootstrapPromise ??= exchangeRefreshCookie();
+  return bootstrapPromise;
+}

--- a/apps/client/e2e/README.md
+++ b/apps/client/e2e/README.md
@@ -162,13 +162,13 @@ run before the tests:
 
 1. **Creates test users** via `/api/test/create-user` with timestamped emails (e.g., `setup-admin-17100000-e2e@test.com`, or `setup-admin-alice-17100000-e2e@test.com` if `E2E_TEST_ID=alice`). The response carries `accessToken` + `refreshToken`.
 2. **Configures features** — enables Agents globally (admin setting) and per-user (preferences)
-3. **Seeds auth** — `seedAuthStorageState` (in `helpers/auth-seed.ts`) writes the returned tokens into the `access-token-storage` localStorage key and saves the browser's `storageState` to `.auth/`
+3. **Seeds auth** — `seedAuthStorageState` (in `helpers/auth-seed.ts`) plants the returned refresh token as the app's HttpOnly `b4m_rt` cookie and saves the browser's `storageState` to `.auth/`. The app's cold-load silent refresh exchanges it for an access token on the first navigation; nothing is written to localStorage.
 4. **Saves credentials** to `.auth/*-data.json` (including tokens) for API-based test setup and mid-test user switching
 5. **Creates invite code** for the signup spec
 
-For mid-test user switching, `seedAuthOnPage` sets the same localStorage value on
-a live page and navigates to `/` to bootstrap the authenticated app. An agent
-(Claude Code + Playwright MCP) authenticates the same way — by token-seeding, not
+For mid-test user switching, `seedAuthOnPage` swaps the same cookie on a live
+page's context and navigates to `/` to bootstrap the authenticated app. An agent
+(Claude Code + Playwright MCP) authenticates the same way — by cookie-seeding, not
 by a password/OTC UI round-trip.
 
 Before setup runs, `global-setup.ts` calls `/api/test/cleanup` to remove stale test users from prior runs. After all tests, `global-teardown.ts` does the same.

--- a/apps/client/e2e/helpers/api.ts
+++ b/apps/client/e2e/helpers/api.ts
@@ -190,16 +190,40 @@ export async function apiLoginViaOtc(
   if (!verifyResponse.ok()) {
     throw new Error(`OTC verify failed: ${verifyResponse.status()} ${verifyResponse.statusText()}`);
   }
+  // The refresh token is no longer in the body - /api/otc/verify sets it as an HttpOnly cookie -
+  // so it has to be read back off Set-Cookie.
+  const refreshToken = refreshTokenFromSetCookie(verifyResponse.headers()['set-cookie']);
+
   // /api/otc/verify returns 200 without tokens in some envs (MFA-enforced ->
   // mfaRequired/mfaSetupRequired; registrationRequired -> no tokens). Fail loud and local
   // here instead of returning undefined tokens that surface later as an opaque auth-seed 401.
-  const body = (await verifyResponse.json()) as { accessToken?: string; refreshToken?: string };
-  if (!body.accessToken || !body.refreshToken) {
+  const body = (await verifyResponse.json()) as { accessToken?: string };
+  if (!body.accessToken || !refreshToken) {
     throw new Error(
-      `OTC verify returned no tokens (mfaRequired/registrationRequired?): keys=${Object.keys(body).join(',')}`
+      `OTC verify returned no tokens (mfaRequired/registrationRequired?): keys=${Object.keys(body).join(',')}, ` +
+        `refreshCookie=${refreshToken ? 'set' : 'missing'}`
     );
   }
-  return { accessToken: body.accessToken, refreshToken: body.refreshToken };
+  return { accessToken: body.accessToken, refreshToken };
+}
+
+/**
+ * Pull the refresh token out of a Set-Cookie response header. Playwright joins multiple
+ * Set-Cookie headers with newlines, so scan line by line. Mirrors REFRESH_COOKIE_NAME in
+ * apps/client/server/auth/refreshCookie.ts - keep in sync.
+ */
+export function refreshTokenFromSetCookie(setCookieHeader: string | undefined): string | null {
+  if (!setCookieHeader) return null;
+  for (const line of setCookieHeader.split('\n')) {
+    const [pair] = line.split(';');
+    const eq = pair.indexOf('=');
+    if (eq === -1) continue;
+    if (pair.slice(0, eq).trim() === 'b4m_rt') {
+      const value = pair.slice(eq + 1).trim();
+      return value.length > 0 ? value : null;
+    }
+  }
+  return null;
 }
 
 export async function apiCreateFile(

--- a/apps/client/e2e/helpers/auth-seed.ts
+++ b/apps/client/e2e/helpers/auth-seed.ts
@@ -1,106 +1,71 @@
 import { type Page } from '@playwright/test';
 
 /**
- * Token-seed auth helpers.
+ * Cookie-seed auth helpers.
  *
  * This is the machine auth path now that login is passwordless (email OTC).
- * `apiCreateTestUser` returns real access/refresh tokens, so we can write the
- * app's persisted auth directly into localStorage - no UI round-trip and no OTC
- * email to read. An agent (e.g. Claude Code + Playwright MCP) authenticates the
- * same way: seed the token, never drive the OTC UI.
+ * `apiCreateTestUser` returns a real opaque `<sid>.<secret>` refresh token, so we can plant it
+ * as the app's HttpOnly refresh cookie and let the app's own cold-load silent refresh
+ * (app/utils/sessionBootstrap.ts) exchange it for an access token - no UI round-trip and no OTC
+ * email to read. An agent (e.g. Claude Code + Playwright MCP) authenticates the same way.
  *
- * We seed BOTH the token store AND the user store (currentUser). The user store is
- * load-bearing: the router guard (`router.tsx` beforeLoad) redirects to /login
- * whenever `currentUser` is null, and /login's on-mount `clearClientCaches()` +
- * `removeQueries()` (routes/login.tsx) tears the session down before `/api/identify`
- * can populate it - so seeding the token alone races the guard and lands on the
- * hostile /login route. Resolving the user up-front (the same endpoint the app uses)
- * and seeding `currentUser` lets the app boot straight into the authenticated shell.
- *
- * The values are injected via `addInitScript` (runs before any app script on the
- * next navigation), so Zustand's persist middleware hydrates from them instead of
- * an empty store - then we navigate to `/`, never to /login.
+ * This deliberately seeds NOTHING in localStorage. The access token is memory-only and the
+ * refresh token is HttpOnly, so a cookie is the only thing there is to seed - and driving the
+ * real bootstrap path means the suite exercises the same cold-load sequence a user gets.
+ * Because the router guard awaits that bootstrap before evaluating `currentUser`, seeding the
+ * `user-context` store to get past it (which the old localStorage seed had to do) is no longer
+ * necessary.
  */
 
-/**
- * localStorage keys for the app's Zustand persist stores. Mirror the app:
- *   token: ACCESS_TOKEN_STORAGE_KEY in apps/client/app/hooks/useAccessToken.ts
- *   user:  name/version in apps/client/app/contexts/UserContext.tsx (currently v2)
- * Hardcoded here so the e2e suite doesn't import from the app - keep in sync.
- */
-const ACCESS_TOKEN_STORAGE_KEY = 'access-token-storage';
-const USER_CONTEXT_STORAGE_KEY = 'user-context';
-const USER_CONTEXT_VERSION = 2; // v2: persisted currentUser includes `preferences`
+/** Mirrors REFRESH_COOKIE_NAME / COOKIE_PATH in apps/client/server/auth/refreshCookie.ts.
+ *  Hardcoded so the e2e suite doesn't import from the app - keep in sync. */
+const REFRESH_COOKIE_NAME = 'b4m_rt';
+const REFRESH_COOKIE_PATH = '/api';
 
 interface SeedTokens {
   accessToken: string;
   refreshToken: string;
 }
 
-/** Persisted token store (version 0) - shape mirrors the partialize in useAccessToken.ts. */
-function buildTokenValue(tokens: SeedTokens): string {
-  return JSON.stringify({
-    state: {
-      accessToken: tokens.accessToken,
-      refreshToken: tokens.refreshToken,
-      returnToken: null,
-      returnRefreshToken: null,
-      expired: false,
-      expiredReason: null,
+/** Plant the refresh cookie on the browser context so the next navigation boots authenticated. */
+async function injectRefreshCookie(page: Page, tokens: SeedTokens): Promise<void> {
+  const baseURL = process.env.API_URL || 'http://localhost:3000';
+  const { hostname } = new URL(baseURL);
+  await page.context().addCookies([
+    {
+      name: REFRESH_COOKIE_NAME,
+      value: tokens.refreshToken,
+      domain: hostname,
+      path: REFRESH_COOKIE_PATH,
+      httpOnly: true,
+      // Secure is omitted: e2e runs against plain http, and a Secure cookie would be dropped.
+      sameSite: 'Strict',
     },
-    version: 0,
-  });
-}
-
-/** Persisted user store - seeds currentUser so the router guard passes on first load. */
-function buildUserContextValue(user: unknown): string {
-  return JSON.stringify({ state: { currentUser: user }, version: USER_CONTEXT_VERSION });
+  ]);
 }
 
 /**
- * Resolve the full user with the same call the app makes (`/api/identify`), so the
- * seeded currentUser is complete (incl. preferences -> useGetIdentify uses it as
- * initialData and skips a refetch). Throws if the token is rejected.
- */
-async function resolveUser(page: Page, accessToken: string): Promise<unknown> {
-  const resp = await page.request.get('/api/identify', {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
-  if (!resp.ok()) {
-    throw new Error(`auth-seed: /api/identify returned ${resp.status()} for the provided token`);
-  }
-  const { user } = (await resp.json()) as { user: unknown };
-  return user;
-}
-
-/** Inject both persisted stores before app scripts run on the next navigation. */
-async function injectStores(page: Page, tokens: SeedTokens, user: unknown): Promise<void> {
-  const entries: [string, string][] = [
-    [ACCESS_TOKEN_STORAGE_KEY, buildTokenValue(tokens)],
-    [USER_CONTEXT_STORAGE_KEY, buildUserContextValue(user)],
-  ];
-  await page.addInitScript(items => {
-    for (const [key, value] of items) localStorage.setItem(key, value);
-  }, entries);
-}
-
-/**
- * Seed auth (token + currentUser) and write a Playwright storageState file.
- * Boots to `/` (never /login) so the seeded session isn't torn down.
+ * Seed auth (refresh cookie) and write a Playwright storageState file.
+ * Boots to `/` (never /login) so the seeded session isn't torn down by the login route's
+ * on-mount clearClientCaches().
  */
 export async function seedAuthStorageState(page: Page, tokens: SeedTokens, path: string): Promise<void> {
-  const user = await resolveUser(page, tokens.accessToken);
-  await injectStores(page, tokens, user);
+  await injectRefreshCookie(page, tokens);
   await page.goto('/');
   await page.context().storageState({ path });
 }
 
 /**
- * Seed auth (token + currentUser) directly onto a page (mid-test user switching),
- * then bootstrap the authenticated app by navigating to `/`.
+ * Seed auth directly onto a page (mid-test user switching), then bootstrap the authenticated
+ * app by navigating to `/`.
  */
 export async function seedAuthOnPage(page: Page, tokens: SeedTokens): Promise<void> {
-  const user = await resolveUser(page, tokens.accessToken);
-  await injectStores(page, tokens, user);
+  // Clear the previous identity's refresh cookie first: the app boots from whichever cookie is
+  // present, so a leftover one would silently win the mid-test user switch. The persisted
+  // user-context store still holds the old identity at this point, but the router guard awaits
+  // the bootstrap refresh (which rewrites currentUser) before reading it, so nothing renders
+  // under the stale identity.
+  await page.context().clearCookies({ name: REFRESH_COOKIE_NAME });
+  await injectRefreshCookie(page, tokens);
   await page.goto('/');
 }

--- a/apps/client/e2e/helpers/mfa.ts
+++ b/apps/client/e2e/helpers/mfa.ts
@@ -1,5 +1,6 @@
 import { type APIRequestContext } from '@playwright/test';
 import speakeasy from 'speakeasy';
+import { refreshTokenFromSetCookie } from './api';
 
 export interface MfaSetupResult {
   secret: string;
@@ -32,9 +33,10 @@ export async function apiSetupMfa(request: APIRequestContext, accessToken: strin
 }
 
 /**
- * POST /api/auth/mfa/verify-setup - enables MFA and returns a fresh token pair. The token used to
+ * POST /api/auth/mfa/verify-setup - enables MFA and issues a fresh session. The token used to
  * call apiSetupMfa is invalidated by this call (tokenVersion bump), so callers must switch to the
- * returned tokens for any request made after enrollment.
+ * returned tokens for any request made after enrollment. Only the access token is in the body;
+ * the refresh token comes back as the HttpOnly cookie, so it has to be read off Set-Cookie.
  */
 export async function apiVerifyMfaSetup(
   request: APIRequestContext,
@@ -49,8 +51,15 @@ export async function apiVerifyMfaSetup(
   if (!response.ok()) {
     throw new Error(`MFA verify-setup failed: ${response.status()} ${response.statusText()}`);
   }
-  const result: MfaTokens = await response.json();
-  return result;
+  const refreshToken = refreshTokenFromSetCookie(response.headers()['set-cookie']);
+  const { accessToken: freshAccessToken } = (await response.json()) as { accessToken?: string };
+  if (!freshAccessToken || !refreshToken) {
+    throw new Error(
+      `MFA verify-setup returned no session (accessToken=${freshAccessToken ? 'set' : 'missing'}, ` +
+        `refreshCookie=${refreshToken ? 'set' : 'missing'})`
+    );
+  }
+  return { accessToken: freshAccessToken, refreshToken };
 }
 
 /**

--- a/apps/client/pages/api/admin/emergency-login.ts
+++ b/apps/client/pages/api/admin/emergency-login.ts
@@ -4,7 +4,7 @@ import { escapeRegex } from '@bike4mind/utils/escapeRegex';
 import { baseApi } from '@server/middlewares/baseApi';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { UnauthorizedError } from '@server/utils/errors';
-import { issueSessionForRequest } from '@server/auth/issueSession';
+import { issueBrowserSession } from '@server/auth/issueSession';
 import { logEvent } from '@server/utils/analyticsLog';
 import { AuthEvents } from '@bike4mind/common';
 import { rateLimit } from '@server/middlewares/rateLimit';
@@ -90,11 +90,11 @@ const handler = baseApi({ auth: false })
       });
 
       // Generate auth tokens
-      const { accessToken, refreshToken } = await issueSessionForRequest(req, user.id, {
+      const { accessToken } = await issueBrowserSession(req, res, user.id, {
         createdVia: 'emergency',
         tokenVersion: user.tokenVersion ?? 0,
       });
-      const tokens = { accessToken, refreshToken };
+      const tokens = { accessToken };
 
       // Remove password from response using destructuring
       const { password: _, ...userResponse } = user.toJSON();

--- a/apps/client/pages/api/auth/[strategy]/callback.ts
+++ b/apps/client/pages/api/auth/[strategy]/callback.ts
@@ -3,7 +3,7 @@
 
 import { AuthStrategy } from '@bike4mind/common';
 import { authFailLogRepository, IUserObject } from '@bike4mind/database';
-import { issueSessionForRequest } from '@server/auth/issueSession';
+import { issueBrowserSession } from '@server/auth/issueSession';
 import { verifyStateToken, BaseStatePayload } from '@server/auth/jwtStateStore';
 import { authSuccessRedirectQuery } from '@server/auth/authSuccessRedirect';
 import { baseApi } from '@server/middlewares/baseApi';
@@ -90,11 +90,11 @@ const handler = baseApi({ auth: false })
           return res.redirect(`/login?error=${encodeURIComponent(oauthFailureRedirectMessage(reason))}`);
         }
 
-        const { accessToken, refreshToken } = await issueSessionForRequest(req, user.id, {
+        const { accessToken } = await issueBrowserSession(req, res, user.id, {
           createdVia: 'oauth',
           tokenVersion: user.tokenVersion ?? 0,
         });
-        const tokens = { accessToken, refreshToken };
+        const tokens = { accessToken };
 
         try {
           await logEvent({
@@ -153,7 +153,7 @@ const handler = baseApi({ auth: false })
         // isNewUser/signupMethod ride the same fragment: /auth/success reads and
         // clears it exactly once, firing the signup ad conversion for new accounts.
         const signupFragment = isNewUser ? `&isNewUser=1&signupMethod=${encodeURIComponent(strategy)}` : '';
-        const redirectUrl = `/auth/success${successQuery}#token=${tokens.accessToken}&refreshToken=${tokens.refreshToken}&userId=${user.id}${signupFragment}`;
+        const redirectUrl = `/auth/success${successQuery}#token=${tokens.accessToken}&userId=${user.id}${signupFragment}`;
         return res.redirect(redirectUrl);
       } catch (callbackError) {
         // Catch any unhandled errors in the callback to prevent unhandled promise rejections

--- a/apps/client/pages/api/auth/__tests__/returnToAdmin.test.ts
+++ b/apps/client/pages/api/auth/__tests__/returnToAdmin.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+// Unwrap the chainable baseApi builder so the raw handler can be invoked directly
+// (same idiom as refreshToken.test.ts).
+vi.mock('@server/middlewares/baseApi', () => {
+  const builder: any = { use: () => builder, post: (fn: any) => fn };
+  return { baseApi: () => builder };
+});
+vi.mock('@server/middlewares/checkBlockedIP', () => ({
+  checkBlockedIP: () => (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('@server/middlewares/rateLimit', () => ({
+  rateLimit: () => (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('@server/utils/errors', () => ({
+  UnauthorizedError: class UnauthorizedError extends Error {},
+}));
+vi.mock('@server/auth/requireNonSystemUser', () => ({ requireNonSystemUser: vi.fn() }));
+vi.mock('@server/auth/tokenGenerator', () => ({
+  authTokenGenerator: { signAccessToken: vi.fn() },
+}));
+vi.mock('@bike4mind/common', () => ({ redactUserSecretsForSelf: (user: unknown) => user }));
+
+const mockRotateSession = vi.fn();
+vi.mock('@bike4mind/services', () => ({
+  authSessionService: {
+    isOpaqueRefreshToken: (t: string) => t.includes('.'),
+    parseRefreshToken: (t: string) => (t.includes('.') ? { sid: t.split('.')[0], secret: t.split('.')[1] } : null),
+    rotateSession: (...args: any[]) => mockRotateSession(...args),
+  },
+}));
+
+const mockRevokeBySid = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  userRepository: {},
+  authSessionRepository: { revokeBySid: (...args: any[]) => mockRevokeBySid(...args) },
+}));
+
+import handler from '../returnToAdmin';
+
+/** baseApi normally attaches req.logger; the mocked builder skips its middleware chain. */
+const post = (cookie: string) => {
+  const { req, res } = createMocks({ method: 'POST', headers: { cookie } });
+  (req as unknown as { logger: unknown }).logger = { error: vi.fn(), log: vi.fn(), info: vi.fn() };
+  return { req, res };
+};
+
+describe('POST /api/auth/returnToAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRevokeBySid.mockResolvedValue(undefined);
+    mockRotateSession.mockResolvedValue({
+      user: { id: 'admin-1' },
+      accessToken: 'admin-access',
+      refreshToken: 'admin-refresh-rotated',
+      sid: 'admin-sid',
+      impersonatedBy: null,
+    });
+  });
+
+  it('restores the admin session: rotates the parked token into the primary cookie and clears the return cookie', async () => {
+    const { req, res } = post('b4m_rt=cust-sid.cust-secret; b4m_rt_admin=admin-sid.admin-secret');
+
+    await handler(req as any, res as any);
+
+    expect(mockRotateSession).toHaveBeenCalledWith('admin-sid.admin-secret', expect.anything());
+
+    const cookies = (res.getHeader('Set-Cookie') as string[]).map(String);
+    expect(cookies.some(c => c.startsWith('b4m_rt=admin-refresh-rotated;'))).toBe(true);
+    // The return slot must be emptied, or a second "return to admin" would replay a dead token.
+    expect(cookies.some(c => c.startsWith('b4m_rt_admin=;') && c.includes('Max-Age=0'))).toBe(true);
+
+    expect(res._getJSONData()).toMatchObject({ accessToken: 'admin-access', impersonating: false });
+  });
+
+  it('revokes the impersonation session so the abandoned customer token cannot be refreshed later', async () => {
+    const { req, res } = post('b4m_rt=cust-sid.cust-secret; b4m_rt_admin=admin-sid.admin-secret');
+
+    await handler(req as any, res as any);
+
+    expect(mockRevokeBySid).toHaveBeenCalledWith('cust-sid');
+  });
+
+  it('still returns the admin to safety when revoking the impersonation session fails', async () => {
+    // Stranding an admin inside an impersonation is worse than a lingering session row.
+    mockRevokeBySid.mockRejectedValue(new Error('db down'));
+    const { req, res } = post('b4m_rt=cust-sid.cust-secret; b4m_rt_admin=admin-sid.admin-secret');
+
+    await handler(req as any, res as any);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('rejects when there is no parked admin session', async () => {
+    const { req, res } = post('b4m_rt=cust-sid.cust-secret');
+
+    await expect(handler(req as any, res as any)).rejects.toBeInstanceOf(Error);
+    expect(mockRotateSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/pages/api/auth/mfa/verify-setup.ts
+++ b/apps/client/pages/api/auth/mfa/verify-setup.ts
@@ -2,7 +2,7 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { mfaService, userService } from '@bike4mind/services';
 import { userRepository, authSessionRepository } from '@bike4mind/database';
-import { issueSessionForRequest } from '@server/auth/issueSession';
+import { issueBrowserSession } from '@server/auth/issueSession';
 import { logAuthAudit } from '@server/utils/authAudit';
 import { redactUserSecretsForSelf } from '@bike4mind/common';
 import * as z from 'zod';
@@ -54,11 +54,11 @@ const handler = baseApi()
           db: { users: userRepository, authSessions: authSessionRepository },
           logger: req.logger,
         });
-        const { accessToken, refreshToken } = await issueSessionForRequest(req, result.user.id, {
+        const { accessToken } = await issueBrowserSession(req, res, result.user.id, {
           createdVia: 'mfa-setup',
           tokenVersion: newTokenVersion,
         });
-        const tokens = { accessToken, refreshToken };
+        const tokens = { accessToken };
 
         await logAuthAudit(req, { userId: result.user.id, event: 'mfa_enrolled' });
 

--- a/apps/client/pages/api/auth/mfa/verify.ts
+++ b/apps/client/pages/api/auth/mfa/verify.ts
@@ -2,7 +2,7 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { mfaService } from '@bike4mind/services';
 import { userRepository } from '@bike4mind/database';
-import { issueSessionForRequest } from '@server/auth/issueSession';
+import { issueBrowserSession } from '@server/auth/issueSession';
 import { redactUserSecretsForSelf } from '@bike4mind/common';
 import * as z from 'zod';
 
@@ -53,11 +53,11 @@ const handler = baseApi() // Now requires authentication
         // Generate FULL access tokens (remove mfaPending) for login completion
         const tokenUserId = result.user.id;
         // No mfaPending: MFA is satisfied, so mint a full session.
-        const { accessToken, refreshToken } = await issueSessionForRequest(req, tokenUserId, {
+        const { accessToken } = await issueBrowserSession(req, res, tokenUserId, {
           createdVia: 'mfa',
           tokenVersion: result.user.tokenVersion ?? 0,
         });
-        const tokens = { accessToken, refreshToken };
+        const tokens = { accessToken };
 
         res.json({
           verified: true,

--- a/apps/client/pages/api/auth/okta/__tests__/callback.test.ts
+++ b/apps/client/pages/api/auth/okta/__tests__/callback.test.ts
@@ -44,11 +44,10 @@ const mockVerifyState = vi.fn();
 vi.mock('@server/auth/jwtStateStore', () => ({ verifyStateToken: (...a: any[]) => mockVerifyState(...a) }));
 
 // Remaining leaf collaborators. Mock the session helper directly (rather than @bike4mind/services)
-// so the test never pulls the real services barrel -- the callback now mints via issueSessionForRequest.
+// so the test never pulls the real services barrel -- the callback mints via issueBrowserSession,
+// which also sets the refresh cookie (so no refresh token appears in the redirect fragment).
 vi.mock('@server/auth/issueSession', () => ({
-  issueSessionForRequest: vi
-    .fn()
-    .mockResolvedValue({ accessToken: 'jwt-access', refreshToken: 'jwt-refresh', sid: 'sid' }),
+  issueBrowserSession: vi.fn().mockResolvedValue({ accessToken: 'jwt-access', sid: 'sid' }),
 }));
 vi.mock('@server/utils/analyticsLog', () => ({ logEvent: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('@server/utils/authAudit', () => ({ logAuthAudit: vi.fn().mockResolvedValue(undefined) }));

--- a/apps/client/pages/api/auth/okta/callback.ts
+++ b/apps/client/pages/api/auth/okta/callback.ts
@@ -22,7 +22,7 @@ import { getOktaConfigWithFallback, exchangeCodeForTokens, fetchUserInfo } from 
 import { verifyStateToken } from '@server/auth/jwtStateStore';
 import { authSuccessRedirectQuery } from '@server/auth/authSuccessRedirect';
 import { OKTA_STATE_AUDIENCE, OktaStatePayload } from '@server/auth/oktaConstants';
-import { issueSessionForRequest } from '@server/auth/issueSession';
+import { issueBrowserSession } from '@server/auth/issueSession';
 import { logEvent } from '@server/utils/analyticsLog';
 import { logAuthAudit } from '@server/utils/authAudit';
 import { AuthEvents, AuthStrategy } from '@bike4mind/common';
@@ -347,11 +347,11 @@ const handleOktaCallback = async (req: Request, res: Response) => {
     }
 
     // Generate our session tokens (distinct from the Okta IdP accessToken/refreshToken above).
-    const session = await issueSessionForRequest(req, user.id, {
+    const session = await issueBrowserSession(req, res, user.id, {
       createdVia: 'okta',
       tokenVersion: user.tokenVersion ?? 0,
     });
-    const tokens = { accessToken: session.accessToken, refreshToken: session.refreshToken };
+    const tokens = { accessToken: session.accessToken };
 
     // Log successful OAuth login
     await logEvent({
@@ -382,7 +382,7 @@ const handleOktaCallback = async (req: Request, res: Response) => {
     // Redirect to the application with tokens in URL fragment (not query string)
     // Using fragments prevents tokens from being logged in server access logs,
     // sent in Referer headers, or stored in browser history as query params
-    const redirectUrl = `/auth/success${successQuery}#token=${tokens.accessToken}&refreshToken=${tokens.refreshToken}&userId=${user.id}`;
+    const redirectUrl = `/auth/success${successQuery}#token=${tokens.accessToken}&userId=${user.id}`;
     return res.redirect(redirectUrl);
   } catch (error) {
     Logger.error('[Okta Callback] Processing error:', error);

--- a/apps/client/pages/api/auth/refreshToken.ts
+++ b/apps/client/pages/api/auth/refreshToken.ts
@@ -3,11 +3,13 @@ import { secretRotationRepository } from '@bike4mind/database/infra';
 import { UnauthorizedError } from '@server/utils/errors';
 import { isRotatedSecretWithinGraceWindow } from '@server/auth/secretRotationGrace';
 import { requireNonSystemUser } from '@server/auth/requireNonSystemUser';
+import { redactUserSecretsForSelf } from '@bike4mind/common';
 import { baseApi } from '@server/middlewares/baseApi';
 import { checkBlockedIP } from '@server/middlewares/checkBlockedIP';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { authTokenGenerator } from '@server/auth/tokenGenerator';
 import { buildSessionDevice } from '@server/auth/sessionDevice';
+import { readRefreshCookie, setRefreshCookie } from '@server/auth/refreshCookie';
 import { isTokenVersionCurrent, authSessionService } from '@bike4mind/services';
 
 const handler = baseApi({ auth: false })
@@ -20,9 +22,26 @@ const handler = baseApi({ auth: false })
   .use(rateLimit({ limit: 60, windowMs: 60 * 1000 }))
   .post(async (req, res) => {
     // Accept multiple field names: "token" (legacy B4M), "refreshToken" (camelCase), "refresh_token" (OAuth standard)
-    const token = req.body.token || req.body.refreshToken || req.body.refresh_token;
+    const bodyToken = req.body.token || req.body.refreshToken || req.body.refresh_token;
+    const cookieToken = readRefreshCookie(req);
+    const token = bodyToken || cookieToken;
 
     if (!token) throw new UnauthorizedError('Refresh token is required');
+
+    // Transport selection. A browser presents the token in the HttpOnly cookie and gets the
+    // rotated one back the same way - never in the JSON body, which page scripts can read.
+    // Non-browser callers (CLI, OAuth flows) present it in the body and get it back in the body.
+    // `cookie: true` is the one-shot migration hook: a browser whose refresh token is still in
+    // localStorage from before this change sends it in the body ONCE with this flag, and is
+    // moved onto the cookie without being logged out.
+    const useCookie = !bodyToken || req.body.cookie === true;
+    const respond = (payload: Record<string, unknown>, refreshToken: string) => {
+      if (useCookie) {
+        setRefreshCookie(res, refreshToken);
+        return res.status(200).json(payload);
+      }
+      return res.status(200).json({ ...payload, refreshToken });
+    };
 
     const signAccessToken = (id: string, tokenVersion: number, extra?: Record<string, unknown>) =>
       authTokenGenerator.signAccessToken(id, tokenVersion, extra);
@@ -36,11 +55,16 @@ const handler = baseApi({ auth: false })
         logger: req.logger,
       });
       requireNonSystemUser(rotated.user);
-      return res.status(200).json({
-        user: rotated.user,
-        accessToken: rotated.accessToken,
-        refreshToken: rotated.refreshToken,
-      });
+      return respond(
+        {
+          // Redact before returning: the bootstrap refresh feeds this straight into the client's
+          // currentUser, so it must carry the same self-view shape as the login endpoints.
+          user: redactUserSecretsForSelf(rotated.user),
+          accessToken: rotated.accessToken,
+          impersonating: !!rotated.impersonatedBy,
+        },
+        rotated.refreshToken
+      );
     }
 
     // Legacy JWT refresh token: verify as before, then lazily migrate the holder onto a session
@@ -82,11 +106,14 @@ const handler = baseApi({ auth: false })
       { db: { authSessions: authSessionRepository }, signAccessToken, logger: req.logger }
     );
 
-    return res.status(200).json({
-      user,
-      accessToken: migrated.accessToken,
-      refreshToken: migrated.refreshToken,
-    });
+    return respond(
+      {
+        user: redactUserSecretsForSelf(user),
+        accessToken: migrated.accessToken,
+        impersonating: !!decoded.impersonatedBy,
+      },
+      migrated.refreshToken
+    );
   });
 
 export const config = {

--- a/apps/client/pages/api/auth/returnToAdmin.ts
+++ b/apps/client/pages/api/auth/returnToAdmin.ts
@@ -1,0 +1,71 @@
+import { userRepository, authSessionRepository } from '@bike4mind/database';
+import { authSessionService } from '@bike4mind/services';
+import { redactUserSecretsForSelf } from '@bike4mind/common';
+import { UnauthorizedError } from '@server/utils/errors';
+import { requireNonSystemUser } from '@server/auth/requireNonSystemUser';
+import { baseApi } from '@server/middlewares/baseApi';
+import { checkBlockedIP } from '@server/middlewares/checkBlockedIP';
+import { rateLimit } from '@server/middlewares/rateLimit';
+import { authTokenGenerator } from '@server/auth/tokenGenerator';
+import {
+  clearAdminReturnCookie,
+  readAdminReturnCookie,
+  readRefreshCookie,
+  setRefreshCookie,
+} from '@server/auth/refreshCookie';
+
+/**
+ * End an impersonation and restore the admin's own session ("Return to safety").
+ *
+ * The admin's refresh token was parked in the HttpOnly return cookie by /api/users/[id]/loginAs.
+ * Possession of that cookie IS the credential here, so the route is auth: false - the
+ * impersonated access token it would otherwise authenticate with belongs to the wrong identity
+ * and may already have expired. Rotating the parked token through the session store both proves
+ * possession and re-arms reuse detection on the admin session.
+ */
+const handler = baseApi({ auth: false })
+  .use(checkBlockedIP())
+  .use(rateLimit({ limit: 20, windowMs: 60 * 1000 }))
+  .post(async (req, res) => {
+    const adminRefreshToken = readAdminReturnCookie(req);
+    if (!adminRefreshToken || !authSessionService.isOpaqueRefreshToken(adminRefreshToken)) {
+      throw new UnauthorizedError('No admin session to return to');
+    }
+
+    // Revoke the impersonation session before restoring the admin. Best-effort: if the
+    // impersonated cookie is already gone or its session was revoked, the return must still
+    // succeed - stranding an admin inside an impersonation is worse than a lingering row that
+    // the session's own expiry will reap.
+    const impersonatedToken = readRefreshCookie(req);
+    const impersonatedSid = impersonatedToken ? authSessionService.parseRefreshToken(impersonatedToken)?.sid : null;
+
+    const restored = await authSessionService.rotateSession(adminRefreshToken, {
+      db: { authSessions: authSessionRepository, users: userRepository },
+      signAccessToken: (id, tokenVersion, extra) => authTokenGenerator.signAccessToken(id, tokenVersion, extra),
+      logger: req.logger,
+    });
+    requireNonSystemUser(restored.user);
+
+    if (impersonatedSid) {
+      await authSessionRepository
+        .revokeBySid(impersonatedSid)
+        .catch(err => req.logger.error('Failed to revoke impersonation session on return to admin', err));
+    }
+
+    setRefreshCookie(res, restored.refreshToken);
+    clearAdminReturnCookie(res);
+
+    return res.status(200).json({
+      user: redactUserSecretsForSelf(restored.user),
+      accessToken: restored.accessToken,
+      impersonating: false,
+    });
+  });
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/apps/client/pages/api/auth/saml/callback.ts
+++ b/apps/client/pages/api/auth/saml/callback.ts
@@ -3,7 +3,7 @@ import { authFailLogRepository, identityProviderRepository } from '@bike4mind/da
 import { baseApi } from '@server/middlewares/baseApi';
 import { checkBlockedIP } from '@server/middlewares/checkBlockedIP';
 import { setupSamlStrategy } from '@server/auth/auth';
-import { issueSessionForRequest } from '@server/auth/issueSession';
+import { issueBrowserSession } from '@server/auth/issueSession';
 import { logEvent } from '@server/utils/analyticsLog';
 import { logAuthAudit } from '@server/utils/authAudit';
 import { AuthEvents, AuthStrategy } from '@bike4mind/common';
@@ -128,11 +128,11 @@ const handleSamlCallback = async (req: any, res: any) => {
         throw new ForbiddenError('User is banned');
       }
 
-      const { accessToken, refreshToken } = await issueSessionForRequest(req, user.id, {
+      const { accessToken } = await issueBrowserSession(req, res, user.id, {
         createdVia: 'saml',
         tokenVersion: user.tokenVersion ?? 0,
       });
-      const tokens = { accessToken, refreshToken };
+      const tokens = { accessToken };
 
       await logEvent({
         userId: user.id,
@@ -158,7 +158,7 @@ const handleSamlCallback = async (req: any, res: any) => {
       // Resume the originally requested path (round-tripped via RelayState);
       // /auth/success sanitizes it before navigating.
       const successQuery = authSuccessRedirectQuery(redirectTo);
-      const redirectUrl = `${baseUrl}/auth/success${successQuery}#token=${tokens.accessToken}&refreshToken=${tokens.refreshToken}&userId=${user.id}`;
+      const redirectUrl = `${baseUrl}/auth/success${successQuery}#token=${tokens.accessToken}&userId=${user.id}`;
 
       console.log('Redirecting to:', redirectUrl.substring(0, LOG_URL_TRUNCATE_LENGTH) + '...');
       return res.redirect(redirectUrl);

--- a/apps/client/pages/api/identify.ts
+++ b/apps/client/pages/api/identify.ts
@@ -2,7 +2,7 @@ import { requireUser } from '@server/middlewares/requireUser';
 import { baseApi } from '@server/middlewares/baseApi';
 import { secretRotationRepository } from '@bike4mind/database/infra';
 import { authTokenGenerator } from '@server/auth/tokenGenerator';
-import { issueSessionForRequest } from '@server/auth/issueSession';
+import { issueBrowserSession } from '@server/auth/issueSession';
 import { isRotatedSecretWithinGraceWindow } from '@server/auth/secretRotationGrace';
 
 const handler = baseApi()
@@ -15,9 +15,8 @@ const handler = baseApi()
       } access token`
     );
 
-    let refreshToken: string | undefined;
     if (!accessToken) {
-      ({ accessToken, refreshToken } = await issueSessionForRequest(req, req.user!.id, {
+      ({ accessToken } = await issueBrowserSession(req, res, req.user!.id, {
         createdVia: 'identify',
         tokenVersion: req.user!.tokenVersion ?? 0,
       }));
@@ -30,7 +29,7 @@ const handler = baseApi()
       }
       const decoded = authTokenGenerator.verifyToken(accessToken, previousSecret);
       if (decoded.exp && decoded.exp < Date.now() / 1000) {
-        ({ accessToken, refreshToken } = await issueSessionForRequest(req, req.user!.id, {
+        ({ accessToken } = await issueBrowserSession(req, res, req.user!.id, {
           createdVia: 'identify',
           tokenVersion: req.user!.tokenVersion ?? 0,
         }));
@@ -40,7 +39,10 @@ const handler = baseApi()
     return res.status(200).json({
       user: req.user,
       accessToken,
-      refreshToken,
+      // impersonatedBy is stamped onto req.user by verifyJwtPayload for an admin-driven
+      // session; surfaced as a plain boolean because the client's only durable impersonation
+      // signal is now the server (the old localStorage returnToken is gone).
+      impersonating: !!(req.user as { impersonatedBy?: string } | undefined)?.impersonatedBy,
     });
   });
 

--- a/apps/client/pages/api/logout.ts
+++ b/apps/client/pages/api/logout.ts
@@ -6,10 +6,17 @@ import { logEvent } from '@server/utils/analyticsLog';
 import { logAuthAudit } from '@server/utils/authAudit';
 import { baseApi } from '@server/middlewares/baseApi';
 import { isApiKeyAuth } from '@server/middlewares/apiKeyAuth';
+import { clearSessionCookies } from '@server/auth/refreshCookie';
 
 const handler = baseApi().get(async (req, res) => {
   const user = req.user as IUserDocument & { impersonatedBy?: string };
   const userId = user?.id;
+
+  // Expire the refresh cookies unconditionally and first: the client can no longer clear them
+  // itself (HttpOnly), and a logout that 500s partway must still leave the browser without a
+  // usable refresh credential. Includes the impersonation return cookie - an admin who logs out
+  // mid-impersonation should not keep a live path back into their own session.
+  clearSessionCookies(res);
 
   await userService.updateLogoutTime(userId, { db: { users: userRepository }, logger: req.logger });
   // Revoke the session server-side, not just client-side: bump tokenVersion so the logged-out

--- a/apps/client/pages/api/otc/verify.ts
+++ b/apps/client/pages/api/otc/verify.ts
@@ -23,6 +23,7 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { checkBlockedIP } from '@server/middlewares/checkBlockedIP';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { authTokenGenerator } from '@server/auth/tokenGenerator';
+import { setRefreshCookie } from '@server/auth/refreshCookie';
 import { buildSessionDevice } from '@server/auth/sessionDevice';
 import { Config } from '@server/utils/config';
 import { logEvent } from '@server/utils/analyticsLog';
@@ -182,7 +183,8 @@ const handler = baseApi({ auth: false })
           logger: req.logger,
         }
       );
-      const tokens = { accessToken, refreshToken };
+      setRefreshCookie(res, refreshToken);
+      const tokens = { accessToken };
       const ip = req.socket?.remoteAddress || (req.headers['x-forwarded-for'] as string) || req.ip || 'unknown';
 
       // Analytics + device history are best-effort for the same post-rotation reason as
@@ -422,10 +424,10 @@ const handler = baseApi({ auth: false })
         logger: req.logger,
       }
     );
+    setRefreshCookie(res, registrationSession.refreshToken);
     return res.status(200).json({
       user: redactUserSecretsForSelf(newUser),
       accessToken: registrationSession.accessToken,
-      refreshToken: registrationSession.refreshToken,
     });
   });
 

--- a/apps/client/pages/api/users/[id]/loginAs.ts
+++ b/apps/client/pages/api/users/[id]/loginAs.ts
@@ -2,7 +2,9 @@ import { adminService } from '@bike4mind/services';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { userRepository } from '@bike4mind/database';
-import { issueSessionForRequest } from '@server/auth/issueSession';
+import { issueBrowserSession } from '@server/auth/issueSession';
+import { readRefreshCookie, setAdminReturnCookie } from '@server/auth/refreshCookie';
+import { UnauthorizedError } from '@server/utils/errors';
 import { BadRequestError } from '@bike4mind/utils';
 import { redactUserSecretsForSelf } from '@bike4mind/common';
 
@@ -15,6 +17,15 @@ const handler = baseApi().post(
 
     if (!mfaToken || typeof mfaToken !== 'string') {
       throw new BadRequestError('MFA token is required to use loginAs');
+    }
+
+    // Capture the admin's own refresh token BEFORE the impersonated one overwrites the cookie
+    // slot; it is parked in the return cookie so /api/auth/returnToAdmin can restore the admin
+    // session. Without it there is no way back, so refuse to start rather than strand the admin
+    // (a caller with no refresh cookie is not a browser session - e.g. an API key).
+    const adminRefreshToken = readRefreshCookie(req);
+    if (!adminRefreshToken) {
+      throw new UnauthorizedError('loginAs requires an interactive browser session');
     }
 
     const targetUser = await adminService.loginAs(
@@ -34,22 +45,23 @@ const handler = baseApi().post(
       }
     );
 
-    // Mint a full token PAIR for the impersonated user. The refresh token must
-    // belong to the target - if the client kept the admin's refresh token, the
-    // first 401-triggered refresh would mint an admin access token and silently
-    // flip the session back to the admin mid-impersonation.
+    // Mint a full session for the impersonated user; its refresh token takes over the primary
+    // cookie. The refresh token must belong to the target - if the browser kept the admin's,
+    // the first 401-triggered refresh would mint an admin access token and silently flip the
+    // session back to the admin mid-impersonation.
     //
     // Stamp an impersonatedBy claim so downstream can tell a real customer session
     // from an admin-driven one: /api/logout skips the tokenVersion revoke for these,
     // otherwise an admin clicking "Log Out" mid-impersonation would force-log-out the
     // real customer on every device.
-    const { accessToken, refreshToken } = await issueSessionForRequest(req, targetUser.id, {
+    const { accessToken } = await issueBrowserSession(req, res, targetUser.id, {
       createdVia: 'impersonation',
       tokenVersion: targetUser.tokenVersion ?? 0,
       impersonatedBy: adminUser.id,
     });
+    setAdminReturnCookie(res, adminRefreshToken);
 
-    return res.json({ user: redactUserSecretsForSelf(targetUser), accessToken, refreshToken });
+    return res.json({ user: redactUserSecretsForSelf(targetUser), accessToken, impersonating: true });
   })
 );
 

--- a/apps/client/server/auth/issueSession.ts
+++ b/apps/client/server/auth/issueSession.ts
@@ -2,8 +2,10 @@ import { AuthSessionCreatedVia, IAuthSessionDevice } from '@bike4mind/common';
 import { authSessionRepository } from '@bike4mind/database';
 import { authSessionService } from '@bike4mind/services';
 import { Logger } from '@bike4mind/observability';
+import type { Response } from 'express';
 import { authTokenGenerator } from './tokenGenerator';
 import { buildSessionDevice } from './sessionDevice';
+import { setRefreshCookie } from './refreshCookie';
 
 interface RequestLike {
   headers: Record<string, string | string[] | undefined>;
@@ -42,4 +44,24 @@ export async function issueSessionForRequest(
       logger: req.logger,
     }
   );
+}
+
+/**
+ * Browser login path: mint a session and hand the refresh token back as an HttpOnly cookie
+ * rather than in the JSON body, so it is never readable by page scripts. Returns only the
+ * access token, which the client keeps in memory (useAccessToken).
+ *
+ * Every browser mint site should use this instead of issueSessionForRequest. The CLI/OAuth
+ * mint sites (pages/api/oauth/*) deliberately do NOT - they have no cookie jar and must keep
+ * receiving the refresh token in the response body.
+ */
+export async function issueBrowserSession(
+  req: RequestLike,
+  res: Response,
+  userId: string,
+  params: Parameters<typeof issueSessionForRequest>[2]
+): Promise<{ accessToken: string; sid: string }> {
+  const { accessToken, refreshToken, sid } = await issueSessionForRequest(req, userId, params);
+  setRefreshCookie(res, refreshToken);
+  return { accessToken, sid };
 }

--- a/apps/client/server/auth/refreshCookie.test.ts
+++ b/apps/client/server/auth/refreshCookie.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Request, Response } from 'express';
+import {
+  ADMIN_RETURN_COOKIE_NAME,
+  REFRESH_COOKIE_NAME,
+  clearSessionCookies,
+  readAdminReturnCookie,
+  readRefreshCookie,
+  setAdminReturnCookie,
+  setRefreshCookie,
+} from './refreshCookie';
+
+/** Minimal stand-in for the Node response header store the helpers get/append/set through. */
+function makeRes() {
+  const headers = new Map<string, string | string[]>();
+  return {
+    getHeader: (name: string) => headers.get(name),
+    setHeader: (name: string, value: string | string[]) => headers.set(name, value),
+    cookies: () => {
+      const raw = headers.get('Set-Cookie');
+      return raw === undefined ? [] : Array.isArray(raw) ? raw.map(String) : [String(raw)];
+    },
+  };
+}
+
+const asRes = (r: ReturnType<typeof makeRes>) => r as unknown as Response;
+const reqWithCookies = (cookie: string) => ({ headers: { cookie } }) as unknown as Request;
+
+describe('refreshCookie', () => {
+  const originalEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  describe('setRefreshCookie', () => {
+    let res: ReturnType<typeof makeRes>;
+    beforeEach(() => {
+      res = makeRes();
+    });
+
+    it('sets an HttpOnly, SameSite=Strict cookie scoped to /api', () => {
+      setRefreshCookie(asRes(res), 'sid.secret');
+
+      const [cookie] = res.cookies();
+      expect(cookie).toContain(`${REFRESH_COOKIE_NAME}=sid.secret`);
+      expect(cookie).toContain('HttpOnly');
+      expect(cookie).toContain('SameSite=Strict');
+      expect(cookie).toContain('Path=/api');
+    });
+
+    it('outlives the 7-day WebKit ITP storage cap this whole design exists to survive', () => {
+      setRefreshCookie(asRes(res), 'sid.secret');
+
+      const maxAge = Number(/Max-Age=(\d+)/.exec(res.cookies()[0])?.[1]);
+      expect(maxAge).toBeGreaterThan(7 * 24 * 60 * 60);
+    });
+
+    it('marks the cookie Secure in production but not in dev/e2e (plain http)', () => {
+      process.env.NODE_ENV = 'production';
+      const prod = makeRes();
+      setRefreshCookie(asRes(prod), 'sid.secret');
+      expect(prod.cookies()[0]).toContain('; Secure');
+
+      process.env.NODE_ENV = 'development';
+      const dev = makeRes();
+      setRefreshCookie(asRes(dev), 'sid.secret');
+      expect(dev.cookies()[0]).not.toContain('Secure');
+    });
+
+    it('appends rather than replacing an existing Set-Cookie (loginAs sets two in one response)', () => {
+      setRefreshCookie(asRes(res), 'impersonated');
+      setAdminReturnCookie(asRes(res), 'admin');
+
+      const cookies = res.cookies();
+      expect(cookies).toHaveLength(2);
+      expect(cookies[0]).toContain(`${REFRESH_COOKIE_NAME}=impersonated`);
+      expect(cookies[1]).toContain(`${ADMIN_RETURN_COOKIE_NAME}=admin`);
+    });
+  });
+
+  describe('clearSessionCookies', () => {
+    it('expires BOTH the session and the impersonation return cookie', () => {
+      // An admin logging out mid-impersonation must not keep a live path back into their session.
+      const res = makeRes();
+      clearSessionCookies(asRes(res));
+
+      const cookies = res.cookies();
+      expect(cookies).toHaveLength(2);
+      expect(cookies.every(c => c.includes('Max-Age=0'))).toBe(true);
+      expect(cookies.some(c => c.startsWith(`${REFRESH_COOKIE_NAME}=;`))).toBe(true);
+      expect(cookies.some(c => c.startsWith(`${ADMIN_RETURN_COOKIE_NAME}=;`))).toBe(true);
+    });
+  });
+
+  describe('reading cookies back', () => {
+    it('picks the right cookie out of a multi-cookie header', () => {
+      const req = reqWithCookies(`other=x; ${REFRESH_COOKIE_NAME}=sid.secret; ${ADMIN_RETURN_COOKIE_NAME}=admin.sec`);
+      expect(readRefreshCookie(req)).toBe('sid.secret');
+      expect(readAdminReturnCookie(req)).toBe('admin.sec');
+    });
+
+    it('does not match on a name prefix', () => {
+      // b4m_rt_admin must never be read as b4m_rt - that would hand a caller the wrong identity.
+      expect(readRefreshCookie(reqWithCookies(`${ADMIN_RETURN_COOKIE_NAME}=admin.sec`))).toBeNull();
+    });
+
+    it('treats a cleared (empty-valued) cookie as absent', () => {
+      expect(readRefreshCookie(reqWithCookies(`${REFRESH_COOKIE_NAME}=`))).toBeNull();
+    });
+
+    it('returns null when no cookie header is present at all', () => {
+      expect(readRefreshCookie({ headers: {} } as unknown as Request)).toBeNull();
+    });
+  });
+});

--- a/apps/client/server/auth/refreshCookie.ts
+++ b/apps/client/server/auth/refreshCookie.ts
@@ -1,0 +1,106 @@
+import type { Request, Response } from 'express';
+
+/**
+ * Refresh-token cookie transport.
+ *
+ * Browser sessions carry the opaque `<sid>.<secret>` refresh token in an HttpOnly cookie
+ * instead of localStorage: script-writable storage is capped at ~7 days by WebKit ITP (so
+ * mobile Safari users were being silently logged out), and a long-lived credential sitting
+ * in localStorage is directly exfiltratable by any XSS. The access token stays in JS memory
+ * (useAccessToken) because the WebSocket is on a different registrable domain and
+ * authenticates with `?token=<accessToken>` - a cookie can't reach it.
+ *
+ * Non-browser callers (CLI, OAuth authorization-code + device flows) keep passing the refresh
+ * token in the request body and receive no cookie - they have no cookie jar. The refresh
+ * endpoint accepts either transport; see pages/api/auth/refreshToken.ts.
+ */
+
+/** Primary session refresh cookie. */
+export const REFRESH_COOKIE_NAME = 'b4m_rt';
+
+/**
+ * Parks the impersonating admin's refresh token for the duration of a loginAs, so
+ * "Return to safety" can restore the admin session. There is only one primary cookie slot per
+ * origin and it is handed to the impersonated user, so the admin's half needs its own name.
+ * Replaces the old client-side returnToken/returnRefreshToken pair, which kept the admin's
+ * credentials in localStorage - exactly what this change removes.
+ */
+export const ADMIN_RETURN_COOKIE_NAME = 'b4m_rt_admin';
+
+/**
+ * Scoped to /api: the cookie only ever needs to reach the refresh, logout and impersonation
+ * endpoints, and this keeps it off every static-asset request. SameSite=Strict is affordable
+ * because normal API calls authenticate with `Authorization: Bearer`, so no cross-site
+ * navigation depends on the cookie riding along.
+ */
+const COOKIE_PATH = '/api';
+
+/**
+ * Bounds a mobile session, so it tracks the AuthSession lifetime (30d), not the access-token TTL.
+ * MUST STAY IN SYNC with DEFAULT_REFRESH_TTL_MS in
+ * b4m-core/services/src/authSessionService/constants.ts. Duplicated rather than imported so this
+ * transport helper - reached from nearly every auth route - does not drag the services barrel in
+ * behind it. A cookie that outlives the session just yields one rejected refresh; one that dies
+ * early logs the user out, which is the failure this whole change exists to prevent, so err long.
+ */
+const REFRESH_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+/** Secure breaks plain-http localhost, where e2e and local dev run. */
+const secureAttribute = (): string => (process.env.NODE_ENV === 'production' ? '; Secure' : '');
+
+/**
+ * Append rather than overwrite: `res.setHeader('Set-Cookie', string)` replaces any Set-Cookie
+ * already on the response (Node treats a string value as the whole header). loginAs sets two
+ * cookies in one response, so this must accumulate.
+ */
+function appendSetCookie(res: Response, cookie: string): void {
+  const existing = res.getHeader('Set-Cookie');
+  const next = existing
+    ? Array.isArray(existing)
+      ? [...existing.map(String), cookie]
+      : [String(existing), cookie]
+    : cookie;
+  res.setHeader('Set-Cookie', next);
+}
+
+function setCookie(res: Response, name: string, value: string): void {
+  appendSetCookie(
+    res,
+    `${name}=${value}; Path=${COOKIE_PATH}; Max-Age=${REFRESH_COOKIE_MAX_AGE_SECONDS}; HttpOnly; SameSite=Strict${secureAttribute()}`
+  );
+}
+
+function expireCookie(res: Response, name: string): void {
+  appendSetCookie(res, `${name}=; Path=${COOKIE_PATH}; Max-Age=0; HttpOnly; SameSite=Strict${secureAttribute()}`);
+}
+
+/** Minimal cookie-header parser (same pattern as publishGateToken / analyticsMiddleware). */
+export function readCookie(req: Pick<Request, 'headers'>, name: string): string | null {
+  const header = req.headers.cookie;
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      const value = part.slice(eq + 1).trim();
+      return value.length > 0 ? value : null;
+    }
+  }
+  return null;
+}
+
+export const setRefreshCookie = (res: Response, token: string): void => setCookie(res, REFRESH_COOKIE_NAME, token);
+export const clearRefreshCookie = (res: Response): void => expireCookie(res, REFRESH_COOKIE_NAME);
+export const readRefreshCookie = (req: Pick<Request, 'headers'>): string | null => readCookie(req, REFRESH_COOKIE_NAME);
+
+export const setAdminReturnCookie = (res: Response, token: string): void =>
+  setCookie(res, ADMIN_RETURN_COOKIE_NAME, token);
+export const clearAdminReturnCookie = (res: Response): void => expireCookie(res, ADMIN_RETURN_COOKIE_NAME);
+export const readAdminReturnCookie = (req: Pick<Request, 'headers'>): string | null =>
+  readCookie(req, ADMIN_RETURN_COOKIE_NAME);
+
+/** Clear every session cookie - logout, and any path that tears a session down. */
+export function clearSessionCookies(res: Response): void {
+  clearRefreshCookie(res);
+  clearAdminReturnCookie(res);
+}

--- a/apps/client/server/auth/tokenGenerator.ts
+++ b/apps/client/server/auth/tokenGenerator.ts
@@ -4,6 +4,11 @@ import { Config } from '@server/utils/config';
 export const authTokenGenerator = new AuthTokenGeneratorService({
   accessTokenSecret: Config.JWT_SECRET,
   refreshTokenSecret: Config.JWT_SECRET,
-  accessTokenExpiresIn: '7d',
+  // The access token is now held in JS memory only and re-obtained by silent refresh, so it can
+  // be short-lived: an hour-scale TTL bounds what an XSS-exfiltrated token is worth, and it is
+  // also the WebSocket's only credential (query-param auth), so it must not be so short that
+  // long-lived connections churn through reconnects. Session length is bounded by the refresh
+  // cookie's 30d lifetime (authSessionService DEFAULT_REFRESH_TTL_MS), not by this.
+  accessTokenExpiresIn: '30m',
   refreshTokenExpiresIn: '30d',
 });

--- a/b4m-core/services/src/authSessionService/rotateSession.ts
+++ b/b4m-core/services/src/authSessionService/rotateSession.ts
@@ -21,6 +21,9 @@ export interface RotatedSession {
   sid: string;
   accessToken: string;
   refreshToken: string;
+  /** Admin id when this session was created by loginAs; null otherwise. Surfaced so the refresh
+   *  endpoint can tell the client it is still inside an impersonation without decoding the JWT. */
+  impersonatedBy: string | null;
 }
 
 /**
@@ -93,5 +96,12 @@ export const rotateSession = async (
     ...(session.impersonatedBy ? { impersonatedBy: session.impersonatedBy } : {}),
   });
 
-  return { userId: user.id, user, sid, accessToken, refreshToken: buildRefreshToken(sid, nextSecret) };
+  return {
+    userId: user.id,
+    user,
+    sid,
+    accessToken,
+    refreshToken: buildRefreshToken(sid, nextSecret),
+    impersonatedBy: session.impersonatedBy ?? null,
+  };
 };


### PR DESCRIPTION
# Pull Request

## Description

Closes #1188.

Session storage moves to a hybrid model: the long-lived refresh token now lives in an `HttpOnly` cookie set by the server, and the short-lived access token lives in memory only (no longer persisted to `localStorage`).

Two motivations:

1. **Mobile sessions survive.** Safari/WebKit ITP caps script-writable storage at ~7 days, which is why mobile users get silently logged out. A server-set `HttpOnly` cookie is not subject to that cap, so a cold load can silently refresh and stay signed in.
2. **The long-lived credential is no longer reachable from JS.** `HttpOnly` stops theft and offline replay via XSS (it does not stop abuse while the page is resident - this is defense in depth, not a cure).

This builds directly on the opaque `<sid>.<secret>` refresh tokens and `authSessionService.rotateSession` from #1213. Rotation, the grace window, and reuse detection already existed and were **not** rebuilt - the change here is transport plus the client-side ordering work that transport forces.

The WebSocket transport is unchanged. The WS is an API Gateway endpoint on a different registrable domain, so it authenticates with `?token=<accessToken>` rather than a cookie; the access token still lives in the JS store, so connect, handshake verify, and per-message re-verify are untouched. The only consequence is that on a cold load the socket waits for the bootstrap refresh to populate the token.

## Changes

**Cookie transport** (`apps/client/server/auth/refreshCookie.ts`, new)
- `b4m_rt` (primary) and `b4m_rt_admin` (the admin's parked token during impersonation). Both `HttpOnly; SameSite=Strict; Path=/api`, `Max-Age` 30d.
- `Secure` only when `NODE_ENV=production` - browsers drop `Secure` cookies over plain http, which is where dev and e2e run.
- `Set-Cookie` is appended rather than overwritten, because `loginAs` sets two cookies in one response.

**Mint sites**
- New `issueBrowserSession()` in `server/auth/issueSession.ts` = mint + set cookie, returning only the access token. The caller opts in, so `pages/api/oauth/*` (authorization-code, device flow, refresh) keeps its body-only behaviour and receives no cookie.
- Browser mint sites migrated: OTC verify, MFA verify, MFA verify-setup, the `[strategy]`/Okta/SAML callbacks, emergency login, identify, loginAs, and the e2e `test/create-user` seed route.
- `mfaPending` still issues no refresh token and no cookie.

**Refresh endpoint** (`pages/api/auth/refreshToken.ts`)
- Reads the token from the cookie when the body has none, and `Set-Cookie`s the rotated token on success.
- `useCookie = !bodyToken || req.body.cookie === true`. The `cookie: true` flag is a one-shot migration hook: a pre-cookie session posts its `localStorage` refresh token once and is moved onto a cookie rather than being logged out.

**Bootstrap silent refresh** (`app/utils/sessionBootstrap.ts`, new)
- Awaited by the layout route's `beforeLoad`, so a cold load on a protected deep link waits for the refresh instead of bouncing through `/login` (which clears caches and would tear the session down). The deep link is preserved.
- Deliberately **not** gated on any `localStorage` flag: ITP evicts `localStorage` while leaving the server-set cookie intact, and that case is the entire premise of the ticket.
- Cached per page load, so a cold load performs exactly one refresh.
- `currentUser` stays persisted. It is not a credential, and keeping it avoids a guard flash.

**Access-token store** (`app/hooks/useAccessToken.ts`)
- `accessToken`, `refreshToken`, `returnToken`, and `returnRefreshToken` all dropped from the `persist` `partialize`. The `return*` pair is the impersonating admin's credentials and is just as sensitive.
- `partialize` alone is not enough, because persist rehydrates whatever is already in storage. Added `version: 1` plus a `migrate` that strips the four credentials and lifts any legacy refresh token into a single-use in-memory carrier for the bootstrap exchange.

**Impersonation**
- `loginAs` parks the admin's refresh token in `b4m_rt_admin` and refuses a caller that arrives with no refresh cookie, rather than stranding an admin with no way back.
- New `POST /api/auth/returnToAdmin`. It is `auth: false` on purpose: possession of `b4m_rt_admin` *is* the credential, and the impersonated access token belongs to the wrong identity.
- `rotateSession` additively returns `impersonatedBy`.

**Cross-tab logout** (`app/utils/crossTabLogout.ts`)
- The `storage`-event signal no longer keys off the persisted access token. A new non-sensitive persisted `hasSession` flag carries it. `expired` / `expiredReason` stay persisted, so the existing `expired`-vs-`revoked` redirect codes, public-path no-op, and refresh no-op all behave as before, tests included.
- Side effect worth knowing: a plain token refresh now writes no changed value, so it emits no storage event at all.

**TTLs**
- Access token `7d` -> `30m` (`server/auth/tokenGenerator.ts`). The refresh cookie's 30d `Max-Age` is now what bounds a mobile session.

**Logout**
- Clears both cookies server-side alongside the existing `revokeUserSessions` bump. Per-device vs all-device semantics are out of scope here (#1194).

**E2E helpers**
- `auth-seed.ts` no longer injects the `access-token-storage` `localStorage` key. It seeds the `b4m_rt` cookie via `context.addCookies(...)` and lets bootstrap mint the access token.
- `apiLoginViaOtc` captures the refresh token from `Set-Cookie` instead of the JSON body.

Two hardcoded constants must stay in sync, and both are flagged in comments: `REFRESH_COOKIE_MAX_AGE_SECONDS` vs `DEFAULT_REFRESH_TTL_MS`, and the `'b4m_rt'` literal duplicated in the e2e helpers.

## Guide for Testers

Use `app.staging.bike4mind.com` (or a PR preview if a maintainer deploys one).

### Login and storage hygiene

1. Open the app in a fresh incognito window and log in normally via the emailed one-time code.
2. Expected: you land on the app, signed in.
3. Open DevTools -> Application -> Local Storage -> the app origin, and click the `access-token-storage` key.
4. Expected: the JSON contains **no** `accessToken`, `refreshToken`, `returnToken`, or `returnRefreshToken`. Seeing `hasSession`, `expired`, or `expiredReason` is correct.
5. Open DevTools -> Application -> Cookies -> the app origin.
6. Expected: a `b4m_rt` cookie exists, with the `HttpOnly` column checked and `SameSite` = `Strict`.
7. In the DevTools Console, type `document.cookie` and press Enter.
8. Expected: the output does **not** contain `b4m_rt`.

### Cold load on a deep link

9. While signed in, navigate to a specific chat or notebook URL and copy that full URL.
10. Close the tab, open a new one, paste the URL, and load it.
11. Expected: the app comes up signed in on that exact page. It must **not** flash `/login`, and must **not** land on `/login` and lose the deep link.
12. Open DevTools -> Network, filter to `refreshToken`, and reload the page.
13. Expected: exactly one `POST /api/auth/refreshToken` returning 200.

### Chat and WebSocket

14. On a signed-in session, open a chat and send `Hello, how are you?`.
15. Expected: a streamed response begins within about 10 seconds, with no console errors.
16. Leave the tab open and idle for **over 30 minutes** (the access token now expires at 30m), then send another message.
17. Expected: the message still sends and streams. There may be a brief reconnect, but no logout and no error toast.

### Logout and cross-tab

18. Open the app in two tabs, both signed in.
19. Log out in tab A.
20. Expected: tab B redirects to `/login` on its own within a few seconds.
21. In tab A, check DevTools -> Application -> Cookies.
22. Expected: `b4m_rt` is gone.

### Impersonation (admin only)

23. As an admin, go to Sidebar -> Admin -> Users, pick any non-admin user, and use "Login As".
24. Expected: the app reloads as that user.
25. Check DevTools -> Application -> Cookies.
26. Expected: both `b4m_rt` and `b4m_rt_admin` are present and both are `HttpOnly`.
27. Click "Return to Admin".
28. Expected: you are back as your admin account, and `b4m_rt_admin` is gone.
29. Reload the page.
30. Expected: still signed in as the admin, not the impersonated user.

### Mobile (the actual point of this PR)

31. On an iPhone in Safari, log in to the app.
32. Use it intermittently over more than 7 days.
33. Expected: no forced re-login. This is the acceptance criterion that cannot be verified in CI and needs real QA time.

### Regression checks

34. CLI login (`b4m` device flow) still completes and stays authenticated across a token refresh - the OAuth routes must keep returning the refresh token in the body and must receive no cookie.
35. Okta and SAML SSO logins still work end to end.
36. MFA enrollment and MFA login still work.
37. An **existing** session created before this deploy: sign in on staging before it ships, then reload after. Expected: you stay signed in, migrated onto a cookie, rather than being logged out.

### What NOT to test

- Per-device vs all-device logout semantics. Logout still revokes all sessions for the user; changing that is #1194.
- WebSocket transport changes. There are none - the socket still authenticates with the access token in the query string.

## Additional Information

Verification run locally:

- `pnpm lint:check` clean
- `pnpm turbo:typecheck` 40/40 passing
- `@bike4mind/database` 1368 tests passing
- 26 auth and context suites, 260 tests passing

The full client suite has 9 failing files, all `mongodb-memory-server` startup timeouts. Each passes in isolation or with `--testTimeout=60000`, none reference a file this PR touches, and the failing set is identical before and after this branch. That is the known local Mongo race that CI shards around.

Not exercised locally, called out honestly:

- The live WebSocket path (connect, subscribe, mid-session refresh and reconnect) is reasoned through and transport-unchanged, but was not run. The 30m access-token TTL makes mid-session refresh a genuinely common path now, so it deserves attention in QA.
- The E2E suite was not run; it needs a live app and SST stack. The helpers are migrated and CI is the real gate.
- The >7-day mobile Safari criterion is inherently QA-only.

## Developer Notes

- **`issueBrowserSession()`** is the single seam for browser session minting. Any new browser-facing login route should call it rather than `issueSessionForRequest` plus hand-rolled cookie code; anything machine-facing keeps `issueSessionForRequest` and stays body-only.
- **`refreshCookie.ts`** owns every cookie name, attribute, and lifetime in one file. Cookie policy changes happen there and nowhere else.
- **The persist `migrate` hook** shows the pattern for removing a field from a Zustand `persist` store safely: `partialize` alone leaves already-written values to be rehydrated, so a `version` bump plus `migrate` is required to actually evict them from existing browsers.
- **`sessionBootstrap.ts`** establishes a bootstrapping-vs-logged-out distinction the router guard respects. Any future async pre-auth work belongs there rather than in a new guard.
- **`rotateSession` now returns `impersonatedBy`** additively, which makes server-side impersonation state readable at refresh time.

## Security Testing

This PR is hardening rather than a fix for a reproducible exploit - there is no BEFORE script that demonstrates a vulnerability, because the pre-change behaviour (a refresh token in `localStorage`) is only exploitable given a separate XSS. The observable AFTER state is the storage-hygiene check in steps 3-8 of the tester guide: no session token in `localStorage`, and `b4m_rt` unreadable from `document.cookie`.

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment) - N/A, see above
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment) - to be done via steps 3-8 once a preview exists
- [x] Production is assumed to match staging (no direct-to-prod deploys)

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no new AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - no new UI; the cold-load guard exists specifically to avoid a login flash
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - `apps/client/e2e/README.md` updated for the new auth seeding
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry changes
