### PR TITLE
fix(billing): sync org seats on existing-org Stripe initial purchase

### DIFF
--- a/apps/client/app/components/admin/OrganizationsTab.tsx
+++ b/apps/client/app/components/admin/OrganizationsTab.tsx
@@ -43,6 +43,7 @@ import {
   useAdminOrgGrants,
   useConvertOrgToPaid,
   useGrantOrganization,
+  useReconcileOrgSeats,
   useRevokeOrganization,
   useTopUpOrganization,
 } from '@client/app/hooks/data/adminOrganizations';
@@ -203,6 +204,7 @@ const OrganizationsTab: React.FC = () => {
   const grantOrgMutation = useGrantOrganization();
   const topUpMutation = useTopUpOrganization();
   const seatsMutation = useAdjustOrgSeats();
+  const reconcileMutation = useReconcileOrgSeats();
   const convertMutation = useConvertOrgToPaid();
   const revokeMutation = useRevokeOrganization();
 
@@ -274,6 +276,15 @@ const OrganizationsTab: React.FC = () => {
     try {
       await seatsMutation.mutateAsync({ organizationId: seatsOrg.id, seats: seatsValue });
       setSeatsOrg(null);
+      refetch();
+    } catch {
+      // toast handled
+    }
+  };
+
+  const handleReconcileSeats = async (org: WithId<IOrganizationDocument>) => {
+    try {
+      await reconcileMutation.mutateAsync({ organizationId: org.id });
       refetch();
     } catch {
       // toast handled
@@ -502,6 +513,14 @@ const OrganizationsTab: React.FC = () => {
                               Adjust seats
                             </MenuItem>
                           )}
+                          {!isGranted && !org.personal && (
+                            <MenuItem
+                              data-testid={`reconcile-seats-${org.id}`}
+                              onClick={() => handleReconcileSeats(org)}
+                            >
+                              Reconcile seats from Stripe
+                            </MenuItem>
+                          )}
                           {isGranted && (
                             <MenuItem
                               data-testid={`convert-to-paid-${org.id}`}
@@ -620,6 +639,14 @@ const OrganizationsTab: React.FC = () => {
                                   }}
                                 >
                                   Adjust seats
+                                </MenuItem>
+                              )}
+                              {!isGranted && !org.personal && (
+                                <MenuItem
+                                  data-testid={`reconcile-seats-${org.id}`}
+                                  onClick={() => handleReconcileSeats(org)}
+                                >
+                                  Reconcile seats from Stripe
                                 </MenuItem>
                               )}
                               {isGranted && (

--- a/apps/client/app/hooks/data/adminOrganizations.test.tsx
+++ b/apps/client/app/hooks/data/adminOrganizations.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { api } from '@client/app/contexts/ApiContext';
+import { useReconcileOrgSeats } from './adminOrganizations';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@client/app/contexts/ApiContext', () => ({ api: { post: vi.fn() } }));
+
+const post = api.post as unknown as Mock;
+
+const renderReconcile = () => {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const { result } = renderHook(() => useReconcileOrgSeats(), { wrapper });
+  return { result, invalidateSpy };
+};
+
+describe('useReconcileOrgSeats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('toasts the before -> after change and invalidates organizations on success', async () => {
+    post.mockResolvedValue({ data: { organizationId: 'org1', before: 10, after: 30 } });
+    const { result, invalidateSpy } = renderReconcile();
+
+    await result.current.mutateAsync({ organizationId: 'org1' });
+
+    expect(post).toHaveBeenCalledWith('/api/admin/organizations/org1/reconcile-seats');
+    expect(toast.success).toHaveBeenCalledWith('Seats reconciled: 10 -> 30');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['organizations'] });
+  });
+
+  it('toasts an already-in-sync message when seats did not change', async () => {
+    post.mockResolvedValue({ data: { organizationId: 'org1', before: 30, after: 30 } });
+    const { result } = renderReconcile();
+
+    await result.current.mutateAsync({ organizationId: 'org1' });
+
+    expect(toast.success).toHaveBeenCalledWith('Seats already in sync (30)');
+  });
+
+  it('surfaces the server error message on failure', async () => {
+    post.mockRejectedValue(new Error('Organization has no active subscription to reconcile seats from'));
+    const { result } = renderReconcile();
+
+    await expect(result.current.mutateAsync({ organizationId: 'org1' })).rejects.toThrow();
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Organization has no active subscription to reconcile seats from')
+    );
+  });
+});

--- a/apps/client/app/hooks/data/adminOrganizations.ts
+++ b/apps/client/app/hooks/data/adminOrganizations.ts
@@ -104,6 +104,33 @@ export function useAdjustOrgSeats() {
   });
 }
 
+/**
+ * Re-sync an org's seat count to its active subscription's billed quantity.
+ * Unlike useAdjustOrgSeats (PATCH /seats, which the backend refuses for
+ * Stripe-billed orgs), this only PULLS from what Stripe already invoices, so
+ * it is the repair path for orgs whose seats drifted from their paid quantity.
+ */
+export function useReconcileOrgSeats() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (params: { organizationId: string }) => {
+      const res = await api.post<{ organizationId: string; before: number; after: number }>(
+        `/api/admin/organizations/${params.organizationId}/reconcile-seats`
+      );
+      return res.data;
+    },
+    onSuccess: data => {
+      toast.success(
+        data.before === data.after
+          ? `Seats already in sync (${data.after})`
+          : `Seats reconciled: ${data.before} -> ${data.after}`
+      );
+      queryClient.invalidateQueries({ queryKey: ['organizations'] });
+    },
+    onError: err => toast.error(apiErrorMessage(err, 'Reconcile failed')),
+  });
+}
+
 export function useConvertOrgToPaid() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/apps/client/lib/userSubscriptions/serverUtils.test.ts
+++ b/apps/client/lib/userSubscriptions/serverUtils.test.ts
@@ -32,6 +32,7 @@ vi.mock('@bike4mind/database', async () => {
     organizationRepository: {
       findById: vi.fn(),
       findByStripeCustomerId: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
     },
     creditTransactionRepository: { findByPaymentIntentId: vi.fn().mockResolvedValue(null) },
     withTransaction: vi.fn(async (fn: () => Promise<unknown>) => fn()),
@@ -236,6 +237,53 @@ describe('handleOrganizationSubscriptionInvoice — conversion flip', () => {
     expect(subscriptionRepository.create).not.toHaveBeenCalled();
     expect(subscriptionRepository.flipAdminGrantToStripe).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('already has an active Stripe subscription'));
+  });
+});
+
+describe('handleOrganizationSubscriptionInvoice - seat sync on initial purchase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (subscriptionRepository.findByStripeSubscriptionId as any).mockResolvedValue(null);
+    (subscriptionRepository.findActiveSubscriptionsByOwner as any).mockResolvedValue([]);
+  });
+
+  it('writes organization.seats to the purchased quantity for an existing org (regression: seats stuck at default)', async () => {
+    // The org starts at the schema default of 10; the checkout was for 4 seats.
+    // Before the fix, the existing-org subscription_create path granted credits and
+    // created the Subscription row but never touched organization.seats.
+    (organizationRepository.findById as any).mockResolvedValue({ id: 'org_seats', name: 'Acme', users: [], seats: 10 });
+
+    await handleOrganizationSubscriptionInvoice(
+      buildInvoice(),
+      buildSubscription(),
+      {
+        userId: 'u1',
+        stage: 'test',
+        ownerType: SubscriptionOwnerType.Organization,
+        organizationId: 'org_seats',
+      } as any,
+      logger
+    );
+
+    expect(organizationRepository.update).toHaveBeenCalledWith(expect.objectContaining({ id: 'org_seats', seats: 4 }));
+  });
+
+  it('does not rewrite seats when they already match the purchased quantity (idempotent on retry)', async () => {
+    (organizationRepository.findById as any).mockResolvedValue({ id: 'org_seats', name: 'Acme', users: [], seats: 4 });
+
+    await handleOrganizationSubscriptionInvoice(
+      buildInvoice(),
+      buildSubscription(),
+      {
+        userId: 'u1',
+        stage: 'test',
+        ownerType: SubscriptionOwnerType.Organization,
+        organizationId: 'org_seats',
+      } as any,
+      logger
+    );
+
+    expect(organizationRepository.update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/client/lib/userSubscriptions/serverUtils.test.ts
+++ b/apps/client/lib/userSubscriptions/serverUtils.test.ts
@@ -285,6 +285,33 @@ describe('handleOrganizationSubscriptionInvoice - seat sync on initial purchase'
 
     expect(organizationRepository.update).not.toHaveBeenCalled();
   });
+
+  it('does not rewrite seats when a different active Stripe subscription exists (refused duplicate)', async () => {
+    // Double-checkout race: a first Stripe sub (quantity 12) is already active when a
+    // second subscription_create (the buildSubscription() 4-seat sub) arrives. The
+    // handler refuses to create the duplicate, so it must NOT adopt the refused sub's
+    // quantity into organization.seats.
+    (organizationRepository.findById as any).mockResolvedValue({ id: 'org_dup', name: 'Acme', users: [], seats: 12 });
+    (subscriptionRepository.findActiveSubscriptionsByOwner as any).mockResolvedValue([
+      { id: 's_first', source: SubscriptionSource.Stripe, subscriptionId: 'sub_first', quantity: 12 },
+    ]);
+
+    await handleOrganizationSubscriptionInvoice(
+      buildInvoice(),
+      buildSubscription(),
+      {
+        userId: 'u1',
+        stage: 'test',
+        ownerType: SubscriptionOwnerType.Organization,
+        organizationId: 'org_dup',
+      } as any,
+      logger
+    );
+
+    expect(organizationRepository.update).not.toHaveBeenCalled();
+    expect(subscriptionRepository.create).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('already has an active Stripe subscription'));
+  });
 });
 
 describe('handleUserSubscriptionInvoice — plan lookup', () => {

--- a/apps/client/lib/userSubscriptions/serverUtils.ts
+++ b/apps/client/lib/userSubscriptions/serverUtils.ts
@@ -137,6 +137,22 @@ export const handleOrganizationSubscriptionInvoice = async (
             logger.debug(`Ignoring unknown organization: ${metadata.organizationId}`);
             return;
           }
+
+          // Sync the org's seat count to the quantity Stripe just billed for. The
+          // new-org branch below sets seats at creation; the existing-org branch
+          // historically never did, so organization.seats stayed at its default (10)
+          // even though billing, the Subscription row, and credits all reflected the
+          // purchased quantity. setSeats only runs on customer.subscription.updated,
+          // which Stripe does not emit for a fresh subscription. Write directly (not
+          // via setSeats) so we never reject a quantity Stripe already charged for;
+          // idempotent, so webhook retries self-heal.
+          if (organization.seats !== subscriptionQuantity) {
+            organization.seats = subscriptionQuantity;
+            await organizationRepository.update(organization);
+            logger.info(
+              `Synced org ${organization.id} seats to ${subscriptionQuantity} from subscription ${subscription.id}`
+            );
+          }
         } else if (metadata.newOrganizationName) {
           // Create a new organization only during subscription creation
           organization = await organizationService.create(

--- a/apps/client/lib/userSubscriptions/serverUtils.ts
+++ b/apps/client/lib/userSubscriptions/serverUtils.ts
@@ -130,6 +130,8 @@ export const handleOrganizationSubscriptionInvoice = async (
     // Handle different billing scenarios
     switch (invoice.billing_reason) {
       case 'subscription_create': {
+        let activeSubs: Awaited<ReturnType<typeof subscriptionRepository.findActiveSubscriptionsByOwner>> = [];
+
         // For new subscriptions, handle organization creation or use existing one
         if (metadata.organizationId) {
           organization = await organizationRepository.findById(metadata.organizationId);
@@ -138,17 +140,26 @@ export const handleOrganizationSubscriptionInvoice = async (
             return;
           }
 
-          // Sync the org's seat count to the quantity Stripe just billed for. The
-          // new-org branch below sets seats at creation; the existing-org branch
-          // historically never did, so organization.seats stayed at its default (10)
-          // even though billing, the Subscription row, and credits all reflected the
-          // purchased quantity. setSeats only runs on customer.subscription.updated,
-          // which Stripe does not emit for a fresh subscription. Write directly (not
-          // via setSeats) so we never reject a quantity Stripe already charged for;
-          // idempotent, so webhook retries self-heal.
-          if (organization.seats !== subscriptionQuantity) {
+          activeSubs = await subscriptionRepository.findActiveSubscriptionsByOwner(
+            SubscriptionOwnerType.Organization,
+            organization.id
+          );
+
+          // Sync seats to the billed quantity (the new-org branch sets this at
+          // creation). Written directly, not via setSeats, so a paid quantity can
+          // never be rejected, and placed above the idempotency break so a webhook
+          // resend re-heals seats. Skipped when a DIFFERENT active Stripe sub exists:
+          // that sub is about to be refused below, so adopting its quantity would
+          // desync seats from what is actually billed.
+          const strayStripeSub = activeSubs.find(
+            s =>
+              resolveSubscriptionSource(s) === SubscriptionSource.Stripe &&
+              s.subscriptionId &&
+              s.subscriptionId !== subscription.id
+          );
+          if (!strayStripeSub && organization.seats !== subscriptionQuantity) {
             organization.seats = subscriptionQuantity;
-            await organizationRepository.update(organization);
+            await organizationRepository.update({ id: organization.id, seats: subscriptionQuantity });
             logger.info(
               `Synced org ${organization.id} seats to ${subscriptionQuantity} from subscription ${subscription.id}`
             );
@@ -199,10 +210,14 @@ export const handleOrganizationSubscriptionInvoice = async (
         // Conversion flip: if an admin_grant sub already exists for this org,
         // upgrade it to Stripe in place rather than inserting a duplicate row.
         // Keeps a single Subscription row across the grant->paid lifecycle.
-        const activeSubs = await subscriptionRepository.findActiveSubscriptionsByOwner(
-          SubscriptionOwnerType.Organization,
-          org.id
-        );
+        // The existing-org branch already loaded activeSubs above; a freshly
+        // created org has none yet, so only the new-org path looks them up.
+        if (!metadata.organizationId) {
+          activeSubs = await subscriptionRepository.findActiveSubscriptionsByOwner(
+            SubscriptionOwnerType.Organization,
+            org.id
+          );
+        }
         const adminGrant = activeSubs.find(s => resolveSubscriptionSource(s) === SubscriptionSource.AdminGrant);
 
         if (adminGrant) {

--- a/apps/client/pages/api/admin/organizations/[id]/reconcile-seats.ts
+++ b/apps/client/pages/api/admin/organizations/[id]/reconcile-seats.ts
@@ -30,29 +30,33 @@ const handler = baseApi().post(
 
     const result = await reconcileOrgSeatsFromSubscription(id);
     if (!result) {
-      throw new BadRequestError('Organization has no active subscription to reconcile seats from');
+      throw new BadRequestError('Organization has no active Stripe subscription to reconcile seats from');
     }
 
-    await logAuditEvent(
-      {
-        userId: result.organization.userId,
-        action: AdminOrgAuditEvents.ORG_SEATS_CHANGED,
-        adminUserId: req.user!.id,
-        adminUsername: req.user!.username,
-        metadata: {
-          organizationId: result.organization.id,
-          seats: result.after,
-          previousSeats: result.before,
-          reconciledFrom: 'subscription',
+    // Only audit + notify on an actual change so a no-op reconcile does not emit a
+    // misleading ORG_SEATS_CHANGED entry or a spurious client invalidation.
+    if (result.before !== result.after) {
+      await logAuditEvent(
+        {
+          userId: result.organization.userId,
+          action: AdminOrgAuditEvents.ORG_SEATS_CHANGED,
+          adminUserId: req.user!.id,
+          adminUsername: req.user!.username,
+          metadata: {
+            organizationId: result.organization.id,
+            seats: result.after,
+            previousSeats: result.before,
+            reconciledFrom: 'subscription',
+          },
         },
-      },
-      req.logger
-    );
+        req.logger
+      );
 
-    await sendToClient(result.organization.userId, Resource.websocket.managementEndpoint, {
-      action: 'invalidate_query',
-      queryKey: ['organizations'],
-    });
+      await sendToClient(result.organization.userId, Resource.websocket.managementEndpoint, {
+        action: 'invalidate_query',
+        queryKey: ['organizations'],
+      });
+    }
 
     return res.status(200).json({
       organizationId: result.organization.id,

--- a/apps/client/pages/api/admin/organizations/[id]/reconcile-seats.ts
+++ b/apps/client/pages/api/admin/organizations/[id]/reconcile-seats.ts
@@ -1,0 +1,65 @@
+import { BadRequestError } from '@bike4mind/utils';
+import { ForbiddenError } from '@server/utils/errors';
+import { baseApi } from '@server/middlewares/baseApi';
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { sendToClient } from '@server/websocket/utils';
+import { AdminOrgAuditEvents, logAuditEvent } from '@server/utils/auditLog';
+import { reconcileOrgSeatsFromSubscription } from '@server/services/organizationService';
+import { Resource } from 'sst';
+
+interface RequestQuery {
+  id: string;
+}
+
+/**
+ * Admin remediation: re-sync an org's `seats` to its active subscription's
+ * billed quantity. Unlike PATCH .../seats (which refuses Stripe-billed orgs
+ * because a push to Stripe there would desync billing), this only PULLS from
+ * the already-billed quantity, so it is safe to run on Stripe-billed orgs and
+ * is the intended fix for orgs left with stale seats by the initial-purchase
+ * webhook bug.
+ */
+const handler = baseApi().post(
+  asyncHandler(async (req, res) => {
+    if (!req.user?.isAdmin) {
+      throw new ForbiddenError('Unauthorized. Admin access required.');
+    }
+
+    const { id } = req.query as RequestQuery;
+    if (!id) throw new BadRequestError('Organization id required');
+
+    const result = await reconcileOrgSeatsFromSubscription(id);
+    if (!result) {
+      throw new BadRequestError('Organization has no active subscription to reconcile seats from');
+    }
+
+    await logAuditEvent(
+      {
+        userId: result.organization.userId,
+        action: AdminOrgAuditEvents.ORG_SEATS_CHANGED,
+        adminUserId: req.user!.id,
+        adminUsername: req.user!.username,
+        metadata: {
+          organizationId: result.organization.id,
+          seats: result.after,
+          previousSeats: result.before,
+          reconciledFrom: 'subscription',
+        },
+      },
+      req.logger
+    );
+
+    await sendToClient(result.organization.userId, Resource.websocket.managementEndpoint, {
+      action: 'invalidate_query',
+      queryKey: ['organizations'],
+    });
+
+    return res.status(200).json({
+      organizationId: result.organization.id,
+      before: result.before,
+      after: result.after,
+    });
+  })
+);
+
+export default handler;

--- a/apps/client/server/services/organizationService.test.ts
+++ b/apps/client/server/services/organizationService.test.ts
@@ -6,6 +6,7 @@ import {
   setSeats,
   pickPrimarySubscription,
   resolveSubscriptionSource,
+  reconcileOrgSeatsFromSubscription,
 } from './organizationService';
 import { SubscriptionSource } from '@client/lib/subscriptions/types';
 import { ORGANIZATION_SUBSCRIPTION_MAX_SEATS } from '@client/lib/subscriptions/constants';
@@ -237,6 +238,47 @@ describe('organizationService', () => {
       await expect(setSeats('org1', 2, { type: 'admin', userId: 'a1' })).rejects.toThrow(
         /Minimum required seats: 5.*including 4 pending invites/
       );
+      expect(organizationRepository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reconcileOrgSeatsFromSubscription', () => {
+    it('pulls seats up to the active subscription quantity, skipping seat-change validation', async () => {
+      // Stale org: seats stuck at the default 10 while the billed sub is 30.
+      // Note there are no members, so validateSeatChange is irrelevant here -
+      // reconcile must set 30 regardless of team-size rules.
+      const org = orgFixture({ id: 'orgR', seats: 10, users: [] });
+      (organizationRepository.findById as any).mockResolvedValue(org);
+      (subscriptionRepository.findActiveSubscriptionsByOwner as any).mockResolvedValue([
+        { id: 's1', source: SubscriptionSource.Stripe, subscriptionId: 'sub_x', quantity: 30 },
+      ]);
+
+      const result = await reconcileOrgSeatsFromSubscription('orgR');
+
+      expect(result).toEqual({ organization: org, before: 10, after: 30 });
+      expect(organizationRepository.update).toHaveBeenCalledWith(expect.objectContaining({ id: 'orgR', seats: 30 }));
+    });
+
+    it('is a no-op when seats already match the billed quantity', async () => {
+      const org = orgFixture({ id: 'orgR', seats: 30, users: [] });
+      (organizationRepository.findById as any).mockResolvedValue(org);
+      (subscriptionRepository.findActiveSubscriptionsByOwner as any).mockResolvedValue([
+        { id: 's1', source: SubscriptionSource.Stripe, subscriptionId: 'sub_x', quantity: 30 },
+      ]);
+
+      const result = await reconcileOrgSeatsFromSubscription('orgR');
+
+      expect(result).toEqual({ organization: org, before: 30, after: 30 });
+      expect(organizationRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the org has no active subscription to reconcile from', async () => {
+      (organizationRepository.findById as any).mockResolvedValue(orgFixture({ id: 'orgR', seats: 10, users: [] }));
+      (subscriptionRepository.findActiveSubscriptionsByOwner as any).mockResolvedValue([]);
+
+      const result = await reconcileOrgSeatsFromSubscription('orgR');
+
+      expect(result).toBeNull();
       expect(organizationRepository.update).not.toHaveBeenCalled();
     });
   });

--- a/apps/client/server/services/organizationService.test.ts
+++ b/apps/client/server/services/organizationService.test.ts
@@ -281,5 +281,20 @@ describe('organizationService', () => {
       expect(result).toBeNull();
       expect(organizationRepository.update).not.toHaveBeenCalled();
     });
+
+    it('returns null (no repair) when the only active subscription is an admin_grant', async () => {
+      // A grant has no billed quantity, so the skip-validation rationale does not
+      // hold; grant-org seat changes must go through setSeats instead. Reconcile
+      // must not pull seats down to the grant quantity.
+      (organizationRepository.findById as any).mockResolvedValue(orgFixture({ id: 'orgR', seats: 20, users: [] }));
+      (subscriptionRepository.findActiveSubscriptionsByOwner as any).mockResolvedValue([
+        { id: 'g1', source: SubscriptionSource.AdminGrant, subscriptionId: 'admin_grant_x', quantity: 5 },
+      ]);
+
+      const result = await reconcileOrgSeatsFromSubscription('orgR');
+
+      expect(result).toBeNull();
+      expect(organizationRepository.update).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/client/server/services/organizationService.ts
+++ b/apps/client/server/services/organizationService.ts
@@ -167,15 +167,19 @@ export async function setSeats(orgId: string, newSeats: number, actor: SeatChang
  * checkout granted credits and created the Subscription row but left
  * `organization.seats` at its default).
  *
- * Pulls FROM `subscription.quantity` - the Stripe-synced billed quantity kept
+ * Pulls FROM a Stripe-managed `subscription.quantity` - the billed quantity kept
  * current by the webhooks - so, unlike `setSeats` from the admin panel, it is
  * safe on Stripe-billed orgs: it aligns the local seat count to what Stripe
  * already invoices and never changes the invoiced quantity itself. Validation
  * is intentionally skipped for the same reason (we must reflect a paid
  * quantity, not reject it).
  *
+ * admin_grant subs are deliberately excluded: a grant has no billed quantity, so
+ * that skip-validation rationale does not hold. Grant-org seat changes must go
+ * through setSeats (the admin seats endpoint), which validates against team size.
+ *
  * Returns the before/after seat counts, or null when the org has no active
- * subscription to reconcile from.
+ * Stripe subscription to reconcile from.
  */
 export async function reconcileOrgSeatsFromSubscription(
   orgId: string
@@ -187,7 +191,10 @@ export async function reconcileOrgSeatsFromSubscription(
     SubscriptionOwnerType.Organization,
     organization.id
   );
-  const primary = pickPrimarySubscription(activeSubs);
+  const stripeSubs = activeSubs.filter(
+    s => resolveSubscriptionSource(s) === SubscriptionSource.Stripe && Boolean(s.subscriptionId)
+  );
+  const primary = pickPrimarySubscription(stripeSubs);
   if (!primary) return null;
 
   const before = organization.seats;
@@ -195,7 +202,7 @@ export async function reconcileOrgSeatsFromSubscription(
   if (before === after) return { organization, before, after };
 
   organization.seats = after;
-  await organizationRepository.update(organization);
+  await organizationRepository.update({ id: organization.id, seats: after });
 
   return { organization, before, after };
 }

--- a/apps/client/server/services/organizationService.ts
+++ b/apps/client/server/services/organizationService.ts
@@ -160,3 +160,42 @@ export async function setSeats(orgId: string, newSeats: number, actor: SeatChang
     return organization;
   });
 }
+
+/**
+ * Repair an org whose `seats` drifted below its active subscription's billed
+ * quantity (the historical initial-purchase bug: an existing org's first Stripe
+ * checkout granted credits and created the Subscription row but left
+ * `organization.seats` at its default).
+ *
+ * Pulls FROM `subscription.quantity` - the Stripe-synced billed quantity kept
+ * current by the webhooks - so, unlike `setSeats` from the admin panel, it is
+ * safe on Stripe-billed orgs: it aligns the local seat count to what Stripe
+ * already invoices and never changes the invoiced quantity itself. Validation
+ * is intentionally skipped for the same reason (we must reflect a paid
+ * quantity, not reject it).
+ *
+ * Returns the before/after seat counts, or null when the org has no active
+ * subscription to reconcile from.
+ */
+export async function reconcileOrgSeatsFromSubscription(
+  orgId: string
+): Promise<{ organization: IOrganizationDocument; before: number; after: number } | null> {
+  const organization = await organizationRepository.findById(orgId);
+  if (!organization) throw new NotFoundError('Organization not found');
+
+  const activeSubs = await subscriptionRepository.findActiveSubscriptionsByOwner(
+    SubscriptionOwnerType.Organization,
+    organization.id
+  );
+  const primary = pickPrimarySubscription(activeSubs);
+  if (!primary) return null;
+
+  const before = organization.seats;
+  const after = primary.quantity;
+  if (before === after) return { organization, before, after };
+
+  organization.seats = after;
+  await organizationRepository.update(organization);
+
+  return { organization, before, after };
+}


### PR DESCRIPTION
Closes #1602

## Description

An existing organization that buys seats through the self-serve Stripe checkout gets charged, but its seat count never updates. The payment, the `Subscription` record, and the seat credits all land correctly, yet `organization.seats` stays at the schema default (10) while the customer has paid for more.

**Root cause.** An existing org's first subscription drives `invoice.payment_succeeded` with `billing_reason = subscription_create`. In `handleOrganizationSubscriptionInvoice`, that branch is asymmetric:

- The **new-org** path sets `seats: subscriptionQuantity` at `organizationService.create`.
- The **existing-org** path (`metadata.organizationId`) only did `findById`, then created the `Subscription` row and granted credits for the purchased quantity, but **never wrote `organization.seats`**.

The only other place that syncs seats from Stripe (`setSeats`) runs on `customer.subscription.updated` and the admin endpoint. Stripe does not emit `updated` for a brand-new subscription, so nothing ever set the seats on the initial purchase. (Later seat *changes* work, because those do emit `updated`.)

This was confirmed against a real affected org: an active `stripe` subscription with `quantity: 30`, `currentCredits` exactly `30 * 50000`, and `organization.seats` still `10`.

## Changes

- **`serverUtils.ts`** - the existing-org `subscription_create` branch now writes `organization.seats = subscriptionQuantity`. Placed before the idempotency `break` so webhook retries self-heal, and written directly (not via `setSeats`) so it can never *reject* a quantity Stripe already charged for.
- **`reconcile-seats.ts`** (new admin endpoint, `POST /api/admin/organizations/[id]/reconcile-seats`) - repairs orgs already left with stale seats. It pulls FROM the active subscription's billed quantity, so - unlike `PATCH .../seats`, which deliberately refuses Stripe-billed orgs - it is safe on Stripe-billed orgs: it aligns the local seat count to what Stripe already invoices and never changes the invoiced quantity.
- **`organizationService.ts`** - `reconcileOrgSeatsFromSubscription(orgId)` service behind the endpoint.
- **Platform-admin UI** - the Organizations tab per-org menu now shows a "Reconcile seats from Stripe" action for non-granted, non-personal orgs, so admins can trigger the repair without a terminal. It toasts the `before -> after` change. New `useReconcileOrgSeats` hook mirrors `useAdjustOrgSeats`.
- Regression tests for the initial-purchase seat write, the reconcile service, and the reconcile hook.

## Guide for Testers

The webhook fix is exercised by unit tests; the admin repair path can be driven from the UI or the API. To verify end-to-end on a preview or staging:

**C. Reconcile via the platform-admin UI (no terminal)**
1. Log in as a platform admin at `app.<env>.bike4mind.com`.
2. Go to Account menu -> Admin -> Organizations tab.
3. Find a Stripe-billed org whose seats are stale, open its actions menu (the `...` button, `org-actions-<id>`).
4. Click "Reconcile seats from Stripe" (`reconcile-seats-<id>`).
5. Expected: a success toast "Seats reconciled: 10 -> 30" (or "Seats already in sync (N)"), and the org's seat count refreshes in the table.
6. Note: the action is hidden for admin_grant orgs (those use "Adjust seats") and for personal orgs.

**A. Fix an already-affected org via the new admin endpoint**
1. Identify an org that paid for seats but shows fewer seats than its active subscription quantity (e.g. seats `10`, subscription `quantity 30`).
2. As a platform admin, `POST` to `app.<env>.bike4mind.com/api/admin/organizations/<orgId>/reconcile-seats` with an `Authorization: Bearer <admin token>` header and an empty body.
3. Expected: `200` with `{ "organizationId": "<orgId>", "before": 10, "after": 30 }`.
4. `GET /api/organizations/<orgId>` and confirm `seats` is now `30`.
5. Re-run step 2. Expected: still `200`, now `{ "before": 30, "after": 30 }` (idempotent no-op).
6. Call it for an org with no active subscription. Expected: `400` "Organization has no active subscription to reconcile seats from".
7. Call it as a non-admin user. Expected: `403`.

**B. New initial purchase (regression)**
1. As an org admin of an existing org, go to Account menu -> Subscriptions and subscribe with a test card, choosing e.g. 12 seats on the Stripe checkout page.
2. After Stripe redirects back, `GET /api/organizations/<orgId>`.
3. Expected: `seats` equals the quantity you selected (12), an active `stripe` subscription exists with matching `quantity`, and credits increased by `quantity * 50000`.

### Regression Checks
- Admin seat change on a non-Stripe (admin_grant) org via `PATCH /api/admin/organizations/[id]/seats` still works.
- `PATCH .../seats` still refuses a Stripe-billed org (the reconcile endpoint is the path for those).
- New-org self-serve subscription still creates the org with the purchased seat count.
- A seat quantity change on an existing subscription (Stripe billing portal) still updates seats via `customer.subscription.updated`.

### What NOT to test
- No UI changes in this PR.
- No changes to credit amounts, pricing, or the checkout/quantity selection flow.

## Additional Information

Same bug is latent in production: any existing org that self-serve-subscribed may have `seats` stuck at the default while paying for more. Remediation for those orgs: after this deploys, either resend the `invoice.payment_succeeded` event from the Stripe dashboard (the fix is idempotent - heals seats, no double credit grant), or call the new `reconcile-seats` endpoint per affected org.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings