### PR TITLE
refactor(common): type credit-transaction metadata as Record<string, unknown>

### DIFF
--- a/apps/client/app/components/ProfileModal/CreditAnalyticsTabContent.tsx
+++ b/apps/client/app/components/ProfileModal/CreditAnalyticsTabContent.tsx
@@ -30,7 +30,7 @@ import dayjs from 'dayjs';
 import { useTheme } from '@mui/joy/styles';
 import { useTranslation } from 'react-i18next';
 import { getModels } from '@client/app/utils/llm';
-import { ModelInfo, usdToCredits } from '@bike4mind/common';
+import { ModelInfo, resolveModelName, usdToCredits } from '@bike4mind/common';
 import SectionContainer from './SectionContainer';
 import { TYPE } from './settingsStyles';
 import Bike4MindIcon from '@client/app/components/svgs/icons/Bike4MindIcon';
@@ -185,19 +185,10 @@ const CreditAnalyticsTabContent: React.FC = () => {
       }
     }
 
-    // Track model usage if available in metadata
     const modelUsageMap: Record<string, number> = {};
 
     allDeductTransactions.forEach(transaction => {
-      let modelName = 'Unknown';
-
-      // Check metadata first
-      if (transaction.metadata?.modelName) {
-        modelName = transaction.metadata.modelName;
-      } else if ('model' in transaction) {
-        // Type-safe check for model property on usage transactions
-        modelName = (transaction as { model?: string }).model || 'Unknown';
-      }
+      const modelName = resolveModelName(transaction);
 
       if (!modelUsageMap[modelName]) {
         modelUsageMap[modelName] = 0;

--- a/b4m-core/common/src/index.ts
+++ b/b4m-core/common/src/index.ts
@@ -52,6 +52,7 @@ export * from './schemas/questmaster';
 export * from './schemas/curation';
 export * from './schemas/imageModerationIncident';
 export * from './utils/artifactHelpers';
+export * from './utils/creditTransactionDisplay';
 export * from './utils/requireEnv';
 export * from './utils/internalStaffDomains';
 export * from './utils/modelHelpers';

--- a/b4m-core/common/src/types/entities/CreditTransactionTypes.ts
+++ b/b4m-core/common/src/types/entities/CreditTransactionTypes.ts
@@ -226,8 +226,10 @@ export const TransferCreditTransaction = BaseCreditTransaction.extend({
  * IMPORTANT: When adding a new transaction type here, you MUST also update:
  * 1. packages/database/src/models/billing/CreditTransactionModel.ts - Add to the `type` enum
  * 2. packages/database/src/models/billing/CreditTransactionModel.ts - Add any new fields to schema
- * 3. b4m-core/services/src/creditService/subtractCredits.ts - Add handler in switch statement
- * 4. apps/client/app/components/ProfileModal/CreditAnalyticsTabContent.tsx - Add filtering and display logic
+ * 3. b4m-core/services/src/creditService/subtractCredits.ts - Add a handler for a deduct type
+ * 4. b4m-core/services/src/creditService/addCredits.ts - Add a handler for an add type; without one
+ *    the new type falls through that branch chain and is written as `generic_add`
+ * 5. apps/client/app/components/ProfileModal/CreditAnalyticsTabContent.tsx - Add filtering and display logic
  *
  * Failure to sync these files will cause validation errors in MongoDB.
  */
@@ -487,8 +489,8 @@ type Expect<T extends true> = T;
 /**
  * Compile-time guard: metadata values must stay `unknown`. `Record<string, any>` here silently
  * disables checking for every consumer of the published declarations, so re-loosening it should
- * break the build rather than rely on review. Same mechanism and reason as the guards in
- * modelCatalog.ts - test files are outside tsconfig's include, so it lives in src.
+ * break the build rather than rely on review. Same kind of guard, and the same placement reason, as
+ * the ones in modelCatalog.ts - test files are outside tsconfig's include, so it lives in src.
  *
  * Interim: the general fix is a lint rule banning `z.any()` in entity schemas, which would retire
  * this. Do not replicate it per field.

--- a/b4m-core/common/src/types/entities/CreditTransactionTypes.ts
+++ b/b4m-core/common/src/types/entities/CreditTransactionTypes.ts
@@ -20,7 +20,13 @@ const BaseCreditTransaction = z.object({
    */
   credits: z.number(),
   description: z.string().optional(),
-  metadata: z.record(z.string(), z.any()).optional(), // For additional context
+  /**
+   * Free-form per-type context; the key set depends on the transaction `type`, so there is no
+   * writer-side contract. Values are `unknown` deliberately - readers must narrow rather than
+   * dereference straight through. Kept that way by CreditMetadataValuesStayNarrowed at the
+   * bottom of this file.
+   */
+  metadata: z.record(z.string(), z.unknown()).optional(),
   /**
    * Where this transaction originated - used to break down usage in reports.
    * Optional because legacy rows (and non-completion transactions like
@@ -218,9 +224,9 @@ export const TransferCreditTransaction = BaseCreditTransaction.extend({
  * Credit transaction
  *
  * IMPORTANT: When adding a new transaction type here, you MUST also update:
- * 1. packages/database/src/models/CreditTransactionModel.ts - Add to the `type` enum
- * 2. packages/database/src/models/CreditTransactionModel.ts - Add any new fields to schema
- * 3. packages/services/src/creditService/subtractCredits.ts - Add handler in switch statement
+ * 1. packages/database/src/models/billing/CreditTransactionModel.ts - Add to the `type` enum
+ * 2. packages/database/src/models/billing/CreditTransactionModel.ts - Add any new fields to schema
+ * 3. b4m-core/services/src/creditService/subtractCredits.ts - Add handler in switch statement
  * 4. apps/client/app/components/ProfileModal/CreditAnalyticsTabContent.tsx - Add filtering and display logic
  *
  * Failure to sync these files will cause validation errors in MongoDB.
@@ -473,3 +479,20 @@ export interface ICreditTransactionRepository extends IBaseRepository<ICreditTra
    */
   sourceUsageForOwner(ownerId: string, ownerType: CreditHolderType, days?: number): Promise<ISourceUsage[]>;
 }
+
+// True only for `any`: `1 & any` collapses to `any`, so `0 extends any` holds.
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Expect<T extends true> = T;
+
+/**
+ * Compile-time guard: metadata values must stay `unknown`. `Record<string, any>` here silently
+ * disables checking for every consumer of the published declarations, so re-loosening it should
+ * break the build rather than rely on review. Same mechanism and reason as the guards in
+ * modelCatalog.ts - test files are outside tsconfig's include, so it lives in src.
+ *
+ * Interim: the general fix is a lint rule banning `z.any()` in entity schemas, which would retire
+ * this. Do not replicate it per field.
+ */
+export type CreditMetadataValuesStayNarrowed = Expect<
+  IsAny<NonNullable<ICreditTransaction['metadata']>[string]> extends true ? false : true
+>;

--- a/b4m-core/common/src/utils/creditTransactionDisplay.test.ts
+++ b/b4m-core/common/src/utils/creditTransactionDisplay.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { resolveModelName } from './creditTransactionDisplay';
+
+// Empty-string and non-string values must fall through, not become a chart label.
+describe('resolveModelName', () => {
+  it.each([
+    ['metadata string wins', { metadata: { modelName: 'gpt-5' }, model: 'claude' }, 'gpt-5'],
+    ['falls back to the model field', { metadata: {}, model: 'claude' }, 'claude'],
+    ['empty metadata name falls through', { metadata: { modelName: '' }, model: 'claude' }, 'claude'],
+    ['non-string metadata name falls through', { metadata: { modelName: 42 }, model: 'claude' }, 'claude'],
+    ['no usable source at all', { metadata: {} }, 'Unknown'],
+    ['absent metadata', {}, 'Unknown'],
+    ['non-string model field', { metadata: {}, model: 99 }, 'Unknown'],
+  ])('%s', (_name, input, expected) => {
+    expect(resolveModelName(input)).toBe(expected);
+  });
+});

--- a/b4m-core/common/src/utils/creditTransactionDisplay.ts
+++ b/b4m-core/common/src/utils/creditTransactionDisplay.ts
@@ -1,0 +1,15 @@
+/**
+ * Chart label and aggregation bucket for the usage-by-model breakdown. Metadata is checked first for
+ * rows predating the top-level `model` field - no current writer sets `metadata.modelName`, so the
+ * branch looks dead: keep it. Non-string or empty values count as absent, since a number or object
+ * reaching the bucket key would render as "42" or "[object Object]".
+ */
+export function resolveModelName(transaction: { metadata?: Record<string, unknown>; model?: unknown }): string {
+  const fromMetadata = transaction.metadata?.modelName;
+  if (typeof fromMetadata === 'string' && fromMetadata) return fromMetadata;
+
+  const fromField = transaction.model;
+  if (typeof fromField === 'string' && fromField) return fromField;
+
+  return 'Unknown';
+}


### PR DESCRIPTION
`CreditTransaction.metadata` was `z.record(z.string(), z.any())`. That type is structurally inlined into the emitted declarations of the packages built on it, so the single `any` accounted for most of their public-API `any` surface: `metadata?: Record<string, any>` appeared **69 times** in one package's `.d.ts`, and is now **1** (that one belongs to an unrelated model).

## Runtime is unchanged

`z.any()` and `z.unknown()` accept the same values, return the same values, and reject the same values. Verified against the installed zod across every input class - plain objects, absent, `undefined` record values, `null`, nested objects, functions, numeric keys, prototype-pollution payloads, and symbol keys (both reject with `invalid_key`). Only the static type moves: readers must narrow instead of dereferencing straight through.

## It exposed a real unsoundness

One reader had to change, and it was wrong:

```ts
if (transaction.metadata?.modelName) {
  modelName = transaction.metadata.modelName;   // modelName is declared string
}
```

Under `any`, a non-string `modelName` flowed into a `string` variable unchecked, then became a chart label and an aggregation key - rendering as `42` or `[object Object]`. Verified this is reachable: the transactions route returns raw Mongo documents and never parses them through the schema, and `metadata` is an unvalidated `Mixed` column, so a row carrying a number arrives at the client as a number.

The resolution now lives in `resolveModelName`, exported from this package so the CLI's copy of the same fallback can be folded into it later. It treats a non-string **or empty** value as absent. Empty matters: a bare `typeof` check admits `''`, which becomes a blank pie slice and a blank bucket key.

## Verification

Six rows seeded directly into Mongo, one per input class, with temporary logging at the resolver and at the exact array handed to the chart. Guard on vs guard off:

| | guard on | guard off |
|---|---|---|
| the `''` row | `-> model-field -> "claude-legacy"` | `-> metadata -> ""` |
| `claude-legacy` bucket | present, 20 | **missing** |
| blank bucket key | no | **yes, holding 20 credits** |
| blank entry in the chart data | no | **yes** |
| empty SVG text nodes | **0** | **1** |
| rendered labels | all 6 | 5 |

Buckets matched expectation exactly (`gpt-5:10 claude-legacy:20 claude-num:30 claude-obj:40 sonnet-top:50 Unknown:160`), and the total was identical in both runs - credits are never lost, only mislabeled. The one row I did not seed was audited to account for it. Markers and fixtures removed afterwards.

Unit side: 7 cases pinning the fallback order, mutation-checked (removing either guard clause fails them).

## Not a breaking change

`metadata` is only ever *read* through this type in one place, which this PR fixes. Writing is unaffected - an object literal is assignable to `Record<string, unknown>` exactly as it was to `Record<string, any>`.

## Also here

- The `IMPORTANT:` sync checklist on the transaction union cited three paths that no longer resolve. Corrected - it is the checklist someone follows when adding a transaction type.
- The trailing note on `metadata` restated the field name. It now records that the key set depends on the transaction `type` and that readers are expected to narrow.
- A compile-time guard keeps the field off `any`: reverting it fails `tsc`. Type-only, so it erases entirely from the shipped bundle. Same mechanism and placement as the guards in `modelCatalog.ts`, and marked interim - a lint rule banning `z.any()` in entity schemas would retire it.

Checks: `turbo:typecheck` 40/40, `lint:check` clean, 1435 tests across 90 files, prettier clean.


---

## Testing guide

This is all on one screen: **Profile -> Usage** (`/profile?tab=usage`).

### Setup (needed on a fresh preview)

The chart only appears once the account has spent credits, so make some usage first:

1. Open a new chat, send any short message, wait for the reply.
2. Click the model name button next to the chat input, pick a **different** model, send another short message.

Now you have spend from two models. Go to **Profile -> Usage**.

### The checks

**1. The tab loads.** No error, and a usage-by-model chart is visible.

**2. Labels are model names.** You should see both models you used. Long names like
`global.anthropic.claude-sonnet-5` are normal.

> Report a bug if any slice is labelled with a **blank**, `[object Object]`, `undefined`, or a plain
> number like `42`.

**3. Both models appear separately.** Two slices, one per model - not merged into one, and not lumped
into `Unknown`.

**4. Amounts match.** Each model's amount matches what the transaction list on the same page shows
for it.

### Not bugs

- No chart at all when the account has zero spend.
- An `Unknown` slice on an account with older history - some past spend has no model recorded.
- Totals changing when you change the time-period selector.
