### PR TITLE
fix(client): drop the redundant cancel-generation toast

### DIFF
--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.stopMessageToast.test.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.stopMessageToast.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression guard: handleStopMessage must not fire a success toast on cancel.
+ *
+ * The bottom-right global Toaster (apps/client/app/providers.tsx) is fixed to the
+ * viewport, not scoped to the chat panel. On narrow layouts - e.g. chat docked to
+ * the right - a bottom-right toast can cover the entire prompt input area. The
+ * inline chatCompletion.statusMessage already surfaces "Generation cancelled by
+ * user" next to the composer, so the success toast was redundant as well as
+ * blocking. Only the error path should still toast, since there is no inline
+ * error surface for a failed cancel.
+ *
+ * A source-level assertion is used (rather than a full renderHook) because
+ * useSendMessage consumes ~15 context providers; this mirrors the existing
+ * useSendMessage.killSwitch.test.ts pattern.
+ */
+describe('useSendMessage - handleStopMessage toast (regression)', () => {
+  const source = readFileSync(resolve(__dirname, 'useSendMessage.ts'), 'utf8');
+  const handleStopMessageMatch = source.match(/const handleStopMessage[\s\S]*?\n {2}\};/);
+
+  it('locates handleStopMessage in the source', () => {
+    expect(handleStopMessageMatch).not.toBeNull();
+  });
+
+  const handleStopMessageSource = handleStopMessageMatch?.[0] ?? '';
+
+  it('does not toast a success message on successful cancellation', () => {
+    expect(handleStopMessageSource).not.toMatch(/toast\.success\(/);
+  });
+
+  it('still toasts on a failed cancellation (no inline error surface exists)', () => {
+    expect(handleStopMessageSource).toContain("toast.error('Error cancelling generation')");
+  });
+});

--- a/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
+++ b/apps/client/app/components/Session/SessionBottom/useSendMessage.ts
@@ -308,7 +308,9 @@ export function useSendMessage({
 
     try {
       await stopChatMessage(currentSessionId);
-      toast.success('Generation cancelled successfully');
+      // No success toast here: the inline statusMessage below already surfaces the
+      // cancellation, and a bottom-right toast covers the whole prompt area on
+      // narrow layouts (e.g. chat docked to the right).
       setChatCompletion(prev => ({
         ...prev,
         completed: true,


### PR DESCRIPTION
## Description
The "Generation cancelled successfully" toast that appeared after stopping an in-flight chat generation was redundant with the inline status message already shown in the message transcript area, and on narrow docked-right chat layouts the bottom-right toast could cover the entire prompt input area. This drops the success toast; cancellation state is still fully visible via the existing inline status message.

## Changes
- Remove the `toast.success('Generation cancelled successfully')` call in `handleStopMessage` (`useSendMessage.ts`); the error-path toast is unchanged.
- Add a source-level regression test locking in that `handleStopMessage` doesn't reintroduce a success toast.

## Guide for Testers
1. Send a message, then click Stop while it's generating.
2. Expected: no toast appears in the bottom-right corner; "Generation cancelled by user" appears briefly above the reply in the message area, and the composer is fully usable immediately (nothing overlaps it).

   <img width="1091" height="122" alt="image" src="https://github.com/user-attachments/assets/b3f85b88-252b-4cf2-9a9e-5c3c95045f68" />
   
3. Regression check: force a cancel failure (e.g. stop network briefly) and confirm the "Error cancelling generation" toast still appears -- only the success toast was removed.