### PR TITLE
fix(data-lakes): stop taxonomy review panel from wiping edits, add accessibility names

### DIFF
--- a/apps/client/app/components/DataLakeWizard/TaxonomyReviewPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/TaxonomyReviewPanel.test.tsx
@@ -163,4 +163,90 @@ describe('TaxonomyReviewPanel', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(dismissMutate).not.toHaveBeenCalled();
   });
+
+  it('gives the icon-only Edit and Delete buttons an accessible name', () => {
+    render(
+      <Wrapper>
+        <TaxonomyReviewPanel batch={readyBatch()} prefix="acme:" onClose={() => {}} />
+      </Wrapper>
+    );
+
+    expect(screen.getAllByRole('button', { name: 'Edit' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(2);
+  });
+
+  it('gives the icon-only Save and Cancel buttons an accessible name while editing', () => {
+    render(
+      <Wrapper>
+        <TaxonomyReviewPanel batch={readyBatch()} prefix="acme:" onClose={() => {}} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getAllByTestId('taxonomy-tag-edit')[0]);
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('keeps in-progress edits when taxonomySuggestions gets a new object reference but the same tag content', () => {
+    // Simulates the batches-list response rebuilding a new array/object on every poll (Map +
+    // spread) even when nothing about THIS batch's suggestions actually changed - e.g. because
+    // some other batch left the list and shifted everyone after it. React Query's default
+    // structural sharing would otherwise hand back a new reference here.
+    const batch = readyBatch();
+    const { rerender } = render(
+      <Wrapper>
+        <TaxonomyReviewPanel batch={batch} prefix="acme:" onClose={() => {}} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getAllByTestId('taxonomy-tag-delete')[0]);
+    expect(screen.getAllByTestId('taxonomy-tag-card')).toHaveLength(1);
+
+    const sameContentNewObject = { ...batch, taxonomySuggestions: { ...batch.taxonomySuggestions } };
+    rerender(
+      <Wrapper>
+        <TaxonomyReviewPanel batch={sameContentNewObject} prefix="acme:" onClose={() => {}} />
+      </Wrapper>
+    );
+
+    expect(screen.getAllByTestId('taxonomy-tag-card')).toHaveLength(1); // the delete survived
+  });
+
+  it('re-seeds and drops in-progress edits when tag content genuinely changes (e.g. a completed re-analyze)', () => {
+    const batch = readyBatch();
+    const { rerender } = render(
+      <Wrapper>
+        <TaxonomyReviewPanel batch={batch} prefix="acme:" onClose={() => {}} />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getAllByTestId('taxonomy-tag-delete')[0]);
+    expect(screen.getAllByTestId('taxonomy-tag-card')).toHaveLength(1);
+
+    const reanalyzed = {
+      ...batch,
+      taxonomySuggestions: {
+        tags: [
+          {
+            suffix: 'type:invoice',
+            originalName: 'acme:type:invoice',
+            strength: 0.92,
+            source: 'ai',
+            matchingFolders: ['finance'],
+            deleted: false,
+          },
+        ],
+        fileAssignments: [],
+      },
+    };
+    rerender(
+      <Wrapper>
+        <TaxonomyReviewPanel batch={reanalyzed} prefix="acme:" onClose={() => {}} />
+      </Wrapper>
+    );
+
+    expect(screen.getAllByTestId('taxonomy-tag-card')).toHaveLength(1);
+    expect(screen.getByText(/type:invoice/)).toBeInTheDocument(); // the freshly re-analyzed tag, not the pre-edit deleted one
+  });
 });

--- a/apps/client/app/components/DataLakeWizard/TaxonomyReviewPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/TaxonomyReviewPanel.tsx
@@ -138,17 +138,23 @@ const TagCard = memo(function TagCard({ tag, prefix, onUpdate, onDelete }: TagCa
             autoFocus
             sx={{ flex: 1, fontFamily: 'monospace' }}
           />
+          {/* A disabled Joy button emits no pointer events, so the tooltip needs the span - but
+              that also means Tooltip's usual aria-label clone lands on the span, not the button
+              (which has no text content), so it needs an explicit one too. */}
           <Tooltip title="Save" size="sm">
-            <IconButton
-              size="sm"
-              variant="soft"
-              color="success"
-              disabled={!canSave}
-              data-testid="taxonomy-tag-save"
-              onClick={handleSave}
-            >
-              <CheckIcon sx={{ fontSize: 14 }} />
-            </IconButton>
+            <span>
+              <IconButton
+                size="sm"
+                variant="soft"
+                color="success"
+                disabled={!canSave}
+                data-testid="taxonomy-tag-save"
+                aria-label="Save"
+                onClick={handleSave}
+              >
+                <CheckIcon sx={{ fontSize: 14 }} />
+              </IconButton>
+            </span>
           </Tooltip>
           <Tooltip title="Cancel" size="sm">
             <IconButton size="sm" variant="soft" color="neutral" onClick={handleCancel}>
@@ -242,7 +248,7 @@ export default function TaxonomyReviewPanel({
   // identity: the batches-list response is rebuilt via a Map + array spread on every poll, so
   // when any other batch leaves the list, every later element shifts index - React Query's
   // default structural sharing compares arrays positionally, so a batch that merely moved
-  // position (its own suggestions unc  hanged) gets a brand-new object reference, which would
+  // position (its own suggestions unchanged) gets a brand-new object reference, which would
   // wipe this panel's in-progress edits with no warning.
   const suggestionsKey = JSON.stringify(batch.taxonomySuggestions?.tags ?? []);
   useEffect(() => {

--- a/apps/client/app/components/DataLakeWizard/TaxonomyReviewPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/TaxonomyReviewPanel.tsx
@@ -250,6 +250,13 @@ export default function TaxonomyReviewPanel({
   // default structural sharing compares arrays positionally, so a batch that merely moved
   // position (its own suggestions unchanged) gets a brand-new object reference, which would
   // wipe this panel's in-progress edits with no warning.
+  //
+  // Stringifies the WHOLE tag (including strength/matchingFolders, which the panel never lets
+  // the user edit), not just suffix/originalName - deliberately broad, not narrowed to what's
+  // editable, because analyzeBatchTaxonomy.ts is the only writer of taxonomySuggestions content
+  // and it always replaces the entire tag set in one shot; there is no partial-re-score writer
+  // today that would change strength alone. If one is ever added, narrow this key to just the
+  // fields the panel actually edits (originalName + suffix) so a re-score doesn't wipe edits.
   const suggestionsKey = JSON.stringify(batch.taxonomySuggestions?.tags ?? []);
   useEffect(() => {
     setTags(batch.taxonomySuggestions?.tags ?? []);

--- a/apps/client/app/components/DataLakeWizard/TaxonomyReviewPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/TaxonomyReviewPanel.tsx
@@ -11,6 +11,7 @@ import {
   Modal,
   ModalDialog,
   Stack,
+  Tooltip,
   Typography,
 } from '@mui/joy';
 import { useTheme } from '@mui/joy/styles';
@@ -137,19 +138,23 @@ const TagCard = memo(function TagCard({ tag, prefix, onUpdate, onDelete }: TagCa
             autoFocus
             sx={{ flex: 1, fontFamily: 'monospace' }}
           />
-          <IconButton
-            size="sm"
-            variant="soft"
-            color="success"
-            disabled={!canSave}
-            data-testid="taxonomy-tag-save"
-            onClick={handleSave}
-          >
-            <CheckIcon sx={{ fontSize: 14 }} />
-          </IconButton>
-          <IconButton size="sm" variant="soft" color="neutral" onClick={handleCancel}>
-            <CloseIcon sx={{ fontSize: 14 }} />
-          </IconButton>
+          <Tooltip title="Save" size="sm">
+            <IconButton
+              size="sm"
+              variant="soft"
+              color="success"
+              disabled={!canSave}
+              data-testid="taxonomy-tag-save"
+              onClick={handleSave}
+            >
+              <CheckIcon sx={{ fontSize: 14 }} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Cancel" size="sm">
+            <IconButton size="sm" variant="soft" color="neutral" onClick={handleCancel}>
+              <CloseIcon sx={{ fontSize: 14 }} />
+            </IconButton>
+          </Tooltip>
         </Stack>
       ) : (
         <Typography
@@ -180,24 +185,28 @@ const TagCard = memo(function TagCard({ tag, prefix, onUpdate, onDelete }: TagCa
       {/* Actions */}
       {!isEditing && (
         <Stack direction="row" gap={0}>
-          <IconButton
-            size="sm"
-            variant="plain"
-            color="neutral"
-            data-testid="taxonomy-tag-edit"
-            onClick={() => setIsEditing(true)}
-          >
-            <EditIcon sx={{ fontSize: 14 }} />
-          </IconButton>
-          <IconButton
-            size="sm"
-            variant="plain"
-            color="danger"
-            data-testid="taxonomy-tag-delete"
-            onClick={() => onDelete(tag.originalName)}
-          >
-            <DeleteOutlineIcon sx={{ fontSize: 14 }} />
-          </IconButton>
+          <Tooltip title="Edit" size="sm">
+            <IconButton
+              size="sm"
+              variant="plain"
+              color="neutral"
+              data-testid="taxonomy-tag-edit"
+              onClick={() => setIsEditing(true)}
+            >
+              <EditIcon sx={{ fontSize: 14 }} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Delete" size="sm">
+            <IconButton
+              size="sm"
+              variant="plain"
+              color="danger"
+              data-testid="taxonomy-tag-delete"
+              onClick={() => onDelete(tag.originalName)}
+            >
+              <DeleteOutlineIcon sx={{ fontSize: 14 }} />
+            </IconButton>
+          </Tooltip>
         </Stack>
       )}
     </Box>
@@ -228,11 +237,17 @@ export default function TaxonomyReviewPanel({
   const dismissMutation = useDismissTaxonomy(batch.id);
   const confirm = useConfirmation();
 
-  // Re-seed local edits whenever the batch's stored suggestions change identity (e.g. after
-  // a re-analyze completes and the list refetches with a fresh taxonomySuggestions object).
+  // Re-seed local edits when the stored suggestions actually CHANGE, e.g. after a re-analyze
+  // completes. Deliberately keyed on tag CONTENT, not batch.taxonomySuggestions's object
+  // identity: the batches-list response is rebuilt via a Map + array spread on every poll, so
+  // when any other batch leaves the list, every later element shifts index - React Query's
+  // default structural sharing compares arrays positionally, so a batch that merely moved
+  // position (its own suggestions unc  hanged) gets a brand-new object reference, which would
+  // wipe this panel's in-progress edits with no warning.
+  const suggestionsKey = JSON.stringify(batch.taxonomySuggestions?.tags ?? []);
   useEffect(() => {
     setTags(batch.taxonomySuggestions?.tags ?? []);
-  }, [batch.taxonomySuggestions]);
+  }, [suggestionsKey]);
 
   const updateTag = (originalName: string, updates: Partial<TaxonomyTag>) =>
     setTags(prev => prev.map(t => (t.originalName === originalName ? { ...t, ...updates } : t)));


### PR DESCRIPTION
## Description

Follow-up from #1268 (background AI-tag-suggestion reliability and correctness gaps) - items 12 and 16, both confirmed still accurate against current code before starting.

**Item 12**: `TaxonomyReviewPanel`'s re-seed effect re-populates local tag edits whenever `batch.taxonomySuggestions` changes object identity. The batches-list API (`GET /api/data-lakes/batches`) rebuilds its response via a `Map` + array spread on every poll - when any other batch leaves the list, every later element shifts index. React Query's default structural sharing compares arrays positionally, so a batch whose own suggestions are completely unchanged can still get handed a brand-new object reference just because it moved position. That silently reset the panel's in-progress edits (deletions, suffix renames) with no warning, mid-review.

**Item 16**: The icon-only Save/Cancel/Edit/Delete buttons in `TagCard` had no `aria-label`/`Tooltip`, unlike the identical icon-button pattern already used in the sibling `DataLakeManagerPanel.tsx` (Restore/Delete actions). WCAG 4.1.2 gap - a screen reader user gets no name for any of the four actions.

## Changes

- The re-seed `useEffect` is now keyed on `JSON.stringify(tags)` (tag content) instead of `batch.taxonomySuggestions`'s object identity, so it only re-seeds when the suggestions actually change (e.g. a completed re-analyze), not when they merely moved position in the polled list.
- Wrapped the four icon-only buttons (Save, Cancel, Edit, Delete) in Joy `Tooltip`, matching `DataLakeManagerPanel.tsx`'s existing Restore/Delete pattern - `Tooltip`'s `title` sets `aria-label` on the child by default, so this also fixes the accessible-name gap, not just the visual hint.
- The Save button is conditionally `disabled` (empty suffix), and a disabled Joy button emits no pointer events, so its tooltip never showed on hover - wrapped it in a `span`, matching the existing pattern in `DiscoveryStatusCard.tsx`. That alone would have regressed the accessible name, though: `Tooltip` clones its `aria-label` onto its immediate child, which becomes the `span` (no text content of its own) instead of the button once wrapped. Added an explicit `aria-label="Save"` on the button itself so the name doesn't depend on `Tooltip` reaching through the wrapper - caught by rerunning the accessible-name test after adding the `span`, which failed until this was added.

## Guide for Testers

**Item 16 (accessible names) - easy to check by hand:**

1. Go to **Sidebar -> Data Lakes**, open a lake with a "Review AI tags" chip (or trigger one - see item 12's setup below).
2. In the review panel, hover over the pencil (Edit) and trash (Delete) icons on any tag row. Expected: a tooltip reading "Edit" / "Delete" appears.

   <img width="786" height="244" alt="image" src="https://github.com/user-attachments/assets/700241fe-1024-46ff-b719-a8724946ba39" />

   <img width="786" height="244" alt="image" src="https://github.com/user-attachments/assets/a79d1c44-a1e4-4171-b46c-2d1a32c0353d" />

3. Click the pencil to enter edit mode, then hover the checkmark (Save) and X (Cancel) icons. Expected: tooltips reading "Save" / "Cancel".

   <img width="786" height="244" alt="image" src="https://github.com/user-attachments/assets/643db53f-4491-4b37-a118-61020b7ce439" />

   <img width="786" height="244" alt="image" src="https://github.com/user-attachments/assets/ef45715b-b564-4595-98b5-c02360dfa301" />

4. With a screen reader on (or the browser's Accessibility inspector), tab to each of the four icon buttons. Expected: each announces its name ("Edit", "Delete", "Save", "Cancel") - not silence or a raw icon description.

**Item 12 (edits surviving a list reshuffle) - needs a second browser tab, since the review panel is a modal and won't let you open a second one in the same tab:**

The panel doesn't need to be the thing that changes - it just needs some *other* batch to leave the merged list while it's open. `DataLakeManagerPanel` (which owns the 10s poll) stays mounted behind the modal, so a change made from a second tab is picked up by the first tab's next poll without you ever closing the panel.

1. Create two lakes with **Suggest tags with AI** checked, so you end up with two batches both showing "Review AI tags" chips at the same time.
2. In **Tab 1**, open the first lake's review panel and delete one suggested tag. Leave the panel open.
3. In **Tab 2** (same account, e.g. a second window), go to **Sidebar -> Data Lakes** and dismiss or apply the *second* lake's chip.
4. Switch back to Tab 1 and wait for the next poll (up to ~10s - no need to click anything). Expected: the tag you deleted in step 2 is still gone, not un-deleted.

This is still a bit fiddly to time by hand, so the real coverage is a pair of automated tests: one rerenders the panel with a same-content-but-new-object-reference `taxonomySuggestions` (simulating exactly the list-position-shift from step 3-4) and asserts a local deletion survives; a sibling test rerenders with genuinely different suggestions (e.g. from a completed re-analyze) and asserts the panel correctly re-seeds and drops the stale edit. I confirmed both are load-bearing by reverting just the component fix and watching the first test fail (2 cards instead of 1) before restoring it.

### What NOT to test

No visible layout change - `Tooltip` only adds a hover/focus label, no new UI chrome. No behavior change to Apply/Dismiss/Re-analyze.

## Additional Information

Verified: `pnpm --filter client typecheck` clean, `pnpm --filter client exec vitest run TaxonomyReviewPanel` green (11 passed - 7 existing + 4 new, no new tests needed for the Save-tooltip follow-up since the existing accessible-name test already covers it). `pnpm lint:check` clean for this file.

Does not close # 1268 - only items 12 and 16 are addressed here; the remaining items are separate follow-up PRs.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
