### PR TITLE
test: assert parallelism by overlap, not wall clock

### DIFF
--- a/packages/cli/src/utils/toolParallelizer.test.ts
+++ b/packages/cli/src/utils/toolParallelizer.test.ts
@@ -417,12 +417,19 @@ describe('toolParallelizer', () => {
     });
   });
 
-  describe('integration: timing verification', () => {
-    it('should complete parallel execution faster than sequential', async () => {
-      const TOOL_DELAY = 50; // ms per tool
-
+  describe('integration: concurrency verification', () => {
+    it('should start every read-only tool before any of them completes', async () => {
+      // Keyed by call index, not tool name: all three tools below are `file_read`,
+      // so the executor cannot tell them apart from its arguments.
+      const executionOrder: string[] = [];
+      let callIndex = 0;
       const executor = vi.fn(async () => {
-        await new Promise(r => setTimeout(r, TOOL_DELAY));
+        const id = callIndex++;
+        executionOrder.push(`start:${id}`);
+        // A real async gap, so serialized execution would be observable as interleaved
+        // start/end pairs. The delay carries no assertion weight.
+        await new Promise(r => setTimeout(r, 10));
+        executionOrder.push(`end:${id}`);
         return 'result';
       });
 
@@ -434,28 +441,23 @@ describe('toolParallelizer', () => {
 
       const plan = categorizeTools(tools);
 
-      // Measure a sequential baseline and the parallel run back-to-back under
-      // the same CPU conditions, then assert the relationship rather than a
-      // fixed wall-clock threshold. An absolute bound (e.g. < 2 * TOOL_DELAY)
-      // is fragile under CI contention - a starved event loop fires the delay
-      // timers late, so the parallel run can drift past the bound (observed:
-      // 102ms vs a 100ms cap). Comparing two measurements taken together is
-      // robust to that variance because both inflate proportionally.
-      const sequentialStart = Date.now();
-      for (let i = 0; i < tools.length; i++) {
-        await executor();
-      }
-      const sequentialDuration = Date.now() - sequentialStart;
-
-      const parallelStart = Date.now();
       await executeToolsInParallel(plan, executor);
-      const parallelDuration = Date.now() - parallelStart;
 
-      // Parallel overlaps the per-tool delays (~TOOL_DELAY total) while
-      // sequential sums them (~tools.length * TOOL_DELAY), so parallel must be
-      // meaningfully faster - half the sequential time leaves wide margin while
-      // still catching a regression that silently serializes execution.
-      expect(parallelDuration).toBeLessThan(sequentialDuration / 2);
+      // Concurrency means every tool starts before any of them finishes; sequential
+      // execution interleaves start/end pairs instead. Asserted on executionOrder (as the
+      // sibling tests above do) rather than on elapsed time. A sequential-vs-parallel
+      // duration ratio is still a wall-clock proxy: a GC pause or scheduler stall landing
+      // between the two measurements skews the ratio without touching real concurrency,
+      // and an absolute bound is worse (observed 102ms against a 100ms cap under CI
+      // contention). Ordering has no such sensitivity.
+      const firstEndIndex = executionOrder.findIndex(entry => entry.startsWith('end:'));
+      // Guard the -1 miss explicitly: slice(0, -1) would silently mean "all but the last
+      // entry" and the count below would then fail for the wrong reason.
+      expect(firstEndIndex).toBeGreaterThan(-1);
+      const startsBeforeFirstEnd = executionOrder.slice(0, firstEndIndex).filter(e => e.startsWith('start:'));
+      expect(startsBeforeFirstEnd).toHaveLength(tools.length);
+
+      expect(executor).toHaveBeenCalledTimes(tools.length);
     });
   });
 });

--- a/packages/database/src/__tests__/facet-compatibility.test.ts
+++ b/packages/database/src/__tests__/facet-compatibility.test.ts
@@ -205,34 +205,55 @@ describe('🎭 DocumentDB $facet Compatibility - Comprehensive Testing', () => {
     });
   });
 
-  describe('⚡ Performance and Parallel Execution', () => {
-    it('should execute facet stages in parallel for DocumentDB mode', async () => {
+  describe('⚡ Parallel Execution', () => {
+    it('should start every facet stage before any of them completes in DocumentDB mode', async () => {
       process.env.USE_DOCUMENTDB_COMPATIBILITY = 'true';
 
       const mockModel = {
         aggregate: vi.fn(),
       } as any;
 
-      // Add delays to simulate real database calls
-      const startTime = Date.now();
-      mockModel.aggregate.mockImplementation(
-        () => new Promise(resolve => setTimeout(() => resolve([{ count: 10 }]), 50))
-      );
+      // Keyed by call index, not by facet name: all three stages below are the identical
+      // [{ $count: 'count' }], so the mock cannot tell them apart from its arguments.
+      const executionLog: string[] = [];
+      let callIndex = 0;
+      mockModel.aggregate.mockImplementation(() => {
+        const id = callIndex++;
+        executionLog.push(`start:${id}`);
+        // A real async gap, so serialized execution would be observable as interleaved
+        // start/end pairs. The delay carries no assertion weight.
+        return new Promise(resolve =>
+          setTimeout(() => {
+            executionLog.push(`end:${id}`);
+            resolve([{ count: 10 }]);
+          }, 10)
+        );
+      });
 
       const facetStages = {
         count1: [{ $count: 'count' }],
         count2: [{ $count: 'count' }],
         count3: [{ $count: 'count' }],
       };
+      const expectedStageCount = Object.keys(facetStages).length;
 
       await executeFacetCompatible(mockModel, [], facetStages);
-      const duration = Date.now() - startTime;
 
-      // Parallel execution should take ~50ms, not ~150ms (3 * 50ms)
-      expect(duration).toBeLessThan(100); // Allow some overhead
-      expect(mockModel.aggregate).toHaveBeenCalledTimes(3);
+      // Concurrency means every stage starts before any of them finishes; sequential
+      // execution interleaves start/end pairs instead. Asserted on executionLog order
+      // (as b4m-core/agents/src/ReActAgent.parallel.test.ts and
+      // b4m-core/agents/src/toolParallelizer.test.ts do) rather than elapsed time: a
+      // wall-clock threshold has to separate ~50ms from ~150ms, which CI contention
+      // routinely erases, and it cannot distinguish real concurrency from queries that
+      // merely ran fast.
+      const firstEndIndex = executionLog.findIndex(entry => entry.startsWith('end:'));
+      // Guard the -1 miss explicitly: slice(0, -1) would silently mean "all but the last
+      // entry" and the count below would then fail for the wrong reason.
+      expect(firstEndIndex).toBeGreaterThan(-1);
+      const startsBeforeFirstEnd = executionLog.slice(0, firstEndIndex).filter(e => e.startsWith('start:'));
+      expect(startsBeforeFirstEnd).toHaveLength(expectedStageCount);
 
-      console.log(`⚡ Parallel execution: ${duration}ms for 3 queries (target: <100ms)`);
+      expect(mockModel.aggregate).toHaveBeenCalledTimes(expectedStageCount);
     });
   });
 


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

No UI to show. For a concurrency test the meaningful evidence is not that it passes - CI
already shows that, and a concurrency test that cannot fail is its own bug (#1001). It is that
the assertion still **catches a regression**. So the capture below runs the test four times:
green as shipped, then with `Promise.all` in `executeFacetCompatible` deliberately replaced by
a sequential `for` loop, then green again after the revert.

<img width="3592" height="1344" alt="image" src="https://github.com/user-attachments/assets/fdffe223-b1c8-48f5-979f-3e9568e769f5" />



Reading the capture:

| Step | What it shows |
|------|---------------|
| 1. GREEN | The test as it ships - 13/13. |
| 2. MUTATE | `Promise.all` -> sequential `for` loop, then a `db-core` rebuild. The rebuild is required: `packages/database` resolves `@bike4mind/db-core` through its built `dist/`, so a source-only edit would leave the mutation invisible and the test would look unkillable. |
| 3. RED | The new assertion catches the serialization - `AssertionError: expected [ 'start:0' ] to have a length of 3 but got 1` at `facet-compatibility.test.ts:254`. 1 failed / 12 passed. |
| 4. REVERT | `documentdb-compat.ts` restored and re-verified byte-identical by sha; working tree clean. |
| 5. GREEN | Back to 13/13. |

The key detail is in step 3: the failure is the **ordering** assertion, not a timeout. The test
detects serialization purely from start/end ordering, with no dependence on how long anything
took. Under the old wall-clock assertion the same mutation would only have been caught by
150ms exceeding a 100ms budget - exactly the comparison CI contention erases.

The same mutation proof was run for the sibling fix in `packages/cli`: serializing the
parallel batch in `executeToolsInParallel` fails the new assertion with
`expected [ 'start:0' ] to have a length of 3 but got 1` at `toolParallelizer.test.ts:458`,
and reverting returns it to 27/27.

Whole-package runs for completeness (both shards this lands in):

```
@bike4mind/database   Test Files  121 passed (121)    Tests  1511 passed | 1 skipped (1512)
@bike4mind/cli        Test Files  131 passed | 1 skipped (132)    Tests  2077 passed | 4 skipped (2081)
```

## Description

Closes #1139.

`packages/database/src/__tests__/facet-compatibility.test.ts` proved that
`executeFacetCompatible` runs its facet stages concurrently by timing the call: three mocked
`aggregate` calls slept 50ms each, and the test asserted `duration < 100ms` on the theory that
serialized execution would take ~150ms. Two problems with that:

- **The margin is smaller than the noise.** The investigation in #1017 measured
  parallel-under-contention at 234ms where sequential-unloaded measures ~154ms. The two
  populations overlap on a loaded runner, so no threshold both stops the test flaking and
  still fails a serialized implementation. Loosening the bound would make the test vacuous
  rather than fix it.
- **`startTime` was sampled before the mock was installed**, so `mockImplementation` setup
  cost landed inside the measured window.

This is the same defect class as #1011 / #1082, and the receipts are on those threads: #1011
records two unrelated PRs (#979, #977) losing a full CI round-trip to it on the same day, both
client-side changes that never touched `b4m-core/agents`; #1082 records it failing on `main`
and again on an untouched-package PR; and #1017 records the `merge_group` variant ejecting
PR #764 - approved, clean, unrelated - from the merge queue 14 minutes after it was queued.
This one had not surfaced yet only because `packages/database` runs in a different shard from
`b4m-core/agents`.

The fix asserts the actual property instead of a proxy for it: the mock records
`start:<n>` / `end:<n>` per call, and the test asserts every stage starts before any stage
completes. Serialized execution interleaves start/end pairs and can never produce that
ordering, so the assertion has no timing sensitivity at all - `executeFacetCompatible` issues
all three `aggregate` calls synchronously inside `Object.entries().map()` before its first
await, so the three `start:` entries land in the same tick no matter how loaded the runner is.

This matches what `main` already does in `b4m-core/agents/src/ReActAgent.parallel.test.ts` and
`b4m-core/agents/src/toolParallelizer.test.ts` after #1017.

## Changes

- Replace the wall-clock assertion in the DocumentDB facet parallel-execution test with an
  overlap assertion on an `executionLog`: `expect(startsBeforeFirstEnd).toHaveLength(...)`
  instead of `expect(duration).toBeLessThan(100)`.
- Key the log entries by call index rather than facet name. The three facet stages in this
  test are the identical `[{ $count: 'count' }]`, so the mock cannot tell them apart from its
  arguments.
- Guard the `findIndex` miss explicitly (`expect(firstEndIndex).toBeGreaterThan(-1)`). A `-1`
  would make `slice(0, -1)` silently mean "all but the last entry", and the count assertion
  would then fail for the wrong reason - a trap called out in #1017.
- Derive the expected stage count from `Object.keys(facetStages).length` instead of hardcoding
  `3` in two places, so adding a stage cannot fail the test with a count mismatch that hides
  the concurrency property being checked.
- Drop `startTime` / `duration` and the `${duration}ms` console.log. A printed duration is
  what invites the next reader to reintroduce a threshold.
- Rename the test to *should start every facet stage before any of them completes in
  DocumentDB mode* and its describe block from `Performance and Parallel Execution` to
  `Parallel Execution`, for the same reason. Nothing in the repo references either old name.
- Keep `expect(mockModel.aggregate).toHaveBeenCalledTimes(...)` - orthogonal to the timing
  problem and still useful.
- Shorten the mock's `setTimeout` from 50ms to 10ms. It is no longer load-bearing; it only
  needs to be a real async gap so serialized execution would be observable as interleaved
  start/end pairs.

And the sibling instance found in review (`packages/cli/src/utils/toolParallelizer.test.ts`):

- Replace `expect(parallelDuration).toBeLessThan(sequentialDuration / 2)` with the same overlap
  assertion. That test measured a sequential baseline and a parallel run back-to-back and
  compared them. The ratio is more robust than the absolute bound it replaced (its comment
  records an observed 102ms against a 100ms cap), but it is still a wall-clock proxy: a GC
  pause or scheduler stall landing between the two measurements skews the ratio without
  touching real concurrency.
- Drop the now-unused sequential baseline loop, so the executor is invoked only by the code
  under test.
- Rename the test to *should start every read-only tool before any of them completes* and its
  describe block from `integration: timing verification` to `integration: concurrency
  verification`. Nothing in the repo references either old name.
- The file already used this pattern in its sibling tests (`start:`/`end:` in `executionOrder`,
  lines 168-206), so this is local precedent rather than a new convention.

Tests:
- `packages/database/src/__tests__/facet-compatibility.test.ts` - one test rewritten.
- `packages/cli/src/utils/toolParallelizer.test.ts` - one test rewritten.
- No production code is touched by this PR.

## Guide for Testers

**No QA pass needed on this one - dev review only.** There is nothing to click: the PR changes
two test files and zero production code, so no UI, API, or behavior changes in the app.
Sign-off is code review plus green CI.

### Regression Checks

- CI is the regression check. The `packages/database` and `packages/cli` shards must stay
  green. What the tests cover is unchanged; only how they prove it changed.
- The mutation evidence above is the proof it can still fail. Anyone wanting to re-run it will
  find the exact commands in Additional Information.

### What NOT to test

- Do not look for a visible difference on the preview link - no app surface changed.
- Do not spin up a preview environment for this PR at all.
- Do not treat a green run as the whole story: a concurrency test passing proves nothing on its
  own (that is the trap in #1001), which is why both rewrites are mutation-tested above.
- No production code changed. `git diff main...HEAD --stat` is two files, both `*.test.ts`.

## Additional Information

**Mutation-tested, because a concurrency test that cannot fail is its own bug** (the trap in
#1001). The capture is in the first section; reproduce it yourself either way below.

By hand:

1. In `b4m-core/db-core/src/utils/documentdb-compat.ts`, replace the `Promise.all` in
   `executeFacetCompatible` with a sequential loop:
   ```ts
   const results = [];
   for (const [key, stages] of Object.entries(facetStages)) {
     const result = await run([...pipeline, ...stages]);
     results.push({ key, result });
   }
   ```
2. `pnpm --filter @bike4mind/db-core build` - **required**. `packages/database` resolves
   `@bike4mind/db-core` through its built `dist/`, so a source-only edit changes nothing and
   the test will appear to pass the mutation.
3. `pnpm --filter @bike4mind/database exec vitest run src/__tests__/facet-compatibility.test.ts`
   -> 1 failed / 12 passed.
4. Revert the file, rebuild, re-run -> 13/13.

Or run the whole thing in one go. It touches only `documentdb-compat.ts`, restores it from a
backup on every exit path including Ctrl-C, verifies the restore by sha, and hard-fails if the
`Promise.all` block ever stops matching - so it can never silently "pass" the mutation. Takes
about a minute. This is a throwaway helper for reviewers, not something the PR adds to the repo.

<details>
<summary><code>facet-1139-mutation-evidence.sh</code> - green -> mutate -> red -> revert -> green</summary>

```bash
#!/usr/bin/env bash
# Evidence run for #1139: proves the new overlap assertion in
# packages/database/src/__tests__/facet-compatibility.test.ts can still FAIL.
#
# Safe to run: the only file touched is b4m-core/db-core/src/utils/documentdb-compat.ts,
# restored from a backup on every exit path (including Ctrl-C), with the sha verified.

set -uo pipefail

REPO="${REPO:-$(git rev-parse --show-toplevel 2>/dev/null)}"
TARGET="$REPO/b4m-core/db-core/src/utils/documentdb-compat.ts"
TEST_FILE="src/__tests__/facet-compatibility.test.ts"
BACKUP="$(mktemp -t documentdb-compat.orig)"

cd "$REPO" || { echo "repo not found: $REPO"; exit 1; }

hr() { printf '\n\033[1;34m%s\033[0m\n' "=========== $* ==========="; }
quiet() { grep -vE "NodeVersionSupport|node >=22|trace-warnings|security updates|versions published|To continue receiving|Unsupported engine|npm warn"; }

cp "$TARGET" "$BACKUP"
ORIG_SHA="$(shasum "$TARGET" | awk '{print $1}')"

restore() {
  cp "$BACKUP" "$TARGET"
  rm -f "$BACKUP"
  pnpm --filter @bike4mind/db-core build >/dev/null 2>&1
}
trap restore EXIT INT TERM

hr "1. GREEN - the test as it ships"
pnpm --filter @bike4mind/database exec vitest run "$TEST_FILE" 2>&1 | quiet | grep -E "Test Files|Tests "

hr "2. MUTATE - serialize executeFacetCompatible"
python3 - "$TARGET" <<'PY'
import sys
path = sys.argv[1]
src = open(path).read()
old = """  const results = await Promise.all(
    Object.entries(facetStages).map(async ([key, stages]) => {
      const result = await run([...pipeline, ...stages]);
      return { key, result };
    })
  );"""
new = """  const results = [];
  for (const [key, stages] of Object.entries(facetStages)) {
    const result = await run([...pipeline, ...stages]);
    results.push({ key, result });
  }"""
if old not in src:
    sys.exit("Promise.all block not found - the impl changed; update this script.")
open(path, 'w').write(src.replace(old, new))
PY
[ $? -eq 0 ] || exit 1
echo "Promise.all -> sequential for loop"
# Required: packages/database resolves @bike4mind/db-core through dist/, so a
# source-only edit is invisible to the test and the mutation would silently no-op.
pnpm --filter @bike4mind/db-core build >/dev/null 2>&1 && echo "db-core rebuilt (dist/ is what the test resolves)"

hr "3. RED - the assertion catches it"
pnpm --filter @bike4mind/database exec vitest run "$TEST_FILE" 2>&1 | quiet \
  | grep -E "AssertionError|toHaveLength|Test Files|Tests |×" | head -8

hr "4. REVERT - restore and rebuild"
restore
trap - EXIT INT TERM
NEW_SHA="$(shasum "$TARGET" | awk '{print $1}')"
if [ "$ORIG_SHA" = "$NEW_SHA" ]; then
  echo "restored byte-identical: $NEW_SHA"
else
  echo "WARNING: sha mismatch - expected $ORIG_SHA got $NEW_SHA"
fi
git status --short

hr "5. GREEN - back to passing"
pnpm --filter @bike4mind/database exec vitest run "$TEST_FILE" 2>&1 | quiet | grep -E "Test Files|Tests "
```

</details>

**On the "last remaining instance" claim, and the sweep bug behind it.** The issue's sweep
pattern (`duration).toBeLessThan` / `elapsed).toBeLessThan`) is **case-sensitive**, and
`packages/cli/src/utils/toolParallelizer.test.ts:458` reads `parallelDuration).toBeLessThan` -
capital D. So it was missed, and the first version of this PR repeated the issue's "last
instance" claim on the strength of a sweep that could not have found it. Caught in review by
@cleffrem-dev; that test is now fixed here too, which is why this PR spans two packages.

Re-swept case-insensitively (`(duration|elapsed|time|ms)[a-z]*\)\.toBeLessThan`, plus every
test file combining `Date.now()`/`performance.now()` with a comparison assert) across
`b4m-core`, `packages`, and `apps`. Remaining hits, all deliberately left alone as a different
class:

- `b4m-core/utils/src/artifactElision.test.ts` (`:244`, `:1238`, `:1259`, `:1287`) and
  `packages/database/src/models/auth/UserModel.findByUsernameOrEmail.test.ts:64` - loose
  quadratic-regression and ReDoS guards whose bounds sit orders of magnitude below the pre-fix
  measurements (tens of seconds), not attempts to separate two overlapping populations.
- `b4m-core/slack/src/services/SlackAuditLogger.test.ts:336` and
  `apps/client/server/integrations/integrationAuditLogger.test.ts:426`
  (`endTime - startTime < 50`) - these assert fire-and-forget against a **deliberately hanging**
  mock, so the two populations are ~0ms and infinity. A regression hangs to test timeout rather
  than landing at 51ms.
- `b4m-core/fab-pipeline/src/dataLake/opensearchClient.test.ts:90` bounds a *computed*
  retry-after delay, and `apps/client/__tests__/channel-phase2.test.ts:377` is arithmetic on
  constants with no clock at all.

## Developer Notes (Optional)

- The overlap assertion is the house pattern for proving concurrency in this repo. When
  writing a new one, copy `b4m-core/agents/src/ReActAgent.parallel.test.ts`: log
  `start:<key>` / `end:<key>`, assert every start precedes the first end, guard the
  `findIndex` miss, and mutation-test it by serializing the code under test. Reach for a
  call-index key when the mocked calls are indistinguishable from their arguments, as they are
  here.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
