### PR TITLE
chore(ci): add a pre-commit guard for raw control bytes in source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,14 @@ jobs:
       - name: Check user $lookup field projections
         run: node scripts/check-user-lookup-projection.mjs
 
+      # Mirrors the husky pre-commit guard so a `--no-verify` bypass is still caught.
+      # Each trigger exposes the base under a different key; the script over-scans the
+      # whole tree if none resolve, so a new-branch push (all-zero `before`) still checks.
+      - name: Check for raw control bytes in source files
+        run: bash scripts/check-no-control-bytes.sh --changed "$CONTROL_BYTES_BASE"
+        env:
+          CONTROL_BYTES_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+
       - name: Check deploy contract matches infra
         run: python3 scripts/check-deploy-contract.py
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -74,6 +74,12 @@ if ! bash scripts/check-no-overlay-lockfile.sh --staged; then
   FINAL_EXIT_CODE=1
 fi
 
+# Check staged source files for raw control bytes (a NUL makes a file binary/ungreppable)
+echo "Running control-byte check..."
+if ! bash scripts/check-no-control-bytes.sh; then
+  FINAL_EXIT_CODE=1
+fi
+
 # Run gitleaks to check for secrets
 echo "Running gitleaks check..."
 if ! sh "$(dirname -- "$0")/gitleaks-pre-commit.sh"; then

--- a/packages/scripts/src/checkNoControlBytes.test.ts
+++ b/packages/scripts/src/checkNoControlBytes.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Behaviour tests for scripts/check-no-control-bytes.sh (the guard added for #1385).
+ *
+ * Each case builds a throwaway git repo under the OS temp dir and runs the real script
+ * against it, so the assertions cover the shipped shell rather than a reimplementation.
+ * Nothing here touches the working repo.
+ *
+ * Must stay in sync with the guard's three modes: default/--staged, --changed <base>, --all.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const GUARD = path.join(REPO_ROOT, 'scripts', 'check-no-control-bytes.sh');
+
+// Absolute, because the fail-closed case stubs PATH down to git only -- a bare 'bash'
+// would then fail to spawn at all, which is a different failure than the one under test.
+const BASH = spawnSync('sh', ['-c', 'command -v bash'], { encoding: 'utf8' }).stdout.trim() || '/bin/bash';
+
+const sandboxes: string[] = [];
+
+afterEach(() => {
+  while (sandboxes.length) fs.rmSync(sandboxes.pop()!, { recursive: true, force: true });
+});
+
+function git(cwd: string, ...args: string[]) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+/** A fresh git repo with one empty commit; returns its path and that commit's sha. */
+function makeRepo(): { dir: string; base: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-guard-'));
+  sandboxes.push(dir);
+  git(dir, 'init', '-q', '.');
+  git(dir, 'config', 'user.email', 'test@example.test');
+  git(dir, 'config', 'user.name', 'test');
+  // A fixture deliberately contains CR; keep git from warning or rewriting it.
+  git(dir, 'config', 'core.safecrlf', 'false');
+  git(dir, 'config', 'core.autocrlf', 'false');
+  git(dir, 'commit', '-q', '--allow-empty', '-m', 'base');
+  return { dir, base: git(dir, 'rev-parse', 'HEAD') };
+}
+
+/** Write raw bytes (control chars survive; a normal string would be re-encoded fine too). */
+function write(dir: string, name: string, contents: string) {
+  fs.writeFileSync(path.join(dir, name), Buffer.from(contents, 'binary'));
+}
+
+function runGuard(dir: string, args: string[] = [], env: NodeJS.ProcessEnv = {}) {
+  const r = spawnSync(BASH, [GUARD, ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  if (r.error) throw r.error; // a spawn failure is not a guard verdict; surface it as such
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('check-no-control-bytes.sh', () => {
+  it('is present and executable', () => {
+    expect(fs.existsSync(GUARD)).toBe(true);
+    // Mode matters: the hook and CI both invoke it, and a non-executable guard is a silent no-op risk.
+    expect(fs.statSync(GUARD).mode & 0o111).toBeGreaterThan(0);
+  });
+
+  describe('staged mode (the pre-commit hook path)', () => {
+    it('allows tab, LF and CR, which are not violations', () => {
+      const { dir } = makeRepo();
+      write(dir, 'clean.ts', 'export const ok = 1;\n\tconst tabbed = 2;\r\n');
+      git(dir, 'add', 'clean.ts');
+      expect(runGuard(dir).status).toBe(0);
+    });
+
+    it('rejects a raw NUL and names the offending file', () => {
+      const { dir } = makeRepo();
+      write(dir, 'nul.ts', 'export const bad = 1;\x00\n');
+      git(dir, 'add', 'nul.ts');
+      const r = runGuard(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('nul.ts');
+    });
+
+    it('rejects DEL (0x7f)', () => {
+      const { dir } = makeRepo();
+      write(dir, 'del.ts', 'export const bad = 1;\x7f\n');
+      git(dir, 'add', 'del.ts');
+      expect(runGuard(dir).status).toBe(1);
+    });
+
+    it('rejects 0x03 / 0x04 in a .tsx file', () => {
+      const { dir } = makeRepo();
+      write(dir, 'ctrl.tsx', 'const a = "\x03";\nconst b = "\x04";\n');
+      git(dir, 'add', 'ctrl.tsx');
+      expect(runGuard(dir).status).toBe(1);
+    });
+
+    it('ignores a NUL outside .ts/.tsx, since that is the declared scope', () => {
+      const { dir } = makeRepo();
+      write(dir, 'notes.md', 'doc with a NUL: \x00\n');
+      git(dir, 'add', 'notes.md');
+      expect(runGuard(dir).status).toBe(0);
+    });
+
+    it('passes when nothing is staged', () => {
+      const { dir } = makeRepo();
+      expect(runGuard(dir).status).toBe(0);
+    });
+  });
+
+  describe('--changed mode (the CI path)', () => {
+    it('rejects a NUL introduced in a commit after the base', () => {
+      const { dir, base } = makeRepo();
+      write(dir, 'added.ts', 'export const later = 1;\x00\n');
+      git(dir, 'add', 'added.ts');
+      git(dir, 'commit', '-q', '-m', 'add a file containing a NUL');
+      expect(runGuard(dir, ['--changed', base]).status).toBe(1);
+    });
+
+    it('passes when the commits after the base are clean', () => {
+      const { dir, base } = makeRepo();
+      write(dir, 'fine.ts', 'export const fine = 1;\n');
+      git(dir, 'add', 'fine.ts');
+      git(dir, 'commit', '-q', '-m', 'add a clean file');
+      expect(runGuard(dir, ['--changed', base]).status).toBe(0);
+    });
+
+    // The important one: both "scanned everything" and "scanned nothing" exit 0 on a clean
+    // tree, so an unresolvable base must visibly widen the scan instead of quietly passing.
+    it.each([
+      ['an empty base', ''],
+      ['an all-zero base, as a new-branch push sends', '0'.repeat(40)],
+      ['a nonexistent sha', 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'],
+    ])('falls back to a full scan given %s', (_label, base) => {
+      const { dir } = makeRepo();
+      write(dir, 'added.ts', 'export const later = 1;\x00\n');
+      git(dir, 'add', 'added.ts');
+      git(dir, 'commit', '-q', '-m', 'add a file containing a NUL');
+      const r = runGuard(dir, ['--changed', base]);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain('unresolvable');
+    });
+  });
+
+  describe('--all mode', () => {
+    it('rejects a tracked file containing a NUL', () => {
+      const { dir } = makeRepo();
+      write(dir, 'added.ts', 'export const later = 1;\x00\n');
+      git(dir, 'add', 'added.ts');
+      git(dir, 'commit', '-q', '-m', 'add a file containing a NUL');
+      expect(runGuard(dir, ['--all']).status).toBe(1);
+    });
+
+    it('skips a path git tracks but the worktree no longer has', () => {
+      const { dir } = makeRepo();
+      write(dir, 'gone.ts', 'export const gone = 1;\n');
+      git(dir, 'add', 'gone.ts');
+      git(dir, 'commit', '-q', '-m', 'add a file');
+      fs.rmSync(path.join(dir, 'gone.ts'));
+      const r = runGuard(dir, ['--all']);
+      expect(r.status).toBe(0);
+      expect(r.stderr).not.toContain("Can't open");
+    });
+  });
+
+  it('fails closed when perl is unavailable rather than reporting clean', () => {
+    const { dir } = makeRepo();
+    write(dir, 'nul.ts', 'export const bad = 1;\x00\n');
+    git(dir, 'add', 'nul.ts');
+
+    // A PATH holding only git: the guard can still list files but cannot scan them.
+    const stubBin = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-guard-bin-'));
+    sandboxes.push(stubBin);
+    const gitPath = spawnSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).stdout.trim();
+    fs.symlinkSync(gitPath, path.join(stubBin, 'git'));
+
+    const r = runGuard(dir, ['--all'], { PATH: stubBin });
+    expect(r.status).toBe(1);
+    expect(`${r.stdout}${r.stderr}`).toContain('perl not found');
+  });
+});

--- a/packages/scripts/src/checkNoControlBytes.test.ts
+++ b/packages/scripts/src/checkNoControlBytes.test.ts
@@ -53,6 +53,15 @@ function write(dir: string, name: string, contents: string) {
   fs.writeFileSync(path.join(dir, name), Buffer.from(contents, 'binary'));
 }
 
+/** A PATH containing only git, so the guard can list files but not scan them. */
+function makeStubBin(): string {
+  const stubBin = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-guard-bin-'));
+  sandboxes.push(stubBin);
+  const gitPath = spawnSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).stdout.trim();
+  fs.symlinkSync(gitPath, path.join(stubBin, 'git'));
+  return stubBin;
+}
+
 function runGuard(dir: string, args: string[] = [], env: NodeJS.ProcessEnv = {}) {
   const r = spawnSync(BASH, [GUARD, ...args], {
     cwd: dir,
@@ -167,6 +176,20 @@ describe('check-no-control-bytes.sh', () => {
       expect(r.status).toBe(0);
       expect(r.stderr).not.toContain("Can't open");
     });
+
+    // Skipping the missing path must not abort the scan: a sibling in the same invocation
+    // still has to be checked, or one deleted file would mask every later violation.
+    it('keeps scanning siblings after skipping a missing path', () => {
+      const { dir } = makeRepo();
+      write(dir, 'gone.ts', 'export const gone = 1;\n');
+      write(dir, 'zz-bad.ts', 'export const bad = 1;\x00\n');
+      git(dir, 'add', '-A');
+      git(dir, 'commit', '-q', '-m', 'add two files');
+      fs.rmSync(path.join(dir, 'gone.ts'));
+      const r = runGuard(dir, ['--all']);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('zz-bad.ts');
+    });
   });
 
   it('fails closed when perl is unavailable rather than reporting clean', () => {
@@ -174,14 +197,103 @@ describe('check-no-control-bytes.sh', () => {
     write(dir, 'nul.ts', 'export const bad = 1;\x00\n');
     git(dir, 'add', 'nul.ts');
 
-    // A PATH holding only git: the guard can still list files but cannot scan them.
-    const stubBin = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-guard-bin-'));
-    sandboxes.push(stubBin);
-    const gitPath = spawnSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).stdout.trim();
-    fs.symlinkSync(gitPath, path.join(stubBin, 'git'));
-
+    const stubBin = makeStubBin();
     const r = runGuard(dir, ['--all'], { PATH: stubBin });
     expect(r.status).toBe(1);
     expect(`${r.stdout}${r.stderr}`).toContain('perl not found');
+  });
+
+  // Distinct from "perl not found": perl exists, so the command -v check passes, but the
+  // scan itself dies. That must not read as a clean tree either.
+  it('fails closed when perl exists but exits non-zero', () => {
+    const { dir } = makeRepo();
+    write(dir, 'nul.ts', 'export const bad = 1;\x00\n');
+    git(dir, 'add', 'nul.ts');
+
+    const stubBin = makeStubBin();
+    const stub = path.join(stubBin, 'perl');
+    fs.writeFileSync(stub, '#!/bin/sh\nexit 3\n');
+    fs.chmodSync(stub, 0o755);
+
+    const r = runGuard(dir, ['--all'], { PATH: stubBin });
+    expect(r.status).not.toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toContain('failing closed');
+  });
+
+  it('fails closed when the file listing fails, rather than passing an empty list', () => {
+    // Outside any git repo, so `git ls-files` errors. A process substitution would hide that
+    // and yield a bogus clean pass; the pipeline must surface it.
+    const notARepo = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-guard-norepo-'));
+    sandboxes.push(notARepo);
+    const r = runGuard(notARepo, ['--all']);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('failing closed');
+  });
+
+  it('rejects an unknown option instead of silently scanning staged files', () => {
+    const { dir } = makeRepo();
+    const r = runGuard(dir, ['--chagned']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("unknown option '--chagned'");
+    expect(r.stderr).toContain('usage:');
+  });
+
+  describe('security: filenames must never reach perl @ARGV', () => {
+    // perl -n wraps the body in `while (<>)`, and the diamond operator does a magic
+    // 2-argument open on @ARGV entries, so a file merely NAMED `|cmd.ts` would run `cmd`.
+    // That is code execution from the same careless-contributor case this guard exists for.
+    const hostile = '|touch PWNED;.ts';
+
+    it('does not execute a command embedded in a filename', () => {
+      const { dir } = makeRepo();
+      write(dir, hostile, 'export const x = 1;\n');
+      git(dir, 'add', '-A');
+      const r = runGuard(dir);
+      expect(r.status).toBe(0);
+      expect(fs.existsSync(path.join(dir, 'PWNED'))).toBe(false);
+    });
+
+    it('still scans a file whose name begins with a pipe', () => {
+      const { dir } = makeRepo();
+      write(dir, hostile, 'export const x = 1;\x00\n');
+      git(dir, 'add', '-A');
+      const r = runGuard(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain(hostile);
+      expect(fs.existsSync(path.join(dir, 'PWNED'))).toBe(false);
+    });
+
+    it('does not treat a file named "-" as stdin', () => {
+      const { dir } = makeRepo();
+      write(dir, '-.ts', 'export const x = 1;\x00\n');
+      git(dir, 'add', '-A');
+      const r = runGuard(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('-.ts');
+    });
+  });
+
+  it('scans a non-ASCII path that git would otherwise C-quote', () => {
+    // With core.quotePath on (git's default), a non-ASCII path is emitted as
+    // "caf\303\251.ts" -- quotes included -- which names no real file. The -z listing
+    // avoids the quoting entirely.
+    const { dir } = makeRepo();
+    git(dir, 'config', 'core.quotePath', 'true');
+    write(dir, 'café.ts', 'export const bad = 1;\x00\n');
+    git(dir, 'add', '-A');
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+  });
+
+  it('reads the staged blob, not the worktree copy', () => {
+    // Stage a bad blob, then clean the file on disk without re-staging. The commit would
+    // still carry the bad blob, so scanning the worktree copy would wave it through.
+    const { dir } = makeRepo();
+    write(dir, 'f.ts', 'export const bad = 1;\x00\n');
+    git(dir, 'add', 'f.ts');
+    write(dir, 'f.ts', 'export const clean = 1;\n');
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('f.ts');
   });
 });

--- a/packages/scripts/src/checkNoControlBytes.test.ts
+++ b/packages/scripts/src/checkNoControlBytes.test.ts
@@ -263,13 +263,41 @@ describe('check-no-control-bytes.sh', () => {
       expect(fs.existsSync(path.join(dir, 'PWNED'))).toBe(false);
     });
 
-    it('does not treat a file named "-" as stdin', () => {
+    // Two different mechanisms neutralise this, so both need pinning: staged mode goes through
+    // the list-form open("-|", "git", "show", ":$f"), while --all/--changed use the 3-arg
+    // open($fh, "<", $f). A test in only one mode leaves the other free to regress.
+    it.each([
+      ['staged mode', [] as string[]],
+      ['--all mode', ['--all']],
+    ])('does not treat a file named "-" as stdin (%s)', (_label, args) => {
       const { dir } = makeRepo();
       write(dir, '-.ts', 'export const x = 1;\x00\n');
       git(dir, 'add', '-A');
-      const r = runGuard(dir);
+      if (args.length) git(dir, 'commit', '-q', '-m', 'add -.ts');
+      const r = runGuard(dir, args);
       expect(r.status).toBe(1);
       expect(r.stdout).toContain('-.ts');
+    });
+
+    it('does not execute a command embedded in a filename under --all', () => {
+      const { dir } = makeRepo();
+      write(dir, hostile, 'export const x = 1;\n');
+      git(dir, 'add', '-A');
+      git(dir, 'commit', '-q', '-m', 'add a hostile filename');
+      const r = runGuard(dir, ['--all']);
+      expect(r.status).toBe(0);
+      expect(fs.existsSync(path.join(dir, 'PWNED'))).toBe(false);
+    });
+
+    it('still scans a hostile filename under --all', () => {
+      const { dir } = makeRepo();
+      write(dir, hostile, 'export const x = 1;\x00\n');
+      git(dir, 'add', '-A');
+      git(dir, 'commit', '-q', '-m', 'add a hostile filename with a NUL');
+      const r = runGuard(dir, ['--all']);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain(hostile);
+      expect(fs.existsSync(path.join(dir, 'PWNED'))).toBe(false);
     });
   });
 
@@ -328,6 +356,19 @@ describe('check-no-control-bytes.sh', () => {
       git(dir, 'mv', 'a.ts', 'b.ts');
       git(dir, 'add', '-A');
       expect(runGuard(dir).status).toBe(0);
+    });
+
+    // Copy detection is off by default, so this is future-proofing rather than a live gap:
+    // with diff.renames=copies a copy-plus-edit can be scored C rather than A.
+    it('catches a control byte added during a copy, with copy detection enabled', () => {
+      const dir = repoWithCommittedFile();
+      git(dir, 'config', 'diff.renames', 'copies');
+      fs.copyFileSync(path.join(dir, 'a.ts'), path.join(dir, 'c.ts'));
+      fs.appendFileSync(path.join(dir, 'c.ts'), Buffer.from('export const bad = 9;\x00\n', 'binary'));
+      git(dir, 'add', '-A');
+      const r = runGuard(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('c.ts');
     });
   });
 

--- a/packages/scripts/src/checkNoControlBytes.test.ts
+++ b/packages/scripts/src/checkNoControlBytes.test.ts
@@ -279,6 +279,17 @@ describe('check-no-control-bytes.sh', () => {
       expect(r.stdout).toContain('-.ts');
     });
 
+    // git's `:<path>` revspec does not reinterpret an option-looking path as a flag. Pinned so
+    // a future change in how git parses odd revspecs cannot silently regress staged mode.
+    it.each(['--foo.ts', '-.ts'])('does not let git reparse a staged path named %s as a flag', name => {
+      const { dir } = makeRepo();
+      write(dir, name, 'export const x = 1;\x00\n');
+      git(dir, 'add', '-A');
+      const r = runGuard(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain(name);
+    });
+
     it('does not execute a command embedded in a filename under --all', () => {
       const { dir } = makeRepo();
       write(dir, hostile, 'export const x = 1;\n');
@@ -370,6 +381,30 @@ describe('check-no-control-bytes.sh', () => {
       expect(r.status).toBe(1);
       expect(r.stdout).toContain('c.ts');
     });
+  });
+
+  describe('symlinks', () => {
+    it('does not scan through a symlink under --all', () => {
+      // git stores the target path string for a symlink, not the target's bytes, so reading
+      // through the link would flag content git is not tracking.
+      const { dir } = makeRepo();
+      write(dir, 'real.ts', 'export const bad = 1;\x00\n');
+      fs.symlinkSync(path.join(dir, 'real.ts'), path.join(dir, 'link.ts'));
+      git(dir, 'add', 'link.ts');
+      git(dir, 'commit', '-q', '-m', 'add only the symlink');
+      const r = runGuard(dir, ['--all']);
+      expect(r.status).toBe(0);
+    });
+
+    it('terminates on a symlink to an endless byte source', () => {
+      // Guards the bounded-read loop: a non-regular target must never enter it.
+      const { dir } = makeRepo();
+      fs.symlinkSync('/dev/urandom', path.join(dir, 'evil.ts'));
+      git(dir, 'add', '-A');
+      git(dir, 'commit', '-q', '-m', 'add a device symlink');
+      const r = runGuard(dir, ['--all']);
+      expect(r.status).toBe(0);
+    }, 15000);
   });
 
   it('finds a control byte beyond the first read chunk', () => {

--- a/packages/scripts/src/checkNoControlBytes.test.ts
+++ b/packages/scripts/src/checkNoControlBytes.test.ts
@@ -285,6 +285,64 @@ describe('check-no-control-bytes.sh', () => {
     expect(r.status).toBe(1);
   });
 
+  describe('renames', () => {
+    // Git detects renames by default and emits them as a single R<score> record. R is not in
+    // ACM, so an ACM filter drops the record entirely and a rename-plus-edit commits clean.
+    // Enough lines that git scores the change as a rename rather than delete-plus-add.
+    const body = Array.from({ length: 5 }, (_, i) => `export const v${i} = ${i};`).join('\n') + '\n';
+
+    function repoWithCommittedFile() {
+      const { dir } = makeRepo();
+      write(dir, 'a.ts', body);
+      git(dir, 'add', 'a.ts');
+      git(dir, 'commit', '-q', '-m', 'add a.ts');
+      return dir;
+    }
+
+    it('catches a control byte added during a rename, in staged mode', () => {
+      const dir = repoWithCommittedFile();
+      git(dir, 'mv', 'a.ts', 'b.ts');
+      fs.appendFileSync(path.join(dir, 'b.ts'), Buffer.from('export const bad = 9;\x00\n', 'binary'));
+      git(dir, 'add', '-A');
+      // Guard against the fixture silently not being a rename any more.
+      expect(git(dir, 'diff', '--cached', '--name-status')).toMatch(/^R/);
+      const r = runGuard(dir);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('b.ts');
+    });
+
+    it('catches a control byte added during a rename, in --changed mode', () => {
+      const dir = repoWithCommittedFile();
+      const base = git(dir, 'rev-parse', 'HEAD');
+      git(dir, 'mv', 'a.ts', 'b.ts');
+      fs.appendFileSync(path.join(dir, 'b.ts'), Buffer.from('export const bad = 9;\x00\n', 'binary'));
+      git(dir, 'add', '-A');
+      git(dir, 'commit', '-q', '-m', 'rename and add a NUL');
+      const r = runGuard(dir, ['--changed', base]);
+      expect(r.status).toBe(1);
+      expect(r.stdout).toContain('b.ts');
+    });
+
+    it('passes a clean rename', () => {
+      const dir = repoWithCommittedFile();
+      git(dir, 'mv', 'a.ts', 'b.ts');
+      git(dir, 'add', '-A');
+      expect(runGuard(dir).status).toBe(0);
+    });
+  });
+
+  it('finds a control byte beyond the first read chunk', () => {
+    // Content is read in bounded chunks rather than slurped, so a hit late in a large file
+    // must still be found. 176KB spans three 64KB chunks.
+    const { dir } = makeRepo();
+    write(dir, 'big.ts', 'export const pad = 1;\n'.repeat(8000) + 'export const bad = 2;\x00\n');
+    expect(fs.statSync(path.join(dir, 'big.ts')).size).toBeGreaterThan(65536 * 2);
+    git(dir, 'add', 'big.ts');
+    const r = runGuard(dir);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('big.ts');
+  });
+
   it('reads the staged blob, not the worktree copy', () => {
     // Stage a bad blob, then clean the file on disk without re-staging. The commit would
     // still carry the bad blob, so scanning the worktree copy would wave it through.

--- a/scripts/check-no-control-bytes.sh
+++ b/scripts/check-no-control-bytes.sh
@@ -90,8 +90,13 @@ if ! hits=$(
       # List form: no shell, so a path cannot be interpreted as a command.
       open($fh, "-|", "git", "show", ":$f") or exit 3;
     } else {
+      # Skip symlinks. What git stores for a symlink is the TARGET PATH STRING, so reading
+      # through the link would scan bytes git is not tracking -- and would disagree with
+      # staged mode, which sees the blob. It also removes any reliance on -f following links.
+      next if -l $f;
       # A path git lists but the worktree lacks (an unstaged deletion under --all) has
-      # nothing to scan; skip it rather than let perl warn.
+      # nothing to scan; skip it rather than let perl warn. -f is also what keeps a device
+      # or fifo target out of the read loop.
       next unless -f $f;
       open($fh, "<", $f) or exit 3;
     }

--- a/scripts/check-no-control-bytes.sh
+++ b/scripts/check-no-control-bytes.sh
@@ -4,31 +4,44 @@
 # unviewable in the PR UI. See #1221 / PR #1367.
 #
 # Modes (one script, one pattern = single source of truth):
-#   (default) / --staged   staged .ts/.tsx only, for the husky pre-commit hook.
-#   --changed <base>       files added/modified vs <base>, for CI so a `--no-verify`
-#                          bypass is still caught. Falls back to --all when <base> is
-#                          missing or unresolvable, so an unknown base over-scans rather
-#                          than silently checking nothing.
+#   (default) / --staged   staged .ts/.tsx only, for the husky pre-commit hook. Reads the
+#                          STAGED BLOB, not the worktree copy, so editing a file after
+#                          `git add` cannot hide a bad blob that is about to be committed.
+#   --changed <base>       files added/modified vs <base>, for CI so a `--no-verify` bypass
+#                          is still caught. Falls back to --all when <base> is missing or
+#                          unresolvable, so an unknown base over-scans rather than silently
+#                          scanning nothing.
 #   --all                  every tracked .ts/.tsx.
 #
 # Uses perl, NOT `grep -P`, for two verified reasons:
 #   1. macOS ships BSD grep, which has no -P (PCRE) flag at all.
 #   2. Even GNU grep needs -a to match a NUL: without it grep treats the file as
 #      binary and skips the match, missing the exact worst case this guard exists for.
-# perl -0777 reads each file as raw bytes and matches reliably on every platform.
 #
-# Fails closed: a missing or erroring perl exits non-zero rather than reporting "clean".
+# SECURITY: filenames are fed to perl on stdin (NUL-separated) and opened with a 3-argument
+# `open`. They must NEVER reach @ARGV: perl's -n wraps the body in `while (<>)`, and the
+# diamond operator does a magic 2-argument open on each @ARGV element, so a tracked file
+# merely NAMED `|cmd.ts` would execute `cmd`. That is code execution triggered by the same
+# careless-contributor case this guard exists to catch. A bare `--` does not help -- it stops
+# perl's own switch parsing, not the diamond operator's runtime behaviour.
+#
+# Fails closed: a missing or erroring perl, and a failing git listing, both exit non-zero
+# rather than reporting "clean".
 set -euo pipefail
 
 # C0 controls except tab (09), LF (0a), CR (0d); plus DEL (7f).
-pattern='[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'
+CB_PATTERN='[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'
+export CB_PATTERN
 
 if ! command -v perl >/dev/null 2>&1; then
   echo "check-no-control-bytes: perl not found, cannot scan for control bytes." >&2
   exit 1
 fi
 
-all_cmd=(git ls-files -- '*.ts' '*.tsx')
+# -z keeps paths raw and NUL-separated. Without it git applies core.quotePath and emits
+# non-ASCII paths C-style-quoted (e.g. "caf\303\251.ts"), which no longer names a real file.
+all_cmd=(git ls-files -z -- '*.ts' '*.tsx')
+staged=
 
 case "${1:-}" in
   --all)
@@ -37,30 +50,50 @@ case "${1:-}" in
   --changed)
     base="${2:-}"
     if [ -n "$base" ] && git rev-parse --verify --quiet "${base}^{commit}" >/dev/null 2>&1; then
-      list_cmd=(git diff --name-only --diff-filter=ACM "${base}...HEAD" -- '*.ts' '*.tsx')
+      list_cmd=(git diff --name-only -z --diff-filter=ACM "${base}...HEAD" -- '*.ts' '*.tsx')
     else
       echo "check-no-control-bytes: base '${base}' unresolvable, scanning all tracked files." >&2
       list_cmd=("${all_cmd[@]}")
     fi
     ;;
+  ''|--staged)
+    list_cmd=(git diff --cached --name-only -z --diff-filter=ACM -- '*.ts' '*.tsx')
+    staged=1
+    ;;
   *)
-    list_cmd=(git diff --cached --name-only --diff-filter=ACM -- '*.ts' '*.tsx')
+    echo "check-no-control-bytes: unknown option '$1'" >&2
+    echo "usage: check-no-control-bytes.sh [--staged | --changed <base> | --all]" >&2
+    exit 1
     ;;
 esac
+export CB_STAGED="$staged"
 
-# Plain read loop (not mapfile/readarray) so this runs on macOS's bash 3.2. The -f test
-# skips paths git lists but the worktree lacks (e.g. a staged deletion under --all), which
-# would otherwise make perl warn about a file there is nothing to scan.
-files=()
-while IFS= read -r f; do [ -f "$f" ] && files+=("$f"); done < <("${list_cmd[@]}")
-[ ${#files[@]} -eq 0 ] && exit 0
-
-set +e
-hits=$(perl -0777 -ne "print \"\$ARGV\\n\" if /$pattern/" "${files[@]}")
-perl_status=$?
-set -e
-if [ "$perl_status" -ne 0 ]; then
-  echo "check-no-control-bytes: perl exited ${perl_status}, failing closed." >&2
+# Piped, not `< <(...)`: process substitution exit codes are invisible to set -e/pipefail, so
+# a failing git listing would yield an empty list and a bogus "clean" pass. In a pipeline
+# pipefail sees it. A non-zero pipeline here therefore means the scan did not complete, which
+# is treated as a failure rather than a pass.
+if ! hits=$(
+  "${list_cmd[@]}" | perl -0 -ne '
+    my $f = $_;
+    $f =~ s/\0\z//;
+    next if $f eq "";
+    my $fh;
+    if ($ENV{CB_STAGED}) {
+      # List form: no shell, so a path cannot be interpreted as a command.
+      open($fh, "-|", "git", "show", ":$f") or exit 3;
+    } else {
+      # A path git lists but the worktree lacks (an unstaged deletion under --all) has
+      # nothing to scan; skip it rather than let perl warn.
+      next unless -f $f;
+      open($fh, "<", $f) or exit 3;
+    }
+    binmode($fh);
+    my $data = do { local $/; <$fh> };
+    close($fh) or exit 3;
+    print "$f\n" if defined($data) && $data =~ /$ENV{CB_PATTERN}/;
+  '
+); then
+  echo "check-no-control-bytes: file listing or scan failed, failing closed." >&2
   exit 1
 fi
 

--- a/scripts/check-no-control-bytes.sh
+++ b/scripts/check-no-control-bytes.sh
@@ -43,6 +43,12 @@ fi
 all_cmd=(git ls-files -z -- '*.ts' '*.tsx')
 staged=
 
+# --diff-filter must include R (and C): git detects renames by default and emits a
+# rename-plus-edit as ONE R<score> record, which a bare ACM filter drops -- so `git mv a.ts
+# b.ts` plus a control-byte edit used to commit clean. C covers the same shape when copy
+# detection is enabled. Same filter set as .husky/check-help-content.sh.
+# Note --name-only emits only the NEW path for R/C records, so no stale old path is handed to
+# `git show` in staged mode.
 case "${1:-}" in
   --all)
     list_cmd=("${all_cmd[@]}")
@@ -50,14 +56,14 @@ case "${1:-}" in
   --changed)
     base="${2:-}"
     if [ -n "$base" ] && git rev-parse --verify --quiet "${base}^{commit}" >/dev/null 2>&1; then
-      list_cmd=(git diff --name-only -z --diff-filter=ACMR "${base}...HEAD" -- '*.ts' '*.tsx')
+      list_cmd=(git diff --name-only -z --diff-filter=ACMRC "${base}...HEAD" -- '*.ts' '*.tsx')
     else
       echo "check-no-control-bytes: base '${base}' unresolvable, scanning all tracked files." >&2
       list_cmd=("${all_cmd[@]}")
     fi
     ;;
   ''|--staged)
-    list_cmd=(git diff --cached --name-only -z --diff-filter=ACMR -- '*.ts' '*.tsx')
+    list_cmd=(git diff --cached --name-only -z --diff-filter=ACMRC -- '*.ts' '*.tsx')
     staged=1
     ;;
   *)

--- a/scripts/check-no-control-bytes.sh
+++ b/scripts/check-no-control-bytes.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Fail if a .ts/.tsx file contains a raw control byte (NUL and friends). A raw NUL makes
+# git/GitHub treat the file as binary, so grep/rg silently return nothing and the diff is
+# unviewable in the PR UI. See #1221 / PR #1367.
+#
+# Modes (one script, one pattern = single source of truth):
+#   (default) / --staged   staged .ts/.tsx only, for the husky pre-commit hook.
+#   --changed <base>       files added/modified vs <base>, for CI so a `--no-verify`
+#                          bypass is still caught. Falls back to --all when <base> is
+#                          missing or unresolvable, so an unknown base over-scans rather
+#                          than silently checking nothing.
+#   --all                  every tracked .ts/.tsx.
+#
+# Uses perl, NOT `grep -P`, for two verified reasons:
+#   1. macOS ships BSD grep, which has no -P (PCRE) flag at all.
+#   2. Even GNU grep needs -a to match a NUL: without it grep treats the file as
+#      binary and skips the match, missing the exact worst case this guard exists for.
+# perl -0777 reads each file as raw bytes and matches reliably on every platform.
+#
+# Fails closed: a missing or erroring perl exits non-zero rather than reporting "clean".
+set -euo pipefail
+
+# C0 controls except tab (09), LF (0a), CR (0d); plus DEL (7f).
+pattern='[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'
+
+if ! command -v perl >/dev/null 2>&1; then
+  echo "check-no-control-bytes: perl not found, cannot scan for control bytes." >&2
+  exit 1
+fi
+
+all_cmd=(git ls-files -- '*.ts' '*.tsx')
+
+case "${1:-}" in
+  --all)
+    list_cmd=("${all_cmd[@]}")
+    ;;
+  --changed)
+    base="${2:-}"
+    if [ -n "$base" ] && git rev-parse --verify --quiet "${base}^{commit}" >/dev/null 2>&1; then
+      list_cmd=(git diff --name-only --diff-filter=ACM "${base}...HEAD" -- '*.ts' '*.tsx')
+    else
+      echo "check-no-control-bytes: base '${base}' unresolvable, scanning all tracked files." >&2
+      list_cmd=("${all_cmd[@]}")
+    fi
+    ;;
+  *)
+    list_cmd=(git diff --cached --name-only --diff-filter=ACM -- '*.ts' '*.tsx')
+    ;;
+esac
+
+# Plain read loop (not mapfile/readarray) so this runs on macOS's bash 3.2. The -f test
+# skips paths git lists but the worktree lacks (e.g. a staged deletion under --all), which
+# would otherwise make perl warn about a file there is nothing to scan.
+files=()
+while IFS= read -r f; do [ -f "$f" ] && files+=("$f"); done < <("${list_cmd[@]}")
+[ ${#files[@]} -eq 0 ] && exit 0
+
+set +e
+hits=$(perl -0777 -ne "print \"\$ARGV\\n\" if /$pattern/" "${files[@]}")
+perl_status=$?
+set -e
+if [ "$perl_status" -ne 0 ]; then
+  echo "check-no-control-bytes: perl exited ${perl_status}, failing closed." >&2
+  exit 1
+fi
+
+if [ -n "$hits" ]; then
+  echo "Raw control bytes found in:"
+  echo "$hits"
+  echo "Replace them with escape sequences (e.g. \\x00, \\x7f), or build the byte at"
+  echo "runtime (String.fromCharCode), so the files stay ASCII and greppable."
+  exit 1
+fi

--- a/scripts/check-no-control-bytes.sh
+++ b/scripts/check-no-control-bytes.sh
@@ -50,14 +50,14 @@ case "${1:-}" in
   --changed)
     base="${2:-}"
     if [ -n "$base" ] && git rev-parse --verify --quiet "${base}^{commit}" >/dev/null 2>&1; then
-      list_cmd=(git diff --name-only -z --diff-filter=ACM "${base}...HEAD" -- '*.ts' '*.tsx')
+      list_cmd=(git diff --name-only -z --diff-filter=ACMR "${base}...HEAD" -- '*.ts' '*.tsx')
     else
       echo "check-no-control-bytes: base '${base}' unresolvable, scanning all tracked files." >&2
       list_cmd=("${all_cmd[@]}")
     fi
     ;;
   ''|--staged)
-    list_cmd=(git diff --cached --name-only -z --diff-filter=ACM -- '*.ts' '*.tsx')
+    list_cmd=(git diff --cached --name-only -z --diff-filter=ACMR -- '*.ts' '*.tsx')
     staged=1
     ;;
   *)
@@ -74,6 +74,8 @@ export CB_STAGED="$staged"
 # is treated as a failure rather than a pass.
 if ! hits=$(
   "${list_cmd[@]}" | perl -0 -ne '
+    # Compiled once, not re-parsed per file.
+    BEGIN { $::RE = qr/$ENV{CB_PATTERN}/ }
     my $f = $_;
     $f =~ s/\0\z//;
     next if $f eq "";
@@ -88,9 +90,19 @@ if ! hits=$(
       open($fh, "<", $f) or exit 3;
     }
     binmode($fh);
-    my $data = do { local $/; <$fh> };
+    # Read in bounded chunks rather than slurping, so a large generated .ts cannot balloon
+    # memory. The pattern is a single-byte character class, so no match can straddle a chunk
+    # boundary. Read to EOF even after a hit: closing a `git show` pipe early would make
+    # close() report the resulting SIGPIPE as a failure and mask the finding.
+    my $found = 0;
+    while (1) {
+      my $n = read($fh, my $buf, 65536);
+      defined($n) or exit 3;
+      last if $n == 0;
+      $found = 1 if $buf =~ $::RE;
+    }
     close($fh) or exit 3;
-    print "$f\n" if defined($data) && $data =~ /$ENV{CB_PATTERN}/;
+    print "$f\n" if $found;
   '
 ); then
   echo "check-no-control-bytes: file listing or scan failed, failing closed." >&2


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

No UI changed - this is developer tooling, so the evidence is the guard's own test suite.

**1. The full suite passing locally**, covering the three modes, the base-resolution fallback,
the fail-closed paths, and the security cases added from review:

<img width="3582" height="2078" alt="image" src="https://github.com/user-attachments/assets/b891398b-8739-4d86-b314-9f91bfab8e2b" />



Reproduce with:

```bash
cd packages/scripts && npx vitest run src/checkNoControlBytes.test.ts
```

**2. The same suite running in CI**, in the `misc` test shard - so it gates every future PR,
not just this one:

<img width="3596" height="2006" alt="image" src="https://github.com/user-attachments/assets/f94532ab-3426-469d-8f0b-b069a9230d87" />


```
packages/scripts test:  OK src/checkNoControlBytes.test.ts (36 tests) 6919ms
```

## Description

Raw control bytes (NUL and friends) keep landing in tracked `.ts`/`.tsx` files, and nothing
in the pre-commit chain catches them. A raw NUL is the worst case: git and GitHub treat the
whole file as binary, so `grep`/`rg` silently return nothing and the file's diff is
unviewable in the PR UI.

The class has already recurred several times: `UserModel.ts` carried two NUL bytes, and the
same review then found two more sites with raw control bytes in test fixtures (a NUL and a
DEL in one, `0x03`/`0x04` in another).

This adds a dedicated staged-file guard wired into `.husky/pre-commit`, plus a CI mirror so
a `--no-verify` bypass is still caught. Closes #1385.

## Changes

- **New `scripts/check-no-control-bytes.sh`** - scans `.ts`/`.tsx` for C0 control bytes
  except tab/LF/CR, plus DEL (`0x7f`). Three modes:
  - default / `--staged` - staged files only, for the pre-commit hook (fast path).
  - `--changed <base>` - files added/modified vs `<base>`, for CI.
  - `--all` - every tracked `.ts`/`.tsx`.
- **`.husky/pre-commit`** - runs the guard as a subprocess between the overlay-lockfile
  check and gitleaks, ORing into `FINAL_EXIT_CODE` like every other check in the chain.
- **`.github/workflows/ci.yml`** - mirrors the guard in `core-build` next to the other
  repo-boundary checks.
- **New `packages/scripts/src/checkNoControlBytes.test.ts`** - 36 vitest cases driving the
  real script against throwaway git repos (see Tests below).

Implementation notes worth a reviewer's attention:

- **Uses perl, not `grep -P`.** macOS ships BSD grep, which has no `-P` flag at all; and
  even GNU grep needs `-a` to match a NUL, since without it grep treats the file as binary
  and skips the match - missing the exact worst case this guard exists for. Perl reads raw
  bytes and matches reliably on every platform.
- **Filenames never reach perl's `@ARGV`** (review finding, P0). `perl -n` wraps the body in
  `while (<>)`, and the diamond operator performs a magic 2-argument open on each `@ARGV`
  entry, so a tracked file merely *named* `|cmd.ts` would execute `cmd` - code execution
  triggered by the same careless-contributor case the guard exists to catch. Paths are now
  piped in NUL-separated on stdin and opened with a 3-argument `open`; staged mode uses the
  list form `open($fh, "-|", "git", "show", ":$f")`, which spawns no shell. Note a bare `--`
  does *not* fix this: it stops perl's own switch parsing, not the diamond operator's runtime
  behavior. Regression-tested, including a file named `-`.
- **Staged mode scans the staged blob, not the worktree copy** (review finding). Staging a
  file with a control byte and then cleaning it on disk without re-staging would otherwise
  pass the hook while `git commit` still committed the bad blob.
- **Listings use `-z`** (review finding). Without it git applies `core.quotePath` and emits a
  non-ASCII path C-quoted (`"caf\303\251.ts"`, quotes included), which names no real file and
  was silently skipped.
- **An unrecognized flag is an error** (review finding). A typo such as `--chagned` used to
  fall through to staged mode and quietly scan the wrong set; it now exits 1 with a usage line.
- **Bash 3.2 compatible.** No bash 4 builtins - notably no `mapfile`/`readarray`, which are
  absent from the `/bin/bash` macOS ships. A `mapfile` version fails with `command not found`,
  and inside the hook that sets `FINAL_EXIT_CODE=1` and blocks *every* commit on macOS. This
  mirrors the constraint already documented in `scripts/verify-infra-concurrency.sh`.
- **Fails closed.** A missing `perl`, an erroring `perl`, and a failing `git` listing all exit
  non-zero rather than reporting "clean". The listing is a real pipeline so `pipefail` sees a
  git failure; a process substitution (the earlier form) hides that exit code and would have
  produced an empty list and a bogus pass (review finding). A guard that silently passes when
  its own tooling breaks is worse than no guard.
- **`--diff-filter=ACMRC`, not `ACM`** (review finding). Git detects renames by default and
  emits a rename-plus-edit as a single `R<score>` record, whose status `ACM` drops entirely -
  so `git mv a.ts b.ts` plus a NUL edit committed clean past both the hook and CI. `ACMR`
  closes it, matching the precedent in `.husky/check-help-content.sh`; `C` covers the same
  shape if copy detection is ever enabled. Note `--name-only -z` emits one record per R/C
  record (the new path), so no stale old path reaches `git show`.
- **Bounded reads, compiled pattern** (review findings). Content is read in 64KB chunks
  rather than slurped, so a large generated `.ts` cannot balloon memory; the byte class has
  no multi-byte members, so no match can straddle a chunk. The chunk loop reads to EOF even
  after a hit, because closing a `git show` pipe early makes `close()` report the SIGPIPE as
  a failure and would mask the finding. The regex is compiled once in a `BEGIN` block
  instead of being re-interpolated per file.
- **Symlinks are skipped in disk modes** (review finding). Git stores a symlink as its
  TARGET PATH STRING, so reading through the link would scan bytes git is not tracking and
  would disagree with staged mode, which reads the blob. `-f` already kept non-regular
  targets (devices, fifos) out of the bounded read loop, so there was no hang to fix - the
  `-l` skip is about scanning the right bytes, and it removes any reliance on how `-f`
  treats links.
- **CI base resolution.** `core-build` fires on three triggers (`push` to main,
  `pull_request`, `merge_group`) and each exposes the base under a different key, so the
  step resolves
  `github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before`.
  When none resolve (for example an all-zero `before` on a new-branch push) the script
  falls back to `--all`, so an unknown base over-scans rather than silently scanning
  nothing.
- **Skips paths git lists but the worktree lacks.** Under `--all`, `git ls-files` reads the
  index, so a file deleted from the worktree without staging the deletion is still listed.
  Without an existence test perl would warn about a file there is nothing to scan. The skip
  does not abort the run - siblings in the same invocation are still scanned (regression-tested).

## Tests

`packages/scripts/src/checkNoControlBytes.test.ts` - 36 cases that run the real shell script
(not a reimplementation) against throwaway `git init` repos under `$TMPDIR`, so nothing
touches the working tree. This is the first test in the repo to cover one of the
`scripts/check-no-*.sh` guards; the siblings are currently untested.

| Group | Cases |
|-------|-------|
| staged mode (hook path) | tab/LF/CR allowed; NUL rejected and named; DEL rejected; `0x03`/`0x04` in `.tsx` rejected; NUL in `.md` ignored (scope); empty stage passes |
| `--changed` mode (CI path) | NUL committed after the base rejected; clean history passes; empty / all-zero / nonexistent base each falls back to a full scan and says so |
| `--all` mode | tracked NUL rejected; a tracked-but-deleted path is skipped; siblings still scanned after that skip |
| fail-closed | perl missing; perl present but exiting non-zero; the git listing failing |
| security | a filename beginning with `\|` is neither executed nor skipped, in BOTH staged and `--all` modes; a file named `-` is not treated as stdin in either mode |
| robustness | a non-ASCII path git would C-quote is still scanned; staged mode reads the staged blob, not the worktree copy |
| renames | a control byte added during a rename is caught in staged and `--changed` modes; a clean rename passes; a copy-plus-edit is caught with copy detection enabled |
| large files | a control byte beyond the first 64KB read chunk is still found |
| symlinks | a symlink is not scanned through in `--all` (git stores the target path, not its bytes), and a device-target symlink cannot enter the read loop |
| wiring | the guard is executable; an unknown option exits 1 with a usage line |

**Verified non-vacuous three ways:**

- **Against the pre-fix script.** 7 of the 9 cases added for the review findings fail when run
  against this branch's earlier guard, and all pass against the current one. The other 2
  cover behavior that already worked.
- **Mutation: pattern.** Removing `\x7f` fails only `rejects DEL (0x7f)`.
- **Mutation: fallback and staged-blob.** Making the `--changed` fallback scan nothing fails
  all three fallback cases; reverting staged mode to read the worktree copy fails exactly the
  staged-blob case. On a clean tree both "scanned everything" and "scanned nothing" exit 0, so
  nothing but these cases would surface the fallback regression.

The guard was restored byte-identical after each mutation.

## Guide for Testers

This is a developer-tooling PR with no application surface. Verification is local only - no
preview environment needed, nothing to click through.

**Prerequisite:** `pnpm install` from the repo root (vitest resolves from `node_modules`).
You do **not** need `pnpm turbo:core:build` - this test file imports only `vitest` and node
built-ins, so no `@bike4mind/*` package has to be built first.

1. Check out this branch and run the guard's test suite.
   Run: `cd packages/scripts && npx vitest run src/checkNoControlBytes.test.ts`
   Expected: `Tests 36 passed (36)`. This covers every mode (staged / `--changed` / `--all`),
   the base-resolution fallback, the fail-closed paths, and the security cases from review. Run `cd ../..` to return to the
   repo root afterwards.

2. Confirm the guard is executable, since both the hook and CI invoke it directly.
   Run: `ls -l scripts/check-no-control-bytes.sh`
   Expected: mode shows `-rwxr-xr-x`.

3. Confirm the guard is clean against the current tree (no false positives).
   Run: `bash scripts/check-no-control-bytes.sh --all; echo "exit=$?"`
   Expected: `exit=0` and no output.

<details>
<summary><b>Optional: standalone shell verification (no JS toolchain needed)</b></summary>

A subset of the vitest coverage (15 checks) as a single script, for anyone who wants to see the guard
exercised without running vitest. It builds throwaway `git init` repos under `$TMPDIR` and
asserts your working tree is unchanged at the end, so it never stages or commits anything in
your checkout. Save as `verify-control-bytes.sh` in the repo root and run `bash verify-control-bytes.sh`.

```bash
#!/usr/bin/env bash
# Verify scripts/check-no-control-bytes.sh (issue #1385). Run from the repo root.
set -euo pipefail

GUARD="$PWD/scripts/check-no-control-bytes.sh"
[ -f "$GUARD" ] || { echo "Run from the repo root."; exit 1; }
REAL_REPO="$PWD"
BEFORE=$(git -C "$REAL_REPO" status --porcelain | sort)

pass=0; fail=0
ok()  { printf '  PASS  %s\n' "$1"; pass=$((pass+1)); }
bad() { printf '  FAIL  %s (%s)\n' "$1" "$2"; fail=$((fail+1)); }
check() { [ "$2" = "$3" ] && ok "$1" || bad "$1" "expected exit $2, got $3"; }

SANDBOX=$(mktemp -d)
trap 'rm -rf "$SANDBOX"' EXIT
cd "$SANDBOX" || { echo "FATAL: cannot enter sandbox"; exit 1; }
case "$PWD" in "$SANDBOX"*) ;; *) echo "FATAL: not in sandbox"; exit 1;; esac
git rev-parse --show-toplevel >/dev/null 2>&1 && { echo "FATAL: sandbox is inside a git repo"; exit 1; }

git init -q .
git config user.email verify@example.test
git config user.name verify
git config core.safecrlf false
git config core.autocrlf false
git commit -q --allow-empty -m base
BASE=$(git rev-parse HEAD)

run() { set +e; bash "$GUARD" "$@" >out.txt 2>err.txt; local rc=$?; set -e; echo $rc; }

echo "staged mode -- what the pre-commit hook runs"
printf 'export const ok = 1;\n\tconst tabbed = 2;\r\n' > clean.ts
git add clean.ts
check "clean file with tab/LF/CR is allowed" 0 "$(run)"

printf 'export const bad = 1;\x00\n' > nul.ts
git add nul.ts
check "raw NUL is rejected" 1 "$(run)"
grep -q 'nul.ts' out.txt && ok "offending file is named" || bad "file named" "absent"
git rm -q --cached nul.ts; rm -f nul.ts

printf 'export const bad = 1;\x7f\n' > del.ts
git add del.ts
check "DEL 0x7f is rejected" 1 "$(run)"
git rm -q --cached del.ts; rm -f del.ts

printf 'const a = "\x03";\nconst b = "\x04";\n' > ctrl.tsx
git add ctrl.tsx
check "0x03 / 0x04 in a .tsx is rejected" 1 "$(run)"
git rm -q --cached ctrl.tsx; rm -f ctrl.tsx

printf 'doc with a NUL: \x00\n' > notes.md
git add notes.md
check "NUL in a .md is ignored (scope is .ts/.tsx)" 0 "$(run)"
git rm -q --cached notes.md; rm -f notes.md

echo ""
echo "--changed mode -- what CI runs"
git commit -q -m "commit the clean file"
printf 'export const later = 1;\x00\n' > added.ts
git add added.ts; git commit -q -m "commit a file containing a NUL"
check "NUL committed after the base is rejected" 1 "$(run --changed "$BASE")"

rc=$(run --changed "")
check "empty base falls back rather than scanning nothing" 1 "$rc"
grep -q 'unresolvable' err.txt && ok "fallback notice on stderr" || bad "fallback notice" "absent"

check "all-zero base (new-branch push) falls back" 1 "$(run --changed 0000000000000000000000000000000000000000)"
check "--all rejects it too" 1 "$(run --all)"
git rm -q added.ts; git commit -q -m "remove the bad file"
check "clean history passes in --changed mode" 0 "$(run --changed "$BASE")"

echo ""
echo "fail-closed behaviour"
FAKEBIN=$(mktemp -d)
ln -s "$(command -v git)" "$FAKEBIN/git"
set +e
env PATH="$FAKEBIN" /bin/bash "$GUARD" --all >out.txt 2>&1
rc=$?
set -e
check "missing perl fails closed instead of reporting clean" 1 "$rc"
grep -q 'perl not found' out.txt && ok "failure explains the cause" || bad "perl message" "absent"
rm -rf "$FAKEBIN"

echo ""
echo "-------------------------------------------"
AFTER=$(git -C "$REAL_REPO" status --porcelain | sort)
[ "$BEFORE" = "$AFTER" ] && ok "your working tree is unchanged by this run" || bad "working tree changed" "unexpected"
printf '\npassed: %d   failed: %d\n' "$pass" "$fail"
[ "$fail" -eq 0 ] || exit 1
```

</details>

### Regression Checks

4. Confirm the rest of the pre-commit chain still runs in order and is not short-circuited by
   the new check. Run the hook directly - no commit needed, so there is nothing to undo:
   Run: `bash .husky/pre-commit`
   Expected: exit 0, and these lines in this order, with the new one before gitleaks and none
   of the later checks missing:

   ```
   Running pnpm link check...
   Running deprecated model usage check on staged files...
   Running no-baseapi check...
   Running user-lookup projection check...
   Running account-tied ID check...
   Running overlay lockfile check...
   Running control-byte check...
   Running gitleaks check...
   ```

   The ordering matters: the hook runs each guard as a subprocess and ORs the exit codes, so
   a guard that used `source` and called `exit` would silently swallow every later check.

### What NOT to test

- No UI, route, API, or database behavior changes - nothing to click through in the app.
- No preview environment needed; do not look for a deployed surface.
- Do not test the CI `--changed` step by pushing junk; the test suite in step 1 covers its
  base resolution and fallback locally.

## Additional Information

Split out of the narrow source-encoding cleanup that surfaced the problem, per #1385: a new
pre-commit guard is its own piece of work with its own review surface, so it is not folded
into that cleanup.

Scope decisions settled during implementation (the three items #1385 left open):

- **File scope:** `.ts`/`.tsx` only, matching the issue title and every recurrence observed
  so far. Widening to `.js`/`.mjs`/`.cjs`/`.json` is a cheap follow-up if wanted.
- **DEL (`0x7f`):** kept in the pattern. It does not break grep, but it tripped the same
  review, and including it keeps the rule simply "no raw control bytes".
- **CI mirror:** included, since catching a `--no-verify` bypass is the main reason to have
  one.

## Developer Notes (Optional)

- **New reusable guard shape:** a single-source guard serving both the hook and CI from one
  pattern with a mode flag (`--staged` / `--changed <base>` / `--all`), instead of
  duplicating the rule in two places where it can drift.
- **CI base-ref resolution pattern:** the
  `pull_request.base.sha || merge_group.base_sha || event.before` chain plus a safe
  over-scan fallback is reusable by any future changed-files CI check in this repo, where
  `core-build` serves three different trigger types.
- **Documented platform constraint:** adds a second in-repo reference point (alongside
  `verify-infra-concurrency.sh`) for why repo shell scripts must avoid bash 4 builtins like
  `mapfile`/`readarray`.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
