### PR TITLE
fix(client): minimize the docked chat on close instead of switching to float

### DIFF
--- a/apps/client/app/components/Session/DockedChatPanel.test.tsx
+++ b/apps/client/app/components/Session/DockedChatPanel.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes/themePrimitives';
+import useSessionLayout, { setSessionLayout } from '@client/app/hooks/useSessionLayout';
+import DockedChatPanel from './DockedChatPanel';
+
+// The control cluster reaches SessionsContext/react-query through useCopySessionMarkdown,
+// which is irrelevant to the header's minimize wiring.
+vi.mock('./ChatPanelControls', () => ({ default: () => null }));
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+describe('DockedChatPanel', () => {
+  beforeEach(() => {
+    setSessionLayout({ layout: 'dockRight', floatingChatMinimized: false, previousLayout: undefined });
+  });
+
+  it('minimizes to the AI Chat launcher instead of switching to the floating window', () => {
+    render(
+      <Wrapper>
+        <DockedChatPanel>chat</DockedChatPanel>
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('docked-chat-close'));
+
+    const state = useSessionLayout.getState();
+    expect(state.floatingChatMinimized).toBe(true);
+    expect(state.layout).toBe('floatingChat');
+  });
+
+  it('records the dock it was minimized from so the float window can close back to it', () => {
+    setSessionLayout({ layout: 'dockBottom' });
+    render(
+      <Wrapper>
+        <DockedChatPanel>chat</DockedChatPanel>
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('docked-chat-close'));
+
+    expect(useSessionLayout.getState().previousLayout).toBe('dockBottom');
+  });
+});

--- a/apps/client/app/components/Session/DockedChatPanel.tsx
+++ b/apps/client/app/components/Session/DockedChatPanel.tsx
@@ -16,9 +16,16 @@ interface DockedChatPanelProps {
 const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActions, title }) => {
   const layout = useSessionLayout(s => s.layout);
 
-  const handleClose = useCallback(() => {
-    setSessionLayout({ layout: 'floatingChat' });
-  }, []);
+  // Dismiss the panel down to the bottom-right "AI Chat" launcher (the minimized
+  // FloatingChatWindow pill) rather than opening the floating window. previousLayout is
+  // recorded so expanding and then closing the float window returns to this dock.
+  const handleMinimize = useCallback(() => {
+    setSessionLayout({
+      layout: 'floatingChat',
+      floatingChatMinimized: true,
+      previousLayout: layout === 'dockRight' || layout === 'dockBottom' ? layout : undefined,
+    });
+  }, [layout]);
 
   return (
     <Box
@@ -67,12 +74,12 @@ const DockedChatPanel: React.FC<DockedChatPanelProps> = ({ children, headerActio
             activeLayout={layout === 'dockRight' || layout === 'dockBottom' ? layout : undefined}
             showFloat
           />
-          <Tooltip title="Close" disableInteractive>
+          <Tooltip title="Minimize" disableInteractive>
             <IconButton
               size="sm"
               variant="plain"
               color="neutral"
-              onClick={handleClose}
+              onClick={handleMinimize}
               data-testid="docked-chat-close"
               sx={{ '--IconButton-size': '28px' }}
             >


### PR DESCRIPTION
## Description

Closes #847.

Clicking the docked chat panel's close (X) did not dismiss the panel — it called
`setSessionLayout({ layout: 'floatingChat' })`, so "close" silently became "change
layout to floating chat". The X now minimizes: the docked panel is dismissed and
the bottom-right "AI Chat" launcher pill is left in its place, which is the same
end state as the existing minimize action.

## Changes

- `DockedChatPanel.tsx`: `handleClose` becomes `handleMinimize`. It sets
  `layout: 'floatingChat'` **plus** `floatingChatMinimized: true`, so what renders is
  `FloatingChatWindow`'s minimized branch (the bottom-right launcher pill), never the
  floating chat window.
- It also records `previousLayout` as the dock it came from (`dockRight` / `dockBottom`),
  so the float window's own Close returns to that dock — matching the existing Float
  button behavior.
- Tooltip changed from "Close" to "Minimize", since the button no longer closes. Icon
  and `data-testid="docked-chat-close"` are unchanged.
- New `DockedChatPanel.test.tsx` (2 tests) pinning the minimized end state and the
  recorded `previousLayout`.

## Guide for Testers

1. Open `app.staging.bike4mind.com` and sign in.
2. Open a chat session so the chat UI is visible.
3. Dock the chat to the right (chat panel controls -> dock right). Expected: the chat
   renders as a panel docked to the right edge.
4. Click the X in the docked panel's header. Expected: the docked panel disappears and a
   small "AI Chat" launcher pill appears in the bottom-right corner. Expected: the
   floating chat window does NOT open.
5. Hover the X before clicking (repeat step 3 first). Expected: the tooltip reads
   "Minimize", not "Close".
6. Click the bottom-right "AI Chat" pill. Expected: the floating chat window expands.
   (Known/unchanged behavior — see Additional Information.)
7. Repeat steps 3-4 with the chat docked to the bottom instead of the right. Expected:
   the same result — panel dismissed, launcher pill in the bottom-right.

### Regression Checks

1. With the chat docked, click the Float button (not the X). Expected: the floating chat
   window opens as before.
2. In that floating window, click its Close. Expected: the chat returns to the dock it
   came from.

### What NOT to test

Nothing backend — this is a client-only layout-state change.

## Additional Information

Residual behavior, deliberately left alone: clicking the launcher pill expands the
*floating* window rather than restoring the dock. Restoring the dock on expand would
mean keying off `previousLayout`, which is shared with the Float button path, and that
would change that unrelated flow. Happy to follow up if pill -> restore dock is the
desired UX.

Verification: `pnpm turbo:typecheck` (40/40 pass), `pnpm lint:check` clean,
`vitest run app/components/Session app/hooks` = 853 passed / 35 skipped.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
