### PR TITLE
fix(datalake): reconcile folder counts with what the tree actually lists

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -76,7 +76,7 @@ const lakeFiles = [
   // from neither the tree nor here.
   { id: 'f4', fileName: 'bare.md', tags: [{ name: 'datalake:mine' }, { name: 'lk:' }] },
   // Tagged with "genre" itself, not a deeper child - "genre" is ALSO the parent of war/peace
-  // above, so this file must stay reachable once genre has subfolders (#1692).
+  // above, so this file must stay reachable once genre has subfolders.
   { id: 'f5', fileName: 'genre-overview.md', tags: [{ name: 'lk:genre' }] },
 ];
 
@@ -323,7 +323,7 @@ describe('DataLakeManagerPanel - lake navigation', () => {
     expect(screen.getByTestId('datalake-manager-overview')).toBeInTheDocument();
   });
 
-  it('lists a category-tagged file alongside its own subfolders, not just inside them (#1692)', async () => {
+  it('lists a category-tagged file alongside its own subfolders, not just inside them', async () => {
     const user = userEvent.setup();
     renderPanel();
 

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -75,6 +75,9 @@ const lakeFiles = [
   // uncategorized and the backfill stamps it. This bucket has to agree, or the file is reachable
   // from neither the tree nor here.
   { id: 'f4', fileName: 'bare.md', tags: [{ name: 'datalake:mine' }, { name: 'lk:' }] },
+  // Tagged with "genre" itself, not a deeper child - "genre" is ALSO the parent of war/peace
+  // above, so this file must stay reachable once genre has subfolders (#1692).
+  { id: 'f5', fileName: 'genre-overview.md', tags: [{ name: 'lk:genre' }] },
 ];
 
 const useGetDataLakes = vi.fn(() => ({ data: [] as unknown[], isLoading: false }));
@@ -318,6 +321,24 @@ describe('DataLakeManagerPanel - lake navigation', () => {
     await user.click(screen.getByTestId('datalake-manager-back'));
     expect(screen.getByTestId('datalake-manager-lake-mine')).toBeInTheDocument();
     expect(screen.getByTestId('datalake-manager-overview')).toBeInTheDocument();
+  });
+
+  it('lists a category-tagged file alongside its own subfolders, not just inside them (#1692)', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByTestId('datalake-manager-lake-mine'));
+    await user.click(screen.getByTestId('datalake-manager-node-genre'));
+
+    // war/peace are genre's children; f5 is tagged "lk:genre" itself - all three must be
+    // reachable from this one folder, or f5 has no path to it anywhere in the tree.
+    expect(screen.getByTestId('datalake-manager-node-war')).toBeInTheDocument();
+    expect(screen.getByTestId('datalake-manager-node-peace')).toBeInTheDocument();
+    expect(screen.getByTestId('datalake-manager-file-f5')).toHaveTextContent('genre-overview');
+
+    // Selecting it opens the file directly - no extra navigation hop.
+    await user.click(screen.getByTestId('datalake-manager-file-f5'));
+    expect(screen.getByTestId('mock-article')).toHaveTextContent('genre-overview.md');
   });
 
   it('opens the Uncategorized bucket and lists the untagged file', async () => {

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
@@ -415,8 +415,8 @@ function ManagerNav({
   }, [isUncategorized, uncategorizedFiles, leafTag, articles]);
 
   // A branch node (has children) can ALSO carry files tagged with its own exact path, not just a
-  // deeper child tag (#1692) - shown as file rows mixed into the folder list below rather than a
-  // separate route, matching DataLakeTreeView's fix for the standalone/chat surfaces.
+  // deeper child tag - shown as file rows mixed into the folder list below rather than a separate
+  // route, matching how DataLakeTreeView handles the same case for the standalone/chat surfaces.
   const ownTag = activeLake && !isUncategorized && !leafTag && path.length > seedDepth ? path.join(':') : null;
   const ownFiles = useMemo(() => {
     if (!ownTag || !currentNode?.ownFileCount) return [];
@@ -851,7 +851,7 @@ function ManagerNav({
               </ListItem>
             )}
 
-            {/* Files tagged with this branch's own exact path, mixed in alongside its subfolders (#1692). */}
+            {/* Files tagged with this branch's own exact path, mixed in alongside its subfolders. */}
             {showOwnFiles &&
               ownFiles.map(file => (
                 <ListItem key={file.id}>

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
@@ -37,7 +37,11 @@ import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
-import { buildTagTree, getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
+import {
+  buildTagTree,
+  getNodeAtPath,
+  getNodesAtPath,
+} from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import { HUES, inkFor } from '@client/app/components/datalake/deckChrome';
 import {
   COUNT_CHIP_SX,
@@ -364,6 +368,7 @@ function ManagerNav({
   }, [articles, activeLake]);
 
   const currentNodes = useMemo(() => getNodesAtPath(tree, path), [tree, path]);
+  const currentNode = useMemo(() => getNodeAtPath(tree, path), [tree, path]);
 
   const filteredNodes = useMemo(() => {
     let nodes = currentNodes;
@@ -404,10 +409,22 @@ function ManagerNav({
   const files = useMemo(() => {
     if (isUncategorized) return uncategorizedFiles;
     if (!leafTag) return [];
-    return [...articles]
+    return articles
       .filter(f => (f.tags ?? []).some(t => t.name === leafTag))
       .sort((a, b) => a.fileName.localeCompare(b.fileName));
   }, [isUncategorized, uncategorizedFiles, leafTag, articles]);
+
+  // A branch node (has children) can ALSO carry files tagged with its own exact path, not just a
+  // deeper child tag (#1692) - shown as file rows mixed into the folder list below rather than a
+  // separate route, matching DataLakeTreeView's fix for the standalone/chat surfaces.
+  const ownTag = activeLake && !isUncategorized && !leafTag && path.length > seedDepth ? path.join(':') : null;
+  const ownFiles = useMemo(() => {
+    if (!ownTag || !currentNode?.ownFileCount) return [];
+    return articles
+      .filter(f => (f.tags ?? []).some(t => t.name === ownTag))
+      .sort((a, b) => a.fileName.localeCompare(b.fileName));
+  }, [ownTag, currentNode, articles]);
+  const showOwnFiles = !searchQuery && ownFiles.length > 0;
 
   const filteredLakes = useMemo(() => {
     let list = lakes ?? [];
@@ -834,9 +851,38 @@ function ManagerNav({
               </ListItem>
             )}
 
-            {filteredNodes.length === 0 && !(atLakeRoot && !searchQuery && uncategorizedFiles.length > 0) && (
-              <EmptyHint text={searchQuery ? 'No matches' : 'No categories'} />
-            )}
+            {/* Files tagged with this branch's own exact path, mixed in alongside its subfolders (#1692). */}
+            {showOwnFiles &&
+              ownFiles.map(file => (
+                <ListItem key={file.id}>
+                  <ListItemButton
+                    selected={selectedFileId === file.id}
+                    onClick={() => onSelectFile(file)}
+                    data-testid={`datalake-manager-file-${file.id}`}
+                    sx={treeRowSx(hoverBg)}
+                  >
+                    <ArticleOutlinedIcon
+                      sx={{
+                        fontSize: 16,
+                        color: selectedFileId === file.id ? inkFor(HUES.cyan, isDark) : 'text.tertiary',
+                        flexShrink: 0,
+                      }}
+                    />
+                    <ListItemContent>
+                      <Typography
+                        noWrap
+                        sx={{ ...rowTypographySx, fontWeight: selectedFileId === file.id ? 'lg' : 400 }}
+                      >
+                        {file.fileName.replace(/\.[^/.]+$/, '')}
+                      </Typography>
+                    </ListItemContent>
+                  </ListItemButton>
+                </ListItem>
+              ))}
+
+            {filteredNodes.length === 0 &&
+              !(atLakeRoot && !searchQuery && uncategorizedFiles.length > 0) &&
+              !showOwnFiles && <EmptyHint text={searchQuery ? 'No matches' : 'No categories'} />}
           </List>
         )}
       </Box>

--- a/apps/client/app/components/Files/Browser/TagView/__tests__/parseTagNamespace.test.ts
+++ b/apps/client/app/components/Files/Browser/TagView/__tests__/parseTagNamespace.test.ts
@@ -69,7 +69,7 @@ describe('buildTagTree', () => {
     const b = a.children[0];
     expect(b.segment).toBe('b');
     expect(b.fileCount).toBe(9); // 2 (own) + 7 (from child c)
-    expect(b.ownFileCount).toBe(2); // #1692: what the tree can't otherwise surface once b has children
+    expect(b.ownFileCount).toBe(2); // what fileCount alone can't surface once b has children
     expect(b.children).toHaveLength(1);
     expect(b.children[0]).toMatchObject({ segment: 'c', fileCount: 7, ownFileCount: 7 });
   });

--- a/apps/client/app/components/Files/Browser/TagView/__tests__/parseTagNamespace.test.ts
+++ b/apps/client/app/components/Files/Browser/TagView/__tests__/parseTagNamespace.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTagTree, getNodesAtPath, TagNode } from '../parseTagNamespace';
+import { buildTagTree, getNodeAtPath, getNodesAtPath, TagNode } from '../parseTagNamespace';
 
 describe('buildTagTree', () => {
   it('returns empty array for empty input', () => {
@@ -64,12 +64,14 @@ describe('buildTagTree', () => {
 
     const a = result[0];
     expect(a.fileCount).toBe(9); // 2 + 7
+    expect(a.ownFileCount).toBe(0); // "a" itself is never a tag on its own here
 
     const b = a.children[0];
     expect(b.segment).toBe('b');
     expect(b.fileCount).toBe(9); // 2 (own) + 7 (from child c)
+    expect(b.ownFileCount).toBe(2); // #1692: what the tree can't otherwise surface once b has children
     expect(b.children).toHaveLength(1);
-    expect(b.children[0]).toMatchObject({ segment: 'c', fileCount: 7 });
+    expect(b.children[0]).toMatchObject({ segment: 'c', fileCount: 7, ownFileCount: 7 });
   });
 
   it('sorts children alphabetically at each level', () => {
@@ -149,5 +151,29 @@ describe('getNodesAtPath', () => {
   it('returns empty array for leaf node breadcrumb (no children)', () => {
     const result = getNodesAtPath(tree, ['opti', 'work']);
     expect(result).toEqual([]); // work is a leaf, has no children
+  });
+});
+
+describe('getNodeAtPath', () => {
+  const tree: TagNode[] = buildTagTree([
+    { tag: 'a:b', count: 2 },
+    { tag: 'a:b:c', count: 7 },
+  ]);
+
+  it('returns null for the root (empty breadcrumb)', () => {
+    expect(getNodeAtPath(tree, [])).toBeNull();
+  });
+
+  it('returns null for a non-existent path', () => {
+    expect(getNodeAtPath(tree, ['nonexistent'])).toBeNull();
+  });
+
+  it('returns the node itself, not its children, so ownFileCount is reachable at a branch', () => {
+    const b = getNodeAtPath(tree, ['a', 'b']);
+    expect(b).not.toBeNull();
+    expect(b!.segment).toBe('b');
+    expect(b!.fileCount).toBe(9);
+    expect(b!.ownFileCount).toBe(2);
+    expect(b!.children).toHaveLength(1);
   });
 });

--- a/apps/client/app/components/Files/Browser/TagView/index.ts
+++ b/apps/client/app/components/Files/Browser/TagView/index.ts
@@ -1,4 +1,4 @@
 export { default as TagViewPanel } from './TagViewPanel';
-export { buildTagTree, getNodesAtPath } from './parseTagNamespace';
+export { buildTagTree, getNodeAtPath, getNodesAtPath } from './parseTagNamespace';
 export type { TagNode } from './parseTagNamespace';
 export { TAG_COLORS, getTagColor } from './tagColors';

--- a/apps/client/app/components/Files/Browser/TagView/parseTagNamespace.ts
+++ b/apps/client/app/components/Files/Browser/TagView/parseTagNamespace.ts
@@ -5,9 +5,9 @@ export interface TagNode {
   fileCount: number;
   /**
    * Files tagged with this node's exact fullPath, as opposed to a deeper child tag. A node can
-   * carry both children AND its own directly-tagged files (e.g. a file tagged "a:b" while
-   * others are tagged "a:b:c") - those own-tagged files are otherwise unreachable from the tree,
-   * since navigating into a branch node only ever shows its children (#1692).
+   * carry both children AND its own directly-tagged files (e.g. a file tagged "a:b" while others
+   * are tagged "a:b:c"). Tracked separately from fileCount because navigating into a branch node
+   * only ever shows its children - without this, those files would have nowhere to render.
    */
   ownFileCount: number;
   children: TagNode[];

--- a/apps/client/app/components/Files/Browser/TagView/parseTagNamespace.ts
+++ b/apps/client/app/components/Files/Browser/TagView/parseTagNamespace.ts
@@ -1,7 +1,15 @@
 export interface TagNode {
   segment: string;
   fullPath: string;
+  /** This node's own count plus every descendant's - what the folder row's chip shows. */
   fileCount: number;
+  /**
+   * Files tagged with this node's exact fullPath, as opposed to a deeper child tag. A node can
+   * carry both children AND its own directly-tagged files (e.g. a file tagged "a:b" while
+   * others are tagged "a:b:c") - those own-tagged files are otherwise unreachable from the tree,
+   * since navigating into a branch node only ever shows its children (#1692).
+   */
+  ownFileCount: number;
   children: TagNode[];
 }
 
@@ -25,25 +33,23 @@ export function buildTagTree(tagCounts: { tag: string; count: number }[]): TagNo
 
       let existing = currentLevel.find(n => n.segment === segment);
       if (!existing) {
-        existing = { segment, fullPath, fileCount: 0, children: [] };
+        existing = { segment, fullPath, fileCount: 0, ownFileCount: 0, children: [] };
         currentLevel.push(existing);
       }
 
       if (isLeaf) {
-        existing.fileCount += count;
+        existing.ownFileCount += count;
       }
 
       currentLevel = existing.children;
     }
   }
 
-  // Propagate counts upward: each node's fileCount = sum of all descendant leaf counts
+  // fileCount = this node's own count plus every descendant's, computed bottom-up.
   function sumCounts(nodes: TagNode[]): number {
     for (const node of nodes) {
-      if (node.children.length > 0) {
-        const childSum = sumCounts(node.children);
-        node.fileCount += childSum;
-      }
+      const childSum = node.children.length > 0 ? sumCounts(node.children) : 0;
+      node.fileCount = node.ownFileCount + childSum;
     }
     return nodes.reduce((sum, n) => sum + n.fileCount, 0);
   }
@@ -73,4 +79,20 @@ export function getNodesAtPath(roots: TagNode[], breadcrumb: string[]): TagNode[
     current = found.children;
   }
   return current;
+}
+
+/**
+ * The node AT a breadcrumb path, as opposed to getNodesAtPath's children of it. Null for the
+ * root (breadcrumb [], which has no single node) or a path that doesn't exist in the tree.
+ */
+export function getNodeAtPath(roots: TagNode[], breadcrumb: string[]): TagNode | null {
+  let current = roots;
+  let node: TagNode | null = null;
+  for (const segment of breadcrumb) {
+    const found = current.find(n => n.segment === segment);
+    if (!found) return null;
+    node = found;
+    current = found.children;
+  }
+  return node;
 }

--- a/apps/client/app/components/datalake/DataLakeExplorer.loading.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.loading.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+import { useDataLakeNav } from './dataLakeNavContext';
+import DataLakeExplorer from './DataLakeExplorer';
+
+// "docs:policy" is tagged directly (own files) AND is the parent of "docs:policy:v2" - a mixed
+// branch node. Its own-tagged files still need a fetch, but the subfolder list itself doesn't:
+// it's already available from tagCounts, so the pane must not blank to a skeleton while that
+// fetch is in flight. "docs:policy:v2" is a true leaf, where nothing renders without its fetch,
+// so that case is a regression control - it must stay gated on isLoading as before.
+vi.mock('@client/app/hooks/data/dataLakes', () => ({
+  activeOrgId: () => undefined,
+  useGetDataLakeTagCounts: () => ({
+    data: {
+      tagCounts: [
+        { tag: 'docs:policy', count: 2 },
+        { tag: 'docs:policy:v2', count: 5 },
+      ],
+      uniqueArticleCounts: { total: 7 },
+    },
+    isLoading: false,
+    isError: false,
+  }),
+  useGetDataLakeArticles: (params?: { tags?: string[] } | null) => {
+    const tag = params?.tags?.[0];
+    if (tag === 'docs:policy' || tag === 'docs:policy:v2') {
+      return { data: undefined, isLoading: true };
+    }
+    return { data: { data: [] }, isLoading: false };
+  },
+}));
+
+vi.mock('@client/app/contexts/SessionsContext', async importOriginal => ({
+  ...(await importOriginal<typeof import('@client/app/contexts/SessionsContext')>()),
+  useSessions: () => ({ currentSessionId: 'sess-1' }),
+  useWorkBenchActions: () => ({ setWorkBenchFiles: vi.fn() }),
+}));
+vi.mock('@client/app/hooks/useSetDataLakeMode', () => ({ default: () => vi.fn() }));
+vi.mock('@client/app/components/DataLakeWizard/DataLakeIngestPickerModal', () => ({ default: () => null }));
+vi.mock('@client/app/components/layouts/Notebook', () => ({
+  useNotebookLayout: (sel: (s: { openSideNav: boolean }) => unknown) => sel({ openSideNav: true }),
+}));
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), error: vi.fn() } }));
+
+// Surface the isLoading prop the Explorer computes so the fix can be asserted directly.
+vi.mock('./DataLakeChatTree', () => ({
+  default: ({ isLoading, breadcrumb }: { isLoading: boolean; breadcrumb: string[] }) => (
+    <div data-testid="mock-tree" data-loading={String(isLoading)} data-breadcrumb={breadcrumb.join('/')} />
+  ),
+}));
+
+// Drives navigation the same way the chatSlot host does elsewhere in this suite.
+function NavProbe() {
+  const nav = useDataLakeNav();
+  if (!nav) return null;
+  return (
+    <>
+      <button data-testid="nav-to-mixed" onClick={() => nav.navigate(['docs', 'policy'])}>
+        mixed
+      </button>
+      <button data-testid="nav-to-leaf" onClick={() => nav.navigate(['docs', 'policy', 'v2'])}>
+        leaf
+      </button>
+    </>
+  );
+}
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+const renderExplorer = () =>
+  render(
+    <CssVarsProvider theme={appTheme}>
+      <DataLakeExplorer source="datalakes" chatSlot={<NavProbe />} />
+    </CssVarsProvider>
+  );
+
+describe('DataLakeExplorer -- loading state at a mixed branch node', () => {
+  it("does not blank the folder list while a mixed node's own-files fetch is in flight", () => {
+    renderExplorer();
+    fireEvent.click(screen.getByTestId('nav-to-mixed'));
+    const tree = screen.getByTestId('mock-tree');
+    expect(tree).toHaveAttribute('data-breadcrumb', 'docs/policy');
+    expect(tree).toHaveAttribute('data-loading', 'false');
+  });
+
+  it('still shows loading at a true leaf whose only content is the in-flight fetch', () => {
+    renderExplorer();
+    fireEvent.click(screen.getByTestId('nav-to-leaf'));
+    const tree = screen.getByTestId('mock-tree');
+    expect(tree).toHaveAttribute('data-breadcrumb', 'docs/policy/v2');
+    expect(tree).toHaveAttribute('data-loading', 'true');
+  });
+});

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -239,6 +239,10 @@ export default function DataLakeExplorer({
     source
   );
   const leafArticles = leafTag ? (leafArticlesResult?.data ?? []) : [];
+  // isLoading passed to the tree below only waits on leafLoading at a true leaf
+  // (currentNodes.length === 0): a branch node's subfolder list needs no fetch at all, so
+  // blocking it on the own-tagged-files fetch would blank an already-renderable folder list
+  // behind a skeleton every time a mixed node is opened.
 
   // Deep-link: fetch the specific article by ID when the URL param is present. Page mode shows
   // it in the inline reader; chat mode opens it in the viewer (effect below).
@@ -500,7 +504,7 @@ export default function DataLakeExplorer({
             onNavigate={handleNavigate}
             selectedFileId={viewerFileId}
             onSelectFile={handleSelectFile}
-            isLoading={tagCountsLoading || (!!leafTag && leafLoading)}
+            isLoading={tagCountsLoading || (!!leafTag && leafLoading && currentNodes.length === 0)}
             isError={tagCountsError}
             title={rootLabel ?? copy.rootLabel}
             onManage={onManage}
@@ -520,7 +524,7 @@ export default function DataLakeExplorer({
             onNavigate={handleNavigate}
             selectedFileId={selectedFile?.id ?? null}
             onSelectFile={handleSelectFile}
-            isLoading={tagCountsLoading || (!!leafTag && leafLoading)}
+            isLoading={tagCountsLoading || (!!leafTag && leafLoading && currentNodes.length === 0)}
             isError={tagCountsError}
           />
           <DataLakeArticle

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -18,7 +18,11 @@ import { setSessionLayout } from '@client/app/hooks/useSessionLayout';
 import { useNotebookLayout } from '@client/app/components/layouts/Notebook';
 import { useGetDataLakeArticles, useGetDataLakeTagCounts } from '@client/app/hooks/data/dataLakes';
 import type { DataLakeBrowseSource } from '@client/app/hooks/data/dataLakes';
-import { buildTagTree, getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
+import {
+  buildTagTree,
+  getNodeAtPath,
+  getNodesAtPath,
+} from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import DataLakeIngestPickerModal from '@client/app/components/DataLakeWizard/DataLakeIngestPickerModal';
 import { readDroppedItems } from '@client/app/utils/dropReader';
 import { DATA_LAKES } from '@client/app/components/datalake/dataLakeBranding';
@@ -218,11 +222,18 @@ export default function DataLakeExplorer({
   const { data: tagCountsData, isLoading: tagCountsLoading, isError: tagCountsError } = useGetDataLakeTagCounts(source);
   const tree = useMemo(() => buildTagTree(tagCountsData?.tagCounts ?? []), [tagCountsData]);
 
-  // Derive the current leaf tag from breadcrumb + tree state
-  const currentNodes = getNodesAtPath(tree, breadcrumb);
-  const leafTag = breadcrumb.length > 0 && currentNodes.length === 0 ? breadcrumb.join(':') : null;
+  // Derive the current leaf tag from breadcrumb + tree state. A branch node (has children) can
+  // ALSO carry files tagged with its own exact path (#1692), which DataLakeTreeView renders
+  // mixed into the folder list - so this must fetch whenever there's anything to show at this
+  // breadcrumb, not only at a true leaf, or those own-tagged files never even reach the tree.
+  const currentNodes = useMemo(() => getNodesAtPath(tree, breadcrumb), [tree, breadcrumb]);
+  const currentNode = useMemo(() => getNodeAtPath(tree, breadcrumb), [tree, breadcrumb]);
+  const leafTag =
+    breadcrumb.length > 0 && (currentNodes.length === 0 || (currentNode?.ownFileCount ?? 0) > 0)
+      ? breadcrumb.join(':')
+      : null;
 
-  // Phase 2: Fetch articles only when at a leaf node (filtered by tag, paginated)
+  // Phase 2: Fetch articles only when there's a tag at this breadcrumb to filter by (paginated)
   const { data: leafArticlesResult, isLoading: leafLoading } = useGetDataLakeArticles(
     leafTag ? { tags: [leafTag], limit: 50 } : null,
     source

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -223,9 +223,9 @@ export default function DataLakeExplorer({
   const tree = useMemo(() => buildTagTree(tagCountsData?.tagCounts ?? []), [tagCountsData]);
 
   // Derive the current leaf tag from breadcrumb + tree state. A branch node (has children) can
-  // ALSO carry files tagged with its own exact path (#1692), which DataLakeTreeView renders
-  // mixed into the folder list - so this must fetch whenever there's anything to show at this
-  // breadcrumb, not only at a true leaf, or those own-tagged files never even reach the tree.
+  // ALSO carry files tagged with its own exact path, which DataLakeTreeView renders mixed into
+  // the folder list - so this must fetch whenever there's anything to show at this breadcrumb,
+  // not only at a true leaf, or those own-tagged files never even reach the tree.
   const currentNodes = useMemo(() => getNodesAtPath(tree, breadcrumb), [tree, breadcrumb]);
   const currentNode = useMemo(() => getNodeAtPath(tree, breadcrumb), [tree, breadcrumb]);
   const leafTag =

--- a/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
@@ -261,10 +261,10 @@ describe('DataLakeTreeView uncategorized bucket', () => {
   });
 });
 
-// #1692: "books" is tagged directly on one file AND is the parent of "books:war"/"books:peace" -
-// that file was previously unreachable from any breadcrumb path once "books" had children. It
-// now renders as an ordinary file row mixed into the folder list, not behind a separate route.
-describe('DataLakeTreeView own-tagged files mixed into the folder list (#1692)', () => {
+// "books" is tagged directly on one file AND is the parent of "books:war"/"books:peace" - that
+// file would otherwise be unreachable from any breadcrumb path once "books" had children. It
+// renders as an ordinary file row mixed into the folder list, not behind a separate route.
+describe('DataLakeTreeView own-tagged files mixed into the folder list', () => {
   const directArticles = [...ARTICLES, file('d1', 'own-books.md', ['books'])];
   const directTree = buildTagTree([
     { tag: 'books:war', count: 2 },

--- a/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.test.tsx
@@ -260,3 +260,53 @@ describe('DataLakeTreeView uncategorized bucket', () => {
     expect(screen.getByTestId('datalake-node-uncategorized')).toBeTruthy();
   });
 });
+
+// #1692: "books" is tagged directly on one file AND is the parent of "books:war"/"books:peace" -
+// that file was previously unreachable from any breadcrumb path once "books" had children. It
+// now renders as an ordinary file row mixed into the folder list, not behind a separate route.
+describe('DataLakeTreeView own-tagged files mixed into the folder list (#1692)', () => {
+  const directArticles = [...ARTICLES, file('d1', 'own-books.md', ['books'])];
+  const directTree = buildTagTree([
+    { tag: 'books:war', count: 2 },
+    { tag: 'books:peace', count: 1 },
+    { tag: 'books', count: 1 },
+    { tag: 'news:today', count: 1 },
+    { tag: 'zebra:x', count: 5 },
+  ]);
+
+  it('lists the directly-tagged file alongside its subfolders, reconciling the branch total', () => {
+    renderTree({ tree: directTree, articles: directArticles, breadcrumb: ['books'] });
+    expect(screen.getByTestId('datalake-node-war')).toBeTruthy();
+    expect(screen.getByTestId('datalake-node-peace')).toBeTruthy();
+    expect(screen.getByTestId('datalake-file-d1')).toBeTruthy();
+    // Reachable from this one folder: war(2) + peace(1) + d1(1) = 4, matching "books".fileCount.
+    const books = directTree[0];
+    expect(books.fileCount).toBe(4);
+  });
+
+  it('selects the file directly on click - no extra navigation hop', () => {
+    const { onNavigate, onSelectFile } = renderTree({
+      tree: directTree,
+      articles: directArticles,
+      breadcrumb: ['books'],
+    });
+    fireEvent.click(screen.getByTestId('datalake-file-d1'));
+    expect(onSelectFile).toHaveBeenCalledWith(directArticles.find(f => f.id === 'd1'));
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('omits any own-file rows for a branch with none of its own', () => {
+    renderTree({ tree: directTree, articles: directArticles, breadcrumb: ['news'] });
+    expect(screen.getByTestId('datalake-node-today')).toBeTruthy();
+    expect(screen.queryAllByTestId(/^datalake-file-/)).toHaveLength(0);
+  });
+
+  it('hides own files while searching, alongside the filtered-out subfolder', async () => {
+    renderTree({ tree: directTree, articles: directArticles, breadcrumb: ['books'] });
+    const searchInput = screen.getByTestId('datalake-search').querySelector('input')!;
+    await userEvent.type(searchInput, 'war');
+    expect(screen.getByTestId('datalake-node-war')).toBeTruthy();
+    expect(screen.queryByTestId('datalake-node-peace')).toBeNull();
+    expect(screen.queryByTestId('datalake-file-d1')).toBeNull();
+  });
+});

--- a/apps/client/app/components/datalake/DataLakeTreeView.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.tsx
@@ -118,9 +118,9 @@ export default function DataLakeTreeView({
   }, [isUncategorized, bucketFiles, leafTag, articles]);
 
   // A branch node (has children) can ALSO carry files tagged with its own exact path, not just
-  // a deeper child tag (#1692) - those render as file rows mixed into the folder list below,
-  // rather than a separate route, so they read like a normal file browser (folders + files
-  // together) instead of a folder that contains only itself.
+  // a deeper child tag. Render those as file rows mixed into the folder list below, so the view
+  // reads like a normal file browser (folders + files together) instead of hiding them behind a
+  // folder that only ever contains itself.
   const ownTag = !isUncategorized && !leafTag && breadcrumb.length > 0 ? breadcrumb.join(':') : null;
   const ownFiles = useMemo(() => {
     if (!ownTag || !currentNode?.ownFileCount) return [];

--- a/apps/client/app/components/datalake/DataLakeTreeView.tsx
+++ b/apps/client/app/components/datalake/DataLakeTreeView.tsx
@@ -3,7 +3,7 @@ import { Box, Input, List, Skeleton, Typography } from '@mui/joy';
 import type { SxProps } from '@mui/joy/styles/types';
 import SearchIcon from '@mui/icons-material/Search';
 import type { TagNode } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
-import { getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
+import { getNodeAtPath, getNodesAtPath } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import type { TreeSortMode } from './treeChrome';
 import type { IFabFileDocument } from '@bike4mind/common';
 
@@ -89,7 +89,10 @@ export default function DataLakeTreeView({
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<TreeSortMode>('count');
 
+  const isUncategorized = !!uncategorized && breadcrumb.length === 1 && breadcrumb[0] === UNCATEGORIZED_KEY;
+
   const currentNodes = useMemo(() => getNodesAtPath(tree, breadcrumb), [tree, breadcrumb]);
+  const currentNode = useMemo(() => getNodeAtPath(tree, breadcrumb), [tree, breadcrumb]);
 
   const filteredNodes = useMemo(() => {
     let nodes = currentNodes;
@@ -102,9 +105,6 @@ export default function DataLakeTreeView({
     );
   }, [currentNodes, searchQuery, sortBy]);
 
-  // The synthetic bucket intercepts before leaf-tag resolution: its key is not a real tag.
-  const isUncategorized = !!uncategorized && breadcrumb.length === 1 && breadcrumb[0] === UNCATEGORIZED_KEY;
-
   // At a leaf node (no children), files are filtered locally by the leaf tag.
   const leafTag = !isUncategorized && breadcrumb.length > 0 && currentNodes.length === 0 ? breadcrumb.join(':') : null;
   const showFiles = isUncategorized || !!leafTag;
@@ -112,14 +112,30 @@ export default function DataLakeTreeView({
   const files = useMemo(() => {
     if (isUncategorized) return bucketFiles!;
     if (!leafTag) return [];
-    return [...articles]
+    return articles
       .filter(f => (f.tags ?? []).some(t => t.name === leafTag))
       .sort((a, b) => a.fileName.localeCompare(b.fileName));
   }, [isUncategorized, bucketFiles, leafTag, articles]);
 
+  // A branch node (has children) can ALSO carry files tagged with its own exact path, not just
+  // a deeper child tag (#1692) - those render as file rows mixed into the folder list below,
+  // rather than a separate route, so they read like a normal file browser (folders + files
+  // together) instead of a folder that contains only itself.
+  const ownTag = !isUncategorized && !leafTag && breadcrumb.length > 0 ? breadcrumb.join(':') : null;
+  const ownFiles = useMemo(() => {
+    if (!ownTag || !currentNode?.ownFileCount) return [];
+    return articles
+      .filter(f => (f.tags ?? []).some(t => t.name === ownTag))
+      .sort((a, b) => a.fileName.localeCompare(b.fileName));
+  }, [ownTag, currentNode, articles]);
+  // Hidden while searching, matching the uncategorized bucket: search filters folder segments,
+  // not files, so a folder's own files are not "search results" either.
+  const showOwnFiles = !searchQuery && ownFiles.length > 0;
+
   const showBucketRow = !!uncategorized && breadcrumb.length === 0 && !searchQuery && uncategorized.files.length > 0;
-  // The bucket standing in for an empty root is still content - don't show "No categories" under it.
-  const showNodeEmpty = filteredNodes.length === 0 && !showBucketRow;
+  // The bucket / own-files rows standing in for an empty node list are still content - don't
+  // show "No categories" under them.
+  const showNodeEmpty = filteredNodes.length === 0 && !showBucketRow && !showOwnFiles;
 
   const backRow =
     breadcrumb.length > 0
@@ -187,6 +203,7 @@ export default function DataLakeTreeView({
             )}
             {showBucketRow &&
               uncategorized!.renderRow(uncategorized!.files.length, () => onNavigate([UNCATEGORIZED_KEY]))}
+            {showOwnFiles && ownFiles.map(f => chrome.renderFileRow(f, selectedFileId === f.id, () => onSelectFile(f)))}
             {showNodeEmpty && (
               <Box sx={{ p: 2, textAlign: 'center' }}>
                 <Typography level="body-xs" sx={{ color: 'text.tertiary' }}>


### PR DESCRIPTION
## Description

Fixes #1692. In the Data Lakes panel, a folder could show a non-zero article count while opening it rendered "No articles found," or a listing whose length disagreed with the count shown on the folder row.

The cause: a tag can be used both directly on some files and as the prefix of a deeper child tag (e.g. one file tagged exactly `docs:policy`, another tagged `docs:policy:v2`). The folder count summed both, but the tree only ever fetched and rendered a branch node's _children_ - so files carrying the branch's own exact tag were unreachable from any breadcrumb path, even though the folder's count included them.

Files tagged with a branch's own exact path now render as ordinary file rows mixed into that folder's listing, alongside its subfolders - so the count and the reachable set are the same set again, in all three places that browse a Data Lake tag tree.

## Changes

- `TagNode` (`parseTagNamespace.ts`) now tracks `ownFileCount` - files tagged with the node's own exact path - separately from `fileCount`, the propagated total shown on the folder chip. Added `getNodeAtPath`, returning the node itself (not just its children) for a breadcrumb path.
- `DataLakeTreeView.tsx` (the standalone `/data-lakes` page and in-chat tree): a branch node with `ownFileCount > 0` now renders those files as regular rows mixed into its subfolder list, hidden while searching (same as the existing "uncategorized" bucket).
- `DataLakeExplorer.tsx`: the article fetch that feeds the tree above was previously gated to only fire at a true leaf (no children). Widened so it also fires for a branch node that has its own directly-tagged files - otherwise the tree-side fix had nothing to render.
- `DataLakeManagerPanel.tsx` (the Manage Data Lakes modal): carries its own independent tag-tree browsing logic, not routed through `DataLakeTreeView`. Applied the same fix here for consistency across both surfaces.

## Guide for Testers

1. Go to **Data Lakes** panel, open a lake, and start the upload wizard to add two small files.
2. In the wizard's config step, set a **Tag Prefix**, e.g. `test:`.
3. After upload, open **Review AI Tag Suggestions** from the Data Lakes manager.
4. Edit the first suggested tag's suffix to `widgets`, and the second one's suffix to `widgets:beta`, then click **Apply Tags**.

   <img width="798" height="327" alt="image" src="https://github.com/user-attachments/assets/82abc3b7-76ec-478b-9cfd-9d00cab66b1b" />

5. Back in the Data Lakes panel (standalone page or in-chat tree), navigate into `test` -> `widgets`.
   - Expected: you see a `beta` subfolder AND the file tagged exactly `test:widgets` listed together in the same view - not a "No articles found" state, and not a separate folder you have to click into.
   - Expected: clicking that file opens it directly, with no extra navigation step.
   
      <img width="280" height="173" alt="image" src="https://github.com/user-attachments/assets/49aa55e5-df93-4927-8abd-28b5e0d606ea" />

6. Open the **Manage Data Lakes** modal, select the same lake, and navigate into `widgets` there too.
   - Expected: the same subfolder + file combination appears together in this panel as well.

### What NOT to test

No change to how a genuine leaf folder (no subfolders) lists its files, to the "uncategorized" bucket, or to file upload/tagging itself - only how a folder that has both subfolders and its own tagged files is browsed.

## Additional Information

Verified: `pnpm turbo:typecheck` clean, `pnpm lint:check` clean. Full test suites for the affected areas pass, including new tests exercising the exact hybrid-node scenario (a tag used both directly and as a parent): `parseTagNamespace.test.ts`, `DataLakeTreeView.test.tsx`, `DataLakeManagerPanel.test.tsx`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
