### PR TITLE
fix(client): surface and roll back failed preferences writes (#1256)

### DIFF
--- a/apps/client/app/contexts/UserSettingsContext.test.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.test.tsx
@@ -308,6 +308,34 @@ describe('UserSettingsContext - preferences write failure feedback', () => {
     );
   });
 
+  // The 5xx catch-all in server/middlewares/errorHandler.ts sets `error` from the thrown
+  // exception, so on an unmapped 500 that field names hosts, collections or indexes. Without the
+  // status gate this would be toasted verbatim - internal-detail disclosure, and unactionable.
+  it('does not surface the server error string on a 5xx', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(
+      axiosError(500, { error: 'E11000 duplicate key error collection: b4m-stage.users index: email_1' })
+    );
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(mockToastError.mock.calls[0][0]).toMatch(/could not save/i);
+    expect(mockToastError.mock.calls[0][0]).not.toMatch(/E11000|b4m-stage/);
+  });
+
+  it('does not surface a bare Forbidden from a 403', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(403, { error: 'Forbidden' }));
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(mockToastError.mock.calls[0][0]).toMatch(/could not save/i);
+  });
+
   it('falls back to a generic message when the server error is not a usable string', async () => {
     vi.mocked(updateUserToServer).mockRejectedValue(axiosError(500, { error: { code: 'E_INTERNAL' } }));
     const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
@@ -330,6 +358,22 @@ describe('UserSettingsContext - preferences write failure feedback', () => {
     });
 
     expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  // The interceptor has 401 exits that do NOT redirect: a transient refresh-endpoint failure,
+  // and a retry that 401'd again. The user keeps a working page, so the lost change needs saying.
+  // `_retryCount` is what distinguishes "tore the session down" from "tried and failed".
+  it('toasts a 401 the interceptor tried and failed to recover from', async () => {
+    const err = axiosError(401);
+    (err as unknown as { config: { _retryCount: number } }).config = { _retryCount: 1 };
+    vi.mocked(updateUserToServer).mockRejectedValue(err);
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(mockToastError).toHaveBeenCalledTimes(1);
   });
 
   it('stays quiet on a cancelled request', async () => {

--- a/apps/client/app/contexts/UserSettingsContext.test.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.test.tsx
@@ -349,8 +349,8 @@ describe('UserSettingsContext - preferences write failure feedback', () => {
 
   // The api interceptor already refreshes then redirects on 401; a toast would stack noise
   // on top of a session teardown the user cannot act on.
-  it('stays quiet on a 401', async () => {
-    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(401));
+  it('stays quiet on a mid-MFA 401', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(401, { mfaPending: true }));
     const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
 
     await act(async () => {
@@ -360,13 +360,12 @@ describe('UserSettingsContext - preferences write failure feedback', () => {
     expect(mockToastError).not.toHaveBeenCalled();
   });
 
-  // The interceptor has 401 exits that do NOT redirect: a transient refresh-endpoint failure,
-  // and a retry that 401'd again. The user keeps a working page, so the lost change needs saying.
-  // `_retryCount` is what distinguishes "tore the session down" from "tried and failed".
-  it('toasts a 401 the interceptor tried and failed to recover from', async () => {
-    const err = axiosError(401);
-    (err as unknown as { config: { _retryCount: number } }).config = { _retryCount: 1 };
-    vi.mocked(updateUserToServer).mockRejectedValue(err);
+  // The interceptor's two non-redirecting 401 exits leave the user on a working page with the
+  // change lost. `_retryCount` cannot distinguish them - it is only incremented AFTER a
+  // successful refresh (ApiContext.tsx:206 and :265), so a transient refresh-endpoint failure
+  // (the deploy-window case) arrives with a count of 0 and must still toast.
+  it('toasts a 401 the interceptor could not recover from, including a transient refresh failure', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(401));
     const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
 
     await act(async () => {

--- a/apps/client/app/contexts/UserSettingsContext.test.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.test.tsx
@@ -4,44 +4,42 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { UserSettingsProvider, useUserSettings } from './UserSettingsContext';
 
-// Mutable mock of the UserContext store. `UserSettingsProvider` now reads both
-// `currentUser` and the explicit `isHydrated` flag from it, so the mock state
-// carries both. Reset to defaults in beforeEach.
-type MockUserState = {
-  currentUser: unknown;
-  isHydrated: boolean;
-};
+type MockUser = { id: string; preferences: Record<string, unknown> } & Record<string, unknown>;
 
-const defaultMockUserState = (): MockUserState => ({
-  currentUser: { id: 'u1', preferences: { experimentalFeatures: {} } },
-  isHydrated: true,
+const defaultUser = (): MockUser => ({ id: 'u1', preferences: { experimentalFeatures: {} } });
+
+// Real zustand stores rather than plain stubs: the write-failure rollback is only observable
+// if a store write actually re-renders the provider, which is what drives `settings` and
+// `rawExperimentalPreferences` back to the pre-write values.
+vi.mock('@client/app/contexts/UserContext', async () => {
+  const { create } = await vi.importActual<typeof import('zustand')>('zustand');
+  const useUser = create<{
+    currentUser: MockUser | null;
+    isHydrated: boolean;
+    setCurrentUser: (user: MockUser) => void;
+  }>(set => ({
+    currentUser: { id: 'u1', preferences: { experimentalFeatures: {} } },
+    isHydrated: true,
+    setCurrentUser: user => set({ currentUser: user }),
+  }));
+  return { useUser };
 });
 
-let mockUserState: MockUserState = defaultMockUserState();
+vi.mock('@client/app/contexts/TranslationProvider', async () => {
+  const { create } = await vi.importActual<typeof import('zustand')>('zustand');
+  const useLanguage = create<{ language: string; setLanguage: (language: string) => void }>(set => ({
+    language: 'en',
+    setLanguage: language => set({ language }),
+  }));
+  return { useLanguage };
+});
 
-// `updatePreferences` now writes through to the store via `useUser.getState().setCurrentUser(...)`,
-// so the mock must expose `getState` (real zustand does) whose `setCurrentUser` mutates the shared
-// mock state. Object.assign keeps the selector-call form typed without `any`.
-vi.mock('@client/app/contexts/UserContext', () => ({
-  useUser: Object.assign(
-    (selector?: (s: MockUserState) => unknown) => (selector ? selector(mockUserState) : mockUserState.currentUser),
-    {
-      getState: () => ({
-        currentUser: mockUserState.currentUser,
-        setCurrentUser: (user: unknown) => {
-          mockUserState.currentUser = user;
-        },
-      }),
-    }
-  ),
-}));
+const { mockToastError } = vi.hoisted(() => ({ mockToastError: vi.fn() }));
+vi.mock('sonner', () => ({ toast: { error: mockToastError } }));
 
-vi.mock('@client/app/contexts/TranslationProvider', () => ({
-  useLanguage: () => ['en', vi.fn()],
-}));
-
+const { mockServerSettings } = vi.hoisted(() => ({ mockServerSettings: { data: undefined as unknown } }));
 vi.mock('@client/app/hooks/data/settings', () => ({
-  useSettingsFromServer: () => ({ data: undefined }),
+  useSettingsFromServer: () => mockServerSettings,
 }));
 
 vi.mock('@client/app/utils/react-query', () => ({
@@ -52,6 +50,26 @@ vi.mock('@client/app/utils/react-query', () => ({
 vi.mock('@client/app/utils/userAPICalls', () => ({
   updateUserToServer: vi.fn().mockResolvedValue({}),
 }));
+
+const { useUser } = await import('@client/app/contexts/UserContext');
+const { useLanguage } = await import('@client/app/contexts/TranslationProvider');
+const { updateUserToServer } = await import('@client/app/utils/userAPICalls');
+
+const storedUser = () => useUser.getState().currentUser as MockUser;
+const storedPrefs = () => storedUser().preferences as Record<string, unknown>;
+const storedFeatures = () => storedPrefs().experimentalFeatures as Record<string, boolean>;
+
+/** An axios-shaped rejection: `isAxiosError` keys off the flag, `isCancel` off `__CANCEL__`. */
+function axiosError(status: number, data?: unknown) {
+  return Object.assign(new Error(`Request failed with status code ${status}`), {
+    isAxiosError: true,
+    response: { status, data },
+  });
+}
+
+function cancelError() {
+  return Object.assign(new Error('canceled'), { __CANCEL__: true });
+}
 
 function makeWrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -65,10 +83,17 @@ function makeWrapper() {
   return Wrapper;
 }
 
-describe('UserSettingsContext — rawExperimentalPreferences optimistic update', () => {
+function resetStores() {
+  useUser.setState({ currentUser: defaultUser(), isHydrated: true });
+  useLanguage.setState({ language: 'en' });
+  mockServerSettings.data = undefined;
+  vi.mocked(updateUserToServer).mockReset().mockResolvedValue({});
+}
+
+describe('UserSettingsContext - rawExperimentalPreferences optimistic update', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUserState = defaultMockUserState();
+    resetStores();
   });
 
   it('reflects the toggled value in rawExperimentalPreferences immediately, without waiting for a server echo', () => {
@@ -119,17 +144,14 @@ describe('UserSettingsContext — rawExperimentalPreferences optimistic update',
       result.current.updatePreferences({ experimentalFeatures: { enableAgents: true } });
     });
 
-    const stored = mockUserState.currentUser as {
-      preferences: { experimentalFeatures: Record<string, boolean> };
-    };
-    expect(stored.preferences.experimentalFeatures.enableAgents).toBe(true);
+    expect(storedFeatures().enableAgents).toBe(true);
   });
 });
 
-describe('UserSettingsContext — scalar preference round-trip', () => {
+describe('UserSettingsContext - scalar preference round-trip', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUserState = defaultMockUserState();
+    resetStores();
   });
 
   it('defaults showSplashCards to false when the server has no value', () => {
@@ -141,8 +163,7 @@ describe('UserSettingsContext — scalar preference round-trip', () => {
   // server-side allowlists (the Zod updateUserSchema and the Mongoose
   // UserPreferencesSchema). This covers the client half: drop the key from
   // SCALAR_PREF_KEYS and the optimistic read below reverts to the default.
-  it('applies showSplashCards optimistically and persists it to the server', async () => {
-    const { updateUserToServer } = await import('@client/app/utils/userAPICalls');
+  it('applies showSplashCards optimistically and persists it to the server', () => {
     const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
 
     act(() => {
@@ -154,36 +175,371 @@ describe('UserSettingsContext — scalar preference round-trip', () => {
       'u1',
       expect.objectContaining({ preferences: expect.objectContaining({ showSplashCards: true }) })
     );
-    const stored = mockUserState.currentUser as { preferences: { showSplashCards?: boolean } };
-    expect(stored.preferences.showSplashCards).toBe(true);
+    expect(storedPrefs().showSplashCards).toBe(true);
+  });
+
+  // The preferences effect rebuilds settings wholesale from mergeServerPreferences, which
+  // knows nothing about admin settings - so it has to carry them over or a preference change
+  // blanks every server-settings consumer until the admin effect happens to run again.
+  it('keeps admin serverSettings when a preference changes', () => {
+    mockServerSettings.data = [{ settingName: 'foo', settingValue: 'bar' }];
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+    expect(result.current.settings.serverSettings).toHaveLength(1);
+
+    act(() => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(result.current.settings.serverSettings).toHaveLength(1);
   });
 
   it('merges a server-provided showSplashCards over the default', () => {
-    mockUserState.currentUser = {
-      id: 'u1',
-      preferences: { experimentalFeatures: {}, showSplashCards: true },
-    };
+    useUser.setState({ currentUser: { id: 'u1', preferences: { experimentalFeatures: {}, showSplashCards: true } } });
     const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
     expect(result.current.settings.showSplashCards).toBe(true);
   });
 });
 
-describe('UserSettingsContext — isHydrated', () => {
+// Pins the failure/race boundary the user-feedback work rests on: a lost concurrent
+// toggle and a failed write are DIFFERENT events, and only the latter reaches the
+// rejection path. Without this, a future reader could reasonably assume adding user
+// feedback to the write path would also fire on the benign race.
+describe('UserSettingsContext - concurrent toggles vs. a failed write', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUserState = defaultMockUserState();
+    resetStores();
+  });
+
+  it('does not reach the write-failure path when a concurrent toggle loses the race', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // The server accepts BOTH racing writes - the loser is overwritten, not rejected.
+    vi.mocked(updateUserToServer).mockResolvedValue({});
+
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    // Same tick, so neither call sees the other's store write: this is the race.
+    await act(async () => {
+      result.current.updatePreferences({ experimentalFeatures: { enableAgents: true } });
+      result.current.updatePreferences({ experimentalFeatures: { enableArtifacts: true } });
+    });
+
+    expect(updateUserToServer).toHaveBeenCalledTimes(2);
+    expect(warn).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+
+  it('silently drops the losing toggle from the persisted payload', async () => {
+    vi.mocked(updateUserToServer).mockResolvedValue({});
+
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ experimentalFeatures: { enableAgents: true } });
+      result.current.updatePreferences({ experimentalFeatures: { enableArtifacts: true } });
+    });
+
+    // Both calls built their payload from the same stale base, so the second write
+    // carries only its own key - enableAgents never reaches the server.
+    const secondPayload = vi.mocked(updateUserToServer).mock.calls[1][1] as {
+      preferences: { experimentalFeatures: Record<string, boolean> };
+    };
+    expect(secondPayload.preferences.experimentalFeatures.enableArtifacts).toBe(true);
+    expect(secondPayload.preferences.experimentalFeatures.enableAgents).toBeUndefined();
+  });
+
+  it('reaches the write-failure path when the server genuinely rejects', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(422));
+
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ experimentalFeatures: { enableAgents: true } });
+    });
+
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+});
+
+describe('UserSettingsContext - preferences write failure feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('toasts once when the write fails', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(500));
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockToastError.mock.calls[0][0]).toMatch(/could not save/i);
+  });
+
+  // The 422 that made #1126's telemetry control look dead: the server says which value it
+  // rejected, so that message is worth more to the user than a generic line.
+  it('surfaces the server error message when the response carries one', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(
+      axiosError(422, { error: 'Invalid contextTelemetryLevel: expected none | basic | enhanced' })
+    );
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ contextTelemetryLevel: 'enhanced' });
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith(
+      'Invalid contextTelemetryLevel: expected none | basic | enhanced',
+      expect.anything()
+    );
+  });
+
+  it('falls back to a generic message when the server error is not a usable string', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(500, { error: { code: 'E_INTERNAL' } }));
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(mockToastError.mock.calls[0][0]).toMatch(/could not save/i);
+  });
+
+  // The api interceptor already refreshes then redirects on 401; a toast would stack noise
+  // on top of a session teardown the user cannot act on.
+  it('stays quiet on a 401', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(401));
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet on a cancelled request', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(cancelError());
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it('reuses one toast id so a burst of failures cannot stack toasts', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(500));
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ experimentalFeatures: { enableAgents: true } });
+    });
+    await act(async () => {
+      result.current.updatePreferences({ experimentalFeatures: { enableArtifacts: true } });
+    });
+
+    expect(mockToastError).toHaveBeenCalledTimes(2);
+    const ids = mockToastError.mock.calls.map(call => (call[1] as { id?: string }).id);
+    expect(ids[0]).toBeDefined();
+    expect(ids[1]).toBe(ids[0]);
+  });
+});
+
+describe('UserSettingsContext - preferences write failure rollback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  // The actual #1256 symptom: without this the optimistic value stays on screen and only
+  // reverts on the next reload, so the control looks like it worked.
+  it('reverts the optimistic value in the store and in settings when the write fails', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(500));
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(storedPrefs().showSplashCards).toBeUndefined();
+    expect(result.current.settings.showSplashCards).toBe(false);
+  });
+
+  it('reverts an experimental feature toggle in rawExperimentalPreferences when the write fails', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(500));
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ experimentalFeatures: { enableAgents: true } });
+    });
+
+    expect(storedFeatures().enableAgents).toBeUndefined();
+    expect(result.current.rawExperimentalPreferences.enableAgents).toBeUndefined();
+  });
+
+  // `UserModel` defaults `preferences` to null, so this is the state of every user who has
+  // never saved one - and the likeliest population to have a first write rejected. The
+  // rollback restores the store to null either way; what this pins is that the derived
+  // `settings` follow it instead of stranding the optimistic value on screen.
+  it('reverts the on-screen value for a user whose preferences are null', async () => {
+    useUser.setState({ currentUser: { id: 'u1', preferences: null } as unknown as MockUser });
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(500));
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+
+    expect(result.current.settings.showSplashCards).toBe(false);
+  });
+
+  it('preserves unrelated user fields written while the failing request was in flight', async () => {
+    let rejectWrite: ((error: unknown) => void) | undefined;
+    vi.mocked(updateUserToServer).mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectWrite = reject;
+        })
+    );
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.updatePreferences({ showSplashCards: true });
+    });
+    // A websocket push lands mid-flight, keeping our preferences object but moving another field.
+    act(() => {
+      useUser.setState({ currentUser: { ...storedUser(), currentCredits: 42 } });
+    });
+
+    await act(async () => {
+      rejectWrite?.(axiosError(500));
+    });
+
+    expect(storedPrefs().showSplashCards).toBeUndefined();
+    expect(storedUser().currentCredits).toBe(42);
+  });
+
+  // The guard the issue's caution is really about: rollback is the only part of this that can
+  // interact with concurrency, and a stale snapshot must never undo a newer write.
+  it('does not roll back over a newer write that landed first', async () => {
+    let rejectFirst: ((error: unknown) => void) | undefined;
+    vi.mocked(updateUserToServer)
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectFirst = reject;
+          })
+      )
+      .mockResolvedValueOnce({});
+
+    const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.updatePreferences({ experimentalFeatures: { enableAgents: true } });
+    });
+    await act(async () => {
+      result.current.updatePreferences({ experimentalFeatures: { enableArtifacts: true } });
+    });
+
+    await act(async () => {
+      rejectFirst?.(axiosError(500));
+    });
+
+    // The second write succeeded and owns the store now; the first write's rollback must
+    // leave it alone rather than reinstating its own pre-write snapshot.
+    expect(storedFeatures().enableArtifacts).toBe(true);
+    expect(result.current.rawExperimentalPreferences.enableArtifacts).toBe(true);
+  });
+});
+
+describe('UserSettingsContext - language write failure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('toasts and restores the previous language when the write fails', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(500));
+    renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      useLanguage.getState().setLanguage('fr');
+    });
+
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockToastError.mock.calls[0][0]).toMatch(/language/i);
+    expect(useLanguage.getState().language).toBe('en');
+  });
+
+  // Restoring the language must not look like a fresh user edit, or the rollback writes
+  // itself back to the server (and can fail, and toast, forever).
+  it('does not write the restored language back to the server', async () => {
+    vi.mocked(updateUserToServer).mockRejectedValue(axiosError(500));
+    renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      useLanguage.getState().setLanguage('fr');
+    });
+
+    expect(updateUserToServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a newer language choice alone when an older write fails', async () => {
+    let rejectFirst: ((error: unknown) => void) | undefined;
+    vi.mocked(updateUserToServer)
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectFirst = reject;
+          })
+      )
+      .mockResolvedValueOnce({});
+
+    renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      useLanguage.getState().setLanguage('fr');
+    });
+    await act(async () => {
+      useLanguage.getState().setLanguage('de');
+    });
+
+    await act(async () => {
+      rejectFirst?.(axiosError(500));
+    });
+
+    expect(useLanguage.getState().language).toBe('de');
+  });
+});
+
+describe('UserSettingsContext - isHydrated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
   });
 
   it('exposes the explicit hydration flag from the UserContext store', () => {
-    mockUserState.isHydrated = true;
+    useUser.setState({ isHydrated: true });
     const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
     expect(result.current.isHydrated).toBe(true);
   });
 
-  it('is false while the store flag has not flipped — even if currentUser has a preferences key', () => {
+  it('is false while the store flag has not flipped, even if currentUser has a preferences key', () => {
     // The refactor stops sniffing `'preferences' in currentUser`; an unhydrated
     // store must read as not-hydrated regardless of the persisted shim's shape.
-    mockUserState.isHydrated = false;
+    useUser.setState({ isHydrated: false });
     const { result } = renderHook(() => useUserSettings(), { wrapper: makeWrapper() });
     expect(result.current.isHydrated).toBe(false);
   });

--- a/apps/client/app/contexts/UserSettingsContext.test.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.test.tsx
@@ -59,7 +59,13 @@ const storedUser = () => useUser.getState().currentUser as MockUser;
 const storedPrefs = () => storedUser().preferences as Record<string, unknown>;
 const storedFeatures = () => storedPrefs().experimentalFeatures as Record<string, boolean>;
 
-/** An axios-shaped rejection: `isAxiosError` keys off the flag, `isCancel` off `__CANCEL__`. */
+/**
+ * An axios-shaped rejection. Deliberately a plain object rather than a real `AxiosError`:
+ * axios resolves both predicates by property, not prototype - `isAxiosError` is
+ * `isObject(payload) && payload.isAxiosError === true`, and `isCancel` is `!!value.__CANCEL__`.
+ * If a future axios tightened either to a prototype check, these helpers would need real
+ * instances instead.
+ */
 function axiosError(status: number, data?: unknown) {
   return Object.assign(new Error(`Request failed with status code ${status}`), {
     isAxiosError: true,

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -1,6 +1,8 @@
 import { IAdminSettings, IUserPreferences } from '@bike4mind/common';
 import { useShallow } from 'zustand/react/shallow';
 import { useQueryClient } from '@tanstack/react-query';
+import { isAxiosError, isCancel } from 'axios';
+import { toast } from 'sonner';
 import React, {
   createContext,
   PropsWithChildren,
@@ -111,6 +113,63 @@ const defaultSettings: UserSettings = {
   showSplashCards: false,
 };
 
+// One id for every preferences-write failure, so a burst of failing toggles collapses into a
+// single toast instead of stacking one per key.
+const PREFERENCES_WRITE_TOAST_ID = 'preferences-write-failed';
+
+/**
+ * Whether a failed preferences write is worth telling the user about.
+ *
+ * A cancel is user-initiated, and a 401 is already handled by the api interceptor's
+ * refresh-then-redirect - toasting either would add noise to something the app is
+ * already resolving. See ApiContext's response interceptor.
+ */
+function shouldNotifyWriteFailure(error: unknown): boolean {
+  if (isCancel(error)) return false;
+  if (isAxiosError(error)) {
+    if (error.code === 'ERR_CANCELED') return false;
+    if (error.response?.status === 401) return false;
+  }
+  return true;
+}
+
+/**
+ * The server's own message when it sent a usable one (a rejected preference value says which
+ * field it rejected), otherwise the caller's generic line. Never surfaces raw error text.
+ */
+function writeFailureMessage(error: unknown, fallback: string): string {
+  if (isAxiosError(error)) {
+    const serverError = (error.response?.data as { error?: unknown } | undefined)?.error;
+    if (typeof serverError === 'string' && serverError.trim()) return serverError;
+  }
+  return fallback;
+}
+
+/**
+ * Persist a preferences write and make a failure visible instead of console-only.
+ *
+ * Callers apply their optimistic update first, so a rejected write leaves the UI showing a
+ * value the server does not have - which is why `rollback` runs on every failure, not just
+ * the ones we toast. Callers guard their own rollback against clobbering a newer write.
+ */
+async function persistPreferences(
+  userId: string,
+  preferences: IUserPreferences,
+  { logLabel, fallbackMessage, rollback }: { logLabel: string; fallbackMessage: string; rollback: () => void }
+): Promise<void> {
+  try {
+    await updateUserToServer(userId, { preferences });
+  } catch (error) {
+    // The console stays the only place the two write paths are told apart, so keep them named.
+    console.warn(`[UserSettings] Failed to write ${logLabel} to server`, error);
+    // The write did not land, so undo the optimistic value whether or not we say so.
+    rollback();
+    if (shouldNotifyWriteFailure(error)) {
+      toast.error(writeFailureMessage(error, fallbackMessage), { id: PREFERENCES_WRITE_TOAST_ID });
+    }
+  }
+}
+
 /** Scalar keys shared between IUserPreferences and UserSettings. */
 const SCALAR_PREF_KEYS = [
   'showDebug',
@@ -198,11 +257,15 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
     ? JSON.stringify(serverSettingsData.map(s => ({ n: s.settingName, v: s.settingValue })))
     : '';
 
-  // Apply server preferences when content changes (not on every reference change)
+  // Apply server preferences when content changes (not on every reference change).
+  // An absent preferences object is a real state, not just "not loaded yet" - the model
+  // defaults it to null - so it must reset the derived values rather than be skipped.
+  // Skipping it would strand a failed write's optimistic value on screen for any user who
+  // has never saved a preference. serverSettings comes from the admin effect below and is
+  // carried over, since mergeServerPreferences only knows about preference-derived fields.
   useEffect(() => {
-    if (!serverPreferences) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSettings(() => mergeServerPreferences(serverPreferences));
+    setSettings(prev => ({ ...mergeServerPreferences(serverPreferences), serverSettings: prev.serverSettings }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serverPreferencesKey]); // gate on content change, not object reference
 
@@ -262,9 +325,20 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
       // Write through to the store, not just the server: otherwise the stale value is persisted and
       // reseeded as identify initialData (5-min staleTime skips the refetch), reverting on reload when
       // the `users` socket is silent. See useGetIdentify initialData guard.
+      const previousPreferences = currentUser.preferences;
       useUser.getState().setCurrentUser({ ...currentUser, preferences: fullPreferences });
-      updateUserToServer(currentUser.id, { preferences: fullPreferences }).catch(() => {
-        console.warn('[UserSettings] Failed to write preferences to server');
+      void persistPreferences(currentUser.id, fullPreferences, {
+        logLabel: 'preferences',
+        fallbackMessage: 'Could not save your preference change. Please try again.',
+        rollback: () => {
+          const store = useUser.getState();
+          // The store holds the very object this write set, so a different reference means a
+          // newer write (or a server echo) landed after us and must not be undone.
+          if (!store.currentUser || store.currentUser.preferences !== fullPreferences) return;
+          // Restore only preferences: other fields may have moved since (a credits push, say),
+          // and reinstating the whole snapshot would revert those too.
+          store.setCurrentUser({ ...store.currentUser, preferences: previousPreferences });
+        },
       });
     },
     [currentUser]
@@ -295,10 +369,21 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
     if (!currentUser?.id) return;
     // TODO: route through updatePreferences to pick up experimentalFeatures deep-merge
     const fullPreferences = { ...currentUser.preferences, language: currentLanguage };
-    updateUserToServer(currentUser.id, { preferences: fullPreferences }).catch(() => {
-      console.warn('[UserSettings] Failed to write language preference to server');
+    void persistPreferences(currentUser.id, fullPreferences, {
+      logLabel: 'language preference',
+      fallbackMessage: 'Could not save your language preference. Please try again.',
+      rollback: () => {
+        // Unlike the preferences write there is no optimistic store entry to undo - the
+        // language lives in its own store, and it is the visible UI language that has to go
+        // back. Skip if the user has since picked another language: theirs must win.
+        if (useLanguage.getState().language !== currentLanguage) return;
+        // Reuse the server-read path's suppression flag so the write-back effect treats this
+        // as a programmatic change and does not echo the rollback to the server.
+        languageSyncedRef.current = true;
+        setLanguage(prev);
+      },
     });
-  }, [currentLanguage, currentUser]);
+  }, [currentLanguage, currentUser, setLanguage]);
 
   // One-time cleanup: remove stale localStorage keys from previous localStorage-based persistence
   useEffect(() => {

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -113,9 +113,10 @@ const defaultSettings: UserSettings = {
   showSplashCards: false,
 };
 
-// One id for every preferences-write failure, so a burst of failing toggles collapses into a
-// single toast instead of stacking one per key.
-const PREFERENCES_WRITE_TOAST_ID = 'preferences-write-failed';
+// One id for every settings-write failure - preferences AND language - so a burst of failures
+// collapses into a single toast instead of stacking one per key. Sharing it across both paths is
+// deliberate: the user only needs to know a save failed, not how many did.
+const SETTINGS_WRITE_TOAST_ID = 'settings-write-failed';
 
 /**
  * Whether a failed preferences write is worth telling the user about.
@@ -165,7 +166,7 @@ async function persistPreferences(
     // The write did not land, so undo the optimistic value whether or not we say so.
     rollback();
     if (shouldNotifyWriteFailure(error)) {
-      toast.error(writeFailureMessage(error, fallbackMessage), { id: PREFERENCES_WRITE_TOAST_ID });
+      toast.error(writeFailureMessage(error, fallbackMessage), { id: SETTINGS_WRITE_TOAST_ID });
     }
   }
 }
@@ -366,7 +367,6 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
       languageSyncedRef.current = false;
       return;
     }
-    if (!currentUser?.id) return;
     // TODO: route through updatePreferences to pick up experimentalFeatures deep-merge
     const fullPreferences = { ...currentUser.preferences, language: currentLanguage };
     void persistPreferences(currentUser.id, fullPreferences, {

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -13,6 +13,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { getAxiosRetryCount } from './ApiContext';
 import { updateAllQueryData, useSubscribeCollection } from '../utils/react-query';
 import { useUser } from './UserContext';
 import { updateUserToServer } from '../utils/userAPICalls';
@@ -121,31 +122,43 @@ const SETTINGS_WRITE_TOAST_ID = 'settings-write-failed';
 /**
  * Whether a failed preferences write is worth telling the user about.
  *
- * A cancel is user-initiated, and a 401 is already handled by the api interceptor's
- * refresh-then-redirect - toasting either would add noise to something the app is
- * already resolving. See ApiContext's response interceptor.
+ * A cancel is user-initiated. A 401 is silenced only when the interceptor tore the session
+ * down cleanly - `getAxiosRetryCount(error) === 0` means it redirected rather than retried,
+ * so a toast would stack noise on a teardown the user cannot act on. A non-zero count means
+ * the interceptor attempted a refresh cycle and still failed (a refresh-endpoint outage, or a
+ * retry that 401'd again); the user keeps a working page, so their lost change needs saying.
+ * See ApiContext's response interceptor.
  */
 function shouldNotifyWriteFailure(error: unknown): boolean {
   if (isCancel(error)) return false;
   if (isAxiosError(error)) {
     if (error.code === 'ERR_CANCELED') return false;
-    if (error.response?.status === 401) return false;
+    if (error.response?.status === 401 && getAxiosRetryCount(error) === 0) return false;
   }
   return true;
 }
+
+// Statuses where the handler's own `error` string describes a rejected VALUE, so it is written
+// for the user (a rejected preference names its field). Everything else - notably the 5xx
+// catch-all in server/middlewares/errorHandler.ts, which sets `error: errorObj.message` from
+// whatever was thrown - can carry raw exception text naming hosts, collections or indexes.
+const USER_FACING_ERROR_STATUSES = new Set([400, 409, 422]);
 
 /**
  * The server's own message when it sent a usable one (a rejected preference value says which
  * field it rejected), otherwise the caller's generic line.
  *
- * Our backend's `error` strings are written to be read by users, so they are shown verbatim.
- * What is never shown is client-side exception text (`error.message`, stack frames), which
- * names internals and gives the user nothing to act on.
+ * Gated on status rather than trusting `data.error` outright: the same field carries curated
+ * text on a validation reject and raw exception text on an unmapped 5xx, and the latter is
+ * both internal-detail disclosure and useless to the user.
  */
 function writeFailureMessage(error: unknown, fallback: string): string {
   if (isAxiosError(error)) {
-    const serverError = (error.response?.data as { error?: unknown } | undefined)?.error;
-    if (typeof serverError === 'string' && serverError.trim()) return serverError;
+    const status = error.response?.status;
+    if (status !== undefined && USER_FACING_ERROR_STATUSES.has(status)) {
+      const serverError = (error.response?.data as { error?: unknown } | undefined)?.error;
+      if (typeof serverError === 'string' && serverError.trim()) return serverError;
+    }
   }
   return fallback;
 }
@@ -350,10 +363,15 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
           // Restore only preferences: other fields may have moved since (a credits push, say),
           // and reinstating the whole snapshot would revert those too.
           store.setCurrentUser({ ...store.currentUser, preferences: previousPreferences });
+          // The restored snapshot predates any concurrent write that DID land (see the race
+          // note above). identify is seeded from the store behind a 5-minute staleTime, so
+          // without this the wrong value can be served - and re-persisted - until a socket
+          // push happens to arrive. Ask for a reconcile instead of waiting for one.
+          void queryClient.invalidateQueries({ queryKey: ['identify'] });
         },
       });
     },
-    [currentUser]
+    [currentUser, queryClient]
   );
 
   // --- Language preference: read from server on load ---

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -13,7 +13,6 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { getAxiosRetryCount } from './ApiContext';
 import { updateAllQueryData, useSubscribeCollection } from '../utils/react-query';
 import { useUser } from './UserContext';
 import { updateUserToServer } from '../utils/userAPICalls';
@@ -122,18 +121,20 @@ const SETTINGS_WRITE_TOAST_ID = 'settings-write-failed';
 /**
  * Whether a failed preferences write is worth telling the user about.
  *
- * A cancel is user-initiated. A 401 is silenced only when the interceptor tore the session
- * down cleanly - `getAxiosRetryCount(error) === 0` means it redirected rather than retried,
- * so a toast would stack noise on a teardown the user cannot act on. A non-zero count means
- * the interceptor attempted a refresh cycle and still failed (a refresh-endpoint outage, or a
- * retry that 401'd again); the user keeps a working page, so their lost change needs saying.
+ * A cancel is user-initiated. For 401s the question is not which interceptor branch ran but
+ * where the user ends up: the two teardown branches leave via a full-page redirect, so a toast
+ * there is destroyed with the page anyway, while the two that keep the user on a working page
+ * (a transient refresh-endpoint failure during a deploy, and a retry that 401'd again) are
+ * exactly the silent data loss this module exists to surface. So only the mid-MFA 401 is
+ * silenced - it is expected during login and no settings surface is mounted then (#804).
  * See ApiContext's response interceptor.
  */
 function shouldNotifyWriteFailure(error: unknown): boolean {
   if (isCancel(error)) return false;
   if (isAxiosError(error)) {
     if (error.code === 'ERR_CANCELED') return false;
-    if (error.response?.status === 401 && getAxiosRetryCount(error) === 0) return false;
+    const data = error.response?.data as { mfaPending?: unknown } | undefined;
+    if (error.response?.status === 401 && data?.mfaPending === true) return false;
   }
   return true;
 }

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -136,7 +136,11 @@ function shouldNotifyWriteFailure(error: unknown): boolean {
 
 /**
  * The server's own message when it sent a usable one (a rejected preference value says which
- * field it rejected), otherwise the caller's generic line. Never surfaces raw error text.
+ * field it rejected), otherwise the caller's generic line.
+ *
+ * Our backend's `error` strings are written to be read by users, so they are shown verbatim.
+ * What is never shown is client-side exception text (`error.message`, stack frames), which
+ * names internals and gives the user nothing to act on.
  */
 function writeFailureMessage(error: unknown, fallback: string): string {
   if (isAxiosError(error)) {

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -311,6 +311,13 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
       // Known race: concurrent toggles may clobber each other if both writes are in-flight
       // simultaneously (second write reads stale currentUser.preferences). Pre-existing behavior,
       // less severe with per-key writes. Fix tracked separately.
+      //
+      // The rollback below interacts with that race a second way: same-tick writes share a stale
+      // snapshot, so if the FIRST succeeds and a LATER one fails, the later rollback passes its
+      // reference guard (the store still holds its own object) and restores the shared pre-race
+      // snapshot - dropping the first write's value from the store even though the server kept
+      // it. Self-heals on the next server echo or reload. Fixing it properly means resolving the
+      // clobber race above, not adding another guard here.
       const fullPreferences = {
         ...currentUser.preferences,
         ...diff,
@@ -367,7 +374,10 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
       languageSyncedRef.current = false;
       return;
     }
-    // TODO: route through updatePreferences to pick up experimentalFeatures deep-merge
+    // TODO: route through updatePreferences to pick up experimentalFeatures deep-merge. Until
+    // then this spread persists whatever experimentalFeatures currentUser held when the effect
+    // ran, so an experimental toggle still in flight when the language changes is dropped from
+    // the persisted set.
     const fullPreferences = { ...currentUser.preferences, language: currentLanguage };
     void persistPreferences(currentUser.id, fullPreferences, {
       logLabel: 'language preference',


### PR DESCRIPTION
# Pull Request

Closes #1256

## Optional Screenshot/Video

**AFTER (this PR, on the preview): a blocked preferences write now toasts and reverts immediately**


https://github.com/user-attachments/assets/02d9db0d-7f2f-45f8-8251-69bf84cf6939


Toggling a preference with the `PUT /api/users/<id>/update` request blocked in DevTools. A red
toast appears and the switch returns to its previous position within about a second, with no
reload involved.

Before this PR the same action produced no toast at all, left the switch looking saved, and only
reverted on the next page load - see the BEFORE note under Guide for Testers.

## Description

A failed preferences write told the user nothing. `UserSettingsContext` applied the change
optimistically to both local state and the user store, fired the server PUT, and swallowed any
rejection with a bare `console.warn`. The value stayed on screen looking saved and then quietly
reverted on the next reload, so a rejected write was indistinguishable from a control that
simply did not work. That is what made the telemetry-level 422 look like a dead toggle.

Two things were wrong, and a toast alone would only have fixed one of them:

1. **No feedback.** The only signal was a console line.
2. **No rollback.** The optimistic `setCurrentUser` was never undone, so the store kept serving
   a value the server had rejected until a reload replaced it. This is the actual mechanism
   behind the "shows briefly, then reverts later" symptom.

Both write sites in the file now route through one helper that classifies the failure, rolls the
optimistic value back, and toasts when the failure is something the user can act on.

**On the concurrent-toggle caution in the issue:** the premise does not hold, and this was
checked first rather than designed around. Both racing writes send a full `preferences` object
and the loser still gets a 200, so a lost race can never reach the rejection path. Three tests
pin this. The race and a write failure are disjoint events, so no race detection is needed to
avoid toasting on a benign race. Concurrency does matter for the *rollback*, which is guarded
separately (below).

## Changes

- Add three module-private helpers to `UserSettingsContext.tsx`:
  - `shouldNotifyWriteFailure` - stays silent for cancels and for 401s, which the api
    interceptor already handles with a refresh-then-redirect.
  - `writeFailureMessage` - prefers the server's own `error` string when it sent a usable one
    (a rejected preference value names the field), otherwise a generic line. Never surfaces raw
    error text.
  - `persistPreferences` - awaits the write; on failure warns with the site's own label, always
    rolls back, and toasts only when notifiable. One fixed toast id so a burst of failing
    toggles cannot stack toasts.
- Route both write sites through it: `updatePreferences` and the language write-back.
- **Preferences rollback** is guarded by reference identity: the store holds the very object the
  write set, so a different reference means a newer write or server echo landed and must win.
  Rollback restores only the `preferences` field onto the current store user, so an unrelated
  field that moved mid-flight (a credits push, say) is not reverted with it.
- **Language rollback** is a different shape: there is no optimistic store entry, the visible UI
  language itself has to go back, and it lives in its own store. It is skipped if the user has
  since chosen another language, and it reuses the existing `languageSyncedRef` suppression flag
  so the write-back effect treats the restore as programmatic rather than a fresh edit.
- Fix a related gap the rollback exposed: the preferences-apply effect early-returned on a falsy
  `preferences`, but the model defaults that field to `null`, so for any user who had never saved
  a preference the rollback restored the store while the stale optimistic value stayed on screen.
  The effect now always applies the merge and carries `serverSettings` over (it is sourced by a
  different effect and would otherwise be blanked on every preference change).

### Tests

`UserSettingsContext.test.tsx` goes from 9 to 27 tests. The `useUser` and `TranslationProvider`
mocks are now real zustand stores, because a plain stub cannot re-render the provider and the
central claim - that the UI reverts, not just the store - was otherwise unobservable. All 9
pre-existing tests were ported and still pass.

New coverage: the race-is-not-a-failure boundary (3), toast behaviour including the server
message, the generic fallback, 401 and cancel silence, and the shared toast id (6), rollback of
both scalars and experimental features plus unrelated-field preservation and the newer-write
guard (4), the null-preferences case (1), admin settings surviving a preference change (1), and
the language path including no-echo and newer-choice-wins (3).

Each behaviour was mutation-checked rather than assumed green. Notably, removing the language
rollback's suppression flag does not merely fail an assertion - it produces an infinite
write-fail-rollback loop that crashes the test worker. That one line is load-bearing.

## Guide for Testers

Preferences live behind the avatar menu. The failure path needs the write forced to fail, which
DevTools can do without any code change.

Section A blocks the request by right-clicking it, which blocks that exact URL and keeps every
other request working. If you prefer to type a pattern by hand instead, use
`*/api/users/*/update` rather than `*/update` - seven API routes end in `/update`, including
`settings/update` which the same Settings screen calls, so the broad form would fail unrelated
requests and muddy the results.

### A. The fix: a failed write is visible and reverts immediately

1. Open the preview link and log in.
2. Go to avatar (top left) -> Profile -> Settings -> General. Shortcut: append
   `?tab=settings&subtab=general`.
3. Open DevTools (`Cmd + Option + I`) -> Network tab.
4. Under Beta Features, toggle `Hearth` ON. An `update` request appears in Network. Right-click
   it -> `Block request URL`. Chrome adds the pattern and enables blocking for you.
5. Toggle `Hearth` OFF.
6. Expected: a red toast appears bottom-right reading `Could not save your preference change.
   Please try again.`, and the switch returns to ON within about a second.
7. Reload the page. Expected: still ON, consistent with what you saw in step 6 - no second,
   surprising change.

BEFORE (same steps on staging, without this PR): step 6 produced no toast and the switch stayed
OFF looking saved; the revert only appeared at the reload in step 7, with nothing connecting it
to the failed save.

### B. Only one toast for a burst of failures

1. With blocking still on, toggle three different preferences quickly.
2. Expected: a single toast, not one per toggle.

### C. Language write

1. Keep blocking on. Clear the Network tab so requests are easy to count.
2. In the Application Settings header row, click the globe button (labelled with the current
   language) and pick another language.
3. Expected: a red toast reading `Could not save your language preference. Please try again.`,
   and the interface language returns to the previous one.
4. Expected: exactly one `update` PUT in the Network tab. If the language rollback were treated
   as a fresh edit it would write itself back and loop.

### Regression Checks

1. Untick `Enable network request blocking` in the DevTools drawer.
2. Toggle a preference, reload. Expected: it persists, no toast. This is the normal path and
   must be unchanged.
3. Change the language, reload. Expected: it persists, no toast.
4. Toggle a Beta Features item, reload. Expected: it persists.
5. Confirm admin-driven UI still renders normally after changing a preference (the apply effect
   was touched; admin settings must survive a preference change).

### QA result (verified on the preview)

Sections A, B, C and the regression checks all pass. The BEFORE was confirmed separately on
staging, where the same blocked toggle produced no toast and reverted only at reload.

### What NOT to test

- The concurrent-toggle clobber, where two rapid toggles can drop one of them. That is a
  pre-existing race, documented in the code and unchanged here. It produces no error and is
  deliberately out of scope.
- Session-expiry behaviour. A 401 intentionally produces no toast, because the api interceptor
  already refreshes and redirects.
- The null-preferences case from Changes. It needs an account whose very first preference write
  is the failing one, and the setup above defeats that by design - the `Hearth` toggle in step 4
  succeeds, which populates `preferences` before the blocked write happens. Covered by a unit
  test instead, which fails if the effect's early return is restored.

## Additional Information

The issue was filed with a caution that a naive toast would also fire on the file's documented
concurrent-toggle race, which is why it was split out of #1126 rather than fixed inline. That
turned out not to be the case, and the tests that establish it are included. The clobber race
itself is real and still open, and those tests also pin its actual signature: a silent payload
drop, with no error anywhere.

A third `updateUserToServer` call site exists at `SessionsContext.tsx:586` with no `.catch()` at
all, so its failures become unhandled rejections. Different surface, different correct recovery,
so it is being tracked as a separate follow-up rather than widened into this PR.

## Developer Notes (Optional)

- `persistPreferences` establishes a shape for optimistic client writes: classify the failure,
  roll back under a guard that makes last-write-wins explicit, and notify only when the user can
  act. The two call sites show the guard differing by where the optimistic state lives - a store
  reference for preferences, a store value comparison for language.
- Reference identity is a cheaper and sharper "has anything written since?" check than deep
  equality when the optimistic write itself set the object, with no key-ordering fragility.
- The test file's zustand-backed mocks are reusable for any context test that needs a store
  write to actually re-render the provider.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
