### PR TITLE
ci(changeset): warn when a hand-edited pr-<N>.md is overwritten

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -310,32 +310,17 @@ jobs:
 
           echo "Packages to bump: ${!CHANGED_PKGS[*]}"
 
-          # A hand-edited pr-<N>.md is a trap in both directions: the write in step 7 overwrites it
-          # unconditionally, and step 6 skips pr-*.md when scanning for manual changesets, so the
+          # A hand-edited pr-<N>.md is a trap in both directions: the write in step 7 overwrites
+          # it unconditionally, and step 6 skips pr-*.md when scanning for manual changesets, so the
           # edit is neither kept nor honored - it just vanishes with CI green. The removal paths
           # above already gate on AUTO_MARKER so this workflow never DELETES human content; this is
-          # the same check on the write side. Warn rather than yield: treating this file as
-          # authoritative would create a second override path step 6 cannot see, letting the
-          # published bump drift from the PR title. `pnpm changeset` is the supported route.
+          # the same check on the write side. Detect only here and report in step 10, AFTER the
+          # changeset is safely committed: this job is not a required check, so an API error before
+          # the write would abort with no changeset generated and merge would not be blocked.
+          HAND_EDITED=false
           if [ -f "$CHANGESET_FILE" ] && ! grep -q "$AUTO_MARKER" "$CHANGESET_FILE" 2>/dev/null; then
+            HAND_EDITED=true
             echo "::warning::${CHANGESET_FILE} looks hand-edited and is being overwritten. Run 'pnpm changeset' to author an override."
-            EDIT_MARKER="<!-- auto-changeset-handedit -->"
-            EDIT_BODY="${EDIT_MARKER}
-          **Auto-Changeset:** \`${CHANGESET_FILE}\` looks hand-edited, and this workflow has just overwritten it.
-
-          That file is generated from the PR title and rewritten on every push, so edits to it are always lost. It is also skipped when scanning for manual changesets, so it never counts as an override either.
-
-          To override the generated bump, run \`pnpm changeset\` and commit the file it creates under any other name. Those are respected: a manual changeset at or above this PR's bump level replaces the auto-generated one, and a lower one is kept alongside it."
-
-            EDIT_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-              --jq ".[] | select(.body | contains(\"${EDIT_MARKER}\")) | .id" | head -1)
-            if [ -n "$EDIT_COMMENT_ID" ]; then
-              gh api "repos/${{ github.repository }}/issues/comments/${EDIT_COMMENT_ID}" \
-                -X PATCH -f body="$EDIT_BODY" > /dev/null
-            else
-              gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-                -f body="$EDIT_BODY" > /dev/null
-            fi
           fi
 
           # ── 7. Generate changeset file ──
@@ -353,23 +338,49 @@ jobs:
           echo "Generated changeset:"
           cat "$CHANGESET_FILE"
 
-          # ── 8. Check if content actually changed ──
+          # ── 8/9. Commit and push if the content actually changed ──
+          # Deliberately not an early `exit 0`: step 10 must still reconcile the PR comments, or a
+          # stale hand-edit warning would survive the very push that fixed the file (that push
+          # regenerates identical content, so this branch is exactly when cleanup is needed).
           git add "$CHANGESET_FILE"
           if git diff --cached --quiet; then
             echo "::notice::Changeset already up-to-date. No commit needed."
-            exit 0
+          else
+            git commit -m "chore: auto-generate changeset for PR #${PR_NUMBER}"
+            git push
           fi
 
-          # ── 9. Commit and push ──
-          git commit -m "chore: auto-generate changeset for PR #${PR_NUMBER}"
-          git push
-
-          # ── 10. Clean up guidance comment if it exists ──
+          # ── 10. Reconcile PR comments (best effort - must never fail the run) ──
+          # Runs only after the changeset is committed, and every call is `|| true`, so a GitHub API
+          # hiccup can cost at most a comment, never the changeset.
           COMMENT_MARKER="<!-- auto-changeset-comment -->"
           EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq ".[] | select(.body | contains(\"${COMMENT_MARKER}\")) | .id" | head -1)
+            --jq ".[] | select(.body | contains(\"${COMMENT_MARKER}\")) | .id" 2>/dev/null | head -1 || true)
           if [ -n "$EXISTING_COMMENT_ID" ]; then
             gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" -X DELETE > /dev/null 2>&1 || true
+          fi
+
+          # Hand-edit warning: post while the condition holds, clear it once the file is ours again.
+          EDIT_MARKER="<!-- auto-changeset-handedit -->"
+          EDIT_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | contains(\"${EDIT_MARKER}\")) | .id" 2>/dev/null | head -1 || true)
+          if [ "$HAND_EDITED" = true ]; then
+            EDIT_BODY="${EDIT_MARKER}
+          **Auto-Changeset:** \`${CHANGESET_FILE}\` looked hand-edited, and this workflow has overwritten it.
+
+          That file is generated from the PR title and rewritten on every push, so edits to it are always lost. It is also skipped when scanning for manual changesets, so it never counts as an override either.
+
+          To override the generated bump, run \`pnpm changeset\` and commit the file it creates under any other name. Those are respected: a manual changeset at or above this PR's bump level replaces the auto-generated one, and a lower one is kept alongside it."
+
+            if [ -n "$EDIT_COMMENT_ID" ]; then
+              gh api "repos/${{ github.repository }}/issues/comments/${EDIT_COMMENT_ID}" \
+                -X PATCH -f body="$EDIT_BODY" > /dev/null 2>&1 || true
+            else
+              gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+                -f body="$EDIT_BODY" > /dev/null 2>&1 || true
+            fi
+          elif [ -n "$EDIT_COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${EDIT_COMMENT_ID}" -X DELETE > /dev/null 2>&1 || true
           fi
 
           echo "::notice::Changeset committed for PR #${PR_NUMBER}"

--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -310,6 +310,34 @@ jobs:
 
           echo "Packages to bump: ${!CHANGED_PKGS[*]}"
 
+          # A hand-edited pr-<N>.md is a trap in both directions: the write in step 7 overwrites it
+          # unconditionally, and step 6 skips pr-*.md when scanning for manual changesets, so the
+          # edit is neither kept nor honored - it just vanishes with CI green. The removal paths
+          # above already gate on AUTO_MARKER so this workflow never DELETES human content; this is
+          # the same check on the write side. Warn rather than yield: treating this file as
+          # authoritative would create a second override path step 6 cannot see, letting the
+          # published bump drift from the PR title. `pnpm changeset` is the supported route.
+          if [ -f "$CHANGESET_FILE" ] && ! grep -q "$AUTO_MARKER" "$CHANGESET_FILE" 2>/dev/null; then
+            echo "::warning::${CHANGESET_FILE} looks hand-edited and is being overwritten. Run 'pnpm changeset' to author an override."
+            EDIT_MARKER="<!-- auto-changeset-handedit -->"
+            EDIT_BODY="${EDIT_MARKER}
+          **Auto-Changeset:** \`${CHANGESET_FILE}\` looks hand-edited, and this workflow has just overwritten it.
+
+          That file is generated from the PR title and rewritten on every push, so edits to it are always lost. It is also skipped when scanning for manual changesets, so it never counts as an override either.
+
+          To override the generated bump, run \`pnpm changeset\` and commit the file it creates under any other name. Those are respected: a manual changeset at or above this PR's bump level replaces the auto-generated one, and a lower one is kept alongside it."
+
+            EDIT_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              --jq ".[] | select(.body | contains(\"${EDIT_MARKER}\")) | .id" | head -1)
+            if [ -n "$EDIT_COMMENT_ID" ]; then
+              gh api "repos/${{ github.repository }}/issues/comments/${EDIT_COMMENT_ID}" \
+                -X PATCH -f body="$EDIT_BODY" > /dev/null
+            else
+              gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+                -f body="$EDIT_BODY" > /dev/null
+            fi
+          fi
+
           # ── 7. Generate changeset file ──
           {
             echo "$AUTO_MARKER"


### PR DESCRIPTION
Closes the open question from #1462's follow-up: **may the auto-changeset generator be hand-overridden?**

## The answer: yes, and the mechanism already exists

`pnpm changeset` produces a randomly-named file, and step 6 honors any changeset whose filename is not `pr-*.md` — at or above this PR's bump level it replaces the auto-generated one, below it is kept alongside. CONTRIBUTING.md:209 already documents this. **No change to that mechanism is needed or made here.**

## The actual defect

The workflow gates every *removal* on `AUTO_MARKER` (`:93`, `:143`, `:230`) specifically so it never deletes human-authored content. The *write* in step 7 had no such check — it is an unconditional `> "$CHANGESET_FILE"`.

Combined with step 6 skipping `pr-*.md`, a hand-edited `pr-<N>.md` was invisible in both directions: not honored as an override, and silently reverted on the next push, CI green throughout. Editing that file is the natural instinct, because it is the changeset that already exists. I hit this myself on #1461 and only noticed because the bot's revert showed up in the diff.

## What this changes

The same marker check, on the write side. It **warns and overwrites** rather than yielding, deliberately: treating a hand-edited `pr-<N>.md` as authoritative would create a second override path that step 6 cannot see, so the published bump could drift from the PR title. One source of truth, loud failure instead of silent.

Detection sets a flag; all reporting happens in step 10, **after** the changeset is committed and pushed, with every API call `|| true`. That placement is deliberate: `auto-changeset` is not a required check on `main`, so an API error before the write would abort with no changeset generated and merge would not be blocked (filed separately as #1467). An API hiccup can now cost at most a comment.

Step 10 reconciles both comment types — post/update the hand-edit warning while the condition holds, delete it once the file is ours again. Step 8's early `exit 0` became an if/else so that cleanup always runs: the push that *fixes* a hand-edited file regenerates byte-identical content, so "no commit needed" is precisely the run where the stale comment must be removed.

Uses its own comment marker, so step 10's conventional-title cleanup does not delete it.

## Verification

- `actionlint` reports **the same 3 findings as `main`** (missing `app-id`, undefined `client-id`, one SC2001 style nit) — all pre-existing, none introduced.
- The `run:` block extracted from the parsed YAML passes `bash -n`.
- The predicate was exercised against four file shapes: bot-generated with marker (silent), hand-edited with marker stripped (fires), empty (fires), missing (silent).
- The step 10 tail was simulated with a stubbed `gh` across six cases, asserting the *action taken* rather than just the exit code: hand-edited/no-comment -> create; hand-edited/existing -> patch (no duplicate); fixed/existing -> delete; fixed/unchanged-content -> delete (the case the old `exit 0` skipped); fixed/no-comment -> no-op; API-down -> both calls fail and the script still completes.
- All 162 existing `.changeset/pr-*.md` files on `main` carry `AUTO_MARKER`, so there is no legacy cohort that would trip the guard spuriously.

**This PR cannot exercise the new path itself.** Its own title is `ci(...)`, which exits at step 2 with "type does not require a changeset" — long before step 7. The first real exercise will be a `feat`/`fix` PR where someone edits the generated file.

## Known limits

- An edit that leaves the `AUTO_MARKER` line intact still passes silently. The marker is a machine tag, so preserving it while editing is a deliberate act; not worth defending against.
- The earlier exit paths (non-conventional title, non-publishable type) return before step 10, so a stale hand-edit comment can outlive a title change. Narrow, and not worth threading cleanup through every exit.
