### PR TITLE
ci: resolve the ASCII checks against the real merge base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,20 +90,49 @@ jobs:
       - name: Check user $lookup field projections
         run: node scripts/check-user-lookup-projection.mjs
 
+      # Resolve what "added" means for the two ASCII checks below.
+      #
+      # `pull_request.base.sha` is the base-branch head recorded when the PR was opened -
+      # NOT the fork point, and it does not move as the base branch advances. Both checks
+      # scan ADDED lines relative to that base, so on a long-lived PR every commit main
+      # gained in the meantime is attributed to the PR. That is not hypothetical: a PR
+      # opened 83 commits back failed this job on em-dashes that were already on main, in
+      # files it never touched, and no change to the PR could have cleared it.
+      #
+      # The real base is the merge base of the base branch and what we have checked out.
+      # On a `pull_request` run the checkout is the merge ref, so this resolves to the base
+      # branch tip and the diff is exactly the PR's net contribution. Falls back to the
+      # event's own sha for push / merge_group, and to the empty string if nothing resolves -
+      # which makes both scripts over-scan the whole tree rather than silently check nothing.
+      - name: Resolve base for the ASCII checks
+        id: ascii-base
+        run: |
+          set -uo pipefail
+          fallback='${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}'
+          base_ref='${{ github.event.pull_request.base.ref }}'
+          resolved="$fallback"
+          if [ -n "$base_ref" ]; then
+            if git fetch --no-tags --quiet origin "$base_ref" 2>/dev/null; then
+              if merge_base=$(git merge-base FETCH_HEAD HEAD 2>/dev/null); then
+                resolved="$merge_base"
+              fi
+            fi
+          fi
+          echo "base=$resolved" >> "$GITHUB_OUTPUT"
+          echo "ASCII checks diff against ${resolved:-<whole tree>} (event base was ${fallback:-<none>})"
+
       # Mirrors the husky pre-commit guard so a `--no-verify` bypass is still caught.
-      # Each trigger exposes the base under a different key; the script over-scans the
-      # whole tree if none resolve, so a new-branch push (all-zero `before`) still checks.
       - name: Check for raw control bytes in source files
         run: bash scripts/check-no-control-bytes.sh --changed "$CONTROL_BYTES_BASE"
         env:
-          CONTROL_BYTES_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          CONTROL_BYTES_BASE: ${{ steps.ascii-base.outputs.base }}
 
       # The other half of the ASCII-only rule. Scans ADDED lines only, so the pre-existing
       # em-dashes in ~645 tracked files do not gate anything; same base resolution as above.
       - name: Check for smart punctuation in added lines
         run: bash scripts/check-no-smart-punctuation.sh --changed "$SMART_PUNCTUATION_BASE"
         env:
-          SMART_PUNCTUATION_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          SMART_PUNCTUATION_BASE: ${{ steps.ascii-base.outputs.base }}
 
       - name: Check deploy contract matches infra
         run: python3 scripts/check-deploy-contract.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,20 +106,26 @@ jobs:
       # which makes both scripts over-scan the whole tree rather than silently check nothing.
       - name: Resolve base for the ASCII checks
         id: ascii-base
+        # Both values arrive as env, never interpolated into the script body. `BASE_REF` is a
+        # branch name, and git permits `;`, `$()`, backticks, `|` and quotes in a ref, so an
+        # inline `${{ }}` would let a crafted base branch break out of the quoting and run
+        # arbitrary commands on the runner. Env values are passed as data and are never parsed
+        # by the shell, which is also the pattern the two checks below already used.
+        env:
+          EVENT_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          set -uo pipefail
-          fallback='${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}'
-          base_ref='${{ github.event.pull_request.base.ref }}'
-          resolved="$fallback"
-          if [ -n "$base_ref" ]; then
-            if git fetch --no-tags --quiet origin "$base_ref" 2>/dev/null; then
+          set -euo pipefail
+          resolved="$EVENT_BASE"
+          if [ -n "$BASE_REF" ]; then
+            if git fetch --no-tags --quiet origin "$BASE_REF" 2>/dev/null; then
               if merge_base=$(git merge-base FETCH_HEAD HEAD 2>/dev/null); then
                 resolved="$merge_base"
               fi
             fi
           fi
           echo "base=$resolved" >> "$GITHUB_OUTPUT"
-          echo "ASCII checks diff against ${resolved:-<whole tree>} (event base was ${fallback:-<none>})"
+          echo "ASCII checks diff against ${resolved:-<whole tree>} (event base was ${EVENT_BASE:-<none>})"
 
       # Mirrors the husky pre-commit guard so a `--no-verify` bypass is still caught.
       - name: Check for raw control bytes in source files


### PR DESCRIPTION
## Description

Both ASCII guards in `Core Build` scan **added lines** relative to a base, and they take that base from `github.event.pull_request.base.sha`. That value is the base-branch head recorded when the PR was opened. It is not the fork point, and it does not move as the base branch advances — so on a long-lived PR, every commit `main` gained in the meantime is attributed to the PR.

The step's own comment states the intent: *"Scans ADDED lines only, so the pre-existing em-dashes in ~645 tracked files do not gate anything."* The base resolution is what defeats it.

**This is not hypothetical.** PR #1356, whose recorded base sits 83 commits behind `main`, failed `Core Build` on em-dashes in five files it never touched:

```
apps/client/__tests__/api/auth/refreshToken.test.ts:150
apps/client/app/components/admin/content/apiReferenceContent.ts:31,115
apps/client/pages/api/admin/__tests__/context-telemetry.test.ts:103
b4m-core/services/src/dataLakeService/dataLakeService.test.ts:183
sst.config.ts:10,13,23
```

Every one of those lines is already on `main` — `sst.config.ts` alone carries 8 em-dash lines there. No change to that PR could have cleared the check, and **rebasing would have made it worse**, pulling still more of `main`'s history into the diff.

It compounds with the merge-ref checkout: on a `pull_request` run the tree is the PR merged into current `main`, so diffing it against a stale base sweeps in everything `main` has landed since.

## Changes

- New `Resolve base for the ASCII checks` step computes `git merge-base` between the base branch and the checked-out tree, and both checks consume its output.
- On a `pull_request` run this lands on the base-branch tip, so the diff is exactly the PR's net contribution.
- `push` and `merge_group` keep their existing sha via the same fallback chain.
- An unresolvable base still yields the empty string, which makes both scripts over-scan the whole tree rather than silently check nothing — the existing fail-safe is preserved.

Both checks are fixed, not just the one that fired; `check-no-control-bytes.sh` had the identical base expression.

## Verification

Reproduced by constructing the same merge ref CI checks out (`main` + the #1356 branch) and running the real script against both bases:

| base | `check-no-smart-punctuation.sh` |
|---|---|
| stale `base.sha` (`9669a57c`) | **exit 1** — reports the same 7 lines CI reported, byte for byte |
| `git merge-base` (`6b796f10`) | **exit 0** |

`check-no-control-bytes.sh` exits 0 under both, confirming this fix doesn't weaken it.

The failing lines the simulation produced match the CI log exactly, so the mechanism is confirmed rather than inferred.

## Guide for Testers

CI-only change; nothing ships to users and no runtime behaviour changes.

1. This PR's own `Core Build` must pass — it exercises the new resolution on itself.
2. Better signal: re-run CI on **#1356** once this merges. Its `Core Build` should go green with no change to that branch. That is the actual regression test.
3. Confirm the guard still bites: add a line containing an em-dash to any `.ts` file in a PR and check that `Core Build` fails on it.

### Regression Checks
- `push` to `main` and `merge_group` runs still resolve a base (they fall through to the existing expression).
- A brand-new branch with an all-zero `before` still over-scans rather than skipping.

### What NOT to test
- No application code changed.
- No AdminSettings, migrations, or telemetry.

## Additional Information

Found while bringing #1356 and #1488 to merge after the 2026-08-06 GitHub Actions outage. #1488 passes the same check because it was opened recently enough that its recorded base still equals its merge base — which is precisely the asymmetry this fixes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — n/a
- [ ] I have made the UI/UX feel good — n/a, CI-only
- [ ] If adding/modifying telemetry fields — n/a
