### PR TITLE
fix(client): recover the viewer session from the refresh cookie in the gated-artifact loader shell

### DIFF
--- a/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
+++ b/apps/client/pages/api/publish/serve/__tests__/serve.test.ts
@@ -337,9 +337,9 @@ describe('GET /api/publish/serve - gated-bundle loader shell', () => {
     const data = res._getData() as string;
     expect(data).toContain('<iframe id="b4m-frame" sandbox="allow-scripts"');
     expect(data).not.toContain('allow-same-origin');
-    expect(data).toContain("localStorage.getItem('access-token-storage')");
+    expect(data).toContain("fetch('/api/auth/refreshToken'");
     expect(data).toContain("'raw=1'");
-    // CSP permits the shell's inline bootstrap + the same-origin ?raw=1 fetch.
+    // CSP permits the shell's inline bootstrap + the same-origin refresh/?raw=1 fetches.
     const csp = res.getHeader('Content-Security-Policy') as string;
     expect(csp).toContain("script-src 'unsafe-inline'");
     expect(csp).toContain('connect-src https://app.bike4mind.com');
@@ -944,7 +944,7 @@ describe('GET /api/publish/serve - gated reply/fabfile loader shell', () => {
     const data = res._getData() as string;
     expect(data).toContain('<iframe id="b4m-frame" sandbox="allow-scripts"');
     expect(data).not.toContain('allow-same-origin');
-    expect(data).toContain("localStorage.getItem('access-token-storage')");
+    expect(data).toContain("fetch('/api/auth/refreshToken'");
     expect(data).toContain("'raw=1'");
     // Shell must NOT leak the gated reply's content or title.
     expect(data).not.toContain('Secret org reply');

--- a/apps/client/server/services/publish/renderBundleLoaderShell.dom.test.ts
+++ b/apps/client/server/services/publish/renderBundleLoaderShell.dom.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+//
+// EXECUTION coverage for the gated-bundle loader shell. Every other test asserts the shell as a
+// static string, which is exactly why #1710 shipped green: the shell read a credential out of
+// localStorage, #1346 moved the refresh token into an HttpOnly cookie and made the access token
+// memory-only, and no test ever RAN the bootstrap to discover the read now returns undefined.
+// The visibility ladder itself was well covered - it was the credential-recovery leg in front of
+// it that was dead, so these tests eval the real inline bootstrap against a stubbed fetch and
+// assert the viewer actually receives bundle bytes.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderBundleLoaderShell } from './renderBundleLoaderShell';
+
+/** The bootstrap is the FIRST inline script in the shell (the second is the hash bridge). */
+function bootstrapSource(): string {
+  const shell = renderBundleLoaderShell();
+  const match = /<script>([\s\S]*?)<\/script>/.exec(shell);
+  if (!match) throw new Error('loader shell has no inline bootstrap script');
+  return match[1];
+}
+
+interface StubbedCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+let calls: StubbedCall[] = [];
+
+/** Route each fetch by URL so a test can describe a session state rather than a call order. */
+function stubFetch(routes: { refresh: () => Response; raw?: () => Response }) {
+  const fetchStub = vi.fn((url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    if (url.includes('/api/auth/refreshToken')) return Promise.resolve(routes.refresh());
+    if (routes.raw) return Promise.resolve(routes.raw());
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchStub);
+  return fetchStub;
+}
+
+function json(status: number, body: unknown): Response {
+  return { status, json: () => Promise.resolve(body), text: () => Promise.resolve('') } as Response;
+}
+
+function html(status: number, body: string): Response {
+  return { status, text: () => Promise.resolve(body), json: () => Promise.resolve({}) } as Response;
+}
+
+function mountShell(): { frame: HTMLIFrameElement; msg: HTMLElement } {
+  document.body.innerHTML = '<iframe id="b4m-frame" style="display:none"></iframe><div id="b4m-msg"></div>';
+  return {
+    frame: document.getElementById('b4m-frame') as HTMLIFrameElement,
+    msg: document.getElementById('b4m-msg') as HTMLElement,
+  };
+}
+
+/** Run the bootstrap and let its promise chain settle. */
+async function runBootstrap(): Promise<void> {
+  // eval, deliberately: executing the REAL shipped bootstrap is the whole point - a test that
+  // reimplemented it would have passed straight through #1710.
+  eval(bootstrapSource());
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe('loader shell bootstrap - execution', () => {
+  beforeEach(() => {
+    calls = [];
+    vi.useFakeTimers();
+    mountShell();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the bundle for a viewer whose session lives only in the refresh cookie', async () => {
+    // The #1710 case: an org member with a perfectly good session and NOTHING in localStorage.
+    stubFetch({
+      refresh: () => json(200, { accessToken: 'fresh.access.token' }),
+      raw: () => html(200, '<h1>org only</h1>'),
+    });
+
+    await runBootstrap();
+
+    const frame = document.getElementById('b4m-frame') as HTMLIFrameElement;
+    expect(frame.srcdoc).toBe('<h1>org only</h1>');
+    expect(frame.style.display).toBe('block');
+    expect((document.getElementById('b4m-msg') as HTMLElement).style.display).toBe('none');
+  });
+
+  it('never reads localStorage for a credential', async () => {
+    const getItem = vi.spyOn(window.localStorage, 'getItem');
+    stubFetch({ refresh: () => json(200, { accessToken: 't' }), raw: () => html(200, 'ok') });
+
+    await runBootstrap();
+
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
+  it('exchanges the cookie with a same-origin POST and forwards the token as a Bearer header', async () => {
+    stubFetch({ refresh: () => json(200, { accessToken: 'fresh.access.token' }), raw: () => html(200, 'ok') });
+
+    await runBootstrap();
+
+    const refresh = calls.find(c => c.url.includes('/api/auth/refreshToken'));
+    expect(refresh?.init?.method).toBe('POST');
+    // 'same-origin' is what actually sends the HttpOnly cookie; 'omit' here is the bug.
+    expect(refresh?.init?.credentials).toBe('same-origin');
+
+    const raw = calls.find(c => c.url.includes('raw=1'));
+    expect((raw?.init?.headers as Record<string, string>).Authorization).toBe('Bearer fresh.access.token');
+    // The recovered token is the ONLY credential on the artifact fetch - no ambient cookie.
+    expect(raw?.init?.credentials).toBe('omit');
+  });
+
+  it('offers sign-in to a viewer with no session, without fetching the artifact', async () => {
+    stubFetch({ refresh: () => json(401, { error: 'Refresh token is required' }) });
+
+    await runBootstrap();
+
+    const msg = document.getElementById('b4m-msg') as HTMLElement;
+    expect(msg.textContent).toContain('Sign in to view this shared item');
+    expect(msg.querySelector('a')?.getAttribute('href')).toContain('/login?redirectTo=');
+    expect(calls.some(c => c.url.includes('raw=1'))).toBe(false);
+    // Terminal, not retried: 401 is the ordinary answer for a signed-out viewer.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(calls.filter(c => c.url.includes('/api/auth/refreshToken'))).toHaveLength(1);
+  });
+
+  it('tells a non-member they lack access rather than telling them to sign in', async () => {
+    // A live session that simply is not in the artifact's org. Sending this viewer to /login
+    // is a loop that cannot help them, which is the ambiguity #1710 called out.
+    stubFetch({ refresh: () => json(200, { accessToken: 't' }), raw: () => html(403, '') });
+
+    await runBootstrap();
+
+    const msg = document.getElementById('b4m-msg') as HTMLElement;
+    expect(msg.textContent).toContain('You do not have access to this shared item');
+    expect(msg.textContent).not.toContain('Sign in to view');
+    expect(document.getElementById('b4m-frame')).toBeNull(); // frame torn down on a terminal state
+  });
+
+  it('prompts a real re-login when the recovered token is rejected', async () => {
+    stubFetch({ refresh: () => json(200, { accessToken: 'stale' }), raw: () => html(401, '') });
+
+    await runBootstrap();
+    // A 401 on the artifact fetch is retried (cold-Lambda tolerance) before it is terminal.
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const msg = document.getElementById('b4m-msg') as HTMLElement;
+    expect(msg.textContent).toContain('Your session has ended');
+    expect(msg.querySelector('a')?.getAttribute('href')).toContain('/login?redirectTo=');
+  });
+
+  it('retries a transient failure of the token exchange before giving up', async () => {
+    let attempts = 0;
+    stubFetch({
+      refresh: () => {
+        attempts++;
+        return attempts < 3 ? json(503, {}) : json(200, { accessToken: 'late.but.valid' });
+      },
+      raw: () => html(200, '<h1>recovered</h1>'),
+    });
+
+    await runBootstrap();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(attempts).toBe(3);
+    expect((document.getElementById('b4m-frame') as HTMLIFrameElement).srcdoc).toBe('<h1>recovered</h1>');
+  });
+});

--- a/apps/client/server/services/publish/renderBundleLoaderShell.test.ts
+++ b/apps/client/server/services/publish/renderBundleLoaderShell.test.ts
@@ -9,8 +9,20 @@ describe('renderBundleLoaderShell', () => {
     expect(shell).not.toContain('allow-same-origin'); // CRITICAL opaque-origin invariant
   });
 
-  it('reads the localStorage JWT and re-fetches ?raw=1 with a Bearer header', () => {
-    expect(shell).toContain("localStorage.getItem('access-token-storage')");
+  it('recovers the session from the refresh cookie, never from localStorage', () => {
+    // REGRESSION (#1710): the shell read `state.accessToken` out of the zustand-persist
+    // envelope, but #1346 moved the refresh token into an HttpOnly cookie and made the access
+    // token memory-only, so that read returns undefined forever - every signed-in viewer of a
+    // gated artifact was shown "sign in". There is no readable credential in script storage;
+    // the only recovery is the cookie exchange, so a localStorage read here is always a bug.
+    expect(shell).not.toContain('localStorage');
+    expect(shell).toContain("fetch('/api/auth/refreshToken'");
+    expect(shell).toContain("method: 'POST'");
+    expect(shell).toContain("credentials: 'same-origin'"); // sends the HttpOnly refresh cookie
+    expect(shell).toContain('data.accessToken');
+  });
+
+  it('re-fetches ?raw=1 with a Bearer header once the token is recovered', () => {
     expect(shell).toContain("'raw=1'");
     expect(shell).toContain("'Bearer '");
     expect(shell).toContain('Authorization');
@@ -43,6 +55,24 @@ describe('renderBundleLoaderShell', () => {
     expect(shell).toContain('res.status === 403');
   });
 
+  // Acceptance criteria of #1710: the three terminal outcomes must be TELLABLE APART. They
+  // were previously one indistinguishable "must be logged in" screen, so an org member with a
+  // live session, a non-member, and a viewer whose session expired all got the same dead end.
+  it('gives no-session, no-access and expired-session distinct copy', () => {
+    expect(shell).toContain('Sign in to view this shared item.');
+    expect(shell).toContain('You do not have access to this shared item.');
+    expect(shell).toContain('Your session has ended.');
+    // Every terminal message routes somewhere actionable rather than dead-ending.
+    expect(shell).toContain('Sign in again');
+    expect(shell).toContain('Ask its owner to share it with you.');
+  });
+
+  // A viewer who is simply signed out is the COMMON case for a private link, and 401 is the
+  // ordinary answer for them - it must not sit through the retry backoff before saying so.
+  it('does not retry a 401 from the token exchange', () => {
+    expect(shell).toContain('if (res.status === 401) { show(signIn); return null; }');
+  });
+
   // The shell must carry NO per-artifact data - the title would otherwise leak to an
   // anonymous viewer of a gated bundle. The page is fully static, so there is also no
   // interpolation/injection surface at all.
@@ -61,13 +91,16 @@ describe('renderBundleLoaderShell', () => {
     expect(shell).toContain('attempt < 4');
     expect(shell).toContain('setTimeout(load, attempt * 600)');
     expect(shell).toContain('res.status >= 500');
+    // The token exchange gets its own backoff: a cold Lambda can fail the FIRST of the two
+    // round trips just as easily as the second.
+    expect(shell).toContain('setTimeout(authenticate, authAttempt * 600)');
   });
 
   // Show "Loading..." and keep the iframe hidden until srcdoc lands, so a slow
   // round-trip doesn't look like a broken/blank page.
   it('shows a Loading placeholder and reveals the iframe only once srcdoc is set', () => {
     expect(shell).toContain('style="display:none"'); // iframe starts hidden
-    expect(shell).toContain("note('Loading…')");
+    expect(shell).toContain("note('Loading...')");
     expect(shell).toContain("frame.style.display = 'block'");
   });
 });

--- a/apps/client/server/services/publish/renderBundleLoaderShell.ts
+++ b/apps/client/server/services/publish/renderBundleLoaderShell.ts
@@ -4,13 +4,24 @@
  * A top-level browser navigation to `/p/...` carries no Authorization header, so the
  * serve route can't authorize a gated bundle on the initial GET. Instead of 401, it
  * returns this small PUBLIC page (no secret). Its inline bootstrap script - running on
- * the app origin, where the JWT lives - reads the access token from localStorage and
- * re-fetches the SAME route with `?raw=1` + `Authorization: Bearer`, then injects the
- * returned srcdoc into the sandboxed iframe client-side.
+ * the app origin, where the session lives - exchanges the HttpOnly refresh cookie for an
+ * access token and re-fetches the SAME route with `?raw=1` + `Authorization: Bearer`,
+ * then injects the returned srcdoc into the sandboxed iframe client-side.
+ *
+ * The credential is obtained by POSTing `/api/auth/refreshToken`, exactly as the app's own
+ * cold-load path does (app/utils/sessionBootstrap.ts) - NOT by reading localStorage. The
+ * access token is memory-only and the refresh token is an HttpOnly cookie, so a fresh
+ * navigation to this shell has no readable credential anywhere in script storage; the shell
+ * used to read one out of the zustand-persist envelope, which silently became `undefined` and
+ * told every signed-in viewer of a gated artifact to sign in. The exchange is also deliberately
+ * unconditional - WebKit ITP evicts script-writable storage after ~7 days while leaving the
+ * server-set cookie intact, so no client-side flag can be trusted to mean "signed out".
+ * MUST STAY IN SYNC with sessionBootstrap.ts: this shell is a second consumer of the browser
+ * session transport and cannot notice on its own when that transport changes.
  *
  * The opaque-origin model is preserved: the bundle still runs in
  * `<iframe sandbox="allow-scripts">` with NO `allow-same-origin`, so it can't read the
- * app's localStorage/cookies. The token is read only by THIS trusted shell on the app
+ * app's localStorage/cookies. The token is held only by THIS trusted shell on the app
  * origin and sent only as a fetch header - it is never placed into the iframe or srcdoc.
  *
  * The shell is served with the SAME CSP as a real wrapped render, so the injected srcdoc
@@ -29,8 +40,7 @@
 import { HASH_BRIDGE_JS } from './fragmentNav';
 
 export function renderBundleLoaderShell(): string {
-  // Bootstrap script: no server-interpolated values. The localStorage key mirrors
-  // ACCESS_TOKEN_STORAGE_KEY in app/hooks/useAccessToken.ts.
+  // Bootstrap script: no server-interpolated values.
   const bootstrap = `(function () {
   var frame = document.getElementById('b4m-frame');
   var msg = document.getElementById('b4m-msg');
@@ -41,17 +51,43 @@ export function renderBundleLoaderShell(): string {
   function note(text) { if (msg) { msg.textContent = text; msg.style.display = 'block'; } }
   var loginUrl = '/login?redirectTo=' + encodeURIComponent(location.pathname + location.search);
   var signIn = 'Sign in to view this shared item. <a href="' + loginUrl + '">Sign in</a>';
-  var token = null, expired = true;
-  try {
-    var stored = localStorage.getItem('access-token-storage');
-    // Fail safe: only treat the session as live when expired is EXPLICITLY false. A missing
-    // expired field (corrupted / hand-edited storage) defaults to expired, so we never send a
-    // token we can't vouch for (the server is authoritative regardless, but this avoids a
-    // pointless 401 round-trip and keeps the client check conservative).
-    if (stored) { var s = (JSON.parse(stored) || {}).state || {}; token = s.accessToken; expired = s.expired !== false; }
-  } catch (e) {}
-  if (!token || expired) { show(signIn); return; }
-  note('Loading…');
+  var expiredMsg = 'Your session has ended. <a href="' + loginUrl + '">Sign in again</a> to view this shared item.';
+  var token = null;
+  note('Loading...');
+
+  // Stage 1: trade the HttpOnly refresh cookie for an access token. Unconditional - no
+  // client-side precheck, for the reasons in this file's header and sessionBootstrap.ts.
+  var authAttempt = 0;
+  function authenticate() {
+    authAttempt++;
+    fetch('/api/auth/refreshToken', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: '{}'
+    })
+      .then(function (res) {
+        if (res.status === 200) return res.json();
+        // 401 is the ORDINARY answer for a viewer with no session (anyone opening a private
+        // link while signed out), so it resolves immediately rather than burning the backoff.
+        // Only a transient failure - cold Lambda 5xx, rate limit - is worth retrying.
+        if (res.status === 401) { show(signIn); return null; }
+        if (authAttempt < 4) { setTimeout(authenticate, authAttempt * 600); return null; }
+        show('This shared item could not be loaded.');
+        return null;
+      })
+      .then(function (data) {
+        if (!data || !data.accessToken) return;
+        token = data.accessToken;
+        load();
+      })
+      .catch(function () {
+        if (authAttempt < 4) { setTimeout(authenticate, authAttempt * 600); }
+        else { show('This shared item could not be loaded.'); }
+      });
+  }
+
+  // Stage 2: re-fetch this same URL with the recovered credential and inject the result.
   var url = location.pathname + (location.search ? location.search + '&' : '?') + 'raw=1';
   var attempt = 0;
   function load() {
@@ -60,10 +96,14 @@ export function renderBundleLoaderShell(): string {
       .then(function (res) {
         if (res.status === 200) return res.text();
         // A freshly-deployed (cold) Lambda can miss JWT verification on its first hit and 401,
-        // or 5xx transiently — retry a few times with backoff before treating it as terminal.
+        // or 5xx transiently - retry a few times with backoff before treating it as terminal.
         if ((res.status === 401 || res.status >= 500) && attempt < 4) { setTimeout(load, attempt * 600); return null; }
-        if (res.status === 401) { show(signIn); return null; }
-        if (res.status === 403) { show('You do not have access to this shared item.'); return null; }
+        // The three terminal outcomes are deliberately distinct: a 401 here means the token we
+        // just minted was rejected (session ended mid-flight), which needs a re-login, while a
+        // 403 means the session is fine and simply lacks access to THIS artifact - telling that
+        // viewer to sign in sends them round a loop that cannot help.
+        if (res.status === 401) { show(expiredMsg); return null; }
+        if (res.status === 403) { show('You do not have access to this shared item. Ask its owner to share it with you.'); return null; }
         show('This shared item could not be loaded.');
         return null;
       })
@@ -72,7 +112,7 @@ export function renderBundleLoaderShell(): string {
       })
       .catch(function () { if (attempt < 4) { setTimeout(load, attempt * 600); } else { show('This shared item could not be loaded.'); } });
   }
-  load();
+  authenticate();
 })();`;
 
   // SECURITY: `sandbox="allow-scripts"` WITHOUT `allow-same-origin` - identical to the


### PR DESCRIPTION
## Description

Fixes #1710. Publishing to `organization` visibility produced an artifact nobody could read: a logged-in org member opening the link got the "must be logged in" view and never saw the content. Every gated visibility was affected -- `private`, `project` and `organization` -- leaving `public` as the only visibility that rendered at all.

**Root cause, confirmed from source.** A top-level navigation to `/p/...` carries no `Authorization` header, so the serve route returns the public loader shell and lets its inline bootstrap recover a credential client-side. That bootstrap read the access token out of the zustand-persist envelope:

```js
var stored = localStorage.getItem('access-token-storage');
if (stored) { var s = (JSON.parse(stored) || {}).state || {}; token = s.accessToken; ... }
if (!token || expired) { show(signIn); return; }
```

`61a747d8` (#1346, "move the refresh token into an HttpOnly cookie") changed `partialize` to persist only `{hasSession, expired, expiredReason}` -- **no credential is persisted any more**, and the access token is memory-only. That commit touched no file under `pages/api/publish/` or `server/services/publish/`, so the shell kept reading a field that is now permanently `undefined`. Every gated artifact navigation short-circuited to "sign in" before it ever issued a request.

This confirms hypothesis #1 in the issue and rules out hypothesis #2: `req.user` being empty on a top-level navigation is by design (the cookie is `Path=/api`, so it is not sent on a `/p` navigation at all), not the deeper bug.

## Changes

- `renderBundleLoaderShell.ts`: the bootstrap now `POST`s `/api/auth/refreshToken` with `credentials: 'same-origin'` to exchange the HttpOnly refresh cookie for an access token, then re-fetches `?raw=1` with the `Bearer` header. This mirrors the app's own cold-load path (`app/utils/sessionBootstrap.ts`) rather than inventing a second session mechanism. The cookie is `Path=/api` + `SameSite=Strict`, which the same-origin fetch from the shell satisfies (Strict only blocks the initial cross-site *navigation*).
- The exchange is **unconditional** -- it reads no client-side flag first. WebKit ITP evicts script-writable storage after ~7 days while leaving the server-set cookie intact, so a persisted flag can report "signed out" for a session that is in fact live. Same reasoning as `sessionBootstrap.ts`.
- **The three terminal outcomes are now tellable apart**, where all three previously rendered the same dead end:
  - no session -> "Sign in to view this shared item" (not retried; 401 is the *ordinary* answer for a signed-out viewer opening a private link, so it resolves immediately instead of burning the backoff)
  - live session without access to this artifact -> "You do not have access to this shared item. Ask its owner to share it with you." -- which does not send that viewer round a `/login` loop that cannot help them
  - session ended mid-flight -> "Your session has ended. Sign in again"
- The token exchange gets its own retry/backoff: a cold Lambda can fail the first of the two round trips as easily as the second.
- New `renderBundleLoaderShell.dom.test.ts` (7 tests) **evals the real shipped bootstrap** against a stubbed fetch and asserts the viewer receives bundle bytes.

## Why the tests did not catch this

The issue asked for integration coverage per visibility. That coverage already exists and is good -- `checkVisibility.test.ts` and `serve.test.ts` cover member / non-member / anonymous for organization, project and private. The gap was one layer earlier: **nothing ever executed the credential-recovery leg in front of the ladder.** Every shell test asserted the shell as a static string, so a permanently dead `localStorage` read shipped green, and would have again.

So the new test is an execution test rather than more ladder coverage. It also pins the invariant directly:

```js
expect(shell).not.toContain('localStorage');   // there is no readable credential in script storage
```

`renderBundleLoaderShell.ts` now carries a `MUST STAY IN SYNC with sessionBootstrap.ts` note, since the shell is a second consumer of the browser session transport and cannot notice on its own when that transport changes -- which is exactly how this broke.

## Guide for Testers

Needs a deploy with at least two accounts in the same organization, plus one outside it.

1. Sign in to the preview app as a member of an organization.
2. Publish any artifact with `"visibility": "organization"`.
3. Copy the returned `/p/u/<scope>/<slug>` URL.
4. Open that URL in a new tab **in the same browser, still signed in**. Expected: the artifact content renders within a couple of seconds. Before this fix you got "Sign in to view this shared item".
5. Reload the page. Expected: renders again, no flicker to a sign-in prompt.
6. Sign in as a user in a **different** organization and open the same URL. Expected: "You do not have access to this shared item. Ask its owner to share it with you." -- NOT a sign-in prompt.
7. Open the same URL in a private/incognito window (signed out). Expected: "Sign in to view this shared item", with a working Sign in link that returns you to the artifact after login. Expected: it appears immediately, not after a multi-second delay.
8. Repeat steps 2-5 with `"visibility": "private"` (as the owner) and `"visibility": "project"` (as a project member). Expected: both render.

Regression checks:

9. Publish with `"visibility": "public"` and open the URL signed out. Expected: renders as before via the isolated `*.usercontent` origin -- this path is untouched.
10. Publish a passphrase-gated artifact and open it. Expected: the passphrase prompt still appears (it takes precedence over the loader shell) and unlocks correctly.
11. With the app open in another tab, open a gated artifact. Expected: both tabs stay signed in. The shell's exchange rotates the shared refresh cookie; concurrent rotations are covered by the 60s one-generation grace window in `rotateSession`, so this must not trip reuse detection.

What NOT to test: the comment-overlay widget's sign-in state -- see Additional Information.

## Additional Information

**Separate defect found, deliberately not fixed here.** `pages/api/publish/widget.ts:43-50` has the identical dead read:

```js
function getToken() {
  var raw = localStorage.getItem('access-token-storage');
  ...
  return (p && p.state && p.state.accessToken) || null;
}
```

So the comment widget authenticates no writes for anyone, and a signed-in viewer is shown "Sign in to comment". Same root cause, different symptom, and a real fix needs the widget's synchronous `headers()` restructured around an async token acquisition -- larger than this PR and worth its own issue. Not folded in to keep this change reviewable.

**Verification:** `renderBundleLoaderShell` + `serve` suites green (272 tests across `server/services/publish`, 136 in `serve.test.ts`); `pnpm lint:check` clean repo-wide; no new type errors (`apps/client` has 324 pre-existing errors from stale core builds, identical on a clean tree).
