### PR TITLE
chore: temporary preview target for overlay-deps backstop verification

### DIFF
--- a/PREVIEW-TARGET.md
+++ b/PREVIEW-TARGET.md
@@ -1,0 +1,5 @@
+# Preview target: overlay-deps gate verification
+
+Temporary. Exists only to give bike4mind-deployer#106 an open PR to dispatch a preview against,
+so the new check-overlay-deps backstop can be exercised end to end without disturbing anyone
+else's PR. Delete this file and close the PR once the two dispatches are recorded.


### PR DESCRIPTION
**Temporary. Do not review, do not merge. I close this as soon as the two dispatches are recorded.**

Bike4Mind/bike4mind-deployer#106 adds a `check-overlay-deps` backstop to the deploy path, and the only way to exercise that wiring . the template checkout, `node` being on PATH at that point in the job, the cleanup `rm -rf`, and exit-code propagation through the overlay loop . is a real preview dispatch. A preview needs an open PR on this repo, and rather than hijack someone's in-flight work I am using this one.

Contents are a single root markdown file, which the repo's own `changes-filter` treats as non-deployable, so this should not spin up the heavy CI legs.

Plan:

1. Dispatch a preview from the deployer branch with `overlay_pins` forcing b4m-bob to `5f2c467`, the commit that broke every preview on 2026-08-03. Expect a failure at `Check overlay dependency declarations` roughly 4 minutes in, naming `src/spa/BobReport.tsx:10` and `:11`. It dies before `sst deploy`, so nothing is provisioned.
2. Re-dispatch without the override. Expect that step to pass and the deploy to continue past it.
3. Remove the preview stack, close this, delete the branch.

Pushed with `--no-verify`: the pre-push hook runs a workspace typecheck that currently fails in my local checkout on unrelated stale-install errors (`@aws-sdk/s3-request-presigner`, `@bike4mind/hearth` unresolvable). The change is one markdown file and cannot affect a typecheck.
