### PR TITLE
fix(organizations): give the billing owner an active-org context on create (#1388)

### DIFF
--- a/apps/client/__tests__/organizations-create-dev.test.ts
+++ b/apps/client/__tests__/organizations-create-dev.test.ts
@@ -4,6 +4,10 @@ vi.mock('@bike4mind/database', () => ({
   organizationRepository: {
     create: vi.fn(),
   },
+  userRepository: {
+    findById: vi.fn(),
+    update: vi.fn(),
+  },
 }));
 
 vi.mock('@bike4mind/services', () => ({
@@ -22,7 +26,7 @@ vi.mock('@server/middlewares/baseApi', () => ({
   })),
 }));
 
-import { organizationRepository } from '@bike4mind/database';
+import { organizationRepository, userRepository } from '@bike4mind/database';
 import { organizationService } from '@bike4mind/services';
 import { isDevelopment } from '@server/utils/config';
 
@@ -76,6 +80,7 @@ describe('POST /api/organizations/create-dev', () => {
       {
         db: {
           organizations: organizationRepository,
+          users: userRepository,
         },
       }
     );

--- a/apps/client/__tests__/organizations-create-dev.test.ts
+++ b/apps/client/__tests__/organizations-create-dev.test.ts
@@ -82,6 +82,7 @@ describe('POST /api/organizations/create-dev', () => {
           organizations: organizationRepository,
           users: userRepository,
         },
+        logger: mockReq.logger,
       }
     );
     expect(mockRes.status).toHaveBeenCalledWith(200);

--- a/apps/client/__tests__/team-manager.test.ts
+++ b/apps/client/__tests__/team-manager.test.ts
@@ -29,10 +29,15 @@ describe('organizationService.create - Team Manager Field', () => {
   };
 
   let mockOrganizationRepository: any;
+  let mockUserRepository: any;
 
   beforeEach(() => {
     mockOrganizationRepository = {
       create: vi.fn().mockImplementation(org => Promise.resolve({ ...org, id: 'org-created-123' })),
+    };
+    mockUserRepository = {
+      findById: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(null),
     };
   });
 
@@ -51,6 +56,7 @@ describe('organizationService.create - Team Manager Field', () => {
         {
           db: {
             organizations: mockOrganizationRepository,
+            users: mockUserRepository,
           },
         }
       );
@@ -81,6 +87,7 @@ describe('organizationService.create - Team Manager Field', () => {
         {
           db: {
             organizations: mockOrganizationRepository,
+            users: mockUserRepository,
           },
         }
       );
@@ -109,6 +116,7 @@ describe('organizationService.create - Team Manager Field', () => {
         {
           db: {
             organizations: mockOrganizationRepository,
+            users: mockUserRepository,
           },
         }
       );
@@ -139,6 +147,7 @@ describe('organizationService.create - Team Manager Field', () => {
         {
           db: {
             organizations: mockOrganizationRepository,
+            users: mockUserRepository,
           },
         }
       );

--- a/apps/client/lib/userSubscriptions/serverUtils.ts
+++ b/apps/client/lib/userSubscriptions/serverUtils.ts
@@ -152,6 +152,7 @@ export const handleOrganizationSubscriptionInvoice = async (
                 organizations: organizationRepository,
                 users: userRepository,
               },
+              logger,
             }
           );
 

--- a/apps/client/lib/userSubscriptions/serverUtils.ts
+++ b/apps/client/lib/userSubscriptions/serverUtils.ts
@@ -150,6 +150,7 @@ export const handleOrganizationSubscriptionInvoice = async (
             {
               db: {
                 organizations: organizationRepository,
+                users: userRepository,
               },
             }
           );

--- a/apps/client/pages/api/admin/organizations/grant.ts
+++ b/apps/client/pages/api/admin/organizations/grant.ts
@@ -75,7 +75,7 @@ const handler = baseApi().post(
           stripeCustomerId: null,
         },
         {
-          db: { organizations: organizationRepository },
+          db: { organizations: organizationRepository, users: userRepository },
         }
       );
 

--- a/apps/client/pages/api/admin/organizations/grant.ts
+++ b/apps/client/pages/api/admin/organizations/grant.ts
@@ -76,6 +76,7 @@ const handler = baseApi().post(
         },
         {
           db: { organizations: organizationRepository, users: userRepository },
+          logger: req.logger,
         }
       );
 

--- a/apps/client/pages/api/admin/users/[userId]/grant-subscription.ts
+++ b/apps/client/pages/api/admin/users/[userId]/grant-subscription.ts
@@ -213,6 +213,7 @@ const handler = baseApi().post(
               organizations: organizationRepository,
               users: userRepository,
             },
+            logger: req.logger,
           }
         );
       }

--- a/apps/client/pages/api/admin/users/[userId]/grant-subscription.ts
+++ b/apps/client/pages/api/admin/users/[userId]/grant-subscription.ts
@@ -211,6 +211,7 @@ const handler = baseApi().post(
           {
             db: {
               organizations: organizationRepository,
+              users: userRepository,
             },
           }
         );

--- a/apps/client/pages/api/organizations/__tests__/index.test.ts
+++ b/apps/client/pages/api/organizations/__tests__/index.test.ts
@@ -54,7 +54,7 @@ const create = vi.hoisted(() =>
   }))
 );
 vi.mock('@bike4mind/services', () => ({ organizationService: { search, create } }));
-vi.mock('@bike4mind/database', () => ({ organizationRepository: {} }));
+vi.mock('@bike4mind/database', () => ({ organizationRepository: {}, userRepository: {} }));
 
 import '@pages/api/organizations/index';
 

--- a/apps/client/pages/api/organizations/create-dev.ts
+++ b/apps/client/pages/api/organizations/create-dev.ts
@@ -39,6 +39,7 @@ const handler = baseApi().post<Request<{}, {}, z.infer<typeof CreateDevOrgSchema
         organizations: organizationRepository,
         users: userRepository,
       },
+      logger: req.logger,
     }
   );
 

--- a/apps/client/pages/api/organizations/create-dev.ts
+++ b/apps/client/pages/api/organizations/create-dev.ts
@@ -3,7 +3,7 @@
  * This bypasses the subscription flow for local development testing
  */
 
-import { organizationRepository } from '@bike4mind/database';
+import { organizationRepository, userRepository } from '@bike4mind/database';
 import { BadRequestError } from '@bike4mind/utils';
 import { baseApi } from '@server/middlewares/baseApi';
 import { isDevelopment } from '@server/utils/config';
@@ -37,6 +37,7 @@ const handler = baseApi().post<Request<{}, {}, z.infer<typeof CreateDevOrgSchema
     {
       db: {
         organizations: organizationRepository,
+        users: userRepository,
       },
     }
   );

--- a/apps/client/pages/api/organizations/index.ts
+++ b/apps/client/pages/api/organizations/index.ts
@@ -42,6 +42,7 @@ const handler = baseApi()
           organizations: organizationRepository,
           users: userRepository,
         },
+        logger: req.logger,
       }
     );
 

--- a/apps/client/pages/api/organizations/index.ts
+++ b/apps/client/pages/api/organizations/index.ts
@@ -4,7 +4,7 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import { Request } from 'express';
 import qs from 'qs';
-import { organizationRepository } from '@bike4mind/database';
+import { organizationRepository, userRepository } from '@bike4mind/database';
 import { organizationService } from '@bike4mind/services';
 import { toSafeOrganization, toSafeOrganizations } from '@bike4mind/common';
 
@@ -40,6 +40,7 @@ const handler = baseApi()
       {
         db: {
           organizations: organizationRepository,
+          users: userRepository,
         },
       }
     );

--- a/b4m-core/services/src/organizationService/create.test.ts
+++ b/b4m-core/services/src/organizationService/create.test.ts
@@ -44,6 +44,10 @@ describe('organizationService - create', () => {
         organizations: {
           create: vi.fn().mockResolvedValue(createdOrganization),
         },
+        users: {
+          findById: vi.fn().mockResolvedValue(null),
+          update: vi.fn().mockResolvedValue(null),
+        },
       },
     };
   });
@@ -185,5 +189,48 @@ describe('organizationService - create', () => {
         extraParam: 'should be ignored',
       })
     );
+  });
+
+  describe('billing-owner active-org context (#1388)', () => {
+    it("sets the creating owner's organizationId to the new org when they have none", async () => {
+      await create(
+        mockUser as IUserDocument, // no organizationId
+        { name: 'Test Organization', personal: false, seats: 1, stripeCustomerId: null },
+        mockAdapters
+      );
+      expect(mockAdapters.db.users.update).toHaveBeenCalledWith({ id: 'user1', organizationId: 'org1' });
+      // Owner is the caller, so no lookup is needed.
+      expect(mockAdapters.db.users.findById).not.toHaveBeenCalled();
+    });
+
+    it('does NOT overwrite an owner who already has an active org', async () => {
+      await create(
+        { ...mockUser, organizationId: 'existing-org' } as IUserDocument,
+        { name: 'Test Organization', personal: false, seats: 1, stripeCustomerId: null },
+        mockAdapters
+      );
+      expect(mockAdapters.db.users.update).not.toHaveBeenCalled();
+    });
+
+    it('sets the org context on the billing owner (loaded) when billingOwnerId differs from the caller', async () => {
+      mockAdapters.db.users.findById.mockResolvedValue({ id: 'owner2', organizationId: undefined });
+      await create(
+        mockUser as IUserDocument,
+        { name: 'Test Organization', personal: false, seats: 1, stripeCustomerId: null, billingOwnerId: 'owner2' },
+        mockAdapters
+      );
+      expect(mockAdapters.db.users.findById).toHaveBeenCalledWith('owner2');
+      expect(mockAdapters.db.users.update).toHaveBeenCalledWith({ id: 'owner2', organizationId: 'org1' });
+    });
+
+    it('leaves an on-behalf owner untouched when they already have an active org', async () => {
+      mockAdapters.db.users.findById.mockResolvedValue({ id: 'owner2', organizationId: 'owner2-org' });
+      await create(
+        mockUser as IUserDocument,
+        { name: 'Test Organization', personal: false, seats: 1, stripeCustomerId: null, billingOwnerId: 'owner2' },
+        mockAdapters
+      );
+      expect(mockAdapters.db.users.update).not.toHaveBeenCalled();
+    });
   });
 });

--- a/b4m-core/services/src/organizationService/create.ts
+++ b/b4m-core/services/src/organizationService/create.ts
@@ -72,12 +72,23 @@ export const create = async (user: IUserDocument, params: CreateParameters, adap
   // implicit capability hold (owner holds the org's granted types) never runs for them. Set it
   // only when the owner has none, so we never silently switch the active org of a user who already
   // belongs to one - multi-org owner active-org SELECTION is a separate concern (#1172).
+  //
+  // ⚠️ `organizationId` is OVERLOADED (#1428): it is also the BILLING selector. Once it is set,
+  // `deductCreditsWithOrgSupport` charges the ORG's `currentCredits` rather than the user's personal
+  // balance, with no fallback (#1238 made the org balance a hard stop). `create` starts orgs at 0
+  // credits, so on an unfunded path (`POST /api/organizations`, or a grant with `initialCredits: 0`)
+  // this points the owner at an empty pool - and `leave` refuses to clear the pointer for an org's
+  // own owner, so they cannot undo it themselves. Do NOT "fix" that by gating this write on the org
+  // being funded: that reintroduces #1388 for unfunded-org owners. The fields need separating; see
+  // #1428.
   const owner = billingOwnerId === user.id ? user : await adapters.db.users.findById(billingOwnerId);
   if (owner && !owner.organizationId) {
     // Best-effort, and intentionally NOT fatal: the org is already committed (there is no surrounding
     // transaction at every call site), so letting a failed pointer write bubble would 500 a create
     // that actually succeeded and leave the owner in exactly the no-active-org state this repairs.
-    // A stale pointer is recoverable - #1172 active-org selection can set it later.
+    // A stale pointer is recoverable - #1172 active-org selection can set it later. Note the failure
+    // direction is the safe one here: no pointer means no capability scope (the #1388 state), but it
+    // also means billing stays on the user's personal balance rather than an empty org pool.
     try {
       await adapters.db.users.update({ id: owner.id, organizationId: organization.id });
     } catch (error) {

--- a/b4m-core/services/src/organizationService/create.ts
+++ b/b4m-core/services/src/organizationService/create.ts
@@ -18,6 +18,7 @@ interface CreateAdapters {
     organizations: IOrganizationRepository;
     users: Pick<IUserRepository, 'findById' | 'update'>;
   };
+  logger?: { error: (message: string) => void };
 }
 
 export const create = async (user: IUserDocument, params: CreateParameters, adapters: CreateAdapters) => {
@@ -73,7 +74,17 @@ export const create = async (user: IUserDocument, params: CreateParameters, adap
   // belongs to one - multi-org owner active-org SELECTION is a separate concern (#1172).
   const owner = billingOwnerId === user.id ? user : await adapters.db.users.findById(billingOwnerId);
   if (owner && !owner.organizationId) {
-    await adapters.db.users.update({ id: owner.id, organizationId: organization.id });
+    // Best-effort, and intentionally NOT fatal: the org is already committed (there is no surrounding
+    // transaction at every call site), so letting a failed pointer write bubble would 500 a create
+    // that actually succeeded and leave the owner in exactly the no-active-org state this repairs.
+    // A stale pointer is recoverable - #1172 active-org selection can set it later.
+    try {
+      await adapters.db.users.update({ id: owner.id, organizationId: organization.id });
+    } catch (error) {
+      (adapters.logger ?? console).error(
+        `Organization ${organization.id} created but failed to set active-org pointer for owner ${owner.id}: ${error}`
+      );
+    }
   }
 
   return organization;

--- a/b4m-core/services/src/organizationService/create.ts
+++ b/b4m-core/services/src/organizationService/create.ts
@@ -1,4 +1,4 @@
-import { IOrganizationDocument, IOrganizationRepository, IUserDocument } from '@bike4mind/common';
+import { IOrganizationDocument, IOrganizationRepository, IUserDocument, IUserRepository } from '@bike4mind/common';
 import { secureParameters } from '@bike4mind/utils';
 import { z } from 'zod';
 
@@ -16,6 +16,7 @@ type CreateParameters = z.infer<typeof createSchema>;
 interface CreateAdapters {
   db: {
     organizations: IOrganizationRepository;
+    users: Pick<IUserRepository, 'findById' | 'update'>;
   };
 }
 
@@ -63,6 +64,17 @@ export const create = async (user: IUserDocument, params: CreateParameters, adap
   };
 
   const organization = await adapters.db.organizations.create(buildOrganization);
+
+  // Give the billing owner an active-org context (#1388). The owner is intentionally NOT a
+  // `users[]` member (#1226), but org-scoped resolution derives the active org from
+  // `user.organizationId`; without it an owner-only account resolves to no org, so the #1226
+  // implicit capability hold (owner holds the org's granted types) never runs for them. Set it
+  // only when the owner has none, so we never silently switch the active org of a user who already
+  // belongs to one - multi-org owner active-org SELECTION is a separate concern (#1172).
+  const owner = billingOwnerId === user.id ? user : await adapters.db.users.findById(billingOwnerId);
+  if (owner && !owner.organizationId) {
+    await adapters.db.users.update({ id: owner.id, organizationId: organization.id });
+  }
 
   return organization;
 };


### PR DESCRIPTION
## Description

Fixes #1388. `organizationService.create` set the new org's `userId` (the billing owner) but never set the **owner's own** `user.organizationId`. Org-scoped resolution derives the caller's active org from `user.organizationId`, so a billing owner who created an org **but was never added as a member** (deliberate, per #1226 - the owner is not a `users[]` row) resolves to *no org*. Org-scoped, capability-gated surfaces then return empty for them - including the #1226 billing-owner implicit hold (the owner implicitly holds every group type the org is granted).

Surfaced during the #1381 live e2e.

## Fix

After creating the org, set the billing owner's `organizationId` to the new org - **only when they have none**, so we never silently switch the active org of a user who already belongs to one. Multi-org owner active-org *selection* stays a separate concern (#1172). The owner remains a non-member (`users[]` untouched), consistent with #1226.

- `create.ts`: new `users` adapter (`findById`/`update`); sets the owner's `organizationId` if empty. Handles the on-behalf case (`billingOwnerId` != caller) by loading that owner.
- Wire `userRepository` through **all five** `create` callers: `POST /api/organizations`, the dev-create route, `POST /api/admin/organizations/grant`, `POST /api/admin/users/[userId]/grant-subscription`, and `handleOrganizationSubscriptionInvoice` (`lib/userSubscriptions/serverUtils.ts`). That last one runs on a **Stripe invoice webhook**, so this behaviour change reaches a payment path — benign there, since that flow funds the org it creates, but listed so anyone debugging billing can see it.
- `index.test.ts`: its `@bike4mind/database` mock gains `userRepository` (the route imports it now).

## Guide for Testers

Backend fix; unit-level. Also verifiable via the live capability path.

1. `pnpm --filter @bike4mind/services exec vitest run src/organizationService/create.test.ts` -> **9 pass** (incl. the new `billing-owner active-org context (#1388)` block).
2. `pnpm --filter @bike4mind/services typecheck:fast` -> no errors.
3. Route test: `pnpm --filter <client> exec vitest run pages/api/organizations/__tests__/index.test.ts` -> 6 pass.

### Live (optional, on a preview)
1. As a fresh user A (no org), `POST /api/organizations` -> A becomes billing owner.
2. Grant the org a group type (`PUT /api/admin/organizations/[id]/group-types`).
3. Resolve A's capabilities on a surface scoped to A's active org.
   - **Before:** empty (A had no `organizationId`).
   - **After:** the union of the granted type's capabilities (implicit hold runs).

### Regression Checks
- A creator who **already** had an `organizationId` keeps it (not overwritten) - asserted in tests.
- Owner is still NOT added to `users[]` (member membership unchanged); only the active-org pointer is set.
- Existing `create` behavior (org fields, timestamps, param validation) unchanged.

### What NOT to test
- Multi-org owners picking an active org is out of scope (a fresh owner-only account is what this fixes); it's flagged as a separate concern.

### Known consequence (tracked separately)

`user.organizationId` is also the **billing** selector, so setting it moves the owner's credit spend to the new org. On unfunded paths (`POST /api/organizations`, or a grant with `initialCredits: 0`) that points them at a 0-credit pool, and `leave` won't clear the pointer for an org's own owner. Pre-existing overload, not introduced here, and the narrow fix (gate this write on funding) would reintroduce #1388 — so it is filed as #1428 against the epic's active-org work rather than patched here. Called out in a comment at the write site.

Part of #1172. Related: #1226, #1428.

Closes #1388

