### PR TITLE
test(utils): fix flaky wall-clock timing assertions

### DIFF
--- a/b4m-core/utils/src/artifactElision.test.ts
+++ b/b4m-core/utils/src/artifactElision.test.ts
@@ -8,6 +8,44 @@ import { parseArtifacts } from './artifactParser';
  * than one that occasionally misses - every "should NOT flag" test is guarding shippability.
  */
 
+/**
+ * Times `run` at a small and a large input size and asserts growth stays roughly linear rather
+ * than quadratic. Ratio-based rather than a fixed wall-clock budget: CI contention that slows the
+ * whole runner inflates both measurements together and cancels out in the ratio, where a
+ * fixed-ms budget flakes under exactly that contention - as these assertions repeatedly did.
+ * Linear growth tracks the size ratio; quadratic growth tracks its square, so the ceiling (2.5x
+ * the linear expectation, plus a fixed floor for near-instant runs) sits clear of both.
+ *
+ * Each size is sampled 3x and the minimum is used: noise (a GC pause, a scheduler preemption) only
+ * ever adds delay, so the fastest sample is the one closest to the true cost, and taking the min
+ * survives a stray spike landing on any one sample instead of the whole measurement.
+ */
+function assertScansLinearly<T>(run: (size: number) => T, smallSize: number, largeSize: number) {
+  const sizeRatio = largeSize / smallSize;
+
+  const fastestOf = (size: number) => {
+    let minElapsed = Infinity;
+    let minResult: T | undefined;
+    for (let sample = 0; sample < 3; sample++) {
+      const started = Date.now();
+      const result = run(size);
+      const elapsed = Date.now() - started;
+      if (elapsed < minElapsed) {
+        minElapsed = elapsed;
+        minResult = result;
+      }
+    }
+    return { elapsed: minElapsed, result: minResult as T };
+  };
+
+  const small = fastestOf(smallSize);
+  const large = fastestOf(largeSize);
+
+  expect(large.elapsed).toBeLessThan(small.elapsed * sizeRatio * 2.5 + 200);
+
+  return { smallResult: small.result, largeResult: large.result };
+}
+
 /** Verbatim shape of the artifact from the originating bug report: correct data, stubbed behaviour. */
 const REAL_ELIDED_BODY = `<!DOCTYPE html>
 <html>
@@ -230,18 +268,17 @@ describe('detectElidedContent', () => {
     it('scans a long member chain in linear time', () => {
       // Regression guard for quadratic backtracking in the dotted-chain hollow-body pattern. A chain
       // written with spaces around the dots made every space a viable match start, each re-walking the
-      // rest of the chain: 191ms / 771ms / 3119ms at 15 / 30 / 60KB through this very call, on the
-      // synchronous completion path ahead of quest save and billing settlement. A hang, so the
-      // surrounding crash guards could not have helped. Bounded chain repetition fixed it.
-      // The threshold is deliberately loose - it needs to catch a return to quadratic, not benchmark
-      // the machine, and the pre-fix number at this size was over 3000ms.
-      let chain = 'a';
-      while (chain.length < 60 * 1024) chain += ' . a';
+      // rest of the chain: 191ms / 771ms / 3119ms at 15 / 30 / 60KB through this very call - a ~16x
+      // slowdown for a 4x size increase, the signature of O(n^2). Bounded chain repetition fixed it.
+      // A hang on the synchronous completion path, so the surrounding crash guards could not have
+      // helped. See assertScansLinearly's doc comment for why this is a ratio, not a fixed budget.
+      const chainOfLength = (bytes: number) => {
+        let chain = 'a';
+        while (chain.length < bytes) chain += ' . a';
+        return chain;
+      };
 
-      const started = Date.now();
-      detectElidedContent(chain, 'react');
-
-      expect(Date.now() - started).toBeLessThan(500);
+      assertScansLinearly(size => detectElidedContent(chainOfLength(size), 'react'), 15 * 1024, 60 * 1024);
     });
   });
 
@@ -1225,17 +1262,15 @@ describe('large bodies', () => {
     // to compile a RegExp per candidate and rescan the whole body: O(names x body). Measured in
     // isolation on this exact input, that step alone took 41.8s; harvesting the declared set in one
     // pass takes 29ms. It runs synchronously on the completion worker and on the publish click, so
-    // the cost is user-visible in both places. The threshold is loose on purpose - it is here to
-    // catch a return to quadratic behaviour, not to police milliseconds.
-    const lines = Array.from({ length: 30000 }, (_, i) => `  const value_${i} = compute_${i}(${i});`).join('\n');
-    const body = `<html><body><script>\n${lines}\n  function go() { document.title = String(value_0); }\n  go();\n</script></body></html>`;
+    // the cost is user-visible in both places. See assertScansLinearly's doc comment for the ratio.
+    const namesBody = (n: number) => {
+      const lines = Array.from({ length: n }, (_, i) => `  const value_${i} = compute_${i}(${i});`).join('\n');
+      return `<html><body><script>\n${lines}\n  function go() { document.title = String(value_0); }\n  go();\n</script></body></html>`;
+    };
 
-    const startedAt = Date.now();
-    const result = detectElidedContent(body, 'html');
-    const elapsedMs = Date.now() - startedAt;
+    const { largeResult } = assertScansLinearly(n => detectElidedContent(namesBody(n), 'html'), 7500, 30000);
 
-    expect(result.signals.length).toBeGreaterThan(0);
-    expect(elapsedMs).toBeLessThan(5000);
+    expect(largeResult.signals.length).toBeGreaterThan(0);
   });
 
   it('stays fast when the body has one comment per line', () => {
@@ -1245,25 +1280,28 @@ describe('large bodies', () => {
     // steered - one trailing comment per line is ordinary LLM output - and it matters beyond the
     // single-response size cap because artifacts are expanded incrementally under one identifier and
     // the client fallback scan re-runs on every historical artifact reply at session load.
-    const lines = Array.from(
-      { length: 12000 },
-      (_, i) => `  const value_${i} = ${i}; // assignment number ${i} for the running total`
-    ).join('\n');
-    const body = `<html><body><script>\n${lines}\n  function go() { document.title = String(value_0); }\n  go();\n</script></body></html>`;
+    const commentsBody = (n: number) => {
+      const lines = Array.from(
+        { length: n },
+        (_, i) => `  const value_${i} = ${i}; // assignment number ${i} for the running total`
+      ).join('\n');
+      return `<html><body><script>\n${lines}\n  function go() { document.title = String(value_0); }\n  go();\n</script></body></html>`;
+    };
 
