### PR TITLE
feat(memory): add lake memory read/delete HTTP surface

### DIFF
--- a/apps/client/pages/api/memory/[kind]/[id].ts
+++ b/apps/client/pages/api/memory/[kind]/[id].ts
@@ -1,6 +1,7 @@
 import { baseApi } from '@server/middlewares/baseApi';
 import {
   agentRepository,
+  dataLakeRepository,
   deepAgentCharterRepository,
   memoryLedgerRepository,
   memoryPrincipalKeyRepository,
@@ -13,29 +14,108 @@ import {
   recall,
   REDACTED_FACT,
   subjectKey,
+  type MemoryStore,
+  type Principal,
   type PrincipalKind,
 } from '@bike4mind/memory';
+import { dataLakeService } from '@bike4mind/services';
 import { createDeepAgentMemoryStore } from '@server/memory/deepAgentMemoryStore';
-import { createLedgerMemoryStore, purgeUserMemory, shredBelief } from '@server/memory/ledgerMemoryStore';
+import {
+  createLedgerMemoryStore,
+  purgeUserMemory,
+  shredBelief,
+  shredPrincipalMemory,
+} from '@server/memory/ledgerMemoryStore';
 import { createKeyProvider } from '@server/memory/factCipher';
 import { createPersonaAgentMemoryStore } from '@server/memory/personaAgentMemoryStore';
 import { createUserMementoMemoryStore } from '@server/memory/userMementoMemoryStore';
+import { toAccessContext } from '@server/dataLakes/toAccessContext';
+import type { EntitlementRequest } from '@server/entitlements';
 
-// The kinds this endpoint will read/delete. A deliberate subset of PrincipalKind: `lake` is
-// persistable and now produced/consumed (#1440), but still has no HTTP read/delete surface here - a
-// lake is org-shared, so its authz is not the owner-scoped rule the other kinds use, and defining it
-// is deferred to a follow-up (#1501). Its retention is handled OUT of band: lake deletion crypto-shreds
-// the ledger in cleanupDeletedDataLake, so a missing read surface does not strand undeletable data.
-const READABLE_PRINCIPAL_KINDS: readonly PrincipalKind[] = ['user', 'agent', 'org', 'system'];
+// The kinds this endpoint reads/deletes. `lake` differs from the owner-scoped kinds: a lake is
+// org-shared, so its READ authz is entitlement/tag/org access (assertLakeAccess) and its DELETE is a
+// MANAGE action (creator/admin) - not the "is this mine" rule the other kinds use. Static-registry
+// (fallback) lakes have no creator and no keyed memory ledger, so they resolve to a 404 here.
+// (Lake retention is also handled OUT of band: lake deletion crypto-shreds the ledger in
+// cleanupDeletedDataLake, so this surface is for the in-app read/manage flows, not retention.)
+const SUPPORTED_PRINCIPAL_KINDS: readonly PrincipalKind[] = ['user', 'agent', 'org', 'system', 'lake'];
+
+/**
+ * Resolve a lake to its memory ledger principal, enforcing the org-shared READ gate. `assertLakeAccess`
+ * denies with a NotFoundError (-> 404 via baseApi) so a caller can't probe for a lake they can't see.
+ * The ledger lives under the lake CREATOR's DEK and is keyed by `datalakeTag`, NOT the URL id (mirrors
+ * recallLakeMemoryForSession). Returns null for a static-registry (fallback) lake, whose synthetic doc
+ * carries an empty `createdByUserId` and has no keyed ledger to read or delete.
+ */
+async function resolveLakeMemoryTarget(
+  req: EntitlementRequest,
+  id: string
+): Promise<{ principal: Principal; ownerUserId: string } | null> {
+  const ctx = await toAccessContext(req);
+  const lake = await dataLakeService.assertLakeAccess(id, ctx, { db: { dataLakes: dataLakeRepository } });
+  if (!lake.createdByUserId) return null;
+  return { principal: { kind: 'lake', id: lake.datalakeTag }, ownerUserId: lake.createdByUserId };
+}
+
+type ReadStore = { principal: Principal; store: MemoryStore } | { status: number; error: string };
+
+/**
+ * Build the read store + principal for a kind, applying that kind's read authz. Returns a
+ * `{ status, error }` sentinel for an authz/absence failure the caller turns into a response
+ * (assertLakeAccess denials instead throw and are handled by baseApi's onError as a 404).
+ */
+async function resolveReadStore(
+  req: EntitlementRequest,
+  kind: PrincipalKind,
+  id: string,
+  ownerUserId: string
+): Promise<ReadStore> {
+  const keys = createKeyProvider(memoryPrincipalKeyRepository);
+
+  // A lake reads under its creator's key, not the caller's: org-shared, so access is by entitlement,
+  // not ownership. The ledger store alone - no memento/charter union, which are user/agent concepts.
+  if (kind === 'lake') {
+    const target = await resolveLakeMemoryTarget(req, id);
+    if (!target) return { status: 404, error: 'No memory found for this principal.' };
+    return {
+      principal: target.principal,
+      store: createLedgerMemoryStore({ ledger: memoryLedgerRepository, keys, ownerUserId: target.ownerUserId }),
+    };
+  }
+
+  // Defense-in-depth: a user may only read their OWN user-memory. Each store already owner-scopes its
+  // reads (a cross-user principal returns null -> 404), but this makes the ownership boundary explicit
+  // and independent of every store re-checking it. Agent/org/system kinds are owner-scoped by the
+  // stores below (charter/persona reads are filtered to ownerUserId).
+  if (kind === 'user' && id !== ownerUserId) {
+    return { status: 403, error: 'You can only read your own user memory.' };
+  }
+
+  const ledgerStore = createLedgerMemoryStore({ ledger: memoryLedgerRepository, keys, ownerUserId });
+
+  // A user's memory is the UNION of their V2 ledger and their legacy V1 mementos, so V2 surfaces
+  // everything they have with no backfill (and a V1-only user, with no ledger, just sees mementos).
+  // An agent principal first-matches the ledger, then its DeepAgent charter / persona journal.
+  const store =
+    kind === 'user'
+      ? mergeStores([ledgerStore, createUserMementoMemoryStore({ mementos: mementoRepository, ownerUserId })])
+      : firstMatchStore([
+          ledgerStore,
+          createDeepAgentMemoryStore({ charters: deepAgentCharterRepository, ownerUserId }),
+          createPersonaAgentMemoryStore({ agents: agentRepository, ownerUserId }),
+        ]);
+  return { principal: { kind, id }, store };
+}
 
 /**
  * GET /api/memory/:kind/:id - read a principal's unified memory profile (Mementos 2.0).
  *
  * The unified surface over the principal-scoped memory core. An agent principal folds that agent's
  * DeepAgent charter (or, failing that, its persona-agent journal); a user principal folds that
- * user's own mementos. Owner-scoped in every store (spec L6): you only see agents you own and only
- * your own user memory, and a not-found / not-owned principal returns 404 so the endpoint never
- * reveals another principal's existence. Org/system kinds 404 until their stores are wired.
+ * user's own mementos; a lake principal folds that lake's extracted-belief ledger. User/agent are
+ * owner-scoped (spec L6): you only see agents you own and only your own user memory, and a
+ * not-found / not-owned principal returns 404 so the endpoint never reveals another principal's
+ * existence. A lake is org-shared, so it is gated by lake access (entitlement/tag/org), not ownership.
  *
  * With `?q=<query>` the response also carries `recalled`: the beliefs ranked for that query by the
  * ACT-R retrieval score (activation + relevance), the read-time pull that a chat preamble would use.
@@ -43,18 +123,23 @@ const READABLE_PRINCIPAL_KINDS: readonly PrincipalKind[] = ['user', 'agent', 'or
 const handler = baseApi();
 
 /**
- * DELETE /api/memory/:kind/:id - delete a user's memory, for real (delete my data).
+ * DELETE /api/memory/:kind/:id - delete a principal's memory, for real (delete my data).
  *
- * BOTH halves of what the unified read serves, because either alone is a false promise:
+ * USER: BOTH halves of what the unified read serves, because either alone is a false promise:
  * - the LEDGER is crypto-shredded: destroy the principal's data-encryption key, so every fact -
  *   including any sitting in a DB backup - becomes permanently unreadable, then clear and flag the
  *   chain. The hash chain still verifies and the beliefs fold to redactions.
  * - the V1 MEMENTOS are hard-deleted: they carry summary, full prompt and a plaintext embedding with
  *   no key to destroy, and the read UNIONS them with the ledger - so leaving them behind would hand
  *   the user's "deleted" memories straight back into the next chat prompt.
+ * Owner-scoped: a caller may delete only their own user memory (agent/org deletion follows the
+ * write path).
  *
- * Authenticated and owner-scoped: a caller may delete only their own user memory for now
- * (agent/org/system deletion follows the write path). Irreversible.
+ * LAKE: a manage action (creator/admin), because a lake's memory is org-shared - only the owner may
+ * shred what the whole org reads. Pure ledger (no V1 memento twin, which is user-scoped), so a shred
+ * never has to reach the memento store the user path reconciles against.
+ *
+ * Irreversible.
  */
 handler.delete(async (req, res) => {
   const ownerUserId = req.user?.id;
@@ -62,23 +147,56 @@ handler.delete(async (req, res) => {
 
   const kind = String(req.query.kind);
   const id = String(req.query.id);
-  if (!READABLE_PRINCIPAL_KINDS.includes(kind as PrincipalKind)) {
+  if (!SUPPORTED_PRINCIPAL_KINDS.includes(kind as PrincipalKind)) {
     return res.status(400).json({ error: `Unsupported principal kind '${kind}'.` });
-  }
-  if (kind !== 'user' || id !== ownerUserId) {
-    return res.status(403).json({ error: 'You can only delete your own user memory for now.' });
   }
 
   // ?subject=<beliefId> shreds ONE belief (the "delete this memory" action from the V2 dashboard); no
   // subject shreds the WHOLE principal ("delete all my memory").
-  //
+  const subject = typeof req.query.subject === 'string' ? req.query.subject : undefined;
+
+  if (kind === 'lake') {
+    const target = await resolveLakeMemoryTarget(req, id);
+    if (!target) return res.status(404).json({ error: 'No memory found for this principal.' });
+
+    // Reading a lake is org-shared, but DELETING it is a MANAGE action: only the creator (or an
+    // admin) may shred what the whole org reads. A reader who isn't the creator gets a 403, not a
+    // 404 - assertLakeAccess already confirmed they can see the lake. Mirrors the lifecycle guards
+    // (data-lakes/[id]/lifecycle.ts).
+    if (!dataLakeService.canManageLake({ createdByUserId: target.ownerUserId }, { userId: ownerUserId, isAdmin: !!req.user?.isAdmin })) {
+      return res.status(403).json({ error: 'Only the lake creator can delete its memory.' });
+    }
+
+    // A lake belief is pure LEDGER - no V1 memento twin (that union is user-scoped), so a single
+    // shred is a straight ledger subject-shred under the creator's key.
+    if (subject) {
+      const shredded = await shredBelief(memoryLedgerRepository, target.principal, target.ownerUserId, subject);
+      return res.status(200).json({ ok: true, shredded, deleted: shredded });
+    }
+
+    // Whole-lake purge: crypto-shred (destroy the DEK, mark the chain shredded) - the same operation
+    // cleanupDeletedDataLake runs on lake deletion, but reachable while the lake is still active. It
+    // resets what the lake has learned; a later extraction mints a fresh DEK and relearns from the
+    // corpus.
+    const shredded = await shredPrincipalMemory(
+      memoryLedgerRepository,
+      createKeyProvider(memoryPrincipalKeyRepository),
+      target.principal,
+      target.ownerUserId
+    );
+    return res.status(200).json({ ok: true, shredded });
+  }
+
+  if (kind !== 'user' || id !== ownerUserId) {
+    return res.status(403).json({ error: 'You can only delete your own user memory for now.' });
+  }
+
   // A belief in the unified view can be backed by the LEDGER (its id is a subject HMAC) or by a V1
   // MEMENTO (its id is a Mongo _id), and a ledger belief can ALSO have a V1 memento TWIN carrying the
   // same plaintext fact. So a real "delete forever" has to hit BOTH stores, exactly like the
   // whole-principal purge - otherwise the memento survives, reappears on refetch, and is re-injected
   // into the next chat prompt. `deleted === 0` means nothing matched (the caller surfaces that as a
   // failure rather than a false success).
-  const subject = typeof req.query.subject === 'string' ? req.query.subject : undefined;
   if (subject) {
     const ledgerStore = createLedgerMemoryStore({
       ledger: memoryLedgerRepository,
@@ -124,38 +242,16 @@ handler.get(async (req, res) => {
 
   const kind = String(req.query.kind);
   const id = String(req.query.id);
-  if (!READABLE_PRINCIPAL_KINDS.includes(kind as PrincipalKind)) {
+  if (!SUPPORTED_PRINCIPAL_KINDS.includes(kind as PrincipalKind)) {
     return res.status(400).json({
-      error: `Unsupported principal kind '${kind}'. Expected one of: ${READABLE_PRINCIPAL_KINDS.join(', ')}.`,
+      error: `Unsupported principal kind '${kind}'. Expected one of: ${SUPPORTED_PRINCIPAL_KINDS.join(', ')}.`,
     });
   }
 
-  // Defense-in-depth: a user may only read their OWN user-memory. Each store already owner-scopes its
-  // reads (a cross-user principal returns null -> 404), but this makes the ownership boundary explicit
-  // and independent of every store re-checking it. Agent/org/system kinds are owner-scoped by the
-  // stores below (charter/persona reads are filtered to ownerUserId).
-  if (kind === 'user' && id !== ownerUserId) {
-    return res.status(403).json({ error: 'You can only read your own user memory.' });
-  }
+  const resolution = await resolveReadStore(req, kind as PrincipalKind, id, ownerUserId);
+  if ('status' in resolution) return res.status(resolution.status).json({ error: resolution.error });
 
-  const ledgerStore = createLedgerMemoryStore({
-    ledger: memoryLedgerRepository,
-    keys: createKeyProvider(memoryPrincipalKeyRepository),
-    ownerUserId,
-  });
-
-  // A user's memory is the UNION of their V2 ledger and their legacy V1 mementos, so V2 surfaces
-  // everything they have with no backfill (and a V1-only user, with no ledger, just sees mementos).
-  // An agent principal first-matches the ledger, then its DeepAgent charter / persona journal.
-  const store =
-    kind === 'user'
-      ? mergeStores([ledgerStore, createUserMementoMemoryStore({ mementos: mementoRepository, ownerUserId })])
-      : firstMatchStore([
-          ledgerStore,
-          createDeepAgentMemoryStore({ charters: deepAgentCharterRepository, ownerUserId }),
-          createPersonaAgentMemoryStore({ agents: agentRepository, ownerUserId }),
-        ]);
-  const profile = await readPrincipalMemory({ kind: kind as PrincipalKind, id }, store);
+  const profile = await readPrincipalMemory(resolution.principal, resolution.store);
   if (!profile) return res.status(404).json({ error: 'No memory found for this principal.' });
 
   // Strip the embedding from each belief before serializing. A vector is 512 floats (~1MB across a

--- a/apps/client/pages/api/memory/[kind]/__tests__/[id].test.ts
+++ b/apps/client/pages/api/memory/[kind]/__tests__/[id].test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  assertLakeAccess: vi.fn(),
+  canManageLake: vi.fn(),
+  toAccessContext: vi.fn(async () => ({ userId: 'caller-1', isAdmin: false })),
+  readPrincipalMemory: vi.fn(),
+  recall: vi.fn(() => []),
+  shredPrincipalMemory: vi.fn(),
+  shredBelief: vi.fn(),
+  purgeUserMemory: vi.fn(),
+}));
+
+// baseApi mock: a callable chain routed by req.method (same shape as the lifecycle test). It does NOT
+// wrap the handler in an error boundary, so a thrown assertLakeAccess denial propagates out of the
+// call - which is exactly how we assert that access denial is delegated to baseApi's onError (a 404).
+vi.mock('@server/middlewares/baseApi', () => ({
+  baseApi: () => {
+    const routes: Record<string, (req: unknown, res: unknown) => unknown> = {};
+    const chain = Object.assign((req: { method?: string }, res: unknown) => routes[req.method ?? 'GET']?.(req, res), {
+      use: () => chain,
+      get: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((routes.GET = fns[fns.length - 1]), chain),
+      delete: (...fns: ((req: unknown, res: unknown) => unknown)[]) => ((routes.DELETE = fns[fns.length - 1]), chain),
+    });
+    return chain;
+  },
+}));
+
+vi.mock('@bike4mind/database', () => ({
+  agentRepository: {},
+  dataLakeRepository: {},
+  deepAgentCharterRepository: {},
+  memoryLedgerRepository: {},
+  memoryPrincipalKeyRepository: {},
+  mementoRepository: {},
+}));
+
+vi.mock('@bike4mind/memory', () => ({
+  firstMatchStore: vi.fn(() => ({ kind: 'firstMatch' })),
+  mergeStores: vi.fn(() => ({ kind: 'merge' })),
+  readPrincipalMemory: h.readPrincipalMemory,
+  recall: h.recall,
+  REDACTED_FACT: '[shredded]',
+  subjectKey: (text: string) => `key:${text}`,
+}));
+
+vi.mock('@bike4mind/services', () => ({
+  dataLakeService: { assertLakeAccess: h.assertLakeAccess, canManageLake: h.canManageLake },
+}));
+
+vi.mock('@server/dataLakes/toAccessContext', () => ({ toAccessContext: h.toAccessContext }));
+vi.mock('@server/memory/deepAgentMemoryStore', () => ({ createDeepAgentMemoryStore: vi.fn(() => ({})) }));
+vi.mock('@server/memory/personaAgentMemoryStore', () => ({ createPersonaAgentMemoryStore: vi.fn(() => ({})) }));
+vi.mock('@server/memory/userMementoMemoryStore', () => ({ createUserMementoMemoryStore: vi.fn(() => ({})) }));
+vi.mock('@server/memory/factCipher', () => ({ createKeyProvider: vi.fn(() => ({})) }));
+vi.mock('@server/memory/ledgerMemoryStore', () => ({
+  createLedgerMemoryStore: vi.fn(() => ({ readProfile: vi.fn() })),
+  purgeUserMemory: h.purgeUserMemory,
+  shredBelief: h.shredBelief,
+  shredPrincipalMemory: h.shredPrincipalMemory,
+}));
+
+import handler from '../[id]';
+
+type Handler = (req: unknown, res: unknown) => Promise<void>;
+const invoke = handler as unknown as Handler;
+
+const makeRes = () => {
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
+  return { res: { json, status } as never, json, status };
+};
+
+type ReqOpts = {
+  method: 'GET' | 'DELETE';
+  kind: string;
+  id: string;
+  user?: { id: string; isAdmin?: boolean } | undefined;
+  subject?: string;
+  q?: string;
+};
+const makeReq = ({ method, kind, id, user = { id: 'caller-1' }, subject, q }: ReqOpts) =>
+  ({ method, query: { kind, id, ...(subject ? { subject } : {}), ...(q !== undefined ? { q } : {}) }, user }) as never;
+
+const LAKE = { id: 'lake-1', datalakeTag: 'tag-abc', createdByUserId: 'creator-1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.toAccessContext.mockResolvedValue({ userId: 'caller-1', isAdmin: false });
+});
+
+describe('GET /api/memory/lake/:id - org-shared read', () => {
+  it('reads the lake ledger under the creator key, keyed by datalakeTag (not the URL id)', async () => {
+    h.assertLakeAccess.mockResolvedValue(LAKE);
+    h.readPrincipalMemory.mockResolvedValue({ beliefs: [{ id: 'b1', fact: 'x', embedding: [0.1, 0.2] }] });
+    const { res, status, json } = makeRes();
+
+    await invoke(makeReq({ method: 'GET', kind: 'lake', id: 'lake-1' }), res);
+
+    // The principal handed to the read is the lake's datalakeTag, never the URL id.
+    expect(h.readPrincipalMemory).toHaveBeenCalledWith({ kind: 'lake', id: 'tag-abc' }, expect.anything());
+    expect(status).toHaveBeenCalledWith(200);
+    const payload = json.mock.calls[0][0];
+    // The embedding is stripped before serialization.
+    expect(payload.profile.beliefs[0]).not.toHaveProperty('embedding');
+    expect(payload.profile.beliefs[0]).toMatchObject({ id: 'b1', fact: 'x' });
+  });
+
+  it('returns 404 for a static-registry (fallback) lake that has no creator/keyed ledger', async () => {
+    h.assertLakeAccess.mockResolvedValue({ ...LAKE, createdByUserId: '' });
+    const { res, status } = makeRes();
+
+    await invoke(makeReq({ method: 'GET', kind: 'lake', id: 'lake-1' }), res);
+
+    expect(status).toHaveBeenCalledWith(404);
+    expect(h.readPrincipalMemory).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the lake has no memory profile yet', async () => {
+    h.assertLakeAccess.mockResolvedValue(LAKE);
+    h.readPrincipalMemory.mockResolvedValue(null);
+    const { res, status } = makeRes();
+
+    await invoke(makeReq({ method: 'GET', kind: 'lake', id: 'lake-1' }), res);
+
+    expect(status).toHaveBeenCalledWith(404);
+  });
+
+  it('delegates an access denial to baseApi (assertLakeAccess throws -> propagates, becomes a 404)', async () => {
+    h.assertLakeAccess.mockRejectedValue(new Error('NotFound'));
+    const { res } = makeRes();
+
+    await expect(invoke(makeReq({ method: 'GET', kind: 'lake', id: 'lake-1' }), res)).rejects.toThrow('NotFound');
+  });
+
+  it('includes ACT-R recall when ?q is present', async () => {
+    h.assertLakeAccess.mockResolvedValue(LAKE);
+    h.readPrincipalMemory.mockResolvedValue({ beliefs: [{ id: 'b1', fact: 'x', embedding: [0.1] }] });
+    h.recall.mockReturnValue([{ belief: { id: 'b1', fact: 'x', embedding: [0.1] }, relevance: 0.9, score: 1.2 }]);
+    const { res, status, json } = makeRes();
+
+    await invoke(makeReq({ method: 'GET', kind: 'lake', id: 'lake-1', q: 'anything' }), res);
+
+    expect(status).toHaveBeenCalledWith(200);
+    const payload = json.mock.calls[0][0];
+    expect(payload.query).toBe('anything');
+    expect(payload.recalled[0].belief).not.toHaveProperty('embedding');
+    expect(payload.recalled[0]).toMatchObject({ relevance: 0.9, score: 1.2 });
+  });
+});
+
+describe('DELETE /api/memory/lake/:id - manage-gated crypto-shred', () => {
+  it('whole-lake purge crypto-shreds the ledger for the creator, keyed by datalakeTag', async () => {
+    h.assertLakeAccess.mockResolvedValue(LAKE);
+    h.canManageLake.mockReturnValue(true);
+    h.shredPrincipalMemory.mockResolvedValue(5);
+    const { res, status, json } = makeRes();
+
+    await invoke(makeReq({ method: 'DELETE', kind: 'lake', id: 'lake-1', user: { id: 'creator-1' } }), res);
+
+    expect(h.canManageLake).toHaveBeenCalledWith(
+      { createdByUserId: 'creator-1' },
+      { userId: 'creator-1', isAdmin: false }
+    );
+    expect(h.shredPrincipalMemory).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { kind: 'lake', id: 'tag-abc' },
+      'creator-1'
+    );
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ ok: true, shredded: 5 });
+  });
+
+  it('a single ?subject shreds one belief (no memento twin - lake memory is pure ledger)', async () => {
+    h.assertLakeAccess.mockResolvedValue(LAKE);
+    h.canManageLake.mockReturnValue(true);
+    h.shredBelief.mockResolvedValue(1);
+    const { res, status, json } = makeRes();
+
+    await invoke(
+      makeReq({ method: 'DELETE', kind: 'lake', id: 'lake-1', subject: 'belief-9', user: { id: 'creator-1' } }),
+      res
+    );
+
+    expect(h.shredBelief).toHaveBeenCalledWith(
+      expect.anything(),
+      { kind: 'lake', id: 'tag-abc' },
+      'creator-1',
+      'belief-9'
+    );
+    expect(h.shredPrincipalMemory).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ ok: true, shredded: 1, deleted: 1 });
+  });
+
+  it('a reader who is not the creator gets 403 (not 404 - they can see the lake) and no shred runs', async () => {
+    h.assertLakeAccess.mockResolvedValue(LAKE);
+    h.canManageLake.mockReturnValue(false);
+    const { res, status } = makeRes();
+
+    await invoke(makeReq({ method: 'DELETE', kind: 'lake', id: 'lake-1', user: { id: 'not-creator' } }), res);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(h.shredPrincipalMemory).not.toHaveBeenCalled();
+    expect(h.shredBelief).not.toHaveBeenCalled();
+  });
+
+  it('an admin who is not the creator may shred (isAdmin flows into the manage check)', async () => {
+    h.assertLakeAccess.mockResolvedValue(LAKE);
+    h.canManageLake.mockReturnValue(true);
+    h.shredPrincipalMemory.mockResolvedValue(2);
+    const { res, status } = makeRes();
+
+    await invoke(
+      makeReq({ method: 'DELETE', kind: 'lake', id: 'lake-1', user: { id: 'admin-1', isAdmin: true } }),
+      res
+    );
+
+    expect(h.canManageLake).toHaveBeenCalledWith(
+      { createdByUserId: 'creator-1' },
+      { userId: 'admin-1', isAdmin: true }
+    );
+    expect(status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 404 for a fallback lake before any manage check runs', async () => {
+    h.assertLakeAccess.mockResolvedValue({ ...LAKE, createdByUserId: '' });
+    const { res, status } = makeRes();
+
+    await invoke(makeReq({ method: 'DELETE', kind: 'lake', id: 'lake-1', user: { id: 'creator-1' } }), res);
+
+    expect(status).toHaveBeenCalledWith(404);
+    expect(h.canManageLake).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const { res, status } = makeRes();
+    const unauthedReq = { method: 'DELETE', query: { kind: 'lake', id: 'lake-1' }, user: undefined } as never;
+
+    await invoke(unauthedReq, res);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(h.assertLakeAccess).not.toHaveBeenCalled();
+  });
+});
+
+describe('kind boundary + owner-scoped regression guards', () => {
+  it('GET rejects an unsupported kind with 400', async () => {
+    const { res, status } = makeRes();
+    await invoke(makeReq({ method: 'GET', kind: 'bogus', id: 'x' }), res);
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  it('DELETE rejects an unsupported kind with 400', async () => {
+    const { res, status } = makeRes();
+    await invoke(makeReq({ method: 'DELETE', kind: 'bogus', id: 'x' }), res);
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  it('GET a user reads their own profile via the unified store (refactor guard)', async () => {
+    h.readPrincipalMemory.mockResolvedValue({ beliefs: [] });
+    const { res, status } = makeRes();
+
+    await invoke(makeReq({ method: 'GET', kind: 'user', id: 'caller-1' }), res);
+
+    expect(h.readPrincipalMemory).toHaveBeenCalledWith({ kind: 'user', id: 'caller-1' }, expect.anything());
+    expect(h.assertLakeAccess).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(200);
+  });
+
+  it('GET a user cannot read another user (403, no lake access path)', async () => {
+    const { res, status } = makeRes();
+
+    await invoke(makeReq({ method: 'GET', kind: 'user', id: 'someone-else' }), res);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(h.readPrincipalMemory).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Adds the `lake` HTTP read/delete surface to `/api/memory/[kind]/[id]`. Part of #1501 (item 5 of the follow-up list) - the endpoint previously 400'd on `kind=lake` because a lake's memory is org-shared, so it needs a different authz rule than the owner-scoped kinds (user/agent/org/system).

#1501 stays open: items 4, 6, and 7 from that issue remain tracked-deferred and are out of scope here.

## Changes

- `GET /api/memory/lake/:id` - reads a lake's extracted-belief ledger, gated by `assertLakeAccess` (entitlement/tag/org access, not ownership). A static-registry (fallback) lake has no creator and no keyed ledger, so it resolves to 404.
- `DELETE /api/memory/lake/:id` - a MANAGE action (`canManageLake`): only the lake creator or an admin may shred it. Supports both a single-belief shred (`?subject=<id>`) and a whole-lake crypto-shred, mirroring the existing user-memory delete semantics.
- Refactored `resolveReadStore` out of the GET handler so the lake and owner-scoped read paths share one shape.
- Lake retention on lake deletion (`cleanupDeletedDataLake`) is unchanged - this is the in-app read/manage surface, not the retention path.

## Guide for Testers

Backend-only change (an API route + its tests) - no UI surface. Exercise it directly against a preview:

1. As an org member, create or identify a data lake you have access to and note its `_id`.
2. `GET https://<preview-host>/api/memory/lake/<lakeId>` with your session's bearer token. Expected: `200` with a memory profile (`beliefs` array, no `embedding` field on any belief).
3. `GET .../api/memory/lake/<lakeId>?q=some+query`. Expected: `200`, response also includes a `recalled` array ranked for that query.
4. `GET .../api/memory/lake/<some-other-orgs-lake-id>` (a lake you have no access to). Expected: `404`.
5. As a non-creator org member with lake access, `DELETE .../api/memory/lake/<lakeId>`. Expected: `403`.
6. As the lake's creator (or an org admin), `DELETE .../api/memory/lake/<lakeId>?subject=<beliefId>`. Expected: `200`, `{ ok: true, shredded, deleted }`.
7. As the lake's creator, `DELETE .../api/memory/lake/<lakeId>` (no `subject`). Expected: `200`, `{ ok: true, shredded }` - whole-lake purge. Re-running `GET` afterwards should show an empty/redacted profile, not an error.

**Regression checks:** `GET`/`DELETE` on `kind=user|agent|org|system` should behave exactly as before (owner-scoped 403/404s unchanged) - covered by the new test file's regression guards on `resolveReadStore`.

**What NOT to test:** no UI change; nothing in the chat/session flow reads this endpoint yet.

## Additional Information

Builds on #1440 (lake memory fold/recall) and the producer-hardening work in #1553 (merged to main). Retention/crypto-shred-on-lake-deletion was already handled in #1488 via `cleanupDeletedDataLake` and is unaffected by this change.

## Developer Notes (Optional)

- `resolveReadStore` is a reusable seam for adding a new principal kind's read authz without re-threading the GET handler.
- `resolveLakeMemoryTarget` centralizes the lake-access-check -> ledger-principal resolution shared by both GET and DELETE, keyed by `datalakeTag` (not the URL id), matching how `recallLakeMemoryForSession` resolves the same lake.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc (not applicable - no telemetry fields touched)
