### PR TITLE
feat(entitlements): register datalake: as a known entitlement key family

### DIFF
--- a/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
+++ b/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
@@ -437,7 +437,10 @@ export default function PartnerSignupRulesTab() {
 
       {/* Create / edit modal */}
       <Modal open={modalOpen} onClose={() => setModalOpen(false)}>
-        <ModalDialog sx={{ minWidth: 440, maxWidth: 540 }} data-testid="partner-rule-modal">
+        <ModalDialog
+          sx={{ minWidth: 440, maxWidth: 540, maxHeight: '90vh', overflowY: 'auto' }}
+          data-testid="partner-rule-modal"
+        >
           <ModalClose />
           <Typography level="h4">{editing ? 'Edit signup rule' : 'Add signup rule'}</Typography>
           <Typography level="body-sm" sx={{ color: 'text.tertiary', mt: -0.5 }}>
@@ -485,9 +488,14 @@ export default function PartnerSignupRulesTab() {
                 data-testid="partner-rule-entitlements-input"
               />
               <FormHelperText>
-                Pick from the products the registry recognizes, or type a lake grant as{' '}
-                <code>datalake:&lt;slug&gt;</code> and press Enter. A new product key must be added to the entitlement
-                registry before it appears in the list.
+                {/* FormHelperText's root is flex, so mixed text/element children become separate
+                    flex items laid out side by side instead of flowing as one paragraph - a single
+                    wrapping child keeps the sentence inline. */}
+                <span>
+                  Pick from the products the registry recognizes, or type a lake grant as{' '}
+                  <code>datalake:&lt;slug&gt;</code> and press Enter. A new product key must be added to the entitlement
+                  registry before it appears in the list.
+                </span>
               </FormHelperText>
             </FormControl>
 

--- a/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
+++ b/apps/client/app/components/admin/PartnerSignupRulesTab.tsx
@@ -477,6 +477,7 @@ export default function PartnerSignupRulesTab() {
               <FormLabel>Entitlements</FormLabel>
               <Autocomplete
                 multiple
+                freeSolo
                 options={ENTITLEMENT_OPTIONS}
                 value={form.entitlements}
                 onChange={(_event, value) => setForm(f => ({ ...f, entitlements: value }))}
@@ -484,8 +485,9 @@ export default function PartnerSignupRulesTab() {
                 data-testid="partner-rule-entitlements-input"
               />
               <FormHelperText>
-                Pick from the products the registry recognizes. A new product key must be added to the entitlement
-                registry before it appears here.
+                Pick from the products the registry recognizes, or type a lake grant as{' '}
+                <code>datalake:&lt;slug&gt;</code> and press Enter. A new product key must be added to the entitlement
+                registry before it appears in the list.
               </FormHelperText>
             </FormControl>
 

--- a/apps/client/lib/entitlements/registry.test.ts
+++ b/apps/client/lib/entitlements/registry.test.ts
@@ -6,6 +6,7 @@ import {
   entitlementsForPriceIds,
   entitlementsForTags,
   grantTagForEntitlement,
+  isDatalakeEntitlementKey,
   normalizeTag,
   resolveEntitlements,
   signupCreditsForEmail,
@@ -340,6 +341,35 @@ describe('KNOWN_ENTITLEMENT_KEYS / unknownEntitlementKeys', () => {
   it('treats a known key as known regardless of case/whitespace', () => {
     const known = KNOWN_ENTITLEMENT_KEYS[0];
     expect(unknownEntitlementKeys([` ${known.toUpperCase()} `])).toEqual([]);
+  });
+
+  it('treats a well-formed datalake:<slug> key as known without listing it', () => {
+    expect(KNOWN_ENTITLEMENT_KEYS).not.toContain('datalake:acme-legal');
+    expect(unknownEntitlementKeys(['datalake:acme-legal'])).toEqual([]);
+    expect(unknownEntitlementKeys([' DataLake:Acme-Legal '])).toEqual([]);
+  });
+
+  it('still flags a malformed datalake key as unknown', () => {
+    expect(unknownEntitlementKeys(['datalake:'])).toEqual(['datalake:']);
+    expect(unknownEntitlementKeys(['datalake:-leading-hyphen'])).toEqual(['datalake:-leading-hyphen']);
+    expect(unknownEntitlementKeys(['datalake:Bad_Char'])).toEqual(['datalake:bad_char']);
+    expect(unknownEntitlementKeys(['datalakes:acme'])).toEqual(['datalakes:acme']);
+  });
+});
+
+describe('isDatalakeEntitlementKey', () => {
+  it('recognizes datalake:<slug> for a valid lake-slug shape', () => {
+    expect(isDatalakeEntitlementKey('datalake:acme-legal')).toBe(true);
+    expect(isDatalakeEntitlementKey('datalake:ab')).toBe(true);
+  });
+
+  it('rejects an empty slug, invalid slug characters, or a lookalike prefix', () => {
+    expect(isDatalakeEntitlementKey('datalake:')).toBe(false);
+    expect(isDatalakeEntitlementKey('datalake:-abc')).toBe(false);
+    expect(isDatalakeEntitlementKey('datalake:abc-')).toBe(false);
+    expect(isDatalakeEntitlementKey('datalake:Abc')).toBe(false); // caller must normalize first
+    expect(isDatalakeEntitlementKey('datalakes:acme')).toBe(false);
+    expect(isDatalakeEntitlementKey('optihashi:pro')).toBe(false);
   });
 });
 

--- a/apps/client/lib/entitlements/registry.test.ts
+++ b/apps/client/lib/entitlements/registry.test.ts
@@ -367,9 +367,21 @@ describe('isDatalakeEntitlementKey', () => {
     expect(isDatalakeEntitlementKey('datalake:')).toBe(false);
     expect(isDatalakeEntitlementKey('datalake:-abc')).toBe(false);
     expect(isDatalakeEntitlementKey('datalake:abc-')).toBe(false);
-    expect(isDatalakeEntitlementKey('datalake:Abc')).toBe(false); // caller must normalize first
     expect(isDatalakeEntitlementKey('datalakes:acme')).toBe(false);
     expect(isDatalakeEntitlementKey('optihashi:pro')).toBe(false);
+  });
+
+  it('normalizes internally, so case/whitespace in the input still resolves correctly', () => {
+    expect(isDatalakeEntitlementKey('  DataLake:Acme-Legal  ')).toBe(true);
+    expect(isDatalakeEntitlementKey('datalake:Bad_Char')).toBe(false); // uppercase segment normalizes to `_`, still invalid
+  });
+
+  it('rejects a slug longer than a real lake slug can be (max 60, matches CreateDataLakeRequestInput)', () => {
+    const maxSlug = 'a'.repeat(60);
+    const tooLong = 'a'.repeat(61);
+    expect(isDatalakeEntitlementKey(`datalake:${maxSlug}`)).toBe(true);
+    expect(isDatalakeEntitlementKey(`datalake:${tooLong}`)).toBe(false);
+    expect(unknownEntitlementKeys([`datalake:${tooLong}`])).toEqual([`datalake:${tooLong}`]);
   });
 });
 

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -303,16 +303,39 @@ export const DOMAIN_GRANTS: ReadonlyMap<string, readonly EntitlementKey[]> = new
 export const KNOWN_ENTITLEMENT_KEYS: readonly EntitlementKey[] = [...allKnownEntitlementKeys()].sort();
 
 /**
+ * Entitlement key family for lake-scoped grants (`IDataLake.requiredEntitlement`,
+ * dataLakes epic #1658 lane D). A datalake entitlement is admin-authored per lake
+ * with an arbitrary slug - there is no fixed catalog of lakes to enumerate as a grant
+ * row here (and an open-core file must never name a customer's lake), so unlike every
+ * other key in this registry it can't be listed. Recognized as KNOWN by pattern
+ * instead: `datalake:<slug>`, slug matching the same rule as a lake slug
+ * (`CreateDataLakeRequestInput` in b4m-core/common/src/schemas/dataLake.ts). Deliberately
+ * NOT added to `KNOWN_ENTITLEMENT_KEYS` (that list is "products with a fixed identity";
+ * a lake slug is per-tenant data) - checked separately in `unknownEntitlementKeys`.
+ */
+const DATALAKE_ENTITLEMENT_PREFIX = 'datalake:';
+const DATALAKE_ENTITLEMENT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+/** Whether `key` (assumed already normalized) is a `datalake:<slug>` entitlement. */
+export function isDatalakeEntitlementKey(key: string): boolean {
+  return (
+    key.startsWith(DATALAKE_ENTITLEMENT_PREFIX) &&
+    DATALAKE_ENTITLEMENT_SLUG_REGEX.test(key.slice(DATALAKE_ENTITLEMENT_PREFIX.length))
+  );
+}
+
+/**
  * The entitlement keys in `keys` the registry does NOT recognize (normalized, de-duplicated).
- * Empty means every key is a known grantable product. Used to reject typo'd keys at admin
- * write boundaries before they persist as a silent no-op grant.
+ * Empty means every key is a known grantable product, or a `datalake:<slug>` grant (see
+ * `isDatalakeEntitlementKey`). Used to reject typo'd keys at admin write boundaries before
+ * they persist as a silent no-op grant.
  */
 export function unknownEntitlementKeys(keys: Iterable<string>): string[] {
   const known = new Set(KNOWN_ENTITLEMENT_KEYS);
   const unknown = new Set<string>();
   for (const raw of keys) {
     const key = normalizeTag(raw);
-    if (key && !known.has(key)) unknown.add(key);
+    if (key && !known.has(key) && !isDatalakeEntitlementKey(key)) unknown.add(key);
   }
   return [...unknown];
 }

--- a/apps/client/lib/entitlements/registry.ts
+++ b/apps/client/lib/entitlements/registry.ts
@@ -312,16 +312,31 @@ export const KNOWN_ENTITLEMENT_KEYS: readonly EntitlementKey[] = [...allKnownEnt
  * (`CreateDataLakeRequestInput` in b4m-core/common/src/schemas/dataLake.ts). Deliberately
  * NOT added to `KNOWN_ENTITLEMENT_KEYS` (that list is "products with a fixed identity";
  * a lake slug is per-tenant data) - checked separately in `unknownEntitlementKeys`.
+ *
+ * Known gap: this only validates SHAPE, not that a lake with that slug exists - a
+ * well-formed but nonexistent/mistyped slug is accepted as "known" and would persist as a
+ * silent no-op grant (the same class of bug #324 fixed for the fixed catalog). Closing that
+ * needs a DB read against `DataLakeModel`, which belongs with the read-time grant resolution
+ * work (dataLakes epic #1658 lane C, #1673), not this pattern-registration step.
  */
 const DATALAKE_ENTITLEMENT_PREFIX = 'datalake:';
 const DATALAKE_ENTITLEMENT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+// Mirrors slug.max(60) on CreateDataLakeRequestInput (schemas/dataLake.ts) - a longer slug
+// can't belong to a real lake, so accepting it here would reopen the exact silent-no-op-grant
+// risk `unknownEntitlementKeys` exists to close. (min(2) is already implied by the regex shape:
+// first char + last char, with the middle `*` allowed to match zero characters.)
+const DATALAKE_ENTITLEMENT_MAX_SLUG_LENGTH = 60;
 
-/** Whether `key` (assumed already normalized) is a `datalake:<slug>` entitlement. */
+/**
+ * Whether `key` is a `datalake:<slug>` entitlement. Normalizes internally (matches
+ * `isBypassExemptEntitlement` above) so a caller can't get a wrong answer by forgetting to
+ * normalize first.
+ */
 export function isDatalakeEntitlementKey(key: string): boolean {
-  return (
-    key.startsWith(DATALAKE_ENTITLEMENT_PREFIX) &&
-    DATALAKE_ENTITLEMENT_SLUG_REGEX.test(key.slice(DATALAKE_ENTITLEMENT_PREFIX.length))
-  );
+  const normalized = normalizeTag(key);
+  if (!normalized.startsWith(DATALAKE_ENTITLEMENT_PREFIX)) return false;
+  const slug = normalized.slice(DATALAKE_ENTITLEMENT_PREFIX.length);
+  return slug.length <= DATALAKE_ENTITLEMENT_MAX_SLUG_LENGTH && DATALAKE_ENTITLEMENT_SLUG_REGEX.test(slug);
 }
 
 /**

--- a/apps/client/pages/api/admin/partner-signup-rules/__tests__/[id].test.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/__tests__/[id].test.ts
@@ -85,6 +85,22 @@ describe('/api/admin/partner-signup-rules/[id] — update (PUT)', () => {
     expect(invalidatePartnerRuleCache).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts a datalake:<slug> entitlement update (#1669), same as the create route', async () => {
+    repo.update.mockResolvedValue({ id: 'r1', domain: 'partner.com', entitlements: ['datalake:acme-legal'] });
+    const { req, res } = makeReqRes('PUT', { body: { entitlements: ['datalake:acme-legal'] } });
+    await handlers.put(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(repo.update).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'r1', entitlements: ['datalake:acme-legal'] })
+    );
+  });
+
+  it('rejects a malformed datalake: key (empty slug) with a 400 and never writes', async () => {
+    const { req, res } = makeReqRes('PUT', { body: { entitlements: ['datalake:'] } });
+    await expect(handlers.put(req, res)).rejects.toThrow(/unknown entitlement key/i);
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when the row was deleted between check and write', async () => {
     repo.update.mockResolvedValue(null);
     const { req, res } = makeReqRes('PUT', { body: { enabled: true } });

--- a/apps/client/pages/api/admin/partner-signup-rules/__tests__/index.test.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/__tests__/index.test.ts
@@ -91,6 +91,15 @@ describe('/api/admin/partner-signup-rules — create (POST)', () => {
     expect(repo.create).toHaveBeenCalledWith(expect.objectContaining({ domain: 'partner.com', createdBy: 'admin-1' }));
     expect(invalidatePartnerRuleCache).toHaveBeenCalledTimes(1);
   });
+
+  it('accepts a datalake:<slug> entitlement, unlisted but matching the registered key family (#1669)', async () => {
+    const body = { ...validRule, entitlements: ['datalake:acme-legal'] };
+    repo.create.mockResolvedValue({ id: 'r1', ...body, enabled: true });
+    const { req, res } = makeReqRes('POST', { body });
+    await handlers.post(req, res);
+    expect(res._getStatusCode()).toBe(201);
+    expect(repo.create).toHaveBeenCalledWith(expect.objectContaining({ entitlements: ['datalake:acme-legal'] }));
+  });
 });
 
 describe('/api/admin/partner-signup-rules — list (GET)', () => {

--- a/apps/client/pages/api/admin/partner-signup-rules/__tests__/index.test.ts
+++ b/apps/client/pages/api/admin/partner-signup-rules/__tests__/index.test.ts
@@ -100,6 +100,12 @@ describe('/api/admin/partner-signup-rules — create (POST)', () => {
     expect(res._getStatusCode()).toBe(201);
     expect(repo.create).toHaveBeenCalledWith(expect.objectContaining({ entitlements: ['datalake:acme-legal'] }));
   });
+
+  it('still rejects a malformed datalake: key (empty slug) with a 400 and never writes', async () => {
+    const { req, res } = makeReqRes('POST', { body: { ...validRule, entitlements: ['datalake:'] } });
+    await expect(handlers.post(req, res)).rejects.toThrow(/unknown entitlement key/i);
+    expect(repo.create).not.toHaveBeenCalled();
+  });
 });
 
 describe('/api/admin/partner-signup-rules — list (GET)', () => {

--- a/apps/client/pages/api/admin/users/[userId]/__tests__/entitlements.test.ts
+++ b/apps/client/pages/api/admin/users/[userId]/__tests__/entitlements.test.ts
@@ -283,6 +283,56 @@ describe('GET /api/admin/users/:userId/entitlements', () => {
     expect(row.held).toBe(false);
   });
 
+  it('surfaces a partner-granted key OUTSIDE the fixed catalog (e.g. a datalake: grant) as its own row', async () => {
+    const key = 'datalake:acme-legal';
+    expect(allKnownEntitlementKeys()).not.toContain(key); // fixture assumption: pattern-family keys are never listed
+    mockPartnerKeys.mockResolvedValue(new Set([key]));
+    mockUserFind.mockResolvedValue({
+      id: 'u1',
+      tags: [],
+      isAdmin: false,
+      email: 'person@partner.example',
+      emailVerified: true,
+    });
+    const { res, promise } = run({ user: ADMIN });
+    await promise;
+    const row = res._getJSONData().entitlements.find((r: { key: string }) => r.key === key);
+    expect(row).toBeDefined();
+    expect(row.held).toBe(true);
+    expect(
+      row.sources.some(
+        (s: { type: string; detail: string }) => s.type === 'domain' && s.detail.includes('partner rule')
+      )
+    ).toBe(true);
+  });
+
+  it('reports admin-bypass for a partner-granted key outside the catalog too, matching real enforcement', async () => {
+    const key = 'datalake:acme-legal';
+    mockPartnerKeys.mockResolvedValue(new Set([key]));
+    mockUserFind.mockResolvedValue({ id: 'u1', tags: [], isAdmin: true, email: null, emailVerified: false });
+    const { res, promise } = run({ user: ADMIN });
+    await promise;
+    const row = res._getJSONData().entitlements.find((r: { key: string }) => r.key === key);
+    expect(row.held).toBe(true);
+    expect(row.sources).toEqual(expect.arrayContaining([{ type: 'admin-bypass', detail: 'Super Admin' }]));
+  });
+
+  it('does not duplicate a row when a partner rule grants a key already in the fixed catalog', async () => {
+    const key = allKnownEntitlementKeys()[0];
+    mockPartnerKeys.mockResolvedValue(new Set([key]));
+    mockUserFind.mockResolvedValue({
+      id: 'u1',
+      tags: [],
+      isAdmin: false,
+      email: 'person@partner.example',
+      emailVerified: true,
+    });
+    const { res, promise } = run({ user: ADMIN });
+    await promise;
+    const rows = res._getJSONData().entitlements.filter((r: { key: string }) => r.key === key);
+    expect(rows).toHaveLength(1);
+  });
+
   it('surfaces an active subscription as a subscription source', async () => {
     const [priceId, keys] = [...PRICE_ENTITLEMENTS.entries()][0] ?? [];
     if (!priceId || !keys?.[0]) return; // no price row configured in this environment

--- a/apps/client/pages/api/admin/users/[userId]/entitlements.ts
+++ b/apps/client/pages/api/admin/users/[userId]/entitlements.ts
@@ -79,7 +79,15 @@ const handler = baseApi().get(
 
     const isDeveloper = hasDeveloperUserTag(tags);
 
-    const rows: EntitlementRow[] = allKnownEntitlementKeys().map(key => {
+    // The catalog (`allKnownEntitlementKeys`) deliberately excludes pattern-matched families
+    // like `datalake:<slug>` (see registry.ts) - there is no fixed row to list. Widen the
+    // reported key set to also cover any partner-granted key outside the catalog, so a
+    // `datalake:` grant still gets a row (with its real sources, bypass included) instead of
+    // being invisible to this "why does this user have access" report.
+    const knownKeys = allKnownEntitlementKeys();
+    const reportedKeys = [...knownKeys, ...[...partnerKeys].filter(key => !knownKeys.includes(key))];
+
+    const rows: EntitlementRow[] = reportedKeys.map(key => {
       const sources: EntitlementSource[] = [];
 
       for (const tag of tags) {

--- a/apps/client/server/entitlements/partnerRules.ts
+++ b/apps/client/server/entitlements/partnerRules.ts
@@ -98,7 +98,7 @@ export function assertKnownEntitlements(entitlements: readonly string[]): void {
   const unknown = unknownEntitlementKeys(entitlements);
   if (unknown.length > 0) {
     throw new BadRequestError(
-      `Unknown entitlement key(s): ${unknown.join(', ')}. Known keys: ${KNOWN_ENTITLEMENT_KEYS.join(', ')}`
+      `Unknown entitlement key(s): ${unknown.join(', ')}. Known keys: ${KNOWN_ENTITLEMENT_KEYS.join(', ')}, or a datalake:<slug> lake grant.`
     );
   }
 }


### PR DESCRIPTION
## Description

Closes #1669

A data lake can gate access on `requiredUserTag` OR `requiredEntitlement`. The entitlement arm has never worked: `KNOWN_ENTITLEMENT_KEYS` is built purely from the union of price/tag/domain grant row values, and no `datalake:` key family was ever registered there. The admin write boundary (`assertKnownEntitlements`) rejects any unregistered key, so a `datalake:*` entitlement could never be added to a partner signup rule through the admin UI - the entitlement gate on a lake was a lock with no key that could legally exist.

A `datalake:<slug>` key can't be added as a literal grant row like other products, because it's admin-authored per lake with an arbitrary slug - there's no fixed catalog of lakes to enumerate, and hardcoding individual lake keys would put customer identifiers in this open-core file. Instead, the registry now recognizes `datalake:<slug>` as a known key **family**, matched by pattern rather than listed explicitly.

## Changes

- `apps/client/lib/entitlements/registry.ts`: added `isDatalakeEntitlementKey()`, which recognizes any normalized key of the form `datalake:<slug>` (slug matching the same shape as a lake slug - lowercase alphanumeric with internal hyphens). `unknownEntitlementKeys()` now treats a match as known without requiring it to appear in `KNOWN_ENTITLEMENT_KEYS`, which stays reserved for the fixed product catalog.
- `apps/client/app/components/admin/PartnerSignupRulesTab.tsx`: the entitlements picker now has `freeSolo` enabled so an admin can type a `datalake:<slug>` value and press Enter, since it can't appear in the fixed options list. Helper text updated to explain it.
- Added test coverage:
  - `apps/client/lib/entitlements/registry.test.ts`: unit tests for `isDatalakeEntitlementKey()` and for `unknownEntitlementKeys()` accepting a well-formed `datalake:` key while still rejecting malformed ones (empty slug, leading/trailing hyphen, invalid characters, lookalike prefixes).
  - `apps/client/pages/api/admin/partner-signup-rules/__tests__/index.test.ts`: an integration test confirming a partner signup rule with a `datalake:<slug>` entitlement is accepted end-to-end through the real write boundary.

## Guide for Testers

1. Log in as a platform admin and go to `Sidebar → Admin`.
2. Click the **Partner Signup Rules** tab (under the "User Ops" section, Handshake icon).
3. Click **Add Rule** (or the equivalent create button) to open the rule modal.
4. Fill in a domain, e.g. `example.com`.
5. In the **Entitlements** field, type `datalake:acme-legal` and press Enter.
6. Expected: the value is added as a chip in the field (previously impossible - the field only accepted values from a fixed dropdown list).
7. Save the rule.
8. Expected: the rule saves successfully (`201`/success toast) with `datalake:acme-legal` in its entitlements list. Before this change, saving with any `datalake:` key would fail with a 400 error: "Unknown entitlement key(s): datalake:acme-legal".

   <img width="1317" height="278" alt="image" src="https://github.com/user-attachments/assets/817d632e-59c4-491d-8b64-4adf2bb5528f" />

10. Reopen the rule for editing.
11. Expected: the `datalake:acme-legal` chip is still present and editable.

### Regression Checks

- The existing fixed-catalog entitlements (e.g. `optihashi:pro`) are still selectable from the dropdown and still save correctly - not touched by this change.
- An unrelated typo'd or unnamespaced key (e.g. `bogus:key`) is still rejected with a 400 error.
- A malformed `datalake:` value (e.g. `datalake:` with no slug, or one with invalid characters) is still rejected with a 400 error.

## Additional Information

This is scoped to registering the key family only. It does not add any UI for browsing which lakes have a `datalake:<slug>` entitlement configured, and it does not change how a lake's own `requiredEntitlement` field is validated (that check already accepts any namespaced string).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
