### PR TITLE
fix(services): stop notebook import overwriting the messages it imports

### DIFF
--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -5,7 +5,6 @@ import { S3Storage } from '@bike4mind/fab-pipeline';
 import {
   inboxRepository,
   sessionRepository,
-  questRepository,
   Quest,
   FabFile,
   Artifact,
@@ -24,6 +23,22 @@ import { v4 as uuidv4 } from 'uuid';
 import { updateImportProgress, markImportComplete, markImportFailed } from '@server/utils/importHistoryProgress';
 
 const { NotebookImportService } = notebookImportService;
+
+/**
+ * The notebook-metadata writes an import performs. Exported for the same reason as the message
+ * writes below: a test that re-implements these cannot catch them regressing.
+ *
+ * No `ctx` is assigned on the repository: transactionAsyncLocalStorage already carries the session
+ * into these queries, and assigning it would strand a finished session on the shared instance -
+ * the next caller to read it fails with "Use of expired sessions".
+ */
+export const createSessionWrites = () => ({
+  create: async (data: any) => sessionRepository.create(data),
+  find: async (query: any) => sessionRepository.find(query),
+  // `update` identifies the row by `id` and throws without it - `_id` here silently made every
+  // overwrite and merge import fail.
+  updateById: async (id: string, data: any) => sessionRepository.update({ id, ...data }),
+});
 
 /**
  * The message writes an import performs. Exported so the invariant below is testable against a
@@ -89,19 +104,8 @@ const processNotebookImport = async (
         // No `ctx` here: transactionAsyncLocalStorage already carries the session into these
         // queries, and assigning it would strand a finished session on the shared repository
         // instance - the next caller to read it fails with "Use of expired sessions".
-        sessionRepository: {
-          ...sessionRepository,
-          create: async (data: any) => sessionRepository.create(data),
-          find: async (query: any) => sessionRepository.find(query),
-          // `update` identifies the row by `id` and throws without it - `_id` here silently made
-          // every overwrite and merge import fail.
-          updateById: async (id: string, data: any) => sessionRepository.update({ id, ...data }),
-        },
-        chatHistoryRepository: {
-          ...questRepository,
-          ctx: session,
-          ...createChatHistoryWrites(session),
-        },
+        sessionRepository: createSessionWrites(),
+        chatHistoryRepository: createChatHistoryWrites(session),
         knowledgeRepository: {
           create: async (data: any) => {
             // Use model directly with session for transaction support

--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -16,7 +16,8 @@ import {
   importHistoryJobRepository,
 } from '@bike4mind/database';
 import { withContext } from '@server/s3/utils';
-import type { ClientSession } from 'mongoose';
+import type { ClientSession, FilterQuery } from 'mongoose';
+import type { IChatHistoryItem, IChatHistoryItemDocument } from '@bike4mind/common';
 import { Resource } from 'sst';
 import { getFilesStorage } from '@server/utils/storage';
 import { v4 as uuidv4 } from 'uuid';
@@ -28,27 +29,33 @@ const { NotebookImportService } = notebookImportService;
  * The message writes an import performs. Exported so the invariant below is testable against a
  * real database rather than a copy of it - see notebookImportOverwrite.e2e.test.ts.
  */
-export const createChatHistoryWrites = (session?: ClientSession) => ({
-  bulkCreate: async (items: any[]) => {
-    // Insert, never upsert: an upsert on the incoming id re-pointed the *source* documents at
-    // the new notebook when an export was imported back into its own database, emptying the
-    // original.
-    //
-    // skipValidation keeps this as lenient as the update it replaces. Inserts validate where
-    // updates do not, and ChatHistoryItemSchema marks `prompt` required (QuestModel.ts) while
-    // the system writes empty ones - an assistant-first turn has no prompt - so validating here
-    // would fail imports that currently work.
-    const ops = items.map(({ id, ...rest }) => ({
-      insertOne: { document: id ? { _id: id, ...rest } : rest },
-    }));
-    return Quest.bulkWrite(ops, { session, skipValidation: true });
-  },
-  deleteMany: async (filter: any) => {
-    // Hard delete: the soft-delete default leaves the rows with their ids, so the replacement
-    // insert in bulkCreate collides with the documents it supersedes.
-    return Quest.deleteMany(filter, { session, hardDelete: true });
-  },
-});
+export const createChatHistoryWrites = (session?: ClientSession) => {
+  // The key must be absent, not present-and-undefined: the session guards are presence checks, so
+  // `{ session: undefined }` makes the write escape the caller's transaction. See BaseModel.delete.
+  const txn = session ? { session } : {};
+  return {
+    bulkCreate: async (items: IChatHistoryItem[]) => {
+      // Insert, never upsert: an upsert on the incoming id re-pointed the *source* documents at
+      // the new notebook when an export was imported back into its own database, emptying the
+      // original.
+      //
+      // skipValidation keeps this as lenient as the update it replaces. Inserts validate where
+      // updates do not, and ChatHistoryItemSchema marks `prompt` required (QuestModel.ts) while
+      // the system writes empty ones - an assistant-first turn has no prompt - so validating here
+      // would fail imports that currently work. Note it waives every validator on the schema, not
+      // just that one; bulkWrite has no per-field opt-out.
+      const ops = items.map(({ id, ...rest }) => ({
+        insertOne: { document: id ? { _id: id, ...rest } : rest },
+      }));
+      return Quest.bulkWrite(ops, { ...txn, skipValidation: true });
+    },
+    deleteMany: async (filter: FilterQuery<IChatHistoryItemDocument>) => {
+      // Hard delete: the soft-delete default leaves the rows with their ids, so the replacement
+      // insert in bulkCreate collides with the documents it supersedes.
+      return Quest.deleteMany(filter, { ...txn, hardDelete: true });
+    },
+  };
+};
 
 const processNotebookImport = async (
   userId: string,
@@ -189,9 +196,8 @@ const processNotebookImport = async (
       const importService = new NotebookImportService(adapters);
       const result = await importService.importNotebooks(userId, importData, options);
 
-      // A failed write has already aborted this transaction server-side, so nothing persists -
-      // not even the notebooks the service counted as imported. Its collected errors must not
-      // reach the user as success.
+      // Any per-notebook failure rolls the whole import back. A failed write usually aborts the
+      // transaction server-side already, but a client-side cast error leaves it healthy.
       if (result.errors?.length) {
         throw new Error(`Imported no notebooks: ${result.errors.join('; ')}`);
       }
@@ -351,8 +357,13 @@ export const dispatch = withContext(async (event, context, logger) => {
             stack: error instanceof Error ? error.stack : undefined,
           });
         }
+      } catch (markFailedErr) {
+        logger.error('Failed to mark import as failed:', markFailedErr);
+      }
 
-        await inboxRepository.createInboxMessage({
+      // Outside the try above, so a failed job lookup does not swallow the user's notification.
+      await inboxRepository
+        .createInboxMessage({
           type: InboxType.COMMON,
           title: '❌ Notebook Import Failed',
           message: `Failed to import notebooks. Error: ${
@@ -360,10 +371,8 @@ export const dispatch = withContext(async (event, context, logger) => {
           }. Please try again or contact support if the issue persists.`,
           receiverId: userId,
           userId,
-        });
-      } catch (markFailedErr) {
-        logger.error('Failed to report import failure:', markFailedErr);
-      }
+        })
+        .catch(notifyErr => logger.error('Failed to notify import failure:', notifyErr));
     }
   }
 });

--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -16,12 +16,39 @@ import {
   importHistoryJobRepository,
 } from '@bike4mind/database';
 import { withContext } from '@server/s3/utils';
+import type { ClientSession } from 'mongoose';
 import { Resource } from 'sst';
 import { getFilesStorage } from '@server/utils/storage';
 import { v4 as uuidv4 } from 'uuid';
 import { updateImportProgress, markImportComplete, markImportFailed } from '@server/utils/importHistoryProgress';
 
 const { NotebookImportService } = notebookImportService;
+
+/**
+ * The message writes an import performs. Exported so the invariant below is testable against a
+ * real database rather than a copy of it - see notebookImportOverwrite.e2e.test.ts.
+ */
+export const createChatHistoryWrites = (session?: ClientSession) => ({
+  bulkCreate: async (items: any[]) => {
+    // Insert, never upsert: an upsert on the incoming id re-pointed the *source* documents at
+    // the new notebook when an export was imported back into its own database, emptying the
+    // original.
+    //
+    // skipValidation keeps this as lenient as the update it replaces. Inserts validate where
+    // updates do not, and ChatHistoryItemSchema marks `prompt` required (QuestModel.ts) while
+    // the system writes empty ones - an assistant-first turn has no prompt - so validating here
+    // would fail imports that currently work.
+    const ops = items.map(({ id, ...rest }) => ({
+      insertOne: { document: id ? { _id: id, ...rest } : rest },
+    }));
+    return Quest.bulkWrite(ops, { session, skipValidation: true });
+  },
+  deleteMany: async (filter: any) => {
+    // Hard delete: the soft-delete default leaves the rows with their ids, so the replacement
+    // insert in bulkCreate collides with the documents it supersedes.
+    return Quest.deleteMany(filter, { session, hardDelete: true });
+  },
+});
 
 const processNotebookImport = async (
   userId: string,
@@ -72,20 +99,7 @@ const processNotebookImport = async (
         chatHistoryRepository: {
           ...questRepository,
           ctx: session,
-          bulkCreate: async (items: any[]) => {
-            // Use Quest model directly for bulk operations
-            const bulkOps = items.map(item => ({
-              updateOne: {
-                filter: { _id: item.id },
-                update: { $set: item },
-                upsert: true,
-              },
-            }));
-            return Quest.bulkWrite(bulkOps, { session });
-          },
-          deleteMany: async (filter: any) => {
-            return Quest.deleteMany(filter, { session });
-          },
+          ...createChatHistoryWrites(session),
         },
         knowledgeRepository: {
           create: async (data: any) => {
@@ -174,6 +188,13 @@ const processNotebookImport = async (
 
       const importService = new NotebookImportService(adapters);
       const result = await importService.importNotebooks(userId, importData, options);
+
+      // A failed write has already aborted this transaction server-side, so nothing persists -
+      // not even the notebooks the service counted as imported. Its collected errors must not
+      // reach the user as success.
+      if (result.errors?.length) {
+        throw new Error(`Imported no notebooks: ${result.errors.join('; ')}`);
+      }
 
       await markImportComplete(importHistoryJobId, userId, {
         processedItems: result.importedNotebooks + result.importedMessages,

--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -93,8 +93,9 @@ const processNotebookImport = async (
           ...sessionRepository,
           create: async (data: any) => sessionRepository.create(data),
           find: async (query: any) => sessionRepository.find(query),
-          // sessionRepository.update expects the full object with _id
-          updateById: async (id: string, data: any) => sessionRepository.update({ _id: id, ...data }),
+          // `update` identifies the row by `id` and throws without it - `_id` here silently made
+          // every overwrite and merge import fail.
+          updateById: async (id: string, data: any) => sessionRepository.update({ id, ...data }),
         },
         chatHistoryRepository: {
           ...questRepository,

--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -214,23 +214,11 @@ const processNotebookImport = async (
       logger.info('Notebook import completed successfully', { userId, result });
       return result;
     } catch (error) {
+      // Reporting the failure happens in the caller, not here. A failed write aborts the
+      // transaction server-side, and every write in this scope picks that session up from
+      // async-local storage, so a status update or inbox message written here would itself fail
+      // and the user would hear nothing.
       logger.error('Notebook import failed', { userId, dataKey, error });
-
-      await markImportFailed(importHistoryJobId, userId, {
-        message: error instanceof Error ? error.message : 'Unknown error',
-        stack: error instanceof Error ? error.stack : undefined,
-      });
-
-      await inboxRepository.createInboxMessage({
-        type: InboxType.COMMON,
-        title: '❌ Notebook Import Failed',
-        message: `Failed to import notebooks. Error: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }. Please try again or contact support if the issue persists.`,
-        receiverId: userId,
-        userId,
-      });
-
       throw error;
     } finally {
       await Promise.all([
@@ -353,6 +341,8 @@ export const dispatch = withContext(async (event, context, logger) => {
         error,
       });
 
+      // Outside the import's transaction, so these still land when it is the transaction that
+      // failed - which is the usual reason to be here.
       try {
         const existingJob = await importHistoryJobRepository.findByS3Key(key);
         if (existingJob && existingJob.status !== 'failed') {
@@ -361,8 +351,18 @@ export const dispatch = withContext(async (event, context, logger) => {
             stack: error instanceof Error ? error.stack : undefined,
           });
         }
+
+        await inboxRepository.createInboxMessage({
+          type: InboxType.COMMON,
+          title: '❌ Notebook Import Failed',
+          message: `Failed to import notebooks. Error: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }. Please try again or contact support if the issue persists.`,
+          receiverId: userId,
+          userId,
+        });
       } catch (markFailedErr) {
-        logger.error('Failed to mark import as failed:', markFailedErr);
+        logger.error('Failed to report import failure:', markFailedErr);
       }
     }
   }

--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -86,22 +86,15 @@ const processNotebookImport = async (
 
       // Create service adapters (matching the export service pattern)
       const adapters = {
+        // No `ctx` here: transactionAsyncLocalStorage already carries the session into these
+        // queries, and assigning it would strand a finished session on the shared repository
+        // instance - the next caller to read it fails with "Use of expired sessions".
         sessionRepository: {
           ...sessionRepository,
-          ctx: session,
-          create: async (data: any) => {
-            sessionRepository.ctx = session;
-            return sessionRepository.create(data);
-          },
-          find: async (query: any) => {
-            sessionRepository.ctx = session;
-            return sessionRepository.find(query);
-          },
-          updateById: async (id: string, data: any) => {
-            // sessionRepository.update expects the full object with _id
-            sessionRepository.ctx = session;
-            return sessionRepository.update({ _id: id, ...data });
-          },
+          create: async (data: any) => sessionRepository.create(data),
+          find: async (query: any) => sessionRepository.find(query),
+          // sessionRepository.update expects the full object with _id
+          updateById: async (id: string, data: any) => sessionRepository.update({ _id: id, ...data }),
         },
         chatHistoryRepository: {
           ...questRepository,

--- a/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
+++ b/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
@@ -5,7 +5,7 @@ import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
 import { Quest, Session, sessionRepository } from '@bike4mind/database';
 import { notebookImportService } from '@bike4mind/services';
-import { createChatHistoryWrites } from './notebookImportComplete';
+import { createChatHistoryWrites, createSessionWrites } from './notebookImportComplete';
 
 /**
  * Guards the invariant this handler exists for: importing an export NEVER rewrites messages that
@@ -13,9 +13,13 @@ import { createChatHistoryWrites } from './notebookImportComplete';
  * database it came from matched the original documents and re-pointed them at the new notebook -
  * the source notebook was emptied and the import reported success.
  *
- * Drives the REAL service through the REAL write adapter against a real database, because the
- * defect lived in the adapter, not in the service. Consumes the built dist, so
- * `pnpm turbo:core:build` must be current.
+ * Drives the REAL service through the REAL write adapters against a real database, because the
+ * defect lived in the adapter, not in the service.
+ *
+ * Run `pnpm --filter @bike4mind/services build` (or `pnpm turbo:core:build`) first. This imports
+ * the service from the built dist, not from src, so a stale dist reports green against whatever
+ * was last compiled - on exactly the service this file exists to guard. CI builds core fresh, so
+ * the hazard is local only.
  */
 
 const { NotebookImportService } = notebookImportService;
@@ -88,13 +92,9 @@ function exportPayload(name: string, ids: string[]) {
 
 function makeService() {
   const adapters = {
-    sessionRepository: {
-      create: async (d: unknown) => sessionRepository.create(d as never),
-      find: async (q: unknown) => sessionRepository.find(q as never),
-      // Delegates to the real repository, as the handler does. Stubbing this with a raw
-      // Session.updateOne is what hid `update` rejecting `_id` and failing every overwrite/merge.
-      updateById: async (id: string, d: Record<string, unknown>) => sessionRepository.update({ id, ...d } as never),
-    },
+    // The real adapter, not a copy: re-implementing it here is what let `update` regress to `_id`
+    // - the test kept passing because it was exercising its own copy, not the handler's.
+    sessionRepository: createSessionWrites(),
     // the real thing, not a copy
     chatHistoryRepository: createChatHistoryWrites(),
     knowledgeRepository: { create: async () => null },

--- a/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
+++ b/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
@@ -138,6 +138,7 @@ describe('notebook import does not overwrite existing messages', () => {
     expect(String(result.errors?.[0])).toMatch(/duplicate key/i);
 
     // The invariant. Before the fix these were 0 and 5: the messages were moved, not copied.
+    // Nothing partial lands: bulkWrite is ordered and every id collides on the first op.
     expect(await Quest.countDocuments({ sessionId })).toBe(5);
     expect(await Quest.countDocuments({})).toBe(5);
   }, 60000);

--- a/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
+++ b/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { Quest, Session, sessionRepository } from '@bike4mind/database';
+import { notebookImportService } from '@bike4mind/services';
+import { createChatHistoryWrites } from './notebookImportComplete';
+
+/**
+ * Guards the invariant this handler exists for: importing an export NEVER rewrites messages that
+ * already exist. The store used to upsert on the incoming id, so re-importing an export into the
+ * database it came from matched the original documents and re-pointed them at the new notebook -
+ * the source notebook was emptied and the import reported success.
+ *
+ * Drives the REAL service through the REAL write adapter against a real database, because the
+ * defect lived in the adapter, not in the service. Consumes the built dist, so
+ * `pnpm turbo:core:build` must be current.
+ */
+
+const { NotebookImportService } = notebookImportService;
+
+let mongoServer: MongoMemoryServer;
+
+const USER = 'import-owner';
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+}, 60000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 60000);
+afterEach(async () => {
+  await Promise.all([Quest.deleteMany({}, { hardDelete: true }), Session.deleteMany({}, { hardDelete: true })]);
+});
+
+/** Seeds a notebook with `count` messages and returns it with the ids the export would carry. */
+async function seedNotebook(name: string, count: number) {
+  const session = await sessionRepository.create({
+    userId: USER,
+    name,
+    firstCreated: new Date('2026-01-01T00:00:00Z'),
+    lastUpdated: new Date('2026-01-02T00:00:00Z'),
+  } as never);
+  const sessionId = String((session as { id: string }).id);
+  const docs = Array.from({ length: count }, (_, i) => ({
+    _id: new mongoose.Types.ObjectId(),
+    sessionId,
+    timestamp: new Date(Date.UTC(2026, 0, 1, 0, i)),
+    type: 'message',
+    prompt: `original ${i}`,
+    reply: `reply ${i}`,
+    status: 'done',
+    pinned: false,
+  }));
+  await Quest.collection.insertMany(docs);
+  return { sessionId, ids: docs.map(d => String(d._id)) };
+}
+
+function exportPayload(name: string, ids: string[]) {
+  return {
+    exportVersion: '1.0.0',
+    notebooks: [
+      {
+        id: 'exported-notebook',
+        name,
+        firstCreated: '2026-01-01T00:00:00.000Z',
+        lastUpdated: '2026-01-02T00:00:00.000Z',
+        chatHistory: ids.map((id, i) => ({
+          id,
+          timestamp: new Date(Date.UTC(2026, 0, 1, 0, i)).toISOString(),
+          type: 'message',
+          prompt: `original ${i}`,
+          reply: `reply ${i}`,
+          status: 'done',
+          pinned: false,
+        })),
+        knowledge: [],
+        artifacts: [],
+        tools: [],
+        agents: [],
+      },
+    ],
+  };
+}
+
+function makeService() {
+  const adapters = {
+    sessionRepository: {
+      create: async (d: unknown) => sessionRepository.create(d as never),
+      find: async (q: unknown) => sessionRepository.find(q as never),
+      updateById: async (id: string, d: unknown) => Session.updateOne({ _id: id }, { $set: d }),
+    },
+    // the real thing, not a copy
+    chatHistoryRepository: createChatHistoryWrites(),
+    knowledgeRepository: { create: async () => null },
+    artifactRepository: { create: async () => null },
+    toolRepository: { create: async () => null, find: async () => [], findById: async () => null },
+    agentRepository: { create: async () => null },
+    userRepository: { findById: async () => ({ id: USER }) },
+    fileStorageService: {
+      getFileContent: async () => null,
+      uploadFile: async () => {},
+      getSignedUrl: async () => null,
+    },
+    logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    generateId: () => new mongoose.Types.ObjectId().toString(),
+  };
+  return new NotebookImportService(adapters as never);
+}
+
+const OPTIONS = {
+  importKnowledge: false,
+  importArtifacts: false,
+  importTools: false,
+  importAgents: false,
+};
+
+describe('notebook import does not overwrite existing messages', () => {
+  it('leaves the source notebook intact when its own export is re-imported', async () => {
+    const { sessionId, ids } = await seedNotebook('Shared Name', 5);
+    const payload = exportPayload('Different Name', ids);
+
+    const result = await makeService().importNotebooks(
+      USER,
+      payload as never,
+      {
+        ...OPTIONS,
+        conflictResolution: 'rename',
+        preserveIds: true,
+      } as never
+    );
+
+    // The ids already exist, so the import must refuse rather than claim them.
+    expect(result.errors?.length).toBe(1);
+    expect(String(result.errors?.[0])).toMatch(/duplicate key/i);
+
+    // The invariant. Before the fix these were 0 and 5: the messages were moved, not copied.
+    expect(await Quest.countDocuments({ sessionId })).toBe(5);
+    expect(await Quest.countDocuments({})).toBe(5);
+  }, 60000);
+
+  it('copies messages into a new notebook rather than moving them', async () => {
+    const { sessionId, ids } = await seedNotebook('Shared Name', 5);
+    const payload = exportPayload('Different Name', ids);
+
+    await makeService().importNotebooks(
+      USER,
+      payload as never,
+      {
+        ...OPTIONS,
+        conflictResolution: 'rename',
+        preserveIds: false,
+      } as never
+    );
+
+    expect(await Quest.countDocuments({ sessionId })).toBe(5);
+    // 5 originals + 5 copies; a move would leave the total at 5.
+    expect(await Quest.countDocuments({})).toBe(10);
+  }, 60000);
+
+  it('replaces rather than collides when overwriting an existing notebook', async () => {
+    const { sessionId, ids } = await seedNotebook('Shared Name', 5);
+    const payload = exportPayload('Shared Name', ids);
+
+    const result = await makeService().importNotebooks(
+      USER,
+      payload as never,
+      {
+        ...OPTIONS,
+        conflictResolution: 'overwrite',
+        preserveIds: true,
+      } as never
+    );
+
+    // The old rows are hard-deleted first; a soft delete would leave their ids to collide with.
+    expect(result.errors).toEqual([]);
+    expect(await Quest.countDocuments({ sessionId })).toBe(5);
+    expect(await Quest.countDocuments({})).toBe(5);
+  }, 60000);
+
+  it('imports a message whose prompt is empty, as the exporter emits', async () => {
+    const { ids } = await seedNotebook('Shared Name', 2);
+    const payload = exportPayload('Different Name', ids);
+    payload.notebooks[0].chatHistory[0].prompt = '';
+
+    const result = await makeService().importNotebooks(
+      USER,
+      payload as never,
+      {
+        ...OPTIONS,
+        conflictResolution: 'rename',
+        preserveIds: false,
+      } as never
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(await Quest.countDocuments({ prompt: '' })).toBe(1);
+  }, 60000);
+});

--- a/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
+++ b/apps/client/server/s3/notebookImportOverwrite.e2e.test.ts
@@ -91,7 +91,9 @@ function makeService() {
     sessionRepository: {
       create: async (d: unknown) => sessionRepository.create(d as never),
       find: async (q: unknown) => sessionRepository.find(q as never),
-      updateById: async (id: string, d: unknown) => Session.updateOne({ _id: id }, { $set: d }),
+      // Delegates to the real repository, as the handler does. Stubbing this with a raw
+      // Session.updateOne is what hid `update` rejecting `_id` and failing every overwrite/merge.
+      updateById: async (id: string, d: Record<string, unknown>) => sessionRepository.update({ id, ...d } as never),
     },
     // the real thing, not a copy
     chatHistoryRepository: createChatHistoryWrites(),
@@ -180,6 +182,28 @@ describe('notebook import does not overwrite existing messages', () => {
     expect(result.errors).toEqual([]);
     expect(await Quest.countDocuments({ sessionId })).toBe(5);
     expect(await Quest.countDocuments({})).toBe(5);
+  }, 60000);
+
+  it('updates the existing notebook metadata when overwriting', async () => {
+    const { sessionId, ids } = await seedNotebook('Same Name', 2);
+    const payload = exportPayload('Same Name', ids);
+    payload.notebooks[0].lastUpdated = '2027-03-04T05:06:07.000Z';
+
+    const result = await makeService().importNotebooks(
+      USER,
+      payload as never,
+      {
+        ...OPTIONS,
+        conflictResolution: 'overwrite',
+        preserveIds: true,
+      } as never
+    );
+
+    // The metadata write goes through the real repository; passing the wrong identity field made
+    // it throw and took the whole import with it.
+    expect(result.errors).toEqual([]);
+    const after = await Session.findById(sessionId);
+    expect(after?.lastUpdated?.toISOString()).toBe('2027-03-04T05:06:07.000Z');
   }, 60000);
 
   it('imports a message whose prompt is empty, as the exporter emits', async () => {

--- a/b4m-core/services/src/notebookImportService/index.test.ts
+++ b/b4m-core/services/src/notebookImportService/index.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NotebookImportService } from './index';
+import type { NotebookImportAdapters } from './index';
+
+/**
+ * Imported messages are keyed by the presence or absence of `id`. Getting it wrong either failed
+ * the import outright or rewrote the source notebook's own documents.
+ */
+const MESSAGE = {
+  id: 'original-message-id',
+  timestamp: '2026-01-01T00:00:00.000Z',
+  type: 'message',
+  status: 'done',
+  pinned: false,
+  prompt: 'hello',
+  promptMeta: { model: { name: 'claude-opus-4' }, tokenUsage: { totalTokens: 10 } },
+};
+
+const NOTEBOOK = {
+  id: 'notebook-1',
+  name: 'Notebook One',
+  firstCreated: '2026-01-01T00:00:00.000Z',
+  lastUpdated: '2026-01-02T00:00:00.000Z',
+  chatHistory: [MESSAGE],
+  knowledge: [],
+  artifacts: [],
+  tools: [],
+  agents: [],
+};
+
+const PAYLOAD = { exportVersion: '1.0.0', notebooks: [NOTEBOOK] };
+
+function makeAdapters(existingSessions: unknown[] = []) {
+  const bulkCreate = vi.fn().mockResolvedValue(undefined);
+  const adapters = {
+    sessionRepository: {
+      find: vi.fn().mockResolvedValue(existingSessions),
+      create: vi.fn(async (data: { id: string }) => ({ ...data, id: 'new-session-id' })),
+      updateById: vi.fn(),
+    },
+    chatHistoryRepository: { bulkCreate, deleteMany: vi.fn() },
+    knowledgeRepository: { create: vi.fn() },
+    artifactRepository: { create: vi.fn() },
+    toolRepository: { create: vi.fn(), find: vi.fn(), findById: vi.fn() },
+    agentRepository: { create: vi.fn() },
+    userRepository: { findById: vi.fn().mockResolvedValue({ id: 'user-1' }) },
+    fileStorageService: { uploadFile: vi.fn(), getFileContent: vi.fn(), getSignedUrl: vi.fn() },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    generateId: () => 'generated-id',
+  } as unknown as NotebookImportAdapters;
+  return { adapters, bulkCreate };
+}
+
+const OPTIONS = {
+  conflictResolution: 'rename',
+  importKnowledge: false,
+  importArtifacts: false,
+  importTools: false,
+  importAgents: false,
+} as unknown as Parameters<NotebookImportService['importNotebooks']>[2];
+
+/** Runs an import and returns the first message handed to the store. */
+async function runImport(opts: Record<string, unknown>, { existing = [] as unknown[], payload = PAYLOAD } = {}) {
+  const { adapters, bulkCreate } = makeAdapters(existing);
+  await new NotebookImportService(adapters).importNotebooks(
+    'user-1',
+    payload as never,
+    {
+      ...OPTIONS,
+      ...opts,
+    } as never
+  );
+  expect(bulkCreate).toHaveBeenCalledTimes(1);
+  return bulkCreate.mock.calls[0][0][0];
+}
+
+/** The conflict-resolution branches only run when a session already exists. */
+const EXISTING = { id: 'existing-session-id', userId: 'existing-owner' };
+
+describe('notebook import: chat history', () => {
+  it('carries no id when ids are not preserved, so the store assigns one', async () => {
+    const item = await runImport({ preserveIds: false });
+    expect('id' in item).toBe(false);
+  });
+
+  it('carries the original id only when the caller asks to preserve ids', async () => {
+    const item = await runImport({ preserveIds: true });
+    expect(item.id).toBe('original-message-id');
+  });
+
+  it('rebuilds promptMeta.session onto the notebook being imported into', async () => {
+    const item = await runImport({ preserveIds: false });
+    // The store requires this and the export does not carry it; it must describe the new
+    // notebook and the importing user, not whatever produced the file.
+    expect(item.promptMeta.session).toEqual({ id: 'new-session-id', userId: 'user-1' });
+    // metrics still survive
+    expect(item.promptMeta.model.name).toBe('claude-opus-4');
+  });
+
+  it.each(['overwrite', 'merge'])(
+    'attributes promptMeta.session to the existing notebook on the %s path',
+    async resolution => {
+      // These branches append to a notebook that already exists, so the session on each message
+      // must name that one. They were previously unreachable in this suite, which let both call
+      // sites be broken without a test failing.
+      const item = await runImport({ conflictResolution: resolution }, { existing: [EXISTING] });
+      expect(item.promptMeta.session).toEqual({ id: 'existing-session-id', userId: 'existing-owner' });
+      expect(item.sessionId).toBe('existing-session-id');
+    }
+  );
+
+  it('omits the id when preserving was asked for but the message has none', async () => {
+    const payload = {
+      exportVersion: '1.0.0',
+      notebooks: [{ ...NOTEBOOK, chatHistory: [{ ...MESSAGE, id: undefined }] }],
+    };
+    const item = await runImport({ preserveIds: true }, { payload: payload as never });
+    expect('id' in item).toBe(false);
+  });
+
+  it('leaves promptMeta absent when the message had none', async () => {
+    const payload = {
+      exportVersion: '1.0.0',
+      notebooks: [{ ...NOTEBOOK, chatHistory: [{ ...MESSAGE, promptMeta: undefined }] }],
+    };
+    const item = await runImport({ preserveIds: false }, { payload: payload as never });
+    expect(item.promptMeta).toBeUndefined();
+  });
+});

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -11,6 +11,7 @@ import {
   NotebookImportError,
   SUPPORTED_IMPORT_VERSIONS,
 } from '../notebookExportService/types';
+import type { IChatHistoryItem } from '@bike4mind/common';
 
 export interface NotebookImportAdapters {
   sessionRepository: any; // SessionRepository
@@ -171,7 +172,7 @@ export class NotebookImportService {
 
     // Import chat history
     if (notebook.chatHistory.length > 0) {
-      await this.importChatHistory(notebook.chatHistory, createdSession.id, options);
+      await this.importChatHistory(notebook.chatHistory, createdSession.id, targetUserId, options);
     }
 
     return createdSession.id;
@@ -203,7 +204,7 @@ export class NotebookImportService {
       case 'overwrite':
         // Delete existing chat history and replace
         await this.adapters.chatHistoryRepository.deleteMany({ sessionId: existingSession.id });
-        await this.importChatHistory(notebook.chatHistory, existingSession.id, options);
+        await this.importChatHistory(notebook.chatHistory, existingSession.id, existingSession.userId, options);
 
         // Update session metadata
         await this.adapters.sessionRepository.updateById(existingSession.id, {
@@ -228,7 +229,7 @@ export class NotebookImportService {
 
       case 'merge':
         // Append chat history to existing session
-        await this.importChatHistory(notebook.chatHistory, existingSession.id, options);
+        await this.importChatHistory(notebook.chatHistory, existingSession.id, existingSession.userId, options);
 
         // Update last updated time
         await this.adapters.sessionRepository.updateById(existingSession.id, {
@@ -245,10 +246,12 @@ export class NotebookImportService {
   private async importChatHistory(
     chatHistory: ExportedChatMessage[],
     sessionId: string,
+    ownerUserId: string,
     options: NotebookImportOptions
   ): Promise<void> {
-    const chatItems = chatHistory.map(message => ({
-      id: options.preserveIds ? message.id : this.adapters.generateId(),
+    const chatItems: (IChatHistoryItem & { id?: string })[] = chatHistory.map(message => ({
+      // A generated id is not a valid key for the message store; omit the field so it assigns one.
+      ...(options.preserveIds && message.id && { id: message.id }),
       sessionId,
       timestamp: new Date(message.timestamp),
       type: message.type,
@@ -258,7 +261,13 @@ export class NotebookImportService {
       questMasterReply: message.questMasterReply,
       images: message.images || [],
       fabFileIds: message.attachedFiles || [],
-      promptMeta: message.promptMeta,
+      // The store requires the owning session on promptMeta. The export carries metrics only,
+      // and an imported message belongs to the new notebook, so this is rebuilt rather than
+      // carried over.
+      promptMeta: message.promptMeta && {
+        ...message.promptMeta,
+        session: { id: sessionId, userId: ownerUserId },
+      },
       status: message.status,
       creditsUsed: message.creditsUsed,
       pinned: message.pinned,
@@ -266,7 +275,6 @@ export class NotebookImportService {
       questMasterPlanId: message.questMasterPlanId,
     }));
 
-    // Bulk create chat history items
     await this.adapters.chatHistoryRepository.bulkCreate(chatItems);
   }
 

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -15,7 +15,11 @@ import type { IChatHistoryItem } from '@bike4mind/common';
 
 export interface NotebookImportAdapters {
   sessionRepository: any; // SessionRepository
-  chatHistoryRepository: any; // ChatHistoryRepository
+  /** Typed because the caller's implementation of these two carries the insert-never-upsert rule. */
+  chatHistoryRepository: {
+    bulkCreate(items: IChatHistoryItem[]): Promise<unknown>;
+    deleteMany(filter: { sessionId: string }): Promise<unknown>;
+  };
   knowledgeRepository: any; // KnowledgeRepository
   artifactRepository: any; // ArtifactRepository
   toolRepository: any; // ToolRepository
@@ -249,7 +253,7 @@ export class NotebookImportService {
     ownerUserId: string,
     options: NotebookImportOptions
   ): Promise<void> {
-    const chatItems: (IChatHistoryItem & { id?: string })[] = chatHistory.map(message => ({
+    const chatItems: IChatHistoryItem[] = chatHistory.map(message => ({
       // A generated id is not a valid key for the message store; omit the field so it assigns one.
       ...(options.preserveIds && message.id && { id: message.id }),
       sessionId,

--- a/packages/database/src/models/auth/SessionModel.ctx.test.ts
+++ b/packages/database/src/models/auth/SessionModel.ctx.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { sessionRepository } from './SessionModel';
+
+/**
+ * `ctx` carries an explicit session into the queries that gate on it (`search`, the paged
+ * listing). It used to be declared as a setter that assigned to itself, so every write recursed
+ * until the stack blew - notebook import, its only caller, died on its first repository call with
+ * "Maximum call stack size exceeded" before reaching any of its own logic.
+ *
+ * Null rather than a real ClientSession here on purpose: the queries only attach an explicit
+ * session when `ctx` is truthy, so null is what leaves transactionAsyncLocalStorage in charge.
+ */
+describe('SessionRepository.ctx is assignable', () => {
+  it('accepts a write without recursing', () => {
+    const previous = sessionRepository.ctx;
+    try {
+      expect(() => {
+        sessionRepository.ctx = null;
+      }).not.toThrow();
+    } finally {
+      sessionRepository.ctx = previous;
+    }
+  });
+
+  it('keeps what it was given', () => {
+    const previous = sessionRepository.ctx;
+    // A stand-in for a ClientSession: the field stores whatever it is handed, and the queries
+    // only test it for truthiness.
+    const marker = { id: 'stand-in-session' } as never;
+    try {
+      sessionRepository.ctx = marker;
+      expect(sessionRepository.ctx).toBe(marker);
+    } finally {
+      sessionRepository.ctx = previous;
+    }
+  });
+
+  it('defaults to null so an unset repository does not override ambient sessions', () => {
+    // Guards the constructor initialising it: `.session(undefined)` and `.session(null)` both
+    // defeat ALS propagation, and the query gate is `if (this.ctx)`.
+    expect([null, undefined]).toContain(sessionRepository.ctx ?? null);
+  });
+});

--- a/packages/database/src/models/auth/SessionModel.ts
+++ b/packages/database/src/models/auth/SessionModel.ts
@@ -191,6 +191,8 @@ const SessionSchema = new Schema<ISession, ISessionModel, {}>(
 
 export class SessionRepository extends BaseRepository<ISessionDocument> implements ISessionRepository {
   shareable: ISessionRepository['shareable'];
+  /** Explicit session for the queries below. Null means "let transactionAsyncLocalStorage decide". */
+  ctx: mongoose.mongo.ClientSession | null;
   private questModel?: Model<unknown>;
 
   constructor(
@@ -204,10 +206,7 @@ export class SessionRepository extends BaseRepository<ISessionDocument> implemen
     this.sessionModel = sessionModel;
     this.shareable = extensions.shareable;
     this.questModel = extensions.questModel;
-  }
-
-  set ctx(ctx: mongoose.mongo.ClientSession | null) {
-    this.ctx = ctx;
+    this.ctx = null;
   }
 
   async search(

--- a/packages/database/src/models/auth/SessionModel.ts
+++ b/packages/database/src/models/auth/SessionModel.ts
@@ -191,7 +191,12 @@ const SessionSchema = new Schema<ISession, ISessionModel, {}>(
 
 export class SessionRepository extends BaseRepository<ISessionDocument> implements ISessionRepository {
   shareable: ISessionRepository['shareable'];
-  /** Explicit session for the queries below. Null means "let transactionAsyncLocalStorage decide". */
+  /**
+   * Explicit session for the queries below. Null means "let transactionAsyncLocalStorage decide",
+   * which is what callers should want: this instance is shared, so a session assigned here
+   * outlives the transaction that created it and the next reader fails with "Use of expired
+   * sessions". Nothing sets it today.
+   */
   ctx: mongoose.mongo.ClientSession | null;
   private questModel?: Model<unknown>;
 


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<!-- before / after re-importing the notebook's own export, on the shipped code -->

The same notebook before and after importing its own export: **emptied**, while the import
reported `success: true`, `messages: 10`, `errors: 0`.

## Description

Importing an export back into the database it came from destroyed the source notebook.

Chat history was written with an upsert keyed on the incoming message id. With "Preserve Original
IDs" on, those ids matched the original documents, so the write re-pointed them at the new notebook
instead of copying them - the source was emptied and the import reported success.

With ids not preserved - the dialog default - the service minted a UUID the message store cannot
use as a key, so those imports failed outright.

Chat history is now inserted rather than upserted: a colliding id fails instead of overwriting, and
no id is carried unless the caller asked to preserve one. Three things fell out of that:

- `deleteMany` was a soft delete, so the old rows kept their ids and the replacement insert
  collided with them. "Overwrite" now hard-deletes.
- Inserts validate where updates did not. The write is kept as lenient as the update it replaces,
  because the exporter emits rows an insert would reject - an assistant-first turn has no prompt.
- `promptMeta` is rebuilt onto the notebook being imported into. The store requires the owning
  session and the export carries metrics only, so the previous write stored invalid documents.

A failed notebook already aborts the surrounding transaction, so nothing persists. The handler no
longer reports that as success, and the failure notification is written from outside the
transaction - written inside it, the notification was rolled back with everything else and the user
heard nothing.

Verifying the above on a deployed worker turned up three more defects that kept import from
running at all. Each is its own commit:

- `SessionRepository.ctx` was declared as a setter that assigned to itself. Every write recursed
  until the stack blew, so import died on its first repository call with "Maximum call stack size
  exceeded" before reaching any of its own logic.
- The handler assigned the request's session onto the shared repository instance. That instance
  outlives the transaction, so the next caller to read it fails with "Use of expired sessions".
  Removed: `transactionAsyncLocalStorage` already carries the session into those queries.
- The metadata write identified the notebook by `_id`, but the repository's `update` requires `id`
  and throws without it. Overwrite and merge failed on every attempt.

## Changes

- Insert chat history instead of upserting it; carry an id only when preserving.
- Hard-delete on the overwrite path.
- Rebuild `promptMeta.session` from the target notebook and owner.
- Fail the handler when the service reports per-notebook errors; report the failure from outside
  the transaction.
- Stop `SessionRepository.ctx` recursing on assignment.
- Stop stranding a finished session on the shared repository.
- Identify the notebook to update by `id`, not `_id`.
- Extract the message writes from the handler so a test can drive the real thing.
- 5 end-to-end tests against a real database, 10 unit tests.

## Guide for Testers

Needs a notebook with a few messages. The destructive case only reproduces when an export is
imported back into the environment it came from.

1. Open a notebook. Note its messages.
2. `Profile -> Settings -> General`, `Notebooks` row, click `Export All`, then `Export Notebooks`.
3. Download the `.json`.
4. Click `Import`, choose that file, turn **on** `Preserve Original IDs`, click `Import Notebooks`.
   - Expected: the import reports a failure naming a duplicate id. It used to report success.
5. Open the notebook from step 1.
   - Expected: **all its messages are still there.** It used to be empty.
6. Import the same file again with `Preserve Original IDs` **off**.
   - Expected: succeeds, a second notebook appears with the same messages, the original is intact.

### Regression Checks

7. Import into an environment that has never seen the file, ids preserved - succeeds.
8. `Overwrite` onto a notebook of the same name - replaced, no duplicates.
9. `Merge` - imported messages appended to the existing notebook.
10. `Skip` - existing notebooks left alone, nothing written.
11. Export a notebook that was itself imported - counts match.

### What NOT to test

- Attachment import (knowledge files, artifacts, tools). Not touched by this change.
- Anything outside the export/import dialogs.

## Additional Information

Verified against a real database driving the real service:

| scenario | before | after |
|---|---|---|
| re-import own export, ids preserved | source 10 -> 0 messages, reported success | fails with a duplicate-id error, source intact |
| default import | failed outright | messages copied, source intact |
| overwrite | collided with soft-deleted rows | replaces in place |
| a notebook fails | reported success while nothing persisted | reported as failed |

Reverting the write back to the previous upsert fails three of the end-to-end tests:

```
x leaves the source notebook intact   ... expected +0 to be 1   (no error raised)
x copies messages rather than moving  ... expected 6 to be 10   (documents consumed)
x imports a message with an empty prompt ... expected +0 to be 1
```

`6 to be 10` is the sharpest: with ids not preserved the old write filtered on `{_id: undefined}`,
which matches any document, so it overwrote arbitrary rows.

Reverting the other three fixes fails their own tests the same way - the `ctx` setter reproduces
the deployed `RangeError`, and the `_id` metadata write fails with `id is required`.

All four conflict modes were then exercised end to end on a deployed preview, since none of this
reproduces locally - the import runs in an S3-triggered worker, and local test runs passed against
code that was completely broken deployed:

| conflict mode | preserve ids | result |
|---|---|---|
| skip | off | 2 skipped, nothing written, committed |
| rename | off | 2 notebooks / 4 messages copied, committed |
| rename | on | aborted on duplicate id, rolled back, user notified |
| overwrite | off | replaced in place, metadata applied, committed |
| merge | off | messages appended, metadata applied, committed |

Exporting before and after those runs shows the invariant this change exists for: both source
notebooks kept their message counts and their exact message ids, and the imported copies are
copies.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
