### PR TITLE
fix(automation): assert pr-bot-review actually posted a review

### DIFF
--- a/.github/scripts/redact-review-transcript.py
+++ b/.github/scripts/redact-review-transcript.py
@@ -6,12 +6,14 @@ workflow artifact so a run that posted no review can be diagnosed. Artifacts on
 a public repo are world-downloadable, so two things must not survive:
 
   1. The bot-review skill body, fetched at run time from the PRIVATE
-     b4m-devtools repo. Any JSON string quoting a substantial line of it is
+     b4m-devtools repo. Any JSON string carrying a verbatim run of it is
      replaced wholesale.
   2. Credentials. Actions masks secrets in logs but NOT in artifacts.
 
-Residual risk: a paraphrase of the skill that quotes no long line verbatim is
-not detectable and would survive. Redaction is deliberately blunt because the
+Detection is by fixed-width windows rather than whole lines, so a skill line
+split across two JSON strings is still caught as long as each piece keeps a
+WINDOW-length verbatim run. Residual risk: a paraphrase, or fragments shorter
+than WINDOW, are not detectable. Redaction is deliberately blunt because the
 transcript's diagnostic value (turn count, tool calls, where it stopped) does
 not depend on the quoted text.
 
@@ -24,7 +26,7 @@ import re
 import sys
 
 REDACTED = "[redacted: bot-review skill content]"
-MIN_NEEDLE_LEN = 30
+WINDOW = 30
 
 TOKEN_PATTERNS = [
     re.compile(r"\bgh[psuor]_[A-Za-z0-9]{16,}"),
@@ -33,21 +35,38 @@ TOKEN_PATTERNS = [
 ]
 
 
-def scrub_string(value, needles):
-    if any(needle in value for needle in needles):
+def windows(text):
+    return {text[i:i + WINDOW] for i in range(len(text) - WINDOW + 1)}
+
+
+def carries_private(value, private):
+    return any(value[i:i + WINDOW] in private for i in range(len(value) - WINDOW + 1))
+
+
+def scrub_string(value, private):
+    if carries_private(value, private):
         return REDACTED
     for pattern in TOKEN_PATTERNS:
         value = pattern.sub("[redacted: credential]", value)
     return value
 
 
-def scrub(node, needles):
+def scrub(node, private, seen):
+    """Rewrites string values; `seen` collects every text the backstop must clear.
+
+    Dict keys are recorded but never rewritten - a needle in a key is a shape we
+    do not expect, so the backstop should refuse the upload rather than mangle
+    the structure.
+    """
     if isinstance(node, str):
-        return scrub_string(node, needles)
+        cleaned = scrub_string(node, private)
+        seen.append(cleaned)
+        return cleaned
     if isinstance(node, list):
-        return [scrub(item, needles) for item in node]
+        return [scrub(item, private, seen) for item in node]
     if isinstance(node, dict):
-        return {key: scrub(item, needles) for key, item in node.items()}
+        seen.extend(node.keys())
+        return {key: scrub(item, private, seen) for key, item in node.items()}
     return node
 
 
@@ -64,16 +83,19 @@ def main(argv):
         print(f"cannot read skill file for redaction: {err}", file=sys.stderr)
         return 1
 
-    needles = {line.strip() for line in skill.splitlines() if len(line.strip()) >= MIN_NEEDLE_LEN}
-    if not needles:
-        print("skill file yielded no redaction needles", file=sys.stderr)
+    private = set()
+    for line in skill.splitlines():
+        private |= windows(line.strip())
+    if not private:
+        print("skill file yielded no redaction fingerprints", file=sys.stderr)
         return 1
 
     with open(src, encoding="utf-8", errors="replace") as handle:
         raw = handle.read()
 
+    seen = []
     try:
-        cleaned = json.dumps(scrub(json.loads(raw), needles))
+        cleaned = json.dumps(scrub(json.loads(raw), private, seen))
     except json.JSONDecodeError:
         # The action has shipped both a JSON array and JSONL; handle either.
         lines = []
@@ -81,15 +103,17 @@ def main(argv):
             if not line.strip():
                 continue
             try:
-                lines.append(json.dumps(scrub(json.loads(line), needles)))
+                lines.append(json.dumps(scrub(json.loads(line), private, seen)))
             except json.JSONDecodeError:
                 print("execution file is neither JSON nor JSONL", file=sys.stderr)
                 return 1
         cleaned = "\n".join(lines)
 
-    surviving = [needle for needle in needles if needle in cleaned]
+    # Checked against the scrubbed leaves, not against `cleaned`: JSON escaping
+    # (`"` -> `\"`) hides a fingerprint from the serialized form.
+    surviving = sum(1 for text in seen if carries_private(text, private))
     if surviving:
-        print(f"{len(surviving)} private needle(s) survived redaction", file=sys.stderr)
+        print(f"{surviving} private fingerprint(s) survived redaction", file=sys.stderr)
         return 1
 
     with open(dest, "w", encoding="utf-8") as handle:

--- a/.github/scripts/redact-review-transcript.py
+++ b/.github/scripts/redact-review-transcript.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Strip private content out of a pr-bot-review execution transcript.
+
+Used by .github/workflows/pr-bot-review.yml, which uploads the result as a
+workflow artifact so a run that posted no review can be diagnosed. Artifacts on
+a public repo are world-downloadable, so two things must not survive:
+
+  1. The bot-review skill body, fetched at run time from the PRIVATE
+     b4m-devtools repo. Any JSON string quoting a substantial line of it is
+     replaced wholesale.
+  2. Credentials. Actions masks secrets in logs but NOT in artifacts.
+
+Residual risk: a paraphrase of the skill that quotes no long line verbatim is
+not detectable and would survive. Redaction is deliberately blunt because the
+transcript's diagnostic value (turn count, tool calls, where it stopped) does
+not depend on the quoted text.
+
+Exits non-zero on anything it cannot redact confidently; the workflow treats
+that as "do not upload".
+"""
+
+import json
+import re
+import sys
+
+REDACTED = "[redacted: bot-review skill content]"
+MIN_NEEDLE_LEN = 30
+
+TOKEN_PATTERNS = [
+    re.compile(r"\bgh[psuor]_[A-Za-z0-9]{16,}"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"\bsk-ant-[A-Za-z0-9\-_]{16,}"),
+]
+
+
+def scrub_string(value, needles):
+    if any(needle in value for needle in needles):
+        return REDACTED
+    for pattern in TOKEN_PATTERNS:
+        value = pattern.sub("[redacted: credential]", value)
+    return value
+
+
+def scrub(node, needles):
+    if isinstance(node, str):
+        return scrub_string(node, needles)
+    if isinstance(node, list):
+        return [scrub(item, needles) for item in node]
+    if isinstance(node, dict):
+        return {key: scrub(item, needles) for key, item in node.items()}
+    return node
+
+
+def main(argv):
+    if len(argv) != 4:
+        print(f"usage: {argv[0]} <execution-file> <skill-file> <dest>", file=sys.stderr)
+        return 2
+    src, skill_path, dest = argv[1:]
+
+    try:
+        with open(skill_path, encoding="utf-8") as handle:
+            skill = handle.read()
+    except OSError as err:
+        print(f"cannot read skill file for redaction: {err}", file=sys.stderr)
+        return 1
+
+    needles = {line.strip() for line in skill.splitlines() if len(line.strip()) >= MIN_NEEDLE_LEN}
+    if not needles:
+        print("skill file yielded no redaction needles", file=sys.stderr)
+        return 1
+
+    with open(src, encoding="utf-8", errors="replace") as handle:
+        raw = handle.read()
+
+    try:
+        cleaned = json.dumps(scrub(json.loads(raw), needles))
+    except json.JSONDecodeError:
+        # The action has shipped both a JSON array and JSONL; handle either.
+        lines = []
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            try:
+                lines.append(json.dumps(scrub(json.loads(line), needles)))
+            except json.JSONDecodeError:
+                print("execution file is neither JSON nor JSONL", file=sys.stderr)
+                return 1
+        cleaned = "\n".join(lines)
+
+    surviving = [needle for needle in needles if needle in cleaned]
+    if surviving:
+        print(f"{len(surviving)} private needle(s) survived redaction", file=sys.stderr)
+        return 1
+
+    with open(dest, "w", encoding="utf-8") as handle:
+        handle.write(cleaned)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/redact-review-transcript.test.sh
+++ b/.github/scripts/redact-review-transcript.test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Self-test for redact-review-transcript.py.
+# Usage: bash .github/scripts/redact-review-transcript.test.sh
+#
+# This script is the only thing between the private bot-review skill body and a
+# world-downloadable artifact on a public repo, and the workflow that runs it
+# only ever executes against real PRs. So the fail-closed paths are pinned here.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REDACTOR="$SCRIPT_DIR/redact-review-transcript.py"
+
+PASSED=0
+FAILED=0
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+SKILL="$TMP/skill.md"
+cat >"$SKILL" <<'EOF'
+# bot-review
+
+Always start by reading the full diff and the linked issue before commenting.
+Classify every finding as P0, P1, P2 or P3 and justify the severity you pick.
+Prefer a data-testid selector like "modal-confirm-btn" over any CSS class name.
+short line
+EOF
+
+EMPTY_SKILL="$TMP/empty-skill.md"
+printf 'short\ntiny\n' >"$EMPTY_SKILL"
+
+DEST="$TMP/out.json"
+RC=0
+OUT=""
+
+# run <transcript-file> [skill-file] -- sets RC and OUT (dest contents, empty if absent)
+run() {
+  rm -f "$DEST"
+  python3 "$REDACTOR" "$1" "${2:-$SKILL}" "$DEST" >/dev/null 2>"$TMP/stderr"
+  RC=$?
+  OUT=""
+  [ -f "$DEST" ] && OUT=$(cat "$DEST")
+  return 0
+}
+
+pass() {
+  echo "ok: $1"
+  PASSED=$((PASSED + 1))
+}
+
+fail() {
+  echo "FAIL: $1 -- $2"
+  echo "  stderr: $(cat "$TMP/stderr")"
+  FAILED=$((FAILED + 1))
+}
+
+# check_rc <name> <want-rc>
+check_rc() {
+  if [ "$RC" -eq "$2" ]; then return 0; fi
+  fail "$1" "exit $RC, wanted $2"
+  return 1
+}
+
+# no_dest <name> -- fail-closed: nothing may be written when redaction is refused
+no_dest() {
+  if [ ! -f "$DEST" ]; then return 0; fi
+  fail "$1" "destination file was written despite a refusal"
+  return 1
+}
+
+# absent <name> <needle>
+absent() {
+  case "$OUT" in
+    *"$2"*) fail "$1" "leaked: $2"; return 1 ;;
+  esac
+  return 0
+}
+
+# present <name> <needle>
+present() {
+  case "$OUT" in
+    *"$2"*) return 0 ;;
+  esac
+  fail "$1" "missing from output: $2"
+  return 1
+}
+
+# --- a whole skill body arriving as a line-numbered Read tool_result ---------
+cat >"$TMP/bulk.json" <<'EOF'
+[{"type":"user","message":{"content":[{"type":"tool_result","content":"     1\t# bot-review\n     2\tAlways start by reading the full diff and the linked issue before commenting.\n     3\tClassify every finding as P0, P1, P2 or P3 and justify the severity you pick.\n"}]}},
+ {"type":"assistant","num_turns":12,"message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"gh pr diff 1"}}]}}]
+EOF
+NAME='bulk Read tool_result is redacted, diagnostics kept'
+run "$TMP/bulk.json"
+check_rc "$NAME" 0 &&
+  absent "$NAME" 'Always start by reading' &&
+  absent "$NAME" 'justify the severity' &&
+  present "$NAME" 'redacted: bot-review skill content' &&
+  present "$NAME" 'num_turns' &&
+  present "$NAME" 'Bash' &&
+  present "$NAME" 'gh pr diff 1' &&
+  pass "$NAME"
+
+# --- a skill line split across two adjacent JSON strings --------------------
+cat >"$TMP/split.json" <<'EOF'
+[{"type":"assistant","message":{"content":[
+  {"type":"text","text":"Always start by reading the full diff and th"},
+  {"type":"text","text":"e linked issue before commenting on the code."}]}}]
+EOF
+NAME='needle split across two strings is caught'
+run "$TMP/split.json"
+check_rc "$NAME" 0 &&
+  absent "$NAME" 'Always start by reading the full diff and th' &&
+  absent "$NAME" 'e linked issue before commenting' &&
+  pass "$NAME"
+
+# --- a needle containing a double quote (JSON-escaped in the output) ---------
+cat >"$TMP/quoted.json" <<'EOF'
+[{"type":"assistant","message":{"content":[{"type":"text","text":"The skill says: Prefer a data-testid selector like \"modal-confirm-btn\" over any CSS class name."}]}}]
+EOF
+NAME='quoted needle does not evade the scrub'
+run "$TMP/quoted.json"
+check_rc "$NAME" 0 &&
+  absent "$NAME" 'modal-confirm-btn' &&
+  pass "$NAME"
+
+# --- a needle sitting in a dict key: refuse rather than mangle the structure --
+cat >"$TMP/key.json" <<'EOF'
+[{"Classify every finding as P0, P1, P2 or P3 and justify the severity you pick.":"note"}]
+EOF
+NAME='needle in a dict key refuses the upload'
+run "$TMP/key.json"
+check_rc "$NAME" 1 && no_dest "$NAME" && pass "$NAME"
+
+# --- JSONL, plus all three credential shapes --------------------------------
+cat >"$TMP/creds.jsonl" <<'EOF'
+{"type":"system","token":"ghs_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789"}
+{"type":"system","token":"github_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz1234"}
+{"type":"system","token":"sk-ant-api03-AbCdEfGhIjKlMnOp","tool":"Grep"}
+EOF
+NAME='JSONL credentials are scrubbed, tool names kept'
+run "$TMP/creds.jsonl"
+check_rc "$NAME" 0 &&
+  absent "$NAME" 'ghs_AbCdEf' &&
+  absent "$NAME" 'github_pat_11ABCDEFG' &&
+  absent "$NAME" 'sk-ant-api03' &&
+  present "$NAME" 'redacted: credential' &&
+  present "$NAME" 'Grep' &&
+  pass "$NAME"
+
+# --- degenerate inputs all fail closed --------------------------------------
+NAME='unreadable skill file refuses the upload'
+run "$TMP/bulk.json" "$TMP/does-not-exist.md"
+check_rc "$NAME" 1 && no_dest "$NAME" && pass "$NAME"
+
+NAME='skill with no long lines refuses the upload'
+run "$TMP/bulk.json" "$EMPTY_SKILL"
+check_rc "$NAME" 1 && no_dest "$NAME" && pass "$NAME"
+
+printf 'not json at all\n' >"$TMP/garbage.txt"
+NAME='transcript that is neither JSON nor JSONL refuses the upload'
+run "$TMP/garbage.txt"
+check_rc "$NAME" 1 && no_dest "$NAME" && pass "$NAME"
+
+NAME='wrong argument count is a usage error'
+rm -f "$DEST"
+python3 "$REDACTOR" "$TMP/bulk.json" >/dev/null 2>"$TMP/stderr"
+RC=$?
+check_rc "$NAME" 2 && no_dest "$NAME" && pass "$NAME"
+
+echo
+echo "passed: $PASSED  failed: $FAILED"
+[ "$FAILED" -eq 0 ]

--- a/.github/workflows/pr-bot-review-guard.yml
+++ b/.github/workflows/pr-bot-review-guard.yml
@@ -1,0 +1,30 @@
+name: PR Bot Review Guard
+
+# Runs the self-tests for the pr-bot-review transcript redactor.
+#
+# The redactor only ever runs inside a real Actions run, where a mistake is
+# expensive and silent: it is the single control keeping the private bot-review
+# skill body out of an artifact that anyone can download from this public repo.
+# A regression that stops it matching would still exit 0 and publish, so the
+# fail-closed paths are pinned by tests that CI runs before that can happen.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/pr-bot-review.yml'
+      - '.github/workflows/pr-bot-review-guard.yml'
+      - '.github/scripts/redact-review-transcript.py'
+      - '.github/scripts/redact-review-transcript.test.sh'
+  merge_group:
+    branches: [main]
+
+jobs:
+  check:
+    if: github.repository == (vars.CANONICAL_REPO || 'MillionOnMars/lumina5')
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest-m' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Transcript redactor tests
+        run: bash .github/scripts/redact-review-transcript.test.sh

--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -218,6 +218,14 @@ jobs:
           echo "skill_file=$DEST" >> "$GITHUB_OUTPUT"
           echo "bot-review skill fetched ($(wc -l < "$DEST") lines) from b4m-devtools@main"
 
+      - name: Record review start time
+        id: review_start
+        if: steps.size_check.outputs.skip == 'false' && steps.substantive.outputs.skip == 'false'
+        run: |
+          # Watermark for the "was a review actually posted?" check below. Taken a
+          # second early so a review posted in the same second still compares >=.
+          echo "at=$(date -u -d '1 second ago' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Run /bot-review
         id: bot_review
         if: steps.size_check.outputs.skip == 'false' && steps.substantive.outputs.skip == 'false'
@@ -260,18 +268,103 @@ jobs:
             # review was posted. The 100-file size guard caps the upper bound.
             --max-turns 80
 
+      - name: Verify a review was actually posted
+        id: review_posted
+        # The completeness assertion is "a review is visible on the PR", NOT "the
+        # process exited 0". A run can end its turn without posting anything and
+        # still report success (observed: 18 turns, is_error false, 0 reviews
+        # posted), which left the author with a green check and no review.
+        # FAIL-CLOSED: an API error resolves to "not posted", because the whole
+        # point of this step is to never claim a review happened without evidence.
+        if: always() && (steps.bot_review.outcome == 'success' || steps.bot_review.outcome == 'failure')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_REVIEW_LOGIN: 'claude[bot]'
+          SINCE: ${{ steps.review_start.outputs.at }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+          emit() { echo "review_posted: $1"; echo "posted=$1" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          if [ -z "$SINCE" ]; then
+            echo "::warning::no review start watermark; treating as no review posted"
+            emit false
+          fi
+
+          # Counts entries authored by the bot at or after the watermark. Both
+          # timestamps are UTC `...Z` of fixed width, so a string compare is a
+          # correct time compare. Prints nothing and returns 1 on API failure.
+          count_since() {
+            local out
+            out=$(gh api --paginate "$1" --jq "$2" 2>&1) || { echo "::warning::gh api $1 failed: $out" >&2; return 1; }
+            printf '%s\n' "$out" | grep -c . || true
+          }
+
+          SEL_REVIEW=".[] | select(.user.login==\"${BOT_REVIEW_LOGIN}\" and .submitted_at != null and .submitted_at >= \"${SINCE}\") | .id"
+          SEL_COMMENT=".[] | select(.user.login==\"${BOT_REVIEW_LOGIN}\" and .created_at >= \"${SINCE}\") | .id"
+
+          REVIEWS=$(count_since "repos/${REPO}/pulls/${PR}/reviews" "$SEL_REVIEW") || emit false
+          INLINE=$(count_since "repos/${REPO}/pulls/${PR}/comments" "$SEL_COMMENT") || emit false
+          ISSUE=$(count_since "repos/${REPO}/issues/${PR}/comments" "$SEL_COMMENT") || emit false
+          echo "review_posted: reviews=$REVIEWS inline=$INLINE comments=$ISSUE since=$SINCE"
+
+          if [ $((REVIEWS + INLINE + ISSUE)) -gt 0 ]; then emit true; else emit false; fi
+
+      - name: Redact and upload review transcript
+        id: transcript
+        # Retained only when something went wrong, so a no-post run can be
+        # diagnosed at all (the workflow log keeps only the init/result blocks).
+        # The transcript quotes this PUBLIC repo's own diff, which is fine, but it
+        # also contains the bot-review skill fetched from the PRIVATE b4m-devtools
+        # repo — and artifacts on a public repo are world-downloadable. So the
+        # skill's own text is stripped first, and the upload is abandoned entirely
+        # if a fingerprint of it survives. Short retention: this is a debugging
+        # aid, not a record.
+        if: always() && (steps.bot_review.outcome == 'failure' || (steps.bot_review.outcome == 'success' && steps.review_posted.outputs.posted != 'true'))
+        env:
+          EXECUTION_FILE: ${{ steps.bot_review.outputs.execution_file }}
+          SKILL_FILE: ${{ steps.skill_fetch.outputs.skill_file }}
+          DEST: ${{ runner.temp }}/review-transcript-redacted.json
+        run: |
+          set -uo pipefail
+          if [ -z "$EXECUTION_FILE" ] || [ ! -s "$EXECUTION_FILE" ]; then
+            echo "::warning::no execution output file to upload"
+            echo "uploadable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! python3 "${GITHUB_WORKSPACE}/.github/scripts/redact-review-transcript.py" \
+                 "$EXECUTION_FILE" "$SKILL_FILE" "$DEST"; then
+            echo "::warning::transcript redaction failed; not uploading"
+            echo "uploadable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "uploadable=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload review transcript
+        if: always() && steps.transcript.outputs.uploadable == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-transcript-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/review-transcript-redacted.json
+          retention-days: 7
+
       - name: Report incomplete review
-        # Fires only when the review step actually ran and failed (e.g.
-        # error_max_turns, API error) — not when the size guard skipped it
-        # (outcome == 'skipped'), which posts its own comment. Without this,
-        # a failed run leaves only a red ✗ in Checks with no signal on the PR.
-        if: always() && steps.bot_review.outcome == 'failure'
+        # Fires when the review step actually ran and either failed (e.g.
+        # error_max_turns, API error) or finished without leaving a review on the
+        # PR — not when the size guard skipped it (outcome == 'skipped'), which
+        # posts its own comment. Without this, such a run leaves the author with
+        # nothing on the PR, and in the no-post case a green check as well.
+        if: always() && (steps.bot_review.outcome == 'failure' || (steps.bot_review.outcome == 'success' && steps.review_posted.outputs.posted != 'true'))
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --body "🤖 Automated review did not complete — the run errored or exhausted its turn budget, so no review was posted. See the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. Re-apply the \`bot-review\` label to retry, or request a human reviewer."
+            --body "🤖 Automated review did not complete — no review from this run was detected on the PR (the run errored, exhausted its turn budget, or ended without posting). See the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details; a redacted transcript is attached to it as an artifact when one was captured. Re-apply the \`bot-review\` label to retry, or request a human reviewer."
+          # Red the job too. A success-with-no-post used to leave a green check,
+          # which reads as "the review happened" - the failure mode this guards.
+          exit 1
 
       - name: Report skill-fetch failure
         # Fail loud + visible: if the skill couldn't be fetched we skipped the review

--- a/.github/workflows/pr-bot-review.yml
+++ b/.github/workflows/pr-bot-review.yml
@@ -296,8 +296,18 @@ jobs:
           # timestamps are UTC `...Z` of fixed width, so a string compare is a
           # correct time compare. Prints nothing and returns 1 on API failure.
           count_since() {
-            local out
-            out=$(gh api --paginate "$1" --jq "$2" 2>&1) || { echo "::warning::gh api $1 failed: $out" >&2; return 1; }
+            local out err status=0
+            err=$(mktemp)
+            # stderr must stay OUT of $out: it is counted line-by-line below, so
+            # folding the streams would let a warning on a successful call read
+            # as a posted review.
+            out=$(gh api --paginate "$1" --jq "$2" 2>"$err") || status=$?
+            if [ "$status" -ne 0 ]; then
+              echo "::warning::gh api $1 failed: $(cat "$err")" >&2
+              rm -f "$err"
+              return 1
+            fi
+            rm -f "$err"
             printf '%s\n' "$out" | grep -c . || true
           }
 
@@ -321,7 +331,7 @@ jobs:
         # skill's own text is stripped first, and the upload is abandoned entirely
         # if a fingerprint of it survives. Short retention: this is a debugging
         # aid, not a record.
-        if: always() && (steps.bot_review.outcome == 'failure' || (steps.bot_review.outcome == 'success' && steps.review_posted.outputs.posted != 'true'))
+        if: always() && (steps.bot_review.outcome == 'failure' || (steps.bot_review.outcome == 'success' && steps.bot_review.outputs.conclusion == 'success')) && steps.review_posted.outputs.posted != 'true'
         env:
           EXECUTION_FILE: ${{ steps.bot_review.outputs.execution_file }}
           SKILL_FILE: ${{ steps.skill_fetch.outputs.skill_file }}
@@ -355,7 +365,15 @@ jobs:
         # PR — not when the size guard skipped it (outcome == 'skipped'), which
         # posts its own comment. Without this, such a run leaves the author with
         # nothing on the PR, and in the no-post case a green check as well.
-        if: always() && (steps.bot_review.outcome == 'failure' || (steps.bot_review.outcome == 'success' && steps.review_posted.outputs.posted != 'true'))
+        #
+        # `outputs.conclusion` (not just `outcome == 'success'`) is the gate for the
+        # success branch: claude-code-action deliberately no-ops with a SUCCESSFUL
+        # exit when the calling workflow file differs from the default-branch copy,
+        # returning before it sets `conclusion`. Without this check, every PR that
+        # edits this file gets a red check and a comment claiming a review was lost.
+        # `posted != 'true'` also gates the failure branch, so a run that posts a
+        # review and then errors does not contradict the measurement above.
+        if: always() && (steps.bot_review.outcome == 'failure' || (steps.bot_review.outcome == 'success' && steps.bot_review.outputs.conclusion == 'success')) && steps.review_posted.outputs.posted != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
# Pull Request

Closes #1134

## Description

A `pr-bot-review` run could finish `completed/success` having posted nothing at all: the
workflow went green, no review or comment appeared on the PR, and the author reasonably
assumed the review had happened. This was observed twice on one PR at the same head SHA -
the first attempt ran to a normal end of turn (no max-turns error, no permission denial)
and posted 0 reviews and 0 comments; re-applying the label with nothing else changed
produced a full review.

Two gaps caused the silence:

1. The completeness guard keyed on the review step's **exit status**, so it caught
   `error_max_turns` and API errors but not success-with-no-post. The assertion is now
   "a review was posted", not "the process exited 0".
2. The execution transcript was written to the runner and discarded. The workflow log
   retains only the `init` and `result` blocks, so a no-post run was undiagnosable after
   the fact.

## Changes

- `Record review start time` step emits a UTC watermark (taken 1s early) before the review runs.
- `Verify a review was actually posted` counts `claude[bot]`-authored entries at or after
  that watermark across `pulls/{pr}/reviews` (by `submitted_at`), `pulls/{pr}/comments`, and
  `issues/{pr}/comments`. It fails closed: any `gh api` error or a missing watermark resolves
  to `posted=false`. stderr is captured separately from stdout, so warning chatter on a
  successful `gh api` call cannot be counted as a posted review.
- `Report incomplete review` fires on review-step failure **or** success-with-no-post, and
  `exit 1`s after commenting so the check goes red instead of green. Two things gate it:
  the success branch requires the action's own `conclusion` output (empty when the action
  self-skips because the workflow file differs from the default-branch copy), and both
  branches require `posted != 'true'`, so a run that posts a review and then errors does not
  claim the review was lost. Conditions are explicit success/failure rather than
  `!= 'skipped'`, so a concurrency-cancelled run posts nothing.
- On that same incomplete path only, the execution transcript is redacted and uploaded as an
  artifact with 7-day retention.
- New `.github/scripts/redact-review-transcript.py`. Artifacts on a public repo are
  world-downloadable and the transcript embeds the review skill body fetched from a private
  repo, so the script blanks any JSON string carrying a 30-character verbatim run of the
  skill and scrubs credential-shaped strings (`gh?_`, `github_pat_`, `sk-ant-`). Matching on
  fixed-width windows rather than whole lines means a skill line split across two adjacent
  JSON strings is still caught. The survivor backstop runs against the scrubbed string
  leaves, not the serialized JSON, where escaping (`"` -> `\"`) could hide a fingerprint; if
  anything survives the script exits non-zero and the workflow skips the upload. Known
  residual risk: a paraphrase, or fragments shorter than 30 characters, are not detectable.
- New `.github/scripts/redact-review-transcript.test.sh` and `pr-bot-review-guard.yml` run
  the redactor's fail-closed paths in CI, following the convention already used for the
  changeset scripts.

## Guide for Testers

This is a CI-workflow-only change; there is nothing to exercise in the app. Note that for
`pull_request` events, Actions resolves the workflow definition from the PR's merge ref, so
labeling an unrelated PR against `main` exercises **main's** copy of this workflow, not this
diff. The only PR that exercises this diff is one carrying it - i.e. this one.

1. Redactor tests (the part that runs anywhere): `bash .github/scripts/redact-review-transcript.test.sh`
   on this branch. Expect 9 passing cases, covering bulk redaction, a needle split across two
   JSON strings, a quoted needle, a needle in a dict key, JSONL plus all three credential
   shapes, and four degenerate inputs that must write no output file. CI runs the same script
   via the new `PR Bot Review Guard` check.
2. Apply the `bot-review` label to **this** PR. Because the file differs from main's copy,
   `claude-code-action` self-skips with a successful exit and posts nothing; the expected
   result after this fix is a **green** `review` check with **no** "did not complete" comment
   and no artifact. Runs
   [31157892694](https://github.com/Bike4Mind/bike4mind/actions/runs/31157892694) and
   [31158369610](https://github.com/Bike4Mind/bike4mind/actions/runs/31158369610) show what
   that same path did before the fix: a red check plus a false "did not complete" comment
   (both comments are still on this PR, dated 2026-08-07).
3. The genuine no-post path (review runs, posts nothing -> red check, comment, redacted
   transcript artifact) cannot be forced from the outside; the closest available check is the
   verify step's shell replayed against a stub `gh`, described under Additional Information.
4. After merge, the next labeled PR against `main` exercises the real success path: a posted
   review, a green check, no "did not complete" comment, and an empty Artifacts list.

### What NOT to test

No application code, API routes, or UI are touched. No client, server, or database behaviour
changes.

## Additional Information

Verified locally: the workflow YAML parses for both files (PyYAML, 14 steps / 2 steps); the
redactor self-tests pass (9/9); the verify step's bash was extracted from the YAML and
dry-run under `bash -e` with a stub `gh` across no results, one review, an API failure, an
empty watermark, and stderr-on-success - the last of which returned `posted=true` before this
fix and `posted=false` after it.

Not verified: a real GitHub Actions run of the review step itself. `pnpm lint:check` and
friends were not run - the change touches no JS/TS.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
