### PR TITLE
fix(services): classify anomalies by category so score > 0 names a real anomaly

### DIFF
--- a/apps/client/app/components/admin/ContextInspectorTab.tsx
+++ b/apps/client/app/components/admin/ContextInspectorTab.tsx
@@ -1958,6 +1958,7 @@ export function ContextInspectorTab() {
             >
               <Option value={null}>All</Option>
               <Option value="context_overflow">Context Overflow</Option>
+              <Option value="high_utilization">High Utilization</Option>
               <Option value="high_truncation">High Truncation</Option>
               <Option value="tool_failure">Tool Failure</Option>
               <Option value="subagent_timeout">Subagent Timeout</Option>

--- a/apps/client/server/services/telemetryFingerprint.test.ts
+++ b/apps/client/server/services/telemetryFingerprint.test.ts
@@ -285,5 +285,6 @@ describe('formatPrimaryAnomaly', () => {
     expect(formatPrimaryAnomaly('slow_response')).toBe('slow response');
     expect(formatPrimaryAnomaly('context_overflow')).toBe('context overflow');
     expect(formatPrimaryAnomaly('tool_failure')).toBe('tool failure');
+    expect(formatPrimaryAnomaly('high_utilization')).toBe('high utilization');
   });
 });

--- a/b4m-core/common/src/schemas/contextTelemetry.test.ts
+++ b/b4m-core/common/src/schemas/contextTelemetry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CONTEXT_TELEMETRY_SCHEMA_VERSION, ToolTelemetrySchema } from './contextTelemetry';
+import { CONTEXT_TELEMETRY_SCHEMA_VERSION, PrimaryAnomalySchema, ToolTelemetrySchema } from './contextTelemetry';
 
 describe('ToolTelemetrySchema web_fetch size fields (issue #452)', () => {
   const base = {
@@ -32,5 +32,26 @@ describe('ToolTelemetrySchema web_fetch size fields (issue #452)', () => {
 
   it('bumped the schema version to 1.2', () => {
     expect(CONTEXT_TELEMETRY_SCHEMA_VERSION).toBe('1.2');
+  });
+});
+
+describe('PrimaryAnomalySchema', () => {
+  it('accepts high_utilization', () => {
+    expect(PrimaryAnomalySchema.parse('high_utilization')).toBe('high_utilization');
+  });
+
+  // Widening the value domain only; pre-existing entries must still parse.
+  it('still accepts the pre-existing values', () => {
+    for (const value of [
+      'none',
+      'context_overflow',
+      'high_truncation',
+      'tool_failure',
+      'subagent_timeout',
+      'slow_response',
+      'multiple',
+    ]) {
+      expect(PrimaryAnomalySchema.parse(value)).toBe(value);
+    }
   });
 });

--- a/b4m-core/common/src/schemas/contextTelemetry.ts
+++ b/b4m-core/common/src/schemas/contextTelemetry.ts
@@ -218,10 +218,13 @@ export const PerformanceTelemetrySchema = z.object({
 // Anomaly severity (aligns with PagerDuty/Datadog)
 export const AnomalySeveritySchema = z.enum(['critical', 'high', 'medium', 'low']);
 
-// Primary anomaly type
+// Primary anomaly type. One member per anomaly category in
+// TelemetryBuilder.computeAnomalies -- must stay in sync with it, since that is
+// what guarantees anomalyScore > 0 always maps to a member other than 'none'.
 export const PrimaryAnomalySchema = z.enum([
   'none',
   'context_overflow',
+  'high_utilization',
   'high_truncation',
   'tool_failure',
   'subagent_timeout',

--- a/b4m-core/services/src/telemetry/AnomalyAlertService.ts
+++ b/b4m-core/services/src/telemetry/AnomalyAlertService.ts
@@ -507,6 +507,8 @@ export class AnomalyAlertService {
     switch (type) {
       case 'context_overflow':
         return 'Context Overflow';
+      case 'high_utilization':
+        return 'High Utilization';
       case 'high_truncation':
         return 'High Truncation';
       case 'tool_failure':

--- a/b4m-core/services/src/telemetry/TelemetryBuilder.test.ts
+++ b/b4m-core/services/src/telemetry/TelemetryBuilder.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ANOMALY_THRESHOLDS,
+  type AnomaliesTelemetry,
+  type SubagentTelemetry,
+  type ToolTelemetry,
+} from '@bike4mind/common';
+import { TelemetryBuilder } from './TelemetryBuilder';
+
+const sessionId = { hash: 'test-hash', dateKey: '2026-01-01' };
+
+/** Builds through the public API so these stay valid if computeAnomalies is refactored. */
+const anomaliesFor = (setup: (b: TelemetryBuilder) => void = () => {}): AnomaliesTelemetry => {
+  const builder = new TelemetryBuilder(sessionId);
+  builder.setRequestedModel('claude-3-5-sonnet', 'anthropic');
+  setup(builder);
+  return builder.build().anomalies;
+};
+
+const withUtilization =
+  (percentage: number, overflowDetected = false) =>
+  (b: TelemetryBuilder) => {
+    b.setContextWindow({ utilizationPercentage: percentage, overflowDetected });
+  };
+
+const withTruncation = (percentage: number) => (b: TelemetryBuilder) => {
+  b.setTruncation({ wasTruncated: true, truncationPercentage: percentage });
+};
+
+const tool = (overrides: Partial<ToolTelemetry> = {}): ToolTelemetry => ({
+  toolName: 'web_fetch',
+  isMcpTool: false,
+  invocationCount: 1,
+  successCount: 1,
+  failureCount: 0,
+  totalDurationMs: 100,
+  maxDurationMs: 100,
+  retryCount: 0,
+  ...overrides,
+});
+
+const subagent = (overrides: Partial<SubagentTelemetry> = {}): SubagentTelemetry => ({
+  agentName: 'researcher',
+  delegationCount: 1,
+  successCount: 1,
+  failureCount: 0,
+  timeoutCount: 0,
+  totalDurationMs: 1000,
+  totalTokensUsed: 100,
+  ...overrides,
+});
+
+describe('TelemetryBuilder anomaly classification', () => {
+  it('reports no anomaly for a clean turn', () => {
+    const anomalies = anomaliesFor();
+
+    expect(anomalies.anomalyScore).toBe(0);
+    expect(anomalies.primaryAnomaly).toBe('none');
+  });
+
+  describe('utilization', () => {
+    // Regression: this band used to score 10 but fall through to primaryAnomaly 'none',
+    // hiding the turn from the admin Severity filter and stat counts.
+    it('classifies a high-utilization-only turn instead of leaving it unclassified', () => {
+      const anomalies = anomaliesFor(withUtilization(92));
+
+      expect(anomalies.primaryAnomaly).toBe('high_utilization');
+      expect(anomalies.anomalyScore).toBe(10);
+      expect(anomalies.severity).toBe('low');
+    });
+
+    it('fires exactly at the high-utilization threshold', () => {
+      expect(anomaliesFor(withUtilization(ANOMALY_THRESHOLDS.highUtilization)).primaryAnomaly).toBe('high_utilization');
+      expect(anomaliesFor(withUtilization(ANOMALY_THRESHOLDS.highUtilization - 0.01)).primaryAnomaly).toBe('none');
+    });
+
+    // Regression: criticalUtilization also sets highUtilization, and counting raw flags
+    // made a single-cause turn look multi-cause.
+    it('keeps a critical-utilization-only turn single-cause', () => {
+      const anomalies = anomaliesFor(withUtilization(97));
+
+      expect(anomalies.primaryAnomaly).toBe('high_utilization');
+      expect(anomalies.anomalyScore).toBe(25);
+    });
+  });
+
+  describe('overflow', () => {
+    // Regression: on the normal capture path utilization is inputTokens/maxSafeInputTokens,
+    // so overflow implies >100% utilization. Counting utilization separately made
+    // 'context_overflow' unreachable there.
+    it('reports overflow rather than utilization when both are set', () => {
+      expect(anomaliesFor(withUtilization(105, true)).primaryAnomaly).toBe('context_overflow');
+    });
+
+    // The hard-overflow path measures utilization against contextLimit, not the safe
+    // input budget, so it can report overflow below the utilization threshold.
+    it('reports overflow when utilization is below the threshold', () => {
+      expect(anomaliesFor(withUtilization(82, true)).primaryAnomaly).toBe('context_overflow');
+    });
+  });
+
+  describe('single-cause turns with paired flags', () => {
+    it('classifies critical truncation as high_truncation', () => {
+      const anomalies = anomaliesFor(withTruncation(80));
+
+      expect(anomalies.primaryAnomaly).toBe('high_truncation');
+      expect(anomalies.anomalyScore).toBe(20);
+    });
+
+    it('classifies a failing slow tool as tool_failure', () => {
+      const anomalies = anomaliesFor(b => {
+        b.addTool(tool({ invocationCount: 3, successCount: 0, failureCount: 3, maxDurationMs: 45_000 }));
+      });
+
+      expect(anomalies.primaryAnomaly).toBe('tool_failure');
+      expect(anomalies.toolFailureSpike).toBe(true);
+      expect(anomalies.toolTimeout).toBe(true);
+    });
+
+    it('classifies both slow-response flags as slow_response', () => {
+      const anomalies = anomaliesFor(b => {
+        b.setPerformance({ totalResponseTimeMs: 70_000, firstTokenTimeMs: 12_000 });
+      });
+
+      expect(anomalies.primaryAnomaly).toBe('slow_response');
+    });
+
+    it('classifies a subagent timeout as subagent_timeout', () => {
+      const anomalies = anomaliesFor(b => {
+        b.addSubagent(subagent({ totalDurationMs: 400_000 }));
+      });
+
+      expect(anomalies.primaryAnomaly).toBe('subagent_timeout');
+    });
+  });
+
+  describe("'multiple'", () => {
+    it('reports multiple when genuinely distinct causes fire', () => {
+      const anomalies = anomaliesFor(b => {
+        withUtilization(92)(b);
+        withTruncation(60)(b);
+      });
+
+      expect(anomalies.primaryAnomaly).toBe('multiple');
+      expect(anomalies.anomalyScore).toBe(20);
+    });
+  });
+
+  describe('dedupKey', () => {
+    it('keys on the primary anomaly and model', () => {
+      expect(anomaliesFor(withUtilization(92)).dedupKey).toBe('high_utilization_claude-3-5-sonnet');
+    });
+
+    it('appends the failing tool name for tool failures', () => {
+      const anomalies = anomaliesFor(b => {
+        b.addTool(tool({ toolName: 'delegate-to-agent', invocationCount: 4, successCount: 0, failureCount: 4 }));
+      });
+
+      expect(anomalies.dedupKey).toBe('tool_failure_claude-3-5-sonnet_delegate-to-agent');
+    });
+  });
+
+  // The equivalence the admin Context Inspector relies on: it filters and counts real
+  // anomalies via primaryAnomaly !== 'none', while the score filter keys anomalyScore.
+  // If the two ever disagree a turn is silently dropped from the list.
+  describe('score/classification equivalence', () => {
+    const cases: Array<[string, (b: TelemetryBuilder) => void]> = [
+      ['clean', () => {}],
+      ['just below utilization threshold', withUtilization(89.99)],
+      ['high utilization', withUtilization(92)],
+      ['critical utilization', withUtilization(97)],
+      ['overflow below utilization threshold', withUtilization(82, true)],
+      ['overflow above utilization threshold', withUtilization(105, true)],
+      ['just below truncation threshold', withTruncation(49.99)],
+      ['high truncation', withTruncation(60)],
+      ['critical truncation', withTruncation(80)],
+      ['tool failure spike', b => b.addTool(tool({ invocationCount: 3, successCount: 0, failureCount: 3 }))],
+      ['tool timeout', b => b.addTool(tool({ maxDurationMs: 45_000 }))],
+      ['subagent timeout', b => b.addSubagent(subagent({ totalDurationMs: 400_000 }))],
+      ['slow first token', b => b.setPerformance({ totalResponseTimeMs: 20_000, firstTokenTimeMs: 12_000 })],
+      ['slow total response', b => b.setPerformance({ totalResponseTimeMs: 70_000 })],
+      [
+        'several causes',
+        b => {
+          withUtilization(97)(b);
+          withTruncation(80)(b);
+          b.addSubagent(subagent({ totalDurationMs: 400_000 }));
+        },
+      ],
+    ];
+
+    it.each(cases)('holds score > 0 <=> primaryAnomaly !== none for %s', (_name, setup) => {
+      const anomalies = anomaliesFor(setup);
+
+      expect(anomalies.anomalyScore > 0).toBe(anomalies.primaryAnomaly !== 'none');
+    });
+  });
+});

--- a/b4m-core/services/src/telemetry/TelemetryBuilder.ts
+++ b/b4m-core/services/src/telemetry/TelemetryBuilder.ts
@@ -25,6 +25,13 @@ import {
 import type { ToolErrorCategory } from '@bike4mind/common';
 
 /**
+ * The single-cause anomaly types: every PrimaryAnomaly except the two aggregate
+ * verdicts ('none', 'multiple'), which computeAnomalies derives from how many of
+ * these are active rather than detecting directly.
+ */
+type AnomalyCategory = Exclude<AnomaliesTelemetry['primaryAnomaly'], 'none' | 'multiple'>;
+
+/**
  * Categorizes a tool error message into a standardized category
  */
 export function categorizeToolError(errorMessage: string): ToolErrorCategory {
@@ -367,22 +374,27 @@ export class TelemetryBuilder {
     else if (score >= 20) severity = 'medium';
     else severity = 'low';
 
-    // Determine primary anomaly
-    let primaryAnomaly: AnomaliesTelemetry['primaryAnomaly'] = 'none';
-    const activeFlags = Object.entries(flags).filter(([, v]) => v);
-    if (activeFlags.length > 1) {
-      primaryAnomaly = 'multiple';
-    } else if (flags.contextOverflow) {
-      primaryAnomaly = 'context_overflow';
-    } else if (flags.criticalTruncation || flags.highTruncation) {
-      primaryAnomaly = 'high_truncation';
-    } else if (flags.toolFailureSpike || flags.toolTimeout) {
-      primaryAnomaly = 'tool_failure';
-    } else if (flags.subagentTimeout) {
-      primaryAnomaly = 'subagent_timeout';
-    } else if (flags.slowTotalResponse || flags.slowFirstToken) {
-      primaryAnomaly = 'slow_response';
-    }
+    // Classify by category, not by raw flag: every scoring flag maps to exactly one
+    // category, which is what makes score > 0 always imply a primaryAnomaly other than
+    // 'none' -- an equivalence the admin Context Inspector filters and stat counts rely on.
+    // Collapsing the critical*/high* tiers of one condition also keeps a single-cause turn
+    // from being mislabelled 'multiple'. Overflow deliberately suppresses utilization: the
+    // normal capture path derives utilization as inputTokens / maxSafeInputTokens, so
+    // overflow always implies criticalUtilization and counting both would make
+    // 'context_overflow' unreachable. Record<AnomalyCategory> keeps this in sync with
+    // PrimaryAnomalySchema -- a new member there fails to compile until it lands here.
+    const categories: Record<AnomalyCategory, boolean> = {
+      context_overflow: flags.contextOverflow,
+      high_utilization: !flags.contextOverflow && (flags.criticalUtilization || flags.highUtilization),
+      high_truncation: flags.criticalTruncation || flags.highTruncation,
+      tool_failure: flags.toolFailureSpike || flags.toolTimeout,
+      subagent_timeout: flags.subagentTimeout,
+      slow_response: flags.slowTotalResponse || flags.slowFirstToken,
+    };
+
+    const activeCategories = (Object.keys(categories) as AnomalyCategory[]).filter(key => categories[key]);
+    const primaryAnomaly: AnomaliesTelemetry['primaryAnomaly'] =
+      activeCategories.length === 0 ? 'none' : activeCategories.length > 1 ? 'multiple' : activeCategories[0];
 
     // Generate dedup key based on pattern
     const dedupParts = [primaryAnomaly, this.actualModelId];


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

Not included: the affected surface is an admin-only debug view, and reproducing it requires telemetry in a narrow utilization band that no ordinary session produces. The Guide for Testers below includes a copy-pasteable snippet that seeds the two rows needed to see the before/after in the UI.

## Description

`TelemetryBuilder.computeAnomalies` chose `primaryAnomaly` from a chain of raw anomaly flags. Because that chain had no branch for the utilization flags, a turn at 90-94.99% context utilization with nothing else firing scored `10` and was graded `severity: 'low'`, but fell through the entire chain and ended up with `primaryAnomaly: 'none'`. That breaks the `anomalyScore > 0` means "real anomaly" equivalence that the admin Context Inspector relies on in three places (introduced in #1415): the severity list filter, the Severity Distribution stat card, and the entry card indicator. The turn stayed in the default list wearing the neutral "benign" icon and disappeared entirely the moment you filtered to `Severity: Low` -- the exact view you would use to find it.

While fixing that, two more defects with the same root cause turned up, both of which the reported issue had assumed were harmless.

First, `activeFlags.length > 1` counted raw flags, but four flag pairs co-fire by definition: `criticalUtilization` always also sets `highUtilization`, `criticalTruncation` always also sets `highTruncation`, and the tool and slow-response pairs commonly fire together. Any single-cause turn hitting a critical tier was therefore labelled `'multiple'`. Since `dedupKey` is built from `primaryAnomaly`, all of those collapsed into one `multiple_<model>` bucket, degrading alert deduplication, the Slack alert title, the auto-filed issue title, and the anomaly-type filter.

Second, on the normal capture path `utilizationPercentage` is `inputTokens / maxSafeInputTokens`, so `overflowDetected` always implies `criticalUtilization`. Counting utilization as a separate cause meant a pure overflow turn always produced three active flags and was labelled `'multiple'`, making `'context_overflow'` unreachable on that path.

The fix replaces the flat if/else chain with a category layer. Each condition's severity tiers collapse into a single category, overflow subsumes utilization, and `'multiple'` is derived from the number of distinct active categories rather than the raw flag count. Typing the map as `Record<AnomalyCategory, boolean>` makes the compiler enforce the invariant going forward: a new member added to `PrimaryAnomalySchema` will not compile until it is given a category, which is precisely the guard whose absence caused this bug.

Scores, severities, thresholds, weights, and the emitted boolean flags are all unchanged. This changes classification only.

## Changes

- `b4m-core/services/src/telemetry/TelemetryBuilder.ts` -- replace the raw-flag if/else chain in `computeAnomalies` with a category map; add the `AnomalyCategory` type alias that keeps the map exhaustive against `PrimaryAnomalySchema`.
- `b4m-core/common/src/schemas/contextTelemetry.ts` -- add `high_utilization` to `PrimaryAnomalySchema`.
- `b4m-core/services/src/telemetry/AnomalyAlertService.ts` -- add the `high_utilization` case to `formatAnomalyType` so alerts render "High Utilization" rather than the raw enum value.
- `apps/client/app/components/admin/ContextInspectorTab.tsx` -- add the "High Utilization" option to the Anomaly Type filter, without which the new type is unfilterable in the very view this issue is about.
- `b4m-core/services/src/telemetry/TelemetryBuilder.test.ts` -- new file. The classifier previously had zero test coverage. 28 tests covering all three defects, the threshold boundaries, `dedupKey` construction, and a parameterised sweep pinning the `anomalyScore > 0` is equivalent to `primaryAnomaly !== 'none'` invariant.
- `b4m-core/common/src/schemas/contextTelemetry.test.ts` -- assert the enum accepts `high_utilization` and still accepts every pre-existing value.
- `apps/client/server/services/telemetryFingerprint.test.ts` -- assert `formatPrimaryAnomaly('high_utilization')` renders as `high utilization`.

## Guide for Testers

This is a backend classification change with one small admin UI addition. The most meaningful verification is the automated suite; the UI steps are optional and require seeding data, because no ordinary session lands in the affected band.

### Part 1 -- Automated verification (primary)

1. Check out this branch and run `pnpm --filter @bike4mind/services test -- src/telemetry/TelemetryBuilder.test.ts`. Expected: `28 passed`, zero failures.
2. Run `pnpm --filter @bike4mind/common test`. Expected: all tests pass, including the new `PrimaryAnomalySchema` block.
3. Run `pnpm turbo:typecheck`. Expected: all tasks succeed.
4. Run `pnpm lint:check`. Expected: no output and a zero exit code.

### Part 2 -- Confirm the tests actually catch the bug (recommended for reviewers)

5. From the repo root run `git stash push -- b4m-core/services/src/telemetry/TelemetryBuilder.ts` to temporarily remove only the fix.
6. Run `pnpm --filter @bike4mind/services test -- src/telemetry/TelemetryBuilder.test.ts` again. Expected: `9 failed | 19 passed`. The failures name each of the three defects, for example `classifies a high-utilization-only turn instead of leaving it unclassified` and `keeps a critical-utilization-only turn single-cause`.
7. Run `git stash pop` to restore the fix, then re-run the same command. Expected: `28 passed` again.

### Part 3 -- Optional UI check in the admin Context Inspector

Requires a local or preview environment with database access. Seeding is necessary because reaching 90-94.99% context utilization organically needs roughly 150k input tokens in a single turn.

8. Connect to the environment's MongoDB and run the snippet below. It inserts two rows: one shaped as the old classifier wrote them (`primaryAnomaly: 'none'`) and one as the new classifier writes them (`primaryAnomaly: 'high_utilization'`). Both are otherwise identical at `anomalyScore: 10`, `severity: 'low'`, 92% utilization.

```js
const anomalies = {
  contextOverflow: false, highUtilization: true, criticalUtilization: false,
  highTruncation: false, criticalTruncation: false, toolFailureSpike: false,
  toolTimeout: false, subagentTimeout: false, slowFirstToken: false,
  slowTotalResponse: false, anomalyScore: 10, severity: 'low',
  dedupKey: 'high_utilization_claude-3-5-sonnet-20241022',
  primaryAnomaly: 'high_utilization',
};
const telemetry = {
  schemaVersion: '1.2', timestamp: new Date().toISOString(), captureOverheadMs: 5,
  anonymousSessionId: { hash: 'qa-seed-hash', dateKey: new Date().toISOString().slice(0, 10) },
  operation: { name: 'chat_completion', finishReason: 'stop' },
  model: { modelId: 'claude-3-5-sonnet-20241022', provider: 'anthropic', fallbackUsed: false, usedThinking: false, usedTools: false },
  systemPrompts: { prompts: [], totalTokens: 0, duplicateCount: 0 },
  features: { contributions: [] },
  contextWindow: { inputTokens: 176463, outputTokens: 500, contextWindowLimit: 200000, utilizationPercentage: 92, reservedOutputTokens: 8192, overflowDetected: false },
  costs: { inputCostUsd: 0, outputCostUsd: 0, totalCostUsd: 0, creditsUsed: 0 },
  truncation: { wasTruncated: false, originalMessageCount: 40, finalMessageCount: 40, truncatedMessageCount: 0, truncationPercentage: 0 },
  performance: { totalResponseTimeMs: 8000, firstTokenTimeMs: 1200 },
  anomalies,
  requestMetadata: { queryComplexity: 'contextual', historyMessageCount: 40, attachedFileCount: 1, mementoCount: 0, enabledFeatures: [] },
  tools: [], subagents: [],
};
const preFix = JSON.parse(JSON.stringify(telemetry));
preFix.anomalies.primaryAnomaly = 'none';
preFix.anomalies.dedupKey = 'none_claude-3-5-sonnet-20241022';
db.quests.insertMany([
  { sessionId: 'qa-seed-1456', timestamp: new Date(Date.now() - 60000), type: 'quest', prompt: '[qa] pre-fix', promptMeta: { contextTelemetry: preFix } },
  { sessionId: 'qa-seed-1456', timestamp: new Date(), type: 'quest', prompt: '[qa] post-fix', promptMeta: { contextTelemetry: telemetry } },
]);
```

9. Navigate to Sidebar -> Admin -> Context Inspector. Expected: both seeded rows appear in the default list. The `[qa] pre-fix` row shows the neutral benign indicator icon despite having a non-zero score; the `[qa] post-fix` row shows a low-severity indicator.
10. Set the Severity filter to `Low`. Expected: only the `[qa] post-fix` row remains. The `[qa] pre-fix` row disappears -- this is the reported bug, preserved here so the contrast is visible.
11. Reset Severity to `All`, then set the Anomaly Type filter to `High Utilization`. Expected: this option exists in the dropdown (it is new in this PR) and selecting it returns only the `[qa] post-fix` row.
12. Check the Severity Distribution stat card with the Severity filter cleared. Expected: the `low` count includes the `[qa] post-fix` row and excludes the `[qa] pre-fix` row.
13. Clean up with `db.quests.deleteMany({ sessionId: 'qa-seed-1456' })`. Expected: 2 documents deleted.

### Regression Checks

14. In the Anomaly Type filter, select each pre-existing option in turn: `Context Overflow`, `High Truncation`, `Tool Failure`, `Subagent Timeout`, `Slow Response`, `Multiple`. Expected: every option still selectable, the list reloads without console errors, and no option was removed.
15. Set the Severity filter to each of `Critical`, `High`, `Medium`, `Low`. Expected: the list and Severity Distribution card update without errors.
16. Clear all filters. Expected: the default list loads with the same rows it showed before this PR, since existing telemetry is not modified.
17. If the environment has an anomaly Slack alert configured, confirm alert titles for existing anomaly types still render in words, for example "Slow Response" rather than `slow_response`.

### What NOT to test

- Do not expect historical telemetry to change. The fix is forward-only with no backfill migration; rows written before this deploy keep whatever `primaryAnomaly` they were stored with, so an old turn in the 90-94.99% band will still be excluded from the severity filter. Only telemetry written by a completion running this code is classified with the new logic.
- Do not attempt to reach 90-94.99% utilization through normal chatting. It needs roughly 150k input tokens in one turn on a 200k-window model, which is why this band went unnoticed.
- No changes to chat, completions, model selection, billing, or any non-admin surface. There is no user-facing behaviour change outside the admin Context Inspector.
- The telemetry alert dry-run tool does not exercise this code path: it hand-writes its `anomalies` block rather than running `TelemetryBuilder`, so it cannot be used to verify this change.

## Additional Information

Alert-volume impact is nil. The reclassified single-cause turns score at or below 25 (`criticalUtilization` 25, `criticalTruncation` 20, `highUtilization` 10), all under the 30-point `ALERT_THRESHOLDS.warning` floor, so none of them ever triggered an alert. The `dedupKey` change for those turns only resets a short TTL suppression window in `AnomalyAlertService`.

The enum widening is safe at the persistence layer. `promptMeta.contextTelemetry` is stored as `Schema.Types.Mixed` on the Quest model and `TelemetryDryRunResultModel.primaryAnomaly` is a bare `String` with no Mongoose `enum` constraint, so no write can fail validation. The client hook types the field as `string`, so nothing breaks there either. `formatPrimaryAnomaly` uses a global regex and needs no change.

No `schemaVersion` bump. No field is added or removed and every pre-existing document still parses; only the value domain of one field widens. Bumping would ripple into `ContextTelemetrySchema` and the version assertion in `contextTelemetry.test.ts` for no reader benefit.

Two adjacent problems were found and deliberately left out of scope. `utilizationPercentage` is computed with two different denominators depending on which capture path writes it -- `contextLimit` on the hard-overflow throw path versus `maxSafeInputTokens` on the normal path -- which means a given percentage reading has two different meanings and quietly skews every utilization threshold. Separately, the admin list endpoint filters on `anomalies.anomalyScore` and `anomalies.primaryAnomaly` but the Quest model indexes neither. Happy to file both as follow-ups.

Unrelated repo hygiene note: the checklist item below links to `docs-site/docs/security/telemetry-data-classification.md`, which does not exist in the tree. Nothing here needed it -- this PR adds no telemetry field and collects no new data -- but the dead link is worth fixing in the template.

## Developer Notes (Optional)

- **Compiler-enforced invariant**: `Record<AnomalyCategory, boolean>` in `computeAnomalies` is load-bearing, not decorative. `AnomalyCategory` is `Exclude<PrimaryAnomaly, 'none' | 'multiple'>`, so adding a member to `PrimaryAnomalySchema` produces a compile error until that member is assigned a detection expression. This is the pattern worth reusing anywhere a derived classification must stay exhaustive against a schema enum -- the original bug existed precisely because the chain and the enum could drift silently.
- **Category layer as a concept**: separating "detection flags" from "classification categories" is what lets severity tiers of one condition (`critical*` and `high*`) collapse cleanly while still scoring independently. Any future anomaly that needs a warn and a critical tier should add one category and two flags, not two categories.
- **Test approach**: `TelemetryBuilder.test.ts` drives the public builder API (`setContextWindow`, `setTruncation`, `addTool`, `build`) rather than reaching into the private `computeAnomalies`, so the suite survives refactors of the internals. The parameterised equivalence sweep at the bottom is the durable guard: it asserts the property the issue is actually about rather than enumerating cases.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) -- N/A, no AdminSettings changes
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) -- one filter option added, consistent with the existing options
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) -- N/A, no user-facing behaviour or documented value list changes
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc -- N/A, no telemetry field added and no new data collected; this widens the value domain of an existing field
