### PR TITLE
test(data-lake): guard the embeddingModel exact-match lockstep

### DIFF
--- a/b4m-core/services/src/dataLakeService/embeddingMismatch.ts
+++ b/b4m-core/services/src/dataLakeService/embeddingMismatch.ts
@@ -190,7 +190,7 @@ export interface EmbeddingLabeledFile {
  *
  * Client badges - divergence misleads rather than loses, prompting a reprocess for a healthy file:
  *  - apps/client/app/components/Session/AISettings/FilesSection.tsx (per-file affordance),
- *  - apps/client/app/hooks/useEmbeddingMismatchStatus.ts (session-toolbar dot).
+ *  - apps/client/app/hooks/useEmbeddingMismatchStatus.ts (reddens the session-toolbar file count).
  *
  * The first two retrieval sites are deliberately STRICTER than this predicate (they count an
  * unlabeled file as unreachable where this one scores it), and their own comments explain why they

--- a/b4m-core/services/src/dataLakeService/embeddingMismatch.ts
+++ b/b4m-core/services/src/dataLakeService/embeddingMismatch.ts
@@ -176,17 +176,26 @@ export interface EmbeddingLabeledFile {
  * layer down: fab-pipeline keys its Atlas index registry with a Map, so an unknown model yields
  * no index target and the search degrades to the brute-force scan instead of querying a bogus one.
  *
- * CANONICAL LIST - three other readers compare this same field to the query's as an exact string,
- * and each holds its OWN copy of the rule rather than calling this function:
- *  - the corpus defer gate (llm/ChatCompletionProcess.ts),
- *  - isFabFileCitable (apps/client/server/memory/lakeSourceReachability.ts),
- *  - the Atlas `$vectorSearch` `filter: { embeddingModel }` clause (packages/database
- *    FabFileChunkRepository.vectorSearch).
+ * CANONICAL LIST - six other readers compare this same field to the query's as an exact string, and
+ * each holds its OWN copy of the rule rather than calling this function. So relaxing the comparison
+ * HERE does not propagate to them - it makes them DIVERGE, which is the actual hazard: the rule
+ * moves across all seven in lockstep or not at all.
  *
- * So relaxing the comparison HERE does not propagate to them - it makes the four DIVERGE, which is
- * the actual hazard: the rule has to move in lockstep across all four or not at all. The first two
- * are also deliberately STRICTER than this predicate (they count an unlabeled file as unreachable
- * where this one scores it), and their own comments explain why the three must not be consolidated.
+ * Retrieval path - divergence drops content from results, silently:
+ *  - the corpus defer gate (b4m-core/services/src/llm/ChatCompletionProcess.ts),
+ *  - isFabFileCitable (apps/client/server/memory/lakeSourceReachability.ts),
+ *  - the Atlas `$vectorSearch` filter clause (packages/database/src/models/content/FabFileModel.ts),
+ *  - the self-host OpenSearch `term` clause, the same rule on the other backend
+ *    (b4m-core/services/src/dataLakeService/openSearchChunkAdapter.ts).
+ *
+ * Client badges - divergence misleads rather than loses, prompting a reprocess for a healthy file:
+ *  - apps/client/app/components/Session/AISettings/FilesSection.tsx (per-file affordance),
+ *  - apps/client/app/hooks/useEmbeddingMismatchStatus.ts (session-toolbar dot).
+ *
+ * The first two retrieval sites are deliberately STRICTER than this predicate (they count an
+ * unlabeled file as unreachable where this one scores it), and their own comments explain why they
+ * must not be consolidated onto it. packages/scripts/src/checkEmbeddingModelComparisonSites.test.ts
+ * fails when a site appears that is on neither list, so keep the two in step.
  */
 export function isForeignEmbeddingModel(parentModel: string | null | undefined, queryModel: string): boolean {
   const parent = parentModel?.trim();

--- a/packages/scripts/src/checkEmbeddingModelComparisonSites.test.ts
+++ b/packages/scripts/src/checkEmbeddingModelComparisonSites.test.ts
@@ -65,7 +65,7 @@ const SITES: { path: string; matches: number; note: string }[] = [
   {
     path: 'apps/client/app/hooks/useEmbeddingMismatchStatus.ts',
     matches: 1,
-    note: 'Client badge: drives the session-toolbar mismatch dot. Same tier as FilesSection',
+    note: 'Client badge: reddens the session-toolbar file count. Same tier as FilesSection',
   },
 ];
 

--- a/packages/scripts/src/checkEmbeddingModelComparisonSites.test.ts
+++ b/packages/scripts/src/checkEmbeddingModelComparisonSites.test.ts
@@ -79,12 +79,13 @@ const INLINE_COMPARISON = /[eE]mbeddingModel['"]?\s*(===|!==)|(===|!==)\s*[A-Za-
 
 /**
  * An embeddingModel key inside a search-filter clause, which is how the two vector backends express
- * the same comparison. Requires the filter context on the same line, so ordinary assignments
- * (`embeddingModel: defaultEmbeddingModel`) and type annotations do not trip it. Known limit: a
- * filter clause split across lines evades this, which is why the docstring stays the canonical
- * list - this test is a tripwire, not a proof.
+ * the same comparison. It is the same-line filter context, not the shape of the value, that keeps
+ * ordinary assignments (`embeddingModel: defaultEmbeddingModel`) and type annotations out - so the
+ * value pattern stays wide enough to cover a constant, a PascalCase binding or a quoted literal.
+ * Known limit: a filter clause split across lines evades this, which is why the docstring stays the
+ * canonical list - this test is a tripwire, not a proof.
  */
-const FILTER_CLAUSE = /['"]?(metadata\.)?embeddingModel['"]?\s*:\s*[a-z]\w*/;
+const FILTER_CLAUSE = /['"]?(metadata\.)?embeddingModel['"]?\s*:\s*['"]?[A-Za-z_][\w-]*/;
 const FILTER_CONTEXT = /\b(filter|term|terms|match)\b/;
 
 /**

--- a/packages/scripts/src/checkEmbeddingModelComparisonSites.test.ts
+++ b/packages/scripts/src/checkEmbeddingModelComparisonSites.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * Guards the FabFile.embeddingModel exact-match lockstep. Several independent readers compare a
+ * file's recorded embedding label to the query's as an exact string, and each holds its OWN copy of
+ * the rule rather than calling isForeignEmbeddingModel. Relaxing one does not propagate - it makes
+ * the sites DIVERGE, and the symptom is silent: a correctly-embedded file stops being retrievable
+ * and the user is told to re-embed it. Nothing crashes.
+ *
+ * So the rule has to move across every site in lockstep or not at all, and until this test existed
+ * the only thing saying so was a docstring. This makes an unregistered site fail loudly instead.
+ *
+ * NOT a push toward uniformity: sites 2 and 3 are deliberately STRICTER than the predicate (they
+ * count an unlabeled file as unreachable where it scores one), and their own comments explain why
+ * they must not be consolidated. The guard protects the SET, not sameness within it.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const PREDICATE_FILE = 'b4m-core/services/src/dataLakeService/embeddingMismatch.ts';
+
+/**
+ * The canonical list, kept in step with the isForeignEmbeddingModel docstring (asserted below).
+ * `matches` is how many CODE lines in that file the patterns below hit, so a comparison added or
+ * removed inside an ALREADY-listed file is caught too - the likeliest drift here, since the two
+ * client sites are already near-duplicates of each other.
+ */
+const SITES: { path: string; matches: number; note: string }[] = [
+  {
+    path: PREDICATE_FILE,
+    matches: 0,
+    // The predicate compares its own parameters (`parent !== queryModel.trim()`), so the token
+    // `embeddingModel` never appears beside the operator and the patterns cannot see it. Listed
+    // anyway because it is site 1 of the rule, and its docstring is what the second test reads.
+    note: 'isForeignEmbeddingModel - the shared predicate. Absent/blank label counts as NOT foreign',
+  },
+  {
+    path: 'b4m-core/services/src/llm/ChatCompletionProcess.ts',
+    matches: 1,
+    note: 'Corpus defer gate. Deliberately STRICTER: an unlabeled file counts as unreachable',
+  },
+  {
+    path: 'apps/client/server/memory/lakeSourceReachability.ts',
+    matches: 1,
+    note: 'isFabFileCitable. Deliberately STRICTER, same reason',
+  },
+  {
+    path: 'packages/database/src/models/content/FabFileModel.ts',
+    matches: 1,
+    note: 'Atlas $vectorSearch filter clause - the match happens inside the database',
+  },
+  {
+    path: 'b4m-core/services/src/dataLakeService/openSearchChunkAdapter.ts',
+    matches: 1,
+    note: 'Self-host OpenSearch term clause - the same rule on the other backend',
+  },
+  {
+    path: 'apps/client/app/components/Session/AISettings/FilesSection.tsx',
+    matches: 1,
+    note: 'Client badge: drives the per-file reprocess affordance. Misleads rather than loses content',
+  },
+  {
+    path: 'apps/client/app/hooks/useEmbeddingMismatchStatus.ts',
+    matches: 1,
+    note: 'Client badge: drives the session-toolbar mismatch dot. Same tier as FilesSection',
+  },
+];
+
+/**
+ * An inline `===`/`!==` against something named embeddingModel, in either operand order. The
+ * capital-E alternative matters: it also catches a comparison whose operands are only ever spelled
+ * `queryEmbeddingModel`/`currentEmbeddingModel`, which the bare lowercase token would walk past.
+ * It costs nothing today - both spellings select the same 4 lines.
+ */
+const INLINE_COMPARISON = /[eE]mbeddingModel['"]?\s*(===|!==)|(===|!==)\s*[A-Za-z0-9_.]*[eE]mbeddingModel\b/;
+
+/**
+ * An embeddingModel key inside a search-filter clause, which is how the two vector backends express
+ * the same comparison. Requires the filter context on the same line, so ordinary assignments
+ * (`embeddingModel: defaultEmbeddingModel`) and type annotations do not trip it. Known limit: a
+ * filter clause split across lines evades this, which is why the docstring stays the canonical
+ * list - this test is a tripwire, not a proof.
+ */
+const FILTER_CLAUSE = /['"]?(metadata\.)?embeddingModel['"]?\s*:\s*[a-z]\w*/;
+const FILTER_CONTEXT = /\b(filter|term|terms|match)\b/;
+
+/**
+ * Matches that are NOT this rule. Line-content rules rather than path exemptions on purpose: an
+ * exempted PATH would also hide a genuinely new comparison added to that same file.
+ */
+const NOT_THIS_RULE: { pattern: RegExp; reason: string }[] = [
+  {
+    pattern: /MEMENTO_EMBEDDING_(ID|MODEL)/,
+    reason:
+      'The memento corpus is deliberately decoupled and pinned to its own model - see the ' +
+      'MEMENTO_EMBEDDING_MODEL rationale in b4m-core/common/src/schemas/embedding.ts. Not this rule.',
+  },
+  {
+    pattern: /\.embedding\.model\b/,
+    reason:
+      'Session-message embeddings (`message.embedding.model`) are a different field on a different ' +
+      'corpus, not FabFile.embeddingModel.',
+  },
+  {
+    pattern: /typeof\s+[A-Za-z0-9_.]*[eE]mbeddingModel\s*(===|!==)/,
+    reason: 'A typeof guard on the queue payload, not a comparison of one model to another.',
+  },
+  {
+    pattern: /(?<![.\w])embeddingModel\s*!==\s*defaultEmbeddingModelForEnv\(\)/,
+    reason:
+      'Compares the QUERY model to the deployment default for a telemetry warning. No file label ' +
+      'is involved; a `file.embeddingModel` form still trips the guard.',
+  },
+];
+
+// This file's own path relative to REPO_ROOT, so it excludes itself by exact match rather than by
+// basename (grep's --exclude matches any file with this name, anywhere in the tree).
+const SELF_PATH = path.relative(REPO_ROOT, fileURLToPath(import.meta.url)).replace(/\\/g, '/'); // normalize on Windows
+
+const isTestFile = (file: string) => /\.test\.[cm]?tsx?$/.test(file) || file.includes('__tests__/');
+
+// Comment lines carry the canonical list itself and the sites' own explanatory notes, which quote
+// the comparisons verbatim. Counting them would make every site self-trip.
+const isCommentLine = (text: string) => /^\s*(\/\/|\/\*|\*)/.test(text);
+
+/**
+ * Every embeddingModel comparison in the tree, as `path:line` plus the source text.
+ *
+ * `packages/premium` is excluded: those overlays are private repos hydrated into this tree locally
+ * and absent in CI, so grepping them would make this test's result depend on whether a developer
+ * has them installed.
+ *
+ * The three roots mirror the checkNoRawS3Client precedent and cover every source tree today
+ * (`apps/` holds only `client`; blueprints/data/docs/docs-site/infra/scripts/selfhost contain no
+ * embeddingModel). A NEW top-level workspace directory would be invisible here - add it to the
+ * grep if one appears.
+ */
+function findComparisonSites(): { location: string; path: string; text: string }[] {
+  const out = execSync(
+    // `[eE]` so the prefilter also admits `queryEmbeddingModel`-style spellings; the JS patterns
+    // below do the real selecting, and a case-sensitive grep here would silently starve them.
+    'grep -rn -E "[eE]mbeddingModel" --include="*.ts" --include="*.tsx" --include="*.mts" --include="*.cts" ' +
+      '--exclude-dir=node_modules --exclude-dir=premium --exclude-dir=dist --exclude-dir=.next ' +
+      'apps/client b4m-core packages || true',
+    { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }
+  );
+
+  return out
+    .split('\n')
+    .filter(Boolean)
+    .map(line => {
+      const match = /^([^:]+):(\d+):(.*)$/.exec(line);
+      return match ? { path: match[1], line: match[2], text: match[3] } : null;
+    })
+    .filter((hit): hit is { path: string; line: string; text: string } => hit !== null)
+    .filter(hit => hit.path !== SELF_PATH && !isTestFile(hit.path))
+    .filter(hit => !isCommentLine(hit.text))
+    .filter(hit => INLINE_COMPARISON.test(hit.text) || (FILTER_CLAUSE.test(hit.text) && FILTER_CONTEXT.test(hit.text)))
+    .filter(hit => !NOT_THIS_RULE.some(exclusion => exclusion.pattern.test(hit.text)))
+    .map(hit => ({ location: `${hit.path}:${hit.line}`, path: hit.path, text: hit.text.trim() }));
+}
+
+describe('the embeddingModel exact-match rule moves in lockstep', () => {
+  it('has no comparison site outside the canonical list', () => {
+    const registered = new Set(SITES.map(site => site.path));
+    const unexpected = findComparisonSites()
+      .filter(hit => !registered.has(hit.path))
+      .map(hit => `${hit.location}  ${hit.text}`);
+
+    expect(
+      unexpected,
+      'A new site compares FabFile.embeddingModel to the query model. That rule is duplicated, not ' +
+        'shared, so it has to move across every site in lockstep or not at all. Either register the ' +
+        'site in SITES here AND in the isForeignEmbeddingModel canonical list ' +
+        `(${PREDICATE_FILE}), or add a NOT_THIS_RULE entry saying why it is a different rule. Do NOT ` +
+        'resolve this by consolidating the sites onto isForeignEmbeddingModel: the defer gate and ' +
+        'isFabFileCitable are deliberately stricter than it, and folding them in loosens them in the ' +
+        'content-losing direction.'
+    ).toEqual([]);
+  });
+
+  it('has no comparison added to or removed from a listed site', () => {
+    const found = findComparisonSites();
+    const drift = SITES.filter(site => found.filter(hit => hit.path === site.path).length !== site.matches).map(
+      site => `${site.path}: expected ${site.matches}, found ${found.filter(hit => hit.path === site.path).length}`
+    );
+
+    expect(
+      drift,
+      'The number of embeddingModel comparisons inside an already-listed file changed. If a ' +
+        'comparison was added, it is a new copy of the rule: fold it into the existing one or update ' +
+        "`matches` and say so in the site's note. If one was removed, update `matches` and the " +
+        `canonical list in ${PREDICATE_FILE}.`
+    ).toEqual([]);
+  });
+
+  it('agrees with the isForeignEmbeddingModel canonical list', () => {
+    const source = readFileSync(path.join(REPO_ROOT, PREDICATE_FILE), 'utf8');
+    const start = source.indexOf('CANONICAL LIST');
+    const end = source.indexOf('export function isForeignEmbeddingModel');
+
+    expect(start, `The CANONICAL LIST marker is gone from ${PREDICATE_FILE}; this test reads it.`).toBeGreaterThan(-1);
+    expect(
+      end,
+      `isForeignEmbeddingModel is gone from ${PREDICATE_FILE}; this test reads its docstring.`
+    ).toBeGreaterThan(start);
+
+    const canonicalList = source.slice(start, end);
+    const unlisted = SITES.filter(site => site.path !== PREDICATE_FILE).filter(
+      site => !canonicalList.includes(site.path)
+    );
+
+    expect(
+      unlisted.map(site => site.path),
+      `Every site listed here must also be named in the CANONICAL LIST docstring in ${PREDICATE_FILE}, ` +
+        'so a reader who finds one site finds all of them. Add the missing path there.'
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="2792" height="2060" alt="image" src="https://github.com/user-attachments/assets/1e68682b-1942-4d17-99ab-f88b43d06b74" />

The screenshot is the output of a local script that injects each drift this guard exists to catch
and shows the matching assertion go red, then restores the tree. Read it as three cause-and-effect
pairs. Note that each mutation reds **exactly one** assertion while the other two stay green: the
arms are independent and specific, not a blanket failure. It ends with a byte-identical restore
check.

There is no UI in this PR. This is test evidence, not a screenshot of a feature.

## Description

`FabFile.embeddingModel` is compared to the query's embedding model as an exact string in several
independent places. Each holds its own copy of the rule; none calls a shared predicate. Relaxing the
comparison in one place does not propagate, it makes the sites DIVERGE, and the symptom is silent: a
correctly embedded file quietly stops being retrievable and the user is told to re-embed it. Nothing
crashes.

PR #1637 documented that coupling in the `isForeignEmbeddingModel` docstring. The review point,
deferred to this issue, was that a comment is doing a guard's job and nothing makes it fail loudly.
This adds the guard, in the shape of the existing `checkNoRawS3Client.test.ts` precedent, and
reconciles the docstring with it.

**The canonical list was already wrong, by more than the issue thought.** The issue reported five
comparison sites (four in the docstring, plus one it found missing). Sweeping the tree while writing
this PR found **seven**. The two extra ones appear in no list anywhere:

- `apps/client/app/hooks/useEmbeddingMismatchStatus.ts:20` compares the same field client-side to
  turn the session-toolbar file-count badge red. It is a near duplicate of the
  `FilesSection.tsx:190` check, with a `String()` coercion the other lacks.
- `b4m-core/services/src/dataLakeService/openSearchChunkAdapter.ts:47` is the self-host OpenSearch
  `term` clause, the same rule as the Atlas `$vectorSearch` filter on the other backend. The
  docstring named the Atlas clause only, so a relaxation applied there alone would silently split
  the two backends.

The issue's own line reference had already drifted before work started, and drifted again during it:
the corpus defer gate was cited as `ChatCompletionProcess.ts:954` in the issue, sat at `:1014` when
this branch was cut, and is at `:1071` after merging `main`. That is the argument for the design
choice below: the guard asserts on paths and per-file counts, never on line numbers.

This does NOT consolidate the sites. The corpus defer gate and `isFabFileCitable` are deliberately
stricter than the predicate, and their own comments say so. The guard protects the set, not sameness
within it, and its failure message says so explicitly.

Closes #1686

## Changes

- **New** `packages/scripts/src/checkEmbeddingModelComparisonSites.test.ts` (222 lines) with three
  assertions:
  1. no comparison site outside the registered list
  2. no comparison added to or removed from an already registered file, via a per-file expected
     count, so a second copy added beside an existing one is caught. That is the likeliest drift
     here, since two of the sites are already near duplicates of each other.
  3. the registered list and the `isForeignEmbeddingModel` canonical docstring name the same files,
     so the two cannot drift apart
- **Updated** the CANONICAL LIST in `b4m-core/services/src/dataLakeService/embeddingMismatch.ts` to
  all seven sites, split into two tiers: retrieval path (divergence drops content from results) and
  client badges (divergence misleads, prompting a reprocess for a healthy file). It keeps the "moves
  in lockstep or not at all" and "do not consolidate" language from #1637, and names the guard test.

Exclusions live in the test file with a stated reason each, so a future reader does not "fix" the
omission: the memento corpus (deliberately decoupled and pinned to its own model), session-message
embeddings (`message.embedding.model`, a different field on a different corpus), a `typeof` payload
guard, and a query-versus-deployment-default telemetry comparison that involves no file label. They
are line-content rules rather than path exemptions on purpose: an exempted path would also hide a
genuinely new comparison added to that same file.

No workflow change is needed. `@bike4mind/scripts` is not named in any test-shard bucket and `misc`
is a negation catch-all, so this file is picked up by `Run Tests (misc)` by construction.

## Guide for Testers

**No manual QA is possible or required, and the preview environment cannot show anything for this
PR.** The only shipped source change is a JSDoc comment block; the other file is a test, executed
only by vitest in the `misc` shard and never imported by application code. There is no runtime code,
no API surface and no UI here, so a preview walkthrough would only attest that the app still works,
while reading on this PR as though the change had been verified.

Verification is code-level and is described under Additional Information.

### What NOT to test

1. Do not look for a UI change. There is none.
2. Do not attempt to verify data-lake retrieval or the file "reprocess" badge. This PR changes
   neither. It only makes a future change to those comparisons fail loudly in CI.
3. Do not treat a green `Run Tests (misc)` shard as proof that the embedding rule is correct. The
   guard asserts that the set of comparison sites is registered, not that any comparison is right.

## Additional Information

The guard was verified by making it fail, not by observing it pass. A tripwire that only ever passes
is indistinguishable from a test that asserts nothing. All three arms were proven deliberately, each
mutation reverted afterwards and the tree confirmed byte-identical:

1. **A new, unregistered comparison site** reds assertion 1, and the failure output names the exact
   `file:line` and tells the author to register the site or add an exclusion with a reason.
2. **A second comparison inside an already registered file** reds assertion 2.
3. **Removing one registered path from the canonical docstring** reds assertion 3, naming the
   missing path.

Assertion 3 was also genuinely red before the docstring was rewritten, listing the five paths the
old text did not contain: three sites it never mentioned at all, and two it referred to without a
full path. That was unplanned, and is the clearest evidence the check does what it claims.

<details>
<summary>The exact script that produced the screenshot (copy, save, run)</summary>

Save as `prove-embedding-lockstep-guard.sh` anywhere and run `bash prove-embedding-lockstep-guard.sh`
from inside the repo. It is idempotent and restores every file it touches through an `EXIT`/`INT`/
`TERM` trap, so interrupting it mid-run still leaves the tree byte-identical. It restores from temp
copies rather than `git checkout`, so it is safe to run with unrelated uncommitted changes present.
Exit code is the number of checks that did not behave as expected, so `echo $?` is `0` on success.

```bash
#!/usr/bin/env bash
#
# Evidence for #1686: proves the embeddingModel lockstep guard FAILS when it should.
#
# A tripwire that only ever passes is indistinguishable from a test that asserts nothing, so
# "3 passed" is not evidence. This injects each drift the guard exists to catch and shows the
# matching assertion go red, then restores the tree.
#
# Reads vitest --reporter=json via --outputFile rather than parsing pretty console output: on a
# FAILING run the JSON reporter's stdout is not cleanly parseable, and pretty output has proven
# locale- and width-dependent. All text filtering here is ASCII-only for the same reason.

set -euo pipefail

REPO_ROOT="$(git rev-parse --show-toplevel)"
cd "$REPO_ROOT"

TEST_PATH="src/checkEmbeddingModelComparisonSites.test.ts"
PROBE_FILE="apps/client/server/memory/lockstepProbeSite.ts"
HOOK_FILE="apps/client/app/hooks/useEmbeddingMismatchStatus.ts"
DOC_FILE="b4m-core/services/src/dataLakeService/embeddingMismatch.ts"
DOC_PATH_LINE="apps/client/app/hooks/useEmbeddingMismatchStatus.ts"

TITLE_UNREGISTERED="has no comparison site outside the canonical list"
TITLE_COUNT_DRIFT="has no comparison added to or removed from a listed site"
TITLE_DOC_DRIFT="agrees with the isForeignEmbeddingModel canonical list"

WORK_DIR="$(mktemp -d)"
JSON_OUT="$WORK_DIR/vitest.json"
FAILURES=0

restore() {
  local status=$?
  [ -f "$WORK_DIR/hook.bak" ] && cp "$WORK_DIR/hook.bak" "$HOOK_FILE"
  [ -f "$WORK_DIR/doc.bak" ] && cp "$WORK_DIR/doc.bak" "$DOC_FILE"
  rm -f "$PROBE_FILE"
  rm -rf "$WORK_DIR"
  return $status
}
trap restore EXIT INT TERM

cp "$HOOK_FILE" "$WORK_DIR/hook.bak"
cp "$DOC_FILE" "$WORK_DIR/doc.bak"

hr() { printf '%s\n' "----------------------------------------------------------------------"; }

run_guard() {
  rm -f "$JSON_OUT"
  pnpm --filter @bike4mind/scripts exec vitest run "$TEST_PATH" \
    --reporter=json --outputFile="$JSON_OUT" >/dev/null 2>&1 || true

  if [ ! -f "$JSON_OUT" ]; then
    echo "  ERROR: vitest produced no JSON output; cannot verify."
    return 1
  fi

  python3 - "$JSON_OUT" "$WORK_DIR/failed_titles" <<'PY'
import json, sys

data = json.load(open(sys.argv[1]))
failed = []
for suite in data.get("testResults", []):
    for a in suite.get("assertionResults", []):
        mark = "PASS" if a["status"] == "passed" else "FAIL"
        print("  [%s] %s" % (mark, a["title"]))
        if a["status"] != "passed":
            failed.append(a["title"])
            msg = a["failureMessages"][0].split("\n")[0]
            # First sentence only: the actionable instruction, without the stack trace.
            head = msg.split(". ")[0]
            if head.startswith("AssertionError: "):
                head = head[len("AssertionError: "):]
            print("         -> %s." % head[:150])

print("  totals: %d passed, %d failed" % (data.get("numPassedTests", 0), data.get("numFailedTests", 0)))
open(sys.argv[2], "w").write("\n".join(failed))
PY
}

# assert_red <expected assertion title> <label>
assert_red() {
  local expected="$1" label="$2"
  if grep -Fxq "$expected" "$WORK_DIR/failed_titles" 2>/dev/null; then
    echo "  RESULT: EXPECTED FAILURE OBSERVED - $label"
  else
    echo "  RESULT: *** NO FAILURE *** - the guard did NOT catch $label"
    FAILURES=$((FAILURES + 1))
  fi
}

assert_green() {
  if [ -s "$WORK_DIR/failed_titles" ]; then
    echo "  RESULT: *** UNEXPECTED FAILURE *** - baseline should be green"
    FAILURES=$((FAILURES + 1))
  else
    echo "  RESULT: all assertions green"
  fi
}

echo
hr
echo "  #1686 evidence: the embeddingModel lockstep guard fails when it should"
echo "  head: $(git rev-parse --short HEAD)  branch: $(git rev-parse --abbrev-ref HEAD)"
hr

echo
echo "STEP 0 - BASELINE (unmodified tree): the guard passes"
run_guard
assert_green

echo
hr
echo "STEP 1 - inject an UNREGISTERED comparison site in a new file"
echo "  file: $PROBE_FILE"
cat > "$PROBE_FILE" <<'EOF'
export function probe(file: { embeddingModel?: string }, queryModel: string): boolean {
  return file.embeddingModel === queryModel;
}
EOF
run_guard
assert_red "$TITLE_UNREGISTERED" "a new comparison site"
rm -f "$PROBE_FILE"

echo
hr
echo "STEP 2 - inject a SECOND comparison inside an already-registered file"
echo "  file: $HOOK_FILE"
python3 - "$HOOK_FILE" <<'PY'
import sys
path = sys.argv[1]
src = open(path).read()
anchor = "      return file.embeddingModel && String(currentEmbeddingModel) !== file.embeddingModel;"
added = "      const probeSecondCopy = file.embeddingModel === currentEmbeddingModel;\n"
assert anchor in src, "anchor line not found in %s" % path
open(path, "w").write(src.replace(anchor, added + anchor, 1))
PY
run_guard
assert_red "$TITLE_COUNT_DRIFT" "a duplicate comparison in a listed file"
cp "$WORK_DIR/hook.bak" "$HOOK_FILE"

echo
hr
echo "STEP 3 - drift the canonical docstring: remove one registered path from it"
echo "  file: $DOC_FILE"
echo "  removed: $DOC_PATH_LINE"
python3 - "$DOC_FILE" "$DOC_PATH_LINE" <<'PY'
import sys
path, needle = sys.argv[1], sys.argv[2]
src = open(path).read()
assert needle in src, "path %s not found in %s" % (needle, path)
open(path, "w").write(src.replace(needle, "", 1))
PY
run_guard
assert_red "$TITLE_DOC_DRIFT" "the docstring drifting from the test"
cp "$WORK_DIR/doc.bak" "$DOC_FILE"

echo
hr
echo "STEP 4 - RESTORED: tree is back to its original state and green again"
run_guard
assert_green

# Byte-identical restore check: proves this script left nothing behind.
if cmp -s "$WORK_DIR/hook.bak" "$HOOK_FILE" && cmp -s "$WORK_DIR/doc.bak" "$DOC_FILE" && [ ! -f "$PROBE_FILE" ]; then
  echo "  RESTORE: both files byte-identical to their pre-run state, probe file removed"
else
  echo "  RESTORE: *** MISMATCH *** - inspect the working tree before committing"
  FAILURES=$((FAILURES + 1))
fi

echo
hr
if [ "$FAILURES" -eq 0 ]; then
  echo "  VERDICT: PASS - the guard caught all 3 drifts and stayed green otherwise."
else
  echo "  VERDICT: FAIL - $FAILURES check(s) did not behave as expected."
fi
hr
echo

exit "$FAILURES"
```

</details>

Self-review found one substantive defect in the guard itself, worth stating because it is the kind
of bug a guard can hide. The comparison pattern originally matched only a lowercase-initial
`embeddingModel`, so a future site written `queryEmbeddingModel !== fileModel`, where neither operand
carries the bare token, would have been missed. Widening the pattern alone was not enough: the `grep`
prefilter was still case-sensitive, so such a line never reached the pattern at all and the first fix
changed nothing. Both stages are widened now, and the probe was re-run to confirm it catches that
shape.

Two deliberate limits, both documented in the test file:

- A search-filter clause split across multiple lines is not matched. The docstring remains the
  canonical list; this test is a tripwire, not a proof.
- The grep roots (`apps/client`, `b4m-core`, `packages`) mirror the S3 precedent. They cover every
  source tree at present: `apps/` contains only `client`, and there are no `embeddingModel`
  occurrences under `blueprints`, `data`, `docs`, `docs-site`, `infra`, `scripts` or `selfhost`. A
  new top-level workspace directory would need adding here.

The grep excludes `packages/premium`, which is empty in this repository and populated only in trusted
contexts. Including it would make the result depend on the environment the test runs in rather than
on the code under review. Any future tree-walking guard needs the same exclusion.

## Developer Notes (Optional)

- **Reusable guard shape.** `checkNoRawS3Client.test.ts` established the pattern: grep the tree,
  allowlist the known sites, fail on anything new. This extends it in two ways that are worth
  copying. A per-path expected count catches drift *inside* an already allowlisted file, which a
  bare path set cannot see. Line-content exclusions replace path exemptions, because an exempted
  path also hides a genuinely new violation added to that same file.
- **The count assertion is also what prevents a vacuous pass.** The grep ends in `|| true`, so if it
  ever breaks it yields empty output and assertion 1 would pass on nothing. Assertion 2 catches that
  as `expected 1, found 0`.
- **Tree-walking guards must exclude `packages/premium`.** One that does not is environment-dependent
  by construction, and can fail locally for reasons unrelated to the code under review.
- **Docstring-as-contract.** Assertion 3 turns a comment into something CI enforces. Where a comment
  is load-bearing, a cheap test asserting that the code and the comment name the same things is worth
  more than a longer comment.

## Checklist

- [x] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable) - N/A, no settings added
- [x] I have made the UI/UX feel good (toasters, size, responsive, etc) - N/A, no UI in this PR
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) - the canonical docstring is updated in the same PR, and assertion 3 enforces that it stays in step
- [x] My changes generate no new warnings
- [x] If adding/modifying telemetry fields: updated telemetry data classification doc - N/A, no telemetry fields touched
