### PR TITLE
fix(organizations): clamp seat raise to unwedge setSeats (#1424)

### DIFF
--- a/apps/client/app/components/admin/OrganizationsTab.tsx
+++ b/apps/client/app/components/admin/OrganizationsTab.tsx
@@ -27,6 +27,7 @@ import {
 } from '@mui/joy';
 import { useIsMobile } from '@client/app/hooks/useIsMobile';
 import { IOrganizationDocument, Permission, WithId } from '@bike4mind/common';
+import { ORGANIZATION_SUBSCRIPTION_MAX_SEATS } from '@client/lib/subscriptions/constants';
 import { toast } from 'sonner';
 import OrganizationProfileUpdated from './OrganizationProfileUpdated';
 import OrganizationMembers from '@client/app/components/organizations/Member';
@@ -112,6 +113,10 @@ const AdjustSeatsModal: React.FC<AdjustSeatsModalProps> = ({
   const pendingCount = pendingUsers?.length ?? 0;
   const acceptedTeamSize = (org.users?.length ?? 0) + 1; // +1 for owner
   const teamSize = acceptedTeamSize + pendingCount;
+  // Clamp the floor at the ceiling so an over-cap org can be set back down to the max (#1424) -
+  // mirrors the server validateSeatChange clamp. Without it, min > max here and the input forces
+  // an unsubmittable value (>= teamSize) that the server then rejects as over the 100-seat cap.
+  const minAllowed = Math.min(teamSize, ORGANIZATION_SUBSCRIPTION_MAX_SEATS);
   const pendingHint = pendingCount > 0 ? ` (${pendingCount} pending invite${pendingCount === 1 ? '' : 's'})` : '';
 
   return (
@@ -122,15 +127,15 @@ const AdjustSeatsModal: React.FC<AdjustSeatsModalProps> = ({
         <Divider sx={{ my: 2 }} />
         <Typography level="body-sm" sx={{ mb: 1 }}>
           Current seats: {org.seats}. Members: {acceptedTeamSize}
-          {pendingHint}. Minimum allowed: {teamSize} (remove members or revoke pending invites to go lower).
+          {pendingHint}. Minimum allowed: {minAllowed} (remove members or revoke pending invites to go lower).
         </Typography>
         <FormControl>
           <FormLabel>New seat count</FormLabel>
           <Input
             type="number"
-            slotProps={{ input: { min: teamSize, max: 100 } }}
+            slotProps={{ input: { min: minAllowed, max: ORGANIZATION_SUBSCRIPTION_MAX_SEATS } }}
             value={seatsValue}
-            onChange={e => setSeatsValue(Math.max(teamSize, Number(e.target.value || teamSize)))}
+            onChange={e => setSeatsValue(Math.max(minAllowed, Number(e.target.value || minAllowed)))}
             data-testid="seats-input"
           />
         </FormControl>

--- a/apps/client/app/components/organizations/OrganizationBillingSection.tsx
+++ b/apps/client/app/components/organizations/OrganizationBillingSection.tsx
@@ -59,7 +59,12 @@ const SubscriptionModal = ({
   subscription?: ISubscription;
   pricePerSeat: number;
 }) => {
-  const minimumSeats = Math.max(ORGANIZATION_SUBSCRIPTION_MIN_SEATS, organization.users.length + 1);
+  // Clamp the floor at the ceiling so an over-cap org can still be set down to the max (#1424) -
+  // mirrors the server validateSeatChange clamp; otherwise the decrement gate never lets it recover.
+  const minimumSeats = Math.min(
+    Math.max(ORGANIZATION_SUBSCRIPTION_MIN_SEATS, organization.users.length + 1),
+    ORGANIZATION_SUBSCRIPTION_MAX_SEATS
+  );
   // Initialize with current seats if it's an existing subscription, otherwise use minimum seats
   const [seats, setSeats] = useState(subscription ? organization.seats : minimumSeats);
   const updateSeats = useUpdateSubscriptionSeats();

--- a/apps/client/lib/subscriptions/constants.ts
+++ b/apps/client/lib/subscriptions/constants.ts
@@ -6,11 +6,11 @@ export const ORGANIZATION_SUBSCRIPTION_PRICE_ID = isTestMode
   ? (process.env.NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_TEST ?? '')
   : (process.env.NEXT_PUBLIC_STRIPE_PRICE_ORG_SUB_PROD ?? '');
 
-export const ORGANIZATION_SUBSCRIPTION_MIN_SEATS = 4;
+// Seat floor/ceiling policy lives in common so the persistence layer can enforce the ceiling
+// too (OrganizationModel.addMemberRaisingSeats). Re-exported here so app importers are unchanged.
+export { ORGANIZATION_SUBSCRIPTION_MIN_SEATS, ORGANIZATION_SUBSCRIPTION_MAX_SEATS } from '@bike4mind/common';
 
 /**
  * Number of credits to add per seat when a subscription quantity update is invoiced
  */
 export const ORGANIZATION_SUBSCRIPTION_CREDITS_PER_SEAT = 50000;
-
-export const ORGANIZATION_SUBSCRIPTION_MAX_SEATS = 100;

--- a/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
@@ -64,14 +64,16 @@ const handler = baseApi().post(
     // Since a commit can now grow the seat ceiling (#1239), the preview surfaces the seat/billing
     // blast radius, not just the head count. A Stripe-billed org keeps its ceiling (candidates past
     // it are rejected, not billed silently); a non-Stripe org raises to fit the whole backfill, but
-    // that raise is clamped at ORGANIZATION_SUBSCRIPTION_MAX_SEATS (#1424), so the projection caps
-    // there too - candidates past the ceiling are rejected, not silently promised a seat.
+    // that raise is clamped at ORGANIZATION_SUBSCRIPTION_MAX_SEATS (#1424): new members cap at the
+    // ceiling, so cap the fit target there. Floor the projection at currentSeats because the backfill
+    // never lowers seats (`$max($seats, $size+1)`), so a legacy org already over the ceiling keeps its
+    // seats rather than the preview reading as a spurious decrease.
     const currentSeats = organization?.seats ?? 0;
     const currentMembers = organization?.users?.length ?? 0;
     const stripeBilled = !!organization?.stripeCustomerId;
     const projectedSeats = stripeBilled
       ? currentSeats
-      : Math.min(ORGANIZATION_SUBSCRIPTION_MAX_SEATS, Math.max(currentSeats, currentMembers + candidates.length));
+      : Math.max(currentSeats, Math.min(ORGANIZATION_SUBSCRIPTION_MAX_SEATS, currentMembers + candidates.length));
 
     if (!body.commit) {
       return res.status(200).json({

--- a/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/backfill.ts
@@ -6,6 +6,7 @@ import { partnerSignupRuleRepository, userRepository, organizationRepository } f
 import { organizationService } from '@bike4mind/services';
 import { assertOrganizationExists } from '@server/entitlements/assertOrganizationExists';
 import { escapeRegex } from '@bike4mind/utils/escapeRegex';
+import { ORGANIZATION_SUBSCRIPTION_MAX_SEATS } from '@client/lib/subscriptions/constants';
 import { auditSeatCeilingRaised } from '@server/organizations/notifySeatCeilingRaised';
 import { postMessageToSlack } from '@server/integrations/slack/slack';
 import { z } from 'zod';
@@ -62,11 +63,15 @@ const handler = baseApi().post(
 
     // Since a commit can now grow the seat ceiling (#1239), the preview surfaces the seat/billing
     // blast radius, not just the head count. A Stripe-billed org keeps its ceiling (candidates past
-    // it are rejected, not billed silently); a non-Stripe org raises to fit the whole backfill.
+    // it are rejected, not billed silently); a non-Stripe org raises to fit the whole backfill, but
+    // that raise is clamped at ORGANIZATION_SUBSCRIPTION_MAX_SEATS (#1424), so the projection caps
+    // there too - candidates past the ceiling are rejected, not silently promised a seat.
     const currentSeats = organization?.seats ?? 0;
     const currentMembers = organization?.users?.length ?? 0;
     const stripeBilled = !!organization?.stripeCustomerId;
-    const projectedSeats = stripeBilled ? currentSeats : Math.max(currentSeats, currentMembers + candidates.length);
+    const projectedSeats = stripeBilled
+      ? currentSeats
+      : Math.min(ORGANIZATION_SUBSCRIPTION_MAX_SEATS, Math.max(currentSeats, currentMembers + candidates.length));
 
     if (!body.commit) {
       return res.status(200).json({

--- a/apps/client/pages/api/email/verify.ts
+++ b/apps/client/pages/api/email/verify.ts
@@ -229,8 +229,9 @@ const handler = baseApi({ auth: false })
               );
             }
           } else if (result.reason === 'at-capacity') {
-            // Stripe-billed org at capacity; its ceiling isn't auto-raised, so alert an admin to add
-            // seats and admit this stranded partner user. Best-effort, never throws.
+            // Org at capacity with no auto-raise: a Stripe-billed org (ceiling not raised out of band)
+            // or a non-Stripe org already at MAX_SEATS (the raise is clamped there, #1424). Alert an
+            // admin to add seats and admit this stranded partner user. Best-effort, never throws.
             await notifyPartnerSignupBlockedAtCapacity(
               {
                 organizationId: partnerOrganizationId,

--- a/apps/client/pages/api/organizations/subscriptions/subscribe.ts
+++ b/apps/client/pages/api/organizations/subscriptions/subscribe.ts
@@ -60,7 +60,12 @@ const handler = baseApi()
         await organizationRepository.update(organization);
       }
 
-      minSeats = Math.max(ORGANIZATION_SUBSCRIPTION_MIN_SEATS, organization.users.length + 1);
+      // Clamp at the ceiling so an over-cap org's checkout minimum can't exceed the maximum (#1424) -
+      // without this, minimum > maximum makes Stripe reject the session and the self-serve checkout wedges.
+      minSeats = Math.min(
+        Math.max(ORGANIZATION_SUBSCRIPTION_MIN_SEATS, organization.users.length + 1),
+        ORGANIZATION_SUBSCRIPTION_MAX_SEATS
+      );
       customerId = organization.stripeCustomerId;
     } else {
       customer = await createCustomer({

--- a/apps/client/pages/api/otc/verify.ts
+++ b/apps/client/pages/api/otc/verify.ts
@@ -408,8 +408,9 @@ const handler = baseApi({ auth: false })
             );
           }
         } else if (result.reason === 'at-capacity') {
-          // A Stripe-billed org was full and its ceiling isn't auto-raised; alert an admin to add
-          // seats so this stranded partner user can be admitted. Best-effort, never throws.
+          // Org at capacity with no auto-raise: a Stripe-billed org (ceiling not raised out of band)
+          // or a non-Stripe org already at MAX_SEATS (the raise is clamped there, #1424). Alert an
+          // admin to add seats so this stranded partner user can be admitted. Best-effort, never throws.
           await notifyPartnerSignupBlockedAtCapacity(
             {
               organizationId: partnerOrganizationId,

--- a/apps/client/server/services/organizationService.test.ts
+++ b/apps/client/server/services/organizationService.test.ts
@@ -8,6 +8,7 @@ import {
   resolveSubscriptionSource,
 } from './organizationService';
 import { SubscriptionSource } from '@client/lib/subscriptions/types';
+import { ORGANIZATION_SUBSCRIPTION_MAX_SEATS } from '@client/lib/subscriptions/constants';
 
 // Vitest hoists vi.mock() calls above imports, so the mocked modules win
 // even though imports appear higher in source order.
@@ -87,6 +88,32 @@ describe('organizationService', () => {
         /Minimum required seats: 5.*including 4 pending invites/
       );
       expect(() => validateSeatChange(org, 5, { type: 'admin', userId: 'a1' }, 4)).not.toThrow();
+    });
+
+    describe('over-capacity recovery (#1424)', () => {
+      // owner + MAX members = team size MAX + 1, one past the ceiling.
+      const overCapOrg = () =>
+        ({
+          users: Array.from({ length: ORGANIZATION_SUBSCRIPTION_MAX_SEATS }, (_, i) => ({ userId: `m${i}` })),
+        }) as any;
+
+      it('lets an over-cap org be corrected DOWN to the maximum in one call', () => {
+        expect(() =>
+          validateSeatChange(overCapOrg(), ORGANIZATION_SUBSCRIPTION_MAX_SEATS, { type: 'admin', userId: 'a1' })
+        ).not.toThrow();
+      });
+
+      it('rejects a reduction below the maximum with the over-cap guidance', () => {
+        expect(() =>
+          validateSeatChange(overCapOrg(), ORGANIZATION_SUBSCRIPTION_MAX_SEATS - 1, { type: 'admin', userId: 'a1' })
+        ).toThrow(/over the 100-seat maximum.*remove members/is);
+      });
+
+      it('still rejects any raise past the maximum', () => {
+        expect(() =>
+          validateSeatChange(overCapOrg(), ORGANIZATION_SUBSCRIPTION_MAX_SEATS + 1, { type: 'admin', userId: 'a1' })
+        ).toThrow(/cannot exceed/i);
+      });
     });
   });
 

--- a/apps/client/server/services/organizationService.ts
+++ b/apps/client/server/services/organizationService.ts
@@ -71,6 +71,11 @@ const ADMIN_MIN_SEATS = 1;
  * the moment the recipient accepts. Letting an admin shrink below
  * `accepted + pending` causes the next acceptance to fail (org full) and may
  * skew billing on conversion.
+ *
+ * The floor is clamped at the ceiling (#1424): an org that grew past MAX_SEATS - reachable via a
+ * force-add or, before the clamp, the partner-rule auto-raise - would otherwise carry a floor above
+ * MAX that no value can satisfy against the ceiling, wedging every seat change. Clamping lets such an
+ * org be corrected DOWN to MAX in one call; it is then over-subscribed until members are removed.
  */
 export function validateSeatChange(
   organization: Pick<IOrganizationDocument, 'users'>,
@@ -81,9 +86,17 @@ export function validateSeatChange(
   // Owner + accepted members + outstanding invites.
   const currentTeamSize = organization.users.length + 1 + pendingInviteCount;
   const platformMin = actor.type === 'stripe' ? ORGANIZATION_SUBSCRIPTION_MIN_SEATS : ADMIN_MIN_SEATS;
-  const minimumRequiredSeats = Math.max(platformMin, currentTeamSize);
+  // Clamp the floor at the ceiling so an over-cap org (team size > MAX) can still be set down to MAX,
+  // instead of a floor above MAX that the ceiling check below would then always reject (#1424).
+  const minimumRequiredSeats = Math.min(Math.max(platformMin, currentTeamSize), ORGANIZATION_SUBSCRIPTION_MAX_SEATS);
 
   if (newSeats < minimumRequiredSeats) {
+    if (currentTeamSize > ORGANIZATION_SUBSCRIPTION_MAX_SEATS) {
+      throw new BadRequestError(
+        `Organization has ${currentTeamSize} team members, over the ${ORGANIZATION_SUBSCRIPTION_MAX_SEATS}-seat maximum. ` +
+          `Set seats to ${ORGANIZATION_SUBSCRIPTION_MAX_SEATS}, then remove members to get back under the cap.`
+      );
+    }
     const pendingNote =
       pendingInviteCount > 0
         ? ` including ${pendingInviteCount} pending invite${pendingInviteCount === 1 ? '' : 's'}`

--- a/b4m-core/common/src/constants/organization.ts
+++ b/b4m-core/common/src/constants/organization.ts
@@ -1,0 +1,18 @@
+/**
+ * Organization seat-limit policy - the floor and ceiling every seat change is bound by.
+ *
+ * Lives in common (not the app's subscriptions constants) because the ceiling has to be
+ * enforced in the persistence layer too: `OrganizationModel.addMemberRaisingSeats` clamps
+ * the auto-raise against MAX, and packages/database cannot import from apps/client. The app
+ * re-exports these from `lib/subscriptions/constants` so existing importers stay unchanged.
+ */
+
+/** Paid-plan minimum seats (Stripe path). Admin grants may go smaller (see ADMIN_MIN_SEATS). */
+export const ORGANIZATION_SUBSCRIPTION_MIN_SEATS = 4;
+
+/**
+ * Hard ceiling on org seats. Both `validateSeatChange` and the unattended partner-rule
+ * auto-raise (`addMemberRaisingSeats`) clamp to this, so a full org falls through to the
+ * at-capacity path instead of growing a seat floor that no `setSeats` value can satisfy (#1424).
+ */
+export const ORGANIZATION_SUBSCRIPTION_MAX_SEATS = 100;

--- a/b4m-core/common/src/index.ts
+++ b/b4m-core/common/src/index.ts
@@ -19,6 +19,7 @@ export * from './musicGeneration';
 export * from './schemas/sora';
 export * from './schemas';
 export * from './constants/user';
+export * from './constants/organization';
 export * from './constants/dataLakes';
 export * from './constants/jupyter';
 export * from './constants/systemUsers';

--- a/b4m-core/common/src/types/entities/OrganizationTypes.ts
+++ b/b4m-core/common/src/types/entities/OrganizationTypes.ts
@@ -96,9 +96,12 @@ export interface IOrganizationRepository extends IBaseRepository<IOrganizationDo
   /**
    * Atomically add a member and raise the seat ceiling to fit, in a single update (#1239).
    * Race-safe: idempotent on a duplicate add, and raises `seats` only to the post-add member count
-   * (never a double-raise). Returns the PRE-image (before/after seats are derived from it), or null
-   * if the user is already a member or the org is gone. Domain-signup auto-add path for orgs NOT
-   * billed through Stripe - it does not sync Stripe's billed quantity (see `addMemberIfUnderCeiling`).
+   * (never a double-raise). The raise is clamped at `ORGANIZATION_SUBSCRIPTION_MAX_SEATS` (#1424), so
+   * a full org matches no doc and returns null - the caller routes that to 'at-capacity' rather than
+   * growing a seat floor no `setSeats` value can satisfy. Returns the PRE-image (before/after seats are
+   * derived from it), or null if the user is already a member, the org is gone, OR the org is at the
+   * ceiling. Domain-signup auto-add path for orgs NOT billed through Stripe - it does not sync Stripe's
+   * billed quantity (see `addMemberIfUnderCeiling`).
    */
   addMemberRaisingSeats(
     organizationId: string,

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
@@ -192,6 +192,20 @@ describe('applyPartnerRuleMembership', () => {
     expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
   });
 
+  it('rejects with at-capacity (no write) when a non-Stripe org is clamped at the seat ceiling (#1424)', async () => {
+    db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
+    // Non-Stripe org already at the maximum: the clamped addMemberRaisingSeats matches no doc and
+    // returns null, and the re-read still shows the user absent -> at-capacity, not already-member.
+    const full = { ...cloneDeep(org), seats: 100, users: [{ userId: 'a' }, { userId: 'b' }] };
+    db.organizations.findById.mockResolvedValue(full);
+    db.organizations.addMemberRaisingSeats.mockResolvedValue(null);
+
+    const result = await run();
+
+    expect(result).toEqual({ added: false, reason: 'at-capacity', seats: 100 });
+    expect(db.users.update).not.toHaveBeenCalled();
+  });
+
   it('does NOT write an org pointer when the org was hard-deleted between read and atomic add (#P3)', async () => {
     db.users.findById.mockResolvedValue({ ...verifiedUser, organizationId: null });
     // Present at the top read, gone by the re-read after the add matched nothing.

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
@@ -10,8 +10,9 @@ import { IOrganizationRepository, IUserDocument, IUserRepository, Permission } f
  *  - 'added'             fit under the existing ceiling; seats unchanged.
  *  - 'added-seat-raised' the org was at capacity and the ceiling was raised to admit the user
  *                        (#1239, non-Stripe orgs only). The signup caller fires the alert + audit.
- *  - 'at-capacity'       a Stripe-billed org was full and its ceiling is deliberately NOT raised
- *                        out of band; the caller alerts an admin to add seats through billing.
+ *  - 'at-capacity'       the org was full and its ceiling was NOT raised: a Stripe-billed org (never
+ *                        raised out of band), or a non-Stripe org already at ORGANIZATION_SUBSCRIPTION_MAX_SEATS
+ *                        (the raise is clamped there, #1424). The caller alerts an admin to add seats.
  */
 export type ApplyPartnerRuleMembershipResult =
   | { added: true; reason: 'added' | 'added-seat-raised'; previousSeats: number; newSeats: number }
@@ -46,7 +47,8 @@ interface ApplyPartnerRuleMembershipAdapters {
  * At capacity the behaviour splits on how the org is billed (#1239):
  *  - NOT Stripe-billed: raise the seat ceiling to admit the user rather than rejecting a legit
  *    domain signup at the door; the caller fires the resulting alert + audit so the grown seat
- *    count is never a silent change.
+ *    count is never a silent change. The raise is clamped at ORGANIZATION_SUBSCRIPTION_MAX_SEATS
+ *    (#1424) - an org already there returns 'at-capacity' instead of wedging seats past the ceiling.
  *  - Stripe-billed: do NOT raise the ceiling out of band (a raise Stripe doesn't know about is
  *    force-reverted by the next `customer.subscription.updated` webhook, which floors seat count at
  *    `users.length + 1 + pendingInvites` and force-writes back to Stripe's quantity). Reject with
@@ -110,12 +112,19 @@ export async function applyPartnerRuleMembership(
   if (!pre) {
     const outcome = await inspectAfterNoMatch(organizationId, userId, db);
     if (outcome.state === 'gone') return { added: false, reason: 'org-missing' };
-    // 'member' (a concurrent signup won the race) or the vanishingly-rare 'absent' anomaly (the org
-    // exists but the guarded add matched nothing without a capacity guard) - both are safe no-ops.
     if (outcome.state === 'member') {
+      // A concurrent signup won the race and already added this user - a safe no-op; repair the pointer.
       await repairOrgPointer(user, userId, organizationId, db);
+      return { added: false, reason: 'already-member' };
     }
-    return { added: false, reason: 'already-member' };
+    // 'absent': the raise is now clamped at ORGANIZATION_SUBSCRIPTION_MAX_SEATS (#1424), so a full org
+    // matches no doc. Fall through to 'at-capacity' - the same alert-an-admin outcome the Stripe path
+    // uses - rather than growing a seat floor no later `setSeats` value could satisfy.
+    logger?.info(
+      `Partner-rule did not add user ${userId} to non-Stripe org ${organizationId}: at capacity ` +
+        `(seats ${outcome.seats}); ceiling clamped at the maximum, alerting an admin to add seats`
+    );
+    return { added: false, reason: 'at-capacity', seats: outcome.seats };
   }
 
   await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
@@ -155,9 +164,10 @@ async function repairOrgPointer(
 /**
  * Re-read the org after an atomic add matched no document, to tell apart the causes the guarded
  * update collapses into a single null: the org vanished mid-flight ('gone'), a concurrent signup
- * already added this user ('member'), or the user is genuinely absent - at capacity on the Stripe
- * path ('absent'). Distinguishing them keeps us from mislabelling a reject or writing an org
- * pointer to a deleted org.
+ * already added this user ('member'), or the user is genuinely absent because the org is at capacity
+ * ('absent') - the Stripe ceiling on `addMemberIfUnderCeiling`, or MAX_SEATS on the clamped
+ * `addMemberRaisingSeats` (#1424). Distinguishing them keeps us from mislabelling a reject or writing
+ * an org pointer to a deleted org.
  */
 async function inspectAfterNoMatch(
   organizationId: string,

--- a/packages/database/src/models/infra/admin/OrganizationModel.addMemberRaisingSeats.integration.test.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.addMemberRaisingSeats.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import mongoose from 'mongoose';
-import { Permission } from '@bike4mind/common';
+import { Permission, ORGANIZATION_SUBSCRIPTION_MAX_SEATS } from '@bike4mind/common';
 import { createMongoServer } from '../../../__test__/createMongoServer';
 import { Organization, organizationRepository } from './OrganizationModel';
 
@@ -36,7 +36,8 @@ afterEach(async () => {
 const member = (userId: string) => ({ userId, permissions: [Permission.read] });
 
 // Read past the soft-delete filter to assert the true post-state of an org.
-const readRaw = (id: string) => Organization.findOne({ _id: id }, null, { includeDeleted: true } as mongoose.QueryOptions);
+const readRaw = (id: string) =>
+  Organization.findOne({ _id: id }, null, { includeDeleted: true } as mongoose.QueryOptions);
 
 describe('OrganizationModel.addMemberRaisingSeats (#1239)', () => {
   it('adds the member and returns the pre-image; ceiling holds when the member fits', async () => {
@@ -117,6 +118,41 @@ describe('OrganizationModel.addMemberRaisingSeats (#1239)', () => {
     const fresh = await readRaw(created.id);
     expect(fresh!.users.map(u => u.userId)).toEqual(['dup']);
     expect(fresh!.seats).toBe(1);
+  });
+
+  it('rejects the add and does not grow seats past the maximum when the org is at the ceiling (#1424)', async () => {
+    const atMax = Array.from({ length: ORGANIZATION_SUBSCRIPTION_MAX_SEATS }, (_, i) => member(`u${i}`));
+    const created = await Organization.create({
+      name: 'Partner',
+      userId: 'owner',
+      seats: ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
+      users: atMax,
+    });
+
+    const pre = await organizationRepository.addMemberRaisingSeats(created.id, member('over'));
+
+    // Clamp matched no doc: no member added, seats never grow above the maximum -> no setSeats wedge.
+    expect(pre).toBeNull();
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users).toHaveLength(ORGANIZATION_SUBSCRIPTION_MAX_SEATS);
+    expect(fresh!.seats).toBe(ORGANIZATION_SUBSCRIPTION_MAX_SEATS);
+  });
+
+  it('still admits a member one below the ceiling, raising seats up to the maximum (#1424 boundary)', async () => {
+    const belowMax = Array.from({ length: ORGANIZATION_SUBSCRIPTION_MAX_SEATS - 1 }, (_, i) => member(`u${i}`));
+    const created = await Organization.create({
+      name: 'Partner',
+      userId: 'owner',
+      seats: ORGANIZATION_SUBSCRIPTION_MAX_SEATS - 1,
+      users: belowMax,
+    });
+
+    const pre = await organizationRepository.addMemberRaisingSeats(created.id, member('last'));
+
+    expect(pre).not.toBeNull();
+    const fresh = await readRaw(created.id);
+    expect(fresh!.users).toHaveLength(ORGANIZATION_SUBSCRIPTION_MAX_SEATS);
+    expect(fresh!.seats).toBe(ORGANIZATION_SUBSCRIPTION_MAX_SEATS);
   });
 });
 

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -1,4 +1,10 @@
-import { IOrganizationDocument, Permission, IOrganizationRepository, IUserShare } from '@bike4mind/common';
+import {
+  IOrganizationDocument,
+  Permission,
+  IOrganizationRepository,
+  IUserShare,
+  ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
+} from '@bike4mind/common';
 import mongoose, { HydratedDocument, Model, Schema } from 'mongoose';
 import { softDeletePlugin } from '../../../utils/mongo';
 import BaseRepository from '@bike4mind/db-core';
@@ -207,7 +213,8 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
    *
    * Returns the PRE-image ({ new: false }) - the caller derives before/after seats from this one
    * atomically-matched document rather than from an earlier read, so two racers can't report
-   * overlapping ranges. Null means the user is already a member (the guard) or the org is gone.
+   * overlapping ranges. Null means the user is already a member (the guard), the org is gone, or the
+   * org is at `ORGANIZATION_SUBSCRIPTION_MAX_SEATS` (see CLAMP below).
    * `$$NOW` stamps `updatedAt` since a pipeline update bypasses Mongoose's timestamp hook.
    *
    * NOTE (Stripe): this deliberately does NOT touch `subscriptions.quantity` or Stripe's billed
@@ -215,20 +222,23 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
    * force-reverted by the next `customer.subscription.updated` webhook. `applyPartnerRuleMembership`
    * routes Stripe-billed orgs to `addMemberIfUnderCeiling` instead.
    *
-   * NOTE (unbounded by decision, #1239): the raise has no upper cap - blocking a legitimate partner
-   * signup was judged the worse outcome, and every raise is alerted + audited instead. Known edge,
-   * deliberately not handled here: nothing clamps against `ORGANIZATION_SUBSCRIPTION_MAX_SEATS`, so
-   * an org grown past it has a `validateSeatChange` floor above that maximum and `setSeats` then
-   * rejects every value until members are removed. Reachable today without this path (`addMember`
-   * fills to `seats`, and `force` bypasses the ceiling), so it is a pre-existing wedge this method
-   * can reach unattended rather than one it introduces. Clamp here if that ever bites.
+   * CLAMP (#1424): the `$size(users) < MAX_SEATS` guard caps the raise at the ceiling. Without it a
+   * full org grew a `seats` floor above `ORGANIZATION_SUBSCRIPTION_MAX_SEATS`, wedging every later
+   * `setSeats` (floor `users.length + 1` > ceiling MAX, so no value satisfies both). At MAX the add
+   * matches no doc and returns null - the caller routes that to the same 'at-capacity' outcome the
+   * Stripe path already uses (an admin is alerted to add seats), rather than raising past the ceiling.
    */
   async addMemberRaisingSeats(
     organizationId: string,
     member: IOrganizationDocument['users'][number]
   ): Promise<IOrganizationDocument | null> {
     return this.organizationModel.findOneAndUpdate(
-      { _id: organizationId, deletedAt: null, 'users.userId': { $ne: member.userId } },
+      {
+        _id: organizationId,
+        deletedAt: null,
+        'users.userId': { $ne: member.userId },
+        $expr: { $lt: [{ $size: '$users' }, ORGANIZATION_SUBSCRIPTION_MAX_SEATS] },
+      },
       [
         {
           $set: {


### PR DESCRIPTION
# Pull Request

## Screenshots

Reproduced on staging (pre-fix) and verified on the PR preview (post-fix), on a throwaway 100-member org.

**BEFORE (staging) - wedged:** the Adjust-seats modal shows `Minimum allowed: 101` and saving is rejected with `Cannot reduce seats below current team size. Minimum required seats: 101`.

<img width="1800" height="1169" alt="Screenshot 2026-08-05 at 1 10 01 PM" src="https://github.com/user-attachments/assets/719dfe8e-e12a-4195-bf80-c53d01311c9d" />


**AFTER (preview) - modal:** the same modal now shows `Minimum allowed: 100`, and `100` stays in the input instead of being forced to 101.

<img width="1800" height="1169" alt="Screenshot 2026-08-05 at 1 58 50 PM" src="https://github.com/user-attachments/assets/735651ab-b707-4c9f-a66b-28d0afb7a59d" />


**AFTER (preview) - saved:** clicking Update seats succeeds with a `Seats updated` toast - the wedged org recovers.

<img width="1800" height="1169" alt="Screenshot 2026-08-05 at 1 59 42 PM" src="https://github.com/user-attachments/assets/0aa0b45e-6694-4a97-bf02-530970a9eb4c" />


## Description

Closes #1424. Once an organization's member count reached `ORGANIZATION_SUBSCRIPTION_MAX_SEATS` (100), the seat floor and ceiling contradicted each other and every `setSeats` call was wedged in both directions - the admin seats endpoint and self-serve org checkout both broke until members were removed.

Two things caused it:

- The non-Stripe partner-rule auto-raise (`addMemberRaisingSeats`) grew the seat ceiling with no upper cap. A full org ended up with a `validateSeatChange` floor (`users.length + 1`) above the maximum, so no seat value could satisfy both the floor and the ceiling.
- `validateSeatChange` had no way to bring an already over-cap org back down, so an org that got there (via a force-add, the reg-invite migrate path, or the pre-clamp partner raise) stayed stuck.

This PR clamps the auto-raise at the ceiling so a full org falls through to the existing `at-capacity` outcome (which already alerts an admin), reconciles the `validateSeatChange` floor so an over-cap org can be corrected down to the maximum in one step, and clamps every other surface that mirrors that floor (the admin modal, the owner billing gate, the backfill preview, and the self-serve checkout) so the whole blast radius is closed. Pre-existing bug, surfaced while reviewing #1407; the partner-rule backfill is the automated path that made reaching it likelier.

## Changes

- Add `$size(users) < ORGANIZATION_SUBSCRIPTION_MAX_SEATS` guard to `OrganizationModel.addMemberRaisingSeats` so a full org matches no document and returns null - the raise never grows `seats` past the ceiling.
- Route the non-Stripe null result in `applyPartnerRuleMembership` through `inspectAfterNoMatch` to `reason: 'at-capacity'`, reusing the same admin-alert path the Stripe branch already uses (no caller changes needed - the backfill tally already counts `atCapacity`).
- Clamp the `validateSeatChange` floor at the ceiling (`min(max(platformMin, teamSize), MAX)`) so an over-cap org can be set down to the maximum in one call, with a distinct over-cap error message.
- Clamp the backfill dry-run `projectedSeats` preview at the maximum so it no longer promises a raise that will not happen.
- Clamp the self-serve checkout floor (`subscribe.ts` `minSeats`) at the maximum, so an over-cap org's `adjustable_quantity.minimum` can't exceed the maximum and wedge Stripe session creation - the last surface #1424 lists as breaking.
- Clamp the seat floor in the two client mirrors of `validateSeatChange` so the admin recovery is actually reachable from the UI: `OrganizationsTab.tsx` (the admin Adjust-seats modal - was showing `Minimum allowed: 101` and forcing typed values up to 101, which the server then rejected) and `OrganizationBillingSection.tsx` (the owner decrement gate). Both now clamp at `ORGANIZATION_SUBSCRIPTION_MAX_SEATS`.
- Relocate `ORGANIZATION_SUBSCRIPTION_MIN_SEATS` and `ORGANIZATION_SUBSCRIPTION_MAX_SEATS` into `@bike4mind/common` (the persistence layer needs the ceiling and cannot import from the app); `apps/client/lib/subscriptions/constants.ts` re-exports them, so every existing importer is unchanged.
- Update the `addMemberRaisingSeats` model + interface docstrings, the `applyPartnerRuleMembership` result/type/inspect docstrings, and the `validateSeatChange` docstring to describe the clamp and the third null cause.
- Tests: at-MAX clamp rejects (no wedge) + just-below-MAX still raises (boundary); non-Stripe at-capacity outcome; over-capacity one-step downward recovery + below-max rejection + raise-past-max rejection. The three UI/checkout clamps (the two client components and `subscribe.ts`, a Stripe-checkout endpoint) have no co-located test harness; they are one-line `Math.min(..., MAX)` mirrors of the tested server floor and are verified by the manual QA / screenshots above.

## Guide for Testers

What you are checking: an organization that was "stuck" - its seat count could not be changed at all - can now be fixed from the admin screen. You only need an admin login; no database or code access.

**Before you start (a developer does this once):** a throwaway test organization named `T1424-Repro` is set up at the 100-seat cap on the preview environment. The bug only appears when an org is exactly at the cap, so this org is pre-filled for you. If it is not there, ask a maintainer to seed it.

**Steps (in the preview environment, signed in as an admin):**

1. Go to the admin area -> **Organizations**.
2. Find the organization named `T1424-Repro` and click its **Adjust seats** action.
3. In the popup, confirm the top line reads: `Current seats: 100. Members: 101. Minimum allowed: 100`.
4. Leave the "New seat count" box at `100` and click **Update seats**. Expected: a green `Seats updated` confirmation appears and the popup closes. (Before the fix, this same click showed a red `Minimum required seats: 101` error and nothing saved.)
5. Open **Adjust seats** again and type `99` in the box. Expected: it changes back to `100` on its own - you cannot set it below 100.
6. Type `101` and click **Update seats**. Expected: a red `Too big: expected number to be <=100` error - it will not save above 100.

### Regression Checks

1. On a **different organization that is NOT at the cap**, open **Adjust seats** and change the seat count up and down within the allowed range. Expected: it saves normally, and `Minimum allowed` matches that org's real team size.
2. Signing up for or paying for a subscription on a normal (under-cap) organization works exactly as before.

### What NOT to test

- The `Members: 101` line in the popup is correct - it is the real number of people in the org. Only the `Minimum allowed` is capped at 100. This is intended, not a bug.
- Billing amounts and Stripe quantity changes for normal subscriptions are unchanged.

### Covered by automated tests / developer verification (no manual QA needed)

- The partner-rule backfill preview capping its projected seats at 100, and the over-the-cap candidates being reported as "at capacity" instead of wedging the org.
- The self-serve checkout minimum clamp for an over-cap org.

## Additional Information

The seat clamp reuses the exact `$expr`/`$size` atomic-guard pattern already proven for `addMemberIfUnderCeiling`, so it inherits the same single-document concurrency safety: by that atomic guard, `seats` cannot grow past the maximum even under concurrent joins. The `at-capacity` outcome, its admin alert, and the backfill tally were already wired end-to-end from #1239; this change only makes the non-Stripe path able to reach them.

Because member accounting excludes the owner (`users.length`) while the seat floor includes it (`users.length + 1`), an org filled to exactly 100 members reads as team size 101 but its enforced minimum is clamped to the 100-seat cap. The modal reflects this: `Members: 101` (true headcount) alongside `Minimum allowed: 100` (the recovery floor). This owner-counting split is pre-existing; the PR clamps the server floor and every UI and checkout mirror of it so the recovery is consistent and reachable.

## Developer Notes

- `ORGANIZATION_SUBSCRIPTION_MIN_SEATS` / `ORGANIZATION_SUBSCRIPTION_MAX_SEATS` now live in `@bike4mind/common` (re-exported from `@client/lib/subscriptions/constants`), so seat policy can be enforced from the persistence layer as well as the app - any future core-layer seat guard can import the ceiling directly.
- `addMemberRaisingSeats` now has a documented three-cause null contract (already-member, org-gone, at-ceiling); callers distinguish the at-ceiling case via `inspectAfterNoMatch`'s `absent` state.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - admin Adjust-seats modal shows the correct `Minimum allowed`, and the `Seats updated` toast fires on recovery
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (docstrings updated)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
