### PR TITLE
fix(llm): stop the corpus deferral stranding docs the knowledge tool cannot reach

### DIFF
--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -630,18 +630,6 @@ describe('ChatCompletionProcess', () => {
       expect(getAccessibleFiles).not.toHaveBeenCalled();
     });
 
-    it('DOES defer the same corpus when the tool is not denied (positive control)', async () => {
-      const plan = await runPlan({
-        files: lakeFiles(40),
-        dataLakeTags: ['datalake:corpus'],
-        threshold: '500',
-        attachedFileTokenBudget: 4000,
-        knowledgeSearchDisabled: false,
-      });
-      expect(plan.deferredToRetrieval).toBe(true);
-      expect(plan.deferredKnowledgeIds).toHaveLength(40);
-    });
-
     it('fails SAFE (inline all) and warns when the file read throws', async () => {
       (service as any).accessibleDataLakeAccessMemo = {
         dataLakeTags: ['datalake:corpus'],

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -24,6 +24,7 @@ import {
   usdToCreditsStochastic,
   getSettingsValue,
 } from '@bike4mind/utils';
+import type { RetrievalExclusionOptions } from '@bike4mind/utils/retrievalExclusion';
 import { getLlmByModel, getAvailableModels } from '@bike4mind/llm-adapters';
 import {
   ChatModels,
@@ -349,12 +350,17 @@ describe('ChatCompletionProcess', () => {
         chunkCount?: number;
         vectorizedChunkCount?: number;
         embeddingModel?: string;
+        fileName?: string;
+        vectorized?: boolean;
+        deletedAt?: Date;
+        archivedAt?: Date;
       }>;
       dataLakeTags: string[];
       threshold: string | undefined;
       attachedFileTokenBudget: number;
       skipAutoOffers?: boolean;
       queryEmbeddingModel?: string;
+      retrievalFilter?: RetrievalExclusionOptions;
     }) => {
       // Seed the per-turn access memo directly (getAccessibleDataLakeAccess returns it when set),
       // so the plan uses these tags without exercising the DB-backed resolver.
@@ -369,6 +375,7 @@ describe('ChatCompletionProcess', () => {
         sessionKnowledgeIds: opts.files.map(f => f.id),
         attachedFileTokenBudget: opts.attachedFileTokenBudget,
         skipAutoOffers: opts.skipAutoOffers ?? false,
+        retrievalFilter: opts.retrievalFilter ?? {},
         defaultAdminSettings: {
           ...(opts.threshold ? { CorpusRetrievalMinInlineTokensPerDoc: opts.threshold } : {}),
           // The query embedding model; a doc is retrievable only if embedded under the same one.
@@ -389,6 +396,8 @@ describe('ChatCompletionProcess', () => {
         chunkCount: 2,
         vectorizedChunkCount: 2,
         embeddingModel: 'model-A',
+        fileName: `k${i}.md`,
+        vectorized: true,
         ...over,
       }));
 
@@ -405,7 +414,14 @@ describe('ChatCompletionProcess', () => {
     });
 
     it('excludes non-lake-tagged attachments from the deferred set (core regression guard)', async () => {
-      const files = [...lakeFiles(30), { id: 'personal1', tags: [{ name: 'notes' }] }, { id: 'personal2', tags: [] }];
+      // The non-lake fixtures carry the fully-retrievable shape so the TAG is the only thing that
+      // differs. Given bare `{id, tags}` they were already excluded by the vectorization and
+      // embedding-model conjuncts, and this test passed with `lakeTagged &&` deleted from the gate.
+      const files = [
+        ...lakeFiles(30),
+        ...lakeFiles(1, 'notes', { id: 'personal1' }),
+        ...lakeFiles(1, 'datalake:corpus', { id: 'personal2', tags: [] }),
+      ];
       const plan = await runPlan({
         files,
         dataLakeTags: ['datalake:corpus'],
@@ -417,6 +433,70 @@ describe('ChatCompletionProcess', () => {
       expect(plan.deferredKnowledgeIds).toHaveLength(30);
       expect(plan.deferredKnowledgeIds).not.toContain('personal1');
       expect(plan.deferredKnowledgeIds).not.toContain('personal2');
+    });
+
+    // The plan and the knowledge tool must agree on reachability. Both cases below are docs that
+    // pass every OTHER gate (lake-tagged, chunk counts complete, matching embedding model) yet the
+    // tool would refuse to return, so deferring them would strand their content silently.
+    it('excludes a doc the session retrieval-exclusion MARKER hides from the tool', async () => {
+      const files = [
+        ...lakeFiles(39),
+        ...lakeFiles(1, 'datalake:corpus', { id: 'marked', fileName: 'MARK - contract.pdf' }),
+      ];
+      const plan = await runPlan({
+        files,
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000, // 4000/39 = 102 < 500, so deferral still fires
+        retrievalFilter: { excludeFilenameMarkers: ['mark'] },
+      });
+      expect(plan.deferredToRetrieval).toBe(true);
+      expect(plan.retrievableCount).toBe(39);
+      expect(plan.deferredKnowledgeIds).not.toContain('marked');
+
+      // Positive control: identical corpus, filter removed. Proves the assertion above is the
+      // filter's doing and not some other gate quietly excluding the fixture.
+      const unfiltered = await runPlan({
+        files,
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000,
+      });
+      expect(unfiltered.retrievableCount).toBe(40);
+      expect(unfiltered.deferredKnowledgeIds).toContain('marked');
+    });
+
+    it('excludes an unflagged doc under retrievalVectorizedOnly, which the chunk-count gate misses', async () => {
+      // `vectorizedOnly` reads the `vectorized` BOOLEAN; the retrievability gate reads the chunk
+      // counts. A doc with complete counts but the flag unset passes one and fails the other, so
+      // this is the arm the chunk-count check does NOT subsume.
+      const files = [...lakeFiles(39), ...lakeFiles(1, 'datalake:corpus', { id: 'unflagged', vectorized: false })];
+      const plan = await runPlan({
+        files,
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000,
+        retrievalFilter: { vectorizedOnly: true },
+      });
+      expect(plan.retrievableCount).toBe(39);
+      expect(plan.deferredKnowledgeIds).not.toContain('unflagged');
+    });
+
+    it('excludes soft-deleted and archived docs, which the tool also refuses to return', async () => {
+      const files = [
+        ...lakeFiles(38),
+        ...lakeFiles(1, 'datalake:corpus', { id: 'gone', deletedAt: new Date() }),
+        ...lakeFiles(1, 'datalake:corpus', { id: 'shelved', archivedAt: new Date() }),
+      ];
+      const plan = await runPlan({
+        files,
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000,
+      });
+      expect(plan.retrievableCount).toBe(38);
+      expect(plan.deferredKnowledgeIds).not.toContain('gone');
+      expect(plan.deferredKnowledgeIds).not.toContain('shelved');
     });
 
     it('defers nothing when the caller has no accessible lake (nothing is retrievable)', async () => {

--- a/b4m-core/services/src/llm/ChatCompletion.test.ts
+++ b/b4m-core/services/src/llm/ChatCompletion.test.ts
@@ -359,6 +359,7 @@ describe('ChatCompletionProcess', () => {
       threshold: string | undefined;
       attachedFileTokenBudget: number;
       skipAutoOffers?: boolean;
+      knowledgeSearchDisabled?: boolean;
       queryEmbeddingModel?: string;
       retrievalFilter?: RetrievalExclusionOptions;
     }) => {
@@ -375,6 +376,7 @@ describe('ChatCompletionProcess', () => {
         sessionKnowledgeIds: opts.files.map(f => f.id),
         attachedFileTokenBudget: opts.attachedFileTokenBudget,
         skipAutoOffers: opts.skipAutoOffers ?? false,
+        knowledgeSearchDisabled: opts.knowledgeSearchDisabled ?? false,
         retrievalFilter: opts.retrievalFilter ?? {},
         defaultAdminSettings: {
           ...(opts.threshold ? { CorpusRetrievalMinInlineTokensPerDoc: opts.threshold } : {}),
@@ -599,6 +601,45 @@ describe('ChatCompletionProcess', () => {
       expect(plan.deferredToRetrieval).toBe(false);
       expect(plan.deferredKnowledgeIds).toHaveLength(0);
       expect(getAccessibleFiles).not.toHaveBeenCalled();
+    });
+
+    it('defers nothing when the session denylist forbids the knowledge-search tool', async () => {
+      // `session.disabledTools` is applied to the built tool list AFTER this plan runs, so a
+      // corpus deferred here would be handed to a tool that is then stripped - losing it outright.
+      // Seed the lake memo and a real file set: without them the no-lake / empty-corpus early
+      // returns catch this case first and the test passes with the denylist guard DELETED.
+      const files = lakeFiles(40);
+      (service as any).accessibleDataLakeAccessMemo = {
+        dataLakeTags: ['datalake:corpus'],
+        dataLakeTagPrefixes: [],
+        scopedTagPrefixes: [],
+      };
+      (service as any).getScopeFilter = vi.fn().mockReturnValue({});
+      const getAccessibleFiles = vi.fn().mockResolvedValue(files);
+      (service as any).db = { fabfiles: { getAccessibleFiles } };
+      const plan = await (service as any).resolveCorpusInlinePlan({
+        sessionKnowledgeIds: files.map(f => f.id),
+        attachedFileTokenBudget: 4000, // 4000/40 = 100 < 500: would defer all 40 but for the guard
+        skipAutoOffers: false,
+        knowledgeSearchDisabled: true,
+        retrievalFilter: {},
+        defaultAdminSettings: { CorpusRetrievalMinInlineTokensPerDoc: '500', defaultEmbeddingModel: 'model-A' },
+      });
+      expect(plan.deferredToRetrieval).toBe(false);
+      expect(plan.deferredKnowledgeIds).toHaveLength(0);
+      expect(getAccessibleFiles).not.toHaveBeenCalled();
+    });
+
+    it('DOES defer the same corpus when the tool is not denied (positive control)', async () => {
+      const plan = await runPlan({
+        files: lakeFiles(40),
+        dataLakeTags: ['datalake:corpus'],
+        threshold: '500',
+        attachedFileTokenBudget: 4000,
+        knowledgeSearchDisabled: false,
+      });
+      expect(plan.deferredToRetrieval).toBe(true);
+      expect(plan.deferredKnowledgeIds).toHaveLength(40);
     });
 
     it('fails SAFE (inline all) and warns when the file read throws', async () => {

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -288,10 +288,12 @@ const CORPUS_RETRIEVAL_MIN_INLINE_TOKENS_PER_DOC = 0;
 
 /**
  * The tool deferral hands the corpus to. A literal because the name is declared inline in the
- * tool's schema (llm/tools/implementation/knowledgeBaseSearch) with no exported constant - must
- * stay in sync with it. Deferring while this tool is denied strands the corpus with no reader.
+ * tool's definition (llm/tools/implementation/knowledgeBaseSearch) with no exported constant.
+ * Deferring while this tool is denied strands the corpus with no reader, and a rename would
+ * un-guard that path silently - so exported, and pinned against the real name by a test rather
+ * than by this comment.
  */
-const KNOWLEDGE_SEARCH_TOOL_NAME = 'search_knowledge_base';
+export const KNOWLEDGE_SEARCH_TOOL_NAME = 'search_knowledge_base';
 
 /**
  * Fraction of the space ACTUALLY AVAILABLE FOR HISTORY (safe input minus the

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -64,7 +64,11 @@ import {
 // Injected into processFabFilesServer so @bike4mind/utils's barrel carries no jimp
 // dependency (keeps it out of the CLI bundle). See issue #660.
 import { ensureImageWithinDimensionLimit } from '@bike4mind/utils/imageResize';
-import { toRetrievalFilter, type RetrievalExclusionOptions } from '@bike4mind/utils/retrievalExclusion';
+import {
+  isRetrievalExcluded,
+  toRetrievalFilter,
+  type RetrievalExclusionOptions,
+} from '@bike4mind/utils/retrievalExclusion';
 import {
   resolveOutputMaxTokens,
   getAvailableModels,
@@ -885,6 +889,8 @@ export class ChatCompletionProcess {
     attachedFileTokenBudget: number;
     skipAutoOffers: boolean;
     defaultAdminSettings: Record<string, string>;
+    /** The SAME filter the knowledge tools are built with - see the retrievability comment below. */
+    retrievalFilter: RetrievalExclusionOptions;
   }): Promise<{
     deferredKnowledgeIds: string[];
     attachedCount: number;
@@ -892,7 +898,8 @@ export class ChatCompletionProcess {
     deferredToRetrieval: boolean;
     minInlineTokensPerDoc: number;
   }> {
-    const { sessionKnowledgeIds, attachedFileTokenBudget, skipAutoOffers, defaultAdminSettings } = input;
+    const { sessionKnowledgeIds, attachedFileTokenBudget, skipAutoOffers, defaultAdminSettings, retrievalFilter } =
+      input;
     const attachedCount = sessionKnowledgeIds.length;
 
     // getSettingsValue coerces via the setting's Zod schema, so this is a number (0 by default).
@@ -944,7 +951,14 @@ export class ChatCompletionProcess {
           // this onto isForeignEmbeddingModel - that loosens the gate to defer unlabeled docs the
           // semantic arm may not actually reach, which is the content-losing direction.
           const sameVectorSpace = Boolean(queryEmbeddingModel) && file.embeddingModel === queryEmbeddingModel;
-          return lakeTagged && fullyVectorized && sameVectorSpace;
+          // The tool is built with `retrievalFilter: toRetrievalFilter(session)` and enforces it on
+          // BOTH arms, so a doc the filter excludes is unreachable however well vectorized it is.
+          // Checking the same predicate here is what stops the two lists diverging - the gap this
+          // closes was a lake-tagged, fully-vectorized doc matching a session exclusion marker being
+          // deferred and then dropped by the tool, losing it silently. Mirrors `isLiveVisibleFile` in
+          // knowledgeBaseRetrieve, which is the canonical "can the tool reach this file" predicate.
+          const liveAndReachable = !file.deletedAt && !file.archivedAt && !isRetrievalExcluded(file, retrievalFilter);
+          return lakeTagged && fullyVectorized && sameVectorSpace && liveAndReachable;
         })
         .map(file => file.id);
 
@@ -2023,6 +2037,8 @@ export class ChatCompletionProcess {
         attachedFileTokenBudget,
         skipAutoOffers,
         defaultAdminSettings,
+        // Same mapping the tool build uses below, so the plan and the tool cannot disagree.
+        retrievalFilter: toRetrievalFilter(session),
       });
 
       const dataSources = await this.buildDataSources({

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -287,6 +287,13 @@ const MIN_ATTACHED_CONTENT_SHARE = 0.15;
 const CORPUS_RETRIEVAL_MIN_INLINE_TOKENS_PER_DOC = 0;
 
 /**
+ * The tool deferral hands the corpus to. A literal because the name is declared inline in the
+ * tool's schema (llm/tools/implementation/knowledgeBaseSearch) with no exported constant - must
+ * stay in sync with it. Deferring while this tool is denied strands the corpus with no reader.
+ */
+const KNOWLEDGE_SEARCH_TOOL_NAME = 'search_knowledge_base';
+
+/**
  * Fraction of the space ACTUALLY AVAILABLE FOR HISTORY (safe input minus the
  * non-history overhead reserved below) kept as VERBATIM conversation history
  * before older turns are folded into contextSummary. The fraction tunes the
@@ -888,6 +895,8 @@ export class ChatCompletionProcess {
     sessionKnowledgeIds: string[];
     attachedFileTokenBudget: number;
     skipAutoOffers: boolean;
+    /** `session.disabledTools` includes the knowledge-search tool - see the guard below. */
+    knowledgeSearchDisabled: boolean;
     defaultAdminSettings: Record<string, string>;
     /** The SAME filter the knowledge tools are built with - see the retrievability comment below. */
     retrievalFilter: RetrievalExclusionOptions;
@@ -898,8 +907,14 @@ export class ChatCompletionProcess {
     deferredToRetrieval: boolean;
     minInlineTokensPerDoc: number;
   }> {
-    const { sessionKnowledgeIds, attachedFileTokenBudget, skipAutoOffers, defaultAdminSettings, retrievalFilter } =
-      input;
+    const {
+      sessionKnowledgeIds,
+      attachedFileTokenBudget,
+      skipAutoOffers,
+      knowledgeSearchDisabled,
+      defaultAdminSettings,
+      retrievalFilter,
+    } = input;
     const attachedCount = sessionKnowledgeIds.length;
 
     // getSettingsValue coerces via the setting's Zod schema, so this is a number (0 by default).
@@ -920,6 +935,11 @@ export class ChatCompletionProcess {
     // promptMode is an eval/passthrough surface where the tool is NOT offered - deferring there
     // would strand the corpus with no retrieval path. Symmetric with the tool-offer gate.
     if (skipAutoOffers) return noDefer;
+    // Same reasoning one step further: `session.disabledTools` wins over every other tool gate
+    // (including the post-build denylist pass, which runs AFTER this plan), so deferring to a
+    // denied tool loses the corpus outright. Read from the session rather than the resolved tool
+    // list because the list is filtered again downstream of this call.
+    if (knowledgeSearchDisabled) return noDefer;
     if (minInlineTokensPerDoc <= 0 || attachedCount === 0) return noDefer;
 
     try {
@@ -2036,8 +2056,12 @@ export class ChatCompletionProcess {
         sessionKnowledgeIds: session.knowledgeIds ?? [],
         attachedFileTokenBudget,
         skipAutoOffers,
+        knowledgeSearchDisabled:
+          Array.isArray(session.disabledTools) && session.disabledTools.includes(KNOWLEDGE_SEARCH_TOOL_NAME),
         defaultAdminSettings,
-        // Same mapping the tool build uses below, so the plan and the tool cannot disagree.
+        // The same mapping the tool build uses below, so the session -> filter translation cannot
+        // drift between them. Narrower than "the two agree": reachability also depends on the tool
+        // surviving the denylist, which is what knowledgeSearchDisabled above covers.
         retrievalFilter: toRetrievalFilter(session),
       });
 

--- a/b4m-core/services/src/llm/knowledgeSearchToolName.test.ts
+++ b/b4m-core/services/src/llm/knowledgeSearchToolName.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { KNOWLEDGE_SEARCH_TOOL_NAME } from './ChatCompletionProcess';
+import { knowledgeBaseSearchTool } from './tools/implementation/knowledgeBaseSearch';
+
+/**
+ * Drift guard, not a unit test. `resolveCorpusInlinePlan` refuses to defer the corpus when
+ * `session.disabledTools` names the knowledge-search tool, and it matches that name as a string.
+ * Renaming the tool without updating the constant would un-guard the path SILENTLY: the corpus
+ * would be deferred to a tool that is then stripped, and no existing test would fail because
+ * every one of them supplies the name itself. This is the only thing that would notice.
+ */
+describe('KNOWLEDGE_SEARCH_TOOL_NAME', () => {
+  it('matches the name the knowledge-search tool actually registers under', () => {
+    expect(KNOWLEDGE_SEARCH_TOOL_NAME).toBe(knowledgeBaseSearchTool.name);
+  });
+});


### PR DESCRIPTION
Closes the P1 raised in review of #1443, plus a second route to the same failure found while adjudicating the review of this PR. Both must be closed before `CorpusRetrievalMinInlineTokensPerDoc` is set non-zero anywhere.

## The gap

`resolveCorpusInlinePlan` decided a document was tool-retrievable from three signals - lake-tag membership, vectorization completeness, and embedding-model agreement - and built its scope from `getScopeFilter(user, Permission.read, 'FabFile')` and nothing else. The knowledge tools it defers to are constructed with `retrievalFilter: toRetrievalFilter(session)` and enforce that filter on **both** arms.

So the two lists could disagree. Threshold 500, a session setting `retrievalExcludeFilenameMarkers: ['mark']`, a lake of 40 fully-vectorized same-model docs including `MARK - contract.pdf`: all 40 pass the gate, all 40 are deferred out of the inline set, and the tool then drops that one. The turn loses it with **no error** - just a document quietly absent from context. The only signal is answer quality, which is exactly the measurement an A/B on this feature would be taking.

## The second route (found in adjudication)

`session.disabledTools` is applied to the built tool list at the post-build denylist pass (`:2210`), which runs **after** the plan (`:2035`) in the same `process()` call, and there is no re-inline fallback. A session naming `search_knowledge_base` there had its whole retrievable corpus deferred to a tool that was stripped moments later. Worse than the marker case: it loses everything, not one document. `disabledTools` is a plain client-settable session field (`apps/client/types/api.ts:47`), not a curated-surface-only capability.

## The fix

Two guards, both mirroring what the tool side already does:

1. Thread the same `toRetrievalFilter(session)` into the plan and apply the canonical reachability predicate - the one `knowledgeBaseRetrieve`'s `isLiveVisibleFile` uses: not deleted, not archived, not retrieval-excluded.
2. Return early when the knowledge-search tool is denied, symmetric with the existing `skipAutoOffers` guard directly above it. Reads `session.disabledTools` rather than the resolved tool list, because that list is filtered again downstream of the plan.

One correction to the #1443 review's wording, found while implementing: it said `vectorizedOnly` "happens to be subsumed by the new check." It is not. The gate reads `chunkCount` / `vectorizedChunkCount`; the filter reads the `vectorized` **boolean**. A doc with complete counts and an unset flag passes one and fails the other, so that arm needed closing too and has its own test.

Direction of both guards is the safe one: failing them shrinks `retrievableCount` or skips deferral entirely, which keeps content inline.

## Tests

Five new cases, each mutation-verified - the guard it targets was removed, exactly that test failed, then it was restored:

- session exclusion marker, **with a positive control** on the identical corpus with the filter removed
- `retrievalVectorizedOnly` against a doc with complete chunk counts but `vectorized: false`
- soft-deleted and archived docs
- knowledge-search tool denied
- a drift guard pinning `KNOWLEDGE_SEARCH_TOOL_NAME` to the name the tool actually registers under, since the guard matches it as a string and a rename would un-guard the path silently. Renaming the constant fails only that guard, with all 116 other tests green - which is the failure shape it closes.

Worth recording: the denylist test was **vacuous in its first form** and mutation caught it. It passed with the guard deleted, because it never seeded the data-lake memo and the no-lake early return caught the case first - the assertion was proving a sibling mechanism, not the guard. It now seeds the memo and a corpus that would otherwise defer.

Also folds in a P3 from the #1443 review: the non-lake fixtures in the tag regression guard carried no chunk counts and no embedding model, so they were excluded before the tag was consulted - that test passed with `lakeTagged &&` deleted from the gate. They now carry the fully retrievable shape, so the tag is the only difference.

117 passed across the two files.

## Blast radius

None while the feature is off - the threshold defaults to 0 and the plan returns before the DB read. `resolveCorpusInlinePlan` is `private`, so the signature changes reach no overlay; no overlay sweep needed.

## Remaining rollout gates from the #1443 review (not addressed here)

Tracked on #1395. Still open before the setting is enabled or the A/B is run:

- legacy lakes with unlabeled `embeddingModel` yield `retrievableCount: 0`, so the A/B would measure zero effect on exactly the corpora the feature targets
- no size input, so a corpus of small docs that would inline losslessly can still be deferred
- no minimum-count guard, so on a small-window model a threshold above the turn budget defers even a single document
- telemetry cannot distinguish the now-five reasons a doc drops out of `retrievableCount`, so a zero reads the same whatever caused it
