### PR TITLE
fix(scripts): register three orphaned core migrations

### DIFF
--- a/packages/scripts/migrate/migrations/index.test.ts
+++ b/packages/scripts/migrate/migrations/index.test.ts
@@ -1,4 +1,6 @@
+import { readdirSync } from 'fs';
 import { describe, it, expect, vi } from 'vitest';
+import type { MigrationFile } from './index';
 
 // At least one real core migration imports ../utils/config, which evaluates SST Resource
 // bindings at module load time and throws outside an SST-linked process (same constraint
@@ -43,5 +45,31 @@ describe('AvailableMigrations (real, unmocked)', () => {
       expect(typeof migration.up).toBe('function');
       expect(typeof migration.down).toBe('function');
     }
+  });
+});
+
+/**
+ * Directory-completeness guard: a migration file can exist on disk and still never run if
+ * nobody adds it to `coreMigrations` in index.ts - index.test.ts above only ever inspects the
+ * built AvailableMigrations array, so an unregistered file is invisible to it. This scans the
+ * directory itself and cross-checks every migration file against the array.
+ */
+describe('every migration file on disk is registered', () => {
+  // Core ids are 13-14 digit timestamps followed by '-' or '_' (both separators appear in the
+  // directory, e.g. `2024052201905_demo_to_paid.ts` vs `20250704005300-add-filename-lowercase.ts`).
+  const MIGRATION_FILE = /^\d{11,14}[-_].+\.ts$/;
+
+  const migrationFiles = readdirSync(new URL('.', import.meta.url)).filter(
+    f => MIGRATION_FILE.test(f) && !f.endsWith('.test.ts')
+  );
+
+  it('found at least one migration file to check (sanity check the scan itself)', () => {
+    expect(migrationFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(migrationFiles)('%s is present in AvailableMigrations', async filename => {
+    const modulePath = `./${filename.replace(/\.ts$/, '')}`;
+    const { default: migration } = (await import(modulePath)) as { default: MigrationFile };
+    expect(AvailableMigrations.map(m => m.id)).toContain(migration.id);
   });
 });

--- a/packages/scripts/migrate/migrations/index.ts
+++ b/packages/scripts/migrate/migrations/index.ts
@@ -11,6 +11,7 @@
  */
 
 // 2. Import the file here:
+import AddMementosToUsers from './20240312000000_add_mementos_to_users';
 import DemoToPaid from './2024052201905_demo_to_paid';
 import CreateAndPopulateQuests from './20240524172716_create-and-populate-quests';
 import CreateDefaultSession from './20240723201224_create-sessions-for-users-with-no-sessions';
@@ -38,6 +39,7 @@ import MigrateOldCreditsTxnHistory from './20250917124558_migrate-old-credits-tx
 import DropRedundantIndexes from './20251002113208_drop-redundant-indexes';
 import DropRedundantIndexes2 from './20251006101839_drop-redundant-indexes';
 import DeleteDeprecatedChunks from './20251008130737_delete-deprecated-chunks';
+import AddEmailIntegrationFields from './20251009000000-add-email-integration-fields';
 import DropConflictingCounterlogIndex from './20251010091008_drop-conflicting-counterlog-index';
 import EnhanceQuestMasterPlans from './20251014000000_enhance-questmaster-plans';
 import DropUnusedProjectUniqueNameIndex from './20251022125702_drop-unused-project-unique-name-index';
@@ -67,6 +69,7 @@ import BaseEntitlementOnDefaultModels from './20260709130000_base-entitlement-on
 import NullShellAccountPasswords from './20260710120000_null-shell-account-passwords';
 import BaseEntitlementCoverDriftedSeedConfigs from './20260710160000_base-entitlement-cover-drifted-seed-configs';
 import ImageGenerationTemplateIndexes from './20260715000000_image-generation-template-indexes';
+import DropFabfileTagsNameIndex from './20260717000000_drop-fabfile-tagsname-index';
 import EnsureFabFileChunkKeysetIndex from './20260728000000_ensure-fabfilechunk-keyset-index';
 import AddOrgGroupsIndexes from './20260730000000_add-org-groups-indexes';
 import ReactivateCollateralDeactivatedApiKeys from './20260731000000_reactivate-collateral-deactivated-api-keys';
@@ -90,6 +93,7 @@ export type { MigrationFile };
 
 // 3. Reference the imported variable here:
 const coreMigrations: MigrationFile[] = [
+  AddMementosToUsers,
   DemoToPaid,
   CreateAndPopulateQuests,
   CreateDefaultSession,
@@ -117,6 +121,7 @@ const coreMigrations: MigrationFile[] = [
   DropRedundantIndexes,
   DropRedundantIndexes2,
   DeleteDeprecatedChunks,
+  AddEmailIntegrationFields,
   DropConflictingCounterlogIndex,
   EnhanceQuestMasterPlans,
   DropUnusedProjectUniqueNameIndex,
@@ -146,6 +151,7 @@ const coreMigrations: MigrationFile[] = [
   NullShellAccountPasswords,
   BaseEntitlementCoverDriftedSeedConfigs,
   ImageGenerationTemplateIndexes,
+  DropFabfileTagsNameIndex,
   EnsureFabFileChunkKeysetIndex,
   AddOrgGroupsIndexes,
   ReactivateCollateralDeactivatedApiKeys,


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="950" height="550" alt="migration-fix-real-db-proof" src="https://github.com/user-attachments/assets/21ee6583-5cdc-4c49-bca4-fbd49f6f3ca9" />
*Before (top): the real AvailableMigrations array omits the orphan and a real migration.up() run leaves the tags.name_1 index in place. After (bottom): the array includes it and up() actually drops the index, against a real local MongoDB.*

## Description

`packages/scripts/migrate/migrations/index.ts` only runs migrations listed in its
`coreMigrations` array, so a file that exists in the directory but is never imported there
silently never executes. Three files were in that state: the fabfile `tags.name` index drop
that prompted this issue, plus two older ones (a mementos backfill, an email-integration
fields backfill/index) found while auditing the rest of the directory for the same gap. All
three are idempotent and safe to run now.

Closes #1046

## Changes

- Register `20260717000000_drop-fabfile-tagsname-index`, `20240312000000_add_mementos_to_users`,
  and `20251009000000-add-email-integration-fields` in `coreMigrations`
- Add a test that reads the migrations directory directly and asserts every timestamp-prefixed
  file is present in `AvailableMigrations`, so an unregistered file fails loudly instead of
  silently never running

## Guide for Testers

The unit test added in this PR is not independent proof (it's this PR's own assertion). The
recipe below instead drives the actual production migration array and the actual migration's
`up()` against a real MongoDB, so you can see the real bug and the real fix rather than trust a
green checkmark. It needs no staging/SST access; a local, disposable replica set is enough.

1. From the repo root, on this branch, `cd packages/database` and create a throwaway script
   `verify.ts` (not committed) with the following. This connects to a real local MongoDB replica
   set and (a) checks whether each id is in the real `AvailableMigrations` array the CLI actually
   runs, and (b) runs the real `migration.up()` against a real index:

   ```ts
   import { MongoMemoryReplSet } from 'mongodb-memory-server';
   import mongoose from 'mongoose';

   async function main() {
     const replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
     const { connectDB, FabFile, Migration } = await import('@bike4mind/database');
     await connectDB(replSet.getUri());

     const { AvailableMigrations } = await import('../scripts/migrate/migrations');
     console.log('registered:', AvailableMigrations.some(m => m.id === 20260717000000));

     await FabFile.collection.createIndex({ 'tags.name': 1 }, { name: 'tags.name_1' });
     console.log('indexes before:', (await FabFile.collection.indexes()).map(i => i.name));
     const m = AvailableMigrations.find(m => m.id === 20260717000000);
     if (m) { await m.up(); await Migration.create({ id: m.id, name: m.name }); }
     console.log('indexes after:', (await FabFile.collection.indexes()).map(i => i.name));

     await mongoose.disconnect();
     await replSet.stop();
   }
   main().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });
   ```

   One caveat: importing the migrations barrel pulls in an unrelated, already-registered
   migration that reads SST-bound config at import time. Stub it the same way
   `packages/scripts/migrate/migrations/index.test.ts` already does via `vi.mock`, just manually
   here: set `(globalThis as any).$SST_LINKS = { App: { stage: 'dev' }, MONGODB_URI: { value: replSet.getUri() }, /* plus one `{ value: 'unused' }` entry per key in packages/scripts/utils/config.ts */ }`
   before the `await import(...)` calls above.

2. Run `npx tsx verify.ts`.
3. On `main` (before this fix; checkout `main`, keep the script): `registered: false`, and
   `indexes after` still lists `tags.name_1`. The real migration array omits the file, so the
   real `up()` never runs and the index is never dropped.
4. On this branch (after this fix): `registered: true`, and `indexes after` no longer lists
   `tags.name_1`. The real migration ran and actually dropped it.

What NOT to test: the two older migrations this PR also registers (a mementos backfill, an
email-integration fields backfill) aren't re-verified here beyond confirming their ids are now in
`AvailableMigrations`. Their own `up()`/`down()` logic predates this PR and is unchanged by it.

## Additional Information

N/A

## Developer Notes (Optional)

N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

