### PR TITLE
fix(data-lakes): add DB backstop for fileTagPrefix collisions

### DIFF
--- a/apps/client/pages/api/data-lakes/[id]/files/__tests__/[fabFileId].test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/files/__tests__/[fabFileId].test.ts
@@ -91,6 +91,21 @@ describe('DELETE /api/data-lakes/[id]/files/[fabFileId]', () => {
     expect(h.removeFileFromDataLake).not.toHaveBeenCalled();
   });
 
+  it('forwards an admin actor through to the service (untested before, so a route that hardcoded isAdmin: false would have gone unnoticed)', async () => {
+    h.assertLakeAccess.mockResolvedValue({ id: 'lake1' });
+    h.toAccessContext.mockResolvedValue({ userId: 'root', isAdmin: true });
+    const { res } = makeRes();
+
+    await call(req({ id: 'lake1', fabFileId: 'f1' }), res);
+
+    expect(h.removeFileFromDataLake).toHaveBeenCalledWith(
+      { userId: 'root', isAdmin: true },
+      'lake1',
+      'f1',
+      expect.anything()
+    );
+  });
+
   it('takes the actor from the access context, never from the request body', async () => {
     h.assertLakeAccess.mockResolvedValue({ id: 'lake1' });
     const { res } = makeRes();

--- a/b4m-core/services/src/dataLakeService/createDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/createDataLake.ts
@@ -56,14 +56,15 @@ async function disambiguateSlug(
  * Refuses a `fileTagPrefix` that another lake in scope already matches.
  *
  * Two lakes sharing a prefix share their prefix-tagged files, so permanently deleting one would
- * destroy files that only the other holds - the prefix arm has no uniqueness constraint to stop
- * it. Rejecting rather than auto-suffixing like the slug: `acme:-1` is not a meaningful prefix,
- * and silently rewriting it would change every tag the taxonomy step just showed the user.
+ * destroy files that only the other holds - overlap (exact or nested) has no DB-level constraint
+ * to stop it. Rejecting rather than auto-suffixing like the slug: `acme:-1` is not a meaningful
+ * prefix, and silently rewriting it would change every tag the taxonomy step just showed the user.
  *
- * Read-then-write, so two concurrent creates in one scope can both pass. Left as-is: the correct
- * key is conditional (org arm OR creator arm) and overlap-aware, which no single unique index
- * expresses, and a case-insensitive one would need a collation and would fail to build on rows
- * that already collide.
+ * Read-then-write, so two concurrent creates in one scope can still both pass for an OVERLAPPING
+ * (not exact-equal) prefix, or for an org-scope exact match - the correct key for either is
+ * conditional (org arm OR creator arm) and overlap-aware, which no single unique index expresses.
+ * A same-creator EXACT match is now backstopped by a real unique index on DataLakeModel
+ * ({ createdByUserId, fileTagPrefix }), closing that one slice of the race.
  */
 async function assertPrefixAvailable(
   db: CreateDataLakeAdapters['db'],

--- a/b4m-core/services/src/dataLakeService/createDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/createDataLake.ts
@@ -129,11 +129,18 @@ export const createDataLake = async (
     // unique index between the assertPrefixAvailable read above and this write (that race is
     // this index's whole reason to exist) - map the raw duplicate-key to the same friendly
     // error the read-arm check produces, rather than surfacing a 500. (Same pattern as
-    // setLakeVisibility.ts's slug-index race.)
-    if ((err as { code?: number })?.code === 11000) {
-      throw new BadRequestError(
-        `Tag prefix "${params.fileTagPrefix}" overlaps an existing data lake - choose a different prefix.`
-      );
+    // setLakeVisibility.ts's slug-index race.) Keyed on `keyPattern.fileTagPrefix`, not a bare
+    // code check: this collection also has unique indexes on `datalakeTag` and
+    // { organizationId, slug } - disambiguateSlug's pre-check makes hitting either of those
+    // here vanishingly rare, but a bare code===11000 would still mislabel that rare collision
+    // as a prefix overlap.
+    if ((err as { code?: number; keyPattern?: Record<string, unknown> })?.code === 11000) {
+      const keyPattern = (err as { keyPattern?: Record<string, unknown> }).keyPattern;
+      if (keyPattern && 'fileTagPrefix' in keyPattern) {
+        throw new BadRequestError(
+          `Tag prefix "${params.fileTagPrefix}" overlaps an existing data lake - choose a different prefix.`
+        );
+      }
     }
     throw err;
   }

--- a/b4m-core/services/src/dataLakeService/createDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/createDataLake.ts
@@ -107,20 +107,34 @@ export const createDataLake = async (
   const datalakeTag = buildDatalakeTag(slug, organizationId);
 
   // Lakes start in 'draft'; the first batch flips them to 'active' (one-way).
-  const dataLake = await db.dataLakes.create({
-    name: params.name,
-    slug,
-    description: params.description,
-    fileTagPrefix: params.fileTagPrefix,
-    datalakeTag,
-    requiredUserTag: params.requiredUserTag,
-    requiredEntitlement: params.requiredEntitlement ? normalizeEntitlementKey(params.requiredEntitlement) : undefined,
-    createdByUserId: userId,
-    organizationId,
-    status: 'draft',
-    fileCount: 0,
-    totalSizeBytes: 0,
-  } as Omit<IDataLakeDocument, 'id' | 'createdAt' | 'updatedAt'>);
+  try {
+    const dataLake = await db.dataLakes.create({
+      name: params.name,
+      slug,
+      description: params.description,
+      fileTagPrefix: params.fileTagPrefix,
+      datalakeTag,
+      requiredUserTag: params.requiredUserTag,
+      requiredEntitlement: params.requiredEntitlement ? normalizeEntitlementKey(params.requiredEntitlement) : undefined,
+      createdByUserId: userId,
+      organizationId,
+      status: 'draft',
+      fileCount: 0,
+      totalSizeBytes: 0,
+    } as Omit<IDataLakeDocument, 'id' | 'createdAt' | 'updatedAt'>);
 
-  return dataLake;
+    return dataLake;
+  } catch (err) {
+    // A concurrent create by the same user can win the { createdByUserId, fileTagPrefix }
+    // unique index between the assertPrefixAvailable read above and this write (that race is
+    // this index's whole reason to exist) - map the raw duplicate-key to the same friendly
+    // error the read-arm check produces, rather than surfacing a 500. (Same pattern as
+    // setLakeVisibility.ts's slug-index race.)
+    if ((err as { code?: number })?.code === 11000) {
+      throw new BadRequestError(
+        `Tag prefix "${params.fileTagPrefix}" overlaps an existing data lake - choose a different prefix.`
+      );
+    }
+    throw err;
+  }
 };

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -867,6 +867,17 @@ describe('createDataLake', () => {
     expect(create).not.toHaveBeenCalled();
   });
 
+  it('maps a concurrent-create index collision to the same friendly error, not a raw 500', async () => {
+    // assertPrefixAvailable's read arm passed (find() sees nothing yet), but another request
+    // from the same creator won the { createdByUserId, fileTagPrefix } unique index between that
+    // read and this write - exactly the race the index exists to catch.
+    const create = vi.fn().mockRejectedValue(Object.assign(new Error('E11000 duplicate key error'), { code: 11000 }));
+    const find = vi.fn().mockResolvedValue([]);
+    await expect(
+      createDataLake('owner', { name: 'X', slug: 'xy', fileTagPrefix: 'xy:' }, { db: { dataLakes: { create, find } } })
+    ).rejects.toThrow(/overlaps an existing data lake/i);
+  });
+
   it('names the clashing lake only when the caller created it', async () => {
     // An org lake gated by a tag the caller lacks is invisible to them everywhere else, so echoing
     // its name here would confirm it exists.

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1431,12 +1431,25 @@ describe('removeFileFromDataLake — single-file removal', () => {
     expect(adapters.db.fabFiles.pullTagsByFabFileId).not.toHaveBeenCalled();
   });
 
-  it('lets an admin remove a prefix-only file they do not own', async () => {
+  it('refuses even an admin removing a prefix-only file the lake creator does not own', async () => {
+    // The prefix arm is anchored to the LAKE'S CREATOR, matching the read path's own membership
+    // predicate - an admin bypass here would let an admin strip a tag off a file the read path
+    // never actually admitted to this lake.
     const someoneElses = { id: 'f1', userId: 'victim', tags: [{ name: 'lk:invoices', strength: 1 }] };
     const adapters = makeAdapters(someoneElses);
     await expect(
       removeFileFromDataLake({ userId: 'root', isAdmin: true }, 'lake1', 'f1', adapters as any)
+    ).rejects.toThrow(/not found in this data lake/i);
+    expect(adapters.db.fabFiles.pullTagsByFabFileId).not.toHaveBeenCalled();
+  });
+
+  it('lets an admin remove a prefix-only file the lake creator DOES own', async () => {
+    const creatorsFile = { id: 'f1', userId: 'owner', tags: [{ name: 'lk:invoices', strength: 1 }] };
+    const adapters = makeAdapters(creatorsFile);
+    await expect(
+      removeFileFromDataLake({ userId: 'root', isAdmin: true }, 'lake1', 'f1', adapters as any)
     ).resolves.toMatchObject({ success: true });
+    expect(adapters.db.fabFiles.pullTagsByFabFileId).toHaveBeenCalledWith('f1', ['datalake:lake', 'lk:invoices']);
   });
 
   it('ignores a fileTagPrefix no read arm would match, rather than clearing every tag', async () => {

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -867,15 +867,36 @@ describe('createDataLake', () => {
     expect(create).not.toHaveBeenCalled();
   });
 
-  it('maps a concurrent-create index collision to the same friendly error, not a raw 500', async () => {
+  it('maps a concurrent-create prefix-index collision to the same friendly error, not a raw 500', async () => {
     // assertPrefixAvailable's read arm passed (find() sees nothing yet), but another request
     // from the same creator won the { createdByUserId, fileTagPrefix } unique index between that
     // read and this write - exactly the race the index exists to catch.
-    const create = vi.fn().mockRejectedValue(Object.assign(new Error('E11000 duplicate key error'), { code: 11000 }));
+    const create = vi.fn().mockRejectedValue(
+      Object.assign(new Error('E11000 duplicate key error'), {
+        code: 11000,
+        keyPattern: { createdByUserId: 1, fileTagPrefix: 1 },
+      })
+    );
     const find = vi.fn().mockResolvedValue([]);
     await expect(
       createDataLake('owner', { name: 'X', slug: 'xy', fileTagPrefix: 'xy:' }, { db: { dataLakes: { create, find } } })
     ).rejects.toThrow(/overlaps an existing data lake/i);
+  });
+
+  it('does not mislabel a duplicate-key collision on a DIFFERENT index as a prefix overlap', async () => {
+    // This collection also has unique indexes on datalakeTag and { organizationId, slug } -
+    // disambiguateSlug's 50-attempt pre-check makes hitting either here vanishingly rare, but
+    // a rare hit must still surface as itself, not get relabeled "prefix overlaps".
+    const create = vi.fn().mockRejectedValue(
+      Object.assign(new Error('E11000 duplicate key error'), {
+        code: 11000,
+        keyPattern: { organizationId: 1, slug: 1 },
+      })
+    );
+    const find = vi.fn().mockResolvedValue([]);
+    await expect(
+      createDataLake('owner', { name: 'X', slug: 'xy', fileTagPrefix: 'xy:' }, { db: { dataLakes: { create, find } } })
+    ).rejects.toThrow('E11000 duplicate key error');
   });
 
   it('names the clashing lake only when the caller created it', async () => {

--- a/b4m-core/services/src/dataLakeService/lakeMembership.test.ts
+++ b/b4m-core/services/src/dataLakeService/lakeMembership.test.ts
@@ -132,6 +132,31 @@ describe('removeFileFromLake', () => {
     expect(adapters.db.fabFiles.pullTagsByFabFileId).not.toHaveBeenCalled();
   });
 
+  it('strips only the meta-tag, not a bystander prefix-matching tag, on a file the creator does not own', async () => {
+    // Admitted to inLake via the meta-tag arm only (e.g. an admin's addFileToLake added a
+    // stranger's file) - the read path's prefix arm never admitted this file since it is not
+    // owned by the lake's creator, so removal must not strip its coincidentally-matching tag.
+    const adapters = {
+      db: {
+        fabFiles: {
+          findById: vi.fn().mockResolvedValue({
+            id: 'f1',
+            userId: 'victim',
+            tags: [
+              { name: 'datalake:lake', strength: 1 },
+              { name: 'lk:invoices', strength: 1 },
+            ],
+          }),
+          pullTagsByFabFileId: vi.fn().mockResolvedValue(1),
+        },
+      },
+    };
+
+    await removeFileFromLake({ userId: 'root', isAdmin: true }, lake(), 'f1', adapters);
+
+    expect(adapters.db.fabFiles.pullTagsByFabFileId).toHaveBeenCalledWith('f1', ['datalake:lake']);
+  });
+
   it('ignores a legacy reserved-namespace fileTagPrefix rather than matching every other lake', async () => {
     // A prefix inside datalake: (predates the create-time guard that now rejects it) must not
     // treat an unrelated lake's meta-tag as this lake's own prefix-tagged content.

--- a/b4m-core/services/src/dataLakeService/lakeMembership.test.ts
+++ b/b4m-core/services/src/dataLakeService/lakeMembership.test.ts
@@ -111,4 +111,24 @@ describe('removeFileFromLake', () => {
     );
     expect(adapters.db.fabFiles.pullTagsByFabFileId).not.toHaveBeenCalled();
   });
+
+  it('refuses even an admin clearing a prefixed tag on a file the lake creator does not own', async () => {
+    // Prefix-only (no meta-tag), owned by someone other than lake()'s creator ('owner'), so the
+    // outcome is decided entirely by the ownership conjunct, not the meta-tag arm.
+    const adapters = {
+      db: {
+        fabFiles: {
+          findById: vi
+            .fn()
+            .mockResolvedValue({ id: 'f1', userId: 'victim', tags: [{ name: 'lk:invoices', strength: 1 }] }),
+          pullTagsByFabFileId: vi.fn().mockResolvedValue(1),
+        },
+      },
+    };
+
+    await expect(removeFileFromLake({ userId: 'root', isAdmin: true }, lake(), 'f1', adapters)).rejects.toThrow(
+      /not found in this data lake/i
+    );
+    expect(adapters.db.fabFiles.pullTagsByFabFileId).not.toHaveBeenCalled();
+  });
 });

--- a/b4m-core/services/src/dataLakeService/lakeMembership.test.ts
+++ b/b4m-core/services/src/dataLakeService/lakeMembership.test.ts
@@ -131,4 +131,25 @@ describe('removeFileFromLake', () => {
     );
     expect(adapters.db.fabFiles.pullTagsByFabFileId).not.toHaveBeenCalled();
   });
+
+  it('ignores a legacy reserved-namespace fileTagPrefix rather than matching every other lake', async () => {
+    // A prefix inside datalake: (predates the create-time guard that now rejects it) must not
+    // treat an unrelated lake's meta-tag as this lake's own prefix-tagged content.
+    const reservedPrefixLake = lake({ fileTagPrefix: 'datalake:evil:' });
+    const adapters = {
+      db: {
+        fabFiles: {
+          findById: vi
+            .fn()
+            .mockResolvedValue({ id: 'f1', userId: 'owner', tags: [{ name: 'datalake:other', strength: 1 }] }),
+          pullTagsByFabFileId: vi.fn().mockResolvedValue(1),
+        },
+      },
+    };
+
+    await expect(removeFileFromLake(owner, reservedPrefixLake, 'f1', adapters)).rejects.toThrow(
+      /not found in this data lake/i
+    );
+    expect(adapters.db.fabFiles.pullTagsByFabFileId).not.toHaveBeenCalled();
+  });
 });

--- a/b4m-core/services/src/dataLakeService/lakeMembership.ts
+++ b/b4m-core/services/src/dataLakeService/lakeMembership.ts
@@ -50,9 +50,11 @@ export const removeFileFromLake = async (
   // Normalized through the same predicate the read arms use, so a lake whose prefix no query
   // matches (empty, or missing its trailing colon) also gets nothing cleared by prefix.
   const prefix = normalizeTagPrefix(lake.fileTagPrefix);
-  // Positive ownership: both ids must be present AND equal, so a file with no owner does not
-  // fall through as a match.
-  const ownsFile = actor.isAdmin || (!!file?.userId && file.userId === actor.userId);
+  // Positive ownership, anchored to the LAKE'S CREATOR (not the acting admin) so this matches
+  // the read path's own membership predicate exactly: both ids must be present AND equal, so a
+  // file with no owner does not fall through as a match, and an admin cannot strip a prefixed
+  // tag off a file the read path never actually admitted to this lake.
+  const ownsFile = !!file?.userId && file.userId === lake.createdByUserId;
   const prefixedTags = prefix ? tagNames.filter(name => name.startsWith(prefix)) : [];
   const inLake = !!file && (tagNames.includes(lake.datalakeTag) || (ownsFile && prefixedTags.length > 0));
   if (!file || !inLake) {

--- a/b4m-core/services/src/dataLakeService/lakeMembership.ts
+++ b/b4m-core/services/src/dataLakeService/lakeMembership.ts
@@ -1,4 +1,4 @@
-import { DATALAKE_TAG_PREFIX, DATALAKE_TAG_STRENGTH, normalizeTagPrefix } from '@bike4mind/common';
+import { DATALAKE_TAG_PREFIX, DATALAKE_TAG_STRENGTH, isReservedTagPrefix, normalizeTagPrefix } from '@bike4mind/common';
 import type { IDataLakeDocument, IFabFileRepository } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
 import { assertLakeWritable } from './assertLakeAccess';
@@ -47,13 +47,19 @@ export const removeFileFromLake = async (
 
   const file = await db.fabFiles.findById(fabFileId);
   const tagNames = (file?.tags ?? []).map(t => t.name).filter((name): name is string => typeof name === 'string');
-  // Normalized through the same predicate the read arms use, so a lake whose prefix no query
-  // matches (empty, or missing its trailing colon) also gets nothing cleared by prefix.
-  const prefix = normalizeTagPrefix(lake.fileTagPrefix);
+  // Normalized through the same predicate buildDataLakeMembershipFilter uses, so a lake whose
+  // prefix no query matches (empty, missing its trailing colon, or - a legacy row predating the
+  // create-time guard - inside the reserved datalake: namespace) also gets nothing cleared by
+  // prefix, matching that its read arm drops the same cases rather than matching every OTHER
+  // lake's meta-tag.
+  const prefix = isReservedTagPrefix(lake.fileTagPrefix) ? null : normalizeTagPrefix(lake.fileTagPrefix);
   // Positive ownership, anchored to the LAKE'S CREATOR (not the acting admin) so this matches
-  // the read path's own membership predicate exactly: both ids must be present AND equal, so a
-  // file with no owner does not fall through as a match, and an admin cannot strip a prefixed
-  // tag off a file the read path never actually admitted to this lake.
+  // buildDataLakeMembershipFilter's own ownership conjunct on the single-lake browse: both ids
+  // must be present AND equal, so a file with no owner does not fall through as a match, and an
+  // admin cannot strip a prefixed tag off a file that predicate never actually admitted to this
+  // lake. Other lake readers (the aggregate browse, semantic search, chat KB tools) still match
+  // the prefix within the VIEWER's own access - that is ownership of the file, not membership in
+  // this lake, and unaffected by this write.
   const ownsFile = !!file?.userId && file.userId === lake.createdByUserId;
   const prefixedTags = prefix ? tagNames.filter(name => name.startsWith(prefix)) : [];
   const inLake = !!file && (tagNames.includes(lake.datalakeTag) || (ownsFile && prefixedTags.length > 0));

--- a/b4m-core/services/src/dataLakeService/lakeMembership.ts
+++ b/b4m-core/services/src/dataLakeService/lakeMembership.ts
@@ -61,8 +61,13 @@ export const removeFileFromLake = async (
   // the prefix within the VIEWER's own access - that is ownership of the file, not membership in
   // this lake, and unaffected by this write.
   const ownsFile = !!file?.userId && file.userId === lake.createdByUserId;
-  const prefixedTags = prefix ? tagNames.filter(name => name.startsWith(prefix)) : [];
-  const inLake = !!file && (tagNames.includes(lake.datalakeTag) || (ownsFile && prefixedTags.length > 0));
+  // Gated on ownsFile, not just prefix: a file admitted to inLake via the META-TAG arm (e.g. an
+  // admin added a stranger's file with addFileToLake, which checks only the ACTOR's access, not
+  // the file's ownership) must not also have its unrelated tags stripped just because one
+  // happens to start with this lake's prefix - the read path's prefix arm never admitted this
+  // file, so the write must not touch prefix-matching tags on it either.
+  const prefixedTags = prefix && ownsFile ? tagNames.filter(name => name.startsWith(prefix)) : [];
+  const inLake = !!file && (tagNames.includes(lake.datalakeTag) || prefixedTags.length > 0);
   if (!file || !inLake) {
     throw new NotFoundError('File not found in this data lake');
   }

--- a/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
@@ -42,10 +42,9 @@ interface RemoveFileFromDataLakeAdapters {
  * A second lake sharing this prefix - not necessarily the caller's, since fileTagPrefix has no
  * org-scope uniqueness (same-creator collisions are blocked by a DB index; see the comment on
  * that index in DataLakeModel.ts for why org-scope is not) - loses the shared prefixed tag too.
- * A lake holding its own meta-tag on
- * the file keeps it and only loses the folder grouping, but a lake whose membership was
- * prefix-only loses the file outright. One tag string cannot be cleared for one lake and kept
- * for another.
+ * A lake holding its own meta-tag on the file keeps it and only loses the folder grouping, but a
+ * lake whose membership was prefix-only loses the file outright. One tag string cannot be
+ * cleared for one lake and kept for another.
  *
  * That "only loses the folder grouping" now costs more than it reads. Every lake file carries a
  * tag under its lake's prefix (see `fallbackLakeTags`), so for a co-prefixed second lake the

--- a/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
@@ -30,12 +30,14 @@ interface RemoveFileFromDataLakeAdapters {
  * by the LAKE'S CREATOR, because fileTagPrefix is user-chosen and not org-scope unique: without
  * that conjunct, minting a lake with someone else's prefix would be a licence to strip their tags.
  *
- * The whole-lake predicate requires the same ownership conjunct on its prefix arm
- * (buildDataLakeMembershipFilter), so both this endpoint and the lake-wide sweep now ask the
- * identical question - "is this file the creator's" - matching the read path's own membership
- * predicate exactly. An admin may call this without owning the file themselves, but the file
- * itself must still belong to the lake's creator; an admin cannot use this to strip a prefixed
- * tag off a file the read path never actually admitted to this lake.
+ * The whole-lake predicate (buildDataLakeMembershipFilter, the single-lake browse's own
+ * membership check) requires the same ownership conjunct on its prefix arm, so both this
+ * endpoint and the lake-wide sweep now ask the identical question - "is this file the creator's".
+ * An admin may call this without owning the file themselves, but the file itself must still
+ * belong to the lake's creator; an admin cannot use this to strip a prefixed tag off a file that
+ * predicate never actually admitted to this lake. Other lake readers (the aggregate browse,
+ * semantic search, chat KB tools) still match the prefix within the VIEWER's own access - a
+ * different, ownership-of-the-file question this endpoint does not touch.
  *
  * A second lake sharing this prefix - not necessarily the caller's, since fileTagPrefix has no
  * org-scope uniqueness (same-creator collisions are blocked by a DB index; see the comment on

--- a/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
@@ -26,20 +26,20 @@ interface RemoveFileFromDataLakeAdapters {
  * the stats reported it as removed.
  *
  * Membership is TESTED against both signals too, so a file carrying only a prefixed tag can
- * be removed rather than 404ing forever. The prefix arm additionally requires the ACTOR to own
- * the file, because fileTagPrefix is user-chosen and neither unique nor reserved: without that
- * conjunct, minting a lake with someone else's prefix would be a licence to strip their tags.
+ * be removed rather than 404ing forever. The prefix arm additionally requires the file be owned
+ * by the LAKE'S CREATOR, because fileTagPrefix is user-chosen and not org-scope unique: without
+ * that conjunct, minting a lake with someone else's prefix would be a licence to strip their tags.
  *
- * The whole-lake predicate requires ownership on its prefix arm too, but anchored to the lake's
- * CREATOR rather than the actor (buildDataLakeMembershipFilter). Neither rides a read share: both
- * are destructive, and a file someone else owns is not the lake's to hide or purge. The asymmetry
- * is only in WHOSE ownership counts - this endpoint strips tags on behalf of its caller, so it asks
- * "may THIS actor edit this file", while archive and delete act on the lake and ask "is this file
- * the creator's". So an admin removing one file must own it, while the lake-wide sweep they trigger
- * takes the creator's files instead.
+ * The whole-lake predicate requires the same ownership conjunct on its prefix arm
+ * (buildDataLakeMembershipFilter), so both this endpoint and the lake-wide sweep now ask the
+ * identical question - "is this file the creator's" - matching the read path's own membership
+ * predicate exactly. An admin may call this without owning the file themselves, but the file
+ * itself must still belong to the lake's creator; an admin cannot use this to strip a prefixed
+ * tag off a file the read path never actually admitted to this lake.
  *
- * A second lake sharing this prefix - not necessarily the caller's, since nothing makes
- * fileTagPrefix unique - loses the shared prefixed tag too. A lake holding its own meta-tag on
+ * A second lake sharing this prefix - not necessarily the caller's, since fileTagPrefix has no
+ * org-scope uniqueness (same-creator collisions are blocked by a DB index; see tagPrefixCollision
+ * for why org-scope is not) - loses the shared prefixed tag too. A lake holding its own meta-tag on
  * the file keeps it and only loses the folder grouping, but a lake whose membership was
  * prefix-only loses the file outright. One tag string cannot be cleared for one lake and kept
  * for another.

--- a/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/removeFileFromDataLake.ts
@@ -38,8 +38,9 @@ interface RemoveFileFromDataLakeAdapters {
  * tag off a file the read path never actually admitted to this lake.
  *
  * A second lake sharing this prefix - not necessarily the caller's, since fileTagPrefix has no
- * org-scope uniqueness (same-creator collisions are blocked by a DB index; see tagPrefixCollision
- * for why org-scope is not) - loses the shared prefixed tag too. A lake holding its own meta-tag on
+ * org-scope uniqueness (same-creator collisions are blocked by a DB index; see the comment on
+ * that index in DataLakeModel.ts for why org-scope is not) - loses the shared prefixed tag too.
+ * A lake holding its own meta-tag on
  * the file keeps it and only loses the folder grouping, but a lake whose membership was
  * prefix-only loses the file outright. One tag string cannot be cleared for one lake and kept
  * for another.

--- a/packages/database/src/models/ai/DataLakeModel.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.test.ts
@@ -442,12 +442,98 @@ describe('DataLakeRepository — slug is unique per org', () => {
   });
 
   it('allows the same slug in different orgs (unique per org, not global)', async () => {
+    // Distinct creators so this is attributable to the (organizationId, slug) index alone -
+    // baseLake defaults fileTagPrefix off the slug, and same-slug would otherwise also collide
+    // on the (createdByUserId, fileTagPrefix) index tested separately below.
     await dataLakeRepository.create(
-      baseLake({ slug: 'shared', organizationId: 'orgA', datalakeTag: 'datalake:orgA:shared' })
+      baseLake({
+        slug: 'shared',
+        organizationId: 'orgA',
+        createdByUserId: 'ownerA',
+        datalakeTag: 'datalake:orgA:shared',
+      })
     );
     await expect(
       dataLakeRepository.create(
-        baseLake({ slug: 'shared', organizationId: 'orgB', datalakeTag: 'datalake:orgB:shared' })
+        baseLake({
+          slug: 'shared',
+          organizationId: 'orgB',
+          createdByUserId: 'ownerB',
+          datalakeTag: 'datalake:orgB:shared',
+        })
+      )
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('DataLakeRepository — fileTagPrefix is unique per creator (DB backstop)', () => {
+  setupMongoTest();
+
+  // cleanupTestDB drops the whole DB before each test, so (re)build the model's indexes
+  // (including the { createdByUserId, fileTagPrefix } unique index) before asserting the
+  // constraint.
+  beforeEach(async () => {
+    await DataLakeModel.ensureIndexes();
+  });
+
+  it('rejects a second lake with the same prefix for the same creator, regardless of org', async () => {
+    await dataLakeRepository.create(
+      baseLake({ slug: 'first', fileTagPrefix: 'acme:', createdByUserId: 'owner', datalakeTag: 'datalake:first' })
+    );
+    await expect(
+      dataLakeRepository.create(
+        baseLake({
+          slug: 'second',
+          fileTagPrefix: 'acme:',
+          createdByUserId: 'owner',
+          organizationId: 'orgA',
+          datalakeTag: 'datalake:orgA:second',
+        })
+      )
+    ).rejects.toThrow();
+  });
+
+  it('allows the same prefix for different creators in the same org (org-scope collisions stay app-level only)', async () => {
+    await dataLakeRepository.create(
+      baseLake({
+        slug: 'first',
+        fileTagPrefix: 'acme:',
+        createdByUserId: 'ownerA',
+        organizationId: 'orgA',
+        datalakeTag: 'datalake:orgA:first',
+      })
+    );
+    await expect(
+      dataLakeRepository.create(
+        baseLake({
+          slug: 'second',
+          fileTagPrefix: 'acme:',
+          createdByUserId: 'ownerB',
+          organizationId: 'orgA',
+          datalakeTag: 'datalake:orgA:second',
+        })
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it('allows the same prefix for different creators who are both org-less (personal lakes)', async () => {
+    await dataLakeRepository.create(
+      baseLake({ slug: 'first', fileTagPrefix: 'acme:', createdByUserId: 'ownerA', datalakeTag: 'datalake:first' })
+    );
+    await expect(
+      dataLakeRepository.create(
+        baseLake({ slug: 'second', fileTagPrefix: 'acme:', createdByUserId: 'ownerB', datalakeTag: 'datalake:second' })
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it('allows a nested (not exact-equal) prefix for the same creator - nesting stays app-level only', async () => {
+    await dataLakeRepository.create(
+      baseLake({ slug: 'outer', fileTagPrefix: 'acme:', createdByUserId: 'owner', datalakeTag: 'datalake:outer' })
+    );
+    await expect(
+      dataLakeRepository.create(
+        baseLake({ slug: 'inner', fileTagPrefix: 'acme:hr:', createdByUserId: 'owner', datalakeTag: 'datalake:inner' })
       )
     ).resolves.toBeDefined();
   });

--- a/packages/database/src/models/ai/DataLakeModel.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.test.ts
@@ -432,12 +432,22 @@ describe('DataLakeRepository — slug is unique per org', () => {
 
   it('rejects a second lake with the same slug in the same org', async () => {
     // Distinct datalakeTags so the rejection is attributable to the (organizationId, slug)
-    // index, not the separate unique index on datalakeTag.
+    // index, not the separate unique index on datalakeTag. Distinct creators for the same
+    // reason against the (createdByUserId, fileTagPrefix) index tested separately below -
+    // baseLake defaults fileTagPrefix off the slug, and same-slug-same-creator would otherwise
+    // also collide there.
     await dataLakeRepository.create(
-      baseLake({ slug: 'dupe', organizationId: 'orgA', datalakeTag: 'datalake:orgA:dupe-1' })
+      baseLake({ slug: 'dupe', organizationId: 'orgA', createdByUserId: 'ownerA', datalakeTag: 'datalake:orgA:dupe-1' })
     );
     await expect(
-      dataLakeRepository.create(baseLake({ slug: 'dupe', organizationId: 'orgA', datalakeTag: 'datalake:orgA:dupe-2' }))
+      dataLakeRepository.create(
+        baseLake({
+          slug: 'dupe',
+          organizationId: 'orgA',
+          createdByUserId: 'ownerB',
+          datalakeTag: 'datalake:orgA:dupe-2',
+        })
+      )
     ).rejects.toThrow();
   });
 

--- a/packages/database/src/models/ai/DataLakeModel.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.test.ts
@@ -466,7 +466,7 @@ describe('DataLakeRepository — slug is unique per org', () => {
   });
 });
 
-describe('DataLakeRepository — fileTagPrefix is unique per creator (DB backstop)', () => {
+describe('DataLakeRepository - fileTagPrefix is unique per creator (DB backstop)', () => {
   setupMongoTest();
 
   // cleanupTestDB drops the whole DB before each test, so (re)build the model's indexes

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -89,13 +89,15 @@ DataLakeSchema.index({ datalakeTag: 1 }, { unique: true, sparse: true });
 DataLakeSchema.index({ organizationId: 1, slug: 1 }, { unique: true });
 // Backstop for the create-time collision guard in createDataLake.ts (assertPrefixAvailable),
 // which is read-then-write and can race under two concurrent creates by the same user.
-// Creator-scope only: createdByUserId is always a required non-empty string, so this is safe
-// to build unconditionally. There is deliberately NO org-scope companion index - org-less lakes
-// persist with organizationId as an explicit null OR empty string (see the `$in: [null, '']`
-// scope elsewhere in this file), so a partial index on `{ $exists: true }` would fold every
-// personal lake in the system into one collision group and fail to build. Org-scope collisions
-// stay app-level only (tagPrefixCollision.ts), matching that file's own documented acceptance
-// that the creator-OR-org scope rule cannot be expressed by a single unique index.
+// Creator-scope only: createDataLake.ts always sets createdByUserId from the authenticated
+// actor, never empty, for every document this index actually covers (the only
+// createdByUserId: '' in this codebase is a synthetic registry-lake fallback with no backing
+// document - see assertLakeAccess.ts - so it never reaches this index). There is deliberately
+// NO org-scope companion index - org-less lakes persist with organizationId as an explicit null
+// OR empty string (see the `$in: [null, '']` scope elsewhere in this file), so a partial index
+// on `{ $exists: true }` would fold every personal lake in the system into one collision group
+// and fail to build. Org-scope collisions stay app-level only: tagPrefixCollision.ts's
+// creator-OR-org scope rule is an OR, which no single Mongo unique index key can express.
 DataLakeSchema.index({ createdByUserId: 1, fileTagPrefix: 1 }, { unique: true });
 
 export const DataLakeModel =

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -87,6 +87,16 @@ DataLakeSchema.index({ datalakeTag: 1 }, { unique: true, sparse: true });
 // Slug is unique PER SCOPE (org). Replaces the former global unique on `slug`.
 // NOTE: deploying this requires dropping the legacy `slug_1` unique index in Mongo.
 DataLakeSchema.index({ organizationId: 1, slug: 1 }, { unique: true });
+// Backstop for the create-time collision guard in createDataLake.ts (assertPrefixAvailable),
+// which is read-then-write and can race under two concurrent creates by the same user.
+// Creator-scope only: createdByUserId is always a required non-empty string, so this is safe
+// to build unconditionally. There is deliberately NO org-scope companion index - org-less lakes
+// persist with organizationId as an explicit null OR empty string (see the `$in: [null, '']`
+// scope elsewhere in this file), so a partial index on `{ $exists: true }` would fold every
+// personal lake in the system into one collision group and fail to build. Org-scope collisions
+// stay app-level only (tagPrefixCollision.ts), matching that file's own documented acceptance
+// that the creator-OR-org scope rule cannot be expressed by a single unique index.
+DataLakeSchema.index({ createdByUserId: 1, fileTagPrefix: 1 }, { unique: true });
 
 export const DataLakeModel =
   (mongoose.models['DataLake'] as unknown as mongoose.Model<IDataLakeDocument>) ||

--- a/packages/database/src/priceCatalogBootstrap.test.ts
+++ b/packages/database/src/priceCatalogBootstrap.test.ts
@@ -11,6 +11,7 @@ const seedModelPrices = vi.fn();
 const seedModelCatalog = vi.fn();
 const catalogInit = vi.fn();
 const discoveryStateInit = vi.fn();
+const dataLakeInit = vi.fn();
 
 vi.mock('@bike4mind/db-core', () => ({ connectDB: baseConnectDB }));
 vi.mock('@bike4mind/llm-adapters', () => ({ setModelPriceRowsProvider, setModelCatalogProvider }));
@@ -20,6 +21,7 @@ vi.mock('./models/ai/ModelCatalogModel', () => ({
   ModelCatalog: { init: catalogInit },
 }));
 vi.mock('./models/ai/ModelDiscoveryStateModel', () => ({ ModelDiscoveryState: { init: discoveryStateInit } }));
+vi.mock('./models/ai/DataLakeModel', () => ({ DataLakeModel: { init: dataLakeInit } }));
 vi.mock('./seeds/seedModelPrices', () => ({ seedModelPrices }));
 vi.mock('./seeds/seedModelCatalog', () => ({ seedModelCatalog }));
 
@@ -41,6 +43,7 @@ describe('priceCatalogBootstrap.connectDB', () => {
     seedModelCatalog.mockResolvedValue({ inserted: 0, skipped: 0 });
     catalogInit.mockResolvedValue(undefined);
     discoveryStateInit.mockResolvedValue(undefined);
+    dataLakeInit.mockResolvedValue(undefined);
   });
 
   it('wires both providers and seeds exactly once across repeated connects', async () => {
@@ -79,14 +82,17 @@ describe('priceCatalogBootstrap.connectDB', () => {
     expect(order).toEqual(['catalog', 'prices']);
   });
 
-  it('awaits both unique-index builds before the first write', async () => {
+  it('awaits all three unique-index builds before the first write', async () => {
     // autoIndex is fire-and-forget: seeding a fresh collection first lets the
     // duplicates land, and createIndexes then fails on them permanently. The
     // discovery drivers gate on whenCatalogSeeded, so the discovery-state index
     // has to be built here too, ahead of the first recordSighting upsert.
+    // DataLakeModel's index build is awaited for a different reason (see
+    // ensureUniqueIndex's docstring): its collection is pre-existing, not fresh.
     const order: string[] = [];
     catalogInit.mockImplementation(async () => order.push('catalog-index'));
     discoveryStateInit.mockImplementation(async () => order.push('discovery-index'));
+    dataLakeInit.mockImplementation(async () => order.push('dataLake-index'));
     seedModelCatalog.mockImplementation(async () => {
       order.push('catalog-seed');
       return { inserted: 0, skipped: 0 };
@@ -96,7 +102,7 @@ describe('priceCatalogBootstrap.connectDB', () => {
     await connectDB('mongodb://x');
     await flushSeeding();
 
-    expect(order).toEqual(['catalog-index', 'discovery-index', 'catalog-seed']);
+    expect(order).toEqual(['catalog-index', 'discovery-index', 'dataLake-index', 'catalog-seed']);
   });
 
   it('still seeds when an index build fails, so an already-duplicated collection is not left empty', async () => {
@@ -110,6 +116,19 @@ describe('priceCatalogBootstrap.connectDB', () => {
     expect(seedModelCatalog).toHaveBeenCalledTimes(1);
     expect(seedModelPrices).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('unique index build failed'), expect.any(Error));
+    warn.mockRestore();
+  });
+
+  it('warns (does not throw or block seeding) when the DataLake index build fails on legacy duplicates', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    dataLakeInit.mockRejectedValue(Object.assign(new Error('E11000 duplicate key'), { code: 11000 }));
+
+    const connectDB = await freshConnectDB();
+    await expect(connectDB('mongodb://x')).resolves.toBe('connection');
+    await flushSeeding();
+
+    expect(seedModelCatalog).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('[dataLake]'), expect.any(Error));
     warn.mockRestore();
   });
 

--- a/packages/database/src/priceCatalogBootstrap.ts
+++ b/packages/database/src/priceCatalogBootstrap.ts
@@ -3,6 +3,7 @@ import { setModelCatalogProvider, setModelPriceRowsProvider } from '@bike4mind/l
 import { modelPriceRepository } from './models/billing/ModelPriceModel';
 import { ModelCatalog, modelCatalogRepository } from './models/ai/ModelCatalogModel';
 import { ModelDiscoveryState } from './models/ai/ModelDiscoveryStateModel';
+import { DataLakeModel } from './models/ai/DataLakeModel';
 import { seedModelCatalog } from './seeds/seedModelCatalog';
 import { seedModelPrices } from './seeds/seedModelPrices';
 
@@ -31,6 +32,15 @@ export const whenCatalogSeeded = (): Promise<boolean> => catalogSeedSettled ?? P
  * ModelDiscoveryState are both new collections, so every deployment gets exactly
  * that cold start. ModelPrice is deliberately absent - its collection and index
  * predate this.
+ *
+ * DataLakeModel is here for a different reason: its new
+ * { createdByUserId, fileTagPrefix } unique index lands on an EXISTING,
+ * populated collection, so a stage with legacy same-creator-prefix duplicates
+ * fails this build on every boot, not just the first - awaiting it turns that
+ * into a warning any deployer watching boot logs sees, instead of a Node
+ * unhandled-rejection with no attribution. The pre-deploy check script
+ * (packages/scripts/migrate/check-datalake-prefix-dupes.ts) is what actually
+ * finds and resolves the duplicates; this only makes a failed build loud.
  *
  * A failed build must not skip the seeding it precedes: an already-duplicated
  * collection would then never receive its rows.
@@ -63,6 +73,7 @@ async function seedCatalogs(): Promise<boolean> {
   await Promise.all([
     ensureUniqueIndex('modelCatalog', ModelCatalog),
     ensureUniqueIndex('modelDiscoveryState', ModelDiscoveryState),
+    ensureUniqueIndex('dataLake', DataLakeModel),
   ]);
 
   let catalogSeeded = true;

--- a/packages/database/src/queries/dataLakeLifecycleScope.ts
+++ b/packages/database/src/queries/dataLakeLifecycleScope.ts
@@ -17,9 +17,10 @@ import { escapeRegex } from '@bike4mind/utils/escapeRegex';
  * viewer-independent `fileCount`; an actor-anchored predicate would make the stored count vary
  * by who triggered the recompute.
  *
- * The prefix arm needs an ownership conjunct at all because `fileTagPrefix` is user-chosen with no
- * uniqueness constraint (see DataLakeModel). Without it, minting a lake with prefix `acme:`
- * would permanently delete every file in the database tagged `acme:*`.
+ * The prefix arm needs an ownership conjunct at all because `fileTagPrefix` is user-chosen and only
+ * unique per creator (see DataLakeModel) - a lake in a different org or by a different creator can
+ * still register the same prefix. Without the conjunct, minting a lake with prefix `acme:` would
+ * permanently delete every file in the database tagged `acme:*`.
  *
  * That conjunct is POSITIVE ownership - `userId` equals the creator - and deliberately NOT
  * "anything the creator can access". A read share must not make someone else's file a member:

--- a/packages/scripts/migrate/check-datalake-prefix-dupes.ts
+++ b/packages/scripts/migrate/check-datalake-prefix-dupes.ts
@@ -1,0 +1,69 @@
+import { connectDB, DataLakeModel } from '@bike4mind/database';
+import { normalizeTagPrefix } from '@bike4mind/common';
+import { Resource } from 'sst';
+import { Config } from '../utils/config';
+
+/**
+ * READ-ONLY pre-flight for the { createdByUserId, fileTagPrefix } unique index.
+ *
+ * Run this BEFORE deploying to a stage that already has lakes (staging/prod). The deploy's
+ * autoIndex build of the new index will FAIL if any duplicate (createdByUserId, fileTagPrefix)
+ * groups exist - so we must confirm zero duplicates first. Exits non-zero (and prints the
+ * offending ids) if any are found, so it can gate a deploy.
+ *
+ * Excludes groups whose prefix normalizeTagPrefix rejects (no trailing colon, blank): those
+ * values contribute no read-path arm today, so two lakes sharing one is inert junk, not a real
+ * collision worth blocking a deploy over.
+ *
+ * Org-scope collisions are NOT checked here - there is no org-scope index (see the comment on
+ * the index itself in DataLakeModel.ts for why) and existing org-scope overlaps, including exact
+ * matches, are already reported non-blockingly by check-datalake-prefix-overlaps.ts.
+ *
+ * Usage:
+ *   ./for-env <env> pnpm sst shell --stage <stage> -- pnpm --filter scripts datalake:check-prefix-dupes
+ */
+async function main() {
+  const dbUri = Config.MONGODB_URI;
+  if (!dbUri) throw new Error('MONGODB_URI is required');
+  const stage = Resource.App.stage;
+  await connectDB(dbUri.replace('%STAGE%', stage));
+
+  console.log(`Checking DataLake (createdByUserId, fileTagPrefix) uniqueness on stage="${stage}"...`);
+
+  const dupes = await DataLakeModel.aggregate<{
+    _id: { createdByUserId: string; fileTagPrefix: string };
+    ids: string[];
+    n: number;
+  }>([
+    {
+      $group: {
+        _id: { createdByUserId: '$createdByUserId', fileTagPrefix: '$fileTagPrefix' },
+        ids: { $push: '$_id' },
+        n: { $sum: 1 },
+      },
+    },
+    { $match: { n: { $gt: 1 } } },
+    { $sort: { n: -1 } },
+  ]).then(groups => groups.filter(g => normalizeTagPrefix(g._id.fileTagPrefix) !== null));
+
+  const total = await DataLakeModel.estimatedDocumentCount();
+  console.log(`Scanned ~${total} data lakes.`);
+
+  if (dupes.length === 0) {
+    console.log('No duplicate (createdByUserId, fileTagPrefix) groups. Safe to deploy.');
+    process.exit(0);
+  }
+
+  console.error(`Found ${dupes.length} duplicate (createdByUserId, fileTagPrefix) group(s) - RESOLVE BEFORE DEPLOY:`);
+  for (const d of dupes) {
+    console.error(
+      `  creator=${d._id.createdByUserId} prefix=${d._id.fileTagPrefix} n=${d.n} ids=[${d.ids.join(', ')}]`
+    );
+  }
+  process.exit(1);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/scripts/migrate/check-datalake-prefix-dupes.ts
+++ b/packages/scripts/migrate/check-datalake-prefix-dupes.ts
@@ -1,5 +1,4 @@
 import { connectDB, DataLakeModel } from '@bike4mind/database';
-import { normalizeTagPrefix } from '@bike4mind/common';
 import { Resource } from 'sst';
 import { Config } from '../utils/config';
 
@@ -11,9 +10,11 @@ import { Config } from '../utils/config';
  * groups exist - so we must confirm zero duplicates first. Exits non-zero (and prints the
  * offending ids) if any are found, so it can gate a deploy.
  *
- * Excludes groups whose prefix normalizeTagPrefix rejects (no trailing colon, blank): those
- * values contribute no read-path arm today, so two lakes sharing one is inert junk, not a real
- * collision worth blocking a deploy over.
+ * Reports every raw duplicate, including a colon-less or blank prefix: the index has no
+ * `sparse`/partial filter, so it compares the stored string as-is regardless of whether
+ * normalizeTagPrefix would treat it as usable. This must predict the index build 1:1 - filtering
+ * by read-path usability (as check-datalake-prefix-overlaps.ts correctly does for ITS job) would
+ * report "safe to deploy" for rows the index build then rejects.
  *
  * Org-scope collisions are NOT checked here - there is no org-scope index (see the comment on
  * the index itself in DataLakeModel.ts for why) and existing org-scope overlaps, including exact
@@ -44,7 +45,7 @@ async function main() {
     },
     { $match: { n: { $gt: 1 } } },
     { $sort: { n: -1 } },
-  ]).then(groups => groups.filter(g => normalizeTagPrefix(g._id.fileTagPrefix) !== null));
+  ]);
 
   const total = await DataLakeModel.estimatedDocumentCount();
   console.log(`Scanned ~${total} data lakes.`);

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -19,6 +19,7 @@
     "migrate": "tsx migrate/index.ts",
     "datalake:check-slug-dupes": "tsx migrate/check-datalake-slug-dupes.ts",
     "datalake:check-prefix-overlaps": "tsx migrate/check-datalake-prefix-overlaps.ts",
+    "datalake:check-prefix-dupes": "tsx migrate/check-datalake-prefix-dupes.ts",
     "datalake:ingest-pdfs": "tsx datalake/ingest-pdf-datalake.ts",
     "db:create-user": "tsx createUser.ts",
     "db:list-users": "tsx listUsers.ts",


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1511" height="812" alt="qa-demo-screenshot" src="https://github.com/user-attachments/assets/c0a49dfa-4320-4522-a743-1312cf420bcf" />

*Real HTTP requests against a locally self-hosted apps/client (real route handlers, real MongoDB): a same-creator prefix collision gets rejected (400), and an admin can no longer strip a prefixed tag off a file the lake creator doesn't own (404), while removal of a file the creator does own still succeeds (200).*

## Description

`fileTagPrefix` has no DB-level uniqueness, so two lakes (same creator, or same org) can register colliding or nested prefixes. PR #1130 already closed the create-time nesting/collision gap app-level (read-then-write); this closes the concurrent-create race it leaves open: a real unique index backstops same-creator exact matches, with a pre-deploy check script to catch legacy collisions before the index build runs.

While auditing the removal path's ownership check for this ticket's authorization-parity ask, found the actual live bug: an admin could strip a prefixed tag off any file regardless of who owned it, wider than the read path's own membership rule. Fixed to match exactly.

Two of the issue's acceptance criteria don't apply as filed - see Additional Information.

Closes #1152

## Changes

- `packages/database`: add a unique `{createdByUserId, fileTagPrefix}` index as a create-time-race backstop (deliberately no org-scope companion index - see the comment on the index for why)
- `packages/scripts`: add `check-datalake-prefix-dupes.ts`, a pre-deploy check mirroring the existing slug-dupe precedent
- `b4m-core/services`: fix an admin bypass in prefix-tag removal so it matches the read path's ownership rule exactly
- Doc-comment corrections in `createDataLake.ts` and `dataLakeLifecycleScope.ts` now that a narrower uniqueness guarantee exists
- Tests for all of the above, including two existing fixtures that were passing for the wrong reason

## Guide for Testers

This ships as DB-layer and service-layer changes with no new UI surface. My own verification below used a local self-hosted server rather than a preview (nothing here needs one), but a preview is still up for QA sign-off per usual process: **https://app.pr1476.preview.bike4mind.com**.

1. Run `pnpm --filter @bike4mind/database test -- DataLakeModel.test.ts`. Expect all tests green, including the new "fileTagPrefix is unique per creator" suite: same-creator exact-match prefix rejected regardless of org; different creators in the same org allowed; different creators both org-less allowed; a nested (not exact-equal) prefix allowed.
2. Run `pnpm --filter @bike4mind/services test -- lakeMembership.test.ts dataLakeService.test.ts`. Expect all tests green, including the new cases: an admin removing a prefix-only file the lake creator does NOT own now gets a 404; the same admin removing one the creator DOES own still succeeds.
3. To reproduce the exact request/response pairs shown in the screenshot above, against the real route handlers and a real MongoDB: boot `apps/client` self-hosted (`B4M_SELF_HOST=true` plus a local `MONGODB_URI`, `JWT_SECRET`, `SESSION_SECRET`, `SECRET_ENCRYPTION_KEY`, `E2E_CLEANUP_SECRET` - see `next.config.mjs`'s self-host alias), flip the `EnableDataLakes` admin setting on in that database, then create two users via `POST /api/test/create-user` (one will own the lake, one will own an unrelated file) and an admin user:
   - `POST /api/data-lakes` as the first user with `{"name":"Invoices A","slug":"invoices-a","fileTagPrefix":"acme:"}` -> `201`.
   - The same request again, same user, `slug` changed but the same `fileTagPrefix` -> `400`, `"Tag prefix ... overlaps an existing data lake"`.
   - Tag a file owned by the SECOND user with `acme:invoices`, then `DELETE /api/data-lakes/<lakeId>/files/<fileId>` as the admin -> `404`, `"File not found in this data lake"` (this is the bug this PR fixes - before, an admin could clear that tag regardless of who owned the file).
   - Tag a file owned by the FIRST user (the lake's creator) the same way, repeat the DELETE as the admin -> `200` success (no regression: an admin can still remove a file the read path actually admitted to the lake).
4. **On the preview**, the same sequence can be run against the real deployed routes instead of localhost: log in as two different real users (or two browser profiles), grab each one's bearer token from browser localStorage (`access-token-storage`, written after login) via devtools, then repeat the four requests in step 3 against `https://app.pr1476.preview.bike4mind.com/api/...` with `Authorization: Bearer <token>`. Confirms the same 201/400/404/200 sequence holds in a real deployed environment, not just locally.
5. Ops-only, optional: against a real stage with existing data, `./for-env <env> pnpm sst shell --stage <stage> -- pnpm --filter scripts datalake:check-prefix-dupes` reports any `(createdByUserId, fileTagPrefix)` duplicate groups or confirms none exist.

**What NOT to test:** no UI changes. The Data Lake wizard's existing prefix-collision warning is unrelated prior work (PR #1130) and unaffected by this PR.

## Additional Information

Two acceptance criteria from the issue don't apply as filed: `fileTagPrefix` has no rename path today (verified across every route/service/UI surface), and closing the full meta-tag/prefix-tag authorization symmetry would let a lake creator freeze tag edits on unrelated users' files - the asymmetry is intentional. The real bug (a narrower admin bypass) is fixed instead.

## Developer Notes (Optional)

N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc


