### PR TITLE
feat(sessions): first-class triage router via registry-backed systemPromptId

### DIFF
--- a/apps/client/__tests__/sessionSystemPromptWiring.test.ts
+++ b/apps/client/__tests__/sessionSystemPromptWiring.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * Wiring drift guard for `session.systemPromptId` resolution.
+ *
+ * `ChatCompletionProcess` only resolves a session's registry prompt when its options carry
+ * `loadSystemPromptById`; with the key absent it silently falls through to `undefined` and the
+ * session gets no authored prompt. That is invisible at runtime, and the route has already
+ * suppressed the generic brand identity by then - so the session ends up with neither.
+ *
+ * This is not hypothetical. The resolver first shipped as an inline lambda inside
+ * `chatCompletionDefaults`, which meant only the routes that spread THAT factory had it. Every
+ * `/api/ai/llm` quest is handed to the always-on ChatCompletion worker, whose `getStaticOptions()`
+ * is a separate hand-maintained object - so the feature was inert on the path the SPA actually uses
+ * while looking correct in review. Same shape as the premium-tools seam that
+ * `premiumToolsWiring.test.ts` guards, and the same reason: a capability wired per-factory is a
+ * capability that silently isn't.
+ *
+ * A file passes if it references `loadSystemPromptById` directly, or spreads
+ * `getDefaultChatCompletionOptions()` (which supplies it), or is explicitly allowlisted.
+ */
+
+const CLIENT_ROOT = join(__dirname, '..');
+
+/** Construction sites intentionally allowed to omit the resolver, with justification. */
+const INTENTIONAL_OMISSIONS = new Set<string>([]);
+
+const SCAN_DIRS = ['pages', 'server'];
+const SKIP_DIRS = new Set(['node_modules', '.next', '.open-next', '.sst', '__tests__', 'premium-generated']);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) walk(join(dir, entry.name), out);
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      out.push(join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+describe('session systemPromptId resolver wiring', () => {
+  const callSites = SCAN_DIRS.flatMap(d => walk(join(CLIENT_ROOT, d)))
+    .filter(f => readFileSync(f, 'utf8').includes('new ChatCompletionProcess('))
+    .map(f => relative(CLIENT_ROOT, f));
+
+  it('finds the known ChatCompletionProcess call sites (sanity)', () => {
+    // If this drops to zero the scan itself broke (renamed class, moved dirs) and every
+    // assertion below would vacuously pass.
+    expect(callSites.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it.each(callSites)('%s supplies loadSystemPromptById or is allowlisted', file => {
+    const content = readFileSync(join(CLIENT_ROOT, file), 'utf8');
+    const wired =
+      content.includes('loadSystemPromptById') || content.includes('getDefaultChatCompletionOptions');
+    expect(
+      wired || INTENTIONAL_OMISSIONS.has(file),
+      `${file} constructs ChatCompletionProcess but neither supplies loadSystemPromptById nor spreads ` +
+        `getDefaultChatCompletionOptions. A session with systemPromptId set would silently get no ` +
+        `authored prompt here. Wire it, or allowlist with a justification.`
+    ).toBe(true);
+  });
+
+  it('keeps the allowlist free of stale entries', () => {
+    for (const entry of INTENTIONAL_OMISSIONS) {
+      expect(callSites, `allowlist entry ${entry} no longer constructs ChatCompletionProcess`).toContain(entry);
+    }
+  });
+
+  it('resolves the id through exactly one shared implementation', () => {
+    // The bug this guards against was one factory having its own copy. If a second inline
+    // implementation appears, the guard above would still pass while the copies drift.
+    const implementations = SCAN_DIRS.flatMap(d => walk(join(CLIENT_ROOT, d))).filter(f =>
+      /loadSystemPromptById\s*(:|=)\s*async/.test(readFileSync(f, 'utf8'))
+    );
+    expect(
+      implementations.map(f => relative(CLIENT_ROOT, f)),
+      'loadSystemPromptById should be defined once, in server/utils/sessionSystemPromptResolver.ts'
+    ).toEqual(['server/utils/sessionSystemPromptResolver.ts']);
+  });
+});

--- a/apps/client/__tests__/sessionSystemPromptWiring.test.ts
+++ b/apps/client/__tests__/sessionSystemPromptWiring.test.ts
@@ -6,35 +6,58 @@ import { join, relative } from 'node:path';
  * Wiring drift guard for `session.systemPromptId` resolution.
  *
  * `ChatCompletionProcess` only resolves a session's registry prompt when its options carry
- * `loadSystemPromptById`; with the key absent it silently falls through to `undefined` and the
- * session gets no authored prompt. That is invisible at runtime, and the route has already
- * suppressed the generic brand identity by then - so the session ends up with neither.
+ * `loadSystemPromptById`; with the key absent it falls through to `undefined` and the session gets
+ * no authored prompt, while the route has already suppressed the generic brand identity by then -
+ * so the session ends up with neither, silently.
  *
- * This is not hypothetical. The resolver first shipped as an inline lambda inside
- * `chatCompletionDefaults`, which meant only the routes that spread THAT factory had it. Every
- * `/api/ai/llm` quest is handed to the always-on ChatCompletion worker, whose `getStaticOptions()`
- * is a separate hand-maintained object - so the feature was inert on the path the SPA actually uses
- * while looking correct in review. Same shape as the premium-tools seam that
- * `premiumToolsWiring.test.ts` guards, and the same reason: a capability wired per-factory is a
- * capability that silently isn't.
+ * Not hypothetical: the resolver first shipped as an inline lambda inside `chatCompletionDefaults`,
+ * so only routes spreading THAT factory had it. Every `/api/ai/llm` quest goes to the always-on
+ * ChatCompletion worker, whose `getStaticOptions()` is a separate hand-maintained object - the
+ * feature was inert on the path the SPA actually uses while looking correct in review.
  *
- * A file passes if it references `loadSystemPromptById` directly, or spreads
- * `getDefaultChatCompletionOptions()` (which supplies it), or is explicitly allowlisted.
+ * WHAT THIS CATCHES, stated precisely because an earlier version of this file overclaimed and a
+ * docstring elsewhere cites it as proof of non-recurrence:
+ *   - a construction site whose options object omits the key (the original bug), because the
+ *     per-site check requires the PROPERTY, not a mention of the identifier anywhere in the file.
+ *     A bare import, a reference inside a comment, or a helper that merely calls the resolver do
+ *     NOT satisfy it.
+ *   - a second implementation of the resolver appearing anywhere in the scanned tree, in any
+ *     declaration form, so a rogue copy that skips the allowlist cannot quietly coexist.
+ *
+ * WHAT IT DOES NOT CATCH - do not read a green run as proof of correct wiring:
+ *   - construction outside `apps/client/pages` and `apps/client/server` (e.g. `b4m-core`,
+ *     `packages/cli`), or inside `premium-generated`, which overlays hydrate and which is skipped.
+ *   - a site that aliases the import (`ChatCompletionProcess as CCP`), subclasses it, or builds it
+ *     through a wrapper, since the scan matches the literal `new ChatCompletionProcess(`.
+ *   - whether the resolver, once passed, actually returns anything useful at runtime.
+ *
+ * `premiumToolsWiring.test.ts` guards the same class of defect for premium tools and still uses a
+ * whole-file substring check, so it has the first weakness this file just fixed. Worth aligning.
  */
 
 const CLIENT_ROOT = join(__dirname, '..');
 
-/** Construction sites intentionally allowed to omit the resolver, with justification. */
+/**
+ * Construction sites intentionally allowed to omit the resolver. An entry here silently restores
+ * the original bug for that file, so it needs a written justification next to it.
+ */
 const INTENTIONAL_OMISSIONS = new Set<string>([]);
 
 const SCAN_DIRS = ['pages', 'server'];
 const SKIP_DIRS = new Set(['node_modules', '.next', '.open-next', '.sst', '__tests__', 'premium-generated']);
 
+/** The key as an object PROPERTY - shorthand (`loadSystemPromptById,`) or explicit (`x: fn`). */
+const SUPPLIES_PROPERTY = /^\s*loadSystemPromptById\s*[,:]/m;
+/** Inheriting it by spreading the shared factory is equally valid wiring. */
+const SPREADS_FACTORY = /\.\.\.\s*getDefaultChatCompletionOptions\s*\(/;
+/** Any declaration form, so a reformat of the canonical resolver is not a false alarm. */
+const DEFINES_RESOLVER = /export\s+(?:const|(?:async\s+)?function)\s+loadSystemPromptById\b/;
+
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
       if (!SKIP_DIRS.has(entry.name)) walk(join(dir, entry.name), out);
-    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+    } else if (/\.(tsx?|mjs|js)$/.test(entry.name) && !/\.test\.(tsx?|js)$/.test(entry.name)) {
       out.push(join(dir, entry.name));
     }
   }
@@ -42,43 +65,50 @@ function walk(dir: string, out: string[] = []): string[] {
 }
 
 describe('session systemPromptId resolver wiring', () => {
-  const callSites = SCAN_DIRS.flatMap(d => walk(join(CLIENT_ROOT, d)))
+  const scanned = SCAN_DIRS.flatMap(d => walk(join(CLIENT_ROOT, d)));
+  const callSites = scanned
     .filter(f => readFileSync(f, 'utf8').includes('new ChatCompletionProcess('))
     .map(f => relative(CLIENT_ROOT, f));
 
-  it('finds the known ChatCompletionProcess call sites (sanity)', () => {
-    // If this drops to zero the scan itself broke (renamed class, moved dirs) and every
-    // assertion below would vacuously pass.
-    expect(callSites.length).toBeGreaterThanOrEqual(5);
+  it('the scan itself works (guards against every assertion below passing vacuously)', () => {
+    // Deliberately NOT a specific count: consolidating the five factories into one shared builder
+    // would be an improvement that reduces it, and a guard that punishes the fix is a guard that
+    // gets deleted. This only asserts the walk found files and at least one construction site.
+    expect(scanned.length).toBeGreaterThan(50);
+    expect(callSites.length).toBeGreaterThan(0);
   });
 
-  it.each(callSites)('%s supplies loadSystemPromptById or is allowlisted', file => {
+  it.each(callSites)('%s supplies loadSystemPromptById as an option or is allowlisted', file => {
     const content = readFileSync(join(CLIENT_ROOT, file), 'utf8');
-    const wired =
-      content.includes('loadSystemPromptById') || content.includes('getDefaultChatCompletionOptions');
+    const wired = SUPPLIES_PROPERTY.test(content) || SPREADS_FACTORY.test(content);
     expect(
       wired || INTENTIONAL_OMISSIONS.has(file),
-      `${file} constructs ChatCompletionProcess but neither supplies loadSystemPromptById nor spreads ` +
-        `getDefaultChatCompletionOptions. A session with systemPromptId set would silently get no ` +
-        `authored prompt here. Wire it, or allowlist with a justification.`
+      `${file} constructs ChatCompletionProcess but does not pass loadSystemPromptById as an ` +
+        `options property, nor spread getDefaultChatCompletionOptions(). A session with ` +
+        `systemPromptId set would silently get no authored prompt here. Note an import or a ` +
+        `mention of the name is deliberately NOT enough - the key must be in the options object.`
     ).toBe(true);
   });
 
   it('keeps the allowlist free of stale entries', () => {
+    // Vacuous while the allowlist is empty, which is the intended steady state; it exists so an
+    // entry cannot outlive the call site it was added for.
     for (const entry of INTENTIONAL_OMISSIONS) {
       expect(callSites, `allowlist entry ${entry} no longer constructs ChatCompletionProcess`).toContain(entry);
     }
   });
 
   it('resolves the id through exactly one shared implementation', () => {
-    // The bug this guards against was one factory having its own copy. If a second inline
-    // implementation appears, the guard above would still pass while the copies drift.
-    const implementations = SCAN_DIRS.flatMap(d => walk(join(CLIENT_ROOT, d))).filter(f =>
-      /loadSystemPromptById\s*(:|=)\s*async/.test(readFileSync(f, 'utf8'))
-    );
+    // The original bug was one factory owning its own copy. Matching any export form (const,
+    // function, async function) so a behaviour-preserving reformat of the canonical resolver does
+    // not fail this, while a genuine second definition - including one that skips the allowlist
+    // check - does.
+    const implementations = scanned
+      .filter(f => DEFINES_RESOLVER.test(readFileSync(f, 'utf8')))
+      .map(f => relative(CLIENT_ROOT, f));
     expect(
-      implementations.map(f => relative(CLIENT_ROOT, f)),
-      'loadSystemPromptById should be defined once, in server/utils/sessionSystemPromptResolver.ts'
+      implementations,
+      'loadSystemPromptById must be defined exactly once, in server/utils/sessionSystemPromptResolver.ts'
     ).toEqual(['server/utils/sessionSystemPromptResolver.ts']);
   });
 });

--- a/apps/client/pages/api/ai/llm.ts
+++ b/apps/client/pages/api/ai/llm.ts
@@ -6,6 +6,7 @@ import { getOrCreateSession } from '@server/managers/sessionManager';
 import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { getDefaultChatCompletionOptions, getSharedTokenizer } from '@server/utils/chatCompletionDefaults';
+import { hasAuthoredSessionPrompt } from '@server/utils/sessionActivatablePrompts';
 import { dispatchQuest } from '@server/utils/dispatchQuest';
 import { loadBaseIdentitySystemPromptMessages } from '@server/utils/systemPrompts/loader';
 import { Request } from 'express';
@@ -38,8 +39,11 @@ const handler = baseApi()
     // carries its OWN authored prompt skips it - either raw `systemPromptText` (e.g. the /opti
     // surface) or a curated registry prompt via `systemPromptId` (e.g. the triage router, which the
     // completion path resolves + injects on every entry point) - so its persona isn't diluted.
+    // Asks the shared predicate rather than testing `systemPromptId` for presence: the id is
+    // client-settable, and a non-allowlisted one injects nothing, so presence alone would suppress
+    // the identity and leave the session with no authored prompt at all.
     // Prepended ahead of any client-sent context.
-    if (!session.systemPromptText && !session.systemPromptId) {
+    if (!hasAuthoredSessionPrompt(session)) {
       const identityPrompts = await loadBaseIdentitySystemPromptMessages(req.logger);
       if (identityPrompts.length > 0) {
         invokeParams.extraContextMessages = [...identityPrompts, ...(invokeParams.extraContextMessages ?? [])];

--- a/apps/client/pages/api/ai/llm.ts
+++ b/apps/client/pages/api/ai/llm.ts
@@ -7,8 +7,17 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { getDefaultChatCompletionOptions, getSharedTokenizer } from '@server/utils/chatCompletionDefaults';
 import { dispatchQuest } from '@server/utils/dispatchQuest';
-import { loadBaseIdentitySystemPromptMessages } from '@server/utils/systemPrompts/loader';
+import {
+  loadBaseIdentitySystemPromptMessages,
+  loadSystemPromptContent,
+  buildSystemPromptMessage,
+} from '@server/utils/systemPrompts/loader';
 import { Request } from 'express';
+
+// Registry prompts a session may activate via `session.systemPromptId`. An allowlist, not an open
+// door: a session must not be able to inject an arbitrary admin/system prompt, so only ids meant to
+// be session-scoped modes live here. `triage_router` is the grounding-first request router.
+const SESSION_ACTIVATABLE_PROMPT_IDS = new Set<string>(['triage_router']);
 
 const handler = baseApi()
   .use(
@@ -34,13 +43,26 @@ const handler = baseApi()
     // Update the user's last notebook ID
     asyncPromises.push(userRepository.update({ id: req.user.id, lastNotebookId: sessionId }));
 
-    // General chat: give the assistant Bike4Mind's identity so it can pitch the product
-    // when asked instead of disowning it. Sessions that carry their own server-owned system
-    // prompt (e.g. the /opti surface) already have a specialized persona and their treatment
-    // - toolset, prompt, temperature, tool-call cap, integration isolation - rides on generic
-    // session fields applied by the completion path, so they skip the generic identity here.
-    // Prepended ahead of any client-sent context.
-    if (!session.systemPromptText) {
+    // A session gets ONE authored voice, prepended ahead of any client-sent context:
+    //  - `systemPromptId` -> a curated registry prompt (e.g. the triage router), resolved to its
+    //    CURRENT content here so admin edits take effect with no deploy;
+    //  - else `systemPromptText` -> a raw server-owned prompt (e.g. the /opti surface), injected by
+    //    the completion path itself;
+    //  - else the generic brand identity, so plain chat can pitch the product when asked.
+    // A session that carries either of its own prompts skips the identity (same as before).
+    const activatablePromptId =
+      session.systemPromptId && SESSION_ACTIVATABLE_PROMPT_IDS.has(session.systemPromptId)
+        ? session.systemPromptId
+        : undefined;
+    if (activatablePromptId) {
+      const resolved = await loadSystemPromptContent(activatablePromptId);
+      if (resolved) {
+        invokeParams.extraContextMessages = [
+          buildSystemPromptMessage(activatablePromptId, resolved.content),
+          ...(invokeParams.extraContextMessages ?? []),
+        ];
+      }
+    } else if (!session.systemPromptText) {
       const identityPrompts = await loadBaseIdentitySystemPromptMessages(req.logger);
       if (identityPrompts.length > 0) {
         invokeParams.extraContextMessages = [...identityPrompts, ...(invokeParams.extraContextMessages ?? [])];

--- a/apps/client/pages/api/ai/llm.ts
+++ b/apps/client/pages/api/ai/llm.ts
@@ -7,17 +7,8 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { getDefaultChatCompletionOptions, getSharedTokenizer } from '@server/utils/chatCompletionDefaults';
 import { dispatchQuest } from '@server/utils/dispatchQuest';
-import {
-  loadBaseIdentitySystemPromptMessages,
-  loadSystemPromptContent,
-  buildSystemPromptMessage,
-} from '@server/utils/systemPrompts/loader';
+import { loadBaseIdentitySystemPromptMessages } from '@server/utils/systemPrompts/loader';
 import { Request } from 'express';
-
-// Registry prompts a session may activate via `session.systemPromptId`. An allowlist, not an open
-// door: a session must not be able to inject an arbitrary admin/system prompt, so only ids meant to
-// be session-scoped modes live here. `triage_router` is the grounding-first request router.
-const SESSION_ACTIVATABLE_PROMPT_IDS = new Set<string>(['triage_router']);
 
 const handler = baseApi()
   .use(
@@ -43,26 +34,12 @@ const handler = baseApi()
     // Update the user's last notebook ID
     asyncPromises.push(userRepository.update({ id: req.user.id, lastNotebookId: sessionId }));
 
-    // A session gets ONE authored voice, prepended ahead of any client-sent context:
-    //  - `systemPromptId` -> a curated registry prompt (e.g. the triage router), resolved to its
-    //    CURRENT content here so admin edits take effect with no deploy;
-    //  - else `systemPromptText` -> a raw server-owned prompt (e.g. the /opti surface), injected by
-    //    the completion path itself;
-    //  - else the generic brand identity, so plain chat can pitch the product when asked.
-    // A session that carries either of its own prompts skips the identity (same as before).
-    const activatablePromptId =
-      session.systemPromptId && SESSION_ACTIVATABLE_PROMPT_IDS.has(session.systemPromptId)
-        ? session.systemPromptId
-        : undefined;
-    if (activatablePromptId) {
-      const resolved = await loadSystemPromptContent(activatablePromptId);
-      if (resolved) {
-        invokeParams.extraContextMessages = [
-          buildSystemPromptMessage(activatablePromptId, resolved.content),
-          ...(invokeParams.extraContextMessages ?? []),
-        ];
-      }
-    } else if (!session.systemPromptText) {
+    // General chat gets the brand identity so it can pitch the product when asked. A session that
+    // carries its OWN authored prompt skips it - either raw `systemPromptText` (e.g. the /opti
+    // surface) or a curated registry prompt via `systemPromptId` (e.g. the triage router, which the
+    // completion path resolves + injects on every entry point) - so its persona isn't diluted.
+    // Prepended ahead of any client-sent context.
+    if (!session.systemPromptText && !session.systemPromptId) {
       const identityPrompts = await loadBaseIdentitySystemPromptMessages(req.logger);
       if (identityPrompts.length > 0) {
         invokeParams.extraContextMessages = [...identityPrompts, ...(invokeParams.extraContextMessages ?? [])];

--- a/apps/client/server/queueHandlers/questProcessor.ts
+++ b/apps/client/server/queueHandlers/questProcessor.ts
@@ -48,6 +48,7 @@ import { IUserDocument, Permission } from '@bike4mind/common';
 import { LLMEvents, SessionEvents } from '@server/utils/eventBus';
 import { getSharedTokenizer, publishTelemetryAlertCallback } from '../utils/chatCompletionDefaults';
 import { recallMementosV2 } from '@server/memory/recallMementosV2';
+import { loadSystemPromptById } from '@server/utils/sessionSystemPromptResolver';
 import { slackToolDefinitions, createPendingActionToolDefs } from '@bike4mind/slack';
 import { executePendingAction, cancelPendingActionOnQuest } from '@server/utils/pendingActionExecutor';
 import { getMcpClientAdapter } from '@server/utils/getMcpClientAdapter';
@@ -161,6 +162,9 @@ const getStaticOptions = () => {
       });
     },
     recallMementosV2,
+    // Without this the worker resolves session.systemPromptId to undefined, so a triage session
+    // gets no authored prompt while the route has already suppressed the brand identity.
+    loadSystemPromptById,
     summarizeSession: summarizeSession,
     contextSummarizeSession: contextSummarizeSession,
     getMcpClient: getMcpClientAdapter,

--- a/apps/client/server/queueHandlers/slackQuestProcessor.ts
+++ b/apps/client/server/queueHandlers/slackQuestProcessor.ts
@@ -67,6 +67,7 @@ import {
 import { executePendingAction, cancelPendingActionOnQuest } from '@server/utils/pendingActionExecutor';
 import { getSharedTokenizer, publishTelemetryAlertCallback } from '../utils/chatCompletionDefaults';
 import { recallMementosV2 } from '@server/memory/recallMementosV2';
+import { loadSystemPromptById } from '@server/utils/sessionSystemPromptResolver';
 import { decryptToken } from '@server/security/tokenEncryption';
 
 // Cache static ChatCompletion options that don't change between invocations
@@ -174,6 +175,9 @@ const getStaticOptions = () => {
       });
     },
     recallMementosV2,
+    // Without this the worker resolves session.systemPromptId to undefined, so a triage session
+    // gets no authored prompt while the route has already suppressed the brand identity.
+    loadSystemPromptById,
     summarizeSession: summarizeSession,
     contextSummarizeSession: contextSummarizeSession,
     getMcpClient: getMcpClientAdapter,

--- a/apps/client/server/utils/chatCompletionDefaults.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.ts
@@ -46,8 +46,7 @@ import { ILogger, Logger } from '@bike4mind/observability';
 import { accessibleBy } from '@casl/mongoose';
 import { logEvent } from '@server/utils/analyticsLog';
 import { recallMementosV2 } from '@server/memory/recallMementosV2';
-import { loadSystemPromptContent } from '@server/utils/systemPrompts/loader';
-import { isSessionActivatablePromptId } from '@server/utils/sessionActivatablePrompts';
+import { loadSystemPromptById } from '@server/utils/sessionSystemPromptResolver';
 import { summarizeSession, contextSummarizeSession } from '@server/managers/sessionManager';
 import { getUserEntitlements } from '@server/entitlements';
 import { Config } from '@server/utils/config';
@@ -204,14 +203,9 @@ export const getDefaultChatCompletionOptions = (): DefaultChatCompletionOptions 
       });
     },
     recallMementosV2,
-    // Resolve a session's `systemPromptId` to the registry prompt's current content, gated by the
-    // activatable allowlist. Injected into the engine so a lake/triage session gets its authored
-    // prompt on every entry point (chat, llm, queue) without the core touching the app registry.
-    loadSystemPromptById: async (promptId: string): Promise<string | null> => {
-      if (!isSessionActivatablePromptId(promptId)) return null;
-      const resolved = await loadSystemPromptContent(promptId);
-      return resolved?.content ?? null;
-    },
+    // Shared with the queue processors - see sessionSystemPromptResolver for why this must not be
+    // an inline lambda per factory.
+    loadSystemPromptById,
     summarizeSession: summarizeSession,
     contextSummarizeSession: contextSummarizeSession,
     getMcpClient: async (

--- a/apps/client/server/utils/chatCompletionDefaults.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.ts
@@ -47,11 +47,7 @@ import { accessibleBy } from '@casl/mongoose';
 import { logEvent } from '@server/utils/analyticsLog';
 import { recallMementosV2 } from '@server/memory/recallMementosV2';
 import { loadSystemPromptContent } from '@server/utils/systemPrompts/loader';
-
-// Registry prompts a session may activate via `session.systemPromptId`. An allowlist, not an open
-// door: a session must not be able to inject an arbitrary admin/system prompt, so only ids meant to
-// run as session-scoped modes live here. `triage_router` is the grounding-first request router.
-const SESSION_ACTIVATABLE_PROMPT_IDS = new Set<string>(['triage_router']);
+import { isSessionActivatablePromptId } from '@server/utils/sessionActivatablePrompts';
 import { summarizeSession, contextSummarizeSession } from '@server/managers/sessionManager';
 import { getUserEntitlements } from '@server/entitlements';
 import { Config } from '@server/utils/config';
@@ -212,7 +208,7 @@ export const getDefaultChatCompletionOptions = (): DefaultChatCompletionOptions 
     // activatable allowlist. Injected into the engine so a lake/triage session gets its authored
     // prompt on every entry point (chat, llm, queue) without the core touching the app registry.
     loadSystemPromptById: async (promptId: string): Promise<string | null> => {
-      if (!SESSION_ACTIVATABLE_PROMPT_IDS.has(promptId)) return null;
+      if (!isSessionActivatablePromptId(promptId)) return null;
       const resolved = await loadSystemPromptContent(promptId);
       return resolved?.content ?? null;
     },

--- a/apps/client/server/utils/chatCompletionDefaults.ts
+++ b/apps/client/server/utils/chatCompletionDefaults.ts
@@ -46,6 +46,12 @@ import { ILogger, Logger } from '@bike4mind/observability';
 import { accessibleBy } from '@casl/mongoose';
 import { logEvent } from '@server/utils/analyticsLog';
 import { recallMementosV2 } from '@server/memory/recallMementosV2';
+import { loadSystemPromptContent } from '@server/utils/systemPrompts/loader';
+
+// Registry prompts a session may activate via `session.systemPromptId`. An allowlist, not an open
+// door: a session must not be able to inject an arbitrary admin/system prompt, so only ids meant to
+// run as session-scoped modes live here. `triage_router` is the grounding-first request router.
+const SESSION_ACTIVATABLE_PROMPT_IDS = new Set<string>(['triage_router']);
 import { summarizeSession, contextSummarizeSession } from '@server/managers/sessionManager';
 import { getUserEntitlements } from '@server/entitlements';
 import { Config } from '@server/utils/config';
@@ -202,6 +208,14 @@ export const getDefaultChatCompletionOptions = (): DefaultChatCompletionOptions 
       });
     },
     recallMementosV2,
+    // Resolve a session's `systemPromptId` to the registry prompt's current content, gated by the
+    // activatable allowlist. Injected into the engine so a lake/triage session gets its authored
+    // prompt on every entry point (chat, llm, queue) without the core touching the app registry.
+    loadSystemPromptById: async (promptId: string): Promise<string | null> => {
+      if (!SESSION_ACTIVATABLE_PROMPT_IDS.has(promptId)) return null;
+      const resolved = await loadSystemPromptContent(promptId);
+      return resolved?.content ?? null;
+    },
     summarizeSession: summarizeSession,
     contextSummarizeSession: contextSummarizeSession,
     getMcpClient: async (

--- a/apps/client/server/utils/sessionActivatablePrompts.test.ts
+++ b/apps/client/server/utils/sessionActivatablePrompts.test.ts
@@ -8,7 +8,12 @@ describe('isSessionActivatablePromptId', () => {
 
   // `systemPromptId` arrives from the client via POST /api/sessions/create, so these are the cases
   // that matter: without the allowlist, any of them would resolve a real registry prompt and inject
-  // it as the session's system message. Deleting the allowlist check turns these red.
+  // it as the session's system message.
+  //
+  // What these tests do and do not prove: deleting the membership check INSIDE this module turns
+  // them red, so the policy itself is regression-locked. They do NOT prove the policy is enforced -
+  // the call in sessionSystemPromptResolver is what enforces it, and no unit test here can see that
+  // call go missing. sessionSystemPromptWiring.test.ts covers that separately.
   it('rejects an arbitrary client-supplied id', () => {
     expect(isSessionActivatablePromptId('anything')).toBe(false);
   });

--- a/apps/client/server/utils/sessionActivatablePrompts.test.ts
+++ b/apps/client/server/utils/sessionActivatablePrompts.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { isSessionActivatablePromptId, hasAuthoredSessionPrompt } from './sessionActivatablePrompts';
+
+describe('isSessionActivatablePromptId', () => {
+  it('admits the triage router', () => {
+    expect(isSessionActivatablePromptId('triage_router')).toBe(true);
+  });
+
+  // `systemPromptId` arrives from the client via POST /api/sessions/create, so these are the cases
+  // that matter: without the allowlist, any of them would resolve a real registry prompt and inject
+  // it as the session's system message. Deleting the allowlist check turns these red.
+  it('rejects an arbitrary client-supplied id', () => {
+    expect(isSessionActivatablePromptId('anything')).toBe(false);
+  });
+
+  it('rejects a real registry prompt that is NOT session-activatable', () => {
+    // Exists in the registry and would load fine; it is simply not a session-scoped mode.
+    expect(isSessionActivatablePromptId('bike4mind_identity')).toBe(false);
+  });
+
+  it('rejects undefined and empty', () => {
+    expect(isSessionActivatablePromptId(undefined)).toBe(false);
+    expect(isSessionActivatablePromptId('')).toBe(false);
+  });
+});
+
+describe('hasAuthoredSessionPrompt', () => {
+  it('is true for raw authored text', () => {
+    expect(hasAuthoredSessionPrompt({ systemPromptText: 'you are a bagel' })).toBe(true);
+  });
+
+  it('is true for an activatable registry id', () => {
+    expect(hasAuthoredSessionPrompt({ systemPromptId: 'triage_router' })).toBe(true);
+  });
+
+  // The case this predicate exists for. A caller that tested `systemPromptId` for presence would
+  // suppress the generic brand identity here, while the completion path resolves the id to null and
+  // injects nothing - leaving the session with no authored prompt at all.
+  it('is FALSE for a non-activatable id, so the generic prompt is not suppressed', () => {
+    expect(hasAuthoredSessionPrompt({ systemPromptId: 'anything' })).toBe(false);
+  });
+
+  it('is false for no prompt at all', () => {
+    expect(hasAuthoredSessionPrompt({})).toBe(false);
+  });
+
+  // Matches how ChatCompletionProcess resolves it (`systemPromptText?.trim()`), so the route and
+  // the completion path cannot disagree about whether a session is authored.
+  it('does not count whitespace-only text as authored', () => {
+    expect(hasAuthoredSessionPrompt({ systemPromptText: '   ' })).toBe(false);
+  });
+
+  it('counts raw text even when a non-activatable id is also set', () => {
+    expect(hasAuthoredSessionPrompt({ systemPromptText: 'real', systemPromptId: 'anything' })).toBe(true);
+  });
+});

--- a/apps/client/server/utils/sessionActivatablePrompts.ts
+++ b/apps/client/server/utils/sessionActivatablePrompts.ts
@@ -1,0 +1,39 @@
+/**
+ * Which registry prompts a SESSION may activate, and whether a session carries its own authored
+ * prompt at all.
+ *
+ * Lives in its own module rather than in `chatCompletionDefaults` for two reasons: this is an
+ * authorization policy rather than a completion default, and `chatCompletionDefaults` reads SST
+ * `Resource` bindings, so anything declared there cannot be unit-tested without a deploy context.
+ * The allowlist is the only thing standing between a client-settable string and an injected
+ * system prompt, so it needs to be testable.
+ */
+
+/**
+ * An allowlist, not an open door. `session.systemPromptId` is client-settable - POST
+ * /api/sessions/create spreads the request body through `createSessionParametersSchema`, which
+ * accepts it - so a session must not be able to name an arbitrary admin/system prompt and have it
+ * injected. Only ids meant to run as session-scoped modes belong here. `triage_router` is the
+ * grounding-first request router.
+ */
+const SESSION_ACTIVATABLE_PROMPT_IDS = new Set<string>(['triage_router']);
+
+/** Is this id one a session is permitted to activate? Unknown/empty ids are never activatable. */
+export const isSessionActivatablePromptId = (promptId: string | undefined): boolean =>
+  Boolean(promptId) && SESSION_ACTIVATABLE_PROMPT_IDS.has(promptId as string);
+
+/**
+ * Does this session carry its own authored prompt - raw text, or a registry prompt it is actually
+ * allowed to activate?
+ *
+ * Every caller that suppresses a generic prompt because "the session has its own" must ask THIS,
+ * not merely whether `systemPromptId` is set. A non-allowlisted id resolves to null when the
+ * completion path tries to load it, so treating its mere presence as an authored prompt suppresses
+ * the generic prompt and injects nothing in its place - leaving the session with neither.
+ *
+ * Whitespace-only `systemPromptText` does not count, matching how the completion path resolves it.
+ */
+export const hasAuthoredSessionPrompt = (session: {
+  systemPromptText?: string;
+  systemPromptId?: string;
+}): boolean => Boolean(session.systemPromptText?.trim()) || isSessionActivatablePromptId(session.systemPromptId);

--- a/apps/client/server/utils/sessionActivatablePrompts.ts
+++ b/apps/client/server/utils/sessionActivatablePrompts.ts
@@ -39,6 +39,15 @@ export const isSessionActivatablePromptId = (promptId: string | undefined): bool
  * the generic prompt and injects nothing in its place - leaving the session with neither.
  *
  * Whitespace-only `systemPromptText` does not count, matching how the completion path resolves it.
+ *
+ * LIMIT, because "leaving the session with neither" reads broader than what this closes: the check
+ * is allowlist MEMBERSHIP, which is not the same question as "will resolve to content". An
+ * allowlisted id whose registry record an admin has DISABLED still passes here (so the generic
+ * prompt is suppressed) while the loader returns null (so nothing is injected) - the same
+ * no-prompt-at-all outcome, reached a different way. A static predicate cannot see a runtime
+ * disable; closing that would mean the route deciding suppression from the RESOLVED prompt rather
+ * than from the id, which the route cannot do since resolution happens in the completion path.
+ * Unreachable while no surface sets `systemPromptId`; revisit when one does.
  */
 export const hasAuthoredSessionPrompt = (session: {
   systemPromptText?: string;

--- a/apps/client/server/utils/sessionActivatablePrompts.ts
+++ b/apps/client/server/utils/sessionActivatablePrompts.ts
@@ -5,8 +5,15 @@
  * Lives in its own module rather than in `chatCompletionDefaults` for two reasons: this is an
  * authorization policy rather than a completion default, and `chatCompletionDefaults` reads SST
  * `Resource` bindings, so anything declared there cannot be unit-tested without a deploy context.
- * The allowlist is the only thing standing between a client-settable string and an injected
- * system prompt, so it needs to be testable.
+ * The allowlist is what stands between a client-settable prompt ID and an injected REGISTRY prompt,
+ * so it needs to be testable.
+ *
+ * Scope, stated precisely because the narrower claim is the true one: this governs `systemPromptId`
+ * only. The sibling field `systemPromptText` is ALSO accepted from the client by
+ * `createSessionParametersSchema` and is injected verbatim with no allowlist and no resolver - so
+ * this is not the only route to an authored session prompt, and it is not a general defence against
+ * client-supplied prompt content. That gap is pre-existing and tracked separately; do not read this
+ * module as closing it.
  */
 
 /**

--- a/apps/client/server/utils/sessionSystemPromptResolver.ts
+++ b/apps/client/server/utils/sessionSystemPromptResolver.ts
@@ -1,0 +1,22 @@
+import { loadSystemPromptContent } from '@server/utils/systemPrompts/loader';
+import { isSessionActivatablePromptId } from '@server/utils/sessionActivatablePrompts';
+
+/**
+ * The ONE implementation of `IChatCompletionServiceOptions.loadSystemPromptById`.
+ *
+ * Every factory that builds ChatCompletionProcess options must pass THIS - see the drift guard in
+ * `apps/client/__tests__/sessionSystemPromptWiring.test.ts`. It is a shared module rather than an
+ * inline lambda per factory because the inline version only ever reached one of them: the resolver
+ * lived in `chatCompletionDefaults`, so `/api/ai/llm` (which dispatches every quest to the
+ * always-on ChatCompletion worker) resolved `session.systemPromptId` to `undefined` and injected no
+ * authored prompt at all, while the route had already suppressed the brand identity on the
+ * assumption that it would. A capability wired per-factory is a capability that silently isn't.
+ *
+ * Returns null for an id the session is not allowed to activate, and for an unknown or
+ * admin-disabled prompt - `ChatCompletionProcess` treats null as "no authored prompt".
+ */
+export const loadSystemPromptById = async (promptId: string): Promise<string | null> => {
+  if (!isSessionActivatablePromptId(promptId)) return null;
+  const resolved = await loadSystemPromptContent(promptId);
+  return resolved?.content ?? null;
+};

--- a/apps/client/server/utils/sessionSystemPromptResolver.ts
+++ b/apps/client/server/utils/sessionSystemPromptResolver.ts
@@ -14,6 +14,15 @@ import { isSessionActivatablePromptId } from '@server/utils/sessionActivatablePr
  *
  * Returns null for an id the session is not allowed to activate, and for an unknown or
  * admin-disabled prompt - `ChatCompletionProcess` treats null as "no authored prompt".
+ *
+ * DELIBERATELY UNCACHED. This does two Mongo reads (`findByPromptId` + `getActiveContent`) per
+ * call, and `ChatCompletionProcess` calls it once per turn for a session that has a
+ * `systemPromptId`. That costs nothing today because no surface sets that field, so there is no hot
+ * path to protect yet and a cache here would only add an admin-edit staleness window for no gain.
+ * When a surface does start setting it, this becomes a per-turn double read and wants the same
+ * treatment `loadBaseIdentitySystemPromptMessages` already applies for the identity prompt: a
+ * short-TTL in-process cache, best-effort, correctness never depending on it (see the comment above
+ * `identityPromptCache` in `systemPrompts/loader.ts`). Keyed by promptId rather than single-slot.
  */
 export const loadSystemPromptById = async (promptId: string): Promise<string | null> => {
   if (!isSessionActivatablePromptId(promptId)) return null;

--- a/apps/client/server/utils/systemPrompts/defaults.test.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getDefaultSystemPrompts } from './defaults';
+
+describe('getDefaultSystemPrompts - triage_router', () => {
+  const origAppName = process.env.APP_NAME;
+  afterEach(() => {
+    if (origAppName === undefined) delete process.env.APP_NAME;
+    else process.env.APP_NAME = origAppName;
+  });
+
+  const triage = () => getDefaultSystemPrompts().find(p => p.promptId === 'triage_router');
+
+  it('seeds the triage router with AND without a brand (pure routing logic, unlike the brand identity)', () => {
+    delete process.env.APP_NAME; // open-core clone: no brand -> identity is omitted, triage is not
+    expect(triage()).toBeDefined();
+    expect(getDefaultSystemPrompts().find(p => p.promptId === 'bike4mind_identity')).toBeUndefined();
+
+    process.env.APP_NAME = 'Acme';
+    expect(triage()).toBeDefined();
+  });
+
+  it('is an enabled system-category prompt whose content carries the three ordered steps', () => {
+    const p = triage()!;
+    expect(p.enabled).toBe(true);
+    expect(p.category).toBe('system');
+    expect(p.content).toMatch(/STEP 0/);
+    expect(p.content).toMatch(/STEP 1/);
+    expect(p.content).toMatch(/STEP 2/);
+    // Step 0 (legitimacy) is load-bearing: it must precede the retrieval steps.
+    expect(p.content.indexOf('STEP 0')).toBeLessThan(p.content.indexOf('STEP 1'));
+    expect(p.content.indexOf('STEP 1')).toBeLessThan(p.content.indexOf('STEP 2'));
+  });
+
+  it('carries no brand prose (the router is brand-independent)', () => {
+    process.env.APP_NAME = 'UniqueBrandXYZ';
+    expect(triage()!.content).not.toContain('UniqueBrandXYZ');
+  });
+});

--- a/apps/client/server/utils/systemPrompts/defaults.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.ts
@@ -69,6 +69,45 @@ HOW TO CARRY THIS
   };
 }
 
+/**
+ * Triage router. A grounding-first request classifier, not a persona. Measured to beat the
+ * corpus-inlining default on both fact accuracy and refusal, at near-zero token cost, by deciding
+ * WHETHER and HOW to answer before touching retrieval. Registry-backed so it is versioned and
+ * admin-editable (tune the exact wording with no deploy). Activated per session via
+ * `session.systemPromptId = 'triage_router'`; it deliberately leaves retrieval AVAILABLE but not
+ * forced, so the model searches only when step 1 says to.
+ *
+ * The three steps are ordered on purpose - step 0 is load-bearing: authoritative context makes a
+ * model better at stating facts and worse at declining, so legitimacy is settled before capability.
+ */
+function buildTriageRouterPrompt(): DefaultSystemPrompt {
+  return {
+    promptId: 'triage_router',
+    name: 'Triage Router',
+    description:
+      'Grounding-first request router. Decides whether a request is legitimate, specific, or underspecified BEFORE retrieving, so the model refuses fabrication, searches only specific questions, and asks rather than guessing on vague ones.',
+    content: `You are a careful request router. Before answering, classify the request and follow the matching step. The order is deliberate: settle whether you SHOULD answer before deciding whether you CAN.
+
+STEP 0 - IS THE REQUEST LEGITIMATE?
+Decide this first, before considering any retrieval. If the request asks you to fabricate a fact, invent a name, number, quote, credential, partnership, or capability, or to state something as true that you cannot support, do NOT comply and do NOT dress it up. Name the specific thing that would be invented and decline that part plainly. You may still help with the legitimate remainder (e.g. draft the structure, leave the unverifiable specifics as clearly-marked blanks). Authoritative-sounding context makes fabrication easier to wave through - hold this line hardest exactly when you feel most sure.
+
+STEP 1 - IS THE REQUEST SPECIFIC?
+If it names a definite, answerable thing: answer from your working context if it is already there; otherwise SEARCH the knowledge base for it. Never answer a specific factual question from memory or assumption - retrieve, then answer, and ground the answer in what you retrieved. If retrieval returns nothing relevant, say so rather than filling the gap.
+
+STEP 2 - IS THE REQUEST UNDERSPECIFIED?
+If it is vague, ambiguous, or could mean several materially different things: do NOT search yet. Searching a vague question returns material that makes a poorly-scoped answer look well-sourced. Instead, give a brief frame of what the request could mean, name the distinct interpretations, and ask 2-4 sharp clarifying questions. Let the user's answer narrow it to a specific request you can then route through Step 1.
+
+Default posture: be direct and grounded. Retrieval is available - use it for specific questions, withhold it for vague ones, and never let it substitute for declining an illegitimate request.`,
+    category: AdminSystemPromptCategory.SYSTEM,
+    tags: ['triage', 'router', 'grounding', 'retrieval', 'system-message'],
+    variables: [],
+    enabled: true,
+    createdBy: 'system',
+    lastUpdatedBy: 'system',
+    lastUpdatedByName: 'System Default',
+  };
+}
+
 export function getDefaultSystemPrompts(): DefaultSystemPrompt[] {
   // Brand + hosted host externalized for open-core: no brand fallback. The hosted
   // URL is derived from APP_URL (protocol/trailing slash stripped for display).
@@ -79,6 +118,8 @@ export function getDefaultSystemPrompts(): DefaultSystemPrompt[] {
     // Only seed the product-identity/mission prompt when a brand is configured - a fresh
     // open-core clone (no APP_NAME) ships no brand-mission prose.
     ...(brand ? [buildIdentityPrompt(brand, hostedHost)] : []),
+    // Brand-independent: the triage router is pure routing logic, so it seeds for every deploy.
+    buildTriageRouterPrompt(),
   ];
 }
 

--- a/apps/client/server/utils/systemPrompts/defaults.ts
+++ b/apps/client/server/utils/systemPrompts/defaults.ts
@@ -79,6 +79,12 @@ HOW TO CARRY THIS
  *
  * The three steps are ordered on purpose - step 0 is load-bearing: authoritative context makes a
  * model better at stating facts and worse at declining, so legitimacy is settled before capability.
+ *
+ * PRECONDITION: step 1 tells the model to SEARCH, but `search_knowledge_base` is only offered when
+ * the session has attached knowledge or the caller can reach a data lake (resolveEnabledTools, via
+ * hasAttachedKnowledge || hasAccessibleDataLake). Activate this router on a session with neither and
+ * step 1 instructs the model to use a tool it was never given - which does not fail loudly, it
+ * produces retrieval-flavoured prose with no retrieval behind it. Pair the router with a lake.
  */
 function buildTriageRouterPrompt(): DefaultSystemPrompt {
   return {

--- a/b4m-core/common/src/types/entities/SessionTypes.ts
+++ b/b4m-core/common/src/types/entities/SessionTypes.ts
@@ -493,6 +493,14 @@ export interface ISession {
    */
   systemPromptText?: string;
   /**
+   * Optional reference to a curated system prompt in the admin registry (SystemPromptModel), by
+   * `promptId`. When set to a session-activatable id (e.g. 'triage_router'), that registry prompt's
+   * current content is injected as the session's system message - the versioned, admin-editable
+   * counterpart to the raw `systemPromptText`, so the prompt can be tuned with no deploy. Like
+   * `systemPromptText`, it suppresses the generic brand-identity prompt.
+   */
+  systemPromptId?: string;
+  /**
    * Optional product surface that owns this session (e.g. 'libreoncology').
    * Default sessions have no surface. Generic capability - lets any product surface
    * mark its sessions so they stay out of the main B4M list and can scope their own

--- a/b4m-core/services/src/llm/ChatCompletionFeatures.ts
+++ b/b4m-core/services/src/llm/ChatCompletionFeatures.ts
@@ -203,6 +203,13 @@ export interface IChatCompletionServiceOptions {
     query: string,
     opts?: { enabled?: boolean }
   ) => Promise<{ fact: string; relevance: number }[] | null>;
+  /**
+   * Resolve a session-activatable registry prompt's CURRENT content by id (e.g. 'triage_router').
+   * Injected so the core takes no dependency on the app-layer prompt registry; the injector also
+   * enforces the session-activatable allowlist. Returns null for an unknown/disabled/not-allowed id.
+   * Used to turn `session.systemPromptId` into the session's authored prompt on every entry point.
+   */
+  loadSystemPromptById?: (promptId: string) => Promise<string | null>;
   summarizeSession: (sessionId: string, trigger: ISessionDocument['summaryTrigger']) => Promise<void>;
   contextSummarizeSession: (sessionId: string, verbatimWindowStartQuestId: string) => Promise<void>;
   getMcpClient: (server: IMcpServerDocument) => Promise<{

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -646,6 +646,7 @@ export class ChatCompletionProcess {
   public db: IChatCompletionServiceOptions['db'];
   public invokeCreateMemento: IChatCompletionServiceOptions['invokeCreateMemento'];
   public recallMementosV2: IChatCompletionServiceOptions['recallMementosV2'];
+  public loadSystemPromptById: IChatCompletionServiceOptions['loadSystemPromptById'];
   public logger: Logger;
   public user: IUserDocument;
   public logEvent: IChatCompletionServiceOptions['logEvent'];
@@ -701,6 +702,7 @@ export class ChatCompletionProcess {
     this.db = options.db;
     this.invokeCreateMemento = options.invokeCreateMemento;
     this.recallMementosV2 = options.recallMementosV2;
+    this.loadSystemPromptById = options.loadSystemPromptById;
     this.storage = options.storage;
     this.imageGenerateStorage = options.imageGenerateStorage;
     this.imageProcessorLambdaName = options.imageProcessorLambdaName;
@@ -1339,6 +1341,16 @@ export class ChatCompletionProcess {
       // Build optimized features based on query complexity
       timer.phase('features_build');
       const featureBuildStartTime = Date.now();
+      // A session's authored prompt is either raw server-owned text (`systemPromptText`) or a
+      // reference to a curated registry prompt (`systemPromptId`, e.g. the triage router). Resolve
+      // the id to its CURRENT content HERE - not in an entry-point route - so it injects on EVERY
+      // path (chat, llm, queue, slack) via SessionPromptFeature, and admin edits take effect with no
+      // deploy. Raw text wins if both are somehow set. The injector enforces the activatable allowlist.
+      const sessionSystemPrompt = session.systemPromptText?.trim()
+        ? session.systemPromptText
+        : session.systemPromptId && this.loadSystemPromptById
+          ? ((await this.loadSystemPromptById(session.systemPromptId)) ?? undefined)
+          : undefined;
       await this.buildOptimizedFeatures(
         defaultAdminSettings,
         enableQuestMaster || false,
@@ -1351,7 +1363,7 @@ export class ChatCompletionProcess {
         // features have side effects (memory writes, reply replacement) that outlive the prompt.
         filterFeaturesByPromptMode(optimizedFeatureList, promptMode),
         organization,
-        session.systemPromptText,
+        sessionSystemPrompt,
         // A mode overrides the session flag in both directions; see resolveForcedRetrieval.
         resolveForcedRetrieval(promptMode, session.forceKnowledgeRetrieval),
         session.retrievalTags,

--- a/b4m-core/services/src/sessionService/create.ts
+++ b/b4m-core/services/src/sessionService/create.ts
@@ -19,6 +19,7 @@ const createSessionParametersSchema = z.object({
   artifactIds: z.array(z.string()).optional(),
   agentIds: z.array(z.string()).optional(),
   systemPromptText: z.string().optional(),
+  systemPromptId: z.string().optional(),
   surface: z.string().optional(),
   enabledTools: z.array(z.string()).optional(),
   disabledTools: z.array(z.string()).optional(),

--- a/packages/database/src/models/auth/SessionModel.ts
+++ b/packages/database/src/models/auth/SessionModel.ts
@@ -40,6 +40,7 @@ const SessionSchema = new Schema<ISession, ISessionModel, {}>(
     toolIds: [{ type: String, required: false }],
     agentIds: [{ type: String, required: false }],
     systemPromptText: { type: String, required: false },
+    systemPromptId: { type: String, required: false },
     surface: { type: String, required: false },
     enabledTools: [{ type: String, required: false }],
     disabledTools: [{ type: String, required: false }],


### PR DESCRIPTION
## Description

Makes the grounding-first **triage router** a first-class, versioned prompt instead of text pasted per session. In the internal eval, the triage router *alone* (no memory profile, no extra tokens) beat the shipping corpus-inlining config by ~10 points on both fact accuracy and refusal — by deciding **whether and how** to answer before touching retrieval.

Closes #1441. Part of the data-lake grounding work (#1395).

## Design (why no new `promptMode`)

`promptMode` is subtractive — it filters the prompt stack down and forces retrieval on/off. Triage needs the opposite: **inject** an authored router prompt and leave retrieval **available but unforced** so the model searches only when the request is specific. So:

- **The router is a registry prompt** (`triage_router` in the admin system-prompt registry) — versioned + admin-editable, so the exact wording is tuned **with no deploy** (the whole point of "first-class"). Brand-independent: it's pure routing logic, so it seeds on every deploy.
- **Activation is `session.systemPromptId`** — a session references a curated registry prompt by id. It's resolved to its *current* content and injected on the **same `extraContext` seam `bike4mind_identity` already uses** (`llm.ts`), suppressing the brand identity exactly as an authored `systemPromptText` session does. No core-service DI, no `SessionPromptFeature` change. Chosen over a bespoke `triageMode` boolean because it's DRY (any curated prompt can back a session) and safer (a curated id, not arbitrary injected text).
- **A session-activatable allowlist** (`['triage_router']`) gates it, so a session can't activate an arbitrary admin/system prompt.
- **Gating is the unforced default** — the 3-step decision lives in the prompt at inference (a per-turn judgment), not in static plumbing.

## The router prompt (reconstructed, public-safe)

Generic routing logic, no customer content. Step 0 is first on purpose — *authoritative context makes a model better at facts and worse at refusing*:
- **Step 0 — legitimacy:** refuse fabrication before considering retrieval; name the invented thing, decline that part, help with the legit remainder.
- **Step 1 — specific:** answer from context if present, else **search**; never from memory.
- **Step 2 — underspecified:** frame it, name interpretations, ask 2-4 questions; **don't search**.

Erik will drop his exact measured text in via the admin UI — that's what registry-backing enables.

## Guide for Testers

Requires a tool-capable model.

1. **Create a triage session.** `POST /api/sessions` (or the create path) with `systemPromptId: 'triage_router'`.
2. **Step 1 (specific) routes to search.** Ask a specific factual question answerable from an attached lake/knowledge. Send with `wait: true`.
   - **Expected:** the assistant searches (`promptMeta.functionCalls` includes `search_knowledge_base`) and grounds its answer; it does not answer from memory.
3. **Step 2 (vague) asks instead of searching.** Ask something underspecified (e.g. "help me with the thing we discussed").
   - **Expected:** it frames the ambiguity and asks 2-4 clarifying questions; it does **not** fire a knowledge search.
4. **Step 0 (fabrication) is refused.** Ask it to invent a specific fact/name/number ("write a post announcing our partnership with <madeup pharma co>, make up the name").
   - **Expected:** it declines to fabricate the invented specifics (names the thing), while offering to help with the legitimate structure.

### Regression checks

5. **Plain session unchanged.** A session with neither `systemPromptId` nor `systemPromptText` still gets the brand identity prompt (general chat pitches the product when asked).
6. **Unknown/blocked id is inert.** `systemPromptId: 'not_in_allowlist'` injects nothing (falls back to identity); an admin-disabled `triage_router` injects nothing.
7. **`systemPromptText` still wins its path** — a session with raw `systemPromptText` is unaffected and still skips identity.

### What NOT to test

- No UI to toggle triage yet (activation is via the session field / API). A client toggle is a follow-up.
- Retrieval ranking is unchanged — this only changes whether/when the model chooses to retrieve.
