### PR TITLE
fix(ci): compare bump levels in the auto-changeset additive-mode dedupe

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -236,8 +236,23 @@ jobs:
           fi
 
           # ── 6. Check for existing manual changesets (additive mode) ──
-          # If a manual changeset already covers a package, skip auto-generating for it.
+          # If a manual changeset already covers a package AT AN EQUAL OR HIGHER bump level, skip
+          # auto-generating for it. The level comparison is the point: this check used to match on
+          # package NAME alone, so a pending manual `patch` would swallow this PR's `minor` or
+          # `major` and the release would understate the change - a breaking change could ship as a
+          # patch with every check green. Additive mode is preserved; it just no longer discards a
+          # bump that the manual changeset does not actually cover.
           declare -A MANUAL_COVERED=()
+
+          # patch < minor < major. Unknown/empty ranks 0 so it never suppresses a real bump.
+          bump_rank() {
+            case "${1:-}" in
+              major) echo 3 ;;
+              minor) echo 2 ;;
+              patch) echo 1 ;;
+              *) echo 0 ;;
+            esac
+          }
 
           for cs_file in .changeset/*.md; do
             [ -f "$cs_file" ] || continue
@@ -259,20 +274,32 @@ jobs:
                 fi
               fi
               if [ "$in_frontmatter" = true ]; then
-                # Extract package name: "@bike4mind/common": minor  OR  @bike4mind/common: minor
+                # Extract package name AND level: "@bike4mind/common": minor  OR  @bike4mind/common: minor
                 pkg=$(echo "$line" | sed -n 's/^"\{0,1\}\(@[^"]*\)"\{0,1\}:.*/\1/p')
+                lvl=$(echo "$line" | sed -n 's/^"\{0,1\}@[^"]*"\{0,1\}:[[:space:]]*\([a-z]\{1,\}\).*/\1/p')
                 if [ -n "$pkg" ]; then
-                  MANUAL_COVERED["$pkg"]=1
+                  # Several manual changesets may name the same package; the highest level wins,
+                  # matching what `changeset version` itself does across multiple files.
+                  prev="${MANUAL_COVERED[$pkg]:-}"
+                  if [ -z "$prev" ] || [ "$(bump_rank "$lvl")" -gt "$(bump_rank "$prev")" ]; then
+                    MANUAL_COVERED["$pkg"]="$lvl"
+                  fi
                 fi
               fi
             done < "$cs_file"
           done
 
-          # Remove packages already covered by manual changesets
+          # Remove packages already covered by a manual changeset at an equal or higher level
+          AUTO_RANK=$(bump_rank "$BUMP")
           for pkg in "${!MANUAL_COVERED[@]}"; do
             if [ -n "${CHANGED_PKGS[$pkg]:-}" ]; then
-              echo "  Package $pkg already covered by manual changeset. Skipping."
-              unset "CHANGED_PKGS[$pkg]"
+              manual_lvl="${MANUAL_COVERED[$pkg]:-}"
+              if [ "$(bump_rank "$manual_lvl")" -ge "$AUTO_RANK" ]; then
+                echo "  Package $pkg already covered by manual changeset ($manual_lvl >= $BUMP). Skipping."
+                unset "CHANGED_PKGS[$pkg]"
+              else
+                echo "  Package $pkg has a manual changeset ($manual_lvl) below this PR's $BUMP. Keeping it."
+              fi
             fi
           done
 


### PR DESCRIPTION
## Description

The auto-changeset workflow's additive-mode dedupe skipped a package whenever **any** pending manual changeset named it — matching on package name and discarding the bump level. So a pending manual `patch` suppressed a PR's `minor` or `major`.

**The bad case:** a `feat(pkg)!:` PR opened while a manual `patch` changeset is pending has its **major bump silently dropped**. The release publishes a breaking change as a patch, every check is green, and consumers on `^x.y` auto-upgrade into it. Nothing fails.

Found while reviewing #1461, which is the benign instance of the same class (both levels happened to be `patch`, so the outcome was correct by luck).

## Approach

The frontmatter parser now records the level alongside the package name — taking the highest when several manual changesets name the same package, which is what `changeset version` does across files — and the dedupe skips only when the manual level is **>= this PR's**.

**Additive mode is preserved deliberately.** "Additive mode: skips packages covered by manual changesets" is a stated feature of the workflow's original commit (`90efbfd` upstream), so this doesn't remove the dedupe. The only behaviour change is that *covered* now means what the word implies.

An unparseable or missing level ranks 0, so a malformed manual changeset can never suppress a real bump — it fails toward over-declaring, which `changeset version` resolves by taking the max.

## Testing

Extracted the logic verbatim and ran every combination:

| manual | auto | result | |
|---|---|---|---|
| patch | patch | skipped | additive mode preserved |
| minor | patch | skipped | |
| major | patch | skipped | |
| minor | minor | skipped | |
| major | minor | skipped | |
| major | major | skipped | |
| **patch** | **minor** | **kept** | was skipped — the bug |
| **patch** | **major** | **kept** | was skipped — breaking shipped as patch |
| **minor** | **major** | **kept** | was skipped — the bug |
| none | major | kept | |
| junk | major | kept | malformed never suppresses |

Also verified the level regex against the quoted and unquoted frontmatter forms the parser already handled (`"@scope/pkg": minor`, `@scope/pkg: patch`, no space, trailing space) and that it still rejects non-package lines. YAML re-parsed after editing.

## Deliberately not addressed

The generator writes the changeset with `>`, so it **silently overwrites a hand-edit on the next push** — an author who corrects a wrong changeset has the correction reverted. Observed live on #1461. Fixing it implies a policy call on whether a human may override the generator, which doesn't belong in this change.

Note also that all packages in a generated changeset share one `$BUMP`, so the generator cannot express per-package levels at all. Out of scope here.