### PR TITLE
test(services): regression-lock a share/group-reached prefix-only file (#1040)

### DIFF
--- a/b4m-core/services/src/dataLakeService/lakeMembership.test.ts
+++ b/b4m-core/services/src/dataLakeService/lakeMembership.test.ts
@@ -132,6 +132,29 @@ describe('removeFileFromLake', () => {
     expect(adapters.db.fabFiles.pullTagsByFabFileId).not.toHaveBeenCalled();
   });
 
+  it('refuses the lake creator removing a prefix-only file merely shared with them (#1040)', async () => {
+    // Same code path as the admin test above - ownsFile never reads file.users/file.groups - but
+    // spelled out for #1040's literal scenario: the ACTOR here is the lake's own creator (passes
+    // canManageLake trivially), and the file's owner shared it with them read/write. A share is
+    // not ownership, so the outcome is identical to the admin case.
+    const adapters = {
+      db: {
+        fabFiles: {
+          findById: vi.fn().mockResolvedValue({
+            id: 'f1',
+            userId: 'victim',
+            users: [{ userId: 'owner', permissions: ['read', 'write'] }],
+            tags: [{ name: 'lk:invoices', strength: 1 }],
+          }),
+          pullTagsByFabFileId: vi.fn().mockResolvedValue(1),
+        },
+      },
+    };
+
+    await expect(removeFileFromLake(owner, lake(), 'f1', adapters)).rejects.toThrow(/not found in this data lake/i);
+    expect(adapters.db.fabFiles.pullTagsByFabFileId).not.toHaveBeenCalled();
+  });
+
   it('strips only the meta-tag, not a bystander prefix-matching tag, on a file the creator does not own', async () => {
     // Admitted to inLake via the meta-tag arm only (e.g. an admin's addFileToLake added a
     // stranger's file) - the read path's prefix arm never admitted this file since it is not

--- a/b4m-core/services/src/dataLakeService/lakeMembership.ts
+++ b/b4m-core/services/src/dataLakeService/lakeMembership.ts
@@ -54,6 +54,11 @@ export const removeFileFromLake = async (
   // lake. Other lake readers (the aggregate browse, semantic search, chat KB tools) still match
   // the prefix within the VIEWER's own access - that is ownership of the file, not membership in
   // this lake, and unaffected by this write.
+  //
+  // This is also why #1040 (a prefix-only file reached through a share or a group looked listed
+  // but unremovable) cannot happen: the same anchor excludes such a file from the single-lake
+  // browse (buildDataLakeMembershipFilter) too, so it is never listed in the first place. See the
+  // #1040 tests in lakeMembership.test.ts and FabFileModel.dataLakeLifecycle.test.ts.
   const ownsFile = !!file?.userId && file.userId === lake.createdByUserId;
   // Gated on ownsFile, not just prefix: a file admitted to inLake via the META-TAG arm (e.g. an
   // admin added a stranger's file with addFileToLake, which checks only the ACTOR's access, not

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -153,6 +153,7 @@ describe('FabFile data lake lifecycle membership', () => {
 
       const result = await fabFileRepository.search(CREATOR, '', {}, pagination, order, {
         includeShared: true,
+        userGroups: [CREATOR_GROUP],
         lakeMembership: scope,
         restrictToDataLake: true,
       });

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -139,6 +139,32 @@ describe('FabFile data lake lifecycle membership', () => {
     });
   });
 
+  // #1040: the single-lake browse (fabFileRepository.search with lakeMembership +
+  // restrictToDataLake, what GET /api/data-lakes/:id/articles runs) must agree with
+  // computeDataLakeStats above about who is a member - a file only reached through a share or a
+  // group grant is excluded from the listing itself, not merely from the count, so it can never
+  // be "listed but unremovable".
+  describe('search under a single-lake browse scope (lakeMembership)', () => {
+    const pagination = { page: 1, limit: 20 };
+    const order = { by: 'fileName', direction: 'asc' } as const;
+
+    it('lists exactly the members computeDataLakeStats counts, excluding every stranger-owned prefix match', async () => {
+      const rows = await seedLakeRows();
+
+      const result = await fabFileRepository.search(CREATOR, '', {}, pagination, order, {
+        includeShared: true,
+        lakeMembership: scope,
+        restrictToDataLake: true,
+      });
+
+      expect(result.data.map(f => f.fileName).sort()).toEqual(['meta.txt', 'prefix-owned.txt']);
+      const listedIds = result.data.map(f => f.id);
+      for (const id of rows.strangerIds) {
+        expect(listedIds).not.toContain(id);
+      }
+    });
+  });
+
   describe('archiveByDataLakeTag / unarchiveByDataLakeTag', () => {
     it('archives the members and leaves every stranger-owned prefix match live', async () => {
       const rows = await seedLakeRows();


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1280" height="766" alt="datalake1040-shared-file-not-listed-after" src="https://github.com/user-attachments/assets/db178387-e01e-483a-9d6d-25fcfdc3ae45" />
*The lake creator's Data Lakes manager, showing "0 files" - the file sharevictim owns and shared read/write with the creator (tagged with the lake's prefix only) never appears.*

<img width="820" height="160" alt="datalake1040-delete-refused-404-after" src="https://github.com/user-attachments/assets/e2f13d6c-4cda-463e-a950-39967d91840a" />
*Same file, DELETE attempt from the browser console as the creator: refused with 404 "File not found in this data lake", not a silent no-op.*

## Description
#1040 asked to widen `removeFileFromLake`'s removal authorization to owner/shared/group access, matching the repo's existing tag-write bar, for a prefix-only lake file reached through a share or a group.

Since filing, `buildDataLakeMembershipFilter` (introduced by #1130, extended by #1532 as the fix for #1263) anchors the prefix arm to `file.userId === lake.createdByUserId` on **both** the single-lake browse and the removal write. That anchor never reads `file.users[]`/`file.groups[]`, so a share/group-only grant now excludes the file from the browse itself rather than producing "listed but unremovable". Widening removal as #1040 proposed would reopen the force-publish/evict gap #1532's security review just closed.

This locks the current (correct) behavior with tests naming #1040's literal scenario, rather than changing production code.

Closes #1040

## Changes
- Unit test in `lakeMembership.test.ts`: the lake creator (not admin) cannot remove a prefix-only file merely shared with them. Same code path as the existing admin test, spelled out for #1040's scenario
- Real-Mongo integration test in `FabFileModel.dataLakeLifecycle.test.ts`: the single-lake browse query (`search` with `lakeMembership` + `restrictToDataLake`) excludes every stranger-owned prefix match, including the two fixture rows reached via a share and a group grant
- One-line docstring note on `removeFileFromLake`'s `ownsFile` conjunct citing #1040 as resolved by this same anchor

## Guide for Testers
Server-side, no UI needed. Two e2e users via the self-host backend (see SELF_HOST.md "Frontend dev mode").

1. `POST /api/test/create-user` (header `x-e2e-cleanup-secret: <value>`) for `creator-e2e@test.com` and `sharevictim-e2e@test.com`.
2. As `sharevictim`, `POST /api/files/createFabFile` with a plain-text file, then share it with `creator` read/write via the invite flow: `POST /api/files/:id/invites` naming `creator`'s email with `update` permission, then as `creator`, `POST /api/invites/:inviteId/accept`.
3. Tag that same file `issue1040:sample` (prefix only, no meta-tag) via `PUT /api/files/:id`.
4. As `creator`, `POST /api/data-lakes` with `fileTagPrefix: "issue1040:"`.
5. As `creator`, `GET /api/data-lakes/:lakeId/articles`. Expected: the shared file is NOT in the list.
6. As `creator`, `DELETE /api/data-lakes/:lakeId/files/:fileId` on that file. Expected: `404`, `"File not found in this data lake"`.

**What NOT to test:** no UI change and no change to any route's response shape. The tests pin an already-shipped predicate, not new behavior.

## Additional Information
N/A

## Developer Notes (Optional)
N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
