### PR TITLE
test(e2e): authenticate AI-latency suites via /auth/success and harden result writes

### DIFF
--- a/apps/client/e2e/ai-latency-intermediate-tools.setup.ts
+++ b/apps/client/e2e/ai-latency-intermediate-tools.setup.ts
@@ -1,3 +1,5 @@
 import { setupSpecUser } from './helpers/spec-setup';
 
-setupSpecUser({ key: 'ai-latency-intermediate-tools', authFile: 'ai-latency-intermediate-tools-user.json' });
+// key is camelCase so it matches projectNameToSpecKey('ai-latency-intermediate-tools') in fixtures.ts;
+// authFile keeps its kebab storageState path (referenced verbatim in playwright.config.ts).
+setupSpecUser({ key: 'aiLatencyIntermediateTools', authFile: 'ai-latency-intermediate-tools-user.json' });

--- a/apps/client/e2e/ai-latency-long-answers.setup.ts
+++ b/apps/client/e2e/ai-latency-long-answers.setup.ts
@@ -1,3 +1,5 @@
 import { setupSpecUser } from './helpers/spec-setup';
 
-setupSpecUser({ key: 'ai-latency-long-answers', authFile: 'ai-latency-long-answers-user.json' });
+// key is camelCase so it matches projectNameToSpecKey('ai-latency-long-answers') in fixtures.ts;
+// authFile keeps its kebab storageState path (referenced verbatim in playwright.config.ts).
+setupSpecUser({ key: 'aiLatencyLongAnswers', authFile: 'ai-latency-long-answers-user.json' });

--- a/apps/client/e2e/ai-latency-short-answers.setup.ts
+++ b/apps/client/e2e/ai-latency-short-answers.setup.ts
@@ -1,3 +1,5 @@
 import { setupSpecUser } from './helpers/spec-setup';
 
-setupSpecUser({ key: 'ai-latency-short-answers', authFile: 'ai-latency-short-answers-user.json' });
+// key is camelCase so it matches projectNameToSpecKey('ai-latency-short-answers') in fixtures.ts;
+// authFile keeps its kebab storageState path (referenced verbatim in playwright.config.ts).
+setupSpecUser({ key: 'aiLatencyShortAnswers', authFile: 'ai-latency-short-answers-user.json' });

--- a/apps/client/e2e/ai-latency-suite-factory.ts
+++ b/apps/client/e2e/ai-latency-suite-factory.ts
@@ -42,6 +42,51 @@ export function createAiLatencySuite({
   // afterAll summary. Stays 'unknown' only if no prompt ran (e.g. all skipped).
   let resolvedModel = 'unknown';
 
+  // Deterministic path relative to this spec folder, not process.cwd() - in CI Playwright can run
+  // with a repo-root CWD, which would write outside apps/client/ and miss the artifact upload.
+  const resultsDir = path.resolve(__dirname, 'test-results', 'ai-latency');
+  const resultsPath = path.join(resultsDir, resultsFilename);
+
+  // Fold newly collected results into whatever is already on disk, then rewrite the summary. Called
+  // after every prompt (not only in afterAll) so a finished prompt's numbers are durable the instant
+  // it completes: a LATER prompt that times out makes Playwright recycle the worker, which resets
+  // this module's in-memory state - an afterAll that knew only in-memory results would then clobber
+  // the file with a partial (or empty) set (the observed `results: []`). Reading the file back and
+  // merging by id keeps each write monotonic. Safe without locking because the AI-latency suites run
+  // serially (PW_WORKERS=1 in e2e-ai-latency.yml), so there is never a concurrent writer.
+  function persistResults(model: string, newResults: PromptResult[]) {
+    fs.mkdirSync(resultsDir, { recursive: true });
+
+    let priorResults: PromptResult[] = [];
+    let priorModel = 'unknown';
+    try {
+      const prior = JSON.parse(fs.readFileSync(resultsPath, 'utf-8'));
+      if (Array.isArray(prior.results)) priorResults = prior.results;
+      if (typeof prior.model === 'string') priorModel = prior.model;
+    } catch {
+      // First prompt (no file yet) or an unreadable/partial file - start from an empty set.
+    }
+
+    // Dedupe by id, last write wins so a retry's result supersedes the original.
+    const results = [...new Map([...priorResults, ...newResults].map(r => [r.id, r])).values()];
+
+    const averageResponseTimeSec =
+      results.length > 0
+        ? Math.round((results.reduce((sum, r) => sum + r.responseTimeSec, 0) / results.length) * 1000) / 1000
+        : 0;
+
+    // Never downgrade an already-resolved model back to 'unknown' (a recycled worker starts fresh).
+    const output = {
+      model: model !== 'unknown' ? model : priorModel,
+      timestamp: new Date().toISOString(),
+      thresholdSec,
+      averageResponseTimeSec,
+      results,
+    };
+
+    fs.writeFileSync(resultsPath, JSON.stringify(output, null, 2));
+  }
+
   function prompt(index: number) {
     const scenario = selectedPrompts[index];
 
@@ -76,14 +121,17 @@ export function createAiLatencySuite({
         )
         .toBeTruthy();
 
-      collectedResults.push({
+      const result: PromptResult = {
         id: scenario.id,
         prompt: scenario.prompt,
         response: responseText,
         responseTimeMs,
         responseTimeSec: Math.round(responseTimeSec * 1000) / 1000,
         responseRateCharsPerSec,
-      });
+      };
+      collectedResults.push(result);
+      // Persist immediately so this prompt's numbers survive a later prompt's timeout/worker recycle.
+      persistResults(resolvedModel, [result]);
     });
   }
 
@@ -97,27 +145,9 @@ export function createAiLatencySuite({
     });
 
     test.afterAll(() => {
-      // Deduplicate by id - retried tests push a second entry; keep the last (retry result wins).
-      const results = [...new Map(collectedResults.map(r => [r.id, r])).values()];
-
-      const averageResponseTimeSec =
-        results.length > 0
-          ? Math.round((results.reduce((sum, r) => sum + r.responseTimeSec, 0) / results.length) * 1000) / 1000
-          : 0;
-
-      const output = {
-        model: resolvedModel,
-        timestamp: new Date().toISOString(),
-        thresholdSec,
-        averageResponseTimeSec,
-        results,
-      };
-
-      // Deterministic path relative to this spec folder, not process.cwd() - in CI Playwright can run
-      // with a repo-root CWD, which would write outside apps/client/ and miss the artifact upload.
-      const resultsDir = path.resolve(__dirname, 'test-results', 'ai-latency');
-      fs.mkdirSync(resultsDir, { recursive: true });
-      fs.writeFileSync(path.join(resultsDir, resultsFilename), JSON.stringify(output, null, 2));
+      // Final summary rewrite, folding this worker's in-memory results into whatever is on disk.
+      // Per-prompt persistence already survives worker recycling; this is the belt-and-suspenders pass.
+      persistResults(resolvedModel, collectedResults);
     });
 
     for (let i = 0; i < 3; i++) {

--- a/apps/client/e2e/ai-latency-tool-prompts.setup.ts
+++ b/apps/client/e2e/ai-latency-tool-prompts.setup.ts
@@ -1,3 +1,5 @@
 import { setupSpecUser } from './helpers/spec-setup';
 
-setupSpecUser({ key: 'ai-latency-tool-prompts', authFile: 'ai-latency-tool-prompts-user.json' });
+// key is camelCase so it matches projectNameToSpecKey('ai-latency-tool-prompts') in fixtures.ts;
+// authFile keeps its kebab storageState path (referenced verbatim in playwright.config.ts).
+setupSpecUser({ key: 'aiLatencyToolPrompts', authFile: 'ai-latency-tool-prompts-user.json' });

--- a/apps/client/e2e/helpers/test-users.ts
+++ b/apps/client/e2e/helpers/test-users.ts
@@ -44,6 +44,14 @@ const SPEC_KEYS = [
   'search',
   'dataLake',
   'skills',
+  // AI-latency suites (only seeded when AI_LATENCY_RUN=true; getTestUsers skips absent files).
+  // Listed here so getTestUsers loads their spec users, which lets specAuthForProject resolve
+  // real auth and route their navigations through /auth/success like every other authed suite -
+  // otherwise they fall back to cold-loading the single-use refresh cookie and get revoked.
+  'aiLatencyShortAnswers',
+  'aiLatencyLongAnswers',
+  'aiLatencyToolPrompts',
+  'aiLatencyIntermediateTools',
 ];
 
 /**


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="696" height="480" alt="Screenshot 2026-08-06 at 5 46 02 PM" src="https://github.com/user-attachments/assets/0b6c60b0-2e34-4f6c-b0be-bc90aabc937e" />
<img width="645" height="694" alt="Screenshot 2026-08-06 at 5 46 18 PM" src="https://github.com/user-attachments/assets/b301e332-6b56-4e6e-b26d-98b8b4a7fd2a" />
<img width="650" height="374" alt="Screenshot 2026-08-06 at 5 46 30 PM" src="https://github.com/user-attachments/assets/e87e95a1-c300-46ac-b6ee-3ce71ce5ae00" />


## Description

The `E2E AI Latency Tests` workflow went red across every suite: each "Run 3 simple prompts" run passed the first two prompts, then the next prompt failed on its very first action -- `navigateToNewChat()` timing out waiting for `sidenav-nav-new-chat` -- through all retries. The failure screenshot shows the app sitting on `/login`: the session was unauthenticated by then, so the sidenav never rendered.

Root cause: the AI-latency suites were the **only authenticated specs never wired into the `/auth/success` auth harness** (added after the refresh-cookie migration). Their setup `key`s were kebab-case (`ai-latency-short-answers`) while every other spec uses camelCase (`dataLake`, `notebookFiles`, `imageGen`), and they were absent from `SPEC_KEYS`. So:

- `getTestUsers()` never loaded their spec users ->
- `specAuthForProject()` returned `null` ->
- `authState.current` stayed `null` ->
- the `page.goto` override **skipped** `/auth/success` for these suites ->
- they fell back to cold-loading the app's **single-use refresh cookie**, which `rotateSession`'s reuse-detection revokes once the same token is replayed past the grace window (across parallel contexts / retries) -> later navigations 401 -> `/login` -> sidenav never renders.

Separately, the results file could come back empty (`{"model":"unknown","results":[]}`) even when earlier prompts passed: results lived only in the worker's in-memory array, and a later prompt's timeout recycles the Playwright worker, whose `afterAll` then overwrote the file with a partial/empty set.

Harness-only; **no application or product behavior changes**.

## Changes

- **`e2e/helpers/test-users.ts`** -- add the four `aiLatency*` keys to `SPEC_KEYS` so `getTestUsers()` loads their spec users (each read is `fs.existsSync`-guarded, so absent files on non-latency runs are skipped).
- **`e2e/ai-latency-{short-answers,long-answers,tool-prompts,intermediate-tools}.setup.ts`** -- align each setup `key` to camelCase so it matches `projectNameToSpecKey()`. `authFile` storageState paths are unchanged (still referenced verbatim in `playwright.config.ts`).
- **`e2e/ai-latency-suite-factory.ts`** -- persist each prompt's result to disk as it completes and merge-on-write (dedupe by id, last write wins, never downgrade a resolved model back to `unknown`), so a later prompt's timeout / worker recycle can no longer clobber the results file.

Net effect: the AI-latency suites now authenticate via `/auth/success` with a memory access token exactly like Projects / Agents / Profile / etc. -- no single-use refresh replay, no session revocation. Prompts pass on the first attempt, so total runtime drops well under the 30-minute access-token TTL, and the single serial worker (`PW_WORKERS=1`, already set in the workflow) accumulates all three results.

## Guide for Testers

This PR touches **only the e2e test harness**. Verification is the E2E suites themselves.

1. Trigger the **E2E AI Latency Tests** workflow against this branch (Actions -> "E2E AI Latency Tests" -> Run workflow -> branch `fix/e2e-ai-latency-auth-success`). Expected: all AI-latency suites green; each suite's uploaded `*-results.json` artifact contains a real `model` and 3 `results` entries (not `{"model":"unknown","results":[]}`).
2. Run **E2E Tests (Manual)** against this branch (or add the `E2E` label). Expected: all authenticated suites stay green -- Projects, Agents, Profile, Tavern, Search, Admin, Skills, Prompts, Data Lake, Notebook.

### Regression Checks
- Every existing authenticated suite continues to authenticate via `/auth/success` unchanged (`specAuthForProject` behavior for those projects is untouched).
- The `@realauth` notebook reload guard still authenticates from its pristine refresh cookie.

### What NOT to test
- No app / UI / API behavior changed -- do not look for product differences. The AI-latency projects are gated behind `AI_LATENCY_RUN=true` and do not exist in Manual/Core runs.

## Additional Information

- Verified locally by the author: E2E Manual, E2E Core, and E2E AI Latency all pass on this branch.
- Process note: auth-touching harness changes should carry the `E2E` label so the browser suite runs pre-merge (this workflow is `workflow_dispatch` and does not run automatically on push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
