### PR TITLE
test(e2e): authenticate specs via /auth/success after the refresh-cookie migration

### DIFF
--- a/apps/client/e2e/fixtures.ts
+++ b/apps/client/e2e/fixtures.ts
@@ -3,7 +3,7 @@ import { test as base, expect } from '@playwright/test';
 import { TIMEOUTS } from './constants';
 import { ConsoleTracker } from './helpers/console-tracker';
 import { LoginPage } from './pages/LoginPage';
-import { seedAuthOnPage } from './helpers/auth-seed';
+import { buildAuthSuccessUrl, type SpecAuth } from './helpers/auth-seed';
 import { NavigationPage } from './pages/NavigationPage';
 import { BasePage } from './pages/BasePage';
 import { SignupPage } from './pages/SignupPage';
@@ -45,18 +45,56 @@ type TestFixtures = {
   dataLakePage: DataLakePage;
   skillsPage: SkillsPage;
   loginAsAdmin: () => Promise<void>;
-  loginAsUser: (user: { accessToken: string; refreshToken: string }) => Promise<void>;
+  loginAsUser: (user: SpecAuth) => Promise<void>;
+  /** Mutable per-test identity the page.goto override authenticates as; loginAs* rewrites `current`
+   *  so a mid-test user switch takes effect on the next navigation. Null on unauthenticated projects. */
+  authState: { current: SpecAuth | null };
 
   verifyAnswers: (answers: string | string[], options?: VerifyAnswersOptions) => Promise<void>;
 };
 
+// playwright.config project names are kebab-case (data-lake); spec-user keys are camelCase (dataLake).
+function projectNameToSpecKey(projectName: string): string {
+  return projectName.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+/** Access token + userId for the spec user backing an authenticated project, or null for projects
+ *  that seed no user (unauthenticated, admin, setup) or before core data exists. */
+function specAuthForProject(projectName: string): SpecAuth | null {
+  try {
+    const u = getTestUsers().specUsers[projectNameToSpecKey(projectName)];
+    return u ? { accessToken: u.accessToken, userId: u.userId } : null;
+  } catch {
+    return null;
+  }
+}
+
 export const test = base.extend<TestFixtures>({
+  // eslint-disable-next-line no-empty-pattern -- no fixture deps; identity derives from the project.
+  authState: async ({}, use, testInfo) => {
+    await use({ current: specAuthForProject(testInfo.project.name) });
+  },
+
   // Suppress the What's New modal globally - return empty modals so it never renders.
   // This eliminates flaky backdrop-interception failures without relying on timing hacks.
-  page: async ({ page }, use) => {
+  page: async ({ page, authState }, use) => {
     await page.route('**/api/modals**', route =>
       route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
     );
+
+    // Authenticated projects: the access token is memory-only and dies on every full load, so a raw
+    // goto to a protected route cold-loads unauthenticated and the router guard bounces to /login.
+    // Route in-app navigations through /auth/success, which re-seeds the token via the client router
+    // without replaying the single-use refresh cookie (whose one shared token got the session
+    // revoked) or hitting the rate-limited OTC path. `authState.current` is read per call so a
+    // mid-test loginAs* switch is honored; unauthenticated projects (current === null) pass through.
+    const rawGoto = page.goto.bind(page);
+    page.goto = (url: string, options?: Parameters<typeof rawGoto>[1]) => {
+      const auth = authState.current;
+      const wrap = !!auth && url.startsWith('/') && !url.startsWith('/auth/success') && !url.startsWith('/login');
+      return rawGoto(wrap ? buildAuthSuccessUrl(url, auth) : url, options);
+    };
+
     await use(page);
   },
 
@@ -125,17 +163,19 @@ export const test = base.extend<TestFixtures>({
     await use(new SkillsPage(page));
   },
 
-  loginAsAdmin: async ({ page }, use) => {
+  loginAsAdmin: async ({ page, authState }, use) => {
     const login = async () => {
       const { admin } = getTestUsers();
-      await seedAuthOnPage(page, { accessToken: admin.accessToken, refreshToken: admin.refreshToken });
+      authState.current = { accessToken: admin.accessToken, userId: admin.userId };
+      await page.goto('/'); // wrapped goto re-seeds the token via /auth/success as the new identity
     };
     await use(login);
   },
 
-  loginAsUser: async ({ page }, use) => {
-    const login = async (user: { accessToken: string; refreshToken: string }) => {
-      await seedAuthOnPage(page, { accessToken: user.accessToken, refreshToken: user.refreshToken });
+  loginAsUser: async ({ page, authState }, use) => {
+    const login = async (user: SpecAuth) => {
+      authState.current = { accessToken: user.accessToken, userId: user.userId };
+      await page.goto('/'); // wrapped goto re-seeds the token via /auth/success as the new identity
     };
     await use(login);
   },

--- a/apps/client/e2e/fixtures.ts
+++ b/apps/client/e2e/fixtures.ts
@@ -58,11 +58,13 @@ function projectNameToSpecKey(projectName: string): string {
   return projectName.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
 }
 
-/** Access token + userId for the spec user backing an authenticated project, or null for projects
- *  that seed no user (unauthenticated, admin, setup) or before core data exists. */
+/** Access token + userId for the user backing an authenticated project, or null for projects that
+ *  seed no user (unauthenticated, setup) or before core data exists. The `admin` project runs off
+ *  the shared core admin rather than a per-spec user. */
 function specAuthForProject(projectName: string): SpecAuth | null {
   try {
-    const u = getTestUsers().specUsers[projectNameToSpecKey(projectName)];
+    const users = getTestUsers();
+    const u = projectName === 'admin' ? users.admin : users.specUsers[projectNameToSpecKey(projectName)];
     return u ? { accessToken: u.accessToken, userId: u.userId } : null;
   } catch {
     return null;

--- a/apps/client/e2e/fixtures.ts
+++ b/apps/client/e2e/fixtures.ts
@@ -74,7 +74,11 @@ function specAuthForProject(projectName: string): SpecAuth | null {
 export const test = base.extend<TestFixtures>({
   // eslint-disable-next-line no-empty-pattern -- no fixture deps; identity derives from the project.
   authState: async ({}, use, testInfo) => {
-    await use({ current: specAuthForProject(testInfo.project.name) });
+    // @realauth tests drive the app's real refresh-cookie bootstrap (e.g. the hard-reload guard),
+    // so they must NOT be wrapped through /auth/success - null passes their gotos through untouched
+    // and they authenticate from the pristine cookie the setup planted (see seedAuthStorageState).
+    const current = testInfo.tags.includes('@realauth') ? null : specAuthForProject(testInfo.project.name);
+    await use({ current });
   },
 
   // Suppress the What's New modal globally - return empty modals so it never renders.

--- a/apps/client/e2e/fixtures.ts
+++ b/apps/client/e2e/fixtures.ts
@@ -3,7 +3,7 @@ import { test as base, expect } from '@playwright/test';
 import { TIMEOUTS } from './constants';
 import { ConsoleTracker } from './helpers/console-tracker';
 import { LoginPage } from './pages/LoginPage';
-import { seedAuthOnPage } from './helpers/auth-seed';
+import { seedAuthOnPage, seedFreshRefreshCookie } from './helpers/auth-seed';
 import { NavigationPage } from './pages/NavigationPage';
 import { BasePage } from './pages/BasePage';
 import { SignupPage } from './pages/SignupPage';
@@ -50,13 +50,41 @@ type TestFixtures = {
   verifyAnswers: (answers: string | string[], options?: VerifyAnswersOptions) => Promise<void>;
 };
 
+// playwright.config project names are kebab-case (data-lake); spec-user keys are camelCase (dataLake).
+function projectNameToSpecKey(projectName: string): string {
+  return projectName.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+/**
+ * Email of the spec user backing an authenticated spec project, or null for projects that seed no
+ * user (unauthenticated, admin, setup). Returns null rather than throwing when core data is absent
+ * so non-spec contexts stay unaffected.
+ */
+function specUserEmailForProject(projectName: string): string | null {
+  try {
+    return getTestUsers().specUsers[projectNameToSpecKey(projectName)]?.email ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export const test = base.extend<TestFixtures>({
   // Suppress the What's New modal globally - return empty modals so it never renders.
   // This eliminates flaky backdrop-interception failures without relying on timing hacks.
-  page: async ({ page }, use) => {
+  page: async ({ page, request }, use, testInfo) => {
     await page.route('**/api/modals**', route =>
       route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
     );
+
+    // Authenticated spec projects seed auth by planting the app's single-use refresh cookie. One
+    // token shared across the project (via storageState) is replayed by every test + retry and
+    // gets the session revoked by reuse-detection, bouncing later tests to /login. Mint a fresh
+    // token per test so the cold-load bootstrap consumes it exactly once. See seedFreshRefreshCookie.
+    const email = specUserEmailForProject(testInfo.project.name);
+    if (email) {
+      await seedFreshRefreshCookie(page, request, email);
+    }
+
     await use(page);
   },
 

--- a/apps/client/e2e/fixtures.ts
+++ b/apps/client/e2e/fixtures.ts
@@ -3,7 +3,7 @@ import { test as base, expect } from '@playwright/test';
 import { TIMEOUTS } from './constants';
 import { ConsoleTracker } from './helpers/console-tracker';
 import { LoginPage } from './pages/LoginPage';
-import { seedAuthOnPage, seedFreshRefreshCookie } from './helpers/auth-seed';
+import { seedAuthOnPage } from './helpers/auth-seed';
 import { NavigationPage } from './pages/NavigationPage';
 import { BasePage } from './pages/BasePage';
 import { SignupPage } from './pages/SignupPage';
@@ -50,41 +50,13 @@ type TestFixtures = {
   verifyAnswers: (answers: string | string[], options?: VerifyAnswersOptions) => Promise<void>;
 };
 
-// playwright.config project names are kebab-case (data-lake); spec-user keys are camelCase (dataLake).
-function projectNameToSpecKey(projectName: string): string {
-  return projectName.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
-}
-
-/**
- * Email of the spec user backing an authenticated spec project, or null for projects that seed no
- * user (unauthenticated, admin, setup). Returns null rather than throwing when core data is absent
- * so non-spec contexts stay unaffected.
- */
-function specUserEmailForProject(projectName: string): string | null {
-  try {
-    return getTestUsers().specUsers[projectNameToSpecKey(projectName)]?.email ?? null;
-  } catch {
-    return null;
-  }
-}
-
 export const test = base.extend<TestFixtures>({
   // Suppress the What's New modal globally - return empty modals so it never renders.
   // This eliminates flaky backdrop-interception failures without relying on timing hacks.
-  page: async ({ page, request }, use, testInfo) => {
+  page: async ({ page }, use) => {
     await page.route('**/api/modals**', route =>
       route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
     );
-
-    // Authenticated spec projects seed auth by planting the app's single-use refresh cookie. One
-    // token shared across the project (via storageState) is replayed by every test + retry and
-    // gets the session revoked by reuse-detection, bouncing later tests to /login. Mint a fresh
-    // token per test so the cold-load bootstrap consumes it exactly once. See seedFreshRefreshCookie.
-    const email = specUserEmailForProject(testInfo.project.name);
-    if (email) {
-      await seedFreshRefreshCookie(page, request, email);
-    }
-
     await use(page);
   },
 

--- a/apps/client/e2e/helpers/auth-seed.ts
+++ b/apps/client/e2e/helpers/auth-seed.ts
@@ -45,13 +45,17 @@ async function injectRefreshCookie(page: Page, tokens: SeedTokens): Promise<void
 }
 
 /**
- * Seed auth (refresh cookie) and write a Playwright storageState file.
- * Boots to `/` (never /login) so the seeded session isn't torn down by the login route's
- * on-mount clearClientCaches().
+ * Seed auth by planting the refresh cookie and writing a Playwright storageState file.
+ *
+ * Deliberately does NOT navigate: booting the app here would make the cold-load bootstrap exchange
+ * (and rotate) the refresh token, leaving the saved cookie a spent generation. Every spec now
+ * authenticates via /auth/success (fixtures.ts) and ignores this cookie, EXCEPT @realauth tests
+ * (the hard-reload guard) which drive the app's real refresh-cookie bootstrap and need a PRISTINE,
+ * never-yet-exchanged cookie. Leaving it unspent costs the other specs nothing and keeps that one
+ * honest. storageState() serializes the context cookie jar with no navigation required.
  */
 export async function seedAuthStorageState(page: Page, tokens: SeedTokens, path: string): Promise<void> {
   await injectRefreshCookie(page, tokens);
-  await page.goto('/');
   await page.context().storageState({ path });
 }
 

--- a/apps/client/e2e/helpers/auth-seed.ts
+++ b/apps/client/e2e/helpers/auth-seed.ts
@@ -1,4 +1,5 @@
-import { type Page } from '@playwright/test';
+import { type Page, type APIRequestContext } from '@playwright/test';
+import { apiLoginViaOtc } from './api';
 
 /**
  * Cookie-seed auth helpers.
@@ -53,6 +54,29 @@ export async function seedAuthStorageState(page: Page, tokens: SeedTokens, path:
   await injectRefreshCookie(page, tokens);
   await page.goto('/');
   await page.context().storageState({ path });
+}
+
+/**
+ * Mint a FRESH single-use refresh cookie for `email` and plant it, WITHOUT navigating.
+ *
+ * The opaque refresh token is single-use: rotateSession's reuse-detection revokes the whole
+ * session the moment an already-rotated token is replayed (b4m-core/services/src/authSessionService/
+ * rotateSession.ts, 60s grace). A token baked once into a shared Playwright storageState is
+ * replayed by every test AND every retry that cold-loads from it; past the grace window the
+ * replay is treated as theft, the session is revoked, and every later cold load 401s -> /login.
+ * That is exactly the projects/agents/profile/tavern/search failure. Handing each test its OWN
+ * freshly-minted token means the app's bootstrap exchange (sessionBootstrap.ts) spends it exactly
+ * once, so reuse-detection never fires - which is what keeps the cookie-seed model compatible with
+ * single-use rotation.
+ *
+ * The caller must NOT have navigated yet: the test's own first `page.goto` performs the single
+ * cold-load exchange that consumes this token.
+ */
+export async function seedFreshRefreshCookie(page: Page, request: APIRequestContext, email: string): Promise<void> {
+  const tokens = await apiLoginViaOtc(request, email);
+  // Drop any stale cookie the per-project storageState planted, so only the fresh token is present.
+  await page.context().clearCookies({ name: REFRESH_COOKIE_NAME });
+  await injectRefreshCookie(page, tokens);
 }
 
 /**

--- a/apps/client/e2e/helpers/auth-seed.ts
+++ b/apps/client/e2e/helpers/auth-seed.ts
@@ -55,6 +55,36 @@ export async function seedAuthStorageState(page: Page, tokens: SeedTokens, path:
   await page.context().storageState({ path });
 }
 
+export interface SpecAuth {
+  accessToken: string;
+  userId: string;
+}
+
+/**
+ * Build an `/auth/success` URL that re-establishes the in-memory access token and then client-side
+ * redirects to `target`.
+ *
+ * The access token is memory-only (app/hooks/useAccessToken.ts) and does NOT survive a full page
+ * load, so a raw `page.goto('/projects')` cold-loads with no credential and the router guard bounces
+ * to /login. `/auth/success` is the app's own SSO landing route: it calls setVerifiedSession(token)
+ * and redirects THROUGH the client router (not a reload), so the token survives. Routing every
+ * authenticated navigation through it re-seeds the token on each full load - with no single-use
+ * refresh replay (a shared refresh cookie replayed across contexts gets the session revoked by
+ * rotateSession's reuse-detection) and no OTC (rate limited). An access token is not single-use, so
+ * one value works across every parallel context.
+ *
+ * Caveat: the access token has a 30m TTL (server/auth/tokenGenerator.ts) and is minted at spec
+ * setup, so a tail/retry test on a ~30-minute run can outlive it and bounce to /login. A purely
+ * test-side seed cannot mint a fresh token for the seeded user without OTC or a dedicated endpoint.
+ */
+export function buildAuthSuccessUrl(target: string, auth: SpecAuth): string {
+  const params = new URLSearchParams({ token: auth.accessToken, userId: auth.userId });
+  // sanitizeRedirectTo (app/utils/authRedirect.ts) requires a leading '/' and rejects bare '/', so
+  // omit redirectTo for '/' - /auth/success then falls back to the dashboard, which is '/' anyway.
+  if (target !== '/') params.set('redirectTo', target);
+  return `/auth/success?${params.toString()}`;
+}
+
 /**
  * Seed auth directly onto a page (mid-test user switching), then bootstrap the authenticated
  * app by navigating to `/`.

--- a/apps/client/e2e/helpers/auth-seed.ts
+++ b/apps/client/e2e/helpers/auth-seed.ts
@@ -1,5 +1,4 @@
-import { type Page, type APIRequestContext } from '@playwright/test';
-import { apiLoginViaOtc } from './api';
+import { type Page } from '@playwright/test';
 
 /**
  * Cookie-seed auth helpers.
@@ -54,29 +53,6 @@ export async function seedAuthStorageState(page: Page, tokens: SeedTokens, path:
   await injectRefreshCookie(page, tokens);
   await page.goto('/');
   await page.context().storageState({ path });
-}
-
-/**
- * Mint a FRESH single-use refresh cookie for `email` and plant it, WITHOUT navigating.
- *
- * The opaque refresh token is single-use: rotateSession's reuse-detection revokes the whole
- * session the moment an already-rotated token is replayed (b4m-core/services/src/authSessionService/
- * rotateSession.ts, 60s grace). A token baked once into a shared Playwright storageState is
- * replayed by every test AND every retry that cold-loads from it; past the grace window the
- * replay is treated as theft, the session is revoked, and every later cold load 401s -> /login.
- * That is exactly the projects/agents/profile/tavern/search failure. Handing each test its OWN
- * freshly-minted token means the app's bootstrap exchange (sessionBootstrap.ts) spends it exactly
- * once, so reuse-detection never fires - which is what keeps the cookie-seed model compatible with
- * single-use rotation.
- *
- * The caller must NOT have navigated yet: the test's own first `page.goto` performs the single
- * cold-load exchange that consumes this token.
- */
-export async function seedFreshRefreshCookie(page: Page, request: APIRequestContext, email: string): Promise<void> {
-  const tokens = await apiLoginViaOtc(request, email);
-  // Drop any stale cookie the per-project storageState planted, so only the fresh token is present.
-  await page.context().clearCookies({ name: REFRESH_COOKIE_NAME });
-  await injectRefreshCookie(page, tokens);
 }
 
 /**

--- a/apps/client/e2e/notebook.spec.ts
+++ b/apps/client/e2e/notebook.spec.ts
@@ -122,58 +122,60 @@ test.describe('Notebook CRUD', () => {
 test.describe('Notebook - Router resilience', () => {
   // Guards against TanStack Router / React Query regressions on deep-route reload
   // and browser history navigation - the surface most likely to break on router/query upgrades.
-  test('survives hard reload and history nav on a deep notebook route', async ({
-    page,
-    request,
-    basePage,
-    consoleTracker,
-  }) => {
-    const NOTEBOOK_NAME = `E2E Router ${Date.now().toString().slice(-6)}`;
-    const { specUsers } = getTestUsers();
-    const token = specUsers.notebook.accessToken;
+  // @realauth: exercises hard reload + history nav, which must hit the app's real refresh-cookie
+  // bootstrap - so this test opts out of the /auth/success seed (see fixtures.ts authState) and
+  // relies on the pristine cookie the setup planted (see seedAuthStorageState).
+  test(
+    'survives hard reload and history nav on a deep notebook route',
+    { tag: '@realauth' },
+    async ({ page, request, basePage, consoleTracker }) => {
+      const NOTEBOOK_NAME = `E2E Router ${Date.now().toString().slice(-6)}`;
+      const { specUsers } = getTestUsers();
+      const token = specUsers.notebook.accessToken;
 
-    const sessionId = await apiCreateSession(request, token);
-    await apiRenameSession(request, token, sessionId, NOTEBOOK_NAME);
+      const sessionId = await apiCreateSession(request, token);
+      await apiRenameSession(request, token, sessionId, NOTEBOOK_NAME);
 
-    try {
-      const deepUrl = `/notebooks/${sessionId}`;
-      const sidebarItem = page.getByTestId('sidenav-item-session-btn').filter({ hasText: NOTEBOOK_NAME });
+      try {
+        const deepUrl = `/notebooks/${sessionId}`;
+        const sidebarItem = page.getByTestId('sidenav-item-session-btn').filter({ hasText: NOTEBOOK_NAME });
 
-      await test.step('deep-link directly to the notebook', async () => {
-        await page.goto(deepUrl);
-        await page.waitForLoadState('domcontentloaded');
-        await basePage.dismissModals();
-        await expect(sidebarItem).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
-      });
-
-      await test.step('hard reload preserves route and rehydrates sidebar query', async () => {
-        consoleTracker.clear();
-        await page.reload({ waitUntil: 'domcontentloaded' });
-        await expect(page).toHaveURL(new RegExp(`/notebooks/${sessionId}`));
-        await expect(sidebarItem).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
-      });
-
-      await test.step('back/forward navigate between notebook and projects', async () => {
-        // Direct nav (projects is earned-nav; the sidenav row may be hidden). goto still
-        // pushes a history entry, so the goBack/goForward assertions below hold.
-        await page.goto('/projects');
-        await expect(page).toHaveURL(/\/projects/);
-
-        await page.goBack();
-        await expect(page).toHaveURL(new RegExp(`/notebooks/${sessionId}`));
-        await expect(sidebarItem).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
-
-        await page.goForward();
-        await expect(page).toHaveURL(/\/projects/);
-        await expect(page.getByTestId('new-project-btn')).toBeVisible({
-          timeout: TIMEOUTS.NAVIGATION,
+        await test.step('deep-link directly to the notebook', async () => {
+          await page.goto(deepUrl);
+          await page.waitForLoadState('domcontentloaded');
+          await basePage.dismissModals();
+          await expect(sidebarItem).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
         });
-      });
 
-      const errors = consoleTracker.getErrors();
-      expect(errors, `Unexpected console errors: ${JSON.stringify(errors, null, 2)}`).toHaveLength(0);
-    } finally {
-      await apiDeleteSession(request, token, sessionId).catch(() => {});
+        await test.step('hard reload preserves route and rehydrates sidebar query', async () => {
+          consoleTracker.clear();
+          await page.reload({ waitUntil: 'domcontentloaded' });
+          await expect(page).toHaveURL(new RegExp(`/notebooks/${sessionId}`));
+          await expect(sidebarItem).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+        });
+
+        await test.step('back/forward navigate between notebook and projects', async () => {
+          // Direct nav (projects is earned-nav; the sidenav row may be hidden). goto still
+          // pushes a history entry, so the goBack/goForward assertions below hold.
+          await page.goto('/projects');
+          await expect(page).toHaveURL(/\/projects/);
+
+          await page.goBack();
+          await expect(page).toHaveURL(new RegExp(`/notebooks/${sessionId}`));
+          await expect(sidebarItem).toBeVisible({ timeout: TIMEOUTS.NAVIGATION });
+
+          await page.goForward();
+          await expect(page).toHaveURL(/\/projects/);
+          await expect(page.getByTestId('new-project-btn')).toBeVisible({
+            timeout: TIMEOUTS.NAVIGATION,
+          });
+        });
+
+        const errors = consoleTracker.getErrors();
+        expect(errors, `Unexpected console errors: ${JSON.stringify(errors, null, 2)}`).toHaveLength(0);
+      } finally {
+        await apiDeleteSession(request, token, sessionId).catch(() => {});
+      }
     }
-  });
+  );
 });

--- a/apps/client/e2e/pages/AdminPage.ts
+++ b/apps/client/e2e/pages/AdminPage.ts
@@ -95,6 +95,9 @@ export class AdminPage extends BasePage {
     // Dropdown options can be detached by React re-renders. Retry: re-open the dropdown.
     for (let attempt = 1; attempt <= 3; attempt++) {
       try {
+        // The floating AI chat can re-open and overlay the sort controls, intercepting pointer
+        // events (same guard as toggleSortOrder). Re-close each attempt in case it reopened.
+        await this.closeFloatingChat();
         // Bound the click so a stuck dropdown-open (unbounded stability check) fails fast into
         // the retry rather than hanging; keeping it inside the try lets a throw retry too.
         await this.page.getByTestId('admin-sort-by-select').click({ timeout: TIMEOUTS.ELEMENT_STATE });


### PR DESCRIPTION
# Pull Request


## Description

The nightly `E2E Tests (Manual)` suite went red after the refresh token moved into an HttpOnly cookie (#1346). Every authenticated spec that cold-loads a protected route (projects, agents, profile, tavern, search, admin, ...) bounced to `/login`.

Root cause: the e2e auth seed plants the app's single-use refresh cookie into a per-project Playwright `storageState`, and the app's cold-load bootstrap exchanges it for an access token. But that refresh token is **single-use** - `rotateSession`'s reuse-detection revokes the whole session the moment an already-rotated token is replayed (60s grace). One token baked into a shared `storageState` is replayed by every test and every retry, so past the grace window the session is revoked and later cold loads 401 -> `/login?error=session_expired`. Minting a fresh token per test instead hits the OTC endpoint's rate limiter (`429`), so that path is a dead end too.

Fix: stop relying on the single-use refresh cookie for normal specs. Authenticate each navigation through `/auth/success?token=&userId=` - the app's own SSO landing route, which sets the in-memory access token and redirects **through the client router** (not a reload), so the memory-only token survives. Access tokens are not single-use, so one value works across every parallel context - no refresh replay, no OTC. This is test-harness only; **no application code changes**.

Result: `54/84 -> 84/84` on the manual suite.

## Changes

- **`e2e/helpers/auth-seed.ts`** - add `buildAuthSuccessUrl()`; `seedAuthStorageState` no longer boots during setup, so the planted refresh cookie stays **pristine** (only the `@realauth` reload test uses it).
- **`e2e/fixtures.ts`** - the `page` fixture overrides `page.goto` to route in-app navigations through `/auth/success`, keyed on a mutable `authState` so a mid-test `loginAs*` switch is honored; unauthenticated projects pass through untouched. Maps the `admin` project to the core admin user.
- **`e2e/notebook.spec.ts`** - tag the hard-reload/history-nav guard `@realauth`. It must exercise the app's real cold-load bootstrap (which `/auth/success` bypasses), so it opts out of the override and authenticates from the pristine cookie.
- **`e2e/pages/AdminPage.ts`** - `setSortBy` now closes the floating chat before opening the sort dropdown (same guard `toggleSortOrder` already had), fixing an unrelated pre-existing flake surfaced now that admin specs actually run.

## Guide for Testers

This PR touches **only the e2e test harness** - no product behavior changes. Verification is the E2E suite itself:

1. Add the `E2E` label to this PR (or trigger `E2E Tests (Manual)` against this branch) so the browser suite runs against `app.staging.bike4mind.com`.
2. Expected result: all authenticated suites green - Projects, Agents, Profile, Tavern, Search, Admin, Skills, Prompts, Data Lake, and the Notebook router-resilience test.

### What NOT to test
- No app/UI/API behavior changed - do not look for product differences. `/auth/success` is an existing route; this only changes how the test harness authenticates.

## Additional Information

- **Known independent flakes** (not caused by this PR, pass on retry): `image-generation` (AI render latency) and `auth.spec` "full OTC flow" (OTC endpoint `429` under parallel load).
- **`@realauth` limitation**: the reload guard shares one pristine cookie across attempts, so a retry replays a rotated generation - it must pass on the first attempt.
- **30-min access-token TTL**: tokens are minted at setup; a tail/retry test on a very long run could outlive its token. Not observed in practice; the durable fix would be an app-side test-mint endpoint or a longer e2e TTL.
- History note: commits `2f8fb3d7` (per-test OTC mint) + `666fd76b` (its revert) are an honest record of the rate-limited dead-end; squash on merge if a cleaner history is preferred.
- Process: auth-touching changes like #1346 should carry the `E2E` label so the browser suite runs pre-merge (this regression slipped through because that PR ran only unit/integration checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
