### PR TITLE
fix(analytics): defragment the User Activity group key

### DIFF
--- a/apps/client/pages/api/users/__tests__/counterLogs.test.ts
+++ b/apps/client/pages/api/users/__tests__/counterLogs.test.ts
@@ -11,9 +11,10 @@ import { SAFE_USER_LOOKUP_PROJECT, USER_SECRET_FIELDS } from '@bike4mind/common'
  * End-to-end tests for the `{logs}` branch, driving the real handler against createMongoServer.
  *
  * Originally written for the M1 $lookup reorder; the row shape they pin is now flat (one row per
- * day/counter/user/metadata) rather than nested under `users[]`, because paging moved server-side.
- * The properties each test guards are unchanged: grouping/count correctness, the orphaned-user
- * $ifNull fallback, the $convert onError arm, the $lookup projection, and metadata fragmentation.
+ * day/counter/user, split by SPLIT_METADATA_KEYS) rather than nested under `users[]`, because
+ * paging moved server-side. The properties each test guards are unchanged: grouping/count
+ * correctness, the orphaned-user $ifNull fallback, the $convert onError arm, and the $lookup
+ * projection.
  *
  * The projection test asserts on the exported builder the handler actually calls, NOT on a copy of
  * the stages. An earlier version re-declared its own pipeline, which meant deleting the production
@@ -97,8 +98,8 @@ describe('GET /api/users/counterLogs (end-to-end, real model + Mongo)', () => {
         metadata: { sessionId: 'session-a' },
       },
       {
-        // Second event for the same user/date/counterName/metadata -> should collapse into the
-        // same group and sum, exactly like the pre-reorder pipeline.
+        // Second event for the same user/date/counterName -> should collapse into the same
+        // group and sum, exactly like the pre-reorder pipeline.
         userId: goodUser.id,
         userName: 'Good User',
         userLevel: 'User',
@@ -181,6 +182,8 @@ describe('GET /api/users/counterLogs (end-to-end, real model + Mongo)', () => {
   });
 
   it('builds the user $lookup with an inner $project restricted to non-secret fields', () => {
+    // email is the only field the route reads off the joined user; the organization comes off
+    // the counter log itself, which is also what the org filters match on.
     // Asserts on the EXPORTED builder the handler calls, so deleting or widening the production
     // $project fails here. Do not inline a copy of the stages: the $lookup's projection has no
     // effect on the HTTP response (the outer $group/$project already forward only named scalars),
@@ -201,15 +204,13 @@ describe('GET /api/users/counterLogs (end-to-end, real model + Mongo)', () => {
     // Exact key set: an inclusion projection that gains a field is exactly the regression to catch,
     // so assert equality rather than a subset. Secret fields are named explicitly too, so the
     // intent survives even if SAFE_USER_LOOKUP_PROJECT itself is ever widened by mistake.
-    expect(new Set(Object.keys(projection!))).toEqual(
-      new Set([...Object.keys(SAFE_USER_LOOKUP_PROJECT), 'email', 'organization'])
-    );
+    expect(new Set(Object.keys(projection!))).toEqual(new Set([...Object.keys(SAFE_USER_LOOKUP_PROJECT), 'email']));
     for (const secret of USER_SECRET_FIELDS) {
       expect(projection, `secret field "${secret}" must never be projected`).not.toHaveProperty(secret);
     }
   });
 
-  it('keeps metadata fragments in separate groups', async () => {
+  it('keeps report activity in separate groups per report', async () => {
     const user = await User.create({
       username: 'e2e-frag-user',
       name: 'Frag User',
@@ -243,7 +244,8 @@ describe('GET /api/users/counterLogs (end-to-end, real model + Mongo)', () => {
     const body = JSON.parse(JSON.stringify(res._getJSONData()));
     const rows = body.logs as Array<{ metadata: { reportId: string } }>;
 
-    // Still two rows, one per distinct reportId - collapsing the group key is not this change's job.
+    // reportId is a SPLIT_METADATA_KEY, so these two views stay apart even though everything
+    // else about them (day, counter, user) is identical.
     expect(rows).toHaveLength(2);
     expect(new Set(rows.map(r => r.metadata.reportId))).toEqual(new Set(['report-1', 'report-2']));
   });

--- a/apps/client/server/analytics/userActivityQuery.rowUnit.e2e.test.ts
+++ b/apps/client/server/analytics/userActivityQuery.rowUnit.e2e.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { buildUserActivityPipeline } from './userActivityQuery';
+import {
+  asWindow,
+  buildWindow,
+  sliceWindow,
+  windowCoversPage,
+  windowRowsFor,
+  type UserActivityWindow,
+} from './userActivityCache';
+
+/**
+ * Acceptance test for the row unit: the server's rows must match what the pre-pagination client
+ * rendered, because that client merged rows the server now has to merge itself.
+ *
+ * `mergedLikeThePrePaginationClient` restates that client's key - date + counter + email, plus
+ * reportId on report counters - over the same raw events, so this is a comparison against the
+ * old behaviour rather than against a hand-written expectation.
+ *
+ * Rows are served through the window cache (`servePage`), not straight off the builder: the cache
+ * is what the grid actually reads, so pinning the guarantee there covers the slicing too.
+ */
+let mongoServer: MongoMemoryServer;
+let counterLogs: mongoose.Collection;
+
+const USER_A = new mongoose.Types.ObjectId();
+const USER_B = new mongoose.Types.ObjectId();
+const EMAIL: Record<string, string> = {
+  [USER_A.toString()]: 'ada@example.com',
+  [USER_B.toString()]: 'poy@example.com',
+};
+
+const RANGE = { startDate: '2026-07-21', endDate: '2026-07-28' };
+
+interface RawLog {
+  userId: string;
+  userName: string;
+  userLevel: string;
+  userOrganization: string;
+  counterName: string;
+  counterValue: number;
+  datetime: Date;
+  metadata: Record<string, unknown>;
+}
+
+const log = (overrides: Partial<RawLog>): RawLog => ({
+  userId: USER_A.toString(),
+  userName: 'a',
+  userLevel: '1',
+  userOrganization: 'Acme',
+  counterName: 'Session Created',
+  counterValue: 1,
+  datetime: new Date('2026-07-24T10:00:00.000Z'),
+  metadata: {},
+  ...overrides,
+});
+
+const times = <T>(n: number, make: (i: number) => T): T[] => Array.from({ length: n }, (_, i) => make(i));
+
+/**
+ * The production shape: every event carries identity metadata (a session, a request, timings),
+ * so with the subdocument in the group key no two events of the same activity ever collapse.
+ */
+const FIXTURE: RawLog[] = [
+  ...times(40, i => log({ metadata: { sessionId: `session-${i}`, sessionName: `chat ${i}` } })),
+  ...times(25, i =>
+    log({
+      counterName: 'Completion API Completed',
+      counterValue: 2,
+      metadata: {
+        requestId: `req-${i}`,
+        modelName: i % 2 ? 'claude-opus-5' : 'claude-sonnet-5',
+        source: i % 3 ? 'web' : 'cli',
+        durationMs: 100 + i,
+      },
+    })
+  ),
+  ...times(10, i =>
+    log({
+      userId: USER_B.toString(),
+      datetime: new Date('2026-07-25T10:00:00.000Z'),
+      metadata: { sessionId: `b-session-${i}` },
+    })
+  ),
+  ...times(4, i =>
+    log({ counterName: 'Marketing Report Opened', metadata: { reportId: 'report-1', viewId: `v${i}` } })
+  ),
+  ...times(2, i =>
+    log({ counterName: 'Marketing Report Opened', metadata: { reportId: 'report-2', viewId: `v${i}` } })
+  ),
+];
+
+interface Row {
+  date: string;
+  counterName: string;
+  userEmail: string;
+  count: number;
+  totalValue: number;
+}
+
+function mergedLikeThePrePaginationClient(events: RawLog[]): Row[] {
+  const merged = new Map<string, Row>();
+
+  for (const event of events) {
+    const date = event.datetime.toISOString().slice(0, 10);
+    const userEmail = EMAIL[event.userId] ?? '';
+    const reportId = event.metadata.reportId;
+    const isReportAction = event.counterName.toLowerCase().includes('report');
+    const key =
+      isReportAction && reportId
+        ? `${date}-${event.counterName}-${userEmail}-${reportId}`
+        : `${date}-${event.counterName}-${userEmail}`;
+
+    const existing = merged.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.totalValue += event.counterValue;
+    } else {
+      merged.set(key, { date, counterName: event.counterName, userEmail, count: 1, totalValue: event.counterValue });
+    }
+  }
+
+  return [...merged.values()];
+}
+
+const identify = (row: Row) => `${row.date}|${row.counterName}|${row.userEmail}`;
+
+type Query = Omit<Parameters<typeof buildUserActivityPipeline>[0], 'skip' | 'limit'>;
+
+/** Stands in for the cache collection, keyed the way the route keys it: by filter set, not page. */
+let windowCache = new Map<string, unknown>();
+
+let aggregations = 0;
+
+/**
+ * Mirrors the route's read path (pages/api/users/counterLogs.ts): serve the page out of a cached
+ * window when one covers it, otherwise aggregate a window from offset 0 and slice this page out.
+ */
+const servePage = async (query: Query, page = 1, limit = 100) => {
+  const cacheKey = JSON.stringify(query);
+  const skip = (page - 1) * limit;
+
+  const cachedWindow = asWindow(windowCache.get(cacheKey));
+  if (cachedWindow && windowCoversPage(cachedWindow, skip, limit)) {
+    return { rows: sliceWindow(cachedWindow, skip, limit) as Row[], total: cachedWindow.total };
+  }
+
+  const windowRows = cachedWindow?.truncated ? null : windowRowsFor(skip, limit, cachedWindow?.rows.length);
+  const { pipeline, facetStages } = buildUserActivityPipeline({
+    ...query,
+    skip: windowRows === null ? skip : 0,
+    limit: windowRows ?? limit,
+  });
+
+  aggregations += 1;
+  const [facet] = await counterLogs.aggregate([...pipeline, { $facet: facetStages }]).toArray();
+  const fetched: unknown[] = facet.rows ?? [];
+  const total = (facet.total[0]?.value ?? 0) as number;
+
+  if (windowRows === null) return { rows: fetched as Row[], total };
+
+  windowCache.set(cacheKey, buildWindow(fetched, total) satisfies UserActivityWindow);
+  return { rows: fetched.slice(skip, skip + limit) as Row[], total };
+};
+
+/** Rows the group key would have produced with the whole metadata subdocument still in it. */
+const countFragments = async () => {
+  const fragments = await counterLogs
+    .aggregate([
+      {
+        $group: {
+          _id: {
+            d: { $dateToString: { format: '%Y-%m-%d', date: '$datetime', timezone: 'UTC' } },
+            c: '$counterName',
+            u: '$userId',
+            m: '$metadata',
+          },
+        },
+      },
+      { $count: 'value' },
+    ])
+    .toArray();
+  return (fragments[0]?.value ?? 0) as number;
+};
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+  const db = mongoose.connection.db!;
+  counterLogs = db.collection('counterlogs');
+
+  await db.collection('users').insertMany([
+    { _id: USER_A, email: EMAIL[USER_A.toString()] },
+    { _id: USER_B, email: EMAIL[USER_B.toString()] },
+  ]);
+  await counterLogs.insertMany(FIXTURE);
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 60000);
+
+beforeEach(() => {
+  windowCache = new Map();
+  aggregations = 0;
+});
+
+describe('user activity row unit', () => {
+  it('returns the same rows and counts as the pre-pagination client merge', async () => {
+    const { rows, total } = await servePage(RANGE);
+    const expected = mergedLikeThePrePaginationClient(FIXTURE);
+
+    expect(total).toBe(expected.length);
+    expect(rows).toHaveLength(expected.length);
+
+    const byKey = new Map(rows.map(row => [identify(row), row]));
+    for (const row of expected) {
+      // Two report rows share a key here, so compare their summed count/value per key: the
+      // reportId split is asserted separately below.
+      expect(byKey.has(identify(row)), `missing row ${identify(row)}`).toBe(true);
+    }
+    const sum = (list: Row[], field: 'count' | 'totalValue') => list.reduce((acc, row) => acc + row[field], 0);
+    expect(sum(rows, 'count')).toBe(sum(expected, 'count'));
+    expect(sum(rows, 'totalValue')).toBe(sum(expected, 'totalValue'));
+  });
+
+  it('collapses events that differ only in identity metadata', async () => {
+    const { rows, total } = await servePage(RANGE);
+
+    // The matched pair: one row per raw event before, one row per activity now.
+    expect(await countFragments()).toBe(FIXTURE.length);
+    expect(total).toBe(5);
+
+    const sessions = rows.find(r => r.counterName === 'Session Created' && r.userEmail === 'ada@example.com');
+    expect(sessions).toMatchObject({ date: '2026-07-24', count: 40, totalValue: 40 });
+
+    const completions = rows.find(r => r.counterName === 'Completion API Completed');
+    expect(completions).toMatchObject({ count: 25, totalValue: 50 });
+  });
+
+  it('still splits report activity per report', async () => {
+    const { rows } = await servePage(RANGE);
+
+    const reports = rows.filter(r => r.counterName === 'Marketing Report Opened');
+    expect(reports).toHaveLength(2);
+    expect(reports.map(r => r.count).sort()).toEqual([2, 4]);
+    expect(new Set(reports.map(r => (r as unknown as { metadata: { reportId: string } }).metadata.reportId))).toEqual(
+      new Set(['report-1', 'report-2'])
+    );
+  });
+
+  it('carries the organization the counter log recorded', async () => {
+    const { rows } = await servePage(RANGE);
+
+    expect(rows.every(r => (r as unknown as { userOrganization: string }).userOrganization === 'Acme')).toBe(true);
+  });
+
+  it('keeps a metadata sample on the collapsed row for the grid to render', async () => {
+    const { rows } = await servePage(RANGE);
+
+    const sessions = rows.find(r => r.counterName === 'Session Created' && r.userEmail === 'ada@example.com');
+    // A sample of the group, not a summary of it - which sample is not guaranteed.
+    expect((sessions as unknown as { metadata: { sessionId: string } }).metadata.sessionId).toMatch(/^session-\d+$/);
+  });
+
+  it('filters on metadata that is no longer part of the group key', async () => {
+    // The filter runs before $group, so a key dropped from the group is still filterable.
+    const { rows, total } = await servePage({
+      ...RANGE,
+      metadataFilters: [{ field: 'source', operator: 'equals', value: 'cli' }],
+    });
+
+    expect(total).toBe(1);
+    expect(rows[0]).toMatchObject({ counterName: 'Completion API Completed', count: 9 });
+  });
+
+  it('pages the collapsed rows without repeating or dropping one', async () => {
+    // Sequential, not concurrent: page 1 has to populate the window the later pages slice.
+    const pages = [];
+    for (const page of [1, 2, 3]) pages.push(await servePage(RANGE, page, 2));
+    const seen = pages.flatMap(p => p.rows).map(identify);
+
+    expect(seen).toHaveLength(5);
+    expect(new Set(seen).size).toBe(4); // the two report rows share a date/counter/email key
+    // The window covers all 5 collapsed rows, so paging through them costs one aggregation.
+    expect(aggregations).toBe(1);
+  });
+});

--- a/apps/client/server/analytics/userActivityQuery.test.ts
+++ b/apps/client/server/analytics/userActivityQuery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildUserActivityPipeline, parseMetadataFilters } from './userActivityQuery';
+import { buildUserActivityPipeline, parseMetadataFilters, SPLIT_METADATA_KEYS } from './userActivityQuery';
 
 const baseQuery = { startDate: '2026-07-21', endDate: '2026-07-28', skip: 0, limit: 25 };
 
@@ -28,6 +28,42 @@ describe('buildUserActivityPipeline - pagination', () => {
     // A second $group is what re-nested rows into users[] and blew up the payload.
     expect(pipeline.filter(s => Object.keys(s)[0] === '$group')).toHaveLength(1);
     expect(JSON.stringify(facetStages.rows)).not.toContain('$push');
+  });
+
+  it('keeps the metadata subdocument out of the group key', () => {
+    const { pipeline } = buildUserActivityPipeline(baseQuery);
+
+    // The whole subdocument in the key made almost every raw event its own row, because most
+    // of what it carries (sessionId, requestId, token counts) is per-event identity.
+    const key = stage(pipeline, '$group').$group._id;
+    expect(Object.values(key)).not.toContain('$metadata');
+    expect(Object.keys(key.metadataKey)).toEqual([...SPLIT_METADATA_KEYS]);
+  });
+
+  it('normalises a missing split key so it does not group apart from an explicit null', () => {
+    const { pipeline } = buildUserActivityPipeline(baseQuery);
+
+    const key = stage(pipeline, '$group').$group._id;
+    for (const field of SPLIT_METADATA_KEYS) {
+      expect(key.metadataKey[field]).toEqual({ $ifNull: [`$metadata.${field}`, null] });
+    }
+  });
+
+  it('returns a representative metadata sample for the collapsed row', () => {
+    const { pipeline, facetStages } = buildUserActivityPipeline(baseQuery);
+
+    expect(stage(pipeline, '$group').$group.metadata).toEqual({ $first: '$metadata' });
+    expect(facetStages.rows.find(s => s.$project)!.$project.metadata).toBe(1);
+  });
+
+  it('reads the organization off the counter log rather than the joined user', () => {
+    const { pipeline, facetStages } = buildUserActivityPipeline(baseQuery);
+
+    // The User document has no `organization` field, so the previous `$user.organization`
+    // projection was undefined on every row. The counter log denormalises it at write time,
+    // and it is the same field the org filters match on.
+    expect(stage(pipeline, '$group').$group.userOrganization).toEqual({ $first: '$userOrganization' });
+    expect(JSON.stringify(facetStages.rows)).not.toContain('$user.organization');
   });
 
   it('joins the user only once per grouped row, not once per raw event', () => {

--- a/apps/client/server/analytics/userActivityQuery.ts
+++ b/apps/client/server/analytics/userActivityQuery.ts
@@ -1,7 +1,7 @@
 /**
  * Builds the User Activity aggregation for GET /api/users/counterLogs.
  *
- * The pipeline emits one flat row per (day, counter, user, metadata) and pages it
+ * The pipeline emits one flat row per (day, counter, user, split metadata) and pages it
  * server-side. The previous shape re-grouped rows into a nested `users[]` array and returned
  * every match unpaginated, which reached ~17MB on production data and tripped Lambda's 6MB
  * response cap (413 -> 502).
@@ -10,11 +10,9 @@
  * costs the same whether the facet returns 25 rows or 25,000. The route therefore asks for a
  * whole window of rows and slices pages out of it - see userActivityCache.ts.
  *
- * ROW UNIT: `metadata` is part of the group key, so two events that differ only in metadata
- * stay separate rows. The pre-pagination client merged them (per day/counter/user), so the
- * grid shows more, finer rows than it used to and `total` counts those finer rows. That is a
- * deliberate interim state - defragmenting the group key is tracked separately, and has to
- * come with a decision about which metadata keys are worth splitting on.
+ * ROW UNIT: one row per day/counter/user, split further only by SPLIT_METADATA_KEYS. The
+ * remaining metadata is per-event identity, so keeping the whole subdocument in the group key
+ * made almost every raw event its own row.
  *
  * Every filter that decides which rows are visible must be applied here, not in the browser:
  * with server-side paging, a client-side filter would only ever filter the current page.
@@ -37,6 +35,17 @@ export const MAX_PAGE_SIZE = 5000;
  * `__proto__`.
  */
 const METADATA_FIELD = /^[A-Za-z][A-Za-z0-9_-]*(\.[A-Za-z][A-Za-z0-9_-]*){0,4}$/;
+
+/**
+ * The only metadata keys that split the row unit. A key belongs here when two rows differing
+ * on it read as two different activities; everything else (sessionId, requestId, token counts,
+ * durations) is per-event identity and would fragment the output back to one row per event.
+ *
+ * `reportId` reproduces the pre-pagination client's key, which split report views per report.
+ * Widening this list is a product decision, not a mechanical one: adding `source` or
+ * `modelName` would split rows the client used to merge.
+ */
+export const SPLIT_METADATA_KEYS = ['reportId'] as const;
 
 const MetadataFilterSchema = z.object({
   field: z.string().max(64).regex(METADATA_FIELD),
@@ -179,10 +188,20 @@ export function buildUserActivityPipeline({
           date: '$dateString',
           counterName: '$counterName',
           userId: '$userId',
-          metadata: '$metadata',
+          // $ifNull normalises a missing key to null, so "absent" and "explicitly null" do not
+          // become two group keys for what the reader sees as the same row.
+          metadataKey: Object.fromEntries(
+            SPLIT_METADATA_KEYS.map(key => [key, { $ifNull: [`$metadata.${key}`, null] }])
+          ),
         },
         totalValue: { $sum: '$counterValue' },
         count: { $sum: 1 },
+        // A sample, not a summary: the row now spans events whose non-split metadata differs,
+        // and the grid renders this subdocument as an example of what the group contains.
+        metadata: { $first: '$metadata' },
+        // The counter log's own denormalised org, which is also what the org filters match on.
+        // The User document carries no organization field, so joining for it yields undefined.
+        userOrganization: { $first: '$userOrganization' },
       },
     },
     {
@@ -192,13 +211,13 @@ export function buildUserActivityPipeline({
     },
     {
       // Aggregation $lookup bypasses Mongoose select:false, so project off the shared
-      // secret-free baseline plus the extra non-secret fields this route reads (email,
-      // organization). Never add credential/secret fields here.
+      // secret-free baseline plus the one extra non-secret field this route reads (email).
+      // Never add credential/secret fields here.
       $lookup: {
         from: usersCollection,
         localField: 'userObjectId',
         foreignField: '_id',
-        pipeline: [{ $project: { ...SAFE_USER_LOOKUP_PROJECT, email: 1, organization: 1 } }],
+        pipeline: [{ $project: { ...SAFE_USER_LOOKUP_PROJECT, email: 1 } }],
         as: 'user',
       },
     },
@@ -209,7 +228,7 @@ export function buildUserActivityPipeline({
     // Sort before the facet: a $sort inside a $facet sub-pipeline is held to the 100MB
     // in-memory limit. The tiebreak has to be TOTAL or a row can straddle or skip a window
     // across the two facet executions - userEmail cannot do it, since every row whose join
-    // missed shares the same '' fallback. Covering the whole group key (userId + metadata,
+    // missed shares the same '' fallback. Covering the whole group key (userId + metadataKey,
     // ordered by BSON comparison) makes the order unique, because the key is unique per row.
     {
       $sort: {
@@ -218,7 +237,7 @@ export function buildUserActivityPipeline({
         '_id.counterName': 1,
         userEmail: 1,
         '_id.userId': 1,
-        '_id.metadata': 1,
+        '_id.metadataKey': 1,
       },
     },
   ];
@@ -234,8 +253,8 @@ export function buildUserActivityPipeline({
           counterName: '$_id.counterName',
           userId: '$_id.userId',
           userEmail: 1,
-          userOrganization: '$user.organization',
-          metadata: '$_id.metadata',
+          userOrganization: 1,
+          metadata: 1,
           count: 1,
           totalValue: 1,
         },


### PR DESCRIPTION
# Pull Request

## Description

`buildUserActivityPipeline` grouped by `date x counterName x userId x metadata`. Because the whole `metadata` object was part of the group key, events that differed only in metadata never collapsed, so the pipeline emitted roughly one output row per raw event.

Before server-side pagination the client merged rows per `date-counterName-userEmail`; now server rows render verbatim, so 50 `Session Created` events by one user on one day rendered as 50 rows of `count: 1` instead of 1 row of `count: 50`, and `total` counted fragments rather than activity rows.

This drops `metadata` out of the group key and splits only on an explicit allowlist of metadata keys that are real dimensions, restoring one row per activity. It is also the main lever on the aggregation cost tracked in #1308.

Fixes #1307

## Changes

- `apps/client/server/analytics/userActivityQuery.ts`
  - New exported `SPLIT_METADATA_KEYS = ['reportId']`. The `$group` `_id` is now `{ date, counterName, userId, metadataKey }`, where `metadataKey` is built only from that allowlist, each value wrapped in `$ifNull: [..., null]` so a missing key does not group apart from an explicit null.
  - `metadata: { $first: '$metadata' }` returns a representative sample for the grid.
  - Sort tiebreak `_id.metadata` -> `_id.metadataKey`; it still covers the whole group key, so paging stays stable and disjoint.
  - Metadata *filtering* is unchanged and still runs in the leading `$match`, before `$group`.
  - `userOrganization` now comes from `{ $first: '$userOrganization' }` on the counter log instead of `$user.organization`. The User document has no `organization` field at all, so the old projection was `undefined` on every row. The counter log denormalises the org name at write time and it is the same field the org filters already `$match` on, so this needs no extra join. `organization: 1` also dropped from the user `$lookup` projection.
  - Interim-state note removed from the module docstring; the ROW UNIT paragraph now describes the real unit.
- New `apps/client/server/analytics/userActivityQuery.rowUnit.e2e.test.ts` (real Mongo via `createMongoServer`) — acceptance test comparing the pipeline against a restatement of the pre-pagination client's merge over the same raw events, on row count, per-row `count`, and `totalValue`. Also covers the fragment measurement, the `reportId` split, org passthrough, the metadata sample, filtering on a key that is no longer in the group key, and disjoint paging.
- `userActivityQuery.test.ts`: 4 new unit tests (metadata out of the key, `$ifNull` normalisation, `$first` sample, org read off the log rather than the join).
- `pages/api/users/__tests__/counterLogs.test.ts`: `$lookup` projection assertion no longer expects `organization`; stale comments updated.

### Measured effect

On a fixture of 81 raw events across 2 users / 4 counters with realistic per-event metadata:

| | rows |
|---|---|
| old group key | 81 |
| new group key | 5 |

Per-row counts: 40 / 25 / 10 / 4 / 2. The "before" number is computed from the same fixture inside the test (`countFragments()`), so the pair is matched rather than asserted from memory.

### On which metadata keys split

Only `reportId` splits today. That exactly reproduces the pre-pagination client's key, which is what the acceptance test requires; adding `source` or a model name would split rows the old client merged and would fail that test. The allowlist is a single named constant so it can be widened in a one-line change once product decides which dimensions are worth splitting on. **That product decision is still open** — this PR parks it behind a clean seam rather than resolving it.

One knowing divergence from the old client: it appended `reportId` to the key only when `counterName` matched `/report/i`. Here `reportId` always splits. No non-report counter in this repo emits `metadata.reportId`, so this is a no-op in practice and avoids a name-sniffing special case inside the pipeline.

## Guide for Testers

1. Go to `app.staging.bike4mind.com` and sign in as an admin.
2. Navigate: Sidebar -> Admin -> Analytics -> User Activity.
3. Set the date range to a single day that has known activity (e.g. today).
4. Expected: each row is one `date + counter + user` combination. A user who created 50 sessions that day appears as ONE `Session Created` row with `Count` = 50, not 50 rows of 1.
5. Check the total/row-count readout above the grid. Expected: it reflects the number of activity rows, and matches the number of rows you can page through.
6. Sort by each column header in turn (Date, Counter, User, Count). Expected: sorting works and no row appears twice or goes missing between pages.
7. Page forward through every page of results, then back. Expected: no duplicated and no skipped rows; the row set is disjoint across pages.
8. Apply a metadata filter (e.g. filter on a `source` value) and re-run. Expected: only matching events are counted, and the surviving rows still show merged counts. Filtering still narrows correctly even for metadata keys that no longer split rows.
9. Look at the `Organization` column. Expected: it shows the organization name for users who have one, instead of being blank on every row (this column was previously always empty).
10. Trigger a report-related counter (any action that records `metadata.reportId`) twice with two different reports on the same day as the same user. Expected: two separate rows, one per report -- report rows still split.

### Regression Checks

- Metadata filters (all supported keys) still narrow results as before.
- Date-range filtering, user filtering, and organization filtering unchanged.
- CSV/export of the grid (if used) contains the same merged rows shown in the UI.
- Other Analytics tabs are untouched and render as before.

### What NOT to test

- No UI layout, styling, or component changes; the grid itself is unchanged.
- No schema or migration changes -- nothing to verify in the database.

## Additional Information

Measurement was done in-test against a real in-memory Mongo, not against production; there is no production `explain()`/timing number in this PR. The expected #1308 cost win follows from the row-count reduction (far fewer `$group` output documents and a smaller result set to sort and page) but has not been measured on production data.

Verification run locally: `pnpm turbo:typecheck` clean, `pnpm lint:check` clean, prettier clean, and 153 targeted tests across `server/analytics`, `pages/api/users/__tests__`, `app/components/admin/Analytics` and `useAnalyticsData` all pass. A full `pnpm turbo:test` showed 11 unrelated suites hitting 15s vitest timeouts under parallel load (api-keys e2e, user-api-keys e2e, artifactModels, QuestModel promptMeta); all re-run green in isolation and none touch analytics -- CPU oversubscription from `mongodb-memory-server` suites, not a regression from this change.

## Developer Notes (Optional)

- `SPLIT_METADATA_KEYS` is the extension point for "which metadata dimensions are worth a separate activity row". Adding a key there changes the group key and the sort tiebreak together, with no other edits.
- The `$ifNull` normalisation in the group key is the pattern to copy for any future metadata-derived grouping: without it, documents missing a key group separately from documents with an explicit `null`, which silently fragments rows again.
- `mergedLikeThePrePaginationClient()` in the new e2e test encodes the historical client-side merge semantics. It is the reference oracle for any future change to the group key.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) -- n/a, no UI changes
- [ ] I have made corresponding changes to the documentation (if applicable) -- n/a
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc -- n/a, no new telemetry fields
