### PR TITLE
fix(security): encrypt sensitive admin settings and provider keys at rest

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -12,8 +12,10 @@ APP_STAGE=selfhost
 
 # -- Core (required to boot) --
 # Generate each secret with: openssl rand -hex 32
-# Never change SECRET_ENCRYPTION_KEY after first boot - it encrypts secrets
-# stored in the database and cannot be rotated in place.
+# SECRET_ENCRYPTION_KEY encrypts secrets stored in the database. Rotation is not
+# automated for self-host: if you ever change it, set SECRET_ENCRYPTION_KEY_PREVIOUS
+# (below) to the old key and keep it set so existing ciphertext still decrypts.
+# Until a valid 64-hex key is set, sensitive settings are stored in plaintext.
 MONGODB_URI=mongodb://mongo:27017/bike4mind?replicaSet=rs0
 JWT_SECRET=change-me-openssl-rand-hex-32
 SESSION_SECRET=change-me-openssl-rand-hex-32

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -43,7 +43,7 @@ openssl rand -hex 32   # -> SESSION_SECRET
 openssl rand -hex 32   # -> SECRET_ENCRYPTION_KEY
 ```
 
-> **Never change `SECRET_ENCRYPTION_KEY` after first boot.** It encrypts other secrets stored in the database - rotating it makes existing encrypted data unreadable.
+> **Do not rotate `SECRET_ENCRYPTION_KEY` casually.** It encrypts other secrets stored in the database, and rotation is not automated for self-host. If you must change it, set `SECRET_ENCRYPTION_KEY_PREVIOUS` to the old key and leave it set permanently: reads fall back to the previous key, so old ciphertext (admin settings, per-user API keys, OAuth tokens, social connections) stays readable. Dropping the previous key makes anything still encrypted under it unrecoverable.
 
 > **Formatting:** compose reads `.env.selfhost` values verbatim - don't add comments on the same line as a value.
 
@@ -598,7 +598,7 @@ Whichever path you choose, do the checklist first.
 
 - [ ] **Use a real SMTP provider.** Mailpit is local-only, so remote friends cannot read their sign-in codes from it. Point `MAIL_*` at a real provider (port 587 STARTTLS or 465 implicit TLS).
 - [ ] **Keep sign-up invite-only and cap per-user usage.** Registration is invite-only by default (`allowOpenRegistration` is OFF; the first account created becomes admin). Leave it off and invite friends explicitly from the admin settings. Self-host also defaults credit enforcement OFF - as admin, turn on **Enforce Credits** and give each friend a finite credit budget so a runaway (or a shared key) cannot burn your LLM spend. Per-key API rate limits default to 60/min and 1000/day.
-- [ ] **Back up `SECRET_ENCRYPTION_KEY`.** It is write-once (it encrypts other secrets in the database) and cannot be rotated in place - losing it makes that data unrecoverable.
+- [ ] **Back up `SECRET_ENCRYPTION_KEY`.** It encrypts other secrets in the database and losing it makes that data unrecoverable. Rotation is not automated for self-host: if you ever change it, set `SECRET_ENCRYPTION_KEY_PREVIOUS` to the old key and keep it configured permanently so existing ciphertext still decrypts.
 
 ### Path A: Tailscale tailnet (recommended for friends)
 

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -1,4 +1,9 @@
-import { IAdminSettings, IUserPreferences, redactSettingSecrets, type AdminSettingDoc } from '@bike4mind/common';
+import {
+  IAdminSettings,
+  IUserPreferences,
+  redactSettingSecretsForBroadcast,
+  type AdminSettingDoc,
+} from '@bike4mind/common';
 import { useShallow } from 'zustand/react/shallow';
 import { useQueryClient } from '@tanstack/react-query';
 import React, {
@@ -318,10 +323,11 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
       // A sensitive value arrives over the wire encrypted (or, pre-migration, plaintext) -
       // the fanout serializes the raw stored document. Mask it before it lands in the shared
       // ['adminsettings'] cache so a live cross-admin update never surfaces ciphertext or a
-      // raw secret in the admin field. The authoritative mask (with the real last-4) still
-      // comes from /api/settings/fetch; the browser cannot decrypt, so a mask derived here
-      // carries the ciphertext tail, which is why fetch remains the source of truth.
-      const safe = redactSettingSecrets(data as unknown as AdminSettingDoc) as unknown as IAdminSettings;
+      // raw secret in the admin field. The broadcast redactor emits a bare mask with no
+      // trailing characters (the browser cannot decrypt, so a last-4 derived here would be
+      // the ciphertext tail - a wrong value an admin could mis-verify). /api/settings/fetch
+      // remains the source of truth for the real last-4.
+      const safe = redactSettingSecretsForBroadcast(data as unknown as AdminSettingDoc) as unknown as IAdminSettings;
       updateAllQueryData(queryClient, 'adminsettings', operation, safe);
     },
     [queryClient]

--- a/apps/client/app/contexts/UserSettingsContext.tsx
+++ b/apps/client/app/contexts/UserSettingsContext.tsx
@@ -1,4 +1,4 @@
-import { IAdminSettings, IUserPreferences } from '@bike4mind/common';
+import { IAdminSettings, IUserPreferences, redactSettingSecrets, type AdminSettingDoc } from '@bike4mind/common';
 import { useShallow } from 'zustand/react/shallow';
 import { useQueryClient } from '@tanstack/react-query';
 import React, {
@@ -315,7 +315,14 @@ export const UserSettingsProvider: React.FC<PropsWithChildren<{}>> = ({ children
   const adminSettingsCallback = useCallback(
     (type: string, data: IAdminSettings) => {
       const operation = type === 'delete' ? type : 'write';
-      updateAllQueryData(queryClient, 'adminsettings', operation, data);
+      // A sensitive value arrives over the wire encrypted (or, pre-migration, plaintext) -
+      // the fanout serializes the raw stored document. Mask it before it lands in the shared
+      // ['adminsettings'] cache so a live cross-admin update never surfaces ciphertext or a
+      // raw secret in the admin field. The authoritative mask (with the real last-4) still
+      // comes from /api/settings/fetch; the browser cannot decrypt, so a mask derived here
+      // carries the ciphertext tail, which is why fetch remains the source of truth.
+      const safe = redactSettingSecrets(data as unknown as AdminSettingDoc) as unknown as IAdminSettings;
+      updateAllQueryData(queryClient, 'adminsettings', operation, safe);
     },
     [queryClient]
   );

--- a/apps/client/pages/api/api-keys/[id]/delete.ts
+++ b/apps/client/pages/api/api-keys/[id]/delete.ts
@@ -24,7 +24,13 @@ const handler = baseApi().delete(
 
     await logEvent({ userId, type: ApiKeyEvents.DELETE_API_KEY, metadata: { id } }, { ability: req.ability });
 
-    return res.status(200).json(deletedApiKey);
+    // Never echo the stored key (ciphertext at rest) back to the browser; the client only
+    // needs the record's id/metadata to drop it from its cache. Mirrors set-active.
+    const record = (deletedApiKey as unknown as { toObject?: () => Record<string, unknown> }).toObject?.() ?? {
+      ...(deletedApiKey as unknown as Record<string, unknown>),
+    };
+    delete record.apiKey;
+    return res.status(200).json(record);
   })
 );
 

--- a/apps/client/pages/api/api-keys/[id]/set-active.ts
+++ b/apps/client/pages/api/api-keys/[id]/set-active.ts
@@ -25,7 +25,14 @@ const handler = baseApi().post(
 
     await logEvent({ userId, type: ApiKeyEvents.SET_API_KEY, metadata: { id } }, { ability: req.ability });
 
-    return res.json(updatedApiKey);
+    // setApiKey returns the stored document, whose apiKey is ciphertext at rest. Never echo the
+    // key field back (matching the create/update write responses); the client only needs the
+    // record's metadata and just invalidates its query on success.
+    const record = (updatedApiKey as unknown as { toObject?: () => Record<string, unknown> }).toObject?.() ?? {
+      ...(updatedApiKey as unknown as Record<string, unknown>),
+    };
+    delete record.apiKey;
+    return res.json(record);
   })
 );
 

--- a/apps/client/pages/api/api-keys/__tests__/create.crossType.e2e.test.ts
+++ b/apps/client/pages/api/api-keys/__tests__/create.crossType.e2e.test.ts
@@ -6,6 +6,7 @@ import type { MongoMemoryServer } from 'mongodb-memory-server';
 import { createMongoServer } from '../../../../../../packages/database/src/__test__/createMongoServer';
 import { apiKeyRepository } from '@bike4mind/database';
 import { ApiKeyType } from '@bike4mind/common';
+import { configureSecretsAtRest, generateEncryptionKey } from '@bike4mind/utils/security';
 
 /**
  * Agreement test for BYOK key creation, driving the REAL service, repository and
@@ -41,6 +42,10 @@ let mongoServer: MongoMemoryServer;
 beforeAll(async () => {
   mongoServer = await createMongoServer();
   await mongoose.connect(mongoServer.getUri());
+  // This test connects via mongoose directly, not the package connectDB, so the at-rest key
+  // seam never fires. Register a key so provider-key creation (now fail-closed without one)
+  // stores ciphertext; findAllByUserId decrypts it back, so the plaintext assertions hold.
+  configureSecretsAtRest(generateEncryptionKey());
 }, 30000);
 afterAll(async () => {
   await mongoose.disconnect();

--- a/apps/client/pages/api/infer.ts
+++ b/apps/client/pages/api/infer.ts
@@ -2,12 +2,14 @@ import { Request, Response } from 'express';
 import { ApiKeyType, IMessage } from '@bike4mind/common';
 import { getAvailableModels, getLlmByModel } from '@bike4mind/llm-adapters';
 import { baseApi } from '@server/middlewares/baseApi';
-import { AdminSettings, apiKeyRepository, adminSettingsRepository } from '@bike4mind/database';
+import { apiKeyRepository, adminSettingsRepository } from '@bike4mind/database';
 import { apiKeyService } from '@bike4mind/services';
 
 const handler = baseApi().post(async (req: Request, res: Response) => {
   const { model, prompt, stream } = req.body as Record<string, string>;
-  const settings = await AdminSettings.find({ settingName: { $in: ['EnableOllama', 'ollamaBackend'] } });
+  // ollamaBackend is isSensitive (encrypted at rest); read through the repository so it is
+  // decrypted before it becomes the ollama entry of apiKeyTable, matching getEffective*.
+  const settings = await adminSettingsRepository.findBySettingNames(['EnableOllama', 'ollamaBackend']);
   const dbAdapters = { db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository } };
   const userIdForService = req.user?.id || 'system';
   const apiKeyTable = {

--- a/apps/client/pages/api/ollama/models.ts
+++ b/apps/client/pages/api/ollama/models.ts
@@ -1,11 +1,13 @@
 import { Request, Response } from 'express';
 import { baseApi } from '@server/middlewares/baseApi';
 import { OllamaBackend } from '@bike4mind/llm-adapters';
-import { AdminSettings } from '@bike4mind/database';
+import { adminSettingsRepository } from '@bike4mind/database';
 
 const handler = baseApi({ auth: false }).get(async (req: Request, res: Response) => {
   try {
-    const ollamaSettings = await AdminSettings.find({ settingName: { $in: ['EnableOllama', 'ollamaBackend'] } });
+    // ollamaBackend is isSensitive (stored encrypted at rest); read through the repository so
+    // it is decrypted, not the raw model which would hand OllamaBackend the ciphertext.
+    const ollamaSettings = await adminSettingsRepository.findBySettingNames(['EnableOllama', 'ollamaBackend']);
     const ollamaBackend = ollamaSettings.find(setting => setting.settingName === 'ollamaBackend')?.settingValue;
     const enableOllama =
       !!ollamaBackend &&

--- a/apps/client/pages/api/settings/__tests__/fetch.test.ts
+++ b/apps/client/pages/api/settings/__tests__/fetch.test.ts
@@ -7,6 +7,11 @@ let stored: Array<Record<string, unknown>> = [];
 vi.mock('@bike4mind/database/infra', () => ({
   AdminSettings: { find: () => ({ lean: () => Promise.resolve(stored) }) },
 }));
+// `enc:` marks ciphertext so a test can prove the mask is derived from decrypted plaintext.
+// A non-`enc:` value passes through, matching decryptAtRest's plaintext-coexistence contract.
+vi.mock('@bike4mind/utils', () => ({
+  decryptAtRest: (v: unknown) => (typeof v === 'string' && v.startsWith('enc:') ? v.slice(4) : v),
+}));
 vi.mock('@server/middlewares/baseApi', () => ({
   baseApi: () => ({ get: (handler: (...a: unknown[]) => unknown) => handler }),
 }));
@@ -68,6 +73,15 @@ describe('settings/fetch sensitive value redaction', () => {
       expect(entry?.settingValue).toBe(`${SENSITIVE_SETTING_MASK}tail`);
       expect(serialized).not.toContain(`sk-live-${key}-tail`);
     }
+  });
+
+  it('masks the decrypted plaintext, so the mask carries the real last-4 not the ciphertext tail', async () => {
+    // Stored as ciphertext ending in a hash tail; decrypted plaintext ends in "real".
+    stored = [{ settingName: 'anthropicDemoKey', settingValue: 'enc:sk-ant-api03-real' }];
+    const result = await runHandler();
+    const entry = result.find(s => s.settingName === 'anthropicDemoKey');
+    expect(entry?.settingValue).toBe(`${SENSITIVE_SETTING_MASK}real`);
+    expect(JSON.stringify(result)).not.toContain('sk-ant-api03-real');
   });
 
   it('still returns non-sensitive values in full', async () => {

--- a/apps/client/pages/api/settings/__tests__/fetch.test.ts
+++ b/apps/client/pages/api/settings/__tests__/fetch.test.ts
@@ -9,7 +9,7 @@ vi.mock('@bike4mind/database/infra', () => ({
 }));
 // `enc:` marks ciphertext so a test can prove the mask is derived from decrypted plaintext.
 // A non-`enc:` value passes through, matching decryptAtRest's plaintext-coexistence contract.
-vi.mock('@bike4mind/utils', () => ({
+vi.mock('@bike4mind/utils/security', () => ({
   decryptAtRest: (v: unknown) => (typeof v === 'string' && v.startsWith('enc:') ? v.slice(4) : v),
 }));
 vi.mock('@server/middlewares/baseApi', () => ({

--- a/apps/client/pages/api/settings/__tests__/index.test.ts
+++ b/apps/client/pages/api/settings/__tests__/index.test.ts
@@ -14,15 +14,22 @@ vi.mock('@server/middlewares/baseApi', () => ({
 }));
 
 // AdminSettings: the full settings collection. It MUST NOT be queried on a denied call,
-// since its rows include unredacted provider API keys.
-const mockFind = vi.fn();
+// since its rows include (encrypted) provider API keys.
+const mockLean = vi.fn();
+const mockFind = vi.fn(() => ({ lean: mockLean }));
 vi.mock('@bike4mind/database/infra', () => ({
   AdminSettings: {
     find: (...args: unknown[]) => mockFind(...args),
   },
 }));
+// Sensitive values are stored encrypted; decryptAtRest passes the plaintext test fixtures
+// through unchanged (they are not in ciphertext format).
+vi.mock('@bike4mind/utils/security', () => ({
+  decryptAtRest: (v: unknown) => v,
+}));
 
 import handler from '../index';
+import { SENSITIVE_SETTING_MASK } from '@bike4mind/common';
 
 type HandlerFn = (req: unknown, res: unknown) => Promise<unknown>;
 
@@ -41,10 +48,10 @@ const SECRET_ROWS = [
   { settingName: 'EnableArtifacts', settingValue: true },
 ];
 
-describe('GET /api/settings (admin-only, full unredacted collection)', () => {
+describe('GET /api/settings (admin-only, sensitive values masked)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFind.mockResolvedValue(SECRET_ROWS);
+    mockLean.mockResolvedValue(SECRET_ROWS);
   });
 
   it('rejects a non-admin with 403 and never queries the settings collection', async () => {
@@ -64,13 +71,21 @@ describe('GET /api/settings (admin-only, full unredacted collection)', () => {
     expect(mockFind).not.toHaveBeenCalled();
   });
 
-  it('returns the full settings collection to an admin', async () => {
+  it('returns the collection to an admin with sensitive values masked, non-sensitive in full', async () => {
     const { req, res } = makeReq({ isAdmin: true });
 
     await (handler as HandlerFn)(req, res);
 
     expect(mockFind).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
-    expect(res._getJSONData()).toEqual(SECRET_ROWS);
+
+    const body = res._getJSONData() as Array<{ settingName: string; settingValue: unknown }>;
+    const secret = body.find(s => s.settingName === 'openaiDemoKey');
+    expect(secret?.settingValue).toBe(`${SENSITIVE_SETTING_MASK}leak`);
+    // The stored secret must never leave the server, even to an admin, through this route.
+    expect(JSON.stringify(body)).not.toContain('sk-live-should-never-leak');
+
+    const nonSensitive = body.find(s => s.settingName === 'EnableArtifacts');
+    expect(nonSensitive?.settingValue).toBe(true);
   });
 });

--- a/apps/client/pages/api/settings/__tests__/update.test.ts
+++ b/apps/client/pages/api/settings/__tests__/update.test.ts
@@ -12,7 +12,17 @@ vi.mock('@bike4mind/database/infra', () => ({
     findOneAndUpdate: (...args: unknown[]) => findOneAndUpdate(...args),
   },
 }));
-vi.mock('@bike4mind/utils', () => ({ invalidateSettingsCache: vi.fn() }));
+// Deterministic stand-ins for the shared crypto. `enc:` marks ciphertext so the tests can
+// assert a value was encrypted at rest without depending on real AES output. update.ts pulls
+// encryptSecret/isEncrypted/isValidEncryptionKey through @server/security/secretEncryption,
+// which re-exports from @bike4mind/utils, so mocking utils covers those too.
+vi.mock('@bike4mind/utils', () => ({
+  invalidateSettingsCache: vi.fn(),
+  decryptAtRest: (v: unknown) => (typeof v === 'string' && v.startsWith('enc:') ? v.slice(4) : v),
+  encryptSecret: (v: string) => `enc:${v}`,
+  isEncrypted: (v: unknown) => typeof v === 'string' && v.startsWith('enc:'),
+  isValidEncryptionKey: (k: unknown) => typeof k === 'string' && k.length === 64,
+}));
 vi.mock('@server/middlewares/baseApi', () => ({
   baseApi: () => ({ put: (handler: (...a: unknown[]) => unknown) => handler }),
 }));
@@ -55,15 +65,18 @@ describe('settings/update sensitive value handling', () => {
     vi.clearAllMocks();
   });
 
-  it('writes a newly submitted secret through', async () => {
-    stageWriteResult('anthropicDemoKey', 'sk-ant-api03-brandnew');
+  it('encrypts a newly submitted secret at rest, never storing the plaintext', async () => {
+    stageWriteResult('anthropicDemoKey', 'enc:sk-ant-api03-brandnew');
     await runHandler('anthropicDemoKey', 'sk-ant-api03-brandnew');
 
     expect(findOneAndUpdate).toHaveBeenCalledWith(
       { settingName: 'anthropicDemoKey' },
-      { $set: { settingValue: 'sk-ant-api03-brandnew' } },
+      { $set: { settingValue: 'enc:sk-ant-api03-brandnew' } },
       expect.anything()
     );
+    // The plaintext must never be the value handed to the store.
+    const storedArg = findOneAndUpdate.mock.calls[0][1] as { $set: { settingValue: string } };
+    expect(storedArg.$set.settingValue).not.toBe('sk-ant-api03-brandnew');
   });
 
   it('never echoes the submitted secret back in the write response', async () => {
@@ -75,7 +88,9 @@ describe('settings/update sensitive value handling', () => {
   });
 
   it('treats a mask written back as "keep the stored secret" and does not overwrite it', async () => {
-    stored = { settingName: 'anthropicDemoKey', settingValue: 'sk-ant-api03-original' };
+    // Stored value is ciphertext; the preserve path must decrypt before masking so the
+    // response carries the real last-4, and must never expose the plaintext.
+    stored = { settingName: 'anthropicDemoKey', settingValue: 'enc:sk-ant-api03-original' };
     const result = await runHandler('anthropicDemoKey', `${SENSITIVE_SETTING_MASK}inal`);
 
     expect(findOneAndUpdate).not.toHaveBeenCalled();
@@ -120,5 +135,31 @@ describe('settings/update sensitive value handling', () => {
     stageWriteResult('enforceMFA', 'true');
     const result = await runHandler('enforceMFA', 'true');
     expect(result.settingValue).toBe('true');
+  });
+
+  it('stores a non-sensitive string verbatim, never encrypting it', async () => {
+    stageWriteResult('tagLineMain', 'Welcome aboard');
+    await runHandler('tagLineMain', 'Welcome aboard');
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { settingName: 'tagLineMain' },
+      { $set: { settingValue: 'Welcome aboard' } },
+      expect.anything()
+    );
+  });
+
+  it('refuses to persist a sensitive value when no valid encryption key is configured', async () => {
+    // Fail closed: a misconfigured stage must not silently store a provider key in plaintext.
+    vi.stubGlobal('__noop__', undefined);
+    const { Config } = (await import('@server/utils/config')) as unknown as {
+      Config: { SECRET_ENCRYPTION_KEY: string };
+    };
+    const original = Config.SECRET_ENCRYPTION_KEY;
+    Config.SECRET_ENCRYPTION_KEY = 'too-short';
+    try {
+      await expect(runHandler('anthropicDemoKey', 'sk-ant-api03-brandnew')).rejects.toThrow(/SECRET_ENCRYPTION_KEY/);
+      expect(findOneAndUpdate).not.toHaveBeenCalled();
+    } finally {
+      Config.SECRET_ENCRYPTION_KEY = original;
+    }
   });
 });

--- a/apps/client/pages/api/settings/__tests__/update.test.ts
+++ b/apps/client/pages/api/settings/__tests__/update.test.ts
@@ -12,12 +12,12 @@ vi.mock('@bike4mind/database/infra', () => ({
     findOneAndUpdate: (...args: unknown[]) => findOneAndUpdate(...args),
   },
 }));
+vi.mock('@bike4mind/utils', () => ({ invalidateSettingsCache: vi.fn() }));
 // Deterministic stand-ins for the shared crypto. `enc:` marks ciphertext so the tests can
 // assert a value was encrypted at rest without depending on real AES output. update.ts pulls
 // encryptSecret/isEncrypted/isValidEncryptionKey through @server/security/secretEncryption,
-// which re-exports from @bike4mind/utils, so mocking utils covers those too.
-vi.mock('@bike4mind/utils', () => ({
-  invalidateSettingsCache: vi.fn(),
+// which re-exports from @bike4mind/utils/security, so mocking the subpath covers those too.
+vi.mock('@bike4mind/utils/security', () => ({
   decryptAtRest: (v: unknown) => (typeof v === 'string' && v.startsWith('enc:') ? v.slice(4) : v),
   encryptSecret: (v: string) => `enc:${v}`,
   isEncrypted: (v: unknown) => typeof v === 'string' && v.startsWith('enc:'),

--- a/apps/client/pages/api/settings/__tests__/update.test.ts
+++ b/apps/client/pages/api/settings/__tests__/update.test.ts
@@ -52,7 +52,7 @@ const runHandler = async (key: string, value: unknown, extra: Record<string, unk
     user: { isAdmin: true },
     ability: { can: () => true },
     body: { key, value, ...extra },
-    logger: { info: vi.fn(), error: vi.fn() },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   };
   await (handler as unknown as (req: unknown, res: unknown) => Promise<unknown>)(req, { json });
   return json.mock.calls[0][0] as { settingName: string; settingValue: unknown };
@@ -160,6 +160,32 @@ describe('settings/update sensitive value handling', () => {
       expect(findOneAndUpdate).not.toHaveBeenCalled();
     } finally {
       Config.SECRET_ENCRYPTION_KEY = original;
+    }
+  });
+
+  it('degrades to plaintext (does not fail closed) on self-host without a key, matching ApiKeyModel', async () => {
+    // A self-host that has not run the openssl step must still be able to save a sensitive,
+    // local-only setting like ollamaBackend, exactly as the per-user provider-key path allows.
+    const { Config } = (await import('@server/utils/config')) as unknown as {
+      Config: { SECRET_ENCRYPTION_KEY: string };
+    };
+    const originalKey = Config.SECRET_ENCRYPTION_KEY;
+    const originalSelfHost = process.env.B4M_SELF_HOST;
+    Config.SECRET_ENCRYPTION_KEY = 'too-short';
+    process.env.B4M_SELF_HOST = 'true';
+    stageWriteResult('ollamaBackend', 'http://localhost:11434');
+    try {
+      await runHandler('ollamaBackend', 'http://localhost:11434');
+      // Stored verbatim (plaintext), and crucially the write was NOT rejected.
+      expect(findOneAndUpdate).toHaveBeenCalledWith(
+        { settingName: 'ollamaBackend' },
+        { $set: { settingValue: 'http://localhost:11434' } },
+        expect.anything()
+      );
+    } finally {
+      Config.SECRET_ENCRYPTION_KEY = originalKey;
+      if (originalSelfHost === undefined) delete process.env.B4M_SELF_HOST;
+      else process.env.B4M_SELF_HOST = originalSelfHost;
     }
   });
 });

--- a/apps/client/pages/api/settings/fetch.ts
+++ b/apps/client/pages/api/settings/fetch.ts
@@ -1,5 +1,6 @@
 import { AdminSettings } from '@bike4mind/database/infra';
 import { redactSettingSecrets, settingsMap, type AdminSettingDoc } from '@bike4mind/common';
+import { decryptAtRest } from '@bike4mind/utils';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ensurePublicSettingsArtifactOncePerInstance } from '@server/utils/publicSettingsArtifact';
 
@@ -34,9 +35,18 @@ const handler = baseApi({ auth: true }).get(async (req, res) => {
   //
   // Server-side consumers (apiKeyService.getEffective*) read AdminSettings directly and
   // are unaffected by this endpoint.
-  const redacted: AdminSettingDoc[] = (settings ?? []).map(setting =>
-    redactSettingSecrets(setting as unknown as AdminSettingDoc)
-  );
+  //
+  // Sensitive values are stored encrypted; decrypt before redacting so the mask carries the
+  // real last-4 rather than the ciphertext tail. Only the mask leaves the server - the
+  // decrypted plaintext exists here just long enough to compute it. decryptAtRest passes a
+  // plaintext (not-yet-migrated) or non-encrypted value through unchanged.
+  const redacted: AdminSettingDoc[] = (settings ?? []).map(setting => {
+    const decrypted =
+      typeof setting.settingValue === 'string'
+        ? { ...setting, settingValue: decryptAtRest(setting.settingValue) }
+        : setting;
+    return redactSettingSecrets(decrypted as unknown as AdminSettingDoc);
+  });
 
   // defaultEmbeddingModel's default is env-dependent on self-host (a local Ollama embedder when
   // no cloud key, else the cloud default - see defaultEmbeddingModelForEnv). The client cannot

--- a/apps/client/pages/api/settings/fetch.ts
+++ b/apps/client/pages/api/settings/fetch.ts
@@ -1,6 +1,6 @@
 import { AdminSettings } from '@bike4mind/database/infra';
 import { redactSettingSecrets, settingsMap, type AdminSettingDoc } from '@bike4mind/common';
-import { decryptAtRest } from '@bike4mind/utils';
+import { decryptAtRest } from '@bike4mind/utils/security';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ensurePublicSettingsArtifactOncePerInstance } from '@server/utils/publicSettingsArtifact';
 

--- a/apps/client/pages/api/settings/index.ts
+++ b/apps/client/pages/api/settings/index.ts
@@ -1,6 +1,6 @@
 import { AdminSettings } from '@bike4mind/database/infra';
 import { redactSettingSecrets, type AdminSettingDoc } from '@bike4mind/common';
-import { decryptAtRest } from '@bike4mind/utils';
+import { decryptAtRest } from '@bike4mind/utils/security';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ensureAdmin } from '@server/utils/errors';
 

--- a/apps/client/pages/api/settings/index.ts
+++ b/apps/client/pages/api/settings/index.ts
@@ -1,23 +1,34 @@
 import { AdminSettings } from '@bike4mind/database/infra';
+import { redactSettingSecrets, type AdminSettingDoc } from '@bike4mind/common';
+import { decryptAtRest } from '@bike4mind/utils';
 import { baseApi } from '@server/middlewares/baseApi';
 import { ensureAdmin } from '@server/utils/errors';
 
-// Get Admin Settings - returns the FULL AdminSettings collection with unredacted
-// settingValues (including provider API keys), so this route is admin-only.
+// Get Admin Settings - returns the FULL AdminSettings collection, and is admin-only.
 //
 // A CASL `req.ability.can('read', AdminSettings)` check is NOT sufficient here: every
 // authenticated user holds a *conditional* read rule for feature-flag settings
 // (see server/auth/ability.ts), and CASL evaluates a subject-*type* check (the model class,
 // not a document instance) as true whenever any conditional rule exists - the condition is
 // never applied. That leaked every secret to any logged-in non-admin.
-// Non-admin/redacted reads must go through /api/settings/fetch, which filters by permitted
-// keys and masks sensitive values.
+//
+// Sensitive values are masked on the way out (the same redactor /api/settings/fetch uses),
+// so an admin secret never leaves the server through this route either - the stored value
+// is encrypted at rest, and only the mask (real last-4) is returned.
 const handler = baseApi().get(async (req, res) => {
   ensureAdmin(req.user?.isAdmin);
 
-  const settings = await AdminSettings.find();
+  const settings = await AdminSettings.find().lean();
 
-  return res.json(settings);
+  const redacted: AdminSettingDoc[] = (settings ?? []).map(setting => {
+    const decrypted =
+      typeof setting.settingValue === 'string'
+        ? { ...setting, settingValue: decryptAtRest(setting.settingValue) }
+        : setting;
+    return redactSettingSecrets(decrypted as unknown as AdminSettingDoc);
+  });
+
+  return res.json(redacted);
 });
 
 export const config = {

--- a/apps/client/pages/api/settings/update.ts
+++ b/apps/client/pages/api/settings/update.ts
@@ -7,7 +7,8 @@ import {
   settingsMap,
 } from '@bike4mind/common';
 import { AdminSettings } from '@bike4mind/database/infra';
-import { decryptAtRest, invalidateSettingsCache } from '@bike4mind/utils';
+import { invalidateSettingsCache } from '@bike4mind/utils';
+import { decryptAtRest } from '@bike4mind/utils/security';
 
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';

--- a/apps/client/pages/api/settings/update.ts
+++ b/apps/client/pages/api/settings/update.ts
@@ -103,7 +103,10 @@ const handler = baseApi().put(
     if (isSensitiveSetting && typeof value === 'string' && value !== '' && !isEncrypted(value)) {
       const encryptionKey = Config.SECRET_ENCRYPTION_KEY;
       if (!encryptionKey || !isValidEncryptionKey(encryptionKey)) {
-        throw new Error('SECRET_ENCRYPTION_KEY is not configured - cannot store a sensitive setting');
+        throw new Error(
+          'SECRET_ENCRYPTION_KEY is not configured (needs a 64-hex value), refusing to store a sensitive ' +
+            'setting in plaintext. Set it on this stage: sst secret set SECRET_ENCRYPTION_KEY <value>.'
+        );
       }
       settingValueToStore = encryptSecret(value, encryptionKey);
     }

--- a/apps/client/pages/api/settings/update.ts
+++ b/apps/client/pages/api/settings/update.ts
@@ -17,6 +17,10 @@ import { BadRequestError, ForbiddenError, NotFoundError } from '@server/utils/er
 import { encryptSecret, isEncrypted, isValidEncryptionKey } from '@server/security/secretEncryption';
 import { materializePublicSettingsArtifactSafe } from '@server/utils/publicSettingsArtifact';
 
+// One-time guard so a self-host install running without a configured key logs the
+// plaintext-at-rest degradation once, rather than silently or on every write.
+let warnedSelfHostPlaintext = false;
+
 // Update Admin Setting
 const handler = baseApi().put(
   asyncHandler<unknown, unknown, { key: string; value: unknown; confirmClear?: boolean }>(async (req, res) => {
@@ -99,16 +103,36 @@ const handler = baseApi().put(
     // not isSensitive and never reaches this branch. A confirmed clear ('') is stored as-is,
     // and an already-encrypted value is left untouched (idempotent). The submitted plaintext
     // stays in `value` for the response mask below so the admin sees the real last-4.
+    //
+    // This handler is the ONLY sanctioned writer of a sensitive admin setting, so the
+    // encrypt-on-write decision lives here rather than at the repository choke point the read
+    // path uses (a future writer - e.g. an OAuth flow persisting a refreshed secret - must
+    // encrypt here too, or route through AdminSettings with the same guard). The fail-closed
+    // contract is kept identical to the per-user provider-key path (ApiKeyModel.create): a
+    // cloud stage without a valid key throws; only a deliberate self-host install
+    // (B4M_SELF_HOST) degrades to plaintext at rest, so an admin can still save a local-only
+    // sensitive setting such as ollamaBackend before running the openssl key step.
     let settingValueToStore: unknown = value;
     if (isSensitiveSetting && typeof value === 'string' && value !== '' && !isEncrypted(value)) {
       const encryptionKey = Config.SECRET_ENCRYPTION_KEY;
-      if (!encryptionKey || !isValidEncryptionKey(encryptionKey)) {
+      if (encryptionKey && isValidEncryptionKey(encryptionKey)) {
+        settingValueToStore = encryptSecret(value, encryptionKey);
+      } else if (process.env.B4M_SELF_HOST === 'true') {
+        if (!warnedSelfHostPlaintext) {
+          warnedSelfHostPlaintext = true;
+          req.logger?.warn(
+            'SECRET_ENCRYPTION_KEY is not configured; storing sensitive admin settings in plaintext at rest ' +
+              '(self-host). Set a 64-hex SECRET_ENCRYPTION_KEY to encrypt them.'
+          );
+        }
+        // settingValueToStore stays the plaintext `value`.
+      } else {
         throw new Error(
           'SECRET_ENCRYPTION_KEY is not configured (needs a 64-hex value), refusing to store a sensitive ' +
-            'setting in plaintext. Set it on this stage: sst secret set SECRET_ENCRYPTION_KEY <value>.'
+            'setting in plaintext. Set a 64-hex key on this stage (sst secret set SECRET_ENCRYPTION_KEY <value>), ' +
+            'or set B4M_SELF_HOST=true to opt into plaintext.'
         );
       }
-      settingValueToStore = encryptSecret(value, encryptionKey);
     }
 
     const updatedSetting = await AdminSettings.findOneAndUpdate(

--- a/apps/client/pages/api/settings/update.ts
+++ b/apps/client/pages/api/settings/update.ts
@@ -7,13 +7,13 @@ import {
   settingsMap,
 } from '@bike4mind/common';
 import { AdminSettings } from '@bike4mind/database/infra';
-import { invalidateSettingsCache } from '@bike4mind/utils';
+import { decryptAtRest, invalidateSettingsCache } from '@bike4mind/utils';
 
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { Config } from '@server/utils/config';
 import { BadRequestError, ForbiddenError, NotFoundError } from '@server/utils/errors';
-import { encryptSecret, isEncrypted } from '@server/security/secretEncryption';
+import { encryptSecret, isEncrypted, isValidEncryptionKey } from '@server/security/secretEncryption';
 import { materializePublicSettingsArtifactSafe } from '@server/utils/publicSettingsArtifact';
 
 // Update Admin Setting
@@ -43,7 +43,11 @@ const handler = baseApi().put(
     if (isSensitiveSetting && isMaskedSensitiveSettingValue(value)) {
       const existing = await AdminSettings.findOne({ settingName: key }).lean();
       if (!existing) throw new NotFoundError('Admin setting not found');
-      return res.json({ ...existing, settingValue: maskSensitiveSettingValue(existing.settingValue) });
+      // The stored value is ciphertext; mask the decrypted plaintext so the admin still
+      // sees the real last-4, not the ciphertext tail. decryptAtRest passes plaintext
+      // (not-yet-migrated) values through unchanged.
+      const existingPlaintext = typeof existing.settingValue === 'string' ? decryptAtRest(existing.settingValue) : '';
+      return res.json({ ...existing, settingValue: maskSensitiveSettingValue(existingPlaintext) });
     }
 
     // Clearing a sensitive setting is a legitimate admin action, but it destroys a live
@@ -90,9 +94,22 @@ const handler = baseApi().put(
       value = sreValue;
     }
 
+    // Encrypt sensitive scalar values at rest. sreAgentConfig (an object handled above) is
+    // not isSensitive and never reaches this branch. A confirmed clear ('') is stored as-is,
+    // and an already-encrypted value is left untouched (idempotent). The submitted plaintext
+    // stays in `value` for the response mask below so the admin sees the real last-4.
+    let settingValueToStore: unknown = value;
+    if (isSensitiveSetting && typeof value === 'string' && value !== '' && !isEncrypted(value)) {
+      const encryptionKey = Config.SECRET_ENCRYPTION_KEY;
+      if (!encryptionKey || !isValidEncryptionKey(encryptionKey)) {
+        throw new Error('SECRET_ENCRYPTION_KEY is not configured - cannot store a sensitive setting');
+      }
+      settingValueToStore = encryptSecret(value, encryptionKey);
+    }
+
     const updatedSetting = await AdminSettings.findOneAndUpdate(
       { settingName: key },
-      { $set: { settingValue: value } },
+      { $set: { settingValue: settingValueToStore } },
       { upsert: true, new: true }
     );
 
@@ -136,11 +153,12 @@ const handler = baseApi().put(
     }
 
     // Never echo a sensitive value back, not even the one just submitted - the write
-    // response is the other way a stored secret could land in the browser payload.
+    // response is the other way a stored secret could land in the browser payload. Mask
+    // the submitted plaintext (`value`), not the stored ciphertext, so the last-4 is real.
     if (isSensitiveSetting) {
       const redacted = updatedSetting.toObject();
       (redacted as unknown as Record<string, unknown>).settingValue = maskSensitiveSettingValue(
-        updatedSetting.settingValue
+        typeof value === 'string' ? value : ''
       );
       return res.json(redacted);
     }

--- a/apps/client/server/jobs/dataSyncerHandler.ts
+++ b/apps/client/server/jobs/dataSyncerHandler.ts
@@ -19,7 +19,7 @@ import { Resource } from 'sst';
 import type { Handler } from 'aws-lambda';
 import mongoose from 'mongoose';
 import { MongoClient } from 'mongodb';
-import { isPlaceholderValue } from '@bike4mind/common';
+import { isPlaceholderValue, settingsMap } from '@bike4mind/common';
 import { rapidReplyMappingRepository } from '@bike4mind/database/ai';
 
 interface DataSyncerEvent {
@@ -43,6 +43,27 @@ const PRODUCTION_B4M_URL = process.env.PROD_SERVER_DOMAIN ? `https://app.${proce
 
 // Collections to sync from staging to preview environments
 const COLLECTIONS_TO_SYNC = ['adminsettings'];
+
+// isSensitive admin settings are encrypted at rest under the SOURCE stage's SECRET_ENCRYPTION_KEY.
+// A preview stage does not have that key linked (SST secrets are per-stage), so copying the
+// ciphertext across would decrypt to '' on read - silently blanking every provider/demo key,
+// Slack token, Firecrawl/Serper key and ollamaBackend at once. Never sync them cross-stage;
+// previews resolve sensitive settings from their own config (or the demo-key fallback).
+const SENSITIVE_ADMIN_SETTING_NAMES = new Set(
+  Object.entries(settingsMap)
+    .filter(([, def]) => (def as { isSensitive?: boolean })?.isSensitive === true)
+    .map(([key]) => key)
+);
+
+// Source-side query for a synced collection. adminsettings excludes sensitive rows (above);
+// every other collection copies in full. Used for BOTH the count and the cursor so the
+// progress total matches what is actually inserted.
+function syncSourceFilter(collectionName: string): Record<string, unknown> {
+  if (collectionName === 'adminsettings' && SENSITIVE_ADMIN_SETTING_NAMES.size > 0) {
+    return { settingName: { $nin: Array.from(SENSITIVE_ADMIN_SETTING_NAMES) } };
+  }
+  return {};
+}
 
 // Batch size for memory-efficient streaming
 const BATCH_SIZE = 1000;
@@ -202,7 +223,15 @@ async function syncPreviewSettingsFromStaging(): Promise<number> {
       const backupCollectionName = `${collectionName}_backup_temp`;
       const backupCollection = targetDb.collection(backupCollectionName);
 
-      const totalDocs = await sourceCollection.countDocuments({});
+      const sourceFilter = syncSourceFilter(collectionName);
+      if (Object.keys(sourceFilter).length > 0) {
+        console.log(
+          `  - Excluding ${SENSITIVE_ADMIN_SETTING_NAMES.size} sensitive settings from the cross-stage sync ` +
+            `(encrypted under the source stage's key; a preview cannot decrypt them).`
+        );
+      }
+
+      const totalDocs = await sourceCollection.countDocuments(sourceFilter);
 
       if (totalDocs === 0) {
         console.log(`  - No documents found in ${collectionName}. Skipping.`);
@@ -242,7 +271,7 @@ async function syncPreviewSettingsFromStaging(): Promise<number> {
         console.log(`  - Cleared ${deleteResult.deletedCount} existing documents in target.`);
 
         // Stream documents from source and insert into target in batches
-        const cursor = sourceCollection.find({});
+        const cursor = sourceCollection.find(sourceFilter);
         let batch: Record<string, unknown>[] = [];
         let insertedCount = 0;
 

--- a/apps/client/server/security/secretEncryption.ts
+++ b/apps/client/server/security/secretEncryption.ts
@@ -12,4 +12,4 @@ export {
   isEncrypted,
   generateEncryptionKey,
   isValidEncryptionKey,
-} from '@bike4mind/utils';
+} from '@bike4mind/utils/security';

--- a/apps/client/server/security/secretEncryption.ts
+++ b/apps/client/server/security/secretEncryption.ts
@@ -1,127 +1,15 @@
 /**
- * Secret Encryption Utility
+ * Secret encryption utility.
  *
- * Provides AES-256-GCM encryption for storing sensitive secrets in the database.
- *
- * Security features:
- * - AES-256-GCM (authenticated encryption with associated data)
- * - Random IV per encryption
- * - Authentication tag prevents tampering
- *
- * TODO(TECH-DEBT): JWT_SECRET in database is a TEMPORARY SOLUTION
- * This should be migrated to AWS Secrets Manager when available.
- * Current tradeoff: Database storage (encrypted) vs SSM (requires redeploy)
- * Expected removal: when a centralized Secrets Manager architecture is implemented
+ * The implementation now lives in @bike4mind/utils so the database layer (which
+ * cannot import from apps/client) can share it. This module is kept as a re-export
+ * so existing server routes and webhooks keep their `@server/security/secretEncryption`
+ * import path unchanged.
  */
-import crypto from 'crypto';
-
-const ALGORITHM = 'aes-256-gcm' as const;
-const IV_LENGTH = 16; // 128 bits
-const AUTH_TAG_LENGTH = 16; // 128 bits
-const KEY_LENGTH = 32; // 256 bits
-
-/**
- * Encrypts a plaintext secret using AES-256-GCM.
- *
- * @param plaintext - The secret to encrypt
- * @param key - 32-byte hex-encoded encryption key
- * @returns Encrypted string in format: iv:authTag:ciphertext (all hex-encoded)
- */
-export function encryptSecret(plaintext: string, key: string): string {
-  if (!plaintext) {
-    throw new Error('Cannot encrypt empty plaintext');
-  }
-
-  if (!key || key.length !== KEY_LENGTH * 2) {
-    throw new Error(`Encryption key must be ${KEY_LENGTH * 2} hex characters (${KEY_LENGTH} bytes)`);
-  }
-
-  const iv = crypto.randomBytes(IV_LENGTH);
-  const cipher = crypto.createCipheriv(ALGORITHM, Buffer.from(key, 'hex'), iv);
-
-  let encrypted = cipher.update(plaintext, 'utf8', 'hex');
-  encrypted += cipher.final('hex');
-  const authTag = cipher.getAuthTag();
-
-  // Format: iv:authTag:encrypted (all hex-encoded)
-  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
-}
-
-/**
- * Decrypts an encrypted secret using AES-256-GCM.
- *
- * @param encrypted - Encrypted string in format: iv:authTag:ciphertext
- * @param key - 32-byte hex-encoded encryption key
- * @returns Decrypted plaintext
- * @throws Error if decryption fails (invalid format, wrong key, or tampered data)
- */
-export function decryptSecret(encrypted: string, key: string): string {
-  if (!encrypted) {
-    throw new Error('Cannot decrypt empty ciphertext');
-  }
-
-  if (!key || key.length !== KEY_LENGTH * 2) {
-    throw new Error(`Encryption key must be ${KEY_LENGTH * 2} hex characters (${KEY_LENGTH} bytes)`);
-  }
-
-  const parts = encrypted.split(':');
-  if (parts.length !== 3) {
-    throw new Error('Invalid encrypted format. Expected iv:authTag:ciphertext');
-  }
-
-  const [ivHex, authTagHex, encryptedData] = parts;
-
-  if (ivHex.length !== IV_LENGTH * 2) {
-    throw new Error(`Invalid IV length. Expected ${IV_LENGTH * 2} hex characters`);
-  }
-
-  if (authTagHex.length !== AUTH_TAG_LENGTH * 2) {
-    throw new Error(`Invalid auth tag length. Expected ${AUTH_TAG_LENGTH * 2} hex characters`);
-  }
-
-  const decipher = crypto.createDecipheriv(ALGORITHM, Buffer.from(key, 'hex'), Buffer.from(ivHex, 'hex'));
-  decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
-
-  let decrypted = decipher.update(encryptedData, 'hex', 'utf8');
-  decrypted += decipher.final('utf8');
-
-  return decrypted;
-}
-
-/**
- * Checks if a string appears to be in encrypted format.
- *
- * @param value - String to check
- * @returns true if the string matches the encrypted format pattern
- */
-export function isEncrypted(value: string): boolean {
-  if (!value) {
-    return false;
-  }
-
-  // Check if value matches encrypted format: iv(32 hex):authTag(32 hex):data(hex)
-  const pattern = /^[a-f0-9]{32}:[a-f0-9]{32}:[a-f0-9]+$/i;
-  return pattern.test(value);
-}
-
-/**
- * Generates a new random encryption key suitable for AES-256-GCM.
- *
- * @returns 32-byte hex-encoded key
- */
-export function generateEncryptionKey(): string {
-  return crypto.randomBytes(KEY_LENGTH).toString('hex');
-}
-
-/**
- * Validates that an encryption key is properly formatted.
- *
- * @param key - Key to validate
- * @returns true if the key is valid
- */
-export function isValidEncryptionKey(key: string): boolean {
-  if (!key || key.length !== KEY_LENGTH * 2) {
-    return false;
-  }
-  return /^[a-f0-9]+$/i.test(key);
-}
+export {
+  encryptSecret,
+  decryptSecret,
+  isEncrypted,
+  generateEncryptionKey,
+  isValidEncryptionKey,
+} from '@bike4mind/utils';

--- a/apps/client/server/utils/config.ts
+++ b/apps/client/server/utils/config.ts
@@ -1,4 +1,5 @@
 import { Resource } from 'sst';
+import { configureSecretsAtRest } from '@bike4mind/utils';
 
 /**
  * Safe read for a manifest-optional secret (see b4m-core/resource manifest.ts
@@ -114,5 +115,11 @@ const isE2EEnabled = () => {
   if (process.env.E2E_ENDPOINTS_ENABLED === 'true') return true;
   return isDevelopment();
 };
+
+// Inject the at-rest encryption key into the shared secrets module once, at module
+// load. Config is imported by every server context before it reaches Mongo (each
+// connectDB call reads Config.MONGODB_URI), so this runs before any repository read
+// decrypts a stored secret. The database layer cannot import Config directly.
+configureSecretsAtRest(Config.SECRET_ENCRYPTION_KEY, Config.SECRET_ENCRYPTION_KEY_PREVIOUS);
 
 export { Config, isProduction, isDevelopment, isE2EEnabled };

--- a/apps/client/server/utils/config.ts
+++ b/apps/client/server/utils/config.ts
@@ -1,5 +1,4 @@
 import { Resource } from 'sst';
-import { configureSecretsAtRest } from '@bike4mind/utils';
 
 /**
  * Safe read for a manifest-optional secret (see b4m-core/resource manifest.ts
@@ -115,11 +114,5 @@ const isE2EEnabled = () => {
   if (process.env.E2E_ENDPOINTS_ENABLED === 'true') return true;
   return isDevelopment();
 };
-
-// Inject the at-rest encryption key into the shared secrets module once, at module
-// load. Config is imported by every server context before it reaches Mongo (each
-// connectDB call reads Config.MONGODB_URI), so this runs before any repository read
-// decrypts a stored secret. The database layer cannot import Config directly.
-configureSecretsAtRest(Config.SECRET_ENCRYPTION_KEY, Config.SECRET_ENCRYPTION_KEY_PREVIOUS);
 
 export { Config, isProduction, isDevelopment, isE2EEnabled };

--- a/b4m-core/common/src/schemas/settings.test.ts
+++ b/b4m-core/common/src/schemas/settings.test.ts
@@ -3,6 +3,7 @@ import {
   settingsMap,
   publicSafeSettingKeys,
   redactSettingSecrets,
+  redactSettingSecretsForBroadcast,
   buildPublicSettingsProjection,
   experimentalFeatureSettingKeys,
   experimentalNonGroupSettingKeys,
@@ -284,6 +285,40 @@ describe('public settings projection (M2.5 security boundary)', () => {
         .map(s => s.key);
 
       expect(offenders, `isSensitive settings that are not plain string inputs: ${offenders.join(', ')}`).toEqual([]);
+    });
+  });
+
+  describe('redactSettingSecretsForBroadcast', () => {
+    it('emits a bare mask with NO tail for a sensitive setting (browser cannot decrypt ciphertext)', () => {
+      // The WS fanout carries the raw stored document - ciphertext post-migration. Masking its
+      // tail would surface a wrong "last 4"; a bare mask cannot be mis-verified.
+      const ciphertext = 'a'.repeat(32) + ':' + 'b'.repeat(32) + ':deadbeef';
+      const redacted = redactSettingSecretsForBroadcast({ settingName: 'anthropicDemoKey', settingValue: ciphertext });
+      expect(redacted.settingValue).toBe(SENSITIVE_SETTING_MASK);
+      // Never the ciphertext tail (the whole point of the fix).
+      expect(redacted.settingValue).not.toBe(`${SENSITIVE_SETTING_MASK}beef`);
+    });
+
+    it('leaves an unset sensitive setting empty', () => {
+      expect(redactSettingSecretsForBroadcast({ settingName: 'anthropicDemoKey', settingValue: '' }).settingValue).toBe(
+        ''
+      );
+    });
+
+    it('still masks sreAgentConfig per-repo secrets (delegates to redactSettingSecrets)', () => {
+      const redacted = redactSettingSecretsForBroadcast({
+        settingName: 'sreAgentConfig',
+        settingValue: { repos: [{ owner: 'a', repo: 'b', webhookSecret: 'hunter2', callbackToken: 'tok' }] },
+      });
+      const repo = (redacted.settingValue as { repos: Array<{ webhookSecret: string; callbackToken: string }> })
+        .repos[0];
+      expect(repo.webhookSecret).toBe(SRE_SECRET_PLACEHOLDER);
+      expect(repo.callbackToken).toBe(SRE_SECRET_PLACEHOLDER);
+    });
+
+    it('passes a non-sensitive setting through untouched', () => {
+      const setting: AdminSettingDoc = { settingName: 'enforceMFA', settingValue: 'true' };
+      expect(redactSettingSecretsForBroadcast(setting)).toEqual(setting);
     });
   });
 });

--- a/b4m-core/common/src/schemas/settings.ts
+++ b/b4m-core/common/src/schemas/settings.ts
@@ -3855,6 +3855,24 @@ export function redactSettingSecrets(setting: AdminSettingDoc): AdminSettingDoc 
   };
 }
 
+/**
+ * Redact a setting for a WebSocket / change-stream broadcast, where the payload is the RAW
+ * stored document. Post-encryption an isSensitive value is ciphertext the browser cannot
+ * decrypt, so it collapses to the bare mask with NO trailing characters: masking the
+ * ciphertext tail (as maskSensitiveSettingValue would) surfaces a wrong "last 4" and lets an
+ * admin watching a live cross-admin update mis-verify which credential is loaded. An unset
+ * value stays empty. The authoritative mask carrying the real last-4 still comes from
+ * /api/settings/fetch. Non-sensitive shapes (sreAgentConfig) fall through to redactSettingSecrets.
+ */
+export function redactSettingSecretsForBroadcast(setting: AdminSettingDoc): AdminSettingDoc {
+  const definition = (settingsMap as Record<string, { isSensitive?: boolean } | undefined>)[setting.settingName];
+  if (definition?.isSensitive) {
+    const hasValue = typeof setting.settingValue === 'string' && setting.settingValue.length > 0;
+    return { ...setting, settingValue: hasValue ? SENSITIVE_SETTING_MASK : '' };
+  }
+  return redactSettingSecrets(setting);
+}
+
 /** Setting keys explicitly tagged `publicSafe` - the only keys allowed in the public artifact. */
 export function publicSafeSettingKeys(): string[] {
   return (Object.values(settingsMap) as Array<{ key: string; publicSafe?: boolean }>)

--- a/b4m-core/utils/package.json
+++ b/b4m-core/utils/package.json
@@ -108,6 +108,16 @@
         "types": "./dist/registrableDomain.d.cts",
         "default": "./dist/registrableDomain.cjs"
       }
+    },
+    "./security": {
+      "import": {
+        "types": "./dist/security/index.d.mts",
+        "default": "./dist/security/index.mjs"
+      },
+      "require": {
+        "types": "./dist/security/index.d.cts",
+        "default": "./dist/security/index.cjs"
+      }
     }
   },
   "files": [

--- a/b4m-core/utils/src/index.ts
+++ b/b4m-core/utils/src/index.ts
@@ -105,4 +105,7 @@ export * from './circuitBreaker';
 export * from './rateLimitHeaders';
 export * from './voiceHistory';
 export * from './lambdaErrorHandler';
-export * from './security';
+// NOT barrel-exported on purpose: at-rest crypto is reached only via the
+// `@bike4mind/utils/security` subpath, so importing it never drags the utils barrel
+// (artifactParser et al.) into a caller's graph or its test mocks. Same pattern as
+// artifactElision above.

--- a/b4m-core/utils/src/index.ts
+++ b/b4m-core/utils/src/index.ts
@@ -105,3 +105,4 @@ export * from './circuitBreaker';
 export * from './rateLimitHeaders';
 export * from './voiceHistory';
 export * from './lambdaErrorHandler';
+export * from './security';

--- a/b4m-core/utils/src/security/index.ts
+++ b/b4m-core/utils/src/security/index.ts
@@ -1,0 +1,2 @@
+export * from './secretEncryption';
+export * from './secretsAtRest';

--- a/b4m-core/utils/src/security/secretEncryption.ts
+++ b/b4m-core/utils/src/security/secretEncryption.ts
@@ -11,6 +11,11 @@
  * This is the canonical implementation. apps/client/server/security/secretEncryption.ts
  * re-exports from here so server routes and webhooks keep their existing import path, and
  * the database layer (which cannot import from apps/client) consumes it via @bike4mind/utils.
+ *
+ * TODO(TECH-DEBT): JWT_SECRET in database is a TEMPORARY SOLUTION
+ * This should be migrated to AWS Secrets Manager when available.
+ * Current tradeoff: Database storage (encrypted) vs SSM (requires redeploy)
+ * Expected removal: when a centralized Secrets Manager architecture is implemented
  */
 import crypto from 'crypto';
 

--- a/b4m-core/utils/src/security/secretEncryption.ts
+++ b/b4m-core/utils/src/security/secretEncryption.ts
@@ -1,0 +1,126 @@
+/**
+ * Secret Encryption Utility
+ *
+ * Provides AES-256-GCM encryption for storing sensitive secrets in the database.
+ *
+ * Security features:
+ * - AES-256-GCM (authenticated encryption with associated data)
+ * - Random IV per encryption
+ * - Authentication tag prevents tampering
+ *
+ * This is the canonical implementation. apps/client/server/security/secretEncryption.ts
+ * re-exports from here so server routes and webhooks keep their existing import path, and
+ * the database layer (which cannot import from apps/client) consumes it via @bike4mind/utils.
+ */
+import crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm' as const;
+const IV_LENGTH = 16; // 128 bits
+const AUTH_TAG_LENGTH = 16; // 128 bits
+const KEY_LENGTH = 32; // 256 bits
+
+/**
+ * Encrypts a plaintext secret using AES-256-GCM.
+ *
+ * @param plaintext - The secret to encrypt
+ * @param key - 32-byte hex-encoded encryption key
+ * @returns Encrypted string in format: iv:authTag:ciphertext (all hex-encoded)
+ */
+export function encryptSecret(plaintext: string, key: string): string {
+  if (!plaintext) {
+    throw new Error('Cannot encrypt empty plaintext');
+  }
+
+  if (!key || key.length !== KEY_LENGTH * 2) {
+    throw new Error(`Encryption key must be ${KEY_LENGTH * 2} hex characters (${KEY_LENGTH} bytes)`);
+  }
+
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, Buffer.from(key, 'hex'), iv);
+
+  let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  const authTag = cipher.getAuthTag();
+
+  // Format: iv:authTag:encrypted (all hex-encoded)
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+}
+
+/**
+ * Decrypts an encrypted secret using AES-256-GCM.
+ *
+ * @param encrypted - Encrypted string in format: iv:authTag:ciphertext
+ * @param key - 32-byte hex-encoded encryption key
+ * @returns Decrypted plaintext
+ * @throws Error if decryption fails (invalid format, wrong key, or tampered data)
+ */
+export function decryptSecret(encrypted: string, key: string): string {
+  if (!encrypted) {
+    throw new Error('Cannot decrypt empty ciphertext');
+  }
+
+  if (!key || key.length !== KEY_LENGTH * 2) {
+    throw new Error(`Encryption key must be ${KEY_LENGTH * 2} hex characters (${KEY_LENGTH} bytes)`);
+  }
+
+  const parts = encrypted.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted format. Expected iv:authTag:ciphertext');
+  }
+
+  const [ivHex, authTagHex, encryptedData] = parts;
+
+  if (ivHex.length !== IV_LENGTH * 2) {
+    throw new Error(`Invalid IV length. Expected ${IV_LENGTH * 2} hex characters`);
+  }
+
+  if (authTagHex.length !== AUTH_TAG_LENGTH * 2) {
+    throw new Error(`Invalid auth tag length. Expected ${AUTH_TAG_LENGTH * 2} hex characters`);
+  }
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, Buffer.from(key, 'hex'), Buffer.from(ivHex, 'hex'));
+  decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
+
+  let decrypted = decipher.update(encryptedData, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+
+  return decrypted;
+}
+
+/**
+ * Checks if a string appears to be in encrypted format.
+ *
+ * @param value - String to check
+ * @returns true if the string matches the encrypted format pattern
+ */
+export function isEncrypted(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+
+  // Check if value matches encrypted format: iv(32 hex):authTag(32 hex):data(hex)
+  const pattern = /^[a-f0-9]{32}:[a-f0-9]{32}:[a-f0-9]+$/i;
+  return pattern.test(value);
+}
+
+/**
+ * Generates a new random encryption key suitable for AES-256-GCM.
+ *
+ * @returns 32-byte hex-encoded key
+ */
+export function generateEncryptionKey(): string {
+  return crypto.randomBytes(KEY_LENGTH).toString('hex');
+}
+
+/**
+ * Validates that an encryption key is properly formatted.
+ *
+ * @param key - Key to validate
+ * @returns true if the key is valid
+ */
+export function isValidEncryptionKey(key: string): boolean {
+  if (!key || key.length !== KEY_LENGTH * 2) {
+    return false;
+  }
+  return /^[a-f0-9]+$/i.test(key);
+}

