### PR TITLE
fix(llm): stop model rows pinning max output to the whole context window

### DIFF
--- a/b4m-core/common/src/modelCatalog.ts
+++ b/b4m-core/common/src/modelCatalog.ts
@@ -10,6 +10,13 @@ import type { ModelRecord } from './types/entities/ModelCatalogTypes';
 export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
 
 /**
+ * Input headroom the chat path holds back on top of a request's reserved output.
+ * safeInputWindow (ChatCompletionProcess) subtracts it, so a text entry whose output
+ * reserve leaves less than this has no room for a prompt at all.
+ */
+export const CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS = 1000;
+
+/**
  * The model types this build's ModelInfo consumers narrow on. ModelRecord.type is
  * wider (embedding / tts / realtime-voice), so the read path drops and counts any
  * record outside this set: an old build must degrade to "I do not see the new video

--- a/b4m-core/llm-adapters/src/bedrockBackend/jurassicTwo.ts
+++ b/b4m-core/llm-adapters/src/bedrockBackend/jurassicTwo.ts
@@ -43,7 +43,9 @@ export default class JurassicTwoBedrockBackend extends BaseBedrockBackend {
         backend: ModelBackend.Bedrock,
         contextWindow: 8192,
         supportsImageVariation: false,
-        max_tokens: 8192,
+        // Half the window, matching the GPT-4 row's 8192/4096 split. The full 8192 left
+        // context - output - buffer negative, which empties the prompt.
+        max_tokens: 4096,
         can_stream: false,
         pricing: {
           4000: { input: 0.0188 / 1000, output: 0.0188 / 1000 }, // $0.0188 / 1,000 Input tokens, $0.0188 / 1,000 Output tokens. @see https://aws.amazon.com/bedrock/pricing/
@@ -61,7 +63,7 @@ export default class JurassicTwoBedrockBackend extends BaseBedrockBackend {
         backend: ModelBackend.Bedrock,
         contextWindow: 8192,
         supportsImageVariation: false,
-        max_tokens: 8192,
+        max_tokens: 4096,
         can_stream: false,
         pricing: {
           4000: { input: 0.0125 / 1000, output: 0.0125 / 1000 }, // $0.0125 / 1,000 Input tokens, $0.0125 / 1,000 Output tokens. @see https://aws.amazon.com/bedrock/pricing/

--- a/b4m-core/llm-adapters/src/bedrockBackend/moonshot.test.ts
+++ b/b4m-core/llm-adapters/src/bedrockBackend/moonshot.test.ts
@@ -19,7 +19,8 @@ describe('MoonshotBedrockBackend payload', () => {
   });
 
   it('clamps max_tokens to the 16K Bedrock ceiling rather than passing the direct-API limit', () => {
-    // Direct Moonshot allows 262144; asking Bedrock for it is a validation error.
+    // 262144 is the direct-served K2.5 context window, not an output budget anywhere:
+    // asking Bedrock for that many output tokens is a validation error.
     expect(bodyOf(ChatModels.KIMI_K2_5_BEDROCK, { maxTokens: 262_144 }).max_tokens).toBe(16_384);
   });
 

--- a/b4m-core/llm-adapters/src/kimiBackend.ts
+++ b/b4m-core/llm-adapters/src/kimiBackend.ts
@@ -88,7 +88,10 @@ export class KimiBackend implements ICompletionBackend {
         name: 'Kimi K2.7 Code',
         backend: ModelBackend.Kimi,
         contextWindow: 262144,
-        max_tokens: 262144,
+        // Half the window, deliberately, and the same output ceiling the K3 row above
+        // carries. At the full 262144 the server's context - output - buffer went
+        // negative, which empties the prompt; every K2.x row has to keep it positive.
+        max_tokens: 131072,
         can_stream: true,
         pricing: {
           // $0.95 / 1M in, $4 / 1M out, $0.19 / 1M cache read.
@@ -109,7 +112,7 @@ export class KimiBackend implements ICompletionBackend {
         name: 'Kimi K2.7 Code (High Speed)',
         backend: ModelBackend.Kimi,
         contextWindow: 262144,
-        max_tokens: 262144,
+        max_tokens: 131072,
         can_stream: true,
         pricing: {
           // Same model on faster infrastructure at 2x the rate: $1.90 / $8.00.
@@ -130,7 +133,7 @@ export class KimiBackend implements ICompletionBackend {
         name: 'Kimi K2.6',
         backend: ModelBackend.Kimi,
         contextWindow: 262144,
-        max_tokens: 262144,
+        max_tokens: 131072,
         can_stream: true,
         pricing: {
           // $0.95 / 1M in, $4 / 1M out, $0.16 / 1M cache read.
@@ -151,7 +154,7 @@ export class KimiBackend implements ICompletionBackend {
         name: 'Kimi K2.5',
         backend: ModelBackend.Kimi,
         contextWindow: 262144,
-        max_tokens: 262144,
+        max_tokens: 131072,
         can_stream: true,
         pricing: {
           // $0.60 / 1M in, $3 / 1M out, $0.10 / 1M cache read.

--- a/b4m-core/llm-adapters/src/ollamaBackend.test.ts
+++ b/b4m-core/llm-adapters/src/ollamaBackend.test.ts
@@ -319,6 +319,12 @@ describe('OllamaBackend.complete tool loop', () => {
 // capabilities rather than a hardcoded list, so a thinking-capable model
 // (e.g. qwen3.5) must surface can_think and drive the Thinking toggle.
 describe('OllamaBackend.getModelInfo capability mapping', () => {
+  // The window cases below stub OLLAMA_MAX_NUM_CTX; leaking it would move the sibling
+  // expectations that assert an unconfigured window.
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   function backendWithCapabilities(capabilities: string[]) {
     const backend = new OllamaBackend('http://localhost:11434', silentLogger);
     (backend as any)._api = {
@@ -333,8 +339,9 @@ describe('OllamaBackend.getModelInfo capability mapping', () => {
     expect(info.can_think).toBe(true);
     expect(info.supportsVision).toBe(true);
     expect(info.supportsTools).toBe(true);
-    // Advertised as the window we will actually allocate (see effectiveContextWindow),
-    // not the 262144 the model reports, so callers size history to what fits.
+    // The window is what we will actually allocate (see effectiveContextWindow), not the
+    // 262144 the model reports, so callers size history to what fits. Output is half of
+    // that, which is what leaves room for the prompt.
     expect(info.contextWindow).toBe(32768);
     expect(info.max_tokens).toBe(16384);
   });
@@ -345,6 +352,15 @@ describe('OllamaBackend.getModelInfo capability mapping', () => {
   // path then refuses to build a prompt at all.
   it('leaves a positive input budget after the advertised output reserve', async () => {
     const [info] = await backendWithCapabilities(['completion', 'tools']).getModelInfo();
+    expect(info.contextWindow - (info.max_tokens ?? 0) - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS).toBeGreaterThan(0);
+  });
+
+  // OLLAMA_MAX_NUM_CTX takes any positive value, so an operator can put every local model at the
+  // bottom of the range at once. Halving alone leaves exactly zero budget at 2000.
+  it.each([2000, 1500, 32768])('keeps the budget positive at an allocated window of %i', async window => {
+    vi.stubEnv('OLLAMA_MAX_NUM_CTX', String(window));
+    const [info] = await backendWithCapabilities(['completion', 'tools']).getModelInfo();
+    expect(info.contextWindow).toBe(window);
     expect(info.contextWindow - (info.max_tokens ?? 0) - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS).toBeGreaterThan(0);
   });
 

--- a/b4m-core/llm-adapters/src/ollamaBackend.test.ts
+++ b/b4m-core/llm-adapters/src/ollamaBackend.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
+import { CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS } from '@bike4mind/common';
 import { OllamaBackend } from './ollamaBackend';
 import type { ICompletionOptionTools } from './backend';
 
@@ -335,7 +336,16 @@ describe('OllamaBackend.getModelInfo capability mapping', () => {
     // Advertised as the window we will actually allocate (see effectiveContextWindow),
     // not the 262144 the model reports, so callers size history to what fits.
     expect(info.contextWindow).toBe(32768);
-    expect(info.max_tokens).toBe(32768);
+    expect(info.max_tokens).toBe(16384);
+  });
+
+  // collectStaticCatalogModels excludes Ollama, so the catalog-wide input-budget test
+  // cannot reach these rows - the same invariant is asserted here instead. A text model
+  // advertising its whole window as output makes safeInputWindow negative, and the chat
+  // path then refuses to build a prompt at all.
+  it('leaves a positive input budget after the advertised output reserve', async () => {
+    const [info] = await backendWithCapabilities(['completion', 'tools']).getModelInfo();
+    expect(info.contextWindow - (info.max_tokens ?? 0) - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS).toBeGreaterThan(0);
   });
 
   it('advertises a small model window verbatim', async () => {

--- a/b4m-core/llm-adapters/src/ollamaBackend.ts
+++ b/b4m-core/llm-adapters/src/ollamaBackend.ts
@@ -163,7 +163,12 @@ export class OllamaBackend implements ICompletionBackend {
    *
    * Halving alone is not enough at the bottom of the range: OLLAMA_MAX_NUM_CTX accepts any positive
    * value, so an operator setting 2000 would leave exactly zero input budget for every local model
-   * at once. The second bound keeps at least one token of input whatever the window is.
+   * at once. The second bound keeps input room for any window ABOVE the safety buffer.
+   *
+   * At or below the buffer nothing here can: a 500-token window yields a cap of 1 and still leaves
+   * 500 - 1 - 1000 negative. Clamping the window up to hide that would advertise more context than
+   * the model has, which is the misreporting this whole change removes, so the honest answer is
+   * that such a model cannot serve a chat prompt at all.
    */
   private static advertisedOutputCap(contextWindow: number): number {
     const halved = Math.floor(contextWindow / 2);

--- a/b4m-core/llm-adapters/src/ollamaBackend.ts
+++ b/b4m-core/llm-adapters/src/ollamaBackend.ts
@@ -1,4 +1,5 @@
 import {
+  CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS,
   IMessage,
   isUserInitiatedAbort,
   ModelBackend,
@@ -105,11 +106,7 @@ export class OllamaBackend implements ICompletionBackend {
             name: model.name,
             backend: ModelBackend.Ollama,
             contextWindow,
-            // Half of what we allocate: advertising the whole window made the server's
-            // context - output - buffer negative and emptied the prompt. Halving only keeps
-            // that positive above ~2000 tokens, and a window that small was already
-            // unusable for chat.
-            max_tokens: Math.floor(contextWindow / 2),
+            max_tokens: OllamaBackend.advertisedOutputCap(contextWindow),
             supportsImageVariation: false,
             // Local models are free. pricing is a tier map keyed by a token
             // threshold (consumed by getTextModelCost), not a flat {input,output}
@@ -159,6 +156,19 @@ export class OllamaBackend implements ICompletionBackend {
    * than the advertised maximum. Override with OLLAMA_MAX_NUM_CTX.
    */
   private static readonly DEFAULT_MAX_NUM_CTX = 32768;
+
+  /**
+   * Output ceiling we advertise for a local model. Half of what we allocate, because advertising
+   * the whole window made the server's context - output - buffer negative and emptied the prompt.
+   *
+   * Halving alone is not enough at the bottom of the range: OLLAMA_MAX_NUM_CTX accepts any positive
+   * value, so an operator setting 2000 would leave exactly zero input budget for every local model
+   * at once. The second bound keeps at least one token of input whatever the window is.
+   */
+  private static advertisedOutputCap(contextWindow: number): number {
+    const halved = Math.floor(contextWindow / 2);
+    return Math.max(1, Math.min(halved, contextWindow - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS - 1));
+  }
 
   /** A model's reported window clamped to what we are willing to allocate. */
   private static effectiveContextWindow(reported: number): number {

--- a/b4m-core/llm-adapters/src/ollamaBackend.ts
+++ b/b4m-core/llm-adapters/src/ollamaBackend.ts
@@ -105,7 +105,11 @@ export class OllamaBackend implements ICompletionBackend {
             name: model.name,
             backend: ModelBackend.Ollama,
             contextWindow,
-            max_tokens: contextWindow,
+            // Half of what we allocate: advertising the whole window made the server's
+            // context - output - buffer negative and emptied the prompt. Halving only keeps
+            // that positive above ~2000 tokens, and a window that small was already
+            // unusable for chat.
+            max_tokens: Math.floor(contextWindow / 2),
             supportsImageVariation: false,
             // Local models are free. pricing is a tier map keyed by a token
             // threshold (consumed by getTextModelCost), not a flat {input,output}
@@ -223,8 +227,9 @@ export class OllamaBackend implements ICompletionBackend {
     return {
       num_ctx: numCtx,
       ...(typeof options.temperature === 'number' && { temperature: options.temperature }),
-      // The catalogue reports max_tokens as the whole context window, so cap
-      // the output budget at what we actually allocated.
+      // A caller can still ask for more than the catalogue advertises - a stale
+      // persisted setting, or a direct API request - so cap the output budget at
+      // what we actually allocated.
       ...(typeof options.maxTokens === 'number' && { num_predict: Math.min(options.maxTokens, numCtx) }),
     };
   }

--- a/b4m-core/llm-adapters/src/openaiBackend.ts
+++ b/b4m-core/llm-adapters/src/openaiBackend.ts
@@ -795,6 +795,11 @@ export class OpenAIBackend implements ICompletionBackend {
           "OpenAI's original GPT-4 model. Legacy model good for basic tasks and content generation, but newer models offer better capabilities.",
       },
       // OpenAI Image Models
+      //
+      // max_tokens equals contextWindow on purpose here: both are the prompt-length limit,
+      // and max_tokens is never sent to the image API. Do not "correct" it to a smaller
+      // output reserve - safeInputWindow (ChatCompletionProcess) skips the reserve for media
+      // types precisely because there is no token output to reserve.
       {
         id: ImageModels.GPT_IMAGE_1,
         type: 'image',

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -462,9 +462,10 @@ describe('ChatCompletionProcess', () => {
       await expect(service.process({ body, logger: mockLogger })).rejects.toThrow(/no input budget/);
     });
 
-    // Image and video entries set max_tokens equal to contextWindow across every backend in the repo -
-    // both are the prompt-length limit, since these models return media rather than tokens. Reserving
-    // that as output left no input room, so the guard above rejected a request that fits fine.
+    // A media entry's max_tokens is a prompt-length limit, not an output budget, since these models
+    // return media rather than tokens. Most rows set it equal to contextWindow; Gemini's image rows
+    // set it lower. Reserving it as output left no input room, so the guard above rejected a request
+    // that fits fine.
     it('does not reserve text output on an image model, whose max_tokens is not an output budget', async () => {
       mockedGetLlmByModel.mockReturnValue({
         complete: vi.fn().mockImplementation(async (_model, _messages, _opts, cb) => {

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -223,8 +223,9 @@ const DEFAULT_OUTPUT_MAX_TOKENS = 4096;
  * not drift apart.
  *
  * The static catalog tables are held to the positive-budget property by
- * modelCatalogInputBudget.test.ts, and a discovered claim that would break it is refused in
- * modelDiscoveryService/catalogWrite.
+ * modelCatalogInputBudget.test.ts, and a discovered claim that would break it for a TEXT row is
+ * refused in modelDiscoveryService/catalogWrite. Neither covers a media row whose window arrives as
+ * 0 from a feed, where the buffer below still makes this negative.
  */
 const safeInputWindow = (
   modelInfo: ModelInfo,
@@ -1678,7 +1679,9 @@ export class ChatCompletionProcess {
       // attachedFileTokenBudget below), so the adaptive default must not balloon it.
       const urlContentBudget = maxTokens ?? DEFAULT_OUTPUT_MAX_TOKENS;
 
-      const safetyBuffer = 1000; // Emergency buffer
+      // The same figure the catalog tests hold rows to, so CI's rule cannot end up looser
+      // than what this call actually reserves. Reported as bufferTokens in the telemetry below.
+      const safetyBuffer = CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS;
       // safeMaxTokens, not the raw (possibly absent) requested maxTokens: this reserves against the
       // output budget actually in play, including the adaptive-reasoning floor above, or an adaptive
       // model could reserve less than it goes on to use and land back on the negative-window bug this

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -145,6 +145,7 @@ import {
   ARTIFACT_EMISSION_PROMPT,
   HELP_CENTER_PROMPT,
   ELISION_WARNING,
+  CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS,
 } from '@bike4mind/common';
 import type { CompletionInfo } from '@bike4mind/llm-adapters';
 
@@ -215,12 +216,21 @@ const DEFAULT_OUTPUT_MAX_TOKENS = 4096;
  * buffer. Deliberately NOT clamped at zero - the empty-prompt guard depends on seeing a non-positive
  * budget for a genuinely misconfigured text model.
  *
- * Image and video models return media rather than tokens, and every image backend here sets
- * max_tokens equal to contextWindow because both are the prompt-length limit, so reserving it as
- * output left no room for the prompt itself. Two callers need this figure - the assembly budget and
- * the verbatim-history window - and they must not drift apart.
+ * Image and video models return media rather than tokens, so their max_tokens is a prompt-length
+ * limit and is never reserved as output - most media rows set it equal to contextWindow, Gemini's
+ * image rows set it lower, and either way subtracting it would leave no room for the prompt itself.
+ * Two callers need this figure - the assembly budget and the verbatim-history window - and they must
+ * not drift apart.
+ *
+ * The static catalog tables are held to the positive-budget property by
+ * modelCatalogInputBudget.test.ts, and a discovered claim that would break it is refused in
+ * modelDiscoveryService/catalogWrite.
  */
-const safeInputWindow = (modelInfo: ModelInfo, requestedMaxTokens: number, safetyBuffer = 1000): number => {
+const safeInputWindow = (
+  modelInfo: ModelInfo,
+  requestedMaxTokens: number,
+  safetyBuffer = CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS
+): number => {
   const contextLimit = modelInfo.contextWindow ?? 200000;
   const modelMaxOutput = modelInfo.max_tokens ?? 16384;
   const returnsMedia = modelInfo.type === 'image' || modelInfo.type === 'video';

--- a/b4m-core/services/src/modelDiscoveryService/catalogWrite.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/catalogWrite.test.ts
@@ -632,6 +632,95 @@ describe('planCatalogWrites', () => {
     expect(alone.diff[0].blockedBy).toEqual(['no-trusted-price']);
   });
 
+  // A text row whose output reserve eats its whole context window makes safeInputWindow
+  // non-positive, and the chat path then refuses to build a prompt at all. The static tables are
+  // held to that by modelCatalogInputBudget.test.ts; these cover the feed, which outranks them.
+  describe('maxOutputTokens that would starve the input budget', () => {
+    const claiming = (patch: DiscoveredModel['patch']) => ({
+      contributions: [{ name: 'openai' as const, kind: 'provider' as const, records: [gpt6(patch)] }],
+    });
+    const gpt6Seed = (patch: Record<string, unknown>) =>
+      seedRow(
+        {
+          id: 'gpt-6',
+          vendor: 'openai',
+          backend: ModelBackend.OpenAI,
+          type: 'text',
+          name: 'GPT-6',
+          contextWindow: 400_000,
+          ...patch,
+        },
+        ['identity', 'limits']
+      );
+
+    it('refuses the claim and reports it, keeping the rest of the record', () => {
+      const result = plan({ resolveDispatch: dispatchable, ...claiming({ maxOutputTokens: 400_000 }) });
+
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].patch).not.toHaveProperty('maxOutputTokens');
+      expect(result.rows[0].patch).toMatchObject({ contextWindow: 400_000 });
+      expect(result.dropped).toContainEqual({
+        source: 'openai',
+        modelId: 'gpt-6',
+        reason:
+          'maxOutputTokens 400000 leaves no input budget in a contextWindow of 400000 (safety buffer 1000); claim refused',
+      });
+    });
+
+    it('leaves the value in force standing when the starving claim was the only limits field', () => {
+      // Refusing the field also un-claims the group, so nothing is appended and the seed's own
+      // figure stays in force. Clamping instead would append a row and overwrite it.
+      const seed = gpt6Seed({ maxOutputTokens: 32_000 });
+      const result = plan({
+        base: asBase([], [seed]),
+        resolveDispatch: dispatchable,
+        contributions: [
+          { name: 'openai', kind: 'provider', records: [{ modelId: 'gpt-6', patch: { maxOutputTokens: 400_000 } }] },
+        ],
+      });
+
+      expect(result.rows).toEqual([]);
+      expect(asBase(result.rows, [seed]).get('gpt-6')?.record.maxOutputTokens).toBe(32_000);
+      expect(result.dropped.map(drop => drop.reason)).toContain(
+        'maxOutputTokens 400000 leaves no input budget in a contextWindow of 400000 (safety buffer 1000); claim refused'
+      );
+    });
+
+    it('persists a claim that leaves room, and says nothing', () => {
+      const result = plan({ resolveDispatch: dispatchable, ...claiming({ maxOutputTokens: 128_000 }) });
+
+      expect(result.rows[0].patch).toMatchObject({ maxOutputTokens: 128_000 });
+      expect(result.dropped).toEqual([]);
+    });
+
+    it('leaves a media claim alone, where max output is the prompt-length limit', () => {
+      const result = plan({
+        resolveDispatch: dispatchable,
+        ...claiming({ type: 'image', contextWindow: 10_000, maxOutputTokens: 10_000 }),
+      });
+
+      expect(result.rows[0].patch).toMatchObject({ maxOutputTokens: 10_000 });
+      expect(result.dropped).toEqual([]);
+    });
+
+    it('drops a text model whose window cannot fund even the default output cap', () => {
+      // Nothing to fall back to here, and listing a model that can only fail once selected is
+      // worse than not listing it.
+      const result = plan({
+        resolveDispatch: dispatchable,
+        ...claiming({ contextWindow: 4_096, maxOutputTokens: 4_096 }),
+      });
+
+      expect(result.rows).toEqual([]);
+      expect(result.dropped).toContainEqual({
+        source: 'openai',
+        modelId: 'gpt-6',
+        reason:
+          'contextWindow 4096 leaves no input budget for a text model even at the default output cap (safety buffer 1000)',
+      });
+    });
+  });
+
   it('distrusts two aggregators that disagree beyond the tolerance', () => {
     const result = plan({
       resolveDispatch: dispatchable,

--- a/b4m-core/services/src/modelDiscoveryService/catalogWrite.test.ts
+++ b/b4m-core/services/src/modelDiscoveryService/catalogWrite.test.ts
@@ -663,7 +663,7 @@ describe('planCatalogWrites', () => {
         source: 'openai',
         modelId: 'gpt-6',
         reason:
-          'maxOutputTokens 400000 leaves no input budget in a contextWindow of 400000 (safety buffer 1000); claim refused',
+          'maxOutputTokens 400000 leaves no input budget in a contextWindow of 400000 (safety buffer 1000); maxOutputTokens dropped',
       });
     });
 
@@ -682,7 +682,7 @@ describe('planCatalogWrites', () => {
       expect(result.rows).toEqual([]);
       expect(asBase(result.rows, [seed]).get('gpt-6')?.record.maxOutputTokens).toBe(32_000);
       expect(result.dropped.map(drop => drop.reason)).toContain(
-        'maxOutputTokens 400000 leaves no input budget in a contextWindow of 400000 (safety buffer 1000); claim refused'
+        'maxOutputTokens 400000 leaves no input budget in a contextWindow of 400000 (safety buffer 1000); maxOutputTokens dropped'
       );
     });
 
@@ -703,12 +703,49 @@ describe('planCatalogWrites', () => {
       expect(result.dropped).toEqual([]);
     });
 
-    it('drops a text model whose window cannot fund even the default output cap', () => {
-      // Nothing to fall back to here, and listing a model that can only fail once selected is
-      // worse than not listing it.
+    it('catches a claim that lowers only contextWindow onto an output cap already in force', () => {
+      // The mirror case, and the one a real feed produces: the Kimi and xAI provider sources emit
+      // contextWindow and never maxOutputTokens. A window lowered to whatever the catalog already
+      // holds as the output cap is the same starving pair, arriving from the other side.
+      const seed = gpt6Seed({ maxOutputTokens: 131_072, contextWindow: 262_144 });
+      const result = plan({
+        base: asBase([], [seed]),
+        resolveDispatch: dispatchable,
+        contributions: [
+          { name: 'openai', kind: 'provider', records: [{ modelId: 'gpt-6', patch: { contextWindow: 131_072 } }] },
+        ],
+      });
+
+      expect(result.rows[0].patch).toMatchObject({ contextWindow: 131_072 });
+      expect(result.rows[0].patch).not.toHaveProperty('maxOutputTokens');
+      expect(result.dropped.map(drop => drop.reason)).toContain(
+        'maxOutputTokens 131072 leaves no input budget in a contextWindow of 131072 (safety buffer 1000); maxOutputTokens dropped'
+      );
+    });
+
+    it('clamps rather than refuses when the window cannot fund the read-path fallback', () => {
+      // Refusing here would hand the read path min(contextWindow, DEFAULT_MAX_OUTPUT_TOKENS), which
+      // starves just as badly. The model still answers at a lower output setting, so it keeps its
+      // row with a reserve that leaves room: half of what is left after the buffer.
       const result = plan({
         resolveDispatch: dispatchable,
         ...claiming({ contextWindow: 4_096, maxOutputTokens: 4_096 }),
+      });
+
+      expect(result.rows[0].patch).toMatchObject({ maxOutputTokens: 1_548 });
+      expect(4_096 - 1_548 - 1_000).toBeGreaterThan(0);
+      expect(result.dropped).toContainEqual({
+        source: 'openai',
+        modelId: 'gpt-6',
+        reason:
+          'maxOutputTokens 4096 leaves no input budget in a contextWindow of 4096 (safety buffer 1000); clamped to 1548',
+      });
+    });
+
+    it('drops a window at or under the buffer, where no reserve leaves room', () => {
+      const result = plan({
+        resolveDispatch: dispatchable,
+        ...claiming({ contextWindow: 1_000, maxOutputTokens: 1_000 }),
       });
 
       expect(result.rows).toEqual([]);
@@ -716,7 +753,7 @@ describe('planCatalogWrites', () => {
         source: 'openai',
         modelId: 'gpt-6',
         reason:
-          'contextWindow 4096 leaves no input budget for a text model even at the default output cap (safety buffer 1000)',
+          'maxOutputTokens 1000 leaves no input budget in a contextWindow of 1000 (safety buffer 1000); no reserve leaves room for a prompt',
       });
     });
   });

--- a/b4m-core/services/src/modelDiscoveryService/catalogWrite.ts
+++ b/b4m-core/services/src/modelDiscoveryService/catalogWrite.ts
@@ -235,21 +235,33 @@ function usableFields(
  * maxOutputTokens is in the feed-claimable `limits` group and a discovery row outranks the seed, so
  * a fetched claim could put the failure back with those tables still clean.
  *
- * Refusing the field rather than clamping it hands the decision to the read path: a feed that
- * reports its whole window as output has told us nothing about the real cap, and
- * DEFAULT_MAX_OUTPUT_TOKENS is already what toModelInfo means by "unknown". Note mergeRows resolves
- * per GROUP, not per key, so the value in force survives only when the refused field was this row's
- * only `limits` claim; alongside a contextWindow claim the row wins the group and that fallback
- * applies instead.
+ * Three remedies, in order of how much the row still tells us:
  *
- * `unfixable` marks the case with no fallback left - a window too small to fund even the default cap
- * - where listing a model that can only fail once selected is worse than not listing it.
+ * `refuse` drops the field and hands the decision to the read path. A feed reporting its whole
+ * window as output has told us nothing about the real cap, and DEFAULT_MAX_OUTPUT_TOKENS is already
+ * what toModelInfo means by "unknown". Note mergeRows resolves per GROUP, not per key, so the value
+ * in force survives only when the refused field was this row's only `limits` claim; alongside a
+ * contextWindow claim the row wins the group and that fallback applies instead.
+ *
+ * `clamp` covers a window too small to fund even that fallback. Such a model still answers at a
+ * lower output setting, so it keeps its row with a reserve that leaves the budget positive - half of
+ * what is left after the buffer, the same split the static tables use.
+ *
+ * `drop` is only for a window at or under the buffer itself, where no reserve leaves room for a
+ * prompt and the model could not answer at any setting.
  */
+type StarvedOutputClaim =
+  { reason: string; action: 'refuse' | 'drop' } | { reason: string; action: 'clamp'; to: number };
+
 function starvedByOutputClaim(
   draft: Record<string, unknown>,
   contributed: Map<string, unknown>
-): { reason: string; unfixable: boolean } | null {
-  if (draft.type !== 'text' || !contributed.has('maxOutputTokens')) return null;
+): StarvedOutputClaim | null {
+  // Gate on the RESULTING draft, not on which field arrived. A run claiming only contextWindow
+  // still lands the starving shape, because draft carries maxOutputTokens forward from the record
+  // in force and both fields are in the `limits` group, so the appended row wins the pair.
+  if (draft.type !== 'text') return null;
+  if (!contributed.has('maxOutputTokens') && !contributed.has('contextWindow')) return null;
   const contextWindow = draft.contextWindow;
   const maxOutputTokens = draft.maxOutputTokens;
   if (typeof contextWindow !== 'number' || typeof maxOutputTokens !== 'number') return null;
@@ -257,20 +269,17 @@ function starvedByOutputClaim(
   const starves = (output: number) => contextWindow - output - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS <= 0;
   if (!starves(maxOutputTokens)) return null;
 
-  if (starves(Math.min(contextWindow, DEFAULT_MAX_OUTPUT_TOKENS))) {
-    return {
-      reason:
-        `contextWindow ${contextWindow} leaves no input budget for a text model even at the default ` +
-        `output cap (safety buffer ${CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS})`,
-      unfixable: true,
-    };
+  const claim =
+    `maxOutputTokens ${maxOutputTokens} leaves no input budget in a contextWindow of ${contextWindow} ` +
+    `(safety buffer ${CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS})`;
+
+  if (!starves(Math.min(contextWindow, DEFAULT_MAX_OUTPUT_TOKENS))) {
+    return { reason: `${claim}; maxOutputTokens dropped`, action: 'refuse' };
   }
-  return {
-    reason:
-      `maxOutputTokens ${maxOutputTokens} leaves no input budget in a contextWindow of ${contextWindow} ` +
-      `(safety buffer ${CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS}); claim refused`,
-    unfixable: false,
-  };
+
+  const halved = Math.floor((contextWindow - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS) / 2);
+  if (halved < 1) return { reason: `${claim}; no reserve leaves room for a prompt`, action: 'drop' };
+  return { reason: `${claim}; clamped to ${halved}`, action: 'clamp', to: halved };
 }
 
 type PlanOneResult = { entry: CatalogDiffEntry; row: IModelCatalogRowInput } | { unchanged: true } | { reason: string };
@@ -298,17 +307,26 @@ function planOne(
     }
   }
 
+  const derivedGroups = new Set<FieldGroup>();
   const outputClaim = starvedByOutputClaim(draft, contributed);
   let claimsMaxOutput = contributed.has('maxOutputTokens');
   if (outputClaim) {
-    if (outputClaim.unfixable) return { reason: outputClaim.reason };
+    if (outputClaim.action === 'drop') return { reason: outputClaim.reason };
     dropped.push({
-      source: candidate.sourceOfField.get('maxOutputTokens') ?? candidate.sourceNames.join('+'),
+      source:
+        candidate.sourceOfField.get('maxOutputTokens') ??
+        candidate.sourceOfField.get('contextWindow') ??
+        candidate.sourceNames.join('+'),
       modelId: candidate.modelId,
       reason: outputClaim.reason,
     });
-    delete draft.maxOutputTokens;
-    claimsMaxOutput = false;
+    if (outputClaim.action === 'clamp') {
+      draft.maxOutputTokens = outputClaim.to;
+      derivedGroups.add('limits');
+    } else {
+      delete draft.maxOutputTokens;
+      claimsMaxOutput = false;
+    }
   }
 
   const ownedGroups = new Set<FieldGroup>();
@@ -399,7 +417,13 @@ function planOne(
     patch: record,
     ownedGroups: owned,
     effectiveFrom: input.runStartedAt,
-    contributors: contributorsFor(candidate, contributed, owned, input.priorContributors?.get(candidate.modelId)),
+    contributors: contributorsFor(
+      candidate,
+      contributed,
+      owned,
+      input.priorContributors?.get(candidate.modelId),
+      derivedGroups
+    ),
     note: `discovery:${candidate.sourceNames.join('+')}@${input.runStartedAt.toISOString()}`,
     runId: input.runId,
   };
@@ -484,7 +508,10 @@ function contributorsFor(
   candidate: Candidate,
   contributed: ReadonlyMap<string, unknown>,
   owned: readonly FieldGroup[],
-  prior: readonly ICatalogContributor[] | undefined
+  prior: readonly ICatalogContributor[] | undefined,
+  // Groups this module computed a value for rather than took from a feed. Crediting the feed for a
+  // number we invented would make the row claim the provider reported it.
+  derived?: ReadonlySet<FieldGroup>
 ): ICatalogContributor[] {
   const bySource = new Map<FieldGroup, string>();
   for (const key of contributed.keys()) {
@@ -498,10 +525,11 @@ function contributorsFor(
   const carried = new Map((prior ?? []).map(entry => [entry.group, entry.source] as const));
   return owned.map(group => ({
     group,
-    source:
-      bySource.get(group) ??
-      carried.get(group) ??
-      (group === 'dispatch' ? DISPATCH_SEED_CONTRIBUTOR : DISCOVERY_CONTRIBUTOR),
+    source: derived?.has(group)
+      ? DISCOVERY_CONTRIBUTOR
+      : (bySource.get(group) ??
+        carried.get(group) ??
+        (group === 'dispatch' ? DISPATCH_SEED_CONTRIBUTOR : DISCOVERY_CONTRIBUTOR)),
   }));
 }
 

--- a/b4m-core/services/src/modelDiscoveryService/catalogWrite.ts
+++ b/b4m-core/services/src/modelDiscoveryService/catalogWrite.ts
@@ -1,4 +1,6 @@
 import {
+  CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS,
+  DEFAULT_MAX_OUTPUT_TOKENS,
   FIELD_GROUPS,
   FIELD_GROUP_OF,
   ModelRecordWrite,
@@ -226,6 +228,51 @@ function usableFields(
   return usable;
 }
 
+/**
+ * A text model whose output reserve eats its whole context window leaves safeInputWindow
+ * (ChatCompletionProcess) a non-positive input budget, and the chat path then refuses to build a
+ * prompt at all. The static tables are held to that by modelCatalogInputBudget.test.ts, but
+ * maxOutputTokens is in the feed-claimable `limits` group and a discovery row outranks the seed, so
+ * a fetched claim could put the failure back with those tables still clean.
+ *
+ * Refusing the field rather than clamping it hands the decision to the read path: a feed that
+ * reports its whole window as output has told us nothing about the real cap, and
+ * DEFAULT_MAX_OUTPUT_TOKENS is already what toModelInfo means by "unknown". Note mergeRows resolves
+ * per GROUP, not per key, so the value in force survives only when the refused field was this row's
+ * only `limits` claim; alongside a contextWindow claim the row wins the group and that fallback
+ * applies instead.
+ *
+ * `unfixable` marks the case with no fallback left - a window too small to fund even the default cap
+ * - where listing a model that can only fail once selected is worse than not listing it.
+ */
+function starvedByOutputClaim(
+  draft: Record<string, unknown>,
+  contributed: Map<string, unknown>
+): { reason: string; unfixable: boolean } | null {
+  if (draft.type !== 'text' || !contributed.has('maxOutputTokens')) return null;
+  const contextWindow = draft.contextWindow;
+  const maxOutputTokens = draft.maxOutputTokens;
+  if (typeof contextWindow !== 'number' || typeof maxOutputTokens !== 'number') return null;
+
+  const starves = (output: number) => contextWindow - output - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS <= 0;
+  if (!starves(maxOutputTokens)) return null;
+
+  if (starves(Math.min(contextWindow, DEFAULT_MAX_OUTPUT_TOKENS))) {
+    return {
+      reason:
+        `contextWindow ${contextWindow} leaves no input budget for a text model even at the default ` +
+        `output cap (safety buffer ${CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS})`,
+      unfixable: true,
+    };
+  }
+  return {
+    reason:
+      `maxOutputTokens ${maxOutputTokens} leaves no input budget in a contextWindow of ${contextWindow} ` +
+      `(safety buffer ${CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS}); claim refused`,
+    unfixable: false,
+  };
+}
+
 type PlanOneResult = { entry: CatalogDiffEntry; row: IModelCatalogRowInput } | { unchanged: true } | { reason: string };
 
 function planOne(
@@ -251,11 +298,25 @@ function planOne(
     }
   }
 
+  const outputClaim = starvedByOutputClaim(draft, contributed);
+  let claimsMaxOutput = contributed.has('maxOutputTokens');
+  if (outputClaim) {
+    if (outputClaim.unfixable) return { reason: outputClaim.reason };
+    dropped.push({
+      source: candidate.sourceOfField.get('maxOutputTokens') ?? candidate.sourceNames.join('+'),
+      modelId: candidate.modelId,
+      reason: outputClaim.reason,
+    });
+    delete draft.maxOutputTokens;
+    claimsMaxOutput = false;
+  }
+
   const ownedGroups = new Set<FieldGroup>();
   for (const key of contributed.keys()) {
     // A refused lifecycle block is not a claim: an ownedGroups entry no field
     // backs is overclaiming, which the row schema rejects at append time.
     if (key === 'lifecycle' && !claimsLifecycle) continue;
+    if (key === 'maxOutputTokens' && !claimsMaxOutput) continue;
     const group = FIELD_GROUP_OF[key as keyof ModelRecord];
     if (group) ownedGroups.add(group);
   }

--- a/packages/database/src/seeds/modelCatalog.seed.json
+++ b/packages/database/src/seeds/modelCatalog.seed.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-29T13:51:57.149Z",
-  "notice": "Fallback defaults last maintained on 2026-07-29. Models and pricing live-update at runtime; this seed only bootstraps empty databases and covers feed outages.",
+  "generatedAt": "2026-08-04T09:38:17.825Z",
+  "notice": "Fallback defaults last maintained on 2026-08-04. Models and pricing live-update at runtime; this seed only bootstraps empty databases and covers feed outages.",
   "entries": [
     {
       "modelId": "ai21.j2-mid-v1",
@@ -18,7 +18,7 @@
         "type": "text",
         "name": "Jurassic-2 Mid",
         "contextWindow": 8192,
-        "maxOutputTokens": 8192,
+        "maxOutputTokens": 4096,
         "canStream": false,
         "supportsVision": false,
         "supportsImageVariation": false,
@@ -46,7 +46,7 @@
         "type": "text",
         "name": "Jurassic-2 Ultra",
         "contextWindow": 8192,
-        "maxOutputTokens": 8192,
+        "maxOutputTokens": 4096,
         "canStream": false,
         "supportsVision": false,
         "supportsImageVariation": false,
@@ -2943,7 +2943,7 @@
         "type": "text",
         "name": "Kimi K2.5",
         "contextWindow": 262144,
-        "maxOutputTokens": 262144,
+        "maxOutputTokens": 131072,
         "canStream": true,
         "reasoning": {
           "supported": true
@@ -2976,7 +2976,7 @@
         "type": "text",
         "name": "Kimi K2.6",
         "contextWindow": 262144,
-        "maxOutputTokens": 262144,
+        "maxOutputTokens": 131072,
         "canStream": true,
         "reasoning": {
           "supported": true
@@ -3009,7 +3009,7 @@
         "type": "text",
         "name": "Kimi K2.7 Code",
         "contextWindow": 262144,
-        "maxOutputTokens": 262144,
+        "maxOutputTokens": 131072,
         "canStream": true,
         "reasoning": {
           "supported": true
@@ -3042,7 +3042,7 @@
         "type": "text",
         "name": "Kimi K2.7 Code (High Speed)",
         "contextWindow": 262144,
-        "maxOutputTokens": 262144,
+        "maxOutputTokens": 131072,
         "canStream": true,
         "reasoning": {
           "supported": true

--- a/packages/database/src/seeds/modelCatalogInputBudget.test.ts
+++ b/packages/database/src/seeds/modelCatalogInputBudget.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS, MODEL_INFO_TYPES } from '@bike4mind/common';
+import type { ModelInfo } from '@bike4mind/common';
+import { collectStaticCatalogModels } from './generateModelCatalogSeed';
+
+/**
+ * safeInputWindow (ChatCompletionProcess) sizes a prompt as
+ * contextWindow - reservedOutput - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS and is deliberately not
+ * clamped at zero, so a text row whose max_tokens eats its whole window makes the chat path refuse
+ * to build a prompt at all. That shipped as a live failure on six rows, which is why the tables are
+ * held to it here rather than at the consumption site.
+ *
+ * Ollama and LocalImage are absent from collectStaticCatalogModels (their listings are live server
+ * calls); the Ollama row carries the same assertion in llm-adapters/src/ollamaBackend.test.ts.
+ */
+
+const describeEntry = (model: ModelInfo) =>
+  `${model.id} (contextWindow ${model.contextWindow}, max_tokens ${model.max_tokens})`;
+
+/**
+ * Every ModelInfo type needs a deliberate rule. A type added to the union without one fails the
+ * exhaustiveness check below instead of silently inheriting an allow.
+ */
+const RULE_BY_TYPE: Record<ModelInfo['type'], 'reserves-output' | 'prompt-length-limit' | 'no-prompt-assembly'> = {
+  text: 'reserves-output',
+  // max_tokens is the prompt-length limit on these, never an output reserve: a model that returns
+  // media has no tokens to reserve, so safeInputWindow subtracts nothing for it.
+  image: 'prompt-length-limit',
+  video: 'prompt-length-limit',
+  // Transcription never enters prompt assembly, so neither figure is a token budget.
+  'speech-to-text': 'no-prompt-assembly',
+};
+
+describe('static model catalog input budget', () => {
+  it('rules on every ModelInfo type, so a new type cannot inherit an allow', () => {
+    expect(Object.keys(RULE_BY_TYPE).sort()).toEqual([...MODEL_INFO_TYPES].sort());
+  });
+
+  it('declares both window figures on every entry', async () => {
+    // An absent figure would pass the checks below vacuously, and safeInputWindow's own fallbacks
+    // (200000 / 16384) would then invent a budget the table never stated.
+    const models = await collectStaticCatalogModels();
+    const missing = models.filter(
+      model => typeof model.contextWindow !== 'number' || typeof model.max_tokens !== 'number'
+    );
+    expect(missing.map(model => model.id)).toEqual([]);
+  });
+
+  it('leaves a positive input budget on every text entry', async () => {
+    // Fix a failure by lowering max_tokens in the adapter table to a real output reserve, then
+    // regenerating the catalog seed - the seed row overlays the literal on a deployed environment.
+    const models = await collectStaticCatalogModels();
+    const starved = models.filter(
+      model =>
+        RULE_BY_TYPE[model.type] === 'reserves-output' &&
+        (model.contextWindow ?? 0) - (model.max_tokens ?? 0) - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS <= 0
+    );
+    expect(starved.map(describeEntry)).toEqual([]);
+  });
+
+  it('leaves a media entry a prompt it can fill', async () => {
+    const models = await collectStaticCatalogModels();
+    const media = models.filter(model => RULE_BY_TYPE[model.type] === 'prompt-length-limit');
+
+    // A prompt-length limit above the window it is measured against is a contradiction. Equality is
+    // the common shape; Gemini's image rows sit below it, and both are legal.
+    const overWindow = media.filter(model => (model.max_tokens ?? 0) > (model.contextWindow ?? 0));
+    expect(overWindow.map(describeEntry)).toEqual([]);
+
+    // No output is reserved for media, but the safety buffer still comes off the top.
+    const starved = media.filter(model => (model.contextWindow ?? 0) - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS <= 0);
+    expect(starved.map(describeEntry)).toEqual([]);
+  });
+});

--- a/packages/database/src/seeds/modelCatalogInputBudget.test.ts
+++ b/packages/database/src/seeds/modelCatalogInputBudget.test.ts
@@ -67,7 +67,9 @@ describe('static model catalog input budget', () => {
     const overWindow = media.filter(model => (model.max_tokens ?? 0) > (model.contextWindow ?? 0));
     expect(overWindow.map(describeEntry)).toEqual([]);
 
-    // No output is reserved for media, but the safety buffer still comes off the top.
+    // No output is reserved for media, but the safety buffer still comes off the top. This holds
+    // for the adapter tables only: two provider feeds report a media window as 0 on purpose, and a
+    // discovery row outranks the seed, which is a live failure tracked separately.
     const starved = media.filter(model => (model.contextWindow ?? 0) - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS <= 0);
     expect(starved.map(describeEntry)).toEqual([]);
   });


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="640" height="710" alt="jurassic2-ultra-token-allocation-after" src="https://github.com/user-attachments/assets/9195e350-1147-4342-9565-8a99557430a6" />

## Description
Closes #1165.

For a text model the server reserves the request's whole max-output out of the context window before it sizes a prompt, so a row advertising `max_tokens` equal to `contextWindow` computes a negative input budget and the chat path refuses to build a prompt at all. Six rows were in that shape: four Kimi (`262144/262144`) and both AI21 Jurassic-2 (`8192/8192`).

It is reachable from the app, not theoretical, and the path is all in code you can read: the output slider's ceiling is the row's own `max_tokens` (`AdvancedAIModal.tsx:806`), `SessionMiddle.tsx:269` sends that value raw rather than the defensively-capped one, and a prompt short enough to clear input validation still gets sent. The server then computes a negative budget and `ChatCompletionProcess.ts:2096` throws.

Measured on staging, which runs `main`, through the same route the picker reads: `ai21.j2-ultra-v1` and `ai21.j2-mid-v1` are both served with `contextWindow 8192` and an output cap of `8192`, leaving `8192 - 8192 - 1000 = -1000`. Negative is the refusal. The four Kimi rows are the same shape at `262144`, but staging carries no Moonshot key so they cannot be measured on a deployed environment at all.

Three things the issue assumed turned out differently, and the diff follows the code rather than the description:

- **The six OpenAI image and video rows the issue names are not the live bug.** `safeInputWindow` reserves no output for a media type, so `10000 - 0 - 1000 = 9000` and they never reach the guard. They keep the equal-value shape, with a comment saying why, because "correcting" them is what would reintroduce a negative budget.
- **The GPT-4 comment reword the issue asks for already landed** in #1004 itself. No change needed.
- **A claim in two existing comments was false.** Both said image and video rows set `max_tokens` equal to `contextWindow` "across every backend in the repo"; Gemini's four image rows set it lower, deliberately. Reworded to the property that holds.

The catalog seed is regenerated as part of the fix, not as housekeeping: `maxOutputTokens` is in the feed-claimable `limits` group and a seed row overlays the adapter literal, so on any database already holding one the corrected value would never have reached the app.

## Changes
- `kimiBackend.ts` — the four K2.x rows drop to `max_tokens: 131072`, half the window and the ceiling the K3 row already carries. Not a claim about Moonshot's real cap; a deliberate split that keeps `context - output - buffer` positive, following the precedent #1004 set for GPT-4.
- `bedrockBackend/jurassicTwo.ts` — both rows drop to `4096`, matching the GPT-4 row's 8192/4096.
- `modelCatalog.seed.json` — regenerated. Exactly those six `maxOutputTokens` values plus the timestamp.
- `ollamaBackend.ts` — stops advertising the whole allocated window as output. `OLLAMA_MAX_NUM_CTX` accepts any positive value, so the cap also stays under what the safety buffer leaves and at least one input token survives whatever the window is.
- `common/modelCatalog.ts` — `CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS` is now a named export rather than a default parameter on a module-private function, so a catalog row can be checked against the same figure the chat path reserves. Wired into both `safeInputWindow` call sites.
- `modelCatalogInputBudget.test.ts` (new) — walks every static backend and holds each text row to a positive input budget, so a row with the two figures conflated fails in CI. Media rows are asserted separately with the weaker bound Gemini's image rows also satisfy. Every `ModelInfo` type needs an entry in the rule table, so a new type cannot inherit an allow.
- `modelDiscoveryService/catalogWrite.ts` — a discovery row outranks the seed for `limits`, so a fetched claim could put the failure back with the static tables clean. `planOne` now refuses a claim that leaves no input room, reading the resulting draft rather than which field arrived: the Kimi and xAI provider sources send `contextWindow` and never an output cap, and a window lowered onto the cap already in force is the same starving pair from the other side. Reported on the existing `dropped` channel, which stays silent on a healthy run.

## Guide for Testers

Read this before starting: **neither Kimi nor Jurassic-2 can be driven end to end on staging**, and that is an environment fact, not a symptom of this PR.

- All four Kimi rows are absent from staging's catalog: `GET /api/models` there returns 83 models and no `kimi-*`, because that stage carries no Moonshot key.
- `ai21.j2-ultra-v1` **is** served on staging via keyless Bedrock, but it is `enabled: false` in the saved LLM Model Configurations, and `isModelAccessible` short-circuits a disabled config for everyone including admins. So the picker shows "No models found" for it.
- AWS has also retired the `ai21.j2-*` ids from Bedrock, so even when selectable the turn fails at the provider.

So verify on **this PR's preview**, where the numbers are what the change controls.

1. Open the preview URL from the deploy comment on this PR.
2. Go to **Admin -> LLM Models** and confirm **Jurassic-2 Ultra** is enabled. If it is not, enable it. This is a preview environment, so changing it affects nobody.
3. Open a new chat, open the model picker, search `Jurassic-2 Ultra`, and select it.
4. Open **Advanced AI settings** and find the **Token Allocation** section.
5. **Expected:** the **Output** field reads `4 096` and the **Input** field reads `4 096`. The slider's maximum is `4 096`.
6. **What this rules out:** on `main` the same panel reads **Output `8 192`, Input `0`** — the model advertises its whole 8192-token window as output, so nothing is left for a prompt and the turn is refused with `no input budget`. An Input of `0` is the bug; an Input of `4 096` is the fix. The PR body carries the `main`-side measurement, taken from staging's own `/api/models`, because reproducing it in the UI would mean flipping a shared admin setting.
7. Select **GPT-Image-1** and generate an image from the prompt `a red bicycle`. It should generate as before. Media rows are deliberately unchanged and this confirms they still work.

**What NOT to test:**

8. Do not try to get a text reply out of Jurassic-2 Ultra. AWS retired those ids, so the turn fails at the provider after the prompt is built. A provider error there is expected and is **NOT** a failure of this PR — what this PR controls is whether a prompt gets built at all.
9. Kimi needs its ids kept apart, and QA hit this on the first pass. The rows this PR corrects are the **Moonshot-direct** ones (`kimi-k2.5`, `kimi-k2.6`, `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`), and neither staging nor the preview carries a Moonshot key, so those ids appear on neither environment. Their absence is **NOT** a regression from this PR, and the `131 072` ceiling applies only to them, so it cannot be observed anywhere here. What the preview *does* list is the **Bedrock-hosted** pair `moonshotai.kimi-k2.5` and `moonshot.kimi-k2-thinking` at `262144 / 16 384`: a different backend, untouched by this PR, whose 16 384 cap is correct by its own model description. An Output ceiling of `16 384` on those rows is **NOT** a failure.
10. The discovery-feed guard has no UI. It runs only during a scheduled model-discovery run and is covered by unit tests in `catalogWrite.test.ts`.
11. Media models whose context window arrives as `0` from a provider feed are a separate, pre-existing failure tracked in #1409 and deliberately not fixed here. Image generation failing on a model whose window shows as `0` is #1409, not this PR.

## Additional Information

**Deferred, with a ticket:** #1409. Two provider feeds report a media model's context window as `0` meaning "not applicable", a discovery row outranks the seed for that field, and `safeInputWindow` then subtracts the safety buffer from zero and the empty-prompt guard throws on an image request. The honest fix is in `safeInputWindow` treating "not applicable" as "zero tokens", which this ticket was scoped not to touch. The new test's comment and the `safeInputWindow` docstring both say the media assertion covers the adapter tables only, so nothing here implies coverage it does not have.

**Not in scope, noted:** with `max_tokens` at exactly 4096 the numeric Output field in `AdvancedAIModal` accepts only that one value. Already true of GPT-4 and GPT-4o, so Jurassic-2 joins them rather than regressing.

**Local test signal:** typecheck and lint clean. `services` 3478, `llm-adapters` 644, `database` 1431, `utils` 669 all pass. The `client` package would not go fully green on my machine: three runs failed 6, 6 and 2 Mongo-backed `*.e2e.test.ts` cases, always a 15s startup timeout, and the failing set was disjoint each run with 8414 of 8497 passing. Every previously-failing file passed on the next run, and none are in this diff.

Five mutation checks were run against the new assertions, one per arm, and all failed as required when the guard or the corrected value was reverted.

## Developer Notes (Optional)
- `CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS` in `@bike4mind/common` is the shared figure for anything that needs to reason about the chat input budget. Both `safeInputWindow` call sites and both new test suites read it, so the rule CI enforces cannot drift from what production reserves.
- `contributorsFor` in `catalogWrite` takes an optional set of `derived` groups. A group whose value this module computed rather than took from a feed is credited to `DISCOVERY_CONTRIBUTOR`, so a row never claims a provider reported a number we invented.
- `modelCatalogInputBudget.test.ts` shows the shape for a catalog-wide invariant: `collectStaticCatalogModels()` plus an exhaustive per-type rule table, which fails when the `ModelInfo` type union grows rather than silently exempting the new member.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc

