### PR TITLE
fix(data-lakes)!: key retrieval-index removal on lake membership

### DIFF
--- a/apps/client/server/services/dataLakePurgeIndexScope.e2e.test.ts
+++ b/apps/client/server/services/dataLakePurgeIndexScope.e2e.test.ts
@@ -139,6 +139,13 @@ describe('data lake purge index-removal scope (real repos + Mongo)', () => {
 
     // d) the stranger's same-prefix file was never a member and must survive.
     expect(await fileExists(strangerFile._id.toString())).toBe(true);
+
+    // e) the sweep's chunk step ran on the same set - a purged file with chunks left behind is
+    // the orphan this whole change is about, just in the chunk store instead of the index.
+    for (const f of [metaTagged, prefixOwned]) {
+      expect(await fabFileChunkRepository.findByFabFileId(f._id.toString())).toHaveLength(0);
+    }
+    expect(await fabFileChunkRepository.findByFabFileId(strangerFile._id.toString())).toHaveLength(1);
   });
 
   it('spares a file that became a member after the sweep resolved its ids', async () => {

--- a/apps/client/server/services/dataLakePurgeIndexScope.e2e.test.ts
+++ b/apps/client/server/services/dataLakePurgeIndexScope.e2e.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+import { KnowledgeType } from '@bike4mind/common';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import {
+  FabFile,
+  DataLakeModel,
+  fabFileRepository,
+  fabFileChunkRepository,
+  dataLakeRepository,
+  dataLakeBatchRepository,
+} from '@bike4mind/database';
+import { dataLakeService } from '@bike4mind/services';
+import type { RetrievalIndexPort, RetrievalIndexRemoval } from '@bike4mind/services';
+
+/**
+ * End-to-end guard for the data lake purge index-removal contract, driving the REAL
+ * cleanupDeletedDataLake service function through the REAL FabFile/DataLake repositories against
+ * createMongoServer: seed a lake with a meta-tagged file and a prefix-only member (both owned by
+ * the creator) plus a same-prefix stranger's file, purge it, and check what the retrieval-index
+ * port was actually told to remove against what really left Mongo. Every unit layer here mocks its
+ * neighbor, so only this test proves the ids the port receives are the SAME set the hard-delete
+ * destroys - a mock can assert a contract the real membership scope doesn't deliver. Lives in
+ * apps/client because it is the only package with both @bike4mind/services and @bike4mind/database
+ * as dependencies. Consumes the built dist, so `pnpm turbo:core:build` must be current.
+ */
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 30000);
+afterEach(async () => {
+  await mongoose.connection.dropDatabase();
+});
+
+const CREATOR = 'u-lake-creator';
+const STRANGER = 'u-stranger';
+
+const makeFile = (overrides: { fileName: string; userId: string; tags: { name: string }[] }) =>
+  FabFile.create({
+    mimeType: 'text/plain',
+    type: KnowledgeType.FILE,
+    filePath: overrides.fileName,
+    fileSize: 100,
+    status: 'complete',
+    ...overrides,
+  });
+
+async function seedLake() {
+  const datalakeTag = `datalake:acme-docs-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const metaTagged = await makeFile({ fileName: 'meta.txt', userId: CREATOR, tags: [{ name: datalakeTag }] });
+  const prefixOwned = await makeFile({
+    fileName: 'prefix-owned.txt',
+    userId: CREATOR,
+    tags: [{ name: 'acme:report' }],
+  });
+  const strangerFile = await makeFile({ fileName: 'stranger.txt', userId: STRANGER, tags: [{ name: 'acme:other' }] });
+
+  const lake = await DataLakeModel.create({
+    name: 'Acme Docs',
+    slug: `acme-docs-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    fileTagPrefix: 'acme:',
+    datalakeTag,
+    createdByUserId: CREATOR,
+    status: 'deleted',
+  });
+
+  for (const f of [metaTagged, prefixOwned, strangerFile]) {
+    // createdAt/updatedAt are declared on IFabFileChunkDocument (via IMongoDocument) but populated
+    // by the schema's `timestamps: true`; passing placeholders satisfies bulkInsert's real type
+    // without a cast.
+    await fabFileChunkRepository.bulkInsert([
+      {
+        text: `chunk for ${f.fileName}`,
+        fabFileId: f._id.toString(),
+        tokenCount: 5,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+  }
+
+  return { lake, metaTagged, prefixOwned, strangerFile };
+}
+
+const fileExists = async (id: string) =>
+  (await FabFile.collection.countDocuments({ _id: new mongoose.Types.ObjectId(id) })) === 1;
+
+const runCleanup = (lakeId: string, retrievalIndex: RetrievalIndexPort) =>
+  dataLakeService.cleanupDeletedDataLake({ userId: CREATOR, isAdmin: false }, lakeId, {
+    db: {
+      dataLakes: dataLakeRepository,
+      batches: dataLakeBatchRepository,
+      fabFiles: fabFileRepository,
+      fabFileChunks: fabFileChunkRepository,
+    },
+    retrievalIndex,
+  });
+
+describe('data lake purge index-removal scope (real repos + Mongo)', () => {
+  it('tells the index every file it purges, prefix-only members included', async () => {
+    const { lake, metaTagged, prefixOwned, strangerFile } = await seedLake();
+    let received: RetrievalIndexRemoval | undefined;
+    const port: RetrievalIndexPort = {
+      async removeForDataLake(input) {
+        received = input;
+      },
+    };
+
+    await runCleanup(lake._id.toString(), port);
+
+    // a) the scope carries every field a meta-tag-only key would lack.
+    expect(received?.scope.datalakeTag).toBeTruthy();
+    expect(received?.scope.fileTagPrefix).toBeTruthy();
+    expect(received?.scope.creatorUserId).toBeTruthy();
+
+    // b) the prefix-only member is in the removal set, not just the meta-tagged file.
+    expect(received?.fabFileIds).toContain(prefixOwned._id.toString());
+    expect(received?.fabFileIds).toContain(metaTagged._id.toString());
+
+    // c) THE KEY INVARIANT: what the port was told to remove is EXACTLY what Mongo actually lost -
+    // no file destroyed behind the index's back, and no id claimed that survived.
+    const stillPresent = await Promise.all(
+      [metaTagged, prefixOwned, strangerFile].map(async f => ({
+        id: f._id.toString(),
+        present: await fileExists(f._id.toString()),
+      }))
+    );
+    const actuallyDeletedIds = stillPresent.filter(f => !f.present).map(f => f.id);
+    expect(actuallyDeletedIds.sort()).toEqual([...(received?.fabFileIds ?? [])].sort());
+
+    // d) the stranger's same-prefix file was never a member and must survive.
+    expect(await fileExists(strangerFile._id.toString())).toBe(true);
+  });
+
+  it('spares a file that became a member after the sweep resolved its ids', async () => {
+    const { lake, prefixOwned } = await seedLake();
+    let received: RetrievalIndexRemoval | undefined;
+    let joiner: Awaited<ReturnType<typeof makeFile>> | undefined;
+    const port: RetrievalIndexPort = {
+      async removeForDataLake(input) {
+        received = input;
+        // The port runs after the sweep resolved its ids and before it destroys anything, so this
+        // is the real mid-sweep window: the creator tags another of their files into the lake.
+        joiner = await makeFile({ fileName: 'joined-mid-sweep.txt', userId: CREATOR, tags: [{ name: 'acme:late' }] });
+      },
+    };
+
+    await runCleanup(lake._id.toString(), port);
+
+    const joinerId = joiner!._id.toString();
+    // Not vacuous: the joiner really does satisfy the membership predicate, so a purge that
+    // re-resolved membership at delete time WOULD have taken it.
+    const membersNow = await fabFileRepository.findIdsByDataLakeTag({
+      datalakeTag: lake.datalakeTag,
+      fileTagPrefix: lake.fileTagPrefix,
+      creatorUserId: lake.createdByUserId,
+    });
+    expect(membersNow).toContain(joinerId);
+
+    // It was never announced to the index, so destroying it would orphan its chunks and its entry.
+    expect(received?.fabFileIds).not.toContain(joinerId);
+    expect(await fileExists(joinerId)).toBe(true);
+    // The members that WERE announced are gone, so this is not just a purge that did nothing.
+    expect(await fileExists(prefixOwned._id.toString())).toBe(false);
+  });
+
+  it('a failing index aborts the purge before anything is destroyed', async () => {
+    const { lake, metaTagged, prefixOwned, strangerFile } = await seedLake();
+    const port: RetrievalIndexPort = {
+      async removeForDataLake() {
+        throw new Error('index unavailable');
+      },
+    };
+
+    await expect(runCleanup(lake._id.toString(), port)).rejects.toThrow('index unavailable');
+
+    for (const f of [metaTagged, prefixOwned, strangerFile]) {
+      expect(await fileExists(f._id.toString())).toBe(true);
+      expect(await fabFileChunkRepository.findByFabFileId(f._id.toString())).toHaveLength(1);
+    }
+  });
+});

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -611,7 +611,13 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
    * destroys rows it never accounted for.
    */
   hardDeleteByDataLakeTag(scope: DataLakeMembershipScope): Promise<string[]>;
-  /** Hard-delete exactly these files, including soft-deleted ones. Returns the ids. Idempotent. */
+  /**
+   * Hard-delete exactly these files, including soft-deleted ones. Idempotent.
+   *
+   * Echoes back the ids it was GIVEN, not the rows it actually removed - a second call with the
+   * same ids returns them again. Do not read the result as "what this call deleted"; if you need
+   * that, count before and after.
+   */
   hardDeleteByIds(fabFileIds: string[]): Promise<string[]>;
   /** All member file ids (including soft-deleted), for chunk/index cleanup. */
   findIdsByDataLakeTag(scope: DataLakeMembershipScope): Promise<string[]>;

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -617,6 +617,9 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
    * Echoes back the ids it was GIVEN, not the rows it actually removed - a second call with the
    * same ids returns them again. Do not read the result as "what this call deleted"; if you need
    * that, count before and after.
+   *
+   * Ids must come from a prior repository read. They go straight into an `_id` query, so a
+   * malformed one throws a CastError partway through the delete.
    */
   hardDeleteByIds(fabFileIds: string[]): Promise<string[]>;
   /** All member file ids (including soft-deleted), for chunk/index cleanup. */

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -602,8 +602,17 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   undeleteByDataLakeTag(scope: DataLakeMembershipScope, excludeIds?: string[]): Promise<number>;
   /** Soft-delete (phase 1) all member files. Returns affected file ids. */
   softDeleteByDataLakeTag(scope: DataLakeMembershipScope): Promise<string[]>;
-  /** Hard-delete (phase 2) all member files, including soft-deleted. Returns purged ids. Idempotent. */
+  /**
+   * Hard-delete (phase 2) all member files, including soft-deleted. Returns purged ids. Idempotent.
+   *
+   * Resolves membership at call time, so it can destroy a file that became a member after the
+   * caller last looked. A caller that has already acted on a resolved id set - deleted its chunks,
+   * told a retrieval index - must purge that same set via `hardDeleteByIds` instead, or it
+   * destroys rows it never accounted for.
+   */
   hardDeleteByDataLakeTag(scope: DataLakeMembershipScope): Promise<string[]>;
+  /** Hard-delete exactly these files, including soft-deleted ones. Returns the ids. Idempotent. */
+  hardDeleteByIds(fabFileIds: string[]): Promise<string[]>;
   /** All member file ids (including soft-deleted), for chunk/index cleanup. */
   findIdsByDataLakeTag(scope: DataLakeMembershipScope): Promise<string[]>;
 }

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -90,6 +90,7 @@ export const createMockFabFileRepository = (): IFabFileRepository => ({
   undeleteByDataLakeTag: vi.fn(),
   softDeleteByDataLakeTag: vi.fn(),
   hardDeleteByDataLakeTag: vi.fn(),
+  hardDeleteByIds: vi.fn(),
   findIdsByDataLakeTag: vi.fn(),
   findByUserId: vi.fn(),
 });

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -14,7 +14,7 @@ interface ArchiveDataLakeAdapters {
   db: {
     dataLakes: Pick<IDataLakeRepository, 'findById' | 'update' | 'setStats' | 'find'>;
     batches: Pick<IDataLakeBatchRepository, 'findActiveByDataLakeId' | 'markTerminalIfActive'>;
-    fabFiles: Pick<IFabFileRepository, 'archiveByDataLakeTag' | 'computeDataLakeStats'>;
+    fabFiles: Pick<IFabFileRepository, 'archiveByDataLakeTag' | 'computeDataLakeStats' | 'findIdsByDataLakeTag'>;
   };
   retrievalIndex?: RetrievalIndexPort;
   logger?: { warn: (msg: string, ...args: unknown[]) => void };
@@ -60,8 +60,12 @@ export const archiveDataLake = async (
   // browse (they filter archivedAt: null) - and unarchiving either lake brings back BOTH lakes'
   // archived files, since the flip matches on archivedAt alone.
   await warnOnPrefixCollision(db, existing, logger);
-  await db.fabFiles.archiveByDataLakeTag(lakeMembershipScope(existing));
-  await bestEffortIndexRemove(retrievalIndex, existing.datalakeTag, logger);
+  const scope = lakeMembershipScope(existing);
+  await db.fabFiles.archiveByDataLakeTag(scope);
+  // Same scope the sweep ran on. findIdsByDataLakeTag is the id source rather than the flip's
+  // count because it reports every member whatever its archived/deleted state, so a re-run after
+  // a crashed attempt still hands the index the full set.
+  await bestEffortIndexRemove(retrievalIndex, scope, () => db.fabFiles.findIdsByDataLakeTag(scope), logger);
 
   // Step 4: settle to archived and reconcile stats from source (now 0 live files).
   const updated = await db.dataLakes.update({ id: dataLakeId, status: 'archived' });

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
@@ -40,9 +40,9 @@ async function inChunks<T>(items: T[], size: number, fn: (item: T) => Promise<un
  * deleteMany are no-ops on already-purged data). Fan-outs are chunked (chunkSize) so a large lake
  * stays inside the Lambda timeout. Owner or admin only.
  *
- * Retrieval-index removal is the one step that can abort the sweep, which is why it runs first:
- * every other door tolerates a stale entry, but nothing can reconcile one whose file this call is
- * about to erase.
+ * Retrieval-index removal is the one step deliberately allowed to abort the sweep - the reversible
+ * doors tolerate a stale entry, but nothing can reconcile one whose file this call is about to
+ * erase. It runs first so that choice costs no partial progress.
  */
 export const cleanupDeletedDataLake = async (
   actor: { userId: string; isAdmin: boolean },

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
@@ -13,7 +13,7 @@ interface CleanupDeletedDataLakeAdapters {
   db: {
     dataLakes: Pick<IDataLakeRepository, 'findById' | 'delete' | 'find'>;
     batches: Pick<IDataLakeBatchRepository, 'find' | 'delete'>;
-    fabFiles: Pick<IFabFileRepository, 'findIdsByDataLakeTag' | 'hardDeleteByDataLakeTag'>;
+    fabFiles: Pick<IFabFileRepository, 'findIdsByDataLakeTag' | 'hardDeleteByIds'>;
     fabFileChunks: Pick<IFabFileChunkRepository, 'deleteManyByFabFileId'>;
   };
   retrievalIndex?: RetrievalIndexPort;
@@ -75,8 +75,11 @@ export const cleanupDeletedDataLake = async (
   // already-purged data, so a DLQ retry resumes safely.
   await inChunks(fileIds, chunkSize, id => db.fabFileChunks.deleteManyByFabFileId(id));
 
-  // 3. Hard-delete the files.
-  await db.fabFiles.hardDeleteByDataLakeTag(scope);
+  // 3. Hard-delete exactly the ids resolved above, NOT by re-running the membership predicate.
+  // Re-resolving would also destroy anything that became a member since - a file the creator
+  // tagged mid-sweep - leaving its chunks behind and its index entry unrequested. It survives
+  // this run instead, which is the recoverable direction.
+  await db.fabFiles.hardDeleteByIds(fileIds);
 
   // 4. Delete the lake's batches (chunked, same rationale as the chunk sweep above).
   const batches = await db.batches.find({ dataLakeId });

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
@@ -7,7 +7,7 @@ import type {
 import { BadRequestError } from '@bike4mind/utils';
 import { lakeMembershipScope } from './lakeMembershipScope';
 import { warnOnPrefixCollision } from './tagPrefixCollision';
-import { bestEffortIndexRemove, type RetrievalIndexPort } from './ports';
+import { strictIndexRemove, type RetrievalIndexPort } from './ports';
 
 interface CleanupDeletedDataLakeAdapters {
   db: {
@@ -39,6 +39,10 @@ async function inChunks<T>(items: T[], size: number, fn: (item: T) => Promise<un
  * lake in 'deleted' and a DLQ retry re-runs it without error or double-deletion (delete-by-id and
  * deleteMany are no-ops on already-purged data). Fan-outs are chunked (chunkSize) so a large lake
  * stays inside the Lambda timeout. Owner or admin only.
+ *
+ * Retrieval-index removal is the one step that can abort the sweep, which is why it runs first:
+ * every other door tolerates a stale entry, but nothing can reconcile one whose file this call is
+ * about to erase.
  */
 export const cleanupDeletedDataLake = async (
   actor: { userId: string; isAdmin: boolean },
@@ -57,16 +61,19 @@ export const cleanupDeletedDataLake = async (
     throw new BadRequestError('Data lake must be soft-deleted before cleanup');
   }
 
-  // 1. Delete chunks for every member file (covers soft-deleted files too). Chunked so a large
-  // lake doesn't fan out unbounded (Lambda timeout/memory); each delete is a no-op on
-  // already-purged data, so a DLQ retry resumes safely.
   await warnOnPrefixCollision(db, existing, logger);
   const scope = lakeMembershipScope(existing);
   const fileIds = await db.fabFiles.findIdsByDataLakeTag(scope);
-  await inChunks(fileIds, chunkSize, id => db.fabFileChunks.deleteManyByFabFileId(id));
 
-  // 2. Best-effort retrieval index removal.
-  await bestEffortIndexRemove(retrievalIndex, existing.datalakeTag, logger);
+  // 1. Retrieval index first, and strict. An entry left behind once the files are gone can never
+  // be reconciled, so unlike the reversible doors this one propagates - and running it before any
+  // destruction means a throw leaves zero progress for the queue's retry to trip over.
+  await strictIndexRemove(retrievalIndex, { scope, fabFileIds: fileIds });
+
+  // 2. Delete chunks for every member file (covers soft-deleted files too). Chunked so a large
+  // lake doesn't fan out unbounded (Lambda timeout/memory); each delete is a no-op on
+  // already-purged data, so a DLQ retry resumes safely.
+  await inChunks(fileIds, chunkSize, id => db.fabFileChunks.deleteManyByFabFileId(id));
 
   // 3. Hard-delete the files.
   await db.fabFiles.hardDeleteByDataLakeTag(scope);

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
@@ -40,9 +40,8 @@ async function inChunks<T>(items: T[], size: number, fn: (item: T) => Promise<un
  * deleteMany are no-ops on already-purged data). Fan-outs are chunked (chunkSize) so a large lake
  * stays inside the Lambda timeout. Owner or admin only.
  *
- * Retrieval-index removal is the one step deliberately allowed to abort the sweep - the reversible
- * doors tolerate a stale entry, but nothing can reconcile one whose file this call is about to
- * erase. It runs first so that choice costs no partial progress.
+ * Retrieval-index removal is the one step deliberately allowed to abort the sweep, which is why it
+ * runs first. See `strictIndexRemove` in ports.ts for that posture and what it does not cover.
  */
 export const cleanupDeletedDataLake = async (
   actor: { userId: string; isAdmin: boolean },
@@ -65,9 +64,7 @@ export const cleanupDeletedDataLake = async (
   const scope = lakeMembershipScope(existing);
   const fileIds = await db.fabFiles.findIdsByDataLakeTag(scope);
 
-  // 1. Retrieval index first, and strict. An entry left behind once the files are gone can never
-  // be reconciled, so unlike the reversible doors this one propagates - and running it before any
-  // destruction means a throw leaves zero progress for the queue's retry to trip over.
+  // 1. Retrieval index first, and strict: a throw here must cost no progress (see ports.ts).
   await strictIndexRemove(retrievalIndex, { scope, fabFileIds: fileIds });
 
   // 2. Delete chunks for every member file (covers soft-deleted files too). Chunked so a large
@@ -79,6 +76,10 @@ export const cleanupDeletedDataLake = async (
   // Re-resolving would also destroy anything that became a member since - a file the creator
   // tagged mid-sweep - leaving its chunks behind and its index entry unrequested. It survives
   // this run instead, which is the recoverable direction.
+  //
+  // The survivor is left carrying a prefix tag whose lake step 5 then deletes, and nothing
+  // reconciles that: a later lake claiming the same prefix would silently adopt it, since the
+  // create-time collision guard only compares against lakes that still exist.
   await db.fabFiles.hardDeleteByIds(fileIds);
 
   // 4. Delete the lake's batches (chunked, same rationale as the chunk sweep above).

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1095,7 +1095,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
       batches: { find: vi.fn().mockResolvedValue([{ id: 'b1' }]), delete: vi.fn().mockResolvedValue(undefined) },
       fabFiles: {
         findIdsByDataLakeTag: vi.fn().mockResolvedValue(['f1', 'f2']),
-        hardDeleteByDataLakeTag: vi.fn().mockResolvedValue(['f1', 'f2']),
+        hardDeleteByIds: vi.fn().mockResolvedValue(['f1', 'f2']),
       },
       fabFileChunks: { deleteManyByFabFileId: vi.fn().mockResolvedValue(undefined) },
     },
@@ -1112,7 +1112,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     const adapters = makeAdapters('deleted');
     await cleanupDeletedDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
     expect(adapters.db.fabFileChunks.deleteManyByFabFileId).toHaveBeenCalledTimes(2);
-    expect(adapters.db.fabFiles.hardDeleteByDataLakeTag).toHaveBeenCalled();
+    expect(adapters.db.fabFiles.hardDeleteByIds).toHaveBeenCalled();
     expect(adapters.db.batches.delete).toHaveBeenCalledWith('b1');
     expect(adapters.db.dataLakes.delete).toHaveBeenCalledWith('lake1');
   });
@@ -1140,7 +1140,23 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     expect(indexRemove).toBeLessThan(
       Math.min(...adapters.db.fabFileChunks.deleteManyByFabFileId.mock.invocationCallOrder)
     );
-    expect(indexRemove).toBeLessThan(adapters.db.fabFiles.hardDeleteByDataLakeTag.mock.invocationCallOrder[0]);
+    expect(indexRemove).toBeLessThan(adapters.db.fabFiles.hardDeleteByIds.mock.invocationCallOrder[0]);
+  });
+
+  it('purges exactly the ids it announced, so a mid-sweep joiner is not destroyed unaccounted for', async () => {
+    const adapters = makeAdapters('deleted');
+    adapters.db.fabFiles.findIdsByDataLakeTag = vi.fn().mockResolvedValue(memberIds);
+    const retrievalIndex = indexPort();
+
+    await cleanupDeletedDataLake({ userId: 'owner', isAdmin: false }, 'lake1', { ...adapters, retrievalIndex });
+
+    // By id, never by re-running the predicate: a file tagged into the lake after the resolve
+    // would otherwise be hard-deleted with its chunks intact and the index never told.
+    expect(adapters.db.fabFiles.hardDeleteByIds).toHaveBeenCalledWith(memberIds);
+    expect(removalInput(retrievalIndex).fabFileIds).toEqual(memberIds);
+    // Resolved once and reused. Re-resolving before the purge would pass the assertions above
+    // while reopening the window they exist to close.
+    expect(adapters.db.fabFiles.findIdsByDataLakeTag).toHaveBeenCalledTimes(1);
   });
 
   it('aborts the purge with nothing destroyed when the index removal fails', async () => {
@@ -1156,7 +1172,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     // can never be reconciled. The queue retry re-runs the whole sweep, so leaving it zero-progress
     // is what makes propagating safe.
     expect(adapters.db.fabFileChunks.deleteManyByFabFileId).not.toHaveBeenCalled();
-    expect(adapters.db.fabFiles.hardDeleteByDataLakeTag).not.toHaveBeenCalled();
+    expect(adapters.db.fabFiles.hardDeleteByIds).not.toHaveBeenCalled();
     expect(adapters.db.batches.delete).not.toHaveBeenCalled();
     expect(adapters.db.dataLakes.delete).not.toHaveBeenCalled();
   });
@@ -1174,7 +1190,7 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
 
     // Ordering contract: last chunk delete -> hard-delete files -> first batch delete -> lake last.
     const lastChunk = Math.max(...adapters.db.fabFileChunks.deleteManyByFabFileId.mock.invocationCallOrder);
-    const hardDelete = adapters.db.fabFiles.hardDeleteByDataLakeTag.mock.invocationCallOrder[0];
+    const hardDelete = adapters.db.fabFiles.hardDeleteByIds.mock.invocationCallOrder[0];
     const firstBatch = Math.min(...adapters.db.batches.delete.mock.invocationCallOrder);
     const lakeDelete = adapters.db.dataLakes.delete.mock.invocationCallOrder[0];
     expect(lastChunk).toBeLessThan(hardDelete);

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -973,7 +973,7 @@ describe('restoreDeletedDataLake — deleted→active with dedup', () => {
   });
 });
 
-describe('archiveDataLake — retrieval-index removal', () => {
+describe('archiveDataLake - retrieval-index removal', () => {
   const makeAdapters = () => ({
     db: {
       dataLakes: {
@@ -1028,9 +1028,22 @@ describe('archiveDataLake — retrieval-index removal', () => {
     expect(adapters.db.fabFiles.findIdsByDataLakeTag).not.toHaveBeenCalled();
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope);
   });
+
+  it('survives a member-id lookup that itself fails', async () => {
+    const adapters = makeAdapters();
+    // The resolver is lazy and inside the try precisely so this cannot abort a best-effort op.
+    adapters.db.fabFiles.findIdsByDataLakeTag = vi.fn().mockRejectedValue(new Error('mongo down'));
+    await expect(
+      archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', { ...adapters, retrievalIndex: indexPort() })
+    ).resolves.toMatchObject({ status: 'archived' });
+    expect(adapters.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Best-effort index removal failed for datalake:lake'),
+      expect.any(Error)
+    );
+  });
 });
 
-describe('deleteDataLake — phase 1 retrieval-index removal', () => {
+describe('deleteDataLake - phase 1 retrieval-index removal', () => {
   const makeAdapters = () => ({
     db: {
       dataLakes: {
@@ -1082,6 +1095,18 @@ describe('deleteDataLake — phase 1 retrieval-index removal', () => {
     await deleteDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
     expect(adapters.db.fabFiles.findIdsByDataLakeTag).not.toHaveBeenCalled();
     expect(adapters.db.fabFiles.softDeleteByDataLakeTag).toHaveBeenCalledWith(lakeScope);
+  });
+
+  it('survives a member-id lookup that itself fails', async () => {
+    const adapters = makeAdapters();
+    adapters.db.fabFiles.findIdsByDataLakeTag = vi.fn().mockRejectedValue(new Error('mongo down'));
+    await expect(
+      deleteDataLake({ userId: 'owner', isAdmin: false }, 'lake1', { ...adapters, retrievalIndex: indexPort() })
+    ).resolves.toMatchObject({ status: 'deleted' });
+    expect(adapters.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Best-effort index removal failed for datalake:lake'),
+      expect.any(Error)
+    );
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -9,6 +9,9 @@ import {
 import { canAccessLake, assertLakeAccess, assertLakeWritable, isFallbackLake } from './assertLakeAccess';
 import { canManageLake, assertLakeWriteAccess, assertCanWriteDataLakeTags } from './authorizeLakeWrite';
 import { createDataLake } from './createDataLake';
+import { archiveDataLake } from './archiveDataLake';
+import { deleteDataLake } from './deleteDataLake';
+import type { RetrievalIndexRemoval } from './ports';
 import { unarchiveDataLake } from './unarchiveDataLake';
 import { restoreDeletedDataLake } from './restoreDeletedDataLake';
 import { cleanupDeletedDataLake } from './cleanupDeletedDataLake';
@@ -38,6 +41,23 @@ const lakeScope = {
   fileTagPrefix: 'lk:',
   creatorUserId: 'owner',
 };
+
+/**
+ * What findIdsByDataLakeTag resolves for the `lake()` fixture. The second is the member a
+ * meta-tag-keyed removal could never reach; that the Mongo predicate genuinely selects a
+ * prefix-only file is proved real-DB in FabFileModel.dataLakeLifecycle.test.ts, not here.
+ */
+const memberIds = ['meta-tagged-file', 'prefix-only-file'];
+
+const indexPort = (behavior: 'ok' | 'fails' = 'ok') => ({
+  removeForDataLake:
+    behavior === 'ok'
+      ? vi.fn().mockResolvedValue(undefined)
+      : vi.fn().mockRejectedValue(new Error('index unreachable')),
+});
+
+const removalInput = (port: ReturnType<typeof indexPort>): RetrievalIndexRemoval =>
+  port.removeForDataLake.mock.calls[0][0];
 
 const ctx = (overrides: Partial<AccessContext> = {}): AccessContext => ({
   userId: 'someone',
@@ -953,6 +973,118 @@ describe('restoreDeletedDataLake — deleted→active with dedup', () => {
   });
 });
 
+describe('archiveDataLake — retrieval-index removal', () => {
+  const makeAdapters = () => ({
+    db: {
+      dataLakes: {
+        findById: vi.fn().mockResolvedValue(lake()),
+        update: vi
+          .fn()
+          .mockImplementation(async ({ status }: { status: IDataLakeDocument['status'] }) => lake({ status })),
+        setStats: vi.fn().mockResolvedValue(undefined),
+        find: vi.fn().mockResolvedValue([]),
+      },
+      batches: {
+        findActiveByDataLakeId: vi.fn().mockResolvedValue([]),
+        markTerminalIfActive: vi.fn().mockResolvedValue(undefined),
+      },
+      fabFiles: {
+        archiveByDataLakeTag: vi.fn().mockResolvedValue(2),
+        computeDataLakeStats: vi.fn().mockResolvedValue({ fileCount: 0, totalSizeBytes: 0 }),
+        findIdsByDataLakeTag: vi.fn().mockResolvedValue(memberIds),
+      },
+    },
+    logger: { warn: vi.fn() },
+  });
+
+  it('hands the index the whole membership scope and every member id', async () => {
+    const adapters = makeAdapters();
+    const retrievalIndex = indexPort();
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', { ...adapters, retrievalIndex });
+
+    // The scope, not the meta-tag: stripped of fileTagPrefix and creatorUserId an implementer
+    // cannot reach the prefix-only member the sweep just archived.
+    expect(removalInput(retrievalIndex)).toEqual({ scope: lakeScope, fabFileIds: memberIds });
+    expect(removalInput(retrievalIndex).fabFileIds).toContain('prefix-only-file');
+  });
+
+  it('still settles the lake to archived when the index removal throws', async () => {
+    const adapters = makeAdapters();
+    await expect(
+      archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', {
+        ...adapters,
+        retrievalIndex: indexPort('fails'),
+      })
+    ).resolves.toMatchObject({ status: 'archived' });
+    expect(adapters.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Best-effort index removal failed for datalake:lake'),
+      expect.any(Error)
+    );
+  });
+
+  it('resolves no member ids when no index is wired', async () => {
+    const adapters = makeAdapters();
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+    expect(adapters.db.fabFiles.findIdsByDataLakeTag).not.toHaveBeenCalled();
+    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope);
+  });
+});
+
+describe('deleteDataLake — phase 1 retrieval-index removal', () => {
+  const makeAdapters = () => ({
+    db: {
+      dataLakes: {
+        findById: vi.fn().mockResolvedValue(lake()),
+        update: vi
+          .fn()
+          .mockImplementation(async ({ status }: { status: IDataLakeDocument['status'] }) => lake({ status })),
+        find: vi.fn().mockResolvedValue([]),
+      },
+      batches: {
+        findActiveByDataLakeId: vi.fn().mockResolvedValue([]),
+        markTerminalIfActive: vi.fn().mockResolvedValue(undefined),
+      },
+      fabFiles: {
+        // Empty is the re-run shape - a crashed prior attempt already flipped these files, so the
+        // flip reports nothing. Sourcing ids from it would send the index an empty set.
+        softDeleteByDataLakeTag: vi.fn().mockResolvedValue([]),
+        findIdsByDataLakeTag: vi.fn().mockResolvedValue(memberIds),
+      },
+    },
+    logger: { warn: vi.fn() },
+  });
+
+  it('hands the index every member id even when the soft-delete flipped nothing', async () => {
+    const adapters = makeAdapters();
+    const retrievalIndex = indexPort();
+    await deleteDataLake({ userId: 'owner', isAdmin: false }, 'lake1', { ...adapters, retrievalIndex });
+
+    expect(removalInput(retrievalIndex)).toEqual({ scope: lakeScope, fabFileIds: memberIds });
+    expect(removalInput(retrievalIndex).fabFileIds).toContain('prefix-only-file');
+  });
+
+  it('still settles the lake to deleted when the index removal throws', async () => {
+    const adapters = makeAdapters();
+    await expect(
+      deleteDataLake({ userId: 'owner', isAdmin: false }, 'lake1', {
+        ...adapters,
+        retrievalIndex: indexPort('fails'),
+      })
+    ).resolves.toMatchObject({ status: 'deleted' });
+    expect(adapters.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Best-effort index removal failed for datalake:lake'),
+      expect.any(Error)
+    );
+  });
+
+  it('resolves no member ids when no index is wired', async () => {
+    const adapters = makeAdapters();
+    await deleteDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+    expect(adapters.db.fabFiles.findIdsByDataLakeTag).not.toHaveBeenCalled();
+    expect(adapters.db.fabFiles.softDeleteByDataLakeTag).toHaveBeenCalledWith(lakeScope);
+  });
+});
+
 describe('cleanupDeletedDataLake — phase 2 sweep', () => {
   const makeAdapters = (status: IDataLakeDocument['status']) => ({
     db: {
@@ -991,6 +1123,41 @@ describe('cleanupDeletedDataLake — phase 2 sweep', () => {
     await expect(
       cleanupDeletedDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters)
     ).resolves.toBeUndefined();
+    expect(adapters.db.dataLakes.delete).not.toHaveBeenCalled();
+  });
+
+  it('hands the index the whole membership scope and every member id, before it destroys any of them', async () => {
+    const adapters = makeAdapters('deleted');
+    adapters.db.fabFiles.findIdsByDataLakeTag = vi.fn().mockResolvedValue(memberIds);
+    const retrievalIndex = indexPort();
+
+    await cleanupDeletedDataLake({ userId: 'owner', isAdmin: false }, 'lake1', { ...adapters, retrievalIndex });
+
+    expect(removalInput(retrievalIndex)).toEqual({ scope: lakeScope, fabFileIds: memberIds });
+    expect(removalInput(retrievalIndex).fabFileIds).toContain('prefix-only-file');
+
+    const indexRemove = retrievalIndex.removeForDataLake.mock.invocationCallOrder[0];
+    expect(indexRemove).toBeLessThan(
+      Math.min(...adapters.db.fabFileChunks.deleteManyByFabFileId.mock.invocationCallOrder)
+    );
+    expect(indexRemove).toBeLessThan(adapters.db.fabFiles.hardDeleteByDataLakeTag.mock.invocationCallOrder[0]);
+  });
+
+  it('aborts the purge with nothing destroyed when the index removal fails', async () => {
+    const adapters = makeAdapters('deleted');
+    await expect(
+      cleanupDeletedDataLake({ userId: 'owner', isAdmin: false }, 'lake1', {
+        ...adapters,
+        retrievalIndex: indexPort('fails'),
+      })
+    ).rejects.toThrow(/index unreachable/);
+
+    // Unlike the reversible doors this one propagates, because an entry pointing at a purged file
+    // can never be reconciled. The queue retry re-runs the whole sweep, so leaving it zero-progress
+    // is what makes propagating safe.
+    expect(adapters.db.fabFileChunks.deleteManyByFabFileId).not.toHaveBeenCalled();
+    expect(adapters.db.fabFiles.hardDeleteByDataLakeTag).not.toHaveBeenCalled();
+    expect(adapters.db.batches.delete).not.toHaveBeenCalled();
     expect(adapters.db.dataLakes.delete).not.toHaveBeenCalled();
   });
 

--- a/b4m-core/services/src/dataLakeService/deleteDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/deleteDataLake.ts
@@ -13,7 +13,7 @@ interface DeleteDataLakeAdapters {
   db: {
     dataLakes: Pick<IDataLakeRepository, 'findById' | 'update' | 'find'>;
     batches: Pick<IDataLakeBatchRepository, 'findActiveByDataLakeId' | 'markTerminalIfActive'>;
-    fabFiles: Pick<IFabFileRepository, 'softDeleteByDataLakeTag'>;
+    fabFiles: Pick<IFabFileRepository, 'softDeleteByDataLakeTag' | 'findIdsByDataLakeTag'>;
   };
   retrievalIndex?: RetrievalIndexPort;
   logger?: { warn: (msg: string, ...args: unknown[]) => void };
@@ -51,8 +51,12 @@ export const deleteDataLake = async (
   await db.dataLakes.update({ id: dataLakeId, status: 'deleting' });
 
   await warnOnPrefixCollision(db, existing, logger);
-  await db.fabFiles.softDeleteByDataLakeTag(lakeMembershipScope(existing));
-  await bestEffortIndexRemove(retrievalIndex, existing.datalakeTag, logger);
+  const scope = lakeMembershipScope(existing);
+  await db.fabFiles.softDeleteByDataLakeTag(scope);
+  // Not softDeleteByDataLakeTag's return: it reports only the files this call flipped, so a re-run
+  // after a crashed attempt would hand the index an empty set. findIdsByDataLakeTag sees
+  // soft-deleted members too and stays stable across re-runs.
+  await bestEffortIndexRemove(retrievalIndex, scope, () => db.fabFiles.findIdsByDataLakeTag(scope), logger);
 
   const updated = await db.dataLakes.update({ id: dataLakeId, status: 'deleted' });
   if (!updated) {

--- a/b4m-core/services/src/dataLakeService/ports.ts
+++ b/b4m-core/services/src/dataLakeService/ports.ts
@@ -1,6 +1,12 @@
 import type { DataLakeMembershipScope } from '@bike4mind/common';
 
-/** What a lifecycle sweep hands the index: the scope it ran on, and the member ids it resolved. */
+/**
+ * What a lifecycle sweep hands the index: the lake it ran on, and the member ids it resolved.
+ *
+ * `fabFileIds` is the removal set and the whole of it. `scope` says WHICH LAKE the sweep was for -
+ * useful to an implementer that partitions by lake - and must never be used to narrow, widen or
+ * second-guess the ids.
+ */
 export interface RetrievalIndexRemoval {
   scope: DataLakeMembershipScope;
   fabFileIds: string[];
@@ -16,10 +22,19 @@ export interface RetrievalIndexRemoval {
  * whole set - so a tag-keyed removal would strand a prefix-only member's entry pointing at a file
  * the phase-2 purge just hard-deleted. `fabFileIds` is passed rather than derived so an
  * implementer never has to rebuild that predicate against index metadata that may not carry the
- * owner or the tag array; the ids are exactly what the accompanying sweep resolved.
+ * owner or the tag array.
  *
- * Removal only - re-populating on unarchive/restore is the implementer's job, and the lifecycle
- * services do not call back in.
+ * DROP THE DOCUMENTS OUTRIGHT, not just from a per-lake view. Every caller is hiding or destroying
+ * the files themselves, so a file left retrievable anywhere is the failure this port exists to
+ * prevent. That is also why the ids can be a superset of what one transition flipped: archive and
+ * phase-1 delete each skip files already in the target state, but the removal covers every member
+ * the scope matches, so a re-run after a crash still converges.
+ *
+ * Wire it at all three doors or not at all - archiveDataLake, deleteDataLake, cleanupDeletedDataLake
+ * each take it separately, and a door left unwired silently keeps the old behavior.
+ *
+ * Removal only: there is no add operation, so an implementer must re-populate through its own
+ * ingest path after unarchive or restore. Those doors do not call back in.
  */
 export interface RetrievalIndexPort {
   removeForDataLake(input: RetrievalIndexRemoval): Promise<void>;

--- a/b4m-core/services/src/dataLakeService/ports.ts
+++ b/b4m-core/services/src/dataLakeService/ports.ts
@@ -66,6 +66,13 @@ export async function bestEffortIndexRemove(
  * to be hard-deleted, so no later run can reconcile it. Call it BEFORE anything destructive, so a
  * throw leaves zero progress and the cleanup queue's retry re-runs the sweep intact. The cost is
  * that a persistently failing index wedges the lake in 'deleted', which beats half-purged.
+ *
+ * "Zero progress" covers the THROW only, and is not an absolute. If removal succeeds and a later
+ * step then fails terminally, the lake stays 'deleted' and restorable - but restoreDeletedDataLake
+ * brings the files back with their entries already dropped, and this port has no add operation to
+ * put them back. That much is progress no retry undoes; re-population is the implementer's job.
+ *
+ * This is the canonical description of both postures. Call sites point here rather than restating.
  */
 export async function strictIndexRemove(
   retrievalIndex: RetrievalIndexPort | undefined,

--- a/b4m-core/services/src/dataLakeService/ports.ts
+++ b/b4m-core/services/src/dataLakeService/ports.ts
@@ -1,29 +1,61 @@
-/**
- * Best-effort retrieval/search index port. Removing a lake's documents on
- * archive/delete is best-effort - a failure is logged, not fatal - so a transiently
- * stale index entry is tolerated rather than blocking the lifecycle transition.
- * Optional: products without a separate index (vectors live in the chunk store) can
- * omit it entirely.
- *
- * Known gap: the key is the meta-tag alone, while the file sweep matches prefix-tagged members
- * too, so a purge can delete a member whose index entry this call does not reach. Latent rather
- * than live - nothing in this repo implements the port, so bestEffortIndexRemove no-ops - but an
- * implementer needs a membership-aware removal, not just a tag.
- */
-export interface RetrievalIndexPort {
-  removeByDataLakeTag(datalakeTag: string): Promise<void>;
+import type { DataLakeMembershipScope } from '@bike4mind/common';
+
+/** What a lifecycle sweep hands the index: the scope it ran on, and the member ids it resolved. */
+export interface RetrievalIndexRemoval {
+  scope: DataLakeMembershipScope;
+  fabFileIds: string[];
 }
 
-/** Wrap a best-effort index removal so a failure never blocks the lifecycle op. */
+/**
+ * Optional retrieval/search index port. Products whose vectors live in the chunk store have no
+ * separate index and omit it; `undefined` is the only case in this repo today.
+ *
+ * Keyed on lake MEMBERSHIP, never on the meta-tag alone. A file belongs to a lake on the exact
+ * `datalake:` tag OR on a `fileTagPrefix` match against a file the lake's creator owns (see
+ * buildDataLakeMembershipFilter in @bike4mind/database), and the lifecycle sweeps act on that
+ * whole set - so a tag-keyed removal would strand a prefix-only member's entry pointing at a file
+ * the phase-2 purge just hard-deleted. `fabFileIds` is passed rather than derived so an
+ * implementer never has to rebuild that predicate against index metadata that may not carry the
+ * owner or the tag array; the ids are exactly what the accompanying sweep resolved.
+ *
+ * Removal only - re-populating on unarchive/restore is the implementer's job, and the lifecycle
+ * services do not call back in.
+ */
+export interface RetrievalIndexPort {
+  removeForDataLake(input: RetrievalIndexRemoval): Promise<void>;
+}
+
+/**
+ * Archive and phase-1 delete: a failure is logged, not fatal. Both are reversible, so a stale
+ * entry is tolerated rather than blocking the transition.
+ *
+ * Ids resolve lazily and inside the try, so a door with no index wired pays no query, and a
+ * lookup failure cannot abort an op that is contractually best-effort.
+ */
 export async function bestEffortIndexRemove(
   retrievalIndex: RetrievalIndexPort | undefined,
-  datalakeTag: string,
+  scope: DataLakeMembershipScope,
+  resolveFabFileIds: () => Promise<string[]>,
   logger?: { warn: (msg: string, ...args: unknown[]) => void }
 ): Promise<void> {
   if (!retrievalIndex) return;
   try {
-    await retrievalIndex.removeByDataLakeTag(datalakeTag);
+    await retrievalIndex.removeForDataLake({ scope, fabFileIds: await resolveFabFileIds() });
   } catch (error) {
-    logger?.warn(`Best-effort index removal failed for ${datalakeTag}:`, error);
+    logger?.warn(`Best-effort index removal failed for ${scope.datalakeTag}:`, error);
   }
+}
+
+/**
+ * Phase-2 purge: propagates. An entry stranded here is permanent - the file it points at is about
+ * to be hard-deleted, so no later run can reconcile it. Call it BEFORE anything destructive, so a
+ * throw leaves zero progress and the cleanup queue's retry re-runs the sweep intact. The cost is
+ * that a persistently failing index wedges the lake in 'deleted', which beats half-purged.
+ */
+export async function strictIndexRemove(
+  retrievalIndex: RetrievalIndexPort | undefined,
+  input: RetrievalIndexRemoval
+): Promise<void> {
+  if (!retrievalIndex) return;
+  await retrievalIndex.removeForDataLake(input);
 }

--- a/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
@@ -67,7 +67,7 @@ interface RemoveFileFromDataLakeAdapters {
  * file is leaving the lake, not being deleted, so dropping its index entry would over-remove and
  * strip it from its OWNER's retrieval everywhere else. That is why the lifecycle doors call the
  * port and this one does not - they destroy or hide the file, this one only unpicks membership.
- * Removal is enforced by Mongo tag state, so it takes effect on the next
+ * That membership removal is enforced by Mongo tag state, so it takes effect on the next
  * read - immediately and completely for the single-lake browse, today the only reader that sets
  * restrictToDataLake. Every other lake reader (the aggregate lake browse, lake semantic search,
  * the chat KB tools) still matches the prefix within the VIEWER's access, so the file's OWNER

--- a/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
@@ -63,9 +63,11 @@ interface RemoveFileFromDataLakeAdapters {
  * `removeFileFromLake` in lakeMembership.ts, shared with the tag-toggle door so both doors clear
  * the same signals.
  *
- * No per-file retrieval-index call: RetrievalIndexPort exposes only removeByDataLakeTag,
- * which would de-index the ENTIRE lake, and it has no implementer here (bestEffortIndexRemove
- * no-ops without one). Removal is enforced by Mongo tag state, so it takes effect on the next
+ * No retrieval-index call, though RetrievalIndexPort could now express a per-file removal: the
+ * file is leaving the lake, not being deleted, so dropping its index entry would over-remove and
+ * strip it from its OWNER's retrieval everywhere else. That is why the lifecycle doors call the
+ * port and this one does not - they destroy or hide the file, this one only unpicks membership.
+ * Removal is enforced by Mongo tag state, so it takes effect on the next
  * read - immediately and completely for the single-lake browse, today the only reader that sets
  * restrictToDataLake. Every other lake reader (the aggregate lake browse, lake semantic search,
  * the chat KB tools) still matches the prefix within the VIEWER's access, so the file's OWNER

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -256,6 +256,33 @@ describe('FabFile data lake lifecycle membership', () => {
     });
   });
 
+  describe('hardDeleteByIds', () => {
+    it('destroys exactly the ids given, soft-deleted included, and nothing a re-resolve would add', async () => {
+      const rows = await seedLakeRows();
+      await FabFile.updateOne({ _id: rows.prefixOwned._id }, { $set: { deletedAt: new Date() } });
+      // Stands in for a file tagged into the lake after the sweep resolved its ids: a member by
+      // the predicate, absent from the snapshot, and so not this run's to destroy.
+      const joinedMidSweep = await makeFile({ fileName: 'late.txt', userId: CREATOR, tags: [{ name: 'acme:late' }] });
+
+      const purged = await fabFileRepository.hardDeleteByIds(rows.memberIds);
+
+      expect(purged.sort()).toEqual([...rows.memberIds].sort());
+      for (const id of rows.memberIds) expect(await readRaw(id)).toBeNull();
+      expect(await readRaw(joinedMidSweep._id.toString())).not.toBeNull();
+      // Whereas the predicate-resolving door would have taken it.
+      expect(await fabFileRepository.findIdsByDataLakeTag(scope)).toContain(joinedMidSweep._id.toString());
+    });
+
+    it('is a no-op on an empty set and on already-purged ids', async () => {
+      const rows = await seedLakeRows();
+      expect(await fabFileRepository.hardDeleteByIds([])).toEqual([]);
+      await fabFileRepository.hardDeleteByIds(rows.memberIds);
+
+      expect(await fabFileRepository.hardDeleteByIds(rows.memberIds)).toEqual(rows.memberIds);
+      for (const id of rows.strangerIds) expect(await readRaw(id)).not.toBeNull();
+    });
+  });
+
   describe('fail-closed scopes', () => {
     it('touches only the meta-tagged file when the lake has no usable prefix', async () => {
       const rows = await seedLakeRows();

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -792,16 +792,19 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     return ids;
   }
 
+  async hardDeleteByIds(fabFileIds: string[]): Promise<string[]> {
+    if (fabFileIds.length === 0) return [];
+    // hardDelete bypasses the soft-delete plugin's deleteMany override (phase-2 purge).
+    await this.fabFileModel.deleteMany({ _id: { $in: fabFileIds } }, { hardDelete: true } as Record<string, unknown>);
+    return fabFileIds;
+  }
+
   async hardDeleteByDataLakeTag(scope: DataLakeMembershipScope): Promise<string[]> {
     // Include soft-deleted files: the phase-2 sweep must purge every member.
     const docs = await this.fabFileModel
       .find(buildDataLakeMembershipFilter(scope), { _id: 1 })
       .setOptions({ includeDeleted: true });
-    const ids = docs.map(d => d._id.toString());
-    if (ids.length === 0) return [];
-    // hardDelete bypasses the soft-delete plugin's deleteMany override (phase-2 purge).
-    await this.fabFileModel.deleteMany({ _id: { $in: ids } }, { hardDelete: true } as Record<string, unknown>);
-    return ids;
+    return this.hardDeleteByIds(docs.map(d => d._id.toString()));
   }
 
   async findIdsByDataLakeTag(scope: DataLakeMembershipScope): Promise<string[]> {


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
[datalake-purge-removes-both-member-types.webm](https://github.com/user-attachments/assets/b3c94924-ca75-4464-a1d5-8cd72f6fcc2d)

*Purging a data lake on the PR preview removes both kinds of member: the file carrying the `datalake:` meta-tag AND the same-owner prefix-only file that has no meta-tag. The lake reads 2 files and both filenames return from a Files-browser search beforehand; after the purge completes the same search returns nothing. Archive, delete and purge are all driven through the real UI controls.*


## Description

Closes #1135.

#1130 widened data-lake membership: a file belongs to a lake on the exact `datalake:` meta-tag OR on a `fileTagPrefix` match against a file the lake's creator owns. Archive, soft-delete, purge and stats all moved onto that one predicate. `RetrievalIndexPort` did not - it took the meta-tag alone, so a purge could hard-delete a prefix-only member while the index entry pointing at it survived. The constraint lived in a comment an implementer had to read and honor.

It is now the type. `removeForDataLake` takes the membership scope plus the ids the sweep resolved, so keying on the tag alone is not expressible. Nothing in or out of this repo implements the port, so runtime behavior is unchanged and the blast radius is the interface.

## Changes

- `ports.ts`: `removeForDataLake({ scope, fabFileIds })` replaces `removeByDataLakeTag(tag)`, and states what an implementer must do - drop the documents outright, and wire all three doors or none.
- Posture split by door: `bestEffortIndexRemove` swallows and warns for the reversible archive and phase-1 delete; `strictIndexRemove` propagates for the purge, where an entry outliving its file can never be reconciled. The purge runs it before any destruction, so a throw costs no progress.
- All three doors resolve ids through `findIdsByDataLakeTag`, the only source stable across a re-run: `archiveByDataLakeTag` returns a count, and `softDeleteByDataLakeTag` returns `[]` the second time.
- New `hardDeleteByIds` on `IFabFileRepository`: the purge destroys the set it announced instead of re-running the predicate, which would have taken a file tagged into the lake mid-sweep, chunks orphaned and index unasked.
- `removeFileFromDataLake` justified having no index call on the port being whole-lake-only. That reason is gone; the surviving one is that the file is leaving the lake, not being deleted.
- Tests: archive and phase-1 delete had no service coverage at all, a prefix-only member is now asserted at all three doors, and `hardDeleteByIds` gets real-Mongo coverage. `dataLakePurgeIndexScope.e2e.test.ts` drives the real purge against real Mongo and checks the set the index was told about against the set Mongo actually lost, including a file tagged into the lake mid-sweep.

## Guide for Testers

Test on the preview: `app.pr1380.preview.bike4mind.com`. Staging will not do - it runs `main`, and the change under test is on this branch.

**What to hunt for.** This PR changes what a permanent purge destroys: it now deletes exactly the member ids it resolved up front, instead of re-running the membership query at delete time. The bug to look for is a purge that leaves member files behind - above all a **prefix-only** member, a file carrying the lake's `fileTagPrefix` but no `datalake:` tag. That is the row this whole ticket is about.

Setup (steps 1-3) builds a lake with one of each kind of member plus one file that must survive.

1. Sign in to the preview and open the Data Lakes manager. Create a lake named `Purge Check` with a file tag prefix nobody else has claimed - use your initials, e.g. `pcjd:`. Expected: it appears in the active lakes list. If create is rejected for an overlapping prefix, that is the create-time collision guard doing its job; pick another prefix. Use your chosen prefix everywhere `acme:` appears below.
2. Upload two files to that lake through the lake's add-files control (`datalake-addfiles-btn-<lakeId>`). Expected: the lake's file count reads 2. One of these carries the lake's `datalake:` membership tag automatically.
3. Upload a third file OUTSIDE any lake, then tag it `acme:report` from the Files browser. Expected: the file shows an `acme:report` chip. This is the prefix-only member - it has the prefix but no `datalake:` tag, and it should now count toward the lake. Confirm the lake's file count went up.
4. Archive the lake (`datalake-archive-btn-<lakeId>`). Expected: the lake leaves the active list and its files stop appearing in the lake browse - **including the file from step 3**. If that one stays visible, stop and report it.
5. Expand the archived list (these lifecycle lists start collapsed) and click restore (`datalake-restore-btn-<lakeId>`). Expected: the lake and all three files come back.
6. Archive it again, then click "Delete (recoverable)" (`datalake-delete-btn-<lakeId>`). Expected: the lake moves to the deleted list and its files disappear from the Files browser.
7. Expand the deleted list, click the purge icon (`datalake-purge-btn-<lakeId>`), and confirm "Purge permanently" in the "Permanently purge data lake?" dialog (`datalake-purge-confirm-btn`). Expected: no error toast. **The purge is asynchronous** - the toast only acknowledges that the sweep was queued, and the actual delete runs as a background job. Give it a few seconds and reload before judging anything below; the lake still being listed the instant you confirm is not a failure.
8. **The main check.** Once the sweep has run, search the Files browser for the step-3 file by name, and for `acme:report` in tags. Expected: it is gone, and the lake is absent from the active and deleted lists. A surviving file here is the failure this PR is meant to prevent - report it with the file name and the lake's prefix.

### Regression Checks

Steps 4 through 7 are the regression pass: archive, restore, phase-1 delete and phase-2 purge are the four doors this PR edited, and none of their user-visible behavior should have changed. Step 8 is the new behavior worth attacking.

One more, if you have time: while a purge is running on a large lake, tag another of your files with the lake's prefix. Expected: that file survives the purge rather than vanishing. It is deliberately not swept up, because the purge only destroys what it accounted for at the start.

### What NOT to test

- Any change in retrieval or search results. `RetrievalIndexPort` has no implementer in this product, so the index call is still a no-op at runtime and nothing about search can change. The contract change is covered by CI (`dataLakePurgeIndexScope.e2e.test.ts` and the data-lake service suite), not by clicking.
- `app.staging.bike4mind.com`. It runs `main`, so it cannot show this branch's behavior.

## Additional Information

Breaking to `@bike4mind/services`: `removeByDataLakeTag` is gone. No implementer exists anywhere, so there is nothing to migrate - the point is that the next one cannot get it wrong.

## Developer Notes (Optional)

- `hardDeleteByIds` on `IFabFileRepository` is the primitive for resolve-once-then-act destruction; `hardDeleteByDataLakeTag` now delegates to it and is documented as unsafe for a caller that has already acted on a resolved id set.
- The lazy-thunk shape of `bestEffortIndexRemove` keeps an optional port from costing a query at doors where it is unwired.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

