### PR TITLE
fix(client): post a failure notice when Slack quest processing throws

### DIFF
--- a/apps/client/server/queueHandlers/slackQuestProcessor.failureNotice.test.ts
+++ b/apps/client/server/queueHandlers/slackQuestProcessor.failureNotice.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+// This exercises the error path of the Slack quest handler: chatCompletion.process()
+// throws, so the normal delivery block below it never runs. Only the thin edges are
+// stubbed (config, event bus, DB models, Slack client) - the handler's own control flow
+// is the thing under test.
+
+const benignStub: ProxyHandler<object> = {
+  get(_, key) {
+    if (key === 'then') return undefined;
+    return `mock-${String(key)}`;
+  },
+};
+
+vi.mock('sst', () => ({
+  Resource: new Proxy({} as Record<string, unknown>, {
+    get() {
+      return new Proxy({}, benignStub);
+    },
+  }),
+}));
+
+vi.mock('@server/integrations/slack/slackPackageInit', () => ({
+  initializeSlackPackage: vi.fn(),
+}));
+
+vi.mock('@server/utils/config', () => ({
+  Config: new Proxy({} as Record<string, unknown>, {
+    get: (_, key) => `mock-${String(key)}`,
+  }),
+}));
+
+vi.mock('@server/utils/eventBus', () => ({
+  LLMEvents: {
+    SlackCompletionStart: { schema: { parse: (v: unknown) => v } },
+    CompletionCompleted: { publish: vi.fn() },
+  },
+  SessionEvents: { AutoName: { publish: vi.fn() } },
+}));
+
+vi.mock('@server/utils/storage', () => ({
+  getFilesStorage: () => ({}),
+  getGeneratedImageStorage: () => ({ download: vi.fn() }),
+}));
+
+vi.mock('@server/utils/chatCompletionDefaults', () => ({
+  getSharedTokenizer: () => ({}),
+  publishTelemetryAlertCallback: vi.fn(),
+}));
+
+vi.mock('@server/security/tokenEncryption', () => ({
+  decryptToken: () => 'xoxb-decrypted',
+}));
+
+const processError = new Error('Model context window is smaller than its reserved output');
+const mockProcess = vi.fn().mockRejectedValue(processError);
+
+vi.mock('@bike4mind/services', async () => {
+  const actual = await vi.importActual<typeof import('@bike4mind/services')>('@bike4mind/services');
+  return {
+    ...actual,
+    ChatCompletionProcess: class {
+      process = mockProcess;
+    },
+  };
+});
+
+const mockUpdateMessage = vi.fn().mockResolvedValue(undefined);
+const mockUploadFile = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@bike4mind/slack', async () => {
+  const actual = await vi.importActual<typeof import('@bike4mind/slack')>('@bike4mind/slack');
+  return {
+    ...actual,
+    SlackClient: class {
+      updateMessage = mockUpdateMessage;
+      uploadFile = mockUploadFile;
+    },
+  };
+});
+
+const QUEST_ID = 'quest-1';
+
+const slackNotification = {
+  workspaceId: 'workspace-1',
+  channelId: 'C123',
+  messageTs: '1700000000.000100',
+};
+
+let questDoc: Record<string, unknown> | null = null;
+const mockFindByIdAndUpdate = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@bike4mind/database', async () => {
+  const actual = await vi.importActual<typeof import('@bike4mind/database')>('@bike4mind/database');
+  return {
+    ...actual,
+    connectDB: vi.fn().mockResolvedValue(undefined),
+    Quest: {
+      findById: vi.fn(async () => questDoc),
+      findByIdAndUpdate: (...args: unknown[]) => mockFindByIdAndUpdate(...args),
+      findOne: vi.fn(() => ({ sort: () => null })),
+    },
+    Session: { findById: vi.fn(async () => ({ userId: 'user-1' })) },
+    User: { findById: vi.fn(async () => ({ _id: 'user-1' })) },
+    sessionRepository: { findById: vi.fn(async () => ({ id: 'session-1' })) },
+    slackDevWorkspaceRepository: {
+      findByIdWithCredentials: vi.fn(async () => ({ name: 'Test WS', slackBotToken: 'encrypted' })),
+    },
+  };
+});
+
+vi.mock('@casl/mongoose', () => ({ accessibleBy: () => ({ ofType: () => ({}) }) }));
+
+function makeEvent() {
+  return {
+    'detail-type': 'slack.completion.started',
+    detail: { userId: 'user-1', sessionId: 'session-1', questId: QUEST_ID, params: {} },
+  } as never;
+}
+
+describe('slackQuestProcessor failure notice', () => {
+  // The handler's transitive import graph (services + database + slack) is heavy enough
+  // that resolving it inside a test blows the default timeout.
+  let handler: (event: never) => Promise<void>;
+
+  beforeAll(async () => {
+    ({ handler } = await import('./slackQuestProcessor'));
+  }, 120_000);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcess.mockRejectedValue(processError);
+    mockUpdateMessage.mockResolvedValue(undefined);
+    mockFindByIdAndUpdate.mockResolvedValue(undefined);
+    questDoc = { slackNotification, type: 'error', reply: processError.message };
+  });
+
+  it('replaces the pending Slack status message when chat processing throws', async () => {
+    await expect(handler(makeEvent())).rejects.toThrow(processError.message);
+
+    expect(mockUpdateMessage).toHaveBeenCalledTimes(1);
+    const [call] = mockUpdateMessage.mock.calls[0];
+    expect(call.channel).toBe(slackNotification.channelId);
+    expect(call.ts).toBe(slackNotification.messageTs);
+    expect(call.text).toContain('something went wrong');
+    expect(call.text).toContain(processError.message);
+
+    // The pending notification is cleared so a retry cannot double-post.
+    expect(mockFindByIdAndUpdate).toHaveBeenCalledWith(QUEST_ID, { $unset: { slackNotification: 1 } });
+  });
+
+  it('omits the detail line when the quest carries no error reply', async () => {
+    questDoc = { slackNotification };
+
+    await expect(handler(makeEvent())).rejects.toThrow(processError.message);
+
+    const [call] = mockUpdateMessage.mock.calls[0];
+    expect(call.text).toContain('something went wrong');
+    expect(call.text).not.toContain(processError.message);
+  });
+
+  it('still rethrows the original error when the Slack notice cannot be delivered', async () => {
+    mockUpdateMessage.mockRejectedValue(new Error('slack down'));
+
+    await expect(handler(makeEvent())).rejects.toThrow(processError.message);
+  });
+
+  it('does not post a failure notice for a quest with no pending Slack notification', async () => {
+    questDoc = { type: 'error', reply: processError.message };
+
+    await expect(handler(makeEvent())).rejects.toThrow(processError.message);
+
+    expect(mockUpdateMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/server/queueHandlers/slackQuestProcessor.ts
+++ b/apps/client/server/queueHandlers/slackQuestProcessor.ts
@@ -224,6 +224,104 @@ function formatSimpleAgentResponse(response: string): { blocks: any[] } {
 }
 
 /**
+ * Clear the quest's pending Slack notification so the "Processing..." status message
+ * is never left waiting on a delivery that already happened or can no longer happen.
+ */
+async function clearSlackNotification(questId: string, logger: Logger, context: string): Promise<void> {
+  try {
+    await Quest.findByIdAndUpdate(questId, { $unset: { slackNotification: 1 } });
+  } catch (cleanupErr) {
+    logger.warn(`[SLACK-NOTIFY] Failed to clear slackNotification ${context}`, { questId, error: cleanupErr });
+  }
+}
+
+/**
+ * Build the Slack client for a quest's pending notification. Returns null when the
+ * workspace, token or decryption is unusable - in that case the pending notification is
+ * cleared so users aren't left hanging on the status message.
+ */
+async function resolveSlackClient(workspaceId: string, questId: string, logger: Logger): Promise<SlackClient | null> {
+  const workspace = await slackDevWorkspaceRepository.findByIdWithCredentials(workspaceId);
+  if (!workspace) {
+    logger.error('[SLACK-NOTIFY] Workspace not found', { workspaceId });
+    await clearSlackNotification(questId, logger, 'on missing workspace');
+    return null;
+  }
+  if (!workspace.slackBotToken) {
+    logger.error('[SLACK-NOTIFY] Workspace found but bot token is missing', {
+      workspaceId,
+      workspaceName: workspace.name,
+    });
+    await clearSlackNotification(questId, logger, 'on missing bot token');
+    return null;
+  }
+
+  const decryptedToken = decryptToken(workspace.slackBotToken);
+  if (!decryptedToken) {
+    logger.error('[SLACK-NOTIFY] Failed to decrypt bot token', {
+      workspaceId,
+      workspaceName: workspace.name,
+    });
+    await clearSlackNotification(questId, logger, 'on decrypt failure');
+    return null;
+  }
+
+  return new SlackClient(decryptedToken, logger);
+}
+
+const SLACK_PROCESSING_FAILURE_TEXT = 'Sorry, something went wrong while processing your request. Please try again.';
+
+/**
+ * Replace the "Processing..." status message with a failure notice when chat processing
+ * throws before any reply is delivered. Without this the Slack message stays pending
+ * forever, since the delivery block below is skipped on the error path.
+ *
+ * Best-effort by contract: it must never mask the original processing error, so every
+ * step swallows its own failures.
+ */
+async function deliverSlackProcessingFailure(questId: string, logger: Logger): Promise<void> {
+  const quest = await Quest.findById(questId);
+  if (!quest?.slackNotification) {
+    return;
+  }
+
+  const { workspaceId, channelId, messageTs } = quest.slackNotification as {
+    workspaceId: string;
+    channelId: string;
+    messageTs: string;
+  };
+
+  const slackClient = await resolveSlackClient(workspaceId, questId, logger);
+  if (!slackClient) {
+    return;
+  }
+
+  // ChatCompletionProcess saves the error as the quest reply before rethrowing, so reuse
+  // it as the detail line when present - it is the same text the web client shows.
+  const detail = quest.type === 'error' && quest.reply ? quest.reply : null;
+  const text = detail ? `${SLACK_PROCESSING_FAILURE_TEXT}\n\n> ${detail}` : SLACK_PROCESSING_FAILURE_TEXT;
+
+  if (messageTs) {
+    try {
+      await slackClient.updateMessage({
+        channel: channelId,
+        ts: messageTs,
+        text,
+        blocks: formatSimpleAgentResponse(text).blocks,
+      });
+    } catch (updateError) {
+      logger.error('[SLACK-NOTIFY] Failed to post failure notice to Slack', {
+        questId,
+        messageTs,
+        error: updateError,
+      });
+    }
+  }
+
+  await clearSlackNotification(questId, logger, 'after failure notice');
+}
+
+/**
  * Slack Quest Processor Lambda Handler
  *
  * Handles Slack-originated completion requests routed via SlackEventBus.
@@ -322,11 +420,27 @@ export const handler = withEventContext(async (event, logger) => {
   // Premium overlay tool implementations merge first so explicit tools win.
   const externalTools = { ...premiumLlmTools, ...withLatticeTools(baseTools, requestBody.enableLattice) };
 
-  await chatCompletion.process({
-    body: requestBody,
-    logger,
-    externalTools,
-  });
+  try {
+    await chatCompletion.process({
+      body: requestBody,
+      logger,
+      externalTools,
+    });
+  } catch (processError) {
+    logger.error('[SLACK-NOTIFY] Chat processing failed before a reply was delivered', {
+      questId: params.questId,
+      error: processError,
+    });
+    try {
+      await deliverSlackProcessingFailure(params.questId, logger);
+    } catch (notifyError) {
+      logger.error('[SLACK-NOTIFY] Failed to deliver failure notice', {
+        questId: params.questId,
+        error: notifyError,
+      });
+    }
+    throw processError;
+  }
 
   // Inline Slack notification delivery - edits the status message with the final AI response
   // and uploads any generated images. Replaces the SlackNotificationEvents EventBridge hop.
@@ -344,45 +458,10 @@ export const handler = withEventContext(async (event, logger) => {
     isPaintCommand?: boolean;
   };
 
-  const workspace = await slackDevWorkspaceRepository.findByIdWithCredentials(workspaceId);
-  if (!workspace) {
-    logger.error('[SLACK-NOTIFY] Workspace not found', { workspaceId });
-    // Best-effort: clear the stuck "Processing..." message so users aren't left hanging
-    try {
-      await Quest.findByIdAndUpdate(params.questId, { $unset: { slackNotification: 1 } });
-    } catch (cleanupErr) {
-      logger.warn('[SLACK-NOTIFY] Failed to clear slackNotification on missing workspace', { cleanupErr });
-    }
+  const slackClient = await resolveSlackClient(workspaceId, params.questId, logger);
+  if (!slackClient) {
     return;
   }
-  if (!workspace.slackBotToken) {
-    logger.error('[SLACK-NOTIFY] Workspace found but bot token is missing', {
-      workspaceId,
-      workspaceName: workspace.name,
-    });
-    try {
-      await Quest.findByIdAndUpdate(params.questId, { $unset: { slackNotification: 1 } });
-    } catch (cleanupErr) {
-      logger.warn('[SLACK-NOTIFY] Failed to clear slackNotification on missing bot token', { cleanupErr });
-    }
-    return;
-  }
-
-  const decryptedToken = decryptToken(workspace.slackBotToken);
-  if (!decryptedToken) {
-    logger.error('[SLACK-NOTIFY] Failed to decrypt bot token', {
-      workspaceId,
-      workspaceName: workspace.name,
-    });
-    try {
-      await Quest.findByIdAndUpdate(params.questId, { $unset: { slackNotification: 1 } });
-    } catch (cleanupErr) {
-      logger.warn('[SLACK-NOTIFY] Failed to clear slackNotification on decrypt failure', { cleanupErr });
-    }
-    return;
-  }
-
-  const slackClient = new SlackClient(decryptedToken, logger);
 
   const aiResponse = quest.reply || quest.replies?.[0] || 'Processing complete.';
   let formatted = formatSimpleAgentResponse(aiResponse);
@@ -459,19 +538,9 @@ export const handler = withEventContext(async (event, logger) => {
     }
   }
 
-  // Wrap cleanup in try-catch: if this fails after successful delivery, EventBridge would retry
-  // the Lambda and the user would receive a duplicate notification.
-  try {
-    await Quest.findByIdAndUpdate(params.questId, { $unset: { slackNotification: 1 } });
-  } catch (cleanupErr) {
-    logger.error(
-      '[SLACK-NOTIFY] Failed to clear slackNotification after delivery — duplicate notification risk on retry',
-      {
-        questId: params.questId,
-        error: cleanupErr,
-      }
-    );
-  }
+  // If this fails after successful delivery, EventBridge would retry the Lambda and the
+  // user would receive a duplicate notification.
+  await clearSlackNotification(params.questId, logger, 'after delivery (duplicate notification risk on retry)');
 
   logger.info('[SLACK-NOTIFY] Slack notification delivered', { questId: params.questId });
 });


### PR DESCRIPTION
# Pull Request

## Description

Fixes #1217.

A Slack-triggered quest posts a "Processing..." message, then runs `chatCompletion.process()`. Until now there was no catch between that call and `withEventContext`'s log-and-rethrow, so any error thrown before the reply was delivered left the Slack user staring at a permanently stuck "Processing..." message with no follow-up.

This is a pre-existing gap. It becomes more visible now that fail-fast guards exist upstream (a misconfigured model whose context window is smaller than its reserved output now throws immediately instead of silently sending an empty prompt) - a config that used to fail silently now fails loudly, and on the Slack path "loudly" meant "stuck".

Scope note: the gentle error classes in `ChatCompletionProcess` (credits, abort, timeout, tool pairing, overloaded, context overflow) `return` rather than throw and already reach Slack through the normal delivery block. Only the terminal rethrow reaches the new catch, so this changes behavior solely for errors that previously produced nothing at all.

## Changes

- `slackQuestProcessor.ts`: wrap `chatCompletion.process()` in try/catch. On throw, log, deliver a failure notice to Slack, then rethrow the original error so EventBridge retry/DLQ behavior is unchanged. The notice delivery is itself try/caught so it can never mask the underlying processing error.
- Add `deliverSlackProcessingFailure()`: re-reads the quest and, if `slackNotification` is still pending, edits the "Processing..." message into a failure notice, then clears `slackNotification` so a retry cannot double-post. An error reply already stored by `ChatCompletionProcess` is appended as a blockquote detail line.
- Extract `clearSlackNotification()` and `resolveSlackClient()` - both are now needed on the success and failure paths.
- Add `slackQuestProcessor.failureNotice.test.ts` (4 cases) covering the throw path, the notice content, the no-double-post guard, and that the original error still propagates.

## Guide for Testers

Backend-only; no UI surface. Behavior is exercised through Slack.

1. In a Slack workspace connected to the app, configure a Slack quest to use a model that will fail at request time (for example a model config whose context window is smaller than its reserved output tokens).
2. In Slack, mention the bot with any prompt, e.g. `hello`.
3. The bot replies with a "Processing..." message. Expected: within the normal request timeout, that message is edited into a failure notice rather than remaining "Processing..." indefinitely.
4. If the underlying error produced an error reply, the notice includes it as a blockquote detail line.
5. Send a second, valid prompt with a working model. Expected: normal successful reply, unchanged from before.

### Regression Checks

1. A normal successful Slack quest still edits "Processing..." into the completed answer exactly as before.
2. The gentle error classes (out of credits, request aborted, timeout, model overloaded, context overflow) still produce their existing Slack messages - they do not go through the new failure path.

### What NOT to test

No client UI changed. No admin settings, schema, or telemetry changes.

## Additional Information

Verified locally: client typecheck exit 0, eslint 0 errors, prettier clean, all pre-commit hooks green. The new test was checked for non-vacuousness by stubbing out the fix and confirming the two message-asserting cases fail.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
