### PR TITLE
fix(client): open data-lake files in the viewer without attaching them

### DIFF
--- a/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
+++ b/apps/client/app/components/Knowledge/KnowledgeViewer.tsx
@@ -391,6 +391,7 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
   const artifactData = useSessionLayout(s => s.artifactData);
   const recentArtifacts = useSessionLayout(s => s.recentArtifacts);
   const selectedArtifactId = useSessionLayout(s => s.selectedArtifactId);
+  const previewFile = useSessionLayout(s => s.previewFile);
   const { canUseAdminTools } = useAdminTools();
   const isMobile = useIsMobile();
   const { selectedTabIndex, showLineNumbers } = useKnowledgeViewer();
@@ -594,6 +595,24 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
         });
       });
 
+    // Data-lake View preview: a file being looked at WITHOUT being attached to the session
+    // (see useSessionLayout.previewFile). Skipped when the same file already has a tab through
+    // any attached list, so attaching a previewed file never duplicates it.
+    if (
+      previewFile &&
+      !workBenchFileIds.has(previewFile.id) &&
+      !systemFileIds.has(previewFile.id) &&
+      !messageFileIds.has(previewFile.id)
+    ) {
+      items.push({
+        id: previewFile.id,
+        type: 'file' as const,
+        content: previewFile,
+        title: previewFile.fileName,
+        timestamp: previewFile.createdAt ? new Date(previewFile.createdAt).getTime() : 0,
+      });
+    }
+
     // Stable timestamp derived from the artifact ID (avoids infinite loops).
     // IDs follow artifact_type_identifier_timestamp_index; extract the timestamp part.
     const getStableTimestamp = (id: string): number => {
@@ -723,7 +742,15 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
 
     return items;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recentArtifacts, workBenchFiles, systemFiles, messageFiles, pendingMessageFiles, latestArtifact?.artifact.id]);
+  }, [
+    recentArtifacts,
+    workBenchFiles,
+    systemFiles,
+    messageFiles,
+    pendingMessageFiles,
+    previewFile,
+    latestArtifact?.artifact.id,
+  ]);
 
   // Effect: Reset view when no selection
   useEffect(() => {
@@ -768,6 +795,11 @@ const KnowledgeViewer: React.FC<KnowledgeViewerProps> = ({ autoHideOnEmpty = tru
     // Only clear if session ID actually changed (not just on re-render)
     if (prevSessionIdRef.current !== currentSessionId) {
       clearRecentArtifacts();
+      // The data-lake View preview is just as session-transient: leaving it set would surface a
+      // stale "just looking" tab inside a different notebook's viewer.
+      if (useSessionLayout.getState().previewFile) {
+        setSessionLayout({ previewFile: null });
+      }
       prevSessionIdRef.current = currentSessionId;
     }
   }, [currentSessionId]);

--- a/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.test.tsx
@@ -293,30 +293,41 @@ describe('DataLakeExplorer chat-first surface', () => {
     errSpy.mockRestore();
   });
 
-  it('view opens the KnowledgeViewer split on the embedded host', async () => {
+  it('view opens the KnowledgeViewer split on the embedded host without touching the workbench', async () => {
     renderExplorer();
     fireEvent.click(screen.getByTestId('mock-view'));
-    // The viewer builds its tabs from the workbench, so the file must land there to have a tab.
+    // The viewer shows the file through the transient previewFile slot - viewing must not
+    // attach it to the prompt (the explicit [+] action does that).
     await vi.waitFor(() => {
-      expect(setWorkBenchFiles).toHaveBeenCalledWith('sess-1', expect.any(Function));
-      expect(setSessionLayout).toHaveBeenCalledWith({ layout: 'vertical', selectedArtifactId: 'file-123' });
+      expect(setSessionLayout).toHaveBeenCalledWith({
+        layout: 'vertical',
+        previewFile: expect.objectContaining({ id: 'file-123' }),
+        selectedArtifactId: 'file-123',
+      });
     });
-    // waitFor (not vi.waitFor) - see the useWorkBenchFiles mock comment above.
-    await waitFor(() => expect(screen.getByTestId('mock-tree')).toHaveAttribute('data-selected', 'file-123'));
+    expect(setWorkBenchFiles).not.toHaveBeenCalled();
+    // No highlight either: the highlight tracks workbench membership (#1693), and View no
+    // longer changes membership.
+    expect(screen.getByTestId('mock-tree')).toHaveAttribute('data-selected', '');
     // The rail keeps the tree; the chat's own SessionContainer renders the viewer here.
     expect(screen.queryByTestId('datalake-rail-viewer')).toBeNull();
   });
 
-  it('view on /new mints the session first, then opens the split', async () => {
+  it('view on /new opens the split without minting a session', async () => {
     sessionState.currentSessionId = null;
     const createSessionForFile = vi.fn().mockResolvedValue('sess-new');
     renderExplorer({ createSessionForFile });
     fireEvent.click(screen.getByTestId('mock-view'));
     await vi.waitFor(() => {
-      expect(setWorkBenchFiles).toHaveBeenCalledWith('sess-new', expect.any(Function));
-      expect(setSessionLayout).toHaveBeenCalledWith({ layout: 'vertical', selectedArtifactId: 'file-123' });
+      expect(setSessionLayout).toHaveBeenCalledWith({
+        layout: 'vertical',
+        previewFile: expect.objectContaining({ id: 'file-123' }),
+        selectedArtifactId: 'file-123',
+      });
     });
-    expect(createSessionForFile).toHaveBeenCalledTimes(1);
+    // Previewing is not a chat mutation, so it must not create the session either.
+    expect(createSessionForFile).not.toHaveBeenCalled();
+    expect(setWorkBenchFiles).not.toHaveBeenCalled();
   });
 
   it('view on an overlay host mounts the viewer in the rail and never sets a layout', async () => {
@@ -332,8 +343,11 @@ describe('DataLakeExplorer chat-first surface', () => {
     expect(screen.getByTestId('mock-tree')).toBeInTheDocument();
     expect(screen.getByTestId('my-chat')).toBeInTheDocument();
     expect(screen.getByTestId('my-chat')).not.toBeVisible();
-    expect(setWorkBenchFiles).toHaveBeenCalledWith('sess-1', expect.any(Function));
-    expect(setSessionLayout).toHaveBeenCalledWith({ selectedArtifactId: 'file-123' });
+    expect(setWorkBenchFiles).not.toHaveBeenCalled();
+    expect(setSessionLayout).toHaveBeenCalledWith({
+      previewFile: expect.objectContaining({ id: 'file-123' }),
+      selectedArtifactId: 'file-123',
+    });
     expect(setSessionLayout).not.toHaveBeenCalledWith(
       expect.objectContaining({ layout: expect.anything() as unknown as string })
     );
@@ -352,10 +366,9 @@ describe('DataLakeExplorer chat-first surface', () => {
     expect(screen.queryByTestId('datalake-rail-viewer')).toBeNull();
     expect(screen.getByTestId('my-chat')).toBeVisible();
     expect(setSessionLayout).toHaveBeenCalledWith({ layout: 'dockRight' });
-    // Closing the viewer does not detach the file - View attaches it to the workbench as a side
-    // effect, and that attachment outlives the look (#1693: highlight tracks "in the prompt",
-    // not "currently open"), so the row must stay highlighted.
-    expect(screen.getByTestId('mock-tree')).toHaveAttribute('data-selected', 'file-123');
+    // View never attached anything, so there is no highlight to keep or clear (the highlight
+    // tracks workbench membership, #1693 - not viewer state).
+    expect(screen.getByTestId('mock-tree')).toHaveAttribute('data-selected', '');
   });
 
   it('any other layout departure closes the viewer without fighting the write (overlay host)', async () => {
@@ -374,20 +387,20 @@ describe('DataLakeExplorer chat-first surface', () => {
     );
   });
 
-  it('view toasts the attachment it performs, and only when it actually attaches', async () => {
-    // Opening a file attaches it by construction (the viewer's tabs come from the workbench),
-    // and that side effect of "just looking" must never be silent - this path also serves
-    // ?article= deep links, where there is no click at all.
+  it('view is silent - it attaches nothing, so there is nothing to toast', async () => {
     renderExplorer();
     fireEvent.click(screen.getByTestId('mock-view'));
-    await vi.waitFor(() => expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining('Added')));
+    await vi.waitFor(() => expect(setSessionLayout).toHaveBeenCalled());
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastInfo).not.toHaveBeenCalled();
   });
 
-  it('view does not re-toast a file already in the workbench', async () => {
+  it('view of an already-attached file opens the viewer without workbench writes', async () => {
     workBenchState.files = [{ id: 'file-123', fileName: 'x.pdf' }];
     renderExplorer();
     fireEvent.click(screen.getByTestId('mock-view'));
     await vi.waitFor(() => expect(setSessionLayout).toHaveBeenCalled());
+    expect(setWorkBenchFiles).not.toHaveBeenCalled();
     expect(toastSuccess).not.toHaveBeenCalled();
   });
 
@@ -400,8 +413,6 @@ describe('DataLakeExplorer chat-first surface', () => {
     fireEvent.click(screen.getByTestId('mock-navigate-back'));
 
     expect(screen.getByTestId('datalake-rail-viewer')).toBeInTheDocument();
-    // The highlight survives too, so returning to the category still shows which file is open.
-    expect(screen.getByTestId('mock-tree')).toHaveAttribute('data-selected', 'file-123');
   });
 
   it('browsing the tree never touches the layout on the embedded host', () => {
@@ -410,25 +421,29 @@ describe('DataLakeExplorer chat-first surface', () => {
     expect(setSessionLayout).not.toHaveBeenCalled();
   });
 
-  it('closing the viewer keeps the row highlighted on the embedded host too, since the file stays attached', async () => {
+  it('attach-driven highlight survives the viewer closing (embedded host)', async () => {
+    // The highlight is workbench membership (#1693): the explicit attach sets it, and viewer
+    // state (open, closed, never opened) has no bearing on it.
     renderExplorer();
-    fireEvent.click(screen.getByTestId('mock-view'));
+    fireEvent.click(screen.getByTestId('mock-attach'));
     // waitFor (not vi.waitFor) - see the useWorkBenchFiles mock comment above.
     await waitFor(() => expect(screen.getByTestId('mock-tree')).toHaveAttribute('data-selected', 'file-123'));
 
     act(() => useSessionLayoutStore.setState({ layout: 'hide' }));
 
-    // Same reasoning as the overlay-host case above: View's attach is not undone by closing the
-    // viewer, so the highlight (driven by workbench membership, not viewer-open state) persists.
     expect(screen.getByTestId('mock-tree')).toHaveAttribute('data-selected', 'file-123');
   });
 
-  it('deep-linked articleId opens it the same way View does', async () => {
+  it('deep-linked articleId opens it the same way View does - preview only, no attach', async () => {
     renderExplorer({ articleId: 'deep-1' });
     await vi.waitFor(() => {
-      expect(setWorkBenchFiles).toHaveBeenCalledWith('sess-1', expect.any(Function));
-      expect(setSessionLayout).toHaveBeenCalledWith({ layout: 'vertical', selectedArtifactId: 'deep-1' });
+      expect(setSessionLayout).toHaveBeenCalledWith({
+        layout: 'vertical',
+        previewFile: expect.objectContaining({ id: 'deep-1' }),
+        selectedArtifactId: 'deep-1',
+      });
     });
+    expect(setWorkBenchFiles).not.toHaveBeenCalled();
   });
 
   it('delete is offered only for a uniquely-resolved manageable lake', () => {

--- a/apps/client/app/components/datalake/DataLakeExplorer.tsx
+++ b/apps/client/app/components/datalake/DataLakeExplorer.tsx
@@ -98,9 +98,10 @@ interface DataLakeExplorerProps {
    */
   chatEmbedded?: boolean;
   /**
-   * Called when a file is ATTACHED or VIEWED with no active session (/new, where creation is
-   * deferred to the first message): must create + adopt the session and resolve its id so the
-   * file can land in a real workbench. Omitted (overlay) -> a guidance toast instead.
+   * Called when a file is ATTACHED with no active session (/new, where creation is deferred to
+   * the first message): must create + adopt the session and resolve its id so the file can land
+   * in a real workbench. Omitted (overlay) -> a guidance toast instead. View never needs this -
+   * previewing a file must not mint a session.
    *
    * Receives the file so the session can be created ALREADY HOLDING it (knowledgeIds): adoption
    * rehydrates the workbench from the session's knowledgeIds, so a file merely written into the
@@ -175,7 +176,7 @@ export default function DataLakeExplorer({
   // Guards double-clicks while createSessionForFile's POST is in flight - a second click
   // would otherwise mint a second session.
   const creatingSessionRef = useRef(false);
-  // The session both chat actions need. On /new creation is deferred to the first message, so
+  // The session the attach action needs. On /new creation is deferred to the first message, so
   // hosts that can mint the grounded session do it here; the rest get guidance. Returns null
   // when there is no session to be had (already explained to the user), so callers just bail.
   const ensureSessionId = useCallback(
@@ -228,10 +229,10 @@ export default function DataLakeExplorer({
     [ensureSessionId, addToWorkBench]
   );
 
-  // View opens the file in the KnowledgeViewer on both hosts. The viewer builds its tabs FROM
-  // the session workbench, so the file has to be attached for it to have a tab at all - and
-  // since that attachment is a side effect of "just looking", it is toasted so it never
-  // happens silently (this path also serves ?article= deep links, where there is no click).
+  // View opens the file in the KnowledgeViewer on both hosts - and ONLY that. It must not
+  // mutate the chat: no workbench attach (the explicit [+] action does that) and no session
+  // mint. The viewer shows the file through the transient `previewFile` slot (see
+  // useSessionLayout), which also serves ?article= deep links, where there is no click.
   //
   // How the viewer gets on screen differs, and only by necessity: with the chat embedded, the
   // chat's own SessionContainer renders it once the layout is `vertical`. External-chat hosts
@@ -240,21 +241,17 @@ export default function DataLakeExplorer({
   // surface restores it. So we set the selected artifact WITHOUT touching `layout` and mount
   // the viewer in our own rail (with its layout-switching controls hidden, for the same reason).
   const handleViewFile = useCallback(
-    async (file: IFabFileDocument) => {
-      const sessionId = await ensureSessionId(file);
-      if (!sessionId) return;
-      const added = addToWorkBench(sessionId, file);
-      if (added) toast.success(`Added "${file.fileName.replace(/\.[^/.]+$/, '')}" to the chat's files`);
+    (file: IFabFileDocument) => {
       if (chatEmbedded) {
-        setSessionLayout({ layout: 'vertical', selectedArtifactId: file.id });
+        setSessionLayout({ layout: 'vertical', previewFile: file, selectedArtifactId: file.id });
       } else {
         hostLayoutRef.current = useSessionLayout.getState().layout;
-        setSessionLayout({ selectedArtifactId: file.id });
+        setSessionLayout({ previewFile: file, selectedArtifactId: file.id });
         railViewerOpenRef.current = true;
         setRailViewerOpen(true);
       }
     },
-    [chatEmbedded, ensureSessionId, addToWorkBench, setRailViewerOpen]
+    [chatEmbedded, setRailViewerOpen]
   );
 
   // Delete gating: the lake list is only needed in chat mode (page mode has no row actions).
@@ -383,7 +380,7 @@ export default function DataLakeExplorer({
   useEffect(() => {
     if (chatMode && deepLinkTarget && openedDeepLinkRef.current !== deepLinkTarget.id) {
       openedDeepLinkRef.current = deepLinkTarget.id;
-      void handleViewFile(deepLinkTarget);
+      handleViewFile(deepLinkTarget);
     }
   }, [chatMode, deepLinkTarget, handleViewFile]);
 

--- a/apps/client/app/hooks/useSessionLayout.ts
+++ b/apps/client/app/hooks/useSessionLayout.ts
@@ -67,6 +67,11 @@ export interface PendingMessageFile {
 interface SessionLayoutControlState {
   layout: DefaultLayoutType;
   artifactData?: ArtifactData;
+  // Data-lake View: a file shown in the KnowledgeViewer WITHOUT being attached to the session
+  // workbench (viewing must not mutate the prompt - the explicit [+] action does that). The
+  // viewer renders it as one extra tab; replaced by the next View, cleared on session switch.
+  // Not persisted: a preview is a transient look, not session state.
+  previewFile: IFabFileDocument | null;
   recentArtifacts: ArtifactData[]; // Collection of recently clicked artifacts
   selectedArtifactId?: string;
   // Selected version number for viewing, keyed by artifact id. Per-artifact so a version
@@ -102,6 +107,7 @@ const useSessionLayout = create<SessionLayoutControlState>()(
   persist(
     _set => ({
       layout: 'hide',
+      previewFile: null,
       knowledgeViewerWidth: 50, // Default to 50% width
       recentArtifacts: [],
       maxRecentArtifacts: 10, // Default max cache size


### PR DESCRIPTION
## What

Opening a data-lake file (the View action, row click, or an `?article=` deep link) now ONLY opens it in the KnowledgeViewer. It no longer attaches the file to the session workbench, no longer toasts "Added ... to the chat's files", and no longer mints a session on `/new` just to have a workbench to attach into. The explicit [+] action remains the only way to attach. Applies to both hosts: the embedded chat (vertical split) and external-chat overlays (rail viewer).

## Why

Viewing was a chat mutation by construction: the KnowledgeViewer built its tabs solely from attached files (workbench / system / message files), so View had to attach the file for it to have a tab at all. "Just looking" at a lake file silently changed what the next prompt would carry - two actions where the user asked for one.

## How

- `useSessionLayout` gains a transient `previewFile` slot: the file being looked at without being attached. Not persisted, replaced by the next View, cleared on session switch (so a stale preview tab never surfaces inside a different notebook's viewer).
- `KnowledgeViewer` renders `previewFile` as one extra file tab, deduped against every attached list - attaching a previewed file never duplicates its tab.
- `DataLakeExplorer.handleViewFile` writes `previewFile` + `selectedArtifactId` (and, embedded only, `layout: 'vertical'`) instead of calling `ensureSessionId` + workbench attach. The deep-link path shares it.

Side effect worth noting: the tree row highlight tracks workbench membership (#1693), so View alone no longer highlights the row - only an actual attach does. That is the correct reading of "highlighted = in the prompt".

## Testing

- `DataLakeExplorer.test.tsx` rewritten for the new contract: view performs no workbench write, no toast, no session mint on `/new`; overlay host still gets the rail viewer with no `layout` write; deep link opens preview-only; attach-driven highlight survives viewer close.
- Focused run: all `app/components/datalake` suites - 25 files, 263 tests green.
- Verified in the dev app on the embedded-chat host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
