### PR TITLE
chore(api): take the file-tag id from the URL on both verbs

### DIFF
--- a/.changeset/tag-update-adapter-write-shape.md
+++ b/.changeset/tag-update-adapter-write-shape.md
@@ -1,0 +1,19 @@
+---
+"@bike4mind/services": patch
+---
+
+`tagService.update`'s adapter no longer asks for `Pick<ITagRepository, 'update' | ...>`. Its
+`tags.update` is now declared as the exact shape the service writes,
+`TagUpdateParams & { updatedAt: Date }`. This is a relaxation, so every adapter that satisfied the
+old type still satisfies the new one - but it is what lets an `IFileTag`-typed repository be passed
+without a cast. `IBaseRepository` declares `update` as a property-syntax function type, so
+`strictFunctionTypes` checks its parameter contravariantly and a `Partial<IBaseTag>` parameter
+rejects a `Partial<IFileTag>` one on `TagType` vs `TagType.FILE`.
+
+Behavioural note for anyone tracking the HTTP surface rather than the package: the caller of this
+service, `PUT/DELETE /api/files/tags/[id]`, now takes the tag id from the URL on both verbs instead
+of from the request body on PUT, and rejects a missing, empty or repeated URL id with a 400. That
+route previously answered 422 (zod) for a repeated id and 404 (Mongoose `CastError`) for an empty
+one. It lives in a private app package, so it has no changelog of its own; it is recorded here
+because the route is reachable with an API key and an external consumer could have depended on the
+old status codes.

--- a/apps/client/pages/api/files/tags/[id].ts
+++ b/apps/client/pages/api/files/tags/[id].ts
@@ -1,13 +1,34 @@
-import { ITagRepository, TagType } from '@bike4mind/common';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
-import { ForbiddenError } from '@server/utils/errors';
+import { BadRequestError, ForbiddenError } from '@server/utils/errors';
 import { tagService } from '@bike4mind/services';
 import { fabFileRepository, fileTagRepository } from '@bike4mind/database';
 
+type TagIdQuery = { id?: string | string[] };
+
+/** The editable fields, minus the id - the URL supplies that. Read off the service so the two cannot drift. */
+type TagUpdateBody = Omit<Parameters<typeof tagService.update>[1], 'id'>;
+
+/**
+ * The `[id]` URL segment is the tag id on both verbs, and it wins over anything in the body. PUT
+ * used to take the id from the body spread instead, which left the URL segment decorative on one
+ * verb and load-bearing on the other: `PUT /api/files/tags/A` with a body of `{"id":"B"}` edited
+ * tag B. Anything other than one non-empty string is refused outright: an array is never a valid
+ * tag id, and picking a member out of one would be guessing at which caller meant what.
+ */
+const requireTagId = (query: TagIdQuery): string => {
+  const { id } = query;
+
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new BadRequestError('A tag id is required in the URL');
+  }
+
+  return id;
+};
+
 const handler = baseApi()
   .put(
-    asyncHandler<{}, unknown, unknown>(async (req, res) => {
+    asyncHandler<{}, unknown, TagUpdateBody, TagIdQuery>(async (req, res) => {
       if (!req.user.id) {
         throw new ForbiddenError('Unauthorized');
       }
@@ -15,12 +36,12 @@ const handler = baseApi()
       const result = await tagService.update(
         req.user.id,
         {
-          type: TagType.FILE,
-          ...(req.body as any),
+          ...req.body,
+          id: requireTagId(req.query),
         },
         {
           db: {
-            tags: fileTagRepository as unknown as ITagRepository,
+            tags: fileTagRepository,
             fabFiles: fabFileRepository,
           },
         }
@@ -30,7 +51,7 @@ const handler = baseApi()
     })
   )
   .delete(
-    asyncHandler<{}, unknown, unknown>(async (req, res) => {
+    asyncHandler<{}, unknown, unknown, TagIdQuery>(async (req, res) => {
       if (!req.user.id) {
         throw new ForbiddenError('Unauthorized');
       }
@@ -38,7 +59,7 @@ const handler = baseApi()
       const result = await tagService.remove(
         req.user.id,
         {
-          ...(req.query as any),
+          id: requireTagId(req.query),
         },
         {
           db: {

--- a/apps/client/pages/api/files/tags/[id].ts
+++ b/apps/client/pages/api/files/tags/[id].ts
@@ -20,7 +20,7 @@ const requireTagId = (query: TagIdQuery): string => {
   const { id } = query;
 
   if (typeof id !== 'string' || id.length === 0) {
-    throw new BadRequestError('A tag id is required in the URL');
+    throw new BadRequestError('The URL must carry exactly one tag id');
   }
 
   return id;

--- a/apps/client/pages/api/files/tags/__tests__/[id].test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/[id].test.ts
@@ -99,7 +99,7 @@ describe('PUT /api/files/tags/[id]', () => {
 
     for (const query of [{}, { id: '' }, { id: ['a', 'b'] }]) {
       await expect(call({ method: 'PUT', query, body: { id: 'from-body' }, user: { id: 'u1' } }, res)).rejects.toThrow(
-        'A tag id is required in the URL'
+        'The URL must carry exactly one tag id'
       );
     }
     expect(h.update).not.toHaveBeenCalled();
@@ -141,7 +141,7 @@ describe('DELETE /api/files/tags/[id]', () => {
 
     for (const query of [{}, { id: '' }, { id: ['a', 'b'] }]) {
       await expect(call({ method: 'DELETE', query, user: { id: 'u1' } }, res)).rejects.toThrow(
-        'A tag id is required in the URL'
+        'The URL must carry exactly one tag id'
       );
     }
     expect(h.remove).not.toHaveBeenCalled();

--- a/apps/client/pages/api/files/tags/__tests__/[id].test.ts
+++ b/apps/client/pages/api/files/tags/__tests__/[id].test.ts
@@ -73,10 +73,35 @@ describe('PUT /api/files/tags/[id]', () => {
     expect(actorId).toBe('u1');
   });
 
+  it('takes the tag id from the URL, not the body', async () => {
+    const { res } = makeRes();
+
+    await call(
+      { method: 'PUT', query: { id: 'from-url' }, body: { id: 'from-body', name: 'receipts' }, user: { id: 'u1' } },
+      res
+    );
+
+    // Whole-object, not just `id`: this also pins that the body's id survives under no other key,
+    // and that the route no longer tacks on a `type` the service only strips again.
+    const [, params] = h.update.mock.calls[0];
+    expect(params).toEqual({ id: 'from-url', name: 'receipts' });
+  });
+
   it('rejects an unauthenticated request before reaching the service', async () => {
     const { res } = makeRes();
 
     await expect(call({ method: 'PUT', query: { id: 't1' }, body: {}, user: {} }, res)).rejects.toThrow('Unauthorized');
+    expect(h.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing or repeated id in the URL rather than passing it on', async () => {
+    const { res } = makeRes();
+
+    for (const query of [{}, { id: '' }, { id: ['a', 'b'] }]) {
+      await expect(call({ method: 'PUT', query, body: { id: 'from-body' }, user: { id: 'u1' } }, res)).rejects.toThrow(
+        'A tag id is required in the URL'
+      );
+    }
     expect(h.update).not.toHaveBeenCalled();
   });
 });
@@ -109,5 +134,25 @@ describe('DELETE /api/files/tags/[id]', () => {
 
     await expect(call({ method: 'DELETE', query: { id: 't1' }, user: {} }, res)).rejects.toThrow('Unauthorized');
     expect(h.remove).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing or repeated id in the URL rather than passing it on', async () => {
+    const { res } = makeRes();
+
+    for (const query of [{}, { id: '' }, { id: ['a', 'b'] }]) {
+      await expect(call({ method: 'DELETE', query, user: { id: 'u1' } }, res)).rejects.toThrow(
+        'A tag id is required in the URL'
+      );
+    }
+    expect(h.remove).not.toHaveBeenCalled();
+  });
+
+  it('passes only the id on, not the rest of the query string', async () => {
+    const { res } = makeRes();
+
+    await call({ method: 'DELETE', query: { id: 't1', userId: 'someone-else' }, user: { id: 'u1' } }, res);
+
+    const [, params] = h.remove.mock.calls[0];
+    expect(params).toEqual({ id: 't1' });
   });
 });

--- a/b4m-core/services/src/tagService/update.ts
+++ b/b4m-core/services/src/tagService/update.ts
@@ -13,9 +13,21 @@ const tagUpdateSchema = z.object({
 
 export type TagUpdateParams = z.infer<typeof tagUpdateSchema>;
 
+/** Exactly what this service hands to `tags.update` - see the note on TagUpdateAdapters. */
+type TagUpdateWrite = TagUpdateParams & { updatedAt: Date };
+
 interface TagUpdateAdapters {
   db: {
-    tags: Pick<ITagRepository, 'update' | 'findByIdAndUserId' | 'findAllByUserId' | 'delete'>;
+    // `update` is spelled out rather than picked off ITagRepository, deliberately. IBaseRepository
+    // declares it as a property-syntax function type, so strictFunctionTypes checks its parameter
+    // contravariantly and a `Partial<IBaseTag>` one refuses the IFileTag-typed repository the
+    // file-tag route passes (`TagType` vs `TagType.FILE`) - which is what forced a double cast at
+    // that call site. Naming the narrow shape this service actually writes takes both repositories
+    // cast-free. tagService/remove needs no equivalent: nothing in its Pick has a tag in parameter
+    // position.
+    tags: Pick<ITagRepository, 'findByIdAndUserId' | 'findAllByUserId' | 'delete'> & {
+      update: (data: TagUpdateWrite) => Promise<unknown>;
+    };
     fabFiles: Pick<IFabFileRepository, 'updateTagsByUserId' | 'dedupeTagByUserId'>;
   };
 }


### PR DESCRIPTION
# Pull Request

Closes #1341

## Optional Screenshot/Video

No UI change - this is an API route and a service type signature.

## Description

Two pre-existing inconsistencies in `apps/client/pages/api/files/tags/[id].ts`, both surfaced while reviewing #1335 and both flagged out of scope for it. Neither was a bug, and neither is user-visible.

**1. The `[id]` URL segment was decorative on PUT and load-bearing on DELETE.** PUT spread `req.body` into the service params, so `PUT /api/files/tags/A` with a body of `{"id":"B"}` edited tag B; DELETE read the id from the query. Never a security issue - `findByIdAndUserId(id, userId)` scopes to the caller, so the worst case was editing a different tag you already own. Both verbs now take the id from the URL, where it overrides anything in the body.

**2. `fileTagRepository as unknown as ITagRepository`.** A double cast on an adapter boundary is where a future signature change stops being type-checked.

### Heads-up for reviewers: the issue's suggested fix for item 2 does not work

The issue proposes narrowing the `update` adapter "to a `Pick` of the methods it actually uses, the way `remove` already does". It already was one - `tagService/update.ts` read `Pick<ITagRepository, 'update' | 'findByIdAndUserId' | 'findAllByUserId' | 'delete'>` - so that change is a no-op.

The real cause is variance. `IBaseRepository` declares its members as property-syntax function types (`update: (data: Partial<T>) => ...`), and `strictFunctionTypes` checks those contravariantly in their parameters. Removing the cast and nothing else gives:

```
pages/api/files/tags/[id].ts(23,13): error TS2322: Type 'FileTagRepository' is not assignable to type 'Pick<ITagRepository, "delete" | "update" | "findByIdAndUserId" | "findAllByUserId">'.
  Types of property 'update' are incompatible.
    Type '({ type: _, ...data }: Partial<IFileTag>, options?: Record<string, unknown> | undefined) => Promise<(FlattenMaps<IFileTag> & { _id: ObjectId; } & { ...; }) | null>' is not assignable to type '(data: Partial<IBaseTag>, options?: Record<string, unknown> | undefined) => Promise<IBaseTag | null>'.
      Types of parameters '__0' and 'data' are incompatible.
        Type 'Partial<IBaseTag>' is not assignable to type 'Partial<IFileTag>'.
          Types of property 'type' are incompatible.
            Type 'TagType | undefined' is not assignable to type 'TagType.FILE | undefined'.
              Type 'TagType.SESSION' is not assignable to type 'TagType.FILE'.
```

Note it names `update` and only `update` of the four picked methods. That is also the precise reason `remove` never needed a cast: `findByIdAndUserId` is declared with method syntax (bivariant, covariant return) and `delete: (id: string) => ...` has no tag type in parameter position.

So the fix declares `tags.update` with the narrow shape the service actually writes - `TagUpdateParams & { updatedAt: Date }`, which is exactly what `buildData` is - rather than borrowing the repository's `Partial<T>` signature. `fileTagRepository` then satisfies it cast-free, which is what the route needed; the narrow write shape is also assignable to `Partial<IBaseTag>`, so a base-tag repository would satisfy it too, though nothing currently passes one. It is written with property syntax on purpose: method syntax would restore bivariance and make the error disappear by discarding the type safety this change exists to restore.

Alternatives considered and rejected: making the adapter generic over `T extends IBaseTag` (a type parameter on a service signature for one call site), and reconciling `ITagRepository` with `IFileTagRepository` (blast radius is every repository plus every adapter that picks off them).

## Changes

- `apps/client/pages/api/files/tags/[id].ts` - a single `requireTagId(req.query)` is the id source on both verbs. On PUT it is placed after the body spread so the URL wins; DELETE passes an explicit `{ id }` rather than spreading the whole query string into the service params. A missing, empty, or array-valued id is now a 400 instead of something the service has to reject.
- Dropped the double cast, now that the adapter no longer demands a `Partial<IBaseTag>` parameter.
- Dropped `type: TagType.FILE` from the PUT params. It never reached the service: `secureParameters` is `schema.parse` on a non-passthrough `z.object`, so zod stripped it, and `FileTagRepository.update` strips `type` again on its own. Removing it is also what lets the body be typed instead of cast.
- The route is now free of `any`: the query and body types come from the `asyncHandler` generics, and the body type is read off the service (`Omit<Parameters<typeof tagService.update>[1], 'id'>`) so it cannot drift from the request schema.
- `b4m-core/services/src/tagService/update.ts` - `tags.update` narrowed to the write shape, with a comment recording why it is spelled out rather than picked.

### Tests

`apps/client/pages/api/files/tags/__tests__/[id].test.ts`, +4 cases (10 total in the file):

- PUT with `query.id` and `body.id` disagreeing reaches the service with the URL's id. Asserted as a whole-object `toEqual`, which also pins that the body id survives under no other key and that `type` is no longer sent.
- PUT rejects a missing, empty, or repeated URL id before calling the service.
- DELETE rejects the same three.
- DELETE passes only the id on, not the rest of the query string.

## Guide for Testers

Two jobs here, because the two halves of this PR are testable in very different ways.

**The `fileTagRepository` cast removal is compile-time only** - the emitted code is unchanged, so there is nothing to click and nothing to observe. CI's Type Check is its verification. Do not write a QA step for it.

**The URL-wins change cannot be seen through the app**, because the client always puts the same id in the URL and the body. No sequence of clicks produces the divergent request this fixes. So the coverage splits in two: part A runs the script, part B is a normal click-through regression pass.

### Part A - verifying the fix (script)

Run `tag-id-source-evidence.sh` from the Test Evidence section below, once against staging and once against the preview link. Needs `curl`, `jq`, and an access token or API key per environment; no codebase knowledge.

1. Get a credential for that environment. A signed-in session's Bearer access token is the path the recorded runs used; a `b4m_live_` key from Settings > API Keys should also work, since this route is a bare `baseApi()` with no scope gate, but that path has not been exercised. Credentials do not carry across environments - get one per host.
2. `read -rs B4M_KEY && export B4M_KEY`, then paste the credential. It is not echoed, so it stays out of your shell history.
3. `BASE_URL='<staging>' ./tag-id-source-evidence.sh`
   - Expected last line: `RESULT: the BODY won - beta was renamed. This is the old behavior.`
4. Repeat with `BASE_URL='<the preview link>'`.
   - Expected last line: `RESULT: the URL won - alpha was renamed. This is the fixed behavior.`
5. Pass condition: staging says BODY, preview says URL. Anything else - especially `RESULT: inconclusive` - is a failure; attach the full output.

The script creates its own two tags and deletes them on exit, so it is safe to run repeatedly and leaves no fixtures behind. Do not point it at a `datalake:` tag; rename and delete are refused for those by design, which is unrelated to this change.

### Part B - regression pass (any tester, no tooling)

The point of this pass is that tag rename and delete still behave exactly as before.

Finding the right surface matters here - there are three tag UIs and only one of them uses the changed route:

| Surface | What it does | Endpoint | Relevant? |
|---|---|---|---|
| **Tags** tab in the Files Manager | Browses files by tag name | read-only | No |
| **Manage Tags** on a file row | Attaches/detaches tags on one file | `tags/toggle` | No |
| **Tag Manager** (List tab) | Renames/deletes the tag itself | `tags/[id]` | **Yes** |

Note the Tags tab and the Tag Manager legitimately disagree: the tab is built from tag names stored on files, while the manager lists tag documents. A fresh account can show tags in the tab and "No tags available" in the manager. Create what you need in step 3 rather than assuming a tag document already exists.

1. Open the preview link and sign in.
2. Open the Files Manager from the sidenav, switch to the **List** tab, and click the tag-icon button next to the "All Files" header to open the **Tag Manager**.
3. Using the `+` button, create a tag and apply it to at least two files (via each file's row action). Note the name and which files carry it.
4. Click the tag's edit action, change its name to something new, and submit.
   - Expected: the modal closes, the sidebar row shows the new name, and no error toast appears.
5. Open one of the files that carried the old name.
   - Expected: the file now shows the new tag name, not the old one.
6. Back in the tag sidebar, check the file count on the renamed tag.
   - Expected: the same count as before the rename - it did not drop to zero.
7. Rename a tag onto the name of another tag you already have (a merge).
   - Expected: the two rows collapse into one, and a file that carried both names ends up with a single entry, not a duplicate.
8. Delete a tag that is applied to at least one file and confirm the dialog.
   - Expected: the row disappears, and opening a file that carried it shows the name gone.

### Regression Checks

- Part A passes on both environments: staging reports BODY, preview reports URL.
- Tag rename, tag merge, and tag delete all still work end to end (Part B steps 4-8). These are the only paths through the changed route.
- Creating a tag and toggling a tag on a file are unaffected - they go through `tags/index.ts` and `tags/toggle.ts`, which this PR does not touch.

### What NOT to test

- The cast removal. Compile-time only, no runtime difference to observe.
- The 400 responses. The app's own hooks always put the real id in the URL, so there is no UI path that produces a missing or malformed id; those cases are covered by the route tests.
- Data lake membership tags. Rename and delete are refused for them by the service, unchanged here.

## Test Evidence

QA PASS 2/2. The same request was sent to both environments: a PUT whose URL names `tag-alpha` while its body names `tag-beta`. Whichever tag comes back renamed is the id source.

### Reproducing it

Save the script below, then run it once per environment. `read -rs` takes the credential without echoing it, so no token ends up in your shell history or in a screenshot:

```bash
read -rs B4M_KEY && export B4M_KEY

BASE_URL='<staging>'          ./tag-id-source-evidence.sh   # expect: the BODY won
BASE_URL='<the preview link>' ./tag-id-source-evidence.sh   # expect: the URL won
```

`B4M_KEY` takes either a `b4m_live_` API key from Settings > API Keys or a Bearer access token; the script picks the right header from the prefix. Needs `curl` and `jq`. It creates its own tags and deletes them on exit, so it leaves nothing behind.

<details>
<summary><code>tag-id-source-evidence.sh</code></summary>

```bash
#!/usr/bin/env bash
# Does PUT /api/files/tags/[id] take the tag id from the URL or from the request body?
#
# Creates two throwaway tags, then sends ONE request whose URL points at alpha while the body
# claims beta. Whichever tag comes back renamed is the id source. Deletes both tags afterwards.
#
# Expected BEFORE (current main): body wins  -> tag-beta is renamed
# Expected AFTER  (this PR):      URL wins   -> tag-alpha is renamed

set -euo pipefail

: "${BASE_URL:?set BASE_URL to the environment root}"
: "${B4M_KEY:?set B4M_KEY to an API key or access token}"

BASE_URL="${BASE_URL%/}"
SUFFIX="$$"
ALPHA="tag-alpha-${SUFFIX}"
BETA="tag-beta-${SUFFIX}"
RENAMED="renamed-by-body-${SUFFIX}"

# Accepts either a b4m_live_ API key (x-api-key) or a short-lived JWT access token (Bearer).
# Both are valid credentials for baseApi() routes; the prefix tells them apart.
if [[ "${B4M_KEY}" == b4m_* ]]; then
  AUTH_HEADER="x-api-key: ${B4M_KEY}"
else
  AUTH_HEADER="Authorization: Bearer ${B4M_KEY#Bearer }"
fi

api() {
  local method="$1" path="$2"
  shift 2
  curl -sS -X "$method" \
    -H "${AUTH_HEADER}" \
    -H 'Content-Type: application/json' \
    "$@" "${BASE_URL}${path}"
}

tag_id_by_name() {
  api GET /api/files/tags | jq -r --arg n "$1" '.[] | select(.name == $n) | .id'
}

tag_name_by_id() {
  api GET /api/files/tags | jq -r --arg i "$1" '.[] | select(.id == $i) | .name'
}

cleanup() {
  for id in "${ALPHA_ID:-}" "${BETA_ID:-}"; do
    [ -n "$id" ] && api DELETE "/api/files/tags/${id}" >/dev/null 2>&1 || true
  done
}
trap cleanup EXIT

command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }

echo "environment: ${BASE_URL}"
echo

api POST /api/files/tags -d "{\"name\":\"${ALPHA}\"}" >/dev/null
api POST /api/files/tags -d "{\"name\":\"${BETA}\"}"  >/dev/null

ALPHA_ID="$(tag_id_by_name "$ALPHA")"
BETA_ID="$(tag_id_by_name "$BETA")"
[ -n "$ALPHA_ID" ] && [ -n "$BETA_ID" ] || { echo "could not create both tags" >&2; exit 1; }

echo "created  alpha=${ALPHA}  id=${ALPHA_ID}"
echo "created  beta =${BETA}  id=${BETA_ID}"
echo
echo "PUT ${BASE_URL}/api/files/tags/${ALPHA_ID}"
echo "    body: {\"id\":\"${BETA_ID}\",\"name\":\"${RENAMED}\"}"
echo "    (URL says alpha, body says beta - they disagree on purpose)"
echo

HTTP_BODY="$(api PUT "/api/files/tags/${ALPHA_ID}" -d "{\"id\":\"${BETA_ID}\",\"name\":\"${RENAMED}\"}")"
echo "response: ${HTTP_BODY}"
echo

ALPHA_NOW="$(tag_name_by_id "$ALPHA_ID")"
BETA_NOW="$(tag_name_by_id "$BETA_ID")"

echo "alpha is now: ${ALPHA_NOW:-<gone>}"
echo "beta  is now: ${BETA_NOW:-<gone>}"
echo

if [ "$ALPHA_NOW" = "$RENAMED" ]; then
  echo "RESULT: the URL won - alpha was renamed. This is the fixed behavior."
elif [ "$BETA_NOW" = "$RENAMED" ]; then
  echo "RESULT: the BODY won - beta was renamed. This is the old behavior."
else
  echo "RESULT: inconclusive - neither tag carries the new name. Check the response above."
  exit 1
fi
```

</details>

### Results

**Before (staging, current `main`) - the body won:**

```
PUT /api/files/tags/6a75c252b8505a4fc4e077f6          <- URL says alpha
    body: {"id":"6a75c253b8505a4fc4e077fa","name":"renamed-by-body-13280"}

response: {"id":"6a75c253b8505a4fc4e077fa","name":"renamed-by-body-13280",...}

alpha is now: tag-alpha-13280           <- untouched
beta  is now: renamed-by-body-13280     <- renamed
```

**After (this PR's preview) - the URL won:**

```
PUT /api/files/tags/6a75c2d81a21e112196f3ef5          <- URL says alpha
    body: {"id":"6a75c2d91a21e112196f3f39","name":"renamed-by-body-49980"}

response: {"id":"6a75c2d81a21e112196f3ef5","name":"renamed-by-body-49980",...}

alpha is now: renamed-by-body-49980     <- renamed
beta  is now: tag-beta-49980            <- untouched
```

The sharpest line is the response itself: given the same payload shape, staging echoes back **beta's** id and the preview echoes back **alpha's**. The URL segment went from ignored to authoritative.

Both runs created their two tags fresh and deleted them afterwards, so neither environment was left dirty.

The cast removal has no runtime evidence to give - identical emitted code. Its verification is the green Type Check on this PR, which is meaningful here because CI builds without the locally-hydrated premium overlays.

## Additional Information

CI is green on this branch's head commit, including Type Check, Lint, Core Build, OpenAPI Spec and all five test shards - that is the authoritative run against the exact code under review.

Locally, on the same code: the route's own test file passes 10/10, `pnpm lint:check` is clean, and the client typecheck reports nothing outside pre-existing errors in locally-hydrated premium overlay packages this PR does not touch. Earlier in development, full-suite runs gave client 8938 passed / 0 failed, `@bike4mind/services` 3733 / 0, `@bike4mind/database` 1527, and `@bike4mind/scripts` 271; those predate a one-line test-assertion change made during self-review, so CI's run on the head commit is the one to trust for the final state.

A sweep for the same shape elsewhere found six other routes that let a body id override a URL id (`organizations/[id]`, `projects/[id]`, `[type]/[id]/invites`, `[type]/[id]/revokeSharing`, `projects/[id]/invites`, `research/agents/[id]/tasks/[taskId]`). None is an escalation, for a structural reason: not one performs a route-level permission check against the URL values before calling, so each service is the sole authorizer and authorizes against the very id it then acts on. Nothing was filed, and nothing outside the file named in the issue was changed.

Two small response-code changes on paths the app never takes: a malformed DELETE id now returns 400 where it previously reached zod and returned 422, and an empty-string id returns 400 where it previously reached Mongo and returned 404 via the `CastError` branch in `errorHandler`.

## Developer Notes (Optional)

- **Adapter typing pattern.** When a service adapter is only ever handed a discriminated subtype's repository (`IFileTagRepository` rather than `ITagRepository`), picking the write method off the base interface will not typecheck under `strictFunctionTypes`, because `IBaseRepository`'s members are property-syntax function types and their parameters are contravariant. Declaring the narrow shape the service actually writes fixes it at the definition instead of pushing a cast onto every call site. `tagService/update.ts` is the worked example, and its comment records the mechanism.
- **Deriving a route's body type from its service** (`Omit<Parameters<typeof service.fn>[1], 'id'>`) types a handler without widening the service package's public exports and without an inline duplicate of the request schema.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a, no AdminSettings added
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - n/a, no documented behavior changes; the id source was never specified anywhere
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc - n/a, no telemetry fields touched
