### PR TITLE
fix(client): recover a focused tab's session without a focus event

### DIFF
--- a/apps/client/app/contexts/ApiContext.test.tsx
+++ b/apps/client/app/contexts/ApiContext.test.tsx
@@ -361,4 +361,83 @@ describe('ApiProvider 401 interceptor -> login redirect', () => {
     expect(replace).not.toHaveBeenCalled();
     expect(useAccessToken.getState().accessToken).toBe('new-access');
   });
+
+  it('collapses concurrent 401s from a burst of parallel requests into one refresh', async () => {
+    let refreshCalls = 0;
+    api.defaults.adapter = ((config: InternalAxiosRequestConfig) => {
+      if (config.url === '/api/auth/refreshToken') {
+        refreshCalls += 1;
+        return Promise.resolve(ok(config, { accessToken: 'new-access' }));
+      }
+      // Every request 401s until it carries the post-refresh token - a burst of 5 all miss
+      // on their first attempt (stale token) and must all queue on the SAME refresh.
+      if (config.headers?.Authorization === 'Bearer new-access') {
+        return Promise.resolve(ok(config, { ok: true }));
+      }
+      return Promise.reject(make401(config));
+    }) as AxiosAdapter;
+
+    const results = await Promise.all([
+      api.get('/api/a'),
+      api.get('/api/b'),
+      api.get('/api/c'),
+      api.get('/api/d'),
+      api.get('/api/e'),
+    ]);
+
+    expect(results.every(r => r.data.ok === true)).toBe(true);
+    expect(refreshCalls).toBe(1);
+  });
+
+  // Known pre-existing gap (FP-4), tracked separately - not fixed by this PR. refreshPromise
+  // nulls in its `finally` as soon as the initiating request's refresh settles, so a second,
+  // already-in-flight request whose own 401 lands just after that clears the guard sees
+  // refreshPromise === null and starts its OWN second refresh - against a refresh token the
+  // first request's rotation already consumed. The server rejects that second attempt with a
+  // 400, which the interceptor currently treats as a genuine revocation and logs the user out,
+  // even though the session is actually fine (the first refresh succeeded moments earlier).
+  it.fails(
+    'does not spuriously log the user out when a second, near-simultaneous 401 starts a refresh against an already-rotated cookie',
+    async () => {
+      let refreshCalls = 0;
+      let releaseB: (() => void) | undefined;
+      const bGate = new Promise<void>(resolve => {
+        releaseB = resolve;
+      });
+
+      api.defaults.adapter = (async (config: InternalAxiosRequestConfig) => {
+        if (config.url === '/api/auth/refreshToken') {
+          refreshCalls += 1;
+          if (refreshCalls === 1) {
+            return ok(config, { accessToken: 'rotated' });
+          }
+          // Second refresh attempt: the refresh token was already consumed by the first
+          // request's rotation - the server sees this as an invalid_grant, not a fluke.
+          throw makeStatus(config, 400);
+        }
+        if (config.url === '/api/x') {
+          if (config.headers?.Authorization === 'Bearer rotated') {
+            return ok(config, { ok: true });
+          }
+          throw make401(config);
+        }
+        // '/api/y' is "already in flight": held open here until request A's refresh has
+        // fully landed and cleared refreshPromise, then rejects with the same stale-token 401.
+        await bGate;
+        throw make401(config);
+      }) as AxiosAdapter;
+
+      const bPromise = api.get('/api/y');
+      const aResult = await api.get('/api/x');
+
+      expect(aResult.data).toEqual({ ok: true });
+      expect(useAccessToken.getState().accessToken).toBe('rotated');
+
+      releaseB?.();
+      await expect(bPromise).rejects.toBeTruthy();
+
+      expect(replace).not.toHaveBeenCalled();
+      expect(useAccessToken.getState().expired).toBe(false);
+    }
+  );
 });

--- a/apps/client/app/contexts/WebsocketContext.test.ts
+++ b/apps/client/app/contexts/WebsocketContext.test.ts
@@ -252,10 +252,10 @@ describe('WebsocketProvider - reconnect recovery on a token change (no focus eve
   });
 
   // A tab that never blurs never sends the visibilitychange/focus event the pulse above
-  // relies on - a token refresh (from ANY path: probeIdentity, the 401 interceptor, this
-  // provider's own onReconnectStop probe) is the only signal such a tab can produce. This
-  // covers the FP-1 fix: once the reconnect budget is exhausted, a token change alone must
-  // still reset it.
+  // relies on - a token refresh (from ANY path: the exhausting attempt's own onClose probe,
+  // scheduleSessionRevalidation's timer, a reactive 401 refresh) is the only signal such a tab
+  // can produce. This covers the FP-1 fix: once the reconnect budget is exhausted, a token
+  // change alone must still reset it.
   it('pulses the reconnect budget when the access token changes after exhaustion, with zero focus events', async () => {
     const rendered = render(
       React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div'))
@@ -289,6 +289,39 @@ describe('WebsocketProvider - reconnect recovery on a token change (no focus eve
     h.capturedUrls = [];
 
     h.accessTokenState.accessToken = 'tok-2';
+    await act(async () => {
+      rendered.rerender(
+        React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div'))
+      );
+    });
+
+    expect(h.capturedUrls).not.toContain(null);
+  });
+
+  // The pulse hands the socket a fresh reconnect budget immediately, not only once it opens -
+  // otherwise a second trigger (another token change, or a refocus) landing anywhere in that
+  // still-connecting window would pulse AGAIN mid-backoff: the exact stale-timer/thundering-herd
+  // case the pulse's own guard comment warns against, and onOpen never fires to clear the guard
+  // if the reconnect fails again.
+  it('does not pulse a second time from a token change landing mid-backoff, before the pulsed attempt opens', async () => {
+    const rendered = render(
+      React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div'))
+    );
+    const opts = h.capturedOptions.current;
+    await act(async () => {
+      opts.onReconnectStop(20);
+    });
+
+    h.accessTokenState.accessToken = 'tok-2';
+    await act(async () => {
+      rendered.rerender(
+        React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div'))
+      );
+    });
+    h.capturedUrls = [];
+
+    // No onOpen in between - the pulsed attempt is still connecting when a second change lands.
+    h.accessTokenState.accessToken = 'tok-3';
     await act(async () => {
       rendered.rerender(
         React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div'))

--- a/apps/client/app/contexts/WebsocketContext.test.ts
+++ b/apps/client/app/contexts/WebsocketContext.test.ts
@@ -133,6 +133,22 @@ describe('WebsocketProvider - onClose auth-probe wiring', () => {
   });
 });
 
+describe('WebsocketProvider - reconnect budget option', () => {
+  beforeEach(() => {
+    h.capturedOptions.current = null as unknown as Record<string, (arg: unknown) => void>;
+    h.capturedUrls = [];
+    h.readyState = 1;
+    h.accessTokenState.accessToken = 'tok';
+    h.accessTokenState.mfaPending = false;
+    stubVisibility('visible');
+  });
+
+  it('passes reconnectAttempts explicitly, so onReconnectStop logs the real limit instead of undefined', () => {
+    render(React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div')));
+    expect((h.capturedOptions.current as unknown as { reconnectAttempts: number }).reconnectAttempts).toBe(20);
+  });
+});
+
 describe('WebsocketProvider - refocus reconnect pulse', () => {
   beforeEach(() => {
     h.probeIdentity.mockReset();

--- a/apps/client/app/contexts/WebsocketContext.test.ts
+++ b/apps/client/app/contexts/WebsocketContext.test.ts
@@ -238,3 +238,63 @@ describe('WebsocketProvider - refocus reconnect pulse', () => {
     expect(h.capturedUrls).not.toContain(null);
   });
 });
+
+describe('WebsocketProvider - reconnect recovery on a token change (no focus event needed)', () => {
+  beforeEach(() => {
+    h.probeIdentity.mockReset();
+    h.probeIdentity.mockResolvedValue(undefined);
+    h.capturedOptions.current = null as unknown as Record<string, (arg: unknown) => void>;
+    h.capturedUrls = [];
+    h.readyState = 1;
+    h.accessTokenState.accessToken = 'tok';
+    h.accessTokenState.mfaPending = false;
+    stubVisibility('visible');
+  });
+
+  // A tab that never blurs never sends the visibilitychange/focus event the pulse above
+  // relies on - a token refresh (from ANY path: probeIdentity, the 401 interceptor, this
+  // provider's own onReconnectStop probe) is the only signal such a tab can produce. This
+  // covers the FP-1 fix: once the reconnect budget is exhausted, a token change alone must
+  // still reset it.
+  it('pulses the reconnect budget when the access token changes after exhaustion, with zero focus events', async () => {
+    const rendered = render(
+      React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div'))
+    );
+    const opts = h.capturedOptions.current;
+    await act(async () => {
+      opts.onReconnectStop(20);
+    });
+    h.capturedUrls = [];
+
+    h.accessTokenState.accessToken = 'tok-2';
+    await act(async () => {
+      rendered.rerender(
+        React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div'))
+      );
+    });
+
+    // The pulse dips the url to null for one commit (resetting react-use-websocket's own
+    // reconnectCount) then straight back, carrying the fresh token in queryParams.
+    expect(h.capturedUrls).toContain(null);
+    expect(h.capturedUrls[h.capturedUrls.length - 1]).toBe('wss://example/ws');
+    expect((h.capturedOptions.current as unknown as { queryParams: { token: string } }).queryParams.token).toBe(
+      'tok-2'
+    );
+  });
+
+  it('does not pulse on a genuine token change while the budget is not exhausted', async () => {
+    const rendered = render(
+      React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div'))
+    );
+    h.capturedUrls = [];
+
+    h.accessTokenState.accessToken = 'tok-2';
+    await act(async () => {
+      rendered.rerender(
+        React.createElement(WebsocketProvider, { url: 'wss://example/ws' }, React.createElement('div'))
+      );
+    });
+
+    expect(h.capturedUrls).not.toContain(null);
+  });
+});

--- a/apps/client/app/contexts/WebsocketContext.tsx
+++ b/apps/client/app/contexts/WebsocketContext.tsx
@@ -131,6 +131,11 @@ export const WebsocketProvider = ({ children, url }: Props) => {
     // thundering herd after a deploy or network blip. Without jitter, 400 users reconnect
     // at the same instant and flood subscribe_query Lambdas simultaneously.
     reconnectInterval: i => 125 * (i + 1) ** 2 + Math.random() * 1000,
+    // Matches the library's own DEFAULT_RECONNECT_LIMIT. Set explicitly (rather than relying
+    // on the default) because the shared-listener close handler passes this raw option value
+    // to onReconnectStop below instead of its resolved default - leaving it unset means
+    // onReconnectStop always logs undefined instead of the real attempt count.
+    reconnectAttempts: 20,
     onOpen: () => {
       console.log('ws connected');
       openedThisAttemptRef.current = true;

--- a/apps/client/app/contexts/WebsocketContext.tsx
+++ b/apps/client/app/contexts/WebsocketContext.tsx
@@ -166,23 +166,13 @@ export const WebsocketProvider = ({ children, url }: Props) => {
     },
     onReconnectStop(numAttempts) {
       console.log('ws reconnect stopped after', numAttempts, 'attempts');
+      // No separate probe needed here: the fork calls onClose and onReconnectStop
+      // synchronously in the same close-event handler (see attach-shared-listeners.ts), so
+      // the FINAL failed attempt's own onClose above has already fired probeIdentity - a
+      // second call here would just hit probeIdentity's own in-flight guard and no-op. If
+      // that probe refreshes the token, the accessToken effect below turns it into a
+      // reconnect pulse with no focus event needed.
       reconnectExhaustedRef.current = true;
-
-      // Exhaustion itself is an auth signal for a focused tab: nothing else will probe (no
-      // refocus is coming if the tab never blurred), so treat "ran out of reconnect attempts"
-      // the same as a failed connect attempt. If the token really did expire, this refreshes
-      // it - which the accessToken effect below turns into a reconnect pulse, closing the loop
-      // with no polling and no dependency on a focus event ever firing.
-      if (
-        shouldProbeOnFailedWsConnect({
-          openedThisAttempt: false,
-          accessToken,
-          mfaPending: useAccessToken.getState().mfaPending,
-          pathname: window.location.pathname,
-        })
-      ) {
-        void probeIdentity(queryClient);
-      }
     },
 
     onMessage: event => {
@@ -266,6 +256,12 @@ export const WebsocketProvider = ({ children, url }: Props) => {
   // refresh) - see each effect's own comment for why a single trigger isn't enough.
   const pulseReconnect = useCallback(() => {
     if (!reconnectExhaustedRef.current) return;
+    // Clear it now, not on the next onOpen: the fresh budget this pulse grants means the
+    // socket is no longer "exhausted" the instant we hand it that budget, regardless of
+    // whether the resulting attempt succeeds. Without this, a second trigger (another token
+    // change, or a refocus) arriving before the pulsed attempt opens would pulse AGAIN
+    // mid-backoff - the exact stale-timer/thundering-herd case the comment above warns about.
+    reconnectExhaustedRef.current = false;
     setForceDisconnected(true);
   }, []);
 

--- a/apps/client/app/contexts/WebsocketContext.tsx
+++ b/apps/client/app/contexts/WebsocketContext.tsx
@@ -167,6 +167,22 @@ export const WebsocketProvider = ({ children, url }: Props) => {
     onReconnectStop(numAttempts) {
       console.log('ws reconnect stopped after', numAttempts, 'attempts');
       reconnectExhaustedRef.current = true;
+
+      // Exhaustion itself is an auth signal for a focused tab: nothing else will probe (no
+      // refocus is coming if the tab never blurred), so treat "ran out of reconnect attempts"
+      // the same as a failed connect attempt. If the token really did expire, this refreshes
+      // it - which the accessToken effect below turns into a reconnect pulse, closing the loop
+      // with no polling and no dependency on a focus event ever firing.
+      if (
+        shouldProbeOnFailedWsConnect({
+          openedThisAttempt: false,
+          accessToken,
+          mfaPending: useAccessToken.getState().mfaPending,
+          pathname: window.location.pathname,
+        })
+      ) {
+        void probeIdentity(queryClient);
+      }
     },
 
     onMessage: event => {
@@ -238,20 +254,25 @@ export const WebsocketProvider = ({ children, url }: Props) => {
     };
   }, []);
 
-  // On refocus, pulse forceDisconnected to force a fresh reconnect attempt with a reset
-  // backoff budget - but ONLY once reconnectExhaustedRef is set (onReconnectStop already
-  // fired, so there is no pending backoff timer left to cancel). Gating on readyState alone
-  // (e.g. "not OPEN") would also pulse mid-backoff: react-use-websocket's own
-  // reconnectInterval below deliberately staggers reconnects with jitter to avoid a
-  // thundering herd after an outage, and cancelling that on every refocus would defeat it -
-  // plus the library never clears its own pending reconnect timer on a url change, so a
-  // mid-backoff pulse leaves a second, stale reconnect attempt to fire later. Once genuinely
-  // exhausted there is no such timer left, so this has neither problem.
+  // Pulse forceDisconnected to force a fresh reconnect attempt with a reset backoff budget -
+  // but ONLY once reconnectExhaustedRef is set (onReconnectStop already fired, so there is no
+  // pending backoff timer left to cancel). Gating on readyState alone (e.g. "not OPEN") would
+  // also pulse mid-backoff: react-use-websocket's own reconnectInterval below deliberately
+  // staggers reconnects with jitter to avoid a thundering herd after an outage, and cancelling
+  // that on every trigger would defeat it - plus the library never clears its own pending
+  // reconnect timer on a url change, so a mid-backoff pulse leaves a second, stale reconnect
+  // attempt to fire later. Once genuinely exhausted there is no such timer left, so this has
+  // neither problem. Shared by both triggers below (refocus, and a post-exhaustion token
+  // refresh) - see each effect's own comment for why a single trigger isn't enough.
+  const pulseReconnect = useCallback(() => {
+    if (!reconnectExhaustedRef.current) return;
+    setForceDisconnected(true);
+  }, []);
+
   useEffect(() => {
     const handleVisibility = () => {
       if (document.visibilityState !== 'visible') return;
-      if (!reconnectExhaustedRef.current) return;
-      setForceDisconnected(true);
+      pulseReconnect();
     };
     document.addEventListener('visibilitychange', handleVisibility);
     window.addEventListener('focus', handleVisibility);
@@ -260,6 +281,21 @@ export const WebsocketProvider = ({ children, url }: Props) => {
       window.removeEventListener('focus', handleVisibility);
     };
   }, []);
+
+  // A token refresh alone changes the socket's queryParams (a new url -> a brand new
+  // WebSocket, per create-or-join.ts's per-url sharedWebSockets map) but never resets the
+  // library's own reconnectCount - so once the budget is exhausted, the fresh connection gets
+  // exactly one attempt and immediately re-exhausts, forever, with no focus event to save it.
+  // That's the focused-tab gap: nothing ever blurs, so the visibilitychange pulse above never
+  // fires. Treat a post-exhaustion token change as the second trigger for the same pulse.
+  // prevAccessTokenRef skips the mount's own token (nothing has exhausted yet at mount).
+  const prevAccessTokenRef = useRef(accessToken);
+  useEffect(() => {
+    const changed = prevAccessTokenRef.current !== accessToken;
+    prevAccessTokenRef.current = accessToken;
+    if (!changed) return;
+    pulseReconnect();
+  }, [accessToken, pulseReconnect]);
 
   // The other half of the pulse: flip back on the next commit so shouldConnect's dip to
   // false was only momentary - enough for react-use-websocket to see url turn null (see

--- a/apps/client/app/contexts/focusedTabSessionRecovery.test.tsx
+++ b/apps/client/app/contexts/focusedTabSessionRecovery.test.tsx
@@ -296,11 +296,10 @@ describe('focused-tab session recovery (#1691)', () => {
       closeAndScheduleReconnect();
     });
 
-    // Run out the full 20-attempt WS reconnect budget while the outage is active. Every probe
-    // attempt during this window 503s and does nothing (a 503 never reaches the interceptor's
-    // 401/refresh branch at all) - don't assert zero requests, assert the outcome. This also
-    // covers onReconnectStop's own exhaustion-triggered probe (FP-1): it fires but 503s too,
-    // since the outage is still active at the exact moment the budget runs out.
+    // Run out the full 20-attempt WS reconnect budget while the outage is active. Every failed
+    // attempt's own onClose fires a probe (including the 20th, exhausting one) and every one
+    // 503s and does nothing (a 503 never reaches the interceptor's 401/refresh branch at all) -
+    // don't assert zero requests, assert the outcome.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(400_000);
     });

--- a/apps/client/app/contexts/focusedTabSessionRecovery.test.tsx
+++ b/apps/client/app/contexts/focusedTabSessionRecovery.test.tsx
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AxiosError, type AxiosAdapter, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
+import { api, resetRefreshPromise, resetRedirectingGuard } from './ApiContext';
+import { useAccessToken } from '../hooks/useAccessToken';
+import { resetProbeGuardForTests, scheduleSessionRevalidation } from '../utils/sessionBootstrap';
+
+/**
+ * Reproduces issue #1691: a browser tab that stays visible/focused the whole time its access
+ * token expires never recovers (repeated 401s, WS reconnect exhausts and gives up), only a
+ * reload fixes it. Real ApiContext interceptors, real sessionBootstrap.probeIdentity, and a
+ * real QueryClient are exercised end-to-end; only 'react-use-websocket' itself is faked, with a
+ * stateful harness that transcribes the vendored fork's shared-listener reconnect scheduling
+ * (see node_modules/.pnpm/react-use-websocket@.../src/lib/attach-shared-listeners.ts and
+ * constants.ts - this fork's SHARED listener path is what's live here, since share:true).
+ */
+
+// vitest.setup.ts globally mocks this module for component tests that don't care about the
+// real WS wiring - unmock it here so this file tests the real provider end-to-end.
+vi.unmock('@/app/contexts/WebsocketContext');
+
+// clearClientCaches touches localStorage/IndexedDB; irrelevant to the auth/WS logic under
+// test, and none of these scenarios should reach the unrecoverable-401 teardown path anyway -
+// stubbed defensively so a mispredicted path doesn't hang on a real IndexedDB delete.
+vi.mock('@client/app/utils/clearClientCaches', () => ({ clearClientCaches: vi.fn().mockResolvedValue(undefined) }));
+
+interface CapturedWsOptions {
+  onOpen?: (event: unknown) => void;
+  onClose?: (event: { code: number; reason: string }) => void;
+  onReconnectStop?: (numAttempts: number) => void;
+  reconnectInterval?: (attempt: number) => number;
+  reconnectAttempts?: number;
+}
+
+// Shared, hoisted so the vi.mock factory below can reference it (mirrors WebsocketContext.test.ts).
+const h = vi.hoisted(() => ({
+  urls: [] as (string | null)[],
+  lastNonNullUrl: null as string | null,
+  connectAttempts: 0,
+  reconnectCount: 0,
+  reconnectStopCalls: 0,
+  lastOptions: null as unknown as CapturedWsOptions,
+}));
+
+vi.mock('react-use-websocket', () => ({
+  ReadyState: { UNINSTANTIATED: -1, CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 },
+  useBaseWebsocket: (url: string | null, options: CapturedWsOptions) => {
+    // Mirrors the real library's optionsCache.current = options happening on every render.
+    h.lastOptions = options;
+    h.urls.push(url);
+    if (url === null) {
+      // Mirrors use-websocket.ts's url===null branch resetting reconnectCount.current - the
+      // lever WebsocketContext.tsx's refocus pulse relies on to get a fresh backoff budget.
+      h.reconnectCount = 0;
+    } else if (url !== h.lastNonNullUrl) {
+      // A new url key means a brand new WebSocket per create-or-join.ts's
+      // sharedWebSockets[url] === undefined check.
+      h.lastNonNullUrl = url;
+      h.connectAttempts += 1;
+    }
+    return { sendJsonMessage: vi.fn(), readyState: 1, lastJsonMessage: null };
+  },
+}));
+
+import { WebsocketProvider } from './WebsocketContext';
+
+/**
+ * Faithful transcription of attach-shared-listeners.ts's bindCloseHandler reconnect
+ * scheduling: while reconnectCount is under the budget, schedule the next attempt via a real
+ * setTimeout (driven by vi.advanceTimersByTimeAsync) at options.reconnectInterval(reconnectCount);
+ * on firing, bump the count and re-invoke the app's onClose (simulating that reconnect attempt's
+ * own failed open), then recurse. Once the budget is exhausted, fire onReconnectStop once.
+ *
+ * Deliberately does NOT wrap each step in its own `act()` - nesting `act()` inside a callback
+ * driven by vi.advanceTimersByTimeAsync fought the fake-timer flush and silently truncated the
+ * recursion after ~14 attempts with no error. Callers wrap the whole advance in one outer
+ * `act()` instead (see the tests below), which flushes every nested state update correctly.
+ */
+function scheduleReconnect(): void {
+  const limit = h.lastOptions?.reconnectAttempts ?? 20;
+  if (h.reconnectCount >= limit) {
+    h.reconnectStopCalls += 1;
+    h.lastOptions?.onReconnectStop?.(limit);
+    return;
+  }
+  const delay = h.lastOptions!.reconnectInterval!(h.reconnectCount);
+  setTimeout(() => {
+    h.reconnectCount += 1;
+    h.lastOptions?.onClose?.({ code: 1006, reason: '' });
+    scheduleReconnect();
+  }, delay);
+}
+
+/**
+ * Simulates one native WebSocket close event: the app's onClose callback fires, then - in the
+ * same handler, per the fork's bindCloseHandler - the library schedules its own reconnect.
+ */
+function closeAndScheduleReconnect(): void {
+  h.lastOptions?.onClose?.({ code: 1006, reason: '' });
+  scheduleReconnect();
+}
+
+const ok = (config: InternalAxiosRequestConfig, data: unknown): AxiosResponse =>
+  ({ data, status: 200, statusText: 'OK', headers: {}, config }) as AxiosResponse;
+
+const make401 = (config: InternalAxiosRequestConfig): AxiosError =>
+  new AxiosError('Unauthorized', 'ERR_BAD_REQUEST', config, {}, {
+    status: 401,
+    statusText: 'Unauthorized',
+    data: { error: 'Unauthorized' },
+    headers: {},
+    config,
+  } as AxiosResponse);
+
+// A 503 during a correlated outage - transient, not a revocation, so it must never resolve
+// through the 401/refresh branch at all.
+const makeStatus = (config: InternalAxiosRequestConfig, status: number): AxiosError =>
+  new AxiosError(`Error ${status}`, 'ERR_BAD_RESPONSE', config, {}, {
+    status,
+    statusText: 'Error',
+    data: {},
+    headers: {},
+    config,
+  } as AxiosResponse);
+
+// Scripted fake server keyed on TOKEN IDENTITY (not clock/JWT-exp claims) so it stays
+// deterministic under fake timers.
+let serverToken = 'tok-1';
+let outage = false;
+let refreshCalls = 0;
+
+const fakeAdapter = ((config: InternalAxiosRequestConfig) => {
+  if (outage) {
+    return Promise.reject(makeStatus(config, 503));
+  }
+  if (config.url === '/api/auth/refreshToken') {
+    // Refresh rides the HttpOnly cookie, not the bearer header - unconditional success.
+    refreshCalls += 1;
+    serverToken = 'tok-2';
+    return Promise.resolve(ok(config, { accessToken: 'tok-2' }));
+  }
+  const authHeader = config.headers?.Authorization as string | undefined;
+  if (authHeader !== `Bearer ${serverToken}`) {
+    return Promise.reject(make401(config));
+  }
+  if (config.url === '/api/identify') {
+    return Promise.resolve(ok(config, { user: { id: 'u1', preferences: {} }, accessToken: serverToken }));
+  }
+  return Promise.resolve(ok(config, { ok: true }));
+}) as AxiosAdapter;
+
+const stubVisibility = (state: DocumentVisibilityState) =>
+  Object.defineProperty(document, 'visibilityState', { configurable: true, value: state });
+
+// Mounts the WS provider AND arms the same expiry-driven revalidation timer providers.tsx
+// wires at the app root (scheduleSessionRevalidation) - the two fixes for #1691 are
+// independent (FP-1 in WebsocketContext.tsx, FP-2 here) and this suite proves the COMBINED,
+// as-shipped system recovers, not either half in isolation. Returns the disposer so each test
+// can tear its timer down and not leak into the next.
+function mount(queryClient: QueryClient): () => void {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <WebsocketProvider url="wss://example/ws">
+        <div />
+      </WebsocketProvider>
+    </QueryClientProvider>
+  );
+  return scheduleSessionRevalidation(queryClient);
+}
+
+describe('focused-tab session recovery (#1691)', () => {
+  const realLocation = window.location;
+  let realAdapter: AxiosAdapter | undefined;
+  let queryClient: QueryClient;
+  let focusProbe: ReturnType<typeof vi.fn>;
+  let disposeRevalidation: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    h.urls = [];
+    h.lastNonNullUrl = null;
+    h.connectAttempts = 0;
+    h.reconnectCount = 0;
+    h.reconnectStopCalls = 0;
+    h.lastOptions = null as unknown as CapturedWsOptions;
+
+    resetRefreshPromise();
+    resetRedirectingGuard();
+    resetProbeGuardForTests();
+
+    serverToken = 'tok-1';
+    outage = false;
+    refreshCalls = 0;
+
+    realAdapter = api.defaults.adapter as AxiosAdapter | undefined;
+    api.defaults.adapter = fakeAdapter;
+
+    useAccessToken.setState({ accessToken: 'tok-1', expired: false, expiredReason: null, mfaPending: false });
+
+    stubVisibility('visible');
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        pathname: '/app',
+        search: '',
+        hash: '',
+        href: 'http://localhost/app',
+        origin: 'http://localhost',
+        replace: vi.fn(),
+      },
+    });
+
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, refetchOnWindowFocus: false, refetchOnReconnect: false },
+        mutations: { retry: false },
+      },
+    });
+
+    focusProbe = vi.fn();
+    document.addEventListener('visibilitychange', focusProbe);
+    window.addEventListener('focus', focusProbe);
+  });
+
+  afterEach(() => {
+    disposeRevalidation?.();
+    document.removeEventListener('visibilitychange', focusProbe);
+    window.removeEventListener('focus', focusProbe);
+    api.defaults.adapter = realAdapter;
+    Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('an established connection dropping is not treated as an auth signal', async () => {
+    disposeRevalidation = mount(queryClient);
+    await act(async () => {
+      h.lastOptions?.onOpen?.({});
+    });
+
+    // Only the established-drop's own onClose has run - do not advance timers, so no
+    // subsequent reconnect attempt has fired yet either.
+    await act(async () => {
+      closeAndScheduleReconnect();
+    });
+
+    expect(refreshCalls).toBe(0);
+    expect(focusProbe).not.toHaveBeenCalled();
+  });
+
+  it('the first failed reconnect attempt self-heals with zero focus events', async () => {
+    disposeRevalidation = mount(queryClient);
+    await act(async () => {
+      h.lastOptions?.onOpen?.({});
+    });
+
+    // Server-side rotation while the store still holds the old token - the real-world case
+    // this self-heal must cover (a token that expired while the tab sat focused).
+    serverToken = 'rotated';
+
+    // Established drop: openedThisAttempt was true, so no probe here (see Test 1).
+    await act(async () => {
+      closeAndScheduleReconnect();
+    });
+
+    // Let the first scheduled reconnect attempt (125ms) fire. That attempt's own close has
+    // openedThisAttempt=false, so WebsocketContext's real onClose fires probeIdentity, which
+    // 401s, refreshes, and retries.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(refreshCalls).toBe(1);
+    expect(useAccessToken.getState().accessToken).toBe('tok-2');
+    expect(focusProbe).not.toHaveBeenCalled();
+  });
+
+  it('budget exhausted during a correlated outage still recovers on its own, with zero focus events', async () => {
+    disposeRevalidation = mount(queryClient);
+    await act(async () => {
+      h.lastOptions?.onOpen?.({});
+    });
+
+    // The same failure that killed the WS also breaks the API - the realistic
+    // deploy/network-blip correlation this repro targets. This also correlates with
+    // scheduleSessionRevalidation's OWN periodic probe (armed at mount, ~300s fallback delay
+    // since these test tokens carry no real exp claim) - it will 503 too while this holds.
+    serverToken = 'rotated';
+    outage = true;
+
+    await act(async () => {
+      closeAndScheduleReconnect();
+    });
+
+    // Run out the full 20-attempt WS reconnect budget while the outage is active. Every probe
+    // attempt during this window 503s and does nothing (a 503 never reaches the interceptor's
+    // 401/refresh branch at all) - don't assert zero requests, assert the outcome. This also
+    // covers onReconnectStop's own exhaustion-triggered probe (FP-1): it fires but 503s too,
+    // since the outage is still active at the exact moment the budget runs out.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400_000);
+    });
+    expect(useAccessToken.getState().accessToken).toBe('tok-1');
+    expect(h.reconnectStopCalls).toBe(1);
+
+    // Service recovers. The WS reconnect budget is already exhausted and nothing else in
+    // WebsocketContext.tsx alone will retry - recovery here depends entirely on
+    // scheduleSessionRevalidation's independent, self-re-arming timer (FP-2), which keeps
+    // re-arming after every attempt (success or failure) regardless of what the WS is doing.
+    outage = false;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    });
+
+    // The fix: scheduleSessionRevalidation's next scheduled probe (well within this hour) lands
+    // after the outage clears, refreshes the token, and WebsocketContext's accessToken-change
+    // effect (the other half of FP-1) then pulses the WS back to life - all with zero focus or
+    // visibilitychange events anywhere in this test.
+    expect(refreshCalls).toBe(1);
+    expect(useAccessToken.getState().accessToken).toBe('tok-2');
+    expect(h.urls).toContain(null);
+    expect(focusProbe).not.toHaveBeenCalled();
+  });
+
+  it('onReconnectStop is invoked with the real limit, not undefined', async () => {
+    disposeRevalidation = mount(queryClient);
+    await act(async () => {
+      h.lastOptions?.onOpen?.({});
+    });
+
+    await act(async () => {
+      closeAndScheduleReconnect();
+      await vi.advanceTimersByTimeAsync(400_000);
+    });
+
+    // Pins the already-landed reconnectAttempts:20 fix from the WS harness's own perspective.
+    expect(h.reconnectStopCalls).toBe(1);
+    expect(focusProbe).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/app/providers.tsx
+++ b/apps/client/app/providers.tsx
@@ -23,7 +23,7 @@ import { CookieConsentBanner } from '@client/app/components/CookieConsentBanner'
 import { TranslationProvider } from '@client/app/contexts/TranslationProvider';
 import { QuestPreparationOverlay } from '@client/app/components/QuestPreparationOverlay';
 import { runLocalStorageCleanup } from '@client/app/utils/localStorageCleanup';
-import { revalidateSessionOnFocus } from '@client/app/utils/sessionBootstrap';
+import { revalidateSessionOnFocus, scheduleSessionRevalidation } from '@client/app/utils/sessionBootstrap';
 
 // Lazy load DevTools only when needed (development only)
 const ReactQueryDevtools = lazy(() =>
@@ -167,6 +167,13 @@ export function ClientProviders({ children }: { children: ReactNode }) {
       window.removeEventListener('focus', handleVisibility);
     };
   }, []);
+
+  // The focus/visibilitychange listener above only ever fires for a tab that blurs and comes
+  // back - a tab that stays focused the whole time its token expires never sends either event,
+  // and an already-established WebSocket carries no further auth check once open. This timer
+  // is the belt to that listener's braces: it probes near the token's actual exp claim
+  // regardless of focus, so recovery doesn't depend on the tab ever having lost focus at all.
+  useEffect(() => scheduleSessionRevalidation(queryClient), []);
 
   return (
     <CoreProviders>

--- a/apps/client/app/utils/sessionBootstrap.test.ts
+++ b/apps/client/app/utils/sessionBootstrap.test.ts
@@ -193,9 +193,9 @@ describe('nextRevalidationDelayMs - pure delay predicate for scheduleSessionReva
     expect(nextRevalidationDelayMs(null, nowMs)).toBeNull();
   });
 
-  it('schedules near the exp claim, minus the same buffer shouldRevalidateOnFocus uses', () => {
+  it('schedules just AFTER the exp claim, not before - the server only rotates a token once it has actually expired', () => {
     const token = makeToken({ exp: Math.floor(nowMs / 1000) + 600 }); // 10 minutes out
-    expect(nextRevalidationDelayMs(token, nowMs)).toBe(600_000 - 30_000);
+    expect(nextRevalidationDelayMs(token, nowMs)).toBe(600_000 + 2_000);
   });
 
   it('floors at a minimum delay for an already-expired token, instead of a near-zero hot loop', () => {
@@ -219,18 +219,37 @@ describe('scheduleSessionRevalidation - expiry-driven timer for a tab that never
     vi.useRealTimers();
   });
 
-  it('probes once the token nears its exp claim, with no focus event', async () => {
+  it('probes shortly AFTER the token exp claim, not before, with no focus event', async () => {
     const nowMs = Date.now();
-    const token = makeToken({ exp: Math.floor(nowMs / 1000) + 60 }); // 60s out; buffer is 30s
+    const token = makeToken({ exp: Math.floor(nowMs / 1000) + 60 }); // 60s out; margin is 2s past
     useAccessToken.setState({ accessToken: token, expired: false, expiredReason: null, mfaPending: false });
     const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: { user: {}, accessToken: token } });
 
     const dispose = scheduleSessionRevalidation(makeQueryClient(vi.fn()));
 
-    await vi.advanceTimersByTimeAsync(20_000);
+    await vi.advanceTimersByTimeAsync(59_000);
     expect(apiGet).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(apiGet).toHaveBeenCalledWith('/api/identify', { timeout: 10000 });
+
+    dispose();
+  });
+
+  it('skips the probe while mfaPending, expired, or on a public path, but still re-arms', async () => {
+    const nowMs = Date.now();
+    const token = makeToken({ exp: Math.floor(nowMs / 1000) + 60 });
+    useAccessToken.setState({ accessToken: token, expired: false, expiredReason: null, mfaPending: true });
+    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: { user: {}, accessToken: token } });
+
+    const dispose = scheduleSessionRevalidation(makeQueryClient(vi.fn()));
+
+    await vi.advanceTimersByTimeAsync(62_000);
+    expect(apiGet).not.toHaveBeenCalled();
+
+    // mfaPending clears; the re-armed timer (same token, same delay computation) picks it up.
+    useAccessToken.setState({ mfaPending: false });
+    await vi.advanceTimersByTimeAsync(62_000);
     expect(apiGet).toHaveBeenCalledWith('/api/identify', { timeout: 10000 });
 
     dispose();
@@ -264,7 +283,7 @@ describe('scheduleSessionRevalidation - expiry-driven timer for a tab that never
     const soonToken = makeToken({ exp: Math.floor(nowMs / 1000) + 60 });
     useAccessToken.setState({ accessToken: soonToken });
 
-    await vi.advanceTimersByTimeAsync(35_000);
+    await vi.advanceTimersByTimeAsync(62_000);
     expect(apiGet).toHaveBeenCalledWith('/api/identify', { timeout: 10000 });
 
     dispose();

--- a/apps/client/app/utils/sessionBootstrap.test.ts
+++ b/apps/client/app/utils/sessionBootstrap.test.ts
@@ -7,6 +7,8 @@ import {
   revalidateSessionOnFocus,
   probeIdentity,
   resetProbeGuardForTests,
+  nextRevalidationDelayMs,
+  scheduleSessionRevalidation,
 } from './sessionBootstrap';
 
 /** A macrotask flush - long enough for a settled promise's .catch().finally() chain to run. */
@@ -180,6 +182,103 @@ describe('revalidateSessionOnFocus - guard gating the shared probe', () => {
     revalidateSessionOnFocus(makeQueryClient(setQueryData));
     await flush();
 
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('nextRevalidationDelayMs - pure delay predicate for scheduleSessionRevalidation', () => {
+  const nowMs = 1_700_000_000_000;
+
+  it('returns null when there is no token to schedule against', () => {
+    expect(nextRevalidationDelayMs(null, nowMs)).toBeNull();
+  });
+
+  it('schedules near the exp claim, minus the same buffer shouldRevalidateOnFocus uses', () => {
+    const token = makeToken({ exp: Math.floor(nowMs / 1000) + 600 }); // 10 minutes out
+    expect(nextRevalidationDelayMs(token, nowMs)).toBe(600_000 - 30_000);
+  });
+
+  it('floors at a minimum delay for an already-expired token, instead of a near-zero hot loop', () => {
+    const token = makeToken({ exp: Math.floor(nowMs / 1000) - 60 });
+    expect(nextRevalidationDelayMs(token, nowMs)).toBe(5_000);
+  });
+
+  it('falls back to a fixed interval when the exp claim is unreadable (malformed/legacy token)', () => {
+    expect(nextRevalidationDelayMs('not-a-jwt', nowMs)).toBe(5 * 60_000);
+  });
+});
+
+describe('scheduleSessionRevalidation - expiry-driven timer for a tab that never blurs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetProbeGuardForTests();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('probes once the token nears its exp claim, with no focus event', async () => {
+    const nowMs = Date.now();
+    const token = makeToken({ exp: Math.floor(nowMs / 1000) + 60 }); // 60s out; buffer is 30s
+    useAccessToken.setState({ accessToken: token, expired: false, expiredReason: null, mfaPending: false });
+    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: { user: {}, accessToken: token } });
+
+    const dispose = scheduleSessionRevalidation(makeQueryClient(vi.fn()));
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(apiGet).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(apiGet).toHaveBeenCalledWith('/api/identify', { timeout: 10000 });
+
+    dispose();
+  });
+
+  it('re-arms after a failed probe instead of permanently stopping', async () => {
+    useAccessToken.setState({ accessToken: 'not-a-jwt', expired: false, expiredReason: null, mfaPending: false });
+    const apiGet = vi.spyOn(api, 'get').mockRejectedValue(new Error('Network Error'));
+
+    const dispose = scheduleSessionRevalidation(makeQueryClient(vi.fn()));
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000); // unreadable-exp fallback interval; probe fails
+    expect(apiGet).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000); // re-armed rather than dead after the failure
+    expect(apiGet).toHaveBeenCalledTimes(2);
+
+    dispose();
+  });
+
+  it('re-arms immediately against a token change from another path, not the stale timer', async () => {
+    const nowMs = Date.now();
+    const farToken = makeToken({ exp: Math.floor(nowMs / 1000) + 60 * 30 }); // 30 minutes out
+    useAccessToken.setState({ accessToken: farToken, expired: false, expiredReason: null, mfaPending: false });
+    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: { user: {}, accessToken: 'x' } });
+
+    const dispose = scheduleSessionRevalidation(makeQueryClient(vi.fn()));
+
+    // A reactive 401 refresh (or any other path) lands a fresh token with a much sooner exp -
+    // the stale 30-minute timer must not be the one still running.
+    const soonToken = makeToken({ exp: Math.floor(nowMs / 1000) + 60 });
+    useAccessToken.setState({ accessToken: soonToken });
+
+    await vi.advanceTimersByTimeAsync(35_000);
+    expect(apiGet).toHaveBeenCalledWith('/api/identify', { timeout: 10000 });
+
+    dispose();
+  });
+
+  it('disposes cleanly: no probe fires after the returned disposer is called', async () => {
+    const nowMs = Date.now();
+    const token = makeToken({ exp: Math.floor(nowMs / 1000) + 60 });
+    useAccessToken.setState({ accessToken: token, expired: false, expiredReason: null, mfaPending: false });
+    const apiGet = vi.spyOn(api, 'get').mockResolvedValue({ data: { user: {}, accessToken: token } });
+
+    scheduleSessionRevalidation(makeQueryClient(vi.fn()))();
+
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(apiGet).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/app/utils/sessionBootstrap.test.ts
+++ b/apps/client/app/utils/sessionBootstrap.test.ts
@@ -90,7 +90,7 @@ describe('probeIdentity - shared single-flight liveness probe', () => {
 
     await probeIdentity(makeQueryClient(setQueryData));
 
-    expect(apiGet).toHaveBeenCalledWith('/api/identify');
+    expect(apiGet).toHaveBeenCalledWith('/api/identify', { timeout: 10000 });
     expect(setQueryData).toHaveBeenCalledWith(['identify'], identify);
   });
 
@@ -100,8 +100,22 @@ describe('probeIdentity - shared single-flight liveness probe', () => {
 
     await probeIdentity(makeQueryClient(setQueryData));
 
-    expect(apiGet).toHaveBeenCalledWith('/api/identify');
+    expect(apiGet).toHaveBeenCalledWith('/api/identify', { timeout: 10000 });
     expect(setQueryData).not.toHaveBeenCalled();
+  });
+
+  it('bounds the request with a timeout so a hanging server cannot wedge the single-flight guard', async () => {
+    const timeoutError = Object.assign(new Error('timeout of 10000ms exceeded'), { code: 'ECONNABORTED' });
+    const apiGet = vi.spyOn(api, 'get');
+    apiGet.mockRejectedValueOnce(timeoutError);
+    apiGet.mockResolvedValueOnce({ data: { user: {}, accessToken: 'x' } });
+    const client = makeQueryClient(vi.fn());
+
+    await probeIdentity(client);
+    await probeIdentity(client);
+
+    expect(apiGet).toHaveBeenCalledTimes(2);
+    expect(apiGet).toHaveBeenNthCalledWith(1, '/api/identify', { timeout: 10000 });
   });
 
   it('collapses a second call that lands while the first probe is still in flight', async () => {
@@ -155,7 +169,7 @@ describe('revalidateSessionOnFocus - guard gating the shared probe', () => {
     revalidateSessionOnFocus(makeQueryClient(setQueryData));
     await flush();
 
-    expect(apiGet).toHaveBeenCalledWith('/api/identify');
+    expect(apiGet).toHaveBeenCalledWith('/api/identify', { timeout: 10000 });
   });
 
   it('does not probe when the guard fails (e.g. mfaPending)', async () => {

--- a/apps/client/app/utils/sessionBootstrap.ts
+++ b/apps/client/app/utils/sessionBootstrap.ts
@@ -206,27 +206,39 @@ const MIN_REVALIDATE_DELAY_MS = 5_000;
  *  just as a bounded interval instead of an unconditional probe. */
 const UNREADABLE_EXP_FALLBACK_MS = 5 * 60_000;
 
+/** Small positive margin PAST the exp claim, not a pre-expiry buffer like
+ *  REVALIDATE_EXPIRY_BUFFER_MS above. The server only rotates the token once it has actually
+ *  expired (pages/api/identify.ts's own refresh branch), and the standard JWT auth middleware
+ *  already rejects an expired token before that - so a probe fired BEFORE the deadline just
+ *  gets the unchanged token back and, since the delay floors at MIN_REVALIDATE_DELAY_MS as
+ *  expiry approaches, would otherwise poll every few seconds for nothing until the deadline
+ *  actually arrives. This margin only exists to tolerate clock skew between this tab and the
+ *  server, not to refresh early. */
+const POST_EXPIRY_PROBE_MARGIN_MS = 2_000;
+
 /**
  * Pure: how long until the current access token is worth a liveness probe. `null` when there
- * is no token to schedule against. Mirrors shouldRevalidateOnFocus's exp-claim buffer, but as
- * a delay to arm a timer with rather than a yes/no gate for an event that already happened.
+ * is no token to schedule against. Deliberately targets just AFTER the exp claim (see
+ * POST_EXPIRY_PROBE_MARGIN_MS) rather than shouldRevalidateOnFocus's pre-expiry buffer above -
+ * that buffer suits a one-shot event-triggered check; a self-re-arming timer has no such
+ * latency to hide and firing early only wastes round trips.
  */
 export function nextRevalidationDelayMs(token: string | null, nowMs: number = Date.now()): number | null {
   if (!token) return null;
   const expMs = decodeTokenExpiryMs(token);
   if (expMs === null) return UNREADABLE_EXP_FALLBACK_MS;
-  return Math.max(MIN_REVALIDATE_DELAY_MS, expMs - REVALIDATE_EXPIRY_BUFFER_MS - nowMs);
+  return Math.max(MIN_REVALIDATE_DELAY_MS, expMs - nowMs + POST_EXPIRY_PROBE_MARGIN_MS);
 }
 
 /**
  * Self-re-arming timer that keeps a focused tab's session fresh even when nothing else ever
  * probes: revalidateSessionOnFocus (above) only fires from a focus/visibilitychange event,
  * which an always-visible tab never sends, and an established WebSocket carries no further
- * auth check once open. Fires probeIdentity near the token's exp claim, then re-arms against
- * whatever the current token is afterward - regardless of whether that probe changed it, so a
- * single failed round trip can't permanently stop the loop. A token change from any other path
- * (a reactive 401 refresh, logout) also re-arms immediately rather than waiting for the stale
- * timer. Returns a disposer; call once per app lifetime (see providers.tsx).
+ * auth check once open. Fires probeIdentity shortly after the token's exp claim, then re-arms
+ * against whatever the current token is afterward - regardless of whether that probe changed
+ * it, so a single failed round trip can't permanently stop the loop. A token change from any
+ * other path (a reactive 401 refresh, logout) also re-arms immediately rather than waiting for
+ * the stale timer. Returns a disposer; call once per app lifetime (see providers.tsx).
  */
 export function scheduleSessionRevalidation(queryClient: QueryClient): () => void {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -236,7 +248,17 @@ export function scheduleSessionRevalidation(queryClient: QueryClient): () => voi
     const delay = nextRevalidationDelayMs(useAccessToken.getState().accessToken);
     if (delay === null) return;
     timer = setTimeout(() => {
-      void probeIdentity(queryClient).then(arm);
+      const { accessToken, mfaPending, expired } = useAccessToken.getState();
+      // Mirrors shouldRevalidateOnFocus's non-visibility gates: an mfaPending or already-torn-
+      // down session has nothing to revalidate, and a public-path tab (e.g. sitting on /login)
+      // has no session to keep warm. Skip the probe but still re-arm - the delay recomputes
+      // against whatever the token is by the time this next fires, so a session that later
+      // clears mfaPending (or navigates off a public path) picks back up on its own.
+      if (accessToken && !mfaPending && !expired && !isPublicPath(window.location.pathname)) {
+        void probeIdentity(queryClient).then(arm);
+      } else {
+        arm();
+      }
     }, delay);
   };
 

--- a/apps/client/app/utils/sessionBootstrap.ts
+++ b/apps/client/app/utils/sessionBootstrap.ts
@@ -155,15 +155,20 @@ interface IdentifyResponse {
 export function probeIdentity(queryClient: QueryClient): Promise<void> {
   if (probeInFlight) return Promise.resolve();
   probeInFlight = true;
-  return api
-    .get<IdentifyResponse>('/api/identify')
-    .then(response => {
-      queryClient.setQueryData(['identify'], response.data);
-    })
-    .catch(() => {})
-    .finally(() => {
-      probeInFlight = false;
-    });
+  return (
+    api
+      // Bounded like the interceptor's own refresh call (ApiContext.tsx): without this, a
+      // hanging server leaves probeInFlight stuck true forever, blocking every future probe
+      // from both the WS close-probe and revalidateSessionOnFocus below.
+      .get<IdentifyResponse>('/api/identify', { timeout: 10000 })
+      .then(response => {
+        queryClient.setQueryData(['identify'], response.data);
+      })
+      .catch(() => {})
+      .finally(() => {
+        probeInFlight = false;
+      })
+  );
 }
 
 /**

--- a/apps/client/app/utils/sessionBootstrap.ts
+++ b/apps/client/app/utils/sessionBootstrap.ts
@@ -196,3 +196,58 @@ export function revalidateSessionOnFocus(queryClient: QueryClient): void {
   }
   void probeIdentity(queryClient);
 }
+
+/** Floor on the delay below so an already-expired token can't schedule a near-zero-delay,
+ *  tight polling loop if a probe is slow to land or fails without changing the token. */
+const MIN_REVALIDATE_DELAY_MS = 5_000;
+
+/** Fallback polling interval when the token's exp claim is unreadable (malformed/legacy) -
+ *  matches the fail-safe direction of shouldRevalidateOnFocus's own exp-claim handling above,
+ *  just as a bounded interval instead of an unconditional probe. */
+const UNREADABLE_EXP_FALLBACK_MS = 5 * 60_000;
+
+/**
+ * Pure: how long until the current access token is worth a liveness probe. `null` when there
+ * is no token to schedule against. Mirrors shouldRevalidateOnFocus's exp-claim buffer, but as
+ * a delay to arm a timer with rather than a yes/no gate for an event that already happened.
+ */
+export function nextRevalidationDelayMs(token: string | null, nowMs: number = Date.now()): number | null {
+  if (!token) return null;
+  const expMs = decodeTokenExpiryMs(token);
+  if (expMs === null) return UNREADABLE_EXP_FALLBACK_MS;
+  return Math.max(MIN_REVALIDATE_DELAY_MS, expMs - REVALIDATE_EXPIRY_BUFFER_MS - nowMs);
+}
+
+/**
+ * Self-re-arming timer that keeps a focused tab's session fresh even when nothing else ever
+ * probes: revalidateSessionOnFocus (above) only fires from a focus/visibilitychange event,
+ * which an always-visible tab never sends, and an established WebSocket carries no further
+ * auth check once open. Fires probeIdentity near the token's exp claim, then re-arms against
+ * whatever the current token is afterward - regardless of whether that probe changed it, so a
+ * single failed round trip can't permanently stop the loop. A token change from any other path
+ * (a reactive 401 refresh, logout) also re-arms immediately rather than waiting for the stale
+ * timer. Returns a disposer; call once per app lifetime (see providers.tsx).
+ */
+export function scheduleSessionRevalidation(queryClient: QueryClient): () => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const arm = () => {
+    if (timer !== undefined) clearTimeout(timer);
+    const delay = nextRevalidationDelayMs(useAccessToken.getState().accessToken);
+    if (delay === null) return;
+    timer = setTimeout(() => {
+      void probeIdentity(queryClient).then(arm);
+    }, delay);
+  };
+
+  arm();
+  const unsubscribe = useAccessToken.subscribe((state, prevState) => {
+    if (state.accessToken === prevState.accessToken) return;
+    arm();
+  });
+
+  return () => {
+    if (timer !== undefined) clearTimeout(timer);
+    unsubscribe();
+  };
+}


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1495" height="812" alt="live-preview-recovery-ui" src="https://github.com/user-attachments/assets/eb99da5f-ee83-4d7d-a29c-bdc251dc6bea" />

*Live PR-preview demo: a real request's Authorization header was corrupted to force a genuine 401 from the deployed server. The app recovered on its own (real refresh + retry, under 800ms) with the Help Center panel staying open throughout - no page reload, no focus/visibilitychange event.*

## Description

A browser tab that stayed visible the whole time its access token expired never recovered: repeated 401s, and the WebSocket's reconnect budget gave up for good, requiring a manual reload. The only thing that ever reset that budget was a focus/visibilitychange event - which a tab that never blurs never sends.

Fixes two independent gaps: the WebSocket now also resets its reconnect budget on a token change (not just on refocus), and a new self-re-arming timer probes the session near the token's own expiry regardless of the WebSocket's state, so recovery no longer depends on the socket ever dropping at all.

Closes #1691

## Changes

- `WebsocketContext.tsx`: pass `reconnectAttempts` explicitly (fixes an `onReconnectStop` logging bug); reset the reconnect budget on an access-token change, not only on refocus
- `sessionBootstrap.ts`: bound the identify liveness probe with a request timeout; add `scheduleSessionRevalidation`, a self-re-arming timer that probes near a token's expiry independent of the WebSocket
- `providers.tsx`: wire the new timer in alongside the existing focus-triggered revalidation
- New end-to-end test (`focusedTabSessionRecovery.test.tsx`) reproducing the gap deterministically, plus sibling coverage in the 401 interceptor

## Guide for Testers

This is proven by an automated, deterministic test suite rather than manual browser steps (no preview environment needed):

1. From the repo root: `pnpm --filter @bike4mind/client test focusedTabSessionRecovery.test.tsx WebsocketContext.test.ts ApiContext.test.tsx sessionBootstrap.test.ts`
2. Expected result: all test files pass. One test in `ApiContext.test.tsx` is intentionally marked `it.fails` (see Additional Information) - that is expected, not a failure.
3. `focusedTabSessionRecovery.test.tsx` specifically simulates a tab that never fires a `visibilitychange`/`focus` event while its token expires (including the harder case of a WebSocket drop correlated with an API outage) and asserts the session recovers on its own.

## Additional Information

Review surfaced a separate, pre-existing bug (a near-simultaneous token refresh race can spuriously log out a valid session) - out of scope here since it's unrelated to the stranded-tab issue. Documented via an `it.fails` test in `ApiContext.test.tsx` and tracked in #1712.

## Developer Notes (Optional)

`scheduleSessionRevalidation` (sessionBootstrap.ts) is a reusable self-re-arming-timer pattern: arm based on a pure delay predicate, always re-arm after the timer fires regardless of outcome, and re-arm immediately on an external state change via a store subscription. Applicable anywhere else a "keep this fresh independent of any UI event" need comes up.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
