### PR TITLE
refactor(admin): rework the users tab for desktop and mobile

### DIFF
--- a/apps/client/app/components/admin/IntegrationHealth/utils/csvExport.ts
+++ b/apps/client/app/components/admin/IntegrationHealth/utils/csvExport.ts
@@ -1,3 +1,4 @@
+import { toCsv } from '@client/app/utils/csv';
 import type { IntegrationDashboardResponse } from '../types';
 
 export function exportDashboardCsv(data: IntegrationDashboardResponse): void {
@@ -46,12 +47,7 @@ export function exportDashboardCsv(data: IntegrationDashboardResponse): void {
     }
   }
 
-  const escapeCell = (cell: string) => {
-    let escaped = cell.replace(/"/g, '""').replace(/\r?\n/g, ' ');
-    if (/^[=+\-@]/.test(escaped)) escaped = "'" + escaped;
-    return `"${escaped}"`;
-  };
-  const csv = rows.map(row => row.map(escapeCell).join(',')).join('\n');
+  const csv = toCsv(rows);
 
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);

--- a/apps/client/app/components/admin/Users/LoginsView.tsx
+++ b/apps/client/app/components/admin/Users/LoginsView.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Tooltip, Stack, Button } from '@mui/joy';
+import { Chip, Tooltip } from '@mui/joy';
+import CircleIcon from '@mui/icons-material/Circle';
 import { IUserDocument, WithOrgRef } from '@bike4mind/common';
 import LoginDetailsModal from './LoginDetailsModal';
 import { useGetUserActivityCounters } from '@client/app/hooks/data/user';
