### PR TITLE
fix(data-lakes): stop taxonomy inference swallowing real API errors as success

### DIFF
--- a/apps/client/server/dataLakes/analyzeBatchTaxonomy.test.ts
+++ b/apps/client/server/dataLakes/analyzeBatchTaxonomy.test.ts
@@ -97,26 +97,18 @@ describe('analyzeBatchTaxonomy', () => {
     expect(result).toMatchObject({ outcome: 'failed', error: 'No OpenAI API key configured' });
   });
 
-  it('fails closed with a curated message (not the raw error) when inference throws, without touching taxonomySuggestions', async () => {
+  it('propagates a genuine inference API failure as an unexpected exception, without touching taxonomySuggestions itself', async () => {
     h.setTaxonomyStatusIfActive.mockResolvedValueOnce({ id: 'b1' }); // claim
-    h.runTaxonomyInference.mockRejectedValue(new Error('401 Incorrect API key provided: sk-***'));
-    h.setTaxonomyStatusIfActive.mockResolvedValueOnce({ id: 'b1', taxonomyStatus: 'failed' }); // fail transition
+    const apiError = new Error('401 Incorrect API key provided: sk-***');
+    h.runTaxonomyInference.mockRejectedValue(apiError);
 
-    const result = await analyzeBatchTaxonomy('b1', 'lake1', 'u1', logger, { from: ['ready', 'failed'] });
-
-    expect(result).toEqual({
-      claimed: true,
-      outcome: 'failed',
-      error: 'AI tagging service is temporarily unavailable - try re-analyzing',
-    });
-    // Raw error text never reaches taxonomyError, and - critically - this write has no
-    // taxonomySuggestions key at all, so a batch re-analyzed from 'ready' keeps whatever good
-    // suggestions it already had instead of losing them to a transient API failure.
-    const failCall = h.setTaxonomyStatusIfActive.mock.calls[1];
-    expect(failCall[2]).toBe('failed');
-    expect(failCall[3]).toEqual({ taxonomyError: 'AI tagging service is temporarily unavailable - try re-analyzing' });
-    expect(failCall[3]).not.toHaveProperty('taxonomySuggestions');
-    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('401 Incorrect API key provided'));
+    await expect(analyzeBatchTaxonomy('b1', 'lake1', 'u1', logger, { from: ['ready', 'failed'] })).rejects.toThrow(
+      apiError
+    );
+    // Left to the caller (queue handler releases the claim for SQS retry; the manual endpoint
+    // marks it failed itself) - this function itself never writes taxonomySuggestions here, so
+    // neither caller's own handling can clobber a prior-good suggestion set either.
+    expect(h.setTaxonomyStatusIfActive).toHaveBeenCalledTimes(1);
   });
 
   it('does not notify a failure if the fail-transition itself lost a concurrent race', async () => {

--- a/apps/client/server/dataLakes/analyzeBatchTaxonomy.test.ts
+++ b/apps/client/server/dataLakes/analyzeBatchTaxonomy.test.ts
@@ -97,6 +97,28 @@ describe('analyzeBatchTaxonomy', () => {
     expect(result).toMatchObject({ outcome: 'failed', error: 'No OpenAI API key configured' });
   });
 
+  it('fails closed with a curated message (not the raw error) when inference throws, without touching taxonomySuggestions', async () => {
+    h.setTaxonomyStatusIfActive.mockResolvedValueOnce({ id: 'b1' }); // claim
+    h.runTaxonomyInference.mockRejectedValue(new Error('401 Incorrect API key provided: sk-***'));
+    h.setTaxonomyStatusIfActive.mockResolvedValueOnce({ id: 'b1', taxonomyStatus: 'failed' }); // fail transition
+
+    const result = await analyzeBatchTaxonomy('b1', 'lake1', 'u1', logger, { from: ['ready', 'failed'] });
+
+    expect(result).toEqual({
+      claimed: true,
+      outcome: 'failed',
+      error: 'AI tagging service is temporarily unavailable - try re-analyzing',
+    });
+    // Raw error text never reaches taxonomyError, and - critically - this write has no
+    // taxonomySuggestions key at all, so a batch re-analyzed from 'ready' keeps whatever good
+    // suggestions it already had instead of losing them to a transient API failure.
+    const failCall = h.setTaxonomyStatusIfActive.mock.calls[1];
+    expect(failCall[2]).toBe('failed');
+    expect(failCall[3]).toEqual({ taxonomyError: 'AI tagging service is temporarily unavailable - try re-analyzing' });
+    expect(failCall[3]).not.toHaveProperty('taxonomySuggestions');
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('401 Incorrect API key provided'));
+  });
+
   it('does not notify a failure if the fail-transition itself lost a concurrent race', async () => {
     h.setTaxonomyStatusIfActive.mockResolvedValueOnce({ id: 'b1' }); // claim wins
     h.fabFindByBatchId.mockResolvedValue([]);

--- a/apps/client/server/dataLakes/analyzeBatchTaxonomy.ts
+++ b/apps/client/server/dataLakes/analyzeBatchTaxonomy.ts
@@ -35,12 +35,21 @@ export interface AnalyzeBatchTaxonomyResult {
  * path, one WebSocket-notification behavior, and one claim/finalize discipline instead of two
  * independently-drifting ~45-line copies.
  *
- * Anticipated failures (no files, no API key, no lake) are handled internally: the batch is
- * transitioned to 'failed' with a real message and the client is notified. An UNEXPECTED
- * exception (DB/network/inference-call error) is left to THROW rather than being swallowed
- * here, because the right recovery differs per caller: the queue handler wants to release the
- * claim so SQS can actually retry; the manual endpoint has no retry mechanism and wants to
- * surface an immediate error to the requester instead. Both callers must catch it themselves.
+ * Anticipated failures (no files, no API key, no lake, and a genuine inference API-call
+ * failure) are handled internally: the batch is transitioned to 'failed' with a real message
+ * and the client is notified. An UNEXPECTED exception (DB/network-outside-inference error) is
+ * left to THROW rather than being swallowed here, because the right recovery differs per
+ * caller: the queue handler wants to release the claim so SQS can actually retry; the manual
+ * endpoint has no retry mechanism and wants to surface an immediate error to the requester
+ * instead. Both callers must catch it themselves.
+ *
+ * Inference-call failures specifically are NOT treated as unexpected: `runTaxonomyInference`
+ * throws only for a genuine API failure (see its doc comment), and that's routed through the
+ * same `fail()` path as every other anticipated failure here rather than left to propagate -
+ * both because it keeps the two callers' behavior consistent (the manual endpoint's own
+ * unexpected-exception handling is a worse experience than its normal failed-outcome response),
+ * and because `fail()` never touches `taxonomySuggestions`, so a failing re-analyze can never
+ * clobber a previously-good suggestion set.
  */
 export async function analyzeBatchTaxonomy(
   batchId: string,
@@ -93,10 +102,18 @@ export async function analyzeBatchTaxonomy(
   if (!lake) return fail('Data lake not found');
 
   const folderTree = sampleFabFilesForTaxonomy(files);
-  const response = await runTaxonomyInference(openaiApiKey, folderTree, {
-    existingPrefix: lake.fileTagPrefix,
-    context: options.context,
-  });
+  let response;
+  try {
+    response = await runTaxonomyInference(openaiApiKey, folderTree, {
+      existingPrefix: lake.fileTagPrefix,
+      context: options.context,
+    });
+  } catch (error) {
+    logger.error(
+      `Taxonomy inference API call failed for batch ${batchId}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return fail('AI tagging service is temporarily unavailable - try re-analyzing');
+  }
 
   const tags = sanitizeCategories(response.categories, lake.fileTagPrefix);
   const fileAssignments = sanitizeFileAssignments(response.fileAssignments);

--- a/apps/client/server/dataLakes/analyzeBatchTaxonomy.ts
+++ b/apps/client/server/dataLakes/analyzeBatchTaxonomy.ts
@@ -35,21 +35,20 @@ export interface AnalyzeBatchTaxonomyResult {
  * path, one WebSocket-notification behavior, and one claim/finalize discipline instead of two
  * independently-drifting ~45-line copies.
  *
- * Anticipated failures (no files, no API key, no lake, and a genuine inference API-call
- * failure) are handled internally: the batch is transitioned to 'failed' with a real message
- * and the client is notified. An UNEXPECTED exception (DB/network-outside-inference error) is
- * left to THROW rather than being swallowed here, because the right recovery differs per
- * caller: the queue handler wants to release the claim so SQS can actually retry; the manual
- * endpoint has no retry mechanism and wants to surface an immediate error to the requester
- * instead. Both callers must catch it themselves.
+ * Anticipated failures (no files, no API key, no lake) are handled internally: the batch is
+ * transitioned to 'failed' with a real message and the client is notified. An UNEXPECTED
+ * exception (DB/network/inference-call error) is left to THROW rather than being swallowed
+ * here, because the right recovery differs per caller: the queue handler wants to release the
+ * claim so SQS can actually retry; the manual endpoint has no retry mechanism and wants to
+ * surface an immediate error to the requester instead. Both callers must catch it themselves.
  *
- * Inference-call failures specifically are NOT treated as unexpected: `runTaxonomyInference`
- * throws only for a genuine API failure (see its doc comment), and that's routed through the
- * same `fail()` path as every other anticipated failure here rather than left to propagate -
- * both because it keeps the two callers' behavior consistent (the manual endpoint's own
- * unexpected-exception handling is a worse experience than its normal failed-outcome response),
- * and because `fail()` never touches `taxonomySuggestions`, so a failing re-analyze can never
- * clobber a previously-good suggestion set.
+ * `runTaxonomyInference` throws for a genuine API-call failure (see its doc comment) - that's
+ * deliberately left in this "unexpected exception" bucket rather than caught and routed through
+ * `fail()` here, so the queue handler's existing claim-release-then-rethrow path can give it a
+ * real automatic SQS retry (a transient 429/5xx is exactly the kind of failure retry helps
+ * with). Note this still can't clobber a prior-good `taxonomySuggestions`: neither caller's own
+ * catch touches that field either - the queue handler only resets `taxonomyStatus`, and the
+ * manual endpoint only sets `taxonomyStatus`/`taxonomyError`.
  */
 export async function analyzeBatchTaxonomy(
   batchId: string,
@@ -102,18 +101,10 @@ export async function analyzeBatchTaxonomy(
   if (!lake) return fail('Data lake not found');
 
   const folderTree = sampleFabFilesForTaxonomy(files);
-  let response;
-  try {
-    response = await runTaxonomyInference(openaiApiKey, folderTree, {
-      existingPrefix: lake.fileTagPrefix,
-      context: options.context,
-    });
-  } catch (error) {
-    logger.error(
-      `Taxonomy inference API call failed for batch ${batchId}: ${error instanceof Error ? error.message : String(error)}`
-    );
-    return fail('AI tagging service is temporarily unavailable - try re-analyzing');
-  }
+  const response = await runTaxonomyInference(openaiApiKey, folderTree, {
+    existingPrefix: lake.fileTagPrefix,
+    context: options.context,
+  });
 
   const tags = sanitizeCategories(response.categories, lake.fileTagPrefix);
   const fileAssignments = sanitizeFileAssignments(response.fileAssignments);

--- a/apps/client/server/dataLakes/runTaxonomyInference.test.ts
+++ b/apps/client/server/dataLakes/runTaxonomyInference.test.ts
@@ -59,6 +59,26 @@ describe('runTaxonomyInference', () => {
     expect(result).toEqual(emptyTaxonomyResponse('acme:'));
   });
 
+  it('returns an empty result (does not throw) when the response has no choices array at all', async () => {
+    createMock.mockResolvedValue({ choices: undefined });
+
+    const result = await runTaxonomyInference('key', [], { existingPrefix: 'acme:' });
+
+    expect(result).toEqual(emptyTaxonomyResponse('acme:'));
+  });
+
+  it('does not wipe a valid result when suggestedPrefix is off-schema (non-string) - defaults it instead', async () => {
+    const categories = [{ tagName: 'acme:type:contract', description: '', confidence: 0.9, matchingFolders: [] }];
+    createMock.mockResolvedValue(
+      completionWith(JSON.stringify({ suggestedPrefix: 123, categories, fileAssignments: [] }))
+    );
+
+    const result = await runTaxonomyInference('key', [], { existingPrefix: 'acme:' });
+
+    expect(result.categories).toEqual(categories);
+    expect(result.suggestedPrefix).toBe('acme:');
+  });
+
   it('does not wipe a valid result just because suggestedPrefix is missing - defaults it instead', async () => {
     const categories = [{ tagName: 'acme:type:contract', description: '', confidence: 0.9, matchingFolders: [] }];
     createMock.mockResolvedValue(completionWith(JSON.stringify({ categories, fileAssignments: [] })));

--- a/apps/client/server/dataLakes/runTaxonomyInference.test.ts
+++ b/apps/client/server/dataLakes/runTaxonomyInference.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+
+vi.mock('openai', () => {
+  const OpenAI = vi.fn(function (this: { chat: { completions: { create: (...a: unknown[]) => unknown } } }) {
+    this.chat = { completions: { create: (...a: unknown[]) => createMock(...a) } };
+  });
+  return { default: OpenAI };
+});
+
+import { runTaxonomyInference, emptyTaxonomyResponse } from './runTaxonomyInference';
+
+const completionWith = (content: string | null) => ({
+  choices: [{ message: { content } }],
+});
+
+describe('runTaxonomyInference', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it('propagates a genuine API-call failure rather than swallowing it', async () => {
+    const apiError = new Error('401 Incorrect API key provided');
+    createMock.mockRejectedValue(apiError);
+
+    await expect(runTaxonomyInference('bad-key', [])).rejects.toThrow(apiError);
+  });
+
+  it('returns an empty result (does not throw) for unparseable JSON content', async () => {
+    createMock.mockResolvedValue(completionWith('not valid json{'));
+
+    const result = await runTaxonomyInference('key', [], { existingPrefix: 'acme:' });
+
+    expect(result).toEqual(emptyTaxonomyResponse('acme:'));
+  });
+
+  it('returns an empty result for a response missing categories', async () => {
+    createMock.mockResolvedValue(completionWith(JSON.stringify({ suggestedPrefix: 'acme:' })));
+
+    const result = await runTaxonomyInference('key', [], { existingPrefix: 'acme:' });
+
+    expect(result).toEqual(emptyTaxonomyResponse('acme:'));
+  });
+
+  it('returns an empty result when categories is not an array', async () => {
+    createMock.mockResolvedValue(completionWith(JSON.stringify({ suggestedPrefix: 'acme:', categories: 'nope' })));
+
+    const result = await runTaxonomyInference('key', [], { existingPrefix: 'acme:' });
+
+    expect(result).toEqual(emptyTaxonomyResponse('acme:'));
+  });
+
+  it('returns an empty result for blank content', async () => {
+    createMock.mockResolvedValue(completionWith(null));
+
+    const result = await runTaxonomyInference('key', [], { existingPrefix: 'acme:' });
+
+    expect(result).toEqual(emptyTaxonomyResponse('acme:'));
+  });
+
+  it('does not wipe a valid result just because suggestedPrefix is missing - defaults it instead', async () => {
+    const categories = [{ tagName: 'acme:type:contract', description: '', confidence: 0.9, matchingFolders: [] }];
+    createMock.mockResolvedValue(completionWith(JSON.stringify({ categories, fileAssignments: [] })));
+
+    const result = await runTaxonomyInference('key', [], { existingPrefix: 'acme:' });
+
+    expect(result.categories).toEqual(categories);
+    expect(result.suggestedPrefix).toBe('acme:');
+  });
+
+  it('returns a fully valid response as-is, with the prefix colon-normalized', async () => {
+    const categories = [{ tagName: 'acme:type:contract', description: '', confidence: 0.9, matchingFolders: [] }];
+    const fileAssignments = [{ relativePath: 'a.pdf', suggestedTags: [{ name: 'acme:type:contract', strength: 0.9 }] }];
+    createMock.mockResolvedValue(
+      completionWith(JSON.stringify({ suggestedPrefix: 'acme', suggestedName: 'Acme', categories, fileAssignments }))
+    );
+
+    const result = await runTaxonomyInference('key', []);
+
+    expect(result.suggestedPrefix).toBe('acme:');
+    expect(result.categories).toEqual(categories);
+    expect(result.fileAssignments).toEqual(fileAssignments);
+  });
+});

--- a/apps/client/server/dataLakes/runTaxonomyInference.ts
+++ b/apps/client/server/dataLakes/runTaxonomyInference.ts
@@ -15,8 +15,9 @@ export interface TaxonomyFolderEntry {
   contentSample?: string;
 }
 
-/** Taxonomy inference is OPTIONAL and non-blocking: on any failure this returns an empty
- * result rather than throwing, so a caller can always proceed with folder-only tags. */
+/** The fallback shape for a malformed/unparseable model response (never for a genuine API-call
+ * failure - see `runTaxonomyInference`'s doc comment for that distinction), so a caller can
+ * always proceed with folder-only tags when the model didn't cooperate with the schema. */
 export const emptyTaxonomyResponse = (existingPrefix?: string): InferTaxonomyResponse => ({
   suggestedPrefix: existingPrefix ?? '',
   suggestedName: '',
@@ -158,7 +159,10 @@ export async function runTaxonomyInference(
     max_tokens: 4000,
   });
 
-  const rawContent = completion.choices[0]?.message?.content;
+  // `?.` all the way through `choices`, not just its elements: a 200 response with a
+  // malformed body (no `choices` array) is a response-format problem, not an API-call
+  // failure, so it belongs in the same "degrade to empty" bucket as blank/unparseable content.
+  const rawContent = completion.choices?.[0]?.message?.content;
   if (!rawContent) return emptyTaxonomyResponse(options?.existingPrefix);
 
   try {
@@ -172,7 +176,11 @@ export async function runTaxonomyInference(
       return emptyTaxonomyResponse(options?.existingPrefix);
     }
 
-    if (!parsed.suggestedPrefix) {
+    // `typeof` guard, not just truthiness: `parsed` is an unchecked cast from untrusted JSON,
+    // so an off-schema value (e.g. a number) must default rather than throw out of
+    // `.endsWith` - a crash here would wipe the already-validated `categories` above via the
+    // outer catch, exactly the "one bad field loses the whole result" bug this fix closes.
+    if (typeof parsed.suggestedPrefix !== 'string' || !parsed.suggestedPrefix) {
       parsed.suggestedPrefix = options?.existingPrefix ?? '';
     } else if (!parsed.suggestedPrefix.endsWith(':')) {
       parsed.suggestedPrefix += ':';

--- a/apps/client/server/dataLakes/runTaxonomyInference.ts
+++ b/apps/client/server/dataLakes/runTaxonomyInference.ts
@@ -102,10 +102,16 @@ const formatSize = (bytes: number): string => {
 };
 
 /**
- * Call the LLM to infer a tag taxonomy from a sampled folder tree. Never throws - every
- * failure mode (blank/unparseable/malformed response) degrades to `emptyTaxonomyResponse`
- * so a caller can always proceed with folder-only tags. The caller resolves/owns the API
- * key (both the auto post-upload job and a manual re-analyze share this one call site).
+ * Call the LLM to infer a tag taxonomy from a sampled folder tree.
+ *
+ * THROWS on a genuine API-call failure (auth/rate-limit/server error, network failure) - that
+ * is a real, curable problem the caller should surface as a failure, not silently swallow.
+ * Never throws for a malformed/unparseable RESPONSE (blank content, invalid JSON, missing
+ * `categories`) - that degrades to `emptyTaxonomyResponse` so a caller can always proceed with
+ * folder-only tags, since a model that returned *something* just didn't cooperate with the
+ * schema, which isn't the same class of problem as the call itself failing. The caller
+ * resolves/owns the API key (both the auto post-upload job and a manual re-analyze share this
+ * one call site).
  */
 export async function runTaxonomyInference(
   openaiApiKey: string,
@@ -138,35 +144,43 @@ export async function runTaxonomyInference(
 
   userPrompt += `\n\nTotal files in folder tree sample: ${folderTree.length}`;
 
+  // Not wrapped in try/catch: a failure here (auth/rate-limit/server/network) is a genuine
+  // API-call problem, not a response-format one, and is left to propagate so the caller can
+  // treat it as a real failure instead of silently getting an empty "success."
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: userPrompt },
+    ],
+    response_format: { type: 'json_object' },
+    temperature: 0.3,
+    max_tokens: 4000,
+  });
+
+  const rawContent = completion.choices[0]?.message?.content;
+  if (!rawContent) return emptyTaxonomyResponse(options?.existingPrefix);
+
   try {
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-4o-mini',
-      messages: [
-        { role: 'system', content: SYSTEM_PROMPT },
-        { role: 'user', content: userPrompt },
-      ],
-      response_format: { type: 'json_object' },
-      temperature: 0.3,
-      max_tokens: 4000,
-    });
-
-    const rawContent = completion.choices[0]?.message?.content;
-    if (!rawContent) return emptyTaxonomyResponse(options?.existingPrefix);
-
     const parsed = JSON.parse(rawContent) as InferTaxonomyResponse;
 
-    // Validate structure minimally - degrade to empty rather than failing the caller.
-    if (!parsed.suggestedPrefix || !parsed.categories || !Array.isArray(parsed.categories)) {
+    // Validate structure minimally - degrade to empty rather than failing the caller. Only
+    // `categories` gates the result: `suggestedPrefix` is never read downstream (the lake's
+    // already-fixed prefix is what's actually used, see the caller), so a model that omits it
+    // gets a sane default instead of losing an otherwise-valid taxonomy over an unused field.
+    if (!parsed.categories || !Array.isArray(parsed.categories)) {
       return emptyTaxonomyResponse(options?.existingPrefix);
     }
 
-    if (!parsed.suggestedPrefix.endsWith(':')) {
+    if (!parsed.suggestedPrefix) {
+      parsed.suggestedPrefix = options?.existingPrefix ?? '';
+    } else if (!parsed.suggestedPrefix.endsWith(':')) {
       parsed.suggestedPrefix += ':';
     }
 
     return parsed;
   } catch (error) {
-    console.warn('Taxonomy inference failed; returning empty taxonomy (non-blocking):', error);
+    console.warn('Taxonomy inference response was malformed; returning empty taxonomy (non-blocking):', error);
     return emptyTaxonomyResponse(options?.existingPrefix);
   }
 }


### PR DESCRIPTION
## Description

Follow-up from #1268 (background AI-tag-suggestion reliability and correctness gaps) - items 10, 11, and 15, all confirmed still accurate against current code before starting.

`runTaxonomyInference` wrapped the OpenAI call AND the response-parsing/validation in one try/catch, so a genuine API failure (401/429/5xx/network) was caught identically to "the model returned malformed JSON" - both silently degraded to an empty taxonomy result, never throwing. The caller, `analyzeBatchTaxonomy`, had no try/catch around that call and unconditionally finalized the batch to `taxonomyStatus: 'ready'` with whatever it got. Since this function is shared verbatim between the automatic post-upload job and the manual re-analyze endpoint, a transient outage during a re-analyze could silently **overwrite a previously-good `taxonomySuggestions` with an empty one** - permanent, silent data loss, with a green "Review AI tags" chip opening onto nothing (items 10 + 11).

Separately, the same function's validation gate wiped the entire result - including genuinely useful `categories` - if the model merely omitted `suggestedPrefix`, a field confirmed (repo-wide grep) to be read nowhere downstream; the lake's already-fixed prefix is what's actually used (item 15).

## Changes

- `runTaxonomyInference` now throws for a genuine API-call failure (auth/rate-limit/server/network) instead of swallowing it. Parsing/validation failures still degrade to an empty result - a malformed response is "the model didn't cooperate," not an infra failure.
- That throw is deliberately left as an **unexpected exception** for `analyzeBatchTaxonomy`'s callers to handle themselves, not caught and converted to a curated failure internally - this preserves the queue handler's existing claim-release-and-SQS-retry path for a transient failure on the automatic post-upload job. (An earlier version of this PR caught it internally and always finalized to `'failed'` after one attempt; reverted once review established `'failed'` has no other automatic recovery path - it's excluded from the stuck-job reconciler's non-terminal set - so that approach was a real loss of retry resilience, not just a messaging difference.) Item 11 is unaffected either way: neither caller's own exception handling touches `taxonomySuggestions`.
- `runTaxonomyInference`'s validation gate no longer requires `suggestedPrefix` - a model that omits it gets a sane default (the lake's existing prefix) instead of losing an otherwise-valid taxonomy.
- Two additional crash/data-loss bugs found and fixed while re-touching this code: `completion.choices[0]` had no guard on `.choices` itself, so a malformed-but-200 API response threw uncaught instead of degrading to empty; and a non-string `suggestedPrefix` (off-schema model output) threw on `.endsWith(':')`, which the outer catch turned into a full wipe of an otherwise-valid response's `categories`.

## Guide for Testers

Not practical to verify manually - reproducing a genuine OpenAI outage has no reliable trigger. Covered by unit tests instead:

- `runTaxonomyInference.test.ts` (new file, 9 tests): a rejected API call propagates rather than being swallowed; unparseable JSON, missing/non-array `categories`, blank content, and a missing `choices` array all degrade to an empty result without throwing; a missing or off-schema (non-string) `suggestedPrefix` no longer wipes valid `categories`; a fully valid response is returned as-is with the prefix colon-normalized.
- `analyzeBatchTaxonomy.test.ts`: a genuine inference API failure now propagates as an unexpected exception (matching the existing DB-error test's contract) rather than being caught internally, and never writes `taxonomySuggestions`.

### What NOT to test

The underlying taxonomy-suggestion UX (Apply/Re-analyze/Dismiss) is unchanged - this only affects behavior during a genuine OpenAI outage or a malformed model response, neither of which has a reliable manual repro.

## Additional Information

Verified: `pnpm turbo:core:build` clean, `pnpm --filter client typecheck` clean, `pnpm lint:check` clean, full `server/dataLakes` test directory (62 passed, 9 files) including the queue handler and manual re-analyze route suites, confirmed unaffected.

Does not close #1268 - only items 10, 11, and 15 are addressed here; the remaining items are separate follow-up PRs.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
