### PR TITLE
feat(agent-quest): publish a machine-readable quest manifest for visiting agents

### DIFF
--- a/BIKE4MIND_CLI.md
+++ b/BIKE4MIND_CLI.md
@@ -149,6 +149,8 @@ It also exposes four resource templates, each with a working `list` and `read` t
 | `b4m://project/{id}` | Your projects | `projects:read` |
 | `b4m://artifact/{id}` | Artifact metadata plus its current content | none (see below) |
 
+Alongside those, `b4m://agent-quest` is a single fixed-URI resource (nothing to list) holding the manifest for **The Open Door**, the onboarding quest for agents. It is the one resource that needs no credentials and makes no API call - the document is served straight from the CLI, because completing the quest is how an agent earns a key in the first place. The same manifest is published over plain HTTP at `/api/agent-quest/manifest`, and each of its steps carries a `status`: only an `available` step has an `endpoint` to call.
+
 Resource *listing* is capped at 100 entries per template and takes no paging arguments. A listing that fails (for example, a key without `projects:read`) degrades to an empty list for that template only, so the other three still enumerate. Because an empty list can therefore also mean an auth failure and not just an empty account, the underlying error is written to the server's stderr; under stdio transport your MCP host captures that stream (for example Claude Desktop's `~/Library/Logs/Claude/mcp-server-*.log`), so check it there if a resource picker comes back unexpectedly empty. There is no `artifacts:*` API-key scope, so an artifact 403 carries no scope recommendation.
 
 The **Scope** column in both tables is the *recommended* key configuration for that tool or resource, not a per-route hard gate: most of these routes do not enforce scopes, so a real 403 can also mean a CASL authorization denial or a suspended account, not just a missing scope.

--- a/apps/client/pages/api/agent-quest/__tests__/manifest.test.ts
+++ b/apps/client/pages/api/agent-quest/__tests__/manifest.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { AGENT_QUEST_MANIFEST } from '@bike4mind/common';
+import handler from '../manifest';
+
+interface Captured {
+  res: NextApiResponse;
+  headers: Record<string, string>;
+  getStatus: () => number;
+  getBody: () => string;
+}
+
+/** Mirrors makeRes in pages/api/v1/__tests__/openapi.json.test.ts. */
+function makeRes(): Captured {
+  const headers: Record<string, string> = {};
+  let statusCode = 200;
+  let body = '';
+  const res = {
+    setHeader: (k: string, v: string) => {
+      headers[k] = v;
+    },
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    send(payload: string) {
+      body = payload ?? '';
+      return res;
+    },
+    end(payload?: string) {
+      if (payload !== undefined) body = payload;
+      return res;
+    },
+  } as unknown as NextApiResponse;
+  return { res, headers, getStatus: () => statusCode, getBody: () => body };
+}
+
+function makeReq(method: 'GET' | 'HEAD' | 'OPTIONS' | 'POST', headers: Record<string, string> = {}): NextApiRequest {
+  return { method, headers } as unknown as NextApiRequest;
+}
+
+describe('GET /api/agent-quest/manifest', () => {
+  it('returns 200 with the quest manifest as JSON', () => {
+    const { res, getStatus, getBody, headers } = makeRes();
+
+    handler(makeReq('GET'), res);
+
+    expect(getStatus()).toBe(200);
+    expect(headers['Content-Type']).toContain('application/json');
+    expect(JSON.parse(getBody())).toEqual(JSON.parse(JSON.stringify(AGENT_QUEST_MANIFEST)));
+  });
+
+  it('serves the agent-quest entry with its steps', () => {
+    const { res, getBody } = makeRes();
+
+    handler(makeReq('GET'), res);
+
+    const manifest = JSON.parse(getBody()) as { id: string; steps: Array<{ id: string; status: string }> };
+    expect(manifest.id).toBe('agent-quest');
+    expect(manifest.steps[0]).toMatchObject({ id: 'read-the-manifest', status: 'available' });
+  });
+
+  // The whole point of the route: an agent has to be able to read the invitation
+  // before it holds any credential, since the quest is how it earns one.
+  it('needs no credential and does not vary by origin', () => {
+    const anonymous = makeRes();
+    const withHost = makeRes();
+
+    handler(makeReq('GET'), anonymous.res);
+    handler(makeReq('GET', { host: 'somewhere.example.test', 'x-forwarded-proto': 'http' }), withHost.res);
+
+    expect(anonymous.getStatus()).toBe(200);
+    expect(withHost.getBody()).toBe(anonymous.getBody());
+    expect(anonymous.headers['Vary']).toBeUndefined();
+  });
+
+  it('sets fully permissive CORS so any agent or browser tool can fetch it', () => {
+    const { res, headers } = makeRes();
+
+    handler(makeReq('GET'), res);
+
+    expect(headers['Access-Control-Allow-Origin']).toBe('*');
+    expect(headers['Access-Control-Allow-Methods']).toContain('GET');
+  });
+
+  it('sets nosniff and a cache header', () => {
+    const { res, headers } = makeRes();
+
+    handler(makeReq('GET'), res);
+
+    expect(headers['X-Content-Type-Options']).toBe('nosniff');
+    expect(headers['Cache-Control']).toContain('max-age');
+  });
+
+  it('answers OPTIONS preflight with 204 + CORS headers', () => {
+    const { res, getStatus, headers } = makeRes();
+
+    handler(makeReq('OPTIONS'), res);
+
+    expect(getStatus()).toBe(204);
+    expect(headers['Access-Control-Allow-Origin']).toBe('*');
+    expect(headers['Access-Control-Max-Age']).toBe('600');
+  });
+
+  it('responds to HEAD with headers but no body', () => {
+    const { res, getStatus, getBody, headers } = makeRes();
+
+    handler(makeReq('HEAD'), res);
+
+    expect(getStatus()).toBe(200);
+    expect(getBody()).toBe('');
+    expect(headers['Content-Type']).toContain('application/json');
+  });
+
+  it('rejects non-GET/HEAD methods with 405', () => {
+    const { res, getStatus, headers } = makeRes();
+
+    handler(makeReq('POST'), res);
+
+    expect(getStatus()).toBe(405);
+    expect(headers['Allow']).toContain('GET');
+  });
+});

--- a/apps/client/pages/api/agent-quest/manifest.ts
+++ b/apps/client/pages/api/agent-quest/manifest.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { AGENT_QUEST_MANIFEST } from '@bike4mind/common';
+
+/**
+ * GET /api/agent-quest/manifest - the machine-readable invitation to The Open Door.
+ *
+ * The quest is meant to be discovered by an agent rather than clicked through by
+ * a person, so the manifest is the entry point: unauthenticated, permissively
+ * CORS'd, and identical for every caller. The same document is served over MCP as
+ * `b4m://agent-quest` (see the CLI's mcp/resources.ts), which is why the manifest
+ * itself lives in @bike4mind/common rather than here.
+ *
+ * Every path inside the manifest is root-relative, so the body does not depend on
+ * the request origin - no Host rewriting and no `Vary`, unlike
+ * pages/api/v1/openapi.json.ts. That also keeps the document correct for
+ * self-hosted deployments.
+ *
+ * A raw Next handler (not baseApi) so the route needs no DB connection and cannot
+ * 5xx on a Mongo outage - same reasoning as openapi.json.ts.
+ */
+
+// Serialized once at module load: the document is a constant, so every response
+// is byte-identical and there is nothing to rebuild per request.
+const MANIFEST_JSON = JSON.stringify(AGENT_QUEST_MANIFEST);
+
+function setCorsHeaders(res: NextApiResponse): void {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  setCorsHeaders(res);
+
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Max-Age', '600');
+    return res.status(204).end();
+  }
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.setHeader('Allow', 'GET, HEAD, OPTIONS');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300');
+
+  if (req.method === 'HEAD') return res.status(200).end();
+  return res.status(200).send(MANIFEST_JSON);
+}

--- a/apps/client/public/llms.txt
+++ b/apps/client/public/llms.txt
@@ -1,0 +1,37 @@
+# Bike4Mind
+
+> An AI workspace: notebooks (sessions) over many LLM providers, files and data
+> lakes, artifacts, and agents. Bike4Mind is open source and self-hostable.
+
+Every path below is root-relative, so resolve it against the origin you fetched
+this file from. That keeps the file correct for bike4mind.com and for any
+self-hosted deployment.
+
+## Agents
+
+- [The Open Door](/api/agent-quest/manifest): `agent-quest` - an onboarding quest
+  built for agents rather than for people. Read the manifest, speak MCP, out-think
+  a scheduling puzzle, make something, and sign the Wall of Agents. Completing it
+  earns a free credit grant and a verifiable badge. Steps carry a `status`; only
+  an `available` step has an `endpoint` to call. Also served over MCP as
+  `b4m://agent-quest`.
+
+## API
+
+- [OpenAPI contract](/api/v1/openapi.json): the machine-readable HTTP API. Served
+  with the current deployment as its `servers` entry, so it is ready for SDK
+  codegen.
+- [API reference](/api/v1/docs): the same contract, rendered for reading.
+
+## MCP
+
+Bike4Mind ships its own MCP server over stdio or loopback HTTP:
+
+```
+npx @bike4mind/cli mcp serve
+```
+
+It exposes the Bike4Mind tools plus the resources `b4m://notebook/{id}`,
+`b4m://file/{id}`, `b4m://project/{id}`, `b4m://artifact/{id}`, and
+`b4m://agent-quest`. Every resource except `b4m://agent-quest` needs
+credentials; the quest manifest is deliberately readable without them.

--- a/b4m-core/common/src/agentQuest.test.ts
+++ b/b4m-core/common/src/agentQuest.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AGENT_QUEST_ID,
+  AGENT_QUEST_MANIFEST,
+  AGENT_QUEST_MANIFEST_PATH,
+  AGENT_QUEST_MANIFEST_VERSION,
+  AGENT_QUEST_MCP_URI,
+} from './agentQuest';
+
+describe('AGENT_QUEST_MANIFEST', () => {
+  it('identifies itself as the agent-quest entry at the current version', () => {
+    expect(AGENT_QUEST_MANIFEST.id).toBe('agent-quest');
+    expect(AGENT_QUEST_ID).toBe('agent-quest');
+    expect(AGENT_QUEST_MANIFEST.manifestVersion).toBe(AGENT_QUEST_MANIFEST_VERSION);
+  });
+
+  it('derives the MCP uri from the quest id', () => {
+    expect(AGENT_QUEST_MCP_URI).toBe('b4m://agent-quest');
+  });
+
+  it('opens with a step that is already callable, so a reader is never stuck', () => {
+    expect(AGENT_QUEST_MANIFEST.steps[0]).toMatchObject({
+      id: 'read-the-manifest',
+      status: 'available',
+      endpoint: AGENT_QUEST_MANIFEST_PATH,
+    });
+  });
+
+  it('covers the five steps of the quest in order', () => {
+    expect(AGENT_QUEST_MANIFEST.steps.map(s => s.id)).toEqual([
+      'read-the-manifest',
+      'mcp-handshake',
+      'scheduling-puzzle',
+      'make-something',
+      'sign-the-wall',
+    ]);
+  });
+
+  // The load-bearing invariant of the whole document: an agent is told to call
+  // `endpoint`, so a planned step carrying one would send it at a route that does
+  // not exist yet. Flipping a step to `available` must come with its endpoint.
+  it('gives an endpoint to exactly the available steps', () => {
+    for (const step of AGENT_QUEST_MANIFEST.steps) {
+      if (step.status === 'available') {
+        expect(step.endpoint, `${step.id} is available but advertises no endpoint`).toBeTruthy();
+      } else {
+        expect(step.endpoint, `${step.id} is planned but advertises an endpoint`).toBeUndefined();
+      }
+    }
+  });
+
+  it('advertises only root-relative endpoints, so the document is origin-agnostic', () => {
+    for (const step of AGENT_QUEST_MANIFEST.steps) {
+      if (step.endpoint) expect(step.endpoint.startsWith('/')).toBe(true);
+    }
+  });
+
+  it('describes every step to the visiting agent', () => {
+    for (const step of AGENT_QUEST_MANIFEST.steps) {
+      expect(step.title.length, `${step.id} has no title`).toBeGreaterThan(0);
+      expect(step.instructions.length, `${step.id} has no instructions`).toBeGreaterThan(0);
+    }
+  });
+
+  it('survives JSON serialization unchanged - both readers serve it as JSON', () => {
+    expect(JSON.parse(JSON.stringify(AGENT_QUEST_MANIFEST))).toEqual(AGENT_QUEST_MANIFEST);
+  });
+});

--- a/b4m-core/common/src/agentQuest.ts
+++ b/b4m-core/common/src/agentQuest.ts
@@ -1,0 +1,114 @@
+/**
+ * The Open Door: a machine-readable invitation for visiting agents.
+ *
+ * This manifest is the quest's entry point and its only contract. It is served
+ * unauthenticated over HTTP (`GET /api/agent-quest/manifest`) and as the
+ * `b4m://agent-quest` MCP resource, so an agent that already speaks MCP and one
+ * that only speaks HTTP read the same document. Both readers import this module,
+ * so it must stay client-safe and dependency-free.
+ *
+ * Every step carries an honest `status`, and only an `available` step has an
+ * `endpoint`. Advertising a verification endpoint before it ships would point
+ * agents at a 404, so a step stays `planned` until its route exists - the
+ * remaining steps are tracked as their own units of work.
+ */
+
+export const AGENT_QUEST_ID = 'agent-quest';
+
+/** Canonical MCP resource URI; must stay in sync with the registration in the CLI's mcp/resources.ts. */
+export const AGENT_QUEST_MCP_URI = `b4m://${AGENT_QUEST_ID}`;
+
+/** Root-relative, so the document is identical for bike4mind.com and every self-host. */
+export const AGENT_QUEST_MANIFEST_PATH = '/api/agent-quest/manifest';
+
+/**
+ * Bumped only on a breaking change to the manifest shape, so an agent can branch
+ * on it. Adding a step or flipping one to `available` is not breaking.
+ */
+export const AGENT_QUEST_MANIFEST_VERSION = 1;
+
+/** `available` steps are callable today; `planned` ones describe the intended arc. */
+export type AgentQuestStepStatus = 'available' | 'planned';
+
+export interface AgentQuestStep {
+  readonly id: string;
+  readonly title: string;
+  /** Addressed to the visiting agent, in the second person. */
+  readonly instructions: string;
+  readonly status: AgentQuestStepStatus;
+  /** Root-relative path that completes the step. Present only when `available`. */
+  readonly endpoint?: string;
+}
+
+export interface AgentQuestReward {
+  readonly status: AgentQuestStepStatus;
+  readonly summary: string;
+}
+
+/** Fully `readonly`: one module-level singleton is shared by every reader, so no consumer may edit it. */
+export interface AgentQuestManifest {
+  readonly id: typeof AGENT_QUEST_ID;
+  readonly manifestVersion: number;
+  readonly title: string;
+  readonly summary: string;
+  /** Ordered; a step may assume every earlier step is complete. */
+  readonly steps: readonly AgentQuestStep[];
+  readonly reward: AgentQuestReward;
+}
+
+const STEPS: readonly AgentQuestStep[] = [
+  {
+    id: 'read-the-manifest',
+    title: 'Read the manifest',
+    instructions:
+      'Fetch this manifest and parse it. You have already done this if you are reading these words. ' +
+      'Re-read it when `manifestVersion` changes: steps flip from planned to available here first.',
+    status: 'available',
+    endpoint: AGENT_QUEST_MANIFEST_PATH,
+  },
+  {
+    id: 'mcp-handshake',
+    title: 'Speak MCP',
+    instructions:
+      'Prove you are an agent that speaks the Model Context Protocol, as either a host or a client. ' +
+      'Bike4Mind ships its own MCP server (`b4m mcp serve`), which also serves this manifest at ' +
+      `\`${AGENT_QUEST_MCP_URI}\`.`,
+    status: 'planned',
+  },
+  {
+    id: 'scheduling-puzzle',
+    title: 'Out-think the scheduler',
+    instructions:
+      'Solve a scheduling problem posed against the real in-browser solver, not a toy stand-in. ' +
+      'Curiosity is the trait this quest is looking for; brute force is not disqualifying, but it is not the point.',
+    status: 'planned',
+  },
+  {
+    id: 'make-something',
+    title: 'Make something',
+    instructions: 'Produce an artifact of any supported type. What you make is up to you.',
+    status: 'planned',
+  },
+  {
+    id: 'sign-the-wall',
+    title: 'Sign the Wall of Agents',
+    instructions:
+      'Add your signature to a public ledger of the agents that made it through, and receive a verifiable ' +
+      'attestation you can present elsewhere.',
+    status: 'planned',
+  },
+];
+
+export const AGENT_QUEST_MANIFEST: AgentQuestManifest = {
+  id: AGENT_QUEST_ID,
+  manifestVersion: AGENT_QUEST_MANIFEST_VERSION,
+  title: 'The Open Door',
+  summary:
+    'An onboarding quest built for agents rather than for people: read the manifest, speak MCP, out-think a ' +
+    'scheduling puzzle, make something, and sign the Wall of Agents.',
+  steps: STEPS,
+  reward: {
+    status: 'planned',
+    summary: 'A free credit grant and a verifiable badge, awarded once the Wall of Agents is signed.',
+  },
+};

--- a/b4m-core/common/src/index.ts
+++ b/b4m-core/common/src/index.ts
@@ -3,6 +3,7 @@ export * from './groupTypes';
 export * from './insufficientCredits';
 export * from './validation';
 export * from './apikey';
+export * from './agentQuest';
 export * from './models';
 export * from './modelPriceCatalog';
 export * from './modelCatalog';

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -392,7 +392,7 @@ You can also run any MCP server via npx or custom executables:
 
 #### Serve Bike4Mind itself as an MCP server (`b4m mcp serve`)
 
-The reverse of adding a server: `b4m mcp serve` exposes your Bike4Mind backend to any MCP client (Claude Desktop, editors, other agents). It advertises eight tools (`list_notebooks`, `get_notebook`, `create_notebook`, `send_message`, `search_knowledge_base`, `list_files`, `get_file`, `generate_sound_effect`) plus four resource templates (`b4m://notebook/{id}`, `b4m://file/{id}`, `b4m://project/{id}`, `b4m://artifact/{id}`), each listable and readable as JSON.
+The reverse of adding a server: `b4m mcp serve` exposes your Bike4Mind backend to any MCP client (Claude Desktop, editors, other agents). It advertises eight tools (`list_notebooks`, `get_notebook`, `create_notebook`, `send_message`, `search_knowledge_base`, `list_files`, `get_file`, `generate_sound_effect`) plus four resource templates (`b4m://notebook/{id}`, `b4m://file/{id}`, `b4m://project/{id}`, `b4m://artifact/{id}`), each listable and readable as JSON, and `b4m://agent-quest` - the credential-free manifest for The Open Door, the onboarding quest for agents.
 
 ```bash
 b4m mcp serve                        # stdio (default) - for local clients that spawn the process

--- a/packages/cli/src/mcp/resources.test.ts
+++ b/packages/cli/src/mcp/resources.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { AxiosError, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
 import type { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ListResourcesResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import { AGENT_QUEST_MANIFEST } from '@bike4mind/common';
 import type { B4mApiClient } from './b4mApiClient';
 import { registerResources } from './resources';
 import { logger } from '../utils/Logger';
@@ -9,10 +10,19 @@ import { logger } from '../utils/Logger';
 type ReadCallback = (uri: URL, variables: Record<string, string | string[]>) => Promise<ReadResourceResult>;
 
 interface Registered {
-  template: ResourceTemplate;
+  /** A string for the fixed-URI `agent-quest` resource, a template for the rest. */
+  uriOrTemplate: ResourceTemplate | string;
   metadata: Record<string, unknown>;
   read: ReadCallback;
 }
+
+/** Narrow to the URI-template form; the fixed-URI resource has no template to inspect. */
+const templateOf = (entry: Registered): ResourceTemplate => {
+  if (typeof entry.uriOrTemplate === 'string') {
+    throw new Error(`resource registered with the fixed uri ${entry.uriOrTemplate}, not a template`);
+  }
+  return entry.uriOrTemplate;
+};
 
 const mockClient = (overrides: Partial<Record<keyof B4mApiClient, unknown>>): B4mApiClient =>
   ({ baseURL: 'http://localhost:3000', ...overrides }) as unknown as B4mApiClient;
@@ -32,11 +42,11 @@ const collectResources = (client: B4mApiClient) => {
   const server = {
     registerResource: (
       name: string,
-      template: ResourceTemplate,
+      uriOrTemplate: ResourceTemplate | string,
       metadata: Record<string, unknown>,
       read: ReadCallback
     ) => {
-      registered.set(name, { template, metadata, read });
+      registered.set(name, { uriOrTemplate, metadata, read });
     },
   } as unknown as McpServer;
   registerResources(server, client);
@@ -44,21 +54,62 @@ const collectResources = (client: B4mApiClient) => {
 };
 
 const listOf = (entry: Registered): Promise<ListResourcesResult> => {
-  const list = entry.template.listCallback;
+  const list = templateOf(entry).listCallback;
   if (!list) throw new Error('template registered without a list callback');
   return Promise.resolve(list({} as Parameters<typeof list>[0]));
 };
 
 describe('registerResources', () => {
-  it('registers exactly the four resource templates', () => {
-    expect([...collectResources(mockClient({})).keys()]).toEqual(['notebook', 'file', 'project', 'artifact']);
+  it('registers the quest manifest plus exactly the four resource templates', () => {
+    expect([...collectResources(mockClient({})).keys()]).toEqual([
+      'agent-quest',
+      'notebook',
+      'file',
+      'project',
+      'artifact',
+    ]);
+  });
+
+  describe('agent-quest', () => {
+    it('registers at a fixed uri, since there is only one manifest to address', () => {
+      const entry = collectResources(mockClient({})).get('agent-quest')!;
+
+      expect(entry.uriOrTemplate).toBe('b4m://agent-quest');
+      expect(entry.metadata).toMatchObject({ mimeType: 'application/json', title: AGENT_QUEST_MANIFEST.title });
+    });
+
+    it('reads the manifest as pretty-printed JSON', async () => {
+      const entry = collectResources(mockClient({})).get('agent-quest')!;
+
+      const result = await entry.read(new URL('b4m://agent-quest'), {});
+
+      expect(result.contents).toEqual([
+        {
+          uri: 'b4m://agent-quest',
+          mimeType: 'application/json',
+          text: JSON.stringify(AGENT_QUEST_MANIFEST, null, 2),
+        },
+      ]);
+    });
+
+    // The quest is how an agent earns a key, so reading the invitation must not
+    // require one. A client with no credentials at all still gets the manifest.
+    it('reads without touching the API client', async () => {
+      const client = mockClient({});
+      const entry = collectResources(client).get('agent-quest')!;
+
+      const result = await entry.read(new URL('b4m://agent-quest'), {});
+
+      const manifest = JSON.parse((result.contents[0] as { text: string }).text) as { id: string };
+      expect(manifest.id).toBe('agent-quest');
+    });
   });
 
   it('registers the notebook template as application/json', () => {
     const entry = collectResources(mockClient({})).get('notebook')!;
 
     expect(entry).toBeDefined();
-    expect(entry.template.uriTemplate.toString()).toBe('b4m://notebook/{id}');
+    expect(templateOf(entry).uriTemplate.toString()).toBe('b4m://notebook/{id}');
     expect(entry.metadata).toMatchObject({ mimeType: 'application/json' });
   });
 
@@ -137,7 +188,7 @@ describe('registerResources', () => {
     const entry = collectResources(mockClient({})).get('file')!;
 
     expect(entry).toBeDefined();
-    expect(entry.template.uriTemplate.toString()).toBe('b4m://file/{id}');
+    expect(templateOf(entry).uriTemplate.toString()).toBe('b4m://file/{id}');
     expect(entry.metadata).toMatchObject({ mimeType: 'application/json' });
   });
 
@@ -187,7 +238,7 @@ describe('registerResources', () => {
     const entry = collectResources(mockClient({})).get('project')!;
 
     expect(entry).toBeDefined();
-    expect(entry.template.uriTemplate.toString()).toBe('b4m://project/{id}');
+    expect(templateOf(entry).uriTemplate.toString()).toBe('b4m://project/{id}');
     expect(entry.metadata).toMatchObject({ mimeType: 'application/json' });
   });
 
@@ -239,7 +290,7 @@ describe('registerResources', () => {
     const entry = collectResources(mockClient({})).get('artifact')!;
 
     expect(entry).toBeDefined();
-    expect(entry.template.uriTemplate.toString()).toBe('b4m://artifact/{id}');
+    expect(templateOf(entry).uriTemplate.toString()).toBe('b4m://artifact/{id}');
     expect(entry.metadata).toMatchObject({ mimeType: 'application/json' });
   });
 
@@ -310,9 +361,12 @@ describe('registerResources', () => {
     );
 
     // Mirrors the SDK's resources/list loop, which awaits every template in
-    // registration order with no try/catch of its own.
+    // registration order with no try/catch of its own. Fixed-URI resources
+    // (agent-quest) are excluded because the SDK emits those directly and never
+    // calls a list callback for them.
     const all: ListResourcesResult['resources'] = [];
     for (const entry of registered.values()) {
+      if (typeof entry.uriOrTemplate === 'string') continue;
       all.push(...(await listOf(entry)).resources);
     }
 
@@ -339,7 +393,7 @@ describe('registerResources', () => {
       // an invalid URI; the read path then safeDecodes it back to the original id.
       expect(listed.uri).toBe(`b4m://artifact/${encodeURIComponent(id)}`);
       // Exactly what the SDK does on resources/read: normalize, then template-match.
-      const variables = entry.template.uriTemplate.match(new URL(listed.uri).toString());
+      const variables = templateOf(entry).uriTemplate.match(new URL(listed.uri).toString());
 
       expect(variables).not.toBeNull();
       await entry.read(new URL(listed.uri), variables!);

--- a/packages/cli/src/mcp/resources.ts
+++ b/packages/cli/src/mcp/resources.ts
@@ -1,4 +1,5 @@
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { AGENT_QUEST_ID, AGENT_QUEST_MANIFEST, AGENT_QUEST_MCP_URI } from '@bike4mind/common';
 import type { B4mApiClient, RawArtifact, RawFile, RawNotebook, RawProject } from './b4mApiClient.js';
 import { mapApiError } from './b4mApiClient.js';
 import { logger } from '../utils/Logger.js';
@@ -94,10 +95,39 @@ function registerJsonResource<T>(server: McpServer, client: B4mApiClient, spec: 
 }
 
 /**
- * Register the Bike4Mind MCP resource templates. Each is served as
- * application/json and backed by its REST list/read pair.
+ * Register `b4m://agent-quest`: the machine-readable invitation to The Open Door.
+ *
+ * A fixed URI rather than a `ResourceTemplate` - there is exactly one manifest, so
+ * there is nothing to list or address by id. It is also the only resource here that
+ * needs no API call and no credentials: the document is a constant in
+ * @bike4mind/common, shared with the public HTTP route that serves it
+ * (apps/client/pages/api/agent-quest/manifest.ts). That means an agent can read the
+ * invitation before it has an API key - which is the point, since the quest is how
+ * it earns one.
+ */
+function registerAgentQuest(server: McpServer): void {
+  server.registerResource(
+    AGENT_QUEST_ID,
+    AGENT_QUEST_MCP_URI,
+    {
+      title: AGENT_QUEST_MANIFEST.title,
+      description: AGENT_QUEST_MANIFEST.summary,
+      mimeType: 'application/json',
+    },
+    uri => ({
+      contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify(AGENT_QUEST_MANIFEST, null, 2) }],
+    })
+  );
+}
+
+/**
+ * Register the Bike4Mind MCP resources: the four templates below, each served as
+ * application/json and backed by its REST list/read pair, plus the credential-free
+ * `b4m://agent-quest` manifest.
  */
 export function registerResources(server: McpServer, client: B4mApiClient): void {
+  registerAgentQuest(server);
+
   registerJsonResource<RawNotebook>(server, client, {
     name: 'notebook',
     title: 'Notebook',

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -12,12 +12,13 @@ export interface BuildServerOptions {
 }
 
 /**
- * Build a fully-configured Bike4Mind MCP server: the tools plus the four
- * resource templates (`b4m://notebook/{id}`, `b4m://file/{id}`,
- * `b4m://project/{id}`, `b4m://artifact/{id}`), backed by a {@link B4mApiClient}
- * bound to the given endpoint and credentials. Tool listing never touches the
- * network - only tool/resource *calls* hit the API - so a server built with an
- * unreachable endpoint still advertises its full capability set.
+ * Build a fully-configured Bike4Mind MCP server: the tools, the four resource
+ * templates (`b4m://notebook/{id}`, `b4m://file/{id}`, `b4m://project/{id}`,
+ * `b4m://artifact/{id}`) backed by a {@link B4mApiClient} bound to the given
+ * endpoint and credentials, and the credential-free `b4m://agent-quest` manifest.
+ * Tool listing never touches the network - only tool/resource *calls* hit the API -
+ * so a server built with an unreachable endpoint still advertises its full
+ * capability set.
  */
 export function buildMcpServer(options: BuildServerOptions): McpServer {
   const client = new B4mApiClient(options.baseURL, options.configStore, options.apiKey);

--- a/scripts/no-baseapi-allowlist.txt
+++ b/scripts/no-baseapi-allowlist.txt
@@ -27,6 +27,8 @@ apps/client/pages/api/v1/openapi.json.ts                # Public OpenAPI spec; r
 apps/client/pages/api/v1/__tests__/openapi.json.test.ts # Test file for the handler above (script greps by path, not export)
 apps/client/pages/api/v1/docs.ts                        # Public Scalar API-reference page; static HTML, no user data, no DB (#39)
 apps/client/pages/api/v1/__tests__/docs.test.ts         # Test file for the handler above (script greps by path, not export)
+apps/client/pages/api/agent-quest/manifest.ts           # Public agent-quest manifest; raw handler (no baseApi/DB) so it can't 5xx on a Mongo outage; a constant document, no user data
+apps/client/pages/api/agent-quest/__tests__/manifest.test.ts # Test file for the handler above (script greps by path, not export)
 
 # Slack — authenticated via HMAC-SHA256 signature (Slack signing secret)
 apps/client/pages/api/slack/commands.ts                 # verifySlackRequest() HMAC check


### PR DESCRIPTION
# Pull Request

## Description

Closes #105 (step 1 of the quest).

An agent that lands on Bike4Mind has no way to find out what it can do here: there was no
`llms.txt`, no machine-readable index, nothing served for a non-human reader. This PR publishes the
invitation - a single manifest describing the agent quest - so a visiting agent can discover the
quest, read its steps, and know which ones are actually callable today.

The manifest is one constant with two readers, so an HTTP-only agent and an MCP-speaking agent get
the same document from the same source of truth.

This is deliberately the discovery surface only. The remaining quest steps (the MCP handshake, the
puzzle, the making step, the Wall of Agents signing, the credit grant and badge) are tracked
separately; every one of them ships in the manifest as `status: "planned"` until it exists.

## Changes

- `b4m-core/common/src/agentQuest.ts` - the single source of truth: `AGENT_QUEST_MANIFEST`, its
  types, and the `AGENT_QUEST_ID` / `AGENT_QUEST_MCP_URI` / `AGENT_QUEST_MANIFEST_PATH` constants.
  Client-safe and dependency-free; exported from `b4m-core/common/src/index.ts`.
- `apps/client/pages/api/agent-quest/manifest.ts` - `GET /api/agent-quest/manifest`, public and
  unauthenticated, permissive CORS, GET/HEAD/OPTIONS with 405 otherwise. A raw Next handler rather
  than `baseApi()` (following `pages/api/v1/openapi.json.ts`), so it touches no DB and cannot 5xx
  during a Mongo outage. Added to `scripts/no-baseapi-allowlist.txt` with that reason.
- `packages/cli/src/mcp/resources.ts` - registers `b4m://agent-quest` as a fixed-URI resource (not a
  `ResourceTemplate`: there is one manifest, nothing to list or address by id). It is the only
  resource that makes no API call and needs no credentials - deliberate, since the quest is how an
  agent earns a key in the first place.
- `apps/client/public/llms.txt` - the discovery surface that did not exist, leading with the
  `agent-quest` entry. Served statically.
- Docs: `BIKE4MIND_CLI.md` (resource table plus a note on the credential-free resource) and
  `packages/cli/README.md`.

### Invariants the tests lock in

- Every step carries a `status`, and only an `available` step may carry an `endpoint`. A `planned`
  step that advertised an endpoint would send agents at a 404. `agentQuest.test.ts` asserts this in
  both directions - keep it when flipping a step to `available`.
- Every path in the manifest is root-relative, so the body never depends on the request origin.
  Hence no Host rewriting and no `Vary` (unlike `openapi.json.ts`), and the document stays correct
  for self-hosted deployments.
- `manifestVersion` is bumped only on a breaking shape change; adding a step, or flipping one to
  `available`, is not breaking.
- The reward is `planned` with no fabricated credit amount.

`llms.txt` (the index convention) was chosen over `llms-full.txt`. Worth knowing: this repo's own
`webfetch` tool prefers `llms-full.txt` and falls back to `llms.txt`, so the full variant is worth
adding only when there is genuinely more long-form content to serve, not a duplicate.

## Guide for Testers

Backend/CLI only - there is no UI in this PR.

Test against the PR preview host below, not staging: this branch is not deployed to staging, where
`/api/agent-quest/manifest` returns 401 and `/llms.txt` falls through to the SPA shell. Both are the
signature of a route that is not in the deployed build, not a defect.

1. Open `https://app.pr1506.preview.bike4mind.com/api/agent-quest/manifest` in a browser (no login, no API
   key). Expect HTTP 200 and a JSON body whose `id` is `agent-quest` and which contains a
   `steps` array.
2. Confirm each entry in `steps` has a `status` field. Expect exactly one step with
   `status: "available"` (the manifest/discovery step) and the rest `"planned"`.
3. Confirm no step whose `status` is `"planned"` has an `endpoint` field.
4. Confirm every path-like value in the body starts with `/` (no absolute `https://...` host names).
5. From a terminal, run `curl -i -X POST https://app.pr1506.preview.bike4mind.com/api/agent-quest/manifest`.
   Expect HTTP 405.
6. Run `curl -I https://app.pr1506.preview.bike4mind.com/api/agent-quest/manifest`. Expect HTTP 200 with no
   body.
7. Run `curl -s -X OPTIONS -i https://app.pr1506.preview.bike4mind.com/api/agent-quest/manifest`. Expect a
   2xx with `Access-Control-Allow-Origin` present.
8. Open `https://app.pr1506.preview.bike4mind.com/llms.txt`. Expect a plain-text index whose first entry
   points at the agent quest.
9. MCP check: start the CLI MCP server with **no** credentials configured but an endpoint pointed at
   the preview (`b4m --api-url https://app.pr1506.preview.bike4mind.com mcp serve`), list resources,
   and read `b4m://agent-quest`. Expect the same manifest JSON as step 1, with no auth error - this
   resource is intentionally the one that works without a key. The endpoint flag is still required:
   the CLI refuses to start with no backend configured at all, which is unchanged by this PR.

### Regression checks

10. Confirm the other `b4m://` MCP resources still list and read as before with credentials
    configured (this PR adds a resource; it does not change the existing ones).

### What NOT to test

- No UI, no database, no migration, no auth changes. Nothing to check in the app itself.

## Additional Information

Verified locally: `pnpm turbo:typecheck` clean (40/40 packages) after rebasing onto current `main`;
`pnpm lint:check` clean; new tests are 8 route tests, 3 MCP resource tests, and 9
manifest-invariant tests. The ASCII-only guards (`check-no-control-bytes.sh`,
`check-no-smart-punctuation.sh`) and `check-no-baseapi.sh` all pass against `origin/main`.

Two pre-existing environment notes, neither caused by this change:

- `pnpm turbo:test` at full fan-out fails `b4m-core/utils/src/artifactElision.test.ts` on a
  wall-clock assertion (`elapsedMs < 3000`); it passes alone in ~514ms. Cap `VITEST_MAX_WORKERS` per
  CLAUDE.md's worker-pool budget. Other packages then report `ELIFECYCLE` purely as turbo
  cancellation cascade.
- `.husky/pre-commit` cannot succeed in a fresh worktree: it runs
  `npx tsx packages/scripts/src/checkDeprecatedModelUsage.ts`, but `tsx` is a devDependency of
  `packages/scripts` only and is not resolvable from the repo root, so the hook exits 1 even when
  every check passes. Each check was run by hand here (including the deprecated-model check via the
  resolved `tsx` binary - green). Worth fixing separately; it affects every commit in this repo.

One thing a reviewer may want to weigh in on: CLAUDE.md's "Public API endpoints" section says a
public endpoint should be defined by an api-contract. This route is a static, unauthenticated
document with no request schema, so it follows the `openapi.json.ts` precedent instead. Happy to move
it onto a contract if that reading is preferred.

## Developer Notes

- `AGENT_QUEST_MANIFEST` is the extension point for the rest of the quest: adding a step is a
  data-only change in `b4m-core/common/src/agentQuest.ts`, and both readers (HTTP route and MCP
  resource) pick it up with no code change.
- Fixed-URI MCP resource registration (as opposed to `ResourceTemplate`) is a pattern this repo did
  not have; use it for singleton documents that have nothing to list.
- The credential-free MCP resource is a new category: a resource deliberately reachable before an
  agent has a key.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no settings
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a, no telemetry

