### PR TITLE
fix(client): honor the memory opt-out on the agent-executor surface (#1337)

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -135,6 +135,7 @@ import { emitMetric } from '@server/utils/cloudwatch';
 import { persistRunAsQuest } from '@server/utils/persistRunAsQuest';
 import { extractFinalAnswer } from '@server/utils/extractFinalAnswer';
 import { publishMementoCompletion } from '@server/utils/publishMementoCompletion';
+import { resolveExecutionMementoGates } from '@server/utils/resolveExecutionMementoGates';
 import { getFirstIterationMementosPreamble } from '@server/utils/getFirstIterationMementosPreamble';
 import { getFirstIterationSkillsPreamble } from '@server/utils/getFirstIterationSkillsPreamble';
 import { getMcpClientAdapter } from '@server/utils/getMcpClientAdapter';
@@ -1879,11 +1880,15 @@ async function processExecution(
       // single materialized string that gets persisted into the checkpoint.
       // Continuation Lambdas, gate-resumes, and DAG-resumes inherit it via
       // the checkpoint replay - same handoff contract as the file preamble.
-      // The helper itself guards on `enableMementos` + `parentExecutionId`,
+      // The helper guards on `parentExecutionId` and the resolved `MementoGates`,
       // matching `publishMementoCompletion` on the write side.
       if (firstIterationQuery !== undefined) {
+        const mementoGates = await resolveExecutionMementoGates(execution, {
+          db: { adminSettings: adminSettingsRepository },
+        });
         const { preamble: mementoPreamble, mementoIds } = await getFirstIterationMementosPreamble(
           execution,
+          mementoGates,
           {
             db: {
               mementos: mementoRepository,
@@ -2293,13 +2298,16 @@ async function processExecution(
       allSideEffects
     );
 
-    // Memento parity with chat_completion. Fires only when the user
-    // (or admin default) opted into mementos for this run; skipped for
-    // subagent / DAG children via the `parentExecutionId` guard inside the
-    // helper. Reads `execution` (loaded at the top of this function) so
-    // continuation Lambdas see the persisted flag the WS handler stamped at
-    // dispatch.
-    await publishMementoCompletion(execution, logger);
+    // Memento parity with chat_completion. Resolve the same gates the read side
+    // resolves (one authority, `resolveExecutionMementoGates`) and hand them to the
+    // publisher; it fires only when a gate is live and skips subagent / DAG children
+    // via the `parentExecutionId` guard inside the helper. Reads `execution` (loaded
+    // at the top of this function) so continuation Lambdas see the persisted tri-state
+    // flag the WS handler stamped at dispatch.
+    const mementoGates = await resolveExecutionMementoGates(execution, {
+      db: { adminSettings: adminSettingsRepository },
+    });
+    await publishMementoCompletion(execution, mementoGates, logger);
 
     logger.info('[Complete] Agent execution finished', {
       iterations: finalCheckpoint.iteration,

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -134,9 +134,8 @@ import { getFilesStorage, getGeneratedImageStorage } from '@server/utils/storage
 import { emitMetric } from '@server/utils/cloudwatch';
 import { persistRunAsQuest } from '@server/utils/persistRunAsQuest';
 import { extractFinalAnswer } from '@server/utils/extractFinalAnswer';
-import { publishMementoCompletion } from '@server/utils/publishMementoCompletion';
-import { resolveExecutionMementoGates } from '@server/utils/resolveExecutionMementoGates';
-import { getFirstIterationMementosPreamble } from '@server/utils/getFirstIterationMementosPreamble';
+import { resolveAndPublishMementoCompletion } from '@server/utils/publishMementoCompletion';
+import { resolveAndBuildMementosPreamble } from '@server/utils/getFirstIterationMementosPreamble';
 import { getFirstIterationSkillsPreamble } from '@server/utils/getFirstIterationSkillsPreamble';
 import { getMcpClientAdapter } from '@server/utils/getMcpClientAdapter';
 import { loadAgentMcpTools, type AgentMcpTools } from '@server/utils/loadAgentMcpTools';
@@ -1883,12 +1882,8 @@ async function processExecution(
       // The helper guards on `parentExecutionId` and the resolved `MementoGates`,
       // matching `publishMementoCompletion` on the write side.
       if (firstIterationQuery !== undefined) {
-        const mementoGates = await resolveExecutionMementoGates(execution, {
-          db: { adminSettings: adminSettingsRepository },
-        });
-        const { preamble: mementoPreamble, mementoIds } = await getFirstIterationMementosPreamble(
+        const { preamble: mementoPreamble, mementoIds } = await resolveAndBuildMementosPreamble(
           execution,
-          mementoGates,
           {
             db: {
               mementos: mementoRepository,
@@ -2301,13 +2296,10 @@ async function processExecution(
     // Memento parity with chat_completion. Resolve the same gates the read side
     // resolves (one authority, `resolveExecutionMementoGates`) and hand them to the
     // publisher; it fires only when a gate is live and skips subagent / DAG children
-    // via the `parentExecutionId` guard inside the helper. Reads `execution` (loaded
+    // via the `parentExecutionId`/`spawnedByExecutionId` guard inside the helper. Reads `execution` (loaded
     // at the top of this function) so continuation Lambdas see the persisted tri-state
     // flag the WS handler stamped at dispatch.
-    const mementoGates = await resolveExecutionMementoGates(execution, {
-      db: { adminSettings: adminSettingsRepository },
-    });
-    await publishMementoCompletion(execution, mementoGates, logger);
+    await resolveAndPublishMementoCompletion(execution, { db: { adminSettings: adminSettingsRepository } }, logger);
 
     logger.info('[Complete] Agent execution finished', {
       iterations: finalCheckpoint.iteration,

--- a/apps/client/server/utils/getFirstIterationMementosPreamble.test.ts
+++ b/apps/client/server/utils/getFirstIterationMementosPreamble.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Logger } from '@bike4mind/observability';
+import type { MementoGates } from '@bike4mind/services';
 import {
   getFirstIterationMementosPreamble,
   type MementoRetrievalAdapters,
@@ -15,7 +16,6 @@ vi.mock('@bike4mind/services', () => ({
   },
 }));
 
-/** V2 returns null for a user who is not on V2 - which is what hands control to the V1 path. */
 const recallMementosV2Mock =
   vi.fn<(...args: unknown[]) => Promise<Array<{ fact: string; relevance: number }> | null>>();
 
@@ -27,9 +27,15 @@ const makeExecution = (overrides: Partial<MementoRetrievalExecution> = {}): Meme
   id: 'exec-1',
   userId: 'user-1',
   query: 'what hobbies do I have',
-  enableMementos: true,
   ...overrides,
 });
+
+/** V1-only user: request flag `true` + admin on, no V2 opt-in. */
+const V1_ONLY: MementoGates = { v1: true, v2: false };
+/** V2-only user: request flag `undefined`, V2 opted in. */
+const V2_ONLY: MementoGates = { v1: false, v2: true };
+/** Explicit per-request opt-out from a V2-opted user (#1337): both pipelines off. */
+const OPTED_OUT: MementoGates = { v1: false, v2: false };
 
 const makeAdapters = (): MementoRetrievalAdapters => ({
   db: {
@@ -54,21 +60,26 @@ describe('getFirstIterationMementosPreamble', () => {
     getRelevantMementosMock.mockReset();
     getRelevantMementosMock.mockResolvedValue([]);
     recallMementosV2Mock.mockReset();
-    recallMementosV2Mock.mockResolvedValue(null); // default: user is NOT on V2, so V1 handles it
+    recallMementosV2Mock.mockResolvedValue([]);
   });
 
-  it('returns a formatted preamble and mementoIds on the happy path', async () => {
+  it('returns a formatted preamble and mementoIds on the happy path (V1)', async () => {
     getRelevantMementosMock.mockResolvedValueOnce([
       { memento: { id: 'm1', summary: 'User enjoys playing chess on Saturdays' }, similarity: 0.92 },
       { memento: { id: 'm2', summary: 'User prefers TypeScript over JavaScript' }, similarity: 0.81 },
     ]);
     const logger = makeLogger();
 
-    const { preamble, mementoIds } = await getFirstIterationMementosPreamble(makeExecution(), makeAdapters(), logger);
+    const { preamble, mementoIds } = await getFirstIterationMementosPreamble(
+      makeExecution(),
+      V1_ONLY,
+      makeAdapters(),
+      logger
+    );
 
     expect(getRelevantMementosMock).toHaveBeenCalledTimes(1);
     // The V1 path matches MementoFeature's chat-path params (topK 10, minSimilarity 0.75) so agent-mode
-    // and chat-mode pull the same set. This is the flag-OFF path, held byte-for-byte to main.
+    // and chat-mode pull the same set.
     const [userId, prompt, options] = getRelevantMementosMock.mock.calls[0] as unknown as [
       string,
       string,
@@ -92,51 +103,46 @@ describe('getFirstIterationMementosPreamble', () => {
     });
   });
 
-  it('returns empty preamble and empty mementoIds when enableMementos is false and the user is not on V2', async () => {
+  it('reads NEITHER pipeline when both gates are off - the per-request opt-out (#1337)', async () => {
+    // A V2-opted user who sent `enableMementos: false` resolves to { v1: false, v2: false }. Before
+    // #1337 the agent read side ran V2 recall unconditionally, injecting beliefs the user opted out of.
     const { preamble, mementoIds } = await getFirstIterationMementosPreamble(
-      makeExecution({ enableMementos: false }),
+      makeExecution(),
+      OPTED_OUT,
       makeAdapters(),
       makeLogger()
     );
 
     expect(preamble).toBe('');
     expect(mementoIds).toEqual([]);
-    expect(getRelevantMementosMock).not.toHaveBeenCalled();
-  });
-
-  it('returns empty preamble and empty mementoIds when enableMementos is undefined', async () => {
-    const logger = makeLogger();
-
-    const { preamble, mementoIds } = await getFirstIterationMementosPreamble(
-      makeExecution({ enableMementos: undefined }),
-      makeAdapters(),
-      logger
-    );
-
-    expect(preamble).toBe('');
-    expect(mementoIds).toEqual([]);
+    expect(recallMementosV2Mock).not.toHaveBeenCalled();
     expect(getRelevantMementosMock).not.toHaveBeenCalled();
   });
 
   it('returns empty preamble and empty mementoIds when parentExecutionId is set (subagent / DAG child)', async () => {
-    const logger = makeLogger();
-
     const { preamble, mementoIds } = await getFirstIterationMementosPreamble(
       makeExecution({ parentExecutionId: 'parent-exec-99' }),
+      V1_ONLY,
       makeAdapters(),
-      logger
+      makeLogger()
     );
 
     expect(preamble).toBe('');
     expect(mementoIds).toEqual([]);
+    expect(recallMementosV2Mock).not.toHaveBeenCalled();
     expect(getRelevantMementosMock).not.toHaveBeenCalled();
   });
 
-  it('returns empty preamble and empty mementoIds when no mementos clear the similarity threshold', async () => {
+  it('returns empty preamble and empty mementoIds when no V1 mementos clear the similarity threshold', async () => {
     getRelevantMementosMock.mockResolvedValueOnce([]);
     const logger = makeLogger();
 
-    const { preamble, mementoIds } = await getFirstIterationMementosPreamble(makeExecution(), makeAdapters(), logger);
+    const { preamble, mementoIds } = await getFirstIterationMementosPreamble(
+      makeExecution(),
+      V1_ONLY,
+      makeAdapters(),
+      logger
+    );
 
     expect(preamble).toBe('');
     expect(mementoIds).toEqual([]);
@@ -149,7 +155,12 @@ describe('getFirstIterationMementosPreamble', () => {
     getRelevantMementosMock.mockRejectedValueOnce(new Error('embedding API down'));
     const logger = makeLogger();
 
-    const { preamble, mementoIds } = await getFirstIterationMementosPreamble(makeExecution(), makeAdapters(), logger);
+    const { preamble, mementoIds } = await getFirstIterationMementosPreamble(
+      makeExecution(),
+      V1_ONLY,
+      makeAdapters(),
+      logger
+    );
 
     expect(preamble).toBe('');
     expect(mementoIds).toEqual([]);
@@ -163,9 +174,13 @@ describe('getFirstIterationMementosPreamble', () => {
     getRelevantMementosMock.mockResolvedValueOnce([
       { memento: { id: 'm1', summary: 'User likes\nchess\rand tennis' }, similarity: 0.9 },
     ]);
-    const logger = makeLogger();
 
-    const { preamble } = await getFirstIterationMementosPreamble(makeExecution(), makeAdapters(), logger);
+    const { preamble } = await getFirstIterationMementosPreamble(
+      makeExecution(),
+      V1_ONLY,
+      makeAdapters(),
+      makeLogger()
+    );
 
     expect(preamble).toContain('User likes chess and tennis');
     expect(preamble).not.toContain('User likes\nchess');
@@ -177,10 +192,13 @@ describe('getFirstIterationMementosPreamble', () => {
 
     const { preamble, mementoIds } = await getFirstIterationMementosPreamble(
       makeExecution(),
+      V2_ONLY,
       makeAdapters(),
       makeLogger()
     );
 
+    // The resolved opt-in is handed to recall so it does not re-look-it-up.
+    expect(recallMementosV2Mock).toHaveBeenCalledWith('user-1', 'what hobbies do I have', { enabled: true });
     expect(preamble).toContain('User is a marine biologist');
     expect(preamble).not.toContain('% relevant'); // framed as knowledge, not a scored list
     // V2 beliefs are not V1 mementos and carry no memento id to track.
@@ -189,13 +207,13 @@ describe('getFirstIterationMementosPreamble', () => {
   });
 
   it('gives a V2 user their memory in agent mode even with V1 switched OFF', async () => {
-    // The regression this exists for: agent mode gated retrieval on `enableMementos` alone, so a user
-    // who had moved to V2 ran completely un-personalized in agent mode while chat knew them fine. That
-    // is also the precondition for ever deleting V1 - agent mode cannot depend on the V1 flag.
+    // A V2-only user sends `enableMementos: undefined`, which resolves to { v1: false, v2: true } - V2
+    // still reads even though V1 is off. (This is distinct from the explicit `false` opt-out above.)
     recallMementosV2Mock.mockResolvedValueOnce([{ fact: 'User keeps a lathe in the woodshop', relevance: 0.63 }]);
 
     const { preamble } = await getFirstIterationMementosPreamble(
-      makeExecution({ enableMementos: false }),
+      makeExecution(),
+      V2_ONLY,
       makeAdapters(),
       makeLogger()
     );
@@ -209,6 +227,7 @@ describe('getFirstIterationMementosPreamble', () => {
 
     const { preamble, mementoIds } = await getFirstIterationMementosPreamble(
       makeExecution(),
+      V2_ONLY,
       makeAdapters(),
       makeLogger()
     );

--- a/apps/client/server/utils/getFirstIterationMementosPreamble.test.ts
+++ b/apps/client/server/utils/getFirstIterationMementosPreamble.test.ts
@@ -133,6 +133,23 @@ describe('getFirstIterationMementosPreamble', () => {
     expect(getRelevantMementosMock).not.toHaveBeenCalled();
   });
 
+  it('returns empty preamble for a BACKGROUND subagent, which sets spawnedByExecutionId and NO parentExecutionId', async () => {
+    // Read-side half of the #1337 background-child leak. `V2_ONLY` on purpose: a background child of an
+    // opted-out parent resolves V2 back on (its own `enableMementos` is undefined), so the gates cannot
+    // be what stops it - only the lineage check can.
+    const { preamble, mementoIds } = await getFirstIterationMementosPreamble(
+      makeExecution({ spawnedByExecutionId: 'spawner-exec-42' }),
+      V2_ONLY,
+      makeAdapters(),
+      makeLogger()
+    );
+
+    expect(preamble).toBe('');
+    expect(mementoIds).toEqual([]);
+    expect(recallMementosV2Mock).not.toHaveBeenCalled();
+    expect(getRelevantMementosMock).not.toHaveBeenCalled();
+  });
+
   it('returns empty preamble and empty mementoIds when no V1 mementos clear the similarity threshold', async () => {
     getRelevantMementosMock.mockResolvedValueOnce([]);
     const logger = makeLogger();

--- a/apps/client/server/utils/getFirstIterationMementosPreamble.ts
+++ b/apps/client/server/utils/getFirstIterationMementosPreamble.ts
@@ -96,20 +96,22 @@ export async function getFirstIterationMementosPreamble(
     // user's memory must reach agent mode too, but only when the resolved V2 gate allows it - an
     // explicit per-request opt-out resolves `gates.v2` off, so V2 recall never runs (#1337). We hand
     // recallMementosV2 the already-resolved opt-in so it does not look it up again.
+    // V2 and V1 are mutually exclusive at inject time. We hand recallMementosV2 the already-resolved
+    // opt-in as `enabled: true`, so it always returns an array here - its only `null` is the
+    // `if (!enabled)` short-circuit, which this branch has already ruled out. A V2-gated turn therefore
+    // resolves here and never falls through to the V1 path below.
     if (gates.v2) {
-      const v2 = await recallMementosV2(execution.userId, execution.query, { enabled: true });
-      if (v2 !== null) {
-        if (v2.length === 0) {
-          logger.info('[Mementos V2] No relevant beliefs for first iteration', { executionId: execution.id });
-          return EMPTY_RESULT;
-        }
-        logger.info('[Mementos V2] Injected beliefs into first-iteration context', {
-          executionId: execution.id,
-          count: v2.length,
-        });
-        // V2 beliefs are not V1 mementos and have no memento id to track; `mementoIds` stays empty.
-        return { preamble: buildV2Preamble(v2.map(({ fact }) => fact)), mementoIds: [] };
+      const v2 = (await recallMementosV2(execution.userId, execution.query, { enabled: true }))!;
+      if (v2.length === 0) {
+        logger.info('[Mementos V2] No relevant beliefs for first iteration', { executionId: execution.id });
+        return EMPTY_RESULT;
       }
+      logger.info('[Mementos V2] Injected beliefs into first-iteration context', {
+        executionId: execution.id,
+        count: v2.length,
+      });
+      // V2 beliefs are not V1 mementos and have no memento id to track; `mementoIds` stays empty.
+      return { preamble: buildV2Preamble(v2.map(({ fact }) => fact)), mementoIds: [] };
     }
 
     if (!gates.v1) return EMPTY_RESULT;

--- a/apps/client/server/utils/getFirstIterationMementosPreamble.ts
+++ b/apps/client/server/utils/getFirstIterationMementosPreamble.ts
@@ -17,9 +17,13 @@
  * - neither gate is live -> no retrieval. V2 (`gates.v2`) is tried first and is mutually exclusive
  *   with V1 at inject time; V1 (`gates.v1`) already folds in the admin setting and the request flag.
  *   An explicit `enableMementos: false` resolves both gates off, so nothing is read.
- * - `parentExecutionId` set -> no retrieval. Subagent / DAG-child executions
- *   inherit the parent's materialized context via the existing handoff path
- *   and must not re-fetch (parity with the publish side).
+ * - `parentExecutionId` OR `spawnedByExecutionId` set -> no retrieval. Subagent / DAG-child
+ *   executions inherit the parent's materialized context via the existing handoff path and must not
+ *   re-fetch (parity with the publish side). Both fields must be checked: a BACKGROUND subagent is
+ *   created with `parentExecutionId` deliberately unset and `spawnedByExecutionId` set instead
+ *   (`agentExecutor.ts` child creation - it bills and counts independently), and `baseFields` never
+ *   copies the parent's `enableMementos`, so a child checked on `parentExecutionId` alone arrives
+ *   with `enableMementos: undefined` and resolves memory back ON despite the parent's opt-out.
  *
  * The caller (`processExecution` in `agentExecutor.ts`) gates on iteration 0
  * of a new execution - same gate as `maybeBuildFirstIterationQuery` - so
@@ -38,8 +42,12 @@ import { buildMemoryContext } from '@bike4mind/common';
 import { recallMementosV2 } from '@server/memory/recallMementosV2';
 import type { IApiKeyRepository, IMementoRepository, IAdminSettingsRepository } from '@bike4mind/common';
 import { mementoService, type MementoGates } from '@bike4mind/services';
+import { resolveExecutionMementoGates, type MementoGateExecution } from './resolveExecutionMementoGates';
 
-export type MementoRetrievalExecution = Pick<IAgentExecution, 'id' | 'userId' | 'query' | 'parentExecutionId'>;
+export type MementoRetrievalExecution = Pick<
+  IAgentExecution,
+  'id' | 'userId' | 'query' | 'parentExecutionId' | 'spawnedByExecutionId'
+>;
 
 export interface MementoRetrievalAdapters {
   db: {
@@ -89,7 +97,7 @@ export async function getFirstIterationMementosPreamble(
   adapters: MementoRetrievalAdapters,
   logger: Logger
 ): Promise<MementosPreambleResult> {
-  if (execution.parentExecutionId) return EMPTY_RESULT;
+  if (execution.parentExecutionId || execution.spawnedByExecutionId) return EMPTY_RESULT;
 
   try {
     // Mementos V2: the two pipelines are mutually exclusive, exactly as in chat (MementoFeature). A V2
@@ -100,6 +108,9 @@ export async function getFirstIterationMementosPreamble(
     // opt-in as `enabled: true`, so it always returns an array here - its only `null` is the
     // `if (!enabled)` short-circuit, which this branch has already ruled out. A V2-gated turn therefore
     // resolves here and never falls through to the V1 path below.
+    // MUST STAY IN SYNC with `recallMementosV2`: the `!` below is only sound while `if (!enabled)` is
+    // that function's ONLY `return null`. A new null-return there would surface here as a caught
+    // TypeError and memory would quietly stop injecting, so add a branch here if one is ever added.
     if (gates.v2) {
       const v2 = (await recallMementosV2(execution.userId, execution.query, { enabled: true }))!;
       if (v2.length === 0) {
@@ -154,4 +165,18 @@ export async function getFirstIterationMementosPreamble(
     });
     return EMPTY_RESULT;
   }
+}
+
+/**
+ * Resolve the memory policy and build the preamble, as ONE step - the read-side counterpart to
+ * `resolveAndPublishMementoCompletion`. The caller never holds a `MementoGates` value, so it cannot
+ * fabricate one; see that function's note for why that matters more than a wiring assertion (#1337).
+ */
+export async function resolveAndBuildMementosPreamble(
+  execution: MementoRetrievalExecution & MementoGateExecution,
+  adapters: MementoRetrievalAdapters,
+  logger: Logger
+): Promise<MementosPreambleResult> {
+  const gates = await resolveExecutionMementoGates(execution, adapters, logger);
+  return getFirstIterationMementosPreamble(execution, gates, adapters, logger);
 }

--- a/apps/client/server/utils/getFirstIterationMementosPreamble.ts
+++ b/apps/client/server/utils/getFirstIterationMementosPreamble.ts
@@ -9,11 +9,14 @@
  * write side was already populating it.
  *
  * This helper produces a preamble string the caller appends to the
- * first-iteration query. It mirrors the guards used by
- * `publishMementoCompletion`:
+ * first-iteration query. The caller resolves the memory policy once, via
+ * `resolveExecutionMementoGates`, and hands us the concrete `MementoGates` - the SAME resolver the
+ * write side (`publishMementoCompletion`) uses, so a per-request opt-out reads the same on both
+ * sides (#1337). It mirrors those guards:
  *
- * - the user is on NEITHER pipeline. V2 (if the user opted in) is tried first and is mutually
- *   exclusive with V1; V1 additionally requires `enableMementos` (user/admin).
+ * - neither gate is live -> no retrieval. V2 (`gates.v2`) is tried first and is mutually exclusive
+ *   with V1 at inject time; V1 (`gates.v1`) already folds in the admin setting and the request flag.
+ *   An explicit `enableMementos: false` resolves both gates off, so nothing is read.
  * - `parentExecutionId` set -> no retrieval. Subagent / DAG-child executions
  *   inherit the parent's materialized context via the existing handoff path
  *   and must not re-fetch (parity with the publish side).
@@ -34,12 +37,9 @@ import type { IAgentExecution } from '@bike4mind/database';
 import { buildMemoryContext } from '@bike4mind/common';
 import { recallMementosV2 } from '@server/memory/recallMementosV2';
 import type { IApiKeyRepository, IMementoRepository, IAdminSettingsRepository } from '@bike4mind/common';
-import { mementoService } from '@bike4mind/services';
+import { mementoService, type MementoGates } from '@bike4mind/services';
 
-export type MementoRetrievalExecution = Pick<
-  IAgentExecution,
-  'id' | 'userId' | 'query' | 'enableMementos' | 'parentExecutionId'
->;
+export type MementoRetrievalExecution = Pick<IAgentExecution, 'id' | 'userId' | 'query' | 'parentExecutionId'>;
 
 export interface MementoRetrievalAdapters {
   db: {
@@ -85,6 +85,7 @@ const buildV2Preamble = (facts: string[]): string => {
 
 export async function getFirstIterationMementosPreamble(
   execution: MementoRetrievalExecution,
+  gates: MementoGates,
   adapters: MementoRetrievalAdapters,
   logger: Logger
 ): Promise<MementosPreambleResult> {
@@ -92,25 +93,26 @@ export async function getFirstIterationMementosPreamble(
 
   try {
     // Mementos V2: the two pipelines are mutually exclusive, exactly as in chat (MementoFeature). A V2
-    // user's memory must reach agent mode too - gating this on `enableMementos` alone is what left a
-    // V2-only user running un-personalized in agent mode while chat knew them perfectly well.
-    //
-    // V2 returns null for a user who is NOT on V2, which is what falls through to the V1 path below.
-    const v2 = await recallMementosV2(execution.userId, execution.query);
-    if (v2 !== null) {
-      if (v2.length === 0) {
-        logger.info('[Mementos V2] No relevant beliefs for first iteration', { executionId: execution.id });
-        return EMPTY_RESULT;
+    // user's memory must reach agent mode too, but only when the resolved V2 gate allows it - an
+    // explicit per-request opt-out resolves `gates.v2` off, so V2 recall never runs (#1337). We hand
+    // recallMementosV2 the already-resolved opt-in so it does not look it up again.
+    if (gates.v2) {
+      const v2 = await recallMementosV2(execution.userId, execution.query, { enabled: true });
+      if (v2 !== null) {
+        if (v2.length === 0) {
+          logger.info('[Mementos V2] No relevant beliefs for first iteration', { executionId: execution.id });
+          return EMPTY_RESULT;
+        }
+        logger.info('[Mementos V2] Injected beliefs into first-iteration context', {
+          executionId: execution.id,
+          count: v2.length,
+        });
+        // V2 beliefs are not V1 mementos and have no memento id to track; `mementoIds` stays empty.
+        return { preamble: buildV2Preamble(v2.map(({ fact }) => fact)), mementoIds: [] };
       }
-      logger.info('[Mementos V2] Injected beliefs into first-iteration context', {
-        executionId: execution.id,
-        count: v2.length,
-      });
-      // V2 beliefs are not V1 mementos and have no memento id to track; `mementoIds` stays empty.
-      return { preamble: buildV2Preamble(v2.map(({ fact }) => fact)), mementoIds: [] };
     }
 
-    if (!execution.enableMementos) return EMPTY_RESULT;
+    if (!gates.v1) return EMPTY_RESULT;
 
     const relevantMementos = await mementoService.getRelevantMementos(
       execution.userId,

--- a/apps/client/server/utils/mementoGateWiring.test.ts
+++ b/apps/client/server/utils/mementoGateWiring.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Wiring tests for the two composed entry points the agent surface actually calls.
+ *
+ * These exist because the helpers being correct was never the weak link. Before the composition, each
+ * of the three call sites resolved gates itself and then passed the value on, and replacing that value
+ * with a hardcoded `{ v1: true, v2: true }` at ALL THREE sites left the entire suite green - the whole
+ * opt-out could be reverted with CI none the wiser. The composition removed the fabrication
+ * opportunity; these tests pin the composition itself (#1337).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const resolveExecutionMementoGatesMock = vi.fn();
+const publishMock = vi.fn();
+const recallMementosV2Mock = vi.fn();
+const getRelevantMementosMock = vi.fn();
+
+vi.mock('./resolveExecutionMementoGates', () => ({
+  resolveExecutionMementoGates: (...args: unknown[]) => resolveExecutionMementoGatesMock(...args),
+}));
+vi.mock('@server/utils/eventBus', () => ({
+  LLMEvents: { CompletionCompleted: { publish: (...args: unknown[]) => publishMock(...args) } },
+}));
+vi.mock('@server/memory/recallMementosV2', () => ({
+  recallMementosV2: (...args: unknown[]) => recallMementosV2Mock(...args),
+}));
+vi.mock('@bike4mind/services', () => ({
+  mementoService: { getRelevantMementos: (...args: unknown[]) => getRelevantMementosMock(...args) },
+}));
+
+const { resolveAndPublishMementoCompletion } = await import('./publishMementoCompletion');
+const { resolveAndBuildMementosPreamble } = await import('./getFirstIterationMementosPreamble');
+
+const makeLogger = () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), log: vi.fn(), debug: vi.fn() }) as never;
+
+const EXECUTION = {
+  id: 'exec-1',
+  userId: 'user-1',
+  sessionId: 'session-1',
+  questId: 'quest-1',
+  query: 'what is the weather',
+  model: 'gpt-5.4',
+  enableMementos: false as boolean | undefined,
+  parentExecutionId: undefined,
+  spawnedByExecutionId: undefined,
+};
+
+const ADAPTERS = {
+  db: {
+    mementos: {} as never,
+    apiKeys: {} as never,
+    adminSettings: { getSettingsValue: vi.fn() } as never,
+  },
+};
+
+describe('memento gate wiring (composed entry points, #1337)', () => {
+  beforeEach(() => {
+    resolveExecutionMementoGatesMock.mockReset();
+    publishMock.mockReset();
+    recallMementosV2Mock.mockReset();
+    getRelevantMementosMock.mockReset();
+  });
+
+  describe('resolveAndPublishMementoCompletion', () => {
+    it('publishes the gates the resolver returned - not a fabricated set', async () => {
+      // The resolver is the only source of truth. If the write path ever hardcodes gates again, the
+      // resolver's verdict stops reaching the payload and this fails.
+      resolveExecutionMementoGatesMock.mockResolvedValue({ v1: true, v2: false, v2OptInLookupFailed: false });
+
+      await resolveAndPublishMementoCompletion(EXECUTION, ADAPTERS, makeLogger());
+
+      expect(resolveExecutionMementoGatesMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith(
+        expect.objectContaining({ enableMementos: true, enableMementosV2: false })
+      );
+    });
+
+    it('an opt-out resolved by the resolver reaches the write path and suppresses the event entirely', async () => {
+      // The actual #1337 guarantee, end to end through the composition: resolver says both gates off,
+      // nothing is published. A call site that fabricated gates would publish here.
+      resolveExecutionMementoGatesMock.mockResolvedValue({ v1: false, v2: false, v2OptInLookupFailed: false });
+
+      await resolveAndPublishMementoCompletion(EXECUTION, ADAPTERS, makeLogger());
+
+      expect(resolveExecutionMementoGatesMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).not.toHaveBeenCalled();
+    });
+
+    it('forwards the resolver failure signal so a blip is not published as an opt-out', async () => {
+      resolveExecutionMementoGatesMock.mockResolvedValue({ v1: true, v2: false, v2OptInLookupFailed: true });
+
+      await resolveAndPublishMementoCompletion(EXECUTION, ADAPTERS, makeLogger());
+
+      const payload = publishMock.mock.calls[0][0];
+      expect('enableMementosV2' in payload).toBe(false);
+    });
+  });
+
+  describe('resolveAndBuildMementosPreamble', () => {
+    it('an opt-out resolved by the resolver suppresses BOTH recall pipelines', async () => {
+      resolveExecutionMementoGatesMock.mockResolvedValue({ v1: false, v2: false, v2OptInLookupFailed: false });
+
+      const { preamble, mementoIds } = await resolveAndBuildMementosPreamble(EXECUTION, ADAPTERS, makeLogger());
+
+      expect(resolveExecutionMementoGatesMock).toHaveBeenCalledTimes(1);
+      expect(preamble).toBe('');
+      expect(mementoIds).toEqual([]);
+      expect(recallMementosV2Mock).not.toHaveBeenCalled();
+      expect(getRelevantMementosMock).not.toHaveBeenCalled();
+    });
+
+    it('a V2 gate from the resolver reaches the V2 recall path', async () => {
+      // Positive control: proves the suppression above is the gate doing work, not the mocks being inert.
+      resolveExecutionMementoGatesMock.mockResolvedValue({ v1: false, v2: true, v2OptInLookupFailed: false });
+      recallMementosV2Mock.mockResolvedValue([{ fact: 'user prefers dark mode' }]);
+
+      const { preamble } = await resolveAndBuildMementosPreamble(EXECUTION, ADAPTERS, makeLogger());
+
+      expect(recallMementosV2Mock).toHaveBeenCalledTimes(1);
+      expect(preamble).toContain('dark mode');
+    });
+  });
+});

--- a/apps/client/server/utils/publishMementoCompletion.test.ts
+++ b/apps/client/server/utils/publishMementoCompletion.test.ts
@@ -94,6 +94,51 @@ describe('publishMementoCompletion', () => {
     expect(logger.info).not.toHaveBeenCalled();
   });
 
+  it('OMITS enableMementosV2 when the opt-in lookup failed, so the subscriber resolves it instead', async () => {
+    // A `v2: false` from a rejected lookup is "we could not tell", not "opted out". Asserting it would
+    // cost a V2 user a turn of learning over a Mongo blip; omitting the field lets the subscriber
+    // resolve the opt-in on its own, which is what this surface did before it published explicit
+    // booleans. V1 is on here because that is the only way the event exists at all in this case.
+    const logger = makeLogger();
+    await publishMementoCompletion(makeExecution(), { v1: true, v2: false, v2OptInLookupFailed: true }, logger);
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const payload = publishMock.mock.calls[0][0];
+    expect(payload).toMatchObject({ enableMementos: true });
+    expect('enableMementosV2' in payload).toBe(false);
+    expect(logger.info).toHaveBeenCalledWith('[Mementos] Published completion event', {
+      executionId: 'exec-1',
+      enableMementos: true,
+      enableMementosV2: 'deferred-to-subscriber (opt-in lookup failed)',
+    });
+  });
+
+  it('publishes an explicit enableMementosV2: false when the opt-in genuinely resolved off', async () => {
+    // The contrast case for the test above - a real resolved `false` MUST still be asserted, or the
+    // subscriber would re-resolve and could write for a user who is legitimately not opted in.
+    await publishMementoCompletion(makeExecution(), { v1: true, v2: false, v2OptInLookupFailed: false }, makeLogger());
+
+    expect(publishMock).toHaveBeenCalledWith(expect.objectContaining({ enableMementosV2: false }));
+  });
+
+  it('skips publish for a BACKGROUND subagent, which sets spawnedByExecutionId and NO parentExecutionId', async () => {
+    // The leak this closes (#1337): a background child is created with `parentExecutionId` deliberately
+    // unset (it bills and counts independently) and `spawnedByExecutionId` set, and `baseFields` never
+    // copies the parent's `enableMementos` - so the child arrives `undefined` and resolves V2 back ON
+    // for any opted-in user, writing beliefs from a turn the parent opted out of. Gates are BOTH on
+    // here on purpose: the guard must refuse a background child on its lineage alone, independently of
+    // how the gates resolved, or this test would pass for the wrong reason.
+    const logger = makeLogger();
+    await publishMementoCompletion(
+      makeExecution({ spawnedByExecutionId: 'spawner-exec-42' }),
+      { v1: true, v2: true },
+      logger
+    );
+
+    expect(publishMock).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
   it('swallows publish errors and warn-logs without throwing', async () => {
     const logger = makeLogger();
     publishMock.mockRejectedValueOnce(new Error('SNS down'));

--- a/apps/client/server/utils/publishMementoCompletion.test.ts
+++ b/apps/client/server/utils/publishMementoCompletion.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Logger } from '@bike4mind/observability';
+import type { MementoGates } from '@bike4mind/services';
 import { publishMementoCompletion, type MementoCompletionExecution } from './publishMementoCompletion';
 
 const publishMock = vi.fn<(payload: unknown) => Promise<void>>();
@@ -12,13 +13,6 @@ vi.mock('@server/utils/eventBus', () => ({
   },
 }));
 
-/** The V2 opt-in. Only consulted when V1 is off - V1 being on already means the event fires. */
-const isMementosV2EnabledMock = vi.fn<(userId: string) => Promise<boolean>>();
-
-vi.mock('@server/memory/mementoLedgerMirror', () => ({
-  isMementosV2Enabled: (userId: string) => isMementosV2EnabledMock(userId),
-}));
-
 const makeExecution = (overrides: Partial<MementoCompletionExecution> = {}): MementoCompletionExecution => ({
   id: 'exec-1',
   userId: 'user-1',
@@ -26,7 +20,6 @@ const makeExecution = (overrides: Partial<MementoCompletionExecution> = {}): Mem
   questId: 'quest-1',
   query: 'what is the weather',
   model: 'gpt-5.4',
-  enableMementos: true,
   ...overrides,
 });
 
@@ -43,13 +36,11 @@ describe('publishMementoCompletion', () => {
   beforeEach(() => {
     publishMock.mockReset();
     publishMock.mockResolvedValue(undefined);
-    isMementosV2EnabledMock.mockReset();
-    isMementosV2EnabledMock.mockResolvedValue(false); // default: user is not on V2
   });
 
-  it('publishes CompletionCompleted with the execution payload on the happy path', async () => {
+  it('publishes the resolved gates verbatim on the happy path (V1 on)', async () => {
     const logger = makeLogger();
-    await publishMementoCompletion(makeExecution(), logger);
+    await publishMementoCompletion(makeExecution(), { v1: true, v2: false }, logger);
 
     expect(publishMock).toHaveBeenCalledTimes(1);
     expect(publishMock).toHaveBeenCalledWith({
@@ -59,32 +50,21 @@ describe('publishMementoCompletion', () => {
       prompt: 'what is the weather',
       model: 'gpt-5.4',
       enableMementos: true,
+      enableMementosV2: false,
     });
     expect(logger.info).toHaveBeenCalledWith('[Mementos] Published completion event', {
       executionId: 'exec-1',
       enableMementos: true,
-      // V1 short-circuited the V2 lookup, so the log says 'deferred' rather than a true-because-V1 opt-in.
-      enableMementosV2: 'deferred-to-subscriber',
+      enableMementosV2: false,
     });
   });
 
-  it('V1 on: does not bother resolving the V2 opt-in - the event fires either way', async () => {
-    await publishMementoCompletion(makeExecution(), makeLogger());
-
-    expect(isMementosV2EnabledMock).not.toHaveBeenCalled();
-    // ...and it must NOT claim enableMementosV2, which would be true-because-V1-is-on, not because the
-    // user opted in. Absent tells the subscriber to resolve it properly.
-    expect(publishMock.mock.calls[0][0]).not.toHaveProperty('enableMementosV2');
-  });
-
   it('V1 OFF but V2 ON still publishes - V2 must keep LEARNING', async () => {
-    // The regression this exists for: `enableMementos` used to gate the event outright, so switching
-    // V1 off silently froze V2's memory. It went on answering from a snapshot it could never add to,
-    // which looks like everything working. V2 having its own write path is the precondition for ever
-    // deleting V1.
-    isMementosV2EnabledMock.mockResolvedValue(true);
-
-    await publishMementoCompletion(makeExecution({ enableMementos: false }), makeLogger());
+    // The regression this exists for: memory used to be gated on `enableMementos` outright, so
+    // switching V1 off silently froze V2's memory. It went on answering from a snapshot it could
+    // never add to, which looks like everything working. V2 having its own write gate is the
+    // precondition for ever deleting V1. Here V1 is off (undefined -> V2-only user), V2 opted in.
+    await publishMementoCompletion(makeExecution(), { v1: false, v2: true }, makeLogger());
 
     expect(publishMock).toHaveBeenCalledTimes(1);
     expect(publishMock).toHaveBeenCalledWith(
@@ -92,24 +72,23 @@ describe('publishMementoCompletion', () => {
     );
   });
 
-  it('skips publish when the user is on NEITHER pipeline', async () => {
+  it('skips publish when BOTH gates are off - the per-request opt-out (#1337)', async () => {
+    // `enableMementos: false` from a V2-opted user resolves to { v1: false, v2: false }. This is the
+    // whole point of #1337: the opt-out must stop the WRITE too, on the agent surface, not just chat.
     const logger = makeLogger();
-    await publishMementoCompletion(makeExecution({ enableMementos: false }), logger);
+    await publishMementoCompletion(makeExecution(), { v1: false, v2: false }, logger);
 
     expect(publishMock).not.toHaveBeenCalled();
     expect(logger.info).not.toHaveBeenCalled();
   });
 
-  it('skips publish when enableMementos is undefined and the user is not on V2', async () => {
-    const logger = makeLogger();
-    await publishMementoCompletion(makeExecution({ enableMementos: undefined }), logger);
-
-    expect(publishMock).not.toHaveBeenCalled();
-  });
-
   it('skips publish when parentExecutionId is set (subagent / DAG child)', async () => {
     const logger = makeLogger();
-    await publishMementoCompletion(makeExecution({ parentExecutionId: 'parent-exec-99' }), logger);
+    await publishMementoCompletion(
+      makeExecution({ parentExecutionId: 'parent-exec-99' }),
+      { v1: true, v2: true },
+      logger
+    );
 
     expect(publishMock).not.toHaveBeenCalled();
     expect(logger.info).not.toHaveBeenCalled();
@@ -119,12 +98,17 @@ describe('publishMementoCompletion', () => {
     const logger = makeLogger();
     publishMock.mockRejectedValueOnce(new Error('SNS down'));
 
-    await expect(publishMementoCompletion(makeExecution(), logger)).resolves.toBeUndefined();
+    await expect(
+      publishMementoCompletion(makeExecution(), { v1: true, v2: false } satisfies MementoGates, logger)
+    ).resolves.toBeUndefined();
 
     expect(publishMock).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
       '[Mementos] Failed to publish completion event — memento creation skipped',
-      { executionId: 'exec-1', error: 'SNS down' }
+      {
+        executionId: 'exec-1',
+        error: 'SNS down',
+      }
     );
     expect(logger.info).not.toHaveBeenCalled();
   });

--- a/apps/client/server/utils/publishMementoCompletion.ts
+++ b/apps/client/server/utils/publishMementoCompletion.ts
@@ -1,5 +1,5 @@
 /**
- * Memento parity helper for agent_executor.
+ * Memento parity helper for agent_executor (write side).
  *
  * The chat-completion flow fires `LLMEvents.CompletionCompleted` from
  * `chatCompletionDefaults.invokeCreateMemento` on the user-authored QuestStart;
@@ -11,12 +11,18 @@
  * the stop-at-gate branch (`handleGateResponse`) - emits the same event with
  * the same guards and the same log line.
  *
+ * The caller resolves the memory policy once, via `resolveExecutionMementoGates`, and hands us the
+ * concrete `MementoGates` - the SAME resolver the read side uses and the same shape the chat path
+ * resolves in ChatCompletionProcess. We publish those gates verbatim; we do not re-derive them, so no
+ * surface can disagree about what `enableMementos: false` means (#1337). The completion event carries
+ * explicit booleans (mirroring the chat path's `MementoFeature.onComplete`), so the subscriber writes
+ * exactly the pipelines the gates allow rather than defaulting anything on.
+ *
  * Skips when:
- * - The user is on NEITHER memory pipeline. V1 is gated by `enableMementos` on the execution
- *   doc (user/admin), V2 by the user's own `enableMementosV2` opt-in - and V2 has to be
- *   checked independently, or turning V1 off would silently stop V2 from LEARNING while it
- *   carried on answering from a frozen snapshot. That is the whole point of V2 having its own
- *   write path: V1 must be switchable off, and one day deletable.
+ * - Both gates are off - the user is on NEITHER pipeline for this turn (V1 off AND V2 off, whether by
+ *   an explicit opt-out, no opt-in, or the admin setting). V2 has its own write flag precisely so V1
+ *   can be switched off without freezing V2's learning; a resolved-off V2 gate is the one thing that
+ *   stops the write.
  * - The execution has a `parentExecutionId` (subagent / DAG child); only the
  *   top-level run emits a memento event so the user's prompt is what gets
  *   evaluated - not internal coordination prompts produced by subagent
@@ -30,23 +36,22 @@
 
 import type { Logger } from '@bike4mind/observability';
 import type { IAgentExecution } from '@bike4mind/database';
+import type { MementoGates } from '@bike4mind/services';
 import { LLMEvents } from '@server/utils/eventBus';
-import { isMementosV2Enabled } from '@server/memory/mementoLedgerMirror';
 
 export type MementoCompletionExecution = Pick<
   IAgentExecution,
-  'id' | 'userId' | 'sessionId' | 'questId' | 'query' | 'model' | 'enableMementos' | 'parentExecutionId'
+  'id' | 'userId' | 'sessionId' | 'questId' | 'query' | 'model' | 'parentExecutionId'
 >;
 
-export async function publishMementoCompletion(execution: MementoCompletionExecution, logger: Logger): Promise<void> {
+export async function publishMementoCompletion(
+  execution: MementoCompletionExecution,
+  gates: MementoGates,
+  logger: Logger
+): Promise<void> {
   if (execution.parentExecutionId) return;
 
-  const enableMementos = execution.enableMementos === true;
-  // Only pay for the opt-in lookup when V1 is off - if V1 is already capturing this turn the event
-  // fires regardless, and the subscriber resolves V2 for itself.
-  const enableMementosV2 = enableMementos || (await isMementosV2Enabled(execution.userId).catch(() => false));
-
-  if (!enableMementos && !enableMementosV2) return;
+  if (!gates.v1 && !gates.v2) return;
 
   try {
     await LLMEvents.CompletionCompleted.publish({
@@ -55,18 +60,14 @@ export async function publishMementoCompletion(execution: MementoCompletionExecu
       userId: execution.userId,
       prompt: execution.query,
       model: execution.model,
-      enableMementos,
-      // Deliberately NOT forwarded when V1 short-circuited the lookup above: the value would be a
-      // lie (`true` because V1 is on, not because the user opted in). Undefined tells the subscriber
-      // to resolve it properly.
-      ...(enableMementos ? {} : { enableMementosV2 }),
+      // Explicit resolved gates - the subscriber writes exactly these, no defaulting.
+      enableMementos: gates.v1,
+      enableMementosV2: gates.v2,
     });
     logger.info('[Mementos] Published completion event', {
       executionId: execution.id,
-      enableMementos,
-      // When V1 short-circuited the lookup, the V2 opt-in was NOT resolved here (the subscriber does it),
-      // so `enableMementosV2` would just be `true` because V1 is on - log 'deferred', not a false opt-in.
-      enableMementosV2: enableMementos ? 'deferred-to-subscriber' : enableMementosV2,
+      enableMementos: gates.v1,
+      enableMementosV2: gates.v2,
     });
   } catch (err) {
     logger.warn('[Mementos] Failed to publish completion event — memento creation skipped', {

--- a/apps/client/server/utils/publishMementoCompletion.ts
+++ b/apps/client/server/utils/publishMementoCompletion.ts
@@ -23,12 +23,16 @@
  *   an explicit opt-out, no opt-in, or the admin setting). V2 has its own write flag precisely so V1
  *   can be switched off without freezing V2's learning; a resolved-off V2 gate is the one thing that
  *   stops the write.
- * - The execution has a `parentExecutionId` (subagent / DAG child); only the
- *   top-level run emits a memento event so the user's prompt is what gets
+ * - The execution has a `parentExecutionId` OR a `spawnedByExecutionId` (subagent / DAG child); only
+ *   the top-level run emits a memento event so the user's prompt is what gets
  *   evaluated - not internal coordination prompts produced by subagent
  *   dispatch. The chat-completion flow only fires on the user-authored
  *   QuestStart; mirroring that intent here keeps memento creation 1:1 with
- *   user turns.
+ *   user turns. Both fields must be checked: a BACKGROUND subagent sets only
+ *   `spawnedByExecutionId` (`parentExecutionId` is deliberately left unset so it bills and counts
+ *   independently), and `baseFields` never copies the parent's `enableMementos` - so a child gated on
+ *   `parentExecutionId` alone arrives with `enableMementos: undefined`, resolves V2 back on for any
+ *   opted-in user, and writes beliefs distilled from a turn the user opted out of (#1337).
  *
  * Best-effort: a publish failure does not roll back the completion - the user
  * already saw `completed` on the wire. Errors log and swallow.
@@ -38,20 +42,35 @@ import type { Logger } from '@bike4mind/observability';
 import type { IAgentExecution } from '@bike4mind/database';
 import type { MementoGates } from '@bike4mind/services';
 import { LLMEvents } from '@server/utils/eventBus';
+import {
+  resolveExecutionMementoGates,
+  type MementoGateAdapters,
+  type MementoGateExecution,
+} from './resolveExecutionMementoGates';
 
 export type MementoCompletionExecution = Pick<
   IAgentExecution,
-  'id' | 'userId' | 'sessionId' | 'questId' | 'query' | 'model' | 'parentExecutionId'
+  'id' | 'userId' | 'sessionId' | 'questId' | 'query' | 'model' | 'parentExecutionId' | 'spawnedByExecutionId'
 >;
 
 export async function publishMementoCompletion(
   execution: MementoCompletionExecution,
-  gates: MementoGates,
+  // `v2OptInLookupFailed` is optional so a caller with plain resolved gates stays valid; absent means
+  // "not known to have failed", which is the safe reading - we only relax to the subscriber on a
+  // POSITIVE failure signal from `resolveExecutionMementoGates`.
+  gates: MementoGates & { v2OptInLookupFailed?: boolean },
   logger: Logger
 ): Promise<void> {
-  if (execution.parentExecutionId) return;
+  if (execution.parentExecutionId || execution.spawnedByExecutionId) return;
 
   if (!gates.v1 && !gates.v2) return;
+
+  // A `v2: false` produced by a FAILED opt-in lookup is not a real opt-out, so we must not assert it:
+  // publishing `enableMementosV2: false` would tell the subscriber the user is opted out and cost them a
+  // turn of V2 learning over a transient blip. Omitting the field instead hands the resolution back to
+  // the subscriber, which resolves the opt-in independently. Only reachable when V1 carries the event on
+  // its own - if both gates are off we returned above and there is no event to attach anything to.
+  const deferV2ToSubscriber = gates.v2OptInLookupFailed === true;
 
   try {
     await LLMEvents.CompletionCompleted.publish({
@@ -62,12 +81,12 @@ export async function publishMementoCompletion(
       model: execution.model,
       // Explicit resolved gates - the subscriber writes exactly these, no defaulting.
       enableMementos: gates.v1,
-      enableMementosV2: gates.v2,
+      ...(deferV2ToSubscriber ? {} : { enableMementosV2: gates.v2 }),
     });
     logger.info('[Mementos] Published completion event', {
       executionId: execution.id,
       enableMementos: gates.v1,
-      enableMementosV2: gates.v2,
+      enableMementosV2: deferV2ToSubscriber ? 'deferred-to-subscriber (opt-in lookup failed)' : gates.v2,
     });
   } catch (err) {
     logger.warn('[Mementos] Failed to publish completion event — memento creation skipped', {
@@ -75,4 +94,23 @@ export async function publishMementoCompletion(
       error: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+/**
+ * Resolve the memory policy and publish, as ONE step.
+ *
+ * Both terminal write paths (the executor's natural completion and the websocket stop-at-gate) call
+ * this rather than resolving gates themselves. That is deliberate: when the two steps were separate,
+ * every call site held a `MementoGates` value it could have fabricated, and nothing failed if it did -
+ * hardcoding `{ v1: true, v2: true }` at all three wiring points left the entire suite green, so the
+ * opt-out could be reverted invisibly. Composing them here removes the value from the call sites
+ * altogether, which is a stronger guarantee than a test asserting they passed the right one (#1337).
+ */
+export async function resolveAndPublishMementoCompletion(
+  execution: MementoCompletionExecution & MementoGateExecution,
+  adapters: MementoGateAdapters,
+  logger: Logger
+): Promise<void> {
+  const gates = await resolveExecutionMementoGates(execution, adapters, logger);
+  await publishMementoCompletion(execution, gates, logger);
 }

--- a/apps/client/server/utils/resolveExecutionMementoGates.test.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  resolveExecutionMementoGates,
+  type MementoGateAdapters,
+  type MementoGateExecution,
+} from './resolveExecutionMementoGates';
+
+const isMementosV2EnabledMock = vi.fn<(userId: string) => Promise<boolean>>();
+
+vi.mock('@server/memory/mementoLedgerMirror', () => ({
+  isMementosV2Enabled: (userId: string) => isMementosV2EnabledMock(userId),
+}));
+
+const getSettingsValueMock = vi.fn();
+
+const makeExecution = (overrides: Partial<MementoGateExecution> = {}): MementoGateExecution => ({
+  userId: 'user-1',
+  enableMementos: true,
+  ...overrides,
+});
+
+const makeAdapters = (): MementoGateAdapters => ({
+  db: { adminSettings: { getSettingsValue: getSettingsValueMock } as MementoGateAdapters['db']['adminSettings'] },
+});
+
+describe('resolveExecutionMementoGates (agent-surface authority, #1337)', () => {
+  beforeEach(() => {
+    isMementosV2EnabledMock.mockReset();
+    isMementosV2EnabledMock.mockResolvedValue(false);
+    getSettingsValueMock.mockReset();
+    getSettingsValueMock.mockResolvedValue(true); // admin EnableMementos on unless a test says otherwise
+  });
+
+  it('an explicit false opts out of BOTH pipelines even for an admin-on, V2-opted user', async () => {
+    // The bug this closes: `enableMementos: false` from a V2 user still distilled beliefs on the agent
+    // path. It must now resolve to no memory at all - the same meaning the flag has on chat.
+    isMementosV2EnabledMock.mockResolvedValue(true);
+    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: false }), makeAdapters());
+    expect(gates).toEqual({ v1: false, v2: false });
+  });
+
+  it('undefined lets V2 ride the account opt-in (V1 stays off)', async () => {
+    isMementosV2EnabledMock.mockResolvedValue(true);
+    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: undefined }), makeAdapters());
+    expect(gates).toEqual({ v1: false, v2: true });
+  });
+
+  it('undefined with no V2 opt-in yields no memory', async () => {
+    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: undefined }), makeAdapters());
+    expect(gates).toEqual({ v1: false, v2: false });
+  });
+
+  it('true enables V1 only when the admin setting also allows it', async () => {
+    getSettingsValueMock.mockResolvedValue(true);
+    expect(await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters())).toEqual({
+      v1: true,
+      v2: false,
+    });
+
+    getSettingsValueMock.mockResolvedValue(false);
+    expect(await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters())).toEqual({
+      v1: false,
+      v2: false,
+    });
+  });
+
+  it('reads the EnableMementos admin setting and defaults it to false when unset', async () => {
+    getSettingsValueMock.mockResolvedValue(undefined);
+    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters());
+
+    expect(getSettingsValueMock).toHaveBeenCalledWith('EnableMementos');
+    expect(gates.v1).toBe(false); // undefined admin -> V1 stays off
+  });
+
+  it('V2 never consults the admin setting - only the opt-in and the request flag', async () => {
+    getSettingsValueMock.mockResolvedValue(false); // admin V1 off
+    isMementosV2EnabledMock.mockResolvedValue(true);
+    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: undefined }), makeAdapters());
+    expect(gates).toEqual({ v1: false, v2: true });
+  });
+
+  it('fails closed to no-V2 when the opt-in lookup rejects', async () => {
+    isMementosV2EnabledMock.mockRejectedValue(new Error('mongo down'));
+    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: undefined }), makeAdapters());
+    expect(gates).toEqual({ v1: false, v2: false });
+  });
+});

--- a/apps/client/server/utils/resolveExecutionMementoGates.test.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.test.ts
@@ -19,6 +19,8 @@ const makeExecution = (overrides: Partial<MementoGateExecution> = {}): MementoGa
   ...overrides,
 });
 
+const makeLogger = () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), log: vi.fn(), debug: vi.fn() }) as never;
+
 const makeAdapters = (): MementoGateAdapters => ({
   db: { adminSettings: { getSettingsValue: getSettingsValueMock } as MementoGateAdapters['db']['adminSettings'] },
 });
@@ -35,38 +37,60 @@ describe('resolveExecutionMementoGates (agent-surface authority, #1337)', () => 
     // The bug this closes: `enableMementos: false` from a V2 user still distilled beliefs on the agent
     // path. It must now resolve to no memory at all - the same meaning the flag has on chat.
     isMementosV2EnabledMock.mockResolvedValue(true);
-    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: false }), makeAdapters());
-    expect(gates).toEqual({ v1: false, v2: false });
+    const gates = await resolveExecutionMementoGates(
+      makeExecution({ enableMementos: false }),
+      makeAdapters(),
+      makeLogger()
+    );
+    expect(gates).toEqual({ v1: false, v2: false, v2OptInLookupFailed: false });
   });
 
   it('undefined lets V2 ride the account opt-in (V1 stays off)', async () => {
     isMementosV2EnabledMock.mockResolvedValue(true);
-    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: undefined }), makeAdapters());
-    expect(gates).toEqual({ v1: false, v2: true });
+    const gates = await resolveExecutionMementoGates(
+      makeExecution({ enableMementos: undefined }),
+      makeAdapters(),
+      makeLogger()
+    );
+    expect(gates).toEqual({ v1: false, v2: true, v2OptInLookupFailed: false });
   });
 
   it('undefined with no V2 opt-in yields no memory', async () => {
-    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: undefined }), makeAdapters());
-    expect(gates).toEqual({ v1: false, v2: false });
+    const gates = await resolveExecutionMementoGates(
+      makeExecution({ enableMementos: undefined }),
+      makeAdapters(),
+      makeLogger()
+    );
+    expect(gates).toEqual({ v1: false, v2: false, v2OptInLookupFailed: false });
   });
 
   it('true enables V1 only when the admin setting also allows it', async () => {
     getSettingsValueMock.mockResolvedValue(true);
-    expect(await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters())).toEqual({
+    expect(
+      await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters(), makeLogger())
+    ).toEqual({
       v1: true,
       v2: false,
+      v2OptInLookupFailed: false,
     });
 
     getSettingsValueMock.mockResolvedValue(false);
-    expect(await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters())).toEqual({
+    expect(
+      await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters(), makeLogger())
+    ).toEqual({
       v1: false,
       v2: false,
+      v2OptInLookupFailed: false,
     });
   });
 
   it('reads the EnableMementos admin setting and defaults it to false when unset', async () => {
     getSettingsValueMock.mockResolvedValue(undefined);
-    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters());
+    const gates = await resolveExecutionMementoGates(
+      makeExecution({ enableMementos: true }),
+      makeAdapters(),
+      makeLogger()
+    );
 
     expect(getSettingsValueMock).toHaveBeenCalledWith('EnableMementos');
     expect(gates.v1).toBe(false); // undefined admin -> V1 stays off
@@ -75,27 +99,51 @@ describe('resolveExecutionMementoGates (agent-surface authority, #1337)', () => 
   it('V2 never consults the admin setting - only the opt-in and the request flag', async () => {
     getSettingsValueMock.mockResolvedValue(false); // admin V1 off
     isMementosV2EnabledMock.mockResolvedValue(true);
-    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: undefined }), makeAdapters());
-    expect(gates).toEqual({ v1: false, v2: true });
+    const gates = await resolveExecutionMementoGates(
+      makeExecution({ enableMementos: undefined }),
+      makeAdapters(),
+      makeLogger()
+    );
+    expect(gates).toEqual({ v1: false, v2: true, v2OptInLookupFailed: false });
   });
 
-  it('fails closed to no-V2 when the opt-in lookup rejects', async () => {
+  it('fails closed to no-V2 when the opt-in lookup rejects, and FLAGS it as a failure not an opt-out', async () => {
+    // The gate value alone is ambiguous: `v2: false` here means "we could not tell", not "opted out".
+    // The write side needs that distinction to avoid asserting a permanent opt-out to the subscriber.
     isMementosV2EnabledMock.mockRejectedValue(new Error('mongo down'));
-    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: undefined }), makeAdapters());
-    expect(gates).toEqual({ v1: false, v2: false });
+    const logger = makeLogger();
+    const gates = await resolveExecutionMementoGates(
+      makeExecution({ enableMementos: undefined }),
+      makeAdapters(),
+      logger
+    );
+    expect(gates).toEqual({ v1: false, v2: false, v2OptInLookupFailed: true });
+    expect((logger as unknown as { warn: ReturnType<typeof vi.fn> }).warn).toHaveBeenCalledWith(
+      '[Mementos] V2 opt-in lookup failed; failing closed to V2 off for this turn',
+      expect.objectContaining({ userId: 'user-1', error: 'mongo down' })
+    );
   });
 
   it('fails closed to no-V1 when the admin-setting lookup rejects (never fails the turn)', async () => {
     // getSettingsValue is an uncached findOne and can reject; a rejection here must degrade to no
     // memory, not escape and fail an agent run that has otherwise completed.
     getSettingsValueMock.mockRejectedValue(new Error('mongo down'));
-    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters());
-    expect(gates).toEqual({ v1: false, v2: false });
+    const logger = makeLogger();
+    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters(), logger);
+    expect(gates).toEqual({ v1: false, v2: false, v2OptInLookupFailed: false });
+    expect((logger as unknown as { warn: ReturnType<typeof vi.fn> }).warn).toHaveBeenCalledWith(
+      '[Mementos] EnableMementos admin-setting lookup failed; failing closed to V1 off',
+      expect.objectContaining({ userId: 'user-1', error: 'mongo down' })
+    );
   });
 
   it('short-circuits both lookups on an explicit opt-out', async () => {
-    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: false }), makeAdapters());
-    expect(gates).toEqual({ v1: false, v2: false });
+    const gates = await resolveExecutionMementoGates(
+      makeExecution({ enableMementos: false }),
+      makeAdapters(),
+      makeLogger()
+    );
+    expect(gates).toEqual({ v1: false, v2: false, v2OptInLookupFailed: false });
     expect(getSettingsValueMock).not.toHaveBeenCalled();
     expect(isMementosV2EnabledMock).not.toHaveBeenCalled();
   });

--- a/apps/client/server/utils/resolveExecutionMementoGates.test.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.test.ts
@@ -84,4 +84,19 @@ describe('resolveExecutionMementoGates (agent-surface authority, #1337)', () => 
     const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: undefined }), makeAdapters());
     expect(gates).toEqual({ v1: false, v2: false });
   });
+
+  it('fails closed to no-V1 when the admin-setting lookup rejects (never fails the turn)', async () => {
+    // getSettingsValue is an uncached findOne and can reject; a rejection here must degrade to no
+    // memory, not escape and fail an agent run that has otherwise completed.
+    getSettingsValueMock.mockRejectedValue(new Error('mongo down'));
+    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: true }), makeAdapters());
+    expect(gates).toEqual({ v1: false, v2: false });
+  });
+
+  it('short-circuits both lookups on an explicit opt-out', async () => {
+    const gates = await resolveExecutionMementoGates(makeExecution({ enableMementos: false }), makeAdapters());
+    expect(gates).toEqual({ v1: false, v2: false });
+    expect(getSettingsValueMock).not.toHaveBeenCalled();
+    expect(isMementosV2EnabledMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/client/server/utils/resolveExecutionMementoGates.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.ts
@@ -1,0 +1,37 @@
+/**
+ * The single authority that turns an agent execution's tri-state memory flag into concrete
+ * `MementoGates` for the agent surface - the read side (`getFirstIterationMementosPreamble`) and the
+ * write side (`publishMementoCompletion`) both resolve through here, so neither can re-implement the
+ * policy or disagree about what `enableMementos: false` means.
+ *
+ * It feeds `resolveMementoGates` the same three inputs the chat path feeds it (ChatCompletionProcess):
+ * the caller's tri-state request flag, the `EnableMementos` admin setting, and the user's V2 opt-in.
+ * That is what makes a per-request opt-out mean the SAME thing on the agent surface as it does on
+ * chat - an explicit `false` disables both pipelines, read and write, V1 and V2 (#1337, following the
+ * chat-path fix #1319 / #1327).
+ *
+ * The tri-state on `execution.enableMementos` is load-bearing and must reach here uncoerced:
+ * `undefined` (a V2-only user, who lets the opt-in ride) is NOT the same as `false` (an explicit
+ * opt-out). Collapsing them with `=== true` is exactly the leak this file closes.
+ */
+
+import type { IAgentExecution } from '@bike4mind/database';
+import type { IAdminSettingsRepository } from '@bike4mind/common';
+import { resolveMementoGates, type MementoGates } from '@bike4mind/services';
+import { isMementosV2Enabled } from '@server/memory/mementoLedgerMirror';
+
+export type MementoGateExecution = Pick<IAgentExecution, 'userId' | 'enableMementos'>;
+
+export interface MementoGateAdapters {
+  db: { adminSettings: Pick<IAdminSettingsRepository, 'getSettingsValue'> };
+}
+
+export async function resolveExecutionMementoGates(
+  execution: MementoGateExecution,
+  adapters: MementoGateAdapters
+): Promise<MementoGates> {
+  const adminEnabled = (await adapters.db.adminSettings.getSettingsValue('EnableMementos')) ?? false;
+  // A lookup failure must fail closed to "not opted in" - the same catch the chat and read paths use.
+  const v2OptIn = await isMementosV2Enabled(execution.userId).catch(() => false);
+  return resolveMementoGates(execution.enableMementos, Boolean(adminEnabled), v2OptIn);
+}

--- a/apps/client/server/utils/resolveExecutionMementoGates.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.ts
@@ -30,8 +30,18 @@ export async function resolveExecutionMementoGates(
   execution: MementoGateExecution,
   adapters: MementoGateAdapters
 ): Promise<MementoGates> {
-  const adminEnabled = (await adapters.db.adminSettings.getSettingsValue('EnableMementos')) ?? false;
-  // A lookup failure must fail closed to "not opted in" - the same catch the chat and read paths use.
-  const v2OptIn = await isMementosV2Enabled(execution.userId).catch(() => false);
+  // An explicit per-request opt-out disables both pipelines regardless of the admin setting or the V2
+  // opt-in (resolveMementoGates(false, ...) is always { v1: false, v2: false }). It is also the
+  // highest-volume input this resolver sees - the Slack senders and the voice proxy all hard-code
+  // false - so short-circuiting skips both round trips and keeps the dominant flow off the reads below.
+  if (execution.enableMementos === false) return { v1: false, v2: false };
+
+  // Both lookups fail closed to "not enabled" (memory degrades, it never fails the turn - the same
+  // convention the chat and read paths use) and are independent - one AdminSettings read, one user
+  // read - so run them concurrently rather than paying their sum on this critical path.
+  const [adminEnabled, v2OptIn] = await Promise.all([
+    adapters.db.adminSettings.getSettingsValue('EnableMementos').catch(() => false),
+    isMementosV2Enabled(execution.userId).catch(() => false),
+  ]);
   return resolveMementoGates(execution.enableMementos, Boolean(adminEnabled), v2OptIn);
 }

--- a/apps/client/server/utils/resolveExecutionMementoGates.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.ts
@@ -15,6 +15,7 @@
  * opt-out). Collapsing them with `=== true` is exactly the leak this file closes.
  */
 
+import type { Logger } from '@bike4mind/observability';
 import type { IAgentExecution } from '@bike4mind/database';
 import type { IAdminSettingsRepository } from '@bike4mind/common';
 import { resolveMementoGates, type MementoGates } from '@bike4mind/services';
@@ -26,22 +27,56 @@ export interface MementoGateAdapters {
   db: { adminSettings: Pick<IAdminSettingsRepository, 'getSettingsValue'> };
 }
 
+export interface ResolvedMementoGates extends MementoGates {
+  /**
+   * True when the V2 opt-in lookup REJECTED, as opposed to returning a legitimate `false`. `v2` is
+   * fail-closed to `false` either way, but the write side has to tell them apart: publishing an
+   * explicit `enableMementosV2: false` that actually came from a Mongo blip asserts a permanent opt-out
+   * to the subscriber, whereas OMITTING the field lets the subscriber resolve the opt-in itself. Before
+   * this surface published explicit booleans it always omitted the field when V1 was on, so the
+   * subscriber's independent retry was the fallback; keeping that fallback for the failure case is what
+   * stops a transient error from silently costing a V2 user a turn of learning.
+   */
+  v2OptInLookupFailed: boolean;
+}
+
 export async function resolveExecutionMementoGates(
   execution: MementoGateExecution,
-  adapters: MementoGateAdapters
-): Promise<MementoGates> {
+  adapters: MementoGateAdapters,
+  logger: Logger
+): Promise<ResolvedMementoGates> {
   // An explicit per-request opt-out disables both pipelines regardless of the admin setting or the V2
   // opt-in (resolveMementoGates(false, ...) is always { v1: false, v2: false }). It is also the
   // highest-volume input this resolver sees - the Slack senders and the voice proxy all hard-code
   // false - so short-circuiting skips both round trips and keeps the dominant flow off the reads below.
-  if (execution.enableMementos === false) return { v1: false, v2: false };
+  if (execution.enableMementos === false) return { v1: false, v2: false, v2OptInLookupFailed: false };
 
   // Both lookups fail closed to "not enabled" (memory degrades, it never fails the turn - the same
   // convention the chat and read paths use) and are independent - one AdminSettings read, one user
   // read - so run them concurrently rather than paying their sum on this critical path.
+  // Each catch WARNS rather than swallowing: a resolved-off gate and a failed lookup produce the same
+  // silent "memory just didn't happen" from the outside, and an operator needs to tell a Mongo blip
+  // from a legitimate opt-out.
+  let v2OptInLookupFailed = false;
   const [adminEnabled, v2OptIn] = await Promise.all([
-    adapters.db.adminSettings.getSettingsValue('EnableMementos').catch(() => false),
-    isMementosV2Enabled(execution.userId).catch(() => false),
+    adapters.db.adminSettings.getSettingsValue('EnableMementos').catch(err => {
+      logger.warn('[Mementos] EnableMementos admin-setting lookup failed; failing closed to V1 off', {
+        userId: execution.userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }),
+    isMementosV2Enabled(execution.userId).catch(err => {
+      v2OptInLookupFailed = true;
+      logger.warn('[Mementos] V2 opt-in lookup failed; failing closed to V2 off for this turn', {
+        userId: execution.userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }),
   ]);
-  return resolveMementoGates(execution.enableMementos, Boolean(adminEnabled), v2OptIn);
+  return {
+    ...resolveMementoGates(execution.enableMementos, Boolean(adminEnabled), v2OptIn),
+    v2OptInLookupFailed,
+  };
 }

--- a/apps/client/server/websocket/agentExecute.ts
+++ b/apps/client/server/websocket/agentExecute.ts
@@ -15,6 +15,7 @@
 
 import { withWebSocketContext } from '@server/websocket/utils';
 import {
+  adminSettingsRepository,
   agentExecutionRepository,
   organizationRepository,
   sessionRepository,
@@ -27,6 +28,7 @@ import { persistRunAsQuest } from '@server/utils/persistRunAsQuest';
 import { MAX_CONCURRENT_EXECUTIONS_PER_USER, STALE_ACTIVE_MS } from '@server/utils/executionLimits';
 import { extractFinalAnswer } from '@server/utils/extractFinalAnswer';
 import { publishMementoCompletion } from '@server/utils/publishMementoCompletion';
+import { resolveExecutionMementoGates } from '@server/utils/resolveExecutionMementoGates';
 import { decideInlineBudgets } from '@server/websocket/reconnectBudget';
 import { verifyJwtToken, checkRateLimit, verifyApiKey, checkApiKeyRateLimitOrThrow } from '@server/cli/auth';
 import { Resource } from 'sst';
@@ -767,9 +769,12 @@ async function handleGateResponse(
     );
     // Memento parity with chat_completion. Stop-at-gate is also a
     // terminal `completed` write, so fire the same event the executor's
-    // natural completion path fires. Guarded inside the helper on
-    // `enableMementos` and `parentExecutionId`.
-    await publishMementoCompletion(execution, logger);
+    // natural completion path fires. Resolve gates through the shared authority
+    // and hand them over; the helper guards on the gates and `parentExecutionId`.
+    const mementoGates = await resolveExecutionMementoGates(execution, {
+      db: { adminSettings: adminSettingsRepository },
+    });
+    await publishMementoCompletion(execution, mementoGates, logger);
     logger.info('[Gate] Stopped execution with partial answer', { executionId: cmd.executionId });
     return;
   }

--- a/apps/client/server/websocket/agentExecute.ts
+++ b/apps/client/server/websocket/agentExecute.ts
@@ -27,8 +27,7 @@ import { buildChildExecutionSnapshots } from '@server/utils/childExecutionSnapsh
 import { persistRunAsQuest } from '@server/utils/persistRunAsQuest';
 import { MAX_CONCURRENT_EXECUTIONS_PER_USER, STALE_ACTIVE_MS } from '@server/utils/executionLimits';
 import { extractFinalAnswer } from '@server/utils/extractFinalAnswer';
-import { publishMementoCompletion } from '@server/utils/publishMementoCompletion';
-import { resolveExecutionMementoGates } from '@server/utils/resolveExecutionMementoGates';
+import { resolveAndPublishMementoCompletion } from '@server/utils/publishMementoCompletion';
 import { decideInlineBudgets } from '@server/websocket/reconnectBudget';
 import { verifyJwtToken, checkRateLimit, verifyApiKey, checkApiKeyRateLimitOrThrow } from '@server/cli/auth';
 import { Resource } from 'sst';
@@ -771,10 +770,7 @@ async function handleGateResponse(
     // terminal `completed` write, so fire the same event the executor's
     // natural completion path fires. Resolve gates through the shared authority
     // and hand them over; the helper guards on the gates and `parentExecutionId`.
-    const mementoGates = await resolveExecutionMementoGates(execution, {
-      db: { adminSettings: adminSettingsRepository },
-    });
-    await publishMementoCompletion(execution, mementoGates, logger);
+    await resolveAndPublishMementoCompletion(execution, { db: { adminSettings: adminSettingsRepository } }, logger);
     logger.info('[Gate] Stopped execution with partial answer', { executionId: cmd.executionId });
     return;
   }

--- a/b4m-core/services/src/llm/index.ts
+++ b/b4m-core/services/src/llm/index.ts
@@ -1,5 +1,6 @@
 export * from './ChatCompletionProcess';
 export * from './ChatCompletionInvoke';
+export * from './mementoGating';
 export * from './ImageGeneration';
 export * from './VideoGeneration';
 export * from './ChatCompletionFeatures';


### PR DESCRIPTION
## Description

Follow-up to #1319 / #1327. Those fixed the per-request memory opt-out on the **chat-completion** path. The **agent-executor** path was never part of that change and still resolved Mementos V2 independently, so an explicit `enableMementos: false` did **not** disable V2 belief distillation for an account-opted user on the agent surface.

Concretely, the write path (`publishMementoCompletion`) collapsed the tri-state flag with `execution.enableMementos === true`, so `false` only gated V1 and V2 rode the account opt-in unconditionally. The read path (`getFirstIterationMementosPreamble`) had the mirror leak: it ran `recallMementosV2` regardless of the flag, injecting beliefs the caller opted out of.

### What is actually reachable today

An earlier version of this description claimed the Slack flows reach the agent executor. **That was wrong** and is corrected here, because it sent reviewers and testers at the wrong surface. `CommandHandler` / `WorkflowStepHandler` pass `enableMementos: false` as parameters *inside* a `chatCompletion.invoke(...)` call, which routes to the chat pipeline — the path #1327 already fixed. Nothing in `b4m-core/slack/**` creates an `AgentExecution`.

The honest split, after tracing every caller:

- **Live defect, fixed here: background subagents write beliefs from their own coordination prompts.** A background child is created with `parentExecutionId` deliberately unset (it bills and counts independently) and `spawnedByExecutionId` set instead, and `baseFields` never copies the parent's `enableMementos` — so the child arrived `undefined`, resolved `v2: true` for any V2-opted user, and both read beliefs into its synthetic task prompt and wrote new ones from it. **This needs no opt-out at all** — any V2-opted user whose agent spawns a background subagent hits it, and it breaks the "memento creation is 1:1 with user turns" invariant the existing guard was written to hold.
- **The explicit-`false` opt-out is hardening, not a live user-facing leak.** The browser sends a *tri-state*, not a resolved boolean: `LLMContext.tsx:396` yields `true` when V1 is on, `undefined` when only V2 is on, and `false` only when both are off — at which point the user has no V2 opt-in for `false` to protect. So the exact #1337 scenario (explicit `false` **and** a V2 opt-in) is not reachable through the UI. It remains reachable in one narrow case: `isExperimentalFeatureEnabled` reads **either** `user.preferences?.experimentalFeatures` **or** `user.experimentalFeatures`, while the client reads one bag — so a user whose V2 flag lives in the bag the client does not read sends `false` while the server resolves the opt-in `true`.

That narrow case, plus keeping the two agent surfaces from ever disagreeing about what the flag means, is what the resolver work buys. It is worth having on a privacy control; it is just not the thing a tester can reproduce by clicking.

**Definition of done (from #1337):** `enableMementos: false` is an absolute, all-surface memory opt-out — read and write, V1 and V2. **This PR does not fully reach that, and the gap is on this very surface.**

It closes the two paths that carry the flag: the WS dispatch path (`agentExecute.ts` stamps the tri-state onto the doc) and lineage-bearing children (sync, DAG, and — new here — background). What it does not close is **QuestMaster V5**: `runQuestNode.ts:149` creates a *top-level* `AgentExecution` with no `enableMementos`, no `parentExecutionId` and no `spawnedByExecutionId`, then invokes the agentExecutor Lambda directly. For a V2-opted-in user that resolves `v2: true`, and because the execution is top-level, **neither lineage guard can catch it** — so a V5 node run reads beliefs into its preamble and writes new ones regardless of any opt-out expressed elsewhere.

That is a different shape from the background-child bug fixed here, and it is not fixable by the same means: a lineage check cannot gate a top-level execution. Closing it requires propagating the originating request's flag onto node executions, which is why it is deferred (see Known gaps) rather than patched. Read the DoD as satisfied for the dispatch and lineage paths only.

## Changes

- **New single authority** `resolveExecutionMementoGates` — feeds `resolveMementoGates` the same three inputs the chat path uses (the tri-state request flag off the execution doc, the `EnableMementos` admin setting, and the user's V2 opt-in). Both agent surfaces resolve through it, so neither can re-implement the policy or disagree about what the flag means.
- `publishMementoCompletion` and `getFirstIterationMementosPreamble` now take the resolved `MementoGates` instead of raw flags. The read side gates V2 recall on `gates.v2`; the write side publishes explicit resolved booleans (mirroring the chat path's `MementoFeature.onComplete`).
- **Both guards now check `parentExecutionId` OR `spawnedByExecutionId`**, and both `Pick` types carry the second field — this is the background-subagent fix above.
- **A failed opt-in lookup is no longer published as an opt-out.** The resolver reports `v2OptInLookupFailed`, and the publisher OMITS `enableMementosV2` in that case so the subscriber resolves the opt-in itself. Previously a transient Mongo error resolved `v2: false` and was asserted to the subscriber as a permanent opt-out, which is strictly narrower than the behaviour before this surface began publishing explicit booleans.
- **Both resolver catches now `warn`.** A resolved-off gate and a failed lookup are indistinguishable from outside, and an operator needs to tell a blip from a legitimate opt-out.
- **Gate resolution is composed with its consumers** (`resolveAndPublishMementoCompletion`, `resolveAndBuildMementosPreamble`). Each of the three call sites previously held a `MementoGates` value it could fabricate, and hardcoding `{ v1: true, v2: true }` at all three left the entire suite green — the opt-out could be reverted invisibly. The call sites no longer touch gates, which is a stronger guarantee than asserting they passed the right ones.
- The tri-state (`undefined` vs `false` vs `true`) is preserved end-to-end onto the execution doc; the bug was only the downstream `=== true` coercion, now removed.
- Exported `resolveMementoGates` / `MementoGates` from the `@bike4mind/services` barrel so the agent surface can share the chat resolver.

**Behaviour change worth a release note.** Routing agent V1 through the resolver means agent-mode V1 now also honours the `EnableMementos` admin setting, exactly as chat does. This is the right direction, but it is **not** a no-op as an earlier version of this description claimed: the UI gates the *switch*, not the *stored preference*. `LLMContext.tsx:394` reads `settings.experimentalFeatures?.enableMementos ?? false` with no admin check, so a user who opted into V1 while the admin setting was on — and whose admin later turned it off — still has `true` stored, cannot see the toggle to change it, and keeps dispatching it. Their agent-mode V1 memory worked before this change and stops after it.

### Known gaps (deliberately not fixed here)

- **QuestMaster V5 node executions** (`runQuestNode.ts:149`) create a **top-level** `AgentExecution` with no `enableMementos` field, so no opt-out expressed anywhere can reach them, and no lineage field either — so neither guard in this PR can gate them. They invoke the agentExecutor Lambda directly, so this is **on** the agent-executor surface, not outside it (an earlier version of this note claimed otherwise). Blast radius is narrower than a user-facing turn (the query is machine-generated node text rather than the user's own prompt), but a V2-opted-in user's V5 graph runs will read and write beliefs. Fixing it means propagating the originating request's flag onto node executions — a different change from a lineage guard, hence deferred.
- **The resolver runs twice per execution** (once for read, once for write) and the two resolutions can disagree if an admin or the user flips a flag mid-run. `main` had one write-side resolution and none on the read side, so this window is new.

## Guide for Testers

Backend-only change to agent-mode memory gating. Nothing new renders.

**Read this first:** the previous version of this guide told you to exercise the opt-out through a Slack agent flow. That does not touch this diff — it verifies the already-shipped #1327 chat-path fix, and would have returned green whether or not this change works. The steps below only ask you to verify what a tester can actually observe.

Prerequisites (staging or a preview env):
1. Log in as a user with **Mementos V2** enabled: Sidebar → profile menu → **Profile → Experimental Features** → toggle **"Mementos V2 (ledger)"** on.
2. Seed a fact in normal (non-agent) chat: `Remember this: my favorite programming language is Rust.` Expected: a normal reply, and a belief distilled for the turn.

Memory must still work in agent mode (the regression that matters):
3. In the web app, turn Agents on for the session and ask: `What is my favorite programming language?`
4. Expected: the agent answers "Rust" from recalled context, and belief distillation continues for qualifying turns. A V2-only user (V1 toggle off, V2 on) must still get memory — that user sends the `undefined` tri-state, which rides the opt-in by design.

Subagent behaviour:
5. Run an agent prompt substantial enough that the agent delegates to subagents (e.g. a multi-part research or comparison task). Expected: exactly **one** memory write for the turn — from your prompt, not one per subagent. Open **Profile → Mementos** and confirm no entry reads like internal coordination text ("dispatch a subagent to...", "synthesize the findings from...").

**What cannot be exercised from the UI, and why:** the explicit-`false` opt-out itself. Per the reachability analysis above, the browser never sends `false` for a V2-opted user, so there is no click path that produces the input. It is covered by unit tests instead, and every one of them is mutation-verified — reverting each guard, the lookup-failure deferral, and the resolver-to-consumer composition fails exactly the tests written for it and nothing else. If you want to drive it deliberately, send an `agent_execute` WS command with `enableMementos: false` as a user who has V2 enabled.

### Regression Checks
- Normal chat-mode mementos (V1 and V2) unchanged — recall and write both still work.
- A V2-only user in **web** agent mode still gets memory (`undefined` rides the opt-in).
- Sync and DAG-child executions still never emit a memento event. **Background children now also skip** — that is this PR's fix, and the previous claim that the unchanged `parentExecutionId` guard already covered them was false for that child type.
- Agent-mode V1 now honours the `EnableMementos` admin setting; if that setting is off, agent V1 memory stops for users with a stale stored `true` (see the release note above).

### What NOT to test
- No UI/visual changes.
- No new AdminSettings, migrations, or telemetry fields.
- Chat-path `EnableMementos` behaviour is unchanged (that was #1327).

## Additional Information

Closes #1337. Follow-up to #1319 (chat-path fix shipped as #1327). Disclosure metadata and a V2 purge path remain open on #1319 and are out of scope here.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — n/a, no new settings
- [ ] I have made the UI/UX feel good — n/a, backend-only
- [ ] If adding/modifying telemetry fields — n/a, no telemetry changes


