### PR TITLE
fix(data-lake)!: stop bulkUpdateTags clobbering concurrent tag edits

### DIFF
--- a/apps/client/pages/api/data-lakes/batches/[batchId]/apply-taxonomy.ts
+++ b/apps/client/pages/api/data-lakes/batches/[batchId]/apply-taxonomy.ts
@@ -5,6 +5,7 @@ import { dataLakeBatchRepository, dataLakeRepository, fabFileRepository } from '
 import { dataLakeService } from '@bike4mind/services';
 import { ApplyTaxonomyRequestInput } from '@bike4mind/common';
 import { Request } from 'express';
+import { recordTaxonomyTagsApplySkipped } from '@server/utils/cloudwatch';
 
 // The guarded 'ready' -> 'applying' claim already means only one apply per completed
 // analysis can succeed, but a rejected call still costs a batch + lake lookup, and this
@@ -28,6 +29,7 @@ const handler = baseApi()
       {
         db: { dataLakes: dataLakeRepository, batches: dataLakeBatchRepository, fabFiles: fabFileRepository },
         logger: console,
+        metrics: { recordTagsApplySkipped: recordTaxonomyTagsApplySkipped },
       }
     );
 

--- a/apps/client/pages/api/data-lakes/batches/[batchId]/apply-taxonomy.ts
+++ b/apps/client/pages/api/data-lakes/batches/[batchId]/apply-taxonomy.ts
@@ -25,7 +25,10 @@ const handler = baseApi()
       { userId: req.user.id, isAdmin: req.user.isAdmin },
       batchId,
       data.tags.filter(t => !t.deleted),
-      { db: { dataLakes: dataLakeRepository, batches: dataLakeBatchRepository, fabFiles: fabFileRepository } }
+      {
+        db: { dataLakes: dataLakeRepository, batches: dataLakeBatchRepository, fabFiles: fabFileRepository },
+        logger: console,
+      }
     );
 
     return res.json(result);

--- a/apps/client/server/utils/cloudwatch.ts
+++ b/apps/client/server/utils/cloudwatch.ts
@@ -451,6 +451,7 @@ export const DataLakeBatchMetrics = {
   STUCK_BATCHES: 'StuckBatches',
   RECONCILE_RUNS: 'ReconcileRuns',
   TAXONOMY_DAILY_CAP_EXCEEDED: 'TaxonomyDailyCapExceeded',
+  TAXONOMY_TAGS_APPLY_SKIPPED: 'TaxonomyTagsApplySkipped',
 } as const;
 
 export async function emitDataLakeBatchMetric(
@@ -490,4 +491,14 @@ export async function recordTaxonomyDailyCapExceeded(): Promise<void> {
 /** Heartbeat: the reconciler cron ran. Emit even on zero work so absence-of-data can alarm. */
 export async function recordReconcileRun(): Promise<void> {
   return emitDataLakeBatchMetric(DataLakeBatchMetrics.RECONCILE_RUNS, 1, {}, StandardUnit.Count);
+}
+
+/**
+ * Count of files an apply-taxonomy call skipped because bulkUpdateTags' optimistic-concurrency
+ * check lost the race (the file's tags changed between the read and the write) - a benign,
+ * expected-under-load outcome, not a failure. Value is the per-call skip count so this is a
+ * real rate over time, not just a per-batch log line.
+ */
+export async function recordTaxonomyTagsApplySkipped(count: number): Promise<void> {
+  return emitDataLakeBatchMetric(DataLakeBatchMetrics.TAXONOMY_TAGS_APPLY_SKIPPED, count, {}, StandardUnit.Count);
 }

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -552,10 +552,24 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
    * Bulk-writes each file's full tags array in a single round trip via bulkWrite, instead of
    * one findOneAndUpdate per file. Used by applyTaxonomySuggestions, where a batch can hold
    * thousands of files and one write per file risks exceeding the caller's request timeout.
-   * @param updates - Each file's id and its complete resolved tags array.
-   * @returns Number of documents modified.
+   *
+   * Optimistic concurrency: each op is additionally filtered on `expectedTags`, the exact
+   * array the caller read before computing `tags`. If another writer (a direct tag edit, a
+   * lake-membership tag pull, a concurrent apply) changed the file's tags since that read, the
+   * filter no longer matches and this op is a silent no-op instead of clobbering the
+   * concurrent change - the caller's merge logic ran against stale data, so writing it would
+   * be wrong regardless of what it computed.
+   * @param updates - Each file's id, its complete resolved tags array, and the tags snapshot
+   * the resolution was computed from.
+   * @returns Number of documents modified (may be less than `updates.length` - see above).
    */
-  bulkUpdateTags(updates: { id: string; tags: { name: string; strength: number }[] }[]): Promise<number>;
+  bulkUpdateTags(
+    updates: {
+      id: string;
+      tags: { name: string; strength: number }[];
+      expectedTags: { name: string; strength: number }[];
+    }[]
+  ): Promise<number>;
 
   /**
    * Find files by content hashes for a given user (deduplication).

--- a/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
+++ b/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
@@ -67,6 +67,7 @@ const makeAdapters = (opts?: {
     },
   },
   logger: { warn: vi.fn() },
+  metrics: { recordTagsApplySkipped: vi.fn().mockResolvedValue(undefined) },
 });
 
 describe('applyTaxonomySuggestions', () => {
@@ -240,9 +241,10 @@ describe('applyTaxonomySuggestions', () => {
     );
 
     expect(adapters.logger.warn).toHaveBeenCalledWith(expect.stringContaining('1/2'));
+    expect(adapters.metrics.recordTagsApplySkipped).toHaveBeenCalledWith(1);
   });
 
-  it('does not warn when every matched file was actually updated', async () => {
+  it('does not warn or record a metric when every matched file was actually updated', async () => {
     const adapters = makeAdapters({
       files: [file({ tags: [{ name: 'acme:legal', strength: 1 }] })],
     });
@@ -255,6 +257,7 @@ describe('applyTaxonomySuggestions', () => {
     );
 
     expect(adapters.logger.warn).not.toHaveBeenCalled();
+    expect(adapters.metrics.recordTagsApplySkipped).not.toHaveBeenCalled();
   });
 
   it('keeps a genuinely suggested tag even after its suffix was edited by the reviewer', async () => {

--- a/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
+++ b/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
@@ -205,6 +205,23 @@ describe('applyTaxonomySuggestions', () => {
     expect(adapters.db.fabFiles.bulkUpdateTags).toHaveBeenCalledWith([]);
   });
 
+  it("passes each file's pre-merge tags snapshot as expectedTags, for bulkUpdateTags' optimistic concurrency check", async () => {
+    const existingTags = [{ name: 'acme:legal', strength: 1 }];
+    const adapters = makeAdapters({
+      files: [file({ tags: existingTags })],
+    });
+
+    await applyTaxonomySuggestions(
+      { userId: 'owner', isAdmin: false },
+      'b1',
+      [tag({ suffix: 'type:contract', matchingFolders: ['legal'] })],
+      adapters as any
+    );
+
+    const updates = adapters.db.fabFiles.bulkUpdateTags.mock.calls[0][0];
+    expect(updates[0].expectedTags).toEqual(existingTags);
+  });
+
   it('keeps a genuinely suggested tag even after its suffix was edited by the reviewer', async () => {
     const adapters = makeAdapters({
       files: [file({ tags: [] })],

--- a/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
+++ b/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.test.ts
@@ -51,6 +51,7 @@ const makeAdapters = (opts?: {
   batchDoc?: IDataLakeBatchDocument | null;
   lakeDoc?: IDataLakeDocument | null;
   files?: ReturnType<typeof file>[];
+  bulkUpdateTagsResult?: number;
 }) => ({
   db: {
     dataLakes: { findById: vi.fn().mockResolvedValue(opts && 'lakeDoc' in opts ? opts.lakeDoc : lake()) },
@@ -60,9 +61,12 @@ const makeAdapters = (opts?: {
     },
     fabFiles: {
       findByBatchId: vi.fn().mockResolvedValue(opts?.files ?? [file()]),
-      bulkUpdateTags: vi.fn().mockImplementation((updates: unknown[]) => Promise.resolve(updates.length)),
+      bulkUpdateTags: vi
+        .fn()
+        .mockImplementation((updates: unknown[]) => Promise.resolve(opts?.bulkUpdateTagsResult ?? updates.length)),
     },
   },
+  logger: { warn: vi.fn() },
 });
 
 describe('applyTaxonomySuggestions', () => {
@@ -220,6 +224,37 @@ describe('applyTaxonomySuggestions', () => {
 
     const updates = adapters.db.fabFiles.bulkUpdateTags.mock.calls[0][0];
     expect(updates[0].expectedTags).toEqual(existingTags);
+  });
+
+  it('warns with the skip count when bulkUpdateTags reports fewer modified than matched (a race lost)', async () => {
+    const adapters = makeAdapters({
+      files: [file(), file({ id: 'f2', relativePath: 'legal/2.pdf' })],
+      bulkUpdateTagsResult: 1, // 2 files matched, only 1 actually written - 1 lost a concurrency race
+    });
+
+    await applyTaxonomySuggestions(
+      { userId: 'owner', isAdmin: false },
+      'b1',
+      [tag({ suffix: 'type:contract', matchingFolders: ['legal'] })],
+      adapters as any
+    );
+
+    expect(adapters.logger.warn).toHaveBeenCalledWith(expect.stringContaining('1/2'));
+  });
+
+  it('does not warn when every matched file was actually updated', async () => {
+    const adapters = makeAdapters({
+      files: [file({ tags: [{ name: 'acme:legal', strength: 1 }] })],
+    });
+
+    await applyTaxonomySuggestions(
+      { userId: 'owner', isAdmin: false },
+      'b1',
+      [tag({ suffix: 'type:contract', matchingFolders: ['legal'] })],
+      adapters as any
+    );
+
+    expect(adapters.logger.warn).not.toHaveBeenCalled();
   });
 
   it('keeps a genuinely suggested tag even after its suffix was edited by the reviewer', async () => {

--- a/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts
+++ b/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts
@@ -9,6 +9,7 @@ interface ApplyTaxonomySuggestionsAdapters {
     fabFiles: Pick<IFabFileRepository, 'findByBatchId' | 'bulkUpdateTags'>;
   };
   logger?: { warn: (msg: string, ...args: unknown[]) => void };
+  metrics?: { recordTagsApplySkipped: (count: number) => Promise<void> };
 }
 
 /**
@@ -39,7 +40,7 @@ export const applyTaxonomySuggestions = async (
   actor: { userId: string; isAdmin: boolean },
   batchId: string,
   acceptedTags: TaxonomyTag[],
-  { db, logger }: ApplyTaxonomySuggestionsAdapters
+  { db, logger, metrics }: ApplyTaxonomySuggestionsAdapters
 ): Promise<{ success: true; filesUpdated: number }> => {
   const batch = await db.batches.findById(batchId);
   if (!batch) throw new NotFoundError('Batch not found');
@@ -116,10 +117,13 @@ export const applyTaxonomySuggestions = async (
       // bulkUpdateTags' optimistic-concurrency check lost the race for `skipped` of them (see
       // its doc comment). Not an error - the concurrent writer's change legitimately wins - but
       // otherwise invisible: filesUpdated just reaches the caller as a smaller-than-expected
-      // number with no signal why.
+      // number with no signal why. Log carries batchId for grepping one occurrence; the metric
+      // (deliberately dimensionless, matching this file's low-cardinality convention) is the
+      // aggregate rate an alarm could eventually watch.
       logger?.warn(
         `applyTaxonomySuggestions: ${skipped}/${updates.length} file(s) skipped on batch ${batchId} - tags changed since read`
       );
+      await metrics?.recordTagsApplySkipped(skipped).catch(() => {});
     }
 
     const finalized = await db.batches.setTaxonomyStatusIfActive(batchId, ['applying'], 'applied');

--- a/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts
+++ b/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts
@@ -8,6 +8,7 @@ interface ApplyTaxonomySuggestionsAdapters {
     batches: Pick<IDataLakeBatchRepository, 'findById' | 'setTaxonomyStatusIfActive'>;
     fabFiles: Pick<IFabFileRepository, 'findByBatchId' | 'bulkUpdateTags'>;
   };
+  logger?: { warn: (msg: string, ...args: unknown[]) => void };
 }
 
 /**
@@ -38,7 +39,7 @@ export const applyTaxonomySuggestions = async (
   actor: { userId: string; isAdmin: boolean },
   batchId: string,
   acceptedTags: TaxonomyTag[],
-  { db }: ApplyTaxonomySuggestionsAdapters
+  { db, logger }: ApplyTaxonomySuggestionsAdapters
 ): Promise<{ success: true; filesUpdated: number }> => {
   const batch = await db.batches.findById(batchId);
   if (!batch) throw new NotFoundError('Batch not found');
@@ -109,6 +110,17 @@ export const applyTaxonomySuggestions = async (
     });
 
     const filesUpdated = await db.fabFiles.bulkUpdateTags(updates);
+    const skipped = updates.length - filesUpdated;
+    if (skipped > 0) {
+      // Every op in `updates` matched a file that needed new tags - a lower filesUpdated means
+      // bulkUpdateTags' optimistic-concurrency check lost the race for `skipped` of them (see
+      // its doc comment). Not an error - the concurrent writer's change legitimately wins - but
+      // otherwise invisible: filesUpdated just reaches the caller as a smaller-than-expected
+      // number with no signal why.
+      logger?.warn(
+        `applyTaxonomySuggestions: ${skipped}/${updates.length} file(s) skipped on batch ${batchId} - tags changed since read`
+      );
+    }
 
     const finalized = await db.batches.setTaxonomyStatusIfActive(batchId, ['applying'], 'applied');
     if (!finalized) {

--- a/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts
+++ b/b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts
@@ -28,6 +28,11 @@ interface ApplyTaxonomySuggestionsAdapters {
  * pre-upload behavior this replaces).
  *
  * No lake-stats recompute: tags don't change lake membership/fileCount/totalSizeBytes.
+ *
+ * `filesUpdated` can be less than the number of matched files: bulkUpdateTags applies
+ * optimistic concurrency per file, so one mutated by something else between the read below and
+ * the write (a direct tag edit, a lake-membership pull, another apply) is silently skipped
+ * rather than having its concurrent change clobbered by a merge computed from stale data.
  */
 export const applyTaxonomySuggestions = async (
   actor: { userId: string; isAdmin: boolean },
@@ -91,7 +96,16 @@ export const applyTaxonomySuggestions = async (
         if (current === undefined || t.strength > current) merged.set(t.name, t.strength);
       }
 
-      return [{ id: file.id, tags: Array.from(merged, ([name, strength]) => ({ name, strength })) }];
+      return [
+        {
+          id: file.id,
+          tags: Array.from(merged, ([name, strength]) => ({ name, strength })),
+          // The exact snapshot this merge was computed from - bulkUpdateTags uses it for
+          // optimistic concurrency, so a file mutated by something else since this read is
+          // skipped rather than clobbered by a merge that's now stale.
+          expectedTags: existingTags,
+        },
+      ];
     });
 
     const filesUpdated = await db.fabFiles.bulkUpdateTags(updates);

--- a/packages/database/src/models/content/FabFileModel.bulkUpdateTags.test.ts
+++ b/packages/database/src/models/content/FabFileModel.bulkUpdateTags.test.ts
@@ -48,8 +48,9 @@ describe('FabFileRepository.bulkUpdateTags', () => {
           { name: 'acme:legal', strength: 1 },
           { name: 'acme:type:contract', strength: 0.9 },
         ],
+        expectedTags: [{ name: 'acme:legal', strength: 1 }],
       },
-      { id: b.id, tags: [{ name: 'acme:finance', strength: 0.8 }] },
+      { id: b.id, tags: [{ name: 'acme:finance', strength: 0.8 }], expectedTags: [] },
     ]);
 
     expect(modifiedCount).toBe(2);
@@ -61,5 +62,80 @@ describe('FabFileRepository.bulkUpdateTags', () => {
   it('is a no-op for an empty update list', async () => {
     const modifiedCount = await fabFileRepository.bulkUpdateTags([]);
     expect(modifiedCount).toBe(0);
+  });
+
+  it('skips a file whose tags changed since expectedTags was read, instead of clobbering the concurrent change', async () => {
+    const a = await FabFile.create({
+      userId,
+      fileName: 'a.txt',
+      mimeType: 'text/plain',
+      type: KnowledgeType.FILE,
+      filePath: 'a.txt',
+      tags: [{ name: 'acme:legal', strength: 1 }],
+    });
+
+    // Simulates a concurrent writer (e.g. a direct tag edit) landing after this caller's read.
+    await fabFileRepository.update({
+      id: a.id,
+      tags: [
+        { name: 'acme:legal', strength: 1 },
+        { name: 'user:added', strength: 1 },
+      ],
+    });
+
+    const modifiedCount = await fabFileRepository.bulkUpdateTags([
+      {
+        id: a.id,
+        tags: [
+          { name: 'acme:legal', strength: 1 },
+          { name: 'acme:type:contract', strength: 0.9 },
+        ],
+        expectedTags: [{ name: 'acme:legal', strength: 1 }], // stale - no longer matches stored tags
+      },
+    ]);
+
+    expect(modifiedCount).toBe(0);
+    const fresh = await fabFileRepository.findById(a.id);
+    // The concurrent writer's tag survives untouched - not overwritten by the stale merge.
+    expect(fresh?.tags?.map(t => t.name).sort()).toEqual(['acme:legal', 'user:added']);
+  });
+
+  it('applies the write when expectedTags matches, alongside a sibling op that is skipped', async () => {
+    const a = await FabFile.create({
+      userId,
+      fileName: 'a.txt',
+      mimeType: 'text/plain',
+      type: KnowledgeType.FILE,
+      filePath: 'a.txt',
+      tags: [{ name: 'acme:legal', strength: 1 }],
+    });
+    const b = await FabFile.create({
+      userId,
+      fileName: 'b.txt',
+      mimeType: 'text/plain',
+      type: KnowledgeType.FILE,
+      filePath: 'b.txt',
+      tags: [],
+    });
+
+    // Only `a` drifts from its snapshot; `b` stays untouched, so its op should still apply.
+    await fabFileRepository.update({ id: a.id, tags: [{ name: 'user:added', strength: 1 }] });
+
+    const modifiedCount = await fabFileRepository.bulkUpdateTags([
+      {
+        id: a.id,
+        tags: [
+          { name: 'acme:legal', strength: 1 },
+          { name: 'acme:type:contract', strength: 0.9 },
+        ],
+        expectedTags: [{ name: 'acme:legal', strength: 1 }],
+      },
+      { id: b.id, tags: [{ name: 'acme:finance', strength: 0.8 }], expectedTags: [] },
+    ]);
+
+    expect(modifiedCount).toBe(1);
+    const [freshA, freshB] = await Promise.all([fabFileRepository.findById(a.id), fabFileRepository.findById(b.id)]);
+    expect(freshA?.tags?.map(t => t.name)).toEqual(['user:added']); // untouched by the skipped op
+    expect(freshB?.tags?.map(t => t.name)).toEqual(['acme:finance']); // applied normally
   });
 });

--- a/packages/database/src/models/content/FabFileModel.bulkUpdateTags.test.ts
+++ b/packages/database/src/models/content/FabFileModel.bulkUpdateTags.test.ts
@@ -183,4 +183,34 @@ describe('FabFileRepository.bulkUpdateTags', () => {
     const fresh = await fabFileRepository.findById(a.id);
     expect(fresh?.tags?.map(t => t.name)).toEqual(['acme:legal']);
   });
+
+  it('does not write tags to a file soft-deleted since expectedTags was read', async () => {
+    const a = await FabFile.create({
+      userId,
+      fileName: 'a.txt',
+      mimeType: 'text/plain',
+      type: KnowledgeType.FILE,
+      filePath: 'a.txt',
+      tags: [{ name: 'acme:legal', strength: 1 }],
+    });
+    // Simulates a delete landing after this caller's read, before its write.
+    await FabFile.updateOne({ _id: a._id }, { $set: { deletedAt: new Date() } });
+
+    const modifiedCount = await fabFileRepository.bulkUpdateTags([
+      {
+        id: a.id,
+        tags: [
+          { name: 'acme:legal', strength: 1 },
+          { name: 'acme:type:contract', strength: 0.9 },
+        ],
+        expectedTags: [{ name: 'acme:legal', strength: 1 }],
+      },
+    ]);
+
+    expect(modifiedCount).toBe(0);
+    // findById excludes soft-deleted docs by default (schema-level `pre('findOne')` guard) -
+    // opt in explicitly to inspect the deleted document's persisted state.
+    const raw = await FabFile.findOne({ _id: a._id }, null, { includeDeleted: true });
+    expect(raw?.tags?.map((t: { name: string }) => t.name)).toEqual(['acme:legal']);
+  });
 });

--- a/packages/database/src/models/content/FabFileModel.bulkUpdateTags.test.ts
+++ b/packages/database/src/models/content/FabFileModel.bulkUpdateTags.test.ts
@@ -138,4 +138,49 @@ describe('FabFileRepository.bulkUpdateTags', () => {
     expect(freshA?.tags?.map(t => t.name)).toEqual(['user:added']); // untouched by the skipped op
     expect(freshB?.tags?.map(t => t.name)).toEqual(['acme:finance']); // applied normally
   });
+
+  // Legacy rows can store "no tags" as a missing/null field rather than `[]` (see the
+  // $ifNull guards in dedupeTagByUserId) - a caller's `file.tags ?? []` read collapses all
+  // three to `[]` before it ever becomes expectedTags, so the write-side filter has to treat
+  // them as equivalent too, or these files could never receive tags again.
+  it('applies the write when tags is a missing field, not just [], for an empty expectedTags snapshot', async () => {
+    const a = await FabFile.create({
+      userId,
+      fileName: 'a.txt',
+      mimeType: 'text/plain',
+      type: KnowledgeType.FILE,
+      filePath: 'a.txt',
+      tags: [],
+    });
+    // Simulates a legacy row: strip the field entirely, bypassing the schema default.
+    await FabFile.updateOne({ _id: a._id }, { $unset: { tags: '' } });
+
+    const modifiedCount = await fabFileRepository.bulkUpdateTags([
+      { id: a.id, tags: [{ name: 'acme:legal', strength: 1 }], expectedTags: [] },
+    ]);
+
+    expect(modifiedCount).toBe(1);
+    const fresh = await fabFileRepository.findById(a.id);
+    expect(fresh?.tags?.map(t => t.name)).toEqual(['acme:legal']);
+  });
+
+  it('applies the write when tags is explicitly null, not just [], for an empty expectedTags snapshot', async () => {
+    const a = await FabFile.create({
+      userId,
+      fileName: 'a.txt',
+      mimeType: 'text/plain',
+      type: KnowledgeType.FILE,
+      filePath: 'a.txt',
+      tags: [],
+    });
+    await FabFile.updateOne({ _id: a._id }, { $set: { tags: null } });
+
+    const modifiedCount = await fabFileRepository.bulkUpdateTags([
+      { id: a.id, tags: [{ name: 'acme:legal', strength: 1 }], expectedTags: [] },
+    ]);
+
+    expect(modifiedCount).toBe(1);
+    const fresh = await fabFileRepository.findById(a.id);
+    expect(fresh?.tags?.map(t => t.name)).toEqual(['acme:legal']);
+  });
 });

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -651,22 +651,28 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
 
     // `tags: expectedTags` is an exact, order-sensitive array match (Mongo array-equality
     // semantics) - ANY concurrent change (add/remove/reorder) makes this op a no-op rather
-    // than overwriting with a merge computed from data that's no longer current.
+    // than overwriting with a merge computed from data that's no longer current. Order-
+    // sensitivity is safe only because every other tags writer in this file (push/pull/dedupe)
+    // preserves order - it appends or removes, never reshuffles. That's an invariant of those
+    // methods, not of this one; a future writer that resorts/rebuilds `tags` would silently
+    // defeat this CAS. Keep it that way, or switch to a version counter instead of a full-array
+    // compare.
     //
     // `tags` is a schema-less [Object] array with no default enforced on legacy rows (see the
     // $ifNull guards in dedupeTagByUserId above), so "no tags" can be stored as `null`, an
     // absent field, or `[]`. A caller's `file.tags ?? []` read collapses all three to `[]`
     // before it ever reaches expectedTags, so an exact-array filter of `{ tags: [] }` would
-    // never match the null/missing cases and permanently strand those files. Match all three
-    // storage forms as equivalent to an empty snapshot, mirroring the read side.
+    // never match the null/missing cases and permanently strand those files. `{ tags: null }`
+    // alone covers both the explicit-null and the missing-field case (Mongo treats them as the
+    // same match), so two clauses - not three - cover all storage forms as equivalent to an
+    // empty snapshot, mirroring the read side.
     const result = await this.fabFileModel.bulkWrite(
       updates.map(({ id, tags, expectedTags }) => ({
         updateOne: {
           filter: {
             _id: convertId(id),
-            ...(expectedTags.length === 0
-              ? { $or: [{ tags: [] }, { tags: null }, { tags: { $exists: false } }] }
-              : { tags: expectedTags }),
+            deletedAt: null,
+            ...(expectedTags.length === 0 ? { $or: [{ tags: [] }, { tags: null }] } : { tags: expectedTags }),
           },
           update: { $set: { tags } },
         },

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -652,10 +652,22 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     // `tags: expectedTags` is an exact, order-sensitive array match (Mongo array-equality
     // semantics) - ANY concurrent change (add/remove/reorder) makes this op a no-op rather
     // than overwriting with a merge computed from data that's no longer current.
+    //
+    // `tags` is a schema-less [Object] array with no default enforced on legacy rows (see the
+    // $ifNull guards in dedupeTagByUserId above), so "no tags" can be stored as `null`, an
+    // absent field, or `[]`. A caller's `file.tags ?? []` read collapses all three to `[]`
+    // before it ever reaches expectedTags, so an exact-array filter of `{ tags: [] }` would
+    // never match the null/missing cases and permanently strand those files. Match all three
+    // storage forms as equivalent to an empty snapshot, mirroring the read side.
     const result = await this.fabFileModel.bulkWrite(
       updates.map(({ id, tags, expectedTags }) => ({
         updateOne: {
-          filter: { _id: convertId(id), tags: expectedTags },
+          filter: {
+            _id: convertId(id),
+            ...(expectedTags.length === 0
+              ? { $or: [{ tags: [] }, { tags: null }, { tags: { $exists: false } }] }
+              : { tags: expectedTags }),
+          },
           update: { $set: { tags } },
         },
       })),

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -640,13 +640,22 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     return result.modifiedCount;
   }
 
-  async bulkUpdateTags(updates: { id: string; tags: { name: string; strength: number }[] }[]): Promise<number> {
+  async bulkUpdateTags(
+    updates: {
+      id: string;
+      tags: { name: string; strength: number }[];
+      expectedTags: { name: string; strength: number }[];
+    }[]
+  ): Promise<number> {
     if (updates.length === 0) return 0;
 
+    // `tags: expectedTags` is an exact, order-sensitive array match (Mongo array-equality
+    // semantics) - ANY concurrent change (add/remove/reorder) makes this op a no-op rather
+    // than overwriting with a merge computed from data that's no longer current.
     const result = await this.fabFileModel.bulkWrite(
-      updates.map(({ id, tags }) => ({
+      updates.map(({ id, tags, expectedTags }) => ({
         updateOne: {
-          filter: { _id: convertId(id) },
+          filter: { _id: convertId(id), tags: expectedTags },
           update: { $set: { tags } },
         },
       })),


### PR DESCRIPTION
## Description

Follow-up from #1268 (background AI-tag-suggestion reliability and correctness gaps) - item 9, "`bulkUpdateTags`'s whole-array `$set` is a lost-update race."

`applyTaxonomySuggestions` (the "Apply" action in the taxonomy review panel) reads each file's current tags, merges in the accepted AI suggestions, then writes the whole merged array back via `FabFileRepository.bulkUpdateTags` - a plain `$set: { tags }` per file, with no check for changes in between the read and the write. Any concurrent tag mutation on one of those files landing in that window - a user editing tags directly, a tag removal, the file leaving another lake's membership tags - is silently and permanently reverted the moment the batch write lands, with no error and no signal to anyone that it happened.

## Changes

- `FabFileRepository.bulkUpdateTags` (`packages/database/src/models/content/FabFileModel.ts`) now takes an `expectedTags` snapshot per update and adds it to the write's filter, so the write only applies if the file's stored tags still match what the caller originally read. A file mutated by something else in between is skipped instead of overwritten.
- Handles the schema's own edge case correctly: `tags` is a schema-less `[Object]` array, and a legacy row can store "no tags" as a missing or `null` field rather than a literal `[]` (the same condition `dedupeTagByUserId` already guards against elsewhere in this file). The filter treats `[]`/`null`/missing as equivalent whenever the snapshot is empty, matching what the read side already does via `file.tags ?? []` - otherwise those files could never receive tags again once this concurrency check landed.
- `applyTaxonomySuggestions` (`b4m-core/services/src/dataLakeService/applyTaxonomySuggestions.ts`) now threads each file's pre-merge tags snapshot through as `expectedTags`.
- `filesUpdated` can now legitimately be less than the number of matched files - that's the safe outcome (skipped, not clobbered), not a bug; documented on the function.
- `applyTaxonomySuggestions` now takes an optional `logger` and warns with the skip count whenever `bulkUpdateTags` reports fewer writes than files matched, so a real concurrency conflict is at least greppable instead of only visible as a smaller-than-expected count in the response. Wired to `console` at the route (`apply-taxonomy.ts`), matching the existing `reconcileStuckTaxonomy`/`archiveDataLake` logger convention.
- `bulkUpdateTags`'s filter now also excludes soft-deleted files (`deletedAt: null`), so a file deleted between the read and the write is a clean no-op instead of getting tags written to a deleted record. Also dropped a redundant `$exists: false` clause from the null/missing-tags `$or` (Mongo's `{ tags: null }` already matches a missing field), and documented the order-sensitivity assumption the array-equality comparison depends on.
- The skip count also now emits a CloudWatch metric (`recordTaxonomyTagsApplySkipped`, `Lumina5/DataLakeBatch` namespace, matching this feature's existing `recordReconcilerForcedTerminal`/`recordTaxonomyDailyCapExceeded` pattern) alongside the log line - the log keeps the batchId for grepping one occurrence, the metric stays dimensionless for an aggregate rate an alarm could eventually watch. The plain `console.warn` alone was logged but not actually alertable: this app's CloudWatch-to-Slack forwarding only matches `ERROR`-level lines, never `WARN`.

## Guide for Testers

Not practical to verify manually - reproducing the race requires a write landing in the narrow window between `applyTaxonomySuggestions`'s read and its bulk write. Covered by unit tests instead:

- `FabFileModel.bulkUpdateTags.test.ts`: a stale snapshot is skipped and the concurrent writer's tag survives; a sibling op in the same batch whose snapshot still matches applies normally; a file with missing or `null` `tags` (not `[]`) still receives its first tags correctly; a file soft-deleted since the read is not written to.
- `applyTaxonomySuggestions.test.ts`: confirms the snapshot passed to `bulkUpdateTags` matches what was actually read for that file, and that the skip-count warning and metric both fire only when a write was actually skipped.

### What NOT to test

The underlying "apply AI tag suggestions" UX is unchanged - this only affects behavior when a genuine concurrent write races the apply, which has no reliable manual repro.

## Additional Information

Verified: `pnpm turbo:core:build` clean, `pnpm turbo:typecheck` clean, `pnpm lint:check` clean, `@bike4mind/database` (1445 passed) and `@bike4mind/services` (3529 passed) full suites green, including 10 new/updated tests across the touched files.

Partially addresses #1268 (item 9); the remaining items are separate follow-up PRs.

**Breaking change to `@bike4mind/common`:** `IFabFileRepository.bulkUpdateTags` gained a required `expectedTags` field on its parameter type. No implementer exists outside this repo's own `FabFileModel.ts`, and the only caller (`applyTaxonomySuggestions.ts`) is updated in this same PR and narrows via `Pick<IFabFileRepository, 'findByBatchId' | 'bulkUpdateTags'>`, so there is nothing to migrate.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
