### PR TITLE
fix(services): enforce the embedding-model invariant at its only writer

### DIFF
--- a/b4m-core/services/src/dataLakeService/embeddingMismatch.test.ts
+++ b/b4m-core/services/src/dataLakeService/embeddingMismatch.test.ts
@@ -33,6 +33,18 @@ describe('isForeignEmbeddingModel', () => {
     // ada-002 and 3-small are both 1536 dims, so only the label can tell them apart.
     expect(isForeignEmbeddingModel(SMALL_3, ADA)).toBe(true);
   });
+
+  // Pins the DELIBERATE choice not to case-fold, so adding a `.toLowerCase()` here has to be a
+  // conscious decision rather than a tidy-up that silently changes what gets excluded. Folding
+  // would hide a malformed label, and an unrecognized id already fails CLOSED further down the
+  // stack (fab-pipeline's ALL_MODEL_DIMENSIONS is a Map, so an unknown key degrades to the
+  // brute-force scan rather than a bogus index target). The write path is what keeps a mis-cased
+  // label out of the database in the first place - see chunkFileSchema in fabFileService/chunk.ts,
+  // the only writer of FabFile.embeddingModel.
+  it('treats a case variant as foreign - the label is compared verbatim, never folded', () => {
+    expect(isForeignEmbeddingModel('Text-Embedding-Ada-002', ADA)).toBe(true);
+    expect(isForeignEmbeddingModel(ADA, 'TEXT-EMBEDDING-ADA-002')).toBe(true);
+  });
 });
 
 describe('classifyLoadedChunk', () => {

--- a/b4m-core/services/src/dataLakeService/embeddingMismatch.ts
+++ b/b4m-core/services/src/dataLakeService/embeddingMismatch.ts
@@ -143,8 +143,35 @@ export interface EmbeddingLabeledFile {
  * rest on positive evidence, so an unknown label is always given the benefit of the doubt and the
  * chunk is scored (and counted under `unlabeled`).
  *
- * No case folding: every id in the embedding-model enums is already canonical lowercase, so
- * folding would only mask a genuinely malformed label.
+ * No case folding, and the exact match is LOAD-BEARING rather than incidental - so it is worth
+ * being precise about what actually backs it, because the embedding-model enums do not. The
+ * `FabFile.embeddingModel` field this reads is a bare `String` with no `enum` and no `lowercase`
+ * (packages/database FabFileSchema), so canonical-lowercase storage rests on the write path, in
+ * two halves:
+ *  - the QUERY model can only be a canonical id: `defaultEmbeddingModel` is declared with an
+ *    `options` list, which makeStringSetting turns into a membership check that the settings
+ *    update route runs on every admin write.
+ *  - the STORED label has exactly one writer - chunkFabfile (fabFileService/chunk.ts) - whose
+ *    `chunkFileSchema` validates it against SupportedEmbeddingModelSchema before the file is
+ *    saved. Chunk labels are stamped from that same validated value by the vectorize handler and by
+ *    the chunk-model backfill script (packages/scripts/datalake).
+ *
+ * Folding here would therefore mask a malformed label without buying anything, and a malformed
+ * label is exactly what should stay visible. An unrecognized id also already fails CLOSED one
+ * layer down: fab-pipeline keys its Atlas index registry with a Map, so an unknown model yields
+ * no index target and the search degrades to the brute-force scan instead of querying a bogus one.
+ *
+ * CANONICAL LIST - three other readers compare this same field to the query's as an exact string,
+ * and each holds its OWN copy of the rule rather than calling this function:
+ *  - the corpus defer gate (llm/ChatCompletionProcess.ts),
+ *  - isFabFileCitable (apps/client/server/memory/lakeSourceReachability.ts),
+ *  - the Atlas `$vectorSearch` `filter: { embeddingModel }` clause (packages/database
+ *    FabFileChunkRepository.vectorSearch).
+ *
+ * So relaxing the comparison HERE does not propagate to them - it makes the four DIVERGE, which is
+ * the actual hazard: the rule has to move in lockstep across all four or not at all. The first two
+ * are also deliberately STRICTER than this predicate (they count an unlabeled file as unreachable
+ * where this one scores it), and their own comments explain why the three must not be consolidated.
  */
 export function isForeignEmbeddingModel(parentModel: string | null | undefined, queryModel: string): boolean {
   const parent = parentModel?.trim();

--- a/b4m-core/services/src/fabFileService/chunk.test.ts
+++ b/b4m-core/services/src/fabFileService/chunk.test.ts
@@ -105,4 +105,24 @@ describe('chunkFabfile', () => {
     expect(mockAdapter.db.fabFileChunks.distinctEmbeddingModelsByFabFileIds).not.toHaveBeenCalled();
     expect(result).toEqual([]);
   });
+
+  // Rejecting at the boundary is what keeps an unmatchable label out of the database: this is the
+  // only writer of FabFile.embeddingModel, and a mis-cased value reads as positively FOREIGN to the
+  // readers rather than unknown. See isForeignEmbeddingModel (dataLakeService/embeddingMismatch.ts)
+  // for those readers and the reasoning. The `embeddingModel` in the message proves it was the
+  // schema that rejected it, not something failing later in the chunker.
+  it.each([
+    ['mis-cased', 'Text-Embedding-3-Small'],
+    ['unrecognized', 'not-a-real-embedder'],
+    ['blank', ''],
+  ])('rejects a %s embedding model without writing anything', async (_label, embeddingModel) => {
+    await expect(chunkFabfile(mockUser, { fabFileId: 'file-1', embeddingModel }, mockAdapter as never)).rejects.toThrow(
+      /embeddingModel/
+    );
+
+    expect(mockAdapter.db.fabFiles.shareable.findAccessibleById).not.toHaveBeenCalled();
+    expect(mockAdapter.db.fabFiles.update).not.toHaveBeenCalled();
+    expect(mockAdapter.db.fabFileChunks.deleteManyByFabFileId).not.toHaveBeenCalled();
+    expect(mockAdapter.db.fabFileChunks.bulkInsert).not.toHaveBeenCalled();
+  });
 });

--- a/b4m-core/services/src/fabFileService/chunk.ts
+++ b/b4m-core/services/src/fabFileService/chunk.ts
@@ -1,11 +1,24 @@
-import { IFabFileChunkDocument, IFabFileRepository, IUserDocument } from '@bike4mind/common';
+import {
+  IFabFileChunkDocument,
+  IFabFileRepository,
+  IUserDocument,
+  SupportedEmbeddingModelSchema,
+} from '@bike4mind/common';
 import { Logger } from '@bike4mind/observability';
 import { NotFoundError, secureParameters, SmartChunker } from '@bike4mind/utils';
 import { z } from 'zod';
 
 const chunkFileSchema = z.object({
   fabFileId: z.string(),
-  embeddingModel: z.string(),
+  // Enum-constrained, not a bare string: this function is the ONLY writer of
+  // FabFile.embeddingModel (below), and several readers compare that stored label to the query's
+  // as an exact string, so a mis-cased or unrecognized value reads as positively FOREIGN rather
+  // than unknown - dropping a correctly-embedded file from retrieval and telling the user to
+  // re-embed it. See isForeignEmbeddingModel (dataLakeService/embeddingMismatch.ts) for the
+  // canonical list of those readers and why the match is not case-folded. The sole caller already
+  // guards with isSupportedEmbeddingModel (queueHandlers/fabFileChunk.ts), so this rejects nothing
+  // sent today - it stops a future writer persisting a label the readers cannot match.
+  embeddingModel: SupportedEmbeddingModelSchema,
   // Soft chunk-size cap in tokens (see DEFAULT_PASSAGE_TOKEN_TARGET). Optional: the
   // chunker's passage-granularity default applies when omitted.
   passageTokenTarget: z.number().int().positive().optional(),

--- a/b4m-core/services/src/fabFileService/chunk.ts
+++ b/b4m-core/services/src/fabFileService/chunk.ts
@@ -24,7 +24,18 @@ const chunkFileSchema = z.object({
   passageTokenTarget: z.number().int().positive().optional(),
 });
 
-type ChunkFileParameters = z.infer<typeof chunkFileSchema>;
+/**
+ * `embeddingModel` is deliberately kept as `string` here rather than inheriting the schema's
+ * narrowed `SupportedEmbeddingModel`. `chunkFabfile` is exported from the published
+ * `@bike4mind/services`, so narrowing an argument type would be a breaking change for any external
+ * caller holding a plain `string` - the same reason the chunk-stamp seams in `@bike4mind/common`
+ * were left alone. The enum is still enforced, at runtime, by `secureParameters` below; a wide input
+ * type is exactly the case that guard exists for, and narrowing it here would invite a reader to
+ * assume the runtime check is redundant.
+ */
+type ChunkFileParameters = Omit<z.infer<typeof chunkFileSchema>, 'embeddingModel'> & {
+  embeddingModel: string;
+};
 
 interface ChunkFileAdapters {
   db: {


### PR DESCRIPTION
# Pull Request

Closes #1260.

## Optional Screenshot/Video

There is no UI change here, so there is nothing to show in the app. The evidence is the test run:
the three rejection tests FAIL against the old schema and PASS against the new one. Both shots are
produced by the scripts in the collapsed block below.

### BEFORE - old `z.string()` schema, 3 rejection tests FAIL

<img width="3584" height="648" alt="image" src="https://github.com/user-attachments/assets/09ceaeff-6b12-464b-8e3b-c35ad1b0efa9" />


The `WHY` line is the substance: `promise resolved "[]" instead of rejecting` means the old schema
**accepted** a mis-cased model, an unrecognized one, and an empty string, returned normally, and
would have written each one onto the file. Note the 3 pre-existing chunking tests already pass, so
the only thing changing is those 3 cases.

### AFTER - real `SupportedEmbeddingModelSchema`, all 6 PASS

<img width="3600" height="524" alt="image" src="https://github.com/user-attachments/assets/124820d9-e954-4998-a632-5990b8feaa97" />



The 3 rejection cases now refuse the bad values, and the 3 pre-existing chunking tests still pass -
so the guard did not break normal chunking.

> **The BEFORE half is not reproducible by checking out this branch.** It requires hand-reverting the
> schema line; a plain checkout plus test run gives 6 green. The first script below is what produces
> it, and it restores the file on exit.

<details>
<summary>Scripts used to produce both runs</summary>

Both read vitest's JSON reporter and format the summary themselves, so the output does not depend on
terminal width, locale, or colour support. An earlier version filtered vitest's human output with
`grep`/`sed` and silently produced different results on different machines - dropping the failure
reason and the totals on one while looking correct on another. Do not "simplify" these back to
filtering pretty output.

The shared formatter (identical in both scripts):

```python
import json, re, sys
d = json.load(open(sys.argv[1]))
tests = [t for r in d.get("testResults", []) for t in r.get("assertionResults", [])]
reasons = []
for t in tests:
    ok = t.get("status") == "passed"
    print(f"  {'PASS' if ok else 'FAIL'}  {t.get('title','?')}")
    if not ok:
        for m in t.get("failureMessages", []):
            first = re.sub(r"\x1b\[[0-9;]*m", "", m).strip().splitlines()[0]
            if first not in reasons:
                reasons.append(first)
for r in reasons:
    print(f"  WHY   {r}")
p = sum(1 for t in tests if t.get("status") == "passed")
f = len(tests) - p
print(f"  TOTAL {f} failed, {p} passed ({len(tests)})")
```

`pr1637-before.sh` - reverts the schema line, runs the suite, and restores the file via an EXIT trap
so it comes back even on failure or Ctrl-C. It refuses to start if the file has uncommitted changes,
and confirms `[restored] chunk.ts matches HEAD.` when done:

```bash
#!/usr/bin/env bash
set -uo pipefail

FILE="b4m-core/services/src/fabFileService/chunk.ts"
NEW="  embeddingModel: SupportedEmbeddingModelSchema,"
OLD="  embeddingModel: z.string(),"

cd "$(git rev-parse --show-toplevel)"

git diff --quiet HEAD -- "$FILE" || { echo "ABORT: $FILE has uncommitted changes."; exit 1; }
grep -qF "$NEW" "$FILE" || { echo "ABORT: schema line not found - did it move?"; exit 1; }

BACKUP="$(mktemp)"; JSON="$(mktemp)"; cp "$FILE" "$BACKUP"
trap 'cp "$BACKUP" "$FILE"; rm -f "$BACKUP" "$JSON"; git diff --quiet HEAD -- "$FILE" \
  && echo "[restored] chunk.ts matches HEAD." \
  || echo "!!! RESTORE FAILED - check: git diff -- $FILE"' EXIT

perl -pi -e "s/\Q$NEW\E/$OLD/" "$FILE"
echo "=== BEFORE (v4): schema is z.string() - expecting 3 FAILURES ==="

VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/services exec vitest run \
  src/fabFileService/chunk.test.ts --silent --reporter=json --outputFile="$JSON" >/dev/null 2>&1

python3 - "$JSON" <<'PY'
# ... shared formatter above ...
PY
```

`pr1637-after.sh` - the same suite against the committed code. It refuses to run unless the file
matches HEAD, so an "after" shot can never be taken against a still-reverted file:

```bash
#!/usr/bin/env bash
set -uo pipefail

FILE="b4m-core/services/src/fabFileService/chunk.ts"

cd "$(git rev-parse --show-toplevel)"

git diff --quiet HEAD -- "$FILE" \
  || { echo "ABORT: $FILE differs from HEAD - run pr1637-before.sh first, it restores."; exit 1; }

JSON="$(mktemp)"
trap 'rm -f "$JSON"' EXIT

echo "=== AFTER (v4): schema is SupportedEmbeddingModelSchema - expecting 6 PASSED ==="

VITEST_MAX_WORKERS=2 pnpm --filter @bike4mind/services exec vitest run \
  src/fabFileService/chunk.test.ts --silent --reporter=json --outputFile="$JSON" >/dev/null 2>&1

python3 - "$JSON" <<'PY'
# ... shared formatter above ...
PY
```

</details>

## Description

`isForeignEmbeddingModel` decides whether a Data Lake file's chunks can be cosine-compared to a
query embedding, by comparing the file's recorded `embeddingModel` to the query's as an exact
string. Its docstring justified skipping case folding on the grounds that "every id in the
embedding-model enums is already canonical lowercase".

That is true of the enums. It was not true of the field the comparison actually reads:
`FabFile.embeddingModel` is a bare `{ type: String, required: false }` - no `enum`, no
`lowercase`, no validator. So the canonical-lowercase property rested entirely on every writer
happening to pass a value derived from the `defaultEmbeddingModel` admin setting. Every writer did,
so nothing was broken - but nothing enforced it either, and the comment read as though something
did.

The failure direction is the expensive one. A mis-cased label is not treated as unknown, it is
treated as positively FOREIGN, so the file is dropped wholesale before its chunks are loaded,
counted in `excludedFiles`, and reported to the user as needing re-embedding. That is the opposite
of how this module handles every other uncertain input: an absent or blank label is deliberately
given the benefit of the doubt, because exclusion is supposed to require positive evidence.

This PR makes the invariant enforced rather than assumed, at the single place that can enforce it
cheaply, and rewrites the comment so it describes what actually backs the guarantee.

**Where the enforcement goes, and why there.** `chunkFabfile`
(`b4m-core/services/src/fabFileService/chunk.ts`) is the only writer of `FabFile.embeddingModel` in
this repository, and also in the premium overlays that hydrate locally, all of which were checked -
no overlay calls `chunkFabfile` or assigns the field. It already validates its parameters through
`secureParameters`, which throws
`UnprocessableEntityError` on a Zod failure rather than failing quiet. So pointing that existing
schema at `SupportedEmbeddingModelSchema` instead of `z.string()` puts the check on the same code
path as the write, with no new branch and no new failure mode. The sole production caller
(`apps/client/server/queueHandlers/fabFileChunk.ts`) already guards with `isSupportedEmbeddingModel`
and returns early, so this rejects nothing sent today - it stops a FUTURE writer persisting a label
the readers cannot match.

**What was deliberately NOT done.** The issue offered two schema-level options and both are worse
here:

- `lowercase: true` on the field is a Mongoose setter. It normalizes only Mongoose-mediated writes
  and never an existing document, so it cannot make the comment true for stored data - which is the
  actual complaint. It is also only half a fix by construction: the same unconstrained
  `embeddingModel: { type: String }` exists on BOTH `FabFileSchema` and `FabFileChunkSchema`, and
  normalizing one side would let file and chunk labels disagree across the exact-match Atlas
  `$vectorSearch` filter, where today they cannot.
- Constraining the field to the enum is the data-visibility-losing direction this module is
  specifically shaped against: a model later retired from the registry would begin failing
  validation on any unrelated save of an old file, while `updateMany` `$set` skips validators
  anyway - so the coverage would be partial while the new failure mode would not be.

No stored data is migrated, no Mongoose behavior changes, and no existing document is reclassified.

## Changes

- `b4m-core/services/src/fabFileService/chunk.ts` - `chunkFileSchema.embeddingModel` is now
  `SupportedEmbeddingModelSchema` rather than `z.string()`, so the one writer of
  `FabFile.embeddingModel` rejects an unsupported or mis-cased label at its existing
  `secureParameters` boundary, before the file is written. `ChunkFileParameters.embeddingModel` is
  pinned to `string` so the exported signature does not narrow (see the Scope note) - the enforcement
  is runtime, which is the layer that can actually catch a bad writer.
- `b4m-core/services/src/dataLakeService/embeddingMismatch.ts` - the `isForeignEmbeddingModel`
  docstring no longer implies the enums back the stored field. It now names both halves of what
  really does (the `defaultEmbeddingModel` `options` membership check on the admin write path, and
  the newly validated `chunkFileSchema` on the storage path), and carries the canonical list of the
  three OTHER readers that compare this field exactly - the corpus defer gate in
  `ChatCompletionProcess`, `isFabFileCitable` in `lakeSourceReachability`, and the Atlas
  `$vectorSearch` `filter: { embeddingModel }` clause. Each of those holds its own independent copy
  of the rule, so relaxing the comparison here would not propagate to them, it would make the four
  diverge - which is why the docstring now says the rule moves in lockstep or not at all.
- `b4m-core/services/src/fabFileService/chunk.test.ts` - three new cases covering a mis-cased, an
  unrecognized, and a blank model. Each asserts the call rejects AND that nothing was written or
  even read: no `findAccessibleById`, no `fabFiles.update`, no `deleteManyByFabFileId`, no
  `bulkInsert`.
- `b4m-core/services/src/dataLakeService/embeddingMismatch.test.ts` - pins that a case variant is
  treated as foreign, so the no-case-folding decision is protected by a test rather than only by a
  comment.

## Guide for Testers

**No manual QA required.** There is no user-visible change, and no observable difference between
this build and `main` - a tester on the preview and a tester on staging would see identical
behavior. A QA "pass" here could only mean "ingest and retrieval still work", never "the fix is
confirmed", so asking for one would produce a green tick that attests to nothing about the change.

The only way this PR could do harm is by rejecting a legitimate upload, and CI already covers that
path: `Run Tests (services)` exercises `chunkFabfile` itself, including the three pre-existing
chunking tests that still pass alongside the new rejection cases (see the screenshots above). CI is
green at 23 passing checks.

### What NOT to test

- **Do not try to reproduce the original bug through the app.** It is not reachable. The
  `defaultEmbeddingModel` setting is a dropdown whose value the server re-validates against its
  `options` list, and the stored label is written by exactly one function that takes its value from
  that same validated setting. A mis-cased label can only arrive via a direct database write or a
  seed/migration, which is precisely why #1260 was filed as a hardening issue rather than a bug
  report.
- **Do not expect a before/after.** Running the same flow against this branch and against `main`
  gives the same result either way. The evidence for the change is the test run in the screenshots
  above, where the bad values were accepted before and are refused now.

### If you want a smoke check anyway

Upload a small file to a Data Lake, wait for processing to finish, then ask a question in a
lake-scoped chat whose answer appears only in that file. Expect the answer to come back with no
"excluded because they are embedded with ..." warning and no `- partial results, some content could
not be searched` suffix. That confirms ingest and retrieval still work; it says nothing either way
about the invariant this PR enforces.

## Additional Information

**Automated tests:** every CI check passes with no failures - including `Type Check`,
`Run Tests (services)` and `Run Tests (client)`; the only non-passing entries are skips (`E2E Tests`,
`review`, `Merge multi-arch manifest`). Locally, `@bike4mind/services` is 3947 passed / 0 failed
(270 files) with `tsc --noEmit` clean for that package.

**Both new guards are mutation-verified.** The three rejection cases were written before the schema
change and ran red against the original `z.string()` with `promise resolved "[]" instead of
rejecting` - proving the old schema accepted all three bad labels and that the new test is not
vacuous. The mutation was re-run after the tests were later refactored to `it.each`, with the same
result.

**If you see a red local typecheck, it is not this PR.** CI's `Type Check` job passes on this
branch, which is the decisive check - but a local `typecheck:fast` may fail in `@bike4mind/client`
with ~400 errors. That is a local-environment artifact, confirmed four ways: CI is green on the same
commit; the identical error count appears with this branch's four files applied AND with them
stashed; none of the errors are in `b4m-core`; and roughly three quarters of them are in the
generated `apps/client/.next/types/validator.ts`, with the rest spread across `pages/**/__tests__/`
files and none in a non-test source file. If you hit it, `pnpm install` and a clean `.next` clear
most of it.

**Scope note: enforcement is runtime-only, on purpose.** `chunkFabfile` is exported from the
published `@bike4mind/services`, so `ChunkFileParameters.embeddingModel` is deliberately declared as
`string` rather than inheriting the schema's narrowed `SupportedEmbeddingModel`. Letting the
`z.infer` narrow it would be a breaking change for any external caller holding a plain `string`, for
a package whose version this PR does not bump. The enum is still enforced - by `secureParameters` at
runtime, which is where it matters, since the entire point is to catch a writer that passes something
wrong. A wide input type is exactly the case that guard exists for; narrowing it would also invite a
reader to assume the runtime check is redundant.

The same reasoning is why the chunk-stamp seams (`stampChunkEmbeddingModel`,
`IFabFileChunkRepository.updateEmbeddingModel`) keep their `string` types - `IFabFileChunkRepository`
lives in the published `@bike4mind/common`. Those seams are safe by construction today: the vectorize
handler validates its SQS payload with `SupportedEmbeddingModelSchema`, and the backfill script
derives its model from either a trusted `FabFile.embeddingModel` or the canonical
`modelsWithDimensions()` registry.

Net effect: no exported type changes, so this stays a genuine non-breaking patch.

## Developer Notes (Optional)

- **The enforcement point is reusable as a pattern, not just a fix.** `secureParameters` +
  a schema field is the cheapest place to convert a convention into an invariant, because it sits on
  the same code path as the write and throws rather than failing quiet. Any other field whose
  correctness currently rests on "every caller happens to pass the right thing" can be hardened the
  same way, with no new code and no data migration.
- **`isForeignEmbeddingModel`'s docstring is now the canonical statement of the exact-match rule.**
  Four sites compare `embeddingModel` exactly: this predicate, plus three that compare it
  independently rather than calling it - two as inline `===` checks in code, one as a Mongo
  `filter` clause. The docstring holds the list; the other sites point at it
  instead of restating it. A fifth reader belongs on that list, not described again locally -
  duplicating the list across files is the same drift this issue is about, one level up.
- **The two predicates that look consolidatable still are not.** The corpus defer gate and
  `isFabFileCitable` are deliberately STRICTER than `isForeignEmbeddingModel`: they treat an
  unlabeled file as unreachable where this one scores it, because they answer "what is safe to rely
  on" rather than "what can be scored". Their existing comments warn against unifying them, and this
  PR reinforces rather than relaxes that boundary.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - **N/A**, this PR adds no admin setting
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - **N/A**, no UI is touched (the diff is 4 files, all under `b4m-core/services/src`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc - **N/A**, no telemetry fields added or modified
