### PR TITLE
fix(services): export every notebook message and drop the inert token ratchet

### DIFF
--- a/b4m-core/services/src/notebookExportService/index.test.ts
+++ b/b4m-core/services/src/notebookExportService/index.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NotebookExportService } from './index';
+import type { NotebookExportAdapters } from './index';
+
+/**
+ * These pin the emitted JSON, because the fields they cover were all silently wrong before the
+ * adapter types were declared: the artifact mapper read a `name` that does not exist on the entity,
+ * and every promptMeta field was read off the top level of a nested structure. Both compiled fine
+ * under `any` and exported undefined.
+ *
+ * The adapters are a declared interface, so plain object literals suffice - no Mongo, no vi.mock.
+ */
+const SESSION = {
+  id: 'session-1',
+  name: 'Notebook One',
+  firstCreated: new Date('2026-01-01T00:00:00Z'),
+  lastUpdated: new Date('2026-01-02T00:00:00Z'),
+  artifactIds: ['artifact-1'],
+};
+
+/** Mirrors the nested shape PromptMeta stores; the old mapper looked for these at the top level. */
+const PROMPT_META = {
+  model: { name: 'claude-opus-4', backend: 'anthropic', parameters: { temperature: 0.7, maxTokens: 4096 } },
+  tokenUsage: { inputTokens: 100, outputTokens: 50, totalTokens: 150, estimatedCost: 0.003 },
+  performance: { totalResponseTime: 1234 },
+  context: {
+    contextWindowUsage: { actualInputTokens: 900 },
+    // Stored on real quests; must not reach the export file.
+    systemPrompt: 'SECRET-SYSTEM-PROMPT',
+    userPrompt: 'SECRET-USER-PROMPT',
+  },
+};
+
+/** Loose on purpose so call sites can pass bare stubs without casting each one. */
+type AdapterOverrides = Partial<Record<keyof NotebookExportAdapters, unknown>>;
+
+function makeAdapters(over: AdapterOverrides = {}) {
+  const uploaded: string[] = [];
+  const none = { find: vi.fn().mockResolvedValue([]) };
+  const adapters = {
+    sessionRepository: { find: vi.fn().mockResolvedValue([SESSION]) },
+    // The loop reads batches until one comes back short, so the second call must be empty.
+    chatHistoryRepository: {
+      find: vi
+        .fn()
+        .mockResolvedValueOnce([{ id: 'msg-1', timestamp: new Date('2026-01-01T00:00:00Z'), promptMeta: PROMPT_META }])
+        .mockResolvedValue([]),
+    },
+    knowledgeRepository: { ...none, findOne: vi.fn().mockResolvedValue(null) },
+    artifactRepository: none,
+    toolRepository: none,
+    agentRepository: none,
+    fileStorageService: {
+      getFileContent: vi.fn().mockResolvedValue(null),
+      uploadFile: vi.fn(async (_path: string, content: Buffer) => {
+        uploaded.push(content.toString('utf-8'));
+      }),
+      getSignedUrl: vi.fn().mockResolvedValue('https://example.test/export.json'),
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    ...over,
+  } as unknown as NotebookExportAdapters;
+  return { adapters, uploaded };
+}
+
+const OPTIONS = {
+  format: 'json',
+  includeMetadata: true,
+  includeArtifacts: true,
+  maxFileSize: 1_000_000,
+} as unknown as Parameters<NotebookExportService['exportNotebooks']>[1];
+
+async function exportOnce(over: AdapterOverrides = {}) {
+  const { adapters, uploaded } = makeAdapters(over);
+  await new NotebookExportService(adapters).exportNotebooks('user-1', OPTIONS);
+  expect(uploaded).toHaveLength(1);
+  return JSON.parse(uploaded[0]);
+}
+
+describe('notebook export', () => {
+  it('emits promptMeta from the nested groups it is actually stored in', async () => {
+    const payload = await exportOnce();
+    const { promptMeta } = payload.notebooks[0].chatHistory[0];
+
+    // model goes through whole rather than rebuilt field-by-field, so a consumer reading
+    // model.backend keeps working.
+    expect(promptMeta.model).toEqual(PROMPT_META.model);
+    expect(promptMeta.tokenUsage.inputTokens).toBe(100);
+    expect(promptMeta.performance.totalResponseTime).toBe(1234);
+    expect(promptMeta.context.contextWindowUsage.actualInputTokens).toBe(900);
+  });
+
+  it('skips a message with no id rather than emitting one that cannot be re-imported', async () => {
+    // Re-import keys updateOne on this id; a missing one casts the filter to {} and upserts over
+    // an arbitrary quest, so the row must not reach the file.
+    const payload = await exportOnce({
+      chatHistoryRepository: {
+        find: vi
+          .fn()
+          .mockResolvedValueOnce([
+            { timestamp: new Date('2026-01-01T00:00:00Z') },
+            { id: 'msg-2', timestamp: new Date('2026-01-01T00:00:00Z') },
+          ])
+          .mockResolvedValue([]),
+      },
+    });
+
+    const ids = payload.notebooks[0].chatHistory.map((m: { id: string }) => m.id);
+    expect(ids).toEqual(['msg-2']);
+  });
+
+  it('does not export raw prompt text from the context group', async () => {
+    const { adapters, uploaded } = makeAdapters();
+    await new NotebookExportService(adapters).exportNotebooks('user-1', OPTIONS);
+
+    expect(uploaded[0]).not.toContain('SECRET-SYSTEM-PROMPT');
+    expect(uploaded[0]).not.toContain('SECRET-USER-PROMPT');
+  });
+
+  it('pages past a full batch and cursors by rows read, not rows kept', async () => {
+    // 152 rows spans two pages of 100. One row has no id, so it is dropped from the output while
+    // still occupying a position in the sort - cursoring by the kept count would re-read the tail.
+    const all = Array.from({ length: 152 }, (_, i) => ({
+      id: i === 7 ? undefined : `msg-${i}`,
+      timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i)),
+      prompt: `message ${i}`,
+    }));
+    const find = vi.fn(async (_q: unknown, opts?: { skip?: number; limit?: number }) =>
+      all.slice(opts?.skip ?? 0, (opts?.skip ?? 0) + (opts?.limit ?? all.length))
+    );
+
+    const payload = await exportOnce({ chatHistoryRepository: { find } });
+
+    const ids = payload.notebooks[0].chatHistory.map((m: { id: string }) => m.id);
+    expect(ids).toHaveLength(151);
+    expect(new Set(ids).size).toBe(151);
+    expect(ids).not.toContain(undefined);
+    expect(ids[ids.length - 1]).toBe('msg-151');
+    expect(find.mock.calls.map(([, opts]) => opts?.skip)).toEqual([0, 100]);
+  });
+
+  it('names an artifact from its title, which is the field the entity actually has', async () => {
+    const payload = await exportOnce({
+      artifactRepository: {
+        find: vi.fn().mockResolvedValue([{ id: 'artifact-1', title: 'My Chart', type: 'recharts' }]),
+      },
+    });
+
+    expect(payload.notebooks[0].artifacts[0].name).toBe('My Chart');
+  });
+});

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -12,16 +12,114 @@ import {
   CURRENT_EXPORT_VERSION,
 } from './types';
 import { isImageServeable } from '@bike4mind/common';
+import type { ILogger } from '@bike4mind/observability';
+import type {
+  IAgentDocument,
+  IArtifactDocument,
+  IChatHistoryItem,
+  IFabFileDocument,
+  ISession,
+  IToolDocument,
+} from '@bike4mind/common';
+
+/** Mongo filter; stays loose because callers pass operator objects (`{ _id: { $in: [...] } }`). */
+type ExportQuery = Record<string, unknown>;
+
+/** Built by mutation below, so the date sub-filter needs a declared shape. */
+type SessionQuery = {
+  userId: string;
+  _id?: { $in: string[] };
+  lastUpdated?: { $gte?: Date; $lte?: Date };
+};
+
+/** What BaseRepository.find destructures; a typo here would land in its projection instead. */
+interface ExportReadOptions {
+  skip?: number;
+  limit?: number;
+  sort?: Record<string, 1 | -1>;
+}
+
+/** The read surface this service uses. Callers wire a real repository or a minimal stand-in. */
+interface ExportReads<T> {
+  // Method syntax on purpose: parameters stay bivariant, which is what lets the real repositories
+  // (and the hand-rolled stub in the API route) satisfy this. An arrow property would not compile.
+  find(query: ExportQuery, options?: ExportReadOptions): Promise<T[]>;
+}
+
+/**
+ * Rows are derived from the entity types rather than typed as `any`, so a field rename on an entity
+ * breaks this file at compile time.
+ */
+type SessionRow = Pick<
+  ISession,
+  | 'id'
+  | 'name'
+  | 'firstCreated'
+  | 'lastUpdated'
+  | 'language'
+  | 'summary'
+  | 'summaryAt'
+  | 'tags'
+  | 'isAutoNamed'
+  | 'lastUsedModel'
+  | 'knowledgeIds'
+  | 'artifactIds'
+  | 'toolIds'
+  | 'agentIds'
+  | 'clonedSourceId'
+  | 'forkedSourceId'
+>;
+
+type KnowledgeRow = Pick<
+  IFabFileDocument,
+  'id' | 'fileName' | 'fileSize' | 'mimeType' | 'createdAt' | 'updatedAt' | 'filePath' | 'moderationStatus' | 'fileUrl'
+>;
+
+/** No `content`: the body lives in a separate collection, reached via contentId. */
+type ArtifactRow = Pick<IArtifactDocument, 'id' | 'title' | 'type' | 'createdAt' | 'updatedAt' | 'metadata'>;
+
+type ToolRow = Pick<IToolDocument, 'id' | 'name' | 'createdAt'>;
+
+type AgentRow = Pick<IAgentDocument, 'id' | 'name' | 'description' | 'createdAt'>;
+
+type ChatMessageRow = Pick<
+  IChatHistoryItem,
+  | 'id'
+  | 'timestamp'
+  | 'type'
+  | 'prompt'
+  | 'status'
+  | 'pinned'
+  | 'reply'
+  | 'replies'
+  | 'questMasterReply'
+  | 'images'
+  | 'fabFileIds'
+  | 'agentIds'
+  | 'questMasterPlanId'
+  | 'creditsUsed'
+  | 'promptMeta'
+>;
+
+/** Only the three storage calls this service makes, not a whole storage client. */
+interface ExportFileStorage {
+  getFileContent(filePath: string): Promise<string | null>;
+  uploadFile(path: string, content: Buffer): Promise<void>;
+  getSignedUrl(filePath: string, expiresIn?: number): Promise<string | null>;
+}
 
 export interface NotebookExportAdapters {
-  sessionRepository: any; // SessionRepository
-  chatHistoryRepository: any; // ChatHistoryRepository
-  knowledgeRepository: any; // KnowledgeRepository
-  artifactRepository: any; // ArtifactRepository
-  toolRepository: any; // ToolRepository
-  agentRepository: any; // AgentRepository
-  fileStorageService: any; // FileStorageService
-  logger: any; // Logger
+  sessionRepository: ExportReads<SessionRow>;
+  /** The caller wires the quest repository here; the name predates that. */
+  chatHistoryRepository: ExportReads<ChatMessageRow>;
+  knowledgeRepository: ExportReads<KnowledgeRow> & {
+    findOne(query: ExportQuery): Promise<KnowledgeRow | null>;
+  };
+  artifactRepository: ExportReads<ArtifactRow>;
+  toolRepository: ExportReads<ToolRow>;
+  agentRepository: ExportReads<AgentRow>;
+  fileStorageService: ExportFileStorage;
+  logger: ILogger;
 }
 
 export class NotebookExportService {
@@ -100,7 +198,7 @@ export class NotebookExportService {
   }
 
   private async getSessionsToExport(userId: string, options: NotebookExportOptions) {
-    const query: any = { userId };
+    const query: SessionQuery = { userId };
 
     // Filter by specific notebook IDs
     if (options.notebookIds && options.notebookIds.length > 0) {
@@ -121,7 +219,7 @@ export class NotebookExportService {
     return await this.adapters.sessionRepository.find(query);
   }
 
-  private async exportSession(session: any, options: NotebookExportOptions): Promise<ExportedNotebook> {
+  private async exportSession(session: SessionRow, options: NotebookExportOptions): Promise<ExportedNotebook> {
     // Export chat history
     const chatHistory = await this.exportChatHistory(session.id, options);
 
@@ -144,37 +242,32 @@ export class NotebookExportService {
       summaryAt: session.summaryAt ? new Date(session.summaryAt).toISOString() : undefined,
       tags: session.tags || [],
       isAutoNamed: session.isAutoNamed || false,
-      lastUsedModel: session.lastUsedModel,
+      lastUsedModel: session.lastUsedModel ?? undefined,
       chatHistory,
       knowledge,
       artifacts,
       tools,
       agents,
-      clonedFromId: session.clonedSourceId,
-      forkedFromId: session.forkedSourceId,
+      clonedFromId: session.clonedSourceId ?? undefined,
+      forkedFromId: session.forkedSourceId ?? undefined,
     };
   }
 
   private async exportChatHistory(sessionId: string, options: NotebookExportOptions): Promise<ExportedChatMessage[]> {
-    // Load messages in token-aware batches (like Claude Code does)
-    // Stop at 100 messages OR 50,000 tokens, whichever comes first
     const MAX_MESSAGES_PER_BATCH = 100;
-    const MAX_TOKENS_PER_BATCH = 50000; // Ratchet: stop early if budget exceeded
 
     const allMessages: ExportedChatMessage[] = [];
     let skip = 0;
     let hasMore = true;
     let totalTokensProcessed = 0;
 
-    this.adapters.logger.info('Starting chat history export with token-aware batched loading', {
+    this.adapters.logger.info('Starting chat history export with batched loading', {
       sessionId,
       maxMessagesPerBatch: MAX_MESSAGES_PER_BATCH,
-      maxTokensPerBatch: MAX_TOKENS_PER_BATCH,
     });
 
     while (hasMore) {
-      // Load batch chronologically (oldest first)
-      // We load MAX_MESSAGES_PER_BATCH, but may stop early if tokens exceeded
+      // Chronological, oldest first
       const batch = await this.adapters.chatHistoryRepository.find(
         { sessionId },
         {
@@ -189,57 +282,20 @@ export class NotebookExportService {
         break;
       }
 
-      // Token-aware processing: stop batch early if token budget exceeded
-      let batchTokens = 0;
-      let messagesInBatch = 0;
       const processedBatch: ExportedChatMessage[] = [];
 
-      this.adapters.logger.debug('Processing message batch (token-aware)', {
-        sessionId,
-        batchNumber: Math.floor(skip / MAX_MESSAGES_PER_BATCH) + 1,
-        maxMessagesInBatch: batch.length,
-        totalProcessed: skip,
-      });
-
-      // Process messages sequentially with token budget checking
       for (const message of batch) {
-        // Estimate tokens for this message (rough: total chars / 4)
-        const messageTokens = this.estimateTokens(message);
-
-        // Ratchet check: would this message exceed our token budget?
-        if (messagesInBatch > 0 && batchTokens + messageTokens > MAX_TOKENS_PER_BATCH) {
-          this.adapters.logger.debug('Token budget exceeded mid-batch, stopping early', {
-            sessionId,
-            messagesInBatch,
-            batchTokens,
-            nextMessageTokens: messageTokens,
-            budgetExceeded: true,
-          });
-          // Stop processing this batch, continue in next iteration
-          break;
-        }
-
-        // Process this message
+        totalTokensProcessed += this.estimateTokens(message);
+        // A row with no id is skipped; see processMessage.
         const exportedMessage = await this.processMessage(message, options);
-        processedBatch.push(exportedMessage);
-
-        batchTokens += messageTokens;
-        messagesInBatch++;
+        if (exportedMessage) processedBatch.push(exportedMessage);
       }
 
-      totalTokensProcessed += batchTokens;
-
-      this.adapters.logger.debug('Batch processing complete', {
-        sessionId,
-        messagesInBatch,
-        batchTokens,
-        totalTokensProcessed,
-        totalMessagesProcessed: skip + messagesInBatch,
-      });
-
       allMessages.push(...processedBatch);
-      skip += messagesInBatch; // Advance by actual messages processed (not MAX_MESSAGES_PER_BATCH)
-      hasMore = messagesInBatch === MAX_MESSAGES_PER_BATCH; // Only continue if we hit message limit (not token limit)
+      // Advance by what the repository returned, not by what we kept: skipped rows still occupy a
+      // position in the sort, so cursoring past anything less would re-read them forever.
+      skip += batch.length;
+      hasMore = batch.length === MAX_MESSAGES_PER_BATCH;
     }
 
     this.adapters.logger.info('Chat history export completed', {
@@ -262,20 +318,18 @@ export class NotebookExportService {
     });
 
     return Promise.all(
-      knowledgeFiles.map(async (file: any) => {
+      knowledgeFiles.map(async (file: KnowledgeRow) => {
         const exportedFile: ExportedKnowledgeFile = {
           id: file.id,
-          name: file.fileName ?? file.name,
+          name: file.fileName,
           mimeType: file.mimeType,
-          size: file.fileSize ?? file.size ?? 0,
+          size: file.fileSize,
           uploadedAt: (file.createdAt ?? file.updatedAt ?? new Date()).toISOString(),
-          // metadata is optional; include if present
-          metadata: file.metadata,
         };
 
-        // A held/blocked uploaded image must not have its bytes or URL exported. Keep the
-        // metadata entry but omit content/contentUrl, matching how a file whose content
-        // fails to load still keeps its metadata.
+        // A held/blocked uploaded image must not have its bytes or URL exported. Keep the file's
+        // listing entry but omit content/contentUrl, matching how a file whose content fails to
+        // load still appears in the export.
         if (!isImageServeable(file)) {
           this.adapters.logger.warn('Skipping content for non-serveable image', {
             fileId: file.id,
@@ -283,7 +337,7 @@ export class NotebookExportService {
           });
         } else if ((exportedFile.size || 0) <= options.maxFileSize) {
           try {
-            const storagePath: string | undefined = file.filePath ?? file.path;
+            const storagePath = file.filePath;
             if (storagePath) {
               const content = await this.adapters.fileStorageService.getFileContent(storagePath);
               if (content) {
@@ -314,11 +368,11 @@ export class NotebookExportService {
       _id: { $in: artifactIds },
     });
 
-    return artifacts.map((artifact: any) => ({
+    return artifacts.map((artifact: ArtifactRow) => ({
       id: artifact.id,
-      name: artifact.name,
+      // Artifacts store this as `title`; reading `name` here always produced undefined.
+      name: artifact.title,
       type: artifact.type,
-      content: artifact.content,
       createdAt: artifact.createdAt?.toISOString() || new Date().toISOString(),
       updatedAt: artifact.updatedAt?.toISOString() || new Date().toISOString(),
       metadata: artifact.metadata,
@@ -332,13 +386,10 @@ export class NotebookExportService {
       _id: { $in: toolIds },
     });
 
-    return tools.map((tool: any) => ({
+    return tools.map((tool: ToolRow) => ({
       id: tool.id,
       name: tool.name,
-      description: tool.description,
-      configuration: tool.configuration,
       createdAt: tool.createdAt?.toISOString() || new Date().toISOString(),
-      metadata: tool.metadata,
     }));
   }
 
@@ -349,13 +400,11 @@ export class NotebookExportService {
       _id: { $in: agentIds },
     });
 
-    return agents.map((agent: any) => ({
+    return agents.map((agent: AgentRow) => ({
       id: agent.id,
       name: agent.name,
       description: agent.description,
-      configuration: agent.configuration,
       createdAt: agent.createdAt?.toISOString() || new Date().toISOString(),
-      metadata: agent.metadata,
     }));
   }
 
@@ -389,6 +438,12 @@ export class NotebookExportService {
 
         try {
           const imageContent = await this.adapters.fileStorageService.getFileContent(imagePath);
+          // getFileContent reports a failed read as null. Buffer.from(null) throws, so without
+          // this the miss would surface as an exception and take the same path as a real error.
+          if (imageContent === null) {
+            this.adapters.logger.warn('Image content unavailable, exporting the path instead', { imagePath });
+            return imagePath;
+          }
           return Buffer.from(imageContent).toString('base64');
         } catch (error) {
           this.adapters.logger.warn('Failed to export image', { imagePath, error });
@@ -404,7 +459,7 @@ export class NotebookExportService {
    * Estimate token count for a message (rough approximation)
    * Uses the standard LLM heuristic: total chars / 4
    */
-  private estimateTokens(message: any): number {
+  private estimateTokens(message: ChatMessageRow): number {
     let totalChars = 0;
 
     // Count prompt
@@ -432,7 +487,17 @@ export class NotebookExportService {
   /**
    * Process a single message into exported format
    */
-  private async processMessage(message: any, options: NotebookExportOptions): Promise<ExportedChatMessage> {
+  private async processMessage(
+    message: ChatMessageRow,
+    options: NotebookExportOptions
+  ): Promise<ExportedChatMessage | null> {
+    // IChatHistoryItem declares `id?`, and re-import keys updateOne on it: a missing id casts the
+    // filter to {} and upserts over an arbitrary quest. Drop the row rather than emit that.
+    if (!message.id) {
+      this.adapters.logger.warn('Skipping chat message with no id');
+      return null;
+    }
+
     const exportedMessage: ExportedChatMessage = {
       id: message.id,
       timestamp: new Date(message.timestamp ?? Date.now()).toISOString(),
@@ -463,16 +528,15 @@ export class NotebookExportService {
 
     // Add metadata
     if (message.promptMeta && options.includeMetadata) {
+      const { model, tokenUsage, performance, context } = message.promptMeta;
       exportedMessage.promptMeta = {
-        model: message.promptMeta.model,
-        temperature: message.promptMeta.temperature,
-        maxTokens: message.promptMeta.maxTokens,
-        tokensUsed: message.promptMeta.tokensUsed,
-        inputTokens: message.promptMeta.inputTokens,
-        outputTokens: message.promptMeta.outputTokens,
-        cost: message.promptMeta.cost,
-        responseTime: message.promptMeta.responseTime,
-        contextLength: message.promptMeta.contextLength,
+        model,
+        tokenUsage,
+        // performance and context are projected, not passed through: the full context group
+        // carries systemPrompt, userPrompt and conversationContext - raw prompt text that this
+        // export has never contained, and that `anonymize` does not strip.
+        performance: performance && { totalResponseTime: performance.totalResponseTime },
+        context: context && { contextWindowUsage: context.contextWindowUsage },
       };
     }
 

--- a/b4m-core/services/src/notebookExportService/types.ts
+++ b/b4m-core/services/src/notebookExportService/types.ts
@@ -1,3 +1,5 @@
+import type { PromptMeta } from '@bike4mind/common';
+
 // Notebook Export/Import Types
 // This defines the standardized format for exporting and importing notebooks/chat sessions
 
@@ -43,9 +45,17 @@ export interface ExportedNotebook {
 }
 
 export interface ExportedChatMessage {
-  id: string; // Original quest/message ID
+  /**
+   * Required: re-import keys `updateOne` on this. A missing id casts the filter to `{}`, which
+   * upserts over an arbitrary document, so a row without one is not exportable.
+   */
+  id: string;
   timestamp: string; // ISO timestamp
-  type: 'message' | 'oob' | 'error' | 'system';
+  /**
+   * Mirrors IChatHistoryItemDocument['type']. `voice_transcript` was missing here: stored rows
+   * carry it, so exports already contained a value this contract did not admit.
+   */
+  type: 'message' | 'oob' | 'error' | 'system' | 'voice_transcript';
 
   // User input
   prompt: string;
@@ -60,16 +70,17 @@ export interface ExportedChatMessage {
   attachedFiles?: string[]; // References to knowledge files
 
   // Metadata
+  /**
+   * Derived from PromptMeta so it cannot drift from what the mapper passes through. Consumers
+   * already read this nested shape - see the bulk-export spreadsheet builder.
+   */
   promptMeta?: {
-    model?: string;
-    temperature?: number;
-    maxTokens?: number;
-    tokensUsed?: number;
-    inputTokens?: number;
-    outputTokens?: number;
-    cost?: number;
-    responseTime?: number;
-    contextLength?: number;
+    /** Passed through whole, so derived - narrowing here would silently drop emitted fields. */
+    model?: PromptMeta['model'];
+    tokenUsage?: PromptMeta['tokenUsage'];
+    /** Projected by the mapper: the full groups carry raw prompt text this export must not ship. */
+    performance?: { totalResponseTime?: number };
+    context?: { contextWindowUsage?: NonNullable<PromptMeta['context']>['contextWindowUsage'] };
   };
 
   // Status and interaction
@@ -90,35 +101,39 @@ export interface ExportedKnowledgeFile {
   uploadedAt: string; // ISO timestamp
   content?: string; // Base64 encoded content for small files
   contentUrl?: string; // Reference URL for large files
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ExportedArtifact {
   id: string;
   name: string;
   type: string;
-  content: string;
+  /** Optional: the artifact body lives in a separate collection and is not joined by this export. */
+  content?: string;
   createdAt: string; // ISO timestamp
   updatedAt: string; // ISO timestamp
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ExportedTool {
   id: string;
   name: string;
   description?: string;
-  configuration: Record<string, any>;
+  /** Optional: the tool entity has no `configuration` field; `llmParams` is the nearest thing
+   * and is deliberately not exported. */
+  configuration?: Record<string, unknown>;
   createdAt: string; // ISO timestamp
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ExportedAgent {
   id: string;
   name: string;
   description?: string;
-  configuration: Record<string, any>;
+  /** Optional: the agent entity has no `configuration` field to source this from. */
+  configuration?: Record<string, unknown>;
   createdAt: string; // ISO timestamp
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 // Import configuration options
@@ -204,7 +219,7 @@ export class NotebookExportError extends Error {
   constructor(
     message: string,
     public code: string,
-    public details?: any
+    public details?: unknown
   ) {
     super(message);
     this.name = 'NotebookExportError';
@@ -215,9 +230,28 @@ export class NotebookImportError extends Error {
   constructor(
     message: string,
     public code: string,
-    public details?: any
+    public details?: unknown
   ) {
     super(message);
     this.name = 'NotebookImportError';
   }
 }
+
+type Expect<T extends true> = T;
+
+/**
+ * Compile-time guard: these interfaces are re-exported from the package entry point, so re-loosening
+ * one to `any` becomes a consumer's looseness. One row per type, so a failure names the regression.
+ * Lives in src, not a test: tsconfig excludes *.test.ts, so only `turbo:typecheck` enforces it.
+ * Same kind of guard, same placement reason, as common's modelCatalog.ts.
+ */
+export type NotebookExportTypesStayNarrowed = [
+  Expect<0 extends 1 & NonNullable<ExportedKnowledgeFile['metadata']>[string] ? false : true>,
+  Expect<0 extends 1 & NonNullable<ExportedArtifact['metadata']>[string] ? false : true>,
+  Expect<0 extends 1 & NonNullable<ExportedTool['metadata']>[string] ? false : true>,
+  Expect<0 extends 1 & NonNullable<ExportedAgent['metadata']>[string] ? false : true>,
+  Expect<0 extends 1 & NonNullable<ExportedTool['configuration']>[string] ? false : true>,
+  Expect<0 extends 1 & NonNullable<ExportedAgent['configuration']>[string] ? false : true>,
+  Expect<0 extends 1 & NotebookExportError['details'] ? false : true>,
+  Expect<0 extends 1 & NotebookImportError['details'] ? false : true>,
+];


### PR DESCRIPTION
# Pull Request

## Description

Exporting a notebook silently truncated the chat history. On a 152-message notebook it exported
51, reported `success`, and showed a plausible message count. A partial export looked exactly
like a complete one.

Cause: the paging loop decided whether to fetch another page from how many messages it had just
*processed*. A "token ratchet" cut batches short at ~50,000 estimated tokens, so whenever it
fired the loop concluded there was nothing left and quit.

That ratchet bounded nothing. Its counters were read only by debug logs, and every message
accumulated into one in-memory array that was uploaded in a single piece regardless. So it is
removed rather than patched, and the loop now cursors by rows read.

Typing the adapters and rows from the entity types (24 `any` removed) then exposed three defects
that had been shipping silently, all fixed here:

- Artifact names exported as `undefined` - the mapper read `artifact.name`, but artifacts have
  `title`.
- All `promptMeta` fields exported as `undefined` - they were read off the top level of a
  structure that stores them nested.
- Raw prompt text (`systemPrompt`, `userPrompt`, `conversationContext`) was passed through into
  the downloadable file. The anonymize option does not strip it. Now projected down to the
  intended metric only.

## Changes

- Page by rows read; remove the token ratchet.
- Type `NotebookExportAdapters` and the row shapes from the entity types (removes 24 `any`), so a
  field rename now breaks the build instead of exporting `undefined`.
- Fix the artifact mapper (`title`) and `promptMeta` (nested groups, `model` passed whole).
- Project `performance` and `context` so raw prompt text cannot reach the file.
- Skip a message with no id, which on re-import would upsert over an arbitrary message.
- Add unit tests for paging, the id skip, `promptMeta`, prompt-text exclusion, and artifact names.

## Guide for Testers

Needs a notebook with **more than 100 messages** to see the truncation. Below that the loop runs
once and the bug is unreachable; steps 1-5 still check for regressions.

1. Log in and pick a notebook. Note roughly how many messages it has, and the text of its first
   message.
2. Go to `Profile -> Settings -> General`.
3. In the `Notebooks` row, click `Export All`.
4. Leave every toggle at its default, format `JSON (Full Data)`, and click `Export Notebooks`.
   - Expected: `Export Complete!` with `Exported N notebooks with M messages`. No error toast.
5. Download the `.json` and open it in a text editor.
6. Count the entries in your notebook's `chatHistory`.
   - Expected: matches the notebook. Nothing missing from the end of the conversation.
7. Check the first entry against the message from step 1.
   - Expected: same text, entries ordered oldest to newest.
8. Search the file for `"systemPrompt"`, `"userPrompt"`, `"conversationContext"`.
   - Expected: zero matches.
9. Find the `artifacts` array for a notebook that has artifacts.
   - Expected: every entry has a real `name`.
10. Find a message with a `promptMeta` object.
    - Expected: `model` is an object with a name; `tokenUsage`,
      `performance.totalResponseTime`, `context.contextWindowUsage` hold real values.

### Regression Checks

11. Export a notebook with fewer than 100 messages - exports completely.
12. Turn off `Artifacts`, `Tools`, `Agents` and export - those arrays are empty, export succeeds.
13. Set a `From Date` / `To Date` range and export - only notebooks updated in range are included.
14. Turn on `Anonymize Export` - succeeds, `exportedBy` absent from the file.
15. Import the file back via `Notebooks -> Import` - runs as before.

### What NOT to test

- Anything outside the export dialog; this is confined to the export service.
- Export timings. Round trips drop on large notebooks, but wall clock is dominated by attachments.

## Additional Information

Verified through the real UI against a local database:

- 154-message notebook exported 154, across two pages (100 then 54).
- The downloaded file checked field by field: 154 unique ids, none missing, timestamps ascending,
  every message body matching its source row.
- Control: notebook trimmed to 2 messages exports 2 in one page.

The tests are mutation tested. Restoring the original cursor, or an intermediate version that
only handles full pages, fails the paging test (50 of 152 and 150 of 152) - so it distinguishes a
complete fix from a partial one.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
