### PR TITLE
fix(users): merge preferences on update instead of replacing them

### DIFF
--- a/b4m-core/services/src/userService/adminUpdate.test.ts
+++ b/b4m-core/services/src/userService/adminUpdate.test.ts
@@ -125,3 +125,20 @@ describe('adminUpdateUser — audited credit adjustments', () => {
     expect(update.mock.calls[0][0].currentCredits).toBe(150);
   });
 });
+
+describe('adminUpdateUser - preferences merge', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('merges a partial preferences write instead of replacing the stored object', async () => {
+    const { adapters, update, target } = makeAdapters(100);
+    target.preferences = { language: 'en', showDebug: true, experimentalFeatures: { agentMode: true } };
+
+    await adminUpdateUser(ADMIN_ID, { id: TARGET_ID, preferences: { showDebug: false } }, adapters);
+
+    expect(update.mock.calls[0][0].preferences).toEqual({
+      language: 'en',
+      showDebug: false,
+      experimentalFeatures: { agentMode: true },
+    });
+  });
+});

--- a/b4m-core/services/src/userService/update.test.ts
+++ b/b4m-core/services/src/userService/update.test.ts
@@ -285,6 +285,91 @@ describe('applyBaseUserUpdates', () => {
   });
 });
 
+describe('applyBaseUserUpdates - preferences merge', () => {
+  const storedPreferences = {
+    language: 'en',
+    showDebug: true,
+    showHelp: false,
+    maxVisibleLines: 20,
+    favoriteTags: ['alpha', 'beta'],
+    optiSessionId: 'session-1',
+    fileBrowserViewMode: 'grid' as const,
+    experimentalFeatures: { agentMode: true, newComposer: false },
+  };
+
+  const makeUser = (preferences: IUserDocument['preferences']): IUserDocument =>
+    ({
+      id: 'user-prefs',
+      username: 'prefsuser',
+      name: 'Prefs User',
+      email: 'prefs@example.com',
+      password: undefined,
+      isAdmin: false,
+      tags: [],
+      level: 'DemoUser',
+      systemFiles: [],
+      preferences,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }) as unknown as IUserDocument;
+
+  it('keeps omitted stored keys when a partial preferences object is written', () => {
+    const result = applyBaseUserUpdates(makeUser(storedPreferences), { preferences: { showHelp: true } });
+
+    expect(result.preferences).toEqual({ ...storedPreferences, showHelp: true });
+  });
+
+  it('keeps other experimental flags when a partial experimentalFeatures object is written', () => {
+    const result = applyBaseUserUpdates(makeUser(storedPreferences), {
+      preferences: { experimentalFeatures: { newComposer: true } },
+    });
+
+    expect(result.preferences?.experimentalFeatures).toEqual({ agentMode: true, newComposer: true });
+    expect(result.preferences?.language).toBe('en');
+  });
+
+  it('produces the same result as a replace when the caller sends the full object', () => {
+    const fullObject = { ...storedPreferences, showDebug: false };
+
+    const result = applyBaseUserUpdates(makeUser(storedPreferences), { preferences: fullObject });
+
+    expect(result.preferences).toEqual(fullObject);
+  });
+
+  it('clears the whole object when preferences is explicitly null', () => {
+    const result = applyBaseUserUpdates(makeUser(storedPreferences), { preferences: null });
+
+    expect(result.preferences).toBeNull();
+  });
+
+  it('leaves stored preferences untouched when preferences is absent', () => {
+    const result = applyBaseUserUpdates(makeUser(storedPreferences), { name: 'Renamed' });
+
+    expect(result.preferences).toEqual(storedPreferences);
+  });
+
+  it('clears a single nullable sub-key when it is explicitly null', () => {
+    const result = applyBaseUserUpdates(makeUser(storedPreferences), { preferences: { optiSessionId: null } });
+
+    expect(result.preferences?.optiSessionId).toBeNull();
+    expect(result.preferences?.language).toBe('en');
+  });
+
+  it('replaces array-valued prefs wholesale rather than merging elements', () => {
+    const result = applyBaseUserUpdates(makeUser(storedPreferences), { preferences: { favoriteTags: ['gamma'] } });
+
+    expect(result.preferences?.favoriteTags).toEqual(['gamma']);
+  });
+
+  it('merges onto a user that has no preferences at all', () => {
+    const result = applyBaseUserUpdates(makeUser(undefined), {
+      preferences: { showHelp: true, experimentalFeatures: { agentMode: true } },
+    });
+
+    expect(result.preferences).toEqual({ showHelp: true, experimentalFeatures: { agentMode: true } });
+  });
+});
+
 describe('updateUser', () => {
   it('should update OAuth user without password', async () => {
     // Arrange

--- a/b4m-core/services/src/userService/update.ts
+++ b/b4m-core/services/src/userService/update.ts
@@ -1,5 +1,5 @@
 import bcrypt from 'bcryptjs';
-import { IUserDocument, IUserRepository } from '@bike4mind/common';
+import { IUserDocument, IUserPreferences, IUserRepository } from '@bike4mind/common';
 import { BadRequestError, secureParameters } from '@bike4mind/utils';
 import { z } from 'zod';
 
@@ -100,7 +100,28 @@ export function applyBaseUserUpdates(user: IUserDocument, params: UpdateUserPara
   return {
     ...user,
     ...params,
+    ...(params.preferences && { preferences: mergePreferences(user.preferences, params.preferences) }),
     updatedAt: new Date(),
+  };
+}
+
+/**
+ * `preferences` is merged onto the stored object, not replaced, so a partial write cannot
+ * silently drop keys the caller omitted. An explicit `null` still clears the whole object -
+ * that is the only way to remove individual keys. `experimentalFeatures` is merged one level
+ * deeper (mirrors the client in UserSettingsContext); nothing else in the schema nests.
+ */
+function mergePreferences(
+  stored: IUserPreferences | null | undefined,
+  incoming: NonNullable<UpdateUserParameters['preferences']>
+): IUserPreferences {
+  const base = stored ?? {};
+  return {
+    ...base,
+    ...incoming,
+    ...(incoming.experimentalFeatures !== undefined && {
+      experimentalFeatures: { ...base.experimentalFeatures, ...incoming.experimentalFeatures },
+    }),
   };
 }
 


### PR DESCRIPTION
# Pull Request

## Description

`PUT /api/users/[id]/update` destroyed preference keys that the request omitted.
`applyBaseUserUpdates` built the updated user with a shallow spread
(`{ ...user, ...params }`) and the result was written with a full-document update, so
`preferences` - a nested object - was replaced wholesale:

```
PUT /api/users/<id>/update  {"preferences":{"showSplashCards":true}}   -> 200 OK, 8 other prefs gone
```

The Zod allowlist and type checks were already correct (unknown keys stripped, type
violations 422); the only gap was that a *partial* `preferences` object was accepted and
silently dropped the omitted keys.

Not reachable from the app today - `UserSettingsContext.updatePreferences` does a
read-modify-write and sends the full object. The exposure is external API consumers and
future server-side callers, for whom replace-not-merge was undocumented.

Fixes #1317

## Changes

- `b4m-core/services/src/userService/update.ts`: `applyBaseUserUpdates` now routes
  `preferences` through a new `mergePreferences(stored, incoming)` helper instead of letting
  the plain spread replace it. Semantics, recorded in a doc comment on the helper:
  - `preferences` absent -> stored object untouched
  - `preferences: null` -> clears the whole object (preserved as the deliberate reset
    escape hatch, and the only way to remove keys now that merge is in place)
  - `preferences` object -> shallow merge over the stored object
  - `preferences.experimentalFeatures` -> merged one level deeper over the stored record, so
    a partial flag write does not wipe unrelated flags (mirrors what the client already does)
  - explicit `null` on a nullable sub-key still clears that key; array-valued prefs
    (`favoriteTags`, `favoriteModelIds`) are still replaced wholesale
- Tests: 8 cases in a new `applyBaseUserUpdates - preferences merge` describe in
  `update.test.ts`, plus 1 admin-path case in `adminUpdate.test.ts`.

No change was needed in `adminUpdate.ts` - `adminUpdateUserSchema` extends
`updateUserSchema` and the admin path calls `applyBaseUserUpdates`, so the merge covers both
the self-service and admin paths.

Backward compatible: the existing client sends the full object, and merging a full object
over the stored one yields the identical result.

## Guide for Testers

Backend-only change with no UI surface. Verify via the API.

1. Log in to `app.staging.bike4mind.com` and open Settings, then toggle a few preferences
   (for example theme, splash cards) so the user record has several preference keys set.
2. Grab the user id and an auth cookie/API key for that account.
3. Send a partial preferences write:
   `PUT /api/users/<id>/update` with body `{"preferences":{"showSplashCards":true}}`.
   Expected: `200 OK`.
4. Re-read the user (`GET /api/users/<id>` or reload Settings).
   Expected: `showSplashCards` is now `true` AND every other preference set in step 1 is
   still present. Before this change, they were gone.
5. Send a partial experimental-flag write:
   `{"preferences":{"experimentalFeatures":{"someFlag":true}}}`.
   Expected: `someFlag` is set and previously-enabled flags are unchanged.
6. Send `{"preferences":null}`.
   Expected: the whole preferences object is cleared (unchanged behavior).
7. Repeat step 3 against the admin update path for another user as an admin.
   Expected: same merge behavior.

### Regression Checks

1. Open Settings in the app and change several preferences through the UI.
   Expected: each change persists and no other preference is lost on reload. The client
   still sends the full object, so behavior here should be identical to before.
2. Toggle an experimental feature in the UI.
   Expected: it persists and other flags are unaffected.

### What NOT to test

No UI was added or changed; there is nothing new to look at visually.

## Additional Information

Out of scope, noted deliberately: a server-side merge also shrinks the documented
concurrent-toggle clobber race in `UserSettingsContext`, but only once the client actually
sends diff-only writes. Switching the client to send just the diff touches the optimistic
update path and the store write-through (which still needs the merged object for local
state), so it is a separate change with its own regression surface. This PR makes the server
merge correct, which is the prerequisite.

Verification:
- `pnpm --filter @bike4mind/services test` - 3068 passed
- `pnpm turbo:typecheck` - clean
- `pnpm lint:check` - clean
- `@bike4mind/database` - 1264 passed
- `@bike4mind/client` - 773 passed / 6 failed; all six are `*.e2e.test.ts` suites that time
  out against in-memory Mongo. Reproduced identically with these changes stashed, so
  pre-existing and unrelated (group invites, org transactions, API keys).
- Confirmed the new tests fail without the fix (4 failures across the two files) and pass
  with it.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
