### PR TITLE
fix(data-lake): stop unarchive from freeing a sibling's files

### DIFF
--- a/b4m-core/common/src/types/entities/DataLakeTypes.ts
+++ b/b4m-core/common/src/types/entities/DataLakeTypes.ts
@@ -136,18 +136,22 @@ export interface IDataLake {
    *
    * The key is a wall-clock `Date`, not a unique token - equality is a best-effort ownership test,
    * not a guarantee, and two lakes claiming in the same millisecond would collide (same design as
-   * `filesDeletedAt`, not new to this field). The same-millisecond collision also has a same-lake
-   * variant: two concurrent archive calls on ONE lake that happen to generate their claim's `Date`
-   * in the same millisecond both read as "freshly minted" to the loser, so its clear-back (see
-   * archiveDataLake) could wipe the winner's just-written stamp. Narrow (needs both a same-lake
-   * race AND a same-millisecond collision), not fixed by the `wasMinted` guard, which only
-   * distinguishes minted-from-echoed, not minted-at-the-same-instant-as-a-peer.
+   * `filesDeletedAt`, not new to this field). A stamp that ends up naming zero rows (an empty lake,
+   * or a concurrent sibling/same-lake claim that swept the shared rows first) is kept, not cleared
+   * back to null - clearing it would read downstream as "pre-field legacy" and unarchive that lake
+   * unbounded, freeing whatever a sibling or a co-owning lake legitimately holds under its own
+   * stamp. An orphaned stamp naming nothing is the safe value: bounding a later unarchive to it
+   * also matches nothing, which is correct for a lake with nothing of its own to restore.
    *
    * Absent on a lake archived before this field existed (or one whose members already carry an
-   * unstamped `archivedAt` for any other reason): restore leaves that archive marker exactly as
-   * it is instead of guessing at a batch it cannot prove, and archive itself skips claiming a
-   * fresh stamp in that case too (see archiveDataLake) rather than recording a mark that would
-   * name none of the pre-existing archived rows.
+   * unstamped `archivedAt` for any other reason). `restoreDeletedDataLake` (the delete axis)
+   * leaves that archive marker exactly as it is instead of guessing at a batch it cannot prove.
+   * `unarchiveDataLake` cannot do the same - unarchiving IS the operation that clears `archivedAt`
+   * - so an absent stamp there falls back to the pre-this-field behavior of unarchiving every
+   * member in scope unbounded; a prefix- or meta-tag-sharing sibling's own archived member is only
+   * safe from that fallback once both lakes carry a real stamp. `archiveDataLake` skips claiming a
+   * fresh stamp in the legacy case too (see its own `hasUnstampedArchive` guard) rather than
+   * recording a mark that would name none of the pre-existing archived rows.
    */
   filesArchivedAt?: Date | null;
   /**

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -696,9 +696,11 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   // matches every stamped row: the pre-mark behavior, and the fallback for a lake torn down before
   // the mark existed. The archive axis is stamped the same way (`at`, `filesArchivedAt`) so restore
   // can also clear `archivedAt` for exactly the batch this lake's own archive wrote, without
-  // freeing a prefix-sharing sibling's independently-archived files. `unarchiveByDataLakeTag`'s own
-  // reversal uses this same equality bound, but only on the prefix arm - see its own doc for why the
-  // meta-tag arm is unconditional instead of stamp-keyed.
+  // freeing a prefix-sharing sibling's independently-archived files. `unarchiveByDataLakeTag` and
+  // `findArchivedByDataLakeTag` use this same equality bound over the WHOLE membership filter, not
+  // just the prefix arm - a meta-tag match is not exempt, because `addFileToLake` lets one file
+  // carry more than one lake's meta-tag with no exclusivity check, so a meta-tagged row can belong
+  // to a co-owning lake's own archive just as a prefix-tagged row can belong to a sibling's.
 
   /**
    * Soft-archive (reversible) all live member files, stamped `at`. Returns affected count.
@@ -707,17 +709,16 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
    */
   archiveByDataLakeTag(scope: DataLakeMembershipScope, at?: Date): Promise<number>;
   /**
-   * Reverse archive for all archived member files. Split by arm, not one unbounded match: the
-   * meta-tag arm is unarchived in full unconditionally (no other lake can carry this lake's own
-   * tag, so ownership needs no stamp to prove); the prefix arm - shared by any lake registering
-   * the same `fileTagPrefix` - is bounded to `stampedAt` by equality, and left untouched (not
-   * "fall back to unbounded") when `stampedAt` is given but names nothing, so a sibling's own
-   * differently-stamped prefix rows are never freed. `stampedAt` omitted still unarchives the
-   * prefix arm unbounded, for a lake archived before `filesArchivedAt` existed.
+   * Reverse archive for member files stamped `stampedAt`, by equality - a sibling or a co-owning
+   * lake's own differently-stamped member is never freed. `stampedAt` omitted unarchives
+   * unbounded, for a lake archived before `filesArchivedAt` existed.
    */
   unarchiveByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<number>;
-  /** Archived member files - used by the unarchive dedup pass. */
-  findArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<IFabFileDocument[]>;
+  /**
+   * Archived member files stamped `stampedAt` - used by the unarchive dedup pass. Omitting
+   * `stampedAt` matches every archived row, same as before this parameter existed.
+   */
+  findArchivedByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<IFabFileDocument[]>;
   /** Existence-only form of findArchivedByDataLakeTag, for a caller that just needs "any?". */
   hasArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<boolean>;
   /** Soft-deleted member files stamped `stampedAt` - used by the deleted->active restore dedup pass. */

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -696,7 +696,9 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   // matches every stamped row: the pre-mark behavior, and the fallback for a lake torn down before
   // the mark existed. The archive axis is stamped the same way (`at`, `filesArchivedAt`) so restore
   // can also clear `archivedAt` for exactly the batch this lake's own archive wrote, without
-  // freeing a prefix-sharing sibling's independently-archived files.
+  // freeing a prefix-sharing sibling's independently-archived files. `unarchiveByDataLakeTag`'s own
+  // reversal uses this same equality bound, but only on the prefix arm - see its own doc for why the
+  // meta-tag arm is unconditional instead of stamp-keyed.
 
   /**
    * Soft-archive (reversible) all live member files, stamped `at`. Returns affected count.
@@ -704,8 +706,16 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
    * absent. See archiveDataLake's `hasUnstampedArchive` guard for when that's intentional.
    */
   archiveByDataLakeTag(scope: DataLakeMembershipScope, at?: Date): Promise<number>;
-  /** Reverse archive for all archived member files. Unbounded - matches on archivedAt alone. */
-  unarchiveByDataLakeTag(scope: DataLakeMembershipScope): Promise<number>;
+  /**
+   * Reverse archive for all archived member files. Split by arm, not one unbounded match: the
+   * meta-tag arm is unarchived in full unconditionally (no other lake can carry this lake's own
+   * tag, so ownership needs no stamp to prove); the prefix arm - shared by any lake registering
+   * the same `fileTagPrefix` - is bounded to `stampedAt` by equality, and left untouched (not
+   * "fall back to unbounded") when `stampedAt` is given but names nothing, so a sibling's own
+   * differently-stamped prefix rows are never freed. `stampedAt` omitted still unarchives the
+   * prefix arm unbounded, for a lake archived before `filesArchivedAt` existed.
+   */
+  unarchiveByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<number>;
   /** Archived member files - used by the unarchive dedup pass. */
   findArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<IFabFileDocument[]>;
   /** Existence-only form of findArchivedByDataLakeTag, for a caller that just needs "any?". */

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -719,7 +719,11 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
    * `stampedAt` matches every archived row, same as before this parameter existed.
    */
   findArchivedByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<IFabFileDocument[]>;
-  /** Existence-only form of findArchivedByDataLakeTag, for a caller that just needs "any?". */
+  /**
+   * Existence-only probe, unbounded by any stamp (unlike findArchivedByDataLakeTag) - a caller
+   * deciding whether to claim a fresh stamp needs to know if ANY member is already archived,
+   * stamped or not.
+   */
   hasArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<boolean>;
   /** Soft-deleted member files stamped `stampedAt` - used by the deleted->active restore dedup pass. */
   findDeletedByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<IFabFileDocument[]>;

--- a/b4m-core/common/src/types/entities/FabFileTypes.ts
+++ b/b4m-core/common/src/types/entities/FabFileTypes.ts
@@ -665,9 +665,9 @@ export interface IFabFileRepository extends IBaseRepository<IFabFileDocument> {
   /**
    * Files in a lake matching any hash, by META-TAG ONLY - deliberately narrower than the
    * `DataLakeMembershipScope` the rest of the lifecycle family takes. Its callers act on the
-   * answer destructively (the unarchive dedup hard-deletes the losing copy) or by skipping a
-   * caller's upload, and every re-upload path that matters writes the meta-tag, so admitting a
-   * prefix match here would risk the wrong file for no gain.
+   * answer destructively (the unarchive dedup soft-deletes, recoverably, the losing copy) or by
+   * skipping a caller's upload, and every re-upload path that matters writes the meta-tag, so
+   * admitting a prefix match here would risk the wrong file for no gain.
    */
   findByContentHashesInDataLake(hashes: string[], datalakeTag: string): Promise<IFabFileDocument[]>;
   markFailedIfNotAlready(fabFileId: string, errorMessage: string): Promise<boolean>;

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -71,10 +71,10 @@ export const archiveDataLake = async (
   // mark. Archiving unstamped instead leaves those rows exactly as unrecoverable as they already
   // were, which is the safe direction to fail in.
   //
-  // Scoped to the META-TAG arm alone, not the full scope: the full scope also matches a
+  // Scoped to the META-TAG arm alone, not the full scope. The full scope also matches a
   // prefix-sharing sibling's own already-archived row, and for the SECOND lake to archive in a
-  // live collision that row is always present - checking the full scope would make that lake skip
-  // claiming a stamp EVERY time, so it could never bound its own later unarchive and would keep
+  // live collision that row is always present, so checking the full scope would make that lake
+  // skip claiming a stamp EVERY time; it could never bound its own later unarchive and would keep
   // freeing the sibling's rows unbounded, the exact bug this whole fix exists to close. No other
   // lake's document can carry this lake's own tag (see buildDataLakeMembershipFilter), so this
   // check cannot get a false positive from a SIBLING's document. It is not immune to a false
@@ -83,12 +83,12 @@ export const archiveDataLake = async (
   // lake's OWN archive, either because that same document also carries a second lake's meta-tag
   // (addFileToLake has no exclusivity check), or because it independently satisfies a sibling's
   // prefix arm (its owner matches that sibling's creator and it carries a tag under that
-  // sibling's prefix) - the sweep that stamps it runs on the sibling's OWN scope, which does not
+  // sibling's prefix). The sweep that stamps it runs on the sibling's OWN scope, which does not
   // care what else the document is tagged with. Either way this guard still trips (correctly
   // conservative: it cannot tell "genuinely mine, never archived" from "mine, but a sibling
   // archived it first"), a known limitation for these rarer, deliberate or coincidental
   // multi-membership cases rather than the ordinary single-arm prefix collision this scoping
-  // closes.
+  // closes. Tracked in #1729.
   //
   // Trade-off worth naming: a lake whose OWN pre-existing unstamped archive is entirely
   // prefix-only (no meta-tagged member at all) no longer trips this guard either, so its next
@@ -116,7 +116,7 @@ export const archiveDataLake = async (
   // Step 3: soft-hide files + best-effort index removal. The scope covers prefix-tagged
   // members too, so a file that never got the meta-tag no longer stays browsable here.
   // Archive hides files, so a colliding sibling lake loses its prefix-tagged files from every
-  // browse (they filter archivedAt: null) - unarchiving either lake now bounds its own reversal
+  // browse (they filter archivedAt: null). Unarchiving either lake now bounds its own reversal
   // to its own stamp, so it no longer brings back the other's (see unarchiveByDataLakeTag).
   await warnOnPrefixCollision(db, existing, logger);
   // Generated here rather than left to archiveByDataLakeTag's default: when `stamp` is undefined,
@@ -126,10 +126,10 @@ export const archiveDataLake = async (
   const sweepStamp = stamp ?? new Date();
   await db.fabFiles.archiveByDataLakeTag(scope, sweepStamp);
   // A stamp is kept even when it names zero rows (an empty lake, or a concurrent sibling/same-lake
-  // claim that swept the shared rows first) - NOT cleared back to null. A cleared stamp reads,
+  // claim that swept the shared rows first), NOT cleared back to null. A cleared stamp reads,
   // downstream, as "this lake predates filesArchivedAt", which makes unarchiveByDataLakeTag run
   // its reversal unbounded and free whatever a sibling or a co-owning lake legitimately holds
-  // archived under its own stamp - exactly the bug this field exists to prevent. An orphaned stamp
+  // archived under its own stamp, exactly the bug this field exists to prevent. An orphaned stamp
   // that names nothing is the safe value here: a later unarchive bounded to it also matches
   // nothing, which is the correct outcome for a lake with nothing of its own to restore.
   // Same scope the sweep ran on. findIdsByDataLakeTag is the id source rather than the flip's
@@ -143,7 +143,7 @@ export const archiveDataLake = async (
     throw new NotFoundError('Data lake not found after archive');
   }
   // Always recompute from source, never short-circuit on the sweep's own count ("it archived
-  // nothing, so stats can't have changed") - a re-entry sweeps 0 for rows a PRIOR attempt already
+  // nothing, so stats can't have changed"): a re-entry sweeps 0 for rows a PRIOR attempt already
   // archived, and those rows are exactly what this recompute needs to reflect.
   await recomputeLakeStats(existing, { db });
 

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -75,13 +75,20 @@ export const archiveDataLake = async (
   // prefix-sharing sibling's own already-archived row, and for the SECOND lake to archive in a
   // live collision that row is always present - checking the full scope would make that lake skip
   // claiming a stamp EVERY time, so it could never bound its own later unarchive and would keep
-  // freeing the sibling's rows unbounded, the exact bug this whole fix exists to close. The
-  // meta-tag arm has no such false positive: no other lake's document can carry this lake's own
-  // tag (see buildDataLakeMembershipFilter), so an unstamped row found there is genuinely this
-  // lake's own history, not a sibling's. The narrower residual case this leaves - a file carrying
-  // more than one lake's meta-tag (addFileToLake has no exclusivity check) that a co-owning lake
-  // already archived - still trips this guard, a known limitation for that rarer, deliberate
-  // multi-membership case rather than the ordinary prefix collision this scoping closes.
+  // freeing the sibling's rows unbounded, the exact bug this whole fix exists to close. No other
+  // lake's document can carry this lake's own tag (see buildDataLakeMembershipFilter), so this
+  // check cannot get a false positive from a SIBLING's document. It is not immune to a false
+  // positive on one of THIS lake's own documents, though: a document genuinely carrying this
+  // lake's meta-tag can still be swept and stamped by a co-owning or prefix-sharing sibling
+  // lake's OWN archive, either because that same document also carries a second lake's meta-tag
+  // (addFileToLake has no exclusivity check), or because it independently satisfies a sibling's
+  // prefix arm (its owner matches that sibling's creator and it carries a tag under that
+  // sibling's prefix) - the sweep that stamps it runs on the sibling's OWN scope, which does not
+  // care what else the document is tagged with. Either way this guard still trips (correctly
+  // conservative: it cannot tell "genuinely mine, never archived" from "mine, but a sibling
+  // archived it first"), a known limitation for these rarer, deliberate or coincidental
+  // multi-membership cases rather than the ordinary single-arm prefix collision this scoping
+  // closes.
   //
   // Trade-off worth naming: a lake whose OWN pre-existing unstamped archive is entirely
   // prefix-only (no meta-tagged member at all) no longer trips this guard either, so its next

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -71,13 +71,19 @@ export const archiveDataLake = async (
   // mark. Archiving unstamped instead leaves those rows exactly as unrecoverable as they already
   // were, which is the safe direction to fail in.
   //
-  // Also wider than the legacy case: the scope-matched query can't tell "pre-field legacy" apart
-  // from "a prefix-sharing sibling's own stamp", so either one skips the claim here - and with it,
-  // any freshly-archived rows this same sweep is about to write. Such a lake stays broken on
-  // restore until someone archives it again (once nothing is left unstamped) and then unarchives
-  // it - not "unarchive once" as a lake fresh out of restore is 'active', and unarchive only
-  // accepts 'archived'/'restoring'. A known limitation, not a full fix for either case.
-  const hasUnstampedArchive = !existing.filesArchivedAt && (await db.fabFiles.hasArchivedByDataLakeTag(scope));
+  // Scoped to the META-TAG arm alone, not the full scope: the full scope also matches a
+  // prefix-sharing sibling's own already-archived row, and for the SECOND lake to archive in a
+  // live collision that row is always present - checking the full scope would make that lake skip
+  // claiming a stamp EVERY time, so it could never bound its own later unarchive and would keep
+  // freeing the sibling's rows unbounded, the exact bug this whole fix exists to close. The
+  // meta-tag arm has no such false positive: no other lake's document can carry this lake's own
+  // tag (see buildDataLakeMembershipFilter), so an unstamped row found there is genuinely this
+  // lake's own history, not a sibling's. The narrower residual case this leaves - a file carrying
+  // more than one lake's meta-tag (addFileToLake has no exclusivity check) that a co-owning lake
+  // already archived - still trips this guard, a known limitation for that rarer, deliberate
+  // multi-membership case rather than the ordinary prefix collision this scoping closes.
+  const hasUnstampedArchive =
+    !existing.filesArchivedAt && (await db.fabFiles.hasArchivedByDataLakeTag({ datalakeTag: existing.datalakeTag }));
   let stamp: Date | undefined;
   if (!hasUnstampedArchive) {
     const at = new Date();

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -82,6 +82,14 @@ export const archiveDataLake = async (
   // more than one lake's meta-tag (addFileToLake has no exclusivity check) that a co-owning lake
   // already archived - still trips this guard, a known limitation for that rarer, deliberate
   // multi-membership case rather than the ordinary prefix collision this scoping closes.
+  //
+  // Trade-off worth naming: a lake whose OWN pre-existing unstamped archive is entirely
+  // prefix-only (no meta-tagged member at all) no longer trips this guard either, so its next
+  // archive claims a real stamp and those old prefix-only rows stop being reachable by the
+  // (now-bounded) unbounded fallback once filesArchivedAt is no longer absent. Accepted
+  // deliberately: that population is fixed and shrinking (only lakes archived before this field
+  // existed), while the sibling-freeing bug this scoping closes is live for as long as prefix
+  // collisions exist.
   const hasUnstampedArchive =
     !existing.filesArchivedAt && (await db.fabFiles.hasArchivedByDataLakeTag({ datalakeTag: existing.datalakeTag }));
   let stamp: Date | undefined;

--- a/b4m-core/services/src/dataLakeService/archiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/archiveDataLake.ts
@@ -79,15 +79,9 @@ export const archiveDataLake = async (
   // accepts 'archived'/'restoring'. A known limitation, not a full fix for either case.
   const hasUnstampedArchive = !existing.filesArchivedAt && (await db.fabFiles.hasArchivedByDataLakeTag(scope));
   let stamp: Date | undefined;
-  // Whether THIS call's claim actually won the set-if-unset, rather than echoing back a value
-  // someone else (a crashed prior attempt, or a concurrent claim on this same lake) already held -
-  // see the zero-swept clear-back below, which only ever fires for a claim we ourselves minted.
-  let wasMinted = false;
   if (!hasUnstampedArchive) {
     const at = new Date();
-    const claimed = (await db.dataLakes.claimFilesArchivedAt(dataLakeId, at)) ?? undefined;
-    stamp = claimed;
-    wasMinted = claimed?.getTime() === at.getTime();
+    stamp = (await db.dataLakes.claimFilesArchivedAt(dataLakeId, at)) ?? undefined;
     if (!stamp) {
       logger?.warn('[dataLakes] archive recorded no stamp; a later restore will not clear archivedAt for this lake', {
         dataLakeId,
@@ -101,26 +95,22 @@ export const archiveDataLake = async (
   // Step 3: soft-hide files + best-effort index removal. The scope covers prefix-tagged
   // members too, so a file that never got the meta-tag no longer stays browsable here.
   // Archive hides files, so a colliding sibling lake loses its prefix-tagged files from every
-  // browse (they filter archivedAt: null) - and unarchiving either lake brings back BOTH lakes'
-  // archived files, since the flip matches on archivedAt alone.
+  // browse (they filter archivedAt: null) - unarchiving either lake now bounds its own reversal
+  // to its own stamp, so it no longer brings back the other's (see unarchiveByDataLakeTag).
   await warnOnPrefixCollision(db, existing, logger);
   // Generated here rather than left to archiveByDataLakeTag's default: when `stamp` is undefined,
   // this row-level timestamp is orphaned (no lake will ever name it) even though it is a real
   // Date, and that decision should be visible at the call site rather than buried in the repo
   // method's fallback.
   const sweepStamp = stamp ?? new Date();
-  const swept = await db.fabFiles.archiveByDataLakeTag(scope, sweepStamp);
-  // The probe-then-claim window above has no lock, so a concurrent archive - on a prefix-colliding
-  // sibling lake stamping a shared file, or on this SAME lake via a duplicate request - can leave
-  // this sweep matching nothing despite a stamp in hand. `wasMinted` is what makes clearing safe:
-  // it is true only when THIS call's claim actually won the set-if-unset, so it is false both for
-  // a crash re-entry (echoes an already-set stamp back) and for a same-lake concurrent claim
-  // (echoes the peer's winning stamp back) - in either of those, the stamp names rows that already
-  // exist and clearing it would strand them, reintroducing the bug this PR exists to fix. Only a
-  // truly fresh mint that then swept zero (the sibling race, or an empty lake) is safe to clear.
-  if (stamp && swept === 0 && wasMinted) {
-    await db.dataLakes.update({ id: dataLakeId, filesArchivedAt: null });
-  }
+  await db.fabFiles.archiveByDataLakeTag(scope, sweepStamp);
+  // A stamp is kept even when it names zero rows (an empty lake, or a concurrent sibling/same-lake
+  // claim that swept the shared rows first) - NOT cleared back to null. A cleared stamp reads,
+  // downstream, as "this lake predates filesArchivedAt", which makes unarchiveByDataLakeTag run
+  // its reversal unbounded and free whatever a sibling or a co-owning lake legitimately holds
+  // archived under its own stamp - exactly the bug this field exists to prevent. An orphaned stamp
+  // that names nothing is the safe value here: a later unarchive bounded to it also matches
+  // nothing, which is the correct outcome for a lake with nothing of its own to restore.
   // Same scope the sweep ran on. findIdsByDataLakeTag is the id source rather than the flip's
   // count because it reports every member whatever its archived/deleted state, so a re-run after
   // a crashed attempt still hands the index the full set.
@@ -131,9 +121,9 @@ export const archiveDataLake = async (
   if (!updated) {
     throw new NotFoundError('Data lake not found after archive');
   }
-  // Always recompute from source, never short-circuit on `swept` (e.g. "swept === 0, so stats
-  // can't have changed") - a re-entry sweeps 0 for rows a PRIOR attempt already archived, and
-  // those rows are exactly what this recompute needs to reflect.
+  // Always recompute from source, never short-circuit on the sweep's own count ("it archived
+  // nothing, so stats can't have changed") - a re-entry sweeps 0 for rows a PRIOR attempt already
+  // archived, and those rows are exactly what this recompute needs to reflect.
   await recomputeLakeStats(existing, { db });
 
   return updated;

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1140,15 +1140,17 @@ describe('unarchiveDataLake — dedup pass (live re-upload wins)', () => {
     // The dedup probe stays on the bare meta-tag: it decides which copy gets soft-deleted, and
     // fileTagPrefix is not unique, so a widened probe could nominate another lake's file.
     expect(fabFiles.findByContentHashesInDataLake).toHaveBeenCalledWith(['h1', 'h2'], 'datalake:lake');
-    // No filesArchivedAt on this lake (a lake archived before the field existed), so the prefix
-    // arm's reversal stays unbounded, unchanged from before this stamp was threaded through.
+    // No filesArchivedAt on this lake (a lake archived before the field existed), so both the
+    // dedup read and the reversal stay unbounded, unchanged from before this stamp was threaded
+    // through.
+    expect(fabFiles.findArchivedByDataLakeTag).toHaveBeenCalledWith(lakeScope, undefined);
     expect(fabFiles.unarchiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, undefined);
     expect(fabFiles.deleteManyInIds).toHaveBeenCalledWith(['a1']);
     expect(result.skippedDuplicates).toBe(1);
     expect(result.restoredCount).toBe(1);
   });
 
-  it("passes this lake's own filesArchivedAt stamp through, so the prefix arm is bounded to it", async () => {
+  it("passes this lake's own filesArchivedAt stamp through to both the dedup read and the reversal", async () => {
     const STAMP = new Date('2026-05-01');
     const fabFiles = {
       findArchivedByDataLakeTag: vi.fn().mockResolvedValue([]),
@@ -1166,6 +1168,7 @@ describe('unarchiveDataLake — dedup pass (live re-upload wins)', () => {
 
     await unarchiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', { db: { dataLakes, fabFiles } });
 
+    expect(fabFiles.findArchivedByDataLakeTag).toHaveBeenCalledWith(lakeScope, STAMP);
     expect(fabFiles.unarchiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, STAMP);
   });
 
@@ -1371,39 +1374,28 @@ describe('archiveDataLake - retrieval-index removal', () => {
       dataLakeId: 'lake1',
     });
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, expect.any(Date));
-    // No stamp means the zero-swept clear-back below can never fire for this lake - nothing to
-    // clear, and clearing would wipe a mark a concurrent claimant may since have written.
     expect(adapters.db.dataLakes.update).not.toHaveBeenCalledWith(expect.objectContaining({ filesArchivedAt: null }));
   });
 
-  it('clears the just-claimed stamp back to null when the sweep matches nothing (a concurrent sibling won the probe-to-claim race)', async () => {
+  it('keeps a freshly-minted stamp even when the sweep matches nothing (an empty lake, or a concurrent sibling/same-lake claim that swept first)', async () => {
+    // Clearing this back to null used to be the behavior - it now reads downstream as "this lake
+    // predates filesArchivedAt" and makes a later unarchive run unbounded, freeing whatever a
+    // sibling or a co-owning lake legitimately holds archived under its OWN stamp. The regression
+    // this test guards against: archiving an ordinary empty lake, in isolation, must never leave it
+    // in a state where its own later unarchive call can reach outside its own batch.
     const adapters = makeAdapters();
-    // Base mock echoes the exact `at` passed in, simulating a claim THIS call actually won
-    // (wasMinted true) - a fixed unrelated Date would simulate an echoed peer's stamp instead.
+    const stamp = new Date('2026-05-01');
+    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
     adapters.db.fabFiles.archiveByDataLakeTag = vi.fn().mockResolvedValue(0);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
-    expect(adapters.db.dataLakes.update).toHaveBeenCalledWith({ id: 'lake1', filesArchivedAt: null });
+    expect(adapters.db.dataLakes.update).not.toHaveBeenCalledWith(expect.objectContaining({ filesArchivedAt: null }));
   });
 
   it('leaves the stamp alone when the sweep matches at least one row', async () => {
     const adapters = makeAdapters();
     adapters.db.fabFiles.archiveByDataLakeTag = vi.fn().mockResolvedValue(1);
-
-    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
-
-    expect(adapters.db.dataLakes.update).not.toHaveBeenCalledWith(expect.objectContaining({ filesArchivedAt: null }));
-  });
-
-  it('leaves the stamp alone when a concurrent claim on this SAME lake wins and our sweep matches nothing (echoed, not minted)', async () => {
-    const adapters = makeAdapters();
-    const peerStamp = new Date('2026-05-01');
-    // Our own claim call loses the set-if-unset to a concurrent request on the same lake and
-    // echoes the peer's winning stamp back - unequal to the `at` this call generated internally,
-    // so wasMinted is false even though a stamp came back and the sweep matched nothing.
-    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(peerStamp);
-    adapters.db.fabFiles.archiveByDataLakeTag = vi.fn().mockResolvedValue(0);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1315,17 +1315,47 @@ describe('archiveDataLake - retrieval-index removal', () => {
 
   // Covers a legacy pre-field lake and a claim-without-sweep crash alike (see archiveDataLake's
   // hasUnstampedArchive guard): naming a fresh batch here would be narrower than what's archived.
-  it('skips the claim when unstamped archived members already exist, archiving unstamped instead', async () => {
+  it('skips the claim when THIS lake already has an unstamped archived member of its own, archiving unstamped instead', async () => {
     const adapters = makeAdapters();
     adapters.db.dataLakes.findById = vi.fn().mockResolvedValue(lake({ filesArchivedAt: undefined }));
     adapters.db.fabFiles.hasArchivedByDataLakeTag = vi.fn().mockResolvedValue(true);
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
+    // Scoped to the meta-tag alone, not the full scope - see the call site's own comment for why
+    // the full scope would make this trip on every second archiver in a live collision.
+    expect(adapters.db.fabFiles.hasArchivedByDataLakeTag).toHaveBeenCalledWith({ datalakeTag: 'datalake:lake' });
     expect(adapters.db.dataLakes.claimFilesArchivedAt).not.toHaveBeenCalled();
     // No stamp to give these rows, so archiveDataLake generates an orphaned one visibly at the
     // call site rather than relying on archiveByDataLakeTag's own default.
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, expect.any(Date));
+  });
+
+  it('claims its own stamp even when a prefix-sharing sibling already has an archived row, so the second lake to archive in a collision is not left permanently unstamped', async () => {
+    // The regression this guards against: a meta-tag-scoped hasArchivedByDataLakeTag mock
+    // returning false (this lake's OWN meta-tag has no archived member) even though a sibling's
+    // prefix-only row is already archived - the full-scope version would have returned true here
+    // and skipped the claim on every archive this lake ever runs while the sibling stays archived.
+    const adapters = makeAdapters();
+    const stamp = new Date('2026-05-01');
+    adapters.db.fabFiles.hasArchivedByDataLakeTag = vi.fn().mockResolvedValue(false);
+    adapters.db.dataLakes.claimFilesArchivedAt = vi.fn().mockResolvedValue(stamp);
+
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+
+    expect(adapters.db.dataLakes.claimFilesArchivedAt).toHaveBeenCalledWith('lake1', expect.any(Date));
+    expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, stamp);
+  });
+
+  it("still skips the claim when a co-owning lake already archived a file carrying THIS lake's own meta-tag too (the residual multi-membership limitation)", async () => {
+    const adapters = makeAdapters();
+    adapters.db.dataLakes.findById = vi.fn().mockResolvedValue(lake({ filesArchivedAt: undefined }));
+    adapters.db.fabFiles.hasArchivedByDataLakeTag = vi.fn().mockResolvedValue(true);
+
+    await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
+
+    expect(adapters.db.fabFiles.hasArchivedByDataLakeTag).toHaveBeenCalledWith({ datalakeTag: 'datalake:lake' });
+    expect(adapters.db.dataLakes.claimFilesArchivedAt).not.toHaveBeenCalled();
   });
 
   it('claims normally when the lake has no unstamped archived members', async () => {
@@ -1335,7 +1365,7 @@ describe('archiveDataLake - retrieval-index removal', () => {
 
     await archiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', adapters);
 
-    expect(adapters.db.fabFiles.hasArchivedByDataLakeTag).toHaveBeenCalledWith(lakeScope);
+    expect(adapters.db.fabFiles.hasArchivedByDataLakeTag).toHaveBeenCalledWith({ datalakeTag: 'datalake:lake' });
     expect(adapters.db.dataLakes.claimFilesArchivedAt).toHaveBeenCalledWith('lake1', expect.any(Date));
     expect(adapters.db.fabFiles.archiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, stamp);
   });

--- a/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
+++ b/b4m-core/services/src/dataLakeService/dataLakeService.test.ts
@@ -1137,13 +1137,36 @@ describe('unarchiveDataLake — dedup pass (live re-upload wins)', () => {
     const result = await unarchiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', {
       db: { dataLakes, fabFiles },
     });
-    // The dedup probe stays on the bare meta-tag: it decides which copy gets hard-deleted, and
+    // The dedup probe stays on the bare meta-tag: it decides which copy gets soft-deleted, and
     // fileTagPrefix is not unique, so a widened probe could nominate another lake's file.
     expect(fabFiles.findByContentHashesInDataLake).toHaveBeenCalledWith(['h1', 'h2'], 'datalake:lake');
-    expect(fabFiles.unarchiveByDataLakeTag).toHaveBeenCalledWith(lakeScope);
+    // No filesArchivedAt on this lake (a lake archived before the field existed), so the prefix
+    // arm's reversal stays unbounded, unchanged from before this stamp was threaded through.
+    expect(fabFiles.unarchiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, undefined);
     expect(fabFiles.deleteManyInIds).toHaveBeenCalledWith(['a1']);
     expect(result.skippedDuplicates).toBe(1);
     expect(result.restoredCount).toBe(1);
+  });
+
+  it("passes this lake's own filesArchivedAt stamp through, so the prefix arm is bounded to it", async () => {
+    const STAMP = new Date('2026-05-01');
+    const fabFiles = {
+      findArchivedByDataLakeTag: vi.fn().mockResolvedValue([]),
+      findByContentHashesInDataLake: vi.fn().mockResolvedValue([]),
+      unarchiveByDataLakeTag: vi.fn().mockResolvedValue(1),
+      deleteManyInIds: vi.fn().mockResolvedValue(undefined),
+      computeDataLakeStats: vi.fn().mockResolvedValue({ fileCount: 1, totalSizeBytes: 10 }),
+    };
+    const dataLakes = {
+      findById: vi.fn().mockResolvedValue(lake({ status: 'archived', filesArchivedAt: STAMP })),
+      update: vi.fn().mockResolvedValue(lake()),
+      setStats: vi.fn().mockResolvedValue(lake()),
+      activateIfDraft: vi.fn(),
+    };
+
+    await unarchiveDataLake({ userId: 'owner', isAdmin: false }, 'lake1', { db: { dataLakes, fabFiles } });
+
+    expect(fabFiles.unarchiveByDataLakeTag).toHaveBeenCalledWith(lakeScope, STAMP);
   });
 
   it('clears filesArchivedAt so a later re-archive claims a fresh stamp, not a stale reused one', async () => {

--- a/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
@@ -27,9 +27,10 @@ interface UnarchiveDataLakeAdapters {
  * the lake was archived, the live copy wins and the archived duplicate is discarded
  * (not restored). Owner or admin only. Uses transitional 'restoring' state.
  *
- * The reversal is bounded by `filesArchivedAt`, this lake's own archive stamp: it stops
- * unarchiving from also freeing a prefix-sharing sibling lake's independently-archived files (see
- * `unarchiveByDataLakeTag`'s own doc for the meta-tag-vs-prefix-arm split that makes this safe).
+ * Both the dedup read and the reversal are bounded by `filesArchivedAt`, this lake's own archive
+ * stamp: it stops the dedup pass from reading (and, on a hash match, soft-deleting) a sibling or
+ * co-owning lake's own archived member, and stops the reversal from freeing it (see
+ * `unarchiveByDataLakeTag`'s own doc for why a meta-tag match is not exempt from the bound).
  */
 export const unarchiveDataLake = async (
   actor: { userId: string; isAdmin: boolean },
@@ -52,10 +53,13 @@ export const unarchiveDataLake = async (
   await db.dataLakes.update({ id: dataLakeId, status: 'restoring' });
 
   const scope = lakeMembershipScope(existing);
+  // undefined for a lake archived before `filesArchivedAt` existed, which keeps both the dedup
+  // read and the reversal unbounded - the pre-this-field behavior.
+  const stampedAt = existing.filesArchivedAt ?? undefined;
 
   // Dedup pass: a LIVE (non-archived, non-deleted) file with the same hash means the
   // file was re-uploaded while archived - the live copy wins.
-  const archived = await db.fabFiles.findArchivedByDataLakeTag(scope);
+  const archived = await db.fabFiles.findArchivedByDataLakeTag(scope, stampedAt);
   const archivedHashes = archived.map(f => f.contentHash).filter((h): h is string => !!h);
 
   let skippedDuplicates = 0;
@@ -75,9 +79,8 @@ export const unarchiveDataLake = async (
     }
   }
 
-  // Restore the remaining archived files (the non-duplicates). undefined for a lake archived
-  // before `filesArchivedAt` existed, which keeps the prefix arm's old unbounded reversal.
-  const restoredCount = await db.fabFiles.unarchiveByDataLakeTag(scope, existing.filesArchivedAt ?? undefined);
+  // Restore the remaining archived files (the non-duplicates).
+  const restoredCount = await db.fabFiles.unarchiveByDataLakeTag(scope, stampedAt);
 
   // Explicit null, not undefined (mongoose drops undefined): a later re-archive claims a FRESH
   // stamp via claimFilesArchivedAt's set-if-unset, rather than reusing this spent one.

--- a/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
+++ b/b4m-core/services/src/dataLakeService/unarchiveDataLake.ts
@@ -26,6 +26,10 @@ interface UnarchiveDataLakeAdapters {
  * Restores an archived data lake with a dedup pass: if a file was re-uploaded while
  * the lake was archived, the live copy wins and the archived duplicate is discarded
  * (not restored). Owner or admin only. Uses transitional 'restoring' state.
+ *
+ * The reversal is bounded by `filesArchivedAt`, this lake's own archive stamp: it stops
+ * unarchiving from also freeing a prefix-sharing sibling lake's independently-archived files (see
+ * `unarchiveByDataLakeTag`'s own doc for the meta-tag-vs-prefix-arm split that makes this safe).
  */
 export const unarchiveDataLake = async (
   actor: { userId: string; isAdmin: boolean },
@@ -56,11 +60,12 @@ export const unarchiveDataLake = async (
 
   let skippedDuplicates = 0;
   if (archivedHashes.length > 0) {
-    // Meta-tag only, NOT the membership scope: the loser of this comparison is hard-deleted
-    // below, and fileTagPrefix is not unique, so a prefix match could nominate a live file
-    // belonging to a DIFFERENT lake as the winner and destroy this lake's archived member.
-    // Any re-upload worth deduping carries the meta-tag, so the narrow probe loses nothing;
-    // at worst a prefix-only re-upload leaves a duplicate, which beats deleting the wrong file.
+    // Meta-tag only, NOT the membership scope: the loser of this comparison is soft-deleted
+    // (recoverable) below, and fileTagPrefix is not unique, so a prefix match could nominate a
+    // live file belonging to a DIFFERENT lake as the winner and soft-delete this lake's archived
+    // member. Any re-upload worth deduping carries the meta-tag, so the narrow probe loses
+    // nothing; at worst a prefix-only re-upload leaves a duplicate, which beats discarding the
+    // wrong file.
     const live = await db.fabFiles.findByContentHashesInDataLake(archivedHashes, existing.datalakeTag);
     const liveHashes = new Set(live.map(f => f.contentHash));
     const duplicateIds = archived.filter(f => f.contentHash && liveHashes.has(f.contentHash)).map(f => f.id);
@@ -70,8 +75,9 @@ export const unarchiveDataLake = async (
     }
   }
 
-  // Restore the remaining archived files (the non-duplicates).
-  const restoredCount = await db.fabFiles.unarchiveByDataLakeTag(scope);
+  // Restore the remaining archived files (the non-duplicates). undefined for a lake archived
+  // before `filesArchivedAt` existed, which keeps the prefix arm's old unbounded reversal.
+  const restoredCount = await db.fabFiles.unarchiveByDataLakeTag(scope, existing.filesArchivedAt ?? undefined);
 
   // Explicit null, not undefined (mongoose drops undefined): a later re-archive claims a FRESH
   // stamp via claimFilesArchivedAt's set-if-unset, rather than reusing this spent one.

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -185,9 +185,53 @@ describe('FabFile data lake lifecycle membership', () => {
       }
     });
 
-    it('restores everything it archived, so no member is stranded', async () => {
+    it('restores everything it archived when the stamp names both arms', async () => {
+      const rows = await seedLakeRows();
+      const STAMP = new Date('2026-06-01T00:00:00.000Z');
+
+      await fabFileRepository.archiveByDataLakeTag(scope, STAMP);
+      const restored = await fabFileRepository.unarchiveByDataLakeTag(scope, STAMP);
+
+      expect(restored).toBe(2);
+      for (const id of rows.memberIds) {
+        expect((await readRaw(id))?.archivedAt ?? null).toBeNull();
+      }
+    });
+
+    it('leaves a differently-stamped prefix member untouched - a sibling lake, or a self-drifted stamp the mechanism cannot tell apart from one', async () => {
+      const rows = await seedLakeRows();
+      const OWN_STAMP = new Date('2026-06-01T00:00:00.000Z');
+      const OTHER_STAMP = new Date('2026-05-01T00:00:00.000Z');
+      // prefixOwned carries no meta-tag, so it is reachable ONLY through the ambiguous prefix arm -
+      // exactly the row a prefix-sharing sibling's own archive could also have stamped this way.
+      await FabFile.updateOne({ _id: rows.prefixOwned._id }, { $set: { archivedAt: OTHER_STAMP } });
+
+      const restored = await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
+
+      expect(restored).toBe(0);
+      expect((await readRaw(rows.prefixOwned._id.toString()))?.archivedAt?.getTime()).toBe(OTHER_STAMP.getTime());
+    });
+
+    it('unconditionally rescues a meta-tagged member regardless of stamp, so the split is not a zero-matched heuristic', async () => {
+      const rows = await seedLakeRows();
+      const OWN_STAMP = new Date('2026-06-01T00:00:00.000Z');
+      const FOREIGN_STAMP = new Date('2026-05-01T00:00:00.000Z');
+      // No other lake's document can ever carry this lake's own meta-tag, so it comes back even
+      // though its stamp does not match what we pass in - ownership needs no stamp to prove here.
+      await FabFile.updateOne({ _id: rows.metaTagged._id }, { $set: { archivedAt: FOREIGN_STAMP } });
+
+      const restored = await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
+
+      expect(restored).toBe(1);
+      expect((await readRaw(rows.metaTagged._id.toString()))?.archivedAt ?? null).toBeNull();
+    });
+
+    it('falls back to unbounded on the prefix arm only when this lake has no stamp at all (legacy, pre-mark lake)', async () => {
       const rows = await seedLakeRows();
 
+      // archiveByDataLakeTag with no `at` still writes a real per-row timestamp (orphaned, no lake
+      // names it) - the lake itself passes `undefined` below, as it would for a lake torn down
+      // before `filesArchivedAt` existed.
       await fabFileRepository.archiveByDataLakeTag(scope);
       const restored = await fabFileRepository.unarchiveByDataLakeTag(scope);
 
@@ -195,6 +239,42 @@ describe('FabFile data lake lifecycle membership', () => {
       for (const id of rows.memberIds) {
         expect((await readRaw(id))?.archivedAt ?? null).toBeNull();
       }
+    });
+
+    it('sends the equality bound to the prefix arm and no bound at all to the meta arm, not just an end-state that could pass by luck', async () => {
+      await seedLakeRows();
+      const OWN_STAMP = new Date('2026-06-01T00:00:00.000Z');
+      const spy = vi.spyOn(FabFile, 'updateMany');
+
+      await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      const filters = spy.mock.calls.map(call => call[0] as Record<string, unknown>);
+      expect(
+        filters.some(
+          f => f['tags.name'] === DATALAKE_TAG && JSON.stringify(f.archivedAt) === JSON.stringify({ $ne: null })
+        )
+      ).toBe(true);
+      expect(filters.some(f => f.archivedAt === OWN_STAMP)).toBe(true);
+      spy.mockRestore();
+    });
+
+    it("is safe to retry after a completed sweep: a second call does not free a sibling's differently-stamped prefix member", async () => {
+      const rows = await seedLakeRows();
+      const OWN_STAMP = new Date('2026-06-01T00:00:00.000Z');
+      const SIBLING_STAMP = new Date('2026-05-01T00:00:00.000Z');
+      await fabFileRepository.archiveByDataLakeTag(scope, OWN_STAMP);
+      // Simulates a sibling lake's own archive on the shared prefix, stamped differently.
+      await FabFile.updateOne({ _id: rows.prefixOwned._id }, { $set: { archivedAt: SIBLING_STAMP } });
+
+      const first = await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
+      // The retry a crash-then-re-entry would produce: the bounded prefix pass now matches nothing
+      // of ours (already cleared), which must NOT fall back to freeing the sibling's row.
+      const second = await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
+
+      expect(first).toBe(1);
+      expect(second).toBe(0);
+      expect((await readRaw(rows.prefixOwned._id.toString()))?.archivedAt?.getTime()).toBe(SIBLING_STAMP.getTime());
     });
 
     it('finds archived members for the unarchive dedup pass', async () => {

--- a/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
+++ b/packages/database/src/models/content/FabFileModel.dataLakeLifecycle.test.ts
@@ -185,7 +185,7 @@ describe('FabFile data lake lifecycle membership', () => {
       }
     });
 
-    it('restores everything it archived when the stamp names both arms', async () => {
+    it('restores everything it archived when the stamp names it', async () => {
       const rows = await seedLakeRows();
       const STAMP = new Date('2026-06-01T00:00:00.000Z');
 
@@ -212,21 +212,40 @@ describe('FabFile data lake lifecycle membership', () => {
       expect((await readRaw(rows.prefixOwned._id.toString()))?.archivedAt?.getTime()).toBe(OTHER_STAMP.getTime());
     });
 
-    it('unconditionally rescues a meta-tagged member regardless of stamp, so the split is not a zero-matched heuristic', async () => {
+    it('leaves a differently-stamped META-TAGGED member untouched too, proving the bound is not exempt on that arm', async () => {
       const rows = await seedLakeRows();
       const OWN_STAMP = new Date('2026-06-01T00:00:00.000Z');
-      const FOREIGN_STAMP = new Date('2026-05-01T00:00:00.000Z');
-      // No other lake's document can ever carry this lake's own meta-tag, so it comes back even
-      // though its stamp does not match what we pass in - ownership needs no stamp to prove here.
-      await FabFile.updateOne({ _id: rows.metaTagged._id }, { $set: { archivedAt: FOREIGN_STAMP } });
+      const OTHER_STAMP = new Date('2026-05-01T00:00:00.000Z');
+      await FabFile.updateOne({ _id: rows.metaTagged._id }, { $set: { archivedAt: OTHER_STAMP } });
 
       const restored = await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
 
-      expect(restored).toBe(1);
-      expect((await readRaw(rows.metaTagged._id.toString()))?.archivedAt ?? null).toBeNull();
+      expect(restored).toBe(0);
+      expect((await readRaw(rows.metaTagged._id.toString()))?.archivedAt?.getTime()).toBe(OTHER_STAMP.getTime());
     });
 
-    it('falls back to unbounded on the prefix arm only when this lake has no stamp at all (legacy, pre-mark lake)', async () => {
+    it('leaves a co-owned member archived when a lake it ALSO belongs to swept it first (addFileToLake allows multi-lake meta-tag membership)', async () => {
+      // A file can carry more than one lake's meta-tag at once - addFileToLake has no exclusivity
+      // check. Lake B's sweep only touches archivedAt: null rows, so once B archives this file
+      // under its own stamp, lake A's own (unrelated) archive/unarchive cycle must not touch it,
+      // even though A's meta-tag arm matches it unconditionally on membership.
+      const SIBLING_TAG = 'datalake:org1:sibling-lake';
+      const coMember = await makeFile({
+        fileName: 'co-member.txt',
+        userId: CREATOR,
+        tags: [{ name: DATALAKE_TAG }, { name: SIBLING_TAG }],
+      });
+      const SIBLING_STAMP = new Date('2026-05-01T00:00:00.000Z');
+      await FabFile.updateOne({ _id: coMember._id }, { $set: { archivedAt: SIBLING_STAMP } });
+      const OWN_STAMP = new Date('2026-06-01T00:00:00.000Z');
+
+      const restored = await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
+
+      expect(restored).toBe(0);
+      expect((await readRaw(coMember._id.toString()))?.archivedAt?.getTime()).toBe(SIBLING_STAMP.getTime());
+    });
+
+    it('falls back to unbounded when this lake has no stamp at all (legacy, pre-mark lake)', async () => {
       const rows = await seedLakeRows();
 
       // archiveByDataLakeTag with no `at` still writes a real per-row timestamp (orphaned, no lake
@@ -241,25 +260,20 @@ describe('FabFile data lake lifecycle membership', () => {
       }
     });
 
-    it('sends the equality bound to the prefix arm and no bound at all to the meta arm, not just an end-state that could pass by luck', async () => {
+    it('sends the equality bound to Mongo, not just an end-state that could pass by luck', async () => {
       await seedLakeRows();
       const OWN_STAMP = new Date('2026-06-01T00:00:00.000Z');
       const spy = vi.spyOn(FabFile, 'updateMany');
 
       await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
 
-      expect(spy).toHaveBeenCalledTimes(2);
-      const filters = spy.mock.calls.map(call => call[0] as Record<string, unknown>);
-      expect(
-        filters.some(
-          f => f['tags.name'] === DATALAKE_TAG && JSON.stringify(f.archivedAt) === JSON.stringify({ $ne: null })
-        )
-      ).toBe(true);
-      expect(filters.some(f => f.archivedAt === OWN_STAMP)).toBe(true);
+      expect(spy).toHaveBeenCalledTimes(1);
+      const filter = spy.mock.calls[0][0] as Record<string, unknown>;
+      expect(filter.archivedAt).toBe(OWN_STAMP);
       spy.mockRestore();
     });
 
-    it("is safe to retry after a completed sweep: a second call does not free a sibling's differently-stamped prefix member", async () => {
+    it("is safe to retry after a completed sweep: a second call does not free a sibling's differently-stamped member", async () => {
       const rows = await seedLakeRows();
       const OWN_STAMP = new Date('2026-06-01T00:00:00.000Z');
       const SIBLING_STAMP = new Date('2026-05-01T00:00:00.000Z');
@@ -268,8 +282,8 @@ describe('FabFile data lake lifecycle membership', () => {
       await FabFile.updateOne({ _id: rows.prefixOwned._id }, { $set: { archivedAt: SIBLING_STAMP } });
 
       const first = await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
-      // The retry a crash-then-re-entry would produce: the bounded prefix pass now matches nothing
-      // of ours (already cleared), which must NOT fall back to freeing the sibling's row.
+      // The retry a crash-then-re-entry would produce: the bounded pass now matches nothing of
+      // ours (already cleared), which must NOT fall back to freeing the sibling's row.
       const second = await fabFileRepository.unarchiveByDataLakeTag(scope, OWN_STAMP);
 
       expect(first).toBe(1);
@@ -277,13 +291,25 @@ describe('FabFile data lake lifecycle membership', () => {
       expect((await readRaw(rows.prefixOwned._id.toString()))?.archivedAt?.getTime()).toBe(SIBLING_STAMP.getTime());
     });
 
-    it('finds archived members for the unarchive dedup pass', async () => {
+    it('finds archived members for the unarchive dedup pass, unbounded when no stamp is given', async () => {
       await seedLakeRows();
       await fabFileRepository.archiveByDataLakeTag(scope);
 
       const found = await fabFileRepository.findArchivedByDataLakeTag(scope);
 
       expect(found.map(f => f.fileName).sort()).toEqual(['meta.txt', 'prefix-owned.txt']);
+    });
+
+    it('excludes a differently-stamped member from the dedup read when a stamp is given, so it cannot be nominated as a duplicate and soft-deleted', async () => {
+      const rows = await seedLakeRows();
+      const OWN_STAMP = new Date('2026-06-01T00:00:00.000Z');
+      const SIBLING_STAMP = new Date('2026-05-01T00:00:00.000Z');
+      await fabFileRepository.archiveByDataLakeTag(scope, OWN_STAMP);
+      await FabFile.updateOne({ _id: rows.prefixOwned._id }, { $set: { archivedAt: SIBLING_STAMP } });
+
+      const found = await fabFileRepository.findArchivedByDataLakeTag(scope, OWN_STAMP);
+
+      expect(found.map(f => f.fileName)).toEqual(['meta.txt']);
     });
 
     it('hasArchivedByDataLakeTag reports existence without materializing the rows', async () => {

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -16,11 +16,7 @@ import BaseRepository from '@bike4mind/db-core';
 import { addLowercaseField } from '../../utils/documentdb-compat';
 import { ShareableDocumentRepository, ShareableDocumentSchema } from './SharableDocumentModel';
 import { buildFabFileSearchQuery, buildOwnershipConditions, escapeRegex } from '../../queries/fabFileSearchQuery';
-import {
-  buildDataLakeMembershipFilter,
-  buildDataLakeMetaTagFilter,
-  buildDataLakePrefixArmFilter,
-} from '../../queries/dataLakeLifecycleScope';
+import { buildDataLakeMembershipFilter } from '../../queries/dataLakeLifecycleScope';
 
 /**
  * "not a lake membership tag", derived from the one constant rather than spelled out, so a change
@@ -935,9 +931,11 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
   // restore now also clears `archivedAt` (an archive->delete->restore must not leave files
   // archived-and-invisible) - so equality-bounding that clear against the stamp is what stops it
   // from freeing a prefix-sharing sibling's independently-archived files, the same way the delete
-  // axis avoids reviving a file the creator deleted on their own. `unarchiveByDataLakeTag`'s own
-  // reversal is bounded the same way, but split by arm (see its own comment) because the two arms
-  // disagree on whether a stamp can even attribute a row to this lake.
+  // axis avoids reviving a file the creator deleted on their own. `unarchiveByDataLakeTag` and
+  // `findArchivedByDataLakeTag` bound themselves the same way, over the WHOLE membership filter -
+  // a meta-tag match is not exempt: `addFileToLake` lets one file carry more than one lake's
+  // meta-tag with no exclusivity check, so a meta-tagged row can just as easily belong to a
+  // co-owning lake's own archive as a prefix-tagged row can belong to a sibling's.
 
   async archiveByDataLakeTag(scope: DataLakeMembershipScope, at: Date = new Date()): Promise<number> {
     const result = await this.fabFileModel.updateMany(
@@ -947,44 +945,24 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     return result.modifiedCount;
   }
 
-  // Split by arm rather than one query over buildDataLakeMembershipFilter, because the two arms
-  // disagree on what "unbounded" costs. The meta-tag arm is unambiguous - no other lake's document
-  // can ever carry this tag - so it is always unarchived in full regardless of `stampedAt`; that is
-  // also what recovers a member whose stamp this lake's own `filesArchivedAt` no longer names (a
-  // same-millisecond mint collision, or any future write that touches `archivedAt` outside
-  // `archiveByDataLakeTag`), since ownership there needs no stamp to prove. The prefix arm is the
-  // opposite: a `fileTagPrefix` is shared by any lake that registers it, so a row reached only
-  // through that arm can belong to a sibling, and `stampedAt` is the only thing that tells them
-  // apart - equality-bound when given, matching `undeleteByDataLakeTag`'s pattern on the delete
-  // axis. Deliberately NOT "falls back to unbounded when the bounded pass matches nothing": a retry
-  // after a crash between a successful sweep and clearing `filesArchivedAt` also matches nothing on
-  // the bounded pass, and that heuristic would then free a sibling's own differently-stamped prefix
-  // rows - reintroducing the bug this split exists to fix. `stampedAt` undefined (a lake archived
-  // before `filesArchivedAt` existed) is the one case that still runs the prefix arm unbounded,
-  // unchanged from today - a prefix-only row stranded under any other stamp drift stays archived,
-  // an accepted limitation matching `archiveDataLake`'s own `hasUnstampedArchive` guard.
   async unarchiveByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<number> {
-    const prefixArm = buildDataLakePrefixArmFilter(scope);
-    const [metaResult, prefixResult] = await Promise.all([
-      this.fabFileModel.updateMany(
-        { ...buildDataLakeMetaTagFilter(scope), deletedAt: null, archivedAt: { $ne: null } },
-        { $set: { archivedAt: null } }
-      ),
-      prefixArm
-        ? this.fabFileModel.updateMany(
-            { ...prefixArm, deletedAt: null, archivedAt: stampedAt ?? { $ne: null } },
-            { $set: { archivedAt: null } }
-          )
-        : Promise.resolve({ modifiedCount: 0 }),
-    ]);
-    return metaResult.modifiedCount + prefixResult.modifiedCount;
+    const result = await this.fabFileModel.updateMany(
+      { ...buildDataLakeMembershipFilter(scope), deletedAt: null, archivedAt: stampedAt ?? { $ne: null } },
+      { $set: { archivedAt: null } }
+    );
+    return result.modifiedCount;
   }
 
-  async findArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<IFabFileDocument[]> {
+  // `stampedAt` narrows the dedup read the same way it narrows the reversal above - omitting it
+  // (a lake with no recorded stamp) matches every archived row, same as before this parameter
+  // existed. Without this, the dedup pass could read a co-owning or sibling lake's own archived
+  // member and, if it happens to share a contentHash with one of THIS lake's live files,
+  // soft-delete that other lake's row as a "duplicate" it never owned.
+  async findArchivedByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<IFabFileDocument[]> {
     const result = await this.fabFileModel.find({
       ...buildDataLakeMembershipFilter(scope),
       deletedAt: null,
-      archivedAt: { $ne: null },
+      archivedAt: stampedAt ?? { $ne: null },
     });
     return result.map(d => d.toJSON());
   }

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -16,7 +16,11 @@ import BaseRepository from '@bike4mind/db-core';
 import { addLowercaseField } from '../../utils/documentdb-compat';
 import { ShareableDocumentRepository, ShareableDocumentSchema } from './SharableDocumentModel';
 import { buildFabFileSearchQuery, buildOwnershipConditions, escapeRegex } from '../../queries/fabFileSearchQuery';
-import { buildDataLakeMembershipFilter } from '../../queries/dataLakeLifecycleScope';
+import {
+  buildDataLakeMembershipFilter,
+  buildDataLakeMetaTagFilter,
+  buildDataLakePrefixArmFilter,
+} from '../../queries/dataLakeLifecycleScope';
 
 /**
  * "not a lake membership tag", derived from the one constant rather than spelled out, so a change
@@ -931,9 +935,9 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
   // restore now also clears `archivedAt` (an archive->delete->restore must not leave files
   // archived-and-invisible) - so equality-bounding that clear against the stamp is what stops it
   // from freeing a prefix-sharing sibling's independently-archived files, the same way the delete
-  // axis avoids reviving a file the creator deleted on their own. `unarchiveByDataLakeTag` still
-  // matches on `archivedAt` alone (unbounded) - that reversal's own bounding is separate,
-  // unresolved scope.
+  // axis avoids reviving a file the creator deleted on their own. `unarchiveByDataLakeTag`'s own
+  // reversal is bounded the same way, but split by arm (see its own comment) because the two arms
+  // disagree on whether a stamp can even attribute a row to this lake.
 
   async archiveByDataLakeTag(scope: DataLakeMembershipScope, at: Date = new Date()): Promise<number> {
     const result = await this.fabFileModel.updateMany(
@@ -943,12 +947,37 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     return result.modifiedCount;
   }
 
-  async unarchiveByDataLakeTag(scope: DataLakeMembershipScope): Promise<number> {
-    const result = await this.fabFileModel.updateMany(
-      { ...buildDataLakeMembershipFilter(scope), deletedAt: null, archivedAt: { $ne: null } },
-      { $set: { archivedAt: null } }
-    );
-    return result.modifiedCount;
+  // Split by arm rather than one query over buildDataLakeMembershipFilter, because the two arms
+  // disagree on what "unbounded" costs. The meta-tag arm is unambiguous - no other lake's document
+  // can ever carry this tag - so it is always unarchived in full regardless of `stampedAt`; that is
+  // also what recovers a member whose stamp this lake's own `filesArchivedAt` no longer names (a
+  // same-millisecond mint collision, or any future write that touches `archivedAt` outside
+  // `archiveByDataLakeTag`), since ownership there needs no stamp to prove. The prefix arm is the
+  // opposite: a `fileTagPrefix` is shared by any lake that registers it, so a row reached only
+  // through that arm can belong to a sibling, and `stampedAt` is the only thing that tells them
+  // apart - equality-bound when given, matching `undeleteByDataLakeTag`'s pattern on the delete
+  // axis. Deliberately NOT "falls back to unbounded when the bounded pass matches nothing": a retry
+  // after a crash between a successful sweep and clearing `filesArchivedAt` also matches nothing on
+  // the bounded pass, and that heuristic would then free a sibling's own differently-stamped prefix
+  // rows - reintroducing the bug this split exists to fix. `stampedAt` undefined (a lake archived
+  // before `filesArchivedAt` existed) is the one case that still runs the prefix arm unbounded,
+  // unchanged from today - a prefix-only row stranded under any other stamp drift stays archived,
+  // an accepted limitation matching `archiveDataLake`'s own `hasUnstampedArchive` guard.
+  async unarchiveByDataLakeTag(scope: DataLakeMembershipScope, stampedAt?: Date): Promise<number> {
+    const prefixArm = buildDataLakePrefixArmFilter(scope);
+    const [metaResult, prefixResult] = await Promise.all([
+      this.fabFileModel.updateMany(
+        { ...buildDataLakeMetaTagFilter(scope), deletedAt: null, archivedAt: { $ne: null } },
+        { $set: { archivedAt: null } }
+      ),
+      prefixArm
+        ? this.fabFileModel.updateMany(
+            { ...prefixArm, deletedAt: null, archivedAt: stampedAt ?? { $ne: null } },
+            { $set: { archivedAt: null } }
+          )
+        : Promise.resolve({ modifiedCount: 0 }),
+    ]);
+    return metaResult.modifiedCount + prefixResult.modifiedCount;
   }
 
   async findArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<IFabFileDocument[]> {

--- a/packages/database/src/models/content/FabFileModel.ts
+++ b/packages/database/src/models/content/FabFileModel.ts
@@ -967,9 +967,11 @@ export class FabFileRepository extends BaseRepository<IFabFileDocument> implemen
     return result.map(d => d.toJSON());
   }
 
-  // Same predicate as findArchivedByDataLakeTag, but an existence probe rather than a full read -
-  // for a caller (archiveDataLake's hasUnstampedArchive guard) that only needs to know "any?", not
-  // the documents themselves, and would otherwise materialize every archived row on every archive.
+  // Unbounded existence probe, deliberately with no `stampedAt` param unlike
+  // findArchivedByDataLakeTag above - its one caller (archiveDataLake's hasUnstampedArchive
+  // guard) needs to know whether ANY member is already archived, stamped or not, to decide
+  // whether claiming a fresh stamp would strand a pre-existing one; scoping it by a stamp that
+  // does not exist yet would defeat the check.
   async hasArchivedByDataLakeTag(scope: DataLakeMembershipScope): Promise<boolean> {
     return (
       (await this.fabFileModel.exists({

--- a/packages/database/src/queries/dataLakeLifecycleScope.ts
+++ b/packages/database/src/queries/dataLakeLifecycleScope.ts
@@ -30,42 +30,25 @@ import { escapeRegex } from '@bike4mind/utils/escapeRegex';
  * is not a member - it survives the teardown and stays in that admin's Files, the safe direction.
  */
 export function buildDataLakeMembershipFilter(scope: DataLakeMembershipScope): Record<string, unknown> {
-  const metaArm = buildDataLakeMetaTagFilter(scope);
-  const prefixArm = buildDataLakePrefixArmFilter(scope);
-  return prefixArm ? { $or: [metaArm, prefixArm] } : metaArm;
-}
-
-/**
- * The meta-tag arm alone: an exact match on the lake's own unique tag. Unlike the prefix arm
- * below, no other lake's document can ever carry this tag, so a file reached ONLY through this
- * arm is unambiguously this lake's own - split out for a caller (unarchiveByDataLakeTag) that
- * needs to tell that apart from the prefix arm's shared, sibling-collidable membership.
- */
-export function buildDataLakeMetaTagFilter(
-  scope: Pick<DataLakeMembershipScope, 'datalakeTag'>
-): Record<string, unknown> {
-  return { 'tags.name': scope.datalakeTag };
-}
-
-/**
- * The prefix arm alone, or null when this scope has no usable prefix arm (same fail-closed rule
- * as buildDataLakeMembershipFilter: no prefix, a reserved namespace, or no creator to anchor it).
- * The ownership conjunct means only a SAME-creator sibling can ever match the same file here - a
- * unique index plus a create-time overlap check now block a fresh same-creator collision, but a
- * legacy pair predating those guards still can, and its files are a permanent liability: a file
- * reached only through this arm cannot be attributed to one lake over that sibling.
- */
-export function buildDataLakePrefixArmFilter(scope: DataLakeMembershipScope): Record<string, unknown> | null {
+  const metaArm = { 'tags.name': scope.datalakeTag };
   const prefix = normalizeTagPrefix(scope.fileTagPrefix);
+  // Fail closed to the meta-tag alone. A reserved-namespace prefix is dropped because it would
+  // match every OTHER lake's membership tag, and a scope with no creator has nothing to anchor
+  // the prefix arm to - in both cases matching less is the safe direction.
   if (!prefix || isReservedTagPrefix(prefix) || !scope.creatorUserId) {
-    return null;
+    return metaArm;
   }
   return {
-    $and: [
-      // Anchored so the index on `tags.name` still bounds the scan; escaped because a
-      // user-chosen prefix can carry regex metacharacters.
-      { 'tags.name': { $regex: new RegExp(`^${escapeRegex(prefix)}`) } },
-      { userId: scope.creatorUserId },
+    $or: [
+      metaArm,
+      {
+        $and: [
+          // Anchored so the index on `tags.name` still bounds the scan; escaped because a
+          // user-chosen prefix can carry regex metacharacters.
+          { 'tags.name': { $regex: new RegExp(`^${escapeRegex(prefix)}`) } },
+          { userId: scope.creatorUserId },
+        ],
+      },
     ],
   };
 }

--- a/packages/database/src/queries/dataLakeLifecycleScope.ts
+++ b/packages/database/src/queries/dataLakeLifecycleScope.ts
@@ -30,25 +30,41 @@ import { escapeRegex } from '@bike4mind/utils/escapeRegex';
  * is not a member - it survives the teardown and stays in that admin's Files, the safe direction.
  */
 export function buildDataLakeMembershipFilter(scope: DataLakeMembershipScope): Record<string, unknown> {
-  const metaArm = { 'tags.name': scope.datalakeTag };
+  const metaArm = buildDataLakeMetaTagFilter(scope);
+  const prefixArm = buildDataLakePrefixArmFilter(scope);
+  return prefixArm ? { $or: [metaArm, prefixArm] } : metaArm;
+}
+
+/**
+ * The meta-tag arm alone: an exact match on the lake's own unique tag. Unlike the prefix arm
+ * below, no other lake's document can ever carry this tag, so a file reached ONLY through this
+ * arm is unambiguously this lake's own - split out for a caller (unarchiveByDataLakeTag) that
+ * needs to tell that apart from the prefix arm's shared, sibling-collidable membership.
+ */
+export function buildDataLakeMetaTagFilter(
+  scope: Pick<DataLakeMembershipScope, 'datalakeTag'>
+): Record<string, unknown> {
+  return { 'tags.name': scope.datalakeTag };
+}
+
+/**
+ * The prefix arm alone, or null when this scope has no usable prefix arm (same fail-closed rule
+ * as buildDataLakeMembershipFilter: no prefix, a reserved namespace, or no creator to anchor it).
+ * A `fileTagPrefix` is registered per-creator, not per-lake, so two lakes owned by the same
+ * creator can share one - a file reached only through this arm cannot be attributed to one lake
+ * over a prefix-sharing sibling.
+ */
+export function buildDataLakePrefixArmFilter(scope: DataLakeMembershipScope): Record<string, unknown> | null {
   const prefix = normalizeTagPrefix(scope.fileTagPrefix);
-  // Fail closed to the meta-tag alone. A reserved-namespace prefix is dropped because it would
-  // match every OTHER lake's membership tag, and a scope with no creator has nothing to anchor
-  // the prefix arm to - in both cases matching less is the safe direction.
   if (!prefix || isReservedTagPrefix(prefix) || !scope.creatorUserId) {
-    return metaArm;
+    return null;
   }
   return {
-    $or: [
-      metaArm,
-      {
-        $and: [
-          // Anchored so the index on `tags.name` still bounds the scan; escaped because a
-          // user-chosen prefix can carry regex metacharacters.
-          { 'tags.name': { $regex: new RegExp(`^${escapeRegex(prefix)}`) } },
-          { userId: scope.creatorUserId },
-        ],
-      },
+    $and: [
+      // Anchored so the index on `tags.name` still bounds the scan; escaped because a
+      // user-chosen prefix can carry regex metacharacters.
+      { 'tags.name': { $regex: new RegExp(`^${escapeRegex(prefix)}`) } },
+      { userId: scope.creatorUserId },
     ],
   };
 }

--- a/packages/database/src/queries/dataLakeLifecycleScope.ts
+++ b/packages/database/src/queries/dataLakeLifecycleScope.ts
@@ -50,9 +50,10 @@ export function buildDataLakeMetaTagFilter(
 /**
  * The prefix arm alone, or null when this scope has no usable prefix arm (same fail-closed rule
  * as buildDataLakeMembershipFilter: no prefix, a reserved namespace, or no creator to anchor it).
- * A `fileTagPrefix` is registered per-creator, not per-lake, so two lakes owned by the same
- * creator can share one - a file reached only through this arm cannot be attributed to one lake
- * over a prefix-sharing sibling.
+ * The ownership conjunct means only a SAME-creator sibling can ever match the same file here - a
+ * unique index plus a create-time overlap check now block a fresh same-creator collision, but a
+ * legacy pair predating those guards still can, and its files are a permanent liability: a file
+ * reached only through this arm cannot be attributed to one lake over that sibling.
  */
 export function buildDataLakePrefixArmFilter(scope: DataLakeMembershipScope): Record<string, unknown> | null {
   const prefix = normalizeTagPrefix(scope.fileTagPrefix);


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1568" height="401" alt="unarchive-leaves-sibling-lake-archived" src="https://github.com/user-attachments/assets/b07f0f34-415b-4df7-9131-bb3e81917f63" />

*Captured on a local self-hosted run: two legacy lakes seeded directly in Mongo sharing the `acme:` prefix (the collision the product itself no longer allows creating fresh), each archived through the real UI at a different moment. After unarchiving "Reports Lake" through its real Restore button, the Files browser shows "Total Files - 1" with only `acme:report-1.txt` back: "Legal Lake"'s differently-stamped file stays archived. Before this fix, both files would have returned.*

## Description

Closes #1431.

Two data lakes can share a `fileTagPrefix`. Unarchiving one lake reversed every archived file in its membership scope unbounded, so it also freed a prefix-sharing sibling's independently-archived files.

Bounds the reversal, and the dedup read that feeds it, to this lake's own archive stamp (`filesArchivedAt`) by equality, mirroring the delete axis's existing stamped-restore pattern. Also fixes the guard that decides whether a lake claims a fresh stamp: it checked the whole membership filter, which always sees a sibling's already-archived row in a live collision, so whichever lake archived second could never claim its own stamp, stayed unbounded, and reintroduced the bug in that ordering. Scoping the guard to the lake's own meta-tag (never shared, unlike a prefix) closes that gap.

A narrower residual case (a file carrying more than one lake's meta-tag) is disclosed in code and in Additional Information below.

## Changes

- `unarchiveByDataLakeTag` / `findArchivedByDataLakeTag`: take an optional `stampedAt`, bound by equality; omitted for the pre-field legacy unbounded fallback.
- `archiveDataLake`: keeps a zero-swept stamp instead of clearing it to null, so an empty-lake archive no longer re-arms the sibling bug on a later unarchive.
- `archiveDataLake`: scopes the unstamped-archive guard to the lake's own meta-tag, not the full scope, so the second lake to archive in a collision still claims its own stamp.
- `unarchiveDataLake`: threads the stamp through both the dedup read and the reversal; corrects a stale comment claiming the dedup loser is hard-deleted (it is soft-deleted, recoverable).
- Real-Mongo tests: sibling-untouched, multi-meta-tag co-membership untouched, empty-lake-keeps-its-stamp, dedup-read bound, and a crash-retry safety case.

## Guide for Testers

This bug's precondition (two lakes sharing a `fileTagPrefix`) can no longer be freshly created: a unique index plus a create-time overlap check both block a new same-creator collision. Only a legacy pair predating those guards can still trigger it. The screenshot above is a live capture against a seeded legacy pair; the same scenario is also proven against a real MongoDB via the added tests:

1. `cd packages/database && pnpm vitest run src/models/content/FabFileModel.dataLakeLifecycle.test.ts`. Expected: all pass, including `leaves a co-owned member archived when a lake it ALSO belongs to swept it first` and `leaves a differently-stamped prefix member untouched`.
2. `cd b4m-core/services && pnpm vitest run src/dataLakeService/dataLakeService.test.ts`. Expected: all pass, including `claims its own stamp even when a prefix-sharing sibling already has an archived row`.

### What NOT to test
- Reproducing the bug fresh via the Data Lakes UI on an ordinary account: the precondition requires a legacy lake pair the product no longer allows creating.
- Archive/unarchive on an ordinary, non-colliding lake: unaffected, and already covered by the pre-existing test suite.

## Additional Information

Two disclosed, narrower-than-the-fixed-bug limitations, tracked in #1729: (1) a document carrying this lake's own meta-tag can still be swept by a co-owning or prefix-sharing sibling's own archive (multi-meta-tag membership, or independently matching that sibling's prefix arm); see `archiveDataLake.ts`'s comment. (2) A true legacy lake whose only pre-existing archive is prefix-only now claims a real stamp sooner, trading perpetual-unstamped-recoverability for closing the sibling-freeing bug.

## Developer Notes (Optional)

The meta-tag-vs-prefix-arm ownership distinction (a unique index backs exclusive `datalakeTag` ownership, while `fileTagPrefix` is shared and only ownership-anchored) is reusable for any future lifecycle write that needs to bound a reversal against a colliding sibling.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc


