### PR TITLE
feat(client): wire Spend tab to real UsageEvent data

### DIFF
--- a/apps/client/app/components/admin/ModelMetrics/components/SpendTab.test.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/components/SpendTab.test.tsx
@@ -44,16 +44,7 @@ describe('SpendTabView', () => {
   it('does not flag truncation when every account is shown', () => {
     const data: SpendData = {
       ...spendMockData,
-      kpis: [
-        {
-          key: 'activeAccounts',
-          label: 'Active Accounts',
-          value: 2,
-          priorValue: 2,
-          format: 'number',
-          higherIsBetter: true,
-        },
-      ],
+      activeAccounts: 2,
       byAccount: spendMockData.byAccount.slice(0, 2),
     };
     render(<SpendTabView data={data} />, { wrapper: TestWrapper });
@@ -114,6 +105,8 @@ describe('SpendTabView', () => {
     const data: SpendData = {
       periodLabel: 'Custom period',
       priorPeriodLabel: 'Custom prior',
+      hasData: true,
+      activeAccounts: 1,
       kpis: [
         { key: 'estCost', label: 'Est. Cost', value: 10, priorValue: 5, format: 'currency', higherIsBetter: false },
       ],
@@ -158,7 +151,9 @@ describe('SpendTab (states)', () => {
   });
 
   it('renders an empty state when there is no spend in the window', () => {
-    render(<SpendTab data={{ ...spendMockData, byAccount: [], dailyCost: [] }} />, { wrapper: TestWrapper });
+    render(<SpendTab data={{ ...spendMockData, hasData: false, byAccount: [], dailyCost: [] }} />, {
+      wrapper: TestWrapper,
+    });
     expect(screen.getByTestId('spend-empty')).toBeInTheDocument();
   });
 

--- a/apps/client/app/components/admin/ModelMetrics/components/SpendTab.test.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/components/SpendTab.test.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
 import { SpendTab, SpendTabView } from './SpendTab';
-import { spendMockData, type SpendData } from '../utils/spendMockData';
-
-// Controls what the container's data hook returns per test.
-const mockUseSpend = vi.fn();
-vi.mock('../hooks/useSpend', () => ({
-  useSpend: (...args: unknown[]) => mockUseSpend(...args),
-}));
+import type { SpendData } from '@bike4mind/common';
+import { spendMockData } from '../utils/spendMockData';
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -37,6 +32,33 @@ describe('SpendTabView', () => {
     for (const account of spendMockData.byAccount) {
       expect(within(table).getByText(account.accountName)).toBeInTheDocument();
     }
+  });
+
+  it('flags a truncated account list as "top N of M" (byAccount < Active Accounts KPI)', () => {
+    // spendMockData: 7 account rows, Active Accounts KPI = 47.
+    render(<SpendTabView data={spendMockData} />, { wrapper: TestWrapper });
+    expect(screen.getByText('Top Spend by Account')).toBeInTheDocument();
+    expect(screen.getByTestId('spend-account-truncation')).toHaveTextContent('Showing top 7 of 47 accounts by spend.');
+  });
+
+  it('does not flag truncation when every account is shown', () => {
+    const data: SpendData = {
+      ...spendMockData,
+      kpis: [
+        {
+          key: 'activeAccounts',
+          label: 'Active Accounts',
+          value: 2,
+          priorValue: 2,
+          format: 'number',
+          higherIsBetter: true,
+        },
+      ],
+      byAccount: spendMockData.byAccount.slice(0, 2),
+    };
+    render(<SpendTabView data={data} />, { wrapper: TestWrapper });
+    expect(screen.getByText('Spend by Account')).toBeInTheDocument();
+    expect(screen.queryByTestId('spend-account-truncation')).not.toBeInTheDocument();
   });
 
   it('renders a cost-by-model bar for every model', () => {
@@ -119,47 +141,29 @@ describe('SpendTabView', () => {
   });
 });
 
-describe('SpendTab (container)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('passes the shared filters through to useSpend', () => {
-    mockUseSpend.mockReturnValue({ data: undefined, isLoading: true, isError: false });
-    render(<SpendTab filters={{ dateFrom: '2026-01-01', userFilter: 'u-1' }} />, { wrapper: TestWrapper });
-    expect(mockUseSpend).toHaveBeenCalledWith({
-      dateFrom: '2026-01-01',
-      dateTo: undefined,
-      userFilter: 'u-1',
-      modelFilter: undefined,
-    });
-  });
-
+describe('SpendTab (states)', () => {
   it('renders a loading state while fetching', () => {
-    mockUseSpend.mockReturnValue({ data: undefined, isLoading: true, isError: false });
-    render(<SpendTab />, { wrapper: TestWrapper });
+    render(<SpendTab isLoading />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('spend-loading')).toBeInTheDocument();
+  });
+
+  it('renders a loading state when data has not arrived yet', () => {
+    render(<SpendTab data={undefined} isLoading={false} />, { wrapper: TestWrapper });
     expect(screen.getByTestId('spend-loading')).toBeInTheDocument();
   });
 
   it('renders an error state when the query fails', () => {
-    mockUseSpend.mockReturnValue({ data: undefined, isLoading: false, isError: true });
-    render(<SpendTab />, { wrapper: TestWrapper });
+    render(<SpendTab isError />, { wrapper: TestWrapper });
     expect(screen.getByTestId('spend-error')).toBeInTheDocument();
   });
 
   it('renders an empty state when there is no spend in the window', () => {
-    mockUseSpend.mockReturnValue({
-      data: { ...spendMockData, byAccount: [], dailyCost: [] },
-      isLoading: false,
-      isError: false,
-    });
-    render(<SpendTab />, { wrapper: TestWrapper });
+    render(<SpendTab data={{ ...spendMockData, byAccount: [], dailyCost: [] }} />, { wrapper: TestWrapper });
     expect(screen.getByTestId('spend-empty')).toBeInTheDocument();
   });
 
   it('renders the view once data arrives', () => {
-    mockUseSpend.mockReturnValue({ data: spendMockData, isLoading: false, isError: false });
-    render(<SpendTab />, { wrapper: TestWrapper });
+    render(<SpendTab data={spendMockData} />, { wrapper: TestWrapper });
     expect(screen.getByTestId('spend-kpi-row')).toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/admin/ModelMetrics/components/SpendTab.test.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/components/SpendTab.test.tsx
@@ -1,24 +1,30 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { SpendTab } from './SpendTab';
+import { SpendTab, SpendTabView } from './SpendTab';
 import { spendMockData, type SpendData } from '../utils/spendMockData';
+
+// Controls what the container's data hook returns per test.
+const mockUseSpend = vi.fn();
+vi.mock('../hooks/useSpend', () => ({
+  useSpend: (...args: unknown[]) => mockUseSpend(...args),
+}));
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
   <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
 );
 
-describe('SpendTab', () => {
-  it('renders the mockup badge so reviewers know the data is fake', () => {
-    render(<SpendTab />, { wrapper: TestWrapper });
-    expect(screen.getByTestId('spend-mockup-badge')).toHaveTextContent('MOCKUP - FAKE DATA');
+describe('SpendTabView', () => {
+  it('renders the period label', () => {
+    render(<SpendTabView data={spendMockData} />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('spend-period-label')).toHaveTextContent('Last 30 days vs Prior 30 days');
   });
 
-  it('renders one KPI card per fixture KPI', () => {
-    render(<SpendTab />, { wrapper: TestWrapper });
+  it('renders one KPI card per KPI', () => {
+    render(<SpendTabView data={spendMockData} />, { wrapper: TestWrapper });
     const row = screen.getByTestId('spend-kpi-row');
     for (const kpi of spendMockData.kpis) {
       expect(within(row).getByText(kpi.label)).toBeInTheDocument();
@@ -26,7 +32,7 @@ describe('SpendTab', () => {
   });
 
   it('renders a spend-by-account row for every account', () => {
-    render(<SpendTab />, { wrapper: TestWrapper });
+    render(<SpendTabView data={spendMockData} />, { wrapper: TestWrapper });
     const table = screen.getByTestId('spend-by-account-table');
     for (const account of spendMockData.byAccount) {
       expect(within(table).getByText(account.accountName)).toBeInTheDocument();
@@ -34,7 +40,7 @@ describe('SpendTab', () => {
   });
 
   it('renders a cost-by-model bar for every model', () => {
-    render(<SpendTab />, { wrapper: TestWrapper });
+    render(<SpendTabView data={spendMockData} />, { wrapper: TestWrapper });
     const bars = screen.getByTestId('spend-by-model-bars');
     for (const model of spendMockData.byModel) {
       expect(within(bars).getByText(model.modelName)).toBeInTheDocument();
@@ -49,7 +55,7 @@ describe('SpendTab', () => {
         { key: 'requests', label: 'Requests', value: 200, priorValue: 100, format: 'number', higherIsBetter: true },
       ],
     };
-    render(<SpendTab data={data} />, { wrapper: TestWrapper });
+    render(<SpendTabView data={data} />, { wrapper: TestWrapper });
 
     // Both rose +100%, but the sign of higherIsBetter flips the semantic color.
     const costDelta = screen.getByTestId('spend-kpi-delta-estCost');
@@ -62,7 +68,7 @@ describe('SpendTab', () => {
   });
 
   it('formats the ms and percent KPI branches', () => {
-    render(<SpendTab />, { wrapper: TestWrapper });
+    render(<SpendTabView data={spendMockData} />, { wrapper: TestWrapper });
     const row = screen.getByTestId('spend-kpi-row');
     // p50Latency 812 -> "812ms" (ms branch), errorRate 0.021 -> "2.1%" (percent branch).
     expect(within(row).getByText('812ms')).toBeInTheDocument();
@@ -76,13 +82,13 @@ describe('SpendTab', () => {
         { key: 'estCost', label: 'Est. Cost', value: 10, priorValue: 0, format: 'currency', higherIsBetter: false },
       ],
     };
-    render(<SpendTab data={data} />, { wrapper: TestWrapper });
+    render(<SpendTabView data={data} />, { wrapper: TestWrapper });
     const chip = screen.getByTestId('spend-kpi-delta-estCost');
     expect(chip).toHaveTextContent('--');
     expect(chip).toHaveAttribute('title', 'No prior-period data');
   });
 
-  it('renders account, model, and period data from the data prop, not the mock', () => {
+  it('renders account, model, and period data from the data prop', () => {
     const data: SpendData = {
       periodLabel: 'Custom period',
       priorPeriodLabel: 'Custom prior',
@@ -105,13 +111,55 @@ describe('SpendTab', () => {
         { date: '2026-01-02', cost: 2 },
       ],
     };
-    render(<SpendTab data={data} />, { wrapper: TestWrapper });
+    render(<SpendTabView data={data} />, { wrapper: TestWrapper });
 
     expect(screen.getByText('Custom period vs Custom prior')).toBeInTheDocument();
     expect(within(screen.getByTestId('spend-by-account-table')).getByText('Zzyzx Corp')).toBeInTheDocument();
     expect(within(screen.getByTestId('spend-by-model-bars')).getByText('Custom Model One')).toBeInTheDocument();
-    // Mock fixture names must not leak through when a data prop is supplied.
-    expect(screen.queryByText('Northwind Labs')).not.toBeInTheDocument();
-    expect(screen.queryByText('Claude Opus 5')).not.toBeInTheDocument();
+  });
+});
+
+describe('SpendTab (container)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes the shared filters through to useSpend', () => {
+    mockUseSpend.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    render(<SpendTab filters={{ dateFrom: '2026-01-01', userFilter: 'u-1' }} />, { wrapper: TestWrapper });
+    expect(mockUseSpend).toHaveBeenCalledWith({
+      dateFrom: '2026-01-01',
+      dateTo: undefined,
+      userFilter: 'u-1',
+      modelFilter: undefined,
+    });
+  });
+
+  it('renders a loading state while fetching', () => {
+    mockUseSpend.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    render(<SpendTab />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('spend-loading')).toBeInTheDocument();
+  });
+
+  it('renders an error state when the query fails', () => {
+    mockUseSpend.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    render(<SpendTab />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('spend-error')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there is no spend in the window', () => {
+    mockUseSpend.mockReturnValue({
+      data: { ...spendMockData, byAccount: [], dailyCost: [] },
+      isLoading: false,
+      isError: false,
+    });
+    render(<SpendTab />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('spend-empty')).toBeInTheDocument();
+  });
+
+  it('renders the view once data arrives', () => {
+    mockUseSpend.mockReturnValue({ data: spendMockData, isLoading: false, isError: false });
+    render(<SpendTab />, { wrapper: TestWrapper });
+    expect(screen.getByTestId('spend-kpi-row')).toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/admin/ModelMetrics/components/SpendTab.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/components/SpendTab.tsx
@@ -1,15 +1,25 @@
 import React from 'react';
-import { Box, Chip, Sheet, Stack, Table, Typography } from '@mui/joy';
+import { Box, Chip, LinearProgress, Sheet, Stack, Table, Typography } from '@mui/joy';
 import { useTheme } from '@mui/joy/styles';
 import { ResponsiveLine } from '@nivo/line';
-import { spendMockData, type SpendData, type SpendKpi, type SpendKpiFormat } from '../utils/spendMockData';
+import { type SpendData, type SpendKpi, type SpendKpiFormat } from '../utils/spendMockData';
+import { useSpend } from '../hooks/useSpend';
 
 // Nivo's generics fight strict TS here; the same assertion is used in AnalyticsTab.
 const ResponsiveLineChart = ResponsiveLine as any;
 
 interface SpendTabProps {
-  /** Defaults to the mock fixture; the wiring ticket swaps in live SpendData. */
-  data?: SpendData;
+  /** Shared ModelMetrics filter bar state; drives the useSpend query window. */
+  filters?: {
+    dateFrom?: string;
+    dateTo?: string;
+    userFilter?: string;
+    modelFilter?: string;
+  };
+}
+
+interface SpendTabViewProps {
+  data: SpendData;
 }
 
 const formatKpiValue = (value: number, format: SpendKpiFormat): string => {
@@ -86,7 +96,7 @@ const KpiCard: React.FC<{ kpi: SpendKpi }> = ({ kpi }) => {
   );
 };
 
-export const SpendTab: React.FC<SpendTabProps> = ({ data = spendMockData }) => {
+export const SpendTabView: React.FC<SpendTabViewProps> = ({ data }) => {
   const theme = useTheme();
 
   // Duplicated from AnalyticsTab's chartTheme (hand-rolled, not shared code).
@@ -117,15 +127,9 @@ export const SpendTab: React.FC<SpendTabProps> = ({ data = spendMockData }) => {
 
   return (
     <Stack spacing={3} sx={{ mt: 1 }}>
-      {/* Mockup banner: remove once wired to live data (issue No. 1507). */}
-      <Stack direction="row" alignItems="center" spacing={1}>
-        <Chip color="warning" variant="solid" size="sm" data-testid="spend-mockup-badge">
-          MOCKUP - FAKE DATA
-        </Chip>
-        <Typography level="body-xs" sx={{ color: 'text.secondary' }}>
-          {data.periodLabel} vs {data.priorPeriodLabel}
-        </Typography>
-      </Stack>
+      <Typography level="body-xs" sx={{ color: 'text.secondary' }} data-testid="spend-period-label">
+        {data.periodLabel} vs {data.priorPeriodLabel}
+      </Typography>
 
       {/* Section 1: KPI row */}
       <Box
@@ -260,4 +264,45 @@ export const SpendTab: React.FC<SpendTabProps> = ({ data = spendMockData }) => {
       </Box>
     </Stack>
   );
+};
+
+export const SpendTab: React.FC<SpendTabProps> = ({ filters }) => {
+  const { data, isLoading, isError } = useSpend({
+    dateFrom: filters?.dateFrom,
+    dateTo: filters?.dateTo,
+    userFilter: filters?.userFilter,
+    modelFilter: filters?.modelFilter,
+  });
+
+  if (isLoading) {
+    return (
+      <Box sx={{ p: 2 }} data-testid="spend-loading">
+        <LinearProgress />
+        <Typography sx={{ mt: 2 }}>Loading spend data...</Typography>
+      </Box>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Chip color="danger" variant="soft" size="sm" data-testid="spend-error">
+          Failed to load spend data
+        </Chip>
+      </Box>
+    );
+  }
+
+  // No accounts means no events settled in the window (dailyCost is empty too).
+  if (data.byAccount.length === 0) {
+    return (
+      <Box sx={{ p: 2 }} data-testid="spend-empty">
+        <Typography level="body-sm" sx={{ color: 'text.secondary' }}>
+          No spend data for {data.periodLabel}.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return <SpendTabView data={data} />;
 };

--- a/apps/client/app/components/admin/ModelMetrics/components/SpendTab.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/components/SpendTab.tsx
@@ -114,10 +114,9 @@ export const SpendTabView: React.FC<SpendTabViewProps> = ({ data }) => {
 
   const maxModelCost = Math.max(...data.byModel.map(m => m.estCost), 0);
 
-  // The by-account table is capped server-side; the Active Accounts KPI holds the
-  // true distinct count, so surface "top N of M" when the list is partial.
-  const totalActiveAccounts = data.kpis.find(k => k.key === 'activeAccounts')?.value;
-  const accountsTruncated = totalActiveAccounts != null && data.byAccount.length < totalActiveAccounts;
+  // The by-account table is capped server-side; data.activeAccounts is the true
+  // distinct count, so surface "top N of M" when the list is partial.
+  const accountsTruncated = data.byAccount.length < data.activeAccounts;
 
   const lineData = [
     {
@@ -153,8 +152,8 @@ export const SpendTabView: React.FC<SpendTabViewProps> = ({ data }) => {
         </Typography>
         {accountsTruncated && (
           <Typography level="body-xs" sx={{ color: 'text.secondary', mb: 2 }} data-testid="spend-account-truncation">
-            Showing top {data.byAccount.length.toLocaleString('en-US')} of{' '}
-            {totalActiveAccounts!.toLocaleString('en-US')} accounts by spend.
+            Showing top {data.byAccount.length.toLocaleString('en-US')} of {data.activeAccounts.toLocaleString('en-US')}{' '}
+            accounts by spend.
           </Typography>
         )}
         {/* Bounded height gives Table stickyHeader a scroll container to stick within. */}
@@ -294,8 +293,8 @@ export const SpendTab: React.FC<SpendTabProps> = ({ data, isLoading, isError }) 
     );
   }
 
-  // Nothing settled in the window: both the account and daily-cost cuts are empty.
-  if (data.byAccount.length === 0 && data.dailyCost.length === 0) {
+  // Nothing settled in the window (authoritative flag, not inferred from a cut).
+  if (!data.hasData) {
     return (
       <Box sx={{ p: 2 }} data-testid="spend-empty">
         <Typography level="body-sm" sx={{ color: 'text.secondary' }}>

--- a/apps/client/app/components/admin/ModelMetrics/components/SpendTab.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/components/SpendTab.tsx
@@ -2,20 +2,16 @@ import React from 'react';
 import { Box, Chip, LinearProgress, Sheet, Stack, Table, Typography } from '@mui/joy';
 import { useTheme } from '@mui/joy/styles';
 import { ResponsiveLine } from '@nivo/line';
-import { type SpendData, type SpendKpi, type SpendKpiFormat } from '../utils/spendMockData';
-import { useSpend } from '../hooks/useSpend';
+import { type SpendData, type SpendKpi, type SpendKpiFormat } from '@bike4mind/common';
 
 // Nivo's generics fight strict TS here; the same assertion is used in AnalyticsTab.
 const ResponsiveLineChart = ResponsiveLine as any;
 
 interface SpendTabProps {
-  /** Shared ModelMetrics filter bar state; drives the useSpend query window. */
-  filters?: {
-    dateFrom?: string;
-    dateTo?: string;
-    userFilter?: string;
-    modelFilter?: string;
-  };
+  /** Live spend for the selected window; the parent owns the useSpend query. */
+  data?: SpendData;
+  isLoading?: boolean;
+  isError?: boolean;
 }
 
 interface SpendTabViewProps {
@@ -118,6 +114,11 @@ export const SpendTabView: React.FC<SpendTabViewProps> = ({ data }) => {
 
   const maxModelCost = Math.max(...data.byModel.map(m => m.estCost), 0);
 
+  // The by-account table is capped server-side; the Active Accounts KPI holds the
+  // true distinct count, so surface "top N of M" when the list is partial.
+  const totalActiveAccounts = data.kpis.find(k => k.key === 'activeAccounts')?.value;
+  const accountsTruncated = totalActiveAccounts != null && data.byAccount.length < totalActiveAccounts;
+
   const lineData = [
     {
       id: 'Daily Cost',
@@ -147,9 +148,15 @@ export const SpendTabView: React.FC<SpendTabViewProps> = ({ data }) => {
 
       {/* Section 2: Spend by account */}
       <Box>
-        <Typography level="h4" sx={{ mb: 2 }}>
-          Spend by Account
+        <Typography level="h4" sx={{ mb: accountsTruncated ? 0.5 : 2 }}>
+          {accountsTruncated ? 'Top Spend by Account' : 'Spend by Account'}
         </Typography>
+        {accountsTruncated && (
+          <Typography level="body-xs" sx={{ color: 'text.secondary', mb: 2 }} data-testid="spend-account-truncation">
+            Showing top {data.byAccount.length.toLocaleString('en-US')} of{' '}
+            {totalActiveAccounts!.toLocaleString('en-US')} accounts by spend.
+          </Typography>
+        )}
         {/* Bounded height gives Table stickyHeader a scroll container to stick within. */}
         <Sheet variant="outlined" sx={{ borderRadius: 'md', overflow: 'auto', maxHeight: 480 }}>
           <Table stickyHeader hoverRow size="sm" data-testid="spend-by-account-table">
@@ -266,24 +273,8 @@ export const SpendTabView: React.FC<SpendTabViewProps> = ({ data }) => {
   );
 };
 
-export const SpendTab: React.FC<SpendTabProps> = ({ filters }) => {
-  const { data, isLoading, isError } = useSpend({
-    dateFrom: filters?.dateFrom,
-    dateTo: filters?.dateTo,
-    userFilter: filters?.userFilter,
-    modelFilter: filters?.modelFilter,
-  });
-
-  if (isLoading) {
-    return (
-      <Box sx={{ p: 2 }} data-testid="spend-loading">
-        <LinearProgress />
-        <Typography sx={{ mt: 2 }}>Loading spend data...</Typography>
-      </Box>
-    );
-  }
-
-  if (isError || !data) {
+export const SpendTab: React.FC<SpendTabProps> = ({ data, isLoading, isError }) => {
+  if (isError) {
     return (
       <Box sx={{ p: 2 }}>
         <Chip color="danger" variant="soft" size="sm" data-testid="spend-error">
@@ -293,8 +284,18 @@ export const SpendTab: React.FC<SpendTabProps> = ({ filters }) => {
     );
   }
 
-  // No accounts means no events settled in the window (dailyCost is empty too).
-  if (data.byAccount.length === 0) {
+  // No data yet (fetching, or the query is gated off) reads as loading.
+  if (isLoading || !data) {
+    return (
+      <Box sx={{ p: 2 }} data-testid="spend-loading">
+        <LinearProgress />
+        <Typography sx={{ mt: 2 }}>Loading spend data...</Typography>
+      </Box>
+    );
+  }
+
+  // Nothing settled in the window: both the account and daily-cost cuts are empty.
+  if (data.byAccount.length === 0 && data.dailyCost.length === 0) {
     return (
       <Box sx={{ p: 2 }} data-testid="spend-empty">
         <Typography level="body-sm" sx={{ color: 'text.secondary' }}>

--- a/apps/client/app/components/admin/ModelMetrics/hooks/useSpend.ts
+++ b/apps/client/app/components/admin/ModelMetrics/hooks/useSpend.ts
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '@client/app/contexts/ApiContext';
 import { useUser } from '@client/app/contexts/UserContext';
-import type { SpendData } from '../utils/spendMockData';
+import type { SpendData } from '@bike4mind/common';
 
 interface SpendFilters {
   dateFrom?: string;
@@ -25,7 +25,7 @@ export const fetchSpend = async (filters?: SpendFilters, recache = false): Promi
   return response.data;
 };
 
-export const useSpend = (filters?: SpendFilters) => {
+export const useSpend = (filters?: SpendFilters, options?: { enabled?: boolean }) => {
   const isAdmin = useUser(s => s.isAdmin);
   const queryClient = useQueryClient();
 
@@ -33,7 +33,8 @@ export const useSpend = (filters?: SpendFilters) => {
     queryKey: ['admin-spend', filters],
     queryFn: () => fetchSpend(filters),
     staleTime: 1000 * 60 * 60, // 1 hour
-    enabled: isAdmin,
+    // Gate on the caller (e.g. only the active Spend tab) so the query stays lazy.
+    enabled: isAdmin && (options?.enabled ?? true),
   });
 
   // Force a server-side recache (bypasses the 12h response cache) and refresh the

--- a/apps/client/app/components/admin/ModelMetrics/hooks/useSpend.ts
+++ b/apps/client/app/components/admin/ModelMetrics/hooks/useSpend.ts
@@ -1,0 +1,50 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@client/app/contexts/ApiContext';
+import { useUser } from '@client/app/contexts/UserContext';
+import type { SpendData } from '../utils/spendMockData';
+
+interface SpendFilters {
+  dateFrom?: string;
+  dateTo?: string;
+  userFilter?: string;
+  modelFilter?: string;
+}
+
+export const fetchSpend = async (filters?: SpendFilters, recache = false): Promise<SpendData> => {
+  const params = new URLSearchParams();
+
+  if (filters?.dateFrom) params.append('dateFrom', filters.dateFrom);
+  if (filters?.dateTo) params.append('dateTo', filters.dateTo);
+  if (filters?.userFilter) params.append('userFilter', filters.userFilter);
+  if (filters?.modelFilter) params.append('modelFilter', filters.modelFilter);
+  // Bust the server's 12h cache entry so Refresh returns live data.
+  if (recache) params.append('recache', 'true');
+
+  const url = `/api/admin/spend${params.toString() ? `?${params.toString()}` : ''}`;
+  const response = await api.get(url);
+  return response.data;
+};
+
+export const useSpend = (filters?: SpendFilters) => {
+  const isAdmin = useUser(s => s.isAdmin);
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ['admin-spend', filters],
+    queryFn: () => fetchSpend(filters),
+    staleTime: 1000 * 60 * 60, // 1 hour
+    enabled: isAdmin,
+  });
+
+  // Force a server-side recache (bypasses the 12h response cache) and refresh the
+  // query data. Mirrors useModelMetrics.recache; a plain refetch would just re-hit
+  // the cached server response.
+  const recache = () =>
+    queryClient.fetchQuery({
+      queryKey: ['admin-spend', filters],
+      queryFn: () => fetchSpend(filters, true),
+      staleTime: 0,
+    });
+
+  return { ...query, recache };
+};

--- a/apps/client/app/components/admin/ModelMetrics/hooks/useSpend.ts
+++ b/apps/client/app/components/admin/ModelMetrics/hooks/useSpend.ts
@@ -1,7 +1,8 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '@client/app/contexts/ApiContext';
 import { useUser } from '@client/app/contexts/UserContext';
-import type { SpendData } from '@bike4mind/common';
+import type { SpendData, SpendServerPayload } from '@bike4mind/common';
+import { spendPeriodLabels } from '../utils/spendPeriodLabels';
 
 interface SpendFilters {
   dateFrom?: string;
@@ -22,7 +23,10 @@ export const fetchSpend = async (filters?: SpendFilters, recache = false): Promi
 
   const url = `/api/admin/spend${params.toString() ? `?${params.toString()}` : ''}`;
   const response = await api.get(url);
-  return response.data;
+  // The server can't format the period labels in the caller's timezone (and they're
+  // kept out of its 12h cache), so add them here from the same filter dates.
+  const payload = response.data as SpendServerPayload;
+  return { ...payload, ...spendPeriodLabels(filters?.dateFrom, filters?.dateTo) };
 };
 
 export const useSpend = (filters?: SpendFilters, options?: { enabled?: boolean }) => {

--- a/apps/client/app/components/admin/ModelMetrics/index.test.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/index.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+// Shared mock handles (hoisted so the vi.mock factories can close over them).
+const { recacheModel, recacheSpend, useSpendSpy } = vi.hoisted(() => ({
+  recacheModel: vi.fn(),
+  recacheSpend: vi.fn(),
+  useSpendSpy: vi.fn(),
+}));
+
+vi.mock('./hooks/useModelMetrics', () => ({
+  useModelMetrics: () => ({ data: [], isLoading: false, recache: recacheModel }),
+}));
+vi.mock('./hooks/useSpend', () => ({
+  useSpend: (...args: unknown[]) => {
+    useSpendSpy(...args);
+    return { data: undefined, isLoading: false, isError: false, recache: recacheSpend };
+  },
+}));
+vi.mock('@client/app/hooks/data/useModelInfo', () => ({ useModelInfo: () => ({ data: [] }) }));
+vi.mock('./utils/chartDataProcessor', () => ({ processChartData: () => [] }));
+vi.mock('./utils/csvExport', () => ({ exportToCSV: vi.fn() }));
+
+// Stub the heavy children; the ControlPanel stub exposes the Refresh action.
+vi.mock('./components/ControlPanel', () => ({
+  ControlPanel: (props: { onRefresh: () => void }) => (
+    <button data-testid="ctrl-refresh" onClick={props.onRefresh}>
+      refresh
+    </button>
+  ),
+}));
+vi.mock('./components/OverviewTab', () => ({ OverviewTab: () => <div data-testid="overview" /> }));
+vi.mock('./components/AnalyticsTab', () => ({ AnalyticsTab: () => <div data-testid="analytics" /> }));
+vi.mock('./components/RawDataTab', () => ({ RawDataTab: () => <div data-testid="rawdata" /> }));
+vi.mock('./components/SpendTab', () => ({ SpendTab: () => <div data-testid="spend" /> }));
+vi.mock('./components/MetricsInfoModal', () => ({ MetricsInfoModal: () => null }));
+vi.mock('@client/app/components/help/ContextHelpButton', () => ({ default: () => null }));
+
+import ModelMetricsTab from './index';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
+);
+
+const lastUseSpendCall = () => useSpendSpy.mock.calls.at(-1) as [unknown, { enabled: boolean }];
+
+describe('ModelMetricsTab - Spend wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the spend query gated off until the Spend tab is active', () => {
+    render(<ModelMetricsTab />, { wrapper: TestWrapper });
+    // Default tab is overview, so the spend query starts disabled.
+    expect(lastUseSpendCall()[1]).toEqual({ enabled: false });
+  });
+
+  it('enables the spend query once the Spend tab is selected', () => {
+    render(<ModelMetricsTab />, { wrapper: TestWrapper });
+    fireEvent.click(screen.getByRole('tab', { name: /Spend/ }));
+    expect(lastUseSpendCall()[1]).toEqual({ enabled: true });
+  });
+
+  it('passes only the spend-relevant filters to useSpend', () => {
+    render(<ModelMetricsTab />, { wrapper: TestWrapper });
+    expect(lastUseSpendCall()[0]).toEqual({
+      dateFrom: undefined,
+      dateTo: undefined,
+      userFilter: undefined,
+      modelFilter: undefined,
+    });
+  });
+
+  it('Refresh busts the model-metrics cache on a non-spend tab', () => {
+    render(<ModelMetricsTab />, { wrapper: TestWrapper });
+    fireEvent.click(screen.getByTestId('ctrl-refresh'));
+    expect(recacheModel).toHaveBeenCalledTimes(1);
+    expect(recacheSpend).not.toHaveBeenCalled();
+  });
+
+  it('Refresh busts the spend cache when the Spend tab is active', () => {
+    render(<ModelMetricsTab />, { wrapper: TestWrapper });
+    fireEvent.click(screen.getByRole('tab', { name: /Spend/ }));
+    fireEvent.click(screen.getByTestId('ctrl-refresh'));
+    expect(recacheSpend).toHaveBeenCalledTimes(1);
+    expect(recacheModel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/components/admin/ModelMetrics/index.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/index.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Box, Typography, LinearProgress, Tabs, TabList, Tab, TabPanel } from '@mui/joy';
 import dayjs from 'dayjs';
 
 import { useModelInfo } from '@client/app/hooks/data/useModelInfo';
 import { useModelMetrics } from './hooks/useModelMetrics';
+import { useSpend } from './hooks/useSpend';
 import { useModelMetricsState, ModelMetricsTabValue } from './hooks/useModelMetricsState';
 import { exportToCSV } from './utils/csvExport';
 import { processChartData } from './utils/chartDataProcessor';
@@ -58,8 +59,34 @@ const ModelMetricsTab: React.FC = () => {
     setDateRange,
   } = useModelMetricsState(metrics);
 
+  // Narrowed to the fields the spend query keys on (statusFilter is not applied to
+  // spend), so its react-query key stays stable across unrelated filter changes.
+  const spendFilters = useMemo(
+    () => ({
+      dateFrom: appliedFilters.dateFrom,
+      dateTo: appliedFilters.dateTo,
+      userFilter: appliedFilters.userFilter,
+      modelFilter: appliedFilters.modelFilter,
+    }),
+    [appliedFilters]
+  );
+
+  // Owned here (not inside SpendTab) so the shared Refresh button can bust the
+  // spend cache too; gated on the active tab to keep the query lazy.
+  const {
+    data: spendData,
+    isLoading: isSpendLoading,
+    isError: isSpendError,
+    recache: recacheSpend,
+  } = useSpend(spendFilters, { enabled: activeTab === 'spend' });
+
   const handleRefresh = () => {
-    recache();
+    // Refresh busts the cache for whichever tab's data is on screen.
+    if (activeTab === 'spend') {
+      recacheSpend();
+    } else {
+      recache();
+    }
   };
 
   const handleExportCSV = () => {
@@ -195,7 +222,7 @@ const ModelMetricsTab: React.FC = () => {
 
         {/* Spend Tab */}
         <TabPanel value="spend" sx={{ p: 1 }}>
-          <SpendTab filters={appliedFilters} />
+          <SpendTab data={spendData} isLoading={isSpendLoading} isError={isSpendError} />
         </TabPanel>
       </Tabs>
 

--- a/apps/client/app/components/admin/ModelMetrics/index.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/index.tsx
@@ -193,9 +193,9 @@ const ModelMetricsTab: React.FC = () => {
           />
         </TabPanel>
 
-        {/* Spend Tab (mock data, issue No. 1507) */}
+        {/* Spend Tab */}
         <TabPanel value="spend" sx={{ p: 1 }}>
-          <SpendTab />
+          <SpendTab filters={appliedFilters} />
         </TabPanel>
       </Tabs>
 

--- a/apps/client/app/components/admin/ModelMetrics/utils/spendMockData.ts
+++ b/apps/client/app/components/admin/ModelMetrics/utils/spendMockData.ts
@@ -1,76 +1,9 @@
 /**
- * Data contract for the Spend tab.
- *
- * The exported types below are the shared contract between the Spend tab and the
- * `/api/admin/spend` endpoint, which returns a live `SpendData`-shaped payload.
- * The `spendMockData` fixture is fabricated sample data retained only for tests;
- * do not read anything into the numbers.
+ * Fabricated sample data for the Spend tab, retained only for tests; do not read
+ * anything into the numbers. The `SpendData` contract itself lives in
+ * `@bike4mind/common` (shared by the tab and the /api/admin/spend handler).
  */
-
-/** How a KPI's raw numeric value should be rendered. */
-export type SpendKpiFormat = 'currency' | 'currencyPrecise' | 'number' | 'ms' | 'percent';
-
-/** Stable identifier for each KPI card so wiring can map query results by key. */
-export type SpendKpiKey =
-  | 'estCost'
-  | 'requests'
-  | 'costPerRequest'
-  | 'creditsUsed'
-  | 'activeAccounts'
-  | 'p50Latency'
-  | 'p95Latency'
-  | 'errorRate'
-  | 'refusalRate';
-
-export interface SpendKpi {
-  key: SpendKpiKey;
-  label: string;
-  /** Raw value for the current period; the component handles formatting. */
-  value: number;
-  /** Raw value for the immediately prior period, used to compute the delta. */
-  priorValue: number;
-  format: SpendKpiFormat;
-  /**
-   * Whether an increase is a good thing. Drives the delta color: cost/latency
-   * rising is bad (red), requests/credits rising is good (green).
-   */
-  higherIsBetter: boolean;
-}
-
-export interface SpendByAccountRow {
-  accountId: string;
-  accountName: string;
-  estCost: number;
-  requests: number;
-  creditsUsed: number;
-  costPerRequest: number;
-}
-
-export interface CostByModelRow {
-  modelId: string;
-  modelName: string;
-  estCost: number;
-  requests: number;
-  /** Share of total est. cost across all models, 0..1. */
-  share: number;
-}
-
-export interface DailyCostPoint {
-  /** ISO date, YYYY-MM-DD. */
-  date: string;
-  cost: number;
-}
-
-export interface SpendData {
-  /** Human label for the selected period (echoes the ControlPanel range). */
-  periodLabel: string;
-  /** Human label for the prior comparison period. */
-  priorPeriodLabel: string;
-  kpis: SpendKpi[];
-  byAccount: SpendByAccountRow[];
-  byModel: CostByModelRow[];
-  dailyCost: DailyCostPoint[];
-}
+import type { SpendData } from '@bike4mind/common';
 
 export const spendMockData: SpendData = {
   periodLabel: 'Last 30 days',

--- a/apps/client/app/components/admin/ModelMetrics/utils/spendMockData.ts
+++ b/apps/client/app/components/admin/ModelMetrics/utils/spendMockData.ts
@@ -1,12 +1,10 @@
 /**
- * Typed mock fixture for the Spend tab (issue No. 1507).
+ * Data contract for the Spend tab.
  *
- * The exported types below are the DATA CONTRACT for the wiring ticket: the
- * real backend query should return a `SpendData`-shaped payload so the Spend
- * tab can drop the mock and consume live data with no component changes.
- *
- * Everything here is fabricated. It only exists so the tab is reviewable as a
- * standalone visual PR; do not read anything into the numbers.
+ * The exported types below are the shared contract between the Spend tab and the
+ * `/api/admin/spend` endpoint, which returns a live `SpendData`-shaped payload.
+ * The `spendMockData` fixture is fabricated sample data retained only for tests;
+ * do not read anything into the numbers.
  */
 
 /** How a KPI's raw numeric value should be rendered. */

--- a/apps/client/app/components/admin/ModelMetrics/utils/spendMockData.ts
+++ b/apps/client/app/components/admin/ModelMetrics/utils/spendMockData.ts
@@ -8,6 +8,8 @@ import type { SpendData } from '@bike4mind/common';
 export const spendMockData: SpendData = {
   periodLabel: 'Last 30 days',
   priorPeriodLabel: 'Prior 30 days',
+  hasData: true,
+  activeAccounts: 47,
   kpis: [
     {
       key: 'estCost',

--- a/apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.test.ts
+++ b/apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import dayjs from 'dayjs';
+import { spendPeriodLabels } from './spendPeriodLabels';
+
+describe('spendPeriodLabels', () => {
+  it('labels the default trailing window when no range is set', () => {
+    expect(spendPeriodLabels()).toEqual({ periodLabel: 'Last 30 days', priorPeriodLabel: 'Prior 30 days' });
+    expect(spendPeriodLabels(undefined, undefined)).toEqual({
+      periodLabel: 'Last 30 days',
+      priorPeriodLabel: 'Prior 30 days',
+    });
+  });
+
+  it('renders the range in local time so the label matches the ControlPanel chips', () => {
+    // Build the bounds as LOCAL wall-clock (no offset), then hand the helper the UTC
+    // instant the ControlPanel would send (dayjs(...).toISOString()). The label must
+    // render that instant back to its local calendar day - not the UTC day that
+    // toISOString().slice(0,10) prints, which is a day early east of UTC (the bug).
+    const from = dayjs('2026-01-01T00:00:00');
+    const to = dayjs('2026-01-08T00:00:00');
+    const { periodLabel } = spendPeriodLabels(from.toISOString(), to.toISOString());
+    expect(periodLabel).toBe('2026-01-01 - 2026-01-08');
+  });
+
+  it('derives an equal-length prior window immediately before the range', () => {
+    const from = dayjs('2026-01-08T00:00:00');
+    const to = dayjs('2026-01-15T00:00:00'); // 7-day window
+    const { priorPeriodLabel } = spendPeriodLabels(from.toISOString(), to.toISOString());
+    expect(priorPeriodLabel).toBe('2026-01-01 - 2026-01-08');
+  });
+});

--- a/apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.ts
+++ b/apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.ts
@@ -1,0 +1,40 @@
+import dayjs from 'dayjs';
+import { SPEND_DEFAULT_WINDOW_DAYS } from '@bike4mind/common';
+
+export interface SpendPeriodLabels {
+  periodLabel: string;
+  priorPeriodLabel: string;
+}
+
+/**
+ * Format the current and prior spend-window labels in the VIEWER's local timezone so
+ * they match the ControlPanel range chips. The server can't produce these: it holds
+ * only UTC instants and never receives the caller's timezone, so a local-midnight
+ * range rendered with toISOString() lands a calendar day early east of UTC.
+ *
+ * Mirrors the window math in the /api/admin/spend handler's resolveWindows: with no
+ * range it is the default trailing window; otherwise the prior window is the same
+ * length immediately before `from`. dateFrom/dateTo are ISO instants from the filter.
+ */
+export function spendPeriodLabels(dateFrom?: string, dateTo?: string): SpendPeriodLabels {
+  const hasFrom = Boolean(dateFrom);
+  const hasTo = Boolean(dateTo);
+  if (!hasFrom && !hasTo) {
+    return {
+      periodLabel: `Last ${SPEND_DEFAULT_WINDOW_DAYS} days`,
+      priorPeriodLabel: `Prior ${SPEND_DEFAULT_WINDOW_DAYS} days`,
+    };
+  }
+
+  const to = hasTo ? dayjs(dateTo) : dayjs();
+  const from = hasFrom ? dayjs(dateFrom) : to.subtract(SPEND_DEFAULT_WINDOW_DAYS, 'day');
+  const windowMs = Math.max(to.valueOf() - from.valueOf(), 0);
+  const priorTo = from;
+  const priorFrom = from.subtract(windowMs, 'millisecond');
+  const fmt = (d: dayjs.Dayjs) => d.format('YYYY-MM-DD');
+
+  return {
+    periodLabel: `${fmt(from)} - ${fmt(to)}`,
+    priorPeriodLabel: `${fmt(priorFrom)} - ${fmt(priorTo)}`,
+  };
+}

--- a/apps/client/pages/api/admin/__tests__/spend.test.ts
+++ b/apps/client/pages/api/admin/__tests__/spend.test.ts
@@ -122,7 +122,10 @@ describe('GET /api/admin/spend', () => {
     expect(data.byAccount[0]).toMatchObject({ accountId: 'user-1', accountName: 'Ada Lovelace' });
     // modelId keys on provider+model so distinct backends serving the same model don't merge.
     expect(data.byModel[0]).toMatchObject({ modelId: 'bedrock/opus', modelName: 'bedrock / opus', share: 12 / 20 });
-    expect(data.periodLabel).toBe('Last 30 days');
+    // Period labels are formatted client-side in the viewer's timezone (see
+    // spendPeriodLabels), so the server payload must not carry them.
+    expect(data.periodLabel).toBeUndefined();
+    expect(data.priorPeriodLabel).toBeUndefined();
     // Authoritative empty/truncation signals emitted on the contract, not inferred.
     expect(data.hasData).toBe(true);
     expect(data.activeAccounts).toBe(3);

--- a/apps/client/pages/api/admin/__tests__/spend.test.ts
+++ b/apps/client/pages/api/admin/__tests__/spend.test.ts
@@ -110,6 +110,18 @@ describe('GET /api/admin/spend', () => {
     expect(data.byAccount[0]).toMatchObject({ accountId: 'user-1', accountName: 'Ada Lovelace' });
     expect(data.byModel[0]).toMatchObject({ modelId: 'opus', share: 12 / 20 });
     expect(data.periodLabel).toBe('Last 30 days');
+    // Authoritative empty/truncation signals emitted on the contract, not inferred.
+    expect(data.hasData).toBe(true);
+    expect(data.activeAccounts).toBe(3);
+  });
+
+  it('reports hasData=false when the window has no requests', async () => {
+    mockSpendSummary.mockResolvedValue(
+      summary({ totals: { requests: 0, cogsUsd: 0, creditsCharged: 0 }, activeAccounts: 0, byAccount: [] })
+    );
+    const { res, run } = call({ query: {} });
+    await run();
+    expect(res._getJSONData().hasData).toBe(false);
   });
 
   it('threads recache=true through to the cache envelope', async () => {

--- a/apps/client/pages/api/admin/__tests__/spend.test.ts
+++ b/apps/client/pages/api/admin/__tests__/spend.test.ts
@@ -26,9 +26,11 @@ vi.mock('@bike4mind/database/infra', () => ({
   organizationRepository: { find: (...a: unknown[]) => mockOrgFind(...a) },
 }));
 
-// Pass the factory straight through so buildSpendData actually runs (no real cache).
+// Pass the factory straight through so buildSpendData actually runs (no real cache),
+// while capturing the key/options so the recache plumbing is testable.
+const mockGetCachedData = vi.fn((_key: string, factory: () => unknown) => factory());
 vi.mock('@bike4mind/services', () => ({
-  cacheService: { getCachedData: (_key: string, factory: () => unknown) => factory() },
+  cacheService: { getCachedData: (...a: unknown[]) => mockGetCachedData(...(a as [string, () => unknown])) },
 }));
 
 const mockResolveUserNames = vi.fn();
@@ -108,6 +110,24 @@ describe('GET /api/admin/spend', () => {
     expect(data.byAccount[0]).toMatchObject({ accountId: 'user-1', accountName: 'Ada Lovelace' });
     expect(data.byModel[0]).toMatchObject({ modelId: 'opus', share: 12 / 20 });
     expect(data.periodLabel).toBe('Last 30 days');
+  });
+
+  it('threads recache=true through to the cache envelope', async () => {
+    const { run } = call({ query: { recache: 'true' } });
+    await run();
+    expect(mockGetCachedData.mock.calls[0][2]).toMatchObject({ recache: true });
+  });
+
+  it('does not bust the cache for a non-true recache value', async () => {
+    const { run } = call({ query: { recache: 'false' } });
+    await run();
+    expect(mockGetCachedData.mock.calls[0][2]).toMatchObject({ recache: false });
+  });
+
+  it('rejects an inverted date range instead of silently blanking the deltas', async () => {
+    const { run } = call({ query: { dateFrom: '2026-08-07', dateTo: '2026-07-08' } });
+    await expect(run()).rejects.toThrow(/dateFrom must not be after dateTo/);
+    expect(mockSpendSummary).not.toHaveBeenCalled();
   });
 
   it('resolves organization owners to their org name', async () => {

--- a/apps/client/pages/api/admin/__tests__/spend.test.ts
+++ b/apps/client/pages/api/admin/__tests__/spend.test.ts
@@ -108,11 +108,26 @@ describe('GET /api/admin/spend', () => {
     expect(byKey.refusalRate).toBeCloseTo(0.05);
 
     expect(data.byAccount[0]).toMatchObject({ accountId: 'user-1', accountName: 'Ada Lovelace' });
-    expect(data.byModel[0]).toMatchObject({ modelId: 'opus', share: 12 / 20 });
+    // modelId keys on provider+model so distinct backends serving the same model don't merge.
+    expect(data.byModel[0]).toMatchObject({ modelId: 'bedrock/opus', modelName: 'bedrock / opus', share: 12 / 20 });
     expect(data.periodLabel).toBe('Last 30 days');
     // Authoritative empty/truncation signals emitted on the contract, not inferred.
     expect(data.hasData).toBe(true);
     expect(data.activeAccounts).toBe(3);
+  });
+
+  it('feeds the current summary to KPI values and the prior summary to priorValues', async () => {
+    // Distinct fixtures per window so a swapped argument order (or reading a KPI
+    // from the wrong summary) can't pass. Order matches buildSpendData's Promise.all.
+    mockSpendSummary
+      .mockResolvedValueOnce(summary({ totals: { requests: 100, cogsUsd: 20, creditsCharged: 2000 } }))
+      .mockResolvedValueOnce(summary({ totals: { requests: 50, cogsUsd: 8, creditsCharged: 900 } }));
+
+    const { res, run } = call({ query: {} });
+    await run();
+
+    const estCost = res._getJSONData().kpis.find((k: { key: string }) => k.key === 'estCost');
+    expect(estCost).toMatchObject({ value: 20, priorValue: 8 });
   });
 
   it('reports hasData=false when the window has no requests', async () => {

--- a/apps/client/pages/api/admin/__tests__/spend.test.ts
+++ b/apps/client/pages/api/admin/__tests__/spend.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMocks } from 'node-mocks-http';
+import type { ISpendSummary } from '@bike4mind/common';
+
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const handlers: Record<string, (req: unknown, res: unknown) => Promise<unknown>> = {};
+    const chain = async (req: { method: string }, res: unknown) => handlers[req.method](req, res);
+    chain.use = () => chain;
+    chain.get = (fn: (typeof handlers)[string]) => {
+      handlers.GET = fn;
+      return chain;
+    };
+    return chain;
+  },
+}));
+
+const mockSpendSummary = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  usageEventRepository: { spendSummary: (...a: unknown[]) => mockSpendSummary(...a) },
+  cacheRepository: {},
+}));
+
+const mockOrgFind = vi.fn();
+vi.mock('@bike4mind/database/infra', () => ({
+  organizationRepository: { find: (...a: unknown[]) => mockOrgFind(...a) },
+}));
+
+// Pass the factory straight through so buildSpendData actually runs (no real cache).
+vi.mock('@bike4mind/services', () => ({
+  cacheService: { getCachedData: (_key: string, factory: () => unknown) => factory() },
+}));
+
+const mockResolveUserNames = vi.fn();
+vi.mock('@server/utils/resolveUserNames', () => ({
+  resolveUserNames: (...a: unknown[]) => mockResolveUserNames(...a),
+}));
+
+import handler from '../spend';
+
+const summary = (over: Partial<ISpendSummary> = {}): ISpendSummary => ({
+  totals: { requests: 100, cogsUsd: 20, creditsCharged: 2000 },
+  activeAccounts: 3,
+  latency: { p50: 500, p95: 1500 },
+  status: { total: 100, errors: 2, timeouts: 1, refusals: 5 },
+  byModel: [{ provider: 'bedrock', model: 'opus', requests: 60, cogsUsd: 12, creditsCharged: 1200 }],
+  byAccount: [{ ownerId: 'user-1', ownerType: 'User', requests: 100, cogsUsd: 20, creditsCharged: 2000 } as never],
+  dailyCost: [{ day: '2026-08-01', cogsUsd: 20 }],
+  ...over,
+});
+
+function call(options: { isAdmin?: boolean; query?: object }) {
+  const { req, res } = createMocks({ method: 'GET', query: options.query ?? {} });
+  (req as unknown as { user?: { isAdmin: boolean; id: string }; logger: unknown }).user = {
+    isAdmin: options.isAdmin ?? true,
+    id: 'admin-1',
+  };
+  (req as unknown as { logger: unknown }).logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { req, res, run: () => (handler as unknown as (rq: unknown, rs: unknown) => Promise<unknown>)(req, res) };
+}
+
+describe('GET /api/admin/spend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSpendSummary.mockResolvedValue(summary());
+    mockOrgFind.mockResolvedValue([]);
+    mockResolveUserNames.mockResolvedValue(new Map([['user-1', 'Ada Lovelace']]));
+  });
+
+  it('rejects a non-admin', async () => {
+    const { run } = call({ isAdmin: false });
+    await expect(run()).rejects.toThrow(/[Aa]dmin/);
+    expect(mockSpendSummary).not.toHaveBeenCalled();
+  });
+
+  it('queries a current and a prior window of equal length', async () => {
+    const { run } = call({ query: { dateFrom: '2026-07-08', dateTo: '2026-08-07' } });
+    await run();
+
+    expect(mockSpendSummary).toHaveBeenCalledTimes(2);
+    const [current] = mockSpendSummary.mock.calls[0];
+    const [prior] = mockSpendSummary.mock.calls[1];
+    const windowMs = current.to.getTime() - current.from.getTime();
+    // Prior window abuts the current one and is the same length.
+    expect(prior.to.getTime()).toBe(current.from.getTime());
+    expect(current.from.getTime() - prior.from.getTime()).toBe(windowMs);
+  });
+
+  it('maps user/model filters into the repository call', async () => {
+    const { run } = call({ query: { userFilter: 'u-9', modelFilter: 'opus' } });
+    await run();
+    expect(mockSpendSummary.mock.calls[0][0]).toMatchObject({ userId: 'u-9', model: 'opus' });
+  });
+
+  it('shapes SpendData: derived KPIs, resolved account name, and model share', async () => {
+    const { res, run } = call({ query: {} });
+    await run();
+    const data = res._getJSONData();
+
+    const byKey = Object.fromEntries(data.kpis.map((k: { key: string; value: number }) => [k.key, k.value]));
+    expect(byKey.estCost).toBe(20);
+    expect(byKey.costPerRequest).toBeCloseTo(0.2); // 20 / 100
+    // errorRate folds timeouts in: (2 + 1) / 100.
+    expect(byKey.errorRate).toBeCloseTo(0.03);
+    // refusalRate is its own bucket: 5 / 100.
+    expect(byKey.refusalRate).toBeCloseTo(0.05);
+
+    expect(data.byAccount[0]).toMatchObject({ accountId: 'user-1', accountName: 'Ada Lovelace' });
+    expect(data.byModel[0]).toMatchObject({ modelId: 'opus', share: 12 / 20 });
+    expect(data.periodLabel).toBe('Last 30 days');
+  });
+
+  it('resolves organization owners to their org name', async () => {
+    mockSpendSummary.mockResolvedValue(
+      summary({
+        byAccount: [
+          {
+            ownerId: '6650000000000000000000aa',
+            ownerType: 'Organization',
+            requests: 10,
+            cogsUsd: 5,
+            creditsCharged: 500,
+          } as never,
+        ],
+      })
+    );
+    mockOrgFind.mockResolvedValue([{ id: '6650000000000000000000aa', name: 'Northwind Labs' }]);
+
+    const { res, run } = call({ query: {} });
+    await run();
+    expect(res._getJSONData().byAccount[0].accountName).toBe('Northwind Labs');
+  });
+});

--- a/apps/client/pages/api/admin/__tests__/spend.test.ts
+++ b/apps/client/pages/api/admin/__tests__/spend.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMocks } from 'node-mocks-http';
-import type { ISpendSummary } from '@bike4mind/common';
+import { ApiKeyScope, type ISpendSummary } from '@bike4mind/common';
 
+// Captures the config so a test can assert requiredScopes: the scope gate lives in
+// apiKeyAuth (real middleware, not exercised here), so asserting the handler is
+// registered with it is the only guard available at this level.
 vi.mock('@server/middlewares/baseApi', () => ({
-  baseApi: () => {
+  baseApi: (config?: unknown) => {
     const handlers: Record<string, (req: unknown, res: unknown) => Promise<unknown>> = {};
     const chain = async (req: { method: string }, res: unknown) => handlers[req.method](req, res);
     chain.use = () => chain;
@@ -11,6 +14,7 @@ vi.mock('@server/middlewares/baseApi', () => ({
       handlers.GET = fn;
       return chain;
     };
+    chain._config = config;
     return chain;
   },
 }));
@@ -67,6 +71,14 @@ describe('GET /api/admin/spend', () => {
     mockSpendSummary.mockResolvedValue(summary());
     mockOrgFind.mockResolvedValue([]);
     mockResolveUserNames.mockResolvedValue(new Map([['user-1', 'Ada Lovelace']]));
+  });
+
+  it('requires the ADMIN scope so an under-scoped admin-owned key is 403d by apiKeyAuth', () => {
+    // Guards the money endpoint against a narrowly-scoped key inheriting its owner's
+    // isAdmin: apiKeyAuth rejects the key before req.user is set. JWT/browser admins
+    // skip that check and are unaffected.
+    const config = (handler as unknown as { _config?: { requiredScopes?: string[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
   });
 
   it('rejects a non-admin', async () => {

--- a/apps/client/pages/api/admin/spend.ts
+++ b/apps/client/pages/api/admin/spend.ts
@@ -216,8 +216,11 @@ async function buildSpendData(query: Omit<SpendQuery, 'recache'>): Promise<Spend
 
   const totalCogs = currentSummary.totals.cogsUsd;
   const byModel: CostByModelRow[] = currentSummary.byModel.map(m => ({
-    modelId: m.model,
-    modelName: m.model,
+    // Key and label on provider+model: the same model id can be served by more than
+    // one backend, so collapsing to model alone would merge rows and collide React
+    // keys. Matches the sibling usage dashboard's `${provider} / ${model}` identity.
+    modelId: `${m.provider}/${m.model}`,
+    modelName: `${m.provider} / ${m.model}`,
     estCost: m.cogsUsd,
     requests: m.requests,
     share: totalCogs > 0 ? m.cogsUsd / totalCogs : 0,

--- a/apps/client/pages/api/admin/spend.ts
+++ b/apps/client/pages/api/admin/spend.ts
@@ -1,0 +1,241 @@
+import { baseApi } from '@server/middlewares/baseApi';
+import { usageEventRepository, cacheRepository } from '@bike4mind/database';
+import { organizationRepository } from '@bike4mind/database/infra';
+import { cacheService } from '@bike4mind/services';
+import { CreditHolderType, type ISpendSummary } from '@bike4mind/common';
+import { CacheKeys } from '@server/utils/cacheKeys';
+import { ForbiddenError } from '@server/utils/errors';
+import { resolveUserNames } from '@server/utils/resolveUserNames';
+import type {
+  CostByModelRow,
+  DailyCostPoint,
+  SpendByAccountRow,
+  SpendData,
+  SpendKpi,
+} from '@client/app/components/admin/ModelMetrics/utils/spendMockData';
+import { Request } from 'express';
+import { z } from 'zod';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_WINDOW_DAYS = 30;
+
+/** Guards org-id casts in the $in lookup from a BSONError 500 (see resolveUserNames). */
+const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
+
+const QuerySchema = z.object({
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+  userFilter: z.string().optional(),
+  modelFilter: z.string().optional(),
+  // Accepted for parity with the shared ModelMetrics filter bar but not applied:
+  // UsageEvent statuses (ok|error|timeout|refusal) do not map to the quest statuses
+  // this filter offers, and filtering here would distort the error/refusal KPIs.
+  statusFilter: z.string().optional(),
+  // Busts the server's 12h cache entry so a Refresh returns live data.
+  recache: z.coerce.boolean().optional(),
+});
+
+type SpendQuery = z.infer<typeof QuerySchema>;
+
+/** Parse an ISO date, treating an unparseable value as absent rather than NaN. */
+const parseDate = (value?: string): Date | undefined => {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+};
+
+const fmtDay = (d: Date): string => d.toISOString().slice(0, 10);
+
+/**
+ * Resolve the current window from the filter dates and derive the immediately
+ * prior window of equal length (for the vs-prior KPI deltas). With no dates the
+ * window defaults to the last 30 days.
+ */
+function resolveWindows(dateFrom?: string, dateTo?: string) {
+  const now = new Date();
+  const to = parseDate(dateTo) ?? now;
+  const from = parseDate(dateFrom) ?? new Date(to.getTime() - DEFAULT_WINDOW_DAYS * DAY_MS);
+  const windowMs = Math.max(to.getTime() - from.getTime(), 0);
+  const priorTo = from;
+  const priorFrom = new Date(from.getTime() - windowMs);
+  const isDefault = !parseDate(dateFrom) && !parseDate(dateTo);
+
+  return {
+    current: { from, to },
+    prior: { from: priorFrom, to: priorTo },
+    periodLabel: isDefault ? `Last ${DEFAULT_WINDOW_DAYS} days` : `${fmtDay(from)} - ${fmtDay(to)}`,
+    priorPeriodLabel: isDefault ? `Prior ${DEFAULT_WINDOW_DAYS} days` : `${fmtDay(priorFrom)} - ${fmtDay(priorTo)}`,
+  };
+}
+
+const costPerRequest = (s: ISpendSummary): number => (s.totals.requests > 0 ? s.totals.cogsUsd / s.totals.requests : 0);
+
+// Timeouts fold into the error rate (both are failed calls); refusals are their
+// own rate. Refusals aren't recorded yet, so refusalRate reads 0 until they are.
+const errorRate = (s: ISpendSummary): number =>
+  s.status.total > 0 ? (s.status.errors + s.status.timeouts) / s.status.total : 0;
+
+const refusalRate = (s: ISpendSummary): number => (s.status.total > 0 ? s.status.refusals / s.status.total : 0);
+
+function buildKpis(current: ISpendSummary, prior: ISpendSummary): SpendKpi[] {
+  return [
+    {
+      key: 'estCost',
+      label: 'Est. Cost',
+      value: current.totals.cogsUsd,
+      priorValue: prior.totals.cogsUsd,
+      format: 'currency',
+      higherIsBetter: false,
+    },
+    {
+      key: 'requests',
+      label: 'Requests',
+      value: current.totals.requests,
+      priorValue: prior.totals.requests,
+      format: 'number',
+      higherIsBetter: true,
+    },
+    {
+      key: 'costPerRequest',
+      label: 'Cost / Req',
+      value: costPerRequest(current),
+      priorValue: costPerRequest(prior),
+      format: 'currencyPrecise',
+      higherIsBetter: false,
+    },
+    {
+      key: 'creditsUsed',
+      label: 'Credits Used',
+      value: current.totals.creditsCharged,
+      priorValue: prior.totals.creditsCharged,
+      format: 'number',
+      higherIsBetter: true,
+    },
+    {
+      key: 'activeAccounts',
+      label: 'Active Accounts',
+      value: current.activeAccounts,
+      priorValue: prior.activeAccounts,
+      format: 'number',
+      higherIsBetter: true,
+    },
+    {
+      key: 'p50Latency',
+      label: 'p50 Latency',
+      value: current.latency.p50,
+      priorValue: prior.latency.p50,
+      format: 'ms',
+      higherIsBetter: false,
+    },
+    {
+      key: 'p95Latency',
+      label: 'p95 Latency',
+      value: current.latency.p95,
+      priorValue: prior.latency.p95,
+      format: 'ms',
+      higherIsBetter: false,
+    },
+    {
+      key: 'errorRate',
+      label: 'Error Rate',
+      value: errorRate(current),
+      priorValue: errorRate(prior),
+      format: 'percent',
+      higherIsBetter: false,
+    },
+    {
+      key: 'refusalRate',
+      label: 'Refusal Rate',
+      value: refusalRate(current),
+      priorValue: refusalRate(prior),
+      format: 'percent',
+      higherIsBetter: false,
+    },
+  ];
+}
+
+/** Resolve each account's ownerId to a display name (org name or user name), keyed by owner type. */
+async function resolveAccountRows(current: ISpendSummary): Promise<SpendByAccountRow[]> {
+  const accounts = current.byAccount;
+  const userOwnerIds = accounts.filter(a => a.ownerType === CreditHolderType.User).map(a => a.ownerId);
+  const orgOwnerIds = [
+    ...new Set(accounts.filter(a => a.ownerType === CreditHolderType.Organization).map(a => a.ownerId)),
+  ].filter(id => OBJECT_ID_RE.test(id));
+
+  const [userNames, orgs] = await Promise.all([
+    resolveUserNames(userOwnerIds),
+    orgOwnerIds.length ? organizationRepository.find({ _id: { $in: orgOwnerIds } }) : Promise.resolve([]),
+  ]);
+  const orgNameById = new Map(orgs.map(o => [String(o.id), o.name]));
+
+  return accounts.map(a => {
+    const name = a.ownerType === CreditHolderType.Organization ? orgNameById.get(a.ownerId) : userNames.get(a.ownerId);
+    return {
+      accountId: a.ownerId,
+      // Fall back to the raw id for unresolved owners (agent pools, legacy ids).
+      accountName: name ?? a.ownerId,
+      estCost: a.cogsUsd,
+      requests: a.requests,
+      creditsUsed: a.creditsCharged,
+      costPerRequest: a.requests > 0 ? a.cogsUsd / a.requests : 0,
+    };
+  });
+}
+
+async function buildSpendData(query: SpendQuery): Promise<SpendData> {
+  const { current, prior, periodLabel, priorPeriodLabel } = resolveWindows(query.dateFrom, query.dateTo);
+  const baseFilters = { userId: query.userFilter || undefined, model: query.modelFilter || undefined };
+
+  const [currentSummary, priorSummary] = await Promise.all([
+    usageEventRepository.spendSummary({ ...current, ...baseFilters }),
+    usageEventRepository.spendSummary({ ...prior, ...baseFilters }),
+  ]);
+
+  const byAccount = await resolveAccountRows(currentSummary);
+
+  const totalCogs = currentSummary.totals.cogsUsd;
+  const byModel: CostByModelRow[] = currentSummary.byModel.map(m => ({
+    modelId: m.model,
+    modelName: m.model,
+    estCost: m.cogsUsd,
+    requests: m.requests,
+    share: totalCogs > 0 ? m.cogsUsd / totalCogs : 0,
+  }));
+
+  const dailyCost: DailyCostPoint[] = currentSummary.dailyCost.map(d => ({ date: d.day, cost: d.cogsUsd }));
+
+  return {
+    periodLabel,
+    priorPeriodLabel,
+    kpis: buildKpis(currentSummary, priorSummary),
+    byAccount,
+    byModel,
+    dailyCost,
+  };
+}
+
+/**
+ * GET /api/admin/spend - real spend for the Model Metrics Spend tab, sourced from
+ * the UsageEvent collection (frozen costUsd/creditsCharged/latencyMs). Computes the
+ * selected window against the immediately prior window for vs-prior KPI deltas.
+ * Admin-only; response cached 12h (bust with ?recache=true).
+ */
+const handler = baseApi().get(async (req: Request<{}, {}, {}, SpendQuery>, res) => {
+  if (!req.user?.isAdmin) {
+    throw new ForbiddenError('Admin access required');
+  }
+
+  const { recache, ...query } = QuerySchema.parse(req.query);
+
+  const cacheKey = CacheKeys.spend(query);
+  const data = await cacheService.getCachedData(cacheKey, () => buildSpendData(query), {
+    db: { caches: cacheRepository },
+    expiry: 12 * 60 * 60 * 1000, // 12 hours
+    recache,
+    logger: req.logger,
+  });
+
+  return res.json(data);
+});
+
+export default handler;

--- a/apps/client/pages/api/admin/spend.ts
+++ b/apps/client/pages/api/admin/spend.ts
@@ -131,6 +131,8 @@ function buildKpis(current: ISpendSummary, prior: ISpendSummary): SpendKpi[] {
       higherIsBetter: true,
     },
     {
+      // Display card only (carries a vs-prior delta). The tab reads the top-level
+      // SpendData.activeAccounts for truncation, not this KPI - keep them separate.
       key: 'activeAccounts',
       label: 'Active Accounts',
       value: current.activeAccounts,
@@ -226,6 +228,7 @@ async function buildSpendData(query: Omit<SpendQuery, 'recache'>): Promise<Spend
   return {
     periodLabel,
     priorPeriodLabel,
+    // "Some events were counted in this window" - requests is $sum:1 in spendSummary.
     hasData: currentSummary.totals.requests > 0,
     activeAccounts: currentSummary.activeAccounts,
     kpis: buildKpis(currentSummary, priorSummary),

--- a/apps/client/pages/api/admin/spend.ts
+++ b/apps/client/pages/api/admin/spend.ts
@@ -3,6 +3,7 @@ import { usageEventRepository, cacheRepository } from '@bike4mind/database';
 import { organizationRepository } from '@bike4mind/database/infra';
 import { cacheService } from '@bike4mind/services';
 import {
+  ApiKeyScope,
   CreditHolderType,
   type CostByModelRow,
   type DailyCostPoint,
@@ -246,23 +247,30 @@ async function buildSpendData(query: Omit<SpendQuery, 'recache'>): Promise<Spend
  * the UsageEvent collection (frozen costUsd/creditsCharged/latencyMs). Computes the
  * selected window against the immediately prior window for vs-prior KPI deltas.
  * Admin-only; response cached 12h (bust with ?recache=true).
+ *
+ * requiredScopes gates the API-key path only: apiKeyAuth 403s an under-scoped key
+ * before req.user is set, so a key issued for a narrow integration can't read org
+ * spend just because its owner is an admin. JWT/browser admins skip that check and
+ * still pass the isAdmin gate below.
  */
-const handler = baseApi().get(async (req: Request<{}, {}, {}, SpendQuery>, res) => {
-  if (!req.user?.isAdmin) {
-    throw new ForbiddenError('Admin access required');
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get(
+  async (req: Request<{}, {}, {}, SpendQuery>, res) => {
+    if (!req.user?.isAdmin) {
+      throw new ForbiddenError('Admin access required');
+    }
+
+    const { recache, ...query } = QuerySchema.parse(req.query);
+
+    const cacheKey = CacheKeys.spend(query);
+    const data = await cacheService.getCachedData(cacheKey, () => buildSpendData(query), {
+      db: { caches: cacheRepository },
+      expiry: 12 * 60 * 60 * 1000, // 12 hours
+      recache,
+      logger: req.logger,
+    });
+
+    return res.json(data);
   }
-
-  const { recache, ...query } = QuerySchema.parse(req.query);
-
-  const cacheKey = CacheKeys.spend(query);
-  const data = await cacheService.getCachedData(cacheKey, () => buildSpendData(query), {
-    db: { caches: cacheRepository },
-    expiry: 12 * 60 * 60 * 1000, // 12 hours
-    recache,
-    logger: req.logger,
-  });
-
-  return res.json(data);
-});
+);
 
 export default handler;

--- a/apps/client/pages/api/admin/spend.ts
+++ b/apps/client/pages/api/admin/spend.ts
@@ -2,17 +2,18 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { usageEventRepository, cacheRepository } from '@bike4mind/database';
 import { organizationRepository } from '@bike4mind/database/infra';
 import { cacheService } from '@bike4mind/services';
-import { CreditHolderType, type ISpendSummary } from '@bike4mind/common';
+import {
+  CreditHolderType,
+  type CostByModelRow,
+  type DailyCostPoint,
+  type ISpendSummary,
+  type SpendByAccountRow,
+  type SpendData,
+  type SpendKpi,
+} from '@bike4mind/common';
 import { CacheKeys } from '@server/utils/cacheKeys';
 import { ForbiddenError } from '@server/utils/errors';
 import { resolveUserNames } from '@server/utils/resolveUserNames';
-import type {
-  CostByModelRow,
-  DailyCostPoint,
-  SpendByAccountRow,
-  SpendData,
-  SpendKpi,
-} from '@client/app/components/admin/ModelMetrics/utils/spendMockData';
 import { Request } from 'express';
 import { z } from 'zod';
 
@@ -22,18 +23,35 @@ const DEFAULT_WINDOW_DAYS = 30;
 /** Guards org-id casts in the $in lookup from a BSONError 500 (see resolveUserNames). */
 const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
 
-const QuerySchema = z.object({
-  dateFrom: z.string().optional(),
-  dateTo: z.string().optional(),
-  userFilter: z.string().optional(),
-  modelFilter: z.string().optional(),
-  // Accepted for parity with the shared ModelMetrics filter bar but not applied:
-  // UsageEvent statuses (ok|error|timeout|refusal) do not map to the quest statuses
-  // this filter offers, and filtering here would distort the error/refusal KPIs.
-  statusFilter: z.string().optional(),
-  // Busts the server's 12h cache entry so a Refresh returns live data.
-  recache: z.coerce.boolean().optional(),
-});
+const QuerySchema = z
+  .object({
+    dateFrom: z.string().optional(),
+    dateTo: z.string().optional(),
+    userFilter: z.string().optional(),
+    modelFilter: z.string().optional(),
+    // Accepted for parity with the shared ModelMetrics filter bar but not applied:
+    // UsageEvent statuses (ok|error|timeout|refusal) do not map to the quest statuses
+    // this filter offers, and filtering here would distort the error/refusal KPIs.
+    statusFilter: z.string().optional(),
+    // Busts the server's 12h cache entry so a Refresh returns live data. Only the
+    // literal "true" busts it (z.coerce.boolean would treat "false" as truthy).
+    recache: z
+      .string()
+      .optional()
+      .transform(v => v === 'true'),
+  })
+  .refine(
+    q => {
+      // Reject an inverted range up front; otherwise the prior window collapses to
+      // zero length and every delta silently blanks with no signal to the caller.
+      if (!q.dateFrom || !q.dateTo) return true;
+      const from = new Date(q.dateFrom);
+      const to = new Date(q.dateTo);
+      if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return true;
+      return from.getTime() <= to.getTime();
+    },
+    { message: 'dateFrom must not be after dateTo', path: ['dateFrom'] }
+  );
 
 type SpendQuery = z.infer<typeof QuerySchema>;
 
@@ -182,7 +200,7 @@ async function resolveAccountRows(current: ISpendSummary): Promise<SpendByAccoun
   });
 }
 
-async function buildSpendData(query: SpendQuery): Promise<SpendData> {
+async function buildSpendData(query: Omit<SpendQuery, 'recache'>): Promise<SpendData> {
   const { current, prior, periodLabel, priorPeriodLabel } = resolveWindows(query.dateFrom, query.dateTo);
   const baseFilters = { userId: query.userFilter || undefined, model: query.modelFilter || undefined };
 

--- a/apps/client/pages/api/admin/spend.ts
+++ b/apps/client/pages/api/admin/spend.ts
@@ -73,6 +73,7 @@ function resolveWindows(dateFrom?: string, dateTo?: string) {
   const now = new Date();
   const to = parseDate(dateTo) ?? now;
   const from = parseDate(dateFrom) ?? new Date(to.getTime() - DEFAULT_WINDOW_DAYS * DAY_MS);
+  // Defensive floor: QuerySchema already rejects inverted ranges, so this stays >= 0.
   const windowMs = Math.max(to.getTime() - from.getTime(), 0);
   const priorTo = from;
   const priorFrom = new Date(from.getTime() - windowMs);
@@ -225,6 +226,8 @@ async function buildSpendData(query: Omit<SpendQuery, 'recache'>): Promise<Spend
   return {
     periodLabel,
     priorPeriodLabel,
+    hasData: currentSummary.totals.requests > 0,
+    activeAccounts: currentSummary.activeAccounts,
     kpis: buildKpis(currentSummary, priorSummary),
     byAccount,
     byModel,

--- a/apps/client/pages/api/admin/spend.ts
+++ b/apps/client/pages/api/admin/spend.ts
@@ -5,12 +5,13 @@ import { cacheService } from '@bike4mind/services';
 import {
   ApiKeyScope,
   CreditHolderType,
+  SPEND_DEFAULT_WINDOW_DAYS,
   type CostByModelRow,
   type DailyCostPoint,
   type ISpendSummary,
   type SpendByAccountRow,
-  type SpendData,
   type SpendKpi,
+  type SpendServerPayload,
 } from '@bike4mind/common';
 import { CacheKeys } from '@server/utils/cacheKeys';
 import { ForbiddenError } from '@server/utils/errors';
@@ -19,7 +20,6 @@ import { Request } from 'express';
 import { z } from 'zod';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const DEFAULT_WINDOW_DAYS = 30;
 
 /** Guards org-id casts in the $in lookup from a BSONError 500 (see resolveUserNames). */
 const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
@@ -63,28 +63,24 @@ const parseDate = (value?: string): Date | undefined => {
   return Number.isNaN(d.getTime()) ? undefined : d;
 };
 
-const fmtDay = (d: Date): string => d.toISOString().slice(0, 10);
-
 /**
  * Resolve the current window from the filter dates and derive the immediately
  * prior window of equal length (for the vs-prior KPI deltas). With no dates the
- * window defaults to the last 30 days.
+ * window defaults to the last 30 days. Human period labels are formatted on the
+ * client (see spendPeriodLabels) since they depend on the viewer's timezone.
  */
 function resolveWindows(dateFrom?: string, dateTo?: string) {
   const now = new Date();
   const to = parseDate(dateTo) ?? now;
-  const from = parseDate(dateFrom) ?? new Date(to.getTime() - DEFAULT_WINDOW_DAYS * DAY_MS);
+  const from = parseDate(dateFrom) ?? new Date(to.getTime() - SPEND_DEFAULT_WINDOW_DAYS * DAY_MS);
   // Defensive floor: QuerySchema already rejects inverted ranges, so this stays >= 0.
   const windowMs = Math.max(to.getTime() - from.getTime(), 0);
   const priorTo = from;
   const priorFrom = new Date(from.getTime() - windowMs);
-  const isDefault = !parseDate(dateFrom) && !parseDate(dateTo);
 
   return {
     current: { from, to },
     prior: { from: priorFrom, to: priorTo },
-    periodLabel: isDefault ? `Last ${DEFAULT_WINDOW_DAYS} days` : `${fmtDay(from)} - ${fmtDay(to)}`,
-    priorPeriodLabel: isDefault ? `Prior ${DEFAULT_WINDOW_DAYS} days` : `${fmtDay(priorFrom)} - ${fmtDay(priorTo)}`,
   };
 }
 
@@ -204,8 +200,8 @@ async function resolveAccountRows(current: ISpendSummary): Promise<SpendByAccoun
   });
 }
 
-async function buildSpendData(query: Omit<SpendQuery, 'recache'>): Promise<SpendData> {
-  const { current, prior, periodLabel, priorPeriodLabel } = resolveWindows(query.dateFrom, query.dateTo);
+async function buildSpendData(query: Omit<SpendQuery, 'recache'>): Promise<SpendServerPayload> {
+  const { current, prior } = resolveWindows(query.dateFrom, query.dateTo);
   const baseFilters = { userId: query.userFilter || undefined, model: query.modelFilter || undefined };
 
   const [currentSummary, priorSummary] = await Promise.all([
@@ -230,8 +226,6 @@ async function buildSpendData(query: Omit<SpendQuery, 'recache'>): Promise<Spend
   const dailyCost: DailyCostPoint[] = currentSummary.dailyCost.map(d => ({ date: d.day, cost: d.cogsUsd }));
 
   return {
-    periodLabel,
-    priorPeriodLabel,
     // "Some events were counted in this window" - requests is $sum:1 in spendSummary.
     hasData: currentSummary.totals.requests > 0,
     activeAccounts: currentSummary.activeAccounts,

--- a/apps/client/server/utils/cacheKeys.ts
+++ b/apps/client/server/utils/cacheKeys.ts
@@ -56,8 +56,10 @@ export const CacheKeys = {
       normalizedFilters.modelFilter = filters.modelFilter;
     }
 
+    // JSON-serialize the sorted pairs so a value containing the delimiter can't
+    // collide with a different set of filters (e.g. "a|userFilter:b").
     const sortedKeys = Object.keys(normalizedFilters).sort();
-    const filterString = sortedKeys.map(key => `${key}:${normalizedFilters[key]}`).join('|');
+    const filterString = JSON.stringify(sortedKeys.map(key => [key, normalizedFilters[key]]));
 
     const hash = crypto.createHash('sha256').update(filterString).digest('hex').substring(0, 16);
 

--- a/apps/client/server/utils/cacheKeys.ts
+++ b/apps/client/server/utils/cacheKeys.ts
@@ -37,6 +37,33 @@ export const CacheKeys = {
     return `model-metrics:${hash}`;
   },
 
+  spend: (filters: { dateFrom?: string; dateTo?: string; userFilter?: string; modelFilter?: string }) => {
+    const normalizedFilters: Record<string, string> = {};
+
+    if (filters.dateFrom && filters.dateFrom !== '') {
+      normalizedFilters.dateFrom = filters.dateFrom;
+    }
+
+    if (filters.dateTo && filters.dateTo !== '') {
+      normalizedFilters.dateTo = filters.dateTo;
+    }
+
+    if (filters.userFilter && filters.userFilter !== '') {
+      normalizedFilters.userFilter = filters.userFilter;
+    }
+
+    if (filters.modelFilter && filters.modelFilter !== '') {
+      normalizedFilters.modelFilter = filters.modelFilter;
+    }
+
+    const sortedKeys = Object.keys(normalizedFilters).sort();
+    const filterString = sortedKeys.map(key => `${key}:${normalizedFilters[key]}`).join('|');
+
+    const hash = crypto.createHash('sha256').update(filterString).digest('hex').substring(0, 16);
+
+    return `admin-spend:${hash}`;
+  },
+
   userInvites: (userId: string, limit: number, page: number) => {
     return `userInvites:${userId}:${limit}:${page}`;
   },

--- a/b4m-core/common/src/types/entities/UsageEventTypes.ts
+++ b/b4m-core/common/src/types/entities/UsageEventTypes.ts
@@ -397,6 +397,78 @@ export interface ISpendSummary {
   dailyCost: ISpendCostDay[];
 }
 
+/*
+ * Spend-tab wire contract. This is the shape GET /api/admin/spend returns and the
+ * admin Spend tab renders - the single source of truth shared by the handler and
+ * the client. The handler maps the raw ISpendSummary rollups (above) into this,
+ * layering display labels, formatting hints, and vs-prior deltas.
+ */
+
+/** How a KPI's raw numeric value should be rendered. */
+export type SpendKpiFormat = 'currency' | 'currencyPrecise' | 'number' | 'ms' | 'percent';
+
+/** Stable identifier for each KPI card so wiring can map query results by key. */
+export type SpendKpiKey =
+  | 'estCost'
+  | 'requests'
+  | 'costPerRequest'
+  | 'creditsUsed'
+  | 'activeAccounts'
+  | 'p50Latency'
+  | 'p95Latency'
+  | 'errorRate'
+  | 'refusalRate';
+
+export interface SpendKpi {
+  key: SpendKpiKey;
+  label: string;
+  /** Raw value for the current period; the component handles formatting. */
+  value: number;
+  /** Raw value for the immediately prior period, used to compute the delta. */
+  priorValue: number;
+  format: SpendKpiFormat;
+  /**
+   * Whether an increase is a good thing. Drives the delta color: cost/latency
+   * rising is bad (red), requests/credits rising is good (green).
+   */
+  higherIsBetter: boolean;
+}
+
+export interface SpendByAccountRow {
+  accountId: string;
+  accountName: string;
+  estCost: number;
+  requests: number;
+  creditsUsed: number;
+  costPerRequest: number;
+}
+
+export interface CostByModelRow {
+  modelId: string;
+  modelName: string;
+  estCost: number;
+  requests: number;
+  /** Share of total est. cost across all models, 0..1. */
+  share: number;
+}
+
+export interface DailyCostPoint {
+  /** ISO date, YYYY-MM-DD. */
+  date: string;
+  cost: number;
+}
+
+export interface SpendData {
+  /** Human label for the selected period (echoes the ControlPanel range). */
+  periodLabel: string;
+  /** Human label for the prior comparison period. */
+  priorPeriodLabel: string;
+  kpis: SpendKpi[];
+  byAccount: SpendByAccountRow[];
+  byModel: CostByModelRow[];
+  dailyCost: DailyCostPoint[];
+}
+
 /** One model's slice of an agent execution's iteration billing. */
 export interface ISessionAgentModelUsage {
   model: string;

--- a/b4m-core/common/src/types/entities/UsageEventTypes.ts
+++ b/b4m-core/common/src/types/entities/UsageEventTypes.ts
@@ -463,6 +463,18 @@ export interface SpendData {
   periodLabel: string;
   /** Human label for the prior comparison period. */
   priorPeriodLabel: string;
+  /**
+   * Whether any events settled in the window. Authoritative empty-state signal
+   * so the tab does not have to infer it from whichever derived cut happens to be
+   * empty.
+   */
+  hasData: boolean;
+  /**
+   * True distinct credit-holder count in the window. `byAccount` is capped to the
+   * top spenders, so the tab compares this against `byAccount.length` to tell when
+   * the table is partial.
+   */
+  activeAccounts: number;
   kpis: SpendKpi[];
   byAccount: SpendByAccountRow[];
   byModel: CostByModelRow[];

--- a/b4m-core/common/src/types/entities/UsageEventTypes.ts
+++ b/b4m-core/common/src/types/entities/UsageEventTypes.ts
@@ -458,10 +458,19 @@ export interface DailyCostPoint {
   cost: number;
 }
 
+/** Default spend window (in days) when no explicit range is selected. */
+export const SPEND_DEFAULT_WINDOW_DAYS = 30;
+
 export interface SpendData {
-  /** Human label for the selected period (echoes the ControlPanel range). */
+  /**
+   * Human label for the selected period, echoing the ControlPanel range. Formatted
+   * on the CLIENT in the viewer's local timezone (see spendPeriodLabels / useSpend),
+   * NOT part of the server payload: the handler only has UTC instants and never
+   * receives the caller's timezone, so a local-midnight range formatted server-side
+   * lands a day early east of UTC. See SpendServerPayload.
+   */
   periodLabel: string;
-  /** Human label for the prior comparison period. */
+  /** Human label for the prior comparison period; client-formatted, see periodLabel. */
   priorPeriodLabel: string;
   /**
    * Whether any events settled in the window. Authoritative empty-state signal
@@ -480,6 +489,13 @@ export interface SpendData {
   byModel: CostByModelRow[];
   dailyCost: DailyCostPoint[];
 }
+
+/**
+ * What GET /api/admin/spend actually returns. The tz-local period labels are added
+ * by the client (they can't be formatted server-side, and are omitted from the 12h
+ * response cache so a label can't leak across callers in different timezones).
+ */
+export type SpendServerPayload = Omit<SpendData, 'periodLabel' | 'priorPeriodLabel'>;
 
 /** One model's slice of an agent execution's iteration billing. */
 export interface ISessionAgentModelUsage {

--- a/b4m-core/common/src/types/entities/UsageEventTypes.ts
+++ b/b4m-core/common/src/types/entities/UsageEventTypes.ts
@@ -31,7 +31,7 @@ export const USAGE_EVENT_FEATURES = [
 
 export type UsageEventFeature = (typeof USAGE_EVENT_FEATURES)[number];
 
-export const USAGE_EVENT_STATUSES = ['ok', 'error', 'timeout'] as const;
+export const USAGE_EVENT_STATUSES = ['ok', 'error', 'timeout', 'refusal'] as const;
 
 export type UsageEventStatus = (typeof USAGE_EVENT_STATUSES)[number];
 
@@ -335,6 +335,68 @@ export interface ISessionUsageSummary {
   byModel: ISessionModelUsage[];
 }
 
+/**
+ * Filters for the admin Spend rollup. Date bounds map to `createdAt` (inclusive);
+ * omitting a field spans all. `userId`/`model` mirror the ModelMetrics user/model
+ * filters. Status is intentionally not a filter here: it would distort the
+ * error-rate KPI, which is derived from the same event set.
+ */
+export interface ISpendSummaryFilters {
+  from?: Date;
+  to?: Date;
+  userId?: string;
+  model?: string;
+}
+
+/** Spend for one credit holder (the account behind the events) over the window. */
+export interface ISpendAccountBucket extends IUsageSpendBucket {
+  ownerId: string;
+  ownerType: CreditHolderType;
+}
+
+/** COGS for one UTC day (Spend daily-cost line point). */
+export interface ISpendCostDay {
+  day: string; // YYYY-MM-DD (UTC)
+  cogsUsd: number;
+}
+
+/** p50/p95 request latency in ms over the window; 0 when no event carries latencyMs. */
+export interface ISpendLatency {
+  p50: number;
+  p95: number;
+}
+
+/**
+ * Request-outcome counts over the window. The error rate folds `errors` and
+ * `timeouts` together (both are failed calls); `refusals` are counted separately
+ * so a model refusal reads as its own rate rather than an error.
+ */
+export interface ISpendStatusCounts {
+  total: number;
+  errors: number;
+  timeouts: number;
+  refusals: number;
+}
+
+/**
+ * One window's spend rolled up every way the admin Spend tab needs it, in a
+ * single aggregation so all cuts reconcile against the same event set. `byModel`
+ * and `byAccount` are descending by creditsCharged; `dailyCost` is ascending by
+ * day. p50/p95 latency and status counts are not available from the margin
+ * rollups, hence this dedicated summary. The API layer adds vs-prior deltas,
+ * owner-name resolution, and the client SpendData shape on top.
+ */
+export interface ISpendSummary {
+  totals: IUsageSpendBucket;
+  /** Distinct credit holders (ownerId) with at least one event in the window. */
+  activeAccounts: number;
+  latency: ISpendLatency;
+  status: ISpendStatusCounts;
+  byModel: IOwnerSpendModel[];
+  byAccount: ISpendAccountBucket[];
+  dailyCost: ISpendCostDay[];
+}
+
 /** One model's slice of an agent execution's iteration billing. */
 export interface ISessionAgentModelUsage {
   model: string;
@@ -379,6 +441,14 @@ export interface IUsageEventRepository extends IBaseRepository<IUsageEventDocume
 
   /** Monthly COGS per provider for invoice reconciliation, newest month first. */
   monthlyCogsByProvider(): Promise<IProviderMonthCogs[]>;
+
+  /**
+   * Spend rollup for the admin Spend tab over a bounded window, honoring optional
+   * user/model filters, in a single aggregation. Includes p50/p95 latency and
+   * status-outcome counts (neither available from the margin rollups). Call once
+   * per window (current + prior) to build vs-prior KPI deltas.
+   */
+  spendSummary(filters?: ISpendSummaryFilters): Promise<ISpendSummary>;
 
   /** Settlement-basis rollup over the trailing N days (default 30): provider-vs-local token delta and written-off credits. */
   settlementBreakdown(days?: number): Promise<ISettlementBreakdown[]>;

--- a/packages/database/src/models/billing/UsageEventModel.test.ts
+++ b/packages/database/src/models/billing/UsageEventModel.test.ts
@@ -559,4 +559,101 @@ describe('UsageEventRepository', () => {
       expect(belongs).toBe(false);
     });
   });
+
+  describe('spendSummary', () => {
+    it('rolls up totals, models, accounts, and daily cost in one pass', async () => {
+      await record({
+        ownerId: 'org-1',
+        ownerType: CreditHolderType.Organization,
+        model: 'opus',
+        costUsd: 2,
+        creditsCharged: 200,
+      });
+      await record({
+        ownerId: 'org-1',
+        ownerType: CreditHolderType.Organization,
+        model: 'opus',
+        costUsd: 1,
+        creditsCharged: 100,
+      });
+      await record({
+        ownerId: 'user-9',
+        ownerType: CreditHolderType.User,
+        model: 'sonnet',
+        costUsd: 1,
+        creditsCharged: 100,
+      });
+
+      const summary = await usageEventRepository.spendSummary();
+
+      expect(summary.totals).toEqual({ requests: 3, cogsUsd: 4, creditsCharged: 400 });
+      expect(summary.activeAccounts).toBe(2);
+
+      // Descending by creditsCharged: opus (300) before sonnet (100).
+      expect(summary.byModel.map(m => m.model)).toEqual(['opus', 'sonnet']);
+      expect(summary.byModel[0]).toMatchObject({ model: 'opus', requests: 2, cogsUsd: 3, creditsCharged: 300 });
+
+      expect(summary.byAccount.map(a => a.ownerId)).toEqual(['org-1', 'user-9']);
+      expect(summary.byAccount[0]).toMatchObject({
+        ownerId: 'org-1',
+        ownerType: CreditHolderType.Organization,
+        requests: 2,
+        cogsUsd: 3,
+        creditsCharged: 300,
+      });
+
+      // Every event shares baseEvent's default createdAt day, so one daily bucket.
+      expect(summary.dailyCost).toHaveLength(1);
+      expect(summary.dailyCost[0].cogsUsd).toBe(4);
+    });
+
+    it('computes p50/p95 latency and error/timeout/refusal counts', async () => {
+      // Latencies 100..500; p50 ~= 300, p95 ~= 500 under approximate percentile.
+      for (const latencyMs of [100, 200, 300, 400, 500]) {
+        await record({ latencyMs, status: 'ok' });
+      }
+      await record({ status: 'error', latencyMs: 600 });
+      await record({ status: 'timeout', latencyMs: 700 });
+      await record({ status: 'refusal', latencyMs: 800 });
+
+      const summary = await usageEventRepository.spendSummary();
+
+      expect(summary.status).toEqual({ total: 8, errors: 1, timeouts: 1, refusals: 1 });
+      expect(summary.latency.p50).toBeGreaterThanOrEqual(200);
+      expect(summary.latency.p50).toBeLessThanOrEqual(500);
+      expect(summary.latency.p95).toBeGreaterThanOrEqual(summary.latency.p50);
+    });
+
+    it('honors the date window and the user/model filters', async () => {
+      // timestamps:true governs createdAt through Mongoose, so age this row via the raw driver.
+      const oldDoc = await record({ userId: 'u-a', model: 'opus' });
+      await UsageEvent.collection.updateOne(
+        { _id: oldDoc!._id },
+        { $set: { createdAt: new Date('2020-01-01T00:00:00Z') } }
+      );
+      await record({ userId: 'u-a', model: 'opus' });
+      await record({ userId: 'u-b', model: 'opus' });
+      await record({ userId: 'u-a', model: 'sonnet' });
+
+      const from = new Date('2024-01-01T00:00:00Z');
+      const byUser = await usageEventRepository.spendSummary({ from, userId: 'u-a' });
+      // Excludes the 2020 row (out of window) and the u-b row (other user).
+      expect(byUser.totals.requests).toBe(2);
+
+      const byModel = await usageEventRepository.spendSummary({ from, userId: 'u-a', model: 'opus' });
+      expect(byModel.totals.requests).toBe(1);
+    });
+
+    it('returns zeroed structure for an empty window', async () => {
+      const summary = await usageEventRepository.spendSummary({ from: new Date('2099-01-01T00:00:00Z') });
+
+      expect(summary.totals).toEqual({ requests: 0, cogsUsd: 0, creditsCharged: 0 });
+      expect(summary.activeAccounts).toBe(0);
+      expect(summary.latency).toEqual({ p50: 0, p95: 0 });
+      expect(summary.status).toEqual({ total: 0, errors: 0, timeouts: 0, refusals: 0 });
+      expect(summary.byModel).toEqual([]);
+      expect(summary.byAccount).toEqual([]);
+      expect(summary.dailyCost).toEqual([]);
+    });
+  });
 });

--- a/packages/database/src/models/billing/UsageEventModel.test.ts
+++ b/packages/database/src/models/billing/UsageEventModel.test.ts
@@ -644,6 +644,25 @@ describe('UsageEventRepository', () => {
       expect(byModel.totals.requests).toBe(1);
     });
 
+    it('treats the window as half-open [from, to): excludes an event at exactly `to`', async () => {
+      const boundary = new Date('2024-06-01T00:00:00Z');
+      const inside = await record();
+      await UsageEvent.collection.updateOne(
+        { _id: inside!._id },
+        { $set: { createdAt: new Date('2024-05-31T23:59:59Z') } }
+      );
+      const onBoundary = await record();
+      await UsageEvent.collection.updateOne({ _id: onBoundary!._id }, { $set: { createdAt: boundary } });
+
+      // The prior window's upper bound abuts the current window's `from`; an event
+      // on that instant must land in exactly one window, not both.
+      const summary = await usageEventRepository.spendSummary({
+        from: new Date('2024-05-01T00:00:00Z'),
+        to: boundary,
+      });
+      expect(summary.totals.requests).toBe(1);
+    });
+
     it('returns zeroed structure for an empty window', async () => {
       const summary = await usageEventRepository.spendSummary({ from: new Date('2099-01-01T00:00:00Z') });
 

--- a/packages/database/src/models/billing/UsageEventModel.ts
+++ b/packages/database/src/models/billing/UsageEventModel.ts
@@ -206,6 +206,9 @@ export class UsageEventRepository extends BaseRepository<IUsageEventDocument> im
     ]);
   }
 
+  // Requires MongoDB 7.0+ for the $percentile accumulator (latency facet) and uses
+  // $facet like the sibling summaries here - both unsupported under DocumentDB
+  // (USE_DOCUMENTDB_COMPATIBILITY), which those methods already assume against.
   async spendSummary(filters: ISpendSummaryFilters = {}): Promise<ISpendSummary> {
     const { from, to, userId, model } = filters;
 

--- a/packages/database/src/models/billing/UsageEventModel.ts
+++ b/packages/database/src/models/billing/UsageEventModel.ts
@@ -39,6 +39,10 @@ export type IUsageEventDocument = IUsageEvent & IMongoDocument;
 // spend spans many accounts.
 const SPEND_ACCOUNT_LIMIT = 50;
 
+// Same payload guard for the "by model" list: a catalog with many provider/model
+// variants would otherwise ship every one. Comfortably above a realistic catalog.
+const SPEND_MODEL_LIMIT = 100;
+
 /**
  * One row per provider API call: provider-side quantities and
  * frozen USD cost next to the credits actually debited. Dual-written at
@@ -214,9 +218,12 @@ export class UsageEventRepository extends BaseRepository<IUsageEventDocument> im
 
     const match: Record<string, unknown> = {};
     if (from || to) {
+      // Half-open window [from, to): the upper bound is exclusive so adjacent
+      // windows (current vs the equal-length prior window, whose `to` is the
+      // current window's `from`) don't both count an event at the shared instant.
       const createdAt: Record<string, Date> = {};
       if (from) createdAt.$gte = from;
-      if (to) createdAt.$lte = to;
+      if (to) createdAt.$lt = to;
       match.createdAt = createdAt;
     }
     if (userId) match.userId = userId;
@@ -261,6 +268,7 @@ export class UsageEventRepository extends BaseRepository<IUsageEventDocument> im
             { $group: { _id: { provider: '$provider', model: '$model' }, ...spendSums } },
             { $project: { _id: 0, provider: '$_id.provider', model: '$_id.model', ...spendFields } },
             { $sort: { creditsCharged: -1 } },
+            { $limit: SPEND_MODEL_LIMIT },
           ],
           byAccount: [
             { $group: { _id: { ownerId: '$ownerId', ownerType: '$ownerType' }, ...spendSums } },
@@ -268,6 +276,9 @@ export class UsageEventRepository extends BaseRepository<IUsageEventDocument> im
             { $sort: { creditsCharged: -1 } },
             { $limit: SPEND_ACCOUNT_LIMIT },
           ],
+          // Uncapped by design: one row per UTC day in the window feeds the line
+          // chart, which needs every point. Bounded by the window length (days),
+          // not by event volume, so it stays small even for wide ranges.
           dailyCost: [
             {
               $group: {

--- a/packages/database/src/models/billing/UsageEventModel.ts
+++ b/packages/database/src/models/billing/UsageEventModel.ts
@@ -18,6 +18,10 @@ import {
   ISessionQuestUsage,
   ISessionUsageSummary,
   ISettlementBreakdown,
+  ISpendAccountBucket,
+  ISpendCostDay,
+  ISpendSummary,
+  ISpendSummaryFilters,
   IUsageEvent,
   IUsageEventInput,
   IUsageEventRepository,
@@ -29,6 +33,11 @@ import {
 } from '@bike4mind/common';
 
 export type IUsageEventDocument = IUsageEvent & IMongoDocument;
+
+// The Spend "by account" table shows top spenders, not every holder; the
+// activeAccounts count carries the true distinct total. Bounds the payload when
+// spend spans many accounts.
+const SPEND_ACCOUNT_LIMIT = 50;
 
 /**
  * One row per provider API call: provider-side quantities and
@@ -195,6 +204,101 @@ export class UsageEventRepository extends BaseRepository<IUsageEventDocument> im
       },
       { $sort: { month: -1, provider: 1 } },
     ]);
+  }
+
+  async spendSummary(filters: ISpendSummaryFilters = {}): Promise<ISpendSummary> {
+    const { from, to, userId, model } = filters;
+
+    const match: Record<string, unknown> = {};
+    if (from || to) {
+      const createdAt: Record<string, Date> = {};
+      if (from) createdAt.$gte = from;
+      if (to) createdAt.$lte = to;
+      match.createdAt = createdAt;
+    }
+    if (userId) match.userId = userId;
+    if (model) match.model = model;
+
+    const spendSums = {
+      requests: { $sum: 1 },
+      cogsUsd: { $sum: '$costUsd' },
+      creditsCharged: { $sum: '$creditsCharged' },
+    } as const;
+    const spendFields = { requests: 1, cogsUsd: 1, creditsCharged: 1 } as const;
+
+    // One $match, fan out with $facet so every cut reconciles against the same
+    // event set in a single index scan.
+    const [result] = await this.model.aggregate<{
+      totals: IUsageSpendBucket[];
+      activeAccounts: Array<{ count: number }>;
+      latency: Array<{ values: number[] }>;
+      status: Array<{ _id: string; count: number }>;
+      byModel: IOwnerSpendModel[];
+      byAccount: ISpendAccountBucket[];
+      dailyCost: ISpendCostDay[];
+    }>([
+      { $match: match },
+      {
+        $facet: {
+          totals: [{ $group: { _id: null, ...spendSums } }, { $project: { _id: 0, ...spendFields } }],
+          activeAccounts: [{ $group: { _id: '$ownerId' } }, { $count: 'count' }],
+          latency: [
+            { $match: { latencyMs: { $ne: null } } },
+            {
+              $group: {
+                _id: null,
+                // $percentile (Mongo 7.0+) keeps this memory-bounded vs pushing every latency into
+                // one doc. any: the operator postdates mongoose's typed AccumulatorOperator.
+                values: { $percentile: { input: '$latencyMs', p: [0.5, 0.95], method: 'approximate' } } as any,
+              },
+            },
+          ],
+          status: [{ $group: { _id: '$status', count: { $sum: 1 } } }],
+          byModel: [
+            { $group: { _id: { provider: '$provider', model: '$model' }, ...spendSums } },
+            { $project: { _id: 0, provider: '$_id.provider', model: '$_id.model', ...spendFields } },
+            { $sort: { creditsCharged: -1 } },
+          ],
+          byAccount: [
+            { $group: { _id: { ownerId: '$ownerId', ownerType: '$ownerType' }, ...spendSums } },
+            { $project: { _id: 0, ownerId: '$_id.ownerId', ownerType: '$_id.ownerType', ...spendFields } },
+            { $sort: { creditsCharged: -1 } },
+            { $limit: SPEND_ACCOUNT_LIMIT },
+          ],
+          dailyCost: [
+            {
+              $group: {
+                _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt', timezone: 'UTC' } },
+                cogsUsd: { $sum: '$costUsd' },
+              },
+            },
+            { $project: { _id: 0, day: '$_id', cogsUsd: 1 } },
+            { $sort: { day: 1 } },
+          ],
+        },
+      },
+    ]);
+
+    const emptyTotals: IUsageSpendBucket = { requests: 0, cogsUsd: 0, creditsCharged: 0 };
+    const statusRows = result?.status ?? [];
+    const countFor = (s: string) => statusRows.find(r => r._id === s)?.count ?? 0;
+    // $percentile emits [p50, p95] in the requested order; empty window => no group => [].
+    const latencyValues = result?.latency?.[0]?.values ?? [];
+
+    return {
+      totals: result?.totals?.[0] ?? emptyTotals,
+      activeAccounts: result?.activeAccounts?.[0]?.count ?? 0,
+      latency: { p50: Math.round(latencyValues[0] ?? 0), p95: Math.round(latencyValues[1] ?? 0) },
+      status: {
+        total: statusRows.reduce((sum, r) => sum + r.count, 0),
+        errors: countFor('error'),
+        timeouts: countFor('timeout'),
+        refusals: countFor('refusal'),
+      },
+      byModel: result?.byModel ?? [],
+      byAccount: result?.byAccount ?? [],
+      dailyCost: result?.dailyCost ?? [],
+    };
   }
 
   async settlementBreakdown(days: number = 30): Promise<ISettlementBreakdown[]> {


### PR DESCRIPTION
## Description

Replaces the Spend tab's mock fixture with real data sourced from the `UsageEvent` collection (authoritative frozen `costUsd` / `creditsCharged` / `latencyMs`). The tab now shows live estimated cost, requests, credits, active accounts, latency percentiles, and error/refusal rates for the selected filter window, each with a vs-prior-period delta.

Builds on No. 1507 (the merged mock PR), whose exported `SpendData` type is the shared client/server contract.

Closes #1508

## Changes

- **New `usageEventRepository.spendSummary(filters)`** (`packages/database`): a single `$facet` aggregation over a bounded `createdAt` window (with optional `userId` / `model` filters) returning totals, distinct active accounts, p50/p95 `latencyMs` (via the `$percentile` accumulator), status-outcome counts, by-model, by-account (top 50 by credits), and daily cost. Types added to `UsageEventTypes.ts`.
- **New `GET /api/admin/spend`** (admin-only, 12h read-through cache, `?recache=true` to bust): runs the summary for the selected window **and the immediately prior equal-length window** for the KPI deltas, resolves owner ids to org/user display names (mirroring `platform-usage`), and returns the shared `SpendData` shape.
- **New `useSpend` hook**: react-query, mirrors `useModelMetrics` (with `recache`), accepts the shared `appliedFilters`.
- **`SpendTab`** split into a container (loading / error / empty states, calls `useSpend`) and a presentational `SpendTabView`; the `MOCKUP - FAKE DATA` badge is removed and `index.tsx` passes `appliedFilters` through.
- **Added a real `refusal` status** to `USAGE_EVENT_STATUSES` so refusal rate is its own countable KPI alongside the error rate (which folds in timeouts). See note below.
- New unit tests: repository (`spendSummary` rollups, percentiles, filters, empty window) and handler (auth, current/prior windows, filter mapping, KPI shaping, org-name resolution); `SpendTab` tests refactored to cover the view + all container states.

## Guide for Testers
<img width="1792" height="953" alt="Screenshot 2026-08-11 at 12 29 17 pm" src="https://github.com/user-attachments/assets/3d165e71-dbef-4d5e-b881-f9509364ae74" />

1. Log in as an admin at `app.staging.bike4mind.com`.
2. Navigate: Sidebar -> Admin -> Model Metrics.
3. Click the `Spend` tab (wallet icon).
4. Expected: no `MOCKUP - FAKE DATA` badge; a period label reads `Last 30 days vs Prior 30 days`; the KPI row shows 9 cards (Est. Cost, Requests, Cost / Req, Credits Used, Active Accounts, p50 Latency, p95 Latency, Error Rate, Refusal Rate), each with a colored delta chip.
5. Expected: a `Spend by Account` table, a `Cost by Model` bar list, and a `Daily Cost` line chart all render with real numbers (values depend on staging data).
6. In the filter bar above the tabs, set a narrower date range and click `Apply`. Expected: all four sections and the period label update to the selected window; the deltas recompute against the equal-length prior window.
7. Set the User or Model filter and click `Apply`. Expected: the sections narrow to that user/model.
8. Pick a date range with no usage. Expected: a `No spend data for <period>.` message instead of the sections.

### Regression Checks
1. Overview, Analytics, and Raw Data tabs still load and respond to the same filter bar unchanged.

### What NOT to test
- The `Refusal Rate` card will read `0.0%` on all data: no code path records `status: 'refusal'` yet (see Additional Information). This is expected, not a bug.
- Model names in `Cost by Model` show the raw model id (no friendly-name mapping yet), matching the existing usage/margin admin endpoints.

## Additional Information

`UsageEvent.status` previously only allowed `ok | error | timeout`, with no refusal concept. Rather than fabricate a refusal number or drop the KPI the design calls for, this PR adds a real `refusal` status to the enum so refusal rate is a genuine, countable metric. No recorder writes `status: 'refusal'` today (the Anthropic backend's refusal path throws and falls back to another model, which settles as `ok`), so the card reads 0% until refusal capture is wired at settlement time -- a natural follow-up with billing implications, kept out of this PR.

The `statusFilter` from the shared filter bar is intentionally not applied to spend: UsageEvent statuses do not map to the quest statuses that filter offers, and filtering on it would distort the error/refusal KPIs.

## Developer Notes

- `usageEventRepository.spendSummary(filters)` is a reusable single-pass spend rollup (window + user/model filters) that any future admin spend view can consume; it is the first repo method to surface p50/p95 latency and status-outcome counts.
- The `SpendData` type in `spendMockData.ts` is the shared client/server contract -- the endpoint produces it and the tab consumes it with no component changes.
- `SpendTab` now follows the container/presentational split (`SpendTab` + `SpendTabView`), so the rendering is unit-testable without mocking the data layer.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
