### PR TITLE
fix(client): stop hydration effect from reverting optimistic file removal

### DIFF
--- a/apps/client/app/contexts/SessionsContext.tsx
+++ b/apps/client/app/contexts/SessionsContext.tsx
@@ -461,7 +461,8 @@ export const SessionsProvider: FC<SessionsProviderProps> = ({ children }) => {
         .filter((file): file is IFabFileDocument => file !== undefined)
         .map(file => ({ ...file, enabled: true }));
     },
-    [] // stable: reads fabFilesRef at call time
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally stable: reads fabFilesRef at call time
+    []
   );
 
   // Persist session knowledgeIds to the backend

--- a/apps/client/app/contexts/SessionsContext.tsx
+++ b/apps/client/app/contexts/SessionsContext.tsx
@@ -321,6 +321,14 @@ export const SessionsProvider: FC<SessionsProviderProps> = ({ children }) => {
 
   const { data: paginatedFabFiles } = useGetFabFiles();
   const fabFiles = useMemo(() => paginatedFabFiles?.pages?.map(page => page.data).flat(), [paginatedFabFiles?.pages]);
+  // Ref mirror so fetchFiles can read the latest fabFiles without re-creating
+  // itself on every paginated refetch. Without this, every fabFiles change
+  // re-triggers the hydration effect, which re-reads currentSession.knowledgeIds
+  // and can overwrite an in-flight optimistic removal.
+  const fabFilesRef = useRef(fabFiles);
+  useEffect(() => {
+    fabFilesRef.current = fabFiles;
+  }, [fabFiles]);
   const queryClient = useQueryClient();
 
   // Memoize the query object to prevent re-subscription churn: this is an
@@ -425,10 +433,12 @@ export const SessionsProvider: FC<SessionsProviderProps> = ({ children }) => {
     [settings.experimentalFeatures, isFeatureEnabled, availableAgents, currentSession, queryClient]
   );
 
-  // Utility function to fetch files, first trying local storage, then the server
+  // Utility function to fetch files, first trying local storage, then the server.
+  // Reads fabFilesRef (not fabFiles) so this callback is stable across paginated
+  // refetches and does not re-trigger the hydration effect.
   const fetchFiles = useCallback(
     async (knowledgeIds: string[]): Promise<IFabFileDocument[]> => {
-      const safeFabFiles = fabFiles ?? [];
+      const safeFabFiles = fabFilesRef.current ?? [];
 
       const localFiles = knowledgeIds
         .map(knowledgeId => safeFabFiles.find(file => file.id === knowledgeId))
@@ -451,7 +461,7 @@ export const SessionsProvider: FC<SessionsProviderProps> = ({ children }) => {
         .filter((file): file is IFabFileDocument => file !== undefined)
         .map(file => ({ ...file, enabled: true }));
     },
-    [fabFiles]
+    [] // stable: reads fabFilesRef at call time
   );
 
   // Persist session knowledgeIds to the backend
@@ -598,7 +608,7 @@ export const SessionsProvider: FC<SessionsProviderProps> = ({ children }) => {
     } else if (currentSessionId) {
       setWorkBenchFiles(currentSessionId, []);
     }
-  }, [currentSession?.knowledgeIds, fabFiles, fetchFiles, currentSessionId, setWorkBenchFiles]);
+  }, [currentSession?.knowledgeIds, fetchFiles, currentSessionId, setWorkBenchFiles]);
 
   // AUTO-DISABLE EXPENSIVE TOOLS: Disable Deep Research and QuestMaster when SWITCHING notebooks (A->B)
   // This prevents accidental expensive operations when users change context


### PR DESCRIPTION



# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description
<!--
Provide a detailed description of what this PR does. Explain the problem you're solving or the feature you're adding.
-->

The workbench hydration effect re-ran whenever fabFiles changed (very frequent -- ~30 invalidation sites). Each re-run read the stale currentSession.knowledgeIds before the in-flight persist() could update it, re-adding the file the user just removed.

Move fabFiles behind a ref so fetchFiles is stable and no longer triggers re-hydration on every paginated refetch. The effect now only fires when knowledgeIds actually changes.

## Changes
<!--
List the changes you've made in this PR. This is to help the reviewers understand the impact of your changes.
- Change 1
- Change 2
- ...
-->

1. fabFilesRef — mirrors fabFiles into a ref via useEffect, so fetchFiles can read it without depending on it.
 2. fetchFiles deps [] — now stable; reads fabFilesRef.current at call time instead of closing over fabFiles.
 3. Hydration effect deps — drops fabFiles (was transitive via fetchFiles). Only fires on currentSession?.knowledgeIds changes.

## Guide for Testers
<!--
Write step-by-step instructions that both human QA testers AND AI agents (e.g., Playwright) can follow without codebase knowledge.

Repro: Attach a file to a notebook, then remove it via the prompt bar files dropdown. The file reappears within seconds.
 
Expected: File stays removed.

Requirements:
- Number every step — one action per step
- Use exact navigation paths: "Sidebar → Admin → DLQ Management"
- Use exact URLs: "app.staging.bike4mind.com"
- Use exact input values: type `Hello, how are you?` in the message input
- State expected results after each step: "A response appears within 10 seconds with no errors"
- Include a "Regression Checks" section for refactors
- Include a "What NOT to test" section for infra/backend-only PRs

See CLAUDE.md → "Test Guide Standards" for full guidelines and examples.
-->

## Additional Information
<!--
Include any additional information or context that you think would be helpful for your reviewers.
-->

## Developer Notes (Optional)
<!--
Document capability unlocks, architectural improvements, and reusable patterns introduced by this PR.
This helps future developers understand what new building blocks are available.

Categories to consider:
- **New Extension Points**: Components/interfaces that accept new props, hooks, or configuration
- **Reusable Patterns**: New components, utilities, or approaches that can be applied elsewhere
- **Data Model Changes**: New fields, types, or structures that enable future features
- **Architecture Decisions**: Why something was built a certain way (not just what changed)

Example:
- `SchedulerTab` now accepts a `familyId` prop — any new pattern family automatically gets a Learn tab
- `ComingSoonPanel` component can be dropped into any tab to indicate future work
- `effectiveTab` pattern shows how to handle persisted tab state when tabs become conditionally disabled
-->

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
