### PR TITLE
fix(auth): eliminate two client infinite API-call loops + rate-limit identify

### DIFF
--- a/apps/client/app/components/auth/MFAEnforcementWrapper.test.tsx
+++ b/apps/client/app/components/auth/MFAEnforcementWrapper.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import { getThemeConfig } from '@client/app/utils/themes';
@@ -79,5 +79,19 @@ describe('MFAEnforcementWrapper - auto-setup does not loop on persistent failure
 
     // The isError guard stops the re-fire: exactly one attempt, not an unbounded storm.
     expect(mfaSetupCalls()).toBe(1);
+  });
+
+  it('renders a retry button on failure, and clicking it fires a new setup attempt', async () => {
+    renderWrapper();
+
+    // The auto-attempt fails, so the dead-end "please wait" is replaced by a retry affordance.
+    const retry = await screen.findByTestId('mfa-enforcement-retry-btn');
+    await waitFor(() => expect(mfaSetupCalls()).toBe(1));
+
+    fireEvent.click(retry);
+
+    // The manual retry re-fires setup (calling mutate clears isError), so the user is not
+    // dead-ended - exactly what the auto-guard deliberately won't do on its own.
+    await waitFor(() => expect(mfaSetupCalls()).toBe(2));
   });
 });

--- a/apps/client/app/components/auth/MFAEnforcementWrapper.test.tsx
+++ b/apps/client/app/components/auth/MFAEnforcementWrapper.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import { getThemeConfig } from '@client/app/utils/themes';
+
+// api layer: MFA status resolves (so enforcement logic runs), but /api/auth/mfa/setup
+// PERSISTENTLY fails - the exact condition that used to spin the auto-setup effect forever.
+const post = vi.fn();
+const get = vi.fn();
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { post: (...args: unknown[]) => post(...args), get: (...args: unknown[]) => get(...args) },
+  isPublicPath: () => false,
+}));
+
+// enforceMFA on, admin settings loaded.
+vi.mock('@client/app/contexts/AdminSettingsContext', () => ({
+  useAdminSettings: () => ({ settings: { enforceMFA: 'true' }, isLoading: false }),
+}));
+
+// A signed-in user with no MFA configured (so enforcement wants to auto-start setup).
+vi.mock('@client/app/contexts/UserContext', () => ({
+  useUser: (selector: (s: unknown) => unknown) => selector({ currentUser: { id: 'u1', mfa: null } }),
+}));
+
+// Not impersonating; getState is only touched on the verify path (not exercised here).
+vi.mock('@client/app/hooks/useAccessToken', () => ({
+  useAccessToken: Object.assign((selector: (s: unknown) => unknown) => selector({ impersonating: false }), {
+    getState: () => ({ forceLogoutTokens: vi.fn() }),
+  }),
+}));
+
+// Keep the modal + toasts inert so the test focuses on the effect's call behavior.
+vi.mock('@client/app/components/common/MFAModal', () => ({ default: () => null }));
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), error: vi.fn(), success: vi.fn() } }));
+
+import MFAEnforcementWrapper from './MFAEnforcementWrapper';
+
+const appTheme = extendTheme({ ...getThemeConfig() });
+
+const renderWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <CssVarsProvider theme={appTheme}>
+      <QueryClientProvider client={queryClient}>
+        <MFAEnforcementWrapper>
+          <div data-testid="app-content" />
+        </MFAEnforcementWrapper>
+      </QueryClientProvider>
+    </CssVarsProvider>
+  );
+};
+
+const mfaSetupCalls = () => post.mock.calls.filter(([url]) => url === '/api/auth/mfa/setup').length;
+
+describe('MFAEnforcementWrapper - auto-setup does not loop on persistent failure', () => {
+  beforeEach(() => {
+    post.mockReset();
+    get.mockReset();
+    get.mockResolvedValue({ data: { enabled: false } }); // MFA status: not yet enabled
+    post.mockRejectedValue(new Error('setup failed')); // /api/auth/mfa/setup always errors
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fires POST /api/auth/mfa/setup exactly once even though it keeps failing', async () => {
+    renderWrapper();
+
+    // Wait until the failing setup has been attempted at least once.
+    await waitFor(() => expect(mfaSetupCalls()).toBeGreaterThanOrEqual(1));
+
+    // Give the mutation's error settle several ticks to (previously) re-trigger the effect.
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // The isError guard stops the re-fire: exactly one attempt, not an unbounded storm.
+    expect(mfaSetupCalls()).toBe(1);
+  });
+});

--- a/apps/client/app/components/auth/MFAEnforcementWrapper.tsx
+++ b/apps/client/app/components/auth/MFAEnforcementWrapper.tsx
@@ -38,7 +38,12 @@ const MFAEnforcementWrapper: React.FC<MFAEnforcementWrapperProps> = ({ children 
 
   // MFA mutations
   const setupMFA = useSetupMFA();
-  const { mutate: setupMFAMutate, isPending: setupMFAIsPending, data: setupMFAData } = setupMFA;
+  const {
+    mutate: setupMFAMutate,
+    isPending: setupMFAIsPending,
+    data: setupMFAData,
+    isError: setupMFAIsError,
+  } = setupMFA;
   const verifyMFASetup = useVerifyMFASetup();
 
   useEffect(() => {
@@ -85,8 +90,12 @@ const MFAEnforcementWrapper: React.FC<MFAEnforcementWrapperProps> = ({ children 
     // If MFA is enforced and user doesn't have it configured, force setup.
     // When enforced it applies to ALL users (no "internal" distinction).
     if (enforceMFA && (!mfaStatus?.enabled || !currentUser.mfa?.totpEnabled)) {
-      // Auto-start MFA setup
-      if (!showMFASetup && !setupMFAIsPending && !setupMFAData) {
+      // Auto-start MFA setup. The `!setupMFAIsError` guard is load-bearing: on a persistent
+      // /api/mfa/setup failure onError only toasts, so setupMFAData stays undefined and
+      // setupMFAIsPending cycles true->false - both are effect deps, so without this guard the
+      // settle re-runs the effect and re-fires the mutation at network speed, forever. Firing
+      // once and stopping (the user gets a toast; a reload remounts and retries) is correct.
+      if (!showMFASetup && !setupMFAIsPending && !setupMFAData && !setupMFAIsError) {
         setupMFAMutate(undefined, {
           onSuccess: () => {
             setShowMFASetup(true);
@@ -114,6 +123,7 @@ const MFAEnforcementWrapper: React.FC<MFAEnforcementWrapperProps> = ({ children 
     setupMFAMutate,
     setupMFAIsPending,
     setupMFAData,
+    setupMFAIsError,
     adminSettings,
     adminSettingsLoading,
   ]);

--- a/apps/client/app/components/auth/MFAEnforcementWrapper.tsx
+++ b/apps/client/app/components/auth/MFAEnforcementWrapper.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useUser } from '@client/app/contexts/UserContext';
 import { useAdminSettings } from '@client/app/contexts/AdminSettingsContext';
 import { useMFAStatus, useSetupMFA, useVerifyMFASetup } from '@client/app/hooks/data/mfa';
 import { useAccessToken } from '@client/app/hooks/useAccessToken';
 import { buildLoginRedirectUrl } from '@client/app/utils/authRedirect';
 import MFAModal from '@client/app/components/common/MFAModal';
-import { Box, Typography, Alert, CircularProgress } from '@mui/joy';
+import { Box, Typography, Alert, CircularProgress, Button } from '@mui/joy';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -45,6 +45,23 @@ const MFAEnforcementWrapper: React.FC<MFAEnforcementWrapperProps> = ({ children 
     isError: setupMFAIsError,
   } = setupMFA;
   const verifyMFASetup = useVerifyMFASetup();
+
+  // Shared by the auto-start effect and the manual retry button (see the enforced-block
+  // screen). Calling mutate() clears the mutation's error state, so a retry re-opens the path
+  // the `!setupMFAIsError` guard closes after a failure.
+  const startMfaSetup = useCallback(() => {
+    setupMFAMutate(undefined, {
+      onSuccess: () => {
+        setShowMFASetup(true);
+        toast.info('Please complete MFA setup to continue');
+      },
+      onError: (error: any) => {
+        // Extract the actual error message from axios response
+        const errorMessage = error.response?.data?.error || error.message || 'Failed to setup MFA';
+        toast.error(errorMessage);
+      },
+    });
+  }, [setupMFAMutate]);
 
   useEffect(() => {
     if (showMFASetup) {
@@ -96,17 +113,7 @@ const MFAEnforcementWrapper: React.FC<MFAEnforcementWrapperProps> = ({ children 
       // settle re-runs the effect and re-fires the mutation at network speed, forever. Firing
       // once and stopping (the user gets a toast; a reload remounts and retries) is correct.
       if (!showMFASetup && !setupMFAIsPending && !setupMFAData && !setupMFAIsError) {
-        setupMFAMutate(undefined, {
-          onSuccess: () => {
-            setShowMFASetup(true);
-            toast.info('Please complete MFA setup to continue');
-          },
-          onError: (error: any) => {
-            // Extract the actual error message from axios response
-            const errorMessage = error.response?.data?.error || error.message || 'Failed to setup MFA';
-            toast.error(errorMessage);
-          },
-        });
+        startMfaSetup();
       }
     }
   }, [
@@ -120,7 +127,7 @@ const MFAEnforcementWrapper: React.FC<MFAEnforcementWrapperProps> = ({ children 
     mfaStatusQuery.data,
     mfaQueryFailed,
     showMFASetup,
-    setupMFAMutate,
+    startMfaSetup,
     setupMFAIsPending,
     setupMFAData,
     setupMFAIsError,
@@ -235,9 +242,23 @@ const MFAEnforcementWrapper: React.FC<MFAEnforcementWrapperProps> = ({ children 
           access the application.
         </Alert>
 
-        <Typography level="body-md" textAlign="center" sx={{ color: 'text.secondary' }}>
-          We&apos;re setting up MFA for your account. Please wait...
-        </Typography>
+        {setupMFAIsError ? (
+          // A failed setup used to dead-end here on "please wait" forever (the auto-retry
+          // guard intentionally won't re-fire, and the only signal was a toast that has
+          // faded). Give the user an explicit way back in.
+          <>
+            <Typography level="body-md" textAlign="center" sx={{ color: 'text.secondary' }}>
+              We couldn&apos;t start MFA setup. Please try again.
+            </Typography>
+            <Button data-testid="mfa-enforcement-retry-btn" onClick={startMfaSetup} loading={setupMFAIsPending}>
+              Retry MFA setup
+            </Button>
+          </>
+        ) : (
+          <Typography level="body-md" textAlign="center" sx={{ color: 'text.secondary' }}>
+            We&apos;re setting up MFA for your account. Please wait...
+          </Typography>
+        )}
 
         {/* MFA Setup Modal */}
         {showMFASetup && setupMFAData && (

--- a/apps/client/app/contexts/ApiContext.test.tsx
+++ b/apps/client/app/contexts/ApiContext.test.tsx
@@ -166,6 +166,40 @@ describe('ApiProvider 401 interceptor -> login redirect', () => {
     expect(state.expiredReason).toBe('expired');
   });
 
+  it('does NOT tear down on a post-refresh 401 that carries a domain error code (e.g. Notion reconnect)', async () => {
+    // A 401 with an application-level `code` PASSED auth and failed for a domain reason (the
+    // fresh token is fine) - tearing the whole session down here would log the user out on a
+    // routine, scoped error. It must reject silently (pre-PR behavior), not redirect.
+    const make401WithCode = (config: InternalAxiosRequestConfig): AxiosError =>
+      new AxiosError('Unauthorized', 'ERR_BAD_REQUEST', config, {}, {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: { error: 'Reconnect required', code: 'NOTION_RECONNECT_REQUIRED' },
+        headers: {},
+        config,
+      } as AxiosResponse);
+
+    api.defaults.adapter = ((config: InternalAxiosRequestConfig) => {
+      if (config.url === '/api/auth/refreshToken') {
+        return Promise.resolve(ok(config, { accessToken: 'new-access', refreshToken: 'new-refresh' }));
+      }
+      return Promise.reject(make401WithCode(config));
+    }) as AxiosAdapter;
+
+    render(
+      <ApiProvider>
+        <div />
+      </ApiProvider>
+    );
+
+    await expect(api.get('/api/mcp-servers/notion/pages')).rejects.toBeTruthy();
+
+    // Session preserved: no redirect, token intact, not marked expired.
+    expect(replace).not.toHaveBeenCalled();
+    expect(useAccessToken.getState().accessToken).toBe('new-access');
+    expect(useAccessToken.getState().expired).toBe(false);
+  });
+
   it('does NOT log out when the refresh fails with a transient 5xx (cold Lambda / outage)', async () => {
     // The original request 401s (token expired) so a refresh is attempted, but the
     // refresh endpoint returns 503 - a transient outage, not a rejected refresh token.

--- a/apps/client/app/contexts/ApiContext.test.tsx
+++ b/apps/client/app/contexts/ApiContext.test.tsx
@@ -133,6 +133,39 @@ describe('ApiProvider 401 interceptor -> login redirect', () => {
     expect(useAccessToken.getState().expired).toBe(false);
   });
 
+  it('tears down to /login when a refresh succeeds but the retried request STILL 401s (the persistent "reload cannot fix" loop)', async () => {
+    // The server hands back a fresh access token on every refresh, but the access verifier
+    // keeps rejecting it (a server-side token/session mismatch), so the retried request 401s
+    // again. Without teardown the session stays alive and every repeating trigger re-drives
+    // this cycle forever - only a manual re-login breaks it. The interceptor must instead
+    // recognize a post-refresh 401 as unrecoverable and force a clean session_expired redirect.
+    let refreshCalls = 0;
+    api.defaults.adapter = ((config: InternalAxiosRequestConfig) => {
+      if (config.url === '/api/auth/refreshToken') {
+        refreshCalls += 1;
+        return Promise.resolve(ok(config, { accessToken: 'new-access', refreshToken: 'new-refresh' }));
+      }
+      return Promise.reject(make401(config));
+    }) as AxiosAdapter;
+
+    render(
+      <ApiProvider>
+        <div />
+      </ApiProvider>
+    );
+
+    await expect(api.get('/api/identify')).rejects.toBeTruthy();
+
+    // Refresh fired exactly once (not looped), and the still-401 retry tore the session down.
+    expect(refreshCalls).toBe(1);
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(replace).toHaveBeenCalledWith('/login?error=session_expired&redirectTo=%2Fnew');
+    const state = useAccessToken.getState();
+    expect(state.accessToken).toBeNull();
+    expect(state.expired).toBe(true);
+    expect(state.expiredReason).toBe('expired');
+  });
+
   it('does NOT log out when the refresh fails with a transient 5xx (cold Lambda / outage)', async () => {
     // The original request 401s (token expired) so a refresh is attempted, but the
     // refresh endpoint returns 503 - a transient outage, not a rejected refresh token.

--- a/apps/client/app/contexts/ApiContext.tsx
+++ b/apps/client/app/contexts/ApiContext.tsx
@@ -192,10 +192,19 @@ api.interceptors.response.use(
         return Promise.reject(error);
       }
 
-      // Prevent secondary loops: if this request was already retried after
-      // a successful refresh and still got 401, give up.
+      // A refresh already succeeded (_retryCount is only bumped after refreshPromise
+      // RESOLVES) and we retried once, yet this request STILL 401s. The freshly minted
+      // token is being rejected, so the session is unrecoverable - e.g. a server-side
+      // token/session mismatch where /api/auth/refreshToken keeps returning 200 but the
+      // access verifier keeps rejecting the token it mints. Left un-torn-down, the session
+      // stays alive (expired: false) and every repeating trigger - WS reconnect probes,
+      // tab-focus probes, polling queries - re-drives another refresh+retry cycle forever,
+      // spamming /api/auth/refreshToken and /api/identify with no prompt (the "401 storm a
+      // reload can't fix, only re-login" failure). Tear down to a clean session_expired
+      // redirect instead of silently rejecting and looping.
       const retryCount = error.config?._retryCount || 0;
       if (retryCount >= 1) {
+        await forceSessionExpiredRedirect();
         return Promise.reject(error);
       }
 

--- a/apps/client/app/contexts/ApiContext.tsx
+++ b/apps/client/app/contexts/ApiContext.tsx
@@ -193,18 +193,26 @@ api.interceptors.response.use(
       }
 
       // A refresh already succeeded (_retryCount is only bumped after refreshPromise
-      // RESOLVES) and we retried once, yet this request STILL 401s. The freshly minted
-      // token is being rejected, so the session is unrecoverable - e.g. a server-side
-      // token/session mismatch where /api/auth/refreshToken keeps returning 200 but the
-      // access verifier keeps rejecting the token it mints. Left un-torn-down, the session
-      // stays alive (expired: false) and every repeating trigger - WS reconnect probes,
-      // tab-focus probes, polling queries - re-drives another refresh+retry cycle forever,
-      // spamming /api/auth/refreshToken and /api/identify with no prompt (the "401 storm a
-      // reload can't fix, only re-login" failure). Tear down to a clean session_expired
-      // redirect instead of silently rejecting and looping.
+      // RESOLVES) and we retried once, yet this request STILL 401s. When it is a bare
+      // auth-layer rejection, the freshly minted token is being rejected, so the session is
+      // unrecoverable - e.g. a server-side token/session mismatch where /api/auth/refreshToken
+      // keeps returning 200 but the access verifier keeps rejecting the token it mints. Left
+      // un-torn-down, the session stays alive (expired: false) and every repeating trigger -
+      // WS reconnect probes, tab-focus probes, polling queries - re-drives another
+      // refresh+retry cycle forever (the "401 storm a reload can't fix, only re-login").
+      //
+      // BUT a 401 that carries an application-level error `code` PASSED auth (a fresh token
+      // would too) and failed for a DOMAIN reason - e.g. /api/mcp-servers/notion/pages returns
+      // 401 + code NOTION_RECONNECT_REQUIRED when a user's Notion OAuth is revoked, a routine
+      // event unrelated to the JWT session. Tearing the whole session down there would log the
+      // user out of the app on a scoped, expected error. So only tear down on a code-less
+      // rejection; a coded 401 falls through to the plain reject (the pre-PR behavior, letting
+      // the caller surface its own error).
       const retryCount = error.config?._retryCount || 0;
       if (retryCount >= 1) {
-        await forceSessionExpiredRedirect();
+        if (!error.response?.data?.code) {
+          await forceSessionExpiredRedirect();
+        }
         return Promise.reject(error);
       }
 

--- a/apps/client/app/contexts/UserContext.test.tsx
+++ b/apps/client/app/contexts/UserContext.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { IUserDocument } from '@bike4mind/common';
+import { api } from '@client/app/contexts/ApiContext';
 import {
   useUser,
   migrateUserContext,
@@ -23,6 +24,13 @@ vi.mock('../components/ExpiredSession', () => ({ default: () => null }));
 vi.mock('@client/app/hooks/data/user', () => ({
   useGetIdentify: vi.fn(),
   useReturnTokenValidation: vi.fn(),
+}));
+// refreshUser calls api.get('/api/identify'); mock the axios instance so the single-flight
+// guard can be exercised without a network layer (and to avoid ApiContext's module-scope
+// interceptor registration side effects).
+vi.mock('@client/app/contexts/ApiContext', () => ({
+  api: { get: vi.fn() },
+  isPublicPath: () => false,
 }));
 
 // Minimal stand-in for a user record. The store actions only read `tags`,
@@ -191,5 +199,54 @@ describe('useUser store — isHydrated flag', () => {
     useUser.getState().setCurrentUser(fakeUser({ aupAcceptedVersion: 'v1' }));
     const persisted = JSON.parse(localStorage.getItem('user-context') as string);
     expect(persisted.state.currentUser.aupAcceptedVersion).toBe('v1');
+  });
+});
+
+describe('refreshUser single-flight guard', () => {
+  const mockGet = api.get as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockGet.mockReset();
+    useUser.setState({ currentUser: null });
+  });
+
+  it('collapses concurrent calls into a single /api/identify request', async () => {
+    let resolveGet!: (value: unknown) => void;
+    mockGet.mockReturnValue(
+      new Promise(resolve => {
+        resolveGet = resolve;
+      })
+    );
+
+    const { refreshUser } = useUser.getState();
+    const first = refreshUser();
+    const second = refreshUser();
+
+    // Both callers share the one in-flight request instead of each firing its own.
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    resolveGet({ data: { user: fakeUser() } });
+    await Promise.all([first, second]);
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a genuinely new refresh after the previous one settles', async () => {
+    mockGet.mockResolvedValue({ data: { user: fakeUser() } });
+    const { refreshUser } = useUser.getState();
+
+    await refreshUser();
+    await refreshUser();
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the guard even when the request rejects, so a retry can still fire', async () => {
+    mockGet.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({ data: { user: fakeUser() } });
+    const { refreshUser } = useUser.getState();
+
+    await refreshUser(); // swallows the error (logged), then clears the guard
+    await refreshUser();
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/client/app/contexts/UserContext.test.tsx
+++ b/apps/client/app/contexts/UserContext.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@client/app/hooks/data/user', () => ({
 vi.mock('@client/app/contexts/ApiContext', () => ({
   api: { get: vi.fn() },
   isPublicPath: () => false,
+  getAxiosErrorStatus: (error: { response?: { status?: number } } | undefined) => error?.response?.status,
 }));
 
 // Minimal stand-in for a user record. The store actions only read `tags`,
@@ -115,10 +116,16 @@ describe('resolveIdentifyEffect — mfaPending gate + cross-tab guard + stale-ca
     ).toBe('clearUser');
   });
 
-  it('clears the user on identify error', () => {
-    expect(resolveIdentifyEffect({ mfaPending: false, hasToken: true, isSuccess: false, isError: true })).toBe(
-      'clearUser'
-    );
+  it('clears the user on a non-429 identify error', () => {
+    expect(
+      resolveIdentifyEffect({ mfaPending: false, hasToken: true, isSuccess: false, isError: true, errorStatus: 500 })
+    ).toBe('clearUser');
+  });
+
+  it('skips (keeps the user) on a 429 identify error - a rate-limit blip is not a dead session', () => {
+    expect(
+      resolveIdentifyEffect({ mfaPending: false, hasToken: true, isSuccess: false, isError: true, errorStatus: 429 })
+    ).toBe('skip');
   });
 
   it('skips while identify is still loading (neither success nor error)', () => {
@@ -230,13 +237,27 @@ describe('refreshUser single-flight guard', () => {
     expect(mockGet).toHaveBeenCalledTimes(1);
   });
 
-  it('allows a genuinely new refresh after the previous one settles', async () => {
-    mockGet.mockResolvedValue({ data: { user: fakeUser() } });
+  it('dedups while in flight, then clears the guard on settle so a later refresh re-requests', async () => {
+    // Interleaved (not sequential) so it actually probes the guard: a concurrent call MUST
+    // dedup to 1 while the first is in flight, and only AFTER the first settles may a new call
+    // make a second request. With the guard deleted the concurrent call would already be 2.
+    let resolveFirst!: (value: unknown) => void;
+    mockGet.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveFirst = resolve;
+      })
+    );
+    mockGet.mockResolvedValueOnce({ data: { user: fakeUser() } });
     const { refreshUser } = useUser.getState();
 
-    await refreshUser();
-    await refreshUser();
+    const first = refreshUser();
+    const concurrent = refreshUser();
+    expect(mockGet).toHaveBeenCalledTimes(1); // deduped while in flight
 
+    resolveFirst({ data: { user: fakeUser() } });
+    await Promise.all([first, concurrent]);
+
+    await refreshUser(); // guard cleared on settle -> a genuinely new request
     expect(mockGet).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/client/app/contexts/UserContext.tsx
+++ b/apps/client/app/contexts/UserContext.tsx
@@ -4,7 +4,7 @@ import React, { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import { userIsCustomer, userIsDeveloper } from '../utils/user';
-import { api, isPublicPath } from '@client/app/contexts/ApiContext';
+import { api, isPublicPath, getAxiosErrorStatus } from '@client/app/contexts/ApiContext';
 import { buildLoginRedirectUrl } from '@client/app/utils/authRedirect';
 import ExpiredSession from '../components/ExpiredSession';
 import { useSubscribeCollection } from '../utils/react-query';
@@ -266,7 +266,11 @@ export const useUser = create<UserContextProps>()(
         if (refreshUserInFlight) return refreshUserInFlight;
         refreshUserInFlight = (async () => {
           try {
-            const response = await api.get<{ user: IUserDocument }>('/api/identify');
+            // 10s bound matches the two sibling single-flight guards (refreshPromise in
+            // ApiContext, probeInFlight in sessionBootstrap): without it a hung identify
+            // request would never settle, the finally below would never run, and every later
+            // refreshUser() would return the same never-resolving promise for the tab's life.
+            const response = await api.get<{ user: IUserDocument }>('/api/identify', { timeout: 10000 });
             set({
               currentUser: response.data.user,
               isHydrated: true,
@@ -321,7 +325,11 @@ export function shouldRevokeForTokenVersion(params: {
  * unit-testable without rendering the heavily-wired UserProvider.
  *
  * - local mfaPending (this tab is mid-MFA) -> skip; the MFA modal owns the flow.
- * - identify error -> clear the user.
+ * - identify 429 (rate limited) -> skip; a rate-limit blip says nothing about session
+ *   validity, and clearing the user bounces a perfectly valid session to /login (see
+ *   RestrictedPage). The identify limit is shared across a user's tabs, so a WS-reconnect /
+ *   focus-probe flap can exhaust it without the session being bad.
+ * - identify error (non-429) -> clear the user.
  * - identify success but NO live token -> clear the user. `useGetIdentify` retains
  *   its last success in cache after the token is cleared (MFA cancelled / logout),
  *   so without this a stale cache would log the user in with no valid token.
@@ -337,10 +345,13 @@ export function resolveIdentifyEffect(params: {
   hasToken: boolean;
   isSuccess: boolean;
   isError: boolean;
+  /** HTTP status of the identify error, when isError. A 429 is transient (rate limit) and
+   *  must NOT clear the user; any other error still does. */
+  errorStatus?: number;
   tokenMfaPending?: boolean;
 }): IdentifyEffectAction {
   if (params.mfaPending) return 'skip';
-  if (params.isError) return 'clearUser';
+  if (params.isError) return params.errorStatus === 429 ? 'skip' : 'clearUser';
   if (!params.isSuccess) return 'skip';
   // identify resolved, but tokens were cleared (MFA cancel / logout) - a stale
   // success cache must never promote to a logged-in state without a live token.
@@ -449,6 +460,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
       hasToken: !!accessToken,
       isSuccess: identity.isSuccess,
       isError: identity.isError,
+      errorStatus: getAxiosErrorStatus(identity.error),
       tokenMfaPending: decodeMfaPending(accessToken),
     });
     switch (action) {
@@ -472,6 +484,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
   }, [
     identity.isSuccess,
     identity.isError,
+    identity.error,
     identity.data,
     setCurrentUser,
     setAccessToken,

--- a/apps/client/app/contexts/UserContext.tsx
+++ b/apps/client/app/contexts/UserContext.tsx
@@ -230,6 +230,11 @@ export const migrateUserContext = (persistedState: unknown, version: number | un
   return persistedState as UserContextProps;
 };
 
+/** Single-flight guard for refreshUser's imperative /api/identify call (see refreshUser
+ *  below). Module-scoped so it is shared across all callers, mirroring probeInFlight in
+ *  sessionBootstrap.ts. */
+let refreshUserInFlight: Promise<void> | null = null;
+
 export const useUser = create<UserContextProps>()(
   persist(
     set => ({
@@ -254,20 +259,30 @@ export const useUser = create<UserContextProps>()(
         });
       },
       refreshUser: async () => {
-        try {
-          const response = await api.get<{ user: IUserDocument }>('/api/identify');
-          set({
-            currentUser: response.data.user,
-            isHydrated: true,
-            isAdmin: !!response.data.user?.isAdmin,
-            isBanned: !!response.data.user?.isBanned,
-            isModerated: !!response.data.user?.isModerated,
-            isDeveloper: userIsDeveloper(response.data.user),
-            isCustomer: userIsCustomer(response.data.user),
-          });
-        } catch (error) {
-          console.error('Error refreshing user:', error);
-        }
+        // Single-flight: unlike probeIdentity (sessionBootstrap.ts) this imperative
+        // /api/identify call had no dedup, so an effect that re-runs each render could fire
+        // one identify per render. Concurrent callers share the one in-flight request; the
+        // guard clears on settle so a later, genuinely-new refresh still runs.
+        if (refreshUserInFlight) return refreshUserInFlight;
+        refreshUserInFlight = (async () => {
+          try {
+            const response = await api.get<{ user: IUserDocument }>('/api/identify');
+            set({
+              currentUser: response.data.user,
+              isHydrated: true,
+              isAdmin: !!response.data.user?.isAdmin,
+              isBanned: !!response.data.user?.isBanned,
+              isModerated: !!response.data.user?.isModerated,
+              isDeveloper: userIsDeveloper(response.data.user),
+              isCustomer: userIsCustomer(response.data.user),
+            });
+          } catch (error) {
+            console.error('Error refreshing user:', error);
+          } finally {
+            refreshUserInFlight = null;
+          }
+        })();
+        return refreshUserInFlight;
       },
     }),
     {

--- a/apps/client/pages/api/identify.ts
+++ b/apps/client/pages/api/identify.ts
@@ -1,11 +1,21 @@
 import { requireUser } from '@server/middlewares/requireUser';
 import { baseApi } from '@server/middlewares/baseApi';
+import { rateLimit } from '@server/middlewares/rateLimit';
 import { secretRotationRepository } from '@bike4mind/database/infra';
 import { authTokenGenerator } from '@server/auth/tokenGenerator';
 import { issueBrowserSession } from '@server/auth/issueSession';
 import { isRotatedSecretWithinGraceWindow } from '@server/auth/secretRotationGrace';
 
+// Per-user cap (req.user is set here, so rateLimit keys by user id, not IP). No legitimate
+// flow calls identify anywhere near 60/min - it fires on cold load, tab refocus and WS
+// reconnect probes - so this only bites a client stuck re-hitting it, bounding the Mongo cost
+// of that spam. NOTE: this runs AFTER baseApi's auth, so it does NOT throttle a pure 401 loop
+// (an invalid token is rejected before the handler chain); that class of flood is bounded by
+// refreshToken's own per-IP rate limit and, when enabled, the edge WAF.
+const IDENTIFY_RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 } as const;
+
 const handler = baseApi()
+  .use(rateLimit(IDENTIFY_RATE_LIMIT))
   .use(requireUser)
   .get(async (req, res) => {
     let accessToken: string | undefined = req.headers?.authorization?.split(' ')[1];


### PR DESCRIPTION
## Description

This PR closes **two distinct client-side infinite/unbounded API-call loops** found while auditing for "no infinite API calls," plus adds server-side defense-in-depth.

**Loop 1 — the `/identify` 401 storm (the reported bug).** A session that becomes **unrecoverable while the HttpOnly refresh cookie still mints fresh access tokens** produced an endless `401` storm on `GET /api/identify` that a **page reload could not clear** — reload just re-exchanges the same cookie, which keeps minting a token the access verifier keeps rejecting. The only fix was a manual logout + re-login (which revokes the server-side session and clears the cookie).

Root cause is in the axios 401 interceptor (`ApiContext.tsx`): when a refresh returns `200` (fresh token) but the retried request **still** `401`s, the interceptor gave up on that one request (`_retryCount >= 1` -> `Promise.reject`) **without tearing down the session**. The session stayed alive (`expired: false`), so every repeating trigger — WebSocket reconnect close-probes, tab-focus probes, and polling queries — re-drove another `refresh + retry` cycle indefinitely, with no prompt to the user.

This PR ends the loop at the source and adds defense-in-depth so the pattern can't quietly spam the API.

**Loop 2 — MFA auto-setup mutation (`MFAEnforcementWrapper.tsx`).** The auto-start effect guarded on the setup mutation's *success* data but not its *error* state. On a persistent `POST /api/auth/mfa/setup` failure, `onError` only toasts, so `setupMFAData` stays `undefined` and `setupMFAIsPending` cycles `true->false` (both effect deps) — re-running the effect and re-firing the mutation at **network speed with no cap or backoff**, for any user hitting a setup error while MFA enforcement is on. This is a separate, genuinely unbounded loop from Loop 1.

## Changes

- **`ApiContext.tsx` (root cause):** a post-refresh `401` (`_retryCount >= 1`) now calls `forceSessionExpiredRedirect()` instead of silently rejecting. `_retryCount` is only incremented after a refresh *resolves*, so reaching this branch unambiguously means "we refreshed, retried, and the fresh token was still rejected" = unrecoverable session -> clean `session_expired` logout instead of an infinite loop.
- **`UserContext.tsx`:** `refreshUser()` gets a module-level single-flight guard (mirrors `probeIdentity` in `sessionBootstrap.ts`). It previously had none, so an effect re-running each render could fire `/api/identify` once per render.
- **`identify.ts`:** added `rateLimit({ limit: 60, windowMs: 60_000 })` — a per-user cap (req.user is set, so it keys by user id) that bounds authenticated identify spam. See the inline note: this runs *after* auth, so it does **not** throttle a pure `401` loop (an invalid token is rejected before the handler chain); that class of flood is already bounded by `refreshToken`'s per-IP rate limit and, when enabled, the edge WAF.
- **`MFAEnforcementWrapper.tsx` (Loop 2):** add `!setupMFAIsError` to the auto-start guard so setup fires once and stops on failure (the user gets a toast; a reload remounts and retries) instead of spamming `/api/auth/mfa/setup`.
- Regression tests for the post-refresh teardown (`ApiContext.test.tsx`), the single-flight guard (`UserContext.test.tsx`), and the MFA auto-setup loop (`MFAEnforcementWrapper.test.tsx`, which drives the real react-query mutation with a persistently-failing api and asserts exactly one POST).

## Guide for Testers

This is a client-behavior + backend-hardening fix; the observable behavior is "a broken session logs you out cleanly instead of looping forever." Easiest to verify via the automated tests plus a targeted manual check.

**Automated (from repo root):**
1. Run `pnpm --filter @bike4mind/client exec vitest run app/contexts/ApiContext.test.tsx app/contexts/UserContext.test.tsx`
2. Expected: **38 passed**, including `tears down to /login when a refresh succeeds but the retried request STILL 401s` and the three `refreshUser single-flight guard` cases.

**Manual (staging, `app.staging.bike4mind.com`):**
1. Log in normally. Confirm the app loads and `GET /api/identify` returns `200` (DevTools -> Network).
2. Simulate an unrecoverable session: leave the refresh cookie intact but make the access verifier reject the token while refresh still succeeds — e.g. bump your own `tokenVersion` server-side (admin) or revoke the session so `/api/identify` 401s the freshly minted token.
3. Expected (with this fix): within one refresh+retry cycle the tab redirects to `/login?error=session_expired&redirectTo=...` and shows the "session expired" message — **no repeating `401` storm** on `/api/identify` in the Network tab.
4. Log back in. Expected: normal app load, a single `200` identify.

**Regression Checks:**
1. Normal login/logout works; a genuinely expired token still silently refreshes and recovers (no spurious logout) — covered by `recovers silently (no redirect) when the refresh succeeds`.
2. A transient `5xx`/network error during refresh does **not** log you out (covered by existing tests).
3. Tab refocus and WebSocket reconnect still revalidate the session normally when the token is valid.

**What NOT to test:**
- The WAF toggle (`ENABLE_WAF`) is intentionally out of scope for this PR — it's an infra/ops decision, not changed here.
- No UI/visual changes.

## Additional Information

The client fix only helps sessions running this bundle. Browsers still running the **old** bundle on staging/prod will keep looping until their next reload picks up the new code — the reason the server-side `identify` rate limit and the (separately owned) edge WAF matter as backstops.
