### PR TITLE
fix(services): spread the skills feature context into the chat system prompt

### DIFF
--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -31,6 +31,8 @@ import {
   type IMessage,
 } from '@bike4mind/common';
 import { ToolBuilder } from './tools/ToolBuilder';
+import { SkillsFeature } from './features/SkillsFeature';
+import type { ISkill } from '@bike4mind/common';
 import { runWithFakeTimers } from './__tests__/helpers/fakeTimers';
 
 vi.mock('@bike4mind/llm-adapters', async importOriginal => {
@@ -1508,6 +1510,99 @@ describe('ChatCompletionProcess', () => {
         allowedAgents: [],
       });
       expect(agentStore).toBeUndefined();
+    });
+  });
+
+  // SkillsFeature computes a catalog + expanded `/skill-name` body, but the drop (#1344) was in the
+  // ASSEMBLY: the `skills` key was never spread into contextAndSystemMessages, so the model never saw
+  // it. A unit test on getContextMessages passes without the spread, so this asserts against the
+  // array actually handed to buildAndSortMessages - mirroring the assert-present/assert-absent
+  // approach requested for the artifact prompt in #1301.
+  describe('SkillsFeature context reaches the assembled system prompt (#1344)', () => {
+    const ownedSkill = (overrides: Partial<ISkill>): ISkill =>
+      ({
+        id: 's1',
+        name: 'skill',
+        description: 'A skill',
+        body: 'Body',
+        userId: 'user1', // matches mockUser.id, so it renders as trusted (no untrusted wrapping)
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides,
+      }) as ISkill;
+
+    // Runs a full turn and returns the flattened text of the system/context messages that the
+    // assembly actually hands to buildAndSortMessages (its 2nd argument).
+    const runAndCaptureSystemText = async (params: {
+      message: string;
+      catalog?: ISkill[];
+      resolved?: ISkill[];
+    }): Promise<string> => {
+      mockDb.skills = {
+        listAccessibleInvocableForUser: vi.fn().mockResolvedValue(params.catalog ?? []),
+        findAccessibleByNamesForUser: vi.fn().mockResolvedValue(params.resolved ?? []),
+      };
+      // buildOptimizedFeatures is stubbed in beforeEach, so register the real feature under the
+      // same key the assembly reads. This exercises both phases against the live feature.
+      service.features.set('skills', new SkillsFeature(service));
+
+      mockedGetLlmByModel.mockReturnValue({
+        complete: vi.fn().mockImplementation(async (_m, _msgs, _opts, cb) => cb(['Hi!'])),
+        getModelInfo: vi.fn().mockResolvedValue([]),
+        currentModel: ChatModels.GPT4,
+      });
+      mockedGetAvailableModels.mockResolvedValue([
+        {
+          id: ChatModels.GPT4,
+          type: 'text',
+          name: 'GPT-4',
+          backend: ModelBackend.OpenAI,
+          max_tokens: 100,
+          contextWindow: 200_000,
+          can_stream: false,
+          pricing: {},
+          supportsImageVariation: false,
+        },
+      ]);
+      mockedBuildAndSortMessages.mockResolvedValue([{ role: 'user', content: params.message }]);
+      mockedFetchAndProcessPreviousMessages.mockResolvedValue([[], 0, {}]);
+      mockedProcessUrlsFromPrompt.mockResolvedValue({ userMessages: [], remainingPrompt: params.message });
+
+      const body = {
+        ...startQuestParams,
+        message: params.message,
+        tools: [],
+        projectId: undefined,
+        organizationId: undefined,
+      };
+      await service.process({ body, logger: mockLogger });
+
+      const contextAndSystemMessages = (mockedBuildAndSortMessages.mock.calls[0]?.[1] ?? []) as IMessage[];
+      return contextAndSystemMessages
+        .map(m => (typeof m.content === 'string' ? m.content : JSON.stringify(m.content)))
+        .join('\n---\n');
+    };
+
+    it('spreads the catalog and the expanded /skill invocation into the system messages', async () => {
+      const systemText = await runAndCaptureSystemText({
+        message: '/greet Bob',
+        catalog: [ownedSkill({ name: 'greet', description: 'Greet someone' })],
+        resolved: [ownedSkill({ name: 'greet', body: 'Say hello to $ARGUMENTS' })],
+      });
+
+      // Model-invocable catalog (the `skill` tool's discovery surface) reaches the prompt.
+      expect(systemText).toContain('Available Skills');
+      expect(systemText).toContain('/greet');
+      // Explicit `/skill-name` expansion reaches the prompt with arguments substituted.
+      expect(systemText).toContain('Skill Invoked: /greet');
+      expect(systemText).toContain('Say hello to Bob');
+    });
+
+    it('emits no skills block when nothing is cataloged or invoked (assert-absent counterpart)', async () => {
+      const systemText = await runAndCaptureSystemText({ message: 'just chatting, no slash command' });
+
+      expect(systemText).not.toContain('Available Skills');
+      expect(systemText).not.toContain('Skill Invoked');
     });
   });
 

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -2030,6 +2030,10 @@ export class ChatCompletionProcess {
         questMaster: featureContextMessages['questMaster'],
         organizationPrompt: featureContextMessages['organizationPrompt'], // Add team-wide system prompt
         sessionPrompt: featureContextMessages['sessionPrompt'], // Per-session system prompt (product surfaces)
+        // Skills catalog (model-invocable `skill` tool discovery) + expanded `/skill-name`
+        // invocations. Grouped with the instruction-shaping blocks above and ahead of the
+        // data-context blocks below so an explicit invocation is not diluted by retrieval noise.
+        skills: featureContextMessages['skills'],
         knowledgeRetrieval: featureContextMessages['knowledgeRetrieval'], // Forced data-lake retrieval (grounding + citations)
         // Add LLM-optimized context summary if available (covers messages before verbatim window)
         contextSummary: session.contextSummary

--- a/b4m-core/services/src/llm/systemPromptSources.ts
+++ b/b4m-core/services/src/llm/systemPromptSources.ts
@@ -31,6 +31,7 @@ export type PromptSourceId =
   | 'questMaster'
   | 'organizationPrompt'
   | 'sessionPrompt'
+  | 'skills'
   | 'knowledgeRetrieval'
   | 'contextSummary'
   | 'mementos'
@@ -55,6 +56,7 @@ export const PROMPT_SOURCE_ORDER: PromptSourceId[] = [
   'questMaster',
   'organizationPrompt',
   'sessionPrompt',
+  'skills',
   'knowledgeRetrieval',
   'contextSummary',
   'mementos',
@@ -172,6 +174,7 @@ export const PROMPT_SOURCE_METADATA: Record<
   questMaster: { origin: 'session', name: 'quest_master' },
   organizationPrompt: { origin: 'org', name: 'organization_prompt' },
   sessionPrompt: { origin: 'session', name: 'session_prompt' },
+  skills: { origin: 'session', name: 'skills' },
   knowledgeRetrieval: { origin: 'session', name: 'knowledge_retrieval' },
   contextSummary: { origin: 'session', name: 'context_summary' },
   mementos: { origin: 'user', name: 'mementos' },


### PR DESCRIPTION
## Description

`SkillsFeature` runs on every chat completion and correctly computes two things: the model-invocable **skills catalog** (the discovery surface for the autonomous `skill` tool) and the expanded body of an explicit `/skill-name args` invocation. Its output is keyed under `featureContextMessages['skills']`.

The chat-completion assembly in `ChatCompletionProcess.ts`, however, only spread seven feature keys (`agentDetection`, `questMaster`, `organizationPrompt`, `sessionPrompt`, `knowledgeRetrieval`, `mementos`, `project`) into the system prompt. `skills` was not among them, and nothing else consumed the key. So the catalog and every `/skill` expansion were computed and then silently discarded before reaching the model.

This is a wiring gap, not a logic bug in the feature. `git blame` shows it has been the case since the initial open-core release; no test asserted skills reach the assembled system messages.

The agent-execution path renders invoked skills through a **separate** route (`getFirstIterationSkillsPreamble.ts`), so this drop was specific to the chat pipeline and the fix carries no double-injection risk.

Closes #1344
Closes #1355

## Changes

- `b4m-core/services/src/llm/ChatCompletionProcess.ts` — spread `featureContextMessages['skills']` into the assembled system messages, placed right after `sessionPrompt` (grouped with the instruction-shaping blocks, ahead of retrieval/mementos so an explicit invocation is not diluted by grounding noise).
- `b4m-core/services/src/llm/ChatCompletion.test.ts` — added a wiring test that asserts against the array actually handed to `buildAndSortMessages` (present when a skill is cataloged/invoked, absent otherwise). A `getContextMessages` unit test passes without the fix and misses this, mirroring the assert-present/assert-absent approach requested in #1301.

## Guide for Testers

This is a backend prompt-assembly fix. The most reliable verification is the wiring test, but it is also observable at runtime.

**Automated (fastest, no environment needed):**
1. From the repo root, run `pnpm --filter @bike4mind/services test -- --run ChatCompletion.test.ts`.
2. Expected: all tests pass, including `ChatCompletionProcess > SkillsFeature context reaches the assembled system prompt (#1344)`.
3. To confirm the test genuinely guards the fix, revert the one-line spread in `ChatCompletionProcess.ts` and re-run — the "spreads the catalog and the expanded /skill invocation" test must FAIL. Restore the line afterward.

**Runtime (requires an environment where the skill repository is wired):**
1. Open a notebook chat.
2. Create a skill (e.g. name `greet`, body `Say hello to $ARGUMENTS`).
3. In the message input, type `/greet Bob` and send.
4. Expected: the model behaves as instructed by the skill body (greets "Bob"). Before this fix the turn behaved as if no skill was invoked.
5. Optional: with at least one model-invocable skill defined, ask the model a task its skill description fits and confirm it can discover/invoke the skill via the `skill` tool (the catalog is now visible to it).

## Regression Checks

1. Send a normal chat message with no `/skill` and no defined skills. Expected: a normal response, no `## Available Skills` or `## Skill Invoked` text leaking into the reply, no errors.
2. Confirm existing system-prompt content (org prompt, session prompt, data-lake retrieval, mementos) still appears/behaves as before — the skills block was inserted between `sessionPrompt` and `knowledgeRetrieval`, not in place of anything.

## What NOT to test

- The agent-execution path — invoked skills there go through a separate route (`getFirstIterationSkillsPreamble.ts`) and are unchanged by this PR.
- Skill CRUD / access-control resolution — unchanged; this PR only wires already-resolved output into the prompt.

## Additional Information

No schema, config, or admin-settings changes. No new warnings.