### PR TITLE
fix(data-lakes): restore also clears the archive stamp its own lake wrote

### DIFF
--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -109,6 +109,19 @@ export interface IDataLake {
    */
   filesDeletedAt?: Date | null;
   /**
+   * The exact `archivedAt` stamp archive wrote on this lake's members, so restore (after a
+   * delete of an already-archived lake) can clear that batch's archive marker and nothing
+   * else's - mirrors `filesDeletedAt` but on the archive axis. Matched by EQUALITY, so a
+   * prefix-sharing sibling lake's independently-archived files (a different or absent stamp)
+   * are never touched. Claimed set-if-unset; cleared by unarchive (so a later re-archive gets
+   * a fresh stamp, not a stale reused one) and by a restore that clears it.
+   *
+   * Absent on a lake archived before this field existed, which leaves its archive marker
+   * unbounded-unclearable on restore (the old, known behavior) rather than clearing a marker
+   * no stamp names.
+   */
+  filesArchivedAt?: Date | null;
+  /**
    * Lake-memory producer (#1440) bookkeeping - server-managed, never client input.
    *
    * A concurrency LEASE, not a status: a run stamps it to claim the lake and clears it when done, so a
@@ -200,6 +213,8 @@ export interface IDataLakeRepository extends IBaseRepository<IDataLakeDocument> 
    * caller sweeps unmarked and must say so, since that lake then restores unbounded.
    */
   claimFilesDeletedAt(id: string, at: Date): Promise<Date | null>;
+  /** Claim `filesArchivedAt` for an archive sweep - same set-if-unset contract as `claimFilesDeletedAt`. */
+  claimFilesArchivedAt(id: string, at: Date): Promise<Date | null>;
   /**
    * Per-lake concurrency claim for the memory producer (#1440): stamp `lakeMemoryExtractionAt = at` only
    * if no run currently holds the lease - the field is unset, OR its stamp is older than `staleBefore`

--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -111,14 +111,18 @@ export interface IDataLake {
   /**
    * The exact `archivedAt` stamp archive wrote on this lake's members, so restore (after a
    * delete of an already-archived lake) can clear that batch's archive marker and nothing
-   * else's - mirrors `filesDeletedAt` but on the archive axis. Matched by EQUALITY, so a
-   * prefix-sharing sibling lake's independently-archived files (a different or absent stamp)
-   * are never touched. Claimed set-if-unset; cleared by unarchive (so a later re-archive gets
-   * a fresh stamp, not a stale reused one) and by a restore that clears it.
+   * else's - mirrors `filesDeletedAt` but on the archive axis. Matched by EQUALITY: a
+   * prefix-sharing sibling lake's own archive of that same file (a different stamp) is never
+   * touched, provided the sibling archived first - `archiveByDataLakeTag` only ever stamps
+   * `archivedAt: null` rows, so whichever lake archives a shared file first owns its marker.
+   * Claimed set-if-unset; cleared by unarchive (so a later re-archive gets a fresh stamp, not a
+   * stale reused one) and by a restore that clears it.
    *
-   * Absent on a lake archived before this field existed, which leaves its archive marker
-   * unbounded-unclearable on restore (the old, known behavior) rather than clearing a marker
-   * no stamp names.
+   * Absent on a lake archived before this field existed (or one whose members already carry an
+   * unstamped `archivedAt` for any other reason): restore leaves that archive marker exactly as
+   * it is instead of guessing at a batch it cannot prove, and archive itself skips claiming a
+   * fresh stamp in that case too (see archiveDataLake) rather than recording a mark that would
+   * name none of the pre-existing archived rows.
    */
   filesArchivedAt?: Date | null;
   /**

--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -120,7 +120,12 @@ export interface IDataLake {
    *
    * The key is a wall-clock `Date`, not a unique token - equality is a best-effort ownership test,
    * not a guarantee, and two lakes claiming in the same millisecond would collide (same design as
-   * `filesDeletedAt`, not new to this field).
+   * `filesDeletedAt`, not new to this field). The same-millisecond collision also has a same-lake
+   * variant: two concurrent archive calls on ONE lake that happen to generate their claim's `Date`
+   * in the same millisecond both read as "freshly minted" to the loser, so its clear-back (see
+   * archiveDataLake) could wipe the winner's just-written stamp. Narrow (needs both a same-lake
+   * race AND a same-millisecond collision), not fixed by the `wasMinted` guard, which only
+   * distinguishes minted-from-echoed, not minted-at-the-same-instant-as-a-peer.
    *
    * Absent on a lake archived before this field existed (or one whose members already carry an
    * unstamped `archivedAt` for any other reason): restore leaves that archive marker exactly as

--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -118,6 +118,10 @@ export interface IDataLake {
    * Claimed set-if-unset; cleared by unarchive (so a later re-archive gets a fresh stamp, not a
    * stale reused one) and by a restore that clears it.
    *
+   * The key is a wall-clock `Date`, not a unique token - equality is a best-effort ownership test,
+   * not a guarantee, and two lakes claiming in the same millisecond would collide (same design as
+   * `filesDeletedAt`, not new to this field).
+   *
    * Absent on a lake archived before this field existed (or one whose members already carry an
    * unstamped `archivedAt` for any other reason): restore leaves that archive marker exactly as
    * it is instead of guessing at a batch it cannot prove, and archive itself skips claiming a

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -681,12 +681,13 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   // lower bound, which would also match a file the creator deleted during the deleted window (the
   // per-file delete routes stamp `deletedAt` too) and revive it on restore. Omitting `stampedAt`
   // matches every stamped row: the pre-mark behavior, and the fallback for a lake torn down before
-  // the mark existed. The archive axis is deliberately NOT stamped - archiveByDataLakeTag is the
-  // only writer of a non-null archivedAt, so no independently-archived file exists to protect.
+  // the mark existed. The archive axis is stamped the same way (`at`, `filesArchivedAt`) so restore
+  // can also clear `archivedAt` for exactly the batch this lake's own archive wrote, without
+  // freeing a prefix-sharing sibling's independently-archived files.
 
-  /** Soft-archive (reversible) all live member files. Returns affected count. */
-  archiveByDataLakeTag(scope: DataLakeMembershipScope): Promise<number>;
-  /** Reverse archive for all archived member files. */
+  /** Soft-archive (reversible) all live member files, stamped `at`. Returns affected count. */
+  archiveByDataLakeTag(scope: DataLakeMembershipScope, at?: Date): Promise<number>;
+  /** Reverse archive for all archived member files. Unbounded - matches on archivedAt alone. */
   unarchiveByDataLakeTag(scope: DataLakeMembershipScope): Promise<number>;
   /** Archived member files - used by the unarchive dedup pass. */
   findArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<IFabFileDocument[]>;
@@ -694,9 +695,16 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   findDeletedByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<IFabFileDocument[]>;
   /**
    * Reverse soft-delete for member files stamped `stampedAt`, minus `excludeIds` (discarded
-   * duplicates). Returns count.
+   * duplicates). When `archiveStampToClear` is given, also clears `archivedAt` on the subset of
+   * the restored batch whose archivedAt equals it (the batch this lake's own archive wrote) -
+   * everything else keeps its archive marker untouched. Returns count restored.
    */
-  undeleteByDataLakeTag(scope: DataLakeMembershipScope, excludeIds?: string[], stampedAt?: Date): Promise<number>;
+  undeleteByDataLakeTag(
+    scope: DataLakeMembershipScope,
+    excludeIds?: string[],
+    stampedAt?: Date,
+    archiveStampToClear?: Date
+  ): Promise<number>;
   /** Soft-delete (phase 1) all member files, stamped `at`. Returns affected file ids. */
   softDeleteByDataLakeTag(scope: DataLakeMembershipScope, at?: Date): Promise<string[]>;
   /**

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -687,16 +687,16 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
 
   /**
    * Soft-archive (reversible) all live member files, stamped `at`. Returns affected count.
-   * Omitting `at` does NOT mean "unstamped" at the row level - it defaults to `new Date()`, so
-   * each row still gets a real timestamp. The caller's actual intent when it omits `at` is "don't
-   * record this batch's key on the lake" (see archiveDataLake's hasUnstampedArchive guard); the
-   * row-level Date exists, it is just orphaned rather than absent.
+   * Omitting `at` still writes a real per-row timestamp - it is orphaned (no lake names it), not
+   * absent. See archiveDataLake's `hasUnstampedArchive` guard for when that's intentional.
    */
   archiveByDataLakeTag(scope: DataLakeMembershipScope, at?: Date): Promise<number>;
   /** Reverse archive for all archived member files. Unbounded - matches on archivedAt alone. */
   unarchiveByDataLakeTag(scope: DataLakeMembershipScope): Promise<number>;
   /** Archived member files - used by the unarchive dedup pass. */
   findArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<IFabFileDocument[]>;
+  /** Existence-only form of findArchivedByDataLakeTag, for a caller that just needs "any?". */
+  hasArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<boolean>;
   /** Soft-deleted member files stamped `stampedAt` - used by the deleted->active restore dedup pass. */
   findDeletedByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<IFabFileDocument[]>;
   /**

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -685,7 +685,13 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   // can also clear `archivedAt` for exactly the batch this lake's own archive wrote, without
   // freeing a prefix-sharing sibling's independently-archived files.
 
-  /** Soft-archive (reversible) all live member files, stamped `at`. Returns affected count. */
+  /**
+   * Soft-archive (reversible) all live member files, stamped `at`. Returns affected count.
+   * Omitting `at` does NOT mean "unstamped" at the row level - it defaults to `new Date()`, so
+   * each row still gets a real timestamp. The caller's actual intent when it omits `at` is "don't
+   * record this batch's key on the lake" (see archiveDataLake's hasUnstampedArchive guard); the
+   * row-level Date exists, it is just orphaned rather than absent.
+   */
   archiveByDataLakeTag(scope: DataLakeMembershipScope, at?: Date): Promise<number>;
   /** Reverse archive for all archived member files. Unbounded - matches on archivedAt alone. */
   unarchiveByDataLakeTag(scope: DataLakeMembershipScope): Promise<number>;

--- a/b4m-core/services/src/__tests__/utils/testUtils.ts
+++ b/b4m-core/services/src/__tests__/utils/testUtils.ts
@@ -86,6 +86,7 @@ export const createMockFabFileRepository = (): IFabFileRepository => ({
   archiveByDataLakeTag: vi.fn(),
   unarchiveByDataLakeTag: vi.fn(),
   findArchivedByDataLakeTag: vi.fn(),
+  hasArchivedByDataLakeTag: vi.fn(),
   findDeletedByDataLakeTag: vi.fn(),
   undeleteByDataLakeTag: vi.fn(),
   softDeleteByDataLakeTag: vi.fn(),

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -104,7 +104,12 @@ export const archiveDataLake = async (
   // browse (they filter archivedAt: null) - and unarchiving either lake brings back BOTH lakes'
   // archived files, since the flip matches on archivedAt alone.
   await warnOnPrefixCollision(db, existing, logger);
-  const swept = await db.fabFiles.archiveByDataLakeTag(scope, stamp);
+  // Generated here rather than left to archiveByDataLakeTag's default: when `stamp` is undefined,
+  // this row-level timestamp is orphaned (no lake will ever name it) even though it is a real
+  // Date, and that decision should be visible at the call site rather than buried in the repo
+  // method's fallback.
+  const sweepStamp = stamp ?? new Date();
+  const swept = await db.fabFiles.archiveByDataLakeTag(scope, sweepStamp);
   // The probe-then-claim window above has no lock, so a concurrent archive - on a prefix-colliding
   // sibling lake stamping a shared file, or on this SAME lake via a duplicate request - can leave
   // this sweep matching nothing despite a stamp in hand. `wasMinted` is what makes clearing safe:
@@ -126,6 +131,9 @@ export const archiveDataLake = async (
   if (!updated) {
     throw new NotFoundError('Data lake not found after archive');
   }
+  // Always recompute from source, never short-circuit on `swept` (e.g. "swept === 0, so stats
+  // can't have changed") - a re-entry sweeps 0 for rows a PRIOR attempt already archived, and
+  // those rows are exactly what this recompute needs to reflect.
   await recomputeLakeStats(existing, { db });
 
   return updated;

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -19,7 +19,7 @@ interface ArchiveDataLakeAdapters {
     batches: Pick<IDataLakeBatchRepository, 'findActiveByDataLakeId' | 'markTerminalIfActive'>;
     fabFiles: Pick<
       IFabFileRepository,
-      'archiveByDataLakeTag' | 'computeDataLakeStats' | 'findIdsByDataLakeTag' | 'findArchivedByDataLakeTag'
+      'archiveByDataLakeTag' | 'computeDataLakeStats' | 'findIdsByDataLakeTag' | 'hasArchivedByDataLakeTag'
     >;
   };
   retrievalIndex?: RetrievalIndexPort;
@@ -71,17 +71,11 @@ export const archiveDataLake = async (
   // mark. Archiving unstamped instead leaves those rows exactly as unrecoverable as they already
   // were, which is the safe direction to fail in.
   //
-  // Deliberately conservative, and wider than just the legacy case: `findArchivedByDataLakeTag`
-  // matches the membership SCOPE, so a row a prefix-sharing sibling archived under its OWN stamp
-  // also counts here even though it is not "unstamped" from the sibling's point of view - we
-  // simply have no way to tell "pre-field legacy" apart from "someone else's batch" from this
-  // query alone. Either way we skip claiming, which also unstamps rows the sweep is ABOUT to
-  // archive fresh (a lake that gains new files and gets re-archived), even though those specific
-  // rows would be safe to bound. Such a lake stays unbounded on every future archive until someone
-  // unarchives it once (which clears the unstamped population) - a known limitation, not a full
-  // fix for either case.
-  const hasUnstampedArchive =
-    !existing.filesArchivedAt && (await db.fabFiles.findArchivedByDataLakeTag(scope)).length > 0;
+  // Also wider than the legacy case: the scope-matched query can't tell "pre-field legacy" apart
+  // from "a prefix-sharing sibling's own stamp", so either one skips the claim here - and with it,
+  // any freshly-archived rows this same sweep is about to write. Such a lake stays unbounded until
+  // someone unarchives it once; a known limitation, not a full fix for either case.
+  const hasUnstampedArchive = !existing.filesArchivedAt && (await db.fabFiles.hasArchivedByDataLakeTag(scope));
   let stamp: Date | undefined;
   if (!hasUnstampedArchive) {
     stamp = (await db.dataLakes.claimFilesArchivedAt(dataLakeId, new Date())) ?? undefined;

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -12,7 +12,10 @@ import { bestEffortIndexRemove, type RetrievalIndexPort } from './ports';
 
 interface ArchiveDataLakeAdapters {
   db: {
-    dataLakes: Pick<IDataLakeRepository, 'findById' | 'update' | 'setStats' | 'activateIfDraft' | 'find'>;
+    dataLakes: Pick<
+      IDataLakeRepository,
+      'findById' | 'update' | 'setStats' | 'activateIfDraft' | 'find' | 'claimFilesArchivedAt'
+    >;
     batches: Pick<IDataLakeBatchRepository, 'findActiveByDataLakeId' | 'markTerminalIfActive'>;
     fabFiles: Pick<IFabFileRepository, 'archiveByDataLakeTag' | 'computeDataLakeStats' | 'findIdsByDataLakeTag'>;
   };
@@ -51,6 +54,24 @@ export const archiveDataLake = async (
   const activeBatches = await db.batches.findActiveByDataLakeId(dataLakeId);
   await Promise.all(activeBatches.map(b => db.batches.markTerminalIfActive(b.id, 'cancelled')));
 
+  // The stamp this sweep keys its batch to (see IDataLake.filesArchivedAt), so a later
+  // archive->delete->restore can clear exactly these rows' archive marker. Skipped when a lake is
+  // already sitting in 'archiving' with no mark: a re-run may have already stamped SOME rows with
+  // an earlier, un-recorded archivedAt (archiveByDataLakeTag only ever touches archivedAt: null
+  // rows), so claiming a fresh stamp now would name a batch narrower than what is actually
+  // archived, stranding the rest. Unmarked archives unbounded instead, same fallback deleteDataLake
+  // uses for filesDeletedAt.
+  const preMarkSweepInFlight = existing.status === 'archiving' && !existing.filesArchivedAt;
+  let stamp: Date | undefined;
+  if (!preMarkSweepInFlight) {
+    stamp = (await db.dataLakes.claimFilesArchivedAt(dataLakeId, new Date())) ?? undefined;
+    if (!stamp) {
+      logger?.warn('[dataLakes] archive recorded no stamp; this lake will restore-clear unbounded', {
+        dataLakeId,
+      });
+    }
+  }
+
   // Step 2: transitional state (crash-visible).
   await db.dataLakes.update({ id: dataLakeId, status: 'archiving' });
 
@@ -61,7 +82,7 @@ export const archiveDataLake = async (
   // archived files, since the flip matches on archivedAt alone.
   await warnOnPrefixCollision(db, existing, logger);
   const scope = lakeMembershipScope(existing);
-  await db.fabFiles.archiveByDataLakeTag(scope);
+  await db.fabFiles.archiveByDataLakeTag(scope, stamp);
   // Same scope the sweep ran on. findIdsByDataLakeTag is the id source rather than the flip's
   // count because it reports every member whatever its archived/deleted state, so a re-run after
   // a crashed attempt still hands the index the full set.

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -71,11 +71,15 @@ export const archiveDataLake = async (
   // mark. Archiving unstamped instead leaves those rows exactly as unrecoverable as they already
   // were, which is the safe direction to fail in.
   //
-  // Deliberately conservative: this also unstamps rows the sweep is ABOUT to archive fresh (a
-  // legacy lake that gains new files, gets re-archived), even though those specific rows would be
-  // safe to bound. A legacy lake stays unbounded on every future archive until someone unarchives
-  // it once (which clears the unstamped population) - a known limitation, not a full fix for
-  // pre-field lakes.
+  // Deliberately conservative, and wider than just the legacy case: `findArchivedByDataLakeTag`
+  // matches the membership SCOPE, so a row a prefix-sharing sibling archived under its OWN stamp
+  // also counts here even though it is not "unstamped" from the sibling's point of view - we
+  // simply have no way to tell "pre-field legacy" apart from "someone else's batch" from this
+  // query alone. Either way we skip claiming, which also unstamps rows the sweep is ABOUT to
+  // archive fresh (a lake that gains new files and gets re-archived), even though those specific
+  // rows would be safe to bound. Such a lake stays unbounded on every future archive until someone
+  // unarchives it once (which clears the unstamped population) - a known limitation, not a full
+  // fix for either case.
   const hasUnstampedArchive =
     !existing.filesArchivedAt && (await db.fabFiles.findArchivedByDataLakeTag(scope)).length > 0;
   let stamp: Date | undefined;

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -70,6 +70,12 @@ export const archiveDataLake = async (
   // restore into believing archivedAt is bounded when nothing on this lake actually carries the
   // mark. Archiving unstamped instead leaves those rows exactly as unrecoverable as they already
   // were, which is the safe direction to fail in.
+  //
+  // Deliberately conservative: this also unstamps rows the sweep is ABOUT to archive fresh (a
+  // legacy lake that gains new files, gets re-archived), even though those specific rows would be
+  // safe to bound. A legacy lake stays unbounded on every future archive until someone unarchives
+  // it once (which clears the unstamped population) - a known limitation, not a full fix for
+  // pre-field lakes.
   const hasUnstampedArchive =
     !existing.filesArchivedAt && (await db.fabFiles.findArchivedByDataLakeTag(scope)).length > 0;
   let stamp: Date | undefined;

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -79,8 +79,15 @@ export const archiveDataLake = async (
   // accepts 'archived'/'restoring'. A known limitation, not a full fix for either case.
   const hasUnstampedArchive = !existing.filesArchivedAt && (await db.fabFiles.hasArchivedByDataLakeTag(scope));
   let stamp: Date | undefined;
+  // Whether THIS call's claim actually won the set-if-unset, rather than echoing back a value
+  // someone else (a crashed prior attempt, or a concurrent claim on this same lake) already held -
+  // see the zero-swept clear-back below, which only ever fires for a claim we ourselves minted.
+  let wasMinted = false;
   if (!hasUnstampedArchive) {
-    stamp = (await db.dataLakes.claimFilesArchivedAt(dataLakeId, new Date())) ?? undefined;
+    const at = new Date();
+    const claimed = (await db.dataLakes.claimFilesArchivedAt(dataLakeId, at)) ?? undefined;
+    stamp = claimed;
+    wasMinted = claimed?.getTime() === at.getTime();
     if (!stamp) {
       logger?.warn('[dataLakes] archive recorded no stamp; a later restore will not clear archivedAt for this lake', {
         dataLakeId,
@@ -98,19 +105,15 @@ export const archiveDataLake = async (
   // archived files, since the flip matches on archivedAt alone.
   await warnOnPrefixCollision(db, existing, logger);
   const swept = await db.fabFiles.archiveByDataLakeTag(scope, stamp);
-  // The probe-then-claim window above has no lock, so a concurrent archive on a prefix-colliding
-  // sibling can stamp our row between the two and leave this sweep matching nothing: `stamp` gets
-  // freshly claimed, but zero rows actually carry it. Clearing the mark in that case closes the
-  // race regardless of how it arose - an empty lake also sweeps zero and clearing its
-  // (already meaningless) mark is harmless.
-  //
-  // `!existing.filesArchivedAt` is load-bearing, not incidental: it's what tells a fresh claim
-  // (the race above) apart from a crash re-entry that echoed an ALREADY-set stamp back (:81's
-  // set-if-unset returns the existing value rather than minting one). A re-entry's sweep also
-  // returns 0 - not because the batch was never written, but because every row already carries
-  // this exact stamp from the completed attempt before the crash - and clearing it there would
-  // strand every one of those rows on restore, reintroducing the bug this PR exists to fix.
-  if (stamp && swept === 0 && !existing.filesArchivedAt) {
+  // The probe-then-claim window above has no lock, so a concurrent archive - on a prefix-colliding
+  // sibling lake stamping a shared file, or on this SAME lake via a duplicate request - can leave
+  // this sweep matching nothing despite a stamp in hand. `wasMinted` is what makes clearing safe:
+  // it is true only when THIS call's claim actually won the set-if-unset, so it is false both for
+  // a crash re-entry (echoes an already-set stamp back) and for a same-lake concurrent claim
+  // (echoes the peer's winning stamp back) - in either of those, the stamp names rows that already
+  // exist and clearing it would strand them, reintroducing the bug this PR exists to fix. Only a
+  // truly fresh mint that then swept zero (the sibling race, or an empty lake) is safe to clear.
+  if (stamp && swept === 0 && wasMinted) {
     await db.dataLakes.update({ id: dataLakeId, filesArchivedAt: null });
   }
   // Same scope the sweep ran on. findIdsByDataLakeTag is the id source rather than the flip's

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -100,10 +100,17 @@ export const archiveDataLake = async (
   const swept = await db.fabFiles.archiveByDataLakeTag(scope, stamp);
   // The probe-then-claim window above has no lock, so a concurrent archive on a prefix-colliding
   // sibling can stamp our row between the two and leave this sweep matching nothing: `stamp` gets
-  // claimed, but zero rows actually carry it. Detecting that after the fact and clearing the mark
-  // closes the invariant regardless of how the race arose - an empty lake also sweeps zero and
-  // clearing its (already meaningless) mark is harmless.
-  if (stamp && swept === 0) {
+  // freshly claimed, but zero rows actually carry it. Clearing the mark in that case closes the
+  // race regardless of how it arose - an empty lake also sweeps zero and clearing its
+  // (already meaningless) mark is harmless.
+  //
+  // `!existing.filesArchivedAt` is load-bearing, not incidental: it's what tells a fresh claim
+  // (the race above) apart from a crash re-entry that echoed an ALREADY-set stamp back (:81's
+  // set-if-unset returns the existing value rather than minting one). A re-entry's sweep also
+  // returns 0 - not because the batch was never written, but because every row already carries
+  // this exact stamp from the completed attempt before the crash - and clearing it there would
+  // strand every one of those rows on restore, reintroducing the bug this PR exists to fix.
+  if (stamp && swept === 0 && !existing.filesArchivedAt) {
     await db.dataLakes.update({ id: dataLakeId, filesArchivedAt: null });
   }
   // Same scope the sweep ran on. findIdsByDataLakeTag is the id source rather than the flip's

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -73,8 +73,10 @@ export const archiveDataLake = async (
   //
   // Also wider than the legacy case: the scope-matched query can't tell "pre-field legacy" apart
   // from "a prefix-sharing sibling's own stamp", so either one skips the claim here - and with it,
-  // any freshly-archived rows this same sweep is about to write. Such a lake stays unbounded until
-  // someone unarchives it once; a known limitation, not a full fix for either case.
+  // any freshly-archived rows this same sweep is about to write. Such a lake stays broken on
+  // restore until someone archives it again (once nothing is left unstamped) and then unarchives
+  // it - not "unarchive once" as a lake fresh out of restore is 'active', and unarchive only
+  // accepts 'archived'/'restoring'. A known limitation, not a full fix for either case.
   const hasUnstampedArchive = !existing.filesArchivedAt && (await db.fabFiles.hasArchivedByDataLakeTag(scope));
   let stamp: Date | undefined;
   if (!hasUnstampedArchive) {
@@ -95,7 +97,15 @@ export const archiveDataLake = async (
   // browse (they filter archivedAt: null) - and unarchiving either lake brings back BOTH lakes'
   // archived files, since the flip matches on archivedAt alone.
   await warnOnPrefixCollision(db, existing, logger);
-  await db.fabFiles.archiveByDataLakeTag(scope, stamp);
+  const swept = await db.fabFiles.archiveByDataLakeTag(scope, stamp);
+  // The probe-then-claim window above has no lock, so a concurrent archive on a prefix-colliding
+  // sibling can stamp our row between the two and leave this sweep matching nothing: `stamp` gets
+  // claimed, but zero rows actually carry it. Detecting that after the fact and clearing the mark
+  // closes the invariant regardless of how the race arose - an empty lake also sweeps zero and
+  // clearing its (already meaningless) mark is harmless.
+  if (stamp && swept === 0) {
+    await db.dataLakes.update({ id: dataLakeId, filesArchivedAt: null });
+  }
   // Same scope the sweep ran on. findIdsByDataLakeTag is the id source rather than the flip's
   // count because it reports every member whatever its archived/deleted state, so a re-run after
   // a crashed attempt still hands the index the full set.

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -17,7 +17,10 @@ interface ArchiveDataLakeAdapters {
       'findById' | 'update' | 'setStats' | 'activateIfDraft' | 'find' | 'claimFilesArchivedAt'
     >;
     batches: Pick<IDataLakeBatchRepository, 'findActiveByDataLakeId' | 'markTerminalIfActive'>;
-    fabFiles: Pick<IFabFileRepository, 'archiveByDataLakeTag' | 'computeDataLakeStats' | 'findIdsByDataLakeTag'>;
+    fabFiles: Pick<
+      IFabFileRepository,
+      'archiveByDataLakeTag' | 'computeDataLakeStats' | 'findIdsByDataLakeTag' | 'findArchivedByDataLakeTag'
+    >;
   };
   retrievalIndex?: RetrievalIndexPort;
   logger?: { warn: (msg: string, ...args: unknown[]) => void };
@@ -54,19 +57,26 @@ export const archiveDataLake = async (
   const activeBatches = await db.batches.findActiveByDataLakeId(dataLakeId);
   await Promise.all(activeBatches.map(b => db.batches.markTerminalIfActive(b.id, 'cancelled')));
 
+  const scope = lakeMembershipScope(existing);
+
   // The stamp this sweep keys its batch to (see IDataLake.filesArchivedAt), so a later
-  // archive->delete->restore can clear exactly these rows' archive marker. Skipped when a lake is
-  // already sitting in 'archiving' with no mark: a re-run may have already stamped SOME rows with
-  // an earlier, un-recorded archivedAt (archiveByDataLakeTag only ever touches archivedAt: null
-  // rows), so claiming a fresh stamp now would name a batch narrower than what is actually
-  // archived, stranding the rest. Unmarked archives unbounded instead, same fallback deleteDataLake
-  // uses for filesDeletedAt.
-  const preMarkSweepInFlight = existing.status === 'archiving' && !existing.filesArchivedAt;
+  // archive->delete->restore can clear exactly these rows' archive marker. Skipped whenever the
+  // lake carries no mark AND already has archived members with no stamp - a lake archived before
+  // this field existed, or (rarer) a crashed prior attempt whose claim landed but whose sweep
+  // never ran, self-heals on its own via the claimed-value-echoed-back path below. Claiming a
+  // FRESH stamp here would name a batch narrower than what is actually archived: the sweep only
+  // ever touches archivedAt: null rows, so the pre-existing ones would never get the new stamp,
+  // and the lake would end up with a filesArchivedAt that names zero rows - poisoning every future
+  // restore into believing archivedAt is bounded when nothing on this lake actually carries the
+  // mark. Archiving unstamped instead leaves those rows exactly as unrecoverable as they already
+  // were, which is the safe direction to fail in.
+  const hasUnstampedArchive =
+    !existing.filesArchivedAt && (await db.fabFiles.findArchivedByDataLakeTag(scope)).length > 0;
   let stamp: Date | undefined;
-  if (!preMarkSweepInFlight) {
+  if (!hasUnstampedArchive) {
     stamp = (await db.dataLakes.claimFilesArchivedAt(dataLakeId, new Date())) ?? undefined;
     if (!stamp) {
-      logger?.warn('[dataLakes] archive recorded no stamp; this lake will restore-clear unbounded', {
+      logger?.warn('[dataLakes] archive recorded no stamp; a later restore will not clear archivedAt for this lake', {
         dataLakeId,
       });
     }
@@ -81,7 +91,6 @@ export const archiveDataLake = async (
   // browse (they filter archivedAt: null) - and unarchiving either lake brings back BOTH lakes'
   // archived files, since the flip matches on archivedAt alone.
   await warnOnPrefixCollision(db, existing, logger);
-  const scope = lakeMembershipScope(existing);
   await db.fabFiles.archiveByDataLakeTag(scope, stamp);
   // Same scope the sweep ran on. findIdsByDataLakeTag is the id source rather than the flip's
   // count because it reports every member whatever its archived/deleted state, so a re-run after

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1110,6 +1110,7 @@ describe('archiveDataLake - retrieval-index removal', () => {
         archiveByDataLakeTag: vi.fn().mockResolvedValue(2),
         computeDataLakeStats: vi.fn().mockResolvedValue({ fileCount: 0, totalSizeBytes: 0 }),
         findIdsByDataLakeTag: vi.fn().mockResolvedValue(memberIds),
+        findArchivedByDataLakeTag: vi.fn().mockResolvedValue([]),
       },
     },
     logger: { warn: vi.fn() },
@@ -1160,11 +1161,10 @@ describe('archiveDataLake - retrieval-index removal', () => {
     );
   });
 
-  it('skips the claim on a pre-mark crash re-run, archiving unstamped rather than naming a batch narrower than what is archived', async () => {
+  it('skips the claim when unstamped archived members already exist (a legacy pre-field lake, or a claim-without-sweep crash), archiving unstamped instead of naming a batch narrower than what is actually archived', async () => {
     const adapters = makeAdapters();
-    adapters.db.dataLakes.findById = vi
-      .fn()
-      .mockResolvedValue(lake({ status: 'archiving', filesArchivedAt: undefined }));
+    adapters.db.dataLakes.findById = vi.fn().mockResolvedValue(lake({ filesArchivedAt: undefined }));
+    adapters.db.fabFiles.findArchivedByDataLakeTag = vi.fn().mockResolvedValue([{ id: 'already-archived' }]);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
@@ -1172,14 +1172,30 @@ describe('archiveDataLake - retrieval-index removal', () => {
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, undefined);
   });
 
-  it('claims normally on a re-run that already holds a mark', async () => {
+  it('claims normally when the lake has no unstamped archived members', async () => {
     const adapters = makeAdapters();
     const stamp = new Date('2026-05-01');
-    adapters.db.dataLakes.findById = vi.fn().mockResolvedValue(lake({ status: 'archiving', filesArchivedAt: stamp }));
     adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
+    expect(adapters.db.fabFiles.findArchivedByDataLakeTag).toHaveBeenCalledWith(lakeScope);
+    expect(adapters.db.dataLakes.claimFilesArchivedAt).toHaveBeenCalledWith('lake1', expect.any(Date));
+    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, stamp);
+  });
+
+  it('claims normally on a re-run that already holds a mark, even with archived members present (they already carry that mark)', async () => {
+    const adapters = makeAdapters();
+    const stamp = new Date('2026-05-01');
+    adapters.db.dataLakes.findById = vi.fn().mockResolvedValue(lake({ status: 'archiving', filesArchivedAt: stamp }));
+    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
+    adapters.db.fabFiles.findArchivedByDataLakeTag = vi.fn().mockResolvedValue([{ id: 'already-archived' }]);
+
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+
+    // filesArchivedAt is already set, so the unstamped-archive check short-circuits false without
+    // even needing to ask - the lake already knows the mark those rows carry.
+    expect(adapters.db.fabFiles.findArchivedByDataLakeTag).not.toHaveBeenCalled();
     expect(adapters.db.dataLakes.claimFilesArchivedAt).toHaveBeenCalledWith('lake1', expect.any(Date));
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, stamp);
   });

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1110,7 +1110,7 @@ describe('archiveDataLake - retrieval-index removal', () => {
         archiveByDataLakeTag: vi.fn().mockResolvedValue(2),
         computeDataLakeStats: vi.fn().mockResolvedValue({ fileCount: 0, totalSizeBytes: 0 }),
         findIdsByDataLakeTag: vi.fn().mockResolvedValue(memberIds),
-        findArchivedByDataLakeTag: vi.fn().mockResolvedValue([]),
+        hasArchivedByDataLakeTag: vi.fn().mockResolvedValue(false),
       },
     },
     logger: { warn: vi.fn() },
@@ -1161,10 +1161,12 @@ describe('archiveDataLake - retrieval-index removal', () => {
     );
   });
 
-  it('skips the claim when unstamped archived members already exist (a legacy pre-field lake, or a claim-without-sweep crash), archiving unstamped instead of naming a batch narrower than what is actually archived', async () => {
+  // Covers a legacy pre-field lake and a claim-without-sweep crash alike (see archiveDataLake's
+  // hasUnstampedArchive guard): naming a fresh batch here would be narrower than what's archived.
+  it('skips the claim when unstamped archived members already exist, archiving unstamped instead', async () => {
     const adapters = makeAdapters();
     adapters.db.dataLakes.findById = vi.fn().mockResolvedValue(lake({ filesArchivedAt: undefined }));
-    adapters.db.fabFiles.findArchivedByDataLakeTag = vi.fn().mockResolvedValue([{ id: 'already-archived' }]);
+    adapters.db.fabFiles.hasArchivedByDataLakeTag = vi.fn().mockResolvedValue(true);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
@@ -1179,7 +1181,7 @@ describe('archiveDataLake - retrieval-index removal', () => {
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
-    expect(adapters.db.fabFiles.findArchivedByDataLakeTag).toHaveBeenCalledWith(lakeScope);
+    expect(adapters.db.fabFiles.hasArchivedByDataLakeTag).toHaveBeenCalledWith(lakeScope);
     expect(adapters.db.dataLakes.claimFilesArchivedAt).toHaveBeenCalledWith('lake1', expect.any(Date));
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, stamp);
   });
@@ -1189,13 +1191,13 @@ describe('archiveDataLake - retrieval-index removal', () => {
     const stamp = new Date('2026-05-01');
     adapters.db.dataLakes.findById = vi.fn().mockResolvedValue(lake({ status: 'archiving', filesArchivedAt: stamp }));
     adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
-    adapters.db.fabFiles.findArchivedByDataLakeTag = vi.fn().mockResolvedValue([{ id: 'already-archived' }]);
+    adapters.db.fabFiles.hasArchivedByDataLakeTag = vi.fn().mockResolvedValue(true);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
     // filesArchivedAt is already set, so the unstamped-archive check short-circuits false without
     // even needing to ask - the lake already knows the mark those rows carry.
-    expect(adapters.db.fabFiles.findArchivedByDataLakeTag).not.toHaveBeenCalled();
+    expect(adapters.db.fabFiles.hasArchivedByDataLakeTag).not.toHaveBeenCalled();
     expect(adapters.db.dataLakes.claimFilesArchivedAt).toHaveBeenCalledWith('lake1', expect.any(Date));
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, stamp);
   });

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1201,6 +1201,43 @@ describe('archiveDataLake - retrieval-index removal', () => {
     expect(adapters.db.dataLakes.claimFilesArchivedAt).toHaveBeenCalledWith('lake1', expect.any(Date));
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, stamp);
   });
+
+  it('warns and archives unstamped when the claim comes back empty (the lake vanished under a concurrent delete)', async () => {
+    const adapters = makeAdapters();
+    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(null);
+
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+
+    expect(adapters.logger.warn).toHaveBeenCalledWith(expect.stringContaining('archive recorded no stamp'), {
+      dataLakeId: 'lake1',
+    });
+    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, undefined);
+    // No stamp means the zero-swept clear-back below can never fire for this lake - nothing to
+    // clear, and clearing would wipe a mark a concurrent claimant may since have written.
+    expect(adapters.db.dataLakes.update).not.toHaveBeenCalledWith(expect.objectContaining({ filesArchivedAt: null }));
+  });
+
+  it('clears the just-claimed stamp back to null when the sweep matches nothing (a concurrent sibling won the probe-to-claim race)', async () => {
+    const adapters = makeAdapters();
+    const stamp = new Date('2026-05-01');
+    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
+    adapters.db.fabFiles.archiveByDataLakeTag = vi.fn().mockResolvedValue(0);
+
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+
+    expect(adapters.db.dataLakes.update).toHaveBeenCalledWith({ id: 'lake1', filesArchivedAt: null });
+  });
+
+  it('leaves the stamp alone when the sweep matches at least one row', async () => {
+    const adapters = makeAdapters();
+    const stamp = new Date('2026-05-01');
+    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
+    adapters.db.fabFiles.archiveByDataLakeTag = vi.fn().mockResolvedValue(1);
+
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+
+    expect(adapters.db.dataLakes.update).not.toHaveBeenCalledWith(expect.objectContaining({ filesArchivedAt: null }));
+  });
 });
 
 describe('deleteDataLake - phase 1 retrieval-index removal', () => {

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1019,6 +1019,26 @@ describe('unarchiveDataLake — dedup pass (live re-upload wins)', () => {
     expect(result.skippedDuplicates).toBe(1);
     expect(result.restoredCount).toBe(1);
   });
+
+  it('clears filesArchivedAt so a later re-archive claims a fresh stamp, not a stale reused one', async () => {
+    const fabFiles = {
+      findArchivedByDataLakeTag: vi.fn().mockResolvedValue([]),
+      findByContentHashesInDataLake: vi.fn().mockResolvedValue([]),
+      unarchiveByDataLakeTag: vi.fn().mockResolvedValue(0),
+      deleteManyInIds: vi.fn().mockResolvedValue(undefined),
+      computeDataLakeStats: vi.fn().mockResolvedValue({ fileCount: 0, totalSizeBytes: 0 }),
+    };
+    const dataLakes = {
+      findById: vi.fn().mockResolvedValue(lake({ status: 'archived', filesArchivedAt: new Date('2026-05-01') })),
+      update: vi.fn().mockResolvedValue(lake()),
+      setStats: vi.fn().mockResolvedValue(lake()),
+      activateIfDraft: vi.fn(),
+    };
+    await unarchiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', { db: { dataLakes, fabFiles } });
+
+    const settle = dataLakes.update.mock.calls.at(-1)?.[0];
+    expect(settle).toEqual({ id: 'lake1', status: 'active', filesArchivedAt: null });
+  });
 });
 
 describe('restoreDeletedDataLake — deleted→active with dedup', () => {
@@ -1061,7 +1081,7 @@ describe('restoreDeletedDataLake — deleted→active with dedup', () => {
     const result = await restoreDeletedDataLake({ userId: 'owner', isAdmin: false }, 'lake1', {
       db: { dataLakes, fabFiles },
     });
-    expect(fabFiles.undeleteByDataLakeTag).toHaveBeenCalledWith(lakeScope, ['d1'], undefined);
+    expect(fabFiles.undeleteByDataLakeTag).toHaveBeenCalledWith(lakeScope, ['d1'], undefined, undefined);
     // Same narrow probe as the unarchive path, for the same reason.
     expect(fabFiles.findByContentHashesInDataLake).toHaveBeenCalledWith(['h1', 'h2'], 'datalake:lake');
     expect(result.skippedDuplicates).toBe(1);
@@ -1080,6 +1100,7 @@ describe('archiveDataLake - retrieval-index removal', () => {
         setStats: vi.fn().mockResolvedValue(undefined),
         activateIfDraft: vi.fn(),
         find: vi.fn().mockResolvedValue([]),
+        claimFilesArchivedAt: vi.fn().mockImplementation(async (_id: string, at: Date) => at),
       },
       batches: {
         findActiveByDataLakeId: vi.fn().mockResolvedValue([]),
@@ -1123,7 +1144,7 @@ describe('archiveDataLake - retrieval-index removal', () => {
     const adapters = makeAdapters();
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
     expect(adapters.db.fabFiles.findIdsByDataLakeTag).not.toHaveBeenCalled();
-    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope);
+    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, expect.any(Date));
   });
 
   it('survives a member-id lookup that itself fails', async () => {
@@ -1137,6 +1158,30 @@ describe('archiveDataLake - retrieval-index removal', () => {
       expect.stringContaining('Best-effort index removal failed for datalake:lake'),
       expect.any(Error)
     );
+  });
+
+  it('skips the claim on a pre-mark crash re-run, archiving unstamped rather than naming a batch narrower than what is archived', async () => {
+    const adapters = makeAdapters();
+    adapters.db.dataLakes.findById = vi
+      .fn()
+      .mockResolvedValue(lake({ status: 'archiving', filesArchivedAt: undefined }));
+
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+
+    expect(adapters.db.dataLakes.claimFilesArchivedAt).not.toHaveBeenCalled();
+    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, undefined);
+  });
+
+  it('claims normally on a re-run that already holds a mark', async () => {
+    const adapters = makeAdapters();
+    const stamp = new Date('2026-05-01');
+    adapters.db.dataLakes.findById = vi.fn().mockResolvedValue(lake({ status: 'archiving', filesArchivedAt: stamp }));
+    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
+
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+
+    expect(adapters.db.dataLakes.claimFilesArchivedAt).toHaveBeenCalledWith('lake1', expect.any(Date));
+    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, stamp);
   });
 });
 
@@ -1210,6 +1255,7 @@ describe('deleteDataLake - phase 1 retrieval-index removal', () => {
 
 describe('teardown stamp bookkeeping', () => {
   const RECORDED = new Date('2026-06-01T00:00:00.000Z');
+  const ARCHIVE_RECORDED = new Date('2026-05-01T00:00:00.000Z');
 
   const teardownAdapters = (existing: IDataLakeDocument) => ({
     db: {
@@ -1328,17 +1374,18 @@ describe('teardown stamp bookkeeping', () => {
       await restoreDeletedDataLake(owner, 'lake1', adapters);
 
       expect(adapters.db.fabFiles.findDeletedByDataLakeTag).toHaveBeenCalledWith(lakeScope, RECORDED);
-      expect(adapters.db.fabFiles.undeleteByDataLakeTag).toHaveBeenCalledWith(lakeScope, [], RECORDED);
+      expect(adapters.db.fabFiles.undeleteByDataLakeTag).toHaveBeenCalledWith(lakeScope, [], RECORDED, undefined);
     });
 
-    it('clears the spent stamp with null as it settles', async () => {
+    it('clears the spent delete AND archive stamps with null as it settles', async () => {
       const adapters = reversalAdapters(lake({ status: 'deleted', filesDeletedAt: RECORDED }));
       await restoreDeletedDataLake(owner, 'lake1', adapters);
 
       const settle = adapters.db.dataLakes.update.mock.calls.at(-1)?.[0];
-      expect(settle).toEqual({ id: 'lake1', status: 'active', filesDeletedAt: null });
+      expect(settle).toEqual({ id: 'lake1', status: 'active', filesDeletedAt: null, filesArchivedAt: null });
       // undefined would be dropped on the way to mongo and leave the spent mark in place.
       expect(settle.filesDeletedAt).toBeNull();
+      expect(settle.filesArchivedAt).toBeNull();
     });
 
     it('reverses unbounded when the lake carries no stamp', async () => {
@@ -1346,7 +1393,21 @@ describe('teardown stamp bookkeeping', () => {
       await restoreDeletedDataLake(owner, 'lake1', adapters);
 
       expect(adapters.db.fabFiles.findDeletedByDataLakeTag).toHaveBeenCalledWith(lakeScope, undefined);
-      expect(adapters.db.fabFiles.undeleteByDataLakeTag).toHaveBeenCalledWith(lakeScope, [], undefined);
+      expect(adapters.db.fabFiles.undeleteByDataLakeTag).toHaveBeenCalledWith(lakeScope, [], undefined, undefined);
+    });
+
+    it('hands the recorded archive stamp to the flip, bounding the archive-clear to this lake', async () => {
+      const adapters = reversalAdapters(
+        lake({ status: 'deleted', filesDeletedAt: RECORDED, filesArchivedAt: ARCHIVE_RECORDED })
+      );
+      await restoreDeletedDataLake(owner, 'lake1', adapters);
+
+      expect(adapters.db.fabFiles.undeleteByDataLakeTag).toHaveBeenCalledWith(
+        lakeScope,
+        [],
+        RECORDED,
+        ARCHIVE_RECORDED
+      );
     });
   });
 });

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1171,7 +1171,9 @@ describe('archiveDataLake - retrieval-index removal', () => {
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
     expect(adapters.db.dataLakes.claimFilesArchivedAt).not.toHaveBeenCalled();
-    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, undefined);
+    // No stamp to give these rows, so archiveDataLake generates an orphaned one visibly at the
+    // call site rather than relying on archiveByDataLakeTag's own default.
+    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, expect.any(Date));
   });
 
   it('claims normally when the lake has no unstamped archived members', async () => {
@@ -1219,7 +1221,7 @@ describe('archiveDataLake - retrieval-index removal', () => {
     expect(adapters.logger.warn).toHaveBeenCalledWith(expect.stringContaining('archive recorded no stamp'), {
       dataLakeId: 'lake1',
     });
-    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, undefined);
+    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, expect.any(Date));
     // No stamp means the zero-swept clear-back below can never fire for this lake - nothing to
     // clear, and clearing would wipe a mark a concurrent claimant may since have written.
     expect(adapters.db.dataLakes.update).not.toHaveBeenCalledWith(expect.objectContaining({ filesArchivedAt: null }));

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1227,8 +1227,8 @@ describe('archiveDataLake - retrieval-index removal', () => {
 
   it('clears the just-claimed stamp back to null when the sweep matches nothing (a concurrent sibling won the probe-to-claim race)', async () => {
     const adapters = makeAdapters();
-    const stamp = new Date('2026-05-01');
-    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
+    // Base mock echoes the exact `at` passed in, simulating a claim THIS call actually won
+    // (wasMinted true) - a fixed unrelated Date would simulate an echoed peer's stamp instead.
     adapters.db.fabFiles.archiveByDataLakeTag = vi.fn().mockResolvedValue(0);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
@@ -1238,9 +1238,21 @@ describe('archiveDataLake - retrieval-index removal', () => {
 
   it('leaves the stamp alone when the sweep matches at least one row', async () => {
     const adapters = makeAdapters();
-    const stamp = new Date('2026-05-01');
-    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
     adapters.db.fabFiles.archiveByDataLakeTag = vi.fn().mockResolvedValue(1);
+
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+
+    expect(adapters.db.dataLakes.update).not.toHaveBeenCalledWith(expect.objectContaining({ filesArchivedAt: null }));
+  });
+
+  it('leaves the stamp alone when a concurrent claim on this SAME lake wins and our sweep matches nothing (echoed, not minted)', async () => {
+    const adapters = makeAdapters();
+    const peerStamp = new Date('2026-05-01');
+    // Our own claim call loses the set-if-unset to a concurrent request on the same lake and
+    // echoes the peer's winning stamp back - unequal to the `at` this call generated internally,
+    // so wasMinted is false even though a stamp came back and the sweep matched nothing.
+    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(peerStamp);
+    adapters.db.fabFiles.archiveByDataLakeTag = vi.fn().mockResolvedValue(0);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1192,6 +1192,11 @@ describe('archiveDataLake - retrieval-index removal', () => {
     adapters.db.dataLakes.findById = vi.fn().mockResolvedValue(lake({ status: 'archiving', filesArchivedAt: stamp }));
     adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
     adapters.db.fabFiles.hasArchivedByDataLakeTag = vi.fn().mockResolvedValue(true);
+    // Realistic for this scenario: a crashed prior attempt already stamped every row before it
+    // died, so the re-entered sweep (still filtering archivedAt: null) matches nothing new - not
+    // because the batch was never written. The base mock's default (2) would never exercise the
+    // zero-swept branch and let a regression on this exact path slip past (caught in review).
+    adapters.db.fabFiles.archiveByDataLakeTag = vi.fn().mockResolvedValue(0);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
@@ -1200,6 +1205,9 @@ describe('archiveDataLake - retrieval-index removal', () => {
     expect(adapters.db.fabFiles.hasArchivedByDataLakeTag).not.toHaveBeenCalled();
     expect(adapters.db.dataLakes.claimFilesArchivedAt).toHaveBeenCalledWith('lake1', expect.any(Date));
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, stamp);
+    // The echoed stamp still names every row (they were stamped before the crash) - clearing it
+    // here, despite sweeping zero, would strand them all on a later restore.
+    expect(adapters.db.dataLakes.update).not.toHaveBeenCalledWith(expect.objectContaining({ filesArchivedAt: null }));
   });
 
   it('warns and archives unstamped when the claim comes back empty (the lake vanished under a concurrent delete)', async () => {

--- a/b4m-core/services/src/dataLakeService/redactLakeForActor.ts
+++ b/b4m-core/services/src/dataLakeService/redactLakeForActor.ts
@@ -72,6 +72,8 @@ export const LAKE_FIELD_VISIBILITY: Record<keyof IDataLake, 'reader' | 'withheld
   lastSyncAt: 'reader',
   // Teardown bookkeeping: of no use to a reader, and it reports when the owner tore the lake down.
   filesDeletedAt: 'withheld',
+  // Same rationale, archive axis.
+  filesArchivedAt: 'withheld',
   // Lake-memory producer bookkeeping (#1440): internal lease + continuation cursor. Of no use to a
   // reader, and the lease timestamp would leak when/whether extraction is running.
   lakeMemoryExtractionAt: 'withheld',

--- a/b4m-core/services/src/dataLakeService/restoreDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/restoreDeletedDataLake.ts
@@ -24,6 +24,12 @@ interface RestoreDeletedDataLakeAdapters {
  * member the creator deleted on their own - before the teardown or while the lake sat deleted -
  * carries a different stamp and stays deleted. A lake torn down before that field existed has no
  * mark and restores unbounded, which is the old behavior and errs toward a file reappearing.
+ *
+ * Also clears `archivedAt` on the restored batch, bounded by `filesArchivedAt`: every UI-driven
+ * delete goes active -> archive -> delete (there is no delete-without-archiving control), so
+ * without this an archive->delete->restore lake comes back active but with its files still
+ * archived and invisible. A lake with no `filesArchivedAt` stamp leaves archivedAt untouched -
+ * the pre-existing, known behavior for a lake archived before that field existed.
  */
 export const restoreDeletedDataLake = async (
   actor: { userId: string; isAdmin: boolean },
@@ -66,10 +72,13 @@ export const restoreDeletedDataLake = async (
     skippedDuplicates = duplicateIds.length;
   }
 
-  const restoredCount = await db.fabFiles.undeleteByDataLakeTag(scope, duplicateIds, stampedAt);
+  // The batch this lake's own archive recorded, if any. undefined for a lake with no mark
+  // (archived before the field existed, or never archived), which leaves archivedAt untouched.
+  const archiveStampToClear = existing.filesArchivedAt ?? undefined;
+  const restoredCount = await db.fabFiles.undeleteByDataLakeTag(scope, duplicateIds, stampedAt, archiveStampToClear);
 
   // Explicit null, not undefined, which mongoose would drop and leave the spent mark in place.
-  await db.dataLakes.update({ id: dataLakeId, status: 'active', filesDeletedAt: null });
+  await db.dataLakes.update({ id: dataLakeId, status: 'active', filesDeletedAt: null, filesArchivedAt: null });
   await recomputeLakeStats(existing, { db });
 
   return { restoredCount, skippedDuplicates };

--- a/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
@@ -73,7 +73,9 @@ export const unarchiveDataLake = async (
   // Restore the remaining archived files (the non-duplicates).
   const restoredCount = await db.fabFiles.unarchiveByDataLakeTag(scope);
 
-  await db.dataLakes.update({ id: dataLakeId, status: 'active' });
+  // Explicit null, not undefined (mongoose drops undefined): a later re-archive claims a FRESH
+  // stamp via claimFilesArchivedAt's set-if-unset, rather than reusing this spent one.
+  await db.dataLakes.update({ id: dataLakeId, status: 'active', filesArchivedAt: null });
   await recomputeLakeStats(existing, { db });
 
   return { restoredCount, skippedDuplicates };

--- a/packages/database/src/models/ai/DataLakeModel.test.ts
+++ b/packages/database/src/models/ai/DataLakeModel.test.ts
@@ -1375,3 +1375,64 @@ describe('DataLakeRepository teardown stamp', () => {
     expect((await dataLakeRepository.claimFilesDeletedAt(created.id, second))?.getTime()).toBe(second.getTime());
   });
 });
+
+// Mirrors the delete-axis teardown stamp above, on the archive axis - same set-if-unset
+// concurrency guard, same round-trip contract, so restore can bound its archive-clear to the
+// batch this lake's own archive wrote.
+describe('DataLakeRepository archive stamp', () => {
+  setupMongoTest();
+
+  it('round-trips the stamp as a Date', async () => {
+    const stamp = new Date('2026-05-01T00:00:00.000Z');
+    const created = await dataLakeRepository.create(baseLake({ slug: 'archived-lake' }));
+
+    await dataLakeRepository.update({ id: created.id, filesArchivedAt: stamp });
+
+    const found = await dataLakeRepository.findById(created.id);
+    expect(found?.filesArchivedAt).toBeInstanceOf(Date);
+    expect(found?.filesArchivedAt?.getTime()).toBe(stamp.getTime());
+  });
+
+  it('clears a spent stamp back to null', async () => {
+    const created = await dataLakeRepository.create(
+      baseLake({ slug: 'unarchived', filesArchivedAt: new Date('2026-05-01T00:00:00.000Z') })
+    );
+
+    await dataLakeRepository.update({ id: created.id, filesArchivedAt: null });
+
+    expect((await dataLakeRepository.findById(created.id))?.filesArchivedAt ?? null).toBeNull();
+  });
+
+  it('leaves the stamp unset on a lake that was never archived', async () => {
+    const created = await dataLakeRepository.create(baseLake({ slug: 'untouched-archive' }));
+    expect((await dataLakeRepository.findById(created.id))?.filesArchivedAt ?? null).toBeNull();
+  });
+
+  it('claims an unset stamp and echoes it back', async () => {
+    const at = new Date('2026-05-01T00:00:00.000Z');
+    const created = await dataLakeRepository.create(baseLake({ slug: 'claiming-archive' }));
+
+    expect((await dataLakeRepository.claimFilesArchivedAt(created.id, at))?.getTime()).toBe(at.getTime());
+    expect((await dataLakeRepository.findById(created.id))?.filesArchivedAt?.getTime()).toBe(at.getTime());
+  });
+
+  it('refuses to overwrite a claimed stamp and hands back the holder', async () => {
+    const first = new Date('2026-05-01T00:00:00.000Z');
+    const second = new Date('2026-05-02T00:00:00.000Z');
+    const created = await dataLakeRepository.create(baseLake({ slug: 'contended-archive' }));
+    await dataLakeRepository.claimFilesArchivedAt(created.id, first);
+
+    expect((await dataLakeRepository.claimFilesArchivedAt(created.id, second))?.getTime()).toBe(first.getTime());
+    expect((await dataLakeRepository.findById(created.id))?.filesArchivedAt?.getTime()).toBe(first.getTime());
+  });
+
+  it('claims again once an unarchive has cleared the stamp', async () => {
+    const first = new Date('2026-05-01T00:00:00.000Z');
+    const second = new Date('2026-05-02T00:00:00.000Z');
+    const created = await dataLakeRepository.create(baseLake({ slug: 'recycled-archive' }));
+    await dataLakeRepository.claimFilesArchivedAt(created.id, first);
+    await dataLakeRepository.update({ id: created.id, filesArchivedAt: null });
+
+    expect((await dataLakeRepository.claimFilesArchivedAt(created.id, second))?.getTime()).toBe(second.getTime());
+  });
+});

--- a/packages/database/src/models/ai/DataLakeModel.ts
+++ b/packages/database/src/models/ai/DataLakeModel.ts
@@ -76,6 +76,9 @@ const DataLakeSchema = new mongoose.Schema(
     // no sweep ever wrote, and the restore keyed to it reverses nothing. Restore clears it to null.
     // No index - the lakes collection is tiny, and it is only ever read from a lake already in hand.
     filesDeletedAt: { type: Date },
+    // Archive batch key (see IDataLake.filesArchivedAt): mirrors filesDeletedAt but on the
+    // archive axis. Set only through claimFilesArchivedAt; cleared by unarchive and by restore.
+    filesArchivedAt: { type: Date },
     // Lake-memory producer (#1440) bookkeeping - server-managed, never client-writable. No index
     // (tiny collection, only read from a lake already in hand, same rationale as filesDeletedAt).
     // lakeMemoryExtractionAt is a concurrency lease; lakeMemoryCursor is the bounded-continuation
@@ -380,6 +383,18 @@ class DataLakeRepository extends BaseRepository<IDataLakeDocument> implements ID
     if (claimed) return claimed.filesDeletedAt ?? null;
     const holder = await this.dataLakeModel.findById(id);
     return holder?.filesDeletedAt ?? null;
+  }
+
+  async claimFilesArchivedAt(id: string, at: Date): Promise<Date | null> {
+    // Same set-if-unset contract as claimFilesDeletedAt (see its comment above).
+    const claimed = await this.dataLakeModel.findOneAndUpdate(
+      { _id: id, $or: [{ filesArchivedAt: null }, { filesArchivedAt: { $exists: false } }] },
+      { $set: { filesArchivedAt: at } },
+      { new: true }
+    );
+    if (claimed) return claimed.filesArchivedAt ?? null;
+    const holder = await this.dataLakeModel.findById(id);
+    return holder?.filesArchivedAt ?? null;
   }
 
   async setStats(id: string, stats: { fileCount: number; totalSizeBytes: number }): Promise<IDataLakeDocument | null> {

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import mongoose from 'mongoose';
 import { KnowledgeType, type DataLakeMembershipScope } from '@bike4mind/common';
 import { createMongoServer } from '../../__test__/createMongoServer';
@@ -387,6 +387,29 @@ describe('FabFile data lake lifecycle membership', () => {
         const diverged = await readRaw(rows.prefixOwned._id.toString());
         expect(diverged?.deletedAt ?? null).toBeNull();
         expect(diverged?.archivedAt?.getTime()).toBe(OTHER_STAMP.getTime());
+      });
+
+      it('sends the $ne bound to Mongo on the non-matching partition, not just an end-state that could pass by resolution-order luck', async () => {
+        // An end-state assertion alone does not reliably catch this: removing partition B's `$ne`
+        // bound (replacing it with the bare base filter) makes the two updateMany calls race on
+        // shared rows against a real DB, so this file's row-level tests fail only intermittently
+        // under that mutation, not every run - easy to write off as flakiness rather than catch.
+        // Spying on the actual filter sent to Mongo asserts the predicate itself, not what it
+        // happens to produce this run, so it fails deterministically.
+        await seedLakeRows();
+        await fabFileRepository.archiveByDataLakeTag(scope, ARCHIVE_STAMP);
+        await fabFileRepository.softDeleteByDataLakeTag(scope, STAMP);
+        const spy = vi.spyOn(FabFile, 'updateMany');
+
+        await fabFileRepository.undeleteByDataLakeTag(scope, [], STAMP, ARCHIVE_STAMP);
+
+        expect(spy).toHaveBeenCalledTimes(2);
+        const filters = spy.mock.calls.map(call => call[0] as Record<string, unknown>);
+        // Partition A: bare equality. Partition B: $ne - both must be present as sent to Mongo,
+        // not merely implied by the rows this run happened to produce.
+        expect(filters.some(f => f.archivedAt === ARCHIVE_STAMP)).toBe(true);
+        expect(filters.some(f => JSON.stringify(f.archivedAt) === JSON.stringify({ $ne: ARCHIVE_STAMP }))).toBe(true);
+        spy.mockRestore();
       });
 
       it('leaves a member archived under a DIFFERENT stamp untouched (a prefix-sharing sibling lake)', async () => {

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -326,6 +326,102 @@ describe('FabFile data lake lifecycle membership', () => {
         expect((await readRaw(rows.prefixOwned._id.toString()))?.deletedAt?.getTime()).toBe(STAMP.getTime());
       });
     });
+
+    // Archive->delete->restore: restore also clears archivedAt, bounded the same way as the
+    // delete axis - by equality against the stamp this lake's own archive wrote.
+    describe('archive axis (restore also clears archivedAt)', () => {
+      const ARCHIVE_STAMP = new Date('2026-05-01T00:00:00.000Z');
+      const OTHER_STAMP = new Date('2026-04-01T00:00:00.000Z');
+
+      it('writes the caller stamp on every row archiveByDataLakeTag flips', async () => {
+        const rows = await seedLakeRows();
+
+        await fabFileRepository.archiveByDataLakeTag(scope, ARCHIVE_STAMP);
+
+        for (const id of rows.memberIds) {
+          expect((await readRaw(id))?.archivedAt?.getTime()).toBe(ARCHIVE_STAMP.getTime());
+        }
+      });
+
+      it('clears archivedAt alongside deletedAt when the archive stamp matches this lake', async () => {
+        const rows = await seedLakeRows();
+        await fabFileRepository.archiveByDataLakeTag(scope, ARCHIVE_STAMP);
+        await fabFileRepository.softDeleteByDataLakeTag(scope, STAMP);
+
+        const restored = await fabFileRepository.undeleteByDataLakeTag(scope, [], STAMP, ARCHIVE_STAMP);
+
+        expect(restored).toBe(2);
+        for (const id of rows.memberIds) {
+          const row = await readRaw(id);
+          expect(row?.deletedAt ?? null).toBeNull();
+          expect(row?.archivedAt ?? null).toBeNull();
+        }
+      });
+
+      it('leaves a member archived under a DIFFERENT stamp untouched (a prefix-sharing sibling lake)', async () => {
+        const rows = await seedLakeRows();
+        // Simulates a file this lake's delete swept up (matching deletedAt) but whose archivedAt
+        // was written by a different lake's archive - a different stamp this restore does not own.
+        await FabFile.updateOne({ _id: rows.metaTagged._id }, { $set: { archivedAt: OTHER_STAMP } });
+        await fabFileRepository.softDeleteByDataLakeTag(scope, STAMP);
+
+        const restored = await fabFileRepository.undeleteByDataLakeTag(scope, [], STAMP, ARCHIVE_STAMP);
+
+        expect(restored).toBe(2);
+        const row = await readRaw(rows.metaTagged._id.toString());
+        expect(row?.deletedAt ?? null).toBeNull();
+        expect(row?.archivedAt?.getTime()).toBe(OTHER_STAMP.getTime());
+      });
+
+      it('leaves archivedAt untouched when no archive stamp is given (pre-mark lake, the known limitation)', async () => {
+        const rows = await seedLakeRows();
+        await fabFileRepository.archiveByDataLakeTag(scope, ARCHIVE_STAMP);
+        await fabFileRepository.softDeleteByDataLakeTag(scope, STAMP);
+
+        const restored = await fabFileRepository.undeleteByDataLakeTag(scope, [], STAMP);
+
+        expect(restored).toBe(2);
+        for (const id of rows.memberIds) {
+          const row = await readRaw(id);
+          expect(row?.deletedAt ?? null).toBeNull();
+          expect(row?.archivedAt?.getTime()).toBe(ARCHIVE_STAMP.getTime());
+        }
+      });
+
+      it('never clears archivedAt on a dedup-discarded duplicate (excludeIds)', async () => {
+        const rows = await seedLakeRows();
+        await fabFileRepository.archiveByDataLakeTag(scope, ARCHIVE_STAMP);
+        await fabFileRepository.softDeleteByDataLakeTag(scope, STAMP);
+
+        const restored = await fabFileRepository.undeleteByDataLakeTag(
+          scope,
+          [rows.prefixOwned._id.toString()],
+          STAMP,
+          ARCHIVE_STAMP
+        );
+
+        expect(restored).toBe(1);
+        const excluded = await readRaw(rows.prefixOwned._id.toString());
+        expect(excluded?.deletedAt).not.toBeNull();
+        expect(excluded?.archivedAt?.getTime()).toBe(ARCHIVE_STAMP.getTime());
+      });
+
+      it('leaves a file archived-by-lake but individually deleted (a different delete stamp) untouched', async () => {
+        const rows = await seedLakeRows();
+        await fabFileRepository.archiveByDataLakeTag(scope, ARCHIVE_STAMP);
+        // Deleted on its own, at a stamp the teardown never wrote.
+        await deleteIndependently(rows.metaTagged._id, EARLIER);
+        await fabFileRepository.softDeleteByDataLakeTag(scope, STAMP);
+
+        const restored = await fabFileRepository.undeleteByDataLakeTag(scope, [], STAMP, ARCHIVE_STAMP);
+
+        // Only prefixOwned matched the teardown's stamp; metaTagged kept its own earlier one.
+        expect(restored).toBe(1);
+        const independentlyDeleted = await readRaw(rows.metaTagged._id.toString());
+        expect(independentlyDeleted?.deletedAt?.getTime()).toBe(EARLIER.getTime());
+        expect(independentlyDeleted?.archivedAt?.getTime()).toBe(ARCHIVE_STAMP.getTime());
+      });
+    });
   });
 
   describe('findIdsByDataLakeTag / hardDeleteByDataLakeTag', () => {

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -421,6 +421,24 @@ describe('FabFile data lake lifecycle membership', () => {
         expect(independentlyDeleted?.deletedAt?.getTime()).toBe(EARLIER.getTime());
         expect(independentlyDeleted?.archivedAt?.getTime()).toBe(ARCHIVE_STAMP.getTime());
       });
+
+      it('the displayed file count agrees with the Files browser after restore (the stale-count symptom)', async () => {
+        const rows = await seedLakeRows();
+        await fabFileRepository.archiveByDataLakeTag(scope, ARCHIVE_STAMP);
+        await fabFileRepository.softDeleteByDataLakeTag(scope, STAMP);
+
+        await fabFileRepository.undeleteByDataLakeTag(scope, [], STAMP, ARCHIVE_STAMP);
+
+        // computeDataLakeStats is what the lake's displayed fileCount is recomputed from - it must
+        // count both restored members now that neither carries a deletedAt or archivedAt marker.
+        const stats = await fabFileRepository.computeDataLakeStats(scope);
+        expect(stats.fileCount).toBe(rows.memberIds.length);
+        for (const id of rows.memberIds) {
+          const row = await readRaw(id);
+          expect(row?.deletedAt ?? null).toBeNull();
+          expect(row?.archivedAt ?? null).toBeNull();
+        }
+      });
     });
   });
 

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -358,6 +358,27 @@ describe('FabFile data lake lifecycle membership', () => {
         }
       });
 
+      it('splits a single mixed batch correctly: one row matches the stamp, the other does not', async () => {
+        // Proves the two-partition update's arithmetic in the one case that actually exercises
+        // both branches at once - every other test here has all-or-nothing rows, which cannot
+        // catch a double-count or a dropped row in ownStamp.modifiedCount + otherStamp.modifiedCount.
+        const rows = await seedLakeRows();
+        await fabFileRepository.archiveByDataLakeTag(scope, ARCHIVE_STAMP);
+        // One member's stamp diverges after the fact (e.g. re-archived by another mechanism).
+        await FabFile.updateOne({ _id: rows.prefixOwned._id }, { $set: { archivedAt: OTHER_STAMP } });
+        await fabFileRepository.softDeleteByDataLakeTag(scope, STAMP);
+
+        const restored = await fabFileRepository.undeleteByDataLakeTag(scope, [], STAMP, ARCHIVE_STAMP);
+
+        expect(restored).toBe(2);
+        const matched = await readRaw(rows.metaTagged._id.toString());
+        expect(matched?.deletedAt ?? null).toBeNull();
+        expect(matched?.archivedAt ?? null).toBeNull();
+        const diverged = await readRaw(rows.prefixOwned._id.toString());
+        expect(diverged?.deletedAt ?? null).toBeNull();
+        expect(diverged?.archivedAt?.getTime()).toBe(OTHER_STAMP.getTime());
+      });
+
       it('leaves a member archived under a DIFFERENT stamp untouched (a prefix-sharing sibling lake)', async () => {
         const rows = await seedLakeRows();
         // Simulates a file this lake's delete swept up (matching deletedAt) but whose archivedAt

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -178,6 +178,16 @@ describe('FabFile data lake lifecycle membership', () => {
 
       expect(found.map(f => f.fileName).sort()).toEqual(['meta.txt', 'prefix-owned.txt']);
     });
+
+    it('hasArchivedByDataLakeTag reports existence without materializing the rows', async () => {
+      await seedLakeRows();
+
+      expect(await fabFileRepository.hasArchivedByDataLakeTag(scope)).toBe(false);
+
+      await fabFileRepository.archiveByDataLakeTag(scope);
+
+      expect(await fabFileRepository.hasArchivedByDataLakeTag(scope)).toBe(true);
+    });
   });
 
   describe('softDeleteByDataLakeTag / undeleteByDataLakeTag', () => {

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -917,14 +917,18 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
   // Omitting `stampedAt` matches every stamped row, which is the pre-mark behavior and the fallback
   // for a lake torn down before the mark existed.
   //
-  // The archive axis deliberately stays unstamped: `archiveByDataLakeTag` is the only writer of a
-  // non-null `archivedAt`, so there is no independently-archived file to protect, and bounding it
-  // would strand any row still holding a stamp its lake no longer names.
+  // The archive axis is stamped the same way (`at`, from `IDataLake.filesArchivedAt`), because
+  // restore now also clears `archivedAt` (an archive->delete->restore must not leave files
+  // archived-and-invisible) - so equality-bounding that clear against the stamp is what stops it
+  // from freeing a prefix-sharing sibling's independently-archived files, the same way the delete
+  // axis avoids reviving a file the creator deleted on their own. `unarchiveByDataLakeTag` still
+  // matches on `archivedAt` alone (unbounded) - that reversal's own bounding is separate,
+  // unresolved scope.
 
-  async archiveByDataLakeTag(scope: DataLakeMembershipScope): Promise<number> {
+  async archiveByDataLakeTag(scope: DataLakeMembershipScope, at: Date = new Date()): Promise<number> {
     const result = await this.fabFileModel.updateMany(
       { ...buildDataLakeMembershipFilter(scope), deletedAt: null, archivedAt: null },
-      { $set: { archivedAt: new Date() } }
+      { $set: { archivedAt: at } }
     );
     return result.modifiedCount;
   }
@@ -959,15 +963,37 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
   async undeleteByDataLakeTag(
     scope: DataLakeMembershipScope,
     excludeIds: string[] = [],
-    stampedAt?: Date
+    stampedAt?: Date,
+    archiveStampToClear?: Date
   ): Promise<number> {
-    const filter: Record<string, unknown> = {
+    const base: Record<string, unknown> = {
       ...buildDataLakeMembershipFilter(scope),
       deletedAt: stampedAt ?? { $ne: null },
     };
-    if (excludeIds.length > 0) filter._id = { $nin: excludeIds };
-    const result = await this.fabFileModel.updateMany(filter, { $set: { deletedAt: null } });
-    return result.modifiedCount;
+    if (excludeIds.length > 0) base._id = { $nin: excludeIds };
+
+    if (!archiveStampToClear) {
+      const result = await this.fabFileModel.updateMany(base, { $set: { deletedAt: null } });
+      return result.modifiedCount;
+    }
+
+    // Two queries partitioned on `archivedAt`, not one update followed by another: both read the
+    // pre-image, so a row's own `archivedAt` value (not whether a prior write already flipped
+    // `deletedAt`) decides which branch it falls into. A row stamped by THIS lake's own archive
+    // gets both fields cleared; any other value (a different lake's stamp, or none) only un-deletes,
+    // leaving its archive marker exactly as it was - the equality bound that keeps this from
+    // freeing a prefix-sharing sibling's independently-archived files.
+    const [ownStamp, otherStamp] = await Promise.all([
+      this.fabFileModel.updateMany(
+        { ...base, archivedAt: archiveStampToClear },
+        { $set: { deletedAt: null, archivedAt: null } }
+      ),
+      this.fabFileModel.updateMany(
+        { ...base, archivedAt: { $ne: archiveStampToClear } },
+        { $set: { deletedAt: null } }
+      ),
+    ]);
+    return ownStamp.modifiedCount + otherStamp.modifiedCount;
   }
 
   async softDeleteByDataLakeTag(scope: DataLakeMembershipScope, at: Date = new Date()): Promise<string[]> {

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -950,6 +950,19 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     return result.map(d => d.toJSON());
   }
 
+  // Same predicate as findArchivedByDataLakeTag, but an existence probe rather than a full read -
+  // for a caller (archiveDataLake's hasUnstampedArchive guard) that only needs to know "any?", not
+  // the documents themselves, and would otherwise materialize every archived row on every archive.
+  async hasArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<boolean> {
+    return (
+      (await this.fabFileModel.exists({
+        ...buildDataLakeMembershipFilter(scope),
+        deletedAt: null,
+        archivedAt: { $ne: null },
+      })) != null
+    );
+  }
+
   async findDeletedByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<IFabFileDocument[]> {
     // `includeDeleted` is load-bearing for BOTH forms, not just tidiness: the soft-delete plugin's
     // find hook does `this.where({ deletedAt: null })`, which REPLACES the condition on that key, so

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -977,12 +977,14 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
       return result.modifiedCount;
     }
 
-    // Two queries partitioned on `archivedAt`, not one update followed by another: both read the
-    // pre-image, so a row's own `archivedAt` value (not whether a prior write already flipped
-    // `deletedAt`) decides which branch it falls into. A row stamped by THIS lake's own archive
-    // gets both fields cleared; any other value (a different lake's stamp, or none) only un-deletes,
-    // leaving its archive marker exactly as it was - the equality bound that keeps this from
-    // freeing a prefix-sharing sibling's independently-archived files.
+    // Two parallel queries partitioned on `archivedAt`, not one update followed by another - not
+    // for snapshot isolation (Mongo gives none across separate updateMany calls), but because the
+    // shared `deletedAt: stampedAt` base filter is a barrier: once either query flips a row's
+    // `deletedAt` to null, that row no longer matches EITHER filter, so it cannot be picked up
+    // twice. A row stamped by THIS lake's own archive gets both fields cleared; any other value (a
+    // different lake's stamp, or none) only un-deletes, leaving its archive marker exactly as it
+    // was - the equality bound that keeps this from freeing a prefix-sharing sibling's
+    // independently-archived files.
     const [ownStamp, otherStamp] = await Promise.all([
       this.fabFileModel.updateMany(
         { ...base, archivedAt: archiveStampToClear },


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="964" height="742" alt="Restored data lake showing 1 file and an active Archive button after an archive, delete, and restore cycle" src="https://github.com/user-attachments/assets/0ded0618-5a63-4c6c-a18f-57c13cf03328" />

*Lake after archive -> delete (recoverable) -> restore: the file count reads "1 file" and the Archive button is back, so the lake is active with its file intact, not still archived and invisible.*

## Description
`restoreDeletedDataLake` un-deleted a lake's files but never cleared `archivedAt`, so an archive -> delete -> restore lake (the only path the UI offers, since there is no direct delete on an active lake, issue 1485) came back active with its files still archived and invisible to the Files browser.

Adds a `filesArchivedAt` lake-level stamp mirroring the existing delete-axis `filesDeletedAt`: archive claims and writes it, unarchive clears it, and restore clears `archivedAt` only on rows matching its own stamp. The equality bound is what keeps a prefix-sharing sibling lake's independently-archived files from getting freed. A lake archived before this field existed keeps today's exact current behavior rather than guessing at a batch it cannot prove.

An independent review of the first pass caught a real gap: re-archiving a legacy unstamped lake would claim a stamp naming zero rows, permanently poisoning future restores. Fixed by checking for pre-existing unstamped archived members before claiming.

Closes #1486

## Changes
- Add `filesArchivedAt` lake-level stamp (mirrors `filesDeletedAt`) + `claimFilesArchivedAt`, including the forced redaction-map and mock updates.
- Wire `archiveDataLake` to claim + write the stamp per-row, guarded against claiming when unstamped archived members already exist.
- `unarchiveDataLake` clears the stamp so a later re-archive gets a fresh one, not a stale reused one.
- Bound `restoreDeletedDataLake`'s archive-clear to the batch via a two-partition update in `undeleteByDataLakeTag`.
- Regression tests across all three axes: claim/round-trip, the legacy/crash guard, mixed-batch partitioning, and the file-count acceptance criterion.

## Guide for Testers
No preview needed. Runs against a locally-run client (`pnpm --filter client dev`), logged in as a user with the `EnableDataLakes` flag on.

1. Navigate to `/data-lakes`. Click **Manage lakes**.
2. Create a new lake (or pick an existing one) and upload at least one file to it. Note the lake's name and file name.
3. In the **Active** section, click **Archive** for that lake. Expected: the lake moves to the **Archived** section.
4. In the **Archived** section, click **Delete (recoverable)** for that lake. Expected: the lake moves to the **Deleted** section.
5. In the **Deleted** section, click **Restore**. Expected: the lake reappears in the **Active** section, and its file count is not 0.
6. Open the Files browser scoped to this lake. Expected: the file uploaded in step 2 is visible and openable, not missing.
7. **Regression check**: repeat steps 3-5 on a second, unrelated lake sharing no files with the first. Expected: throughout, neither lake's files leak into or vanish from the other.

**What NOT to test**: prefix-sharing sibling-lake isolation and the pre-existing-unstamped-legacy-lake path are covered only by the automated tests (`FabFileModel.dataLakeLifecycle.test.ts`, `dataLakeService.test.ts`). They need seeded pre-migration data or two lakes deliberately sharing a file-tag prefix, and neither is a supported UI flow to set up by hand.

## Additional Information
A lake archived before this PR deploys has no `filesArchivedAt` stamp; its restore leaves `archivedAt` exactly as it already was, not newly broken. There is also a narrow, pre-existing race between archive and a concurrent unarchive on the same lake, shared with the existing delete/restore pair. It's not introduced here, and it's out of scope for this ticket's sequential, single-actor bug.

## Developer Notes (Optional)
The claim-then-sweep, equality-bounded stamp pattern (`filesDeletedAt`/`claimFilesDeletedAt`) is now mirrored on the archive axis (`filesArchivedAt`/`claimFilesArchivedAt`). It's a reusable shape for any future soft-teardown/reversal pair on `FabFile` that needs to bound its reversal to the batch it itself wrote, rather than an entire tag scope.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc


