### PR TITLE
feat(client): add direct delete affordance to active data lake

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -9,6 +9,8 @@ import DataLakeManagerPanel from './DataLakeManagerPanel';
 
 // Archive resolves synchronously so the onSuccess (exit-to-root) wiring is exercised.
 const archiveMutate = vi.fn((_id: string, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.());
+// Same for the active-lake delete button, so its onSuccess (exit-to-root) wiring is exercised too.
+const deleteMutate = vi.fn((_id: string, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.());
 // Same for purge, so the confirm dialog's close-on-success wiring is exercised.
 const cleanupMutate = vi.fn((_id: string, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.());
 const useActiveDataLakeBatches = vi.fn(() => ({ data: [] as unknown[] }));
@@ -22,7 +24,7 @@ vi.mock('@client/app/hooks/data/dataLakes', () => {
     useArchiveDataLake: () => ({ mutate: archiveMutate, isPending: false }),
     useUnarchiveDataLake: mutation,
     useRestoreDeletedDataLake: mutation,
-    usePermanentDeleteDataLake: mutation,
+    usePermanentDeleteDataLake: () => ({ mutate: deleteMutate, isPending: false }),
     useCleanupDataLake: () => ({ mutate: cleanupMutate, isPending: false }),
     useGetArchivedDataLakes: () => useGetArchivedDataLakes(),
     useGetDeletedDataLakes: () => useGetDeletedDataLakes(),
@@ -164,6 +166,7 @@ beforeEach(() => {
   useGetDataLakes.mockReset();
   useGetDataLakes.mockReturnValue({ data: [mineLake, theirsLake], isLoading: false });
   archiveMutate.mockClear();
+  deleteMutate.mockClear();
   cleanupMutate.mockClear();
   useGetDeletedDataLakes.mockReset();
   useGetDeletedDataLakes.mockReturnValue({ data: undefined });
@@ -428,7 +431,7 @@ describe('DataLakeManagerPanel - lake navigation', () => {
 });
 
 describe('DataLakeManagerPanel - management affordances gate on canManage', () => {
-  it('shows Add files / Settings / Archive on a lake the caller can manage', async () => {
+  it('shows Add files / Settings / Archive / Delete on a lake the caller can manage', async () => {
     const user = userEvent.setup();
     renderPanel();
 
@@ -437,9 +440,10 @@ describe('DataLakeManagerPanel - management affordances gate on canManage', () =
     expect(screen.getByTestId('datalake-addfiles-btn-mine')).toBeInTheDocument();
     expect(screen.getByTestId('datalake-settings-btn-mine')).toBeInTheDocument();
     expect(screen.getByTestId('datalake-archive-btn-mine')).toBeInTheDocument();
+    expect(screen.getByTestId('datalake-delete-active-btn-mine')).toBeInTheDocument();
   });
 
-  it("hides all three on a lake the caller cannot manage (someone else's public lake)", async () => {
+  it("hides all four on a lake the caller cannot manage (someone else's public lake)", async () => {
     const user = userEvent.setup();
     renderPanel();
 
@@ -450,6 +454,7 @@ describe('DataLakeManagerPanel - management affordances gate on canManage', () =
     expect(screen.queryByTestId('datalake-addfiles-btn-theirs')).toBeNull();
     expect(screen.queryByTestId('datalake-settings-btn-theirs')).toBeNull();
     expect(screen.queryByTestId('datalake-archive-btn-theirs')).toBeNull();
+    expect(screen.queryByTestId('datalake-delete-active-btn-theirs')).toBeNull();
   });
 
   it('archiving the active lake exits to the root overview (no re-entry on a later restore)', async () => {
@@ -462,6 +467,20 @@ describe('DataLakeManagerPanel - management affordances gate on canManage', () =
     // The archive's onSuccess clears the active lake, so even though the mocked list still
     // contains 'mine', the panel is back at root - a restore later can't teleport back in.
     expect(archiveMutate).toHaveBeenCalledWith('mine', expect.objectContaining({ onSuccess: expect.any(Function) }));
+    expect(screen.queryByTestId('datalake-manager-lakeinfo')).not.toBeInTheDocument();
+    expect(screen.getByTestId('datalake-manager-overview')).toBeInTheDocument();
+  });
+
+  it('deleting the active lake directly (skipping archive) exits to the root overview', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByTestId('datalake-manager-lake-mine'));
+    await user.click(screen.getByTestId('datalake-delete-active-btn-mine'));
+
+    // Same lifecycle action the archived row's Delete button calls - deleteDataLake has no
+    // archived-status precondition, so this reaches the same recoverable soft-delete.
+    expect(deleteMutate).toHaveBeenCalledWith('mine', expect.objectContaining({ onSuccess: expect.any(Function) }));
     expect(screen.queryByTestId('datalake-manager-lakeinfo')).not.toBeInTheDocument();
     expect(screen.getByTestId('datalake-manager-overview')).toBeInTheDocument();
   });

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
@@ -260,6 +260,11 @@ export default function DataLakeManagerPanel() {
               setPath([]);
               setSelectedFile(null);
             }}
+            onDeleted={() => {
+              setLakeId(null);
+              setPath([]);
+              setSelectedFile(null);
+            }}
           />
         )
       ) : managerTab === 'discover' ? (
@@ -1085,6 +1090,7 @@ function LakeInfoPanel({
   onOpenSettings,
   onReviewTaxonomy,
   onArchived,
+  onDeleted,
 }: {
   lake: ManagerLake;
   fileCount: number | undefined;
@@ -1097,9 +1103,14 @@ function LakeInfoPanel({
    *  derived activeLake re-binding to a lake that just left the list (and a later restore
    *  teleporting back in). */
   onArchived: () => void;
+  /** Same exit-to-root need as onArchived: a direct delete also removes the lake from the
+   *  active list, skipping the archive step entirely (the lifecycle 'delete' action has no
+   *  archived-status precondition). */
+  onDeleted: () => void;
 }) {
   const openWizardForLake = useDataLakeWizardStore(s => s.openWizardForLake);
   const archiveLake = useArchiveDataLake();
+  const deleteLake = usePermanentDeleteDataLake();
   const startChatWithLake = useStartChatWithLake();
   const [startingChat, setStartingChat] = useState(false);
   const visibility = lake.isPublic ? 'Public' : lake.organizationId ? 'Organization' : 'Private';
@@ -1269,6 +1280,24 @@ function LakeInfoPanel({
             </Chip>
           )}
         </Box>
+        {lake.canManage && (
+          <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
+            <Tooltip title="Delete (recoverable - restore from the Deleted section)" size="sm">
+              <Button
+                variant="outlined"
+                color="danger"
+                size="sm"
+                startDecorator={<DeleteOutlineIcon sx={{ fontSize: 16 }} />}
+                data-testid={`datalake-delete-active-btn-${lake.id}`}
+                loading={deleteLake.isPending}
+                onClick={() => deleteLake.mutate(lake.id, { onSuccess: onDeleted })}
+                sx={{ flexShrink: 0, fontSize: '13px' }}
+              >
+                Delete
+              </Button>
+            </Tooltip>
+          </Box>
+        )}
       </Box>
       <Box sx={{ ...TREE_SCROLL_SX, px: 3, py: 2 }}>
         {lake.description ? (


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="964" height="742" alt="delete-button-on-active-lake-after" src="https://github.com/user-attachments/assets/e93f4048-0651-4205-ad71-7fabaf1fd894" />

The new Delete button, live on the PR preview - no archive step needed first.

<img width="246" height="29" alt="lake-moved-to-deleted-section-after" src="https://github.com/user-attachments/assets/cb457e7f-253f-4011-a86f-51a8c0c7d114" />

After clicking it, the lake lands in the Deleted section (restorable), same as the existing archived-row delete.


## Description

An active data lake's header only offered Add files / Settings / Archive, so deleting a lake required archiving it first - and archiving stamps `archivedAt` on every member file, which is a real side effect just to reach a delete button. The backend's delete action (`deleteDataLake`) has no archived-status precondition; it works from any non-deleted status. This PR adds a Delete affordance directly to the active lake's header, reusing the exact lifecycle action the Archived section's Delete button already calls.

Closes #1485

## Changes

- Added a "Danger Zone" block (border-top divider + small outlined danger button) to the active lake's detail header, gated by `lake.canManage` like the existing Add files/Settings/Archive buttons
- Reuses the existing `usePermanentDeleteDataLake` mutation - no backend changes
- Added an `onDeleted` callback (mirrors the existing `onArchived` one) so the panel exits to the root overview after a direct delete
- Added component tests covering the button's canManage gating, the mutation call, and the exit-to-root behavior on success

## Guide for Testers

1. Go to `app.staging.bike4mind.com/data-lakes` (or a PR preview at the same path) and log in as a user with the `EnableDataLakes` flag on.
2. Click "Manage" to open the Data Lakes manager, then click into any active lake you own (or can manage).
3. Confirm a small outlined red "Delete" button appears below the visibility/tag chips, separated by a divider line - this is new; only Add files/Settings/Archive existed before.
4. Click "Delete". Expected: a "Data lake deleted (recoverable)" toast, and the panel returns to the manager's root overview (the lake list).
5. Expand the "Deleted" section in the sidebar. Expected: the lake you just deleted now appears there, with a "Restore" action available.

What NOT to test: the archived-lake lifecycle (archive -> delete -> purge) is unchanged and not part of this PR.

## Additional Information

N/A

## Developer Notes (Optional)

N/A

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated telemetry data classification doc

