### PR TITLE
feat(llm): defer large retrievable knowledge corpus to retrieval instead of inlining

### DIFF
--- a/b4m-core/common/src/schemas/promptMeta.ts
+++ b/b4m-core/common/src/schemas/promptMeta.ts
@@ -148,6 +148,20 @@ const PromptMetaContextSchema = z.object({
   globalSystemFileIds: z.array(z.string()).optional(),
   userSystemFileIds: z.array(z.string()).optional(),
   projectSystemFileIds: z.array(z.string()).optional(),
+  // What the assembler decided about inlining the attached knowledge corpus vs deferring it to
+  // the offered search_knowledge_base tool. Pairs with `offeredTools` + `tokensBySource.fabFiles`
+  // so one row shows: tools offered, docs deferred, resulting inline token cost. `deferredCount`
+  // counts only the RETRIEVABLE subset (docs the tool can actually reach); non-retrievable
+  // attachments are always inlined and never counted here.
+  knowledgeInlining: z
+    .object({
+      attachedCount: z.number(),
+      retrievableCount: z.number(),
+      deferredCount: z.number(),
+      deferredToRetrieval: z.boolean(),
+      minInlineTokensPerDoc: z.number(),
+    })
+    .optional(),
   // Phase 2: Context window debug fields
   contextWindowUsage: z
     .object({

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -354,6 +354,7 @@ export const SettingKeySchema = z.enum([
   'EnableContextTelemetry',
   'contextTelemetryAlerts',
   'ContextVerbatimWindowFraction',
+  'CorpusRetrievalMinInlineTokensPerDoc',
 
   // SRE AGENT SETTINGS
   'sreAgentConfig',
@@ -3545,6 +3546,17 @@ export const settingsMap = {
       'Fraction of a model usable input budget (context window minus reserved output) kept as verbatim conversation history before older turns are summarized into working memory. Lower = compact sooner (cheaper, less verbatim detail); higher = keep more raw history.',
     category: 'AI',
     order: 121,
+  }),
+  CorpusRetrievalMinInlineTokensPerDoc: makeNumberSetting({
+    key: 'CorpusRetrievalMinInlineTokensPerDoc',
+    name: 'Corpus Retrieval Min Inline Tokens Per Doc',
+    defaultValue: 0,
+    min: 0,
+    max: 100000,
+    description:
+      'When a session has a large RETRIEVABLE knowledge corpus attached, stop force-inlining it and let the offered search_knowledge_base tool fetch the relevant docs on demand, IF the even-split inline depth (attached-content budget / retrievable doc count) would fall below this many tokens per doc. 0 disables (always inline). Only documents the retrieval tool can actually reach are ever deferred; other attachments always inline.',
+    category: 'AI',
+    order: 122,
   }),
   sreAgentConfig: makeObjectSetting({
     key: 'sreAgentConfig',

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -330,8 +330,12 @@ describe('ChatCompletionProcess', () => {
     // The suite mocks @bike4mind/utils wholesale (getSettingsValue -> vi.fn() -> undefined). Restore
     // the production-equivalent numeric coercion so the threshold read behaves realistically here.
     beforeEach(() => {
-      mockedGetSettingsValue.mockImplementation(((key: string, settings: Record<string, string>) =>
-        settings?.[key] !== undefined ? Number(settings[key]) : undefined) as typeof getSettingsValue);
+      mockedGetSettingsValue.mockImplementation(((key: string, settings: Record<string, string>) => {
+        const v = settings?.[key];
+        if (v === undefined) return undefined;
+        // Only the threshold is numeric; other keys (e.g. defaultEmbeddingModel) stay strings.
+        return key === 'CorpusRetrievalMinInlineTokensPerDoc' ? Number(v) : v;
+      }) as typeof getSettingsValue);
     });
     afterEach(() => {
       mockedGetSettingsValue.mockReset();
@@ -339,11 +343,18 @@ describe('ChatCompletionProcess', () => {
 
     // Helper: partition knowledge ids into deferred vs inlined for a given lake/threshold setup.
     const runPlan = async (opts: {
-      files: Array<{ id: string; tags: Array<{ name: string }> }>;
+      files: Array<{
+        id: string;
+        tags: Array<{ name: string }>;
+        chunkCount?: number;
+        vectorizedChunkCount?: number;
+        embeddingModel?: string;
+      }>;
       dataLakeTags: string[];
       threshold: string | undefined;
       attachedFileTokenBudget: number;
       skipAutoOffers?: boolean;
+      queryEmbeddingModel?: string;
     }) => {
       // Seed the per-turn access memo directly (getAccessibleDataLakeAccess returns it when set),
       // so the plan uses these tags without exercising the DB-backed resolver.
@@ -358,12 +369,28 @@ describe('ChatCompletionProcess', () => {
         sessionKnowledgeIds: opts.files.map(f => f.id),
         attachedFileTokenBudget: opts.attachedFileTokenBudget,
         skipAutoOffers: opts.skipAutoOffers ?? false,
-        defaultAdminSettings: opts.threshold ? { CorpusRetrievalMinInlineTokensPerDoc: opts.threshold } : {},
+        defaultAdminSettings: {
+          ...(opts.threshold ? { CorpusRetrievalMinInlineTokensPerDoc: opts.threshold } : {}),
+          // The query embedding model; a doc is retrievable only if embedded under the same one.
+          // Defaults to the model the fixtures embed under ('model-A') unless a test overrides it.
+          ...(opts.queryEmbeddingModel === undefined
+            ? { defaultEmbeddingModel: 'model-A' }
+            : { defaultEmbeddingModel: opts.queryEmbeddingModel }),
+        },
       });
     };
 
-    const lakeFiles = (n: number, tag = 'datalake:corpus') =>
-      Array.from({ length: n }, (_, i) => ({ id: `k${i}`, tags: [{ name: tag }] }));
+    // Retrievable-by-default fixtures: fully vectorized and embedded under the query model ('model-A').
+    // Pass `over` to make an unvectorized / wrong-model / partially-vectorized variant.
+    const lakeFiles = (n: number, tag = 'datalake:corpus', over: Record<string, unknown> = {}) =>
+      Array.from({ length: n }, (_, i) => ({
+        id: `k${i}`,
+        tags: [{ name: tag }],
+        chunkCount: 2,
+        vectorizedChunkCount: 2,
+        embeddingModel: 'model-A',
+        ...over,
+      }));
 
     it('defers the whole corpus when every doc is lake-tagged and the split goes shallow', async () => {
       const plan = await runPlan({
@@ -401,6 +428,59 @@ describe('ChatCompletionProcess', () => {
       });
       expect(plan.deferredToRetrieval).toBe(false);
       expect(plan.deferredKnowledgeIds).toHaveLength(0);
+    });
+
+    it('excludes lake-tagged but UNVECTORIZED docs - the search tool cannot surface them (#1411 gap)', async () => {
+      const vectorized = lakeFiles(30); // k0..k29, fully vectorized under the query model
+      const unvectorized = lakeFiles(10, 'datalake:corpus', { chunkCount: 0, vectorizedChunkCount: 0 }).map(f => ({
+        ...f,
+        id: `u${f.id}`,
+      }));
+      const plan = await runPlan({
+        files: [...vectorized, ...unvectorized],
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000, // 4000/30 = 133 < 500
+      });
+      expect(plan.deferredToRetrieval).toBe(true);
+      expect(plan.retrievableCount).toBe(30); // only the vectorized docs count
+      expect(plan.deferredKnowledgeIds).toHaveLength(30);
+      expect(plan.deferredKnowledgeIds.some((id: string) => id.startsWith('u'))).toBe(false);
+    });
+
+    it('excludes a partially-vectorized doc (vectorizedChunkCount < chunkCount)', async () => {
+      const plan = await runPlan({
+        files: lakeFiles(40, 'datalake:corpus', { chunkCount: 4, vectorizedChunkCount: 2 }),
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000,
+      });
+      expect(plan.deferredToRetrieval).toBe(false);
+      expect(plan.retrievableCount).toBe(0);
+    });
+
+    it('excludes lake-tagged docs embedded under a DIFFERENT model than the query', async () => {
+      const plan = await runPlan({
+        files: lakeFiles(40, 'datalake:corpus', { embeddingModel: 'model-B' }),
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000,
+        queryEmbeddingModel: 'model-A',
+      });
+      expect(plan.deferredToRetrieval).toBe(false);
+      expect(plan.retrievableCount).toBe(0);
+    });
+
+    it('defers nothing when the query embedding model is unresolvable (semantic arm cannot run)', async () => {
+      const plan = await runPlan({
+        files: lakeFiles(40), // vectorized under 'model-A', but the query has no model
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000,
+        queryEmbeddingModel: '',
+      });
+      expect(plan.deferredToRetrieval).toBe(false);
+      expect(plan.retrievableCount).toBe(0);
     });
 
     it('keeps a small corpus inlined (per-doc share stays above the floor)', async () => {

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -3,6 +3,7 @@ import {
   ChatCompletionProcess,
   addPairedTool,
   resolveEnabledTools,
+  shouldDeferCorpusToRetrieval,
   computeSettlementDelta,
   clampFraction,
   dropOldestHistoryTurn,
@@ -21,6 +22,7 @@ import {
   getLlmWithFallback,
   usdToCredits,
   usdToCreditsStochastic,
+  getSettingsValue,
 } from '@bike4mind/utils';
 import { getLlmByModel, getAvailableModels } from '@bike4mind/llm-adapters';
 import {
@@ -128,6 +130,7 @@ const mockedIsOverloadedError = vi.mocked(isOverloadedError);
 const mockedGetLlmWithFallback = vi.mocked(getLlmWithFallback);
 const mockedUsdToCredits = vi.mocked(usdToCredits);
 const mockedUsdToCreditsStochastic = vi.mocked(usdToCreditsStochastic);
+const mockedGetSettingsValue = vi.mocked(getSettingsValue);
 const mockedCalculateTotalTokenLength = vi.mocked(calculateTotalTokenLength);
 
 const mockDb = {};
@@ -301,7 +304,7 @@ describe('ChatCompletionProcess', () => {
       // The `=== undefined` sentinel is what makes a false result stick. A falsy check would
       // re-run the DB lookup every turn for every caller who has no lake - the common case.
       const findLakes = vi.fn().mockResolvedValue([]);
-      (service as any).hasAccessibleKnowledgeLakeMemo = undefined;
+      (service as any).accessibleDataLakeAccessMemo = undefined;
       (service as any).db = { dataLakes: { findActiveByUserTagsAndEntitlements: findLakes } };
       (service as any).getEntitlements = vi.fn().mockResolvedValue([]);
       (service as any).entitlementsResolved = false;
@@ -313,12 +316,147 @@ describe('ChatCompletionProcess', () => {
     });
 
     it('fails SAFE to false and warns when the lookup throws - never breaks the turn', async () => {
-      (service as any).hasAccessibleKnowledgeLakeMemo = undefined;
+      (service as any).accessibleDataLakeAccessMemo = undefined;
       // No db at all: the access resolver dereferences `db.dataLakes` and throws.
       (service as any).db = undefined;
       (service as any).logger = { warn: vi.fn() };
 
       await expect(service.userHasAccessibleKnowledgeLake()).resolves.toBe(false);
+      expect((service as any).logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveCorpusInlinePlan (defer only the tool-retrievable corpus subset)', () => {
+    // The suite mocks @bike4mind/utils wholesale (getSettingsValue -> vi.fn() -> undefined). Restore
+    // the production-equivalent numeric coercion so the threshold read behaves realistically here.
+    beforeEach(() => {
+      mockedGetSettingsValue.mockImplementation(((key: string, settings: Record<string, string>) =>
+        settings?.[key] !== undefined ? Number(settings[key]) : undefined) as typeof getSettingsValue);
+    });
+    afterEach(() => {
+      mockedGetSettingsValue.mockReset();
+    });
+
+    // Helper: partition knowledge ids into deferred vs inlined for a given lake/threshold setup.
+    const runPlan = async (opts: {
+      files: Array<{ id: string; tags: Array<{ name: string }> }>;
+      dataLakeTags: string[];
+      threshold: string | undefined;
+      attachedFileTokenBudget: number;
+      skipAutoOffers?: boolean;
+    }) => {
+      // Seed the per-turn access memo directly (getAccessibleDataLakeAccess returns it when set),
+      // so the plan uses these tags without exercising the DB-backed resolver.
+      (service as any).accessibleDataLakeAccessMemo = {
+        dataLakeTags: opts.dataLakeTags,
+        dataLakeTagPrefixes: [],
+        scopedTagPrefixes: [],
+      };
+      (service as any).getScopeFilter = vi.fn().mockReturnValue({});
+      (service as any).db = { fabfiles: { getAccessibleFiles: vi.fn().mockResolvedValue(opts.files) } };
+      return (service as any).resolveCorpusInlinePlan({
+        sessionKnowledgeIds: opts.files.map(f => f.id),
+        attachedFileTokenBudget: opts.attachedFileTokenBudget,
+        skipAutoOffers: opts.skipAutoOffers ?? false,
+        defaultAdminSettings: opts.threshold ? { CorpusRetrievalMinInlineTokensPerDoc: opts.threshold } : {},
+      });
+    };
+
+    const lakeFiles = (n: number, tag = 'datalake:corpus') =>
+      Array.from({ length: n }, (_, i) => ({ id: `k${i}`, tags: [{ name: tag }] }));
+
+    it('defers the whole corpus when every doc is lake-tagged and the split goes shallow', async () => {
+      const plan = await runPlan({
+        files: lakeFiles(40),
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000, // 4000/40 = 100 < 500
+      });
+      expect(plan.deferredToRetrieval).toBe(true);
+      expect(plan.deferredKnowledgeIds).toHaveLength(40);
+      expect(plan.retrievableCount).toBe(40);
+    });
+
+    it('excludes non-lake-tagged attachments from the deferred set (core regression guard)', async () => {
+      const files = [...lakeFiles(30), { id: 'personal1', tags: [{ name: 'notes' }] }, { id: 'personal2', tags: [] }];
+      const plan = await runPlan({
+        files,
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000, // 4000/30 = 133 < 500
+      });
+      expect(plan.deferredToRetrieval).toBe(true);
+      expect(plan.retrievableCount).toBe(30);
+      expect(plan.deferredKnowledgeIds).toHaveLength(30);
+      expect(plan.deferredKnowledgeIds).not.toContain('personal1');
+      expect(plan.deferredKnowledgeIds).not.toContain('personal2');
+    });
+
+    it('defers nothing when the caller has no accessible lake (nothing is retrievable)', async () => {
+      const plan = await runPlan({
+        files: lakeFiles(40),
+        dataLakeTags: [],
+        threshold: '500',
+        attachedFileTokenBudget: 4000,
+      });
+      expect(plan.deferredToRetrieval).toBe(false);
+      expect(plan.deferredKnowledgeIds).toHaveLength(0);
+    });
+
+    it('keeps a small corpus inlined (per-doc share stays above the floor)', async () => {
+      const plan = await runPlan({
+        files: lakeFiles(3),
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000, // 4000/3 = 1333 >= 500
+      });
+      expect(plan.deferredToRetrieval).toBe(false);
+      expect(plan.deferredKnowledgeIds).toHaveLength(0);
+      expect(plan.retrievableCount).toBe(3);
+    });
+
+    it('defers nothing when the threshold is unset (feature off = today behavior)', async () => {
+      const plan = await runPlan({
+        files: lakeFiles(40),
+        dataLakeTags: ['datalake:corpus'],
+        threshold: undefined,
+        attachedFileTokenBudget: 4000,
+      });
+      expect(plan.deferredToRetrieval).toBe(false);
+      expect(plan.deferredKnowledgeIds).toHaveLength(0);
+    });
+
+    it('defers nothing under promptMode (skipAutoOffers) and never reads files', async () => {
+      (service as any).accessibleDataLakeAccessMemo = undefined;
+      const getAccessibleFiles = vi.fn();
+      (service as any).db = { fabfiles: { getAccessibleFiles } };
+      const plan = await (service as any).resolveCorpusInlinePlan({
+        sessionKnowledgeIds: ['k0', 'k1'],
+        attachedFileTokenBudget: 4000,
+        skipAutoOffers: true,
+        defaultAdminSettings: { CorpusRetrievalMinInlineTokensPerDoc: '500' },
+      });
+      expect(plan.deferredToRetrieval).toBe(false);
+      expect(plan.deferredKnowledgeIds).toHaveLength(0);
+      expect(getAccessibleFiles).not.toHaveBeenCalled();
+    });
+
+    it('fails SAFE (inline all) and warns when the file read throws', async () => {
+      (service as any).accessibleDataLakeAccessMemo = {
+        dataLakeTags: ['datalake:corpus'],
+        dataLakeTagPrefixes: [],
+        scopedTagPrefixes: [],
+      };
+      (service as any).getScopeFilter = vi.fn().mockReturnValue({});
+      (service as any).db = { fabfiles: { getAccessibleFiles: vi.fn().mockRejectedValue(new Error('db down')) } };
+      (service as any).logger = { warn: vi.fn() };
+      const plan = await (service as any).resolveCorpusInlinePlan({
+        sessionKnowledgeIds: ['k0'],
+        attachedFileTokenBudget: 4000,
+        skipAutoOffers: false,
+        defaultAdminSettings: { CorpusRetrievalMinInlineTokensPerDoc: '500' },
+      });
+      expect(plan.deferredKnowledgeIds).toHaveLength(0);
       expect((service as any).logger.warn).toHaveBeenCalled();
     });
   });
@@ -2393,6 +2531,41 @@ describe('resolveEnabledTools', () => {
     });
     const twice = resolveEnabledTools({ requestTools: once, hasAttachedKnowledge: true });
     expect(twice).toEqual(once);
+  });
+});
+
+describe('shouldDeferCorpusToRetrieval (per-doc even-split depth floor)', () => {
+  it('is OFF (never defers) when the threshold is 0, regardless of size', () => {
+    expect(
+      shouldDeferCorpusToRetrieval({ retrievableCount: 40, attachedFileTokenBudget: 4000, minInlineTokensPerDoc: 0 })
+    ).toBe(false);
+  });
+
+  it('defers when the per-doc split falls below the floor (large corpus)', () => {
+    // 4000 / 40 = 100 < 500
+    expect(
+      shouldDeferCorpusToRetrieval({ retrievableCount: 40, attachedFileTokenBudget: 4000, minInlineTokensPerDoc: 500 })
+    ).toBe(true);
+  });
+
+  it('keeps a small corpus inlined (per-doc split stays above the floor)', () => {
+    // 4000 / 3 = 1333 >= 500
+    expect(
+      shouldDeferCorpusToRetrieval({ retrievableCount: 3, attachedFileTokenBudget: 4000, minInlineTokensPerDoc: 500 })
+    ).toBe(false);
+  });
+
+  it('treats the floor as strict (depth exactly equal to the floor stays inlined)', () => {
+    // 1000 / 2 = 500, not < 500
+    expect(
+      shouldDeferCorpusToRetrieval({ retrievableCount: 2, attachedFileTokenBudget: 1000, minInlineTokensPerDoc: 500 })
+    ).toBe(false);
+  });
+
+  it('never defers when nothing is retrievable', () => {
+    expect(
+      shouldDeferCorpusToRetrieval({ retrievableCount: 0, attachedFileTokenBudget: 4000, minInlineTokensPerDoc: 500 })
+    ).toBe(false);
   });
 });
 

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -270,6 +270,19 @@ const ATTACHED_CONTENT_SHARE = 0.35;
 const MIN_ATTACHED_CONTENT_SHARE = 0.15;
 
 /**
+ * Below this per-doc even-split inline depth (tokens), inlining a RETRIEVABLE data-lake corpus
+ * goes breadth-shallow: buildDataSources splits attachedFileTokenBudget evenly across every file
+ * (processFabFilesServer in utils.ts), so many docs each get a thin, poorly-ranked slice - which
+ * an internal eval scored WORSE than deferring the corpus to the offered search_knowledge_base
+ * tool. When the estimated depth falls below this floor AND the corpus is retrievable, defer it.
+ *
+ * 0 = OFF (preserve today's force-inline) and is the default until tuned; override per-deploy via
+ * the `CorpusRetrievalMinInlineTokensPerDoc` admin setting. Expressed in tokens-per-doc, not a raw
+ * doc count, so the threshold auto-scales with the model's window through attachedFileTokenBudget.
+ */
+const CORPUS_RETRIEVAL_MIN_INLINE_TOKENS_PER_DOC = 0;
+
+/**
  * Fraction of the space ACTUALLY AVAILABLE FOR HISTORY (safe input minus the
  * non-history overhead reserved below) kept as VERBATIM conversation history
  * before older turns are folded into contextSummary. The fraction tunes the
@@ -618,6 +631,29 @@ export function resolveEnabledTools(input: ResolveEnabledToolsInput): string[] {
 }
 
 /**
+ * Whether to stop force-inlining a retrievable data-lake corpus and let the offered
+ * search_knowledge_base tool fetch it on demand. Pure so it is unit-testable in isolation from the
+ * DB reads that produce `retrievableCount`.
+ *
+ * The condition is the per-doc even-split depth falling below the floor: attachedFileTokenBudget is
+ * divided evenly across the inlined files (processFabFilesServer), so a large corpus gives each doc
+ * a shallow slice. `retrievableCount` (not the full attached count) is the divisor on purpose - it
+ * is the set eligible to defer, and the real per-file split includes the always-inlined sources
+ * too, so this estimate is <= the real depth: if it already trips the floor, the real split is
+ * definitely shallow. Small corpora keep a high per-doc share and stay inlined (strictly better).
+ */
+export function shouldDeferCorpusToRetrieval(input: {
+  retrievableCount: number;
+  attachedFileTokenBudget: number;
+  minInlineTokensPerDoc: number;
+}): boolean {
+  const { retrievableCount, attachedFileTokenBudget, minInlineTokensPerDoc } = input;
+  if (minInlineTokensPerDoc <= 0) return false; // feature off -> today's force-inline behavior
+  if (retrievableCount <= 0) return false; // nothing retrievable -> never defer (would lose content)
+  return Math.floor(attachedFileTokenBudget / retrievableCount) < minInlineTokensPerDoc;
+}
+
+/**
  * Tools this process auto-adds server-side regardless of user selection. Two auto-add sites feed
  * this: the request-parse method (blog_publish/blog_edit/blog_draft for admins, navigate_view,
  * skill) and `resolveEnabledTools` (the attached-knowledge offer). Small local (Ollama) models get
@@ -677,8 +713,13 @@ export class ChatCompletionProcess {
   public entitlementKeys: string[] = [];
   private getEntitlements: IChatCompletionServiceOptions['getEntitlements'];
   private entitlementsResolved = false;
-  /** Per-turn memo for the accessible-owned-lake offering check (see userHasAccessibleKnowledgeLake). */
-  private hasAccessibleKnowledgeLakeMemo: boolean | undefined;
+  /**
+   * Per-turn memo for the caller's resolved data-lake access. Shared by the tool-offer check
+   * (userHasAccessibleKnowledgeLake) and the corpus inline-defer plan (resolveCorpusInlinePlan) so
+   * the two can never disagree - it is the SAME access the knowledge tool resolves with.
+   */
+  private accessibleDataLakeAccessMemo:
+    { dataLakeTags: string[]; dataLakeTagPrefixes: string[]; scopedTagPrefixes: string[] } | undefined;
   private storage: IChatCompletionServiceOptions['storage'];
   private imageGenerateStorage: IChatCompletionServiceOptions['imageGenerateStorage'];
   private imageProcessorLambdaName?: string;
@@ -788,25 +829,118 @@ export class ChatCompletionProcess {
    * from lakes the caller was already authorized to read - this signal never widens that set.
    */
   public async userHasAccessibleKnowledgeLake(): Promise<boolean> {
-    if (this.hasAccessibleKnowledgeLakeMemo === undefined) {
+    return (await this.getAccessibleDataLakeAccess()).dataLakeTags.length > 0;
+  }
+
+  /**
+   * The caller's resolved data-lake access (owned + org + shared/entitlement-gated lakes they can
+   * reach), memoized per turn. This is the SAME resolver the knowledge tool executes with, so the
+   * tool-offer and the inline-defer decisions can never disagree. Fail-safe: any error degrades to
+   * empty access (treated as "no lake"), never breaks the turn.
+   */
+  private async getAccessibleDataLakeAccess(): Promise<{
+    dataLakeTags: string[];
+    dataLakeTagPrefixes: string[];
+    scopedTagPrefixes: string[];
+  }> {
+    if (this.accessibleDataLakeAccessMemo === undefined) {
       try {
         const entitlementKeys = await this.resolveEntitlementKeys();
-        const { dataLakeTags } = await getDynamicDataLakeAccess({
+        this.accessibleDataLakeAccessMemo = await getDynamicDataLakeAccess({
           db: this.db,
           user: this.user,
           entitlementKeys,
         });
-        this.hasAccessibleKnowledgeLakeMemo = dataLakeTags.length > 0;
       } catch (err) {
-        // Never break a chat turn over an offering hint - degrade to "no lake" (the tool simply
-        // isn't auto-offered), matching the entitlement-resolution fail-safe above.
         this.logger.warn(
-          `[dataLakes] accessible-lake offering check failed; not auto-offering: ${(err as Error)?.message}`
+          `[dataLakes] accessible-lake resolution failed; treating as no lake: ${(err as Error)?.message}`
         );
-        this.hasAccessibleKnowledgeLakeMemo = false;
+        this.accessibleDataLakeAccessMemo = { dataLakeTags: [], dataLakeTagPrefixes: [], scopedTagPrefixes: [] };
       }
     }
-    return this.hasAccessibleKnowledgeLakeMemo;
+    return this.accessibleDataLakeAccessMemo;
+  }
+
+  /**
+   * Decide which attached-knowledge documents to STOP inlining and leave to the offered
+   * search_knowledge_base tool. Returns the deferred id subset plus telemetry. See
+   * `shouldDeferCorpusToRetrieval` for the size rule and `CORPUS_RETRIEVAL_MIN_INLINE_TOKENS_PER_DOC`
+   * for why this is off by default.
+   *
+   * Anti-regression is the whole design: a file is deferrable ONLY when the tool can actually reach
+   * it, which for the unscoped semantic arm means an EXACT match against the caller's accessible
+   * `dataLakeTags` (the ownership-independent membership branch). Prefix-only / non-lake attachments
+   * are never deferred - they stay inlined, because deferring content the tool cannot fetch would
+   * silently lose it. Only `sessionKnowledgeIds` are ever considered; message- and session-attached
+   * fab files and system files are always inlined by the caller.
+   */
+  private async resolveCorpusInlinePlan(input: {
+    sessionKnowledgeIds: string[];
+    attachedFileTokenBudget: number;
+    skipAutoOffers: boolean;
+    defaultAdminSettings: Record<string, string>;
+  }): Promise<{
+    deferredKnowledgeIds: string[];
+    attachedCount: number;
+    retrievableCount: number;
+    deferredToRetrieval: boolean;
+    minInlineTokensPerDoc: number;
+  }> {
+    const { sessionKnowledgeIds, attachedFileTokenBudget, skipAutoOffers, defaultAdminSettings } = input;
+    const attachedCount = sessionKnowledgeIds.length;
+
+    // getSettingsValue coerces via the setting's Zod schema, so this is a number (0 by default).
+    const rawThreshold = getSettingsValue('CorpusRetrievalMinInlineTokensPerDoc', defaultAdminSettings);
+    const minInlineTokensPerDoc =
+      typeof rawThreshold === 'number' && Number.isFinite(rawThreshold) && rawThreshold >= 0
+        ? rawThreshold
+        : CORPUS_RETRIEVAL_MIN_INLINE_TOKENS_PER_DOC;
+
+    const noDefer = {
+      deferredKnowledgeIds: [] as string[],
+      attachedCount,
+      retrievableCount: 0,
+      deferredToRetrieval: false,
+      minInlineTokensPerDoc,
+    };
+
+    // promptMode is an eval/passthrough surface where the tool is NOT offered - deferring there
+    // would strand the corpus with no retrieval path. Symmetric with the tool-offer gate.
+    if (skipAutoOffers) return noDefer;
+    if (minInlineTokensPerDoc <= 0 || attachedCount === 0) return noDefer;
+
+    try {
+      const access = await this.getAccessibleDataLakeAccess();
+      if (access.dataLakeTags.length === 0) return noDefer; // no accessible lake -> nothing retrievable
+
+      const accessibleTags = new Set(access.dataLakeTags);
+      const scope = this.getScopeFilter(this.user, Permission.read, 'FabFile');
+      const files = await this.db.fabfiles.getAccessibleFiles(sessionKnowledgeIds, scope);
+
+      const retrievableIds = files
+        .filter(file => (file.tags ?? []).some(tag => accessibleTags.has(tag.name)))
+        .map(file => file.id);
+
+      const deferredToRetrieval = shouldDeferCorpusToRetrieval({
+        retrievableCount: retrievableIds.length,
+        attachedFileTokenBudget,
+        minInlineTokensPerDoc,
+      });
+
+      return {
+        deferredKnowledgeIds: deferredToRetrieval ? retrievableIds : [],
+        attachedCount,
+        retrievableCount: retrievableIds.length,
+        deferredToRetrieval,
+        minInlineTokensPerDoc,
+      };
+    } catch (err) {
+      // Never lose content over an optimization: any failure degrades to today's full inline.
+      this.logger.warn(
+        `[dataLakes] corpus inline-defer plan failed; inlining all attached knowledge: ${(err as Error)?.message}`
+      );
+      return noDefer;
+    }
   }
 
   private async initializeProcessContext(
@@ -1843,11 +1977,23 @@ export class ChatCompletionProcess {
         )
       );
 
+      // Once the knowledge tools are offered (above), stop ALSO force-inlining a large retrievable
+      // corpus - the even-split inline goes breadth-shallow and the tool can fetch the relevant
+      // docs on demand. Off by default; defers only the tool-retrievable subset. `skipAutoOffers`
+      // mirrors the tool-offer gate (the tool isn't offered under promptMode, so we don't defer).
+      const corpusInlinePlan = await this.resolveCorpusInlinePlan({
+        sessionKnowledgeIds: session.knowledgeIds ?? [],
+        attachedFileTokenBudget,
+        skipAutoOffers,
+        defaultAdminSettings,
+      });
+
       const dataSources = await this.buildDataSources({
         defaultAdminSettings,
         sessionFabFileIds,
         messageFileIds,
         sessionKnowledgeIds: session.knowledgeIds ?? [],
+        deferredKnowledgeIds: corpusInlinePlan.deferredKnowledgeIds,
         message,
         maxTokens: urlContentBudget,
         attachedFileTokenBudget,
@@ -2733,6 +2879,13 @@ export class ChatCompletionProcess {
       // Add system prompt tracking to promptMeta
       quest.promptMeta!.context!.sessionFileIds = sessionFabFileIds;
       quest.promptMeta!.context!.messageFileIds = messageFileIds;
+      quest.promptMeta!.context!.knowledgeInlining = {
+        attachedCount: corpusInlinePlan.attachedCount,
+        retrievableCount: corpusInlinePlan.retrievableCount,
+        deferredCount: corpusInlinePlan.deferredKnowledgeIds.length,
+        deferredToRetrieval: corpusInlinePlan.deferredToRetrieval,
+        minInlineTokensPerDoc: corpusInlinePlan.minInlineTokensPerDoc,
+      };
       quest.promptMeta!.context!.globalSystemFileIds = globalSystemFileIds;
       quest.promptMeta!.context!.userSystemFileIds = enabledSystemFileIds;
       quest.promptMeta!.context!.dedupedSystemPrompts = dedupedFileIds;
@@ -5080,6 +5233,7 @@ When using tools that require file IDs (like edit_image), use the ID shown above
     sessionFabFileIds,
     messageFileIds,
     sessionKnowledgeIds,
+    deferredKnowledgeIds = [],
     message,
     maxTokens,
     attachedFileTokenBudget,
@@ -5093,6 +5247,9 @@ When using tools that require file IDs (like edit_image), use the ID shown above
     sessionFabFileIds: string[];
     messageFileIds: string[];
     sessionKnowledgeIds: string[];
+    /** Subset of `sessionKnowledgeIds` to leave OUT of the inline merge and defer to retrieval
+     *  (resolveCorpusInlinePlan). Full `sessionKnowledgeIds` is still reported in logs/telemetry. */
+    deferredKnowledgeIds?: string[];
     message: string;
     maxTokens: number;
     attachedFileTokenBudget: number;
@@ -5161,13 +5318,21 @@ When using tools that require file IDs (like edit_image), use the ID shown above
       this.systemFilesCache.set(systemFilesCacheKey, [globalSystemFileIds, enabledSystemFileIds]);
     }
 
+    // Defer the retrievable-corpus subset out of the inline set (resolveCorpusInlinePlan); the
+    // offered search_knowledge_base tool fetches those on demand. Only knowledge IDs are affected -
+    // message/session fab files and system files always inline.
+    const deferred = new Set(deferredKnowledgeIds);
+    const inlineKnowledgeIds = deferred.size
+      ? sessionKnowledgeIds.filter(id => !deferred.has(id))
+      : sessionKnowledgeIds;
+
     // Pre-compute file dedup (synchronous) before deciding whether to skip
     const allFileIdsBeforeDedup = [
       ...sessionFabFileIds,
       ...messageFileIds,
       ...enabledSystemFileIds,
       ...globalSystemFileIds,
-      ...sessionKnowledgeIds,
+      ...inlineKnowledgeIds,
     ];
     const dedupedFileIds = Array.from(new Set(allFileIdsBeforeDedup));
 

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -638,9 +638,13 @@ export function resolveEnabledTools(input: ResolveEnabledToolsInput): string[] {
  * The condition is the per-doc even-split depth falling below the floor: attachedFileTokenBudget is
  * divided evenly across the inlined files (processFabFilesServer), so a large corpus gives each doc
  * a shallow slice. `retrievableCount` (not the full attached count) is the divisor on purpose - it
- * is the set eligible to defer, and the real per-file split includes the always-inlined sources
- * too, so this estimate is <= the real depth: if it already trips the floor, the real split is
- * definitely shallow. Small corpora keep a high per-doc share and stay inlined (strictly better).
+ * is the set eligible to defer. The real per-file split divides the same budget across MORE files
+ * (the always-inlined message/session/system sources share it too), so with
+ * retrievableCount <= totalAttached this estimate is an UPPER bound on the real depth
+ * (budget / retrievableCount >= budget / totalAttached). That biases conservatively in the safe
+ * direction: an estimate below the floor guarantees the real split is below it too, so we never
+ * over-defer - at worst we under-defer a corpus whose real split is shallow but whose estimate
+ * is not. Small corpora keep a high per-doc share and stay inlined (strictly better).
  */
 export function shouldDeferCorpusToRetrieval(input: {
   retrievableCount: number;
@@ -917,6 +921,14 @@ export class ChatCompletionProcess {
       const scope = this.getScopeFilter(this.user, Permission.read, 'FabFile');
       const files = await this.db.fabfiles.getAccessibleFiles(sessionKnowledgeIds, scope);
 
+      // KNOWN GAP: tag membership is necessary but NOT sufficient for retrievability. A doc that
+      // carries an accessible lake tag but is not vectorized yet, or is embedded under a different
+      // model than the current query vector, passes this filter yet search_knowledge_base will not
+      // surface it - deferring it would strand its content silently. This is safe only because the
+      // feature is off by default; before the CorpusRetrievalMinInlineTokensPerDoc rollout the eval
+      // must exclude or account for non-vectorized docs, and the real fix is to gate on
+      // vectorization state + embedding-model agreement here (follow-up on top of #1411, which
+      // hardens the retrieval-side reads this defer relies on).
       const retrievableIds = files
         .filter(file => (file.tags ?? []).some(tag => accessibleTags.has(tag.name)))
         .map(file => file.id);

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -936,6 +936,11 @@ export class ChatCompletionProcess {
           const lakeTagged = (file.tags ?? []).some(tag => accessibleTags.has(tag.name));
           const chunks = file.chunkCount ?? 0;
           const fullyVectorized = chunks > 0 && (file.vectorizedChunkCount ?? 0) >= chunks;
+          // Exact-match on purpose, and deliberately STRICTER than embeddingMismatch's
+          // isForeignEmbeddingModel, which counts an absent/blank label as comparable. Here an
+          // unlabeled-but-vectorized doc stays inlined rather than risk a strand. Do NOT consolidate
+          // this onto isForeignEmbeddingModel - that loosens the gate to defer unlabeled docs the
+          // semantic arm may not actually reach, which is the content-losing direction.
           const sameVectorSpace = Boolean(queryEmbeddingModel) && file.embeddingModel === queryEmbeddingModel;
           return lakeTagged && fullyVectorized && sameVectorSpace;
         })

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -921,16 +921,24 @@ export class ChatCompletionProcess {
       const scope = this.getScopeFilter(this.user, Permission.read, 'FabFile');
       const files = await this.db.fabfiles.getAccessibleFiles(sessionKnowledgeIds, scope);
 
-      // KNOWN GAP: tag membership is necessary but NOT sufficient for retrievability. A doc that
-      // carries an accessible lake tag but is not vectorized yet, or is embedded under a different
-      // model than the current query vector, passes this filter yet search_knowledge_base will not
-      // surface it - deferring it would strand its content silently. This is safe only because the
-      // feature is off by default; before the CorpusRetrievalMinInlineTokensPerDoc rollout the eval
-      // must exclude or account for non-vectorized docs, and the real fix is to gate on
-      // vectorization state + embedding-model agreement here (follow-up on top of #1411, which
-      // hardens the retrieval-side reads this defer relies on).
+      // Retrievability = tag membership AND real vector-search reachability. A lake-tagged doc is
+      // deferrable only if search_knowledge_base's semantic arm can actually surface it: it must be
+      // FULLY VECTORIZED (vectorizedChunkCount >= chunkCount, chunkCount > 0) AND embedded under the
+      // SAME model as the query (embeddingModel agreement). A doc that is unvectorized, still
+      // vectorizing, or embedded in another model's space passes the tag check but the semantic arm
+      // skips it - deferring it would strand its content silently. When the query embedding model is
+      // unresolvable the semantic arm cannot run at all (the tool falls back to metadata-only keyword
+      // search), so nothing is deferrable. Closes the tag-only gap; #1411 hardened the retrieval-side
+      // reads this now relies on. `vectorizedChunkCount >= chunkCount` is the usable-data condition.
+      const queryEmbeddingModel = getSettingsValue('defaultEmbeddingModel', defaultAdminSettings);
       const retrievableIds = files
-        .filter(file => (file.tags ?? []).some(tag => accessibleTags.has(tag.name)))
+        .filter(file => {
+          const lakeTagged = (file.tags ?? []).some(tag => accessibleTags.has(tag.name));
+          const chunks = file.chunkCount ?? 0;
+          const fullyVectorized = chunks > 0 && (file.vectorizedChunkCount ?? 0) >= chunks;
+          const sameVectorSpace = Boolean(queryEmbeddingModel) && file.embeddingModel === queryEmbeddingModel;
+          return lakeTagged && fullyVectorized && sameVectorSpace;
+        })
         .map(file => file.id);
 
       const deferredToRetrieval = shouldDeferCorpusToRetrieval({

--- a/packages/database/src/models/content/QuestModel.ts
+++ b/packages/database/src/models/content/QuestModel.ts
@@ -212,6 +212,15 @@ export const PromptMetaSchema = new Schema<PromptMeta>(
       globalSystemFileIds: { type: [String], required: false, default: undefined },
       userSystemFileIds: { type: [String], required: false, default: undefined },
       projectSystemFileIds: { type: [String], required: false, default: undefined },
+      // Corpus inline-vs-retrieve decision for the turn (ChatCompletionProcess.resolveCorpusInlinePlan).
+      // Must stay in sync with the Zod PromptMeta `context.knowledgeInlining` (parity test enforces it).
+      knowledgeInlining: {
+        attachedCount: { type: Number, required: false },
+        retrievableCount: { type: Number, required: false },
+        deferredCount: { type: Number, required: false },
+        deferredToRetrieval: { type: Boolean, required: false },
+        minInlineTokensPerDoc: { type: Number, required: false },
+      },
       messageTruncation: { type: MessageTruncationSchema, required: false, default: undefined },
       tokensBySource: {
         systemPrompts: { type: Number, required: false },


### PR DESCRIPTION
## Description

Completes the arc started by #1383/#1398 (part of #1395). Those PRs made the knowledge-retrieval tools *offered* whenever a session has attached knowledge; this one stops us *also* force-inlining a large corpus on top of the offer.

`buildDataSources` splits the attached-content token budget **evenly across every attached file**, so a large corpus gives each doc a shallow, poorly-ranked slice (breadth-shallow) rather than a deep, query-ranked retrieval of the relevant ones. When the offered `search_knowledge_base` tool can fetch those docs on demand, inlining them too is redundant and measurably lower-quality.

Closes #1438.

## Why it's not a monkey-patch

The tool-offer decision and the inline decision are two halves of one policy: we defer inlining a corpus *because* we offered a tool that can fetch it. So the decision lives at the call site next to `resolveEnabledTools`; `buildDataSources` stays a dumb "assemble these IDs" function and just receives a `deferredKnowledgeIds` list to leave out of the merge. One new call, one merge-line change.

## The anti-regression core

The offered `search_knowledge_base` unscoped arm only reaches **data-lake-tagged** content; a plain personal attachment that isn't lake-tagged is not retrievable by it. So deferral is gated on a **per-file** check: a knowledge doc is deferred only when it carries a tag that exactly matches the caller's accessible data-lake tags (the same resolver the tool executes with). Non-lake attachments, message attachments, session fab files, and system files are **always inlined** - nothing the tool can't reach is ever stranded.

## Changes

- `resolveCorpusInlinePlan` (call site) partitions `session.knowledgeIds` into a retrievable subset and defers it only when large enough.
- `shouldDeferCorpusToRetrieval` (pure) gates on per-doc even-split depth: `attachedFileTokenBudget / retrievableCount < floor`.
- Admin setting `CorpusRetrievalMinInlineTokensPerDoc`, **default 0 = OFF** (byte-for-byte today's behavior until an admin opts in).
- Suppressed under `promptMode` (the tool isn't offered there).
- New `promptMeta.context.knowledgeInlining` telemetry.
- Fail-safe: any error in the plan degrades to today's full inline.

## Guide for Testers

Requires a user with an accessible data lake (their own/org's, or a shared/entitlement-gated one) and a tool-capable model. The feature is **off by default** - set the admin setting to enable it.

1. **Enable the feature.** Admin Settings -> AI -> "Corpus Retrieval Min Inline Tokens Per Doc" -> set to e.g. `500` (0 disables).
2. **Large lake corpus deferred.** In a session, attach a large lake corpus as knowledge (many lake-tagged docs). Ask a domain question and send with `wait: true`.
   - **Expected:** `promptMeta.context.knowledgeInlining.deferredToRetrieval = true`, `deferredCount` > 0; `promptMeta.offeredTools` includes `search_knowledge_base`; `promptMeta.context.tokensBySource.fabFiles` drops sharply vs. before; the answer still cites the docs (fetched via the tool).
3. **Small attachment still inlined.** New session, attach 1-3 lake-tagged docs. Send with `wait: true`.
   - **Expected:** `knowledgeInlining.deferredToRetrieval = false`, `deferredCount = 0`; docs are inlined as before (per-doc share stays above the floor).

### Regression checks

4. **Non-lake attachment never deferred (critical).** Attach a personal, non-lake-tagged file alongside a large lake corpus.
   - **Expected:** the personal file is NOT in the deferred set (`knowledgeInlining.retrievableCount` counts only lake-tagged docs); its content still inlines and the model can answer about it.
5. **Default off = no change.** With the admin setting at `0` (default), attach any corpus.
   - **Expected:** `deferredToRetrieval = false`, everything inlines exactly as on `main`.
6. **promptMode passthrough.** Send with `promptMode: 'raw'` (or grounded/surface).
   - **Expected:** `deferredToRetrieval = false` (nothing deferred), regardless of the setting.

### What NOT to test

- No UI changes.
- Retrieval ranking/citation behavior is unchanged - this only changes whether the corpus is *also* pasted inline.

## Measurement

Pairs with `offeredTools` + `tokensBySource.fabFiles` in `promptMeta.context` so a before/after run (threshold `0` vs `500`) shows the fab-token drop and the deferral decision in one place - hand to the eval harness for an A/B on answer quality before any wider rollout.
