### PR TITLE
fix(client): route Data Lake segment labels through the injected taxonomy

### DIFF
--- a/apps/client/app/components/datalake/DataLakeArticle.tsx
+++ b/apps/client/app/components/datalake/DataLakeArticle.tsx
@@ -4,8 +4,12 @@ import AddIcon from '@mui/icons-material/Add';
 import ChatIcon from '@mui/icons-material/Chat';
 import MarkdownViewer from '@client/app/components/Knowledge/MarkdownViewer';
 import { REDUCED_MOTION_OFF, driftFloat, inkFor, ringPing } from '@client/app/components/datalake/surfaceChrome';
-import { useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
-import type { DataLakeSurfaceCopy, DataLakeSurfaceTheme } from '@client/app/components/datalake/surfaceTokens';
+import { humanizeSegment, useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
+import type {
+  DataLakeSurfaceCopy,
+  DataLakeSurfaceTaxonomy,
+  DataLakeSurfaceTheme,
+} from '@client/app/components/datalake/surfaceTokens';
 import { useGetFabFileContent } from '@client/app/hooks/data/fabFiles';
 import type { IFabFileDocument } from '@bike4mind/common';
 
@@ -37,10 +41,6 @@ function getMeaningfulTags(file: IFabFileDocument): string[] {
   return file.tags.map(t => t.name).filter(name => !name.startsWith('datalake:'));
 }
 
-function humanizeDive(segment: string): string {
-  return segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' ');
-}
-
 /* Drifting motes behind the empty state; `hue` picks which token ink each one takes. */
 const MOTES: {
   left: string;
@@ -66,6 +66,7 @@ function EmptyState({
   onCreate,
   theme,
   copy,
+  taxonomy,
 }: {
   isDark: boolean;
   quickDives: QuickDive[];
@@ -73,6 +74,7 @@ function EmptyState({
   onCreate?: () => void;
   theme: DataLakeSurfaceTheme;
   copy: DataLakeSurfaceCopy;
+  taxonomy: DataLakeSurfaceTaxonomy;
 }) {
   const accent = inkFor(theme.accent, isDark);
   return (
@@ -196,7 +198,9 @@ function EmptyState({
                 },
               }}
             >
-              {humanizeDive(dive.segment)}
+              {/* Same humanizer as the tree, so an injected label reads identically; the depth
+                  is the segment's index in the path. */}
+              {humanizeSegment(dive.segment, dive.path.length - 1, taxonomy)}
             </Chip>
           ))}
         </Box>
@@ -208,7 +212,7 @@ function EmptyState({
 export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onDive, onCreate }: DataLakeArticleProps) {
   const muiTheme = useTheme();
   const isDark = muiTheme.palette.mode === 'dark';
-  const { theme, copy, icons } = useDataLakeSurface();
+  const { theme, copy, icons, taxonomy } = useDataLakeSurface();
   const { secondaryActionLabel, secondaryActionPrompt } = copy;
   const SecondaryActionIcon = icons.secondaryAction;
   const { data: content, isLoading } = useGetFabFileContent(file);
@@ -222,6 +226,7 @@ export default function DataLakeArticle({ file, onAskAbout, quickDives = [], onD
         onCreate={onCreate}
         theme={theme}
         copy={copy}
+        taxonomy={taxonomy}
       />
     );
   }

--- a/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { toast } from 'sonner';
 import { getThemeConfig } from '@client/app/utils/themes';
 import DataLakeExplorer from './DataLakeExplorer';
+import { DataLakeSurfaceProvider } from './surfaceTokens';
 
 // Chat-first mode opens a clicked file INLINE in the KnowledgeViewer by adding it to the
 // session workbench and switching layout to `vertical`. Spy on those two seams.
@@ -23,10 +24,19 @@ vi.mock('@client/app/hooks/useSessionLayout', async importOriginal => ({
   setSessionLayout,
 }));
 
+// Mutable so a test can supply a real tag tree to navigate into; empty by default, which is
+// what every other test here expects.
+const { tagCountsState } = vi.hoisted(() => ({
+  tagCountsState: { tagCounts: [] as { tag: string; count: number }[], total: 0 },
+}));
+
 vi.mock('@client/app/hooks/data/dataLakes', () => ({
   activeOrgId: () => undefined,
   useGetDataLakeTagCounts: () => ({
-    data: { tagCounts: [], uniqueArticleCounts: { total: 0 } },
+    data: {
+      tagCounts: tagCountsState.tagCounts,
+      uniqueArticleCounts: { total: tagCountsState.total },
+    },
     isLoading: false,
     isError: false,
   }),
@@ -299,5 +309,39 @@ describe('DataLakeExplorer - drag-and-drop discoverability (#839)', () => {
     });
 
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/^2 files /)));
+  });
+});
+
+describe('DataLakeExplorer - depth trail reads the injected taxonomy (#1077)', () => {
+  beforeEach(() => {
+    tagCountsState.tagCounts = [{ tag: 'books:business', count: 4 }];
+    tagCountsState.total = 4;
+  });
+  afterEach(() => {
+    tagCountsState.tagCounts = [];
+    tagCountsState.total = 0;
+  });
+
+  it('humanizes each depth-stat crumb like the tree instead of showing the raw segment', () => {
+    render(
+      <TestWrapper>
+        <DataLakeSurfaceProvider
+          tokens={{
+            taxonomy: { prefixLabels: { books: 'Library' }, categoryLabels: { business: 'Business Strategy' } },
+          }}
+        >
+          <DataLakeExplorer source="datalakes" onBack={vi.fn()} />
+        </DataLakeSurfaceProvider>
+      </TestWrapper>
+    );
+
+    // Depth 0 -> prefixLabels, so the trail must not read the raw 'books'.
+    fireEvent.click(screen.getByTestId('datalake-node-books'));
+    expect(screen.getByText('Library')).toBeInTheDocument();
+    expect(screen.queryByText('books')).not.toBeInTheDocument();
+
+    // Depth 1 -> categoryLabels; each crumb is humanized at its own depth.
+    fireEvent.click(screen.getByTestId('datalake-node-business'));
+    expect(screen.getByText('Library : Business Strategy')).toBeInTheDocument();
   });
 });

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -10,7 +10,7 @@ import DataLakeChatTree from './DataLakeChatTree';
 import DataLakeArticle from './DataLakeArticle';
 import { DataLakeNavProvider } from './dataLakeNavContext';
 import { StatTicker, inkFor, surfaceBackground } from '@client/app/components/datalake/surfaceChrome';
-import { useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
+import { humanizeSegment, useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
 import { ManageKnowledgeButton } from '@client/app/components/datalake/manageKnowledge';
 import { useSessions, useWorkBenchActions } from '@client/app/contexts/SessionsContext';
 import useSetDataLakeMode from '@client/app/hooks/useSetDataLakeMode';
@@ -111,7 +111,7 @@ export default function DataLakeExplorer({
   const chatMode = chatSlot != null;
   const muiTheme = useTheme();
   const isDark = muiTheme.palette.mode === 'dark';
-  const { theme, copy } = useDataLakeSurface();
+  const { theme, copy, taxonomy } = useDataLakeSurface();
   const acceptedHint = copy.dropAcceptedHint;
   const accentInk = inkFor(theme.accent, isDark);
   const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
@@ -429,7 +429,12 @@ export default function DataLakeExplorer({
                 {
                   label: copy.statDepthLabel,
                   value: String(breadcrumb.length),
-                  sub: breadcrumb.length === 0 ? copy.depthRootLabel : breadcrumb.join(' : '),
+                  // Humanized like the tree beside it - a raw segment here would disagree with
+                  // the branch label whenever a taxonomy is injected. Index = depth.
+                  sub:
+                    breadcrumb.length === 0
+                      ? copy.depthRootLabel
+                      : breadcrumb.map((segment, depth) => humanizeSegment(segment, depth, taxonomy)).join(' : '),
                 },
               ]}
               isDark={isDark}

--- a/apps/client/app/components/datalake/surfaceTokens.test.tsx
+++ b/apps/client/app/components/datalake/surfaceTokens.test.tsx
@@ -36,6 +36,23 @@ const treeProps = {
 
 const FILE = { id: 'f1', fileName: 'Ion traps.md', tags: [] } as unknown as IFabFileDocument;
 
+/** Quick dives are always second-level branches, so their segment is a depth-1 (category) key. */
+const DIVE = { path: ['books', 'business'], segment: 'business', count: 4 };
+
+/** Tree parked one level in, so the same 'business' segment renders at the dive's depth. */
+const nestedTreeProps = {
+  ...treeProps,
+  tree: [
+    {
+      segment: 'books',
+      fullPath: 'books',
+      fileCount: 4,
+      children: [{ segment: 'business', fullPath: 'books:business', fileCount: 4, children: [] }],
+    },
+  ],
+  breadcrumb: ['books'],
+};
+
 const StubLeafIcon = () => <span data-testid="stub-leaf-icon" />;
 
 /** Product-flavored wording the shared surface must never render on its own. */
@@ -78,6 +95,21 @@ describe('Data Lake surface - brand-agnostic defaults (#842)', () => {
     expect(screen.getByTestId('datalake-node-opti').textContent ?? '').not.toMatch(BRANDED);
     // De-slugged in place, not looked up in a product taxonomy.
     expect(screen.getByTestId('datalake-node-shared-notes')).toHaveTextContent('Shared notes');
+  });
+
+  it('labels quick-dive chips from the raw segment when no taxonomy is injected (#1077)', () => {
+    render(
+      <Wrapper>
+        <DataLakeArticle
+          file={null}
+          onAskAbout={vi.fn()}
+          quickDives={[{ path: ['books', 'shared-notes'], segment: 'shared-notes', count: 2 }]}
+          onDive={vi.fn()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId('datalake-dive-books-shared-notes')).toHaveTextContent('Shared notes');
   });
 });
 
@@ -140,5 +172,18 @@ describe('Data Lake surface - injected tokens (#842)', () => {
     const node = screen.getByTestId('datalake-node-opti');
     expect(node).toHaveTextContent('Optimization Knowledge');
     expect(node.querySelector('[data-testid="stub-leaf-icon"]')).not.toBeNull();
+  });
+
+  it('labels a quick-dive chip and its tree branch identically from the taxonomy (#1077)', () => {
+    render(
+      <Wrapper tokens={{ taxonomy: { categoryLabels: { business: 'Business Strategy' } } }}>
+        <DataLakeArticle file={null} onAskAbout={vi.fn()} quickDives={[DIVE]} onDive={vi.fn()} />
+        <DataLakeTree {...nestedTreeProps} />
+      </Wrapper>
+    );
+
+    // The two surfaces must agree on the injected label - the chip used to bypass the taxonomy.
+    expect(screen.getByTestId('datalake-dive-books-business')).toHaveTextContent('Business Strategy');
+    expect(screen.getByTestId('datalake-node-business')).toHaveTextContent('Business Strategy');
   });
 });


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

**BEFORE (staging) - the trail disagrees with the tree beside it**

<img width="1568" height="161" alt="04-staging-BEFORE-zoom-backrow-Opti-vs-trail-opti-family" src="https://github.com/user-attachments/assets/366be64b-9c77-47f0-a6d7-8d6ebc779fac" />


One frame, two renderings of the same two segments: the tree's back row reads `Opti`, the header trail reads `opti : family`.

**AFTER (preview `pr1700`) - the trail matches the tree**

<img width="1568" height="207" alt="08-preview-AFTER-zoom-backrow-T1700-matches-trail" src="https://github.com/user-attachments/assets/309b7a89-a6ed-4f30-873a-5d9c42992a05" />


Back row reads `T1700`; header trail reads `T1700 : Shared notes`. Both crumbs resolved: `t1700` capitalized, `shared-notes` de-slugged.

**AFTER (preview) - raw tag and rendered trail in one frame**

<img width="1450" height="840" alt="09-preview-AFTER-article-raw-tag-vs-humanized-trail" src="https://github.com/user-attachments/assets/fb3410fd-e1d6-4275-9dcf-20dbfc7a1007" />

The document's tag chip shows the stored tag verbatim - `t1700:shared-notes:uncategorized` - while the header renders `T1700 : Shared notes : Uncategorized`. This is the clearest single proof: same data, one raw, one humanized.

## Description

`#1068` moved every product-specific string, hue, glyph and tag label on the standalone Data Lake surface into `surfaceTokens.tsx`, so a branded surface can inject its own taxonomy through `DataLakeSurfaceProvider` without editing the shared components. `humanizeSegment(segment, depth, taxonomy)` does two jobs: look up an injected label (`prefixLabels` at depth 0, `categoryLabels` at depth 1), and otherwise fall back to sentence-case plus hyphen-to-space.

The tree calls it. Two other widgets on the same surface did not.

1. **Quick-dive chips** (`DataLakeArticle.tsx`) used a file-local `humanizeDive(segment)` - byte-identical to `humanizeSegment`'s fallback, but with no taxonomy lookup. This is the leak `#1077` reports.
2. **The header's Depth trail** (`DataLakeExplorer.tsx`) rendered `breadcrumb.join(' : ')` - no lookup and no fallback either. Found by the fix-completeness sweep during self-review; the issue does not name it.

The two halves surface differently, which decides how each is verified:

- The **chip** bug is latent. With empty default tokens both humanizers return the same string, so chips and tree agree by accident until something injects a taxonomy. Verified `DataLakeSurfaceProvider` has zero non-test mount points repo-wide, including all six `packages/premium/*` overlays - so nothing injects one today, and no UI input can make old and new differ. Covered by tests.
- The **Depth trail** bug is live. Because it skipped the helper entirely it disagrees with the tree on any lowercase or hyphenated segment, taxonomy or not. Reproduced on staging and fixed on the preview - see the screenshots.

Closes #1077.

## Changes

- **`DataLakeArticle.tsx`** - deleted `humanizeDive`; quick-dive chips now call the shared `humanizeSegment`, with `taxonomy` threaded from `useDataLakeSurface()` into `EmptyState` alongside the `theme` and `copy` slices it already took. Deleting the duplicate was chosen over teaching it the taxonomy, since keeping two humanizers preserves the divergence that is the bug.
- **`DataLakeExplorer.tsx`** - the Depth trail humanizes per crumb via `breadcrumb.map((segment, depth) => humanizeSegment(segment, depth, taxonomy))`, with `taxonomy` added to the token destructure at `:114`. The array index is the crumb's depth, so each resolves against the correct map.
- **`surfaceTokens.test.tsx`** - two tests: a chip and its tree branch render the same injected label under one provider; with no provider the chip still de-slugs.
- **`DataLakeExplorer.test.tsx`** - one test covering the trail at depth 0 and depth 1. Its tag-counts mock was a fixed empty literal, so it was made mutable via `vi.hoisted`, mirroring the file's existing `sessionState` pattern and defaulting to empty so no sibling test changed behavior.

Both call sites derive depth from position rather than hardcoding a level, so neither goes stale if the surface ever exposes segments at another depth. Confirmed on the preview at depth 3 (`T1700 : Shared notes : Uncategorized`), which the tests do not reach.

**Deliberately left raw:** `DataLakeExplorer.tsx:223` and `DataLakeTreeView.tsx:109`, where `breadcrumb.join(':')` builds a tag string for file lookup, not a label. Humanizing those would break leaf-file resolution.

**Out of scope:** the separate hardcoded `humanizeSegment` in `treeChrome.ts` used by the chat-mode tree. That surface never went through the `#1068` token treatment, so routing it through the provider is its own change.

## Guide for Testers

Read this first, because half of this PR is not observable and the other half needs specific data.

- **The Depth trail fix IS visible.** Steps 1-9 check it.
- **The quick-dive chip fix is NOT visible.** Old and new code return identical strings with the default tokens, and nothing mounts a taxonomy. Do not try to eyeball it. Steps 10-14 are regression checks - they confirm nothing on this surface broke, not that anything changed.

**Precondition - without this there is nothing to see.** You need a Data Lake whose tag prefix has at least two levels and contains a lowercase or hyphenated segment. An already-capitalized single word (`QUBO`, `TSP`) renders identically before and after and proves nothing.

A lake meeting this already exists on the `pr1700` preview: tag prefix `t1700:shared-notes:`, shown in the tree as `T1700`. If it has been deleted, create a lake with any name and set **Tag Prefix** to `t1700:shared-notes:` on the Configure step, then upload one small text file.

**Note:** the standalone page has no link in the app - reach it by appending `/data-lakes` to the host. Do **not** use the "Data Lakes" pill in a chat header; that opens the chat-mode surface, which has no Depth stat and which this PR does not touch.

### The fix

1. Open the preview and go to `/data-lakes`. Expected: a header row reading `Data Lakes / Data Lake Explorer`, and three stats on the far right labelled `DOCUMENTS`, `BRANCHES`, `DEPTH`.
2. Expected: `DEPTH` reads `0` with `top` beneath it. (`top` is a fixed label, not a segment - the root is correct on both builds.)
3. In the left rail, click **`T1700`**.
4. Expected: `DEPTH` reads `1` and the small line beneath it reads **`T1700`** - capitalized. On `main` this same spot reads the raw `t1700`.
5. Click **`Shared notes`**.
6. Expected: `DEPTH` reads `2` and the line beneath reads **`T1700 : Shared notes`** - capitalized, hyphen gone. On `main`: `t1700 : shared-notes`.
7. Compare that line to the back row at the top of the rail. Expected: the rail's crumb and the trail's first crumb are the same word. On `main` they differ.
8. Click **`Uncategorized`**, then click the file. Expected: the article opens, and its tag chip shows the stored tag verbatim - `t1700:shared-notes:uncategorized` - while the header trail reads `T1700 : Shared notes : Uncategorized`. Raw and rendered, same screen.
9. Use the rail's back row to return to the root. Expected: `DEPTH` reads `0` and the line beneath reads `top`.

### Regression Checks

Everything a tester can reach is behavior-preserving, so these matter as much as the steps above.

10. From the root with nothing selected, expected: the quick-dive chips render, each capitalized and de-slugged with a count (the seeded lake shows `Shared notes 1`). They must be **unchanged** from `main`.
11. Click a chip. Expected: the tree jumps to that branch and the chip's wording matches the trail crumb it produces.
12. Open a file from a leaf. Expected: the article renders with its title, its tag chip, and both action buttons ("Ask about this document", "Summarize the key points").
13. On an account or org with no lakes, expected: the "Nothing here yet" copy and the create CTA, with no chips.
14. Open the Data Lake tree beside a chat via the "Data Lakes" pill. Expected: labels, navigation and the back row behave exactly as on `main` - this PR touches no code on that surface.

### What NOT to test

- Injected taxonomy labels. Nothing in the app supplies them, so there is nothing to observe; three tests cover it.
- Any label in chat mode. That tree uses a different, hardcoded humanizer this PR does not touch.

## Additional Information

**Automated.** Three tests added. The two that guard the fix are mutation-verified: reverting the chip fix in place reds exactly the chip/tree agreement test and no other; reverting the trail fix reds exactly the trail test and no other. So neither is vacuous. The chip test also pins the depth argument - passing `0` there would look up `prefixLabels`, fall through to the de-slug, and fail.

The third test (no provider mounted, chip still de-slugs) is a pinning test, not a guard: it asserts the fallback path, which this PR does not change, so reverting the fix leaves it green by design. It earns its place by proving unbranded surfaces are unaffected - which is why this ships without a flag - but it has not been mutation-verified and should not be read as evidence the fix works.

Local: 45/45 across the five affected datalake suites, `tsc --noEmit` clean for the touched area, eslint clean on all four files, both repo ASCII guards pass.

CI on this head is green: zero failing checks. Passing includes `Type Check`, `Lint`, all five `Run Tests` shards (`client`, `services`, `data`, `misc`, `cli-slack`) and their aggregate `Run Tests`, plus `Core Build`, `Build amd64`, `OpenAPI Spec`, `CLI e2e harness` and `CI Complete`.

Three jobs report `skipping`: `Merge multi-arch manifest` and `E2E Tests`, neither triggered for this change, and `review` - the bot review, which has not run yet.

Worth recording for anyone who saw the earlier run: `Run Tests (misc)` failed once on a wall-clock assertion in `b4m-core/utils/src/artifactElision.test.ts:244` (536ms against a 500ms cap), then passed on re-run. That file is untouched by this branch, the test passes locally, and the guard's own comment puts the pre-fix cost at that input size at 3119ms - so 536ms was a loaded runner, not a regression. It is a flake in a shared test, not a signal about this PR.

**Manual.** BEFORE reproduced on staging, AFTER confirmed on the `pr1700` preview, which built this exact head (`b818568b`).

Walked on the preview and passing: steps 1-8, 10, 11, 12. Not exercised, and not claimed:

- step 9 (back row returns to root) - the root was re-reached by re-navigating, not by clicking the back row
- step 13 (zero-lake empty state) - seeding the lake destroyed that state
- step 14 (chat mode) - reasoned from the diff, which touches no code on that surface, rather than clicked

**One caveat on the screenshots.** The BEFORE and AFTER use different segments - staging showed `opti : family`, the preview shows `T1700 : Shared notes` - because the preview had no Data Lake data and its only pre-existing lake (prefix `opti:`) holds zero files. The pair demonstrates the same defect on the same widget, not a pixel-for-pixel comparison of identical data. Screenshot `09` is the strongest single frame regardless, since it carries the raw tag and the rendered trail together.

## Developer Notes (Optional)

- **One humanizer for the token-driven surface.** `humanizeSegment` is now the only path by which `/data-lakes` turns a raw tag segment into a user-visible label. Any new component there should call it rather than de-slugging inline - an inline copy is what caused this twice.
- **Depth is positional.** Both call sites derive it from position (`path.length - 1` for a dive whose segment is its last element; the array index when mapping a breadcrumb). Worth copying: the lookup stays correct with no magic number to go stale.
- **The raw/label distinction is load-bearing.** `breadcrumb.join(':')` builds a tag for lookup; `breadcrumb.join(' : ')` built a label for display. Near-identical expressions in the same files, which is how the display copy escaped `#1068`. When adding a breadcrumb consumer, decide which one it is first.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no settings added
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - the Depth trail now matches the wording of the tree beside it instead of printing slugs. The chip row already wraps (`flexWrap: 'wrap'`), so a longer injected label reflows rather than overflowing.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable) - N/A, no documented behavior changed
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry touched
