### PR TITLE
feat(drive-as-lake): OrgGoogleDriveConnection model + server-side folder listing

### DIFF
--- a/apps/client/pages/api/google-drive/list-folder.ts
+++ b/apps/client/pages/api/google-drive/list-folder.ts
@@ -12,8 +12,12 @@ import {
  * List the immediate children of a Google Drive folder, server-side, using the current user's
  * connected Drive OAuth credential. This is the read primitive the Drive-as-lake ingest (issue C)
  * builds on, and the surface the live smoke test exercises (#1588).
+ *
+ * `auth: 'jwtOnly'` keeps this OFF the api-key surface: it walks the caller's whole Drive a folder
+ * at a time under drive.readonly, which an unrelated `b4m_live_` key should not authorize. It's an
+ * internal/UI surface, not a public contract endpoint, so a key-bearing request is rejected outright.
  */
-const handler = baseApi().post(
+const handler = baseApi({ auth: 'jwtOnly' }).post(
   asyncHandler<{}, unknown, { folderId?: string }>(async (req, res) => {
     const folderId = req.body?.folderId;
     if (!folderId || typeof folderId !== 'string') {

--- a/apps/client/pages/api/google-drive/list-folder.ts
+++ b/apps/client/pages/api/google-drive/list-folder.ts
@@ -2,7 +2,11 @@ import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
 import { BadRequestError } from '@server/utils/errors';
 import { getValidUserDriveAccessToken } from '@server/integrations/google/drive/common';
-import { createDriveClient, listFolderChildren } from '@server/integrations/google/drive/driveClient';
+import {
+  createDriveClient,
+  listFolderChildren,
+  isValidDriveFolderId,
+} from '@server/integrations/google/drive/driveClient';
 
 /**
  * List the immediate children of a Google Drive folder, server-side, using the current user's
@@ -14,6 +18,9 @@ const handler = baseApi().post(
     const folderId = req.body?.folderId;
     if (!folderId || typeof folderId !== 'string') {
       throw new BadRequestError('folderId is required');
+    }
+    if (!isValidDriveFolderId(folderId)) {
+      throw new BadRequestError('folderId is not a valid Drive folder id');
     }
 
     const accessToken = await getValidUserDriveAccessToken(req.user.id);

--- a/apps/client/pages/api/google-drive/list-folder.ts
+++ b/apps/client/pages/api/google-drive/list-folder.ts
@@ -1,0 +1,33 @@
+import { asyncHandler } from '@server/middlewares/asyncHandler';
+import { baseApi } from '@server/middlewares/baseApi';
+import { BadRequestError } from '@server/utils/errors';
+import { getValidUserDriveAccessToken } from '@server/integrations/google/drive/common';
+import { createDriveClient, listFolderChildren } from '@server/integrations/google/drive/driveClient';
+
+/**
+ * List the immediate children of a Google Drive folder, server-side, using the current user's
+ * connected Drive OAuth credential. This is the read primitive the Drive-as-lake ingest (issue C)
+ * builds on, and the surface the live smoke test exercises (#1588).
+ */
+const handler = baseApi().post(
+  asyncHandler<{}, unknown, { folderId?: string }>(async (req, res) => {
+    const folderId = req.body?.folderId;
+    if (!folderId || typeof folderId !== 'string') {
+      throw new BadRequestError('folderId is required');
+    }
+
+    const accessToken = await getValidUserDriveAccessToken(req.user.id);
+    const drive = createDriveClient(accessToken);
+    const files = await listFolderChildren(drive, folderId);
+
+    return res.json({ folderId, count: files.length, files });
+  })
+);
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default handler;

--- a/apps/client/server/integrations/google/drive/common.ts
+++ b/apps/client/server/integrations/google/drive/common.ts
@@ -1,5 +1,8 @@
 import { Config } from '@server/utils/config';
 import { google } from 'googleapis';
+import dayjs from 'dayjs';
+import { User } from '@bike4mind/database';
+import { encryptToken, decryptToken } from '@server/security/tokenEncryption';
 
 const SCOPES = ['https://www.googleapis.com/auth/drive.readonly'];
 
@@ -27,4 +30,40 @@ export async function refreshAccessToken(refreshToken: string) {
 
 export async function revokeToken(accessToken: string) {
   await oauth2Client.revokeToken(accessToken);
+}
+
+/**
+ * Resolve a valid Google Drive access token for a user from their stored (encrypted) OAuth
+ * credential, refreshing + persisting it if expired. Throws if the user has no connection or the
+ * refresh fails - the caller decides whether to surface a re-auth prompt.
+ *
+ * NOTE: `pages/api/google-drive/token.ts` has parallel inline logic tuned to return an authUrl on
+ * failure for the browser attach flow; this helper is the throw-on-failure form for server jobs.
+ * Keep the two in sync if the refresh/persist shape changes.
+ */
+export async function getValidUserDriveAccessToken(userId: string): Promise<string> {
+  const user = await User.findById(userId, 'googleDrive');
+  if (!user?.googleDrive) throw new Error('Google Drive not connected');
+
+  const { accessToken: rawAccess, refreshToken: rawRefresh, expiresAt } = user.googleDrive;
+  const accessToken = decryptToken(rawAccess);
+  const isExpired = !expiresAt || dayjs().isAfter(dayjs(expiresAt));
+  if (!isExpired && accessToken) return accessToken;
+
+  const refreshToken = decryptToken(rawRefresh);
+  if (!refreshToken) throw new Error('Google Drive refresh token missing - reconnect required');
+
+  const credentials = await refreshAccessToken(refreshToken);
+  if (!credentials.access_token) throw new Error('Google Drive token refresh returned no access token');
+
+  await User.updateOne(
+    { _id: userId },
+    {
+      'googleDrive.accessToken': encryptToken(credentials.access_token)!,
+      'googleDrive.refreshToken': credentials.refresh_token ? encryptToken(credentials.refresh_token)! : rawRefresh,
+      'googleDrive.expiresAt': credentials.expiry_date ? new Date(credentials.expiry_date) : undefined,
+    }
+  );
+
+  return credentials.access_token;
 }

--- a/apps/client/server/integrations/google/drive/common.ts
+++ b/apps/client/server/integrations/google/drive/common.ts
@@ -79,22 +79,18 @@ export async function getValidUserDriveAccessToken(userId: string): Promise<stri
   const credentials = await refreshAccessToken(refreshToken);
   if (!credentials.access_token) throw new BadRequestError('Google Drive token refresh returned no access token');
 
-  const update: { $set: Record<string, unknown>; $unset?: Record<string, 1> } = {
-    $set: {
+  await User.updateOne(
+    { _id: userId },
+    {
       'googleDrive.accessToken': encryptToken(credentials.access_token)!,
       'googleDrive.refreshToken': credentials.refresh_token ? encryptToken(credentials.refresh_token)! : rawRefresh,
-    },
-  };
-  // expiresAt is `required` in the schema, so persisting null makes the whole googleDrive subdoc
-  // invalid and fails the NEXT user.save() anywhere (e.g. the websocket connect handler) - not here.
-  // $unset instead: an absent value reads as expired via the `!expiresAt` check above, preserving
-  // the "unknown -> refresh" intent without writing an invalid value.
-  if (credentials.expiry_date) {
-    update.$set['googleDrive.expiresAt'] = new Date(credentials.expiry_date);
-  } else {
-    update.$unset = { 'googleDrive.expiresAt': 1 };
-  }
-  await User.updateOne({ _id: userId }, update);
+      // expiresAt is `required`, so it must be a real Date - both `null` AND an absent ($unset) path
+      // fail the validator on the next user.save() (e.g. the websocket connect handler). When Google
+      // omits expiry_date, write epoch: it satisfies `required` and `dayjs().isAfter(epoch)` reads as
+      // already-expired, so the next call refreshes.
+      'googleDrive.expiresAt': credentials.expiry_date ? new Date(credentials.expiry_date) : new Date(0),
+    }
+  );
 
   return credentials.access_token;
 }

--- a/apps/client/server/integrations/google/drive/common.ts
+++ b/apps/client/server/integrations/google/drive/common.ts
@@ -3,6 +3,7 @@ import { google } from 'googleapis';
 import dayjs from 'dayjs';
 import { User } from '@bike4mind/database';
 import { encryptToken, decryptToken } from '@server/security/tokenEncryption';
+import { BadRequestError } from '@server/utils/errors';
 
 const SCOPES = ['https://www.googleapis.com/auth/drive.readonly'];
 
@@ -23,8 +24,13 @@ export async function getTokens(code: string) {
 }
 
 export async function refreshAccessToken(refreshToken: string) {
-  oauth2Client.setCredentials({ refresh_token: refreshToken });
-  const { credentials } = await oauth2Client.refreshAccessToken();
+  // Fresh client per call - NEVER the shared module-level `oauth2Client`. google-auth-library
+  // re-reads `refresh_token` off the client's mutable `credentials` AFTER the network await, so a
+  // concurrent refresh for another user racing on the shared singleton can cross-write one user's
+  // refresh token into another user's persisted record (same hazard createDriveClient avoids).
+  const client = new google.auth.OAuth2(Config.GOOGLE_CLIENT_ID, Config.GOOGLE_CLIENT_SECRET, REDIRECT_URI);
+  client.setCredentials({ refresh_token: refreshToken });
+  const { credentials } = await client.refreshAccessToken();
   return credentials;
 }
 
@@ -43,25 +49,38 @@ export async function revokeToken(accessToken: string) {
  */
 export async function getValidUserDriveAccessToken(userId: string): Promise<string> {
   const user = await User.findById(userId, 'googleDrive');
-  if (!user?.googleDrive) throw new Error('Google Drive not connected');
+  // Expected user states (not connected / needs reconnect) are BadRequestError, not bare Error:
+  // errorHandler only maps status-bearing errors, so a bare Error here becomes a 500 logged at
+  // `error` level, which trips the LiveOps CloudWatch filter for the most common non-error state.
+  if (!user?.googleDrive) throw new BadRequestError('Google Drive not connected');
 
   const { accessToken: rawAccess, refreshToken: rawRefresh, expiresAt } = user.googleDrive;
-  const accessToken = decryptToken(rawAccess);
+  // A corrupt/undecryptable CACHED access token must not hard-fail - fall through to the refresh
+  // path, which can still succeed from the refresh token.
+  let accessToken: string | null = null;
+  try {
+    accessToken = decryptToken(rawAccess);
+  } catch {
+    accessToken = null;
+  }
   const isExpired = !expiresAt || dayjs().isAfter(dayjs(expiresAt));
   if (!isExpired && accessToken) return accessToken;
 
   const refreshToken = decryptToken(rawRefresh);
-  if (!refreshToken) throw new Error('Google Drive refresh token missing - reconnect required');
+  if (!refreshToken) throw new BadRequestError('Google Drive refresh token missing - reconnect required');
 
   const credentials = await refreshAccessToken(refreshToken);
-  if (!credentials.access_token) throw new Error('Google Drive token refresh returned no access token');
+  if (!credentials.access_token) throw new BadRequestError('Google Drive token refresh returned no access token');
 
   await User.updateOne(
     { _id: userId },
     {
       'googleDrive.accessToken': encryptToken(credentials.access_token)!,
       'googleDrive.refreshToken': credentials.refresh_token ? encryptToken(credentials.refresh_token)! : rawRefresh,
-      'googleDrive.expiresAt': credentials.expiry_date ? new Date(credentials.expiry_date) : undefined,
+      // null, not undefined: Mongoose strips undefined from $set, which would leave a stale
+      // (already-expired) expiresAt and force a re-refresh every call. null reads as "unknown" ->
+      // expired -> one refresh next time.
+      'googleDrive.expiresAt': credentials.expiry_date ? new Date(credentials.expiry_date) : null,
     }
   );
 

--- a/apps/client/server/integrations/google/drive/common.ts
+++ b/apps/client/server/integrations/google/drive/common.ts
@@ -66,23 +66,35 @@ export async function getValidUserDriveAccessToken(userId: string): Promise<stri
   const isExpired = !expiresAt || dayjs().isAfter(dayjs(expiresAt));
   if (!isExpired && accessToken) return accessToken;
 
-  const refreshToken = decryptToken(rawRefresh);
-  if (!refreshToken) throw new BadRequestError('Google Drive refresh token missing - reconnect required');
+  // Same corrupt-credential shape as the cached access token: an undecryptable refresh token
+  // (post key-rotation / partial restore) must be a reconnect (400), not a bare Error -> 500.
+  let refreshToken: string | null = null;
+  try {
+    refreshToken = decryptToken(rawRefresh);
+  } catch {
+    refreshToken = null;
+  }
+  if (!refreshToken) throw new BadRequestError('Google Drive refresh token unreadable - reconnect required');
 
   const credentials = await refreshAccessToken(refreshToken);
   if (!credentials.access_token) throw new BadRequestError('Google Drive token refresh returned no access token');
 
-  await User.updateOne(
-    { _id: userId },
-    {
+  const update: { $set: Record<string, unknown>; $unset?: Record<string, 1> } = {
+    $set: {
       'googleDrive.accessToken': encryptToken(credentials.access_token)!,
       'googleDrive.refreshToken': credentials.refresh_token ? encryptToken(credentials.refresh_token)! : rawRefresh,
-      // null, not undefined: Mongoose strips undefined from $set, which would leave a stale
-      // (already-expired) expiresAt and force a re-refresh every call. null reads as "unknown" ->
-      // expired -> one refresh next time.
-      'googleDrive.expiresAt': credentials.expiry_date ? new Date(credentials.expiry_date) : null,
-    }
-  );
+    },
+  };
+  // expiresAt is `required` in the schema, so persisting null makes the whole googleDrive subdoc
+  // invalid and fails the NEXT user.save() anywhere (e.g. the websocket connect handler) - not here.
+  // $unset instead: an absent value reads as expired via the `!expiresAt` check above, preserving
+  // the "unknown -> refresh" intent without writing an invalid value.
+  if (credentials.expiry_date) {
+    update.$set['googleDrive.expiresAt'] = new Date(credentials.expiry_date);
+  } else {
+    update.$unset = { 'googleDrive.expiresAt': 1 };
+  }
+  await User.updateOne({ _id: userId }, update);
 
   return credentials.access_token;
 }

--- a/apps/client/server/integrations/google/drive/driveClient.test.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { drive_v3 } from 'googleapis';
-import { listFolderChildren, isFolder, FOLDER_MIME_TYPE } from './driveClient';
+import { listFolderChildren, isFolder, isValidDriveFolderId, FOLDER_MIME_TYPE } from './driveClient';
 
 /**
  * Mocks just the `files.list` surface listFolderChildren uses, returning a queue of pages so
@@ -51,6 +51,26 @@ describe('listFolderChildren', () => {
 
     const files = await listFolderChildren(drive, 'FOLDER_X');
     expect(files).toEqual([{ id: '1', name: 'ok.txt', mimeType: 'text/plain' }]);
+  });
+
+  it('throws on an invalid folder id before issuing any query (injection guard)', async () => {
+    const { drive, list } = mockDrive([{ files: [] }]);
+    await expect(listFolderChildren(drive, "x' in parents or '1'='1")).rejects.toThrow(/Invalid Drive folder id/);
+    expect(list).not.toHaveBeenCalled();
+  });
+});
+
+describe('isValidDriveFolderId', () => {
+  it('accepts real Drive ids and the root alias', () => {
+    expect(isValidDriveFolderId('1_BPIetEv-aLXcWp5Tvhc0miCMA2Hwc11')).toBe(true);
+    expect(isValidDriveFolderId('root')).toBe(true);
+  });
+
+  it('rejects ids with quotes, spaces, or empty/non-string input', () => {
+    expect(isValidDriveFolderId("x' in parents")).toBe(false);
+    expect(isValidDriveFolderId('has space')).toBe(false);
+    expect(isValidDriveFolderId('')).toBe(false);
+    expect(isValidDriveFolderId(undefined)).toBe(false);
   });
 });
 

--- a/apps/client/server/integrations/google/drive/driveClient.test.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { drive_v3 } from 'googleapis';
+import { listFolderChildren, isFolder, FOLDER_MIME_TYPE } from './driveClient';
+
+/**
+ * Mocks just the `files.list` surface listFolderChildren uses, returning a queue of pages so
+ * pagination and the shared-drive flags can be asserted without hitting Google.
+ */
+function mockDrive(pages: Array<{ files?: unknown[]; nextPageToken?: string }>) {
+  const list = vi.fn();
+  for (const page of pages) list.mockResolvedValueOnce({ data: page });
+  return { drive: { files: { list } } as unknown as drive_v3.Drive, list };
+}
+
+describe('listFolderChildren', () => {
+  it('scopes the query to the folder and requests shared-drive items', async () => {
+    const { drive, list } = mockDrive([{ files: [] }]);
+    await listFolderChildren(drive, 'FOLDER_X');
+
+    expect(list).toHaveBeenCalledTimes(1);
+    const args = list.mock.calls[0][0];
+    expect(args.q).toContain("'FOLDER_X' in parents");
+    expect(args.q).toContain('trashed = false');
+    expect(args.supportsAllDrives).toBe(true);
+    expect(args.includeItemsFromAllDrives).toBe(true);
+  });
+
+  it('follows pagination and concatenates every page', async () => {
+    const { drive, list } = mockDrive([
+      { files: [{ id: '1', name: 'a.txt', mimeType: 'text/plain' }], nextPageToken: 'p2' },
+      { files: [{ id: '2', name: 'b.txt', mimeType: 'text/plain' }] },
+    ]);
+
+    const files = await listFolderChildren(drive, 'FOLDER_X');
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(list.mock.calls[1][0].pageToken).toBe('p2');
+    expect(files.map(f => f.id)).toEqual(['1', '2']);
+  });
+
+  it('skips entries missing id/name/mimeType', async () => {
+    const { drive } = mockDrive([
+      {
+        files: [
+          { id: '1', name: 'ok.txt', mimeType: 'text/plain' },
+          { id: '2', name: 'no-mime' }, // dropped
+          { name: 'no-id', mimeType: 'text/plain' }, // dropped
+        ],
+      },
+    ]);
+
+    const files = await listFolderChildren(drive, 'FOLDER_X');
+    expect(files).toEqual([{ id: '1', name: 'ok.txt', mimeType: 'text/plain' }]);
+  });
+});
+
+describe('isFolder', () => {
+  it('detects the Drive folder mime type', () => {
+    expect(isFolder({ id: '1', name: 'sub', mimeType: FOLDER_MIME_TYPE })).toBe(true);
+    expect(isFolder({ id: '2', name: 'a.txt', mimeType: 'text/plain' })).toBe(false);
+  });
+});

--- a/apps/client/server/integrations/google/drive/driveClient.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.ts
@@ -8,6 +8,14 @@ export function isFolder(file: DriveFile): boolean {
   return file.mimeType === FOLDER_MIME_TYPE;
 }
 
+// Drive file/folder ids are URL-safe tokens ([A-Za-z0-9_-]); the alias 'root' also matches.
+// Validate before interpolating into the `q` string so a crafted id can't break out of the query.
+const DRIVE_FOLDER_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export function isValidDriveFolderId(id: unknown): id is string {
+  return typeof id === 'string' && DRIVE_FOLDER_ID_PATTERN.test(id);
+}
+
 /**
  * Build a per-call Drive v3 client from an OAuth access token.
  *
@@ -30,6 +38,12 @@ export function createDriveClient(accessToken: string): drive_v3.Drive {
  * ingest job (issue C); this is the read primitive the smoke test and ingest both build on.
  */
 export async function listFolderChildren(drive: drive_v3.Drive, folderId: string): Promise<DriveFile[]> {
+  // Defense-in-depth: never interpolate an unvalidated id into the query (callers should also
+  // validate at their trust boundary).
+  if (!isValidDriveFolderId(folderId)) {
+    throw new Error(`Invalid Drive folder id: ${folderId}`);
+  }
+
   const files: DriveFile[] = [];
   let pageToken: string | undefined;
 

--- a/apps/client/server/integrations/google/drive/driveClient.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.ts
@@ -1,0 +1,57 @@
+import { google, drive_v3 } from 'googleapis';
+
+export type DriveFile = { id: string; name: string; mimeType: string };
+
+export const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
+
+export function isFolder(file: DriveFile): boolean {
+  return file.mimeType === FOLDER_MIME_TYPE;
+}
+
+/**
+ * Build a per-call Drive v3 client from an OAuth access token.
+ *
+ * IMPORTANT: constructs a FRESH OAuth2 client every call. Never reuse the module-level
+ * singleton in common.ts - its credentials are mutable shared state (`setCredentials`), so
+ * concurrent multi-tenant syncs on one process would race and bleed tokens across tenants.
+ */
+export function createDriveClient(accessToken: string): drive_v3.Drive {
+  const auth = new google.auth.OAuth2();
+  auth.setCredentials({ access_token: accessToken });
+  return google.drive({ version: 'v3', auth });
+}
+
+/**
+ * List the immediate children of a Drive folder (one level), following pagination.
+ *
+ * `supportsAllDrives`/`includeItemsFromAllDrives` are set so items that live in a Shared Drive
+ * are returned - omitting them silently drops shared-drive items (a bug that passes unit tests
+ * and fails in prod). The recursive tree-walk and content download/export are layered on in the
+ * ingest job (issue C); this is the read primitive the smoke test and ingest both build on.
+ */
+export async function listFolderChildren(drive: drive_v3.Drive, folderId: string): Promise<DriveFile[]> {
+  const files: DriveFile[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const res = await drive.files.list({
+      q: `'${folderId}' in parents and trashed = false`,
+      fields: 'nextPageToken, files(id, name, mimeType)',
+      pageSize: 1000,
+      supportsAllDrives: true,
+      includeItemsFromAllDrives: true,
+      pageToken,
+    });
+
+    for (const f of res.data.files ?? []) {
+      // Skip anything missing an id/name/mimeType - it isn't a usable ingest candidate.
+      if (f.id && f.name && f.mimeType) {
+        files.push({ id: f.id, name: f.name, mimeType: f.mimeType });
+      }
+    }
+
+    pageToken = res.data.nextPageToken ?? undefined;
+  } while (pageToken);
+
+  return files;
+}

--- a/apps/client/server/integrations/google/drive/driveClient.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.ts
@@ -17,8 +17,9 @@ export function isValidDriveFolderId(id: unknown): id is string {
   return typeof id === 'string' && DRIVE_FOLDER_ID_PATTERN.test(id);
 }
 
-// Defensive cap: a folder shouldn't exceed this many pages of children, and an unbounded loop on a
-// pathological/looping pageToken would issue unlimited outbound Drive calls. 100 x pageSize(1000).
+// Page cap: bounds outbound Drive calls against a pathological/looping pageToken. Exceeding it
+// THROWS in listFolderChildren rather than truncating - a partial listing under a "the folder's
+// children" contract would silently drop files. 100 x pageSize(1000) = 100k children.
 const MAX_LIST_PAGES = 100;
 
 /**
@@ -72,7 +73,13 @@ export async function listFolderChildren(drive: drive_v3.Drive, folderId: string
 
     pageToken = res.data.nextPageToken ?? undefined;
     pages++;
-  } while (pageToken && pages < MAX_LIST_PAGES);
+    // Fail loudly rather than silently truncate: a partial answer under "the folder's children"
+    // would let ingest drop files while reporting success. Throwing forces the incremental design
+    // at the point it belongs (issue C).
+    if (pageToken && pages >= MAX_LIST_PAGES) {
+      throw new Error(`Drive folder ${folderId} exceeded ${MAX_LIST_PAGES} pages; listing is not exhaustive`);
+    }
+  } while (pageToken);
 
   return files;
 }

--- a/apps/client/server/integrations/google/drive/driveClient.ts
+++ b/apps/client/server/integrations/google/drive/driveClient.ts
@@ -8,13 +8,18 @@ export function isFolder(file: DriveFile): boolean {
   return file.mimeType === FOLDER_MIME_TYPE;
 }
 
-// Drive file/folder ids are URL-safe tokens ([A-Za-z0-9_-]); the alias 'root' also matches.
-// Validate before interpolating into the `q` string so a crafted id can't break out of the query.
-const DRIVE_FOLDER_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+// Drive file/folder ids are URL-safe tokens ([A-Za-z0-9_-]); the alias 'root' also matches. The
+// length bound (real ids are ~33-44 chars) stops ~1MB of legal characters being interpolated into
+// the `q` string and sent outbound. Validate before interpolating so a crafted id can't break out.
+const DRIVE_FOLDER_ID_PATTERN = /^[A-Za-z0-9_-]{1,256}$/;
 
 export function isValidDriveFolderId(id: unknown): id is string {
   return typeof id === 'string' && DRIVE_FOLDER_ID_PATTERN.test(id);
 }
+
+// Defensive cap: a folder shouldn't exceed this many pages of children, and an unbounded loop on a
+// pathological/looping pageToken would issue unlimited outbound Drive calls. 100 x pageSize(1000).
+const MAX_LIST_PAGES = 100;
 
 /**
  * Build a per-call Drive v3 client from an OAuth access token.
@@ -46,6 +51,7 @@ export async function listFolderChildren(drive: drive_v3.Drive, folderId: string
 
   const files: DriveFile[] = [];
   let pageToken: string | undefined;
+  let pages = 0;
 
   do {
     const res = await drive.files.list({
@@ -65,7 +71,8 @@ export async function listFolderChildren(drive: drive_v3.Drive, folderId: string
     }
 
     pageToken = res.data.nextPageToken ?? undefined;
-  } while (pageToken);
+    pages++;
+  } while (pageToken && pages < MAX_LIST_PAGES);
 
   return files;
 }

--- a/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
+++ b/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
@@ -1,0 +1,170 @@
+import { IBaseRepository } from './BaseTypes';
+import { IMongoDocument } from './common';
+
+/**
+ * Auth method for an org-level Google Drive connection.
+ * v1 implements only 'oauth' (an org admin connects a Google account); 'service_account'
+ * is a reserved, deferred cloud-only mode. See the #1587 auth-model resolution.
+ */
+export type GoogleDriveConnectionAuthMode = 'oauth' | 'service_account';
+
+/**
+ * Health/lifecycle state of the connection.
+ * - connected: syncing normally
+ * - needs_reconnect: the folder is no longer reachable (un-shared / trashed: 403/404 on the folder)
+ * - credential_error: the stored credential failed (e.g. invalid_grant) - operator/admin attention
+ */
+export type GoogleDriveConnectionStatus = 'connected' | 'needs_reconnect' | 'credential_error';
+
+/**
+ * Organization-level Google Drive connection: binds a single Drive folder to a single
+ * data lake so the folder's contents are ingested and kept in sync.
+ *
+ * Unlike the per-user `User.googleDrive`, the credential is org-owned and lives here, so a
+ * reconnect is an explicit admin action rather than a silent outage when the connecting
+ * user churns. Follows the org-connection pattern of IOrgGitHubConnection / IOrgJiraConnection
+ * (org-scoped collection, secret excluded from default reads, encrypted at rest).
+ *
+ * An org may hold MANY connections (one per folder/lake). A given Drive folder is claimable by
+ * at most one org, ever (global uniqueness on driveFolderId), and a lake is fed by at most one
+ * folder (v1). See OrgGoogleDriveConnectionModel for the indexes that enforce this.
+ */
+export interface IOrgGoogleDriveConnection {
+  /** Organization that owns this connection (required - no system-default row). */
+  organizationId: string;
+
+  /** Authentication method (v1: 'oauth'). */
+  authMode: GoogleDriveConnectionAuthMode;
+
+  /** Google Drive folder id being ingested. Globally unique across all orgs. */
+  driveFolderId: string;
+
+  /** Human-readable folder name (for admin UI; not authoritative). */
+  folderName?: string;
+
+  /** The data lake this folder feeds (FK -> DataLake). */
+  targetDataLakeId: string;
+
+  /**
+   * OAuth refresh token for the org-owned Google connection, ENCRYPTED at rest.
+   * SECURITY: `select: false` in the schema; only ever read via findByIdWithCredentials
+   * and decrypted server-side. Never include in an API response.
+   */
+  oauthRefreshToken?: string;
+
+  // === Metadata ===
+
+  /** User id who created the connection. */
+  connectedBy: string;
+
+  /** When the connection was created. */
+  connectedAt: Date;
+
+  /** Whether the connection is active (operational disable switch; accessors split on this). */
+  enabled: boolean;
+
+  // === Health tracking ===
+
+  /** Current health state. */
+  status: GoogleDriveConnectionStatus;
+
+  /** Last error message (payload for status !== 'connected'; cleared on a healthy update). */
+  lastError?: string;
+
+  /** Last successful Drive API call. */
+  lastUsedAt?: Date;
+
+  /** Last time the folder was polled for changes. */
+  lastPolledAt?: Date;
+
+  // === Incremental sync ===
+
+  /**
+   * Drive changes pageToken - the durable cross-run resumption point for re-sync.
+   * Advisory only: the changes feed is not guaranteed-complete for shared items, so re-sync
+   * also reconciles by modifiedTime. Advance only after a sync batch is durably created.
+   */
+  syncCursor?: string;
+}
+
+export interface IOrgGoogleDriveConnectionDocument extends IOrgGoogleDriveConnection, IMongoDocument {}
+
+/**
+ * API response shape - never exposes the refresh token.
+ */
+export interface IOrgGoogleDriveConnectionResponse {
+  id: string;
+  organizationId: string;
+  authMode: GoogleDriveConnectionAuthMode;
+  driveFolderId: string;
+  folderName?: string;
+  targetDataLakeId: string;
+  /** Whether a stored credential exists (never the token itself). */
+  hasCredentials: boolean;
+  connectedBy: string;
+  connectedAt: string;
+  enabled: boolean;
+  status: GoogleDriveConnectionStatus;
+  lastError?: string;
+  lastUsedAt?: string;
+  lastPolledAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Request body to connect a Drive folder to a lake. The credential is captured server-side via OAuth, not in this body. */
+export interface IConnectGoogleDriveRequest {
+  driveFolderId: string;
+  folderName?: string;
+  targetDataLakeId: string;
+}
+
+/** Request body to update connection settings. */
+export interface IUpdateGoogleDriveConnectionRequest {
+  enabled?: boolean;
+  folderName?: string;
+}
+
+/** Health-update payload. Omit `lastError` (or pass undefined) to clear it on a healthy update. */
+export interface IGoogleDriveConnectionHealthUpdate {
+  status: GoogleDriveConnectionStatus;
+  lastError?: string;
+  lastUsedAt?: Date;
+  lastPolledAt?: Date;
+}
+
+/**
+ * Repository for org-level Google Drive connections.
+ *
+ * SECURITY: `findByIdWithCredentials` returns the encrypted `oauthRefreshToken`. It must be
+ * decrypted server-side only (via the app's tokenEncryption helper) and NEVER included in an
+ * API response. All other accessors exclude the credential by default (`select: false`).
+ */
+export interface IOrgGoogleDriveConnectionRepository extends IBaseRepository<IOrgGoogleDriveConnectionDocument> {
+  /** All enabled connections for an org (excludes credentials). */
+  findByOrganizationId(organizationId: string): Promise<IOrgGoogleDriveConnectionDocument[]>;
+
+  /** All connections for an org regardless of enabled status (admin/management views). */
+  findByOrganizationIdAny(organizationId: string): Promise<IOrgGoogleDriveConnectionDocument[]>;
+
+  /** The enabled connection feeding a given lake, if any (excludes credentials). */
+  findByDataLakeId(targetDataLakeId: string): Promise<IOrgGoogleDriveConnectionDocument | null>;
+
+  /** The connection that has claimed a given Drive folder, if any (for claim checks; excludes credentials). */
+  findByDriveFolderId(driveFolderId: string): Promise<IOrgGoogleDriveConnectionDocument | null>;
+
+  /**
+   * Load a connection WITH its encrypted credential.
+   * SECURITY: server-side only; decrypt before use; never expose in a response.
+   */
+  findByIdWithCredentials(id: string): Promise<IOrgGoogleDriveConnectionDocument | null>;
+
+  /** Update health state; clears `lastError` on a healthy update. */
+  updateHealth(
+    id: string,
+    update: IGoogleDriveConnectionHealthUpdate
+  ): Promise<IOrgGoogleDriveConnectionDocument | null>;
+
+  /** Advance the incremental-sync cursor after a sync batch is durably created. */
+  updateSyncCursor(id: string, syncCursor: string, polledAt: Date): Promise<IOrgGoogleDriveConnectionDocument | null>;
+}

--- a/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
+++ b/b4m-core/common/src/types/entities/OrgGoogleDriveConnectionTypes.ts
@@ -147,17 +147,26 @@ export interface IOrgGoogleDriveConnectionRepository extends IBaseRepository<IOr
   /** All connections for an org regardless of enabled status (admin/management views). */
   findByOrganizationIdAny(organizationId: string): Promise<IOrgGoogleDriveConnectionDocument[]>;
 
-  /** The enabled connection feeding a given lake, if any (excludes credentials). */
-  findByDataLakeId(targetDataLakeId: string): Promise<IOrgGoogleDriveConnectionDocument | null>;
+  /**
+   * The enabled connection feeding a given lake in a given org, if any (excludes credentials).
+   * organizationId is REQUIRED so a missing tenant scope is a compile error, not a review catch.
+   */
+  findByDataLakeId(targetDataLakeId: string, organizationId: string): Promise<IOrgGoogleDriveConnectionDocument | null>;
 
-  /** The connection that has claimed a given Drive folder, if any (for claim checks; excludes credentials). */
+  /**
+   * The connection that has claimed a given Drive folder, if any. Deliberately GLOBAL (no org
+   * filter) - it answers "is this folder already claimed by ANY org", which is the whole point of
+   * the global-unique index. SECURITY: server-side claim check only; the returned document (which
+   * excludes the credential) must never be handed to a cross-org caller.
+   */
   findByDriveFolderId(driveFolderId: string): Promise<IOrgGoogleDriveConnectionDocument | null>;
 
   /**
-   * Load a connection WITH its encrypted credential.
+   * Load a connection WITH its encrypted credential, scoped to an org.
+   * organizationId is REQUIRED so this accessor cannot hand one org's Google credential to another.
    * SECURITY: server-side only; decrypt before use; never expose in a response.
    */
-  findByIdWithCredentials(id: string): Promise<IOrgGoogleDriveConnectionDocument | null>;
+  findByIdWithCredentials(id: string, organizationId: string): Promise<IOrgGoogleDriveConnectionDocument | null>;
 
   /** Update health state; clears `lastError` on a healthy update. */
   updateHealth(

--- a/b4m-core/common/src/types/entities/index.ts
+++ b/b4m-core/common/src/types/entities/index.ts
@@ -83,6 +83,7 @@ export * from './JiraWebhookConfigTypes';
 export * from './JiraWebhookSubscriptionTypes';
 export * from './JiraWebhookDeliveryTypes';
 export * from './OrgGitHubConnectionTypes';
+export * from './OrgGoogleDriveConnectionTypes';
 export * from './OrgJiraConnectionTypes';
 export * from './QuestCapabilityTypes';
 export * from './SystemPromptTypes';

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import { createMongoServer } from '../../../__test__/createMongoServer';
+import { OrgGoogleDriveConnection, orgGoogleDriveConnectionRepository } from './OrgGoogleDriveConnectionModel';
+
+/**
+ * Invariants for the org Google Drive connection (#1588). The load-bearing ones are the global
+ * uniqueness of driveFolderId (a folder is claimable by one org, ever - the anti-cross-org-claim
+ * control from the #1587 security review) and that oauthRefreshToken never leaks into a default read.
+ */
+
+let server: Awaited<ReturnType<typeof createMongoServer>>;
+
+const base = {
+  organizationId: 'org-1',
+  authMode: 'oauth' as const,
+  driveFolderId: 'folder-1',
+  targetDataLakeId: 'lake-1',
+  connectedBy: 'user-1',
+};
+
+beforeAll(async () => {
+  server = await createMongoServer();
+  await mongoose.connect(server.getUri());
+  // Build the unique indexes so the uniqueness invariants below actually fire.
+  await OrgGoogleDriveConnection.syncIndexes();
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await server?.stop();
+}, 30000);
+
+afterEach(async () => {
+  await OrgGoogleDriveConnection.deleteMany({}, { hardDelete: true });
+});
+
+describe('OrgGoogleDriveConnectionModel - credential handling', () => {
+  it('excludes oauthRefreshToken from default reads but returns it via findByIdWithCredentials', async () => {
+    const created = await OrgGoogleDriveConnection.create({ ...base, oauthRefreshToken: 'enc-token' });
+
+    const defaultRead = await OrgGoogleDriveConnection.findById(created.id);
+    expect(defaultRead).not.toBeNull();
+    expect(defaultRead?.oauthRefreshToken).toBeUndefined();
+
+    const withCreds = await orgGoogleDriveConnectionRepository.findByIdWithCredentials(created.id);
+    expect(withCreds?.oauthRefreshToken).toBe('enc-token');
+  });
+});
+
+describe('OrgGoogleDriveConnectionModel - uniqueness invariants', () => {
+  it('rejects a second org claiming the same Drive folder (global folder uniqueness)', async () => {
+    await OrgGoogleDriveConnection.create(base);
+    await expect(
+      OrgGoogleDriveConnection.create({
+        ...base,
+        organizationId: 'org-2',
+        targetDataLakeId: 'lake-2', // different lake, same folder
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects two connections feeding the same lake (one folder per lake)', async () => {
+    await OrgGoogleDriveConnection.create(base);
+    await expect(
+      OrgGoogleDriveConnection.create({
+        ...base,
+        organizationId: 'org-2',
+        driveFolderId: 'folder-2', // different folder, same lake
+      })
+    ).rejects.toThrow();
+  });
+
+  it('allows one org to hold multiple connections (distinct folders + lakes)', async () => {
+    await OrgGoogleDriveConnection.create(base);
+    const second = await OrgGoogleDriveConnection.create({
+      ...base,
+      driveFolderId: 'folder-2',
+      targetDataLakeId: 'lake-2',
+    });
+    expect(second.id).toBeTruthy();
+
+    const all = await orgGoogleDriveConnectionRepository.findByOrganizationId('org-1');
+    expect(all).toHaveLength(2);
+  });
+});
+
+describe('OrgGoogleDriveConnectionModel - accessors', () => {
+  it('findByOrganizationId excludes disabled; findByOrganizationIdAny includes it', async () => {
+    await OrgGoogleDriveConnection.create(base);
+    await OrgGoogleDriveConnection.create({
+      ...base,
+      driveFolderId: 'folder-2',
+      targetDataLakeId: 'lake-2',
+      enabled: false,
+    });
+
+    const enabledOnly = await orgGoogleDriveConnectionRepository.findByOrganizationId('org-1');
+    expect(enabledOnly).toHaveLength(1);
+    expect(enabledOnly[0].driveFolderId).toBe('folder-1');
+
+    const any = await orgGoogleDriveConnectionRepository.findByOrganizationIdAny('org-1');
+    expect(any).toHaveLength(2);
+  });
+
+  it('findByDataLakeId and findByDriveFolderId resolve the connection', async () => {
+    const created = await OrgGoogleDriveConnection.create(base);
+    expect((await orgGoogleDriveConnectionRepository.findByDataLakeId('lake-1'))?.id).toBe(created.id);
+    expect((await orgGoogleDriveConnectionRepository.findByDriveFolderId('folder-1'))?.id).toBe(created.id);
+  });
+
+  it('findByDataLakeId excludes a disabled connection', async () => {
+    await OrgGoogleDriveConnection.create({ ...base, enabled: false });
+    // BaseRepository.findOne resolves to undefined (not null) on no match - matches the sibling repos.
+    expect(await orgGoogleDriveConnectionRepository.findByDataLakeId('lake-1')).toBeFalsy();
+  });
+});
+
+describe('OrgGoogleDriveConnectionModel - health + sync cursor', () => {
+  it('updateHealth sets an error and then clears it on a healthy update', async () => {
+    const created = await OrgGoogleDriveConnection.create(base);
+
+    const failed = await orgGoogleDriveConnectionRepository.updateHealth(created.id, {
+      status: 'needs_reconnect',
+      lastError: 'folder 404',
+    });
+    expect(failed?.status).toBe('needs_reconnect');
+    expect(failed?.lastError).toBe('folder 404');
+
+    const recovered = await orgGoogleDriveConnectionRepository.updateHealth(created.id, {
+      status: 'connected',
+      lastUsedAt: new Date(),
+    });
+    expect(recovered?.status).toBe('connected');
+    expect(recovered?.lastError ?? null).toBeNull();
+  });
+
+  it('updateSyncCursor advances the cursor and stamps lastPolledAt', async () => {
+    const created = await OrgGoogleDriveConnection.create(base);
+    const when = new Date();
+    const updated = await orgGoogleDriveConnectionRepository.updateSyncCursor(created.id, 'page-token-2', when);
+    expect(updated?.syncCursor).toBe('page-token-2');
+    expect(updated?.lastPolledAt?.getTime()).toBe(when.getTime());
+  });
+});

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts
@@ -43,8 +43,11 @@ describe('OrgGoogleDriveConnectionModel - credential handling', () => {
     expect(defaultRead).not.toBeNull();
     expect(defaultRead?.oauthRefreshToken).toBeUndefined();
 
-    const withCreds = await orgGoogleDriveConnectionRepository.findByIdWithCredentials(created.id);
+    const withCreds = await orgGoogleDriveConnectionRepository.findByIdWithCredentials(created.id, 'org-1');
     expect(withCreds?.oauthRefreshToken).toBe('enc-token');
+
+    // org-scoped: another org cannot load this connection's credential by id alone.
+    expect(await orgGoogleDriveConnectionRepository.findByIdWithCredentials(created.id, 'org-2')).toBeFalsy();
   });
 });
 
@@ -105,14 +108,16 @@ describe('OrgGoogleDriveConnectionModel - accessors', () => {
 
   it('findByDataLakeId and findByDriveFolderId resolve the connection', async () => {
     const created = await OrgGoogleDriveConnection.create(base);
-    expect((await orgGoogleDriveConnectionRepository.findByDataLakeId('lake-1'))?.id).toBe(created.id);
+    expect((await orgGoogleDriveConnectionRepository.findByDataLakeId('lake-1', 'org-1'))?.id).toBe(created.id);
     expect((await orgGoogleDriveConnectionRepository.findByDriveFolderId('folder-1'))?.id).toBe(created.id);
+    // org-scoped: a different org sees no connection for this lake.
+    expect(await orgGoogleDriveConnectionRepository.findByDataLakeId('lake-1', 'org-2')).toBeFalsy();
   });
 
   it('findByDataLakeId excludes a disabled connection', async () => {
     await OrgGoogleDriveConnection.create({ ...base, enabled: false });
     // BaseRepository.findOne resolves to undefined (not null) on no match - matches the sibling repos.
-    expect(await orgGoogleDriveConnectionRepository.findByDataLakeId('lake-1')).toBeFalsy();
+    expect(await orgGoogleDriveConnectionRepository.findByDataLakeId('lake-1', 'org-1')).toBeFalsy();
   });
 });
 
@@ -133,6 +138,18 @@ describe('OrgGoogleDriveConnectionModel - health + sync cursor', () => {
     });
     expect(recovered?.status).toBe('connected');
     expect(recovered?.lastError ?? null).toBeNull();
+  });
+
+  it('updateHealth redacts token-shaped fragments and truncates lastError', async () => {
+    const created = await OrgGoogleDriveConnection.create(base);
+    const raw = 'GET https://oauth2.googleapis.com/token?access_token=ya29.A0ARrdaM9longtokenfragmentxyz123 failed';
+    const updated = await orgGoogleDriveConnectionRepository.updateHealth(created.id, {
+      status: 'credential_error',
+      lastError: raw,
+    });
+    expect(updated?.lastError).toContain('[redacted]');
+    expect(updated?.lastError).not.toContain('ya29.A0ARrdaM9longtokenfragmentxyz123');
+    expect((updated?.lastError || '').length).toBeLessThanOrEqual(520);
   });
 
   it('updateSyncCursor advances the cursor and stamps lastPolledAt', async () => {

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
@@ -19,12 +19,17 @@ const OrgGoogleDriveConnectionSchema = new Schema<IOrgGoogleDriveConnectionDocum
   {
     organizationId: { type: String, required: true },
     authMode: { type: String, enum: ['oauth', 'service_account'], required: true },
-    driveFolderId: { type: String, required: true },
+    // trim + match at the DB layer too: isValidDriveFolderId lives in apps/client and isn't
+    // reachable from packages/database, so without this 'F' / 'F ' / ' F' would be distinct unique
+    // keys for one folder. Keep the pattern in sync with driveClient.isValidDriveFolderId.
+    driveFolderId: { type: String, required: true, trim: true, match: /^[A-Za-z0-9_-]{1,256}$/ },
     folderName: { type: String },
     targetDataLakeId: { type: String, required: true },
 
-    // OAuth refresh token - encrypted at rest by the service layer (encryptToken on write /
-    // decryptToken on read); select:false so it never leaks into default reads or toJSON.
+    // OAuth refresh token. select:false so it never leaks into default reads or toJSON. NO writer
+    // exists yet - the org-owned connect flow that persists this (and MUST encryptToken it first)
+    // lands with issue D. Encryption is call-site convention here, as with the sibling Org*
+    // connections and User.googleDrive; a pre-save encrypt guard should land with that first writer.
     oauthRefreshToken: { type: String, select: false },
 
     // Metadata
@@ -52,9 +57,12 @@ const OrgGoogleDriveConnectionSchema = new Schema<IOrgGoogleDriveConnectionDocum
   }
 );
 
-// A Drive folder is claimable by at most one org, ever - prevents cross-org folder-claim
-// (a member of org A binding a folder that belongs to org B). driveFolderId is required, so a
-// plain unique index is correct here.
+// FIRST-CLAIM-WINS on the Drive folder id: the unique index rejects a SECOND row for a folder
+// already claimed. It does NOT verify the first claimant actually owns the folder - that ownership
+// check (a files.get capabilities lookup with the connecting user's credential) lands with the
+// connect flow (issue D). This is a NEW pattern, not sibling precedent: the sibling Org* connections
+// scope uniqueness to the org and never make a third-party resource id globally unique; making
+// driveFolderId global is a deliberate anti-double-claim choice.
 OrgGoogleDriveConnectionSchema.index({ driveFolderId: 1 }, { unique: true, name: 'org_gdrive_conn_folder_id' });
 
 // A lake is fed by at most one Drive folder (v1: one-folder-per-lake).

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
@@ -1,0 +1,136 @@
+import {
+  IOrgGoogleDriveConnectionDocument,
+  IOrgGoogleDriveConnectionRepository,
+  IGoogleDriveConnectionHealthUpdate,
+  IMongoDocument,
+} from '@bike4mind/common';
+import mongoose, { Schema, Model, model } from 'mongoose';
+import BaseRepository from '@bike4mind/db-core';
+
+/**
+ * Organization-level Google Drive connection: binds one Drive folder to one data lake as an
+ * ingest source. Org-owned credential (not the per-user User.googleDrive), following the
+ * OrgGitHubConnection / OrgJiraConnection pattern (org-scoped, secret excluded from default
+ * reads, encrypted at rest by the service layer). See the #1587 auth-model resolution.
+ *
+ * v1 auth mode is 'oauth'; 'service_account' is reserved for a deferred cloud-only mode.
+ */
+const OrgGoogleDriveConnectionSchema = new Schema<IOrgGoogleDriveConnectionDocument>(
+  {
+    organizationId: { type: String, required: true },
+    authMode: { type: String, enum: ['oauth', 'service_account'], required: true },
+    driveFolderId: { type: String, required: true },
+    folderName: { type: String },
+    targetDataLakeId: { type: String, required: true },
+
+    // OAuth refresh token - encrypted at rest by the service layer (encryptToken on write /
+    // decryptToken on read); select:false so it never leaks into default reads or toJSON.
+    oauthRefreshToken: { type: String, select: false },
+
+    // Metadata
+    connectedBy: { type: String, required: true },
+    connectedAt: { type: Date, default: Date.now },
+    enabled: { type: Boolean, default: true },
+
+    // Health tracking
+    status: {
+      type: String,
+      enum: ['connected', 'needs_reconnect', 'credential_error'],
+      default: 'connected',
+    },
+    lastError: { type: String },
+    lastUsedAt: { type: Date },
+    lastPolledAt: { type: Date },
+
+    // Incremental-sync resumption (Drive changes pageToken)
+    syncCursor: { type: String },
+  },
+  {
+    timestamps: true,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
+  }
+);
+
+// A Drive folder is claimable by at most one org, ever - prevents cross-org folder-claim
+// (a member of org A binding a folder that belongs to org B). driveFolderId is required, so a
+// plain unique index is correct here.
+OrgGoogleDriveConnectionSchema.index({ driveFolderId: 1 }, { unique: true, name: 'org_gdrive_conn_folder_id' });
+
+// A lake is fed by at most one Drive folder (v1: one-folder-per-lake).
+OrgGoogleDriveConnectionSchema.index({ targetDataLakeId: 1 }, { unique: true, name: 'org_gdrive_conn_lake_id' });
+
+// Org lookups - NON-unique: an org may connect several folders/lakes.
+OrgGoogleDriveConnectionSchema.index({ organizationId: 1 }, { name: 'org_gdrive_conn_org_id' });
+
+export interface IOrgGoogleDriveConnectionModel extends Model<IOrgGoogleDriveConnectionDocument & IMongoDocument> {}
+
+export const OrgGoogleDriveConnection: IOrgGoogleDriveConnectionModel =
+  mongoose.models.OrgGoogleDriveConnection ??
+  model<IOrgGoogleDriveConnectionDocument>('OrgGoogleDriveConnection', OrgGoogleDriveConnectionSchema);
+
+class OrgGoogleDriveConnectionRepository
+  extends BaseRepository<IOrgGoogleDriveConnectionDocument & IMongoDocument>
+  implements IOrgGoogleDriveConnectionRepository
+{
+  /** All enabled connections for an org (excludes credentials). */
+  async findByOrganizationId(organizationId: string): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument)[]> {
+    return this.find({ organizationId, enabled: true });
+  }
+
+  /** All connections for an org regardless of enabled status (admin/management views). */
+  async findByOrganizationIdAny(
+    organizationId: string
+  ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument)[]> {
+    return this.find({ organizationId });
+  }
+
+  /** The enabled connection feeding a given lake, if any. */
+  async findByDataLakeId(
+    targetDataLakeId: string
+  ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
+    return this.findOne({ targetDataLakeId, enabled: true });
+  }
+
+  /** The connection that has claimed a given Drive folder, if any (claim checks). */
+  async findByDriveFolderId(
+    driveFolderId: string
+  ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
+    return this.findOne({ driveFolderId });
+  }
+
+  /**
+   * Load a connection WITH its encrypted credential.
+   * SECURITY: returns the encrypted `oauthRefreshToken`. Decrypt server-side only; never expose it.
+   */
+  async findByIdWithCredentials(id: string): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
+    const result = await this.model.findById(id).select('+oauthRefreshToken');
+    return result?.toJSON() || null;
+  }
+
+  /** Update health state; clears `lastError` on a healthy update (mirrors OrgGitHubConnection.updateHealthInfo). */
+  async updateHealth(
+    id: string,
+    update: IGoogleDriveConnectionHealthUpdate
+  ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
+    const set: Record<string, unknown> = { status: update.status };
+    if (update.lastUsedAt !== undefined) set.lastUsedAt = update.lastUsedAt;
+    if (update.lastPolledAt !== undefined) set.lastPolledAt = update.lastPolledAt;
+    // Explicitly clear the error when none is supplied so a recovered connection doesn't keep a stale message.
+    set.lastError = update.lastError ?? null;
+    return this.model.findByIdAndUpdate(id, { $set: set }, { new: true });
+  }
+
+  /** Advance the incremental-sync cursor after a sync batch is durably created. */
+  async updateSyncCursor(
+    id: string,
+    syncCursor: string,
+    polledAt: Date
+  ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
+    return this.model.findByIdAndUpdate(id, { $set: { syncCursor, lastPolledAt: polledAt } }, { new: true });
+  }
+}
+
+export const orgGoogleDriveConnectionRepository = new OrgGoogleDriveConnectionRepository(OrgGoogleDriveConnection);
+
+export default OrgGoogleDriveConnection;

--- a/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
+++ b/packages/database/src/models/infra/integrations/OrgGoogleDriveConnectionModel.ts
@@ -7,6 +7,19 @@ import {
 import mongoose, { Schema, Model, model } from 'mongoose';
 import BaseRepository from '@bike4mind/db-core';
 
+const MAX_LAST_ERROR_LEN = 500;
+
+/**
+ * lastError is client-visible (a response-DTO member, no select:false) and its predictable writer is
+ * `lastError: err.message` from a provider (Gaxios) failure, which can carry URLs, query strings, or
+ * token fragments. Strip token-shaped runs and cap the length in this one writer so raw provider
+ * output can't leak into an admin-visible field.
+ */
+function redactLastError(message: string): string {
+  const redacted = message.replace(/[A-Za-z0-9._~+/=-]{24,}/g, '[redacted]');
+  return redacted.length > MAX_LAST_ERROR_LEN ? `${redacted.slice(0, MAX_LAST_ERROR_LEN)}...` : redacted;
+}
+
 /**
  * Organization-level Google Drive connection: binds one Drive folder to one data lake as an
  * ingest source. Org-owned credential (not the per-user User.googleDrive), following the
@@ -93,14 +106,20 @@ class OrgGoogleDriveConnectionRepository
     return this.find({ organizationId });
   }
 
-  /** The enabled connection feeding a given lake, if any. */
+  /** The enabled connection feeding a given lake in a given org, if any. */
   async findByDataLakeId(
-    targetDataLakeId: string
+    targetDataLakeId: string,
+    organizationId: string
   ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
-    return this.findOne({ targetDataLakeId, enabled: true });
+    return this.findOne({ targetDataLakeId, organizationId, enabled: true });
   }
 
-  /** The connection that has claimed a given Drive folder, if any (claim checks). */
+  /**
+   * The connection that has claimed a given Drive folder, if any. Deliberately GLOBAL - it answers
+   * "is this folder claimed by ANY org" (the point of the global-unique index). SECURITY: the
+   * returned document (which excludes the credential) is a server-side claim check; never hand it to
+   * a cross-org caller.
+   */
   async findByDriveFolderId(
     driveFolderId: string
   ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
@@ -108,11 +127,15 @@ class OrgGoogleDriveConnectionRepository
   }
 
   /**
-   * Load a connection WITH its encrypted credential.
-   * SECURITY: returns the encrypted `oauthRefreshToken`. Decrypt server-side only; never expose it.
+   * Load a connection WITH its encrypted credential, scoped to an org.
+   * SECURITY: org-scoped so it cannot hand one org's `oauthRefreshToken` to another. Decrypt
+   * server-side only; never expose it.
    */
-  async findByIdWithCredentials(id: string): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
-    const result = await this.model.findById(id).select('+oauthRefreshToken');
+  async findByIdWithCredentials(
+    id: string,
+    organizationId: string
+  ): Promise<(IOrgGoogleDriveConnectionDocument & IMongoDocument) | null> {
+    const result = await this.model.findOne({ _id: id, organizationId }).select('+oauthRefreshToken');
     return result?.toJSON() || null;
   }
 
@@ -124,8 +147,9 @@ class OrgGoogleDriveConnectionRepository
     const set: Record<string, unknown> = { status: update.status };
     if (update.lastUsedAt !== undefined) set.lastUsedAt = update.lastUsedAt;
     if (update.lastPolledAt !== undefined) set.lastPolledAt = update.lastPolledAt;
-    // Explicitly clear the error when none is supplied so a recovered connection doesn't keep a stale message.
-    set.lastError = update.lastError ?? null;
+    // Clear the error on a healthy update; redact + truncate otherwise (lastError is client-visible
+    // and its predictable caller is a raw provider err.message - see redactLastError).
+    set.lastError = update.lastError ? redactLastError(update.lastError) : null;
     return this.model.findByIdAndUpdate(id, { $set: set }, { new: true });
   }
 

--- a/packages/database/src/models/infra/integrations/index.ts
+++ b/packages/database/src/models/infra/integrations/index.ts
@@ -4,6 +4,7 @@ export * from './JiraWebhookConfigModel';
 export * from './JiraWebhookDeliveryModel';
 export * from './JiraWebhookSubscriptionModel';
 export * from './OrgGitHubConnectionModel';
+export * from './OrgGoogleDriveConnectionModel';
 export * from './OrgJiraConnectionModel';
 export * from './OrgSlackWorkspaceModel';
 export * from './OrgWebhookConfigModel';


### PR DESCRIPTION
# Pull Request

## Description

Foundation for **an org Google Drive folder as a data-lake source** ([#1586](https://github.com/Bike4Mind/bike4mind/issues/1586)) - part of [#1588](https://github.com/Bike4Mind/bike4mind/issues/1588). This is a **draft**: it lands the persistence model and the server-side read primitive (plus a thin endpoint to exercise it live), not the full ingest/UI.

The auth model was decided in the [#1587](https://github.com/Bike4Mind/bike4mind/issues/1587) spike after a four-lens senior review that overturned the initial service-account-first lean: **v1 is user OAuth** (works in cloud and self-host, reuses the existing Drive OAuth stack + Google Picker), with an `authMode` discriminator reserving a deferred `service_account` mode.

## Changes

- **`OrgGoogleDriveConnection` model** (`@bike4mind/database`) + types (`@bike4mind/common`), following the `OrgGitHubConnection`/`OrgJiraConnection` pattern (org-scoped collection; credential `select:false`, encrypted at rest by the service layer). Hardened per the review:
  - `driveFolderId` **globally unique** - a folder is claimable by one org, ever (anti cross-org folder-claim).
  - `targetDataLakeId` unique - one folder per lake (v1).
  - `enabled` + `lastError` + health accessor that clears the error on recovery; `syncCursor` for re-sync.
  - `findByIdWithCredentials` is the only accessor that returns the encrypted token; all others exclude it.
- **Server-side Drive read primitive** (`apps/client/server/integrations/google/drive/driveClient.ts`): a **per-call** Drive v3 client (never the mutable module singleton, which would race across tenants) and `listFolderChildren` (shared-drive flags, pagination, skips malformed entries).
- **`getValidUserDriveAccessToken`** (in `common.ts`): decrypt + refresh the stored per-user Drive credential. `token.ts` is left untouched (it returns an authUrl for the browser attach flow); cross-referenced in a comment.
- **`POST /api/google-drive/list-folder`**: authenticated endpoint that lists a folder's immediate children server-side - the live smoke-test surface and the base the ingest job (C) builds on.
- Tests: `OrgGoogleDriveConnectionModel.integration.test.ts` (9, `createMongoServer`) and `driveClient.test.ts` (4, mocked `files.list`).

## Guide for Testers

Automated (no env needed), from the repo root:
1. Run `pnpm --filter @bike4mind/database exec vitest run src/models/infra/integrations/OrgGoogleDriveConnectionModel.integration.test.ts` -> **9 passed** (credential exclusion, both uniqueness invariants, enabled/disabled split, health/cursor).
2. Run `pnpm --filter ./apps/client exec vitest run server/integrations/google/drive/driveClient.test.ts` -> **4 passed** (folder-scoped query, pagination, malformed-entry skip).

Live smoke test (on the PR preview once deployed) - proves the core bet that we can read a Drive folder server-side via OAuth:
1. Log in to the preview as a user, then connect Google Drive (Profile -> Settings -> Connected Apps -> Connect Google Drive) and complete the Google consent.
2. In Google Drive, note the folder id from any folder's URL (`https://drive.google.com/drive/folders/<FOLDER_ID>`).
3. From the authenticated app, `POST /api/google-drive/list-folder` with body `{ "folderId": "<FOLDER_ID>" }` (Authorization: Bearer <token>).
4. Expected: `200` with `{ folderId, count, files: [{ id, name, mimeType }, ...] }` listing that folder's immediate children. A folder with subfolders returns entries with `mimeType: "application/vnd.google-apps.folder"`.
5. Negative: omit `folderId` -> `400 "folderId is required"`; call without Google Drive connected -> error indicating the connection is required.

## What NOT to test (yet)

- No ingest into a lake, no vectorization, no re-sync, no wizard UI - those are follow-up issues (C/D/E). This PR only reads a folder listing and persists the connection model.
- Recursion into subfolders is not wired yet (one level only); the recursive walk lands with ingest (C).
- The `service_account` auth mode is reserved but not implemented.

## Additional Information

Verification done locally: 13 tests green; `@bike4mind/common` typecheck clean; eslint clean on all new/edited files; the new files produce **zero** typecheck errors (the worktree's pre-existing stale-dist errors are unrelated and clear in CI).

## Developer Notes

- **Data model**: `OrgGoogleDriveConnection` is the org-owned credential/source record - the pattern any future org-level connector can follow. The `authMode` discriminator makes adding the `service_account` mode a non-migration change.
- **Reusable primitive**: `createDriveClient` + `listFolderChildren` are the server-side Drive read building blocks the ingest job reuses; `getValidUserDriveAccessToken` centralizes credential refresh for server jobs.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A (no admin settings)
- [ ] I have made the UI/UX feel good - N/A (no UI in this PR)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)



Closes #1588
