### PR TITLE
fix(data-lake): self-host reconciler parity and a stuck-batches alarm

### DIFF
--- a/apps/client/server/cron/dataLakeBatchReconcile.e2e.test.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.e2e.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+// createMongoServer is not exported from the package barrel / dist; deep-import the source.
+import { createMongoServer } from '../../../../packages/database/src/__test__/createMongoServer';
+import { dataLakeBatchRepository } from '@bike4mind/database';
+import { dataLakeService } from '@bike4mind/services';
+
+/**
+ * Real-Mongo guard for runStuckBatchSweep: both the hosted daily cron (handler(), in
+ * dataLakeBatchReconcile.test.ts, fully mocked) and the self-host worker's new scheduled task
+ * (worker/main.ts) call this function directly, so proving it actually persists the
+ * forced-terminal transition against a real batch document - not a mocked reconciler - is what
+ * backs self-host's new dependency on it. Lives in apps/client because it is the only package
+ * with both @bike4mind/services and @bike4mind/database as dependencies. Consumes the built
+ * dist, so `pnpm turbo:core:build` must be current.
+ */
+
+const h = vi.hoisted(() => ({
+  recordForced: vi.fn(),
+  recordGauge: vi.fn(),
+}));
+vi.mock('@server/utils/cloudwatch', () => ({
+  recordReconcilerForcedTerminal: (...a: unknown[]) => h.recordForced(...a),
+  recordStuckBatchGauge: (...a: unknown[]) => h.recordGauge(...a),
+}));
+
+import { runStuckBatchSweep } from './dataLakeBatchReconcile';
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await createMongoServer();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+}, 30000);
+afterEach(async () => {
+  await mongoose.connection.dropDatabase();
+  vi.clearAllMocks();
+});
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Parameters<typeof runStuckBatchSweep>[0];
+
+const TIMEOUT_MS = dataLakeService.DEFAULT_STUCK_BATCH_TIMEOUT_MS;
+
+// timestamps:true auto-stamps updatedAt to now on create, so backdate it directly
+// (timestamps:false) to seed a genuinely-stale doc - mirrors DataLakeModel.test.ts's seedBatch.
+async function seedBatch(status: string, ageMs: number) {
+  const batch = await dataLakeBatchRepository.create({
+    dataLakeId: 'lake1',
+    userId: 'u1',
+    status,
+    totalFiles: 1,
+  } as never);
+  await mongoose.models.DataLakeBatch.updateOne(
+    { _id: batch.id },
+    { $set: { updatedAt: new Date(Date.now() - ageMs) } },
+    { timestamps: false }
+  );
+  return batch;
+}
+
+describe('runStuckBatchSweep - real repos + real Mongo (hosted + self-host shared entrypoint)', () => {
+  it('forces a genuinely-stuck batch terminal in the real DB and reports it', async () => {
+    const stuck = await seedBatch('processing', TIMEOUT_MS + 60_000);
+
+    const result = await runStuckBatchSweep(logger);
+
+    expect(result.candidates).toBe(1);
+    expect(result.forced).toEqual([stuck.id]);
+    const after = await dataLakeBatchRepository.findById(stuck.id);
+    expect(after?.status).toBe('completed_with_errors');
+    expect(h.recordGauge).toHaveBeenCalledWith(1);
+    expect(h.recordForced).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a batch under the timeout untouched', async () => {
+    const fresh = await seedBatch('processing', TIMEOUT_MS - 60_000);
+
+    const result = await runStuckBatchSweep(logger);
+
+    expect(result.candidates).toBe(0);
+    expect(result.forced).toEqual([]);
+    const after = await dataLakeBatchRepository.findById(fresh.id);
+    expect(after?.status).toBe('processing');
+    expect(h.recordForced).not.toHaveBeenCalled();
+  });
+
+  it('a zero-candidate run reports cleanly with no side effects', async () => {
+    const result = await runStuckBatchSweep(logger);
+    expect(result).toEqual({ candidates: 0, forced: [] });
+    expect(h.recordForced).not.toHaveBeenCalled();
+    expect(h.recordGauge).toHaveBeenCalledWith(0);
+  });
+});

--- a/apps/client/server/cron/dataLakeBatchReconcile.ts
+++ b/apps/client/server/cron/dataLakeBatchReconcile.ts
@@ -10,6 +10,9 @@
  * so a race between the two just makes the loser a no-op. Idempotent across runs (forced batches
  * leave the non-terminal set), capped per run so it stays inside the Lambda timeout.
  *
+ * runStuckBatchSweep is also the self-host worker's counterpart (worker/main.ts) - self-host has
+ * no SST cron, so it drives the same sweep off its own scheduled-task interval.
+ *
  * Schedule: daily. Enabled: production + dev.
  */
 
@@ -61,17 +64,19 @@ async function rescueUnchunkedFiles(): Promise<number> {
   return candidates.length;
 }
 
-export async function handler() {
-  const stage = Resource.App.stage;
-  await connectDB(Config.MONGODB_URI.replace('%STAGE%', stage));
-
+/**
+ * Find + reconcile stuck data-lake batches. The hosted daily cron (handler(), below) and the
+ * self-host worker's scheduled task (worker/main.ts) both come through here, so the two drivers
+ * run the exact same stuck-batch logic rather than the self-host path drifting from the cron.
+ */
+export async function runStuckBatchSweep(runLogger: Logger): Promise<{ candidates: number; forced: string[] }> {
   const timeoutMs = dataLakeService.DEFAULT_STUCK_BATCH_TIMEOUT_MS;
   const cutoff = new Date(Date.now() - timeoutMs);
   const stuck = await dataLakeBatchRepository.findStuck(cutoff, MAX_PER_RUN);
 
   const forced = await dataLakeService.reconcileStuckBatches(stuck, timeoutMs, {
     db: { dataLakes: dataLakeRepository, batches: dataLakeBatchRepository, fabFiles: fabFileRepository },
-    logger,
+    logger: runLogger,
     metrics: {
       // Also backstops the taxonomy enqueue for a batch that never reached upload-complete
       // NOR a terminal chunk/vectorize event (finalizeBatchIfComplete already backstops the
@@ -80,11 +85,20 @@ export async function handler() {
       emitForcedTerminal: batch =>
         Promise.all([
           recordReconcilerForcedTerminal().catch(() => {}),
-          enqueueTaxonomyAnalysisIfWanted(batch, logger).catch(() => {}),
+          enqueueTaxonomyAnalysisIfWanted(batch, runLogger).catch(() => {}),
         ]).then(() => {}),
       emitStuckGauge: count => recordStuckBatchGauge(count).catch(() => {}),
     },
   });
+
+  return { candidates: stuck.length, forced };
+}
+
+export async function handler() {
+  const stage = Resource.App.stage;
+  await connectDB(Config.MONGODB_URI.replace('%STAGE%', stage));
+
+  const { candidates, forced } = await runStuckBatchSweep(logger);
 
   // Global fallback for the background AI-tagging phase - the read-time reconciler
   // (10-minute timeout) is the primary backstop; this daily sweep catches a stuck job on a
@@ -107,7 +121,7 @@ export async function handler() {
   await recordReconcileRun().catch(() => {});
 
   logger.info('[DataLakeBatchReconcile] Sweep complete', {
-    candidates: stuck.length,
+    candidates,
     forced: forced.length,
     taxonomyCandidates: stuckTaxonomy.length,
     taxonomyForced: forcedTaxonomy.length,
@@ -116,7 +130,7 @@ export async function handler() {
   return {
     statusCode: 200,
     body: JSON.stringify({
-      candidates: stuck.length,
+      candidates,
       forced: forced.length,
       taxonomyCandidates: stuckTaxonomy.length,
       taxonomyForced: forcedTaxonomy.length,

--- a/apps/client/server/worker/main.ts
+++ b/apps/client/server/worker/main.ts
@@ -12,6 +12,7 @@ import { dispatch as fabFileVectorizeDispatch } from '@server/queueHandlers/fabF
 import { dispatch as dataLakeTaxonomyAnalysisDispatch } from '@server/queueHandlers/dataLakeTaxonomyAnalysis';
 import { modelDiscoveryIntervalMs, runScheduledDiscovery } from '@server/modelDiscovery/scheduledRun';
 import { isDiscoveryDriver, startDiscoveryOnStartup } from '@server/modelDiscovery/startupLeg';
+import { runStuckBatchSweep } from '@server/cron/dataLakeBatchReconcile';
 import { SelfHostWorker } from './selfHostWorker';
 import { dispatchSelfHostEvent } from './eventDispatch';
 import { buildFabFileChunkScanFilter, CHUNK_SCAN_BATCH, CHUNK_SCAN_MIN_AGE_MS } from './chunkScan';
@@ -42,6 +43,8 @@ const FAB_FILE_VISIBILITY_TIMEOUT_SEC = 300;
 const SCHEDULER_INTERVAL_MS = 5 * 60_000;
 /** Safety-net scan cadence: catches uploads whose MinIO webhook never arrived. */
 const CHUNK_SCAN_INTERVAL_MS = 60_000;
+/** Matches hosted's daily dataLakeBatchReconcile cron cadence (infra/cron.ts). */
+const DATA_LAKE_BATCH_RECONCILE_INTERVAL_MS = 24 * 60 * 60_000;
 /** Grace period on SIGTERM/SIGINT for in-flight message handling to finish before exit. */
 const DRAIN_GRACE_MS = 20_000;
 
@@ -151,6 +154,13 @@ async function main() {
     }
   });
 
+  // Self-host counterpart of the hosted daily dataLakeBatchReconcile cron (infra/cron.ts):
+  // without this, a self-host batch that nobody's list-view revisits stays stuck indefinitely
+  // now that the timeout is 3 hours instead of 30 minutes. Same shared sweep, same timeout.
+  worker.registerScheduledTask('dataLakeBatchReconcile', DATA_LAKE_BATCH_RECONCILE_INTERVAL_MS, async () => {
+    await runStuckBatchSweep(bootLogger);
+  });
+
   // Remote-provider catalog freshness (sec 6.2). The enableModelDiscovery gate,
   // the lease and the per-source minimum interval all live inside the service,
   // so this closure is the same call the hosted cron makes.
@@ -173,6 +183,15 @@ async function main() {
   // Held (not fire-and-forget) so shutdown can wait for it: a run abandoned
   // mid-flight strands its Mongo lease until the TTL expires.
   const startupLeg = startDiscoveryOnStartup({ logger: bootLogger, host: 'selfhost' });
+
+  // Same "don't wait a full interval" reasoning as the discovery startup leg above, but not
+  // held for shutdown: each batch transition is an atomic guarded single-document update
+  // (markTerminalIfActive), so an abandoned run leaves no lease behind to strand.
+  runStuckBatchSweep(bootLogger).catch(err => {
+    bootLogger.error('[dataLakeBatchReconcile] startup sweep failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
 
   const shutdown = async (signal: string) => {
     bootLogger.info(`${signal} received - draining selfHostWorker (up to ${DRAIN_GRACE_MS}ms)`);

--- a/infra/alarms.ts
+++ b/infra/alarms.ts
@@ -125,6 +125,10 @@ export const deprecatedModelRequestAlarm = isMonitoredStage
   ? new sst.aws.SnsTopic('DeprecatedModelRequestAlarm')
   : undefined;
 
+export const dataLakeStuckBatchesAlarm = isMonitoredStage
+  ? new sst.aws.SnsTopic('DataLakeStuckBatchesAlarm')
+  : undefined;
+
 // --- MetricAlarm definitions (only created for monitored stages) ---
 
 if (isMonitoredStage) {
@@ -1028,6 +1032,37 @@ if (isMonitoredStage) {
     alarmActions: [deprecatedModelRequestAlarm!.arn],
     tags: {
       Application: 'ModelSunset',
+      Severity: 'Medium',
+    },
+  });
+
+  /**
+   * Alarm: Data Lake stuck-batch count
+   *
+   * The reconciler (hosted cron + self-host worker) samples the stuck-batch gauge once per
+   * sweep; each forced-terminal batch is lost work for a user, but an occasional one is expected
+   * noise (e.g. a browser tab closed mid-upload). Threshold 10 in one sample is a systemic
+   * problem, not a one-off.
+   *
+   * Metric emitted by: server/utils/cloudwatch.ts -> recordStuckBatchGauge, wired from
+   * server/cron/dataLakeBatchReconcile.ts's runStuckBatchSweep.
+   * Namespace: Lumina5/DataLakeBatch / StuckBatches
+   */
+  new aws.cloudwatch.MetricAlarm('dataLakeStuckBatchesHigh', {
+    name: `${$app.name}-${$app.stage}-data-lake-stuck-batches-high`,
+    alarmDescription:
+      'Data lake stuck-batch count crossed threshold - the reconciler is forcing an unusual number of batches terminal',
+    comparisonOperator: 'GreaterThanThreshold',
+    evaluationPeriods: 1,
+    metricName: 'StuckBatches',
+    namespace: 'Lumina5/DataLakeBatch',
+    period: 86400, // 1 day - matches the once-per-sweep sample cadence
+    statistic: 'Maximum',
+    threshold: 10,
+    treatMissingData: 'notBreaching',
+    alarmActions: [dataLakeStuckBatchesAlarm!.arn],
+    tags: {
+      Application: 'DataLakeBatch',
       Severity: 'Medium',
     },
   });


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video

<img width="824" height="517" alt="reconciler-before-after" src="https://github.com/user-attachments/assets/4c975122-43e1-4ca2-b3f8-32730f4743c9" />

*A real (unmocked) data-lake batch, seeded stuck for 4 hours, before and after `runStuckBatchSweep` runs against a real MongoDB - status flips from `processing` to `completed_with_errors`. This is the exact function the new self-host scheduled task and the existing hosted cron both call.*

## Description

Raising the stuck-batch timeout to 3 hours (#1511) widened two pre-existing gaps: self-host never scheduled the reconciler at all, only the read-time path triggered by opening the batch list, so a batch nobody revisits could sit non-terminal indefinitely; and nothing alarmed on the stuck-batch count metric the reconciler already emits.

Extracted the reconcile logic into `runStuckBatchSweep`, shared by the hosted daily cron and a new self-host scheduled task (with a startup fire, since a scheduled task never runs on registration). Added a CloudWatch alarm on the existing `StuckBatches` gauge.

Closes #1515

## Changes

- Extract `runStuckBatchSweep` out of the hosted cron's handler in `apps/client/server/cron/dataLakeBatchReconcile.ts`; behavior unchanged
- Register the sweep as a self-host scheduled task (daily cadence, matching the hosted cron) plus a startup fire in `apps/client/server/worker/main.ts`
- Add a real-Mongo test proving the sweep actually persists the forced-terminal transition
- Add a CloudWatch alarm on the `Lumina5/DataLakeBatch` / `StuckBatches` metric in `infra/alarms.ts`

## Guide for Testers

Neither half of this PR is UI-reachable, and neither can be fully proven on this PR's own preview (see step 2), so this walks through where each half actually gets verified: self-host, standalone, for the reconciler; `dev`/`production` only for the alarm.

**1. Self-host reconciler parity - runnable standalone, no Docker needed:**

```
docker run -d --rm -p 27019:27017 --name b4m-test-mongo mongo:7
cd apps/client
B4M_SELF_HOST=true APP_STAGE=selfhost \
  MONGODB_URI="mongodb://localhost:27019/b4m_test" \
  JWT_SECRET=x SESSION_SECRET=x SECRET_ENCRYPTION_KEY=x E2E_CLEANUP_SECRET=x \
  RESEARCH_ENGINE_QUEUE=http://localhost:19324/000000000000/researchEngineQueue \
  FAB_FILE_CHUNK_QUEUE=http://localhost:19324/000000000000/fabFileChunkQueue \
  FAB_FILE_VECTORIZE_QUEUE=http://localhost:19324/000000000000/fabFileVectorizeQueue \
  pnpm exec tsx --import ./server/chatCompletion/selfhostSstAlias.mjs server/worker/main.ts
```

- Seed a stuck batch BEFORE starting the worker: insert a `datalakebatches` document with `status: 'processing'` and `updatedAt` backdated more than 3 hours, into the same Mongo.
- Expected: the log line `[selfHostWorker] started: 3 queue(s), 3 scheduled task(s)` (the 3rd task is the new reconciler), immediately followed by `Reconciler forced stuck batch <id> terminal` and `Reconciler forced 1 stuck batch(es) terminal` - fired on worker BOOT, with no API call or UI interaction. Querying the batch afterward shows `status: 'completed_with_errors'`, `completionReason: 'reconciler'`. (The queue pollers will log repeated "Could not load credentials" retries against the dummy queue URLs above - harmless, unrelated to this fix.)
- This is a real run of `apps/client/server/worker/main.ts`, the same entrypoint the self-host Docker image runs - not a mocked unit test.

**2. The CloudWatch alarm - only testable on `dev`/`production`, not on any PR preview:**

`infra/alarms.ts` only creates alarms on the `dev`/`production` stages (or with `ENABLE_MONITORING=true`, which nothing in the deploy pipeline sets for an ordinary PR preview) - so `aws cloudwatch describe-alarms` against THIS PR's preview stage correctly returns nothing, and that's expected, not a bug. After merge, on `dev` or `production`:
```
aws cloudwatch describe-alarms --alarm-name-prefix bike4mind-dev-data-lake-stuck-batches
```
Expected: one alarm named `...-data-lake-stuck-batches-high` on `Lumina5/DataLakeBatch` / `StuckBatches`, threshold 10, period 1 day.

What NOT to test: actually triggering the alarm into ALARM state (would need 10+ genuinely-stuck batches on a shared environment), or the alarm on this PR's own preview (see above).

## Additional Information

The alarm threshold (10 stuck batches in one daily sample) is a judgment call, not a measured value — a handful of forced-terminals from legitimate causes (e.g. a closed browser tab mid-upload) is expected noise; double digits signals a systemic problem. Open to adjustment.

## Developer Notes (Optional)

`runStuckBatchSweep` (in `apps/client/server/cron/dataLakeBatchReconcile.ts`) is now the single entrypoint for the stuck-batch sweep, called by both the hosted cron and the self-host worker - mirrors the existing `runScheduledDiscovery` pattern used for model discovery.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc



