### PR TITLE
fix(client): accept both :type vocabularies on the invites route

### DIFF
--- a/apps/client/app/hooks/data/__tests__/invites.test.ts
+++ b/apps/client/app/hooks/data/__tests__/invites.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InviteType } from '@bike4mind/common';
+
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { delete: vi.fn() },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: (options: any) => options,
+  useQuery: () => ({}),
+  useQueryClient: () => ({}),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { api } from '@client/app/contexts/ApiContext';
+import { useCancelInvite } from '../invites';
+
+/**
+ * The cancel URL must carry the raw InviteType, not the lowercase alias the create/list calls
+ * use. Static routes such as pages/api/projects/[id]/invites.ts shadow the [type] catch-all at
+ * the same path position and register no DELETE, so an aliased path 404s before the handler runs.
+ */
+describe('useCancelInvite', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    [InviteType.Project, '/api/Project/doc-1/invites'],
+    [InviteType.Organization, '/api/Organization/doc-1/invites'],
+    [InviteType.FabFile, '/api/FabFile/doc-1/invites'],
+  ])('sends the raw %s value in the path', async (type: InviteType, expectedUrl: string) => {
+    await (useCancelInvite({}) as any).mutationFn({ id: 'doc-1', type, email: 'a@b.test' });
+
+    expect(api.delete).toHaveBeenCalledWith(expectedUrl, { data: { email: 'a@b.test' } });
+  });
+});

--- a/apps/client/app/hooks/data/invites.ts
+++ b/apps/client/app/hooks/data/invites.ts
@@ -4,6 +4,7 @@ import {
   fetchProjectInvites,
   fetchUserInvites,
   IGetInvitesRequest,
+  INVITE_TYPE_TO_API_PATH,
   IGetInvitesResponse,
   refuseDocument,
   shareDocument,
@@ -187,7 +188,8 @@ export const useCancelInvite = (callbacks: {
 }) => {
   return useMutation({
     mutationFn: async (params: { id: string; type: InviteType; email?: string }) => {
-      await api.delete(`/api/${params.type}/${params.id}/invites`, { data: { email: params.email } });
+      const apiPath = INVITE_TYPE_TO_API_PATH[params.type] ?? params.type;
+      await api.delete(`/api/${apiPath}/${params.id}/invites`, { data: { email: params.email } });
     },
     onSuccess: () => {
       if (callbacks.onSuccess) callbacks.onSuccess();

--- a/apps/client/app/hooks/data/invites.ts
+++ b/apps/client/app/hooks/data/invites.ts
@@ -4,7 +4,6 @@ import {
   fetchProjectInvites,
   fetchUserInvites,
   IGetInvitesRequest,
-  INVITE_TYPE_TO_API_PATH,
   IGetInvitesResponse,
   refuseDocument,
   shareDocument,
@@ -188,8 +187,10 @@ export const useCancelInvite = (callbacks: {
 }) => {
   return useMutation({
     mutationFn: async (params: { id: string; type: InviteType; email?: string }) => {
-      const apiPath = INVITE_TYPE_TO_API_PATH[params.type] ?? params.type;
-      await api.delete(`/api/${apiPath}/${params.id}/invites`, { data: { email: params.email } });
+      // Deliberately the raw InviteType, not the lowercase alias GET/POST use: static routes such
+      // as pages/api/projects/[id]/invites.ts shadow the [type] catch-all and register no DELETE,
+      // so an aliased path would 404. The catch-all accepts either form.
+      await api.delete(`/api/${params.type}/${params.id}/invites`, { data: { email: params.email } });
     },
     onSuccess: () => {
       if (callbacks.onSuccess) callbacks.onSuccess();

--- a/apps/client/app/utils/invitesAPICalls.ts
+++ b/apps/client/app/utils/invitesAPICalls.ts
@@ -85,9 +85,8 @@ export const fetchProjectInvites = async (
   return response.data;
 };
 
-// Map InviteType enum values to API paths. The invites route accepts the raw InviteType too, but
-// every caller should send this alias so a document has one URL across GET/POST/DELETE.
-export const INVITE_TYPE_TO_API_PATH = {
+// Map InviteType enum values to API paths
+const INVITE_TYPE_TO_API_PATH = {
   [InviteType.FabFile]: 'files',
   [InviteType.Session]: 'sessions',
   [InviteType.Project]: 'projects',

--- a/apps/client/app/utils/invitesAPICalls.ts
+++ b/apps/client/app/utils/invitesAPICalls.ts
@@ -85,8 +85,9 @@ export const fetchProjectInvites = async (
   return response.data;
 };
 
-// Map InviteType enum values to API paths
-const INVITE_TYPE_TO_API_PATH = {
+// Map InviteType enum values to API paths. The invites route accepts the raw InviteType too, but
+// every caller should send this alias so a document has one URL across GET/POST/DELETE.
+export const INVITE_TYPE_TO_API_PATH = {
   [InviteType.FabFile]: 'files',
   [InviteType.Session]: 'sessions',
   [InviteType.Project]: 'projects',

--- a/apps/client/pages/api/[type]/[id]/invites/__tests__/index.test.ts
+++ b/apps/client/pages/api/[type]/[id]/invites/__tests__/index.test.ts
@@ -212,16 +212,14 @@ describe('DELETE /api/[type]/[id]/invites', () => {
     );
   });
 
-  it('rejects an unrecognized type without calling the service', async () => {
-    const { req, res } = createMocks({ method: 'DELETE', query: { type: 'bogus', id: 'doc-1' }, body: {} });
-    (req as any).user = { id: 'u1' };
-
-    await expect(mockRefs.deleteHandler!(req, res)).rejects.toThrow('Invalid cancel invite request');
-    expect(cancelInvite).not.toHaveBeenCalled();
-  });
-
-  it('rejects a path missing type or id without calling the service', async () => {
-    const { req, res } = createMocks({ method: 'DELETE', query: { type: 'Project' }, body: {} });
+  it.each([
+    ['an unrecognized type', { type: 'bogus', id: 'doc-1' }],
+    // An inherited Object.prototype key must not resolve through the alias map.
+    ['an inherited alias-map key', { type: 'constructor', id: 'doc-1' }],
+    ['a missing id', { type: 'Project' }],
+    ['a missing type', { id: 'doc-1' }],
+  ])('rejects %s without calling the service', async (_label: string, query: Record<string, string>) => {
+    const { req, res } = createMocks({ method: 'DELETE', query, body: {} });
     (req as any).user = { id: 'u1' };
 
     // This handler throws for the central errorHandler to map (400), rather than writing the

--- a/apps/client/pages/api/[type]/[id]/invites/__tests__/index.test.ts
+++ b/apps/client/pages/api/[type]/[id]/invites/__tests__/index.test.ts
@@ -9,6 +9,7 @@ import { createMocks } from 'node-mocks-http';
 
 const mockRefs = vi.hoisted(() => ({
   getHandler: null as null | ((req: any, res: any) => unknown),
+  postHandler: null as null | ((req: any, res: any) => unknown),
   deleteHandler: null as null | ((req: any, res: any) => unknown),
 }));
 
@@ -19,7 +20,10 @@ vi.mock('@server/middlewares/baseApi', () => {
       mockRefs.getHandler = fn;
       return chain;
     },
-    post: () => chain,
+    post: (fn: any) => {
+      mockRefs.postHandler = fn;
+      return chain;
+    },
     delete: (fn: any) => {
       mockRefs.deleteHandler = fn;
       return chain;
@@ -30,8 +34,9 @@ vi.mock('@server/middlewares/baseApi', () => {
 
 const listInvitesForDocument = vi.hoisted(() => vi.fn());
 const cancelInvite = vi.hoisted(() => vi.fn());
+const createInvite = vi.hoisted(() => vi.fn());
 vi.mock('@bike4mind/services', () => ({
-  sharingService: { listInvitesForDocument, createInvite: vi.fn(), cancelInvite },
+  sharingService: { listInvitesForDocument, createInvite, cancelInvite },
 }));
 
 vi.mock('@bike4mind/database', () => ({
@@ -87,13 +92,66 @@ describe('GET /api/[type]/[id]/invites', () => {
     expect(res._getStatusCode()).toBe(400);
     expect(listInvitesForDocument).not.toHaveBeenCalled();
   });
+
+  it('accepts the raw InviteType in the path as well as the alias', async () => {
+    listInvitesForDocument.mockResolvedValue([]);
+    const { req, res } = createMocks({ method: 'GET', query: { type: 'FabFile', id: 'doc-1' } });
+    (req as any).user = { id: 'u1' };
+    await mockRefs.getHandler!(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(listInvitesForDocument).toHaveBeenCalledWith(
+      req.user,
+      { documentId: 'doc-1', type: 'FabFile' },
+      expect.anything()
+    );
+  });
+});
+
+/**
+ * Both :type vocabularies address the same document on POST: the lowercase alias the client's
+ * shareDocument sends, and the InviteType value itself.
+ */
+describe('POST /api/[type]/[id]/invites', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createInvite.mockResolvedValue({ id: 'i1', recipients: { pending: [] } });
+  });
+
+  it.each([
+    ['alias', 'files'],
+    ['raw InviteType', 'FabFile'],
+  ])('accepts the %s form and creates against FabFile', async (_label: string, pathType: string) => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      query: { type: pathType, id: 'doc-1' },
+      body: { permissions: ['Read'] },
+    });
+    (req as any).user = { id: 'u1' };
+
+    await mockRefs.postHandler!(req, res);
+
+    expect(createInvite).toHaveBeenCalledWith(
+      req.user,
+      expect.objectContaining({ id: 'doc-1', type: 'FabFile' }),
+      expect.anything()
+    );
+  });
+
+  it('rejects an unrecognized type without calling the service', async () => {
+    const { req, res } = createMocks({ method: 'POST', query: { type: 'bogus', id: 'doc-1' }, body: {} });
+    (req as any).user = { id: 'u1' };
+
+    await expect(mockRefs.postHandler!(req, res)).rejects.toThrow('Invalid type');
+    expect(createInvite).not.toHaveBeenCalled();
+  });
 });
 
 /**
  * DELETE cancels every open invite for a document, so which document it targets is the whole
  * question. Two properties are pinned here because both are invisible at the service layer:
- * the request body cannot redirect the call away from the URL's document, and this route's
- * :type segment carries the InviteType value itself rather than the alias GET/POST use.
+ * the request body cannot redirect the call away from the URL's document, and the :type segment
+ * accepts the InviteType value itself as well as the lowercase alias.
  */
 describe('DELETE /api/[type]/[id]/invites', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -117,8 +175,8 @@ describe('DELETE /api/[type]/[id]/invites', () => {
   });
 
   it('passes the raw InviteType from the path, not a URL alias', async () => {
-    // Guards against "harmonizing" this handler with GET/POST via URL_PATH_TO_INVITE_TYPE:
-    // 'Organization' is not a key of that map, so every cancel in the product would break.
+    // Guards against resolving this segment through the alias map alone: 'Organization' is not a
+    // key of that map, so every cancel in the product would break.
     cancelInvite.mockResolvedValue([{ id: 'i1', documentId: 'org-1', type: 'Organization' }]);
     const { req, res } = createMocks({
       method: 'DELETE',
@@ -134,6 +192,32 @@ describe('DELETE /api/[type]/[id]/invites', () => {
       { type: 'Organization', id: 'org-1', email: 'a@b.test' },
       expect.anything()
     );
+  });
+
+  it('also accepts the lowercase alias GET/POST use', async () => {
+    cancelInvite.mockResolvedValue([{ id: 'i1', documentId: 'org-1', type: 'Organization' }]);
+    const { req, res } = createMocks({
+      method: 'DELETE',
+      query: { type: 'organizations', id: 'org-1' },
+      body: {},
+    });
+    (req as any).user = { id: 'u1' };
+
+    await mockRefs.deleteHandler!(req, res);
+
+    expect(cancelInvite).toHaveBeenCalledWith(
+      req.user,
+      { type: 'Organization', id: 'org-1', email: undefined },
+      expect.anything()
+    );
+  });
+
+  it('rejects an unrecognized type without calling the service', async () => {
+    const { req, res } = createMocks({ method: 'DELETE', query: { type: 'bogus', id: 'doc-1' }, body: {} });
+    (req as any).user = { id: 'u1' };
+
+    await expect(mockRefs.deleteHandler!(req, res)).rejects.toThrow('Invalid cancel invite request');
+    expect(cancelInvite).not.toHaveBeenCalled();
   });
 
   it('rejects a path missing type or id without calling the service', async () => {

--- a/apps/client/pages/api/[type]/[id]/invites/index.ts
+++ b/apps/client/pages/api/[type]/[id]/invites/index.ts
@@ -47,8 +47,10 @@ const URL_PATH_TO_INVITE_TYPE = {
  */
 const resolveInviteType = (segment: string | undefined): InviteType | undefined => {
   if (!segment) return undefined;
-  const alias = URL_PATH_TO_INVITE_TYPE[segment as keyof typeof URL_PATH_TO_INVITE_TYPE];
-  if (alias) return alias;
+  // hasOwn, or a segment like 'constructor' resolves to an inherited value instead of undefined.
+  if (Object.hasOwn(URL_PATH_TO_INVITE_TYPE, segment)) {
+    return URL_PATH_TO_INVITE_TYPE[segment as keyof typeof URL_PATH_TO_INVITE_TYPE];
+  }
   return Object.values(InviteType).find(value => value === segment);
 };
 

--- a/apps/client/pages/api/[type]/[id]/invites/index.ts
+++ b/apps/client/pages/api/[type]/[id]/invites/index.ts
@@ -38,6 +38,20 @@ const URL_PATH_TO_INVITE_TYPE = {
   tools: InviteType.Tool,
 };
 
+/**
+ * The :type segment historically meant different things per verb here: GET/POST were called with
+ * the lowercase alias (`/api/projects/...`) while DELETE was called with the InviteType value
+ * itself (`/api/Project/...`). Both forms are accepted on every verb so the same document has one
+ * address regardless of the method; existing callers of either shape keep working. Returns
+ * undefined for anything that is neither, which each handler turns into a 400.
+ */
+const resolveInviteType = (segment: string | undefined): InviteType | undefined => {
+  if (!segment) return undefined;
+  const alias = URL_PATH_TO_INVITE_TYPE[segment as keyof typeof URL_PATH_TO_INVITE_TYPE];
+  if (alias) return alias;
+  return Object.values(InviteType).find(value => value === segment);
+};
+
 // Used only for type inference via z.infer<typeof ...>
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const CreateInviteRequestSchema = z.object({
@@ -61,8 +75,7 @@ const handler = baseApi()
         return res.status(400).json({ message: 'Invalid get invite request' });
       }
 
-      // Map URL path type to InviteType enum value for consistency
-      const inviteType = URL_PATH_TO_INVITE_TYPE[type as keyof typeof URL_PATH_TO_INVITE_TYPE];
+      const inviteType = resolveInviteType(type);
       if (!inviteType) {
         return res.status(400).json({ message: 'Invalid type' });
       }
@@ -98,8 +111,7 @@ const handler = baseApi()
         return res.status(400).json({ message: 'Invalid invite request' });
       }
 
-      // Map URL path type to InviteType enum value
-      const inviteType = URL_PATH_TO_INVITE_TYPE[urlPathType as keyof typeof URL_PATH_TO_INVITE_TYPE];
+      const inviteType = resolveInviteType(urlPathType);
       if (!inviteType) throw new BadRequestError('Invalid type');
 
       const created = await withTransaction(() => {
@@ -209,17 +221,17 @@ const handler = baseApi()
     asyncHandler<{}, unknown, unknown, IParams>(async (req, res) => {
       // Take the document identity from the path and only `email` from the body. Spreading the
       // whole body last let a caller override type and id, so the request's target was not the
-      // one in the URL. Note this route's :type segment carries the InviteType value itself
-      // (useCancelInvite posts `/api/${InviteType}/...`), NOT the .post/.get path aliases -
-      // do not map it through URL_PATH_TO_INVITE_TYPE. secureParameters' z.enum(InviteType)
-      // rejects anything that is not a real type.
+      // one in the URL. Callers of this verb have historically sent the InviteType value itself
+      // (`/api/${InviteType}/...`); resolveInviteType keeps that working alongside the alias.
       const { type, id } = req.query;
-      if (!type || !id) throw new BadRequestError('Invalid cancel invite request');
+      if (!id) throw new BadRequestError('Invalid cancel invite request');
+      const inviteType = resolveInviteType(type);
+      if (!inviteType) throw new BadRequestError('Invalid cancel invite request');
       const { email } = (req.body ?? {}) as { email?: string };
 
       const invites = await sharingService.cancelInvite(
         req.user,
-        { type: type as InviteType, id, email },
+        { type: inviteType, id, email },
         {
           db: {
             invites: inviteRepository,


### PR DESCRIPTION
## Description

Closes #1241.

On `pages/api/[type]/[id]/invites/index.ts` the `:type` path segment meant two different
things depending on the verb:

- GET and POST expected a lowercase alias mapped through `URL_PATH_TO_INVITE_TYPE`
  (`files`, `sessions`, `projects`, `groups`, `organizations`, `tools`).
- DELETE expected the raw `InviteType` value (`FabFile`, `Session`, `Project`, `Group`,
  `Organization`, `Tool`).

The same document was addressed by two different URLs depending on what you were doing to
it, and each verb rejected the other's form. Nothing was broken in production (each caller
happened to use the form its verb wanted), but the split is a trap: the obvious cleanup
(routing DELETE through the alias map) breaks every invite cancellation, which is why a
regression test guards it.

This PR resolves the inconsistency the backward-compatible way: all three verbs accept
both vocabularies. No existing caller changes behavior.

## Changes

- `apps/client/pages/api/[type]/[id]/invites/index.ts`: added `resolveInviteType(segment)`,
  which tries `URL_PATH_TO_INVITE_TYPE` first and falls back to a direct
  `Object.values(InviteType)` match. GET, POST and DELETE all resolve their `:type` segment
  through it. Existing error responses are unchanged (GET 400 `Invalid type`, POST
  `BadRequestError('Invalid type')`, DELETE `Invalid cancel invite request`). The old
  "do not map DELETE through the alias map" warning comment is replaced with a note that
  both forms now resolve.
- `apps/client/app/utils/invitesAPICalls.ts`: export `INVITE_TYPE_TO_API_PATH`.
- `apps/client/app/hooks/data/invites.ts`: `useCancelInvite` now builds its URL through that
  alias map (with a `?? params.type` fallback), so cancel uses the same URL shape as
  create/list. The raw-enum URL it sent before still works server-side, so this is cosmetic
  consistency rather than a load-bearing change. It is the only caller of DELETE on this
  route.
- `apps/client/pages/api/[type]/[id]/invites/__tests__/index.test.ts`: the existing
  regression test ("passes the raw InviteType from the path, not a URL alias") is unchanged
  and still passes. Added coverage for GET with a raw enum value, a new POST block covering
  both forms plus rejection of an unknown segment, and DELETE accepting the `organizations`
  alias plus rejecting an unknown segment. 12/12 pass.

## Guide for Testers

This is a backend routing change with no visible UI change. The user-facing behavior should
be identical before and after.

Regression checks (UI):

1. Go to `app.staging.bike4mind.com` and open any Project you own.
2. Invite a user to the project. Expected: the invite is created and appears in the
   project's invite list with no error toast.
3. Cancel that invite from the list. Expected: the invite disappears and no error toast
   appears.
4. Repeat steps 2-3 for an Organization and for a Session. Expected: same result each time.

API checks (curl, authenticated session cookie required). Substitute a real project id for
`<id>`:

5. `GET /api/projects/<id>/invites` -> 200 with the invite list (worked before this PR).
6. `GET /api/Project/<id>/invites` -> 200 with the same list. Before this PR this returned
   400 `Invalid type`.
7. `DELETE /api/Project/<id>/invites` with a valid body -> succeeds (worked before this PR;
   this must not regress).
8. `DELETE /api/projects/<id>/invites` with the same body -> succeeds. Before this PR this
   returned 422.
9. `GET /api/bogus/<id>/invites` -> 400 `Invalid type` (unknown segments are still
   rejected).

What NOT to test: no infra, schema, or permission changes are in this PR. Authorization on
the route is untouched -- an unknown or mismatched `:type` is still rejected, and callers
still need the same permissions they needed before.

## Additional Information

Verification run locally: `vitest run` on the route's test file (12/12), 
`pnpm --filter @bike4mind/client typecheck` clean, and `eslint` on the four changed files
with 0 errors (only pre-existing `any` warnings in test mocks). The full-repo
`turbo:test` / `lint:check` sweep was not run locally -- left to CI.
