### PR TITLE
fix(client): expose every BYOK provider in API key settings

### DIFF
--- a/apps/client/app/components/ProfileModal/SettingsTabContent/ApiKeysSection.test.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/ApiKeysSection.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { ApiKeyType, IApiKeyDocument } from '@bike4mind/common';
+
+let apiKeys: Partial<IApiKeyDocument>[] = [];
+const setActiveCalls: string[] = [];
+
+vi.mock('@client/app/hooks/data/apiKeys', () => ({
+  useGetAllApiKeys: () => ({ data: apiKeys, isFetching: false }),
+  useSetActiveApiKey: (type: string) => ({
+    mutate: () => setActiveCalls.push(type),
+  }),
+  useDeleteApiKey: () => ({ mutate: vi.fn(), isPending: false }),
+  useAddNewApiKey: () => ({ mutate: vi.fn(), reset: vi.fn(), isError: false, isSuccess: false, isPending: false }),
+}));
+
+vi.mock('@client/app/hooks/data/voice', () => ({
+  useGetAllVoice: () => ({ data: [], isLoading: false }),
+  useSetVoice: () => ({ mutate: vi.fn() }),
+  useDeleteVoice: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@client/app/components/ProfileModal/AddVoiceModal', () => ({
+  default: () => <div data-testid="add-voice-modal-stub" />,
+}));
+
+import ApiKeysSection from './ApiKeysSection';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+const renderSection = () =>
+  render(
+    <CssVarsProvider theme={appTheme}>
+      <ApiKeysSection />
+    </CssVarsProvider>
+  );
+
+// Every provider getEffectiveLLMApiKeys resolves a per-user key for must be addable,
+// otherwise the BYOK tier is unreachable and usage silently bills the org demo key.
+const BYOK_TYPES = [
+  ApiKeyType.openai,
+  ApiKeyType.anthropic,
+  ApiKeyType.gemini,
+  ApiKeyType.xai,
+  ApiKeyType.kimi,
+  ApiKeyType.bfl,
+  ApiKeyType.voyageai,
+  ApiKeyType.elevenlabs,
+];
+
+describe('ApiKeysSection', () => {
+  beforeEach(() => {
+    apiKeys = [];
+    setActiveCalls.length = 0;
+  });
+
+  it.each(BYOK_TYPES)('exposes an add-key affordance for %s', type => {
+    renderSection();
+
+    expect(screen.getByTestId(`api-keys-provider-${type}`)).toBeTruthy();
+    expect(screen.getByTestId(`api-keys-add-${type}-btn`)).toBeTruthy();
+  });
+
+  it('does not render sections for admin-configured types', () => {
+    renderSection();
+
+    expect(screen.queryByTestId(`api-keys-provider-${ApiKeyType.serpapi}`)).toBeNull();
+    expect(screen.queryByTestId(`api-keys-provider-${ApiKeyType.ollama}`)).toBeNull();
+  });
+
+  it('files each key under its own provider rather than defaulting to openAi', () => {
+    apiKeys = [
+      {
+        id: 'k1',
+        apiKey: 'sk-ant-abcdefgh1234',
+        type: ApiKeyType.anthropic,
+        description: 'my anthropic key',
+        isActive: false,
+      },
+    ];
+
+    renderSection();
+
+    const anthropic = screen.getByTestId(`api-keys-provider-${ApiKeyType.anthropic}`);
+    expect(anthropic.textContent).toContain('my anthropic key');
+
+    const openai = screen.getByTestId(`api-keys-provider-${ApiKeyType.openai}`);
+    expect(openai.textContent).not.toContain('my anthropic key');
+  });
+});

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/ApiKeysSection.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/ApiKeysSection.tsx
@@ -204,11 +204,31 @@ const SpeechTabContent = () => {
   );
 };
 
+// Display name per provider; null means the type is not user-managed here (it is
+// configured org-wide by an admin, or is a base URL rather than a key). The map is
+// exhaustive over ApiKeyType so a new provider forces a decision instead of silently
+// staying invisible. Must stay in sync with getEffectiveLLMApiKeys (b4m-core/auth),
+// which is what makes a per-user key take precedence over the org demo key.
+const PROVIDER_LABELS: Record<ApiKeyType, string | null> = {
+  [ApiKeyType.openai]: 'OpenAI',
+  [ApiKeyType.anthropic]: 'Anthropic',
+  [ApiKeyType.gemini]: 'Google Gemini',
+  [ApiKeyType.xai]: 'xAI',
+  [ApiKeyType.kimi]: 'Moonshot (Kimi)',
+  [ApiKeyType.bfl]: 'Black Forest Labs',
+  [ApiKeyType.voyageai]: 'Voyage AI',
+  [ApiKeyType.elevenlabs]: 'ElevenLabs',
+  [ApiKeyType.serpapi]: null,
+  [ApiKeyType.ollama]: null,
+};
+
+const BYOK_PROVIDERS = (Object.keys(PROVIDER_LABELS) as ApiKeyType[])
+  .map(type => ({ type, title: PROVIDER_LABELS[type] }))
+  .filter((provider): provider is { type: ApiKeyType; title: string } => provider.title !== null);
+
 const ApiKeysSection = () => {
   const [targetDeleteId, setTargetDeleteId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState(0);
-  const { mutate: setOpenAiActive } = useSetActiveApiKey();
-  const { mutate: setElabsActive } = useSetActiveApiKey(ApiKeyType.elevenlabs);
   const query = useGetAllApiKeys();
   const deleteApiKey = useDeleteApiKey({
     onSuccess: () => {
@@ -217,20 +237,14 @@ const ApiKeysSection = () => {
     },
   });
 
-  const initialKeys: { [key in ApiKeyType]?: { data: IApiKeyDocument[] } } = {
-    [ApiKeyType.openai]: { data: [] },
-    [ApiKeyType.elevenlabs]: { data: [] },
-  };
+  // Bucket strictly by the stored type - defaulting a missing type to openAi would
+  // file another provider's key under OpenAI and hide it from its own section.
+  const groupedApiKeys = (query.data ?? []).reduce<{ [key in ApiKeyType]?: IApiKeyDocument[] }>((acc, curr) => {
+    if (!curr.type) return acc;
 
-  const groupedApiKeys = (query.data ?? []).reduce<{ [key in ApiKeyType]?: { data: IApiKeyDocument[] } }>(
-    (acc, curr) => {
-      const type = curr.type ?? ApiKeyType.openai;
-
-      acc[type]?.data.push(curr);
-      return acc;
-    },
-    initialKeys
-  );
+    (acc[curr.type] ??= []).push(curr);
+    return acc;
+  }, {});
 
   return (
     <>
@@ -248,23 +262,17 @@ const ApiKeysSection = () => {
           </TabList>
 
           <TabPanel value={0} sx={{ pt: '20px' }}>
-            <Box sx={{ mb: '20px' }}>
-              <ProviderContainer
-                title="OpenAI"
-                type={ApiKeyType.openai}
-                items={groupedApiKeys.openAi?.data ?? []}
-                onActivate={id => setOpenAiActive(id)}
-                onDelete={id => setTargetDeleteId(id)}
-              />
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+              {BYOK_PROVIDERS.map(({ type, title }) => (
+                <ProviderContainer
+                  key={type}
+                  title={title}
+                  type={type}
+                  items={groupedApiKeys[type] ?? []}
+                  onDelete={id => setTargetDeleteId(id)}
+                />
+              ))}
             </Box>
-
-            <ProviderContainer
-              title="ElevenLabs"
-              type={ApiKeyType.elevenlabs}
-              items={groupedApiKeys.elevenLabs?.data ?? []}
-              onActivate={id => setElabsActive(id)}
-              onDelete={id => setTargetDeleteId(id)}
-            />
           </TabPanel>
 
           <TabPanel value={1} sx={{ pt: '20px' }}>
@@ -295,17 +303,18 @@ const ProviderContainer = ({
   title,
   type,
   items,
-  onActivate,
   onDelete,
 }: {
   title: string;
   type: ApiKeyType;
   items: IApiKeyDocument[];
-  onActivate: (id: string) => void;
   onDelete: (id: string) => void;
 }) => {
+  const { mutate: setActive } = useSetActiveApiKey(type);
+
   return (
     <Box
+      data-testid={`api-keys-provider-${type}`}
       sx={theme => ({
         ...cardSurfaceSx(theme),
         display: 'flex',
@@ -318,152 +327,156 @@ const ProviderContainer = ({
         {title}
       </Typography>
 
-      {/* Horizontal scroll keeps Date Added / Expires At inside the card on narrow viewports. */}
-      <Box sx={{ overflowX: 'auto' }}>
-        <Table
-          sx={{
-            minWidth: 680,
-            tableLayout: 'auto',
-            '& thead th': { ...tableHeaderSx, whiteSpace: 'nowrap' },
-            '& td': { fontSize: '14px', color: 'text.primary', verticalAlign: 'middle' },
-          }}
-        >
-          <thead>
-            <tr>
-              <th>Key</th>
-              <th>Description</th>
-              <th>Date Added</th>
-              <th>Expires At</th>
-              <th aria-label="Actions" style={{ width: '140px' }} />
-            </tr>
-          </thead>
-          <tbody>
-            {items.map(key => {
-              const isExpired = key.expiresAt ? new Date(key.expiresAt) < new Date() : false;
-              return (
-                <tr key={key.id}>
-                  <td style={{ whiteSpace: 'nowrap' }}>
-                    {key.apiKey.length <= 20
-                      ? key.apiKey
-                      : key.apiKey.substring(0, 8) + '...' + key.apiKey.substring(key.apiKey.length - 4)}
-                  </td>
-                  <td>
-                    <Tooltip title={key.description} placement="top" arrow>
-                      <Box
-                        sx={{
-                          display: '-webkit-box',
-                          WebkitLineClamp: 2,
-                          WebkitBoxOrient: 'vertical',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          lineHeight: 1.4,
-                          maxHeight: '2.8em', // 2 lines * 1.4 line height
-                          cursor: 'pointer',
-                        }}
-                      >
-                        {key.description}
-                      </Box>
-                    </Tooltip>
-                  </td>
-                  <td style={{ whiteSpace: 'nowrap' }}>
-                    {key.createdAt ? new Intl.DateTimeFormat().format(new Date(key.createdAt)) : 'N/A'}
-                  </td>
-                  <td style={{ whiteSpace: 'nowrap' }}>
-                    {key.expiresAt ? (
-                      // Non-expired renders as plain text like the "Date Added" cell so it
-                      // inherits the table's td -> text.primary. A bare <Typography> would
-                      // apply body-sm's own color (text.tertiary) and read grayer than its
-                      // neighbor, so only the expired state uses <Typography color="danger">.
-                      isExpired ? (
-                        <Typography level="body-sm" color="danger">
-                          {new Intl.DateTimeFormat().format(new Date(key.expiresAt))} - Expired
-                        </Typography>
-                      ) : (
-                        new Intl.DateTimeFormat().format(new Date(key.expiresAt))
-                      )
-                    ) : (
-                      'N/A'
-                    )}
-                  </td>
-                  <td>
-                    <Box sx={{ display: 'flex', gap: '12px', justifyContent: 'flex-end', alignItems: 'center' }}>
-                      {!key.isActive ? (
-                        <Button
-                          variant="solid"
-                          onClick={() => onActivate(key.id)}
+      {/* Horizontal scroll keeps Date Added / Expires At inside the card on narrow viewports.
+          The whole table is dropped when empty so the provider list stays scannable. */}
+      {items.length > 0 && (
+        <Box sx={{ overflowX: 'auto' }}>
+          <Table
+            sx={{
+              minWidth: 680,
+              tableLayout: 'auto',
+              '& thead th': { ...tableHeaderSx, whiteSpace: 'nowrap' },
+              '& td': { fontSize: '14px', color: 'text.primary', verticalAlign: 'middle' },
+            }}
+          >
+            <thead>
+              <tr>
+                <th>Key</th>
+                <th>Description</th>
+                <th>Date Added</th>
+                <th>Expires At</th>
+                <th aria-label="Actions" style={{ width: '140px' }} />
+              </tr>
+            </thead>
+            <tbody>
+              {items.map(key => {
+                const isExpired = key.expiresAt ? new Date(key.expiresAt) < new Date() : false;
+                return (
+                  <tr key={key.id}>
+                    <td style={{ whiteSpace: 'nowrap' }}>
+                      {key.apiKey.length <= 20
+                        ? key.apiKey
+                        : key.apiKey.substring(0, 8) + '...' + key.apiKey.substring(key.apiKey.length - 4)}
+                    </td>
+                    <td>
+                      <Tooltip title={key.description} placement="top" arrow>
+                        <Box
                           sx={{
-                            height: '28px',
-                            minHeight: '28px',
-                            padding: '4px 12px',
-                            fontWeight: 500,
-                            whiteSpace: 'nowrap',
-                            backgroundColor: green[800],
-                            color: 'white',
-                            '&:hover': {
-                              backgroundColor: green[875],
-                            },
+                            display: '-webkit-box',
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: 'vertical',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            lineHeight: 1.4,
+                            maxHeight: '2.8em', // 2 lines * 1.4 line height
+                            cursor: 'pointer',
                           }}
                         >
-                          Activate
-                        </Button>
-                      ) : (
-                        <Box sx={{ color: green[800], fontSize: '14px', fontWeight: 600, whiteSpace: 'nowrap' }}>
-                          Active
+                          {key.description}
                         </Box>
+                      </Tooltip>
+                    </td>
+                    <td style={{ whiteSpace: 'nowrap' }}>
+                      {key.createdAt ? new Intl.DateTimeFormat().format(new Date(key.createdAt)) : 'N/A'}
+                    </td>
+                    <td style={{ whiteSpace: 'nowrap' }}>
+                      {key.expiresAt ? (
+                        // Non-expired renders as plain text like the "Date Added" cell so it
+                        // inherits the table's td -> text.primary. A bare <Typography> would
+                        // apply body-sm's own color (text.tertiary) and read grayer than its
+                        // neighbor, so only the expired state uses <Typography color="danger">.
+                        isExpired ? (
+                          <Typography level="body-sm" color="danger">
+                            {new Intl.DateTimeFormat().format(new Date(key.expiresAt))} - Expired
+                          </Typography>
+                        ) : (
+                          new Intl.DateTimeFormat().format(new Date(key.expiresAt))
+                        )
+                      ) : (
+                        'N/A'
                       )}
+                    </td>
+                    <td>
+                      <Box sx={{ display: 'flex', gap: '12px', justifyContent: 'flex-end', alignItems: 'center' }}>
+                        {!key.isActive ? (
+                          <Button
+                            variant="solid"
+                            onClick={() => setActive(key.id)}
+                            sx={{
+                              height: '28px',
+                              minHeight: '28px',
+                              padding: '4px 12px',
+                              fontWeight: 500,
+                              whiteSpace: 'nowrap',
+                              backgroundColor: green[800],
+                              color: 'white',
+                              '&:hover': {
+                                backgroundColor: green[875],
+                              },
+                            }}
+                          >
+                            Activate
+                          </Button>
+                        ) : (
+                          <Box sx={{ color: green[800], fontSize: '14px', fontWeight: 600, whiteSpace: 'nowrap' }}>
+                            Active
+                          </Box>
+                        )}
 
-                      <Dropdown>
-                        <MenuButton
-                          size="sm"
-                          sx={{
-                            padding: '8px',
-                            border: '1px solid',
-                            borderColor: 'neutral.outlinedBorder',
-                            color: 'neutral.outlinedColor',
-                            width: '28px !important',
-                            height: '28px !important',
-                            minWidth: '28px !important',
-                            minHeight: '28px !important',
-                            '&:hover': {
-                              backgroundColor: 'neutral.outlinedHoverBg',
-                              borderColor: 'neutral.outlinedHoverBorder',
-                            },
-                          }}
-                          slots={{ root: IconButton }}
-                          slotProps={{ root: { variant: 'outlined', color: 'neutral' } }}
-                        >
-                          <MoreVertIcon sx={{ fontSize: '18px' }} width={'16px'} height={'16px'} />
-                        </MenuButton>
-                        <Menu
-                          className="menuSurface"
-                          sx={{
-                            zIndex: 10001,
-                            borderRadius: '10px',
-                          }}
-                          variant={'outlined'}
-                          placement={'bottom'}
-                          direction="ltr"
-                        >
-                          <MenuItem onClick={() => onDelete(key.id)} color="danger">
-                            <DeleteOutline sx={{ fontSize: '20px' }} />
-                            Delete a Key
-                          </MenuItem>
-                        </Menu>
-                      </Dropdown>
-                    </Box>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </Table>
-      </Box>
+                        <Dropdown>
+                          <MenuButton
+                            size="sm"
+                            sx={{
+                              padding: '8px',
+                              border: '1px solid',
+                              borderColor: 'neutral.outlinedBorder',
+                              color: 'neutral.outlinedColor',
+                              width: '28px !important',
+                              height: '28px !important',
+                              minWidth: '28px !important',
+                              minHeight: '28px !important',
+                              '&:hover': {
+                                backgroundColor: 'neutral.outlinedHoverBg',
+                                borderColor: 'neutral.outlinedHoverBorder',
+                              },
+                            }}
+                            slots={{ root: IconButton }}
+                            slotProps={{ root: { variant: 'outlined', color: 'neutral' } }}
+                          >
+                            <MoreVertIcon sx={{ fontSize: '18px' }} width={'16px'} height={'16px'} />
+                          </MenuButton>
+                          <Menu
+                            className="menuSurface"
+                            sx={{
+                              zIndex: 10001,
+                              borderRadius: '10px',
+                            }}
+                            variant={'outlined'}
+                            placement={'bottom'}
+                            direction="ltr"
+                          >
+                            <MenuItem onClick={() => onDelete(key.id)} color="danger">
+                              <DeleteOutline sx={{ fontSize: '20px' }} />
+                              Delete a Key
+                            </MenuItem>
+                          </Menu>
+                        </Dropdown>
+                      </Box>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        </Box>
+      )}
 
       <Box>
-        <AddApiKeyModal type={type as ApiKeyType}>
+        <AddApiKeyModal type={type}>
           {({ toggle }) => (
             <Tooltip title={`Add New ${title} Key`}>
               <Button
+                data-testid={`api-keys-add-${type}-btn`}
                 variant="outlined"
                 color="neutral"
                 sx={{


### PR DESCRIPTION
# Pull Request

Closes #1092

## Description

The backend resolves per-user (BYOK) API keys for seven provider types, but the settings UI
only ever let a user add two of them (`openai` and `elevenlabs`). For the other five the
per-user tier was unreachable: `getEffectiveLLMApiKeys` resolves
`userKey || demoKey || envKey`, so with no way to store a user key every request fell through
to the org demo key. The org paid for usage a user was willing to fund themselves, and there
was no per-user attribution.

The root cause was a hardcoded list of provider sections, so the fix derives the list from
`ApiKeyType` instead of adding five more hardcoded blocks.

## Changes

- `ApiKeysSection.tsx`: replaced the two hardcoded provider blocks with a
  `PROVIDER_LABELS: Record<ApiKeyType, string | null>` map that is **exhaustive over the
  enum** - a newly added `ApiKeyType` now fails typecheck until someone decides whether it is
  user-managed. `null` marks a type that is not BYOK-addable here (`serpapi` and `ollama` are
  admin-configured org-wide, and `ollama` is a base URL rather than a key). `BYOK_PROVIDERS`
  derives the rendered sections from that map.
- Eight sections now render: openai, anthropic, gemini, xai, kimi, bfl, voyageai (the seven
  the backend resolves) plus the pre-existing elevenlabs.
- Dropped the `curr.type ?? ApiKeyType.openai` default when grouping keys. That silent default
  would have mis-filed keys for the newly exposed providers under OpenAI; a typeless key is now
  skipped instead. Also dropped the `initialKeys` seed, since sections come from
  `BYOK_PROVIDERS` and no longer depend on pre-seeded buckets.
- Moved `useSetActiveApiKey(type)` into `ProviderContainer` (one hook per provider) and removed
  its now-redundant `onActivate` prop, replacing the two lifted per-provider mutations.
- Each provider's key table only renders when that provider has keys, so eight mostly-empty
  cards stay scannable. This reindent is why the diff is large relative to the change.
- Added `data-testid` hooks: `api-keys-provider-<type>`, `api-keys-add-<type>-btn`.
- New `ApiKeysSection.test.tsx`, table-driven over the eight BYOK types.

No backend change was needed: `AddApiKeyModal`, `useSetActiveApiKey` / `useAddNewApiKey`, and
`POST /api/api-keys/[id]/set-active` were already type-agnostic and pass the type through -
which is exactly why the hardcoded UI list was the whole bug.

## Guide for Testers

1. Log in at `app.staging.bike4mind.com`.
2. Open the profile menu (top-right avatar) and choose **Profile / Settings**.
3. Select the **Settings** tab, then scroll to the **API Keys** section.
4. Expected: eight provider cards are listed - OpenAI, Anthropic, Google Gemini, xAI, Kimi,
   Black Forest Labs, Voyage AI, and ElevenLabs. Each has an add-key button. Providers with no
   keys show no table, just the card header and add button.
5. Expected: there is **no** card for SerpAPI or Ollama (those stay admin-configured).
6. Click the add-key button on the **Anthropic** card.
7. In the modal, enter a name such as `my-anthropic-key` and paste any non-empty string as the
   key value, then save.
8. Expected: a success toast appears, and the new key is listed **under the Anthropic card
   only** - it must not appear under OpenAI.
9. Repeat steps 6-8 for one more newly exposed provider (e.g. **xAI**) and confirm the key
   lands under that provider's card.
10. On a provider with two or more keys, click the activate/set-active control on the inactive
    key. Expected: that key becomes the active one for that provider and the other becomes
    inactive; no other provider's active key changes.
11. Delete one of the test keys. Expected: it disappears from its provider's card and, when it
    was the last key for that provider, the table disappears leaving just the header and add
    button.

### Regression Checks

1. Adding, activating, and deleting an **OpenAI** key still behaves exactly as before.
2. Adding, activating, and deleting an **ElevenLabs** key still behaves exactly as before.
3. Start a chat using a model from a provider where you saved a personal key. Expected: the
   request succeeds, now billed against your own key rather than the org demo key.

### What NOT to test

- Admin/org-level key configuration (SerpAPI, Ollama) - deliberately unchanged and not exposed
  in this pane.
- Backend key-resolution precedence - `getEffectiveLLMApiKeys` was not touched.

## Additional Information

Verification run locally:

- `ApiKeysSection.test.tsx` - 10/10 pass.
- ProfileModal plus `pages/api/api-keys` suites - 62/62 pass across 10 files.
- `pnpm turbo:typecheck` - clean, 40/40 packages. This is what proves `PROVIDER_LABELS` is
  exhaustive over `ApiKeyType`.
- `pnpm lint:check` - clean.

Not done: no manual/browser pass over the rendered settings pane; correctness rests on the
tests above, so the tester guide above is worth walking end to end.

## Developer Notes

- `PROVIDER_LABELS` is the reusable pattern here: an exhaustive `Record<Enum, T | null>` turns
  "someone added a provider and forgot the UI" from a silent runtime gap into a compile error.
  Worth copying anywhere else a UI list has to track a backend enum.
- `ProviderContainer` now owns its own `useSetActiveApiKey(type)`, so the component scales to
  any number of providers without the parent lifting one mutation hook per provider.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no new AdminSettings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a
