### PR TITLE
fix(organizations): seed userDetails on every membership grant

### DIFF
--- a/apps/client/__tests__/team-manager.test.ts
+++ b/apps/client/__tests__/team-manager.test.ts
@@ -35,8 +35,10 @@ describe('organizationService.create - Team Manager Field', () => {
     mockOrganizationRepository = {
       create: vi.fn().mockImplementation(org => Promise.resolve({ ...org, id: 'org-created-123' })),
     };
+    // create() now resolves a provided billingOwnerId to a real user (to seed userDetails
+    // from the OWNER) and fails loud if it can't, so findById must return the billing owner.
     mockUserRepository = {
-      findById: vi.fn().mockResolvedValue(null),
+      findById: vi.fn().mockResolvedValue(mockBillingOwner),
       update: vi.fn().mockResolvedValue(null),
     };
   });

--- a/apps/client/pages/api/invites/[id]/__tests__/accept.test.ts
+++ b/apps/client/pages/api/invites/[id]/__tests__/accept.test.ts
@@ -41,6 +41,7 @@ vi.mock('@bike4mind/database', () => ({
   // accept.ts adapters + inviteManager's module-load imports
   inviteRepository: {},
   Organization: {},
+  organizationRepository: {},
   sessionRepository: {},
   projectRepository: {},
   fabFileRepository: { findById: tagMocks.fabFileFindById },

--- a/apps/client/pages/api/invites/[id]/accept.ts
+++ b/apps/client/pages/api/invites/[id]/accept.ts
@@ -4,7 +4,7 @@
 import { sharingService } from '@bike4mind/services';
 import {
   inviteRepository,
-  Organization,
+  organizationRepository,
   sessionRepository,
   projectRepository,
   fabFileRepository,
@@ -88,7 +88,7 @@ const handler = baseApi().post(async (req, res) => {
           projects: projectRepository,
           fabFiles: fabFileRepository,
           groups: Group,
-          organization: Organization,
+          organization: organizationRepository,
           users: userRepository,
         },
       }

--- a/b4m-core/common/src/types/entities/OrganizationTypes.ts
+++ b/b4m-core/common/src/types/entities/OrganizationTypes.ts
@@ -143,8 +143,21 @@ export interface IOrganizationRepository extends IBaseRepository<IOrganizationDo
   incrementCurrentStorage(organizationId: string, count: number): Promise<void>;
 
   /**
+   * Seed a zero-usage `userDetails` row for a member if absent (idempotent). Must be called wherever
+   * membership is granted so `userDetails[]` stays in sync with `users[]`: `updateUserDetails` uses a
+   * positional update that cannot create the row it positions on, so a member with no row tracks no
+   * usage and escapes `maxCreditsPerMember` entirely.
+   *
+   * @param organizationId - The ID of the organization
+   * @param member - The member identity to seed (id + email/name for the row's display fields)
+   */
+  ensureUserDetails(organizationId: string, member: { id: string; email?: string; name: string }): Promise<void>;
+
+  /**
    * Update a user's usage details within an organization.
    * Uses $inc for creditsDelta (atomic increment) and $set for lastCreditUsedAt.
+   * The caller must ensure the row exists first (see `ensureUserDetails`); the positional update
+   * cannot create a missing row and no-ops if one is absent.
    *
    * @param organizationId - The ID of the organization
    * @param userId - The ID of the user within the organization

--- a/b4m-core/common/src/types/entities/OrganizationTypes.ts
+++ b/b4m-core/common/src/types/entities/OrganizationTypes.ts
@@ -151,7 +151,7 @@ export interface IOrganizationRepository extends IBaseRepository<IOrganizationDo
    * @param organizationId - The ID of the organization
    * @param member - The member identity to seed (id + email/name for the row's display fields)
    */
-  ensureUserDetails(organizationId: string, member: { id: string; email?: string; name: string }): Promise<void>;
+  ensureUserDetails(organizationId: string, member: { id: string; email: string; name: string }): Promise<void>;
 
   /**
    * Update a user's usage details within an organization.

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -186,6 +186,7 @@ export const createMockOrganizationRepository = (): MockedObject<IOrganizationRe
     incrementCredits: vi.fn(),
     incrementCurrentStorage: vi.fn(),
     findByIdAndUserId: vi.fn(),
+    ensureUserDetails: vi.fn(),
     updateUserDetails: vi.fn(),
   });
 

--- a/b4m-core/services/src/cliCompletions.embedMetering.test.ts
+++ b/b4m-core/services/src/cliCompletions.embedMetering.test.ts
@@ -47,6 +47,7 @@ function buildDb() {
       organizations: {
         findById: vi.fn().mockResolvedValue(org),
         incrementCredits: vi.fn().mockResolvedValue({ ...org, currentCredits: org.currentCredits - 10 }),
+        ensureUserDetails: vi.fn().mockResolvedValue(undefined),
         updateUserDetails: vi.fn().mockResolvedValue(undefined),
       } as never,
     },

--- a/b4m-core/services/src/cliCompletions.orgBilling.test.ts
+++ b/b4m-core/services/src/cliCompletions.orgBilling.test.ts
@@ -135,6 +135,50 @@ describe('executeCompletion - org billing routing', () => {
     expect(mockSubtractCredits).not.toHaveBeenCalled();
   });
 
+  it('self-heals a missing userDetails row before recording org-billed usage', async () => {
+    // Org snapshot carries no row for the acting member (added before grant-point seeding existed).
+    // The positional $inc in updateUserDetails cannot create it, so without this self-heal their
+    // usage would never track and maxCreditsPerMember would never trip. Guards the deleteable
+    // `if (!member)` block in cliCompletions.
+    const { db, organizations } = buildDb();
+    db.users.findById = vi
+      .fn()
+      .mockResolvedValue({ id: 'user1', email: 'u1@example.com', username: 'u1', name: 'User One' });
+
+    await executeCompletion({ ...baseParams, db, billingOrganizationId: 'org1' });
+
+    expect(organizations.ensureUserDetails).toHaveBeenCalledWith('org1', {
+      id: 'user1',
+      email: 'u1@example.com',
+      name: 'User One',
+    });
+    expect(organizations.updateUserDetails).toHaveBeenCalledWith(
+      'org1',
+      'user1',
+      expect.objectContaining({ creditsDelta: 10 })
+    );
+  });
+
+  it('does not self-heal when the member already has a userDetails row', async () => {
+    const { db, organizations } = buildDb({
+      org: {
+        id: 'org1',
+        currentCredits: 500,
+        maxCreditsPerMember: null,
+        userDetails: [{ id: 'user1', usedCredits: 0 }],
+      },
+    });
+
+    await executeCompletion({ ...baseParams, db, billingOrganizationId: 'org1' });
+
+    expect(organizations.ensureUserDetails).not.toHaveBeenCalled();
+    expect(organizations.updateUserDetails).toHaveBeenCalledWith(
+      'org1',
+      'user1',
+      expect.objectContaining({ creditsDelta: 10 })
+    );
+  });
+
   it('rejects when the org member credit cap would be exceeded', async () => {
     const { db } = buildDb({
       org: {

--- a/b4m-core/services/src/cliCompletions.orgBilling.test.ts
+++ b/b4m-core/services/src/cliCompletions.orgBilling.test.ts
@@ -41,6 +41,7 @@ function buildDb(overrides: { org?: any } = {}) {
   const organizations = {
     findById: vi.fn().mockResolvedValue(org),
     incrementCredits: vi.fn().mockResolvedValue({ ...org, currentCredits: org.currentCredits - 10 }),
+    ensureUserDetails: vi.fn().mockResolvedValue(undefined),
     updateUserDetails: vi.fn().mockResolvedValue(undefined),
   };
   const usageEvents = { record: vi.fn().mockResolvedValue(undefined) };

--- a/b4m-core/services/src/cliCompletions.serverTools.test.ts
+++ b/b4m-core/services/src/cliCompletions.serverTools.test.ts
@@ -42,6 +42,7 @@ function buildDb() {
   const organizations = {
     findById: vi.fn().mockResolvedValue(org),
     incrementCredits: vi.fn().mockResolvedValue({ ...org, currentCredits: 490 }),
+    ensureUserDetails: vi.fn().mockResolvedValue(undefined),
     updateUserDetails: vi.fn().mockResolvedValue(undefined),
   };
   const usageEvents = { record: vi.fn().mockResolvedValue(undefined) };

--- a/b4m-core/services/src/cliCompletions.ts
+++ b/b4m-core/services/src/cliCompletions.ts
@@ -554,6 +554,22 @@ export async function executeCompletion(params: CompletionParams): Promise<void>
         // together: a null holder fetch skips both, never advancing usedCredits
         // without a matching transaction.
         if (billToOrg) {
+          // Self-heal a member with no `userDetails` row (added before grant-point seeding existed):
+          // the positional $inc in updateUserDetails cannot create the row it positions on, so without
+          // this their org-billed usage is never tracked and `maxCreditsPerMember` never trips. Only
+          // pays the extra read/write when the row is actually absent.
+          const member = organization!.userDetails?.find(u => u.id === userId);
+          if (!member) {
+            const actingUser = await db.users.findById(userId);
+            if (actingUser) {
+              await db.organizations!.ensureUserDetails(holderId, {
+                id: userId,
+                email: actingUser.email ?? actingUser.username,
+                name: actingUser.name,
+              });
+            }
+          }
+
           await db.organizations!.updateUserDetails(holderId, userId, {
             creditsDelta: actualCredits,
             lastCreditUsedAt: new Date(),

--- a/b4m-core/services/src/creditService/deductCreditsWithOrgSupport.test.ts
+++ b/b4m-core/services/src/creditService/deductCreditsWithOrgSupport.test.ts
@@ -21,6 +21,8 @@ const mockSubtractCredits = vi.mocked(subtractCredits);
 describe('creditService - deductCreditsWithOrgSupport', () => {
   const mockUser = {
     id: 'user1',
+    name: 'Test User',
+    email: 'user1@example.com',
     currentCredits: 100,
   } as IUserDocument;
 
@@ -149,6 +151,9 @@ describe('creditService - deductCreditsWithOrgSupport', () => {
         lastCreditUsedAt: expect.any(Date),
       });
 
+      // Member already has a userDetails row, so no self-heal seed is issued.
+      expect(mockOrgRepo.ensureUserDetails).not.toHaveBeenCalled();
+
       expect(mockSubtractCredits).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'text_generation_usage',
@@ -169,7 +174,7 @@ describe('creditService - deductCreditsWithOrgSupport', () => {
       );
     });
 
-    it('should call updateUserDetails even when user has no existing entry (repo handles warning)', async () => {
+    it('self-heals a missing userDetails row before incrementing, so the positional $inc lands (#1460)', async () => {
       const orgWithoutUser = {
         id: 'org1',
         currentCredits: 500,
@@ -188,7 +193,13 @@ describe('creditService - deductCreditsWithOrgSupport', () => {
 
       await deductCreditsWithOrgSupport(params, mockAdapters);
 
-      // Should still call updateUserDetails - the repo layer handles the no-match warning
+      // The member has no row, so seed one first - otherwise the positional $inc below no-ops and
+      // the spend (and the cap) never track for them.
+      expect(mockOrgRepo.ensureUserDetails).toHaveBeenCalledWith('org1', {
+        id: 'user1',
+        email: 'user1@example.com',
+        name: 'Test User',
+      });
       expect(mockOrgRepo.updateUserDetails).toHaveBeenCalledWith('org1', 'user1', {
         creditsDelta: 50,
         lastCreditUsedAt: expect.any(Date),

--- a/b4m-core/services/src/creditService/deductCreditsWithOrgSupport.ts
+++ b/b4m-core/services/src/creditService/deductCreditsWithOrgSupport.ts
@@ -161,12 +161,13 @@ export async function deductCreditsWithOrgSupport(
   let creditHolderMethods: ICreditHolderMethods = adapters.db.users;
 
   if (organization) {
+    const memberDetails = organization.userDetails?.find(u => u.id === user.id);
+
     // Enforce per-member credit cap if configured
     // NOTE: Known TOCTOU - pre-check and atomic increment are separate operations.
     // A concurrent request can exceed the limit by one. Accepted: window is tiny, stakes are low.
     if (organization.maxCreditsPerMember != null) {
-      const userDetails = organization.userDetails?.find(u => u.id === user.id);
-      const usedCredits = userDetails?.usedCredits ?? 0;
+      const usedCredits = memberDetails?.usedCredits ?? 0;
       if (usedCredits + credits > organization.maxCreditsPerMember) {
         throw new BadRequestError('Organization member credit limit reached');
       }
@@ -175,6 +176,18 @@ export async function deductCreditsWithOrgSupport(
     ownerId = organization.id;
     ownerType = CreditHolderType.Organization;
     creditHolderMethods = adapters.db.organizations;
+
+    // Self-heal a member with no `userDetails` row - one added before grant-point seeding existed
+    // (see `ensureUserDetails`). The positional $inc below cannot create a missing row, so without
+    // this their usage is never tracked and `maxCreditsPerMember` never trips for them. Idempotent
+    // and only writes when the row is actually absent, so already-tracked members pay nothing extra.
+    if (!memberDetails) {
+      await adapters.db.organizations.ensureUserDetails(organization.id, {
+        id: user.id,
+        email: user.email ?? user.username,
+        name: user.name,
+      });
+    }
 
     // Atomically increment per-user usage tracking within the organization.
     // Uses $inc to avoid race conditions with concurrent requests.

--- a/b4m-core/services/src/organizationService/addMember.test.ts
+++ b/b4m-core/services/src/organizationService/addMember.test.ts
@@ -266,4 +266,35 @@ describe('addMember', () => {
       users: [{ userId: 'user-id', permissions: [Permission.read] }],
     });
   });
+
+  describe('userDetails seeding (#1460)', () => {
+    it('seeds a zero-usage userDetails row for a newly added member', async () => {
+      mockAdapters.db.users.findById.mockResolvedValue(mockUser);
+      mockAdapters.db.organizations.shareable.findAccessibleById.mockResolvedValue(cloneDeep(mockOrganization));
+
+      const result = await addMember(mockOwnerUser, { userId: 'user-id', organizationId: 'org-id' }, mockAdapters);
+
+      expect(result.organization.userDetails).toEqual([
+        { id: 'user-id', email: 'test@example.com', name: 'Test User', usedCredits: 0, lastCreditUsedAt: null },
+      ]);
+    });
+
+    it('does not duplicate the row when the member already has one (re-add)', async () => {
+      mockAdapters.db.users.findById.mockResolvedValue(mockUser);
+      mockAdapters.db.organizations.shareable.findAccessibleById.mockResolvedValue({
+        ...cloneDeep(mockOrganization),
+        users: [{ userId: 'user-id', permissions: [] }],
+        userDetails: [
+          { id: 'user-id', email: 'test@example.com', name: 'Test User', usedCredits: 42, lastCreditUsedAt: null },
+        ],
+      });
+
+      const result = await addMember(mockOwnerUser, { userId: 'user-id', organizationId: 'org-id' }, mockAdapters);
+
+      // Existing usage is preserved (not reset to 0) and the row is not duplicated.
+      expect(result.organization.userDetails).toEqual([
+        { id: 'user-id', email: 'test@example.com', name: 'Test User', usedCredits: 42, lastCreditUsedAt: null },
+      ]);
+    });
+  });
 });

--- a/b4m-core/services/src/organizationService/addMember.test.ts
+++ b/b4m-core/services/src/organizationService/addMember.test.ts
@@ -44,6 +44,7 @@ describe('addMember', () => {
         organizations: {
           findById: vi.fn(),
           update: vi.fn(),
+          ensureUserDetails: vi.fn(),
           shareable: {
             findAccessibleById: vi.fn(),
           },
@@ -195,8 +196,10 @@ describe('addMember', () => {
       },
       user: mockUser,
     });
+    // Targeted write: only users[] is persisted, never the whole document (which would carry a stale
+    // userDetails snapshot able to clobber a concurrent credit increment).
     expect(mockAdapters.db.organizations.update).toHaveBeenCalledWith({
-      ...mockOrganization,
+      id: 'org-id',
       users: [{ userId: 'user-id', permissions: [Permission.read] }],
     });
   });
@@ -262,24 +265,29 @@ describe('addMember', () => {
       user: mockUser,
     });
     expect(mockAdapters.db.organizations.update).toHaveBeenCalledWith({
-      ...mockOrganization,
+      id: 'org-id',
       users: [{ userId: 'user-id', permissions: [Permission.read] }],
     });
   });
 
   describe('userDetails seeding (#1460)', () => {
-    it('seeds a zero-usage userDetails row for a newly added member', async () => {
+    it('seeds the per-member credit row via the atomic ensureUserDetails primitive', async () => {
       mockAdapters.db.users.findById.mockResolvedValue(mockUser);
       mockAdapters.db.organizations.shareable.findAccessibleById.mockResolvedValue(cloneDeep(mockOrganization));
 
-      const result = await addMember(mockOwnerUser, { userId: 'user-id', organizationId: 'org-id' }, mockAdapters);
+      await addMember(mockOwnerUser, { userId: 'user-id', organizationId: 'org-id' }, mockAdapters);
 
-      expect(result.organization.userDetails).toEqual([
-        { id: 'user-id', email: 'test@example.com', name: 'Test User', usedCredits: 0, lastCreditUsedAt: null },
-      ]);
+      // Seeded through the guarded $push, NOT pushed into the whole-doc write - so it can never
+      // clobber a concurrent credit increment. Idempotency is the primitive's own guarantee
+      // (see OrganizationModel.integration.test.ts), so addMember calls it unconditionally.
+      expect(mockAdapters.db.organizations.ensureUserDetails).toHaveBeenCalledWith('org-id', {
+        id: 'user-id',
+        email: 'test@example.com',
+        name: 'Test User',
+      });
     });
 
-    it('does not duplicate the row when the member already has one (re-add)', async () => {
+    it('never carries userDetails through the whole-doc write', async () => {
       mockAdapters.db.users.findById.mockResolvedValue(mockUser);
       mockAdapters.db.organizations.shareable.findAccessibleById.mockResolvedValue({
         ...cloneDeep(mockOrganization),
@@ -289,12 +297,17 @@ describe('addMember', () => {
         ],
       });
 
-      const result = await addMember(mockOwnerUser, { userId: 'user-id', organizationId: 'org-id' }, mockAdapters);
+      await addMember(mockOwnerUser, { userId: 'user-id', organizationId: 'org-id' }, mockAdapters);
 
-      // Existing usage is preserved (not reset to 0) and the row is not duplicated.
-      expect(result.organization.userDetails).toEqual([
-        { id: 'user-id', email: 'test@example.com', name: 'Test User', usedCredits: 42, lastCreditUsedAt: null },
-      ]);
+      // The persisted document update is scoped to users[] only; a stale userDetails snapshot
+      // (usedCredits: 42 here) is never $set back over a possibly-newer value.
+      const updateArg = mockAdapters.db.organizations.update.mock.calls[0][0];
+      expect(updateArg).not.toHaveProperty('userDetails');
+      expect(mockAdapters.db.organizations.ensureUserDetails).toHaveBeenCalledWith('org-id', {
+        id: 'user-id',
+        email: 'test@example.com',
+        name: 'Test User',
+      });
     });
   });
 });

--- a/b4m-core/services/src/organizationService/addMember.ts
+++ b/b4m-core/services/src/organizationService/addMember.ts
@@ -55,22 +55,21 @@ export async function addMember(user: IUserDocument, parameters: AddMemberParame
     organization.users.push({ userId: userToAdd.id, permissions: [Permission.read] });
   }
 
-  // Seed the per-member credit side-table in the same write so `users[]` and `userDetails[]` stay in
-  // sync at the grant point. Without a row, `updateUserDetails`'s positional $inc no-ops and the member
-  // escapes `maxCreditsPerMember` entirely (reads as 0 spend forever). Guarded so a re-add never
-  // duplicates a row - and so it also backfills an existing member who predates this seeding.
-  organization.userDetails ||= [];
-  if (!organization.userDetails.some(detail => detail.id === userToAdd.id)) {
-    organization.userDetails.push({
-      id: userToAdd.id,
-      email: userToAdd.email ?? userToAdd.username,
-      name: userToAdd.name,
-      usedCredits: 0,
-      lastCreditUsedAt: null,
-    });
-  }
+  // Persist ONLY the users[] edit with a targeted write. A whole-document write would $set the entire
+  // userDetails array from this stale snapshot and could revert a concurrent credit increment
+  // (updateUserDetails' atomic positional $inc), defeating the very cap this seeding enables.
+  await db.organizations.update({ id: organization.id, users: organization.users });
 
-  await db.organizations.update(organization);
+  // Seed the per-member credit side-table so `users[]` and `userDetails[]` stay in sync at the grant
+  // point. Without a row, `updateUserDetails`'s positional $inc no-ops and the member escapes
+  // `maxCreditsPerMember` entirely (reads as 0 spend forever). ensureUserDetails is an idempotent
+  // guarded $push: a re-add never duplicates, and an existing member who predates this seeding is
+  // backfilled - all as a targeted atomic op, never a whole-doc overwrite.
+  await db.organizations.ensureUserDetails(organizationId, {
+    id: userToAdd.id,
+    email: userToAdd.email ?? userToAdd.username,
+    name: userToAdd.name,
+  });
 
   // Establish org membership on the user document. Org-scoped features (e.g.
   // data-lake AccessContext) read user.organizationId; without this, members

--- a/b4m-core/services/src/organizationService/addMember.ts
+++ b/b4m-core/services/src/organizationService/addMember.ts
@@ -55,6 +55,21 @@ export async function addMember(user: IUserDocument, parameters: AddMemberParame
     organization.users.push({ userId: userToAdd.id, permissions: [Permission.read] });
   }
 
+  // Seed the per-member credit side-table in the same write so `users[]` and `userDetails[]` stay in
+  // sync at the grant point. Without a row, `updateUserDetails`'s positional $inc no-ops and the member
+  // escapes `maxCreditsPerMember` entirely (reads as 0 spend forever). Guarded so a re-add never
+  // duplicates a row - and so it also backfills an existing member who predates this seeding.
+  organization.userDetails ||= [];
+  if (!organization.userDetails.some(detail => detail.id === userToAdd.id)) {
+    organization.userDetails.push({
+      id: userToAdd.id,
+      email: userToAdd.email ?? userToAdd.username,
+      name: userToAdd.name,
+      usedCredits: 0,
+      lastCreditUsedAt: null,
+    });
+  }
+
   await db.organizations.update(organization);
 
   // Establish org membership on the user document. Org-scoped features (e.g.

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.test.ts
@@ -20,6 +20,7 @@ describe('applyPartnerRuleMembership', () => {
         findById: vi.fn(),
         addMemberRaisingSeats: vi.fn(),
         addMemberIfUnderCeiling: vi.fn(),
+        ensureUserDetails: vi.fn(),
       },
     };
     logger = { info: vi.fn() };
@@ -42,6 +43,13 @@ describe('applyPartnerRuleMembership', () => {
     });
     expect(db.organizations.addMemberIfUnderCeiling).not.toHaveBeenCalled();
     expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
+    // The atomic seat-add touches only users[]; seed the credit side-table so the new member is
+    // tracked and subject to maxCreditsPerMember (#1460).
+    expect(db.organizations.ensureUserDetails).toHaveBeenCalledWith('org-id', {
+      id: 'user-id',
+      email: 'test@partner.com',
+      name: 'Test User',
+    });
   });
 
   it('raises the seat ceiling to admit a user at capacity instead of rejecting (#1239)', async () => {
@@ -164,6 +172,13 @@ describe('applyPartnerRuleMembership', () => {
     expect(result).toEqual({ added: false, reason: 'already-member' });
     expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
     expect(db.users.update).not.toHaveBeenCalled();
+    // Even for an existing member this backfills a missing credit row (idempotent), which is how
+    // members added before grant-point seeding get healed on their next signup/verify (#1460).
+    expect(db.organizations.ensureUserDetails).toHaveBeenCalledWith('org-id', {
+      id: 'user-id',
+      email: 'test@partner.com',
+      name: 'Test User',
+    });
   });
 
   it('repairs a half-set membership: in users[] but organizationId unset', async () => {
@@ -175,6 +190,11 @@ describe('applyPartnerRuleMembership', () => {
     expect(result).toEqual({ added: false, reason: 'already-member' });
     expect(db.organizations.addMemberRaisingSeats).not.toHaveBeenCalled();
     expect(db.users.update).toHaveBeenCalledWith({ id: 'user-id', organizationId: 'org-id' });
+    expect(db.organizations.ensureUserDetails).toHaveBeenCalledWith('org-id', {
+      id: 'user-id',
+      email: 'test@partner.com',
+      name: 'Test User',
+    });
   });
 
   it('reports already-member (and repairs the pointer) when the atomic add loses a race', async () => {

--- a/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
+++ b/b4m-core/services/src/organizationService/applyPartnerRuleMembership.ts
@@ -72,8 +72,11 @@ export async function applyPartnerRuleMembership(
   const alreadyMember = organization.users.some(u => u.userId === userId);
   if (alreadyMember) {
     // Repair a half-set membership (in the ACL but organizationId never set) without
-    // touching the org. Partial update so no other user field is disturbed.
+    // touching the org. Partial update so no other user field is disturbed. Also seed the
+    // credit side-table: an existing member added before grant-point seeding has no
+    // `userDetails` row, so this re-run (every signup/verify) backfills it - idempotent.
     await repairOrgPointer(user, userId, organizationId, db);
+    await seedUserDetails(user, organizationId, db);
     return { added: false, reason: 'already-member' };
   }
 
@@ -90,6 +93,7 @@ export async function applyPartnerRuleMembership(
       if (outcome.state === 'gone') return { added: false, reason: 'org-missing' };
       if (outcome.state === 'member') {
         await repairOrgPointer(user, userId, organizationId, db);
+        await seedUserDetails(user, organizationId, db);
         return { added: false, reason: 'already-member' };
       }
       logger?.info(
@@ -99,6 +103,7 @@ export async function applyPartnerRuleMembership(
       return { added: false, reason: 'at-capacity', seats: outcome.seats };
     }
     await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
+    await seedUserDetails(user, organizationId, db);
     logger?.info(
       `Partner-rule auto-added user ${userId} to Stripe-billed org ${organizationId} under the existing ceiling`
     );
@@ -113,8 +118,10 @@ export async function applyPartnerRuleMembership(
     const outcome = await inspectAfterNoMatch(organizationId, userId, db);
     if (outcome.state === 'gone') return { added: false, reason: 'org-missing' };
     if (outcome.state === 'member') {
-      // A concurrent signup won the race and already added this user - a safe no-op; repair the pointer.
+      // A concurrent signup won the race and already added this user - a safe no-op; repair the
+      // pointer and seed the credit side-table (idempotent) so a race can't drop the member's row.
       await repairOrgPointer(user, userId, organizationId, db);
+      await seedUserDetails(user, organizationId, db);
       return { added: false, reason: 'already-member' };
     }
     // 'absent': the raise is now clamped at ORGANIZATION_SUBSCRIPTION_MAX_SEATS (#1424), so a full org
@@ -128,6 +135,7 @@ export async function applyPartnerRuleMembership(
   }
 
   await db.users.update({ id: userId, organizationId } as Partial<IUserDocument>);
+  await seedUserDetails(user, organizationId, db);
 
   const previousSeats = pre.seats;
   // Mirror the model's `$max($seats, $size(users) + 1)`: the pre-image `users` is the pre-add array,
@@ -147,6 +155,23 @@ export async function applyPartnerRuleMembership(
     previousSeats,
     newSeats,
   };
+}
+
+/**
+ * Seed the member's zero-usage `userDetails` row (idempotent). Mirrors `addMember` / `accept`: the
+ * atomic seat-add pipelines here touch only `users[]`, so `userDetails[]` must be seeded separately
+ * to keep the two in sync at the grant point (see `ensureUserDetails`).
+ */
+async function seedUserDetails(
+  user: IUserDocument,
+  organizationId: string,
+  db: ApplyPartnerRuleMembershipAdapters['db']
+): Promise<void> {
+  await db.organizations.ensureUserDetails(organizationId, {
+    id: user.id,
+    email: user.email ?? user.username,
+    name: user.name,
+  });
 }
 
 /** Set the user's org pointer if unset - a partial update so no other user field is disturbed. */

--- a/b4m-core/services/src/organizationService/create.test.ts
+++ b/b4m-core/services/src/organizationService/create.test.ts
@@ -213,7 +213,12 @@ describe('organizationService - create', () => {
     });
 
     it('sets the org context on the billing owner (loaded) when billingOwnerId differs from the caller', async () => {
-      mockAdapters.db.users.findById.mockResolvedValue({ id: 'owner2', organizationId: undefined });
+      mockAdapters.db.users.findById.mockResolvedValue({
+        id: 'owner2',
+        name: 'Owner Two',
+        email: 'owner2@example.com',
+        organizationId: undefined,
+      });
       await create(
         mockUser as IUserDocument,
         { name: 'Test Organization', personal: false, seats: 1, stripeCustomerId: null, billingOwnerId: 'owner2' },
@@ -224,13 +229,69 @@ describe('organizationService - create', () => {
     });
 
     it('leaves an on-behalf owner untouched when they already have an active org', async () => {
-      mockAdapters.db.users.findById.mockResolvedValue({ id: 'owner2', organizationId: 'owner2-org' });
+      mockAdapters.db.users.findById.mockResolvedValue({
+        id: 'owner2',
+        name: 'Owner Two',
+        email: 'owner2@example.com',
+        organizationId: 'owner2-org',
+      });
       await create(
         mockUser as IUserDocument,
         { name: 'Test Organization', personal: false, seats: 1, stripeCustomerId: null, billingOwnerId: 'owner2' },
         mockAdapters
       );
       expect(mockAdapters.db.users.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('userDetails seeding at create (#1460)', () => {
+    it('seeds the credit side-table for the acting user when no billingOwnerId is given', async () => {
+      await create(
+        mockUser as IUserDocument,
+        { name: 'Test Organization', personal: false, seats: 1, stripeCustomerId: null },
+        mockAdapters
+      );
+      expect(mockAdapters.db.organizations.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userDetails: [
+            { id: 'user1', email: 'test@example.com', name: 'Test User', usedCredits: 0, lastCreditUsedAt: null },
+          ],
+        })
+      );
+    });
+
+    it('seeds the credit side-table for the resolved billing owner, not the acting caller', async () => {
+      mockAdapters.db.users.findById.mockResolvedValue({
+        id: 'owner2',
+        name: 'Owner Two',
+        email: 'owner2@example.com',
+        organizationId: undefined,
+      });
+      await create(
+        mockUser as IUserDocument,
+        { name: 'Test Organization', personal: false, seats: 1, stripeCustomerId: null, billingOwnerId: 'owner2' },
+        mockAdapters
+      );
+      expect(mockAdapters.db.organizations.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'owner2',
+          userDetails: [
+            { id: 'owner2', email: 'owner2@example.com', name: 'Owner Two', usedCredits: 0, lastCreditUsedAt: null },
+          ],
+        })
+      );
+    });
+
+    it('throws when an explicit billingOwnerId cannot be resolved to a user', async () => {
+      mockAdapters.db.users.findById.mockResolvedValue(null);
+      await expect(
+        create(
+          mockUser as IUserDocument,
+          { name: 'Test Organization', personal: false, seats: 1, stripeCustomerId: null, billingOwnerId: 'ghost' },
+          mockAdapters
+        )
+      ).rejects.toThrow(/Billing owner ghost not found/);
+      expect(mockAdapters.db.organizations.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/b4m-core/services/src/organizationService/create.ts
+++ b/b4m-core/services/src/organizationService/create.ts
@@ -1,5 +1,5 @@
 import { IOrganizationDocument, IOrganizationRepository, IUserDocument, IUserRepository } from '@bike4mind/common';
-import { secureParameters } from '@bike4mind/utils';
+import { secureParameters, NotFoundError } from '@bike4mind/utils';
 import { z } from 'zod';
 
 const createSchema = z.object({
@@ -32,6 +32,16 @@ export const create = async (user: IUserDocument, params: CreateParameters, adap
     throw new Error('Manager cannot be the same as the billing owner');
   }
 
+  // Resolve the billing owner up front so the seeded `userDetails` row (and the active-org
+  // pointer below) both describe the OWNER, not the acting caller: on an on-behalf create
+  // (`POST /api/organizations` with an explicit `billingOwnerId`) the admin issuing the call
+  // is not the member whose usage the org tracks. A provided-but-unresolvable owner is a broken
+  // request - the org's `userId` would point at a non-existent user - so fail loudly.
+  const owner = billingOwnerId === user.id ? user : await adapters.db.users.findById(billingOwnerId);
+  if (!owner) {
+    throw new NotFoundError(`Billing owner ${billingOwnerId} not found`);
+  }
+
   const buildOrganization: Omit<IOrganizationDocument, 'id'> = {
     ...validatedParams,
 
@@ -46,11 +56,14 @@ export const create = async (user: IUserDocument, params: CreateParameters, adap
     users: [],
     seats: validatedParams.seats,
     billingContact: user.email!,
+    // Seed the credit side-table for the billing OWNER (not the acting caller), so an on-behalf
+    // create tracks the member the org actually bills. Keep in sync with `users[]` at every grant
+    // point (see `ensureUserDetails`).
     userDetails: [
       {
-        id: user.id,
-        email: user.email ?? user.username,
-        name: user.name,
+        id: owner.id,
+        email: owner.email ?? owner.username,
+        name: owner.name,
         usedCredits: 0,
         lastCreditUsedAt: null,
       },
@@ -81,8 +94,7 @@ export const create = async (user: IUserDocument, params: CreateParameters, adap
   // own owner, so they cannot undo it themselves. Do NOT "fix" that by gating this write on the org
   // being funded: that reintroduces #1388 for unfunded-org owners. The fields need separating; see
   // #1428.
-  const owner = billingOwnerId === user.id ? user : await adapters.db.users.findById(billingOwnerId);
-  if (owner && !owner.organizationId) {
+  if (!owner.organizationId) {
     // Best-effort, and intentionally NOT fatal: the org is already committed (there is no surrounding
     // transaction at every call site), so letting a failed pointer write bubble would 500 a create
     // that actually succeeded and leave the owner in exactly the no-active-org state this repairs.

--- a/b4m-core/services/src/sharingService/accept.test.ts
+++ b/b4m-core/services/src/sharingService/accept.test.ts
@@ -15,7 +15,7 @@ describe('sharingService - acceptInvite (Organization)', () => {
       projects: { findById: Mock; update: Mock };
       fabFiles: { findById: Mock; update: Mock; findAllByIds: Mock };
       groups: { findById: Mock };
-      organization: { findById: Mock; update: Mock };
+      organization: { findById: Mock; update: Mock; ensureUserDetails: Mock };
       users: { findById: Mock; update: Mock };
     };
   };
@@ -56,7 +56,7 @@ describe('sharingService - acceptInvite (Organization)', () => {
         projects: { findById: vi.fn(), update: vi.fn() },
         fabFiles: { findById: vi.fn(), update: vi.fn(), findAllByIds: vi.fn() },
         groups: { findById: vi.fn() },
-        organization: { findById: vi.fn(), update: vi.fn() },
+        organization: { findById: vi.fn(), update: vi.fn(), ensureUserDetails: vi.fn() },
         users: { findById: vi.fn(), update: vi.fn() },
       },
     };
@@ -73,19 +73,51 @@ describe('sharingService - acceptInvite (Organization)', () => {
     expect(mockAdapters.db.users.update).toHaveBeenCalledWith(expect.objectContaining({ id: userId, organizationId }));
   });
 
-  it('adds the user to the organization users and userDetails arrays', async () => {
+  it('adds the user to the organization users[] via a targeted write and seeds the credit row atomically', async () => {
     mockAdapters.db.users.findById.mockResolvedValue(makeUser());
     mockAdapters.db.invites.findById.mockResolvedValue(makeInvite());
     mockAdapters.db.organization.findById.mockResolvedValue(makeOrganization());
 
     await acceptInvite(userId, { id: inviteId }, mockAdapters as any);
 
-    expect(mockAdapters.db.organization.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        users: expect.arrayContaining([expect.objectContaining({ userId, permissions: [Permission.read] })]),
-        userDetails: expect.arrayContaining([expect.objectContaining({ id: userId, email: 'member@example.com' })]),
+    // users[] persisted through a targeted write - never the whole document (which would $set a
+    // stale userDetails snapshot able to clobber a concurrent credit increment).
+    const updateArg = mockAdapters.db.organization.update.mock.calls[0][0];
+    expect(updateArg).toEqual({
+      id: organizationId,
+      users: expect.arrayContaining([expect.objectContaining({ userId, permissions: [Permission.read] })]),
+    });
+    expect(updateArg).not.toHaveProperty('userDetails');
+
+    // Credit side-table seeded through the idempotent guarded $push, not an unconditional push.
+    expect(mockAdapters.db.organization.ensureUserDetails).toHaveBeenCalledWith(organizationId, {
+      id: userId,
+      email: 'member@example.com',
+      name: 'Member',
+    });
+  });
+
+  it('seeds the credit row via ensureUserDetails so a re-accept cannot create a duplicate row', async () => {
+    // The old path did `userDetails.push(...)` unconditionally, so re-accepting an invite for an org
+    // the member already had a row in produced a second phantom row. Routing through the guarded
+    // primitive is what makes the seed idempotent - mirrors the Group double-accept guard below.
+    mockAdapters.db.users.findById.mockResolvedValue(makeUser());
+    mockAdapters.db.invites.findById.mockResolvedValue(makeInvite());
+    mockAdapters.db.organization.findById.mockResolvedValue(
+      makeOrganization({
+        userDetails: [{ id: userId, email: 'member@example.com', name: 'Member', usedCredits: 7 }],
       })
     );
+
+    await acceptInvite(userId, { id: inviteId }, mockAdapters as any);
+
+    expect(mockAdapters.db.organization.ensureUserDetails).toHaveBeenCalledWith(organizationId, {
+      id: userId,
+      email: 'member@example.com',
+      name: 'Member',
+    });
+    // No raw push into the persisted document.
+    expect(mockAdapters.db.organization.update.mock.calls[0][0]).not.toHaveProperty('userDetails');
   });
 
   it('updates the organization before persisting the user (membership is fully provisioned)', async () => {

--- a/b4m-core/services/src/sharingService/accept.ts
+++ b/b4m-core/services/src/sharingService/accept.ts
@@ -38,7 +38,8 @@ interface AcceptInviteAdapters {
     };
     organization: {
       findById: (id: string) => Promise<IOrganizationDocument | null>;
-      update: (data: IOrganizationDocument) => Promise<unknown>;
+      update: (data: Partial<IOrganizationDocument>) => Promise<unknown>;
+      ensureUserDetails: (organizationId: string, member: { id: string; email: string; name: string }) => Promise<void>;
     };
     users: {
       findById: (id: string) => Promise<IUserDocument | null>;
@@ -201,17 +202,19 @@ const acceptOrganization = async (
   }
 
   pushShareable(organization, { userId: user.id, permissions });
-  organization.userDetails ||= [];
 
-  organization.userDetails.push({
+  // Persist ONLY the users[] edit with a targeted write. A whole-document write would $set the entire
+  // userDetails array from this stale snapshot and could revert a concurrent credit increment
+  // (updateUserDetails' atomic positional $inc); see organizationService/addMember.
+  await db.organization.update({ id: organization.id, users: organization.users });
+
+  // Seed the credit side-table via the idempotent guarded $push - keeps users[]/userDetails[] in sync
+  // and, unlike the previous unconditional push, never creates a duplicate row on a re-accept.
+  await db.organization.ensureUserDetails(organizationId, {
     id: user.id,
     email: user.email ?? user.username,
     name: user.name,
-    usedCredits: 0,
-    lastCreditUsedAt: null,
   });
-
-  await db.organization.update(organization);
 
   // Establish full membership on the user document. Without this, the accepting
   // user's `organizationId` stays null and every org-scoped feature that reads

--- a/packages/database/src/models/infra/admin/OrganizationModel.integration.test.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import mongoose from 'mongoose';
 import { createMongoServer } from '../../../__test__/createMongoServer';
-import { Organization } from './OrganizationModel';
+import { Organization, organizationRepository } from './OrganizationModel';
 
 /**
  * Round-trip guard for the org-groups #1172 fields. `adminUserIds` is load-bearing for
@@ -44,5 +44,69 @@ describe('OrganizationModel - org-groups fields', () => {
     const reloaded = await Organization.findById(created.id);
     expect(reloaded?.adminUserIds).toEqual([]);
     expect(reloaded?.allowedGroupTypes).toEqual([]);
+  });
+});
+
+describe('OrganizationModel - ensureUserDetails (#1460)', () => {
+  it('seeds a zero-usage row for a member that has none', async () => {
+    const org = await Organization.create({ name: 'Acme', userId: 'owner-1', personal: false, userDetails: [] });
+
+    await organizationRepository.ensureUserDetails(org.id, {
+      id: 'member-1',
+      email: 'member1@example.com',
+      name: 'Member One',
+    });
+
+    const reloaded = await Organization.findById(org.id);
+    expect(reloaded?.userDetails).toHaveLength(1);
+    expect(reloaded?.userDetails?.[0]).toMatchObject({
+      id: 'member-1',
+      email: 'member1@example.com',
+      name: 'Member One',
+      usedCredits: 0,
+      lastCreditUsedAt: null,
+    });
+  });
+
+  it('is idempotent and never overwrites an existing row (preserves usedCredits)', async () => {
+    const org = await Organization.create({
+      name: 'Acme',
+      userId: 'owner-1',
+      personal: false,
+      userDetails: [
+        { id: 'member-1', email: 'member1@example.com', name: 'Member One', usedCredits: 75, lastCreditUsedAt: null },
+      ],
+    });
+
+    // A second seed for the same member must NOT reset their tracked usage or duplicate the row.
+    await organizationRepository.ensureUserDetails(org.id, {
+      id: 'member-1',
+      email: 'changed@example.com',
+      name: 'Changed Name',
+    });
+
+    const reloaded = await Organization.findById(org.id);
+    expect(reloaded?.userDetails).toHaveLength(1);
+    expect(reloaded?.userDetails?.[0]).toMatchObject({
+      id: 'member-1',
+      email: 'member1@example.com',
+      name: 'Member One',
+      usedCredits: 75,
+    });
+  });
+
+  it('makes the positional updateUserDetails increment land where it previously no-oped', async () => {
+    const org = await Organization.create({ name: 'Acme', userId: 'owner-1', personal: false, userDetails: [] });
+
+    // Before seeding, the positional $inc matches no element and does nothing.
+    await organizationRepository.updateUserDetails(org.id, 'member-1', { creditsDelta: 10 });
+    let reloaded = await Organization.findById(org.id);
+    expect(reloaded?.userDetails).toHaveLength(0);
+
+    // After seeding, the same increment tracks against the member's row.
+    await organizationRepository.ensureUserDetails(org.id, { id: 'member-1', email: 'm@example.com', name: 'M' });
+    await organizationRepository.updateUserDetails(org.id, 'member-1', { creditsDelta: 10 });
+    reloaded = await Organization.findById(org.id);
+    expect(reloaded?.userDetails?.[0]).toMatchObject({ id: 'member-1', usedCredits: 10 });
   });
 });

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -414,7 +414,7 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
    * must seed the row so `users[]` and `userDetails[]` stay in sync at the grant point
    * (schema comment above).
    */
-  async ensureUserDetails(organizationId: string, member: { id: string; email?: string; name: string }): Promise<void> {
+  async ensureUserDetails(organizationId: string, member: { id: string; email: string; name: string }): Promise<void> {
     await this.organizationModel.updateOne(
       { _id: organizationId, 'userDetails.id': { $ne: member.id } },
       {

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -402,9 +402,43 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
   }
 
   /**
+   * Seed a zero-usage `userDetails` row for a member if one is not already present. Idempotent by
+   * construction: the `userDetails.id != member.id` guard means a member who already has a row
+   * matches no document and the `$push` is skipped, so this is safe to call on every membership
+   * grant and as a self-heal before a spend.
+   *
+   * WHY THIS EXISTS: `updateUserDetails` increments via the positional `$` operator, which can only
+   * update an element that already exists - it cannot create the row it positions on. A member with
+   * no row therefore tracks no usage and is invisible to `maxCreditsPerMember` (reads `usedCredits`
+   * as 0 forever). Every path that adds a member (`create`, `addMember`, `applyPartnerRuleMembership`)
+   * must seed the row so `users[]` and `userDetails[]` stay in sync at the grant point
+   * (schema comment above).
+   */
+  async ensureUserDetails(organizationId: string, member: { id: string; email?: string; name: string }): Promise<void> {
+    await this.organizationModel.updateOne(
+      { _id: organizationId, 'userDetails.id': { $ne: member.id } },
+      {
+        $push: {
+          userDetails: {
+            id: member.id,
+            email: member.email,
+            name: member.name,
+            usedCredits: 0,
+            lastCreditUsedAt: null,
+          },
+        },
+      }
+    );
+  }
+
+  /**
    * Update a user's usage details within an organization.
    * Uses $inc for creditsDelta (atomic increment) and $set for lastCreditUsedAt
    * to avoid race conditions with concurrent requests.
+   *
+   * The caller must ensure a `userDetails` row exists first (see `ensureUserDetails`): the positional
+   * `$` operator here updates an existing element and cannot create one, so a missing row makes this
+   * a no-op (logged below).
    *
    * @param organizationId - The ID of the organization
    * @param userId - The ID of the user within the organization


### PR DESCRIPTION
## Description

Organizations keep a per-member credit side-table (`userDetails[]`) alongside the authoritative membership list (`users[]`). Only two paths ever seeded a `userDetails` row - org creation (acting user only) and invite-accept. Every other membership-granting path added the member to `users[]` but seeded no row, and the increment could not backfill: `OrganizationModel.updateUserDetails` matches with the positional `$` operator, so with no element to position on it no-ops (a positional update cannot create the element it positions on).

Consequences:
- `maxCreditsPerMember` was inert for admin- and partner-rule-added members - they read as zero spend forever, so the cap never tripped.
- Per-member usage was never recorded for them.
- The org page rendered untracked members as `0 credits`, indistinguishable from idle.

Separately, `create` seeded the row from the acting caller rather than the resolved billing owner, so creating an org with an explicit `billingOwnerId` gave the row to the admin and none to the owner.

## Changes

- New repository primitive `OrganizationRepository.ensureUserDetails(orgId, {id, email?, name})` - an idempotent push-if-absent of a zero row (guard on `userDetails.id != id` + `$push`). This is the one thing the positional `updateUserDetails` cannot do. Added to `IOrganizationRepository` and the `testUtils` mock.
- Seed a `userDetails` row at every membership-granting path:
  - `create.ts` - resolves the billing owner up front and seeds from the **owner** (was: the acting caller). A provided-but-unresolvable `billingOwnerId` now throws `NotFoundError` (fail loud rather than leave the org pointing at a ghost). The admin-grant path is unaffected - it already passes the owner as the caller.
  - `addMember.ts` - seeds the row in the same document update (guarded; also backfills a re-added existing member).
  - `applyPartnerRuleMembership.ts` - seeds on every successful atomic add and on every already-member repair branch. The already-member branch runs on each signup/verify and heals a missing row idempotently, which is the automatic backfill for existing partner-org members.
- Self-heal on spend: `deductCreditsWithOrgSupport` and the CLI completion settlement path seed the row (only when absent) before the positional `$inc`, so any member who predates grant-point seeding starts tracking on their first org-billed spend.

**Decision on existing untracked members: upsert-on-spend, no data migration.** Past usage was never recorded (nothing to accurately backfill), a bulk write is avoided, and the approach self-heals any future missed path. Partner orgs additionally heal via the already-member path above.

**Deferred:** the org-page display conflates "untracked" with "0 spent" (`Member.tsx`, `UserCard.tsx` render `usedCredits || 0`). After this fix that only persists for a pre-existing member until their first spend, then self-heals - a shrinking edge case. Distinguishing the two states in the UI is an existing-design change and would need a client-side row-existence check; left for a follow-up.

## Guide for Testers

This is a backend/data-integrity change. It is best verified by unit/integration tests (included) and by inspecting the org document after the relevant actions. There is no new user-facing UI.

**Setup**
1. Have an admin account and a preview or staging environment.
2. Note the target org's id so you can inspect its document via the DB or an admin read path.

**Scenario A - admin adds a member seeds a row**
1. As an admin, add a user to an organization via the member-add flow (Admin -> organization members -> add).
2. Inspect the org document's `userDetails` array.
3. Expected: a `userDetails` entry exists for the added user with `usedCredits: 0`. Re-adding the same user does not duplicate the row.

**Scenario B - `maxCreditsPerMember` now caps an admin-added member**
1. Set `maxCreditsPerMember` on the org to a small value.
2. As the admin-added member, run org-billed completions until spend exceeds the cap.
3. Expected: the member's `usedCredits` increments as they spend, and once it exceeds `maxCreditsPerMember` the cap trips (further org-billed spend is blocked). Before this fix their `usedCredits` stayed at zero and the cap never tripped.

**Scenario C - create-from-owner**
1. `POST /api/organizations` with an explicit `billingOwnerId` different from the acting admin.
2. Expected: the `userDetails` row is seeded for the **owner**, not the acting admin. Passing a `billingOwnerId` that resolves to no user returns a not-found error rather than silently creating a ghost-owner org.

**Scenario D - self-heal on first spend (pre-existing untracked member)**
1. Take a member who currently has no `userDetails` row (predates this fix).
2. Have them run one org-billed completion.
3. Expected: a `userDetails` row appears for them and begins tracking from that spend.

## Regression Checks

- Existing invite-accept flow still seeds exactly one row (no duplication).
- Org creation for the common case (no explicit `billingOwnerId`) still seeds the creator.
- Credit deduction totals for already-tracked members are unchanged (the seed only fires when the row is absent, then the existing positional `$inc` runs as before).

## What NOT to test

- No UI/UX changes ship in this PR; the org-page display conflation is explicitly deferred (see Description).
- No schema/index changes; no AdminSettings changes.

## Additional Information

Verified locally: `pnpm turbo:typecheck` (40/40), `pnpm lint:check`, full `@bike4mind/services` (3644 passed) and `@bike4mind/database` (1521 passed) suites green. New tests cover create-from-owner + ghost-owner throw, addMember seed + idempotency, partner-rule seed on add and already-member, deduct self-heal only when the row is missing, and an `OrganizationModel` integration test proving `ensureUserDetails` is idempotent, preserves `usedCredits`, and makes a previously no-op `updateUserDetails` increment land.

## Developer Notes

- `OrganizationRepository.ensureUserDetails` is a reusable idempotent "seed the credit side-table row if absent" primitive - use it at any new membership-granting path to keep `users[]` and `userDetails[]` in sync at the grant point.

Closes #1460
