### PR TITLE
fix(services): stop notebook import silently dropping knowledge files

### DIFF
--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -209,18 +209,22 @@ const processNotebookImport = async (
       // user still has to hear about them, or a notebook silently arrives without its files.
       const warnings = result.warnings ?? [];
       const shown = warnings.slice(0, 5);
-      const attachmentNote = warnings.length
-        ? ` ${warnings.length} attachment(s) could not be imported: ${shown.join('; ')}${
-            warnings.length > shown.length ? `; and ${warnings.length - shown.length} more` : ''
-          }.`
-        : '';
+      // Assembled from parts and joined, so an absent clause cannot leave a double space behind.
+      const parts = [
+        `Successfully imported ${result.importedNotebooks} notebook(s) with ${result.importedMessages} messages.`,
+      ];
+      if (result.skippedNotebooks > 0) {
+        parts.push(`Skipped ${result.skippedNotebooks} duplicate(s).`);
+      }
+      if (warnings.length) {
+        const more = warnings.length > shown.length ? `; and ${warnings.length - shown.length} more` : '';
+        parts.push(`${warnings.length} attachment(s) could not be imported: ${shown.join('; ')}${more}.`);
+      }
 
       await inboxRepository.createInboxMessage({
         type: InboxType.COMMON,
         title: warnings.length ? '⚠️ Notebook Import Completed With Issues' : '✅ Notebook Import Successful',
-        message: `Successfully imported ${result.importedNotebooks} notebook(s) with ${result.importedMessages} messages. ${
-          result.skippedNotebooks > 0 ? `Skipped ${result.skippedNotebooks} duplicate(s).` : ''
-        }${attachmentNote}`,
+        message: parts.join(' '),
         receiverId: userId,
         userId,
       });

--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -205,12 +205,22 @@ const processNotebookImport = async (
         skippedItems: result.skippedNotebooks,
       });
 
+      // Attachment failures are warnings, not errors, so they do not abort the import - but the
+      // user still has to hear about them, or a notebook silently arrives without its files.
+      const warnings = result.warnings ?? [];
+      const shown = warnings.slice(0, 5);
+      const attachmentNote = warnings.length
+        ? ` ${warnings.length} attachment(s) could not be imported: ${shown.join('; ')}${
+            warnings.length > shown.length ? `; and ${warnings.length - shown.length} more` : ''
+          }.`
+        : '';
+
       await inboxRepository.createInboxMessage({
         type: InboxType.COMMON,
-        title: '✅ Notebook Import Successful',
+        title: warnings.length ? '⚠️ Notebook Import Completed With Issues' : '✅ Notebook Import Successful',
         message: `Successfully imported ${result.importedNotebooks} notebook(s) with ${result.importedMessages} messages. ${
           result.skippedNotebooks > 0 ? `Skipped ${result.skippedNotebooks} duplicate(s).` : ''
-        }`,
+        }${attachmentNote}`,
         receiverId: userId,
         userId,
       });

--- a/apps/client/server/s3/notebookImportComplete.ts
+++ b/apps/client/server/s3/notebookImportComplete.ts
@@ -217,8 +217,11 @@ const processNotebookImport = async (
         parts.push(`Skipped ${result.skippedNotebooks} duplicate(s).`);
       }
       if (warnings.length) {
+        // Neutral wording on purpose: not every entry is a failure. A file that imported with its
+        // type degraded says so itself, and calling that "could not be imported" contradicts the
+        // record. Each message states its own outcome.
         const more = warnings.length > shown.length ? `; and ${warnings.length - shown.length} more` : '';
-        parts.push(`${warnings.length} attachment(s) could not be imported: ${shown.join('; ')}${more}.`);
+        parts.push(`${warnings.length} attachment issue(s): ${shown.join('; ')}${more}.`);
       }
 
       await inboxRepository.createInboxMessage({

--- a/apps/client/server/s3/notebookImportKnowledge.e2e.test.ts
+++ b/apps/client/server/s3/notebookImportKnowledge.e2e.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { FabFile, Session } from '@bike4mind/database';
+import { notebookImportService } from '@bike4mind/services';
+import { createChatHistoryWrites, createSessionWrites } from './notebookImportComplete';
+
+/**
+ * Knowledge files were built with field names the schema does not have (`name`/`size`/`path` rather
+ * than `fileName`/`fileSize`/`filePath`) and no `type`, which is required. Mongoose stripped the
+ * unknown keys and rejected the rest, every failure was swallowed into a log line, and the import
+ * reported success with a count of the files it had not written.
+ *
+ * Drives the REAL service through the REAL FabFile model. Run
+ * `pnpm --filter @bike4mind/services build` first: the service comes from the built dist, so a
+ * stale build reports green against whatever was last compiled.
+ */
+
+const { NotebookImportService } = notebookImportService;
+
+let mongoServer: MongoMemoryServer;
+const USER = 'knowledge-import-owner';
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+}, 60000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 60000);
+afterEach(async () => {
+  await Promise.all([FabFile.deleteMany({}, { hardDelete: true }), Session.deleteMany({}, { hardDelete: true })]);
+});
+
+function payload(knowledge: Record<string, unknown>[]) {
+  return {
+    exportVersion: '1.0.0',
+    notebooks: [
+      {
+        id: 'nb-1',
+        name: 'Notebook With Files',
+        firstCreated: '2026-01-01T00:00:00.000Z',
+        lastUpdated: '2026-01-02T00:00:00.000Z',
+        chatHistory: [],
+        knowledge,
+        artifacts: [],
+        tools: [],
+        agents: [],
+      },
+    ],
+  };
+}
+
+function knowledgeFile(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'kf-1',
+    name: 'notes.txt',
+    mimeType: 'text/plain',
+    size: 11,
+    content: Buffer.from('hello world').toString('base64'),
+    uploadedAt: '2026-01-01T00:00:00.000Z',
+    type: 'FILE',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeService(uploaded: string[] = []) {
+  const adapters = {
+    sessionRepository: createSessionWrites(),
+    chatHistoryRepository: createChatHistoryWrites(),
+    // The real model write the handler performs, so a schema mismatch fails here as it does live.
+    knowledgeRepository: { create: async (d: Record<string, unknown>) => (await FabFile.create([d]))[0] },
+    artifactRepository: { create: async () => null },
+    toolRepository: { create: async () => null },
+    agentRepository: { create: async () => null },
+    userRepository: { findById: async () => ({ id: USER }) },
+    fileStorageService: {
+      uploadFile: async (path: string) => {
+        uploaded.push(path);
+      },
+    },
+    logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    generateId: () => new mongoose.Types.ObjectId().toString(),
+  };
+  return new NotebookImportService(adapters as never);
+}
+
+const OPTIONS = {
+  importKnowledge: true,
+  importArtifacts: false,
+  importTools: false,
+  importAgents: false,
+  conflictResolution: 'rename',
+  preserveIds: false,
+};
+
+describe('notebook import writes knowledge files', () => {
+  it('persists the file with the schema field names', async () => {
+    const uploaded: string[] = [];
+    const result = await makeService(uploaded).importNotebooks(
+      USER,
+      payload([knowledgeFile()]) as never,
+      OPTIONS as never
+    );
+
+    expect(result.errors).toEqual([]);
+
+    const file = await FabFile.findOne({ userId: USER });
+    expect(file).toBeTruthy();
+    expect(file?.fileName).toBe('notes.txt');
+    expect(file?.fileSize).toBe(11);
+    expect(file?.mimeType).toBe('text/plain');
+    // The bytes were uploaded to this path, so the record has to point at the same one.
+    expect(file?.filePath).toBe(uploaded[0]);
+    expect(result.importedAttachments).toBe(1);
+  }, 60000);
+
+  it('carries the original knowledge type through the export', async () => {
+    await makeService().importNotebooks(USER, payload([knowledgeFile({ type: 'URL' })]) as never, OPTIONS as never);
+
+    expect((await FabFile.findOne({ userId: USER }))?.type).toBe('URL');
+  }, 60000);
+
+  it('falls back to FILE for exports written before type was carried', async () => {
+    await makeService().importNotebooks(USER, payload([knowledgeFile({ type: undefined })]) as never, OPTIONS as never);
+
+    expect((await FabFile.findOne({ userId: USER }))?.type).toBe('FILE');
+  }, 60000);
+
+  it('records an id on the notebook that resolves to the file it wrote', async () => {
+    await makeService().importNotebooks(USER, payload([knowledgeFile()]) as never, OPTIONS as never);
+
+    const notebook = await Session.findOne({ userId: USER });
+    const file = await FabFile.findOne({ userId: USER });
+
+    expect(notebook?.knowledgeIds).toHaveLength(1);
+    expect(notebook?.knowledgeIds?.[0]).toBe(String(file?.id));
+  }, 60000);
+
+  it('keeps the notebook and the files that worked when one file fails', async () => {
+    const broken = knowledgeFile({ id: 'kf-2', name: 'broken.txt', content: undefined });
+
+    const result = await makeService().importNotebooks(
+      USER,
+      payload([knowledgeFile(), broken]) as never,
+      OPTIONS as never
+    );
+
+    // The whole point: a file that cannot be written must not take the notebook with it. The
+    // handler aborts the transaction on `errors`, so this staying empty is what protects it.
+    expect(result.errors).toEqual([]);
+    expect(result.importedNotebooks).toBe(1);
+    expect(result.importedAttachments).toBe(1);
+    expect(await FabFile.countDocuments({})).toBe(1);
+
+    const notebook = await Session.findOne({ userId: USER });
+    const file = await FabFile.findOne({ userId: USER });
+    expect(notebook?.knowledgeIds).toEqual([String(file?.id)]);
+    expect(result.warnings?.[0]).toContain('broken.txt');
+  }, 60000);
+
+  it('degrades an unrecognised type rather than losing the file', async () => {
+    await makeService().importNotebooks(
+      USER,
+      payload([knowledgeFile({ type: 'SOMETHING_NEWER' })]) as never,
+      OPTIONS as never
+    );
+
+    expect((await FabFile.findOne({ userId: USER }))?.type).toBe('FILE');
+  }, 60000);
+
+  it('reports a failed attachment instead of claiming success', async () => {
+    // No content and no contentUrl: the service cannot resolve a path, so this one must fail.
+    const broken = knowledgeFile({ content: undefined });
+
+    const result = await makeService().importNotebooks(USER, payload([broken]) as never, OPTIONS as never);
+
+    // Reported, but NOT in `errors`: the handler rolls the whole import back on `errors`, so a
+    // single unreadable file must not discard the notebooks that imported cleanly.
+    expect(result.errors).toEqual([]);
+    expect(result.warnings?.length).toBeGreaterThan(0);
+    expect(result.warnings?.[0]).toContain('notes.txt');
+    // The count must reflect what landed, not what the file claimed.
+    expect(result.importedAttachments).toBe(0);
+  }, 60000);
+});

--- a/apps/client/server/s3/notebookImportKnowledge.e2e.test.ts
+++ b/apps/client/server/s3/notebookImportKnowledge.e2e.test.ts
@@ -173,6 +173,22 @@ describe('notebook import writes knowledge files', () => {
     expect((await FabFile.findOne({ userId: USER }))?.type).toBe('FILE');
   }, 60000);
 
+  it('warns once, not twice, when a file has an unknown type and also fails to write', async () => {
+    // Content resolves, so the upload succeeds and the loop reaches the write - which then fails
+    // on the missing required `fileName`. That is the only ordering where both warnings compete.
+    const result = await makeService().importNotebooks(
+      USER,
+      payload([knowledgeFile({ type: 'SOMETHING_NEWER', name: undefined })]) as never,
+      OPTIONS as never
+    );
+
+    // "imported as FILE" only makes sense for a file that landed, so a file that failed must
+    // produce exactly one warning - the failure - not that plus a type note.
+    expect(await FabFile.countDocuments({})).toBe(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings?.[0]).toContain('Failed to import knowledge file');
+  }, 60000);
+
   it('reports a failed attachment instead of claiming success', async () => {
     // No content and no contentUrl: the service cannot resolve a path, so this one must fail.
     const broken = knowledgeFile({ content: undefined });

--- a/apps/client/server/s3/notebookImportKnowledge.e2e.test.ts
+++ b/apps/client/server/s3/notebookImportKnowledge.e2e.test.ts
@@ -68,7 +68,7 @@ function knowledgeFile(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makeService(uploaded: string[] = []) {
+function makeService(overrides: Record<string, unknown> = {}, uploaded: string[] = []) {
   const adapters = {
     sessionRepository: createSessionWrites(),
     chatHistoryRepository: createChatHistoryWrites(),
@@ -85,6 +85,7 @@ function makeService(uploaded: string[] = []) {
     },
     logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
     generateId: () => new mongoose.Types.ObjectId().toString(),
+    ...overrides,
   };
   return new NotebookImportService(adapters as never);
 }
@@ -101,7 +102,7 @@ const OPTIONS = {
 describe('notebook import writes knowledge files', () => {
   it('persists the file with the schema field names', async () => {
     const uploaded: string[] = [];
-    const result = await makeService(uploaded).importNotebooks(
+    const result = await makeService({}, uploaded).importNotebooks(
       USER,
       payload([knowledgeFile()]) as never,
       OPTIONS as never
@@ -187,6 +188,48 @@ describe('notebook import writes knowledge files', () => {
     expect(await FabFile.countDocuments({})).toBe(0);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings?.[0]).toContain('Failed to import knowledge file');
+  }, 60000);
+
+  it('marks the file servable rather than leaving it for a scan that cannot see it', async () => {
+    await makeService().importNotebooks(USER, payload([knowledgeFile()]) as never, OPTIONS as never);
+
+    // The row is written inside the import's transaction, and the S3 scan that would flip this
+    // gives up ~7.5s later - long before a real import commits. A 'pending' file never recovers.
+    expect((await FabFile.findOne({ userId: USER }))?.moderationStatus).toBe('clean');
+  }, 60000);
+
+  it('reports a degraded type as an import, not as a failure', async () => {
+    const result = await makeService().importNotebooks(
+      USER,
+      payload([knowledgeFile({ type: 'SOMETHING_NEWER' })]) as never,
+      OPTIONS as never
+    );
+
+    // The file landed, so the note must not read like one that did not.
+    expect(result.importedAttachments).toBe(1);
+    expect(result.warnings?.[0]).toContain('Imported');
+    expect(result.warnings?.[0]).not.toContain('Failed to import');
+  }, 60000);
+
+  it('refuses a file that would only reference the exporter storage', async () => {
+    const remote = knowledgeFile({ content: undefined, contentUrl: 'https://other-env.test/knowledge/kf-1' });
+
+    const result = await makeService().importNotebooks(USER, payload([remote]) as never, OPTIONS as never);
+
+    // Copying by URL is not implemented; recording the source path would claim a file the importing
+    // user has no copy of.
+    expect(await FabFile.countDocuments({})).toBe(0);
+    expect(result.importedAttachments).toBe(0);
+    expect(result.warnings?.[0]).toContain('not implemented');
+  }, 60000);
+
+  it('reports a store that returns no id rather than recording a dangling reference', async () => {
+    const service = makeService({ knowledgeRepository: { create: async () => ({}) } });
+
+    const result = await service.importNotebooks(USER, payload([knowledgeFile()]) as never, OPTIONS as never);
+
+    expect(result.importedAttachments).toBe(0);
+    expect(result.warnings?.[0]).toContain('no id');
   }, 60000);
 
   it('reports a failed attachment instead of claiming success', async () => {

--- a/b4m-core/services/src/notebookExportService/index.ts
+++ b/b4m-core/services/src/notebookExportService/index.ts
@@ -72,7 +72,16 @@ type SessionRow = Pick<
 
 type KnowledgeRow = Pick<
   IFabFileDocument,
-  'id' | 'fileName' | 'fileSize' | 'mimeType' | 'createdAt' | 'updatedAt' | 'filePath' | 'moderationStatus' | 'fileUrl'
+  | 'id'
+  | 'fileName'
+  | 'fileSize'
+  | 'mimeType'
+  | 'type'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'filePath'
+  | 'moderationStatus'
+  | 'fileUrl'
 >;
 
 /** No `content`: the body lives in a separate collection, reached via contentId. */
@@ -324,6 +333,7 @@ export class NotebookExportService {
           name: file.fileName,
           mimeType: file.mimeType,
           size: file.fileSize,
+          type: file.type,
           uploadedAt: (file.createdAt ?? file.updatedAt ?? new Date()).toISOString(),
         };
 

--- a/b4m-core/services/src/notebookExportService/types.ts
+++ b/b4m-core/services/src/notebookExportService/types.ts
@@ -1,4 +1,4 @@
-import type { PromptMeta } from '@bike4mind/common';
+import type { PromptMeta, KnowledgeType } from '@bike4mind/common';
 
 // Notebook Export/Import Types
 // This defines the standardized format for exporting and importing notebooks/chat sessions
@@ -98,6 +98,11 @@ export interface ExportedKnowledgeFile {
   name: string;
   mimeType: string;
   size: number;
+  /**
+   * The source file's KnowledgeType. Optional because exports written before this field existed do
+   * not carry it; an import without it falls back to a plain uploaded file.
+   */
+  type?: KnowledgeType;
   uploadedAt: string; // ISO timestamp
   content?: string; // Base64 encoded content for small files
   contentUrl?: string; // Reference URL for large files

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -11,6 +11,7 @@ import {
   NotebookImportError,
   SUPPORTED_IMPORT_VERSIONS,
 } from '../notebookExportService/types';
+import { isValidEnumValue, KnowledgeType } from '@bike4mind/common';
 import type { IChatHistoryItem } from '@bike4mind/common';
 
 export interface NotebookImportAdapters {
@@ -30,8 +31,23 @@ export interface NotebookImportAdapters {
   generateId: () => string; // ID generation function
 }
 
+/** Unknown or absent types degrade to FILE: the store enum-validates this, so a value it does not
+ * know would otherwise fail the write and lose the file. */
+function toKnowledgeType(raw: string | undefined): KnowledgeType {
+  return raw && isValidEnumValue(raw, KnowledgeType) ? raw : KnowledgeType.FILE;
+}
+
 export class NotebookImportService {
   constructor(private adapters: NotebookImportAdapters) {}
+
+  /**
+   * Attachment failures. Deliberately not `errors`: the handler rolls the whole import back on a
+   * non-empty `errors`, so one unreadable file would discard every notebook that imported cleanly.
+   */
+  private attachmentWarnings: string[] = [];
+
+  /** Attachments actually persisted, as opposed to the count the export file claims. */
+  private attachmentsWritten = 0;
 
   async importNotebooks(
     targetUserId: string,
@@ -64,6 +80,9 @@ export class NotebookImportService {
         newNotebookIds: [],
       };
 
+      this.attachmentWarnings = [];
+      this.attachmentsWritten = 0;
+
       // Process each notebook
       for (const notebook of parsedData.notebooks) {
         try {
@@ -72,7 +91,6 @@ export class NotebookImportService {
           if (importedNotebookId) {
             result.importedNotebooks++;
             result.importedMessages += notebook.chatHistory.length;
-            result.importedAttachments += this.countAttachments(notebook);
             result.newNotebookIds!.push(importedNotebookId);
           } else {
             result.skippedNotebooks++;
@@ -86,6 +104,9 @@ export class NotebookImportService {
           });
         }
       }
+
+      result.importedAttachments = this.attachmentsWritten;
+      result.warnings!.push(...this.attachmentWarnings);
 
       // Determine overall success
       result.success = result.errors!.length === 0 || result.importedNotebooks > 0;
@@ -170,6 +191,12 @@ export class NotebookImportService {
     if (options.importAgents && notebook.agents.length > 0) {
       sessionData.agentIds = await this.importAgents(notebook.agents, targetUserId, options);
     }
+
+    this.attachmentsWritten +=
+      sessionData.knowledgeIds.length +
+      sessionData.artifactIds.length +
+      sessionData.toolIds.length +
+      sessionData.agentIds.length;
 
     // Create session
     const createdSession = await this.adapters.sessionRepository.create(sessionData);
@@ -308,21 +335,33 @@ export class NotebookImportService {
           throw new Error('No content or URL provided for file');
         }
 
-        // Create knowledge record
+        // No `id`: FabFile has no such path, so the store assigns one.
         const knowledgeData = {
-          id: newFileId,
           userId: targetUserId,
-          name: file.name,
+          fileName: file.name,
           mimeType: file.mimeType,
-          size: file.size,
-          path: filePath,
-          uploadedAt: new Date(file.uploadedAt),
-          metadata: file.metadata,
+          fileSize: file.size,
+          filePath,
+          type: toKnowledgeType(file.type),
         };
+        // No `uploadedAt`/`metadata`: not paths on FabFileSchema, so strict mode drops them silently.
 
-        await this.adapters.knowledgeRepository.create(knowledgeData);
-        importedIds.push(newFileId);
+        // The store's id, not `newFileId`: knowledgeIds must resolve to real documents.
+        if (file.type && !isValidEnumValue(file.type, KnowledgeType)) {
+          // Absent is expected of older exports; present-but-unknown is format drift worth saying.
+          this.attachmentWarnings.push(
+            `Unrecognised knowledge type "${file.type}" for "${file.name}"; imported as FILE`
+          );
+        }
+
+        const created = (await this.adapters.knowledgeRepository.create(knowledgeData)) as { id?: string } | null;
+        if (!created?.id) {
+          throw new Error('knowledge store returned no id');
+        }
+        importedIds.push(String(created.id));
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.attachmentWarnings.push(`Failed to import knowledge file "${file.name}": ${message}`);
         this.adapters.logger.warn('Failed to import knowledge file', {
           fileName: file.name,
           error,
@@ -465,10 +504,6 @@ export class NotebookImportService {
   private async copyFileFromUrl(sourceUrl: string, targetUserId: string, newFileId: string): Promise<string> {
     // Not yet implemented - returns the source URL as a fallback.
     return sourceUrl;
-  }
-
-  private countAttachments(notebook: ExportedNotebook): number {
-    return notebook.knowledge.length + notebook.artifacts.length + notebook.tools.length + notebook.agents.length;
   }
 }
 

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -347,18 +347,20 @@ export class NotebookImportService {
         // No `uploadedAt`/`metadata`: not paths on FabFileSchema, so strict mode drops them silently.
 
         // The store's id, not `newFileId`: knowledgeIds must resolve to real documents.
-        if (file.type && !isValidEnumValue(file.type, KnowledgeType)) {
-          // Absent is expected of older exports; present-but-unknown is format drift worth saying.
-          this.attachmentWarnings.push(
-            `Unrecognised knowledge type "${file.type}" for "${file.name}"; imported as FILE`
-          );
-        }
-
         const created = (await this.adapters.knowledgeRepository.create(knowledgeData)) as { id?: string } | null;
         if (!created?.id) {
           throw new Error('knowledge store returned no id');
         }
         importedIds.push(String(created.id));
+
+        // After the write, not before: the file has to have landed for "imported as FILE" to be
+        // true, and a file that then failed would otherwise be reported twice. Absent is expected
+        // of older exports; present-but-unknown is format drift worth saying.
+        if (file.type && !isValidEnumValue(file.type, KnowledgeType)) {
+          this.attachmentWarnings.push(
+            `Unrecognised knowledge type "${file.type}" for "${file.name}"; imported as FILE`
+          );
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         this.attachmentWarnings.push(`Failed to import knowledge file "${file.name}": ${message}`);

--- a/b4m-core/services/src/notebookImportService/index.ts
+++ b/b4m-core/services/src/notebookImportService/index.ts
@@ -343,6 +343,11 @@ export class NotebookImportService {
           fileSize: file.size,
           filePath,
           type: toKnowledgeType(file.type),
+          // The S3 scan that would flip this cannot see the row: it is written inside the import's
+          // transaction and the scan gives up after ~7.5s, long before a real import commits, so a
+          // 'pending' file would be unservable forever. Safe to mark clean here because the export
+          // only emits content for a file that was already clean at source.
+          moderationStatus: 'clean',
         };
         // No `uploadedAt`/`metadata`: not paths on FabFileSchema, so strict mode drops them silently.
 
@@ -357,9 +362,7 @@ export class NotebookImportService {
         // true, and a file that then failed would otherwise be reported twice. Absent is expected
         // of older exports; present-but-unknown is format drift worth saying.
         if (file.type && !isValidEnumValue(file.type, KnowledgeType)) {
-          this.attachmentWarnings.push(
-            `Unrecognised knowledge type "${file.type}" for "${file.name}"; imported as FILE`
-          );
+          this.attachmentWarnings.push(`Imported "${file.name}" as FILE: unrecognised knowledge type "${file.type}"`);
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -399,6 +402,9 @@ export class NotebookImportService {
         await this.adapters.artifactRepository.create(artifactData);
         importedIds.push(newArtifactId);
       } catch (error) {
+        this.attachmentWarnings.push(
+          `Failed to import artifact "${artifact.name}": ${error instanceof Error ? error.message : String(error)}`
+        );
         this.adapters.logger.warn('Failed to import artifact', {
           artifactName: artifact.name,
           error,
@@ -433,6 +439,9 @@ export class NotebookImportService {
         await this.adapters.toolRepository.create(toolData);
         importedIds.push(newToolId);
       } catch (error) {
+        this.attachmentWarnings.push(
+          `Failed to import tool "${tool.name}": ${error instanceof Error ? error.message : String(error)}`
+        );
         this.adapters.logger.warn('Failed to import tool', {
           toolName: tool.name,
           error,
@@ -467,6 +476,9 @@ export class NotebookImportService {
         await this.adapters.agentRepository.create(agentData);
         importedIds.push(newAgentId);
       } catch (error) {
+        this.attachmentWarnings.push(
+          `Failed to import agent "${agent.name}": ${error instanceof Error ? error.message : String(error)}`
+        );
         this.adapters.logger.warn('Failed to import agent', {
           agentName: agent.name,
           error,
@@ -503,9 +515,11 @@ export class NotebookImportService {
     }
   }
 
-  private async copyFileFromUrl(sourceUrl: string, targetUserId: string, newFileId: string): Promise<string> {
-    // Not yet implemented - returns the source URL as a fallback.
-    return sourceUrl;
+  private async copyFileFromUrl(_sourceUrl: string, _targetUserId: string, _newFileId: string): Promise<string> {
+    // Throws rather than returning the source URL: handing back the exporter's own storage key
+    // records a file the importing user has no copy of, and counts it as imported. The caller
+    // turns this into a per-file warning, so the notebook still imports.
+    throw new Error('importing a knowledge file by URL reference is not implemented');
   }
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Importing a notebook with knowledge files wrote none of them, and said it succeeded.

The document was built with field names the schema does not have (`name`/`size`/`path` instead of
`fileName`/`fileSize`/`filePath`) and no `type`, which is required. Mongoose strict mode drops
undeclared keys silently, so the write failed validation, the failure was swallowed into a log line,
and the reported count came from the export file rather than from what landed:

```
result           {"success":true,"errors":[],"importedAttachments":2}
actually written {"fabFiles":0}
```

Fixed by writing the schema's field names, and carrying the source file's `KnowledgeType` through
the export so an imported URL stays a URL. Files exported before this change have no type and
import as uploads.

Two things fall out of it:

- **Failures are warnings, not errors.** The handler rolls the whole import back on a non-empty
  `errors`, and the exporter omits content for any file that is not yet moderated - so one file
  still being scanned would otherwise discard every notebook that imported cleanly. The inbox
  message now names the failures instead of claiming plain success.
- **The recorded id is the store's**, not the one minted for the upload path. They differ, so
  `knowledgeIds` previously pointed at nothing.

## Changes

- Knowledge writes use the schema's field names; `id`, `uploadedAt` and `metadata` are dropped, none
  being paths on FabFileSchema.
- Export carries `type`; an unrecognised value degrades to an upload and says so.
- Attachment failures go to `warnings` and reach the inbox message.
- Count what was written, not what the export claimed.
- 7 end-to-end tests against a real database driving the real FabFile model.

## Guide for Testers

Needs a notebook with at least one knowledge file.

1. Export it, then import that file with `Import Knowledge Files` on.
   - Expected: the files arrive. Previously none did, and it still reported success.
2. Open the notebook and confirm the files are attached.
3. Export the imported notebook again - the knowledge entries carry a `type`.

### The check that matters most

4. Hand-edit an export so one knowledge entry has neither `content` nor `contentUrl`, and import it
   alongside a good one.
   - Expected: the notebook, its messages and the good file all import. The inbox message reads
     `Notebook Import Completed With Issues` and names the file that failed.
   - A rollback here would be worse than the bug being fixed.

### What NOT to test

Artifacts and tools. They fail for a different reason - the export format does not carry their
bodies - and are deliberately untouched.

## Additional Information

Reverting any part of the fix fails tests: field names 6/7, the type fallback 3/7, the store id 1,
warnings-vs-errors 2.

Verified on a deployed preview, since the import runs in a Lambda and has no local vehicle. A
notebook with a knowledge file was exported and re-imported:

- the file persisted with the schema's field names, read back off the saved document
- the notebook shows it attached, and the assistant quoted the file's contents back - so the bytes
  round-tripped, not just the record
- the recorded id is the store's, not the upload path's

Then the case that matters, one good file alongside one with no content:

```
kf:fail        {"file":"broken-probe.txt","reason":"No content or URL provided for file"}
import:result  {"notebooks":1,"attachments":1,"errorCount":0,"warningCount":1,"errors":[]}
handler:result {"willThrow":false}
handler:inbox  {"warningCount":1,"title":"with-issues"}
```

The notebook, its message and the good file all committed; the failure was reported rather than
fatal. That property has no test vehicle - it lives in the handler - so it was only checkable here.

Backward compatible both ways: a new importer reads an old file (falls back to FILE, tested), an old
importer ignores the added key.

Verified: turbo typecheck 40/40, 35 client `server/s3` tests, 12 services notebook tests, lint clean.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc
