### PR TITLE
fix(api): stringify org id in public chat request boundary

### DIFF
--- a/apps/client/pages/api/__tests__/chat.integration.test.ts
+++ b/apps/client/pages/api/__tests__/chat.integration.test.ts
@@ -160,6 +160,7 @@ vi.mock('@server/auth/auth', async orig => {
 
 import handler from '../chat';
 import { ApiKeyScope } from '@bike4mind/common';
+import { Types } from 'mongoose';
 
 const VALID_KEY = 'sk-test-valid-key';
 
@@ -407,6 +408,61 @@ describe('POST /api/chat (integration — scope enforcement via real middleware 
       await handler(req, res);
       expect(res._getStatusCode()).toBe(200);
       expect((mockInvoke.mock.calls[0][0] as { body: { historyCount?: number } }).body.historyCount).toBe(10);
+    });
+  });
+
+  // req.user.organizationId arrives as a Mongo ObjectId (or, after a .populate(),
+  // a full Organization doc). It flows into the internal request at both top-level
+  // `organizationId` and `promptMeta.session.organizationId`, where a downstream
+  // schema parses it as z.string(). Un-normalized, an org-associated caller 422s
+  // ("expected string, received ObjectId"). The handler must coerce to a hex string
+  // at the boundary. The invoke stub here can't reproduce the downstream 422, so we
+  // assert the shape it receives instead - that IS the fix.
+  describe('organizationId boundary normalization', () => {
+    const invokedBody = () =>
+      mockInvoke.mock.calls[0][0] as {
+        body: { organizationId?: unknown; promptMeta?: { session?: { organizationId?: unknown } } };
+      };
+
+    it('coerces an ObjectId organizationId to a hex string on both surfaces (no 422)', async () => {
+      const orgId = new Types.ObjectId();
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      mockFindById.mockReturnValue(
+        Promise.resolve({ id: 'user-1', _id: 'user-1', isBanned: false, disputePending: false, organizationId: orgId })
+      );
+      const { req, res } = fire();
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      const { body } = invokedBody();
+      expect(body.organizationId).toBe(orgId.toHexString());
+      expect(body.promptMeta?.session?.organizationId).toBe(orgId.toHexString());
+    });
+
+    it('flattens a populated Organization document to its _id hex string, never "[object Object]"', async () => {
+      const orgId = new Types.ObjectId();
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      mockFindById.mockReturnValue(
+        Promise.resolve({
+          id: 'user-1',
+          _id: 'user-1',
+          isBanned: false,
+          disputePending: false,
+          organizationId: { _id: orgId, name: 'Acme' },
+        })
+      );
+      const { req, res } = fire();
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(invokedBody().body.organizationId).toBe(orgId.toHexString());
+    });
+
+    it('leaves organizationId absent for a personal (org-less) caller', async () => {
+      validateWithScopes([ApiKeyScope.AI_CHAT]);
+      // beforeEach already returns a user with organizationId: undefined.
+      const { req, res } = fire();
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(invokedBody().body.organizationId).toBeUndefined();
     });
   });
 

--- a/apps/client/pages/api/chat.ts
+++ b/apps/client/pages/api/chat.ts
@@ -1,5 +1,12 @@
 import { ChatCompletionFeature, ChatCompletionInvoke, ChatCompletionProcess, featureNames } from '@bike4mind/services';
-import { BadRequestError, getSettingsMap, getSettingsValue, NotFoundError, SQSService } from '@bike4mind/utils';
+import {
+  BadRequestError,
+  getSettingsMap,
+  getSettingsValue,
+  normalizeId,
+  NotFoundError,
+  SQSService,
+} from '@bike4mind/utils';
 import { PipelineTimer } from '@bike4mind/llm-adapters';
 import { rateLimit } from '@server/middlewares/rateLimit';
 import { resolveUserRateLimitPerMin } from '@server/utils/userRateTier';
@@ -69,11 +76,13 @@ const handler = route.post(async (req, res) => {
   // Pre-compute tool recommendations once (used by both transform and response metadata)
   const recommendations = simplifiedRequest.toolMode === 'smart' ? recommendTools(simplifiedRequest.message) : [];
 
-  // Transform to internal format, including user's organization for team-wide system prompts
+  // Transform to internal format, including user's organization for team-wide system prompts.
+  // req.user.organizationId arrives as a Mongo ObjectId (or a populated Organization doc); a
+  // downstream schema parses it as z.string(), so normalize to a hex string at the boundary.
   const internalRequest = transformToInternalFormat(
     { ...simplifiedRequest, model, sessionId },
     req.user.id,
-    req.user.organizationId ?? undefined,
+    normalizeId(req.user.organizationId),
     recommendations
   );
 


### PR DESCRIPTION
## Description

The public `POST /api/chat` endpoint (the api-key-callable contract path) returned **422** for any authenticated caller whose account has an `organizationId`. Personal (org-less) callers were unaffected.

```
422 UnprocessableEntityError
Validation error: Invalid input: expected string, received ObjectId at "organizationId"
```

`req.user.organizationId` arrives as a Mongo `ObjectId` (or, after an upstream `.populate`, a populated `Organization` document). It flows into the internal chat request at both top-level `organizationId` and `promptMeta.session.organizationId`, where a downstream schema parses it as `z.string()` - so org-associated callers failed validation.

The app UI is not affected: it uses the internal `POST /api/sessions/{id}/chat` path, which skips this contract transform.

## Changes

- `apps/client/pages/api/chat.ts`: normalize `req.user.organizationId` to a hex string at the `transformToInternalFormat` boundary using `normalizeId` (from `@bike4mind/utils`) instead of the ObjectId-passthrough `?? undefined`.
  - Chose `normalizeId` over a plain `.toString()` because it is the established helper for this and additionally flattens a populated `Organization` document to its `_id` hex - `.toString()` on a populated doc yields `"[object Object]"`. It also returns `undefined` for absent ids, so personal callers keep the org field absent.
- `apps/client/pages/api/__tests__/chat.integration.test.ts`: added an `organizationId boundary normalization` block (3 cases) asserting the shape handed to `ChatCompletionInvoke`:
  - ObjectId caller -> string on both `organizationId` and `promptMeta.session.organizationId`.
  - populated-doc caller -> `_id` hex (never `[object Object]`).
  - personal caller -> org id absent.

## Guide for Testers

This is a backend request-boundary fix; verify via the public API, not the UI.

1. Obtain an API key for an account that **has an `organizationId`**.
2. Call the public endpoint:
   ```bash
   curl -sS -X POST https://app.staging.bike4mind.com/api/chat \
     -H "Authorization: Bearer <API_KEY>" \
     -H "Content-Type: application/json" \
     -d '{"message":"Hello, how are you?"}'
   ```
   - Expected (with fix): a normal chat response, **no 422**.
   - Before the fix: `422 UnprocessableEntityError - ... expected string, received ObjectId at "organizationId"`.
3. Repeat with an API key for a **personal (org-less)** account.
   - Expected: unchanged behavior, a normal chat response.

### Regression Checks

- App chat in the browser (a session created, message sent, streamed response) still works - it uses `POST /api/sessions/{id}/chat`, which does not go through this transform, so behavior must be identical.

### What NOT to test

- No UI, styling, or client-routing changes here. The only runtime change is one call-site argument on the public `/api/chat` handler.

## Additional Information

Unit + integration coverage runs the transform boundary directly. The invoke path is stubbed in the integration test, so the assertion is on the exact request shape passed to `ChatCompletionInvoke` - the boundary this fix corrects.

Closes #1531
