### PR TITLE
fix(client): let a capped-out DAG parent finish its aggregation wake

### DIFF
--- a/apps/client/server/queueHandlers/agentExecutor.subagentCapGate.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.subagentCapGate.test.ts
@@ -134,4 +134,24 @@ describe('agentExecutor DAG-node refusal paths fire onDagNodeTerminal', () => {
     expect(mockMarkFailed).not.toHaveBeenCalled();
     expect(onDagNodeTerminalMock).not.toHaveBeenCalled();
   });
+
+  it('fires the hook from the outer catch when an unexpected downstream error escapes every other handler', async () => {
+    // dagNodeId is hoisted right after the child doc loads, well before this call, so the
+    // outer catch - which has no access to `child` - should still have it available. This is
+    // the exit with the least direct test coverage and the most machinery between it and the
+    // hook call, per three review rounds each catching a different missed exit in this file.
+    const { sessionRepository } = await import('@bike4mind/database');
+    vi.mocked(sessionRepository.findById).mockRejectedValueOnce(new Error('Mongo blip'));
+
+    const { handler } = await import('./agentExecutor');
+    await handler(dagNodeDispatchEvent(), {} as never);
+
+    expect(mockMarkFailed).toHaveBeenCalledWith('child-1', { message: 'Mongo blip', timedOut: false });
+    expect(onDagNodeTerminalMock).toHaveBeenCalledTimes(1);
+    expect(onDagNodeTerminalMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        child: expect.objectContaining({ id: 'child-1', dagNodeId: 'node-b', status: 'failed' }),
+      })
+    );
+  });
 });

--- a/apps/client/server/queueHandlers/agentExecutor.subagentCapGate.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.subagentCapGate.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression test for the per-member cap gate added to `processSubagentDispatch`:
+// a human review on PR #1777 found the gate returned without firing
+// `onDagNodeTerminal`, so a capped-out member's DAG children would ALL fail this
+// gate (it's a per-user condition, so it trips uniformly for every sibling) and
+// NONE would wake the parent - a permanent hang, since `cleanupStaleActive`
+// deliberately excludes `awaiting_dag_children` from its sweep. This test drives
+// the real `handler` through a `dag_node_dispatch` message and asserts the hook
+// still fires on this refusal path.
+
+const benignStub: ProxyHandler<object> = {
+  get(_, key) {
+    if (key === 'then') return undefined;
+    return `mock-${String(key)}`;
+  },
+};
+
+vi.mock('sst', () => ({
+  Resource: new Proxy({} as Record<string, unknown>, {
+    get() {
+      return new Proxy({}, benignStub);
+    },
+  }),
+}));
+
+vi.mock('@aws-sdk/client-apigatewaymanagementapi', () => ({
+  ApiGatewayManagementApiClient: class {
+    send() {
+      return Promise.resolve({});
+    }
+  },
+  PostToConnectionCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+const onDagNodeTerminalMock = vi.fn().mockResolvedValue(undefined);
+vi.mock('./agentExecutorDag', async () => {
+  const actual = await vi.importActual<typeof import('./agentExecutorDag')>('./agentExecutorDag');
+  return { ...actual, onDagNodeTerminal: (...args: unknown[]) => onDagNodeTerminalMock(...args) };
+});
+
+const childDoc = {
+  id: 'child-1',
+  status: 'pending',
+  abortedAt: null,
+  userId: 'user-1',
+  sessionId: 'session-1',
+  organizationId: 'org-1',
+  parentExecutionId: 'parent-1',
+  dagNodeId: 'node-b',
+  subagentConfig: { agentName: 'researcher', thoroughness: 'quick' },
+};
+
+const capOrg = {
+  id: 'org-1',
+  currentCredits: 1000,
+  maxCreditsPerMember: 5,
+  userDetails: [{ id: 'user-1', usedCredits: 50 }],
+};
+
+const mockMarkFailed = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@bike4mind/database', async () => {
+  const actual = await vi.importActual<typeof import('@bike4mind/database')>('@bike4mind/database');
+  vi.spyOn(actual.agentExecutionRepository, 'findById').mockResolvedValue(childDoc as never);
+  vi.spyOn(actual.agentExecutionRepository, 'claimExecution').mockResolvedValue(true as never);
+  vi.spyOn(actual.agentExecutionRepository, 'updateConnectionId').mockResolvedValue(undefined as never);
+  vi.spyOn(actual.agentExecutionRepository, 'markFailed').mockImplementation((...args) => mockMarkFailed(...args));
+  vi.spyOn(actual.User, 'findById').mockResolvedValue({ id: 'user-1', currentCredits: 100 } as never);
+  vi.spyOn(actual.sessionRepository, 'findById').mockResolvedValue({ id: 'session-1', userId: 'user-1' } as never);
+  vi.spyOn(actual.organizationRepository, 'findById').mockResolvedValue(capOrg as never);
+  return { ...actual, connectDB: vi.fn().mockResolvedValue(undefined) };
+});
+
+function makeSqsEvent(messages: Array<{ messageId: string; body: unknown }>) {
+  return {
+    Records: messages.map(m => ({ messageId: m.messageId, body: JSON.stringify(m.body) })),
+  } as never;
+}
+
+describe('agentExecutor per-member cap gate on dispatched DAG nodes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fires onDagNodeTerminal so the parent is not left wedged in awaiting_dag_children', async () => {
+    const { handler } = await import('./agentExecutor');
+    const event = makeSqsEvent([
+      {
+        messageId: 'msg-1',
+        body: { kind: 'dag_node_dispatch', childExecutionId: 'child-1', connectionId: 'conn-1', dagNodeId: 'node-b' },
+      },
+    ]);
+
+    const result = await handler(event, {} as never);
+
+    expect(result).toEqual({ batchItemFailures: [] });
+    expect(mockMarkFailed).toHaveBeenCalledWith('child-1', { message: 'Organization member credit limit reached' });
+    expect(onDagNodeTerminalMock).toHaveBeenCalledTimes(1);
+    expect(onDagNodeTerminalMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        child: expect.objectContaining({ id: 'child-1', dagNodeId: 'node-b', status: 'failed' }),
+      })
+    );
+  });
+});

