### PR TITLE
fix(secops): make unreachable gitleaks rules detect again

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -57,13 +57,18 @@ regexes = [
 [[rules]]
 id = "bike4mind-mongodb-uri"
 description = "MongoDB Connection String"
-regex = "mongodb(\\+srv)?://[^\\s'\"]*"
+# The group is non-capturing and there is no entropy floor on purpose. gitleaks
+# applies an entropy floor to capture group 1, not to the whole match, whatever
+# secretGroup says - with `(\+srv)` captured and `entropy = 3.0` this rule scored
+# the literal "+srv" and therefore never reported anything.
+regex = "mongodb(?:\\+srv)?://[^\\s'\"]*"
 tags = ["mongodb", "connection-string"]
-secretGroup = 0
-entropy = 3.0
 
 [rules.allowlist]
 regexes = [
+  # Scheme prefix with no host or credentials: startsWith() guards and prose that
+  # names the scheme. The optional trailing dot is a sentence terminator in prose.
+  "^mongodb(\\+srv)?://\\.?$",
   "mongodb(\\+srv)?://localhost",
   "mongodb(\\+srv)?://127\\.0\\.0\\.1",
   "mongodb(\\+srv)?://mongo(:[0-9]+)?/",
@@ -95,9 +100,10 @@ entropy = 3.0
 [[rules]]
 id = "bike4mind-stripe-keys"
 description = "Stripe API Key"
-regex = "(sk|pk|whsec)_(test|live)_[0-9a-zA-Z]{24,}"
+# Groups stay non-capturing so the entropy floor scores the key, not the "sk"/
+# "test" alternation - see the note on bike4mind-mongodb-uri above.
+regex = "(?:sk|pk|whsec)_(?:test|live)_[0-9a-zA-Z]{24,}"
 tags = ["stripe", "payment"]
-secretGroup = 0
 entropy = 3.0
 
 [[rules]]

--- a/scripts/gitleaks-config-selftest.sh
+++ b/scripts/gitleaks-config-selftest.sh
@@ -46,11 +46,16 @@ FAILED=0
 # not from the domain rules in .gitleaks.toml, so it can only match when
 # `[extend] useDefault = true` is in effect. Generated, never hardcoded. Do not
 # substitute AWS's canonical documentation key - this repo allowlists it by design.
-CANARY_SUFFIX=$(LC_ALL=C tr -dc 'A-Z0-9' < /dev/urandom | head -c 16)
+#
+# The suffix charset is base32, not A-Z0-9: gitleaks 8.28 narrowed the builtin rule
+# to [A-Z2-7]{16} (real AWS key ids are base32), so a suffix containing 0/1/8/9 goes
+# undetected there and this assertion reports a config outage that is not happening.
+# Base32 matches the wider 8.24.3 charset too, so one canary covers both versions.
+CANARY_SUFFIX=$(LC_ALL=C tr -dc 'A-Z2-7' < /dev/urandom | head -c 16)
 printf "const canary = 'AKIA%s';\n" "$CANARY_SUFFIX" > "$TEMP_DIR/canary.ts"
 
 if "$GITLEAKS_PATH" detect --no-git --redact --no-banner \
-    --config "$CONFIG" -s "$TEMP_DIR" >/dev/null 2>&1; then
+    --config "$CONFIG" -s "$TEMP_DIR/canary.ts" >/dev/null 2>&1; then
   echo "FAIL: builtin rules are not active - a planted AWS-key shape was not detected."
   echo "      Check that .gitleaks.toml still contains [extend] useDefault = true."
   FAILED=1
@@ -100,6 +105,68 @@ if [ -f "$REPO_ROOT/$PROBE" ]; then
     FAILED=1
   fi
 fi
+
+# --- Assertion 4: every domain rule is reachable ------------------------------
+# Assertions 1-3 all pass while a domain rule matches nothing, which is how two of
+# them stayed dead: gitleaks applies an `entropy` floor to capture group 1 rather
+# than to the group named by `secretGroup`, so a rule whose regex captured a short
+# literal (`(\+srv)`, `(sk|pk|whsec)`) scored that literal and never reported. The
+# stripe one was invisible from the outside because the builtin stripe-access-token
+# rule caught the same shape.
+#
+# So each rule is checked by rule id in the JSON report, not by exit status - an
+# overlapping builtin must not be able to stand in for a dead domain rule.
+rand_str() {
+  LC_ALL=C tr -dc "$1" < /dev/urandom | head -c "$2"
+}
+
+assert_rule_reachable() {
+  rule_id=$1
+  canary=$2
+  canary_file="$TEMP_DIR/domain-$rule_id.ts"
+  report_file="$TEMP_DIR/domain-$rule_id.json"
+  printf '%s\n' "$canary" > "$canary_file"
+  "$GITLEAKS_PATH" detect --no-git --redact --no-banner --config "$CONFIG" \
+    -s "$canary_file" --report-format json --report-path "$report_file" \
+    >/dev/null 2>&1 || true
+  if [ -f "$report_file" ] && grep -q "\"RuleID\": *\"$rule_id\"" "$report_file"; then
+    echo "ok: $rule_id matched a generated canary"
+  else
+    echo "FAIL: $rule_id matched nothing - the rule is unreachable and scans nothing."
+    echo "      Most likely its regex has a capture group that an entropy floor is"
+    echo "      being applied to. Make the group non-capturing, or point the floor at"
+    echo "      the credential. Verify with: gitleaks detect --no-git -s <canary>."
+    FAILED=1
+  fi
+}
+
+# Three of the canaries below would be findings in this very file if written out
+# whole, because the shape that makes them match is a literal rather than generated:
+# the mongodb rule needs only a bare scheme, and the JWT/session rules need only
+# `<KEY>=` followed by any run of non-space. Splitting the shape across a variable
+# keeps this script clean under its own config. The other rules need a long
+# high-entropy run that `$(rand_str ...)` does not supply, so they are safe inline.
+MONGO_SCHEME="mongodb+srv"
+JWT_KEY="JWT_SECRET"
+SESSION_KEY="SESSION_SECRET"
+
+assert_rule_reachable bike4mind-mongodb-uri \
+  "const uri = '$MONGO_SCHEME://svc_$(rand_str 'a-z0-9' 8):$(rand_str 'A-Za-z0-9' 24)@cluster0.$(rand_str 'a-z0-9' 5).mongodb.net/app';"
+# The JWT/session rules require [_.] or start-of-text before the key name, and
+# gitleaks compiles rule regexes without the multiline flag, so `^` only ever
+# matches the start of the file - the prefix here is what makes the canary match.
+assert_rule_reachable bike4mind-jwt-secret \
+  "B4M_$JWT_KEY=$(rand_str 'A-Za-z0-9' 40)"
+assert_rule_reachable bike4mind-session-secret \
+  "B4M_$SESSION_KEY=$(rand_str 'A-Za-z0-9' 40)"
+assert_rule_reachable bike4mind-stripe-keys \
+  "const key = 'sk_live_$(rand_str 'A-Za-z0-9' 32)';"
+assert_rule_reachable bike4mind-anthropic-key \
+  "const key = 'sk-ant-$(rand_str 'A-Za-z0-9' 48)';"
+assert_rule_reachable bike4mind-gemini-key \
+  "const key = 'AIza$(rand_str 'A-Za-z0-9' 35)';"
+assert_rule_reachable bike4mind-slack-webhook \
+  "const hook = 'https://hooks.slack.com/services/T$(rand_str 'A-Za-z0-9' 9)/B$(rand_str 'A-Za-z0-9' 9)/$(rand_str 'A-Za-z0-9' 24)';"
 
 if [ "$FAILED" -ne 0 ]; then
   echo ""


### PR DESCRIPTION
# Pull Request

## Description

Two custom rules in `.gitleaks.toml` never matched anything: `bike4mind-mongodb-uri` and `bike4mind-stripe-keys`.

Root cause is an `entropy` floor combined with `secretGroup = 0` on a regex that contains a capture group. Gitleaks applies the entropy check to capture group 1, which for these two rules is a short literal alternation (`(\+srv)` and `(sk|pk|whsec)`) that can never clear an entropy floor of 3.0. The other custom rules survive only because their regexes have no capture groups at all.

The mongodb rule was a real detection gap: an Atlas SRV connection string with inline credentials was caught by neither the custom rule nor any builtin, while a connection-string env var is a live config value in this repo. The stripe rule was masked by the builtin `stripe-access-token` once `[extend] useDefault = true` was restored.

Verified empirically on a runtime-generated, live-shaped SRV canary with builtins off: the old rule reports 0 findings, the new rule reports 1.

## Changes

- **Rule definitions.** Both regexes now use non-capturing groups. `bike4mind-mongodb-uri` drops `entropy`/`secretGroup` entirely (the scheme + host + credential shape is specific enough on its own); `bike4mind-stripe-keys` keeps `entropy = 3.0`, which now scores the key body rather than the prefix alternation.
- **Triage of the revived findings.** Reviving the mongodb rule surfaced 10 whole-repo findings (6 in `apps/client/server/security/tier1SecretValidators.ts`, 3 in `scripts/migrate-sre-v2.mjs`, 1 in `apps/client/pages/api/admin/system-secrets/tier1-status.ts`). All 10 are documentation/validation literals, not credentials. They are covered by two rule-level allowlist regexes: a new bare-scheme-with-no-host pattern (covering `startsWith()` guards and prose), and the pre-existing ellipsis pattern (covering the usage examples). Kept deliberately rule-level rather than a global `paths` entry, so those files stay in scope for every other rule.
- **Self-test.** `scripts/gitleaks-config-selftest.sh` gains assertion 4: each of the 7 domain rules must match a runtime-generated canary, checked **by rule id in the JSON report**, so an overlapping builtin cannot mask a dead domain rule again. Assertion 1 also fixed: the AWS canary suffix charset is now base32 (`A-Z2-7`) because gitleaks 8.28+ narrowed the builtin to `[A-Z2-7]{16}`, and it now scans the canary file rather than the whole temp dir.

No credential-shaped literals are committed; every canary is generated at runtime.

### Self-referential-canary gotcha

Reviving the mongodb rule made the self-test script itself a finding: a canary template whose *shape* is a literal matches even when the credential body is `$(rand_str ...)`. Three canaries now split that shape across a variable (`MONGO_SCHEME`, `JWT_KEY`, `SESSION_KEY`). The stripe/anthropic/gemini/slack canaries need a long high-entropy run that `rand_str` does not supply, so they are safe inline. Worth knowing before editing this script: writing the bare scheme followed by a scheme separator anywhere in the repo will now trip the rule.

## Guide for Testers

Backend/tooling only. No UI surface, no runtime code path.

1. Check out this branch.
2. Run `sh scripts/gitleaks-config-selftest.sh`. Expected: all 10 assertions pass, exit code 0.
3. Run `gitleaks detect --no-git --config .gitleaks.toml`. Expected: "no leaks found".
4. Run `gitleaks detect --config .gitleaks.toml` (full git history). Expected: "no leaks found".
5. Repeat steps 2-4 with gitleaks `8.24.3` (the version CI pins) as well as a current release. Expected: identical results on both.

### What NOT to test

Nothing in the app changed. No client, API, or database behavior is touched; only `.gitleaks.toml` and one shell script.

## Additional Information

Verified locally against both gitleaks versions in play: `8.24.3` (pinned by `secrets-scan.yml` and `gitleaks-config-guard.yml`) and `8.30.1` (current brew). Self-test passes on both; whole-repo and full-history scans report no leaks on both. `sh -n` parses clean (the script is POSIX `#!/bin/sh`), and the changes are ASCII-only.

`turbo:typecheck` / `turbo:test` / `lint:check` were not run: the diff touches only a TOML config and a shell script, with no TypeScript or JavaScript involved, and CI does not lint shell.

## Security Testing

Not applicable in the staging/preview sense: this changes a scanning config and its self-test, not a deployed surface, so there is nothing to reproduce against a running environment. The equivalent before/after evidence is the isolated-rule scan described above (0 findings on the old rule, 1 on the new, against the same generated canary).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