--- a/b4m-core/utils/src/security/secretsAtRest.test.ts
+++ b/b4m-core/utils/src/security/secretsAtRest.test.ts
@@ -45,10 +45,16 @@ describe('secretsAtRest', () => {
     expect(decryptAtRest(legacyCipher)).toBe('rotated-secret');
   });
 
-  it('returns ciphertext unchanged (never a plaintext guess) when no key can decrypt it', () => {
+  it('returns "" (not the ciphertext) when no key can decrypt it, so downstream guards fire', () => {
     const cipher = encryptSecret('secret', generateEncryptionKey());
     configureSecretsAtRest(KEY); // neither current nor previous can decrypt this
-    expect(decryptAtRest(cipher)).toBe(cipher);
+    expect(decryptAtRest(cipher)).toBe('');
+  });
+
+  it('returns "" for a ciphertext value when no key is configured at all', () => {
+    const cipher = encryptSecret('secret', KEY);
+    configureSecretsAtRest(undefined);
+    expect(decryptAtRest(cipher)).toBe('');
   });
 
   it('leaves an empty string alone', () => {

--- a/b4m-core/utils/src/security/secretsAtRest.test.ts
+++ b/b4m-core/utils/src/security/secretsAtRest.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { encryptSecret, generateEncryptionKey, isEncrypted } from './secretEncryption';
+import { configureSecretsAtRest, decryptAtRest, encryptAtRest, isSecretsAtRestConfigured } from './secretsAtRest';
+
+const KEY = generateEncryptionKey();
+const PREVIOUS_KEY = generateEncryptionKey();
+
+describe('secretsAtRest', () => {
+  beforeEach(() => {
+    configureSecretsAtRest(KEY);
+  });
+
+  it('round-trips a secret through encryptAtRest/decryptAtRest', () => {
+    const cipher = encryptAtRest('sk-ant-api03-secret');
+    expect(cipher).not.toBe('sk-ant-api03-secret');
+    expect(isEncrypted(cipher)).toBe(true);
+    expect(decryptAtRest(cipher)).toBe('sk-ant-api03-secret');
+  });
+
+  it('reports configuration state from the registered key', () => {
+    expect(isSecretsAtRestConfigured()).toBe(true);
+    configureSecretsAtRest(undefined);
+    expect(isSecretsAtRestConfigured()).toBe(false);
+  });
+
+  it('passes a plaintext (not-yet-migrated) value through decryptAtRest unchanged', () => {
+    expect(decryptAtRest('sk-plaintext-not-migrated')).toBe('sk-plaintext-not-migrated');
+  });
+
+  it('is idempotent: encryptAtRest leaves already-encrypted input untouched', () => {
+    const cipher = encryptAtRest('secret');
+    expect(encryptAtRest(cipher)).toBe(cipher);
+  });
+
+  it('rejects a malformed key by treating storage as unconfigured (plaintext passthrough)', () => {
+    configureSecretsAtRest('too-short');
+    expect(isSecretsAtRestConfigured()).toBe(false);
+    // No key -> encryptAtRest cannot encrypt, so it must not throw or corrupt; it passes through.
+    expect(encryptAtRest('secret')).toBe('secret');
+  });
+
+  it('decrypts a value encrypted under the previous key after rotation', () => {
+    const legacyCipher = encryptSecret('rotated-secret', PREVIOUS_KEY);
+    configureSecretsAtRest(KEY, PREVIOUS_KEY);
+    expect(decryptAtRest(legacyCipher)).toBe('rotated-secret');
+  });
+
+  it('returns ciphertext unchanged (never a plaintext guess) when no key can decrypt it', () => {
+    const cipher = encryptSecret('secret', generateEncryptionKey());
+    configureSecretsAtRest(KEY); // neither current nor previous can decrypt this
+    expect(decryptAtRest(cipher)).toBe(cipher);
+  });
+
+  it('leaves an empty string alone', () => {
+    expect(encryptAtRest('')).toBe('');
+    expect(decryptAtRest('')).toBe('');
+  });
+});

--- a/b4m-core/utils/src/security/secretsAtRest.ts
+++ b/b4m-core/utils/src/security/secretsAtRest.ts
@@ -30,6 +30,10 @@ let warnedDecryptFailure = false;
 export function configureSecretsAtRest(key: string | undefined, previous?: string | undefined): void {
   currentKey = key && isValidEncryptionKey(key) ? key : undefined;
   previousKey = previous && isValidEncryptionKey(previous) ? previous : undefined;
+  // Reset the log-once guards so a genuinely new misconfiguration or decrypt failure after a
+  // (re)configuration - e.g. a key rotation - is still surfaced once.
+  warnedMissingKey = false;
+  warnedDecryptFailure = false;
 }
 
 /** True when a usable encryption key is registered. */

--- a/b4m-core/utils/src/security/secretsAtRest.ts
+++ b/b4m-core/utils/src/security/secretsAtRest.ts
@@ -23,6 +23,7 @@ let currentKey: string | undefined;
 let previousKey: string | undefined;
 let warnedMissingKey = false;
 let warnedDecryptFailure = false;
+let warnedPlaintextWrite = false;
 
 /**
  * Register the at-rest encryption key(s). Called once from app boot with
@@ -37,6 +38,7 @@ export function configureSecretsAtRest(key: string | undefined, previous?: strin
   // (re)configuration - e.g. a key rotation - is still surfaced once.
   warnedMissingKey = false;
   warnedDecryptFailure = false;
+  warnedPlaintextWrite = false;
 }
 
 /** True when a usable encryption key is registered. */
@@ -53,7 +55,17 @@ export function isSecretsAtRestConfigured(): boolean {
  */
 export function encryptAtRest(plaintext: string): string {
   if (!plaintext || isEncrypted(plaintext)) return plaintext;
-  if (!currentKey) return plaintext;
+  if (!currentKey) {
+    // Degrading to plaintext storage (self-host without a key, or a stage that fails closed
+    // upstream before reaching here). Never silent: log once so an operator can see it.
+    if (!warnedPlaintextWrite) {
+      warnedPlaintextWrite = true;
+      Logger.globalInstance.warn(
+        '[secrets-at-rest] no SECRET_ENCRYPTION_KEY configured; storing a secret in plaintext at rest'
+      );
+    }
+    return plaintext;
+  }
   return encryptSecret(plaintext, currentKey);
 }
 

--- a/b4m-core/utils/src/security/secretsAtRest.ts
+++ b/b4m-core/utils/src/security/secretsAtRest.ts
@@ -1,0 +1,86 @@
+/**
+ * Secrets-at-rest key injection.
+ *
+ * The database layer (packages/database) and core services must encrypt/decrypt
+ * stored secrets, but cannot import SST `Config` (that lives in apps/client). The
+ * app injects the encryption key once at boot via `configureSecretsAtRest`, and the
+ * repository read paths call `decryptAtRest` / write paths call `encryptAtRest`.
+ *
+ * Mirrors the `setModelCatalogProvider` one-time-injection pattern used by connectDB.
+ *
+ * Rollout contract: a value that is NOT in ciphertext format passes through unchanged,
+ * so plaintext rows written before the backfill migration keep working until they are
+ * re-encrypted. Decryption tries the current key then `SECRET_ENCRYPTION_KEY_PREVIOUS`
+ * so a key rotation does not strand values encrypted under the old key.
+ */
+import { Logger } from '@bike4mind/observability';
+import { decryptSecret, encryptSecret, isEncrypted, isValidEncryptionKey } from './secretEncryption';
+
+let currentKey: string | undefined;
+let previousKey: string | undefined;
+let warnedMissingKey = false;
+let warnedDecryptFailure = false;
+
+/**
+ * Register the at-rest encryption key(s). Called once from app boot with
+ * `Config.SECRET_ENCRYPTION_KEY` (and optionally the previous key during rotation).
+ * An absent or malformed key registers as "unconfigured" so writes degrade to
+ * plaintext (self-host without a key) rather than throwing on every store.
+ */
+export function configureSecretsAtRest(key: string | undefined, previous?: string | undefined): void {
+  currentKey = key && isValidEncryptionKey(key) ? key : undefined;
+  previousKey = previous && isValidEncryptionKey(previous) ? previous : undefined;
+}
+
+/** True when a usable encryption key is registered. */
+export function isSecretsAtRestConfigured(): boolean {
+  return !!currentKey;
+}
+
+/**
+ * Encrypt a plaintext secret for storage.
+ * - Already-ciphertext input is returned unchanged (idempotent).
+ * - When no key is configured, returns the plaintext unchanged so callers that
+ *   tolerate unencrypted storage (self-host, per-user keys) keep working. Callers
+ *   that must fail closed should check `isSecretsAtRestConfigured()` first.
+ */
+export function encryptAtRest(plaintext: string): string {
+  if (!plaintext || isEncrypted(plaintext)) return plaintext;
+  if (!currentKey) return plaintext;
+  return encryptSecret(plaintext, currentKey);
+}
+
+/**
+ * Decrypt a value read from storage. Plaintext (pre-migration) values and any
+ * non-ciphertext input pass through unchanged. On a genuine decrypt failure the
+ * ciphertext is returned as-is (fail-broken, never a silent plaintext leak) and the
+ * failure is logged once.
+ */
+export function decryptAtRest(value: string): string {
+  if (!value || !isEncrypted(value)) return value;
+
+  if (!currentKey && !previousKey) {
+    if (!warnedMissingKey) {
+      warnedMissingKey = true;
+      Logger.globalInstance.error(
+        '[secrets-at-rest] read an encrypted value but no SECRET_ENCRYPTION_KEY is configured; cannot decrypt'
+      );
+    }
+    return value;
+  }
+
+  for (const key of [currentKey, previousKey]) {
+    if (!key) continue;
+    try {
+      return decryptSecret(value, key);
+    } catch {
+      // Try the next key (rotation) before giving up.
+    }
+  }
+
+  if (!warnedDecryptFailure) {
+    warnedDecryptFailure = true;
+    Logger.globalInstance.error('[secrets-at-rest] failed to decrypt a stored secret with the configured key(s)');
+  }
+  return value;
+}

--- a/b4m-core/utils/src/security/secretsAtRest.ts
+++ b/b4m-core/utils/src/security/secretsAtRest.ts
@@ -2,9 +2,12 @@
  * Secrets-at-rest key injection.
  *
  * The database layer (packages/database) and core services must encrypt/decrypt
- * stored secrets, but cannot import SST `Config` (that lives in apps/client). The
- * app injects the encryption key once at boot via `configureSecretsAtRest`, and the
- * repository read paths call `decryptAtRest` / write paths call `encryptAtRest`.
+ * stored secrets, but cannot import SST `Config` (that lives in apps/client). The key
+ * is registered via `configureSecretsAtRest`; in practice `connectDB`
+ * (packages/database/src/priceCatalogBootstrap.ts) calls it from `Resource` on first
+ * connect, so every process that reaches Mongo - API routes, cron/queue handlers, and
+ * the packages/scripts CLIs - is covered without an apps/client-only boot import.
+ * Read paths call `decryptAtRest`; write paths call `encryptAtRest`.
  *
  * Mirrors the `setModelCatalogProvider` one-time-injection pattern used by connectDB.
  *
@@ -56,9 +59,11 @@ export function encryptAtRest(plaintext: string): string {
 
 /**
  * Decrypt a value read from storage. Plaintext (pre-migration) values and any
- * non-ciphertext input pass through unchanged. On a genuine decrypt failure the
- * ciphertext is returned as-is (fail-broken, never a silent plaintext leak) and the
- * failure is logged once.
+ * non-ciphertext input pass through unchanged. When a ciphertext value cannot be
+ * decrypted (no key configured, or none of the keys work after a botched rotation) it
+ * returns '' rather than the raw ciphertext: '' makes downstream `if (!key)` guards fire
+ * and degrade to the demo-key fallback, whereas returning the hex blob would be sent
+ * upstream as a live credential and read as "configured". The failure is logged once.
  */
 export function decryptAtRest(value: string): string {
   if (!value || !isEncrypted(value)) return value;
@@ -70,7 +75,7 @@ export function decryptAtRest(value: string): string {
         '[secrets-at-rest] read an encrypted value but no SECRET_ENCRYPTION_KEY is configured; cannot decrypt'
       );
     }
-    return value;
+    return '';
   }
 
   for (const key of [currentKey, previousKey]) {
@@ -86,5 +91,5 @@ export function decryptAtRest(value: string): string {
     warnedDecryptFailure = true;
     Logger.globalInstance.error('[secrets-at-rest] failed to decrypt a stored secret with the configured key(s)');
   }
-  return value;
+  return '';
 }

--- a/b4m-core/utils/tsdown.config.ts
+++ b/b4m-core/utils/tsdown.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
     'src/normalizeId.ts',
     'src/retrievalExclusion.ts',
     'src/registrableDomain.ts',
+    // Own entry so callers that only need at-rest crypto (apps/client server routes, the
+    // database repositories, migration scripts) import it without dragging the whole utils
+    // barrel - which reaches artifactParser and other modules - into their graph or tests.
+    'src/security/index.ts',
   ],
   format: ['esm', 'cjs'],
   dts: true,

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -70,6 +70,7 @@
     "dayjs": "^1.11.21",
     "mongoose": "^8.24.1",
     "mongoose-lean-virtuals": "^2.1.0",
+    "sst": "4.17.1",
     "typescript": "^5.9.3"
   },
   "devDependencies": {

--- a/packages/database/src/models/auth/ApiKeyModel.encryption.test.ts
+++ b/packages/database/src/models/auth/ApiKeyModel.encryption.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ApiKeyType } from '@bike4mind/common';
+import { configureSecretsAtRest, generateEncryptionKey, isEncrypted } from '@bike4mind/utils';
+import { setupMongoTest } from '../../__test__/utils';
+import { ApiKey, apiKeyRepository } from './ApiKeyModel';
+
+const KEY = generateEncryptionKey();
+
+describe('ApiKeyRepository encrypt-on-write / decrypt-on-read', () => {
+  setupMongoTest();
+
+  beforeAll(() => {
+    configureSecretsAtRest(KEY);
+  });
+
+  const base = {
+    userId: 'user-1',
+    type: ApiKeyType.anthropic,
+    isActive: true,
+    expiresAt: new Date(Date.now() + 86_400_000),
+  };
+
+  it('encrypts the key at rest but echoes the submitted plaintext from create', async () => {
+    const created = await apiKeyRepository.create({ ...base, apiKey: 'sk-ant-plainkey' });
+    // The create response echoes the plaintext the caller submitted...
+    expect(created.apiKey).toBe('sk-ant-plainkey');
+    // ...but the stored document is ciphertext.
+    const raw = await ApiKey.findOne({ userId: 'user-1', type: ApiKeyType.anthropic }).lean();
+    expect(isEncrypted(raw?.apiKey as string)).toBe(true);
+    expect(raw?.apiKey).not.toBe('sk-ant-plainkey');
+  });
+
+  it('decrypts the key on the read paths consumers use', async () => {
+    await apiKeyRepository.create({ ...base, apiKey: 'sk-ant-readable' });
+
+    const byType = await apiKeyRepository.findByUserIdAndType('user-1', ApiKeyType.anthropic);
+    expect(byType?.apiKey).toBe('sk-ant-readable');
+
+    const byTypes = await apiKeyRepository.findByUserIdAndTypes('user-1', [ApiKeyType.anthropic]);
+    expect(byTypes[0]?.apiKey).toBe('sk-ant-readable');
+  });
+});

--- a/packages/database/src/models/auth/ApiKeyModel.encryption.test.ts
+++ b/packages/database/src/models/auth/ApiKeyModel.encryption.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { ApiKeyType } from '@bike4mind/common';
-import { configureSecretsAtRest, generateEncryptionKey, isEncrypted } from '@bike4mind/utils';
+import { configureSecretsAtRest, generateEncryptionKey, isEncrypted } from '@bike4mind/utils/security';
 import { setupMongoTest } from '../../__test__/utils';
 import { ApiKey, apiKeyRepository } from './ApiKeyModel';
 

--- a/packages/database/src/models/auth/ApiKeyModel.encryption.test.ts
+++ b/packages/database/src/models/auth/ApiKeyModel.encryption.test.ts
@@ -13,30 +13,33 @@ describe('ApiKeyRepository encrypt-on-write / decrypt-on-read', () => {
     configureSecretsAtRest(KEY);
   });
 
-  const base = {
-    userId: 'user-1',
+  // setupMongoTest drops the DB before each `it`, but each test also uses a distinct userId so
+  // the assertions never depend on that reset scoping (findByUserIdAndType is an unsorted
+  // findOne, so a stray same-user document would otherwise make the read flaky).
+  const base = (userId: string) => ({
+    userId,
     type: ApiKeyType.anthropic,
     isActive: true,
     expiresAt: new Date(Date.now() + 86_400_000),
-  };
+  });
 
   it('encrypts the key at rest but echoes the submitted plaintext from create', async () => {
-    const created = await apiKeyRepository.create({ ...base, apiKey: 'sk-ant-plainkey' });
+    const created = await apiKeyRepository.create({ ...base('user-encrypt'), apiKey: 'sk-ant-plainkey' });
     // The create response echoes the plaintext the caller submitted...
     expect(created.apiKey).toBe('sk-ant-plainkey');
     // ...but the stored document is ciphertext.
-    const raw = await ApiKey.findOne({ userId: 'user-1', type: ApiKeyType.anthropic }).lean();
+    const raw = await ApiKey.findOne({ userId: 'user-encrypt', type: ApiKeyType.anthropic }).lean();
     expect(isEncrypted(raw?.apiKey as string)).toBe(true);
     expect(raw?.apiKey).not.toBe('sk-ant-plainkey');
   });
 
   it('decrypts the key on the read paths consumers use', async () => {
-    await apiKeyRepository.create({ ...base, apiKey: 'sk-ant-readable' });
+    await apiKeyRepository.create({ ...base('user-read'), apiKey: 'sk-ant-readable' });
 
-    const byType = await apiKeyRepository.findByUserIdAndType('user-1', ApiKeyType.anthropic);
+    const byType = await apiKeyRepository.findByUserIdAndType('user-read', ApiKeyType.anthropic);
     expect(byType?.apiKey).toBe('sk-ant-readable');
 
-    const byTypes = await apiKeyRepository.findByUserIdAndTypes('user-1', [ApiKeyType.anthropic]);
+    const byTypes = await apiKeyRepository.findByUserIdAndTypes('user-read', [ApiKeyType.anthropic]);
     expect(byTypes[0]?.apiKey).toBe('sk-ant-readable');
   });
 });

--- a/packages/database/src/models/auth/ApiKeyModel.ts
+++ b/packages/database/src/models/auth/ApiKeyModel.ts
@@ -1,33 +1,64 @@
 import mongoose from 'mongoose';
 import { softDeletePlugin } from '../../utils/mongo';
 import { ApiKeyType, IApiKeyDocument, IApiKeyRepository } from '@bike4mind/common';
+import { decryptAtRest, encryptAtRest } from '@bike4mind/utils';
 import BaseRepository from '@bike4mind/db-core';
 
 interface IApiKeyModel extends mongoose.Model<IApiKeyDocument> {}
+
+/**
+ * Per-user provider keys are stored encrypted at rest. Decrypt on read so callers
+ * (apiKeyService.getApiKey / getEffective*) receive the usable plaintext key; a
+ * not-yet-migrated plaintext value passes through unchanged. Mutates in place.
+ */
+function decryptApiKeyInPlace<T extends { apiKey?: string }>(doc: T): T;
+function decryptApiKeyInPlace<T extends { apiKey?: string }>(doc: T | null): T | null;
+function decryptApiKeyInPlace(doc: { apiKey?: string } | null) {
+  if (doc && typeof doc.apiKey === 'string') {
+    doc.apiKey = decryptAtRest(doc.apiKey);
+  }
+  return doc;
+}
 
 class ApiKeyRepository extends BaseRepository<IApiKeyDocument> implements IApiKeyRepository {
   constructor(model: IApiKeyModel) {
     super(model);
   }
 
+  // Encrypt the provider key at rest on the way in (createApiKey stores through
+  // BaseRepository.create). The returned object echoes the submitted plaintext rather
+  // than the stored ciphertext, preserving the create response shape callers expect.
+  async create(data: Omit<IApiKeyDocument, 'id' | 'updatedAt' | 'createdAt'>) {
+    const stored = await super.create({ ...data, apiKey: encryptAtRest(data.apiKey) });
+    return { ...stored, apiKey: data.apiKey };
+  }
   createe(apiKey: Omit<IApiKeyDocument, 'id' | 'updatedAt' | 'createdAt'>) {
-    return this.model.create(apiKey);
+    return this.model.create({ ...apiKey, apiKey: encryptAtRest(apiKey.apiKey) });
   }
-  findByUserIdAndType(userId: string, type: ApiKeyType) {
-    return this.model.findOne({ userId, type, isActive: true }).exec();
+  async findByUserIdAndType(userId: string, type: ApiKeyType) {
+    const doc = await this.model.findOne({ userId, type, isActive: true }).lean().exec();
+    return decryptApiKeyInPlace(doc as (IApiKeyDocument & { apiKey?: string }) | null);
   }
-  findByUserIdAndTypes(userId: string, types: ApiKeyType[]) {
-    return this.model.find({ userId, type: { $in: types }, isActive: true }).exec();
+  async findByUserIdAndTypes(userId: string, types: ApiKeyType[]) {
+    const result = await this.model
+      .find({ userId, type: { $in: types }, isActive: true })
+      .lean()
+      .exec();
+    return result.map(doc => decryptApiKeyInPlace(doc as IApiKeyDocument & { apiKey?: string }));
   }
-  findByIdAndUserId(id: string, userId: string) {
-    return this.model.findOne({ _id: id, userId });
+  async findByIdAndUserId(id: string, userId: string) {
+    const doc = await this.model.findOne({ _id: id, userId }).lean();
+    return decryptApiKeyInPlace(doc as (IApiKeyDocument & { apiKey?: string }) | null);
   }
+  // Returns a hydrated document (not lean) and does NOT decrypt: setApiKey mutates
+  // isActive on the result and writes it straight back, so the stored apiKey must
+  // stay ciphertext here or the write-back would persist plaintext over it.
   findByIdAndUserIdAndType(id: string, userId: string, type: ApiKeyType) {
     return this.model.findOne({ _id: id, userId, type });
   }
   async findAllByUserId(userId: string) {
     const result = await this.model.find({ userId });
-    return result.map(doc => doc.toJSON());
+    return result.map(doc => decryptApiKeyInPlace(doc.toJSON()));
   }
   updateAllByUserId(userId: string, value: Partial<IApiKeyDocument>) {
     return this.model.updateMany({ userId }, value);

--- a/packages/database/src/models/auth/ApiKeyModel.ts
+++ b/packages/database/src/models/auth/ApiKeyModel.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 import { softDeletePlugin } from '../../utils/mongo';
 import { ApiKeyType, IApiKeyDocument, IApiKeyRepository } from '@bike4mind/common';
-import { decryptAtRest, encryptAtRest, isSecretsAtRestConfigured } from '@bike4mind/utils';
+import { decryptAtRest, encryptAtRest, isSecretsAtRestConfigured } from '@bike4mind/utils/security';
 import BaseRepository from '@bike4mind/db-core';
 
 interface IApiKeyModel extends mongoose.Model<IApiKeyDocument> {}

--- a/packages/database/src/models/auth/ApiKeyModel.ts
+++ b/packages/database/src/models/auth/ApiKeyModel.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 import { softDeletePlugin } from '../../utils/mongo';
 import { ApiKeyType, IApiKeyDocument, IApiKeyRepository } from '@bike4mind/common';
-import { decryptAtRest, encryptAtRest } from '@bike4mind/utils';
+import { decryptAtRest, encryptAtRest, isSecretsAtRestConfigured } from '@bike4mind/utils';
 import BaseRepository from '@bike4mind/db-core';
 
 interface IApiKeyModel extends mongoose.Model<IApiKeyDocument> {}
@@ -28,12 +28,16 @@ class ApiKeyRepository extends BaseRepository<IApiKeyDocument> implements IApiKe
   // Encrypt the provider key at rest on the way in (createApiKey stores through
   // BaseRepository.create). The returned object echoes the submitted plaintext rather
   // than the stored ciphertext, preserving the create response shape callers expect.
+  //
+  // Fail closed in a cloud stage: if no key is configured we must not silently persist a
+  // provider key in plaintext. Only a deliberate self-host install (B4M_SELF_HOST) is allowed
+  // to store plaintext, matching how the rest of the app degrades without SECRET_ENCRYPTION_KEY.
   async create(data: Omit<IApiKeyDocument, 'id' | 'updatedAt' | 'createdAt'>) {
+    if (!isSecretsAtRestConfigured() && process.env.B4M_SELF_HOST !== 'true') {
+      throw new Error('SECRET_ENCRYPTION_KEY is not configured - cannot store a provider API key');
+    }
     const stored = await super.create({ ...data, apiKey: encryptAtRest(data.apiKey) });
     return { ...stored, apiKey: data.apiKey };
-  }
-  createe(apiKey: Omit<IApiKeyDocument, 'id' | 'updatedAt' | 'createdAt'>) {
-    return this.model.create({ ...apiKey, apiKey: encryptAtRest(apiKey.apiKey) });
   }
   async findByUserIdAndType(userId: string, type: ApiKeyType) {
     const doc = await this.model.findOne({ userId, type, isActive: true }).lean().exec();

--- a/packages/database/src/models/auth/ApiKeyModel.ts
+++ b/packages/database/src/models/auth/ApiKeyModel.ts
@@ -34,25 +34,32 @@ class ApiKeyRepository extends BaseRepository<IApiKeyDocument> implements IApiKe
   // to store plaintext, matching how the rest of the app degrades without SECRET_ENCRYPTION_KEY.
   async create(data: Omit<IApiKeyDocument, 'id' | 'updatedAt' | 'createdAt'>) {
     if (!isSecretsAtRestConfigured() && process.env.B4M_SELF_HOST !== 'true') {
-      throw new Error('SECRET_ENCRYPTION_KEY is not configured - cannot store a provider API key');
+      throw new Error(
+        'SECRET_ENCRYPTION_KEY is not configured, refusing to store a provider API key in plaintext. ' +
+          'Set a 64-hex key on this stage (sst secret set SECRET_ENCRYPTION_KEY <value>), or set B4M_SELF_HOST=true to opt into plaintext.'
+      );
     }
     const stored = await super.create({ ...data, apiKey: encryptAtRest(data.apiKey) });
     return { ...stored, apiKey: data.apiKey };
   }
   async findByUserIdAndType(userId: string, type: ApiKeyType) {
-    const doc = await this.model.findOne({ userId, type, isActive: true }).lean().exec();
+    // lean({ virtuals: true }) so the id virtual survives (mongoose-lean-virtuals only fires
+    // with the flag - see packages/database/src/index.ts); callers spread the result.
+    const doc = await this.model.findOne({ userId, type, isActive: true }).lean({ virtuals: true }).exec();
     return decryptApiKeyInPlace(doc as (IApiKeyDocument & { apiKey?: string }) | null);
   }
   async findByUserIdAndTypes(userId: string, types: ApiKeyType[]) {
     const result = await this.model
       .find({ userId, type: { $in: types }, isActive: true })
-      .lean()
+      .lean({ virtuals: true })
       .exec();
     return result.map(doc => decryptApiKeyInPlace(doc as IApiKeyDocument & { apiKey?: string }));
   }
-  async findByIdAndUserId(id: string, userId: string) {
-    const doc = await this.model.findOne({ _id: id, userId }).lean();
-    return decryptApiKeyInPlace(doc as (IApiKeyDocument & { apiKey?: string }) | null);
+  // Consumed only by deleteApiKey, whose result is returned in the DELETE response. Do NOT
+  // decrypt here: that would put a live plaintext provider key in a browser payload (the delete
+  // route strips apiKey regardless). Hydrated (not lean) so the id virtual survives.
+  findByIdAndUserId(id: string, userId: string) {
+    return this.model.findOne({ _id: id, userId });
   }
   // Returns a hydrated document (not lean) and does NOT decrypt: setApiKey mutates
   // isActive on the result and writes it straight back, so the stored apiKey must

--- a/packages/database/src/models/infra/ops/AdminSettingsModel.encryption.test.ts
+++ b/packages/database/src/models/infra/ops/AdminSettingsModel.encryption.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { configureSecretsAtRest, encryptSecret, generateEncryptionKey, isEncrypted } from '@bike4mind/utils';
+import { setupMongoTest } from '../../../__test__/utils';
+import { AdminSettings, adminSettingsRepository } from './AdminSettingsModel';
+
+const KEY = generateEncryptionKey();
+
+describe('AdminSettingsRepository decrypt-on-read', () => {
+  setupMongoTest();
+
+  beforeAll(() => {
+    configureSecretsAtRest(KEY);
+  });
+
+  it('returns decrypted plaintext for a sensitive setting stored as ciphertext', async () => {
+    const plaintext = 'sk-ant-api03-super-secret';
+    await AdminSettings.create({ settingName: 'anthropicDemoKey', settingValue: encryptSecret(plaintext, KEY) });
+
+    const byName = await adminSettingsRepository.findBySettingName('anthropicDemoKey');
+    expect(byName?.settingValue).toBe(plaintext);
+
+    const byNames = await adminSettingsRepository.findBySettingNames(['anthropicDemoKey']);
+    expect(byNames[0]?.settingValue).toBe(plaintext);
+
+    const all = await adminSettingsRepository.findAll();
+    expect(all.find(s => s.settingName === 'anthropicDemoKey')?.settingValue).toBe(plaintext);
+  });
+
+  it('leaves a not-yet-migrated plaintext sensitive value unchanged', async () => {
+    await AdminSettings.create({ settingName: 'openaiDemoKey', settingValue: 'sk-plaintext-legacy' });
+    const setting = await adminSettingsRepository.findBySettingName('openaiDemoKey');
+    expect(setting?.settingValue).toBe('sk-plaintext-legacy');
+  });
+
+  it('does not touch a non-sensitive setting value', async () => {
+    // A non-sensitive value that happens to be a plain string is returned verbatim.
+    await AdminSettings.create({ settingName: 'tagLineMain', settingValue: 'Welcome aboard' });
+    const setting = await adminSettingsRepository.findBySettingName('tagLineMain');
+    expect(setting?.settingValue).toBe('Welcome aboard');
+  });
+
+  it('stores sensitive values as ciphertext (raw model read is not plaintext)', async () => {
+    const plaintext = 'sk-live-should-be-encrypted';
+    await AdminSettings.create({ settingName: 'geminiDemoKey', settingValue: encryptSecret(plaintext, KEY) });
+    const raw = await AdminSettings.findOne({ settingName: 'geminiDemoKey' }).lean();
+    expect(typeof raw?.settingValue).toBe('string');
+    expect(isEncrypted(raw?.settingValue as string)).toBe(true);
+    expect(raw?.settingValue).not.toBe(plaintext);
+  });
+});

--- a/packages/database/src/models/infra/ops/AdminSettingsModel.encryption.test.ts
+++ b/packages/database/src/models/infra/ops/AdminSettingsModel.encryption.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { configureSecretsAtRest, encryptSecret, generateEncryptionKey, isEncrypted } from '@bike4mind/utils';
+import { configureSecretsAtRest, encryptSecret, generateEncryptionKey, isEncrypted } from '@bike4mind/utils/security';
 import { setupMongoTest } from '../../../__test__/utils';
 import { AdminSettings, adminSettingsRepository } from './AdminSettingsModel';
 

--- a/packages/database/src/models/infra/ops/AdminSettingsModel.ts
+++ b/packages/database/src/models/infra/ops/AdminSettingsModel.ts
@@ -56,7 +56,9 @@ class AdminSettingsRepository extends BaseRepository<IAdminSettings> implements 
   }
 
   async findBySettingName(settingName: IAdminSettings['settingName']) {
-    const setting = await this.model.findOne({ settingName }).lean();
+    // lean({ virtuals: true }) keeps the id virtual the prior hydrated toJSON produced
+    // (mongoose-lean-virtuals only fires with the flag - see packages/database/src/index.ts).
+    const setting = await this.model.findOne({ settingName }).lean({ virtuals: true });
     return decryptSettingInPlace(setting as (IAdminSettings & { settingName: string }) | null);
   }
 

--- a/packages/database/src/models/infra/ops/AdminSettingsModel.ts
+++ b/packages/database/src/models/infra/ops/AdminSettingsModel.ts
@@ -1,6 +1,6 @@
 import mongoose, { Model, Schema } from 'mongoose';
 import { IAdminSettings, IAdminSettingsRepository, SettingKey, settingsMap, SettingValue } from '@bike4mind/common';
-import { decryptAtRest } from '@bike4mind/utils';
+import { decryptAtRest } from '@bike4mind/utils/security';
 import { softDeletePlugin } from '../../../utils/mongo';
 import BaseRepository from '@bike4mind/db-core';
 

--- a/packages/database/src/models/infra/ops/AdminSettingsModel.ts
+++ b/packages/database/src/models/infra/ops/AdminSettingsModel.ts
@@ -1,10 +1,29 @@
 import mongoose, { Model, Schema } from 'mongoose';
 import { IAdminSettings, IAdminSettingsRepository, SettingKey, settingsMap, SettingValue } from '@bike4mind/common';
+import { decryptAtRest } from '@bike4mind/utils';
 import { softDeletePlugin } from '../../../utils/mongo';
 import BaseRepository from '@bike4mind/db-core';
 
-interface IAdminSettingsMethods {
+/**
+ * Sensitive setting values are stored encrypted at rest (see apps/client settings/update.ts
+ * and the backfill migration). Decrypt on the way out so server consumers - apiKeyService,
+ * getSettingsMap, the Slack/integration readers - transparently receive plaintext. Gated so
+ * only an isSensitive key whose value is a ciphertext string is touched: sreAgentConfig (an
+ * object, manages its own per-repo secrets) and any not-yet-migrated plaintext value pass
+ * through unchanged. Mutates the passed plain object in place and returns it.
+ */
+function decryptSettingInPlace<T extends { settingName?: string; settingValue?: unknown }>(setting: T): T;
+function decryptSettingInPlace<T extends { settingName?: string; settingValue?: unknown }>(setting: T | null): T | null;
+function decryptSettingInPlace(setting: { settingName?: string; settingValue?: unknown } | null) {
+  if (!setting || typeof setting.settingValue !== 'string') return setting;
+  const definition = settingsMap[setting.settingName as SettingKey] as { isSensitive?: boolean } | undefined;
+  if (definition?.isSensitive) {
+    setting.settingValue = decryptAtRest(setting.settingValue);
+  }
+  return setting;
 }
+
+interface IAdminSettingsMethods {}
 
 interface IAdminSettingsModel extends Model<IAdminSettings, {}, IAdminSettingsMethods> {}
 
@@ -37,25 +56,27 @@ class AdminSettingsRepository extends BaseRepository<IAdminSettings> implements 
   }
 
   async findBySettingName(settingName: IAdminSettings['settingName']) {
-    return this.model.findOne({ settingName });
+    const setting = await this.model.findOne({ settingName }).lean();
+    return decryptSettingInPlace(setting as (IAdminSettings & { settingName: string }) | null);
   }
 
   async findBySettingNames(settingNames: IAdminSettings['settingName'][]) {
     const result = await this.model.find({ settingName: { $in: settingNames } });
-    return result.map(r => r.toJSON());
+    return result.map(r => decryptSettingInPlace(r.toJSON()));
   }
 
   async findAllByTag(tag: string) {
     const result = await this.model.find({ tags: { $in: [tag] } });
-    return result.map(r => r.toJSON());
+    return result.map(r => decryptSettingInPlace(r.toJSON()));
   }
 
   async findAll() {
-    return this.model.find();
+    const result = await this.model.find();
+    return result.map(r => decryptSettingInPlace(r.toJSON()));
   }
 
   async getSettingsValue<K extends SettingKey>(settingName: K): Promise<SettingValue<K> | undefined> {
-    const setting = await this.findOne({ settingName });
+    const setting = decryptSettingInPlace(await this.findOne({ settingName }));
     const value = settingsMap?.[settingName]?.schema?.safeParse(setting?.settingValue);
 
     if (value.success) {

--- a/packages/database/src/priceCatalogBootstrap.secretsAtRest.test.ts
+++ b/packages/database/src/priceCatalogBootstrap.secretsAtRest.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { configureSecretsAtRest, decryptAtRest, encryptSecret, generateEncryptionKey } from '@bike4mind/utils';
+
+const KEY = generateEncryptionKey();
+
+// Stand in for the SST runtime so this test proves the connectDB seam can source the key
+// from Resource - the path a scripts/cron process (which never imports apps/client Config) takes.
+vi.mock('sst', () => ({
+  Resource: {
+    SECRET_ENCRYPTION_KEY: { value: KEY },
+    SECRET_ENCRYPTION_KEY_PREVIOUS: { value: undefined },
+    App: { stage: 'test' },
+  },
+}));
+
+describe('connectDB seam registers the at-rest key from SST resources', () => {
+  beforeEach(() => {
+    // Simulate a fresh process that has NOT imported @server/utils/config: no key registered.
+    configureSecretsAtRest(undefined);
+  });
+
+  it('lets a config-less process decrypt a stored sensitive value after the seam runs', async () => {
+    const cipher = encryptSecret('sk-secret-from-a-script', KEY);
+
+    // Before the seam runs this is the P1 gap: unconfigured -> ciphertext returned as-is.
+    expect(decryptAtRest(cipher)).toBe(cipher);
+
+    const { configureSecretsAtRestFromResource } = await import('./priceCatalogBootstrap');
+    configureSecretsAtRestFromResource();
+
+    // The seam sourced the key from Resource, so the same module-scoped state now decrypts.
+    expect(decryptAtRest(cipher)).toBe('sk-secret-from-a-script');
+  });
+});

--- a/packages/database/src/priceCatalogBootstrap.secretsAtRest.test.ts
+++ b/packages/database/src/priceCatalogBootstrap.secretsAtRest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { configureSecretsAtRest, decryptAtRest, encryptSecret, generateEncryptionKey } from '@bike4mind/utils';
+import { configureSecretsAtRest, decryptAtRest, encryptSecret, generateEncryptionKey } from '@bike4mind/utils/security';
 
 const KEY = generateEncryptionKey();
 

--- a/packages/database/src/priceCatalogBootstrap.secretsAtRest.test.ts
+++ b/packages/database/src/priceCatalogBootstrap.secretsAtRest.test.ts
@@ -22,8 +22,9 @@ describe('connectDB seam registers the at-rest key from SST resources', () => {
   it('lets a config-less process decrypt a stored sensitive value after the seam runs', async () => {
     const cipher = encryptSecret('sk-secret-from-a-script', KEY);
 
-    // Before the seam runs this is the P1 gap: unconfigured -> ciphertext returned as-is.
-    expect(decryptAtRest(cipher)).toBe(cipher);
+    // Before the seam runs this is the P1 gap: unconfigured, so it cannot decrypt and
+    // returns '' (never the raw ciphertext).
+    expect(decryptAtRest(cipher)).toBe('');
 
     const { configureSecretsAtRestFromResource } = await import('./priceCatalogBootstrap');
     configureSecretsAtRestFromResource();

--- a/packages/database/src/priceCatalogBootstrap.ts
+++ b/packages/database/src/priceCatalogBootstrap.ts
@@ -1,6 +1,6 @@
 import { connectDB as baseConnectDB } from '@bike4mind/db-core';
 import { setModelCatalogProvider, setModelPriceRowsProvider } from '@bike4mind/llm-adapters';
-import { configureSecretsAtRest } from '@bike4mind/utils';
+import { configureSecretsAtRest } from '@bike4mind/utils/security';
 import { Resource } from 'sst';
 import { modelPriceRepository } from './models/billing/ModelPriceModel';
 import { ModelCatalog, modelCatalogRepository } from './models/ai/ModelCatalogModel';

--- a/packages/database/src/priceCatalogBootstrap.ts
+++ b/packages/database/src/priceCatalogBootstrap.ts
@@ -1,5 +1,7 @@
 import { connectDB as baseConnectDB } from '@bike4mind/db-core';
 import { setModelCatalogProvider, setModelPriceRowsProvider } from '@bike4mind/llm-adapters';
+import { configureSecretsAtRest } from '@bike4mind/utils';
+import { Resource } from 'sst';
 import { modelPriceRepository } from './models/billing/ModelPriceModel';
 import { ModelCatalog, modelCatalogRepository } from './models/ai/ModelCatalogModel';
 import { ModelDiscoveryState } from './models/ai/ModelDiscoveryStateModel';
@@ -9,6 +11,30 @@ import { seedModelPrices } from './seeds/seedModelPrices';
 
 let catalogWired = false;
 let catalogSeedSettled: Promise<boolean> | null = null;
+let secretsAtRestConfigured = false;
+
+/** Guarded read: an unlinked/unprovisioned SST secret throws in the getter itself. */
+function readSecretFromResource(name: string): string | undefined {
+  try {
+    return (Resource as unknown as Record<string, { value?: string } | undefined>)[name]?.value;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Register the at-rest encryption key from SST resources. Wiring this into connectDB (rather
+ * than a single apps/client module) is what lets EVERY process that reaches Mongo decrypt
+ * sensitive settings and per-user keys - API routes, queue/cron handlers, AND the
+ * packages/scripts CLIs, which never import apps/client's Config. Idempotent and safe to call
+ * with no key configured (reads then degrade to plaintext passthrough). Exported for tests.
+ */
+export function configureSecretsAtRestFromResource(): void {
+  configureSecretsAtRest(
+    readSecretFromResource('SECRET_ENCRYPTION_KEY'),
+    readSecretFromResource('SECRET_ENCRYPTION_KEY_PREVIOUS')
+  );
+}
 
 /**
  * Resolves once the boot-time catalog seed has settled, to whether the CATALOG
@@ -117,6 +143,10 @@ async function seedCatalogs(): Promise<boolean> {
  */
 export const connectDB: typeof baseConnectDB = async (url, logger) => {
   const result = await baseConnectDB(url, logger);
+  if (!secretsAtRestConfigured) {
+    secretsAtRestConfigured = true;
+    configureSecretsAtRestFromResource();
+  }
   if (!catalogWired) {
     catalogWired = true;
     setModelCatalogProvider(() => modelCatalogRepository.rowsInForce());

--- a/packages/scripts/migrate/encrypt-admin-settings-and-apikeys.ts
+++ b/packages/scripts/migrate/encrypt-admin-settings-and-apikeys.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env tsx
+
+/**
+ * Migration: Encrypt Admin Settings + Per-User API Keys at Rest
+ *
+ * Encrypts plaintext secrets stored in MongoDB using AES-256-GCM, matching the
+ * decrypt-on-read the repositories now perform:
+ *   - adminsettings: settingValue of every `isSensitive` setting (settingsMap)
+ *   - apikeys: the per-user provider `apiKey` field
+ *
+ * Safety:
+ *   - Uses isEncrypted() to skip already-encrypted values (idempotent, re-runnable)
+ *   - Skips masked placeholders (values starting with the sensitive-setting mask), which
+ *     are display artifacts, never real secrets
+ *   - Only touches string values (sreAgentConfig is an object and manages its own
+ *     per-repo secrets; it is not isSensitive and is skipped here)
+ *   - Atomic per-document updates
+ *   - --dry-run mode makes no writes
+ *   - --reencrypt rotates values from SECRET_ENCRYPTION_KEY_PREVIOUS to SECRET_ENCRYPTION_KEY
+ *
+ * Usage:
+ *   pnpm --filter scripts migrate:encrypt-admin-secrets -- --dry-run
+ *   pnpm --filter scripts migrate:encrypt-admin-secrets
+ *   pnpm --filter scripts migrate:encrypt-admin-secrets -- --reencrypt
+ */
+
+import { connectDB } from '@bike4mind/database';
+import { settingsMap, SENSITIVE_SETTING_MASK } from '@bike4mind/common';
+import { decryptSecret, encryptSecret, isEncrypted, isValidEncryptionKey } from '@bike4mind/utils';
+import { Resource } from 'sst';
+import mongoose from 'mongoose';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const REENCRYPT = process.argv.includes('--reencrypt');
+
+interface MigrationStats {
+  collection: string;
+  scanned: number;
+  encrypted: number;
+  skipped: number;
+  errors: number;
+}
+
+function getResource(name: string): string | undefined {
+  return (Resource as unknown as Record<string, { value?: string }>)[name]?.value;
+}
+
+/** Setting keys tagged isSensitive - the only adminsettings values we encrypt. */
+const SENSITIVE_SETTING_KEYS = new Set(
+  Object.entries(settingsMap)
+    .filter(([, def]) => (def as { isSensitive?: boolean })?.isSensitive === true)
+    .map(([key]) => key)
+);
+
+/**
+ * Normal mode: encrypt plaintext, skip already-encrypted (returns null).
+ * Reencrypt mode: decrypt with the old key and re-encrypt with the new key.
+ * Returns null when there is nothing to do, or 'error' when a value cannot be recovered.
+ */
+function encryptIfNeeded(value: unknown, newKey: string, oldKey?: string): string | null | 'error' {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  // A masked display value is never a real secret - never persist it.
+  if (value.startsWith(SENSITIVE_SETTING_MASK)) return null;
+
+  if (REENCRYPT && oldKey) {
+    if (!isEncrypted(value)) return null;
+    try {
+      decryptSecret(value, newKey);
+      return null; // already under the new key
+    } catch {
+      /* not the new key - fall through to rotate */
+    }
+    try {
+      return encryptSecret(decryptSecret(value, oldKey), newKey);
+    } catch (err) {
+      console.error(
+        '    ERROR: value could not be decrypted with either key:',
+        err instanceof Error ? err.message : err
+      );
+      return 'error';
+    }
+  }
+
+  if (isEncrypted(value)) return null; // already encrypted
+  return encryptSecret(value, newKey);
+}
+
+async function migrateAdminSettings(db: mongoose.mongo.Db, key: string, oldKey?: string): Promise<MigrationStats> {
+  const stats: MigrationStats = { collection: 'adminsettings', scanned: 0, encrypted: 0, skipped: 0, errors: 0 };
+  const collection = db.collection('adminsettings');
+
+  const cursor = collection.find({ settingName: { $in: Array.from(SENSITIVE_SETTING_KEYS) } });
+  for await (const doc of cursor) {
+    stats.scanned++;
+    const next = encryptIfNeeded(doc.settingValue, key, oldKey);
+    if (next === 'error') {
+      console.error(`  ERROR AdminSetting ${doc.settingName}: failed to decrypt`);
+      stats.errors++;
+      continue;
+    }
+    if (!next) {
+      stats.skipped++;
+      continue;
+    }
+    console.log(`  AdminSetting ${doc.settingName}: ${REENCRYPT ? 're-encrypting' : 'encrypting'}`);
+    if (!DRY_RUN) {
+      try {
+        await collection.updateOne({ _id: doc._id }, { $set: { settingValue: next } });
+        stats.encrypted++;
+      } catch (err) {
+        console.error(`  ERROR AdminSetting ${doc.settingName}:`, err);
+        stats.errors++;
+      }
+    } else {
+      stats.encrypted++;
+    }
+  }
+  return stats;
+}
+
+async function migrateApiKeys(db: mongoose.mongo.Db, key: string, oldKey?: string): Promise<MigrationStats> {
+  const stats: MigrationStats = { collection: 'apikeys', scanned: 0, encrypted: 0, skipped: 0, errors: 0 };
+  const collection = db.collection('apikeys');
+
+  const cursor = collection.find({ apiKey: { $exists: true, $ne: '' } });
+  for await (const doc of cursor) {
+    stats.scanned++;
+    const next = encryptIfNeeded(doc.apiKey, key, oldKey);
+    if (next === 'error') {
+      console.error(`  ERROR ApiKey ${doc._id}: failed to decrypt`);
+      stats.errors++;
+      continue;
+    }
+    if (!next) {
+      stats.skipped++;
+      continue;
+    }
+    console.log(`  ApiKey ${doc._id} (${doc.type}): ${REENCRYPT ? 're-encrypting' : 'encrypting'}`);
+    if (!DRY_RUN) {
+      try {
+        await collection.updateOne({ _id: doc._id }, { $set: { apiKey: next } });
+        stats.encrypted++;
+      } catch (err) {
+        console.error(`  ERROR ApiKey ${doc._id}:`, err);
+        stats.errors++;
+      }
+    } else {
+      stats.encrypted++;
+    }
+  }
+  return stats;
+}
+
+async function run() {
+  const encryptionKey = getResource('SECRET_ENCRYPTION_KEY');
+  if (!encryptionKey || !isValidEncryptionKey(encryptionKey)) {
+    console.error('SECRET_ENCRYPTION_KEY is not configured or is not 64 hex characters');
+    process.exit(1);
+  }
+
+  let previousKey: string | undefined;
+  if (REENCRYPT) {
+    previousKey = getResource('SECRET_ENCRYPTION_KEY_PREVIOUS');
+    if (!previousKey || !isValidEncryptionKey(previousKey) || previousKey === 'not-configured') {
+      console.error('--reencrypt requires SECRET_ENCRYPTION_KEY_PREVIOUS to be set to the old key');
+      process.exit(1);
+    }
+  }
+
+  const mongoURI = (getResource('MONGODB_URI') ?? process.env.MONGODB_URI ?? '').replace('%STAGE%', Resource.App.stage);
+
+  console.log('\n=== Admin Settings + API Key Encryption Migration ===');
+  console.log(`Stage: ${Resource.App.stage}`);
+  let mode = 'LIVE';
+  if (DRY_RUN) mode = 'DRY RUN (no changes)';
+  else if (REENCRYPT) mode = 'RE-ENCRYPT (key rotation)';
+  console.log(`Mode: ${mode}\n`);
+
+  await connectDB(mongoURI);
+  const db = mongoose.connection.db!;
+
+  const allStats: MigrationStats[] = [];
+  allStats.push(await migrateAdminSettings(db, encryptionKey, previousKey));
+  allStats.push(await migrateApiKeys(db, encryptionKey, previousKey));
+
+  console.log('\n=== Migration Summary ===');
+  for (const stats of allStats) {
+    console.log(
+      `  ${stats.collection}: ${stats.encrypted} encrypted, ${stats.skipped} skipped, ${stats.errors} errors (${stats.scanned} scanned)`
+    );
+  }
+
+  const totalEncrypted = allStats.reduce((sum, s) => sum + s.encrypted, 0);
+  const totalErrors = allStats.reduce((sum, s) => sum + s.errors, 0);
+  console.log(`\n  Total: ${totalEncrypted} fields encrypted, ${totalErrors} errors`);
+  if (DRY_RUN) console.log('  (DRY RUN - no changes written)\n');
+
+  process.exit(totalErrors > 0 ? 1 : 0);
+}
+
+run().catch(err => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});

--- a/packages/scripts/migrate/encrypt-admin-settings-and-apikeys.ts
+++ b/packages/scripts/migrate/encrypt-admin-settings-and-apikeys.ts
@@ -26,7 +26,7 @@
 
 import { connectDB } from '@bike4mind/database';
 import { settingsMap, SENSITIVE_SETTING_MASK } from '@bike4mind/common';
-import { decryptSecret, encryptSecret, isEncrypted, isValidEncryptionKey } from '@bike4mind/utils';
+import { decryptSecret, encryptSecret, isEncrypted, isValidEncryptionKey } from '@bike4mind/utils/security';
 import { Resource } from 'sst';
 import mongoose from 'mongoose';
 

--- a/packages/scripts/migrate/encrypt-admin-settings-and-apikeys.ts
+++ b/packages/scripts/migrate/encrypt-admin-settings-and-apikeys.ts
@@ -17,11 +17,30 @@
  *   - Atomic per-document updates
  *   - --dry-run mode makes no writes
  *   - --reencrypt rotates values from SECRET_ENCRYPTION_KEY_PREVIOUS to SECRET_ENCRYPTION_KEY
+ *   - --decrypt reverses this migration (ciphertext -> plaintext), the inverse used to roll
+ *     back past it (see below). Mutually exclusive with --reencrypt.
+ *
+ * Rollback / deploy order:
+ *   This migration is NOT self-reversing. Old code that predates decrypt-on-read reads the
+ *   iv:authTag:ciphertext blob as a live credential, so rolling the app back past this change
+ *   while the data is encrypted breaks Slack signature checks, demo-key inference, OAuth, etc.
+ *   The ciphertext is not destroyed (recovery is roll-forward, not a DB restore), but if you
+ *   must run older code against this data, run `--decrypt` first to return the rows to plaintext.
+ *
+ * Coverage (rotation caveat): --reencrypt / --decrypt only touch `adminsettings` and
+ *   `apikeys`. Other at-rest ciphertext stores - UserModel accessToken/refreshToken,
+ *   OverwatchSocialConnectionModel, SRE per-repo secrets - are NOT covered here, so
+ *   SECRET_ENCRYPTION_KEY_PREVIOUS must remain configured after any rotation; dropping it
+ *   silently blanks those uncovered stores on read.
+ *
+ * Config is read from SST resources (run under `sst shell`); MONGODB_URI falls back to the
+ * process env when not linked.
  *
  * Usage:
  *   pnpm --filter scripts migrate:encrypt-admin-secrets -- --dry-run
  *   pnpm --filter scripts migrate:encrypt-admin-secrets
  *   pnpm --filter scripts migrate:encrypt-admin-secrets -- --reencrypt
+ *   pnpm --filter scripts migrate:encrypt-admin-secrets -- --decrypt
  */
 
 import { connectDB } from '@bike4mind/database';
@@ -32,6 +51,7 @@ import mongoose from 'mongoose';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const REENCRYPT = process.argv.includes('--reencrypt');
+const DECRYPT = process.argv.includes('--decrypt');
 
 interface MigrationStats {
   collection: string;
@@ -41,8 +61,28 @@ interface MigrationStats {
   errors: number;
 }
 
+// Gerund + past tense used in the per-document progress logs and the summary.
+const ACTION_VERB = DECRYPT ? 'decrypting' : REENCRYPT ? 're-encrypting' : 'encrypting';
+const ACTION_PAST = DECRYPT ? 'decrypted' : REENCRYPT ? 're-encrypted' : 'encrypted';
+
+// Guarded read: an unlinked/unprovisioned SST secret throws in the getter itself, so a bare
+// `Resource[name]?.value` never falls through to a `?? process.env` arm. Matches the reader in
+// packages/database/src/priceCatalogBootstrap.ts.
 function getResource(name: string): string | undefined {
-  return (Resource as unknown as Record<string, { value?: string }>)[name]?.value;
+  try {
+    return (Resource as unknown as Record<string, { value?: string } | undefined>)[name]?.value;
+  } catch {
+    return undefined;
+  }
+}
+
+// Resource.App also throws when the script runs outside `sst shell`; fall back to the seed env.
+function getStage(): string {
+  try {
+    return Resource.App.stage;
+  } catch {
+    return process.env.SEED_STAGE_NAME ?? process.env.STAGE ?? '';
+  }
 }
 
 /** Setting keys tagged isSensitive - the only adminsettings values we encrypt. */
@@ -53,14 +93,31 @@ const SENSITIVE_SETTING_KEYS = new Set(
 );
 
 /**
- * Normal mode: encrypt plaintext, skip already-encrypted (returns null).
- * Reencrypt mode: decrypt with the old key and re-encrypt with the new key.
- * Returns null when there is nothing to do, or 'error' when a value cannot be recovered.
+ * Compute the new stored value for one field, or null when there is nothing to do.
+ * - Normal mode: encrypt plaintext; already-encrypted -> null (skip).
+ * - --reencrypt: decrypt with the old key and re-encrypt with the new; already-new -> null.
+ * - --decrypt: ciphertext -> plaintext (the inverse, for rolling back past this migration);
+ *   already-plaintext -> null.
+ * Returns 'error' when a ciphertext value cannot be recovered with the available key(s).
  */
-function encryptIfNeeded(value: unknown, newKey: string, oldKey?: string): string | null | 'error' {
+function transformIfNeeded(value: unknown, newKey: string, oldKey?: string): string | null | 'error' {
   if (typeof value !== 'string' || value.length === 0) return null;
   // A masked display value is never a real secret - never persist it.
   if (value.startsWith(SENSITIVE_SETTING_MASK)) return null;
+
+  if (DECRYPT) {
+    if (!isEncrypted(value)) return null; // already plaintext
+    for (const key of [newKey, oldKey]) {
+      if (!key) continue;
+      try {
+        return decryptSecret(value, key);
+      } catch {
+        /* try the next key (rotation) before giving up */
+      }
+    }
+    console.error('    ERROR: value could not be decrypted with either key');
+    return 'error';
+  }
 
   if (REENCRYPT && oldKey) {
     if (!isEncrypted(value)) return null;
@@ -92,17 +149,17 @@ async function migrateAdminSettings(db: mongoose.mongo.Db, key: string, oldKey?:
   const cursor = collection.find({ settingName: { $in: Array.from(SENSITIVE_SETTING_KEYS) } });
   for await (const doc of cursor) {
     stats.scanned++;
-    const next = encryptIfNeeded(doc.settingValue, key, oldKey);
+    const next = transformIfNeeded(doc.settingValue, key, oldKey);
     if (next === 'error') {
       console.error(`  ERROR AdminSetting ${doc.settingName}: failed to decrypt`);
       stats.errors++;
       continue;
     }
-    if (!next) {
+    if (next === null) {
       stats.skipped++;
       continue;
     }
-    console.log(`  AdminSetting ${doc.settingName}: ${REENCRYPT ? 're-encrypting' : 'encrypting'}`);
+    console.log(`  AdminSetting ${doc.settingName}: ${ACTION_VERB}`);
     if (!DRY_RUN) {
       try {
         await collection.updateOne({ _id: doc._id }, { $set: { settingValue: next } });
@@ -125,17 +182,17 @@ async function migrateApiKeys(db: mongoose.mongo.Db, key: string, oldKey?: strin
   const cursor = collection.find({ apiKey: { $exists: true, $ne: '' } });
   for await (const doc of cursor) {
     stats.scanned++;
-    const next = encryptIfNeeded(doc.apiKey, key, oldKey);
+    const next = transformIfNeeded(doc.apiKey, key, oldKey);
     if (next === 'error') {
       console.error(`  ERROR ApiKey ${doc._id}: failed to decrypt`);
       stats.errors++;
       continue;
     }
-    if (!next) {
+    if (next === null) {
       stats.skipped++;
       continue;
     }
-    console.log(`  ApiKey ${doc._id} (${doc.type}): ${REENCRYPT ? 're-encrypting' : 'encrypting'}`);
+    console.log(`  ApiKey ${doc._id} (${doc.type}): ${ACTION_VERB}`);
     if (!DRY_RUN) {
       try {
         await collection.updateOne({ _id: doc._id }, { $set: { apiKey: next } });
@@ -152,26 +209,34 @@ async function migrateApiKeys(db: mongoose.mongo.Db, key: string, oldKey?: strin
 }
 
 async function run() {
+  if (REENCRYPT && DECRYPT) {
+    console.error('Pass at most one of --reencrypt or --decrypt');
+    process.exit(1);
+  }
+
   const encryptionKey = getResource('SECRET_ENCRYPTION_KEY');
   if (!encryptionKey || !isValidEncryptionKey(encryptionKey)) {
     console.error('SECRET_ENCRYPTION_KEY is not configured or is not 64 hex characters');
     process.exit(1);
   }
 
-  let previousKey: string | undefined;
-  if (REENCRYPT) {
-    previousKey = getResource('SECRET_ENCRYPTION_KEY_PREVIOUS');
-    if (!previousKey || !isValidEncryptionKey(previousKey) || previousKey === 'not-configured') {
-      console.error('--reencrypt requires SECRET_ENCRYPTION_KEY_PREVIOUS to be set to the old key');
-      process.exit(1);
-    }
+  // Load the previous key best-effort: --reencrypt requires it (to decrypt old ciphertext),
+  // --decrypt uses it as a second decrypt candidate when a value is still under the old key.
+  let previousKey = getResource('SECRET_ENCRYPTION_KEY_PREVIOUS');
+  if (previousKey && (!isValidEncryptionKey(previousKey) || previousKey === 'not-configured')) {
+    previousKey = undefined;
+  }
+  if (REENCRYPT && !previousKey) {
+    console.error('--reencrypt requires SECRET_ENCRYPTION_KEY_PREVIOUS to be set to the old key');
+    process.exit(1);
   }
 
-  const mongoURI = (getResource('MONGODB_URI') ?? process.env.MONGODB_URI ?? '').replace('%STAGE%', Resource.App.stage);
+  const stage = getStage();
+  const mongoURI = (getResource('MONGODB_URI') ?? process.env.MONGODB_URI ?? '').replace('%STAGE%', stage);
 
   console.log('\n=== Admin Settings + API Key Encryption Migration ===');
-  console.log(`Stage: ${Resource.App.stage}`);
-  const action = REENCRYPT ? 'RE-ENCRYPT (key rotation)' : 'ENCRYPT';
+  console.log(`Stage: ${stage}`);
+  const action = DECRYPT ? 'DECRYPT (rollback to plaintext)' : REENCRYPT ? 'RE-ENCRYPT (key rotation)' : 'ENCRYPT';
   const mode = DRY_RUN ? `DRY RUN - ${action} (no changes)` : `LIVE - ${action}`;
   console.log(`Mode: ${mode}\n`);
 
@@ -185,13 +250,13 @@ async function run() {
   console.log('\n=== Migration Summary ===');
   for (const stats of allStats) {
     console.log(
-      `  ${stats.collection}: ${stats.encrypted} encrypted, ${stats.skipped} skipped, ${stats.errors} errors (${stats.scanned} scanned)`
+      `  ${stats.collection}: ${stats.encrypted} ${ACTION_PAST}, ${stats.skipped} skipped, ${stats.errors} errors (${stats.scanned} scanned)`
     );
   }
 
   const totalEncrypted = allStats.reduce((sum, s) => sum + s.encrypted, 0);
   const totalErrors = allStats.reduce((sum, s) => sum + s.errors, 0);
-  console.log(`\n  Total: ${totalEncrypted} fields encrypted, ${totalErrors} errors`);
+  console.log(`\n  Total: ${totalEncrypted} fields ${ACTION_PAST}, ${totalErrors} errors`);
   if (DRY_RUN) console.log('  (DRY RUN - no changes written)\n');
 
   process.exit(totalErrors > 0 ? 1 : 0);

--- a/packages/scripts/migrate/encrypt-admin-settings-and-apikeys.ts
+++ b/packages/scripts/migrate/encrypt-admin-settings-and-apikeys.ts
@@ -171,9 +171,8 @@ async function run() {
 
   console.log('\n=== Admin Settings + API Key Encryption Migration ===');
   console.log(`Stage: ${Resource.App.stage}`);
-  let mode = 'LIVE';
-  if (DRY_RUN) mode = 'DRY RUN (no changes)';
-  else if (REENCRYPT) mode = 'RE-ENCRYPT (key rotation)';
+  const action = REENCRYPT ? 'RE-ENCRYPT (key rotation)' : 'ENCRYPT';
+  const mode = DRY_RUN ? `DRY RUN - ${action} (no changes)` : `LIVE - ${action}`;
   console.log(`Mode: ${mode}\n`);
 
   await connectDB(mongoURI);

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -43,6 +43,7 @@
     "help:regenerate": "pnpm help:build-index && pnpm help:bundle-content && pnpm help:vectorize",
     "test:seed-context-summary": "tsx seedContextSummary.ts",
     "migrate:encrypt-tokens": "tsx migrate/encrypt-tokens-at-rest.ts",
+    "migrate:encrypt-admin-secrets": "tsx migrate/encrypt-admin-settings-and-apikeys.ts",
     "backfill:pending-free-credits": "tsx backfillPendingFreeCredits.ts",
     "backfill:fabfile-moderation-status": "tsx src/backfill-fabfile-moderation-status.ts",
     "tavern:upload-icons": "tsx src/uploadTavernIcons.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1996,6 +1996,9 @@ importers:
       mongoose-lean-virtuals:
         specifier: ^2.1.0
         version: 2.1.0(mongoose@8.24.1(@aws-sdk/credential-providers@3.1050.0)(socks@2.8.6))
+      sst:
+        specifier: 4.17.1
+        version: 4.17.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2249,6 +2252,10 @@ packages:
     resolution: {integrity: sha512-9XmVmMTBfxJdFz+aM/jtNKer967q6wHVyBbUAsy1obgJnG28IXafHwhIjkZG5ZS3N3frb5Y7T/xpqJLtUJFksA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-lambda@3.1061.0':
+    resolution: {integrity: sha512-xsGBwa5Fyhe5bPRpa6dSu9TOQw9QddSUbytIyKQHabY1tm4BT9DSTR81neIFWxXz0UHoDq3qGLcOZdFiS9yiZg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-lambda@3.1080.0':
     resolution: {integrity: sha512-rTitNyvjgBrJzjDkzLRcLi1QcxSomomLRjhYXJWID97uaw1uxtmer8wOVi8l6UFxzlRVa83laZ3srAeWRs509A==}
     engines: {node: '>=20.0.0'}
@@ -2285,6 +2292,10 @@ packages:
     resolution: {integrity: sha512-p0KNL2GnwlORVD9uW9/uyLrYuQlQyiJcL7J139AdJ6yiXCMjJJU6FsrgP6HPlBtHcAAPzlcZsdq8ouLsCvGz9w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.17':
+    resolution: {integrity: sha512-r8o4h2K7j6P9ngno+8ei0aK0U/4JwDb7A2fMMxGVoSqDN8AFlIzSDeZHME9LcVLR2codyhtr1WAAg+/nmkeeMA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.28':
     resolution: {integrity: sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==}
     engines: {node: '>=20.0.0'}
@@ -2301,6 +2312,10 @@ packages:
     resolution: {integrity: sha512-i4HTkP21eHaXA+XKoc6dYxlKPvYUqbusGGIsFRcSGTF8ln/q6RrWoRdVJ6UVODTCW59Ot1mVcbJXRAEf6kxa3w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.43':
+    resolution: {integrity: sha512-g0XVQKzaA/4cq1vz1IvCQwYM+1Pkv01J9yHDpCTXekVuGZRDEz0wqBQ1AuYTq7FM6uik4uBGH8Tb5d9YvgeA7g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.54':
     resolution: {integrity: sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==}
     engines: {node: '>=20.0.0'}
@@ -2311,6 +2326,10 @@ packages:
 
   '@aws-sdk/credential-provider-env@3.972.67':
     resolution: {integrity: sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.45':
+    resolution: {integrity: sha512-w9PuOoKCt6+xoESvY+zlV0u3PKQ0mVL259PcsVR6a3S/uYJJHnIi4r1NxdJHEcNldUVRIciltWnFMGBR4YEm3g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.56':
@@ -2325,6 +2344,10 @@ packages:
     resolution: {integrity: sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.48':
+    resolution: {integrity: sha512-+6BQ6Lrnc+EyAGElLRW6j+Sa+RirPHnIJsobvYO6nnyK+oGKmz1ne/ieclbLWyjyDKEU3/JVJWcWY3VLFPvGtQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.61':
     resolution: {integrity: sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==}
     engines: {node: '>=20.0.0'}
@@ -2335,6 +2358,10 @@ packages:
 
   '@aws-sdk/credential-provider-ini@3.973.12':
     resolution: {integrity: sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.47':
+    resolution: {integrity: sha512-Iy2ebWVgrZBH05464uJiQYu6HSSiROnwVZptthEFXx2gWjo1ORCxEAFZB5Cr2MdfrSnZ+0QUPkZ1ZpCqpkUrLQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.60':
@@ -2349,6 +2376,10 @@ packages:
     resolution: {integrity: sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.50':
+    resolution: {integrity: sha512-b05Aelq5cqAvCCDQjCYacl0XmR8QhBNSqLbsdISkQmlQBa5oPS66zYPteWcSp5LswbpoIe552EUGjluKiadBig==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.63':
     resolution: {integrity: sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==}
     engines: {node: '>=20.0.0'}
@@ -2359,6 +2390,10 @@ packages:
 
   '@aws-sdk/credential-provider-node@3.972.73':
     resolution: {integrity: sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.43':
+    resolution: {integrity: sha512-GPokLNyvTfCmuaHk+v3GKVs4ZT3cMu5kgS2a+NPkOMt96cq6fSIK0g+mZHpGS6Cd4QGrPKesANEaLUKgOskTzg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.54':
@@ -2373,6 +2408,10 @@ packages:
     resolution: {integrity: sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.47':
+    resolution: {integrity: sha512-0AzvLrzlvJs0DzbeWGvNj+bX3Uzd7VNS6vDqCOdZzBlCGKGd78uxctJSW9iK/Rt/nxiJqpTvrYQlVJ4guVM2Dw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.60':
     resolution: {integrity: sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==}
     engines: {node: '>=20.0.0'}
@@ -2383,6 +2422,10 @@ packages:
 
   '@aws-sdk/credential-provider-sso@3.973.11':
     resolution: {integrity: sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.47':
+    resolution: {integrity: sha512-eksfbUErOejUAGWBAcNqaP7IX21oUOEo73d9R56k9Ua4d57qS90NEYkWJsuSGzTXMFulCu17qXJI/qGmM7hvoA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.60':
@@ -2425,6 +2468,10 @@ packages:
     resolution: {integrity: sha512-BD8tYKNAc8dyN7q4NU1wsA1ZgRTBAjbqH04I5SfoqJaOmwlUab6AI7GRapSt8fxf9sq3GyAhioK0qHLCTnuZ9A==}
     engines: {node: '>= 14.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.15':
+    resolution: {integrity: sha512-Fpri1/PXKMKveORZ7E00VLTlWS5DkfZkW70PUE+bOnpWpAeHAQLoiDHhkzN3kNWbbSsGg64+IZYiq/EZgME3Mg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.997.28':
     resolution: {integrity: sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==}
     engines: {node: '>=20.0.0'}
@@ -2445,6 +2492,10 @@ packages:
     resolution: {integrity: sha512-htvnMiDGioaV5zOEkXi6EBI6md1s2tYVD/h3ihAhvpJpZZ3bS6xsfq313IK8orMi7LpOWIT3ha1fPgXrhc+TCA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.31':
+    resolution: {integrity: sha512-Kn2up9SlG1KC6wRtwf0d7waTGF6rvp9DxYqB54x6UCKdQ6kyaXCqHL4WGb5vUJga5kS8FxnjhY0LqM28aMvnNQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.38':
     resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
     engines: {node: '>=20.0.0'}
@@ -2455,6 +2506,10 @@ packages:
 
   '@aws-sdk/signature-v4-multi-region@3.996.43':
     resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1060.0':
+    resolution: {integrity: sha512-6NZaMKkFhpaNiwLpHi1sZaYjidL/lCJE6ME6NxwA8gv9vQna+Kr0j4OFwVoz6tANRWM3WbGz6jiPsGX/Vkjwow==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1080.0':
@@ -2469,6 +2524,10 @@ packages:
     resolution: {integrity: sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/types@3.973.10':
+    resolution: {integrity: sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.15':
     resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
     engines: {node: '>=20.0.0'}
@@ -2481,8 +2540,8 @@ packages:
     resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-locate-window@3.965.8':
-    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+  '@aws-sdk/util-locate-window@3.965.4':
+    resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.33':
@@ -2501,6 +2560,10 @@ packages:
     resolution: {integrity: sha512-KIYBVqV9gArkWdPEDYOjJqLlO+NecmCXOXadNBlOspJTmqztwuiyb6aZc468bYWSGuL4Me/gyTIK97ubkwFNCw==}
     engines: {node: '>=22'}
 
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
   '@aws/lambda-invoke-store@0.3.0':
     resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
@@ -2511,6 +2574,10 @@ packages:
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/code-frame@7.29.7':
@@ -2529,6 +2596,10 @@ packages:
     resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.29.7':
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
@@ -2543,6 +2614,10 @@ packages:
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.29.7':
@@ -2561,6 +2636,10 @@ packages:
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -2582,6 +2661,11 @@ packages:
 
   '@babel/parser@7.28.6':
     resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2615,6 +2699,10 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
@@ -2623,12 +2711,20 @@ packages:
     resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -4859,12 +4955,20 @@ packages:
     resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/credential-provider-imds@4.4.2':
+    resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.6':
     resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.4.7':
     resolution: {integrity: sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.5.2':
+    resolution: {integrity: sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.13':
@@ -4887,6 +4991,10 @@ packages:
     resolution: {integrity: sha512-BTRqmd5xIL6hFiJzWlQsMPSRmedAbBLEKIiwgvwdDom6tyKty2TWne48pehQPHwjYhCEiqJTlADjqXV36EI3sQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.8.2':
+    resolution: {integrity: sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.9.13':
     resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
     engines: {node: '>=18.0.0'}
@@ -4897,6 +5005,10 @@ packages:
 
   '@smithy/node-http-handler@4.9.4':
     resolution: {integrity: sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.5.2':
+    resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.12':
@@ -6229,11 +6341,6 @@ packages:
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.18.0:
-    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -9767,8 +9874,8 @@ packages:
   nise@6.1.1:
     resolution: {integrity: sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==}
 
-  node-abi@3.94.0:
-    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
+  node-abi@3.87.0:
+    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
 
   node-addon-api@7.1.1:
@@ -10708,11 +10815,6 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  resolve@1.22.12:
-    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
@@ -11356,8 +11458,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tar-fs@2.1.5:
-    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -12397,30 +12499,26 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.974.2
-      '@aws-sdk/util-locate-window': 3.965.8
+      '@aws-sdk/types': 3.973.10
+      '@aws-sdk/util-locate-window': 3.965.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
-    optional: true
 
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/types': 3.973.10
       tslib: 2.8.1
-    optional: true
 
   '@aws-crypto/supports-web-crypto@5.2.0':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/types': 3.973.10
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/checksums@3.1000.13':
     dependencies:
@@ -12517,12 +12615,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.977.6
-      '@aws-sdk/credential-provider-node': 3.972.73
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/credential-provider-node': 3.972.50
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.0
-      '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
       '@smithy/types': 4.15.1
       tslib: 2.8.1
     optional: true
@@ -12559,6 +12657,19 @@ snapshots:
       '@smithy/core': 3.29.0
       '@smithy/fetch-http-handler': 5.6.3
       '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-lambda@3.1061.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/credential-provider-node': 3.972.50
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
@@ -12665,6 +12776,17 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.17':
+    dependencies:
+      '@aws-sdk/types': 3.973.10
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.29.0
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.28':
     dependencies:
       '@aws-sdk/types': 3.973.15
@@ -12708,6 +12830,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@aws-sdk/credential-provider-env@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.54':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -12732,6 +12862,16 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
     optional: true
+
+  '@aws-sdk/credential-provider-http@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.56':
     dependencies:
@@ -12763,6 +12903,22 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
     optional: true
+
+  '@aws-sdk/credential-provider-ini@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/credential-provider-env': 3.972.43
+      '@aws-sdk/credential-provider-http': 3.972.45
+      '@aws-sdk/credential-provider-login': 3.972.47
+      '@aws-sdk/credential-provider-process': 3.972.43
+      '@aws-sdk/credential-provider-sso': 3.972.47
+      '@aws-sdk/credential-provider-web-identity': 3.972.47
+      '@aws-sdk/nested-clients': 3.997.15
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.61':
     dependencies:
@@ -12813,6 +12969,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@aws-sdk/credential-provider-login@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/nested-clients': 3.997.15
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.60':
     dependencies:
       '@aws-sdk/core': 3.975.1
@@ -12840,6 +13005,20 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
     optional: true
+
+  '@aws-sdk/credential-provider-node@3.972.50':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.43
+      '@aws-sdk/credential-provider-http': 3.972.45
+      '@aws-sdk/credential-provider-ini': 3.972.48
+      '@aws-sdk/credential-provider-process': 3.972.43
+      '@aws-sdk/credential-provider-sso': 3.972.47
+      '@aws-sdk/credential-provider-web-identity': 3.972.47
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.63':
     dependencies:
@@ -12884,6 +13063,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@aws-sdk/credential-provider-process@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.54':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -12908,6 +13095,16 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
     optional: true
+
+  '@aws-sdk/credential-provider-sso@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/nested-clients': 3.997.15
+      '@aws-sdk/token-providers': 3.1060.0
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.60':
     dependencies:
@@ -12940,6 +13137,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@aws-sdk/credential-provider-web-identity@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/nested-clients': 3.997.15
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.60':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -12971,20 +13177,20 @@ snapshots:
   '@aws-sdk/credential-providers@3.1050.0':
     dependencies:
       '@aws-sdk/client-cognito-identity': 3.1050.0
-      '@aws-sdk/core': 3.977.6
+      '@aws-sdk/core': 3.974.17
       '@aws-sdk/credential-provider-cognito-identity': 3.972.66
-      '@aws-sdk/credential-provider-env': 3.972.67
-      '@aws-sdk/credential-provider-http': 3.972.69
-      '@aws-sdk/credential-provider-ini': 3.973.12
-      '@aws-sdk/credential-provider-login': 3.972.74
-      '@aws-sdk/credential-provider-node': 3.972.73
-      '@aws-sdk/credential-provider-process': 3.972.67
-      '@aws-sdk/credential-provider-sso': 3.973.11
-      '@aws-sdk/credential-provider-web-identity': 3.972.73
-      '@aws-sdk/nested-clients': 3.997.41
-      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/credential-provider-env': 3.972.43
+      '@aws-sdk/credential-provider-http': 3.972.45
+      '@aws-sdk/credential-provider-ini': 3.972.48
+      '@aws-sdk/credential-provider-login': 3.972.47
+      '@aws-sdk/credential-provider-node': 3.972.50
+      '@aws-sdk/credential-provider-process': 3.972.43
+      '@aws-sdk/credential-provider-sso': 3.972.47
+      '@aws-sdk/credential-provider-web-identity': 3.972.47
+      '@aws-sdk/nested-clients': 3.997.15
+      '@aws-sdk/types': 3.973.10
       '@smithy/core': 3.29.0
-      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/credential-provider-imds': 4.4.2
       '@smithy/types': 4.15.1
       tslib: 2.8.1
     optional: true
@@ -13035,6 +13241,19 @@ snapshots:
       '@smithy/core': 3.29.0
       '@smithy/fetch-http-handler': 5.6.3
       '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.15':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/signature-v4-multi-region': 3.996.31
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
@@ -13091,6 +13310,13 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.31':
+    dependencies:
+      '@aws-sdk/types': 3.973.10
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.38':
     dependencies:
       '@aws-sdk/types': 3.973.15
@@ -13112,6 +13338,15 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
     optional: true
+
+  '@aws-sdk/token-providers@3.1060.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/nested-clients': 3.997.15
+      '@aws-sdk/types': 3.973.10
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1080.0':
     dependencies:
@@ -13141,6 +13376,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@aws-sdk/types@3.973.10':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.15':
     dependencies:
       '@smithy/types': 4.15.1
@@ -13157,10 +13397,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/util-locate-window@3.965.8':
+  '@aws-sdk/util-locate-window@3.965.4':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/xml-builder@3.972.33':
     dependencies:
@@ -13176,11 +13415,12 @@ snapshots:
     dependencies:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
-    optional: true
 
   '@aws/durable-execution-sdk-js@1.0.2':
     dependencies:
-      '@aws-sdk/client-lambda': 3.1080.0
+      '@aws-sdk/client-lambda': 3.1061.0
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@aws/lambda-invoke-store@0.3.0': {}
 
@@ -13193,6 +13433,12 @@ snapshots:
   '@babel/code-frame@7.28.6':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -13232,6 +13478,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/generator@7.29.7':
     dependencies:
       '@babel/parser': 7.29.7
@@ -13251,6 +13505,13 @@ snapshots:
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
@@ -13272,6 +13533,8 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
+  '@babel/helper-validator-identifier@7.28.5': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.29.7': {}
@@ -13288,6 +13551,10 @@ snapshots:
   '@babel/parser@7.28.6':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.2':
     dependencies:
@@ -13311,6 +13578,12 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -13325,6 +13598,18 @@ snapshots:
       '@babel/parser': 7.28.6
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -13345,6 +13630,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -13729,7 +14019,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-module-imports': 7.28.6
       '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -15899,6 +16189,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@smithy/credential-provider-imds@4.4.2':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.6':
     dependencies:
       '@smithy/core': 3.29.0
@@ -15906,6 +16202,12 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/credential-provider-imds@4.4.7':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.5.2':
     dependencies:
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.1
@@ -15933,13 +16235,18 @@ snapshots:
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@smithy/middleware-compression@4.5.6':
     dependencies:
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.1
       fflate: 0.8.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.8.2':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.9.13':
@@ -15956,6 +16263,12 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.9.4':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.5.2':
     dependencies:
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.1
@@ -15988,13 +16301,11 @@ snapshots:
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
-    optional: true
 
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
-    optional: true
 
   '@stablelib/base64@1.0.1': {}
 
@@ -16191,7 +16502,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.7
+      '@babel/code-frame': 7.28.6
       '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -17335,9 +17646,6 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  acorn@8.18.0:
-    optional: true
-
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -17589,7 +17897,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       cosmiconfig: 7.1.0
-      resolve: 1.22.12
+      resolve: 1.22.11
 
   bail@2.0.2: {}
 
@@ -21604,9 +21912,9 @@ snapshots:
       just-extend: 6.2.0
       path-to-regexp: 8.4.2
 
-  node-abi@3.94.0:
+  node-abi@3.87.0:
     dependencies:
-      semver: 7.8.5
+      semver: 7.7.4
     optional: true
 
   node-addon-api@7.1.1:
@@ -22106,11 +22414,11 @@ snapshots:
       minimist: 1.2.8
       mkdirp-classic: 0.5.3
       napi-build-utils: 2.0.0
-      node-abi: 3.94.0
+      node-abi: 3.87.0
       pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1
-      tar-fs: 2.1.5
+      tar-fs: 2.1.4
       tunnel-agent: 0.6.0
     optional: true
 
@@ -22636,13 +22944,6 @@ snapshots:
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
-  resolve@1.22.12:
-    dependencies:
-      es-errors: 1.3.0
-      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -23479,7 +23780,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tar-fs@2.1.5:
+  tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
@@ -23534,7 +23835,7 @@ snapshots:
   terser@5.44.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.18.0
+      acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
     optional: true


### PR DESCRIPTION
## Description

Closes #1592.

PR [#1054](https://github.com/Bike4Mind/bike4mind/pull/1054) stopped sensitive admin settings from leaving the server, but the stored value was still plaintext in Mongo. Encryption-at-rest already existed in the repo (AES-256-GCM, keyed by `SECRET_ENCRYPTION_KEY`) and was wired into the write path, but only for `sreAgentConfig`. This generalizes it to every `isSensitive` admin setting and to the per-user provider `apiKey`, so a database dump (backup, snapshot, leaked connection string) no longer exposes live credentials.

The design is one transparent choke point at the repository layer: consumers keep reading plaintext and are unchanged. Values are encrypted on write, decrypted on read, and the PR-1054 display mask is preserved (real last-4, never the ciphertext tail).

## Changes

**Shared crypto (no behavior change)**
- Promoted the pure AES-256-GCM helper to `@bike4mind/utils` (`security/secretEncryption.ts`) so the database layer, which cannot import from `apps/client`, can share it. `apps/client/server/security/secretEncryption.ts` is now a thin re-export, so every existing importer (SRE, Jira/GitHub webhooks, Okta) is untouched.
- New `security/secretsAtRest.ts`: `configureSecretsAtRest` / `encryptAtRest` / `decryptAtRest`. A non-ciphertext value passes through unchanged (plaintext coexists during rollout); decryption tries the current key then `SECRET_ENCRYPTION_KEY_PREVIOUS` so a rotation does not strand old values.

**Key injection**
- `config.ts` injects `SECRET_ENCRYPTION_KEY` into the shared module once at module load. Config is imported by every server context before it reaches Mongo (each `connectDB` reads `Config.MONGODB_URI`), so the key is set before any repository read decrypts. The database layer cannot import Config directly.

**Decrypt-on-read (transparent to consumers)**
- `AdminSettingsModel`: decrypts sensitive string `settingValue` on `findBySettingName` / `findBySettingNames` / `findAllByTag` / `findAll` / `getSettingsValue`. Gated on `isSensitive && string && isEncrypted`, so `sreAgentConfig` (an object) and not-yet-migrated plaintext pass through. `apiKeyService.getEffective*`, `getSettingsMap`, the Slack/Jira/Notion/Google/ElevenLabs readers, and the settings cache all funnel through these and receive plaintext with zero call-site changes.
- `ApiKeyModel`: decrypts `apiKey` on the real-key read paths (`findByUserIdAndType[s]`, `findByIdAndUserId`, `findAllByUserId`). `findByIdAndUserIdAndType` deliberately stays a non-decrypting hydrated document: `setApiKey` mutates `isActive` on that result and writes it straight back, so the stored key must stay ciphertext there.

**Encrypt-on-write**
- `settings/update.ts`: generalizes the `sreAgentConfig` encryption branch to every sensitive scalar. Fails closed if no valid key is configured (no silent plaintext store). A confirmed clear (`''`) and an already-encrypted value are left as-is.
- `ApiKeyModel.create`: encrypts before store, echoes the submitted plaintext in the create response so that response shape is unchanged.

**Display mask stays correct on ciphertext**
- `settings/fetch.ts` and `update.ts` mask the decrypted plaintext, so the mask still carries the real last-4 rather than the ciphertext tail. Only the mask leaves the server.
- `GET /api/settings` now masks sensitive values too (see Additional Information - this is a deliberate behavior change to an admin-only route).
- `UserSettingsContext`: the `adminsettings` WebSocket fanout serializes raw stored documents; mask sensitive values before they land in the shared react-query cache so a live cross-admin update never surfaces ciphertext or a raw secret in the admin field. `/api/settings/fetch` remains the source of truth for the real last-4.

**Migration (in this PR)**
- `packages/scripts/migrate/encrypt-admin-settings-and-apikeys.ts` backfills existing plaintext rows in `adminsettings` (sensitive keys only) and `apikeys.apiKey`. Idempotent via `isEncrypted()`, skips masked placeholders, supports `--dry-run` and `--reencrypt`. Run: `pnpm --filter scripts migrate:encrypt-admin-secrets`.

## Test Plan

Automated (all green locally):
- `secretsAtRest` unit tests: round-trip, plaintext passthrough, idempotency, rotation fallback, malformed-key handling.
- DB round-trips: `AdminSettingsModel.encryption.test.ts` (sensitive decrypts, plaintext coexistence, non-sensitive untouched, stored value is ciphertext) and `ApiKeyModel.encryption.test.ts` (encrypt-on-create, decrypt-on-read, create echoes plaintext).
- `settings/update.test.ts` and `settings/fetch.test.ts`: sensitive value encrypted at rest, never stored/echoed as plaintext, mask derived from plaintext (real last-4), fail-closed without a key, non-sensitive stored verbatim.
- `pnpm --filter @bike4mind/{utils,database,scripts,client} typecheck`, `pnpm lint:check`, and the ASCII guards pass.

Manual, on a preview with a configured `SECRET_ENCRYPTION_KEY` (not staging):
1. Set a provider key (e.g. Anthropic API Key) via Admin to Settings. Confirm inference works.
<img width="715" height="68" alt=" " src="https://github.com/user-attachments/assets/8f9afdac-7db2-4c96-8ed6-93884570ded5" />


2. Inspect the `adminsettings` document in Mongo: `settingValue` is `iv:authTag:ciphertext`, not the key.
3. Reload Settings: the field shows the mask with the real last-4.
4. Run the migration against a copy of the DB and confirm existing plaintext rows become ciphertext and the app still resolves keys.
<img width="469" height="320" alt="Screenshot 2026-08-10 at 5 36 36 pm" src="https://github.com/user-attachments/assets/c71395bd-4a8c-44e4-bb83-83aec117ee60" />

`for-env bike4mind-previews sst shell --stage pr1600 -- pnpm --filter scripts migrate:encrypt-admin-secrets -- --dry-run`

### Tester guide: confirm provider keys still work (chat smoke test)

Encryption changes how keys are *stored*, not how they *resolve* - but the whole point is that inference keeps working. Verify both key sources actually drive a completion.

**Pick the model carefully (most important step).** Use a DIRECT provider model, e.g. a bare `gpt-...` (OpenAI), `gemini-...` (Gemini), or `claude-...-YYYYMMDD` (Anthropic). Do NOT use a `global.`/`us.`-prefixed id like `global.anthropic.claude-...` - those are Bedrock inference profiles that authenticate with AWS credentials and never read the stored provider key, so they pass even with a broken/absent key and prove nothing. Only the direct adapter families consume the stored key.

**A. Admin fallback (demo) key**
1. Admin -> Settings -> AI. Set a provider key you have (e.g. OpenAI API Key or Gemini API Key). Save.
2. (Optional, proves at-rest) The `adminsettings` doc for that key shows `settingValue` as `iv:authTag:ciphertext`, not the raw key.
3. As a user with NO personal key for that provider, start a chat with a direct model on that provider and send a message. Expect a normal completion.

**B. Per-user BYO key**
4. User settings -> API keys. Add your own OpenAI/Gemini key. Save. (Optional: the `apikeys` doc's `apiKey` is ciphertext.)
5. Chat with a direct model on that provider. Expect a normal completion (a BYO key takes precedence over the admin key).

**C. Existing keys after the backfill migration (the real regression check)**
6. Run `migrate:encrypt-admin-secrets` against the stage.
7. Without re-entering anything, chat again on each provider whose key predated encryption. Expect normal completions - this proves decrypt-on-read works for the migrated values, not just newly-saved ones.

**D. Negative check (optional but convincing)**
8. Enter a deliberately wrong key and chat -> expect an auth error from the provider; fix it -> works again. Confirms the stored value is actually decrypted and used, not ignored.

## Additional Information

- **Behavior change, needs a human call:** `GET /api/settings` (admin-only) previously returned the full collection unredacted; it now masks sensitive values, matching `/api/settings/fetch`. No client code calls it, but if an admin automation reads secrets through it, that will now get a mask. Encryption alone already stops the plaintext leak there (it would otherwise return ciphertext); the redaction makes it return a clean mask.
- **WebSocket live updates:** the `adminsettings` change-stream fanout is a separate container image and serializes raw stored documents, so post-encryption it emits ciphertext for live sensitive-setting updates. The client-side mask handles display; this is a net improvement over the prior plaintext-over-the-wire behavior. A schema-level redaction transform would be the fuller fix and is worth a follow-up.
- **No-reader sensitive keys:** `slackBotToken`, `slackSigningSecret`, `FeedbackSendEmail*`, `qWorkToken`, and `PotionQuestApiKey` have no runtime `adminsettings` readers today (the live Slack integration reads a separate workspace collection). Encrypting them is harmless and future-proofs them.
- **No key configured (fail closed):** when `SECRET_ENCRYPTION_KEY` is not a valid 64-hex value, BOTH admin sensitive-setting writes and per-user provider-key writes throw rather than persist plaintext. Only a deliberate self-host install (`B4M_SELF_HOST=true`) degrades provider-key writes to plaintext passthrough. The `infra/secrets.ts` placeholder defaults are non-hex, so a stage that never ran `sst secret set SECRET_ENCRYPTION_KEY` will 500 on these writes until a real key is set - intended fail-closed behavior, not a regression. Reads of an encrypted value that cannot be decrypted resolve to empty (provider-key resolution then falls back to the demo key) rather than surfacing ciphertext upstream as a credential.


