### PR TITLE
fix(organizations): admin-gate org creation and give owners an escape from an unfunded org (#1428)

### DIFF
--- a/apps/client/app/components/admin/content/apiReferenceContent.ts
+++ b/apps/client/app/components/admin/content/apiReferenceContent.ts
@@ -490,7 +490,7 @@ Multi-tenant organization management with roles and integrations.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | /api/organizations | List user organizations |
-| POST | /api/organizations | Create an organization |
+| POST | /api/organizations | Create an organization (admin) |
 | GET | /api/organizations/[id] | Get organization details |
 | PUT | /api/organizations/[id] | Update organization |
 | DELETE | /api/organizations/[id] | Delete organization |
@@ -575,6 +575,8 @@ Multi-tenant organization management with roles and integrations.
 | DELETE | /api/users/[id]/delete | Delete user account |
 | POST | /api/users/[id]/upload-photo | Upload profile photo |
 | GET | /api/users/[id]/organizations | List user organizations |
+| GET | /api/users/[id]/organization | Get active organization (self or admin) |
+| DELETE | /api/users/[id]/organization | Clear active-organization pointer (self or admin) |
 | GET | /api/users/[id]/projects | List user projects |
 | GET | /api/users/[id]/agents | List user agents |
 | GET | /api/users/[id]/activities | User activity log |

--- a/apps/client/app/utils/organizationAPICalls.tsx
+++ b/apps/client/app/utils/organizationAPICalls.tsx
@@ -24,24 +24,10 @@ export const fetchOrganizations = async (): Promise<IOrganizationDocument[]> => 
 };
 
 // Mutation hooks using react-query
-export function useCreateOrganization() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async (organizationData: Partial<IOrganization>) => {
-      const { data } = await api.post('/api/organizations', organizationData);
-      return data;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['organizations'] });
-      toast.success('Organization created successfully!');
-    },
-    onError: (error: unknown) => {
-      console.error('Failed to create organization:', error);
-      toast.error('Failed to create organization. Please try again.');
-    },
-  });
-}
-
+// NOTE: org creation deliberately does NOT live here. `POST /api/organizations` is admin-only,
+// and its one caller is the admin panel via `useCreateOrganization` in
+// app/hooks/data/organizations.ts. An unused duplicate here would 403 for any non-admin surface
+// that picked it up, surfacing as a generic toast rather than a permission error.
 export function useUpdateOrganization() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/apps/client/pages/api/organizations/__tests__/index.test.ts
+++ b/apps/client/pages/api/organizations/__tests__/index.test.ts
@@ -108,15 +108,24 @@ describe('GET /api/organizations - scoping + safe serialization', () => {
   });
 });
 
-describe('POST /api/organizations - safe serialization', () => {
+describe('POST /api/organizations - admin gate + safe serialization', () => {
   beforeEach(() => create.mockClear());
 
-  it('strips stripeCustomerId from the created org before returning it', async () => {
+  it('rejects a non-admin caller and does not create (#1428)', async () => {
+    // The route creates an org and re-points the caller's own billing/scope (#1405) onto a
+    // 0-credit org, so it must be admin-only - a stray authenticated caller can't self-brick.
     const { req, res } = mocks({ id: 'creator1', isAdmin: false });
+    (req as any).body = { name: 'Acme' };
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow(/admin/i);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('strips stripeCustomerId from the created org before returning it (admin)', async () => {
+    const { req, res } = mocks({ id: 'admin1', isAdmin: true });
     (req as any).body = { name: 'Acme' };
     await mockRefs.postHandler!(req, res);
     const body = res._getJSONData();
-    // creator is the owner, so billingContact is kept, but stripeCustomerId never leaks
+    // owner view keeps billingContact, but stripeCustomerId never leaks
     expect(body.name).toBe('Acme');
     expect('stripeCustomerId' in body).toBe(false);
     expect(body.billingContact).toBe('billing@acme.com');

--- a/apps/client/pages/api/organizations/index.ts
+++ b/apps/client/pages/api/organizations/index.ts
@@ -7,6 +7,7 @@ import qs from 'qs';
 import { organizationRepository, userRepository } from '@bike4mind/database';
 import { organizationService } from '@bike4mind/services';
 import { toSafeOrganization, toSafeOrganizations } from '@bike4mind/common';
+import { ensureAdmin } from '@server/utils/errors';
 
 const handler = baseApi()
   .get<Request<{}, {}, {}, Record<string, string>>>(async (req, res) => {
@@ -31,6 +32,12 @@ const handler = baseApi()
     });
   })
   .post(async (req, res) => {
+    // Admin-only: creating an org also re-points the caller's own billing/scope to it when they
+    // have none (#1405), and this org starts at 0 credits (#1428). The only caller today is the
+    // admin panel's Create Organization action; gate the route so a stray authenticated caller
+    // can't create an org and silently move their own spend onto an unfunded balance.
+    ensureAdmin(req.user?.isAdmin);
+
     const organization = await organizationService.create(
       req.user,
       {

--- a/apps/client/pages/api/users/[id]/__tests__/organization.test.ts
+++ b/apps/client/pages/api/users/[id]/__tests__/organization.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 
+/**
+ * /api/users/[id]/organization has two handlers: GET reads the org document (billing + member
+ * data), so only the user themselves or an admin may read it and billing identifiers are stripped
+ * for non-owners; DELETE clears the active-org pointer (#1428 escape) delegating authz to the
+ * service. Both are captured below so neither loses route-level coverage.
+ */
 const h = vi.hoisted(() => ({
+  getHandler: null as null | ((req: any, res: any) => unknown),
   deleteHandler: null as null | ((req: any, res: any) => unknown),
   userRepository: { update: vi.fn() },
   clearActiveOrganization: vi.fn(async () => undefined),
@@ -10,7 +17,10 @@ const h = vi.hoisted(() => ({
 vi.mock('@server/middlewares/baseApi', () => {
   const chain: any = {
     use: () => chain,
-    get: () => chain,
+    get: (fn: any) => {
+      h.getHandler = fn;
+      return chain;
+    },
     delete: (fn: any) => {
       h.deleteHandler = fn;
       return chain;
@@ -18,14 +28,67 @@ vi.mock('@server/middlewares/baseApi', () => {
   };
   return { baseApi: () => chain };
 });
-vi.mock('@server/middlewares/asyncHandler', () => ({
-  asyncHandler: (handler: (...a: unknown[]) => unknown) => handler,
-}));
-vi.mock('@bike4mind/database', () => ({ User: {}, userRepository: h.userRepository }));
+
+const findById = vi.hoisted(() =>
+  vi.fn(() => ({
+    populate: () => ({
+      select: () =>
+        Promise.resolve({
+          // Org owned by someone else -> the profile owner is a member, not owner.
+          organizationId: {
+            id: 'org1',
+            userId: 'someoneElse',
+            name: 'Acme',
+            billingContact: 'billing@acme.com',
+            stripeCustomerId: 'cus_SECRET',
+          },
+        }),
+    }),
+  }))
+);
+vi.mock('@bike4mind/database', () => ({ User: { findById }, userRepository: h.userRepository }));
 vi.mock('@bike4mind/services', () => ({ organizationService: { clearActiveOrganization: h.clearActiveOrganization } }));
-vi.mock('@bike4mind/common', () => ({ toSafeOrganization: (o: unknown) => o }));
 
 import '@pages/api/users/[id]/organization';
+
+function getMocks(user: unknown, id: string) {
+  const { req, res } = createMocks({ method: 'GET', query: { id } });
+  (req as any).user = user;
+  return { req, res };
+}
+
+describe('GET /api/users/[id]/organization - ownership gate', () => {
+  beforeEach(() => findById.mockClear());
+
+  it("rejects reading another user's org without querying the DB", async () => {
+    const { req, res } = getMocks({ id: 'me', isAdmin: false }, 'someone-else');
+    await expect(h.getHandler!(req, res)).rejects.toThrow(/not authorized/i);
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  it('allows a user to read their own org', async () => {
+    const { req, res } = getMocks({ id: 'me', isAdmin: false }, 'me');
+    await h.getHandler!(req, res);
+    expect(findById).toHaveBeenCalledWith('me');
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('strips billing identifiers when the caller is a member (not owner) of their org', async () => {
+    const { req, res } = getMocks({ id: 'me', isAdmin: false }, 'me');
+    await h.getHandler!(req, res);
+    const body = res._getJSONData();
+    expect(body.name).toBe('Acme');
+    expect('stripeCustomerId' in body).toBe(false);
+    expect('billingContact' in body).toBe(false);
+    expect(JSON.stringify(body)).not.toContain('cus_SECRET');
+  });
+
+  it("allows an admin to read any user's org", async () => {
+    const { req, res } = getMocks({ id: 'admin1', isAdmin: true }, 'someone-else');
+    await h.getHandler!(req, res);
+    expect(findById).toHaveBeenCalledWith('someone-else');
+  });
+});
 
 describe('DELETE /api/users/[id]/organization - clear the active-org pointer (#1428 escape)', () => {
   beforeEach(() => h.clearActiveOrganization.mockClear());

--- a/apps/client/pages/api/users/[id]/__tests__/organization.test.ts
+++ b/apps/client/pages/api/users/[id]/__tests__/organization.test.ts
@@ -1,83 +1,47 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
 
-/**
- * /api/users/[id]/organization returns an org document (billing + member data),
- * so only the user themselves or an admin may read it. Prove the gate rejects a
- * cross-user read before hitting the database.
- */
-
-const mockRefs = vi.hoisted(() => ({
-  getHandler: null as null | ((req: any, res: any) => unknown),
+const h = vi.hoisted(() => ({
+  deleteHandler: null as null | ((req: any, res: any) => unknown),
+  userRepository: { update: vi.fn() },
+  clearActiveOrganization: vi.fn(async () => undefined),
 }));
 
 vi.mock('@server/middlewares/baseApi', () => {
   const chain: any = {
     use: () => chain,
-    get: (fn: any) => {
-      mockRefs.getHandler = fn;
+    get: () => chain,
+    delete: (fn: any) => {
+      h.deleteHandler = fn;
       return chain;
     },
   };
   return { baseApi: () => chain };
 });
-
-const findById = vi.hoisted(() =>
-  vi.fn(() => ({
-    populate: () => ({
-      select: () =>
-        Promise.resolve({
-          // Org owned by someone else -> the profile owner is a member, not owner.
-          organizationId: {
-            id: 'org1',
-            userId: 'someoneElse',
-            name: 'Acme',
-            billingContact: 'billing@acme.com',
-            stripeCustomerId: 'cus_SECRET',
-          },
-        }),
-    }),
-  }))
-);
-vi.mock('@bike4mind/database', () => ({ User: { findById } }));
+vi.mock('@server/middlewares/asyncHandler', () => ({
+  asyncHandler: (handler: (...a: unknown[]) => unknown) => handler,
+}));
+vi.mock('@bike4mind/database', () => ({ User: {}, userRepository: h.userRepository }));
+vi.mock('@bike4mind/services', () => ({ organizationService: { clearActiveOrganization: h.clearActiveOrganization } }));
+vi.mock('@bike4mind/common', () => ({ toSafeOrganization: (o: unknown) => o }));
 
 import '@pages/api/users/[id]/organization';
 
-function mocks(user: unknown, id: string) {
-  const { req, res } = createMocks({ method: 'GET', query: { id } });
-  (req as any).user = user;
-  return { req, res };
-}
+describe('DELETE /api/users/[id]/organization - clear the active-org pointer (#1428 escape)', () => {
+  beforeEach(() => h.clearActiveOrganization.mockClear());
 
-describe('GET /api/users/[id]/organization - ownership gate', () => {
-  beforeEach(() => findById.mockClear());
+  it('delegates to clearActiveOrganization with the caller and target userId, then 204s', async () => {
+    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'u1' } });
+    (req as any).user = { id: 'u1', isAdmin: false };
 
-  it("rejects reading another user's org without querying the DB", async () => {
-    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'someone-else');
-    await expect(mockRefs.getHandler!(req, res)).rejects.toThrow(/not authorized/i);
-    expect(findById).not.toHaveBeenCalled();
-  });
+    await h.deleteHandler!(req, res);
 
-  it('allows a user to read their own org', async () => {
-    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'me');
-    await mockRefs.getHandler!(req, res);
-    expect(findById).toHaveBeenCalledWith('me');
-    expect(res._getStatusCode()).toBe(200);
-  });
-
-  it('strips billing identifiers when the caller is a member (not owner) of their org', async () => {
-    const { req, res } = mocks({ id: 'me', isAdmin: false }, 'me');
-    await mockRefs.getHandler!(req, res);
-    const body = res._getJSONData();
-    expect(body.name).toBe('Acme');
-    expect('stripeCustomerId' in body).toBe(false);
-    expect('billingContact' in body).toBe(false);
-    expect(JSON.stringify(body)).not.toContain('cus_SECRET');
-  });
-
-  it("allows an admin to read any user's org", async () => {
-    const { req, res } = mocks({ id: 'admin1', isAdmin: true }, 'someone-else');
-    await mockRefs.getHandler!(req, res);
-    expect(findById).toHaveBeenCalledWith('someone-else');
+    // authz (self-or-admin) lives in the service; the route just forwards the caller + target.
+    expect(h.clearActiveOrganization).toHaveBeenCalledWith(
+      { id: 'u1', isAdmin: false },
+      { userId: 'u1' },
+      { db: { users: h.userRepository } }
+    );
+    expect(res.statusCode).toBe(204);
   });
 });

--- a/apps/client/pages/api/users/[id]/organization.ts
+++ b/apps/client/pages/api/users/[id]/organization.ts
@@ -1,37 +1,49 @@
 import { IOrganization, toSafeOrganization } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
-import { User } from '@bike4mind/database';
+import { User, userRepository } from '@bike4mind/database';
+import { organizationService } from '@bike4mind/services';
 import { ForbiddenError } from '@server/utils/errors';
 
 /**
- * Get the organization of a user
+ * A user's active organization: read it (GET) or clear the pointer (DELETE).
  */
-const handler = baseApi().get(
-  asyncHandler<{}, unknown, unknown, { id?: string }>(async (req, res) => {
-    const userId = req.query.id;
+const handler = baseApi()
+  .get(
+    asyncHandler<{}, unknown, unknown, { id?: string }>(async (req, res) => {
+      const userId = req.query.id;
 
-    // The organization document carries billing and member data, so only the
-    // user themselves or an admin may read their org via this route.
-    if (userId !== req.user.id && !req.user.isAdmin) {
-      throw new ForbiddenError('Not authorized to view this organization');
-    }
+      // The organization document carries billing and member data, so only the
+      // user themselves or an admin may read their org via this route.
+      if (userId !== req.user.id && !req.user.isAdmin) {
+        throw new ForbiddenError('Not authorized to view this organization');
+      }
 
-    const user = await User.findById(userId)
-      .populate({
-        path: 'organizationId',
-        populate: {
-          path: 'logo',
-        },
-      })
-      .select('organizationId');
-    const organization = (user?.organizationId as unknown as IOrganization) || null;
+      const user = await User.findById(userId)
+        .populate({
+          path: 'organizationId',
+          populate: {
+            path: 'logo',
+          },
+        })
+        .select('organizationId');
+      const organization = (user?.organizationId as unknown as IOrganization) || null;
 
-    // The caller may be a member (not owner) of their primary org, so strip billing
-    // identifiers unless they own it or are an admin.
-    return res.json(toSafeOrganization(organization, { userId: req.user.id, isAdmin: req.user.isAdmin }));
-  })
-);
+      // The caller may be a member (not owner) of their primary org, so strip billing
+      // identifiers unless they own it or are an admin.
+      return res.json(toSafeOrganization(organization, { userId: req.user.id, isAdmin: req.user.isAdmin }));
+    })
+  )
+  // Clear the user's active-organization pointer, returning them to their personal scope + balance.
+  // The self-service escape for #1428 - `leave` refuses the owner, so an owner pointed at an
+  // unfunded org otherwise has no way out. authz (self or admin) is enforced in the service.
+  .delete(
+    asyncHandler<{}, unknown, unknown, { id?: string }>(async (req, res) => {
+      const userId = req.query.id ?? '';
+      await organizationService.clearActiveOrganization(req.user, { userId }, { db: { users: userRepository } });
+      return res.status(204).end();
+    })
+  );
 
 export const config = {
   api: {

--- a/b4m-core/services/src/organizationService/clearActiveOrganization.test.ts
+++ b/b4m-core/services/src/organizationService/clearActiveOrganization.test.ts
@@ -1,0 +1,34 @@
+import { clearActiveOrganization } from './clearActiveOrganization';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('clearActiveOrganization', () => {
+  let db: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = { users: { update: vi.fn().mockResolvedValue(undefined) } };
+  });
+
+  const run = (actingUser: { id: string; isAdmin: boolean }, userId: string) =>
+    clearActiveOrganization(actingUser as any, { userId }, { db });
+
+  it('clears the pointer when a user clears their own', async () => {
+    await run({ id: 'u1', isAdmin: false }, 'u1');
+    expect(db.users.update).toHaveBeenCalledWith({ id: 'u1', organizationId: null });
+  });
+
+  it("lets a platform admin clear another user's pointer", async () => {
+    await run({ id: 'admin1', isAdmin: true }, 'victim');
+    expect(db.users.update).toHaveBeenCalledWith({ id: 'victim', organizationId: null });
+  });
+
+  it("refuses a non-admin clearing another user's pointer and writes nothing", async () => {
+    await expect(run({ id: 'u1', isAdmin: false }, 'u2')).rejects.toThrow(/not authorized/i);
+    expect(db.users.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty userId (schema guard) before any write', async () => {
+    await expect(run({ id: 'u1', isAdmin: true }, '')).rejects.toThrow();
+    expect(db.users.update).not.toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/organizationService/clearActiveOrganization.ts
+++ b/b4m-core/services/src/organizationService/clearActiveOrganization.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
-import { secureParameters, ForbiddenError } from '@bike4mind/utils';
-import { IUserDocument, IUserRepository } from '@bike4mind/common';
+import { IUserDocument, IUserRepository, secureParameters, ForbiddenError } from '@bike4mind/common';
 
 const clearActiveOrganizationSchema = z.object({
   userId: z.string().min(1),
@@ -21,9 +20,16 @@ interface ClearActiveOrganizationAdapters {
  * up pointed at an unfunded org gets "insufficient credits" with no way out - `leave` refuses the
  * owner and only ever removes a member row, never the owner's pointer.
  *
+ * Cost of clearing is wider than balance: the same pointer also gates org-scoped reads and writes -
+ * org-tier artifact visibility, publishing to org scope, the data-lake access context, and
+ * knowledgeBaseSearch all key off it - so clearing drops the caller's org-scoped access too, not
+ * just their spend. Still the right trade against being unable to spend at all, but callers must
+ * not treat it as a balance-only reset (e.g. no UI affordance built on the narrower promise).
+ *
  * Clears the pointer ONLY - no membership, group, or ownership change - so it is safe for an owner
  * or a plain member, and idempotent (clearing an already-null pointer is a harmless no-op write).
- * It does NOT separate the field's two overloaded meanings; that is #1172's active-org work.
+ * There is no automatic re-set path: restoring the pointer, and separating the field's two
+ * overloaded meanings, is #1172's active-org work.
  *
  * authz: the user themselves, or a platform admin clearing another user's pointer.
  */

--- a/b4m-core/services/src/organizationService/clearActiveOrganization.ts
+++ b/b4m-core/services/src/organizationService/clearActiveOrganization.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { secureParameters, ForbiddenError } from '@bike4mind/utils';
+import { IUserDocument, IUserRepository } from '@bike4mind/common';
+
+const clearActiveOrganizationSchema = z.object({
+  userId: z.string().min(1),
+});
+
+type ClearActiveOrganizationParameters = z.infer<typeof clearActiveOrganizationSchema>;
+
+interface ClearActiveOrganizationAdapters {
+  db: {
+    users: Pick<IUserRepository, 'update'>;
+  };
+}
+
+/**
+ * Clears a user's active-organization pointer (`user.organizationId`), returning them to their
+ * personal scope and balance. This is the self-service escape for #1428: `user.organizationId` is
+ * both the capability-resolution scope AND the billing selector, so an org's billing owner who ends
+ * up pointed at an unfunded org gets "insufficient credits" with no way out - `leave` refuses the
+ * owner and only ever removes a member row, never the owner's pointer.
+ *
+ * Clears the pointer ONLY - no membership, group, or ownership change - so it is safe for an owner
+ * or a plain member, and idempotent (clearing an already-null pointer is a harmless no-op write).
+ * It does NOT separate the field's two overloaded meanings; that is #1172's active-org work.
+ *
+ * authz: the user themselves, or a platform admin clearing another user's pointer.
+ */
+export const clearActiveOrganization = async (
+  actingUser: IUserDocument,
+  parameters: ClearActiveOrganizationParameters,
+  adapters: ClearActiveOrganizationAdapters
+): Promise<void> => {
+  const { userId } = secureParameters(parameters, clearActiveOrganizationSchema);
+
+  if (actingUser.id !== userId && !actingUser.isAdmin) {
+    throw new ForbiddenError("Not authorized to clear this user's active organization");
+  }
+
+  await adapters.db.users.update({ id: userId, organizationId: null });
+};

--- a/b4m-core/services/src/organizationService/index.ts
+++ b/b4m-core/services/src/organizationService/index.ts
@@ -13,6 +13,7 @@ import { listOwn } from './listOwn';
 import { listPendingUsers } from './listPendingUsers';
 import { revokeAccess } from './revokeAccess';
 import { leave } from './leave';
+import { clearActiveOrganization } from './clearActiveOrganization';
 import { setOrganizationGroupTypes } from './setOrganizationGroupTypes';
 import {
   assignUserToGroup,
@@ -43,6 +44,7 @@ export {
   listPendingUsers,
   revokeAccess,
   leave,
+  clearActiveOrganization,
   setOrganizationGroupTypes,
   assignUserToGroup,
   assertCanManageOrgGroups,


### PR DESCRIPTION
## Description

`user.organizationId` is overloaded: it is **both** the capability-resolution scope **and** the billing selector, so any write to it silently moves that user's money. `organizationService.create` starts an org at **0 credits**, and (post-#1405) sets the creator's pointer to it - so an owner can end up pointed at an unfunded org, hit "insufficient credits" on their next request, and have **no way out**: `leave` refuses the owner and only ever removes a member row.

This ships the two cheap, correct-in-isolation mitigations from #1428. The proper field split (a distinct scope pointer vs billing pointer) is **deferred to #1172's active-org work** - doing it standalone needs a migration decision and would likely be done twice.

## Changes

- **Admin-gate `POST /api/organizations`.** It had only `baseApi()` auth - any authenticated caller could create an org and re-point their own billing onto a fresh 0-credit balance. The only caller today is the admin panel's **Create Organization** action, so gating to admin closes the hole with zero UX change.
- **`organizationService.clearActiveOrganization` + `DELETE /api/users/[id]/organization`.** A self-service escape that clears `user.organizationId` (the user themselves, or an admin clearing another's), returning them to their personal scope + balance. Clears the **pointer only** - no membership, group, or ownership change - so it is safe for an owner or a plain member, and idempotent.

### Deliberately NOT done

Both would trade one bug for another, so they're left out on purpose:
- Making the credit path fall back to the personal balance - reverses #1238's deliberate hard stop.
- Gating the #1405 pointer write on the org being funded - reintroduces #1388 for exactly the population it was written for.

## Guide for Testers

Backend change; exercise via the API (Bearer token). Two behaviors:

### A) Org creation is admin-only
1. As a **non-admin**: `POST /api/organizations` with body `{"name":"Test Org"}`. **Expected: 403** ("Admin access required"); no org created.
2. As an **admin** (or via Admin -> Organizations -> **Create Organization**): same POST. **Expected: 201**, org created. The admin-panel flow is unchanged.

### B) Owner escape - clear the active-org pointer
Setup (as admin): create an org owned by some user **U** who has no other org, so `U.organizationId` now points at the new 0-credit org.
1. As **U**: `DELETE /api/users/<U.id>/organization`. **Expected: 204**; `U.organizationId` is now `null` and U resolves to their personal scope/balance again.
2. As an **admin**: `DELETE /api/users/<otherUserId>/organization`. **Expected: 204** (an admin may clear another user's pointer).
3. As **non-admin U**: `DELETE /api/users/<someoneElse.id>/organization`. **Expected: 403** (you may only clear your own).
4. Idempotent: repeat step 1 when already `null`. **Expected: 204**, no error.
5. Confirm clearing did **not** remove U from any org's members or delete the org - only the pointer changed.

### Regression Checks
1. An owner of a **funded** org is unaffected; #1405 (owner gets an active-org pointer on create) still fires.
2. `leave` still works for members and still refuses the owner (unchanged).
3. Admin-panel Create Organization still succeeds and returns the org (stripeCustomerId still stripped).

### What NOT to test
- No UI changes - the admin Create Organization action is the only create caller; the escape is an API endpoint (a UI affordance can land with #1172's switcher).
- Field separation of scope-vs-billing is out of scope (deferred to #1172).

## Verification

Local gates green: services + client typecheck (tsgo + 8GB tsc), lint 0 errors, and tests - new service suite (4), new DELETE route test (1), updated POST-gate route tests (7), full organizationService suite (160).

Closes #1428