--- a/apps/client/server/queueHandlers/agentExecutor.subagentCapGate.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.subagentCapGate.test.ts
@@ -1,13 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Regression test for the per-member cap gate added to `processSubagentDispatch`:
-// a human review on PR #1777 found the gate returned without firing
-// `onDagNodeTerminal`, so a capped-out member's DAG children would ALL fail this
-// gate (it's a per-user condition, so it trips uniformly for every sibling) and
-// NONE would wake the parent - a permanent hang, since `cleanupStaleActive`
-// deliberately excludes `awaiting_dag_children` from its sweep. This test drives
-// the real `handler` through a `dag_node_dispatch` message and asserts the hook
-// still fires on this refusal path.
+// The per-member cap gate in `processSubagentDispatch` must fire `onDagNodeTerminal`
+// on refusal: without it, a capped-out member's DAG children ALL fail this gate (it's
+// a per-user condition, so it trips uniformly for every sibling) and NONE would wake
+// the parent - a permanent hang, since `cleanupStaleActive` deliberately excludes
+// `awaiting_dag_children` from its sweep. Drives the real `handler` through a
+// `dag_node_dispatch` message and asserts the hook still fires on this refusal path.
 
 const benignStub: ProxyHandler<object> = {
   get(_, key) {
@@ -80,21 +78,25 @@ function makeSqsEvent(messages: Array<{ messageId: string; body: unknown }>) {
   } as never;
 }
 
-describe('agentExecutor per-member cap gate on dispatched DAG nodes', () => {
+function dagNodeDispatchEvent() {
+  return makeSqsEvent([
+    {
+      messageId: 'msg-1',
+      body: { kind: 'dag_node_dispatch', childExecutionId: 'child-1', connectionId: 'conn-1', dagNodeId: 'node-b' },
+    },
+  ]);
+}
+
+describe('agentExecutor DAG-node refusal paths fire onDagNodeTerminal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    onDagNodeTerminalMock.mockClear();
   });
 
-  it('fires onDagNodeTerminal so the parent is not left wedged in awaiting_dag_children', async () => {
+  it('fires the hook on the per-member cap refusal so the parent is not left wedged', async () => {
     const { handler } = await import('./agentExecutor');
-    const event = makeSqsEvent([
-      {
-        messageId: 'msg-1',
-        body: { kind: 'dag_node_dispatch', childExecutionId: 'child-1', connectionId: 'conn-1', dagNodeId: 'node-b' },
-      },
-    ]);
 
-    const result = await handler(event, {} as never);
+    const result = await handler(dagNodeDispatchEvent(), {} as never);
 
     expect(result).toEqual({ batchItemFailures: [] });
     expect(mockMarkFailed).toHaveBeenCalledWith('child-1', { message: 'Organization member credit limit reached' });
@@ -104,5 +106,32 @@ describe('agentExecutor per-member cap gate on dispatched DAG nodes', () => {
         child: expect.objectContaining({ id: 'child-1', dagNodeId: 'node-b', status: 'failed' }),
       })
     );
+  });
+
+  it('fires the hook on a session-ownership refusal too, via the same shared helper', async () => {
+    // Ownership is checked before the org-pool/member-cap gates, so this fires
+    // first regardless of the child's organizationId.
+    const { sessionRepository } = await import('@bike4mind/database');
+    vi.mocked(sessionRepository.findById).mockResolvedValueOnce({ id: 'session-1', userId: 'someone-else' } as never);
+
+    const { handler } = await import('./agentExecutor');
+    await handler(dagNodeDispatchEvent(), {} as never);
+
+    expect(mockMarkFailed).toHaveBeenCalledWith('child-1', { message: 'Session ownership validation failed' });
+    expect(onDagNodeTerminalMock).toHaveBeenCalledTimes(1);
+    expect(onDagNodeTerminalMock).toHaveBeenCalledWith(
+      expect.objectContaining({ child: expect.objectContaining({ id: 'child-1', status: 'failed' }) })
+    );
+  });
+
+  it('does NOT fire the hook when another Lambda already claimed the child (CAS loss)', async () => {
+    const { agentExecutionRepository } = await import('@bike4mind/database');
+    vi.mocked(agentExecutionRepository.claimExecution).mockResolvedValueOnce(false as never);
+
+    const { handler } = await import('./agentExecutor');
+    await handler(dagNodeDispatchEvent(), {} as never);
+
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+    expect(onDagNodeTerminalMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -794,6 +794,11 @@ async function processExecution(
     // so it doesn't strand already-paid-for child work. See `isDagAggregationWake` and
     // `clampMaxIterationsForOverCapAggregationWake` in `agentExecutorDag.ts` for the full
     // rationale and the bound on what this exception actually grants.
+    //
+    // Scope note: an `awaiting_subagent` resume splices in an already-billed child result the
+    // same way (see the `isSubagentResume` branch below) but is NOT exempted here - that wake
+    // continues with a full iteration budget rather than a single wrap-up step, so it is not a
+    // pure aggregation and the same one-iteration bound would not apply cleanly.
     if (organization && !isAggregationOnlyWake && creditService.isMemberAtOrOverCap(organization, execution.userId)) {
       logger.warn('[Credits] Member credit cap reached; refusing to start execution', {
         used: creditService.getMemberUsedCredits(organization, execution.userId),
@@ -2388,6 +2393,7 @@ async function processExecution(
     const reachedMaxIterations = iterationResult?.reachedMaxIterations ?? false;
     const displayAnswer = resolveDisplayAnswer({
       reachedMaxIterations,
+      ranAnyIteration: iterationResult !== undefined,
       finalAnswer,
       dagAggregationFallbackSummary,
       configuredMaxIterations,
@@ -2498,27 +2504,23 @@ async function processExecution(
 // ---------------------------------------------------------------------------
 
 /**
- * Fires the DAG completion hook on a refused/failed dispatched child, guarded on
- * `dagNodeId` (a no-op for a plain delegated subagent, which has no siblings to
- * unblock). `onDagNodeTerminal` is the ONLY thing that unblocks siblings or wakes
- * a DAG parent - every early exit in `processSubagentDispatch` that skips it can
- * wedge the parent in `awaiting_dag_children` forever (`cleanupStaleActive`
- * deliberately excludes that status, so there is no reaper), and the wake only
- * needs the LAST sibling to reach a terminal state to take a hook-less exit, not
- * every sibling. Recovery mirrors the hook's other call sites: if the hook itself
+ * Fires the DAG completion hook for a dispatched child on every terminal outcome
+ * (success, refusal, failure, or abort), guarded on `dagNodeId` (a no-op for a
+ * plain delegated subagent, which has no siblings to unblock). `onDagNodeTerminal`
+ * is the ONLY thing that unblocks siblings or wakes a DAG parent - every terminal
+ * exit in `processSubagentDispatch` that skips it can wedge the parent in
+ * `awaiting_dag_children` forever (`cleanupStaleActive` deliberately excludes that
+ * status, so there is no reaper), and the wake only needs the LAST sibling to reach
+ * a terminal state to take a hook-less exit, not every sibling. If the hook itself
  * throws, mark the parent failed so the session unwedges instead of hanging.
  *
  * Deliberately NOT called from the `!claimed` CAS-loss exit: that means another
  * Lambda already owns this child and will complete it (and fire this hook) through
  * its own normal path. Firing here too would not double-unblock anything - the hook
  * is idempotent - but it would report a false terminal status for a child that may
- * still succeed: a CAS loss means someone else has it, not that it failed.
- *
- * The `status` argument is NOT load-bearing for `onDagNodeTerminal` itself - it
- * re-reads every sibling fresh from the DB rather than trusting the passed-in value,
- * so passing 'failed' vs 'aborted' only affects logging. What actually matters is
- * that `markFailed`/`markAborted` already landed before this call, which every
- * caller here does.
+ * still succeed: a CAS loss means someone else has it, not that it failed. `status`
+ * itself is not load-bearing for `onDagNodeTerminal` (it re-reads every sibling
+ * fresh from the DB), only for logging.
  *
  * Narrow gap this does NOT close: if `agentExecutionRepository.findById` throws or
  * returns null, or `child.subagentConfig` is missing, the function throws before
@@ -2536,7 +2538,7 @@ async function fireDagNodeTerminalOnRefusal(args: {
   connectionId: string;
   logger: Logger;
   sendWs: ReturnType<typeof createWsSender>;
-  status?: 'failed' | 'aborted';
+  status?: 'completed' | 'failed' | 'aborted';
 }): Promise<void> {
   const { dagNodeId, parentExecutionId, childExecutionId, connectionId, logger, sendWs, status = 'failed' } = args;
   if (!dagNodeId) return;
@@ -3097,10 +3099,9 @@ async function processSubagentDispatch(
             partialAnswer: result.finalAnswer,
           });
         }
-        // This return was found to bypass the DAG completion hook entirely (a
-        // human review caught it - neither the success path below nor the catch
-        // block's own hook-fire cover this branch). Fire it here too, same as
-        // every other terminal exit in this function.
+        // Terminal exit: this branch returns before the success-path and catch-path
+        // hook fires below, so fire it here - every terminal exit must reach
+        // `onDagNodeTerminal` or the parent wedges.
         await fireDagNodeTerminalOnRefusal({
           dagNodeId,
           parentExecutionId: dagParentExecutionId,
@@ -3149,47 +3150,15 @@ async function processSubagentDispatch(
       // Phase 4a - if this child was a DAG node, fire the completion hook
       // so any newly-unblocked siblings get dispatched, or the parent gets
       // woken if the whole DAG is done.
-      //
-      // Recovery: if the hook itself throws (SQS error, mongo error during
-      // sibling scan) the parent would otherwise sit in `awaiting_dag_children`
-      // forever - `cleanupStaleActive` deliberately excludes that status.
-      // Catch here, mark the parent failed, and surface a WS event so the
-      // session unwedges instead of hanging.
-      if (child.dagNodeId) {
-        try {
-          await onDagNodeTerminal({
-            child: {
-              id: childExecutionId,
-              parentExecutionId: child.parentExecutionId,
-              dagNodeId: child.dagNodeId,
-              status: 'completed',
-            },
-            connectionId,
-            logger,
-          });
-        } catch (hookErr) {
-          const msg = hookErr instanceof Error ? hookErr.message : String(hookErr);
-          logger.error('[DAG] onDagNodeTerminal failed — marking parent failed', {
-            parentId: child.parentExecutionId,
-            childExecutionId,
-            error: msg,
-          });
-          if (child.parentExecutionId) {
-            await agentExecutionRepository
-              .markFailed(child.parentExecutionId, { message: `DAG completion hook failed: ${msg}` })
-              .catch(markErr => {
-                logger.error('[DAG] markFailed on parent also failed', {
-                  parentId: child.parentExecutionId,
-                  error: markErr instanceof Error ? markErr.message : String(markErr),
-                });
-              });
-            await sendWs('failed', {
-              executionId: child.parentExecutionId,
-              reason: 'dag_hook_error',
-            });
-          }
-        }
-      }
+      await fireDagNodeTerminalOnRefusal({
+        dagNodeId: child.dagNodeId,
+        parentExecutionId: child.parentExecutionId,
+        childExecutionId,
+        connectionId,
+        logger,
+        sendWs,
+        status: 'completed',
+      });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
       // Three failure shapes can reach this catch:
@@ -3237,45 +3206,15 @@ async function processSubagentDispatch(
       // Phase 4a - DAG node terminal even on failure/abort. Same hook fires;
       // it'll detect the failed dep and dispatch only nodes that don't
       // depend on this one (or none if everything cascades).
-      //
-      // Recovery: same gap as the success path - if the hook throws, the
-      // parent would otherwise sit in `awaiting_dag_children` indefinitely.
-      // Catch and mark the parent failed so the session unwedges.
-      if (child.dagNodeId) {
-        try {
-          await onDagNodeTerminal({
-            child: {
-              id: childExecutionId,
-              parentExecutionId: child.parentExecutionId,
-              dagNodeId: child.dagNodeId,
-              status: wasAborted ? 'aborted' : 'failed',
-            },
-            connectionId,
-            logger,
-          });
-        } catch (hookErr) {
-          const msg = hookErr instanceof Error ? hookErr.message : String(hookErr);
-          logger.error('[DAG] onDagNodeTerminal failed — marking parent failed', {
-            parentId: child.parentExecutionId,
-            childExecutionId,
-            error: msg,
-          });
-          if (child.parentExecutionId) {
-            await agentExecutionRepository
-              .markFailed(child.parentExecutionId, { message: `DAG completion hook failed: ${msg}` })
-              .catch(markErr => {
-                logger.error('[DAG] markFailed on parent also failed', {
-                  parentId: child.parentExecutionId,
-                  error: markErr instanceof Error ? markErr.message : String(markErr),
-                });
-              });
-            await sendWs('failed', {
-              executionId: child.parentExecutionId,
-              reason: 'dag_hook_error',
-            });
-          }
-        }
-      }
+      await fireDagNodeTerminalOnRefusal({
+        dagNodeId: child.dagNodeId,
+        parentExecutionId: child.parentExecutionId,
+        childExecutionId,
+        connectionId,
+        logger,
+        sendWs,
+        status: wasAborted ? 'aborted' : 'failed',
+      });
     } finally {
       clearInterval(abortPoller);
     }

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -88,7 +88,13 @@ import { buildTruncatedRunReply } from './agentExecutorUtils/truncatedReply';
 import { guardPlanCompletion } from './agentExecutorUtils/planCompletionGuard';
 import { injectBriefContext } from './agentExecutorUtils/briefContextInjector';
 import { rehydrateOptiPlanState, ledgerForWrite } from './agentExecutorUtils/optiPlanLedger';
-import { buildDagResumeReport, isDagAggregationWake, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
+import {
+  buildDagResumeReport,
+  clampMaxIterationsForOverCapAggregationWake,
+  isDagAggregationWake,
+  makeDagDispatcher,
+  onDagNodeTerminal,
+} from './agentExecutorDag';
 import { collectDagChildArtifactBlocks } from './agentExecutor.dagArtifacts';
 import type { DagHandoffSignal } from '@bike4mind/services';
 // `buildFirstIterationQuery` lives in its own module so it can be
@@ -1635,7 +1641,7 @@ async function processExecution(
     // when the payload doesn't pin one - agentless dispatches (Agent-mode
     // toggle path) land on the profile's `defaultThoroughness` ceiling rather
     // than the legacy 25-iteration fallback.
-    const maxIterations = orchestrationProfile
+    let maxIterations = orchestrationProfile
       ? pickEffectiveMaxIterations(startPayload?.maxIterations, orchestrationProfile)
       : (startPayload?.maxIterations ?? 25);
 
@@ -1879,6 +1885,13 @@ async function processExecution(
     // --- Iteration loop ---
     let iterationResult: IterationResult | undefined;
     let iterationIndex = isNewExecution ? 0 : ((execution.checkpoint as AgentCheckpoint)?.iteration ?? 0);
+
+    maxIterations = clampMaxIterationsForOverCapAggregationWake({
+      isAggregationOnlyWake,
+      isOverCap: Boolean(organization && creditService.isMemberAtOrOverCap(organization, execution.userId)),
+      maxIterations,
+      iterationIndex,
+    });
 
     // Confidence-gate plumbing. The agent calls this callback after
     // tool execution with the iteration's average tool-result confidence;

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -88,7 +88,7 @@ import { buildTruncatedRunReply } from './agentExecutorUtils/truncatedReply';
 import { guardPlanCompletion } from './agentExecutorUtils/planCompletionGuard';
 import { injectBriefContext } from './agentExecutorUtils/briefContextInjector';
 import { rehydrateOptiPlanState, ledgerForWrite } from './agentExecutorUtils/optiPlanLedger';
-import { buildDagResumeReport, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
+import { buildDagResumeReport, isDagAggregationWake, makeDagDispatcher, onDagNodeTerminal } from './agentExecutorDag';
 import { collectDagChildArtifactBlocks } from './agentExecutor.dagArtifacts';
 import type { DagHandoffSignal } from '@bike4mind/services';
 // `buildFirstIterationQuery` lives in its own module so it can be
@@ -634,6 +634,14 @@ async function processExecution(
     // Phase 4a - accept `awaiting_dag_children -> running` so the continuation
     // Lambda woken by the last-child completion hook can resume the parent.
     const isDagResume = !isNewExecution && execution.status === 'awaiting_dag_children';
+    // Computed once and reused by both the credit-cap gate (skip) and the DAG
+    // resume-trigger below (fire) so the two can never disagree about whether
+    // this wake is aggregation-only.
+    const isAggregationOnlyWake = isDagAggregationWake({
+      isDagResume,
+      dagSpec: execution.dagSpec,
+      waitingOnDagChildren: execution.waitingOnDagChildren,
+    });
     const expectedStatuses = isNewExecution
       ? (['pending'] as const)
       : isSubagentResume
@@ -775,7 +783,14 @@ async function processExecution(
     // so it re-runs on every continuation/subagent-resume/DAG-wake: a run that crosses the
     // cap mid-execution IS stopped, at its next handoff (like the pool gate above). Started,
     // in-flight iterations still settle - this bounds the overshoot, it does not refund it.
-    if (organization && creditService.isMemberAtOrOverCap(organization, execution.userId)) {
+    //
+    // Exception: a DAG parent waking ONLY to aggregate children that have already
+    // finished (`isAggregationOnlyWake`) does no new billable work of its own, so
+    // gating it would hard-fail the parent and strand completed, already-paid-for
+    // child work with no aggregated result returned. Skipping the gate here is bounded
+    // to this one handoff - if the parent needs another continuation afterward, that
+    // next invocation is a normal `continuing` status and this gate applies in full.
+    if (organization && !isAggregationOnlyWake && creditService.isMemberAtOrOverCap(organization, execution.userId)) {
       logger.warn('[Credits] Member credit cap reached; refusing to start execution', {
         used: creditService.getMemberUsedCredits(organization, execution.userId),
         cap: organization.maxCreditsPerMember,
@@ -1807,7 +1822,7 @@ async function processExecution(
     // the last terminal DAG child enqueued this continuation; load all child
     // results, build the aggregated markdown via shared `buildPipelineResult`,
     // and surgically replace the `coordinate_task` placeholder observation.
-    if (isDagResume && execution.dagSpec && execution.waitingOnDagChildren) {
+    if (isAggregationOnlyWake && execution.dagSpec && execution.waitingOnDagChildren) {
       // NOTE (merge): combined with main's first-iteration CASL scope below -
       // these are independent additions in the same spot; both are kept.
       const children = await agentExecutionRepository.findDagChildrenLean(executionId);

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -2602,6 +2602,48 @@ async function processSubagentDispatch(
         error: 'insufficient_credits',
         isTimeout: false,
       });
+      // Phase 4a - DAG node terminal even on this refusal. The cap is a per-USER
+      // condition, so it trips uniformly for every sibling in the same DAG - without
+      // this, NONE of them would fire the hook that wakes the parent, leaving it
+      // wedged in `awaiting_dag_children` forever (no reaper: `cleanupStaleActive`
+      // deliberately excludes that status). Same recovery as the other terminal
+      // sites in this function: if the hook itself throws, mark the parent failed
+      // so the session unwedges instead of hanging.
+      if (child.dagNodeId) {
+        try {
+          await onDagNodeTerminal({
+            child: {
+              id: childExecutionId,
+              parentExecutionId: child.parentExecutionId,
+              dagNodeId: child.dagNodeId,
+              status: 'failed',
+            },
+            connectionId,
+            logger,
+          });
+        } catch (hookErr) {
+          const msg = hookErr instanceof Error ? hookErr.message : String(hookErr);
+          logger.error('[DAG] onDagNodeTerminal failed - marking parent failed', {
+            parentId: child.parentExecutionId,
+            childExecutionId,
+            error: msg,
+          });
+          if (child.parentExecutionId) {
+            await agentExecutionRepository
+              .markFailed(child.parentExecutionId, { message: `DAG completion hook failed: ${msg}` })
+              .catch(markErr => {
+                logger.error('[DAG] markFailed on parent also failed', {
+                  parentId: child.parentExecutionId,
+                  error: markErr instanceof Error ? markErr.message : String(markErr),
+                });
+              });
+            await sendWs('failed', {
+              executionId: child.parentExecutionId,
+              reason: 'dag_hook_error',
+            });
+          }
+        }
+      }
       return;
     }
 

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -2581,6 +2581,30 @@ async function processSubagentDispatch(
       return;
     }
 
+    // Org-billed per-member cap, mirroring the parent gate in processExecution. Every
+    // DAG node and every delegated subagent lands here as a fresh execution (never an
+    // aggregation-only wake, since only the top-level parent can be resumed from
+    // `awaiting_dag_children`), so this always applies - no exemption needed. Without
+    // it, a capped-out member could dispatch unlimited child work through the
+    // org-pool-only check above, which does not see the per-member limit at all.
+    if (organization && creditService.isMemberAtOrOverCap(organization, child.userId)) {
+      logger.warn('[Credits] Member credit cap reached; refusing to start subagent', {
+        used: creditService.getMemberUsedCredits(organization, child.userId),
+        cap: organization.maxCreditsPerMember,
+      });
+      await agentExecutionRepository.markFailed(childExecutionId, {
+        message: 'Organization member credit limit reached',
+      });
+      await sendWs('subagent_failed', {
+        executionId: parentId,
+        childExecutionId,
+        agentName,
+        error: 'insufficient_credits',
+        isTimeout: false,
+      });
+      return;
+    }
+
     // Resolve LLM + models.
     const apiKeyTable = await apiKeyService.getEffectiveLLMApiKeys(child.userId, {
       db: { apiKeys: apiKeyRepository, adminSettings: adminSettingsRepository },

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -791,9 +791,12 @@ async function processExecution(
     // in-flight iterations still settle - this bounds the overshoot, it does not refund it.
     //
     // Exception: a DAG parent waking ONLY to aggregate children that have already
-    // finished (`isAggregationOnlyWake`) does no new billable work of its own, so
-    // gating it would hard-fail the parent and strand completed, already-paid-for
-    // child work with no aggregated result returned. Skipping the gate here is bounded
+    // finished (`isAggregationOnlyWake`) does no new billable work IN THE WAKE ITSELF
+    // (the read-and-splice), so gating it would hard-fail the parent and strand
+    // completed, already-paid-for child work with no aggregated result returned. The
+    // same invocation still runs one billed grace iteration afterward - see
+    // `clampMaxIterationsForOverCapAggregationWake` for why that is bounded and safe.
+    // Skipping the gate here is bounded
     // to this one handoff - if the parent needs another continuation afterward, that
     // next invocation is a normal `continuing` status and this gate applies in full.
     if (organization && !isAggregationOnlyWake && creditService.isMemberAtOrOverCap(organization, execution.userId)) {
@@ -2471,6 +2474,60 @@ async function processExecution(
 // ---------------------------------------------------------------------------
 
 /**
+ * Fires the DAG completion hook on a refused/failed dispatched child, guarded on
+ * `dagNodeId` (a no-op for a plain delegated subagent, which has no siblings to
+ * unblock). `onDagNodeTerminal` is the ONLY thing that unblocks siblings or wakes
+ * a DAG parent - every early exit in `processSubagentDispatch` that skips it can
+ * wedge the parent in `awaiting_dag_children` forever (`cleanupStaleActive`
+ * deliberately excludes that status, so there is no reaper), and the wake only
+ * needs the LAST sibling to reach a terminal state to take a hook-less exit, not
+ * every sibling. Recovery mirrors the hook's other call sites: if the hook itself
+ * throws, mark the parent failed so the session unwedges instead of hanging.
+ *
+ * Deliberately NOT called from the `!claimed` CAS-loss exit: that means another
+ * Lambda already owns this child and will complete it (and fire this hook) through
+ * its own normal path. Firing here too would report a false terminal status for a
+ * child that may still succeed.
+ */
+async function fireDagNodeTerminalOnRefusal(args: {
+  dagNodeId: string | undefined;
+  parentExecutionId: string | undefined;
+  childExecutionId: string;
+  connectionId: string;
+  logger: Logger;
+  sendWs: ReturnType<typeof createWsSender>;
+  status?: 'failed' | 'aborted';
+}): Promise<void> {
+  const { dagNodeId, parentExecutionId, childExecutionId, connectionId, logger, sendWs, status = 'failed' } = args;
+  if (!dagNodeId) return;
+  try {
+    await onDagNodeTerminal({
+      child: { id: childExecutionId, parentExecutionId, dagNodeId, status },
+      connectionId,
+      logger,
+    });
+  } catch (hookErr) {
+    const msg = hookErr instanceof Error ? hookErr.message : String(hookErr);
+    logger.error('[DAG] onDagNodeTerminal failed - marking parent failed', {
+      parentId: parentExecutionId,
+      childExecutionId,
+      error: msg,
+    });
+    if (parentExecutionId) {
+      await agentExecutionRepository
+        .markFailed(parentExecutionId, { message: `DAG completion hook failed: ${msg}` })
+        .catch(markErr => {
+          logger.error('[DAG] markFailed on parent also failed', {
+            parentId: parentExecutionId,
+            error: markErr instanceof Error ? markErr.message : String(markErr),
+          });
+        });
+      await sendWs('failed', { executionId: parentExecutionId, reason: 'dag_hook_error' });
+    }
+  }
+}
+
+/**
  * Runs a subagent that was dispatched to its own Lambda (either via `background: true`
  * or via the parent's mid-poll handoff when running out of time). The child doc
  * already has `subagentConfig` populated by the orchestrator; we resolve the agent
@@ -2511,6 +2568,10 @@ async function processSubagentDispatch(
 
   let parentId: string | undefined;
   let agentName: string | undefined;
+  // Hoisted so the outer catch (which has no access to `child`) can still fire the
+  // DAG completion hook on a fatal error - see `fireDagNodeTerminalOnRefusal`.
+  let dagNodeId: string | undefined;
+  let dagParentExecutionId: string | undefined;
 
   try {
     const child = await agentExecutionRepository.findById(childExecutionId);
@@ -2521,6 +2582,8 @@ async function processSubagentDispatch(
 
     parentId = child.parentExecutionId ?? child.spawnedByExecutionId ?? childExecutionId;
     agentName = child.subagentConfig.agentName;
+    dagNodeId = child.dagNodeId;
+    dagParentExecutionId = child.parentExecutionId;
 
     // Check abort flag before claiming.
     if (child.abortedAt) {
@@ -2532,10 +2595,23 @@ async function processSubagentDispatch(
         error: 'Subagent was aborted before start',
         isTimeout: false,
       });
+      await fireDagNodeTerminalOnRefusal({
+        dagNodeId,
+        parentExecutionId: dagParentExecutionId,
+        childExecutionId,
+        connectionId,
+        logger,
+        sendWs,
+        status: 'aborted',
+      });
       return;
     }
 
-    // Atomic CAS: only the first dispatched Lambda claims the child.
+    // Atomic CAS: only the first dispatched Lambda claims the child. Deliberately
+    // does NOT fire the DAG completion hook on a lost race: the winning Lambda owns
+    // this child and will complete it (success or failure) through its own normal
+    // path, firing the hook itself then. Firing it here too would report a false
+    // terminal status for a child that may still succeed.
     const claimed = await agentExecutionRepository.claimExecution(childExecutionId, ['pending'], 'running');
     if (!claimed) {
       logger.warn('[CAS] Another Lambda already claimed this subagent, exiting gracefully', {
@@ -2559,6 +2635,14 @@ async function processSubagentDispatch(
         error: 'unauthorized',
         isTimeout: false,
       });
+      await fireDagNodeTerminalOnRefusal({
+        dagNodeId,
+        parentExecutionId: dagParentExecutionId,
+        childExecutionId,
+        connectionId,
+        logger,
+        sendWs,
+      });
       return;
     }
     const organization = child.organizationId ? await organizationRepository.findById(child.organizationId) : null;
@@ -2577,6 +2661,14 @@ async function processSubagentDispatch(
         agentName,
         error: 'insufficient_credits',
         isTimeout: false,
+      });
+      await fireDagNodeTerminalOnRefusal({
+        dagNodeId,
+        parentExecutionId: dagParentExecutionId,
+        childExecutionId,
+        connectionId,
+        logger,
+        sendWs,
       });
       return;
     }
@@ -2602,48 +2694,14 @@ async function processSubagentDispatch(
         error: 'insufficient_credits',
         isTimeout: false,
       });
-      // Phase 4a - DAG node terminal even on this refusal. The cap is a per-USER
-      // condition, so it trips uniformly for every sibling in the same DAG - without
-      // this, NONE of them would fire the hook that wakes the parent, leaving it
-      // wedged in `awaiting_dag_children` forever (no reaper: `cleanupStaleActive`
-      // deliberately excludes that status). Same recovery as the other terminal
-      // sites in this function: if the hook itself throws, mark the parent failed
-      // so the session unwedges instead of hanging.
-      if (child.dagNodeId) {
-        try {
-          await onDagNodeTerminal({
-            child: {
-              id: childExecutionId,
-              parentExecutionId: child.parentExecutionId,
-              dagNodeId: child.dagNodeId,
-              status: 'failed',
-            },
-            connectionId,
-            logger,
-          });
-        } catch (hookErr) {
-          const msg = hookErr instanceof Error ? hookErr.message : String(hookErr);
-          logger.error('[DAG] onDagNodeTerminal failed - marking parent failed', {
-            parentId: child.parentExecutionId,
-            childExecutionId,
-            error: msg,
-          });
-          if (child.parentExecutionId) {
-            await agentExecutionRepository
-              .markFailed(child.parentExecutionId, { message: `DAG completion hook failed: ${msg}` })
-              .catch(markErr => {
-                logger.error('[DAG] markFailed on parent also failed', {
-                  parentId: child.parentExecutionId,
-                  error: markErr instanceof Error ? markErr.message : String(markErr),
-                });
-              });
-            await sendWs('failed', {
-              executionId: child.parentExecutionId,
-              reason: 'dag_hook_error',
-            });
-          }
-        }
-      }
+      await fireDagNodeTerminalOnRefusal({
+        dagNodeId,
+        parentExecutionId: dagParentExecutionId,
+        childExecutionId,
+        connectionId,
+        logger,
+        sendWs,
+      });
       return;
     }
 
@@ -2707,6 +2765,14 @@ async function processSubagentDispatch(
         agentName,
         error: `Unknown agent: ${agentName}`,
         isTimeout: false,
+      });
+      await fireDagNodeTerminalOnRefusal({
+        dagNodeId,
+        parentExecutionId: dagParentExecutionId,
+        childExecutionId,
+        connectionId,
+        logger,
+        sendWs,
       });
       return;
     }
@@ -3179,6 +3245,14 @@ async function processSubagentDispatch(
         agentName,
         error: 'Subagent dispatch failed',
         isTimeout: false,
+      });
+      await fireDagNodeTerminalOnRefusal({
+        dagNodeId,
+        parentExecutionId: dagParentExecutionId,
+        childExecutionId,
+        connectionId,
+        logger,
+        sendWs,
       });
     } catch (cleanupErr) {
       logger.error('[SubagentDispatch] Cleanup also failed', {

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -1897,9 +1897,15 @@ async function processExecution(
     let iterationResult: IterationResult | undefined;
     let iterationIndex = isNewExecution ? 0 : ((execution.checkpoint as AgentCheckpoint)?.iteration ?? 0);
 
+    // Captured once and reused below at `displayAnswer` - the truncation message needs to know
+    // whether a later `reachedMaxIterations` was caused by THIS clamp specifically (where a
+    // "send a follow-up" suggestion is a dead end) rather than the run's own real ceiling.
+    const isOverCapForAggregationClamp = Boolean(
+      organization && creditService.isMemberAtOrOverCap(organization, execution.userId)
+    );
     maxIterations = clampMaxIterationsForOverCapAggregationWake({
       isAggregationOnlyWake,
-      isOverCap: Boolean(organization && creditService.isMemberAtOrOverCap(organization, execution.userId)),
+      isOverCap: isOverCapForAggregationClamp,
       maxIterations,
       iterationIndex,
     });
@@ -2385,6 +2391,7 @@ async function processExecution(
       finalAnswer,
       dagAggregationFallbackSummary,
       configuredMaxIterations,
+      isOverCapGraceIteration: isAggregationOnlyWake && isOverCapForAggregationClamp,
     });
 
     await agentExecutionRepository.markComplete(executionId, {
@@ -2503,8 +2510,9 @@ async function processExecution(
  *
  * Deliberately NOT called from the `!claimed` CAS-loss exit: that means another
  * Lambda already owns this child and will complete it (and fire this hook) through
- * its own normal path. Firing here too would report a false terminal status for a
- * child that may still succeed.
+ * its own normal path. Firing here too would not double-unblock anything - the hook
+ * is idempotent - but it would report a false terminal status for a child that may
+ * still succeed: a CAS loss means someone else has it, not that it failed.
  *
  * The `status` argument is NOT load-bearing for `onDagNodeTerminal` itself - it
  * re-reads every sibling fresh from the DB rather than trusting the passed-in value,

--- a/apps/client/server/queueHandlers/agentExecutor.ts
+++ b/apps/client/server/queueHandlers/agentExecutor.ts
@@ -84,7 +84,7 @@ import { creditService, apiKeyService, estimateGeneratedMediaUsd } from '@bike4m
 import { resolveLatticeTools, buildSubagentLatticeToolPool } from './agentExecutor.latticeTools';
 import { selectGatedAction } from './agentExecutorUtils/toolPermissions';
 import { guardDecomposeOnce } from './agentExecutorUtils/decomposeGuard';
-import { buildTruncatedRunReply } from './agentExecutorUtils/truncatedReply';
+import { resolveDisplayAnswer } from './agentExecutorUtils/truncatedReply';
 import { guardPlanCompletion } from './agentExecutorUtils/planCompletionGuard';
 import { injectBriefContext } from './agentExecutorUtils/briefContextInjector';
 import { rehydrateOptiPlanState, ledgerForWrite } from './agentExecutorUtils/optiPlanLedger';
@@ -790,15 +790,10 @@ async function processExecution(
     // cap mid-execution IS stopped, at its next handoff (like the pool gate above). Started,
     // in-flight iterations still settle - this bounds the overshoot, it does not refund it.
     //
-    // Exception: a DAG parent waking ONLY to aggregate children that have already
-    // finished (`isAggregationOnlyWake`) does no new billable work IN THE WAKE ITSELF
-    // (the read-and-splice), so gating it would hard-fail the parent and strand
-    // completed, already-paid-for child work with no aggregated result returned. The
-    // same invocation still runs one billed grace iteration afterward - see
-    // `clampMaxIterationsForOverCapAggregationWake` for why that is bounded and safe.
-    // Skipping the gate here is bounded
-    // to this one handoff - if the parent needs another continuation afterward, that
-    // next invocation is a normal `continuing` status and this gate applies in full.
+    // Exception: skip the gate for a genuine aggregation-only wake (`isAggregationOnlyWake`)
+    // so it doesn't strand already-paid-for child work. See `isDagAggregationWake` and
+    // `clampMaxIterationsForOverCapAggregationWake` in `agentExecutorDag.ts` for the full
+    // rationale and the bound on what this exception actually grants.
     if (organization && !isAggregationOnlyWake && creditService.isMemberAtOrOverCap(organization, execution.userId)) {
       logger.warn('[Credits] Member credit cap reached; refusing to start execution', {
         used: creditService.getMemberUsedCredits(organization, execution.userId),
@@ -1647,6 +1642,11 @@ async function processExecution(
     let maxIterations = orchestrationProfile
       ? pickEffectiveMaxIterations(startPayload?.maxIterations, orchestrationProfile)
       : (startPayload?.maxIterations ?? 25);
+    // Preserved before the aggregation-wake clamp below can shrink `maxIterations` for
+    // this invocation - the truncation message must report the run's real configured
+    // ceiling, not the one-iteration grace grant, or the number and the "send a
+    // follow-up" advice are both wrong (a follow-up hits the same cap gate again).
+    const configuredMaxIterations = maxIterations;
 
     // Track cumulative usage for delta-based billing.
     // Token counts in iterationBilling are stored as per-iteration deltas, so
@@ -1827,6 +1827,13 @@ async function processExecution(
       }
     }
 
+    // Fallback reply if the grace iteration below (a capped-out member's one-iteration
+    // aggregation grant) hits its own ceiling without producing a final_answer step -
+    // `extractFinalAnswer` would then find nothing, silently dropping the very
+    // already-paid-for child work this PR exists to return. See its use at
+    // `displayAnswer` below.
+    let dagAggregationFallbackSummary: string | undefined;
+
     // Phase 4a - resume from `awaiting_dag_children`. The completion hook for
     // the last terminal DAG child enqueued this continuation; load all child
     // results, build the aggregated markdown via shared `buildPipelineResult`,
@@ -1839,6 +1846,7 @@ async function processExecution(
         dagSpec: execution.dagSpec,
         children,
       });
+      dagAggregationFallbackSummary = summary;
       try {
         agent.replaceLastToolResultObservation(execution.waitingOnDagChildren.toolUseId, summary);
       } catch (err) {
@@ -2367,8 +2375,17 @@ async function processExecution(
     // A run that stopped on the iteration ceiling (not model completion) leaves `finalAnswer` as
     // a mid-sentence fragment; wrap it in a deterministic truncation notice so the user sees an
     // honest "partial, hit the limit" reply instead of a trailed-off thought. See #674.
+    // See `resolveDisplayAnswer` for the capped-out-member grace-iteration case this
+    // must also handle: `finalAnswer` can be undefined entirely, and falling back to
+    // `dagAggregationFallbackSummary` there is what keeps the aggregated child report
+    // from being silently dropped on exactly the path this PR exists to protect.
     const reachedMaxIterations = iterationResult?.reachedMaxIterations ?? false;
-    const displayAnswer = reachedMaxIterations ? buildTruncatedRunReply(maxIterations, finalAnswer) : finalAnswer;
+    const displayAnswer = resolveDisplayAnswer({
+      reachedMaxIterations,
+      finalAnswer,
+      dagAggregationFallbackSummary,
+      configuredMaxIterations,
+    });
 
     await agentExecutionRepository.markComplete(executionId, {
       answer: displayAnswer,
@@ -2488,6 +2505,21 @@ async function processExecution(
  * Lambda already owns this child and will complete it (and fire this hook) through
  * its own normal path. Firing here too would report a false terminal status for a
  * child that may still succeed.
+ *
+ * The `status` argument is NOT load-bearing for `onDagNodeTerminal` itself - it
+ * re-reads every sibling fresh from the DB rather than trusting the passed-in value,
+ * so passing 'failed' vs 'aborted' only affects logging. What actually matters is
+ * that `markFailed`/`markAborted` already landed before this call, which every
+ * caller here does.
+ *
+ * Narrow gap this does NOT close: if `agentExecutionRepository.findById` throws or
+ * returns null, or `child.subagentConfig` is missing, the function throws before
+ * `dagNodeId`/`dagParentExecutionId` are ever assigned, so the outer catch's call to
+ * this helper no-ops (both hoisted vars stay `undefined`). Not cheaply fixable - the
+ * dispatch message carries `dagNodeId` but not `parentExecutionId`
+ * (`agentExecutorDag.ts` `DagNodeDispatchSchema`), and `onDagNodeTerminal` requires
+ * both. A genuinely rare window (the dispatcher always sets `subagentConfig`; this
+ * needs a `findById` read blip immediately after create).
  */
 async function fireDagNodeTerminalOnRefusal(args: {
   dagNodeId: string | undefined;
@@ -3057,6 +3089,19 @@ async function processSubagentDispatch(
             partialAnswer: result.finalAnswer,
           });
         }
+        // This return was found to bypass the DAG completion hook entirely (a
+        // human review caught it - neither the success path below nor the catch
+        // block's own hook-fire cover this branch). Fire it here too, same as
+        // every other terminal exit in this function.
+        await fireDagNodeTerminalOnRefusal({
+          dagNodeId,
+          parentExecutionId: dagParentExecutionId,
+          childExecutionId,
+          connectionId,
+          logger,
+          sendWs,
+          status: userAborted ? 'aborted' : 'failed',
+        });
         return;
       }
 

--- a/apps/client/server/queueHandlers/agentExecutorDag.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.test.ts
@@ -86,7 +86,7 @@ vi.mock('@bike4mind/database', () => ({
 }));
 
 // Import AFTER mocks are registered so the module picks up our stubs.
-const { buildDagResumeReport, onDagNodeTerminal } = await import('./agentExecutorDag');
+const { buildDagResumeReport, isDagAggregationWake, onDagNodeTerminal } = await import('./agentExecutorDag');
 
 const spec: IDagSpec = {
   toolUseId: 'tool_use_1',
@@ -208,6 +208,36 @@ describe('buildDagResumeReport', () => {
     expect(report.failedNodes).toContain('explore');
     expect(report.summary).toContain('Failed Tasks (1)');
     expect(report.summary).toMatch(/Aborted|Unknown error/);
+  });
+});
+
+describe('isDagAggregationWake', () => {
+  it('is true only when resuming a DAG wake with both dagSpec and waitingOnDagChildren present', () => {
+    expect(
+      isDagAggregationWake({ isDagResume: true, dagSpec: spec, waitingOnDagChildren: { toolUseId: 'tool_use_1' } })
+    ).toBe(true);
+  });
+
+  it('is false when not a DAG resume, even with a stale dagSpec/waitingOnDagChildren left on the doc', () => {
+    expect(
+      isDagAggregationWake({ isDagResume: false, dagSpec: spec, waitingOnDagChildren: { toolUseId: 'tool_use_1' } })
+    ).toBe(false);
+  });
+
+  it('is false when resuming but dagSpec is missing', () => {
+    expect(
+      isDagAggregationWake({ isDagResume: true, dagSpec: undefined, waitingOnDagChildren: { toolUseId: 'tool_use_1' } })
+    ).toBe(false);
+  });
+
+  it('is false when resuming but waitingOnDagChildren is missing', () => {
+    expect(isDagAggregationWake({ isDagResume: true, dagSpec: spec, waitingOnDagChildren: undefined })).toBe(false);
+  });
+
+  it('is false when both are missing', () => {
+    expect(isDagAggregationWake({ isDagResume: true, dagSpec: undefined, waitingOnDagChildren: undefined })).toBe(
+      false
+    );
   });
 });
 

--- a/apps/client/server/queueHandlers/agentExecutorDag.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.test.ts
@@ -86,7 +86,8 @@ vi.mock('@bike4mind/database', () => ({
 }));
 
 // Import AFTER mocks are registered so the module picks up our stubs.
-const { buildDagResumeReport, isDagAggregationWake, onDagNodeTerminal } = await import('./agentExecutorDag');
+const { buildDagResumeReport, clampMaxIterationsForOverCapAggregationWake, isDagAggregationWake, onDagNodeTerminal } =
+  await import('./agentExecutorDag');
 
 const spec: IDagSpec = {
   toolUseId: 'tool_use_1',
@@ -238,6 +239,52 @@ describe('isDagAggregationWake', () => {
     expect(isDagAggregationWake({ isDagResume: true, dagSpec: undefined, waitingOnDagChildren: undefined })).toBe(
       false
     );
+  });
+});
+
+describe('clampMaxIterationsForOverCapAggregationWake', () => {
+  it('caps to the next iteration when the wake is aggregation-only and the member is over cap', () => {
+    expect(
+      clampMaxIterationsForOverCapAggregationWake({
+        isAggregationOnlyWake: true,
+        isOverCap: true,
+        maxIterations: 25,
+        iterationIndex: 7,
+      })
+    ).toBe(8);
+  });
+
+  it('never raises the ceiling above the original maxIterations', () => {
+    expect(
+      clampMaxIterationsForOverCapAggregationWake({
+        isAggregationOnlyWake: true,
+        isOverCap: true,
+        maxIterations: 5,
+        iterationIndex: 20,
+      })
+    ).toBe(5);
+  });
+
+  it('leaves maxIterations untouched when not an aggregation-only wake, even if over cap', () => {
+    expect(
+      clampMaxIterationsForOverCapAggregationWake({
+        isAggregationOnlyWake: false,
+        isOverCap: true,
+        maxIterations: 25,
+        iterationIndex: 7,
+      })
+    ).toBe(25);
+  });
+
+  it('leaves maxIterations untouched on an aggregation-only wake when under cap', () => {
+    expect(
+      clampMaxIterationsForOverCapAggregationWake({
+        isAggregationOnlyWake: true,
+        isOverCap: false,
+        maxIterations: 25,
+        iterationIndex: 7,
+      })
+    ).toBe(25);
   });
 });
 

--- a/apps/client/server/queueHandlers/agentExecutorDag.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.ts
@@ -370,8 +370,14 @@ export function isDagAggregationWake(args: {
  * work (no new billable work of its own) - it does not license the run to keep
  * iterating past it. If the member is still over cap once the DAG's own
  * already-paid-for cost has settled, this caps the parent's own loop to the one
- * iteration that turns the aggregated result into an answer. A no-op (returns
- * `maxIterations` unchanged) outside that exact case.
+ * iteration that turns the aggregated result into an answer for THIS wake. A
+ * no-op (returns `maxIterations` unchanged) outside that exact case.
+ *
+ * This is a per-wake bound, not a lifetime one: `maxIterations` is recomputed
+ * fresh from `iterationIndex` on every invocation, so a run that dispatches a
+ * new `coordinate_task` from within its grace iteration gets another one-iteration
+ * grant on its next aggregation wake. The real overall ceiling stays the run's
+ * original `maxIterations` - each wake just narrows what's left of it to one step.
  *
  * This only bounds the PARENT's own further iterations. A new subagent or DAG
  * fan-out dispatched from within that one grace iteration is a separate fresh

--- a/apps/client/server/queueHandlers/agentExecutorDag.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.ts
@@ -359,8 +359,8 @@ export function buildDagResumeReport(args: {
  */
 export function isDagAggregationWake(args: {
   isDagResume: boolean;
-  dagSpec: unknown;
-  waitingOnDagChildren: unknown;
+  dagSpec: IDagSpec | undefined;
+  waitingOnDagChildren: { toolUseId: string } | undefined;
 }): boolean {
   return args.isDagResume && args.dagSpec != null && args.waitingOnDagChildren != null;
 }

--- a/apps/client/server/queueHandlers/agentExecutorDag.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.ts
@@ -369,15 +369,15 @@ export function isDagAggregationWake(args: {
  * The aggregation-wake exemption above only excuses the wake's own read-and-splice
  * work (no new billable work of its own) - it does not license the run to keep
  * iterating past it. If the member is still over cap once the DAG's own
- * already-paid-for cost has settled, this caps the PARENT's own loop to the one
+ * already-paid-for cost has settled, this caps the parent's own loop to the one
  * iteration that turns the aggregated result into an answer. A no-op (returns
  * `maxIterations` unchanged) outside that exact case.
  *
- * Scope note: this only bounds the parent's own further LLM iterations. If that
- * one grace iteration itself dispatches a new subagent or DAG fan-out, those
- * children are gated by `processSubagentDispatch`'s org-pool check, not by this
- * per-member cap - closing that gap is tracked separately (per-member enforcement
- * on agent-tool/dispatch spend paths), not attempted here.
+ * This only bounds the PARENT's own further iterations. A new subagent or DAG
+ * fan-out dispatched from within that one grace iteration is a separate fresh
+ * execution, gated independently by `processSubagentDispatch`'s own per-member
+ * cap check - see that function for why a capped-out member cannot use this
+ * grace iteration to launch further uncapped child work.
  */
 export function clampMaxIterationsForOverCapAggregationWake(args: {
   isAggregationOnlyWake: boolean;

--- a/apps/client/server/queueHandlers/agentExecutorDag.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.ts
@@ -369,10 +369,15 @@ export function isDagAggregationWake(args: {
  * The aggregation-wake exemption above only excuses the wake's own read-and-splice
  * work (no new billable work of its own) - it does not license the run to keep
  * iterating past it. If the member is still over cap once the DAG's own
- * already-paid-for cost has settled, this caps the loop to the one iteration that
- * turns the aggregated result into an answer, so a capped-out member can't chain
- * `coordinate_task` calls into unbounded further billable work through the
- * exemption. A no-op (returns `maxIterations` unchanged) outside that exact case.
+ * already-paid-for cost has settled, this caps the PARENT's own loop to the one
+ * iteration that turns the aggregated result into an answer. A no-op (returns
+ * `maxIterations` unchanged) outside that exact case.
+ *
+ * Scope note: this only bounds the parent's own further LLM iterations. If that
+ * one grace iteration itself dispatches a new subagent or DAG fan-out, those
+ * children are gated by `processSubagentDispatch`'s org-pool check, not by this
+ * per-member cap - closing that gap is tracked separately (per-member enforcement
+ * on agent-tool/dispatch spend paths), not attempted here.
  */
 export function clampMaxIterationsForOverCapAggregationWake(args: {
   isAggregationOnlyWake: boolean;

--- a/apps/client/server/queueHandlers/agentExecutorDag.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.ts
@@ -381,11 +381,12 @@ export function isDagAggregationWake(args: {
  * grant on its next aggregation wake. The real overall ceiling stays the run's
  * original `maxIterations` - each wake just narrows what's left of it to one step.
  *
- * This only bounds the PARENT's own further iterations. A new subagent or DAG
- * fan-out dispatched from within that one grace iteration is a separate fresh
- * execution, gated independently by `processSubagentDispatch`'s own per-member
- * cap check - see that function for why a capped-out member cannot use this
- * grace iteration to launch further uncapped child work.
+ * This only bounds the PARENT's own further iterations. A DAG fan-out, or a
+ * `background: true` subagent, dispatched from within that one grace iteration
+ * is a separate fresh execution gated independently by `processSubagentDispatch`'s
+ * own per-member cap check. A plain (non-background) `delegate_to_agent` call
+ * runs in-process instead and is NOT covered by that gate - a pre-existing gap
+ * (in-process delegation was never capped by anything), tracked in #1824.
  */
 export function clampMaxIterationsForOverCapAggregationWake(args: {
   isAggregationOnlyWake: boolean;

--- a/apps/client/server/queueHandlers/agentExecutorDag.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.ts
@@ -368,10 +368,12 @@ export function isDagAggregationWake(args: {
 /**
  * The aggregation-wake exemption above only excuses the wake's own read-and-splice
  * work (no new billable work of its own) - it does not license the run to keep
- * iterating past it. If the member is still over cap once the DAG's own
- * already-paid-for cost has settled, this caps the parent's own loop to the one
- * iteration that turns the aggregated result into an answer for THIS wake. A
- * no-op (returns `maxIterations` unchanged) outside that exact case.
+ * iterating past it. If the member reads as over cap at the moment of the wake
+ * (per whatever the org's `userDetails[].usedCredits` counter reflects at that
+ * point - it does not yet see dispatched-child spend, tracked separately), this
+ * caps the parent's own loop to the one iteration that turns the aggregated
+ * result into an answer for THIS wake. A no-op (returns `maxIterations`
+ * unchanged) outside that exact case.
  *
  * This is a per-wake bound, not a lifetime one: `maxIterations` is recomputed
  * fresh from `iterationIndex` on every invocation, so a run that dispatches a

--- a/apps/client/server/queueHandlers/agentExecutorDag.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.ts
@@ -364,3 +364,24 @@ export function isDagAggregationWake(args: {
 }): boolean {
   return args.isDagResume && args.dagSpec != null && args.waitingOnDagChildren != null;
 }
+
+/**
+ * The aggregation-wake exemption above only excuses the wake's own read-and-splice
+ * work (no new billable work of its own) - it does not license the run to keep
+ * iterating past it. If the member is still over cap once the DAG's own
+ * already-paid-for cost has settled, this caps the loop to the one iteration that
+ * turns the aggregated result into an answer, so a capped-out member can't chain
+ * `coordinate_task` calls into unbounded further billable work through the
+ * exemption. A no-op (returns `maxIterations` unchanged) outside that exact case.
+ */
+export function clampMaxIterationsForOverCapAggregationWake(args: {
+  isAggregationOnlyWake: boolean;
+  isOverCap: boolean;
+  maxIterations: number;
+  iterationIndex: number;
+}): number {
+  if (args.isAggregationOnlyWake && args.isOverCap) {
+    return Math.min(args.maxIterations, args.iterationIndex + 1);
+  }
+  return args.maxIterations;
+}

--- a/apps/client/server/queueHandlers/agentExecutorDag.ts
+++ b/apps/client/server/queueHandlers/agentExecutorDag.ts
@@ -347,3 +347,20 @@ export function buildDagResumeReport(args: {
 
   return { summary, success, failedNodes };
 }
+
+/**
+ * Whether this invocation is a DAG parent waking ONLY to aggregate children
+ * that have already finished, with no new billable work of its own to start.
+ * Shared by the per-member credit cap gate (skip - an aggregation wake should
+ * not be blocked, it just returns work the org already paid for) and the
+ * resume-trigger check below in `agentExecutor.ts` (fire - inject the
+ * aggregated result and clear `waitingOnDagChildren`), so the two decisions
+ * can never drift apart.
+ */
+export function isDagAggregationWake(args: {
+  isDagResume: boolean;
+  dagSpec: unknown;
+  waitingOnDagChildren: unknown;
+}): boolean {
+  return args.isDagResume && args.dagSpec != null && args.waitingOnDagChildren != null;
+}

--- a/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.test.ts
@@ -38,6 +38,7 @@ describe('resolveDisplayAnswer', () => {
       finalAnswer: 'a clean answer',
       dagAggregationFallbackSummary: 'unused summary',
       configuredMaxIterations: 25,
+      isOverCapGraceIteration: false,
     });
     expect(out).toBe('a clean answer');
   });
@@ -48,6 +49,7 @@ describe('resolveDisplayAnswer', () => {
       finalAnswer: undefined,
       dagAggregationFallbackSummary: '# DAG result\n\ncoffee, tea, chocolate summaries here',
       configuredMaxIterations: 25,
+      isOverCapGraceIteration: false,
     });
     expect(out).toContain('coffee, tea, chocolate summaries here');
     // Must not be silently dropped - the whole point of the fallback.
@@ -62,6 +64,7 @@ describe('resolveDisplayAnswer', () => {
       finalAnswer: undefined,
       dagAggregationFallbackSummary: 'aggregated report',
       configuredMaxIterations: 25,
+      isOverCapGraceIteration: false,
     });
     expect(out).toContain('25-iteration limit');
     expect(out).not.toContain('8-iteration limit');
@@ -73,6 +76,7 @@ describe('resolveDisplayAnswer', () => {
       finalAnswer: 'the model did answer before hitting the ceiling',
       dagAggregationFallbackSummary: 'aggregated report',
       configuredMaxIterations: 25,
+      isOverCapGraceIteration: false,
     });
     expect(out).toContain('the model did answer before hitting the ceiling');
     expect(out).not.toContain('aggregated report');
@@ -84,7 +88,26 @@ describe('resolveDisplayAnswer', () => {
       finalAnswer: undefined,
       dagAggregationFallbackSummary: undefined,
       configuredMaxIterations: 10,
+      isOverCapGraceIteration: false,
     });
     expect(out).toContain('10-iteration limit');
+  });
+
+  it('uses the honest credit-cap message, not the misleading iteration-limit one, on the over-cap grace path', () => {
+    const out = resolveDisplayAnswer({
+      reachedMaxIterations: true,
+      finalAnswer: undefined,
+      dagAggregationFallbackSummary: 'aggregated report',
+      configuredMaxIterations: 25,
+      isOverCapGraceIteration: true,
+    });
+    expect(out).toContain('aggregated report');
+    expect(out).toContain('credit cap');
+    // Neither the run's ceiling nor the internal clamp size should appear - a
+    // credit-cap stop is not an iteration-count story.
+    expect(out).not.toContain('25-iteration limit');
+    expect(out).not.toContain('8-iteration limit');
+    // The generic advice is a dead end here: a follow-up hits the same cap gate.
+    expect(out).not.toMatch(/send a follow-up to continue/i);
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.test.ts
@@ -35,6 +35,7 @@ describe('resolveDisplayAnswer', () => {
   it('returns the final answer unchanged when the run did not hit its ceiling', () => {
     const out = resolveDisplayAnswer({
       reachedMaxIterations: false,
+      ranAnyIteration: true,
       finalAnswer: 'a clean answer',
       dagAggregationFallbackSummary: 'unused summary',
       configuredMaxIterations: 25,
@@ -46,6 +47,7 @@ describe('resolveDisplayAnswer', () => {
   it('falls back to the DAG aggregation summary when a grace iteration ends with no final_answer step', () => {
     const out = resolveDisplayAnswer({
       reachedMaxIterations: true,
+      ranAnyIteration: true,
       finalAnswer: undefined,
       dagAggregationFallbackSummary: '# DAG result\n\ncoffee, tea, chocolate summaries here',
       configuredMaxIterations: 25,
@@ -61,6 +63,7 @@ describe('resolveDisplayAnswer', () => {
   it('uses the configured ceiling, not a clamped one, in the truncation message', () => {
     const out = resolveDisplayAnswer({
       reachedMaxIterations: true,
+      ranAnyIteration: true,
       finalAnswer: undefined,
       dagAggregationFallbackSummary: 'aggregated report',
       configuredMaxIterations: 25,
@@ -70,9 +73,10 @@ describe('resolveDisplayAnswer', () => {
     expect(out).not.toContain('8-iteration limit');
   });
 
-  it('prefers a real final answer over the DAG fallback when both are present', () => {
+  it('prefers a real final answer over the DAG fallback when both are present and the run is not over cap', () => {
     const out = resolveDisplayAnswer({
       reachedMaxIterations: true,
+      ranAnyIteration: true,
       finalAnswer: 'the model did answer before hitting the ceiling',
       dagAggregationFallbackSummary: 'aggregated report',
       configuredMaxIterations: 25,
@@ -85,6 +89,7 @@ describe('resolveDisplayAnswer', () => {
   it('still returns a coherent notice when neither a final answer nor a DAG summary exists', () => {
     const out = resolveDisplayAnswer({
       reachedMaxIterations: true,
+      ranAnyIteration: true,
       finalAnswer: undefined,
       dagAggregationFallbackSummary: undefined,
       configuredMaxIterations: 10,
@@ -96,6 +101,7 @@ describe('resolveDisplayAnswer', () => {
   it('uses the honest credit-cap message, not the misleading iteration-limit one, on the over-cap grace path', () => {
     const out = resolveDisplayAnswer({
       reachedMaxIterations: true,
+      ranAnyIteration: true,
       finalAnswer: undefined,
       dagAggregationFallbackSummary: 'aggregated report',
       configuredMaxIterations: 25,
@@ -109,5 +115,51 @@ describe('resolveDisplayAnswer', () => {
     expect(out).not.toContain('8-iteration limit');
     // The generic advice is a dead end here: a follow-up hits the same cap gate.
     expect(out).not.toMatch(/send a follow-up to continue/i);
+  });
+
+  it("prefers the DAG summary over ReActAgent's own synthesized ceiling notice on the over-cap grace path (the actual caller shape)", () => {
+    // ReActAgent never actually returns finalAnswer === undefined when reachedMaxIterations
+    // is true - it synthesizes this exact notice first. A prior version of this function
+    // only fell back to the summary on finalAnswer === undefined, so it never fired for the
+    // real caller and silently dropped the aggregated report every time.
+    const out = resolveDisplayAnswer({
+      reachedMaxIterations: true,
+      ranAnyIteration: true,
+      finalAnswer: 'I reached the maximum number of iterations (8/8) without arriving at a final answer.',
+      dagAggregationFallbackSummary: '# DAG result\n\ncoffee, tea, chocolate summaries here',
+      configuredMaxIterations: 25,
+      isOverCapGraceIteration: true,
+    });
+    expect(out).toContain('coffee, tea, chocolate summaries here');
+    // The clamped grant size must not leak through as if it were the run's real ceiling.
+    expect(out).not.toContain('8/8');
+    expect(out).not.toContain('8-iteration limit');
+  });
+
+  it('uses the fresh DAG summary, not a stale earlier final_answer, when the wake left no room for a grace iteration to run', () => {
+    // iterationIndex was already at or past configuredMaxIterations when the aggregation
+    // splice happened, so the loop never runs this invocation - `finalAnswer` here would be
+    // read from an EARLIER iteration's checkpoint, not this wake's result.
+    const out = resolveDisplayAnswer({
+      reachedMaxIterations: false,
+      ranAnyIteration: false,
+      finalAnswer: 'a stale answer from a much earlier iteration',
+      dagAggregationFallbackSummary: 'the fresh aggregated report',
+      configuredMaxIterations: 25,
+      isOverCapGraceIteration: true,
+    });
+    expect(out).toBe('the fresh aggregated report');
+  });
+
+  it('falls back to the stale final answer only when no fresh DAG summary exists either', () => {
+    const out = resolveDisplayAnswer({
+      reachedMaxIterations: false,
+      ranAnyIteration: false,
+      finalAnswer: 'a stale answer from a much earlier iteration',
+      dagAggregationFallbackSummary: undefined,
+      configuredMaxIterations: 25,
+      isOverCapGraceIteration: false,
+    });
+    expect(out).toBe('a stale answer from a much earlier iteration');
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.test.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTruncatedRunReply } from './truncatedReply';
+import { buildTruncatedRunReply, resolveDisplayAnswer } from './truncatedReply';
 
 describe('buildTruncatedRunReply', () => {
   it('states the run was truncated and names the iteration limit', () => {
@@ -28,5 +28,63 @@ describe('buildTruncatedRunReply', () => {
     const noArg = buildTruncatedRunReply(30);
     expect(whitespaceOnly).toBe(noArg);
     expect(withPartial).not.toBe(noArg);
+  });
+});
+
+describe('resolveDisplayAnswer', () => {
+  it('returns the final answer unchanged when the run did not hit its ceiling', () => {
+    const out = resolveDisplayAnswer({
+      reachedMaxIterations: false,
+      finalAnswer: 'a clean answer',
+      dagAggregationFallbackSummary: 'unused summary',
+      configuredMaxIterations: 25,
+    });
+    expect(out).toBe('a clean answer');
+  });
+
+  it('falls back to the DAG aggregation summary when a grace iteration ends with no final_answer step', () => {
+    const out = resolveDisplayAnswer({
+      reachedMaxIterations: true,
+      finalAnswer: undefined,
+      dagAggregationFallbackSummary: '# DAG result\n\ncoffee, tea, chocolate summaries here',
+      configuredMaxIterations: 25,
+    });
+    expect(out).toContain('coffee, tea, chocolate summaries here');
+    // Must not be silently dropped - the whole point of the fallback.
+    expect(out).not.toBe(
+      'This run reached its 25-iteration limit before finishing, so the result below is partial.\n\nSend a follow-up to continue from where this left off.'
+    );
+  });
+
+  it('uses the configured ceiling, not a clamped one, in the truncation message', () => {
+    const out = resolveDisplayAnswer({
+      reachedMaxIterations: true,
+      finalAnswer: undefined,
+      dagAggregationFallbackSummary: 'aggregated report',
+      configuredMaxIterations: 25,
+    });
+    expect(out).toContain('25-iteration limit');
+    expect(out).not.toContain('8-iteration limit');
+  });
+
+  it('prefers a real final answer over the DAG fallback when both are present', () => {
+    const out = resolveDisplayAnswer({
+      reachedMaxIterations: true,
+      finalAnswer: 'the model did answer before hitting the ceiling',
+      dagAggregationFallbackSummary: 'aggregated report',
+      configuredMaxIterations: 25,
+    });
+    expect(out).toContain('the model did answer before hitting the ceiling');
+    expect(out).not.toContain('aggregated report');
+  });
+
+  it('still returns a coherent notice when neither a final answer nor a DAG summary exists', () => {
+    const out = resolveDisplayAnswer({
+      reachedMaxIterations: true,
+      finalAnswer: undefined,
+      dagAggregationFallbackSummary: undefined,
+      configuredMaxIterations: 10,
+    });
+    expect(out).toContain('10-iteration limit');
   });
 });

--- a/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
@@ -8,20 +8,35 @@
  * a deterministic, honest notice: the run was truncated, here is the partial progress, and the
  * user can continue with a follow-up. Pure + side-effect-free so it is unit-testable. See #674.
  */
-export function buildTruncatedRunReply(maxIterations: number, finalAnswer?: string): string {
+export function buildTruncatedRunReply(
+  maxIterations: number,
+  finalAnswer?: string,
+  reason: 'iteration-limit' | 'credit-cap' = 'iteration-limit'
+): string {
   const partial = finalAnswer?.trim();
-  const header = `This run reached its ${maxIterations}-iteration limit before finishing, so the result below is partial.`;
-  const footer = 'Send a follow-up to continue from where this left off.';
+  // 'credit-cap' omits the iteration count entirely rather than reporting the clamped
+  // grace-grant size (e.g. 8) as if it were the run's real ceiling - see resolveDisplayAnswer.
+  const header =
+    reason === 'credit-cap'
+      ? "This run stopped early because your organization's per-member credit cap was reached, so the result below is partial."
+      : `This run reached its ${maxIterations}-iteration limit before finishing, so the result below is partial.`;
+  const footer =
+    reason === 'credit-cap'
+      ? "A follow-up will hit the same cap, so it won't be able to continue this run."
+      : 'Send a follow-up to continue from where this left off.';
   return partial ? `${header}\n\n${partial}\n\n${footer}` : `${header}\n\n${footer}`;
 }
 
 /**
- * Resolves the user-facing reply for a completed run, including the one case
- * `buildTruncatedRunReply` alone can silently get wrong: a capped-out member's
- * one-iteration DAG-aggregation grace grant that hits its own ceiling without
- * producing a `final_answer` step. Without the `dagAggregationFallbackSummary`
- * fallback, that path would report the truncation notice with nothing behind it,
- * dropping the already-paid-for child work this exemption exists to return.
+ * Resolves the user-facing reply for a completed run, including two cases
+ * `buildTruncatedRunReply` alone can silently get wrong on a capped-out member's
+ * one-iteration DAG-aggregation grace grant:
+ * - If that grace iteration hits its own ceiling without producing a `final_answer` step,
+ *   falling back to `dagAggregationFallbackSummary` is what keeps the already-paid-for
+ *   child work from being silently dropped.
+ * - The generic "send a follow-up" footer is actively wrong here: a follow-up creates a
+ *   new execution that the same per-member cap gate immediately refuses. `isOverCapGraceIteration`
+ *   selects the honest credit-cap message instead of the misleading iteration-limit one.
  * `configuredMaxIterations` must be the run's real ceiling, not a clamped one -
  * see `clampMaxIterationsForOverCapAggregationWake` in `agentExecutorDag.ts`.
  */
@@ -30,7 +45,14 @@ export function resolveDisplayAnswer(args: {
   finalAnswer: string | undefined;
   dagAggregationFallbackSummary: string | undefined;
   configuredMaxIterations: number;
+  isOverCapGraceIteration: boolean;
 }): string | undefined {
   if (!args.reachedMaxIterations) return args.finalAnswer;
-  return buildTruncatedRunReply(args.configuredMaxIterations, args.finalAnswer ?? args.dagAggregationFallbackSummary);
+  // If neither exists, this still falls through to buildTruncatedRunReply's own
+  // no-partial-content form (header + footer, no dropped middle section).
+  return buildTruncatedRunReply(
+    args.configuredMaxIterations,
+    args.finalAnswer ?? args.dagAggregationFallbackSummary,
+    args.isOverCapGraceIteration ? 'credit-cap' : 'iteration-limit'
+  );
 }

--- a/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
@@ -14,3 +14,23 @@ export function buildTruncatedRunReply(maxIterations: number, finalAnswer?: stri
   const footer = 'Send a follow-up to continue from where this left off.';
   return partial ? `${header}\n\n${partial}\n\n${footer}` : `${header}\n\n${footer}`;
 }
+
+/**
+ * Resolves the user-facing reply for a completed run, including the one case
+ * `buildTruncatedRunReply` alone can silently get wrong: a capped-out member's
+ * one-iteration DAG-aggregation grace grant that hits its own ceiling without
+ * producing a `final_answer` step. Without the `dagAggregationFallbackSummary`
+ * fallback, that path would report the truncation notice with nothing behind it,
+ * dropping the already-paid-for child work this exemption exists to return.
+ * `configuredMaxIterations` must be the run's real ceiling, not a clamped one -
+ * see `clampMaxIterationsForOverCapAggregationWake` in `agentExecutorDag.ts`.
+ */
+export function resolveDisplayAnswer(args: {
+  reachedMaxIterations: boolean;
+  finalAnswer: string | undefined;
+  dagAggregationFallbackSummary: string | undefined;
+  configuredMaxIterations: number;
+}): string | undefined {
+  if (!args.reachedMaxIterations) return args.finalAnswer;
+  return buildTruncatedRunReply(args.configuredMaxIterations, args.finalAnswer ?? args.dagAggregationFallbackSummary);
+}

--- a/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
@@ -59,6 +59,11 @@ export function resolveDisplayAnswer(args: {
   configuredMaxIterations: number;
   isOverCapGraceIteration: boolean;
 }): string | undefined {
+  // Returned raw, with no truncation notice wrapper, even on the credit-cap path: the
+  // aggregated report IS the complete answer for this wake (nothing failed to finish, the
+  // loop just had no room to run), so wrapping it in "this run stopped early" would describe
+  // a run that did not happen. This does mean the reply gives no hint that the member is
+  // over cap on this specific path - accepted, since the report itself is genuinely complete.
   if (!args.ranAnyIteration && args.dagAggregationFallbackSummary !== undefined) {
     return args.dagAggregationFallbackSummary;
   }

--- a/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
+++ b/apps/client/server/queueHandlers/agentExecutorUtils/truncatedReply.ts
@@ -28,31 +28,49 @@ export function buildTruncatedRunReply(
 }
 
 /**
- * Resolves the user-facing reply for a completed run, including two cases
+ * Resolves the user-facing reply for a completed run, including cases
  * `buildTruncatedRunReply` alone can silently get wrong on a capped-out member's
  * one-iteration DAG-aggregation grace grant:
- * - If that grace iteration hits its own ceiling without producing a `final_answer` step,
- *   falling back to `dagAggregationFallbackSummary` is what keeps the already-paid-for
- *   child work from being silently dropped.
- * - The generic "send a follow-up" footer is actively wrong here: a follow-up creates a
- *   new execution that the same per-member cap gate immediately refuses. `isOverCapGraceIteration`
- *   selects the honest credit-cap message instead of the misleading iteration-limit one.
+ * - `ReActAgent` always synthesizes a `final_answer` step before returning
+ *   `reachedMaxIterations: true` (its own "I reached the maximum number of
+ *   iterations..." notice, or genuine trailing content) - `finalAnswer` is
+ *   therefore NEVER actually undefined on that path, so a plain `finalAnswer ??
+ *   dagAggregationFallbackSummary` never reaches the fallback. On the credit-cap
+ *   grace path specifically, `isOverCapGraceIteration` inverts that precedence:
+ *   the summary is preferred, since the synthesized notice would also leak the
+ *   clamped grant size (e.g. "8/8") as if it were the run's real ceiling.
+ * - If the wake lands with the iteration loop unable to run at all (e.g.
+ *   `iterationIndex` was already at or past `configuredMaxIterations`),
+ *   `ranAnyIteration` is false and `finalAnswer` (if set) is read from an
+ *   EARLIER iteration's checkpoint, not this wake's result - the just-built
+ *   summary is the only fresh content this invocation actually produced.
+ * - The generic "send a follow-up" footer is actively wrong on the credit-cap
+ *   path: a follow-up creates a new execution that the same per-member cap gate
+ *   immediately refuses. `isOverCapGraceIteration` selects the honest
+ *   credit-cap message instead.
  * `configuredMaxIterations` must be the run's real ceiling, not a clamped one -
  * see `clampMaxIterationsForOverCapAggregationWake` in `agentExecutorDag.ts`.
  */
 export function resolveDisplayAnswer(args: {
   reachedMaxIterations: boolean;
+  ranAnyIteration: boolean;
   finalAnswer: string | undefined;
   dagAggregationFallbackSummary: string | undefined;
   configuredMaxIterations: number;
   isOverCapGraceIteration: boolean;
 }): string | undefined {
+  if (!args.ranAnyIteration && args.dagAggregationFallbackSummary !== undefined) {
+    return args.dagAggregationFallbackSummary;
+  }
   if (!args.reachedMaxIterations) return args.finalAnswer;
   // If neither exists, this still falls through to buildTruncatedRunReply's own
   // no-partial-content form (header + footer, no dropped middle section).
+  const answer = args.isOverCapGraceIteration
+    ? (args.dagAggregationFallbackSummary ?? args.finalAnswer)
+    : (args.finalAnswer ?? args.dagAggregationFallbackSummary);
   return buildTruncatedRunReply(
     args.configuredMaxIterations,
-    args.finalAnswer ?? args.dagAggregationFallbackSummary,
+    answer,
     args.isOverCapGraceIteration ? 'credit-cap' : 'iteration-limit'
   );
 }


### PR DESCRIPTION
# Pull Request

## Optional Screenshot/Video
<img width="1440" height="900" alt="dag-capped-mid-run-completes-after" src="https://github.com/user-attachments/assets/c28f131d-a0c9-4c13-9dbd-9fae8b315978" />

*Figure: a member seeded under a low per-member cap sends a `coordinate_task` prompt; the dispatch and aggregation iterations bill 132 and 138 credits respectively, and the DAG completes with a full synthesized answer. See the PR conversation for a second run that forces the cap down mid-flight and confirms the aggregation-wake exemption fires even ~393x over cap.*

## Description

Skips the org member's credit cap for a DAG parent that wakes only to aggregate children that already finished (and already billed) - previously this hard-failed the parent and discarded the paid-for result. Each aggregation wake grants the parent exactly one more iteration to turn the result into an answer; the same per-member check is added to `processSubagentDispatch` (every dispatched DAG node and every delegated subagent, not just DAG work) so that one grace iteration can't be used to fan out further uncapped child work. Worst case, a run that keeps re-dispatching from its grace iteration can still spend up to its full configured `maxIterations` in one-iteration grants across repeated wakes; the fix bounds each individual wake, not the run's lifetime total.

Closes #1716.

## Changes

- Extract a shared `isDagAggregationWake` predicate so the cap-gate skip and the existing DAG resume-trigger check read the same decision and can't drift apart.
- Skip the per-member cap gate only for a genuine DAG-aggregation-only wake.
- Clamp the iteration loop to one wrap-up iteration when the member is still over cap once the DAG's own already-paid-for cost has settled.
- Add the same per-member cap check to `processSubagentDispatch` (every dispatched DAG node and every delegated subagent), which previously only checked the org-wide pool.
- Unit tests for both new predicates (`agentExecutorDag.test.ts`).

## Guide for Testers

This is internal credit-gate logic in an SQS Lambda continuation path (`processExecution` in `agentExecutor.ts` is not exported/directly invocable), but the fix is reachable end-to-end through the ordinary chat UI, since it changes what happens when a DAG (`coordinate_task`) run finishes while its owner is over their org's per-member credit cap. See the PR conversation for a corrected live capture plus a direct DB-level trace of the exemption firing.

**Live reproduction (starts UNDER cap, crosses it mid-run via real billing - a member already over cap before starting is refused before ever reaching `coordinate_task`, so that is NOT the setup):**
1. As an org admin, set the org's `maxCreditsPerMember` to a value the member is currently under but that their own iteration billing will plausibly cross during the run (no admin UI for this field yet - set it directly, or via the organization update service). As that member, go to Profile -> Settings -> Experimental Features and turn Agent Mode on.
2. In chat as that member, send a prompt that names explicit parallel subtasks and asks the agent to coordinate them, e.g.: "Break this into 3 independent parallel subtasks and coordinate them: (1) summarize the history of coffee, (2) summarize the history of tea, (3) summarize the history of chocolate. Use your task coordination tool to run these in parallel."
3. Wait for the DAG round-trip to finish. Expected: the chat completes with a real combined answer, not a failure/refusal, even once the member's own iteration billing has crossed the cap by the time the parent wakes to aggregate - this is the fix; on `main` today this hard-fails with "Organization member credit limit reached" and the paid-for child work is discarded. (Whether a given run's `usedCredits` actually crosses the cap by completion depends on real token costs, so the exemption may or may not be exercised on any single attempt - see the PR conversation for a forced-cap run that isolates and confirms the exemption itself.)

**Unit-test reproduction** (deterministic, covers the exact decision boundaries):

1. From the repo root, run: `pnpm --filter client test -- server/queueHandlers/agentExecutorDag.test.ts`. Expected: all tests pass, including the `isDagAggregationWake` and `clampMaxIterationsForOverCapAggregationWake` describe blocks.
2. Open `apps/client/server/queueHandlers/agentExecutorDag.test.ts` and read those two describe blocks against the decision table: an aggregation-only wake skips the gate; an over-cap aggregation wake caps the loop to one more iteration; every other invocation shape (new execution, plain continuation, subagent resume) is unchanged.

## Additional Information

Dispatched subagent/DAG-node spend is audited on the execution doc only and doesn't yet update the org's per-member `usedCredits` counter this check reads (tracked in #1651). This PR adds the missing per-member CHECK at both gates; it does not change how spend is counted, so accounting accuracy stays #1651's scope.

A plain (non-`background`) `delegate_to_agent` call runs in-process and was never covered by any per-member cap check, before or after this PR - this PR's new gate only covers the Lambda-dispatched path (DAG nodes and `background: true` subagents). Tracked in #1824.

## Developer Notes (Optional)

`isDagAggregationWake` and `clampMaxIterationsForOverCapAggregationWake` in `agentExecutorDag.ts` are pure, dependency-free predicates - reuse this pattern (see `agentExecutor.checkpointDepth.ts`) for any new `processExecution` guard that needs unit coverage without mocking the whole handler.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc



