### PR TITLE
perf(admin): cache a window of Analytics rows instead of one page

### DIFF
--- a/apps/client/app/components/admin/Analytics/exportUserActivity.ts
+++ b/apps/client/app/components/admin/Analytics/exportUserActivity.ts
@@ -1,9 +1,10 @@
 import type { CounterLogRow } from '@client/app/utils/userAPICalls';
 
 /**
- * Per-request page size, at the endpoint's own MAX_PAGE_SIZE. Every page re-runs the full
- * aggregation before $skip/$limit trims it, so the request count is what an export costs the
- * database: 5000 turns a 50k export into 10 round trips instead of 25.
+ * Per-request page size, at the endpoint's own MAX_PAGE_SIZE: 5000 turns a 50k export into 10
+ * round trips instead of 25. The server caches a window of the sorted result set that spans the
+ * whole export, so those trips share one aggregation - keep this at or below the server's
+ * MAX_CACHED_ROWS (server/analytics/userActivityCache.ts) or the tail pages fall out of it.
  */
 export const EXPORT_PAGE_SIZE = 5000;
 /** Hard ceiling on an export, so a broad filter can't page indefinitely. */

--- a/apps/client/pages/api/users/__tests__/counterLogs.paging.test.ts
+++ b/apps/client/pages/api/users/__tests__/counterLogs.paging.test.ts
@@ -66,6 +66,7 @@ vi.mock('@client/services/operationsModelService', () => ({
 }));
 
 import '@pages/api/users/counterLogs';
+import { MAX_CACHED_ROWS } from '@server/analytics/userActivityCache';
 
 const DATES = { startDate: '2026-07-21', endDate: '2026-07-28' };
 
@@ -92,16 +93,27 @@ describe('GET /api/users/counterLogs - user activity paging', () => {
   });
 
   it('returns one page plus the total instead of every matching row', async () => {
-    const { req, res } = mocks({ ...DATES, page: '2', limit: '10' });
+    const { req, res } = mocks({ ...DATES, page: '1', limit: '10' });
 
     await mockRefs.getHandler!(req, res);
 
     expect(res._getJSONData()).toEqual({
       logs: [{ date: '2026-07-28', counterName: 'Login' }],
       total: 42,
-      page: 2,
+      page: 1,
       limit: 10,
     });
+  });
+
+  it('slices the requested page out of the window it just materialized', async () => {
+    const rows = Array.from({ length: 30 }, (_, i) => ({ date: '2026-07-28', counterName: `c${i}` }));
+    mockRefs.facetResult = { rows, total: [{ value: 30 }] };
+    const { req, res } = mocks({ ...DATES, page: '3', limit: '10' });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(stageValue('$skip'), 'the window itself always starts at 0').toBe(0);
+    expect(res._getJSONData()).toMatchObject({ logs: rows.slice(20, 30), total: 30, page: 3 });
   });
 
   it('defaults to the first page, skipping nothing', async () => {
@@ -138,9 +150,23 @@ describe('GET /api/users/counterLogs - user activity paging', () => {
 
     await mockRefs.getHandler!(req, res);
 
-    expect(stageValue('$limit')).toBe(5000);
     expect(res._getJSONData().limit).toBe(5000);
+    // The window read ahead of the page is bounded too - it is held in Lambda memory and written
+    // to a single cache document.
+    expect(stageValue('$limit')).toBeLessThanOrEqual(MAX_CACHED_ROWS);
   });
+
+  it.each(['', 'not-a-date', '2026-13-01', '2026-02-30'])(
+    'rejects the date %j instead of widening the window to all time',
+    async (startDate: string) => {
+      // An unparseable date became an Invalid Date, which serializes to epoch 0 - so the query
+      // silently scanned the whole collection rather than the week the caller asked for.
+      const { req, res } = mocks({ ...DATES, startDate });
+
+      await expect(mockRefs.getHandler!(req, res)).rejects.toMatchObject({ statusCode: 400 });
+      expect(mockRefs.facetStages).toBeUndefined();
+    }
+  );
 
   it('rejects a non-positive page rather than skipping a negative number of rows', async () => {
     const { req, res } = mocks({ ...DATES, page: '0' });
@@ -157,13 +183,57 @@ describe('GET /api/users/counterLogs - user activity paging', () => {
     await expect(mockRefs.getHandler!(req, res)).rejects.toMatchObject({ statusCode: 400 });
   });
 
-  it('caches each page under its own key so page 2 cannot serve page 1', async () => {
+  it('shares one cache entry across the pages of a filter set', async () => {
+    // Page-scoped keys meant browsing N pages cost N full aggregations, because $skip/$limit only
+    // trims a result the pipeline has already materialized.
     const first = mocks({ ...DATES, page: '1', limit: '10' });
     await mockRefs.getHandler!(first.req, first.res);
     const second = mocks({ ...DATES, page: '2', limit: '10' });
     await mockRefs.getHandler!(second.req, second.res);
 
-    expect(mockRefs.cacheKeys[0]).not.toBe(mockRefs.cacheKeys[1]);
+    expect(mockRefs.cacheKeys[0]).toBe(mockRefs.cacheKeys[1]);
+  });
+
+  it('materializes a window past the requested page so later pages need no aggregation', async () => {
+    const { req, res } = mocks({ ...DATES, page: '1', limit: '10' });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(stageValue('$skip')).toBe(0);
+    expect(stageValue('$limit')).toBeGreaterThan(10);
+  });
+
+  it('slices a later page out of the cached window instead of re-aggregating', async () => {
+    const rows = Array.from({ length: 30 }, (_, i) => ({ date: '2026-07-28', counterName: `c${i}` }));
+    mockRefs.cached = { result: { rows, total: 30, truncated: false } };
+    const { req, res } = mocks({ ...DATES, page: '3', limit: '10' });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(mockRefs.facetStages, 'no aggregation should have run').toBeUndefined();
+    expect(res._getJSONData()).toMatchObject({ logs: rows.slice(20, 30), total: 30, page: 3 });
+  });
+
+  it('answers a page past the end of a fully cached result set without re-aggregating', async () => {
+    mockRefs.cached = { result: { rows: [{ date: '2026-07-28' }], total: 1, truncated: false } };
+    const { req, res } = mocks({ ...DATES, page: '9', limit: '10' });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(mockRefs.facetStages).toBeUndefined();
+    expect(res._getJSONData()).toMatchObject({ logs: [], total: 1 });
+  });
+
+  it('fetches just the page when it lies past a window the byte budget cut short', async () => {
+    // Re-materializing the window would return the same truncated prefix, so the page would never
+    // be reachable - and each attempt would pay for the larger fetch.
+    mockRefs.cached = { result: { rows: [{ date: '2026-07-28' }], total: 9000, truncated: true } };
+    const { req, res } = mocks({ ...DATES, page: '3', limit: '10' });
+
+    await mockRefs.getHandler!(req, res);
+
+    expect(stageValue('$skip')).toBe(20);
+    expect(stageValue('$limit')).toBe(10);
   });
 
   it('keeps two filter sets apart when a search term contains the key delimiter', async () => {
@@ -196,14 +266,14 @@ describe('GET /api/users/counterLogs - user activity paging', () => {
   });
 
   it('keeps the cached envelope shape when it serves a cache hit', async () => {
-    mockRefs.cached = { result: { rows: [{ date: '2026-07-27', counterName: 'Logout' }], total: 7 } };
+    mockRefs.cached = { result: { rows: [{ date: '2026-07-27', counterName: 'Logout' }], total: 1, truncated: false } };
     const { req, res } = mocks({ ...DATES, page: '1', limit: '10' });
 
     await mockRefs.getHandler!(req, res);
 
     expect(res._getJSONData()).toEqual({
       logs: [{ date: '2026-07-27', counterName: 'Logout' }],
-      total: 7,
+      total: 1,
       page: 1,
       limit: 10,
     });

--- a/apps/client/pages/api/users/__tests__/counterLogs.test.ts
+++ b/apps/client/pages/api/users/__tests__/counterLogs.test.ts
@@ -188,7 +188,7 @@ describe('GET /api/users/counterLogs (end-to-end, real model + Mongo)', () => {
     const { pipeline: stages } = buildUserActivityPipeline({
       startDate: '2026-07-21',
       endDate: '2026-07-21',
-      page: 1,
+      skip: 0,
       limit: 25,
     });
 

--- a/apps/client/pages/api/users/counterLogs.ts
+++ b/apps/client/pages/api/users/counterLogs.ts
@@ -26,6 +26,13 @@ import {
   DEFAULT_PAGE_SIZE,
   MAX_PAGE_SIZE,
 } from '@server/analytics/userActivityQuery';
+import {
+  asWindow,
+  buildWindow,
+  sliceWindow,
+  windowCoversPage,
+  windowRowsFor,
+} from '@server/analytics/userActivityCache';
 
 dayjs.extend(isSameOrBefore);
 
@@ -35,9 +42,23 @@ dayjs.extend(isSameOrBefore);
 // its Lambda budget is 60s, so it is sized to this route rather than copied from elsewhere.
 const AGGREGATION_MAX_TIME_MS = 45000;
 
+/**
+ * Both dates are interpolated into `new Date(`${date}T00:00:00.000Z`)`. Unvalidated, anything
+ * unparseable produced an Invalid Date, which serializes to epoch 0 and silently widened the
+ * window to all time - a far heavier query than the caller asked for. The refine rejects a
+ * well-shaped but unreal date (2026-02-30), which ISO parsing rejects outright.
+ */
+const IsoDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected a YYYY-MM-DD date')
+  .refine(value => {
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(value);
+  }, 'Not a calendar date');
+
 const CounterLogsQuerySchema = z.object({
-  startDate: z.string(),
-  endDate: z.string(),
+  startDate: IsoDateSchema,
+  endDate: IsoDateSchema,
   events: z
     .string()
     .optional()
@@ -184,20 +205,20 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
 
       return sendMaybeGzip(req, res, response);
     } else {
-      // Page-scoped key: the pre-pagination key omitted page/limit/search, so any change
-      // of page would have been served the first page's cached body.
+      // Filter-scoped, NOT page-scoped: the entry holds a window of the sorted result set, so
+      // every page of one filter set shares it and costs one aggregation between them
+      // (userActivityCache.ts). `limit` stays out of the key for the same reason - the window is
+      // sliced to whatever page size asks for it.
       //
       // Each segment is percent-encoded before joining. counterName/userEmail are free text,
       // so a raw ':' in one segment would otherwise shift the delimiter and let two different
       // filter sets collide - e.g. counterName='a:b' + userEmail='c' vs counterName='a' +
       // userEmail='b:c' - serving one admin the other's rows and total for the full hour.
       const cacheKey = [
-        'logs:v2',
+        'logs:v3',
         ...[
           startDate,
           endDate,
-          String(page),
-          String(limit),
           events?.join(',') ?? '',
           orgs?.join(',') ?? '',
           excludeOrgs?.join(',') ?? '',
@@ -207,17 +228,29 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
         ].map(encodeURIComponent),
       ].join(':');
 
+      const skip = (page - 1) * limit;
+
       const cachedResult = await cacheRepository.findByKey(cacheKey);
-      if (cachedResult) {
-        const cached = cachedResult.result as { rows: unknown[]; total: number };
-        return sendMaybeGzip(req, res, { logs: cached.rows, total: cached.total, page, limit });
+      const cachedWindow = asWindow(cachedResult?.result);
+      if (cachedWindow && windowCoversPage(cachedWindow, skip, limit)) {
+        return sendMaybeGzip(req, res, {
+          logs: sliceWindow(cachedWindow, skip, limit),
+          total: cachedWindow.total,
+          page,
+          limit,
+        });
       }
+
+      // A window that the byte budget already cut short cannot be grown by re-fetching it, so a
+      // page beyond it is fetched alone rather than re-materializing the same truncated window.
+      const windowRows = cachedWindow?.truncated ? null : windowRowsFor(skip, limit, cachedWindow?.rows.length);
 
       const { pipeline, facetStages } = buildUserActivityPipeline({
         startDate,
         endDate,
-        page,
-        limit,
+        // A cacheable window always starts at 0 so any earlier page can be sliced out of it.
+        skip: windowRows === null ? skip : 0,
+        limit: windowRows ?? limit,
         events,
         orgs,
         excludeOrgs,
@@ -236,21 +269,29 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
         allowDiskUse: true,
         maxTimeMS: AGGREGATION_MAX_TIME_MS,
       });
-      const rows = facet?.rows ?? [];
+      const fetched: unknown[] = facet?.rows ?? [];
       const total = facet?.total?.[0]?.value ?? 0;
 
-      // Cache the result with 1 hour expiry
+      if (windowRows === null) {
+        return sendMaybeGzip(req, res, { logs: fetched, total, page, limit });
+      }
+
+      const cacheEntry = buildWindow(fetched, total);
+
+      // Cache the window with 1 hour expiry
       try {
         await cacheRepository.createOrUpdate({
           key: cacheKey,
-          result: { rows, total },
+          result: cacheEntry,
           expiresAt: new Date(Date.now() + 3600000), // 1 hour from now
         });
       } catch (error) {
         console.error('Failed to cache logs: %s', error);
       }
 
-      return sendMaybeGzip(req, res, { logs: rows, total, page, limit });
+      // Sliced from what was fetched, not from the cache entry: the byte budget only bounds what is
+      // stored, and this page was materialized whether or not it survived the trim.
+      return sendMaybeGzip(req, res, { logs: fetched.slice(skip, skip + limit), total, page, limit });
     }
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/apps/client/server/analytics/userActivityCache.test.ts
+++ b/apps/client/server/analytics/userActivityCache.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  asWindow,
+  buildWindow,
+  sliceWindow,
+  windowCoversPage,
+  windowRowsFor,
+  CACHE_WINDOW_PAGES,
+  MAX_CACHED_ROWS,
+} from './userActivityCache';
+
+const makeWindow = (rowCount: number, total = rowCount, truncated = false) => ({
+  rows: Array.from({ length: rowCount }, (_, i) => ({ i })),
+  total,
+  truncated,
+});
+
+describe('windowRowsFor', () => {
+  it('reads ahead of the requested page so later pages need no second aggregation', () => {
+    expect(windowRowsFor(0, 25)).toBe(25 * CACHE_WINDOW_PAGES);
+  });
+
+  it('widens the window to reach a page beyond the read-ahead', () => {
+    const skip = 25 * CACHE_WINDOW_PAGES * 2;
+
+    expect(windowRowsFor(skip, 25)).toBe(skip + 25);
+  });
+
+  it('never shrinks a window a later page already paid for', () => {
+    // Without the floor, alternating between page 1 and a far page re-aggregates every time.
+    expect(windowRowsFor(0, 25, 4000)).toBe(4000);
+  });
+
+  it('caps the window at the row ceiling', () => {
+    expect(windowRowsFor(0, MAX_CACHED_ROWS)).toBe(MAX_CACHED_ROWS);
+  });
+
+  it('refuses to window a page past the ceiling, so it is fetched on its own', () => {
+    expect(windowRowsFor(MAX_CACHED_ROWS, 25)).toBeNull();
+  });
+
+  it('spans a whole CSV export in one window at the export page size', () => {
+    // The export walks pages of 5000 up to 50000 rows; every one of them must land in the window
+    // or the tail pages each pay for their own aggregation again.
+    expect(windowRowsFor(0, 5000)).toBe(MAX_CACHED_ROWS);
+    expect(windowRowsFor(45_000, 5000)).toBe(MAX_CACHED_ROWS);
+  });
+});
+
+describe('windowCoversPage', () => {
+  it('covers a page inside the cached prefix', () => {
+    expect(windowCoversPage(makeWindow(100, 900), 50, 25)).toBe(true);
+  });
+
+  it('does not cover a page past the cached prefix of a larger result set', () => {
+    expect(windowCoversPage(makeWindow(100, 900), 100, 25)).toBe(false);
+  });
+
+  it('covers a page past the end of a fully cached result set', () => {
+    // The empty slice is the right answer here, not a reason to re-run the aggregation.
+    expect(windowCoversPage(makeWindow(5), 100, 25)).toBe(true);
+  });
+
+  it('covers an empty result set', () => {
+    expect(windowCoversPage(makeWindow(0), 0, 25)).toBe(true);
+  });
+});
+
+describe('sliceWindow', () => {
+  it('returns the requested page', () => {
+    expect(sliceWindow(makeWindow(100), 50, 3)).toEqual([{ i: 50 }, { i: 51 }, { i: 52 }]);
+  });
+});
+
+describe('buildWindow', () => {
+  it('keeps the whole window when it fits the budget', () => {
+    const entry = buildWindow([{ a: 1 }, { a: 2 }], 2);
+
+    expect(entry).toEqual({ rows: [{ a: 1 }, { a: 2 }], total: 2, truncated: false });
+  });
+
+  it('trims to the longest prefix inside the budget and flags it', () => {
+    // The entry is one Mongo document, and an untrimmed window is what blew past the 16MB BSON
+    // limit before paging existed - a write that throws leaves the route uncached forever.
+    const rows = Array.from({ length: 10 }, (_, i) => ({ pad: 'x'.repeat(100), i }));
+
+    const entry = buildWindow(rows, 10, 400);
+
+    expect(entry.truncated).toBe(true);
+    expect(entry.rows.length).toBeGreaterThan(0);
+    expect(entry.rows.length).toBeLessThan(rows.length);
+    expect(entry.total, 'the total counts every matching row, not the cached ones').toBe(10);
+  });
+
+  it('measures UTF-8 bytes rather than characters', () => {
+    // A 3-byte-per-character metadata value must not be sized as if it were ASCII.
+    const rows = [{ v: '\u4e2d'.repeat(20) }];
+
+    expect(buildWindow(rows, 1, 40).truncated).toBe(true);
+  });
+});
+
+describe('asWindow', () => {
+  it('narrows a stored window', () => {
+    expect(asWindow({ rows: [{ a: 1 }], total: 9, truncated: true })).toEqual({
+      rows: [{ a: 1 }],
+      total: 9,
+      truncated: true,
+    });
+  });
+
+  it('defaults a missing truncated flag rather than treating the entry as unusable', () => {
+    expect(asWindow({ rows: [], total: 0 })?.truncated).toBe(false);
+  });
+
+  it.each([null, undefined, 'nope', {}, { rows: [] }, { rows: 'no', total: 1 }])(
+    'rejects the non-window cache payload %j',
+    (payload: unknown) => {
+      expect(asWindow(payload)).toBeNull();
+    }
+  );
+});

--- a/apps/client/server/analytics/userActivityCache.ts
+++ b/apps/client/server/analytics/userActivityCache.ts
@@ -1,0 +1,89 @@
+/**
+ * Window caching for GET /api/users/counterLogs.
+ *
+ * The User Activity aggregation costs ~8-9s and ~1.5GB on a 7-day production window, and the
+ * $skip/$limit at the end only trims a result the pipeline has already materialized. Caching one
+ * PAGE per key therefore made browsing N pages cost N full aggregations, and a CSV export - which
+ * walks the endpoint page by page - cost one per page.
+ *
+ * So the cache entry is a prefix of the sorted result set rather than a single page: one
+ * aggregation per filter set, sliced per page. Two bounds keep that safe:
+ *
+ *  - CACHE_MAX_BYTES, because the entry is one Mongo document and the 16MB BSON limit is exactly
+ *    what the old unpaginated cache write blew past.
+ *  - MAX_CACHED_ROWS, because the rows are held in Lambda memory before they are written.
+ *
+ * A page past either bound is fetched on its own and not cached, so the bounds cost efficiency,
+ * never correctness.
+ */
+
+/** Rows of a window kept in one cache entry. Sized to cover a whole CSV export in one pass. */
+export const MAX_CACHED_ROWS = 50_000;
+
+/**
+ * Byte budget for the cached rows. Well under Mongo's 16MB document limit: the measure below is
+ * of the JSON, and the same text as BSON with non-ASCII metadata can run somewhat larger.
+ */
+export const CACHE_MAX_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Pages a single aggregation reads ahead. Only a lower bound on the window - a request for a
+ * later page widens it to reach that page instead of paying for a second aggregation.
+ */
+export const CACHE_WINDOW_PAGES = 10;
+
+/** A cached prefix of the sorted result set, always starting at offset 0. */
+export interface UserActivityWindow {
+  rows: unknown[];
+  /** Rows matching the filter set, which is `rows.length` only when the whole set fits. */
+  total: number;
+  /** The byte budget cut this window short of what was fetched, so it cannot be grown by re-asking. */
+  truncated: boolean;
+}
+
+/**
+ * Rows to materialize so the window reaches `skip + limit`, or null when that page is past
+ * MAX_CACHED_ROWS and has to be fetched on its own.
+ *
+ * `floor` (an existing window's length) keeps a request for an early page from shrinking a window
+ * a later page already paid for, which would otherwise re-aggregate on every alternation.
+ */
+export function windowRowsFor(skip: number, limit: number, floor = 0): number | null {
+  const pageEnd = skip + limit;
+  if (pageEnd > MAX_CACHED_ROWS) return null;
+  return Math.min(Math.max(pageEnd, limit * CACHE_WINDOW_PAGES, floor), MAX_CACHED_ROWS);
+}
+
+/**
+ * Whether `window` can answer this page. `total <= rows.length` covers a page past the end of a
+ * fully-cached result set: the empty slice is the right answer, not a miss.
+ */
+export function windowCoversPage(window: UserActivityWindow, skip: number, limit: number): boolean {
+  return skip + limit <= window.rows.length || window.total <= window.rows.length;
+}
+
+/** The page `skip`/`limit` asked for, taken out of a window that covers it. */
+export function sliceWindow(window: UserActivityWindow, skip: number, limit: number): unknown[] {
+  return window.rows.slice(skip, skip + limit);
+}
+
+/** Builds the cache entry for a freshly fetched window, trimmed to the byte budget. */
+export function buildWindow(rows: unknown[], total: number, budgetBytes = CACHE_MAX_BYTES): UserActivityWindow {
+  let used = 0;
+  for (let i = 0; i < rows.length; i++) {
+    // +1 for the separating comma; the enclosing brackets are noise at this scale.
+    used += Buffer.byteLength(JSON.stringify(rows[i]) ?? 'null') + 1;
+    if (used > budgetBytes) {
+      return { rows: rows.slice(0, i), total, truncated: true };
+    }
+  }
+  return { rows, total, truncated: false };
+}
+
+/** Narrows a cache document's untyped `result` to a window, rejecting entries of any older shape. */
+export function asWindow(result: unknown): UserActivityWindow | null {
+  if (!result || typeof result !== 'object') return null;
+  const { rows, total } = result as Partial<UserActivityWindow>;
+  if (!Array.isArray(rows) || typeof total !== 'number') return null;
+  return { rows, total, truncated: (result as UserActivityWindow).truncated === true };
+}

--- a/apps/client/server/analytics/userActivityQuery.e2e.test.ts
+++ b/apps/client/server/analytics/userActivityQuery.e2e.test.ts
@@ -68,7 +68,7 @@ afterAll(async () => {
 
 describe('user activity pipeline against MongoDB', () => {
   it('groups per day, counter and user, and counts the repeats', async () => {
-    const { rows, total } = await run({ ...RANGE, page: 1, limit: 50 });
+    const { rows, total } = await run({ ...RANGE, skip: 0, limit: 50 });
 
     expect(total).toBe(5);
     const login = rows.find((r: any) => r.counterName === 'Login' && r.userEmail === 'ada@example.com');
@@ -76,15 +76,15 @@ describe('user activity pipeline against MongoDB', () => {
   });
 
   it('resolves the email through the user join', async () => {
-    const { rows } = await run({ ...RANGE, page: 1, limit: 50 });
+    const { rows } = await run({ ...RANGE, skip: 0, limit: 50 });
 
     expect(rows.map((r: any) => r.userEmail)).toContain('poy@example.com');
   });
 
   it('returns disjoint pages that add up to the total', async () => {
-    const first = await run({ ...RANGE, page: 1, limit: 2 });
-    const second = await run({ ...RANGE, page: 2, limit: 2 });
-    const third = await run({ ...RANGE, page: 3, limit: 2 });
+    const first = await run({ ...RANGE, skip: 0, limit: 2 });
+    const second = await run({ ...RANGE, skip: 2, limit: 2 });
+    const third = await run({ ...RANGE, skip: 4, limit: 2 });
 
     expect(first.rows).toHaveLength(2);
     expect(first.total).toBe(5);
@@ -95,20 +95,20 @@ describe('user activity pipeline against MongoDB', () => {
   });
 
   it('filters by counter name in Mongo', async () => {
-    const { rows, total } = await run({ ...RANGE, page: 1, limit: 50, counterName: 'logout' });
+    const { rows, total } = await run({ ...RANGE, skip: 0, limit: 50, counterName: 'logout' });
 
     expect(total).toBe(1);
     expect(rows[0].counterName).toBe('Logout');
   });
 
   it('filters by email in Mongo', async () => {
-    const { total } = await run({ ...RANGE, page: 1, limit: 50, userEmail: 'poy@' });
+    const { total } = await run({ ...RANGE, skip: 0, limit: 50, userEmail: 'poy@' });
 
     expect(total).toBe(1);
   });
 
   it('excludes an organization', async () => {
-    const { rows } = await run({ ...RANGE, page: 1, limit: 50, excludeOrgs: ['Personal'] });
+    const { rows } = await run({ ...RANGE, skip: 0, limit: 50, excludeOrgs: ['Personal'] });
 
     expect(rows).toHaveLength(4);
   });
@@ -116,7 +116,7 @@ describe('user activity pipeline against MongoDB', () => {
   it('filters on a metadata field', async () => {
     const { rows, total } = await run({
       ...RANGE,
-      page: 1,
+      skip: 0,
       limit: 50,
       metadataFilters: [{ field: 'source', operator: 'equals', value: 'cli' }],
     });
@@ -126,7 +126,7 @@ describe('user activity pipeline against MongoDB', () => {
   });
 
   it('ignores activity outside the requested range', async () => {
-    const { total } = await run({ startDate: '2026-07-24', endDate: '2026-07-24', page: 1, limit: 50 });
+    const { total } = await run({ startDate: '2026-07-24', endDate: '2026-07-24', skip: 0, limit: 50 });
 
     expect(total).toBe(1);
   });

--- a/apps/client/server/analytics/userActivityQuery.test.ts
+++ b/apps/client/server/analytics/userActivityQuery.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { buildUserActivityPipeline, parseMetadataFilters } from './userActivityQuery';
 
-const baseQuery = { startDate: '2026-07-21', endDate: '2026-07-28', page: 1, limit: 25 };
+const baseQuery = { startDate: '2026-07-21', endDate: '2026-07-28', skip: 0, limit: 25 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const stage = (pipeline: any[], name: string) => pipeline.find(s => Object.keys(s)[0] === name);
 
 describe('buildUserActivityPipeline - pagination', () => {
-  it('skips prior pages and limits the row facet to the page size', () => {
-    const { facetStages } = buildUserActivityPipeline({ ...baseQuery, page: 3, limit: 25 });
+  it('skips and limits the row facet to the window the caller asked for', () => {
+    const { facetStages } = buildUserActivityPipeline({ ...baseQuery, skip: 50, limit: 25 });
 
     expect(facetStages.rows).toEqual(expect.arrayContaining([{ $skip: 50 }, { $limit: 25 }]));
   });

--- a/apps/client/server/analytics/userActivityQuery.ts
+++ b/apps/client/server/analytics/userActivityQuery.ts
@@ -6,6 +6,10 @@
  * every match unpaginated, which reached ~17MB on production data and tripped Lambda's 6MB
  * response cap (413 -> 502).
  *
+ * Everything up to the facet is the expensive part (~8-9s on a 7-day production window), and it
+ * costs the same whether the facet returns 25 rows or 25,000. The route therefore asks for a
+ * whole window of rows and slices pages out of it - see userActivityCache.ts.
+ *
  * ROW UNIT: `metadata` is part of the group key, so two events that differ only in metadata
  * stay separate rows. The pre-pagination client merged them (per day/counter/user), so the
  * grid shows more, finer rows than it used to and `total` counts those finer rows. That is a
@@ -53,7 +57,9 @@ export function parseMetadataFilters(raw: string | undefined): MetadataFilter[] 
 export interface UserActivityQueryParams {
   startDate: string;
   endDate: string;
-  page: number;
+  /** Rows to skip before the returned window. The caller pages by moving this, not by re-sorting. */
+  skip: number;
+  /** Rows to return. Sized by the caller: one page for a deep page, a whole cache window otherwise. */
   limit: number;
   events?: string[];
   orgs?: string[];
@@ -123,7 +129,7 @@ export interface UserActivityPipeline {
 export function buildUserActivityPipeline({
   startDate,
   endDate,
-  page,
+  skip,
   limit,
   events,
   orgs,
@@ -201,7 +207,7 @@ export function buildUserActivityPipeline({
     // The email lives on the joined user, so this can only be matched after the join.
     ...(userEmail ? [{ $match: { userEmail: { $regex: escapeRegex(userEmail), $options: 'i' } } }] : []),
     // Sort before the facet: a $sort inside a $facet sub-pipeline is held to the 100MB
-    // in-memory limit. The tiebreak has to be TOTAL or a row can straddle or skip a page
+    // in-memory limit. The tiebreak has to be TOTAL or a row can straddle or skip a window
     // across the two facet executions - userEmail cannot do it, since every row whose join
     // missed shares the same '' fallback. Covering the whole group key (userId + metadata,
     // ordered by BSON comparison) makes the order unique, because the key is unique per row.
@@ -219,7 +225,7 @@ export function buildUserActivityPipeline({
 
   const facetStages: Record<string, any[]> = {
     rows: [
-      { $skip: (page - 1) * limit },
+      { $skip: skip },
       { $limit: limit },
       {
         $project: {


### PR DESCRIPTION
# Pull Request

## Description

Closes #1308.

The Analytics user-activity aggregation appends `$facet{rows,total}` after the whole `$match -> $addFields -> $group -> $convert -> $lookup -> $unwind -> $addFields -> $sort` chain, so `$skip`/`$limit` only trim an already-materialized result set. The expensive part (roughly 8-9s and over a gigabyte of working set on a 7-day production window) ran once per request, and the cache key included page and limit. Browsing N pages cost N full aggregations; a single CSV export, which walks the pages, cost 10.

This PR keeps the pipeline shape but changes what gets cached: the cache entry now holds a prefix (a "window") of the sorted result set, keyed on the filter set alone. Every page of a given filter set is served from one aggregation.

## Changes

- Add `apps/client/server/analytics/userActivityCache.ts` (with tests) holding the window logic:
  - `windowRowsFor(skip, limit, floor)` decides how many rows to materialize. It reads ahead `CACHE_WINDOW_PAGES` (10) pages, widens to reach a later page, and floors at an existing window's length so an early-page request cannot shrink a window a later page already paid for. Returns `null` past `MAX_CACHED_ROWS` (50000), sized so one CSV export at the 5000-row export page size fits in a single window.
  - `buildWindow` trims to the longest prefix that fits `CACHE_MAX_BYTES` (8MB, measured as UTF-8) and flags `truncated`. A cache entry is a single Mongo document, and the 16MB BSON limit is what the previous unpaginated cache write ran into.
  - `windowCoversPage` / `sliceWindow` serve a page out of a covering window; `total <= rows.length` covers a page past the end of a fully cached set.
- A page past the row ceiling, or past a window the byte budget cut short, is fetched on its own and left uncached. The bounds cost efficiency, never correctness.
- Cache key version bumped to `logs:v3`; page and limit dropped from the key.
- `buildUserActivityPipeline` now takes `skip`/`limit` instead of `page`/`limit`, since callers ask for windows rather than pages.
- Validate `startDate`/`endDate` with a new ISO date schema (`YYYY-MM-DD` plus a refine that the date is real, so `2026-02-30` is rejected). Previously an unparseable value became an `Invalid Date`, serialized to epoch 0, and silently widened the window to all time.

Effect: browsing 10 pages at the default page size costs 1 aggregation instead of 10, and a CSV export's 10 requests share 1 aggregation. The export path is the only one that materializes the full 50k window, and it previously did 10x that work, so it is strictly better.

Deliberately out of scope: no single-pass streaming export endpoint (the paged walk now shares one aggregation, which was the actual cost); no `explain()` re-measurement of the `$lookup` (needs production data; the existing no-`hint` comment records the last measurement); #1307 is untouched and cuts this further on its own.

## Guide for Testers

Backend/perf change to an admin-only endpoint. The visible behavior of the Analytics page should be unchanged apart from being faster.

1. Log in as an admin at `app.staging.bike4mind.com`.
2. Navigate: Sidebar -> Admin -> Analytics.
3. Set the date range to the last 7 days and apply it. Expected: the user activity table loads with rows; note the load time for the first page.
4. Click through to page 2, then 3, then 4. Expected: each page loads noticeably faster than page 1 (they are served from the cached window), and the rows are correct and non-overlapping - the last row of page 1 is not repeated at the top of page 2.
5. Page back to page 1. Expected: same rows as the first time you saw page 1.
6. Change the date range (e.g. last 30 days) and apply. Expected: rows refresh for the new range; page 1 may again take the full load time since this is a different filter set.
7. Apply a user or organization filter if the page offers one. Expected: rows narrow to the filter, and paging within the filtered set is fast.
8. Export the table to CSV. Expected: the download completes and the row count matches the total shown in the UI, with no duplicated or missing rows at the 5000-row page boundaries.

Invalid-date handling:

9. Call the endpoint directly with a bad date, e.g. `GET /api/users/counterLogs?startDate=2026-02-30&endDate=2026-08-01`. Expected: a 400 validation error, not a 200 with all-time data.
10. Repeat with `startDate=not-a-date`. Expected: a 400 validation error.

### Regression Checks

- Row totals shown in the UI match what the same date range reported before this change.
- Sort order is unchanged (same ordering as before on the same filter set).
- Paging past the end of the result set returns an empty page rather than an error.

### What NOT to test

- No UI layout or styling changed; no need to check responsiveness or theming.
- No schema or migration changes.

## Additional Information

Verification run locally:

- `pnpm turbo:typecheck` clean, `pnpm lint:check` clean.
- `@bike4mind/client` analytics + counterLogs surface: 139 tests pass (unit, mocked-handler paging, real-Mongo e2e).
- `@bike4mind/database`: 1409 pass.
- On a full `@bike4mind/client` run, 6 unrelated `*.e2e.test.ts` files (api-keys, group invites, embed spend cap) time out under parallel mongo-memory-server startup on this machine. They pass in isolation both with and without this change, and none of them touch the files changed here.

## Developer Notes (Optional)

- **Reusable pattern**: `userActivityCache.ts` is a pure module - no Mongo, no request context - so the window arithmetic (read-ahead, floor, byte budget, page slicing) is unit-testable on its own and can be reused for any other paged aggregation that is expensive to run but cheap to slice.
- **Architecture decision**: caching a prefix of the result set rather than a page trades one bounded write (8MB / 50k rows) for eliminating the per-page re-aggregation. The bounds are the escape hatch: anything outside them falls back to an uncached single-page fetch, so correctness never depends on the cache being able to hold the data.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI change
- [ ] I have made corresponding changes to the documentation (if applicable) - n/a
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
