### PR TITLE
test(e2e): stop ai-latency image and artifact prompts from flaking

### DIFF
--- a/apps/client/app/components/Session/PromptReplies.tsx
+++ b/apps/client/app/components/Session/PromptReplies.tsx
@@ -1786,7 +1786,11 @@ const ReplyContainer: FC<ReplyContainerProps> = ({
                                 },
                               }}
                             />
-                            <Typography level="body-sm" sx={{ color: 'primary.700' }}>
+                            <Typography
+                              level="body-sm"
+                              sx={{ color: 'primary.700' }}
+                              data-testid="generating-artifact-indicator"
+                            >
                               Generating artifact...
                             </Typography>
                           </Box>

--- a/apps/client/e2e/ai-latency-helpers.ts
+++ b/apps/client/e2e/ai-latency-helpers.ts
@@ -109,6 +109,18 @@ export interface PromptScenario {
   id: string;
   prompt: string;
   expectedKeywords: string[];
+  /**
+   * The reply's deliverable is a generated image (rendered as `ai-response-image`). Success is
+   * asserted on the rendered image, not on text keywords - an image-only reply carries no prose,
+   * so keyword-on-text is a false negative for it. Also grants the image-generation time budget.
+   */
+  expectsImage?: boolean;
+  /**
+   * The reply streams an artifact (shows the "Generating artifact..." placeholder) before its
+   * text is final. Grants the image-generation time budget and waits for the placeholder to clear
+   * before scraping text, so the keyword check reads the resolved article rather than the spinner.
+   */
+  generatesArtifact?: boolean;
 }
 
 export interface PromptResult {

--- a/apps/client/e2e/ai-latency-helpers.ts
+++ b/apps/client/e2e/ai-latency-helpers.ts
@@ -127,13 +127,17 @@ export interface PromptResult {
   id: string;
   prompt: string;
   response: string;
+  /** Token-stream latency only (start -> stop-generation button gone), excluding image/artifact render. */
   responseTimeMs: number;
   responseTimeSec: number;
   responseRateCharsPerSec: number;
+  /** Image render / artifact settle time after the stream ended; 0 for plain text prompts. */
+  renderTimeMs: number;
+  renderTimeSec: number;
   /**
-   * True for image/artifact prompts, whose responseTime measures end-to-end deliverable
-   * generation rather than a text streaming rate. Excluded from the gated latency average so the
-   * workflow's threshold check stays a text-streaming signal. Absent (falsy) for text prompts.
+   * True for image/artifact prompts. Even measured stream-only their window runs for minutes, so
+   * they are excluded from the gated latency average, which must stay a text-streaming signal that
+   * still catches a real text regression. Absent (falsy) for text prompts.
    */
   measuresDeliverable?: boolean;
 }

--- a/apps/client/e2e/ai-latency-helpers.ts
+++ b/apps/client/e2e/ai-latency-helpers.ts
@@ -130,4 +130,10 @@ export interface PromptResult {
   responseTimeMs: number;
   responseTimeSec: number;
   responseRateCharsPerSec: number;
+  /**
+   * True for image/artifact prompts, whose responseTime measures end-to-end deliverable
+   * generation rather than a text streaming rate. Excluded from the gated latency average so the
+   * workflow's threshold check stays a text-streaming signal. Absent (falsy) for text prompts.
+   */
+  measuresDeliverable?: boolean;
 }

--- a/apps/client/e2e/ai-latency-intermediate-tools.spec.ts
+++ b/apps/client/e2e/ai-latency-intermediate-tools.spec.ts
@@ -5,7 +5,10 @@ import type { PromptScenario } from './ai-latency-helpers';
 createAiLatencySuite({
   prompts: config.prompts as PromptScenario[],
   describeLabel: 'Run 3 intermediate prompts using tools',
-  timeoutMultiplier: 15,
+  // 20 * TEST = 1200s so a real failure surfaces as a clean assertion, not an opaque test
+  // timeout: an artifact prompt can spend the image-generation send budget twice (the one
+  // "request timed out" retry in sendMessageAndWaitForResponse) plus the artifact settle wait.
+  timeoutMultiplier: 20,
   thresholdSec: config.thresholdSec,
   resultsFilename: 'ai-latency-intermediate-tools-results.json',
 });

--- a/apps/client/e2e/ai-latency-suite-factory.ts
+++ b/apps/client/e2e/ai-latency-suite-factory.ts
@@ -97,8 +97,29 @@ export function createAiLatencySuite({
       resolvedModel = await resolveSelectedModel(modelSelector);
       await modelSelector.selectTextModel(resolvedModel, disableSmartTools ? { disableSmartTools: true } : undefined);
 
+      // Image-generating and artifact-producing prompts render past the flat text-streaming
+      // budget, so give them the image-generation budget (the long pole is the render, not the
+      // token stream). Plain text prompts keep the standard streaming budget.
+      const streamBudget =
+        scenario.expectsImage || scenario.generatesArtifact ? TIMEOUTS.IMAGE_GENERATION : TIMEOUTS.AI_RESPONSE;
+
       const startMs = Date.now();
-      await chatPage.sendMessageAndWaitForResponse(scenario.prompt, TIMEOUTS.AI_RESPONSE);
+      let imageAsserted = false;
+      if (scenario.expectsImage) {
+        // Image flow: do not gate on the text container (it only mounts with the image), then
+        // assert the image itself as the success signal. If no image renders within budget (e.g.
+        // a model without image generation), fall through to the keyword check below rather than
+        // hard-failing, so the suite stays meaningful across model capabilities.
+        await chatPage.sendImageMessageAndWaitForResponse(scenario.prompt, streamBudget);
+        imageAsserted = await chatPage.tryWaitForImageResponse(streamBudget);
+      } else {
+        await chatPage.sendMessageAndWaitForResponse(scenario.prompt, streamBudget);
+        // Streaming completing does not mean the artifact resolved; wait out the placeholder so
+        // the scrape below reads the finished reply instead of "Generating artifact...".
+        if (scenario.generatesArtifact) {
+          await chatPage.waitForArtifactSettled(streamBudget);
+        }
+      }
       const responseTimeMs = Date.now() - startMs;
 
       const allTexts = await chatPage.aiResponseRoot.allInnerTexts();
@@ -107,19 +128,27 @@ export function createAiLatencySuite({
       const responseTimeSec = responseTimeMs / 1000;
       const responseRateCharsPerSec = responseText.length > 0 ? Math.round(responseText.length / responseTimeSec) : 0;
 
-      const normalizedResponse = normalizeForMatch(responseText);
-      const foundKeywords = scenario.expectedKeywords.filter(kw => normalizedResponse.includes(normalizeForMatch(kw)));
-      const matchedKeyword = foundKeywords[0];
+      // Keyword-on-text validates prose replies. Skip it only when a rendered image was actually
+      // asserted above: an image-only reply carries no caption, so keyword matching would be a
+      // false negative. When an image prompt produced no image (imageAsserted false), fall through
+      // and validate on text - the graceful path for models without image generation.
+      if (!imageAsserted) {
+        const normalizedResponse = normalizeForMatch(responseText);
+        const foundKeywords = scenario.expectedKeywords.filter(kw =>
+          normalizedResponse.includes(normalizeForMatch(kw))
+        );
+        const matchedKeyword = foundKeywords[0];
 
-      expect
-        .soft(
-          matchedKeyword,
-          `Keyword match failed — ` +
-            `found: [${foundKeywords.length ? foundKeywords.join(', ') : 'none'}], ` +
-            `missing: [${scenario.expectedKeywords.filter(kw => !foundKeywords.includes(kw)).join(', ')}]. ` +
-            `Response: "${responseText.slice(0, 300)}"`
-        )
-        .toBeTruthy();
+        expect
+          .soft(
+            matchedKeyword,
+            `Keyword match failed - ` +
+              `found: [${foundKeywords.length ? foundKeywords.join(', ') : 'none'}], ` +
+              `missing: [${scenario.expectedKeywords.filter(kw => !foundKeywords.includes(kw)).join(', ')}]. ` +
+              `Response: "${responseText.slice(0, 300)}"`
+          )
+          .toBeTruthy();
+      }
 
       const result: PromptResult = {
         id: scenario.id,

--- a/apps/client/e2e/ai-latency-suite-factory.ts
+++ b/apps/client/e2e/ai-latency-suite-factory.ts
@@ -70,9 +70,15 @@ export function createAiLatencySuite({
     // Dedupe by id, last write wins so a retry's result supersedes the original.
     const results = [...new Map([...priorResults, ...newResults].map(r => [r.id, r])).values()];
 
+    // The gated latency average must stay text-streaming-only. Image/artifact prompts measure a
+    // much longer, different thing (deliverable generation, which for artifacts runs during the
+    // stream), so fold only the text prompts into the average - otherwise the workflow's
+    // AVG > thresholdSec check would go red on generation time and mask real streaming regressions.
+    // Any 3-of-N pick includes at least one text prompt, but guard the empty case anyway.
+    const gatedResults = results.filter(r => !r.measuresDeliverable);
     const averageResponseTimeSec =
-      results.length > 0
-        ? Math.round((results.reduce((sum, r) => sum + r.responseTimeSec, 0) / results.length) * 1000) / 1000
+      gatedResults.length > 0
+        ? Math.round((gatedResults.reduce((sum, r) => sum + r.responseTimeSec, 0) / gatedResults.length) * 1000) / 1000
         : 0;
 
     // Never downgrade an already-resolved model back to 'unknown' (a recycled worker starts fresh).
@@ -97,27 +103,27 @@ export function createAiLatencySuite({
       resolvedModel = await resolveSelectedModel(modelSelector);
       await modelSelector.selectTextModel(resolvedModel, disableSmartTools ? { disableSmartTools: true } : undefined);
 
-      // Image-generating and artifact-producing prompts render past the flat text-streaming
-      // budget, so give them the image-generation budget (the long pole is the render, not the
-      // token stream). Plain text prompts keep the standard streaming budget.
-      const streamBudget =
-        scenario.expectsImage || scenario.generatesArtifact ? TIMEOUTS.IMAGE_GENERATION : TIMEOUTS.AI_RESPONSE;
-
       const startMs = Date.now();
       let imageAsserted = false;
       if (scenario.expectsImage) {
         // Image flow: do not gate on the text container (it only mounts with the image), then
         // assert the image itself as the success signal. If no image renders within budget (e.g.
         // a model without image generation), fall through to the keyword check below rather than
-        // hard-failing, so the suite stays meaningful across model capabilities.
-        await chatPage.sendImageMessageAndWaitForResponse(scenario.prompt, streamBudget);
-        imageAsserted = await chatPage.tryWaitForImageResponse(streamBudget);
+        // hard-failing, so the suite stays meaningful across model capabilities. Budgets mirror
+        // image-generation.spec.ts: the standard streaming budget for the send (the token stream
+        // is short), the image-generation budget for the render (the long pole).
+        await chatPage.sendImageMessageAndWaitForResponse(scenario.prompt, TIMEOUTS.AI_RESPONSE);
+        imageAsserted = await chatPage.tryWaitForImageResponse(TIMEOUTS.IMAGE_GENERATION);
       } else {
-        await chatPage.sendMessageAndWaitForResponse(scenario.prompt, streamBudget);
-        // Streaming completing does not mean the artifact resolved; wait out the placeholder so
-        // the scrape below reads the finished reply instead of "Generating artifact...".
+        // An artifact is generated while the reply is still streaming (the stop button stays
+        // visible), so an artifact prompt needs the image-generation budget for the send itself;
+        // plain text keeps the standard streaming budget.
+        const sendBudget = scenario.generatesArtifact ? TIMEOUTS.IMAGE_GENERATION : TIMEOUTS.AI_RESPONSE;
+        await chatPage.sendMessageAndWaitForResponse(scenario.prompt, sendBudget);
+        // Streaming completing does not mean the artifact resolved; wait out the placeholders so
+        // the scrape below reads the finished reply, not "Generating artifact..."/"Loading artifact...".
         if (scenario.generatesArtifact) {
-          await chatPage.waitForArtifactSettled(streamBudget);
+          await chatPage.waitForArtifactSettled(TIMEOUTS.IMAGE_GENERATION);
         }
       }
       const responseTimeMs = Date.now() - startMs;
@@ -157,6 +163,10 @@ export function createAiLatencySuite({
         responseTimeMs,
         responseTimeSec: Math.round(responseTimeSec * 1000) / 1000,
         responseRateCharsPerSec,
+        // Image/artifact prompts time end-to-end deliverable generation (image render / artifact
+        // settle), not a text streaming rate - flag them so persistResults keeps them out of the
+        // gated latency average, which must stay streaming-only to still catch a text regression.
+        measuresDeliverable: Boolean(scenario.expectsImage || scenario.generatesArtifact),
       };
       collectedResults.push(result);
       // Persist immediately so this prompt's numbers survive a later prompt's timeout/worker recycle.

--- a/apps/client/e2e/ai-latency-suite-factory.ts
+++ b/apps/client/e2e/ai-latency-suite-factory.ts
@@ -105,33 +105,46 @@ export function createAiLatencySuite({
 
       const startMs = Date.now();
       let imageAsserted = false;
+      // streamEndMs marks the end of the token stream (the send helper returns once the
+      // stop-generation button is gone). The image render and artifact settle that follow are a
+      // separate, much longer measurement, so latency and streaming rate below are taken over the
+      // stream window only and the render/settle tail is recorded separately as renderTimeMs.
+      let streamEndMs: number;
       if (scenario.expectsImage) {
-        // Image flow: do not gate on the text container (it only mounts with the image), then
-        // assert the image as the success signal. The image is tool-produced WHILE the reply
-        // streams - the stop button hides only once generation finishes (city-no-cars streams no
-        // caption, textlen 0), so the send needs the image-generation budget too, not just the
-        // render wait. A short send budget here would throw before the render budget is ever used.
+        // The image is tool-produced around the stream (the stop button can hide only once
+        // generation finishes; city-no-cars streams no caption, textlen 0), so the send needs the
+        // image-generation budget, not just the render wait - a short send budget would throw
+        // before the render budget is ever used. Do not gate on the text container (it only mounts
+        // with the image); assert the image as the success signal.
         await chatPage.sendImageMessageAndWaitForResponse(scenario.prompt, TIMEOUTS.IMAGE_GENERATION);
+        streamEndMs = Date.now();
         imageAsserted = await chatPage.tryWaitForImageResponse(TIMEOUTS.IMAGE_GENERATION);
       } else {
-        // An artifact is likewise generated while the reply is still streaming, so an artifact
-        // prompt needs the image-generation budget for the send; plain text keeps the standard
-        // streaming budget.
+        // An artifact is likewise generated around the stream, so an artifact prompt needs the
+        // image-generation budget for the send; plain text keeps the standard streaming budget.
         const sendBudget = scenario.generatesArtifact ? TIMEOUTS.IMAGE_GENERATION : TIMEOUTS.AI_RESPONSE;
         await chatPage.sendMessageAndWaitForResponse(scenario.prompt, sendBudget);
+        streamEndMs = Date.now();
         // Streaming completing does not mean the artifact resolved; wait out the placeholders so
         // the scrape below reads the finished reply, not "Generating artifact..."/"Loading artifact...".
         if (scenario.generatesArtifact) {
           await chatPage.waitForArtifactSettled(TIMEOUTS.IMAGE_GENERATION);
         }
       }
-      const responseTimeMs = Date.now() - startMs;
+      const settleEndMs = Date.now();
+
+      // Measure latency and streaming rate over the token-stream window only; keep the image
+      // render / artifact settle as a separate number so a 6-minute artifact mount neither reads
+      // as a slow stream nor distorts chars/sec (a short article over a long settle).
+      const responseTimeMs = streamEndMs - startMs;
+      const renderTimeMs = settleEndMs - streamEndMs;
 
       const allTexts = await chatPage.aiResponseRoot.allInnerTexts();
       const responseText = allTexts.join('\n');
 
       const responseTimeSec = responseTimeMs / 1000;
-      const responseRateCharsPerSec = responseText.length > 0 ? Math.round(responseText.length / responseTimeSec) : 0;
+      const responseRateCharsPerSec =
+        responseText.length > 0 && responseTimeSec > 0 ? Math.round(responseText.length / responseTimeSec) : 0;
 
       // An image prompt's only trustworthy signal is the rendered image. Its keyword list is
       // generic prose ("here", "picture", "generated") that a refusal or any description also
@@ -174,9 +187,14 @@ export function createAiLatencySuite({
         responseTimeMs,
         responseTimeSec: Math.round(responseTimeSec * 1000) / 1000,
         responseRateCharsPerSec,
-        // Image/artifact prompts time end-to-end deliverable generation (image render / artifact
-        // settle), not a text streaming rate - flag them so persistResults keeps them out of the
-        // gated latency average, which must stay streaming-only to still catch a text regression.
+        // Time spent rendering the image / settling the artifact after the stream ended. 0 for
+        // plain text prompts. Kept as its own field so "this artifact took N seconds to mount"
+        // stays visible without polluting the streaming latency/rate above.
+        renderTimeMs,
+        renderTimeSec: Math.round(renderTimeMs) / 1000,
+        // Even measured stream-only, an artifact prompt's stream window runs for minutes, so flag
+        // image/artifact prompts to keep them out of the gated latency average - it must stay a
+        // text-streaming signal that still catches a real text regression.
         measuresDeliverable: Boolean(scenario.expectsImage || scenario.generatesArtifact),
       };
       collectedResults.push(result);

--- a/apps/client/e2e/ai-latency-suite-factory.ts
+++ b/apps/client/e2e/ai-latency-suite-factory.ts
@@ -107,17 +107,16 @@ export function createAiLatencySuite({
       let imageAsserted = false;
       if (scenario.expectsImage) {
         // Image flow: do not gate on the text container (it only mounts with the image), then
-        // assert the image itself as the success signal. If no image renders within budget (e.g.
-        // a model without image generation), fall through to the keyword check below rather than
-        // hard-failing, so the suite stays meaningful across model capabilities. Budgets mirror
-        // image-generation.spec.ts: the standard streaming budget for the send (the token stream
-        // is short), the image-generation budget for the render (the long pole).
-        await chatPage.sendImageMessageAndWaitForResponse(scenario.prompt, TIMEOUTS.AI_RESPONSE);
+        // assert the image as the success signal. The image is tool-produced WHILE the reply
+        // streams - the stop button hides only once generation finishes (city-no-cars streams no
+        // caption, textlen 0), so the send needs the image-generation budget too, not just the
+        // render wait. A short send budget here would throw before the render budget is ever used.
+        await chatPage.sendImageMessageAndWaitForResponse(scenario.prompt, TIMEOUTS.IMAGE_GENERATION);
         imageAsserted = await chatPage.tryWaitForImageResponse(TIMEOUTS.IMAGE_GENERATION);
       } else {
-        // An artifact is generated while the reply is still streaming (the stop button stays
-        // visible), so an artifact prompt needs the image-generation budget for the send itself;
-        // plain text keeps the standard streaming budget.
+        // An artifact is likewise generated while the reply is still streaming, so an artifact
+        // prompt needs the image-generation budget for the send; plain text keeps the standard
+        // streaming budget.
         const sendBudget = scenario.generatesArtifact ? TIMEOUTS.IMAGE_GENERATION : TIMEOUTS.AI_RESPONSE;
         await chatPage.sendMessageAndWaitForResponse(scenario.prompt, sendBudget);
         // Streaming completing does not mean the artifact resolved; wait out the placeholders so
@@ -134,11 +133,23 @@ export function createAiLatencySuite({
       const responseTimeSec = responseTimeMs / 1000;
       const responseRateCharsPerSec = responseText.length > 0 ? Math.round(responseText.length / responseTimeSec) : 0;
 
-      // Keyword-on-text validates prose replies. Skip it only when a rendered image was actually
-      // asserted above: an image-only reply carries no caption, so keyword matching would be a
-      // false negative. When an image prompt produced no image (imageAsserted false), fall through
-      // and validate on text - the graceful path for models without image generation.
-      if (!imageAsserted) {
+      // An image prompt's only trustworthy signal is the rendered image. Its keyword list is
+      // generic prose ("here", "picture", "generated") that a refusal or any description also
+      // satisfies (matching is a lowercased substring includes, so "here" even hits inside
+      // "there"), so a keyword fallback would pass on a real image-generation outage. Soft-assert
+      // the image instead: the Quality column turns red when no image renders, while latency for
+      // the run still records and later prompts still execute. Text and artifact prompts validate
+      // on keywords - and an artifact prompt that renders no artifact degrades to that same text
+      // check, which is meaningful for prose (unlike the image list).
+      if (scenario.expectsImage) {
+        expect
+          .soft(
+            imageAsserted,
+            `Expected a generated image for "${scenario.prompt}" but none rendered within ` +
+              `${TIMEOUTS.IMAGE_GENERATION}ms - image generation may be unavailable or broken.`
+          )
+          .toBe(true);
+      } else {
         const normalizedResponse = normalizeForMatch(responseText);
         const foundKeywords = scenario.expectedKeywords.filter(kw =>
           normalizedResponse.includes(normalizeForMatch(kw))

--- a/apps/client/e2e/ai-latency-tool-prompts.spec.ts
+++ b/apps/client/e2e/ai-latency-tool-prompts.spec.ts
@@ -5,7 +5,9 @@ import type { PromptScenario } from './ai-latency-helpers';
 createAiLatencySuite({
   prompts: config.prompts as PromptScenario[],
   describeLabel: 'Run 3 simple prompts explicitly targeting tools',
-  timeoutMultiplier: 10,
+  // 15 * TEST = 900s: the image prompt sends and renders under the image-generation budget
+  // (generation runs during the stream), which the prior 600s cap could not cover.
+  timeoutMultiplier: 15,
   thresholdSec: config.thresholdSec,
   resultsFilename: 'ai-latency-tool-prompts-results.json',
 });

--- a/apps/client/e2e/fixtures/ai-latency/ai-latency-intermediate-tools-config.json
+++ b/apps/client/e2e/fixtures/ai-latency/ai-latency-intermediate-tools-config.json
@@ -14,12 +14,14 @@
     {
       "id": "childrens-storybook",
       "prompt": "Make a 10-page children's story book with a picture for the cover and each page",
-      "expectedKeywords": ["page", "story", "once upon", "illustration", "children"]
+      "expectedKeywords": ["page", "story", "once upon", "illustration", "children"],
+      "generatesArtifact": true
     },
     {
       "id": "taipei-night-markets",
       "prompt": "Create an article about the 3 most popular night markets in Taipei and add images for each market",
-      "expectedKeywords": ["Shilin", "Raohe", "Tonghua", "night market", "Taipei"]
+      "expectedKeywords": ["Shilin", "Raohe", "Tonghua", "night market", "Taipei"],
+      "generatesArtifact": true
     },
     {
       "id": "smartphone-comparison",

--- a/apps/client/e2e/fixtures/ai-latency/ai-latency-tool-prompts-config.json
+++ b/apps/client/e2e/fixtures/ai-latency/ai-latency-tool-prompts-config.json
@@ -4,7 +4,8 @@
     {
       "id": "city-no-cars-image",
       "prompt": "Generate a picture of a futuristic city without cars",
-      "expectedKeywords": ["city", "image", "futuristic", "streets", "generated", "here", "picture"]
+      "expectedKeywords": ["city", "image", "futuristic", "streets", "generated", "here", "picture"],
+      "expectsImage": true
     },
     {
       "id": "usd-php-exchange",

--- a/apps/client/e2e/pages/ChatPage.ts
+++ b/apps/client/e2e/pages/ChatPage.ts
@@ -269,4 +269,40 @@ export class ChatPage extends BasePage {
 
     return img;
   }
+
+  /**
+   * Non-throwing {@link waitForImageResponse}: resolves true when an image renders within the
+   * budget, false when none does. Lets a caller assert on a produced image but fall back to a
+   * text check when the model has no image generation, instead of hard-failing the prompt.
+   */
+  async tryWaitForImageResponse(timeout: number = TIMEOUTS.IMAGE_GENERATION): Promise<boolean> {
+    try {
+      await this.waitForImageResponse(timeout);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Waits for the artifact placeholders to clear on the newest reply, so a text scrape reads
+   * the resolved content instead of a spinner.
+   *
+   * Streaming completing (stop-generation-btn gone) does NOT mean the reply text is final. An
+   * artifact reply passes through TWO sequential placeholders before its content mounts:
+   *   1. "Generating artifact..." (PromptReplies, testid `generating-artifact-indicator`) while
+   *      the artifact is being produced, then
+   *   2. "Loading artifact..." (ArtifactRenderer, testid `artifact-loading`) while the renderer
+   *      resolves and lazy-loads it.
+   * ArtifactRenderer mounts already showing "Loading..." in the same commit that removes
+   * "Generating...", so the COMBINED count never dips to 0 mid-handoff - polling the sum to 0
+   * waits out the whole lifecycle without racing the transition. No-op (returns at once) when
+   * neither placeholder is present, so it is safe on prompts that may not render an artifact.
+   */
+  async waitForArtifactSettled(timeout: number = TIMEOUTS.IMAGE_GENERATION) {
+    const root = this.aiResponseRoot.last();
+    const generating = root.getByTestId('generating-artifact-indicator');
+    const loading = root.getByTestId('artifact-loading');
+    await expect.poll(async () => (await generating.count()) + (await loading.count()), { timeout }).toBe(0);
+  }
 }

--- a/apps/client/e2e/pages/ChatPage.ts
+++ b/apps/client/e2e/pages/ChatPage.ts
@@ -237,9 +237,14 @@ export class ChatPage extends BasePage {
    * deferred to {@link waitForImageResponse}, which holds the full IMAGE_GENERATION budget.
    */
   async sendImageMessageAndWaitForResponse(text: string, timeout: number = TIMEOUTS.IMAGE_GENERATION) {
+    // Baseline the newest reply before sending: waitForStreamingComplete's "stop button never
+    // appeared" fallback returns as soon as it sees any non-empty reply, so without this baseline
+    // a prior chat's leftover reply (navigateToNewChat does not await DOM clearing) could be
+    // mistaken for this turn's response.
+    const previousResponse = await this.newestResponseText();
     await this.typeAndWaitForSendReady(text);
     await this.page.keyboard.press('Enter');
-    await this.waitForStreamingComplete(timeout);
+    await this.waitForStreamingComplete(timeout, previousResponse);
   }
 
   /**
@@ -298,11 +303,22 @@ export class ChatPage extends BasePage {
    * "Generating...", so the COMBINED count never dips to 0 mid-handoff - polling the sum to 0
    * waits out the whole lifecycle without racing the transition. No-op (returns at once) when
    * neither placeholder is present, so it is safe on prompts that may not render an artifact.
+   *
+   * Caveat: this only guarantees no placeholder is currently pending, not that an artifact
+   * rendered. waitForStreamingComplete has early-return paths (stop button never appeared; text
+   * stabilised while it stayed visible) that can return before "<artifact" has streamed; in that
+   * narrow window the count is already 0 and this returns at once. Fine for these prompts, which
+   * do stream an artifact - revisit if a prompt relies on this as proof one mounted.
    */
   async waitForArtifactSettled(timeout: number = TIMEOUTS.IMAGE_GENERATION) {
     const root = this.aiResponseRoot.last();
     const generating = root.getByTestId('generating-artifact-indicator');
     const loading = root.getByTestId('artifact-loading');
-    await expect.poll(async () => (await generating.count()) + (await loading.count()), { timeout }).toBe(0);
+    await expect
+      .poll(async () => (await generating.count()) + (await loading.count()), {
+        timeout,
+        message: 'Artifact placeholders ("Generating artifact..." / "Loading artifact...") never cleared',
+      })
+      .toBe(0);
   }
 }


### PR DESCRIPTION
## Description

The `E2E AI Latency Tests` suites flaked and intermittently went red on image-generating and artifact-producing prompts, in three distinct ways (all diagnosed and tracked in #1696):

1. **Streamed past the flat 120s cap.** The per-response wait used `TIMEOUTS.AI_RESPONSE` (120s) even though the test budget is 15m, so heavy multi-image prompts (the 10-page children's story book, ~11 images) blew the cap and hard-failed at 120s.
2. **Scraped an artifact placeholder as the answer.** Streaming completing does not mean the reply is final: an artifact reply shows `Generating artifact...` then `Loading artifact...` before its content mounts. The keyword check ran on that placeholder text and failed (Taipei night markets, story book).
3. **Keyword-matched text on an image-only reply.** The futuristic-city image prompt generated the image correctly but with no caption, so the text keyword check found nothing and failed - a model-dependent false negative (empty on GPT, captioned on Claude).

None of these were app regressions; they were test-harness assumptions that do not hold for image/artifact replies.

## Changes

- Added `expectsImage` / `generatesArtifact` flags to `PromptScenario` and tagged the three affected prompts in the config fixtures.
- **Budget:** image/artifact prompts now use `TIMEOUTS.IMAGE_GENERATION` (360s) for the per-response wait; plain text prompts keep the 120s budget.
- **Image prompts** assert on the rendered image (`waitForImageResponse`, which already checks `naturalWidth > 0`) instead of text keywords.
- **Artifact prompts** wait out both placeholders via a new `waitForArtifactSettled` that polls the combined count of `generating-artifact-indicator` + `artifact-loading` to zero (they hand off in a single React commit, so the sum never dips to 0 mid-transition - no race), then run the keyword check on the resolved content.
- **Image prompt asserts on the image, not text.** An image prompt soft-asserts that an image rendered (`tryWaitForImageResponse` -> `expect.soft(...).toBe(true)`): a missing image turns the Quality column red while latency still records and the run continues. It deliberately does NOT fall back to its keyword list, which is generic prose (`here`, `picture`, `generated`) that a refusal would also satisfy - that fallback would green-light a real image-generation outage.
- **Artifact prompts degrade gracefully:** `waitForArtifactSettled` is a no-op when no placeholder appears, so an artifact prompt that produces plain text still validates on its (meaningful) keyword list rather than failing.
- Added `data-testid="generating-artifact-indicator"` to the "Generating artifact..." spinner in `PromptReplies.tsx` (the "Loading artifact..." one in `ArtifactRenderer.tsx` already had `artifact-loading`).

## Guide for Testers

This is an E2E-harness change; it is validated by running the `ai-latency` suites against staging. Requires `E2E_CLEANUP_SECRET` in `apps/client/.env.e2e` with `API_URL=https://app.staging.bike4mind.com`.

1. From `apps/client/`, run the tool-prompts suite pinned to an image-capable model:
   `AI_LATENCY_RUN=true AI_MODEL="GPT-5.6 Sol" npx playwright test --project=ai-latency-tool-prompts --retries=0`
   Expected: the `Generate a picture of a futuristic city without cars` prompt passes even when the reply has no caption text.
2. Run the intermediate-tools suite pinned to a model:
   `AI_LATENCY_RUN=true AI_MODEL="Claude 5 Opus" npx playwright test --project=ai-latency-intermediate-tools --retries=0`
   Expected: the story-book and Taipei night-markets prompts pass; neither fails on a `Generating artifact...` / `Loading artifact...` placeholder, and story-book is not cut off at 120s.

Note: the suites deterministically pick 3 prompts per day, so forcing a specific prompt requires temporarily reducing the config fixture to the target prompt(s). This was done during verification and reverted.

### Regression Checks
- Plain text prompts (short-answers, long-answers, the non-image tool prompts) still keyword-check on text and pass unchanged.
- An artifact prompt on a model that produces no artifact still validates on its text keyword list (the settle wait no-ops).
- An image prompt on a model that renders no image soft-fails (Quality red), rather than green-lighting via a generic keyword match.

### What NOT to test
- No app/UI behavior changes here beyond one added `data-testid`. There is nothing to click through in the product UI.

## Additional Information

**Verified on staging across both matrix models (retries off, first-attempt passes):**

| Prompt | Failure mode | GPT-5.6 Sol | Claude 5 Opus |
|---|---|---|---|
| `city-no-cars-image` | image-only reply -> text-keyword false negative | PASS (~33-41s, `textlen=0`, passed on the image) | PASS (~22s, `textlen=317`, caption present) |
| `taipei-night-markets` | scraped `Generating/Loading artifact...` placeholder | PASS (2.4m) | PASS (5.1m) |
| `childrens-storybook` | streamed past the flat 120s cap | PASS (2.7m) | PASS (6.2m) |

The cross-model run also surfaced the second placeholder (`Loading artifact...`, distinct from `Generating artifact...`) on GPT story-book, which the `waitForArtifactSettled` combined-count poll now covers. `city-no-cars-image` passing with an empty caption on GPT and a caption on Claude is the point of asserting on the image rather than text.

Closes #1696.

## Developer Notes (Optional)

- `PromptScenario` now supports `expectsImage` / `generatesArtifact` - a reusable way to declare a prompt's deliverable so the harness asserts on the right signal (rendered image vs resolved artifact vs prose) and budgets time accordingly.
- `ChatPage.waitForArtifactSettled` and `ChatPage.tryWaitForImageResponse` are reusable for any spec that drives artifact- or image-producing replies.
- The combined-count-to-zero pattern is a general way to wait out a multi-stage placeholder handoff without racing the transition between components.

---

## Update: metric semantics (addressing review)

Chose **option 3** from the review: keep the gated latency average **text-streaming-only** by excluding image/artifact prompts, rather than raising `thresholdSec` (which would blind the gate to real text-streaming regressions, since `intermediate-tools` mixes text and artifact prompts under one average).

- Image/artifact results are flagged `measuresDeliverable` and folded **out** of `averageResponseTimeSec` in `persistResults`. Text prompts (always >= 1 in any 3-of-N pick) still form the gated average. `responseTimeMs` is still recorded per prompt for observability.
- Verified on Claude 5 Opus (worst case): `night-markets` 253.8s and `story-book` 273.6s are excluded; the average is the lone text prompt at **83.2s < 150** -> not exceeded. Under the prior revision the 3-prompt average was ~203s -> red.

Also applied the non-blocking nits: image-path budgets now mirror `image-generation.spec.ts` (`AI_RESPONSE` send + `IMAGE_GENERATION` render); `sendImageMessageAndWaitForResponse` baselines the prior reply; the artifact poll has a named failure message and a doc caveat about its early-return no-op.

---

## Update 2: round-2 review (@cgtorniado)

Two blocking items addressed:

1. **Image fallback could green-light a real image-gen outage.** The `expectsImage` path no longer falls back to the keyword list (which is generic prose a refusal also matches); it soft-asserts the rendered image. A missing image now reddens the Quality column, while latency still records and the run continues.
2. **Image send budget was too small.** The image is tool-produced while the reply streams (stop button hides only when generation finishes; `textlen 0`), so the send now uses `IMAGE_GENERATION`, not `AI_RESPONSE`. `image-generation.spec.ts` was not a valid precedent - it selects an image model. Bumped `tool-prompts` `timeoutMultiplier` 10 -> 15 to fit.

Also from the round-2 notes: bumped `intermediate-tools` `timeoutMultiplier` 15 -> 20 so an artifact prompt that hits the one `request timed out` retry (image-gen send budget spent twice) plus the settle wait surfaces as a clean assertion failure rather than an opaque test timeout.

Left as-is with rationale: the image send keeps no `request timed out` retry (image gen does not emit that string, and the soft-assert already surfaces a missing image); no loud throw on `gatedResults.length === 0` (`persistResults` runs per-prompt, so a deliverable prompt persisted before any text prompt transiently has an empty gated set - a throw there would break mid-run persistence; the empty case is unreachable anyway since every 3-of-N pick includes >= 1 text prompt).

---

## Update 3: measurement window (@ken-b4m / @onoya)

Remaining P1 from the latest reviews: `responseTimeMs` (and the `responseRateCharsPerSec` derived from it) spanned the image render / artifact settle, so per-prompt numbers claimed streaming latency but were not. The `measuresDeliverable` exclusion had fixed the gated average but not these per-prompt fields.

Implemented the reviewers' prescribed shape: capture `streamEndMs` right after the send (stop-generation button gone, before the image/artifact wait). `responseTimeMs` and `responseRateCharsPerSec` are now over the stream window; the render/settle tail is recorded as its own `renderTimeMs` / `renderTimeSec`. Text prompts get `renderTime` 0 and a `responseTimeMs` identical to `origin/main`.

Verified on GPT-5.6 Sol: storybook stream 126.0s / render 0.375s, night-markets 118.4s / 0.922s, smartphone (text) 26.9s / 0s; `averageResponseTimeSec` 26.867 (text only) < 150.
