### PR TITLE
refactor(data-lake): converge retrieval-path org-id coercion onto normalizeId (#1343)

### DIFF
--- a/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
+++ b/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
@@ -183,4 +183,17 @@ describe('resolveRetrievalLakeScope', () => {
       entitlementKeys: [],
     });
   });
+
+  it('normalizes a populated-document organizationId at the seam (#1343)', async () => {
+    // A .populate('organizationId') upstream would hand req.user a full Organization doc. It must
+    // reach the shared resolver as its hex string, not "[object Object]", mirroring toAccessContext.
+    const populatedOrg = { _id: { toHexString: () => 'org-hex' }, name: 'Acme' } as unknown as string;
+    await resolveRetrievalLakeScope(asReq({ id: 'u1', tags: ['Opti'], organizationId: populatedOrg }));
+
+    expect(mockGetDynamicDataLakeAccess).toHaveBeenCalledWith({
+      db: { dataLakes: dataLakeRepository },
+      user: { id: 'u1', tags: ['Opti'], organizationId: 'org-hex' },
+      entitlementKeys: [],
+    });
+  });
 });

--- a/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
+++ b/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
@@ -196,4 +196,18 @@ describe('resolveRetrievalLakeScope', () => {
       entitlementKeys: [],
     });
   });
+
+  it('normalizes an empty-string organizationId to undefined (org-less), not literal "" (#1343)', async () => {
+    // An empty string is not a valid org id: normalizeId('') returns undefined, so the caller is
+    // treated as org-less (only org-less lakes resolve) rather than filtering on a literal "".
+    // This is the intended, safer behavior - locking it in so the delta from the old `?? undefined`
+    // pass-through stays deliberate.
+    await resolveRetrievalLakeScope(asReq({ id: 'u1', tags: ['Opti'], organizationId: '' }));
+
+    expect(mockGetDynamicDataLakeAccess).toHaveBeenCalledWith({
+      db: { dataLakes: dataLakeRepository },
+      user: { id: 'u1', tags: ['Opti'], organizationId: undefined },
+      entitlementKeys: [],
+    });
+  });
 });

--- a/apps/client/server/dataLakes/resolveRetrievalLakeScope.ts
+++ b/apps/client/server/dataLakes/resolveRetrievalLakeScope.ts
@@ -14,6 +14,7 @@
 import { DATA_LAKES, hasDeveloperUserTag, type DataLakeConfig } from '@bike4mind/common';
 import { dataLakeService } from '@bike4mind/services';
 import { dataLakeRepository } from '@bike4mind/database';
+import { normalizeId } from '@bike4mind/utils/normalizeId';
 import { getRequestEntitlements, type EntitlementRequest } from '@server/entitlements';
 import type { Logger } from '@bike4mind/observability';
 
@@ -77,7 +78,9 @@ export async function resolveRetrievalLakeScope(req: RetrievalScopeRequest): Pro
     user: {
       id: user.id,
       tags: user.tags ?? [],
-      organizationId: user.organizationId ?? undefined,
+      // Normalize once at the retrieval context seam, mirroring toAccessContext on the management
+      // side (#1281): a populated-doc org id would otherwise reach the gate as "[object Object]".
+      organizationId: normalizeId(user.organizationId),
     },
     entitlementKeys,
     logger: req.logger,

--- a/b4m-core/services/src/dataLakeService/getDataLakePrompts.test.ts
+++ b/b4m-core/services/src/dataLakeService/getDataLakePrompts.test.ts
@@ -69,9 +69,10 @@ describe('getAccessibleDataLakePrompts', () => {
   });
 
   /**
-   * The trust check compares ids across a String schema and a String()-coerced actor. If a future
-   * migration ever stored `createdByUserId` (or `organizationId`) as an ObjectId, a raw `===` would
-   * fail SILENTLY - the lake is simply never trusted, no error anywhere. Lock the coercion.
+   * The trust check compares ids across a String schema and a coerced actor. If a future migration
+   * ever stored `createdByUserId` (or `organizationId`) as an ObjectId - or a populated doc reached
+   * the actor org - a raw `===` would fail SILENTLY: the lake is never trusted, no error anywhere.
+   * Lock the coercion (createdByUserId via String(), organizationId via normalizeId; see #1281/#1343).
    */
   it('trusts an owner whose lake id is ObjectId-like rather than a plain string', async () => {
     const objectIdLike = { toString: () => OWNER } as unknown as string;
@@ -81,13 +82,30 @@ describe('getAccessibleDataLakePrompts', () => {
     expect(prompts.map(p => p.name)).toEqual(['Lake One']);
   });
 
-  it('trusts an org lake whose organizationId is ObjectId-like rather than a plain string', async () => {
-    const objectIdLike = { toString: () => ORG } as unknown as string;
+  it('trusts an org lake whose organizationId is an ObjectId rather than a plain string', async () => {
+    // A real ObjectId exposes toHexString - the shape normalizeId reads (raw String() on a populated
+    // doc would yield "[object Object]"). The lake side is normalized inside isTrustedForInjection.
+    const objectId = { toHexString: () => ORG } as unknown as string;
     const prompts = await getAccessibleDataLakePrompts(
-      makeContext([makeLake({ createdByUserId: 'colleague', organizationId: objectIdLike })], {
+      makeContext([makeLake({ createdByUserId: 'colleague', organizationId: objectId })], {
         id: 'me',
         tags: [],
         organizationId: ORG,
+      })
+    );
+    expect(prompts.map(p => p.name)).toEqual(['Lake One']);
+  });
+
+  it('trusts an org lake for a POPULATED-document actor org vs a String lake org (#1343)', async () => {
+    // The #1343 shape: a .populate('organizationId') upstream hands the actor a full Organization
+    // doc. Normalized at the resolver seam to its hex, it agrees with the lake's stored String org;
+    // a raw String(actor) would be "[object Object]" and silently deny injection.
+    const populatedActorOrg = { _id: { toHexString: () => ORG }, name: 'Acme' } as unknown as string;
+    const prompts = await getAccessibleDataLakePrompts(
+      makeContext([makeLake({ createdByUserId: 'colleague', organizationId: ORG })], {
+        id: 'me',
+        tags: [],
+        organizationId: populatedActorOrg,
       })
     );
     expect(prompts.map(p => p.name)).toEqual(['Lake One']);

--- a/b4m-core/services/src/dataLakeService/getDataLakePrompts.ts
+++ b/b4m-core/services/src/dataLakeService/getDataLakePrompts.ts
@@ -1,5 +1,6 @@
 import { DATALAKE_TAG_PREFIX, lakeMatchesAccess, normalizeEntitlementKey } from '@bike4mind/common';
 import type { IDataLakeDocument } from '@bike4mind/common';
+import { normalizeId } from '@bike4mind/utils/normalizeId';
 import type { DataLakeAccessContext } from './getDynamicDataLakeTags';
 
 /**
@@ -39,17 +40,20 @@ export interface DataLakePrompt {
  * governance path). The surviving lakes are rendered by renderDataLakePromptSection at each
  * retrieval-scoped injection site (forced retrieval + the model-driven knowledge tools).
  *
- * Both sides of each comparison are String-coerced (behind a truthiness guard, so an absent
- * value never becomes the string "undefined"). The schema stores these as Strings today, but an
- * ObjectId-vs-String comparison would fail SILENTLY - denying injection with no error - which is
- * the hard failure mode to notice. Same reasoning as the actor-side coercion in the resolver.
+ * Both sides of the org comparison are normalized through normalizeId (which yields undefined for
+ * an absent value, so it never becomes the string "undefined"). The schema stores these as Strings
+ * today, but an ObjectId- or populated-document-vs-String comparison would fail SILENTLY - denying
+ * injection with no error - which is the hard failure mode to notice. Same reasoning and normalizer
+ * as the actor-side coercion in the resolver (#1281 / @bike4mind/utils/normalizeId).
  */
 function isTrustedForInjection(
   lake: Pick<IDataLakeDocument, 'createdByUserId' | 'organizationId'>,
   actor: { userId?: string; organizationId?: string }
 ): boolean {
   if (actor.userId && lake.createdByUserId && String(lake.createdByUserId) === actor.userId) return true;
-  return !!lake.organizationId && !!actor.organizationId && String(lake.organizationId) === actor.organizationId;
+  const lakeOrg = normalizeId(lake.organizationId);
+  const actorOrg = normalizeId(actor.organizationId);
+  return !!lakeOrg && !!actorOrg && lakeOrg === actorOrg;
 }
 
 /**
@@ -92,9 +96,9 @@ export async function getAccessibleDataLakePrompts(
 
   const userTags = context.user.tags || [];
   const entitlementKeys = context.entitlementKeys ?? [];
-  // String-coerce for the same reason getDynamicDataLakeAccess does: a hydrated user doc
-  // carries ObjectIds, and the lake's owner/org fields are Strings.
-  const organizationId = context.user.organizationId ? String(context.user.organizationId) : undefined;
+  // Normalize for the same reason getDynamicDataLakeAccess does: a hydrated user doc carries an
+  // ObjectId (or a populated Organization document), and the lake's owner/org fields are Strings.
+  const organizationId = normalizeId(context.user.organizationId);
   const userId = context.user.id ? String(context.user.id) : undefined;
 
   let lakes: IDataLakeDocument[];

--- a/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.test.ts
+++ b/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.test.ts
@@ -73,15 +73,26 @@ describe('getDynamicDataLakeAccess — entitlement-aware lake resolution', () =>
     expect(spy).toHaveBeenCalledWith([], [], undefined, undefined);
   });
 
-  it('string-coerces non-string organizationId + id (hydrated ObjectIds) before querying', async () => {
+  it('normalizes an ObjectId organizationId (and string-coerces id) before querying', async () => {
     const spy = vi.fn().mockResolvedValue([]);
-    // Simulates a hydrated user doc carrying ObjectIds - no cast needed now that the
-    // context type accepts ObjectId-like values.
+    // Simulates a hydrated user doc: organizationId arrives as an ObjectId (exposes toHexString),
+    // id as an ObjectId-like value. normalizeId yields the org hex; id keeps its String() coercion.
     await getDynamicDataLakeAccess({
       db: { dataLakes: { findActiveByUserTagsAndEntitlements: spy } as never },
-      user: { id: { toString: () => 'user-oid' }, tags: [], organizationId: { toString: () => 'org-oid' } },
+      user: { id: { toString: () => 'user-oid' }, tags: [], organizationId: { toHexString: () => 'org-oid' } },
     });
     expect(spy).toHaveBeenCalledWith([], [], 'org-oid', 'user-oid');
+  });
+
+  it('normalizes a POPULATED-document organizationId to its hex, never "[object Object]" (#1343)', async () => {
+    const spy = vi.fn().mockResolvedValue([]);
+    // A .populate('organizationId') upstream would hand a full Organization doc here. Raw String()
+    // would make the org filter "[object Object]" and match no org lake; normalizeId reads its _id.
+    await getDynamicDataLakeAccess({
+      db: { dataLakes: { findActiveByUserTagsAndEntitlements: spy } as never },
+      user: { tags: [], organizationId: { _id: { toHexString: () => 'org-hex' }, name: 'Acme' } },
+    });
+    expect(spy).toHaveBeenCalledWith([], [], 'org-hex', undefined);
   });
 
   it('drops a DB lake that carries a static-registry meta-tag, gate or no gate', async () => {

--- a/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.ts
+++ b/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.ts
@@ -10,6 +10,14 @@ import { normalizeId } from '@bike4mind/utils/normalizeId';
 import { buildDatalakeTag } from './createDataLake';
 
 /**
+ * An id value `normalizeId` resolves: a plain string, a Mongo ObjectId (via `toHexString`), or a
+ * populated Mongoose document (`{ _id }` / string `{ id }`). Deliberately excludes a bare
+ * `{ toString(): string }` - `normalizeId` ignores that shape and returns undefined - which is why
+ * `organizationId` uses this while `id`, still `String()`-coerced, keeps the wider `toString` form.
+ */
+type NormalizableId = string | { toHexString(): string } | { _id: unknown } | { id: string };
+
+/**
  * The minimal context the data-lake access resolver needs. The knowledge tools
  * (ToolContext), the forced-retrieval feature (ChatCompletionContext), and the app-layer
  * semantic-search route (via server/dataLakes/resolveRetrievalLakeScope) all satisfy this
@@ -27,13 +35,14 @@ export interface DataLakeAccessContext {
    * The caller. `organizationId` scopes org lakes (org-less lakes stay open to all);
    * `id` is the owner bypass - the caller always retrieves their own lakes (re-checked in
    * memory against each lake's persisted `createdByUserId`, not assumed from the query), and a
-   * gateless org-less lake is owner-only (Private-by-default). Both accept an ObjectId-like
-   * value too (a hydrated user doc carries ObjectIds); they're string-coerced before querying.
+   * gateless org-less lake is owner-only (Private-by-default). A hydrated user doc carries
+   * ObjectIds, so `organizationId` is resolved via `normalizeId` (string, ObjectId, or populated
+   * `{ _id }` doc) while `id` is `String()`-coerced before querying.
    */
   user: {
     id?: string | { toString(): string } | null;
     tags?: string[] | null;
-    organizationId?: string | { toString(): string } | null;
+    organizationId?: NormalizableId | null;
   };
   /** Caller's resolved entitlement keys; absent means tag-only matching. */
   entitlementKeys?: string[];

--- a/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.ts
+++ b/b4m-core/services/src/dataLakeService/getDynamicDataLakeTags.ts
@@ -6,6 +6,7 @@ import {
   type IDataLakeRepository,
 } from '@bike4mind/common';
 import type { Logger } from '@bike4mind/observability';
+import { normalizeId } from '@bike4mind/utils/normalizeId';
 import { buildDatalakeTag } from './createDataLake';
 
 /**
@@ -75,9 +76,11 @@ export async function getDynamicDataLakeAccess(
 ): Promise<{ dataLakeTags: string[]; dataLakeTagPrefixes: string[]; scopedTagPrefixes: string[] }> {
   const userTags = context.user.tags || [];
   const entitlementKeys = context.entitlementKeys ?? [];
-  // Coerce to string: the lake's organizationId/createdByUserId are String fields, but a
-  // hydrated user doc may carry ObjectIds here - an ObjectId query against a String never matches.
-  const organizationId = context.user.organizationId ? String(context.user.organizationId) : undefined;
+  // Coerce to string: the lake's organizationId/createdByUserId are String fields, but a hydrated
+  // user doc may carry an ObjectId - or a populated Organization document - here, and an
+  // ObjectId/document query against a String never matches. normalizeId handles all three shapes;
+  // plain String() would turn a populated doc into "[object Object]" (#1281 / @bike4mind/utils/normalizeId).
+  const organizationId = normalizeId(context.user.organizationId);
   const userId = context.user.id ? String(context.user.id) : undefined;
   let dynamicDataLakes: DataLakeConfig[] | undefined;
   // Ids of fetched lakes whose PERSISTED createdByUserId is this caller. Read off the raw


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

No UI changed - proof is the executable verification (populated-doc org cases green at all three sites).

**Services tests (42 passed):**

<img width="3600" height="1036" alt="1" src="https://github.com/user-attachments/assets/e549241b-76d3-4cfd-a9b2-ad27bc8cade0" />


**Client tests (14 passed):**

<img width="3600" height="1752" alt="2" src="https://github.com/user-attachments/assets/185f2b1d-44d1-492e-933a-7ad8d87be5c9" />


**Before/after repro:** temporarily reverting the coercion to raw `String(...)` turns the org filter
into `"[object Object]"` (test RED); restoring `normalizeId` yields the hex (test GREEN). This is a
unit-level repro by necessity - the populated-document shape cannot be produced through the app (see
Guide for Testers), so the bug is only demonstrable where the shape can be constructed directly.

<img width="3600" height="1032" alt="3" src="https://github.com/user-attachments/assets/149485a4-8408-4efa-8a1e-3ef7f519f9e8" />



## Description

Closes #1343. Convergence follow-up to #1281.

#1281 added `normalizeId` (`@bike4mind/utils/normalizeId`) - the one coercion that handles all
three shapes an org id arrives in: a plain string, a Mongo `ObjectId` (via `toHexString`), and a
populated Mongoose document (`{ _id, ... }`) - but scoped it to the MANAGEMENT path. The RETRIEVAL
path still coerced the org id with raw `String(...)`.

`String()` is correct for a string and an `ObjectId` (it yields the hex), but for a
populated-document it yields `"[object Object]"`. Used as the org filter in
`findActiveByUserTagsAndEntitlements`, that value matches no org-scoped lakes, so the caller
silently gets none of their org's dynamic data-lake tags or org system-prompts for that turn. It
fails CLOSED (no over-exposure) - the hard-to-notice mode the surrounding comments already warn
about.

**This is latent, not a live incident.** The populated-document org shape is produced only by the
repo's `.populate('organizationId')` call sites (REST/admin/analytics endpoints such as `feedback`
and `users`), none of which feed retrieval - the retrieval `context.user` is loaded via `findById`
with no populate, so its `organizationId` is always an `ObjectId`, which `String()` coerces
correctly. So no shape that reaches this path today behaves differently. The point is to stop the
same feature area from drifting back into the exact bug class #1281 fixed, using the normalizer that
already handles every shape.

## Changes

- `getDynamicDataLakeAccess` (`getDynamicDataLakeTags.ts`): coerce caller `organizationId` with
  `normalizeId` instead of `String(...)`.
- `getAccessibleDataLakePrompts` (`getDataLakePrompts.ts`): same at the resolver, plus normalize
  BOTH sides of the org compare in `isTrustedForInjection` so a populated-doc actor org and a
  stored-String lake org agree.
- `resolveRetrievalLakeScope` (`apps/client/server/dataLakes/`): normalize `user.organizationId`
  once at the retrieval-context seam, mirroring `toAccessContext` on the management side (#1281).
- `userId` / `createdByUserId` coercions left untouched - scoped to the org id per #1343.
- Import via the `@bike4mind/utils/normalizeId` subpath (as #1281 did), not the utils barrel.

Tests (new populated-document case at each site; ObjectId stand-ins moved to the realistic
`{ toHexString }` shape):
- `getDynamicDataLakeTags.test.ts`: populated-doc org id reaches the DB filter as hex, never
  `"[object Object]"`.
- `getDataLakePrompts.test.ts`: populated-doc actor org vs stored-String lake org resolves as
  TRUSTED (injection allowed).
- `resolveRetrievalLakeScope.test.ts`: populated-doc org id is normalized to hex at the seam.

## Guide for Testers

**The fix cannot be exercised through the app, by design.** The bug only manifests for the
populated-document org shape, and that shape never reaches the retrieval path (retrieval's
`context.user.organizationId` is always an `ObjectId`, which `String()` already coerces correctly).
So there is no before/after behavior to observe on the preview build.

- **Actual correctness** is proved by the unit tests (the populated-doc cases at all three sites),
  which are green - see the screenshots at the top. That is the real verification for this PR.
- **The preview build is a regression net only** - it confirms the common `ObjectId` path was not
  narrowed. The check below would pass identically with or without this diff; run it only to confirm
  nothing broke, not to see the fix work.

### Regression Checks

One org account is enough - no need to provision multiple orgs:

1. Sign in at `app.staging.bike4mind.com` as an org member whose org has an org-scoped data lake.
2. Start a chat with a message that retrieves from that lake (e.g. ask about a document only that
   lake contains). Expected: the lake's files are still retrieved, its org system-prompt still
   applies, and no error appears.
3. Optional, to go further: sign in as a member of a DIFFERENT org and repeat step 2. Expected: that
   lake's content and prompt still do NOT apply (org stays a hard prerequisite - access was not
   widened).

### What NOT to test

- No UI changed - there is no new screen, control, or setting to exercise.
- Do not try to trigger the populated-document org shape through the app: it is never produced on
  the retrieval path, so it cannot be reached from the UI. It is covered by the unit tests, which is
  the entire point of this defense.

## Additional Information

- Out of scope (per #1343): the management path is already normalized in #1281 (`toAccessContext`,
  `canAccessLake`, `resolveFallbackLake`) and is not re-touched.
- Both retrieval entrypoints (`resolveRetrievalLakeScope` and the chat process via
  `ChatCompletionFeatures.resolveDataLakeAccess`) funnel through the two shared functions converted
  here, so no raw `String(...)` org-id coercion remains on the retrieval path.

## Developer Notes (Optional)

- **Reusable pattern**: `normalizeId` (`@bike4mind/utils/normalizeId`) is now the single org-id
  coercion on BOTH the management (#1281) and retrieval (#1343) data-lake paths. Any new site that
  coerces an org id from a `context.user` / actor should use it rather than raw `String(...)`, so a
  populated-Mongoose-document shape can never collapse to `"[object Object]"`.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A
