### PR TITLE
fix(data-lakes): harden lake memory producer (continuation, concurrency lease, single profile read)

### DIFF
--- a/apps/client/server/dataLakes/extractLakeMemory.ts
+++ b/apps/client/server/dataLakes/extractLakeMemory.ts
@@ -91,10 +91,11 @@ const CHUNK_PAGE_LIMIT = 1_000;
  * Fold a data lake's documents into its memory profile (#1440 producer): enumerate the lake's live
  * docs, extract durable facts from each with an LLM, and append them to the `{ kind: 'lake' }` ledger
  * owned by the lake's creator. Runs on ingest-finalize (a sibling of the taxonomy job) and is idempotent
- * by construction: `appendFactToLedger` semantically de-dups against the lake's own ledger, so a
- * re-scan re-asserts an existing fact under its subject (a fresh presentation that keeps it hot) rather
- * than duplicating it. That is what makes a full-lake re-scan on each finalize SAFE - correctness does
- * not depend on batch-scoping the docs (a per-batch incremental scan is a later cost optimization).
+ * by construction: the ledger append session (`createLedgerAppendSession`) semantically de-dups
+ * against the lake's own ledger, so a re-scan re-asserts an existing fact under its subject (a fresh
+ * presentation that keeps it hot) rather than duplicating it. That is what makes a full-lake re-scan
+ * on each finalize SAFE - correctness does not depend on batch-scoping the docs (a per-batch
+ * incremental scan is a later cost optimization).
  *
  * Best-effort throughout: a doc that will not read or extract simply contributes no beliefs. Embeddings
  * are best-effort too - a vectorless write stays lexically recallable and can be re-embedded later.

