### PR TITLE
fix(types): type the render props that stock tsc checks but CI never sees

### DIFF
--- a/apps/client/app/components/Charts/RechartsChart.tsx
+++ b/apps/client/app/components/Charts/RechartsChart.tsx
@@ -26,6 +26,7 @@ import {
   CartesianGrid,
   Tooltip,
   Legend,
+  type LegendProps,
   ResponsiveContainer,
   Cell,
 } from 'recharts';
@@ -239,7 +240,7 @@ const RechartsChart: React.FC<RechartsChartProps> = ({ config, title, descriptio
               {tooltip && <Tooltip />}
               {legend && (
                 <Legend
-                  content={({ payload }) => (
+                  content={({ payload }: LegendProps) => (
                     <div
                       style={{
                         display: 'flex',

--- a/apps/client/app/components/Session/FilePond.tsx
+++ b/apps/client/app/components/Session/FilePond.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 
 import { FilePond, registerPlugin } from 'react-filepond';
+import type { ProcessServerConfigFunction } from 'filepond';
 
 import FilePondPluginFileValidateSize from 'filepond-plugin-file-validate-size';
 import 'filepond/dist/filepond.min.css';
@@ -86,31 +87,33 @@ const FilePondModal: React.FC<FilePondModalProps> = ({ onFileProcessComplete }) 
         '.xlsx',
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
       ]}
-      server={{
-        process: (fieldName, file, metadata, load, error, progress, abort) => {
-          const reader = new FileReader();
-          reader.onload = async () => {
-            const data = {
-              type: KnowledgeType.FILE,
-              fileName: file.name,
-              mimeType: file.type,
-              fileSize: file.size,
-            };
+      server={
+        {
+          process: (fieldName, file, metadata, load, error, progress, abort) => {
+            const reader = new FileReader();
+            reader.onload = async () => {
+              const data = {
+                type: KnowledgeType.FILE,
+                fileName: file.name,
+                mimeType: file.type,
+                fileSize: file.size,
+              };
 
-            createFabFileOnServerWithUpload(data, file)
-              .then(async fabFile => {
-                onFileProcessComplete(fabFile);
-                load(fabFile.id);
-                toast.success('File uploaded successfully');
-              })
-              .catch(e => {
-                console.error(e);
-                error('Failed to upload file');
-              });
-          };
-          reader.readAsArrayBuffer(file);
-        },
-      }}
+              createFabFileOnServerWithUpload(data, file)
+                .then(async fabFile => {
+                  onFileProcessComplete(fabFile);
+                  load(fabFile.id);
+                  toast.success('File uploaded successfully');
+                })
+                .catch(e => {
+                  console.error(e);
+                  error('Failed to upload file');
+                });
+            };
+            reader.readAsArrayBuffer(file);
+          },
+        } as { process: ProcessServerConfigFunction }
+      }
       name="content"
       oninit={handleInit}
     />

--- a/apps/client/app/components/admin/EventMetrics/components/OverviewTab.tsx
+++ b/apps/client/app/components/admin/EventMetrics/components/OverviewTab.tsx
@@ -75,7 +75,7 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({ metrics, chartData }) 
                     cx="50%"
                     cy="50%"
                     outerRadius={100}
-                    label={entry => {
+                    label={(entry: PieLabelRenderProps) => {
                       const { category, count } = entry as PieLabelRenderProps & {
                         category: string;
                         count: number;

--- a/apps/client/app/components/admin/EventMetrics/components/UsageBySourceCard.tsx
+++ b/apps/client/app/components/admin/EventMetrics/components/UsageBySourceCard.tsx
@@ -90,7 +90,7 @@ export const UsageBySourceCard: React.FC = () => {
                     cx="50%"
                     cy="50%"
                     outerRadius={90}
-                    label={entry => {
+                    label={(entry: PieLabelRenderProps) => {
                       const { source, uniqueUsers } = entry as PieLabelRenderProps & {
                         source: string;
                         uniqueUsers: number;

--- a/packages/cli/src/components/EnvironmentPicker.tsx
+++ b/packages/cli/src/components/EnvironmentPicker.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Text } from 'ink';
-import SelectInput from 'ink-select-input';
+import SelectInput, { type ItemProps } from 'ink-select-input';
 import TextInput from 'ink-text-input';
 import { LOCAL_DEV_URL, parseApiUrl } from '../utils/apiUrl.js';
 
@@ -90,7 +90,7 @@ export function EnvironmentPicker({ onSelect }: EnvironmentPickerProps) {
       <SelectInput
         items={items}
         onSelect={handleMenuSelect}
-        itemComponent={({ isSelected, label }) => (
+        itemComponent={({ isSelected, label }: ItemProps) => (
           <Box>
             <Text color={isSelected ? 'cyan' : undefined}>
               {isSelected ? '❯ ' : '  '}

--- a/packages/cli/src/components/ModelPicker.tsx
+++ b/packages/cli/src/components/ModelPicker.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
-import SelectInput from 'ink-select-input';
+import SelectInput, { type ItemProps } from 'ink-select-input';
 import type { ModelInfo } from '@bike4mind/common';
 import { CustomTextInput } from './CustomTextInput';
 
@@ -60,7 +60,7 @@ export function ModelPicker({ models, currentModelId, onSelect, onCancel }: Mode
           items={items}
           limit={10}
           onSelect={item => onSelect(item.value)}
-          itemComponent={({ isSelected, label }) => (
+          itemComponent={({ isSelected, label }: ItemProps) => (
             <Box>
               <Text color={isSelected ? 'cyan' : undefined}>{label}</Text>
             </Box>

--- a/packages/cli/src/components/RewindSelector.tsx
+++ b/packages/cli/src/components/RewindSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
-import SelectInput from 'ink-select-input';
+import SelectInput, { type ItemProps } from 'ink-select-input';
 import type { Message } from '../storage/types';
 
 interface RewindSelectorProps {
@@ -92,7 +92,7 @@ export function RewindSelector({ messages, onSelect, onCancel }: RewindSelectorP
         <SelectInput
           items={items}
           onSelect={handleSelectionSelect}
-          itemComponent={({ isSelected, label }) => (
+          itemComponent={({ isSelected, label }: ItemProps) => (
             <Box>
               <Text color={isSelected ? 'cyan' : undefined}>
                 {isSelected ? '❯ ' : '  '}
@@ -140,7 +140,7 @@ export function RewindSelector({ messages, onSelect, onCancel }: RewindSelectorP
       <SelectInput
         items={confirmationItems}
         onSelect={handleConfirmationSelect}
-        itemComponent={({ isSelected, label }) => (
+        itemComponent={({ isSelected, label }: ItemProps) => (
           <Box>
             <Text color={isSelected ? 'cyan' : undefined}>
               {isSelected ? '❯ ' : '  '}

--- a/packages/cli/src/components/SessionSelector.tsx
+++ b/packages/cli/src/components/SessionSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
-import SelectInput from 'ink-select-input';
+import SelectInput, { type ItemProps } from 'ink-select-input';
 import type { Session } from '../storage/types';
 
 interface SessionSelectorProps {
@@ -106,7 +106,7 @@ export function SessionSelector({ sessions, currentSession, onSelect, onCancel }
         <SelectInput
           items={items}
           onSelect={handleSelectionSelect}
-          itemComponent={({ isSelected, label }) => (
+          itemComponent={({ isSelected, label }: ItemProps) => (
             <Box>
               <Text color={isSelected ? 'cyan' : undefined}>{label}</Text>
             </Box>
@@ -142,7 +142,7 @@ export function SessionSelector({ sessions, currentSession, onSelect, onCancel }
       <SelectInput
         items={confirmationItems}
         onSelect={handleConfirmationSelect}
-        itemComponent={({ isSelected, label }) => (
+        itemComponent={({ isSelected, label }: ItemProps) => (
           <Box>
             <Text color={isSelected ? 'cyan' : undefined}>{label}</Text>
           </Box>

--- a/packages/cli/src/components/TrustLocationSelector.tsx
+++ b/packages/cli/src/components/TrustLocationSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import SelectInput from 'ink-select-input';
+import SelectInput, { type ItemProps } from 'ink-select-input';
 
 interface TrustLocationSelectorProps {
   inProject: boolean;
@@ -46,7 +46,7 @@ export function TrustLocationSelector({ inProject, onSelect, onCancel }: TrustLo
       <SelectInput
         items={items}
         onSelect={handleSelect}
-        itemComponent={({ isSelected, label }) => (
+        itemComponent={({ isSelected, label }: ItemProps) => (
           <Box>
             <Text color={isSelected ? 'cyan' : undefined}>
               {isSelected ? '❯ ' : '  '}


### PR DESCRIPTION
# Pull Request

## Description

`typecheck:fast` is defined as `tsgo --noEmit --types node || tsc --noEmit`. The `||` means the script reports success whenever **either** compiler is happy. On the CI runner `tsgo` exits 0, so the `tsc` fallback never executes and its findings are silently discarded.

The result is that stock `tsc` errors can sit on `main` indefinitely without CI ever reporting them, while blocking the pre-push hook for any developer whose machine disagrees. That is the state today: on current `main`, with a clean `pnpm install --frozen-lockfile`, `packages/cli` reports **28** errors and `apps/client` reports **15**, all `TS7006`/`TS7031` implicit-`any`. None of them appear in CI.

The cause in every case is the same: an inline callback handed to a third-party component does not get contextually typed, so its destructured parameters fall to implicit `any`. The clearest example is `ink-select-input`, whose `SelectInput` is generic in `V` and declares `itemComponent?: FC<ItemProps>` - stock `tsc` will not thread the contextual type through that generic inference.

Every fix here uses the library's own exported type. No `any`, no `@ts-ignore`, no casts that suppress a signal.

**Verified against the exact CI commit** (`d8d13590`), detached, with `pnpm install --frozen-lockfile`, to rule out local drift: the installed tree matches the lockfile exactly (`ink@7.1.0_@types+react@19.2.17_react@19.2.7`), yet `pnpm --filter @bike4mind/cli run typecheck:fast` exits 2 while CI's Type Check job for that same SHA reports `packages/cli typecheck:fast: Done`.

## Changes

**`packages/cli`** - 28 errors to **0**

- `EnvironmentPicker`, `ModelPicker`, `RewindSelector`, `SessionSelector`, `TrustLocationSelector`: import `type ItemProps` from `ink-select-input` and annotate the 7 `itemComponent` render props with it.

**`apps/client`** - 15 errors to **5**

- `OverviewTab`, `UsageBySourceCard`: annotate recharts `Pie.label` with `PieLabelRenderProps`. Both callbacks already cast to that type in the body, so this only moves the type to where it gives the parameter its shape.
- `RechartsChart`: annotate `Legend.content` with recharts' `LegendProps`.
- `FilePond`: assert the `server` object as `{ process: ProcessServerConfigFunction }`, which contextually types all seven callback parameters from one annotation instead of restating filepond's signature at the call site.

## What this PR deliberately does NOT fix

Five errors remain in `apps/client`, and they are a different defect:

```
FilePond.tsx(37,5)           TS2607  JSX element class does not support attributes (no 'props' property)
FilePond.tsx(37,6)           TS2786  'FilePond' cannot be used as a JSX component
FloatingChatWindow.tsx(352)  TS2786  'DraggableComponent' cannot be used as a JSX component
LexicalChatInput.tsx(68,20)  TS2339  Property 'style' does not exist on type '{}'
layout.tsx(40,15)            TS2322  ScriptProps mismatch
```

These are an **install-layout** problem, not a code problem. `react-filepond`'s isolated pnpm directory contains only `filepond react react-dom react-filepond` - no `@types/react`. Its declaration does `import * as React from 'react'`, which therefore resolves to the untyped JS package, so `React.Component<FilePondProps>` degrades and the class loses its `props`. `react-draggable` has the same shape.

The correct fix is probably `public-hoist-pattern[]=@types/react` in `.npmrc`, which would likely clear all five at once - but it changes dependency resolution for all 24 workspace packages and deserves its own PR and its own reviewer. The alternative, casting at each use site, would suppress the signal on the file-upload, chat-input and root-layout paths; if `react-filepond` genuinely does not support React 19, a cast hides that until runtime.

## Guide for Testers

No user-visible behaviour changes - this is types only. Verify mechanically:

1. Check out this branch and run `pnpm install --frozen-lockfile`. Expected: completes without error.
2. Run `pnpm --filter @bike4mind/cli run typecheck:fast`. Expected: exit code 0, no output.
3. Run `cd apps/client && ./node_modules/.bin/tsc --noEmit`. Expected: exactly the 5 errors listed above, and no `TS7006` or `TS7031`.
4. Run `pnpm --filter @bike4mind/cli test`. Expected: 2162 passed, 1 skipped.
5. Launch the CLI and open any picker (`/model`, session selector, rewind selector). Expected: the highlighted row still renders with the cyan `>` marker exactly as before.
6. In the web app, open a chat session and drag a file onto the upload area. Expected: the file uploads and appears in the session, unchanged.
7. Go to Admin -> Event Metrics. Expected: the pie charts render with their category/source labels and the legend, unchanged.

## Additional Information

Two follow-ups worth filing:

- **The `||` should fail closed.** As written, `typecheck:fast` treats "at least one compiler is happy" as success. Whatever the two compilers disagree about will keep accumulating on `main` unseen. Running both and requiring both to pass - or dropping the fallback - would surface this class at the point it is introduced.
- **The `@types/react` hoisting decision** described above.

I have not been able to determine *why* `tsgo` exits 0 on the CI runner and non-zero locally on the same pinned version (`7.0.0-dev.20260707.2`); ruled out node version (fails identically on 22 and 24), `jsx` mode, module resolution, duplicate React types, stale `.tsbuildinfo`, `node_modules` drift, and stray `node_modules` above the repo. That question is worth answering separately, but it does not change that the errors fixed here are real under stock `tsc`.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - no UI change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
