### PR TITLE
fix(client): stop seeding model popularity and speed from stale display names

### DIFF
--- a/apps/client/app/utils/__tests__/aiSettingsUtils.test.ts
+++ b/apps/client/app/utils/__tests__/aiSettingsUtils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { computeDefaultMaxTokens, refitMaxTokensForModel } from '../aiSettingsUtils';
+import {
+  computeDefaultMaxTokens,
+  getModelSpeedFromStats,
+  getTopUsedModelsFromStats,
+  refitMaxTokensForModel,
+} from '../aiSettingsUtils';
 
 describe('computeDefaultMaxTokens', () => {
   it('falls back to the catalog max_tokens when contextWindow is missing/0', () => {
@@ -90,5 +95,32 @@ describe('refitMaxTokensForModel', () => {
     it('still lowers a value the model cannot accept', () => {
       expect(refitMaxTokensForModel(128000, small, { allowRaise: false })).toBe(16384);
     });
+  });
+});
+
+describe('getTopUsedModelsFromStats', () => {
+  it('returns nothing when there are no stats', () => {
+    expect(getTopUsedModelsFromStats({})).toEqual([]);
+    expect(getTopUsedModelsFromStats(undefined as unknown as Record<string, number>)).toEqual([]);
+  });
+
+  it('returns the ids the stats payload is keyed by, most used first', () => {
+    const popularity = { 'gpt-5': 4, 'claude-opus-4-5': 9, 'gemini-3-pro': 7 };
+    expect(getTopUsedModelsFromStats(popularity, 2)).toEqual(['claude-opus-4-5', 'gemini-3-pro']);
+  });
+});
+
+describe('getModelSpeedFromStats', () => {
+  it('returns null when there are no stats, or none for this model', () => {
+    expect(getModelSpeedFromStats('gpt-5', {})).toBeNull();
+    expect(getModelSpeedFromStats('gpt-5', undefined as unknown as Record<string, number>)).toBeNull();
+    expect(getModelSpeedFromStats('gpt-5', { 'claude-opus-4-5': 1000 })).toBeNull();
+  });
+
+  it('buckets the model average against the tooltip thresholds', () => {
+    expect(getModelSpeedFromStats('m', { m: 6999 })).toBe('fast');
+    expect(getModelSpeedFromStats('m', { m: 7000 })).toBe('medium');
+    expect(getModelSpeedFromStats('m', { m: 14999 })).toBe('medium');
+    expect(getModelSpeedFromStats('m', { m: 15000 })).toBe('slow');
   });
 });

--- a/apps/client/app/utils/aiSettingsUtils.ts
+++ b/apps/client/app/utils/aiSettingsUtils.ts
@@ -1,40 +1,6 @@
 import { FIXED_TEMPERATURE_MODELS, ModelInfo } from '@bike4mind/common';
 import dayjs from 'dayjs';
 
-interface ModelMetric {
-  id: string;
-  timestamp: string;
-  model: {
-    name: string;
-    type?: string;
-    backend?: string;
-    parameters?: {
-      temperature?: number;
-      topP?: number;
-      maxTokens?: number;
-    };
-  };
-  tokenUsage: {
-    inputTokens?: number;
-    outputTokens?: number;
-    totalTokens?: number;
-    estimatedCost?: number;
-    creditsUsed?: number;
-  };
-  performance: {
-    totalResponseTime?: number;
-    contextRetrievalTime?: number;
-    modelInferenceTime?: number;
-    clientFirstTokenTime?: number;
-  };
-  session: {
-    userId?: string;
-    organizationId?: string;
-    projectId?: string;
-  };
-  status: string;
-}
-
 export const isOpenAIModel = (modelName: string): boolean => {
   const lowerName = modelName.toLowerCase();
   return ['gpt', 'o1', 'o3', 'o4'].some(pattern => lowerName.includes(pattern));
@@ -159,94 +125,24 @@ export const getChipStyles = (variant: ChipVariant, isMaximum: boolean, mode: st
   return { ...baseStyles, ...variantStyles[variant] };
 };
 
-// Model metrics analysis functions (dynamic data with static fallback)
-export const getTopUsedModels = (metrics: ModelMetric[], count: number = 3): string[] => {
-  if (!metrics || metrics.length === 0) {
-    // Fallback to static data when no metrics available
-    return ['GPT-4', 'Claude 3.5 Sonnet', 'GPT-4 Turbo'];
-  }
-
-  // Modelname in metrics is modelid
-  const modelUsage = metrics.reduce(
-    (acc, metric) => {
-      const modelName = metric.model?.name || 'Unknown';
-      acc[modelName] = (acc[modelName] || 0) + 1;
-      return acc;
-    },
-    {} as Record<string, number>
-  );
-
-  return Object.entries(modelUsage)
-    .sort(([, a], [, b]) => (b as number) - (a as number))
-    .slice(0, count)
-    .map(([modelName]) => modelName);
-};
-
-export const getModelSpeed = (modelId: string, metrics: ModelMetric[]): 'fast' | 'medium' | 'slow' | null => {
-  if (!metrics || metrics.length === 0) {
-    // Fallback to static data when no metrics available
-    const staticModelSpeeds: Record<string, 'fast' | 'medium' | 'slow'> = {
-      'GPT-4': 'medium',
-      'Claude 3.5 Sonnet': 'fast',
-      'GPT-4 Turbo': 'fast',
-      'GPT-3.5 Turbo': 'fast',
-      'Claude 3 Haiku': 'fast',
-      'Claude 3 Opus': 'slow',
-      'Gemini Pro': 'medium',
-      'Llama 3': 'medium',
-    };
-    return staticModelSpeeds[modelId] || null;
-  }
-
-  // Modelname in metrics is modelid
-  const modelMetrics = metrics.filter(m => {
-    return m.model?.name === modelId;
-  });
-
-  if (modelMetrics.length === 0) return null;
-
-  const avgResponseTime =
-    modelMetrics.reduce((sum, metric) => {
-      return sum + (metric.performance?.totalResponseTime || 0);
-    }, 0) / modelMetrics.length;
-
-  // Thresholds in milliseconds - adjusted based on tooltip values
-  if (avgResponseTime < 7000) return 'fast'; // < 7s
-  if (avgResponseTime < 15000) return 'medium'; // 7-15s
-  return 'slow'; // > 15s
-};
-
-// Stats-based helpers (used by non-admin components with pre-aggregated data from /api/models/stats)
+// Stats-based helpers (used by non-admin components with pre-aggregated data from /api/models/stats).
+// Keyed by model id like the stats payload and the callers' comparisons - never by display name.
+// Empty stats yield an empty result, not a seed: popularity and speed are claims about observed
+// usage, and a hardcoded seed would go stale silently while still looking authoritative.
 export const getTopUsedModelsFromStats = (popularity: Record<string, number>, count: number = 3): string[] => {
-  if (!popularity || Object.keys(popularity).length === 0) {
-    return ['GPT-4', 'Claude 3.5 Sonnet', 'GPT-4 Turbo'];
-  }
+  if (!popularity) return [];
 
   return Object.entries(popularity)
     .sort(([, a], [, b]) => b - a)
     .slice(0, count)
-    .map(([modelName]) => modelName);
+    .map(([modelId]) => modelId);
 };
 
 export const getModelSpeedFromStats = (
   modelId: string,
   avgResponseTime: Record<string, number>
 ): 'fast' | 'medium' | 'slow' | null => {
-  if (!avgResponseTime || Object.keys(avgResponseTime).length === 0) {
-    const staticModelSpeeds: Record<string, 'fast' | 'medium' | 'slow'> = {
-      'GPT-4': 'medium',
-      'Claude 3.5 Sonnet': 'fast',
-      'GPT-4 Turbo': 'fast',
-      'GPT-3.5 Turbo': 'fast',
-      'Claude 3 Haiku': 'fast',
-      'Claude 3 Opus': 'slow',
-      'Gemini Pro': 'medium',
-      'Llama 3': 'medium',
-    };
-    return staticModelSpeeds[modelId] || null;
-  }
-
-  const avg = avgResponseTime[modelId];
+  const avg = avgResponseTime?.[modelId];
   if (avg == null) return null;
 
   if (avg < 7000) return 'fast';


### PR DESCRIPTION
## Description

Closes #1304.

`getTopUsedModelsFromStats` and `getModelSpeedFromStats` in `apps/client/app/utils/aiSettingsUtils.ts` both fell back to hardcoded 2024-era **display names** (`'GPT-4'`, `'Claude 3.5 Sonnet'`, `'GPT-4 Turbo'`, and a `staticModelSpeeds` map keyed the same way) when no usage stats were available. Every caller looks these up by model **id**, and no id in `modelCatalog.ts` equals any of those strings, so the fallbacks never matched anything: the popularity pill in the details dialog was silently always off, and the speed chip was always absent.

The failure mode is invisible - the fallback returns plausible-looking data, so the feature appears to have a sensible empty state instead of none. The tempting alternative fix (compare against `name` instead of id) would be worse: it would make the pill fire on a hardcoded list of several-generations-stale models.

This is the same id-versus-name confusion that was removed from the model card in #1271; it survived in the details dialog and was deliberately left out of that PR to keep it scoped to the picker surface.

## Changes

- `getTopUsedModelsFromStats`: dropped the empty-stats fallback, now returns `[]`. Renamed the destructured key `modelName` -> `modelId` so the id contract reads correctly.
- `getModelSpeedFromStats`: dropped the `staticModelSpeeds` map; the empty-stats branch collapses into the existing per-model lookup (`avgResponseTime?.[modelId]`, else `null`).
- Removed `getTopUsedModels`, `getModelSpeed`, and the local `ModelMetric` interface - zero callers anywhere in the repo (the admin Model Metrics tab has its own `components/admin/ModelMetrics/types.ts`), and they carried the same display-name maps, so leaving them would preserve the exact trap. This goes slightly beyond the issue's literal ask; that hunk can be dropped without touching the fix.
- Added tests in `apps/client/app/utils/__tests__/aiSettingsUtils.test.ts` covering empty/absent stats for both helpers, id-keyed ordering, and the 7s/15s speed thresholds.

No caller changes needed - all three call sites already handle the empty result: `AdvancedAIModal.tsx` (`.includes` -> false), `ModelSelection.tsx`, and `ImageGenerationModelSelectionModal.tsx` each guard the speed chip on `modelSpeed &&`.

## Guide for Testers

Behavior only changes on the empty-stats path, where the affected UI elements were already never rendering. There is no user-visible difference to verify manually.

Regression checks:

1. Go to `app.staging.bike4mind.com` and open the model picker (chat composer -> model selector).
2. Confirm the list renders and models are selectable, with no console errors.
3. Open a model's details dialog (Advanced AI settings -> a model's info/details).
4. Confirm the dialog renders. If the account has real usage stats, the "popular" pill and speed chip behave as before (driven by actual `modelUsageStats`). With no usage stats, neither should appear - same as today.

What NOT to test: nothing backend or infra changed; no API, schema, or deploy surface is touched.

## Additional Information

Verification run locally:

- `apps/client` vitest on `aiSettingsUtils.test.ts` plus the affected component tests: 32 passed.
- `pnpm turbo:typecheck`: 40/40 pass.
- `pnpm lint:check`: clean.
- The full `pnpm -r test` suite was not run locally; CI covers it.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
