### PR TITLE
refactor(client): unify the three data-lake tree implementations

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeViewer.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeViewer.tsx
@@ -7,8 +7,6 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
-  Input,
-  List,
   ListItem,
   ListItemButton,
   ListItemContent,
@@ -18,7 +16,6 @@ import {
   Tooltip,
   Typography,
 } from '@mui/joy';
-import SearchIcon from '@mui/icons-material/Search';
 import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
 import FolderIcon from '@mui/icons-material/Folder';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
@@ -28,12 +25,16 @@ import ChatIcon from '@mui/icons-material/Chat';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { DataLakeIcon } from '@client/app/components/datalake/dataLakeBranding';
-import { buildTagTree, getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
+import { buildTagTree } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import { useGetFabFileContent } from '@client/app/hooks/data/fabFiles';
 import { useDataLakeFiles, useReprocessFabFile, useRemoveFileFromDataLake } from '@client/app/hooks/data/dataLakes';
 import MarkdownViewer from '@client/app/components/Knowledge/MarkdownViewer';
 import type { IFabFileDocument } from '@bike4mind/common';
 import { satisfiesTagPrefix } from '@bike4mind/common';
+import DataLakeTreeView, {
+  UNCATEGORIZED_KEY,
+  type DataLakeTreeChrome,
+} from '@client/app/components/datalake/DataLakeTreeView';
 
 // Utilities
 
@@ -156,10 +157,6 @@ export default function DataLakeViewer({
 
 // Tree Sidebar
 
-// Synthetic category for lake files that carry no prefix-matching tag (e.g.
-// appended/meta-tag-only files), so every file is always reachable in the viewer.
-const UNCATEGORIZED_KEY = '__uncategorized__';
-
 interface TreeSidebarProps {
   tree: ReturnType<typeof buildTagTree>;
   articles: IFabFileDocument[];
@@ -183,22 +180,6 @@ function TreeSidebar({
   isLoading,
   isError,
 }: TreeSidebarProps) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<'count' | 'alpha'>('count');
-
-  const currentNodes = useMemo(() => getNodesAtPath(tree, breadcrumb), [tree, breadcrumb]);
-
-  const filteredNodes = useMemo(() => {
-    let nodes = currentNodes;
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      nodes = nodes.filter(node => node.segment.toLowerCase().includes(q));
-    }
-    return [...nodes].sort((a, b) =>
-      sortBy === 'count' ? b.fileCount - a.fileCount : a.segment.localeCompare(b.segment)
-    );
-  }, [currentNodes, searchQuery, sortBy]);
-
   // Files in the lake with no prefix-matching (non-meta) tag - surfaced under "Uncategorized".
   // Shares the server's predicate so this bucket holds exactly the files the write doors and the
   // backfill consider uncategorized; a local copy already drifted on the bare-prefix case.
@@ -217,164 +198,125 @@ function TreeSidebar({
     [articles, prefixNorm]
   );
 
-  const isUncategorized = breadcrumb.length === 1 && breadcrumb[0] === UNCATEGORIZED_KEY;
-  const leafTag = !isUncategorized && breadcrumb.length > 0 && currentNodes.length === 0 ? breadcrumb.join(':') : null;
-  const showFiles = isUncategorized || !!leafTag;
-  const files = useMemo(() => {
-    if (isUncategorized) return uncategorizedFiles;
-    if (!leafTag) return [];
-    return [...articles]
-      .filter(f => (f.tags ?? []).some(t => t.name === leafTag))
-      .sort((a, b) => a.fileName.localeCompare(b.fileName));
-  }, [isUncategorized, uncategorizedFiles, leafTag, articles]);
+  const chrome: DataLakeTreeChrome = {
+    containerSx: {
+      width: 280,
+      minWidth: 280,
+      borderRight: '1px solid',
+      borderColor: 'divider',
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+    },
+    toolbarSx: { p: 1.5, pb: 1, display: 'flex', gap: 0.5, alignItems: 'center' },
+    searchPlaceholder: 'Filter...',
+    searchSx: { fontSize: '13px', flex: 1 },
+    renderSortButton: (sortBy, toggle) => (
+      <Tooltip title={sortBy === 'count' ? 'Sort: by count (click for A-Z)' : 'Sort: A-Z (click for count)'} size="sm">
+        <IconButton
+          size="sm"
+          variant={sortBy === 'alpha' ? 'soft' : 'plain'}
+          color="neutral"
+          onClick={toggle}
+          data-testid="datalake-sort-toggle"
+          data-sort={sortBy}
+          sx={{ flexShrink: 0 }}
+        >
+          <SortByAlphaIcon sx={{ fontSize: 18 }} />
+        </IconButton>
+      </Tooltip>
+    ),
+    renderBackRow: (label, onBack) => (
+      <ListItemButton onClick={onBack} sx={{ px: 1.5, py: 0.75, gap: 1, minHeight: 36 }} data-testid="datalake-back">
+        <ArrowBackIcon sx={{ fontSize: 16, color: 'text.tertiary' }} />
+        <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+          {label}
+        </Typography>
+      </ListItemButton>
+    ),
+    scrollSx: { flex: 1, overflow: 'auto' },
+    nodeListSx: { '--ListItem-paddingX': '12px', '--ListItem-paddingY': '4px' },
+    fileListSx: { '--ListItem-paddingX': '12px', '--ListItem-paddingY': '6px' },
+    renderNodeRow: (node, _depth, onOpen) => (
+      <ListItem key={node.segment}>
+        <ListItemButton
+          onClick={onOpen}
+          sx={{ borderRadius: 'sm', gap: 1 }}
+          data-testid={`datalake-node-${node.segment}`}
+        >
+          {node.children.length > 0 ? (
+            <FolderIcon sx={{ fontSize: 18, color: 'warning.400' }} />
+          ) : (
+            <FolderOpenIcon sx={{ fontSize: 18, color: 'warning.300' }} />
+          )}
+          <ListItemContent>
+            <Typography level="body-sm" sx={{ fontWeight: 'md' }}>
+              {humanizeSegment(node.segment)}
+            </Typography>
+          </ListItemContent>
+          <Chip size="sm" variant="soft" color="neutral" sx={{ minHeight: 20, fontSize: '11px' }}>
+            {node.fileCount}
+          </Chip>
+        </ListItemButton>
+      </ListItem>
+    ),
+    renderFileRow: (file, selected, onSelect) => (
+      <ListItem key={file.id}>
+        <ListItemButton
+          selected={selected}
+          onClick={onSelect}
+          sx={{ borderRadius: 'sm', gap: 1 }}
+          data-testid={`datalake-file-${file.id}`}
+        >
+          <ArticleIcon sx={{ fontSize: 16, color: 'text.tertiary', flexShrink: 0 }} />
+          <ListItemContent>
+            <Typography level="body-xs" noWrap sx={{ fontWeight: selected ? 'lg' : undefined }}>
+              {file.fileName.replace(/\.[^/.]+$/, '')}
+            </Typography>
+          </ListItemContent>
+        </ListItemButton>
+      </ListItem>
+    ),
+    humanize: segment => humanizeSegment(segment),
+    allCategoriesLabel: 'All Categories',
+    emptyFilesLabel: 'No files found',
+    errorLabel: 'Failed to load files',
+  };
 
   return (
-    <Box
-      data-testid="datalake-tree"
-      sx={{
-        width: 280,
-        minWidth: 280,
-        borderRight: '1px solid',
-        borderColor: 'divider',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
+    <DataLakeTreeView
+      tree={tree}
+      articles={articles}
+      breadcrumb={breadcrumb}
+      onNavigate={onNavigate}
+      selectedFileId={selectedFileId}
+      onSelectFile={onSelectFile}
+      isLoading={isLoading}
+      isError={isError}
+      chrome={chrome}
+      uncategorized={{
+        files: uncategorizedFiles,
+        renderRow: (count, onOpen) => (
+          <ListItem key={UNCATEGORIZED_KEY}>
+            <ListItemButton
+              onClick={onOpen}
+              sx={{ borderRadius: 'sm', gap: 1 }}
+              data-testid="datalake-node-uncategorized"
+            >
+              <FolderOpenIcon sx={{ fontSize: 18, color: 'neutral.400' }} />
+              <ListItemContent>
+                <Typography level="body-sm" sx={{ fontWeight: 'md', fontStyle: 'italic', color: 'text.secondary' }}>
+                  Uncategorized
+                </Typography>
+              </ListItemContent>
+              <Chip size="sm" variant="soft" color="neutral" sx={{ minHeight: 20, fontSize: '11px' }}>
+                {count}
+              </Chip>
+            </ListItemButton>
+          </ListItem>
+        ),
       }}
-    >
-      <Box sx={{ p: 1.5, pb: 1, display: 'flex', gap: 0.5, alignItems: 'center' }}>
-        <Input
-          size="sm"
-          placeholder="Filter..."
-          startDecorator={<SearchIcon sx={{ fontSize: 18 }} />}
-          value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
-          sx={{ fontSize: '13px', flex: 1 }}
-        />
-        <Tooltip
-          title={sortBy === 'count' ? 'Sort: by count (click for A-Z)' : 'Sort: A-Z (click for count)'}
-          size="sm"
-        >
-          <IconButton
-            size="sm"
-            variant={sortBy === 'alpha' ? 'soft' : 'plain'}
-            color="neutral"
-            onClick={() => setSortBy(prev => (prev === 'count' ? 'alpha' : 'count'))}
-            sx={{ flexShrink: 0 }}
-          >
-            <SortByAlphaIcon sx={{ fontSize: 18 }} />
-          </IconButton>
-        </Tooltip>
-      </Box>
-
-      {breadcrumb.length > 0 && (
-        <ListItemButton
-          onClick={() => onNavigate(breadcrumb.slice(0, -1))}
-          sx={{ px: 1.5, py: 0.75, gap: 1, minHeight: 36 }}
-        >
-          <ArrowBackIcon sx={{ fontSize: 16, color: 'text.tertiary' }} />
-          <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-            {breadcrumb.length === 1 ? 'All Categories' : humanizeSegment(breadcrumb[breadcrumb.length - 2])}
-          </Typography>
-        </ListItemButton>
-      )}
-
-      <Box sx={{ flex: 1, overflow: 'auto' }}>
-        {isError ? (
-          <Box sx={{ p: 2, textAlign: 'center' }}>
-            <Typography level="body-xs" sx={{ color: 'danger.400' }}>
-              Failed to load files
-            </Typography>
-          </Box>
-        ) : isLoading ? (
-          <Box sx={{ p: 1.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {[1, 2, 3, 4].map(i => (
-              <Skeleton key={i} variant="rectangular" height={32} sx={{ borderRadius: 'sm' }} />
-            ))}
-          </Box>
-        ) : showFiles ? (
-          <List size="sm" sx={{ '--ListItem-paddingX': '12px', '--ListItem-paddingY': '6px' }}>
-            {files.length === 0 ? (
-              <Box sx={{ p: 2, textAlign: 'center' }}>
-                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                  No files found
-                </Typography>
-              </Box>
-            ) : (
-              files.map(file => (
-                <ListItem key={file.id}>
-                  <ListItemButton
-                    selected={selectedFileId === file.id}
-                    onClick={() => onSelectFile(file)}
-                    sx={{ borderRadius: 'sm', gap: 1 }}
-                  >
-                    <ArticleIcon sx={{ fontSize: 16, color: 'text.tertiary', flexShrink: 0 }} />
-                    <ListItemContent>
-                      <Typography
-                        level="body-xs"
-                        noWrap
-                        sx={{ fontWeight: selectedFileId === file.id ? 'lg' : undefined }}
-                      >
-                        {file.fileName.replace(/\.[^/.]+$/, '')}
-                      </Typography>
-                    </ListItemContent>
-                  </ListItemButton>
-                </ListItem>
-              ))
-            )}
-          </List>
-        ) : (
-          <List size="sm" sx={{ '--ListItem-paddingX': '12px', '--ListItem-paddingY': '4px' }}>
-            {filteredNodes.map(node => (
-              <ListItem key={node.segment}>
-                <ListItemButton
-                  onClick={() => onNavigate([...breadcrumb, node.segment])}
-                  sx={{ borderRadius: 'sm', gap: 1 }}
-                >
-                  {node.children.length > 0 ? (
-                    <FolderIcon sx={{ fontSize: 18, color: 'warning.400' }} />
-                  ) : (
-                    <FolderOpenIcon sx={{ fontSize: 18, color: 'warning.300' }} />
-                  )}
-                  <ListItemContent>
-                    <Typography level="body-sm" sx={{ fontWeight: 'md' }}>
-                      {humanizeSegment(node.segment)}
-                    </Typography>
-                  </ListItemContent>
-                  <Chip size="sm" variant="soft" color="neutral" sx={{ minHeight: 20, fontSize: '11px' }}>
-                    {node.fileCount}
-                  </Chip>
-                </ListItemButton>
-              </ListItem>
-            ))}
-
-            {/* Fallback bucket: files with no prefix-matching tag, so nothing is hidden. */}
-            {breadcrumb.length === 0 && !searchQuery && uncategorizedFiles.length > 0 && (
-              <ListItem key={UNCATEGORIZED_KEY}>
-                <ListItemButton onClick={() => onNavigate([UNCATEGORIZED_KEY])} sx={{ borderRadius: 'sm', gap: 1 }}>
-                  <FolderOpenIcon sx={{ fontSize: 18, color: 'neutral.400' }} />
-                  <ListItemContent>
-                    <Typography level="body-sm" sx={{ fontWeight: 'md', fontStyle: 'italic', color: 'text.secondary' }}>
-                      Uncategorized
-                    </Typography>
-                  </ListItemContent>
-                  <Chip size="sm" variant="soft" color="neutral" sx={{ minHeight: 20, fontSize: '11px' }}>
-                    {uncategorizedFiles.length}
-                  </Chip>
-                </ListItemButton>
-              </ListItem>
-            )}
-
-            {filteredNodes.length === 0 && !(breadcrumb.length === 0 && uncategorizedFiles.length > 0) && (
-              <Box sx={{ p: 2, textAlign: 'center' }}>
-                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                  {searchQuery ? 'No matches' : 'No categories'}
-                </Typography>
-              </Box>
-            )}
-          </List>
-        )}
-      </Box>
-    </Box>
+    />
   );
 }
 

--- a/apps/client/app/components/datalake/DataLakeChatTree.tsx
+++ b/apps/client/app/components/datalake/DataLakeChatTree.tsx
@@ -1,20 +1,15 @@
-import { useState, useMemo } from 'react';
 import {
   Box,
   Button,
   Chip,
   IconButton,
-  Input,
-  List,
   ListItem,
   ListItemButton,
   ListItemContent,
-  Skeleton,
   Tooltip,
   Typography,
   useTheme,
 } from '@mui/joy';
-import SearchIcon from '@mui/icons-material/Search';
 import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -22,7 +17,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { HEADER_ICON_BUTTON_SX } from '@client/app/components/Session/AISettings/headerIconButtonSx';
 import type { TagNode } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
-import { getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
+import DataLakeTreeView, { type DataLakeTreeChrome } from './DataLakeTreeView';
 import { HUES, inkFor } from '@client/app/components/datalake/deckChrome';
 import {
   COUNT_CHIP_SX,
@@ -37,7 +32,6 @@ import {
   treeBackRowSx,
   treeRowSx,
 } from '@client/app/components/datalake/treeChrome';
-import type { TreeSortMode } from '@client/app/components/datalake/treeChrome';
 import type { IFabFileDocument } from '@bike4mind/common';
 import { gray } from '@client/app/utils/themes/colors';
 
@@ -82,125 +76,124 @@ export default function DataLakeChatTree({
 }: DataLakeChatTreeProps) {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<TreeSortMode>('count');
-  const SortModeIcon = SORT_MODE_ICON[sortBy];
 
-  const currentNodes = useMemo(() => getNodesAtPath(tree, breadcrumb), [tree, breadcrumb]);
-
-  const filteredNodes = useMemo(() => {
-    let nodes = currentNodes;
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      nodes = nodes.filter(node => node.segment.toLowerCase().includes(q));
-    }
-    return [...nodes].sort((a, b) =>
-      sortBy === 'count' ? b.fileCount - a.fileCount : a.segment.localeCompare(b.segment)
-    );
-  }, [currentNodes, searchQuery, sortBy]);
-
-  // At a leaf node (no children), filter articles locally by the leaf tag
-  const leafTag = breadcrumb.length > 0 && currentNodes.length === 0 ? breadcrumb.join(':') : null;
-  const showFiles = !!leafTag;
-  const files = useMemo(() => {
-    if (!leafTag) return [];
-    return [...articles]
-      .filter(f => (f.tags ?? []).some(t => t.name === leafTag))
-      .sort((a, b) => a.fileName.localeCompare(b.fileName));
-  }, [leafTag, articles]);
-
-  return (
+  const header = (
     <Box
-      className="datalake-tree"
-      data-testid="datalake-tree"
+      className="datalake-tree-header"
       sx={{
-        width: 260,
-        minWidth: 260,
+        height: '48px',
+        boxSizing: 'border-box',
+        p: '12px',
         display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-        // Styled to match the main app sidenav (see layouts/Notebook/Sidenav/index.tsx).
-        backgroundColor: 'background.surface2',
-        border: '1px solid',
+        alignItems: 'center',
+        gap: '10px',
+        borderBottom: '1px solid',
         borderColor: isDark ? gray[800] : gray[200],
-        borderRadius: '10px',
       }}
     >
-      {/* Header: title + close (turns Data Lake mode off for this chat). */}
-      <Box
-        className="datalake-tree-header"
-        sx={{
-          height: '48px',
-          boxSizing: 'border-box',
-          p: '12px',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '10px',
-          borderBottom: '1px solid',
-          borderColor: isDark ? gray[800] : gray[200],
-        }}
-      >
-        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: '6px' }}>
-          <Typography noWrap sx={{ fontSize: '14px', fontWeight: 300, color: 'text.primary' }}>
-            {title}
-          </Typography>
-          <Tooltip
-            title="Ground this chat in your Data Lakes - the assistant answers from the files in your lakes, with citations. Turn it on for any chat; use Create to add a lake and Manage to organize them."
-            placement="top"
-            size="sm"
-            sx={{ maxWidth: 280 }}
-          >
-            <IconButton
-              size="sm"
-              variant="plain"
-              color="neutral"
-              aria-label="About Data Lakes"
-              data-testid="datalake-info-icon"
-              sx={{ ...HEADER_ICON_BUTTON_SX, flexShrink: 0 }}
-            >
-              <HelpOutlineIcon sx={{ fontSize: 16 }} />
-            </IconButton>
-          </Tooltip>
-        </Box>
-        {onClose && (
-          <Tooltip title="Close Data Lakes" size="sm">
-            <IconButton
-              variant="plain"
-              color="neutral"
-              onClick={onClose}
-              aria-label="Close Data Lakes"
-              data-testid="datalake-close-btn"
-              sx={theme => ({
-                ...ICON_BTN_SX,
-                // No pressed/active fill - the icon brightening is the only affordance.
-                '--variant-plainActiveBg': 'transparent',
-                // Icon reads this var; the button flips it on hover so the swap can't lose a
-                // specificity fight with the icon's own color. text.icon == text.tertiary in
-                // this theme, so hover uses the brighter neutral plain color instead.
-                '--dl-close-color': theme.vars.palette.text.tertiary,
-                '&:hover': { '--dl-close-color': theme.vars.palette.neutral.plainColor },
-              })}
-            >
-              <CloseIcon sx={{ fontSize: 18, color: 'var(--dl-close-color)', transition: 'color 0.15s' }} />
-            </IconButton>
-          </Tooltip>
-        )}
-      </Box>
-
-      {/* Search bar + sort toggle */}
-      <Box
-        className="datalake-tree-toolbar"
-        sx={{ mt: '12px', mb: '20px', px: '12px', display: 'flex', gap: '10px', alignItems: 'center' }}
-      >
-        <Input
+      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <Typography noWrap sx={{ fontSize: '14px', fontWeight: 300, color: 'text.primary' }}>
+          {title}
+        </Typography>
+        <Tooltip
+          title="Ground this chat in your Data Lakes - the assistant answers from the files in your lakes, with citations. Turn it on for any chat; use Create to add a lake and Manage to organize them."
+          placement="top"
           size="sm"
-          placeholder="Search"
-          startDecorator={<SearchIcon sx={{ fontSize: 18 }} />}
-          value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
-          data-testid="datalake-search"
-          sx={{ flex: 1, '--Input-minHeight': '32px', color: 'text.primary', boxShadow: 'none' }}
-        />
+          sx={{ maxWidth: 280 }}
+        >
+          <IconButton
+            size="sm"
+            variant="plain"
+            color="neutral"
+            aria-label="About Data Lakes"
+            data-testid="datalake-info-icon"
+            sx={{ ...HEADER_ICON_BUTTON_SX, flexShrink: 0 }}
+          >
+            <HelpOutlineIcon sx={{ fontSize: 16 }} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+      {onClose && (
+        <Tooltip title="Close Data Lakes" size="sm">
+          <IconButton
+            variant="plain"
+            color="neutral"
+            onClick={onClose}
+            aria-label="Close Data Lakes"
+            data-testid="datalake-close-btn"
+            sx={theme => ({
+              ...ICON_BTN_SX,
+              // No pressed/active fill - the icon brightening is the only affordance.
+              '--variant-plainActiveBg': 'transparent',
+              // Icon reads this var; the button flips it on hover so the swap can't lose a
+              // specificity fight with the icon's own color. text.icon == text.tertiary in
+              // this theme, so hover uses the brighter neutral plain color instead.
+              '--dl-close-color': theme.vars.palette.text.tertiary,
+              '&:hover': { '--dl-close-color': theme.vars.palette.neutral.plainColor },
+            })}
+          >
+            <CloseIcon sx={{ fontSize: 18, color: 'var(--dl-close-color)', transition: 'color 0.15s' }} />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Box>
+  );
+
+  const footer = (onManage || onCreateLake) && (
+    <Box
+      className="datalake-tree-footer"
+      sx={{
+        display: 'flex',
+        gap: '8px',
+        p: '12px',
+        borderTop: '1px solid',
+        borderColor: isDark ? gray[800] : gray[200],
+      }}
+    >
+      {onManage && (
+        <Button
+          variant="outlined"
+          color="neutral"
+          onClick={onManage}
+          data-testid="datalake-manage-btn"
+          sx={FOOTER_BTN_SX}
+        >
+          Manage
+        </Button>
+      )}
+      {onCreateLake && (
+        <Button
+          variant="solid"
+          color="primary"
+          onClick={onCreateLake}
+          data-testid="datalake-create-btn"
+          sx={FOOTER_BTN_SX}
+        >
+          Create
+        </Button>
+      )}
+    </Box>
+  );
+
+  const chrome: DataLakeTreeChrome = {
+    containerSx: {
+      width: 260,
+      minWidth: 260,
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+      // Styled to match the main app sidenav (see layouts/Notebook/Sidenav/index.tsx).
+      backgroundColor: 'background.surface2',
+      border: '1px solid',
+      borderColor: isDark ? gray[800] : gray[200],
+      borderRadius: '10px',
+    },
+    toolbarSx: { mt: '12px', mb: '20px', px: '12px', display: 'flex', gap: '10px', alignItems: 'center' },
+    searchPlaceholder: 'Search',
+    searchSx: { flex: 1, '--Input-minHeight': '32px', color: 'text.primary', boxShadow: 'none' },
+    renderSortButton: (sortBy, toggle) => {
+      const SortModeIcon = SORT_MODE_ICON[sortBy];
+      return (
         <Tooltip
           title={sortBy === 'count' ? 'Sort: by count (click for A-Z)' : 'Sort: A-Z (click for count)'}
           size="sm"
@@ -208,7 +201,7 @@ export default function DataLakeChatTree({
           <IconButton
             variant="outlined"
             color="neutral"
-            onClick={() => setSortBy(prev => (prev === 'count' ? 'alpha' : 'count'))}
+            onClick={toggle}
             data-testid="datalake-sort-toggle"
             data-sort={sortBy}
             sx={{ ...ICON_BTN_SX, flexShrink: 0 }}
@@ -216,154 +209,84 @@ export default function DataLakeChatTree({
             <SortModeIcon sx={{ fontSize: 18 }} />
           </IconButton>
         </Tooltip>
-      </Box>
-
-      {/* Tree / file list */}
-      <Box className="datalake-tree-list" sx={{ ...TREE_SCROLL_SX, px: '8px' }}>
-        {/* Breadcrumb back - styled like the tree items (14px / gray[200]), pinned while scrolling. */}
-        {breadcrumb.length > 0 && (
-          <Box sx={TREE_BACK_STICKY_SX}>
-            <ListItemButton
-              onClick={() => onNavigate(breadcrumb.slice(0, -1))}
-              data-testid="datalake-back"
-              sx={treeBackRowSx(theme.palette.notebooklist.hoverBg)}
-            >
-              <ArrowBackIcon sx={{ fontSize: 16, color: 'text.secondary', flexShrink: 0 }} />
+      );
+    },
+    renderBackRow: (label, onBack) => (
+      <ListItemButton
+        onClick={onBack}
+        data-testid="datalake-back"
+        sx={treeBackRowSx(theme.palette.notebooklist.hoverBg)}
+      >
+        <ArrowBackIcon sx={{ fontSize: 16, color: 'text.secondary', flexShrink: 0 }} />
+        <Typography noWrap sx={{ fontSize: '14px', fontWeight: 400, color: 'text.primary' }}>
+          {label}
+        </Typography>
+      </ListItemButton>
+    ),
+    stickyBackSx: TREE_BACK_STICKY_SX,
+    scrollSx: { ...TREE_SCROLL_SX, px: '8px' },
+    nodeListSx: TREE_LIST_SX,
+    fileListSx: TREE_LIST_SX,
+    renderNodeRow: (node, depth, onOpen) => {
+      const branchInk = inkFor(hueForBranch(node.segment, breadcrumb), isDark);
+      return (
+        <ListItem key={node.segment}>
+          <ListItemButton
+            onClick={onOpen}
+            sx={treeRowSx(theme.palette.notebooklist.hoverBg)}
+            data-testid={`datalake-node-${node.segment}`}
+          >
+            <FolderOutlinedIcon sx={{ fontSize: 16, color: branchInk, flexShrink: 0 }} />
+            <ListItemContent>
               <Typography noWrap sx={{ fontSize: '14px', fontWeight: 400, color: 'text.primary' }}>
-                {breadcrumb.length === 1
-                  ? 'All Categories'
-                  : humanizeSegment(breadcrumb[breadcrumb.length - 2], breadcrumb.length - 2)}
+                {humanizeSegment(node.segment, depth)}
               </Typography>
-            </ListItemButton>
-          </Box>
-        )}
-        {isError ? (
-          <Box sx={{ p: 2, textAlign: 'center' }} data-testid="datalake-error">
-            <Typography level="body-xs" sx={{ color: 'danger.400' }}>
-              Failed to load articles
-            </Typography>
-          </Box>
-        ) : isLoading ? (
-          <Box sx={{ p: 1.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {[1, 2, 3, 4].map(i => (
-              <Skeleton key={i} variant="rectangular" height={32} sx={{ borderRadius: 'sm' }} />
-            ))}
-          </Box>
-        ) : showFiles ? (
-          /* File list at leaf */
-          <List size="sm" sx={TREE_LIST_SX}>
-            {files.length === 0 ? (
-              <Box sx={{ p: 2, textAlign: 'center' }}>
-                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                  No articles found
-                </Typography>
-              </Box>
-            ) : (
-              files.map(file => (
-                <ListItem key={file.id}>
-                  <ListItemButton
-                    selected={selectedFileId === file.id}
-                    onClick={() => onSelectFile(file)}
-                    data-testid={`datalake-file-${file.id}`}
-                    sx={treeRowSx(theme.palette.notebooklist.hoverBg)}
-                  >
-                    <ArticleOutlinedIcon
-                      sx={{
-                        fontSize: 16,
-                        color: selectedFileId === file.id ? inkFor(HUES.cyan, isDark) : 'text.tertiary',
-                        flexShrink: 0,
-                      }}
-                    />
-                    <ListItemContent>
-                      <Typography
-                        noWrap
-                        sx={{
-                          fontSize: '14px',
-                          fontWeight: selectedFileId === file.id ? 'lg' : 400,
-                          color: 'text.primary',
-                        }}
-                      >
-                        {file.fileName.replace(/\.[^/.]+$/, '')}
-                      </Typography>
-                    </ListItemContent>
-                  </ListItemButton>
-                </ListItem>
-              ))
-            )}
-          </List>
-        ) : (
-          /* Folder tree */
-          <List size="sm" sx={TREE_LIST_SX}>
-            {filteredNodes.length === 0 ? (
-              <Box sx={{ p: 2, textAlign: 'center' }}>
-                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                  {searchQuery ? 'No matches' : 'No categories'}
-                </Typography>
-              </Box>
-            ) : (
-              filteredNodes.map(node => {
-                const branchInk = inkFor(hueForBranch(node.segment, breadcrumb), isDark);
-                return (
-                  <ListItem key={node.segment}>
-                    <ListItemButton
-                      onClick={() => onNavigate([...breadcrumb, node.segment])}
-                      sx={treeRowSx(theme.palette.notebooklist.hoverBg)}
-                      data-testid={`datalake-node-${node.segment}`}
-                    >
-                      <FolderOutlinedIcon sx={{ fontSize: 16, color: branchInk, flexShrink: 0 }} />
-                      <ListItemContent>
-                        <Typography noWrap sx={{ fontSize: '14px', fontWeight: 400, color: 'text.primary' }}>
-                          {humanizeSegment(node.segment, breadcrumb.length)}
-                        </Typography>
-                      </ListItemContent>
-                      <Chip size="sm" variant="soft" color="neutral" sx={COUNT_CHIP_SX}>
-                        {node.fileCount}
-                      </Chip>
-                    </ListItemButton>
-                  </ListItem>
-                );
-              })
-            )}
-          </List>
-        )}
-      </Box>
-
-      {/* Sticky bottom bar: manage / create lakes. Pinned below the scrollable list. */}
-      {(onManage || onCreateLake) && (
-        <Box
-          className="datalake-tree-footer"
-          sx={{
-            display: 'flex',
-            gap: '8px',
-            p: '12px',
-            borderTop: '1px solid',
-            borderColor: isDark ? gray[800] : gray[200],
-          }}
+            </ListItemContent>
+            <Chip size="sm" variant="soft" color="neutral" sx={COUNT_CHIP_SX}>
+              {node.fileCount}
+            </Chip>
+          </ListItemButton>
+        </ListItem>
+      );
+    },
+    renderFileRow: (file, selected, onSelect) => (
+      <ListItem key={file.id}>
+        <ListItemButton
+          selected={selected}
+          onClick={onSelect}
+          data-testid={`datalake-file-${file.id}`}
+          sx={treeRowSx(theme.palette.notebooklist.hoverBg)}
         >
-          {onManage && (
-            <Button
-              variant="outlined"
-              color="neutral"
-              onClick={onManage}
-              data-testid="datalake-manage-btn"
-              sx={FOOTER_BTN_SX}
-            >
-              Manage
-            </Button>
-          )}
-          {onCreateLake && (
-            <Button
-              variant="solid"
-              color="primary"
-              onClick={onCreateLake}
-              data-testid="datalake-create-btn"
-              sx={FOOTER_BTN_SX}
-            >
-              Create
-            </Button>
-          )}
-        </Box>
-      )}
-    </Box>
+          <ArticleOutlinedIcon
+            sx={{ fontSize: 16, color: selected ? inkFor(HUES.cyan, isDark) : 'text.tertiary', flexShrink: 0 }}
+          />
+          <ListItemContent>
+            <Typography noWrap sx={{ fontSize: '14px', fontWeight: selected ? 'lg' : 400, color: 'text.primary' }}>
+              {file.fileName.replace(/\.[^/.]+$/, '')}
+            </Typography>
+          </ListItemContent>
+        </ListItemButton>
+      </ListItem>
+    ),
+    humanize: humanizeSegment,
+    allCategoriesLabel: 'All Categories',
+    emptyFilesLabel: 'No articles found',
+    errorLabel: 'Failed to load articles',
+  };
+
+  return (
+    <DataLakeTreeView
+      tree={tree}
+      articles={articles}
+      breadcrumb={breadcrumb}
+      onNavigate={onNavigate}
+      selectedFileId={selectedFileId}
+      onSelectFile={onSelectFile}
+      isLoading={isLoading}
+      isError={isError}
+      chrome={chrome}
+      header={header}
+      footer={footer}
+    />
   );
 }

--- a/apps/client/app/components/datalake/DataLakeChatTree.tsx
+++ b/apps/client/app/components/datalake/DataLakeChatTree.tsx
@@ -140,6 +140,8 @@ export default function DataLakeChatTree({
   );
 
   const footer = (onManage || onCreateLake) && (
+    // Sticky bottom bar: manage / create lakes. Pinned below the scrollable list by being
+    // TreeView's footer slot, outside the scroll pane.
     <Box
       className="datalake-tree-footer"
       sx={{

--- a/apps/client/app/components/datalake/DataLakeTree.tsx
+++ b/apps/client/app/components/datalake/DataLakeTree.tsx
@@ -1,24 +1,9 @@
-import { useState, useMemo } from 'react';
-import {
-  Box,
-  Chip,
-  IconButton,
-  Input,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemContent,
-  Skeleton,
-  Tooltip,
-  Typography,
-  useTheme,
-} from '@mui/joy';
+import { Chip, IconButton, ListItem, ListItemButton, ListItemContent, Tooltip, Typography, useTheme } from '@mui/joy';
 import { alpha } from '@mui/system';
-import SearchIcon from '@mui/icons-material/Search';
 import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import type { TagNode } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
-import { getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
+import DataLakeTreeView, { type DataLakeTreeChrome } from './DataLakeTreeView';
 import { inkFor } from '@client/app/components/datalake/surfaceChrome';
 import type { Hue } from '@client/app/components/datalake/surfaceChrome';
 import { humanizeSegment, useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
@@ -41,211 +26,124 @@ interface DataLakeTreeProps {
   isError?: boolean;
 }
 
-export default function DataLakeTree({
-  tree,
-  articles,
-  breadcrumb,
-  onNavigate,
-  selectedFileId,
-  onSelectFile,
-  isLoading,
-  isError,
-}: DataLakeTreeProps) {
+/**
+ * The standalone /data-lakes page tree: brand-agnostic, themed entirely through the
+ * DataLakeSurface tokens. All tree logic lives in DataLakeTreeView; this shell only
+ * declares the page chrome.
+ */
+export default function DataLakeTree(props: DataLakeTreeProps) {
   const muiTheme = useTheme();
   const isDark = muiTheme.palette.mode === 'dark';
   const { theme, copy, icons, taxonomy } = useDataLakeSurface();
   const { article: ArticleGlyph, branch: BranchGlyph, leafBranch: LeafBranchGlyph } = icons;
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<'count' | 'alpha'>('count');
 
-  const currentNodes = useMemo(() => getNodesAtPath(tree, breadcrumb), [tree, breadcrumb]);
-
-  const filteredNodes = useMemo(() => {
-    let nodes = currentNodes;
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      nodes = nodes.filter(node => node.segment.toLowerCase().includes(q));
-    }
-    return [...nodes].sort((a, b) =>
-      sortBy === 'count' ? b.fileCount - a.fileCount : a.segment.localeCompare(b.segment)
-    );
-  }, [currentNodes, searchQuery, sortBy]);
-
-  // At a leaf node (no children), filter articles locally by the leaf tag
-  const leafTag = breadcrumb.length > 0 && currentNodes.length === 0 ? breadcrumb.join(':') : null;
-  const showFiles = !!leafTag;
-  const files = useMemo(() => {
-    if (!leafTag) return [];
-    return [...articles]
-      .filter(f => (f.tags ?? []).some(t => t.name === leafTag))
-      .sort((a, b) => a.fileName.localeCompare(b.fileName));
-  }, [leafTag, articles]);
-
-  return (
-    <Box
-      data-testid="datalake-tree"
-      sx={{
-        width: 280,
-        minWidth: 280,
-        borderRight: '1px solid',
-        borderColor: 'divider',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-      }}
-    >
-      {/* Search bar + sort toggle */}
-      <Box sx={{ p: 1.5, pb: 1, display: 'flex', gap: 0.5, alignItems: 'center' }}>
-        <Input
+  const chrome: DataLakeTreeChrome = {
+    containerSx: {
+      width: 280,
+      minWidth: 280,
+      borderRight: '1px solid',
+      borderColor: 'divider',
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+    },
+    toolbarSx: { p: 1.5, pb: 1, display: 'flex', gap: 0.5, alignItems: 'center' },
+    searchPlaceholder: 'Filter...',
+    searchSx: { fontSize: '13px', flex: 1 },
+    renderSortButton: (sortBy, toggle) => (
+      <Tooltip title={sortBy === 'count' ? 'Sort: by count (click for A-Z)' : 'Sort: A-Z (click for count)'} size="sm">
+        <IconButton
           size="sm"
-          placeholder="Filter..."
-          startDecorator={<SearchIcon sx={{ fontSize: 18 }} />}
-          value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
-          data-testid="datalake-search"
-          sx={{ fontSize: '13px', flex: 1 }}
-        />
-        <Tooltip
-          title={sortBy === 'count' ? 'Sort: by count (click for A-Z)' : 'Sort: A-Z (click for count)'}
-          size="sm"
+          variant={sortBy === 'alpha' ? 'soft' : 'plain'}
+          color="neutral"
+          onClick={toggle}
+          data-testid="datalake-sort-toggle"
+          data-sort={sortBy}
+          sx={{ flexShrink: 0 }}
         >
-          <IconButton
-            size="sm"
-            variant={sortBy === 'alpha' ? 'soft' : 'plain'}
-            color="neutral"
-            onClick={() => setSortBy(prev => (prev === 'count' ? 'alpha' : 'count'))}
-            data-testid="datalake-sort-toggle"
-            data-sort={sortBy}
-            sx={{ flexShrink: 0 }}
+          <SortByAlphaIcon sx={{ fontSize: 18 }} />
+        </IconButton>
+      </Tooltip>
+    ),
+    renderBackRow: (label, onBack) => (
+      <ListItemButton onClick={onBack} sx={{ px: 1.5, py: 0.75, gap: 1, minHeight: 36 }} data-testid="datalake-back">
+        <ArrowBackIcon sx={{ fontSize: 16, color: 'text.tertiary' }} />
+        <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+          {label}
+        </Typography>
+      </ListItemButton>
+    ),
+    scrollSx: { flex: 1, overflow: 'auto' },
+    nodeListSx: { '--ListItem-paddingX': '12px', '--ListItem-paddingY': '4px' },
+    fileListSx: { '--ListItem-paddingX': '12px', '--ListItem-paddingY': '6px' },
+    renderNodeRow: (node, depth, onOpen) => {
+      const branchInk = inkFor(hueForBranch(node.segment, props.breadcrumb, theme), isDark);
+      return (
+        <ListItem key={node.segment}>
+          <ListItemButton
+            onClick={onOpen}
+            sx={{
+              borderRadius: 'sm',
+              gap: 1,
+              '&:hover': { backgroundColor: alpha(branchInk, isDark ? 0.08 : 0.06) },
+            }}
+            data-testid={`datalake-node-${node.segment}`}
           >
-            <SortByAlphaIcon sx={{ fontSize: 18 }} />
-          </IconButton>
-        </Tooltip>
-      </Box>
-
-      {/* Breadcrumb back */}
-      {breadcrumb.length > 0 && (
+            {node.children.length > 0 ? (
+              <BranchGlyph sx={{ fontSize: 18, color: branchInk }} />
+            ) : (
+              <LeafBranchGlyph sx={{ fontSize: 18, color: alpha(branchInk, 0.7) }} />
+            )}
+            <ListItemContent>
+              <Typography level="body-sm" sx={{ fontWeight: 'md' }}>
+                {humanizeSegment(node.segment, depth, taxonomy)}
+              </Typography>
+            </ListItemContent>
+            <Chip
+              size="sm"
+              variant="outlined"
+              sx={{
+                minHeight: 20,
+                fontSize: '11px',
+                fontFamily: 'monospace',
+                color: alpha(branchInk, 0.9),
+                borderColor: alpha(branchInk, 0.35),
+              }}
+            >
+              {node.fileCount}
+            </Chip>
+          </ListItemButton>
+        </ListItem>
+      );
+    },
+    renderFileRow: (file, selected, onSelect) => (
+      <ListItem key={file.id}>
         <ListItemButton
-          onClick={() => onNavigate(breadcrumb.slice(0, -1))}
-          sx={{ px: 1.5, py: 0.75, gap: 1, minHeight: 36 }}
-          data-testid="datalake-back"
+          selected={selected}
+          onClick={onSelect}
+          sx={{ borderRadius: 'sm', gap: 1 }}
+          data-testid={`datalake-file-${file.id}`}
         >
-          <ArrowBackIcon sx={{ fontSize: 16, color: 'text.tertiary' }} />
-          <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-            {breadcrumb.length === 1
-              ? copy.allCategoriesLabel
-              : humanizeSegment(breadcrumb[breadcrumb.length - 2], breadcrumb.length - 2, taxonomy)}
-          </Typography>
-        </ListItemButton>
-      )}
-
-      {/* Tree / file list */}
-      <Box sx={{ flex: 1, overflow: 'auto' }}>
-        {isError ? (
-          <Box sx={{ p: 2, textAlign: 'center' }} data-testid="datalake-error">
-            <Typography level="body-xs" sx={{ color: 'danger.400' }}>
-              Failed to load articles
+          <ArticleGlyph
+            sx={{
+              fontSize: 16,
+              color: selected ? inkFor(theme.accent, isDark) : 'text.tertiary',
+              flexShrink: 0,
+            }}
+          />
+          <ListItemContent>
+            <Typography level="body-xs" noWrap sx={{ fontWeight: selected ? 'lg' : undefined }}>
+              {file.fileName.replace(/\.[^/.]+$/, '')}
             </Typography>
-          </Box>
-        ) : isLoading ? (
-          <Box sx={{ p: 1.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
-            {[1, 2, 3, 4].map(i => (
-              <Skeleton key={i} variant="rectangular" height={32} sx={{ borderRadius: 'sm' }} />
-            ))}
-          </Box>
-        ) : showFiles ? (
-          /* File list at leaf */
-          <List size="sm" sx={{ '--ListItem-paddingX': '12px', '--ListItem-paddingY': '6px' }}>
-            {files.length === 0 ? (
-              <Box sx={{ p: 2, textAlign: 'center' }}>
-                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                  No articles found
-                </Typography>
-              </Box>
-            ) : (
-              files.map(file => (
-                <ListItem key={file.id}>
-                  <ListItemButton
-                    selected={selectedFileId === file.id}
-                    onClick={() => onSelectFile(file)}
-                    sx={{ borderRadius: 'sm', gap: 1 }}
-                    data-testid={`datalake-file-${file.id}`}
-                  >
-                    <ArticleGlyph
-                      sx={{
-                        fontSize: 16,
-                        color: selectedFileId === file.id ? inkFor(theme.accent, isDark) : 'text.tertiary',
-                        flexShrink: 0,
-                      }}
-                    />
-                    <ListItemContent>
-                      <Typography
-                        level="body-xs"
-                        noWrap
-                        sx={{ fontWeight: selectedFileId === file.id ? 'lg' : undefined }}
-                      >
-                        {file.fileName.replace(/\.[^/.]+$/, '')}
-                      </Typography>
-                    </ListItemContent>
-                  </ListItemButton>
-                </ListItem>
-              ))
-            )}
-          </List>
-        ) : (
-          /* Folder tree */
-          <List size="sm" sx={{ '--ListItem-paddingX': '12px', '--ListItem-paddingY': '4px' }}>
-            {filteredNodes.length === 0 ? (
-              <Box sx={{ p: 2, textAlign: 'center' }}>
-                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
-                  {searchQuery ? 'No matches' : 'No categories'}
-                </Typography>
-              </Box>
-            ) : (
-              filteredNodes.map(node => {
-                const branchInk = inkFor(hueForBranch(node.segment, breadcrumb, theme), isDark);
-                return (
-                  <ListItem key={node.segment}>
-                    <ListItemButton
-                      onClick={() => onNavigate([...breadcrumb, node.segment])}
-                      sx={{
-                        borderRadius: 'sm',
-                        gap: 1,
-                        '&:hover': { backgroundColor: alpha(branchInk, isDark ? 0.08 : 0.06) },
-                      }}
-                      data-testid={`datalake-node-${node.segment}`}
-                    >
-                      {node.children.length > 0 ? (
-                        <BranchGlyph sx={{ fontSize: 18, color: branchInk }} />
-                      ) : (
-                        <LeafBranchGlyph sx={{ fontSize: 18, color: alpha(branchInk, 0.7) }} />
-                      )}
-                      <ListItemContent>
-                        <Typography level="body-sm" sx={{ fontWeight: 'md' }}>
-                          {humanizeSegment(node.segment, breadcrumb.length, taxonomy)}
-                        </Typography>
-                      </ListItemContent>
-                      <Chip
-                        size="sm"
-                        variant="outlined"
-                        sx={{
-                          minHeight: 20,
-                          fontSize: '11px',
-                          fontFamily: 'monospace',
-                          color: alpha(branchInk, 0.9),
-                          borderColor: alpha(branchInk, 0.35),
-                        }}
-                      >
-                        {node.fileCount}
-                      </Chip>
-                    </ListItemButton>
-                  </ListItem>
-                );
-              })
-            )}
-          </List>
-        )}
-      </Box>
-    </Box>
-  );
+          </ListItemContent>
+        </ListItemButton>
+      </ListItem>
+    ),
+    humanize: (segment, depth) => (segment ? humanizeSegment(segment, depth, taxonomy) : ''),
+    allCategoriesLabel: copy.allCategoriesLabel,
+    emptyFilesLabel: 'No articles found',
+    errorLabel: 'Failed to load articles',
+  };
+
+  return <DataLakeTreeView {...props} chrome={chrome} />;
 }

--- a/apps/client/app/components/datalake/DataLakeTree.tsx
+++ b/apps/client/app/components/datalake/DataLakeTree.tsx
@@ -139,7 +139,7 @@ export default function DataLakeTree(props: DataLakeTreeProps) {
         </ListItemButton>
       </ListItem>
     ),
-    humanize: (segment, depth) => (segment ? humanizeSegment(segment, depth, taxonomy) : ''),
+    humanize: (segment, depth) => humanizeSegment(segment, depth, taxonomy),
     allCategoriesLabel: copy.allCategoriesLabel,
     emptyFilesLabel: 'No articles found',
     errorLabel: 'Failed to load articles',

--- a/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
@@ -100,15 +100,13 @@ describe('DataLakeTreeView nodes', () => {
 
   it('search filters segments and shows No matches when nothing survives', async () => {
     renderTree();
-    const searchInput = screen.getByTestId('datalake-search').querySelector('input');
-    if (searchInput) {
-      await userEvent.type(searchInput, 'new');
-      expect(screen.queryByTestId('datalake-node-books')).toBeNull();
-      expect(screen.getByTestId('datalake-node-news')).toBeTruthy();
-      await userEvent.clear(searchInput);
-      await userEvent.type(searchInput, 'zzz');
-      expect(screen.getByText('No matches')).toBeTruthy();
-    }
+    const searchInput = screen.getByTestId('datalake-search').querySelector('input')!;
+    await userEvent.type(searchInput, 'new');
+    expect(screen.queryByTestId('datalake-node-books')).toBeNull();
+    expect(screen.getByTestId('datalake-node-news')).toBeTruthy();
+    await userEvent.clear(searchInput);
+    await userEvent.type(searchInput, 'zzz');
+    expect(screen.getByText('No matches')).toBeTruthy();
   });
 
   it('navigates into a node via the chrome row', () => {
@@ -154,6 +152,25 @@ describe('DataLakeTreeView back row', () => {
     fireEvent.click(screen.getByTestId('datalake-back'));
     expect(onNavigate).toHaveBeenCalledWith(['books']);
   });
+
+  it('renders sticky-back wrapped inside scroll pane when chrome.stickyBackSx is set', () => {
+    const stickyChrome: DataLakeTreeChrome = {
+      ...testChrome,
+      stickyBackSx: { position: 'sticky', top: 0 },
+    };
+    const { onNavigate } = renderTree({ breadcrumb: ['books'], chrome: stickyChrome });
+    const backBtn = screen.getByTestId('datalake-back');
+    expect(backBtn.textContent).toBe('All Categories');
+    fireEvent.click(backBtn);
+    expect(onNavigate).toHaveBeenCalledWith([]);
+    // With sticky chrome, back row is nested inside scroll pane (one level deeper wrapper).
+    // The search input's container and sticky-back wrapper are siblings under the tree container.
+    // Assertion: sticky-back wrapper is a different element than search input's ancestor.
+    const searchInput = screen.getByTestId('datalake-search');
+    const backWrapper = backBtn.closest('div')?.parentElement; // back row is inside a wrapper Box
+    expect(backWrapper).toBeTruthy();
+    expect(searchInput.parentElement).not.toBe(backWrapper?.parentElement); // different parent hierarchies
+  });
 });
 
 describe('DataLakeTreeView states', () => {
@@ -184,11 +201,9 @@ describe('DataLakeTreeView uncategorized bucket', () => {
   it('renders the bucket row at root and hides it while searching', async () => {
     renderTree({ uncategorized });
     expect(screen.getByTestId('datalake-node-uncategorized').textContent).toBe('Uncategorized (1)');
-    const searchInput = screen.getByTestId('datalake-search').querySelector('input');
-    if (searchInput) {
-      await userEvent.type(searchInput, 'x');
-      expect(screen.queryByTestId('datalake-node-uncategorized')).toBeNull();
-    }
+    const searchInput = screen.getByTestId('datalake-search').querySelector('input')!;
+    await userEvent.type(searchInput, 'x');
+    expect(screen.queryByTestId('datalake-node-uncategorized')).toBeNull();
   });
 
   it('opens the bucket via the synthetic breadcrumb key and lists its files', () => {

--- a/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
@@ -143,6 +143,17 @@ describe('DataLakeTreeView back row', () => {
     expect(screen.queryByTestId('datalake-back')).toBeNull();
   });
 
+  it('never calls humanize at root breadcrumb', () => {
+    const humanizeSpy = vi.fn(() => 'x');
+    const spyChrome: DataLakeTreeChrome = {
+      ...testChrome,
+      humanize: humanizeSpy,
+    };
+    renderTree({ chrome: spyChrome });
+    expect(screen.queryByTestId('datalake-back')).toBeNull();
+    expect(humanizeSpy).not.toHaveBeenCalled();
+  });
+
   it('labels depth-1 with allCategoriesLabel and deeper with the humanized parent', () => {
     const first = renderTree({ breadcrumb: ['books'] });
     expect(screen.getByTestId('datalake-back').textContent).toBe('All Categories');

--- a/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { ListItem, ListItemButton } from '@mui/joy';
+import { getThemeConfig } from '@client/app/utils/themes';
+import type { IFabFileDocument } from '@bike4mind/common';
+import { buildTagTree } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
+import DataLakeTreeView, { UNCATEGORIZED_KEY, type DataLakeTreeChrome } from './DataLakeTreeView';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+/** Minimal chrome: enough structure to drive the logic; no styling opinions under test. */
+const testChrome: DataLakeTreeChrome = {
+  containerSx: {},
+  toolbarSx: {},
+  searchPlaceholder: 'Filter...',
+  searchSx: {},
+  renderSortButton: (sortBy, toggle) => (
+    <button data-testid="datalake-sort-toggle" data-sort={sortBy} onClick={toggle}>
+      sort
+    </button>
+  ),
+  renderBackRow: (label, onBack) => (
+    <ListItemButton data-testid="datalake-back" onClick={onBack}>
+      {label}
+    </ListItemButton>
+  ),
+  scrollSx: {},
+  nodeListSx: {},
+  fileListSx: {},
+  renderNodeRow: (node, _depth, onOpen) => (
+    <ListItem key={node.segment}>
+      <ListItemButton data-testid={`datalake-node-${node.segment}`} onClick={onOpen}>
+        {node.segment} ({node.fileCount})
+      </ListItemButton>
+    </ListItem>
+  ),
+  renderFileRow: (file, selected, onSelect) => (
+    <ListItem key={file.id}>
+      <ListItemButton data-testid={`datalake-file-${file.id}`} data-selected={selected} onClick={onSelect}>
+        {file.fileName}
+      </ListItemButton>
+    </ListItem>
+  ),
+  humanize: (segment, depth) => `${segment}@${depth}`,
+  allCategoriesLabel: 'All Categories',
+  emptyFilesLabel: 'No articles found',
+  errorLabel: 'Failed to load articles',
+};
+
+const file = (id: string, fileName: string, tags: string[]): IFabFileDocument =>
+  ({ id, fileName, tags: tags.map(name => ({ name })) }) as unknown as IFabFileDocument;
+
+// books:war (2 files), books:peace (1), news:today (1)
+const ARTICLES = [
+  file('f1', 'b-war-one.md', ['books:war']),
+  file('f2', 'a-war-two.md', ['books:war']),
+  file('f3', 'peace.md', ['books:peace']),
+  file('f4', 'today.md', ['news:today']),
+];
+const TREE = buildTagTree([
+  { tag: 'books:war', count: 2 },
+  { tag: 'books:peace', count: 1 },
+  { tag: 'news:today', count: 1 },
+]);
+
+const renderTree = (over: Partial<React.ComponentProps<typeof DataLakeTreeView>> = {}) => {
+  const onNavigate = vi.fn();
+  const onSelectFile = vi.fn();
+  const utils = render(
+    <DataLakeTreeView
+      tree={TREE}
+      articles={ARTICLES}
+      breadcrumb={[]}
+      onNavigate={onNavigate}
+      selectedFileId={null}
+      onSelectFile={onSelectFile}
+      isLoading={false}
+      chrome={testChrome}
+      {...over}
+    />,
+    { wrapper: Wrapper }
+  );
+  return { ...utils, onNavigate, onSelectFile };
+};
+
+describe('DataLakeTreeView nodes', () => {
+  it('renders root nodes sorted by count desc, toggling to alpha', () => {
+    renderTree();
+    const nodes = () => screen.getAllByTestId(/^datalake-node-/).map(el => el.dataset.testid);
+    expect(nodes()).toEqual(['datalake-node-books', 'datalake-node-news']);
+    fireEvent.click(screen.getByTestId('datalake-sort-toggle'));
+    // alpha: books < news (same order here); assert the mode flag flipped
+    expect(screen.getByTestId('datalake-sort-toggle').dataset.sort).toBe('alpha');
+  });
+
+  it('search filters segments and shows No matches when nothing survives', async () => {
+    renderTree();
+    const searchInput = screen.getByTestId('datalake-search').querySelector('input');
+    if (searchInput) {
+      await userEvent.type(searchInput, 'new');
+      expect(screen.queryByTestId('datalake-node-books')).toBeNull();
+      expect(screen.getByTestId('datalake-node-news')).toBeTruthy();
+      await userEvent.clear(searchInput);
+      await userEvent.type(searchInput, 'zzz');
+      expect(screen.getByText('No matches')).toBeTruthy();
+    }
+  });
+
+  it('navigates into a node via the chrome row', () => {
+    const { onNavigate } = renderTree();
+    fireEvent.click(screen.getByTestId('datalake-node-books'));
+    expect(onNavigate).toHaveBeenCalledWith(['books']);
+  });
+});
+
+describe('DataLakeTreeView leaf files', () => {
+  it('lists files carrying the leaf tag, name-sorted, and selects through the chrome row', () => {
+    const { onSelectFile } = renderTree({ breadcrumb: ['books', 'war'] });
+    const files = screen.getAllByTestId(/^datalake-file-/).map(el => el.dataset.testid);
+    expect(files).toEqual(['datalake-file-f2', 'datalake-file-f1']); // a-war-two before b-war-one
+    fireEvent.click(screen.getByTestId('datalake-file-f1'));
+    expect(onSelectFile).toHaveBeenCalledWith(ARTICLES[0]);
+  });
+
+  it('marks the selected file through the chrome flag', () => {
+    renderTree({ breadcrumb: ['books', 'war'], selectedFileId: 'f1' });
+    expect(screen.getByTestId('datalake-file-f1').dataset.selected).toBe('true');
+    expect(screen.getByTestId('datalake-file-f2').dataset.selected).toBe('false');
+  });
+
+  it('shows the chrome empty-files label at an empty leaf', () => {
+    renderTree({ breadcrumb: ['books', 'war'], articles: [] });
+    expect(screen.getByText('No articles found')).toBeTruthy();
+  });
+});
+
+describe('DataLakeTreeView back row', () => {
+  it('is absent at root', () => {
+    renderTree();
+    expect(screen.queryByTestId('datalake-back')).toBeNull();
+  });
+
+  it('labels depth-1 with allCategoriesLabel and deeper with the humanized parent', () => {
+    const first = renderTree({ breadcrumb: ['books'] });
+    expect(screen.getByTestId('datalake-back').textContent).toBe('All Categories');
+    first.unmount();
+    const { onNavigate } = renderTree({ breadcrumb: ['books', 'war'] });
+    expect(screen.getByTestId('datalake-back').textContent).toBe('books@0');
+    fireEvent.click(screen.getByTestId('datalake-back'));
+    expect(onNavigate).toHaveBeenCalledWith(['books']);
+  });
+});
+
+describe('DataLakeTreeView states', () => {
+  it('shows the chrome error label on error', () => {
+    renderTree({ isError: true });
+    expect(screen.getByTestId('datalake-error').textContent).toContain('Failed to load articles');
+  });
+
+  it('shows skeletons while loading', () => {
+    const { container } = renderTree({ isLoading: true });
+    expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThan(0);
+  });
+});
+
+describe('DataLakeTreeView uncategorized bucket', () => {
+  const loose = [file('u1', 'loose.md', ['datalake:mine'])];
+  const uncategorized = {
+    files: loose,
+    renderRow: (count: number, onOpen: () => void) => (
+      <ListItem key={UNCATEGORIZED_KEY}>
+        <ListItemButton data-testid="datalake-node-uncategorized" onClick={onOpen}>
+          Uncategorized ({count})
+        </ListItemButton>
+      </ListItem>
+    ),
+  };
+
+  it('renders the bucket row at root and hides it while searching', async () => {
+    renderTree({ uncategorized });
+    expect(screen.getByTestId('datalake-node-uncategorized').textContent).toBe('Uncategorized (1)');
+    const searchInput = screen.getByTestId('datalake-search').querySelector('input');
+    if (searchInput) {
+      await userEvent.type(searchInput, 'x');
+      expect(screen.queryByTestId('datalake-node-uncategorized')).toBeNull();
+    }
+  });
+
+  it('opens the bucket via the synthetic breadcrumb key and lists its files', () => {
+    const { onNavigate } = renderTree({ uncategorized });
+    fireEvent.click(screen.getByTestId('datalake-node-uncategorized'));
+    expect(onNavigate).toHaveBeenCalledWith([UNCATEGORIZED_KEY]);
+    const opened = renderTree({ uncategorized, breadcrumb: [UNCATEGORIZED_KEY] });
+    expect(opened.getAllByTestId(/^datalake-file-/).map(el => el.dataset.testid)).toEqual(['datalake-file-u1']);
+  });
+
+  it('suppresses the node empty-state while the bucket is visible at an empty root', () => {
+    renderTree({ uncategorized, tree: [] });
+    expect(screen.queryByText('No categories')).toBeNull();
+    expect(screen.getByTestId('datalake-node-uncategorized')).toBeTruthy();
+  });
+});

--- a/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
@@ -55,17 +55,24 @@ const testChrome: DataLakeTreeChrome = {
 const file = (id: string, fileName: string, tags: string[]): IFabFileDocument =>
   ({ id, fileName, tags: tags.map(name => ({ name })) }) as unknown as IFabFileDocument;
 
-// books:war (2 files), books:peace (1), news:today (1)
+// books:war (2 files), books:peace (1), news:today (1), zebra:x (5) - zebra's count rank (highest)
+// disagrees with its alpha rank (last), so count-desc and alpha sorts produce different orders.
 const ARTICLES = [
   file('f1', 'b-war-one.md', ['books:war']),
   file('f2', 'a-war-two.md', ['books:war']),
   file('f3', 'peace.md', ['books:peace']),
   file('f4', 'today.md', ['news:today']),
+  file('f5', 'x1.md', ['zebra:x']),
+  file('f6', 'x2.md', ['zebra:x']),
+  file('f7', 'x3.md', ['zebra:x']),
+  file('f8', 'x4.md', ['zebra:x']),
+  file('f9', 'x5.md', ['zebra:x']),
 ];
 const TREE = buildTagTree([
   { tag: 'books:war', count: 2 },
   { tag: 'books:peace', count: 1 },
   { tag: 'news:today', count: 1 },
+  { tag: 'zebra:x', count: 5 },
 ]);
 
 const renderTree = (over: Partial<React.ComponentProps<typeof DataLakeTreeView>> = {}) => {
@@ -92,10 +99,12 @@ describe('DataLakeTreeView nodes', () => {
   it('renders root nodes sorted by count desc, toggling to alpha', () => {
     renderTree();
     const nodes = () => screen.getAllByTestId(/^datalake-node-/).map(el => el.dataset.testid);
-    expect(nodes()).toEqual(['datalake-node-books', 'datalake-node-news']);
+    // count desc: zebra(5) > books(3) > news(1)
+    expect(nodes()).toEqual(['datalake-node-zebra', 'datalake-node-books', 'datalake-node-news']);
     fireEvent.click(screen.getByTestId('datalake-sort-toggle'));
-    // alpha: books < news (same order here); assert the mode flag flipped
     expect(screen.getByTestId('datalake-sort-toggle').dataset.sort).toBe('alpha');
+    // alpha: books < news < zebra - a genuinely different order than count desc
+    expect(nodes()).toEqual(['datalake-node-books', 'datalake-node-news', 'datalake-node-zebra']);
   });
 
   it('search filters segments and shows No matches when nothing survives', async () => {
@@ -154,6 +163,17 @@ describe('DataLakeTreeView back row', () => {
     expect(humanizeSpy).not.toHaveBeenCalled();
   });
 
+  it('never calls humanize at depth 1 either (allCategoriesLabel path, not humanize(parent))', () => {
+    const humanizeSpy = vi.fn(() => 'x');
+    const spyChrome: DataLakeTreeChrome = {
+      ...testChrome,
+      humanize: humanizeSpy,
+    };
+    renderTree({ breadcrumb: ['books'], chrome: spyChrome });
+    expect(screen.getByTestId('datalake-back').textContent).toBe('All Categories');
+    expect(humanizeSpy).not.toHaveBeenCalled();
+  });
+
   it('labels depth-1 with allCategoriesLabel and deeper with the humanized parent', () => {
     const first = renderTree({ breadcrumb: ['books'] });
     expect(screen.getByTestId('datalake-back').textContent).toBe('All Categories');
@@ -164,7 +184,7 @@ describe('DataLakeTreeView back row', () => {
     expect(onNavigate).toHaveBeenCalledWith(['books']);
   });
 
-  it('renders sticky-back wrapped inside scroll pane when chrome.stickyBackSx is set', () => {
+  it('renders sticky-back inside the scroll pane when chrome.stickyBackSx is set', () => {
     const stickyChrome: DataLakeTreeChrome = {
       ...testChrome,
       stickyBackSx: { position: 'sticky', top: 0 },
@@ -174,13 +194,19 @@ describe('DataLakeTreeView back row', () => {
     expect(backBtn.textContent).toBe('All Categories');
     fireEvent.click(backBtn);
     expect(onNavigate).toHaveBeenCalledWith([]);
-    // With sticky chrome, back row is nested inside scroll pane (one level deeper wrapper).
-    // The search input's container and sticky-back wrapper are siblings under the tree container.
-    // Assertion: sticky-back wrapper is a different element than search input's ancestor.
-    const searchInput = screen.getByTestId('datalake-search');
-    const backWrapper = backBtn.closest('div')?.parentElement; // back row is inside a wrapper Box
-    expect(backWrapper).toBeTruthy();
-    expect(searchInput.parentElement).not.toBe(backWrapper?.parentElement); // different parent hierarchies
+
+    // Sticky chrome: the back row shares the scroll pane (the Box wrapping the node <ul>)
+    // with the node rows - it is a descendant of that same container.
+    const scrollPane = screen.getByTestId('datalake-node-war').closest('ul')!.parentElement!;
+    expect(scrollPane.contains(screen.getByTestId('datalake-back'))).toBe(true);
+  });
+
+  it('keeps the back row outside the scroll pane under default chrome (no stickyBackSx)', () => {
+    renderTree({ breadcrumb: ['books'] });
+    // Default chrome renders the back row as a preceding sibling of the scroll pane, so it
+    // is NOT contained within it - the inverse of the sticky-chrome case above.
+    const scrollPane = screen.getByTestId('datalake-node-war').closest('ul')!.parentElement!;
+    expect(scrollPane.contains(screen.getByTestId('datalake-back'))).toBe(false);
   });
 });
 
@@ -215,6 +241,9 @@ describe('DataLakeTreeView uncategorized bucket', () => {
     const searchInput = screen.getByTestId('datalake-search').querySelector('input')!;
     await userEvent.type(searchInput, 'x');
     expect(screen.queryByTestId('datalake-node-uncategorized')).toBeNull();
+    // The bucket is the only root content once searching hides it: no other node matches
+    // "x" either, so the empty state must re-show rather than leave a blank pane.
+    expect(screen.getByText('No matches')).toBeTruthy();
   });
 
   it('opens the bucket via the synthetic breadcrumb key and lists its files', () => {

--- a/apps/client/app/components/datalake/DataLakeTreeView.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.tsx
@@ -1,0 +1,200 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { Box, Input, List, Skeleton, Typography } from '@mui/joy';
+import type { SxProps } from '@mui/joy/styles/types';
+import SearchIcon from '@mui/icons-material/Search';
+import type { TagNode } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
+import { getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
+import type { TreeSortMode } from './treeChrome';
+import type { IFabFileDocument } from '@bike4mind/common';
+
+/**
+ * Synthetic breadcrumb key for the Viewer's "files with no prefix-matching tag" bucket.
+ * Kept identical to the manager's constant so both surfaces mean the same bucket.
+ */
+export const UNCATEGORIZED_KEY = '__uncategorized__';
+
+/**
+ * Everything visual about a tree surface, injected by the shell that owns the look:
+ * the page tree derives its chrome from surfaceTokens, the chat tree from treeChrome,
+ * the discover viewer keeps its neutral look. TreeView itself owns only logic and
+ * structure - if a knob here starts encoding BEHAVIOR, it belongs in TreeView instead.
+ */
+export interface DataLakeTreeChrome {
+  /** Outer column: width, borders, background - the surface's visual identity. */
+  containerSx: SxProps;
+  /** Search + sort toolbar wrapper. */
+  toolbarSx: SxProps;
+  searchPlaceholder: string;
+  searchSx: SxProps;
+  /** Sort toggle; TreeView owns the mode state, the chrome owns the button. Must carry
+   *  data-testid="datalake-sort-toggle" and data-sort={sortBy} for the shared tests. */
+  renderSortButton: (sortBy: TreeSortMode, toggle: () => void) => ReactNode;
+  /** Back row (chrome carries data-testid="datalake-back"). */
+  renderBackRow: (label: string, onBack: () => void) => ReactNode;
+  /** When set, the back row renders INSIDE the scroll pane wrapped in this sx (the chat
+   *  tree's pinned back row); when absent it renders as a sibling above the scroll pane. */
+  stickyBackSx?: SxProps;
+  scrollSx: SxProps;
+  nodeListSx: SxProps;
+  fileListSx: SxProps;
+  renderNodeRow: (node: TagNode, depth: number, onOpen: () => void) => ReactNode;
+  renderFileRow: (file: IFabFileDocument, selected: boolean, onSelect: () => void) => ReactNode;
+  /** Human label for a raw tag segment at a depth (taxonomy-aware per surface). */
+  humanize: (segment: string, depth: number) => string;
+  /** Back-crumb label when popping out of a first-level branch. */
+  allCategoriesLabel: string;
+  emptyFilesLabel: string;
+  errorLabel: string;
+}
+
+export interface DataLakeTreeViewProps {
+  tree: TagNode[];
+  /** All articles in scope, used to resolve leaf-tag files locally without extra API calls. */
+  articles: IFabFileDocument[];
+  breadcrumb: string[];
+  onNavigate: (breadcrumb: string[]) => void;
+  selectedFileId: string | null;
+  onSelectFile: (file: IFabFileDocument) => void;
+  isLoading: boolean;
+  isError?: boolean;
+  chrome: DataLakeTreeChrome;
+  /**
+   * Optional root bucket for files that carry no prefix-matching tag (the Viewer), so every
+   * file stays reachable. TreeView owns the visibility rules (root only, hidden while
+   * searching) and the synthetic-breadcrumb interception; the chrome renders the row.
+   */
+  uncategorized?: {
+    files: IFabFileDocument[];
+    renderRow: (count: number, onOpen: () => void) => ReactNode;
+  };
+  /** Slots above the toolbar / below the scroll pane (the chat tree's header and footer). */
+  header?: ReactNode;
+  footer?: ReactNode;
+}
+
+export default function DataLakeTreeView({
+  tree,
+  articles,
+  breadcrumb,
+  onNavigate,
+  selectedFileId,
+  onSelectFile,
+  isLoading,
+  isError,
+  chrome,
+  uncategorized,
+  header,
+  footer,
+}: DataLakeTreeViewProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<TreeSortMode>('count');
+
+  const currentNodes = useMemo(() => getNodesAtPath(tree, breadcrumb), [tree, breadcrumb]);
+
+  const filteredNodes = useMemo(() => {
+    let nodes = currentNodes;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      nodes = nodes.filter(node => node.segment.toLowerCase().includes(q));
+    }
+    return [...nodes].sort((a, b) =>
+      sortBy === 'count' ? b.fileCount - a.fileCount : a.segment.localeCompare(b.segment)
+    );
+  }, [currentNodes, searchQuery, sortBy]);
+
+  // The synthetic bucket intercepts before leaf-tag resolution: its key is not a real tag.
+  const isUncategorized = !!uncategorized && breadcrumb.length === 1 && breadcrumb[0] === UNCATEGORIZED_KEY;
+
+  // At a leaf node (no children), files are filtered locally by the leaf tag.
+  const leafTag = !isUncategorized && breadcrumb.length > 0 && currentNodes.length === 0 ? breadcrumb.join(':') : null;
+  const showFiles = isUncategorized || !!leafTag;
+  const files = useMemo(() => {
+    if (isUncategorized) return uncategorized!.files;
+    if (!leafTag) return [];
+    return [...articles]
+      .filter(f => (f.tags ?? []).some(t => t.name === leafTag))
+      .sort((a, b) => a.fileName.localeCompare(b.fileName));
+  }, [isUncategorized, uncategorized, leafTag, articles]);
+
+  const showBucketRow = !!uncategorized && breadcrumb.length === 0 && !searchQuery && uncategorized.files.length > 0;
+  // The bucket standing in for an empty root is still content - don't show "No categories" under it.
+  const showNodeEmpty = filteredNodes.length === 0 && !showBucketRow;
+
+  const backLabel =
+    breadcrumb.length === 1
+      ? chrome.allCategoriesLabel
+      : chrome.humanize(breadcrumb[breadcrumb.length - 2], breadcrumb.length - 2);
+  const backRow =
+    breadcrumb.length > 0 ? chrome.renderBackRow(backLabel, () => onNavigate(breadcrumb.slice(0, -1))) : null;
+
+  return (
+    <Box data-testid="datalake-tree" sx={chrome.containerSx}>
+      {header}
+
+      {/* Search bar + sort toggle */}
+      <Box sx={chrome.toolbarSx}>
+        <Input
+          size="sm"
+          placeholder={chrome.searchPlaceholder}
+          startDecorator={<SearchIcon sx={{ fontSize: 18 }} />}
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          data-testid="datalake-search"
+          sx={chrome.searchSx}
+        />
+        {chrome.renderSortButton(sortBy, () => setSortBy(prev => (prev === 'count' ? 'alpha' : 'count')))}
+      </Box>
+
+      {/* Back row above the scroll pane unless the chrome pins it inside (chat tree). */}
+      {!chrome.stickyBackSx && backRow}
+
+      <Box sx={chrome.scrollSx}>
+        {chrome.stickyBackSx && backRow && <Box sx={chrome.stickyBackSx}>{backRow}</Box>}
+        {isError ? (
+          <Box sx={{ p: 2, textAlign: 'center' }} data-testid="datalake-error">
+            <Typography level="body-xs" sx={{ color: 'danger.400' }}>
+              {chrome.errorLabel}
+            </Typography>
+          </Box>
+        ) : isLoading ? (
+          <Box sx={{ p: 1.5, display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {[1, 2, 3, 4].map(i => (
+              <Skeleton key={i} variant="rectangular" height={32} sx={{ borderRadius: 'sm' }} />
+            ))}
+          </Box>
+        ) : showFiles ? (
+          /* File list at a leaf (or the uncategorized bucket) */
+          <List size="sm" sx={chrome.fileListSx}>
+            {files.length === 0 ? (
+              <Box sx={{ p: 2, textAlign: 'center' }}>
+                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                  {chrome.emptyFilesLabel}
+                </Typography>
+              </Box>
+            ) : (
+              files.map(f => chrome.renderFileRow(f, selectedFileId === f.id, () => onSelectFile(f)))
+            )}
+          </List>
+        ) : (
+          /* Folder tree */
+          <List size="sm" sx={chrome.nodeListSx}>
+            {filteredNodes.map(node =>
+              chrome.renderNodeRow(node, breadcrumb.length, () => onNavigate([...breadcrumb, node.segment]))
+            )}
+            {showBucketRow &&
+              uncategorized!.renderRow(uncategorized!.files.length, () => onNavigate([UNCATEGORIZED_KEY]))}
+            {showNodeEmpty && (
+              <Box sx={{ p: 2, textAlign: 'center' }}>
+                <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>
+                  {searchQuery ? 'No matches' : 'No categories'}
+                </Typography>
+              </Box>
+            )}
+          </List>
+        )}
+      </Box>
+
+      {footer}
+    </Box>
+  );
+}

--- a/apps/client/app/components/datalake/DataLakeTreeView.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.tsx
@@ -108,13 +108,14 @@ export default function DataLakeTreeView({
   // At a leaf node (no children), files are filtered locally by the leaf tag.
   const leafTag = !isUncategorized && breadcrumb.length > 0 && currentNodes.length === 0 ? breadcrumb.join(':') : null;
   const showFiles = isUncategorized || !!leafTag;
+  const bucketFiles = uncategorized?.files;
   const files = useMemo(() => {
-    if (isUncategorized) return uncategorized!.files;
+    if (isUncategorized) return bucketFiles!;
     if (!leafTag) return [];
     return [...articles]
       .filter(f => (f.tags ?? []).some(t => t.name === leafTag))
       .sort((a, b) => a.fileName.localeCompare(b.fileName));
-  }, [isUncategorized, uncategorized, leafTag, articles]);
+  }, [isUncategorized, bucketFiles, leafTag, articles]);
 
   const showBucketRow = !!uncategorized && breadcrumb.length === 0 && !searchQuery && uncategorized.files.length > 0;
   // The bucket standing in for an empty root is still content - don't show "No categories" under it.

--- a/apps/client/app/components/datalake/DataLakeTreeView.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.tsx
@@ -120,12 +120,15 @@ export default function DataLakeTreeView({
   // The bucket standing in for an empty root is still content - don't show "No categories" under it.
   const showNodeEmpty = filteredNodes.length === 0 && !showBucketRow;
 
-  const backLabel =
-    breadcrumb.length === 1
-      ? chrome.allCategoriesLabel
-      : chrome.humanize(breadcrumb[breadcrumb.length - 2], breadcrumb.length - 2);
   const backRow =
-    breadcrumb.length > 0 ? chrome.renderBackRow(backLabel, () => onNavigate(breadcrumb.slice(0, -1))) : null;
+    breadcrumb.length > 0
+      ? chrome.renderBackRow(
+          breadcrumb.length === 1
+            ? chrome.allCategoriesLabel
+            : chrome.humanize(breadcrumb[breadcrumb.length - 2], breadcrumb.length - 2),
+          () => onNavigate(breadcrumb.slice(0, -1))
+        )
+      : null;
 
   return (
     <Box data-testid="datalake-tree" sx={chrome.containerSx}>

--- a/apps/client/app/hooks/data/dataLakeKeys.ts
+++ b/apps/client/app/hooks/data/dataLakeKeys.ts
@@ -13,6 +13,9 @@
  *   Invalidate the root so every variant refreshes; a fully-specified key would refresh only
  *   one surface.
  */
+// Type-only: keeps this module runtime-free (no cycle with dataLakes.ts, which value-imports us).
+import type { DataLakeArticlesParams, DataLakeBrowseSource } from '@client/app/hooks/data/dataLakes';
+
 export const dataLakeKeys = {
   /** The lake list (GET /api/data-lakes). */
   list: ['data-lakes'] as const,
@@ -29,8 +32,9 @@ export const dataLakeKeys = {
   filesOf: (dataLakeId: string) => ['dataLakeFiles', dataLakeId] as const,
   /** Invalidation prefix covering all lakes' file lists. */
   filesRoot: ['dataLakeFiles'] as const,
-  tagCounts: (source: string) => ['dataLakeTagCounts', source] as const,
+  tagCounts: (source: DataLakeBrowseSource) => ['dataLakeTagCounts', source] as const,
   tagCountsRoot: ['dataLakeTagCounts'] as const,
-  articles: (source: string, params?: unknown) => ['dataLakeArticles', source, params] as const,
+  articles: (source: DataLakeBrowseSource, params?: DataLakeArticlesParams) =>
+    ['dataLakeArticles', source, params] as const,
   articlesRoot: ['dataLakeArticles'] as const,
 };

--- a/apps/client/app/hooks/data/dataLakes.ts
+++ b/apps/client/app/hooks/data/dataLakes.ts
@@ -541,7 +541,8 @@ export function useDataLakeArticleCounts(): { total: number; sales: number; opti
  */
 export function useGetDataLakeArticles(params?: DataLakeArticlesParams | null, source: DataLakeBrowseSource = 'opti') {
   return useQuery({
-    queryKey: dataLakeKeys.articles(source, params),
+    // `null` means disabled-below, but the key type takes the params shape or undefined only.
+    queryKey: dataLakeKeys.articles(source, params ?? undefined),
     queryFn: async () => {
       const response = await api.get<{ data: IFabFileDocument[]; total: number; hasMore: boolean }>(
         `${browseBase(source)}/articles`,


### PR DESCRIPTION
## What

PR 2 of the data-lake client refactor series (follows #1483). Three byte-similar tree implementations — `DataLakeTree` (page), `DataLakeChatTree` (chat rail), and the `TreeSidebar` inside `DataLakeViewer` (discover) — collapse onto one new `DataLakeTreeView` that owns ALL logic (search/sort state, node filtering, leaf-tag file resolution, the Uncategorized bucket rules, loading/error/empty branches). Everything visual is injected via a `DataLakeTreeChrome` contract (sx values + render props), so the three components keep their exact names and props and become thin chrome shells. No consumer changed; net -237 lines across the shells; the shared logic gained its own direct test suite (previously only smoke-tested through stubs).

## Behavior

Behavior-neutral except two sanctioned additive changes:
- the Viewer's rows gained the standard `datalake-*` testids (they had none);
- "No matches" now re-shows when a search zeroes out nodes while the Uncategorized bucket exists (the old Viewer left a blank list; the other two surfaces and the manager already behaved this way).

## Verification

- Moved logic verified verbatim against all three sources by the review chain; every sx value compared one-for-one.
- Overlay-frozen files (`deckChrome`, `DataLakeExplorer`, `dataLakeNavContext`, `DataLakeToggle`) untouched.
- Suites green including the new 24-test `DataLakeTreeView` suite; full client suite green apart from known parallel Mongo-e2e flakiness (passes serially) and one environment-dependent generated-glue test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Merge order

This is the HEAD of a 3-PR stack: merge **#1517 first**, then #1518, then #1519. The children are based on each other's branches and auto-retarget to `main` as their parent merges - merging out of order would pull parent commits in twice.