### PR TITLE
feat(client): let external callers request composer focus without a session switch

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -120,8 +120,8 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
   const [, setAgentBenchCollapsed] = useState<boolean>(false);
   const [filesDropdownOpen, setFilesDropdownOpen] = useState<boolean>(false);
 
-  const [chatInputValue, setChatInputValue, setDraft, getDraft, clearDraft] = useChatInput(
-    useShallow(s => [s.chatInputValue, s.setChatInputValue, s.setDraft, s.getDraft, s.clearDraft])
+  const [chatInputValue, setChatInputValue, setDraft, getDraft, clearDraft, focusRequestId] = useChatInput(
+    useShallow(s => [s.chatInputValue, s.setChatInputValue, s.setDraft, s.getDraft, s.clearDraft, s.focusRequestId])
   );
   const [rephraseGlow, setRephraseGlow] = useState(false);
   const [showSlashSuggestions, setShowSlashSuggestions] = useState(false);
@@ -338,8 +338,9 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
     }
   };
 
-  // Auto-focus the chat input when component mounts or session changes
-  useAutoFocus(lexicalInputRef as any, { enabled: true });
+  // Auto-focus the chat input when component mounts or session changes, or when an
+  // external prefill requests focus without a session change.
+  useAutoFocus(lexicalInputRef as any, { enabled: true, focusTrigger: focusRequestId });
 
   // Persists draft per session and restores it on session switch
   useMessageDraft(currentSessionId, setChatInputValue, setDraft, getDraft, clearDraft);

--- a/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
+++ b/apps/client/app/components/Session/SessionBottom/SessionBottom.tsx
@@ -338,8 +338,10 @@ const SessionBottom = forwardRef<HTMLDivElement, Props>(({ enableFileAttachments
     }
   };
 
-  // Auto-focus the chat input when component mounts or session changes, or when an
-  // external prefill requests focus without a session change.
+  // Auto-focus the chat input on mount, and again whenever an external prefill (via
+  // useChatInput.requestFocus()) asks for focus without a session change. SessionBottom
+  // itself is never remounted on a session switch, so a session-change refocus is not
+  // this hook's doing -- if one is observed, it comes from elsewhere.
   useAutoFocus(lexicalInputRef as any, { enabled: true, focusTrigger: focusRequestId });
 
   // Persists draft per session and restores it on session switch

--- a/apps/client/app/hooks/useAutoFocus.focusTrigger.test.ts
+++ b/apps/client/app/hooks/useAutoFocus.focusTrigger.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createRef } from 'react';
+import { useAutoFocus } from './useAutoFocus';
+
+describe('useAutoFocus - focusTrigger', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('refocuses when focusTrigger changes without the ref/enabled changing (e.g. a prefill with no session switch)', () => {
+    const el = document.createElement('input');
+    document.body.appendChild(el);
+    const ref = createRef<HTMLInputElement>();
+    (ref as { current: HTMLInputElement }).current = el;
+    const focusSpy = vi.spyOn(el, 'focus');
+
+    const { rerender } = renderHook(({ trigger }) => useAutoFocus(ref, { enabled: true, focusTrigger: trigger }), {
+      initialProps: { trigger: 0 },
+    });
+    vi.runAllTimers();
+    expect(focusSpy).toHaveBeenCalledTimes(2); // immediate + the 100ms fallback
+
+    focusSpy.mockClear();
+    rerender({ trigger: 1 });
+    vi.runAllTimers();
+    expect(focusSpy).toHaveBeenCalledTimes(2);
+
+    el.remove();
+  });
+
+  it('does not refocus on an unrelated re-render when focusTrigger is unchanged', () => {
+    const el = document.createElement('input');
+    document.body.appendChild(el);
+    const ref = createRef<HTMLInputElement>();
+    (ref as { current: HTMLInputElement }).current = el;
+    const focusSpy = vi.spyOn(el, 'focus');
+
+    const { rerender } = renderHook(({ trigger }) => useAutoFocus(ref, { enabled: true, focusTrigger: trigger }), {
+      initialProps: { trigger: 0 },
+    });
+    vi.runAllTimers();
+    focusSpy.mockClear();
+
+    rerender({ trigger: 0 });
+    vi.runAllTimers();
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    el.remove();
+  });
+});

--- a/apps/client/app/hooks/useAutoFocus.focusTrigger.test.ts
+++ b/apps/client/app/hooks/useAutoFocus.focusTrigger.test.ts
@@ -52,4 +52,24 @@ describe('useAutoFocus - focusTrigger', () => {
 
     el.remove();
   });
+
+  it('does not focus on a focusTrigger bump while disabled', () => {
+    const el = document.createElement('input');
+    document.body.appendChild(el);
+    const ref = createRef<HTMLInputElement>();
+    (ref as { current: HTMLInputElement }).current = el;
+    const focusSpy = vi.spyOn(el, 'focus');
+
+    const { rerender } = renderHook(({ trigger }) => useAutoFocus(ref, { enabled: false, focusTrigger: trigger }), {
+      initialProps: { trigger: 0 },
+    });
+    vi.runAllTimers();
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    rerender({ trigger: 1 });
+    vi.runAllTimers();
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    el.remove();
+  });
 });

--- a/apps/client/app/hooks/useAutoFocus.ts
+++ b/apps/client/app/hooks/useAutoFocus.ts
@@ -8,15 +8,18 @@ import { useEffect, RefObject } from 'react';
  * @param options - Optional configuration
  * @param options.enabled - Whether auto-focus is enabled (default: true)
  * @param options.focusOnClick - Whether to refocus when clicking outside the element (default: false)
