### PR TITLE
ci(release): keep openapi spec in sync on version bump; exempt release PR from preview gate

### DIFF
--- a/.github/workflows/sst-infra-preview-gate.yml
+++ b/.github/workflows/sst-infra-preview-gate.yml
@@ -54,13 +54,19 @@ jobs:
           # still redden. Filtering the diff instead of short-circuiting the whole
           # PR preserves that. Same-repo predicate mirrors auto-changeset.yml.
           if [ "$IS_SAME_REPO" = "true" ] && [ "$HEAD_REF" = "changeset-release/main" ]; then
-            jq '[.[] | select((.filename == "b4m-core/infra/package.json" or .filename == "CHANGELOG.md" or (.filename | endswith("/CHANGELOG.md"))) | not)]' /tmp/pr_files_raw.json > /tmp/pr_files.json
-            echo "Release PR: excluded version-bump artifacts (b4m-core/infra/package.json, CHANGELOGs) from gate detection."
+            # Drop CHANGELOGs entirely (pure release artifacts, no deploy surface).
+            # Keep b4m-core/infra/package.json in pr_files.json so the sst-pin patch
+            # check below still inspects it; exclude it only from the path-glob input
+            # (files.txt), so its version bump does not trip the glob while a
+            # hand-pushed sst pin on that same file still reddens the gate.
+            jq '[.[] | select((.filename == "CHANGELOG.md" or (.filename | endswith("/CHANGELOG.md"))) | not)]' /tmp/pr_files_raw.json > /tmp/pr_files.json
+            jq -r '.[].filename' /tmp/pr_files.json > /tmp/files_all.txt
+            grep -v '^b4m-core/infra/package\.json$' /tmp/files_all.txt > /tmp/files.txt || true
+            echo "Release PR: excluded CHANGELOGs from detection; b4m-core/infra/package.json excluded from the path glob but still patch-inspected for sst pins."
           else
             cp /tmp/pr_files_raw.json /tmp/pr_files.json
+            jq -r '.[].filename' /tmp/pr_files.json > /tmp/files.txt
           fi
-
-          jq -r '.[].filename' /tmp/pr_files.json > /tmp/files.txt
           echo "Changed files considered:"; sed 's/^/  /' /tmp/files.txt || true
 
           applicable=0

--- a/.github/workflows/sst-infra-preview-gate.yml
+++ b/.github/workflows/sst-infra-preview-gate.yml
@@ -37,23 +37,31 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref }}
+          IS_SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           set -euo pipefail
 
-          # The changesets "version packages" PR only bumps versions + CHANGELOGs.
-          # Its b4m-core/infra/package.json bump trips the infra glob below with no
-          # real infra change, so exempt the bot branch instead of forcing a
-          # throwaway preview on every release.
-          if [ "$HEAD_REF" = "changeset-release/main" ]; then
-            echo "Changesets release PR (version bumps only). Gate not applicable -> pass."
-            exit 0
-          fi
-
           # Single fetch of changed files (with patches). No `|| true`: a fetch
           # failure must redden this gate (fail closed), never silently pass.
-          gh api "repos/$REPO/pulls/$PR/files" --paginate > /tmp/pr_files.json
+          gh api "repos/$REPO/pulls/$PR/files" --paginate > /tmp/pr_files_raw.json
+
+          # The changesets "version packages" PR bumps versions + CHANGELOGs; its
+          # b4m-core/infra/package.json bump trips the infra glob below with no real
+          # infra change. Exempt those ARTIFACTS on a same-repo release PR rather
+          # than trusting the branch name: `github.head_ref` is attacker-chosen on a
+          # fork (this public repo takes external PRs), and the release branch is
+          # long-lived and human-pushed -- so a real infra change riding it must
+          # still redden. Filtering the diff instead of short-circuiting the whole
+          # PR preserves that. Same-repo predicate mirrors auto-changeset.yml.
+          if [ "$IS_SAME_REPO" = "true" ] && [ "$HEAD_REF" = "changeset-release/main" ]; then
+            jq '[.[] | select((.filename == "b4m-core/infra/package.json" or .filename == "CHANGELOG.md" or (.filename | endswith("/CHANGELOG.md"))) | not)]' /tmp/pr_files_raw.json > /tmp/pr_files.json
+            echo "Release PR: excluded version-bump artifacts (b4m-core/infra/package.json, CHANGELOGs) from gate detection."
+          else
+            cp /tmp/pr_files_raw.json /tmp/pr_files.json
+          fi
+
           jq -r '.[].filename' /tmp/pr_files.json > /tmp/files.txt
