### PR TITLE
fix(questmaster): honor memory opt-out in v5 node runs

### DIFF
--- a/apps/client/server/questmaster/v5/runQuestNode.test.ts
+++ b/apps/client/server/questmaster/v5/runQuestNode.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IQuestGraphDocument, IQuestNodeDocument } from '@bike4mind/common';
+
 import { buildNodeQuery } from './runQuestNode';
 
 describe('buildNodeQuery', () => {
@@ -21,5 +23,105 @@ describe('buildNodeQuery', () => {
   it('omits the acceptance-criteria section when it is blank', () => {
     const query = buildNodeQuery({ title: 'T', task: 'Do it', acceptanceCriteria: '   ' });
     expect(query).not.toContain('Acceptance criteria');
+  });
+});
+
+const create = vi.fn();
+const claimForRun = vi.fn();
+const setExecution = vi.fn();
+const updateStatus = vi.fn();
+const cleanupStaleActive = vi.fn();
+const countActiveByUserId = vi.fn();
+const markFailed = vi.fn();
+const questCreate = vi.fn();
+const questUpdateOne = vi.fn();
+const questDeleteOne = vi.fn();
+const lambdaSend = vi.fn();
+
+vi.mock('@bike4mind/database', () => ({
+  agentExecutionRepository: {
+    cleanupStaleActive: (...a: unknown[]) => cleanupStaleActive(...a),
+    countActiveByUserId: (...a: unknown[]) => countActiveByUserId(...a),
+    create: (...a: unknown[]) => create(...a),
+    markFailed: (...a: unknown[]) => markFailed(...a),
+  },
+  questNodeRepository: {
+    claimForRun: (...a: unknown[]) => claimForRun(...a),
+    setExecution: (...a: unknown[]) => setExecution(...a),
+    updateStatus: (...a: unknown[]) => updateStatus(...a),
+  },
+  Quest: {
+    create: (...a: unknown[]) => questCreate(...a),
+    updateOne: (...a: unknown[]) => questUpdateOne(...a),
+    deleteOne: (...a: unknown[]) => questDeleteOne(...a),
+  },
+}));
+
+vi.mock('@aws-sdk/client-lambda', () => ({
+  LambdaClient: class {
+    send = (...a: unknown[]) => lambdaSend(...a);
+  },
+  InvokeCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+vi.mock('sst', () => ({
+  Resource: { lambdaFunctionNames: { agentExecutor: 'agent-executor-fn' } },
+}));
+
+const { runQuestNode } = await import('./runQuestNode');
+
+const logger = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+const node = (over: Partial<IQuestNodeDocument> = {}): IQuestNodeDocument =>
+  ({
+    id: 'n1',
+    graphId: 'g1',
+    dependsOn: [],
+    order: 0,
+    depth: 0,
+    kind: 'task',
+    title: 'Fetch the data',
+    task: 'Pull the last 30 days of logs.',
+    acceptanceCriteria: '',
+    status: 'pending',
+    enabledTools: [],
+    artifactIds: [],
+    ...over,
+  }) as IQuestNodeDocument;
+
+const graph = (over: Partial<IQuestGraphDocument> = {}): IQuestGraphDocument =>
+  ({ id: 'g1', sessionId: 's1', ...over }) as IQuestGraphDocument;
+
+describe('runQuestNode memory gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanupStaleActive.mockResolvedValue(undefined);
+    countActiveByUserId.mockResolvedValue(0);
+    claimForRun.mockResolvedValue(node({ status: 'in_progress' }));
+    questCreate.mockResolvedValue({ id: 'q1' });
+    create.mockResolvedValue({ id: 'exec-1' });
+    questUpdateOne.mockResolvedValue(undefined);
+    setExecution.mockResolvedValue(node({ status: 'in_progress', execution: { agentExecutionId: 'exec-1' } }));
+    lambdaSend.mockResolvedValue(undefined);
+  });
+
+  // The load-bearing assertion for #1523: a V5 node execution must be stamped
+  // enableMementos: false at creation. It is genuinely top-level (no lineage
+  // guard fires) and carries no per-request opt-out, so this explicit false is
+  // the only thing that makes resolveExecutionMementoGates short-circuit both
+  // the read and write memory pipelines for the machine-generated node query.
+  it('stamps enableMementos: false on the execution it creates', async () => {
+    await runQuestNode({ node: node(), graph: graph(), userId: 'u1', model: 'gpt-x', logger });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0]).toMatchObject({ enableMementos: false });
+  });
+
+  it('never leaves enableMementos undefined (which a V2-opted user would read as memory-on)', async () => {
+    await runQuestNode({ node: node(), graph: graph(), userId: 'u1', model: 'gpt-x', logger });
+
+    expect(create.mock.calls[0][0].enableMementos).toBe(false);
   });
 });

--- a/apps/client/server/questmaster/v5/runQuestNode.ts
+++ b/apps/client/server/questmaster/v5/runQuestNode.ts
@@ -160,6 +160,16 @@ export async function runQuestNode(args: {
       totalCreditsUsed: 0,
       lambdaInvocationCount: 1,
       childExecutionIds: [],
+      // A node query is machine-generated text, not a user turn, and a node run
+      // is a genuinely top-level execution with no upward lineage - so neither
+      // the tri-state opt-out (there is no per-request memory toggle on this
+      // dispatch path) nor the lineage guard (`parentExecutionId` /
+      // `spawnedByExecutionId`) would otherwise fire. Stamp an explicit `false`
+      // so `resolveExecutionMementoGates` short-circuits both the read
+      // (`getFirstIterationMementosPreamble`) and write (`publishMementoCompletion`)
+      // pipelines: a V5 node never reads a user's beliefs into its prompt nor
+      // writes machine-authored ones back.
+      enableMementos: false,
     });
 
     executionId = execution.id;


### PR DESCRIPTION
## Description

QuestMaster V5 node runs create a top-level `AgentExecution` in `runQuestNode.ts` that invokes the agent-executor Lambda directly. That execution carried no `enableMementos` value and no `parentExecutionId` / `spawnedByExecutionId`, so:

- the resolver saw `enableMementos: undefined`, which for a user opted into Mementos V2 resolves to `{ v1: false, v2: true }`, and
- neither lineage guard could fire, because a V5 node execution is genuinely top-level (it has no upward lineage).

Net effect: for a V2-opted user, a V5 graph read the user's beliefs into node prompts and wrote new ones back, regardless of an `enableMementos: false` opt-out. This was the last surface where the opt-out was not honoured; the earlier lineage-based fix could not cover it.

A node query is machine-generated text, not a user turn, so it should not participate in the user's memory at all. This PR stamps an explicit `enableMementos: false` on the execution at its creation site, which makes `resolveExecutionMementoGates` short-circuit to `{ v1: false, v2: false }` and gates both the read (`getFirstIterationMementosPreamble`) and write (`publishMementoCompletion`) pipelines. The executor resolves gates from the execution doc it loads by `executionId`, so stamping the field on the doc is sufficient and no Lambda-payload change is needed.

## Changes

- `apps/client/server/questmaster/v5/runQuestNode.ts`: stamp `enableMementos: false` on the `agentExecutionRepository.create(...)` call, with a comment explaining why (machine-generated query + top-level execution -> no other guard fires).
- `apps/client/server/questmaster/v5/runQuestNode.test.ts`: add mocked-dispatch tests asserting the created execution is stamped `enableMementos: false` (and is never left `undefined`).

## Guide for Testers

This is a backend-only change gated behind the `enableQuestMasterV5` admin setting (off by default). The observable behaviour is "no memory read/write on V5 node runs", which is best verified by the added unit tests plus a manual DB inspection.

Automated coverage:

1. From the repo root, run `pnpm --filter @bike4mind/client test -- runQuestNode`.
2. Expected: all `runQuestNode` tests pass, including `runQuestNode memory gating > stamps enableMementos: false on the execution it creates`.

Manual verification (requires an env with `enableQuestMasterV5` enabled and a user opted into Mementos V2 with `enableMementos: false`):

1. As that user, run a QuestMaster V5 graph so at least one node executes.
2. In the `agentexecutions` collection, find the execution created for that node run.
3. Expected: the document has `enableMementos: false`.
4. Confirm no new memento/belief document was written for that user as a result of the node run, and that the node prompt did not include a mementos preamble.

### Regression Checks

- Normal chat and agent-mode memory for V2-opted users is unchanged (the change is scoped to `runQuestNode.ts`). A V2-opted user's regular chat should still read and write mementos as before.

### What NOT to test

- No UI surface changes; there is nothing visual to check.
- No API request-shape changes; the node dispatch request (`RunNodeSchema`) still carries only `{ model }`.

## Additional Information

The "propagate the opt-out" alternative from the issue has nothing to propagate: the node dispatch request carries no per-request `enableMementos` value (unlike the WS `agent_execute` path, which forwards `cmd.enableMementos`). Stamping `false` at the creation site is the correct fix because a node query is machine-generated and should never participate in a user's memory.

Closes #1523
