### PR TITLE
test(e2e): fix websocket-auth spec and add it to the manual E2E dropdown

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -34,6 +34,7 @@ on:
           - Search
           - Data Lake
           - Skills
+          - WebSocket Auth
         default: All tests
       pr_number:
         description: 'PR number for preview env (overrides stage, e.g. 123)'
@@ -87,6 +88,7 @@ jobs:
             "Search")           ARGS="--project=search" ;;
             "Data Lake")        ARGS="--project=data-lake" ;;
             "Skills")           ARGS="--project=skills" ;;
+            "WebSocket Auth")   ARGS="--project=websocket-auth" ;;
             *)                  ARGS="" ; echo "Unknown selection '$TEST_PROJECT' — running full suite" ;;
           esac
           echo "playwright_args=$ARGS" >> "$GITHUB_OUTPUT"

--- a/apps/client/e2e/websocket-auth.spec.ts
+++ b/apps/client/e2e/websocket-auth.spec.ts
@@ -8,15 +8,17 @@ import { apiCreateTestUser } from './helpers/api';
  * The WebSocket verifiers ($connect, subscribe_query, unsubscribe_query) enforce the same
  * token gates as the REST strategy: `typ` and the tokenVersion kill switch. These tests pin
  * the observable end of that from a real deploy - a current token still gets a working
- * realtime subscription, and a token revoked by logout no longer completes the handshake.
+ * realtime subscription, and a token revoked server-side no longer completes the handshake.
  *
- * Each test mints its own throwaway account: revoking bumps tokenVersion for ALL of a user's
- * tokens, so a shared spec user would have its session killed for every parallel spec. The
+ * Revocation here means the tokenVersion kill switch (admin "sign out everywhere"), NOT per-device
+ * /api/logout - that path deliberately never bumps tokenVersion (issue #1194), so it would not
+ * revoke the socket. Each test mints its own throwaway account: the bump invalidates ALL of a
+ * user's tokens, so a shared spec user would have its session killed for every parallel spec. The
  * retry index is baked into the identity because createUser rejects a duplicate email, so a
  * retry would otherwise die during setup. The email mirrors the setup convention
  * (`...-<id>-e2e@test.com`) so global-teardown's cleanup sweep matches it.
  */
-async function createWsUser(request: APIRequestContext, label: string) {
+async function createWsUser(request: APIRequestContext, label: string, options: { isAdmin?: boolean } = {}) {
   const e2eId = getE2ETestId();
   const idSuffix = e2eId ? `${e2eId}-${getTestRunId()}` : getTestRunId();
   const slug = `wsauth-${label}${test.info().retry}`;
@@ -26,7 +28,7 @@ async function createWsUser(request: APIRequestContext, label: string) {
     email,
     name: `WsAuth ${label} ${idSuffix}`,
     password: `E2eWsAuth${label}Pass123!`,
-    isAdmin: false,
+    isAdmin: options.isAdmin ?? false,
   });
   return {
     email,
@@ -48,12 +50,18 @@ async function getWebsocketUrl(request: APIRequestContext, token: string): Promi
   return websocketUrl;
 }
 
-/** Logout revokes every token the user holds by bumping tokenVersion server-side. */
-async function apiLogout(request: APIRequestContext, token: string): Promise<void> {
-  const response = await request.get(`${baseURL()}/api/logout`, {
-    headers: { Authorization: `Bearer ${token}` },
+/**
+ * Admin "sign out everywhere" force-logout: bumps the target's tokenVersion, the kill switch every
+ * verifier (REST, CLI, WS $connect) enforces. This is the only lever that revokes an already-issued
+ * access token - per-device /api/logout revokes just the session `sid` and never bumps tokenVersion
+ * (issue #1194), so $connect (which checks tokenVersion, not the session store) would still accept
+ * the token. The caller revokes itself, so it must be an admin (createWsUser(..., { isAdmin: true })).
+ */
+async function apiForceLogout(request: APIRequestContext, adminToken: string, userId: string): Promise<void> {
+  const response = await request.post(`${baseURL()}/api/users/${userId}/revoke-sessions`, {
+    headers: { Authorization: `Bearer ${adminToken}` },
   });
-  if (!response.ok()) throw new Error(`Logout failed: ${response.status()}`);
+  if (!response.ok()) throw new Error(`Force-logout failed: ${response.status()}`);
 }
 
 /**
@@ -128,7 +136,9 @@ async function subscribeRoundTrip(
               subscriptionId,
               collectionName: 'users',
               query: { _id: id },
-              fields: { email: true },
+              // No `fields`: the server adds exclusion-based fieldLimits for `users` (password etc),
+              // and an inclusion projection here would mix inclusions+exclusions and be rejected.
+              // The real client (UserContext.tsx) subscribes to `users` without a projection too.
               fetchInitialData: true,
             })
           );
@@ -163,8 +173,9 @@ test.describe('WebSocket token enforcement', () => {
     expect(openAfterUnsubscribe).toBe(true);
   });
 
-  test('a token revoked by logout is refused at connect', async ({ page, request }) => {
-    const user = await createWsUser(request, 'revoked');
+  test('a token revoked server-side (force-logout) is refused at connect', async ({ page, request }) => {
+    // Admin so the user can pull the tokenVersion kill switch on itself; see apiForceLogout.
+    const user = await createWsUser(request, 'revoked', { isAdmin: true });
     const wsUrl = await getWebsocketUrl(request, user.accessToken);
     await page.goto('/login');
 
@@ -172,7 +183,7 @@ test.describe('WebSocket token enforcement', () => {
     // is the kill switch firing and not a broken deploy or a bad URL.
     expect(await tryWsConnect(page, wsUrl, user.accessToken)).toBe(true);
 
-    await apiLogout(request, user.accessToken);
+    await apiForceLogout(request, user.accessToken, user.userId);
 
     expect(await tryWsConnect(page, wsUrl, user.accessToken)).toBe(false);
   });

--- a/apps/client/e2e/websocket-auth.spec.ts
+++ b/apps/client/e2e/websocket-auth.spec.ts
@@ -136,9 +136,11 @@ async function subscribeRoundTrip(
               subscriptionId,
               collectionName: 'users',
               query: { _id: id },
-              // No `fields`: the server adds exclusion-based fieldLimits for `users` (password etc),
-              // and an inclusion projection here would mix inclusions+exclusions and be rejected.
-              // The real client (UserContext.tsx) subscribes to `users` without a projection too.
+              // `fields` is required by the schema, and for `users` the server merges in
+              // exclusion-based fieldLimits (password etc); an inclusion projection here would mix
+              // inclusions+exclusions and be rejected, so send {} - exactly what the real client
+              // (useSubscribeCollection) sends - and only the server exclusions apply.
+              fields: {},
               fetchInitialData: true,
             })
           );


### PR DESCRIPTION
#Pull Request

## Screenshots
<img width="640" height="296" alt="Screenshot 2026-08-14 at 1 31 00 PM" src="https://github.com/user-attachments/assets/666ee1b2-72da-413d-9b73-0724c4fec455" />



## Description

The `websocket-auth` E2E spec failed on the nightly staging run (issue #1764). Both non-trivial
assertions were test bugs: they were added alongside the WS-auth enforcement but never ran in PR CI
(E2E was skipped on the introducing PR), so they first executed against a real deploy on the nightly
and immediately failed. This PR fixes the spec and makes the project runnable on its own from the
manual E2E dispatch.

Root causes:

1. **Revoked-token test drove `/api/logout`**, which is per-device by design (issue #1194) and never
   bumps `tokenVersion` - the only gate `$connect` enforces. So the token kept connecting and the
   test's `toBe(false)` could never pass. Switched to the admin force-logout lever
   (`POST /api/users/[id]/revoke-sessions`), which does bump `tokenVersion`.

2. **Subscribe round-trip sent `fields: { email: true }`.** For the `users` collection the server
   merges in exclusion-based `fieldLimits` (password, etc.), so an inclusion projection trips the
   `Cannot mix exclusions and inclusions` guard and no `data_update` is delivered. `fields` is also
   required by `DataSubscribeRequestAction`, so simply omitting it makes the parse throw. The fix
   sends `fields: {}` - exactly what the real client (`useSubscribeCollection`) sends - which
   satisfies the schema and leaves only the server exclusions.

No product code changed - these are test-only corrections plus one CI workflow convenience.

## Changes

- `apps/client/e2e/websocket-auth.spec.ts`
  - Revoke via admin force-logout (`revoke-sessions`) instead of `/api/logout`; the subject user is
    now created `isAdmin: true` so it can pull the `tokenVersion` kill switch on itself. Renamed the
    test to "a token revoked server-side (force-logout) is refused at connect".
  - Subscribe round-trip now sends `fields: {}`, matching the real client.
  - Updated the file-level docstring to describe the `tokenVersion` kill switch (not per-device logout).
- `.github/workflows/e2e-manual.yml`
  - Added `WebSocket Auth` to the `test_project` dropdown and mapped it to `--project=websocket-auth`
    so the suite can be run on its own.

## Guide for Testers

1. Open the Actions tab: `https://github.com/Bike4Mind/bike4mind/actions/workflows/e2e-manual.yml`.
2. Click **Run workflow**.
3. In **Use workflow from**, select the branch `fix/websocket-auth-e2e-1764` (the new dropdown option
   only exists on this branch until it merges to `main`).
4. Set **Specific test to run** to `WebSocket Auth`. Leave environment as `dev`.
5. Click **Run workflow** and wait for the run to finish (about 5 minutes).
6. Expected result: the `run / E2E Tests` job is green and the log shows `4 passed` with:
   - `a current access token connects and receives its subscription data`
   - `a token revoked server-side (force-logout) is refused at connect`
   - `a refresh token is refused at connect`
   (the 4th is the `setup-core` admin-auth setup.)

Reference run on this branch (green): https://github.com/Bike4Mind/bike4mind/actions/runs/31772547483

### What NOT to test

- No UI changes; nothing to click in the app.
- No product/runtime behavior changed - this is E2E test wiring plus a CI dropdown entry only.

## Additional Information

Closes #1764.

A latent, non-user-facing observation surfaced while fixing this (not addressed here): in
`dataSubscribeRequest.ts` the projection guard throws before reaching the `{...inclusions, deletedAt: true}`
branch, so any `users` subscription with an inclusion projection is effectively unreachable. No current
client passes one (`useSubscribeCollection` always sends `fields: {}`), so there is no runtime impact.
Can file separately if worth cleaning up.
