### PR TITLE
fix(database): resolve agent memory gates once per execution and persist

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -137,10 +137,6 @@ import { persistRunAsQuest } from '@server/utils/persistRunAsQuest';
 import { extractFinalAnswer } from '@server/utils/extractFinalAnswer';
 import { resolveAndPublishMementoCompletion } from '@server/utils/publishMementoCompletion';
 import { resolveAndBuildMementosPreamble } from '@server/utils/getFirstIterationMementosPreamble';
-// Resolve the memory gates once per execution and persist them (#1525). The composed
-// read/write helpers above route through `resolveExecutionMementoGates`, which memoizes on
-// the persisted value - so both paths observe one verdict instead of re-deriving it from
-// mutable state at two moments a whole agent run apart.
 import { resolveExecutionMementoGates } from '@server/utils/resolveExecutionMementoGates';
 import { getFirstIterationSkillsPreamble } from '@server/utils/getFirstIterationSkillsPreamble';
 import { getMcpClientAdapter } from '@server/utils/getMcpClientAdapter';
@@ -727,29 +723,6 @@ async function processExecution(
       });
     }
 
-    // Resolve the memory gates ONCE, here at the start, and persist them (#1525). Before this the
-    // read path (first-iteration preamble) and the write path (completion event) each resolved
-    // independently - one AdminSettings read plus one V2-opt-in lookup apiece - a whole agent run
-    // apart, so a mid-run flip of `EnableMementos` or the user's V2 opt-in made the two disagree
-    // (memory injected-but-not-recorded, or recorded-but-not-injected). Persisting the verdict lets
-    // continuation Lambdas and the stop-at-gate WS handler read the same value; the downstream
-    // helpers route through `resolveExecutionMementoGates`, which short-circuits to it.
-    //
-    // Only new executions resolve (continuations load the persisted value). An explicit per-request
-    // opt-out (`enableMementos === false`, e.g. Slack/voice/questmaster-V5 senders) resolves
-    // deterministically and read-free in the resolver, so persisting it would only add a write on the
-    // highest-volume path for a value nothing can disagree about - skip it. The in-memory stamp makes
-    // the read and write paths in THIS Lambda reuse the value too, not just cross-Lambda resumes.
-    if (isNewExecution && execution.enableMementos !== false && !execution.resolvedMementoGates) {
-      const resolvedGates = await resolveExecutionMementoGates(
-        execution,
-        { db: { adminSettings: adminSettingsRepository } },
-        logger
-      );
-      await agentExecutionRepository.persistResolvedMementoGates(executionId, resolvedGates);
-      execution.resolvedMementoGates = resolvedGates;
-    }
-
     // Get API keys and LLM backend
     const apiKeyTable = await apiKeyService.getEffectiveLLMApiKeys(execution.userId, {
       db: {
@@ -780,6 +753,32 @@ async function processExecution(
       });
       await sendWs('failed', { executionId, reason: 'insufficient_credits' });
       return;
+    }
+
+    // Resolve the memory gates ONCE and persist them (#1525). The read path (first-iteration
+    // preamble) and the write path (completion event) used to resolve independently a whole run
+    // apart, so a mid-run flip of `EnableMementos` or the user's V2 opt-in made them disagree.
+    // Persisting one verdict lets continuation Lambdas and the stop-at-gate WS handler read it back;
+    // the downstream helpers route through `resolveExecutionMementoGates`, which short-circuits to it.
+    // Only new executions resolve; an explicit opt-out (`enableMementos === false`) resolves read-free
+    // in the resolver, so we skip the write for it. Runs below the credit/backend guards so a doomed
+    // execution never pays for it. The persist is best-effort: the in-memory stamp below already gives
+    // THIS Lambda read/write consistency, so a write blip must degrade memoization, not fail the run.
+    if (isNewExecution && execution.enableMementos !== false && !execution.resolvedMementoGates) {
+      const resolvedGates = await resolveExecutionMementoGates(
+        execution,
+        { db: { adminSettings: adminSettingsRepository } },
+        logger
+      );
+      try {
+        await agentExecutionRepository.persistResolvedMementoGates(executionId, resolvedGates);
+      } catch (err) {
+        logger.warn('[Mementos] Failed to persist resolved gates; continuing with the in-memory value', {
+          executionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      execution.resolvedMementoGates = resolvedGates;
     }
 
     // Resolve the top-level orchestration profile. Two paths:
@@ -1944,16 +1943,11 @@ async function processExecution(
         logger,
         fabFileRepository
       );
-      // Memento retrieval parity with chat_completion. Append the
+      // Memento retrieval parity with chat_completion. Appends the
       // `[KNOWN FACTS ABOUT THE USER ...]` preamble to the same iteration-0 user
-      // message the file preamble lands in, so the agent reads both from a
-      // single materialized string that gets persisted into the checkpoint.
-      // Continuation Lambdas, gate-resumes, and DAG-resumes inherit it via
-      // the checkpoint replay - same handoff contract as the file preamble.
-      // The helper guards on `parentExecutionId` and the resolved `MementoGates`,
-      // matching `publishMementoCompletion` on the write side. It routes through
-      // `resolveExecutionMementoGates`, which returns the gates resolved once at
-      // execution start (#1525), so read and write cannot disagree mid-run.
+      // message the file preamble lands in, so both survive into the checkpoint and
+      // inherit through continuation/gate/DAG resumes. Gates come from the resolver,
+      // which returns the verdict resolved once at execution start (#1525).
       if (firstIterationQuery !== undefined) {
         const { preamble: mementoPreamble, mementoIds } = await resolveAndBuildMementosPreamble(
           execution,
@@ -2366,13 +2360,9 @@ async function processExecution(
       allSideEffects
     );
 
-    // Memento parity with chat_completion. Routes through the one authority
-    // (`resolveExecutionMementoGates`), which returns the gates resolved and persisted at
-    // execution start (#1525) - so this write agrees with the read-path preamble even if the
-    // admin setting or V2 opt-in flipped mid-run. The publisher fires only when a gate is live
-    // and skips subagent / DAG children via the `parentExecutionId`/`spawnedByExecutionId` guard
-    // inside the helper. Reads `execution` (loaded at the top of this function), which carries the
-    // persisted gates on continuation Lambdas and the in-memory stamp on the resolving Lambda.
+    // Memento parity with chat_completion, write side. Gates come from the resolver's verdict
+    // resolved once at execution start (#1525), so this write agrees with the read-path preamble
+    // even across a mid-run flip. The publisher's own guards skip subagent/DAG children.
     await resolveAndPublishMementoCompletion(execution, { db: { adminSettings: adminSettingsRepository } }, logger);
 
     logger.info('[Complete] Agent execution finished', {

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -137,6 +137,11 @@ import { persistRunAsQuest } from '@server/utils/persistRunAsQuest';
 import { extractFinalAnswer } from '@server/utils/extractFinalAnswer';
 import { resolveAndPublishMementoCompletion } from '@server/utils/publishMementoCompletion';
 import { resolveAndBuildMementosPreamble } from '@server/utils/getFirstIterationMementosPreamble';
+// Resolve the memory gates once per execution and persist them (#1525). The composed
+// read/write helpers above route through `resolveExecutionMementoGates`, which memoizes on
+// the persisted value - so both paths observe one verdict instead of re-deriving it from
+// mutable state at two moments a whole agent run apart.
+import { resolveExecutionMementoGates } from '@server/utils/resolveExecutionMementoGates';
 import { getFirstIterationSkillsPreamble } from '@server/utils/getFirstIterationSkillsPreamble';
 import { getMcpClientAdapter } from '@server/utils/getMcpClientAdapter';
 import { loadAgentMcpTools, type AgentMcpTools } from '@server/utils/loadAgentMcpTools';
@@ -720,6 +725,29 @@ async function processExecution(
         executionId,
         ...(startPayload?.questId ? { questId: startPayload.questId } : {}),
       });
+    }
+
+    // Resolve the memory gates ONCE, here at the start, and persist them (#1525). Before this the
+    // read path (first-iteration preamble) and the write path (completion event) each resolved
+    // independently - one AdminSettings read plus one V2-opt-in lookup apiece - a whole agent run
+    // apart, so a mid-run flip of `EnableMementos` or the user's V2 opt-in made the two disagree
+    // (memory injected-but-not-recorded, or recorded-but-not-injected). Persisting the verdict lets
+    // continuation Lambdas and the stop-at-gate WS handler read the same value; the downstream
+    // helpers route through `resolveExecutionMementoGates`, which short-circuits to it.
+    //
+    // Only new executions resolve (continuations load the persisted value). An explicit per-request
+    // opt-out (`enableMementos === false`, e.g. Slack/voice/questmaster-V5 senders) resolves
+    // deterministically and read-free in the resolver, so persisting it would only add a write on the
+    // highest-volume path for a value nothing can disagree about - skip it. The in-memory stamp makes
+    // the read and write paths in THIS Lambda reuse the value too, not just cross-Lambda resumes.
+    if (isNewExecution && execution.enableMementos !== false && !execution.resolvedMementoGates) {
+      const resolvedGates = await resolveExecutionMementoGates(
+        execution,
+        { db: { adminSettings: adminSettingsRepository } },
+        logger
+      );
+      await agentExecutionRepository.persistResolvedMementoGates(executionId, resolvedGates);
+      execution.resolvedMementoGates = resolvedGates;
     }
 
     // Get API keys and LLM backend
@@ -1923,7 +1951,9 @@ async function processExecution(
       // Continuation Lambdas, gate-resumes, and DAG-resumes inherit it via
       // the checkpoint replay - same handoff contract as the file preamble.
       // The helper guards on `parentExecutionId` and the resolved `MementoGates`,
-      // matching `publishMementoCompletion` on the write side.
+      // matching `publishMementoCompletion` on the write side. It routes through
+      // `resolveExecutionMementoGates`, which returns the gates resolved once at
+      // execution start (#1525), so read and write cannot disagree mid-run.
       if (firstIterationQuery !== undefined) {
         const { preamble: mementoPreamble, mementoIds } = await resolveAndBuildMementosPreamble(
           execution,
@@ -2336,12 +2366,13 @@ async function processExecution(
       allSideEffects
     );
 
-    // Memento parity with chat_completion. Resolve the same gates the read side
-    // resolves (one authority, `resolveExecutionMementoGates`) and hand them to the
-    // publisher; it fires only when a gate is live and skips subagent / DAG children
-    // via the `parentExecutionId`/`spawnedByExecutionId` guard inside the helper. Reads `execution` (loaded
-    // at the top of this function) so continuation Lambdas see the persisted tri-state
-    // flag the WS handler stamped at dispatch.
+    // Memento parity with chat_completion. Routes through the one authority
+    // (`resolveExecutionMementoGates`), which returns the gates resolved and persisted at
+    // execution start (#1525) - so this write agrees with the read-path preamble even if the
+    // admin setting or V2 opt-in flipped mid-run. The publisher fires only when a gate is live
+    // and skips subagent / DAG children via the `parentExecutionId`/`spawnedByExecutionId` guard
+    // inside the helper. Reads `execution` (loaded at the top of this function), which carries the
+    // persisted gates on continuation Lambdas and the in-memory stamp on the resolving Lambda.
     await resolveAndPublishMementoCompletion(execution, { db: { adminSettings: adminSettingsRepository } }, logger);
 
     logger.info('[Complete] Agent execution finished', {

--- a/apps/client/server/utils/resolveExecutionMementoGates.test.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.test.ts
@@ -149,6 +149,23 @@ describe('resolveExecutionMementoGates (agent-surface authority, #1337)', () => 
   });
 
   describe('resolve-once memoization (#1525)', () => {
+    it('an explicit opt-out wins even when a persisted verdict is present', async () => {
+      // The opt-out short-circuit is ordered ABOVE the memo short-circuit, so `enableMementos: false`
+      // is authoritative here regardless of any persisted gates - it never has to trust the executor
+      // guard to have skipped the persist. Both lookups stay untouched.
+      const gates = await resolveExecutionMementoGates(
+        makeExecution({
+          enableMementos: false,
+          resolvedMementoGates: { v1: true, v2: true, v2OptInLookupFailed: false },
+        }),
+        makeAdapters(),
+        makeLogger()
+      );
+      expect(gates).toEqual({ v1: false, v2: false, v2OptInLookupFailed: false });
+      expect(getSettingsValueMock).not.toHaveBeenCalled();
+      expect(isMementosV2EnabledMock).not.toHaveBeenCalled();
+    });
+
     it('returns the persisted gates verbatim and reads NO mutable state', async () => {
       // This is the whole fix: once the execution start has resolved and persisted a verdict, every
       // downstream site (read preamble, write completion, stop-at-gate) gets that same verdict back

--- a/apps/client/server/utils/resolveExecutionMementoGates.test.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.test.ts
@@ -147,4 +147,47 @@ describe('resolveExecutionMementoGates (agent-surface authority, #1337)', () => 
     expect(getSettingsValueMock).not.toHaveBeenCalled();
     expect(isMementosV2EnabledMock).not.toHaveBeenCalled();
   });
+
+  describe('resolve-once memoization (#1525)', () => {
+    it('returns the persisted gates verbatim and reads NO mutable state', async () => {
+      // This is the whole fix: once the execution start has resolved and persisted a verdict, every
+      // downstream site (read preamble, write completion, stop-at-gate) gets that same verdict back
+      // instead of re-deriving it from the admin setting + V2 opt-in a whole agent run later.
+      const persisted = { v1: true, v2: false, v2OptInLookupFailed: false };
+      const gates = await resolveExecutionMementoGates(
+        makeExecution({ enableMementos: true, resolvedMementoGates: persisted }),
+        makeAdapters(),
+        makeLogger()
+      );
+      expect(gates).toEqual(persisted);
+      expect(getSettingsValueMock).not.toHaveBeenCalled();
+      expect(isMementosV2EnabledMock).not.toHaveBeenCalled();
+    });
+
+    it('reuses the persisted verdict even when the live flags now disagree with it', async () => {
+      // A mid-run flip is exactly the disagreement window this closes: the admin setting is now ON and
+      // the user is now V2-opted-in, but the run resolved OFF at its start, so it must stay OFF.
+      getSettingsValueMock.mockResolvedValue(true);
+      isMementosV2EnabledMock.mockResolvedValue(true);
+      const persisted = { v1: false, v2: false, v2OptInLookupFailed: false };
+      const gates = await resolveExecutionMementoGates(
+        makeExecution({ enableMementos: undefined, resolvedMementoGates: persisted }),
+        makeAdapters(),
+        makeLogger()
+      );
+      expect(gates).toEqual(persisted);
+      expect(getSettingsValueMock).not.toHaveBeenCalled();
+      expect(isMementosV2EnabledMock).not.toHaveBeenCalled();
+    });
+
+    it('preserves the persisted opt-in-lookup-failure signal for the write side', async () => {
+      const persisted = { v1: true, v2: false, v2OptInLookupFailed: true };
+      const gates = await resolveExecutionMementoGates(
+        makeExecution({ enableMementos: undefined, resolvedMementoGates: persisted }),
+        makeAdapters(),
+        makeLogger()
+      );
+      expect(gates.v2OptInLookupFailed).toBe(true);
+    });
+  });
 });

--- a/apps/client/server/utils/resolveExecutionMementoGates.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.ts
@@ -45,17 +45,18 @@ export async function resolveExecutionMementoGates(
   adapters: MementoGateAdapters,
   logger: Logger
 ): Promise<ResolvedMementoGates> {
+  // An explicit per-request opt-out disables both pipelines regardless of the admin setting or the V2
+  // opt-in (resolveMementoGates(false, ...) is always { v1: false, v2: false }). Checked FIRST so an
+  // opt-out is unconditionally authoritative here, independent of whether the executor happened to
+  // persist a verdict. It is also the highest-volume input this resolver sees - the Slack senders and
+  // the voice proxy all hard-code false - so short-circuiting skips both round trips below.
+  if (execution.enableMementos === false) return { v1: false, v2: false, v2OptInLookupFailed: false };
+
   // Resolve-once memoization (#1525). When the execution start already resolved and persisted the
   // gates, reuse them verbatim - the read path, the write path, and the stop-at-gate WS handler all
   // route through here, so returning the persisted verdict is what stops a mid-run flip of the admin
   // setting or the V2 opt-in from making those sites disagree. Also skips the two DB reads below.
   if (execution.resolvedMementoGates) return execution.resolvedMementoGates;
-
-  // An explicit per-request opt-out disables both pipelines regardless of the admin setting or the V2
-  // opt-in (resolveMementoGates(false, ...) is always { v1: false, v2: false }). It is also the
-  // highest-volume input this resolver sees - the Slack senders and the voice proxy all hard-code
-  // false - so short-circuiting skips both round trips and keeps the dominant flow off the reads below.
-  if (execution.enableMementos === false) return { v1: false, v2: false, v2OptInLookupFailed: false };
 
   // Both lookups fail closed to "not enabled" (memory degrades, it never fails the turn - the same
   // convention the chat and read paths use) and are independent - one AdminSettings read, one user

--- a/apps/client/server/utils/resolveExecutionMementoGates.ts
+++ b/apps/client/server/utils/resolveExecutionMementoGates.ts
@@ -21,7 +21,7 @@ import type { IAdminSettingsRepository } from '@bike4mind/common';
 import { resolveMementoGates, type MementoGates } from '@bike4mind/services';
 import { isMementosV2Enabled } from '@server/memory/mementoLedgerMirror';
 
-export type MementoGateExecution = Pick<IAgentExecution, 'userId' | 'enableMementos'>;
+export type MementoGateExecution = Pick<IAgentExecution, 'userId' | 'enableMementos' | 'resolvedMementoGates'>;
 
 export interface MementoGateAdapters {
   db: { adminSettings: Pick<IAdminSettingsRepository, 'getSettingsValue'> };
@@ -45,6 +45,12 @@ export async function resolveExecutionMementoGates(
   adapters: MementoGateAdapters,
   logger: Logger
 ): Promise<ResolvedMementoGates> {
+  // Resolve-once memoization (#1525). When the execution start already resolved and persisted the
+  // gates, reuse them verbatim - the read path, the write path, and the stop-at-gate WS handler all
+  // route through here, so returning the persisted verdict is what stops a mid-run flip of the admin
+  // setting or the V2 opt-in from making those sites disagree. Also skips the two DB reads below.
+  if (execution.resolvedMementoGates) return execution.resolvedMementoGates;
+
   // An explicit per-request opt-out disables both pipelines regardless of the admin setting or the V2
   // opt-in (resolveMementoGates(false, ...) is always { v1: false, v2: false }). It is also the
   // highest-volume input this resolver sees - the Slack senders and the voice proxy all hard-code

--- a/packages/database/src/models/billing/AgentExecutionModel.test.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.test.ts
@@ -121,6 +121,58 @@ describe('AgentExecutionRepository', () => {
     });
   });
 
+  describe('persistResolvedMementoGates (#1525)', () => {
+    it('is absent on a fresh execution', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution());
+      const loaded = await agentExecutionRepository.findById(exec.id);
+      expect(loaded?.resolvedMementoGates).toBeUndefined();
+    });
+
+    it('persists the resolved gates and reads them back verbatim through the typed sub-schema', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution());
+      await agentExecutionRepository.persistResolvedMementoGates(exec.id, {
+        v1: true,
+        v2: false,
+        v2OptInLookupFailed: true,
+      });
+      const loaded = await agentExecutionRepository.findById(exec.id);
+      expect(loaded?.resolvedMementoGates).toEqual({ v1: true, v2: false, v2OptInLookupFailed: true });
+    });
+
+    it('stores the sub-document without an _id and drops unknown fields (typed sub-schema, not Mixed)', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution());
+      // Cast: the typed method never passes extras, but the sub-schema must strip them rather than
+      // let arbitrary keys ride into the DB - the reason this is a Schema and not `Mixed`.
+      await agentExecutionRepository.persistResolvedMementoGates(exec.id, {
+        v1: false,
+        v2: true,
+        v2OptInLookupFailed: false,
+        rogue: 'nope',
+      } as unknown as { v1: boolean; v2: boolean; v2OptInLookupFailed: boolean });
+      const loaded = await agentExecutionRepository.findById(exec.id);
+      const gates = loaded?.resolvedMementoGates as Record<string, unknown> | undefined;
+      expect(gates).toEqual({ v1: false, v2: true, v2OptInLookupFailed: false });
+      expect(gates?.rogue).toBeUndefined();
+      expect(gates?._id).toBeUndefined();
+    });
+
+    it('overwrites a prior verdict (last write wins)', async () => {
+      const exec = await agentExecutionRepository.create(makeBaseExecution());
+      await agentExecutionRepository.persistResolvedMementoGates(exec.id, {
+        v1: true,
+        v2: true,
+        v2OptInLookupFailed: false,
+      });
+      await agentExecutionRepository.persistResolvedMementoGates(exec.id, {
+        v1: false,
+        v2: false,
+        v2OptInLookupFailed: false,
+      });
+      const loaded = await agentExecutionRepository.findById(exec.id);
+      expect(loaded?.resolvedMementoGates).toEqual({ v1: false, v2: false, v2OptInLookupFailed: false });
+    });
+  });
+
   describe('addChildExecution', () => {
     it('links a child id to the parent without duplicating', async () => {
       const parent = await agentExecutionRepository.create(makeBaseExecution());

--- a/packages/database/src/models/billing/AgentExecutionModel.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.ts
@@ -284,6 +284,18 @@ export interface IAgentExecution {
   /** IDs of mementos injected into the first-iteration prompt. Written once at iteration 0;
    * read by persistRunAsQuest so all terminal paths (continuation, gate-stop, abort) get the badge. */
   usedMementoIds?: string[];
+  /**
+   * The memory gates (V1/V2 + opt-in-lookup-failure signal) resolved ONCE at the
+   * start of this execution and persisted so every downstream site observes the
+   * same verdict. The read path (first-iteration preamble), the write path
+   * (completion event), and the stop-at-gate WS handler all resolve through
+   * `resolveExecutionMementoGates`, which short-circuits to this value when set -
+   * so a mid-run flip of the `EnableMementos` admin setting or the user's V2
+   * opt-in can no longer make the read and write paths disagree. Absent for
+   * per-request opt-outs (`enableMementos === false`), which resolve read-free and
+   * deterministically, and for legacy executions dispatched before this field.
+   */
+  resolvedMementoGates?: { v1: boolean; v2: boolean; v2OptInLookupFailed: boolean };
 
   // Execution state
   status: AgentExecutionStatus;
@@ -626,6 +638,20 @@ const AgentExecutionSchema = new mongoose.Schema(
     enableMementos: { type: Boolean },
     enableLattice: { type: Boolean },
     usedMementoIds: [{ type: String }],
+    // Memory gates resolved once at execution start and persisted so read/write/
+    // stop-at-gate all agree even if the underlying flags flip mid-run. Typed
+    // sub-schema (not Mixed) so the three booleans are enforced at the DB layer.
+    resolvedMementoGates: {
+      type: new mongoose.Schema(
+        {
+          v1: { type: Boolean, required: true },
+          v2: { type: Boolean, required: true },
+          v2OptInLookupFailed: { type: Boolean, required: true },
+        },
+        { _id: false }
+      ),
+      required: false,
+    },
 
     // Execution state
     status: {
@@ -1234,6 +1260,19 @@ class AgentExecutionRepository extends BaseRepository<IAgentExecution> {
 
   async persistMementoIds(id: string, mementoIds: string[]): Promise<void> {
     await this.model.updateOne({ _id: id }, { $set: { usedMementoIds: mementoIds } });
+  }
+
+  /**
+   * Persist the memory gates resolved at execution start so continuation Lambdas
+   * and the stop-at-gate WS handler read the same verdict rather than re-deriving
+   * it from mutable state (see `resolveExecutionMementoGates`). Written once, on
+   * the first invocation, before any handoff could resume the execution.
+   */
+  async persistResolvedMementoGates(
+    id: string,
+    gates: { v1: boolean; v2: boolean; v2OptInLookupFailed: boolean }
+  ): Promise<void> {
+    await this.model.updateOne({ _id: id }, { $set: { resolvedMementoGates: gates } });
   }
 
   async updatePermissionState(

--- a/packages/database/src/models/billing/AgentExecutionModel.ts
+++ b/packages/database/src/models/billing/AgentExecutionModel.ts
@@ -285,15 +285,9 @@ export interface IAgentExecution {
    * read by persistRunAsQuest so all terminal paths (continuation, gate-stop, abort) get the badge. */
   usedMementoIds?: string[];
   /**
-   * The memory gates (V1/V2 + opt-in-lookup-failure signal) resolved ONCE at the
-   * start of this execution and persisted so every downstream site observes the
-   * same verdict. The read path (first-iteration preamble), the write path
-   * (completion event), and the stop-at-gate WS handler all resolve through
-   * `resolveExecutionMementoGates`, which short-circuits to this value when set -
-   * so a mid-run flip of the `EnableMementos` admin setting or the user's V2
-   * opt-in can no longer make the read and write paths disagree. Absent for
-   * per-request opt-outs (`enableMementos === false`), which resolve read-free and
-   * deterministically, and for legacy executions dispatched before this field.
+   * Memory gates resolved once at execution start and persisted so the read, write, and
+   * stop-at-gate paths all observe one verdict via `resolveExecutionMementoGates` (#1525).
+   * Absent for per-request opt-outs (`enableMementos === false`) and legacy executions.
    */
   resolvedMementoGates?: { v1: boolean; v2: boolean; v2OptInLookupFailed: boolean };
 


### PR DESCRIPTION
# Pull Request

## Description
An agent execution resolves its memory gates (`MementoGates`) twice with a real
time gap: once on the read path (first-iteration mementos preamble) and once on
the write path (completion event). Each independently reads the `EnableMementos`
admin setting and the user's V2 opt-in (`isMementosV2Enabled`). If either flips
mid-run the two resolutions disagree: memory can end up injected-but-not-recorded,
or recorded-but-not-injected. This also affected the stop-at-gate WS write
(`agentExecute.handleGateResponse`).

This PR makes gate resolution happen once per execution and persists the result,
so every later read of the same execution (continuations, handoffs, the WS
stop-path) observes one consistent value instead of re-deriving it.

Closes #1525

## Changes
- Added `IAgentExecution.resolvedMementoGates { v1, v2, v2OptInLookupFailed }` to
  the execution model, plus a schema sub-schema and repo
  `persistResolvedMementoGates` helper.
- `resolveExecutionMementoGates` now short-circuits to
  `execution.resolvedMementoGates` when already present, making it the single
  memoized authority. Existing call sites (`resolveAndBuildMementosPreamble`,
  `resolveAndPublishMementoCompletion`) and the WS handler are unchanged - they
  now transparently observe the memoized value.
- `processExecution` resolves gates once at the start of a new, non-opt-out
  execution, persists the result, and stamps it in-memory so both the read and
  write paths within the same invocation reuse it. Opt-out runs
  (`enableMementos === false`, including questmaster V5 nodes) resolve
  read-free and deterministically, so they skip the persist write.

## Guide for Testers
This is a backend-only consistency fix with no new UI surface; there is no
user-visible flow to click through.

### What NOT to test
- No UI changes - nothing to click through in the client.
- Do not test by flipping `EnableMementos` mid-run in a live session; there is
  no supported way to trigger that race from the UI within a single agent
  execution's lifetime.

### Regression Checks
- Run an agent execution with mementos enabled (V1) end to end and confirm
  memory is still injected on the first iteration and a memento is still
  recorded on completion, as before.
- Run an agent execution with `enableMementos: false` (or on a questmaster V5
  node) and confirm no gate resolution / DB read happens and no memento
  persistence occurs, as before.
- Stop an execution at a gate (WS `handleGateResponse`) and confirm resume
  behavior is unchanged.

## Additional Information
Introduced by #1356 (shared resolver called from both the read and write
paths without memoization). Composition invariant from #1337 (call sites never
fabricate gates themselves) is preserved.

Verification (local):
- `pnpm turbo:core:build` - 18/18 (database dist rebuilt after model change)
- `pnpm turbo:typecheck` - 40/40 clean (tsc); `typecheck:fast` (tsgo, CI gate)
  clean for client + database
- `pnpm lint:check` - clean, no changed file flagged
- `resolveExecutionMementoGates` + `mementoGateWiring` suites - 17/17 (incl. 3
  new memoization tests)
- `agentExecutor` + `getFirstIterationMementosPreamble` +
  `publishMementoCompletion` suites - 217/217
- Full client suite: 8 unrelated failures (`apiKeyRateLimitReset` /
  `user-api-keys` e2e) are CPU-contention timeouts; all pass in isolation.

## Developer Notes (Optional)
- `resolveExecutionMementoGates` is now the single memoization point for gate
  resolution - any new call site should read through it (or the execution's
  `resolvedMementoGates` field directly) rather than re-resolving from admin
  settings / user opt-in.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
