### PR TITLE
feat(organizations): inject group-type capability map into capability resolution (#1178)

### DIFF
--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -24,6 +24,7 @@ import {
 import { resolveGroupTypesForUser } from './resolveGroupTypesForUser';
 import type { GroupTypeResolutionOverride } from './resolveGroupTypesForUser';
 import { resolveCapabilitiesForUser, userHasCapability } from './resolveCapabilitiesForUser';
+import type { GroupTypeCapabilityMap } from './resolveCapabilitiesForUser';
 
 export {
   search,
@@ -55,3 +56,4 @@ export {
 
 export type { SearchParameters };
 export type { GroupTypeResolutionOverride };
+export type { GroupTypeCapabilityMap };

--- a/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.test.ts
+++ b/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.test.ts
@@ -234,4 +234,76 @@ describe('resolveCapabilitiesForUser (#1234)', () => {
       ).resolves.toBe(false);
     });
   });
+
+  describe('consumer-injected capability map (#1178)', () => {
+    // The overlay owns the type -> capability mapping; product keys never live in core.
+    const INJECTED = {
+      research: ['analytics:read'],
+      customer: ['analytics:read', 'analytics:write'],
+    } as const;
+
+    it('resolves from the injected map, taking precedence over the catalog capabilities', async () => {
+      // research maps to analytics:read here, NOT the catalog's qwork:submit/crm:read.
+      const { adapters } = makeAdapters(org(), [group('g-research', 'research')]);
+      await expect(
+        resolveCapabilitiesForUser(
+          { user: user('member-1', ['g-research']), organizationId: ORG, capabilitiesByType: INJECTED },
+          adapters
+        )
+      ).resolves.toEqual(['analytics:read']);
+    });
+
+    it('unions the injected capabilities across a multi-group member', async () => {
+      const { adapters } = makeAdapters(org(), [group('g-research', 'research'), group('g-customer', 'customer')]);
+      await expect(
+        resolveCapabilitiesForUser(
+          { user: user('member-1', ['g-research', 'g-customer']), organizationId: ORG, capabilitiesByType: INJECTED },
+          adapters
+        )
+      ).resolves.toEqual(['analytics:read', 'analytics:write']);
+    });
+
+    it('falls back to the catalog for a type the injected map omits', async () => {
+      // `sales` is not in INJECTED, so it uses the catalog's sales capabilities.
+      const { adapters } = makeAdapters(org(), [group('g-sales', 'sales')]);
+      await expect(
+        resolveCapabilitiesForUser(
+          { user: user('member-1', ['g-sales']), organizationId: ORG, capabilitiesByType: INJECTED },
+          adapters
+        )
+      ).resolves.toEqual(['crm:read', 'sales:brief']);
+    });
+
+    it('flows through the billing-owner implicit hold', async () => {
+      const { adapters } = makeAdapters(org({ userId: OWNER, allowedGroupTypes: ['customer'] }), []);
+      await expect(
+        resolveCapabilitiesForUser(
+          { user: user(OWNER, []), organizationId: ORG, capabilitiesByType: INJECTED },
+          adapters
+        )
+      ).resolves.toEqual(['analytics:read', 'analytics:write']);
+    });
+
+    it('flows through the platform-admin override', async () => {
+      const { adapters } = makeAdapters(org(), []);
+      await expect(
+        resolveCapabilitiesForUser(
+          {
+            user: admin('admin-1', []),
+            organizationId: ORG,
+            override: { organizationId: ORG, groupTypes: ['customer'] },
+            capabilitiesByType: INJECTED,
+          },
+          adapters
+        )
+      ).resolves.toEqual(['analytics:read', 'analytics:write']);
+    });
+
+    it('gates userHasCapability off the injected map', async () => {
+      const { adapters } = makeAdapters(org(), [group('g-research', 'research')]);
+      const params = { user: user('member-1', ['g-research']), organizationId: ORG, capabilitiesByType: INJECTED };
+      await expect(userHasCapability({ ...params, capability: 'analytics:read' }, adapters)).resolves.toBe(true);
+      await expect(userHasCapability({ ...params, capability: 'analytics:write' }, adapters)).resolves.toBe(false);
+    });
+  });
 });

--- a/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.ts
+++ b/b4m-core/services/src/organizationService/resolveCapabilitiesForUser.ts
@@ -23,6 +23,18 @@ interface CapabilityAdapters {
 type CapabilityUser = Pick<IUserDocument, 'id' | 'groups'> & { isAdmin?: boolean };
 
 /**
+ * Group-type -> capability keys, injected by the consumer (org-groups #1178).
+ *
+ * `GROUP_TYPE_CATALOG` ships `capabilities` EMPTY in open core on purpose: what a type confers is
+ * product-specific (e.g. `crm:read`) and a product key can't live in the generic public
+ * catalog. The consuming overlay owns that mapping and passes it here; core stays generic and simply
+ * resolves the union. A type absent from the map falls back to the catalog's own capabilities (empty
+ * today), so omitting a type means it confers nothing. Code-defined and platform-controlled - never
+ * org-writable, which is what keeps an org from granting itself a capability (#1178 decision).
+ */
+export type GroupTypeCapabilityMap = Readonly<Record<string, readonly string[]>>;
+
+/**
  * Resolve the CAPABILITY set a user holds within an organization (org-groups #1234).
  *
  * `GroupTypeDefinition.capabilities` is the product-behaviour axis a group type confers; until this
@@ -50,7 +62,13 @@ export async function resolveCapabilitiesForUser(
     user,
     organizationId,
     override,
-  }: { user: CapabilityUser; organizationId: string; override?: GroupTypeResolutionOverride },
+    capabilitiesByType,
+  }: {
+    user: CapabilityUser;
+    organizationId: string;
+    override?: GroupTypeResolutionOverride;
+    capabilitiesByType?: GroupTypeCapabilityMap;
+  },
   adapters: CapabilityAdapters
 ): Promise<string[]> {
   const organization = await adapters.db.organizations.findById(organizationId);
@@ -78,9 +96,11 @@ export async function resolveCapabilitiesForUser(
     }
   }
 
+  // Prefer the consumer-injected mapping (#1178); fall back to the catalog's own capabilities
+  // (empty in open core). A type absent from the injected map contributes nothing.
   const capabilities = new Set<string>();
   for (const type of effectiveTypes) {
-    for (const capability of getGroupType(type)?.capabilities ?? []) {
+    for (const capability of capabilitiesByType?.[type] ?? getGroupType(type)?.capabilities ?? []) {
       capabilities.add(capability);
     }
   }
@@ -98,9 +118,19 @@ export async function userHasCapability(
     organizationId,
     capability,
     override,
-  }: { user: CapabilityUser; organizationId: string; capability: string; override?: GroupTypeResolutionOverride },
+    capabilitiesByType,
+  }: {
+    user: CapabilityUser;
+    organizationId: string;
+    capability: string;
+    override?: GroupTypeResolutionOverride;
+    capabilitiesByType?: GroupTypeCapabilityMap;
+  },
   adapters: CapabilityAdapters
 ): Promise<boolean> {
-  const capabilities = await resolveCapabilitiesForUser({ user, organizationId, override }, adapters);
+  const capabilities = await resolveCapabilitiesForUser(
+    { user, organizationId, override, capabilitiesByType },
+    adapters
+  );
   return capabilities.includes(capability);
 }


### PR DESCRIPTION
## Description

Makes the org-groups **capability layer usable**. `resolveCapabilitiesForUser` (#1234) reads `GroupTypeDefinition.capabilities`, but that field ships **empty** in open core on purpose — what a group type *confers* is product-specific (a product capability key can't live in the generic public catalog). So today `userHasCapability(...)` resolves to empty for everyone, and the layer is inert.

This adds the missing piece — the "separate capability-resolution design" that #1178 explicitly deferred:

- `resolveCapabilitiesForUser` / `userHasCapability` take an optional **`capabilitiesByType`** map (exported as `GroupTypeCapabilityMap`). The consuming overlay owns the type → capability mapping and injects it; **core stays generic** and just resolves the union.
- A type **absent** from the map falls back to the catalog's own capabilities, so the default (no map passed) behaviour is **unchanged** — fully backward-compatible.
- The mapping is **code-defined and platform-controlled** — never org-writable, which is what stops an org from granting its own group a capability (the deliberate authority boundary).

It flows through every existing resolution path — the group-membership union, the billing-owner implicit-hold (#1226), and the platform-admin override (#1236).

## Changes

- `resolveCapabilitiesForUser.ts` — add optional `capabilitiesByType` to both functions; union prefers the injected map, falls back to the catalog. New exported type `GroupTypeCapabilityMap`.
- `organizationService/index.ts` — export `GroupTypeCapabilityMap`.
- `resolveCapabilitiesForUser.test.ts` — 6 new cases (injected map takes precedence over the catalog; unions across a multi-group member; falls back for an unmapped type; flows through billing-owner and override; gates `userHasCapability`).

## Guide for Testers

Backend, pure-resolution change — no UI, no endpoint, no runtime behaviour change on its own (nothing passes a map yet).

1. From the repo root: `pnpm --filter @bike4mind/services exec vitest run src/organizationService/resolveCapabilitiesForUser.test.ts`
2. Expected: **23 passed** (17 existing + 6 new under `consumer-injected capability map (#1178)`).
3. Type check: `pnpm --filter @bike4mind/services typecheck:fast` → no errors.

### Regression Checks

- The existing `resolveCapabilitiesForUser (#1234)`, billing-owner (#1226), and override (#1236) cases must still pass unchanged — the map is an optional param and omitting it is the prior behaviour.
- Confirm no caller is forced to pass `capabilitiesByType` (it's optional).

### What NOT to test

- No consumer gates a real surface in this PR — that's the overlay follow-up. Don't look for a UI or an access change here.

## Developer Notes

- **New extension point**: `GroupTypeCapabilityMap` — a consumer injects `{ [groupTypeKey]: capabilityKey[] }` to define what its group types confer, without any product key landing in open core. This is how the capability layer becomes real per product while core stays generic.

Part of #1172 / #1178. Unblocks the overlay gate migration and #1237.