@@ -32,19 +33,18 @@ const LoginsView: React.FC<LoginsViewProps> = ({ user }) => {
 
   return (
     <>
-      <Stack direction="row" spacing={2} display={'flex'} justifyContent={'flex-start'}>
-        <Tooltip title="Tap for Last Login Details">
-          <Button
-            size="md"
-            variant="plain"
-            startDecorator={isAlert ? '🚨' : '🟢'}
-            color={isAlert ? 'danger' : 'neutral'}
-            onClick={handleOpenModal}
-          >
-            {logins}
-          </Button>
-        </Tooltip>
-      </Stack>
+      <Tooltip title="Tap for Last Login Details">
+        <Chip
+          data-testid="admin-user-logins-chip"
+          size="sm"
+          variant="soft"
+          color={isAlert ? 'danger' : 'success'}
+          startDecorator={<CircleIcon sx={{ fontSize: 8 }} />}
+          onClick={handleOpenModal}
+        >
+          {logins}
+        </Chip>
+      </Tooltip>
       <LoginDetailsModal open={isModalOpen} onClose={handleCloseModal} user={user} lastLoginRecord={lastLoginRecord} />
     </>
   );

--- a/apps/client/app/components/admin/Users/LoginsView.tsx
+++ b/apps/client/app/components/admin/Users/LoginsView.tsx
@@ -36,6 +36,8 @@ const LoginsView: React.FC<LoginsViewProps> = ({ user }) => {
       <Tooltip title="Tap for Last Login Details">
         <Chip
           data-testid="admin-user-logins-chip"
+          // The count alone announces as a bare number; Tooltip only sets aria-describedby.
+          aria-label={`${logins} logins, view last login details`}
           size="sm"
           variant="soft"
           color={isAlert ? 'danger' : 'success'}

--- a/apps/client/app/components/admin/Users/MobileFiltersDrawer.tsx
+++ b/apps/client/app/components/admin/Users/MobileFiltersDrawer.tsx
@@ -1,0 +1,77 @@
+import { Button, DialogContent, DialogTitle, Divider, Drawer, ModalClose, Stack, Typography } from '@mui/joy';
+import React from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import OrganizationsFilter from './filters/OrganizationsFilter';
+import SortControls from './filters/SortControls';
+import UserTagsFilter from './filters/UserTagsFilter';
+import { CLEARED_FILTER_PARAMS, countActiveFilters, useUsersTab } from './useUsersTabParams';
+
+interface MobileFiltersDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  loading: boolean;
+}
+
+/**
+ * Bottom sheet hosting the org/tag/sort controls on phones. Changes apply live through the
+ * shared params store, so "Done" only dismisses the sheet.
+ */
+const MobileFiltersDrawer: React.FC<MobileFiltersDrawerProps> = ({ open, onClose, loading }) => {
+  const [params, setParams] = useUsersTab(useShallow(state => [state.params, state.setParams]));
+  const activeFilterCount = countActiveFilters(params);
+
+  return (
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={onClose}
+      data-testid="admin-users-filters-drawer"
+      slotProps={{
+        content: {
+          sx: {
+            height: 'auto',
+            maxHeight: '80dvh',
+            borderTopLeftRadius: 'lg',
+            borderTopRightRadius: 'lg',
+          },
+        },
+      }}
+    >
+      <ModalClose />
+      <DialogTitle>Filters</DialogTitle>
+      <Divider />
+      <DialogContent sx={{ gap: 2, p: 2 }}>
+        <Stack spacing={0.5}>
+          <Typography level="title-sm">Organizations</Typography>
+          <OrganizationsFilter disabled={loading} fullWidth />
+        </Stack>
+        <Stack spacing={0.5}>
+          <Typography level="title-sm">User Tags</Typography>
+          <UserTagsFilter disabled={loading} fullWidth />
+        </Stack>
+        <Stack spacing={0.5}>
+          <Typography level="title-sm">Sort</Typography>
+          <SortControls disabled={loading} fullWidth />
+        </Stack>
+      </DialogContent>
+      <Divider />
+      <Stack direction="row" spacing={1} sx={{ p: 2 }}>
+        <Button
+          data-testid="admin-users-filters-clear-btn"
+          variant="plain"
+          color="neutral"
+          disabled={activeFilterCount === 0}
+          onClick={() => setParams(CLEARED_FILTER_PARAMS)}
+          sx={{ flex: 1 }}
+        >
+          Clear all
+        </Button>
+        <Button data-testid="admin-users-filters-done-btn" onClick={onClose} sx={{ flex: 1 }}>
+          Done
+        </Button>
+      </Stack>
+    </Drawer>
+  );
+};
+
+export default MobileFiltersDrawer;

--- a/apps/client/app/components/admin/Users/PaginationControls.test.tsx
+++ b/apps/client/app/components/admin/Users/PaginationControls.test.tsx
@@ -48,6 +48,22 @@ describe('PaginationControls', () => {
     expect(screen.getByTestId('admin-page-size-select')).toHaveTextContent('10 / page');
   });
 
+  it('omits the total until the first response lands', () => {
+    // totalPages is 0 before data arrives; "Page 1 of 0" reads as an empty result set.
+    const { unmount } = render(<PaginationControls {...baseProps} currentPage={1} totalPages={0} variant="full" />, {
+      wrapper: TestWrapper,
+    });
+    expect(screen.getByText('Page 1')).toBeInTheDocument();
+    expect(screen.queryByText(/of 0/)).not.toBeInTheDocument();
+    unmount();
+
+    render(<PaginationControls {...baseProps} currentPage={1} totalPages={0} variant="compact" />, {
+      wrapper: TestWrapper,
+    });
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.queryByText(/of 0/)).not.toBeInTheDocument();
+  });
+
   it('disables the pager at both ends of the range', () => {
     const { unmount } = render(<PaginationControls {...baseProps} currentPage={1} variant="compact" />, {
       wrapper: TestWrapper,

--- a/apps/client/app/components/admin/Users/PaginationControls.test.tsx
+++ b/apps/client/app/components/admin/Users/PaginationControls.test.tsx
@@ -1,0 +1,73 @@
+import { getThemeConfig } from '@client/app/utils/themes';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import PaginationControls from './PaginationControls';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const baseProps = {
+  currentPage: 2,
+  totalPages: 4,
+  onPageChange: vi.fn(),
+  currentLimit: 10,
+  onLimitChange: vi.fn(),
+  totalUsers: 37,
+  pageLimitOptions: [5, 10, 20],
+};
+
+describe('PaginationControls', () => {
+  it('shows the page size picker and total count in the full variant', () => {
+    render(<PaginationControls {...baseProps} variant="full" />, { wrapper: TestWrapper });
+
+    expect(screen.getByText('Page 2 of 4')).toBeInTheDocument();
+    expect(screen.getByText('37 users')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-page-size-select')).toBeInTheDocument();
+  });
+
+  it('keeps the page size picker but drops the total count in the compact variant', () => {
+    render(<PaginationControls {...baseProps} variant="compact" />, { wrapper: TestWrapper });
+
+    expect(screen.getByText('2 of 4')).toBeInTheDocument();
+    // Compact is the only pager on phones, so page size has to stay reachable here.
+    expect(screen.getByTestId('admin-page-size-select')).toBeInTheDocument();
+    expect(screen.queryByText('37 users')).not.toBeInTheDocument();
+  });
+
+  it('shows the active page size in both variants', () => {
+    const { unmount } = render(<PaginationControls {...baseProps} variant="compact" />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('admin-page-size-select')).toHaveTextContent('10 / page');
+    unmount();
+
+    render(<PaginationControls {...baseProps} variant="full" />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('admin-page-size-select')).toHaveTextContent('10 / page');
+  });
+
+  it('disables the pager at both ends of the range', () => {
+    const { unmount } = render(<PaginationControls {...baseProps} currentPage={1} variant="compact" />, {
+      wrapper: TestWrapper,
+    });
+    expect(screen.getByLabelText('Previous page')).toBeDisabled();
+    expect(screen.getByLabelText('Next page')).toBeEnabled();
+    unmount();
+
+    render(<PaginationControls {...baseProps} currentPage={4} variant="compact" />, { wrapper: TestWrapper });
+    expect(screen.getByLabelText('Next page')).toBeDisabled();
+  });
+
+  it('reports page changes', async () => {
+    const onPageChange = vi.fn();
+    render(<PaginationControls {...baseProps} onPageChange={onPageChange} variant="compact" />, {
+      wrapper: TestWrapper,
+    });
+
+    await userEvent.click(screen.getByLabelText('Next page'));
+
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+});

--- a/apps/client/app/components/admin/Users/PaginationControls.test.tsx
+++ b/apps/client/app/components/admin/Users/PaginationControls.test.tsx
@@ -27,7 +27,7 @@ describe('PaginationControls', () => {
 
     expect(screen.getByText('Page 2 of 4')).toBeInTheDocument();
     expect(screen.getByText('37 users')).toBeInTheDocument();
-    expect(screen.getByTestId('admin-page-size-select')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-page-size-select-full')).toBeInTheDocument();
   });
 
   it('keeps the page size picker but drops the total count in the compact variant', () => {
@@ -35,17 +35,39 @@ describe('PaginationControls', () => {
 
     expect(screen.getByText('2 of 4')).toBeInTheDocument();
     // Compact is the only pager on phones, so page size has to stay reachable here.
-    expect(screen.getByTestId('admin-page-size-select')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-page-size-select-compact')).toBeInTheDocument();
     expect(screen.queryByText('37 users')).not.toBeInTheDocument();
   });
 
   it('shows the active page size in both variants', () => {
     const { unmount } = render(<PaginationControls {...baseProps} variant="compact" />, { wrapper: TestWrapper });
-    expect(screen.getByTestId('admin-page-size-select')).toHaveTextContent('10 / page');
+    expect(screen.getByTestId('admin-page-size-select-compact')).toHaveTextContent('10 / page');
     unmount();
 
     render(<PaginationControls {...baseProps} variant="full" />, { wrapper: TestWrapper });
-    expect(screen.getByTestId('admin-page-size-select')).toHaveTextContent('10 / page');
+    expect(screen.getByTestId('admin-page-size-select-full')).toHaveTextContent('10 / page');
+  });
+
+  it('keeps each pager addressable when both mount together, as they do on desktop', () => {
+    // A shared testid across variants resolves to two elements and trips Playwright strict mode.
+    render(
+      <>
+        <PaginationControls {...baseProps} variant="full" />
+        <PaginationControls {...baseProps} variant="compact" />
+      </>,
+      { wrapper: TestWrapper }
+    );
+
+    expect(screen.getAllByTestId('admin-page-size-select-full')).toHaveLength(1);
+    expect(screen.getAllByTestId('admin-page-size-select-compact')).toHaveLength(1);
+  });
+
+  it('falls back to the current limit when it is not one of the options', () => {
+    // A limit persisted under admin-user-tab-01 can outlive a change to PAGE_LIMIT_OPTIONS;
+    // without the fallback the control reads as a bare " / page".
+    render(<PaginationControls {...baseProps} currentLimit={15} variant="full" />, { wrapper: TestWrapper });
+
+    expect(screen.getByTestId('admin-page-size-select-full')).toHaveTextContent('15 / page');
   });
 
   it('omits the total until the first response lands', () => {

--- a/apps/client/app/components/admin/Users/PaginationControls.tsx
+++ b/apps/client/app/components/admin/Users/PaginationControls.tsx
@@ -28,6 +28,12 @@ const PaginationControls: React.FC<PaginationControlsProps> = ({
   const isCompact = variant === 'compact';
   // totalPages is 0 until the first response lands; "of 0" would read as an empty result set.
   const pageLabel = totalPages > 0 ? `${currentPage} of ${totalPages}` : `${currentPage}`;
+  // A limit persisted under admin-user-tab-01 can outlive a change to the option list. Joy renders
+  // an empty button when the value matches no Option (renderValue is never called), so keep the
+  // active limit in the list rather than trying to patch the label.
+  const limitOptions = pageLimitOptions.includes(currentLimit)
+    ? pageLimitOptions
+    : [...pageLimitOptions, currentLimit].sort((a, b) => a - b);
 
   const pager = (
     <Stack direction="row" spacing={0.5} alignItems="center">
@@ -59,17 +65,19 @@ const PaginationControls: React.FC<PaginationControlsProps> = ({
 
   const pageSizeSelect = (
     <Select
-      data-testid="admin-page-size-select"
+      // Suffixed per variant: both pagers mount together on desktop, so a shared testid would
+      // resolve to two elements and trip Playwright's strict mode.
+      data-testid={`admin-page-size-select-${variant}`}
       size="sm"
       value={currentLimit}
       onChange={(_, value) => {
         if (value) onLimitChange(value);
       }}
       sx={{ minWidth: 104 }}
-      renderValue={option => <Box component="span">{option?.value} / page</Box>}
+      renderValue={option => <Box component="span">{option?.value ?? currentLimit} / page</Box>}
       slotProps={{ listbox: { placement: isCompact ? 'top' : 'bottom' } }}
     >
-      {pageLimitOptions.map(limit => (
+      {limitOptions.map(limit => (
         <Option key={limit} value={limit}>
           {limit} / page
         </Option>

--- a/apps/client/app/components/admin/Users/PaginationControls.tsx
+++ b/apps/client/app/components/admin/Users/PaginationControls.tsx
@@ -1,0 +1,95 @@
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { Box, IconButton, Option, Select, Stack, Typography } from '@mui/joy';
+import React from 'react';
+
+interface PaginationControlsProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  currentLimit: number;
+  onLimitChange: (limit: number) => void;
+  totalUsers: number;
+  pageLimitOptions: number[];
+  /** 'full' adds the page-size picker and total count; 'compact' is the pager alone. */
+  variant?: 'full' | 'compact';
+}
+
+const PaginationControls: React.FC<PaginationControlsProps> = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+  currentLimit,
+  onLimitChange,
+  totalUsers,
+  pageLimitOptions,
+  variant = 'full',
+}) => {
+  const isCompact = variant === 'compact';
+
+  const pager = (
+    <Stack direction="row" spacing={0.5} alignItems="center">
+      <IconButton
+        size="sm"
+        variant="outlined"
+        color="neutral"
+        aria-label="Previous page"
+        disabled={currentPage <= 1}
+        onClick={() => onPageChange(currentPage - 1)}
+      >
+        <ChevronLeftIcon />
+      </IconButton>
+      <Typography level="body-sm" sx={{ px: 0.5, whiteSpace: 'nowrap' }}>
+        {isCompact ? `${currentPage} of ${totalPages}` : `Page ${currentPage} of ${totalPages}`}
+      </Typography>
+      <IconButton
+        size="sm"
+        variant="outlined"
+        color="neutral"
+        aria-label="Next page"
+        disabled={currentPage >= totalPages || totalPages === 0}
+        onClick={() => onPageChange(currentPage + 1)}
+      >
+        <ChevronRightIcon />
+      </IconButton>
+    </Stack>
+  );
+
+  const pageSizeSelect = (
+    <Select
+      data-testid="admin-page-size-select"
+      size="sm"
+      value={currentLimit}
+      onChange={(_, value) => {
+        if (value) onLimitChange(value);
+      }}
+      sx={{ minWidth: 104 }}
+      renderValue={option => <Box component="span">{option?.value} / page</Box>}
+      slotProps={{ listbox: { placement: isCompact ? 'top' : 'bottom' } }}
+    >
+      {pageLimitOptions.map(limit => (
+        <Option key={limit} value={limit}>
+          {limit} / page
+        </Option>
+      ))}
+    </Select>
+  );
+
+  // Both variants keep the same geometry - pager left, page size right - so the top and
+  // bottom bars line up. Compact only drops the total count and shortens the page label.
+  return (
+    <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between" width="100%" sx={{ my: 1 }}>
+      {pager}
+      <Stack direction="row" spacing={1} alignItems="center">
+        {pageSizeSelect}
+        {!isCompact && (
+          <Typography level="body-sm" sx={{ color: 'text.secondary', whiteSpace: 'nowrap' }}>
+            {totalUsers} users
+          </Typography>
+        )}
+      </Stack>
+    </Stack>
+  );
+};
+
+export default PaginationControls;

--- a/apps/client/app/components/admin/Users/PaginationControls.tsx
+++ b/apps/client/app/components/admin/Users/PaginationControls.tsx
@@ -26,6 +26,8 @@ const PaginationControls: React.FC<PaginationControlsProps> = ({
   variant = 'full',
 }) => {
   const isCompact = variant === 'compact';
+  // totalPages is 0 until the first response lands; "of 0" would read as an empty result set.
+  const pageLabel = totalPages > 0 ? `${currentPage} of ${totalPages}` : `${currentPage}`;
 
   const pager = (
     <Stack direction="row" spacing={0.5} alignItems="center">
@@ -40,7 +42,7 @@ const PaginationControls: React.FC<PaginationControlsProps> = ({
         <ChevronLeftIcon />
       </IconButton>
       <Typography level="body-sm" sx={{ px: 0.5, whiteSpace: 'nowrap' }}>
-        {isCompact ? `${currentPage} of ${totalPages}` : `Page ${currentPage} of ${totalPages}`}
+        {isCompact ? pageLabel : `Page ${pageLabel}`}
       </Typography>
       <IconButton
         size="sm"

--- a/apps/client/app/components/admin/Users/UserIdChip.test.tsx
+++ b/apps/client/app/components/admin/Users/UserIdChip.test.tsx
@@ -1,0 +1,47 @@
+import { getThemeConfig } from '@client/app/utils/themes';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import UserIdChip, { truncateUserId } from './UserIdChip';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const writeText = vi.fn();
+
+beforeEach(() => {
+  writeText.mockReset().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+
+describe('truncateUserId', () => {
+  it('keeps the head and tail of a Mongo object id', () => {
+    const truncated = truncateUserId('6900781a8c1b76a684f80001');
+    expect(truncated.startsWith('690078')).toBe(true);
+    expect(truncated.endsWith('0001')).toBe(true);
+    expect(truncated).toHaveLength(11); // 6 head + 1 ellipsis + 4 tail
+  });
+
+  it('leaves short ids untouched', () => {
+    expect(truncateUserId('abc123')).toBe('abc123');
+  });
+});
+
+describe('UserIdChip', () => {
+  it('renders the truncated id and copies the full id on click', async () => {
+    const fullId = '6900781a8c1b76a684f80001';
+    render(<UserIdChip userId={fullId} />, { wrapper: TestWrapper });
+
+    const chip = screen.getByTestId('admin-user-id-chip');
+    expect(chip).toHaveTextContent(truncateUserId(fullId));
+    expect(chip).not.toHaveTextContent(fullId);
+
+    // Joy renders the clickable surface as a button nested inside the chip root.
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(fullId));
+  });
+});

--- a/apps/client/app/components/admin/Users/UserIdChip.test.tsx
+++ b/apps/client/app/components/admin/Users/UserIdChip.test.tsx
@@ -3,6 +3,10 @@ import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const toastError = vi.hoisted(() => vi.fn());
+vi.mock('sonner', () => ({ toast: { error: toastError } }));
+
 import UserIdChip, { truncateUserId } from './UserIdChip';
 
 const appTheme = extendTheme({ ...getThemeConfig() });
@@ -14,6 +18,7 @@ const writeText = vi.fn();
 
 beforeEach(() => {
   writeText.mockReset().mockResolvedValue(undefined);
+  toastError.mockReset();
   Object.assign(navigator, { clipboard: { writeText } });
 });
 
@@ -43,5 +48,16 @@ describe('UserIdChip', () => {
     fireEvent.click(screen.getByRole('button'));
 
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(fullId));
+  });
+
+  it('reports a clipboard failure instead of looking like a dead click', async () => {
+    // Rejects on an insecure origin or when the permission is denied.
+    writeText.mockRejectedValue(new Error('NotAllowedError'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<UserIdChip userId="6900781a8c1b76a684f80001" />, { wrapper: TestWrapper });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
   });
 });

--- a/apps/client/app/components/admin/Users/UserIdChip.tsx
+++ b/apps/client/app/components/admin/Users/UserIdChip.tsx
@@ -1,0 +1,47 @@
+import CheckIcon from '@mui/icons-material/Check';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Chip, Tooltip } from '@mui/joy';
+import React, { useEffect, useRef, useState } from 'react';
+
+interface UserIdChipProps {
+  userId: string;
+}
+
+export const truncateUserId = (userId: string): string =>
+  userId.length > 12 ? `${userId.slice(0, 6)}\u2026${userId.slice(-4)}` : userId;
+
+const UserIdChip: React.FC<UserIdChipProps> = ({ userId }) => {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(resetTimer.current), []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(userId);
+      setCopied(true);
+      clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error('Failed to copy user id:', err);
+    }
+  };
+
+  return (
+    <Tooltip title={copied ? 'Copied' : userId} placement="top">
+      <Chip
+        data-testid="admin-user-id-chip"
+        size="sm"
+        variant="outlined"
+        color={copied ? 'success' : 'neutral'}
+        onClick={handleCopy}
+        endDecorator={copied ? <CheckIcon sx={{ fontSize: 12 }} /> : <ContentCopyIcon sx={{ fontSize: 12 }} />}
+        sx={{ fontFamily: 'monospace', fontSize: '11px', maxWidth: '100%' }}
+      >
+        {truncateUserId(userId)}
+      </Chip>
+    </Tooltip>
+  );
+};
+
+export default UserIdChip;

--- a/apps/client/app/components/admin/Users/UserIdChip.tsx
+++ b/apps/client/app/components/admin/Users/UserIdChip.tsx
@@ -2,6 +2,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { Chip, Tooltip } from '@mui/joy';
 import React, { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 interface UserIdChipProps {
   userId: string;
@@ -23,7 +24,10 @@ const UserIdChip: React.FC<UserIdChipProps> = ({ userId }) => {
       clearTimeout(resetTimer.current);
       resetTimer.current = setTimeout(() => setCopied(false), 1500);
     } catch (err) {
+      // Rejects on an insecure origin or a denied permission; without this the chip is
+      // indistinguishable from a dead click.
       console.error('Failed to copy user id:', err);
+      toast.error('Could not copy the user id.');
     }
   };
 

--- a/apps/client/app/components/admin/Users/UsersFilterBar.test.tsx
+++ b/apps/client/app/components/admin/Users/UsersFilterBar.test.tsx
@@ -1,0 +1,108 @@
+import { getThemeConfig } from '@client/app/utils/themes';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockIsMobile = vi.fn(() => false);
+
+vi.mock('@client/app/hooks/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile(),
+  useIsTablet: () => false,
+}));
+
+vi.mock('@client/app/utils/organizationAPICalls', () => ({
+  useGetAllOrganizations: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('@client/app/hooks/data/user', () => ({
+  useGetUserTags: () => ({ data: [] }),
+}));
+
+vi.mock('@client/app/components/help/ContextHelpButton', () => ({
+  default: () => <button data-testid="admin-help-btn" />,
+}));
+
+import UsersFilterBar from './UsersFilterBar';
+import { DEFAULT_USERS_PARAMS, useUsersTab } from './useUsersTabParams';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const baseProps = {
+  displayMode: 'slim' as const,
+  onDisplayModeChange: vi.fn(),
+  loading: false,
+  search: '',
+  onSearchChange: vi.fn(),
+  onRefresh: vi.fn(),
+  onDownloadCsv: vi.fn(),
+  onCreateUser: vi.fn(),
+  downloadDisabled: false,
+  onOpenFilters: vi.fn(),
+};
+
+beforeEach(() => {
+  mockIsMobile.mockReset().mockReturnValue(false);
+  useUsersTab.setState({ params: { ...DEFAULT_USERS_PARAMS } });
+});
+
+describe('UsersFilterBar', () => {
+  it('shows the filter and sort controls inline on desktop, with no mobile filter toggle', () => {
+    render(<UsersFilterBar {...baseProps} />, { wrapper: TestWrapper });
+
+    expect(screen.getByTestId('admin-search-users-input')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-org-filter-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-tags-filter-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-sort-by-select')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-sort-order-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('admin-users-filter-toggle')).not.toBeInTheDocument();
+  });
+
+  it('moves the filter controls behind a toggle on mobile so the bar stays compact', () => {
+    mockIsMobile.mockReturnValue(true);
+    render(<UsersFilterBar {...baseProps} />, { wrapper: TestWrapper });
+
+    expect(screen.getByTestId('admin-users-filter-toggle')).toBeInTheDocument();
+    // The drawer owns these on mobile; rendering them here too would duplicate the testids.
+    expect(screen.queryByTestId('admin-org-filter-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('admin-sort-order-btn')).not.toBeInTheDocument();
+  });
+
+  it('keeps the create-user action reachable in both layouts', () => {
+    const { unmount } = render(<UsersFilterBar {...baseProps} />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('admin-create-user-btn')).toHaveTextContent('Create User');
+    unmount();
+
+    mockIsMobile.mockReturnValue(true);
+    render(<UsersFilterBar {...baseProps} />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('admin-create-user-btn')).toBeInTheDocument();
+  });
+
+  it('offers a clear button only while the search box has text', async () => {
+    const onSearchChange = vi.fn();
+    const { unmount } = render(<UsersFilterBar {...baseProps} onSearchChange={onSearchChange} />, {
+      wrapper: TestWrapper,
+    });
+    expect(screen.queryByTestId('admin-search-clear-btn')).not.toBeInTheDocument();
+    unmount();
+
+    render(<UsersFilterBar {...baseProps} search="ada" onSearchChange={onSearchChange} />, { wrapper: TestWrapper });
+    await userEvent.click(screen.getByTestId('admin-search-clear-btn'));
+
+    expect(onSearchChange).toHaveBeenCalledWith('');
+  });
+
+  it('offers a clear-filters chip only once a filter is active', () => {
+    const { unmount } = render(<UsersFilterBar {...baseProps} />, { wrapper: TestWrapper });
+    expect(screen.queryByTestId('admin-clear-filters-chip')).not.toBeInTheDocument();
+    unmount();
+
+    useUsersTab.setState({ params: { ...DEFAULT_USERS_PARAMS, tags: ['Admin'] } });
+    render(<UsersFilterBar {...baseProps} />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('admin-clear-filters-chip')).toHaveTextContent('1 filter');
+  });
+});

--- a/apps/client/app/components/admin/Users/UsersFilterBar.test.tsx
+++ b/apps/client/app/components/admin/Users/UsersFilterBar.test.tsx
@@ -67,6 +67,11 @@ describe('UsersFilterBar', () => {
     render(<UsersFilterBar {...baseProps} />, { wrapper: TestWrapper });
 
     expect(screen.getByTestId('admin-users-filter-toggle')).toBeInTheDocument();
+    // Icon-only buttons need a real accessible name; Tooltip only sets aria-describedby.
+    expect(screen.getByLabelText('Open filters')).toBeInTheDocument();
+    expect(screen.getByLabelText('Create user')).toBeInTheDocument();
+    expect(screen.getByLabelText('Refresh users')).toBeInTheDocument();
+    expect(screen.getByLabelText('Download users CSV')).toBeInTheDocument();
     // The drawer owns these on mobile; rendering them here too would duplicate the testids.
     expect(screen.queryByTestId('admin-org-filter-btn')).not.toBeInTheDocument();
     expect(screen.queryByTestId('admin-sort-order-btn')).not.toBeInTheDocument();

--- a/apps/client/app/components/admin/Users/UsersFilterBar.tsx
+++ b/apps/client/app/components/admin/Users/UsersFilterBar.tsx
@@ -132,6 +132,8 @@ const UsersFilterBar: React.FC<UsersFilterBarProps> = ({
       <Tooltip title="Create User">
         <IconButton
           data-testid="admin-create-user-btn"
+          // Tooltip only sets aria-describedby, so icon-only buttons still need their own name.
+          aria-label="Create user"
           size="sm"
           variant="solid"
           color="primary"
@@ -146,6 +148,7 @@ const UsersFilterBar: React.FC<UsersFilterBarProps> = ({
     <Tooltip title="Refresh">
       <IconButton
         data-testid="admin-refresh-btn"
+        aria-label="Refresh users"
         size="sm"
         variant="outlined"
         color="neutral"
@@ -161,6 +164,7 @@ const UsersFilterBar: React.FC<UsersFilterBarProps> = ({
     <Tooltip title="Download CSV">
       <IconButton
         data-testid="admin-download-csv-btn"
+        aria-label="Download users CSV"
         size="sm"
         variant="outlined"
         color="neutral"
@@ -190,6 +194,7 @@ const UsersFilterBar: React.FC<UsersFilterBarProps> = ({
           {viewModeSelect}
           <IconButton
             data-testid="admin-users-filter-toggle"
+            aria-label="Open filters"
             size="sm"
             variant={activeFilterCount > 0 ? 'soft' : 'outlined'}
             color={activeFilterCount > 0 ? 'primary' : 'neutral'}

--- a/apps/client/app/components/admin/Users/UsersFilterBar.tsx
+++ b/apps/client/app/components/admin/Users/UsersFilterBar.tsx
@@ -1,0 +1,247 @@
+import ContextHelpButton from '@client/app/components/help/ContextHelpButton';
+import { useIsMobile } from '@client/app/hooks/useIsMobile';
+import CloseIcon from '@mui/icons-material/Close';
+import DownloadIcon from '@mui/icons-material/Download';
+import ExpandIcon from '@mui/icons-material/Expand';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import HikingIcon from '@mui/icons-material/Hiking';
+import HistoryIcon from '@mui/icons-material/History';
+import PersonAddIcon from '@mui/icons-material/PersonAdd';
+import PersonSearchIcon from '@mui/icons-material/PersonSearch';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
+import { Badge, Box, Button, Card, Chip, IconButton, Input, Option, Select, Stack, Tooltip } from '@mui/joy';
+import React from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import OrganizationsFilter from './filters/OrganizationsFilter';
+import SortControls from './filters/SortControls';
+import UserTagsFilter from './filters/UserTagsFilter';
+import { CLEARED_FILTER_PARAMS, countActiveFilters, useUsersTab } from './useUsersTabParams';
+
+export type UsersDisplayMode = 'full' | 'slim' | 'userJourney' | 'recentActivity';
+
+const DISPLAY_MODES: { value: UsersDisplayMode; label: string; icon: React.ReactNode }[] = [
+  { value: 'slim', label: 'Slim', icon: <UnfoldLessIcon fontSize="small" /> },
+  { value: 'full', label: 'Full', icon: <ExpandIcon fontSize="small" /> },
+  { value: 'userJourney', label: 'User Journey', icon: <HikingIcon fontSize="small" /> },
+  { value: 'recentActivity', label: 'Recent Activity', icon: <HistoryIcon fontSize="small" /> },
+];
+
+interface UsersFilterBarProps {
+  displayMode: UsersDisplayMode;
+  onDisplayModeChange: (mode: UsersDisplayMode) => void;
+  loading: boolean;
+  search: string;
+  onSearchChange: (value: string) => void;
+  onRefresh: () => void;
+  onDownloadCsv: () => void;
+  onCreateUser: () => void;
+  downloadDisabled: boolean;
+  /** Mobile only: opens the filter drawer that hosts org/tag/sort controls. */
+  onOpenFilters: () => void;
+}
+
+const UsersFilterBar: React.FC<UsersFilterBarProps> = ({
+  displayMode,
+  onDisplayModeChange,
+  loading,
+  search,
+  onSearchChange,
+  onRefresh,
+  onDownloadCsv,
+  onCreateUser,
+  downloadDisabled,
+  onOpenFilters,
+}) => {
+  const isMobile = useIsMobile();
+  const [params, setParams] = useUsersTab(useShallow(state => [state.params, state.setParams]));
+  const activeFilterCount = countActiveFilters(params);
+
+  const searchInput = (
+    <Input
+      data-testid="admin-search-users-input"
+      size="sm"
+      startDecorator={<PersonSearchIcon />}
+      endDecorator={
+        search ? (
+          <IconButton
+            data-testid="admin-search-clear-btn"
+            size="sm"
+            variant="plain"
+            color="neutral"
+            aria-label="Clear search"
+            onClick={() => onSearchChange('')}
+          >
+            <CloseIcon />
+          </IconButton>
+        ) : null
+      }
+      placeholder="Search users"
+      value={search}
+      onChange={event => onSearchChange(event.target.value)}
+      sx={{ flex: 1, minWidth: 0 }}
+    />
+  );
+
+  const viewModeSelect = (
+    <Select
+      data-testid="admin-view-mode-select"
+      size="sm"
+      value={displayMode}
+      onChange={(_, value) => {
+        if (value) onDisplayModeChange(value);
+      }}
+      disabled={loading}
+      sx={{ minWidth: isMobile ? 110 : 170, flexShrink: 0 }}
+      renderValue={option => {
+        const mode = DISPLAY_MODES.find(m => m.value === option?.value);
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+            {mode?.icon}
+            <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {mode?.label}
+            </Box>
+          </Box>
+        );
+      }}
+    >
+      {DISPLAY_MODES.map(mode => (
+        <Option key={mode.value} value={mode.value}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {mode.icon}
+            {mode.label}
+          </Box>
+        </Option>
+      ))}
+    </Select>
+  );
+
+  const createUserButton = (label: boolean) =>
+    label ? (
+      <Button
+        data-testid="admin-create-user-btn"
+        size="sm"
+        color="primary"
+        startDecorator={<PersonAddIcon />}
+        onClick={onCreateUser}
+        sx={{ flexShrink: 0 }}
+      >
+        Create User
+      </Button>
+    ) : (
+      <Tooltip title="Create User">
+        <IconButton
+          data-testid="admin-create-user-btn"
+          size="sm"
+          variant="solid"
+          color="primary"
+          onClick={onCreateUser}
+        >
+          <PersonAddIcon />
+        </IconButton>
+      </Tooltip>
+    );
+
+  const refreshButton = (
+    <Tooltip title="Refresh">
+      <IconButton
+        data-testid="admin-refresh-btn"
+        size="sm"
+        variant="outlined"
+        color="neutral"
+        disabled={loading}
+        onClick={onRefresh}
+      >
+        <RefreshIcon />
+      </IconButton>
+    </Tooltip>
+  );
+
+  const downloadButton = (
+    <Tooltip title="Download CSV">
+      <IconButton
+        data-testid="admin-download-csv-btn"
+        size="sm"
+        variant="outlined"
+        color="neutral"
+        disabled={downloadDisabled}
+        onClick={onDownloadCsv}
+      >
+        <DownloadIcon />
+      </IconButton>
+    </Tooltip>
+  );
+
+  // Create User is the only accented control, so the secondary actions share one quiet style.
+  const helpButton = (
+    <ContextHelpButton
+      helpId="admin/user-management"
+      tooltipText="User Management Help"
+      variant="outlined"
+      data-testid="admin-help-btn"
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <Card sx={{ px: 1, py: 0.75, gap: 0.75 }}>
+        <Stack direction="row" spacing={0.75} alignItems="center">
+          {searchInput}
+          {viewModeSelect}
+          <IconButton
+            data-testid="admin-users-filter-toggle"
+            size="sm"
+            variant={activeFilterCount > 0 ? 'soft' : 'outlined'}
+            color={activeFilterCount > 0 ? 'primary' : 'neutral'}
+            onClick={onOpenFilters}
+            sx={{ flexShrink: 0 }}
+          >
+            <Badge badgeContent={activeFilterCount} badgeInset="14%" size="sm" invisible={activeFilterCount === 0}>
+              <FilterListIcon />
+            </Badge>
+          </IconButton>
+        </Stack>
+        <Stack direction="row" spacing={0.75} alignItems="center" justifyContent="flex-end">
+          {createUserButton(false)}
+          {refreshButton}
+          {downloadButton}
+          {helpButton}
+        </Stack>
+      </Card>
+    );
+  }
+
+  return (
+    <Card sx={{ px: 2, py: 1, gap: 1 }}>
+      {/* Search stretches into the remaining space so the row has no dead gap. */}
+      <Stack direction="row" spacing={1} alignItems="center">
+        {searchInput}
+        {viewModeSelect}
+        {createUserButton(true)}
+        {refreshButton}
+        {downloadButton}
+        {helpButton}
+      </Stack>
+
+      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+        <OrganizationsFilter disabled={loading} />
+        <UserTagsFilter disabled={loading} />
+        <SortControls disabled={loading} />
+        {activeFilterCount > 0 && (
+          <Chip
+            data-testid="admin-clear-filters-chip"
+            size="sm"
+            variant="soft"
+            color="primary"
+            endDecorator={<CloseIcon sx={{ fontSize: 14 }} />}
+            onClick={() => setParams(CLEARED_FILTER_PARAMS)}
+          >
+            {activeFilterCount} {activeFilterCount === 1 ? 'filter' : 'filters'}
+          </Chip>
+        )}
+      </Stack>
+    </Card>
+  );
+};
+
+export default UsersFilterBar;

--- a/apps/client/app/components/admin/Users/Views/SlimUsersView.test.tsx
+++ b/apps/client/app/components/admin/Users/Views/SlimUsersView.test.tsx
@@ -1,0 +1,86 @@
+import type { IUserDocument, WithOrgRef } from '@bike4mind/common';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockIsMobile = vi.fn(() => false);
+
+vi.mock('@client/app/hooks/useIsMobile', () => ({
+  useIsMobile: () => mockIsMobile(),
+  useIsTablet: () => false,
+}));
+
+vi.mock('@client/app/hooks/data/user', () => ({
+  useGetRecentActivities: () => ({ data: [] }),
+  useGetUserActivityCounters: () => ({ data: [] }),
+  useGetUser: () => ({ data: undefined, isLoading: false }),
+}));
+
+import SlimUsersContainer from './SlimUsersView';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const makeUser = (id: string, name: string): WithOrgRef<IUserDocument> =>
+  ({
+    id,
+    name,
+    email: `${name.toLowerCase()}@example.com`,
+    storageLimit: 1024,
+    currentStorageSize: 0,
+    loginRecords: [],
+  }) as unknown as WithOrgRef<IUserDocument>;
+
+const users = [makeUser('6900781a8c1b76a684f80001', 'Ada'), makeUser('68f727e8e537d08a1af4dacf', 'Grace')];
+
+beforeEach(() => {
+  mockIsMobile.mockReset().mockReturnValue(false);
+  Object.assign(navigator, { clipboard: { writeText: vi.fn() } });
+});
+
+describe('SlimUsersContainer', () => {
+  it('renders the column header and one row per user on desktop', () => {
+    render(<SlimUsersContainer users={users} />, { wrapper: TestWrapper });
+
+    expect(screen.getByText('Recent Activity')).toBeInTheDocument();
+    expect(screen.getAllByTestId('admin-user-card')).toHaveLength(2);
+    expect(screen.getByTestId('user-name-Ada')).toBeInTheDocument();
+  });
+
+  it('drops the column header on mobile and still renders one card per user', () => {
+    mockIsMobile.mockReturnValue(true);
+    render(<SlimUsersContainer users={users} />, { wrapper: TestWrapper });
+
+    // The header row is table chrome; the stacked cards replace it entirely.
+    expect(screen.queryByText('Recent Activity')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('admin-user-card')).toHaveLength(2);
+    expect(screen.getByTestId('user-name-Grace')).toBeInTheDocument();
+  });
+
+  it('keeps user rows free of the horizontal scroll that broke the mobile layout', () => {
+    mockIsMobile.mockReturnValue(true);
+    render(<SlimUsersContainer users={users} />, { wrapper: TestWrapper });
+
+    for (const card of screen.getAllByTestId('admin-user-card')) {
+      const styles = getComputedStyle(card);
+      expect(styles.overflowX).not.toBe('auto');
+      expect(styles.minWidth).not.toBe('800px');
+    }
+  });
+
+  it('exposes exactly one admin action pair per user in each layout', () => {
+    const { unmount } = render(<SlimUsersContainer users={users} />, { wrapper: TestWrapper });
+    expect(screen.getAllByTestId('admin-user-admin-btn')).toHaveLength(2);
+    expect(screen.getAllByTestId('admin-user-profile-btn')).toHaveLength(2);
+    unmount();
+
+    mockIsMobile.mockReturnValue(true);
+    render(<SlimUsersContainer users={users} />, { wrapper: TestWrapper });
+    expect(screen.getAllByTestId('admin-user-admin-btn')).toHaveLength(2);
+    expect(screen.getAllByTestId('admin-user-profile-btn')).toHaveLength(2);
+  });
+});

--- a/apps/client/app/components/admin/Users/Views/SlimUsersView.tsx
+++ b/apps/client/app/components/admin/Users/Views/SlimUsersView.tsx
@@ -1,13 +1,15 @@
 import { IUserDocument, WithOrgRef } from '@bike4mind/common';
-import { Button, Card, Grid, Typography, Tooltip, LinearProgress, Box } from '@mui/joy';
-import React from 'react';
+import { useFullUserViewModal } from '@client/app/components/admin/Users/Views/FullUserViewModal';
+import { useGetRecentActivities } from '@client/app/hooks/data/user';
+import { useIsMobile } from '@client/app/hooks/useIsMobile';
+import { relativeTimeFormat } from '@client/app/utils/dateUtils';
+import { Box, Button, Card, Grid, LinearProgress, Stack, Tooltip, Typography } from '@mui/joy';
+import prettyBytes from 'pretty-bytes';
+import React, { useMemo } from 'react';
 import AdminProfile from '../../AdminProfile';
 import LoginsView from '../LoginsView';
 import MFAStatusBadge from '../MFAStatusBadge';
-import { useFullUserViewModal } from '@client/app/components/admin/Users/Views/FullUserViewModal';
-import { useGetRecentActivities } from '@client/app/hooks/data/user';
-import { useMemo } from 'react';
-import prettyBytes from 'pretty-bytes';
+import UserIdChip from '../UserIdChip';
 import { computeStoragePercent } from './storageUtils';
 
 interface SlimUsersViewProps {
@@ -19,216 +21,227 @@ interface SlimUsersContainerProps {
   users: WithOrgRef<IUserDocument>[];
 }
 
-const SlimUsersViewHeader: React.FC = () => {
-  return (
-    <Card
-      variant="outlined"
-      sx={{
-        mb: 1,
-        width: '100%',
-        bgcolor: 'background.surface',
-        p: { xs: 0.5, sm: 1 },
-        position: 'sticky',
-        top: 0,
-        zIndex: 1,
-        borderBottom: 2,
-        borderColor: 'divider',
-        overflowX: { xs: 'auto', sm: 'visible' },
-      }}
-    >
-      <Grid
-        container
-        spacing={2}
-        sx={{ width: '100%', minWidth: { xs: '800px', sm: 'auto' } }}
-        justifyContent={'center'}
-        alignItems={'center'}
-      >
-        <Grid xs={1.5}>
-          <Typography level="title-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            Name
-          </Typography>
-        </Grid>
-        <Grid xs={1.5}>
-          <Typography level="title-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            User ID
-          </Typography>
-        </Grid>
-        <Grid xs={2.5}>
-          <Typography level="title-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            Email
-          </Typography>
-        </Grid>
-        <Grid xs={1}>
-          <Typography level="title-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            Logins
-          </Typography>
-        </Grid>
-        <Grid xs={1.5}>
-          <Typography level="title-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            Storage
-          </Typography>
-        </Grid>
-        <Grid xs={1}>
-          <Typography level="title-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            Security
-          </Typography>
-        </Grid>
-        <Grid xs={1}>
-          <Typography level="title-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            Recent Activity
-          </Typography>
-        </Grid>
-        <Grid xs={2}>
-          <Typography level="title-sm" sx={{ fontWeight: 600, color: 'text.primary' }}>
-            Actions
-          </Typography>
-        </Grid>
-      </Grid>
-    </Card>
-  );
-};
+/** Header and row share these widths; they must be edited together or the table skews. */
+const COLUMN_WIDTHS = {
+  name: 2,
+  userId: 1.25,
+  email: 2.25,
+  logins: 0.75,
+  storage: 1.25,
+  security: 1,
+  activity: 1.5,
+  actions: 2,
+} as const;
 
-const SlimUsersView: React.FC<SlimUsersViewProps> = ({ user, index }) => {
-  const setFullUserViewUserId = useFullUserViewModal(state => state.setUserId);
-  const recentActivities = useGetRecentActivities({ coverage: 'all', userId: user.id });
-  const latestActivity = useMemo(() => recentActivities.data?.slice(0, 1) ?? [], [recentActivities.data]);
+const ELLIPSIS_SX = { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } as const;
 
+const StorageCell: React.FC<{ user: WithOrgRef<IUserDocument> }> = ({ user }) => {
   const storageLimitBytes = user.storageLimit * 1024 * 1024;
   const storagePercent = computeStoragePercent(user.currentStorageSize, user.storageLimit);
+  // Below 1% a percentage reads as "no data"; show the raw size so the cell stays meaningful.
+  const label = storagePercent < 1 ? prettyBytes(user.currentStorageSize || 0) : `${Math.round(storagePercent)}%`;
 
   return (
-    <Card
-      variant="outlined"
-      key={index}
-      data-testid="admin-user-card"
-      sx={{
-        mb: 1,
-        width: '100%',
-        bgcolor: index % 2 ? 'background.level1' : 'background.level2',
-        p: { xs: 0.5, sm: 1 },
-        overflowX: { xs: 'auto', sm: 'visible' },
-      }}
-    >
-      <Grid
-        container
-        spacing={2}
-        sx={{ width: '100%', minWidth: { xs: '800px', sm: 'auto' } }}
-        justifyContent={'center'}
-        alignItems={'center'}
-      >
-        {/* Name, User Name, Organization, Email */}
-        <Grid xs={1.5}>
-          <Tooltip title={user.name} placement="top">
-            <Typography
-              level="body-sm"
-              sx={{
-                whiteSpace: 'nowrap',
-                maxWidth: '100%',
-                cursor: 'help',
-                fontWeight: 500,
-              }}
-              data-testid={`user-name-${user.name}`}
-            >
-              {user.name.length > 15 ? `${user.name.substring(0, 15)}...` : user.name}
-            </Typography>
-          </Tooltip>
-        </Grid>
-
-        <Grid xs={1.5}>
-          <Typography
-            level="body-xs"
-            sx={{
-              wordBreak: 'break-all',
-              fontFamily: 'monospace',
-              color: 'text.tertiary',
-              fontSize: '10px',
-            }}
-          >
-            {user.id}
-          </Typography>
-        </Grid>
-
-        <Grid xs={2.5}>
-          <Typography
-            level="body-sm"
-            sx={{
-              wordBreak: 'break-all',
-              color: 'text.secondary',
-            }}
-          >
-            {user.email}
-          </Typography>
-        </Grid>
-
-        <Grid xs={1}>
-          <LoginsView user={user} />
-        </Grid>
-
-        <Grid xs={1.5}>
-          <Tooltip
-            title={`${prettyBytes(user.currentStorageSize || 0)} / ${prettyBytes(storageLimitBytes)}`}
-            placement="top"
-          >
-            <Box sx={{ width: '100%', px: 1 }}>
-              <LinearProgress
-                determinate
-                thickness={20}
-                value={storagePercent}
-                sx={{
-                  '--LinearProgress-progressThickness': '16px',
-                  borderRadius: '4px',
-                  border: '1px solid',
-                  borderColor: 'neutral.outlinedBorder',
-                  height: '16px',
-                  backgroundColor: 'background.level2',
-                }}
-                color={storagePercent >= 90 ? 'danger' : storagePercent >= 75 ? 'warning' : 'primary'}
-              >
-                <Typography
-                  level="body-xs"
-                  sx={{
-                    fontSize: '9px',
-                    mixBlendMode: 'normal',
-                    color: 'text.primary',
-                    fontWeight: 500,
-                    zIndex: 2,
-                  }}
-                >
-                  {Math.round(storagePercent)}%
-                </Typography>
-              </LinearProgress>
-            </Box>
-          </Tooltip>
-        </Grid>
-
-        <Grid xs={1}>
-          <MFAStatusBadge user={user} />
-        </Grid>
-
-        <Grid xs={1}>
-          {latestActivity[0] ? (
-            <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-              {new Date(latestActivity[0].datetime).toDateString()} {latestActivity[0].counterName}
-            </Typography>
-          ) : (
-            <Typography level="body-xs" sx={{ color: 'text.tertiary', fontStyle: 'italic' }}>
-              No activity
-            </Typography>
-          )}
-        </Grid>
-
-        <Grid xs={2} sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-          <Button data-testid="admin-user-admin-btn" size="sm" onClick={() => setFullUserViewUserId(user.id)}>
-            Admin
-          </Button>
-          <AdminProfile userId={user.id} size="sm" />
-        </Grid>
-      </Grid>
-    </Card>
+    <Tooltip title={`${prettyBytes(user.currentStorageSize || 0)} / ${prettyBytes(storageLimitBytes)}`} placement="top">
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ cursor: 'help' }}>
+        <LinearProgress
+          determinate
+          thickness={6}
+          value={storagePercent}
+          color={storagePercent >= 90 ? 'danger' : storagePercent >= 75 ? 'warning' : 'primary'}
+          sx={{ flex: 1, minWidth: 0 }}
+        />
+        <Typography level="body-xs" sx={{ color: 'text.secondary', flexShrink: 0 }}>
+          {label}
+        </Typography>
+      </Stack>
+    </Tooltip>
   );
 };
 
+const useLatestActivity = (userId: string) => {
+  const recentActivities = useGetRecentActivities({ coverage: 'all', userId });
+  return useMemo(() => recentActivities.data?.[0], [recentActivities.data]);
+};
+
+const RecentActivityCell: React.FC<{ userId: string }> = ({ userId }) => {
+  const latestActivity = useLatestActivity(userId);
+
+  if (!latestActivity) {
+    return (
+      <Typography level="body-xs" sx={{ color: 'text.tertiary', fontStyle: 'italic', ...ELLIPSIS_SX }}>
+        No activity
+      </Typography>
+    );
+  }
+
+  return (
+    <Tooltip
+      title={`${new Date(latestActivity.datetime).toLocaleString()} - ${latestActivity.counterName}`}
+      placement="top"
+    >
+      <Typography level="body-xs" sx={{ color: 'text.secondary', cursor: 'help', ...ELLIPSIS_SX }}>
+        {relativeTimeFormat(new Date(latestActivity.datetime))}
+      </Typography>
+    </Tooltip>
+  );
+};
+
+const UserActions: React.FC<{ userId: string }> = ({ userId }) => {
+  const setFullUserViewUserId = useFullUserViewModal(state => state.setUserId);
+
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ flexShrink: 0 }}>
+      <Button data-testid="admin-user-admin-btn" size="sm" onClick={() => setFullUserViewUserId(userId)}>
+        Admin
+      </Button>
+      <AdminProfile userId={userId} size="sm" />
+    </Stack>
+  );
+};
+
+const SlimUsersViewHeader: React.FC = () => (
+  <Card
+    variant="outlined"
+    sx={{
+      mb: 1,
+      width: '100%',
+      bgcolor: 'background.surface',
+      p: 1,
+      position: 'sticky',
+      top: 0,
+      zIndex: 1,
+      borderBottom: 2,
+      borderColor: 'divider',
+    }}
+  >
+    <Grid container spacing={2} sx={{ width: '100%' }} alignItems="center">
+      {(
+        [
+          ['Name', COLUMN_WIDTHS.name],
+          ['User ID', COLUMN_WIDTHS.userId],
+          ['Email', COLUMN_WIDTHS.email],
+          ['Logins', COLUMN_WIDTHS.logins],
+          ['Storage', COLUMN_WIDTHS.storage],
+          ['Security', COLUMN_WIDTHS.security],
+          ['Recent Activity', COLUMN_WIDTHS.activity],
+          ['Actions', COLUMN_WIDTHS.actions],
+        ] as const
+      ).map(([label, width]) => (
+        <Grid key={label} xs={width}>
+          <Typography level="title-sm" sx={{ fontWeight: 600, color: 'text.primary', ...ELLIPSIS_SX }}>
+            {label}
+          </Typography>
+        </Grid>
+      ))}
+    </Grid>
+  </Card>
+);
+
+const SlimUsersView: React.FC<SlimUsersViewProps> = ({ user, index }) => (
+  <Card
+    variant="outlined"
+    data-testid="admin-user-card"
+    sx={{
+      mb: 1,
+      width: '100%',
+      bgcolor: index % 2 ? 'background.level1' : 'background.level2',
+      p: 1,
+    }}
+  >
+    <Grid container spacing={2} sx={{ width: '100%' }} alignItems="center">
+      <Grid xs={COLUMN_WIDTHS.name}>
+        <Tooltip title={user.name} placement="top">
+          <Typography
+            level="body-sm"
+            sx={{ cursor: 'help', fontWeight: 500, ...ELLIPSIS_SX }}
+            data-testid={`user-name-${user.name}`}
+          >
+            {user.name}
+          </Typography>
+        </Tooltip>
+      </Grid>
+
+      <Grid xs={COLUMN_WIDTHS.userId} sx={{ minWidth: 0 }}>
+        <UserIdChip userId={user.id} />
+      </Grid>
+
+      <Grid xs={COLUMN_WIDTHS.email} sx={{ minWidth: 0 }}>
+        <Tooltip title={user.email} placement="top">
+          <Typography level="body-sm" sx={{ color: 'text.secondary', cursor: 'help', ...ELLIPSIS_SX }}>
+            {user.email}
+          </Typography>
+        </Tooltip>
+      </Grid>
+
+      <Grid xs={COLUMN_WIDTHS.logins}>
+        <LoginsView user={user} />
+      </Grid>
+
+      <Grid xs={COLUMN_WIDTHS.storage}>
+        <StorageCell user={user} />
+      </Grid>
+
+      <Grid xs={COLUMN_WIDTHS.security}>
+        <MFAStatusBadge user={user} />
+      </Grid>
+
+      <Grid xs={COLUMN_WIDTHS.activity} sx={{ minWidth: 0 }}>
+        <RecentActivityCell userId={user.id} />
+      </Grid>
+
+      <Grid xs={COLUMN_WIDTHS.actions}>
+        <UserActions userId={user.id} />
+      </Grid>
+    </Grid>
+  </Card>
+);
+
+/**
+ * Phone layout: stacked card instead of the 800px-wide grid, which previously gave every
+ * row its own horizontal scrollbar. Storage is omitted here and stays in the Admin modal.
+ */
+const SlimUserCardMobile: React.FC<SlimUsersViewProps> = ({ user, index }) => (
+  <Card
+    variant="outlined"
+    data-testid="admin-user-card"
+    sx={{ mb: 1, width: '100%', bgcolor: index % 2 ? 'background.level1' : 'background.level2', p: 1, gap: 1 }}
+  >
+    <Stack direction="row" spacing={1} alignItems="flex-start" justifyContent="space-between">
+      <Box sx={{ minWidth: 0 }}>
+        <Typography level="title-sm" data-testid={`user-name-${user.name}`} sx={ELLIPSIS_SX}>
+          {user.name}
+        </Typography>
+        <Typography level="body-xs" sx={{ color: 'text.secondary', ...ELLIPSIS_SX }}>
+          {user.email}
+        </Typography>
+      </Box>
+      <UserActions userId={user.id} />
+    </Stack>
+
+    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+      <UserIdChip userId={user.id} />
+      <LoginsView user={user} />
+      <MFAStatusBadge user={user} />
+      <RecentActivityCell userId={user.id} />
+    </Stack>
+  </Card>
+);
+
 const SlimUsersContainer: React.FC<SlimUsersContainerProps> = ({ users }) => {
+  const isMobile = useIsMobile();
+
+  // Rendered conditionally rather than hidden with CSS so row testids never appear twice.
+  if (isMobile) {
+    return (
+      <>
+        {users.map((user, index) => (
+          <SlimUserCardMobile user={user} index={index} key={user.id} />
+        ))}
+      </>
+    );
+  }
+
   return (
     <>
       <SlimUsersViewHeader />

--- a/apps/client/app/components/admin/Users/exportUsersCsv.test.ts
+++ b/apps/client/app/components/admin/Users/exportUsersCsv.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IGetUsersParams } from '@client/app/utils/userAPICalls';
+
+const get = vi.hoisted(() => vi.fn());
+const downloadData = vi.hoisted(() => vi.fn());
+
+vi.mock('@client/app/contexts/ApiContext', () => ({ api: { get } }));
+vi.mock('@client/app/utils/download', () => ({ downloadData }));
+
+import { exportUsersCsv } from './exportUsersCsv';
+
+const PARAMS: IGetUsersParams = { page: 1, limit: 10 };
+
+const makeUser = (overrides: Record<string, unknown> = {}) => ({
+  name: 'Ada',
+  username: 'ada',
+  email: 'ada@example.com',
+  organizationId: { name: 'Acme' },
+  loginRecords: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  isAdmin: false,
+  isBanned: false,
+  ...overrides,
+});
+
+const respondWith = (...users: Record<string, unknown>[]) =>
+  get.mockResolvedValue({ data: { users, currentPage: 1, totalPages: 1, totalUsers: users.length } });
+
+/** The CSV handed to the download helper, split into lines. */
+const writtenLines = () => (downloadData.mock.calls[0][0] as string).split('\n');
+const dataRow = () => writtenLines()[1];
+
+beforeEach(() => {
+  get.mockReset();
+  downloadData.mockReset();
+});
+
+describe('exportUsersCsv', () => {
+  it('asks for every user rather than the current page', async () => {
+    respondWith(makeUser());
+
+    await exportUsersCsv({ page: 3, limit: 10, search: 'ada' });
+
+    expect(get.mock.calls[0][1].params).toMatchObject({ downloadAll: true, page: 1, search: 'ada' });
+  });
+
+  it('reads the organization from the populated organizationId ref', async () => {
+    respondWith(makeUser({ organizationId: { name: 'Acme' } }));
+
+    await exportUsersCsv(PARAMS);
+
+    expect(dataRow()).toContain('"Acme"');
+  });
+
+  it('leaves the organization cell blank when the ref is not populated', async () => {
+    respondWith(makeUser({ organizationId: undefined }));
+
+    await exportUsersCsv(PARAMS);
+
+    expect(dataRow()).toBe('"Ada","","ada","ada@example.com","0","N/A","2026-01-01T00:00:00.000Z","No","No"');
+  });
+
+  it('keeps a name containing a comma in a single field', async () => {
+    respondWith(makeUser({ name: 'Lovelace, Ada' }));
+
+    await exportUsersCsv(PARAMS);
+
+    expect(dataRow()).toContain('"Lovelace, Ada"');
+    expect(dataRow().split(',')).toHaveLength(10); // 9 fields, one split inside the quoted name
+  });
+
+  it('defuses a name that a spreadsheet would run as a formula', async () => {
+    respondWith(makeUser({ name: '=HYPERLINK("http://evil/")' }));
+
+    await exportUsersCsv(PARAMS);
+
+    expect(dataRow().startsWith(`"'=HYPERLINK`)).toBe(true);
+  });
+
+  it('reports the newest login rather than the first array element', async () => {
+    respondWith(
+      makeUser({
+        loginRecords: [
+          { loginTime: '2026-02-01T00:00:00.000Z' },
+          { loginTime: '2026-06-01T00:00:00.000Z' },
+          { loginTime: '2026-03-01T00:00:00.000Z' },
+        ],
+      })
+    );
+
+    await exportUsersCsv(PARAMS);
+
+    expect(dataRow()).toContain('"2026-06-01T00:00:00.000Z"');
+    expect(dataRow()).toContain('"3"'); // login count
+  });
+
+  it('writes a header row', async () => {
+    respondWith(makeUser());
+
+    await exportUsersCsv(PARAMS);
+
+    expect(writtenLines()[0]).toBe(
+      '"Name","Organization","Username","Email","Logins","Last Login","Created At","Is Admin","Is Banned"'
+    );
+    expect(downloadData).toHaveBeenCalledWith(expect.any(String), 'users.csv', 'text/csv;charset=utf-8;');
+  });
+
+  it('propagates a failed request and writes no file', async () => {
+    // fetchUsers would swallow this into an empty list, downloading a header-only CSV that reads
+    // as a successful export of zero users.
+    get.mockRejectedValue(new Error('Request failed with status code 403'));
+
+    await expect(exportUsersCsv(PARAMS)).rejects.toThrow('403');
+    expect(downloadData).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/admin/Users/exportUsersCsv.ts
+++ b/apps/client/app/components/admin/Users/exportUsersCsv.ts
@@ -1,0 +1,54 @@
+import { IGetUsersParams, fetchUsers } from '@client/app/utils/userAPICalls';
+
+const CSV_HEADERS = [
+  'Name',
+  'Organization',
+  'Username',
+  'Email',
+  'Logins',
+  'Last Login',
+  'Created At',
+  'Is Admin',
+  'Is Banned',
+];
+
+export const exportUsersCsv = async (params: IGetUsersParams): Promise<void> => {
+  const { users } = await fetchUsers({ ...params, downloadAll: true, page: 1, limit: 1000000 });
+
+  const rows = users.map(
+    // any: the row shape is looser than IUserDocument here; kept as-is from the original
+    // inline implementation so this extraction changes no output.
+    (user: {
+      name: any;
+      organization?: { name: string };
+      username: any;
+      email: any;
+      loginRecords: any;
+      createdAt: any;
+      isAdmin: any;
+      isBanned: any;
+    }) => [
+      user.name,
+      user.organization?.name,
+      user.username,
+      user.email,
+      user.loginRecords.length,
+      user.loginRecords?.length > 0 ? user.loginRecords[0].loginTime : 'N/A',
+      user.createdAt,
+      user.isAdmin ? 'Yes' : 'No',
+      user.isBanned ? 'Yes' : 'No',
+    ]
+  );
+
+  const csvData = [CSV_HEADERS, ...rows].map(row => row.join(',')).join('\n');
+
+  const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  const url = URL.createObjectURL(blob);
+  link.setAttribute('href', url);
+  link.setAttribute('download', 'users.csv');
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};

--- a/apps/client/app/components/admin/Users/exportUsersCsv.ts
+++ b/apps/client/app/components/admin/Users/exportUsersCsv.ts
@@ -1,4 +1,8 @@
-import { IGetUsersParams, fetchUsers } from '@client/app/utils/userAPICalls';
+import { api } from '@client/app/contexts/ApiContext';
+import { toCsv } from '@client/app/utils/csv';
+import { downloadData } from '@client/app/utils/download';
+import { getLastLoginDate } from '@client/app/utils/user';
+import { IGetUsersParams, IGetUsersResponse } from '@client/app/utils/userAPICalls';
 
 const CSV_HEADERS = [
   'Name',
@@ -12,40 +16,31 @@ const CSV_HEADERS = [
   'Is Banned',
 ];
 
-/** Wraps values containing a comma/quote/newline so they survive a spreadsheet import. */
-const escapeCell = (value: unknown): string => {
-  const text = value === null || value === undefined ? '' : String(value);
-  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
-};
-
 export const exportUsersCsv = async (params: IGetUsersParams): Promise<void> => {
-  const { users } = await fetchUsers({ ...params, downloadAll: true, page: 1, limit: 1000000 });
+  // Deliberately not fetchUsers: that helper turns a failure into an empty result set, which here
+  // would download a header-only file reading as "zero users". The rejection has to reach the
+  // caller so it can say the export failed. Same reasoning as fetchCounterLogs in userAPICalls.
+  const { data } = await api.get<IGetUsersResponse>('/api/users', {
+    params: { ...params, downloadAll: true, page: 1, limit: 1000000 },
+  });
 
-  const rows = users.map(user => [
-    user.name,
-    // The populated org ref lives on organizationId; the old `user.organization` read was
-    // always undefined, so this column shipped empty. Reads as undefined (blank cell) if the
-    // API ever returns a bare id string instead of the populated document.
-    user.organizationId?.name,
-    user.username,
-    user.email,
-    user.loginRecords?.length ?? 0,
-    user.loginRecords?.length ? user.loginRecords[0].loginTime : 'N/A',
-    user.createdAt,
-    user.isAdmin ? 'Yes' : 'No',
-    user.isBanned ? 'Yes' : 'No',
-  ]);
+  const rows = data.users.map(user => {
+    const lastLogin = getLastLoginDate(user);
 
-  const csvData = [CSV_HEADERS, ...rows].map(row => row.map(escapeCell).join(',')).join('\n');
+    return [
+      user.name,
+      // The populated org ref lives on organizationId; reading `user.organization` left this
+      // column empty. Undefined (a blank cell) if the API returns a bare id instead of the doc.
+      user.organizationId?.name,
+      user.username,
+      user.email,
+      user.loginRecords?.length ?? 0,
+      lastLogin ? lastLogin.toISOString() : 'N/A',
+      user.createdAt,
+      user.isAdmin ? 'Yes' : 'No',
+      user.isBanned ? 'Yes' : 'No',
+    ];
+  });
 
-  const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.setAttribute('href', url);
-  link.setAttribute('download', 'users.csv');
-  link.style.visibility = 'hidden';
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  downloadData(toCsv([CSV_HEADERS, ...rows]), 'users.csv', 'text/csv;charset=utf-8;');
 };

--- a/apps/client/app/components/admin/Users/exportUsersCsv.ts
+++ b/apps/client/app/components/admin/Users/exportUsersCsv.ts
@@ -12,43 +12,40 @@ const CSV_HEADERS = [
   'Is Banned',
 ];
 
+/** Wraps values containing a comma/quote/newline so they survive a spreadsheet import. */
+const escapeCell = (value: unknown): string => {
+  const text = value === null || value === undefined ? '' : String(value);
+  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+};
+
 export const exportUsersCsv = async (params: IGetUsersParams): Promise<void> => {
   const { users } = await fetchUsers({ ...params, downloadAll: true, page: 1, limit: 1000000 });
 
-  const rows = users.map(
-    // any: the row shape is looser than IUserDocument here; kept as-is from the original
-    // inline implementation so this extraction changes no output.
-    (user: {
-      name: any;
-      organization?: { name: string };
-      username: any;
-      email: any;
-      loginRecords: any;
-      createdAt: any;
-      isAdmin: any;
-      isBanned: any;
-    }) => [
-      user.name,
-      user.organization?.name,
-      user.username,
-      user.email,
-      user.loginRecords.length,
-      user.loginRecords?.length > 0 ? user.loginRecords[0].loginTime : 'N/A',
-      user.createdAt,
-      user.isAdmin ? 'Yes' : 'No',
-      user.isBanned ? 'Yes' : 'No',
-    ]
-  );
+  const rows = users.map(user => [
+    user.name,
+    // The populated org ref lives on organizationId; the old `user.organization` read was
+    // always undefined, so this column shipped empty. Reads as undefined (blank cell) if the
+    // API ever returns a bare id string instead of the populated document.
+    user.organizationId?.name,
+    user.username,
+    user.email,
+    user.loginRecords?.length ?? 0,
+    user.loginRecords?.length ? user.loginRecords[0].loginTime : 'N/A',
+    user.createdAt,
+    user.isAdmin ? 'Yes' : 'No',
+    user.isBanned ? 'Yes' : 'No',
+  ]);
 
-  const csvData = [CSV_HEADERS, ...rows].map(row => row.join(',')).join('\n');
+  const csvData = [CSV_HEADERS, ...rows].map(row => row.map(escapeCell).join(',')).join('\n');
 
   const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' });
-  const link = document.createElement('a');
   const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
   link.setAttribute('href', url);
   link.setAttribute('download', 'users.csv');
   link.style.visibility = 'hidden';
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 };

--- a/apps/client/app/components/admin/Users/filters/OrganizationsFilter.tsx
+++ b/apps/client/app/components/admin/Users/filters/OrganizationsFilter.tsx
@@ -1,0 +1,88 @@
+import { Box, Checkbox, Dropdown, Menu, MenuButton, MenuItem } from '@mui/joy';
+import CorporateFareIcon from '@mui/icons-material/CorporateFare';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { useGetAllOrganizations } from '@client/app/utils/organizationAPICalls';
+import React from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useUsersTab } from '../useUsersTabParams';
+
+interface OrganizationsFilterProps {
+  disabled?: boolean;
+  /** Stretch to the container width (mobile drawer) instead of a fixed desktop width. */
+  fullWidth?: boolean;
+}
+
+const OrganizationsFilter: React.FC<OrganizationsFilterProps> = ({ disabled, fullWidth }) => {
+  const [params, setParams] = useUsersTab(useShallow(state => [state.params, state.setParams]));
+  const organizations = useGetAllOrganizations({ filters: { personal: false } });
+
+  const selected = params.orgSearch || [];
+
+  const displayLabel = (() => {
+    if (selected.length === 0 || selected.includes('all')) return 'All Organizations';
+    if (selected.length === 1) return selected[0];
+    return `${selected.length} Selected`;
+  })();
+
+  const toggleOrganization = (orgName: string) => {
+    if (orgName === 'all') {
+      setParams({ orgSearch: selected.includes('all') ? [] : ['all'], page: 1 });
+      return;
+    }
+
+    const withoutAll = selected.filter(org => org !== 'all');
+    const next = selected.includes(orgName) ? withoutAll.filter(org => org !== orgName) : [...withoutAll, orgName];
+    setParams({ orgSearch: next, page: 1 });
+  };
+
+  return (
+    <Dropdown>
+      <MenuButton
+        data-testid="admin-org-filter-btn"
+        size="sm"
+        variant="outlined"
+        color="neutral"
+        disabled={disabled}
+        startDecorator={<CorporateFareIcon />}
+        endDecorator={<KeyboardArrowDownIcon />}
+        sx={{
+          width: fullWidth ? '100%' : undefined,
+          minWidth: fullWidth ? undefined : 190,
+          justifyContent: 'space-between',
+          textAlign: 'left',
+          fontWeight: 'normal',
+        }}
+      >
+        <Box sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {displayLabel}
+        </Box>
+      </MenuButton>
+      <Menu sx={{ maxHeight: 300, overflowY: 'auto', minWidth: 260, zIndex: 1300 }}>
+        <MenuItem onClick={() => toggleOrganization('all')}>
+          <Checkbox checked={selected.includes('all')} onChange={() => toggleOrganization('all')} sx={{ mr: 1 }} />
+          All
+        </MenuItem>
+        <MenuItem onClick={() => toggleOrganization('Unassigned')}>
+          <Checkbox
+            checked={selected.includes('Unassigned')}
+            onChange={() => toggleOrganization('Unassigned')}
+            sx={{ mr: 1 }}
+          />
+          Unassigned
+        </MenuItem>
+        {organizations.data?.map(org => (
+          <MenuItem key={org.id} onClick={() => toggleOrganization(org.name)}>
+            <Checkbox
+              checked={selected.includes(org.name)}
+              onChange={() => toggleOrganization(org.name)}
+              sx={{ mr: 1 }}
+            />
+            {org.name}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Dropdown>
+  );
+};
+
+export default OrganizationsFilter;

--- a/apps/client/app/components/admin/Users/filters/OrganizationsFilter.tsx
+++ b/apps/client/app/components/admin/Users/filters/OrganizationsFilter.tsx
@@ -26,7 +26,10 @@ const OrganizationsFilter: React.FC<OrganizationsFilterProps> = ({ disabled, ful
 
   const toggleOrganization = (orgName: string) => {
     if (orgName === 'all') {
-      setParams({ orgSearch: selected.includes('all') ? [] : ['all'], page: 1 });
+      // "All" only ever selects: an empty orgSearch is reset straight back to ['all'] by the
+      // effect in ../index.tsx, so an un-toggle branch here would be dead code. Keep the two in
+      // sync if that reset ever changes.
+      setParams({ orgSearch: ['all'], page: 1 });
       return;
     }
 

--- a/apps/client/app/components/admin/Users/filters/SortControls.tsx
+++ b/apps/client/app/components/admin/Users/filters/SortControls.tsx
@@ -1,0 +1,68 @@
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import SwapVertIcon from '@mui/icons-material/SwapVert';
+import { IconButton, Option, Select, Stack, Tooltip } from '@mui/joy';
+import React from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useUsersTab } from '../useUsersTabParams';
+
+interface SortControlsProps {
+  disabled?: boolean;
+  fullWidth?: boolean;
+}
+
+/**
+ * Owns the sort testids the admin e2e suite depends on. The order button must keep
+ * its `disabled` binding: the suite uses its enabled state as the "fetch finished" probe.
+ */
+const SortControls: React.FC<SortControlsProps> = ({ disabled, fullWidth }) => {
+  const [params, setParams] = useUsersTab(useShallow(state => [state.params, state.setParams]));
+
+  const isAscending = params.sortOrder === 'asc';
+
+  return (
+    <Stack direction="row" sx={{ width: fullWidth ? '100%' : undefined, flexShrink: 0 }}>
+      <Select
+        data-testid="admin-sort-by-select"
+        slotProps={{ listbox: { 'data-testid': 'admin-sort-by-listbox', sx: { zIndex: 1300 } } }}
+        size="sm"
+        variant="outlined"
+        startDecorator={<SwapVertIcon />}
+        value={params.sortField}
+        onChange={(_, value) => {
+          if (value) setParams({ sortField: value, page: 1 });
+        }}
+        disabled={disabled}
+        sx={{
+          flex: fullWidth ? 1 : undefined,
+          minWidth: fullWidth ? undefined : 150,
+          borderTopRightRadius: 0,
+          borderBottomRightRadius: 0,
+        }}
+      >
+        <Option value="createdAt" data-testid="sort-option-created-at">
+          Created At
+        </Option>
+        <Option value="name" data-testid="sort-option-name">
+          Name
+        </Option>
+      </Select>
+      <Tooltip title={isAscending ? 'Ascending (A to Z)' : 'Descending (Z to A)'}>
+        <IconButton
+          data-testid="admin-sort-order-btn"
+          aria-label={isAscending ? 'Sort ascending' : 'Sort descending'}
+          size="sm"
+          variant="outlined"
+          color="neutral"
+          disabled={disabled}
+          onClick={() => setParams({ sortOrder: isAscending ? 'desc' : 'asc', page: 1 })}
+          sx={{ ml: '-1px', borderTopLeftRadius: 0, borderBottomLeftRadius: 0, flexShrink: 0 }}
+        >
+          {isAscending ? <ArrowUpwardIcon /> : <ArrowDownwardIcon />}
+        </IconButton>
+      </Tooltip>
+    </Stack>
+  );
+};
+
+export default SortControls;

--- a/apps/client/app/components/admin/Users/filters/UserTagsFilter.tsx
+++ b/apps/client/app/components/admin/Users/filters/UserTagsFilter.tsx
@@ -1,0 +1,71 @@
+import { PREDEFINED_USER_TAGS } from '@bike4mind/common';
+import { useGetUserTags } from '@client/app/hooks/data/user';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import { Box, Checkbox, Dropdown, Menu, MenuButton, MenuItem } from '@mui/joy';
+import React, { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useUsersTab } from '../useUsersTabParams';
+
+interface UserTagsFilterProps {
+  disabled?: boolean;
+  fullWidth?: boolean;
+}
+
+const UserTagsFilter: React.FC<UserTagsFilterProps> = ({ disabled, fullWidth }) => {
+  const [params, setParams] = useUsersTab(useShallow(state => [state.params, state.setParams]));
+  const userTags = useGetUserTags();
+
+  const selected = params.tags || [];
+
+  const availableTags = useMemo(
+    () => Array.from(new Set(['Admin', ...PREDEFINED_USER_TAGS, ...(userTags.data || [])])),
+    [userTags.data]
+  );
+
+  const displayLabel = (() => {
+    if (selected.length === 0) return 'All Tags';
+    if (selected.length === 1) return selected[0];
+    return `${selected.length} tags selected`;
+  })();
+
+  const toggleTag = (tagName: string) => {
+    const next = selected.includes(tagName) ? selected.filter(tag => tag !== tagName) : [...selected, tagName];
+    setParams({ tags: next, page: 1 });
+  };
+
+  return (
+    <Dropdown>
+      <MenuButton
+        data-testid="admin-tags-filter-btn"
+        size="sm"
+        variant="outlined"
+        color="neutral"
+        disabled={disabled}
+        startDecorator={<LocalOfferIcon />}
+        endDecorator={<KeyboardArrowDownIcon />}
+        sx={{
+          width: fullWidth ? '100%' : undefined,
+          minWidth: fullWidth ? undefined : 160,
+          justifyContent: 'space-between',
+          textAlign: 'left',
+          fontWeight: 'normal',
+        }}
+      >
+        <Box sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {displayLabel}
+        </Box>
+      </MenuButton>
+      <Menu sx={{ maxHeight: 300, overflowY: 'auto', minWidth: 200, zIndex: 1300 }}>
+        {availableTags.map(tag => (
+          <MenuItem key={tag} onClick={() => toggleTag(tag)}>
+            <Checkbox checked={selected.includes(tag)} onChange={() => toggleTag(tag)} sx={{ mr: 1 }} />
+            {tag}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Dropdown>
+  );
+};
+
+export default UserTagsFilter;

--- a/apps/client/app/components/admin/Users/index.tsx
+++ b/apps/client/app/components/admin/Users/index.tsx
@@ -1,203 +1,43 @@
-import { useGetUsers, useGetUserTags } from '@client/app/hooks/data/user';
-import { IGetUsersParams, fetchUsers } from '@client/app/utils/userAPICalls';
-import ExpandIcon from '@mui/icons-material/Expand';
-import FilterListIcon from '@mui/icons-material/FilterList';
-import HikingIcon from '@mui/icons-material/Hiking';
-import PersonSearchIcon from '@mui/icons-material/PersonSearch';
-import RefreshIcon from '@mui/icons-material/Refresh';
-import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
-import HistoryIcon from '@mui/icons-material/History';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import FullUserViewModal from '@client/app/components/admin/Users/Views/FullUserViewModal';
-import ContextHelpButton from '@client/app/components/help/ContextHelpButton';
-import CreateUserModal, { useCreateUserModal } from './CreateUserModal';
-import {
-  Badge,
-  Button,
-  Card,
-  Box,
-  FormControl,
-  IconButton,
-  Input,
-  LinearProgress,
-  Select,
-  Option,
-  Sheet,
-  Stack,
-  Typography,
-  Dropdown,
-  MenuButton,
-  Menu,
-  MenuItem,
-  Checkbox,
-  RadioGroup,
-  Radio,
-} from '@mui/joy';
+import { useGetUsers } from '@client/app/hooks/data/user';
+import { useDebounceValue } from '@client/app/hooks/useDebouncedValue';
+import { useIsMobile } from '@client/app/hooks/useIsMobile';
+import { useGetAllOrganizations } from '@client/app/utils/organizationAPICalls';
+import { Box, LinearProgress, Sheet, Stack } from '@mui/joy';
 import React, { useEffect, useMemo, useState } from 'react';
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { useShallow } from 'zustand/react/shallow';
 import AdminProfileModal from '../AdminProfileModal';
 import ComplianceModal from './ComplianceModal';
+import CreateUserModal, { useCreateUserModal } from './CreateUserModal';
+import { exportUsersCsv } from './exportUsersCsv';
+import MobileFiltersDrawer from './MobileFiltersDrawer';
+import PaginationControls from './PaginationControls';
+import { PAGE_LIMIT_OPTIONS, useUsersTab } from './useUsersTabParams';
+import UsersFilterBar, { UsersDisplayMode } from './UsersFilterBar';
 import { FullUsersView } from './Views/FullUsersView';
+import RecentActivityView from './Views/RecentActivityView';
 import SlimUsersContainer from './Views/SlimUsersView';
 import UserJourney from './Views/UserJourney';
-import { useGetAllOrganizations } from '@client/app/utils/organizationAPICalls';
-import { useShallow } from 'zustand/react/shallow';
-import DownloadIcon from '@mui/icons-material/Download';
-import RecentActivityView from './Views/RecentActivityView';
-import { PREDEFINED_USER_TAGS } from '@bike4mind/common';
-import { useDebounceValue } from '@client/app/hooks/useDebouncedValue';
-
-const PAGE_LIMIT_OPTIONS = [5, 10, 20];
-
-export type EditedFieldsType = {
-  [userId: string]: {
-    name?: boolean;
-    username?: boolean;
-    email?: boolean;
-    password?: boolean;
-    isAdmin?: boolean;
-    isBanned?: boolean;
-    isModerated?: boolean;
-    subscribedUntil?: boolean;
-    userLevel?: boolean;
-    userTags?: boolean;
-    storageLimit?: boolean;
-    currentCredits?: boolean;
-    referralAvailable?: boolean;
-  };
-};
-
-const useUsersTab = create<{
-  params: IGetUsersParams;
-  setParams: (params: Partial<IGetUsersParams>) => void;
-}>()(
-  persist(
-    (set, get) => ({
-      params: {
-        page: 1,
-        limit: 10,
-        search: '',
-        sortField: 'createdAt',
-        sortOrder: 'desc',
-        orgSearch: ['all'],
-        tags: [],
-      },
-      setParams: params => set({ params: { ...get().params, ...params } }),
-    }),
-    { name: 'admin-user-tab-01' }
-  )
-);
-
-const PaginationControls: React.FC<{
-  currentPage: number;
-  totalPages: number;
-  maxPage: number;
-  onPageChange: (page: number) => void;
-  currentLimit: number;
-  onLimitChange: (limit: number) => void;
-  totalUsers: number;
-  pageLimitOptions: number[];
-}> = ({
-  currentPage,
-  totalPages,
-  maxPage,
-  onPageChange,
-  currentLimit,
-  onLimitChange,
-  totalUsers,
-  pageLimitOptions,
-}) => (
-  <Stack
-    direction="row"
-    justifyContent="space-between"
-    alignItems="center"
-    sx={{ my: { xs: 0.5, sm: 1 } }}
-    width="100%"
-  >
-    <Stack direction="row" spacing={{ xs: 1, sm: 2 }} justifyContent="center" alignItems="center">
-      <Button size="sm" disabled={currentPage <= 1} onClick={() => onPageChange(currentPage - 1)}>
-        Previous
-      </Button>
-      <Typography level="body-xs" sx={{ display: { sm: 'none' } }}>
-        {currentPage}/{totalPages}
-      </Typography>
-      <Typography level="title-sm" sx={{ display: { xs: 'none', sm: 'block' } }}>
-        Page {currentPage} of {totalPages}
-      </Typography>
-      <Button
-        size="sm"
-        disabled={currentPage >= maxPage || maxPage === 0}
-        onClick={() => onPageChange(currentPage + 1)}
-      >
-        Next
-      </Button>
-    </Stack>
-
-    {/* Mobile: compact Select for page size */}
-    <Stack
-      direction="row"
-      spacing={1}
-      alignItems="center"
-      justifyContent="flex-end"
-      sx={{ display: { xs: 'flex', sm: 'none' } }}
-    >
-      <Select
-        size="sm"
-        value={currentLimit}
-        onChange={(_, value) => {
-          if (value) onLimitChange(value);
-        }}
-        sx={{ minWidth: 70 }}
-      >
-        {pageLimitOptions.map(limit => (
-          <Option key={limit} value={limit}>
-            {limit}
-          </Option>
-        ))}
-      </Select>
-    </Stack>
-
-    {/* Desktop: RadioGroup for page size */}
-    <Stack
-      direction="row"
-      spacing={2}
-      alignItems="center"
-      justifyContent="flex-end"
-      sx={{ display: { xs: 'none', sm: 'flex' } }}
-    >
-      <FormControl>
-        <RadioGroup orientation="horizontal" value={currentLimit} onChange={e => onLimitChange(Number(e.target.value))}>
-          {pageLimitOptions.map(limit => (
-            <Radio key={limit} value={limit} label={`${limit} per page`} size="sm" sx={{ mr: 2, p: 0.5 }} />
-          ))}
-        </RadioGroup>
-      </FormControl>
-      <Typography level="title-sm" fontWeight={800}>
-        Total Users: {totalUsers}
-      </Typography>
-    </Stack>
-  </Stack>
-);
 
 const UsersTab: React.FC = () => {
-  const [displayMode, setDisplayMode] = useState<'full' | 'slim' | 'userJourney' | 'recentActivity'>('slim');
-  const [showFilters, setShowFilters] = useState(false);
+  const isMobile = useIsMobile();
+  const [displayMode, setDisplayMode] = useState<UsersDisplayMode>('slim');
+  const [filtersDrawerOpen, setFiltersDrawerOpen] = useState(false);
   const organizations = useGetAllOrganizations({ filters: { personal: false } });
-  const userTags = useGetUserTags();
   const { setOpen: setCreateUserModalOpen } = useCreateUserModal();
 
   const [totalUsers, setTotalUsers] = useState<number>(1);
-  const { value: search, debouncedValue: debouncedSearch, setValue: setSearch } = useDebounceValue('');
-
   const [params, setParams] = useUsersTab(useShallow(state => [state.params, state.setParams]));
+
+  const { value: search, debouncedValue: debouncedSearch, setValue: setSearch } = useDebounceValue('');
 
   const usersQuery = useGetUsers(params);
   const users = useMemo(() => usersQuery.data?.users ?? [], [usersQuery.data]);
+
   useEffect(() => {
     setTotalUsers(curr => usersQuery?.data?.totalUsers ?? curr);
   }, [usersQuery?.data?.totalUsers, setTotalUsers]);
+
   // Reset to "All" if no orgs selected or if selected orgs don't exist in available options
   useEffect(() => {
     if (!params.orgSearch || params.orgSearch.length === 0) {
@@ -205,7 +45,6 @@ const UsersTab: React.FC = () => {
       return;
     }
 
-    // Check if selected orgs are valid (exist in available orgs or are special values)
     if (organizations.data && !organizations.isLoading) {
       const availableOrgNames = organizations.data.map(org => org.name);
       const specialValues = ['all', 'Unassigned'];
@@ -219,164 +58,15 @@ const UsersTab: React.FC = () => {
     }
   }, [params.orgSearch, organizations.data, organizations.isLoading, setParams]);
 
-  // Update the search parameter in params only when the debounced search value changes
   useEffect(() => {
     if (debouncedSearch === params.search) return;
-
-    setParams({ ...params, search: debouncedSearch, page: 1 });
-  }, [debouncedSearch, params, setParams]);
-
-  const handleDownloadCSV = async () => {
-    const downloadParams = {
-      ...params,
-      downloadAll: true,
-      page: 1,
-      limit: 1000000, // Set a high limit to ensure all users are fetched
-    };
-
-    const allUsersData = await fetchUsers(downloadParams);
-    const users = allUsersData.users;
-
-    console.log('All users', users);
-
-    const convertToCSV = (users: any[]) => {
-      const headers = [
-        'Name',
-        'Organization',
-        'Username',
-        'Email',
-        'Logins',
-        'Last Login',
-        'Created At',
-        'Is Admin',
-        'Is Banned',
-      ];
-      const rows = users.map(
-        (user: {
-          name: any;
-          organization?: { name: string };
-          username: any;
-          email: any;
-          numLogins: any;
-          loginRecords: any;
-          createdAt: any;
-          isAdmin: any;
-          isBanned: any;
-        }) => [
-          user.name,
-          user.organization?.name,
-          user.username,
-          user.email,
-          user.loginRecords.length,
-          user.loginRecords?.length > 0 ? user.loginRecords[0].loginTime : 'N/A',
-          user.createdAt,
-          user.isAdmin ? 'Yes' : 'No',
-          user.isBanned ? 'Yes' : 'No',
-        ]
-      );
-      return [headers, ...rows].map(row => row.join(',')).join('\n');
-    };
-
-    const csvData = convertToCSV(users);
-
-    const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8;' });
-
-    const link = document.createElement('a');
-    if (link.download !== undefined) {
-      const url = URL.createObjectURL(blob);
-      link.setAttribute('href', url);
-      link.setAttribute('download', 'users.csv');
-      link.style.visibility = 'hidden';
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    }
-  };
-
-  const handleOrgSearchChange = (selectedOrgs: string[]) => {
-    console.log('selectedOrgs', selectedOrgs);
-
-    if (selectedOrgs.length === 0) {
-      setParams({ orgSearch: [], page: 1 });
-    } else {
-      setParams({ orgSearch: selectedOrgs, page: 1 });
-    }
-  };
-
-  const toggleOrganization = (orgName: string) => {
-    const currentSelection = params.orgSearch || [];
-
-    if (orgName === 'all') {
-      // If "all" is clicked, either select all or deselect all
-      if (currentSelection.includes('all')) {
-        handleOrgSearchChange([]);
-      } else {
-        handleOrgSearchChange(['all']);
-      }
-    } else {
-      const withoutAll = currentSelection.filter(org => org !== 'all');
-
-      if (currentSelection.includes(orgName)) {
-        handleOrgSearchChange(withoutAll.filter(org => org !== orgName));
-      } else {
-        handleOrgSearchChange([...withoutAll, orgName]);
-      }
-    }
-  };
-
-  const toggleTag = (tagName: string) => {
-    const currentTags = params.tags || [];
-
-    if (currentTags.includes(tagName)) {
-      setParams({ tags: currentTags.filter(tag => tag !== tagName), page: 1 });
-    } else {
-      setParams({ tags: [...currentTags, tagName], page: 1 });
-    }
-  };
-
-  const getDisplayLabel = () => {
-    const selected = params.orgSearch || [];
-    if (selected.length === 0 || selected.includes('all')) {
-      return 'All Organizations';
-    }
-    if (selected.length === 1) {
-      return selected[0];
-    }
-    return `${selected.length} Selected`;
-  };
-
-  const getTagsDisplayLabel = (selectedTags: string[]): string => {
-    if (selectedTags.length === 0) return 'All Tags';
-    if (selectedTags.length === 1) return selectedTags[0];
-    return `${selectedTags.length} tags selected`;
-  };
-
-  const availableTags = useMemo(() => {
-    const apiTags = userTags.data || [];
-    return Array.from(new Set(['Admin', ...PREDEFINED_USER_TAGS, ...apiTags]));
-  }, [userTags.data]);
-
-  const handleToggleSortOrder = () => {
-    setParams({ ...params, sortOrder: params.sortOrder === 'asc' ? 'desc' : 'asc', page: 1 });
-  };
-
-  const handleSearchTermChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.preventDefault();
-    setSearch(event.target.value);
-  };
+    setParams({ search: debouncedSearch, page: 1 });
+  }, [debouncedSearch, params.search, setParams]);
 
   const loading = useMemo(
     () => usersQuery.isLoading || usersQuery.isFetching,
     [usersQuery.isLoading, usersQuery.isFetching]
   );
-
-  const activeFilterCount = useMemo(() => {
-    let count = 0;
-    if (params.orgSearch && !params.orgSearch.includes('all') && params.orgSearch.length > 0) count++;
-    if (params.tags && params.tags.length > 0) count++;
-    if (params.sortField !== 'createdAt' || params.sortOrder !== 'desc') count++;
-    return count;
-  }, [params.orgSearch, params.tags, params.sortField, params.sortOrder]);
 
   return (
     <Sheet
@@ -390,327 +80,34 @@ const UsersTab: React.FC = () => {
       }}
     >
       <Box sx={{ flexShrink: 0 }}>
-        <Stack direction="column" justifyContent={'center'} spacing={1} sx={{ width: '100%' }}>
-          <Stack direction="column" spacing={1} sx={{ mb: { xs: 1, sm: 3 }, pt: { xs: 0.5, sm: 1 } }}>
-            <Card sx={{ px: { xs: 1, sm: 2 }, py: { xs: 0.5, sm: 1 } }}>
-              <Stack spacing={1}>
-                {/* Always-visible row: Search + View Mode + mobile filter toggle */}
-                <Stack direction="row" spacing={1} alignItems="end">
-                  <FormControl sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography
-                      level="title-sm"
-                      sx={{ fontWeight: 500, mb: 0.5, display: { xs: 'none', sm: 'block' } }}
-                    >
-                      Search Users
-                    </Typography>
-                    <Input
-                      data-testid="admin-search-users-input"
-                      size="sm"
-                      startDecorator={<PersonSearchIcon />}
-                      placeholder="Search users"
-                      value={search}
-                      onChange={handleSearchTermChange}
-                    />
-                  </FormControl>
-
-                  <FormControl sx={{ minWidth: { xs: 'auto', sm: 180 }, flexShrink: 0 }}>
-                    <Typography
-                      level="title-sm"
-                      sx={{ fontWeight: 500, mb: 0.5, display: { xs: 'none', sm: 'block' } }}
-                    >
-                      View Mode
-                    </Typography>
-                    <Select
-                      size="sm"
-                      value={displayMode}
-                      onChange={(_, value) => {
-                        if (value) {
-                          setDisplayMode(value as 'full' | 'slim' | 'userJourney' | 'recentActivity');
-                        }
-                      }}
-                      disabled={loading}
-                      sx={{ '& .MuiSelect-button': { minWidth: { xs: 0 } } }}
-                      renderValue={option => (
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          {option?.value === 'slim' && <UnfoldLessIcon fontSize="small" />}
-                          {option?.value === 'full' && <ExpandIcon fontSize="small" />}
-                          {option?.value === 'userJourney' && <HikingIcon fontSize="small" />}
-                          {option?.value === 'recentActivity' && <HistoryIcon fontSize="small" />}
-                          <Box component="span" sx={{ fontSize: { xs: 'xs', sm: 'sm' } }}>
-                            {option?.label}
-                          </Box>
-                        </Box>
-                      )}
-                    >
-                      <Option value="slim">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <UnfoldLessIcon fontSize="small" />
-                          Slim
-                        </Box>
-                      </Option>
-                      <Option value="full">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <ExpandIcon fontSize="small" />
-                          Full
-                        </Box>
-                      </Option>
-                      <Option value="userJourney">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <HikingIcon fontSize="small" />
-                          User Journey
-                        </Box>
-                      </Option>
-                      <Option value="recentActivity">
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <HistoryIcon fontSize="small" />
-                          Recent Activity
-                        </Box>
-                      </Option>
-                    </Select>
-                  </FormControl>
-
-                  {/* Mobile filter toggle */}
-                  <IconButton
-                    data-testid="admin-users-filter-toggle"
-                    variant={showFilters ? 'soft' : 'plain'}
-                    color={activeFilterCount > 0 ? 'primary' : 'neutral'}
-                    onClick={() => setShowFilters(prev => !prev)}
-                    sx={{ display: { xs: 'flex', sm: 'none' }, flexShrink: 0 }}
-                  >
-                    <Badge
-                      badgeContent={activeFilterCount}
-                      badgeInset="14%"
-                      size="sm"
-                      invisible={activeFilterCount === 0}
-                    >
-                      <FilterListIcon />
-                    </Badge>
-                  </IconButton>
-                </Stack>
-
-                {/* Collapsible filters: hidden on mobile by default, always visible on sm+ */}
-                <Box sx={{ display: { xs: showFilters ? 'block' : 'none', sm: 'block' } }}>
-                  <Stack spacing={1}>
-                    <Stack
-                      direction={{ xs: 'column', sm: 'row' }}
-                      spacing={2}
-                      alignItems={{ xs: 'stretch', sm: 'end' }}
-                    >
-                      {/* Organizations */}
-                      <FormControl sx={{ minWidth: { xs: '100%', sm: 200 } }}>
-                        <Typography level="title-sm" sx={{ fontWeight: 500, mb: 0.5 }}>
-                          Organizations
-                        </Typography>
-                        <Dropdown>
-                          <MenuButton
-                            disabled={loading}
-                            endDecorator={<KeyboardArrowDownIcon />}
-                            sx={{
-                              minWidth: { xs: '100%', sm: 200 },
-                              justifyContent: 'space-between',
-                              textAlign: 'left',
-                              fontWeight: 'normal',
-                            }}
-                          >
-                            <Box
-                              sx={{
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                                maxWidth: '150px',
-                              }}
-                            >
-                              {getDisplayLabel()}
-                            </Box>
-                          </MenuButton>
-                          <Menu sx={{ maxHeight: 300, overflowY: 'auto', minWidth: 300 }}>
-                            <MenuItem onClick={() => toggleOrganization('all')}>
-                              <Checkbox
-                                checked={(params.orgSearch || []).includes('all')}
-                                onChange={() => toggleOrganization('all')}
-                                sx={{ mr: 1 }}
-                              />
-                              All
-                            </MenuItem>
-                            <MenuItem onClick={() => toggleOrganization('Unassigned')}>
-                              <Checkbox
-                                checked={(params.orgSearch || []).includes('Unassigned')}
-                                onChange={() => toggleOrganization('Unassigned')}
-                                sx={{ mr: 1 }}
-                              />
-                              Unassigned
-                            </MenuItem>
-                            {organizations.data?.map(org => (
-                              <MenuItem key={org.id} onClick={() => toggleOrganization(org.name)}>
-                                <Checkbox
-                                  checked={(params.orgSearch || []).includes(org.name)}
-                                  onChange={() => toggleOrganization(org.name)}
-                                  sx={{ mr: 1 }}
-                                />
-                                {org.name}
-                              </MenuItem>
-                            ))}
-                          </Menu>
-                        </Dropdown>
-                      </FormControl>
-
-                      <Box sx={{ minWidth: { xs: '100%', sm: 180 } }}>
-                        <Typography level="title-sm" sx={{ fontWeight: 500, mb: 0.5 }}>
-                          User Tags
-                        </Typography>
-                        <Dropdown>
-                          <MenuButton
-                            disabled={loading}
-                            endDecorator={<KeyboardArrowDownIcon />}
-                            sx={{
-                              minWidth: { xs: '100%', sm: 180 },
-                              justifyContent: 'space-between',
-                              textAlign: 'left',
-                              fontWeight: 'normal',
-                            }}
-                          >
-                            <Box
-                              sx={{
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                                maxWidth: '120px',
-                              }}
-                            >
-                              {getTagsDisplayLabel(params.tags || [])}
-                            </Box>
-                          </MenuButton>
-                          <Menu sx={{ maxHeight: 300, overflowY: 'auto', minWidth: 200 }}>
-                            {availableTags.map(tag => (
-                              <MenuItem key={tag} onClick={() => toggleTag(tag)}>
-                                <Checkbox
-                                  checked={(params.tags || []).includes(tag)}
-                                  onChange={() => toggleTag(tag)}
-                                  sx={{ mr: 1 }}
-                                />
-                                {tag}
-                              </MenuItem>
-                            ))}
-                          </Menu>
-                        </Dropdown>
-                      </Box>
-                    </Stack>
-
-                    <Stack
-                      direction={{ xs: 'column', md: 'row' }}
-                      spacing={2}
-                      alignItems={{ xs: 'stretch', md: 'end' }}
-                      justifyContent="space-between"
-                    >
-                      <Stack
-                        direction={{ xs: 'column', sm: 'row' }}
-                        spacing={2}
-                        alignItems={{ xs: 'stretch', sm: 'center' }}
-                      >
-                        <Stack direction="row" spacing={1} alignItems="center">
-                          <Typography level="title-sm" sx={{ fontWeight: 500, minWidth: 'max-content' }}>
-                            Sort By:
-                          </Typography>
-                          <Select
-                            data-testid="admin-sort-by-select"
-                            slotProps={{ listbox: { 'data-testid': 'admin-sort-by-listbox' } }}
-                            value={params.sortField}
-                            onChange={(_, value) => {
-                              if (value) {
-                                setParams({ ...params, sortField: value, page: 1 });
-                              }
-                            }}
-                            disabled={loading}
-                            sx={{ minWidth: 120 }}
-                          >
-                            <Option value="createdAt" data-testid="sort-option-created-at">
-                              Created At
-                            </Option>
-                            <Option value="name" data-testid="sort-option-name">
-                              Name
-                            </Option>
-                          </Select>
-                        </Stack>
-
-                        <Stack direction="row" spacing={1} alignItems="center">
-                          <Typography level="title-sm" sx={{ fontWeight: 500, minWidth: 'max-content' }}>
-                            Order:
-                          </Typography>
-                          <Button
-                            data-testid="admin-sort-order-btn"
-                            variant="outlined"
-                            onClick={handleToggleSortOrder}
-                            disabled={loading}
-                          >
-                            {params.sortOrder === 'asc' ? 'A → Z' : 'Z → A'}
-                          </Button>
-                        </Stack>
-                      </Stack>
-
-                      {/* Action Buttons Group */}
-                      <Stack
-                        direction={{ xs: 'column', md: 'row' }}
-                        spacing={1}
-                        sx={{
-                          minWidth: { xs: '100%', md: 'auto' },
-                          justifyContent: { xs: 'stretch', md: 'flex-end' },
-                        }}
-                      >
-                        <Button
-                          data-testid="admin-create-user-btn"
-                          startDecorator={<PersonAddIcon />}
-                          onClick={() => setCreateUserModalOpen(true)}
-                          color="primary"
-                          sx={{ minWidth: { xs: '100%', md: 'auto' } }}
-                        >
-                          Create User
-                        </Button>
-                        <Button
-                          data-testid="admin-refresh-btn"
-                          disabled={loading}
-                          startDecorator={<RefreshIcon />}
-                          onClick={() => usersQuery.refetch()}
-                          sx={{ minWidth: { xs: '100%', md: 'auto' } }}
-                        >
-                          Refresh
-                        </Button>
-                        <Button
-                          data-testid="admin-download-csv-btn"
-                          disabled={loading || users.length === 0}
-                          startDecorator={<DownloadIcon />}
-                          onClick={handleDownloadCSV}
-                          color="success"
-                          sx={{ minWidth: { xs: '100%', md: 'auto' } }}
-                        >
-                          Download
-                        </Button>
-                        <ContextHelpButton
-                          helpId="admin/user-management"
-                          tooltipText="User Management Help"
-                          data-testid="admin-help-btn"
-                        />
-                      </Stack>
-                    </Stack>
-                  </Stack>
-                </Box>
-              </Stack>
-            </Card>
-          </Stack>
+        <Stack sx={{ pt: { xs: 0.5, sm: 1 }, mb: { xs: 0.5, sm: 1 } }}>
+          <UsersFilterBar
+            displayMode={displayMode}
+            onDisplayModeChange={setDisplayMode}
+            loading={loading}
+            search={search}
+            onSearchChange={setSearch}
+            onRefresh={() => usersQuery.refetch()}
+            onDownloadCsv={() => exportUsersCsv(params)}
+            onCreateUser={() => setCreateUserModalOpen(true)}
+            downloadDisabled={loading || users.length === 0}
+            onOpenFilters={() => setFiltersDrawerOpen(true)}
+          />
         </Stack>
 
-        {/* Top pagination - desktop only */}
-        <Box sx={{ display: { xs: 'none', sm: 'block' } }}>
+        {/* Full pagination lives above the table on desktop; phones get the compact pager only. */}
+        {!isMobile && (
           <PaginationControls
+            variant="full"
             currentPage={params.page}
             totalPages={usersQuery.data?.totalPages ?? 0}
-            maxPage={usersQuery.data?.totalPages ?? 0}
-            onPageChange={p => setParams({ ...params, page: p })}
+            onPageChange={page => setParams({ page })}
             currentLimit={params.limit}
-            onLimitChange={l => setParams({ ...params, limit: l, page: 1 })}
+            onLimitChange={limit => setParams({ limit, page: 1 })}
             totalUsers={totalUsers}
             pageLimitOptions={PAGE_LIMIT_OPTIONS}
           />
-        </Box>
+        )}
 
         {loading && (
           <LinearProgress
@@ -737,16 +134,18 @@ const UsersTab: React.FC = () => {
 
       <Box sx={{ flexShrink: 0 }}>
         <PaginationControls
+          variant="compact"
           currentPage={params.page}
           totalPages={usersQuery.data?.totalPages ?? 0}
-          maxPage={usersQuery.data?.totalPages ?? 0}
-          onPageChange={p => setParams({ ...params, page: p })}
+          onPageChange={page => setParams({ page })}
           currentLimit={params.limit}
-          onLimitChange={l => setParams({ ...params, limit: l, page: 1 })}
+          onLimitChange={limit => setParams({ limit, page: 1 })}
           totalUsers={totalUsers}
           pageLimitOptions={PAGE_LIMIT_OPTIONS}
         />
       </Box>
+
+      <MobileFiltersDrawer open={filtersDrawerOpen} onClose={() => setFiltersDrawerOpen(false)} loading={loading} />
 
       {/* Place all modals in one area */}
       <AdminProfileModal />

--- a/apps/client/app/components/admin/Users/index.tsx
+++ b/apps/client/app/components/admin/Users/index.tsx
@@ -160,7 +160,10 @@ const UsersTab: React.FC = () => {
         />
       </Box>
 
-      <MobileFiltersDrawer open={filtersDrawerOpen} onClose={() => setFiltersDrawerOpen(false)} loading={loading} />
+      {/* Mobile-only: nothing opens this on desktop, since the filter toggle is mobile-only. */}
+      {isMobile && (
+        <MobileFiltersDrawer open={filtersDrawerOpen} onClose={() => setFiltersDrawerOpen(false)} loading={loading} />
+      )}
 
       {/* Place all modals in one area */}
       <AdminProfileModal />

--- a/apps/client/app/components/admin/Users/index.tsx
+++ b/apps/client/app/components/admin/Users/index.tsx
@@ -4,7 +4,8 @@ import { useDebounceValue } from '@client/app/hooks/useDebouncedValue';
 import { useIsMobile } from '@client/app/hooks/useIsMobile';
 import { useGetAllOrganizations } from '@client/app/utils/organizationAPICalls';
 import { Box, LinearProgress, Sheet, Stack } from '@mui/joy';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
 import { useShallow } from 'zustand/react/shallow';
 import AdminProfileModal from '../AdminProfileModal';
 import ComplianceModal from './ComplianceModal';
@@ -29,7 +30,12 @@ const UsersTab: React.FC = () => {
   const [totalUsers, setTotalUsers] = useState<number>(1);
   const [params, setParams] = useUsersTab(useShallow(state => [state.params, state.setParams]));
 
-  const { value: search, debouncedValue: debouncedSearch, setValue: setSearch } = useDebounceValue('');
+  // Seed from the persisted params so the sync effect below does not wipe a restored search.
+  const {
+    value: search,
+    debouncedValue: debouncedSearch,
+    setValue: setSearch,
+  } = useDebounceValue(useUsersTab.getState().params.search ?? '');
 
   const usersQuery = useGetUsers(params);
   const users = useMemo(() => usersQuery.data?.users ?? [], [usersQuery.data]);
@@ -68,6 +74,15 @@ const UsersTab: React.FC = () => {
     [usersQuery.isLoading, usersQuery.isFetching]
   );
 
+  const handleDownloadCsv = useCallback(async () => {
+    try {
+      await exportUsersCsv(params);
+    } catch (err) {
+      console.error('Failed to export users CSV:', err);
+      toast.error('Failed to download the user CSV.');
+    }
+  }, [params]);
+
   return (
     <Sheet
       sx={{
@@ -88,7 +103,7 @@ const UsersTab: React.FC = () => {
             search={search}
             onSearchChange={setSearch}
             onRefresh={() => usersQuery.refetch()}
-            onDownloadCsv={() => exportUsersCsv(params)}
+            onDownloadCsv={handleDownloadCsv}
             onCreateUser={() => setCreateUserModalOpen(true)}
             downloadDisabled={loading || users.length === 0}
             onOpenFilters={() => setFiltersDrawerOpen(true)}

--- a/apps/client/app/components/admin/Users/useUsersTabParams.ts
+++ b/apps/client/app/components/admin/Users/useUsersTabParams.ts
@@ -1,0 +1,49 @@
+import { IGetUsersParams } from '@client/app/utils/userAPICalls';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const PAGE_LIMIT_OPTIONS = [5, 10, 20];
+
+export const DEFAULT_USERS_PARAMS: IGetUsersParams = {
+  page: 1,
+  limit: 10,
+  search: '',
+  sortField: 'createdAt',
+  sortOrder: 'desc',
+  orgSearch: ['all'],
+  tags: [],
+};
+
+// Persist key must stay 'admin-user-tab-01': changing it silently discards
+// every admin's saved filters.
+export const useUsersTab = create<{
+  params: IGetUsersParams;
+  setParams: (params: Partial<IGetUsersParams>) => void;
+}>()(
+  persist(
+    (set, get) => ({
+      params: { ...DEFAULT_USERS_PARAMS },
+      setParams: params => set({ params: { ...get().params, ...params } }),
+    }),
+    { name: 'admin-user-tab-01' }
+  )
+);
+
+/** Filters that the mobile drawer's "Clear all" and the desktop filter chip reset. */
+export const CLEARED_FILTER_PARAMS: Partial<IGetUsersParams> = {
+  orgSearch: DEFAULT_USERS_PARAMS.orgSearch,
+  tags: DEFAULT_USERS_PARAMS.tags,
+  sortField: DEFAULT_USERS_PARAMS.sortField,
+  sortOrder: DEFAULT_USERS_PARAMS.sortOrder,
+  page: 1,
+};
+
+export const countActiveFilters = (params: IGetUsersParams): number => {
+  let count = 0;
+  if (params.orgSearch && !params.orgSearch.includes('all') && params.orgSearch.length > 0) count++;
+  if (params.tags && params.tags.length > 0) count++;
+  if (params.sortField !== DEFAULT_USERS_PARAMS.sortField || params.sortOrder !== DEFAULT_USERS_PARAMS.sortOrder) {
+    count++;
+  }
+  return count;
+};

--- a/apps/client/app/utils/csv.test.ts
+++ b/apps/client/app/utils/csv.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { escapeCsvCell, toCsv } from './csv';
+
+describe('escapeCsvCell', () => {
+  it('quotes every value so callers never have to decide', () => {
+    expect(escapeCsvCell('Ada')).toBe('"Ada"');
+  });
+
+  it('keeps a value containing a comma in one field', () => {
+    expect(escapeCsvCell('Lovelace, Ada')).toBe('"Lovelace, Ada"');
+  });
+
+  it('doubles embedded quotes', () => {
+    expect(escapeCsvCell('Ada "The Enchantress" Lovelace')).toBe('"Ada ""The Enchantress"" Lovelace"');
+  });
+
+  it('flattens newlines so a row stays on one line', () => {
+    expect(escapeCsvCell('line one\r\nline two\rline three\nline four')).toBe(
+      '"line one line two line three line four"'
+    );
+  });
+
+  it.each(['=HYPERLINK("http://evil/")', '+1234', '-1234', '@SUM(A1)', '\tstartsWithTab'])(
+    'defuses the formula-injection prefix in %j',
+    value => {
+      expect(escapeCsvCell(value)).toBe(`"'${value.replace(/"/g, '""')}"`);
+    }
+  );
+
+  it('renders null and undefined as empty cells', () => {
+    expect(escapeCsvCell(null)).toBe('""');
+    expect(escapeCsvCell(undefined)).toBe('""');
+  });
+
+  it('stringifies non-string scalars', () => {
+    expect(escapeCsvCell(0)).toBe('"0"');
+    expect(escapeCsvCell(false)).toBe('"false"');
+  });
+});
+
+describe('toCsv', () => {
+  it('escapes every cell and joins rows with newlines', () => {
+    expect(
+      toCsv([
+        ['Name', 'Org'],
+        ['Lovelace, Ada', undefined],
+      ])
+    ).toBe('"Name","Org"\n"Lovelace, Ada",""');
+  });
+});

--- a/apps/client/app/utils/csv.test.ts
+++ b/apps/client/app/utils/csv.test.ts
@@ -27,6 +27,12 @@ describe('escapeCsvCell', () => {
     }
   );
 
+  it('leaves a leading CR harmless by flattening it to a space before the guard', () => {
+    // Not apostrophe-prefixed, and does not need to be: a leading space stops Excel and Sheets
+    // evaluating the cell. This pins the flatten-then-guard order the guard depends on.
+    expect(escapeCsvCell('\r=SUM(A1)')).toBe('" =SUM(A1)"');
+  });
+
   it('renders null and undefined as empty cells', () => {
     expect(escapeCsvCell(null)).toBe('""');
     expect(escapeCsvCell(undefined)).toBe('""');

--- a/apps/client/app/utils/csv.ts
+++ b/apps/client/app/utils/csv.ts
@@ -1,0 +1,22 @@
+/**
+ * Escapes one CSV cell for spreadsheet import.
+ *
+ * Beyond RFC 4180 quoting this also defuses formula injection: a cell starting with =, +, -, @,
+ * tab or CR is evaluated as a formula by Excel and Google Sheets, so exported user-supplied text
+ * (display names, organization names) could run on the machine of whoever opens the file. Such
+ * values get an apostrophe prefix, which spreadsheets strip on display.
+ *
+ * Every field is quoted rather than only the ones that need it - valid CSV, and one less rule to
+ * get wrong. Newlines are flattened to spaces so a row always occupies a single line.
+ */
+export function escapeCsvCell(value: unknown): string {
+  const text = value === null || value === undefined ? '' : String(value);
+  const flattened = text.replace(/\r\n|\r|\n/g, ' ').replace(/"/g, '""');
+  const guarded = /^[=+\-@\t]/.test(flattened) ? `'${flattened}` : flattened;
+  return `"${guarded}"`;
+}
+
+/** Joins rows of already-raw values into a CSV document, escaping every cell. */
+export function toCsv(rows: unknown[][]): string {
+  return rows.map(row => row.map(escapeCsvCell).join(',')).join('\n');
+}

--- a/apps/client/app/utils/csv.ts
+++ b/apps/client/app/utils/csv.ts
@@ -1,13 +1,16 @@
 /**
  * Escapes one CSV cell for spreadsheet import.
  *
- * Beyond RFC 4180 quoting this also defuses formula injection: a cell starting with =, +, -, @,
- * tab or CR is evaluated as a formula by Excel and Google Sheets, so exported user-supplied text
+ * Beyond RFC 4180 quoting this also defuses formula injection: a cell starting with =, +, -, @
+ * or tab is evaluated as a formula by Excel and Google Sheets, so exported user-supplied text
  * (display names, organization names) could run on the machine of whoever opens the file. Such
  * values get an apostrophe prefix, which spreadsheets strip on display.
  *
  * Every field is quoted rather than only the ones that need it - valid CSV, and one less rule to
  * get wrong. Newlines are flattened to spaces so a row always occupies a single line.
+ *
+ * Order matters: flattening runs first, so a leading CR arrives at the guard as a space and needs
+ * no entry in the character class. Swap those two lines and CR becomes a real hole.
  */
 export function escapeCsvCell(value: unknown): string {
   const text = value === null || value === undefined ? '' : String(value);

--- a/apps/client/app/utils/download.ts
+++ b/apps/client/app/utils/download.ts
@@ -7,7 +7,8 @@ export function downloadData(data: BlobPart, filename: string, type?: string) {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  // Deferred a tick: Safari aborts the download if the object URL is revoked in the same one.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 export function downloadUrl(url: string, filename: string) {


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
### BEFORE
<img width="1295" height="832" alt="Screenshot 2026-08-03 at 10 39 31 PM" src="https://github.com/user-attachments/assets/803b3cd9-4f85-4837-9444-4e44ea67a833" />
<img width="367" height="789" alt="Screenshot 2026-08-03 at 10 40 19 PM" src="https://github.com/user-attachments/assets/4673e34b-0bab-4c53-b5b4-c744b3b3c316" />
<img width="376" height="791" alt="Screenshot 2026-08-03 at 10 40 26 PM" src="https://github.com/user-attachments/assets/49cca286-bbf8-4214-b5c6-64c5ca6b7418" />

### AFTER
<img width="1295" height="789" alt="Screenshot 2026-08-03 at 10 32 41 PM" src="https://github.com/user-attachments/assets/2c2faba1-d2f9-47a4-b016-bb5a3bcf885f" />
<img width="351" height="752" alt="Screenshot 2026-08-03 at 10 33 17 PM" src="https://github.com/user-attachments/assets/e2385395-696d-421a-ac3f-792a528244fe" />
<img width="357" height="758" alt="Screenshot 2026-08-03 at 10 33 32 PM" src="https://github.com/user-attachments/assets/e2dbc25e-795f-4f3e-a7fd-fafd3f37c41c" />

## Description

Closes #1375.

The Admin > Users tab was awkward to use at both ends of the responsive range.

On desktop, the filter header spent three tall rows on stacked labels and dead
space, the search field ran nearly the full width while View Mode sat far right
with a gap between them, and the page-size picker was a radio group duplicated
in the top and bottom pagination bars. Table cells wrapped badly: the 24-character
object id broke over two lines and Recent Activity over four.

On phones it was worse. Every row was a card wrapping an 800px-wide grid with
`overflowX: auto`, so **each row had its own horizontal scrollbar** and the
Actions column was off-screen. Tapping the filter icon expanded a tall stack of
full-width controls plus three large buttons inline, pushing the table down.

This PR reworks the layout for both breakpoints and splits the 760-line
`index.tsx` into focused modules. A second commit fixes three pre-existing bugs
that surfaced during the work.

## Changes

**Desktop toolbar**
- Two compact rows instead of three tall ones; labels became placeholders and start decorators
- Search stretches to meet the action group, so there is no gap mid-row, and gained a clear button
- Refresh / Download / Help share one quiet outlined style, leaving Create User as the only accent
- Sort order is an arrow toggle (with tooltip and `aria-label`) rather than a "Z to A" text button
- An "N filters" chip clears org/tag/sort in one click

**Pagination**
- The radio group is replaced by one compact "10 / page" select, present on both bars
- Top and bottom bars share a single layout, so the pager and page size line up
- The count reads a quiet "37 users" instead of a bold "Total Users:"

**Table (slim view)**
- Object id is a truncated monospace chip that copies the full value on click
- Recent Activity is a single relative time ("2 days ago") with the exact timestamp on hover
- Storage bar is thinner with the percentage beside it, and shows the raw size below 1% so a
  screen of "0%" no longer reads as broken data
- Login count is a chip instead of an emoji; name and email use CSS ellipsis

**Mobile**
- Stacked cards replace the wide grid: no horizontal scrolling anywhere, actions always reachable
- Org / tag / sort controls moved into a bottom sheet with Clear all and Done; filters apply live
- Create / Refresh / Download / Help became a compact icon row instead of three full-width buttons
- Desktop and mobile trees render conditionally rather than one being hidden with CSS, so element
  test ids stay unique for Playwright

**Structure**
- `index.tsx` 760 -> ~175 lines; params store, filter controls, pagination, CSV export extracted
- Filter controls are shared between the desktop toolbar and the mobile sheet
- The persisted store key is unchanged, so saved filters carry over

**Fixes (second commit)**
- CSV export's Organization column was always blank: it read `user.organization`, but the populated
  reference lives on `organizationId`. The row mapper was loosely typed, so the compiler never caught it
- CSV fields were joined without quoting, so a value containing a comma shifted every later column
- A search term restored from persisted filters was wiped ~300ms after load, because the debounce hook
  seeded from an empty string and synced that back over the stored value
- A failed CSV download was silent; it now surfaces an error

## Guide for Testers

Use a desktop browser at 1400px or wider unless a step says otherwise.

**Desktop toolbar**
1. Sign in as an admin and go to Sidebar -> Admin -> Users. The user table loads.
2. Confirm the filter card is two rows tall with no floating labels above the controls, and no empty
   gap between the search field and the View Mode select.
3. Type `test` in the search field. The list filters within about a second and pagination resets to page 1.
4. Click the X at the right of the search field. The text clears and the full list returns.
5. Reload the page with a search term still in the box. Expected: the term is still there after load and
   the list stays filtered (before this PR the box emptied itself shortly after load).
6. Hover Refresh, Download and Help. Each shows a tooltip. All three look the same weight; only
   Create User is colored.
7. Click the arrow button beside the "Created At" select. The arrow flips between up and down and the
   list re-sorts. It is briefly disabled while data loads.
8. Change the "Created At" select to `Name`. The list re-sorts by name.
9. Set an organization or tag filter. Expected: an "N filters" chip appears at the right of the second
   row. Click its X. Filters reset to All Organizations / All Tags and Created At descending.

**Pagination**
10. Confirm both the top and bottom bars show the pager on the left and "10 / page" on the right,
    aligned in the same columns, with "37 users" (your total) only on the top bar.
11. Set the bottom bar's select to `20`. Expected: 20 rows load and both bars now read "20 / page".
12. Click the right chevron on the bottom bar. Expected: page 2 loads and both bars show the new page.
    On page 1 the left chevron is disabled; on the last page the right chevron is disabled.

**Table cells**
13. Click the id chip on any row (e.g. `690078...0001`). Expected: it turns green with a check for about
    a second, and pasting elsewhere yields the full 24-character id. Hovering shows the full id.
14. Hover a Recent Activity cell. Expected: one line like "2 days ago", with the exact date and event
    name in the tooltip. No four-line wrapping.
15. Hover a Storage bar. Expected: a "used / limit" tooltip. For users with almost no usage the cell
    shows a byte size (e.g. "0 B") rather than "0%".

**Mobile**
16. Open DevTools device mode at 390x844 (or use a phone) and return to Admin -> Users.
17. Scroll the list and try dragging a row sideways. Expected: nothing scrolls horizontally, and no
    row has its own scrollbar. Each user is a stacked card showing name, email, id chip, login count,
    MFA and activity, with Admin and Profile buttons.
18. Tap the filter icon in the header. Expected: a sheet slides up from the bottom titled "Filters"
    with Organizations, User Tags and Sort.
19. Pick a tag in the sheet. Expected: the list behind it updates immediately. Tap Done. The sheet closes
    and the filter icon shows a badge count.
20. Tap the filter icon again and tap Clear all. Expected: filters reset and the badge disappears.
21. Confirm Create User, Refresh, Download and Help are a small icon row under the search field, not
    full-width buttons, and not inside the sheet.

**CSV export**
22. Back on desktop, click the Download icon and open `users.csv`.
23. Expected: the Organization column is populated for users who belong to an organization (it was
    always empty before this PR).
24. If any user's name or organization contains a comma, confirm its row's columns still line up
    rather than shifting one place right.

**Regression Checks**
25. Switch View Mode through Full, User Journey and Recent Activity. Each renders as before, at both
    desktop and phone widths.
26. Click Admin on a row. The full user view modal opens. Close it.
27. Click Profile on a row. The admin profile modal opens. Close it.
28. Click the login-count chip on a row. The last-login details modal opens.
29. Create a user via Create User, then find it with search. It appears.
30. Set a filter and a page size, reload the page, and confirm both are still applied (persisted
    filters are unchanged by this PR).

**What NOT to test**
- No API, query or database behavior changed. The users endpoint receives the same parameters.
- No other admin tab was touched.

## Additional Information

The two commits are deliberately separate: the refactor commit moves the CSV logic across with its
original behavior intact (bugs and all) so it stays reviewable as a no-behavior-change move, and the
fix commit is two files. Both were verified to typecheck and pass tests independently, so the branch
is safe to bisect. If you squash on merge, note that the PR title says `refactor` while the branch
also carries a `fix`.

Verification run locally: `pnpm --filter client typecheck`, `pnpm lint:check`, and the admin test
suite (42 files, 434 tests). 12 new unit tests cover the id chip truncation and clipboard copy, both
pagination variants, and the desktop/mobile split. The app itself was not launched, as that needs SST
binding and database credentials, so please exercise the manual steps above.

## Developer Notes (Optional)

- `PaginationControls` takes a `variant: 'full' | 'compact'` and is reusable by any admin table needing
  the same pager and page-size pattern
- `UserIdChip` (with the exported `truncateUserId`) is a reusable copy-on-click chip for object ids
- The `filters/` components read and write the shared params store directly, so the desktop toolbar and
  the mobile sheet render the same controls with no duplicated state or JSX
- Conditional rendering via `useIsMobile()` rather than CSS `display: none` is the pattern to follow when
  a component ships distinct desktop and mobile trees, since duplicated `data-testid`s break Playwright's
  strict mode
