### PR TITLE
fix(auth): enforce typ + tokenVersion on WebSocket token verifiers

### DIFF
--- a/apps/client/e2e/README.md
+++ b/apps/client/e2e/README.md
@@ -144,6 +144,7 @@ setup → unauthenticated
 |---------|---------|------------|
 | **setup** | Creates test users, logs them in, saves browser state | None (creates auth) |
 | **unauthenticated** | Login and signup flows | None (tests auth UI) |
+| **websocket-auth** | WebSocket token gates (`typ`, tokenVersion revocation) | None (mints throwaway users) |
 | **admin** | Admin-only features (dashboard, settings) | `.auth/admin.json` |
 | **chromium** | Main test suite (everything except auth/signup/admin) | `.auth/user.json` |
 

--- a/apps/client/e2e/websocket-auth.spec.ts
+++ b/apps/client/e2e/websocket-auth.spec.ts
@@ -1,0 +1,191 @@
+import { type APIRequestContext, type Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+import { TIMEOUTS } from './constants';
+import { getTestRunId, getE2ETestId } from './helpers/test-users';
+import { apiCreateTestUser } from './helpers/api';
+
+/**
+ * The WebSocket verifiers ($connect, subscribe_query, unsubscribe_query) enforce the same
+ * token gates as the REST strategy: `typ` and the tokenVersion kill switch. These tests pin
+ * the observable end of that from a real deploy - a current token still gets a working
+ * realtime subscription, and a token revoked by logout no longer completes the handshake.
+ *
+ * Each test mints its own throwaway account: revoking bumps tokenVersion for ALL of a user's
+ * tokens, so a shared spec user would have its session killed for every parallel spec. The
+ * retry index is baked into the identity because createUser rejects a duplicate email, so a
+ * retry would otherwise die during setup. The email mirrors the setup convention
+ * (`...-<id>-e2e@test.com`) so global-teardown's cleanup sweep matches it.
+ */
+async function createWsUser(request: APIRequestContext, label: string) {
+  const e2eId = getE2ETestId();
+  const idSuffix = e2eId ? `${e2eId}-${getTestRunId()}` : getTestRunId();
+  const slug = `wsauth-${label}${test.info().retry}`;
+  const email = `${slug}-${idSuffix}-e2e@test.com`;
+  const result = await apiCreateTestUser(request, {
+    username: `${slug}-${idSuffix}`,
+    email,
+    name: `WsAuth ${label} ${idSuffix}`,
+    password: `E2eWsAuth${label}Pass123!`,
+    isAdmin: false,
+  });
+  return {
+    email,
+    userId: (result.user.id || result.user._id) as string,
+    accessToken: result.accessToken,
+    refreshToken: result.refreshToken,
+  };
+}
+
+const baseURL = () => process.env.API_URL || 'http://localhost:3000';
+
+async function getWebsocketUrl(request: APIRequestContext, token: string): Promise<string> {
+  const response = await request.get(`${baseURL()}/api/settings/serverConfig`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok()) throw new Error(`serverConfig failed: ${response.status()}`);
+  const { websocketUrl } = await response.json();
+  if (!websocketUrl) throw new Error('serverConfig returned no websocketUrl');
+  return websocketUrl;
+}
+
+/** Logout revokes every token the user holds by bumping tokenVersion server-side. */
+async function apiLogout(request: APIRequestContext, token: string): Promise<void> {
+  const response = await request.get(`${baseURL()}/api/logout`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok()) throw new Error(`Logout failed: ${response.status()}`);
+}
+
+/**
+ * Open a socket in the page context (the browser's WebSocket is the only WS client available
+ * to Playwright) and report whether the handshake completed. API Gateway rejects a failed
+ * $connect at the handshake, which surfaces as an error/close rather than an open.
+ */
+async function tryWsConnect(page: Page, wsUrl: string, token: string): Promise<boolean> {
+  return page.evaluate(
+    ([url, accessToken, timeoutMs]) =>
+      new Promise<boolean>(resolve => {
+        const socket = new WebSocket(`${url}?token=${encodeURIComponent(accessToken as string)}`);
+        const finish = (opened: boolean) => {
+          clearTimeout(timer);
+          try {
+            socket.close();
+          } catch {
+            // already closed
+          }
+          resolve(opened);
+        };
+        const timer = setTimeout(() => finish(false), timeoutMs as number);
+        socket.onopen = () => finish(true);
+        socket.onerror = () => finish(false);
+        socket.onclose = () => finish(false);
+      }),
+    [wsUrl, token, TIMEOUTS.ELEMENT_STATE] as const
+  );
+}
+
+/**
+ * Full subscribe round-trip: connect, subscribe to the caller's own user document with
+ * fetchInitialData, and resolve on the first data_update frame. Exercises the subscribe
+ * verifier end to end, then unsubscribes and reports whether the socket survived it.
+ */
+async function subscribeRoundTrip(
+  page: Page,
+  wsUrl: string,
+  token: string,
+  userId: string
+): Promise<{ receivedUpdate: boolean; openAfterUnsubscribe: boolean }> {
+  return page.evaluate(
+    ([url, accessToken, id, timeoutMs]) =>
+      new Promise<{ receivedUpdate: boolean; openAfterUnsubscribe: boolean }>(resolve => {
+        const subscriptionId = `e2e-ws-auth-${id}`;
+        const socket = new WebSocket(`${url}?token=${encodeURIComponent(accessToken as string)}`);
+        let receivedUpdate = false;
+        const finish = () => {
+          clearTimeout(timer);
+          if (receivedUpdate && socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ action: 'unsubscribe_query', accessToken, subscriptionId }));
+          }
+          // The unsubscribe ack is a status code on the Lambda, not a frame, so settle briefly
+          // and report whether the socket is still open - a rejected frame must not kill it.
+          setTimeout(() => {
+            const openAfterUnsubscribe = socket.readyState === WebSocket.OPEN;
+            try {
+              socket.close();
+            } catch {
+              // already closed
+            }
+            resolve({ receivedUpdate, openAfterUnsubscribe });
+          }, 1_000);
+        };
+        const timer = setTimeout(finish, timeoutMs as number);
+
+        socket.onopen = () =>
+          socket.send(
+            JSON.stringify({
+              action: 'subscribe_query',
+              accessToken,
+              subscriptionId,
+              collectionName: 'users',
+              query: { _id: id },
+              fields: { email: true },
+              fetchInitialData: true,
+            })
+          );
+        socket.onmessage = event => {
+          const message = JSON.parse(String(event.data));
+          if (message.action === 'data_update' && message.subscriptionId === subscriptionId) {
+            receivedUpdate = true;
+            finish();
+          }
+        };
+        socket.onerror = finish;
+      }),
+    [wsUrl, token, userId, TIMEOUTS.ACTION] as const
+  );
+}
+
+test.describe('WebSocket token enforcement', () => {
+  test('a current access token connects and receives its subscription data', async ({ page, request }) => {
+    const user = await createWsUser(request, 'ok');
+    const wsUrl = await getWebsocketUrl(request, user.accessToken);
+    await page.goto('/login');
+
+    expect(await tryWsConnect(page, wsUrl, user.accessToken)).toBe(true);
+
+    const { receivedUpdate, openAfterUnsubscribe } = await subscribeRoundTrip(
+      page,
+      wsUrl,
+      user.accessToken,
+      user.userId
+    );
+    expect(receivedUpdate).toBe(true);
+    expect(openAfterUnsubscribe).toBe(true);
+  });
+
+  test('a token revoked by logout is refused at connect', async ({ page, request }) => {
+    const user = await createWsUser(request, 'revoked');
+    const wsUrl = await getWebsocketUrl(request, user.accessToken);
+    await page.goto('/login');
+
+    // Positive control first: the same token must work before the revoke, so a failure below
+    // is the kill switch firing and not a broken deploy or a bad URL.
+    expect(await tryWsConnect(page, wsUrl, user.accessToken)).toBe(true);
+
+    await apiLogout(request, user.accessToken);
+
+    expect(await tryWsConnect(page, wsUrl, user.accessToken)).toBe(false);
+  });
+
+  test('a refresh token is refused at connect', async ({ page, request }) => {
+    const user = await createWsUser(request, 'refreshtok');
+    const wsUrl = await getWebsocketUrl(request, user.accessToken);
+    await page.goto('/login');
+
+    // Session-store refresh tokens are the opaque `<sid>.<secret>` form, so this is refused
+    // before the `typ` gate is even reached. The gate itself is unit-tested against a
+    // same-secret JWT refresh token (verifyWsAccessToken.test.ts, connect.test.ts), which is
+    // the case this cannot construct from the browser - it has no signing secret.
+    expect(await tryWsConnect(page, wsUrl, user.refreshToken)).toBe(false);
+  });
+});

--- a/apps/client/playwright.config.ts
+++ b/apps/client/playwright.config.ts
@@ -158,6 +158,14 @@ export default defineConfig({
       testMatch: [/(?:^|\/)auth\.spec\.ts$/, /(?:^|\/)signup\.spec\.ts$/, /(?:^|\/)mfa\.spec\.ts$/],
       dependencies: ['setup-core', 'setup-projects'],
     },
+    // WebSocket token enforcement: mints its own throwaway users (revoking a token kills every
+    // token that user holds), so it needs no shared auth state - only core setup.
+    {
+      name: 'websocket-auth',
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: [/(?:^|\/)websocket-auth\.spec\.ts$/],
+      dependencies: ['setup-core'],
+    },
     // Admin specs
     {
       name: 'admin',

--- a/apps/client/server/auth/verifyJwtPayload.ts
+++ b/apps/client/server/auth/verifyJwtPayload.ts
@@ -23,9 +23,9 @@ export async function verifyJwtPayload(
     // token presented as a Bearer access token). Missing typ = legacy pre-claim token,
     // accepted (self-expiring grace); the mfaPending access token is also typ-less and
     // handled by the mfaPending gate below. Shares isTokenTypeAcceptable with the
-    // refresh path (verifyRefreshToken) so those two REST verifiers enforce identically.
-    // NOTE: the WS/CLI verifiers (verifyToken / server/cli/auth.ts verifyJwtToken) do
-    // NOT yet apply this check - tracked as a follow-up, not covered here.
+    // refresh path (verifyRefreshToken), the CLI verifier (cli/auth.ts verifyJwtToken) and
+    // the WS verifiers (websocket/verifyWsAccessToken.ts, websocket/connect.ts) so every
+    // verifier enforces identically.
     if (!isTokenTypeAcceptable(jwt_payload.typ, 'access')) {
       return done(null, false);
     }

--- a/apps/client/server/websocket/__tests__/dataSubscribeRequest.test.ts
+++ b/apps/client/server/websocket/__tests__/dataSubscribeRequest.test.ts
@@ -16,10 +16,9 @@ vi.mock('@aws-sdk/client-apigatewaymanagementapi', () => ({
   GoneException: class GoneException extends Error {},
 }));
 
-vi.mock('@bike4mind/common', () => ({
+vi.mock('@bike4mind/common', async importOriginal => ({
+  ...(await importOriginal<typeof import('@bike4mind/common')>()),
   DataSubscribeRequestAction: { parse: (x: unknown) => x },
-  InviteType: {},
-  Permission: {},
 }));
 
 vi.mock('@bike4mind/database', () => ({

--- a/apps/client/server/websocket/__tests__/dataUnsubscribeRequest.test.ts
+++ b/apps/client/server/websocket/__tests__/dataUnsubscribeRequest.test.ts
@@ -8,7 +8,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * decides whether `previousSecret` is passed to `verifyToken`.
  */
 
-vi.mock('@bike4mind/common', () => ({
+vi.mock('@bike4mind/common', async importOriginal => ({
+  ...(await importOriginal<typeof import('@bike4mind/common')>()),
   DataUnsubscribeRequestAction: { parse: (x: unknown) => x },
 }));
 

--- a/apps/client/server/websocket/connect.test.ts
+++ b/apps/client/server/websocket/connect.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Covers the connect-time token gates only: `typ` and the tokenVersion kill switch.
+ * These must agree with the REST strategy (auth/verifyJwtPayload.ts) and the
+ * subscribe/unsubscribe path (verifyWsAccessToken.ts).
+ */
+
+const mockFindById = vi.fn();
+const mockConnectionCreate = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  User: { findById: (...args: unknown[]) => mockFindById(...args) },
+  Connection: { create: (...args: unknown[]) => mockConnectionCreate(...args) },
+}));
+
+const mockVerifyToken = vi.fn();
+vi.mock('@server/auth/tokenGenerator', () => ({
+  authTokenGenerator: { verifyToken: (...args: unknown[]) => mockVerifyToken(...args) },
+}));
+
+const mockVerifyApiKey = vi.fn();
+vi.mock('@server/cli/auth', () => ({
+  verifyApiKey: (...args: unknown[]) => mockVerifyApiKey(...args),
+}));
+
+vi.mock('@server/websocket/utils', () => ({
+  withWebSocketContext: vi.fn(
+    (handler: (event: unknown, context: unknown, logger: unknown) => Promise<unknown>) => handler
+  ),
+}));
+
+import { func } from './connect';
+
+const eventWithToken = (token = 'token-123') => ({
+  requestContext: { connectionId: 'conn-1' },
+  queryStringParameters: { token },
+  headers: {},
+});
+const noopLogger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+
+const connect = (token?: string) => func(eventWithToken(token) as any, {} as any, noopLogger as any);
+
+describe('websocket connect - token gates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifyToken.mockReturnValue({ id: 'user-1', tokenVersion: 3, typ: 'access' });
+    mockFindById.mockResolvedValue({ id: 'user-1', tokenVersion: 3, save: vi.fn() });
+    mockVerifyApiKey.mockRejectedValue(new Error('not an api key'));
+    mockConnectionCreate.mockResolvedValue({});
+  });
+
+  it('registers the connection for a current access token', async () => {
+    await expect(connect()).resolves.toEqual({ statusCode: 200 });
+    expect(mockConnectionCreate).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-1', source: 'web' }));
+  });
+
+  it('refuses a refresh token presented as a connect token', async () => {
+    mockVerifyToken.mockReturnValue({ id: 'user-1', tokenVersion: 3, typ: 'refresh' });
+
+    await expect(connect()).rejects.toThrow('Invalid authentication token');
+    expect(mockConnectionCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses a token whose tokenVersion is stale relative to the user', async () => {
+    mockVerifyToken.mockReturnValue({ id: 'user-1', tokenVersion: 2, typ: 'access' });
+
+    await expect(connect()).rejects.toThrow('Session expired');
+    expect(mockConnectionCreate).not.toHaveBeenCalled();
+  });
+
+  it('accepts a legacy token carrying no typ against a default-version user', async () => {
+    mockVerifyToken.mockReturnValue({ id: 'user-1' });
+    mockFindById.mockResolvedValue({ id: 'user-1', save: vi.fn() });
+
+    await expect(connect()).resolves.toEqual({ statusCode: 200 });
+  });
+
+  it('still allows the API-key fallback when the token is not a JWT', async () => {
+    mockVerifyToken.mockImplementation(() => {
+      throw new Error('jwt malformed');
+    });
+    mockVerifyApiKey.mockResolvedValue({ userId: 'user-1', scopes: ['ai:chat'] });
+
+    await expect(connect()).resolves.toEqual({ statusCode: 200 });
+    expect(mockConnectionCreate).toHaveBeenCalledWith(expect.objectContaining({ scopes: ['ai:chat'] }));
+  });
+});

--- a/apps/client/server/websocket/connect.ts
+++ b/apps/client/server/websocket/connect.ts
@@ -2,7 +2,7 @@ import { Connection, User } from '@bike4mind/database';
 import { ApiKeyScope } from '@bike4mind/common';
 import { Logger } from '@bike4mind/observability';
 import { authTokenGenerator } from '@server/auth/tokenGenerator';
-import { isTokenVersionCurrent } from '@bike4mind/services';
+import { isTokenTypeAcceptable, isTokenVersionCurrent } from '@bike4mind/services';
 import { verifyApiKey } from '@server/cli/auth';
 import { UnauthorizedError } from '@server/utils/errors';
 import { withWebSocketContext } from '@server/websocket/utils';
@@ -61,6 +61,12 @@ async function resolveIdentity(
   let jwtErr: unknown;
   try {
     const decoded = authTokenGenerator.verifyToken(token) as jwt.JwtPayload;
+    // Reject a token minted for a different path (e.g. a refresh token opening a socket).
+    // Missing typ = legacy pre-claim token, accepted (self-expiring grace). Thrown rather
+    // than returned so the API-key fallback below still gets its chance.
+    if (!isTokenTypeAcceptable(decoded?.typ, 'access')) {
+      throw new UnauthorizedError('Invalid token type');
+    }
     // JWT connections are always version-gated. A legacy token issued before
     // this field existed carries no version and normalizes to 0, mirroring the
     // REST path (auth.ts) so the kill switch still fires for it once the user's

--- a/apps/client/server/websocket/dataSubscribeRequest.ts
+++ b/apps/client/server/websocket/dataSubscribeRequest.ts
@@ -22,16 +22,12 @@ import { Session as SessionModel } from '@bike4mind/database/auth';
 import { accessibleBy } from '@casl/mongoose';
 import { Subscription } from '@server/models/Subscription';
 import { questMasterPlanSubscriptionScope } from '@server/websocket/subscriptionScopes';
-import { NotFoundError } from '@server/utils/errors';
 import { sendToConnection, withWebSocketContext } from '@server/websocket/utils';
+import { verifyWsAccessToken } from '@server/websocket/verifyWsAccessToken';
 import crypto from 'crypto';
-import jwt from 'jsonwebtoken';
 import { pickBy } from 'lodash';
 import pLimit from 'p-limit';
 import ability from '../auth/ability';
-import { secretRotationRepository } from '@bike4mind/database/infra';
-import { authTokenGenerator } from '@server/auth/tokenGenerator';
-import { isRotatedSecretWithinGraceWindow } from '@server/auth/secretRotationGrace';
 import { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
 import { Resource } from 'sst';
 
@@ -53,16 +49,7 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
     fetchInitialData,
   } = DataSubscribeRequestAction.parse(JSON.parse(event.body ?? ''));
 
-  const secretRotation = await secretRotationRepository.findByKeyName('JWT_SECRET');
-  let previousSecret = undefined;
-  // Accept the previous key only within the shared rotation grace window.
-  if (isRotatedSecretWithinGraceWindow(secretRotation?.rotatedAt)) {
-    previousSecret = secretRotation?.previousKey;
-  }
-  const decoded = authTokenGenerator.verifyToken(accessToken!, previousSecret) as jwt.JwtPayload;
-
-  const user = await User.findById(decoded.id);
-  if (!user) throw new NotFoundError('User not found');
+  const user = await verifyWsAccessToken(accessToken);
   const userAbility = ability(user);
 
   // 'scope' limits the scope of the query, to only things you're allowed to see.

--- a/apps/client/server/websocket/dataUnsubscribeRequest.ts
+++ b/apps/client/server/websocket/dataUnsubscribeRequest.ts
@@ -1,12 +1,8 @@
 import { DataUnsubscribeRequestAction } from '@bike4mind/common';
-import { QuerySubscription, User } from '@bike4mind/database';
-import { secretRotationRepository } from '@bike4mind/database/infra';
-import { authTokenGenerator } from '@server/auth/tokenGenerator';
-import { isRotatedSecretWithinGraceWindow } from '@server/auth/secretRotationGrace';
-import { NotFoundError } from '@server/utils/errors';
+import { QuerySubscription } from '@bike4mind/database';
+import { verifyWsAccessToken } from '@server/websocket/verifyWsAccessToken';
 import { withWebSocketContext } from '@server/websocket/utils';
 import { APIGatewayProxyWebsocketEventV2 } from 'aws-lambda';
-import jwt from 'jsonwebtoken';
 import { Resource } from 'sst';
 
 export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async (event, context, logger) => {
@@ -17,16 +13,7 @@ export const func = withWebSocketContext<APIGatewayProxyWebsocketEventV2>(async 
     JSON.parse(event.body ?? '')
   );
 
-  const secretRotation = await secretRotationRepository.findByKeyName('JWT_SECRET');
-  let previousSecret = undefined;
-  // Accept the previous key only within the shared rotation grace window.
-  if (isRotatedSecretWithinGraceWindow(secretRotation?.rotatedAt)) {
-    previousSecret = secretRotation?.previousKey;
-  }
-  const decoded = authTokenGenerator.verifyToken(accessToken!, previousSecret) as jwt.JwtPayload;
-
-  const user = await User.findById(decoded.id);
-  if (!user) throw new NotFoundError('User not found');
+  await verifyWsAccessToken(accessToken);
 
   // If this was the last subscriber, subscriber-fanout removes the record and drops
   // the change-stream subscription.

--- a/apps/client/server/websocket/verifyWsAccessToken.test.ts
+++ b/apps/client/server/websocket/verifyWsAccessToken.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFindByKeyName = vi.fn();
+vi.mock('@bike4mind/database/infra', () => ({
+  secretRotationRepository: { findByKeyName: (...args: unknown[]) => mockFindByKeyName(...args) },
+}));
+
+const mockIsWithinGraceWindow = vi.fn();
+vi.mock('@server/auth/secretRotationGrace', () => ({
+  isRotatedSecretWithinGraceWindow: (...args: unknown[]) => mockIsWithinGraceWindow(...args),
+}));
+
+const mockVerifyToken = vi.fn();
+vi.mock('@server/auth/tokenGenerator', () => ({
+  authTokenGenerator: { verifyToken: (...args: unknown[]) => mockVerifyToken(...args) },
+}));
+
+const mockFindById = vi.fn();
+vi.mock('@bike4mind/database', () => ({
+  User: { findById: (...args: unknown[]) => mockFindById(...args) },
+}));
+
+vi.mock('@server/utils/errors', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+  UnauthorizedError: class UnauthorizedError extends Error {},
+}));
+
+import { verifyWsAccessToken } from './verifyWsAccessToken';
+
+describe('verifyWsAccessToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindByKeyName.mockResolvedValue(null);
+    mockIsWithinGraceWindow.mockReturnValue(false);
+    mockVerifyToken.mockReturnValue({ id: 'user-1', tokenVersion: 3, typ: 'access' });
+    mockFindById.mockResolvedValue({ id: 'user-1', tokenVersion: 3 });
+  });
+
+  it('returns the user for a current access token', async () => {
+    await expect(verifyWsAccessToken('token-123')).resolves.toEqual({ id: 'user-1', tokenVersion: 3 });
+  });
+
+  it('rejects a token whose tokenVersion is stale relative to the user', async () => {
+    mockVerifyToken.mockReturnValue({ id: 'user-1', tokenVersion: 2, typ: 'access' });
+
+    await expect(verifyWsAccessToken('token-123')).rejects.toThrow('Session expired');
+  });
+
+  it('rejects a refresh token presented as an access token', async () => {
+    mockVerifyToken.mockReturnValue({ id: 'user-1', tokenVersion: 3, typ: 'refresh' });
+
+    await expect(verifyWsAccessToken('token-123')).rejects.toThrow('Invalid token type');
+    expect(mockFindById).not.toHaveBeenCalled();
+  });
+
+  it('accepts a legacy token carrying no typ and no tokenVersion against a default-version user', async () => {
+    mockVerifyToken.mockReturnValue({ id: 'user-1' });
+    mockFindById.mockResolvedValue({ id: 'user-1' });
+
+    await expect(verifyWsAccessToken('token-123')).resolves.toEqual({ id: 'user-1' });
+  });
+
+  it('fires the kill switch on a legacy token once the user version is bumped', async () => {
+    mockVerifyToken.mockReturnValue({ id: 'user-1' });
+    mockFindById.mockResolvedValue({ id: 'user-1', tokenVersion: 1 });
+
+    await expect(verifyWsAccessToken('token-123')).rejects.toThrow('Session expired');
+  });
+
+  it('throws when the decoded user no longer exists', async () => {
+    mockFindById.mockResolvedValue(null);
+
+    await expect(verifyWsAccessToken('token-123')).rejects.toThrow('User not found');
+  });
+
+  it('passes the rotated previousKey only within the grace window', async () => {
+    mockFindByKeyName.mockResolvedValue({ rotatedAt: new Date(), previousKey: 'prev-secret' });
+    mockIsWithinGraceWindow.mockReturnValue(true);
+
+    await verifyWsAccessToken('token-123');
+
+    expect(mockVerifyToken).toHaveBeenCalledWith('token-123', 'prev-secret');
+  });
+});

--- a/apps/client/server/websocket/verifyWsAccessToken.ts
+++ b/apps/client/server/websocket/verifyWsAccessToken.ts
@@ -1,0 +1,41 @@
+import { User } from '@bike4mind/database';
+import { secretRotationRepository } from '@bike4mind/database/infra';
+import { isTokenTypeAcceptable, isTokenVersionCurrent } from '@bike4mind/services';
+import { isRotatedSecretWithinGraceWindow } from '@server/auth/secretRotationGrace';
+import { authTokenGenerator } from '@server/auth/tokenGenerator';
+import { NotFoundError, UnauthorizedError } from '@server/utils/errors';
+import jwt from 'jsonwebtoken';
+
+/**
+ * Rotation-aware access-token verification for the data subscribe/unsubscribe WS actions.
+ *
+ * Applies the same three gates as the REST strategy (auth/verifyJwtPayload.ts) and the CLI
+ * verifier (cli/auth.ts verifyJwtToken): signature (with the rotation grace window), the
+ * `typ` claim, and the tokenVersion kill switch. MUST stay in sync with those two - any gate
+ * missing here lets a revoked or wrong-type token ride the socket after REST already refused it.
+ */
+export async function verifyWsAccessToken(accessToken: string | undefined) {
+  const secretRotation = await secretRotationRepository.findByKeyName('JWT_SECRET');
+  let previousSecret = undefined;
+  // Accept the previous key only within the shared rotation grace window.
+  if (isRotatedSecretWithinGraceWindow(secretRotation?.rotatedAt)) {
+    previousSecret = secretRotation?.previousKey;
+  }
+  const decoded = authTokenGenerator.verifyToken(accessToken!, previousSecret) as jwt.JwtPayload;
+
+  // Missing typ = legacy pre-claim token, accepted (self-expiring grace). See the helper.
+  if (!isTokenTypeAcceptable(decoded.typ, 'access')) {
+    throw new UnauthorizedError('Invalid token type');
+  }
+
+  const user = await User.findById(decoded.id);
+  if (!user) throw new NotFoundError('User not found');
+
+  // Legacy tokens carry no version and normalize to 0, so they stay valid until a revoke
+  // bumps the user's version.
+  if (!isTokenVersionCurrent(decoded.tokenVersion, user.tokenVersion)) {
+    throw new UnauthorizedError('Session expired');
+  }
+
+  return user;
+}


### PR DESCRIPTION
# Pull Request

Closes #1195

## Description

Some WebSocket verifiers checked only the JWT signature, so a token the REST and CLI verifiers would already refuse still rode the socket:

- `dataSubscribeRequest.ts` — signature only: no `tokenVersion` kill switch, no `typ` gate
- `dataUnsubscribeRequest.ts` — same
- `connect.ts` (`$connect`) — gated `tokenVersion`, but not `typ`

Concretely: a token captured before a logout / admin force-logout / MFA bump kept working on the realtime subscribe paths until its natural 7-day TTL, and a refresh token (signed with the same secret as access tokens) could be presented anywhere a WS access token was expected.

The enforcement predicates already existed and are already used by the REST strategy (`verifyJwtPayload.ts`), the refresh path (`verifyRefreshToken`) and the CLI verifier (`cli/auth.ts`). This applies them on the WS paths so every verifier enforces the same three gates: signature (with the rotation grace window), `typ`, and `tokenVersion`.

`typ`/`tokenVersion` both keep their "missing normalizes to valid" shape, so no live session is logged out on deploy — legacy pre-claim tokens age out within their TTL, and the kill switch starts firing for them once the user's version is bumped.

## Changes

- New `apps/client/server/websocket/verifyWsAccessToken.ts` — the rotation-aware verify that `dataSubscribeRequest` and `dataUnsubscribeRequest` had duplicated inline, now also applying `isTokenTypeAcceptable(typ, 'access')` and `isTokenVersionCurrent`. Both handlers call it; the duplicated blocks are gone.
- `connect.ts` — added the `typ` gate to the JWT branch of `resolveIdentity`. Thrown rather than returned so the API-key fallback still gets its chance (an API key is not a JWT and must keep working).
- `verifyJwtPayload.ts` — removed the now-stale "the WS/CLI verifiers do NOT yet apply this check" note; it lists the sibling verifiers instead.
- Unit tests: `verifyWsAccessToken.test.ts` (stale `tokenVersion` refused, refresh token refused, legacy no-`typ`/no-version token accepted, kill switch fires on a legacy token once the user version is bumped) and a new `connect.test.ts` for the same gates plus the API-key fallback.
- E2E: new `e2e/websocket-auth.spec.ts` and a `websocket-auth` Playwright project — a current token connects and completes a subscribe round-trip; a token revoked by logout is refused at connect; a refresh token is refused at connect. Each test mints its own throwaway user because revoking bumps `tokenVersion` for every token that user holds. The `websocket-auth` project is deliberately **not** in the Core gate set: it depends on a live WS deploy, and the Core set is meant to stay fast and deterministic.

Note on the refresh-token E2E case: session-store refresh tokens are the opaque `<sid>.<secret>` form, so that case is refused on signature/parse before the `typ` gate is reached. The gate itself needs a same-secret JWT refresh token, which the browser cannot mint — that is covered by the unit tests instead.

### Out of scope (two gaps found while here, neither changed)

- **`sid` revocation.** The session store has landed on `main` (access tokens now carry `sid`, and `authSessionService` exposes `revokeBySid` / `revokeAllByUserId`), but *no* verifier checks whether a token's `sid` points at a revoked session — not REST, not the CLI, not the WS paths. So this is a cross-cutting follow-up for every verifier rather than a WS-specific gap, and enforcing it only here would put the WS paths ahead of REST instead of level with it. Worth its own issue.
- **`mfaPending` on the WS paths.** `cli/auth.ts` rejects a first-factor-only token; the WS paths do not. `mfaPending` tokens are minted by raw `jwt.sign` with no `typ`, so the `typ` gate added here does not catch them. Also worth its own issue.

## Guide for Testers

Backend-only change; there is no UI surface. Regression risk is "realtime silently stops working", so the checks below are about the app still receiving live updates.

### Regression Checks

1. Open the app on the PR preview env (`app.pr<N>.<preview-domain>`) and log in normally.
2. Open a notebook and send any message (e.g. type `Hello, how are you?` and submit). Expected: the response streams in token by token within 10 seconds. Streaming arrives over the WebSocket, so this fails outright if `$connect` or `subscribe_query` regressed.
3. Leave that tab open. In a second browser window, log in as the **same** user and rename a session in the sidebar. Expected: the rename appears in the first tab within a few seconds without a refresh (live subscription delivering an update).
4. Open DevTools → Network → WS in the first tab. Expected: exactly one WebSocket connection in state `101 Switching Protocols`, not a repeating connect/fail loop.
5. Click your avatar → Logout, then log back in. Expected: login succeeds and step 2 works again (the new token's `tokenVersion` matches).

### Revocation behavior (the actual fix)

Access tokens are 30m, so run steps 6-8 back to back — a token that expires on its own proves nothing about the kill switch.

6. Log in on the preview env and capture the current access token. It is held in JS memory now (not localStorage), so take it from DevTools → Network: click any `/api/...` request and copy the token out of its `Authorization: Bearer <token>` request header.
7. In a second browser (or an incognito window) log in as the **same** user and click Logout. This bumps the user's `tokenVersion` server-side, revoking every token that user holds.
8. Back in DevTools Console of any page on the preview origin, run:
   ```js
   const cfg = await (await fetch('/api/settings/serverConfig', { headers: { Authorization: 'Bearer <PASTE_TOKEN_FROM_STEP_6>' } })).json();
   const ws = new WebSocket(`${cfg.websocketUrl}?token=<PASTE_TOKEN_FROM_STEP_6>`);
   ws.onopen = () => console.log('OPENED - BUG');
   ws.onclose = () => console.log('REFUSED - correct');
   ```
   Note `/api/settings/serverConfig` itself will 401 with the revoked token after step 7, which is the REST side already working — grab `websocketUrl` before step 7 if so.
   Expected: `REFUSED - correct`. On `main` this logs `OPENED - BUG`.

### What NOT to test

- No UI, styling, or copy changed.
- No admin settings, migrations, or infra changes.
- API-key WebSocket connections (CLI bridge) are deliberately untouched: they resolve no `tokenVersion` and are not JWTs, so neither new gate applies to them.

## Additional Information

Part of #1187. Sibling of the hybrid-session-storage work (#1188), which has since landed — see the `sid` note above for why that does not extend this PR's scope.

Verified locally after rebasing onto current `main`: `pnpm turbo:typecheck`, `pnpm turbo:test`, and `pnpm lint:check` are green. Run the test suite with `VITEST_MAX_WORKERS=2`; at full worker count the client and database packages oversubscribe CPU on one machine and produce unrelated flakes. The E2E spec has **not** been executed — it needs a deployed preview env, so it first runs when a maintainer adds `run-e2e`.

## Security Testing (for security-labeled PRs only)

- [ ] Vulnerability reproduced on **staging** with a script/curl (output attached as PR comment)
- [ ] Fix verified on **PR preview** env with the same script (output attached as PR comment)
- [ ] Production is assumed to match staging (no direct-to-prod deploys).

Both boxes are unchecked because I have no deploy access to staging or to a preview env. The repro/verify script is the DevTools snippet in step 8 above, and the E2E spec added here automates exactly that pair (positive control before the revoke, refusal after) once a preview exists. `git log origin/main -- apps/client/server/websocket/` confirms no upstream fix has landed for these paths.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) — n/a, no new settings
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) — n/a, no UI
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc — n/a
