### PR TITLE
feat(organizations): raise seat ceiling to admit partner-rule signups at capacity

### DIFF
--- a/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
+++ b/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
@@ -180,8 +180,9 @@ export default function PartnerSignupRulesTab() {
       setBackfillTarget(null);
       toast.success(
         `Backfill complete: ${result.added} added` +
+          (result.seatRaised ? `, ${result.seatRaised} seat${result.seatRaised === 1 ? '' : 's'} added` : '') +
           (result.alreadyMember ? `, ${result.alreadyMember} already members` : '') +
-          (result.atCapacity ? `, ${result.atCapacity} skipped (org full)` : '') +
+          (result.atCapacity ? `, ${result.atCapacity} at capacity (Stripe org - add seats)` : '') +
           (result.failed ? `, ${result.failed} failed` : '')
       );
     },
@@ -633,6 +634,19 @@ export default function PartnerSignupRulesTab() {
               <Typography level="title-md">
                 {backfillPreview?.matched ?? 0} user{(backfillPreview?.matched ?? 0) === 1 ? '' : 's'} will be added
               </Typography>
+              {backfillPreview && (
+                <Typography
+                  level="body-sm"
+                  sx={{ mt: 0.5, color: 'text.secondary' }}
+                  data-testid="partner-rule-backfill-seat-impact"
+                >
+                  {backfillPreview.stripeBilled
+                    ? `Stripe-billed org: seat ceiling stays at ${backfillPreview.seats}; candidates past it are rejected (add seats to admit them).`
+                    : backfillPreview.projectedSeats > backfillPreview.seats
+                      ? `Seat ceiling: ${backfillPreview.seats} -> ${backfillPreview.projectedSeats} (raised to fit)`
+                      : `Seat ceiling: ${backfillPreview.seats} (unchanged; everyone fits under it)`}
+                </Typography>
+              )}
               {!!backfillPreview?.sample.length && (
                 <Stack spacing={0.25} sx={{ mt: 1, maxHeight: 180, overflow: 'auto' }}>
                   {backfillPreview.sample.map(user => (

--- a/apps/client/app/utils/partnerSignupRuleAPICalls.ts
+++ b/apps/client/app/utils/partnerSignupRuleAPICalls.ts
@@ -50,6 +50,11 @@ export type BackfillPreview = {
   organizationId: string;
   domain: string;
   matched: number;
+  /** Current seat ceiling and the projected ceiling after commit (#1239 - the seat blast radius). */
+  seats: number;
+  projectedSeats: number;
+  /** Stripe-billed orgs keep their ceiling (candidates past it are rejected, never silently billed). */
+  stripeBilled: boolean;
   sample: Array<{ id: string; email?: string; name: string }>;
 };
 
@@ -59,7 +64,10 @@ export type BackfillResult = {
   domain: string;
   matched: number;
   added: number;
+  /** Adds that also raised the org's seat ceiling (subset of `added`, non-Stripe orgs only). */
+  seatRaised: number;
   alreadyMember: number;
+  /** Candidates a full Stripe-billed org couldn't admit without an out-of-band (billed) seat raise. */
   atCapacity: number;
   unverified: number;
   failed: number;

--- a/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
@@ -68,16 +68,21 @@ const handler = baseApi().post(
       });
     }
 
-    const tally = { added: 0, alreadyMember: 0, atCapacity: 0, unverified: 0, failed: 0 };
+    // `seatRaised` counts adds that also lifted the org's seat ceiling (#1239): a full org no longer
+    // rejects a domain candidate, it raises to fit. It's a subset of `added`, surfaced separately so
+    // the admin sees how much the backfill grew the seat count. The admin already sees this tally, so
+    // the per-signup Slack alert is intentionally NOT fired for a deliberate bulk backfill.
+    const tally = { added: 0, seatRaised: 0, alreadyMember: 0, unverified: 0, failed: 0 };
     for (const candidate of candidates) {
       try {
         const result = await organizationService.applyPartnerRuleMembership(
           { userId: candidate.id, organizationId: rule.organizationId },
           { db: { users: userRepository, organizations: organizationRepository }, logger: req.logger }
         );
-        if (result.added) tally.added += 1;
-        else if (result.reason === 'already-member') tally.alreadyMember += 1;
-        else if (result.reason === 'at-capacity') tally.atCapacity += 1;
+        if (result.added) {
+          tally.added += 1;
+          if (result.reason === 'added-seat-raised') tally.seatRaised += 1;
+        } else if (result.reason === 'already-member') tally.alreadyMember += 1;
         else tally.unverified += 1; // 'unverified' | 'org-missing' | 'user-missing' - candidate was verified, so effectively a skip
       } catch (error) {
         tally.failed += 1;

--- a/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
@@ -6,6 +6,8 @@ import { partnerSignupRuleRepository, userRepository, organizationRepository } f
 import { organizationService } from '@bike4mind/services';
 import { assertOrganizationExists } from '@server/entitlements/assertOrganizationExists';
 import { escapeRegex } from '@bike4mind/utils/escapeRegex';
+import { auditSeatCeilingRaised } from '@server/organizations/notifySeatCeilingRaised';
+import { postMessageToSlack } from '@server/integrations/slack/slack';
 import { z } from 'zod';
 
 /**
@@ -58,21 +60,34 @@ const handler = baseApi().post(
     const memberIds = new Set((organization?.users ?? []).map(u => u.userId));
     const candidates = domainUsers.filter(u => !memberIds.has(u.id));
 
+    // Since a commit can now grow the seat ceiling (#1239), the preview surfaces the seat/billing
+    // blast radius, not just the head count. A Stripe-billed org keeps its ceiling (candidates past
+    // it are rejected, not billed silently); a non-Stripe org raises to fit the whole backfill.
+    const currentSeats = organization?.seats ?? 0;
+    const currentMembers = organization?.users?.length ?? 0;
+    const stripeBilled = !!organization?.stripeCustomerId;
+    const projectedSeats = stripeBilled ? currentSeats : Math.max(currentSeats, currentMembers + candidates.length);
+
     if (!body.commit) {
       return res.status(200).json({
         dryRun: true,
         organizationId: rule.organizationId,
         domain: rule.domain,
         matched: candidates.length,
+        seats: currentSeats,
+        projectedSeats,
+        stripeBilled,
         sample: candidates.slice(0, SAMPLE_LIMIT).map(u => ({ id: u.id, email: u.email, name: u.name })),
       });
     }
 
-    // `seatRaised` counts adds that also lifted the org's seat ceiling (#1239): a full org no longer
-    // rejects a domain candidate, it raises to fit. It's a subset of `added`, surfaced separately so
-    // the admin sees how much the backfill grew the seat count. The admin already sees this tally, so
-    // the per-signup Slack alert is intentionally NOT fired for a deliberate bulk backfill.
-    const tally = { added: 0, seatRaised: 0, alreadyMember: 0, unverified: 0, failed: 0 };
+    // `seatRaised` counts adds that also lifted the org's seat ceiling (#1239): a full non-Stripe org
+    // raises to fit rather than rejecting; a full Stripe-billed org keeps its ceiling and the candidate
+    // is counted in `atCapacity`. Each raise still writes a durable ORG_SEAT_CEILING_RAISED audit event
+    // (actor = the admin running the backfill); the per-candidate Slack ping is skipped for a deliberate
+    // bulk action, replaced by one summary post after the loop.
+    const actingAdminId = req.user?.id;
+    const tally = { added: 0, seatRaised: 0, atCapacity: 0, alreadyMember: 0, unverified: 0, failed: 0 };
     for (const candidate of candidates) {
       try {
         const result = await organizationService.applyPartnerRuleMembership(
@@ -81,8 +96,22 @@ const handler = baseApi().post(
         );
         if (result.added) {
           tally.added += 1;
-          if (result.reason === 'added-seat-raised') tally.seatRaised += 1;
-        } else if (result.reason === 'already-member') tally.alreadyMember += 1;
+          if (result.reason === 'added-seat-raised') {
+            tally.seatRaised += 1;
+            await auditSeatCeilingRaised(
+              {
+                organizationId: rule.organizationId,
+                userId: candidate.id,
+                previousSeats: result.previousSeats,
+                newSeats: result.newSeats,
+                trigger: 'admin-backfill',
+                actingAdminId,
+              },
+              req.logger
+            );
+          }
+        } else if (result.reason === 'at-capacity') tally.atCapacity += 1;
+        else if (result.reason === 'already-member') tally.alreadyMember += 1;
         else tally.unverified += 1; // 'unverified' | 'org-missing' | 'user-missing' - candidate was verified, so effectively a skip
       } catch (error) {
         tally.failed += 1;
@@ -91,6 +120,19 @@ const handler = baseApi().post(
           error
         );
       }
+    }
+
+    if (tally.seatRaised > 0) {
+      // One LiveOps summary for the whole bulk raise (per-candidate Slack is intentionally skipped).
+      await postMessageToSlack(
+        `🎟️ *Org seat ceiling auto-raised (admin backfill)*\n` +
+          `*Organization:* ${rule.organizationId}\n` +
+          `*Ceiling grown by:* ${tally.seatRaised} seat${tally.seatRaised === 1 ? '' : 's'}\n` +
+          `*Domain:* ${rule.domain}\n` +
+          `*Run by admin:* ${actingAdminId ?? 'unknown'}`
+      ).catch(err =>
+        req.logger.error(`Partner-rule backfill seat-raise summary alert failed for org ${rule.organizationId}`, err)
+      );
     }
 
     return res.status(200).json({

--- a/apps/client/pages/api/email/verify.ts
+++ b/apps/client/pages/api/email/verify.ts
@@ -17,7 +17,10 @@ import { AuthEvents } from '@bike4mind/common';
 import { logAuditEvent, EmailAuditEvents, calculateTokenAge } from '@server/utils/auditLog';
 import { entitlementsForEmail, signupCreditsForKeys } from '@client/lib/entitlements/registry';
 import { partnerSignupGrantForEmail } from '@server/entitlements/partnerRules';
-import { notifySeatCeilingRaised } from '@server/organizations/notifySeatCeilingRaised';
+import {
+  notifySeatCeilingRaised,
+  notifyPartnerSignupBlockedAtCapacity,
+} from '@server/organizations/notifySeatCeilingRaised';
 import { pushEntitlementInvalidation } from '@server/entitlements/invalidate';
 import { z } from 'zod';
 
@@ -218,13 +221,25 @@ const handler = baseApi({ auth: false })
                 {
                   organizationId: partnerOrganizationId,
                   userId: userBeforeVerify.id,
-                  previousSeats: result.previousSeats!,
-                  newSeats: result.newSeats!,
+                  previousSeats: result.previousSeats,
+                  newSeats: result.newSeats,
                   trigger: 'email-verification',
                 },
                 req.logger
               );
             }
+          } else if (result.reason === 'at-capacity') {
+            // Stripe-billed org at capacity; its ceiling isn't auto-raised, so alert an admin to add
+            // seats and admit this stranded partner user. Best-effort, never throws.
+            await notifyPartnerSignupBlockedAtCapacity(
+              {
+                organizationId: partnerOrganizationId,
+                userId: userBeforeVerify.id,
+                seats: result.seats,
+                trigger: 'email-verification',
+              },
+              req.logger
+            );
           } else if (result.reason === 'org-missing') {
             // Surfaces a misconfiguration (dangling org ref) without failing verification.
             req.logger.warn(

--- a/apps/client/pages/api/email/verify.ts
+++ b/apps/client/pages/api/email/verify.ts
@@ -17,6 +17,7 @@ import { AuthEvents } from '@bike4mind/common';
 import { logAuditEvent, EmailAuditEvents, calculateTokenAge } from '@server/utils/auditLog';
 import { entitlementsForEmail, signupCreditsForKeys } from '@client/lib/entitlements/registry';
 import { partnerSignupGrantForEmail } from '@server/entitlements/partnerRules';
+import { notifySeatCeilingRaised } from '@server/organizations/notifySeatCeilingRaised';
 import { pushEntitlementInvalidation } from '@server/entitlements/invalidate';
 import { z } from 'zod';
 
@@ -211,8 +212,21 @@ const handler = baseApi({ auth: false })
             req.logger.info(
               `Partner-rule org membership: added verified user ${userBeforeVerify.id} to org ${partnerOrganizationId}`
             );
-          } else if (result.reason === 'org-missing' || result.reason === 'at-capacity') {
-            // Surfaces a misconfiguration (dangling org ref / full org) without failing verification.
+            if (result.reason === 'added-seat-raised') {
+              // Membership + raise already committed; the alert/audit is best-effort and never throws.
+              await notifySeatCeilingRaised(
+                {
+                  organizationId: partnerOrganizationId,
+                  userId: userBeforeVerify.id,
+                  previousSeats: result.previousSeats!,
+                  newSeats: result.newSeats!,
+                  trigger: 'email-verification',
+                },
+                req.logger
+              );
+            }
+          } else if (result.reason === 'org-missing') {
+            // Surfaces a misconfiguration (dangling org ref) without failing verification.
             req.logger.warn(
               `Partner-rule org membership not applied for user ${userBeforeVerify.id} ` +
                 `(org ${partnerOrganizationId}): ${result.reason}`

--- a/apps/client/pages/api/otc/verify.ts
+++ b/apps/client/pages/api/otc/verify.ts
@@ -19,7 +19,10 @@ import {
 import { creditService, userService, organizationService, authSessionService } from '@bike4mind/services';
 import { entitlementsForEmail, signupCreditsForKeys } from '@client/lib/entitlements/registry';
 import { partnerSignupGrantForEmail } from '@server/entitlements/partnerRules';
-import { notifySeatCeilingRaised } from '@server/organizations/notifySeatCeilingRaised';
+import {
+  notifySeatCeilingRaised,
+  notifyPartnerSignupBlockedAtCapacity,
+} from '@server/organizations/notifySeatCeilingRaised';
 import { baseApi } from '@server/middlewares/baseApi';
 import { checkBlockedIP } from '@server/middlewares/checkBlockedIP';
 import { rateLimit } from '@server/middlewares/rateLimit';
@@ -397,13 +400,25 @@ const handler = baseApi({ auth: false })
               {
                 organizationId: partnerOrganizationId,
                 userId: newUser.id,
-                previousSeats: result.previousSeats!,
-                newSeats: result.newSeats!,
+                previousSeats: result.previousSeats,
+                newSeats: result.newSeats,
                 trigger: 'otc-signup',
               },
               req.logger
             );
           }
+        } else if (result.reason === 'at-capacity') {
+          // A Stripe-billed org was full and its ceiling isn't auto-raised; alert an admin to add
+          // seats so this stranded partner user can be admitted. Best-effort, never throws.
+          await notifyPartnerSignupBlockedAtCapacity(
+            {
+              organizationId: partnerOrganizationId,
+              userId: newUser.id,
+              seats: result.seats,
+              trigger: 'otc-signup',
+            },
+            req.logger
+          );
         } else if (result.reason === 'org-missing') {
           req.logger.warn(
             `Partner-rule org membership not applied for OTC user ${newUser.id} ` +

--- a/apps/client/pages/api/otc/verify.ts
+++ b/apps/client/pages/api/otc/verify.ts
@@ -19,6 +19,7 @@ import {
 import { creditService, userService, organizationService, authSessionService } from '@bike4mind/services';
 import { entitlementsForEmail, signupCreditsForKeys } from '@client/lib/entitlements/registry';
 import { partnerSignupGrantForEmail } from '@server/entitlements/partnerRules';
+import { notifySeatCeilingRaised } from '@server/organizations/notifySeatCeilingRaised';
 import { baseApi } from '@server/middlewares/baseApi';
 import { checkBlockedIP } from '@server/middlewares/checkBlockedIP';
 import { rateLimit } from '@server/middlewares/rateLimit';
@@ -390,7 +391,20 @@ const handler = baseApi({ auth: false })
         if (result.added) {
           newUser.organizationId = partnerOrganizationId;
           req.logger.info(`Partner-rule org membership: added OTC user ${newUser.id} to org ${partnerOrganizationId}`);
-        } else if (result.reason === 'org-missing' || result.reason === 'at-capacity') {
+          if (result.reason === 'added-seat-raised') {
+            // Never awaited-into-failure: the join already committed; the alert/audit is best-effort.
+            await notifySeatCeilingRaised(
+              {
+                organizationId: partnerOrganizationId,
+                userId: newUser.id,
+                previousSeats: result.previousSeats!,
+                newSeats: result.newSeats!,
+                trigger: 'otc-signup',
+              },
+              req.logger
+            );
+          }
+        } else if (result.reason === 'org-missing') {
           req.logger.warn(
             `Partner-rule org membership not applied for OTC user ${newUser.id} ` +
               `(org ${partnerOrganizationId}): ${result.reason}`

--- a/apps/client/server/organizations/notifySeatCeilingRaised.test.ts
+++ b/apps/client/server/organizations/notifySeatCeilingRaised.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPostToSlack = vi.fn();
+const mockLogAuditEvent = vi.fn();
+
+vi.mock('@server/integrations/slack/slack', () => ({
+  postMessageToSlack: (...args: unknown[]) => mockPostToSlack(...args),
+}));
+
+vi.mock('@server/utils/auditLog', () => ({
+  AdminOrgAuditEvents: { ORG_SEAT_CEILING_RAISED: 'ORG_SEAT_CEILING_RAISED' },
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+}));
+
+import {
+  auditSeatCeilingRaised,
+  notifySeatCeilingRaised,
+  notifyPartnerSignupBlockedAtCapacity,
+} from './notifySeatCeilingRaised';
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe('auditSeatCeilingRaised', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogAuditEvent.mockResolvedValue(undefined);
+    mockPostToSlack.mockResolvedValue(undefined);
+  });
+
+  it('writes the ORG_SEAT_CEILING_RAISED audit event and does NOT post to Slack', async () => {
+    await auditSeatCeilingRaised(
+      { organizationId: 'org-1', userId: 'user-1', previousSeats: 2, newSeats: 3, trigger: 'otc-signup' },
+      logger
+    );
+
+    expect(mockPostToSlack).not.toHaveBeenCalled();
+    expect(mockLogAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        action: 'ORG_SEAT_CEILING_RAISED',
+        metadata: { organizationId: 'org-1', previousSeats: 2, newSeats: 3, trigger: 'otc-signup' },
+      }),
+      logger
+    );
+    // No admin actor on a live signup.
+    expect(mockLogAuditEvent.mock.calls[0][0]).not.toHaveProperty('adminUserId');
+  });
+
+  it('records the acting admin as the audit actor for a bulk backfill raise', async () => {
+    await auditSeatCeilingRaised(
+      {
+        organizationId: 'org-1',
+        userId: 'user-1',
+        previousSeats: 4,
+        newSeats: 5,
+        trigger: 'admin-backfill',
+        actingAdminId: 'admin-9',
+      },
+      logger
+    );
+
+    expect(mockLogAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ adminUserId: 'admin-9', metadata: expect.objectContaining({ trigger: 'admin-backfill' }) }),
+      logger
+    );
+  });
+});
+
+describe('notifySeatCeilingRaised', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogAuditEvent.mockResolvedValue(undefined);
+    mockPostToSlack.mockResolvedValue(undefined);
+  });
+
+  it('posts the Slack alert AND writes the audit event for a live signup raise', async () => {
+    await notifySeatCeilingRaised(
+      { organizationId: 'org-1', userId: 'user-1', previousSeats: 2, newSeats: 3, trigger: 'email-verification' },
+      logger
+    );
+
+    expect(mockPostToSlack).toHaveBeenCalledTimes(1);
+    expect(mockPostToSlack.mock.calls[0][0]).toContain('2 -> 3');
+    expect(mockLogAuditEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws when Slack fails - a signup already committed must not be broken', async () => {
+    mockPostToSlack.mockRejectedValue(new Error('slack down'));
+
+    await expect(
+      notifySeatCeilingRaised(
+        { organizationId: 'org-1', userId: 'user-1', previousSeats: 2, newSeats: 3, trigger: 'otc-signup' },
+        logger
+      )
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+describe('notifyPartnerSignupBlockedAtCapacity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPostToSlack.mockResolvedValue(undefined);
+  });
+
+  it('posts a Slack alert naming the blocked user and the full ceiling', async () => {
+    await notifyPartnerSignupBlockedAtCapacity(
+      { organizationId: 'org-1', userId: 'user-1', seats: 2, trigger: 'otc-signup' },
+      logger
+    );
+
+    expect(mockPostToSlack).toHaveBeenCalledTimes(1);
+    const message = mockPostToSlack.mock.calls[0][0] as string;
+    expect(message).toContain('user-1');
+    expect(message).toContain('2');
+  });
+
+  it('never throws when Slack fails', async () => {
+    mockPostToSlack.mockRejectedValue(new Error('slack down'));
+
+    await expect(
+      notifyPartnerSignupBlockedAtCapacity(
+        { organizationId: 'org-1', userId: 'user-1', seats: 2, trigger: 'email-verification' },
+        logger
+      )
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/apps/client/server/organizations/notifySeatCeilingRaised.ts
+++ b/apps/client/server/organizations/notifySeatCeilingRaised.ts
@@ -1,0 +1,65 @@
+import { postMessageToSlack } from '@server/integrations/slack/slack';
+import { AdminOrgAuditEvents, logAuditEvent } from '@server/utils/auditLog';
+
+interface SeatCeilingRaisedLogger {
+  info: (message: string, ...args: unknown[]) => void;
+  warn: (message: string, ...args: unknown[]) => void;
+  error: (message: string, ...args: unknown[]) => void;
+}
+
+interface NotifySeatCeilingRaisedParams {
+  organizationId: string;
+  /** The domain-verified user admitted by the raise. */
+  userId: string;
+  previousSeats: number;
+  newSeats: number;
+  /** Which signup route triggered the raise - carried into the alert + audit for traceability. */
+  trigger: 'otc-signup' | 'email-verification';
+}
+
+/**
+ * Fire the human ALERT (Slack) + AUDIT record for a partner-rule seat-ceiling raise (#1239).
+ *
+ * Domain-signup provisioning raises the seat ceiling rather than rejecting a legit partner user at
+ * capacity, so the billing owner's seat count can grow without any admin action. That is only
+ * acceptable if every raise is loud: this posts to the LiveOps Slack channel AND writes an
+ * ORG_SEAT_CEILING_RAISED audit event so "who added seats and why" is always answerable.
+ *
+ * Best-effort and never throws: both underlying calls swallow their own errors, and this wraps them
+ * so an alerting hiccup can never break an already-successful signup/verification. The core service
+ * has already committed the membership + seat raise by the time this runs.
+ */
+export async function notifySeatCeilingRaised(
+  { organizationId, userId, previousSeats, newSeats, trigger }: NotifySeatCeilingRaisedParams,
+  logger?: SeatCeilingRaisedLogger
+): Promise<void> {
+  try {
+    await Promise.all([
+      postMessageToSlack(
+        `🎟️ *Org seat ceiling auto-raised*\n` +
+          `*Organization:* ${organizationId}\n` +
+          `*Seats:* ${previousSeats} -> ${newSeats}\n` +
+          `*Admitted user:* ${userId}\n` +
+          `*Trigger:* ${trigger} (partner-rule domain signup)`
+      ),
+      logAuditEvent(
+        {
+          userId,
+          action: AdminOrgAuditEvents.ORG_SEAT_CEILING_RAISED,
+          reason: `partner-rule domain signup (${trigger})`,
+          metadata: { organizationId, previousSeats, newSeats, trigger },
+        },
+        logger
+      ),
+    ]);
+  } catch (error) {
+    logger?.error('Failed to alert/audit partner-rule seat-ceiling raise', {
+      organizationId,
+      userId,
+      previousSeats,
+      newSeats,
+      trigger,
+      error,
+    });
+  }
+}

--- a/apps/client/server/organizations/notifySeatCeilingRaised.ts
+++ b/apps/client/server/organizations/notifySeatCeilingRaised.ts
@@ -7,32 +7,62 @@ interface SeatCeilingRaisedLogger {
   error: (message: string, ...args: unknown[]) => void;
 }
 
-interface NotifySeatCeilingRaisedParams {
+/** Which path triggered the raise - carried into the alert + audit for traceability. */
+type SeatCeilingRaiseTrigger = 'otc-signup' | 'email-verification' | 'admin-backfill';
+
+interface SeatCeilingRaisedParams {
   organizationId: string;
   /** The domain-verified user admitted by the raise. */
   userId: string;
   previousSeats: number;
   newSeats: number;
-  /** Which signup route triggered the raise - carried into the alert + audit for traceability. */
-  trigger: 'otc-signup' | 'email-verification';
+  trigger: SeatCeilingRaiseTrigger;
+  /** The admin who ran a bulk raise (backfill). Recorded as the audit actor; absent on live signup. */
+  actingAdminId?: string;
 }
 
 /**
- * Fire the human ALERT (Slack) + AUDIT record for a partner-rule seat-ceiling raise (#1239).
+ * Write the AUDIT record for a partner-rule seat-ceiling raise (#1239) - no Slack.
+ *
+ * Every path that can grow an org's seat count without an admin seat change must leave a durable
+ * record ("who added seats and why"), including the admin backfill, which raises many ceilings in
+ * one deliberate action and so skips the per-raise Slack ping. Best-effort: `logAuditEvent` swallows
+ * its own errors; the membership + seat raise have already committed by the time this runs.
+ */
+export async function auditSeatCeilingRaised(
+  { organizationId, userId, previousSeats, newSeats, trigger, actingAdminId }: SeatCeilingRaisedParams,
+  logger?: SeatCeilingRaisedLogger
+): Promise<void> {
+  await logAuditEvent(
+    {
+      userId,
+      action: AdminOrgAuditEvents.ORG_SEAT_CEILING_RAISED,
+      reason: `partner-rule domain signup (${trigger})`,
+      ...(actingAdminId ? { adminUserId: actingAdminId } : {}),
+      metadata: { organizationId, previousSeats, newSeats, trigger },
+    },
+    logger
+  );
+}
+
+/**
+ * Fire the human ALERT (Slack) + AUDIT record for a partner-rule seat-ceiling raise on a live
+ * signup (#1239).
  *
  * Domain-signup provisioning raises the seat ceiling rather than rejecting a legit partner user at
  * capacity, so the billing owner's seat count can grow without any admin action. That is only
  * acceptable if every raise is loud: this posts to the LiveOps Slack channel AND writes an
- * ORG_SEAT_CEILING_RAISED audit event so "who added seats and why" is always answerable.
+ * ORG_SEAT_CEILING_RAISED audit event.
  *
  * Best-effort and never throws: both underlying calls swallow their own errors, and this wraps them
  * so an alerting hiccup can never break an already-successful signup/verification. The core service
  * has already committed the membership + seat raise by the time this runs.
  */
 export async function notifySeatCeilingRaised(
-  { organizationId, userId, previousSeats, newSeats, trigger }: NotifySeatCeilingRaisedParams,
+  params: SeatCeilingRaisedParams,
   logger?: SeatCeilingRaisedLogger
 ): Promise<void> {
+  const { organizationId, userId, previousSeats, newSeats, trigger } = params;
   try {
     await Promise.all([
       postMessageToSlack(
@@ -42,15 +72,7 @@ export async function notifySeatCeilingRaised(
           `*Admitted user:* ${userId}\n` +
           `*Trigger:* ${trigger} (partner-rule domain signup)`
       ),
-      logAuditEvent(
-        {
-          userId,
-          action: AdminOrgAuditEvents.ORG_SEAT_CEILING_RAISED,
-          reason: `partner-rule domain signup (${trigger})`,
-          metadata: { organizationId, previousSeats, newSeats, trigger },
-        },
-        logger
-      ),
+      auditSeatCeilingRaised(params, logger),
     ]);
   } catch (error) {
     logger?.error('Failed to alert/audit partner-rule seat-ceiling raise', {
@@ -58,6 +80,47 @@ export async function notifySeatCeilingRaised(
       userId,
       previousSeats,
       newSeats,
+      trigger,
+      error,
+    });
+  }
+}
+
+interface PartnerSignupBlockedParams {
+  organizationId: string;
+  /** The domain-verified user who could not be admitted. */
+  userId: string;
+  /** The org's current (unchanged) seat ceiling. */
+  seats: number;
+  trigger: SeatCeilingRaiseTrigger;
+}
+
+/**
+ * Alert (Slack) that a partner-rule domain signup was BLOCKED because a Stripe-billed org was at
+ * capacity and its ceiling is deliberately not raised out of band (#1239).
+ *
+ * This is the "loud" half of the reject: a legit partner user is stranded at the door, so an admin
+ * must be told to add seats through the billing-aware path (which pushes the quantity to Stripe).
+ * Best-effort and never throws - the signup/verification itself has already succeeded.
+ */
+export async function notifyPartnerSignupBlockedAtCapacity(
+  { organizationId, userId, seats, trigger }: PartnerSignupBlockedParams,
+  logger?: SeatCeilingRaisedLogger
+): Promise<void> {
+  try {
+    await postMessageToSlack(
+      `🚧 *Partner signup blocked - org at capacity*\n` +
+        `*Organization:* ${organizationId} (Stripe-billed)\n` +
+        `*Seats:* ${seats} (full; ceiling not auto-raised for a billed org)\n` +
+        `*Blocked user:* ${userId}\n` +
+        `*Trigger:* ${trigger} (partner-rule domain signup)\n` +
+        `Add seats to admit this user.`
+    );
+  } catch (error) {
+    logger?.error('Failed to alert partner-rule signup blocked at capacity', {
+      organizationId,
+      userId,
+      seats,
       trigger,
       error,
     });

--- a/apps/client/server/utils/auditLogEvents.ts
+++ b/apps/client/server/utils/auditLogEvents.ts
@@ -55,6 +55,11 @@ export enum AdminOrgAuditEvents {
   ORG_GRANTED = 'ORG_GRANTED',
   ORG_TOPPED_UP = 'ORG_TOPPED_UP',
   ORG_SEATS_CHANGED = 'ORG_SEATS_CHANGED',
+  // Domain-signup provisioning raised the seat ceiling to admit a partner-rule user instead of
+  // rejecting at capacity (#1239). System action (no admin actor); the audited userId is the
+  // admitted user, with the org, before/after ceiling, and trigger route in metadata - a raise
+  // nobody can see is indistinguishable from having no ceiling at all.
+  ORG_SEAT_CEILING_RAISED = 'ORG_SEAT_CEILING_RAISED',
   ORG_CONVERT_INITIATED = 'ORG_CONVERT_INITIATED',
   ORG_REVOKED = 'ORG_REVOKED',
   // Group-type grant/revoke (org-groups #1172). One event carries the diff (added/removed types

--- a/b4m-core/common/src/types/entities/OrganizationTypes.ts
+++ b/b4m-core/common/src/types/entities/OrganizationTypes.ts
@@ -94,6 +94,17 @@ export interface IOrganizationRepository extends IBaseRepository<IOrganizationDo
   findByStripeCustomerId(stripeCustomerId: string): Promise<IOrganizationDocument | null>;
 
   /**
+   * Atomically add a member and raise the seat ceiling to fit, in a single update (#1239).
+   * Race-safe: idempotent on a duplicate add (returns null), and raises `seats` only to the
+   * post-add member count (never a double-raise). Returns the updated org, or null if the user
+   * is already a member or the org is gone. Used by the domain-signup auto-add path.
+   */
+  addMemberRaisingSeats(
+    organizationId: string,
+    member: IOrganizationDocument['users'][number]
+  ): Promise<IOrganizationDocument | null>;
+
+  /**
    * IDs of every organization the user administers (billing owner or manager).
    *
    * @param userId - The user ID

--- a/b4m-core/common/src/types/entities/OrganizationTypes.ts
+++ b/b4m-core/common/src/types/entities/OrganizationTypes.ts
@@ -95,11 +95,23 @@ export interface IOrganizationRepository extends IBaseRepository<IOrganizationDo
 
   /**
    * Atomically add a member and raise the seat ceiling to fit, in a single update (#1239).
-   * Race-safe: idempotent on a duplicate add (returns null), and raises `seats` only to the
-   * post-add member count (never a double-raise). Returns the updated org, or null if the user
-   * is already a member or the org is gone. Used by the domain-signup auto-add path.
+   * Race-safe: idempotent on a duplicate add, and raises `seats` only to the post-add member count
+   * (never a double-raise). Returns the PRE-image (before/after seats are derived from it), or null
+   * if the user is already a member or the org is gone. Domain-signup auto-add path for orgs NOT
+   * billed through Stripe - it does not sync Stripe's billed quantity (see `addMemberIfUnderCeiling`).
    */
   addMemberRaisingSeats(
+    organizationId: string,
+    member: IOrganizationDocument['users'][number]
+  ): Promise<IOrganizationDocument | null>;
+
+  /**
+   * Atomically add a member only if it fits under the current seat ceiling, never raising it - the
+   * domain-signup auto-add path for Stripe-billed orgs (#1239), where an out-of-band raise would
+   * desync Stripe's billed quantity. Returns the PRE-image, or null if the user is already a member,
+   * the org is gone, OR the org is at capacity (the caller re-reads to distinguish those).
+   */
+  addMemberIfUnderCeiling(
     organizationId: string,
     member: IOrganizationDocument['users'][number]
   ): Promise<IOrganizationDocument | null>;

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -179,6 +179,7 @@ export const createMockOrganizationRepository = (): MockedObject<IOrganizationRe
     shareable: createMockShareableRepository<IOrganizationDocument>(),
     search: vi.fn(),
     findByStripeCustomerId: vi.fn(),
+    addMemberRaisingSeats: vi.fn(),
     findIdsAdministeredBy: vi.fn(),
     incrementCredits: vi.fn(),
     incrementCurrentStorage: vi.fn(),

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -180,6 +180,7 @@ export const createMockOrganizationRepository = (): MockedObject<IOrganizationRe
     search: vi.fn(),
     findByStripeCustomerId: vi.fn(),
     addMemberRaisingSeats: vi.fn(),
+    addMemberIfUnderCeiling: vi.fn(),
     findIdsAdministeredBy: vi.fn(),
     incrementCredits: vi.fn(),
     incrementCurrentStorage: vi.fn(),

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
@@ -57,6 +57,31 @@ describe('applyPartnerRuleMembership', () => {
     expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
   });
 
+  it('reports the seat range from the atomic PRE-IMAGE, not the earlier read (concurrent raise)', async () => {
+    // Guards the fix for the reported race: deriving previousSeats/newSeats from the top-of-function
+    // findById makes two racers report OVERLAPPING ranges (2->3 and 2->4), so an operator
+    // reconciling seat growth double-counts the 2->3 interval. The two mocks must therefore
+    // disagree, or the test cannot tell the two sources apart.
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    // Stale read: what this caller saw before a concurrent signup landed.
+    db.organizations.findById.mockResolvedValue({
+      ...cloneDeep(org),
+      seats: 2,
+      users: [{ userId: 'a' }, { userId: 'b' }],
+    });
+    // Atomic pre-image: a racer already added a third member and raised seats to 3.
+    db.organizations.addMemberRaisingSeats.mockResolvedValue({
+      ...cloneDeep(org),
+      seats: 3,
+      users: [{ userId: 'a' }, { userId: 'b' }, { userId: 'racer' }],
+    });
+
+    const result = await run();
+
+    // From the pre-image: 3 -> max(3, 3 + 1) = 4. From the stale read it would be 2 -> 3.
+    expect(result).toEqual({ added: true, reason: 'added-seat-raised', previousSeats: 3, newSeats: 4 });
+  });
+
   it('adds a Stripe-billed org member that fits WITHOUT raising the ceiling', async () => {
     db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
     const fits = { ...cloneDeep(stripeOrg), seats: 5, users: [{ userId: 'a' }] };

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
@@ -5,7 +5,9 @@ import { cloneDeep } from 'lodash';
 
 describe('applyPartnerRuleMembership', () => {
   const verifiedUser = { id: 'user-id', name: 'Test User', email: 'test@partner.com', emailVerified: true };
+  // No stripeCustomerId => a non-Stripe (admin-granted) org, which raises the seat ceiling to fit.
   const org = { id: 'org-id', name: 'Partner Org', seats: 5, users: [] as Array<{ userId: string }> };
+  const stripeOrg = { ...org, stripeCustomerId: 'cus_123' };
 
   let db: any;
   let logger: any;
@@ -14,7 +16,11 @@ describe('applyPartnerRuleMembership', () => {
     vi.clearAllMocks();
     db = {
       users: { findById: vi.fn(), update: vi.fn() },
-      organizations: { findById: vi.fn(), addMemberRaisingSeats: vi.fn() },
+      organizations: {
+        findById: vi.fn(),
+        addMemberRaisingSeats: vi.fn(),
+        addMemberIfUnderCeiling: vi.fn(),
+      },
     };
     logger = { info: vi.fn() };
   });
@@ -24,11 +30,8 @@ describe('applyPartnerRuleMembership', () => {
   it('adds a verified user that fits under the ceiling as a read-permission member and sets organizationId', async () => {
     db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
     db.organizations.findById.mockResolvedValue(cloneDeep(org));
-    // Fits under the existing ceiling: seats unchanged.
-    db.organizations.addMemberRaisingSeats.mockResolvedValue({
-      ...cloneDeep(org),
-      users: [{ userId: 'user-id', permissions: [Permission.read] }],
-    });
+    // addMemberRaisingSeats returns the PRE-image (users empty, seats 5); fits, so seats unchanged.
+    db.organizations.addMemberRaisingSeats.mockResolvedValue(cloneDeep(org));
 
     const result = await run();
 
@@ -37,26 +40,66 @@ describe('applyPartnerRuleMembership', () => {
       userId: 'user-id',
       permissions: [Permission.read],
     });
+    expect(db.organizations.addMemberIfUnderCeiling).not.toHaveBeenCalled();
     expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
   });
 
   it('raises the seat ceiling to admit a user at capacity instead of rejecting (#1239)', async () => {
     db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
-    db.organizations.findById.mockResolvedValue({
-      ...cloneDeep(org),
-      seats: 2,
-      users: [{ userId: 'a' }, { userId: 'b' }],
-    });
-    // Atomic op raised seats 2 -> 3 to fit the third member.
-    db.organizations.addMemberRaisingSeats.mockResolvedValue({
-      ...cloneDeep(org),
-      seats: 3,
-      users: [{ userId: 'a' }, { userId: 'b' }, { userId: 'user-id', permissions: [Permission.read] }],
-    });
+    const full = { ...cloneDeep(org), seats: 2, users: [{ userId: 'a' }, { userId: 'b' }] };
+    db.organizations.findById.mockResolvedValue(full);
+    // PRE-image: 2 members, seats 2. The service derives newSeats = max(2, 2 + 1) = 3.
+    db.organizations.addMemberRaisingSeats.mockResolvedValue(cloneDeep(full));
 
     const result = await run();
 
     expect(result).toEqual({ added: true, reason: 'added-seat-raised', previousSeats: 2, newSeats: 3 });
+    expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
+  });
+
+  it('adds a Stripe-billed org member that fits WITHOUT raising the ceiling', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    const fits = { ...cloneDeep(stripeOrg), seats: 5, users: [{ userId: 'a' }] };
+    db.organizations.findById.mockResolvedValue(fits);
+    db.organizations.addMemberIfUnderCeiling.mockResolvedValue(cloneDeep(fits));
+
+    const result = await run();
+
+    expect(result).toEqual({ added: true, reason: 'added', previousSeats: 5, newSeats: 5 });
+    expect(db.organizations.addMemberIfUnderCeiling).toHaveBeenCalledWith('org-id', {
+      userId: 'user-id',
+      permissions: [Permission.read],
+    });
+    // A Stripe org's ceiling is never raised out of band.
+    expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
+    expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
+  });
+
+  it('rejects with at-capacity (no write) when a full Stripe-billed org cannot fit the user', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    const full = { ...cloneDeep(stripeOrg), seats: 2, users: [{ userId: 'a' }, { userId: 'b' }] };
+    // Top-of-function read, then the re-read after the atomic add matches nothing.
+    db.organizations.findById.mockResolvedValue(full);
+    db.organizations.addMemberIfUnderCeiling.mockResolvedValue(null);
+
+    const result = await run();
+
+    expect(result).toEqual({ added: false, reason: 'at-capacity', seats: 2 });
+    expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
+    expect(db.users.update).not.toHaveBeenCalled();
+  });
+
+  it('reports already-member when a Stripe-billed add loses the race to a concurrent signup', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    // First read: user absent. addMemberIfUnderCeiling returns null (raced). Re-read: user now present.
+    db.organizations.findById
+      .mockResolvedValueOnce({ ...cloneDeep(stripeOrg), seats: 5, users: [{ userId: 'a' }] })
+      .mockResolvedValueOnce({ ...cloneDeep(stripeOrg), seats: 5, users: [{ userId: 'a' }, { userId: 'user-id' }] });
+    db.organizations.addMemberIfUnderCeiling.mockResolvedValue(null);
+
+    const result = await run();
+
+    expect(result).toEqual({ added: false, reason: 'already-member' });
     expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
   });
 
@@ -68,6 +111,7 @@ describe('applyPartnerRuleMembership', () => {
     expect(result).toEqual({ added: false, reason: 'unverified' });
     expect(db.organizations.findById).not.toHaveBeenCalled();
     expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
+    expect(db.organizations.addMemberIfUnderCeiling).not.toHaveBeenCalled();
     expect(db.users.update).not.toHaveBeenCalled();
   });
 
@@ -110,14 +154,29 @@ describe('applyPartnerRuleMembership', () => {
 
   it('reports already-member (and repairs the pointer) when the atomic add loses a race', async () => {
     // findById saw an open seat, but a concurrent signup added this user first, so the atomic
-    // guarded update matched no doc and returned null. Must not report a fresh add.
+    // guarded update matched no doc and returned null. The re-read shows the user is now a member.
     db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
-    db.organizations.findById.mockResolvedValue(cloneDeep(org));
+    db.organizations.findById
+      .mockResolvedValueOnce(cloneDeep(org))
+      .mockResolvedValueOnce({ ...cloneDeep(org), users: [{ userId: 'user-id' }] });
     db.organizations.addMemberRaisingSeats.mockResolvedValue(null);
 
     const result = await run();
 
     expect(result).toEqual({ added: false, reason: 'already-member' });
     expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
+  });
+
+  it('does NOT write an org pointer when the org was hard-deleted between read and atomic add (#P3)', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    // Present at the top read, gone by the re-read after the add matched nothing.
+    db.organizations.findById.mockResolvedValueOnce(cloneDeep(org)).mockResolvedValueOnce(null);
+    db.organizations.addMemberRaisingSeats.mockResolvedValue(null);
+
+    const result = await run();
+
+    expect(result).toEqual({ added: false, reason: 'org-missing' });
+    // Never point the user at an org that vanished mid-flight.
+    expect(db.users.update).not.toHaveBeenCalled();
   });
 });

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
@@ -14,23 +14,49 @@ describe('applyPartnerRuleMembership', () => {
     vi.clearAllMocks();
     db = {
       users: { findById: vi.fn(), update: vi.fn() },
-      organizations: { findById: vi.fn(), update: vi.fn() },
+      organizations: { findById: vi.fn(), addMemberRaisingSeats: vi.fn() },
     };
     logger = { info: vi.fn() };
   });
 
   const run = () => applyPartnerRuleMembership({ userId: 'user-id', organizationId: 'org-id' }, { db, logger });
 
-  it('adds a verified user to the org as a read-permission member and sets organizationId', async () => {
+  it('adds a verified user that fits under the ceiling as a read-permission member and sets organizationId', async () => {
     db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
     db.organizations.findById.mockResolvedValue(cloneDeep(org));
+    // Fits under the existing ceiling: seats unchanged.
+    db.organizations.addMemberRaisingSeats.mockResolvedValue({
+      ...cloneDeep(org),
+      users: [{ userId: 'user-id', permissions: [Permission.read] }],
+    });
 
     const result = await run();
 
-    expect(result).toEqual({ added: true, reason: 'added' });
-    expect(db.organizations.update).toHaveBeenCalledWith(
-      expect.objectContaining({ users: [{ userId: 'user-id', permissions: [Permission.read] }] })
-    );
+    expect(result).toEqual({ added: true, reason: 'added', previousSeats: 5, newSeats: 5 });
+    expect(db.organizations.addMemberRaisingSeats).toHaveBeenCalledWith('org-id', {
+      userId: 'user-id',
+      permissions: [Permission.read],
+    });
+    expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
+  });
+
+  it('raises the seat ceiling to admit a user at capacity instead of rejecting (#1239)', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    db.organizations.findById.mockResolvedValue({
+      ...cloneDeep(org),
+      seats: 2,
+      users: [{ userId: 'a' }, { userId: 'b' }],
+    });
+    // Atomic op raised seats 2 -> 3 to fit the third member.
+    db.organizations.addMemberRaisingSeats.mockResolvedValue({
+      ...cloneDeep(org),
+      seats: 3,
+      users: [{ userId: 'a' }, { userId: 'b' }, { userId: 'user-id', permissions: [Permission.read] }],
+    });
+
+    const result = await run();
+
+    expect(result).toEqual({ added: true, reason: 'added-seat-raised', previousSeats: 2, newSeats: 3 });
     expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
   });
 
@@ -41,14 +67,14 @@ describe('applyPartnerRuleMembership', () => {
 
     expect(result).toEqual({ added: false, reason: 'unverified' });
     expect(db.organizations.findById).not.toHaveBeenCalled();
-    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
     expect(db.users.update).not.toHaveBeenCalled();
   });
 
   it('no-ops when the user is missing', async () => {
     db.users.findById.mockResolvedValue(null);
     expect(await run()).toEqual({ added: false, reason: 'user-missing' });
-    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
   });
 
   it('fails safe when the org is missing (e.g. soft-deleted)', async () => {
@@ -56,7 +82,7 @@ describe('applyPartnerRuleMembership', () => {
     db.organizations.findById.mockResolvedValue(null);
 
     expect(await run()).toEqual({ added: false, reason: 'org-missing' });
-    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
     expect(db.users.update).not.toHaveBeenCalled();
   });
 
@@ -67,7 +93,7 @@ describe('applyPartnerRuleMembership', () => {
     const result = await run();
 
     expect(result).toEqual({ added: false, reason: 'already-member' });
-    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
     expect(db.users.update).not.toHaveBeenCalled();
   });
 
@@ -78,22 +104,20 @@ describe('applyPartnerRuleMembership', () => {
     const result = await run();
 
     expect(result).toEqual({ added: false, reason: 'already-member' });
-    expect(db.organizations.update).not.toHaveBeenCalled();
+    expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
     expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
   });
 
-  it('does not overfill an at-capacity org (no silent seat overflow)', async () => {
-    db.users.findById.mockResolvedValue({ ...verifiedUser });
-    db.organizations.findById.mockResolvedValue({
-      ...cloneDeep(org),
-      seats: 2,
-      users: [{ userId: 'a' }, { userId: 'b' }],
-    });
+  it('reports already-member (and repairs the pointer) when the atomic add loses a race', async () => {
+    // findById saw an open seat, but a concurrent signup added this user first, so the atomic
+    // guarded update matched no doc and returned null. Must not report a fresh add.
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    db.organizations.findById.mockResolvedValue(cloneDeep(org));
+    db.organizations.addMemberRaisingSeats.mockResolvedValue(null);
 
     const result = await run();
 
-    expect(result).toEqual({ added: false, reason: 'at-capacity' });
-    expect(db.organizations.update).not.toHaveBeenCalled();
-    expect(db.users.update).not.toHaveBeenCalled();
+    expect(result).toEqual({ added: false, reason: 'already-member' });
+    expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
   });
 });

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
@@ -4,18 +4,19 @@ import { IOrganizationRepository, IUserDocument, IUserRepository, Permission } f
  * Why the auto-add did or didn't happen - returned (not thrown) so the signup paths can
  * log the outcome without a failure here ever breaking verification, and so the backfill
  * route can tally results.
+ *
+ * Discriminated on `added` so the compiler ties `previousSeats`/`newSeats` to the outcomes that
+ * carry them - no non-null assertions at the call sites:
+ *  - 'added'             fit under the existing ceiling; seats unchanged.
+ *  - 'added-seat-raised' the org was at capacity and the ceiling was raised to admit the user
+ *                        (#1239, non-Stripe orgs only). The signup caller fires the alert + audit.
+ *  - 'at-capacity'       a Stripe-billed org was full and its ceiling is deliberately NOT raised
+ *                        out of band; the caller alerts an admin to add seats through billing.
  */
-export type ApplyPartnerRuleMembershipResult = {
-  added: boolean;
-  // 'added-seat-raised' (#1239): the org was at capacity and the seat ceiling was raised to admit
-  // the domain-verified user (vs a plain 'added' that fit under the existing ceiling). The signup
-  // caller fires the human alert + audit off this reason. There is no longer an 'at-capacity'
-  // outcome - the auto-add path raises to fit rather than rejecting.
-  reason: 'added' | 'added-seat-raised' | 'unverified' | 'user-missing' | 'org-missing' | 'already-member';
-  /** Seat ceiling before/after the add; present on an 'added' or 'added-seat-raised' outcome. */
-  previousSeats?: number;
-  newSeats?: number;
-};
+export type ApplyPartnerRuleMembershipResult =
+  | { added: true; reason: 'added' | 'added-seat-raised'; previousSeats: number; newSeats: number }
+  | { added: false; reason: 'unverified' | 'user-missing' | 'org-missing' | 'already-member' }
+  | { added: false; reason: 'at-capacity'; seats: number };
 
 interface ApplyPartnerRuleMembershipParams {
   userId: string;
@@ -41,10 +42,15 @@ interface ApplyPartnerRuleMembershipAdapters {
  * `emailVerified`. Gating on the freshly-read `emailVerified` also closes the hole where an
  * unverified address could land inside a partner's private org.
  *
- * Idempotent and additive: an existing member is never duplicated, and this never removes
- * anyone. At capacity it raises the seat ceiling to admit the user rather than rejecting a
- * legit domain signup at the door (#1239); the caller is responsible for the resulting alert +
- * audit so the billing owner's grown seat count is never a silent change.
+ * Idempotent and additive: an existing member is never duplicated, and this never removes anyone.
+ * At capacity the behaviour splits on how the org is billed (#1239):
+ *  - NOT Stripe-billed: raise the seat ceiling to admit the user rather than rejecting a legit
+ *    domain signup at the door; the caller fires the resulting alert + audit so the grown seat
+ *    count is never a silent change.
+ *  - Stripe-billed: do NOT raise the ceiling out of band (a raise Stripe doesn't know about is
+ *    force-reverted by the next `customer.subscription.updated` webhook, which floors seat count at
+ *    `users.length + 1 + pendingInvites` and force-writes back to Stripe's quantity). Reject with
+ *    'at-capacity' so the caller can alert an admin to add seats through the billing-aware path.
  */
 export async function applyPartnerRuleMembership(
   { userId, organizationId }: ApplyPartnerRuleMembershipParams,
@@ -65,45 +71,101 @@ export async function applyPartnerRuleMembership(
   if (alreadyMember) {
     // Repair a half-set membership (in the ACL but organizationId never set) without
     // touching the org. Partial update so no other user field is disturbed.
-    if (user.organizationId !== organizationId) {
-      await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
+    await repairOrgPointer(user, userId, organizationId, db);
+    return { added: false, reason: 'already-member' };
+  }
+
+  const member = { userId, permissions: [Permission.read] };
+  const isStripeBilled = !!organization.stripeCustomerId;
+
+  // Stripe-billed org: add only if it fits under the current ceiling, never raising it (see the
+  // doc comment above). A null result means already-member, org-gone, or at-capacity - re-read to
+  // tell them apart precisely rather than blindly writing an org pointer or mislabelling a reject.
+  if (isStripeBilled) {
+    const pre = await db.organizations.addMemberIfUnderCeiling(organizationId, member);
+    if (!pre) {
+      const outcome = await inspectAfterNoMatch(organizationId, userId, db);
+      if (outcome.state === 'gone') return { added: false, reason: 'org-missing' };
+      if (outcome.state === 'member') {
+        await repairOrgPointer(user, userId, organizationId, db);
+        return { added: false, reason: 'already-member' };
+      }
+      logger?.info(
+        `Partner-rule did not add user ${userId} to Stripe-billed org ${organizationId}: at capacity ` +
+          `(seats ${outcome.seats}); ceiling not raised out of band, alerting an admin to add seats`
+      );
+      return { added: false, reason: 'at-capacity', seats: outcome.seats };
+    }
+    await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
+    logger?.info(
+      `Partner-rule auto-added user ${userId} to Stripe-billed org ${organizationId} under the existing ceiling`
+    );
+    return { added: true, reason: 'added', previousSeats: pre.seats, newSeats: pre.seats };
+  }
+
+  // Non-Stripe org: atomic add + raise the seat ceiling to fit (#1239). `addMemberRaisingSeats` is
+  // race-safe (idempotent on a duplicate; raises seats only to the real post-add member count) and
+  // returns the pre-image, so before/after seats come from one atomically-matched document.
+  const pre = await db.organizations.addMemberRaisingSeats(organizationId, member);
+  if (!pre) {
+    const outcome = await inspectAfterNoMatch(organizationId, userId, db);
+    if (outcome.state === 'gone') return { added: false, reason: 'org-missing' };
+    // 'member' (a concurrent signup won the race) or the vanishingly-rare 'absent' anomaly (the org
+    // exists but the guarded add matched nothing without a capacity guard) - both are safe no-ops.
+    if (outcome.state === 'member') {
+      await repairOrgPointer(user, userId, organizationId, db);
     }
     return { added: false, reason: 'already-member' };
   }
 
-  // Atomic add + raise the seat ceiling to fit (#1239): a domain-verified signup is never
-  // rejected at capacity (Ken's call - blocking a legit partner user at the door is the worst
-  // outcome). `addMemberRaisingSeats` is race-safe (idempotent on a duplicate; raises seats only
-  // to the real post-add member count), so concurrent signups can't double-raise.
-  const previousSeats = organization.seats;
-  const updated = await db.organizations.addMemberRaisingSeats(organizationId, {
-    userId,
-    permissions: [Permission.read],
-  });
-  if (!updated) {
-    // Lost the race: a concurrent signup already added this user. Ensure their org pointer is set
-    // (mirrors the already-member repair above) and report it as such rather than a fresh add.
-    if (user.organizationId !== organizationId) {
-      await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
-    }
-    return { added: false, reason: 'already-member' };
-  }
-
-  // Partial update - see the stale-doc note above.
   await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
 
-  const seatCeilingRaised = updated.seats > previousSeats;
+  const previousSeats = pre.seats;
+  // Mirror the model's `$max($seats, $size(users) + 1)`: the pre-image `users` is the pre-add array,
+  // so `users.length + 1` is the post-add member count the pipeline raised `seats` to.
+  const newSeats = Math.max(pre.seats, pre.users.length + 1);
+  const seatCeilingRaised = newSeats > previousSeats;
   // Logged here for the CloudWatch trail; the human ALERT + audit record fire at the signup caller
   // off the 'added-seat-raised' reason, so this core service stays free of Slack/audit ports.
   logger?.info(
     seatCeilingRaised
-      ? `Partner-rule raised organization ${organizationId} seat ceiling ${previousSeats} -> ${updated.seats} to admit user ${userId}`
+      ? `Partner-rule raised organization ${organizationId} seat ceiling ${previousSeats} -> ${newSeats} to admit user ${userId}`
       : `Partner-rule auto-added user ${userId} to organization ${organizationId}`
   );
   return {
     added: true,
     reason: seatCeilingRaised ? 'added-seat-raised' : 'added',
     previousSeats,
-    newSeats: updated.seats,
+    newSeats,
   };
+}
+
+/** Set the user's org pointer if unset - a partial update so no other user field is disturbed. */
+async function repairOrgPointer(
+  user: { organizationId?: string | null },
+  userId: string,
+  organizationId: string,
+  db: ApplyPartnerRuleMembershipAdapters['db']
+): Promise<void> {
+  if (user.organizationId !== organizationId) {
+    await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
+  }
+}
+
+/**
+ * Re-read the org after an atomic add matched no document, to tell apart the causes the guarded
+ * update collapses into a single null: the org vanished mid-flight ('gone'), a concurrent signup
+ * already added this user ('member'), or the user is genuinely absent - at capacity on the Stripe
+ * path ('absent'). Distinguishing them keeps us from mislabelling a reject or writing an org
+ * pointer to a deleted org.
+ */
+async function inspectAfterNoMatch(
+  organizationId: string,
+  userId: string,
+  db: ApplyPartnerRuleMembershipAdapters['db']
+): Promise<{ state: 'gone' } | { state: 'member' } | { state: 'absent'; seats: number }> {
+  const fresh = await db.organizations.findById(organizationId);
+  if (!fresh) return { state: 'gone' };
+  if (fresh.users.some(u => u.userId === userId)) return { state: 'member' };
+  return { state: 'absent', seats: fresh.seats };
 }

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
@@ -7,7 +7,14 @@ import { IOrganizationRepository, IUserDocument, IUserRepository, Permission } f
  */
 export type ApplyPartnerRuleMembershipResult = {
   added: boolean;
-  reason: 'added' | 'unverified' | 'user-missing' | 'org-missing' | 'already-member' | 'at-capacity';
+  // 'added-seat-raised' (#1239): the org was at capacity and the seat ceiling was raised to admit
+  // the domain-verified user (vs a plain 'added' that fit under the existing ceiling). The signup
+  // caller fires the human alert + audit off this reason. There is no longer an 'at-capacity'
+  // outcome - the auto-add path raises to fit rather than rejecting.
+  reason: 'added' | 'added-seat-raised' | 'unverified' | 'user-missing' | 'org-missing' | 'already-member';
+  /** Seat ceiling before/after the add; present on an 'added' or 'added-seat-raised' outcome. */
+  previousSeats?: number;
+  newSeats?: number;
 };
 
 interface ApplyPartnerRuleMembershipParams {
@@ -35,8 +42,9 @@ interface ApplyPartnerRuleMembershipAdapters {
  * unverified address could land inside a partner's private org.
  *
  * Idempotent and additive: an existing member is never duplicated, and this never removes
- * anyone. Respects the org's seat cap (no silent overfill); at capacity it no-ops and the
- * caller logs, rather than forcing a billing change the admin didn't consent to per-signup.
+ * anyone. At capacity it raises the seat ceiling to admit the user rather than rejecting a
+ * legit domain signup at the door (#1239); the caller is responsible for the resulting alert +
+ * audit so the billing owner's grown seat count is never a silent change.
  */
 export async function applyPartnerRuleMembership(
   { userId, organizationId }: ApplyPartnerRuleMembershipParams,
@@ -63,19 +71,39 @@ export async function applyPartnerRuleMembership(
     return { added: false, reason: 'already-member' };
   }
 
-  if (organization.users.length >= organization.seats) {
-    logger?.info(
-      `Partner-rule auto-add skipped: organization ${organizationId} is at capacity (${organization.seats} seats)`
-    );
-    return { added: false, reason: 'at-capacity' };
+  // Atomic add + raise the seat ceiling to fit (#1239): a domain-verified signup is never
+  // rejected at capacity (Ken's call - blocking a legit partner user at the door is the worst
+  // outcome). `addMemberRaisingSeats` is race-safe (idempotent on a duplicate; raises seats only
+  // to the real post-add member count), so concurrent signups can't double-raise.
+  const previousSeats = organization.seats;
+  const updated = await db.organizations.addMemberRaisingSeats(organizationId, {
+    userId,
+    permissions: [Permission.read],
+  });
+  if (!updated) {
+    // Lost the race: a concurrent signup already added this user. Ensure their org pointer is set
+    // (mirrors the already-member repair above) and report it as such rather than a fresh add.
+    if (user.organizationId !== organizationId) {
+      await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
+    }
+    return { added: false, reason: 'already-member' };
   }
-
-  organization.users.push({ userId, permissions: [Permission.read] });
-  await db.organizations.update(organization);
 
   // Partial update - see the stale-doc note above.
   await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
 
-  logger?.info(`Partner-rule auto-added user ${userId} to organization ${organizationId}`);
-  return { added: true, reason: 'added' };
+  const seatCeilingRaised = updated.seats > previousSeats;
+  // Logged here for the CloudWatch trail; the human ALERT + audit record fire at the signup caller
+  // off the 'added-seat-raised' reason, so this core service stays free of Slack/audit ports.
+  logger?.info(
+    seatCeilingRaised
+      ? `Partner-rule raised organization ${organizationId} seat ceiling ${previousSeats} -> ${updated.seats} to admit user ${userId}`
+      : `Partner-rule auto-added user ${userId} to organization ${organizationId}`
+  );
+  return {
+    added: true,
+    reason: seatCeilingRaised ? 'added-seat-raised' : 'added',
+    previousSeats,
+    newSeats: updated.seats,
+  };
 }

--- a/packages/database/src/models/infra/admin/OrganizationModel.addMemberRaisingSeats.integration.test.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.addMemberRaisingSeats.integration.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import { Permission } from '@bike4mind/common';
+import { createMongoServer } from '../../../__test__/createMongoServer';
+import { Organization, organizationRepository } from './OrganizationModel';
+
+/**
+ * Concurrency proof for `addMemberRaisingSeats` (#1239). The domain-signup auto-add raises the seat
+ * ceiling to fit rather than rejecting at capacity, so N racing signups into one org must land N
+ * members with `seats` equal to the real member count - never a double-raise and never a duplicate.
+ *
+ * A standalone mongod is enough: this is single-document atomicity (one guarded `findOneAndUpdate`
+ * with a `$max` seat pipeline), not a multi-document transaction, so Mongo serialises the writes on
+ * the one org doc and each update sees the committed result of the prior.
+ */
+let server: Awaited<ReturnType<typeof createMongoServer>>;
+
+beforeAll(async () => {
+  server = await createMongoServer();
+  await mongoose.connect(server.getUri());
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server?.stop();
+}, 60000);
+
+afterEach(async () => {
+  await Organization.deleteMany({}, { hardDelete: true } as mongoose.QueryOptions);
+});
+
+const member = (userId: string) => ({ userId, permissions: [Permission.read] });
+
+describe('OrganizationModel.addMemberRaisingSeats (#1239)', () => {
+  it('raises the ceiling to fit a member added past capacity', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 2, users: [] });
+
+    const updated = await organizationRepository.addMemberRaisingSeats(created.id, member('u1'));
+
+    expect(updated).not.toBeNull();
+    expect(updated!.users.map(u => u.userId)).toEqual(['u1']);
+    // Only 1 real member, so the ceiling holds at the existing 2 rather than dropping.
+    expect(updated!.seats).toBe(2);
+  });
+
+  it('leaves the ceiling alone when the member fits under it', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 10, users: [member('a')] });
+
+    const updated = await organizationRepository.addMemberRaisingSeats(created.id, member('b'));
+
+    expect(updated!.seats).toBe(10);
+    expect(updated!.users).toHaveLength(2);
+  });
+
+  it('returns null and writes nothing when the user is already a member (idempotent guard)', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 1, users: [member('u1')] });
+
+    const updated = await organizationRepository.addMemberRaisingSeats(created.id, member('u1'));
+
+    expect(updated).toBeNull();
+    const fresh = await Organization.findById(created.id);
+    expect(fresh!.users).toHaveLength(1);
+    expect(fresh!.seats).toBe(1);
+  });
+
+  it('N concurrent DISTINCT signups all land, with seats == member count (no double-raise)', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 1, users: [] });
+    const userIds = Array.from({ length: 8 }, (_, i) => `u${i}`);
+
+    const results = await Promise.all(
+      userIds.map(id => organizationRepository.addMemberRaisingSeats(created.id, member(id)))
+    );
+
+    // Every distinct add succeeded (non-null).
+    expect(results.every(r => r !== null)).toBe(true);
+    const fresh = await Organization.findById(created.id);
+    expect(fresh!.users).toHaveLength(userIds.length);
+    expect(new Set(fresh!.users.map(u => u.userId)).size).toBe(userIds.length);
+    // The invariant: seats was raised exactly to the real member count, never past it.
+    expect(fresh!.seats).toBe(userIds.length);
+  });
+
+  it('the SAME user racing itself is admitted exactly once and raises seats once', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 1, users: [] });
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => organizationRepository.addMemberRaisingSeats(created.id, member('dup')))
+    );
+
+    // Exactly one update matched the `$ne` guard; the rest lost the race and returned null.
+    expect(results.filter(r => r !== null)).toHaveLength(1);
+    const fresh = await Organization.findById(created.id);
+    expect(fresh!.users.map(u => u.userId)).toEqual(['dup']);
+    expect(fresh!.seats).toBe(1);
+  });
+});

--- a/packages/database/src/models/infra/admin/OrganizationModel.addMemberRaisingSeats.integration.test.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.addMemberRaisingSeats.integration.test.ts
@@ -5,13 +5,17 @@ import { createMongoServer } from '../../../__test__/createMongoServer';
 import { Organization, organizationRepository } from './OrganizationModel';
 
 /**
- * Concurrency proof for `addMemberRaisingSeats` (#1239). The domain-signup auto-add raises the seat
- * ceiling to fit rather than rejecting at capacity, so N racing signups into one org must land N
- * members with `seats` equal to the real member count - never a double-raise and never a duplicate.
+ * Concurrency + guard proof for the domain-signup auto-add model methods (#1239).
  *
- * A standalone mongod is enough: this is single-document atomicity (one guarded `findOneAndUpdate`
- * with a `$max` seat pipeline), not a multi-document transaction, so Mongo serialises the writes on
- * the one org doc and each update sees the committed result of the prior.
+ * `addMemberRaisingSeats` (non-Stripe orgs) raises the seat ceiling to fit rather than rejecting at
+ * capacity, so N racing signups into one org must land N members with `seats` equal to the real
+ * member count - never a double-raise and never a duplicate. `addMemberIfUnderCeiling` (Stripe
+ * orgs) instead adds ONLY under the existing ceiling and never raises it. Both skip soft-deleted
+ * orgs and return the PRE-image.
+ *
+ * A standalone mongod is enough: this is single-document atomicity (one guarded `findOneAndUpdate`),
+ * not a multi-document transaction, so Mongo serialises the writes on the one org doc and each
+ * update sees the committed result of the prior.
  */
 let server: Awaited<ReturnType<typeof createMongoServer>>;
 
@@ -31,36 +35,57 @@ afterEach(async () => {
 
 const member = (userId: string) => ({ userId, permissions: [Permission.read] });
 
+// Read past the soft-delete filter to assert the true post-state of an org.
+const readRaw = (id: string) => Organization.findOne({ _id: id }, null, { includeDeleted: true } as mongoose.QueryOptions);
+
 describe('OrganizationModel.addMemberRaisingSeats (#1239)', () => {
-  it('raises the ceiling to fit a member added past capacity', async () => {
+  it('adds the member and returns the pre-image; ceiling holds when the member fits', async () => {
     const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 2, users: [] });
 
-    const updated = await organizationRepository.addMemberRaisingSeats(created.id, member('u1'));
+    const pre = await organizationRepository.addMemberRaisingSeats(created.id, member('u1'));
 
-    expect(updated).not.toBeNull();
-    expect(updated!.users.map(u => u.userId)).toEqual(['u1']);
-    // Only 1 real member, so the ceiling holds at the existing 2 rather than dropping.
-    expect(updated!.seats).toBe(2);
+    // Return value is the PRE-image (before the add), so the caller can derive before/after seats.
+    expect(pre).not.toBeNull();
+    expect(pre!.users).toHaveLength(0);
+    expect(pre!.seats).toBe(2);
+    // Post-state: the member landed and the ceiling held at 2 (only 1 real member).
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users.map(u => u.userId)).toEqual(['u1']);
+    expect(fresh!.seats).toBe(2);
   });
 
-  it('leaves the ceiling alone when the member fits under it', async () => {
-    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 10, users: [member('a')] });
+  it('raises the ceiling to fit a member added past capacity', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 1, users: [member('a')] });
 
-    const updated = await organizationRepository.addMemberRaisingSeats(created.id, member('b'));
+    const pre = await organizationRepository.addMemberRaisingSeats(created.id, member('b'));
 
-    expect(updated!.seats).toBe(10);
-    expect(updated!.users).toHaveLength(2);
+    expect(pre!.seats).toBe(1);
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users).toHaveLength(2);
+    // 2 members past a ceiling of 1 => raised to 2.
+    expect(fresh!.seats).toBe(2);
   });
 
   it('returns null and writes nothing when the user is already a member (idempotent guard)', async () => {
     const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 1, users: [member('u1')] });
 
-    const updated = await organizationRepository.addMemberRaisingSeats(created.id, member('u1'));
+    const pre = await organizationRepository.addMemberRaisingSeats(created.id, member('u1'));
 
-    expect(updated).toBeNull();
-    const fresh = await Organization.findById(created.id);
+    expect(pre).toBeNull();
+    const fresh = await readRaw(created.id);
     expect(fresh!.users).toHaveLength(1);
     expect(fresh!.seats).toBe(1);
+  });
+
+  it('does not write into a soft-deleted org', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 5, users: [] });
+    await created.softDelete();
+
+    const pre = await organizationRepository.addMemberRaisingSeats(created.id, member('u1'));
+
+    expect(pre).toBeNull();
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users).toHaveLength(0);
   });
 
   it('N concurrent DISTINCT signups all land, with seats == member count (no double-raise)', async () => {
@@ -71,9 +96,9 @@ describe('OrganizationModel.addMemberRaisingSeats (#1239)', () => {
       userIds.map(id => organizationRepository.addMemberRaisingSeats(created.id, member(id)))
     );
 
-    // Every distinct add succeeded (non-null).
+    // Every distinct add matched a doc (non-null pre-image).
     expect(results.every(r => r !== null)).toBe(true);
-    const fresh = await Organization.findById(created.id);
+    const fresh = await readRaw(created.id);
     expect(fresh!.users).toHaveLength(userIds.length);
     expect(new Set(fresh!.users.map(u => u.userId)).size).toBe(userIds.length);
     // The invariant: seats was raised exactly to the real member count, never past it.
@@ -89,8 +114,74 @@ describe('OrganizationModel.addMemberRaisingSeats (#1239)', () => {
 
     // Exactly one update matched the `$ne` guard; the rest lost the race and returned null.
     expect(results.filter(r => r !== null)).toHaveLength(1);
-    const fresh = await Organization.findById(created.id);
+    const fresh = await readRaw(created.id);
     expect(fresh!.users.map(u => u.userId)).toEqual(['dup']);
     expect(fresh!.seats).toBe(1);
+  });
+});
+
+describe('OrganizationModel.addMemberIfUnderCeiling (#1239, Stripe path)', () => {
+  it('adds a member that fits under the ceiling WITHOUT raising it', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 5, users: [member('a')] });
+
+    const pre = await organizationRepository.addMemberIfUnderCeiling(created.id, member('b'));
+
+    expect(pre).not.toBeNull();
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users.map(u => u.userId)).toEqual(['a', 'b']);
+    // Ceiling untouched - a Stripe org's billed quantity is never grown out of band.
+    expect(fresh!.seats).toBe(5);
+  });
+
+  it('returns null and writes nothing when the org is at capacity', async () => {
+    const created = await Organization.create({
+      name: 'Partner',
+      userId: 'owner',
+      seats: 2,
+      users: [member('a'), member('b')],
+    });
+
+    const pre = await organizationRepository.addMemberIfUnderCeiling(created.id, member('c'));
+
+    expect(pre).toBeNull();
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users).toHaveLength(2);
+    expect(fresh!.seats).toBe(2);
+  });
+
+  it('returns null when the user is already a member (idempotent guard)', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 5, users: [member('a')] });
+
+    const pre = await organizationRepository.addMemberIfUnderCeiling(created.id, member('a'));
+
+    expect(pre).toBeNull();
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users).toHaveLength(1);
+  });
+
+  it('does not write into a soft-deleted org', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 5, users: [] });
+    await created.softDelete();
+
+    const pre = await organizationRepository.addMemberIfUnderCeiling(created.id, member('u1'));
+
+    expect(pre).toBeNull();
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users).toHaveLength(0);
+  });
+
+  it('N concurrent signups into a capped Stripe org never exceed the ceiling', async () => {
+    const created = await Organization.create({ name: 'Partner', userId: 'owner', seats: 3, users: [] });
+    const userIds = Array.from({ length: 8 }, (_, i) => `u${i}`);
+
+    const results = await Promise.all(
+      userIds.map(id => organizationRepository.addMemberIfUnderCeiling(created.id, member(id)))
+    );
+
+    // Exactly `seats` adds matched the atomic capacity guard; the rest were rejected (null).
+    expect(results.filter(r => r !== null)).toHaveLength(3);
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users).toHaveLength(3);
+    expect(fresh!.seats).toBe(3);
   });
 });

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -214,6 +214,14 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
    * quantity, so it must never run for a Stripe-billed org - a raise it doesn't know about would be
    * force-reverted by the next `customer.subscription.updated` webhook. `applyPartnerRuleMembership`
    * routes Stripe-billed orgs to `addMemberIfUnderCeiling` instead.
+   *
+   * NOTE (unbounded by decision, #1239): the raise has no upper cap - blocking a legitimate partner
+   * signup was judged the worse outcome, and every raise is alerted + audited instead. Known edge,
+   * deliberately not handled here: nothing clamps against `ORGANIZATION_SUBSCRIPTION_MAX_SEATS`, so
+   * an org grown past it has a `validateSeatChange` floor above that maximum and `setSeats` then
+   * rejects every value until members are removed. Reachable today without this path (`addMember`
+   * fills to `seats`, and `force` bypasses the ceiling), so it is a pre-existing wedge this method
+   * can reach unattended rather than one it introduces. Clamp here if that ever bites.
    */
   async addMemberRaisingSeats(
     organizationId: string,

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -193,22 +193,34 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
 
   /**
    * Atomically add a member and raise the seat ceiling to fit, in ONE updateOne
-   * (aggregation pipeline) - the domain-signup auto-add path (#1239). Concurrency-safe by
-   * construction:
+   * (aggregation pipeline) - the domain-signup auto-add path for orgs NOT billed through Stripe
+   * (#1239). Concurrency-safe by construction:
    *  - the `users.userId != member` filter is idempotent (a racing duplicate add matches no
    *    doc and returns null), and
-   *  - `seats` is raised with `$max` to the real POST-add member count (`$size users + 1`),
-   *    never blindly incremented - so N racing joins land N members with `seats` equal to that
-   *    count, never a double-raise past it.
-   * Returns the updated org, or null if the user is already a member (the guard) or the org is
-   * gone. `$$NOW` stamps `updatedAt` since a pipeline update bypasses Mongoose's timestamp hook.
+   *  - `seats` is raised with `$max` to the real POST-add member count (`$size users + 1`,
+   *    the same `users.length` accounting `addMember` uses), never blindly incremented - so N
+   *    racing joins land N members with `seats` equal to that count, never a double-raise past it.
+   *
+   * `deletedAt: null` keeps the write off a soft-deleted org: the softDeletePlugin only hooks
+   * `find`/`findOne`, not `findOneAndUpdate`, so without this a delete landing between the caller's
+   * read and this write would grow a dead org's ceiling.
+   *
+   * Returns the PRE-image ({ new: false }) - the caller derives before/after seats from this one
+   * atomically-matched document rather than from an earlier read, so two racers can't report
+   * overlapping ranges. Null means the user is already a member (the guard) or the org is gone.
+   * `$$NOW` stamps `updatedAt` since a pipeline update bypasses Mongoose's timestamp hook.
+   *
+   * NOTE (Stripe): this deliberately does NOT touch `subscriptions.quantity` or Stripe's billed
+   * quantity, so it must never run for a Stripe-billed org - a raise it doesn't know about would be
+   * force-reverted by the next `customer.subscription.updated` webhook. `applyPartnerRuleMembership`
+   * routes Stripe-billed orgs to `addMemberIfUnderCeiling` instead.
    */
   async addMemberRaisingSeats(
     organizationId: string,
     member: IOrganizationDocument['users'][number]
   ): Promise<IOrganizationDocument | null> {
     return this.organizationModel.findOneAndUpdate(
-      { _id: organizationId, 'users.userId': { $ne: member.userId } },
+      { _id: organizationId, deletedAt: null, 'users.userId': { $ne: member.userId } },
       [
         {
           $set: {
@@ -218,7 +230,42 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
           },
         },
       ],
-      { new: true }
+      { new: false }
+    );
+  }
+
+  /**
+   * Atomically add a member ONLY if it fits under the current seat ceiling, never raising it - the
+   * domain-signup auto-add path for Stripe-billed orgs (#1239). Raising a Stripe org's ceiling out
+   * of band would desync the billed quantity and get force-reverted by the next subscription
+   * webhook, so such an org keeps its ceiling and a candidate past it is rejected (the caller then
+   * alerts an admin to add seats through the billing-aware path).
+   *
+   * The `$expr` capacity guard (`$size users < seats`, the same `users.length < seats` accounting
+   * `addMember` uses) is evaluated inside the atomic match, so the fit check can't race the write.
+   * Returns the PRE-image ({ new: false }); null means already a member, org gone, OR at capacity -
+   * the caller re-reads to tell those apart.
+   */
+  async addMemberIfUnderCeiling(
+    organizationId: string,
+    member: IOrganizationDocument['users'][number]
+  ): Promise<IOrganizationDocument | null> {
+    return this.organizationModel.findOneAndUpdate(
+      {
+        _id: organizationId,
+        deletedAt: null,
+        'users.userId': { $ne: member.userId },
+        $expr: { $lt: [{ $size: '$users' }, '$seats'] },
+      },
+      [
+        {
+          $set: {
+            users: { $concatArrays: ['$users', [member]] },
+            updatedAt: '$$NOW',
+          },
+        },
+      ],
+      { new: false }
     );
   }
 

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -192,6 +192,37 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
   }
 
   /**
+   * Atomically add a member and raise the seat ceiling to fit, in ONE updateOne
+   * (aggregation pipeline) - the domain-signup auto-add path (#1239). Concurrency-safe by
+   * construction:
+   *  - the `users.userId != member` filter is idempotent (a racing duplicate add matches no
+   *    doc and returns null), and
+   *  - `seats` is raised with `$max` to the real POST-add member count (`$size users + 1`),
+   *    never blindly incremented - so N racing joins land N members with `seats` equal to that
+   *    count, never a double-raise past it.
+   * Returns the updated org, or null if the user is already a member (the guard) or the org is
+   * gone. `$$NOW` stamps `updatedAt` since a pipeline update bypasses Mongoose's timestamp hook.
+   */
+  async addMemberRaisingSeats(
+    organizationId: string,
+    member: IOrganizationDocument['users'][number]
+  ): Promise<IOrganizationDocument | null> {
+    return this.organizationModel.findOneAndUpdate(
+      { _id: organizationId, 'users.userId': { $ne: member.userId } },
+      [
+        {
+          $set: {
+            users: { $concatArrays: ['$users', [member]] },
+            seats: { $max: ['$seats', { $add: [{ $size: '$users' }, 1] }] },
+            updatedAt: '$$NOW',
+          },
+        },
+      ],
+      { new: true }
+    );
+  }
+
+  /**
    * Search for organizations with filtering, sorting, and pagination
    *
    * @param options - Search options


### PR DESCRIPTION
## Description

A domain-verified signup matched by a `PartnerSignupRule` used to be **rejected** when the target org was already at its seat ceiling (`at-capacity` + a log line, no override), silently stranding a legitimate partner user at the door and forcing a support round-trip. Per the product decision in #1239 (part of #1172), we now **raise the ceiling to admit them** and make every raise loud (alert + audit), so the ceiling stays honest and every increase is observable and reconcilable against billing.

The raise is scoped to the **domain-verified signup path only** — manual invites past the ceiling are untouched and remain a deliberate act. Growth is **unbounded + alerted** (the decision recorded on #1239: blocking a legit user during a partner eval is the worst outcome; a cap can be layered on later alongside `maxCreditsPerMember`/`seats` if a mis-scoped domain rule ever becomes a concern).

## Changes

- **db** — atomic `addMemberRaisingSeats` (one guarded `findOneAndUpdate` aggregation pipeline: `$concatArrays` the member if absent + `$max` `seats` to the real post-add member count). Race-safe by construction: N concurrent joins land N members with `seats` equal to that count (never a double-raise); a duplicate add matches no doc and no-ops.
- **service** — `applyPartnerRuleMembership` raises-to-fit instead of no-op'ing at capacity, returning `added-seat-raised` (with `previousSeats`/`newSeats`) vs a plain `added`. The now-unreachable `at-capacity` outcome is removed from the result union.
- **client** — a human alert (LiveOps Slack) + an `ORG_SEAT_CEILING_RAISED` audit event fire off `added-seat-raised` at both live signup paths (`otc/verify`, `email/verify`), so a grown seat count is never an invisible billing change. The admin backfill surfaces a `seatRaised` tally instead of a Slack ping (a deliberate bulk action — the returned tally is the record).
- **tests** — service raise / no-raise / lost-race branches; a standalone-mongo concurrency suite proving N distinct racers land with `seats == member count` and a self-racing user is admitted exactly once.

## Guide for Testers

This is a backend/provisioning path with no dedicated UI, so verification is API + admin driven. Use a non-prod environment (local or a preview).

**Setup**
1. As a platform admin, create a non-personal org with a low seat cap — e.g. `POST /api/organizations/create-dev` with `{ "name": "Seat Test", "seats": 2 }` (dev), or the admin org UI. Note its `id`.
2. Fill the org to capacity: add 2 members so `users.length === seats === 2`.
3. Create a partner signup rule pointing a domain (e.g. `@seattest.com`) at that org's `id` via the admin Partner Signup Rules surface.

**Exercise the raise**
4. Register + verify a new user on that domain (e.g. `newperson@seattest.com`) through the normal OTC or email-verification signup flow.
5. Expected: the signup **succeeds** and the user lands in the org. Confirm via `GET /api/organizations/<id>` that `users.length === 3` and `seats === 3` (raised from 2 to fit).
6. Expected: an **alert** posts to the LiveOps Slack channel reading `Org seat ceiling auto-raised` with the org id, `Seats: 2 -> 3`, the admitted user id, and the trigger route.
7. Expected: an `ORG_SEAT_CEILING_RAISED` **audit event** is recorded for the admitted user (metadata carries org id, previous/new seats, trigger).

**Regression Checks**
8. A domain signup that fits **under** the ceiling still joins with `seats` unchanged and NO alert/audit fires (reason is a plain `added`).
9. A user already in the org re-running the path is a no-op (`already-member`), seats unchanged.
10. A **manual invite** past the ceiling still behaves exactly as before (this path does NOT auto-raise).
11. Admin backfill (`POST /api/admin/partner-signup-rules/backfill` with `commit: true`) still adds candidates; the response now includes a `seatRaised` count (subset of `added`) and no longer has `atCapacity`.

**What NOT to test**
- No UI changes ship in this PR — nothing to click through beyond the flows above.
- The Slack post itself is best-effort/fire-and-forget; if the LiveOps webhook isn't configured in the test env, the raise still succeeds (the alert is logged as skipped) — that's expected, not a failure.

## Additional Information

Concurrency safety is proven by `OrganizationModel.addMemberRaisingSeats.integration.test.ts` (a standalone mongod suffices — this is single-document atomicity, not a multi-doc transaction). The `previousSeats!`/`newSeats!` non-null assertions at the callers are sound: both are always present on an `added`/`added-seat-raised` result.

Closes #1239