### PR TITLE
fix(llm): stop file-access denial and filename-driven row guesses

### DIFF
--- a/b4m-core/utils/src/llm/processFabFilesServer.test.ts
+++ b/b4m-core/utils/src/llm/processFabFilesServer.test.ts
@@ -71,11 +71,12 @@ const emittedChars = (userMessages: Array<{ content: unknown }>) =>
 
 /**
  * Each included file carries a short label ("Here is the content from the attached
- * file ...") that is not charged against the content budget. It is tens of characters
- * per file against a budget in the thousands, and assembly re-counts everything with
- * the real tokenizer afterwards, so it is allowed for rather than engineered away.
+ * file ...") plus the anti-inference/truncation notices, none of which are charged
+ * against the content budget. It is roughly a hundred characters per file against a
+ * budget in the thousands, and assembly re-counts everything with the real tokenizer
+ * afterwards, so it is allowed for rather than engineered away.
  */
-const FRAMING_ALLOWANCE_PER_FILE = 200;
+const FRAMING_ALLOWANCE_PER_FILE = 300;
 
 describe('processFabFilesServer attached-content budget', () => {
   beforeEach(() => {
@@ -215,5 +216,88 @@ describe('processFabFilesServer attached-content budget', () => {
     );
 
     expect(emittedChars(userMessages)).toBeLessThan(MAX_FILE_SIZE);
+  });
+});
+
+describe('filename handling in the delivered-content wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFileContent.mockResolvedValue('some file content');
+  });
+
+  it('keeps digits in a filename out of the wrapper header un-flagged', async () => {
+    // A number embedded in the filename (e.g. 30000.txt) sits right next to the content; the model
+    // must be told it is part of the name, not a row/record count it can echo back.
+    const { userMessages } = await processFabFilesServer(
+      embeddingFactory,
+      [textFile('30000')],
+      'prompt',
+      4000,
+      modelInfo,
+      async () => {},
+      deps()
+    );
+
+    const content = userMessages[0].content as string;
+    expect(content).toContain('Here is the content from the attached file "30000.txt" for context:');
+    expect(content).toContain(
+      'Digits in the file name are part of the name, not a count of its rows, records, or sections.'
+    );
+  });
+
+  it('sanitizes bracket and quote characters out of the wrapper header filename', async () => {
+    const crafted = {
+      id: 'a',
+      fileName: 'weird[1]"name.txt',
+      mimeType: 'text/plain',
+      vectorized: false,
+    } as IFabFileDocument;
+    const { userMessages } = await processFabFilesServer(
+      embeddingFactory,
+      [crafted],
+      'prompt',
+      4000,
+      modelInfo,
+      async () => {},
+      deps()
+    );
+
+    const content = userMessages[0].content as string;
+    expect(content).not.toContain('weird[1]"name.txt');
+    expect(content).toContain('weird 1  name.txt');
+  });
+
+  it('falls back to a placeholder when sanitizing empties the filename', async () => {
+    const crafted = { id: 'a', fileName: '["]', mimeType: 'text/plain', vectorized: false } as IFabFileDocument;
+    const { userMessages } = await processFabFilesServer(
+      embeddingFactory,
+      [crafted],
+      'prompt',
+      4000,
+      modelInfo,
+      async () => {},
+      deps()
+    );
+
+    const content = userMessages[0].content as string;
+    expect(content).toContain('Here is the content from the attached file "unnamed attachment" for context:');
+  });
+
+  it('states the digit-in-filename caveat once, not per file, when multiple files are attached', async () => {
+    const { userMessages } = await processFabFilesServer(
+      embeddingFactory,
+      [textFile('30000'), textFile('40000')],
+      'prompt',
+      4000,
+      modelInfo,
+      async () => {},
+      deps()
+    );
+
+    const content = userMessages[0].content as string;
+    const occurrences = content.split('Digits in the file name are part of the name').length - 1;
+    expect(occurrences).toBe(1);
+    expect(content).toContain('--- File 1: 30000.txt ---');
+    expect(content).toContain('--- File 2: 40000.txt ---');
   });
 });

--- a/b4m-core/utils/src/llm/upstreamTruncation.test.ts
+++ b/b4m-core/utils/src/llm/upstreamTruncation.test.ts
@@ -20,6 +20,7 @@ import {
   buildAndSortMessages,
   getLastBuildDebugInfo,
   calculateTotalTokenLength,
+  ATTACHMENT_DELIVERED_NOTICE,
 } from './utils';
 
 const mockLogger = {
@@ -492,6 +493,34 @@ describe('content cut before assembly is declared to the model', () => {
 
       const text = result.map(m => (typeof m.content === 'string' ? m.content : '')).join('\n');
       expect(text).not.toContain('could not be included');
+    });
+
+    it('does not tell the model it can read attachments when the content is a fetched page, not one', async () => {
+      // The delivered-content assurance is gated on isAttachment, which this WeakSet-based check
+      // already excludes URL-derived content from - a fetched page is not an attachment the user
+      // added, so wording that says "the content below" was attached would misdescribe it.
+      const { userMessages } = await processUrlsFromPrompt(
+        'summarise https://example.com/report',
+        100000,
+        'user-1',
+        async () => {},
+        mockLogger as any
+      );
+
+      const result = await buildAndSortMessages(
+        [],
+        userMessages,
+        [{ role: 'user', content: 'summarise it' }],
+        20000,
+        {},
+        5,
+        mockLogger as any,
+        tokenizer as any
+      );
+
+      const text = result.map(m => (typeof m.content === 'string' ? m.content : '')).join('\n');
+      expect(text).toContain('PAGE-START');
+      expect(text).not.toContain(ATTACHMENT_DELIVERED_NOTICE.trim());
     });
 
     it('cuts content that merely contains the excerpt prefix and ends with a bracket', async () => {

--- a/b4m-core/utils/src/llm/utils.test.ts
+++ b/b4m-core/utils/src/llm/utils.test.ts
@@ -10,6 +10,7 @@ import {
   includeHardcodedSystemMessage,
   includeImagePromptSystemMessage,
   TOOL_RESULT_NOT_RECORDED,
+  ATTACHMENT_DELIVERED_NOTICE,
 } from './utils';
 import { ensureToolPairingIntegrity, stripAllToolBlocks } from '@bike4mind/llm-adapters';
 import { DEFAULT_HISTORY_FETCH_LIMIT, FORMAT_PROMPT_TEMPLATE, UNLIMITED_HISTORY_COUNT } from '@bike4mind/common';
@@ -453,7 +454,7 @@ describe('Context Management Tests', () => {
     });
 
     const hasFileContent = (messages: IMessage[]) =>
-      messages.some(m => typeof m.content === 'string' && m.content.startsWith('File content:'));
+      messages.some(m => typeof m.content === 'string' && m.content.includes('File content:'));
 
     it('should split the budget between files and history when no window is set', async () => {
       const { previousMessages, fabMessages } = oversubscribed();
@@ -1892,8 +1893,10 @@ describe('Token budget allocation', () => {
     content: ATTACHED_FILE_PREFIX + 'C'.repeat(totalChars - ATTACHED_FILE_PREFIX.length),
   });
 
+  // The delivered-content notice (see ATTACHMENT_DELIVERED_NOTICE) rides ahead of the file's own
+  // framing, so the message no longer starts with ATTACHED_FILE_PREFIX - it contains it.
   const findAttachedFile = (messages: IMessage[]) =>
-    messages.find(m => typeof m.content === 'string' && m.content.startsWith(ATTACHED_FILE_PREFIX));
+    messages.find(m => typeof m.content === 'string' && m.content.includes(ATTACHED_FILE_PREFIX));
   const historyLabels = (messages: IMessage[]) =>
     messages
       .filter(m => typeof m.content === 'string' && (m.content as string).startsWith('history-'))
@@ -2038,12 +2041,14 @@ describe('Token budget allocation', () => {
       );
 
       // floor = floor(6992 * 0.35) = 2447, so the file is truncated to 7708 chars (~2203 tokens)
-      // rather than dropped.
+      // rather than dropped. Offset by the delivered-content notice, which rides ahead of the file.
       const file = findAttachedFile(result);
       expect(file).toBeDefined();
       // 7708 chars of the file, plus the notice telling the model this is not where the file ends.
       expect(file!.content as string).toContain('Content truncated to fit the context window');
-      expect((file!.content as string).indexOf('\n\n[Content truncated')).toBe(7708);
+      expect((file!.content as string).indexOf('\n\n[Content truncated')).toBe(
+        7708 + ATTACHMENT_DELIVERED_NOTICE.length
+      );
 
       // History still holds the majority of the budget and keeps its newest exchange.
       const labels = historyLabels(result);
@@ -2051,8 +2056,9 @@ describe('Token budget allocation', () => {
       expect(labels).toContain('history-39');
       expect(labels).toContain('history-38');
 
-      // The primary allocation kept us in bounds, so the final safety net never had to fire.
-      expect(await calculateTotalTokenLength(result, { estimateOnly: false, tokenizer })).toBe(6661);
+      // The primary allocation kept us in bounds, so the final safety net never had to fire. 6661 plus
+      // the delivered-content and anti-inference notices' own real token cost (both fixed, both counted).
+      expect(await calculateTotalTokenLength(result, { estimateOnly: false, tokenizer })).toBe(6723);
       expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining('exceeds maxInputTokens'));
 
       // The squeeze is reported, and it names the file so a support engineer can see which one lost.
@@ -2066,9 +2072,9 @@ describe('Token budget allocation', () => {
 
       const result = await buildAndSortMessages([], [attached], [], 8000, {}, 10, mockLogger as any, tokenizer);
 
-      // Byte-identical, not merely present: the squeeze check compares estimates against estimates,
-      // so an attachment that fits can never be reported as squeezed.
-      expect(findAttachedFile(result)?.content).toBe(attached.content);
+      // Byte-identical past the delivered-content notice, not merely present: the squeeze check
+      // compares estimates against estimates, so an attachment that fits can never be reported as squeezed.
+      expect(findAttachedFile(result)?.content).toBe(ATTACHMENT_DELIVERED_NOTICE + attached.content);
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
@@ -2127,7 +2133,7 @@ describe('Token budget allocation', () => {
         tokenizer
       );
 
-      expect(findAttachedFile(result)?.content).toBe(attached.content);
+      expect(findAttachedFile(result)?.content).toBe(ATTACHMENT_DELIVERED_NOTICE + attached.content);
       expect(historyLabels(result)).toHaveLength(172);
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
@@ -2297,6 +2303,16 @@ describe('processFabFilesServer chunk retrieval', () => {
     expect(content).toContain('chunk-0-');
     expect(content).not.toContain('chunk-1-');
   });
+
+  it("tells the model a filename's digits are not a row count on the vectorized body header", async () => {
+    const messages = await runRetrieval(makeChunks(3, 200), 4000);
+
+    const content = messages[0].content as string;
+    expect(content).toContain('Data for roster.csv:');
+    expect(content).toContain(
+      'Digits in the file name are part of the name, not a count of its rows, records, or sections.'
+    );
+  });
 });
 
 // The default mock tokenizer is ceil(len / 3.5), byte-identical to the internal estimator, so any
@@ -2367,7 +2383,7 @@ describe('final safety pass under a denser-than-estimated tokenizer', () => {
       makeHistory(60, 1000),
       [{ role: 'user', content: 'F'.repeat(30000) }],
       [{ role: 'user', content: 'Summarize the attached file' }],
-      4952,
+      5200,
       {},
       20,
       mockLogger as any,
@@ -2539,11 +2555,15 @@ describe('truncated attachments are marked', () => {
       tokenizer
     );
 
-    const file = result.find(m => typeof m.content === 'string' && (m.content as string).startsWith('row-data,'));
+    const file = result.find(m => typeof m.content === 'string' && (m.content as string).includes('row-data,'));
     expect(file).toBeDefined();
     const text = file!.content as string;
     expect(text).toContain(NOTICE);
-    expect(text.endsWith(NOTICE + '. This is NOT the end of the file - later content was not sent.]')).toBe(true);
+    expect(
+      text.endsWith(
+        'later content was not sent. Do not infer a total row, record, or section count, or a final row, from what is above.]'
+      )
+    ).toBe(true);
     // The tail the marker lives in genuinely did not survive, which is exactly why the notice matters.
     expect(text).not.toContain('FINAL_ROW_MARKER');
   });
@@ -2571,16 +2591,21 @@ describe('truncated attachments are marked', () => {
       tokenizer
     );
 
-    const delivered = result.filter(m => typeof m.content === 'string' && (m.content as string).startsWith('id,name'));
+    const delivered = result.filter(m => typeof m.content === 'string' && (m.content as string).includes('id,name'));
     expect(delivered).toHaveLength(2);
-    expect(delivered.map(m => m.content)).toEqual(expect.arrayContaining([small, large]));
+    expect(delivered.map(m => m.content)).toEqual(
+      expect.arrayContaining([ATTACHMENT_DELIVERED_NOTICE + small, ATTACHMENT_DELIVERED_NOTICE + large])
+    );
     for (const m of delivered) expect(m.content as string).not.toContain(NOTICE);
   });
 
   it('never leaves more than one truncation notice, even when the safety pass cuts twice', async () => {
     // A dense tokenizer forces the safety pass to run after the primary pass already cut and marked the
     // file. Cutting notice-carrying content again lands mid-notice, so appending another one would leave
-    // a mangled fragment followed by a whole notice.
+    // a mangled fragment followed by a whole notice. Budget nudged up from the original 4952: the fixed
+    // per-file overhead (the delivered-content and anti-inference notices) now costs more under this
+    // dense 2.0-chars/token tokenizer, and the old figure squeezed the file below the useful-content
+    // floor entirely rather than leaving it cut-but-delivered.
     const tokenizer = createDenseTokenizer(2.0);
     const body = 'row-data,'.repeat(4000) + '\nFINAL_ROW_MARKER: pineapple';
 
@@ -2588,18 +2613,22 @@ describe('truncated attachments are marked', () => {
       makeHistory(60, 1000),
       [{ role: 'user', content: body }],
       [{ role: 'user', content: 'What is FINAL_ROW_MARKER?' }],
-      4952,
+      5200,
       {},
       20,
       mockLogger as any,
       tokenizer
     );
 
-    const file = result.find(m => typeof m.content === 'string' && (m.content as string).startsWith('row-data,'));
+    const file = result.find(m => typeof m.content === 'string' && (m.content as string).includes('row-data,'));
     expect(file).toBeDefined();
     const text = file!.content as string;
     expect(text.split(NOTICE)).toHaveLength(2); // exactly one occurrence
-    expect(text.endsWith('later content was not sent.]')).toBe(true);
+    expect(
+      text.endsWith(
+        'later content was not sent. Do not infer a total row, record, or section count, or a final row, from what is above.]'
+      )
+    ).toBe(true);
     // No fragment of a notice stranded earlier in the payload.
     expect(text.slice(0, text.indexOf(NOTICE))).not.toContain('[Content truncated');
   });
@@ -2619,8 +2648,8 @@ describe('truncated attachments are marked', () => {
       tokenizer
     );
 
-    const file = result.find(m => typeof m.content === 'string' && (m.content as string).startsWith('row-data,'));
-    expect(file!.content).toBe(whole);
+    const file = result.find(m => typeof m.content === 'string' && (m.content as string).includes('row-data,'));
+    expect(file!.content).toBe(ATTACHMENT_DELIVERED_NOTICE + whole);
     expect(file!.content as string).not.toContain(NOTICE);
     expect(file!.content as string).toContain('FINAL_ROW_MARKER: apricot');
   });
@@ -2643,10 +2672,106 @@ describe('truncated attachments are marked', () => {
       tokenizer
     );
 
-    const delivered = result.find(m => typeof m.content === 'string' && (m.content as string).startsWith('row,value'));
-    expect(delivered!.content).toBe(file);
+    const delivered = result.find(m => typeof m.content === 'string' && (m.content as string).includes('row,value'));
+    expect(delivered!.content).toBe(ATTACHMENT_DELIVERED_NOTICE + file);
     expect(delivered!.content as string).toContain('FINAL_ROW_MARKER: apricot');
     expect(delivered!.content as string).not.toContain(NOTICE);
+  });
+});
+
+// A model handed real content still opens some replies by denying it can read attachments. The notice
+// must ride on content that genuinely survived to the final payload, never on a message that says
+// content was dropped - that exact false claim is why an earlier, differently-placed attempt at this
+// was reverted.
+describe('attachment access notice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('marks a delivered attachment as readable', async () => {
+    const result = await buildAndSortMessages(
+      [],
+      [{ role: 'user', content: 'id,fruit\nr,apple\n' }],
+      [{ role: 'user', content: 'summarize' }],
+      8000,
+      {},
+      10,
+      mockLogger as any,
+      createMockTokenizer()
+    );
+
+    const delivered = result.find(m => typeof m.content === 'string' && (m.content as string).includes('id,fruit'));
+    expect(delivered!.content as string).toMatch(
+      new RegExp(`^${ATTACHMENT_DELIVERED_NOTICE.replace(/[[\]().]/g, '\\$&')}`)
+    );
+  });
+
+  it('never marks the note that says content could not be delivered', async () => {
+    const tokenizer: ITokenizer = {
+      countTokens: vi.fn(async (text: string) => Math.ceil(text.length / 3.5)),
+      encodeTokens: vi.fn(async (text: string) => Array(Math.ceil(text.length / 3.5)).fill(1)),
+      clearCache: vi.fn(),
+      getCacheStats: vi.fn(() => ({ size: 0, keys: [] })),
+      warmUpCache: vi.fn(async () => {}),
+    };
+    const history = Array.from({ length: 40 }, (_, i) => ({
+      role: i % 2 === 0 ? ('user' as const) : ('assistant' as const),
+      content: `history-${i}-` + 'h'.repeat(240),
+    }));
+
+    const result = await buildAndSortMessages(
+      history,
+      [
+        { role: 'system', content: 'S'.repeat(1500 * 3.5) },
+        { role: 'user', content: 'alpha,col\n' + 'r,1\n'.repeat(3000) },
+        { role: 'user', content: 'bravo,col\n' + 'r,1\n'.repeat(3000) },
+      ],
+      [{ role: 'user', content: 'What do the attached files contain?' }],
+      2200,
+      {},
+      20,
+      mockLogger as any,
+      tokenizer
+    );
+
+    const note = result.find(
+      m => typeof m.content === 'string' && (m.content as string).includes('could not be included')
+    );
+    expect(note).toBeDefined();
+    expect(note!.content as string).not.toContain(ATTACHMENT_DELIVERED_NOTICE.trim());
+  });
+
+  it('marks one delivered file while its dropped sibling is only named in the undelivered note', async () => {
+    const tokenizer: ITokenizer = {
+      countTokens: vi.fn(async (text: string) => Math.ceil(text.length / 3.5)),
+      encodeTokens: vi.fn(async (text: string) => Array(Math.ceil(text.length / 3.5)).fill(1)),
+      clearCache: vi.fn(),
+      getCacheStats: vi.fn(() => ({ size: 0, keys: [] })),
+      warmUpCache: vi.fn(async () => {}),
+    };
+
+    const result = await buildAndSortMessages(
+      [],
+      [
+        { role: 'user', content: 'small,file\nrow,1\n' },
+        { role: 'system', content: 'S'.repeat(1500 * 3.5) },
+        { role: 'user', content: 'big,file\n' + 'row,1\n'.repeat(3000) },
+      ],
+      [{ role: 'user', content: 'summarize both' }],
+      2200,
+      {},
+      20,
+      mockLogger as any,
+      tokenizer
+    );
+
+    const small = result.find(m => typeof m.content === 'string' && (m.content as string).includes('small,file'));
+    const note = result.find(
+      m => typeof m.content === 'string' && (m.content as string).includes('could not be included')
+    );
+    expect(small!.content as string).toContain(ATTACHMENT_DELIVERED_NOTICE.trim());
+    expect(note).toBeDefined();
+    expect(result.some(m => typeof m.content === 'string' && (m.content as string).includes('big,file'))).toBe(false);
   });
 });
 
@@ -2700,9 +2825,9 @@ describe('allocation under a production-shaped system-prompt load', () => {
     );
 
     const delivered = result.find(
-      m => typeof m.content === 'string' && (m.content as string).startsWith('id,fruit,color')
+      m => typeof m.content === 'string' && (m.content as string).includes('id,fruit,color')
     );
-    expect(delivered!.content).toBe(file.content);
+    expect(delivered!.content).toBe(ATTACHMENT_DELIVERED_NOTICE + file.content);
     expect(delivered!.content as string).toContain('FINAL_ROW_MARKER: apricot');
     expect(delivered!.content as string).not.toContain(NOTICE);
     expect(await calculateTotalTokenLength(result, { estimateOnly: false, tokenizer })).toBeLessThanOrEqual(
@@ -2729,7 +2854,7 @@ describe('allocation under a production-shaped system-prompt load', () => {
     );
 
     const delivered = result.find(
-      m => typeof m.content === 'string' && (m.content as string).startsWith('id,fruit,color')
+      m => typeof m.content === 'string' && (m.content as string).includes('id,fruit,color')
     );
     expect(delivered).toBeDefined();
     const text = delivered!.content as string;
@@ -2763,7 +2888,7 @@ describe('allocation under a production-shaped system-prompt load', () => {
     );
 
     const delivered = result.find(
-      m => typeof m.content === 'string' && (m.content as string).startsWith('id,fruit,color')
+      m => typeof m.content === 'string' && (m.content as string).includes('id,fruit,color')
     );
     expect(delivered).toBeDefined();
     // Cut, and said so - a silent cut is the failure this area exists to prevent.
@@ -2895,7 +3020,7 @@ describe('system-message retention under a capped budget', () => {
     expect(result.some(m => m.role === 'system')).toBe(false);
     expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('No system instructions fit the budget'));
     // And the attachment keeps its budget rather than paying for an unmeasured block.
-    const delivered = result.find(m => typeof m.content === 'string' && m.content.startsWith('id,fruit,color'));
+    const delivered = result.find(m => typeof m.content === 'string' && m.content.includes('id,fruit,color'));
     expect(delivered?.content as string).toContain(marker);
   });
 
@@ -2932,7 +3057,7 @@ describe('system-message retention under a capped budget', () => {
     );
 
     const delivered = result.find(
-      m => typeof m.content === 'string' && (m.content as string).startsWith('id,fruit,color')
+      m => typeof m.content === 'string' && (m.content as string).includes('id,fruit,color')
     );
     expect(delivered).toBeDefined();
     expect(delivered!.content as string).toContain('FINAL_ROW_MARKER: apricot');

--- a/b4m-core/utils/src/llm/utils.ts
+++ b/b4m-core/utils/src/llm/utils.ts
@@ -125,7 +125,19 @@ const MAX_SAFETY_SHRINK_ROUNDS = 5;
  * model only - what later steps read to know a message was cut is processMessages' truncatedMessages.
  */
 const CONTENT_TRUNCATION_NOTICE =
-  '\n\n[Content truncated to fit the context window. This is NOT the end of the file - later content was not sent.]';
+  '\n\n[Content truncated to fit the context window. This is NOT the end of the file - later content was ' +
+  'not sent. Do not infer a total row, record, or section count, or a final row, from what is above.]';
+
+/**
+ * Prefixed onto a delivered attachment's own content in `assemble`, never added as a separate system
+ * message: the system-message loop further down picks messages first-fit-with-break by budget, so a new
+ * one there risks silently starving the `file.system` branch's own content on a marginal turn. Riding on
+ * the content message itself means it lives or dies with what it is asserting, so it can never claim
+ * content is present when `declareUndeliveredAttachments` has already dropped or replaced it.
+ */
+export const ATTACHMENT_DELIVERED_NOTICE =
+  '[The content below is included in this request and you can read it. Do not tell the user you are ' +
+  'unable to access or open it.]\n\n';
 
 /**
  * Below this many tokens of a file, a slice is not worth sending. A few dozen characters of a CSV does
@@ -167,8 +179,17 @@ const sanitizeNoticeFileName = (fileName: string): string =>
     .trim()
     .slice(0, MAX_NOTICE_FILENAME_CHARS);
 
+// A name that is only brackets/quotes/newlines sanitizes to '', which would otherwise show the model an
+// empty quoted name or break the line-anchored ATTACHMENT_NAME_HEADERS match.
+const noticeFileName = (fileName: string): string => sanitizeNoticeFileName(fileName) || 'unnamed attachment';
+
+// Placed next to a filename, never inside CONTENT_TRUNCATION_NOTICE: that notice is also used for
+// URL-derived content with no filename at all, where this sentence would be nonsensical.
+const FILENAME_DIGIT_NOTICE =
+  '(Digits in the file name are part of the name, not a count of its rows, records, or sections.)';
+
 const excerptNotice = (fileName: string): string =>
-  `${EXCERPT_NOTICE_PREFIX}"${sanitizeNoticeFileName(fileName)}"${EXCERPT_NOTICE_TAIL}`;
+  `${EXCERPT_NOTICE_PREFIX}"${noticeFileName(fileName)}"${EXCERPT_NOTICE_TAIL}`;
 
 const URL_TRUNCATION_NOTICE =
   '\n\n[Fetched page content truncated to fit the context window. This is NOT the end of the page - later ' +
@@ -1522,7 +1543,7 @@ export async function processFabFilesServer(
             if (!deliveredEveryChunk) notice = excerptNotice(file.fileName);
             else if (anyChunkCut) notice = CONTENT_TRUNCATION_NOTICE;
 
-            const body = `Data for ${file.fileName}:\n${truncatedResults.map(r => `For context: ${r.content}`).join('\n')}`;
+            const body = `Data for ${noticeFileName(file.fileName)}:\n${FILENAME_DIGIT_NOTICE}\n${truncatedResults.map(r => `For context: ${r.content}`).join('\n')}`;
             userMessages.push({ role: 'user', content: body + notice });
 
             if (notice) {
@@ -1662,12 +1683,12 @@ export async function processFabFilesServer(
 
     if (contextFiles.length === 1) {
       // Single file: simple format
-      combinedContent = `Here is the content from the attached file "${contextFiles[0].fileName}" for context:\n\n${contextFiles[0].content}`;
+      combinedContent = `Here is the content from the attached file "${noticeFileName(contextFiles[0].fileName)}" for context:\n${FILENAME_DIGIT_NOTICE}\n\n${contextFiles[0].content}`;
     } else {
       // Multiple files: structured format with clear separation
-      combinedContent = `Here are the contents from ${contextFiles.length} attached files for context:\n\n`;
+      combinedContent = `Here are the contents from ${contextFiles.length} attached files for context. ${FILENAME_DIGIT_NOTICE}\n\n`;
       contextFiles.forEach((file, index) => {
-        combinedContent += `--- File ${index + 1}: ${file.fileName} ---\n${file.content}\n\n`;
+        combinedContent += `--- File ${index + 1}: ${noticeFileName(file.fileName)} ---\n${file.content}\n\n`;
       });
       combinedContent += `--- End of attached files ---`;
     }
@@ -2424,7 +2445,21 @@ export async function buildAndSortMessages(
    * tool_use and the prompt carries the matching tool_result, other context moves after the prompt to
    * keep the pair adjacent.
    */
+  // Gated on the exact survivor predicate declareUndeliveredAttachments already applies, so a message
+  // this array still holds is one that really did survive: excludes undeliveredNote by identity (it
+  // exists to say content did NOT arrive) and mirrors the cutContentMessages/fileTokens sliver check,
+  // even though a sliver never reaches this array today - a future caller of assemble should not have to
+  // re-derive that invariant to stay correct.
+  const withDeliveredNotice = (message: IMessage): IMessage =>
+    typeof message.content === 'string' &&
+    message !== undeliveredNote &&
+    isAttachment(message) &&
+    !(cutContentMessages.has(message) && fileTokens(message) < MIN_USEFUL_ATTACHED_CONTENT_TOKENS)
+      ? { ...message, content: ATTACHMENT_DELIVERED_NOTICE + message.content }
+      : message;
+
   const assemble = (content: IMessage[], history: IMessage[]): IMessage[] => {
+    const deliveredContent = content.map(withDeliveredNotice);
     const lastHistoryMessage = history[history.length - 1];
     const historyEndsWithToolUse =
       lastHistoryMessage?.role === 'assistant' &&
@@ -2432,8 +2467,8 @@ export async function buildAndSortMessages(
       lastHistoryMessage.content.some((block: any) => block.type === 'tool_use');
 
     return historyEndsWithToolUse && promptHasToolResult
-      ? [...systemMessages, ...history, ...userPrompt, ...imageMessages, ...content]
-      : [...systemMessages, ...history, ...imageMessages, ...content, ...userPrompt];
+      ? [...systemMessages, ...history, ...userPrompt, ...imageMessages, ...deliveredContent]
+      : [...systemMessages, ...history, ...imageMessages, ...deliveredContent, ...userPrompt];
   };
 
   const messages: IMessage[] = assemble(processedContentMessages, processedPreviousMessages);


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="879" height="48" alt="Model summarizes an attached CSV without denying it can read the file" src="https://github.com/user-attachments/assets/d292c455-eaec-4472-b466-0417782d9e99" />
*Figure: attached a 50-row CSV and asked what it contains - the reply answers directly, no denial of file access.*

<img width="879" height="48" alt="Model calls out that a number in the filename is not a row count" src="https://github.com/user-attachments/assets/a8a5d4f0-dc38-4549-85f4-fafd7f8ec65c" />
*Figure: attached a CSV named with a fake "99999" and asked for the row count - the reply explicitly flags the filename number as not a row count, instead of parroting it back.*

## Description

QA found two prompt-wording defects in the file-attachment pipeline, split into their own issue: GPT-4 can open a reply denying it can read an attachment even after excerpts were genuinely delivered, and a numeric filename (e.g. r5-fresh-30000.csv) can make the model fabricate a row total or final row matching the number in the name once the file is truncated.

The denial fix rides a short assurance directly on each delivered attachment's own content, computed after the token-budget squeeze has already decided what survives, so it can never assert delivery of content that was actually dropped or reduced to a sliver. It intentionally avoids a new system message, since that selection loop drops every message behind the first one that does not fit its own budget.

The filename fix ports the vectorized-excerpt path's anti-inference wording onto the raw-truncation notice, and sanitizes every raw filename that reaches the model.

Closes #1166

## Changes

- Adds a delivered-content notice to each surviving attachment message, computed after the token-budget squeeze so it can never claim content the squeeze already dropped or reduced to a sliver
- Ports the raw-truncation notice's anti-inference wording to match what the vectorized-excerpt path already carries
- Sanitizes every raw filename that reaches the model (not just the vectorized path), with a fallback for a name that sanitizes to an empty string
- Adds an explicit note next to each filename that digits in it are not a row/record count
- Extends unit tests for both behaviors, including a fetched-URL-content exclusion case

## Guide for Testers

Both fixes are about model behavior, so they need a live model call to verify - neither reproduces in a unit test (unit tests here cover the deterministic prompt-construction code, not the model's actual reply). Already verified against this PR's preview at `app.pr1526.preview.bike4mind.com` - screenshots attached below.

1. Go to `app.pr1526.preview.bike4mind.com` (or `app.staging.bike4mind.com` once merged) and start a new chat.
2. Attach a CSV with 50+ rows and ask: `What does this file contain?`
   Expected: the reply does not open with a denial ("I cannot access/open the attached file"). It answers from the file's content.
3. Create a CSV with a small number of real rows (e.g. 20) but name it something like `report-50000.csv` - a number that does not match the row count - and pad it large enough to trigger truncation on attach.
4. Attach it and ask: `How many rows are in this file, and what is the last row?`
   Expected: the reply does not state 50000 (or any number from the filename) as the row count, and does not fabricate a final row matching it.
5. LLM replies are not fully deterministic - repeat steps 2 and 4 two or three times if a reply looks borderline.

**What NOT to test:** the ReAct/agent-executor attachment path (`agentExecutor.firstIterationQuery.ts`'s preamble, the Optimizer surface's `retrieve_knowledge_content` tool) already has its own, differently-worded mitigation for a similar denial symptom. This PR does not touch that path - it is a structurally separate code path from chat completion's message-assembly pipeline that this PR changes.

## Additional Information

A similar denial-of-access symptom is already mitigated on the ReAct-agent path via a different mechanism (a tool that lets the agent read the file itself, rather than a prompt notice). This PR does not touch that path; it is a structurally separate pipeline from the chat-completion assembly this PR changes.

## Developer Notes (Optional)

The delivered-content notice is applied inside `assemble()`, the single point both of `buildAndSortMessages`' return paths route through after the token-budget squeeze - a reusable pattern for any future per-message assurance that must never survive being dropped or replaced upstream.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

