### PR TITLE
fix(subscriptions): reject non-integer and out-of-range seat quantity

### DIFF
--- a/apps/client/lib/subscriptions/schema.test.ts
+++ b/apps/client/lib/subscriptions/schema.test.ts
@@ -1,0 +1,50 @@
+import {
+  ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
+  ORGANIZATION_SUBSCRIPTION_MIN_SEATS,
+} from '@client/lib/subscriptions/constants';
+import { OrgSubscriptionSubscribeSchema } from '@client/lib/subscriptions/schema';
+import { describe, expect, it } from 'vitest';
+
+const baseRequest = {
+  priceId: 'price_test',
+  callbackUrl: 'https://app.example.com/return',
+  organizationId: 'org_test',
+};
+
+describe('OrgSubscriptionSubscribeSchema.quantity', () => {
+  it('accepts an in-range integer seat count', () => {
+    const result = OrgSubscriptionSubscribeSchema.safeParse({
+      ...baseRequest,
+      quantity: ORGANIZATION_SUBSCRIPTION_MIN_SEATS,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-integer seat count', () => {
+    const result = OrgSubscriptionSubscribeSchema.safeParse({
+      ...baseRequest,
+      quantity: ORGANIZATION_SUBSCRIPTION_MIN_SEATS + 0.5,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a seat count below the platform minimum', () => {
+    const result = OrgSubscriptionSubscribeSchema.safeParse({
+      ...baseRequest,
+      quantity: ORGANIZATION_SUBSCRIPTION_MIN_SEATS - 1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a seat count above the platform maximum', () => {
+    const result = OrgSubscriptionSubscribeSchema.safeParse({
+      ...baseRequest,
+      quantity: ORGANIZATION_SUBSCRIPTION_MAX_SEATS + 1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/client/lib/subscriptions/schema.ts
+++ b/apps/client/lib/subscriptions/schema.ts
@@ -1,4 +1,7 @@
-import { ORGANIZATION_SUBSCRIPTION_MIN_SEATS } from '@client/lib/subscriptions/constants';
+import {
+  ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
+  ORGANIZATION_SUBSCRIPTION_MIN_SEATS,
+} from '@client/lib/subscriptions/constants';
 import { SubscriptionOwnerType } from '@client/lib/subscriptions/types';
 import { z } from 'zod';
 
@@ -33,9 +36,12 @@ export const OrgSubscriptionSubscribeSchema = z
     priceId: z.string(),
 
     /**
-     * Number of seats to subscribe to. Minimum enforced by ORGANIZATION_SUBSCRIPTION_MIN_SEATS.
+     * Number of seats to subscribe to. Whole seats only, bounded by the platform
+     * min/max - this value flows into Stripe checkout line_items and into
+     * organization.seats at creation, so a non-integer or over-cap value must be
+     * rejected here rather than relying on Stripe to bounce it.
      */
-    quantity: z.number().min(ORGANIZATION_SUBSCRIPTION_MIN_SEATS),
+    quantity: z.number().int().min(ORGANIZATION_SUBSCRIPTION_MIN_SEATS).max(ORGANIZATION_SUBSCRIPTION_MAX_SEATS),
 
     /**
      * The organization that is subscribing. If not provided, a new organization will be created.

--- a/apps/client/pages/api/organizations/subscriptions/update-seats.ts
+++ b/apps/client/pages/api/organizations/subscriptions/update-seats.ts
@@ -4,7 +4,10 @@ import { ForbiddenError } from '@server/utils/errors';
 import { baseApi } from '@server/middlewares/baseApi';
 import { stripe } from '@server/integrations/stripe/stripe';
 import { z } from 'zod';
-import { ORGANIZATION_SUBSCRIPTION_MIN_SEATS } from '@client/lib/subscriptions/constants';
+import {
+  ORGANIZATION_SUBSCRIPTION_MAX_SEATS,
+  ORGANIZATION_SUBSCRIPTION_MIN_SEATS,
+} from '@client/lib/subscriptions/constants';
 import { SubscriptionOwnerType, SubscriptionSource } from '@client/lib/subscriptions/types';
 import { subscriptionRepository } from '@server/models/Subscription';
 import dayjs from 'dayjs';
@@ -17,7 +20,10 @@ import {
 
 const UpdateSeatsSchema = z.object({
   organizationId: z.string(),
-  seats: z.number().min(ORGANIZATION_SUBSCRIPTION_MIN_SEATS),
+  // Whole seats only, within platform bounds. validateSeatChange re-checks the floor
+  // against team size and the ceiling, but only for finite integers - keep the .int()
+  // and .max() here so a fractional or over-cap value is rejected before Stripe.
+  seats: z.number().int().min(ORGANIZATION_SUBSCRIPTION_MIN_SEATS).max(ORGANIZATION_SUBSCRIPTION_MAX_SEATS),
 });
 
 const handler = baseApi()


### PR DESCRIPTION
## Description

`OrgSubscriptionSubscribeSchema.quantity` validated only a minimum (`z.number().min(MIN_SEATS)`) - no integer guard and no ceiling. That value flows straight into Stripe checkout `line_items[].quantity` and into `organization.seats` at creation, so a non-integer (e.g. `2.5`) or an over-cap value could reach billing and seat provisioning, with Stripe's own range check as the only backstop. The existing-org subscribe path now writes `seats` from this quantity too, so the gap became reachable for existing orgs as well.

This tightens the schema so bad values are rejected with a 422 before any Stripe call. The same gap existed on the `update-seats` endpoint (it leaned on `validateSeatChange` for the ceiling but had no integer guard), so it is tightened the same way.

## Changes

- `apps/client/lib/subscriptions/schema.ts` - `OrgSubscriptionSubscribeSchema.quantity` is now `z.number().int().min(MIN_SEATS).max(MAX_SEATS)` (was min-only).
- `apps/client/pages/api/organizations/subscriptions/update-seats.ts` - `UpdateSeatsSchema.seats` gains `.int()` and `.max(MAX_SEATS)`.
- `apps/client/lib/subscriptions/schema.test.ts` (new) - unit tests covering a valid value plus the three reject cases (non-integer, below-min, above-max).

Other seat entry points were checked and already guarded: admin `grant.ts` and `[id]/seats.ts` already use `.int().min(1).max(MAX_SEATS)`; `create-dev.ts` is dev-only and non-Stripe (out of scope). `MAX_SEATS` was already re-exported from `apps/client/lib/subscriptions/constants.ts`.

## Guide for Testers

This is a backend request-validation change. It can be exercised via the org subscription / seat-update endpoints.

1. Attempt to subscribe an org with a non-integer seat quantity (e.g. `quantity: 2.5`). Expected: request rejected with a 422 before any Stripe checkout session is created.
2. Attempt to subscribe with a quantity below the platform minimum. Expected: 422.
3. Attempt to subscribe with a quantity above the platform maximum. Expected: 422.
4. Subscribe with a valid whole-number quantity within bounds. Expected: request passes validation and proceeds to Stripe as before.
5. Repeat steps 1-4 against the `update-seats` endpoint (`seats` field) - same accept/reject behavior.

### Regression Checks
- A normal, in-bounds seat subscription and seat update still succeed end to end (Stripe checkout / update proceeds, `organization.seats` set correctly).

### What NOT to test
- No UI changes. The seat-count input already constrains values client-side; this PR hardens the server so the API cannot be bypassed with a crafted request.

## Additional Information

Unit tests pass (4/4). `typecheck` (tsc) + `typecheck:fast` (tsgo), `pnpm lint:check`, and the ASCII guard scripts are all green.

Closes #1604
