### PR TITLE
test(client): pin the spend period-label regression test to a non-UTC zone

### DIFF
--- a/apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.test.ts
+++ b/apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.test.ts
@@ -1,8 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import dayjs from 'dayjs';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spendPeriodLabels } from './spendPeriodLabels';
 
+// The bug this suite guards - rendering an ISO instant as its UTC calendar day rather
+// than the viewer's - is only observable east of UTC, and GitHub runners default to UTC
+// (nothing in .github/workflows or the vitest config sets TZ). Pin an eastern, DST-free
+// zone so the suite actually fails on a revert. Every expectation below is a hand-computed
+// local day for a literal UTC instant, never a round trip through the helper's own
+// formatting, so an unpinned run fails loudly instead of silently agreeing with itself.
+const PINNED_TZ = 'Asia/Shanghai'; // UTC+8 year-round
+const originalTz = process.env.TZ;
+
 describe('spendPeriodLabels', () => {
+  beforeAll(() => {
+    process.env.TZ = PINNED_TZ;
+  });
+
+  afterAll(() => {
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+  });
+
   it('labels the default trailing window when no range is set', () => {
     expect(spendPeriodLabels()).toEqual({ periodLabel: 'Last 30 days', priorPeriodLabel: 'Prior 30 days' });
     expect(spendPeriodLabels(undefined, undefined)).toEqual({
@@ -12,20 +29,17 @@ describe('spendPeriodLabels', () => {
   });
 
   it('renders the range in local time so the label matches the ControlPanel chips', () => {
-    // Build the bounds as LOCAL wall-clock (no offset), then hand the helper the UTC
-    // instant the ControlPanel would send (dayjs(...).toISOString()). The label must
-    // render that instant back to its local calendar day - not the UTC day that
-    // toISOString().slice(0,10) prints, which is a day early east of UTC (the bug).
-    const from = dayjs('2026-01-01T00:00:00');
-    const to = dayjs('2026-01-08T00:00:00');
-    const { periodLabel } = spendPeriodLabels(from.toISOString(), to.toISOString());
+    // Local midnight on 2026-01-01 and 2026-01-08 in UTC+8 - the instants the
+    // ControlPanel sends. Their UTC calendar days are a day earlier, so formatting
+    // via toISOString().slice(0, 10) (the bug) prints '2025-12-31 - 2026-01-07'.
+    const { periodLabel } = spendPeriodLabels('2025-12-31T16:00:00.000Z', '2026-01-07T16:00:00.000Z');
     expect(periodLabel).toBe('2026-01-01 - 2026-01-08');
   });
 
   it('derives an equal-length prior window immediately before the range', () => {
-    const from = dayjs('2026-01-08T00:00:00');
-    const to = dayjs('2026-01-15T00:00:00'); // 7-day window
-    const { priorPeriodLabel } = spendPeriodLabels(from.toISOString(), to.toISOString());
+    // Local 2026-01-08 through 2026-01-15 in UTC+8: a 7-day window whose prior
+    // window is local 2026-01-01 through 2026-01-08.
+    const { priorPeriodLabel } = spendPeriodLabels('2026-01-07T16:00:00.000Z', '2026-01-14T16:00:00.000Z');
     expect(priorPeriodLabel).toBe('2026-01-01 - 2026-01-08');
   });
 });

--- a/apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.ts
+++ b/apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.ts
@@ -15,6 +15,12 @@ export interface SpendPeriodLabels {
  * Mirrors the window math in the /api/admin/spend handler's resolveWindows: with no
  * range it is the default trailing window; otherwise the prior window is the same
  * length immediately before `from`. dateFrom/dateTo are ISO instants from the filter.
+ *
+ * @see apps/client/pages/api/admin/spend.ts `resolveWindows` - the server twin these
+ * labels describe; the two derivations must stay in sync. They already diverge on the
+ * dateTo-only path: the subtract() below is calendar-aware while the server subtracts a
+ * fixed 30 * DAY_MS, so a derived `from` landing within an hour of local midnight on a
+ * DST-transition day labels one calendar day and queries another.
  */
 export function spendPeriodLabels(dateFrom?: string, dateTo?: string): SpendPeriodLabels {
   const hasFrom = Boolean(dateFrom);

--- a/apps/client/pages/api/admin/spend.ts
+++ b/apps/client/pages/api/admin/spend.ts
@@ -68,6 +68,12 @@ const parseDate = (value?: string): Date | undefined => {
  * prior window of equal length (for the vs-prior KPI deltas). With no dates the
  * window defaults to the last 30 days. Human period labels are formatted on the
  * client (see spendPeriodLabels) since they depend on the viewer's timezone.
+ *
+ * @see apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.ts - the
+ * client re-derives these same bounds to label them, and the two must stay in sync.
+ * They already diverge on the dateTo-only path: the client subtracts 30 days with a
+ * calendar-aware dayjs subtract while the fixed 30 * DAY_MS below is not, so across a
+ * DST transition the label can name a different day than the one queried here.
  */
 function resolveWindows(dateFrom?: string, dateTo?: string) {
   const now = new Date();

--- a/b4m-core/common/src/types/entities/UsageEventTypes.ts
+++ b/b4m-core/common/src/types/entities/UsageEventTypes.ts
@@ -336,10 +336,12 @@ export interface ISessionUsageSummary {
 }
 
 /**
- * Filters for the admin Spend rollup. Date bounds map to `createdAt` (inclusive);
- * omitting a field spans all. `userId`/`model` mirror the ModelMetrics user/model
- * filters. Status is intentionally not a filter here: it would distort the
- * error-rate KPI, which is derived from the same event set.
+ * Filters for the admin Spend rollup. Date bounds map to `createdAt` as the half-open
+ * window `[from, to)` - the upper bound is exclusive so a window and the equal-length
+ * prior window before it (whose `to` is this window's `from`) don't both count an event
+ * at the shared instant. Omitting a field spans all. `userId`/`model` mirror the
+ * ModelMetrics user/model filters. Status is intentionally not a filter here: it would
+ * distort the error-rate KPI, which is derived from the same event set.
  */
 export interface ISpendSummaryFilters {
   from?: Date;


### PR DESCRIPTION
# Pull Request

## Description

Two follow-ups from the review on [PR No. 1556](https://github.com/Bike4Mind/bike4mind/pull/1556), both on the admin Spend window surface. Bundled because they touch the same three files and the same window math.

**Closes No. 1706** - the period-label regression test could not fail. It built its input and its expectation with the same local round trip:

```ts
const from = dayjs('2026-01-01T00:00:00');            // encode with the runner's offset
spendPeriodLabels(from.toISOString(), ...)            // decode with the same offset
expect(periodLabel).toBe('2026-01-01 - 2026-01-08');
```

Encode and decode shared the runner's offset, so the assertion held at any offset - including `0`. The bug it documents (rendering an ISO instant as its UTC calendar day) is only observable **east** of UTC, and GitHub-hosted runners default to UTC: nothing under `.github/workflows/` sets `TZ`, and neither `apps/client/vitest.config.mts` nor `vitest.setup.ts` sets `process.env.TZ`. The test therefore passed against the pre-fix implementation it was written to guard.

**Closes No. 1707** - two contract comments on the same surface disagreed with the code. No behavior change.

## Changes

- **`spendPeriodLabels.test.ts`** - pin the suite to `Asia/Shanghai` (UTC+8, no DST) in `beforeAll`, restored in `afterAll`, and rewrite the two date cases to assert hand-computed local days against literal UTC instants rather than round-tripping through the helper's own formatting. Both halves of the issue's suggested fix, because they cover different failure modes: the pin makes a reverted implementation fail, and the independent expectations make an *unpinned* run fail too (under UTC the labels come out `2025-12-31 - 2026-01-07`) instead of silently agreeing with itself again.
- **`UsageEventTypes.ts`** - `ISpendSummaryFilters` said the date bounds were inclusive; `spendSummary` deliberately queries `$gte`/`$lt`. Corrected to `[from, to)` with the reason the upper bound is exclusive (adjacent current/prior windows must not both count an event at the shared instant).
- **`spendPeriodLabels.ts`** and **`pages/api/admin/spend.ts`** - added a `@see` on each pointing at the other, naming the known divergence on the `dateTo`-only path: the client subtracts 30 days with a calendar-aware `dayjs.subtract`, the server with a fixed `30 * DAY_MS`. They differ by an hour across a DST transition, so a derived boundary landing within an hour of local midnight on a transition day can label a different day than the one queried.

## Guide for Testers

Code-and-tests only, no runtime behavior change. Verification is at the command line.

1. From the repo root, run the suite: `pnpm --filter @bike4mind/client test app/components/admin/ModelMetrics/utils/spendPeriodLabels.test.ts`. Expected: 3 tests pass.
2. Re-run it forcing a UTC runner, matching CI: `TZ=UTC pnpm --filter @bike4mind/client test app/components/admin/ModelMetrics/utils/spendPeriodLabels.test.ts`. Expected: still 3 passing - the in-file pin overrides the ambient zone.
3. Confirm the test now has teeth. In `apps/client/app/components/admin/ModelMetrics/utils/spendPeriodLabels.ts`, temporarily change the `fmt` helper to the pre-fix version:
   ```ts
   const fmt = (d: dayjs.Dayjs) => new Date(d.valueOf()).toISOString().slice(0, 10);
   ```
   Re-run step 1. Expected: **2 of 3 tests fail**, both reporting `expected '2025-12-31 - 2026-01-07' to be '2026-01-01 - 2026-01-08'`. Revert the edit afterward.

### Regression Checks

4. Run the Spend API suite: `pnpm --filter @bike4mind/client test pages/api/admin/__tests__/spend.test.ts`. Expected: 11 tests pass.
5. Run the whole ModelMetrics tree: `pnpm --filter @bike4mind/client test app/components/admin/ModelMetrics`. Expected: 3 files, 23 tests pass.
6. Optional UI smoke: Sidebar -> Admin -> Model Metrics -> Spend tab. Set a date range and confirm the period label above the KPI row still names the same days as the range chips. Nothing here changed, so any difference is a regression.

### What NOT to test

No API contract, query, response shape, or rendered output changed. The `UsageEventTypes.ts` and `spend.ts` edits are comments only - no need to re-verify spend totals, KPI deltas, or the half-open window behavior itself.

## Additional Information

Step 3 above is the confirmation issue No. 1706 asked for before closing, and it was run: the reverted implementation fails 2 of 3 cases, the current one passes all 3.

Runtime `process.env.TZ` assignment was verified to actually take effect under this vitest config before relying on it - `apps/client/vitest.config.mts` sets `define: { 'process.env': {} }`, which could plausibly have compiled the assignment into a no-op. It does not: inside the pinned block `Intl.DateTimeFormat().resolvedOptions().timeZone` reads `Asia/Shanghai` and the offset is `-480`. The independent expectations mean a future config change that *did* break the pin would fail the suite rather than quietly re-inert it.

Two pre-existing worktree problems surfaced while verifying and were fixed locally, not in this diff: `apps/client/node_modules/@bike4mind/db-core` was missing (stale install, fixed by `pnpm install`), and `.sst/platform` types predated `nodejs24.x`, failing `typecheck:infra` with 95 errors on `origin/main` as well (fixed by `sst install`). Neither is touched by this PR.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - n/a
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc) - n/a, no UI change
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc - n/a

---

Closes #1706
Closes #1707
