### PR TITLE
chore(entitlements): retire optihashi:compute and optihashi:hardware tag grants (#1237)

### DIFF
--- a/apps/client/app/components/admin/Users/ProductAccess.test.tsx
+++ b/apps/client/app/components/admin/Users/ProductAccess.test.tsx
@@ -55,25 +55,25 @@ describe('ProductAccess', () => {
 
   it('shows Grant + None when the live user lacks the grant tag', () => {
     mockProductAccess.mockReturnValue({
-      data: { entitlements: [{ key: 'optihashi:compute', held: false, grantTag: 'opti-compute', sources: [] }] },
+      data: { entitlements: [{ key: 'optihashi:pro', held: false, grantTag: 'opti', sources: [] }] },
       isLoading: false,
       error: null,
     });
     render(<ProductAccess user={makeUser([])} onFieldChange={vi.fn()} />, { wrapper: TestWrapper });
     expect(screen.getByText('None')).toBeInTheDocument();
-    expect(screen.getByTestId('product-access-toggle-optihashi:compute')).toHaveTextContent('Grant (opti-compute)');
+    expect(screen.getByTestId('product-access-toggle-optihashi:pro')).toHaveTextContent('Grant (opti)');
   });
 
   it('staging a Grant calls onFieldChange with the tag appended (single batched-save source of truth)', () => {
     const onFieldChange = vi.fn();
     mockProductAccess.mockReturnValue({
-      data: { entitlements: [{ key: 'optihashi:compute', held: false, grantTag: 'opti-compute', sources: [] }] },
+      data: { entitlements: [{ key: 'optihashi:pro', held: false, grantTag: 'opti', sources: [] }] },
       isLoading: false,
       error: null,
     });
     render(<ProductAccess user={makeUser(['existing-tag'])} onFieldChange={onFieldChange} />, { wrapper: TestWrapper });
-    fireEvent.click(screen.getByTestId('product-access-toggle-optihashi:compute'));
-    expect(onFieldChange).toHaveBeenCalledWith('tags', ['existing-tag', 'opti-compute']);
+    fireEvent.click(screen.getByTestId('product-access-toggle-optihashi:pro'));
+    expect(onFieldChange).toHaveBeenCalledWith('tags', ['existing-tag', 'opti']);
   });
 
   it('staging a Revoke removes the tag case-insensitively', () => {

--- a/apps/client/app/components/admin/Users/UserPermissions.test.tsx
+++ b/apps/client/app/components/admin/Users/UserPermissions.test.tsx
@@ -120,10 +120,10 @@ describe('UserPermissions - Role', () => {
 });
 
 describe('UserPermissions - Custom Tags', () => {
-  it('does not show a product-access comp tag (e.g. opti) in the Custom Tags list - it has its own control in Product Access', () => {
+  it('does not show a SURVIVING product-access comp tag (opti) in the Custom Tags list - it has its own control in Product Access', () => {
     render(
       <UserPermissions
-        user={baseUser({ tags: ['opti', 'opti-compute'] })}
+        user={baseUser({ tags: ['opti'] })}
         editedFields={{}}
         onFieldChange={noop}
         handleUserLevelButtonChange={noop}
@@ -131,7 +131,24 @@ describe('UserPermissions - Custom Tags', () => {
       { wrapper: TestWrapper }
     );
     expect(screen.queryByText('opti')).not.toBeInTheDocument();
-    expect(screen.queryByText('opti-compute')).not.toBeInTheDocument();
+  });
+
+  it('shows a RETIRED tier tag (opti-compute) as a removable custom-tag chip', () => {
+    // #1237 retired optihashi:compute, so `opti-compute` no longer maps to an entitlement and is no
+    // longer a managed tag. It renders as a removable chip like any freeform tag - the deliberate,
+    // documented consequence of the retirement: the tag is an inert leftover, and surfacing it is
+    // how an operator strips it. (See the note in lib/entitlements/registry.ts.)
+    render(
+      <UserPermissions
+        user={baseUser({ tags: ['opti-compute'] })}
+        editedFields={{}}
+        onFieldChange={noop}
+        handleUserLevelButtonChange={noop}
+      />,
+      { wrapper: TestWrapper }
+    );
+    expect(screen.getByText('opti-compute')).toBeInTheDocument();
+    expect(screen.getByTestId('remove-tag-opti-compute')).toBeInTheDocument();
   });
 
   it('does not show the Developer tag in the Custom Tags list - it is represented by the Role radio', () => {

--- a/apps/client/app/components/admin/Users/UserPermissions.tsx
+++ b/apps/client/app/components/admin/Users/UserPermissions.tsx
@@ -5,10 +5,11 @@ import { Button, FormHelperText, FormLabel, Input, Radio, RadioGroup, Stack, Too
 import React, { useState } from 'react';
 
 /**
- * Comp tags that grant a product entitlement (e.g. `opti`, `opti-compute`) -
- * these have their own dedicated grant/revoke control in the Product Access
- * section, so the freeform "Custom Tags" list below hides them to avoid two
- * controls editing the same tag.
+ * Comp tags that grant a product entitlement (e.g. `opti`) - these have their
+ * own dedicated grant/revoke control in the Product Access section, so the
+ * freeform "Custom Tags" list below hides them to avoid two controls editing
+ * the same tag. Derived from the live registry, so a RETIRED tag (e.g. the
+ * former `opti-compute`, #1237) is intentionally no longer hidden here.
  */
 const PRODUCT_GRANT_TAGS = allKnownEntitlementKeys()
   .map(grantTagForEntitlement)

--- a/apps/client/lib/entitlements/registry.test.ts
+++ b/apps/client/lib/entitlements/registry.test.ts
@@ -132,18 +132,6 @@ describe('entitlementsForTags', () => {
   it('ignores empty/whitespace tags', () => {
     expect(entitlementsForTags(['', '   '])).toEqual(new Set());
   });
-
-  it('grants optihashi:hardware ONLY via opti-hardware, never via a cheaper tier', () => {
-    // Pins the exact grant path an operator uses to authorize a partner account for
-    // external-provider hardware spend: tagging `opti-hardware` must confer `optihashi:hardware`,
-    // the key the overlay's hardware submit gate reads. A rename/removal here silently locks
-    // everyone (incl. non-admins) out of hardware compute, so lock it by name.
-    expect(entitlementsForTags(['opti-hardware']).has('optihashi:hardware')).toBe(true);
-    // The invariant that actually matters: cheaper tiers must NOT confer real-money hardware.
-    // Fails loudly if someone later widens a cheaper row into hardware.
-    expect(entitlementsForTags(['opti-compute']).has('optihashi:hardware')).toBe(false);
-    expect(entitlementsForTags(['opti']).has('optihashi:hardware')).toBe(false);
-  });
 });
 
 describe('entitlementsForPriceIds', () => {

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -140,6 +140,12 @@ const TAG_GRANT_ROWS: TagGrantRow[] = [
   // capability map, #1178), so `optihashi:pro` is the single product-level grant
   // and group membership decides what you reach within it. The tag rows were
   // already inert in open core (no gate here ever read the keys).
+  // INTENDED CONSEQUENCE (deliberate, not a regression): removing the rows also
+  // drops `opti-compute` / `opti-hardware` from `allKnownEntitlementKeys()`, so
+  // `UserPermissions.tsx` no longer classifies them as managed - a leftover
+  // `opti-compute` tag now renders as a removable custom-tag chip in the admin
+  // Users panel (with no Product Access control, because the tier is retired).
+  // That is how an operator strips the inert leftover; see UserPermissions.test.tsx.
   // [DELETION-FOOTPRINT] Overwatch comp grant: the `overwatch` tag bridges to
   // `overwatch:pro`. Admin-only gate was a stopgap before the entitlement model
   // existed (Open Core M0). No Stripe price yet; granted-only initially. Removed

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -134,25 +134,12 @@ const TAG_GRANT_ROWS: TagGrantRow[] = [
   // The `opti` tag confers local OptiHashi access via `optihashi:pro` (solver
   // race, problem/run CRUD, UI/routing).
   { tag: 'opti', entitlements: ['optihashi:pro'] },
-  // Remote compute is a SEPARATE, stricter tier from local OptiHashi: the
-  // `opti-compute` tag bridges to `optihashi:compute`. Holding `optihashi:pro`
-  // alone will NOT confer remote compute once the server gate checks
-  // `optihashi:compute` (see M2) - until then this row is inert (no gate reads
-  // the key yet). Granted-only for now (no Stripe price yet); deliberately absent
-  // from DOMAIN_GRANT_ROWS / INTERNAL_STAFF_ENTITLEMENTS / SIGNUP_CREDIT_ROWS -
-  // internal users reach it via admin/developer bypass, and no signup credits
-  // attach to the compute tier.
-  { tag: 'opti-compute', entitlements: ['optihashi:compute'] },
-  // Real hardware compute is the STRICTEST tier: the `opti-hardware` tag bridges to
-  // `optihashi:hardware`. Like `opti-compute` above, no gate in THIS repo reads the key yet -
-  // the hardware submit gate lives in the premium overlay - so this row is inert host-side
-  // until that overlay is composed in; it exists so the key is grantable/known here.
-  // Deliberately its own tier, NOT implied by `optihashi:compute` (classical/simulator) or
-  // `optihashi:pro` (local): a compute-tier user must not silently reach real external-provider
-  // (real-money) spend. Granted-only (no Stripe price yet) and intentionally absent from
-  // DOMAIN_GRANT_ROWS / INTERNAL_STAFF_ENTITLEMENTS / SIGNUP_CREDIT_ROWS - admins reach it via
-  // bypass, and it is granted per-account rather than by domain/signup.
-  { tag: 'opti-hardware', entitlements: ['optihashi:hardware'] },
+  // The `optihashi:compute` / `optihashi:hardware` execution tiers used to be
+  // granted here via the `opti-compute` / `opti-hardware` tags. Retired (#1237):
+  // those tiers now resolve from org group membership (the overlay's group->
+  // capability map, #1178), so `optihashi:pro` is the single product-level grant
+  // and group membership decides what you reach within it. The tag rows were
+  // already inert in open core (no gate here ever read the keys).
   // [DELETION-FOOTPRINT] Overwatch comp grant: the `overwatch` tag bridges to
   // `overwatch:pro`. Admin-only gate was a stopgap before the entitlement model
   // existed (Open Core M0). No Stripe price yet; granted-only initially. Removed


### PR DESCRIPTION
> 🚧 **HELD AS DRAFT - do not merge yet (2026-08-04).** This is the deploy-coupled *final* step of the #1172 entitlement->capability migration. The moment it lands on `main`, the next production deploy removes the legacy `optihashi:compute` / `optihashi:hardware` grant path - and that must not reach production until the affected org's members have been assigned to their groups (the group instances exist but are currently **empty**) and the corresponding partner-signup rules have been switched to `optihashi:pro`. Otherwise every non-owner member loses access in the gap.
>
> **Unblock order:** (1) capability code deployed to prod -> (2) assign the org's members to their groups -> (3) switch the partner-signup rules to `optihashi:pro` -> (4) mark this PR ready + merge. Parked deliberately so it can't ride an unrelated prod deploy early. This is not blocked on review (already approved) - only on that sequence.

---

## Description

Retires the two OptiHashi execution-tier entitlement keys, `optihashi:compute` and `optihashi:hardware`, from the open-core entitlement registry. Both were already **inert in this repo** — no gate here has ever read either key (the registry rows only bridged a tag to a key that nothing checks host-side).

With the overlay's access decisions now resolved from **org group membership** (#1178) rather than user tags, these keys became a redundant, parallel grant axis. Collapse to a single product-level entitlement: **`optihashi:pro` grants the product, and group membership determines what is reachable within it.** A pleasant side effect — with one entitlement, `optihashi:pro` is now the complete product-level kill switch.

This is the last item in the #1172 deploy sequence and is intentionally sequenced **after** the capability layer (#1234), the map injection (#1357), and the overlay gate migration land — so there is always a grant mechanism in place.

## Changes

- `apps/client/lib/entitlements/registry.ts` — remove the `opti-compute` and `opti-hardware` `TAG_GRANT_ROWS`; replace their block comments with a short retirement note. `optihashi:pro` (the `opti` tag) is unchanged.
- `apps/client/lib/entitlements/registry.test.ts` — remove the tier-ordering test that pinned `optihashi:hardware` to the `opti-hardware` tag (the invariant it protected no longer exists once the keys are gone). The dynamic `TAG_GRANTS` passthrough test still covers every remaining row.

## Guide for Testers

Backend/registry-only change. No UI, no endpoint, no runtime behaviour change on its own.

1. From the repo root: `pnpm --filter @bike4mind/client exec vitest run lib/entitlements/registry.test.ts`
2. Expected: **45 passed** (the removed tier test is gone; all remaining registry cases pass).
3. Type check: `pnpm --filter @bike4mind/client typecheck:fast` -> no errors.
4. Confirm no host-repo reference remains: `grep -rn "opti-compute\|opti-hardware\|optihashi:compute\|optihashi:hardware" apps b4m-core packages --include='*.ts'` returns only (a) the retirement comment in `registry.ts` and (b) an unrelated services test fixture (see Regression Checks).

### Regression Checks

- The `optihashi:pro` grant via the `opti` tag must still resolve — unchanged.
- `entitlementsForTags(['opti-compute'])` / `(['opti-hardware'])` now return only the 1:1 tag passthrough (no `optihashi:*` key), which is the point.
- The remaining `applies every TAG_GRANTS remap row case-insensitively` test iterates the row list dynamically, so it simply covers fewer rows — no edit needed.

### What NOT to test

- No access change is observable from this repo. The actual grant path (group membership -> capability) lives in the overlay (#1178) and is already merged; nothing here gates a live surface.
- The `optihashi:compute` string in `b4m-core/.../resolveGroupTypesForUser.test.ts` is an arbitrary "retired group type" fixture, **not** the entitlement key — deliberately left untouched.

## Developer Notes

- After this, the entitlement registry no longer expresses an OptiHashi execution ladder at all — the ladder is expressed entirely by group-type -> capability resolution in the overlay. Grant authority for the higher tiers now sits with the org's own admins (the intended self-service); the bounding controls (`maxCreditsPerMember`, `currentCredits`, seats) remain `isAdmin`-gated and are not org-writable.

Part of #1172. Closes #1237.

