### PR TITLE
fix(files): stop bulk-delete reporting permission denials as success

### DIFF
--- a/apps/client/app/hooks/data/fabFiles.test.tsx
+++ b/apps/client/app/hooks/data/fabFiles.test.tsx
@@ -3,8 +3,20 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import type { IFabFileDocument } from '@bike4mind/common';
-import { useDeleteAllFiles, useGetFabFilesBySessionId, useGetFabFilesByQuestId, useUpdateFabFile } from './fabFiles';
+import {
+  useBulkDeleteFiles,
+  useDeleteAllFiles,
+  useGetFabFilesBySessionId,
+  useGetFabFilesByQuestId,
+  useUpdateFabFile,
+} from './fabFiles';
 import useSessionLayout, { setPendingMessageFiles } from '@client/app/hooks/useSessionLayout';
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: { success: (...args: unknown[]) => toastSuccess(...args), error: (...args: unknown[]) => toastError(...args) },
+}));
 
 // Mock the axios-backed api context - we only care that the GET/DELETE is (or isn't) fired.
 const apiGet = vi.fn();
@@ -144,6 +156,46 @@ describe('useDeleteAllFiles', () => {
 
     const keys = invalidate.mock.calls.map(call => JSON.stringify((call[0] as { queryKey: unknown[] })?.queryKey));
     expect(keys).toContain(JSON.stringify(['file-tags']));
+  });
+});
+
+describe('useBulkDeleteFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a success toast when the batch actually removed something', async () => {
+    apiDelete.mockResolvedValue({
+      data: { message: 'Deleted 1 file(s)', results: { deleted: ['f1'], unshared: [], notFound: [], failed: [] } },
+    });
+
+    const { result } = renderHook(() => useBulkDeleteFiles(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync(['f1']);
+    });
+
+    expect(toastSuccess).toHaveBeenCalledWith('Deleted 1 file(s)');
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  // Regression: a batch where every id was notFound (including the access-denied ids that server
+  // folds into notFound to avoid leaking their existence) used to render as a green success toast
+  // even though nothing was removed.
+  it('shows an error toast, not success, when nothing was actually removed', async () => {
+    apiDelete.mockResolvedValue({
+      data: {
+        message: '1 file(s) not found',
+        results: { deleted: [], unshared: [], notFound: ['f1'], failed: [] },
+      },
+    });
+
+    const { result } = renderHook(() => useBulkDeleteFiles(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync(['f1']);
+    });
+
+    expect(toastError).toHaveBeenCalledWith('1 file(s) not found');
+    expect(toastSuccess).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/client/app/hooks/data/fabFiles.test.tsx
+++ b/apps/client/app/hooks/data/fabFiles.test.tsx
@@ -14,8 +14,13 @@ import useSessionLayout, { setPendingMessageFiles } from '@client/app/hooks/useS
 
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
+const toastWarning = vi.fn();
 vi.mock('sonner', () => ({
-  toast: { success: (...args: unknown[]) => toastSuccess(...args), error: (...args: unknown[]) => toastError(...args) },
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+    warning: (...args: unknown[]) => toastWarning(...args),
+  },
 }));
 
 // Mock the axios-backed api context - we only care that the GET/DELETE is (or isn't) fired.
@@ -196,6 +201,31 @@ describe('useBulkDeleteFiles', () => {
 
     expect(toastError).toHaveBeenCalledWith('1 file(s) not found');
     expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  // Regression: a batch that deleted some files but also failed on others used to render a plain
+  // green success toast, masking a mostly-failed destructive operation.
+  it('shows a warning toast, not success, when some deletes failed alongside real deletions', async () => {
+    apiDelete.mockResolvedValue({
+      data: {
+        message: 'Deleted 1 file(s), Failed to process 9 file(s)',
+        results: {
+          deleted: ['f1'],
+          unshared: [],
+          notFound: [],
+          failed: Array.from({ length: 9 }, (_, i) => ({ id: `f${i + 2}`, error: 'boom' })),
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useBulkDeleteFiles(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync(['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10']);
+    });
+
+    expect(toastWarning).toHaveBeenCalledWith('Deleted 1 file(s), Failed to process 9 file(s)');
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -85,6 +85,7 @@ interface BulkDeleteResponse {
   results: {
     deleted: string[];
     unshared: string[];
+    notFound: string[];
     /** @deprecated Use deleted/unshared instead */
     success?: string[];
     failed: {
@@ -105,7 +106,13 @@ export function useBulkDeleteFiles(options?: { onSuccess?: () => void; onError?:
       queryClient.invalidateQueries({ queryKey: ['fabFiles'], exact: false });
       // Invalidate the tag query to refresh the number of files with that tag
       queryClient.invalidateQueries({ queryKey: ['file-tags'] });
-      toast.success(data.message);
+      // A batch that only hit notFound/failed removed nothing - don't show a green toast for it.
+      const removedSomething = data.results.deleted.length > 0 || data.results.unshared.length > 0;
+      if (removedSomething) {
+        toast.success(data.message);
+      } else {
+        toast.error(data.message);
+      }
       options?.onSuccess?.();
     },
     onError: error => {

--- a/apps/client/app/hooks/data/fabFiles.ts
+++ b/apps/client/app/hooks/data/fabFiles.ts
@@ -106,12 +106,16 @@ export function useBulkDeleteFiles(options?: { onSuccess?: () => void; onError?:
       queryClient.invalidateQueries({ queryKey: ['fabFiles'], exact: false });
       // Invalidate the tag query to refresh the number of files with that tag
       queryClient.invalidateQueries({ queryKey: ['file-tags'] });
-      // A batch that only hit notFound/failed removed nothing - don't show a green toast for it.
+      // A batch that only hit notFound/failed removed nothing - don't show a green toast for it,
+      // and a batch that removed some files but also had errors isn't a clean success either.
       const removedSomething = data.results.deleted.length > 0 || data.results.unshared.length > 0;
-      if (removedSomething) {
-        toast.success(data.message);
-      } else {
+      const hasFailures = data.results.failed.length > 0;
+      if (!removedSomething) {
         toast.error(data.message);
+      } else if (hasFailures) {
+        toast.warning(data.message);
+      } else {
+        toast.success(data.message);
       }
       options?.onSuccess?.();
     },

--- a/apps/client/pages/api/files/[id]/__tests__/index.delete.test.ts
+++ b/apps/client/pages/api/files/[id]/__tests__/index.delete.test.ts
@@ -266,3 +266,26 @@ describe('DELETE /api/files/[id] - tag activity', () => {
     expect(h.touchLastActivityBy).toHaveBeenCalledWith({ name: 'invoices', userId: OWNER });
   });
 });
+
+// Regression: deleteFabFile's 'denied' action (file exists, caller has no access) must never
+// reach the client as-is - that would let this route be used to probe for other users' file ids,
+// the same no-enumeration convention bulk-delete.ts follows.
+describe('DELETE /api/files/[id] - denied normalization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.userFindById.mockResolvedValue({ id: OWNER });
+    h.findAllWithKnowledgeId.mockResolvedValue([]);
+  });
+
+  it('reports a denied outcome as action "not_found", not "denied"', async () => {
+    // Exists, but the caller is neither owner nor in the share list.
+    const inaccessible = fabFile({ userId: 'someone-else', users: [] });
+    h.findById.mockResolvedValue(inaccessible);
+    h.findByIdAndUserId.mockResolvedValue(null);
+    const { res, json } = makeRes();
+
+    await run(res);
+
+    expect(json.mock.calls[0][0]).toMatchObject({ action: 'not_found' });
+  });
+});

--- a/apps/client/pages/api/files/[id]/index.ts
+++ b/apps/client/pages/api/files/[id]/index.ts
@@ -230,7 +230,12 @@ const handler = baseApi()
       );
     }
 
-    return res.json({ msg: 'Fab file deleted', action: deleteAction });
+    // 'denied' collapses to 'not_found' here too: the response must not let a caller distinguish
+    // "doesn't exist" from "exists but you can't access it" (see bulk-delete.ts for the same rule).
+    return res.json({
+      msg: 'Fab file deleted',
+      action: deleteAction === 'denied' ? 'not_found' : deleteAction,
+    });
   });
 
 export const config = {

--- a/apps/client/pages/api/files/[id]/index.ts
+++ b/apps/client/pages/api/files/[id]/index.ts
@@ -164,9 +164,7 @@ const handler = baseApi()
 
     let sizeToDeduct = 0;
 
-    let deleteAction: string = 'not_found';
-
-    await withTransaction(async session => {
+    const deleteAction = await withTransaction(async session => {
       const result = await fabFilesService.deleteFabFile(
         userId,
         { id: fabFileId },
@@ -184,8 +182,6 @@ const handler = baseApi()
         }
       );
 
-      deleteAction = result.action;
-
       if (result.action === 'deleted') {
         await logEvent(
           { userId, type: FileEvents.DELETE_FILE, metadata: { fileId: fabFileId } },
@@ -201,6 +197,8 @@ const handler = baseApi()
           { ability: req.ability, session }
         );
       }
+
+      return result.action;
     });
 
     // Deduct storage size after successful deletion
@@ -230,11 +228,9 @@ const handler = baseApi()
       );
     }
 
-    // 'denied' collapses to 'not_found' here too: the response must not let a caller distinguish
-    // "doesn't exist" from "exists but you can't access it" (see bulk-delete.ts for the same rule).
     return res.json({
       msg: 'Fab file deleted',
-      action: deleteAction === 'denied' ? 'not_found' : deleteAction,
+      action: fabFilesService.toPublicDeleteAction(deleteAction),
     });
   });
 

--- a/apps/client/pages/api/files/__tests__/bulk-delete.test.ts
+++ b/apps/client/pages/api/files/__tests__/bulk-delete.test.ts
@@ -187,6 +187,42 @@ describe('bulk-delete - not-found reporting', () => {
     expect(body.results).not.toHaveProperty('denied');
     expect(body.message).toBe('1 file(s) not found');
   });
+
+  it('composes the message correctly when a batch deletes, not-founds, and fails all at once', async () => {
+    const DELETED_ID = '507f1f77bcf86cd799439021';
+    const MISSING_ID = '507f1f77bcf86cd799439022';
+    const FAILING_ID = '507f1f77bcf86cd799439023';
+
+    const deletedFile = { id: DELETED_ID, userId: OWNER, fileName: 'a.txt', tags: [], users: [] };
+    const failingFile = {
+      id: FAILING_ID,
+      userId: OWNER,
+      fileName: 'b.txt',
+      tags: [],
+      users: [],
+      filePath: 'uploads/b.txt',
+    };
+
+    h.findByIdAndUserId.mockImplementation(async (id: string) =>
+      id === DELETED_ID ? deletedFile : id === FAILING_ID ? failingFile : null
+    );
+    h.findById.mockImplementation(async (id: string) =>
+      id === DELETED_ID ? deletedFile : id === FAILING_ID ? failingFile : null
+    );
+    h.storageDelete.mockImplementation(async (path: string) => {
+      if (path === 'uploads/b.txt') throw new Error('S3 unavailable');
+    });
+
+    const { res, json } = makeRes();
+
+    await run([DELETED_ID, MISSING_ID, FAILING_ID], res);
+
+    const body = json.mock.calls[0][0];
+    expect(body.results.deleted).toEqual([DELETED_ID]);
+    expect(body.results.notFound).toEqual([MISSING_ID]);
+    expect(body.results.failed).toEqual([{ id: FAILING_ID, error: 'S3 unavailable' }]);
+    expect(body.message).toBe('Deleted 1 file(s), 1 file(s) not found, Failed to process 1 file(s)');
+  });
 });
 
 // Deleting files changes which files carry a tag, so each one is marked as recently used. The

--- a/apps/client/pages/api/files/__tests__/bulk-delete.test.ts
+++ b/apps/client/pages/api/files/__tests__/bulk-delete.test.ts
@@ -152,7 +152,7 @@ describe('bulk-delete - data-lake stats', () => {
   });
 });
 
-describe('bulk-delete - not-found and denied reporting', () => {
+describe('bulk-delete - not-found reporting', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.userFindById.mockResolvedValue({ id: OWNER });
@@ -168,12 +168,13 @@ describe('bulk-delete - not-found and denied reporting', () => {
 
     const body = json.mock.calls[0][0];
     expect(body.results.notFound).toEqual(['507f1f77bcf86cd799439011']);
-    expect(body.results.denied).toEqual([]);
     expect(body.message).toBe('1 file(s) not found');
   });
 
-  it('reports a file the actor has no access to under denied, distinct from notFound', async () => {
-    // Exists, but the actor is neither owner nor in the share list.
+  it('reports a file the actor has no access to under the same notFound bucket, not a distinct "denied" one', async () => {
+    // Exists, but the actor is neither owner nor in the share list. The response must not let a
+    // caller distinguish this from genuine absence - that would let bulk-delete be used to probe
+    // for other users' file ids (see fabFileService/get.ts et al for the same no-enumeration rule).
     const inaccessible = { ...memberFile('507f1f77bcf86cd799439011', 'someone-else'), users: [] };
     h.findById.mockResolvedValue(inaccessible);
     h.findByIdAndUserId.mockResolvedValue(null);
@@ -182,9 +183,9 @@ describe('bulk-delete - not-found and denied reporting', () => {
     await run(['507f1f77bcf86cd799439011'], res);
 
     const body = json.mock.calls[0][0];
-    expect(body.results.denied).toEqual(['507f1f77bcf86cd799439011']);
-    expect(body.results.notFound).toEqual([]);
-    expect(body.message).toBe('Access denied for 1 file(s)');
+    expect(body.results.notFound).toEqual(['507f1f77bcf86cd799439011']);
+    expect(body.results).not.toHaveProperty('denied');
+    expect(body.message).toBe('1 file(s) not found');
   });
 });
 

--- a/apps/client/pages/api/files/__tests__/bulk-delete.test.ts
+++ b/apps/client/pages/api/files/__tests__/bulk-delete.test.ts
@@ -152,6 +152,42 @@ describe('bulk-delete - data-lake stats', () => {
   });
 });
 
+describe('bulk-delete - not-found and denied reporting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.userFindById.mockResolvedValue({ id: OWNER });
+    h.findAllWithKnowledgeId.mockResolvedValue([]);
+  });
+
+  it('reports a genuinely missing file under notFound, not silently', async () => {
+    h.findById.mockResolvedValue(null);
+    h.findByIdAndUserId.mockResolvedValue(null);
+    const { res, json } = makeRes();
+
+    await run(['507f1f77bcf86cd799439011'], res);
+
+    const body = json.mock.calls[0][0];
+    expect(body.results.notFound).toEqual(['507f1f77bcf86cd799439011']);
+    expect(body.results.denied).toEqual([]);
+    expect(body.message).toBe('1 file(s) not found');
+  });
+
+  it('reports a file the actor has no access to under denied, distinct from notFound', async () => {
+    // Exists, but the actor is neither owner nor in the share list.
+    const inaccessible = { ...memberFile('507f1f77bcf86cd799439011', 'someone-else'), users: [] };
+    h.findById.mockResolvedValue(inaccessible);
+    h.findByIdAndUserId.mockResolvedValue(null);
+    const { res, json } = makeRes();
+
+    await run(['507f1f77bcf86cd799439011'], res);
+
+    const body = json.mock.calls[0][0];
+    expect(body.results.denied).toEqual(['507f1f77bcf86cd799439011']);
+    expect(body.results.notFound).toEqual([]);
+    expect(body.message).toBe('Access denied for 1 file(s)');
+  });
+});
+
 // Deleting files changes which files carry a tag, so each one is marked as recently used. The
 // ownership check is the route's own decision - deleting a file shared WITH you is an unshare, which
 // changes nothing about your tags - and the same decision is made independently in files/[id].

--- a/apps/client/pages/api/files/bulk-delete.ts
+++ b/apps/client/pages/api/files/bulk-delete.ts
@@ -39,7 +39,6 @@ const handler = baseApi()
       deleted: [] as string[],
       unshared: [] as string[],
       notFound: [] as string[],
-      denied: [] as string[],
       failed: [] as { id: string; error: string }[],
     };
 
@@ -108,11 +107,11 @@ const handler = baseApi()
               { ability: req.ability, session }
             );
             results.unshared.push(fileId);
-          } else if (result.action === 'denied') {
-            // File exists but the actor is neither owner nor sharee - a denial, not a no-op.
-            results.denied.push(fileId);
           } else {
-            // 'not_found': file genuinely absent, or already soft-deleted by an earlier run.
+            // 'not_found' and 'denied' surface identically to the caller - deleteFabFile already
+            // logs the denied case server-side, but the response must not let a caller distinguish
+            // "doesn't exist" from "exists but you can't access it" (same no-enumeration convention
+            // as fabFileService/get.ts, edit.ts, addFavorite.ts et al).
             results.notFound.push(fileId);
           }
         });
@@ -152,7 +151,6 @@ const handler = baseApi()
     const parts: string[] = [];
     if (results.deleted.length > 0) parts.push(`Deleted ${results.deleted.length} file(s)`);
     if (results.unshared.length > 0) parts.push(`Removed ${results.unshared.length} shared file(s) from your library`);
-    if (results.denied.length > 0) parts.push(`Access denied for ${results.denied.length} file(s)`);
     if (results.notFound.length > 0) parts.push(`${results.notFound.length} file(s) not found`);
     if (results.failed.length > 0) parts.push(`Failed to process ${results.failed.length} file(s)`);
     const message = parts.join(', ') || `0 of ${fileIds.length} file(s) resolved`;

--- a/apps/client/pages/api/files/bulk-delete.ts
+++ b/apps/client/pages/api/files/bulk-delete.ts
@@ -38,6 +38,8 @@ const handler = baseApi()
     const results = {
       deleted: [] as string[],
       unshared: [] as string[],
+      notFound: [] as string[],
+      denied: [] as string[],
       failed: [] as { id: string; error: string }[],
     };
 
@@ -106,8 +108,13 @@ const handler = baseApi()
               { ability: req.ability, session }
             );
             results.unshared.push(fileId);
+          } else if (result.action === 'denied') {
+            // File exists but the actor is neither owner nor sharee - a denial, not a no-op.
+            results.denied.push(fileId);
+          } else {
+            // 'not_found': file genuinely absent, or already soft-deleted by an earlier run.
+            results.notFound.push(fileId);
           }
-          // 'not_found' is silently ignored (idempotent)
         });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -145,8 +152,10 @@ const handler = baseApi()
     const parts: string[] = [];
     if (results.deleted.length > 0) parts.push(`Deleted ${results.deleted.length} file(s)`);
     if (results.unshared.length > 0) parts.push(`Removed ${results.unshared.length} shared file(s) from your library`);
+    if (results.denied.length > 0) parts.push(`Access denied for ${results.denied.length} file(s)`);
+    if (results.notFound.length > 0) parts.push(`${results.notFound.length} file(s) not found`);
     if (results.failed.length > 0) parts.push(`Failed to process ${results.failed.length} file(s)`);
-    const message = parts.join(', ') || 'No files processed';
+    const message = parts.join(', ') || `0 of ${fileIds.length} file(s) resolved`;
 
     return res.json({
       message,

--- a/apps/client/pages/api/files/bulk-delete.ts
+++ b/apps/client/pages/api/files/bulk-delete.ts
@@ -107,11 +107,7 @@ const handler = baseApi()
               { ability: req.ability, session }
             );
             results.unshared.push(fileId);
-          } else {
-            // 'not_found' and 'denied' surface identically to the caller - deleteFabFile already
-            // logs the denied case server-side, but the response must not let a caller distinguish
-            // "doesn't exist" from "exists but you can't access it" (same no-enumeration convention
-            // as fabFileService/get.ts, edit.ts, addFavorite.ts et al).
+          } else if (fabFilesService.toPublicDeleteAction(result.action) === 'not_found') {
             results.notFound.push(fileId);
           }
         });
@@ -153,7 +149,9 @@ const handler = baseApi()
     if (results.unshared.length > 0) parts.push(`Removed ${results.unshared.length} shared file(s) from your library`);
     if (results.notFound.length > 0) parts.push(`${results.notFound.length} file(s) not found`);
     if (results.failed.length > 0) parts.push(`Failed to process ${results.failed.length} file(s)`);
-    const message = parts.join(', ') || `0 of ${fileIds.length} file(s) resolved`;
+    // Every id lands in exactly one bucket above and the schema requires at least one id, so
+    // `parts` is never empty.
+    const message = parts.join(', ');
 
     return res.json({
       message,

--- a/b4m-core/services/src/fabFileService/delete.test.ts
+++ b/b4m-core/services/src/fabFileService/delete.test.ts
@@ -198,7 +198,7 @@ describe('deleteFabFile', () => {
       expect(mockAdapter.storage.delete).not.toHaveBeenCalled();
     });
 
-    it('should return action "not_found" when file exists but user is not in share list', async () => {
+    it('should return action "denied" when file exists but user is not in share list', async () => {
       const fileNotSharedToUser: Partial<IFabFileDocument> = {
         ...createMockSharedFile(),
         users: [{ userId: 'other-user', permissions: ['read'] }],
@@ -208,7 +208,7 @@ describe('deleteFabFile', () => {
 
       const result = await deleteFabFile(mockUserId, { id: mockFileId }, mockAdapter);
 
-      expect(result.action).toBe('not_found');
+      expect(result.action).toBe('denied');
       expect(result.fabFile).toBeNull();
       expect(mockAdapter.db.fabFiles.update).not.toHaveBeenCalled();
     });

--- a/b4m-core/services/src/fabFileService/delete.ts
+++ b/b4m-core/services/src/fabFileService/delete.ts
@@ -15,7 +15,7 @@ const deleteFabFileSchema = z.object({
 
 type DeleteFabFileParameters = z.infer<typeof deleteFabFileSchema>;
 
-export type DeleteFabFileAction = 'deleted' | 'unshared' | 'not_found';
+export type DeleteFabFileAction = 'deleted' | 'unshared' | 'not_found' | 'denied';
 
 export interface DeleteFabFileResult {
   action: DeleteFabFileAction;
@@ -101,11 +101,12 @@ export const deleteFabFile = async (
 
   const userShareIndex = sharedFile.users?.findIndex(u => u.userId.toString() === userId);
   if (userShareIndex === undefined || userShareIndex === -1) {
-    // File exists but user has no direct share - may be group-shared or data-lake
+    // File exists but user has no direct share - may be group-shared or data-lake. Distinct from
+    // genuine absence: callers must not report this identically to a no-op (see bulk-delete.ts).
     Logger.globalInstance.warn(
       `[deleteFabFile] File exists but user is not in share list — fileId: ${id}, userId: ${userId}. Cannot unshare.`
     );
-    return { action: 'not_found', fabFile: null };
+    return { action: 'denied', fabFile: null };
   }
 
   // 3. Remove the user from the share list (self-unshare)

--- a/b4m-core/services/src/fabFileService/delete.ts
+++ b/b4m-core/services/src/fabFileService/delete.ts
@@ -22,6 +22,18 @@ export interface DeleteFabFileResult {
   fabFile: IFabFileDocument | null;
 }
 
+export type PublicDeleteFabFileAction = Exclude<DeleteFabFileAction, 'denied'>;
+
+/**
+ * Maps deleteFabFile's action to what's safe to expose to a caller. Collapses 'denied' into
+ * 'not_found' so a response can never be used to tell "doesn't exist" apart from "exists but you
+ * can't access it" - the same no-enumeration convention as get.ts, edit.ts, addFavorite.ts, et al.
+ * Every consumer that returns deleteFabFile's action to a client must go through this, rather than
+ * re-deriving the fold inline, so a future action value can't slip through unmapped.
+ */
+export const toPublicDeleteAction = (action: DeleteFabFileAction): PublicDeleteFabFileAction =>
+  action === 'denied' ? 'not_found' : action;
+
 export interface DeleteFabFileAdapter {
   db: {
     fabFiles: Pick<


### PR DESCRIPTION
## Description

Fixes #1463. `DELETE /api/files/bulk-delete` could return `deleted: []`, `unshared: []`, `failed: []` and the message `"No files processed"` while every id in the request was rejected - including ids rejected for lack of permission. The caller had no way to tell "there was nothing to delete" from "you were not allowed to delete any of these." The route silently discarded the `not_found` outcome from `deleteFabFile`, and `deleteFabFile` itself returned that same `not_found` value for two structurally different cases: the file genuinely doesn't exist (or was already soft-deleted by an earlier run), and the file exists but the caller is neither its owner nor in its share list (an authz denial, previously logged only at `warn` server-side and then thrown away).

A first pass split those two cases into distinct `not_found`/`denied` values and surfaced both to the client. That regressed a convention every other function in `fabFileService` relies on: `get.ts`, `edit.ts`, `applyEdit.ts`, `addFavorite.ts`, and `deleteFavorite.ts` all deliberately blur "doesn't exist" and "exists but you can't access it" into one message, specifically so a caller can't use the endpoint to enumerate other users' file ids. `deleteFabFile` followed that same pattern before this change. This PR keeps the distinction internal (still logged server-side) and folds both into a single `notFound` bucket before it reaches the client - fixing the original silent-success bug without reopening an existence-disclosure hole.

## Changes

- `b4m-core/services/src/fabFileService/delete.ts`: `deleteFabFile` now returns a `denied` action (added to `DeleteFabFileAction`) for the "exists but caller has no access" case, distinct from `not_found` for genuine absence. This distinction is internal/server-side only - see below.
- `apps/client/pages/api/files/bulk-delete.ts`: added a `notFound` bucket to the response `results`, alongside `deleted`/`unshared`/`failed`. Both `not_found` and `denied` outcomes land in this one bucket, so the response can't be used to tell the two apart. The summary message now reports it (e.g. `"2 file(s) not found"`) instead of falling through to the misleading `"No files processed"`.
- `apps/client/pages/api/files/[id]/index.ts` (single-file delete): the same `deleteFabFile` call can now return `denied`; the response normalizes it back to `not_found` for the same no-enumeration reason before sending it to the client. Internal gating (storage recompute) is unaffected since it only ever checked for `'deleted'`.
- `apps/client/app/hooks/data/fabFiles.ts`: `BulkDeleteResponse['results']` gained `notFound`. `useBulkDeleteFiles` now only shows a success toast when the batch actually deleted or unshared something; a batch that only hit `notFound`/`failed` now shows an error toast instead of a misleading green success one.

## Guide for Testers

1. As user A, upload a file and note its id.
2. As user B (not the owner, not shared on it), call `DELETE /api/files/bulk-delete` with `{"fileIds": ["<that id>"]}`.
3. Response is `200` with `results: { deleted: [], unshared: [], notFound: ["<that id>"], failed: [] }` and `message: "1 file(s) not found"` - no longer `"No files processed"`, and the id is not reported under any access-denied-specific field.

   <img width="751" height="470" alt="image" src="https://github.com/user-attachments/assets/ec8d31ec-f7e5-41e2-a7ed-c4ab7e4f92a2" />

4. Server logs still contain `[deleteFabFile] File exists but user is not in share list` at `warn`, so the denial is diagnosable from the backend even though the client response stays ambiguous.

   <img width="1255" height="77" alt="image" src="https://github.com/user-attachments/assets/d537b4d7-16fa-408b-ab12-23721476afd0" />

5. In the Files browser UI, select only files you don't have access to (or that were already deleted) and bulk-delete them - the resulting toast is red/error, not green/success.
6. Re-run a bulk delete over ids already deleted by an earlier run - same `notFound` shape, confirming the benign idempotent case is reported identically to the denied case (by design).

### What NOT to test

Whether the response text distinguishes "access denied" from "doesn't exist" - it deliberately does not, to avoid leaking file existence across users. This is a design tradeoff, not a gap.

## Additional Information

Verified: `pnpm turbo:core:build` (rebuilt `@bike4mind/services`, which `apps/client` consumes via `dist`), `tsc --noEmit` clean for `@bike4mind/services` and `client` (pre-existing, unrelated Slack/data-lake typecheck errors present on `main` too), `eslint` clean on all touched files, and targeted vitest suites green: `fabFileService/delete.test.ts`, `researchData/remove.test.ts`, `pages/api/files/__tests__/bulk-delete.test.ts`, `pages/api/files/[id]/__tests__/index.delete.test.ts`, and `app/hooks/data/fabFiles.test.tsx` (new tests added for the not-found/denied merge and the toast behavior).

Not the same as #1232 (closed) - that was a `TypeError` from `.session()` being called on a Promise in `DELETE /api/files`. This is a different route and a different failure mode: that one threw, this one succeeded quietly.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
