### PR TITLE
chore: overlay preview boot (do not merge)

### DIFF
--- a/PREVIEW.md
+++ b/PREVIEW.md
@@ -1,0 +1,1 @@
+Throwaway draft PR used only to boot an overlay preview stack. Do not merge.


### PR DESCRIPTION
Throwaway draft PR to boot a preview stack for an overlay change. Do not merge; will be closed once the preview has served its purpose.