### PR TITLE
fix(client): clear pending composer chips on Delete All Knowledge

### DIFF
--- a/apps/client/app/hooks/data/fabFiles.test.tsx
+++ b/apps/client/app/hooks/data/fabFiles.test.tsx
@@ -124,6 +124,27 @@ describe('useDeleteAllFiles', () => {
     expect(apiDelete).toHaveBeenCalledWith('/api/files');
     expect(useSessionLayout.getState().pendingMessageFiles).toEqual([]);
   });
+
+  // Deleting all files zeroes every tag's file count, so the tag browser's cached counts go
+  // stale the same way useDeleteFile/useBulkDeleteFiles already guard against.
+  it('invalidates file-tags so per-tag counts do not go stale', async () => {
+    apiDelete.mockResolvedValue({});
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    Wrapper.displayName = 'TestQueryClientWrapper';
+
+    const { result } = renderHook(() => useDeleteAllFiles(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    const keys = invalidate.mock.calls.map(call => JSON.stringify((call[0] as { queryKey: unknown[] })?.queryKey));
+    expect(keys).toContain(JSON.stringify(['file-tags']));
+  });
 });
 
 describe('useUpdateFabFile', () => {

--- a/apps/client/app/hooks/data/fabFiles.test.tsx
+++ b/apps/client/app/hooks/data/fabFiles.test.tsx
@@ -2,13 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
-import { useGetFabFilesBySessionId, useGetFabFilesByQuestId, useUpdateFabFile } from './fabFiles';
+import type { IFabFileDocument } from '@bike4mind/common';
+import { useDeleteAllFiles, useGetFabFilesBySessionId, useGetFabFilesByQuestId, useUpdateFabFile } from './fabFiles';
+import useSessionLayout, { setPendingMessageFiles } from '@client/app/hooks/useSessionLayout';
 
-// Mock the axios-backed api context - we only care that the GET is (or isn't) fired.
+// Mock the axios-backed api context - we only care that the GET/DELETE is (or isn't) fired.
 const apiGet = vi.fn();
+const apiDelete = vi.fn();
 vi.mock('@client/app/contexts/ApiContext', () => ({
   api: {
     get: (...args: unknown[]) => apiGet(...args),
+    delete: (...args: unknown[]) => apiDelete(...args),
   },
 }));
 
@@ -87,6 +91,38 @@ describe('useGetFabFilesByQuestId', () => {
   it('respects the caller-supplied enabled=false', () => {
     renderQuest('507f1f77bcf86cd799439012', false);
     expect(apiGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDeleteAllFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPendingMessageFiles([]);
+  });
+
+  // Regression (#1279): pendingMessageFiles is a Zustand snapshot, not backed by the
+  // fabFiles query cache, so the ['fabFiles'] invalidation this mutation already does never
+  // reaches it - a composer chip attached-but-not-sent this session kept pointing at a
+  // deleted FabFile after "Delete All Knowledge".
+  it('clears pendingMessageFiles so stale composer chips do not survive the bulk delete', async () => {
+    apiDelete.mockResolvedValue({});
+    setPendingMessageFiles([
+      {
+        fabFile: { id: 'file-1', fileName: 'notes.txt', mimeType: 'text/plain' } as IFabFileDocument,
+        uploadProgress: 100,
+        status: 'complete',
+        scope: 'notebook',
+        uploadSessionId: 'session-1',
+      },
+    ]);
+
+    const { result } = renderHook(() => useDeleteAllFiles(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(apiDelete).toHaveBeenCalledWith('/api/files');
+    expect(useSessionLayout.getState().pendingMessageFiles).toEqual([]);
   });
 });
 

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -37,6 +37,9 @@ export function useDeleteAllFiles(options: { onSuccess?: () => void } = {}) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
+      // Deleting all files zeroes every tag's file count - invalidate so the tag browser
+      // doesn't keep showing stale counts (matches useDeleteFile/useBulkDeleteFiles below).
+      queryClient.invalidateQueries({ queryKey: ['file-tags'] });
       // The composer's pending-attachment chips are a denormalized Zustand snapshot, not
       // backed by the fabFiles query cache, so invalidation above doesn't reach them - clear
       // them explicitly or they keep rendering chips for now-deleted files (see #1279).

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -8,6 +8,7 @@ import {
   type IFabFileDocument,
 } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
+import { setPendingMessageFiles } from '@client/app/hooks/useSessionLayout';
 import {
   chunkFileUtility,
   createFabFileOnServer,
@@ -36,6 +37,10 @@ export function useDeleteAllFiles(options: { onSuccess?: () => void } = {}) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['fabFiles'] });
+      // The composer's pending-attachment chips are a denormalized Zustand snapshot, not
+      // backed by the fabFiles query cache, so invalidation above doesn't reach them - clear
+      // them explicitly or they keep rendering chips for now-deleted files (see #1279).
+      setPendingMessageFiles([]);
       if (onSuccess) onSuccess();
     },
     onError: error => {


### PR DESCRIPTION
## Description
After using **Settings > General > Knowledge Files > (kebab menu) > Delete All Knowledge**, any file that was attached to the composer but not yet sent in a message kept showing its chip, now pointing at a deleted file. The Files Manager and Profile Collection correctly showed 0 files immediately; only the composer was stale until the next session switch.

The composer's pending-attachment list is held in a Zustand store, separate from the React Query cache that backs the rest of the file lists. The bulk-delete mutation invalidated the query cache but never cleared that store, so it kept rendering chips for files that no longer existed.

## Changes
- `useDeleteAllFiles`'s `onSuccess` now also clears the composer's pending-attachment state, so stale chips disappear immediately after a bulk delete.
- Added a regression test covering that the mutation clears pending composer attachments.

## Guide for Testers
1. Open a notebook/session and attach a file to the composer (upload it, but do not send the message).
2. Go to **Settings → General → Knowledge Files**, open the kebab menu, and choose **Delete All Knowledge**. Confirm the deletion.

   <img width="1155" height="374" alt="image" src="https://github.com/user-attachments/assets/e76331aa-8142-4d84-b339-b4a9b7057aaa" />

3. Return to the composer. Expected: the attachment chip is gone immediately — no stale chip pointing at a deleted file.
4. Check the Files Manager and Profile Collection. Expected: both show 0 files, as before.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
