### PR TITLE
feat(api): return the per-source prompt breakdown on request

### DIFF
--- a/apps/client/pages/api/__tests__/chat.integration.test.ts
+++ b/apps/client/pages/api/__tests__/chat.integration.test.ts
@@ -26,6 +26,7 @@ const {
   mockFindById,
   mockRateLimit,
   mockInvoke,
+  mockProcess,
   mockGetSettingsMap,
   mockResolveDefaultChatModel,
   mockIsChatModelUsable,
@@ -34,6 +35,7 @@ const {
   mockFindById: vi.fn(),
   mockRateLimit: vi.fn(),
   mockInvoke: vi.fn(),
+  mockProcess: vi.fn(),
   mockGetSettingsMap: vi.fn(),
   mockResolveDefaultChatModel: vi.fn(),
   mockIsChatModelUsable: vi.fn(),
@@ -87,8 +89,14 @@ vi.mock('@bike4mind/services', async orig => {
     prefetchedOrganization = undefined;
     invoke = (...a: unknown[]) => mockInvoke(...a);
   }
+  // The wait=true path constructs this directly; the async-path tests never reach it.
+  class MockChatCompletionProcess {
+    pipelinePhases = undefined;
+    process = (...a: unknown[]) => mockProcess(...a);
+  }
   return {
     ...actual,
+    ChatCompletionProcess: MockChatCompletionProcess,
     userApiKeyService: {
       ...(actual.userApiKeyService as object),
       validateUserApiKey: (...a: unknown[]) => mockValidate(...a),
@@ -318,11 +326,22 @@ describe('POST /api/chat (integration — scope enforcement via real middleware 
   });
 });
 
-describe('POST /api/chat (integration - promptMode request contract)', () => {
+describe('POST /api/chat (integration - wait path promptDetails exposure)', () => {
+  // What process() leaves on the in-memory quest; the route must surface it only on request.
+  const DETAILS = [{ source: 'hardcoded', name: 'date_time_context', tokenCount: 12, wasIncluded: true }];
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSettingsMap.mockResolvedValue({});
-    mockInvoke.mockResolvedValue({ id: 'quest-1', status: 'queued' });
+    mockInvoke.mockResolvedValue({
+      id: 'quest-2',
+      status: 'done',
+      reply: 'hi',
+      replies: ['hi'],
+      createdAt: new Date('2026-08-03T00:00:00Z'),
+      promptMeta: { context: { systemPromptDetails: DETAILS } },
+    });
+    mockProcess.mockResolvedValue(undefined);
     mockFindById.mockReturnValue(
       Promise.resolve({ id: 'user-1', _id: 'user-1', isBanned: false, disputePending: false })
     );
@@ -336,6 +355,22 @@ describe('POST /api/chat (integration - promptMode request contract)', () => {
       scopes: [ApiKeyScope.AI_CHAT],
       rateLimit: { requestsPerMinute: 60, requestsPerDay: 1000 },
     });
+  });
+
+  it('returns the per-source breakdown when includePromptDetails is set', async () => {
+    const { req, res } = fire({
+      body: { message: 'hello', sessionId: 'sess-1', wait: true, includePromptDetails: true },
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().promptDetails).toEqual(DETAILS);
+  });
+
+  it('omits the breakdown without the flag, keeping the response shape unchanged', async () => {
+    const { req, res } = fire({ body: { message: 'hello', sessionId: 'sess-1', wait: true } });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).not.toHaveProperty('promptDetails');
   });
 
   it('accepts promptMode: raw at the HTTP boundary', async () => {

--- a/apps/client/pages/api/chat.ts
+++ b/apps/client/pages/api/chat.ts
@@ -56,6 +56,10 @@ const SimplifiedChatRequestSchema = z.object({
   // 'grounded' adds data-lake retrieval only; 'surface' adds the org/session prompts on top.
   // Retrieval itself comes from the session (forceKnowledgeRetrieval), not from this flag.
   promptMode: z.enum(['raw', 'grounded', 'surface']).optional(),
+  // With wait, also return the per-source system prompt breakdown the completion was
+  // assembled from (promptDetails), so callers can verify what fed the model instead of
+  // inferring it from behavior.
+  includePromptDetails: z.boolean().optional(),
 });
 
 type SimplifiedChatRequest = z.infer<typeof SimplifiedChatRequestSchema>;
@@ -219,6 +223,9 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_CHAT, ApiKeyScope.AI_G
         response: completedQuest.reply,
         responses: completedQuest.replies,
         createdAt: completedQuest.createdAt,
+        ...(simplifiedRequest.includePromptDetails && completedQuest.promptMeta?.context?.systemPromptDetails
+          ? { promptDetails: completedQuest.promptMeta.context.systemPromptDetails }
+          : {}),
         ...(toolMeta && { tools: toolMeta }),
         performance,
         tracking_info: {

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ContextTelemetrySchema } from './contextTelemetry';
+import { ContextTelemetrySchema, SystemPromptDetailSchema } from './contextTelemetry';
 
 /**
  * A Date that also accepts its own JSON form. promptMeta makes a round trip through the client:
@@ -113,6 +113,11 @@ const PromptMetaContextSchema = z.object({
   mementoCount: z.number().optional(),
   mementoIds: z.array(z.string()).optional(),
   tokensBySource: PromptMetaTokensBySourceSchema.optional(),
+  // Per-source system prompt breakdown, derived from the tagged assembly (see
+  // services systemPromptSources). Stored on every completion - unlike contextTelemetry,
+  // which only exists when enhanced telemetry is enabled - so the API layer can report
+  // which prompts fed a completion.
+  systemPromptDetails: z.array(SystemPromptDetailSchema).optional(),
   systemPrompt: z.string().optional(),
   userPrompt: z.string().optional(),
   conversationContext: z

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -375,6 +375,12 @@ describe('ChatCompletionProcess', () => {
           contextAndSystemMessages.some(m => typeof m.content === 'string' && m.content.startsWith('Current date:'))
         ).toBe(true);
         expect(options).toEqual(expect.objectContaining({ skipAdminPromptTemplates: false }));
+        // The per-source breakdown persists on the quest unconditionally - not only when enhanced
+        // telemetry is enabled - so the API layer can report which prompts fed a completion.
+        const savedQuest = vi.mocked(mockDb.quests.update).mock.calls.at(-1)?.[0] as {
+          promptMeta?: { context?: { systemPromptDetails?: { name: string }[] } };
+        };
+        expect(savedQuest.promptMeta?.context?.systemPromptDetails?.map(d => d.name)).toContain('date_time_context');
       });
 
       it('hands an EMPTY system stack to the builder under raw, and skips the admin templates', async () => {

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -2275,45 +2275,50 @@ export class ChatCompletionProcess {
         logger.warn(`📊 Failed to calculate token breakdown:`, tokenBreakdownError);
       }
 
+      // Per-source breakdown, derived from the same tagged list the prompt was assembled
+      // from (see systemPromptSources) rather than re-listed by hand here. The hand-written
+      // version this replaces covered a third of the sources and reported a `session_summary`
+      // row built from `session.summary`, a field the assembled prompt never carried - it
+      // carries `session.contextSummary`. Sources appended downstream by buildAndSortMessages
+      // (FormatPromptTemplate, image prompt) are still not represented here. The two always-on
+      // floor sources come from systemPromptFloorTelemetry, which owns those rows outright -
+      // including the wasIncluded:false inventory rows a derivation from the admitted stack
+      // cannot produce; inclusion is read off the admitted stack rather than the raw settings
+      // gates, so a promptMode that strips a block reports it excluded instead of billed (#810).
+      //
+      // Persisted on the quest for every completion - unlike contextTelemetry, which exists
+      // only when enhanced telemetry is on - so the API layer can report which prompts fed a
+      // completion instead of leaving callers to infer it from behavior. Guarded: a counting
+      // failure must degrade to a missing breakdown, never a failed completion.
+      let systemPromptDetails: SystemPromptDetail[] | undefined;
+      try {
+        const floorSources: PromptSourceId[] = ['artifactEmission', 'helpCenter'];
+        systemPromptDetails = await toPromptDetails(
+          admittedContextMessages.filter(t => !floorSources.includes(t.source)),
+          messages => calculateTotalTokenLength(messages, tokenCalcOptions)
+        );
+        const admitted = (source: PromptSourceId) => admittedContextMessages.some(t => t.source === source);
+        systemPromptDetails.push(
+          ...(await buildAlwaysOnFloorDetails(
+            {
+              artifactEmissionEnabled: admitted('artifactEmission'),
+              artifactEmissionContent,
+              // The helper models exactly one exclusion ("local model"); a mode that strips
+              // the help-center block must surface the same way: excluded, zero tokens.
+              isLocalModel: !admitted('helpCenter'),
+              helpCenterContent,
+            },
+            content => calculateTotalTokenLength([{ role: 'system' as const, content }], tokenCalcOptions)
+          ))
+        );
+        quest.promptMeta!.context!.systemPromptDetails = systemPromptDetails;
+      } catch (detailsError) {
+        logger.warn(`📊 Failed to derive system prompt details:`, detailsError);
+      }
+
       // Feed breakdown into telemetry builder for detailed system prompt tracking
-      if (telemetryBuilder) {
+      if (telemetryBuilder && systemPromptDetails) {
         try {
-          // Per-source breakdown, derived from the same tagged list the prompt was assembled
-          // from (see systemPromptSources) rather than re-listed by hand here. The hand-written
-          // version this replaces covered a third of the sources and reported a `session_summary`
-          // row built from `session.summary`, a field the assembled prompt never carried - it
-          // carries `session.contextSummary`. Sources appended downstream by buildAndSortMessages
-          // (FormatPromptTemplate, image prompt) are still not represented here. The two always-on
-          // floor sources are excluded: systemPromptFloorTelemetry owns those rows outright
-          // (pushed below), including the wasIncluded:false inventory rows a derivation from the
-          // admitted stack cannot produce.
-          const floorSources: PromptSourceId[] = ['artifactEmission', 'helpCenter'];
-          const systemPromptDetails: SystemPromptDetail[] = await toPromptDetails(
-            admittedContextMessages.filter(t => !floorSources.includes(t.source)),
-            messages => calculateTotalTokenLength(messages, tokenCalcOptions)
-          );
-
-          // Always-on floor blocks (artifact-emission, help-center) billed on every basic
-          // turn. Previously invisible inside the systemPrompts residual; itemized here so
-          // the fixed prompt cost is auditable in the Context Inspector (#810). Inclusion is
-          // read off the admitted stack rather than the raw settings gates, so a promptMode
-          // that strips a block reports it excluded instead of billed.
-          const admitted = (source: PromptSourceId) => admittedContextMessages.some(t => t.source === source);
-          systemPromptDetails.push(
-            ...(await buildAlwaysOnFloorDetails(
-              {
-                artifactEmissionEnabled: admitted('artifactEmission'),
-                artifactEmissionContent,
-                // The helper models exactly one exclusion ("local model"); a mode that strips
-                // the help-center block must surface the same way: excluded, zero tokens.
-                isLocalModel: !admitted('helpCenter'),
-                helpCenterContent,
-              },
-              content => calculateTotalTokenLength([{ role: 'system' as const, content }], tokenCalcOptions)
-            ))
-          );
-
-          // Calculate total system prompt tokens
           const systemPromptTokensTotal = systemPromptDetails.reduce((sum, p) => sum + p.tokenCount, 0);
 
           telemetryBuilder.setSystemPrompts({

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -42,6 +42,18 @@ const SystemPromptSourceSchema = subSchema({
   enabled: { type: Boolean, required: false },
 });
 
+// Per-source system prompt breakdown derived from the tagged assembly (see
+// services systemPromptSources). Declared or Mongoose strict mode silently strips
+// it on save; the API's includePromptDetails and any DB read depend on it persisting.
+// Kept in sync with SystemPromptDetailSchema in @bike4mind/common contextTelemetry.
+const SystemPromptDetailSubSchema = subSchema({
+  source: { type: String, required: false },
+  name: { type: String, required: false },
+  tokenCount: { type: Number, required: false },
+  wasIncluded: { type: Boolean, required: false },
+  exclusionReason: { type: String, required: false },
+});
+
 const ArtifactSchema = subSchema({
   // No enum: writers emit internal artifact types and can fall back to a raw MIME string.
   // Kept in sync with PromptMetaArtifactSchema, which is deliberately open for the same reason.
@@ -191,6 +203,7 @@ export const PromptMetaSchema = new Schema<PromptMeta>(
       mementoCount: { type: Number, required: false },
       mementoIds: [{ type: String, required: false }],
       systemPromptSources: { type: [SystemPromptSourceSchema], required: false, default: undefined },
+      systemPromptDetails: { type: [SystemPromptDetailSubSchema], required: false, default: undefined },
       dedupedSystemPrompts: { type: [String], required: false, default: undefined },
       totalSystemPromptCount: { type: Number, required: false },
       duplicateSystemPromptCount: { type: Number, required: false },


### PR DESCRIPTION
# Pull Request

## Description

Stacked on #1347. Closes the observability half of the eval P1: `systemPromptDetails` existed server-side but was unreachable via API, so every finding about the prompt stack had to be inferred from model behavior.

Two changes:

- The derived per-source breakdown now persists on `promptMeta.context` for **every** completion, not only when enhanced telemetry is enabled.
- `/api/chat` accepts `includePromptDetails: true` on the `wait` path and returns the breakdown as `promptDetails`.

## Changes

- `PromptMetaContextSchema` gains `systemPromptDetails` (array of the existing `SystemPromptDetailSchema` rows).
- `ChatCompletionProcess`: the derivation moved out of the `if (telemetryBuilder)` gate; the telemetry block reuses the same array. Guarded so a token-counting failure degrades to a missing breakdown, never a failed completion.
- `/api/chat`: `includePromptDetails` schema flag + response field; absent unless requested, so the response shape is unchanged for existing callers.

## Guide for Testers

1. POST `/api/chat` with `{"message": "Reply with ping.", "wait": true, "toolMode": "fast", "includePromptDetails": true}` and an `ai:chat` API key. Expected: the JSON response has a `promptDetails` array with rows like `date_time_context`, `tool_guidance`, `help_center`, each with a `tokenCount` and `wasIncluded`.
2. Repeat with `"promptMode": "raw"`. Expected: `promptDetails` contains no `wasIncluded: true` rows - only the two floor inventory rows (`artifact_emission`, `help_center`) marked excluded with zero tokens.
3. Repeat step 1 WITHOUT `includePromptDetails`. Expected: no `promptDetails` key in the response.

Verified live on a self-host stack: outputs matched all three expectations exactly.

## Additional Information

This is the "expose the effective system messages per completion" item from the eval-cleanup P1. Merge #1347 first; this PR retargets to main automatically when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)