### PR TITLE
fix(client): stop Share modal By Users tab from silently no-oping

### DIFF
--- a/apps/client/app/components/common/ShareModal.test.tsx
+++ b/apps/client/app/components/common/ShareModal.test.tsx
@@ -144,6 +144,33 @@ describe('ShareModal - By Users tab', () => {
     expect(mocks.mutateAsync).not.toHaveBeenCalled();
   });
 
+  it('blocks a case-varied self-share too, matching the server side case-insensitive resolution', async () => {
+    // Regression guard: the server now resolves recipients case-insensitively, so a
+    // differently-cased self-share must still be caught client-side or it would silently
+    // create a real self-invite instead of erroring. Pressing Enter would route this through
+    // the onChange filter instead (also fixed, but then the array is empty by submit time and
+    // "Recipients is required" fires first) - the backstop path is what this test targets.
+    const user = await openByUsersTab();
+    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    await user.type(input, 'Me@Test.com');
+    await user.click(screen.getByTestId('share-modal-submit-button'));
+
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith('You cannot share files to yourself'));
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('the onChange filter also strips a case-varied self-share chip before submit', async () => {
+    // Exercises the OTHER guard (the Autocomplete onChange filter, not the submit backstop):
+    // committing a case-varied self-share with Enter must still end up with nothing to submit.
+    const user = await openByUsersTab();
+    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    await user.type(input, 'Me@Test.com{Enter}');
+    await user.click(screen.getByTestId('share-modal-submit-button'));
+
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith('Recipients is required'));
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
+  });
+
   it('shows exactly one error toast, with the server message, when the share request fails', async () => {
     rejectWith({ isAxiosError: true, response: { data: { message: 'File no longer exists' } } });
     const user = await openByUsersTab();

--- a/apps/client/app/components/common/ShareModal.test.tsx
+++ b/apps/client/app/components/common/ShareModal.test.tsx
@@ -4,8 +4,10 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
-import { InviteType } from '@bike4mind/common';
+import { InviteType, IFabFileDocument } from '@bike4mind/common';
 import ShareDocumentModal from './ShareModal';
+
+const RECIPIENT_INPUT_PLACEHOLDER = 'Enter email or username - press Enter to add multiple recipients';
 
 // ShareModal pulls in several data/context hooks. Stub them so the modal renders
 // in isolation. useShareDocument's options are captured so a test can simulate
@@ -49,10 +51,14 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => (
   <CssVarsProvider theme={appTheme}>{children}</CssVarsProvider>
 );
 
-const renderModal = () =>
+const renderModal = (files?: IFabFileDocument[]) =>
   render(
     <TestWrapper>
-      <ShareDocumentModal id="notebook-1" name="My Notebook" type={InviteType.Session} open onClose={vi.fn()} />
+      {files ? (
+        <ShareDocumentModal files={files} type={InviteType.FabFile} open onClose={vi.fn()} />
+      ) : (
+        <ShareDocumentModal id="notebook-1" name="My Notebook" type={InviteType.Session} open onClose={vi.fn()} />
+      )}
     </TestWrapper>
   );
 
@@ -70,8 +76,8 @@ beforeEach(() => {
   mocks.currentUser = { id: 'u1', email: 'me@test.com', username: 'me' };
 });
 
-const openByUsersTab = async () => {
-  renderModal();
+const openByUsersTab = async (files?: IFabFileDocument[]) => {
+  renderModal(files);
   const user = userEvent.setup();
   await user.click(screen.getByText('By Users'));
   return user;
@@ -93,7 +99,7 @@ describe('ShareModal - By Link tab', () => {
 describe('ShareModal - By Users tab', () => {
   it('fires the share request when a recipient is committed with Enter', async () => {
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
     await user.type(input, 'friend@test.com{Enter}');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -104,7 +110,7 @@ describe('ShareModal - By Users tab', () => {
 
   it('fires the share request from the typed value alone, without pressing Enter', async () => {
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
     await user.type(input, 'friend@test.com');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -116,7 +122,7 @@ describe('ShareModal - By Users tab', () => {
   it('still fires the share request when currentUser has not loaded yet (regression guard)', async () => {
     mocks.currentUser = null;
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
     await user.type(input, 'friend@test.com{Enter}');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -127,7 +133,7 @@ describe('ShareModal - By Users tab', () => {
 
   it('blocks self-sharing and surfaces one error, without ever calling the API', async () => {
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
     // Deliberately not pressing Enter: the Autocomplete's onChange filter already strips a
     // self-share chip on commit, so this exercises the submit-time backstop check instead
     // (the currentInputValue merge at handleShareSubmit), which is what surfaces this message.
@@ -141,7 +147,7 @@ describe('ShareModal - By Users tab', () => {
   it('shows exactly one error toast, with the server message, when the share request fails', async () => {
     rejectWith({ isAxiosError: true, response: { data: { message: 'File no longer exists' } } });
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
     await user.type(input, 'friend@test.com{Enter}');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -160,19 +166,11 @@ describe('ShareModal - By Users tab', () => {
         throw error;
       });
 
-    render(
-      <TestWrapper>
-        <ShareDocumentModal
-          files={[{ id: 'file-1', fileName: 'a.pdf' } as never, { id: 'file-2', fileName: 'b.pdf' } as never]}
-          type={InviteType.FabFile}
-          open
-          onClose={vi.fn()}
-        />
-      </TestWrapper>
-    );
-    const user = userEvent.setup();
-    await user.click(screen.getByText('By Users'));
-    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    const user = await openByUsersTab([
+      { id: 'file-1', fileName: 'a.pdf' } as IFabFileDocument,
+      { id: 'file-2', fileName: 'b.pdf' } as IFabFileDocument,
+    ]);
+    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
     await user.type(input, 'friend@test.com{Enter}');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 

--- a/apps/client/app/components/common/ShareModal.test.tsx
+++ b/apps/client/app/components/common/ShareModal.test.tsx
@@ -7,8 +7,6 @@ import { getThemeConfig } from '@client/app/utils/themes';
 import { InviteType, IFabFileDocument } from '@bike4mind/common';
 import ShareDocumentModal from './ShareModal';
 
-const RECIPIENT_INPUT_PLACEHOLDER = 'Enter email or username - press Enter to add multiple recipients';
-
 // ShareModal pulls in several data/context hooks. Stub them so the modal renders
 // in isolation. useShareDocument's options are captured so a test can simulate
 // react-query's real onError-then-reject sequence on shareDocument.mutateAsync.
@@ -99,7 +97,7 @@ describe('ShareModal - By Link tab', () => {
 describe('ShareModal - By Users tab', () => {
   it('fires the share request when a recipient is committed with Enter', async () => {
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    const input = screen.getByTestId('share-modal-recipients-input');
     await user.type(input, 'friend@test.com{Enter}');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -110,7 +108,7 @@ describe('ShareModal - By Users tab', () => {
 
   it('fires the share request from the typed value alone, without pressing Enter', async () => {
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    const input = screen.getByTestId('share-modal-recipients-input');
     await user.type(input, 'friend@test.com');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -122,7 +120,7 @@ describe('ShareModal - By Users tab', () => {
   it('still fires the share request when currentUser has not loaded yet (regression guard)', async () => {
     mocks.currentUser = null;
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    const input = screen.getByTestId('share-modal-recipients-input');
     await user.type(input, 'friend@test.com{Enter}');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -133,7 +131,7 @@ describe('ShareModal - By Users tab', () => {
 
   it('blocks self-sharing and surfaces one error, without ever calling the API', async () => {
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    const input = screen.getByTestId('share-modal-recipients-input');
     // Deliberately not pressing Enter: the Autocomplete's onChange filter already strips a
     // self-share chip on commit, so this exercises the submit-time backstop check instead
     // (the currentInputValue merge at handleShareSubmit), which is what surfaces this message.
@@ -151,7 +149,7 @@ describe('ShareModal - By Users tab', () => {
     // the onChange filter instead (also fixed, but then the array is empty by submit time and
     // "Recipients is required" fires first) - the backstop path is what this test targets.
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    const input = screen.getByTestId('share-modal-recipients-input');
     await user.type(input, 'Me@Test.com');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -163,7 +161,7 @@ describe('ShareModal - By Users tab', () => {
     // Exercises the OTHER guard (the Autocomplete onChange filter, not the submit backstop):
     // committing a case-varied self-share with Enter must still end up with nothing to submit.
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    const input = screen.getByTestId('share-modal-recipients-input');
     await user.type(input, 'Me@Test.com{Enter}');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -174,7 +172,7 @@ describe('ShareModal - By Users tab', () => {
   it('shows exactly one error toast, with the server message, when the share request fails', async () => {
     rejectWith({ isAxiosError: true, response: { data: { message: 'File no longer exists' } } });
     const user = await openByUsersTab();
-    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    const input = screen.getByTestId('share-modal-recipients-input');
     await user.type(input, 'friend@test.com{Enter}');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 
@@ -197,7 +195,7 @@ describe('ShareModal - By Users tab', () => {
       { id: 'file-1', fileName: 'a.pdf' } as IFabFileDocument,
       { id: 'file-2', fileName: 'b.pdf' } as IFabFileDocument,
     ]);
-    const input = screen.getByPlaceholderText(RECIPIENT_INPUT_PLACEHOLDER);
+    const input = screen.getByTestId('share-modal-recipients-input');
     await user.type(input, 'friend@test.com{Enter}');
     await user.click(screen.getByTestId('share-modal-submit-button'));
 

--- a/apps/client/app/components/common/ShareModal.test.tsx
+++ b/apps/client/app/components/common/ShareModal.test.tsx
@@ -11,7 +11,7 @@ import ShareDocumentModal from './ShareModal';
 // in isolation. useShareDocument's options are captured so a test can simulate
 // react-query's real onError-then-reject sequence on shareDocument.mutateAsync.
 const mocks = vi.hoisted(() => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
   mutateAsync: vi.fn(),
   shareDocumentOptions: null as { onError?: (error: unknown) => void } | null,
   currentUser: { id: 'u1', email: 'me@test.com', username: 'me' } as {
@@ -147,5 +147,39 @@ describe('ShareModal - By Users tab', () => {
 
     await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith('File no longer exists'));
     expect(mocks.toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('aggregates a bulk share failure into one toast instead of a per-item duplicate', async () => {
+    // First file shares fine; the second's mutateAsync fails (e.g. an unresolved recipient),
+    // exercising the same onError path as the single-item case but through the bulk loop.
+    mocks.mutateAsync
+      .mockImplementationOnce(async () => ({}))
+      .mockImplementationOnce(async () => {
+        const error = { isAxiosError: true, response: { data: { message: 'Could not find a user for: x' } } };
+        mocks.shareDocumentOptions?.onError?.(error);
+        throw error;
+      });
+
+    render(
+      <TestWrapper>
+        <ShareDocumentModal
+          files={[{ id: 'file-1', fileName: 'a.pdf' } as never, { id: 'file-2', fileName: 'b.pdf' } as never]}
+          type={InviteType.FabFile}
+          open
+          onClose={vi.fn()}
+        />
+      </TestWrapper>
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByText('By Users'));
+    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    await user.type(input, 'friend@test.com{Enter}');
+    await user.click(screen.getByTestId('share-modal-submit-button'));
+
+    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(2));
+    // showBulkFeedback's own aggregate toast (a partial success -> toast.warning) is the only
+    // one that should fire; the per-item onError toast must stay suppressed for bulk shares.
+    expect(mocks.toast.warning).toHaveBeenCalledTimes(1);
+    expect(mocks.toast.error).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/components/common/ShareModal.test.tsx
+++ b/apps/client/app/components/common/ShareModal.test.tsx
@@ -117,6 +117,20 @@ describe('ShareModal - By Users tab', () => {
     );
   });
 
+  it('reports the server-resolved recipient count in the success toast, not the raw typed count', async () => {
+    // Two typed recipients (an email and that same person's username) resolve server-side
+    // to one unique person - the toast must say "1 recipient", not "2 recipients".
+    mocks.mutateAsync.mockResolvedValue({ recipients: { pending: ['friend@test.com'] } });
+    const user = await openByUsersTab();
+    const input = screen.getByTestId('share-modal-recipients-input');
+    await user.type(input, 'friend@test.com{Enter}friend{Enter}');
+    await user.click(screen.getByTestId('share-modal-submit-button'));
+
+    await waitFor(() =>
+      expect(mocks.toast.success).toHaveBeenCalledWith('Successfully shared My Notebook to 1 recipient')
+    );
+  });
+
   it('still fires the share request when currentUser has not loaded yet (regression guard)', async () => {
     mocks.currentUser = null;
     const user = await openByUsersTab();

--- a/apps/client/app/components/common/ShareModal.test.tsx
+++ b/apps/client/app/components/common/ShareModal.test.tsx
@@ -1,15 +1,31 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
 import { InviteType } from '@bike4mind/common';
 import ShareDocumentModal from './ShareModal';
 
 // ShareModal pulls in several data/context hooks. Stub them so the modal renders
-// in isolation; the regression we guard is purely about the "By Link" tab UI.
+// in isolation. useShareDocument's options are captured so a test can simulate
+// react-query's real onError-then-reject sequence on shareDocument.mutateAsync.
+const mocks = vi.hoisted(() => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+  mutateAsync: vi.fn(),
+  shareDocumentOptions: null as { onError?: (error: unknown) => void } | null,
+  currentUser: { id: 'u1', email: 'me@test.com', username: 'me' } as {
+    id: string;
+    email: string;
+    username: string;
+  } | null,
+}));
+
 vi.mock('@client/app/hooks/data/invites', () => ({
-  useShareDocument: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+  useShareDocument: (options: { onError?: (error: unknown) => void }) => {
+    mocks.shareDocumentOptions = options;
+    return { mutate: vi.fn(), mutateAsync: mocks.mutateAsync, data: undefined };
+  },
 }));
 vi.mock('@client/app/hooks/data/user', () => ({
   useUserRevokeSharing: () => ({ mutate: vi.fn() }),
@@ -21,11 +37,12 @@ vi.mock('@client/app/hooks/useConfirmation', () => ({
   useConfirmation: () => vi.fn(),
 }));
 vi.mock('@client/app/contexts/UserContext', () => ({
-  useUser: () => ({ currentUser: { id: 'u1', email: 'me@test.com', username: 'me' } }),
+  useUser: () => ({ currentUser: mocks.currentUser }),
 }));
 vi.mock('@client/app/contexts/ApiContext', () => ({
   api: {},
 }));
+vi.mock('sonner', () => ({ toast: mocks.toast }));
 
 const appTheme = extendTheme({ ...getThemeConfig() });
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
@@ -39,7 +56,28 @@ const renderModal = () =>
     </TestWrapper>
   );
 
-describe('ShareModal — By Link tab', () => {
+// react-query's mutateAsync always rejects on failure even when onError is provided;
+// this mirrors that so tests exercise the same sequence the real hook produces.
+const rejectWith = (error: unknown) =>
+  mocks.mutateAsync.mockImplementation(async () => {
+    mocks.shareDocumentOptions?.onError?.(error);
+    throw error;
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.mutateAsync.mockResolvedValue({});
+  mocks.currentUser = { id: 'u1', email: 'me@test.com', username: 'me' };
+});
+
+const openByUsersTab = async () => {
+  renderModal();
+  const user = userEvent.setup();
+  await user.click(screen.getByText('By Users'));
+  return user;
+};
+
+describe('ShareModal - By Link tab', () => {
   it('marks the Description field as optional', () => {
     renderModal();
     // The "By Link" tab is the default (tabIndex 1), so the Description field is visible.
@@ -49,5 +87,65 @@ describe('ShareModal — By Link tab', () => {
   it('enables the Generate button with an empty Description (description is not required)', () => {
     renderModal();
     expect(screen.getByTestId('share-modal-submit-button')).not.toBeDisabled();
+  });
+});
+
+describe('ShareModal - By Users tab', () => {
+  it('fires the share request when a recipient is committed with Enter', async () => {
+    const user = await openByUsersTab();
+    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    await user.type(input, 'friend@test.com{Enter}');
+    await user.click(screen.getByTestId('share-modal-submit-button'));
+
+    await waitFor(() =>
+      expect(mocks.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ recipients: ['friend@test.com'] }))
+    );
+  });
+
+  it('fires the share request from the typed value alone, without pressing Enter', async () => {
+    const user = await openByUsersTab();
+    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    await user.type(input, 'friend@test.com');
+    await user.click(screen.getByTestId('share-modal-submit-button'));
+
+    await waitFor(() =>
+      expect(mocks.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ recipients: ['friend@test.com'] }))
+    );
+  });
+
+  it('still fires the share request when currentUser has not loaded yet (regression guard)', async () => {
+    mocks.currentUser = null;
+    const user = await openByUsersTab();
+    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    await user.type(input, 'friend@test.com{Enter}');
+    await user.click(screen.getByTestId('share-modal-submit-button'));
+
+    await waitFor(() =>
+      expect(mocks.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({ recipients: ['friend@test.com'] }))
+    );
+  });
+
+  it('blocks self-sharing and surfaces one error, without ever calling the API', async () => {
+    const user = await openByUsersTab();
+    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    // Deliberately not pressing Enter: the Autocomplete's onChange filter already strips a
+    // self-share chip on commit, so this exercises the submit-time backstop check instead
+    // (the currentInputValue merge at handleShareSubmit), which is what surfaces this message.
+    await user.type(input, 'me@test.com');
+    await user.click(screen.getByTestId('share-modal-submit-button'));
+
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith('You cannot share files to yourself'));
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('shows exactly one error toast, with the server message, when the share request fails', async () => {
+    rejectWith({ isAxiosError: true, response: { data: { message: 'File no longer exists' } } });
+    const user = await openByUsersTab();
+    const input = screen.getByPlaceholderText('Enter email or username - press Enter to add multiple recipients');
+    await user.type(input, 'friend@test.com{Enter}');
+    await user.click(screen.getByTestId('share-modal-submit-button'));
+
+    await waitFor(() => expect(mocks.toast.error).toHaveBeenCalledWith('File no longer exists'));
+    expect(mocks.toast.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/client/app/components/common/ShareModal.tsx
+++ b/apps/client/app/components/common/ShareModal.tsx
@@ -38,9 +38,9 @@ import UsernameText from './UsernameText';
 import { FormEvent, useEffect, useState } from 'react';
 import { cloneDeep } from 'lodash';
 import { toast } from 'sonner';
-import { isAxiosError } from 'axios';
 import { brandAlpha } from '../../utils/themes/colors';
 import { api } from '@client/app/contexts/ApiContext';
+import { getErrorMessage } from '@client/app/utils/error';
 
 // Helper to show bulk operation feedback with success/partial/failure states
 const showBulkFeedback = (
@@ -128,8 +128,7 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
       // Bulk sharing aggregates its own per-item failures into one showBulkFeedback toast
       // below; showing this hook's toast too would double up per failed item.
       if (isBulkSharing) return;
-      const serverMessage = isAxiosError(error) ? error.response?.data?.message : undefined;
-      toast.error(serverMessage || 'Failed to share document');
+      toast.error(getErrorMessage(error));
     },
     onSettled: () => {
       if (!isBulkSharing) {
@@ -158,8 +157,9 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
       }
 
       if (recipientValue.length === 0) {
-        setRecipients({ ...recipients, error: 'Recipients is required' });
-        toast.error('Recipients is required');
+        const message = 'Recipients is required';
+        setRecipients({ ...recipients, error: message });
+        toast.error(message);
         isInvalid = true;
       } else if (
         tabIndex === 0 &&
@@ -171,8 +171,9 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
         )
       ) {
         // Prevent self-sharing and show error message (only for "By Users" tab)
-        setRecipients({ ...recipients, error: 'You cannot share files to yourself' });
-        toast.error('You cannot share files to yourself');
+        const message = 'You cannot share files to yourself';
+        setRecipients({ ...recipients, error: message });
+        toast.error(message);
         isInvalid = true;
       } else {
         setRecipients({ ...recipients, error: null });

--- a/apps/client/app/components/common/ShareModal.tsx
+++ b/apps/client/app/components/common/ShareModal.tsx
@@ -363,7 +363,7 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
           return;
         }
 
-        await shareDocument.mutateAsync({
+        const result = await shareDocument.mutateAsync({
           description,
           recipients: recipientValue,
           id: id,
@@ -372,10 +372,10 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
         });
 
         if (tabIndex === 0) {
-          // Sharing by users
-          toast.success(
-            `Successfully shared ${displayName} to ${recipientValue.length} recipient${recipientValue.length > 1 ? 's' : ''}`
-          );
+          // Sharing by users. Report the server-resolved, deduped recipient count (e.g. an
+          // email and that same person's username collapse to one), not the raw typed count.
+          const sharedCount = result?.recipients?.pending?.length ?? recipientValue.length;
+          toast.success(`Successfully shared ${displayName} to ${sharedCount} recipient${sharedCount > 1 ? 's' : ''}`);
 
           // Clear input and close modal after showing toast
           setCurrentInputValue('');

--- a/apps/client/app/components/common/ShareModal.tsx
+++ b/apps/client/app/components/common/ShareModal.tsx
@@ -565,6 +565,9 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
                             alignItems: 'flex-start',
                           },
                         },
+                        input: {
+                          'data-testid': 'share-modal-recipients-input',
+                        },
                       }}
                       sx={{ width: '100%', '--Input-minHeight': '100px' }}
                       value={recipients.value}

--- a/apps/client/app/components/common/ShareModal.tsx
+++ b/apps/client/app/components/common/ShareModal.tsx
@@ -66,6 +66,23 @@ const showBulkFeedback = (
   }
 };
 
+// The server now resolves recipients case-insensitively (UserModel.findAllByEmailsOrUsernames),
+// so a case-varied self-share (e.g. "Me@Test.com") must be caught here too, or it silently
+// creates a real self-invite instead of erroring. Shared by both the Autocomplete's onChange
+// filter and the submit-time backstop check below so they cannot drift out of sync again.
+const isSelfShareRecipient = (
+  recipient: string,
+  currentUser: { id: string; email?: string | null; username?: string | null } | null
+): boolean => {
+  if (!currentUser) return false;
+  const lower = recipient.toLowerCase();
+  return (
+    lower === currentUser.email?.toLowerCase() ||
+    lower === currentUser.username?.toLowerCase() ||
+    lower === currentUser.id.toLowerCase()
+  );
+};
+
 interface IProps {
   // Single item props
   id?: string;
@@ -161,15 +178,7 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
         setRecipients({ ...recipients, error: message });
         toast.error(message);
         isInvalid = true;
-      } else if (
-        tabIndex === 0 &&
-        currentUser &&
-        recipientValue.some(
-          recipient =>
-            // Check if user is trying to share to themselves via email, username, or ID
-            recipient === currentUser.email || recipient === currentUser.username || recipient === currentUser.id
-        )
-      ) {
+      } else if (tabIndex === 0 && recipientValue.some(recipient => isSelfShareRecipient(recipient, currentUser))) {
         // Prevent self-sharing and show error message (only for "By Users" tab)
         const message = 'You cannot share files to yourself';
         setRecipients({ ...recipients, error: message });
@@ -560,13 +569,13 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
                       sx={{ width: '100%', '--Input-minHeight': '100px' }}
                       value={recipients.value}
                       onChange={(_, value) => {
-                        // Filter out current user's email/username (only for "By Users" tab)
+                        // Filter out current user's email/username/id (only for "By Users" tab).
+                        // isSelfShareRecipient itself treats a not-yet-loaded currentUser as
+                        // "nothing to compare against" (returns false), so this never drops
+                        // every recipient just because currentUser hasn't loaded yet.
                         if (tabIndex === 0) {
-                          // A not-yet-loaded currentUser (e.g. mid rehydrate) must never drop
-                          // every recipient -- only filter once we can actually name the user.
                           const filteredValue = value.filter(
-                            recipient =>
-                              !currentUser || (recipient !== currentUser.email && recipient !== currentUser.username)
+                            recipient => !isSelfShareRecipient(recipient, currentUser)
                           );
                           if (filteredValue.length !== value.length) {
                             setRecipients({ value: filteredValue, error: 'You cannot share files to yourself' });

--- a/apps/client/app/components/common/ShareModal.tsx
+++ b/apps/client/app/components/common/ShareModal.tsx
@@ -38,6 +38,7 @@ import UsernameText from './UsernameText';
 import { FormEvent, useEffect, useState } from 'react';
 import { cloneDeep } from 'lodash';
 import { toast } from 'sonner';
+import { isAxiosError } from 'axios';
 import { brandAlpha } from '../../utils/themes/colors';
 import { api } from '@client/app/contexts/ApiContext';
 
@@ -123,6 +124,13 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
       // Don't close the modal here; handleShareSubmit closes it after the toast is visible.
       // Bulk completion is handled in the loop; link generation in the useEffect below.
     },
+    onError: error => {
+      // Bulk sharing aggregates its own per-item failures into one showBulkFeedback toast
+      // below; showing this hook's toast too would double up per failed item.
+      if (isBulkSharing) return;
+      const serverMessage = isAxiosError(error) ? error.response?.data?.message : undefined;
+      toast.error(serverMessage || 'Failed to share document');
+    },
     onSettled: () => {
       if (!isBulkSharing) {
         setLoading(false);
@@ -151,6 +159,7 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
 
       if (recipientValue.length === 0) {
         setRecipients({ ...recipients, error: 'Recipients is required' });
+        toast.error('Recipients is required');
         isInvalid = true;
       } else if (
         tabIndex === 0 &&
@@ -163,6 +172,7 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
       ) {
         // Prevent self-sharing and show error message (only for "By Users" tab)
         setRecipients({ ...recipients, error: 'You cannot share files to yourself' });
+        toast.error('You cannot share files to yourself');
         isInvalid = true;
       } else {
         setRecipients({ ...recipients, error: null });
@@ -368,11 +378,10 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
         }
       }
     } catch (error) {
-      // This catch handles single-item sharing failures only
-      // Bulk sharing errors are handled within the loops above
+      // Single-item failures are toasted by useShareDocument's onError above; bulk failures
+      // are aggregated within the loops above. Just log here to avoid a duplicate toast.
       if (!isBulkSharing) {
         console.error('Error in sharing:', error);
-        toast.error('Failed to share file');
       }
     } finally {
       if (isBulkSharing) {
@@ -552,9 +561,11 @@ const ShareDocumentModal = ({ id, onClose, type, open, name, users, files, sessi
                       onChange={(_, value) => {
                         // Filter out current user's email/username (only for "By Users" tab)
                         if (tabIndex === 0) {
+                          // A not-yet-loaded currentUser (e.g. mid rehydrate) must never drop
+                          // every recipient -- only filter once we can actually name the user.
                           const filteredValue = value.filter(
                             recipient =>
-                              currentUser && recipient !== currentUser.email && recipient !== currentUser.username
+                              !currentUser || (recipient !== currentUser.email && recipient !== currentUser.username)
                           );
                           if (filteredValue.length !== value.length) {
                             setRecipients({ value: filteredValue, error: 'You cannot share files to yourself' });

--- a/apps/client/pages/api/projects/[id]/files.ts
+++ b/apps/client/pages/api/projects/[id]/files.ts
@@ -1,4 +1,10 @@
-import { withTransaction, projectRepository, fabFileRepository, userRepository } from '@bike4mind/database';
+import {
+  withTransaction,
+  projectRepository,
+  fabFileRepository,
+  userRepository,
+  inviteRepository,
+} from '@bike4mind/database';
 import { projectService } from '@bike4mind/services';
 import { asyncHandler } from '@server/middlewares/asyncHandler';
 import { baseApi } from '@server/middlewares/baseApi';
@@ -87,6 +93,7 @@ const handler = baseApi()
               fabFiles: fabFileRepository,
               projects: projectRepository,
               users: userRepository,
+              invites: inviteRepository,
             },
           }
         )

--- a/b4m-core/services/src/projectService/removeFiles.test.ts
+++ b/b4m-core/services/src/projectService/removeFiles.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InviteType, IUserDocument } from '@bike4mind/common';
+import { removeFiles } from './removeFiles';
+
+/**
+ * IUserShare tracks a single projectId, so a user who is both a project member AND holds a
+ * separately-accepted direct invite for the same file could not otherwise be told apart from
+ * one whose only access came from the project - a bot review on #1151 found that the
+ * pushShareable merge fix there makes this reachable via either accept ordering, where before
+ * it depended on which grant happened first. These tests pin the fix: keep (with projectId
+ * cleared) an entry backed by an accepted direct invite; drop a project-only entry entirely.
+ */
+describe('projectService - removeFiles (project-derived access revocation)', () => {
+  const OWNER_ID = 'owner-1';
+  const PROJECT_ID = 'project-1';
+  const FILE_ID = 'file-1';
+
+  const asUser = (id: string) => ({ id, username: 'u', isAdmin: false }) as IUserDocument;
+
+  let db: any;
+  let project: any;
+  let file: any;
+
+  beforeEach(() => {
+    project = { id: PROJECT_ID, userId: OWNER_ID, fileIds: [FILE_ID], users: [] };
+    file = { id: FILE_ID, userId: OWNER_ID, users: [] };
+
+    db = {
+      users: {
+        findById: vi.fn(async (id: string) => asUser(id)),
+      },
+      projects: {
+        shareable: { findAccessibleById: vi.fn(async () => project) },
+        update: vi.fn(async () => project),
+      },
+      fabFiles: {
+        shareable: { findAllAccessibleByIds: vi.fn(async () => [file]) },
+        update: vi.fn(async () => file),
+      },
+      invites: {
+        findAllByDocumentId: vi.fn(async () => []),
+      },
+    };
+  });
+
+  const call = () => removeFiles(OWNER_ID, { projectId: PROJECT_ID, fileIds: [FILE_ID] }, { db });
+
+  it('drops a user whose only access to the file came from this project', async () => {
+    file.users = [{ userId: 'member-1', permissions: ['read'], projectId: PROJECT_ID }];
+
+    await call();
+
+    expect(file.users).toEqual([]);
+    expect(db.invites.findAllByDocumentId).toHaveBeenCalledWith(FILE_ID);
+  });
+
+  it('keeps a project member who also holds an accepted direct invite, clearing only projectId', async () => {
+    file.users = [{ userId: 'member-1', permissions: ['read', 'share'], projectId: PROJECT_ID }];
+    db.users.findById = vi.fn(async () => ({ ...asUser('member-1'), email: 'member@x.com' }));
+    db.invites.findAllByDocumentId = vi.fn(async () => [
+      { type: InviteType.FabFile, recipients: { pending: [], accepted: ['member@x.com'], refused: [] } },
+    ]);
+
+    await call();
+
+    expect(file.users).toEqual([{ userId: 'member-1', permissions: ['read', 'share'], projectId: undefined }]);
+  });
+
+  it('leaves an entry unrelated to this project untouched', async () => {
+    file.users = [{ userId: 'other-project-member', permissions: ['read'], projectId: 'a-different-project' }];
+
+    await call();
+
+    expect(file.users).toEqual([
+      { userId: 'other-project-member', permissions: ['read'], projectId: 'a-different-project' },
+    ]);
+  });
+
+  it('skips the invite lookup entirely when no entry is project-derived (common case)', async () => {
+    file.users = [{ userId: 'other-project-member', permissions: ['read'], projectId: 'a-different-project' }];
+
+    await call();
+
+    expect(db.invites.findAllByDocumentId).not.toHaveBeenCalled();
+    // findById is still called once for the caller (OWNER_ID); it must not ALSO be
+    // called to resolve the unrelated file.users entry's email.
+    expect(db.users.findById).toHaveBeenCalledTimes(1);
+    expect(db.users.findById).toHaveBeenCalledWith(OWNER_ID);
+  });
+
+  it('only counts an accepted invite of type FabFile, not an unrelated invite for the same document id', async () => {
+    file.users = [{ userId: 'member-1', permissions: ['read'], projectId: PROJECT_ID }];
+    db.users.findById = vi.fn(async () => ({ ...asUser('member-1'), email: 'member@x.com' }));
+    // Same documentId, but a Session-type invite - must not be mistaken for a FabFile share.
+    db.invites.findAllByDocumentId = vi.fn(async () => [
+      { type: InviteType.Session, recipients: { pending: [], accepted: ['member@x.com'], refused: [] } },
+    ]);
+
+    await call();
+
+    expect(file.users).toEqual([]);
+  });
+});

--- a/b4m-core/services/src/projectService/removeFiles.test.ts
+++ b/b4m-core/services/src/projectService/removeFiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { InviteType, IUserDocument } from '@bike4mind/common';
+import { InviteType, IUserDocument, Permission } from '@bike4mind/common';
 import { removeFiles } from './removeFiles';
 
 /**
@@ -7,15 +7,20 @@ import { removeFiles } from './removeFiles';
  * separately-accepted direct invite for the same file could not otherwise be told apart from
  * one whose only access came from the project - a bot review on #1151 found that the
  * pushShareable merge fix there makes this reachable via either accept ordering, where before
- * it depended on which grant happened first. These tests pin the fix: keep (with projectId
- * cleared) an entry backed by an accepted direct invite; drop a project-only entry entirely.
+ * it depended on which grant happened first. A human reviewer then found the first pass of this
+ * fix kept the FULL merged permission set (project-derived permissions included) rather than
+ * resetting to what the independent direct invite itself grants, and that the per-entry
+ * `users.findById` inside this loop is unmemoized inside the route's transaction. These tests
+ * pin all three: drop a project-only entry entirely; for one with an accepted direct invite,
+ * clear projectId AND reset permissions to just the direct invite's own grant; resolve grantee
+ * emails via one batched `findByIds` call, not one per entry.
  */
 describe('projectService - removeFiles (project-derived access revocation)', () => {
   const OWNER_ID = 'owner-1';
   const PROJECT_ID = 'project-1';
   const FILE_ID = 'file-1';
 
-  const asUser = (id: string) => ({ id, username: 'u', isAdmin: false }) as IUserDocument;
+  const asUser = (id: string, email?: string) => ({ id, username: 'u', isAdmin: false, email }) as IUserDocument;
 
   let db: any;
   let project: any;
@@ -28,6 +33,7 @@ describe('projectService - removeFiles (project-derived access revocation)', () 
     db = {
       users: {
         findById: vi.fn(async (id: string) => asUser(id)),
+        findByIds: vi.fn(async (ids: string[]) => ids.map(id => asUser(id))),
       },
       projects: {
         shareable: { findAccessibleById: vi.fn(async () => project) },
@@ -46,7 +52,7 @@ describe('projectService - removeFiles (project-derived access revocation)', () 
   const call = () => removeFiles(OWNER_ID, { projectId: PROJECT_ID, fileIds: [FILE_ID] }, { db });
 
   it('drops a user whose only access to the file came from this project', async () => {
-    file.users = [{ userId: 'member-1', permissions: ['read'], projectId: PROJECT_ID }];
+    file.users = [{ userId: 'member-1', permissions: [Permission.read], projectId: PROJECT_ID }];
 
     await call();
 
@@ -54,50 +60,106 @@ describe('projectService - removeFiles (project-derived access revocation)', () 
     expect(db.invites.findAllByDocumentId).toHaveBeenCalledWith(FILE_ID);
   });
 
-  it('keeps a project member who also holds an accepted direct invite, clearing only projectId', async () => {
-    file.users = [{ userId: 'member-1', permissions: ['read', 'share'], projectId: PROJECT_ID }];
-    db.users.findById = vi.fn(async () => ({ ...asUser('member-1'), email: 'member@x.com' }));
+  it('keeps a project member with an accepted direct invite, resetting to the direct grant only', async () => {
+    // Project granted [read, update, share] (via pushShareable's union); the direct invite
+    // only ever granted [read, share] - the update permission must NOT survive the revoke.
+    file.users = [
+      {
+        userId: 'member-1',
+        permissions: [Permission.read, Permission.update, Permission.share],
+        projectId: PROJECT_ID,
+      },
+    ];
+    db.users.findByIds = vi.fn(async () => [asUser('member-1', 'member@x.com')]);
     db.invites.findAllByDocumentId = vi.fn(async () => [
-      { type: InviteType.FabFile, recipients: { pending: [], accepted: ['member@x.com'], refused: [] } },
+      {
+        type: InviteType.FabFile,
+        permissions: [Permission.read, Permission.share],
+        recipients: { pending: [], accepted: ['member@x.com'], refused: [] },
+      },
     ]);
-
-    await call();
-
-    expect(file.users).toEqual([{ userId: 'member-1', permissions: ['read', 'share'], projectId: undefined }]);
-  });
-
-  it('leaves an entry unrelated to this project untouched', async () => {
-    file.users = [{ userId: 'other-project-member', permissions: ['read'], projectId: 'a-different-project' }];
 
     await call();
 
     expect(file.users).toEqual([
-      { userId: 'other-project-member', permissions: ['read'], projectId: 'a-different-project' },
+      { userId: 'member-1', permissions: [Permission.read, Permission.share], projectId: undefined },
     ]);
   });
 
-  it('skips the invite lookup entirely when no entry is project-derived (common case)', async () => {
-    file.users = [{ userId: 'other-project-member', permissions: ['read'], projectId: 'a-different-project' }];
+  it('unions permissions across more than one accepted direct invite for the same recipient', async () => {
+    file.users = [{ userId: 'member-1', permissions: [Permission.read], projectId: PROJECT_ID }];
+    db.users.findByIds = vi.fn(async () => [asUser('member-1', 'member@x.com')]);
+    db.invites.findAllByDocumentId = vi.fn(async () => [
+      {
+        type: InviteType.FabFile,
+        permissions: [Permission.read],
+        recipients: { pending: [], accepted: ['member@x.com'], refused: [] },
+      },
+      {
+        type: InviteType.FabFile,
+        permissions: [Permission.share],
+        recipients: { pending: [], accepted: ['member@x.com'], refused: [] },
+      },
+    ]);
+
+    await call();
+
+    expect(file.users[0].permissions).toEqual(expect.arrayContaining([Permission.read, Permission.share]));
+    expect(file.users[0].permissions).toHaveLength(2);
+  });
+
+  it('leaves an entry unrelated to this project untouched', async () => {
+    file.users = [{ userId: 'other-project-member', permissions: [Permission.read], projectId: 'a-different-project' }];
+
+    await call();
+
+    expect(file.users).toEqual([
+      { userId: 'other-project-member', permissions: [Permission.read], projectId: 'a-different-project' },
+    ]);
+  });
+
+  it('skips the invite lookup and the batched user lookup when no entry is project-derived (common case)', async () => {
+    file.users = [{ userId: 'other-project-member', permissions: [Permission.read], projectId: 'a-different-project' }];
 
     await call();
 
     expect(db.invites.findAllByDocumentId).not.toHaveBeenCalled();
-    // findById is still called once for the caller (OWNER_ID); it must not ALSO be
-    // called to resolve the unrelated file.users entry's email.
-    expect(db.users.findById).toHaveBeenCalledTimes(1);
-    expect(db.users.findById).toHaveBeenCalledWith(OWNER_ID);
+    expect(db.users.findByIds).not.toHaveBeenCalled();
   });
 
   it('only counts an accepted invite of type FabFile, not an unrelated invite for the same document id', async () => {
-    file.users = [{ userId: 'member-1', permissions: ['read'], projectId: PROJECT_ID }];
-    db.users.findById = vi.fn(async () => ({ ...asUser('member-1'), email: 'member@x.com' }));
+    file.users = [{ userId: 'member-1', permissions: [Permission.read], projectId: PROJECT_ID }];
+    db.users.findByIds = vi.fn(async () => [asUser('member-1', 'member@x.com')]);
     // Same documentId, but a Session-type invite - must not be mistaken for a FabFile share.
     db.invites.findAllByDocumentId = vi.fn(async () => [
-      { type: InviteType.Session, recipients: { pending: [], accepted: ['member@x.com'], refused: [] } },
+      {
+        type: InviteType.Session,
+        permissions: [Permission.read],
+        recipients: { pending: [], accepted: ['member@x.com'], refused: [] },
+      },
     ]);
 
     await call();
 
     expect(file.users).toEqual([]);
+  });
+
+  it('resolves grantee emails with one batched findByIds call, not one findById per project-member entry', async () => {
+    file.users = [
+      { userId: 'member-1', permissions: [Permission.read], projectId: PROJECT_ID },
+      { userId: 'member-2', permissions: [Permission.read], projectId: PROJECT_ID },
+    ];
+    db.invites.findAllByDocumentId = vi.fn(async () => [
+      {
+        type: InviteType.FabFile,
+        permissions: [Permission.read],
+        recipients: { pending: [], accepted: [], refused: [] },
+      },
+    ]);
+
+    await call();
+
+    expect(db.users.findByIds).toHaveBeenCalledTimes(1);
+    expect(db.users.findByIds).toHaveBeenCalledWith(expect.arrayContaining(['member-1', 'member-2']));
   });
 });

--- a/b4m-core/services/src/projectService/removeFiles.ts
+++ b/b4m-core/services/src/projectService/removeFiles.ts
@@ -56,13 +56,18 @@ export const removeFiles = async (
   // access came from the project, and would lose the direct share too.
   for (const file of files) {
     const projectMemberEntries = file.users.filter(u => u.projectId === project.id);
-    const directlySharedEmails = projectMemberEntries.length
-      ? new Set(
-          (await db.invites.findAllByDocumentId(file.id))
-            .filter(invite => invite.type === InviteType.FabFile)
-            .flatMap(invite => invite.recipients?.accepted ?? [])
-        )
-      : new Set<string>();
+    const directInvites = projectMemberEntries.length
+      ? (await db.invites.findAllByDocumentId(file.id)).filter(invite => invite.type === InviteType.FabFile)
+      : [];
+
+    // Batched, not one findById per entry: this loop runs inside the route's transaction, so
+    // an unmemoized per-entry lookup would hold it open for one round trip per project member.
+    const granteeEmailsById = new Map<string, string>();
+    if (directInvites.length) {
+      for (const grantee of await db.users.findByIds(projectMemberEntries.map(u => u.userId))) {
+        if (grantee.email) granteeEmailsById.set(grantee.id, grantee.email);
+      }
+    }
 
     const nextUsers: typeof file.users = [];
     for (const entry of file.users) {
@@ -70,9 +75,22 @@ export const removeFiles = async (
         nextUsers.push(entry);
         continue;
       }
-      const grantee = directlySharedEmails.size ? await db.users.findById(entry.userId) : null;
-      if (grantee?.email && directlySharedEmails.has(grantee.email)) {
-        nextUsers.push({ ...entry, projectId: undefined });
+      const email = granteeEmailsById.get(entry.userId);
+      const directGrantPermissions = email
+        ? Array.from(
+            new Set(
+              directInvites
+                .filter(invite => invite.recipients?.accepted?.includes(email))
+                .flatMap(invite => ('permissions' in invite ? invite.permissions : []))
+            )
+          )
+        : [];
+      if (directGrantPermissions.length) {
+        // Keep only what the independent direct invite itself grants, not the full
+        // permission union pushShareable may have merged in from the project side -
+        // otherwise a permission that came SOLELY from project membership (e.g. update,
+        // when the direct invite only ever granted read+share) would outlive this revoke.
+        nextUsers.push({ ...entry, projectId: undefined, permissions: directGrantPermissions });
       }
       // else: access came solely from this project - drop the entry entirely.
     }

--- a/b4m-core/services/src/projectService/removeFiles.ts
+++ b/b4m-core/services/src/projectService/removeFiles.ts
@@ -1,4 +1,10 @@
-import { IFabFileRepository, IProjectRepository, IUserRepository } from '@bike4mind/common';
+import {
+  IFabFileRepository,
+  InviteType,
+  IInviteRepository,
+  IProjectRepository,
+  IUserRepository,
+} from '@bike4mind/common';
 import { secureParameters } from '@bike4mind/utils';
 import { z } from 'zod';
 
@@ -14,6 +20,7 @@ interface RemoveProjectFilesAdapters {
     projects: IProjectRepository;
     fabFiles: IFabFileRepository;
     users: IUserRepository;
+    invites: Pick<IInviteRepository, 'findAllByDocumentId'>;
   };
 }
 
@@ -42,9 +49,34 @@ export const removeFiles = async (
   project.fileIds = project.fileIds.filter(id => !fileIds.includes(id));
   project.updatedAt = new Date();
 
-  // Revoke all project users access to the file
+  // Revoke project-derived access to the file, but keep an entry that ALSO has an
+  // independently-accepted direct invite to the same file (only clearing its projectId) -
+  // IUserShare tracks one projectId, so a user who both is a project member and separately
+  // accepted a direct share for this file cannot otherwise be told apart from one whose only
+  // access came from the project, and would lose the direct share too.
   for (const file of files) {
-    file.users = file.users.filter(u => u.projectId !== project.id);
+    const projectMemberEntries = file.users.filter(u => u.projectId === project.id);
+    const directlySharedEmails = projectMemberEntries.length
+      ? new Set(
+          (await db.invites.findAllByDocumentId(file.id))
+            .filter(invite => invite.type === InviteType.FabFile)
+            .flatMap(invite => invite.recipients?.accepted ?? [])
+        )
+      : new Set<string>();
+
+    const nextUsers: typeof file.users = [];
+    for (const entry of file.users) {
+      if (entry.projectId !== project.id) {
+        nextUsers.push(entry);
+        continue;
+      }
+      const grantee = directlySharedEmails.size ? await db.users.findById(entry.userId) : null;
+      if (grantee?.email && directlySharedEmails.has(grantee.email)) {
+        nextUsers.push({ ...entry, projectId: undefined });
+      }
+      // else: access came solely from this project - drop the entry entirely.
+    }
+    file.users = nextUsers;
     await db.fabFiles.update(file);
   }
 

--- a/b4m-core/services/src/sharingService/accept.test.ts
+++ b/b4m-core/services/src/sharingService/accept.test.ts
@@ -296,3 +296,73 @@ describe('sharingService - acceptInvite (Group)', () => {
     expect(mockAdapters.db.users.update).toHaveBeenCalledWith(expect.objectContaining({ groups: [groupId] }));
   });
 });
+
+/**
+ * `remaining` on a By-Users FabFile invite now scales to the number of named recipients
+ * (#1151), not a flat 1 - a human reviewer caught that acceptInvite never checked the
+ * accepter was actually one of the recipients named in `pending`, so an unintended
+ * accepter could claim a slot meant for someone else while a named recipient still
+ * hadn't accepted. Link-only invites (empty `pending` from creation) must stay open to
+ * anyone; a fully-consumed named invite is already blocked by the `remaining <= 0` check
+ * regardless of identity, so this only needs to gate the "still has named recipients left" case.
+ */
+describe('sharingService - acceptInvite (FabFile recipient membership)', () => {
+  const userId = 'user-1';
+  const fileId = 'file-1';
+  const inviteId = 'invite-1';
+
+  const makeUser = (email: string) => ({ id: userId, email, username: 'u' });
+
+  const makeInvite = (pending: string[], remaining: number) => ({
+    id: inviteId,
+    type: InviteType.FabFile,
+    documentId: fileId,
+    permissions: [Permission.read, Permission.share],
+    remaining,
+    accepted: 0,
+    recipients: { pending, refused: [], accepted: [] },
+  });
+
+  const makeAdapters = () => ({
+    db: {
+      invites: { findById: vi.fn(), update: vi.fn() },
+      fabFiles: { findById: vi.fn(async () => ({ id: fileId, users: [] })), update: vi.fn() },
+      sessions: { findById: vi.fn(), update: vi.fn() },
+      projects: { findById: vi.fn(), update: vi.fn() },
+      groups: { findById: vi.fn() },
+      organization: { findById: vi.fn(), update: vi.fn(), ensureUserDetails: vi.fn() },
+      users: { findById: vi.fn(), update: vi.fn() },
+    },
+  });
+
+  it('rejects an accepter who is not among the still-pending named recipients', async () => {
+    const adapters = makeAdapters();
+    adapters.db.users.findById.mockResolvedValue(makeUser('uninvited@x.com'));
+    adapters.db.invites.findById.mockResolvedValue(makeInvite(['a@x.com', 'b@x.com'], 2));
+
+    await expect(acceptInvite(userId, { id: inviteId }, adapters as any)).rejects.toThrow(ForbiddenError);
+    expect(adapters.db.invites.update).not.toHaveBeenCalled();
+    expect(adapters.db.fabFiles.update).not.toHaveBeenCalled();
+  });
+
+  it('allows an accepter who is one of the named pending recipients', async () => {
+    const adapters = makeAdapters();
+    adapters.db.users.findById.mockResolvedValue(makeUser('a@x.com'));
+    adapters.db.invites.findById.mockResolvedValue(makeInvite(['a@x.com', 'b@x.com'], 2));
+
+    await acceptInvite(userId, { id: inviteId }, adapters as any);
+
+    expect(adapters.db.invites.update).toHaveBeenCalled();
+    expect(adapters.db.fabFiles.update).toHaveBeenCalled();
+  });
+
+  it('allows anyone to accept a link-only invite (pending was never populated)', async () => {
+    const adapters = makeAdapters();
+    adapters.db.users.findById.mockResolvedValue(makeUser('anyone@x.com'));
+    adapters.db.invites.findById.mockResolvedValue(makeInvite([], 1000));
+
+    await acceptInvite(userId, { id: inviteId }, adapters as any);
+
+    expect(adapters.db.invites.update).toHaveBeenCalled();
+  });
+});

--- a/b4m-core/services/src/sharingService/accept.test.ts
+++ b/b4m-core/services/src/sharingService/accept.test.ts
@@ -365,4 +365,19 @@ describe('sharingService - acceptInvite (FabFile recipient membership)', () => {
 
     expect(adapters.db.invites.update).toHaveBeenCalled();
   });
+
+  it('reports "already accepted" for a re-accept, not "not sent to your account", when other recipients are still pending', async () => {
+    const adapters = makeAdapters();
+    adapters.db.users.findById.mockResolvedValue(makeUser('a@x.com'));
+    // a@x.com already accepted and moved out of pending; b@x.com is still pending.
+    adapters.db.invites.findById.mockResolvedValue({
+      ...makeInvite(['b@x.com'], 1),
+      recipients: { pending: ['b@x.com'], refused: [], accepted: ['a@x.com'] },
+    });
+
+    await expect(acceptInvite(userId, { id: inviteId }, adapters as any)).rejects.toThrow(
+      'User has already accepted the invite'
+    );
+    expect(adapters.db.invites.update).not.toHaveBeenCalled();
+  });
 });

--- a/b4m-core/services/src/sharingService/accept.ts
+++ b/b4m-core/services/src/sharingService/accept.ts
@@ -273,6 +273,16 @@ export const pushShareable = (
   if (userIndex === -1) {
     entity.users.push({ userId: data.userId, permissions: data.permissions, projectId: data.projectId });
   } else {
-    entity.users[userIndex] = data;
+    // Merge, don't replace: every call site here is an additive invite-accept, so accepting a
+    // new invite must never silently drop the existing entry's projectId/extraData or narrow
+    // permissions it already carries (e.g. from a broader project-cascaded share) down to just
+    // what this invite grants.
+    const existing = entity.users[userIndex];
+    entity.users[userIndex] = {
+      ...existing,
+      userId: data.userId,
+      projectId: data.projectId ?? existing.projectId,
+      permissions: Array.from(new Set([...(existing.permissions ?? []), ...data.permissions])),
+    };
   }
 };

--- a/b4m-core/services/src/sharingService/accept.ts
+++ b/b4m-core/services/src/sharingService/accept.ts
@@ -273,10 +273,11 @@ export const pushShareable = (
   if (userIndex === -1) {
     entity.users.push({ userId: data.userId, permissions: data.permissions, projectId: data.projectId });
   } else {
-    // Merge, don't replace: every call site here is an additive invite-accept, so accepting a
-    // new invite must never silently drop the existing entry's projectId/extraData or narrow
-    // permissions it already carries (e.g. from a broader project-cascaded share) down to just
-    // what this invite grants.
+    // Merge, don't replace: pushShareable's callers are this file's own invite-accept arms plus
+    // projectService's addFiles/addSessions/addSystemPrompts (propagating a member's current
+    // project access onto a newly-added file/session) - every one of them grants or refreshes
+    // access, none narrows it, so an update here must never silently drop the existing entry's
+    // projectId/extraData or narrow permissions it already carries down to just this grant.
     const existing = entity.users[userIndex];
     entity.users[userIndex] = {
       ...existing,

--- a/b4m-core/services/src/sharingService/accept.ts
+++ b/b4m-core/services/src/sharingService/accept.ts
@@ -70,6 +70,16 @@ export const acceptInvite = async (userId: string, params: AcceptInviteParameter
     throw new UnprocessableEntityError('Invite has no remaining users');
   }
 
+  // A By-Users invite names specific recipients in `pending`; only they may consume a slot,
+  // or `remaining` (now sized to the recipient count, not a flat 1) lets an unintended
+  // accepter claim a share meant for someone else while a named recipient still hasn't
+  // accepted. A link-only invite never populates `pending`, so this never applies to one -
+  // and once every named recipient has accepted, `pending` is empty and `remaining <= 0`
+  // above already blocks further accepts regardless of who is asking.
+  if ((invite.recipients?.pending?.length ?? 0) > 0 && !invite.recipients?.pending?.includes(user.email)) {
+    throw new ForbiddenError('This invite was not sent to your account');
+  }
+
   if ((invite.recipients?.accepted || []).includes(user.email)) {
     throw new UnprocessableEntityError('User has already accepted the invite');
   }

--- a/b4m-core/services/src/sharingService/accept.ts
+++ b/b4m-core/services/src/sharingService/accept.ts
@@ -70,6 +70,14 @@ export const acceptInvite = async (userId: string, params: AcceptInviteParameter
     throw new UnprocessableEntityError('Invite has no remaining users');
   }
 
+  // Checked before the pending-membership gate below: a user who already accepted has moved
+  // out of `pending` into `accepted`, so on a multi-recipient invite where others are still
+  // pending, checking membership first would misreport a re-accept as "not sent to your
+  // account" instead of "already accepted".
+  if ((invite.recipients?.accepted || []).includes(user.email)) {
+    throw new UnprocessableEntityError('User has already accepted the invite');
+  }
+
   // A By-Users invite names specific recipients in `pending`; only they may consume a slot,
   // or `remaining` (now sized to the recipient count, not a flat 1) lets an unintended
   // accepter claim a share meant for someone else while a named recipient still hasn't
@@ -78,10 +86,6 @@ export const acceptInvite = async (userId: string, params: AcceptInviteParameter
   // above already blocks further accepts regardless of who is asking.
   if ((invite.recipients?.pending?.length ?? 0) > 0 && !invite.recipients?.pending?.includes(user.email)) {
     throw new ForbiddenError('This invite was not sent to your account');
-  }
-
-  if ((invite.recipients?.accepted || []).includes(user.email)) {
-    throw new UnprocessableEntityError('User has already accepted the invite');
   }
 
   if (invite.recipients) {

--- a/b4m-core/services/src/sharingService/create.test.ts
+++ b/b4m-core/services/src/sharingService/create.test.ts
@@ -167,3 +167,73 @@ describe('sharingService - createInvite (project arm authority)', () => {
     expect(db.invites.create).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * A recipient that findAllByEmailsOrUsernames does not resolve previously fell through
+ * silently: the invite was still created with an empty pending list and the route returned
+ * 200, so the recipient's inbox stayed empty with no visible failure anywhere (#1151). Scoped
+ * to FabFile/Session, since Organization/Project send raw user ids through this same
+ * recipients array via a different resolution path and must keep tolerating a 0-match result.
+ */
+describe('sharingService - createInvite (recipient resolution)', () => {
+  const FILE_ID = 'file-1';
+  const FILE_NAME = 'doc.pdf';
+  const PROJECT_ID = 'project-9';
+  const PROJECT_NAME = 'Some Project';
+
+  const asUser = (id: string) => ({ id, username: 'u', isAdmin: false }) as IUserDocument;
+
+  let db: any;
+
+  beforeEach(() => {
+    db = {
+      invites: { create: vi.fn(async (build: unknown) => ({ id: 'invite-3', ...(build as object) })) },
+      users: { findAllByEmailsOrUsernames: vi.fn(async () => []) },
+      fabFiles: { shareable: { findShareAccessById: vi.fn(async () => ({ id: FILE_ID, fileName: FILE_NAME })) } },
+      projects: { shareable: { findShareAccessById: vi.fn(async () => ({ id: PROJECT_ID, name: PROJECT_NAME })) } },
+    };
+  });
+
+  const createFabFile = (recipients: string[]) =>
+    createInvite(
+      asUser('owner-3'),
+      { id: FILE_ID, type: InviteType.FabFile, permissions: [Permission.read], recipients } as any,
+      { db }
+    );
+
+  const createProject = (recipients: string[]) =>
+    createInvite(
+      asUser('owner-4'),
+      { id: PROJECT_ID, type: InviteType.Project, permissions: [Permission.read], recipients } as any,
+      { db }
+    );
+
+  it('throws for an unresolved recipient on a FabFile (By Users) invite instead of silently creating a 0-recipient share', async () => {
+    db.users.findAllByEmailsOrUsernames = vi.fn(async () => [{ email: 'a@x.com', username: 'a' }]);
+
+    await expect(createFabFile(['a@x.com', 'nobody@x.com'])).rejects.toSatisfy(
+      (e: Error) => e instanceof BadRequestError && e.message.includes('nobody@x.com')
+    );
+    expect(db.invites.create).not.toHaveBeenCalled();
+  });
+
+  it('resolves a recipient against a matched user record with different casing', async () => {
+    db.users.findAllByEmailsOrUsernames = vi.fn(async () => [{ email: 'Friend@Example.com', username: 'friend' }]);
+
+    const invite = await createFabFile(['friend@example.com']);
+
+    expect(db.invites.create).toHaveBeenCalled();
+    expect((invite as any).recipients.pending).toEqual(['Friend@Example.com']);
+  });
+
+  it('does not throw on an Organization/Project invite with an unmatched, id-shaped recipient', async () => {
+    // No match, same as today, for an id-shaped recipient - the point is this must not become
+    // a hard failure just because milestone 2 added unresolved-recipient checking elsewhere.
+    db.users.findAllByEmailsOrUsernames = vi.fn(async () => []);
+
+    const invite = await createProject(['user-id-123']);
+
+    expect(db.invites.create).toHaveBeenCalled();
+    expect((invite as any).recipients.pending).toEqual([]);
+  });
+});

--- a/b4m-core/services/src/sharingService/create.test.ts
+++ b/b4m-core/services/src/sharingService/create.test.ts
@@ -236,4 +236,55 @@ describe('sharingService - createInvite (recipient resolution)', () => {
     expect(db.invites.create).toHaveBeenCalled();
     expect((invite as any).recipients.pending).toEqual([]);
   });
+
+  it('throws for a recipient matched only by username with no email, instead of silently dropping them', async () => {
+    // accept.ts keys recipients.pending/accepted on email and rejects an emailless accepter
+    // outright, so a username-only match is not actually shareable - it must fail loudly here,
+    // not vanish from pending while the sharer is told the share succeeded.
+    db.users.findAllByEmailsOrUsernames = vi.fn(async () => [{ email: null, username: 'noemail' }]);
+
+    await expect(createFabFile(['noemail'])).rejects.toSatisfy(
+      (e: Error) => e instanceof BadRequestError && e.message.includes('noemail')
+    );
+    expect(db.invites.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when one recipient string matches more than one distinct user (case-insensitive collision)', async () => {
+    // Uniqueness on the User schema is case-sensitive, so "Bob" and "bob" can be two real,
+    // distinct accounts. The now-case-insensitive lookup can return both for one input - that
+    // must fail as ambiguous, not silently grant access to whichever one happened to match.
+    db.users.findAllByEmailsOrUsernames = vi.fn(async () => [
+      { email: 'bob@x.com', username: 'Bob' },
+      { email: 'BOB@x.com', username: 'bob' },
+    ]);
+
+    await expect(createFabFile(['bob'])).rejects.toSatisfy(
+      (e: Error) => e instanceof BadRequestError && e.message.includes('bob')
+    );
+    expect(db.invites.create).not.toHaveBeenCalled();
+  });
+
+  it('sets remaining to the number of distinct resolved recipients, not a flat 1, for a multi-recipient share', async () => {
+    // Previously every By-Users invite defaulted to remaining:1 regardless of recipient count,
+    // so only the first of several recipients could ever accept while the sharer was told all
+    // of them succeeded (#1151 acceptance criteria 1).
+    db.users.findAllByEmailsOrUsernames = vi.fn(async () => [
+      { email: 'a@x.com', username: 'a' },
+      { email: 'b@x.com', username: 'b' },
+    ]);
+
+    const invite = await createFabFile(['a@x.com', 'b@x.com']);
+
+    expect((invite as any).remaining).toBe(2);
+    expect((invite as any).recipients.pending).toEqual(['a@x.com', 'b@x.com']);
+  });
+
+  it('dedupes when two recipient strings resolve to the same person, and remaining matches the unique count', async () => {
+    db.users.findAllByEmailsOrUsernames = vi.fn(async () => [{ email: 'a@x.com', username: 'a' }]);
+
+    const invite = await createFabFile(['a@x.com', 'a']);
+
+    expect((invite as any).remaining).toBe(1);
+    expect((invite as any).recipients.pending).toEqual(['a@x.com']);
+  });
 });

--- a/b4m-core/services/src/sharingService/create.ts
+++ b/b4m-core/services/src/sharingService/create.ts
@@ -123,8 +123,25 @@ export const createInvite = async (
 
   const recipientsArray = recipients ?? [];
   const users = await db.users.findAllByEmailsOrUsernames(recipientsArray, recipientsArray);
-  // we push emails on pending regardless if username was sought for
-  const pending = users.map(user => user.email as string);
+
+  // By-Users sharing (FabFile/Session) sends real emails/usernames and must not silently
+  // create a share nobody can see. Organization/Project/Group invites send raw user ids
+  // through this same recipients array via a different resolution path (inviteToOrg above,
+  // and organizationService/groupMembership for Group), so this check does not apply to them.
+  if ((type === InviteType.FabFile || type === InviteType.Session) && recipientsArray.length > 0) {
+    const matched = new Set(
+      users.flatMap(u => [u.email, u.username].filter((v): v is string => Boolean(v)).map(v => v.toLowerCase()))
+    );
+    const unresolved = recipientsArray.filter(r => !matched.has(r.toLowerCase()));
+    if (unresolved.length > 0) {
+      throw new BadRequestError(`Could not find a user for: ${unresolved.join(', ')}`);
+    }
+  }
+
+  // we push emails on pending regardless if username was sought for; a username-matched user
+  // with no email has nothing to push here (accept.ts already blocks an emailless user from
+  // accepting any invite, so this only avoids polluting pending with a literal undefined).
+  const pending = users.map(user => user.email).filter((email): email is string => Boolean(email));
   const isLinkOnlyInvite = recipients?.length === 0;
 
   const build: Omit<IInvite, 'id'> = {

--- a/b4m-core/services/src/sharingService/create.ts
+++ b/b4m-core/services/src/sharingService/create.ts
@@ -125,9 +125,11 @@ export const createInvite = async (
   const users = await db.users.findAllByEmailsOrUsernames(recipientsArray, recipientsArray);
 
   // By-Users sharing (FabFile/Session) sends real emails/usernames and must not silently
-  // create a share nobody can see. Organization/Project/Group invites send raw user ids
-  // through this same recipients array via a different resolution path (inviteToOrg above,
-  // and organizationService/groupMembership for Group), so this check does not apply to them.
+  // create a share nobody can see. Organization/Project invites send raw user ids through
+  // this same recipients array (Organization resolves them separately via inviteToOrg
+  // above); Group invites do not use recipients at all (membership authority is checked via
+  // assertCanManageOrgGroups above, and the join itself happens on accept - see accept.ts).
+  // None of that is this check's concern, so it stays scoped to FabFile/Session only.
   if ((type === InviteType.FabFile || type === InviteType.Session) && recipientsArray.length > 0) {
     const matched = new Set(
       users.flatMap(u => [u.email, u.username].filter((v): v is string => Boolean(v)).map(v => v.toLowerCase()))

--- a/b4m-core/services/src/sharingService/create.ts
+++ b/b4m-core/services/src/sharingService/create.ts
@@ -29,7 +29,9 @@ const createInviteSchema = z.object({
   recipients: z.string().array().optional(),
   description: z.string().optional(),
   expiresAt: z.date().optional().prefault(defaultExpiration()),
-  available: z.number().optional().prefault(DEFAULT_AVAILABLE),
+  // No prefault here: the default depends on recipients.length (below), which this schema
+  // cannot see. No caller currently sets this explicitly.
+  available: z.number().optional(),
 });
 
 type CreateInviteParameters = z.infer<typeof createInviteSchema>;
@@ -123,6 +125,7 @@ export const createInvite = async (
 
   const recipientsArray = recipients ?? [];
   const users = await db.users.findAllByEmailsOrUsernames(recipientsArray, recipientsArray);
+  const isLinkOnlyInvite = recipients?.length === 0;
 
   // By-Users sharing (FabFile/Session) sends real emails/usernames and must not silently
   // create a share nobody can see. Organization/Project invites send raw user ids through
@@ -130,27 +133,43 @@ export const createInvite = async (
   // above); Group invites do not use recipients at all (membership authority is checked via
   // assertCanManageOrgGroups above, and the join itself happens on accept - see accept.ts).
   // None of that is this check's concern, so it stays scoped to FabFile/Session only.
+  let pending: string[];
   if ((type === InviteType.FabFile || type === InviteType.Session) && recipientsArray.length > 0) {
-    const matched = new Set(
-      users.flatMap(u => [u.email, u.username].filter((v): v is string => Boolean(v)).map(v => v.toLowerCase()))
-    );
-    const unresolved = recipientsArray.filter(r => !matched.has(r.toLowerCase()));
-    if (unresolved.length > 0) {
-      throw new BadRequestError(`Could not find a user for: ${unresolved.join(', ')}`);
-    }
+    // Per-recipient, not a shared matched-set: (1) a username match with no email is not
+    // actually shareable (accept.ts's recipients.pending/accepted are keyed on email, and
+    // acceptInvite rejects an emailless accepter outright), so it must count as unresolved
+    // rather than silently vanishing from `pending`; (2) findAllByEmailsOrUsernames is now
+    // case-insensitive, and this schema's uniqueness is case-SENSITIVE (username_1, email_1),
+    // so two real accounts differing only by case can both match one input string - that must
+    // fail loudly, not silently grant access to whichever one happened to match.
+    const resolvable = users.filter((u): u is IUserDocument & { email: string } => Boolean(u.email));
+    const resolved = recipientsArray.map(recipient => {
+      const lower = recipient.toLowerCase();
+      const matches = resolvable.filter(u => u.email.toLowerCase() === lower || u.username.toLowerCase() === lower);
+      if (matches.length === 0) throw new BadRequestError(`Could not find a user for: ${recipient}`);
+      if (matches.length > 1) throw new BadRequestError(`More than one user matches: ${recipient}`);
+      return matches[0].email;
+    });
+    // Dedupe: two recipient strings (an email and that same person's username) can resolve to
+    // the same one user, and pending.length below counts unique resolved users, not raw entries.
+    pending = Array.from(new Set(resolved));
+  } else {
+    pending = users.map(user => user.email).filter((email): email is string => Boolean(email));
   }
 
-  // we push emails on pending regardless if username was sought for; a username-matched user
-  // with no email has nothing to push here (accept.ts already blocks an emailless user from
-  // accepting any invite, so this only avoids polluting pending with a literal undefined).
-  const pending = users.map(user => user.email).filter((email): email is string => Boolean(email));
-  const isLinkOnlyInvite = recipients?.length === 0;
+  // No caller sets `available` explicitly today. Defaulting it to a flat 1 regardless of
+  // recipient count meant a multi-recipient By-Users share minted one invite whose single
+  // accept slot only the first recipient could ever claim, while the sharer was told all of
+  // them succeeded - so the default has to track how many people this invite is actually for.
+  // pending.length (not recipientsArray.length): two recipient strings that resolve to the
+  // same person, or an org/project id that resolves to nobody, must not inflate the count.
+  const resolvedAvailable = available ?? (isLinkOnlyInvite ? 1000 : Math.max(pending.length, DEFAULT_AVAILABLE));
 
   const build: Omit<IInvite, 'id'> = {
     // We suggest that it's a FabFile so that permissions is a valid/required field
     type: type as InviteType,
     documentId: id,
-    remaining: isLinkOnlyInvite ? 1000 : available,
+    remaining: resolvedAvailable,
     ...rest,
     recipients: {
       pending,

--- a/b4m-core/services/src/sharingService/pushShareable.test.ts
+++ b/b4m-core/services/src/sharingService/pushShareable.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { IShareableDocument, Permission } from '@bike4mind/common';
+import { pushShareable } from './accept';
+
+const asEntity = (users: IShareableDocument['users'] = []): IShareableDocument =>
+  ({ id: 'doc-1', isGlobalRead: false, isGlobalWrite: false, users, groups: [] }) as unknown as IShareableDocument;
+
+describe('sharingService - pushShareable', () => {
+  it('adds a fresh entry with exactly the granted permissions', () => {
+    const entity = asEntity();
+
+    pushShareable(entity, { userId: 'user-1', permissions: [Permission.read, Permission.share] });
+
+    expect(entity.users).toEqual([
+      { userId: 'user-1', permissions: [Permission.read, Permission.share], projectId: undefined },
+    ]);
+  });
+
+  it('preserves an existing projectId when the new grant does not carry one', () => {
+    // A user with project-cascaded access (accept.ts's acceptProject arm) later accepts a
+    // direct FabFile/Session invite for the same document (accept.ts's `update` has no
+    // projectId) -- that must not silently disassociate them from the project.
+    const entity = asEntity([{ userId: 'user-1', permissions: [Permission.read], projectId: 'project-9' }]);
+
+    pushShareable(entity, { userId: 'user-1', permissions: [Permission.read, Permission.share] });
+
+    expect(entity.users[0].projectId).toBe('project-9');
+  });
+
+  it('unions permissions instead of narrowing them on a re-share', () => {
+    const entity = asEntity([
+      { userId: 'user-1', permissions: [Permission.read, Permission.update, Permission.share] },
+    ]);
+
+    // A plain By-Users invite only ever grants [read, share] -- accepting it must not strip
+    // the update permission this user already held from a broader grant.
+    pushShareable(entity, { userId: 'user-1', permissions: [Permission.read, Permission.share] });
+
+    expect(new Set(entity.users[0].permissions)).toEqual(
+      new Set([Permission.read, Permission.update, Permission.share])
+    );
+  });
+
+  it('carries a new projectId forward when one is provided', () => {
+    const entity = asEntity([{ userId: 'user-1', permissions: [Permission.read] }]);
+
+    pushShareable(entity, { userId: 'user-1', permissions: [Permission.read], projectId: 'project-42' });
+
+    expect(entity.users[0].projectId).toBe('project-42');
+  });
+});

--- a/packages/database/src/models/auth/UserModel.findAllByEmailsOrUsernames.test.ts
+++ b/packages/database/src/models/auth/UserModel.findAllByEmailsOrUsernames.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { User, userRepository } from './UserModel';
+import { setupMongoTest } from '../../__test__/utils';
+
+setupMongoTest();
+
+beforeEach(async () => {
+  await User.syncIndexes();
+});
+
+/**
+ * findAllByEmailsOrUsernames backs sharing-invite recipient resolution (#1151): a caller-typed
+ * case variant of a real user's stored email/username must still resolve, matching the
+ * case-insensitive behavior findByUsernameOrEmail already has.
+ */
+describe('UserModel.findAllByEmailsOrUsernames', () => {
+  it('matches a stored email case-insensitively', async () => {
+    await User.create({ username: 'alice', name: 'Alice', email: 'Alice@Example.com' });
+
+    const found = await userRepository.findAllByEmailsOrUsernames(['alice@example.com'], []);
+    expect(found.map(u => u.email)).toEqual(['Alice@Example.com']);
+  });
+
+  it('matches a stored username case-insensitively', async () => {
+    await User.create({ username: 'Bob', name: 'Bob', email: 'bob@example.com' });
+
+    const found = await userRepository.findAllByEmailsOrUsernames([], ['bob']);
+    expect(found.map(u => u.username)).toEqual(['Bob']);
+  });
+
+  it('returns no match for a recipient nobody has', async () => {
+    await User.create({ username: 'charlie', name: 'Charlie', email: 'charlie@example.com' });
+
+    const found = await userRepository.findAllByEmailsOrUsernames(['nobody@example.com'], ['nobody']);
+    expect(found).toEqual([]);
+  });
+});

--- a/packages/database/src/models/auth/UserModel.ts
+++ b/packages/database/src/models/auth/UserModel.ts
@@ -893,6 +893,12 @@ UserSchema.index(
   }
 );
 
+// Case-insensitive username index for collation-based lookups (findAllByEmailsOrUsernames).
+// Same reasoning as email_ci above: the case-sensitive username_1 index above won't be used
+// by a .collation() query, and without a matching collated index that $in falls back to a
+// full collection scan.
+UserSchema.index({ username: 1 }, { collation: { locale: 'en', strength: 2 }, name: 'username_ci' });
+
 // resetPasswordToken index intentionally removed - password reset flow replaced by OTC email auth
 // Non-unique multikey index for the two-stage OAuth lookup (stage-1 matches by provider identity).
 // NOT unique: legacy rows carry id:null; a unique multikey would collide every (strategy, null).

--- a/packages/database/src/models/auth/UserModel.ts
+++ b/packages/database/src/models/auth/UserModel.ts
@@ -288,9 +288,13 @@ export class UserRepository extends BaseRepository<IUserDocument> implements IUs
   }
 
   async findAllByEmailsOrUsernames(emails: string[], usernames: string[]) {
-    const result = await this.model.find({
-      $or: [{ email: { $in: emails } }, { username: { $in: usernames } }],
-    });
+    // Case-insensitive to match findByUsernameOrEmail below -- email/username are stored
+    // verbatim (no lowercase transform), so a caller-typed case variant must still resolve.
+    const result = await this.model
+      .find({
+        $or: [{ email: { $in: emails } }, { username: { $in: usernames } }],
+      })
+      .collation({ locale: 'en', strength: 2 });
     return result.map(d => d.toJSON());
   }
 

--- a/packages/database/src/models/auth/UserModel.ts
+++ b/packages/database/src/models/auth/UserModel.ts
@@ -290,6 +290,10 @@ export class UserRepository extends BaseRepository<IUserDocument> implements IUs
   async findAllByEmailsOrUsernames(emails: string[], usernames: string[]) {
     // Case-insensitive to match findByUsernameOrEmail below -- email/username are stored
     // verbatim (no lowercase transform), so a caller-typed case variant must still resolve.
+    // Caveat for callers: uniqueness on this schema is case-SENSITIVE (username_1, email_1),
+    // so two distinct real accounts differing only by case can both match one input string.
+    // A caller that grants access based on a result here (sharingService/create.ts is the one
+    // that does) must treat more than one match per input as ambiguous, not pick one silently.
     const result = await this.model
       .find({
         $or: [{ email: { $in: emails } }, { username: { $in: usernames } }],


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1440" height="900" alt="Share modal By Users tab showing the success toast after sharing a file" src="https://github.com/user-attachments/assets/b1c5c9de-a98e-43e8-acd9-32e5a1aca051" />
*Captured on the PR preview: sharing a file via the By Users tab now fires the request and shows "Successfully shared ... to 1 recipient" instead of silently doing nothing.*

## Description

The Share modal's By Users tab silently did nothing when Share was clicked: no request fired, no error shown, and the recipient never got access. Root cause: the self-share filter treated a not-yet-loaded `currentUser` as "block every recipient" instead of "nothing to compare yet." That's a real rehydration race, not a UI glitch.

Tracing the fix through to the actual grant surfaced three more silent-failure paths: a multi-recipient share only let the first person ever accept (the invite's accept-slot count defaulted to 1 regardless of recipient count); an unresolved or case-mismatched recipient created a share nobody could see instead of failing; and accepting a new invite could silently overwrite an existing collaborator's permissions. Fixing the case-sensitivity gap also opened a new one: two accounts differing only by case can now both match one input, so an ambiguous match now errors instead of picking one.

Closes #1151.

## Changes

- Fix the self-share filter so a not-yet-loaded user never blocks every recipient (the root cause of the no-op)
- Surface every By-Users validation/mutation failure as a single toast instead of a silent no-op or a duplicate, and report the server-resolved recipient count on success rather than the raw typed count
- Fail loudly when a recipient does not resolve to exactly one real account (unresolved, emailless-username-only, or an ambiguous case-insensitive match), scoped to file/notebook invites
- Make recipient email/username lookup case-insensitive, with a matching collated index
- Size a multi-recipient invite's accept slots to the number of resolved recipients instead of a flat 1, and require an accepter to actually be one of the named recipients
- Merge, don't overwrite, an existing collaborator's permissions/projectId when they accept another invite for the same document
- When a file leaves a project, reset a collaborator who also holds a direct share to just that direct grant (not the project's permissions too), resolving grantee emails with one batched lookup instead of one per member
- Add component, service, and model-level tests for all of the above

## Guide for Testers

1. Log in as User A, who owns at least one file or notebook.
2. From the Files browser (or notebook list), use the Share action on an item you own.
3. In the Share modal, click the **By Users** tab.
4. Type User B's email or username in the Recipients field and press Enter, then click **Share**. Expect a success toast (e.g. "Successfully shared ... to 1 recipient"), the modal closes, and no console errors.
5. Log in as User B. Expect their inbox/invites view to show the pending share from User A.
6. Accept the invite. Expect User B can now open the item with read + share access, the same permissions the modal advertised.
7. Repeat steps 2-4, but this time type two valid recipients before clicking Share. Expect both can independently accept the invite (this is the multi-recipient fix; previously only the first acceptor would succeed).
8. Repeat steps 2-4 with an identifier that matches no real account (e.g. `nobody-xyz@example.com`). Expect a clear error toast naming the unresolved recipient, the modal stays open, and no invite is created.
9. Repeat steps 2-4 typing your own email/username in a different letter case than your login (e.g. `YourName@Example.com` if you log in as `yourname@example.com`). Expect the "You cannot share files to yourself" error and no request is sent.
10. As User A, add a file to a project and separately share that same file directly with User B (By Users, read + share only). Remove the file from the project. Expect User B still has read + share access afterward, but nothing broader that only came from the project.
11. As User B, try to accept an invite that names a different recipient (e.g. by hitting the accept endpoint for an invite sent to someone else). Expect a "this invite was not sent to your account" error and no access granted.

Regression check: the **By Link** and **Email** tabs share the same submit handler and validation branch as By Users, so confirm both still work as before (Generate Link produces a working `/share/<id>` link; email sharing still sends).

## Additional Information

The new unresolved/ambiguous-recipient check is scoped to file and notebook invites; organization and project invites resolve recipients through a different path (raw user ids) and are untouched. `findAllByEmailsOrUsernames`'s two other callers (security alerting, org pending-members list) inherit the case-insensitive lookup, but only for non-granting reads/notifications, not permission grants.

## Developer Notes (Optional)

- `isSelfShareRecipient` (ShareModal.tsx) centralizes self-share detection so the Autocomplete filter and the submit-time check cannot drift out of sync again.
- `pushShareable` (sharingService/accept.ts) now merges a permission grant instead of replacing it. That matters for any future caller that re-shares a document a user already has access to.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc


