### PR TITLE
feat(admin): surface billing owner's implicit group-type access

### DIFF
--- a/apps/client/app/components/admin/OrganizationGroupMembersCard.test.tsx
+++ b/apps/client/app/components/admin/OrganizationGroupMembersCard.test.tsx
@@ -112,4 +112,31 @@ describe('OrganizationGroupMembersCard', () => {
     fireEvent.click(screen.getByText('Alice'));
     await waitFor(() => expect(assignGroupMember).toHaveBeenCalledWith('org1', 'g1', 'u1'));
   });
+
+  it('surfaces the billing owner as a non-removable implicit chip on a group they are granted', async () => {
+    fetchOrganizationGroups.mockResolvedValue([
+      { id: 'g1', name: 'Sales', type: 'sales', organizationId: 'org1', memberIds: [], memberCount: 0 },
+    ]);
+    renderCard({ ...org, allowedGroupTypes: ['sales'] } as typeof org);
+
+    const card = await screen.findByTestId('org-group-card-sales');
+    const ownerChip = await screen.findByTestId('org-group-owner-sales');
+    expect(ownerChip).toHaveTextContent('Olivia Owner');
+    expect(ownerChip).toHaveTextContent('implicit');
+    // Not removable: unlike an assigned-member chip, there is no ChipDelete/unassign control on it.
+    expect(ownerChip.querySelector('[data-testid^="org-group-unassign-"]')).not.toBeInTheDocument();
+    // "No members assigned" still shows too - the owner's access is implicit, not an explicit row.
+    expect(card).toHaveTextContent('No members assigned.');
+  });
+
+  it('does not surface the owner chip for a group type the org no longer has granted', async () => {
+    fetchOrganizationGroups.mockResolvedValue([
+      { id: 'g1', name: 'Sales', type: 'sales', organizationId: 'org1', memberIds: [], memberCount: 0 },
+    ]);
+    // allowedGroupTypes omits 'sales' - e.g. the type was revoked after the group was provisioned.
+    renderCard({ ...org, allowedGroupTypes: [] } as typeof org);
+
+    await screen.findByTestId('org-group-card-sales');
+    expect(screen.queryByTestId('org-group-owner-sales')).not.toBeInTheDocument();
+  });
 });

--- a/apps/client/app/components/admin/OrganizationsTab.tsx
+++ b/apps/client/app/components/admin/OrganizationsTab.tsx
@@ -677,7 +677,7 @@ const OrganizationsTab: React.FC = () => {
       {/* Organization Profile Modal */}
       {selectedOrg && (
         <Modal open={!!selectedOrg} onClose={() => setSelectedOrg(null)}>
-          <ModalDialog size="lg">
+          <ModalDialog size="lg" sx={{ maxHeight: '80vh', overflow: 'auto' }}>
             <ModalClose />
             <OrganizationProfileUpdated
               org={selectedOrg}

--- a/apps/client/app/components/organizations/OrganizationGroupsList.tsx
+++ b/apps/client/app/components/organizations/OrganizationGroupsList.tsx
@@ -15,7 +15,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import EditIcon from '@mui/icons-material/Edit';
 import CheckIcon from '@mui/icons-material/Check';
 import GroupWorkOutlinedIcon from '@mui/icons-material/GroupWorkOutlined';
-import { getGroupType, IOrganizationDocument, IUserDocument, WithId } from '@bike4mind/common';
+import { getGroupType, IOrganizationDocument, isKnownGroupType, IUserDocument, WithId } from '@bike4mind/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useGetOrganizationUsers } from '@client/app/hooks/data/user';
@@ -114,6 +114,12 @@ export const OrganizationGroupsList: FC<OrganizationGroupsListProps> = ({
     onError: error => toast.error(getErrorMessage(error)),
   });
 
+  // The billing owner implicitly holds every granted group type without a users[] row (#1226), so
+  // they never appear in group.memberIds - surface that here rather than let 0 assigned members
+  // read as "owner has no access" (#1445).
+  const owner = membersById.get(organization.userId);
+  const allowedGroupTypes = organization.allowedGroupTypes ?? [];
+
   const groups = groupsQuery.data ?? [];
 
   // Render nothing for a personal org rather than the permanent "Loading groups..." a disabled
@@ -150,6 +156,7 @@ export const OrganizationGroupsList: FC<OrganizationGroupsListProps> = ({
             group={group}
             membersById={membersById}
             members={assignableMembers}
+            owner={isKnownGroupType(group.type) && allowedGroupTypes.includes(group.type) ? owner : undefined}
             onRename={name => renameMutation.mutate({ groupId: group.id, name })}
             onAssign={userId => assignMutation.mutate({ groupId: group.id, userId })}
             onUnassign={userId => unassignMutation.mutate({ groupId: group.id, userId })}
@@ -166,11 +173,13 @@ const GroupCard: FC<{
   group: GroupWithMembers;
   membersById: Map<string, IUserDocument>;
   members: IUserDocument[];
+  /** The org's billing owner, when they implicitly hold this group's type (#1445). Undefined otherwise. */
+  owner: IUserDocument | undefined;
   onRename: (name: string) => void;
   onAssign: (userId: string) => void;
   onUnassign: (userId: string) => void;
   isMutating: boolean;
-}> = ({ group, membersById, members, onRename, onAssign, onUnassign, isMutating }) => {
+}> = ({ group, membersById, members, owner, onRename, onAssign, onUnassign, isMutating }) => {
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(group.name);
 
@@ -266,6 +275,13 @@ const GroupCard: FC<{
         </Stack>
 
         <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          {owner && (
+            // Not removable - owner access comes from billing ownership, not a users[] row, so
+            // there is nothing here for ChipDelete to unassign.
+            <Chip size="sm" variant="soft" color="neutral" data-testid={`org-group-owner-${group.type}`}>
+              {owner.name || owner.email || 'Owner'} - Owner (implicit)
+            </Chip>
+          )}
           {group.memberIds.length === 0 ? (
             <Typography level="body-sm" color="neutral">
               No members assigned.


### PR DESCRIPTION
## Description

The Admin -> Organizations panel lets a platform admin grant an org group types and assign members to them. The org's billing owner implicitly holds every granted group type without ever being added as a member row (the assign endpoint validates against `users[]` alone, so the assign picker correctly excludes them). Nothing in the panel indicated this, though: an admin viewing a group with 0 assigned members could reasonably conclude the owner had no access, when they actually held every granted type.

This adds a read-only, non-removable "Owner (implicit)" chip to each group card so the owner's implicit access is visible alongside any explicitly assigned members.

Closes #1445.

## Changes

- `OrganizationGroupsList`: each group card now shows an "Owner (implicit)" chip for the org's billing owner, gated on the group's type being both a known catalog type and currently in the org's `allowedGroupTypes` (mirrors the server-side capability resolution, so the chip disappears if a type is later revoked).
- Added test coverage: the chip renders and is non-removable when the owner holds the type, and is absent when the type isn't granted.
- `OrganizationsTab`: fixed the Organization Profile modal so it scrolls as one region (`ModalDialog` gets `maxHeight: '80vh', overflow: 'auto'`, matching the sibling Members Modal in the same file). The modal previously had no height cap, so on an org with several granted group types the Groups card - what this PR's chip lives on - was unreachable and this PR's own change couldn't be tested. Bundled here rather than filed separately since it was a prerequisite for verifying this PR, not an unrelated drive-by.

## Guide for Testers

1. Sign in as a platform admin and navigate to Sidebar -> Admin -> Organizations.
2. Select an organization that has at least one group type granted (or grant one via the Group Types card).
3. In the Groups card below, locate a group card for a granted type.
4. Confirm a chip reading "<owner name> - Owner (implicit)" appears among the member chips, and that it has no remove/delete control (unlike assigned-member chips).

   <img width="364" height="268" alt="image" src="https://github.com/user-attachments/assets/7f5cd4ae-d8c8-4d7e-8176-e0c26ad40c61" />

5. Confirm the group's assign-member picker still does not offer the owner as an option.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
