### PR TITLE
fix(llm): offer knowledge-base search when a session has attached knowledge

### DIFF
--- a/apps/client/pages/api/chat.ts
+++ b/apps/client/pages/api/chat.ts
@@ -227,9 +227,10 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_CHAT, ApiKeyScope.AI_G
           ? { promptDetails: completedQuest.promptMeta.context.systemPromptDetails }
           : {}),
         ...(toolMeta && { tools: toolMeta }),
-        // The tools actually offered to the model server-side (post per-session resolution +
-        // denylist). Unlike toolMeta.effectiveTools (API-layer selection only), this reflects
-        // server-side offers like the attached-knowledge auto-offer - the signal an eval needs.
+        // The tools actually offered to the model server-side: the built tool list after the
+        // denylist pass and Ollama trim, so it also includes MCP tools and delegate_to_agent.
+        // Unlike toolMeta.effectiveTools (API-layer selection only), this reflects server-side
+        // offers like the attached-knowledge auto-offer - the signal an eval needs.
         ...(completedQuest.promptMeta?.offeredTools ? { offeredTools: completedQuest.promptMeta.offeredTools } : {}),
         performance,
         tracking_info: {

--- a/apps/client/pages/api/chat.ts
+++ b/apps/client/pages/api/chat.ts
@@ -227,6 +227,10 @@ const handler = baseApi({ requiredScopes: [ApiKeyScope.AI_CHAT, ApiKeyScope.AI_G
           ? { promptDetails: completedQuest.promptMeta.context.systemPromptDetails }
           : {}),
         ...(toolMeta && { tools: toolMeta }),
+        // The tools actually offered to the model server-side (post per-session resolution +
+        // denylist). Unlike toolMeta.effectiveTools (API-layer selection only), this reflects
+        // server-side offers like the attached-knowledge auto-offer - the signal an eval needs.
+        ...(completedQuest.promptMeta?.offeredTools ? { offeredTools: completedQuest.promptMeta.offeredTools } : {}),
         performance,
         tracking_info: {
           quest_id: completedQuest.id,

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -287,12 +287,14 @@ export const PromptMetaZodSchema = z.object({
   context: PromptMetaContextSchema.optional(),
   functionCalls: z.array(PromptMetaFunctionCallSchema).optional(),
   /**
-   * Names of the tools actually offered to the model this turn - the final server-side
-   * `enabledTools` handed to buildTools, after per-session resolution and the denylist.
-   * Distinct from the chat response's `effectiveTools`, which reflects only the API-layer
-   * (phrase-recommender) selection and so cannot see server-side offers like the attached-
-   * knowledge auto-offer. This is the authoritative "what did the model actually get" signal
-   * for eval/measurement and for diagnosing the silent no-tool-offered state.
+   * Names of the tools actually offered to the model this turn - the output of `buildTools`
+   * (`allTools`), after the post-build denylist pass and the Ollama auto-added trim. This is a
+   * superset of the resolved `enabledTools`: it also includes MCP server tools and the
+   * auto-injected `delegate_to_agent`, neither of which ever appears in `enabledTools`. Distinct
+   * from the chat response's `effectiveTools`, which reflects only the API-layer (phrase-
+   * recommender) selection and so cannot see server-side offers like the attached-knowledge
+   * auto-offer. This is the authoritative "what did the model actually get" signal for
+   * eval/measurement and for diagnosing the silent no-tool-offered state.
    */
   offeredTools: z.array(z.string()).optional(),
   performance: PromptMetaPerformanceSchema.optional(),

--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -286,6 +286,15 @@ export const PromptMetaZodSchema = z.object({
   tokenUsage: PromptMetaTokenUsageSchema.optional(),
   context: PromptMetaContextSchema.optional(),
   functionCalls: z.array(PromptMetaFunctionCallSchema).optional(),
+  /**
+   * Names of the tools actually offered to the model this turn - the final server-side
+   * `enabledTools` handed to buildTools, after per-session resolution and the denylist.
+   * Distinct from the chat response's `effectiveTools`, which reflects only the API-layer
+   * (phrase-recommender) selection and so cannot see server-side offers like the attached-
+   * knowledge auto-offer. This is the authoritative "what did the model actually get" signal
+   * for eval/measurement and for diagnosing the silent no-tool-offered state.
+   */
+  offeredTools: z.array(z.string()).optional(),
   performance: PromptMetaPerformanceSchema.optional(),
   session: PromptMetaSessionSchema.optional(),
   questId: z.string().optional(),

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -2098,6 +2098,27 @@ describe('resolveEnabledTools', () => {
     expect(result).toEqual(['web_search']);
   });
 
+  it('skips the attached-knowledge offer when skipAutoOffers is set (prompt-mode eval)', () => {
+    const result = resolveEnabledTools({
+      requestTools: [],
+      hasAttachedKnowledge: true,
+      skipAutoOffers: true,
+    });
+    expect(result).not.toContain('search_knowledge_base');
+    expect(result).not.toContain('retrieve_knowledge_content');
+  });
+
+  it('still honors caller-selected knowledge tools under skipAutoOffers', () => {
+    // skipAutoOffers gates only OUR offer; a tool the caller explicitly sent stays and still pairs.
+    const result = resolveEnabledTools({
+      requestTools: ['search_knowledge_base'],
+      hasAttachedKnowledge: true,
+      skipAutoOffers: true,
+    });
+    expect(result).toContain('search_knowledge_base');
+    expect(result).toContain('retrieve_knowledge_content');
+  });
+
   it('pairs edit_image for a session-forced image_generation (latent-gap fix)', () => {
     const result = resolveEnabledTools({
       requestTools: [],

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   ChatCompletionProcess,
   addPairedTool,
+  resolveEnabledTools,
   computeSettlementDelta,
   clampFraction,
   dropOldestHistoryTurn,
@@ -2063,6 +2064,68 @@ describe('addPairedTool', () => {
       'image_generation',
       'edit_image',
     ]);
+  });
+});
+
+describe('resolveEnabledTools', () => {
+  it('offers search_knowledge_base (and pairs retrieve) when knowledge is attached', () => {
+    const result = resolveEnabledTools({ requestTools: [], hasAttachedKnowledge: true });
+    expect(result).toContain('search_knowledge_base');
+    expect(result).toContain('retrieve_knowledge_content');
+  });
+
+  it('does not duplicate search_knowledge_base when the request already has it', () => {
+    const result = resolveEnabledTools({
+      requestTools: ['search_knowledge_base'],
+      hasAttachedKnowledge: true,
+    });
+    expect(result.filter(t => t === 'search_knowledge_base')).toHaveLength(1);
+  });
+
+  it('lets the session denylist win over the attached-knowledge offer', () => {
+    const result = resolveEnabledTools({
+      requestTools: [],
+      hasAttachedKnowledge: true,
+      sessionDisabledTools: ['search_knowledge_base'],
+    });
+    expect(result).not.toContain('search_knowledge_base');
+    // retrieve rides on search's pairing, so it must not survive alone either.
+    expect(result).not.toContain('retrieve_knowledge_content');
+  });
+
+  it('leaves the tool list untouched when no knowledge is attached', () => {
+    const result = resolveEnabledTools({ requestTools: ['web_search'], hasAttachedKnowledge: false });
+    expect(result).toEqual(['web_search']);
+  });
+
+  it('pairs edit_image for a session-forced image_generation (latent-gap fix)', () => {
+    const result = resolveEnabledTools({
+      requestTools: [],
+      sessionEnabledTools: ['image_generation'],
+      hasAttachedKnowledge: false,
+    });
+    expect(result).toContain('image_generation');
+    expect(result).toContain('edit_image');
+  });
+
+  it('strips a denied companion (edit_image) even when its trigger stays', () => {
+    const result = resolveEnabledTools({
+      requestTools: ['image_generation'],
+      hasAttachedKnowledge: false,
+      sessionDisabledTools: ['edit_image'],
+    });
+    expect(result).toContain('image_generation');
+    expect(result).not.toContain('edit_image');
+  });
+
+  it('is idempotent on its own output', () => {
+    const once = resolveEnabledTools({
+      requestTools: ['web_search'],
+      sessionEnabledTools: ['image_generation'],
+      hasAttachedKnowledge: true,
+    });
+    const twice = resolveEnabledTools({ requestTools: once, hasAttachedKnowledge: true });
+    expect(twice).toEqual(once);
   });
 });
 

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -537,6 +537,15 @@ export interface ResolveEnabledToolsInput {
   sessionDisabledTools?: string[];
   /** True when the session has documents attached (`session.knowledgeIds`). */
   hasAttachedKnowledge: boolean;
+  /**
+   * Skip OUR server-side auto-offers (step 2, the attached-knowledge offer). Set for any
+   * `promptMode`, matching the auto-add gate at the request-parse site (`if (!parsedBody.promptMode)`):
+   * auto-adds are our additions, not the caller's, and attaching a tool also pulls the provider's
+   * tool-use preamble into the request - so a mode-driven eval, above all `raw` (the bare-model
+   * control arm), must not get surprise tools. Caller-selected and session-forced tools are
+   * unaffected; only step 2 is gated.
+   */
+  skipAutoOffers?: boolean;
 }
 
 /**
@@ -546,7 +555,8 @@ export interface ResolveEnabledToolsInput {
  *   2. attached-knowledge offer - documents attached => make them reachable via the
  *      knowledge-base tool. Attaching files is a far stronger retrieval signal than any
  *      phrase match, and offering a tool is cheap (the model may decline) whereas
- *      withholding it is unrecoverable.
+ *      withholding it is unrecoverable. Skipped when `skipAutoOffers` is set (prompt-mode
+ *      requests), since the offer is our addition, not the caller's.
  *   3. companion pairing        - a tool useless without its partner rides along
  *      (search_knowledge_base -> retrieve_knowledge_content, image_generation ->
  *      edit_image). Runs AFTER the union/offer so session-forced and auto-offered tools
@@ -566,7 +576,7 @@ export function resolveEnabledTools(input: ResolveEnabledToolsInput): string[] {
     if (!tools.includes(tool)) tools.push(tool);
   }
 
-  if (input.hasAttachedKnowledge && !tools.includes('search_knowledge_base')) {
+  if (!input.skipAutoOffers && input.hasAttachedKnowledge && !tools.includes('search_knowledge_base')) {
     tools.push('search_knowledge_base');
   }
 
@@ -577,11 +587,17 @@ export function resolveEnabledTools(input: ResolveEnabledToolsInput): string[] {
 }
 
 /**
- * Tools this process auto-adds server-side regardless of user selection (see the
- * auto-add pushes in the request-parse method: blog_publish/blog_edit/blog_draft
- * for admins, navigate_view, skill). Small local (Ollama) models get confused by
- * tools they didn't ask for, so these are trimmed for that backend unless the user
- * explicitly enabled them. Keep this list in sync with those auto-add sites.
+ * Tools this process auto-adds server-side regardless of user selection. Two auto-add sites feed
+ * this: the request-parse method (blog_publish/blog_edit/blog_draft for admins, navigate_view,
+ * skill) and `resolveEnabledTools` (the attached-knowledge offer). Small local (Ollama) models get
+ * confused by tools they didn't ask for, so the names in this list are trimmed for that backend
+ * unless the user explicitly enabled them. Keep this list in sync with those auto-add sites.
+ *
+ * Deliberately NOT listed: search_knowledge_base / retrieve_knowledge_content. Attaching a
+ * document is itself an explicit user signal that the docs should be used, unlike the genuinely
+ * unrequested capabilities above - so the attached-knowledge offer must survive the Ollama trim,
+ * which is the whole point of the feature for local models. Listing them here would silently
+ * defeat it.
  */
 export const AUTO_ADDED_TOOL_NAMES = ['blog_draft', 'blog_publish', 'blog_edit', 'navigate_view', 'skill'];
 
@@ -1150,19 +1166,13 @@ export class ChatCompletionProcess {
         sessionEnabledTools: Array.isArray(session.enabledTools) ? session.enabledTools : undefined,
         sessionDisabledTools: Array.isArray(session.disabledTools) ? session.disabledTools : undefined,
         hasAttachedKnowledge,
+        // Any promptMode is an eval/passthrough that must not receive our server-side offers.
+        skipAutoOffers: Boolean(promptMode),
       });
       enabledTools.splice(0, enabledTools.length, ...resolvedTools);
 
-      // Loud warning for the invisible failure mode: knowledge attached but no knowledge
-      // tool offered (the model can't run tools, or a denylist stripped it). Silent here
-      // means the model answers from its weights while the user believes their attached
-      // documents were consulted.
-      if (hasAttachedKnowledge && !enabledTools.includes('search_knowledge_base')) {
-        this.logger.warn(
-          `[knowledge] session ${session.id} has ${session.knowledgeIds!.length} attached document(s) but ` +
-            `search_knowledge_base is not offered - the answer will come from model weights, not the documents.`
-        );
-      }
+      // The invisible-failure warning ("knowledge attached but no knowledge tool offered")
+      // moved to after buildTools, where the authoritative post-build tool list is known.
 
       // Generic per-session integration isolation: a curated-surface session (e.g. /opti)
       // can suppress the user's personal integrations so it runs only its server-owned
@@ -1951,6 +1961,30 @@ export class ChatCompletionProcess {
       // the model was actually given, so it reflects server-side offers like the attached-
       // knowledge auto-offer above.
       if (quest.promptMeta) quest.promptMeta.offeredTools = offeredToolNames;
+
+      // Loud warning for the invisible failure mode: knowledge attached but no knowledge tool
+      // survived into the final offered set. Checked here against offeredToolNames (not at
+      // resolveEnabledTools) because this is the authoritative post-build list - it sees the
+      // post-build denylist pass, the Ollama auto-added trim, and tools injected inside
+      // buildTools, none of which the pre-build enabledTools filter can. Skipped under promptMode,
+      // where withholding the offer is deliberate (see skipAutoOffers), not a failure. Silent
+      // otherwise means the model answers from its weights while the user believes their attached
+      // documents were consulted.
+      if (hasAttachedKnowledge && !promptMode) {
+        if (!offeredToolNames.includes('search_knowledge_base')) {
+          this.logger.warn(
+            `[knowledge] session ${session.id} has ${session.knowledgeIds!.length} attached document(s) but ` +
+              `search_knowledge_base is not offered - the answer will come from model weights, not the documents.`
+          );
+        } else if (!offeredToolNames.includes('retrieve_knowledge_content')) {
+          // Search survived but its companion did not (e.g. a denylist stripped retrieve): the
+          // model can locate passages but cannot read their text. See addPairedTool.
+          this.logger.warn(
+            `[knowledge] session ${session.id} offers search_knowledge_base without ` +
+              `retrieve_knowledge_content - the model can locate passages but cannot read them.`
+          );
+        }
+      }
 
       // For tool prompt guidance, only include MCP tools given directly to the main LLM
       // (agent-only tools like Atlassian are excluded - they're accessed via delegate_to_agent)

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -528,6 +528,54 @@ export function addPairedTool<T extends string>(tools: readonly T[], trigger: T,
   return [...tools];
 }
 
+export interface ResolveEnabledToolsInput {
+  /** Tools already assembled for this request: client selection + server auto-adds. */
+  requestTools: string[];
+  /** `session.enabledTools` - tools a surface forces on regardless of the client toggle. */
+  sessionEnabledTools?: string[];
+  /** `session.disabledTools` - tools a curated surface forbids. Wins over everything else. */
+  sessionDisabledTools?: string[];
+  /** True when the session has documents attached (`session.knowledgeIds`). */
+  hasAttachedKnowledge: boolean;
+}
+
+/**
+ * Single owner for the final tool-offer list handed to `buildTools`. The step order is
+ * deliberate:
+ *   1. session-forced union     - a surface can guarantee a tool is offered.
+ *   2. attached-knowledge offer - documents attached => make them reachable via the
+ *      knowledge-base tool. Attaching files is a far stronger retrieval signal than any
+ *      phrase match, and offering a tool is cheap (the model may decline) whereas
+ *      withholding it is unrecoverable.
+ *   3. companion pairing        - a tool useless without its partner rides along
+ *      (search_knowledge_base -> retrieve_knowledge_content, image_generation ->
+ *      edit_image). Runs AFTER the union/offer so session-forced and auto-offered tools
+ *      get paired too; pairing used to run at request-parse time, before the union, so
+ *      anything added later was silently left unpaired.
+ *   4. session denylist wraps pairing - a curated surface ("approved sources only") wins.
+ *      We strip denied tools BEFORE pairing so a denied trigger can't drag its companion
+ *      in (deny search_knowledge_base => retrieve_knowledge_content must not ride along),
+ *      and AFTER pairing so a denied companion can't ride in on a surviving trigger (keep
+ *      image_generation but deny edit_image). The final filter is the authoritative last word.
+ */
+export function resolveEnabledTools(input: ResolveEnabledToolsInput): string[] {
+  const denied = new Set(input.sessionDisabledTools ?? []);
+  const tools = [...input.requestTools];
+
+  for (const tool of input.sessionEnabledTools ?? []) {
+    if (!tools.includes(tool)) tools.push(tool);
+  }
+
+  if (input.hasAttachedKnowledge && !tools.includes('search_knowledge_base')) {
+    tools.push('search_knowledge_base');
+  }
+
+  const survivors = tools.filter(tool => !denied.has(tool));
+  let paired = addPairedTool(survivors, 'image_generation', 'edit_image');
+  paired = addPairedTool(paired, 'search_knowledge_base', 'retrieve_knowledge_content');
+  return paired.filter(tool => !denied.has(tool));
+}
+
 /**
  * Tools this process auto-adds server-side regardless of user selection (see the
  * auto-add pushes in the request-parse method: blog_publish/blog_edit/blog_draft
@@ -730,10 +778,11 @@ export class ChatCompletionProcess {
       timezone: userTimezone,
     } = parsedBody;
 
-    // Pair tools that are useless without their companion. The UI exposes single toggles
-    // ("Image Generation", "Knowledge Base Search") that imply the paired capability.
-    let finalEnabledTools: string[] = addPairedTool(enabledTools, 'image_generation', 'edit_image');
-    finalEnabledTools = addPairedTool(finalEnabledTools, 'search_knowledge_base', 'retrieve_knowledge_content');
+    // Companion pairing now runs once in `resolveEnabledTools` (see process()), after the
+    // per-session union and attached-knowledge offer, so session-forced and auto-offered
+    // tools get paired too. Here we only copy the request selection so the auto-adds below
+    // don't mutate `parsedBody.tools`.
+    const finalEnabledTools: string[] = [...enabledTools];
     let hasContentTransform = false;
 
     // Auto-added capabilities are OUR additions, not the caller's, so a prompt mode skips this
@@ -1090,27 +1139,29 @@ export class ChatCompletionProcess {
       }
       quest.status = 'running';
 
-      // Generic per-session tool defaults: a session may carry tools that must
-      // always be offered to the model, unioned with the per-request selection.
-      // Lets a product surface guarantee grounded retrieval (or other tools)
-      // regardless of the client's Smart/Fast toggle. No product-specific branch
-      // in core - mirrors the generic `session.systemPromptText` capability.
-      if (Array.isArray(session.enabledTools)) {
-        for (const tool of session.enabledTools) {
-          if (!enabledTools.includes(tool)) enabledTools.push(tool);
-        }
-      }
+      // Finalize the tool-offer list in one place: union the session's forced tools,
+      // offer the knowledge-base tool when documents are attached, pair companion tools,
+      // and apply the session denylist last (so a curated "approved sources only" surface
+      // still wins). `enabledTools` is the array reference handed to buildTools, so splice
+      // the result back in place rather than reassigning the binding.
+      const hasAttachedKnowledge = (session.knowledgeIds?.length ?? 0) > 0;
+      const resolvedTools = resolveEnabledTools({
+        requestTools: enabledTools,
+        sessionEnabledTools: Array.isArray(session.enabledTools) ? session.enabledTools : undefined,
+        sessionDisabledTools: Array.isArray(session.disabledTools) ? session.disabledTools : undefined,
+        hasAttachedKnowledge,
+      });
+      enabledTools.splice(0, enabledTools.length, ...resolvedTools);
 
-      // Generic per-session tool denylist: strip tools the session forbids, even if
-      // the request or a global auto-add (e.g. navigate_view) included them. Lets a
-      // product surface enforce an approved toolset ("curated sources only" -> no web
-      // search). Applied last so it wins over every other tool source. Mutates in
-      // place since `enabledTools` is the array reference passed to buildTools.
-      if (Array.isArray(session.disabledTools) && session.disabledTools.length > 0) {
-        const denied = new Set(session.disabledTools);
-        for (let i = enabledTools.length - 1; i >= 0; i--) {
-          if (denied.has(enabledTools[i])) enabledTools.splice(i, 1);
-        }
+      // Loud warning for the invisible failure mode: knowledge attached but no knowledge
+      // tool offered (the model can't run tools, or a denylist stripped it). Silent here
+      // means the model answers from its weights while the user believes their attached
+      // documents were consulted.
+      if (hasAttachedKnowledge && !enabledTools.includes('search_knowledge_base')) {
+        this.logger.warn(
+          `[knowledge] session ${session.id} has ${session.knowledgeIds!.length} attached document(s) but ` +
+            `search_knowledge_base is not offered - the answer will come from model weights, not the documents.`
+        );
       }
 
       // Generic per-session integration isolation: a curated-surface session (e.g. /opti)

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -1941,10 +1941,16 @@ export class ChatCompletionProcess {
         }
       }
 
+      const offeredToolNames = allTools?.map(t => t.toolSchema.name) ?? [];
       logger.info('🔧 [Tools] allTools:', {
-        count: allTools?.length ?? 0,
-        names: allTools?.map(t => t.toolSchema.name) ?? [],
+        count: offeredToolNames.length,
+        names: offeredToolNames,
       });
+      // Record the final offered tool list for telemetry/eval. The API response's
+      // effectiveTools is the API-layer (phrase-recommender) selection only; this is what
+      // the model was actually given, so it reflects server-side offers like the attached-
+      // knowledge auto-offer above.
+      if (quest.promptMeta) quest.promptMeta.offeredTools = offeredToolNames;
 
       // For tool prompt guidance, only include MCP tools given directly to the main LLM
       // (agent-only tools like Atlassian are excluded - they're accessed via delegate_to_agent)

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -252,6 +252,7 @@ export const PromptMetaSchema = new Schema<PromptMeta>(
         id: { type: String, required: false },
       },
     ],
+    offeredTools: [{ type: String, required: false }],
     performance: {
       totalResponseTime: { type: Number, required: false },
       contextRetrievalTime: { type: Number, required: false },


### PR DESCRIPTION
## Description

A session with attached documents answered **entirely from model weights** because the knowledge tools were never offered to the model. The only automatic path that added `search_knowledge_base` to the offered-tool list was a client-side phrase recommender (`toolRecommender.ts`) matching literal phrases like "in my files". Normal domain questions never match, so the tool was never offered and the server's tool gate dropped it. Attaching documents injects their *content* but did not make them searchable via a tool.

The strongest available signal of retrieval intent is that the user attached documents — far stronger than phrase matching. So: **when a session has attached knowledge (`session.knowledgeIds`), offer `search_knowledge_base`.** Offering a tool is cheap (the model can decline); withholding it is unrecoverable.

Closes #1383. Part of epic #1395.

## Changes

- Extract `enabledTools` finalization into a single pure `resolveEnabledTools()` with a deliberate order:
  1. union the session's forced tools (`session.enabledTools`)
  2. **offer `search_knowledge_base` when the session has attached knowledge**
  3. pair companion tools (`search_knowledge_base` → `retrieve_knowledge_content`, `image_generation` → `edit_image`)
  4. apply the session denylist last, **wrapping** the pairing so a denied trigger can't drag its companion in and a denied companion can't ride in on a surviving trigger
- This consolidates the two `addPairedTool` calls that previously ran at request-parse time (before the per-session merge), which closes a **latent gap**: a session-forced `image_generation` never paired `edit_image`.
- Warn loudly when knowledge is attached but no knowledge tool survives (non-tool model, or a denylist stripped it) — the invisible state that hid this failure mode.
- Unit tests for `resolveEnabledTools` (offer, no-duplicate, denylist-wins, no-attachment no-op, image pairing, denied-companion, idempotency).

**Deliberately unchanged:** the phrase recommender (harmless, covers the "search my knowledge base" case with nothing attached), and `forceKnowledgeRetrieval` (a separate pre-answer injection mechanism — not flipped globally). Data Lake **mode** sessions are unaffected: they set `forceKnowledgeRetrieval: true` and are already grounded. The remaining owner-has-a-lake-in-a-plain-session case is tracked in #1398.

## Guide for Testers

Backend change to server-side tool assembly. Verify on a preview/staging env with a tool-capable model (e.g. an Anthropic/OpenAI chat model).

1. Log in and create a new notebook/session.
2. Attach a document to the session (Sidebar → the session's knowledge/files attach control) — e.g. upload a short text/PDF file containing a distinctive fact like `The internal codename for project Q3 is BLUEHERON.`
3. Wait until the file finishes processing (it appears as attached knowledge on the session).
4. In the message input, type a question that does **not** contain the phrases "my files" or "search my knowledge base" — e.g. `What is the internal codename mentioned in the attached material?`
5. Send. **Expected:** the model invokes the `search_knowledge_base` tool (visible in the tool-activity trace / status chips), and the answer cites the document and returns `BLUEHERON`. Before this change, the model would answer without calling the tool (and typically say it doesn't know).

### Regression Checks

6. New session, **no** attached documents, ask any normal question → **Expected:** no knowledge tool is auto-added; behaves exactly as before.
7. Session with attached documents where the surface/session sets `disabledTools: ['search_knowledge_base']` → **Expected:** the tool is NOT offered (denylist still wins), and a warning is logged server-side.
8. Image generation: on a tool-capable model, ask to generate an image → **Expected:** `image_generation` still works and its `edit_image` companion is available (unchanged, now also correct for session-forced image generation).
9. Data Lake mode session (created via the Data Lake toggle, `forceKnowledgeRetrieval: true`) → **Expected:** grounding/citations behave exactly as before this PR.

### What NOT to test

- No UI changes — nothing to click that looks different. This is server-side tool-list assembly only.
- No changes to how retrieval results are ranked, cited, or rendered.

## Additional Information

Verified locally: `pnpm --filter @bike4mind/services test` (full suite green), `typecheck:fast` clean, eslint clean (pre-existing `any` warnings only).

## Developer Notes

- `resolveEnabledTools(input)` is now the single owner of the final tool-offer list — a pure, exported, unit-testable function. Future per-session tool rules (new auto-offers, new pairings) belong here in one place, rather than scattered across the request-parse method and `process()`.

## Verification (real-key preview e2e)

Verified on the `pr1400` preview against `gpt-4o`, same question/model both sides, reading the new `offeredTools` telemetry:

| | `offeredTools` | `effectiveTools` | answer |
|---|---|---|---|
| session with knowledge attached | `search_knowledge_base` + `retrieve_knowledge_content` present | `[]` | correct (from the attached fact) |
| control (no knowledge) | neither present | `[]` | hallucinated a wrong answer |

Confirms: (1) the tool is offered only when knowledge is attached, (2) the companion pairing rides along, (3) `effectiveTools` cannot see this (API-layer only) - which is why the second commit adds `promptMeta.offeredTools` as the authoritative signal.