+ * @param options.focusTrigger - Refocus whenever this value changes, in addition to on mount
+ *   (e.g. a store counter bumped by an external "prefill and focus" action).
  */
 export function useAutoFocus<T extends HTMLElement>(
   ref: RefObject<T>,
   options?: {
     enabled?: boolean;
     focusOnClick?: boolean;
+    focusTrigger?: unknown;
   }
 ) {
-  const { enabled = true, focusOnClick = false } = options || {};
+  const { enabled = true, focusOnClick = false, focusTrigger } = options || {};
 
   useEffect(() => {
     if (!enabled) return;
@@ -38,7 +41,7 @@ export function useAutoFocus<T extends HTMLElement>(
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [ref, enabled]);
+  }, [ref, enabled, focusTrigger]);
 
   // Optionally refocus when clicking outside the element
   useEffect(() => {

--- a/apps/client/app/hooks/useAutoFocus.ts
+++ b/apps/client/app/hooks/useAutoFocus.ts
@@ -9,14 +9,16 @@ import { useEffect, RefObject } from 'react';
  * @param options.enabled - Whether auto-focus is enabled (default: true)
  * @param options.focusOnClick - Whether to refocus when clicking outside the element (default: false)
  * @param options.focusTrigger - Refocus whenever this value changes, in addition to on mount
- *   (e.g. a store counter bumped by an external "prefill and focus" action).
+ *   (e.g. a store counter bumped by an external "prefill and focus" action). Must be a
+ *   primitive (number/string) compared by value across renders -- an inline object/array/
+ *   function literal has a new identity every render and would refocus on every render.
  */
 export function useAutoFocus<T extends HTMLElement>(
   ref: RefObject<T>,
   options?: {
     enabled?: boolean;
     focusOnClick?: boolean;
-    focusTrigger?: unknown;
+    focusTrigger?: string | number;
   }
 ) {
   const { enabled = true, focusOnClick = false, focusTrigger } = options || {};

--- a/apps/client/app/hooks/useChatInput.focusRequest.test.ts
+++ b/apps/client/app/hooks/useChatInput.focusRequest.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useChatInput } from './useChatInput';
+
+describe('useChatInput - requestFocus', () => {
+  beforeEach(() => {
+    useChatInput.setState({ focusRequestId: 0 });
+  });
+
+  it('bumps focusRequestId on each call so consumers watching it as a dep see a change', () => {
+    expect(useChatInput.getState().focusRequestId).toBe(0);
+    useChatInput.getState().requestFocus();
+    expect(useChatInput.getState().focusRequestId).toBe(1);
+    useChatInput.getState().requestFocus();
+    expect(useChatInput.getState().focusRequestId).toBe(2);
+  });
+});

--- a/apps/client/app/hooks/useChatInput.ts
+++ b/apps/client/app/hooks/useChatInput.ts
@@ -43,6 +43,13 @@ interface ChatInputStore {
   briefcaseLaunchInFlight: boolean;
   setBriefcaseLaunchInFlight: (inFlight: boolean) => void;
 
+  // Bumped to ask the mounted composer to focus itself (e.g. after a prefill
+  // that doesn't change session/mount, so useAutoFocus's mount effect won't
+  // refire on its own). A counter rather than a boolean so two requests in a
+  // row are both observable as distinct changes.
+  focusRequestId: number;
+  requestFocus: () => void;
+
   // Actions
   resetHistoryNavigation: () => void;
 }
@@ -94,6 +101,10 @@ export const useChatInput = create<ChatInputStore>()(
       // Briefcase single-flight (shared across launcher instances)
       briefcaseLaunchInFlight: false,
       setBriefcaseLaunchInFlight: inFlight => set({ briefcaseLaunchInFlight: inFlight }),
+
+      // Composer focus request
+      focusRequestId: 0,
+      requestFocus: () => set(state => ({ focusRequestId: state.focusRequestId + 1 })),
 
       // Reset history navigation (called when user types)
       resetHistoryNavigation: () => {


### PR DESCRIPTION
## Description

Adds a way to prefill the chat composer's value and separately request that it grab focus, without needing a session change.

`useAutoFocus` currently only refocuses the composer on mount or session switch. `useChatInput.setChatInputValue()` already lets a caller set the composer's text programmatically, but there was no way for that same caller to also pull focus to it when neither the ref nor the session changes -- the text would land in the box, but the user would have to click in manually to start editing.

## Changes

- `useChatInput`: adds `focusRequestId` (a counter) and `requestFocus()` to bump it.
- `useAutoFocus`: adds an optional `focusTrigger` param -- when it changes, the hook re-fires focus in addition to its existing mount/enabled triggers. Backward compatible: no existing caller passes it, so behavior is unchanged for all current usages.
- `SessionBottom`: wires the composer's `focusRequestId` into `useAutoFocus`'s new `focusTrigger`.

## Guide for Testers

This PR is additive infrastructure with no consumer in this repo yet, so there's no new UI flow to click through.

1. Go to `pr<N>.preview.bike4mind.com` (URL posted by the deploy bot once a maintainer triggers the preview) and open any chat session.
2. Confirm the composer still auto-focuses on load and on switching sessions, same as before.
3. Confirm no other behavior changed anywhere in the chat composer.

### What NOT to test

No new UI, admin setting, or user-facing flow was added -- this is a capability addition consumed elsewhere, not a behavior change in this repo.

## Developer Notes (Optional)

- **New Extension Points**: `useAutoFocus(ref, { focusTrigger })` -- any external value bumped on write lets a caller request focus on an already-mounted input without remounting it or changing its ref.
- **Reusable Patterns**: `useChatInput.requestFocus()` / `focusRequestId` is a ready-made focus-request trigger for the chat composer specifically; other composer-adjacent features can call it directly.

## Checklist

- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) -- N/A, no UI change in this repo
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings