### PR TITLE
test(e2e): decouple ai-latency suite from credit enforcement

### DIFF
--- a/apps/client/e2e/helpers/api.ts
+++ b/apps/client/e2e/helpers/api.ts
@@ -96,6 +96,9 @@ export async function apiCreateTestUser(
     // /accept-policies interstitial). Suppresses both the server-side stamp and the auto-accept
     // fallback below. Defaults to consented so ordinary setup isn't 403'd by the gate.
     acceptedPolicies?: boolean;
+    // Starting credit balance. Omit for the default effectively-unlimited grant; pass a small
+    // value to mint a low-balance user for the credit-gate spec.
+    initialCredits?: number;
   }
 ): Promise<LoginResponse> {
   const baseURL = process.env.API_URL || 'http://localhost:3000';

--- a/apps/client/pages/api/test/create-user.ts
+++ b/apps/client/pages/api/test/create-user.ts
@@ -20,7 +20,15 @@ interface CreateTestUserBody {
   // /accept-policies interstitial. Defaults to true - test users start fully onboarded like
   // `emailVerified`. Pass false to mint an un-consented user for testing the gate itself.
   acceptedPolicies?: boolean;
+  // Starting credit balance. Defaults to a deliberately enormous grant so latency/tool suites
+  // never run dry mid-run. Pass a small value to mint a low-balance user for the credit-gate spec.
+  initialCredits?: number;
 }
+
+// Effectively unlimited for E2E: large enough that no realistic multi-prompt run can exhaust it,
+// decoupling the latency/tool suites from model pricing. Credit enforcement stays ON, so the
+// reservation/reconciliation path is still exercised - the user just never hits the gate.
+const DEFAULT_E2E_INITIAL_CREDITS = 10_000_000;
 
 const handler = baseApi({ auth: false }).post(
   asyncHandler(async (req: Request<unknown, unknown, CreateTestUserBody>, res) => {
@@ -36,7 +44,8 @@ const handler = baseApi({ auth: false }).post(
       return res.status(401).json({ error: 'Invalid cleanup secret' });
     }
 
-    const { username, email, name, password, isAdmin, emailVerified, tags, acceptedPolicies } = req.body;
+    const { username, email, name, password, isAdmin, emailVerified, tags, acceptedPolicies, initialCredits } =
+      req.body;
 
     // Guard 3: Only allow creating users with the E2E email pattern
     const E2E_EMAIL_PATTERN = /-e2e@test\.com$/i;
@@ -61,7 +70,7 @@ const handler = baseApi({ auth: false }).post(
         isAdmin: isAdmin ?? false,
         emailVerified: emailVerified ?? true,
         tags: [...PREDEFINED_USER_TAGS, ...(tags ?? [])],
-        initialCredits: 10_000,
+        initialCredits: initialCredits ?? DEFAULT_E2E_INITIAL_CREDITS,
       },
       { db: { users: userRepository } }
     );


### PR DESCRIPTION
## Description

The `ai-latency-intermediate-tools` E2E suite was intermittently failing on a `toBeVisible` timeout waiting for the AI response. Root cause was **not latency and not a pricing bug**: the test user ran out of credits mid-run.

E2E test users are minted with a fixed **10,000-credit** grant and never topped up. The suite runs **3 prompts sequentially against one user**, and `pickDeterministic(prompts, 3, dailySeed)` rotates which 3 of the 5 configured prompts run each day. On days the seed selected the tool-heavy prompts (multi-image storybook, search-driven comparison), the per-request pre-flight credit reservation exceeded the remaining balance. The server threw `InsufficientCreditsError`, the client rendered `InsufficientCreditsNotice` instead of `ai-response-root-container`, no response streamed, and `expect(aiResponseRoot).toBeVisible({ timeout: 120000 })` timed out.

Bumping the grant to a price-tuned number would be a treadmill (model prices rise, prompts get added, the daily draw rotates). Instead this decouples the latency benchmark from the billing subsystem entirely: default the E2E grant to an effectively-unlimited value, keeping `enforceCredits` ON so the reservation/reconciliation path is still exercised end-to-end -- the user just never hits the gate.

Closes #1391

## Changes

- `apps/client/pages/api/test/create-user.ts`: default E2E credit grant `10_000` -> `10_000_000` via a named `DEFAULT_E2E_INITIAL_CREDITS` constant; made `initialCredits` an optional request-body param (defaults to the constant).
- `apps/client/e2e/helpers/api.ts`: added optional `initialCredits?: number` to `apiCreateTestUser` params (forwarded to the endpoint automatically).

No product code changed. No existing test depended on the old 10,000 value.

## Guide for Testers

This is a backend/test-harness change; there is no user-facing UI to click. Verification is via the E2E CI workflow.

1. Trigger the workflow: GitHub -> Actions -> **E2E AI Latency Tests** -> Run workflow, stage `dev` (or against a PR preview).
2. Wait for all matrix cells to complete (~15 min).
3. Expected: the two `ai-latency-intermediate-tools` cells (Claude 5 Opus and GPT-5.6 Sol) both pass. Previously one or both failed with a 120s `toBeVisible` timeout on `ai-response-root-container` and a "You're out of credits" banner in the screenshot.
4. Optional confirmation the grant applied: in the failing screenshots the credit banner read "only 3535 / 2275 available"; with this change the test user starts at 10,000,000, so no run in the suite can exhaust it.

### Regression Checks

1. Run the full **E2E AI Latency Tests** matrix. Expected: all cells green (short-answers, long-answers, tool-prompts, intermediate-tools) for both models.
2. Confirm other E2E suites that create users via `/api/test/create-user` still pass (any suite using `setupSpecUser`). Expected: unchanged -- they now start with the larger grant but assert nothing on the grant value.

### What NOT to test

- No production credit/billing behavior changes. `/api/test/create-user` is gated to dev/preview by `isE2EEnabled()` + the E2E secret and can never run in production.
- `enforceCredits` is intentionally left ON; this PR does not disable credit enforcement anywhere.

## Additional Information

Filed alongside two follow-ups surfaced during the investigation:
- #1393 -- add a dedicated credit-enforcement E2E spec (uses the new optional `initialCredits` param to mint a low-balance user).
- #1392 -- the pre-flight reservation holds the full max-output window on premium models, which can false-block affordable real-user requests (product-side, separate from this test fix).

## Developer Notes (Optional)

- `/api/test/create-user` now accepts an optional `initialCredits` -- specs can mint users at any starting balance (default effectively-unlimited, or a small value for gate/enforcement tests). This is the building block #1393 uses.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
