### PR TITLE
refactor(data-lake): make redactLakeForActor an allow-list so new editor-only fields cannot leak

### DIFF
--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -17,7 +17,7 @@ import { setLakeVisibility } from './setLakeVisibility';
 import { updateDataLake } from './updateDataLake';
 import { reconcileStuckBatches, DEFAULT_STUCK_BATCH_TIMEOUT_MS } from './reconcileStuckBatches';
 import { listDataLakes, listAllDataLakes, listArchivedDataLakes, listDeletedDataLakes } from './listDataLakes';
-import { redactLakeForActor } from './redactLakeForActor';
+import { redactLakeForActor, READER_LAKE_FIELDS } from './redactLakeForActor';
 import { browsePublicDataLakes } from './browsePublicDataLakes';
 
 const lake = (overrides: Partial<IDataLakeDocument> = {}): IDataLakeDocument =>
@@ -410,6 +410,8 @@ describe('listAllDataLakes - the admin list still gates the prompt on canManage'
 
 // The raw-document exits (GET /api/data-lakes/:id, /archived, /deleted) are gated on READ
 // access, which is deliberately wider than manage - so each one must redact before serializing.
+// The redaction is an ALLOW-LIST (toReaderLake): a non-editor receives only the named fields, so
+// a field added to IDataLake later is withheld by default rather than shipped.
 describe('redactLakeForActor - editor-only fields on the raw-document exits', () => {
   const prompted = (overrides: Partial<IDataLakeDocument> = {}) =>
     lake({ createdByUserId: 'owner', systemPrompt: 'Answer only from this lake.', ...overrides });
@@ -421,12 +423,14 @@ describe('redactLakeForActor - editor-only fields on the raw-document exits', ()
 
   it('leaves the document untouched for an admin', () => {
     const l = prompted();
-    expect(redactLakeForActor(l, { userId: 'admin', isAdmin: true }).systemPrompt).toBe('Answer only from this lake.');
+    const visible = redactLakeForActor(l, { userId: 'admin', isAdmin: true });
+    expect(visible).toBe(l);
+    expect((visible as IDataLakeDocument).systemPrompt).toBe('Answer only from this lake.');
   });
 
   it('strips the prompt for a stranger who can READ a published lake', () => {
     const l = prompted({ isPublic: true });
-    const visible = redactLakeForActor(l, { userId: 'stranger', isAdmin: false });
+    const visible = redactLakeForActor(l, { userId: 'stranger', isAdmin: false }) as IDataLakeDocument;
 
     expect(visible.systemPrompt).toBeUndefined();
     expect('systemPrompt' in visible).toBe(false);
@@ -435,11 +439,74 @@ describe('redactLakeForActor - editor-only fields on the raw-document exits', ()
     expect(visible.datalakeTag).toBe('datalake:lake');
   });
 
+  it('serves a stranger ONLY the allow-listed fields, never an unlisted one', () => {
+    // An extra own-enumerable key (as a hydrated document could carry) must not pass through: the
+    // allow-list emits named fields only, so the deny-list's "unlisted field leaks" failure is gone.
+    const l = prompted({ isPublic: true, secretField: 'leak-me' } as unknown as Partial<IDataLakeDocument>);
+    const visible = redactLakeForActor(l, { userId: 'stranger', isAdmin: false });
+
+    expect('secretField' in visible).toBe(false);
+    expect('systemPrompt' in visible).toBe(false);
+    expect(Object.keys(visible).every(k => (READER_LAKE_FIELDS as readonly string[]).includes(k))).toBe(true);
+  });
+
   it('reports a whitespace-only prompt as absent for the OWNER too, matching the list projection', () => {
     // Without this the same lake reads as "has a prompt" on GET /:id and "has none" in the list.
     const blank = lake({ createdByUserId: 'owner', systemPrompt: '   \n ' });
     const visible = redactLakeForActor(blank, { userId: 'owner', isAdmin: false });
     expect('systemPrompt' in visible).toBe(false);
+  });
+
+  it('reports an EMPTY-STRING prompt as absent for the OWNER, like the list projection does', () => {
+    // '' must be normalized identically to whitespace: the list omits it (''?.trim() is falsy), so
+    // GET /:id must not echo it back as a present-but-empty field for an editor.
+    const empty = lake({ createdByUserId: 'owner', systemPrompt: '' });
+    const visible = redactLakeForActor(empty, { userId: 'owner', isAdmin: false });
+    expect('systemPrompt' in visible).toBe(false);
+  });
+
+  it('trims a padded-but-non-blank prompt for the OWNER, matching the list projection', () => {
+    // GET /:id must not echo stored padding an editor never typed while the list sends it trimmed.
+    const padded = lake({ createdByUserId: 'owner', systemPrompt: '  Cite the source.  ' });
+    const visible = redactLakeForActor(padded, { userId: 'owner', isAdmin: false }) as IDataLakeDocument;
+    expect(visible.systemPrompt).toBe('Cite the source.');
+    // A copy, not the source - the padded original is left intact for any write path still holding it.
+    expect(visible).not.toBe(padded);
+    expect(padded.systemPrompt).toBe('  Cite the source.  ');
+  });
+
+  it('treats a null prompt as blank for an editor rather than throwing on .trim()', () => {
+    // Only a direct DB write or migration produces null; the predicate must stay null-safe regardless.
+    const nulled = lake({ createdByUserId: 'owner', systemPrompt: null as unknown as string });
+    const visible = redactLakeForActor(nulled, { userId: 'owner', isAdmin: false });
+    expect('systemPrompt' in visible).toBe(false);
+  });
+
+  it('pins the reader allow-list so a new IDataLake field forces a visibility decision', () => {
+    // If this fails, a field was added to IDataLake (or READER_LAKE_FIELDS changed) without deciding
+    // whether a non-editor may receive it. Add it to READER_LAKE_FIELDS on purpose, or leave it out.
+    expect([...READER_LAKE_FIELDS].sort()).toEqual(
+      [
+        'createdAt',
+        'createdByUserId',
+        'datalakeTag',
+        'description',
+        'fileCount',
+        'fileTagPrefix',
+        'id',
+        'isPublic',
+        'lastSyncAt',
+        'name',
+        'organizationId',
+        'requiredEntitlement',
+        'requiredUserTag',
+        'slug',
+        'status',
+        'totalSizeBytes',
+        'updatedAt',
+      ].sort()
+    );
+    expect((READER_LAKE_FIELDS as readonly string[]).includes('systemPrompt')).toBe(false);
   });
 
   it('does not mutate the source document (the caller may still hold it for a write path)', () => {
@@ -455,7 +522,7 @@ describe('redactLakeForActor - editor-only fields on the raw-document exits', ()
 
     const result = await listArchivedDataLakes(ctx({ userId: 'me', organizationId: 'orgA' }), { db });
 
-    expect(result.find(l => l.id === 'mine')?.systemPrompt).toBe('Answer only from this lake.');
+    expect((result.find(l => l.id === 'mine') as IDataLakeDocument)?.systemPrompt).toBe('Answer only from this lake.');
     // Key absence, not undefined: blanking instead of deleting would pass the weaker assertion.
     const redactedArchived = result.find(l => l.id === 'org')!;
     expect('systemPrompt' in redactedArchived).toBe(false);

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -6,7 +6,7 @@ import type {
   ManageableDataLakeConfig,
 } from '@bike4mind/common';
 import { DATA_LAKES, toDataLakeConfig, lakeMatchesAccess, normalizeEntitlementKey } from '@bike4mind/common';
-import { redactLakesForActor } from './redactLakeForActor';
+import { redactLakesForActor, type ReaderDataLake } from './redactLakeForActor';
 
 interface ListDataLakesAdapters {
   db: {
@@ -115,7 +115,7 @@ export const listAllDataLakes = async ({ db }: ListDataLakesAdapters): Promise<M
 export const listArchivedDataLakes = async (
   ctx: AccessContext,
   { db }: ListDataLakesAdapters
-): Promise<IDataLakeDocument[]> => {
+): Promise<(IDataLakeDocument | ReaderDataLake)[]> => {
   const lakes = await db.dataLakes.findAccessible(ctx, { statuses: ['archived'], includePublic: false });
   return redactLakesForActor(lakes, ctx);
 };
@@ -128,7 +128,7 @@ export const listArchivedDataLakes = async (
 export const listDeletedDataLakes = async (
   ctx: AccessContext,
   { db }: ListDataLakesAdapters
-): Promise<IDataLakeDocument[]> => {
+): Promise<(IDataLakeDocument | ReaderDataLake)[]> => {
   const lakes = await db.dataLakes.findAccessible(ctx, { statuses: ['deleted'], includePublic: false });
   return redactLakesForActor(lakes, ctx);
 };

--- a/b4m-core/services/src/dataLakeService/redactLakeForActor.ts
+++ b/b4m-core/services/src/dataLakeService/redactLakeForActor.ts
@@ -2,12 +2,66 @@ import type { AccessContext, IDataLakeDocument } from '@bike4mind/common';
 import { canManageLake } from './authorizeLakeWrite';
 
 /**
- * Strip the editor-only fields from a lake document that is about to leave the server, unless
- * the caller may MANAGE it. Today that is `systemPrompt`: it steers answers for everyone who
- * queries the lake, but its wording is readable only by the lake's editors (creator or admin).
+ * The fields a NON-editor reader may receive from a lake document. This is an ALLOW-LIST: the
+ * safe default is "withheld", so a field added to `IDataLake` later is not shipped to readers
+ * until it is named here on purpose. `systemPrompt` is the field that must never appear (it steers
+ * every answer drawn from the lake but is editable only by the lake's editors); it is absent from
+ * this list, so `toReaderLake` never emits it.
  *
- * Needed because the READ-gated exits are gated on access, which is deliberately wider than
- * manage: `assertLakeAccess` hands back a stranger's PUBLISHED lake (public arm, crosses orgs),
+ * `satisfies readonly (keyof IDataLakeDocument)[]` makes a typo or a renamed field a COMPILE error,
+ * and the redaction suite in `dataLakeService.test.ts` pins the served key set at runtime - so adding
+ * a field to `IDataLake` forces a reader-visibility decision rather than leaking it silently.
+ *
+ * Membership deliberately reproduces exactly what a reader receives today (see #1112): the
+ * obviously-public fields plus `createdByUserId`, `organizationId`, `requiredUserTag` and
+ * `requiredEntitlement`. None is a secret in the sense `systemPrompt` is, and narrowing the set is
+ * a behavior change (no consumer was checked for it), so this refactor preserves the current shape.
+ */
+export const READER_LAKE_FIELDS = [
+  'id',
+  'createdAt',
+  'updatedAt',
+  'name',
+  'slug',
+  'description',
+  'fileTagPrefix',
+  'datalakeTag',
+  'createdByUserId',
+  'organizationId',
+  'requiredUserTag',
+  'requiredEntitlement',
+  'isPublic',
+  'status',
+  'fileCount',
+  'totalSizeBytes',
+  'lastSyncAt',
+] as const satisfies readonly (keyof IDataLakeDocument)[];
+
+/** A lake as served to a non-editor: the allow-listed subset, with `systemPrompt` unreachable. */
+export type ReaderDataLake = Pick<IDataLakeDocument, (typeof READER_LAKE_FIELDS)[number]>;
+
+/**
+ * Project a lake down to the reader allow-list. Only ever emits fields named in
+ * `READER_LAKE_FIELDS`, so - unlike an object-rest strip - it cannot leak an unlisted field even
+ * if handed a hydrated Mongoose document (whose own-enumerable keys a rest-spread would carry
+ * through). Omits absent optionals rather than setting them `undefined`, so the served shape stays
+ * clean and `'field' in result` stays meaningful.
+ */
+function toReaderLake(lake: IDataLakeDocument): ReaderDataLake {
+  const reader = {} as Record<string, unknown>;
+  for (const field of READER_LAKE_FIELDS) {
+    if (lake[field] !== undefined) reader[field] = lake[field];
+  }
+  return reader as ReaderDataLake;
+}
+
+/**
+ * Serialize a lake for `actor`. An editor (creator or admin, via `canManageLake`) receives the
+ * full document; everyone else receives the reader allow-list (`toReaderLake`), which withholds
+ * `systemPrompt` by construction.
+ *
+ * Redaction is needed because the READ-gated exits are gated on access, which is deliberately wider
+ * than manage: `assertLakeAccess` hands back a stranger's PUBLISHED lake (public arm, crosses orgs),
  * and the archived/deleted management views hand an org member a lake they don't own. Every
  * READ-gated exit must therefore pass through here: `GET /api/data-lakes/:id`, `/archived`,
  * `/deleted`. The write/lifecycle paths (POST /api/data-lakes, PUT, DELETE, /visibility, /lifecycle)
@@ -16,28 +70,39 @@ import { canManageLake } from './authorizeLakeWrite';
  * actor-aware LIST projection has its own gate (see toManageableConfig in listDataLakes) since it
  * returns configs, not documents.
  *
- * Deletes the key rather than blanking it, so a reader cannot tell an unset prompt from a
- * withheld one, and a round-tripped document can never write '' back over a real prompt.
- *
- * For an editor, a whitespace-only prompt is reported as absent rather than echoed verbatim. That
- * keeps this endpoint's answer identical to the list projection's (see toManageableConfig), which
- * already treats blank as unset - otherwise the same lake reads as "has a prompt" here and "has
- * none" there, and an editor seeding a form from either one gets a different result.
+ * For an editor, a blank (empty or whitespace-only) prompt is reported as ABSENT and a
+ * padded-but-non-blank prompt is TRIMMED, so this endpoint's answer matches the list projection's (toManageableConfig
+ * already normalizes both) - otherwise the same lake reads as "has a prompt" here and "has none"
+ * there, and an editor seeding a form from either one gets a different result. The document is
+ * returned by identity in the common case (prompt absent or already trimmed) and only copied when
+ * stored padding must be normalized, so no caller's document is mutated. `?.trim()` is null-safe:
+ * a `null` prompt from a direct DB write or migration is treated as blank, not thrown on.
  */
 export function redactLakeForActor(
   lake: IDataLakeDocument,
   actor: Pick<AccessContext, 'userId' | 'isAdmin'>
-): IDataLakeDocument {
-  const blankPrompt = lake.systemPrompt !== undefined && !lake.systemPrompt.trim();
-  if (canManageLake(lake, actor) && !blankPrompt) return lake;
-  const { systemPrompt: _redacted, ...visible } = lake;
-  return visible;
+): IDataLakeDocument | ReaderDataLake {
+  if (canManageLake(lake, actor)) {
+    const trimmed = lake.systemPrompt?.trim();
+    // Blank in any form - unset, null, empty, or whitespace-only - is reported as absent, matching
+    // the list projection (toManageableConfig) and getDataLakePrompts. An unset prompt needs no
+    // strip, so keep identity; every other blank drops the key so a reader sees "unset".
+    if (!trimmed) {
+      if (lake.systemPrompt === undefined) return lake;
+      const { systemPrompt: _blank, ...rest } = lake;
+      return rest as IDataLakeDocument;
+    }
+    // Non-blank: identity when already trimmed (the common case), else a trimmed copy so stored
+    // padding isn't echoed only on this path.
+    return lake.systemPrompt === trimmed ? lake : { ...lake, systemPrompt: trimmed };
+  }
+  return toReaderLake(lake);
 }
 
 /** `redactLakeForActor` over a list - the archived/deleted management views. */
 export function redactLakesForActor(
   lakes: IDataLakeDocument[],
   actor: Pick<AccessContext, 'userId' | 'isAdmin'>
-): IDataLakeDocument[] {
+): (IDataLakeDocument | ReaderDataLake)[] {
   return lakes.map(lake => redactLakeForActor(lake, actor));
 }

--- a/b4m-core/services/src/dataLakeService/redactLakeForActor.ts
+++ b/b4m-core/services/src/dataLakeService/redactLakeForActor.ts
@@ -89,6 +89,10 @@ export function redactLakeForActor(
     // strip, so keep identity; every other blank drops the key so a reader sees "unset".
     if (!trimmed) {
       if (lake.systemPrompt === undefined) return lake;
+      // Object-rest spread is safe here (unlike the reader path, which uses the allow-list): this
+      // branch runs only for an editor, who is already authorized to see the whole document, so a
+      // stray key it fails to drop is at worst their own re-exposed blank prompt - never a leak to
+      // an unauthorized reader. Only the reader path needs the leak-proof allow-list projection.
       const { systemPrompt: _blank, ...rest } = lake;
       return rest as IDataLakeDocument;
     }


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="3592" height="414" alt="image" src="https://github.com/user-attachments/assets/bf6ae02d-31b5-41bc-8094-a48c386b4f7f" />

Passing `redactLakeForActor` redaction suite (12/12) - the backend equivalent of a UI screenshot.

## Description

Hardening refactor of `redactLakeForActor`, the function that strips editor-only fields from a
data-lake document before it leaves the server on the READ-gated exits (`GET /api/data-lakes/:id`,
`/archived`, `/deleted`). Those exits are gated on access, which is deliberately wider than manage -
a stranger reading a PUBLISHED lake (public arm crosses orgs) and a non-owner org member both reach
them - so the redaction is the last line before a raw document is serialized.

This is a P3 follow-up deferred from #1067 (see #1112). Nothing leaks today; both reviewers on #1067
verified the current implementation is correct. The change is about making it hard to *stop* being
correct later, and it folds in three normalization fixes that live in the same function.

The old implementation was a DENY-LIST: take the whole document, delete `systemPrompt`, return the
rest. Two silent failure modes:

- A new editor-only field added to `IDataLake` later ships to every reader unless someone remembers
  to add it to the deny-list. No test fails, no type complains. `systemPrompt` itself is the proof
  such fields get added.
- Object-rest spread only drops OWN ENUMERABLE keys, so a future repository method returning a
  hydrated Mongoose document would defeat the strip silently and still typecheck.

This PR converts it to an ALLOW-LIST (`toReaderLake`): a non-editor receives only the fields named in
`READER_LAKE_FIELDS`, so the safe default flips from "sent unless deleted" to "withheld unless named".
The allow-list carries every business field a reader receives today; the only difference is that the
incidental Mongo internals a raw `toJSON()` document exposes (`_id` and `__v`) are no longer emitted -
the reader still gets the `id` virtual. Dropping `_id`/`__v` is a deliberate, benign narrowing (a
bonus of the allow-list), and no consumer reads them: no client hook calls `GET /api/data-lakes/:id`.
So for a reader this is a refactor, not a meaningful behavior change.

Not a live-leak fix - there is no vulnerability to reproduce. The value is future leak-prevention plus
the three editor-path normalization fixes below.

## Changes

- **Allow-list redaction.** `redactLakeForActor` now returns the full document to an editor
  (creator/admin) - subject to the prompt normalization in Fixes 1-3 below - and the allow-listed
  subset to everyone else via `toReaderLake`, which only ever emits fields named in
  `READER_LAKE_FIELDS`. A hydrated document or a future stray key cannot leak through it.
- **Compile-time + runtime pin.** `READER_LAKE_FIELDS` is declared
  `as const satisfies readonly (keyof IDataLakeDocument)[]` (a typo or renamed field fails to
  compile), and a test asserts the served key set - so adding a field to `IDataLake` forces a
  reader-visibility decision instead of leaking it silently.
- **Return type narrowed.** `redactLakeForActor` / `redactLakesForActor` now return
  `IDataLakeDocument | ReaderDataLake`, threaded through `listArchivedDataLakes` /
  `listDeletedDataLakes`, so the type stops over-claiming fields the reader response no longer carries.
- **Fix 1 - null-safe blank check.** The prompt blank check is now `lake.systemPrompt?.trim()`; a
  `null` from a direct DB write or migration is treated as blank instead of throwing on `.trim()`.
- **Fix 2 - empty/blank editor prompt normalized as absent.** For an editor, an unset/`null`/empty/
  whitespace-only prompt is reported as absent (key dropped), matching the list projection
  (`toManageableConfig`) and `getDataLakePrompts`, so `GET /:id` and the list agree.
- **Fix 3 - padded editor prompt trimmed.** A padded-but-non-blank prompt is returned TRIMMED for an
  editor (a copy, source unmutated), so stored padding is not echoed only on this path. The document
  is still returned by identity in the common case (prompt absent or already trimmed).
- **Tests.** Added stranger-only-allow-listed-fields, empty-string and whitespace normalization,
  null-safety, padded-trim (copy, source unmutated), and the allow-list pin test.

## Guide for Testers

**No manual QA required - the automated suite is the verification.** This is a backend-only change in
`@bike4mind/services` with no UI and no user-visible surface, and no client hook calls
`GET /api/data-lakes/:id`, so there is no screen where the change is observable. A tester clicking
through the app sees identical behavior by design. The redaction is covered by
`dataLakeService.test.ts` (owner/admin identity, stranger gets only allow-listed fields, empty/
whitespace/null normalized to absent, padded-prompt trimmed, source unmutated, allow-list pin) and the
route wiring test `id-get-redaction.test.ts` - all green.

### Optional API-level spot-check

Only if you want to confirm at the endpoint (curl/Postman) - not required for sign-off:

1. As a NON-owner reading a PUBLISHED lake, call `GET /api/data-lakes/:id`. Expect the response to
   carry the public fields (name, slug, description, tags, counts, status, etc.) and to NOT contain
   `systemPrompt`.
2. As the lake OWNER or an admin, call the same endpoint on a lake that HAS a `systemPrompt`. Expect
   `systemPrompt` to be present and equal to the stored text.
3. As the OWNER of a lake whose `systemPrompt` is empty or whitespace-only, call the endpoint. Expect
   `systemPrompt` to be ABSENT from the response (not present-and-empty), matching `GET /api/data-lakes`.
4. As the OWNER of a lake whose `systemPrompt` has leading/trailing whitespace around real text, call
   the endpoint. Expect the prompt returned TRIMMED, matching what the list endpoint sends.
5. Confirm the `/archived` and `/deleted` management views still redact per lake for a non-owner org
   member (no `systemPrompt` on lakes they do not own).

### What NOT to test

- No UI flows - this PR touches no client component or route.
- No migrations, no schema changes, no new settings or env vars.

## Additional Information

- Follow-up to #1067 (which introduced `redactLakeForActor`); per #1112's References the field it
  guards (`systemPrompt`) landed in #980 and the injection layer in #1008. Closes #1112.
- Allow-list precedent already in the codebase: `browsePublicDataLakes` builds an explicit
  `PublicDataLakeSummary` for the same public audience. This PR removes the inconsistency of two
  functions serving overlapping audiences with opposite defaults.
- Reader business-field membership is deliberately unchanged from today's response (the only drop is
  the incidental `_id`/`__v` internals noted above). Deciding whether a non-editor should keep
  receiving `createdByUserId` / `organizationId` / `requiredUserTag` / `requiredEntitlement` is a
  separate behavior change and is intentionally out of scope here - the allow-list just makes that
  decision explicit and per-field for the next person.

## Developer Notes (Optional)

- **`READER_LAKE_FIELDS` + `ReaderDataLake`**: a reusable allow-list pattern for a
  serve-to-non-owner projection - `as const satisfies readonly (keyof T)[]` plus a runtime key-set
  test gives both compile-time and test-time protection against a new field leaking by default.
- **`toReaderLake`**: emits only named, defined fields, so it is safe against hydrated Mongoose
  documents (whose own-enumerable keys an object-rest spread would carry through).

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
