### PR TITLE
fix(llm-utils): stop silently dropping array-content user messages with no image block

### DIFF
--- a/b4m-core/utils/src/llm/utils.test.ts
+++ b/b4m-core/utils/src/llm/utils.test.ts
@@ -2677,6 +2677,16 @@ describe('array-content fabMessages that carry no image block', () => {
     expect(warnings()).toContain('untyped');
     expect(warnings()).toContain('Dropped 1');
   });
+
+  it('does not throw on a null content block', async () => {
+    const fab: IMessage[] = [{ role: 'user', content: [null] as any }];
+
+    await expect(
+      buildAndSortMessages([], fab, [], 10000, {}, 5, mockLogger as any, createMockTokenizer())
+    ).resolves.toBeDefined();
+    expect(warnings()).toContain('untyped');
+    expect(warnings()).toContain('Dropped 1');
+  });
 });
 
 // A file cut to fit must say so. Without this the model treats the last surviving row as the end of

--- a/b4m-core/utils/src/llm/utils.test.ts
+++ b/b4m-core/utils/src/llm/utils.test.ts
@@ -2516,6 +2516,169 @@ describe('history windowing edge cases', () => {
   });
 });
 
+describe('array-content fabMessages that carry no image block', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const warnings = () => mockLogger.warn.mock.calls.map(call => String(call[0])).join('\n');
+
+  it('delivers a text-only array-content message to the model (fails against the old two-filter split)', async () => {
+    const fab: IMessage[] = [{ role: 'user', content: [{ type: 'text', text: 'MARKER-TEXT-BLOCK from the caller' }] }];
+
+    const result = await buildAndSortMessages(
+      [],
+      fab,
+      [{ role: 'user', content: 'ASK-MARKER' }],
+      10000,
+      {},
+      5,
+      mockLogger as any,
+      createMockTokenizer()
+    );
+
+    const blocks = result.flatMap(m => (Array.isArray(m.content) ? m.content : []));
+    expect(
+      blocks.some(block => block.type === 'text' && (block as { text: string }).text.includes('MARKER-TEXT-BLOCK'))
+    ).toBe(true);
+    // Assembled ahead of the prompt, like any other content message.
+    const contentIndex = result.findIndex(m => Array.isArray(m.content));
+    const promptIndex = result.findIndex(m => m.content === 'ASK-MARKER');
+    expect(contentIndex).toBeGreaterThanOrEqual(0);
+    expect(contentIndex).toBeLessThan(promptIndex);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('drops a tool_result-bearing array-content message with a warning naming what and why', async () => {
+    const fab: IMessage[] = [
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_x', content: 'TOOL-PAYLOAD-DO-NOT-LOG' }] },
+    ];
+
+    const result = await buildAndSortMessages(
+      [],
+      fab,
+      [{ role: 'user', content: 'ASK-MARKER' }],
+      10000,
+      {},
+      5,
+      mockLogger as any,
+      createMockTokenizer()
+    );
+
+    const blocks = result.flatMap(m => (Array.isArray(m.content) ? m.content : []));
+    expect(blocks.some(block => block.type === 'tool_result')).toBe(false);
+    expect(warnings()).toContain('tool_result');
+    expect(warnings()).toContain('Dropped 1');
+    expect(warnings()).toContain('message 1');
+    expect(warnings()).not.toContain('TOOL-PAYLOAD-DO-NOT-LOG');
+    expect(result.some(m => m.content === 'ASK-MARKER')).toBe(true);
+  });
+
+  it('drops a mixed text+tool_result message whole, not just the tool_result block', async () => {
+    const fab: IMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'PARTNER-TEXT' },
+          { type: 'tool_result', tool_use_id: 'toolu_y', content: 'irrelevant' },
+        ],
+      },
+    ];
+
+    const result = await buildAndSortMessages([], fab, [], 10000, {}, 5, mockLogger as any, createMockTokenizer());
+
+    const text = result
+      .flatMap(m => (Array.isArray(m.content) ? m.content : []))
+      .filter(block => block.type === 'text')
+      .map(block => (block as { text: string }).text)
+      .join('');
+    expect(text).not.toContain('PARTNER-TEXT');
+    expect(warnings()).toContain('text');
+    expect(warnings()).toContain('tool_result');
+  });
+
+  it('keeps image priority when an image block shares an array with a tool_result block', async () => {
+    const fab: IMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+          { type: 'tool_result', tool_use_id: 'toolu_z', content: 'irrelevant' },
+        ],
+      },
+    ];
+
+    const result = await buildAndSortMessages([], fab, [], 10000, {}, 5, mockLogger as any, createMockTokenizer());
+
+    // Classified as an image message (not dropped as "undeliverable blocks") - the image-priority
+    // check runs before the allowlist/drop check. The tool_result block riding alongside it is then
+    // stripped by ensureToolPairingIntegrity's orphan cleanup at the very end (no tool_use exists
+    // anywhere in this call to pair it with), which is correct and separate from classification.
+    const imageMessage = result.find(
+      m => Array.isArray(m.content) && m.content.some(block => (block as { type?: string }).type === 'image')
+    );
+    expect(imageMessage).toBeDefined();
+    expect(warnings()).not.toContain('Dropped');
+  });
+
+  it('drops empty array content with a warning, never as a blank message', async () => {
+    const fab: IMessage[] = [{ role: 'user', content: [] }];
+
+    const result = await buildAndSortMessages([], fab, [], 10000, {}, 5, mockLogger as any, createMockTokenizer());
+
+    expect(result.every(m => !Array.isArray(m.content) || m.content.length > 0)).toBe(true);
+    expect(warnings()).toContain('Ignored 1');
+    expect(warnings()).toContain('empty content array');
+  });
+
+  it('drops a thinking-only array-content message with a named warning', async () => {
+    const fab: IMessage[] = [{ role: 'user', content: [{ type: 'thinking', thinking: 'internal reasoning' }] }];
+
+    const result = await buildAndSortMessages([], fab, [], 10000, {}, 5, mockLogger as any, createMockTokenizer());
+
+    const blocks = result.flatMap(m => (Array.isArray(m.content) ? m.content : []));
+    expect(blocks.some(block => block.type === 'thinking')).toBe(false);
+    expect(warnings()).toContain('thinking');
+    expect(warnings()).toContain('Dropped 1');
+  });
+
+  it('delivers two qualifying text-only array-content messages in order', async () => {
+    const fab: IMessage[] = [
+      { role: 'user', content: [{ type: 'text', text: 'MARKER-A' }] },
+      { role: 'user', content: [{ type: 'text', text: 'MARKER-B' }] },
+    ];
+
+    const result = await buildAndSortMessages([], fab, [], 10000, {}, 5, mockLogger as any, createMockTokenizer());
+
+    const text = (m: IMessage) => (Array.isArray(m.content) ? ((m.content[0] as { text?: string }).text ?? '') : '');
+    const indexA = result.findIndex(m => text(m).includes('MARKER-A'));
+    const indexB = result.findIndex(m => text(m).includes('MARKER-B'));
+    expect(indexA).toBeGreaterThanOrEqual(0);
+    expect(indexB).toBeGreaterThanOrEqual(0);
+    expect(indexA).toBeLessThan(indexB);
+  });
+
+  it('ignores a non-user-role fabMessage with a named warning (the split-filter hole beyond user array content)', async () => {
+    const fab: IMessage[] = [{ role: 'assistant', content: 'ROLE-MARKER should never reach the model this way' }];
+
+    const result = await buildAndSortMessages([], fab, [], 10000, {}, 5, mockLogger as any, createMockTokenizer());
+
+    expect(result.some(m => typeof m.content === 'string' && m.content.includes('ROLE-MARKER'))).toBe(false);
+    expect(warnings()).toContain('Ignored 1');
+    expect(warnings()).toContain('role assistant');
+  });
+
+  it('does not throw on an untyped content block', async () => {
+    const fab: IMessage[] = [{ role: 'user', content: [{}] as any }];
+
+    await expect(
+      buildAndSortMessages([], fab, [], 10000, {}, 5, mockLogger as any, createMockTokenizer())
+    ).resolves.toBeDefined();
+    expect(warnings()).toContain('untyped');
+    expect(warnings()).toContain('Dropped 1');
+  });
+});
+
 // A file cut to fit must say so. Without this the model treats the last surviving row as the end of
 // the file and answers about it confidently - QA hit exactly that, reading a mid-file row as the
 // final row of a 416-row CSV.

--- a/b4m-core/utils/src/llm/utils.ts
+++ b/b4m-core/utils/src/llm/utils.ts
@@ -244,6 +244,13 @@ const urlDerivedMessages = new WeakSet<IMessage>();
  */
 const IMAGE_TOKEN_ESTIMATE = 1600;
 
+/**
+ * Block types a caller-supplied user-role message can deliver on its own. An allowlist rather than
+ * a denylist, so a block type added to MessageContentTypes later is dropped loudly by the
+ * classifier below instead of forwarded to a provider that rejects it.
+ */
+const DELIVERABLE_USER_BLOCK_TYPES = new Set<string>(['text']);
+
 /** Bounded so building a log label never walks a multi-MB attachment. */
 const ATTACHMENT_LABEL_SCAN_CHARS = 400;
 
@@ -2126,9 +2133,76 @@ export async function buildAndSortMessages(
   // CSS classes only", and said nothing about publishing - so the model followed it and produced
   // non-publishable artifacts. It has been removed so ArtifactEmissionPrompt is the single source of truth.
 
-  const nonImageMessages: IMessage[] = fabMessages.filter(
-    message => message.role === 'user' && !Array.isArray(message.content)
-  );
+  // Classifies every non-system fabMessage into exactly one bucket (system messages are handled by
+  // systemCandidates below), rather than two positive filters that could both miss a message: a
+  // role:user array-content message with no image block (only text, or a tool_use/tool_result/
+  // thinking block) used to match neither the old nonImageMessages nor imageMessages filter and
+  // vanish with no trace. This is reachable today - extraContextMessages accepts z.array(z.any())
+  // content, so a caller can post exactly that shape.
+  const imageMessages: IMessage[] = [];
+  const nonImageMessages: IMessage[] = [];
+  const undeliverableBlockMessages: Array<{ index: number; message: IMessage }> = [];
+  const unassignableMessages: Array<{ index: number; message: IMessage }> = [];
+
+  fabMessages.forEach((message, index) => {
+    if (message.role === 'system') return; // handled by systemCandidates below
+    if (message.role !== 'user') {
+      unassignableMessages.push({ index, message });
+      return;
+    }
+    const blocks = message.content;
+    if (!Array.isArray(blocks)) {
+      nonImageMessages.push(message);
+      return;
+    }
+    if (blocks.length === 0) {
+      unassignableMessages.push({ index, message });
+      return;
+    }
+    // Image priority checked first so a block mixing an image with e.g. a tool_result still delivers
+    // as an image message rather than being caught by the undeliverable-block bucket below.
+    if (blocks.some(isImageBlock)) {
+      imageMessages.push(message);
+      return;
+    }
+    if (blocks.every(block => DELIVERABLE_USER_BLOCK_TYPES.has((block as { type?: string })?.type ?? ''))) {
+      nonImageMessages.push(message);
+      return;
+    }
+    undeliverableBlockMessages.push({ index, message });
+  });
+
+  // Content-free labels (block types, position, est. tokens only - never payload text), matching the
+  // no-content-in-logs convention attachmentLabel already follows below.
+  const blockTypesLabel = ({ index, message }: { index: number; message: IMessage }): string => {
+    const types = Array.isArray(message.content)
+      ? Array.from(new Set(message.content.map(block => (block as { type?: string })?.type ?? 'untyped')))
+      : [];
+    return `message ${index + 1} [${types.join(', ')}] (~${estimateMessageTokens(message)} est. tokens)`;
+  };
+
+  if (undeliverableBlockMessages.length > 0) {
+    logger.warn(
+      `Dropped ${undeliverableBlockMessages.length} user context message(s) carrying block types that cannot ` +
+        `be delivered in a user turn: ${undeliverableBlockMessages.map(blockTypesLabel).join(' | ')}. A ` +
+        `tool_result supplied here has no tool_use to pair with - replayed history already pairs every ` +
+        `tool_use it emits - so it would be stripped as an orphan after assembly; a thinking block is ` +
+        `assistant-only and the provider rejects it on a user turn.`
+    );
+  }
+  if (unassignableMessages.length > 0) {
+    logger.warn(
+      `Ignored ${unassignableMessages.length} context message(s) assembly has no slot for: ` +
+        `${unassignableMessages
+          .map(
+            ({ index, message }) =>
+              `message ${index + 1} (role ${message.role}${
+                Array.isArray(message.content) && message.content.length === 0 ? ', empty content array' : ''
+              })`
+          )
+          .join(' | ')}. Only system and user messages are assembled from this argument.`
+    );
+  }
 
   // Attached content is reserved out of the budget BEFORE system instructions are charged against it,
   // and only on a turn that actually carries a file: with no attachment the reserve is 0 and the cap
@@ -2237,6 +2311,12 @@ export async function buildAndSortMessages(
   // not. URL-derived content opens with the fetched page body and has no header at all, so it is
   // labelled positionally rather than by echoing what it contains.
   const attachmentLabel = (message: IMessage, index: number): string => {
+    // Array content (e.g. caller-supplied text blocks routed here by the classifier above) has no
+    // filename header to find; naming it "attachment N" would misreport a context block as a file.
+    if (Array.isArray(message.content)) {
+      const types = Array.from(new Set(message.content.map(block => (block as { type?: string })?.type ?? 'untyped')));
+      return `context blocks [${types.join(', ')}] (~${estimateMessageTokens(message)} est. tokens)`;
+    }
     const head = messageContentText(message).slice(0, ATTACHMENT_LABEL_SCAN_CHARS);
     const named: string[] = [];
     for (const pattern of ATTACHMENT_NAME_HEADERS) {
@@ -2345,8 +2425,15 @@ export async function buildAndSortMessages(
   // counting it would report a truncation on a completely healthy turn. URL-derived content is
   // excluded on the same grounds: it rides in this block but is not an attachment, and counting it
   // made the note claim a file was lost on turns where the file arrived whole, or where the prompt
-  // carried only a link and no file existed at all.
-  const isAttachment = (message: IMessage): boolean => !urlDerivedMessages.has(message) && fileTokens(message) > 0;
+  // carried only a link and no file existed at all. The array-content builders that exist today
+  // (processUrlsFromPrompt's image URLs, processFabFilesServer's image blocks) emit image-only
+  // arrays, which imageMessages claims before nonImageMessages ever sees them - so nonImageMessages
+  // only ever held string content until the classifier above started routing caller-supplied
+  // array-content context blocks here too. The string guard excludes those: without it, one could
+  // join attachmentsWithContent, get told to the model as an undelivered FILE it never was, and be
+  // deleted outright by the sliver rule below.
+  const isAttachment = (message: IMessage): boolean =>
+    typeof message.content === 'string' && !urlDerivedMessages.has(message) && fileTokens(message) > 0;
   const attachmentsWithContent = nonImageMessages.filter(isAttachment);
   let undeliveredNote: IMessage | null = null;
 
@@ -2418,14 +2505,6 @@ export async function buildAndSortMessages(
   };
 
   processedContentMessages = declareUndeliveredAttachments(processedContentMessages);
-
-  // Separate image and non-image messages
-  const imageMessages: IMessage[] = fabMessages.filter(
-    message =>
-      message.role === 'user' &&
-      Array.isArray(message.content) &&
-      message.content.some(obj => obj.type.startsWith('image'))
-  );
 
   // Check if the user prompt contains a tool_result
   const promptHasToolResult = userPrompt.some(

--- a/b4m-core/utils/src/llm/utils.ts
+++ b/b4m-core/utils/src/llm/utils.ts
@@ -271,7 +271,11 @@ const estimateTokenLength = (text: string): number => {
   return Math.ceil(text.length / CHARS_PER_TOKEN);
 };
 
-const isImageBlock = (obj: { type?: string }): boolean => obj.type === 'image' || obj.type === 'image_url';
+// Array content is caller-controlled (extraContextMessages accepts z.array(z.any())), so a block can
+// be null/undefined/not-an-object at runtime despite the static type; every caller here iterates raw
+// message.content, so the null-safety has to live in this one shared helper rather than at each call site.
+const isImageBlock = (obj: { type?: string } | null | undefined): boolean =>
+  obj?.type === 'image' || obj?.type === 'image_url';
 
 /**
  * Flattens a message's content to its text, skipping image blocks - their base64 payload is not text


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="893" height="445" alt="live-extraContextMessages-proof-before" src="https://github.com/user-attachments/assets/15715f77-44f8-47f0-8ac6-7eaca3f3a012" />

*Before (staging, main): `POST /api/ai/llm` with an array-content-only `extraContextMessages` entry carrying a passphrase. The model replies that it has no such passphrase, proving the message never reached it.*

<img width="893" height="355" alt="live-extraContextMessages-proof-after" src="https://github.com/user-attachments/assets/5f4f4dc0-4911-4708-9199-761f6b0b4b2f" />

*After (this PR's live preview): the same request, same passphrase. The model echoes it back correctly, proving the fix delivers the message.*

## Description
`buildAndSortMessages` partitioned incoming context messages with two positive filters that left a gap: a `role: 'user'` message whose content is an array but carries no image block (only text, or a `tool_use`/`tool_result`/`thinking` block) matched neither filter and was dropped with no trace. This is reachable today via the `extraContextMessages` request field, which accepts arbitrary array content, so an accepted API input was being silently discarded.

Replaces the two filters with one exhaustive classification pass so every message lands in exactly one bucket. Text-only array content now goes through the same budget/truncation pipeline as string content. A `tool_use`/`tool_result`/`thinking`-bearing message can't be delivered safely from this argument (tool pairing is reconstructed from conversation history, not from this input), so those are dropped with a warning naming what was dropped and why, instead of vanishing silently. Also closes the same gap for any non-user/non-system message, and fixes a `.startsWith('image')` check that could throw on a malformed block.

Closes #1113

## Changes
- Replace the two-filter `nonImageMessages`/`imageMessages` split in `buildAndSortMessages` with one exhaustive classification pass (image / text-only / undeliverable-blocks / unassignable-role)
- Log a warning naming what was dropped and why, for both the tool/thinking-bearing case and any non-user/non-system message
- Guard `isAttachment` and `attachmentLabel` so array-content context blocks are never mislabeled or accounted as a file attachment
- Swap a throw-prone `.startsWith('image')` check for the existing null-safe `isImageBlock` helper
- Add 8 tests covering the new classification, the drop-with-warning path, and the existing image-priority/edge-case behavior

## Guide for Testers
The bug is reachable live via the `extraContextMessages` request field on `POST /api/ai/llm`. There is no UI affordance for it; only a programmatic caller (an API-key integration) would send this shape today.

1. Authenticate (bearer token) and call:
   ```
   POST /api/ai/llm
   {
     "message": "Reply with ONLY the archive passphrase mentioned in your context above, and nothing else.",
     "fabFileIds": [], "messageFileIds": [], "historyCount": 0,
     "params": { "model": "<any available text model, see GET /api/models>" },
     "extraContextMessages": [
       { "role": "user", "content": [{ "type": "text", "text": "Archive note: the archive passphrase is zamboni-quartz-19." }] }
     ]
   }
   ```
2. Poll `GET /api/quests/{id}` (the `quest.id` from the response above) until `replies` is non-empty.
3. On this PR: the reply contains `zamboni-quartz-19`. On main/staging (pre-fix): the model says it has no such passphrase in its context, meaning the message never reached it. See the screenshots above for a captured run of both against staging (before) and this PR's preview (after).
4. Quick local check: run `pnpm --filter @bike4mind/utils test -- utils.test.ts`. All tests pass, including the new suite `array-content fabMessages that carry no image block`. Reverting just `utils.ts` to `origin/main` and re-running fails that suite, including one test that throws a `TypeError` before the fix.

## Additional Information
N/A

## Developer Notes (Optional)
N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
