### PR TITLE
fix(datalake): fix bracket-prefix sort and add hover tooltips in the Manage Data Lakes modal

### DIFF
--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.test.tsx
@@ -84,6 +84,11 @@ const lakeFiles = [
   // Tagged with "genre" itself, not a deeper child - "genre" is ALSO the parent of war/peace
   // above, so this file must stay reachable once genre has subfolders.
   { id: 'f5', fileName: 'genre-overview.md', tags: [{ name: 'lk:genre' }] },
+  // Bracket-prefixed source names, all under one leaf - group by category then title, not the
+  // raw leading "[" (which would put every one of these in the same "no signal" bucket).
+  { id: 'f6', fileName: '[Marketing] Zebra Plan.md', tags: [{ name: 'lk:briefs:x' }] },
+  { id: 'f7', fileName: '[Marketing] Apple Plan.md', tags: [{ name: 'lk:briefs:x' }] },
+  { id: 'f8', fileName: '[Sales] Intro.md', tags: [{ name: 'lk:briefs:x' }] },
 ];
 
 const useGetDataLakes = vi.fn(() => ({ data: [] as unknown[], isLoading: false }));
@@ -378,6 +383,20 @@ describe('DataLakeManagerPanel - lake navigation', () => {
     // Selecting it opens the file directly - no extra navigation hop.
     await user.click(screen.getByTestId('datalake-manager-file-f5'));
     expect(screen.getByTestId('mock-article')).toHaveTextContent('genre-overview.md');
+  });
+
+  it('sorts bracket-prefixed file names by category then title, not the raw leading "["', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByTestId('datalake-manager-lake-mine'));
+    await user.click(screen.getByTestId('datalake-manager-node-briefs'));
+    await user.click(screen.getByTestId('datalake-manager-node-x'));
+
+    // Marketing group (Apple before Zebra within it) sorts before Sales - a raw-name sort would
+    // instead tiebreak on the shared "[" and give a different, meaningless order.
+    const fileRows = screen.getAllByTestId(/^datalake-manager-file-/).map(el => el.getAttribute('data-testid'));
+    expect(fileRows).toEqual(['datalake-manager-file-f7', 'datalake-manager-file-f6', 'datalake-manager-file-f8']);
   });
 
   it('opens the Uncategorized bucket and lists the untagged file', async () => {

--- a/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
+++ b/apps/client/app/components/DataLakeWizard/DataLakeManagerPanel.tsx
@@ -43,6 +43,7 @@ import {
   getNodesAtPath,
 } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import { HUES, inkFor } from '@client/app/components/datalake/deckChrome';
+import TreeRowLabel from '@client/app/components/datalake/TreeRowLabel';
 import {
   COUNT_CHIP_SX,
   FOOTER_BTN_SX,
@@ -98,6 +99,22 @@ const normalizePrefix = (fileTagPrefix: string) => (fileTagPrefix.endsWith(':') 
 /** The prefix's namespace segments, e.g. 'books' -> ['books']. Lake navigation seeds the
  *  path past these so clicking a lake lands directly on its categories. */
 const prefixSegments = (fileTagPrefix: string) => fileTagPrefix.replace(/:+$/, '').split(':').filter(Boolean);
+
+/** Splits "[Category] Title.ext" into [category, title] so files sharing a bracketed source
+ *  prefix sort by the group then the title instead of piling up on the shared leading "[".
+ *  Mirrors DataLakeTreeView's compareByCategoryThenTitle - this surface carries its own tag-tree
+ *  browsing logic rather than routing through DataLakeTreeView, so the two stay in sync by hand. */
+function categoryTitleKey(fileName: string): [string, string] {
+  const withoutExt = fileName.replace(/\.[^/.]+$/, '');
+  const match = withoutExt.match(/^\[(.*?)\]\s*(.*)$/);
+  return match ? [match[1], match[2]] : ['', withoutExt];
+}
+
+function compareByCategoryThenTitle(a: IFabFileDocument, b: IFabFileDocument): number {
+  const [categoryA, titleA] = categoryTitleKey(a.fileName);
+  const [categoryB, titleB] = categoryTitleKey(b.fileName);
+  return categoryA.localeCompare(categoryB) || titleA.localeCompare(titleB);
+}
 
 /**
  * Data Lakes management surface: one persistent two-pane layout. The left sidebar navigates
@@ -394,7 +411,7 @@ function ManagerNav({
             prefix
           )
       )
-      .sort((a, b) => a.fileName.localeCompare(b.fileName));
+      .sort(compareByCategoryThenTitle);
   }, [articles, activeLake]);
 
   const seedDepth = activeLake ? prefixSegments(activeLake.fileTagPrefix).length : 0;
@@ -408,9 +425,7 @@ function ManagerNav({
   const files = useMemo(() => {
     if (isUncategorized) return uncategorizedFiles;
     if (!leafTag) return [];
-    return articles
-      .filter(f => (f.tags ?? []).some(t => t.name === leafTag))
-      .sort((a, b) => a.fileName.localeCompare(b.fileName));
+    return articles.filter(f => (f.tags ?? []).some(t => t.name === leafTag)).sort(compareByCategoryThenTitle);
   }, [isUncategorized, uncategorizedFiles, leafTag, articles]);
 
   // A branch node (has children) can ALSO carry files tagged with its own exact path, not just a
@@ -419,9 +434,7 @@ function ManagerNav({
   const ownTag = activeLake && !isUncategorized && !leafTag && path.length > seedDepth ? path.join(':') : null;
   const ownFiles = useMemo(() => {
     if (!ownTag || !currentNode?.ownFileCount) return [];
-    return articles
-      .filter(f => (f.tags ?? []).some(t => t.name === ownTag))
-      .sort((a, b) => a.fileName.localeCompare(b.fileName));
+    return articles.filter(f => (f.tags ?? []).some(t => t.name === ownTag)).sort(compareByCategoryThenTitle);
   }, [ownTag, currentNode, articles]);
   const showOwnFiles = !searchQuery && ownFiles.length > 0;
 
@@ -773,12 +786,7 @@ function ManagerNav({
                       }}
                     />
                     <ListItemContent>
-                      <Typography
-                        noWrap
-                        sx={{ ...rowTypographySx, fontWeight: selectedFileId === file.id ? 'lg' : 400 }}
-                      >
-                        {file.fileName.replace(/\.[^/.]+$/, '')}
-                      </Typography>
+                      <TreeRowLabel label={file.fileName.replace(/\.[^/.]+$/, '')} />
                     </ListItemContent>
                   </ListItemButton>
                 </ListItem>
@@ -849,12 +857,7 @@ function ManagerNav({
                       }}
                     />
                     <ListItemContent>
-                      <Typography
-                        noWrap
-                        sx={{ ...rowTypographySx, fontWeight: selectedFileId === file.id ? 'lg' : 400 }}
-                      >
-                        {file.fileName.replace(/\.[^/.]+$/, '')}
-                      </Typography>
+                      <TreeRowLabel label={file.fileName.replace(/\.[^/.]+$/, '')} />
                     </ListItemContent>
                   </ListItemButton>
                 </ListItem>

--- a/apps/client/app/components/datalake/DataLakeTree.tsx
+++ b/apps/client/app/components/datalake/DataLakeTree.tsx
@@ -4,6 +4,7 @@ import SortByAlphaIcon from '@mui/icons-material/SortByAlpha';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import type { TagNode } from '@client/app/components/Files/Browser/TagView/parseTagNamespace';
 import DataLakeTreeView, { type DataLakeTreeChrome } from './DataLakeTreeView';
+import TreeRowLabel from './TreeRowLabel';
 import { inkFor } from '@client/app/components/datalake/surfaceChrome';
 import type { Hue } from '@client/app/components/datalake/surfaceChrome';
 import { humanizeSegment, useDataLakeSurface } from '@client/app/components/datalake/surfaceTokens';
@@ -137,11 +138,7 @@ export default function DataLakeTree(props: DataLakeTreeProps) {
               }}
             />
             <ListItemContent>
-              <Tooltip title={displayName} size="sm" enterDelay={500}>
-                <Typography level="body-xs" noWrap sx={{ fontWeight: selected ? 'lg' : undefined }}>
-                  {displayName}
-                </Typography>
-              </Tooltip>
+              <TreeRowLabel label={displayName} level="body-xs" />
             </ListItemContent>
           </ListItemButton>
         </ListItem>

--- a/apps/client/app/components/datalake/TreeRowLabel.tsx
+++ b/apps/client/app/components/datalake/TreeRowLabel.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { Tooltip, Typography } from '@mui/joy';
+import type { TypographyProps } from '@mui/joy/Typography';
 
 interface TreeRowLabelProps {
   /** The row's name. Rendered clipped, and shown whole in a tooltip once it no longer fits. */
   label: string;
+  /** Joy Typography level override - e.g. the standalone page tree's file rows use the smaller
+   *  `body-xs` to stay visually subordinate to their `body-sm` folder rows. Omit for the flat
+   *  14px/400 the in-chat tree and the manager modal use. */
+  level?: TypographyProps['level'];
 }
 
 /**
@@ -13,7 +18,7 @@ interface TreeRowLabelProps {
  * so a long name behaves the same in both lists. Lives in its own component because the rows are
  * built inside a render callback, where per-row hooks are not an option.
  */
-export default function TreeRowLabel({ label }: TreeRowLabelProps) {
+export default function TreeRowLabel({ label, level }: TreeRowLabelProps) {
   const textRef = useRef<HTMLParagraphElement>(null);
   const [isClipped, setIsClipped] = useState(false);
 
@@ -30,7 +35,12 @@ export default function TreeRowLabel({ label }: TreeRowLabelProps) {
 
   return (
     <Tooltip title={isClipped ? label : ''} followCursor sx={{ zIndex: 10001 }}>
-      <Typography ref={textRef} noWrap sx={{ fontSize: '14px', fontWeight: 400, color: 'text.primary' }}>
+      <Typography
+        ref={textRef}
+        level={level}
+        noWrap
+        sx={{ ...(level ? undefined : { fontSize: '14px' }), fontWeight: 400, color: 'text.primary' }}
+      >
         {label}
       </Typography>
     </Tooltip>


### PR DESCRIPTION
## Description

Follow-up to #1693, picking up where #1726 left off. That PR bundled items 1-4 (search, persistent selection, name truncation, taxonomy-aware sort) and explicitly deferred item 5 (hide empty Archived/Deleted sections) plus two P2s found in review, since all three live in `DataLakeManagerPanel.tsx` - the Manage Data Lakes modal - which carries its own independent tag-tree browsing logic rather than routing through the shared `DataLakeTreeView`.

Item 5 turned out to already be effectively addressed: the modal's `NavLifecycleSection` shows a static "No files" row instead of a full accordion when Archived/Deleted is empty, rather than a dead, misleading empty accordion. That's arguably better than fully hiding the section (it distinguishes "nothing here" from "this feature doesn't exist"), so no code change was needed there - this PR is just the two P2s:

- **Bracket-prefix sort bug.** Same bug #1726 fixed in `DataLakeTreeView.tsx`, unfixed here: file sort still compared raw `fileName`, so `[Category] Title`-style names sorted on the shared leading `[` instead of grouping by category.
- **Missing tooltip on file rows.** Truncated file names in this modal had no way to be read in full - no hover affordance at all.

While fixing the tooltip gap, found the standalone `/data-lakes` page tree (`DataLakeTree.tsx`) had the same gap in reverse: it still carried the older always-show `Tooltip` from #1726, while `DataLakeChatTree.tsx` had already picked up the newer measured-clip `TreeRowLabel` via #1640. Folded that fix in too, so all three surfaces that render a file-name row are consistent.

## Changes

- `DataLakeManagerPanel.tsx`: added a local `compareByCategoryThenTitle` (mirrors `DataLakeTreeView`'s implementation; duplicated rather than shared, consistent with this file's existing acknowledged duplication of tree-browsing logic) and applied it to all three file-sort call sites (`uncategorizedFiles`, `files`, `ownFiles`).
- `DataLakeManagerPanel.tsx` and `DataLakeTree.tsx`: swapped their file-row `Typography` blocks for `TreeRowLabel` - the measured-clip tooltip component `DataLakeChatTree.tsx` already uses (only shows a tooltip when the name is actually truncated). Selection is no longer conveyed by bold text weight in these rows - each row's own `selected` background already carries that, same tradeoff `DataLakeChatTree.tsx` made when it adopted `TreeRowLabel`.
- `TreeRowLabel.tsx`: added an optional `level` prop (Joy Typography level). `DataLakeTree.tsx`'s file rows previously used the smaller `body-xs` (12px) to stay visually subordinate to their `body-sm` (14px) folder rows; `TreeRowLabel` was hardcoded to a flat 14px, which would have silently erased that hierarchy. Passing `level="body-xs"` there preserves the original size; the other two callers are unaffected (prop is optional, defaults to the existing flat 14px/400 look).

## Guide for Testers

1. Open the **Manage Data Lakes** modal and navigate into a lake with a folder containing 2+ files, where at least two file names look like `[SomeCategory] Some Title` (bracket prefix must come from the uploaded file's own name - see the #1726 PR notes on how to produce one).
2. **Sort check:** confirm the files group by category first, then title within category - not sorted by the raw `[` character.
3. **Tooltip check (Manage Data Lakes modal):** find a file row with a truncated name (or shrink the modal/browser until one truncates). Hover over it. Expected: a tooltip appears showing the full, untruncated name, following the cursor. Hovering a *short*, already-fully-visible name should show no tooltip.

   <img width="433" height="314" alt="image" src="https://github.com/user-attachments/assets/e7c86177-7131-4c9d-849f-1d02cb13bb18" />

5. **Tooltip check (standalone `/data-lakes` page):** same check as above, on the page tree instead of the modal. Also confirm file-row text still reads visibly smaller than folder-row text (the size hierarchy this fix was careful to preserve).

   <img width="433" height="314" alt="image" src="https://github.com/user-attachments/assets/eb107f43-ba10-42f1-8f31-ee81cbbc5a61" />

6. **Archived/Deleted check (regression only, no change expected):** with no archived or deleted lakes, confirm the Archived and Deleted sections in the root view show a static "No files" row - not an accordion, and not fully hidden.

   <img width="433" height="314" alt="image" src="https://github.com/user-attachments/assets/e7a9078b-c86a-4e5d-8209-a53d8e8886dd" />


### What NOT to test

No change to the Archived/Deleted empty-state behavior itself (already correct, verified as a regression check only). No change to `DataLakeChatTree.tsx`'s tooltip (already correct from #1640, unaffected here).

## Additional Information

Verified: `pnpm turbo:typecheck` clean, `pnpm lint:check` clean. Full suite for the touched areas green (`DataLakeWizard` + `datalake` + `TagView`: 272 tests, including one new test pinning the sort fix with fixture data where raw-string and category-grouped order would disagree).

## Developer Notes (Optional)

- `TreeRowLabel` (`components/datalake/TreeRowLabel.tsx`) is now used consistently by all three tree/list surfaces that render a file name row (`DataLakeChatTree`, `DataLakeManagerPanel`, `DataLakeTree`). Its new optional `level` prop is the seam for a caller that needs a non-default Typography size instead of the flat 14px/400 the first two callers use.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
