### PR TITLE
fix(client): recover the session automatically on tab refocus

### DIFF
--- a/apps/client/app/contexts/WebsocketContext.test.ts
+++ b/apps/client/app/contexts/WebsocketContext.test.ts
@@ -29,7 +29,8 @@ vi.mock('react-use-websocket', () => ({
   },
 }));
 
-vi.mock('@tanstack/react-query', () => ({
+vi.mock('@tanstack/react-query', async importOriginal => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
   useQueryClient: () => h.queryClient,
 }));
 
@@ -144,9 +145,16 @@ describe('WebsocketProvider - refocus reconnect pulse', () => {
     stubVisibility('visible');
   });
 
-  it('pulses the url to null and back on refocus when the socket is not open (forces a fresh reconnect budget)', async () => {
-    h.readyState = 3; // ReadyState.CLOSED - e.g. reconnect budget already exhausted while idle
+  const mount = () => {
     render(React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div')));
+    return h.capturedOptions.current;
+  };
+
+  it('pulses the url to null and back on refocus once the reconnect budget is exhausted', async () => {
+    const opts = mount();
+    await act(async () => {
+      opts.onReconnectStop(20); // the budget genuinely ran out - no pending backoff timer left
+    });
     h.capturedUrls = [];
 
     await act(async () => {
@@ -159,9 +167,37 @@ describe('WebsocketProvider - refocus reconnect pulse', () => {
     expect(h.capturedUrls[h.capturedUrls.length - 1]).toBe('wss://example/ws');
   });
 
-  it('does not pulse on refocus when the socket is already open', async () => {
-    h.readyState = 1; // ReadyState.OPEN
-    render(React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div')));
+  it('does not pulse on refocus while still mid-backoff (budget not yet exhausted)', async () => {
+    mount(); // no onReconnectStop - a reconnect attempt may still be pending its own backoff
+    h.capturedUrls = [];
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(h.capturedUrls).not.toContain(null);
+  });
+
+  it('does not pulse on refocus when the socket is open', async () => {
+    const opts = mount();
+    await act(async () => {
+      opts.onOpen({});
+    });
+    h.capturedUrls = [];
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(h.capturedUrls).not.toContain(null);
+  });
+
+  it('a successful reconnect clears the exhausted flag, so a later refocus does not pulse again', async () => {
+    const opts = mount();
+    await act(async () => {
+      opts.onReconnectStop(20);
+      opts.onOpen({});
+    });
     h.capturedUrls = [];
 
     await act(async () => {
@@ -172,8 +208,10 @@ describe('WebsocketProvider - refocus reconnect pulse', () => {
   });
 
   it('does not pulse when the tab is backgrounded (only a return to visible should)', async () => {
-    h.readyState = 3;
-    render(React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div')));
+    const opts = mount();
+    await act(async () => {
+      opts.onReconnectStop(20);
+    });
     h.capturedUrls = [];
     stubVisibility('hidden');
 

--- a/apps/client/app/contexts/WebsocketContext.test.ts
+++ b/apps/client/app/contexts/WebsocketContext.test.ts
@@ -10,23 +10,38 @@ vi.unmock('@/app/contexts/WebsocketContext');
 // Shared, hoisted so the vi.mock factories below can reference them.
 const h = vi.hoisted(() => ({
   capturedOptions: { current: null as unknown as Record<string, (arg: unknown) => void> },
-  apiGet: vi.fn(),
+  capturedUrls: [] as (string | null)[],
+  readyState: 1 as number, // ReadyState.OPEN
+  probeIdentity: vi.fn(),
+  queryClient: {} as unknown,
   accessTokenState: { accessToken: 'tok' as string | null, mfaPending: false },
 }));
 
-// Capture the options react-use-websocket is called with (esp. onOpen/onClose) so the test
-// can drive them directly, and return a stable stub instead of opening a real socket.
+// Capture the url + options react-use-websocket is called with on every render (esp.
+// onOpen/onClose, and whether url dips to null - the reconnect-pulse signal) and return a
+// stable stub instead of opening a real socket.
 vi.mock('react-use-websocket', () => ({
   ReadyState: { UNINSTANTIATED: -1, CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 },
-  useBaseWebsocket: (_url: string | null, options: Record<string, (arg: unknown) => void>) => {
+  useBaseWebsocket: (url: string | null, options: Record<string, (arg: unknown) => void>) => {
     h.capturedOptions.current = options;
-    return { sendJsonMessage: vi.fn(), readyState: 1, lastJsonMessage: null };
+    h.capturedUrls.push(url);
+    return { sendJsonMessage: vi.fn(), readyState: h.readyState, lastJsonMessage: null };
   },
 }));
 
-// The probe fires through this `api` instance; isPublicPath treats only /login as public.
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => h.queryClient,
+}));
+
+// The close-probe and the refocus reconnect-pulse both funnel through this shared,
+// single-flight helper (tested on its own in sessionBootstrap.test.ts) - mocked here so
+// this file tests only WebsocketContext's own wiring, not probeIdentity's internals.
+vi.mock('@client/app/utils/sessionBootstrap', () => ({
+  probeIdentity: h.probeIdentity,
+}));
+
+// isPublicPath treats only /login as public.
 vi.mock('@client/app/contexts/ApiContext', () => ({
-  api: { get: h.apiGet },
   isPublicPath: (p: string) => p === '/login',
 }));
 
@@ -44,6 +59,9 @@ vi.mock('@client/app/hooks/useAccessToken', () => {
 import { shouldProbeOnFailedWsConnect, WebsocketProvider } from './WebsocketContext';
 
 const base = { openedThisAttempt: false, accessToken: 'tok', mfaPending: false, pathname: '/new' };
+
+const stubVisibility = (state: DocumentVisibilityState) =>
+  Object.defineProperty(document, 'visibilityState', { configurable: true, value: state });
 
 describe('shouldProbeOnFailedWsConnect - WS connect-failure auth probe gate (Part 2, reuses Fix B)', () => {
   it('probes on a failed connect ATTEMPT while holding a token', () => {
@@ -67,13 +85,16 @@ describe('shouldProbeOnFailedWsConnect - WS connect-failure auth probe gate (Par
   });
 });
 
-describe('WebsocketProvider - onClose auth-probe wiring (single-flight + fire)', () => {
+describe('WebsocketProvider - onClose auth-probe wiring', () => {
   beforeEach(() => {
-    h.apiGet.mockReset();
-    h.apiGet.mockResolvedValue({ data: {} });
+    h.probeIdentity.mockReset();
+    h.probeIdentity.mockResolvedValue(undefined);
     h.capturedOptions.current = null as unknown as Record<string, (arg: unknown) => void>;
+    h.capturedUrls = [];
+    h.readyState = 1;
     h.accessTokenState.accessToken = 'tok';
     h.accessTokenState.mfaPending = false;
+    stubVisibility('visible');
   });
 
   const mount = () => {
@@ -81,25 +102,13 @@ describe('WebsocketProvider - onClose auth-probe wiring (single-flight + fire)',
     return h.capturedOptions.current;
   };
 
-  it('fires exactly one /api/identify probe on a failed connect attempt', async () => {
+  it('fires probeIdentity with the shared query client on a failed connect attempt', async () => {
     const opts = mount();
     await act(async () => {
       opts.onClose({ code: 1006, reason: '' });
     });
-    expect(h.apiGet).toHaveBeenCalledTimes(1);
-    expect(h.apiGet).toHaveBeenCalledWith('/api/identify');
-  });
-
-  it('single-flights the probe across a burst of closes (one in-flight probe max)', async () => {
-    let resolveGet: (v: unknown) => void = () => {};
-    h.apiGet.mockReturnValue(new Promise(r => (resolveGet = r)));
-    const opts = mount();
-    await act(async () => {
-      opts.onClose({ code: 1006 });
-      opts.onClose({ code: 1006 });
-    });
-    expect(h.apiGet).toHaveBeenCalledTimes(1);
-    await act(async () => resolveGet({}));
+    expect(h.probeIdentity).toHaveBeenCalledTimes(1);
+    expect(h.probeIdentity).toHaveBeenCalledWith(h.queryClient);
   });
 
   it('does not probe when the connection had opened this attempt (a drop is not an auth signal)', async () => {
@@ -108,10 +117,10 @@ describe('WebsocketProvider - onClose auth-probe wiring (single-flight + fire)',
       opts.onOpen({});
       opts.onClose({ code: 1006 });
     });
-    expect(h.apiGet).not.toHaveBeenCalled();
+    expect(h.probeIdentity).not.toHaveBeenCalled();
   });
 
-  it('resets the guard after settle so a later failed attempt probes again', async () => {
+  it("fires again on a later failed attempt (dedup across a burst is probeIdentity's own job, tested separately)", async () => {
     const opts = mount();
     await act(async () => {
       opts.onClose({ code: 1006 });
@@ -119,6 +128,59 @@ describe('WebsocketProvider - onClose auth-probe wiring (single-flight + fire)',
     await act(async () => {
       opts.onClose({ code: 1006 });
     });
-    expect(h.apiGet).toHaveBeenCalledTimes(2);
+    expect(h.probeIdentity).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('WebsocketProvider - refocus reconnect pulse', () => {
+  beforeEach(() => {
+    h.probeIdentity.mockReset();
+    h.probeIdentity.mockResolvedValue(undefined);
+    h.capturedOptions.current = null as unknown as Record<string, (arg: unknown) => void>;
+    h.capturedUrls = [];
+    h.readyState = 1;
+    h.accessTokenState.accessToken = 'tok';
+    h.accessTokenState.mfaPending = false;
+    stubVisibility('visible');
+  });
+
+  it('pulses the url to null and back on refocus when the socket is not open (forces a fresh reconnect budget)', async () => {
+    h.readyState = 3; // ReadyState.CLOSED - e.g. reconnect budget already exhausted while idle
+    render(React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div')));
+    h.capturedUrls = [];
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    // The pulse dips the url to null for one commit (resetting react-use-websocket's own
+    // reconnectCount) then straight back to the real url, so both appear in the sequence.
+    expect(h.capturedUrls).toContain(null);
+    expect(h.capturedUrls[h.capturedUrls.length - 1]).toBe('wss://example/ws');
+  });
+
+  it('does not pulse on refocus when the socket is already open', async () => {
+    h.readyState = 1; // ReadyState.OPEN
+    render(React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div')));
+    h.capturedUrls = [];
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(h.capturedUrls).not.toContain(null);
+  });
+
+  it('does not pulse when the tab is backgrounded (only a return to visible should)', async () => {
+    h.readyState = 3;
+    render(React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div')));
+    h.capturedUrls = [];
+    stubVisibility('hidden');
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(h.capturedUrls).not.toContain(null);
   });
 });

--- a/apps/client/app/contexts/WebsocketContext.tsx
+++ b/apps/client/app/contexts/WebsocketContext.tsx
@@ -91,6 +91,10 @@ export const WebsocketProvider = ({ children, url }: Props) => {
   // True once `onOpen` has fired for the CURRENT connect attempt; reset on each close.
   // Mirrors the same flag in the CLI's WebSocketConnectionManager.
   const openedThisAttemptRef = useRef(false);
+  // True once `onReconnectStop` has fired (the reconnect budget below is exhausted, no pending
+  // backoff timer left); reset on the next successful open. Gates the refocus pulse so it only
+  // fires once there is genuinely nothing left running - see the pulse effect below for why.
+  const reconnectExhaustedRef = useRef(false);
 
   // Map the action being listened for to the callbacks that want to hear about it
   const listeners = useRef(new Map<string, ((message: IMessageDataToClient) => Promise<void>)[]>());
@@ -130,6 +134,7 @@ export const WebsocketProvider = ({ children, url }: Props) => {
     onOpen: () => {
       console.log('ws connected');
       openedThisAttemptRef.current = true;
+      reconnectExhaustedRef.current = false;
     },
     onClose(event: CloseEvent) {
       console.log('ws disconnected', event.code, event.reason);
@@ -156,6 +161,7 @@ export const WebsocketProvider = ({ children, url }: Props) => {
     },
     onReconnectStop(numAttempts) {
       console.log('ws reconnect stopped after', numAttempts, 'attempts');
+      reconnectExhaustedRef.current = true;
     },
 
     onMessage: event => {
@@ -227,14 +233,19 @@ export const WebsocketProvider = ({ children, url }: Props) => {
     };
   }, []);
 
-  // On refocus, if the socket isn't open, pulse forceDisconnected to force a fresh
-  // reconnect attempt with a reset backoff budget - a tab idle long enough to exhaust
-  // DEFAULT_RECONNECT_LIMIT would otherwise stay dead until reload even after any token
-  // refresh (see the forceDisconnected declaration above for why this is the only lever).
+  // On refocus, pulse forceDisconnected to force a fresh reconnect attempt with a reset
+  // backoff budget - but ONLY once reconnectExhaustedRef is set (onReconnectStop already
+  // fired, so there is no pending backoff timer left to cancel). Gating on readyState alone
+  // (e.g. "not OPEN") would also pulse mid-backoff: react-use-websocket's own
+  // reconnectInterval below deliberately staggers reconnects with jitter to avoid a
+  // thundering herd after an outage, and cancelling that on every refocus would defeat it -
+  // plus the library never clears its own pending reconnect timer on a url change, so a
+  // mid-backoff pulse leaves a second, stale reconnect attempt to fire later. Once genuinely
+  // exhausted there is no such timer left, so this has neither problem.
   useEffect(() => {
     const handleVisibility = () => {
       if (document.visibilityState !== 'visible') return;
-      if (readyState === ReadyState.OPEN || readyState === ReadyState.CONNECTING) return;
+      if (!reconnectExhaustedRef.current) return;
       setForceDisconnected(true);
     };
     document.addEventListener('visibilitychange', handleVisibility);
@@ -243,7 +254,7 @@ export const WebsocketProvider = ({ children, url }: Props) => {
       document.removeEventListener('visibilitychange', handleVisibility);
       window.removeEventListener('focus', handleVisibility);
     };
-  }, [readyState]);
+  }, []);
 
   // The other half of the pulse: flip back on the next commit so shouldConnect's dip to
   // false was only momentary - enough for react-use-websocket to see url turn null (see

--- a/apps/client/app/contexts/WebsocketContext.tsx
+++ b/apps/client/app/contexts/WebsocketContext.tsx
@@ -1,10 +1,12 @@
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { ReadyState, useBaseWebsocket } from 'react-use-websocket';
 import { HeartbeatAction, IMessageDataToClient, IMessageDataToServer } from '@bike4mind/common';
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
-import { api, isPublicPath } from '@client/app/contexts/ApiContext';
+import { isPublicPath } from '@client/app/contexts/ApiContext';
+import { probeIdentity } from '@client/app/utils/sessionBootstrap';
 
 export { ReadyState };
 
@@ -85,11 +87,10 @@ export const WebsocketProvider = ({ children, url }: Props) => {
   const didUnmount = useRef(false);
   const setLastJsonMessage = useLastJsonMessage(useShallow(s => s.setLastJsonMessage));
   const accessToken = useAccessToken(useCallback(state => state.accessToken, []));
+  const queryClient = useQueryClient();
   // True once `onOpen` has fired for the CURRENT connect attempt; reset on each close.
   // Mirrors the same flag in the CLI's WebSocketConnectionManager.
   const openedThisAttemptRef = useRef(false);
-  // Single-flight guard so a burst of close events fires at most one auth probe.
-  const probeInFlightRef = useRef(false);
 
   // Map the action being listened for to the callbacks that want to hear about it
   const listeners = useRef(new Map<string, ((message: IMessageDataToClient) => Promise<void>)[]>());
@@ -97,9 +98,19 @@ export const WebsocketProvider = ({ children, url }: Props) => {
   const [activeSubscriptions, setActiveSubscriptions] = useState<ReadonlySet<string>>(() => new Set());
   const [clientId] = useState(() => crypto.randomUUID().slice(0, 8));
 
+  // Pulsed true-then-false to force react-use-websocket to tear down and reconnect with a
+  // fresh backoff budget (see the visibilitychange effect below). react-use-websocket only
+  // resets its internal reconnectCount on a successful connect or when its url argument goes
+  // null - the former isn't available to us (the socket isn't open, that's the problem), so a
+  // null url is the only lever we have. reconnectCount is capped at DEFAULT_RECONNECT_LIMIT
+  // (20 attempts, ~6 minutes of quadratic backoff - see reconnectInterval below); a tab idle
+  // longer than that exhausts the budget and onReconnectStop fires. Without this, the socket
+  // stays dead until a full reload even after the token refreshes.
+  const [forceDisconnected, setForceDisconnected] = useState(false);
+
   // Only connect when we have both a valid URL and access token
   // URL validation guards against build-time env vars that were undefined
-  const shouldConnect = !!accessToken && isValidWebsocketUrl(url);
+  const shouldConnect = !forceDisconnected && !!accessToken && isValidWebsocketUrl(url);
 
   const { sendJsonMessage, readyState } = useBaseWebsocket(shouldConnect ? url : null, {
     queryParams: { token: accessToken as string },
@@ -126,7 +137,6 @@ export const WebsocketProvider = ({ children, url }: Props) => {
       openedThisAttemptRef.current = false;
 
       if (
-        !probeInFlightRef.current &&
         shouldProbeOnFailedWsConnect({
           openedThisAttempt,
           accessToken,
@@ -134,18 +144,14 @@ export const WebsocketProvider = ({ children, url }: Props) => {
           pathname: window.location.pathname,
         })
       ) {
-        probeInFlightRef.current = true;
         // A connect ATTEMPT just failed to open while holding a token - the closest signal
-        // to "the server rejected this connection" a WS close can carry. Fire one authed
-        // request through `api` and let its existing 401 interceptor (ApiContext) do the
-        // work: refresh -> forceSessionExpiredRedirect on a genuine revocation, or nothing
-        // on a network error (WS keeps retrying on its own backoff either way).
-        api
-          .get('/api/identify')
-          .catch(() => {})
-          .finally(() => {
-            probeInFlightRef.current = false;
-          });
+        // to "the server rejected this connection" a WS close can carry. probeIdentity's own
+        // single-flight (shared with revalidateSessionOnFocus in sessionBootstrap.ts) covers
+        // both a burst of close events here and a refocus landing at the same moment, so this
+        // reduces to at most one authed round trip either way: refresh -> forceSessionExpiredRedirect
+        // on a genuine revocation, or nothing on a network error (WS keeps retrying on its own
+        // backoff either way).
+        void probeIdentity(queryClient);
       }
     },
     onReconnectStop(numAttempts) {
@@ -220,6 +226,31 @@ export const WebsocketProvider = ({ children, url }: Props) => {
       didUnmount.current = true;
     };
   }, []);
+
+  // On refocus, if the socket isn't open, pulse forceDisconnected to force a fresh
+  // reconnect attempt with a reset backoff budget - a tab idle long enough to exhaust
+  // DEFAULT_RECONNECT_LIMIT would otherwise stay dead until reload even after any token
+  // refresh (see the forceDisconnected declaration above for why this is the only lever).
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState !== 'visible') return;
+      if (readyState === ReadyState.OPEN || readyState === ReadyState.CONNECTING) return;
+      setForceDisconnected(true);
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleVisibility);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleVisibility);
+    };
+  }, [readyState]);
+
+  // The other half of the pulse: flip back on the next commit so shouldConnect's dip to
+  // false was only momentary - enough for react-use-websocket to see url turn null (see
+  // the DEFAULT_RECONNECT_LIMIT comment above) and reset before reconnecting.
+  useEffect(() => {
+    if (forceDisconnected) setForceDisconnected(false);
+  }, [forceDisconnected]);
 
   const subscribeToAction = useCallback(
     (action: IMessageDataToClient['action'], callback: (message: IMessageDataToClient) => Promise<void>) => {

--- a/apps/client/app/providers.tsx
+++ b/apps/client/app/providers.tsx
@@ -23,6 +23,7 @@ import { CookieConsentBanner } from '@client/app/components/CookieConsentBanner'
 import { TranslationProvider } from '@client/app/contexts/TranslationProvider';
 import { QuestPreparationOverlay } from '@client/app/components/QuestPreparationOverlay';
 import { runLocalStorageCleanup } from '@client/app/utils/localStorageCleanup';
+import { revalidateSessionOnFocus } from '@client/app/utils/sessionBootstrap';
 
 // Lazy load DevTools only when needed (development only)
 const ReactQueryDevtools = lazy(() =>
@@ -149,6 +150,21 @@ export function ClientProviders({ children }: { children: ReactNode }) {
     };
     window.addEventListener('storage', handleStorageChange);
     return () => window.removeEventListener('storage', handleStorageChange);
+  }, []);
+
+  // A reload runs the bootstrap refresh on load, but nothing ran its equivalent on
+  // tab refocus - so a token that expired while the tab was hidden wasn't caught until
+  // whichever refetchOnWindowFocus query happened to fire (and 401) first. Both events
+  // are listened for since a tab-switch fires visibilitychange while an OS-level app-switch
+  // back to the same foreground tab only fires focus; revalidateSessionOnFocus's own
+  // in-flight guard collapses a double-fire into one probe.
+  useEffect(() => {
+    document.addEventListener('visibilitychange', revalidateSessionOnFocus);
+    window.addEventListener('focus', revalidateSessionOnFocus);
+    return () => {
+      document.removeEventListener('visibilitychange', revalidateSessionOnFocus);
+      window.removeEventListener('focus', revalidateSessionOnFocus);
+    };
   }, []);
 
   return (

--- a/apps/client/app/providers.tsx
+++ b/apps/client/app/providers.tsx
@@ -152,18 +152,19 @@ export function ClientProviders({ children }: { children: ReactNode }) {
     return () => window.removeEventListener('storage', handleStorageChange);
   }, []);
 
-  // A reload runs the bootstrap refresh on load, but nothing ran its equivalent on
-  // tab refocus - so a token that expired while the tab was hidden wasn't caught until
-  // whichever refetchOnWindowFocus query happened to fire (and 401) first. Both events
-  // are listened for since a tab-switch fires visibilitychange while an OS-level app-switch
-  // back to the same foreground tab only fires focus; revalidateSessionOnFocus's own
-  // in-flight guard collapses a double-fire into one probe.
+  // A reload runs the bootstrap refresh on load, but nothing ran its equivalent on tab
+  // refocus - see revalidateSessionOnFocus's own doc comment for why an idle tab's expired
+  // token could otherwise sit unrefreshed. Both events are listened for since a tab-switch
+  // fires visibilitychange while an OS-level app-switch back to the same foreground tab
+  // only fires focus; the shared probeIdentity single-flight collapses a double-fire (and
+  // a WebsocketContext close-probe landing at the same time) into one round trip.
   useEffect(() => {
-    document.addEventListener('visibilitychange', revalidateSessionOnFocus);
-    window.addEventListener('focus', revalidateSessionOnFocus);
+    const handleVisibility = () => revalidateSessionOnFocus(queryClient);
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleVisibility);
     return () => {
-      document.removeEventListener('visibilitychange', revalidateSessionOnFocus);
-      window.removeEventListener('focus', revalidateSessionOnFocus);
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleVisibility);
     };
   }, []);
 

--- a/apps/client/app/utils/sessionBootstrap.test.ts
+++ b/apps/client/app/utils/sessionBootstrap.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { api } from '@client/app/contexts/ApiContext';
+import { useAccessToken } from '@client/app/hooks/useAccessToken';
+import { shouldRevalidateOnFocus, revalidateSessionOnFocus } from './sessionBootstrap';
+
+const base = {
+  visibilityState: 'visible' as DocumentVisibilityState,
+  accessToken: 'tok',
+  mfaPending: false,
+  expired: false,
+  pathname: '/new',
+};
+
+describe('shouldRevalidateOnFocus - refocus liveness-check gate', () => {
+  it('revalidates when the tab is visible and holding a token', () => {
+    expect(shouldRevalidateOnFocus(base)).toBe(true);
+  });
+
+  it('does not revalidate when the tab is not the visible one', () => {
+    expect(shouldRevalidateOnFocus({ ...base, visibilityState: 'hidden' })).toBe(false);
+  });
+
+  it('does not revalidate when there is no access token (logged-out tab)', () => {
+    expect(shouldRevalidateOnFocus({ ...base, accessToken: null })).toBe(false);
+  });
+
+  it('does not revalidate during mfaPending (no refresh token by design - mirrors ApiContext)', () => {
+    expect(shouldRevalidateOnFocus({ ...base, mfaPending: true })).toBe(false);
+  });
+
+  it('does not revalidate once the session is already torn down', () => {
+    expect(shouldRevalidateOnFocus({ ...base, expired: true })).toBe(false);
+  });
+
+  it('does not revalidate on a public path', () => {
+    expect(shouldRevalidateOnFocus({ ...base, pathname: '/login' })).toBe(false);
+  });
+});
+
+describe('revalidateSessionOnFocus - probe firing + single-flight', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useAccessToken.setState({
+      accessToken: 'tok',
+      refreshToken: 'refresh',
+      expired: false,
+      expiredReason: null,
+      mfaPending: false,
+    });
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, pathname: '/new' },
+    });
+  });
+
+  it('pings /api/identify through the shared api instance when the guard passes', () => {
+    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: {} });
+
+    revalidateSessionOnFocus();
+
+    expect(apiGet).toHaveBeenCalledWith('/api/identify');
+  });
+
+  it('does not ping when the guard fails (e.g. mfaPending)', () => {
+    useAccessToken.setState({ mfaPending: true });
+    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: {} });
+
+    revalidateSessionOnFocus();
+
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it('collapses a second call that lands while the first probe is still in flight', async () => {
+    let resolveFirst: (() => void) | undefined;
+    const apiGet = vi.spyOn(api, 'get').mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveFirst = () => resolve({ data: {} });
+        })
+    );
+
+    revalidateSessionOnFocus();
+    revalidateSessionOnFocus();
+    expect(apiGet).toHaveBeenCalledTimes(1);
+
+    resolveFirst?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The in-flight guard cleared after the first probe settled - a later call fires again.
+    revalidateSessionOnFocus();
+    expect(apiGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/client/app/utils/sessionBootstrap.test.ts
+++ b/apps/client/app/utils/sessionBootstrap.test.ts
@@ -92,7 +92,6 @@ describe('revalidateSessionOnFocus - guard gating the shared probe', () => {
     resetProbeGuardForTests();
     useAccessToken.setState({
       accessToken: 'tok',
-      refreshToken: 'refresh',
       expired: false,
       expiredReason: null,
       mfaPending: false,

--- a/apps/client/app/utils/sessionBootstrap.test.ts
+++ b/apps/client/app/utils/sessionBootstrap.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { api } from '@client/app/contexts/ApiContext';
+import type { QueryClient } from '@tanstack/react-query';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
-import { shouldRevalidateOnFocus, revalidateSessionOnFocus } from './sessionBootstrap';
+import { shouldRevalidateOnFocus, revalidateSessionOnFocus, probeIdentity } from './sessionBootstrap';
+
+/** A macrotask flush - long enough for a settled promise's .catch().finally() chain to run. */
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const makeQueryClient = (refetchQueries: ReturnType<typeof vi.fn>): QueryClient =>
+  ({ refetchQueries }) as unknown as QueryClient;
 
 const base = {
   visibilityState: 'visible' as DocumentVisibilityState,
@@ -37,9 +43,43 @@ describe('shouldRevalidateOnFocus - refocus liveness-check gate', () => {
   });
 });
 
-describe('revalidateSessionOnFocus - probe firing + single-flight', () => {
+describe('probeIdentity - shared single-flight liveness probe', () => {
+  it('refetches the identify query through the shared query client', async () => {
+    const refetchQueries = vi.fn().mockResolvedValue(undefined);
+
+    await probeIdentity(makeQueryClient(refetchQueries));
+
+    expect(refetchQueries).toHaveBeenCalledWith({ queryKey: ['identify'] });
+  });
+
+  it('collapses a second call that lands while the first probe is still in flight', async () => {
+    let resolveFirst: (() => void) | undefined;
+    // The first call hangs until resolved manually; every later call resolves immediately -
+    // otherwise the final probeIdentity call below would await a promise nothing ever settles.
+    const refetchQueries = vi.fn().mockResolvedValue(undefined);
+    refetchQueries.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          resolveFirst = resolve;
+        })
+    );
+    const client = makeQueryClient(refetchQueries);
+
+    const first = probeIdentity(client);
+    const second = probeIdentity(client);
+    expect(refetchQueries).toHaveBeenCalledTimes(1);
+
+    resolveFirst?.();
+    await Promise.all([first, second]);
+
+    // The in-flight guard cleared after the first probe settled - a later call fires again.
+    await probeIdentity(client);
+    expect(refetchQueries).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('revalidateSessionOnFocus - guard gating the shared probe', () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
     useAccessToken.setState({
       accessToken: 'tok',
       refreshToken: 'refresh',
@@ -53,42 +93,22 @@ describe('revalidateSessionOnFocus - probe firing + single-flight', () => {
     });
   });
 
-  it('pings /api/identify through the shared api instance when the guard passes', () => {
-    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: {} });
+  it('probes the identify query through the given client when the guard passes', async () => {
+    const refetchQueries = vi.fn().mockResolvedValue(undefined);
 
-    revalidateSessionOnFocus();
+    revalidateSessionOnFocus(makeQueryClient(refetchQueries));
+    await flush();
 
-    expect(apiGet).toHaveBeenCalledWith('/api/identify');
+    expect(refetchQueries).toHaveBeenCalledWith({ queryKey: ['identify'] });
   });
 
-  it('does not ping when the guard fails (e.g. mfaPending)', () => {
+  it('does not probe when the guard fails (e.g. mfaPending)', async () => {
     useAccessToken.setState({ mfaPending: true });
-    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: {} });
+    const refetchQueries = vi.fn().mockResolvedValue(undefined);
 
-    revalidateSessionOnFocus();
+    revalidateSessionOnFocus(makeQueryClient(refetchQueries));
+    await flush();
 
-    expect(apiGet).not.toHaveBeenCalled();
-  });
-
-  it('collapses a second call that lands while the first probe is still in flight', async () => {
-    let resolveFirst: (() => void) | undefined;
-    const apiGet = vi.spyOn(api, 'get').mockImplementation(
-      () =>
-        new Promise(resolve => {
-          resolveFirst = () => resolve({ data: {} });
-        })
-    );
-
-    revalidateSessionOnFocus();
-    revalidateSessionOnFocus();
-    expect(apiGet).toHaveBeenCalledTimes(1);
-
-    resolveFirst?.();
-    await Promise.resolve();
-    await Promise.resolve();
-
-    // The in-flight guard cleared after the first probe settled - a later call fires again.
-    revalidateSessionOnFocus();
-    expect(apiGet).toHaveBeenCalledTimes(2);
+    expect(refetchQueries).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/utils/sessionBootstrap.test.ts
+++ b/apps/client/app/utils/sessionBootstrap.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { QueryClient } from '@tanstack/react-query';
+import { api } from '@client/app/contexts/ApiContext';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import {
   shouldRevalidateOnFocus,
@@ -11,8 +12,13 @@ import {
 /** A macrotask flush - long enough for a settled promise's .catch().finally() chain to run. */
 const flush = () => new Promise(resolve => setTimeout(resolve, 0));
 
-const makeQueryClient = (refetchQueries: ReturnType<typeof vi.fn>): QueryClient =>
-  ({ refetchQueries }) as unknown as QueryClient;
+const makeQueryClient = (setQueryData: ReturnType<typeof vi.fn>): QueryClient =>
+  ({ setQueryData }) as unknown as QueryClient;
+
+/** Builds an unsigned JWT carrying only the given claims - decodeTokenExpiryMs never verifies
+ *  the signature, so a fake one is enough to exercise the exp-gating branch. */
+const makeToken = (claims: Record<string, unknown>) =>
+  `${btoa(JSON.stringify({ alg: 'none' }))}.${btoa(JSON.stringify(claims))}.sig`;
 
 const base = {
   visibilityState: 'visible' as DocumentVisibilityState,
@@ -48,48 +54,88 @@ describe('shouldRevalidateOnFocus - refocus liveness-check gate', () => {
   });
 });
 
+describe('shouldRevalidateOnFocus - exp-claim gating (the common refocus should be free)', () => {
+  const nowMs = 1_700_000_000_000;
+
+  it('revalidates when the token is already expired', () => {
+    const token = makeToken({ exp: Math.floor(nowMs / 1000) - 60 });
+    expect(shouldRevalidateOnFocus({ ...base, accessToken: token, nowMs })).toBe(true);
+  });
+
+  it('revalidates when the token is within the buffer of expiring', () => {
+    const token = makeToken({ exp: Math.floor(nowMs / 1000) + 10 }); // 10s out; buffer is 30s
+    expect(shouldRevalidateOnFocus({ ...base, accessToken: token, nowMs })).toBe(true);
+  });
+
+  it('skips the round trip when the token is nowhere near expiring', () => {
+    const token = makeToken({ exp: Math.floor(nowMs / 1000) + 60 * 20 }); // 20 minutes out
+    expect(shouldRevalidateOnFocus({ ...base, accessToken: token, nowMs })).toBe(false);
+  });
+
+  it('revalidates when the token has no readable exp claim (fail-safe, not fail-silent)', () => {
+    expect(shouldRevalidateOnFocus({ ...base, accessToken: 'not-a-jwt', nowMs })).toBe(true);
+  });
+});
+
 describe('probeIdentity - shared single-flight liveness probe', () => {
   beforeEach(() => {
     resetProbeGuardForTests();
+    vi.restoreAllMocks();
   });
 
-  it('refetches the identify query through the shared query client', async () => {
-    const refetchQueries = vi.fn().mockResolvedValue(undefined);
+  it('writes a successful response into the identify query cache', async () => {
+    const identify = { user: { id: 'u1' }, accessToken: 'fresh' };
+    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: identify });
+    const setQueryData = vi.fn();
 
-    await probeIdentity(makeQueryClient(refetchQueries));
+    await probeIdentity(makeQueryClient(setQueryData));
 
-    expect(refetchQueries).toHaveBeenCalledWith({ queryKey: ['identify'] });
+    expect(apiGet).toHaveBeenCalledWith('/api/identify');
+    expect(setQueryData).toHaveBeenCalledWith(['identify'], identify);
+  });
+
+  it('does not touch the cache on a failed probe (a transient network error must not poison the identify query)', async () => {
+    const apiGet = vi.spyOn(api, 'get').mockRejectedValue(new Error('Network Error'));
+    const setQueryData = vi.fn();
+
+    await probeIdentity(makeQueryClient(setQueryData));
+
+    expect(apiGet).toHaveBeenCalledWith('/api/identify');
+    expect(setQueryData).not.toHaveBeenCalled();
   });
 
   it('collapses a second call that lands while the first probe is still in flight', async () => {
-    let resolveFirst: (() => void) | undefined;
+    let resolveFirst: ((v: { data: unknown }) => void) | undefined;
+    const apiGet = vi.spyOn(api, 'get');
     // The first call hangs until resolved manually; every later call resolves immediately -
     // otherwise the final probeIdentity call below would await a promise nothing ever settles.
-    const refetchQueries = vi.fn().mockResolvedValue(undefined);
-    refetchQueries.mockImplementationOnce(
+    apiGet.mockImplementationOnce(
       () =>
-        new Promise<void>(resolve => {
+        new Promise(resolve => {
           resolveFirst = resolve;
         })
     );
-    const client = makeQueryClient(refetchQueries);
+    apiGet.mockResolvedValue({ data: { user: {}, accessToken: 'x' } });
+    const setQueryData = vi.fn();
+    const client = makeQueryClient(setQueryData);
 
     const first = probeIdentity(client);
     const second = probeIdentity(client);
-    expect(refetchQueries).toHaveBeenCalledTimes(1);
+    expect(apiGet).toHaveBeenCalledTimes(1);
 
-    resolveFirst?.();
+    resolveFirst?.({ data: { user: {}, accessToken: 'x' } });
     await Promise.all([first, second]);
 
     // The in-flight guard cleared after the first probe settled - a later call fires again.
     await probeIdentity(client);
-    expect(refetchQueries).toHaveBeenCalledTimes(2);
+    expect(apiGet).toHaveBeenCalledTimes(2);
   });
 });
 
 describe('revalidateSessionOnFocus - guard gating the shared probe', () => {
   beforeEach(() => {
     resetProbeGuardForTests();
+    vi.restoreAllMocks();
     useAccessToken.setState({
       accessToken: 'tok',
       expired: false,
@@ -102,22 +148,24 @@ describe('revalidateSessionOnFocus - guard gating the shared probe', () => {
     });
   });
 
-  it('probes the identify query through the given client when the guard passes', async () => {
-    const refetchQueries = vi.fn().mockResolvedValue(undefined);
+  it('probes the identify endpoint when the guard passes', async () => {
+    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: { user: {}, accessToken: 'tok' } });
+    const setQueryData = vi.fn();
 
-    revalidateSessionOnFocus(makeQueryClient(refetchQueries));
+    revalidateSessionOnFocus(makeQueryClient(setQueryData));
     await flush();
 
-    expect(refetchQueries).toHaveBeenCalledWith({ queryKey: ['identify'] });
+    expect(apiGet).toHaveBeenCalledWith('/api/identify');
   });
 
   it('does not probe when the guard fails (e.g. mfaPending)', async () => {
     useAccessToken.setState({ mfaPending: true });
-    const refetchQueries = vi.fn().mockResolvedValue(undefined);
+    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: { user: {}, accessToken: 'tok' } });
+    const setQueryData = vi.fn();
 
-    revalidateSessionOnFocus(makeQueryClient(refetchQueries));
+    revalidateSessionOnFocus(makeQueryClient(setQueryData));
     await flush();
 
-    expect(refetchQueries).not.toHaveBeenCalled();
+    expect(apiGet).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/utils/sessionBootstrap.test.ts
+++ b/apps/client/app/utils/sessionBootstrap.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { QueryClient } from '@tanstack/react-query';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
-import { shouldRevalidateOnFocus, revalidateSessionOnFocus, probeIdentity } from './sessionBootstrap';
+import {
+  shouldRevalidateOnFocus,
+  revalidateSessionOnFocus,
+  probeIdentity,
+  resetProbeGuardForTests,
+} from './sessionBootstrap';
 
 /** A macrotask flush - long enough for a settled promise's .catch().finally() chain to run. */
 const flush = () => new Promise(resolve => setTimeout(resolve, 0));
@@ -44,6 +49,10 @@ describe('shouldRevalidateOnFocus - refocus liveness-check gate', () => {
 });
 
 describe('probeIdentity - shared single-flight liveness probe', () => {
+  beforeEach(() => {
+    resetProbeGuardForTests();
+  });
+
   it('refetches the identify query through the shared query client', async () => {
     const refetchQueries = vi.fn().mockResolvedValue(undefined);
 
@@ -80,6 +89,7 @@ describe('probeIdentity - shared single-flight liveness probe', () => {
 
 describe('revalidateSessionOnFocus - guard gating the shared probe', () => {
   beforeEach(() => {
+    resetProbeGuardForTests();
     useAccessToken.setState({
       accessToken: 'tok',
       refreshToken: 'refresh',

--- a/apps/client/app/utils/sessionBootstrap.ts
+++ b/apps/client/app/utils/sessionBootstrap.ts
@@ -1,5 +1,5 @@
 import { IUserDocument } from '@bike4mind/common';
-import { api } from '@client/app/contexts/ApiContext';
+import { api, isPublicPath } from '@client/app/contexts/ApiContext';
 import { takeLegacyRefreshToken, useAccessToken } from '@client/app/hooks/useAccessToken';
 import { useUser } from '@client/app/contexts/UserContext';
 
@@ -72,4 +72,58 @@ export function bootstrapSession(): Promise<void> {
   }
   bootstrapPromise ??= exchangeRefreshCookie();
   return bootstrapPromise;
+}
+
+/**
+ * Refocus liveness check - pure predicate, unit-testable in isolation.
+ * Mirrors shouldProbeOnFailedWsConnect (WebsocketContext.tsx): decides whether a tab
+ * returning to the foreground is worth pinging the server for, without doing the ping itself.
+ */
+export function shouldRevalidateOnFocus(params: {
+  visibilityState: DocumentVisibilityState;
+  accessToken: string | null;
+  mfaPending: boolean;
+  expired: boolean;
+  pathname: string;
+}): boolean {
+  if (params.visibilityState !== 'visible') return false;
+  if (!params.accessToken) return false;
+  if (params.mfaPending) return false;
+  if (params.expired) return false;
+  if (isPublicPath(params.pathname)) return false;
+  return true;
+}
+
+/** Single-flight guard so visibilitychange and focus firing together only probes once. */
+let revalidateInFlight = false;
+
+/**
+ * On a tab returning from idle, `bootstrapSession` only runs at page load (see router.tsx's
+ * beforeLoad), so nothing proactively checks whether the access token expired while the tab was
+ * hidden. The first refetchOnWindowFocus query to 401 is what currently starts recovery via the
+ * ApiContext interceptor - this fires that recovery explicitly, through the SAME interceptor
+ * (no separate refresh path), instead of leaving it to whichever query happens to race there
+ * first. `/api/identify` is the same cheap authed endpoint WebsocketContext's close-probe uses.
+ */
+export function revalidateSessionOnFocus(): void {
+  if (revalidateInFlight) return;
+  const { accessToken, mfaPending, expired } = useAccessToken.getState();
+  if (
+    !shouldRevalidateOnFocus({
+      visibilityState: document.visibilityState,
+      accessToken,
+      mfaPending,
+      expired,
+      pathname: window.location.pathname,
+    })
+  ) {
+    return;
+  }
+  revalidateInFlight = true;
+  api
+    .get('/api/identify')
+    .catch(() => {})
+    .finally(() => {
+      revalidateInFlight = false;
+    });
 }

--- a/apps/client/app/utils/sessionBootstrap.ts
+++ b/apps/client/app/utils/sessionBootstrap.ts
@@ -75,6 +75,25 @@ export function bootstrapSession(): Promise<void> {
   return bootstrapPromise;
 }
 
+/** How close to its `exp` claim a token has to be before a refocus is worth a round trip.
+ *  Generous enough to absorb clock skew between this tab and the server. */
+const REVALIDATE_EXPIRY_BUFFER_MS = 30_000;
+
+/** Decode the `exp` claim (seconds since epoch) from a JWT without verifying the signature
+ *  (client-side only) - same pattern as UserContext's decodeTokenVersion/decodeMfaPending.
+ *  Returns null when absent, malformed, or on a legacy token with no exp claim. */
+function decodeTokenExpiryMs(token: string): number | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const payload = JSON.parse(atob(base64)) as { exp?: unknown };
+    return typeof payload.exp === 'number' ? payload.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Refocus liveness check - pure predicate, unit-testable in isolation.
  * Mirrors shouldProbeOnFailedWsConnect (WebsocketContext.tsx): decides whether a tab
@@ -86,12 +105,20 @@ export function shouldRevalidateOnFocus(params: {
   mfaPending: boolean;
   expired: boolean;
   pathname: string;
+  /** Injectable for tests; real callers take the default (now). */
+  nowMs?: number;
 }): boolean {
   if (params.visibilityState !== 'visible') return false;
   if (!params.accessToken) return false;
   if (params.mfaPending) return false;
   if (params.expired) return false;
   if (isPublicPath(params.pathname)) return false;
+  const expMs = decodeTokenExpiryMs(params.accessToken);
+  // No readable exp claim (malformed/legacy token) is treated as "could be stale" - probe
+  // rather than silently skip, matching the fail-safe direction of every guard above.
+  if (expMs !== null && expMs - (params.nowMs ?? Date.now()) > REVALIDATE_EXPIRY_BUFFER_MS) {
+    return false;
+  }
   return true;
 }
 
@@ -105,21 +132,34 @@ export function resetProbeGuardForTests(): void {
   probeInFlight = false;
 }
 
+interface IdentifyResponse {
+  user: IUserDocument;
+  accessToken: string;
+}
+
 /**
  * Liveness probe shared by revalidateSessionOnFocus (below) and WebsocketContext's
- * close-probe. Refetches the `['identify']` query directly - rather than a bare
- * `api.get('/api/identify')` - so that when the 401 interceptor refreshes the token, the
- * fresh { user, accessToken } response lands back in the SAME query cache UserProvider's
- * identify effect reads. A bare fetch would leave that cache holding the pre-refresh
- * response; the effect re-runs on the accessToken change and feeds the STALE cached token
- * right back into the store, undoing the refresh (see useGetIdentify's own doc comment on
- * this exact stale-cache-feedback failure mode).
+ * close-probe. Goes through the same `api` instance (the 401 interceptor still refreshes and
+ * retries on a genuine expiry), but on SUCCESS writes the fresh response directly into the
+ * `['identify']` query cache via setQueryData - the same cache UserProvider's identify effect
+ * reads - so a refreshed token doesn't get fed back to stale by that effect (see
+ * useGetIdentify's own doc comment on this exact stale-cache-feedback failure mode).
+ *
+ * Deliberately NOT queryClient.refetchQueries: that would also propagate a FAILED probe (a
+ * transient network error, not a real 401) into the query's error state, and
+ * resolveIdentifyEffect checks isError before isSuccess - so a laptop waking with wifi still
+ * coming up would clear currentUser and bounce the user to /login. A failed probe here just
+ * throws it away; the interceptor's own forceSessionExpiredRedirect (unaffected by this
+ * function) is still what handles a genuinely revoked session.
  */
 export function probeIdentity(queryClient: QueryClient): Promise<void> {
   if (probeInFlight) return Promise.resolve();
   probeInFlight = true;
-  return queryClient
-    .refetchQueries({ queryKey: ['identify'] })
+  return api
+    .get<IdentifyResponse>('/api/identify')
+    .then(response => {
+      queryClient.setQueryData(['identify'], response.data);
+    })
     .catch(() => {})
     .finally(() => {
       probeInFlight = false;
@@ -133,6 +173,8 @@ export function probeIdentity(queryClient: QueryClient): Promise<void> {
  * surfaces, so an idle tab's expired token could sit unrefreshed indefinitely. This fires that
  * recovery explicitly, through probeIdentity above (the SAME interceptor, no separate refresh
  * path), instead of leaving it to whichever query happens to opt in and race there first.
+ * shouldRevalidateOnFocus's exp check means a refocus well before the token's TTL elapses
+ * skips the round trip entirely, so this stays free on the common case.
  */
 export function revalidateSessionOnFocus(queryClient: QueryClient): void {
   const { accessToken, mfaPending, expired } = useAccessToken.getState();

--- a/apps/client/app/utils/sessionBootstrap.ts
+++ b/apps/client/app/utils/sessionBootstrap.ts
@@ -1,4 +1,5 @@
 import { IUserDocument } from '@bike4mind/common';
+import type { QueryClient } from '@tanstack/react-query';
 import { api, isPublicPath } from '@client/app/contexts/ApiContext';
 import { takeLegacyRefreshToken, useAccessToken } from '@client/app/hooks/useAccessToken';
 import { useUser } from '@client/app/contexts/UserContext';
@@ -94,19 +95,40 @@ export function shouldRevalidateOnFocus(params: {
   return true;
 }
 
-/** Single-flight guard so visibilitychange and focus firing together only probes once. */
-let revalidateInFlight = false;
+/** Single-flight guard, shared by every caller of probeIdentity below, so a refocus that
+ *  coincides with a WebsocketContext close-probe fires one authed round trip, not two. */
+let probeInFlight = false;
+
+/**
+ * Liveness probe shared by revalidateSessionOnFocus (below) and WebsocketContext's
+ * close-probe. Refetches the `['identify']` query directly - rather than a bare
+ * `api.get('/api/identify')` - so that when the 401 interceptor refreshes the token, the
+ * fresh { user, accessToken } response lands back in the SAME query cache UserProvider's
+ * identify effect reads. A bare fetch would leave that cache holding the pre-refresh
+ * response; the effect re-runs on the accessToken change and feeds the STALE cached token
+ * right back into the store, undoing the refresh (see useGetIdentify's own doc comment on
+ * this exact stale-cache-feedback failure mode).
+ */
+export function probeIdentity(queryClient: QueryClient): Promise<void> {
+  if (probeInFlight) return Promise.resolve();
+  probeInFlight = true;
+  return queryClient
+    .refetchQueries({ queryKey: ['identify'] })
+    .catch(() => {})
+    .finally(() => {
+      probeInFlight = false;
+    });
+}
 
 /**
  * On a tab returning from idle, `bootstrapSession` only runs at page load (see router.tsx's
- * beforeLoad), so nothing proactively checks whether the access token expired while the tab was
- * hidden. The first refetchOnWindowFocus query to 401 is what currently starts recovery via the
- * ApiContext interceptor - this fires that recovery explicitly, through the SAME interceptor
- * (no separate refresh path), instead of leaving it to whichever query happens to race there
- * first. `/api/identify` is the same cheap authed endpoint WebsocketContext's close-probe uses.
+ * beforeLoad); nothing re-validates the session on refocus. refetchOnWindowFocus defaults to
+ * false (see providers.tsx), and the handful of queries that opt in are mostly admin/settings
+ * surfaces, so an idle tab's expired token could sit unrefreshed indefinitely. This fires that
+ * recovery explicitly, through probeIdentity above (the SAME interceptor, no separate refresh
+ * path), instead of leaving it to whichever query happens to opt in and race there first.
  */
-export function revalidateSessionOnFocus(): void {
-  if (revalidateInFlight) return;
+export function revalidateSessionOnFocus(queryClient: QueryClient): void {
   const { accessToken, mfaPending, expired } = useAccessToken.getState();
   if (
     !shouldRevalidateOnFocus({
@@ -119,11 +141,5 @@ export function revalidateSessionOnFocus(): void {
   ) {
     return;
   }
-  revalidateInFlight = true;
-  api
-    .get('/api/identify')
-    .catch(() => {})
-    .finally(() => {
-      revalidateInFlight = false;
-    });
+  void probeIdentity(queryClient);
 }

--- a/apps/client/app/utils/sessionBootstrap.ts
+++ b/apps/client/app/utils/sessionBootstrap.ts
@@ -99,6 +99,12 @@ export function shouldRevalidateOnFocus(params: {
  *  coincides with a WebsocketContext close-probe fires one authed round trip, not two. */
 let probeInFlight = false;
 
+/** Drop a stuck in-flight flag (a test left its promise unsettled). Mirrors resetRefreshPromise
+ *  in ApiContext.tsx for the same guard shape. */
+export function resetProbeGuardForTests(): void {
+  probeInFlight = false;
+}
+
 /**
  * Liveness probe shared by revalidateSessionOnFocus (below) and WebsocketContext's
  * close-probe. Refetches the `['identify']` query directly - rather than a bare


### PR DESCRIPTION
## Optional Screenshot/Video
<img width="1440" height="900" alt="session-recovered-after-refocus-after" src="https://github.com/user-attachments/assets/eb27f6fa-82dd-46db-be82-7de2e58b37b7" />

*The chat shell right after a refocus that hit a simulated expired-token 401. Still logged in, composer ready, no login redirect and no reload.*

## Description
After a tab sat idle long enough for the access token to expire, refocusing it produced a storm of 401s and repeated WebSocket drops that never recovered on their own. Only a full-page reload fixed it. Nothing ran the page-load bootstrap refresh's equivalent on visibilitychange/focus, so an idle tab's expired token just sat there until some opted-in `refetchOnWindowFocus` query happened to 401 first.

Adds a refocus-triggered liveness probe that, on success, writes the fresh response directly into the identify query cache UserProvider's identify effect reads. A bare fetch with no cache write would let that effect feed the stale cached token straight back into the store, undoing the refresh; a naive `refetchQueries` would also propagate a transient network failure into the same cache and clear the logged-in user. The probe skips the round trip entirely unless the token is actually near its expiry. This also resets the WebSocket's reconnect budget on refocus, since react-use-websocket's own backoff can exhaust itself while a tab sits idle, leaving the socket dead even after the token refreshes. The pulse only fires once the budget is genuinely exhausted, so it never cancels a reconnect already in backoff.

Closes #1616

## Changes
- Add `revalidateSessionOnFocus` + `probeIdentity` (`sessionBootstrap.ts`): a shared single-flight liveness probe fired on `visibilitychange`/`focus`, gated on the token's `exp` claim so a refocus well before expiry costs nothing; on success it writes straight into the `['identify']` query cache without ever propagating a failed probe into that cache's error state
- Wire the refocus listener into `providers.tsx`
- Share `probeIdentity` with `WebsocketContext`'s existing close-probe, replacing its own local single-flight guard so a refocus landing next to a WS drop fires one round trip
- Add a refocus-triggered reconnect pulse in `WebsocketContext`, gated on the reconnect budget being genuinely exhausted (not just "not open"), that resets react-use-websocket's reconnect budget without cancelling a backoff already in progress
- Tests: guard branches, exp gating, cache-isolation-on-failure, and single-flight dedupe (`sessionBootstrap.test.ts`); probe wiring and the narrowed reconnect pulse (`WebsocketContext.test.ts`)

## Guide for Testers
This bug only manifests once the access token has genuinely expired (30 minute TTL), so the wait below is real, not padding.

1. Go to `app.staging.bike4mind.com` (or a local dev build) and log in normally.
2. Leave the tab open but switch away (another tab, another app, or lock the screen) for at least 35 minutes.
3. Return and bring the tab back to the foreground.
4. Expected: no error toast, no red 401 spam in the DevTools console, and any visible data (sidebar, chat, settings) loads normally within a few seconds, with no manual reload needed.
5. In DevTools Network, confirm one `POST /api/auth/refreshToken` succeeds shortly after refocus, not a repeated storm of 401s.
6. In DevTools Console, if `ws disconnected` had logged while idle, confirm `ws connected` logs again shortly after refocus without a reload.

What NOT to test: refocusing before the 30-minute token TTL elapses is a genuine no-op. The probe checks the token's own expiry claim and skips the network call entirely, so there is nothing to observe, and that is not a failure.

## Additional Information
Independent review caught several subtleties before this shipped: a raw fetch would have let a stale query-cache effect stomp the refreshed token right back to expired; routing the probe through a naive query refetch instead would have let a transient network failure (not a real 401) clear the logged-in user; and the WebSocket reconnect pulse needed to be gated on the backoff budget being exhausted, not just "not open," so it never cancels a reconnect already in backoff. All are handled in the diff.

## Developer Notes (Optional)
`probeIdentity` (`sessionBootstrap.ts`) is a shared, single-flight `/api/identify` liveness-probe primitive. Any other auth-adjacent client code that needs to proactively check session liveness can call it instead of writing its own probe and guard.

## Security Testing (for security-labeled PRs only)
This closes a `security`-labeled issue, but the underlying bug is a session-recovery UX defect (a storm of 401s that never self-heals), not an exploitable vulnerability. There is no attack payload to reproduce via curl. A dedicated `/security-review` pass on this diff found no new vulnerability; the server-side rotation/reuse-detection logic this fix's probe relies on is unchanged.

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment) (N/A, no vulnerability to reproduce)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment) (N/A)
- [ ] Production is assumed to match staging (no direct-to-prod deploys). If BEFORE reproduction on staging fails unexpectedly, verify no upstream fix has already landed: `git log origin/main -- <file>`

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc


