### PR TITLE
chore(llm): clamp search_knowledge_base max_results to the schema bound

### DIFF
--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.test.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.test.ts
@@ -34,7 +34,7 @@ vi.mock('../../../../apiKeyService', () => ({
 
 import { invalidateSettingsCache } from '@bike4mind/utils';
 import { RETRIEVED_CONTENT_BEGIN } from '../../../../dataLakeService/renderRetrievedContentBlock';
-import { knowledgeBaseSearchTool } from './index';
+import { knowledgeBaseSearchTool, KB_SEARCH_MAX_RESULTS, KB_SEARCH_DEFAULT_RESULTS } from './index';
 import { emptyEmbeddingMismatchReport } from '../../../../dataLakeService/embeddingMismatch';
 import type { ToolContext } from '../../base/types';
 
@@ -1402,5 +1402,258 @@ describe('search_knowledge_base clip order vs the untrusted-content defense (#16
     expect(out).toContain('SENTINEL-INSIDE-BUDGET');
     // And the defense is still applied to what survived: no forged separator at column 0.
     expect(out).not.toMatch(/^--- f$/m);
+  });
+});
+
+/**
+ * max_results clamp (#1757). The tool schema declares `minimum: 1, maximum: 10` and the
+ * description states the bound, but nothing in tool dispatch validates params - model arguments are
+ * JSON.parsed and handed to the handler as-is. Unclamped, an eager model asking for 100 got 100
+ * passages injected into the turn, at up to maxChunkChars each (#1661 raised that from 1200 to 3072
+ * by default, up to an 8000 ceiling - so the same request became 2.6x-6.7x more expensive).
+ *
+ * Asserted on the tool OUTPUT, never on an internal variable: the output is what costs tokens, and a
+ * test reading the clamped local would still pass if a consumer went back to the raw param.
+ */
+describe('search_knowledge_base max_results clamp (#1757)', () => {
+  const scan = {
+    truncated: false,
+    fileBudgetHit: false,
+    chunkBudgetHit: false,
+    filesMatching: 200,
+    filesScoped: 200,
+    filesScanned: 200,
+    chunksScanned: 400,
+    chunksSkippedDimensionMismatch: 0,
+    annFilesQueried: 0,
+    annHits: 0,
+    budgets: { maxFiles: 20000, maxChunks: 100000 },
+  };
+
+  /** Distinct fileName per hit so a numbered-block count cannot be inflated by dedup or repetition. */
+  const hits = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      chunkId: `c${i}`,
+      fileId: `f${i}`,
+      fileName: `Doc ${i}.pdf`,
+      fileTags: [],
+      chunkText: `passage body ${i}`,
+      score: 0.9 - i / 1000,
+    }));
+
+  /** Full logger surface: the settings cache calls debug, and the resolver would swallow the
+   *  resulting TypeError as a settings outage, passing the test for the wrong reason (#1661). */
+  const clampLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() } as never;
+
+  function semanticContext(overrides: Partial<ToolContext> = {}): ToolContext {
+    return makeContext({
+      logger: clampLogger,
+      retrievalFilter: undefined,
+      db: {
+        fabfiles: { search: vi.fn().mockResolvedValue({ data: [], total: 0 }), getAccessibleFiles: vi.fn() },
+        fabfilechunks: { findVectorsByFabFileIds: vi.fn() },
+        adminSettings: { getSettingsValue: vi.fn().mockResolvedValue('text-embedding-ada-002') },
+        apiKeys: {},
+        usageEvents: { record: vi.fn() },
+      } as never,
+      ...overrides,
+    });
+  }
+
+  /** Passages are emitted as "1. **Name** (relevance x.xx)", so the markers count the served set. */
+  const passageCount = (out: string) => (out.match(/^\d+\. \*\*Doc /gm) ?? []).length;
+
+  async function runWith(params: Record<string, unknown>, context = semanticContext()) {
+    const tool = knowledgeBaseSearchTool.implementation(context, undefined);
+    return (await tool.toolFn({ query: 'anything', ...params })) as string;
+  }
+
+  beforeEach(() => {
+    getDynamicDataLakeAccessMock.mockResolvedValue({
+      dataLakeTags: ['datalake:x'],
+      dataLakeTagPrefixes: [],
+      scopedTagPrefixes: [],
+    });
+    invalidateSettingsCache();
+  });
+
+  it('serves at most KB_SEARCH_MAX_RESULTS passages when the model asks for far more', async () => {
+    semanticDataLakeSearchMock.mockResolvedValue({
+      results: hits(100),
+      totalChunksSearched: 400,
+      filesInScope: 200,
+      scan,
+    });
+
+    const out = await runWith({ max_results: 100 });
+
+    expect(passageCount(out)).toBe(KB_SEARCH_MAX_RESULTS);
+    expect(out).toContain(`Found ${KB_SEARCH_MAX_RESULTS} relevant passage(s)`);
+    // Both sides of the boundary, against the RENDERED label: hits are named through
+    // prettyFileName, which strips the extension, so asserting on "Doc 10.pdf" would be a
+    // string the output can never contain and would pass at any served count.
+    expect(out).toContain('**Doc 9**');
+    expect(out).not.toContain('**Doc 10**');
+  });
+
+  it('is not a floor - an in-range request still gets exactly what it asked for', async () => {
+    semanticDataLakeSearchMock.mockResolvedValue({
+      results: hits(100),
+      totalChunksSearched: 400,
+      filesInScope: 200,
+      scan,
+    });
+
+    const out = await runWith({ max_results: 3 });
+
+    expect(passageCount(out)).toBe(3);
+    expect(out).toContain('Found 3 relevant passage(s)');
+  });
+
+  it('enforces the same number the schema advertises to the model', async () => {
+    semanticDataLakeSearchMock.mockResolvedValue({
+      results: hits(100),
+      totalChunksSearched: 400,
+      filesInScope: 200,
+      scan,
+    });
+    const tool = knowledgeBaseSearchTool.implementation(semanticContext(), undefined);
+    // ICompletionOptionTools' property type declares no minimum/maximum (the adapters pass the
+    // schema through verbatim), so reading the bound back needs a cast - narrow, and only here.
+    const schema = tool.toolSchema.parameters.properties.max_results as { description: string; maximum: number };
+
+    const out = await runWith({ max_results: KB_SEARCH_MAX_RESULTS + 1 });
+
+    // Both sides read the exported constant, so a future edit to either cannot leave the number the
+    // model is told and the number it is held to disagreeing - the failure #1661 was itself about.
+    expect(schema.maximum).toBe(KB_SEARCH_MAX_RESULTS);
+    expect(schema.description).toContain(String(KB_SEARCH_MAX_RESULTS));
+    expect(passageCount(out)).toBe(schema.maximum);
+  });
+
+  it('does not widen the candidate pool either - topK is sized from the clamped value', async () => {
+    semanticDataLakeSearchMock.mockResolvedValue({
+      results: hits(100),
+      totalChunksSearched: 400,
+      filesInScope: 200,
+      scan,
+    });
+
+    await runWith({ max_results: 100 });
+
+    // An inflated request pulled 100 chunks into embedding-similarity scoring, not just into the
+    // reply, so clamping only the slice would have left the scan cost untouched.
+    expect(semanticDataLakeSearchMock.mock.calls[0][0].topK).toBe(KB_SEARCH_MAX_RESULTS);
+  });
+
+  it('clamps the agent-scoped arm too - neither surface may serve past the bound', async () => {
+    fileScopedSemanticSearchMock.mockResolvedValue({
+      results: hits(100),
+      totalChunksSearched: 400,
+      filesInScope: 200,
+      scan,
+    });
+
+    const out = await runWith({ max_results: 100 }, semanticContext({ kbScope: { fileIds: ['f1'] } as never }));
+
+    expect(fileScopedSemanticSearchMock).toHaveBeenCalled();
+    expect(passageCount(out)).toBe(KB_SEARCH_MAX_RESULTS);
+  });
+
+  it('clamps the keyword fallback arm, which the semantic tests never reach', async () => {
+    // Semantic returns nothing, so the keyword path owns the reply. Its slice reads the same value.
+    semanticDataLakeSearchMock.mockResolvedValue(emptySemanticResult());
+    const files = Array.from({ length: 100 }, (_, i) => ({
+      id: `k${i}`,
+      fileName: `Keyword doc ${i}.pdf`,
+      tags: [],
+      vectorized: true,
+      mimeType: 'application/pdf',
+    }));
+    const context = semanticContext({
+      db: {
+        fabfiles: {
+          search: vi.fn().mockResolvedValue({ data: files, total: 100 }),
+          getAccessibleFiles: vi.fn(),
+        },
+        fabfilechunks: { findVectorsByFabFileIds: vi.fn() },
+        adminSettings: { getSettingsValue: vi.fn().mockResolvedValue('text-embedding-ada-002') },
+        apiKeys: {},
+        usageEvents: { record: vi.fn() },
+      } as never,
+    });
+
+    const out = await runWith({ max_results: 100 }, context);
+
+    expect(out).toContain(`Found ${KB_SEARCH_MAX_RESULTS} document(s)`);
+    expect((out.match(/^\d+\. \*\*Keyword doc /gm) ?? []).length).toBe(KB_SEARCH_MAX_RESULTS);
+  });
+
+  /**
+   * The low end. Every one of these fails SILENTLY without the floor: the model is told nothing and
+   * the reply simply contains less than it should, which is indistinguishable from a thin corpus.
+   */
+  describe('values below the advertised minimum', () => {
+    beforeEach(() => {
+      semanticDataLakeSearchMock.mockResolvedValue({
+        results: hits(100),
+        totalChunksSearched: 400,
+        filesInScope: 200,
+        scan,
+      });
+    });
+
+    it('serves one passage for 0, not zero passages', async () => {
+      expect(passageCount(await runWith({ max_results: 0 }))).toBe(1);
+    });
+
+    it('serves one passage for a negative, not a slice that drops the best-ranked hits', async () => {
+      // slice(0, -5) returns everything EXCEPT the last five, so unclamped this served 95 passages
+      // - the opposite of what a negative request could possibly mean.
+      expect(passageCount(await runWith({ max_results: -5 }))).toBe(1);
+    });
+
+    it('floors a fractional request rather than passing it to slice', async () => {
+      expect(passageCount(await runWith({ max_results: 4.7 }))).toBe(4);
+    });
+  });
+
+  /**
+   * Non-numeric input. The declared `number` is a claim about JSON we parsed, not a guarantee -
+   * models do emit stringified numbers, and NaN propagated into topK as well as into the slice.
+   */
+  describe('non-numeric input', () => {
+    beforeEach(() => {
+      semanticDataLakeSearchMock.mockResolvedValue({
+        results: hits(100),
+        totalChunksSearched: 400,
+        filesInScope: 200,
+        scan,
+      });
+    });
+
+    it('accepts a stringified number at its numeric value', async () => {
+      expect(passageCount(await runWith({ max_results: '8' }))).toBe(8);
+    });
+
+    it('clamps a stringified out-of-range number too', async () => {
+      expect(passageCount(await runWith({ max_results: '100' }))).toBe(KB_SEARCH_MAX_RESULTS);
+    });
+
+    it('falls back to the default for an unparseable value instead of serving nothing', async () => {
+      // Number('lots') is NaN: slice(0, NaN) is empty AND Math.max(NaN, 6) sent NaN to the engine.
+      const out = await runWith({ max_results: 'lots' });
+
+      expect(passageCount(out)).toBe(KB_SEARCH_DEFAULT_RESULTS);
+      expect(semanticDataLakeSearchMock.mock.calls[0][0].topK).toBe(6);
+    });
+
+    it('treats null as unset rather than as zero', async () => {
+      expect(passageCount(await runWith({ max_results: null }))).toBe(KB_SEARCH_DEFAULT_RESULTS);
+    });
+
+    it('keeps the documented default when the param is omitted entirely', async () => {
+      expect(passageCount(await runWith({}))).toBe(KB_SEARCH_DEFAULT_RESULTS);
+    });
   });
 });

--- a/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.ts
+++ b/b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.ts
@@ -416,9 +416,10 @@ async function trySemanticKbSearch(
     // No hits: the keyword arm answers, but it has to carry the notice with it.
     if (search.results.length === 0) return { output: null, skipNotice, datalakeTags: [], fileHits: [] };
 
-    // Honor the max_results contract: topK fetches a wider pool (≥6) so cosine ranking has
+    // Honor the max_results contract: topK fetches a wider pool (>=6) so cosine ranking has
     // candidates, but we return at most maxResults passages - parity with the keyword path's
-    // .slice(0, max_results) so the tool output can't exceed what the caller asked for.
+    // .slice(0, maxResults) so the tool output can't exceed what the caller asked for. The
+    // value arrives already clamped to KB_SEARCH_MAX_RESULTS; this arm must not re-derive it.
     const ranked = search.results.slice(0, maxResults);
 
     await emitSemanticCitables(context, ranked, 'the data lake', skipNotice);
@@ -501,6 +502,37 @@ async function tryScopedSemanticKbSearch(
     context.logger.warn('📚 [semantic] scoped KB search failed, falling back to scoped keyword:', err);
     return NO_SEMANTIC_RESULT;
   }
+}
+
+/**
+ * Bounds on `max_results`. The tool schema below and the clamp in the handler BOTH read these,
+ * so the number advertised to the model and the number enforced on it cannot drift apart - the
+ * same reason the serve budget is derived from the chunk policy rather than set beside it.
+ */
+export const KB_SEARCH_MAX_RESULTS = 10;
+export const KB_SEARCH_DEFAULT_RESULTS = 5;
+
+/**
+ * Narrow a model-supplied `max_results` to the bound the schema advertises.
+ *
+ * The schema's `minimum`/`maximum` are advisory: nothing in the chat path's tool dispatch
+ * validates params, so whatever the model emits arrives here as-is and must be made safe at the
+ * handler (the shape knowledgeBaseRetrieve, bashExecute and wolfram_alpha already use). The CLI's
+ * tool_search takes the other route for the same problem - see ToolSearchParamsSchema in
+ * packages/cli/src/tools/toolSearchTool.ts, which safeParses and REJECTS out-of-range rather than
+ * clamping; that stays out of the chat path, where a rejected search costs the turn. Both ends are clamped
+ * because every out-of-range value fails SILENTLY otherwise: 0 serves no passages while telling
+ * the model nothing, a negative slices off the best-ranked results, and a non-numeric poisons
+ * topK as NaN. Typed `unknown` because the declared `number` is only a claim about JSON we parsed.
+ *
+ * Unset takes the default rather than the floor, matching positiveIntOr in resolveSearchBudgets:
+ * `null` and `''` are the model declining to choose, not a request for one result.
+ */
+function clampMaxResults(raw: unknown): number {
+  if (raw === undefined || raw === null || raw === '') return KB_SEARCH_DEFAULT_RESULTS;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return KB_SEARCH_DEFAULT_RESULTS;
+  return Math.min(Math.max(Math.floor(n), 1), KB_SEARCH_MAX_RESULTS);
 }
 
 interface KnowledgeBaseSearchParams {
@@ -636,7 +668,10 @@ export const knowledgeBaseSearchTool: ToolDefinition = {
       toolFn: async value => {
         const params = value as KnowledgeBaseSearchParams;
         await context.onStart?.('search_knowledge_base', params);
-        const { query, tags, file_type, max_results = 5 } = params;
+        const { query, tags, file_type } = params;
+        // Every consumer below reads maxResults, never params.max_results: one clamp at the
+        // single entry point is what keeps a later edit from reopening the hole at one of them.
+        const maxResults = clampMaxResults(params.max_results);
 
         searchCallCount++;
         if (searchCallCount > MAX_SEARCHES) {
@@ -676,8 +711,8 @@ export const knowledgeBaseSearchTool: ToolDefinition = {
         // embedding deps aren't wired or nothing matches. The scoped arm never consults
         // owner-wide data-lake access.
         const semantic = scope
-          ? await tryScopedSemanticKbSearch(context, scope.fileIds, query, max_results)
-          : await trySemanticKbSearch(context, query, tags, max_results);
+          ? await tryScopedSemanticKbSearch(context, scope.fileIds, query, maxResults)
+          : await trySemanticKbSearch(context, query, tags, maxResults);
         lastSkipNotice = semantic.skipNotice;
         // Attach the retrieved lakes' scoped prompts (no-op for the agent-scoped arm, whose
         // datalakeTags are empty). The keyword fallback below returns metadata only (no grounded
@@ -793,7 +828,7 @@ export const knowledgeBaseSearchTool: ToolDefinition = {
             })
             .map((f: IFabFileDocument) => ({ f, score: scoreFile(f) }))
             .sort((a, b) => b.score - a.score || a.f.fileName.localeCompare(b.f.fileName))
-            .slice(0, max_results)
+            .slice(0, maxResults)
             .map(r => r.f);
 
           context.logger.log(
@@ -901,9 +936,9 @@ export const knowledgeBaseSearchTool: ToolDefinition = {
             },
             max_results: {
               type: 'number',
-              description: 'Maximum number of results to return (default: 5, max: 10)',
+              description: `Maximum number of results to return (default: ${KB_SEARCH_DEFAULT_RESULTS}, max: ${KB_SEARCH_MAX_RESULTS})`,
               minimum: 1,
-              maximum: 10,
+              maximum: KB_SEARCH_MAX_RESULTS,
             },
           },
           required: ['query'],


### PR DESCRIPTION
# Pull Request

Closes #1757

## Optional Screenshot/Video

This change has no UI surface, so the evidence is the tool's behavior: three captures from the
running app on the preview, and one at the handler boundary under test.


**1. The clamp engaging on the preview** - the model was told to send `max_results: 100`, and
reports back that it sent 100 and received 10, from a lake holding 14 documents.

<img width="1481" height="812" alt="T1757-preview-clamp-100-to-10" src="https://github.com/user-attachments/assets/5682d8a1-ce4e-4940-a2d6-f1f3a7a8f2fa" />

**2. No regression** - a broad query with no `max_results` returns the documented default of
5 sources, with a grounded answer and citation chips.

<img width="1481" height="812" alt="T1757-preview-grounded-answer-sources5" src="https://github.com/user-attachments/assets/c0e1eca3-8069-43db-a751-87cb65a1bfee" />

**3. The keyword-fallback arm** - the tool's raw return, pasted verbatim by the model. This is
the third `max_results` consumer, the one the issue's affected-surfaces list omitted.

<img width="1450" height="840" alt="T1757-preview-keyword-arm-raw-output" src="https://github.com/user-attachments/assets/5969ba93-2136-4ba0-a195-7a307fbf06b4" />


**4. Before/after at the handler boundary** - the same request run with the clamp removed and
then in place, with the test suite in each state.

<img width="3600" height="1468" alt="T1757-before-after-clamp" src="https://github.com/user-attachments/assets/16db09c6-4728-47e3-b940-49b8e95ab0ed" />

```
BEFORE - clamp removed (reproduces the state on main)
  model requested : max_results = 100
  passages served : 100
  clamp tests failing: 9

AFTER - clamp in place (this branch)
  model requested : max_results = 100
  passages served : 10 (KB_SEARCH_MAX_RESULTS)
  suite           : 79 passed, 0 failed

source file restored: clean
```

Both counts there are parsed from the tool's real returned string, not from an internal
variable, but the search engine is stubbed to return 100 hits - so the `100` is the stub's
hit count, and that image proves the clamp governs the tool's output at the handler boundary.
Image 1 is the live end-to-end case. See
[Reproducing the before/after](#reproducing-the-beforeafter) for the two steps behind image 4.

## Description

`search_knowledge_base` declared `max_results` with `minimum: 1, maximum: 10` and stated the
bound in the description the model reads, then trusted the model to obey it. Nothing enforced
it. Tool dispatch has no schema-validation step: each provider adapter `JSON.parse`s the
model's arguments and calls the handler with the result, with nothing in between - see
`openaiBackend.ts:1218` (`JSON.parse(toolCall.function.arguments)`) and `:1253`
(`await toolFn(parsedParams)`), typed `Record<string, unknown>` at `:1207`. The same shape
repeats in `anthropicBackend`, `kimiBackend`, `geminiBackend`, `bedrockBackend` and
`ollamaBackend`, so this is every provider path, not one. The value therefore flowed straight
into an unclamped `.slice()`, and a model asking for 100 got up to 100 passages injected into
the turn.

Not a correctness bug: no wrong answers, no crash, no data loss. It is cost exposure, and PR
#1731 widened it. Before that change every passage was clipped at a fixed 1200 characters.
It replaced that with a budget derived from the chunk policy, in
`b4m-core/common/src/constants/chunking.ts`:

- `DEFAULT_PASSAGE_TOKEN_TARGET = 512` (`:29`) x `CHARS_PER_TOKEN_SERVE_BOUND = 6` (`:58`)
  = **3072 characters** per passage at the default policy
- clamped to `SERVE_CHUNK_CHARS_FLOOR = 1200` (`:64`) and
  `SERVE_CHUNK_CHARS_CEILING = 8000` (`:77`)

Against the 1200 that floor preserves, the same out-of-range request now carries
**2.56x the per-passage character budget at the default policy, and up to 6.67x** where an
operator has raised the chunk size enough for the ceiling to bind. Those are ratios of the
character budget, not measured token spend - characters-to-tokens is not perfectly linear,
and no benchmark was run.

The bound already existed and was already advertised to the model. This applies it.

## Changes

- `KB_SEARCH_MAX_RESULTS` (10) and `KB_SEARCH_DEFAULT_RESULTS` (5) added as exported
  constants. The schema's `maximum`, the schema's description text, and the handler's clamp
  all read them, so the number the model is told and the number it is held to cannot drift
  apart - the same "derive, do not reconcile" reasoning #1731 applied to the serve cap.
- `clampMaxResults()` applied once at the handler's entry point rather than at each slice.
  `max_results` has three consumers - both semantic arms and the keyword fallback - all
  receiving the same value, so one expression is total coverage.
- Both ends of the range are clamped, not only the top. Every out-of-range value failed
  silently before: `0` served zero passages while telling the model nothing, a negative ran
  `slice(0, -5)` and dropped the best-ranked results off the end, and a non-numeric produced
  `NaN` that reached the search engine as `topK`. Unset (`undefined`/`null`/`''`) takes the
  documented default of 5 rather than the floor, matching `positiveIntOr` in
  `resolveSearchBudgets.ts`.
- `topK` narrows with it, since it is sized from the same value. An inflated request pulled
  extra chunks into embedding-similarity scoring, so clamping only the slice would have left
  the scan cost untouched.
- Clamping is silent. The model already receives fewer results than it asked for and the
  schema stated the bound. A log line here sits on the hot chat path - search runs up to
  `MAX_SEARCHES = 3` times per turn, per user - and would need the same once-per-value
  throttling #1731 gave its ceiling warn, which is disproportionate for this.

Diff is +297 / -9 across two files: the tool handler and its co-located test.

### Scope notes

The keyword-fallback consumer was not in the issue's "Affected surfaces" list. It surfaced
while verifying the anchors and is covered by the same single clamp. Smaller blast radius
than the semantic arms - metadata only, no passage content - but it read the same unchecked
value.

`websearch`'s `num_results` has the identical shape (schema `maximum: 10`, passed to the
provider unclamped) and is deliberately untouched here, per the issue. Its exposure is a
provider result count, not multi-kilobyte passages.

## Tests

14 new cases, all asserting on the tool's returned string rather than on an internal
variable - the output is what costs tokens, and a test reading the clamped local would still
pass if a consumer went back to the raw param.

- An out-of-range request serves exactly 10, with both sides of the boundary pinned against
  the rendered labels.
- An in-range request for 3 still returns 3, so the clamp did not become a floor.
- The schema's `maximum` and the enforced count are asserted to be the same constant.
- `topK` is sized from the clamped value, not the raw one.
- All three arms covered independently: unscoped semantic, agent-scoped semantic, and the
  keyword fallback the semantic tests never reach.
- Low-end and non-numeric input: `0`, `-5`, `4.7`, `'8'`, `'100'`, `'lots'`, `null`, and the
  param omitted entirely.

Knowledge-base search suite: 79 passed. Full `@bike4mind/services` suite: 4560 passed, 11
skipped (skips pre-existing on `main`).

### Reproducing the before/after

The suite was mutation-tested rather than trusted green. Two steps, no tooling beyond the
repo:

1. In `b4m-core/services/src/llm/tools/implementation/knowledgeBaseSearch/index.ts`, replace
   `const maxResults = clampMaxResults(params.max_results);`
   with `const maxResults = (params.max_results ?? 5) as number;`
2. `pnpm --filter @bike4mind/services test -- knowledgeBaseSearch`

**9 of the 14 fail**, and the boundary assertion reports the served count directly:
`AssertionError: expected 100 to be 10`. Restore the line and all 79 pass.

The four that survive that mutation (`max_results: 3`, `4.7`, `'8'`, and the param omitted)
are cases where the clamped and unclamped paths agree by construction; they are guard-rails,
not padding.

Separately, raising `KB_SEARCH_MAX_RESULTS` to 11 trips the boundary assertion while the
count assertion stays green - the count compares against the same constant, so on its own it
would track an off-by-one rather than catch it. That is why the boundary is pinned with
literal labels.

## Verification performed

Already run, on the preview, against a 14-document synthetic corpus loaded into a lake with
files confirmed vectorized (so the semantic arm was genuinely exercised, not the keyword
fallback alone).

- **The clamp engaging.** Told to send an out-of-range value directly, the model complied and
  reported: *"Exact `max_results` value I sent: 100 / Number of passages the tool actually
  returned: 10 / The tool silently capped the request at its documented schema maximum (10)
  rather than honoring the literal 100."* It then listed the 10 documents it received, from a
  lake holding 14. 100 requested, 14 available, 10 served - the #1757 defect reproduced and
  closed in the running app, and confirmation the clamp is silent as designed.
- **No regression.** A broad query with no `max_results` returned 5 sources - the documented
  default - with an accurate grounded answer and citation chips.
- **The keyword-fallback arm.** Asked to paste the tool's raw return verbatim, the model
  produced `Found 1 document(s) in your knowledge base:` followed by metadata and
  `*Use retrieve_knowledge_content ...*` - the keyword arm's exact output shape. That is the
  third `max_results` consumer, the one the issue's "Affected surfaces" list omitted, reached
  and returning through the clamped value.

Behavior belonging to #1661 (the truncation `NOTE:`) and #1659 (the delimiter block) was not
exercised, because both only appear when the semantic arm serves passage content that exceeds
the budget. **This PR does not touch either.** `formatSemanticResults`, the clip and the
delimiter block are outside the diff - confirmed with
`git diff origin/main...HEAD | grep -iE 'truncat|defang|RETRIEVED_CONTENT|maxChunkChars'`,
whose only hits are a comment and a test fixture. Steps 8-9 below are therefore optional
neighbouring-feature checks, not open items for this change.

## Guide for Testers

There is no UI control for `max_results` - the model chooses it. But the clamp is still
testable by hand, because nothing validates tool arguments: instruct the model to send a
specific out-of-range value and it will. **Step 10 is the step that tests this change.**
Steps 1-9 are a regression pass around it.

### Setup

1. Open the preview link and sign in.
2. Open a chat session with a data lake attached holding **more than 10 indexed documents** on
   a common topic. The count matters: with 10 or fewer, a clamped and an unclamped build
   return the same thing and step 10 proves nothing.
3. Confirm the documents are indexed - in Files Manager, a file's badge tooltip should read
   `Vectorized`. Do **not** try to enable Knowledge Base from the composer's Tools panel: that
   row appears greyed out and un-toggleable, which looks like the tool is unavailable. It is
   not. The tool runs under Smart tools regardless, because `search_knowledge_base` is in
   `ALWAYS_OFFERABLE` (`toolAvailability.ts:279`).

### Regression pass

4. Ask a broad question matching many documents, for example
   `Summarize everything in the knowledge base about onboarding`.
   **Expected:** a grounded answer, citation chips render, reply reads normally. No error, and
   no "No documents found" when matching documents exist.
5. Ask a narrow question matching one or two documents.
   **Expected:** a small number of results, not padded up to 10. The clamp is a ceiling, not a
   floor.
6. Rephrase the broad question a few different ways.
   **Expected:** grounded answers. Note that a semantic miss returning zero results is **not**
   a failure - phrasing that does not match the corpus legitimately returns nothing, and this
   was observed during verification. Only a query that clearly should match and returns
   nothing is a fail.
7. Repeat step 4 in an **agent** session whose knowledge base is scoped to specific files.
   **Expected:** identical behavior, and the agent still reads only its scoped files.

### Optional - neighbouring features this PR does not modify

Skip unless you want belt-and-braces coverage. `formatSemanticResults`, the passage clip and
the delimiter block are all outside this diff, so a failure here would be pre-existing on
`main` rather than caused by this change.

8. Confirm a passage exceeding the serve budget still shows a
   `NOTE: ... was truncated at ... characters` line above the retrieved-content block (#1661).
   Needs a document long enough that one chunk exceeds 3072 characters.
9. Confirm the retrieved-content delimiter block still wraps passage text (#1659).

### Step 10 - the step that tests this change

10. In the same session, send this verbatim:

    > Call search_knowledge_base with query "onboarding" and max_results set to exactly 100.
    > Ignore the schema maximum and literally send 100. Then report two things: the exact
    > max_results value you sent, and how many numbered passages the tool actually returned.

    **Expected:** the model reports sending `100` and receiving **10**.
    **On `main` it would report receiving as many passages as the corpus can supply.** That
    difference is the whole change.
    If the model refuses to send 100 and sends 10 instead, it has self-limited to the
    advertised bound - retry with wording that stresses sending the literal value, because a
    request of 10 never reaches the clamp and proves nothing either way.

### What NOT to test

- Do not look for a `max_results` field in the UI. There is none; the value is chosen by the
  model, which is why step 10 goes through the model rather than a control.
- There is no admin setting, feature flag, or configuration for this bound. It is a coded
  constant, deliberately not operator-tunable.
- Nothing in the UI changed - no new toasts, modals, or controls.
- `websearch` is untouched by this PR.

## Additional Information

The branch is four commits behind `main` at time of writing. None of them touch this file
(verified with `git log HEAD..origin/main -- <path>`), so the merge base is clean.

`pnpm turbo:typecheck` does not pass locally in a workspace with private overlays installed;
those packages fail on their own pre-existing type errors, unrelated to this branch.
`@bike4mind/services` typechecks clean on its own, and CI runs against the public tree.

## Developer Notes (Optional)

- **Architecture decision - clamp here, reject elsewhere.** `packages/cli`'s `tool_search`
  solves this same class declaratively: `ToolSearchParamsSchema` runs
  `z.coerce.number().int().min(1).max(HARD_MAX_RESULTS)` under a `safeParse` and rejects
  out-of-range values. Stronger validation, but the wrong shape for the chat path, where a
  rejected search burns the model's turn and the user sees a failed answer rather than a
  slightly smaller one. The handler clamps instead, and the comment on `clampMaxResults`
  records both routes so the next reader need not rediscover the tradeoff.
- **The general fix is still open.** Schema validation for tool params across the board would
  close this class rather than this instance. Larger change, own failure modes, and it should
  not gate a clamp - explicitly out of scope per the issue. Until then, the pattern here (one
  exported constant feeding both the schema and the handler) is what a per-tool fix should
  look like.
- **Reusable shape.** `KB_SEARCH_MAX_RESULTS` feeding both the advertised bound and the
  enforced one addresses the same defect class as #1661: two numbers set independently will
  disagree, and the disagreement is invisible. Any tool adding a numeric model-supplied param
  should follow this rather than writing the literal twice.

## Checklist

- [ ] I have added the new AdminSettings to Staging, prod and the hydration script (if applicable)
- [ ] I have made the UI/UX feel good (toasters, size, responsive, etc)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] If adding/modifying telemetry fields: updated [telemetry data classification](../docs-site/docs/security/telemetry-data-classification.md) doc
