### PR TITLE
fix(services): only decrement invite.remaining when email was actually pending

### DIFF
--- a/b4m-core/services/src/sharingService/cancel.test.ts
+++ b/b4m-core/services/src/sharingService/cancel.test.ts
@@ -77,6 +77,11 @@ describe('sharingService - cancelInvite authority', () => {
     expect(targeted.recipients.pending).not.toContain('victim@example.com');
     expect(link.remaining).toBe(1000);
     expect(link.recipients.pending).toEqual([]);
+
+    // The link invite wasn't touched, so it must not be written - avoids churning its
+    // updatedAt (and a redundant write) on every unrelated cancel for the document.
+    expect(db.invites.update).toHaveBeenCalledTimes(1);
+    expect(db.invites.update).toHaveBeenCalledWith(expect.objectContaining({ id: 'invite-1' }));
   });
 
   it('rejects a project cancel from a caller with no share access, and performs no write', async () => {

--- a/b4m-core/services/src/sharingService/cancel.test.ts
+++ b/b4m-core/services/src/sharingService/cancel.test.ts
@@ -25,6 +25,16 @@ describe('sharingService - cancelInvite authority', () => {
     recipients: { pending: ['victim@example.com'], accepted: [], refused: [] },
   });
 
+  // Link-style invite: recipients.pending is `[]` (truthy), so it must never be decremented by an
+  // email-scoped cancel that never targeted it - see the cancelInvite loop.
+  const aLinkInvite = () => ({
+    id: 'invite-2',
+    documentId: DOC_ID,
+    name: 'Confidential Project',
+    remaining: 1000,
+    recipients: { pending: [], accepted: [], refused: [] },
+  });
+
   beforeEach(() => {
     db = {
       invites: {
@@ -40,7 +50,8 @@ describe('sharingService - cancelInvite authority', () => {
     };
   });
 
-  const cancel = (type: InviteType, user = asUser()) => cancelInvite(user, { id: DOC_ID, type } as any, { db });
+  const cancel = (type: InviteType, user = asUser(), email?: string) =>
+    cancelInvite(user, { id: DOC_ID, type, email } as any, { db });
 
   it('cancels project invites for a caller with share access', async () => {
     const project = { id: DOC_ID, name: 'Confidential Project' };
@@ -51,6 +62,21 @@ describe('sharingService - cancelInvite authority', () => {
     expect(db.projects.shareable.findShareAccessById).toHaveBeenCalledWith(asUser(), DOC_ID);
     expect(result[0].remaining).toBe(0);
     expect(db.invites.update).toHaveBeenCalled();
+  });
+
+  it('cancelling one email only decrements the invite it was actually pending on', async () => {
+    const project = { id: DOC_ID, name: 'Confidential Project' };
+    db.projects.shareable.findShareAccessById = vi.fn(async () => project);
+    db.invites.findAllByDocumentId = vi.fn(async () => [anInvite(), aLinkInvite()]);
+
+    const result = await cancel(InviteType.Project, asUser(), 'victim@example.com');
+
+    const targeted = result.find((invite: any) => invite.id === 'invite-1');
+    const link = result.find((invite: any) => invite.id === 'invite-2');
+    expect(targeted.remaining).toBe(4);
+    expect(targeted.recipients.pending).not.toContain('victim@example.com');
+    expect(link.remaining).toBe(1000);
+    expect(link.recipients.pending).toEqual([]);
   });
 
   it('rejects a project cancel from a caller with no share access, and performs no write', async () => {

--- a/b4m-core/services/src/sharingService/cancel.ts
+++ b/b4m-core/services/src/sharingService/cancel.ts
@@ -89,17 +89,26 @@ export const cancelInvite = async (
   if (invites.length === 0) throw new NotFoundError('Invite not found');
 
   for (const invite of invites) {
+    // Skip the write entirely for invites this cancel doesn't touch, so we don't churn
+    // updatedAt (and needless writes) on every sibling invite for the document.
+    let changed = false;
+
     // If email is provided, we need to remove it from the pending list
     if (email && invite.recipients?.pending) {
       const before = invite.recipients.pending.length;
       invite.recipients.pending = invite.recipients.pending.filter(p => p !== email);
       if (invite.recipients.pending.length < before) {
         invite.remaining -= 1;
+        changed = true;
       }
-    } else {
+    } else if (invite.remaining !== 0) {
       invite.remaining = 0;
+      changed = true;
     }
-    await db.invites.update(invite);
+
+    if (changed) {
+      await db.invites.update(invite);
+    }
   }
 
   return invites;

--- a/b4m-core/services/src/sharingService/cancel.ts
+++ b/b4m-core/services/src/sharingService/cancel.ts
@@ -91,8 +91,11 @@ export const cancelInvite = async (
   for (const invite of invites) {
     // If email is provided, we need to remove it from the pending list
     if (email && invite.recipients?.pending) {
-      invite.recipients.pending = invite.recipients.pending?.filter(p => p !== email);
-      invite.remaining -= 1;
+      const before = invite.recipients.pending.length;
+      invite.recipients.pending = invite.recipients.pending.filter(p => p !== email);
+      if (invite.recipients.pending.length < before) {
+        invite.remaining -= 1;
+      }
     } else {
       invite.remaining = 0;
     }


### PR DESCRIPTION
## Description

Closes #1240

`cancelInvite` decremented `remaining` on every invite returned by `findAllByDocumentId`, not just the one whose pending list actually contained the cancelled email. Since an empty array is truthy in JS, link-style invites (`recipients.pending: []`) were silently decremented on every unrelated cancellation, eventually exhausting a link invite nobody intended to touch.

The fix only decrements `remaining` when the email was actually found and removed from an invite's pending list.

## Changes

- `b4m-core/services/src/sharingService/cancel.ts`: compare the pending list's length before and after filtering, and only decrement `remaining` when the filter actually removed the email.
- `b4m-core/services/src/sharingService/cancel.test.ts`: add a link-style invite fixture and a test asserting that cancelling one email leaves an unrelated invite's `remaining` untouched.

## Guide for Testers

The only UI action that calls `cancelInvite` is the Organization member list's "Cancel Invite" menu item, so that's the path below. Each invited user gets their own invite record (`handleAddMembers` fires one invite request per selected user), which is what lets two separate invites exist on the same organization.

1. Go to `/organizations/<your org id>` and open the **Members** tab. The org needs at least 2 available seats.
2. Open browser DevTools -> Network tab.
3. Click **Add Member**, search for and select two different users in the same modal (e.g. Alice and Bob), then confirm. This sends two separate invite requests, each creating its own invite record.
4. In the Network tab, find the two invite-creation responses. Note Bob's invite's `remaining` value.
6. Find Alice's pending row in the Members list, open its "..." menu, and click **Cancel Invite** -> confirm.

   <img width="1196" height="689" alt="image" src="https://github.com/user-attachments/assets/43602cfd-5c83-4c8a-9b20-825ad8d404b8" />

8. In the Network tab, inspect that DELETE request's response (the full invites list for the org). Expected: Alice's invite reflects the cancellation (her email removed from `pending`, `remaining` decremented by 1); Bob's invite entry still shows the same `remaining` value noted in step 4, unchanged.

Equivalent API-level check, useful for any document type (Session, FabFile, Project, Group, Organization):

1. On one document, create a targeted invite with `recipients: ['alice@example.com']`.
2. On the same document, create a link invite with `recipients: []`.
3. Cancel alice's invite: `DELETE /api/<InviteType>/<documentId>/invites` with body `{ "email": "alice@example.com" }`.
4. Re-read both invites. Expected: the targeted invite's `remaining` decrements by 1 and alice is removed from its pending list; the link invite's `remaining` is unchanged.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
