### PR TITLE
fix(client): route the remaining window.open call sites through openInNewTab

### DIFF
--- a/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
@@ -78,6 +78,7 @@ import { z } from 'zod';
 import XLSXViewer from './XLSXViewer';
 import { toast } from 'react-hot-toast';
 import DownloadMenu, { downloadFile, copyToClipboard } from '../common/DownloadMenu';
+import { openInNewTab } from '@client/app/utils/externalLinks';
 import ShareIcon from '@mui/icons-material/Share';
 import { useUser } from '@client/app/contexts/UserContext';
 import { usePublishShare } from '@client/app/hooks/usePublishShare';
@@ -1186,7 +1187,7 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
             toast.error('No file URL available');
             return;
           }
-          window.open(currentItem.content.fileUrl, '_blank');
+          openInNewTab(currentItem.content.fileUrl);
         } else if (currentItem.content.mimeType === 'text/markdown') {
           try {
             if (!currentItem.content.fileUrl) {

--- a/apps/client/app/components/ProfileModal/ContentPreviewModal.tsx
+++ b/apps/client/app/components/ProfileModal/ContentPreviewModal.tsx
@@ -39,6 +39,7 @@ import { useUser } from '@client/app/contexts/UserContext';
 import { uploadBlogImage, generatePostIdFromTitle } from '@client/app/utils/blogImageUpload';
 import { useImageBrowser } from '@client/app/hooks/agent/useImageBrowser';
 import ImageBrowserModal from '../Agent/ImageBrowserModal';
+import { openInNewTab } from '@client/app/utils/externalLinks';
 
 // Dynamic import to avoid SSR issues
 const MDEditor = dynamic(() => import('@uiw/react-md-editor'), { ssr: false });
@@ -82,7 +83,7 @@ const ContentPreviewModal: React.FC<ContentPreviewModalProps> = ({
         duration: 10000,
         action: {
           label: 'Open',
-          onClick: () => window.open(data.url, '_blank'),
+          onClick: () => openInNewTab(data.url),
         },
       });
       handleClose();

--- a/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
+++ b/apps/client/app/components/ProfileModal/NotebookExportModal.tsx
@@ -29,6 +29,7 @@ import {
   downloadBlob,
   BulkExportData,
 } from '@client/app/utils/bulkNotebookExport';
+import { openInNewTab } from '@client/app/utils/externalLinks';
 
 type ExportFormat = 'json' | 'excel' | 'word' | 'markdown';
 
@@ -95,7 +96,7 @@ const NotebookExportModal: React.FC<NotebookExportModalProps> = ({ open, onClose
 
     if (options.format === 'json') {
       // Direct download for JSON
-      window.open(exportResult.downloadUrl, '_blank');
+      openInNewTab(exportResult.downloadUrl);
       return;
     }
 

--- a/apps/client/app/components/ProfileModal/SettingsTabContent/GitHubIntegrationSection.tsx
+++ b/apps/client/app/components/ProfileModal/SettingsTabContent/GitHubIntegrationSection.tsx
@@ -23,6 +23,7 @@ import { mcpServerKeys } from '@client/app/hooks/data/mcpServers';
 import { useUser } from '@client/app/contexts/UserContext';
 import GitHubNotificationsSection from './GitHubNotificationsSection';
 import { api } from '@client/app/contexts/ApiContext';
+import { openInNewTab } from '@client/app/utils/externalLinks';
 
 interface GitHubIntegrationProps {
   userId: string;
@@ -488,7 +489,7 @@ const GitHubIntegrationSection = ({ userId }: GitHubIntegrationProps) => {
                 <Button
                   variant="outlined"
                   color="neutral"
-                  onClick={() => window.open('https://github.com/settings/connections/applications', '_blank')}
+                  onClick={() => openInNewTab('https://github.com/settings/connections/applications')}
                   size="sm"
                 >
                   Manage on GitHub

--- a/apps/client/app/components/ResearchTasks/Detail/Info.tsx
+++ b/apps/client/app/components/ResearchTasks/Detail/Info.tsx
@@ -24,6 +24,7 @@ import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import BoltIcon from '@mui/icons-material/Bolt';
 import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined';
 import { brand, purple, brandAlpha, orangeAlpha, greenAlpha, grayAlpha } from '../../../utils/themes/colors';
+import { openInNewTab } from '@client/app/utils/externalLinks';
 
 interface ResearchTaskDetailInfoProps {
   task: IResearchTask;
@@ -182,7 +183,7 @@ const ResearchTaskDetailInfo: FC<ResearchTaskDetailInfoProps> = ({ task }) => {
                           <IconButton
                             size="sm"
                             variant="soft"
-                            onClick={() => window.open(url, '_blank')}
+                            onClick={() => openInNewTab(url)}
                             sx={{
                               transition: 'all 0.2s ease',
                               '&:hover': { transform: 'scale(1.1)' },

--- a/apps/client/app/components/Session/ImageContainer.tsx
+++ b/apps/client/app/components/Session/ImageContainer.tsx
@@ -26,6 +26,7 @@ import ImageMaskerFlux from './ImageMaskerFlux';
 import { ImageModerationPlaceholder } from './ImageModerationPlaceholder';
 import { SendMessageOptions } from '@client/app/utils/llm';
 import { blackAlpha, whiteAlpha } from '@client/app/utils/themes/colors';
+import { openInNewTab } from '@client/app/utils/externalLinks';
 
 // Add FabAPI interface
 interface FabAPI {
@@ -306,7 +307,7 @@ const ImageContainer: FC<ImageContainerProps> = ({
 
         // Fallback - open in new tab
         const url = URL.createObjectURL(blob);
-        window.open(url, '_blank');
+        openInNewTab(url);
         toast.success('Image opened in a new tab. Right-click and select "Copy Image" to copy it.');
       }
     } catch (error) {

--- a/apps/client/app/components/admin/DocumentationTab/components/DocSection.tsx
+++ b/apps/client/app/components/admin/DocumentationTab/components/DocSection.tsx
@@ -9,6 +9,7 @@ import LaunchIcon from '@mui/icons-material/Launch';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 
 import { DocumentationItem, DocumentationCategory } from '../utils/docData';
+import { openInNewTab } from '@client/app/utils/externalLinks';
 
 interface DocSectionProps {
   doc: DocumentationItem;
@@ -38,7 +39,7 @@ export const DocSection: React.FC<DocSectionProps> = ({ doc }) => {
   const categoryInfo = categoryConfig[doc.category];
 
   const handleOpenDocumentation = () => {
-    window.open(doc.docusaurusUrl, '_blank');
+    openInNewTab(doc.docusaurusUrl);
   };
 
   return (

--- a/apps/client/app/components/profile/ProfileCollectionSection.tsx
+++ b/apps/client/app/components/profile/ProfileCollectionSection.tsx
@@ -36,6 +36,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { ReactNode, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { openInNewTab } from '@client/app/utils/externalLinks';
 
 dayjs.extend(relativeTime);
 
@@ -105,7 +106,7 @@ const ProfileCollectionSection = ({ userId }: { userId: string }) => {
     try {
       // CORS Workaround for local development
       if (isLocalDev()) {
-        window.open(selectedImage || '', '_blank');
+        openInNewTab(selectedImage);
         toast.success('Image opened in a new tab. Right-click and select "Save Image As..." to save it.');
         setSaving(false);
         return;
@@ -139,7 +140,7 @@ const ProfileCollectionSection = ({ userId }: { userId: string }) => {
     try {
       // CORS Workaround for local development
       if (isLocalDev()) {
-        window.open(selectedImage || '', '_blank');
+        openInNewTab(selectedImage);
         toast.success('Image opened in a new tab. Right-click and select "Copy Image" to copy it.');
         setCopying(false);
         return;
@@ -166,7 +167,7 @@ const ProfileCollectionSection = ({ userId }: { userId: string }) => {
     try {
       // CORS Workaround for local development
       if (isLocalDev()) {
-        window.open(selectedImage || '', '_blank');
+        openInNewTab(selectedImage);
         toast.success('Image opened in a new tab. Right-click and select "Save As..." to download it.');
         setDownloading(false);
         return;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -170,6 +170,37 @@ const WALK_MESSAGE =
   'Do not walk the filesystem (readdir/opendir/glob) in tests under pages/ (#9627): Next traces ' +
   'these as routes, and the dynamic reads pull the whole project into the server Lambda (>250MB, ' +
   'breaks preview deploys). Move fs-scanning tests out of pages/ — e.g. to apps/client/server/__tests__/.';
+// Ban window.open in client UI code: it opens a popup WINDOW rather than a tab in Safari (whose
+// default is windows unless the user has switched "Open pages in tabs instead of windows" to
+// Automatically), and in EVERY browser the moment a feature string is passed - even just
+// 'noopener'. openInNewTab() synthesises an <a target="_blank" rel="noopener noreferrer"> click,
+// which opens a tab and applies both protections at open time.
+//
+// This rule exists because fixing the call sites alone did not hold: the same defect was fixed once
+// for a single screen and ten other call sites kept the old behaviour, with nothing to stop an
+// eleventh appearing. Scoped to apps/client/app/** (the SPA's UI); apps/client/pages/** is the
+// Pages-API backend, where there is no window to open.
+//
+// Covered by the selectors below: `window.open(...)` and its `globalThis`/`self` aliases. The bare
+// `open(url)` form is covered by no-restricted-globals in the same block instead - a syntax
+// selector cannot tell the global from a local binding, and this codebase has plenty of callable
+// locals named `open` (zustand setters like `set(state => ({ open: open(state.open) }))`), which a
+// selector flags and scope analysis correctly ignores.
+//
+// NOT covered (and deliberately so): the string form `vi.spyOn(window, 'open')`, which tests use
+// to prove the helper does NOT reach for it.
+const WINDOW_OPEN_MESSAGE =
+  'Use openInNewTab() from @client/app/utils/externalLinks instead of window.open: window.open ' +
+  'spawns a popup WINDOW rather than a tab in Safari, and in all browsers as soon as any feature ' +
+  'string is passed. If a popup is genuinely intended (an OAuth flow, a print view), add an ' +
+  'eslint-disable with a comment saying why.';
+const noWindowOpenInClientUi = [
+  // `window.open(url)` / `globalThis.open(url)` / `self.open(url)`
+  {
+    selector: `CallExpression[callee.object.name=/^(window|globalThis|self)$/][callee.property.name='open']`,
+    message: WINDOW_OPEN_MESSAGE,
+  },
+];
 const noTreeWalkInPagesTests = [
   // bare call: `readdirSync(dir)` (named/destructured import)
   { selector: `CallExpression[callee.name=/${TREE_WALK_NAMES}/]`, message: WALK_MESSAGE },
@@ -517,6 +548,19 @@ export default defineConfig([
     files: ['apps/client/pages/**/*.{test,spec}.{ts,tsx}'],
     rules: {
       'no-restricted-syntax': ['error', ...noTreeWalkInPagesTests],
+    },
+  },
+
+  // Ban window.open in the SPA's UI code - see noWindowOpenInClientUi above for the Safari
+  // popup-window rationale. Glob is disjoint from the pages-tests block above, so flat-config
+  // last-rule-wins on no-restricted-syntax leaves that rule intact.
+  {
+    files: ['apps/client/app/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': ['error', ...noWindowOpenInClientUi],
+      // Catches the bare `open(url)` form the selectors above cannot safely match. Scope-aware,
+      // so a local/parameter named `open` is untouched.
+      'no-restricted-globals': ['error', { name: 'open', message: WINDOW_OPEN_MESSAGE }],
     },
   },
 ]);


### PR DESCRIPTION
## Description

Addresses #1711. `window.open` opens a popup **window** rather than a tab in Safari (whose default is windows unless the user has switched *"Open pages in tabs instead of windows"* to Automatically), and in **every** browser as soon as any feature string is passed -- even just `'noopener'`. `openInNewTab()` synthesises an `<a target="_blank" rel="noopener noreferrer">` click, which opens a tab and applies both protections at open time.

The issue's framing is right: `947c32a7` (#1258) fixed this correctly but scoped the change to the Gear CTAs, so ten other call sites kept the old behaviour with nothing to stop an eleventh appearing. This converts the rest **and adds the guard**, which is the part that makes it stick.

## Changes

All ten call sites now route through `openInNewTab` from `@client/app/utils/externalLinks`. Each was reviewed individually -- all ten are plain new-tab intents (image previews, doc links, download links, a toast "Open" action, a GitHub settings link, a clipboard fallback). None wants a popup, so none is allowlisted.

| File | Line |
|---|---|
| `app/components/ProfileModal/ContentPreviewModal.tsx` | 85 |
| `app/components/Session/ImageContainer.tsx` | 309 |
| `app/components/Knowledge/KnowledgeViewer.tsx` | 1189 |
| `app/components/ProfileModal/NotebookExportModal.tsx` | 98 |
| `app/components/profile/ProfileCollectionSection.tsx` | 108, 142, 169 |
| `app/components/ResearchTasks/Detail/Info.tsx` | 185 |
| `app/components/admin/DocumentationTab/components/DocSection.tsx` | 41 |
| `app/components/ProfileModal/SettingsTabContent/GitHubIntegrationSection.tsx` | 491 |

One small behaviour change: the three `ProfileCollectionSection` sites drop a `selectedImage || ''` fallback. `openInNewTab` no-ops on a falsy URL, where `window.open('')` opened a blank tab.

**Lint guard** (`eslint.config.mjs`), scoped to `apps/client/app/**`:

- `no-restricted-syntax` for `window.open` / `globalThis.open` / `self.open`
- `no-restricted-globals` for the bare `open(url)` form

The bare form needs the **scope-aware** rule rather than a selector. My first attempt used `CallExpression[callee.name='open']` as the issue suggested, and it produced two false positives -- `KnowledgeModal.tsx:103` and `useAdminModal.ts:22`, both zustand setters of the shape `set(state => ({ open: typeof open === 'function' ? open(state.open) : open }))`, where `open` is a function *parameter*. A syntax selector cannot tell that from the global; `no-restricted-globals` resolves scope and correctly ignores it. Both rules are paired so neither shape escapes.

`vi.spyOn(window, 'open')` stays legal -- it is a string argument, not a member call, and `externalLinks.test.ts` uses it to prove the helper does *not* reach for `window.open`.

Verified against a probe file: `window.open(...)` and `globalThis.open(...)` are flagged by `no-restricted-syntax`, bare `open(...)` by `no-restricted-globals`, and a local parameter named `open` by neither. `pnpm lint:check` is clean repo-wide, and zero violations remain under `apps/client/app/**`.

## Guide for Testers

Best done in **Safari**, where the defect is most visible. Chrome opens tabs either way.

1. Open `app.staging.bike4mind.com` in Safari and sign in.
2. Safari -> Settings -> General. Note the value of "Open pages in tabs instead of windows"; leave it at the default (or set it to "Never") so programmatic opens would spawn windows.
3. Go to Profile -> Collections and click any image to preview it, then click Save. Expected: on a local-dev CORS fallback the image opens in a new **tab** in the same window, not a separate window.
4. Open Admin -> Documentation and click through to any doc. Expected: the Docusaurus page opens in a new tab.
5. Open Profile -> Settings -> integrations and click "Manage on GitHub". Expected: the GitHub settings page opens in a new tab.
6. Open a Knowledge item that is an image and use its open action. Expected: a new tab.
7. Open a Research Task detail with a discovered link and click the "Open in new tab" icon button. Expected: a new tab.
8. Publish a blog post from the content preview modal and click "Open" in the success toast. Expected: a new tab.

Regression checks:

9. Confirm each opened tab has no access to the opener: in the new tab's console, `window.opener` should be `null`.
10. Confirm the Gear external CTAs (fixed in #1258) still open tabs -- untouched by this PR, listed to be sure nothing regressed.
11. Confirm a published artifact still opens correctly from Profile -> Published Artifacts and from Admin -> Published Artifacts.

What NOT to test: no backend, API or data behaviour changes in this PR.

## Additional Information

**One thing I could not confirm.** The issue names `ContentPreviewModal.tsx:85` and `ImageContainer.tsx:309` as the likely artifact "click to open" path, hedged with "worth confirming against the exact button before assuming." That hedge was warranted -- neither is a published-artifact surface. `ContentPreviewModal:85` is the blog-publish success toast; `ImageContainer:309` is a clipboard-failure fallback. The actual published-artifact open affordances already use correct anchors with `target="_blank" rel="noopener noreferrer"`:

- `app/components/ProfileModal/PublishedArtifactsTabContent.tsx:219`
- `app/components/admin/PublishedArtifactsTab.tsx:225`
- the livery bar in the served wrapper, `pages/api/publish/serve/[...path].ts:1010`

Those open a tab in every browser including Safari. So the ten fixed sites are all real defects with a real cross-browser consequence, but **none of them explains a published artifact opening in a new window**, and I could not reproduce that specific symptom from the code. If the "click to open" that prompted this was one of the eight surfaces in the test guide above, it is fixed. If it was genuinely a published-artifact link, the cause is still unidentified and worth a follow-up with the exact button.
