### PR TITLE
fix(files): show the tag's real file count in the Edit Tag preview chip

### DIFF
--- a/apps/client/app/components/Tag/Form.test.tsx
+++ b/apps/client/app/components/Tag/Form.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { TagType } from '@bike4mind/common';
+import type { IFileTag } from '@bike4mind/common';
+import TagForm from './Form';
+
+// The pickers pull in emoji-picker-react and dropdown chrome irrelevant to
+// the preview card under test
+vi.mock('../common/fields/ColorPicker', () => ({ default: () => null }));
+vi.mock('../common/fields/EmojiPicker', () => ({ default: () => null }));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const makeFileTag = (overrides: Partial<IFileTag>): IFileTag =>
+  ({
+    id: 'tag-1',
+    type: TagType.FILE,
+    name: 'invoices',
+    icon: '😇',
+    color: '#185EA5',
+    fileCount: 0,
+    ...overrides,
+  }) as IFileTag;
+
+describe('TagForm preview file count', () => {
+  it('shows the tag file count when editing an existing tag', () => {
+    render(
+      <TestWrapper>
+        <TagForm data={makeFileTag({ fileCount: 4 })} onSubmit={vi.fn()} />
+      </TestWrapper>
+    );
+    expect(screen.getByTestId('tag-form-preview-file-count').textContent).toBe('📁 4 files');
+  });
+
+  it('singularizes a count of one', () => {
+    render(
+      <TestWrapper>
+        <TagForm data={makeFileTag({ fileCount: 1 })} onSubmit={vi.fn()} />
+      </TestWrapper>
+    );
+    expect(screen.getByTestId('tag-form-preview-file-count').textContent).toBe('📁 1 file');
+  });
+
+  it('shows 0 files in create mode, where the tag does not exist yet', () => {
+    render(
+      <TestWrapper>
+        <TagForm onSubmit={vi.fn()} />
+      </TestWrapper>
+    );
+    expect(screen.getByTestId('tag-form-preview-file-count').textContent).toBe('📁 0 files');
+  });
+});

--- a/apps/client/app/components/Tag/Form.tsx
+++ b/apps/client/app/components/Tag/Form.tsx
@@ -1,4 +1,4 @@
-import { ITag } from '@bike4mind/common';
+import { ITag, TagType } from '@bike4mind/common';
 import { colorPalettes, emojis, shades } from '@client/app/constants/tools';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Casino } from '@mui/icons-material';
@@ -60,6 +60,9 @@ const TagForm: FC<{
 
   // Pre-select a random inspiration item if creating a new tag
   const initialInspiration = !data ? inspirationItems[0] : null;
+
+  // Only file tags carry a count; create mode (no data) correctly previews 0
+  const fileCount = data?.type === TagType.FILE ? data.fileCount : 0;
 
   const {
     control,
@@ -151,13 +154,14 @@ const TagForm: FC<{
           </Typography>
           <Typography
             level="body-xs"
+            data-testid="tag-form-preview-file-count"
             sx={{
               color: 'fileBrowser.createTag.previewTextSecondaryColor',
               fontWeight: '400',
               fontSize: '11px',
             }}
           >
-            📁 0 files
+            📁 {fileCount} {fileCount === 1 ? 'file' : 'files'}
           </Typography>
         </Box>
       </Box>


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

Before screenshots are on #1154: the Edit Tag dialog chip reads `📁 0 files` for a tag the Tag Manager panel behind it counts at `(4)`.

After:
<img width="411" height="163" alt="image" src="https://github.com/user-attachments/assets/948d7ff2-d64c-42fa-95f6-fe505dc509d6" />

## Description

The Edit Tag dialog (Files Manager -> List -> Tag Manager -> tag row menu -> Edit) shows a preview card with a file-count chip that always read `📁 0 files`, whatever the tag's real count. The root cause is blunter than a wiring bug: the chip in the shared `TagForm` component was the hardcoded JSX literal `📁 0 files`, with no way to receive a count at all.

The fix derives the count from the `data` prop the edit call site already passes. Since that tag object comes from `GET /api/files/tags` (`listFileTags`), its `fileCount` is the same recomputed aggregate that #1132/#1208 standardized the other four surfaces on — so the chip, the panel badge, the Manage Tags dialog, the Tags tab card, and the filtered list now agree by construction, with no new fetch. Create mode passes no `data` and keeps its correct `0 files`.

Fixes #1154. Part of epic #1200.

## Changes

- `apps/client/app/components/Tag/Form.tsx`: derive `fileCount` from the `ITag` union discriminant (`data?.type === TagType.FILE ? data.fileCount : 0`), render it in the preview chip with singular/plural handling (`1 file` / `N files`), and add `data-testid="tag-form-preview-file-count"`.
- `apps/client/app/components/Tag/Form.test.tsx` (new, first test for this component): edit mode shows the real count (`📁 4 files`), a count of one singularizes (`📁 1 file`), and create mode still shows `📁 0 files`.

## Guide for Testers

On the PR preview environment (URL appears as a bot comment once a maintainer triggers a deploy):

1. Sign in as a test user (e.g. `qa-admin-e2e@test.com`, OTC login). Expected: the app loads to the main workspace.
2. If the account has no tagged files: open **Files Manager** (sidebar) -> **Upload Files** -> **From device** and upload 3 small files. Expected: the files appear in the list.
3. Open **Files Manager** -> **List** tab -> click **Tag Manager** in the toolbar. Expected: the Tag Manager panel opens.
4. Click the panel's **+** button, name the tag `pr-check-alpha`, and save. Expected: the tag appears in the panel with `(0)`.
5. Apply the tag to 2 of the files via each file's row menu -> **Manage Tags**. Expected: the panel now shows `pr-check-alpha (2)`.
6. Hover the tag row, click its **⋮** menu, choose **Edit**. Expected: the Edit Tag dialog opens and the preview chip reads `📁 2 files` — matching the panel's `(2)`, not `0`.
7. Apply the tag to a 3rd file, reopen **Edit**. Expected: the chip reads `📁 3 files`.
8. Create a second tag applied to exactly 1 file and open **Edit** on it. Expected: the chip reads `📁 1 file` (singular).
9. Open the **Create a New Tag** dialog (Tag Manager **+**). Expected: the preview chip reads `📁 0 files` — correct for a tag that does not exist yet.

Regression Checks:

- The four surfaces fixed by #1132/#1208 are untouched and should keep agreeing with each other and with the Edit chip: Tag Manager panel badge, Manage Tags dialog counts, Tags tab card, and the filtered file list total.
- Saving from the Edit dialog (rename/recolor -> **Update Tag**) still persists correctly and does not alter any count.

## Additional Information

- Epic #1200 sequenced #1179 (count semantics) ahead of this; #1179 was closed by #1208, so this closes out the fifth and last count surface QA flagged.
- Deliberately reads the recomputed aggregate already on the client's tag objects, not the persisted `FileTag.fileCount` column — that column is slated for removal in #1180 and nothing here would block it.
- `FileBrowserTagList` feeds a tag into the same form and had the same symptom, but it appears to be dead code (no importers repo-wide); the shared-component fix covers it regardless, and it was otherwise left untouched.

## Developer Notes (Optional)

- `Form.test.tsx` establishes the testing pattern for `TagForm`: MUI Joy theme wrapper (the preview card uses `fileBrowser.createTag.*` palette tokens) plus stub mocks for the color/emoji pickers to keep `emoji-picker-react` out of the render.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
