### PR TITLE
fix(client): disambiguate duplicate model names in the Agent Ops picker

### DIFF
--- a/apps/client/app/components/admin/AgentOpsTab.tsx
+++ b/apps/client/app/components/admin/AgentOpsTab.tsx
@@ -31,7 +31,7 @@ import { toast } from 'sonner';
 import { api } from '@client/app/contexts/ApiContext';
 import ContextHelpButton from '@client/app/components/help/ContextHelpButton';
 import { useModelInfo } from '@client/app/hooks/data/useModelInfo';
-import { agentOpsModelOptions } from '@client/app/utils/agentOpsModels';
+import { agentOpsModelLabels, agentOpsModelOptions } from '@client/app/utils/agentOpsModels';
 
 interface MetaPromptVersion {
   versionNumber: number;
@@ -91,7 +91,9 @@ const AgentOpsTab: React.FC = () => {
 
   const { data: catalogModels } = useModelInfo();
   const modelOptions = React.useMemo(() => agentOpsModelOptions(catalogModels ?? []), [catalogModels]);
-  const modelLabel = (modelId?: string) => modelOptions.find(m => m.id === modelId)?.name ?? modelId ?? 'Unknown';
+  // Names collide across backends (a direct-provider vs Bedrock twin), so disambiguate before display (#1596).
+  const modelLabels = React.useMemo(() => agentOpsModelLabels(modelOptions), [modelOptions]);
+  const modelLabel = (modelId?: string) => (modelId ? modelLabels.get(modelId) : undefined) ?? modelId ?? 'Unknown';
 
   // Modal states
   const [isCreateVersionModalOpen, setIsCreateVersionModalOpen] = useState(false);
@@ -481,7 +483,7 @@ const AgentOpsTab: React.FC = () => {
                   )}
                 {modelOptions.map(model => (
                   <Option key={model.id} value={model.id} disabled={model.disabled}>
-                    {model.name}
+                    {modelLabels.get(model.id) ?? model.name}
                     {model.disabled ? ' (unavailable)' : ''}
                   </Option>
                 ))}

--- a/apps/client/app/utils/__tests__/agentOpsModels.test.ts
+++ b/apps/client/app/utils/__tests__/agentOpsModels.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import type { ModelInfo } from '@bike4mind/common';
 import { ModelBackend } from '@bike4mind/common';
-import { agentOpsModelOptions, agentOpsModelRejection, isSelectableAgentOpsModel } from '../agentOpsModels';
+import {
+  agentOpsModelLabels,
+  agentOpsModelOptions,
+  agentOpsModelRejection,
+  isSelectableAgentOpsModel,
+} from '../agentOpsModels';
 
 /**
  * Agent-ops used to keep its own model lists -- an allowlist in the endpoint, a picker array in
@@ -105,5 +110,46 @@ describe('agentOpsModelRejection', () => {
 
   it('reports an unknown id as an invalid model', () => {
     expect(agentOpsModelRejection(catalog, 'nonesuch')).toBe('Invalid LLM model specified');
+  });
+});
+
+describe('agentOpsModelLabels', () => {
+  it('leaves a unique name untouched', () => {
+    const labels = agentOpsModelLabels([model({ id: 'claude-opus-5', name: 'Claude 5 Opus' })]);
+
+    expect(labels.get('claude-opus-5')).toBe('Claude 5 Opus');
+  });
+
+  it('suffixes the backend on names shared across two backends (the #1596 case)', () => {
+    // The direct-provider and Bedrock twins of the same model carry an identical `name`.
+    const labels = agentOpsModelLabels([
+      model({ id: 'us.anthropic.claude-opus-4-20250514-v1:0', name: 'Claude 4 Opus', backend: ModelBackend.Bedrock }),
+      model({ id: 'claude-opus-4-20250514', name: 'Claude 4 Opus', backend: ModelBackend.Anthropic }),
+    ]);
+
+    expect(labels.get('us.anthropic.claude-opus-4-20250514-v1:0')).toBe('Claude 4 Opus (Bedrock)');
+    expect(labels.get('claude-opus-4-20250514')).toBe('Claude 4 Opus (Anthropic)');
+  });
+
+  it('does not suffix a backend-unique name that merely shares a substring', () => {
+    const labels = agentOpsModelLabels([
+      model({ id: 'claude-sonnet-4', name: 'Claude 4 Sonnet' }),
+      model({ id: 'claude-opus-5', name: 'Claude 5 Opus' }),
+    ]);
+
+    expect(labels.get('claude-sonnet-4')).toBe('Claude 4 Sonnet');
+    expect(labels.get('claude-opus-5')).toBe('Claude 5 Opus');
+  });
+
+  it('falls back to the id when the backend does not break the tie either', () => {
+    // Two same-name options on the SAME backend: the backend suffix alone stays ambiguous, so the
+    // id is appended to keep every option distinguishable.
+    const labels = agentOpsModelLabels([
+      model({ id: 'twin-a', name: 'Twin', backend: ModelBackend.Bedrock }),
+      model({ id: 'twin-b', name: 'Twin', backend: ModelBackend.Bedrock }),
+    ]);
+
+    expect(labels.get('twin-a')).toBe('Twin (Bedrock: twin-a)');
+    expect(labels.get('twin-b')).toBe('Twin (Bedrock: twin-b)');
   });
 });

--- a/apps/client/app/utils/agentOpsModels.ts
+++ b/apps/client/app/utils/agentOpsModels.ts
@@ -1,4 +1,4 @@
-import type { ModelInfo } from '@bike4mind/common';
+import { ModelBackend, type ModelInfo } from '@bike4mind/common';
 
 /**
  * Which catalog models agent-ops may generate with. Shared by the AgentOpsTab picker and the
@@ -34,4 +34,53 @@ export function agentOpsModelRejection(models: ModelInfo[], modelId: string): st
 /** Whether an admin may newly pin `modelId`. Disabled models are listed but not saveable. */
 export function isSelectableAgentOpsModel(models: ModelInfo[], modelId: string): boolean {
   return agentOpsModelRejection(models, modelId) === null;
+}
+
+const BACKEND_LABELS: Partial<Record<ModelBackend, string>> = {
+  [ModelBackend.OpenAI]: 'OpenAI',
+  [ModelBackend.Bedrock]: 'Bedrock',
+  [ModelBackend.Anthropic]: 'Anthropic',
+  [ModelBackend.Gemini]: 'Gemini',
+  [ModelBackend.Ollama]: 'Ollama',
+  [ModelBackend.XAI]: 'xAI',
+  [ModelBackend.Kimi]: 'Kimi',
+  [ModelBackend.VoyageAI]: 'Voyage AI',
+  [ModelBackend.AWS]: 'AWS',
+  [ModelBackend.BFL]: 'BFL',
+  [ModelBackend.LocalImage]: 'Local',
+};
+
+const backendLabel = (backend: ModelBackend): string => BACKEND_LABELS[backend] ?? backend;
+
+/**
+ * Display label per model id, disambiguating names shared across backends. Two catalog models can
+ * carry the same `name` -- the direct-provider and Bedrock twins of "Claude 4 Opus" -- yet route to
+ * different credentials, and the picker rendered only the name, so an admin had no way to tell them
+ * apart and a wrong pick billed the unintended account (#1596). A name used by more than one option
+ * gets a `(Backend)` suffix on every twin; if the backend does not break the tie either, the model
+ * id is appended so every option stays distinguishable.
+ */
+export function agentOpsModelLabels(models: ModelInfo[]): Map<string, string> {
+  const byName = new Map<string, ModelInfo[]>();
+  for (const m of models) {
+    const group = byName.get(m.name);
+    if (group) group.push(m);
+    else byName.set(m.name, [m]);
+  }
+
+  const labels = new Map<string, string>();
+  for (const [name, group] of byName) {
+    if (group.length === 1) {
+      for (const m of group) labels.set(m.id, name);
+      continue;
+    }
+    const backendCounts = new Map<ModelBackend, number>();
+    for (const m of group) backendCounts.set(m.backend, (backendCounts.get(m.backend) ?? 0) + 1);
+    for (const m of group) {
+      const suffix =
+        (backendCounts.get(m.backend) ?? 0) > 1 ? `${backendLabel(m.backend)}: ${m.id}` : backendLabel(m.backend);
+      labels.set(m.id, `${name} (${suffix})`);
+    }
+  }
+  return labels;
 }


### PR DESCRIPTION
## Optional Screenshot/Video

N/A (admin-only picker; verification steps below run on the PR preview).

## Description

The Agent Ops generation-model dropdown (**Admin -> AI & Agents -> Agent Operations -> Edit Settings -> LLM Model for Generation**) shows some options with identical display names. Each such pair is the same model offered through two different backends -- the direct provider platform and AWS Bedrock -- which route to **different provider credentials** but differ only in the underlying model id. The picker rendered only `name`, so an admin had no way to tell the twins apart, and picking the wrong one can silently bill the unintended account (per #1596, the reporter hit exactly this while restoring a setting).

This disambiguates the labels **in the picker**: a display name shared by more than one option gets a `(Backend)` suffix on every twin, e.g. `Claude 4 Opus (Bedrock)` vs `Claude 4 Opus (Anthropic)` -- matching the convention the catalog already uses for the Kimi entries. Names that are already unique are left untouched. The same disambiguated label is used for the **System Status** card, so the active variant is now verifiable at a glance (previously only checkable via `GET /api/admin/agent-ops-settings`).

Closes #1596.

## Changes

- **`agentOpsModels.ts`**: add `agentOpsModelLabels(models)` -> `Map<id, label>`. Groups options by `name`; a name used by only one option maps to the raw name; a colliding name gets a `(Backend)` suffix per twin. If the backend does not break the tie either (two same-name options on the same backend), the model id is appended so every option stays distinguishable.
- **`AgentOpsTab.tsx`**: memoize the label map from the current options and apply it at both render sites -- the `<Option>` list and the System Status `modelLabel`. The retired-pin fallback Option is unchanged.
- **`agentOpsModels.test.ts`**: +4 tests -- unique name untouched, cross-backend collision suffixed (the #1596 case), substring-only names not suffixed, same-backend id-fallback.

## Guide for Testers

1. Sign in as an admin on the PR preview and go to **Admin -> AI & Agents -> Agent Operations -> Edit Settings**.
2. Open the **LLM Model for Generation** dropdown.
3. **Expected:** the previously-duplicated Claude entries now read as distinct pairs, e.g. `Claude 4 Opus (Bedrock)` and `Claude 4 Opus (Anthropic)`. Models with a unique name (e.g. `Claude 4 Sonnet`, `Claude 5 Opus`) show no suffix.
4. Select the Bedrock variant of a model and Save; the **System Status** card now shows the same suffixed label, so the active backend is visible without an API call. Re-open the dropdown and confirm the saved twin is the one selected.
5. Unit proof: `cd apps/client && npx vitest run app/utils/__tests__/agentOpsModels.test.ts` -> 16/16.

## Additional Information

**Scope (deliberate).** This fixes the Agent Ops generation picker -- the surface #1596 was filed against. The same raw-`model.name` ambiguity exists in other catalog-fed admin pickers (`AdminOperationsModelSetting`, `SecopsTriageTab`, `AdminLiveOpsTriageMultiConfigTab`, `RapidReplyTab`). The issue's own primary recommendation -- disambiguate at the source by suffixing the Bedrock variants' `name` in the model catalog -- would fix every picker at once but is a backend/catalog (`b4m-core/common`) naming change, out of scope here. `agentOpsModelLabels` is written to be liftable into a shared util if a follow-up generalizes the picker-level fix. Not claiming a repo-wide resolution.

## Developer Notes (Optional)

The helper derives the disambiguator from `ModelInfo.backend` (already on the catalog type), not from parsing the id prefix, so it stays correct if id conventions change.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings