### PR TITLE
refactor(admin): type the GET /api/users response so field-name drift is a compile error

### DIFF
--- a/apps/client/app/components/admin/CreditAnalysis/components/CreditAdjustmentModal.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/CreditAdjustmentModal.tsx
@@ -20,11 +20,12 @@ import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import { useQueryClient } from '@tanstack/react-query';
 import { useUserCreditAdjustments, userCreditAdjustmentsKey } from '../hooks/useUserCreditAdjustments';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 
 interface CreditAdjustmentModalProps {
   open: boolean;
   onClose: () => void;
-  selectedUser: any;
+  selectedUser: AdminUserListItem | null;
   onCreditAdjustment: (userId: string, currentCredits: number, adjustment: number, note?: string) => Promise<void>;
 }
 

--- a/apps/client/app/components/admin/CreditAnalysis/components/UserCreditsManager.tsx
+++ b/apps/client/app/components/admin/CreditAnalysis/components/UserCreditsManager.tsx
@@ -22,21 +22,10 @@ import SortIcon from '@mui/icons-material/Sort';
 import CreditCardIcon from '@mui/icons-material/CreditCard';
 import SharedPaginationControls from '@client/app/components/admin/Subscriptions/components/PaginationControls';
 import { useIsMobile } from '@client/app/hooks/useIsMobile';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { useUserCreditsManager } from '../hooks/useUserCreditsManager';
 import ViewUserProfile from './ViewUserProfile';
 import { CreditAdjustmentModal } from './CreditAdjustmentModal';
-
-interface AdminUser {
-  id: string;
-  name?: string;
-  email?: string;
-  currentCredits?: number;
-  loginRecords?: Array<{ loginTime?: string | Date }> | null;
-  lastActiveAt?: string | Date;
-  isOnline?: boolean;
-  isAdmin?: boolean;
-  createdAt: string;
-}
 
 interface UserCreditsManagerProps {
   onRefresh?: () => void;
@@ -47,7 +36,7 @@ const ACTIVE_WITHIN_DAYS = 30;
 
 // Most recent explicit login (loginRecords, as the Admin > Users view uses); falls back
 // to the websocket-tracked lastActiveAt for users with no recorded login yet.
-const getLastLoginDate = (user: AdminUser): Date | null => {
+const getLastLoginDate = (user: AdminUserListItem): Date | null => {
   const latest = user.loginRecords?.reduce<string | Date | undefined>((acc, record) => {
     const t = record?.loginTime;
     if (!t) return acc;
@@ -57,7 +46,7 @@ const getLastLoginDate = (user: AdminUser): Date | null => {
   return source ? new Date(source) : null;
 };
 
-const getActivityStatus = (user: AdminUser): { label: string; color: 'success' | 'neutral' } => {
+const getActivityStatus = (user: AdminUserListItem): { label: string; color: 'success' | 'neutral' } => {
   if (user.isOnline) return { label: 'Online', color: 'success' };
   if (user.lastActiveAt) {
     const daysSince = (Date.now() - new Date(user.lastActiveAt).getTime()) / 86_400_000;
@@ -67,11 +56,11 @@ const getActivityStatus = (user: AdminUser): { label: string; color: 'success' |
 };
 
 export const UserCreditsManager: React.FC<UserCreditsManagerProps> = ({ onRefresh }) => {
-  const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
+  const [selectedUser, setSelectedUser] = useState<AdminUserListItem | null>(null);
   const [creditsModalOpen, setCreditsModalOpen] = useState(false);
   const isMobile = useIsMobile();
 
-  const openCreditsModal = (user: AdminUser) => {
+  const openCreditsModal = (user: AdminUserListItem) => {
     setSelectedUser(user);
     setCreditsModalOpen(true);
   };
@@ -164,7 +153,7 @@ export const UserCreditsManager: React.FC<UserCreditsManagerProps> = ({ onRefres
         </Alert>
       ) : isMobile ? (
         <Stack spacing={1}>
-          {(paginatedUsers as AdminUser[]).map(user => {
+          {paginatedUsers.map(user => {
             const lastLogin = getLastLoginDate(user);
             const status = getActivityStatus(user);
             return (
@@ -233,7 +222,7 @@ export const UserCreditsManager: React.FC<UserCreditsManagerProps> = ({ onRefres
               </tr>
             </thead>
             <tbody>
-              {(paginatedUsers as AdminUser[]).map(user => {
+              {paginatedUsers.map(user => {
                 const lastLogin = getLastLoginDate(user);
                 const status = getActivityStatus(user);
                 return (

--- a/apps/client/app/components/admin/CreditAnalysis/hooks/useUserCreditsManager.ts
+++ b/apps/client/app/components/admin/CreditAnalysis/hooks/useUserCreditsManager.ts
@@ -48,7 +48,7 @@ export function useUserCreditsManager(onRefresh?: () => void) {
     onRefresh?.();
   };
 
-  const users = (allUsers.data?.users ?? []) as any[];
+  const users = allUsers.data?.users ?? [];
 
   const handleCreditAdjustment = async (userId: string, currentCredits: number, adjustment: number, note?: string) => {
     const newCredits = Math.max(0, currentCredits + adjustment);

--- a/apps/client/app/components/admin/Users/Details/AdminApiKeysModal.tsx
+++ b/apps/client/app/components/admin/Users/Details/AdminApiKeysModal.tsx
@@ -1,6 +1,7 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { useAdminGetUserApiKeys, useAdminResetApiKeyRateLimit } from '@client/app/hooks/data/userApiKeys';
 import { useConfirmation } from '@client/app/hooks/useConfirmation';
-import { ApiKeyStatus, IUserApiKeyDocument, IUserDocument } from '@bike4mind/common';
+import { ApiKeyStatus, IUserApiKeyDocument } from '@bike4mind/common';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import {
@@ -28,7 +29,7 @@ dayjs.extend(relativeTime);
 interface AdminApiKeysModalProps {
   open: boolean;
   onClose: () => void;
-  user: IUserDocument;
+  user: AdminUserListItem;
 }
 
 const STATUS_CHIP: Record<ApiKeyStatus, { color: 'success' | 'neutral' | 'warning' | 'danger'; label: string }> = {

--- a/apps/client/app/components/admin/Users/Details/AdminGenerateApiKeyModal.tsx
+++ b/apps/client/app/components/admin/Users/Details/AdminGenerateApiKeyModal.tsx
@@ -1,6 +1,6 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { useAdminGenerateApiKey, CreateUserApiKeyRequest } from '@client/app/hooks/data/userApiKeys';
 import { useCopyToClipboard } from '@client/app/hooks/useCopyToClipboard';
-import { IUserDocument } from '@bike4mind/common';
 import { GENERIC_MODAL_API_KEY_SCOPES } from '@client/app/constants/apiKeyScopes';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -26,7 +26,7 @@ import dayjs from 'dayjs';
 interface AdminGenerateApiKeyModalProps {
   open: boolean;
   onClose: () => void;
-  user: IUserDocument;
+  user: AdminUserListItem;
 }
 
 // Embed keys are minted through the dedicated embed flow (epic #41 Phase E), not

--- a/apps/client/app/components/admin/Users/Details/Bike4MindUserDetails.tsx
+++ b/apps/client/app/components/admin/Users/Details/Bike4MindUserDetails.tsx
@@ -1,3 +1,4 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { EditedFieldsState } from '@client/app/components/admin/Users/Views/FullUsersView';
 import { IUserDocument } from '@bike4mind/common';
 import GroupAddIcon from '@mui/icons-material/GroupAdd';
@@ -11,7 +12,7 @@ import { api } from '@client/app/contexts/ApiContext';
 import { useQueryClient } from '@tanstack/react-query';
 
 interface Bike4MindUserDetailsProps {
-  user: IUserDocument;
+  user: AdminUserListItem;
   userKey: string;
   editedFields: EditedFieldsState;
   onFieldChange: (fieldName: keyof IUserDocument, value: unknown) => void;

--- a/apps/client/app/components/admin/Users/Details/GrantSubscriptionModal.tsx
+++ b/apps/client/app/components/admin/Users/Details/GrantSubscriptionModal.tsx
@@ -1,3 +1,4 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { useGetSubscriptionPlans } from '@client/app/hooks/data/stripe';
 import { useGrantSubscription } from '@client/app/hooks/data/subscriptions';
 import { SUBSCRIPTION_PLANS } from '@client/lib/userSubscriptions/constants';
@@ -5,7 +6,6 @@ import {
   ORGANIZATION_SUBSCRIPTION_MIN_SEATS,
   ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
 } from '@client/lib/subscriptions/constants';
-import { IUserDocument } from '@bike4mind/common';
 import {
   Modal,
   ModalDialog,
@@ -28,7 +28,7 @@ import React, { useState, useMemo } from 'react';
 import UserSelector from './UserSelector';
 
 interface GrantSubscriptionModalProps {
-  user: IUserDocument;
+  user: AdminUserListItem;
   open: boolean;
   onClose: () => void;
 }

--- a/apps/client/app/components/admin/Users/Details/LoginDetails.tsx
+++ b/apps/client/app/components/admin/Users/Details/LoginDetails.tsx
@@ -1,4 +1,4 @@
-import { IUserDocument, WithOrgRef } from '@bike4mind/common';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { Card, Stack, Typography } from '@mui/joy';
 import React from 'react';
 import LoginsView from '../LoginsView';
@@ -9,7 +9,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 dayjs.extend(relativeTime);
 
 interface LoginDetailsProps {
-  user: WithOrgRef<IUserDocument>;
+  user: AdminUserListItem;
 }
 
 const LoginDetails: React.FC<LoginDetailsProps> = React.memo(({ user }) => {

--- a/apps/client/app/components/admin/Users/Details/UserDetails.tsx
+++ b/apps/client/app/components/admin/Users/Details/UserDetails.tsx
@@ -1,3 +1,4 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { EditedFieldsState } from '@client/app/components/admin/Users/Views/FullUsersView';
 
 import GrantSubscriptionModal from './GrantSubscriptionModal';
@@ -6,7 +7,7 @@ import AdminApiKeysModal from './AdminApiKeysModal';
 import MFAStatusBadge from '../MFAStatusBadge';
 import { useForceResetMFA } from '@client/app/hooks/data/mfa';
 import { useConfirmation } from '@client/app/hooks/useConfirmation';
-import { IUserDocument, WithOrgRef } from '@bike4mind/common';
+import { IUserDocument } from '@bike4mind/common';
 import KeyIcon from '@mui/icons-material/Key';
 import CardGiftcardIcon from '@mui/icons-material/CardGiftcard';
 import SecurityIcon from '@mui/icons-material/Security';
@@ -20,7 +21,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@client/app/contexts/ApiContext';
 
 interface UserDetailsProps {
-  user: WithOrgRef<IUserDocument>;
+  user: AdminUserListItem;
   editedFields: EditedFieldsState;
   onFieldChange: (fieldName: keyof IUserDocument, value: unknown) => void;
 }

--- a/apps/client/app/components/admin/Users/Details/UserSelector.tsx
+++ b/apps/client/app/components/admin/Users/Details/UserSelector.tsx
@@ -1,5 +1,5 @@
 import { useGetUsers } from '@client/app/hooks/data/user';
-import { IUserDocument } from '@bike4mind/common';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import {
   Autocomplete,
   AutocompleteOption,
@@ -32,7 +32,7 @@ const UserSelector: React.FC<UserSelectorProps> = ({
   excludeUserId,
 }) => {
   const { value: inputValue, debouncedValue: debouncedSearch, setValue: setInputValue } = useDebounceValue('');
-  const [selectedUserCache, setSelectedUserCache] = useState<IUserDocument | null>(null);
+  const [selectedUserCache, setSelectedUserCache] = useState<AdminUserListItem | null>(null);
 
   // Fetch users with debounced search
   const { data, isLoading } = useGetUsers({
@@ -67,7 +67,7 @@ const UserSelector: React.FC<UserSelectorProps> = ({
   }, [selectedUser, value]);
 
   const handleChange = useCallback(
-    (_event: React.SyntheticEvent, newValue: IUserDocument | null) => {
+    (_event: React.SyntheticEvent, newValue: AdminUserListItem | null) => {
       onChange(newValue?.id || null);
       if (newValue) {
         setSelectedUserCache(newValue);

--- a/apps/client/app/components/admin/Users/Details/UserSubscriptionStatus.tsx
+++ b/apps/client/app/components/admin/Users/Details/UserSubscriptionStatus.tsx
@@ -1,5 +1,5 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { useGetUserSubscriptions, useRemoveSubscription } from '@client/app/hooks/data/subscriptions';
-import { IUserDocument } from '@bike4mind/common';
 import {
   Box,
   Card,
@@ -26,7 +26,7 @@ import { useConfirmation } from '@client/app/hooks/useConfirmation';
 import EditCreditsModal from './EditCreditsModal';
 
 interface UserSubscriptionStatusProps {
-  user: IUserDocument;
+  user: AdminUserListItem;
 }
 
 const UserSubscriptionStatus: React.FC<UserSubscriptionStatusProps> = ({ user }) => {

--- a/apps/client/app/components/admin/Users/LoginDetailsModal.tsx
+++ b/apps/client/app/components/admin/Users/LoginDetailsModal.tsx
@@ -1,6 +1,7 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import React from 'react';
 import { Box, Card, DialogContent, Modal, ModalDialog, Typography, Divider, Stack, Avatar } from '@mui/joy';
-import { ILoginRecord, IUserDocument, WithOrgRef } from '@bike4mind/common';
+import { ILoginRecord } from '@bike4mind/common';
 import PersonIcon from '@mui/icons-material/Person';
 import BusinessIcon from '@mui/icons-material/Business';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
@@ -20,7 +21,7 @@ import AlternateEmailIcon from '@mui/icons-material/AlternateEmail';
 interface LoginDetailsModalProps {
   open: boolean;
   onClose: () => void;
-  user: WithOrgRef<IUserDocument>;
+  user: AdminUserListItem;
   lastLoginRecord: ILoginRecord | undefined;
 }
 

--- a/apps/client/app/components/admin/Users/LoginsView.tsx
+++ b/apps/client/app/components/admin/Users/LoginsView.tsx
@@ -1,13 +1,13 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import React, { useState } from 'react';
 import { Chip, Tooltip } from '@mui/joy';
 import CircleIcon from '@mui/icons-material/Circle';
-import { IUserDocument, WithOrgRef } from '@bike4mind/common';
 import LoginDetailsModal from './LoginDetailsModal';
 import { useGetUserActivityCounters } from '@client/app/hooks/data/user';
 import { AuthEvents } from '@bike4mind/common';
 
 interface LoginsViewProps {
-  user: WithOrgRef<IUserDocument>;
+  user: AdminUserListItem;
 }
 
 const LoginsView: React.FC<LoginsViewProps> = ({ user }) => {

--- a/apps/client/app/components/admin/Users/MFAStatusBadge.tsx
+++ b/apps/client/app/components/admin/Users/MFAStatusBadge.tsx
@@ -1,10 +1,10 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import React from 'react';
 import { Chip, Tooltip } from '@mui/joy';
 import { CheckCircle, RadioButtonUnchecked } from '@mui/icons-material';
-import { IUserDocument } from '@bike4mind/common';
 
 interface MFAStatusBadgeProps {
-  user: IUserDocument;
+  user: AdminUserListItem;
   size?: 'sm' | 'md' | 'lg';
 }
 

--- a/apps/client/app/components/admin/Users/MigrateAgain.tsx
+++ b/apps/client/app/components/admin/Users/MigrateAgain.tsx
@@ -1,11 +1,11 @@
-import { IUserDocument, WithOrgRef } from '@bike4mind/common';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { useMigrateUsers } from '@client/app/utils/userAPICalls';
 import ForwardToInboxIcon from '@mui/icons-material/ForwardToInbox';
 import { Button, Tooltip } from '@mui/joy';
 import React from 'react';
 
 interface MigrateAgainProps {
-  user: WithOrgRef<IUserDocument>;
+  user: AdminUserListItem;
   size?: 'sm' | 'md' | 'lg';
 }
 

--- a/apps/client/app/components/admin/Users/ProductAccess.tsx
+++ b/apps/client/app/components/admin/Users/ProductAccess.tsx
@@ -1,3 +1,4 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import React from 'react';
 import { Alert, Button, Chip, CircularProgress, Stack, Tooltip, Typography } from '@mui/joy';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
@@ -6,7 +7,7 @@ import { EntitlementSourceType, useGetUserProductAccess } from '@client/app/hook
 
 interface ProductAccessProps {
   /** The live-edited user (FullUsersView's formState) - tag grants are staged into it. */
-  user: IUserDocument;
+  user: AdminUserListItem;
   onFieldChange: (fieldName: keyof IUserDocument, value: unknown) => void;
 }
 

--- a/apps/client/app/components/admin/Users/SpicyUserActions.tsx
+++ b/apps/client/app/components/admin/Users/SpicyUserActions.tsx
@@ -1,3 +1,4 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { EditedFieldsState } from '@client/app/components/admin/Users/Views/FullUsersView';
 import { IUserDocument } from '@bike4mind/common';
 import { Button, Checkbox, Input, Modal, ModalDialog, Stack, Tooltip, Typography } from '@mui/joy';
@@ -6,7 +7,7 @@ import { toast } from 'sonner';
 import DestructiveActionHelp from '@client/app/components/help/DestructiveActionHelp';
 
 interface SpicyUserActionsProps {
-  user: IUserDocument;
+  user: AdminUserListItem;
   editedFields: EditedFieldsState;
   onFieldChange: (fieldName: keyof IUserDocument, value: unknown) => void;
   handleDeleteUser: (userId: string) => Promise<void>;

--- a/apps/client/app/components/admin/Users/UserPermissions.tsx
+++ b/apps/client/app/components/admin/Users/UserPermissions.tsx
@@ -1,3 +1,4 @@
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { EditedFieldsState } from '@client/app/components/admin/Users/Views/FullUsersView';
 import { allKnownEntitlementKeys, grantTagForEntitlement } from '@client/lib/entitlements/registry';
 import { DEVELOPER_USER_TAGS, IUserDocument, hasDeveloperUserTag } from '@bike4mind/common';
@@ -24,7 +25,7 @@ const isManagedTag = (tag: string): boolean => {
 };
 
 interface UserPermissionsProps {
-  user: IUserDocument;
+  user: AdminUserListItem;
   handleUserLevelButtonChange: (userId: string) => void;
   editedFields: EditedFieldsState;
   onFieldChange: (fieldName: keyof IUserDocument, value: unknown) => void;
@@ -56,7 +57,7 @@ const ROLE_OPTIONS: { value: Role; label: string }[] = [
 const withoutDeveloperTags = (tags: readonly string[]): string[] =>
   tags.filter(tag => !(DEVELOPER_USER_TAGS as readonly string[]).includes(tag));
 
-const userLevelColor = (user: IUserDocument) => {
+const userLevelColor = (user: AdminUserListItem) => {
   switch (user.level) {
     case 'DemoUser':
       return 'neutral';
@@ -73,7 +74,7 @@ const userLevelColor = (user: IUserDocument) => {
   }
 };
 
-const userLevelDisplay = (user: IUserDocument) => {
+const userLevelDisplay = (user: AdminUserListItem) => {
   switch (user.level) {
     case 'DemoUser':
       return 'Demo User';

--- a/apps/client/app/components/admin/Users/Views/FullUsersView.tsx
+++ b/apps/client/app/components/admin/Users/Views/FullUsersView.tsx
@@ -41,7 +41,8 @@ import ProductAccess from '../ProductAccess';
 import SystemMessageModal from '../SystemMessageModal';
 import { useFullUserViewModal } from '@client/app/components/admin/Users/Views/FullUserViewModal';
 import { useDeleteUser, useUpdateUser, useLoginAsUser } from '@client/app/hooks/data/user';
-import { IUserDocument, UserLevelType, WithOrgRef } from '@bike4mind/common';
+import { IUserDocument, UserLevelType } from '@bike4mind/common';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { useUser } from '@client/app/contexts/UserContext';
 import { useShallow } from 'zustand/shallow';
 import { useQueryClient } from '@tanstack/react-query';
@@ -51,11 +52,14 @@ import { useNavigate } from '@tanstack/react-router';
 import { useAdminSettings } from '@client/app/contexts/AdminSettingsContext';
 
 interface UsersViewProps {
-  user: WithOrgRef<IUserDocument>;
+  user: AdminUserListItem;
   index: number;
   inModal?: boolean;
 }
 
+// Keyed by IUserDocument, not the narrower list-projection row: admins edit fields the
+// list endpoint does not read back (e.g. emailVerifiedAt), and the PATCH body is a
+// Partial<IUserDocument>.
 export type EditedFieldsState = {
   [key in keyof Partial<IUserDocument>]: boolean;
 };
@@ -75,7 +79,7 @@ export const FullUsersView: React.FC<UsersViewProps> = ({ user, index, inModal }
   const enforceMFA = adminSettings?.enforceMFA === 'true';
 
   const [editedFields, setEditedFields] = useState<EditedFieldsState>({});
-  const [formState, setFormState] = useState<WithOrgRef<IUserDocument>>({ ...user });
+  const [formState, setFormState] = useState<AdminUserListItem>({ ...user });
   // Optional reason for a manual credit change; persisted on the audit record
   // (see adminUpdateUser) only when currentCredits is actually edited.
   const [creditReason, setCreditReason] = useState('');
@@ -128,7 +132,9 @@ export const FullUsersView: React.FC<UsersViewProps> = ({ user, index, inModal }
     const data = Object.entries(editedFields).reduce<Partial<IUserDocument> & { creditReason?: string }>(
       (acc, [key, value]) => {
         if (value) {
-          acc[key as keyof IUserDocument] = formState[key as keyof IUserDocument] as any;
+          // formState carries admin-editable fields beyond the list projection, so index it
+          // structurally rather than through AdminUserListItem's narrower keys.
+          (acc as Record<string, unknown>)[key] = (formState as Record<string, unknown>)[key];
         }
         return acc;
       },

--- a/apps/client/app/components/admin/Users/Views/SlimUsersView.tsx
+++ b/apps/client/app/components/admin/Users/Views/SlimUsersView.tsx
@@ -1,7 +1,7 @@
-import { IUserDocument, WithOrgRef } from '@bike4mind/common';
 import { useFullUserViewModal } from '@client/app/components/admin/Users/Views/FullUserViewModal';
 import { useGetRecentActivities } from '@client/app/hooks/data/user';
 import { useIsMobile } from '@client/app/hooks/useIsMobile';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import { relativeTimeFormat } from '@client/app/utils/dateUtils';
 import { Box, Button, Card, Grid, LinearProgress, Stack, Tooltip, Typography } from '@mui/joy';
 import prettyBytes from 'pretty-bytes';
@@ -13,12 +13,12 @@ import UserIdChip from '../UserIdChip';
 import { computeStoragePercent } from './storageUtils';
 
 interface SlimUsersViewProps {
-  user: WithOrgRef<IUserDocument>;
+  user: AdminUserListItem;
   index: number;
 }
 
 interface SlimUsersContainerProps {
-  users: WithOrgRef<IUserDocument>[];
+  users: AdminUserListItem[];
 }
 
 /** Header and row share these widths; they must be edited together or the table skews. */
@@ -35,7 +35,7 @@ const COLUMN_WIDTHS = {
 
 const ELLIPSIS_SX = { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } as const;
 
-const StorageCell: React.FC<{ user: WithOrgRef<IUserDocument> }> = ({ user }) => {
+const StorageCell: React.FC<{ user: AdminUserListItem }> = ({ user }) => {
   const storageLimitBytes = user.storageLimit * 1024 * 1024;
   const storagePercent = computeStoragePercent(user.currentStorageSize, user.storageLimit);
   // Below 1% a percentage reads as "no data"; show the raw size so the cell stays meaningful.

--- a/apps/client/app/components/admin/Users/Views/UserJourney.tsx
+++ b/apps/client/app/components/admin/Users/Views/UserJourney.tsx
@@ -1,4 +1,4 @@
-import { IUserDocument, WithOrgRef } from '@bike4mind/common';
+import type { AdminUserListItem } from '@client/app/utils/adminUserProjection';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import FormatListNumberedRtlIcon from '@mui/icons-material/FormatListNumberedRtl';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -14,7 +14,7 @@ import { useFullUserViewModal } from '@client/app/components/admin/Users/Views/F
 import { useGetUserActivityCounters } from '@client/app/hooks/data/user';
 
 interface UserJourneyProps {
-  user: WithOrgRef<IUserDocument>;
+  user: AdminUserListItem;
   index: number;
 }
 

--- a/apps/client/app/utils/adminUserProjection.ts
+++ b/apps/client/app/utils/adminUserProjection.ts
@@ -1,0 +1,67 @@
+import type { IMFAConfig, IOrganizationDocument, IUserDocument } from '@bike4mind/common';
+
+// Both the GET /api/users projection and the client row type (AdminUserListItem) derive from
+// this list, so reading a field the endpoint does not emit is a compile error. Shared here
+// rather than in the route so pages/api/users/index.ts and the client agree by construction.
+//
+// The projection is an inclusion allowlist, so a newly-added secret field on the User
+// schema can never silently appear here. Aggregation ignores Mongoose select:false, so
+// this projection is the only guard. MFA is narrowed to enrollment status -- totpSecret /
+// backupCodes must never reach the client, even an admin's browser. (The joined
+// `organization` object is admin-scoped org data; its own field-level exposure is tracked
+// separately, not here.)
+export const ADMIN_USER_LIST_FIELDS = [
+  'name',
+  'username',
+  'email',
+  'isAdmin',
+  'level',
+  'tags',
+  'isBanned',
+  'isModerated',
+  'photoUrl',
+  'phone',
+  'role',
+  'team',
+  'isOnline',
+  'preferences',
+  'storageLimit',
+  'currentStorageSize',
+  'createdAt',
+  'updatedAt',
+  'lastActiveAt',
+  // loginRecords is admin-only PII (IPs/userAgents): it is in USER_SECRET_FIELDS so the
+  // toSafeUser/redactUserSecretsForSelf serializers drop it, but the admin activity view
+  // reads it here. Intentional admin-only exposure, not a serialize-everywhere field.
+  'loginRecords',
+  'subscribedUntil',
+  'numReferralsAvailable',
+  'currentCredits',
+  'organizationId',
+  'pendingEmail',
+  'emailVerified',
+] as const satisfies readonly (keyof IUserDocument)[];
+
+export const ADMIN_USER_PROJECTION: Record<string, 1> = {
+  _id: 1,
+  ...Object.fromEntries(ADMIN_USER_LIST_FIELDS.map(field => [field, 1])),
+  'mfa.totpEnabled': 1,
+  'mfa.setupAt': 1,
+  'mfa.lastUsedAt': 1,
+  organization: 1,
+};
+
+// Deliberately a structural subset of IUserDocument (no `_id`) so the wider single-user
+// response, WithOrgRef<IUserDocument> from GET /api/users/[id], is assignable to it -- the
+// admin user views render rows from either endpoint.
+export type AdminUserListItem = Omit<Pick<IUserDocument, (typeof ADMIN_USER_LIST_FIELDS)[number]>, 'organizationId'> & {
+  // Rows are returned through User.hydrate(), so JSON carries the `id` virtual.
+  id: string;
+  // The endpoint populates organizationId, so it arrives as the org document (null when unset).
+  organizationId: IOrganizationDocument | null;
+  mfa?: Pick<IMFAConfig, 'totpEnabled' | 'setupAt' | 'lastUsedAt'> | null;
+  // Joined by the $lookup stage, absent when the user has no organization.
+  organization?: IOrganizationDocument;
+};
+
+export const PUBLIC_USER_LIST_PROJECTION: Record<string, 1> = { _id: 1, username: 1, name: 1, email: 1 };

--- a/apps/client/app/utils/user.ts
+++ b/apps/client/app/utils/user.ts
@@ -19,7 +19,7 @@ export const userIsCustomer = (user: IUserDocument | null): boolean => {
   return (user?.tags ?? []).some(tag => ['Customer', 'customer', 'Customers', 'customers'].includes(tag));
 };
 
-export function getLastLoginDate(user: IUserDocument | undefined): Date | null {
+export function getLastLoginDate(user: Pick<IUserDocument, 'loginRecords'> | undefined): Date | null {
   if (!user) return null;
   const lastLogin = user.loginRecords?.reduce(
     (acc, curr) => (acc.loginTime > curr.loginTime ? acc : curr),

--- a/apps/client/app/utils/userAPICalls.tsx
+++ b/apps/client/app/utils/userAPICalls.tsx
@@ -2,9 +2,8 @@ import {
   FileGeneratePresignedUrlResponseType,
   FileGeneratePresignedUrlRequestInputType,
   IUser,
-  IUserDocument,
-  WithOrgRef,
 } from '@bike4mind/common';
+import type { AdminUserListItem } from './adminUserProjection';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import axios, { AxiosResponse } from 'axios';
@@ -30,7 +29,10 @@ export interface IGetUsersParams {
 }
 
 export interface IGetUsersResponse {
-  users: WithOrgRef<IUserDocument>[];
+  // Derived from the endpoint's projection, so reading a field GET /api/users does not
+  // emit is a compile error. publicView requests return only the PUBLIC_USER_LIST_PROJECTION
+  // subset of these fields.
+  users: AdminUserListItem[];
   currentPage: number;
   totalPages: number;
   totalUsers: number;

--- a/apps/client/pages/api/users/index.ts
+++ b/apps/client/pages/api/users/index.ts
@@ -3,6 +3,7 @@ import { baseApi } from '@server/middlewares/baseApi';
 import { IUserObject, Project, User, executeFacetCompatible, convertPipelineForDocumentDB } from '@bike4mind/database';
 import { mongoose } from '@bike4mind/database';
 import { escapeRegex } from '@bike4mind/utils/escapeRegex';
+import { ADMIN_USER_PROJECTION, PUBLIC_USER_LIST_PROJECTION } from '@client/app/utils/adminUserProjection';
 import * as z from 'zod';
 import qs from 'qs';
 import { Request } from 'express';
@@ -28,49 +29,6 @@ const querySchema = z.object({
     .optional()
     .transform(val => val === 'true'),
 });
-
-// Admin users-list projection: an inclusion allowlist, so a newly-added secret
-// field on the User schema can never silently appear here. Aggregation ignores
-// Mongoose select:false, so this projection is the only guard. MFA is narrowed to
-// enrollment status -- totpSecret / backupCodes must never reach the client, even
-// an admin's browser. (The joined `organization` object is admin-scoped org data;
-// its own field-level exposure is tracked separately, not here.)
-const ADMIN_USER_PROJECTION: Record<string, 1> = {
-  _id: 1,
-  name: 1,
-  username: 1,
-  email: 1,
-  isAdmin: 1,
-  level: 1,
-  tags: 1,
-  isBanned: 1,
-  isModerated: 1,
-  photoUrl: 1,
-  phone: 1,
-  role: 1,
-  team: 1,
-  isOnline: 1,
-  preferences: 1,
-  'mfa.totpEnabled': 1,
-  'mfa.setupAt': 1,
-  'mfa.lastUsedAt': 1,
-  storageLimit: 1,
-  currentStorageSize: 1,
-  createdAt: 1,
-  updatedAt: 1,
-  lastActiveAt: 1,
-  // loginRecords is admin-only PII (IPs/userAgents): it is in USER_SECRET_FIELDS so the
-  // toSafeUser/redactUserSecretsForSelf serializers drop it, but the admin activity view
-  // reads it here. Intentional admin-only exposure, not a serialize-everywhere field.
-  loginRecords: 1,
-  subscribedUntil: 1,
-  numReferralsAvailable: 1,
-  currentCredits: 1,
-  organizationId: 1,
-  organization: 1,
-  pendingEmail: 1,
-  emailVerified: 1,
-};
 
 const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async (req, res) => {
   try {
@@ -224,7 +182,7 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
         },
         {
           $project: {
-            ...(publicView ? { _id: 1, username: 1, name: 1, email: 1 } : ADMIN_USER_PROJECTION),
+            ...(publicView ? PUBLIC_USER_LIST_PROJECTION : ADMIN_USER_PROJECTION),
             score: 1,
           },
         },
@@ -252,7 +210,7 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
           },
         },
         { $sort: { [sortField]: sortOrder === 'asc' ? 1 : -1 } },
-        { $project: publicView ? { _id: 1, username: 1, name: 1, email: 1 } : ADMIN_USER_PROJECTION },
+        { $project: publicView ? PUBLIC_USER_LIST_PROJECTION : ADMIN_USER_PROJECTION },
       ];
     }
 


### PR DESCRIPTION
Closes #914.

## Why

The admin User Credits bug repaired in #893 was caused by field-name drift: the client
row type declared `fullName` / `isActive` / `lastLoginAt`, while `/api/users` actually
returns `name` / `isOnline` / `lastActiveAt` / `loginRecords`. Because the rows were cast
`as any[]` in `useUserCreditsManager.ts` and only narrowed at the component boundary, the
mismatch compiled fine and every row silently rendered `No Name` / `Inactive` / `Never`.

## What changed

New module `apps/client/app/utils/adminUserProjection.ts` is the single source of truth:

- `ADMIN_USER_LIST_FIELDS` - `as const satisfies readonly (keyof IUserDocument)[]`, so a
  field name not on the User schema is a compile error.
- `ADMIN_USER_PROJECTION` - derived from that list (plus `_id`, the three narrowed `mfa.*`
  keys, and the `$lookup`-joined `organization`). `pages/api/users/index.ts` imports it
  instead of holding its own literal.
- `PUBLIC_USER_LIST_PROJECTION` - replaces the two inline `publicView` literals.
- `AdminUserListItem` - the row type, `Pick<IUserDocument, ...ADMIN_USER_LIST_FIELDS>`
  with `id`, populated `organizationId`, narrowed `mfa`, and the joined `organization`.
  Deliberately a structural subset of `IUserDocument` (no `_id`) so the wider single-user
  response from `GET /api/users/[id]` stays assignable - the admin views render rows from
  either endpoint.

`IGetUsersResponse.users` is now `AdminUserListItem[]`, and the `as any[]` is gone. The 20
admin Users / CreditAnalysis components that took `IUserDocument` / `WithOrgRef<IUserDocument>`
now take `AdminUserListItem`; `UserCreditsManager`'s local duplicate `AdminUser` interface
was deleted along with its two `as AdminUser[]` casts.

`FullUsersView` keeps `EditedFieldsState` keyed by `IUserDocument`, not the narrower row
type: admins edit fields the list endpoint does not read back and the PATCH body is a
`Partial<IUserDocument>`. Its save reducer now indexes `formState` through
`Record<string, unknown>` rather than `as any`.

The server route imports from `@client/app/utils` - an established pattern here (13 other
`pages/api` files do it), and the module is dependency-free constants + types.

## Verification

- Projection key set proven **identical** to the literal it replaced (31 keys, set-diff
  empty), so the wire response is unchanged. This was the only behavioral risk.
- Acceptance proven with a temporary probe file (since removed): reading `fullName`,
  `isActive` or `lastLoginAt` on `AdminUserListItem` produces TS2339, while `name`,
  `isOnline`, `lastActiveAt` and `loginRecords` resolve. The original bug is now a build
  error.
- `pnpm lint:check` clean; `pnpm turbo:typecheck` 40/40 green.
- `pnpm turbo:test`: 7907 passed, 19 failed - all Mongo-backed e2e/integration suites that
  are pre-existing failures locally (confirmed by re-running the same files on a stashed,
  clean tree, which failed worse). `pages/api/users/__tests__/counterLogs.test.ts` was the
  only failure in a directory this change touches; it passes in isolation.

No new tests: the guard is compile-time (`satisfies` plus the derived types).
