### PR TITLE
feat(client): export and refresh actions for published artifacts

### DIFF
--- a/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.test.tsx
+++ b/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.test.tsx
@@ -1,11 +1,20 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes/themePrimitives';
 
-const { mockList } = vi.hoisted(() => ({ mockList: vi.fn() }));
+const { mockList, mockExport, mockDownloadData, mockToastError, mockToastSuccess, mockRefresh } = vi.hoisted(() => ({
+  mockList: vi.fn(),
+  mockExport: vi.fn(),
+  mockDownloadData: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockRefresh: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: mockToastError, success: mockToastSuccess } }));
 
 vi.mock('@client/app/utils/publishApi', () => ({
   listMyPublishedArtifacts: (...a: unknown[]) => mockList(...a),
@@ -14,6 +23,15 @@ vi.mock('@client/app/utils/publishApi', () => ({
   updatePublishedCommentPolicy: vi.fn(),
   restorePreviousVersion: vi.fn(),
   toArtifactSharePath: (_t: string, s: string, slug: string) => `/p/u/${s}/${slug}`,
+  fetchPublishedExport: (...a: unknown[]) => mockExport(...a),
+  refreshPublishedFromSource: (...a: unknown[]) => mockRefresh(...a),
+  // Real predicate - the point of these tests is that the button follows it.
+  canRefreshFromSource: (a: { source: { kind: string; artifactId?: string } }) =>
+    a.source.kind === 'bundle' && !!a.source.artifactId,
+}));
+
+vi.mock('@client/app/utils/download', () => ({
+  downloadData: (...a: unknown[]) => mockDownloadData(...a),
 }));
 
 // Stub the panel so this test targets the toggle wiring, not the panel's fetch.
@@ -35,20 +53,28 @@ const renderTab = () => {
   );
 };
 
+const bundleRow = {
+  publicId: 'pub-1',
+  tier: 'user',
+  scopeId: 'erik',
+  slug: 's',
+  title: 'My Artifact',
+  visibility: 'public',
+  commentPolicy: 'none',
+  source: { kind: 'bundle' },
+  versionsCount: 1,
+};
+const replyRow = { ...bundleRow, publicId: 'pub-2', title: 'My Reply', source: { kind: 'reply' } };
+/** A bundle that still knows its in-app source, so it can be refreshed. */
+const sourcedRow = { ...bundleRow, publicId: 'pub-3', source: { kind: 'bundle', artifactId: 'artifact_html_x_1_0' } };
+
 beforeEach(() => {
-  mockList.mockReset().mockResolvedValue([
-    {
-      publicId: 'pub-1',
-      tier: 'user',
-      scopeId: 'erik',
-      slug: 's',
-      title: 'My Artifact',
-      visibility: 'public',
-      commentPolicy: 'none',
-      source: { kind: 'bundle' },
-      versionsCount: 1,
-    },
-  ]);
+  mockList.mockReset().mockResolvedValue([bundleRow]);
+  mockExport.mockReset().mockResolvedValue('# exported');
+  mockDownloadData.mockReset();
+  mockRefresh.mockReset().mockResolvedValue({ publicId: 'pub-3' });
+  mockToastError.mockReset();
+  mockToastSuccess.mockReset();
 });
 
 describe('PublishedArtifactsTabContent - manage toggle', () => {
@@ -64,5 +90,117 @@ describe('PublishedArtifactsTabContent - manage toggle', () => {
 
     fireEvent.click(screen.getByTestId('published-artifact-manage-pub-1'));
     expect(screen.queryByTestId('stub-panel-pub-1')).toBeNull();
+  });
+});
+
+describe('PublishedArtifactsTabContent - export actions (issue #1142)', () => {
+  it('hides Copy-as-Markdown for a bundle, which has no faithful Markdown form', async () => {
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+
+    expect(screen.queryByTestId('published-artifact-copy-md-pub-1')).toBeNull();
+    // HTML is faithful for every kind, so that action is always present.
+    expect(screen.getByTestId('published-artifact-save-html-pub-1')).not.toBeNull();
+  });
+
+  it('copies a reply as Markdown through the authenticated export fetch', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } });
+    mockList.mockResolvedValue([replyRow]);
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-2');
+
+    fireEvent.click(screen.getByTestId('published-artifact-copy-md-pub-2'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('# exported'));
+    // Fetched via the api client (not a bare download link), keyed on the viewer path.
+    expect(mockExport).toHaveBeenCalledWith('/p/r/pub-2', 'md');
+    expect(mockDownloadData).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('saves as HTML with the slugified filename and the right content type', async () => {
+    mockExport.mockResolvedValue('<html></html>');
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+
+    fireEvent.click(screen.getByTestId('published-artifact-save-html-pub-1'));
+    await waitFor(() =>
+      expect(mockDownloadData).toHaveBeenCalledWith('<html></html>', 'my-artifact.html', 'text/html; charset=utf-8')
+    );
+    expect(mockExport).toHaveBeenCalledWith('/p/u/erik/s', 'html');
+  });
+
+  it('surfaces an export failure instead of downloading an empty file', async () => {
+    mockExport.mockRejectedValue(new Error('boom'));
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+
+    fireEvent.click(screen.getByTestId('published-artifact-save-html-pub-1'));
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockDownloadData).not.toHaveBeenCalled();
+  });
+});
+
+describe('PublishedArtifactsTabContent - refresh from source (issue #1142, option 2)', () => {
+  it('offers Refresh only for a bundle that still knows its source artifact', async () => {
+    mockList.mockResolvedValue([bundleRow, replyRow, sourcedRow]);
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-3');
+
+    expect(screen.getByTestId('published-artifact-refresh-pub-3')).not.toBeNull();
+    // No artifactId (published from outside the app) - nothing to read back.
+    expect(screen.queryByTestId('published-artifact-refresh-pub-1')).toBeNull();
+    // A reply snapshots an immutable chat message.
+    expect(screen.queryByTestId('published-artifact-refresh-pub-2')).toBeNull();
+  });
+
+  it('confirms before refreshing, since it replaces what viewers of a live link see', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    mockList.mockResolvedValue([sourcedRow]);
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-3');
+
+    fireEvent.click(screen.getByTestId('published-artifact-refresh-pub-3'));
+    expect(confirm).toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    confirm.mockRestore();
+  });
+
+  it('refreshes the row on confirm and reports success', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockList.mockResolvedValue([sourcedRow]);
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-3');
+
+    fireEvent.click(screen.getByTestId('published-artifact-refresh-pub-3'));
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalledWith(expect.objectContaining({ publicId: 'pub-3' })));
+    await waitFor(() => expect(mockToastSuccess).toHaveBeenCalled());
+    confirm.mockRestore();
+  });
+
+  it('surfaces a refresh failure', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockRefresh.mockRejectedValue(new Error('boom'));
+    mockList.mockResolvedValue([sourcedRow]);
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-3');
+
+    fireEvent.click(screen.getByTestId('published-artifact-refresh-pub-3'));
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    confirm.mockRestore();
+  });
+
+  it('points the single-version hint at Refresh when the row can use it', async () => {
+    mockList.mockResolvedValue([sourcedRow]);
+    renderTab();
+    const hint = await screen.findByTestId('published-artifact-single-version-pub-3');
+    expect(hint.textContent).toContain('refresh it from source');
+  });
+
+  it('keeps the generic hint wording when the row cannot be refreshed', async () => {
+    renderTab();
+    const hint = await screen.findByTestId('published-artifact-single-version-pub-1');
+    expect(hint.textContent).toContain('re-publish this artifact');
   });
 });

--- a/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.test.tsx
+++ b/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.test.tsx
@@ -5,14 +5,17 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes/themePrimitives';
 
-const { mockList, mockExport, mockDownloadData, mockToastError, mockToastSuccess, mockRefresh } = vi.hoisted(() => ({
-  mockList: vi.fn(),
-  mockExport: vi.fn(),
-  mockDownloadData: vi.fn(),
-  mockToastError: vi.fn(),
-  mockToastSuccess: vi.fn(),
-  mockRefresh: vi.fn(),
-}));
+const { mockList, mockExport, mockDownloadData, mockToastError, mockToastSuccess, mockRefresh, mockPrint } = vi.hoisted(
+  () => ({
+    mockList: vi.fn(),
+    mockExport: vi.fn(),
+    mockDownloadData: vi.fn(),
+    mockToastError: vi.fn(),
+    mockToastSuccess: vi.fn(),
+    mockRefresh: vi.fn(),
+    mockPrint: vi.fn(),
+  })
+);
 
 vi.mock('sonner', () => ({ toast: { error: mockToastError, success: mockToastSuccess } }));
 
@@ -32,6 +35,10 @@ vi.mock('@client/app/utils/publishApi', () => ({
 
 vi.mock('@client/app/utils/download', () => ({
   downloadData: (...a: unknown[]) => mockDownloadData(...a),
+}));
+
+vi.mock('@client/app/utils/printToPdf', () => ({
+  printHtmlForPdf: (...a: unknown[]) => mockPrint(...a),
 }));
 
 // Stub the panel so this test targets the toggle wiring, not the panel's fetch.
@@ -75,6 +82,7 @@ beforeEach(() => {
   mockRefresh.mockReset().mockResolvedValue({ publicId: 'pub-3' });
   mockToastError.mockReset();
   mockToastSuccess.mockReset();
+  mockPrint.mockReset();
 });
 
 describe('PublishedArtifactsTabContent - manage toggle', () => {
@@ -138,6 +146,30 @@ describe('PublishedArtifactsTabContent - export actions (issue #1142)', () => {
     fireEvent.click(screen.getByTestId('published-artifact-save-html-pub-1'));
     await waitFor(() => expect(mockToastError).toHaveBeenCalled());
     expect(mockDownloadData).not.toHaveBeenCalled();
+  });
+
+  it('saves as PDF by printing the HTML export - offered for every kind', async () => {
+    mockExport.mockResolvedValue('<html><body>bundle</body></html>');
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+
+    // Present on a bundle, which has no faithful Markdown form - PDF is not gated.
+    fireEvent.click(screen.getByTestId('published-artifact-save-pdf-pub-1'));
+    // Reuses the HTML export as the source of truth, then hands it to the print frame.
+    expect(mockExport).toHaveBeenCalledWith('/p/u/erik/s', 'html');
+    await waitFor(() => expect(mockPrint).toHaveBeenCalledWith('<html><body>bundle</body></html>'));
+    // Never downloaded: PDF is the browser's dialog, not a file we emit.
+    expect(mockDownloadData).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failure to fetch the export for printing', async () => {
+    mockExport.mockRejectedValue(new Error('boom'));
+    renderTab();
+    await screen.findByTestId('published-artifact-pub-1');
+
+    fireEvent.click(screen.getByTestId('published-artifact-save-pdf-pub-1'));
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(mockPrint).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.tsx
+++ b/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.tsx
@@ -19,6 +19,9 @@ import RestoreIcon from '@mui/icons-material/Restore';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import CodeIcon from '@mui/icons-material/Code';
+import NotesIcon from '@mui/icons-material/Notes';
+import DownloadIcon from '@mui/icons-material/Download';
+import PublishedWithChangesIcon from '@mui/icons-material/PublishedWithChanges';
 import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
 import type { PublishVisibility } from '@bike4mind/common';
@@ -29,8 +32,13 @@ import {
   updatePublishedCommentPolicy,
   restorePreviousVersion,
   toArtifactSharePath,
+  fetchPublishedExport,
+  canRefreshFromSource,
+  refreshPublishedFromSource,
   type ManagedArtifact,
 } from '@client/app/utils/publishApi';
+import { EXPORT_CONTENT_TYPE, exportFilename, supportsExport } from '@client/app/utils/publishExport';
+import { downloadData } from '@client/app/utils/download';
 import { ManageSharingPanel } from '@client/app/components/common/ManageSharingPanel';
 
 const QUERY_KEY = ['published-artifacts', 'mine'] as const;
@@ -49,9 +57,10 @@ function sharePath(a: ManagedArtifact): string {
 
 /**
  * Profile Published tab: manage the artifacts the caller has published. Toggle
- * who can view, turn comments on/off, restore the previous version, copy/open
- * the share link, or delete - all reachable for ANY published artifact, not
- * just one freshly shared in-session.
+ * who can view, turn comments on/off, refresh a link from its source artifact,
+ * restore the previous version, copy/open the share link, export the content, or
+ * delete - all reachable for ANY published artifact, not just one freshly shared
+ * in-session.
  */
 export default function PublishedArtifactsTabContent() {
   const qc = useQueryClient();
@@ -89,6 +98,14 @@ export default function PublishedArtifactsTabContent() {
     },
     onError: (e: unknown) => toast.error(apiError(e, 'Restore failed')),
   });
+  const refreshMut = useMutation({
+    mutationFn: (a: ManagedArtifact) => refreshPublishedFromSource(a),
+    onSuccess: () => {
+      toast.success('Refreshed from source - a new version is live');
+      invalidate();
+    },
+    onError: (e: unknown) => toast.error(apiError(e, 'Refresh failed')),
+  });
   const deleteMut = useMutation({
     mutationFn: (publicId: string) => deletePublishedArtifact(publicId),
     onSuccess: () => {
@@ -98,9 +115,40 @@ export default function PublishedArtifactsTabContent() {
     onError: (e: unknown) => toast.error(apiError(e, 'Failed to delete')),
   });
 
-  const busy = visibilityMut.isPending || commentsMut.isPending || restoreMut.isPending || deleteMut.isPending;
+  const busy =
+    visibilityMut.isPending ||
+    commentsMut.isPending ||
+    restoreMut.isPending ||
+    refreshMut.isPending ||
+    deleteMut.isPending;
   // One row's sharing panel open at a time.
   const [manageOpen, setManageOpen] = useState<string | null>(null);
+  // publicId+format of an export in flight, so only the clicked button disables.
+  const [exporting, setExporting] = useState<string | null>(null);
+
+  /**
+   * Run an export through the authenticated api client (a plain download link would
+   * navigate uncredentialed and get the loader shell for anything gated), then either
+   * copy it or save it. Owner-side only: these buttons are the export path for private
+   * and org-gated artifacts, whose public pages deliberately show no export links.
+   */
+  const runExport = async (a: ManagedArtifact, format: 'md' | 'html', action: 'copy' | 'download') => {
+    const key = `${a.publicId}:${format}`;
+    setExporting(key);
+    try {
+      const content = await fetchPublishedExport(sharePath(a), format);
+      if (action === 'copy') {
+        await navigator.clipboard.writeText(content);
+        toast.success('Markdown copied');
+      } else {
+        downloadData(content, exportFilename(a.title, format), EXPORT_CONTENT_TYPE[format]);
+      }
+    } catch (e) {
+      toast.error(apiError(e, format === 'md' ? 'Could not copy as Markdown' : 'Could not save as HTML'));
+    } finally {
+      setExporting(cur => (cur === key ? null : cur));
+    }
+  };
 
   if (isLoading) return <LinearProgress data-testid="published-artifacts-loading" />;
   if (isError) {
@@ -117,8 +165,8 @@ export default function PublishedArtifactsTabContent() {
         Live Artifacts
       </Typography>
       <Typography level="body-sm" sx={{ mb: 2, opacity: 0.8 }}>
-        Everything you&apos;ve published as a live link. Change who can view, turn comments on or off, restore a
-        previous version, or delete.
+        Everything you&apos;ve published as a live link. Change who can view, turn comments on or off, export the
+        content, refresh a link from its source artifact, restore a previous version, or delete.
       </Typography>
 
       {artifacts.length === 0 ? (
@@ -132,6 +180,7 @@ export default function PublishedArtifactsTabContent() {
             const path = sharePath(a);
             const url = `${window.location.origin}${path}`;
             const isBundle = a.source.kind === 'bundle';
+            const canRefresh = canRefreshFromSource(a);
             const hasPrevious = Boolean(a.previousVersionMeta?.sha256Index);
             const commentsOn = a.commentPolicy === 'open' || a.commentPolicy === 'restricted';
 
@@ -242,6 +291,66 @@ export default function PublishedArtifactsTabContent() {
                     </IconButton>
                   </Tooltip>
 
+                  {/* Markdown is offered only for kinds it converts to faithfully (replies,
+                      whose stored body IS markdown) - see exportFormatsFor. Hidden, not
+                      disabled: a greyed button implies the export exists and is unavailable,
+                      when in fact there is no honest Markdown form of an HTML bundle. */}
+                  {supportsExport(a.source.kind, 'md') && (
+                    <Tooltip title="Copy as Markdown">
+                      <IconButton
+                        size="sm"
+                        variant="plain"
+                        color="neutral"
+                        loading={exporting === `${a.publicId}:md`}
+                        onClick={() => void runExport(a, 'md', 'copy')}
+                        data-testid={`published-artifact-copy-md-${a.publicId}`}
+                      >
+                        <NotesIcon />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+
+                  <Tooltip title="Save as HTML">
+                    <IconButton
+                      size="sm"
+                      variant="plain"
+                      color="neutral"
+                      loading={exporting === `${a.publicId}:html`}
+                      onClick={() => void runExport(a, 'html', 'download')}
+                      data-testid={`published-artifact-save-html-${a.publicId}`}
+                    >
+                      <DownloadIcon />
+                    </IconButton>
+                  </Tooltip>
+
+                  {/* Refresh re-publishes from the source artifact's CURRENT content onto
+                      the same link. Hidden where there is no source to read back (a reply
+                      snapshot, or a bundle published from outside the app). */}
+                  {canRefresh && (
+                    <Tooltip title="Refresh from source (publishes a new version)">
+                      <IconButton
+                        size="sm"
+                        variant="plain"
+                        color="neutral"
+                        disabled={busy}
+                        loading={refreshMut.isPending && refreshMut.variables?.publicId === a.publicId}
+                        onClick={() => {
+                          // Outward-facing: it replaces what viewers of a live link see.
+                          if (
+                            window.confirm(
+                              `Refresh "${a.title}" from its source artifact? This publishes a new version to the same link.`
+                            )
+                          ) {
+                            refreshMut.mutate(a);
+                          }
+                        }}
+                        data-testid={`published-artifact-refresh-${a.publicId}`}
+                      >
+                        <PublishedWithChangesIcon />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+
                   {isBundle && (
                     <Tooltip title={hasPrevious ? 'Restore the previous version' : 'No previous version to restore'}>
                       <span>
@@ -298,8 +407,9 @@ export default function PublishedArtifactsTabContent() {
                     sx={{ opacity: 0.7 }}
                     data-testid={`published-artifact-single-version-${a.publicId}`}
                   >
-                    Only one version published - re-publish this artifact (or use AI Revise) to create version history.
-                    A version switcher appears on the page once there are 2 or more versions.
+                    Only one version published -{' '}
+                    {canRefresh ? 'refresh it from source (or use AI Revise)' : 're-publish this artifact'} to create
+                    version history. A version switcher appears on the page once there are 2 or more versions.
                   </Typography>
                 )}
               </Sheet>

--- a/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.tsx
+++ b/apps/client/app/components/ProfileModal/PublishedArtifactsTabContent.tsx
@@ -21,6 +21,7 @@ import VisibilityIcon from '@mui/icons-material/Visibility';
 import CodeIcon from '@mui/icons-material/Code';
 import NotesIcon from '@mui/icons-material/Notes';
 import DownloadIcon from '@mui/icons-material/Download';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import PublishedWithChangesIcon from '@mui/icons-material/PublishedWithChanges';
 import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
@@ -39,6 +40,7 @@ import {
 } from '@client/app/utils/publishApi';
 import { EXPORT_CONTENT_TYPE, exportFilename, supportsExport } from '@client/app/utils/publishExport';
 import { downloadData } from '@client/app/utils/download';
+import { printHtmlForPdf } from '@client/app/utils/printToPdf';
 import { ManageSharingPanel } from '@client/app/components/common/ManageSharingPanel';
 
 const QUERY_KEY = ['published-artifacts', 'mine'] as const;
@@ -145,6 +147,25 @@ export default function PublishedArtifactsTabContent() {
       }
     } catch (e) {
       toast.error(apiError(e, format === 'md' ? 'Could not copy as Markdown' : 'Could not save as HTML'));
+    } finally {
+      setExporting(cur => (cur === key ? null : cur));
+    }
+  };
+
+  /**
+   * Save as PDF via the browser's print dialog (issue #1142 item 2). Reuses the HTML
+   * export as the source of truth and hands it to an isolated print frame rather than
+   * opening author HTML in the app origin - see printToPdf.ts. Owner-only (the public
+   * footers are CSP-locked); offered for every kind since the browser renders it.
+   */
+  const runPrint = async (a: ManagedArtifact) => {
+    const key = `${a.publicId}:pdf`;
+    setExporting(key);
+    try {
+      const content = await fetchPublishedExport(sharePath(a), 'html');
+      printHtmlForPdf(content);
+    } catch (e) {
+      toast.error(apiError(e, 'Could not open the print view'));
     } finally {
       setExporting(cur => (cur === key ? null : cur));
     }
@@ -320,6 +341,22 @@ export default function PublishedArtifactsTabContent() {
                       data-testid={`published-artifact-save-html-${a.publicId}`}
                     >
                       <DownloadIcon />
+                    </IconButton>
+                  </Tooltip>
+
+                  {/* PDF is produced client-side by printing the HTML export from an
+                      isolated frame (printToPdf), not a server export format. Offered
+                      for every kind - the browser renders it visually. */}
+                  <Tooltip title="Save as PDF (opens print dialog)">
+                    <IconButton
+                      size="sm"
+                      variant="plain"
+                      color="neutral"
+                      loading={exporting === `${a.publicId}:pdf`}
+                      onClick={() => void runPrint(a)}
+                      data-testid={`published-artifact-save-pdf-${a.publicId}`}
+                    >
+                      <PictureAsPdfIcon />
                     </IconButton>
                   </Tooltip>
 

--- a/apps/client/app/utils/printToPdf.test.ts
+++ b/apps/client/app/utils/printToPdf.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { buildPrintDocument, printHtmlForPdf } from './printToPdf';
+
+describe('buildPrintDocument', () => {
+  it('injects the print trigger just before </body>', () => {
+    const doc = buildPrintDocument('<html><body><h1>Hi</h1></body></html>');
+    expect(doc).toContain('window.print()');
+    // The trigger precedes the closing body so it runs after the artifact's content.
+    expect(doc.indexOf('window.print()')).toBeLessThan(doc.indexOf('</body>'));
+    expect(doc).toContain('<h1>Hi</h1>');
+  });
+
+  it('appends the trigger when there is no body tag (e.g. a bare fragment)', () => {
+    const doc = buildPrintDocument('<svg></svg>');
+    expect(doc.startsWith('<svg></svg>')).toBe(true);
+    expect(doc).toContain('window.print()');
+  });
+
+  it('drops an author CSP meta that would otherwise block the inline trigger', () => {
+    const html =
+      '<html><head><meta http-equiv="Content-Security-Policy" content="script-src \'none\'"></head>' +
+      '<body>x</body></html>';
+    const doc = buildPrintDocument(html);
+    expect(doc.toLowerCase()).not.toContain('content-security-policy');
+    expect(doc).toContain('window.print()');
+  });
+});
+
+describe('printHtmlForPdf', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const frame = () => document.querySelector('iframe');
+
+  it('mounts an opaque-origin sandboxed frame carrying the print document', () => {
+    printHtmlForPdf('<html><body>doc</body></html>');
+    const f = frame();
+    expect(f).not.toBeNull();
+    const sandbox = f!.getAttribute('sandbox') ?? '';
+    expect(sandbox).toContain('allow-scripts');
+    expect(sandbox).toContain('allow-modals');
+    // No allow-same-origin: the frame cannot reach app cookies/DOM.
+    expect(sandbox).not.toContain('allow-same-origin');
+    expect(f!.getAttribute('srcdoc')).toContain('doc');
+    expect(f!.getAttribute('srcdoc')).toContain('window.print()');
+  });
+
+  it('removes the frame when it reports completion from its own window', () => {
+    printHtmlForPdf('<html><body>doc</body></html>');
+    const f = frame();
+    expect(f).not.toBeNull();
+
+    // A completion ping from the frame we created reclaims the node.
+    window.dispatchEvent(new MessageEvent('message', { data: 'b4m-print-complete', source: f!.contentWindow }));
+    expect(frame()).toBeNull();
+  });
+
+  it('ignores completion pings from an unrelated window', () => {
+    printHtmlForPdf('<html><body>doc</body></html>');
+    window.dispatchEvent(new MessageEvent('message', { data: 'b4m-print-complete', source: window }));
+    expect(frame()).not.toBeNull();
+  });
+
+  it('reclaims the frame on the backstop timeout if no completion arrives', () => {
+    printHtmlForPdf('<html><body>doc</body></html>');
+    expect(frame()).not.toBeNull();
+    vi.advanceTimersByTime(120000);
+    expect(frame()).toBeNull();
+  });
+});

--- a/apps/client/app/utils/printToPdf.ts
+++ b/apps/client/app/utils/printToPdf.ts
@@ -1,0 +1,81 @@
+/**
+ * "Save as PDF" for published artifacts (issue #1142, item 2) via the browser's
+ * own print dialog - the "cheapest" of the rendering approaches: no server-side
+ * headless renderer, no new infra.
+ *
+ * The one constraint that shapes this file: author HTML must never execute in the
+ * app origin. The rest of the export pipeline serves it sandboxed or as an
+ * attachment for exactly that reason. So we do NOT `window.open` the content (a
+ * blob/document URL would inherit the app origin). Instead we mount it in an
+ * off-screen iframe sandboxed WITHOUT `allow-same-origin`, giving it an opaque
+ * origin that cannot read app cookies, storage, or DOM. `allow-scripts` lets a
+ * bundle (React/HTML) actually render, and `allow-modals` lets the injected
+ * trigger open the print dialog. Because the parent cannot reach into a
+ * cross-origin frame's `print()`, the trigger lives inside the frame and reports
+ * back over `postMessage` so we can reclaim the node.
+ *
+ * Owner-path only. The public viewer footers stay CSP-locked (see publishExport.ts).
+ */
+
+const COMPLETE = 'b4m-print-complete';
+
+// Runs inside the sandboxed frame: print once painted, then ping the parent so it
+// can remove the frame (afterprint is unreliable in some browsers, hence the
+// post-print fallback ping).
+const PRINT_BOOTSTRAP =
+  '<script>(function(){' +
+  'function done(){try{parent.postMessage("' +
+  COMPLETE +
+  '","*");}catch(e){}}' +
+  'window.addEventListener("afterprint",done);' +
+  'window.addEventListener("load",function(){' +
+  'setTimeout(function(){try{window.focus();window.print();}catch(e){}setTimeout(done,500);},400);' +
+  '});' +
+  '})();</script>';
+
+/**
+ * Inject the print trigger into an HTML export. An author `Content-Security-Policy`
+ * meta would only block the inline trigger without adding any protection here (the
+ * opaque-origin sandbox is the real boundary), so it is dropped.
+ */
+export function buildPrintDocument(html: string): string {
+  const withoutCsp = html.replace(/<meta\b[^>]*http-equiv\s*=\s*["']?content-security-policy["']?[^>]*>/gi, '');
+  return /<\/body\s*>/i.test(withoutCsp)
+    ? withoutCsp.replace(/<\/body\s*>/i, `${PRINT_BOOTSTRAP}</body>`)
+    : withoutCsp + PRINT_BOOTSTRAP;
+}
+
+/**
+ * Render a self-contained HTML export in an isolated frame and open the print
+ * dialog, where the user picks "Save as PDF". Fire-and-forget: the frame removes
+ * itself once printing finishes (or after a backstop timeout if the dialog is
+ * dismissed without an afterprint event).
+ */
+export function printHtmlForPdf(html: string): void {
+  if (typeof document === 'undefined') return;
+
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('sandbox', 'allow-scripts allow-modals');
+  iframe.setAttribute('aria-hidden', 'true');
+  // Off-screen but sized so the content lays out and paints (a 0x0 or display:none
+  // frame prints blank). Letter-ish dimensions in px.
+  iframe.style.cssText = 'position:fixed;left:-10000px;top:0;width:816px;height:1056px;border:0';
+  iframe.srcdoc = buildPrintDocument(html);
+
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    window.removeEventListener('message', onMessage);
+    window.clearTimeout(fallback);
+    iframe.remove();
+  };
+  const onMessage = (e: MessageEvent) => {
+    if (e.source === iframe.contentWindow && e.data === COMPLETE) cleanup();
+  };
+  window.addEventListener('message', onMessage);
+  // Backstop for a dialog dismissed without firing afterprint.
+  const fallback = window.setTimeout(cleanup, 120000);
+
+  document.body.appendChild(iframe);
+}

--- a/apps/client/app/utils/publishApi.refresh.test.ts
+++ b/apps/client/app/utils/publishApi.refresh.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * refreshPublishedFromSource lands a new VERSION of an existing publication by
+ * re-running the ordinary publish pipeline with the slug pinned. The cases that
+ * matter are the ones where finalize's unconditional `$set` would otherwise change
+ * something the owner did not ask to change.
+ */
+
+const { mockGet, mockPost } = vi.hoisted(() => ({ mockGet: vi.fn(), mockPost: vi.fn() }));
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: mockGet, post: mockPost, patch: vi.fn(), delete: vi.fn() },
+}));
+
+// The bundler pulls brand config + the elision detector; neither is under test here.
+vi.mock('@client/app/utils/shareFooter', () => ({ buildShareFooterHtml: () => '<footer/>' }));
+
+import { canRefreshFromSource, refreshPublishedFromSource } from './publishApi';
+import type { ManagedArtifact } from './publishApi';
+
+const row = (over: Partial<ManagedArtifact> = {}): ManagedArtifact =>
+  ({
+    publicId: 'pub-1',
+    tier: 'user',
+    scopeId: 'user-1',
+    slug: 'my-slug',
+    title: 'Published Title',
+    visibility: 'private',
+    commentPolicy: 'open',
+    description: 'the blurb',
+    source: { kind: 'bundle', artifactId: 'artifact_html_x_1_0' },
+    ...over,
+  }) as ManagedArtifact;
+
+/** Wire the 3-step pipeline: artifact read -> upload-url -> S3 PUT -> finalize. */
+function wirePipeline() {
+  mockGet.mockResolvedValue({
+    data: { artifact: { type: 'html', title: 'Source Title' }, content: { content: '<h1>fresh</h1>' } },
+  });
+  mockPost.mockImplementation((url: string) => {
+    if (url.endsWith('/upload-url')) {
+      return Promise.resolve({
+        data: { draftId: 'd1', uploadUrls: [{ path: 'index.html', url: 'https://s3.example/put', expiresAt: 'x' }] },
+      });
+    }
+    return Promise.resolve({ data: { publicId: 'pub-1', url: '/p/u/user-1/my-slug' } });
+  });
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+}
+
+const uploadUrlBody = () => mockPost.mock.calls.find(c => String(c[0]).endsWith('/upload-url'))![1];
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe('canRefreshFromSource', () => {
+  it('allows a bundle that carries its source artifactId', () => {
+    expect(canRefreshFromSource(row())).toBe(true);
+  });
+
+  it('refuses a bundle published from outside the app (no artifactId to read back)', () => {
+    expect(canRefreshFromSource(row({ source: { kind: 'bundle' } }))).toBe(false);
+  });
+
+  it('refuses reply and fabfile snapshots', () => {
+    expect(canRefreshFromSource(row({ source: { kind: 'reply', artifactId: 'a' } }))).toBe(false);
+    expect(canRefreshFromSource(row({ source: { kind: 'fabfile', artifactId: 'a' } }))).toBe(false);
+  });
+});
+
+describe('refreshPublishedFromSource', () => {
+  it('pins the existing slug and scope so finalize lands a VERSION, not a second page', async () => {
+    wirePipeline();
+    await refreshPublishedFromSource(row());
+
+    const body = uploadUrlBody();
+    expect(body.slug).toBe('my-slug');
+    expect(body.tier).toBe('user');
+    expect(body.scopeId).toBe('user-1');
+  });
+
+  it('carries visibility through - omitting it would make a private page PUBLIC', async () => {
+    wirePipeline();
+    await refreshPublishedFromSource(row({ visibility: 'private' }));
+    expect(uploadUrlBody().visibility).toBe('private');
+  });
+
+  it('carries commentPolicy and description through, which finalize would otherwise reset', async () => {
+    wirePipeline();
+    await refreshPublishedFromSource(row());
+
+    const body = uploadUrlBody();
+    expect(body.commentPolicy).toBe('open');
+    expect(body.description).toBe('the blurb');
+  });
+
+  it("takes the SOURCE artifact's current title (a refresh re-syncs from source)", async () => {
+    wirePipeline();
+    await refreshPublishedFromSource(row());
+    expect(uploadUrlBody().title).toBe('Source Title');
+  });
+
+  it('falls back to the published title when the source has none', async () => {
+    wirePipeline();
+    mockGet.mockResolvedValue({ data: { artifact: { type: 'html' }, content: { content: '<h1>x</h1>' } } });
+    await refreshPublishedFromSource(row());
+    expect(uploadUrlBody().title).toBe('Published Title');
+  });
+
+  it('uploads the source content, and flags react so finalize transpiles it', async () => {
+    wirePipeline();
+    mockGet.mockResolvedValue({
+      data: { artifact: { type: 'react', title: 'App' }, content: { content: 'export default () => <div/>;' } },
+    });
+    await refreshPublishedFromSource(row());
+
+    const body = uploadUrlBody();
+    expect(body.source).toEqual({ kind: 'bundle', artifactId: 'artifact_html_x_1_0', artifactType: 'react' });
+    // React uploads RAW JSX; the server transpiles it at finalize.
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body).toBe('export default () => <div/>;');
+  });
+
+  it('refuses a row with no source artifact before touching the network', async () => {
+    await expect(refreshPublishedFromSource(row({ source: { kind: 'bundle' } }))).rejects.toThrow(
+      /no source artifact/i
+    );
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('refuses an empty source rather than publishing a blank version over a good one', async () => {
+    mockGet.mockResolvedValue({ data: { artifact: { type: 'html', title: 'T' }, content: { content: '   ' } } });
+    await expect(refreshPublishedFromSource(row())).rejects.toThrow(/no content/i);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unreadable source', async () => {
+    mockGet.mockResolvedValue({ data: {} });
+    await expect(refreshPublishedFromSource(row())).rejects.toThrow(/could not be read/i);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed S3 upload instead of finalizing a half-written version', async () => {
+    wirePipeline();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403 }));
+    await expect(refreshPublishedFromSource(row())).rejects.toThrow(/Upload failed \(403\)/);
+    expect(mockPost.mock.calls.some(c => String(c[0]).endsWith('/finalize'))).toBe(false);
+  });
+});

--- a/apps/client/app/utils/publishApi.ts
+++ b/apps/client/app/utils/publishApi.ts
@@ -11,6 +11,7 @@ import type {
 import { ELISION_PUBLISH_BODY, SCOPE_URL_PREFIX } from '@bike4mind/common';
 import { detectElidedSafe } from '@client/app/utils/artifactParser';
 import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
+import { exportHref, type PublishExportFormat } from '@client/app/utils/publishExport';
 
 /** Summary row for the published-artifacts management list. */
 export interface ManagedArtifact {
@@ -66,6 +67,28 @@ export async function findPublishedByArtifact(artifactId: string): Promise<Manag
     // degrade to "not published" and let the dialog offer a plain publish-as-new.
     return null;
   }
+}
+
+/**
+ * Fetch a published artifact's content in an export format (issue #1142).
+ *
+ * Goes through the authenticated `api` client rather than a plain `<a download>`: a
+ * top-level navigation to `/p/...?export=` carries no Authorization header, so a
+ * private or org-gated artifact would answer with the loader shell (an HTML page)
+ * instead of the file. The viewer-facing surfaces use plain anchors instead, and
+ * only where the artifact re-authorizes without a credential.
+ *
+ * Callers must check `supportsExport(kind, format)` first - the server 404s a format
+ * with no faithful conversion for the kind, deliberately rather than degrading.
+ */
+export async function fetchPublishedExport(viewerPath: string, format: PublishExportFormat): Promise<string> {
+  const { data } = await api.get<string>(exportHref(viewerPath, format), {
+    // Keep the payload as the raw text it is - axios would otherwise JSON.parse a
+    // markdown/HTML body that happens to start with a JSON-looking token.
+    responseType: 'text',
+    transformResponse: [(d: unknown) => (typeof d === 'string' ? d : String(d ?? ''))],
+  });
+  return data;
 }
 
 /** Soft-delete (archive) a published artifact (owner/admin). */
@@ -270,6 +293,71 @@ export async function restorePreviousVersion(publicId: string): Promise<{ sha256
 }
 
 /**
+ * Whether a publication can be refreshed from its in-app source artifact.
+ *
+ * Bundles only, and only when `source.artifactId` is set. A `reply` snapshots an
+ * immutable chat message so there is nothing to re-read; a bundle published from
+ * outside the app (no artifactId) has no source to read back; and bundles are the
+ * only kind with the version history a refresh lands in - the same restriction the
+ * restore endpoint applies.
+ */
+export function canRefreshFromSource(a: ManagedArtifact): boolean {
+  return a.source.kind === 'bundle' && !!a.source.artifactId;
+}
+
+/** Slice of `GET /api/artifacts/{id}?includeContent=true` a refresh needs. */
+interface SourceArtifactResponse {
+  artifact?: { type?: string; title?: string };
+  content?: { content?: string };
+}
+
+/**
+ * Re-publish an existing publication from its source artifact's CURRENT content,
+ * landing a new version on the SAME `/p/...` URL.
+ *
+ * Runs the ordinary publish pipeline (upload-url -> PUT -> finalize) with the slug
+ * pinned to the existing publication, so finalize upserts a new version instead of
+ * creating a second page - and so the refreshed bytes go through the same
+ * `validateBundle` security contract and React transpile as any other publish. That
+ * reuse is the point: a bespoke "refresh" endpoint would have to restate the publish
+ * contract and could drift from it.
+ *
+ * Every field finalize's `$set` overwrites unconditionally is passed through from the
+ * current row - `visibility`, `commentPolicy`, `description`. Omitting them would not
+ * leave them alone: finalize falls back to the publish DEFAULT, which would turn a
+ * private page public and drop comments to `none`. Fields finalize never touches
+ * (`accessGate`, `discoverable`, `embedOrigins`, `shareToken`) survive on their own.
+ *
+ * The source's CURRENT title wins, since re-syncing from source is the whole point;
+ * the slug stays pinned, so the public URL never moves.
+ */
+export async function refreshPublishedFromSource(a: ManagedArtifact): Promise<PublishResult> {
+  const artifactId = a.source.artifactId;
+  if (!artifactId) throw new Error('This publication has no source artifact to refresh from');
+
+  const { data } = await api.get<SourceArtifactResponse>(
+    `/api/artifacts/${encodeURIComponent(artifactId)}?includeContent=true`
+  );
+  const type = data.artifact?.type;
+  const content = data.content?.content;
+  if (!type) throw new Error('The source artifact could not be read');
+  if (!content?.trim()) throw new Error('The source artifact has no content to publish');
+
+  return publishArtifactBundle({
+    artifactId,
+    type,
+    content,
+    title: data.artifact?.title || a.title,
+    tier: a.tier,
+    scopeId: a.scopeId,
+    slug: a.slug,
+    visibility: a.visibility,
+    commentPolicy: a.commentPolicy,
+    description: a.description,
+  });
+}
+
+/**
  * Publish an artifact as a hosted static bundle (/p/u/{userId}/{slug}) via the
  * 3-step flow: request presigned upload -> PUT index.html to S3 -> finalize.
  *
@@ -283,7 +371,12 @@ export async function publishArtifactBundle(input: {
   type: string;
   content: string;
   title: string;
-  userId: string;
+  /**
+   * The publishing user, used only as the default `scopeId` for the `user` tier.
+   * Optional when `scopeId` is passed explicitly - a refresh pins the existing scope,
+   * so it has no separate use for the caller's id.
+   */
+  userId?: string;
   /**
    * Scope tier to publish under. Defaults to `'user'` (a personal `/p/u/{userId}` page).
    * Pass `'organization'` with `scopeId` set to the org id to publish an org-scoped page
@@ -294,6 +387,12 @@ export async function publishArtifactBundle(input: {
   scopeId?: string;
   visibility?: PublishVisibility;
   commentPolicy?: CommentPolicy;
+  /**
+   * Public blurb. finalize `$set`s `description` unconditionally, so a re-publish that
+   * omits it CLEARS an existing one - pass it through when landing a new version of a
+   * publication that already has one.
+   */
+  description?: string;
   /**
    * Publish to this exact slug instead of deriving one from the title. Pass the existing
    * publication's slug to land a new VERSION of it (finalize upserts on
@@ -311,6 +410,9 @@ export async function publishArtifactBundle(input: {
 }): Promise<PublishResult> {
   const content = (input.content ?? '').trim();
   if (!content) throw new Error('This artifact has no content to publish');
+
+  const scopeId = input.scopeId ?? input.userId;
+  if (!scopeId) throw new Error('publishArtifactBundle needs either scopeId or userId to resolve the scope');
 
   // React artifacts upload their RAW JSX as index.html; the server transpiles it into a
   // self-contained inert HTML bundle at finalize (issue #21). Every other type renders to static
@@ -332,11 +434,12 @@ export async function publishArtifactBundle(input: {
   // Step 1 - request a presigned PUT for index.html.
   const { data: draft } = await api.post<UploadUrlResponse>('/api/publish/artifact/upload-url', {
     tier: input.tier ?? 'user',
-    scopeId: input.scopeId ?? input.userId,
+    scopeId,
     slug,
     title: input.title || 'Shared artifact',
     visibility: input.visibility ?? DEFAULT_SHARE_VISIBILITY,
     ...(input.commentPolicy ? { commentPolicy: input.commentPolicy } : {}),
+    ...(input.description ? { description: input.description } : {}),
     source: { kind: 'bundle', artifactId: input.artifactId, ...(isReact ? { artifactType: 'react' as const } : {}) },
     files: [{ path: 'index.html', size, mimeType: 'text/html' }],
   });

--- a/apps/client/app/utils/publishExport.test.ts
+++ b/apps/client/app/utils/publishExport.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EXPORT_CONTENT_TYPE,
+  buildExportActionsHtml,
+  buildMarkdownExport,
+  exportFilename,
+  exportFormatsFor,
+  exportHref,
+  parseExportFormat,
+  supportsExport,
+} from './publishExport';
+
+describe('exportFormatsFor', () => {
+  it('offers Markdown only for replies, whose stored body IS markdown', () => {
+    expect(exportFormatsFor('reply')).toEqual(['md', 'html']);
+    expect(exportFormatsFor('bundle')).toEqual(['html']);
+    expect(exportFormatsFor('fabfile')).toEqual(['html']);
+  });
+
+  it('never withholds HTML - every kind has a faithful HTML form', () => {
+    for (const kind of ['bundle', 'reply', 'fabfile'] as const) {
+      expect(supportsExport(kind, 'html')).toBe(true);
+    }
+  });
+
+  it('withholds Markdown for bundles rather than emitting a lossy conversion', () => {
+    expect(supportsExport('bundle', 'md')).toBe(false);
+    expect(supportsExport('fabfile', 'md')).toBe(false);
+  });
+});
+
+describe('parseExportFormat', () => {
+  it('accepts only the supported formats', () => {
+    expect(parseExportFormat('md')).toBe('md');
+    expect(parseExportFormat('html')).toBe('html');
+  });
+
+  it('rejects anything else, including a repeated query param', () => {
+    for (const raw of ['pdf', '', 'MD', undefined, null, 1, ['md', 'html']]) {
+      expect(parseExportFormat(raw)).toBeNull();
+    }
+  });
+});
+
+describe('exportFilename', () => {
+  it('slugifies the title and appends the extension', () => {
+    expect(exportFilename('My Great Artifact', 'md')).toBe('my-great-artifact.md');
+    expect(exportFilename('My Great Artifact', 'html')).toBe('my-great-artifact.html');
+  });
+
+  it('falls back to a neutral stem when the title slugifies to nothing', () => {
+    expect(exportFilename('???', 'md')).toBe('artifact.md');
+    expect(exportFilename('', 'html')).toBe('artifact.html');
+  });
+
+  it('stays quote-free and ASCII so it needs no Content-Disposition escaping', () => {
+    // Escapes, not literals - this file stays ASCII (see CLAUDE.md).
+    const name = exportFilename('He said "hi" \u2014 na\u00EFve/\u00FCnicode', 'html');
+    expect(name).toBe('he-said-hi-na-ve-nicode.html');
+    expect(name).toMatch(/^[a-z0-9.-]+$/);
+  });
+
+  it('bounds the stem length', () => {
+    expect(exportFilename('a'.repeat(200), 'md')).toBe(`${'a'.repeat(60)}.md`);
+  });
+});
+
+describe('buildMarkdownExport', () => {
+  it('leads with the title, then the description, then the body verbatim', () => {
+    expect(buildMarkdownExport('Title', 'A description', '## Body\n\ntext')).toBe(
+      '# Title\n\nA description\n\n## Body\n\ntext\n'
+    );
+  });
+
+  it('omits an absent or blank description and an empty body', () => {
+    expect(buildMarkdownExport('Title', undefined, '')).toBe('# Title\n');
+    expect(buildMarkdownExport('Title', '   ', 'body')).toBe('# Title\n\nbody\n');
+  });
+
+  it('does not escape or reflow the body - markdown must round-trip', () => {
+    const body = '- item <b>raw html</b> & "quotes"\n\n```js\nconst a = 1;\n```';
+    expect(buildMarkdownExport('T', undefined, body)).toContain(body);
+  });
+});
+
+describe('buildExportActionsHtml', () => {
+  it('renders a download anchor per format, with no script', () => {
+    const html = buildExportActionsHtml('/p/r/abc123', ['md', 'html']);
+    expect(html).toContain('href="/p/r/abc123?export=md" download');
+    expect(html).toContain('href="/p/r/abc123?export=html" download');
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('onclick');
+  });
+
+  it('renders nothing when there is no path or no offerable format', () => {
+    expect(buildExportActionsHtml('/p/r/abc123', [])).toBe('');
+    expect(buildExportActionsHtml('', ['html'])).toBe('');
+  });
+
+  it('escapes the viewer path into the href', () => {
+    const html = buildExportActionsHtml('/a/tok"onmouseover=alert(1)', ['html']);
+    expect(html).not.toContain('"onmouseover');
+    expect(html).toContain('&quot;onmouseover');
+  });
+});
+
+describe('EXPORT_CONTENT_TYPE / exportHref', () => {
+  it('maps each format to its charset-qualified type', () => {
+    expect(EXPORT_CONTENT_TYPE.md).toBe('text/markdown; charset=utf-8');
+    expect(EXPORT_CONTENT_TYPE.html).toBe('text/html; charset=utf-8');
+  });
+
+  it('builds the query for both viewer path shapes', () => {
+    expect(exportHref('/p/u/user1/my-slug', 'html')).toBe('/p/u/user1/my-slug?export=html');
+    expect(exportHref('/a/token123', 'md')).toBe('/a/token123?export=md');
+  });
+});

--- a/apps/client/app/utils/publishExport.ts
+++ b/apps/client/app/utils/publishExport.ts
@@ -8,11 +8,11 @@
  * data helpers with no imports beyond the escaper - the serve surfaces run under
  * `script-src 'none'`, so anything here must work with zero JS.
  *
- * PDF is deliberately absent. Neither viewer surface can run a `window.print()`
- * button (the reply/fabfile page is served `script-src 'none'`, and the bundle
- * wrapper's script-src admits only the comment widget), so a PDF action needs
- * either a JS-capable surface or a server-side renderer. It is tracked separately
- * rather than shipped as a lossy screenshot of the sandboxed iframe.
+ * PDF is not a server `?export=` format: it is produced client-side on the owner
+ * path (the Published tab) by printing the HTML export from an isolated sandboxed
+ * frame - see printToPdf.ts. The CSP-locked viewer footers still cannot offer it
+ * (the reply/fabfile page is served `script-src 'none'`, and the bundle wrapper's
+ * script-src admits only the comment widget), so PDF stays owner-only.
  */
 
 import { escapeAttr } from './htmlEscape';

--- a/apps/client/app/utils/publishExport.ts
+++ b/apps/client/app/utils/publishExport.ts
@@ -1,0 +1,115 @@
+/**
+ * Export affordances for published artifacts (issue #1142): which formats a given
+ * artifact kind converts to WITHOUT loss, the `?export=` URLs, the download
+ * filenames, and the CSP-safe footer markup.
+ *
+ * Shared by the serve route (which renders the footer and answers `?export=`) and
+ * the app-side Published tab, so both agree on what may be offered. Pure string /
+ * data helpers with no imports beyond the escaper - the serve surfaces run under
+ * `script-src 'none'`, so anything here must work with zero JS.
+ *
+ * PDF is deliberately absent. Neither viewer surface can run a `window.print()`
+ * button (the reply/fabfile page is served `script-src 'none'`, and the bundle
+ * wrapper's script-src admits only the comment widget), so a PDF action needs
+ * either a JS-capable surface or a server-side renderer. It is tracked separately
+ * rather than shipped as a lossy screenshot of the sandboxed iframe.
+ */
+
+import { escapeAttr } from './htmlEscape';
+
+export type PublishExportFormat = 'md' | 'html';
+
+export type PublishSourceKindName = 'bundle' | 'reply' | 'fabfile';
+
+/**
+ * Formats a FAITHFUL conversion exists for, per publish source kind. Anything not
+ * listed is withheld rather than emitted lossily:
+ *
+ *  - reply:   `renderedBody` IS the assistant's markdown, so `md` round-trips
+ *             exactly; `html` is that same body rendered.
+ *  - fabfile: literal file text of unknown syntax. Fencing arbitrary bytes and
+ *             calling the result Markdown would be a fabrication, so `md` is
+ *             withheld; `html` reproduces the text verbatim in a <pre>.
+ *  - bundle:  `index.html` IS the artifact. React/HTML/SVG have no faithful
+ *             Markdown form, so only `html` is offered.
+ */
+export function exportFormatsFor(kind: PublishSourceKindName): PublishExportFormat[] {
+  return kind === 'reply' ? ['md', 'html'] : ['html'];
+}
+
+export function supportsExport(kind: PublishSourceKindName, format: PublishExportFormat): boolean {
+  return exportFormatsFor(kind).includes(format);
+}
+
+/** Response Content-Type per export format. */
+export const EXPORT_CONTENT_TYPE: Record<PublishExportFormat, string> = {
+  md: 'text/markdown; charset=utf-8',
+  html: 'text/html; charset=utf-8',
+};
+
+const EXPORT_EXTENSION: Record<PublishExportFormat, string> = { md: 'md', html: 'html' };
+
+const EXPORT_LABEL: Record<PublishExportFormat, string> = { md: 'Markdown', html: 'HTML' };
+
+/** Narrow an untrusted query value to a supported format, or null. */
+export function parseExportFormat(raw: unknown): PublishExportFormat | null {
+  return raw === 'md' || raw === 'html' ? raw : null;
+}
+
+/**
+ * Download filename for an export. ASCII-only and quote-free so it can go into a
+ * `Content-Disposition: attachment; filename="..."` header unescaped.
+ */
+export function exportFilename(title: string, format: PublishExportFormat): string {
+  const stem =
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'artifact';
+  return `${stem}.${EXPORT_EXTENSION[format]}`;
+}
+
+/** `?export=` URL for a viewer path (`/p/r/{id}`, `/p/u/{scope}/{slug}`, `/a/{token}`). */
+export function exportHref(viewerPath: string, format: PublishExportFormat): string {
+  return `${viewerPath}?export=${format}`;
+}
+
+/**
+ * A published artifact rendered as a Markdown document: the title as an H1, the
+ * description, then the body verbatim. Matches the shape `?format=raw` already
+ * emits, so the two text views of an artifact agree.
+ */
+export function buildMarkdownExport(title: string, description: string | undefined, body: string): string {
+  const parts = [`# ${title}`];
+  const desc = description?.trim();
+  if (desc) parts.push('', desc);
+  const trimmed = body.trim();
+  if (trimmed) parts.push('', trimmed);
+  return `${parts.join('\n')}\n`;
+}
+
+/**
+ * Export links for a viewer footer: plain `download` anchors, no JS, so they stay
+ * valid under `script-src 'none'`. Returns '' when there is nothing offerable.
+ *
+ * Callers must only render these where a credential-free navigation will
+ * re-authorize (open-public, `/a/<token>` share, or a passphrase-verified gate) -
+ * a Bearer-gated artifact would answer the click with the loader shell instead of
+ * a file. Owners reach the same exports through the Published tab, which does
+ * carry a credential.
+ */
+export function buildExportActionsHtml(viewerPath: string, formats: readonly PublishExportFormat[]): string {
+  if (!viewerPath || formats.length === 0) return '';
+  const links = formats
+    .map(
+      f =>
+        `<a href="${escapeAttr(exportHref(viewerPath, f))}" download` +
+        ` style="color:#94a3b8;text-decoration:none">&#8681; ${EXPORT_LABEL[f]}</a>`
+    )
+    .join('<span style="opacity:.4">&middot;</span>');
+  return (
+    `<div style="margin-top:10px;display:flex;justify-content:center;gap:10px;font-size:11.5px;` +
+    `font-family:ui-sans-serif,system-ui,-apple-system,sans-serif">${links}</div>`
+  );
+}

--- a/apps/client/pages/api/publish/serve/[...path].ts
+++ b/apps/client/pages/api/publish/serve/[...path].ts
@@ -36,6 +36,17 @@ import {
 } from '@server/services/publish/viewerSecurity';
 import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
 import {
+  EXPORT_CONTENT_TYPE,
+  buildExportActionsHtml,
+  buildMarkdownExport,
+  exportFilename,
+  exportFormatsFor,
+  exportHref,
+  parseExportFormat,
+  supportsExport,
+  type PublishExportFormat,
+} from '@client/app/utils/publishExport';
+import {
   parseArtifacts,
   parseArtifactsWithFallback,
   type ParsedArtifact,
@@ -54,6 +65,11 @@ import type { PublishScopeTier, PublishVisibility } from '@bike4mind/common';
  *   /p/u|pj|o/{scopeId}/{slug}[/asset]  -> hosted HTML bundle
  *   /p/r/{publicId}                     -> published reply (rendered markdown)
  *   /p/f/{publicId}                     -> published fabfile (rendered text)
+ *
+ * `?export=md|html` on any of the above (and on `/a/<shareToken>`) returns the artifact's
+ * CONTENT as an attachment, in the formats that convert faithfully for its kind - see
+ * `exportFormatsFor`. It is resolved after the visibility gate, so it is reachable on
+ * exactly the paths the page itself is.
  *
  * Bundles are served inside a sandboxed iframe: the `/p/...` HTML response
  * is a minimal trusted wrapper page whose only content is an
@@ -223,6 +239,12 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
   // Approach B: set by the `/uc/*` rewrite - this request is for the bundle on
   // its per-artifact isolated origin ({publicId}.usercontent.app.<domain>), served AS the page.
   const isIsolated = !isShare && req.query.__uc === '1';
+  // `?export=md|html` (issue #1142) - hand the artifact's CONTENT back as a downloaded
+  // file. Distinct from `?format=raw` (a public plain-text alternate for agents and
+  // unfurlers): an export is an attachment, is offered on share links and gated pages the
+  // viewer is already authorized for, and only in formats that convert faithfully for the
+  // artifact's kind. An empty `?export=` falls through to the normal page render.
+  const rawExport = typeof req.query.export === 'string' ? req.query.export : '';
 
   // Resolve the artifact.
   let artifact: PublishedArtifactLean | null = null;
@@ -294,6 +316,7 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
   //                  via rel="alternate" on the page that just became indexable.
   //  - ?raw=1:       the loader shell's internal srcdoc fetch, not a page.
   //  - ?a=<N>:       one embedded sub-artifact as a bare srcdoc document.
+  //  - ?export=<f>:  an attachment copy of the page, not the page.
   //  - assetPath:    an individual bundle file. A bundle may ship .html assets, which
   //                  would otherwise be standalone indexable pages with no wrapper.
   // Read `embed` off the query directly: the `isEmbed` binding is computed further down,
@@ -306,6 +329,7 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     req.query.embed !== '1' &&
     !req.query.v &&
     !req.query.a &&
+    !rawExport &&
     !(resolved.kind === 'bundle' && resolved.assetPath);
   const searchIndexable = isCanonicalDoc && isOpenPublic && artifact.discoverable === true;
   if (!searchIndexable) {
@@ -387,9 +411,19 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     // links grant unconditionally; passphrase share links took the prompt branch
     // above). The loader shell's localStorage-JWT re-fetch is exactly the recovery a
     // domain gate needs, so share navigations (not share asset sub-paths) get it too.
+    // `?export=` is excluded for the same reason as `?raw=1`: the shell recovers a
+    // NAVIGATION by re-fetching `?raw=1`, which yields the page, not the export - so an
+    // export request would dead-end on an HTML shell delivered as a download. Hard-fail
+    // instead. (The passphrase prompt above is different: it reloads the SAME url on
+    // success, so a gated export URL genuinely unlocks through it.)
     const isShareAsset = isShare && !!shareAssetPath;
     const wantsLoaderShell =
-      !isRaw && !isFormatRaw && !req.user && !isShareAsset && (resolved.kind === 'bundle' ? !resolved.assetPath : true);
+      !isRaw &&
+      !isFormatRaw &&
+      !rawExport &&
+      !req.user &&
+      !isShareAsset &&
+      (resolved.kind === 'bundle' ? !resolved.assetPath : true);
     if (wantsLoaderShell) {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.setHeader('Content-Security-Policy', buildWrapperCsp(req));
@@ -423,8 +457,51 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     res.setHeader('Referrer-Policy', 'no-referrer');
   }
 
+  // Resolve `?export=` only AFTER the gate above, so an export can never be reachable
+  // on a path the viewer page itself isn't - it hands back the whole content, so it must
+  // sit behind exactly the same visibility/share/passphrase check. Reject anything we
+  // cannot answer honestly: an unknown format, a format with no faithful conversion for
+  // this kind (see exportFormatsFor), or the isolated origin, which serves the bare
+  // bundle and carries none of the app's affordances.
+  const exportFormat: PublishExportFormat | null = rawExport ? parseExportFormat(rawExport) : null;
+  if (rawExport && (!exportFormat || !supportsExport(artifact.source.kind, exportFormat) || isIsolated)) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  // Exports are always no-store, even for an open-public artifact - the same reasoning that
+  // made `?v=` a no-store cold path: if the shared cache does not key on the query string, a
+  // cached `?export=` response would be an ATTACHMENT served in place of the page. A
+  // user-initiated download is not a hot path, so there is nothing to trade away.
+  const exportCacheControl = 'private, no-store, must-revalidate';
+
+  // Whether a plain, credential-free navigation to this artifact re-authorizes - the
+  // condition for OFFERING an export link on a viewer surface. A `?export=` click is a
+  // fresh top-level request with no Authorization header, so anything that needs a Bearer
+  // would answer it with a 401 instead of a file; those owners export from the Published
+  // tab, which does send one. Cookies DO ride along, so a verified passphrase counts, and
+  // an open share token counts because possession IS the grant. A share link with a DOMAIN
+  // gate does NOT: that gate reads `req.user`, which a navigation cannot supply.
+  // Deliberately stricter than `canFrameArtifacts` below, which treats every share link as
+  // self-authorizing and has the same domain-gate gap for its `?a=` frames.
+  const exportSelfAuthorizes = isOpenPublic || passphraseVerified || (isShare && !artifact.accessGate);
+
   // -- Reply / fabfile: render the snapshot body to a sanitized viewer page. --
   if (artifact.source.kind === 'reply' || artifact.source.kind === 'fabfile') {
+    if (exportFormat) {
+      // Markdown is offered for replies only - `renderedBody` is the assistant's own
+      // markdown there, so the export is the source text, not a conversion of it. The
+      // HTML export is the viewer page rendered standalone (embedded artifacts inlined,
+      // app-origin chrome dropped) so the saved file stands on its own offline.
+      const body =
+        exportFormat === 'md'
+          ? buildMarkdownExport(
+              artifact.title || SHARED_FALLBACK_TITLE,
+              artifact.description,
+              artifact.renderedBody ?? ''
+            )
+          : renderViewerPage(artifact, { noindex: true, noReferrer: isShare, standalone: true });
+      bumpViewCount(artifact, req.user as { id?: string } | undefined, req.headers['user-agent'], gateViewAudit);
+      return sendExport(res, exportFormat, artifact.title, body, exportCacheControl);
+    }
     // Reply/fabfile artifact sub-document (`?a={index}`): serve one embedded HTML/SVG artifact as a
     // standalone SANDBOXED document for the viewer page's iframe. Author JS runs, but the
     // response's `sandbox allow-scripts` CSP forces an opaque origin (NO allow-same-origin)
@@ -485,7 +562,14 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     // an iframe navigation cannot send - so it would dead-end at a nested loader shell. For those
     // we render the placeholder card instead of a frame that can never load.
     const canFrameArtifacts = isOpenPublic || isShare || passphraseVerified;
-    const page = renderViewerPage(artifact, !searchIndexable, isShare, selfPath, canFrameArtifacts);
+    const exportFormats = exportSelfAuthorizes ? exportFormatsFor(artifact.source.kind) : [];
+    const page = renderViewerPage(artifact, {
+      noindex: !searchIndexable,
+      noReferrer: isShare,
+      selfPath,
+      canFrameArtifacts,
+      exportFormats,
+    });
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     // The page itself stays script-free (`script-src 'none'` neutralizes any markup that
     // slipped past the sanitizer); embedded artifacts run only inside their own sandboxed
@@ -602,6 +686,35 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
   // format-validates AND allowlists the host, so a crafted `Host: attacker.com`
   // can't mint a CSP whitelisting attacker.com - it falls back to the app host.
   const docOrigin = resolveDocOrigin(req.headers.host, req.headers['x-forwarded-proto']);
+
+  // Bundle export (`?export=html` - the only faithful format for a bundle; the guard above
+  // already rejected `md`). Assets are inlined REGARDLESS of visibility, unlike the served
+  // view: a downloaded file has no route to fetch them back through, so the export is only
+  // faithful if it is self-contained. Blessed-library <script> refs still absolutize to the
+  // app host, so a saved bundle that used one needs network to render fully.
+  if (exportFormat) {
+    const collected = await collectInlineAssets({
+      manifest: artifact.manifest,
+      load: path => storage.download(`${artifact.storageKeyPrefix}${path}`),
+    });
+    const skipped = [...collected.oversized, ...collected.failed];
+    if (skipped.length) {
+      // No silent truncation - the download is missing bytes, so say which.
+      console.warn(`[publish] export ${artifact.publicId} dropped ${skipped.length} asset(s):`, skipped);
+      res.setHeader('X-Publish-Dropped-Assets', String(skipped.length));
+      res.setHeader('X-Publish-Dropped-Asset-Names', truncateHeaderList(skipped, 1024));
+    }
+    const { srcdoc: exportHtml } = renderSandboxedBundle({
+      indexHtml,
+      urlBase: '',
+      origin: docOrigin,
+      visibility: effectiveVisibility,
+      assetMode: 'inline',
+      assets: collected.assets,
+    });
+    bumpViewCount(artifact, req.user as { id?: string } | undefined, req.headers['user-agent'], gateViewAudit);
+    return sendExport(res, exportFormat, artifact.title, exportHtml, exportCacheControl);
+  }
 
   // Gated (non-public) bundles: the opaque-origin iframe can't fetch assets through the
   // gated route (uncredentialed -> 401/403), so pre-fetch them HERE (post-gate, credentialed)
@@ -758,6 +871,10 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
       : '';
   const pillHref = isEmbed ? marketing('embed-badge') || `${docOrigin}${canonicalPath}` : '';
   const barHref = !isEmbed && isOpenPublic ? marketing('share-bar') || `${docOrigin}/` : '';
+  // "Save as HTML" on the wrapper - see `exportSelfAuthorizes`. Dropped in embed mode,
+  // which is chrome-less by design.
+  const exportHtmlHref =
+    !isEmbed && exportSelfAuthorizes ? exportHref(isShare ? shareBase : canonicalPath, 'html') : '';
   const wrapperPage = renderBundleWrapper(
     artifact,
     srcdoc,
@@ -769,7 +886,8 @@ const handler = baseApi({ auth: false }).get(async (req: Request, res: Response)
     isEmbed,
     pillHref,
     barHref,
-    pillHref || barHref ? getBrandName() : ''
+    pillHref || barHref ? getBrandName() : '',
+    exportHtmlHref
   );
 
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
@@ -822,7 +940,9 @@ function renderBundleWrapper(
   embed = false,
   pillHref = '',
   barHref = '',
-  brandName = ''
+  brandName = '',
+  /** `?export=html` href for the "Save as HTML" affordance; '' hides it. */
+  exportHtmlHref = ''
 ): string {
   const titleHtml = escapeHtml(artifact.title || SHARED_FALLBACK_TITLE);
   // HTML attribute escape: inside a double-quoted attribute value only `&` and `"` are
@@ -875,10 +995,15 @@ function renderBundleWrapper(
         )}${LIVERY_REG}</a>`
       : '';
   const barPresent = !embed && !!barHref && !!brandName;
+  // Plain top-level `download` anchor - no JS, so it works under the tightened
+  // Approach-B wrapper CSP (script-src admits only the comment widget).
+  const barExport = exportHtmlHref
+    ? `\n    <a class="b4m-bar-export" href="${escapeHtml(exportHtmlHref)}" download target="_top">Save as HTML</a>`
+    : '';
   const bar = barPresent
     ? `\n<div class="b4m-bar">
   <span class="b4m-bar-l">Built with ${liveryBarMark(brandName)}${LIVERY_REG}</span>
-  <span class="b4m-bar-r">
+  <span class="b4m-bar-r">${barExport}
     <a class="b4m-bar-report" href="${reportHref}" rel="nofollow" target="_top">Report</a>
     <a class="b4m-bar-cta" href="${escapeHtml(
       barHref
@@ -886,9 +1011,12 @@ function renderBundleWrapper(
   </span>
 </div>`
     : '';
+  const floatingExport = exportHtmlHref
+    ? `<a class="b4m-export" href="${escapeHtml(exportHtmlHref)}" download target="_top">&#8681; HTML</a>`
+    : '';
   const floatingReport = barPresent
     ? ''
-    : `\n<a class="b4m-report" href="${reportHref}" rel="nofollow" target="_top">&#9873; Report</a>`;
+    : `\n<div class="b4m-actions">${floatingExport}<a class="b4m-report" href="${reportHref}" rel="nofollow" target="_top">&#9873; Report</a></div>`;
   const iframeHeight = barPresent ? 'calc(100vh - 52px)' : '100vh';
 
   return `<!doctype html>
@@ -898,9 +1026,10 @@ function renderBundleWrapper(
 <meta name="viewport" content="width=device-width, initial-scale=1">${noindexHead}
 <title>${titleHtml}</title>${metaHead}
 <style>html,body{margin:0;padding:0;height:100%}iframe{border:0;display:block;width:100%;height:${iframeHeight}}
-.b4m-report{position:fixed;bottom:10px;right:10px;z-index:2147483647;font:500 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
+.b4m-actions{position:fixed;bottom:10px;right:10px;z-index:2147483647;display:flex;gap:8px}
+.b4m-report,.b4m-export{font:500 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
   color:#cbd5e1;background:rgba(13,24,48,.78);padding:5px 9px;border-radius:8px;text-decoration:none;backdrop-filter:blur(4px)}
-.b4m-report:hover{color:#fff;background:rgba(13,24,48,.95)}
+.b4m-report:hover,.b4m-export:hover{color:#fff;background:rgba(13,24,48,.95)}
 .b4m-brand{position:fixed;bottom:10px;left:10px;z-index:2147483647;font:600 11px/1 ui-sans-serif,system-ui,-apple-system,sans-serif;
   color:#fff;background:${LIVERY_ORANGE};padding:6px 11px;border-radius:8px;text-decoration:none;box-shadow:0 2px 10px rgba(0,0,0,.28)}
 .b4m-brand:hover{filter:brightness(1.07)}
@@ -913,8 +1042,8 @@ function renderBundleWrapper(
 .b4m-bar-logo svg{height:22px;width:auto;display:block}
 .b4m-reg{font-size:.62em;vertical-align:super;font-weight:400;margin-left:1px}
 .b4m-bar-r{display:flex;align-items:center;gap:14px}
-.b4m-bar-report{color:#94a3b8;text-decoration:none;font-weight:500;font-size:12px}
-.b4m-bar-report:hover{color:#cbd5e1}
+.b4m-bar-report,.b4m-bar-export{color:#94a3b8;text-decoration:none;font-weight:500;font-size:12px}
+.b4m-bar-report:hover,.b4m-bar-export:hover{color:#cbd5e1}
 .b4m-bar-cta{padding:8px 14px;border-radius:9px;background:${LIVERY_ORANGE};color:#fff;font-weight:700;text-decoration:none;white-space:nowrap}
 .b4m-bar-cta:hover{filter:brightness(1.07)}
 .b4m-ver{position:fixed;bottom:${barPresent ? '62px' : '10px'};left:10px;z-index:2147483647;display:flex;align-items:center;gap:8px;
@@ -1231,6 +1360,31 @@ function sendRawArtifact(
 }
 
 /**
+ * Send an `?export=` payload as a downloaded file.
+ *
+ * `Content-Disposition: attachment` + `nosniff` + `default-src 'none'; sandbox` is what
+ * makes it safe to hand author-controlled HTML back on the APP origin: the browser saves
+ * the bytes instead of parsing them as a document, so they never execute here (the same
+ * reasoning as the `?raw=1` text/plain response, which cannot use attachment because the
+ * loader shell fetch()es it). Callers must have cleared the visibility gate first.
+ */
+function sendExport(
+  res: Response,
+  format: PublishExportFormat,
+  title: string,
+  body: string,
+  cacheControl: string
+): void {
+  res.setHeader('Content-Type', EXPORT_CONTENT_TYPE[format]);
+  // exportFilename is ASCII and quote-free by construction, so no header escaping is needed.
+  res.setHeader('Content-Disposition', `attachment; filename="${exportFilename(title || 'artifact', format)}"`);
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
+  res.setHeader('Cache-Control', cacheControl);
+  res.status(200).send(body);
+}
+
+/**
  * Extract embedded artifacts for the viewer, in DOCUMENT order. Parser choice is kind-dependent:
  * - reply: `parseArtifactsWithFallback` also promotes fenced code / bare-HTML docs to artifacts,
  *   matching the in-app render of agent markdown.
@@ -1269,9 +1423,26 @@ function cleanViewerTitle(rawTitle: string | undefined, artifacts: ParsedArtifac
  * mermaid/recharts) needs the app runtime the static viewer can't provide, so it also gets a
  * clean placeholder card instead of leaking raw markup. `index` MUST match the position in the
  * same parseArtifactsWithFallback result the `?a` handler indexes into.
+ *
+ * `standalone` (the `?export=html` download) has no `?a=` route to point at, so an html/svg
+ * artifact is inlined as an iframe `srcdoc` instead - same `sandbox="allow-scripts"` opaque-origin
+ * posture, but self-contained, so the saved file renders offline.
  */
-function renderArtifactBlock(artifact: ParsedArtifact, index: number, selfPath: string, canFrame: boolean): string {
+function renderArtifactBlock(
+  artifact: ParsedArtifact,
+  index: number,
+  selfPath: string,
+  canFrame: boolean,
+  standalone = false
+): string {
   const title = escapeHtml(artifact.title || 'Artifact');
+  if (standalone && (artifact.type === 'html' || artifact.type === 'svg')) {
+    // srcdoc attribute escape: inside a double-quoted value only `&` and `"` are unsafe -
+    // `<`/`>` are literal data. Escaping them would corrupt the framed document (see the
+    // identical note in renderBundleWrapper). `&` first so it can't double-escape `&quot;`.
+    const doc = artifact.content.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+    return `<iframe class="b4m-artifact" sandbox="allow-scripts" title="${title}" srcdoc="${doc}"></iframe>`;
+  }
   if (canFrame && selfPath && (artifact.type === 'html' || artifact.type === 'svg')) {
     const src = escapeHtml(`${selfPath}?a=${index}`);
     return `<iframe class="b4m-artifact" sandbox="allow-scripts" loading="lazy" title="${title}" src="${src}"></iframe>`;
@@ -1291,12 +1462,33 @@ function renderArtifactBlock(artifact: ParsedArtifact, index: number, selfPath: 
  */
 function renderViewerPage(
   artifact: PublishedArtifactLean,
-  noindex: boolean,
-  /** Share links only - see NO_REFERRER_META. */
-  noReferrer: boolean,
-  selfPath = '',
-  canFrameArtifacts = false
+  opts: {
+    noindex: boolean;
+    /** Share links only - see NO_REFERRER_META. */
+    noReferrer: boolean;
+    /** Path this page was reached at, so embedded artifacts frame back through it. */
+    selfPath?: string;
+    canFrameArtifacts?: boolean;
+    /** Formats to offer as footer download links; empty hides the row. */
+    exportFormats?: readonly PublishExportFormat[];
+    /**
+     * The `?export=html` download rather than a served page. A saved file resolves
+     * nothing against the app origin, so embedded artifacts inline as `srcdoc` and the
+     * served-page-only chrome is dropped: the CSP meta (which exists for the loader
+     * shell's srcdoc injection, and would neutralize the inlined artifacts' own JS), the
+     * root-relative report link, and the export links themselves.
+     */
+    standalone?: boolean;
+  }
 ): string {
+  const {
+    noindex,
+    noReferrer,
+    selfPath = '',
+    canFrameArtifacts = false,
+    exportFormats = [],
+    standalone = false,
+  } = opts;
   const body = artifact.renderedBody ?? '';
   let contentHtml: string;
   let displayTitle = artifact.title || SHARED_FALLBACK_TITLE;
@@ -1305,7 +1497,9 @@ function renderViewerPage(
     const article = cleanedContent
       ? sanitizeRenderedHtml(marked.parse(cleanedContent, { async: false }) as string)
       : '';
-    const blocks = artifacts.map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts)).join('\n');
+    const blocks = artifacts
+      .map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts, standalone))
+      .join('\n');
     contentHtml = `${article}${blocks}`;
     displayTitle = cleanViewerTitle(artifact.title, artifacts);
   } else {
@@ -1326,23 +1520,37 @@ function renderViewerPage(
       // artifacts loses document order; the common case (prose then one trailing artifact) is fine.
       // Revisit if fabfiles ever need interleaved text/artifact authoring.
       const pre = cleanedContent ? `<pre class="b4m-pre">${escapeHtml(cleanedContent)}</pre>` : '';
-      const blocks = artifacts.map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts)).join('\n');
+      const blocks = artifacts
+        .map((a, i) => renderArtifactBlock(a, i, selfPath, canFrameArtifacts, standalone))
+        .join('\n');
       contentHtml = `${pre}${blocks}`;
     }
     displayTitle = cleanViewerTitle(artifact.title, artifacts);
   }
   const titleHtml = escapeHtml(displayTitle);
   const noindexHead = `${noindex ? `\n${NOINDEX_META}` : ''}${noReferrer ? `\n${NO_REFERRER_META}` : ''}`;
+  // CSP as a meta so the no-JS posture survives when this page is injected as the loader
+  // shell's iframe srcdoc (a srcdoc carries no HTTP CSP header, and the shell's iframe is
+  // sandbox="allow-scripts"). Mirrors the direct-serve HTTP header's script-src 'none'.
+  // Omitted for a standalone export: no shell injects it, and `script-src 'none'` would be
+  // inherited by the inlined artifact srcdoc frames and kill their JS.
+  const cspMeta = standalone
+    ? ''
+    : `\n<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'none'; style-src 'unsafe-inline'; ${withAppHost(
+        "img-src 'self' data:"
+      )}; font-src 'self' https://fonts.gstatic.com; frame-src 'self'; child-src 'self'; base-uri 'self'; form-action 'none'">`;
+  const footer = standalone
+    ? buildShareFooterHtml({ source: artifact.source.kind === 'reply' ? 'reply' : 'fabfile' })
+    : buildShareFooterHtml({
+        source: artifact.source.kind === 'reply' ? 'reply' : 'fabfile',
+        reportPublicId: artifact.publicId,
+      }) + buildExportActionsHtml(selfPath, exportFormats);
 
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">${noindexHead}
-<!-- CSP as a meta so the no-JS posture survives when this page is injected as the loader
-     shell's iframe srcdoc (a srcdoc carries no HTTP CSP header, and the shell's iframe is
-     sandbox="allow-scripts"). Mirrors the direct-serve HTTP header's script-src 'none'. -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'none'; style-src 'unsafe-inline'; ${withAppHost("img-src 'self' data:")}; font-src 'self' https://fonts.gstatic.com; frame-src 'self'; child-src 'self'; base-uri 'self'; form-action 'none'">
+<meta name="viewport" content="width=device-width, initial-scale=1">${noindexHead}${cspMeta}
 <meta property="og:title" content="${titleHtml}">
 <meta property="og:description" content="${escapeHtml(SHARED_FALLBACK_TITLE)}">
 <title>${titleHtml}</title>
@@ -1365,10 +1573,7 @@ function renderViewerPage(
 </head>
 <body>
 <article>${contentHtml}</article>
-${buildShareFooterHtml({
-  source: artifact.source.kind === 'reply' ? 'reply' : 'fabfile',
-  reportPublicId: artifact.publicId,
-})}
+${footer}
 </body>
 </html>`;
 }

--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 
-const { mockArtifactFindOne, mockProjectFindOne, mockDownload, mockUpdateOne } = vi.hoisted(() => ({
+const { mockArtifactFindOne, mockProjectFindOne, mockDownload, mockUpdateOne, mockUserFindById } = vi.hoisted(() => ({
   mockArtifactFindOne: vi.fn(),
   mockProjectFindOne: vi.fn(),
   mockDownload: vi.fn(),
   mockUpdateOne: vi.fn(() => Promise.resolve()),
+  // Domain access gates look the viewer's verified email up through User (checkVisibility).
+  mockUserFindById: vi.fn(),
 }));
 
 // baseApi mock: callable chain routed by req.method; .use() no-op; last fn per verb is handler.
@@ -47,6 +49,9 @@ vi.mock('@bike4mind/database', () => ({
   Project: {
     findOne: (...a: unknown[]) => ({ select: () => ({ lean: () => Promise.resolve(mockProjectFindOne(...a)) }) }),
   },
+  User: {
+    findById: (...a: unknown[]) => ({ select: () => ({ lean: () => Promise.resolve(mockUserFindById(...a)) }) }),
+  },
 }));
 
 import handler from '../[...path]';
@@ -66,10 +71,11 @@ type RunOpts = {
   userAgent?: string;
   embed?: boolean;
   a?: string;
+  exportAs?: unknown;
 };
 const run = (
   segments: string[],
-  { user, host = 'app.bike4mind.com', raw, v, uc, format, cookie, userAgent, embed, a }: RunOpts = {}
+  { user, host = 'app.bike4mind.com', raw, v, uc, format, cookie, userAgent, embed, a, exportAs }: RunOpts = {}
 ) => {
   const query: Record<string, unknown> = { path: segments };
   if (raw) query.raw = '1';
@@ -77,6 +83,7 @@ const run = (
   if (format) query.format = format;
   if (embed) query.embed = '1';
   if (a !== undefined) query.a = a;
+  if (exportAs !== undefined) query.export = exportAs;
   const effectiveHost = uc ? `${uc}.usercontent.app.bike4mind.com` : host;
   if (uc) query.__uc = '1';
   const headers: Record<string, string> = { host: effectiveHost };
@@ -106,6 +113,7 @@ beforeEach(() => {
   mockProjectFindOne.mockReset().mockResolvedValue(null);
   mockDownload.mockReset();
   mockUpdateOne.mockReset().mockResolvedValue(undefined);
+  mockUserFindById.mockReset().mockResolvedValue(null);
 });
 
 describe('GET /api/publish/serve - sandboxed bundle', () => {
@@ -1993,5 +2001,343 @@ describe('GET /api/publish/serve - search-engine discoverability is opt-in', () 
 
     expect(res._getStatusCode()).toBe(200);
     expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+});
+
+describe('GET /api/publish/serve - ?export= content export (issue #1142)', () => {
+  const publicReply = (over: Record<string, unknown> = {}) => ({
+    publicId: 'rexp',
+    title: 'My Reply',
+    description: 'A short blurb',
+    visibility: 'public',
+    ownerId: 'owner1',
+    source: { kind: 'reply' },
+    renderedBody: '## Heading\n\nSome *markdown* body.',
+    storageKeyPrefix: '',
+    manifest: [],
+    tier: 'user',
+    scopeId: 's',
+    slug: 'rexp',
+    ...over,
+  });
+
+  it('exports a reply as Markdown: attachment, title heading, body verbatim', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply());
+    const { res, promise } = run(['r', 'rexp'], { exportAs: 'md' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('Content-Type')).toBe('text/markdown; charset=utf-8');
+    expect(res.getHeader('Content-Disposition')).toBe('attachment; filename="my-reply.md"');
+    expect(res.getHeader('X-Content-Type-Options')).toBe('nosniff');
+    // Author bytes never render on the app origin: attachment + nosniff + a sandbox CSP.
+    expect(res.getHeader('Content-Security-Policy')).toBe("default-src 'none'; sandbox");
+    const data = res._getData() as string;
+    expect(data).toBe('# My Reply\n\nA short blurb\n\n## Heading\n\nSome *markdown* body.\n');
+  });
+
+  it('exports a reply as a STANDALONE html file - no CSP meta, no root-relative report link', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply());
+    const { res, promise } = run(['r', 'rexp'], { exportAs: 'html' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('Content-Type')).toBe('text/html; charset=utf-8');
+    expect(res.getHeader('Content-Disposition')).toBe('attachment; filename="my-reply.html"');
+    const data = res._getData() as string;
+    expect(data).toContain('<h2>Heading</h2>');
+    // A downloaded file resolves nothing against the app origin, so the served-page-only
+    // chrome is dropped (the CSP meta would also kill inlined artifacts' JS).
+    expect(data).not.toContain('http-equiv="Content-Security-Policy"');
+    expect(data).not.toContain('/report/rexp');
+    expect(data).not.toContain('?export=');
+  });
+
+  it('inlines an embedded html artifact as srcdoc in a standalone export (not a ?a= URL)', async () => {
+    mockArtifactFindOne.mockReturnValue(
+      publicReply({
+        renderedBody:
+          '<artifact identifier="t" type="text/html" title="Tip"><html><body><script>window.ok=1</script></body></html></artifact>',
+      })
+    );
+    const { res, promise } = run(['r', 'rexp'], { exportAs: 'html' });
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain('srcdoc=');
+    expect(data).not.toContain('?a=0');
+    // Same opaque-origin posture as the served page; the artifact's own JS travels with it.
+    expect(data).toContain('sandbox="allow-scripts"');
+    expect(data).toContain('window.ok=1');
+  });
+
+  it('exports a fabfile as html but 404s a Markdown request (no faithful conversion)', async () => {
+    const fab = publicReply({ publicId: 'fexp', source: { kind: 'fabfile' }, renderedBody: 'col_a,col_b\n1,2\n' });
+    mockArtifactFindOne.mockReturnValue(fab);
+    const { res, promise } = run(['f', 'fexp'], { exportAs: 'html' });
+    await promise;
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData() as string).toContain('col_a,col_b');
+
+    mockArtifactFindOne.mockReturnValue(fab);
+    const md = run(['f', 'fexp'], { exportAs: 'md' });
+    await md.promise;
+    expect(md.res._getStatusCode()).toBe(404);
+  });
+
+  it('exports a bundle as a self-contained html file with its assets inlined', async () => {
+    mockArtifactFindOne.mockReturnValue(
+      bundle({
+        manifest: [
+          { path: 'index.html', mimeType: 'text/html' },
+          { path: 'logo.png', mimeType: 'image/png' },
+        ],
+      })
+    );
+    mockDownload.mockImplementation((key: string) =>
+      Promise.resolve(
+        key.endsWith('index.html')
+          ? Buffer.from('<html><body><img src="logo.png"><h1>Hi</h1></body></html>')
+          : Buffer.from([1, 2, 3])
+      )
+    );
+
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { exportAs: 'html' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('Content-Disposition')).toBe('attachment; filename="my-artifact.html"');
+    const data = res._getData() as string;
+    // Assets inline even though the artifact is PUBLIC (the served view would use <base>):
+    // a downloaded file has no route to fetch them back through.
+    expect(data).toContain('data:image/png;base64,');
+    expect(data).not.toContain('<base href=');
+  });
+
+  it('404s a Markdown export of a bundle', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle());
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { exportAs: 'md' });
+    await promise;
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockDownload).not.toHaveBeenCalled(); // rejected before touching storage
+  });
+
+  it('404s an unknown export format, and ignores an empty one', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply());
+    const pdf = run(['r', 'rexp'], { exportAs: 'pdf' });
+    await pdf.promise;
+    expect(pdf.res._getStatusCode()).toBe(404);
+
+    // `?export=` with no value falls through to the normal page render.
+    mockArtifactFindOne.mockReturnValue(publicReply());
+    const empty = run(['r', 'rexp'], { exportAs: '' });
+    await empty.promise;
+    expect(empty.res._getStatusCode()).toBe(200);
+    expect(empty.res.getHeader('Content-Type')).toBe('text/html; charset=utf-8');
+    expect(empty.res.getHeader('Content-Disposition')).toBeUndefined();
+  });
+
+  it('is never search-indexable, even for a discoverable open-public artifact', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply({ discoverable: true }));
+    const { res, promise } = run(['r', 'rexp'], { exportAs: 'md' });
+    await promise;
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+
+  it('hard-fails an anonymous export of a gated reply instead of returning the loader shell', async () => {
+    // The shell recovers a NAVIGATION by re-fetching ?raw=1, which yields the page - so a
+    // shell delivered as a download would dead-end. 401, and never the body.
+    mockArtifactFindOne.mockReturnValue(
+      publicReply({ visibility: 'organization', tier: 'organization', scopeId: 'org_1' })
+    );
+    const { res, promise } = run(['r', 'rexp'], { exportAs: 'md' });
+    await promise;
+    expect(res._getStatusCode()).toBe(401);
+    const data = res._getData() as string;
+    expect(data).not.toContain('Some *markdown* body.');
+    expect(data).not.toContain('b4m-frame'); // not the loader shell either
+    expect(res.getHeader('Content-Disposition')).toBeUndefined();
+  });
+
+  it('403s an export for an authenticated viewer the gate rejects', async () => {
+    mockArtifactFindOne.mockReturnValue(
+      publicReply({ visibility: 'organization', tier: 'organization', scopeId: 'org_1' })
+    );
+    const { res, promise } = run(['r', 'rexp'], { exportAs: 'md', user: { id: 'other', organizationId: 'org_9' } });
+    await promise;
+    expect(res._getStatusCode()).toBe(403);
+  });
+
+  it('exports for an authorized org member', async () => {
+    mockArtifactFindOne.mockReturnValue(
+      publicReply({ visibility: 'organization', tier: 'organization', scopeId: 'org_1' })
+    );
+    const { res, promise } = run(['r', 'rexp'], { exportAs: 'md', user: { id: 'other', organizationId: 'org_1' } });
+    await promise;
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData() as string).toContain('Some *markdown* body.');
+  });
+
+  it('exports through a /a/<shareToken> link, no-store and no-referrer', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply({ visibility: 'private', shareToken: 'tok123' }));
+    const { res, promise } = run(['a', 'tok123'], { exportAs: 'md' });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData() as string).toContain('Some *markdown* body.');
+    expect(res.getHeader('Cache-Control')).toContain('no-store');
+    expect(res.getHeader('Referrer-Policy')).toBe('no-referrer');
+    expect(res.getHeader('X-Robots-Tag')).toBe('noindex, nofollow');
+  });
+
+  it('404s an export on the isolated usercontent origin (bare bundle, no app affordances)', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle());
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { uc: 'pub1', exportAs: 'html' });
+    await promise;
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('never shared-caches an export, not even an open-public one', async () => {
+    // A cached `?export=` would be an ATTACHMENT served in place of the page on any shared
+    // cache that does not key on the query string. Same reasoning as the `?v=` cold path.
+    mockArtifactFindOne.mockReturnValue(publicReply());
+    const { res, promise } = run(['r', 'rexp'], { exportAs: 'md' });
+    await promise;
+    expect(res.getHeader('Cache-Control')).toBe('private, no-store, must-revalidate');
+
+    mockArtifactFindOne.mockReturnValue(
+      publicReply({ visibility: 'organization', tier: 'organization', scopeId: 'org_1' })
+    );
+    const gated = run(['r', 'rexp'], { exportAs: 'md', user: { id: 'other', organizationId: 'org_1' } });
+    await gated.promise;
+    expect(gated.res.getHeader('Cache-Control')).toContain('no-store');
+  });
+});
+
+describe('GET /api/publish/serve - export affordances on the viewer surfaces (issue #1142)', () => {
+  const publicReply = (over: Record<string, unknown> = {}) => ({
+    publicId: 'rexp',
+    title: 'My Reply',
+    visibility: 'public',
+    ownerId: 'owner1',
+    source: { kind: 'reply' },
+    renderedBody: 'body text',
+    storageKeyPrefix: '',
+    manifest: [],
+    tier: 'user',
+    scopeId: 's',
+    slug: 'rexp',
+    ...over,
+  });
+
+  it('offers Markdown + HTML downloads on an open-public reply page, with no script', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply());
+    const { res, promise } = run(['r', 'rexp']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain('href="/p/r/rexp?export=md" download');
+    expect(data).toContain('href="/p/r/rexp?export=html" download');
+    // The page is served script-src 'none' - the affordance must be pure markup.
+    expect(data).not.toContain('<script');
+  });
+
+  it('offers only HTML on a fabfile page (no faithful Markdown form)', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply({ publicId: 'fexp', source: { kind: 'fabfile' }, slug: 'fexp' }));
+    const { res, promise } = run(['f', 'fexp']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain('href="/p/f/fexp?export=html" download');
+    expect(data).not.toContain('?export=md');
+  });
+
+  it('points the links at the token path on a /a/<shareToken> view', async () => {
+    mockArtifactFindOne.mockReturnValue(publicReply({ visibility: 'private', shareToken: 'tok123' }));
+    const { res, promise } = run(['a', 'tok123']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain('href="/a/tok123?export=md" download');
+    expect(data).not.toContain('/p/r/rexp?export=');
+  });
+
+  it('omits the links on a Bearer-gated reply, which would answer the click with the loader shell', async () => {
+    mockArtifactFindOne.mockReturnValue(
+      publicReply({ visibility: 'organization', tier: 'organization', scopeId: 'org_1' })
+    );
+    const { res, promise } = run(['r', 'rexp'], { user: { id: 'other', organizationId: 'org_1' } });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getData() as string;
+    expect(data).toContain('body text'); // authorized, page rendered
+    expect(data).not.toContain('?export=');
+  });
+
+  it('puts "Save as HTML" in the lead-gen bar on an own-tab open-public bundle', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle());
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+    const { res, promise } = run(['u', 'scope123', 'my-slug']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain('class="b4m-bar-export"');
+    expect(data).toContain('href="/p/u/scope123/my-slug?export=html" download');
+  });
+
+  it('drops the bundle export affordance in chrome-less embed mode', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle());
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+    const { res, promise } = run(['u', 'scope123', 'my-slug'], { embed: true });
+    await promise;
+
+    expect(res._getData() as string).not.toContain('?export=');
+  });
+
+  it('offers the bundle export as a floating chip on a share-token view', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle({ visibility: 'private' }));
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+    const { res, promise } = run(['a', 'tok123']);
+    await promise;
+
+    const data = res._getData() as string;
+    expect(data).toContain('<div class="b4m-actions">');
+    expect(data).toContain('class="b4m-export"');
+    expect(data).toContain('href="/a/tok123?export=html" download');
+  });
+
+  it('omits the links on a DOMAIN-gated share link, whose gate reads req.user', async () => {
+    // Possession of the token is not enough for a domain gate, and a `?export=` navigation
+    // carries no Bearer - so the link would 401. Stricter than canFrameArtifacts on purpose.
+    mockArtifactFindOne.mockReturnValue(
+      publicReply({ shareToken: 'tok123', accessGate: { kind: 'domain', allowedDomains: ['acme.com'] } })
+    );
+    mockUserFindById.mockResolvedValue({ email: 'a@acme.com', emailVerified: true });
+    const { res, promise } = run(['a', 'tok123'], { user: { id: 'u1' } });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData() as string).not.toContain('?export=');
+  });
+
+  it('offers the links on a passphrase-verified page - the proof cookie rides the navigation', async () => {
+    const { signGateToken } = await import('@server/services/publish/publishGateToken');
+    mockArtifactFindOne.mockReturnValue(publicReply({ accessGate: { kind: 'passphrase' } }));
+    const { res, promise } = run(['r', 'rexp'], { cookie: `b4m_pg_rexp=${signGateToken({ publicId: 'rexp' })}` });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData() as string).toContain('?export=md');
+  });
+
+  it('omits the bundle export affordance for a Bearer-gated bundle', async () => {
+    mockArtifactFindOne.mockReturnValue(bundle({ visibility: 'organization', tier: 'organization', scopeId: 'org_1' }));
+    mockDownload.mockResolvedValue(Buffer.from('<html><body><h1>Hi</h1></body></html>'));
+    const { res, promise } = run(['u', 'org_1', 'my-slug'], { user: { id: 'other', organizationId: 'org_1' } });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData() as string).not.toContain('?export=');
   });
 });


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<!--
If applicable, add screenshots or a video to help explain your changes. This can be particularly useful for UI changes or visual bug fixes.
-->

## Description

Published artifacts could only be shared as a link - there was no way to get their **content** out, and no way for an author to push a live link to a newer version without returning to the notebook. This PR adds the content-export and refresh actions from issue #1142 to the Published tab (`/profile?tab=published`), plus a print-based Save-as-PDF.

Three capabilities:

1. **Content export** (issue #1142, item 1) - Copy-as-Markdown and Save-as-HTML, offered only where a faithful conversion exists for the artifact kind and hidden (not disabled, not lossy) where it does not.
2. **Save-as-PDF** (issue #1142, item 2) - via the browser's own print dialog, the cheapest rendering approach (no server-side renderer, no new infra).
3. **Refresh from source** (issue #1142, item 2 / re-publish reading) - re-publish a bundle from its source artifact's current content onto the same `/p/...` link.

## Changes

**Content export**
- New `publishExport.ts` - single source of truth for which formats each publish-source kind converts to without loss: `reply` -> Markdown + HTML (the stored body IS the assistant's markdown), `fabfile` / `bundle` -> HTML only. Shared by the serve route and the app so both agree on what may be offered.
- Server: `?export=md|html` on `pages/api/publish/serve/[...path].ts`, resolved AFTER the visibility gate (so it is reachable on exactly the paths the page is), always `no-store`, `Content-Disposition: attachment` + `nosniff` + strict sandbox CSP so returning author HTML on the app origin is safe. Added to the noindex exclusion list.
- Owner path: Copy-as-Markdown + Save-as-HTML buttons per row, fetched through the authenticated api client - the export route for private / org-gated artifacts whose public pages correctly show no links.
- Public viewer footers: plain `download` anchors (no JS, since both viewer surfaces are script-restricted), emitted only where a credential-free navigation re-authorizes.

**Save-as-PDF**
- New `printToPdf.ts` - mounts the HTML export in an off-screen iframe sandboxed WITHOUT `allow-same-origin` (opaque origin, no access to app cookies/DOM); `allow-scripts` renders bundles, `allow-modals` lets an injected in-frame trigger open the print dialog (the parent cannot reach a cross-origin frame's `print()`), and the frame reports completion over `postMessage` so the node is reclaimed. Deliberately NOT `window.open`, which would inherit the app origin.
- Save-as-PDF button per row, owner-path only (the public footers stay CSP-locked), offered for every kind since the browser renders it visually.

**Refresh from source**
- `refreshPublishedFromSource()` + a confirm-gated Refresh button. Re-publishes from the source artifact's CURRENT content, landing a new version on the SAME link. Reuses the ordinary publish pipeline with the slug pinned rather than adding a bespoke endpoint that would restate the publish security contract.
- Passes `visibility`, `commentPolicy`, and `description` through from the current row: finalize `$set`s all three unconditionally, so omitting them would silently fall back to public and leak a private page. Scoped to bundles that still know their in-app source (same restriction restore applies).

## Guide for Testers

Preconditions: log in as a user who has at least one published bundle artifact and one published reply. If none exist, publish an artifact first (open an artifact -> Share to public link).

1. Navigate to `app.staging.bike4mind.com/profile?tab=published` (or avatar menu -> Profile -> "Live Artifacts").
   - Expected: the "Live Artifacts" list shows one row per published artifact.
2. On a **bundle** row, click the download icon (tooltip "Save as HTML").
   - Expected: a `.html` file downloads with a slugified filename. Opening it renders the artifact standalone (assets inlined).
3. On the same bundle row, click the PDF icon (tooltip "Save as PDF (opens print dialog)").
   - Expected: the browser print dialog opens within a couple of seconds; choosing "Save as PDF" produces a PDF of the artifact. No new browser tab opens.
4. On a **reply** row, click the notes icon (tooltip "Copy as Markdown").
   - Expected: a "Markdown copied" toast; pasting yields the reply's markdown (an H1 title, then the body).
5. Confirm the reply row does NOT show a "Copy as Markdown" button on a **bundle** row (bundles have no faithful Markdown form) but DOES show Save-as-HTML and Save-as-PDF on every row.
6. On a bundle row that was published from an in-app artifact, click the refresh icon (tooltip "Refresh from source ..."), then confirm the dialog.
   - Expected: a success toast; the live `/p/...` link now serves the source artifact's current content as a new version (same URL).

### Regression Checks
1. The existing per-row actions still work: manage sharing (`</>` toggle), copy link, comments toggle, restore previous version, delete.
2. Open a **private** or **org-gated** artifact's public page in a logged-out browser: it must show NO export links in the footer, and a direct `?export=html` on it must not return the content.
3. After a Refresh, the artifact's visibility, comment policy, and description are unchanged (a private page stays private).

### What NOT to test
- PDF pagination fidelity / exact layout: this is browser print-to-PDF by design, so output varies by browser and there is no pagination control. Verifying a PDF is produced is enough.
- Server-side PDF rendering: intentionally not built (see Additional Information).

## Additional Information

- **PDF approach is deliberately the "cheap" one.** A faithful cross-kind PDF would need a headless renderer (Chromium in Lambda) - real new infra the issue flagged as "the heavy one." This ships the browser-print path now; a server-side renderer can be tracked separately if higher fidelity is needed.
- **Re-share (issue #1142, item 3) is intentionally NOT in this PR** - it is blocked on the issue's open "actor" question (viewer-side onward-share vs. author re-publish vs. in-platform share). Minting a viewer-facing capability link is not possible today because the share token is a single owner/admin-scoped scalar; a real re-share needs per-grant tokens. Left for a follow-up once the actor is confirmed.

## Developer Notes (Optional)

- `publishExport.ts` is the single source of truth for export faithfulness (`exportFormatsFor(kind)`), shared by the serve route and the app so a new artifact kind only has to declare its faithful formats once.
- `printToPdf.ts` (`buildPrintDocument` + `printHtmlForPdf`) is a reusable, origin-isolating print-to-PDF helper: any surface that has trusted HTML and needs a client PDF can call it without running that HTML in the app origin.
- Refresh reuses the publish pipeline with the slug pinned instead of a bespoke `/refresh` endpoint - the pattern for "re-run publish onto an existing version" without duplicating the publish security contract.

## Security Testing (for security-labeled PRs only)
<!--
Required for any PR closing a security-labeled issue. Delete this section
if the PR is not security-related.

Preview environments are created on demand by maintainers via an internal deploy pipeline.
There's no label or comment command to request one yourself. When a maintainer triggers a
preview, a bot comment with the `pr<N>.preview.bike4mind.com` URL appears on this PR.
See CONTRIBUTING.md → "Preview deploys".
-->

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A (no AdminSettings)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A (no telemetry changes)


Closes https://github.com/Bike4Mind/bike4mind/issues/1142