-    const startedAt = Date.now();
-    const result = detectElidedContent(body, 'html');
-    const elapsedMs = Date.now() - startedAt;
+    const { largeResult } = assertScansLinearly(n => detectElidedContent(commentsBody(n), 'html'), 3000, 12000);
 
-    expect(result.elided).toBe(false);
-    expect(elapsedMs).toBeLessThan(3000);
+    expect(largeResult.elided).toBe(false);
   });
 
   it('scans a large complete artifact quickly and without flagging it', () => {
-    const rows = Array.from({ length: 4000 }, (_, i) => `  { id: ${i}, name: 'row-${i}', score: ${i % 97} },`).join(
-      '\n'
-    );
-    const body = `<html><body><div id="board"></div><script>
+    // General perf smoke test, not tied to a specific documented regression like its neighbors above.
+    // See assertScansLinearly's doc comment for the ratio.
+    const artifactBody = (rowCount: number) => {
+      const rows = Array.from(
+        { length: rowCount },
+        (_, i) => `  { id: ${i}, name: 'row-${i}', score: ${i % 97} },`
+      ).join('\n');
+      return `<html><body><div id="board"></div><script>
       const DATA = [
 ${rows}
       ];
@@ -1275,16 +1313,17 @@ ${rows}
       function init() { renderBoard(); }
       init();
     </script></body></html>`;
+    };
 
-    expect(body.length).toBeGreaterThan(150_000);
+    expect(artifactBody(4000).length).toBeGreaterThan(150_000);
 
-    const started = performance.now();
-    const result = detectElidedContent(body, 'html');
-    const elapsed = performance.now() - started;
+    const { largeResult } = assertScansLinearly(
+      rowCount => detectElidedContent(artifactBody(rowCount), 'html'),
+      1000,
+      4000
+    );
 
-    expect(result.elided).toBe(false);
-    // Generous bound - the point is to catch a return to quadratic behaviour, not to benchmark.
-    expect(elapsed).toBeLessThan(1000);
+    expect(largeResult.elided).toBe(false);
   });
 
   it('still distinguishes a member call from a bare call across long whitespace', () => {

--- a/b4m-core/utils/src/artifactElision.test.ts
+++ b/b4m-core/utils/src/artifactElision.test.ts
@@ -18,32 +18,40 @@ import { parseArtifacts } from './artifactParser';
  *
  * Each size is sampled 3x and the minimum is used: noise (a GC pause, a scheduler preemption) only
  * ever adds delay, so the fastest sample is the one closest to the true cost, and taking the min
- * survives a stray spike landing on any one sample instead of the whole measurement.
+ * survives a stray spike landing on any one sample instead of the whole measurement. The small and
+ * large samples are INTERLEAVED (small, large, small, large, ...) rather than run as two separate
+ * blocks - a contention burst confined to one block would otherwise hit only one size's samples,
+ * defeating the cancellation the ratio depends on.
  */
 function assertScansLinearly<T>(run: (size: number) => T, smallSize: number, largeSize: number) {
   const sizeRatio = largeSize / smallSize;
 
-  const fastestOf = (size: number) => {
-    let minElapsed = Infinity;
-    let minResult: T | undefined;
-    for (let sample = 0; sample < 3; sample++) {
-      const started = Date.now();
-      const result = run(size);
-      const elapsed = Date.now() - started;
-      if (elapsed < minElapsed) {
-        minElapsed = elapsed;
-        minResult = result;
-      }
+  let smallElapsed = Infinity;
+  let smallResult: T | undefined;
+  let largeElapsed = Infinity;
+  let largeResult: T | undefined;
+
+  for (let sample = 0; sample < 3; sample++) {
+    const smallStarted = Date.now();
+    const thisSmallResult = run(smallSize);
+    const thisSmallElapsed = Date.now() - smallStarted;
+    if (thisSmallElapsed < smallElapsed) {
+      smallElapsed = thisSmallElapsed;
+      smallResult = thisSmallResult;
     }
-    return { elapsed: minElapsed, result: minResult as T };
-  };
 
-  const small = fastestOf(smallSize);
-  const large = fastestOf(largeSize);
+    const largeStarted = Date.now();
+    const thisLargeResult = run(largeSize);
+    const thisLargeElapsed = Date.now() - largeStarted;
+    if (thisLargeElapsed < largeElapsed) {
+      largeElapsed = thisLargeElapsed;
+      largeResult = thisLargeResult;
+    }
+  }
 
-  expect(large.elapsed).toBeLessThan(small.elapsed * sizeRatio * 2.5 + 200);
+  expect(largeElapsed).toBeLessThan(smallElapsed * sizeRatio * 2.5 + 200);
 
-  return { smallResult: small.result, largeResult: large.result };
+  return { smallResult: smallResult as T, largeResult: largeResult as T };
 }
 
 /** Verbatim shape of the artifact from the originating bug report: correct data, stubbed behaviour. */


### PR DESCRIPTION
# Pull Request

## Description

Closes #1745. The quadratic-regression guards in `artifactElision.test.ts` timed one input against a fixed millisecond budget, which is contention-sensitive on a shared CI runner and has flaked repeatedly (14+ times across unrelated PRs) regardless of the diff under test.

Replaced each with a ratio check: time a small and a large input (4x apart, 3 samples each, fastest kept) and assert the large run stays within a ceiling scaled off that ratio. Linear growth tracks the ratio; quadratic tracks its square, so the ceiling sits clear of both, and runner-wide contention inflates both measurements proportionally and cancels out - which a fixed-ms budget structurally cannot do.

The sibling flake this issue also names, in `ReActAgent.parallel.test.ts`, was already fixed by a prior merged PR that replaced its wall-clock assertions with log-order assertions - confirmed via `git blame`, no change needed there.

## Changes

- Added `assertScansLinearly`, a local test helper that measures growth at two input sizes and asserts a ratio-based ceiling instead of a fixed wall-clock budget.
- Converted all 4 wall-clock timing assertions in `artifactElision.test.ts` to use it.

## Guide for Testers

No UI/API surface - this is a test-infrastructure fix, so the test file is the artifact under test.

1. Run `pnpm --filter @bike4mind/utils test -- artifactElision.test.ts` on this branch. Expected: all 109 tests pass.
2. Confirm the guard still catches a real regression: in `b4m-core/utils/src/artifactElision.ts`, change the bounded chain pattern `){0,8}` to `)*` (removes the bound that fixed the original quadratic bug), then re-run `pnpm --filter @bike4mind/utils test -- artifactElision.test.ts -t "linear time"`. Expected: that one test fails with an assertion like "expected NNNN to be less than NNNN". Revert the source change afterward.
3. Confirm no wall-clock timing assertions remain in `b4m-core/agents/src/ReActAgent.parallel.test.ts`: `grep -n "Date.now\|performance.now" b4m-core/agents/src/ReActAgent.parallel.test.ts`. Expected: no matches.

## Additional Information

N/A

## Developer Notes (Optional)

`assertScansLinearly` (in `artifactElision.test.ts`) is a reusable pattern for any future "stays fast, not quadratic" test in this repo: sample-and-take-minimum at two sizes, assert on the growth ratio rather than an absolute ms budget.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc

