### PR TITLE
fix(client): stop toasts from intercepting clicks on the UI beneath them (#1429)

### DIFF
--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -655,3 +655,25 @@ ul.custom-mentions-menu-upward > li[aria-selected="true"] {
     color: var(--joy-palette-text-primary, #1a1a1a);
   }
 }
+
+/*
+ * Toasts must never intercept clicks meant for the UI beneath them (#1429). The bottom-right Sonner
+ * toaster (z-index 999999999) overlapped the Data Lake wizard footer and swallowed "Start Upload"
+ * clicks for the few seconds a dedup toast was on screen: Sonner leaves the toaster and each toast at
+ * pointer-events: auto, so a toast <li> covering a button consumes the click with no feedback.
+ *
+ * Make the toaster and toast bodies click-through, and re-enable pointer events only on a toast's own
+ * controls so those stay usable. Trade-off: swipe-to-dismiss is lost (drag needs pointer events on the
+ * toast body); the close button and the auto-dismiss timer remain, and no toast in the app relies on a
+ * whole-body click.
+ */
+[data-sonner-toaster],
+[data-sonner-toast] {
+  pointer-events: none;
+}
+
+[data-sonner-toast] [data-button],
+[data-sonner-toast] [data-cancel],
+[data-sonner-toast] [data-close-button] {
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Description

The global bottom-right Sonner toaster (`z-index: 999999999`) leaves both the toaster and each toast at `pointer-events: auto`, so a transient toast rendered over a button **consumes the click**. In the Data Lake wizard this silently dropped **Start Upload** clicks for the ~5s a dedup toast ("Hashed N files for deduplication", "Found N duplicate files") sat over the footer — the button looked enabled but nothing happened and there was no feedback. Confirmed by the issue's hit-test: `document.elementFromPoint` at the button's centre returned `LI[data-sonner-toast]` for ~5s, then the button once the toast cleared.

## Fix

One CSS block in `apps/client/app/globals.css`:
- `[data-sonner-toaster]` and `[data-sonner-toast]` → `pointer-events: none` (toaster + toast bodies are click-through).
- `[data-sonner-toast] [data-button]` / `[data-cancel]` / `[data-close-button]` → `pointer-events: auto` (a toast's own controls stay clickable).

So notifications can never intercept a click meant for the UI beneath them, while their own buttons still work. This is a **global** fix, not wizard-specific — the same overlap could bite any action rendered in the toaster's corner.

**Trade-off / no-regression check:** the only behaviour lost is swipe-to-dismiss (drag needs pointer events on the toast body); the **close button and the auto-dismiss timer remain**. I grepped the app + core — no toast uses a whole-body `onClick` / action / `onDismiss`, so nothing that depends on toast-body interaction regresses.

## Guide for Testers

Repro (from the issue): Data Lakes → Create data lake → name it → Upload folder with ~20+ files (dedup toasts fire) → **Next** immediately → click **Start Upload** right away.

- **Before:** the click does nothing for ~5s (the toast eats it); works only after the toast fades.
- **After (expected):** **Start Upload** works immediately even with a toast on screen.

Definitive check (the issue's method): with a dedup toast visible over the footer, `document.elementFromPoint(<centre of [data-testid="wizard-start-upload-btn"]>)` should return the **button** (or an element beneath the toast), not `LI[data-sonner-toast]`.

### Regression checks
1. Toast **close button** (the `×`) still dismisses a toast.
2. Toasts still auto-dismiss on their timer; `richColors` styling unchanged.
3. Any other toast in the app still displays normally (this only changes pointer-events, not rendering).

### What NOT to test
- No behaviour change to what triggers toasts or their content — purely a pointer-events/layering fix.

## Verification

CSS-only change; there's no meaningful jsdom unit test for pointer-events hit-testing, so the authoritative verification is the live `elementFromPoint` check above on a preview (happy to run it via review-and-verify).

Closes #1429