### PR TITLE
fix(client): let Context Inspector list benign score-0 telemetry turns

### DIFF
--- a/apps/client/app/components/admin/ContextInspectorTab.tsx
+++ b/apps/client/app/components/admin/ContextInspectorTab.tsx
@@ -119,8 +119,12 @@ const SEVERITY_COLORS: Record<AnomalySeverity, string> = {
   critical: '#f44336',
 };
 
-// Severity icons
-const SeverityIcon = ({ severity }: { severity: AnomalySeverity }) => {
+// Severity icons. Benign turns are stored as severity 'low' (there is no benign tier),
+// so they are flagged separately rather than sharing the real low-severity indicator.
+const SeverityIcon = ({ severity, benign }: { severity: AnomalySeverity; benign?: boolean }) => {
+  if (benign) {
+    return <InfoIcon sx={{ color: 'neutral.400' }} />;
+  }
   switch (severity) {
     case 'critical':
       return <ErrorIcon sx={{ color: SEVERITY_COLORS.critical }} />;
@@ -1402,7 +1406,7 @@ const TelemetryEntryCard = ({
       <CardContent>
         <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 1 }}>
           <Stack direction="row" spacing={1} alignItems="center">
-            <SeverityIcon severity={anomalies.severity} />
+            <SeverityIcon severity={anomalies.severity} benign={anomalies.primaryAnomaly === 'none'} />
             <Typography level="title-sm">{model.modelId}</Typography>
             <Chip size="sm" variant="outlined">
               {model.provider}

--- a/apps/client/app/components/admin/ContextInspectorTab.tsx
+++ b/apps/client/app/components/admin/ContextInspectorTab.tsx
@@ -1854,19 +1854,43 @@ export function ContextInspectorTab() {
             <Typography level="body-sm" sx={{ mb: 0.5 }}>
               Start Date
             </Typography>
-            <Input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} size="sm" />
+            <Input
+              type="date"
+              value={startDate}
+              onChange={e => {
+                setStartDate(e.target.value);
+                setPage(0);
+              }}
+              size="sm"
+            />
           </Grid>
           <Grid xs={6} md={2}>
             <Typography level="body-sm" sx={{ mb: 0.5 }}>
               End Date
             </Typography>
-            <Input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} size="sm" />
+            <Input
+              type="date"
+              value={endDate}
+              onChange={e => {
+                setEndDate(e.target.value);
+                setPage(0);
+              }}
+              size="sm"
+            />
           </Grid>
           <Grid xs={6} md={2}>
             <Typography level="body-sm" sx={{ mb: 0.5 }}>
               Provider
             </Typography>
-            <Select size="sm" value={provider} onChange={(_, v) => setProvider(v)} placeholder="All Providers">
+            <Select
+              size="sm"
+              value={provider}
+              onChange={(_, v) => {
+                setProvider(v);
+                setPage(0);
+              }}
+              placeholder="All Providers"
+            >
               <Option value={null}>All Providers</Option>
               {data?.stats?.providers?.map(p => (
                 <Option key={p} value={p}>
@@ -1879,7 +1903,15 @@ export function ContextInspectorTab() {
             <Typography level="body-sm" sx={{ mb: 0.5 }}>
               Min Anomaly Score
             </Typography>
-            <Select size="sm" value={minAnomalyScore} onChange={(_, v) => setMinAnomalyScore(v)} placeholder="Any">
+            <Select
+              size="sm"
+              value={minAnomalyScore}
+              onChange={(_, v) => {
+                setMinAnomalyScore(v);
+                setPage(0);
+              }}
+              placeholder="Any"
+            >
               <Option value={null}>Any (&gt;0)</Option>
               <Option value={0}>0 / All</Option>
               <Option value={30}>30+</Option>
@@ -1891,7 +1923,15 @@ export function ContextInspectorTab() {
             <Typography level="body-sm" sx={{ mb: 0.5 }}>
               Severity
             </Typography>
-            <Select size="sm" value={severity} onChange={(_, v) => setSeverity(v)} placeholder="All">
+            <Select
+              size="sm"
+              value={severity}
+              onChange={(_, v) => {
+                setSeverity(v);
+                setPage(0);
+              }}
+              placeholder="All"
+            >
               <Option value={null}>All</Option>
               <Option value="critical">Critical</Option>
               <Option value="high">High</Option>
@@ -1903,7 +1943,15 @@ export function ContextInspectorTab() {
             <Typography level="body-sm" sx={{ mb: 0.5 }}>
               Anomaly Type
             </Typography>
-            <Select size="sm" value={anomalyType} onChange={(_, v) => setAnomalyType(v)} placeholder="All">
+            <Select
+              size="sm"
+              value={anomalyType}
+              onChange={(_, v) => {
+                setAnomalyType(v);
+                setPage(0);
+              }}
+              placeholder="All"
+            >
               <Option value={null}>All</Option>
               <Option value="context_overflow">Context Overflow</Option>
               <Option value="high_truncation">High Truncation</Option>

--- a/apps/client/app/components/admin/ContextInspectorTab.tsx
+++ b/apps/client/app/components/admin/ContextInspectorTab.tsx
@@ -1880,6 +1880,7 @@ export function ContextInspectorTab() {
               Min Anomaly Score
             </Typography>
             <Select size="sm" value={minAnomalyScore} onChange={(_, v) => setMinAnomalyScore(v)} placeholder="Any">
+              <Option value={0}>0 / All</Option>
               <Option value={null}>Any (&gt;0)</Option>
               <Option value={30}>30+</Option>
               <Option value={50}>50+</Option>

--- a/apps/client/app/components/admin/ContextInspectorTab.tsx
+++ b/apps/client/app/components/admin/ContextInspectorTab.tsx
@@ -1880,8 +1880,8 @@ export function ContextInspectorTab() {
               Min Anomaly Score
             </Typography>
             <Select size="sm" value={minAnomalyScore} onChange={(_, v) => setMinAnomalyScore(v)} placeholder="Any">
-              <Option value={0}>0 / All</Option>
               <Option value={null}>Any (&gt;0)</Option>
+              <Option value={0}>0 / All</Option>
               <Option value={30}>30+</Option>
               <Option value={50}>50+</Option>
               <Option value={70}>70+</Option>

--- a/apps/client/pages/api/admin/__tests__/context-telemetry.test.ts
+++ b/apps/client/pages/api/admin/__tests__/context-telemetry.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+
+const { mockFind, mockCount, mockAggregate } = vi.hoisted(() => ({
+  mockFind: vi.fn(),
+  mockCount: vi.fn(),
+  mockAggregate: vi.fn(),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
+      {
+        use: () => chain,
+        get: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.GET = fns[fns.length - 1]), chain),
+      }
+    );
+    return chain;
+  },
+}));
+
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (fn: (req: unknown, res: unknown) => unknown) => fn,
+}));
+
+vi.mock('@server/utils/errors', () => ({
+  ForbiddenError: class ForbiddenError extends Error {},
+}));
+
+vi.mock('@server/utils/telemetryProjection', () => ({
+  TELEMETRY_SAFE_PROJECTION: 'timestamp promptMeta.contextTelemetry',
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  Quest: {
+    find: (...a: unknown[]) => mockFind(...a),
+    countDocuments: (...a: unknown[]) => mockCount(...a),
+    aggregate: (...a: unknown[]) => mockAggregate(...a),
+  },
+}));
+
+import handler from '../context-telemetry';
+
+const SCORE_PATH = 'promptMeta.contextTelemetry.anomalies.anomalyScore';
+
+const run = (query: Record<string, string> = {}, user: unknown = { id: 'admin1', isAdmin: true }) => {
+  const { req, res } = createMocks({ method: 'GET', query });
+  if (user) (req as Record<string, unknown>).user = user;
+  return { res, promise: (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res) };
+};
+
+const findQuery = () => mockFind.mock.calls[0][0] as Record<string, unknown>;
+
+const questChain = (entries: unknown[]) => ({
+  select: vi.fn().mockReturnThis(),
+  sort: vi.fn().mockReturnThis(),
+  skip: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  lean: vi.fn().mockResolvedValue(entries),
+});
+
+beforeEach(() => {
+  mockFind.mockReset().mockReturnValue(questChain([]));
+  mockCount.mockReset().mockResolvedValue(0);
+  mockAggregate.mockReset().mockResolvedValue([]);
+});
+
+describe('GET /api/admin/context-telemetry', () => {
+  it('rejects non-admin callers', async () => {
+    const { promise } = run({}, { id: 'u2', isAdmin: false });
+    await expect(promise).rejects.toThrow(/Admin access required/);
+  });
+
+  it('defaults to anomalous turns only when no minimum is requested', async () => {
+    const { res, promise } = run();
+    await promise;
+    expect(res._getStatusCode()).toBe(200);
+    expect(findQuery()[SCORE_PATH]).toEqual({ $gt: 0 });
+  });
+
+  it('drops the score filter entirely when minAnomalyScore=0', async () => {
+    const { promise } = run({ minAnomalyScore: '0' });
+    await promise;
+    const query = findQuery();
+    expect(query[SCORE_PATH]).toBeUndefined();
+    expect(query['promptMeta.contextTelemetry']).toEqual({ $exists: true });
+    // total and stats must reflect the same widened filter as the entry list
+    expect(mockCount).toHaveBeenCalledWith(query);
+    expect(mockAggregate.mock.calls[0][0][0]).toEqual({ $match: query });
+  });
+
+  it('filters to scores at or above the requested minimum', async () => {
+    const { promise } = run({ minAnomalyScore: '30' });
+    await promise;
+    expect(findQuery()[SCORE_PATH]).toEqual({ $gte: 30 });
+  });
+
+  it.each(['abc', '-5', '150', ''])(
+    'falls back to the anomalies-only default for invalid minAnomalyScore=%j',
+    async raw => {
+      const { promise } = run({ minAnomalyScore: raw });
+      await promise;
+      expect(findQuery()[SCORE_PATH]).toEqual({ $gt: 0 });
+    }
+  );
+
+  it('returns benign entries with their telemetry when minAnomalyScore=0', async () => {
+    const timestamp = new Date('2026-08-04T06:27:22.185Z');
+    const telemetry = { captureLevel: 'enhanced', anomalies: { anomalyScore: 0, primaryAnomaly: 'none' } };
+    mockFind.mockReturnValue(questChain([{ _id: 'quest-1', timestamp, promptMeta: { contextTelemetry: telemetry } }]));
+    mockCount.mockResolvedValue(1);
+
+    const { res, promise } = run({ minAnomalyScore: '0' });
+    await promise;
+
+    const body = res._getJSONData();
+    expect(body.total).toBe(1);
+    expect(body.entries).toEqual([{ id: 'quest-1', timestamp: timestamp.toISOString(), telemetry }]);
+  });
+});

--- a/apps/client/pages/api/admin/__tests__/context-telemetry.test.ts
+++ b/apps/client/pages/api/admin/__tests__/context-telemetry.test.ts
@@ -124,6 +124,27 @@ describe('GET /api/admin/context-telemetry', () => {
     }
   );
 
+  it('excludes benign turns when filtering by severity', async () => {
+    const { promise } = run({ minAnomalyScore: '0', severity: 'low' });
+    await promise;
+    const query = findQuery();
+    expect(query['promptMeta.contextTelemetry.anomalies.severity']).toBe('low');
+    // benign turns are stored as severity 'low', so "Severity: Low" must not match them
+    expect(query['promptMeta.contextTelemetry.anomalies.primaryAnomaly']).toEqual({ $ne: 'none' });
+  });
+
+  it('lets an explicit anomaly type win over the severity exclusion', async () => {
+    const { promise } = run({ severity: 'high', anomalyType: 'tool_failure' });
+    await promise;
+    expect(findQuery()['promptMeta.contextTelemetry.anomalies.primaryAnomaly']).toBe('tool_failure');
+  });
+
+  it('leaves primaryAnomaly unconstrained when neither severity nor type is filtered', async () => {
+    const { promise } = run({ minAnomalyScore: '0' });
+    await promise;
+    expect(findQuery()['promptMeta.contextTelemetry.anomalies.primaryAnomaly']).toBeUndefined();
+  });
+
   it('returns benign entries with their telemetry when minAnomalyScore=0', async () => {
     const timestamp = new Date('2026-08-04T06:27:22.185Z');
     const telemetry = { captureLevel: 'enhanced', anomalies: { anomalyScore: 0, primaryAnomaly: 'none' } };

--- a/apps/client/pages/api/admin/__tests__/context-telemetry.test.ts
+++ b/apps/client/pages/api/admin/__tests__/context-telemetry.test.ts
@@ -80,15 +80,33 @@ describe('GET /api/admin/context-telemetry', () => {
     expect(findQuery()[SCORE_PATH]).toEqual({ $gt: 0 });
   });
 
-  it('drops the score filter entirely when minAnomalyScore=0', async () => {
+  it('widens to benign score-0 turns when minAnomalyScore=0', async () => {
     const { promise } = run({ minAnomalyScore: '0' });
     await promise;
     const query = findQuery();
-    expect(query[SCORE_PATH]).toBeUndefined();
+    // $gte: 0 rather than a dropped predicate, so every path filters on the same
+    // anomalyScore key and legacy docs without the anomalies sub-object stay out
+    expect(query[SCORE_PATH]).toEqual({ $gte: 0 });
     expect(query['promptMeta.contextTelemetry']).toEqual({ $exists: true });
     // total and stats must reflect the same widened filter as the entry list
     expect(mockCount).toHaveBeenCalledWith(query);
     expect(mockAggregate.mock.calls[0][0][0]).toEqual({ $match: query });
+  });
+
+  it('excludes benign turns from the severity distribution', async () => {
+    const { promise } = run({ minAnomalyScore: '0' });
+    await promise;
+    const groupStage = (mockAggregate.mock.calls[0][0] as Record<string, unknown>[])[1] as {
+      $group: { severityCounts: { $push: { $cond: unknown[] } } };
+    };
+    // benign turns are stored as severity 'low', so the distribution must only
+    // describe real anomalies — same condition totalAnomalies uses
+    expect(groupStage.$group.severityCounts.$push.$cond[0]).toEqual({
+      $and: [
+        { $ne: ['$promptMeta.contextTelemetry.anomalies.severity', null] },
+        { $ne: ['$promptMeta.contextTelemetry.anomalies.primaryAnomaly', 'none'] },
+      ],
+    });
   });
 
   it('filters to scores at or above the requested minimum', async () => {

--- a/apps/client/pages/api/admin/context-telemetry.ts
+++ b/apps/client/pages/api/admin/context-telemetry.ts
@@ -66,8 +66,15 @@ const handler = baseApi().get(
       query['promptMeta.contextTelemetry.anomalies.severity'] = params.severity;
     }
 
+    // primaryAnomaly: an explicit type filter wins; otherwise a severity filter still
+    // has to exclude benign turns, which are stored as severity 'low' because there is
+    // no benign tier (TelemetryBuilder floors at 'low'). Keeps "Severity: Low" meaning
+    // real low-severity anomalies, matching the Severity Distribution stat. No-op on
+    // the default view, where score > 0 already implies a real anomaly.
     if (params.anomalyType && params.anomalyType !== 'none') {
       query['promptMeta.contextTelemetry.anomalies.primaryAnomaly'] = params.anomalyType;
+    } else if (params.severity) {
+      query['promptMeta.contextTelemetry.anomalies.primaryAnomaly'] = { $ne: 'none' };
     }
 
     const [entries, total] = await Promise.all([

--- a/apps/client/pages/api/admin/context-telemetry.ts
+++ b/apps/client/pages/api/admin/context-telemetry.ts
@@ -33,7 +33,6 @@ const handler = baseApi().get(
     // Build query - only fetch quests with context telemetry
     const query: Record<string, unknown> = {
       'promptMeta.contextTelemetry': { $exists: true },
-      'promptMeta.contextTelemetry.anomalies.anomalyScore': { $gt: 0 },
     };
 
     if (params.startDate || params.endDate) {
@@ -50,12 +49,14 @@ const handler = baseApi().get(
       query['promptMeta.contextTelemetry.model.provider'] = params.provider;
     }
 
-    if (params.minAnomalyScore) {
-      const minScore = parseInt(params.minAnomalyScore, 10);
-      // Validate parsed number to prevent NaN from breaking the query
-      if (!Number.isNaN(minScore) && minScore > 0 && minScore <= 100) {
-        query['promptMeta.contextTelemetry.anomalies.anomalyScore'] = { $gte: minScore };
-      }
+    // Score filter: absent or invalid minAnomalyScore keeps the legacy default of
+    // anomalous turns only ($gt: 0); an explicit 0 includes benign score-0 turns
+    // (no score filter); 1-100 filters to scores >= the requested minimum.
+    const minScore = params.minAnomalyScore === undefined ? NaN : parseInt(params.minAnomalyScore, 10);
+    if (Number.isNaN(minScore) || minScore < 0 || minScore > 100) {
+      query['promptMeta.contextTelemetry.anomalies.anomalyScore'] = { $gt: 0 };
+    } else if (minScore > 0) {
+      query['promptMeta.contextTelemetry.anomalies.anomalyScore'] = { $gte: minScore };
     }
 
     if (params.severity) {

--- a/apps/client/pages/api/admin/context-telemetry.ts
+++ b/apps/client/pages/api/admin/context-telemetry.ts
@@ -50,12 +50,15 @@ const handler = baseApi().get(
     }
 
     // Score filter: absent or invalid minAnomalyScore keeps the legacy default of
-    // anomalous turns only ($gt: 0); an explicit 0 includes benign score-0 turns
-    // (no score filter); 1-100 filters to scores >= the requested minimum.
+    // anomalous turns only ($gt: 0); an explicit 0-100 filters to scores >= the
+    // requested minimum, so 0 includes benign turns. The 0 case deliberately uses
+    // $gte: 0 rather than dropping the predicate: every path then hits the same
+    // anomalyScore key (index-ready), and legacy docs lacking the anomalies
+    // sub-object stay excluded (TelemetryEntryCard reads anomalies.* unguarded).
     const minScore = params.minAnomalyScore === undefined ? NaN : parseInt(params.minAnomalyScore, 10);
     if (Number.isNaN(minScore) || minScore < 0 || minScore > 100) {
       query['promptMeta.contextTelemetry.anomalies.anomalyScore'] = { $gt: 0 };
-    } else if (minScore > 0) {
+    } else {
       query['promptMeta.contextTelemetry.anomalies.anomalyScore'] = { $gte: minScore };
     }
 
@@ -96,11 +99,19 @@ const handler = baseApi().get(
           avgResponseTime: { $avg: '$promptMeta.contextTelemetry.performance.totalResponseTimeMs' },
           providers: { $addToSet: '$promptMeta.contextTelemetry.model.provider' },
           models: { $addToSet: '$promptMeta.contextTelemetry.model.modelId' },
-          // Only push non-null severity values
+          // Only count severity for real anomalies (must stay in sync with the
+          // totalAnomalies condition above): benign turns are stored as severity
+          // 'low' (there is no benign tier), so with minAnomalyScore=0 they would
+          // otherwise swamp the distribution.
           severityCounts: {
             $push: {
               $cond: [
-                { $ne: ['$promptMeta.contextTelemetry.anomalies.severity', null] },
+                {
+                  $and: [
+                    { $ne: ['$promptMeta.contextTelemetry.anomalies.severity', null] },
+                    { $ne: ['$promptMeta.contextTelemetry.anomalies.primaryAnomaly', 'none'] },
+                  ],
+                },
                 '$promptMeta.contextTelemetry.anomalies.severity',
                 '$$REMOVE',
               ],


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
New filter: "0 / All"
<img width="1111" height="962" alt="Screenshot 2026-08-04 at 20 21 09" src="https://github.com/user-attachments/assets/039ba0cc-fa0e-459e-a38b-4a0501124340" />


## Description

Fixes #1255.

The admin Context Inspector could not surface benign turns (anomaly score 0). The list endpoint (`GET /api/admin/context-telemetry`) hardcoded `anomalyScore: { $gt: 0 }` into its base query, and an explicit `minAnomalyScore=0` was silently discarded by the `minScore > 0` validation guard — so no parameter combination could return a score-0 entry. The UI compounded this: the Min Anomaly Score filter only offered `Any (>0)` / `30+` / `50+` / `70+`, with no zero state. A normal turn was therefore only inspectable if it happened to earn a non-zero anomaly score, which defeats the point of inspecting the per-section context makeup of an ordinary turn (the #810 use case).

This PR adds an explicit zero passthrough while preserving the existing default: with no `minAnomalyScore` param (or an invalid one), the endpoint still returns anomalous turns only, so existing behavior and stats are unchanged for anyone not opting in.

## Changes

- `apps/client/pages/api/admin/context-telemetry.ts`: removed the hardcoded `$gt: 0` from the base query and centralized the score filter in one decision block — param absent/invalid → legacy `$gt: 0` (anomalies only), explicit `0-100` → `$gte: N`, so `0` includes benign turns while still filtering on the same `anomalyScore` key on every path (index-ready, and legacy docs without the `anomalies` sub-object stay excluded). `countDocuments` and the stats aggregation reuse the same query object, so totals and stat cards follow the selected filter automatically.
- `apps/client/pages/api/admin/context-telemetry.ts` (review follow-up): the Severity Distribution stat now only counts entries with `primaryAnomaly != 'none'` (same condition as `totalAnomalies`), so benign turns — stored as severity `low` — don't swamp the card when `0 / All` is selected.
- `apps/client/app/components/admin/ContextInspectorTab.tsx`: added a `0 / All` option to the Min Anomaly Score select (labels per the issue's suggestion); the default remains `Any (>0)` and stays first in the list. No plumbing changes were needed — the existing `?? undefined` and `!== undefined` checks already pass `0` through correctly.
- `apps/client/app/components/admin/ContextInspectorTab.tsx` (separate commit): changing any of the six list filters now resets pagination to the first page, fixing a pre-existing papercut where switching filters from a later page kept the stale offset and could render an empty page.
- Both files (second review round): the Severity **filter** now also requires `primaryAnomaly != 'none'`, so `Severity: Low` means real low-severity anomalies rather than every benign turn — the other half of the conflation the stat-card fix addressed. An explicit Anomaly Type filter still wins, and the default view is unaffected since `score > 0` already implies a real anomaly. Entry cards show a neutral indicator for benign turns instead of the green check used for genuine low-severity anomalies, so the display agrees with the filter.
- `apps/client/pages/api/admin/__tests__/context-telemetry.test.ts` (new; first tests for this route): covers admin rejection, the anomalies-only default, the zero passthrough (including that `countDocuments` and the aggregation `$match` receive the same widened query), `$gte` mapping for `minAnomalyScore=30`, fallback-to-default for invalid params (`abc`, `-5`, `150`, empty), response-shape mapping for a benign entry, and a regression pin on the severity-distribution condition staying in sync with `totalAnomalies`.

## Guide for Testers

1. Log in to `app.staging.bike4mind.com` as an **admin** user.
2. Navigate to Sidebar → **Admin** → **AI & Agents** → **Context Inspector**. Expected: the Context Telemetry Inspector page loads.
3. Confirm the **Telemetry Collection** toggle (top right) shows **Enabled**. If not, enable it.
4. Click your avatar (bottom left) → **Profile** → **Experimental Features** → under **Help Improve**, select **Enhanced**. Expected: the Enhanced button is highlighted.
5. Open a **New Chat** and type `Hello` in the message input, then send. Expected: a response streams in within a few seconds with no errors. (If the response takes longer than ~10 seconds to start, the turn scores non-zero for slow first token — send another `Hello` once the model is warm and use that turn instead.)
6. Return to **Admin** → **Context Inspector** and click **Refresh**. Expected: the `Hello` turn does **not** appear in the list (default filter unchanged: anomalies only).
7. In the **Min Anomaly Score** filter, select **`0 / All`**. Expected: the `Hello` turn appears with Anomaly Score `0/100`, a green "No Anomalies" chip, and the **Total Entries** stat includes it.
8. Expand the entry's **Details** accordion. Expected: Token Distribution and System Prompts sections render (Enhanced capture) — this is the #810 inspection flow that was previously unreachable.
9. Switch the filter back to **`Any (>0)`**. Expected: the benign entry disappears from the list and the stats shrink accordingly.
10. Select **`30+`**. Expected: only entries with score ≥ 30 are listed (the list may be empty on a quiet environment).

### Regression Checks

- On first load (no filters touched), the list shows the same anomalies-only content as before this PR.
- Combine `0 / All` with the other filters (Provider, Severity, Anomaly Type, Start/End Date) — each still narrows the result set correctly.
- `GET /api/admin/context-telemetry?minAnomalyScore=abc` and `?minAnomalyScore=150` behave like no param at all (anomalies only), not an error.
- Non-admin users still receive a 403 from the endpoint.
- The Analyze and Create GitHub Issue actions still work on a listed entry (score-0 entries included).
- With `0 / All` selected, the Severity Distribution card still shows only real anomalies (a benign `Hello` turn increases Total Entries but not the `low` chip).
- With `0 / All` + `Severity: Low`, benign turns are **not** listed (only genuine low-severity anomalies, scores 1-19). With `Any (>0)` + `Severity: Low`, the result set is unchanged from before this PR.
- `Severity: High` + `Anomaly Type: Tool Failure` still filters to that anomaly type (the explicit type filter takes precedence).
- Pagination reset: with `0 / All` selected and more than 20 entries, go to page 2, then change any filter (e.g. Severity). Expected: the list returns to page 1 and shows results, not an empty page.

## Additional Information

- Found during QA of #1126; filed as #1255. The single-entry route (`context-telemetry/[id]`) and `export.ts` never had the score exclusion and are intentionally untouched; `metrics.ts` keeps its `$gt: 0` because there it is a semantically correct "count of anomalous entries", not a listing filter.
- A pre-existing papercut noticed during this work — filter changes not resetting pagination — is fixed here in its own commit rather than deferred, since the fix is six one-line handler changes in the same filter row this PR already touches.
- Review follow-ups from the first round are addressed in a dedicated commit: severity stats are anomaly-only, the zero path uses `$gte: 0` (index-ready; see the inline reply on the index thread for why the index itself is deferred), and the filter options are ordered default-first. The second round's severity-filter finding is fixed in a further commit, so the benign/low conflation is now closed on the stat card, the list filter, and the entry indicator.
- Still deliberately deferred: a supporting index for the widened `0 / All` query path. All filter paths now share the `anomalies.anomalyScore` key, so a future `{ anomalyScore: 1, timestamp: -1 }` index (likely with a `partialFilterExpression` on telemetry existence) would cover them all — but it is write cost on every telemetry-bearing quest write to speed up an admin-only, opt-in filter, so it should be decided against production numbers in its own PR rather than bundled here. The endpoint is no slower than before for the default view.

## Developer Notes (Optional)

- The new test file establishes the mock harness pattern for this route (mocked `baseApi`/`asyncHandler`/`Quest` with query-object assertions, mirroring `credit-adjustments.test.ts`) — future changes to the telemetry list endpoint have a place to land tests.
- The score-filter contract is now centralized in a single decision block in the endpoint, so future filter states (e.g. severity-aware defaults) have one obvious place to go.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
