### PR TITLE
fix(admin): keep an expanded sidebar section above neighboring headers

### DIFF
--- a/apps/client/app/components/admin/AdminPage.tsx
+++ b/apps/client/app/components/admin/AdminPage.tsx
@@ -186,7 +186,15 @@ const SidebarNav = ({
         const { Icon: SectionIcon } = section;
         const visibleItems = section.items.filter(item => !item.gate || gates[item.gate]);
         return (
-          <Accordion key={section.key} expanded={isExpanded(section.key)} onChange={() => toggleSection(section.key)}>
+          <Accordion
+            key={section.key}
+            expanded={isExpanded(section.key)}
+            onChange={() => toggleSection(section.key)}
+            // raise an expanded panel above its neighbors so a neighboring
+            // header cannot intercept clicks on this section's nav items. Joy
+            // elevates a summary to zIndex 1 on focus/hover, so beat that.
+            sx={{ position: 'relative', ...(isExpanded(section.key) && { zIndex: 2 }) }}
+          >
             <AccordionSummary>
               <SectionIcon color="primary" />
               <Typography color="primary" level="body-md">


### PR DESCRIPTION
## Description

The admin nav shell stacks each section in a Joy `AccordionGroup`. The accordions render in normal document flow with no stacking handling, so a neighboring collapsed summary could sit above an expanded panel and intercept pointer clicks on that panel's nav items. This was surfaced during QA of #1556 (the "Model Metrics" item could not be clicked with a normal pointer and needed a scripted `.click()`), but the defect is in the nav shell (`AdminPage.tsx`), not the Model Metrics / Spend content.

Root cause: Joy elevates an `AccordionSummary` to `zIndex: 1` on focus/hover ("to make the focus ring appear above the next Accordion"), and with no stacking context on the panels a neighboring header's layer can win the pointer over an open panel's items. Whichever element is stacked higher on a shared pixel receives the click, so raising the expanded panel above its neighbors makes each open section's nav items own their click target.

Closes #1629

## Changes

- `apps/client/app/components/admin/AdminPage.tsx`: give each sidebar `Accordion` `position: relative`, and raise an **expanded** section to `zIndex: 2` (beating Joy's `zIndex: 1` summary focus/hover layer) so a neighboring header can no longer intercept clicks on its nav items.

## Guide for Testers

1. Open the admin area (desktop width, `md+`) so the left sidebar accordion nav is shown.
2. Expand a section (e.g. the one containing **Model Metrics**) and click each nav item with a normal mouse pointer.
3. Verify every item activates on the first click - no item requires a second try or feels "unclickable".
4. Expand a different section and repeat, including items that sit directly next to another section's header.
5. Confirm expand/collapse still toggles normally and the active-tab highlight is unchanged.

Note: this is a stacking/layout fix. jsdom has no layout engine, so pointer interception is not unit-testable; the existing admin sidebar unit tests (18) still pass, and visual confirmation belongs on the preview.

## Additional Information

Scope check: the other 9 `AccordionGroup` usages in the client are content/detail panels (email job detail, context inspector, iteration stream, research mode, etc.), not stacked nav menus with adjacent click targets, so they do not share this interception shape and are intentionally left untouched.

## Developer Notes (Optional)

The raised `zIndex` is applied only while a panel is expanded, so collapsed sections keep default stacking and there is no broader z-index churn in the sidebar.

## Checklist
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings