### PR TITLE
refactor(data-lakes): consolidate the lake manage rule onto canManageLake

### DIFF
--- a/apps/client/pages/api/data-lakes/[id]/__tests__/lifecycle.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/lifecycle.test.ts
@@ -103,7 +103,7 @@ describe('POST /api/data-lakes/[id]/lifecycle - cleanup action (enqueue offload)
 
   it('now delegates to canManageLake, so a blank-identity lake is rejected rather than granted (#1153)', async () => {
     h.toAccessContext.mockResolvedValueOnce({ userId: '', isAdmin: false });
-    h.assertLakeAccess.mockResolvedValue({ id: 'lake1', status: 'deleted', createdByUserId: undefined });
+    h.assertLakeAccess.mockResolvedValue({ id: 'lake1', status: 'deleted', createdByUserId: '' });
     const { res } = makeRes();
     await (handler as (req: unknown, res: unknown) => Promise<void>)(req({ action: 'cleanup' }), res);
 

--- a/apps/client/pages/api/data-lakes/[id]/__tests__/lifecycle.test.ts
+++ b/apps/client/pages/api/data-lakes/[id]/__tests__/lifecycle.test.ts
@@ -6,6 +6,12 @@ const h = vi.hoisted(() => ({
   archiveDataLake: vi.fn(),
   deleteDataLake: vi.fn(),
   cleanupDeletedDataLake: vi.fn(),
+  // Real admin-or-creator logic (not a bare stub) so the cleanup action's canManageLake call
+  // behaves identically to production for these tests, including the blank-identity case.
+  canManageLake: vi.fn(
+    (lake: { createdByUserId?: string }, actor: { userId?: string; isAdmin: boolean }) =>
+      actor.isAdmin || (!!actor.userId && !!lake.createdByUserId && lake.createdByUserId === actor.userId)
+  ),
   openSearchRetrievalIndex: vi.fn(() => ({ removeForDataLake: vi.fn() })),
   sendToQueue: vi.fn(),
   getSourceQueueUrl: vi.fn(() => 'https://sqs.example.com/data-lake-cleanup'),
@@ -32,6 +38,7 @@ vi.mock('@bike4mind/services', () => ({
     archiveDataLake: h.archiveDataLake,
     deleteDataLake: h.deleteDataLake,
     cleanupDeletedDataLake: h.cleanupDeletedDataLake,
+    canManageLake: h.canManageLake,
     openSearchRetrievalIndex: h.openSearchRetrievalIndex,
   },
 }));
@@ -91,6 +98,17 @@ describe('POST /api/data-lakes/[id]/lifecycle - cleanup action (enqueue offload)
     await (handler as (req: unknown, res: unknown) => Promise<void>)(req({ action: 'cleanup' }), res);
 
     expect(res.status).toHaveBeenCalledWith(400);
+    expect(h.sendToQueue).not.toHaveBeenCalled();
+  });
+
+  it('now delegates to canManageLake, so a blank-identity lake is rejected rather than granted (#1153)', async () => {
+    h.toAccessContext.mockResolvedValueOnce({ userId: '', isAdmin: false });
+    h.assertLakeAccess.mockResolvedValue({ id: 'lake1', status: 'deleted', createdByUserId: undefined });
+    const { res } = makeRes();
+    await (handler as (req: unknown, res: unknown) => Promise<void>)(req({ action: 'cleanup' }), res);
+
+    expect(h.canManageLake).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
     expect(h.sendToQueue).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/pages/api/data-lakes/[id]/lifecycle.ts
+++ b/apps/client/pages/api/data-lakes/[id]/lifecycle.ts
@@ -88,7 +88,7 @@ const handler = baseApi()
         // Mirror the service's owner/admin + soft-deleted guards synchronously so a non-owner or
         // a not-deleted request gets an immediate 4xx rather than a 202 for a message the consumer
         // would just drop (the consumer re-checks the same guards, so a stale message is still safe).
-        if (!actor.isAdmin && lake.createdByUserId !== actor.userId) {
+        if (!dataLakeService.canManageLake(lake, actor)) {
           return res.status(403).json({ error: 'Only the creator can clean up this data lake' });
         }
         if (lake.status !== 'deleted') {

--- a/apps/client/pages/api/data-lakes/batches/[batchId]/__tests__/reanalyze-taxonomy.test.ts
+++ b/apps/client/pages/api/data-lakes/batches/[batchId]/__tests__/reanalyze-taxonomy.test.ts
@@ -5,6 +5,12 @@ const h = vi.hoisted(() => ({
   lakeFindById: vi.fn(),
   setTaxonomyStatusIfActive: vi.fn(),
   analyzeBatchTaxonomy: vi.fn(),
+  // Real admin-or-creator logic (not a bare stub), matching the sibling lifecycle.test.ts mock,
+  // so the manage-gate call behaves identically to production, including the blank-identity case.
+  canManageLake: vi.fn(
+    (lake: { createdByUserId?: string }, actor: { userId?: string; isAdmin: boolean }) =>
+      actor.isAdmin || (!!actor.userId && !!lake.createdByUserId && lake.createdByUserId === actor.userId)
+  ),
 }));
 
 vi.mock('@server/middlewares/baseApi', () => ({
@@ -26,6 +32,7 @@ vi.mock('@bike4mind/database', () => ({
   dataLakeBatchRepository: { findById: h.batchFindById, setTaxonomyStatusIfActive: h.setTaxonomyStatusIfActive },
   dataLakeRepository: { findById: h.lakeFindById },
 }));
+vi.mock('@bike4mind/services', () => ({ dataLakeService: { canManageLake: h.canManageLake } }));
 
 import handler from '../reanalyze-taxonomy';
 
@@ -60,6 +67,15 @@ describe('POST /api/data-lakes/batches/[batchId]/reanalyze-taxonomy', () => {
     const { res } = makeRes();
 
     await expect(run('b1', res)).rejects.toThrow(/creator/i);
+    expect(h.analyzeBatchTaxonomy).not.toHaveBeenCalled();
+  });
+
+  it('now delegates to canManageLake, so a blank-identity lake is rejected rather than granted (#1153)', async () => {
+    h.lakeFindById.mockResolvedValue({ id: 'lake1', createdByUserId: undefined, fileTagPrefix: 'acme:' });
+    const { res } = makeRes();
+
+    await expect(run('b1', res, {}, { id: '', isAdmin: false })).rejects.toThrow(/creator/i);
+    expect(h.canManageLake).toHaveBeenCalled();
     expect(h.analyzeBatchTaxonomy).not.toHaveBeenCalled();
   });
 

--- a/apps/client/pages/api/data-lakes/batches/[batchId]/__tests__/reanalyze-taxonomy.test.ts
+++ b/apps/client/pages/api/data-lakes/batches/[batchId]/__tests__/reanalyze-taxonomy.test.ts
@@ -71,7 +71,7 @@ describe('POST /api/data-lakes/batches/[batchId]/reanalyze-taxonomy', () => {
   });
 
   it('now delegates to canManageLake, so a blank-identity lake is rejected rather than granted (#1153)', async () => {
-    h.lakeFindById.mockResolvedValue({ id: 'lake1', createdByUserId: undefined, fileTagPrefix: 'acme:' });
+    h.lakeFindById.mockResolvedValue({ id: 'lake1', createdByUserId: '', fileTagPrefix: 'acme:' });
     const { res } = makeRes();
 
     await expect(run('b1', res, {}, { id: '', isAdmin: false })).rejects.toThrow(/creator/i);

--- a/apps/client/pages/api/data-lakes/batches/[batchId]/reanalyze-taxonomy.ts
+++ b/apps/client/pages/api/data-lakes/batches/[batchId]/reanalyze-taxonomy.ts
@@ -9,6 +9,7 @@ import {
   TAXONOMY_RATE_LIMIT_WINDOW_MS,
 } from '@server/dataLakes/taxonomyRateLimit';
 import { BadRequestError, NotFoundError, ReanalyzeTaxonomyRequestInput, hasDeveloperUserTag } from '@bike4mind/common';
+import { dataLakeService } from '@bike4mind/services';
 import { dataLakeBatchRepository, dataLakeRepository } from '@bike4mind/database';
 import { Request } from 'express';
 
@@ -42,7 +43,7 @@ const handler = baseApi()
 
     const lake = await dataLakeRepository.findById(batch.dataLakeId);
     if (!lake) throw new NotFoundError('Data lake not found');
-    if (!req.user.isAdmin && lake.createdByUserId !== userId) {
+    if (!dataLakeService.canManageLake(lake, { userId, isAdmin: req.user.isAdmin })) {
       throw new BadRequestError('Only the creator can re-analyze this batch');
     }
 

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -5,7 +5,7 @@ import type {
   IFabFileRepository,
 } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
-import { canManageLake } from './authorizeLakeWrite';
+import { canManageLake } from './manageRule';
 import { recomputeLakeStats } from './recomputeLakeStats';
 import { lakeMembershipScope } from './lakeMembershipScope';
 import { warnOnPrefixCollision } from './tagPrefixCollision';

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -5,6 +5,7 @@ import type {
   IFabFileRepository,
 } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { canManageLake } from './authorizeLakeWrite';
 import { recomputeLakeStats } from './recomputeLakeStats';
 import { lakeMembershipScope } from './lakeMembershipScope';
 import { warnOnPrefixCollision } from './tagPrefixCollision';
@@ -42,7 +43,7 @@ export const archiveDataLake = async (
     throw new NotFoundError('Data lake not found');
   }
 
-  if (!actor.isAdmin && existing.createdByUserId !== actor.userId) {
+  if (!canManageLake(existing, actor)) {
     throw new BadRequestError('Only the creator can archive this data lake');
   }
 

--- a/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
+++ b/b4m-core/services/src/dataLakeService/assertLakeAccess.ts
@@ -1,6 +1,7 @@
 import type { AccessContext, IDataLakeDocument, IDataLakeRepository } from '@bike4mind/common';
 import { DATA_LAKES, lakeMatchesAccess, normalizeEntitlementKey } from '@bike4mind/common';
 import { BadRequestError, NotFoundError, normalizeId } from '@bike4mind/utils';
+import { canManageLake } from './manageRule';
 
 interface AssertLakeAccessAdapters {
   db: {
@@ -36,7 +37,7 @@ export function canAccessLake(
   >,
   ctx: AccessContext
 ): boolean {
-  if (ctx.isAdmin || lake.createdByUserId === ctx.userId) return true;
+  if (canManageLake(lake, ctx)) return true;
 
   const normalizedTags = ctx.userTags.map(t => t.toLowerCase());
   const normalizedKeys = (ctx.entitlementKeys ?? []).map(normalizeEntitlementKey);

--- a/b4m-core/services/src/dataLakeService/authorizeLakeWrite.ts
+++ b/b4m-core/services/src/dataLakeService/authorizeLakeWrite.ts
@@ -2,30 +2,9 @@ import type { AccessContext, IDataLakeBatchDocument, IDataLakeDocument, IDataLak
 import { DATALAKE_TAG_PREFIX } from '@bike4mind/common';
 import { BadRequestError } from '@bike4mind/utils';
 import { assertLakeAccess, assertLakeWritable } from './assertLakeAccess';
+import { canManageLake, type ManageActor } from './manageRule';
 
-/** The acting principal for a write/manage decision - resolved from auth, never the body. */
-type ManageActor = Pick<AccessContext, 'userId' | 'isAdmin'>;
-
-/**
- * The single WRITE/MANAGE decision for a lake: platform admin, or the lake's creator. This is
- * the exact rule the remove path (`removeFileFromDataLake`) and the visibility change already
- * enforce inline - centralized here so every mutating path agrees on who may write.
- *
- * Deliberately narrower than `canAccessLake` (read): a tag/entitlement/org grant lets a member
- * READ a lake but NOT write into it. Injecting a file (applying the lake's meta-tag) is a write,
- * so it must clear this gate, closing the read-can-write asymmetry.
- *
- * The truthiness guard makes the owner arm fail closed on a blank identity: without it, a lake with
- * no `createdByUserId` (the synthetic fallback document) would match an actor with no `userId`, since
- * `undefined === undefined` and `'' === ''`. Unreachable today - the schema requires the field and
- * `AccessContext.userId` is a required string - but this predicate now gates prompt DISCLOSURE as
- * well as writes, so it should not depend on those invariants holding elsewhere. Mirrors the same
- * guard in `getDataLakePrompts.ts`.
- */
-export function canManageLake(lake: Pick<IDataLakeDocument, 'createdByUserId'>, actor: ManageActor): boolean {
-  if (actor.isAdmin) return true;
-  return !!actor.userId && !!lake.createdByUserId && lake.createdByUserId === actor.userId;
-}
+export { canManageLake, type ManageActor } from './manageRule';
 
 /**
  * Resolve a lake by id-or-slug and assert the caller may WRITE into it. Read access is checked

--- a/b4m-core/services/src/dataLakeService/browsePublicDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/browsePublicDataLakes.ts
@@ -4,7 +4,7 @@ import type {
   IDataLakeRepository,
   PublicDataLakeSummary,
 } from '@bike4mind/common';
-import { canManageLake } from './manageRule';
+import { canManageLake, isLakeCreator } from './manageRule';
 
 /** The browsing caller. Only identity is needed - the public catalog is the same for everyone. */
 interface BrowseActor {
@@ -63,10 +63,8 @@ export const browsePublicDataLakes = async (
   const nameById = new Map(owners.map(u => [String(u.id), u.name || u.username || undefined]));
 
   const data: PublicDataLakeSummary[] = lakes.map((lake: IDataLakeDocument) => {
-    // Truthy-guarded like canManageLake's owner arm, but deliberately not that predicate: isOwn
-    // has no admin bypass, and a blank-creator legacy lake must not read as owned by a caller
-    // with no identity.
-    const isOwn = !!actor.userId && !!lake.createdByUserId && lake.createdByUserId === actor.userId;
+    // isLakeCreator, not canManageLake: isOwn has no admin bypass.
+    const isOwn = isLakeCreator(lake, actor);
     return {
       id: lake.id,
       slug: lake.slug,

--- a/b4m-core/services/src/dataLakeService/browsePublicDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/browsePublicDataLakes.ts
@@ -4,6 +4,7 @@ import type {
   IDataLakeRepository,
   PublicDataLakeSummary,
 } from '@bike4mind/common';
+import { canManageLake } from './authorizeLakeWrite';
 
 /** The browsing caller. Only identity is needed - the public catalog is the same for everyone. */
 interface BrowseActor {
@@ -73,7 +74,7 @@ export const browsePublicDataLakes = async (
       fileCount: lake.fileCount ?? 0,
       totalSizeBytes: lake.totalSizeBytes ?? 0,
       isOwn,
-      canManage: actor.isAdmin || isOwn,
+      canManage: canManageLake(lake, actor),
     };
   });
 

--- a/b4m-core/services/src/dataLakeService/browsePublicDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/browsePublicDataLakes.ts
@@ -4,7 +4,7 @@ import type {
   IDataLakeRepository,
   PublicDataLakeSummary,
 } from '@bike4mind/common';
-import { canManageLake } from './authorizeLakeWrite';
+import { canManageLake } from './manageRule';
 
 /** The browsing caller. Only identity is needed - the public catalog is the same for everyone. */
 interface BrowseActor {
@@ -63,7 +63,10 @@ export const browsePublicDataLakes = async (
   const nameById = new Map(owners.map(u => [String(u.id), u.name || u.username || undefined]));
 
   const data: PublicDataLakeSummary[] = lakes.map((lake: IDataLakeDocument) => {
-    const isOwn = lake.createdByUserId === actor.userId;
+    // Truthy-guarded like canManageLake's owner arm, but deliberately not that predicate: isOwn
+    // has no admin bypass, and a blank-creator legacy lake must not read as owned by a caller
+    // with no identity.
+    const isOwn = !!actor.userId && !!lake.createdByUserId && lake.createdByUserId === actor.userId;
     return {
       id: lake.id,
       slug: lake.slug,

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
@@ -5,6 +5,7 @@ import type {
   IFabFileChunkRepository,
 } from '@bike4mind/common';
 import { BadRequestError } from '@bike4mind/utils';
+import { canManageLake } from './authorizeLakeWrite';
 import { lakeMembershipScope } from './lakeMembershipScope';
 import { warnOnPrefixCollision } from './tagPrefixCollision';
 import { strictIndexRemove, type RetrievalIndexPort } from './ports';
@@ -61,7 +62,7 @@ export const cleanupDeletedDataLake = async (
     // Already gone - idempotent success.
     return;
   }
-  if (!actor.isAdmin && existing.createdByUserId !== actor.userId) {
+  if (!canManageLake(existing, actor)) {
     throw new BadRequestError('Only the creator can clean up this data lake');
   }
   if (existing.status !== 'deleted') {

--- a/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/cleanupDeletedDataLake.ts
@@ -5,7 +5,7 @@ import type {
   IFabFileChunkRepository,
 } from '@bike4mind/common';
 import { BadRequestError } from '@bike4mind/utils';
-import { canManageLake } from './authorizeLakeWrite';
+import { canManageLake } from './manageRule';
 import { lakeMembershipScope } from './lakeMembershipScope';
 import { warnOnPrefixCollision } from './tagPrefixCollision';
 import { strictIndexRemove, type RetrievalIndexPort } from './ports';

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -80,6 +80,12 @@ describe('canAccessLake — the single access gate rule', () => {
     );
   });
 
+  it('now delegates the owner arm to canManageLake, so a blank identity fails closed (#1153)', () => {
+    // Before: `ctx.isAdmin || lake.createdByUserId === ctx.userId` granted when both sides were
+    // blank/undefined. A revert back to that bare form would flip this to true.
+    expect(canAccessLake(lake({ createdByUserId: undefined as unknown as string }), ctx({ userId: '' }))).toBe(false);
+  });
+
   it('grants a non-owner who satisfies BOTH org and tag', () => {
     const l = lake({ organizationId: 'orgA', requiredUserTag: 'Opti' });
     expect(canAccessLake(l, ctx({ organizationId: 'orgA', userTags: ['opti'] }))).toBe(true);
@@ -377,6 +383,15 @@ describe('listDataLakes - per-lake canManage flag for the UI', () => {
     const result = await listDataLakes(ctx({ userId: 'admin', isAdmin: true }), { db });
 
     expect(result.find(l => l.id === 'theirs')?.canManage).toBe(true);
+  });
+
+  it('now delegates to canManageLake, so a blank-identity lake stays unmanageable (#1153)', async () => {
+    const blank = lake({ id: 'blank', slug: 'blank', createdByUserId: undefined as unknown as string });
+    const db = { dataLakes: { findAccessible: vi.fn().mockResolvedValue([blank]), find: vi.fn() } };
+
+    const result = await listDataLakes(ctx({ userId: '' }), { db });
+
+    expect(result.find(l => l.id === 'blank')?.canManage).toBe(false);
   });
 
   it('marks built-in fallback lakes read-only even for their access holders', async () => {
@@ -785,6 +800,17 @@ describe('assertLakeWriteAccess — read-then-manage gate for the upload doors',
   });
 });
 
+describe('updateDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
+  it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
+    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn() } };
+    await expect(updateDataLake({ userId: '', isAdmin: false }, 'lake1', { name: 'Renamed' }, { db })).rejects.toThrow(
+      /creator/i
+    );
+    expect(db.dataLakes.update).not.toHaveBeenCalled();
+  });
+});
+
 describe('updateDataLake — gate-after-publish guardrail', () => {
   it('refuses adding a required tag or entitlement to a public lake (mirrors setLakeVisibility)', async () => {
     const l = lake({ createdByUserId: 'owner', isPublic: true });
@@ -1114,6 +1140,15 @@ describe('createDataLake', () => {
   });
 });
 
+describe('unarchiveDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
+  it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
+    const blank = lake({ createdByUserId: undefined as unknown as string, status: 'archived' });
+    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn(), setStats: vi.fn() } };
+    await expect(unarchiveDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(/creator/i);
+    expect(db.dataLakes.update).not.toHaveBeenCalled();
+  });
+});
+
 describe('unarchiveDataLake — dedup pass (live re-upload wins)', () => {
   it('discards archived duplicates and restores the rest', async () => {
     const archived = [
@@ -1167,6 +1202,17 @@ describe('unarchiveDataLake — dedup pass (live re-upload wins)', () => {
   });
 });
 
+describe('restoreDeletedDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
+  it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
+    const blank = lake({ createdByUserId: undefined as unknown as string, status: 'deleted' });
+    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn(), setStats: vi.fn() } };
+    await expect(restoreDeletedDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(
+      /creator/i
+    );
+    expect(db.dataLakes.update).not.toHaveBeenCalled();
+  });
+});
+
 describe('restoreDeletedDataLake — deleted→active with dedup', () => {
   it('rejects a lake that is not soft-deleted', async () => {
     const dataLakes = {
@@ -1212,6 +1258,15 @@ describe('restoreDeletedDataLake — deleted→active with dedup', () => {
     expect(fabFiles.findByContentHashesInDataLake).toHaveBeenCalledWith(['h1', 'h2'], 'datalake:lake');
     expect(result.skippedDuplicates).toBe(1);
     expect(result.restoredCount).toBe(1);
+  });
+});
+
+describe('archiveDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
+  it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
+    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn(), setStats: vi.fn() } };
+    await expect(archiveDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(/creator/i);
+    expect(db.dataLakes.update).not.toHaveBeenCalled();
   });
 });
 
@@ -1385,6 +1440,15 @@ describe('archiveDataLake - retrieval-index removal', () => {
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
     expect(adapters.db.dataLakes.update).not.toHaveBeenCalledWith(expect.objectContaining({ filesArchivedAt: null }));
+  });
+});
+
+describe('deleteDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
+  it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
+    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn() } };
+    await expect(deleteDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(/creator/i);
+    expect(db.dataLakes.update).not.toHaveBeenCalled();
   });
 });
 
@@ -1612,6 +1676,16 @@ describe('teardown stamp bookkeeping', () => {
         ARCHIVE_RECORDED
       );
     });
+  });
+});
+
+describe('cleanupDeletedDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
+  it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
+    const blank = lake({ createdByUserId: undefined as unknown as string, status: 'deleted' });
+    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank) } };
+    await expect(cleanupDeletedDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(
+      /creator/i
+    );
   });
 });
 
@@ -2029,6 +2103,28 @@ describe('removeFileFromDataLake — single-file removal', () => {
   });
 });
 
+describe('setLakeVisibility - now delegates the manage gate to canManageLake (#1153)', () => {
+  it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
+    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn() } };
+    await expect(setLakeVisibility({ userId: '', isAdmin: false }, 'lake1', 'private', { db } as any)).rejects.toThrow(
+      /creator/i
+    );
+    expect(db.dataLakes.update).not.toHaveBeenCalled();
+  });
+
+  it('the separate owner-only expose check ALSO fails closed on a blank identity, without an admin bypass', async () => {
+    // Line 50 is deliberately NOT canManageLake (no admin bypass), so pin it with its own case:
+    // an admin with a blank userId must still be refused when exposing a blank-owner lake.
+    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn() } };
+    await expect(setLakeVisibility({ userId: '', isAdmin: true }, 'lake1', 'public', { db } as any)).rejects.toThrow(
+      /owner/i
+    );
+    expect(db.dataLakes.update).not.toHaveBeenCalled();
+  });
+});
+
 describe('setLakeVisibility — personal ↔ org promotion', () => {
   const makeDb = (existing: Partial<IDataLakeDocument> = {}, clashes: IDataLakeDocument[] = []) => ({
     dataLakes: {
@@ -2207,6 +2303,20 @@ describe('setLakeVisibility — personal ↔ org promotion', () => {
     const db = makeDb({ isPublic: true });
     await setLakeVisibility({ userId: 'owner', isAdmin: false }, 'lake1', 'public', { db } as any);
     expect(db.dataLakes.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('browsePublicDataLakes - canManage now delegates to canManageLake (#1153)', () => {
+  it('a blank-identity lake reports canManage: false rather than granting on the both-unset match', async () => {
+    const blank = lake({
+      id: 'pub-blank',
+      slug: 'pub-blank',
+      createdByUserId: undefined as unknown as string,
+      isPublic: true,
+    });
+    const db = { dataLakes: { findPublicLakes: vi.fn().mockResolvedValue({ lakes: [blank], total: 1 }) }, users: {} };
+    const { data } = await browsePublicDataLakes({ userId: '', isAdmin: false }, {}, { db } as any);
+    expect(data[0].canManage).toBe(false);
   });
 });
 

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -83,7 +83,7 @@ describe('canAccessLake — the single access gate rule', () => {
   it('now delegates the owner arm to canManageLake, so a blank identity fails closed (#1153)', () => {
     // Before: `ctx.isAdmin || lake.createdByUserId === ctx.userId` granted when both sides were
     // blank/undefined. A revert back to that bare form would flip this to true.
-    expect(canAccessLake(lake({ createdByUserId: undefined as unknown as string }), ctx({ userId: '' }))).toBe(false);
+    expect(canAccessLake(lake({ createdByUserId: '' }), ctx({ userId: '' }))).toBe(false);
   });
 
   it('grants a non-owner who satisfies BOTH org and tag', () => {
@@ -386,7 +386,7 @@ describe('listDataLakes - per-lake canManage flag for the UI', () => {
   });
 
   it('now delegates to canManageLake, so a blank-identity lake stays unmanageable (#1153)', async () => {
-    const blank = lake({ id: 'blank', slug: 'blank', createdByUserId: undefined as unknown as string });
+    const blank = lake({ id: 'blank', slug: 'blank', createdByUserId: '' });
     const db = { dataLakes: { findAccessible: vi.fn().mockResolvedValue([blank]), find: vi.fn() } };
 
     const result = await listDataLakes(ctx({ userId: '' }), { db });
@@ -802,7 +802,7 @@ describe('assertLakeWriteAccess — read-then-manage gate for the upload doors',
 
 describe('updateDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
   it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
-    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const blank = lake({ createdByUserId: '' });
     const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn() } };
     await expect(updateDataLake({ userId: '', isAdmin: false }, 'lake1', { name: 'Renamed' }, { db })).rejects.toThrow(
       /creator/i
@@ -1142,7 +1142,7 @@ describe('createDataLake', () => {
 
 describe('unarchiveDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
   it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
-    const blank = lake({ createdByUserId: undefined as unknown as string, status: 'archived' });
+    const blank = lake({ createdByUserId: '', status: 'archived' });
     const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn(), setStats: vi.fn() } };
     await expect(unarchiveDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(/creator/i);
     expect(db.dataLakes.update).not.toHaveBeenCalled();
@@ -1204,7 +1204,7 @@ describe('unarchiveDataLake — dedup pass (live re-upload wins)', () => {
 
 describe('restoreDeletedDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
   it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
-    const blank = lake({ createdByUserId: undefined as unknown as string, status: 'deleted' });
+    const blank = lake({ createdByUserId: '', status: 'deleted' });
     const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn(), setStats: vi.fn() } };
     await expect(restoreDeletedDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(
       /creator/i
@@ -1263,7 +1263,7 @@ describe('restoreDeletedDataLake — deleted→active with dedup', () => {
 
 describe('archiveDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
   it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
-    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const blank = lake({ createdByUserId: '' });
     const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn(), setStats: vi.fn() } };
     await expect(archiveDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(/creator/i);
     expect(db.dataLakes.update).not.toHaveBeenCalled();
@@ -1445,7 +1445,7 @@ describe('archiveDataLake - retrieval-index removal', () => {
 
 describe('deleteDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
   it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
-    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const blank = lake({ createdByUserId: '' });
     const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn() } };
     await expect(deleteDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(/creator/i);
     expect(db.dataLakes.update).not.toHaveBeenCalled();
@@ -1681,7 +1681,7 @@ describe('teardown stamp bookkeeping', () => {
 
 describe('cleanupDeletedDataLake - now delegates the manage gate to canManageLake (#1153)', () => {
   it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
-    const blank = lake({ createdByUserId: undefined as unknown as string, status: 'deleted' });
+    const blank = lake({ createdByUserId: '', status: 'deleted' });
     const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank) } };
     await expect(cleanupDeletedDataLake({ userId: '', isAdmin: false }, 'lake1', { db } as any)).rejects.toThrow(
       /creator/i
@@ -2105,7 +2105,7 @@ describe('removeFileFromDataLake — single-file removal', () => {
 
 describe('setLakeVisibility - now delegates the manage gate to canManageLake (#1153)', () => {
   it('denies a blank-identity lake rather than granting on the both-unset match', async () => {
-    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const blank = lake({ createdByUserId: '' });
     const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn() } };
     await expect(setLakeVisibility({ userId: '', isAdmin: false }, 'lake1', 'private', { db } as any)).rejects.toThrow(
       /creator/i
@@ -2116,7 +2116,7 @@ describe('setLakeVisibility - now delegates the manage gate to canManageLake (#1
   it('the separate owner-only expose check ALSO fails closed on a blank identity, without an admin bypass', async () => {
     // Line 50 is deliberately NOT canManageLake (no admin bypass), so pin it with its own case:
     // an admin with a blank userId must still be refused when exposing a blank-owner lake.
-    const blank = lake({ createdByUserId: undefined as unknown as string });
+    const blank = lake({ createdByUserId: '' });
     const db = { dataLakes: { findById: vi.fn().mockResolvedValue(blank), update: vi.fn() } };
     await expect(setLakeVisibility({ userId: '', isAdmin: true }, 'lake1', 'public', { db } as any)).rejects.toThrow(
       /owner/i
@@ -2311,7 +2311,7 @@ describe('browsePublicDataLakes - canManage now delegates to canManageLake (#115
     const blank = lake({
       id: 'pub-blank',
       slug: 'pub-blank',
-      createdByUserId: undefined as unknown as string,
+      createdByUserId: '',
       isPublic: true,
     });
     const db = { dataLakes: { findPublicLakes: vi.fn().mockResolvedValue({ lakes: [blank], total: 1 }) }, users: {} };

--- a/b4m-core/services/src/dataLakeService/deleteDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/deleteDataLake.ts
@@ -5,6 +5,7 @@ import type {
   IFabFileRepository,
 } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { canManageLake } from './authorizeLakeWrite';
 import { lakeMembershipScope } from './lakeMembershipScope';
 import { warnOnPrefixCollision } from './tagPrefixCollision';
 import { bestEffortIndexRemove, type RetrievalIndexPort } from './ports';
@@ -35,7 +36,7 @@ export const deleteDataLake = async (
   if (!existing) {
     throw new NotFoundError('Data lake not found');
   }
-  if (!actor.isAdmin && existing.createdByUserId !== actor.userId) {
+  if (!canManageLake(existing, actor)) {
     throw new BadRequestError('Only the creator can delete this data lake');
   }
   // Only short-circuit on the terminal state. A lake stuck in transitional 'deleting'

--- a/b4m-core/services/src/dataLakeService/deleteDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/deleteDataLake.ts
@@ -5,7 +5,7 @@ import type {
   IFabFileRepository,
 } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
-import { canManageLake } from './authorizeLakeWrite';
+import { canManageLake } from './manageRule';
 import { lakeMembershipScope } from './lakeMembershipScope';
 import { warnOnPrefixCollision } from './tagPrefixCollision';
 import { bestEffortIndexRemove, type RetrievalIndexPort } from './ports';

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -32,6 +32,12 @@ interface ListDataLakesAdapters {
 
 const toConfig = (dl: IDataLakeDocument): DataLakeConfig => toDataLakeConfig(dl);
 
+// Truthy-guarded like canManageLake's owner arm, but deliberately not that predicate: isOwn has
+// no admin bypass (it answers "did I create this", not "may I manage this"), and it gates the
+// UI's "not your lake" warning marker - a blank-creator legacy lake must not read as owned.
+const isOwnLake = (dl: Pick<IDataLakeDocument, 'createdByUserId'>, ctx: Pick<AccessContext, 'userId'>): boolean =>
+  !!ctx.userId && !!dl.createdByUserId && dl.createdByUserId === ctx.userId;
+
 /**
  * Batch-resolve creator display names (name || username, never email - the same PII rule as the
  * discover catalog) for the lakes the caller does not own, in one round-trip. Returns an empty
@@ -124,12 +130,7 @@ export const listDataLakes = async (
   // content-scope resolver passes no `users` adapter and this resolves to an empty map).
   const ownerNames = await resolveOwnerNames(dynamicLakes, ctx.userId, db.users);
   const dynamicConfigs = dynamicLakes.map(dl =>
-    toManageableConfig(
-      dl,
-      canManageLake(dl, ctx),
-      dl.createdByUserId === ctx.userId,
-      ownerNames.get(dl.createdByUserId)
-    )
+    toManageableConfig(dl, canManageLake(dl, ctx), isOwnLake(dl, ctx), ownerNames.get(dl.createdByUserId))
   );
 
   // Merge with hardcoded fallbacks (DB entries take precedence by slug/id).
@@ -168,7 +169,7 @@ export const listAllDataLakes = async (
 
   const ownerNames = await resolveOwnerNames(dynamicLakes, ctx.userId, db.users);
   const dynamicConfigs = dynamicLakes.map(dl =>
-    toManageableConfig(dl, true, dl.createdByUserId === ctx.userId, ownerNames.get(dl.createdByUserId))
+    toManageableConfig(dl, true, isOwnLake(dl, ctx), ownerNames.get(dl.createdByUserId))
   );
   const dynamicIds = new Set(dynamicLakes.map(d => d.slug));
   const fallbacks = DATA_LAKES.filter(dl => !dynamicIds.has(dl.id)).map(toFallbackConfig);

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -6,7 +6,7 @@ import type {
   ManageableDataLakeConfig,
 } from '@bike4mind/common';
 import { DATA_LAKES, toDataLakeConfig, lakeMatchesAccess, normalizeEntitlementKey } from '@bike4mind/common';
-import { canManageLake } from './manageRule';
+import { canManageLake, isLakeCreator } from './manageRule';
 import { redactLakesForActor, type ReaderDataLake } from './redactLakeForActor';
 
 /**
@@ -31,12 +31,6 @@ interface ListDataLakesAdapters {
 }
 
 const toConfig = (dl: IDataLakeDocument): DataLakeConfig => toDataLakeConfig(dl);
-
-// Truthy-guarded like canManageLake's owner arm, but deliberately not that predicate: isOwn has
-// no admin bypass (it answers "did I create this", not "may I manage this"), and it gates the
-// UI's "not your lake" warning marker - a blank-creator legacy lake must not read as owned.
-const isOwnLake = (dl: Pick<IDataLakeDocument, 'createdByUserId'>, ctx: Pick<AccessContext, 'userId'>): boolean =>
-  !!ctx.userId && !!dl.createdByUserId && dl.createdByUserId === ctx.userId;
 
 /**
  * Batch-resolve creator display names (name || username, never email - the same PII rule as the
@@ -130,7 +124,7 @@ export const listDataLakes = async (
   // content-scope resolver passes no `users` adapter and this resolves to an empty map).
   const ownerNames = await resolveOwnerNames(dynamicLakes, ctx.userId, db.users);
   const dynamicConfigs = dynamicLakes.map(dl =>
-    toManageableConfig(dl, canManageLake(dl, ctx), isOwnLake(dl, ctx), ownerNames.get(dl.createdByUserId))
+    toManageableConfig(dl, canManageLake(dl, ctx), isLakeCreator(dl, ctx), ownerNames.get(dl.createdByUserId))
   );
 
   // Merge with hardcoded fallbacks (DB entries take precedence by slug/id).
@@ -169,7 +163,7 @@ export const listAllDataLakes = async (
 
   const ownerNames = await resolveOwnerNames(dynamicLakes, ctx.userId, db.users);
   const dynamicConfigs = dynamicLakes.map(dl =>
-    toManageableConfig(dl, true, isOwnLake(dl, ctx), ownerNames.get(dl.createdByUserId))
+    toManageableConfig(dl, true, isLakeCreator(dl, ctx), ownerNames.get(dl.createdByUserId))
   );
   const dynamicIds = new Set(dynamicLakes.map(d => d.slug));
   const fallbacks = DATA_LAKES.filter(dl => !dynamicIds.has(dl.id)).map(toFallbackConfig);

--- a/b4m-core/services/src/dataLakeService/listDataLakes.ts
+++ b/b4m-core/services/src/dataLakeService/listDataLakes.ts
@@ -6,6 +6,7 @@ import type {
   ManageableDataLakeConfig,
 } from '@bike4mind/common';
 import { DATA_LAKES, toDataLakeConfig, lakeMatchesAccess, normalizeEntitlementKey } from '@bike4mind/common';
+import { canManageLake } from './manageRule';
 import { redactLakesForActor, type ReaderDataLake } from './redactLakeForActor';
 
 /**
@@ -55,14 +56,6 @@ const resolveOwnerNames = async (
   }
   return nameById;
 };
-
-/**
- * Per-lake write/manage flag for the caller. Mirrors canManageLake (admin or creator)
- * so the client's management affordances agree with what the write paths enforce. Kept
- * local rather than importing authorizeLakeWrite to avoid a cycle - it is a one-liner.
- */
-const canManage = (dl: Pick<IDataLakeDocument, 'createdByUserId'>, ctx: AccessContext): boolean =>
-  ctx.isAdmin || dl.createdByUserId === ctx.userId;
 
 /**
  * The one place a list response may carry an editor-only field: the shared config, the caller's
@@ -131,7 +124,12 @@ export const listDataLakes = async (
   // content-scope resolver passes no `users` adapter and this resolves to an empty map).
   const ownerNames = await resolveOwnerNames(dynamicLakes, ctx.userId, db.users);
   const dynamicConfigs = dynamicLakes.map(dl =>
-    toManageableConfig(dl, canManage(dl, ctx), dl.createdByUserId === ctx.userId, ownerNames.get(dl.createdByUserId))
+    toManageableConfig(
+      dl,
+      canManageLake(dl, ctx),
+      dl.createdByUserId === ctx.userId,
+      ownerNames.get(dl.createdByUserId)
+    )
   );
 
   // Merge with hardcoded fallbacks (DB entries take precedence by slug/id).

--- a/b4m-core/services/src/dataLakeService/manageRule.ts
+++ b/b4m-core/services/src/dataLakeService/manageRule.ts
@@ -1,0 +1,29 @@
+import type { AccessContext, IDataLakeDocument } from '@bike4mind/common';
+
+/** The acting principal for a write/manage decision - resolved from auth, never the body. */
+export type ManageActor = Pick<AccessContext, 'userId' | 'isAdmin'>;
+
+/**
+ * The single WRITE/MANAGE decision for a lake: platform admin, or the lake's creator. This is
+ * the exact rule the remove path (`removeFileFromDataLake`) and the visibility change already
+ * enforce inline - centralized here so every mutating path agrees on who may write.
+ *
+ * Deliberately narrower than `canAccessLake` (read): a tag/entitlement/org grant lets a member
+ * READ a lake but NOT write into it. Injecting a file (applying the lake's meta-tag) is a write,
+ * so it must clear this gate, closing the read-can-write asymmetry.
+ *
+ * The truthiness guard makes the owner arm fail closed on a blank identity: without it, a lake with
+ * no `createdByUserId` (the synthetic fallback document) would match an actor with no `userId`, since
+ * `undefined === undefined` and `'' === ''`. Unreachable today - the schema requires the field and
+ * `AccessContext.userId` is a required string - but this predicate now gates prompt DISCLOSURE as
+ * well as writes, so it should not depend on those invariants holding elsewhere. Mirrors the same
+ * guard in `getDataLakePrompts.ts`.
+ *
+ * Lives in its own module (not `authorizeLakeWrite.ts`, which re-exports it for existing callers)
+ * because `canAccessLake` (in `assertLakeAccess.ts`) also needs it, and `authorizeLakeWrite.ts`
+ * already imports FROM `assertLakeAccess.ts` - importing back would cycle.
+ */
+export function canManageLake(lake: Pick<IDataLakeDocument, 'createdByUserId'>, actor: ManageActor): boolean {
+  if (actor.isAdmin) return true;
+  return !!actor.userId && !!lake.createdByUserId && lake.createdByUserId === actor.userId;
+}

--- a/b4m-core/services/src/dataLakeService/manageRule.ts
+++ b/b4m-core/services/src/dataLakeService/manageRule.ts
@@ -5,10 +5,11 @@ export type ManageActor = Pick<AccessContext, 'userId' | 'isAdmin'>;
 
 /**
  * Truthy-guarded creator match, shared by `canManageLake` and every site that needs the SAME
- * ownership check WITHOUT the admin bypass (`setLakeVisibility`'s owner-only expose gate,
- * `isOwn`/`isOwnLake` display labels). The truthiness guard makes it fail closed on a blank
- * identity: without it, a lake with no `createdByUserId` (the synthetic fallback document) would
- * match an actor with no `userId`, since `undefined === undefined` and `'' === ''`. Unreachable
+ * ownership check WITHOUT the admin bypass (`setLakeVisibility`'s owner-only expose gate, and
+ * the `isOwn` display label in `browsePublicDataLakes`/`listDataLakes`). The truthiness guard
+ * makes it fail closed on a blank identity: without it, a lake with no `createdByUserId` (the
+ * synthetic fallback document) would match an actor with no `userId`, since
+ * `undefined === undefined` and `'' === ''`. Unreachable
  * today - the schema requires the field and `AccessContext.userId` is a required string - but this
  * predicate now gates prompt DISCLOSURE as well as writes, so it should not depend on those
  * invariants holding elsewhere. Mirrors the same guard in `getDataLakePrompts.ts`.

--- a/b4m-core/services/src/dataLakeService/manageRule.ts
+++ b/b4m-core/services/src/dataLakeService/manageRule.ts
@@ -4,6 +4,23 @@ import type { AccessContext, IDataLakeDocument } from '@bike4mind/common';
 export type ManageActor = Pick<AccessContext, 'userId' | 'isAdmin'>;
 
 /**
+ * Truthy-guarded creator match, shared by `canManageLake` and every site that needs the SAME
+ * ownership check WITHOUT the admin bypass (`setLakeVisibility`'s owner-only expose gate,
+ * `isOwn`/`isOwnLake` display labels). The truthiness guard makes it fail closed on a blank
+ * identity: without it, a lake with no `createdByUserId` (the synthetic fallback document) would
+ * match an actor with no `userId`, since `undefined === undefined` and `'' === ''`. Unreachable
+ * today - the schema requires the field and `AccessContext.userId` is a required string - but this
+ * predicate now gates prompt DISCLOSURE as well as writes, so it should not depend on those
+ * invariants holding elsewhere. Mirrors the same guard in `getDataLakePrompts.ts`.
+ */
+export function isLakeCreator(
+  lake: Pick<IDataLakeDocument, 'createdByUserId'>,
+  actor: Pick<ManageActor, 'userId'>
+): boolean {
+  return !!actor.userId && !!lake.createdByUserId && lake.createdByUserId === actor.userId;
+}
+
+/**
  * The single WRITE/MANAGE decision for a lake: platform admin, or the lake's creator. This is
  * the exact rule the remove path (`removeFileFromDataLake`) and the visibility change already
  * enforce inline - centralized here so every mutating path agrees on who may write.
@@ -12,18 +29,10 @@ export type ManageActor = Pick<AccessContext, 'userId' | 'isAdmin'>;
  * READ a lake but NOT write into it. Injecting a file (applying the lake's meta-tag) is a write,
  * so it must clear this gate, closing the read-can-write asymmetry.
  *
- * The truthiness guard makes the owner arm fail closed on a blank identity: without it, a lake with
- * no `createdByUserId` (the synthetic fallback document) would match an actor with no `userId`, since
- * `undefined === undefined` and `'' === ''`. Unreachable today - the schema requires the field and
- * `AccessContext.userId` is a required string - but this predicate now gates prompt DISCLOSURE as
- * well as writes, so it should not depend on those invariants holding elsewhere. Mirrors the same
- * guard in `getDataLakePrompts.ts`.
- *
  * Lives in its own module (not `authorizeLakeWrite.ts`, which re-exports it for existing callers)
  * because `canAccessLake` (in `assertLakeAccess.ts`) also needs it, and `authorizeLakeWrite.ts`
  * already imports FROM `assertLakeAccess.ts` - importing back would cycle.
  */
 export function canManageLake(lake: Pick<IDataLakeDocument, 'createdByUserId'>, actor: ManageActor): boolean {
-  if (actor.isAdmin) return true;
-  return !!actor.userId && !!lake.createdByUserId && lake.createdByUserId === actor.userId;
+  return actor.isAdmin || isLakeCreator(lake, actor);
 }

--- a/b4m-core/services/src/dataLakeService/restoreDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/restoreDeletedDataLake.ts
@@ -1,6 +1,6 @@
 import type { IDataLakeRepository, IFabFileRepository } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
-import { canManageLake } from './authorizeLakeWrite';
+import { canManageLake } from './manageRule';
 import { recomputeLakeStats } from './recomputeLakeStats';
 import { lakeMembershipScope } from './lakeMembershipScope';
 import type { UnarchiveResult } from './unarchiveDataLake';

--- a/b4m-core/services/src/dataLakeService/restoreDeletedDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/restoreDeletedDataLake.ts
@@ -1,5 +1,6 @@
 import type { IDataLakeRepository, IFabFileRepository } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { canManageLake } from './authorizeLakeWrite';
 import { recomputeLakeStats } from './recomputeLakeStats';
 import { lakeMembershipScope } from './lakeMembershipScope';
 import type { UnarchiveResult } from './unarchiveDataLake';
@@ -40,7 +41,7 @@ export const restoreDeletedDataLake = async (
   if (!existing) {
     throw new NotFoundError('Data lake not found');
   }
-  if (!actor.isAdmin && existing.createdByUserId !== actor.userId) {
+  if (!canManageLake(existing, actor)) {
     throw new BadRequestError('Only the creator can restore this data lake');
   }
   // Allow re-entry from the transitional 'restoring' state so a crashed prior attempt

--- a/b4m-core/services/src/dataLakeService/setLakeVisibility.ts
+++ b/b4m-core/services/src/dataLakeService/setLakeVisibility.ts
@@ -1,5 +1,6 @@
 import type { IDataLakeDocument, IDataLakeRepository } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { canManageLake } from './manageRule';
 import { findCollidingPrefixLakes } from './tagPrefixCollision';
 
 /**
@@ -40,14 +41,16 @@ export const setLakeVisibility = async (
   if (!existing) {
     throw new NotFoundError('Data lake not found');
   }
-  if (!actor.isAdmin && existing.createdByUserId !== actor.userId) {
+  if (!canManageLake(existing, actor)) {
     throw new BadRequestError('Only the creator can change a data lake’s visibility');
   }
   const exposes = visibility === 'organization' || visibility === 'public';
   // Exposing (org or public) targets the ACTOR's own scope, so only the owner may do it -
   // otherwise a platform admin acting on someone else's lake would expose it without consent
   // (and org promotion would pull it into the admin's org). Demotion to private stays owner/admin.
-  if (exposes && existing.createdByUserId !== actor.userId) {
+  // Deliberately NOT canManageLake: that rule includes the admin bypass this check must exclude,
+  // so it stays a separate, hardened (fails closed on a blank identity) comparison.
+  if (exposes && (!actor.userId || !existing.createdByUserId || existing.createdByUserId !== actor.userId)) {
     throw new BadRequestError('Only the lake’s owner can change how it is shared.');
   }
   if (visibility === 'organization' && !actor.organizationId) {

--- a/b4m-core/services/src/dataLakeService/setLakeVisibility.ts
+++ b/b4m-core/services/src/dataLakeService/setLakeVisibility.ts
@@ -1,6 +1,6 @@
 import type { IDataLakeDocument, IDataLakeRepository } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
-import { canManageLake } from './manageRule';
+import { canManageLake, isLakeCreator } from './manageRule';
 import { findCollidingPrefixLakes } from './tagPrefixCollision';
 
 /**
@@ -48,9 +48,9 @@ export const setLakeVisibility = async (
   // Exposing (org or public) targets the ACTOR's own scope, so only the owner may do it -
   // otherwise a platform admin acting on someone else's lake would expose it without consent
   // (and org promotion would pull it into the admin's org). Demotion to private stays owner/admin.
-  // Deliberately NOT canManageLake: that rule includes the admin bypass this check must exclude,
-  // so it stays a separate, hardened (fails closed on a blank identity) comparison.
-  if (exposes && (!actor.userId || !existing.createdByUserId || existing.createdByUserId !== actor.userId)) {
+  // Deliberately isLakeCreator, not canManageLake: that rule includes the admin bypass this
+  // check must exclude.
+  if (exposes && !isLakeCreator(existing, actor)) {
     throw new BadRequestError('Only the lake’s owner can change how it is shared.');
   }
   if (visibility === 'organization' && !actor.organizationId) {

--- a/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
@@ -1,6 +1,6 @@
 import type { IDataLakeRepository, IFabFileRepository } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
-import { canManageLake } from './authorizeLakeWrite';
+import { canManageLake } from './manageRule';
 import { recomputeLakeStats } from './recomputeLakeStats';
 import { lakeMembershipScope } from './lakeMembershipScope';
 

--- a/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
@@ -1,5 +1,6 @@
 import type { IDataLakeRepository, IFabFileRepository } from '@bike4mind/common';
 import { BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { canManageLake } from './authorizeLakeWrite';
 import { recomputeLakeStats } from './recomputeLakeStats';
 import { lakeMembershipScope } from './lakeMembershipScope';
 
@@ -36,7 +37,7 @@ export const unarchiveDataLake = async (
   if (!existing) {
     throw new NotFoundError('Data lake not found');
   }
-  if (!actor.isAdmin && existing.createdByUserId !== actor.userId) {
+  if (!canManageLake(existing, actor)) {
     throw new BadRequestError('Only the creator can restore this data lake');
   }
   // Allow re-entry from the transitional 'restoring' state so a crashed prior attempt

--- a/b4m-core/services/src/dataLakeService/updateDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/updateDataLake.ts
@@ -1,6 +1,7 @@
 import type { IDataLakeDocument, IDataLakeRepository } from '@bike4mind/common';
 import { UpdateDataLakeRequestInput, normalizeEntitlementKey } from '@bike4mind/common';
 import { secureParameters, BadRequestError, NotFoundError } from '@bike4mind/utils';
+import { canManageLake } from './authorizeLakeWrite';
 import type { z } from 'zod';
 
 type UpdateDataLakeParams = z.infer<typeof UpdateDataLakeRequestInput>;
@@ -32,7 +33,7 @@ export const updateDataLake = async (
     throw new NotFoundError(`Data lake not found`);
   }
 
-  if (!actor.isAdmin && existing.createdByUserId !== actor.userId) {
+  if (!canManageLake(existing, actor)) {
     throw new BadRequestError('Only the creator can update this data lake');
   }
 

--- a/b4m-core/services/src/dataLakeService/updateDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/updateDataLake.ts
@@ -1,7 +1,7 @@
 import type { IDataLakeDocument, IDataLakeRepository } from '@bike4mind/common';
 import { UpdateDataLakeRequestInput, normalizeEntitlementKey } from '@bike4mind/common';
 import { secureParameters, BadRequestError, NotFoundError } from '@bike4mind/utils';
-import { canManageLake } from './authorizeLakeWrite';
+import { canManageLake } from './manageRule';
 import type { z } from 'zod';
 
 type UpdateDataLakeParams = z.infer<typeof UpdateDataLakeRequestInput>;


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="860" height="499" alt="Terminal output of canManageLake and archiveDataLake called directly against a blank-identity lake, showing the blank-vs-blank case now denied" src="https://github.com/user-attachments/assets/79eb7dea-02bd-44b2-89ca-bfccc6d94b97" />
*A real terminal run of the shipped `canManageLake` predicate and `archiveDataLake` service call: a blank-creator lake against a blank-identity caller now returns `false` / throws, instead of being granted.*

## Description

The lake manage rule ("platform admin, or the lake's creator") was already centralized in `canManageLake`, but a dozen call sites still re-derived it inline with the bare `isAdmin || createdByUserId === userId` shape, which incorrectly grants when both sides are blank/undefined. This consolidates every site onto the shared predicate. `setLakeVisibility`'s separate owner-only "expose" check (deliberately no admin bypass) is hardened in place rather than routed through `canManageLake`, since that predicate's admin bypass would be a regression there. `canManageLake` moved into its own module since the read gate needed it too and the old host module already imports from the read gate's file.

Closes #1153

## Changes

- Add `manageRule.ts`, extract `canManageLake` there (was in `authorizeLakeWrite.ts`, which re-exports it for existing callers)
- Route 9 service-layer sites and 2 API-layer sites (one beyond the issue's original list) through `canManageLake`
- Harden `setLakeVisibility`'s separate owner-only check and the `isOwn` display label in-place (same both-blank collision, no `canManageLake` call)
- Add a blank-identity regression test per converted site

## Guide for Testers

This is a pure server-side authorization refactor with no new user-facing behavior; the artifact is the test suite, not a UI/API response change.

1. From `b4m-core/services`, run `npx vitest run dataLakeService.test.ts`. Expect all tests green, including the new cases named `(#1153)` (e.g. "now delegates to canManageLake, so a blank identity fails closed"). (`pnpm --filter @bike4mind/services test -- dataLakeService` also works but runs the whole package, not just this file - a pnpm passthrough quirk in this repo, not specific to this PR.)
2. From `apps/client`, run `npx vitest run "pages/api/data-lakes/[id]/__tests__/lifecycle.test.ts" "pages/api/data-lakes/batches/[batchId]/__tests__/reanalyze-taxonomy.test.ts"`. Expect both files green, including the two new blank-identity cases.
3. Regression check: confirm a normal owner/admin can still archive, delete, restore, unarchive, update, and change visibility of a lake they own (or of any lake, if admin). The large pre-existing suite in `dataLakeService.test.ts` covers this and is unchanged by this PR.

What NOT to test: there is no reachable path to exercise the blank-identity case against a real deployed lake today, since the schema requires `createdByUserId`. This closes a backstop, not a live bug, so don't expect a visible behavior change on staging.

## Additional Information

N/A

## Developer Notes (Optional)

`manageRule.ts` is the new canonical home for the manage-decision predicate; a future site needing it should import from there directly rather than via `authorizeLakeWrite.ts`'s re-export.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

