### PR TITLE
fix(client): stop the reply status overlapping itself when it wraps

### DIFF
--- a/apps/client/app/components/common/ReplyStatus.test.tsx
+++ b/apps/client/app/components/common/ReplyStatus.test.tsx
@@ -127,4 +127,29 @@ describe('ReplyStatus', () => {
     // elapsed clamps to 0, and the badge only renders when elapsedSeconds > 0
     expect(screen.queryByTestId('reply-status-elapsed')).toBeNull();
   });
+
+  // jsdom does no layout, so the overlap itself cannot be measured. What it can prove is
+  // that the line box is taller than the glyphs: a line-height of '100%' (or any value
+  // equal to the font-size) leaves zero leading, which is what made wrapped status lines
+  // collide. jsdom reports a unitless line-height verbatim, so resolve each form to px.
+  const resolveLineBoxPx = (lineHeight: string, fontSizePx: number): number => {
+    if (lineHeight === 'normal') return Number.POSITIVE_INFINITY; // font metrics supply leading
+    if (lineHeight.endsWith('px')) return parseFloat(lineHeight);
+    if (lineHeight.endsWith('%')) return (parseFloat(lineHeight) / 100) * fontSizePx;
+    return parseFloat(lineHeight) * fontSizePx;
+  };
+
+  it('status text has leading, so a wrapped line cannot collide with the one above it', () => {
+    render(
+      <Wrapper>
+        <ReplyStatus status={'\u{1F310} Searching the web: "a query long enough to wrap onto a second line"'} />
+      </Wrapper>
+    );
+
+    const { lineHeight, fontSize } = window.getComputedStyle(screen.getByTestId('reply-status-text'));
+    const fontSizePx = parseFloat(fontSize);
+
+    expect(fontSizePx).toBeGreaterThan(0);
+    expect(resolveLineBoxPx(lineHeight, fontSizePx)).toBeGreaterThan(fontSizePx);
+  });
 });

--- a/apps/client/app/components/common/ReplyStatus.tsx
+++ b/apps/client/app/components/common/ReplyStatus.tsx
@@ -102,7 +102,7 @@ const ReplyStatus = ({ renderSpinnerStatusNull = false, status, createdAt, userM
             // Unitless line-height so the nested 14px elapsed badge gets a proportional
             // line box too. A percentage here resolves against this element's own
             // font-size, which meant zero leading and wrapped lines colliding.
-            sx={{ color: 'text.primary50', lineHeight: 1.4, fontSize: '16px', textAlign: 'center' }}
+            sx={{ color: 'text.primary50', lineHeight: 1.5, fontSize: '16px', textAlign: 'center' }}
             level="body-lg"
           >
             {status}

--- a/apps/client/app/components/common/ReplyStatus.tsx
+++ b/apps/client/app/components/common/ReplyStatus.tsx
@@ -98,7 +98,11 @@ const ReplyStatus = ({ renderSpinnerStatusNull = false, status, createdAt, userM
         {status && (
           <Typography
             className="reply-status-text"
-            sx={{ color: 'text.primary50', lineHeight: '100%', fontSize: '16px' }}
+            data-testid="reply-status-text"
+            // Unitless line-height so the nested 14px elapsed badge gets a proportional
+            // line box too. A percentage here resolves against this element's own
+            // font-size, which meant zero leading and wrapped lines colliding.
+            sx={{ color: 'text.primary50', lineHeight: 1.4, fontSize: '16px', textAlign: 'center' }}
             level="body-lg"
           >
             {status}


### PR DESCRIPTION
# Pull Request

Closes #1585.

## Optional Screenshot/Video

Same prompt in both. The status wraps onto two lines either way - the wrap is normal and is not
the bug. What changes is whether the two lines have any space between them.

**Before - staging (`main`, without this fix)**

<img width="3600" height="2004" alt="2026-08-10_14-09" src="https://github.com/user-attachments/assets/ead76fe6-e87a-43d4-aeac-7c4b9325c625" />


The two lines are jammed together: the descenders of `Searching` and `battery` on the first line
run into the tops of the letters on the second.

**After - this PR's preview**

<img width="3600" height="2010" alt="2026-08-10_14-19" src="https://github.com/user-attachments/assets/03d3b46f-7398-4942-a511-4af845a24a0c" />


A clear band of space between the lines, and the shorter second line is centred rather than
left-aligned.

Both runs used the same model (GPT-4.1) and the same prompt. The model composes its own search
query, so the quoted text inside the status differs slightly between the two captures - that is
the model's wording, not a behaviour change, and it does not affect what is being compared. The
captures are also from different accounts, so the sidebars differ. The status row is the only
thing under comparison here, and the fix is CSS-only. The AFTER capture was taken at the earlier
`lineHeight: 1.4` revision of this branch; the value has since been raised to `1.5`, which widens
that gap slightly and changes nothing else.

## Description

The web-search status row (`Searching the web: "<query>"`) rendered its two wrapped lines on top
of each other. What looks like a label overlapping the query is really one string colliding with
itself: the status is a single string, not two elements.

The cause is one CSS property. `ReplyStatus` set `lineHeight: '100%'` on the status `Typography`
alongside `fontSize: '16px'`. A percentage line-height resolves against the element's own
font-size, so each line box computed to exactly 16px - the same height as the glyphs it contains,
with zero leading. A single line looks fine, so the bug stays invisible until the string wraps;
then the second line's ascenders occupy the same pixels as the first line's descenders.

The fix is `lineHeight: 1.5`, unitless rather than a percentage. Unitless matters here: the
elapsed-timer badge nested inside the status (`(12s)`) renders as a Joy `Typography` at 14px with
level `inherit`, so it takes the parent's line-height. A percentage would have handed it a fixed
16px box computed from the parent; unitless re-resolves per element and gives it 21px.
`textAlign: 'center'` is added so a wrapped status reads as centred text inside the
already-centred loading area instead of going ragged-left.

**Why an explicit `1.5` rather than deleting the override?** The element already carries
`level="body-lg"`, so removing `lineHeight` entirely would fall back to Joy's own default and
would also fix the bug. An explicit value is preferred here because it cannot silently shift
when Joy is upgraded, and because the accompanying comment can then state the constraint that
caused the bug in the first place. `1.5` also satisfies the WCAG 1.4.8 (AAA) line-spacing
guidance, so the value does not become a snag if this pattern is copied to primary reading
content. The `fontSize: '16px'` override next to it is pre-existing and untouched.

**Wider than the issue states, in a good way.** `ReplyStatus` has five call sites across three
files (`SessionMiddle.tsx:541,561,609`, `SessionContainer.tsx:151`,
`ActiveAgentExecutions.tsx:136`), all inheriting the same zero-leading style, so this one
property fixes every status surface rather than only web search.

**`ToolBuilder.ts` is deliberately untouched.** The 64-char truncation in `truncateForStatus` is
working as designed and is not the cause; shortening it would only hide the wrap at wide
viewports while leaving it on narrow ones.

**Note for reviewers:** the line references in the issue body have drifted. The web-search status
string is built at `ToolBuilder.ts:184` (issue says 178) and `truncateForStatus` is at
`ToolBuilder.ts:158-161` (issue says 155-158). The `ReplyStatus.tsx` references in the issue are
still accurate.

## Changes

- `apps/client/app/components/common/ReplyStatus.tsx` - `lineHeight: '100%'` -> `lineHeight: 1.5`
  on the status `Typography`, plus `textAlign: 'center'`. Added `data-testid="reply-status-text"`
  (the element previously had only a `className`, and the repo convention is to select on
  `data-testid`). A three-line comment records why the value is unitless, since that is the part
  a future editor would otherwise "simplify" back into a percentage.
- `apps/client/app/components/common/ReplyStatus.test.tsx` - one new regression test.

Deliberately left alone:

- `b4m-core/services/src/llm/tools/ToolBuilder.ts` - see above.
- The `className="reply-status-text"` on the same element is kept; it is not ours to remove in a
  bug fix, and the new `data-testid` sits beside it.

## Tests

One test added, in the existing co-located file:

- `apps/client/app/components/common/ReplyStatus.test.tsx` - "status text has leading, so a
  wrapped line cannot collide with the one above it". jsdom performs no layout, so the overlap
  itself cannot be measured; what is asserted instead is the condition that causes it - that the
  computed line box is taller than the font size. Emotion injects real CSS in jsdom, so
  `getComputedStyle` returns the value the `sx` produced rather than a class-name string.

Two details worth flagging, because the obvious version of this test is not a real guard:

- The naive assertion `parseFloat(lineHeight) * fontSize > fontSize` **passes under the bug** -
  `'100%'` parses to `100`, and `100 * 16 = 1600`. The test therefore resolves each line-height
  form explicitly (`px`, `%`, unitless, `normal`) before comparing.
- **Mutation-verified.** Reverting the property to `lineHeight: '100%'` fails exactly one test,
  with `AssertionError: expected 16 to be greater than 16` - i.e. it fails on the zero-leading
  condition itself, not incidentally.

Suite: 6/6 (was 5). `pnpm turbo:typecheck` 40/40. `pnpm lint:check` clean.

## Guide for Testers

All steps run on the PR preview. The status row is only on screen while a reply is being
generated and disappears when it completes, so start a screen recording first or simply re-send
the prompt and watch again - it reproduces every time.

### The fix

1. Open the preview link and sign in.
2. Zoom the page to about 200% (press `Cmd +` four times), or narrow the window to roughly 700px.
   Either forces the status to wrap, which is when the bug was visible.
3. Turn Web Search on: **AI Settings** -> **Tools** (click the section header to expand the
   catalog if it is collapsed) -> switch **Web Search** ON.
4. Send: `Search the web for the current state of solid state battery manufacturing and who is shipping`
5. Watch the grey status text while the search runs. It reads `Searching the web: "<query>"` and
   wraps onto two lines. Depending on window width the spinner sits either beside the text or
   centred just above it; both are normal.
   - **PASS:** a clear band of space between the two lines, both fully legible, and the shorter
     second line centred.
   - **FAIL:** the two lines touch or overlap, with descenders running into the line below.

### Regression Checks

6. Return to full desktop width with no zoom and send another web-search prompt.
   - Expected: the status renders on a single line as it always has. No new wrapping was
     introduced at desktop width.
7. Send an ordinary prompt with no tool call and watch the `Running...` status.
   - Expected: unchanged - single line, centred.

### What NOT to test

- **The elapsed timer badge past 30s, and the agent-execution rotating copy.** Both were
  considered and deliberately left out. Past 30s the only thing that changes is the badge's
  colour, which line-height has no bearing on, and its layout inside the shared line box is
  already exercised by any shorter run. The agent surface wraps `ReplyStatus` in a
  `width: '100%'` centred column (`ActiveAgentExecutions.tsx:127-134`), the same wrapper shape as
  the main chat, so it cannot wrap differently from step 6.
- No API, route, schema, setting, or flag changed. This PR is one CSS property, a `data-testid`,
  and a test.
- The 64-character truncation of the query is unchanged and out of scope; a query cut off with an
  ellipsis is correct existing behaviour, not a bug in this PR.

## Additional Information

**Verified on the preview against the live DOM.** Sampling `.reply-status-text` across a full
turn returned 14 distinct status states, and every one of them carried the fixed line-height
against `fontSize: 16px`, with `textAlign: center` and `maxWidth: none`. The wrapped web-search
status rendered as two separated visual lines rather than colliding ones. The states sampled
included non-tool statuses (`Generating...`, `Generating insights...`, `Web search complete`), so
the fix demonstrably applies to statuses other than the web-search string, all of which render
through this same element.

That sampling was run against the preview at the earlier revision of this branch, which used
`lineHeight: 1.4` and measured `22.4px` with the two wrapped lines 22px apart. The value has
since been raised to `1.5` for the WCAG point above, which makes the computed box `24px` by
arithmetic; the structural findings (fix live on every status, centred, no `maxWidth`) are
unaffected by that change.

**No new wrapping at desktop width.** Measuring the status text's natural single-line width in
the real font: 670px for the observed string, and 746px for the worst case (a full 64-char query
plus a `(1m 5s)` badge). Both sit under the 950px chat-column cap from `SessionMiddle.tsx:520`,
so the status stays on one line at desktop width.

**One issue found in my own diff during self-review, and removed.** An earlier revision also set
`maxWidth: '32rem'` on the status as a readability tidy-up. `32rem` is 512px, and the worst-case
status measures 746px, so it would have forced the exact status this issue is about onto two
lines where it fits on one today - a visible change nobody asked for, riding along inside a bug
fix. The cap was dropped; only the leading fix and the centring remain.

## Developer Notes (Optional)

- **Architecture decision:** unitless line-height over a percentage or a fixed px value, so
  nested `Typography` elements at other font sizes inherit a proportional line box instead of the
  parent's computed one. Worth copying wherever a `Typography` wraps another.
- **Reusable pattern:** the test shows that jsdom plus Emotion does surface `sx`-derived values
  through `getComputedStyle`, so a style regression can be guarded directly rather than by
  asserting on a generated class name. The `Could not parse CSS stylesheet` lines jsdom prints
  during these runs are pre-existing noise, not failures.
- **Data model changes:** none.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no settings added
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - this PR is the UI polish
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, no docs affected
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A

