### PR TITLE
fix(admin): rank the Spend tab's model/account facets by cost, not credits

### DIFF
--- a/apps/client/app/components/admin/ModelMetrics/components/SpendTab.test.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/components/SpendTab.test.tsx
@@ -60,6 +60,22 @@ describe('SpendTabView', () => {
     }
   });
 
+  it('scales model bars by cost, so a zero-credit cost leader draws the widest bar', () => {
+    // The payload arrives cost-descending (spendSummary ranks byModel on cogsUsd);
+    // the bars are drawn from estCost, so the list must read monotonically here.
+    const data: SpendData = {
+      ...spendMockData,
+      byModel: [
+        { modelId: 'p/embed', modelName: 'p / embed', estCost: 40, requests: 10, share: 0.8 },
+        { modelId: 'p/opus', modelName: 'p / opus', estCost: 10, requests: 2, share: 0.2 },
+      ],
+    };
+    render(<SpendTabView data={data} />, { wrapper: TestWrapper });
+
+    expect(screen.getByTestId('spend-model-bar-p/embed')).toHaveStyle({ width: '100%' });
+    expect(screen.getByTestId('spend-model-bar-p/opus')).toHaveStyle({ width: '25%' });
+  });
+
   it('colors a rising cost metric red (higherIsBetter=false) and a rising good metric green', () => {
     const data: SpendData = {
       ...spendMockData,

--- a/apps/client/app/components/admin/ModelMetrics/components/SpendTab.tsx
+++ b/apps/client/app/components/admin/ModelMetrics/components/SpendTab.tsx
@@ -210,6 +210,7 @@ export const SpendTabView: React.FC<SpendTabViewProps> = ({ data }) => {
                   }}
                 >
                   <Box
+                    data-testid={`spend-model-bar-${model.modelId}`}
                     sx={{
                       height: '100%',
                       borderRadius: 'sm',

--- a/b4m-core/common/src/types/entities/UsageEventTypes.ts
+++ b/b4m-core/common/src/types/entities/UsageEventTypes.ts
@@ -381,10 +381,11 @@ export interface ISpendStatusCounts {
 /**
  * One window's spend rolled up every way the admin Spend tab needs it, in a
  * single aggregation so all cuts reconcile against the same event set. `byModel`
- * and `byAccount` are descending by creditsCharged; `dailyCost` is ascending by
- * day. p50/p95 latency and status counts are not available from the margin
- * rollups, hence this dedicated summary. The API layer adds vs-prior deltas,
- * owner-name resolution, and the client SpendData shape on top.
+ * and `byAccount` are descending by cogsUsd (both are capped, and the tab ranks
+ * and truncates them by cost); `dailyCost` is ascending by day. p50/p95 latency
+ * and status counts are not available from the margin rollups, hence this
+ * dedicated summary. The API layer adds vs-prior deltas, owner-name resolution,
+ * and the client SpendData shape on top.
  */
 export interface ISpendSummary {
   totals: IUsageSpendBucket;

--- a/packages/database/src/models/billing/UsageEventModel.test.ts
+++ b/packages/database/src/models/billing/UsageEventModel.test.ts
@@ -589,7 +589,7 @@ describe('UsageEventRepository', () => {
       expect(summary.totals).toEqual({ requests: 3, cogsUsd: 4, creditsCharged: 400 });
       expect(summary.activeAccounts).toBe(2);
 
-      // Descending by creditsCharged: opus (300) before sonnet (100).
+      // Descending by cogsUsd: opus (3) before sonnet (1).
       expect(summary.byModel.map(m => m.model)).toEqual(['opus', 'sonnet']);
       expect(summary.byModel[0]).toMatchObject({ model: 'opus', requests: 2, cogsUsd: 3, creditsCharged: 300 });
 
@@ -605,6 +605,55 @@ describe('UsageEventRepository', () => {
       // Every event shares baseEvent's default createdAt day, so one daily bucket.
       expect(summary.dailyCost).toHaveLength(1);
       expect(summary.dailyCost[0].cogsUsd).toBe(4);
+    });
+
+    it('ranks both spend facets by cost, so a zero-credit cost driver leads', async () => {
+      // Embeds with enforcement off, abort settlements and media all settle a real
+      // costUsd with creditsCharged 0; a credit sort would bury this row last.
+      await record({
+        ownerId: 'org-embed',
+        ownerType: CreditHolderType.Organization,
+        model: 'titan-embed',
+        costUsd: 9,
+        creditsCharged: 0,
+      });
+      await record({
+        ownerId: 'org-chat',
+        ownerType: CreditHolderType.Organization,
+        model: 'opus',
+        costUsd: 1,
+        creditsCharged: 5000,
+      });
+
+      const summary = await usageEventRepository.spendSummary();
+
+      expect(summary.byModel.map(m => m.model)).toEqual(['titan-embed', 'opus']);
+      expect(summary.byAccount.map(a => a.ownerId)).toEqual(['org-embed', 'org-chat']);
+    });
+
+    it('keeps the top cost driver when the account cap truncates the list', async () => {
+      // 60 credit-heavy accounts whose cost is a rounding error, plus one zero-credit
+      // account that dominates cost: ranked by credits it lands past the cap and
+      // disappears from the one dashboard built to find it.
+      await Promise.all([
+        ...Array.from({ length: 60 }, (_, i) =>
+          record({
+            ownerId: `org-filler-${i}`,
+            ownerType: CreditHolderType.Organization,
+            costUsd: 0.01,
+            creditsCharged: 1000,
+          })
+        ),
+        record({ ownerId: 'org-embed', ownerType: CreditHolderType.Organization, costUsd: 50, creditsCharged: 0 }),
+      ]);
+
+      const summary = await usageEventRepository.spendSummary();
+
+      // Asserted against the account count rather than SPEND_ACCOUNT_LIMIT so
+      // retuning the cap doesn't break the test.
+      expect(summary.activeAccounts).toBe(61);
+      expect(summary.byAccount.length).toBeLessThan(61);
+      expect(summary.byAccount[0]).toMatchObject({ ownerId: 'org-embed', cogsUsd: 50, creditsCharged: 0 });
     });
 
     it('computes p50/p95 latency and error/timeout/refusal counts', async () => {

--- a/packages/database/src/models/billing/UsageEventModel.ts
+++ b/packages/database/src/models/billing/UsageEventModel.ts
@@ -264,16 +264,21 @@ export class UsageEventRepository extends BaseRepository<IUsageEventDocument> im
             },
           ],
           status: [{ $group: { _id: '$status', count: { $sum: 1 } } }],
+          // Both spend facets rank by cogsUsd, not creditsCharged like the sibling
+          // usage summaries below: this is a cost dashboard, and cost with zero
+          // credits is a normal path (embeds with enforcement off, abort
+          // settlements, media), so a credit sort would truncate away real top cost
+          // drivers. Secondary keys make the cap deterministic across equal-cost ties.
           byModel: [
             { $group: { _id: { provider: '$provider', model: '$model' }, ...spendSums } },
             { $project: { _id: 0, provider: '$_id.provider', model: '$_id.model', ...spendFields } },
-            { $sort: { creditsCharged: -1 } },
+            { $sort: { cogsUsd: -1, provider: 1, model: 1 } },
             { $limit: SPEND_MODEL_LIMIT },
           ],
           byAccount: [
             { $group: { _id: { ownerId: '$ownerId', ownerType: '$ownerType' }, ...spendSums } },
             { $project: { _id: 0, ownerId: '$_id.ownerId', ownerType: '$_id.ownerType', ...spendFields } },
-            { $sort: { creditsCharged: -1 } },
+            { $sort: { cogsUsd: -1, ownerId: 1 } },
             { $limit: SPEND_ACCOUNT_LIMIT },
           ],
           // Uncapped by design: one row per UTC day in the window feeds the line


### PR DESCRIPTION
# Pull Request

## Description

Fixes https://github.com/Bike4Mind/bike4mind/issues/1705

The admin Spend tab's `byModel` and `byAccount` facets were ordered and capped by
`creditsCharged`, but the tab ranks and draws both by **Est. Cost**. Cost with zero
credits is a normal path -- embeds with enforcement off, abort/disconnect settlements,
media generation -- so a genuine top cost driver could sort last and be truncated away
by the cap, invisible on the one dashboard built to find it. The "Cost by Model" bars
also came out visibly non-monotonic whenever the two rankings diverged, which reads as
a rendering bug.

Both spend facets now sort by `cogsUsd` before their `$limit`, so the cap keeps the real
top cost drivers and the bar list is monotonic. The sibling `ownerUsageSummary` /
`platformUsageSummary` / `sessionUsageSummary` facets stay credit-ordered on purpose --
those are credit/usage dashboards, not cost dashboards.

Ranking and truncation only. KPI totals and `dailyCost` sum the whole window and are
unchanged.

## Changes

- `UsageEventModel.spendSummary()`: `byModel` sorts `{ cogsUsd: -1, provider: 1, model: 1 }`
  and `byAccount` sorts `{ cogsUsd: -1, ownerId: 1 }`. The secondary keys make the cap
  deterministic when two rows tie on cost, so the truncation boundary can't flip between
  runs.
- Comment at the facet records why these two diverge from the sibling credit-ordered
  summaries, so the next reader doesn't "fix" them back.
- `ISpendSummary` doc updated to state cogsUsd ordering.
- Tests: a zero-credit/high-cost row leads both facets, and survives the account cap
  against 60 credit-heavy accounts; `SpendTab` bar widths are asserted proportional to
  `estCost` (needed a `data-testid` on the bar fill).
- No client re-sort was added -- the payload arrives cost-descending, and the existing
  "Showing top N of M accounts by spend" caption is accurate now that the cap selects by
  cost.

## Guide for Testers

<img width="1561" height="162" alt="Screenshot 2026-08-12 at 6 35 18 pm" src="https://github.com/user-attachments/assets/872c31ea-301b-49d0-89c4-1d593a1c27db" />


1. Go to `app.staging.bike4mind.com` and sign in as an admin.
2. Navigate: Sidebar -> Admin -> Model Metrics -> **Spend** tab.
3. Expected: the page loads with the KPI row, "Spend by Account", "Cost by Model", and
   "Daily Cost" sections, no error chip.
4. Read the **Cost by Model** section top to bottom. Expected: the `Est. Cost` values are
   in descending order and each bar is no wider than the one above it (a monotonically
   shrinking staircase).
5. Read the **Spend by Account** table's `Est. Cost` column top to bottom. Expected:
   descending. The `Credits` column may be out of order -- that is correct, the table is
   ranked by cost.
6. If the account section is titled "Top Spend by Account" with a "Showing top N of M
   accounts by spend" caption, expected: the highest-cost accounts are the ones listed,
   including any account whose `Credits` reads 0 but whose `Est. Cost` is large.
7. Change the date range in the filter bar and click Refresh. Expected: both sections
   reload and remain cost-descending.

### Regression Checks

1. Admin -> Model Metrics -> Overview / Analytics / Raw Data tabs still load unchanged.
2. Org usage dashboard (per-organization usage breakdowns) still lists members/models/
   features biggest-credits-first -- those facets were deliberately not changed.
3. Per-session usage detail still lists quests/models by credits.

### What NOT to test

The KPI cards and the Daily Cost line chart -- they sum the entire window and no code
path feeding them changed.

## Additional Information

The credit sort was inherited from the sibling usage summaries, which is why the two
looked consistent; the divergence only matters here because this tab is explicitly a
cost view.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
