### PR TITLE
feat(publish): make artifact rendering server-authoritative in finalize

### DIFF
--- a/apps/client/app/utils/htmlEscape.ts
+++ b/apps/client/app/utils/htmlEscape.ts
@@ -6,3 +6,17 @@
 export function escapeAttr(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
+
+/**
+ * Like escapeAttr but also escapes ' (single quote) as &#39; - the stricter form used when
+ * rendering source into a code view or interpolating into single-quoted attributes. Shared
+ * by the server artifact renderer; keep byte-identical to any sibling copies it pins against.
+ */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/apps/client/app/utils/publishApi.ts
+++ b/apps/client/app/utils/publishApi.ts
@@ -484,8 +484,14 @@ function uniqueSlugDiscriminator(): string {
   return `${time}${rand}`;
 }
 
-/** Render an artifact to a single static index.html based on its type. */
-function buildArtifactIndexHtml(type: string, content: string, title: string): string {
+/**
+ * Render an artifact to a single static index.html based on its type.
+ *
+ * Exported so the server renderer's byte-parity tests can pin their output to this
+ * (`apps/client/server/services/publish/renderArtifactHtml.ts`). The server copy is the
+ * permanent home; this client pre-render is removed once the raw-upload switch lands (#1492).
+ */
+export function buildArtifactIndexHtml(type: string, content: string, title: string): string {
   const t = escapeHtml(title || 'Shared artifact');
   // Full HTML doc -> serve as-is, but still inject the lead-gen footer before
   // </body> (fall back to appending) so every published page is branded.

--- a/apps/client/app/utils/shareFooter.ts
+++ b/apps/client/app/utils/shareFooter.ts
@@ -2,8 +2,9 @@
  * Lead-gen footer for published share pages (reply/fabfile viewers + artifact
  * bundles). Pure string builder - NO imports beyond the inlined logo, NO JS -
  * so it's safe under the strict serve CSP (`script-src 'none'`) and passes
- * `validateBundle` (no external asset fetch). Used by both `renderViewerPage`
- * (serve handler) and `buildArtifactIndexHtml` (client bundler).
+ * `validateBundle` (no external asset fetch). Used by `renderViewerPage` (serve
+ * handler), `renderArtifactIndexHtml` (server artifact renderer - the permanent
+ * home), and `buildArtifactIndexHtml` (client bundler, removed in #1492).
  *
  * Dark-navy card, a brand wordmark (the inlined built-in SVG when the operator
  * opts in via NEXT_PUBLIC_SHARE_BUILTIN_LOGO, otherwise a text wordmark of the

--- a/apps/client/pages/api/publish/artifact/__tests__/finalize.render.test.ts
+++ b/apps/client/pages/api/publish/artifact/__tests__/finalize.render.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import { renderArtifactIndexHtml } from '@server/services/publish';
+
+// Integration guard for the server-authoritative render branch of finalize (issue #1491): a draft
+// that signals a non-react `artifactType` uploads RAW artifact content as index.html; finalize must
+// render it into the canonical published page (byte-identical to renderArtifactIndexHtml), recompute
+// size/sha, and promote the RENDERED bytes - while a draft with NO artifactType (an already-inert
+// bundle from the current web client) must promote its uploaded bytes unchanged (backward compat).
+// Keeps the REAL renderArtifactIndexHtml + validateBundle and stubs the heavy service surface.
+
+const { mockFindOne, mockFindOneAndUpdate, mockDownload, mockUpload } = vi.hoisted(() => ({
+  mockFindOne: vi.fn(),
+  mockFindOneAndUpdate: vi.fn(),
+  mockDownload: vi.fn(),
+  mockUpload: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign(
+      (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
+      {
+        use: () => chain,
+        post: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.POST = fns[fns.length - 1]), chain),
+      }
+    );
+    return chain;
+  },
+}));
+
+vi.mock('@server/utils/storage', () => ({
+  getPublishedArtifactsStorage: () => ({
+    download: mockDownload,
+    upload: mockUpload,
+    delete: vi.fn(() => Promise.resolve()),
+  }),
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  PublishedArtifact: {
+    findOne: () => ({ select: () => ({ lean: () => Promise.resolve(mockFindOne()) }) }),
+    findOneAndUpdate: (...a: unknown[]) => Promise.resolve(mockFindOneAndUpdate(...a)),
+  },
+}));
+
+vi.mock('@server/services/publish', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    checkScopePermission: () => Promise.resolve({ ok: true }),
+    checkPublishQuota: () => Promise.resolve({ ok: true }),
+    resolveVisibility: (_tier: string, visibility: string) => ({ ok: true, visibility }),
+    buildPublishS3KeyPrefix: () => 'user/owner1/art/',
+    buildPublishUrlPath: () => '/p/u/owner1/art',
+    invalidatePublishCdn: () => undefined,
+    toCacheTarget: () => ({}),
+  };
+});
+
+import handler from '../finalize';
+
+const DRAFT_ID = '33333333-3333-4333-8333-333333333333';
+
+const manifest = (over: Record<string, unknown>) => ({
+  draftId: DRAFT_ID,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  createdBy: 'owner1',
+  tier: 'user',
+  scopeId: 'owner1',
+  slug: 'art',
+  title: 'My Artifact',
+  visibility: 'public',
+  files: [{ path: 'index.html', size: 1, mimeType: 'text/html' }],
+  ...over,
+});
+
+const setDraft = (m: Record<string, unknown>, rawIndexHtml: string) => {
+  mockDownload.mockImplementation((key: string) =>
+    key.endsWith('_manifest.json')
+      ? Promise.resolve(Buffer.from(JSON.stringify(m)))
+      : Promise.resolve(Buffer.from(rawIndexHtml))
+  );
+};
+
+const run = (body: unknown) => {
+  const { req, res } = createMocks({ method: 'POST', body });
+  const r = req as Record<string, unknown>;
+  r.user = { id: 'owner1', isAdmin: false, organizationId: null };
+  r.logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return { res, promise: (handler as unknown as (req: unknown, res: unknown) => Promise<void>)(req, res) };
+};
+
+const promotedIndexHtml = () => {
+  const call = mockUpload.mock.calls.find(c => String(c[1]).endsWith('index.html'));
+  return (call![0] as Buffer).toString('utf-8');
+};
+const savedSet = () => (mockFindOneAndUpdate.mock.calls[0]?.[1] as { $set: Record<string, unknown> }).$set;
+
+beforeEach(() => {
+  mockFindOne.mockReset().mockResolvedValue(null);
+  mockFindOneAndUpdate.mockReset().mockResolvedValue({ visibility: 'public', publicId: 'pub1' });
+  mockDownload.mockReset();
+  mockUpload.mockReset().mockResolvedValue(undefined);
+});
+
+describe('finalize - server-authoritative render branch', () => {
+  it('renders a raw svg draft to the canonical page and promotes the RENDERED bytes (200)', async () => {
+    const rawSvg = '<svg viewBox="0 0 10 10"><rect width="10" height="10"/></svg>';
+    setDraft(manifest({ source: { kind: 'bundle', artifactId: 'a1', artifactType: 'svg' } }), rawSvg);
+    const { res, promise } = run({ draftId: DRAFT_ID });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const promoted = promotedIndexHtml();
+    expect(promoted).toBe(renderArtifactIndexHtml('svg', rawSvg, 'My Artifact'));
+    expect(promoted.startsWith('<!doctype html>')).toBe(true);
+    expect(promoted).toContain(rawSvg); // inline svg is embedded, not escaped
+
+    // size + sha recomputed on the FINAL rendered bytes.
+    const set = savedSet();
+    expect((set.size as { totalBytes: number }).totalBytes).toBe(Buffer.byteLength(promoted, 'utf-8'));
+    expect(typeof set.sha256Index).toBe('string');
+  });
+
+  it('renders a raw code draft into an escaped code view (200)', async () => {
+    const rawCode = 'const x = 1 < 2 && "y" > 0;';
+    setDraft(manifest({ source: { kind: 'bundle', artifactId: 'a1', artifactType: 'code' } }), rawCode);
+    const { res, promise } = run({ draftId: DRAFT_ID });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const promoted = promotedIndexHtml();
+    expect(promoted).toBe(renderArtifactIndexHtml('code', rawCode, 'My Artifact'));
+    expect(promoted).toContain('<pre><code>const x = 1 &lt; 2 &amp;&amp; &quot;y&quot; &gt; 0;</code></pre>');
+  });
+
+  it('promotes an already-inert bundle unchanged when no artifactType is signaled (backward compat)', async () => {
+    const inert = '<!doctype html><html lang="en"><head><title>x</title></head><body><h1>Prebuilt</h1></body></html>';
+    setDraft(manifest({ source: { kind: 'bundle', artifactId: 'a1' } }), inert);
+    const { res, promise } = run({ draftId: DRAFT_ID });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(promotedIndexHtml()).toBe(inert); // rendered nowhere - served exactly as uploaded
+  });
+});

--- a/apps/client/pages/api/publish/artifact/finalize.ts
+++ b/apps/client/pages/api/publish/artifact/finalize.ts
@@ -6,6 +6,7 @@ import { PublishedArtifact } from '@bike4mind/database';
 import {
   FinalizeRequestSchema,
   PUBLISH_LIMITS,
+  ArtifactTypeSchema,
   type ArtifactFile,
   type PublishResult,
   type ValidationViolation,
@@ -21,6 +22,7 @@ import {
   toCacheTarget,
   validateEmbedOrigins,
   buildReactArtifactBundle,
+  renderArtifactIndexHtml,
   UnsupportedReactDependencyError,
   ReactArtifactTranspileError,
   type PublishUser,
@@ -55,8 +57,10 @@ const DraftManifestSchema = z.object({
     sessionId: z.string().optional(),
     messageId: z.string().optional(),
     fabFileId: z.string().optional(),
-    // Raw JSX uploaded as index.html; transpiled to an inert bundle below (issue #21).
-    artifactType: z.literal('react').optional(),
+    // Raw artifact content uploaded as index.html; rendered server-side below. `react`
+    // transpiles to an inert bundle (issue #21); every other type is wrapped by
+    // renderArtifactIndexHtml. Absent means the bytes are already the final page.
+    artifactType: ArtifactTypeSchema.optional(),
   }),
   files: z.array(z.object({ path: z.string(), size: z.number(), mimeType: z.string() })),
 });
@@ -181,6 +185,19 @@ const handler = baseApi().post(async (req, res) => {
       }
       throw err;
     }
+  } else if (manifest.source.artifactType) {
+    // Non-react artifact types signal "render this raw content server-side": wrap the uploaded
+    // source into the canonical published page (byte-identical to the web client's pre-render)
+    // so the caps, validateBundle, and promote below all operate on the FINAL served bytes.
+    const rendered = renderArtifactIndexHtml(
+      manifest.source.artifactType,
+      bufferCache.get('index.html')!.toString('utf-8'),
+      manifest.title
+    );
+    const buf = Buffer.from(rendered, 'utf-8');
+    bufferCache.set('index.html', buf);
+    indexEntry.size = buf.length;
+    indexEntry.sha256 = createHash('sha256').update(buf).digest('hex');
   }
 
   // 4b. Size caps (post-transpile, so a React bundle's FINAL size is what's enforced)

--- a/apps/client/server/services/publish/index.ts
+++ b/apps/client/server/services/publish/index.ts
@@ -87,3 +87,4 @@ export {
   UnsupportedReactDependencyError,
   ReactArtifactTranspileError,
 } from './transpileReactArtifact';
+export { renderArtifactIndexHtml } from './renderArtifactHtml';

--- a/apps/client/server/services/publish/renderArtifactHtml.test.ts
+++ b/apps/client/server/services/publish/renderArtifactHtml.test.ts
@@ -65,4 +65,8 @@ describe('renderArtifactIndexHtml byte-parity with the client pre-render', () =>
     const out = renderArtifactIndexHtml('svg', '<svg/>', '');
     expect(out).toContain('<title>Shared artifact</title>');
   });
+
+  it('throws on react rather than code-viewing raw JSX', () => {
+    expect(() => renderArtifactIndexHtml('react', '<App/>', title)).toThrow(/transpiled/);
+  });
 });

--- a/apps/client/server/services/publish/renderArtifactHtml.test.ts
+++ b/apps/client/server/services/publish/renderArtifactHtml.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { renderArtifactIndexHtml } from './renderArtifactHtml';
+import { buildArtifactIndexHtml } from '@client/app/utils/publishApi';
+
+/**
+ * The server renderer is the permanent home for artifact -> published bytes. Until #1492
+ * removes the web client's pre-render, both must emit BYTE-IDENTICAL output so switching the
+ * client to raw upload cannot change any already-published page. These tests pin the server
+ * output to the current client output (`buildArtifactIndexHtml`) per artifact type.
+ *
+ * `react` is intentionally absent: the client uploads raw JSX (it does not pre-render react)
+ * and finalize transpiles it via `buildReactArtifactBundle` - that path is covered by
+ * `transpileReactArtifact.test.ts`, not this wrapper.
+ */
+describe('renderArtifactIndexHtml byte-parity with the client pre-render', () => {
+  const title = 'My "Cool" <Artifact> & Friends';
+
+  const cases: Array<{ name: string; type: Parameters<typeof renderArtifactIndexHtml>[0]; content: string }> = [
+    {
+      name: 'html with <!doctype> (full document)',
+      type: 'html',
+      content: '<!doctype html><html lang="en"><head><title>x</title></head><body><h1>Hi</h1></body></html>',
+    },
+    {
+      name: 'html full document without a </body> (footer appended)',
+      type: 'html',
+      content: '<html><head><title>x</title></head><h1>no body close</h1></html>',
+    },
+    { name: 'html fragment (wrapped in page shell)', type: 'html', content: '<h1>Just a fragment</h1><p>hi</p>' },
+    {
+      name: 'svg (wrapped in page shell)',
+      type: 'svg',
+      content: '<svg viewBox="0 0 10 10"><rect width="10" height="10"/></svg>',
+    },
+    { name: 'code (code view)', type: 'code', content: 'const x = 1 < 2 && 3 > 2;\nconsole.log("<script>");' },
+    { name: 'python (code view)', type: 'python', content: 'print("hello & <world>")' },
+    { name: 'mermaid (code view)', type: 'mermaid', content: 'graph TD;\n  A-->B;' },
+    { name: 'recharts (code view)', type: 'recharts', content: '{"type":"bar","data":[1,2,3]}' },
+  ];
+
+  it.each(cases)('matches the client output for $name', ({ type, content }) => {
+    expect(renderArtifactIndexHtml(type, content, title)).toBe(buildArtifactIndexHtml(type, content, title));
+  });
+
+  it('injects the footer before </body> for a full HTML document', () => {
+    const out = renderArtifactIndexHtml('html', '<html><body><h1>Hi</h1></body></html>', title);
+    expect(out.startsWith('<html><body><h1>Hi</h1>')).toBe(true);
+    // Whatever the footer resolves to (env-dependent), it lands before the closing tag.
+    expect(out.endsWith('</body></html>')).toBe(true);
+  });
+
+  it('wraps fragments and svg in a doctype page shell with the escaped title', () => {
+    const frag = renderArtifactIndexHtml('html', '<h1>frag</h1>', title);
+    expect(frag.startsWith('<!doctype html>')).toBe(true);
+    expect(frag).toContain('<title>My &quot;Cool&quot; &lt;Artifact&gt; &amp; Friends</title>');
+    expect(frag).toContain('<h1>frag</h1>');
+  });
+
+  it('escapes source content in the code view', () => {
+    const out = renderArtifactIndexHtml('code', '1 < 2 && "x" > \'y\'', title);
+    expect(out).toContain('<pre><code>1 &lt; 2 &amp;&amp; &quot;x&quot; &gt; &#39;y&#39;</code></pre>');
+  });
+
+  it('falls back to the default title when none is given', () => {
+    const out = renderArtifactIndexHtml('svg', '<svg/>', '');
+    expect(out).toContain('<title>Shared artifact</title>');
+  });
+});

--- a/apps/client/server/services/publish/renderArtifactHtml.ts
+++ b/apps/client/server/services/publish/renderArtifactHtml.ts
@@ -1,0 +1,52 @@
+import type { ArtifactType } from '@bike4mind/common';
+import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
+
+/**
+ * Server-authoritative renderer: turn a B4M artifact's RAW content into the canonical
+ * published `index.html`. This is the single source of truth for artifact -> published
+ * bytes; every publish surface (web client, MCP publish tool, CLI) can upload raw content
+ * and let `finalize` render it here rather than re-implementing the wrapper and drifting.
+ *
+ * React is NOT handled here - it needs transpilation (see `buildReactArtifactBundle`) and
+ * finalize routes it separately. Every other artifact type renders to a self-contained
+ * static page: full HTML docs pass through with only the share footer injected; HTML
+ * fragments and inline SVG are wrapped in a minimal page shell; all source-bearing types
+ * (code/python/mermaid/recharts/json/...) render their source in a code view.
+ *
+ * MUST stay byte-identical to the web client's `buildArtifactIndexHtml`
+ * (`apps/client/app/utils/publishApi.ts`) until #1492 removes the client copy - the
+ * byte-parity tests in `renderArtifactHtml.test.ts` guard that invariant.
+ */
+
+/** Escapes &, <, >, ", ' for interpolation into HTML text/attributes. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Render an artifact to a single static index.html based on its type. */
+export function renderArtifactIndexHtml(type: ArtifactType, content: string, title: string): string {
+  const t = escapeHtml(title || 'Shared artifact');
+  // Full HTML doc -> serve as-is, but still inject the lead-gen footer before
+  // </body> (fall back to appending) so every published page is branded.
+  if (type === 'html' && /<html[\s>]/i.test(content)) {
+    const footer = buildShareFooterHtml({ source: 'artifact' });
+    return /<\/body>/i.test(content) ? content.replace(/<\/body>/i, `${footer}</body>`) : content + footer;
+  }
+
+  const PAGE = (inner: string, extraStyle = '') => `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta property="og:title" content="${t}"><title>${t}</title>
+<style>:root{color-scheme:light dark}body{font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;line-height:1.6;max-width:900px;margin:0 auto;padding:2rem 1.25rem 4rem}pre{background:rgba(127,127,127,.12);padding:1rem;border-radius:8px;overflow-x:auto;white-space:pre-wrap;word-wrap:break-word}img,svg{max-width:100%;height:auto}${extraStyle}</style>
+</head><body>${inner}${buildShareFooterHtml({ source: 'artifact' })}</body></html>`;
+
+  if (type === 'html') return PAGE(content); // HTML fragment
+  if (type === 'svg') return PAGE(content); // inline SVG markup
+  // Source-bearing types (code/python/react/recharts/mermaid/json/...) -> code view.
+  return PAGE(`<pre><code>${escapeHtml(content)}</code></pre>`);
+}

--- a/apps/client/server/services/publish/renderArtifactHtml.ts
+++ b/apps/client/server/services/publish/renderArtifactHtml.ts
@@ -1,4 +1,5 @@
 import type { ArtifactType } from '@bike4mind/common';
+import { escapeHtml } from '@client/app/utils/htmlEscape';
 import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
 
 /**
@@ -18,18 +19,15 @@ import { buildShareFooterHtml } from '@client/app/utils/shareFooter';
  * byte-parity tests in `renderArtifactHtml.test.ts` guard that invariant.
  */
 
-/** Escapes &, <, >, ", ' for interpolation into HTML text/attributes. */
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
 /** Render an artifact to a single static index.html based on its type. */
 export function renderArtifactIndexHtml(type: ArtifactType, content: string, title: string): string {
+  // React is transpiled via buildReactArtifactBundle, never rendered here. Enforce the
+  // contract at runtime (not just in the docstring) so a future caller passing artifact.type
+  // straight through gets a loud failure instead of raw JSX quietly published as escaped source.
+  if (type === 'react') {
+    throw new Error('react artifacts must be transpiled via buildReactArtifactBundle, not rendered here');
+  }
+
   const t = escapeHtml(title || 'Shared artifact');
   // Full HTML doc -> serve as-is, but still inject the lead-gen footer before
   // </body> (fall back to appending) so every published page is branded.
@@ -47,6 +45,6 @@ export function renderArtifactIndexHtml(type: ArtifactType, content: string, tit
 
   if (type === 'html') return PAGE(content); // HTML fragment
   if (type === 'svg') return PAGE(content); // inline SVG markup
-  // Source-bearing types (code/python/react/recharts/mermaid/json/...) -> code view.
+  // Source-bearing types (code/python/recharts/mermaid/json/...) -> code view.
   return PAGE(`<pre><code>${escapeHtml(content)}</code></pre>`);
 }

--- a/b4m-core/common/src/schemas/publishedArtifact.ts
+++ b/b4m-core/common/src/schemas/publishedArtifact.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { VisibilitySchema } from './artifacts';
 import { CommentPolicySchema } from './annotation';
+import { ArtifactTypeSchema } from '../types/entities/ArtifactTypes';
 
 /**
  * Published-artifact schemas - the B4M instantiation of the `artifact-publishing`
@@ -67,11 +68,14 @@ export const PublishSourceSchema = z.object({
   /** Set when kind === 'fabfile'. */
   fabFileId: z.string().optional(),
   /**
-   * Set when the uploaded index.html is RAW React/JSX source rather than an inert page: finalize
-   * transpiles it into a self-contained inert HTML bundle at publish time (issue #21). Absent for
-   * already-inert HTML/SVG bundles that need no server transform.
+   * Set when the uploaded index.html is RAW artifact content that finalize must render into the
+   * canonical published page server-side, rather than an already-inert bundle. `react` transpiles
+   * to a self-contained inert HTML bundle (issue #21); every other type is wrapped by
+   * `renderArtifactIndexHtml`. Absent for already-inert HTML/SVG bundles that need no server
+   * transform (the web client pre-renders those until the raw-upload switch lands), so this stays
+   * backward compatible: existing drafts omit it and finalize serves their bytes unchanged.
    */
-  artifactType: z.literal('react').optional(),
+  artifactType: ArtifactTypeSchema.optional(),
 });
 export type PublishSource = z.infer<typeof PublishSourceSchema>;
 


### PR DESCRIPTION
## Description

Turning a B4M artifact into the canonical published `index.html` currently happens
client-side in `buildArtifactIndexHtml` (`apps/client/app/utils/publishApi.ts`). It wraps
content by type (react / html / svg / code-view fallback) and appends the share footer.
Because that path imports `@client/*` config, it is not importable outside the web client,
so other publish surfaces cannot reuse it and would have to re-implement a second renderer
guaranteed to drift.

This PR makes the **server** authoritative for artifact -> published bytes. It extracts the
type->HTML wrapper + share-footer logic into a server module and teaches `finalize` to
render uploaded raw content when a draft signals its artifact type. Output is byte-identical
to the current client renderer, proven per type by unit tests.

This is purely additive: no existing client changes behavior. The web client still
pre-renders today; that pre-render is removed in a follow-up.

## Changes

- **New** `apps/client/server/services/publish/renderArtifactHtml.ts` -
  `renderArtifactIndexHtml(type, content, title)`, the permanent server-side home for
  artifact -> published bytes. Byte-identical to the client's `buildArtifactIndexHtml`,
  reusing the shared (already env-driven) `buildShareFooterHtml`. React is intentionally not
  handled here (it transpiles via `buildReactArtifactBundle`); every other type wraps as before.
- `b4m-core/common/src/schemas/publishedArtifact.ts` - generalized
  `PublishSourceSchema.artifactType` from `z.literal('react')` to `ArtifactTypeSchema.optional()`.
  Backward compatible: absent = already-inert bytes served unchanged; `react` = transpile;
  any other type = render server-side.
- `apps/client/pages/api/publish/artifact/finalize.ts` - draft manifest `artifactType`
  widened to `ArtifactTypeSchema`; added an `else if (artifactType)` branch that renders raw
  uploaded content via `renderArtifactIndexHtml`, recomputing size/sha on the FINAL bytes
  (mirrors the react branch) so caps + validateBundle + promote all see the served bytes.
- `apps/client/server/services/publish/index.ts` - export the new renderer.
- `apps/client/app/utils/publishApi.ts` - exported `buildArtifactIndexHtml` (was private) so
  the byte-parity tests can pin server output to current client output. No behavior change.

## Guide for Testers

This is a **backend-only** capability addition with no client wiring yet, so there is no UI
flow to exercise. Verification is via the automated tests below.

1. From the repo root, run the server-side publish tests:
   `pnpm --filter @bike4mind/client test -- server/services/publish pages/api/publish/artifact`
2. Expected: all tests pass, including `renderArtifactHtml.test.ts` (byte-parity per type:
   html-full-doc, html-no-body, html-fragment, svg, code/python/mermaid/recharts code views)
   and `finalize.render.test.ts` (a non-react `artifactType` draft promotes the rendered
   bytes; a draft with no `artifactType` promotes its uploaded bytes unchanged).
3. Run the common schema tests: `pnpm --filter @bike4mind/common test -- schemas`
4. Expected: all pass, confirming the `PublishSourceSchema` generalization stays valid.

### Regression Checks

- Existing `react` drafts still transpile and finalize exactly as before.
- Drafts with no `artifactType` (already-inert html/svg bundles) finalize with their uploaded
  bytes unchanged.

### What NOT to test

- No UI/UX to click through - the web client still pre-renders and does not send the new
  server-render signal yet (that is removed in the follow-up client change).
- No infra, deploy, or preview-gate implications.

## Additional Information

Part of the epic to expose create + publish artifact tools in the B4M MCP server. The
downstream client change (raw upload, dropping the client pre-render) stacks on this; the
CLI/MCP tools consume the same server renderer.

## Developer Notes

- `renderArtifactIndexHtml(type, content, title)` in
  `apps/client/server/services/publish/` is now the single server-authoritative artifact ->
  published-bytes renderer. Any publish surface (client, CLI, MCP) can produce identical
  published output by handing raw content + type to `finalize`; no need to re-wrap or
  re-append the share footer client-side.
- `PublishSourceSchema.artifactType` (`ArtifactTypeSchema.optional()`) is the signal a draft
  uses to request server-side rendering at finalize time.

Closes #1491
