### PR TITLE
fix(deploy): copy @bike4mind/hearth into the mcpHandler bundle

### DIFF
--- a/infra/mcp.ts
+++ b/infra/mcp.ts
@@ -4,11 +4,11 @@ import { DEFAULT_LAMBDA_ENVIRONMENT } from './constants';
 import { router } from './router';
 import { secrets } from './secrets';
 
-// Calculate content hash from git tree - changes immediately when MCP/Common code changes
+// Calculate content hash from git tree - changes immediately when MCP/Common/Hearth code changes
 // Matches the content hash pattern used in ci.yml for caching
 // This is a workaround for SST not detecting copyFiles content changes
 const MCP_CONTENT_HASH = execSync(
-  "git ls-tree -r HEAD b4m-core/mcp b4m-core/common | awk '{print $3}' | sort | md5sum | awk '{print $1}'"
+  "git ls-tree -r HEAD b4m-core/mcp b4m-core/common b4m-core/hearth | awk '{print $3}' | sort | md5sum | awk '{print $1}'"
 )
   .toString()
   .trim()
@@ -71,6 +71,17 @@ export const mcpHandler = new sst.aws.Function('mcpHandler', {
     {
       from: 'b4m-core/common/package.json',
       to: 'node_modules/@bike4mind/common/package.json',
+    },
+    // Copied, not installed: hearth is workspace:*, so `install` cannot fetch it. The common
+    // barrel imports it at module load, and an unresolvable import kills the child before the
+    // stdio handshake - surfacing only as `MCP error -32000: Connection closed`.
+    {
+      from: 'b4m-core/hearth/dist',
+      to: 'node_modules/@bike4mind/hearth/dist',
+    },
+    {
+      from: 'b4m-core/hearth/package.json',
+      to: 'node_modules/@bike4mind/hearth/package.json',
     },
   ],
 });


### PR DESCRIPTION
## Problem

Every MCP server child spawned by the `mcpHandler` Lambda dies at module load, so all MCP tools are unavailable on deployed stages. The only symptom in CloudWatch is:

```
MCP Handler failed for github (action: getTools): MCP error -32000: Connection closed
MCP Handler failed for atlassian (action: getTools): MCP error -32000: Connection closed
```

The real error never reaches the logs:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@bike4mind/hearth'
  imported from node_modules/@bike4mind/common/dist/index.mjs
```

## Cause

The children import the `@bike4mind/common` barrel, which imports `@bike4mind/hearth` at module load. `infra/mcp.ts` copies only `mcp` and `common` into the bundle, and `nodejs.install` cannot fetch hearth because it is a `workspace:*` package. The child exits before the stdio handshake, and the SDK reports that as a bare closed transport.

## Fix

Two `copyFiles` entries for `hearth/dist` and `hearth/package.json`, mirroring the existing `mcp` and `common` entries. Hearth also joins the `MCP_CONTENT_HASH` paths so a hearth-only change retriggers the Lambda rebuild.

No change to `nodejs.install` (hearth's only runtime dep is `zod`, already installed at a matching version) and none to `esbuild.external` (the handler imports only `@bike4mind/mcp` and `sst`, so esbuild never resolves a hearth specifier).

## Verification

Reproduced locally by rebuilding the Lambda's `node_modules` layout from the `copyFiles` and `nodejs.install` lists, then spawning the real children with valid credentials so a credential failure could not be confused with a packaging one:

| | github | atlassian | notion |
|---|---|---|---|
| Before | `ERR_MODULE_NOT_FOUND` | `ERR_MODULE_NOT_FOUND` | ok |
| After | 43 tools | 63 tools | 4 tools |

Removing only the hearth entries brings the exact production error back, which is what makes this the cause rather than a coincidence. Notion was unaffected throughout because it does not import the common barrel.

Please confirm on the preview deploy that the bundle contains `node_modules/@bike4mind/hearth/` and that `getTools` returns a non-empty list for github and atlassian.
