### PR TITLE
fix(llm): treat a media model's zero contextWindow as not-applicable

### DIFF
--- a/apps/client/app/hooks/__tests__/useTokenLimits.test.ts
+++ b/apps/client/app/hooks/__tests__/useTokenLimits.test.ts
@@ -72,6 +72,41 @@ describe('useTokenLimits', () => {
     expect(result.current.isOverContextWindow).toBe(false);
   });
 
+  // A discovery run can overwrite a seeded media row's contextWindow with the literal 0, meaning
+  // "not applicable" to the feed, not a real zero-token budget (see safeInputWindow in
+  // @bike4mind/utils). Before this fix, maxInputTokens landed at 0 and validateChatInput blocked
+  // every send with a misleading "No AI model selected" - even though a model WAS selected.
+  it('falls back to a usable input budget for a media model whose contextWindow arrives as 0', () => {
+    const modelInfo = [{ id: 'flux-pro-1.1', type: 'image', contextWindow: 0, max_tokens: 10_000 }];
+    const { result } = renderHook(() =>
+      useTokenLimits({
+        model: 'flux-pro-1.1',
+        modelInfo,
+        max_tokens: undefined,
+        chatInputLength: 50,
+      })
+    );
+    expect(result.current.maxInputTokens).toBeGreaterThan(0);
+    expect(result.current.isOverContextWindow).toBe(false);
+  });
+
+  it('still reports a zero input budget for a TEXT model whose contextWindow arrives as 0', () => {
+    // Text rows keep 0 literal: this hook's "still loading" suppression (contextWindowLimit > 0)
+    // is what the caller relies on to avoid a false over-limit flash, and a media-only fallback
+    // must not weaken that for a genuinely misconfigured text row.
+    const modelInfo = [{ id: 'broken-text', type: 'text', contextWindow: 0, max_tokens: 4_096 }];
+    const { result } = renderHook(() =>
+      useTokenLimits({
+        model: 'broken-text',
+        modelInfo,
+        max_tokens: undefined,
+        chatInputLength: 50,
+      })
+    );
+    expect(result.current.contextWindowLimit).toBe(0);
+    expect(result.current.maxInputTokens).toBe(0);
+  });
+
   it('flips isOverContextWindow when input genuinely exceeds the available budget', () => {
     const { result } = renderHook(() =>
       useTokenLimits({

--- a/apps/client/app/hooks/useTokenLimits.ts
+++ b/apps/client/app/hooks/useTokenLimits.ts
@@ -3,6 +3,7 @@ import { computeDefaultMaxTokens } from '../utils/aiSettingsUtils';
 
 interface ModelInfoEntry {
   id: string;
+  type?: string;
   contextWindow?: number;
   max_tokens?: number;
 }
@@ -23,7 +24,13 @@ export function useTokenLimits({ model, modelInfo, max_tokens, chatInputLength }
   const safeMaxTokens = max_tokens ?? 2048;
 
   const activeModelEntry = useMemo(() => modelInfo?.find(m => m.id === model), [model, modelInfo]);
-  const contextWindowLimit = activeModelEntry?.contextWindow ?? 0;
+  const returnsMedia = activeModelEntry?.type === 'image' || activeModelEntry?.type === 'video';
+  // A media row's contextWindow arriving as the literal 0 means "not applicable" (two provider
+  // feeds report it that way on purpose - see safeInputWindow in @bike4mind/utils), not a real
+  // zero-token budget. Falls back the same way an absent window would; a text row keeps 0
+  // literal, so contextWindowLimit === 0 still means "modelInfo hasn't loaded yet" below.
+  const rawContextWindow = activeModelEntry?.contextWindow;
+  const contextWindowLimit = returnsMedia && !rawContextWindow ? 200000 : (rawContextWindow ?? 0);
   const modelCatalogMaxOutput = activeModelEntry?.max_tokens ?? 0;
 
   // Must agree with the store's default (computeDefaultMaxTokens) - this only stands in for the

--- a/apps/client/app/hooks/useTokenLimits.ts
+++ b/apps/client/app/hooks/useTokenLimits.ts
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
+import { DEFAULT_UNKNOWN_CONTEXT_WINDOW, isMediaModelType, type ModelInfo } from '@bike4mind/common';
 import { computeDefaultMaxTokens } from '../utils/aiSettingsUtils';
 
 interface ModelInfoEntry {
   id: string;
-  type?: string;
+  type?: ModelInfo['type'];
   contextWindow?: number;
   max_tokens?: number;
 }
@@ -24,13 +25,14 @@ export function useTokenLimits({ model, modelInfo, max_tokens, chatInputLength }
   const safeMaxTokens = max_tokens ?? 2048;
 
   const activeModelEntry = useMemo(() => modelInfo?.find(m => m.id === model), [model, modelInfo]);
-  const returnsMedia = activeModelEntry?.type === 'image' || activeModelEntry?.type === 'video';
+  const returnsMedia = activeModelEntry?.type !== undefined && isMediaModelType(activeModelEntry.type);
   // A media row's contextWindow arriving as the literal 0 means "not applicable" (two provider
   // feeds report it that way on purpose - see safeInputWindow in @bike4mind/utils), not a real
   // zero-token budget. Falls back the same way an absent window would; a text row keeps 0
   // literal, so contextWindowLimit === 0 still means "modelInfo hasn't loaded yet" below.
   const rawContextWindow = activeModelEntry?.contextWindow;
-  const contextWindowLimit = returnsMedia && !rawContextWindow ? 200000 : (rawContextWindow ?? 0);
+  const contextWindowLimit =
+    returnsMedia && !rawContextWindow ? DEFAULT_UNKNOWN_CONTEXT_WINDOW : (rawContextWindow ?? 0);
   const modelCatalogMaxOutput = activeModelEntry?.max_tokens ?? 0;
 
   // Must agree with the store's default (computeDefaultMaxTokens) - this only stands in for the

--- a/b4m-core/common/src/modelCatalog.ts
+++ b/b4m-core/common/src/modelCatalog.ts
@@ -17,6 +17,14 @@ export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
 export const CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS = 1000;
 
 /**
+ * Fallback context window for a media row whose catalog value is not usable (a discovery feed's
+ * literal 0, meaning "not applicable" rather than a real budget - see isMediaModelType). Shared by
+ * effectiveContextWindow (@bike4mind/utils, server) and useTokenLimits (apps/client, browser) so
+ * the two do not drift onto different placeholder numbers for the same "unknown" case.
+ */
+export const DEFAULT_UNKNOWN_CONTEXT_WINDOW = 200000;
+
+/**
  * The model types this build's ModelInfo consumers narrow on. ModelRecord.type is
  * wider (embedding / tts / realtime-voice), so the read path drops and counts any
  * record outside this set: an old build must degrade to "I do not see the new video
@@ -41,6 +49,14 @@ export type RenderableModelRecord = Omit<ModelRecord, 'type'> & { type: ModelInf
 
 export const isRenderableModelType = (type: string): type is ModelInfoType =>
   (MODEL_INFO_TYPES as readonly string[]).includes(type);
+
+/**
+ * Whether a ModelInfo type returns media (image/video) rather than tokens. Shared by
+ * safeInputWindow/effectiveContextWindow (@bike4mind/utils, server) and useTokenLimits
+ * (apps/client, browser) so "what counts as media" cannot drift between the two halves of the
+ * same guard - both need it, and common is the one package already safe to import from either.
+ */
+export const isMediaModelType = (type: ModelInfo['type']): boolean => type === 'image' || type === 'video';
 
 /**
  * Compile-time guard (T1): toModelInfo must turn a record carrying only the

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -61,6 +61,7 @@ import {
   getLastBuildDebugInfo,
   getSettingsByNames,
   attachedContentExtractionBudget,
+  effectiveContextWindow,
   safeInputWindow,
 } from '@bike4mind/utils';
 // Injected into processFabFilesServer so @bike4mind/utils's barrel carries no jimp
@@ -1594,7 +1595,7 @@ export class ChatCompletionProcess {
 
       // Dynamic history adjustment: now that we have modelInfo, adjust history count
       // based on model's actual context window
-      const contextWindow = modelInfo.contextWindow ?? 200000;
+      const contextWindow = effectiveContextWindow(modelInfo);
 
       // Image models generate from the current prompt alone: the image backend
       // ignores conversation history. Sending history only inflates the token count
@@ -1967,7 +1968,7 @@ export class ChatCompletionProcess {
       this.sendStatusUpdate(quest, 'Gathering data sources...', { statusAt: new Date() });
       // Input-window limits, needed BEFORE building messages because the amount of
       // attached-file content we extract has to be derived from them.
-      const contextLimit = modelInfo.contextWindow ?? 200000;
+      const contextLimit = effectiveContextWindow(modelInfo);
       // safeMaxTokens is resolved once further up, where the verbatim-history window
       // needs it too. An explicit caller budget is honored as-is; only its absence is
       // sized for the model. See resolveOutputMaxTokens for why raising an explicit

--- a/b4m-core/services/src/llm/ChatCompletionProcess.ts
+++ b/b4m-core/services/src/llm/ChatCompletionProcess.ts
@@ -25,6 +25,7 @@ import {
   isExperimentalFeatureEnabled,
   isImageAttachment,
   isImageServeable,
+  isMediaModelType,
   isUnlimitedHistory,
   normalizeRequestedHistoryCount,
   resolveHistoryFetchLimit,
@@ -1597,11 +1598,11 @@ export class ChatCompletionProcess {
       // based on model's actual context window
       const contextWindow = effectiveContextWindow(modelInfo);
 
-      // Image models generate from the current prompt alone: the image backend
+      // Image and video models generate from the current prompt alone: the media backend
       // ignores conversation history. Sending history only inflates the token count
-      // and trips a false context-overflow against the image model's small context
+      // and trips a false context-overflow against the media model's small context
       // window (e.g. FLUX Pro 1.1 at 10k).
-      if (modelInfo.type === 'image') {
+      if (isMediaModelType(modelInfo.type)) {
         historyCount = 0;
       }
 

--- a/b4m-core/utils/src/llm/contextBudget.test.ts
+++ b/b4m-core/utils/src/llm/contextBudget.test.ts
@@ -4,6 +4,7 @@ import {
   attachedContentAssemblyFloor,
   attachedContentBudgetsAgree,
   attachedContentExtractionBudget,
+  effectiveContextWindow,
   EXTRACTION_SYSTEM_RESERVE_MAX_SHARE,
   MIN_ATTACHED_CONTENT_EXTRACTION_SHARE,
   safeInputWindow,
@@ -21,6 +22,24 @@ const GPT4_8K = { contextWindow: 8192, max_tokens: 4096, type: 'text' as const }
 const CLAUDE_200K = { contextWindow: 200_000, max_tokens: 8192, type: 'text' as const };
 
 const CHARS_PER_TOKEN = 3.5;
+
+describe('effectiveContextWindow', () => {
+  it('returns the catalog figure unchanged for a healthy media row', () => {
+    expect(effectiveContextWindow({ contextWindow: 10_000, type: 'image' })).toBe(10_000);
+  });
+
+  it('falls back like an absent value for a media row whose window arrives as 0', () => {
+    expect(effectiveContextWindow({ contextWindow: 0, type: 'video' })).toBe(200000);
+  });
+
+  it('keeps 0 literal for a text row', () => {
+    expect(effectiveContextWindow({ contextWindow: 0, type: 'text' })).toBe(0);
+  });
+
+  it('returns the catalog figure unchanged for a healthy text row', () => {
+    expect(effectiveContextWindow({ contextWindow: 128_000, type: 'text' })).toBe(128_000);
+  });
+});
 
 describe('safeInputWindow', () => {
   it('reserves the requested output and the safety buffer', () => {

--- a/b4m-core/utils/src/llm/contextBudget.test.ts
+++ b/b4m-core/utils/src/llm/contextBudget.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { DEFAULT_UNKNOWN_CONTEXT_WINDOW } from '@bike4mind/common';
 import {
   ATTACHED_CONTENT_EXTRACTION_SHARE,
   attachedContentAssemblyFloor,
@@ -29,7 +30,7 @@ describe('effectiveContextWindow', () => {
   });
 
   it('falls back like an absent value for a media row whose window arrives as 0', () => {
-    expect(effectiveContextWindow({ contextWindow: 0, type: 'video' })).toBe(200000);
+    expect(effectiveContextWindow({ contextWindow: 0, type: 'video' })).toBe(DEFAULT_UNKNOWN_CONTEXT_WINDOW);
   });
 
   it('keeps 0 literal for a text row', () => {
@@ -55,7 +56,9 @@ describe('safeInputWindow', () => {
   // negative and the caller's empty-prompt guard threw on every image/video request once a
   // discovery run wrote that shape over an existing row.
   it('falls back like an absent value when a media row reports its window as 0', () => {
-    expect(safeInputWindow({ contextWindow: 0, max_tokens: 10_000, type: 'image' }, 10_000)).toBe(200000 - 1000);
+    expect(safeInputWindow({ contextWindow: 0, max_tokens: 10_000, type: 'image' }, 10_000)).toBe(
+      DEFAULT_UNKNOWN_CONTEXT_WINDOW - 1000
+    );
   });
 
   it('still goes negative on a TEXT row whose window arrives as 0, preserving the misconfiguration guard', () => {

--- a/b4m-core/utils/src/llm/contextBudget.test.ts
+++ b/b4m-core/utils/src/llm/contextBudget.test.ts
@@ -31,6 +31,18 @@ describe('safeInputWindow', () => {
     expect(safeInputWindow({ contextWindow: 10_000, max_tokens: 10_000, type: 'image' }, 10_000)).toBe(9000);
   });
 
+  // A media row's contextWindow arriving as the literal 0 means "not applicable" (two provider
+  // feeds report it that way on purpose), not a real zero-token budget. Before the fix this went
+  // negative and the caller's empty-prompt guard threw on every image/video request once a
+  // discovery run wrote that shape over an existing row.
+  it('falls back like an absent value when a media row reports its window as 0', () => {
+    expect(safeInputWindow({ contextWindow: 0, max_tokens: 10_000, type: 'image' }, 10_000)).toBe(200000 - 1000);
+  });
+
+  it('still goes negative on a TEXT row whose window arrives as 0, preserving the misconfiguration guard', () => {
+    expect(safeInputWindow({ contextWindow: 0, max_tokens: 4096, type: 'text' }, 4096)).toBeLessThan(0);
+  });
+
   it('caps the reservation at what the model can actually emit', () => {
     expect(safeInputWindow(LLAMA_8K, 999_999)).toBe(8000 - 2048 - 1000);
   });

--- a/b4m-core/utils/src/llm/contextBudget.ts
+++ b/b4m-core/utils/src/llm/contextBudget.ts
@@ -18,7 +18,12 @@
  * will fit does not have to build a completion to find out.
  */
 
-import { CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS, type ModelInfo } from '@bike4mind/common';
+import {
+  CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS,
+  DEFAULT_UNKNOWN_CONTEXT_WINDOW,
+  isMediaModelType,
+  type ModelInfo,
+} from '@bike4mind/common';
 
 /**
  * The context window a caller should reason against: the catalog's own figure, except for a media
@@ -34,9 +39,11 @@ import { CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS, type ModelInfo } from '@bike4mind/
  * video's dynamic-history sizing both read the raw catalog value directly).
  */
 export function effectiveContextWindow(modelInfo: Pick<ModelInfo, 'contextWindow' | 'type'>): number {
-  const returnsMedia = modelInfo.type === 'image' || modelInfo.type === 'video';
+  const returnsMedia = isMediaModelType(modelInfo.type);
   const rawContextWindow = modelInfo.contextWindow;
-  return returnsMedia && !rawContextWindow ? 200000 : (rawContextWindow ?? 200000);
+  return returnsMedia && !rawContextWindow
+    ? DEFAULT_UNKNOWN_CONTEXT_WINDOW
+    : (rawContextWindow ?? DEFAULT_UNKNOWN_CONTEXT_WINDOW);
 }
 
 /**
@@ -62,7 +69,7 @@ export function safeInputWindow(
   requestedMaxTokens: number,
   safetyBuffer = CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS
 ): number {
-  const returnsMedia = modelInfo.type === 'image' || modelInfo.type === 'video';
+  const returnsMedia = isMediaModelType(modelInfo.type);
   const contextLimit = effectiveContextWindow(modelInfo);
   const modelMaxOutput = modelInfo.max_tokens ?? 16384;
   const reservedOutput = returnsMedia ? 0 : Math.min(requestedMaxTokens, modelMaxOutput);

--- a/b4m-core/utils/src/llm/contextBudget.ts
+++ b/b4m-core/utils/src/llm/contextBudget.ts
@@ -21,6 +21,25 @@
 import { CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS, type ModelInfo } from '@bike4mind/common';
 
 /**
+ * The context window a caller should reason against: the catalog's own figure, except for a media
+ * (image/video) row whose window arrives as the literal 0, which falls back the same as an absent
+ * one. Two provider feeds report a media row that way on purpose to mean "not applicable" (see
+ * ModelCatalogTypes.ts), not a real zero-token budget - a text row keeps 0 literal, since a
+ * misconfigured text row is exactly what safeInputWindow's caller-side empty-prompt guard exists to
+ * catch, and that guard has to see a non-positive budget to fire.
+ *
+ * Extracted so every ChatCompletionProcess call site that reasons about the window - not just the
+ * one computing the input budget - shares this fallback instead of each redeclaring `?? 200000` and
+ * drifting from it for exactly this shape (telemetry's contextWindowLimit/utilizationPercentage and
+ * video's dynamic-history sizing both read the raw catalog value directly).
+ */
+export function effectiveContextWindow(modelInfo: Pick<ModelInfo, 'contextWindow' | 'type'>): number {
+  const returnsMedia = modelInfo.type === 'image' || modelInfo.type === 'video';
+  const rawContextWindow = modelInfo.contextWindow;
+  return returnsMedia && !rawContextWindow ? 200000 : (rawContextWindow ?? 200000);
+}
+
+/**
  * Usable input window: the context window less the output this request will reserve, less a safety
  * buffer. Deliberately NOT clamped at zero - the caller's empty-prompt guard depends on seeing a
  * non-positive budget for a genuinely misconfigured text model.
@@ -33,9 +52,7 @@ import { CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS, type ModelInfo } from '@bike4mind/
  *
  * The static catalog tables are held to the positive-budget property by
  * modelCatalogInputBudget.test.ts, and a discovered claim that would break it for a TEXT row is
- * refused in modelDiscoveryService/catalogWrite. A media row whose window arrives as 0 from a feed
- * falls back the same as an absent one, below - two provider sources report it that way on purpose to
- * mean "not applicable" (see ModelCatalogTypes.ts), not a real zero-token budget.
+ * refused in modelDiscoveryService/catalogWrite.
  *
  * The buffer figure is imported rather than redeclared here: common owns it, and two copies of the
  * same number is the drift that made it a shared export in the first place.
@@ -46,10 +63,7 @@ export function safeInputWindow(
   safetyBuffer = CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS
 ): number {
   const returnsMedia = modelInfo.type === 'image' || modelInfo.type === 'video';
-  // A text row keeps 0 literal: a misconfigured text row is exactly what the caller's empty-prompt
-  // guard exists to catch, and that has to see a non-positive budget to fire.
-  const rawContextWindow = modelInfo.contextWindow;
-  const contextLimit = returnsMedia && !rawContextWindow ? 200000 : (rawContextWindow ?? 200000);
+  const contextLimit = effectiveContextWindow(modelInfo);
   const modelMaxOutput = modelInfo.max_tokens ?? 16384;
   const reservedOutput = returnsMedia ? 0 : Math.min(requestedMaxTokens, modelMaxOutput);
   return contextLimit - reservedOutput - safetyBuffer;

--- a/b4m-core/utils/src/llm/contextBudget.ts
+++ b/b4m-core/utils/src/llm/contextBudget.ts
@@ -33,8 +33,9 @@ import { CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS, type ModelInfo } from '@bike4mind/
  *
  * The static catalog tables are held to the positive-budget property by
  * modelCatalogInputBudget.test.ts, and a discovered claim that would break it for a TEXT row is
- * refused in modelDiscoveryService/catalogWrite. Neither covers a media row whose window arrives as 0
- * from a feed, where the buffer still makes this negative.
+ * refused in modelDiscoveryService/catalogWrite. A media row whose window arrives as 0 from a feed
+ * falls back the same as an absent one, below - two provider sources report it that way on purpose to
+ * mean "not applicable" (see ModelCatalogTypes.ts), not a real zero-token budget.
  *
  * The buffer figure is imported rather than redeclared here: common owns it, and two copies of the
  * same number is the drift that made it a shared export in the first place.
@@ -44,9 +45,12 @@ export function safeInputWindow(
   requestedMaxTokens: number,
   safetyBuffer = CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS
 ): number {
-  const contextLimit = modelInfo.contextWindow ?? 200000;
-  const modelMaxOutput = modelInfo.max_tokens ?? 16384;
   const returnsMedia = modelInfo.type === 'image' || modelInfo.type === 'video';
+  // A text row keeps 0 literal: a misconfigured text row is exactly what the caller's empty-prompt
+  // guard exists to catch, and that has to see a non-positive budget to fire.
+  const rawContextWindow = modelInfo.contextWindow;
+  const contextLimit = returnsMedia && !rawContextWindow ? 200000 : (rawContextWindow ?? 200000);
+  const modelMaxOutput = modelInfo.max_tokens ?? 16384;
   const reservedOutput = returnsMedia ? 0 : Math.min(requestedMaxTokens, modelMaxOutput);
   return contextLimit - reservedOutput - safetyBuffer;
 }

--- a/packages/database/src/seeds/modelCatalogInputBudget.test.ts
+++ b/packages/database/src/seeds/modelCatalogInputBudget.test.ts
@@ -90,9 +90,9 @@ describe('static model catalog input budget', () => {
     const overWindow = media.filter(model => (model.max_tokens ?? 0) > (model.contextWindow ?? 0));
     expect(overWindow.map(describeEntry)).toEqual([]);
 
-    // No output is reserved for media, but the safety buffer still comes off the top. This holds
-    // for the adapter tables only: two provider feeds report a media window as 0 on purpose, and a
-    // discovery row outranks the seed, which is a live failure tracked separately.
+    // No output is reserved for media, but the safety buffer still comes off the top. Holds for the
+    // adapter tables directly; a discovered row whose feed reports the window as 0 goes through
+    // safeInputWindow's own fallback for that shape instead of this raw arithmetic.
     const starved = media.filter(model => (model.contextWindow ?? 0) - CONTEXT_WINDOW_SAFETY_BUFFER_TOKENS <= 0);
     expect(starved.map(describeEntry)).toEqual([]);
   });


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1511" height="812" alt="flux-pro-1 1-zero-context-window-clears-guard" src="https://github.com/user-attachments/assets/29d44d38-60ac-48fd-8d02-e3964392bedb" />

*Live repro on a self-hosted stack: `flux-pro-1.1` seeded with `contextWindow: 0` (the real post-discovery shape). Sending a prompt clears both guards and reaches the server - it fails only on an unrelated local infra gap (missing image-gen queue), never on "No AI model selected" or "no input budget".*

## Description
Closes #1409.

Two provider feeds (BFL, xAI) report an image/video model's context window as the literal `0` on purpose, meaning "not applicable" rather than a real zero-token budget. `safeInputWindow` only fell back to a default when the window was absent (`??`), not when it was the literal `0`, so once a discovery run wrote that shape over an existing seeded row, every request against that model computed a negative input budget and hit the empty-prompt guard (added in #1004) instead of generating anything.

Media rows now fall back the same way an absent window would. Text rows keep `0` literal on purpose - a misconfigured text row is exactly what that guard exists to catch, and it needs to see a non-positive budget to fire.

While reproducing this live, I found the client has its own copy of the same defect. `useTokenLimits` also reads `contextWindow` literally, so a browser hitting this exact catalog shape got blocked before the request ever reached the server, with a misleading "No AI model selected" - even though a model was selected. Fixed the same way in both places.

## Changes
- `contextBudget.ts` (`safeInputWindow`) - a media (image/video) row whose `contextWindow` arrives as `0` now falls back to the same default an absent window would use, instead of subtracting the safety buffer from zero.
- `contextBudget.test.ts` - new cases for the fixed media shape and for the preserved text-row guard.
- `modelCatalogInputBudget.test.ts` - updated a comment that called the feed-tier gap "a live failure tracked separately"; it's fixed at `safeInputWindow` now.
- `useTokenLimits.ts` - the client-side companion fix, same fallback shape.
- `useTokenLimits.test.ts` - new cases mirroring the server-side ones.

## Guide for Testers
The bug only reproduces once a catalog row carries this shape, which normally only a discovery run writes - not reproducible through the UI without seeding that row first. Verified live against a self-hosted stack by seeding one real image-model row with `contextWindow: 0` (the exact post-discovery shape) and driving the actual chat composer:

1. With that row selected, typing a prompt and sending it no longer shows "No AI model selected" (the client-side symptom) or "Cannot build a prompt ... no input budget" (the server-side symptom) - the request reaches the server and proceeds to the provider call.
2. Automated coverage for both layers:
   - `pnpm --filter @bike4mind/utils test -- src/llm/contextBudget.test.ts`
   - `pnpm --filter client test -- app/hooks/__tests__/useTokenLimits.test.ts`
3. Expected: all tests pass, including the fixed-media-shape case and the preserved-text-row-guard case in each file.

**What NOT to test:** a healthy image/video request on `main` today already works fine, since the seeded rows never carry this shape - only a row a discovery run (or a manual DB edit reproducing it) has touched shows the bug.

## Additional Information
N/A

## Developer Notes (Optional)
N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
