### PR TITLE
fix(ai): degrade to another TTS provider instead of hard-failing

### DIFF
--- a/apps/client/app/components/Files/GenerateAudio/useGenerateAudio.test.ts
+++ b/apps/client/app/components/Files/GenerateAudio/useGenerateAudio.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { AxiosError, AxiosHeaders } from 'axios';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    post: vi.fn(),
+    toastInfo: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+    getState: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    info: (...a: unknown[]) => mocks.toastInfo(...a),
+    error: (...a: unknown[]) => mocks.toastError(...a),
+    success: (...a: unknown[]) => mocks.toastSuccess(...a),
+  },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { post: (...a: unknown[]) => mocks.post(...a) },
+}));
+
+vi.mock('@client/app/stores/useAudioGenSettings', () => ({
+  useAudioGenSettings: { getState: () => mocks.getState() },
+}));
+
+import { useGenerateAudio } from './useGenerateAudio';
+
+// A 4xx from the route arrives as an axios error carrying the JSON error body.
+const axiosFailure = (status: number, data: unknown) =>
+  new AxiosError('Request failed', 'ERR_BAD_REQUEST', undefined, null, {
+    status,
+    statusText: '',
+    data,
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  });
+
+const generate = async (text = 'hello') => {
+  const { result } = renderHook(() => useGenerateAudio());
+  await act(async () => {
+    await result.current.generate(text);
+  });
+  return result;
+};
+
+beforeEach(() => {
+  Object.values(mocks).forEach(m => m.mockReset());
+  mocks.getState.mockReturnValue({ mode: 'tts', ttsProvider: 'openai', voice: '', format: 'mp3' });
+  URL.createObjectURL = vi.fn(() => 'blob:audio');
+  URL.revokeObjectURL = vi.fn();
+});
+
+describe('useGenerateAudio provider substitution', () => {
+  it('tells the user which provider stood in, since the voice will not be the one selected', async () => {
+    mocks.post.mockResolvedValue({
+      data: { audio: 'AAA=', format: 'mp3', contentType: 'audio/mpeg', provider: 'elevenlabs', fallbackFrom: 'openai' },
+    });
+
+    await generate();
+
+    expect(mocks.toastInfo).toHaveBeenCalledWith(
+      'OpenAI was unavailable, so this audio was generated with ElevenLabs.'
+    );
+  });
+
+  it('stays quiet about providers when the requested one was used', async () => {
+    mocks.post.mockResolvedValue({ data: { audio: 'AAA=', format: 'mp3', contentType: 'audio/mpeg' } });
+
+    await generate();
+
+    expect(mocks.toastInfo).not.toHaveBeenCalled();
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Audio generated.');
+  });
+
+  it('advises switching provider when a configured key was rejected and nothing could cover for it', async () => {
+    mocks.post.mockRejectedValue(
+      axiosFailure(401, {
+        error: 'TTS request rejected by the openai provider',
+        provider: 'openai',
+        errorCode: 'provider_rejected',
+      })
+    );
+
+    await generate();
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'TTS request rejected by the openai provider. Try a different provider in the audio settings.'
+    );
+  });
+
+  it('keeps the ask-your-admin message when no provider is configured at all', async () => {
+    mocks.post.mockRejectedValue(
+      axiosFailure(401, { error: 'OpenAI API key not configured', errorCode: 'provider_not_configured' })
+    );
+
+    await generate();
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'No provider API key is configured. Ask your administrator to set one up.'
+    );
+  });
+});

--- a/apps/client/app/components/Files/GenerateAudio/useGenerateAudio.ts
+++ b/apps/client/app/components/Files/GenerateAudio/useGenerateAudio.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
+import { VOICE_VENDOR_LABELS, type VoiceGenerationVendor } from '@bike4mind/common';
 import { api } from '@client/app/contexts/ApiContext';
 import { getErrorMessage } from '@client/app/utils/error';
 import { useAudioGenSettings } from '@client/app/stores/useAudioGenSettings';
@@ -24,6 +25,9 @@ interface TtsBase64Response {
   fabFileId?: string;
   fileUrl?: string;
   saveSkippedReason?: 'storage_limit' | 'file_too_large' | 'error';
+  /** Present only when the selected provider was unusable and another stood in. */
+  provider?: VoiceGenerationVendor;
+  fallbackFrom?: VoiceGenerationVendor;
 }
 
 const SAVE_SKIPPED_MESSAGES: Record<NonNullable<TtsBase64Response['saveSkippedReason']>, string> = {
@@ -153,6 +157,16 @@ export function useGenerateAudio() {
             contentType: data.contentType,
           });
 