--- a/apps/client/server/dataLakes/extractLakeMemory.ts
+++ b/apps/client/server/dataLakes/extractLakeMemory.ts
@@ -177,7 +177,14 @@ export async function extractLakeMemoryForBatch(
     // Bounded continuation: resume AFTER the last document a prior interrupted run attempted (the
     // persisted cursor), not from the cap boundary - the deadline guard can end a run mid-slice, so the
     // cap is not the only place a run stops. Absent cursor = start from the beginning.
-    const cursor = lake.lakeMemoryCursor ?? null;
+    //
+    // Read the cursor from a POST-claim snapshot, not the pre-claim `lake` read above: in the window
+    // between that read and winning the lease, a run that just released the lease may have advanced the
+    // cursor. Resuming from the stale pre-claim value would re-scan (and re-bill the LLM for) an
+    // already-covered slice - the ledger de-dup keeps it correct, but the wasted cost is exactly what the
+    // lease exists to prevent. Falls back to the pre-claim value if the re-read fails.
+    const claimedLake = await dataLakeRepository.findById(lake.id).catch(() => null);
+    const cursor = (claimedLake ?? lake).lakeMemoryCursor ?? null;
     const remainingDocs = cursor ? liveDocs.filter(f => f.id > cursor) : liveDocs;
     const docs = remainingDocs.slice(0, MAX_DOCS_PER_RUN);
     if (remainingDocs.length > docs.length) {

--- a/apps/client/server/dataLakes/extractLakeMemory.ts
+++ b/apps/client/server/dataLakes/extractLakeMemory.ts
@@ -11,7 +11,7 @@ import { EmbeddingFactory, getProviderFromModel, resolveEmbeddingConfig } from '
 import { getSettingsByNames } from '@bike4mind/utils';
 import type { EvidenceTier } from '@bike4mind/memory';
 import type { Logger } from '@bike4mind/observability';
-import { appendFactToLedger } from '@server/memory/mementoLedgerMirror';
+import { createLedgerAppendSession } from '@server/memory/mementoLedgerMirror';
 
 /**
  * Reserved curator-tag markers that promote a lake document's facts to the `human-reviewed` tier. A
@@ -39,8 +39,9 @@ const MAX_DOC_CHARS = 24_000;
 /**
  * Bound on LIVE documents per run, sized to clear the internal eval corpus (47 docs). The cap applies
  * AFTER tombstones are filtered, so it bounds real work rather than tombstones. A lake larger than this
- * extracts its first slice and LOGS the remainder (never a silent drop); full coverage for genuinely
- * large lakes is the bounded-continuation follow-up (a cursor + re-enqueue).
+ * extracts its first slice and defers the rest to a CONTINUATION run: the run persists a keyset cursor
+ * (the last doc it attempted) and the handler re-enqueues, so chained runs cover the whole lake instead
+ * of the remainder being dropped.
  *
  * This cap is NOT by itself timeout-safe, and an earlier version of this comment claiming ~2-5s per
  * document was measured optimistically. A real preview run took **8.8s for a single document** - one
@@ -75,6 +76,14 @@ const LAKE_EXTRACTION_DEADLINE_BUFFER_MS = 90_000;
  * would mean the guard exists only where someone remembered to wire it.
  */
 const DEFAULT_RUN_BUDGET_MS = 9 * 60_000;
+/**
+ * How long a per-lake extraction lease is honored before another run may reclaim it. Longer than the
+ * Lambda's own 10-minute timeout (infra/queues.ts), so a healthy in-flight run is never stolen; short
+ * enough that a crashed run (which never released its lease) is reclaimable on the next finalize without
+ * a reconciler. A continuation chain runs as separate invocations that each claim + release their own
+ * lease, so this only has to cover ONE slice, not the whole chain.
+ */
+const LAKE_MEMORY_EXTRACTION_LEASE_MS = 15 * 60_000;
 /** Chunk page size when reconstructing a document's text. */
 const CHUNK_PAGE_LIMIT = 1_000;
 
@@ -101,7 +110,7 @@ export async function extractLakeMemoryForBatch(
     getRemainingTimeInMillis?: () => number;
   },
   logger: Logger
-): Promise<{ docsProcessed: number; factsWritten: number }> {
+): Promise<{ docsProcessed: number; factsWritten: number; hasMore: boolean }> {
   const startedAt = Date.now();
   // `?? ` alone would not be enough: a non-finite reading (NaN, Infinity) is not nullish, and every
   // comparison against it is false - which would disable the guard silently rather than fall back.
@@ -114,117 +123,197 @@ export async function extractLakeMemoryForBatch(
   const lake = await dataLakeRepository.findById(params.dataLakeId);
   if (!lake?.createdByUserId || !lake.datalakeTag) {
     logger.warn('[lakeMemory] lake missing owner or tag; skipping extraction', { dataLakeId: params.dataLakeId });
-    return { docsProcessed: 0, factsWritten: 0 };
+    return { docsProcessed: 0, factsWritten: 0, hasMore: false };
   }
   const ownerUserId = lake.createdByUserId;
   const datalakeTag = lake.datalakeTag;
 
-  const apiKeyTable = await apiKeyService.getEffectiveLLMApiKeys(
-    ownerUserId,
-    { db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository }, getSettingsByNames },
-    { logger }
-  );
-
-  // Embed each fact in the MEMENTO space (the ledger's own corpus, pinned to MEMENTO_EMBEDDING_MODEL).
-  // Best-effort: with no key we write facts WITHOUT a vector - they stay lexically recallable and the
-  // re-embed backfill vectorizes them once a key is present (mirrors createMemento's V2 write).
-  let embed: (text: string) => Promise<number[] | undefined> = async () => undefined;
-  const provider = getProviderFromModel(MEMENTO_EMBEDDING_MODEL);
-  const { config, missing } = resolveEmbeddingConfig(provider, apiKeyTable);
-  if (missing) {
-    logger.warn(`[lakeMemory] no ${provider} key for ${MEMENTO_EMBEDDING_MODEL}; writing facts without vectors`);
-  } else {
-    const svc = new EmbeddingFactory(config).createEmbeddingService(MEMENTO_EMBEDDING_MODEL);
-    embed = async text => toMementoVector(await svc.generateEmbedding(text));
+  // Per-lake concurrency guard: two near-simultaneous batch finalizes would otherwise each run a full,
+  // LLM-billed extraction of the same lake. Claim a LEASE (not a status) so a crashed run frees itself
+  // after LAKE_MEMORY_EXTRACTION_LEASE_MS without a reconciler.
+  const claimedAt = new Date();
+  const staleBefore = new Date(claimedAt.getTime() - LAKE_MEMORY_EXTRACTION_LEASE_MS);
+  const claimed = await dataLakeRepository.claimLakeMemoryExtraction(lake.id, claimedAt, staleBefore);
+  if (!claimed) {
+    logger.info('[lakeMemory] another run holds the extraction lease for this lake; skipping duplicate run', {
+      dataLakeId: params.dataLakeId,
+    });
+    return { docsProcessed: 0, factsWritten: 0, hasMore: false };
   }
 
-  const extractor = new LakeMemoryExtractionService(logger);
-  const allDocIds = await fabFileRepository.findIdsByDataLakeTag(dataLakeService.lakeMembershipScope(lake));
-  // Fetch the docs and drop tombstones BEFORE applying the cap. `findIdsByDataLakeTag` includes
-  // soft-deleted/archived ids (it must, for lifecycle), so slicing first would let tombstones consume
-  // cap slots and push live docs out - a lake of 40 tombstones + 10 live would fold nothing. Filtering
-  // first also replaces the per-doc findById with one batched read.
-  const liveDocs = (await fabFileRepository.findAllByIds(allDocIds)).filter(f => !f.deletedAt && !f.archivedAt);
-  const docs = liveDocs.slice(0, MAX_DOCS_PER_RUN);
-  if (liveDocs.length > docs.length) {
-    // Never silently truncate: a large lake covers only its first slice this run. Surfacing the
-    // remainder is what keeps "the card looks complete" from masking a partial extraction.
-    logger.warn(
-      `[lakeMemory] lake ${datalakeTag} has ${liveDocs.length} live docs; extracting ${docs.length} this run, ` +
-        `${liveDocs.length - docs.length} not yet covered (bounded-continuation follow-up)`
+  try {
+    const apiKeyTable = await apiKeyService.getEffectiveLLMApiKeys(
+      ownerUserId,
+      { db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository }, getSettingsByNames },
+      { logger }
     );
-  }
 
-  let docsProcessed = 0;
-  let factsWritten = 0;
-  let docsAttempted = 0;
-  for (const file of docs) {
-    // Yield rather than get killed. Checked BEFORE starting a doc, since the expensive, unresumable
-    // part (the LLM call) is at the start of one.
-    if (remainingMs() < LAKE_EXTRACTION_DEADLINE_BUFFER_MS) {
-      // Word this as the dead end it is. There is no cursor, no cron, and no self-re-enqueue: the only
-      // producer trigger is a batch finalize (`enqueueLakeMemoryExtractionIfWanted`), itself capped at
-      // LAKE_MEMORY_DAILY_CAP per lake per day. So these documents are NOT picked up later by anything -
-      // they wait for the next upload to that lake. Saying "not yet covered this run" would imply a
-      // follow-up run that does not exist.
-      logger.warn(
-        `[lakeMemory] lake ${datalakeTag} ran out of time after ${docsAttempted}/${docs.length} docs. ` +
-          `${docs.length - docsAttempted} document(s) are NOT extracted and nothing will retry them: the only ` +
-          `trigger is a new batch finalize for this lake. Beliefs already written are kept, and stopping here ` +
-          `avoids a redelivery re-billing the whole lake. Full coverage needs the bounded-continuation follow-up.`
-      );
-      break;
+    // Embed each fact in the MEMENTO space (the ledger's own corpus, pinned to MEMENTO_EMBEDDING_MODEL).
+    // Best-effort: with no key we write facts WITHOUT a vector - they stay lexically recallable and the
+    // re-embed backfill vectorizes them once a key is present (mirrors createMemento's V2 write).
+    let embed: (text: string) => Promise<number[] | undefined> = async () => undefined;
+    const provider = getProviderFromModel(MEMENTO_EMBEDDING_MODEL);
+    const { config, missing } = resolveEmbeddingConfig(provider, apiKeyTable);
+    if (missing) {
+      logger.warn(`[lakeMemory] no ${provider} key for ${MEMENTO_EMBEDDING_MODEL}; writing facts without vectors`);
+    } else {
+      const svc = new EmbeddingFactory(config).createEmbeddingService(MEMENTO_EMBEDDING_MODEL);
+      embed = async text => toMementoVector(await svc.generateEmbedding(text));
     }
-    docsAttempted++;
-    try {
-      const chunks = await fabFileChunkRepository.findTextsByFabFileId(file.id, { limit: CHUNK_PAGE_LIMIT });
-      const text = chunks
-        .map(c => c.text)
-        .join('\n')
-        .slice(0, MAX_DOC_CHARS);
-      if (!text.trim()) continue;
 
-      docsProcessed++;
-      const facts = await extractor.evaluate({
-        apiKeyTable,
-        docTitle: file.fileName,
-        docText: text,
-        endUserId: ownerUserId,
-      });
-      if (!facts?.length) continue;
+    const extractor = new LakeMemoryExtractionService(logger);
+    const allDocIds = await fabFileRepository.findIdsByDataLakeTag(dataLakeService.lakeMembershipScope(lake));
+    // Drop tombstones BEFORE applying the cap, and sort by id so the continuation cursor is a stable
+    // keyset boundary. `findIdsByDataLakeTag` includes soft-deleted/archived ids (it must, for
+    // lifecycle), so filtering first keeps tombstones from consuming cap slots and pushing live docs out
+    // (a lake of 40 tombstones + 10 live would otherwise fold nothing). FabFile ids are ObjectId hex,
+    // whose lexicographic order is creation order, so a new upload sorts AFTER the cursor and is picked
+    // up on a later run rather than shifting the window under an in-progress scan.
+    const liveDocs = (await fabFileRepository.findAllByIds(allDocIds))
+      .filter(f => !f.deletedAt && !f.archivedAt)
+      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
-      const tier = evidenceTierForDoc((file.tags ?? []).map(t => t.name));
-      for (const { fact } of facts) {
-        const embedding = await embed(fact).catch(() => undefined);
-        await appendFactToLedger({
-          principal: { kind: 'lake', id: datalakeTag },
-          ownerUserId,
-          summary: fact,
-          evidenceTier: tier,
-          sources: [file.id],
-          embedding,
-        });
-        factsWritten++;
+    // Bounded continuation: resume AFTER the last document a prior interrupted run attempted (the
+    // persisted cursor), not from the cap boundary - the deadline guard can end a run mid-slice, so the
+    // cap is not the only place a run stops. Absent cursor = start from the beginning.
+    const cursor = lake.lakeMemoryCursor ?? null;
+    const remainingDocs = cursor ? liveDocs.filter(f => f.id > cursor) : liveDocs;
+    const docs = remainingDocs.slice(0, MAX_DOCS_PER_RUN);
+    if (remainingDocs.length > docs.length) {
+      logger.info(
+        `[lakeMemory] lake ${datalakeTag}: ${remainingDocs.length} docs remain this scan, extracting ` +
+          `${docs.length} now; a continuation run will cover the rest`
+      );
+    }
+
+    // One de-dup session for the whole run: reads the lake's profile ONCE instead of re-decrypting the
+    // append-only chain per fact (which grows quadratically as the run's own writes lengthen it).
+    const session = await createLedgerAppendSession({
+      principal: { kind: 'lake', id: datalakeTag },
+      ownerUserId,
+    });
+
+    let docsProcessed = 0;
+    let factsWritten = 0;
+    let docsAttempted = 0;
+    let lastAttemptedId: string | null = null;
+    for (const file of docs) {
+      // Yield rather than get killed. Checked BEFORE starting a doc, since the expensive, unresumable
+      // part (the LLM call) is at the start of one. Unlike before, the uncovered docs are NOT lost: the
+      // cursor bookkeeping below persists progress and a continuation run picks them up.
+      if (remainingMs() < LAKE_EXTRACTION_DEADLINE_BUFFER_MS) {
+        logger.warn(
+          `[lakeMemory] lake ${datalakeTag} ran out of time after ${docsAttempted}/${docs.length} docs; ` +
+            `${docs.length - docsAttempted} not extracted this run. Beliefs already written are kept; stopping ` +
+            `here avoids a redelivery re-billing the whole lake, and a continuation run covers the rest.`
+        );
+        break;
       }
-    } catch (err) {
-      // One bad document must not abort the whole lake. Without this, a doc that reliably throws in
-      // extractor.evaluate aborts the run, SQS redelivers, every earlier doc is re-billed (the LLM call
-      // precedes the ledger de-dup), it throws again, and the run DLQs - docs after it never fold. Skip
-      // + log so the rest of the lake still folds; the next finalize's re-scan retries the bad doc.
+      docsAttempted++;
+      lastAttemptedId = file.id;
+      try {
+        const chunks = await fabFileChunkRepository.findTextsByFabFileId(file.id, { limit: CHUNK_PAGE_LIMIT });
+        const text = chunks
+          .map(c => c.text)
+          .join('\n')
+          .slice(0, MAX_DOC_CHARS);
+        if (!text.trim()) continue;
+
+        docsProcessed++;
+        const facts = await extractor.evaluate({
+          apiKeyTable,
+          docTitle: file.fileName,
+          docText: text,
+          endUserId: ownerUserId,
+        });
+        if (!facts?.length) continue;
+
+        const tier = evidenceTierForDoc((file.tags ?? []).map(t => t.name));
+        for (const { fact } of facts) {
+          const embedding = await embed(fact).catch(() => undefined);
+          await session.append({ summary: fact, evidenceTier: tier, sources: [file.id], embedding });
+          factsWritten++;
+        }
+      } catch (err) {
+        // One bad document must not abort the whole lake. Without this, a doc that reliably throws in
+        // extractor.evaluate aborts the run, SQS redelivers, every earlier doc is re-billed (the LLM call
+        // precedes the ledger de-dup), it throws again, and the run DLQs - docs after it never fold. Skip
+        // + log so the rest of the lake still folds; a re-scan retries the bad doc.
+        logger.warn(
+          `[lakeMemory] doc ${file.id} failed; skipping it this run: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+
+    // Continuation bookkeeping. `uncovered` counts docs in THIS scan not yet attempted, whether the run
+    // stopped at the cap or the deadline.
+    const uncovered = remainingDocs.length - docsAttempted;
+    let hasMore = false;
+    if (docsAttempted > 0 && uncovered > 0 && lastAttemptedId) {
+      try {
+        // Resume from what was ATTEMPTED, not the cap: persist the last attempted id as the cursor.
+        await dataLakeRepository.setLakeMemoryCursor(lake.id, lastAttemptedId);
+        hasMore = true; // only ask for a continuation once progress is durably recorded
+      } catch (err) {
+        // Gate hasMore on the cursor actually landing. If it will not persist, a re-enqueued
+        // continuation would read the un-advanced cursor, redo this slice and re-bill it - and a
+        // persistent failure would loop. Leave the remainder to the next batch finalize, which re-scans
+        // from the top; failing loudly here rather than papering over it.
+        logger.warn(
+          `[lakeMemory] lake ${datalakeTag} could not persist the continuation cursor; the remaining ` +
+            `${uncovered} doc(s) will be picked up on the next finalize: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+        );
+      }
+    } else if (uncovered === 0) {
+      // Whole scan covered. Clear the cursor so the next batch finalize does a fresh full re-scan, which
+      // re-asserts existing facts and keeps their ACT-R salience hot (the idempotency contract above).
+      // Best-effort: a failed clear self-heals - the next run resumes from a cursor past the last doc,
+      // finds nothing uncovered, and clears it again.
+      if (cursor) {
+        await dataLakeRepository
+          .setLakeMemoryCursor(lake.id, null)
+          .catch(err =>
+            logger.warn(
+              `[lakeMemory] lake ${datalakeTag} could not clear the continuation cursor: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            )
+          );
+      }
+    } else {
+      // uncovered > 0 but nothing attempted: the deadline hit before the first doc. Advancing the cursor
+      // or re-enqueuing here would be a no-progress loop, so do neither - the next finalize retries.
       logger.warn(
-        `[lakeMemory] doc ${file.id} failed; skipping it this run: ${err instanceof Error ? err.message : String(err)}`
+        `[lakeMemory] lake ${datalakeTag} made no progress before the deadline; ${uncovered} doc(s) still ` +
+          `uncovered, not enqueuing a continuation (would loop)`
       );
     }
-  }
 
-  logger.info('[lakeMemory] extraction complete', {
-    dataLakeId: params.dataLakeId,
-    docsProcessed,
-    factsWritten,
-    // `docsAttempted < docs.length` is the deadline-stop signal, distinct from the cap's own log above.
-    docsAttempted,
-    docsAvailableThisRun: docs.length,
-    elapsedMs: Date.now() - startedAt,
-  });
-  return { docsProcessed, factsWritten };
+    logger.info('[lakeMemory] extraction complete', {
+      dataLakeId: params.dataLakeId,
+      docsProcessed,
+      factsWritten,
+      // `docsAttempted < docs.length` is the deadline-stop signal; `hasMore` is whether a continuation
+      // was enqueued (cap or deadline left docs uncovered and we made progress).
+      docsAttempted,
+      docsAvailableThisRun: docs.length,
+      hasMore,
+      elapsedMs: Date.now() - startedAt,
+    });
+    return { docsProcessed, factsWritten, hasMore };
+  } finally {
+    // Compare-and-clear so a stale takeover's lease is not cleared by our late finish. Best-effort: a
+    // failed release just leaves the lease to expire on its own after the window.
+    await dataLakeRepository
+      .releaseLakeMemoryExtraction(lake.id, claimedAt)
+      .catch(err =>
+        logger.warn(
+          `[lakeMemory] failed to release extraction lease for ${datalakeTag}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        )
+      );
+  }
 }

--- a/apps/client/server/dataLakes/extractLakeMemoryDeadline.test.ts
+++ b/apps/client/server/dataLakes/extractLakeMemoryDeadline.test.ts
@@ -16,12 +16,20 @@ const findIdsByDataLakeTagMock = vi.fn();
 const findAllByIdsMock = vi.fn();
 const findTextsByFabFileIdMock = vi.fn();
 const evaluateMock = vi.fn();
-const appendFactToLedgerMock = vi.fn();
+const appendMock = vi.fn();
+const claimLakeMemoryExtractionMock = vi.fn();
+const releaseLakeMemoryExtractionMock = vi.fn();
+const setLakeMemoryCursorMock = vi.fn();
 
 vi.mock('@bike4mind/database', () => ({
   adminSettingsRepository: { getSettingsValue: vi.fn().mockResolvedValue(undefined) },
   apiKeyRepository: {},
-  dataLakeRepository: { findById: (...a: unknown[]) => findByIdMock(...a) },
+  dataLakeRepository: {
+    findById: (...a: unknown[]) => findByIdMock(...a),
+    claimLakeMemoryExtraction: (...a: unknown[]) => claimLakeMemoryExtractionMock(...a),
+    releaseLakeMemoryExtraction: (...a: unknown[]) => releaseLakeMemoryExtractionMock(...a),
+    setLakeMemoryCursor: (...a: unknown[]) => setLakeMemoryCursorMock(...a),
+  },
   fabFileChunkRepository: { findTextsByFabFileId: (...a: unknown[]) => findTextsByFabFileIdMock(...a) },
   fabFileRepository: {
     findIdsByDataLakeTag: (...a: unknown[]) => findIdsByDataLakeTagMock(...a),
@@ -49,7 +57,7 @@ vi.mock('@bike4mind/fab-pipeline', () => ({
 }));
 vi.mock('@bike4mind/utils', () => ({ getSettingsByNames: vi.fn() }));
 vi.mock('@server/memory/mementoLedgerMirror', () => ({
-  appendFactToLedger: (...a: unknown[]) => appendFactToLedgerMock(...a),
+  createLedgerAppendSession: async () => ({ append: (...a: unknown[]) => appendMock(...a) }),
 }));
 
 const { extractLakeMemoryForBatch } = await import('./extractLakeMemory');
@@ -69,6 +77,11 @@ const seedLake = (docCount: number) => {
 describe('extractLakeMemoryForBatch deadline guard (#1440)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Win the per-lake extraction lease by default; the concurrency-skip case overrides this.
+    claimLakeMemoryExtractionMock.mockResolvedValue(true);
+    // release/setCursor return promises - the producer awaits (and .catch-es) them.
+    releaseLakeMemoryExtractionMock.mockResolvedValue(undefined);
+    setLakeMemoryCursorMock.mockResolvedValue(undefined);
   });
 
   it('processes every doc when there is plenty of time left', async () => {
@@ -81,13 +94,17 @@ describe('extractLakeMemoryForBatch deadline guard (#1440)', () => {
     );
 
     expect(result.docsProcessed).toBe(5);
-    expect(appendFactToLedgerMock).toHaveBeenCalledTimes(5);
+    expect(result.hasMore).toBe(false);
+    expect(appendMock).toHaveBeenCalledTimes(5);
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('ran out of time'));
+    // Releases the lease it claimed.
+    expect(releaseLakeMemoryExtractionMock).toHaveBeenCalledTimes(1);
   });
 
-  it('stops cleanly, keeps what it wrote, and logs the remainder when time runs low', async () => {
+  it('stops cleanly, keeps what it wrote, and defers the remainder to a continuation when time runs low', async () => {
     // 10 docs, but the clock reports "under the buffer" from the third check onward. The run must yield
-    // rather than throw: the two docs already folded stay in the ledger.
+    // rather than throw: the two docs already folded stay in the ledger, and the rest are NOT lost - a
+    // cursor is persisted and hasMore signals the handler to re-enqueue a continuation.
     seedLake(10);
     const logger = makeLogger();
     let call = 0;
@@ -99,12 +116,11 @@ describe('extractLakeMemoryForBatch deadline guard (#1440)', () => {
     );
 
     expect(result.docsProcessed).toBe(2);
-    expect(appendFactToLedgerMock).toHaveBeenCalledTimes(2);
+    expect(result.hasMore).toBe(true);
+    expect(appendMock).toHaveBeenCalledTimes(2);
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('ran out of time after 2/10 docs'));
-    // The wording must not imply a follow-up run that does not exist: there is no cursor, no cron, and
-    // no self-re-enqueue, so the uncovered docs wait for the next batch finalize on this lake.
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('8 document(s) are NOT extracted'));
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('nothing will retry them'));
+    // The cursor resumes from the last doc ATTEMPTED (doc index 1), not the cap boundary.
+    expect(setLakeMemoryCursorMock).toHaveBeenCalledWith('lake-1', 'doc-1');
   });
 
   it('falls back to the wall clock when the Lambda clock reports a non-finite value', async () => {
@@ -164,5 +180,94 @@ describe('extractLakeMemoryForBatch deadline guard (#1440)', () => {
       '[lakeMemory] extraction complete',
       expect.objectContaining({ docsAttempted: 1, docsAvailableThisRun: 6 })
     );
+  });
+});
+
+describe('extractLakeMemoryForBatch continuation + concurrency guard (#1501)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    claimLakeMemoryExtractionMock.mockResolvedValue(true);
+    releaseLakeMemoryExtractionMock.mockResolvedValue(undefined);
+    setLakeMemoryCursorMock.mockResolvedValue(undefined);
+  });
+
+  it('skips the run entirely when another run already holds the lease', async () => {
+    seedLake(5);
+    claimLakeMemoryExtractionMock.mockResolvedValue(false);
+    const logger = makeLogger();
+
+    const result = await extractLakeMemoryForBatch(
+      { dataLakeId: 'lake-1', getRemainingTimeInMillis: () => 10 * 60_000 },
+      logger as never
+    );
+
+    expect(result).toEqual({ docsProcessed: 0, factsWritten: 0, hasMore: false });
+    expect(evaluateMock).not.toHaveBeenCalled();
+    // Nothing to release - it never won the claim.
+    expect(releaseLakeMemoryExtractionMock).not.toHaveBeenCalled();
+  });
+
+  it('signals hasMore and persists the 100th doc as the cursor when the doc cap is hit', async () => {
+    // Zero-padded ids so lexicographic order == numeric order, making the keyset boundary deterministic.
+    findByIdMock.mockResolvedValue({ id: 'lake-1', createdByUserId: 'owner-1', datalakeTag: 'datalake:test' });
+    const ids = Array.from({ length: 150 }, (_, i) => `doc-${String(i).padStart(3, '0')}`);
+    findIdsByDataLakeTagMock.mockResolvedValue(ids);
+    findAllByIdsMock.mockResolvedValue(ids.map(id => ({ id, fileName: `${id}.md`, tags: [] })));
+    findTextsByFabFileIdMock.mockResolvedValue([{ text: 'durable reference text' }]);
+    evaluateMock.mockResolvedValue([{ fact: 'a durable fact' }]);
+    const logger = makeLogger();
+
+    const result = await extractLakeMemoryForBatch(
+      { dataLakeId: 'lake-1', getRemainingTimeInMillis: () => 10 * 60_000 },
+      logger as never
+    );
+
+    expect(result.docsProcessed).toBe(100);
+    expect(result.hasMore).toBe(true);
+    expect(setLakeMemoryCursorMock).toHaveBeenCalledWith('lake-1', 'doc-099');
+    expect(releaseLakeMemoryExtractionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes from the persisted cursor and clears it once the scan reaches the end', async () => {
+    // Cursor set to doc-1, so only doc-2..doc-4 remain and all fit this run -> the scan completes and
+    // the cursor is cleared so the next finalize re-scans the whole lake.
+    findByIdMock.mockResolvedValue({
+      id: 'lake-1',
+      createdByUserId: 'owner-1',
+      datalakeTag: 'datalake:test',
+      lakeMemoryCursor: 'doc-1',
+    });
+    const ids = ['doc-0', 'doc-1', 'doc-2', 'doc-3', 'doc-4'];
+    findIdsByDataLakeTagMock.mockResolvedValue(ids);
+    findAllByIdsMock.mockResolvedValue(ids.map(id => ({ id, fileName: `${id}.md`, tags: [] })));
+    findTextsByFabFileIdMock.mockResolvedValue([{ text: 'durable reference text' }]);
+    evaluateMock.mockResolvedValue([{ fact: 'a durable fact' }]);
+    const logger = makeLogger();
+
+    const result = await extractLakeMemoryForBatch(
+      { dataLakeId: 'lake-1', getRemainingTimeInMillis: () => 10 * 60_000 },
+      logger as never
+    );
+
+    // doc-0 and doc-1 are skipped (at or before the cursor); only the 3 docs after it are processed.
+    expect(result.docsProcessed).toBe(3);
+    expect(result.hasMore).toBe(false);
+    expect(appendMock).toHaveBeenCalledTimes(3);
+    expect(setLakeMemoryCursorMock).toHaveBeenCalledWith('lake-1', null);
+  });
+
+  it('releases the lease even when every doc throws mid-run', async () => {
+    seedLake(3);
+    evaluateMock.mockRejectedValue(new Error('LLM 500'));
+    const logger = makeLogger();
+
+    const result = await extractLakeMemoryForBatch(
+      { dataLakeId: 'lake-1', getRemainingTimeInMillis: () => 10 * 60_000 },
+      logger as never
+    );
+
+    // Each doc failed and was skipped, but the run returned normally and released its lease (finally).
+    expect(result.factsWritten).toBe(0);
+    expect(releaseLakeMemoryExtractionMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/client/server/dataLakes/extractLakeMemoryDeadline.test.ts
+++ b/apps/client/server/dataLakes/extractLakeMemoryDeadline.test.ts
@@ -256,6 +256,41 @@ describe('extractLakeMemoryForBatch continuation + concurrency guard (#1501)', (
     expect(setLakeMemoryCursorMock).toHaveBeenCalledWith('lake-1', null);
   });
 
+  it('reads the continuation cursor from the post-claim snapshot, not the pre-claim read', async () => {
+    // The pre-claim findById can be stale: a run that just released the lease may have advanced the
+    // cursor in the window before this run wins the claim. Resuming from the stale value would re-scan
+    // (and re-bill) an already-covered slice. Pre-claim read reports cursor doc-0; the post-claim read
+    // reports the advanced doc-3, and the run must honor the latter.
+    const ids = ['doc-0', 'doc-1', 'doc-2', 'doc-3', 'doc-4'];
+    findIdsByDataLakeTagMock.mockResolvedValue(ids);
+    findAllByIdsMock.mockResolvedValue(ids.map(id => ({ id, fileName: `${id}.md`, tags: [] })));
+    findTextsByFabFileIdMock.mockResolvedValue([{ text: 'durable reference text' }]);
+    evaluateMock.mockResolvedValue([{ fact: 'a durable fact' }]);
+    findByIdMock
+      .mockResolvedValueOnce({
+        id: 'lake-1',
+        createdByUserId: 'owner-1',
+        datalakeTag: 'datalake:test',
+        lakeMemoryCursor: 'doc-0',
+      })
+      .mockResolvedValueOnce({
+        id: 'lake-1',
+        createdByUserId: 'owner-1',
+        datalakeTag: 'datalake:test',
+        lakeMemoryCursor: 'doc-3',
+      });
+    const logger = makeLogger();
+
+    const result = await extractLakeMemoryForBatch(
+      { dataLakeId: 'lake-1', getRemainingTimeInMillis: () => 10 * 60_000 },
+      logger as never
+    );
+
+    // Post-claim cursor doc-3 leaves only doc-4; the stale doc-0 would have reprocessed doc-1..doc-4.
+    expect(result.docsProcessed).toBe(1);
+    expect(appendMock).toHaveBeenCalledTimes(1);
+  });
+
   it('releases the lease even when every doc throws mid-run', async () => {
     seedLake(3);
     evaluateMock.mockRejectedValue(new Error('LLM 500'));

--- a/apps/client/server/dataLakes/lakeMemoryRateLimit.ts
+++ b/apps/client/server/dataLakes/lakeMemoryRateLimit.ts
@@ -11,5 +11,18 @@ export const LAKE_MEMORY_DAILY_CAP = 6;
 export const LAKE_MEMORY_RATE_LIMIT_BUCKET = 'data-lakes/lake-memory-extraction';
 export const LAKE_MEMORY_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Hard ceiling on how many slices ONE extraction chain runs before it stops re-enqueuing itself. The
+ * daily cap above bounds how OFTEN a chain STARTS (per finalize); this is the independent bound on how
+ * LONG a single chain runs, so a pathologically large lake cannot silently turn one finalize into an
+ * unbounded run of LLM-billed slices - the failure mode that only shows up on a bill.
+ *
+ * At MAX_DOCS_PER_RUN=100 docs/slice this covers up to ~2000 docs in a single chain, which comfortably
+ * clears any realistically-sized lake. A lake larger than that is not dropped: the chain logs loudly and
+ * stops, and because the continuation cursor is persisted, the next batch finalize resumes from where the
+ * chain left off. So this caps per-chain SPEND, not eventual coverage.
+ */
+export const LAKE_MEMORY_MAX_CONTINUATION_SLICES = 20;
+
 export const lakeMemoryRateLimitKey = (dataLakeId: string) =>
   `rate-limit:${dataLakeId}:${LAKE_MEMORY_RATE_LIMIT_BUCKET}`;

--- a/apps/client/server/memory/mementoLedgerMirror.test.ts
+++ b/apps/client/server/memory/mementoLedgerMirror.test.ts
@@ -1,0 +1,119 @@
+/**
+ * `createLedgerAppendSession` is the batch write seam that fixes the quadratic profile read (#1501): the
+ * per-fact path decrypted the whole append-only chain once PER FACT, so a producer folding a data lake
+ * paid O(facts x chain). These tests pin the two properties that make the hoist correct rather than just
+ * faster:
+ *   1. the profile is read ONCE for the whole run (and only when a fact actually carries an embedding), and
+ *   2. de-dup still coalesces a later fact with an earlier one from the SAME run - the behaviour the
+ *      per-fact re-read used to give for free, now carried by an in-memory set kept current as it writes.
+ *
+ * `appendMemoryEvent` and the profile read are mocked (this is not a persistence test); `resolveSubject`
+ * and `cosineSimilarity` are the REAL implementations, so subject selection is exercised for real.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const appendMemoryEventMock = vi.fn();
+const readProfileMock = vi.fn();
+
+vi.mock('@bike4mind/database', () => ({
+  memoryLedgerRepository: {},
+  memoryPrincipalKeyRepository: {},
+  userRepository: {},
+}));
+vi.mock('@bike4mind/common', () => ({
+  MEMENTO_DEDUP_SIMILARITY: 0.85,
+  isExperimentalFeatureEnabled: () => false,
+}));
+vi.mock('./ledgerMemoryStore', () => ({
+  appendMemoryEvent: (...a: unknown[]) => appendMemoryEventMock(...a),
+  createLedgerMemoryStore: () => ({ readProfile: (...a: unknown[]) => readProfileMock(...a) }),
+}));
+vi.mock('./factCipher', () => ({ createKeyProvider: () => ({}) }));
+
+const { createLedgerAppendSession } = await import('./mementoLedgerMirror');
+const { resolveSubject } = await import('@bike4mind/memory');
+
+// The subject/options a captured appendMemoryEvent call was made with.
+const callSubject = (i: number) => appendMemoryEventMock.mock.calls[i][3].subject as string;
+const callHashed = (i: number) => appendMemoryEventMock.mock.calls[i][4].subjectIsHashed as boolean;
+
+const LAKE = { principal: { kind: 'lake' as const, id: 'datalake:test' }, ownerUserId: 'owner-1' };
+
+describe('createLedgerAppendSession - hoisted de-dup (#1501)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appendMemoryEventMock.mockResolvedValue(undefined);
+  });
+
+  it('reads the profile once for the whole run and coalesces across existing AND same-run beliefs', async () => {
+    // One existing belief whose id IS its stored subject HMAC, embedded near [1,0,0].
+    readProfileMock.mockResolvedValue({
+      principal: LAKE.principal,
+      beliefs: [{ id: 'HMAC_existing', shredded: false, embedding: [1, 0, 0] }],
+    });
+
+    const session = await createLedgerAppendSession(LAKE);
+
+    // Two facts near the existing belief -> both assert under its HMAC, marked already-hashed.
+    await session.append({
+      summary: 'the reactor core temperature is 900 degrees',
+      evidenceTier: 'external-facing',
+      embedding: [1, 0, 0],
+    });
+    await session.append({
+      summary: 'reactor core runs at nine hundred degrees celsius',
+      evidenceTier: 'external-facing',
+      embedding: [1, 0, 0],
+    });
+
+    // A fact orthogonal to the existing belief -> a NEW plaintext subject.
+    const f3 = 'the coolant pump model is XZ-40';
+    await session.append({ summary: f3, evidenceTier: 'external-facing', embedding: [0, 1, 0] });
+    // A fourth fact near f3 (but far from the existing belief) must coalesce with f3 - proving the
+    // in-memory set carries same-run writes, which a hoisted single read would otherwise miss.
+    await session.append({
+      summary: 'coolant pump is the XZ-40 unit',
+      evidenceTier: 'external-facing',
+      embedding: [0, 1, 0],
+    });
+
+    expect(appendMemoryEventMock).toHaveBeenCalledTimes(4);
+    expect(callSubject(0)).toBe('HMAC_existing');
+    expect(callHashed(0)).toBe(true);
+    expect(callSubject(1)).toBe('HMAC_existing');
+    expect(callHashed(1)).toBe(true);
+
+    const f3Subject = resolveSubject({ fact: f3 });
+    expect(callSubject(2)).toBe(f3Subject);
+    expect(callHashed(2)).toBe(false);
+    // f4 coalesced with f3: same subject, still plaintext (a freshly derived subject, not an HMAC).
+    expect(callSubject(3)).toBe(f3Subject);
+    expect(callHashed(3)).toBe(false);
+
+    // The whole point: ONE profile read, not one per fact.
+    expect(readProfileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never reads the profile when no fact carries an embedding (lazy load)', async () => {
+    const session = await createLedgerAppendSession(LAKE);
+
+    await session.append({ summary: 'a durable fact with no vector', evidenceTier: 'external-facing' });
+
+    expect(appendMemoryEventMock).toHaveBeenCalledTimes(1);
+    expect(callHashed(0)).toBe(false); // fresh plaintext subject
+    expect(readProfileMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to writing (no coalesce) when the profile read fails', async () => {
+    readProfileMock.mockRejectedValue(new Error('mongo down'));
+    const session = await createLedgerAppendSession(LAKE);
+
+    const summary = 'a fact whose de-dup lookup could not run';
+    await session.append({ summary, evidenceTier: 'external-facing', embedding: [1, 0, 0] });
+
+    // The fact is still written, under its freshly derived (plaintext) subject.
+    expect(appendMemoryEventMock).toHaveBeenCalledTimes(1);
+    expect(callSubject(0)).toBe(resolveSubject({ fact: summary }));
+    expect(callHashed(0)).toBe(false);
+  });
+});

--- a/apps/client/server/memory/mementoLedgerMirror.ts
+++ b/apps/client/server/memory/mementoLedgerMirror.ts
@@ -32,43 +32,148 @@ export async function isMementosV2Enabled(userId: string): Promise<boolean> {
   return isExperimentalFeatureEnabled(user, 'enableMementosV2');
 }
 
+/** One in-memory de-dup candidate for a write session, matched by embedding cosine. */
+type DedupEntry = {
+  /** The value to pass as the assert's subject to coalesce with this belief. */
+  subject: string;
+  /** Whether `subject` is ALREADY the stored HMAC (an existing belief) or plaintext (a fresh subject). */
+  subjectIsHashed: boolean;
+  embedding: number[];
+};
+
+/** The best (highest-cosine) entry at or above the de-dup threshold, or null. Pure. */
+function bestDedupMatch(entries: DedupEntry[], embedding: number[]): DedupEntry | null {
+  let best: DedupEntry | null = null;
+  let bestSimilarity = -Infinity;
+  for (const entry of entries) {
+    const similarity = cosineSimilarity(embedding, entry.embedding);
+    if (similarity >= MEMENTO_DEDUP_SIMILARITY && similarity > bestSimilarity) {
+      best = entry;
+      bestSimilarity = similarity;
+    }
+  }
+  return best;
+}
+
+/** A batched append session for one principal's ledger. See `createLedgerAppendSession`. */
+export interface LedgerAppendSession {
+  append(fact: {
+    summary: string;
+    evidenceTier: EvidenceTier;
+    sources?: string[];
+    embedding?: number[];
+  }): Promise<void>;
+}
+
 /**
- * Write one extracted fact into the user's ledger as an `assert`. This is V2's OWN write path - it
- * does not require, read, or produce a V1 memento, which is what lets V1 be switched off (and one day
- * deleted) without memory going deaf.
+ * Open a batched write session for ONE principal's ledger. This is the principal-generic core of the V2
+ * write path: `appendFactToLedger` is the single-fact convenience wrapper, `writeFactToLedger` is the
+ * user specialization, and the lake-memory producer (#1440) is the batch caller, writing under
+ * `{ kind: 'lake', id: datalakeTag }` owned by the lake's creator. `ownerUserId` is the DEK owner (whose
+ * key seals the fact + vector at rest), which is a user even when the principal is not.
  *
- * The fact is the LLM's summary; the evidence tier is the lowest (`engineering-proxy`) because a
- * memento is an unverified extraction. The fact and its vector are encrypted at rest under the user's
- * key, so a crypto-shred takes both.
+ * SUBJECT SELECTION is the whole game, because the subject is the belief's identity: the fold keys
+ * beliefs by it, so an assert on an EXISTING subject updates that belief in place and counts as another
+ * presentation of it (raising its ACT-R activation), while an assert on a NEW subject creates a second
+ * belief. The default subject is derived from the fact's words (`resolveSubject`), a sorted token bag
+ * that coalesces only on near-identical wording ("favorite color is green" vs "favourite colour is
+ * green" would fork into two). So when an embedding is supplied we first look for a semantic
+ * near-duplicate and, if one exists, assert under ITS subject.
  *
- * SUBJECT SELECTION is the whole game here, because the subject is the belief's identity: the fold
- * keys beliefs by it, so an assert on an EXISTING subject replaces that belief's content and counts as
- * another presentation of it (raising its ACT-R activation), while an assert on a NEW subject creates
- * a second belief.
+ * WHY A SESSION rather than a per-fact function: finding that near-duplicate means reading the
+ * principal's profile, which decrypts the whole append-only chain. A producer folding a data lake
+ * appends hundreds of facts in a loop, so re-reading per fact is O(facts x chain) - quadratic in the
+ * run, and worsening as the run's OWN writes lengthen the chain. The session reads the profile ONCE
+ * (lazily, on the first fact that actually carries an embedding) and de-dups every fact against an
+ * in-memory set it keeps current as it writes - so a later fact still coalesces with an earlier one from
+ * the same run, exactly as the per-fact re-read used to, without re-decrypting the chain.
  *
- * The default subject is derived from the fact's words (`resolveSubject`), which coalesces only on
- * near-identical WORDING - it is a sorted bag of tokens. That is too brittle on its own: "User's
- * favorite color is green" and "User said their favourite colour is green" are the same belief stated
- * twice, and would become two. So we first look for a semantic near-duplicate among the beliefs the
- * user already has and, if one exists, assert under ITS subject. The fact then updates in place and
- * the re-mention makes it hotter - which is exactly what a user repeating themselves should do, and
- * strictly more than V1 managed (it bumped a weight and lost the frequency signal entirely).
+ * Best-effort: a profile read that fails leaves the set empty and is logged, so facts still get written
+ * (possibly as duplicate beliefs - a cosmetic loss, never a lost fact), mirroring the old per-fact path.
  */
+export async function createLedgerAppendSession(params: {
+  principal: Principal;
+  /** DEK owner - the user whose key seals this principal's facts at rest. */
+  ownerUserId: string;
+}): Promise<LedgerAppendSession> {
+  const keys = createKeyProvider(memoryPrincipalKeyRepository);
+  const entries: DedupEntry[] = [];
+  let profileLoaded = false;
+
+  // Lazy: a run with no embeddings (no API key) never needs the profile, so it never pays the decrypt -
+  // the same "no embedding -> no read" shortcut the single-fact path had.
+  const ensureProfileLoaded = async (): Promise<void> => {
+    if (profileLoaded) return;
+    profileLoaded = true;
+    try {
+      const store = createLedgerMemoryStore({
+        ledger: memoryLedgerRepository,
+        keys,
+        ownerUserId: params.ownerUserId,
+      });
+      const profile = await store.readProfile(params.principal);
+      for (const belief of profile?.beliefs ?? []) {
+        if (belief.shredded || !belief.embedding?.length) continue;
+        // A folded belief's id IS its stored subject HMAC (subjects are never kept in plaintext), so it
+        // re-asserts with subjectIsHashed to avoid a double-hash that would fork instead of coalesce.
+        entries.push({ subject: belief.id, subjectIsHashed: true, embedding: belief.embedding });
+      }
+    } catch (error) {
+      console.warn(
+        `[Mementos V2] de-dup profile read failed; facts this run may store as duplicate beliefs: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  };
+
+  return {
+    async append(fact) {
+      const derivedSubject = resolveSubject({ fact: fact.summary });
+      if (!derivedSubject) return; // nothing to key on (content-free summary)
+
+      let match: DedupEntry | null = null;
+      if (fact.embedding?.length) {
+        await ensureProfileLoaded();
+        match = bestDedupMatch(entries, fact.embedding);
+      }
+
+      await appendMemoryEvent(
+        memoryLedgerRepository,
+        keys,
+        params.ownerUserId,
+        {
+          principal: params.principal,
+          kind: 'assert',
+          subject: match ? match.subject : derivedSubject,
+          fact: fact.summary,
+          evidenceTier: fact.evidenceTier,
+          at: new Date().toISOString(),
+          sources: fact.sources,
+          embedding: fact.embedding,
+        },
+        // Carry the matched entry's OWN flag - a match can be an existing belief (id is already the
+        // stored HMAC) OR a same-run new belief (its subject is still the plaintext derived one, so it
+        // must be hashed here to land on the SAME stored HMAC and coalesce). No match -> a fresh
+        // plaintext subject that needs hashing. Forcing `match !== null` would store a same-run new
+        // subject as if already hashed and silently fork instead of coalescing.
+        { subjectIsHashed: match ? match.subjectIsHashed : false }
+      );
+
+      // Keep the in-memory set current so a later fact in this run coalesces with this one, exactly as
+      // the per-fact profile re-read used to. On a coalesce the assert's embedding wins (mirrors the
+      // fold), so update it; a genuinely new belief joins the set under its plaintext derived subject.
+      if (fact.embedding?.length) {
+        if (match) match.embedding = fact.embedding;
+        else entries.push({ subject: derivedSubject, subjectIsHashed: false, embedding: fact.embedding });
+      }
+    },
+  };
+}
+
 /**
- * Write one extracted fact into an ARBITRARY principal's ledger as an `assert`. The principal-generic
- * core of the write path: `writeFactToLedger` is its user specialization, and the lake-memory producer
- * (#1440) is the other caller, writing under `{ kind: 'lake', id: datalakeTag }` owned by the lake's
- * creator. `ownerUserId` is the DEK owner (whose key encrypts the fact + vector at rest), which is a
- * user even when the principal is not - a lake's beliefs are readable only to a chat resolving that
- * owner's key, exactly as owner-scoped reads require.
- *
- * SUBJECT SELECTION is the whole game here, because the subject is the belief's identity: the fold
- * keys beliefs by it, so an assert on an EXISTING subject replaces that belief's content and counts as
- * another presentation of it (raising its ACT-R activation), while an assert on a NEW subject creates
- * a second belief. The default subject is derived from the fact's words (`resolveSubject`), a sorted
- * token bag that coalesces only on near-identical wording; when an embedding is supplied we first look
- * for a semantic near-duplicate among the principal's existing beliefs and, if one exists, assert under
- * ITS subject so the fact updates in place and the re-mention makes it hotter.
+ * Write ONE extracted fact into an arbitrary principal's ledger as an `assert` - the single-fact
+ * convenience wrapper over `createLedgerAppendSession` (see there for subject-selection and de-dup).
  */
 export async function appendFactToLedger(params: {
   principal: Principal;
@@ -79,34 +184,13 @@ export async function appendFactToLedger(params: {
   sources?: string[];
   embedding?: number[];
 }): Promise<void> {
-  const derivedSubject = resolveSubject({ fact: params.summary });
-  if (!derivedSubject) return; // nothing to key on (content-free summary)
-
-  const keys = createKeyProvider(memoryPrincipalKeyRepository);
-  const existing = params.embedding?.length
-    ? await findExistingSubject(params.principal, params.ownerUserId, keys, params.embedding)
-    : null;
-
-  await appendMemoryEvent(
-    memoryLedgerRepository,
-    keys,
-    params.ownerUserId,
-    {
-      principal: params.principal,
-      kind: 'assert',
-      subject: existing ?? derivedSubject,
-      fact: params.summary,
-      evidenceTier: params.evidenceTier,
-      at: new Date().toISOString(),
-      sources: params.sources,
-      embedding: params.embedding,
-    },
-    // A subject recovered from an existing belief is ALREADY the HMAC (the ledger never stores it in
-    // plaintext), so it must not be hashed a second time - that would key the assert to nothing and
-    // duplicate the belief instead of coalescing it. A freshly derived subject is plaintext and does
-    // need hashing.
-    { subjectIsHashed: existing !== null }
-  );
+  const session = await createLedgerAppendSession({ principal: params.principal, ownerUserId: params.ownerUserId });
+  await session.append({
+    summary: params.summary,
+    evidenceTier: params.evidenceTier,
+    sources: params.sources,
+    embedding: params.embedding,
+  });
 }
 
 /**
@@ -132,51 +216,4 @@ export async function writeFactToLedger(params: {
     sources: params.sources,
     embedding: params.embedding,
   });
-}
-
-/**
- * The subject of the principal's existing belief that this fact is a restatement of, or null if it is
- * new.
- *
- * Compares against the LEDGER's own beliefs only - not the V1 union. A V1 memento's belief id is a
- * Mongo id, not a subject key, so asserting under it would mint a belief the fold can never coalesce.
- * The read path already de-dups the union by fact text, and legacy mementos age out.
- *
- * Returns the belief's id, which IS its subject - and note that the ledger stores subjects HMAC'd, so
- * what comes back is the HASH. The caller must pass it to `appendMemoryEvent` with
- * `subjectIsHashed`, or it gets hashed twice and coalesces with nothing.
- *
- * Best-effort: if the ledger cannot be read, fall back to a fresh subject. A duplicate belief is a
- * cosmetic loss; failing the write would lose the fact entirely. The failure is LOGGED rather than
- * swallowed silently - a de-dup that has quietly stopped working looks exactly like a user who repeats
- * themselves a lot, which is to say it looks like nothing at all.
- */
-async function findExistingSubject(
-  principal: Principal,
-  ownerUserId: string,
-  keys: ReturnType<typeof createKeyProvider>,
-  embedding: number[]
-): Promise<string | null> {
-  try {
-    const store = createLedgerMemoryStore({ ledger: memoryLedgerRepository, keys, ownerUserId });
-    const profile = await store.readProfile(principal);
-    if (!profile) return null;
-
-    let best: { subject: string; similarity: number } | null = null;
-    for (const belief of profile.beliefs) {
-      if (belief.shredded || !belief.embedding?.length) continue;
-      const similarity = cosineSimilarity(embedding, belief.embedding);
-      if (similarity >= MEMENTO_DEDUP_SIMILARITY && (!best || similarity > best.similarity)) {
-        best = { subject: belief.id, similarity }; // the fold keys beliefs BY subject, so id IS subject
-      }
-    }
-    return best?.subject ?? null;
-  } catch (error) {
-    console.warn(
-      `[Mementos V2] de-dup lookup failed; this fact may be stored as a duplicate belief: ${
-        error instanceof Error ? error.message : String(error)
-      }`
-    );
-    return null;
-  }
 }

--- a/apps/client/server/queueHandlers/lakeMemoryExtraction.test.ts
+++ b/apps/client/server/queueHandlers/lakeMemoryExtraction.test.ts
@@ -12,6 +12,7 @@ import type { Context, SQSEvent } from 'aws-lambda';
 
 const getSettingsValueMock = vi.fn();
 const extractMock = vi.fn();
+const sendToQueueMock = vi.fn();
 
 // Pass the inner handler straight through so the test drives it directly, skipping connectDB and the
 // warmer-invocation shortcut that the real wrapper performs.
@@ -26,6 +27,8 @@ vi.mock('@bike4mind/database', () => ({
 vi.mock('@server/dataLakes/extractLakeMemory', () => ({
   extractLakeMemoryForBatch: (...a: unknown[]) => extractMock(...a),
 }));
+vi.mock('@server/utils/sqs', () => ({ sendToQueue: (...a: unknown[]) => sendToQueueMock(...a) }));
+vi.mock('sst', () => ({ Resource: { lakeMemoryQueue: { url: 'https://sqs.example/lake-memory' } } }));
 
 const { dispatch } = await import('./lakeMemoryExtraction');
 
@@ -36,7 +39,7 @@ const PAYLOAD = { batchId: 'batch-1', dataLakeId: 'lake-1', userId: 'user-1' };
 describe('lakeMemoryExtraction handler (#1440)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    extractMock.mockResolvedValue({ docsProcessed: 1, factsWritten: 1 });
+    extractMock.mockResolvedValue({ docsProcessed: 1, factsWritten: 1, hasMore: false });
   });
 
   it('extracts when EnableLakeMemory is on', async () => {
@@ -46,6 +49,27 @@ describe('lakeMemoryExtraction handler (#1440)', () => {
 
     expect(getSettingsValueMock).toHaveBeenCalledWith('EnableLakeMemory');
     expect(extractMock).toHaveBeenCalledTimes(1);
+    // Fully covered (hasMore:false) -> no continuation enqueued.
+    expect(sendToQueueMock).not.toHaveBeenCalled();
+  });
+
+  it('re-enqueues a continuation run when the lake was not fully covered', async () => {
+    getSettingsValueMock.mockResolvedValue(true);
+    extractMock.mockResolvedValue({ docsProcessed: 100, factsWritten: 250, hasMore: true });
+
+    await dispatch(event(PAYLOAD), context());
+
+    // Same payload re-queued; the next invocation resumes from the persisted cursor.
+    expect(sendToQueueMock).toHaveBeenCalledWith('https://sqs.example/lake-memory', PAYLOAD);
+  });
+
+  it('does not re-enqueue a continuation when the flag was turned off after enqueue', async () => {
+    getSettingsValueMock.mockResolvedValue(false);
+
+    await dispatch(event(PAYLOAD), context());
+
+    expect(extractMock).not.toHaveBeenCalled();
+    expect(sendToQueueMock).not.toHaveBeenCalled();
   });
 
   it('drops a queued extraction when the flag was turned off after enqueue', async () => {

--- a/apps/client/server/queueHandlers/lakeMemoryExtraction.test.ts
+++ b/apps/client/server/queueHandlers/lakeMemoryExtraction.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Context, SQSEvent } from 'aws-lambda';
+import { LAKE_MEMORY_MAX_CONTINUATION_SLICES } from '@server/dataLakes/lakeMemoryRateLimit';
 
 const getSettingsValueMock = vi.fn();
 const extractMock = vi.fn();
@@ -59,8 +60,21 @@ describe('lakeMemoryExtraction handler (#1440)', () => {
 
     await dispatch(event(PAYLOAD), context());
 
-    // Same payload re-queued; the next invocation resumes from the persisted cursor.
-    expect(sendToQueueMock).toHaveBeenCalledWith('https://sqs.example/lake-memory', PAYLOAD);
+    // Same payload re-queued with the next slice; the next invocation resumes from the persisted cursor.
+    expect(sendToQueueMock).toHaveBeenCalledWith('https://sqs.example/lake-memory', { ...PAYLOAD, slice: 1 });
+  });
+
+  it('stops the continuation chain at the slice ceiling instead of re-enqueuing unbounded', async () => {
+    // A pathologically large lake keeps returning hasMore. The chain must not grow without limit: once
+    // the slice count reaches LAKE_MEMORY_MAX_CONTINUATION_SLICES the handler stops re-enqueuing and logs,
+    // leaving the persisted cursor for the next finalize to resume from.
+    getSettingsValueMock.mockResolvedValue(true);
+    extractMock.mockResolvedValue({ docsProcessed: 100, factsWritten: 250, hasMore: true });
+
+    await dispatch(event({ ...PAYLOAD, slice: LAKE_MEMORY_MAX_CONTINUATION_SLICES - 1 }), context());
+
+    expect(extractMock).toHaveBeenCalledTimes(1);
+    expect(sendToQueueMock).not.toHaveBeenCalled();
   });
 
   it('does not re-enqueue a continuation when the flag was turned off after enqueue', async () => {

--- a/apps/client/server/queueHandlers/lakeMemoryExtraction.ts
+++ b/apps/client/server/queueHandlers/lakeMemoryExtraction.ts
@@ -1,5 +1,6 @@
 import { dispatchWithLogger } from '@server/queueHandlers/utils';
 import { extractLakeMemoryForBatch } from '@server/dataLakes/extractLakeMemory';
+import { LAKE_MEMORY_MAX_CONTINUATION_SLICES } from '@server/dataLakes/lakeMemoryRateLimit';
 import { adminSettingsRepository } from '@bike4mind/database';
 import { sendToQueue } from '@server/utils/sqs';
 import { Resource } from 'sst';
@@ -9,6 +10,10 @@ const LakeMemoryPayload = z.object({
   batchId: z.string(),
   dataLakeId: z.string(),
   userId: z.string(),
+  // Continuation depth: 0 for the finalize-triggered run, incremented on each self-re-enqueue. Bounds
+  // the chain length (LAKE_MEMORY_MAX_CONTINUATION_SLICES) so a huge lake cannot chain unbounded. Absent
+  // on the finalize enqueue, so it defaults to 0.
+  slice: z.number().int().nonnegative().default(0),
 });
 
 /**
@@ -48,17 +53,33 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
     );
 
     // Bounded continuation: a lake too large for one invocation persisted a cursor and asked for another
-    // run. Re-enqueue the SAME payload; the next invocation resumes from the cursor and re-checks the
-    // kill-switch at entry (above), so a flag flip between slices stops the chain. Progress is monotonic
-    // (the cursor only advances and a no-progress run returns hasMore:false), so the chain terminates.
+    // run. Re-enqueue the same payload with an incremented slice; the next invocation resumes from the
+    // cursor and re-checks the kill-switch at entry (above), so a flag flip between slices stops the
+    // chain. Progress is monotonic (the cursor only advances and a no-progress run returns hasMore:false),
+    // so the chain terminates - but a pathologically large lake could still chain far enough to run up a
+    // surprising LLM bill, so cap the chain length independently of that.
     if (hasMore) {
+      const nextSlice = payload.slice + 1;
+      if (nextSlice >= LAKE_MEMORY_MAX_CONTINUATION_SLICES) {
+        // The daily cap bounds how often a chain starts; this bounds how long one chain runs. Coverage is
+        // not lost: the persisted cursor lets the next batch finalize resume from where this chain
+        // stopped. Log loudly so an oversized lake surfaces here rather than on a bill.
+        logger.warn('[lakeMemory] continuation chain hit the slice ceiling; not enqueuing further', {
+          dataLakeId: payload.dataLakeId,
+          slice: payload.slice,
+          maxSlices: LAKE_MEMORY_MAX_CONTINUATION_SLICES,
+        });
+        return;
+      }
       await sendToQueue(Resource.lakeMemoryQueue.url, {
         batchId: payload.batchId,
         dataLakeId: payload.dataLakeId,
         userId: payload.userId,
+        slice: nextSlice,
       });
       logger.info('[lakeMemory] enqueued continuation run for the remaining docs', {
         dataLakeId: payload.dataLakeId,
+        slice: nextSlice,
       });
     }
   } catch (err) {

--- a/apps/client/server/queueHandlers/lakeMemoryExtraction.ts
+++ b/apps/client/server/queueHandlers/lakeMemoryExtraction.ts
@@ -1,6 +1,8 @@
 import { dispatchWithLogger } from '@server/queueHandlers/utils';
 import { extractLakeMemoryForBatch } from '@server/dataLakes/extractLakeMemory';
 import { adminSettingsRepository } from '@bike4mind/database';
+import { sendToQueue } from '@server/utils/sqs';
+import { Resource } from 'sst';
 import { z, ZodError } from 'zod';
 
 const LakeMemoryPayload = z.object({
@@ -39,11 +41,26 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
       return;
     }
 
-    await extractLakeMemoryForBatch(
+    const { hasMore } = await extractLakeMemoryForBatch(
       // Real Lambda clock, so the deadline guard accounts for cold start and time already spent.
       { dataLakeId: payload.dataLakeId, getRemainingTimeInMillis: () => context.getRemainingTimeInMillis() },
       logger
     );
+
+    // Bounded continuation: a lake too large for one invocation persisted a cursor and asked for another
+    // run. Re-enqueue the SAME payload; the next invocation resumes from the cursor and re-checks the
+    // kill-switch at entry (above), so a flag flip between slices stops the chain. Progress is monotonic
+    // (the cursor only advances and a no-progress run returns hasMore:false), so the chain terminates.
+    if (hasMore) {
+      await sendToQueue(Resource.lakeMemoryQueue.url, {
+        batchId: payload.batchId,
+        dataLakeId: payload.dataLakeId,
+        userId: payload.userId,
+      });
+      logger.info('[lakeMemory] enqueued continuation run for the remaining docs', {
+        dataLakeId: payload.dataLakeId,
+      });
+    }
   } catch (err) {
     // Permanently-invalid message (malformed payload) - retrying can't fix it.
     if (err instanceof ZodError || err instanceof SyntaxError) {

--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -108,6 +108,23 @@ export interface IDataLake {
    * behavior) rather than restoring nothing.
    */
   filesDeletedAt?: Date | null;
+  /**
+   * Lake-memory producer (#1440) bookkeeping - server-managed, never client input.
+   *
+   * A concurrency LEASE, not a status: a run stamps it to claim the lake and clears it when done, so a
+   * second near-simultaneous batch finalize that finds a fresh stamp skips its (LLM-billed, redundant)
+   * extraction. A lease rather than a boolean so a crashed run frees itself once the stamp ages past the
+   * lease window, without needing a reconciler. Absent/null = no run holds the lease.
+   */
+  lakeMemoryExtractionAt?: Date | null;
+  /**
+   * Bounded-continuation watermark for the lake-memory producer (#1440): the id of the last document an
+   * interrupted run ATTEMPTED. The next run resumes from the document after it (keyset), so a lake too
+   * large for one Lambda invocation is covered across chained runs instead of silently truncated.
+   * Cleared once a scan reaches the end, so the following finalize does a fresh whole-lake re-scan (which
+   * re-asserts existing facts and keeps them hot). Absent/null = start from the beginning.
+   */
+  lakeMemoryCursor?: string | null;
 }
 
 export interface IDataLakeDocument extends IDataLake, IMongoDocument {}
@@ -183,6 +200,25 @@ export interface IDataLakeRepository extends IBaseRepository<IDataLakeDocument> 
    * caller sweeps unmarked and must say so, since that lake then restores unbounded.
    */
   claimFilesDeletedAt(id: string, at: Date): Promise<Date | null>;
+  /**
+   * Per-lake concurrency claim for the memory producer (#1440): stamp `lakeMemoryExtractionAt = at` only
+   * if no run currently holds the lease - the field is unset, OR its stamp is older than `staleBefore`
+   * (a crashed run's expired lease). Returns whether THIS caller won the claim. Guarded in the query, so
+   * a concurrent claimer that already stamped a FRESH value makes this a no-op; exactly one run wins.
+   */
+  claimLakeMemoryExtraction(id: string, at: Date, staleBefore: Date): Promise<boolean>;
+  /**
+   * Release the extraction lease, but only if THIS run still holds it (the stamp still equals
+   * `claimedAt`). The guard matters when a stale takeover occurred mid-run: a late finish must not clear
+   * the lease a newer run has since claimed.
+   */
+  releaseLakeMemoryExtraction(id: string, claimedAt: Date): Promise<void>;
+  /**
+   * Persist (with a doc id) or clear (with null) the bounded-continuation cursor - the id of the last
+   * document the current scan attempted. Null marks the scan complete, so the next finalize re-scans the
+   * whole lake.
+   */
+  setLakeMemoryCursor(id: string, cursor: string | null): Promise<void>;
 }
 
 // ── Data Lake Batch ─────────────────────────────────────────────────────────

--- a/b4m-core/services/src/dataLakeService/redactLakeForActor.ts
+++ b/b4m-core/services/src/dataLakeService/redactLakeForActor.ts
@@ -72,6 +72,10 @@ export const LAKE_FIELD_VISIBILITY: Record<keyof IDataLake, 'reader' | 'withheld
   lastSyncAt: 'reader',
   // Teardown bookkeeping: of no use to a reader, and it reports when the owner tore the lake down.
   filesDeletedAt: 'withheld',
+  // Lake-memory producer bookkeeping (#1440): internal lease + continuation cursor. Of no use to a
+  // reader, and the lease timestamp would leak when/whether extraction is running.
+  lakeMemoryExtractionAt: 'withheld',
+  lakeMemoryCursor: 'withheld',
 };
 
 /**

--- a/infra/queues.ts
+++ b/infra/queues.ts
@@ -728,7 +728,10 @@ const lakeMemoryQueueSubscription = lakeMemoryQueue.subscribe(
     runtime: 'nodejs24.x',
     timeout: '10 minutes',
     vpc: lambdaVpc,
-    link: [...allSecrets, websocketApi],
+    // lakeMemoryQueue: this handler self-re-enqueues for bounded continuation (a lake too large for one
+    // run sends the next slice's message to its own queue), so it needs Resource.lakeMemoryQueue.url and
+    // the sqs:SendMessage grant that linking the queue confers.
+    link: [...allSecrets, websocketApi, lakeMemoryQueue],
     logging: {
       retention: '3 days',
     },

--- a/packages/database/src/models/ai/DataLakeModel.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.test.ts
@@ -563,6 +563,62 @@ describe('DataLakeRepository - fileTagPrefix is unique per creator (DB backstop)
   });
 });
 
+describe('DataLakeRepository - lake-memory extraction lease + continuation cursor (#1501)', () => {
+  setupMongoTest();
+
+  const makeLake = () => dataLakeRepository.create(baseLake({ slug: 'mem-lake' }));
+
+  it('claims the lease when free, blocks a fresh concurrent claim, and frees it on release', async () => {
+    const lake = await makeLake();
+    const t1 = new Date('2026-01-01T00:00:00Z');
+    const staleBefore1 = new Date(t1.getTime() - 15 * 60_000);
+    expect(await dataLakeRepository.claimLakeMemoryExtraction(lake.id, t1, staleBefore1)).toBe(true);
+
+    // A run a minute later sees a FRESH stamp (not older than its staleBefore) and loses.
+    const t2 = new Date('2026-01-01T00:01:00Z');
+    const staleBefore2 = new Date(t2.getTime() - 15 * 60_000);
+    expect(await dataLakeRepository.claimLakeMemoryExtraction(lake.id, t2, staleBefore2)).toBe(false);
+
+    // The holder releases and the lease is claimable again.
+    await dataLakeRepository.releaseLakeMemoryExtraction(lake.id, t1);
+    expect((await dataLakeRepository.findById(lake.id))?.lakeMemoryExtractionAt ?? null).toBeNull();
+    expect(await dataLakeRepository.claimLakeMemoryExtraction(lake.id, t2, staleBefore2)).toBe(true);
+  });
+
+  it('reclaims a lease whose stamp has aged past the window (crashed run, no reconciler)', async () => {
+    const lake = await makeLake();
+    await DataLakeModel.updateOne(
+      { _id: lake.id },
+      { $set: { lakeMemoryExtractionAt: new Date('2026-01-01T00:00:00Z') } }
+    );
+
+    const now = new Date('2026-01-01T01:00:00Z'); // an hour later - well past the 15-minute lease
+    const staleBefore = new Date(now.getTime() - 15 * 60_000);
+    expect(await dataLakeRepository.claimLakeMemoryExtraction(lake.id, now, staleBefore)).toBe(true);
+  });
+
+  it('release is a compare-and-clear: a late finish does not clear a newer run lease', async () => {
+    const lake = await makeLake();
+    const mine = new Date('2026-01-01T00:00:00Z');
+    // A stale takeover has since replaced my stamp with a newer one.
+    const newer = new Date('2026-01-01T00:30:00Z');
+    await DataLakeModel.updateOne({ _id: lake.id }, { $set: { lakeMemoryExtractionAt: newer } });
+
+    await dataLakeRepository.releaseLakeMemoryExtraction(lake.id, mine);
+    const after = await dataLakeRepository.findById(lake.id);
+    expect(after?.lakeMemoryExtractionAt?.getTime()).toBe(newer.getTime());
+  });
+
+  it('persists and clears the continuation cursor', async () => {
+    const lake = await makeLake();
+    await dataLakeRepository.setLakeMemoryCursor(lake.id, 'doc-42');
+    expect((await dataLakeRepository.findById(lake.id))?.lakeMemoryCursor).toBe('doc-42');
+
+    await dataLakeRepository.setLakeMemoryCursor(lake.id, null);
+    expect((await dataLakeRepository.findById(lake.id))?.lakeMemoryCursor ?? null).toBeNull();
+  });
+});
+
 describe('DataLakeBatchRepository.markTerminalIfActive — completionReason', () => {
   setupMongoTest();
 

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -76,6 +76,12 @@ const DataLakeSchema = new mongoose.Schema(
     // no sweep ever wrote, and the restore keyed to it reverses nothing. Restore clears it to null.
     // No index - the lakes collection is tiny, and it is only ever read from a lake already in hand.
     filesDeletedAt: { type: Date },
+    // Lake-memory producer (#1440) bookkeeping - server-managed, never client-writable. No index
+    // (tiny collection, only read from a lake already in hand, same rationale as filesDeletedAt).
+    // lakeMemoryExtractionAt is a concurrency lease; lakeMemoryCursor is the bounded-continuation
+    // watermark (last attempted doc id). See IDataLake for the full contract.
+    lakeMemoryExtractionAt: { type: Date },
+    lakeMemoryCursor: { type: String },
   },
   {
     timestamps: true,
@@ -396,6 +402,38 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
       { $set: { status: 'active' } }
     );
     return res.modifiedCount === 1;
+  }
+
+  async claimLakeMemoryExtraction(id: string, at: Date, staleBefore: Date): Promise<boolean> {
+    // Guard in the FILTER, not a prior read: an unset/missing field OR a stamp older than staleBefore (a
+    // crashed run's expired lease) is claimable. A concurrent claimer that already wrote a FRESH stamp
+    // fails this filter and loses, so exactly one run holds the lease. Mirrors activateIfDraft's
+    // guarded-in-query idiom.
+    const res = await this.dataLakeModel.updateOne(
+      {
+        _id: id,
+        $or: [
+          { lakeMemoryExtractionAt: null },
+          { lakeMemoryExtractionAt: { $exists: false } },
+          { lakeMemoryExtractionAt: { $lt: staleBefore } },
+        ],
+      },
+      { $set: { lakeMemoryExtractionAt: at } }
+    );
+    return res.modifiedCount === 1;
+  }
+
+  async releaseLakeMemoryExtraction(id: string, claimedAt: Date): Promise<void> {
+    // Compare-and-clear: only release if our stamp is still the one in force. If a stale takeover
+    // replaced it, clearing would strand the newer run's lease.
+    await this.dataLakeModel.updateOne(
+      { _id: id, lakeMemoryExtractionAt: claimedAt },
+      { $set: { lakeMemoryExtractionAt: null } }
+    );
+  }
+
+  async setLakeMemoryCursor(id: string, cursor: string | null): Promise<void> {
+    await this.dataLakeModel.updateOne({ _id: id }, { $set: { lakeMemoryCursor: cursor } });
   }
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Hardens the lake-memory producer (the background extraction that folds data-lake documents into a lake-scoped memory profile). This is the first slice of a larger follow-up bundle; it lands the three items that form a coherent, ship-ready unit. The feature remains off by default behind the `EnableLakeMemory` flag, so there is no runtime behavior change unless an admin turns it on.

Three problems are addressed:

1. **Large lakes were only partially covered.** A single extraction run stops at `MAX_DOCS_PER_RUN=100` and at an elapsed-time deadline guard, so lakes bigger than one slice never got fully folded.
2. **Concurrent finalizes ran duplicate full extractions.** Two near-simultaneous batch finalizes on the same lake would each kick off a full extraction pass.
3. **Profile reads were quadratic.** `appendFactToLedger` decrypted and read the full profile once per fact (`O(facts x chain)`), which got ~6.25x worse after the per-doc fact cap was raised to `LAKE_FACTS_PER_DOC_MAX=12`.

## Changes

- **Bounded continuation for large lakes.** A new keyset cursor `lakeMemoryCursor` on the lake doc records the id of the last document a run *attempted* (not the cap boundary -- the deadline guard can stop a run mid-slice, so resuming from the cap would skip documents). The queue handler re-enqueues the same payload while `hasMore` is set; each continuation resumes from the cursor and re-checks the kill-switch. The cursor clears on full coverage so the next finalize does a fresh whole-lake re-scan. Cursor writes are best-effort and `hasMore` is gated on the write landing, so there is no re-bill loop.
- **Per-lake concurrency lease.** A new `lakeMemoryExtractionAt` lease uses a guarded compare-and-set claim plus a compare-and-clear release (mirroring the batch `setStatusIfActive` pattern). It is a lease, not a status, so a crashed run self-recovers after `LAKE_MEMORY_EXTRACTION_LEASE_MS` (15m) with no reconciler needed.
- **Single profile read per append session.** The per-fact `readProfile` is replaced by `createLedgerAppendSession`, which reads the profile once (lazily, on first embedded fact) and de-dups against an in-memory subject set kept current as it writes. This also fixed a real subject-hashing bug uncovered by the new test: a same-run new-subject match must carry its own `subjectIsHashed=false` rather than forcing `true`.
- **Redaction.** Both new internal fields are classified `withheld` in `redactLakeForActor` (enforced by a typed keyof-`IDataLake` map), and the list path (`toManageableConfig`) uses a typed projection so neither field leaks.

## Guide for Testers

This is a backend-only change behind an off-by-default flag. It ships no UI and, with the flag off, changes no observable behavior. The scenarios below assume a maintainer has enabled `EnableLakeMemory` on a non-prod stage (staging or a PR preview).

### A. No behavior change with the flag OFF (default state)
1. On a stage where `EnableLakeMemory` is **off** (the default), open any data lake and add/activate a batch of documents so a finalize runs.
2. Expected: extraction is skipped entirely -- no memory profile is produced, and the lake document has no `lakeMemoryCursor` or `lakeMemoryExtractionAt` set. Nothing about existing lake behavior differs from `main`.

### B. Bounded continuation covers a large lake
1. Enable `EnableLakeMemory` on the stage.
2. Create a data lake and add **more than 100** documents (e.g. ~250) so coverage requires multiple slices.
3. Activate a batch so a finalize triggers extraction.
4. Expected: the first run processes up to its slice/deadline limit and sets `lakeMemoryCursor` on the lake doc to the last document it attempted; the queue handler re-enqueues follow-up runs automatically.
5. Wait for the chain of continuations to drain (each resumes from the cursor).
6. Expected: every document is eventually folded into the profile, and once coverage completes `lakeMemoryCursor` is cleared. Re-running a finalize starts a fresh whole-lake scan.
7. Idempotency: because the memory ledger de-dups, re-running extraction over already-covered documents produces no duplicate facts.

### C. Concurrency lease prevents duplicate extraction
1. With the flag on and a lake present, trigger two batch finalizes on the **same lake** in quick succession.
2. Expected: only one extraction run proceeds; the second sees the `lakeMemoryExtractionAt` lease held and backs off rather than running a second full pass.
3. Crash-recovery: the lease is time-bounded (`LAKE_MEMORY_EXTRACTION_LEASE_MS`, 15m). If a run dies without releasing, a later finalize can re-claim after the lease expires -- no manual cleanup or reconciler.

### Regression Checks
- With the flag off, confirm data-lake create / activate / batch-finalize behave exactly as on `main`.
- Confirm the lake config surfaces (single-lake read and the manageable-config list) do not expose `lakeMemoryCursor` or `lakeMemoryExtractionAt` to any actor.

### What NOT to test
- No UI to exercise -- there is no user-facing surface in this PR.
- Do not test lake memory read/delete HTTP endpoints or contradiction handling; those are separate, still-unimplemented follow-up items.

## Additional Information

Part of #1501 (items 1-3 of a 7-item follow-up bundle; the remaining items need design or are deliberately deferred, so this PR does **not** close the issue). Part of the data-lake grounding epic (#1395 / #1437) and builds on #1440.

Verification: `pnpm turbo:typecheck` (40/40), `pnpm lint:check` clean, ASCII guard clean, and targeted tests green -- client (deadline + continuation + concurrency handler re-enqueue + dedup-hoist), database (lease/cursor guarded transitions against real Mongo), services (redaction pinning).

## Developer Notes

- `createLedgerAppendSession` (in `mementoLedgerMirror.ts`) is a reusable pattern for batch ledger appends: read-once profile + in-memory subject set, de-dup as you write, instead of a decrypt-per-fact loop.
- The `lakeMemoryExtractionAt` lease shows the lease-not-status pattern for per-entity work claims that must self-recover without a reconciler: guarded compare-and-set claim, compare-and-clear release, time-based expiry.
- The `lakeMemoryCursor` keyset-cursor + re-enqueue-while-`hasMore` pattern is reusable for any bounded background pass over a large collection that must survive a mid-slice deadline stop.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) -- N/A, backend only
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc -- N/A
