### PR TITLE
fix(analytics): close correctness gaps around the counterLogs endpoint

### DIFF
--- a/apps/client/app/utils/userAPICalls.tsx
+++ b/apps/client/app/utils/userAPICalls.tsx
@@ -70,6 +70,12 @@ export interface FetchCounterLogsParams {
   counterName?: string;
   userEmail?: string;
   metadataFilters?: CounterLogMetadataFilter[];
+  /**
+   * IANA zone startDate/endDate name a day in. Defaults to the viewer's own zone so "today" means
+   * their today rather than a UTC day shifted by their offset. Ignored by the report paths, whose
+   * cached rows are UTC-day-keyed and shared between admins.
+   */
+  timezone?: string;
 }
 
 /**
@@ -119,11 +125,17 @@ export const fetchCounterLogs = async ({
   counterName,
   userEmail,
   metadataFilters,
+  timezone,
 }: FetchCounterLogsParams): Promise<CounterLogsResponse> => {
   const queryParams: Record<string, string> = {
     startDate: startDate || '',
     endDate: endDate || '',
   };
+
+  // The report paths stay UTC-keyed: their rows are cached per UTC day and shared between admins.
+  if (!report && !weeklyReport) {
+    queryParams.timezone = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
 
   // Handle arrays by joining with commas and encoding each value
   if (events?.length) {

--- a/apps/client/pages/api/users/__tests__/counterLogs.test.ts
+++ b/apps/client/pages/api/users/__tests__/counterLogs.test.ts
@@ -25,12 +25,16 @@ import { SAFE_USER_LOOKUP_PROJECT, USER_SECRET_FIELDS } from '@bike4mind/common'
  * and live in counterLogs.paging.test.ts, which cannot share this file's real-Mongo harness.
  */
 
+// The mock surfaces baseApi's options as `_config`. Without that, no test could see the route's
+// requiredScopes and a suite that read as scope coverage would pass with requiredScopes omitted -
+// the same trap documented in pages/api/hearth/__tests__/hearthRoutes.test.ts.
 vi.mock('@server/middlewares/baseApi', () => ({
-  baseApi: () => {
+  baseApi: (options?: Record<string, unknown>) => {
     const h: Record<string, (req: unknown, res: unknown) => unknown> = {};
     const chain = Object.assign(
       (req: unknown, res: unknown) => h[(req as { method?: string }).method ?? 'GET']?.(req, res),
       {
+        _config: options,
         use: () => chain,
         get: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((h.GET = fns[fns.length - 1]), chain),
       }
@@ -41,6 +45,7 @@ vi.mock('@server/middlewares/baseApi', () => ({
 
 import handler from '../counterLogs';
 import { buildUserActivityPipeline } from '@server/analytics/userActivityQuery';
+import { ApiKeyScope } from '@bike4mind/common';
 
 let mongoServer: MongoMemoryServer;
 
@@ -248,5 +253,169 @@ describe('GET /api/users/counterLogs (end-to-end, real model + Mongo)', () => {
     // else about them (day, counter, user) is identical.
     expect(rows).toHaveLength(2);
     expect(new Set(rows.map(r => r.metadata.reportId))).toEqual(new Set(['report-1', 'report-2']));
+  });
+
+  it('requires the admin API-key scope', () => {
+    // The CASL check inside the handler is not sufficient on its own: apiKeyAuth rebuilds
+    // req.ability from user.isAdmin, so `can(read, CounterLog)` passes for ANY key an admin owns,
+    // whatever scopes it was issued with. The scope gate in baseApi is what keeps a narrow key
+    // narrow, so assert it is actually declared.
+    const config = (handler as unknown as { _config?: { requiredScopes?: ApiKeyScope[] } })._config;
+    expect(config?.requiredScopes).toEqual([ApiKeyScope.ADMIN]);
+  });
+
+  it('cuts the window and the day buckets in the requested timezone', async () => {
+    const user = await User.create({
+      username: 'e2e-tz-user',
+      name: 'TZ User',
+      email: 'tz-user@example.com',
+    });
+
+    const log = (datetime: string, sessionId: string) => ({
+      userId: user.id,
+      userName: 'TZ User',
+      userLevel: 'User',
+      counterName: 'Session Created',
+      counterValue: 1,
+      datetime: new Date(datetime),
+      metadata: { sessionId },
+    });
+
+    await CounterLog.create([
+      // 2026-07-21 18:00 in America/Chicago (UTC-5 in July) - a UTC window would place this on
+      // the 21st too, so it only pins the bucket label.
+      log('2026-07-21T23:00:00.000Z', 'evening-of-21st'),
+      // 2026-07-21 20:00 Chicago, but already 2026-07-22 in UTC. Under the old UTC-only window
+      // this fell outside a "21st to 21st" request entirely.
+      log('2026-07-22T01:00:00.000Z', 'late-on-21st'),
+      // 2026-07-20 23:00 Chicago - the previous local day, so it must stay excluded.
+      log('2026-07-21T04:00:00.000Z', 'still-the-20th'),
+    ]);
+
+    const { res, promise } = run({
+      startDate: '2026-07-21',
+      endDate: '2026-07-21',
+      timezone: 'America/Chicago',
+    });
+    await promise;
+
+    expect(res._getStatusCode()).toBe(200);
+    const rows = JSON.parse(JSON.stringify(res._getJSONData())).logs as Array<{
+      date: string;
+      count: number;
+    }>;
+
+    // Both in-window events share the row unit (same local day, counter and user), so they land in
+    // one row labelled with the local 21st rather than splitting across a UTC 21st/22nd pair - and
+    // its count is 2, not 3, because the previous local day stays excluded.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].date).toBe('2026-07-21');
+    expect(rows[0].count).toBe(2);
+  });
+
+  it('defaults to UTC when no timezone is given', async () => {
+    const user = await User.create({
+      username: 'e2e-tz-default-user',
+      name: 'TZ Default User',
+      email: 'tz-default-user@example.com',
+    });
+
+    await CounterLog.create({
+      userId: user.id,
+      userName: 'TZ Default User',
+      userLevel: 'User',
+      counterName: 'Session Created',
+      counterValue: 1,
+      datetime: new Date('2026-07-21T23:30:00.000Z'),
+      metadata: { sessionId: 'late-utc' },
+    });
+
+    const { res, promise } = run({ startDate: '2026-07-21', endDate: '2026-07-21' });
+    await promise;
+
+    const rows = JSON.parse(JSON.stringify(res._getJSONData())).logs as Array<{ date: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].date).toBe('2026-07-21');
+  });
+
+  it('labels the org column with the same field the org filter matches on', async () => {
+    // The filter matches CounterLog.userOrganization; the column used to be projected from the
+    // joined user, so a user who moved orgs filtered under one name and displayed under another
+    // (and in practice displayed nothing at all, since the User schema has no `organization`).
+    const user = await User.create({
+      username: 'e2e-moved-user',
+      name: 'Moved User',
+      email: 'moved-user@example.com',
+    });
+
+    await CounterLog.create([
+      {
+        userId: user.id,
+        userName: 'Moved User',
+        userLevel: 'User',
+        userOrganization: 'Old Org',
+        counterName: 'Session Created',
+        counterValue: 1,
+        datetime: new Date('2026-07-21T10:00:00.000Z'),
+        metadata: { sessionId: 'while-at-old-org' },
+      },
+      {
+        userId: user.id,
+        userName: 'Moved User',
+        userLevel: 'User',
+        userOrganization: 'New Org',
+        counterName: 'Session Created',
+        counterValue: 1,
+        datetime: new Date('2026-07-21T11:00:00.000Z'),
+        metadata: { sessionId: 'while-at-new-org' },
+      },
+    ]);
+
+    const { res, promise } = run({ startDate: '2026-07-21', endDate: '2026-07-21', orgs: 'Old Org' });
+    await promise;
+
+    const rows = JSON.parse(JSON.stringify(res._getJSONData())).logs as Array<{
+      metadata: { sessionId: string };
+      userOrganization: string;
+    }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata.sessionId).toBe('while-at-old-org');
+    expect(rows[0].userOrganization).toBe('Old Org');
+  });
+
+  it('applies orgs and excludeOrgs together instead of letting one drop the other', async () => {
+    const user = await User.create({
+      username: 'e2e-both-org-filters',
+      name: 'Both Filters User',
+      email: 'both-filters@example.com',
+    });
+
+    const log = (org: string, sessionId: string) => ({
+      userId: user.id,
+      userName: 'Both Filters User',
+      userLevel: 'User',
+      userOrganization: org,
+      counterName: 'Session Created',
+      counterValue: 1,
+      datetime: new Date('2026-07-21T10:00:00.000Z'),
+      metadata: { sessionId },
+    });
+
+    await CounterLog.create([log('Keep Org', 'keep'), log('Drop Org', 'drop'), log('Unlisted Org', 'unlisted')]);
+
+    const { res, promise } = run({
+      startDate: '2026-07-21',
+      endDate: '2026-07-21',
+      orgs: 'Keep Org,Drop Org',
+      excludeOrgs: 'Drop Org',
+    });
+    await promise;
+
+    const rows = JSON.parse(JSON.stringify(res._getJSONData())).logs as Array<{ metadata: { sessionId: string } }>;
+
+    // Only 'keep' satisfies both operators. The previous code assigned userOrganization twice, so
+    // the $nin overwrote the $in and 'unlisted' came back too.
+    expect(rows.map(r => r.metadata.sessionId)).toEqual(['keep']);
   });
 });

--- a/apps/client/pages/api/users/counterLogs.ts
+++ b/apps/client/pages/api/users/counterLogs.ts
@@ -1,4 +1,4 @@
-import { Permission, dayjs, type CompletionSource } from '@bike4mind/common';
+import { ApiKeyScope, Permission, dayjs, type CompletionSource } from '@bike4mind/common';
 import {
   CounterLog,
   DailyReport,
@@ -56,9 +56,31 @@ const IsoDateSchema = z
     return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(value);
   }, 'Not a calendar date');
 
+const isValidTimeZone = (tz: string): boolean => {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const CounterLogsQuerySchema = z.object({
   startDate: IsoDateSchema,
   endDate: IsoDateSchema,
+  /**
+   * IANA zone that startDate/endDate name a calendar day in, and that the day buckets are cut in.
+   * Defaults to UTC, which is how this route behaved before the parameter existed.
+   *
+   * Applies to the `{logs}` branch only. The report branches persist to DailyReport /
+   * WeeklyReport, whose rows are keyed by UTC date and shared across every admin, so honouring a
+   * per-request zone there would let one admin's locale overwrite another's cached report.
+   */
+  timezone: z
+    .string()
+    .optional()
+    .refine(val => val === undefined || isValidTimeZone(val), { message: 'Unknown IANA time zone' })
+    .transform(val => val ?? 'UTC'),
   events: z
     .string()
     .optional()
@@ -146,7 +168,13 @@ interface WeeklyReportData {
   usageBySource?: Array<{ source: CompletionSource; count: number }>;
 }
 
-const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async (req, res) => {
+// requiredScopes: an API key reaching this route gets its CASL ability rebuilt from `user.isAdmin`
+// (server/middlewares/apiKeyAuth.ts), so the `Permission.read` check below passes for any
+// admin-owned key regardless of the scopes it was issued with. The scope gate is what makes a
+// narrow key stay narrow; it only runs for API-key callers, so browser/JWT admins are unaffected.
+const handler = baseApi({ requiredScopes: [ApiKeyScope.ADMIN] }).get<
+  Request<{}, {}, {}, Record<string, string>>
+>(async (req, res) => {
   if (!req.ability?.can(Permission.read, CounterLog)) {
     throw new ForbiddenError('Unauthorized');
   }
@@ -155,6 +183,7 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
     const {
       startDate,
       endDate,
+      timezone,
       events,
       orgs,
       excludeOrgs,
@@ -215,10 +244,13 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
       // filter sets collide - e.g. counterName='a:b' + userEmail='c' vs counterName='a' +
       // userEmail='b:c' - serving one admin the other's rows and total for the full hour.
       const cacheKey = [
-        'logs:v3',
+        // v4: day buckets are now cut in the caller's timezone, so a v3 window holds rows bucketed
+        // differently for what is otherwise the same filter set.
+        'logs:v4',
         ...[
           startDate,
           endDate,
+          timezone,
           events?.join(',') ?? '',
           orgs?.join(',') ?? '',
           excludeOrgs?.join(',') ?? '',
@@ -248,6 +280,7 @@ const handler = baseApi().get<Request<{}, {}, {}, Record<string, string>>>(async
       const { pipeline, facetStages } = buildUserActivityPipeline({
         startDate,
         endDate,
+        timezone,
         // A cacheable window always starts at 0 so any earlier page can be sliced out of it.
         skip: windowRows === null ? skip : 0,
         limit: windowRows ?? limit,

--- a/apps/client/server/analytics/userActivityQuery.ts
+++ b/apps/client/server/analytics/userActivityQuery.ts
@@ -22,7 +22,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { z } from 'zod';
-import { SAFE_USER_LOOKUP_PROJECT } from '@bike4mind/common';
+import { SAFE_USER_LOOKUP_PROJECT, dayjs } from '@bike4mind/common';
 import { escapeRegex } from '@bike4mind/utils/escapeRegex';
 
 export const DEFAULT_PAGE_SIZE = 25;
@@ -66,6 +66,11 @@ export function parseMetadataFilters(raw: string | undefined): MetadataFilter[] 
 export interface UserActivityQueryParams {
   startDate: string;
   endDate: string;
+  /**
+   * IANA zone that startDate/endDate name a calendar day in, and that the day buckets are cut in.
+   * One value drives both, or the first and last buckets are partial days. Defaults to UTC.
+   */
+  timezone?: string;
   /** Rows to skip before the returned window. The caller pages by moving this, not by re-sorting. */
   skip: number;
   /** Rows to return. Sized by the caller: one page for a deep page, a whole cache window otherwise. */
@@ -138,6 +143,7 @@ export interface UserActivityPipeline {
 export function buildUserActivityPipeline({
   startDate,
   endDate,
+  timezone = 'UTC',
   skip,
   limit,
   events,
@@ -148,10 +154,13 @@ export function buildUserActivityPipeline({
   metadataFilters = [],
   usersCollection = 'users',
 }: UserActivityQueryParams): UserActivityPipeline {
+  // startDate/endDate name calendar days in `timezone`, so their local midnight and end-of-day
+  // resolve to instants in that zone rather than being pinned to UTC. The same zone cuts the day
+  // buckets below, so the window and the buckets line up.
   const matchCondition: any = {
     datetime: {
-      $gte: new Date(`${startDate}T00:00:00.000Z`),
-      $lte: new Date(`${endDate}T23:59:59.999Z`),
+      $gte: dayjs.tz(`${startDate}T00:00:00.000`, timezone).toDate(),
+      $lte: dayjs.tz(`${endDate}T23:59:59.999`, timezone).toDate(),
     },
   };
 
@@ -163,13 +172,18 @@ export function buildUserActivityPipeline({
     matchCondition.counterName = counterNameCondition;
   }
 
-  // excludeOrgs wins over orgs, matching the pre-existing endpoint behaviour: the UI only
-  // offers the exclusion checkboxes while "All Organizations" is selected.
+  // Both constrain userOrganization, so they merge into one operator. Assigning twice dropped the
+  // $in whenever both were sent - invisible from the UI, which only offers the exclusion
+  // checkboxes while "All Organizations" is selected, but an API caller can send both.
+  const orgFilter: Record<string, string[]> = {};
   if (orgs?.length && !orgs.includes('all')) {
-    matchCondition.userOrganization = { $in: orgs };
+    orgFilter.$in = orgs;
   }
   if (excludeOrgs?.length) {
-    matchCondition.userOrganization = { $nin: excludeOrgs };
+    orgFilter.$nin = excludeOrgs;
+  }
+  if (Object.keys(orgFilter).length) {
+    matchCondition.userOrganization = orgFilter;
   }
 
   if (metadataFilters.length) {
@@ -178,7 +192,7 @@ export function buildUserActivityPipeline({
 
   const pipeline: any[] = [
     { $match: matchCondition },
-    { $addFields: { dateString: { $dateToString: { format: '%Y-%m-%d', date: '$datetime', timezone: 'UTC' } } } },
+    { $addFields: { dateString: { $dateToString: { format: '%Y-%m-%d', date: '$datetime', timezone } } } },
     {
       // Group BEFORE the join: userEmail/userOrganization are functionally determined by userId,
       // so joining once per grouped row instead of once per raw document is ~2x faster on a
@@ -230,6 +244,7 @@ export function buildUserActivityPipeline({
     // across the two facet executions - userEmail cannot do it, since every row whose join
     // missed shares the same '' fallback. Covering the whole group key (userId + metadataKey,
     // ordered by BSON comparison) makes the order unique, because the key is unique per row.
+    // Every field added to the group key has to be added here too.
     {
       $sort: {
         '_id.date': -1,

--- a/apps/client/server/models/Subscription.ts
+++ b/apps/client/server/models/Subscription.ts
@@ -191,7 +191,9 @@ class SubscriptionRepository extends BaseRepository<ISubscription & IMongoDocume
       $lookup: {
         from: 'users',
         let: {
-          ownerId: { $toObjectId: '$ownerId' },
+          // $convert, not $toObjectId: ownerId is a plain string, so one malformed row would
+          // abort the whole aggregation. onError: null leaves that row's owner unjoined.
+          ownerId: { $convert: { input: '$ownerId', to: 'objectId', onError: null } },
           ownerType: '$ownerType',
         },
         pipeline: [
@@ -211,7 +213,7 @@ class SubscriptionRepository extends BaseRepository<ISubscription & IMongoDocume
       $lookup: {
         from: 'organizations',
         let: {
-          ownerId: { $toObjectId: '$ownerId' },
+          ownerId: { $convert: { input: '$ownerId', to: 'objectId', onError: null } },
           ownerType: '$ownerType',
         },
         pipeline: [

--- a/apps/client/server/models/UserSubscription.ts
+++ b/apps/client/server/models/UserSubscription.ts
@@ -91,7 +91,9 @@ class UserSubscriptionRepository extends BaseRepository<IUserSubscription> imple
       {
         $lookup: {
           from: 'users',
-          let: { userId: { $toObjectId: '$userId' } },
+          // $convert, not $toObjectId: one subscription with a non-ObjectId userId would abort
+          // the whole aggregation; onError: null leaves that row's user unjoined.
+          let: { userId: { $convert: { input: '$userId', to: 'objectId', onError: null } } },
           pipeline: [{ $match: { $expr: { $eq: ['$_id', '$$userId'] } } }],
           as: 'user',
         },

--- a/packages/database/src/models/content/ResearchDataModel.ts
+++ b/packages/database/src/models/content/ResearchDataModel.ts
@@ -87,7 +87,9 @@ class ResearchDataRepository extends BaseRepository<IResearchData> implements IR
       {
         $addFields: {
           originalFabFileId: '$fabFileId',
-          fabFileId: { $toObjectId: '$fabFileId' },
+          // $convert, not $toObjectId: one row with a non-ObjectId fabFileId would abort the
+          // whole aggregation; onError: null leaves just that row unjoined.
+          fabFileId: { $convert: { input: '$fabFileId', to: 'objectId', onError: null } },
         },
       },
       {

--- a/packages/database/src/models/infra/ops/CacheModel.test.ts
+++ b/packages/database/src/models/infra/ops/CacheModel.test.ts
@@ -194,3 +194,36 @@ describe('CacheRepository.tryIncrementWithinLimitFixedWindow', () => {
     failures.forEach(r => expect(r.count).toBe(limit));
   });
 });
+
+describe('CacheRepository.findByKey', () => {
+  it('returns a live entry', async () => {
+    const key = `cache:live:${Date.now()}`;
+    await Cache.create({ key, result: { value: 'fresh' }, expiresAt: new Date(Date.now() + 60_000) });
+
+    const doc = await cacheRepository.findByKey(key);
+
+    expect(doc?.result).toEqual({ value: 'fresh' });
+  });
+
+  it('does not return an entry that has expired but is awaiting TTL cleanup', async () => {
+    // Mongo's TTL monitor sweeps about once a minute, so a row can outlive its own expiresAt by
+    // that long. Before the expiresAt guard, findByKey handed those out as hits - which meant a
+    // stale analytics report served as fresh and a closed rate-limit window reading as open.
+    const key = `cache:stale:${Date.now()}`;
+    await Cache.create({ key, result: { value: 'stale' }, expiresAt: new Date(Date.now() - 1000) });
+
+    // Falsy, not null: the underlying findOne yields undefined for a miss.
+    expect(await cacheRepository.findByKey(key)).toBeFalsy();
+    // Still physically present - the guard is what excludes it, not a deletion.
+    expect(await Cache.findOne({ key })).not.toBeNull();
+  });
+
+  it('returns an entry written with no expiresAt', async () => {
+    // createOrUpdate upserts without running validators, so rows with no expiry exist. The TTL
+    // index skips those, so they never expire and the guard must not hide them.
+    const key = `cache:noexpiry:${Date.now()}`;
+    await Cache.collection.insertOne({ key, result: { value: 'permanent' } });
+
+    expect(await cacheRepository.findByKey(key)).toBeTruthy();
+  });
+});

--- a/packages/database/src/models/infra/ops/CacheModel.ts
+++ b/packages/database/src/models/infra/ops/CacheModel.ts
@@ -18,8 +18,18 @@ class CacheRepository extends BaseRepository<ICacheDocument> implements ICacheRe
     super(model);
   }
 
+  /**
+   * Returns the entry only while it is still live. The `expiresAt` TTL index is what eventually
+   * deletes the row, but Mongo's TTL monitor runs about once a minute, so without this guard an
+   * entry stayed readable for up to ~60s past its own expiry - a stale report served as fresh, a
+   * closed rate-limit window read as open. Callers that need the expired document itself (to
+   * report a window's reset time, say) must query the model directly.
+   *
+   * A row with no `expiresAt` at all never expires - the TTL index ignores it too - so it stays
+   * readable.
+   */
   async findByKey(key: string) {
-    return this.findOne({ key });
+    return this.findOne({ key, $or: [{ expiresAt: null }, { expiresAt: { $gt: new Date() } }] });
   }
 
   async deleteByKey(key: string) {

--- a/packages/database/src/models/infra/ops/CounterLogModel.ts
+++ b/packages/database/src/models/infra/ops/CounterLogModel.ts
@@ -19,6 +19,12 @@ import { executeFacetCompatible, convertPipelineForDocumentDB } from '../../../u
 
 export interface ICounterLogModel extends mongoose.Model<ICounterLogDocument, {}, {}>, ICounterLogRepository {}
 
+// CounterLog.userId is a free-form string and real rows carry non-ObjectId values such as
+// 'SYSTEM'. Every user $lookup below therefore derives userObjectId with
+// `$convert ... onError: null` rather than `$toObjectId`: one such row makes $toObjectId abort the
+// whole aggregation, while $convert yields null and that single row simply fails to join. Keep any
+// new user join in this file on the same form.
+
 class CounterLogRepository extends BaseRepository<ICounterLogDocument> implements ICounterLogRepository {
   constructor(model: ICounterLogModel) {
     super(model);
@@ -45,7 +51,7 @@ class CounterLogRepository extends BaseRepository<ICounterLogDocument> implement
       },
       {
         $addFields: {
-          userObjectId: { $toObjectId: '$userId' },
+          userObjectId: { $convert: { input: '$userId', to: 'objectId', onError: null } },
         },
       },
       {
@@ -90,7 +96,7 @@ class CounterLogRepository extends BaseRepository<ICounterLogDocument> implement
       },
       {
         $addFields: {
-          userObjectId: { $toObjectId: '$userId' },
+          userObjectId: { $convert: { input: '$userId', to: 'objectId', onError: null } },
         },
       },
       {
@@ -246,7 +252,7 @@ class CounterLogRepository extends BaseRepository<ICounterLogDocument> implement
         },
         {
           $addFields: {
-            userObjectId: { $toObjectId: '$userId' },
+            userObjectId: { $convert: { input: '$userId', to: 'objectId', onError: null } },
           },
         },
         {
@@ -462,7 +468,7 @@ class CounterLogRepository extends BaseRepository<ICounterLogDocument> implement
             },
             {
               $addFields: {
-                userObjectId: { $toObjectId: '$userId' },
+                userObjectId: { $convert: { input: '$userId', to: 'objectId', onError: null } },
               },
             },
             {
@@ -596,7 +602,7 @@ class CounterLogRepository extends BaseRepository<ICounterLogDocument> implement
             },
             {
               $addFields: {
-                userObjectId: { $toObjectId: '$userId' },
+                userObjectId: { $convert: { input: '$userId', to: 'objectId', onError: null } },
               },
             },
             {
@@ -1040,7 +1046,7 @@ const CounterLogSchema = new mongoose.Schema<ICounterLog>(
           },
           {
             $addFields: {
-              userObjectId: { $toObjectId: '$userId' },
+              userObjectId: { $convert: { input: '$userId', to: 'objectId', onError: null } },
             },
           },
           {
@@ -1080,7 +1086,7 @@ const CounterLogSchema = new mongoose.Schema<ICounterLog>(
           },
           {
             $addFields: {
-              userObjectId: { $toObjectId: '$userId' },
+              userObjectId: { $convert: { input: '$userId', to: 'objectId', onError: null } },
             },
           },
           {

--- a/packages/database/src/models/social/InviteModel.ts
+++ b/packages/database/src/models/social/InviteModel.ts
@@ -166,10 +166,12 @@ export class InviteRepository extends BaseRepository<IInviteDocument> implements
       { type: InviteType.Project, collection: 'projects' },
     ];
 
-    // Always convert documentId to ObjectId for all lookups
+    // Always convert documentId to ObjectId for all lookups. $convert, not $toObjectId: a single
+    // invite whose documentId is not a valid ObjectId would make $toObjectId abort the whole
+    // aggregation, whereas onError: null leaves that one invite unjoined.
     pipeline.push({
       $addFields: {
-        documentObjectId: { $toObjectId: '$documentId' },
+        documentObjectId: { $convert: { input: '$documentId', to: 'objectId', onError: null } },
       },
     });
 


### PR DESCRIPTION
# Pull Request

Closes #1310

## Description

A pass over the counter-logs analytics endpoint turned up five independent
correctness gaps. None of them were introduced by recent work; they were being
rediscovered on every review of this route, so they are fixed together here.

The biggest one is authorization: the route calls `baseApi()` with no
`requiredScopes`. API-key auth rebuilds the CASL ability from `user.isAdmin`, so
the read check alone let any admin-owned API key read all counter logs no matter
what scopes the key was actually issued with. The rest are aggregation and
caching correctness: unguarded `$toObjectId` casts that abort a whole pipeline on
one malformed id, a date window that silently reinterpreted the caller's local
dates as UTC boundaries, an org column that disagreed with the org filter next to
it, a filter that dropped its `$in` when both include and exclude lists were
sent, and a cache read that served entries already past `expiresAt` while waiting
for the TTL monitor.

## Changes

- **Scopes.** `apps/client/pages/api/users/counterLogs.ts` now declares
  `baseApi({ requiredScopes: [ApiKeyScope.ADMIN] })`.
- **`$toObjectId` sweep.** Replaced with `$convert ... onError: null` across
  `CounterLogModel` (7 sites), `InviteModel`, `ResearchDataModel`,
  `Subscription`, and `UserSubscription`. A malformed id now yields a null join
  instead of a failed aggregation. Remaining `$toObjectId` uses in the repo are
  historical migrations plus `documentdb-compat` handling and its fixtures, and
  are intentionally untouched.
- **Timezone.** The logs path accepts an optional IANA `timezone` query param
  that cuts both the `datetime` window and the `$dateToString` day buckets in
  that zone. Defaults to `UTC`, the prior behaviour. The client sends the
  viewer's resolved zone. The cached `DailyReport`/`WeeklyReport` branches stay
  UTC-keyed on purpose - those rows are cached and shared across admins, so a
  per-request zone would let one admin's locale overwrite another's report.
- **Org column.** Now taken from the log's own denormalized `userOrganization`
  (promoted into the `$group` key), the same field `$match` filters on, so a user
  who changed orgs no longer filters under one name and displays under another.
  The `organization` projection was dropped from the user `$lookup` - the User
  schema has `organizationId`, not `organization`, so that column was empty
  regardless.
- **`orgs` + `excludeOrgs`.** Both were assigned to
  `matchCondition.userOrganization` in sequence, so sending both silently
  discarded the `$in`. They are merged into a single operator.
- **Cache expiry.** `cacheRepository.findByKey` now guards on `expiresAt`:
  `$or: [{ expiresAt: null }, { expiresAt: { $gt: now } }]`. A row with no
  expiry means never expires, matching the TTL index, which skips those rows.
  Guarding on `$gt` alone hides them and breaks rate-limit-reset callers.

## Guide for Testers

Backend/API-only change; no new UI. All steps use the admin analytics page and
the API directly.

1. Sign in to `app.staging.bike4mind.com` as an admin.
2. Navigate to Sidebar -> Admin -> Usage/Counter Logs.
3. Set a date range of the last 7 days and load the report. Expected: rows
   render, each with a User, Organization, and day bucket; no error toast.
4. Confirm the Organization column is populated (before this change it was
   blank). Expected: every row shows the org recorded on the log itself.
5. Set the range to today only, from a machine whose OS timezone is NOT UTC
   (e.g. UTC-6). Expected: the returned rows cover your local day, not a window
   shifted by your UTC offset.
6. In the browser devtools Network tab, inspect the counter-logs request.
   Expected: the query string includes a `timezone` param with your IANA zone
   (e.g. `America/Chicago`).
7. Call the endpoint with an API key that is NOT scoped `ADMIN`:
   `curl -H "x-api-key: <non-admin-scoped key>" https://app.staging.bike4mind.com/api/users/counterLogs`
   Expected: rejected for insufficient scope. Before this change an
   admin-owned key succeeded regardless of its scopes.
8. Call the same endpoint with an `ADMIN`-scoped key. Expected: 200 with the
   report payload.

### Regression Checks

1. Load the Daily Report and Weekly Report views. Expected: unchanged output,
   still keyed to UTC days, and still served from cache on a second load.
2. Filter by a single organization. Expected: only that org's rows.
3. Filter with an organization include list AND an exclude list at the same
   time. Expected: both are honoured (previously the include list was dropped).
4. Exercise anything that reads the shared cache - API-key rate limiting is the
   easiest. Expected: limits and resets behave as before; nothing reports a
   stale-but-unexpired entry as missing.

### What NOT to test

No UI layout, styling, or responsive behaviour changed. No schema migration and
no index change - the cache TTL index is untouched; only the read query is
narrowed.

## Additional Information

Rebased onto current `main` after #1056 and #1364 landed, which moved the
aggregation out of the route and into `server/analytics/userActivityQuery.ts`.
The timezone, org-column, and `orgs`/`excludeOrgs` fixes therefore live in that
module now rather than in the route; the scope gate and the query-schema
`timezone` param stay in the route. Two consequences of the newer pipeline worth
a reviewer's eye:

- `userOrganization` joins the `$group` key, so it also had to join the `$sort`
  tiebreak - that sort has to cover the whole group key or a row can straddle or
  skip a window across the two facet executions. `userActivityQuery.test.ts`
  already asserts sort-covers-group-key, so it enforces this.
- The logs cache key is bumped `logs:v3` -> `logs:v4` and now includes the
  timezone, since v3 windows hold the old (empty) org column.

Verification run locally:

- `pnpm turbo:typecheck` - 40/40 green.
- `pnpm lint:check` - clean.
- `@bike4mind/database` - 122 files, 1539 tests pass (1 pre-existing skip),
  including a new `CacheModel.test.ts` case for the expiry guard.
- `apps/client` - the counter-logs, analytics-pipeline, and cache-window suites
  plus `app/utils`: 70 files, 916 tests pass. I did not re-run the whole client
  suite after the rebase; on the pre-rebase run it showed 8
  `mongodb-memory-server` startup timeouts under parallel load on this machine,
  each of which passed in isolation. Leaving that to CI.

Note on the security checklist below: I do not have staging or preview access, so
the before/after reproduction on deployed environments is not done. Step 7 in the
tester guide is the reproduction to run - it fails (returns data) on current
staging and should be rejected on a preview of this branch.

## Security Testing

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