-          echo "Changed files:"; sed 's/^/  /' /tmp/files.txt || true
+          echo "Changed files considered:"; sed 's/^/  /' /tmp/files.txt || true
 
           applicable=0
           reason=""

--- a/.github/workflows/sst-infra-preview-gate.yml
+++ b/.github/workflows/sst-infra-preview-gate.yml
@@ -36,8 +36,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
+
+          # The changesets "version packages" PR only bumps versions + CHANGELOGs.
+          # Its b4m-core/infra/package.json bump trips the infra glob below with no
+          # real infra change, so exempt the bot branch instead of forcing a
+          # throwaway preview on every release.
+          if [ "$HEAD_REF" = "changeset-release/main" ]; then
+            echo "Changesets release PR (version bumps only). Gate not applicable -> pass."
+            exit 0
+          fi
 
           # Single fetch of changed files (with patches). No `|| true`: a fetch
           # failure must redden this gate (fail closed), never silently pass.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typecheck:fast": "tsgo --noEmit --types node || tsc --noEmit",
     "weekly-insights:generate": "pnpm --filter scripts weekly-insights:generate",
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:version": "changeset version && pnpm turbo:openapi:generate",
     "changeset:publish": "changeset publish",
     "changeset:status": "changeset status"
   },


### PR DESCRIPTION
## Description

The changesets "version packages" release PR (currently #601) fails CI on two checks, and both are structural artifacts of the version-bump flow rather than code regressions. This fixes the root cause for future release PRs.

**1. OpenAPI Spec drift.** `b4m-core/common/src/openapi/generate.ts` stamps `@bike4mind/common`'s package version into the spec's `info.version` (single source of truth, bumped on release). The `changeset:version` script only ran `changeset version`, so the release PR bumped `common`'s version but never regenerated the committed `apps/client/public/openapi.json`. Every release PR that bumps `common`'s major/minor therefore drifts (e.g. spec `3.0.0` vs generated `4.0.0`) and reddens the "no drift" gate.

**2. preview gate false positive.** `sst-infra-preview-gate.yml` flags any change under `b4m-core/infra/`. A release PR's only change there is a version bump to `b4m-core/infra/package.json` + its `CHANGELOG.md` — no real infra/deploy change — yet it trips the infra glob and demands a throwaway preview deploy on every release.

## Changes

- `package.json`: `changeset:version` now runs `changeset version && pnpm turbo:openapi:generate`, so the version PR carries a freshly regenerated spec and can't drift. The generate task is `cache: false` with no `dependsOn`, so it just re-runs `tsx generate.ts` (no build) and the changesets action commits the result onto the release branch.
- `sst-infra-preview-gate.yml`: early-exit (pass) when the PR head ref is `changeset-release/main`. Release PRs are version + CHANGELOG bumps only; there is no hand-authored infra change for the gate to catch, so requiring a preview is pure friction. All other PRs are evaluated exactly as before.

## Guide for Testers

This is CI/release-automation only — there is no runtime/UI surface. Verify via the release flow:

1. After merge, the next changesets release PR (branch `changeset-release/main`) should be created/updated with an already-regenerated `apps/client/public/openapi.json` whose `info.version` matches the bumped `@bike4mind/common` version.
2. On that release PR, the **OpenAPI Spec** check ("Verify committed spec is up to date (no drift)") should pass with no manual regeneration.
3. On that release PR, the **preview gate** check should report `Changesets release PR (version bumps only). Gate not applicable -> pass.` and pass without a preview deploy.

### Regression Checks
1. Open any normal (non-release) PR that changes `b4m-core/infra/`, `infra/`, `sst.config.ts`, or an `sst` pin in a `package.json`. The **preview gate** must still fail until a preview is deployed (unchanged behavior — the exemption is scoped strictly to head ref `changeset-release/main`).
2. Open any normal PR that changes a Zod request/response schema without regenerating the spec. The **OpenAPI Spec** drift check must still fail (this PR does not touch that check, only the release-time regeneration).

### What NOT to test
- No app behavior, endpoints, or UI change. `openapi.json` content is byte-identical for a given `common` version; only the moment of regeneration moved into the release step.

## Additional Information

For the in-flight release PR #601, the regenerated spec has already been committed to its branch directly, and the preview gate there needs a one-time label/bypass since `pull_request` checks run the workflow definition from the head branch (which predates this exemption). Once this merges, subsequent release PRs self-heal on both checks.