+          // The server substituted a provider, so the voice will not be the one
+          // selected. Say so before the outcome toast rather than letting an
+          // unexplained voice change look like a bug.
+          if (data.fallbackFrom && data.provider) {
+            toast.info(
+              `${VOICE_VENDOR_LABELS[data.fallbackFrom]} was unavailable, so this audio was generated with ` +
+                `${VOICE_VENDOR_LABELS[data.provider]}.`
+            );
+          }
+
           if (data.saved === true) {
             refreshFiles();
             toast.success('Audio generated and saved to your Files.');
@@ -212,6 +226,11 @@ export function useGenerateAudio() {
 
         if (parsed.status === 413) {
           toast.error('The generated audio is too large to return. Try shorter text.');
+        } else if (parsed.errorCode === 'provider_rejected') {
+          // A key is configured but the provider refused it, and no other
+          // provider could cover for it: switching providers is the one thing
+          // the user can act on themselves.
+          toast.error(`${parsed.message}. Try a different provider in the audio settings.`);
         } else if (parsed.status === 401) {
           toast.error('No provider API key is configured. Ask your administrator to set one up.');
         } else if (parsed.status === 402 || parsed.errorCode === 'insufficient_credits') {

--- a/apps/client/app/components/Session/AISettings/AudioGenerationSettings.tsx
+++ b/apps/client/app/components/Session/AISettings/AudioGenerationSettings.tsx
@@ -4,16 +4,12 @@ import GraphicEqIcon from '@mui/icons-material/GraphicEq';
 import {
   AVAILABLE_TTS_VOICES,
   supportedVoiceGenerationVendor,
+  VOICE_VENDOR_LABELS,
   VOICE_VENDOR_SUPPORTED_FORMATS,
   type VoiceGenerationVendor,
   type VoiceOutputFormat,
 } from '@bike4mind/common';
 import { useAudioGenSettings, type AudioGenMode } from '@client/app/stores/useAudioGenSettings';
-
-const PROVIDER_LABELS: Record<VoiceGenerationVendor, string> = {
-  openai: 'OpenAI',
-  elevenlabs: 'ElevenLabs',
-};
 
 const PROVIDERS = supportedVoiceGenerationVendor.options;
 
@@ -101,7 +97,7 @@ export const AudioGenerationSettings: React.FC<{ mode?: AudioGenMode }> = ({ mod
         >
           {PROVIDERS.map(provider => (
             <Option key={provider} value={provider}>
-              {PROVIDER_LABELS[provider]}
+              {VOICE_VENDOR_LABELS[provider]}
             </Option>
           ))}
         </Select>

--- a/apps/client/pages/api/ai/__tests__/tts.test.ts
+++ b/apps/client/pages/api/ai/__tests__/tts.test.ts
@@ -11,10 +11,9 @@ const { mocks, InsufficientTtsCreditsError, TtsProviderNotConfiguredError, Unpro
       TtsProviderNotConfiguredError,
       UnprocessableEntityError,
       mocks: {
-        resolveTtsProvider: vi.fn(),
+        synthesizeTts: vi.fn(),
         assertTtsCreditsAvailable: vi.fn(),
         deductTtsCredits: vi.fn(),
-        synthesize: vi.fn(),
         exceedsTtsResponseLimit: vi.fn(),
         persistGeneratedAudio: vi.fn(),
       },
@@ -36,13 +35,18 @@ vi.mock('@bike4mind/common', () => ({
   VOICE_VENDOR_SUPPORTED_FORMATS: { openai: ['mp3', 'wav'], elevenlabs: ['mp3', 'pcm', 'opus'] },
 }));
 
-vi.mock('@bike4mind/utils', () => ({
-  aiVoiceService: () => ({ synthesize: (...a: unknown[]) => mocks.synthesize(...a) }),
-}));
-
 vi.mock('@server/utils/resolveTtsProvider', () => ({
-  resolveTtsProvider: (...a: unknown[]) => mocks.resolveTtsProvider(...a),
   TtsProviderNotConfiguredError,
+}));
+// The provider-selection + fallback loop is covered in synthesizeTts.test.ts;
+// here it is a seam so the route's own branching is what's under test.
+vi.mock('@server/utils/synthesizeTts', () => ({
+  synthesizeTts: (...a: unknown[]) => mocks.synthesizeTts(...a),
+  upstreamStatus: (error: unknown) => (error as { status?: number })?.status,
+  isCredentialRejection: (error: unknown) => {
+    const status = (error as { status?: number })?.status;
+    return status === 401 || status === 403;
+  },
 }));
 vi.mock('@server/utils/deductTtsCredits', () => ({
   assertTtsCreditsAvailable: (...a: unknown[]) => mocks.assertTtsCreditsAvailable(...a),
@@ -75,18 +79,19 @@ const run = (
   };
 };
 
-const okSynthesis = () =>
-  mocks.synthesize.mockResolvedValue({
-    audio: Buffer.from([1, 2, 3]),
-    contentType: 'audio/mpeg',
-    format: 'mp3',
-    model: 'tts-1',
-    characters: 5,
-  });
+const synthesisResult = () => ({
+  audio: Buffer.from([1, 2, 3]),
+  contentType: 'audio/mpeg',
+  format: 'mp3',
+  model: 'tts-1',
+  characters: 5,
+});
+
+const okSynthesis = (vendor = 'openai', fallbackFrom?: string) =>
+  mocks.synthesizeTts.mockResolvedValue({ vendor, result: synthesisResult(), fallbackFrom });
 
 beforeEach(() => {
   Object.values(mocks).forEach(m => m.mockReset());
-  mocks.resolveTtsProvider.mockResolvedValue({ apiKey: 'key', voice: 'alloy' });
   mocks.assertTtsCreditsAvailable.mockResolvedValue(undefined);
   mocks.deductTtsCredits.mockResolvedValue(undefined);
   mocks.exceedsTtsResponseLimit.mockReturnValue(false);
@@ -103,16 +108,15 @@ describe('POST /api/ai/tts', () => {
   it('rejects an unsupported (vendor, format) pair with 422 before any provider cost', async () => {
     const { promise } = run({ text: 'hi', provider: 'elevenlabs', format: 'wav' });
     await expect(promise).rejects.toBeInstanceOf(UnprocessableEntityError);
-    expect(mocks.resolveTtsProvider).not.toHaveBeenCalled();
-    expect(mocks.synthesize).not.toHaveBeenCalled();
+    expect(mocks.synthesizeTts).not.toHaveBeenCalled();
   });
 
-  it('returns 401 when the provider is not configured', async () => {
-    mocks.resolveTtsProvider.mockRejectedValue(new TtsProviderNotConfiguredError('no key'));
+  it('returns 401 with an actionable code when no provider is configured', async () => {
+    mocks.synthesizeTts.mockRejectedValue(new TtsProviderNotConfiguredError('no key'));
     const { res, promise } = run({ text: 'hi' });
     await promise;
     expect(res._getStatusCode()).toBe(401);
-    expect(mocks.synthesize).not.toHaveBeenCalled();
+    expect(res._getJSONData()).toMatchObject({ error: 'no key', errorCode: 'provider_not_configured' });
   });
 
   it('returns 402 and never calls the provider when credits are exhausted', async () => {
@@ -121,7 +125,7 @@ describe('POST /api/ai/tts', () => {
     await promise;
     expect(res._getStatusCode()).toBe(402);
     expect(res._getJSONData()).toMatchObject({ provider: 'openai' });
-    expect(mocks.synthesize).not.toHaveBeenCalled();
+    expect(mocks.synthesizeTts).not.toHaveBeenCalled();
   });
 
   it('bills for the synthesis before the size guard, then returns 413 when the audio is too large', async () => {
@@ -134,20 +138,52 @@ describe('POST /api/ai/tts', () => {
   });
 
   it('passes an upstream 4xx through with a generic body, without leaking provider text', async () => {
-    mocks.synthesize.mockRejectedValue({ status: 429, message: 'raw provider detail' });
+    mocks.synthesizeTts.mockRejectedValue({ status: 429, message: 'raw provider detail' });
     const { res, promise } = run({ text: 'hi' });
     await promise;
     expect(res._getStatusCode()).toBe(429);
     const body = res._getJSONData();
     expect(body.error).not.toContain('raw provider detail');
     expect(body).toMatchObject({ provider: 'openai' });
+    // A rate limit is not a credential problem, so no switch-provider hint.
+    expect(body.errorCode).toBeUndefined();
+  });
+
+  it('flags a credential rejection so the client can advise switching provider', async () => {
+    mocks.synthesizeTts.mockRejectedValue({ status: 401, message: 'raw provider detail' });
+    const { res, promise } = run({ text: 'hi' });
+    await promise;
+    expect(res._getStatusCode()).toBe(401);
+    const body = res._getJSONData();
+    expect(body.error).not.toContain('raw provider detail');
+    expect(body).toMatchObject({ provider: 'openai', errorCode: 'provider_rejected' });
   });
 
   it('maps a non-4xx provider failure to 502', async () => {
-    mocks.synthesize.mockRejectedValue(new Error('network blip'));
+    mocks.synthesizeTts.mockRejectedValue(new Error('network blip'));
     const { res, promise } = run({ text: 'hi' });
     await promise;
     expect(res._getStatusCode()).toBe(502);
+  });
+
+  it('reports a substituted provider in the body and headers, and bills the vendor that did the work', async () => {
+    okSynthesis('elevenlabs', 'openai');
+    const { res, promise } = run({ text: 'hi', encoding: 'base64' });
+    await promise;
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({ provider: 'elevenlabs', fallbackFrom: 'openai' });
+    expect(res.getHeader('X-B4M-Tts-Provider')).toBe('elevenlabs');
+    expect(res.getHeader('X-B4M-Tts-Provider-Fallback-From')).toBe('openai');
+    expect(mocks.deductTtsCredits).toHaveBeenCalledWith(expect.objectContaining({ vendor: 'elevenlabs' }));
+  });
+
+  it('omits the substitution fields when the requested provider was used', async () => {
+    const { res, promise } = run({ text: 'hi', encoding: 'base64' });
+    await promise;
+    const body = res._getJSONData();
+    expect(body.provider).toBeUndefined();
+    expect(body.fallbackFrom).toBeUndefined();
+    expect(res.getHeader('X-B4M-Tts-Provider')).toBeUndefined();
   });
 
   it('returns base64 JSON when encoding is base64 and charges once', async () => {
@@ -162,16 +198,12 @@ describe('POST /api/ai/tts', () => {
     expect(mocks.deductTtsCredits).toHaveBeenCalledTimes(1);
   });
 
-  it('forwards languageCode to the provider as the language option', async () => {
-    const { promise } = run({ text: '2', provider: 'elevenlabs', languageCode: 'en' });
+  it('forwards the request options for synthesis', async () => {
+    const { promise } = run({ text: '2', provider: 'elevenlabs', languageCode: 'en', voice: 'v1' });
     await promise;
-    expect(mocks.synthesize).toHaveBeenCalledWith('2', expect.objectContaining({ language: 'en' }));
-  });
-
-  it('passes language as undefined when languageCode is omitted (preserves default behavior)', async () => {
-    const { promise } = run({ text: 'hi' });
-    await promise;
-    expect(mocks.synthesize).toHaveBeenCalledWith('hi', expect.objectContaining({ language: undefined }));
+    expect(mocks.synthesizeTts).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'elevenlabs', text: '2', languageCode: 'en', requestedVoice: 'v1' })
+    );
   });
 
   it('does not bill a caller without a resolved user id', async () => {

--- a/apps/client/pages/api/ai/tts.ts
+++ b/apps/client/pages/api/ai/tts.ts
@@ -6,8 +6,8 @@ import {
   UnprocessableEntityError,
   VoiceGenerationVendor,
 } from '@bike4mind/common';
-import { aiVoiceService } from '@bike4mind/utils';
-import { resolveTtsProvider, TtsProviderNotConfiguredError } from '@server/utils/resolveTtsProvider';
+import { TtsProviderNotConfiguredError } from '@server/utils/resolveTtsProvider';
+import { synthesizeTts, upstreamStatus, isCredentialRejection } from '@server/utils/synthesizeTts';
 import { exceedsTtsResponseLimit, TTS_RESPONSE_TOO_LARGE_MESSAGE } from '@server/utils/ttsResponseLimit';
 import {
   assertTtsCreditsAvailable,
@@ -25,6 +25,9 @@ const DEFAULT_PROVIDER: VoiceGenerationVendor = 'openai';
  * - provider defaults to openai; model/voice/format fall back to per-provider defaults.
  * - encoding 'binary' (default) streams raw audio bytes with an audio/* Content-Type;
  *   'base64' returns JSON { audio, format, contentType }.
+ * - when the chosen provider has no usable key or rejects our credentials, another
+ *   configured provider stands in (see synthesizeTts) and the response reports the
+ *   substitution via { provider, fallbackFrom } / the X-B4M-Tts-Provider* headers.
  *
  * Mirrors the multi-vendor image API (aiImageService). The legacy
  * /api/ai/text-to-speech and /api/elabs/text-to-speech routes remain as thin
@@ -56,23 +59,7 @@ const handler = baseApi().post(async (req, res) => {
     );
   }
 
-  let resolved;
-  try {
-    resolved = await resolveTtsProvider({
-      provider: vendor,
-      userId: req.user?.id,
-      requestedVoice: voice,
-      preferredVoice: req.user?.preferredVoice,
-    });
-  } catch (error) {
-    if (error instanceof TtsProviderNotConfiguredError) {
-      return res.status(401).json({ error: error.message });
-    }
-    throw error;
-  }
-
-  // Pre-flight credit gate: reject before incurring provider cost. userId is
-  // guaranteed here (resolveTtsProvider throws without one).
+  // Pre-flight credit gate: reject before incurring provider cost.
   const userId = req.user?.id;
   if (userId) {
     try {
@@ -86,14 +73,31 @@ const handler = baseApi().post(async (req, res) => {
   }
 
   try {
-    const result = await aiVoiceService(vendor, resolved.apiKey, req.logger).synthesize(text, {
-      voice: resolved.voice,
+    const synthesized = await synthesizeTts({
+      provider: vendor,
+      text,
+      userId,
+      requestedVoice: voice,
+      preferredVoice: req.user?.preferredVoice,
       model,
       format,
       stability,
       similarityBoost,
-      language: languageCode,
+      languageCode,
+      logger: req.logger,
     });
+    // usedVendor is the provider that actually produced the audio: synthesizeTts
+    // may stand in another one, and billing/reporting must follow the vendor
+    // that did the work.
+    const { result, fallbackFrom, vendor: usedVendor } = synthesized;
+
+    // A substituted provider means a different voice, so the caller is always
+    // told. Header form too, for the binary encoding, which has no JSON body.
+    const providerInfo = fallbackFrom ? { provider: usedVendor, fallbackFrom } : undefined;
+    if (fallbackFrom) {
+      res.setHeader('X-B4M-Tts-Provider', usedVendor);
+      res.setHeader('X-B4M-Tts-Provider-Fallback-From', fallbackFrom);
+    }
 
     // Charge for the successful synthesis. Done before the size guard below
     // because the provider cost is already incurred regardless of whether we
@@ -101,7 +105,7 @@ const handler = baseApi().post(async (req, res) => {
     if (userId) {
       await deductTtsCredits({
         userId,
-        vendor,
+        vendor: usedVendor,
         model: result.model,
         characters: result.characters,
         logger: req.logger,
@@ -143,7 +147,7 @@ const handler = baseApi().post(async (req, res) => {
     if (exceedsTtsResponseLimit(result.audio.length)) {
       return res.status(413).json({
         error: TTS_RESPONSE_TOO_LARGE_MESSAGE,
-        provider: vendor,
+        provider: usedVendor,
         ...(saveInfo?.saved ? { saved: true, fabFileId: saveInfo.fabFileId, fileUrl: saveInfo.fileUrl } : {}),
       });
     }
@@ -154,6 +158,7 @@ const handler = baseApi().post(async (req, res) => {
         format: result.format,
         contentType: result.contentType,
         ...(saveInfo ?? {}),
+        ...(providerInfo ?? {}),
       });
     }
 
@@ -161,12 +166,26 @@ const handler = baseApi().post(async (req, res) => {
     res.setHeader('Content-Length', result.audio.length);
     return res.send(result.audio);
   } catch (error) {
+    // No provider is usable (the requested one and every alternate lack a key).
+    // errorCode lets the client separate this from a configured-but-rejected
+    // key, which needs different advice.
+    if (error instanceof TtsProviderNotConfiguredError) {
+      return res.status(401).json({ error: error.message, errorCode: 'provider_not_configured' });
+    }
+
     // Pass through client-actionable upstream errors (bad voice/param, invalid
     // key, rate limit) with a generic body so the provider's raw error text
     // never leaks; treat everything else as an upstream (502) failure.
-    const status = (error as { status?: number })?.status;
+    const status = upstreamStatus(error);
     if (typeof status === 'number' && status >= 400 && status < 500) {
-      return res.status(status).json({ error: `TTS request rejected by the ${vendor} provider`, provider: vendor });
+      return res.status(status).json({
+        error: `TTS request rejected by the ${vendor} provider`,
+        provider: vendor,
+        // Reaching here on a credential rejection means no alternate could
+        // cover for it either, so the actionable next step is a different
+        // provider (or a fixed key), not a different request.
+        ...(isCredentialRejection(error) ? { errorCode: 'provider_rejected' } : {}),
+      });
     }
     req.logger.error('TTS synthesis failed', { error, provider: vendor });
     return res.status(502).json({ error: 'Failed to generate speech', provider: vendor });

--- a/apps/client/server/utils/synthesizeTts.test.ts
+++ b/apps/client/server/utils/synthesizeTts.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mocks, TtsProviderNotConfiguredError } = vi.hoisted(() => {
+  class TtsProviderNotConfiguredError extends Error {}
+  return {
+    TtsProviderNotConfiguredError,
+    mocks: {
+      resolveTtsProvider: vi.fn(),
+      synthesize: vi.fn(),
+      aiVoiceService: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@bike4mind/common', () => ({
+  supportedVoiceGenerationVendor: { options: ['openai', 'elevenlabs'] },
+  TTS_MAX_INPUT_CHARS: { openai: 4096, elevenlabs: 10000 },
+  VOICE_VENDOR_SUPPORTED_FORMATS: { openai: ['mp3', 'wav'], elevenlabs: ['mp3', 'pcm', 'opus'] },
+}));
+
+vi.mock('@bike4mind/utils', () => ({
+  aiVoiceService: (...a: unknown[]) => {
+    mocks.aiVoiceService(...a);
+    return { synthesize: (...s: unknown[]) => mocks.synthesize(...s) };
+  },
+}));
+
+vi.mock('./resolveTtsProvider', () => ({
+  resolveTtsProvider: (...a: unknown[]) => mocks.resolveTtsProvider(...a),
+  TtsProviderNotConfiguredError,
+}));
+
+import { synthesizeTts, upstreamStatus, isCredentialRejection } from './synthesizeTts';
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+const audio = () => ({
+  audio: Buffer.from([1, 2, 3]),
+  contentType: 'audio/mpeg',
+  format: 'mp3',
+  model: 'tts-1',
+  characters: 2,
+});
+
+const run = (overrides: Record<string, unknown> = {}) =>
+  synthesizeTts({
+    provider: 'openai',
+    text: 'hi',
+    userId: 'u1',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- any: the test drives partial arg sets through the real signature
+    logger: logger as any,
+    ...overrides,
+  } as Parameters<typeof synthesizeTts>[0]);
+
+// The OpenAI SDK shape; the ElevenLabs (axios) shape nests it under `response`.
+const rejection = (status: number) => Object.assign(new Error('upstream said no'), { status });
+const axiosRejection = (status: number) => Object.assign(new Error('upstream said no'), { response: { status } });
+
+beforeEach(() => {
+  Object.values(mocks).forEach(m => m.mockReset());
+  logger.warn.mockReset();
+  mocks.resolveTtsProvider.mockResolvedValue({ apiKey: 'key', voice: 'alloy' });
+  mocks.synthesize.mockResolvedValue(audio());
+});
+
+describe('upstreamStatus', () => {
+  it('reads the SDK shape, the axios shape, and neither', () => {
+    expect(upstreamStatus(rejection(429))).toBe(429);
+    expect(upstreamStatus(axiosRejection(401))).toBe(401);
+    expect(upstreamStatus(new Error('network blip'))).toBeUndefined();
+    expect(upstreamStatus(undefined)).toBeUndefined();
+  });
+});
+
+describe('isCredentialRejection', () => {
+  it('is true only for 401/403, in either error shape', () => {
+    expect(isCredentialRejection(rejection(401))).toBe(true);
+    expect(isCredentialRejection(axiosRejection(403))).toBe(true);
+    expect(isCredentialRejection(rejection(400))).toBe(false);
+    expect(isCredentialRejection(rejection(429))).toBe(false);
+    expect(isCredentialRejection(new Error('network blip'))).toBe(false);
+  });
+});
+
+describe('synthesizeTts', () => {
+  it('uses the requested provider and reports no fallback on success', async () => {
+    const out = await run({ requestedVoice: 'nova', model: 'tts-1-hd', format: 'wav' });
+    expect(out.vendor).toBe('openai');
+    expect(out.fallbackFrom).toBeUndefined();
+    expect(mocks.synthesize).toHaveBeenCalledTimes(1);
+    expect(mocks.synthesize).toHaveBeenCalledWith(
+      'hi',
+      expect.objectContaining({ voice: 'alloy', model: 'tts-1-hd', format: 'wav' })
+    );
+  });
+
+  it('maps languageCode onto the provider language option, defaulting to undefined', async () => {
+    await run({ languageCode: 'en' });
+    expect(mocks.synthesize).toHaveBeenLastCalledWith('hi', expect.objectContaining({ language: 'en' }));
+
+    await run();
+    expect(mocks.synthesize).toHaveBeenLastCalledWith('hi', expect.objectContaining({ language: undefined }));
+  });
+
+  it('falls back to another provider when the requested one rejects our credentials', async () => {
+    mocks.synthesize.mockRejectedValueOnce(rejection(401)).mockResolvedValueOnce(audio());
+
+    const out = await run();
+
+    expect(out.vendor).toBe('elevenlabs');
+    expect(out.fallbackFrom).toBe('openai');
+    expect(mocks.aiVoiceService).toHaveBeenNthCalledWith(1, 'openai', 'key', logger);
+    expect(mocks.aiVoiceService).toHaveBeenNthCalledWith(2, 'elevenlabs', 'key', logger);
+  });
+
+  it('falls back when the requested provider has no key configured at all', async () => {
+    mocks.resolveTtsProvider
+      .mockRejectedValueOnce(new TtsProviderNotConfiguredError('OpenAI API key not configured'))
+      .mockResolvedValueOnce({ apiKey: 'xi-key', voice: 'rachel' });
+
+    const out = await run();
+
+    expect(out).toMatchObject({ vendor: 'elevenlabs', fallbackFrom: 'openai' });
+  });
+
+  it('drops the vendor-scoped voice and model when standing in another provider', async () => {
+    mocks.synthesize.mockRejectedValueOnce(rejection(401)).mockResolvedValueOnce(audio());
+
+    await run({ requestedVoice: 'nova', model: 'tts-1-hd', preferredVoice: 'echo' });
+
+    // An OpenAI voice name is not a valid ElevenLabs voiceId, so the alternate
+    // resolves its own; preferredVoice is OpenAI-scoped inside the resolver and
+    // passes through untouched.
+    expect(mocks.resolveTtsProvider).toHaveBeenNthCalledWith(2, {
+      provider: 'elevenlabs',
+      userId: 'u1',
+      requestedVoice: undefined,
+      preferredVoice: 'echo',
+    });
+    expect(mocks.synthesize).toHaveBeenNthCalledWith(2, 'hi', expect.objectContaining({ model: undefined }));
+  });
+
+  it('drops a format the alternate cannot produce rather than failing on it', async () => {
+    mocks.synthesize.mockRejectedValueOnce(rejection(401)).mockResolvedValueOnce(audio());
+
+    await run({ format: 'wav' });
+
+    expect(mocks.synthesize).toHaveBeenNthCalledWith(2, 'hi', expect.objectContaining({ format: undefined }));
+  });
+
+  it('keeps a format the alternate does support', async () => {
+    mocks.synthesize.mockRejectedValueOnce(rejection(401)).mockResolvedValueOnce(audio());
+
+    await run({ format: 'mp3' });
+
+    expect(mocks.synthesize).toHaveBeenNthCalledWith(2, 'hi', expect.objectContaining({ format: 'mp3' }));
+  });
+
+  it('does not consider an alternate whose input ceiling is below the text', async () => {
+    const text = 'x'.repeat(5000);
+    mocks.synthesize.mockRejectedValue(axiosRejection(401));
+
+    await expect(run({ provider: 'elevenlabs', text })).rejects.toMatchObject({ response: { status: 401 } });
+    // openai caps at 4096, so it was never a real alternate for this text.
+    expect(mocks.synthesize).toHaveBeenCalledTimes(1);
+  });
+
+  it('never retries elsewhere for a request-shaped failure', async () => {
+    mocks.synthesize.mockRejectedValue(rejection(400));
+
+    await expect(run()).rejects.toMatchObject({ status: 400 });
+    expect(mocks.synthesize).toHaveBeenCalledTimes(1);
+  });
+
+  it('never retries elsewhere for a rate limit', async () => {
+    mocks.synthesize.mockRejectedValue(rejection(429));
+
+    await expect(run()).rejects.toMatchObject({ status: 429 });
+    expect(mocks.synthesize).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the requested provider error when every candidate is unusable', async () => {
+    mocks.synthesize.mockRejectedValueOnce(rejection(401)).mockRejectedValueOnce(rejection(403));
+
+    await expect(run()).rejects.toMatchObject({ status: 401 });
+    expect(mocks.synthesize).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports the requested provider error when the alternate fails for its own reason', async () => {
+    mocks.resolveTtsProvider
+      .mockRejectedValueOnce(new TtsProviderNotConfiguredError('OpenAI API key not configured'))
+      .mockResolvedValueOnce({ apiKey: 'xi-key', voice: 'rachel' });
+    mocks.synthesize.mockRejectedValueOnce(rejection(400));
+
+    await expect(run()).rejects.toBeInstanceOf(TtsProviderNotConfiguredError);
+  });
+
+  it('logs every unusable provider so the operator sees which keys are failing', async () => {
+    mocks.synthesize.mockRejectedValueOnce(rejection(401)).mockResolvedValueOnce(audio());
+
+    await run();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'TTS provider unusable',
+      expect.objectContaining({ vendor: 'openai', error: 'upstream said no' })
+    );
+  });
+});

--- a/apps/client/server/utils/synthesizeTts.ts
+++ b/apps/client/server/utils/synthesizeTts.ts
@@ -1,0 +1,137 @@
+import {
+  supportedVoiceGenerationVendor,
+  TTS_MAX_INPUT_CHARS,
+  VOICE_VENDOR_SUPPORTED_FORMATS,
+  VoiceGenerationVendor,
+  VoiceOutputFormat,
+} from '@bike4mind/common';
+import { aiVoiceService, type VoiceSynthesisResult } from '@bike4mind/utils';
+import { type Logger } from '@bike4mind/observability';
+import { resolveTtsProvider, TtsProviderNotConfiguredError } from './resolveTtsProvider';
+
+/**
+ * HTTP status of an upstream provider failure. The OpenAI SDK exposes it as
+ * `status`; axios (the ElevenLabs transport) puts it on `response.status`, so
+ * both shapes have to be read or an ElevenLabs 4xx looks like a network error.
+ */
+export function upstreamStatus(error: unknown): number | undefined {
+  const candidate = error as { status?: unknown; response?: { status?: unknown } } | null;
+  const status = typeof candidate?.status === 'number' ? candidate.status : candidate?.response?.status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+/**
+ * A provider rejecting our credentials is a property of the stored key, not of
+ * the request, so another vendor may well succeed. Every other 4xx (bad voice,
+ * bad model, rate limit) either belongs to the request or would recur, so those
+ * are never retried elsewhere.
+ */
+export function isCredentialRejection(error: unknown): boolean {
+  const status = upstreamStatus(error);
+  return status === 401 || status === 403;
+}
+
+const isRecoverable = (error: unknown) =>
+  error instanceof TtsProviderNotConfiguredError || isCredentialRejection(error);
+
+// Alternates worth attempting after `primary` fails, in preference order. A
+// vendor whose input ceiling is below this text is not a real alternate: it
+// would only fail on length.
+function alternatesFor(primary: VoiceGenerationVendor, text: string): VoiceGenerationVendor[] {
+  return supportedVoiceGenerationVendor.options.filter(
+    vendor => vendor !== primary && text.length <= TTS_MAX_INPUT_CHARS[vendor]
+  );
+}
+
+// An alternate may not support the requested container; drop back to its own
+// default (mp3) rather than turning a recovered request into a 422.
+const formatFor = (vendor: VoiceGenerationVendor, format: VoiceOutputFormat | undefined) =>
+  format && VOICE_VENDOR_SUPPORTED_FORMATS[vendor].includes(format) ? format : undefined;
+
+export interface SynthesizeTtsArgs {
+  provider: VoiceGenerationVendor;
+  text: string;
+  userId: string | undefined;
+  requestedVoice?: string;
+  preferredVoice?: string | null;
+  model?: string;
+  format?: VoiceOutputFormat;
+  stability?: number;
+  similarityBoost?: number;
+  languageCode?: string;
+  logger: Logger;
+}
+
+export interface SynthesizedTts {
+  /** The vendor that actually produced the audio. */
+  vendor: VoiceGenerationVendor;
+  result: VoiceSynthesisResult;
+  /** Set only when the requested vendor was unusable and `vendor` stood in for it. */
+  fallbackFrom?: VoiceGenerationVendor;
+}
+
+/**
+ * Synthesizes speech with the requested provider, degrading to another
+ * configured provider when that one has no usable key or is rejected by the
+ * upstream service. Mirrors the principle established for the embedding path:
+ * an upstream credential failure should degrade rather than hard-fail.
+ *
+ * The substitution is never silent - callers must surface `fallbackFrom`, since
+ * a different vendor means a different voice. If no candidate succeeds, the
+ * requested provider's own error is thrown so the response still describes the
+ * vendor the caller asked for.
+ */
+export async function synthesizeTts(args: SynthesizeTtsArgs): Promise<SynthesizedTts> {
+  const { provider, text, logger } = args;
+  const candidates: VoiceGenerationVendor[] = [provider, ...alternatesFor(provider, text)];
+  let primaryError: unknown;
+
+  for (const vendor of candidates) {
+    const isAlternate = vendor !== provider;
+    try {
+      const resolved = await resolveTtsProvider({
+        provider: vendor,
+        userId: args.userId,
+        // A requested voice belongs to the requested vendor's namespace (an
+        // OpenAI voice name is not an ElevenLabs voiceId), so an alternate
+        // resolves its own voice instead. preferredVoice is already scoped to
+        // OpenAI inside resolveTtsProvider, so it passes through untouched.
+        requestedVoice: isAlternate ? undefined : args.requestedVoice,
+        preferredVoice: args.preferredVoice,
+      });
+
+      const result = await aiVoiceService(vendor, resolved.apiKey, logger).synthesize(text, {
+        voice: resolved.voice,
+        // model is vendor-specific too; let an alternate apply its default.
+        model: isAlternate ? undefined : args.model,
+        format: isAlternate ? formatFor(vendor, args.format) : args.format,
+        stability: args.stability,
+        similarityBoost: args.similarityBoost,
+        language: args.languageCode,
+      });
+
+      return { vendor, result, ...(isAlternate ? { fallbackFrom: provider } : {}) };
+    } catch (error) {
+      if (!isRecoverable(error)) {
+        // The requested vendor failed for a request-shaped reason: report it as
+        // asked. An alternate failing this way still leaves the primary's
+        // error as the one worth reporting.
+        if (!isAlternate) throw error;
+        logger.warn('TTS fallback provider failed', {
+          vendor,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        continue;
+      }
+
+      if (!isAlternate) primaryError = error;
+      logger.warn('TTS provider unusable', {
+        vendor,
+        willTryAlternate: !isAlternate && candidates.length > 1,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  throw primaryError;
+}

--- a/b4m-core/common/src/voiceGeneration.ts
+++ b/b4m-core/common/src/voiceGeneration.ts
@@ -5,6 +5,14 @@ export const supportedVoiceGenerationVendor = z.enum(['openai', 'elevenlabs']);
 
 export type VoiceGenerationVendor = z.infer<typeof supportedVoiceGenerationVendor>;
 
+// Display names for the TTS providers. Shared so the provider picker and any
+// message that has to name the vendor that actually produced the audio (e.g. a
+// fallback notice) read identically.
+export const VOICE_VENDOR_LABELS: Record<VoiceGenerationVendor, string> = {
+  openai: 'OpenAI',
+  elevenlabs: 'ElevenLabs',
+};
+
 // Output container the caller wants back. All providers accept mp3; the rest are
 // best-effort per provider (OpenAI supports the full set, ElevenLabs maps a
 // subset). The vendor implementation is responsible for the format -> API param


### PR DESCRIPTION
# Pull Request

## Description

`POST /api/ai/tts` hard-fails when the configured provider's credential is rejected upstream. `resolveTtsProvider` picked exactly one vendor, the route never tried another, and the modal gave the user no signal that switching providers would work. Issue #1299 established that an upstream credential failure should degrade rather than hard-fail; TTS had no equivalent.

This PR adds that degradation path. It does not touch the environment half of #1316 (the stored staging OpenAI key is still wrong and needs to be rotated separately) - it means a bad key no longer surfaces as a dead feature.

Degradation is deliberately narrow. It happens only on failures that are properties of the stored credential: provider-not-configured, or an upstream 401/403. Every other 4xx (bad voice, bad model, 429) belongs to the request itself and would recur on any vendor, so it is reported as-is and never retried.

## Changes

- New `apps/client/server/utils/synthesizeTts.ts` owns provider resolution plus synthesis, lifted out of the route.
  - Tries the requested vendor, then any other supported vendor whose `TTS_MAX_INPUT_CHARS` ceiling fits the text - a vendor that would only fail on length is not a real alternate.
  - Drops vendor-scoped params for an alternate (voice, model, and a format that vendor cannot produce) so a recovered request does not turn into a 422.
  - If nothing succeeds, throws the *requested* vendor's error, so the response still describes the provider the caller asked for.
  - `upstreamStatus()` reads both error shapes: OpenAI SDK `status` and axios/ElevenLabs `response.status`. Previously an ElevenLabs 4xx looked like a network error and mapped to 502.
- `pages/api/ai/tts.ts`: bills and reports the vendor that actually did the work; reports a substitution via `{ provider, fallbackFrom }` plus `X-B4M-Tts-Provider` / `X-B4M-Tts-Provider-Fallback-From` headers (the headers are required because the binary response has no JSON body); distinguishes `errorCode: 'provider_rejected'` (key configured but refused, nothing could cover) from `'provider_not_configured'` (no key anywhere).
- `useGenerateAudio`: toasts which provider stood in - a substitution means a different voice, so it is never silent - and on `provider_rejected` advises switching providers, the one thing the user can act on.
- `VOICE_VENDOR_LABELS` moved into `@bike4mind/common` so the voice picker and the fallback notice name vendors identically.

Credit handling was already correct and is unchanged: `deductTtsCredits` runs only after `synthesize` resolves, and now bills the vendor that actually synthesized.

## Guide for Testers

Preconditions: an account with TTS access on `app.staging.bike4mind.com`, and both OpenAI and ElevenLabs TTS keys configured in admin settings.

Happy path (no regression):
1. Go to `app.staging.bike4mind.com` and sign in.
2. Open any chat session with at least one assistant message.
3. Click the speaker / "Read aloud" control on an assistant message.
4. Expected: audio plays within about 10 seconds. No toast about a provider substitution appears.
5. Open the voice settings and pick an ElevenLabs voice explicitly, then repeat step 3.
6. Expected: audio plays, and again no substitution toast.

Fallback path (this is the fix):
7. In admin settings, replace the OpenAI API key with an invalid value (e.g. `sk-invalid-000`). Keep the ElevenLabs key valid.
8. Open the voice settings and select an OpenAI voice (e.g. `alloy`).
9. Click "Read aloud" on an assistant message.
10. Expected: audio still plays. A toast appears naming the provider that stood in - text of the form "OpenAI was unavailable, used ElevenLabs instead". The voice audibly differs from the OpenAI voice selected in step 8.
11. Restore the valid OpenAI key.

No-provider-available path:
12. In admin settings, make BOTH the OpenAI and ElevenLabs keys invalid.
13. Click "Read aloud" on an assistant message.
14. Expected: playback fails with a user-facing error that names the provider you selected and advises trying a different provider. No credits are deducted (check the credit balance before and after - it is unchanged).
15. Restore both valid keys.

Regression Checks:
16. Confirm the credit balance decreases by the expected TTS amount on a successful synthesis (step 4), and does not decrease on a failed one (step 14).
17. Confirm the voice picker still lists every vendor with its normal label - `VOICE_VENDOR_LABELS` moved packages, so a missing or blank vendor label here would be a regression.
18. Confirm long text (over the OpenAI input-character ceiling) still produces the same length error it did before rather than silently retrying elsewhere.

What NOT to test: nothing about the staging OpenAI key itself is fixed here. If step 8-10 shows a substitution toast with the *unmodified* staging key, that is the separate environment half of #1316, not a defect in this PR.

## Additional Information

Verification on this branch: `pnpm turbo:typecheck` clean (40/40), `pnpm lint:check` clean, `pnpm turbo:core:build` clean. 34 TTS tests pass - `synthesizeTts.test.ts` (15), `tts.test.ts` (15), new `useGenerateAudio.test.ts` (4). `@bike4mind/common` full suite (1402 tests) passes, which covers the `VOICE_VENDOR_LABELS` move.

A full `pnpm turbo:test` leaves 11 failing client files, all Mongo-backed `*.e2e`/integration tests: 39 of 40 individual failures are hook/test timeouts plus one Mongo `ECONNREFUSED`. They pass in isolation (e.g. embedSpendCap + agentExecutor.sqsBatch take 17s isolated vs 235s under load), so this is the MongoMemoryServer contention CLAUDE.md warns about, not a regression from these changes. None of them touch TTS.

## Developer Notes (Optional)

- **New Extension Point**: `synthesizeTts()` is now the single entry point for TTS synthesis - provider resolution, fallback selection, and param sanitization live behind it, so any future caller (batch narration, a worker) gets the same degradation behavior for free rather than reimplementing it.
- **Reusable Pattern**: the recoverable-vs-request-scoped error split (degrade only on provider-not-configured / 401 / 403; never on 422 / 429 / bad-param) generalizes to any multi-vendor adapter in `llm-adapters`. The key insight is that retrying a request-scoped failure elsewhere just burns a second vendor's quota to produce the same error.
- **Architecture Decision**: on total failure the *requested* vendor's error is rethrown rather than the last alternate's, so the error a caller sees always describes the provider they asked for. Reporting the last-tried vendor's error would make the response describe a provider the user never selected.
- `upstreamStatus()` normalizes OpenAI-SDK-shaped and axios-shaped errors to one status number - worth reusing anywhere both adapter families are handled in the same catch.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry changes
