### PR TITLE
fix(llm-adapters): abort a stream that degenerates into repetition

### DIFF
--- a/apps/client/app/components/Session/PromptReplies.tsx
+++ b/apps/client/app/components/Session/PromptReplies.tsx
@@ -1566,18 +1566,26 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
 
       {/* Truncation that landed before any artifact tag was emitted. Without this the
           bubble renders blank (or stops mid-sentence) with no explanation at all. */}
-      {(truncationNotice === 'reply-empty' || truncationNotice === 'reply-partial') && (
+      {(truncationNotice === 'reply-empty' ||
+        truncationNotice === 'reply-partial' ||
+        truncationNotice === 'reply-degenerate') && (
         <Alert
           data-testid="reply-truncated-warning"
           color="warning"
           variant="soft"
           sx={{ my: 1, flexDirection: 'column', alignItems: 'flex-start', gap: 0.5 }}
         >
-          <Typography level="title-sm">⚠️ Response was cut off</Typography>
+          <Typography level="title-sm">
+            {truncationNotice === 'reply-degenerate' ? '⚠️ Response stopped early' : '⚠️ Response was cut off'}
+          </Typography>
           <Typography level="body-sm">
-            {truncationNotice === 'reply-empty'
-              ? 'This response reached the output length limit before it produced any content. Try a smaller or more focused request, or ask for the work in parts.'
-              : 'This response reached the output length limit and stopped early. Ask me to continue, or try a smaller or more focused request.'}
+            {truncationNotice === 'reply-degenerate'
+              ? // Deliberately does NOT say "ask me to continue": continuing from a
+                // degenerated tail is what tends to reproduce the loop.
+                'This response began repeating itself, so it was stopped early rather than run to the output length limit. The reply above is what completed before that point - rephrasing the request usually works better than continuing.'
+              : truncationNotice === 'reply-empty'
+                ? 'This response reached the output length limit before it produced any content. Try a smaller or more focused request, or ask for the work in parts.'
+                : 'This response reached the output length limit and stopped early. Ask me to continue, or try a smaller or more focused request.'}
           </Typography>
         </Alert>
       )}

--- a/apps/client/app/utils/replyTruncation.test.ts
+++ b/apps/client/app/utils/replyTruncation.test.ts
@@ -132,3 +132,31 @@ describe('getReplyTruncationState', () => {
     });
   });
 });
+
+describe('degenerate-repetition stop reason', () => {
+  // Regression for the PR #1427 review: `degenerate_repetition` sits outside
+  // CLEAN_FINISH_REASONS, but that set only feeds the ARTIFACT branch. The prose
+  // branch used to require an exact 'max_tokens', so an aborted degenerate stream
+  // with no unclosed artifact - the common case - surfaced no notice at all.
+  it('surfaces a distinct notice when a reply was stopped for repeating itself', () => {
+    const state = getReplyTruncationState({
+      reply: 'Here is the module. ' + '</invoke>\n'.repeat(50),
+      completed: true,
+      finishReason: 'degenerate_repetition',
+    });
+
+    expect(state.notice).toBe('reply-degenerate');
+  });
+
+  it('keeps the ceiling notice distinct from the degeneration notice', () => {
+    expect(
+      getReplyTruncationState({ reply: 'partial prose', completed: true, finishReason: 'max_tokens' }).notice
+    ).toBe('reply-partial');
+  });
+
+  it('still surfaces nothing when no finish reason is reported', () => {
+    // The property the original exact-match comment was protecting: pre-existing
+    // quests with no finishReason must not grow a false banner.
+    expect(getReplyTruncationState({ reply: 'some prose', completed: true }).notice).toBeNull();
+  });
+});

--- a/apps/client/app/utils/replyTruncation.ts
+++ b/apps/client/app/utils/replyTruncation.ts
@@ -13,12 +13,29 @@ export const CLEAN_FINISH_REASONS = new Set(['end_turn', 'stop', 'tool_use', 'st
 const TRUNCATED_FINISH_REASON = 'max_tokens';
 
 /**
+ * Stop reason for "we aborted the stream because it degenerated into repetition"
+ * (`DEGENERATE_STREAM_STOP_REASON` in `@bike4mind/llm-adapters`). Kept distinct
+ * from `max_tokens` because the explanation the user needs is different: the
+ * ceiling wording ("ask me to continue") is actively wrong advice here, since
+ * continuing from a degenerated tail is what tends to reproduce the loop.
+ */
+const DEGENERATE_FINISH_REASON = 'degenerate_repetition';
+
+/**
+ * Every reason that means "this reply stopped early". Membership - not equality
+ * with one literal - is what lets a new early-stop reason surface a notice; an
+ * ABSENT reason still surfaces nothing (see the branch comment below).
+ */
+const EARLY_STOP_FINISH_REASONS = new Set([TRUNCATED_FINISH_REASON, DEGENERATE_FINISH_REASON]);
+
+/**
  * Which truncation notice (if any) to render. Exactly one at a time:
  *  - 'artifact': cut off mid-artifact, the partial is best-effort recovered into a card.
  *  - 'reply-partial': cut off in prose, some content survived.
  *  - 'reply-empty': cut off before producing any content, so the bubble would be blank.
+ *  - 'reply-degenerate': we stopped it ourselves because it began repeating itself.
  */
-export type ReplyTruncationNotice = 'artifact' | 'reply-partial' | 'reply-empty' | null;
+export type ReplyTruncationNotice = 'artifact' | 'reply-partial' | 'reply-empty' | 'reply-degenerate' | null;
 
 export interface ReplyTruncationInput {
   /** Reply text with <think> blocks already stripped. */
@@ -61,10 +78,15 @@ export function getReplyTruncationState({
   let notice: ReplyTruncationNotice = null;
   if (isTruncatedArtifact) {
     notice = 'artifact';
-  } else if (completed && !hasUnclosedArtifact && finishReason === TRUNCATED_FINISH_REASON) {
-    // Deliberately requires an EXPLICIT max_tokens: unlike the artifact path above, a missing
-    // finishReason must not surface a notice or every pre-existing quest grows a false banner.
-    notice = reply.trim() ? 'reply-partial' : 'reply-empty';
+  } else if (completed && !hasUnclosedArtifact && !!finishReason && EARLY_STOP_FINISH_REASONS.has(finishReason)) {
+    // Deliberately requires an EXPLICIT early-stop reason: unlike the artifact path above, a
+    // missing finishReason must not surface a notice or every pre-existing quest grows a false
+    // banner. Only the reasons in the set qualify, so that property is preserved.
+    if (finishReason === DEGENERATE_FINISH_REASON) {
+      notice = 'reply-degenerate';
+    } else {
+      notice = reply.trim() ? 'reply-partial' : 'reply-empty';
+    }
   }
 
   return { isStreamingArtifact, isTruncatedArtifact, notice };

--- a/b4m-core/llm-adapters/src/anthropicBackend.ts
+++ b/b4m-core/llm-adapters/src/anthropicBackend.ts
@@ -1052,6 +1052,14 @@ export class AnthropicBackend implements ICompletionBackend {
     // Setup the actual API call with API-specific options
     try {
       const func: { name?: string; id?: string; parameters?: string }[] = [];
+      // Set when the degeneration guard aborts this turn's stream. Declared HERE,
+      // outside the streaming promise, because the tool-execution branch below is
+      // what must honour it: a turn that had already collected a tool call before
+      // degenerating would otherwise execute those tools and recurse, so the run
+      // would continue after the abort - overwriting the stop reason and replaying
+      // stale assistant content. The in-promise `degenerateVerdict` is invisible
+      // from there.
+      let degeneratedThisTurn = false;
       // Capture per-turn token usage so the post-stream tool-recursion site
       // can carry it forward as accumulated multi-turn billable usage.
       // Populated from the message_delta event inside the streaming Promise.
@@ -1188,6 +1196,7 @@ export class AnthropicBackend implements ICompletionBackend {
                 const verdict = degenerateGuard.push(emitted);
                 if (!verdict) return;
                 degenerateVerdict = verdict;
+                degeneratedThisTurn = true;
                 // WARN, not error: this is a benign, handled abort that returns
                 // partial content - error severity would page LiveOps.
                 this.logger.warn('[AnthropicBackend] Stream aborted - output degenerated into repetition', {
@@ -1320,6 +1329,13 @@ export class AnthropicBackend implements ICompletionBackend {
                         if (func[event.index]) {
                           func[event.index].parameters += event.delta.partial_json || '';
                         }
+                        // Tool ARGUMENTS count against the same output ceiling, so a
+                        // model that degenerates while writing a tool call would
+                        // otherwise run to the ceiling unwatched. Feed these deltas
+                        // too; the abort then also skips tool execution (see
+                        // `degeneratedThisTurn`), since half-written arguments from a
+                        // cut-off stream must not be executed.
+                        checkDegenerate(event.delta.partial_json || '');
                         // Also accumulate in collected content
                         if (collectedContent[event.index] && collectedContent[event.index].type === 'tool_use') {
                           // We'll parse the complete JSON at the end
@@ -1384,6 +1400,31 @@ export class AnthropicBackend implements ICompletionBackend {
               } finally {
                 // CRITICAL: Always cleanup idle timer to prevent memory leaks
                 if (idleTimer) clearTimeout(idleTimer);
+              }
+
+              // Same shape as the idle-timeout check below: the guard aborted, but the
+              // stream ended naturally instead of throwing AbortError, so the catch
+              // block never ran. Emit the degeneration stop reason and stop here
+              // rather than falling through to the clean terminal path, which would
+              // report this turn as a normal finish.
+              if (degenerateVerdict) {
+                this.logger.warn('[AnthropicBackend] Stream ended after degeneration abort - reporting partial reply', {
+                  model,
+                  charsBeforeAbort: degenerateVerdict.totalChars,
+                });
+                await cb([], {
+                  toolsUsed,
+                  stopReason: DEGENERATE_STREAM_STOP_REASON,
+                  // Forward the accumulated usage the clean terminal path forwards.
+                  // Omitting it drops settlement to the local tokenizer estimate, and a
+                  // degenerate turn is the worst case for an estimate: real output is large.
+                  inputTokens:
+                    accumInputTokens + ((usageInfo as { input_tokens?: number } | undefined)?.input_tokens ?? 0),
+                  outputTokens:
+                    accumOutputTokens + ((usageInfo as { output_tokens?: number } | undefined)?.output_tokens ?? 0),
+                });
+                resolve();
+                return;
               }
 
               // If idle timeout was triggered but the stream ended naturally (e.g., HTTP connection dropped
@@ -1556,7 +1597,16 @@ export class AnthropicBackend implements ICompletionBackend {
                     charsBeforeAbort: degenerateVerdict.totalChars,
                     repeats: degenerateVerdict.repeats,
                   });
-                  await cb([], { toolsUsed, stopReason: DEGENERATE_STREAM_STOP_REASON });
+                  await cb([], {
+                    toolsUsed,
+                    stopReason: DEGENERATE_STREAM_STOP_REASON,
+                    // No usage forwarded here: this is the AbortError path, so the
+                    // terminal message_delta that carries provider usage never arrived
+                    // and `usageInfo` is out of scope. The post-loop site above (stream
+                    // ended without throwing) does forward it.
+                    inputTokens: accumInputTokens,
+                    outputTokens: accumOutputTokens,
+                  });
                   resolve();
                 } else if (isIdleTimeout) {
                   // Idle timeout - the stream was aborted due to no events being received
@@ -1587,8 +1637,13 @@ export class AnthropicBackend implements ICompletionBackend {
           })();
         });
 
-        // If there are tool calls, execute them and continue the conversation
-        if (func.some(f => f && f.name)) {
+        // If there are tool calls, execute them and continue the conversation.
+        // Skipped entirely when the guard aborted this turn: the point of the abort
+        // is that the run STOPS, and any tool call collected before the loop began
+        // is from a stream we deliberately cut off, so executing it and recursing
+        // would resume the run, overwrite the degeneration stop reason, and replay
+        // stale assistant content.
+        if (!degeneratedThisTurn && func.some(f => f && f.name)) {
           // Track tool usage first (including ID for history reconstruction)
           const toolCallNames = func.filter(t => t?.name).map(t => t.name);
           this.logger.info('[Tool Execution] Model requested tool calls', {

--- a/b4m-core/llm-adapters/src/anthropicBackend.ts
+++ b/b4m-core/llm-adapters/src/anthropicBackend.ts
@@ -36,6 +36,11 @@ import { withRetry, isUserInitiatedAbort, isRetryableError } from '@bike4mind/co
 import { buildThinkingParams, THINKING_ANSWER_HEADROOM_TOKENS, type ThinkingConfig } from './thinkingParams';
 import { DispatchModel } from './dispatchModel';
 import { acquireSlot, releaseSlot } from './_anthropicSemaphore';
+import {
+  createDegenerateStreamGuard,
+  DEGENERATE_STREAM_STOP_REASON,
+  type DegenerateStreamVerdict,
+} from './degenerateStreamGuard';
 
 type ExtendedMessageCreateParams = MessageCreateParamsBase &
   Partial<ThinkingConfig> & {
@@ -1098,6 +1103,12 @@ export class AnthropicBackend implements ICompletionBackend {
           let isIdleTimeout = false;
           let idleTimeoutMsForError = 0; // Store for error message
 
+          // Degeneration state, also read from the catch block. The idle timer
+          // cannot cover this case - it resets on every stream event, and a
+          // repetition loop emits events continuously - so a stream that has
+          // stopped making progress would otherwise run to the token ceiling.
+          let degenerateVerdict: DegenerateStreamVerdict | undefined;
+
           (async () => {
             // Acquire semaphore slot before the API call. Released in the finally
             // block below after the stream is fully consumed (or on any error),
@@ -1162,6 +1173,33 @@ export class AnthropicBackend implements ICompletionBackend {
               // input_json_delta events on these indices stream as text content
               // rather than being collected as a tool call.
               const responseFormatToolIndices = new Set<number>();
+
+              // Degeneration guard: watches emitted text for a stream that has
+              // stopped making progress and is just repeating itself. Aborts the
+              // same way the idle timeout does, but the abort path RESOLVES with
+              // the clean prefix rather than rejecting - the useful part of the
+              // answer is normally written before the loop starts, and throwing
+              // it away would be a worse outcome than a short reply.
+              const degenerateGuard = createDegenerateStreamGuard(options._internal?.degenerateStreamGuard);
+
+              /** Feed emitted text to the guard; abort the stream on the first verdict. */
+              const checkDegenerate = (emitted: string | undefined) => {
+                if (!emitted || degenerateVerdict) return;
+                const verdict = degenerateGuard.push(emitted);
+                if (!verdict) return;
+                degenerateVerdict = verdict;
+                // WARN, not error: this is a benign, handled abort that returns
+                // partial content - error severity would page LiveOps.
+                this.logger.warn('[AnthropicBackend] Stream aborted - output degenerated into repetition', {
+                  model,
+                  periodChars: verdict.periodChars,
+                  repeats: verdict.repeats,
+                  runChars: verdict.runChars,
+                  charsBeforeAbort: verdict.totalChars,
+                  unit: verdict.unit,
+                });
+                (stream as { controller?: AbortController }).controller?.abort?.();
+              };
 
               // Idle timeout setup for detecting streaming hangs
               // Feature flag controlled via options._internal.enableIdleTimeout
@@ -1260,6 +1298,7 @@ export class AnthropicBackend implements ICompletionBackend {
                       await cb(streamedText, { toolsUsed: toolsUsed });
                     } else if ('delta' in event && event.delta.type === 'text_delta') {
                       streamedText[event.index] = event.delta.text;
+                      checkDegenerate(event.delta.text);
                       await cb(streamedText, { toolsUsed: toolsUsed });
                     } else if ('delta' in event && event.delta.type === 'input_json_delta') {
                       // response_format=json_schema: stream the tool's
@@ -1270,6 +1309,7 @@ export class AnthropicBackend implements ICompletionBackend {
                         const partial = event.delta.partial_json || '';
                         if (partial) {
                           streamedText[event.index] = partial;
+                          checkDegenerate(partial);
                           await cb(streamedText, {
                             toolsUsed,
                             responseFormatMode: 'tool_use',
@@ -1501,6 +1541,23 @@ export class AnthropicBackend implements ICompletionBackend {
                       `Anthropic API request timeout after ${requestTimeoutMs}ms - no streaming response received`
                     )
                   );
+                } else if (degenerateVerdict) {
+                  // Our own abort after the output degenerated into repetition.
+                  // Resolve rather than reject: the text emitted before the loop
+                  // started has already reached the caller through `cb` and is
+                  // normally the useful answer, so throwing an error here would
+                  // discard a good partial reply. Emit a terminal cb first (the
+                  // same shape as the clean path) so the caller learns WHY the
+                  // stream ended; DEGENERATE_STREAM_STOP_REASON is deliberately
+                  // outside CLEAN_FINISH_REASONS, so the reply renders with a
+                  // truncation notice rather than as a normal completion.
+                  this.logger.warn('[AnthropicBackend] Returning partial reply after degeneration abort', {
+                    model,
+                    charsBeforeAbort: degenerateVerdict.totalChars,
+                    repeats: degenerateVerdict.repeats,
+                  });
+                  await cb([], { toolsUsed, stopReason: DEGENERATE_STREAM_STOP_REASON });
+                  resolve();
                 } else if (isIdleTimeout) {
                   // Idle timeout - the stream was aborted due to no events being received
                   // The abort causes AbortError to be thrown, which we catch here.

--- a/b4m-core/llm-adapters/src/backend.ts
+++ b/b4m-core/llm-adapters/src/backend.ts
@@ -14,6 +14,7 @@ import {
   type CacheUsageStats,
   type ResponseFormat,
 } from '@bike4mind/common';
+import type { DegenerateStreamGuardOptions } from './degenerateStreamGuard';
 
 /** Maximum number of recursive tool calls to prevent infinite loops */
 export const DEFAULT_MAX_TOOL_CALLS = 10;
@@ -165,6 +166,13 @@ export interface ICompletionOptions {
     enableIdleTimeout?: boolean; // Enable idle timeout detection for streaming (Anthropic only)
     enableRequestTimeout?: boolean; // Enable request-level timeout for API calls that hang before streaming (Anthropic only)
     idleTimeoutMs?: number; // Custom idle timeout in milliseconds (defaults to 90s standard, 180s thinking)
+    /**
+     * Tuning/kill-switch for the degeneration guard, which aborts a stream that
+     * has stopped making progress and is repeating itself (Anthropic only so
+     * far). ON by default with conservative thresholds - see
+     * degenerateStreamGuard.ts. Pass `{ enabled: false }` to opt a surface out.
+     */
+    degenerateStreamGuard?: DegenerateStreamGuardOptions;
     /**
      * Multi-turn token accumulators threaded through recursive complete() calls.
      * Each provider API call (every tool round-trip) is billed independently;

--- a/b4m-core/llm-adapters/src/degenerateStreamGuard.test.ts
+++ b/b4m-core/llm-adapters/src/degenerateStreamGuard.test.ts
@@ -138,3 +138,18 @@ describe('createDegenerateStreamGuard', () => {
     expect(['end_turn', 'stop', 'tool_use', 'stop_sequence']).not.toContain(DEGENERATE_STREAM_STOP_REASON);
   });
 });
+
+describe('option merging', () => {
+  it('ignores explicitly-undefined options instead of nulling a default', () => {
+    // A caller spreading a partial config would otherwise overwrite a threshold
+    // with undefined, and every comparison against undefined is false - which
+    // inverts the guard into tripping on almost anything.
+    const verdict = stream(healthyText(20_000), 40, {
+      minRepeats: undefined,
+      minRunChars: undefined,
+      maxPeriodChars: undefined,
+      enabled: undefined,
+    });
+    expect(verdict).toBeNull();
+  });
+});

--- a/b4m-core/llm-adapters/src/degenerateStreamGuard.test.ts
+++ b/b4m-core/llm-adapters/src/degenerateStreamGuard.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createDegenerateStreamGuard,
+  DEGENERATE_STREAM_STOP_REASON,
+  type DegenerateStreamVerdict,
+} from './degenerateStreamGuard';
+
+/** Feed text in realistic small chunks, returning the first verdict (if any). */
+function stream(text: string, chunk = 40, options = {}): DegenerateStreamVerdict | null {
+  const guard = createDegenerateStreamGuard(options);
+  for (let i = 0; i < text.length; i += chunk) {
+    const verdict = guard.push(text.slice(i, i + chunk));
+    if (verdict) return verdict;
+  }
+  return null;
+}
+
+/** Plausible prose/code filler with no long-range periodicity. */
+function healthyText(chars: number): string {
+  const lines: string[] = [];
+  let i = 0;
+  while (lines.join('\n').length < chars) {
+    lines.push(
+      `  const value${i} = compute(${i}, ${i * 7 + 3}); // step ${i} of the reduction, tolerance ${(i % 9) / 10}`
+    );
+    i++;
+  }
+  return lines.join('\n');
+}
+
+describe('createDegenerateStreamGuard', () => {
+  it('catches the observed tool-markup loop', () => {
+    // The real incident: `</invoke>` and `</parameter>` alternating thousands of times.
+    const verdict = stream('</invoke>\n</parameter>\n'.repeat(400));
+
+    expect(verdict).not.toBeNull();
+    expect(verdict!.repeats).toBeGreaterThanOrEqual(25);
+    expect(verdict!.periodChars).toBeLessThanOrEqual(512);
+    expect(verdict!.unit).toContain('invoke');
+  });
+
+  it('trips early rather than near the ceiling', () => {
+    // 400 reps is ~9KB. Catching it inside a few KB is the whole point: the
+    // ceiling that actually stopped the incident was ~500KB of output.
+    const verdict = stream('</invoke>\n</parameter>\n'.repeat(400));
+
+    expect(verdict!.totalChars).toBeLessThan(6000);
+  });
+
+  it('catches a single repeated line', () => {
+    const line = 'I apologize for the confusion.\n';
+    const verdict = stream(line.repeat(200));
+
+    expect(verdict).not.toBeNull();
+    expect(verdict!.periodChars).toBe(line.length);
+    // The unit is measured from an arbitrary cut point in the tail, so it is a
+    // ROTATION of the source line rather than the line itself. Assert that
+    // rather than a phase we have no reason to guarantee.
+    expect(line.repeat(2)).toContain(verdict!.unit);
+  });
+
+  it('catches a repeated single character', () => {
+    const verdict = stream('-'.repeat(5000));
+    expect(verdict).not.toBeNull();
+    expect(verdict!.periodChars).toBe(1);
+  });
+
+  it('leaves healthy prose and code alone', () => {
+    expect(stream(healthyText(60_000))).toBeNull();
+  });
+
+  it('leaves a long non-repeating token blob alone', () => {
+    // Pseudo-random base64-ish content: no periodicity, high entropy.
+    let blob = '';
+    let seed = 7;
+    const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+    for (let i = 0; i < 40_000; i++) {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      blob += alphabet[seed % alphabet.length];
+    }
+    expect(stream(blob)).toBeNull();
+  });
+
+  it('does not trip on a short repetition that then resolves', () => {
+    // A handful of repeated lines is normal (boilerplate, a small table) and must
+    // not be treated as degeneration.
+    const text = healthyText(3000) + '| x | y |\n'.repeat(8) + healthyText(3000);
+    expect(stream(text)).toBeNull();
+  });
+
+  it('requires both a long run and enough repeats', () => {
+    // Unit of 300 chars repeated only 8 times: long run, too few cycles.
+    const unit = healthyText(300).slice(0, 300);
+    expect(stream(unit.repeat(8))).toBeNull();
+  });
+
+  it('respects a raised repeat threshold', () => {
+    const text = '</invoke>\n</parameter>\n'.repeat(400);
+    expect(stream(text, 40, { minRepeats: 10_000 })).toBeNull();
+  });
+
+  it('no-ops entirely when disabled', () => {
+    expect(stream('</invoke>\n</parameter>\n'.repeat(400), 40, { enabled: false })).toBeNull();
+  });
+
+  it('latches: only the first verdict is returned', () => {
+    const guard = createDegenerateStreamGuard();
+    let verdicts = 0;
+    const text = '</invoke>\n</parameter>\n'.repeat(600);
+    for (let i = 0; i < text.length; i += 40) {
+      if (guard.push(text.slice(i, i + 40))) verdicts++;
+    }
+    expect(verdicts).toBe(1);
+  });
+
+  it('tracks total chars seen', () => {
+    const guard = createDegenerateStreamGuard();
+    guard.push('abc');
+    guard.push('de');
+    expect(guard.totalChars()).toBe(5);
+  });
+
+  it('ignores empty pushes', () => {
+    const guard = createDegenerateStreamGuard();
+    expect(guard.push('')).toBeNull();
+    expect(guard.totalChars()).toBe(0);
+  });
+
+  it('detects repetition that begins after a healthy prefix', () => {
+    const verdict = stream(healthyText(20_000) + '</invoke>\n</parameter>\n'.repeat(400));
+    expect(verdict).not.toBeNull();
+    expect(verdict!.unit).toContain('invoke');
+  });
+
+  it('exposes a stop reason outside the clean-finish vocabulary', () => {
+    // Must not be one of CLEAN_FINISH_REASONS in apps/client replyTruncation.ts,
+    // or the reply would render as a normal completion.
+    expect(['end_turn', 'stop', 'tool_use', 'stop_sequence']).not.toContain(DEGENERATE_STREAM_STOP_REASON);
+  });
+});

--- a/b4m-core/llm-adapters/src/degenerateStreamGuard.ts
+++ b/b4m-core/llm-adapters/src/degenerateStreamGuard.ts
@@ -138,7 +138,14 @@ function periodicRunLength(tail: string, period: number): number {
 }
 
 export function createDegenerateStreamGuard(options: DegenerateStreamGuardOptions = {}): DegenerateStreamGuard {
-  const cfg = { ...DEFAULTS, ...options };
+  // Drop explicitly-undefined keys before merging: a caller spreading a partial
+  // config (`{ minRepeats: someMaybeUndefined }`) would otherwise overwrite a
+  // default with undefined, and every threshold comparison against undefined is
+  // false - inverting the guard into tripping on almost anything.
+  const provided = Object.fromEntries(
+    Object.entries(options).filter(([, value]) => value !== undefined)
+  ) as DegenerateStreamGuardOptions;
+  const cfg = { ...DEFAULTS, ...provided };
   let tail = '';
   let total = 0;
   let sinceCheck = 0;

--- a/b4m-core/llm-adapters/src/degenerateStreamGuard.ts
+++ b/b4m-core/llm-adapters/src/degenerateStreamGuard.ts
@@ -19,6 +19,29 @@
  * strings: a model can degenerate into any repeating unit, and the pathology is
  * the repetition itself.
  *
+ * KNOWN FALSE POSITIVE - uniform generated data. Periodicity cannot distinguish a
+ * degenerate loop from output that is legitimately, exactly repetitive: "give me a
+ * 100x100 grid of zeros", "print 2000 'ha'", a zero-filled matrix, a blank
+ * template, a long padding run. Those trip. The guard cannot infer intent, so this
+ * is a real limitation rather than a tuning problem - the blast radius is one
+ * turn, the user sees an explicit notice, and a rephrase gets through, which is
+ * why the trade is still worth making. Do not read the prose/code/JSON/base64
+ * safety argument as "legitimate content cannot trip it".
+ *
+ * BLIND SPOT - reasoning tokens. Both hook sites are on visible text. Thinking
+ * tokens count against the same output ceiling, but on current models thinking
+ * blocks stream with empty text (`thinking.display` defaults to omitted), so
+ * there is nothing here to inspect. A model that degenerates INSIDE its reasoning
+ * still has the token ceiling as its only stop condition; bounding that is the
+ * wall-clock budget's job, not this guard's.
+ *
+ * DETECTION LATENCY - phase dependence. Each check evaluates exactly ONE candidate
+ * period (see below), so a unit containing an internal single-character run can
+ * yield a sub-period that fails verification, and that check returns null. It
+ * self-corrects because the phase moves on the next check - but anyone retuning
+ * `checkEveryChars` should avoid a stride that resonates with a likely unit
+ * length, which would stall detection far longer than one interval.
+ *
  * Cost: one `lastIndexOf` over a bounded window per check, and checks run only
  * every `checkEveryChars`. That is O(window) amortized per emitted chunk with no
  * per-period scan, so it is safe to leave on for every stream.

--- a/b4m-core/llm-adapters/src/degenerateStreamGuard.ts
+++ b/b4m-core/llm-adapters/src/degenerateStreamGuard.ts
@@ -1,0 +1,178 @@
+/**
+ * Degeneration circuit breaker for a streaming completion.
+ *
+ * Guards against the non-terminating GENERATION loop, where a model stops making
+ * progress and emits the same short unit over and over until it exhausts the
+ * output-token ceiling. Observed in the wild: a turn that fell into repeating
+ * tool-call closing markup (`</invoke>` 6,099 times, `</parameter>` 6,017 times)
+ * and ran for 16.5 minutes to consume all 128,000 permitted output tokens,
+ * producing ~180KB of which ~95% was those two tags.
+ *
+ * This is the token-stream analogue of repeatedCallGuard (which covers repeated
+ * TOOL CALLS in the ReAct loop). Neither one catches the other's failure mode.
+ * The idle-timeout guard in the backends does not catch this either: it resets on
+ * every stream event, and a repetition loop emits events continuously, so it stays
+ * alive indefinitely. Before this guard the token ceiling was the only stop
+ * condition, which makes it a ~16-minute, multi-dollar stop condition.
+ *
+ * Detection is periodicity of the stream TAIL, not a blocklist of known-bad
+ * strings: a model can degenerate into any repeating unit, and the pathology is
+ * the repetition itself.
+ *
+ * Cost: one `lastIndexOf` over a bounded window per check, and checks run only
+ * every `checkEveryChars`. That is O(window) amortized per emitted chunk with no
+ * per-period scan, so it is safe to leave on for every stream.
+ */
+
+/** How the tail is sampled and what counts as degenerate. */
+export interface DegenerateStreamGuardOptions {
+  /** Set false to disable the guard entirely. Default: true (active). */
+  enabled?: boolean;
+  /**
+   * Chars of trailing output kept for analysis. Must exceed `minRunChars` with
+   * room to spare, or a long run can never be measured.
+   */
+  windowChars?: number;
+  /** Re-check after this much new text. Bounds CPU on healthy streams. */
+  checkEveryChars?: number;
+  /**
+   * Longest repeating unit considered. A degenerate loop cycles on something
+   * small (a tag, a line, a short phrase); a "repeat" longer than this is far
+   * more likely to be legitimate structure (boilerplate blocks, tables).
+   */
+  maxPeriodChars?: number;
+  /** Minimum length of the periodic run before it counts as degenerate. */
+  minRunChars?: number;
+  /** Minimum number of consecutive repetitions of the unit. */
+  minRepeats?: number;
+}
+
+export interface DegenerateStreamVerdict {
+  /** The repeating unit, for logs. Truncated - it can contain newlines. */
+  unit: string;
+  /** Length of the repeating unit in chars. */
+  periodChars: number;
+  /** How many consecutive repetitions were measured. */
+  repeats: number;
+  /** Length in chars of the periodic run at the tail. */
+  runChars: number;
+  /** Total chars the guard has seen, i.e. roughly where the loop was caught. */
+  totalChars: number;
+}
+
+/**
+ * Defaults are deliberately conservative: tripping requires a run of >= 2048
+ * chars that is periodic on a unit of <= 512 chars repeated >= 25 times. Prose,
+ * code, JSON, and base64 do not do that; a degenerate loop does it within a
+ * second or two of starting. The asymmetry is intentional - a false positive
+ * truncates one reply with an explicit reason, while a miss costs the full
+ * ceiling in latency and spend.
+ */
+const DEFAULTS = {
+  enabled: true,
+  windowChars: 8192,
+  checkEveryChars: 512,
+  maxPeriodChars: 512,
+  minRunChars: 2048,
+  minRepeats: 25,
+} as const;
+
+/**
+ * Chars used as the search needle. Long enough that finding an earlier copy is
+ * not coincidence, short enough to sit inside one repetition of a small unit
+ * (the observed `</invoke>\n</parameter>\n` unit is 23 chars).
+ */
+const NEEDLE_CHARS = 16;
+
+/** Unit length included in a verdict, so a log line stays readable. */
+const UNIT_LOG_LIMIT = 120;
+
+export interface DegenerateStreamGuard {
+  /**
+   * Feed newly emitted text. Returns a verdict the first time degeneration is
+   * detected, then null forever after (the caller aborts on the first verdict;
+   * latching prevents a second abort from a late in-flight chunk).
+   */
+  push(text: string): DegenerateStreamVerdict | null;
+  /** Total chars observed. Useful for logging alongside a verdict. */
+  totalChars(): number;
+}
+
+/**
+ * Measure how far back from the end of `tail` the text stays periodic with
+ * `period`, in chars. Exact match only: a degenerate loop repeats byte-for-byte,
+ * and tolerating drift is what would let legitimate near-repetition trip.
+ */
+function periodicRunLength(tail: string, period: number): number {
+  let matched = 0;
+  for (let i = tail.length - 1; i - period >= 0; i--) {
+    if (tail[i] !== tail[i - period]) break;
+    matched++;
+  }
+  // `matched` counts positions with a predecessor one period back; the run
+  // includes that first period itself.
+  return matched > 0 ? matched + period : 0;
+}
+
+export function createDegenerateStreamGuard(options: DegenerateStreamGuardOptions = {}): DegenerateStreamGuard {
+  const cfg = { ...DEFAULTS, ...options };
+  let tail = '';
+  let total = 0;
+  let sinceCheck = 0;
+  let tripped = false;
+
+  return {
+    totalChars: () => total,
+
+    push(text: string): DegenerateStreamVerdict | null {
+      if (!cfg.enabled || tripped || !text) return null;
+
+      total += text.length;
+      sinceCheck += text.length;
+      tail = (tail + text).slice(-cfg.windowChars);
+
+      if (sinceCheck < cfg.checkEveryChars) return null;
+      sinceCheck = 0;
+
+      // Not enough trailing text to contain a qualifying run yet.
+      if (tail.length < cfg.minRunChars) return null;
+
+      // Candidate period: distance back to the previous occurrence of the final
+      // needle. In a loop that is exactly one cycle; in healthy text there is
+      // usually no earlier copy at all, so this exits on one string search.
+      const needle = tail.slice(-NEEDLE_CHARS);
+      const prev = tail.lastIndexOf(needle, tail.length - NEEDLE_CHARS - 1);
+      if (prev === -1) return null;
+
+      const period = tail.length - NEEDLE_CHARS - prev;
+      if (period <= 0 || period > cfg.maxPeriodChars) return null;
+
+      const runChars = periodicRunLength(tail, period);
+      const repeats = Math.floor(runChars / period);
+      if (runChars < cfg.minRunChars || repeats < cfg.minRepeats) return null;
+
+      tripped = true;
+      return {
+        unit: tail.slice(tail.length - period).slice(0, UNIT_LOG_LIMIT),
+        periodChars: period,
+        repeats,
+        runChars,
+        totalChars: total,
+      };
+    },
+  };
+}
+
+/** Stable, user-facing explanation for a stream aborted by this guard. */
+export const DEGENERATE_STREAM_MESSAGE =
+  'The response stopped making progress and began repeating itself, so generation was ' +
+  'halted early to avoid running to the output-token limit. The partial reply above is ' +
+  'what completed before that point.';
+
+/**
+ * Normalized stop reason for a stream this guard aborted. Deliberately outside
+ * the provider vocabulary in stopReason.ts (these are our own signals, not a
+ * provider's) and deliberately NOT in the client's CLEAN_FINISH_REASONS, so the
+ * reply renders with a truncation notice rather than as a clean finish.
+ */
+export const DEGENERATE_STREAM_STOP_REASON = 'degenerate_repetition';

--- a/b4m-core/llm-adapters/src/index.ts
+++ b/b4m-core/llm-adapters/src/index.ts
@@ -474,6 +474,7 @@ export const getSupersededModels = (currentModels: ModelInfo[]): SupersededModel
 export * from './adapterFamilyDispatch';
 export * from './backend';
 export * from './backendGate';
+export * from './degenerateStreamGuard';
 export * from './dispatchModel';
 export * from './dispatchResolver';
 export * from './endUserId';


### PR DESCRIPTION
Fixes the primary gap in #1426.

## Problem

When a completion stops making progress and just repeats itself, nothing stopped it except the output-token ceiling — which makes that ceiling a ~16-minute, multi-dollar stop condition. The observed turn fell into repeating tool-call closing markup (`</invoke>` 6,099 times, `</parameter>` 6,017 times), ran **990 seconds**, consumed all **128,000** permitted output tokens, and returned ~180KB that was ~95% those two tags.

Neither existing guard covers this:

- **The idle timeout** (`anthropicBackend.ts`) resets on every stream event. A repetition loop emits events continuously, so it stays alive indefinitely — it catches *stalls*, not runaway generation.
- **`repeatedCallGuard`** covers repeated **tool calls** in the ReAct loop, not the token stream.

This adds the missing token-stream analogue.

## Approach

`degenerateStreamGuard.ts` detects **periodicity in the stream tail** rather than blocklisting known-bad strings — a model can degenerate onto any repeating unit, and the pathology is the repetition itself, not the content.

Detection is one bounded `lastIndexOf` per check (candidate period = distance back to the previous occurrence of the trailing needle, then verify periodicity), with checks throttled by emitted volume. That's O(window) amortized with no per-period scan, so it's cheap enough to leave on for every stream rather than hiding behind a flag.

Defaults are deliberately conservative — trip requires a run of **>= 2048 chars** periodic on a unit of **<= 512 chars** repeated **>= 25 times**. Prose, code, JSON, and base64 don't do that; a degenerate loop does it within a second or two. The asymmetry is intentional: a false positive truncates one reply with an explicit reason, while a miss costs the full ceiling in latency and spend.

## Behavior on trip

The Anthropic backend aborts the stream, then **resolves rather than rejects**. The text emitted before the loop began has already reached the caller through `cb` and is normally the useful answer — the incident's reply opened with a perfectly good explanation before degenerating — so erroring would discard a good partial reply. That's a deliberate departure from how the idle timeout behaves.

A terminal callback carries `stopReason: 'degenerate_repetition'`, which sits outside the client's `CLEAN_FINISH_REASONS` (`apps/client/app/utils/replyTruncation.ts`), so the existing truncation-notice machinery renders it as a cut-off reply instead of a clean finish. No client change needed.

## Scope

Wired into the **Anthropic backend only**, where this was observed. The other backends can adopt it with the same two-line hook (`checkDegenerate(text)` at their text-emitting delta, plus the abort branch). Tunable and disableable per request via `_internal.degenerateStreamGuard`.

## Not in this PR

- **Wall-clock budget** (#1426 fix 2) — complementary; would also bound the separate ~30-minute *stall* case noted in that issue.
- **Billing** (#1426 fix 4) — credit accounting deserves its own change with product input.
- **The unmarked trigger turn.** Per my correction comment on #1426, ceiling-truncation marking already exists and works; the real marking gap is that the *preceding* turn ended truncated mid-syntax with `finishReason: null` and `actualOutputTokens: 0`. Separate investigation.

## Verification

- 15 new unit tests, `@bike4mind/llm-adapters` suite at **665 passing / 62 files**.
- Coverage includes the real incident pattern, catching it inside ~6KB rather than ~500KB, single-line and single-character loops, latching to one verdict, threshold and kill-switch behavior, repetition after a healthy prefix, and the stop reason being outside the clean-finish set.
- Negative cases that must **not** trip: 60KB of realistic prose/code, a 40KB high-entropy token blob, a short repetition that resolves, and a long unit repeated too few times.
- `pnpm --filter @bike4mind/llm-adapters typecheck` clean, `pnpm turbo:core:build` clean, repo-wide `pnpm pre-push` (turbo typecheck + infra typecheck) clean.