### PR TITLE
fix(data-lake): membership follow-ups - request memo, dead Slack field, one predicate spelling

### DIFF
--- a/apps/client/pages/api/slack/events.ts
+++ b/apps/client/pages/api/slack/events.ts
@@ -50,7 +50,6 @@ import {
   isDataLakeCommand,
 } from '@bike4mind/slack';
 import { adminSettingsRepository } from '@bike4mind/database';
-import { normalizeId } from '@bike4mind/utils/normalizeId';
 import { runDataLakeSlackCommand } from '@server/slack/handleDataLakeCommand';
 import { buildSlackLakeIngestDeps } from '@server/slack/dataLakeIngestDeps';
 import { logEvent } from '@server/utils/analyticsLog';
@@ -720,7 +719,6 @@ const handler = baseApi({ auth: false }).post(async (req, res) => {
         id: user.id,
         isAdmin: user.isAdmin,
         tags: user.tags,
-        organizationId: normalizeId(user.organizationId),
         email: user.email,
         emailVerified: user.emailVerified,
       },

--- a/apps/client/server/dataLakes/requestMembership.test.ts
+++ b/apps/client/server/dataLakes/requestMembership.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getRequestMembershipOrgIds, type MembershipRequest } from './requestMembership';
+
+const { mockFindMembershipOrgIds } = vi.hoisted(() => ({ mockFindMembershipOrgIds: vi.fn() }));
+vi.mock('@bike4mind/database', () => ({
+  organizationRepository: { findMembershipOrgIds: mockFindMembershipOrgIds },
+}));
+
+describe('getRequestMembershipOrgIds', () => {
+  beforeEach(() => {
+    mockFindMembershipOrgIds.mockReset();
+  });
+
+  it('memoizes on the request object - two awaits, one repository call', async () => {
+    mockFindMembershipOrgIds.mockResolvedValue(['org-1']);
+    const req = { user: { id: 'u1' } } as unknown as MembershipRequest;
+    expect(await getRequestMembershipOrgIds(req)).toEqual(['org-1']);
+    expect(await getRequestMembershipOrgIds(req)).toEqual(['org-1']);
+    expect(mockFindMembershipOrgIds).toHaveBeenCalledTimes(1);
+    expect(mockFindMembershipOrgIds).toHaveBeenCalledWith('u1');
+  });
+
+  it('memoizes an empty set too (??= semantics, not ||=)', async () => {
+    mockFindMembershipOrgIds.mockResolvedValue([]);
+    const req = { user: { id: 'u1' } } as unknown as MembershipRequest;
+    expect(await getRequestMembershipOrgIds(req)).toEqual([]);
+    expect(await getRequestMembershipOrgIds(req)).toEqual([]);
+    expect(mockFindMembershipOrgIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed on a nullish user without touching the repository', async () => {
+    expect(await getRequestMembershipOrgIds({} as MembershipRequest)).toEqual([]);
+    expect(mockFindMembershipOrgIds).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/server/dataLakes/requestMembership.ts
+++ b/apps/client/server/dataLakes/requestMembership.ts
@@ -1,0 +1,26 @@
+import type { IUserDocument } from '@bike4mind/common';
+import { organizationRepository } from '@bike4mind/database';
+
+/**
+ * Minimal structural request shape for the membership memo - the same pattern (and the same
+ * cross-package-compilability reason) as `EntitlementRequest`; see the comment there.
+ */
+export interface MembershipRequest {
+  user?: IUserDocument;
+  membershipOrgIds?: string[];
+}
+
+/**
+ * The caller's authoritative org-membership set (owner + users[] ACL - see
+ * `organizationRepository.findMembershipOrgIds`, #1674), memoized per request the same way
+ * `getRequestEntitlements` memoizes entitlement keys: resolved lazily on first use, cached on
+ * `req.membershipOrgIds` so every later gate within the same request reuses the result.
+ *
+ * `??=` is correct here: an empty membership list is a valid, non-nullish result that must
+ * memoize (`||=` would re-query on every org-less user's request).
+ */
+export async function getRequestMembershipOrgIds(req: MembershipRequest): Promise<string[]> {
+  // Fail closed: a nullish user belongs to nothing.
+  if (!req.user) return [];
+  return (req.membershipOrgIds ??= await organizationRepository.findMembershipOrgIds(req.user.id));
+}

--- a/apps/client/server/dataLakes/requestMembership.ts
+++ b/apps/client/server/dataLakes/requestMembership.ts
@@ -18,6 +18,10 @@ export interface MembershipRequest {
  *
  * `??=` is correct here: an empty membership list is a valid, non-nullish result that must
  * memoize (`||=` would re-query on every org-less user's request).
+ *
+ * No request path resolves membership more than once today, so this memo is not currently
+ * saving a query - it exists as parity with `getRequestEntitlements` so that a second gate
+ * added later cannot silently double the membership lookup.
  */
 export async function getRequestMembershipOrgIds(req: MembershipRequest): Promise<string[]> {
   // Fail closed: a nullish user belongs to nothing.

--- a/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
+++ b/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
@@ -161,7 +161,10 @@ describe('resolveRetrievalLakeScope', () => {
     // organizationRepository so the resolver can derive membership itself - user.organizationId
     // (the selected-org pointer) is NOT forwarded (#1674).
     expect(mockGetDynamicDataLakeAccess).toHaveBeenCalledWith({
-      db: { dataLakes: dataLakeRepository, organizations: organizationRepository },
+      db: {
+        dataLakes: dataLakeRepository,
+        organizations: expect.objectContaining({ findMembershipOrgIds: expect.any(Function) }),
+      },
       user: { id: 'u1', tags: ['Opti'] },
       entitlementKeys: ['optihashi:pro'],
     });
@@ -211,7 +214,10 @@ describe('resolveRetrievalLakeScope', () => {
     await resolveRetrievalLakeScope(asReq({ id: 'u1', tags: null }));
 
     expect(mockGetDynamicDataLakeAccess).toHaveBeenCalledWith({
-      db: { dataLakes: dataLakeRepository, organizations: organizationRepository },
+      db: {
+        dataLakes: dataLakeRepository,
+        organizations: expect.objectContaining({ findMembershipOrgIds: expect.any(Function) }),
+      },
       user: { id: 'u1', tags: [] },
       entitlementKeys: [],
     });
@@ -226,9 +232,25 @@ describe('resolveRetrievalLakeScope', () => {
     await resolveRetrievalLakeScope(asReq({ id: 'u1', tags: ['Opti'], organizationId: populatedOrg }));
 
     expect(mockGetDynamicDataLakeAccess).toHaveBeenCalledWith({
-      db: { dataLakes: dataLakeRepository, organizations: organizationRepository },
+      db: {
+        dataLakes: dataLakeRepository,
+        organizations: expect.objectContaining({ findMembershipOrgIds: expect.any(Function) }),
+      },
       user: { id: 'u1', tags: ['Opti'] },
       entitlementKeys: [],
     });
+  });
+
+  it('serves the resolver membership lookup from the request memo (one repository call per request)', async () => {
+    const req = asReq({ id: 'u1', tags: ['Opti'] }) as EntitlementRequest & { membershipOrgIds?: string[] };
+    // The repository mock is the __marker stub; give it a spy so a fall-through call is visible.
+    organizationRepository.findMembershipOrgIds = vi.fn().mockResolvedValue([]);
+
+    await resolveRetrievalLakeScope(req);
+    const { db } = mockGetDynamicDataLakeAccess.mock.calls.at(-1)![0];
+
+    req.membershipOrgIds = ['memoized-org'];
+    await expect(db.organizations.findMembershipOrgIds(req.user!.id)).resolves.toEqual(['memoized-org']);
+    expect(organizationRepository.findMembershipOrgIds).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
+++ b/apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { DataLakeConfig } from '@bike4mind/common';
 
 // Hoisted so the vi.mock factories (hoisted above imports) can reference them.
@@ -150,6 +150,12 @@ describe('resolveRetrievalLakeScope', () => {
     mockGetDynamicDataLakeAccess.mockResolvedValue(scopeOf());
   });
 
+  afterEach(() => {
+    // A couple of tests below assign a spy directly onto the mocked module singleton (it has no
+    // findMembershipOrgIds by default); strip it so a later test never inherits a leftover spy.
+    delete (organizationRepository as unknown as { findMembershipOrgIds?: unknown }).findMembershipOrgIds;
+  });
+
   it('calls the shared resolver with exactly the context the chat tool passes', async () => {
     mockGetRequestEntitlements.mockResolvedValue(['optihashi:pro']);
 
@@ -241,7 +247,7 @@ describe('resolveRetrievalLakeScope', () => {
     });
   });
 
-  it('serves the resolver membership lookup from the request memo (one repository call per request)', async () => {
+  it('serves the resolver membership lookup from the request memo for the requesting user', async () => {
     const req = asReq({ id: 'u1', tags: ['Opti'] }) as EntitlementRequest & { membershipOrgIds?: string[] };
     // The repository mock is the __marker stub; give it a spy so a fall-through call is visible.
     organizationRepository.findMembershipOrgIds = vi.fn().mockResolvedValue([]);
@@ -252,5 +258,20 @@ describe('resolveRetrievalLakeScope', () => {
     req.membershipOrgIds = ['memoized-org'];
     await expect(db.organizations.findMembershipOrgIds(req.user!.id)).resolves.toEqual(['memoized-org']);
     expect(organizationRepository.findMembershipOrgIds).not.toHaveBeenCalled();
+  });
+
+  it('does not serve another user id from the request memo (cross-user leak guard)', async () => {
+    const req = asReq({ id: 'u1', tags: ['Opti'] }) as EntitlementRequest & { membershipOrgIds?: string[] };
+    organizationRepository.findMembershipOrgIds = vi.fn().mockResolvedValue(['other-org']);
+
+    await resolveRetrievalLakeScope(req);
+    const { db } = mockGetDynamicDataLakeAccess.mock.calls.at(-1)![0];
+
+    // The memo was seeded for 'u1'; a lookup for a different user must still hit the repository
+    // rather than fall through to the memoized value - collapsing this to "always use the memo"
+    // would leak one user's org membership onto another's request.
+    req.membershipOrgIds = ['memoized-org'];
+    await expect(db.organizations.findMembershipOrgIds('other-user')).resolves.toEqual(['other-org']);
+    expect(organizationRepository.findMembershipOrgIds).toHaveBeenCalledWith('other-user');
   });
 });

--- a/apps/client/server/dataLakes/resolveRetrievalLakeScope.ts
+++ b/apps/client/server/dataLakes/resolveRetrievalLakeScope.ts
@@ -16,9 +16,10 @@ import { dataLakeService } from '@bike4mind/services';
 import { dataLakeRepository, organizationRepository } from '@bike4mind/database';
 import { getRequestEntitlements, type EntitlementRequest } from '@server/entitlements';
 import type { Logger } from '@bike4mind/observability';
+import { getRequestMembershipOrgIds, type MembershipRequest } from './requestMembership';
 
 /** EntitlementRequest carries no logger; the routes calling this are Express requests that do. */
-type RetrievalScopeRequest = EntitlementRequest & { logger?: Logger };
+type RetrievalScopeRequest = EntitlementRequest & MembershipRequest & { logger?: Logger };
 
 /** The tag/prefix triple `semanticDataLakeSearch` scopes on. Mirrors the core resolver's return. */
 export type RetrievalLakeScope = Awaited<ReturnType<typeof dataLakeService.getDynamicDataLakeAccess>>;
@@ -92,7 +93,17 @@ export async function resolveRetrievalLakeScope(req: RetrievalScopeRequest): Pro
   // INSIDE the shared resolver from user.id, not from user.organizationId (the selected-org
   // display pointer) - see DataLakeAccessContext (#1674).
   const scope = await dataLakeService.getDynamicDataLakeAccess({
-    db: { dataLakes: dataLakeRepository, organizations: organizationRepository },
+    db: {
+      dataLakes: dataLakeRepository,
+      // The resolver derives membership itself from user.id; serve that lookup from the
+      // request memo so one request resolves membership once across toAccessContext and this
+      // scope. Any other id (defense-in-depth - the resolver only asks about user.id today)
+      // falls through to the repository.
+      organizations: {
+        findMembershipOrgIds: (uid: string) =>
+          uid === user.id ? getRequestMembershipOrgIds(req) : organizationRepository.findMembershipOrgIds(uid),
+      },
+    },
     user: {
       id: user.id,
       tags: user.tags ?? [],

--- a/apps/client/server/dataLakes/toAccessContext.ts
+++ b/apps/client/server/dataLakes/toAccessContext.ts
@@ -1,6 +1,7 @@
 import type { AccessContext } from '@bike4mind/common';
 import { organizationRepository } from '@bike4mind/database';
 import { getRequestEntitlements, type EntitlementRequest } from '@server/entitlements';
+import { getRequestMembershipOrgIds } from './requestMembership';
 
 /**
  * Builds the `AccessContext` for the data-lake management gates
@@ -34,11 +35,12 @@ export async function toAccessContext(req: EntitlementRequest): Promise<AccessCo
     userId: user.id,
     isAdmin,
     userTags: user.tags ?? [],
-    // Authoritative membership set (owner + users[] ACL), resolved per request - NOT
-    // user.organizationId, the selected-org display preference (#1674). Resolved for admins
-    // too: the fallback-lake org prerequisite and findBySlug's own-org preference apply to
-    // admins as well, unlike the entitlement gates below.
-    organizationIds: await organizationRepository.findMembershipOrgIds(user.id),
+    // Authoritative membership set (owner + users[] ACL), memoized per request by
+    // getRequestMembershipOrgIds - NOT user.organizationId, the selected-org display
+    // preference (#1674). Resolved for admins too: the fallback-lake org prerequisite and
+    // findBySlug's own-org preference apply to admins as well, unlike the entitlement gates
+    // below.
+    organizationIds: await getRequestMembershipOrgIds(req),
     entitlementKeys: isAdmin ? [] : await getRequestEntitlements(req),
     administeredOrgIds: isAdmin ? [] : await organizationRepository.findIdsWithAdminRights(user.id),
   };

--- a/apps/client/server/slack/dataLakeFileIngest.test.ts
+++ b/apps/client/server/slack/dataLakeFileIngest.test.ts
@@ -19,7 +19,6 @@ const actor = {
   id: 'user-1',
   isAdmin: false,
   tags: ['beta'],
-  organizationId: 'org-1',
   email: 'a@example.com',
   emailVerified: true,
 };

--- a/apps/client/server/slack/dataLakeIngestAuthz.ts
+++ b/apps/client/server/slack/dataLakeIngestAuthz.ts
@@ -27,7 +27,6 @@ export interface SlackIngestActor {
   id: string;
   isAdmin?: boolean;
   tags?: string[] | null;
-  organizationId?: string;
   email?: string | null;
   emailVerified?: boolean | null;
 }

--- a/apps/client/server/slack/dataLakeLinkIngest.test.ts
+++ b/apps/client/server/slack/dataLakeLinkIngest.test.ts
@@ -19,7 +19,6 @@ const actor = {
   id: 'user-1',
   isAdmin: false,
   tags: ['beta'],
-  organizationId: 'org-1',
   email: 'a@example.com',
   emailVerified: true,
 };

--- a/apps/client/server/slack/handleDataLakeCommand.test.ts
+++ b/apps/client/server/slack/handleDataLakeCommand.test.ts
@@ -20,7 +20,7 @@ vi.mock('./dataLakeLinkIngest', () => ({ ingestSlackLinkIntoLake }));
 
 import { handleDataLakeCommand, runDataLakeSlackCommand, formatIngestOutcome } from './handleDataLakeCommand';
 
-const actor = { id: 'u1', isAdmin: false, organizationId: 'org1' };
+const actor = { id: 'u1', isAdmin: false };
 const ingestDeps = { dataLakes: {} } as never;
 
 const baseParams = (overrides: Record<string, unknown> = {}) => ({

--- a/docs/superpowers/plans/2026-08-14-membership-followups.md
+++ b/docs/superpowers/plans/2026-08-14-membership-followups.md
@@ -1,0 +1,344 @@
+# Membership Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the three follow-ups promised in PR #1762: request-scoped memoization of the membership set, deletion of the dead `SlackIngestActor.organizationId`, and one shared spelling for the users[]-ACL membership predicate.
+
+**Architecture:** Three independent tasks. Task 1 adds a `getRequestMembershipOrgIds` helper (the `req.entitlements ??=` pattern) and wires it into the two client-server call sites. Task 2 is a mechanical field deletion. Task 3 extracts a `MEMBER_PERMISSIONS` constant in `OrganizationModel` and aligns `search()` to it (deliberate behavior change for write-only members).
+
+**Tech Stack:** TypeScript, vitest (client: mocked `@bike4mind/database`; database: real Mongo via `setupMongoTest()`/`createMongoServer()`).
+
+## Global Constraints
+
+- ASCII only on every added `.ts` line (CI-gated).
+- Node 24 for every command: prefix with `PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH"`.
+- Client tests: NEVER `pnpm --filter @bike4mind/client test -- run <path>` (full 20-min suite). Only `pnpm --filter @bike4mind/client exec vitest run <path>`.
+- Database tests must use the shared Mongo test utils (`setupMongoTest()` already wraps `createMongoServer()`), never `MongoMemoryServer.create()`.
+- `??=` (never `||=`) for the memo: an empty list is a valid, non-nullish result that must memoize.
+- Out of scope (do not touch): `findIdsWithAdminRights`, `resolveActiveOrg`, the shareable/groups arms, ToolContext-level caching, the Slack ingest deps.
+- Commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Request-scoped membership memo + two call sites
+
+**Files:**
+- Create: `apps/client/server/dataLakes/requestMembership.ts`
+- Create (test): `apps/client/server/dataLakes/requestMembership.test.ts`
+- Modify: `apps/client/server/dataLakes/toAccessContext.ts` (the `organizationIds:` line, ~41)
+- Modify: `apps/client/server/dataLakes/resolveRetrievalLakeScope.ts` (the `db:` adapter, ~95)
+- Modify (test): `apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts` (assertions that pin `organizations: organizationRepository` verbatim)
+
+**Interfaces:**
+- Consumes: `organizationRepository.findMembershipOrgIds(userId: string): Promise<string[]>` (exists).
+- Produces: `getRequestMembershipOrgIds(req: MembershipRequest): Promise<string[]>` and `interface MembershipRequest { user?: IUserDocument; membershipOrgIds?: string[] }` — no later task consumes them.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/client/server/dataLakes/requestMembership.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getRequestMembershipOrgIds, type MembershipRequest } from './requestMembership';
+
+const { mockFindMembershipOrgIds } = vi.hoisted(() => ({ mockFindMembershipOrgIds: vi.fn() }));
+vi.mock('@bike4mind/database', () => ({
+  organizationRepository: { findMembershipOrgIds: mockFindMembershipOrgIds },
+}));
+
+describe('getRequestMembershipOrgIds', () => {
+  beforeEach(() => {
+    mockFindMembershipOrgIds.mockReset();
+  });
+
+  it('memoizes on the request object - two awaits, one repository call', async () => {
+    mockFindMembershipOrgIds.mockResolvedValue(['org-1']);
+    const req = { user: { id: 'u1' } } as unknown as MembershipRequest;
+    expect(await getRequestMembershipOrgIds(req)).toEqual(['org-1']);
+    expect(await getRequestMembershipOrgIds(req)).toEqual(['org-1']);
+    expect(mockFindMembershipOrgIds).toHaveBeenCalledTimes(1);
+    expect(mockFindMembershipOrgIds).toHaveBeenCalledWith('u1');
+  });
+
+  it('memoizes an empty set too (??= semantics, not ||=)', async () => {
+    mockFindMembershipOrgIds.mockResolvedValue([]);
+    const req = { user: { id: 'u1' } } as unknown as MembershipRequest;
+    expect(await getRequestMembershipOrgIds(req)).toEqual([]);
+    expect(await getRequestMembershipOrgIds(req)).toEqual([]);
+    expect(mockFindMembershipOrgIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed on a nullish user without touching the repository', async () => {
+    expect(await getRequestMembershipOrgIds({} as MembershipRequest)).toEqual([]);
+    expect(mockFindMembershipOrgIds).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails on the missing module**
+
+Run: `PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" pnpm --filter @bike4mind/client exec vitest run server/dataLakes/requestMembership.test.ts`
+Expected: FAIL - cannot resolve `./requestMembership`.
+
+- [ ] **Step 3: Create `apps/client/server/dataLakes/requestMembership.ts`**
+
+```ts
+import type { IUserDocument } from '@bike4mind/common';
+import { organizationRepository } from '@bike4mind/database';
+
+/**
+ * Minimal structural request shape for the membership memo - the same pattern (and the same
+ * cross-package-compilability reason) as `EntitlementRequest`; see the comment there.
+ */
+export interface MembershipRequest {
+  user?: IUserDocument;
+  membershipOrgIds?: string[];
+}
+
+/**
+ * The caller's authoritative org-membership set (owner + users[] ACL - see
+ * `organizationRepository.findMembershipOrgIds`, #1674), memoized per request the same way
+ * `getRequestEntitlements` memoizes entitlement keys: resolved lazily on first use, cached on
+ * `req.membershipOrgIds` so every later gate within the same request reuses the result.
+ *
+ * `??=` is correct here: an empty membership list is a valid, non-nullish result that must
+ * memoize (`||=` would re-query on every org-less user's request).
+ */
+export async function getRequestMembershipOrgIds(req: MembershipRequest): Promise<string[]> {
+  // Fail closed: a nullish user belongs to nothing.
+  if (!req.user) return [];
+  return (req.membershipOrgIds ??= await organizationRepository.findMembershipOrgIds(req.user.id));
+}
+```
+
+- [ ] **Step 4: Run the test file, verify all 3 pass**
+
+Same command as Step 2. Expected: PASS (3/3).
+
+- [ ] **Step 5: Wire into `toAccessContext.ts`**
+
+Replace (current text at ~lines 37-41):
+
+```ts
+    // Authoritative membership set (owner + users[] ACL), resolved per request - NOT
+    // user.organizationId, the selected-org display preference (#1674). Resolved for admins
+    // too: the fallback-lake org prerequisite and findBySlug's own-org preference apply to
+    // admins as well, unlike the entitlement gates below.
+    organizationIds: await organizationRepository.findMembershipOrgIds(user.id),
+```
+
+with:
+
+```ts
+    // Authoritative membership set (owner + users[] ACL), memoized per request by
+    // getRequestMembershipOrgIds - NOT user.organizationId, the selected-org display
+    // preference (#1674). Resolved for admins too: the fallback-lake org prerequisite and
+    // findBySlug's own-org preference apply to admins as well, unlike the entitlement gates
+    // below.
+    organizationIds: await getRequestMembershipOrgIds(req),
+```
+
+Add the import `import { getRequestMembershipOrgIds } from './requestMembership';`. Keep the `organizationRepository` import - `administeredOrgIds` still uses it. If the current text differs from the block above, stop and report BLOCKED.
+
+- [ ] **Step 6: Run the toAccessContext tests (mock already routes through `@bike4mind/database`)**
+
+Run: `PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" pnpm --filter @bike4mind/client exec vitest run server/dataLakes/toAccessContext.test.ts`
+Expected: PASS unchanged - the helper calls the same mocked `organizationRepository.findMembershipOrgIds`. If a test constructs one `req` and asserts two repository calls, update it to expect the memoized single call and note that in the report.
+
+- [ ] **Step 7: Wire the wrapper into `resolveRetrievalLakeScope.ts`**
+
+Replace:
+
+```ts
+  const scope = await dataLakeService.getDynamicDataLakeAccess({
+    db: { dataLakes: dataLakeRepository, organizations: organizationRepository },
+```
+
+with:
+
+```ts
+  const scope = await dataLakeService.getDynamicDataLakeAccess({
+    db: {
+      dataLakes: dataLakeRepository,
+      // The resolver derives membership itself from user.id; serve that lookup from the
+      // request memo so one request resolves membership once across toAccessContext and this
+      // scope. Any other id (defense-in-depth - the resolver only asks about user.id today)
+      // falls through to the repository.
+      organizations: {
+        findMembershipOrgIds: (uid: string) =>
+          uid === user.id
+            ? getRequestMembershipOrgIds(req)
+            : organizationRepository.findMembershipOrgIds(uid),
+      },
+    },
+```
+
+Add the import `import { getRequestMembershipOrgIds } from './requestMembership';`. `RetrievalScopeRequest` already extends `EntitlementRequest`, which is structurally assignable to `MembershipRequest`; if TypeScript rejects the `req` argument, intersect the local type (`type RetrievalScopeRequest = EntitlementRequest & MembershipRequest & { logger?: Logger }`) rather than casting.
+
+- [ ] **Step 8: Update `resolveRetrievalLakeScope.test.ts` and add the memo-sharing assertion**
+
+The existing assertions that pin the adapter verbatim (`db: { dataLakes: dataLakeRepository, organizations: organizationRepository }` at ~164, ~214, ~229) now fail. For each, replace the `organizations:` expectation with `organizations: expect.objectContaining({ findMembershipOrgIds: expect.any(Function) })` (keep the `dataLakes: dataLakeRepository` part).
+
+Add one behavioral test in the same file (adapt the file's existing mock names for `getDynamicDataLakeAccess` and its captured call args; the repository mock object is the `__marker` stub, so give it a `findMembershipOrgIds` vi.fn for this test):
+
+```ts
+  it('serves the resolver membership lookup from the request memo (one repository call per request)', async () => {
+    const req = makeReq(); // the file's existing request factory/shape for a plain user
+    await resolveRetrievalLakeScope(req);
+    const { db } = mockGetDynamicDataLakeAccess.mock.calls.at(-1)![0];
+    req.membershipOrgIds = ['memoized-org'];
+    await expect(db.organizations.findMembershipOrgIds(req.user!.id)).resolves.toEqual(['memoized-org']);
+  });
+```
+
+(The exact factory/mock names differ in the file - read it first and keep its conventions. The assertion that matters: the captured wrapper, called with the requesting user's id, returns `req`'s memoized set without hitting the repository.)
+
+- [ ] **Step 9: Run both scope test files**
+
+Run: `PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" pnpm --filter @bike4mind/client exec vitest run server/dataLakes/resolveRetrievalLakeScope.test.ts server/dataLakes/requestMembership.test.ts server/dataLakes/toAccessContext.test.ts`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/client/server/dataLakes/requestMembership.ts apps/client/server/dataLakes/requestMembership.test.ts apps/client/server/dataLakes/toAccessContext.ts apps/client/server/dataLakes/resolveRetrievalLakeScope.ts apps/client/server/dataLakes/resolveRetrievalLakeScope.test.ts
+git commit -m "perf(client): memoize the membership org set per request
+
+One HTTP request could resolve findMembershipOrgIds several times
+(toAccessContext per gate, plus the retrieval-scope resolver's internal
+lookup). Mirror the getRequestEntitlements pattern: lazy, cached on the
+request object, empty list memoizes too.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 2: Delete the dead `SlackIngestActor.organizationId`
+
+**Files:**
+- Modify: `apps/client/server/slack/dataLakeIngestAuthz.ts` (~line 30)
+- Modify (fixtures): `apps/client/server/slack/handleDataLakeCommand.test.ts:23`, `apps/client/server/slack/dataLakeFileIngest.test.ts:22`, `apps/client/server/slack/dataLakeLinkIngest.test.ts:22`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: nothing.
+
+Since #1674 removed the selected-org pointer from authorization, no production code reads this field (verified by grep; the compiler re-verifies below). Only the three test fixtures set it.
+
+- [ ] **Step 1: Remove the field**
+
+In `dataLakeIngestAuthz.ts`, delete the line `  organizationId?: string;` from `SlackIngestActor` (between `tags?: string[] | null;` and `email?: string | null;`).
+
+- [ ] **Step 2: Remove the fixture usages**
+
+- `handleDataLakeCommand.test.ts:23`: `const actor = { id: 'u1', isAdmin: false, organizationId: 'org1' };` -> `const actor = { id: 'u1', isAdmin: false };`
+- `dataLakeFileIngest.test.ts:22`: delete the `  organizationId: 'org-1',` line from the actor fixture.
+- `dataLakeLinkIngest.test.ts:22`: delete the `  organizationId: 'org-1',` line from the actor fixture.
+
+Do NOT touch `dataLakeFileIngest.test.ts:237-240` (asserts `params.organizationId` is undefined on the CREATED FILE - a different object, still meaningful) or the comment at `dataLakeLinkIngest.test.ts:185`.
+
+- [ ] **Step 3: Typecheck the client - the compiler enumerates any reader the grep missed**
+
+Run: `PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" pnpm --filter @bike4mind/client typecheck`
+Expected: exit 0. If a production reader errors, STOP and report BLOCKED with the site.
+
+- [ ] **Step 4: Run the three slack test files**
+
+Run: `PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" pnpm --filter @bike4mind/client exec vitest run server/slack/handleDataLakeCommand.test.ts server/slack/dataLakeFileIngest.test.ts server/slack/dataLakeLinkIngest.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/client/server/slack/dataLakeIngestAuthz.ts apps/client/server/slack/handleDataLakeCommand.test.ts apps/client/server/slack/dataLakeFileIngest.test.ts apps/client/server/slack/dataLakeLinkIngest.test.ts
+git commit -m "chore(client): drop the dead SlackIngestActor.organizationId
+
+Nothing has read it since authorization switched to the membership set;
+only test fixtures still set it.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 3: One membership-predicate spelling in `OrganizationModel`
+
+**Files:**
+- Modify: `packages/database/src/models/infra/admin/OrganizationModel.ts` (lines ~341 and ~407, plus a module constant)
+- Test: `packages/database/src/models/infra/admin/OrganizationModel.membershipOrgIds.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: module-private `MEMBER_PERMISSIONS` (not exported).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `OrganizationModel.membershipOrgIds.test.ts` (reuse the file's existing `makeOrg` helper and `setupMongoTest()` import; add a second `describe` block):
+
+```ts
+describe('OrganizationRepository.search - users[] ACL membership arm', () => {
+  setupMongoTest();
+
+  const searchByUser = async (userId: string) =>
+    (
+      await organizationRepository.search('', { userId }, { page: 1, limit: 10 }, { field: 'name', direction: 'asc' })
+    ).data.map(d => String(d._id));
+
+  it('a write-only ACL member finds the org (same predicate as findMembershipOrgIds)', async () => {
+    const org = await makeOrg('write-only-search', { users: [{ userId: 'u1', permissions: ['write'] }] });
+    expect(await searchByUser('u1')).toEqual([String(org._id)]);
+    // The read-side set must agree - the whole point of the shared constant.
+    expect(await organizationRepository.findMembershipOrgIds('u1')).toEqual([String(org._id)]);
+  });
+
+  it('a user with no ACL entry and no ownership matches nothing', async () => {
+    await makeOrg('unrelated', { users: [{ userId: 'someone', permissions: ['read'] }] });
+    expect(await searchByUser('u1')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify the write-only case fails**
+
+Run: `PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" pnpm --filter @bike4mind/database exec vitest run src/models/infra/admin/OrganizationModel.membershipOrgIds.test.ts`
+Expected: the write-only test FAILS on the `search` assertion (current predicate is `$in: ['read']`); the no-entry test passes.
+
+- [ ] **Step 3: Extract the constant and use it at both sites**
+
+In `OrganizationModel.ts`, above the schema definition add:
+
+```ts
+// The users[] ACL permission values that constitute org membership. 'write' implies membership
+// even when 'read' was never explicitly granted - the #1674 read-side set (findMembershipOrgIds)
+// already treats it so, and search() must agree or a write-only member can reach an org they
+// cannot find. Must stay the union used by BOTH call sites below.
+const MEMBER_PERMISSIONS = ['read', 'write'];
+```
+
+Then:
+- line ~341 (`search()`): `permissions: { $in: ['read'] }` -> `permissions: { $in: MEMBER_PERMISSIONS }`
+- line ~407 (`findMembershipOrgIds()`): `permissions: { $in: ['read', 'write'] }` -> `permissions: { $in: MEMBER_PERMISSIONS }`
+
+No other `permissions` site changes (line ~135 is a share-permission check, not membership).
+
+- [ ] **Step 4: Run the full test file, verify all pass**
+
+Same command as Step 2. Expected: PASS (existing membership tests + both new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/database/src/models/infra/admin/OrganizationModel.ts packages/database/src/models/infra/admin/OrganizationModel.membershipOrgIds.test.ts
+git commit -m "fix(database): one spelling for the users[] membership predicate
+
+search() said ['read'] while findMembershipOrgIds said ['read','write'],
+so a write-only member passed every read gate yet could not find the org
+in search. Shared MEMBER_PERMISSIONS constant; search now includes
+write-only members (deliberate).
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## After all tasks (orchestrator)
+
+Full `pnpm turbo:typecheck` plus the touched suites before push. PR title suggestion:
+`fix(data-lake): membership follow-ups - request memo, dead Slack field, one predicate spelling`.

--- a/docs/superpowers/plans/2026-08-14-membership-followups.md
+++ b/docs/superpowers/plans/2026-08-14-membership-followups.md
@@ -31,7 +31,7 @@
 
 **Interfaces:**
 - Consumes: `organizationRepository.findMembershipOrgIds(userId: string): Promise<string[]>` (exists).
-- Produces: `getRequestMembershipOrgIds(req: MembershipRequest): Promise<string[]>` and `interface MembershipRequest { user?: IUserDocument; membershipOrgIds?: string[] }` — no later task consumes them.
+- Produces: `getRequestMembershipOrgIds(req: MembershipRequest): Promise<string[]>` and `interface MembershipRequest { user?: IUserDocument; membershipOrgIds?: string[] }` - no later task consumes them.
 
 - [ ] **Step 1: Write the failing test**
 

--- a/docs/superpowers/specs/2026-08-14-membership-followups-design.md
+++ b/docs/superpowers/specs/2026-08-14-membership-followups-design.md
@@ -1,0 +1,109 @@
+# Membership follow-ups from the AccessContext org-set work (PR #1762)
+
+Three small, independent items promised in the #1762 review thread. No new features; each is a
+cleanup or micro-optimization of the membership plumbing that PR introduced.
+
+## 1. Request-scoped memoization of the membership set
+
+### Problem
+
+`organizationRepository.findMembershipOrgIds(user.id)` is resolved fresh on every call. Within a
+single HTTP request it can run more than once: `toAccessContext` resolves it for every management
+gate, and `resolveRetrievalLakeScope` passes the raw repository into
+`dataLakeService.getDynamicDataLakeAccess`, which resolves it again internally. The entitlements
+read on the same requests is already memoized per request (`req.entitlements ??=` in
+`getRequestEntitlements`); membership deserves the same treatment.
+
+### Change
+
+New module `apps/client/server/dataLakes/requestMembership.ts`:
+
+- `export interface MembershipRequest { user?: IUserDocument; membershipOrgIds?: string[] }` -
+  the same minimal structural-request pattern as `EntitlementRequest` (and for the same
+  cross-package-compilability reason; see the comment on `EntitlementRequest`).
+- `export async function getRequestMembershipOrgIds(req: MembershipRequest): Promise<string[]>`:
+  fail closed on a nullish user (return `[]`), else
+  `return (req.membershipOrgIds ??= await organizationRepository.findMembershipOrgIds(req.user.id));`
+  `??=` (not `||=`): an empty membership list is a valid result that must memoize.
+
+Consumers:
+
+- `toAccessContext` replaces its direct
+  `organizationIds: await organizationRepository.findMembershipOrgIds(user.id)` with
+  `organizationIds: await getRequestMembershipOrgIds(req)`.
+- `resolveRetrievalLakeScope` replaces the raw `organizations: organizationRepository` adapter
+  entry with a wrapper that serves the requesting user from the memo and anyone else (a
+  defense-in-depth arm; the resolver only ever asks about `user.id` today) from the repository:
+
+  ```ts
+  organizations: {
+    findMembershipOrgIds: (uid: string) =>
+      uid === user.id ? getRequestMembershipOrgIds(req) : organizationRepository.findMembershipOrgIds(uid),
+  },
+  ```
+
+Out of scope, deliberately:
+
+- The completion/ToolContext path (chat knowledge tools): not an HTTP request; its resolvers get
+  `db.organizations` from `ToolContext`, whose lifecycle differs. A per-turn cache there is its
+  own change with its own invalidation questions.
+- The Slack ingest path: one membership resolution per ingest; nothing to memoize.
+
+### Tests
+
+New `requestMembership.test.ts` (co-located): memoizes (two awaits -> one repository call);
+empty-list result memoizes too (`??=` semantics); nullish user returns `[]` without a repository
+call. Plus one `resolveRetrievalLakeScope` assertion that the wrapper serves `user.id` from the
+memo (repository called at most once across `toAccessContext` + scope resolution when both run
+on one request object).
+
+## 2. Delete the dead `SlackIngestActor.organizationId`
+
+`apps/client/server/slack/dataLakeIngestAuthz.ts:30` (the field moved here from
+`dataLakeFileIngest.ts` when #1735 extracted the shared authz prologue). Since #1674 removed the
+selected-org pointer from authorization, nothing reads it: zero production readers in the slack
+modules; only three test fixtures still set it (`dataLakeFileIngest.test.ts`,
+`handleDataLakeCommand.test.ts`, `dataLakeLinkIngest.test.ts`).
+
+Change: remove the field from the interface and every fixture that sets it. The compiler
+enumerates any reader this grep missed; if one exists, stop and report rather than adapting it.
+
+## 3. One spelling for the membership predicate in `OrganizationModel`
+
+Two methods encode "is a member via the users[] ACL" differently
+(`packages/database/src/models/infra/admin/OrganizationModel.ts`):
+
+- `search()` line ~341: `permissions: { $in: ['read'] }`
+- `findMembershipOrgIds()` line ~407: `permissions: { $in: ['read', 'write'] }`
+
+Change: one module-level constant above the schema,
+
+```ts
+// The users[] ACL permission values that constitute org membership. 'write' implies membership
+// even when 'read' was never explicitly granted - the #1674 read-side set already treats it so,
+// and search() must agree or a write-only member can reach an org they cannot find.
+const MEMBER_PERMISSIONS = ['read', 'write'];
+```
+
+used by both call sites (`$in: MEMBER_PERMISSIONS`).
+
+**Deliberate behavior change:** a member holding only `write` in their `permissions` array will
+now match `search()`'s membership arm (previously invisible there while still passing every
+#1674 read gate). This corrects a latent inconsistency, not preserves it.
+
+### Tests
+
+In the existing OrganizationModel/repository test suite (uses `createMongoServer()`): a
+write-only member (a) appears in `search()` filtered by their userId, (b) appears in
+`findMembershipOrgIds`. A user with no ACL entry matches neither.
+
+## Out of scope
+
+- Any change to `findIdsWithAdminRights`, `resolveActiveOrg` (write-target validation is
+  deliberately wider than the read set - see its comment), or the shareable/groups arms.
+- ToolContext-level membership caching (noted above).
+
+## Verification
+
+- `pnpm --filter @bike4mind/database test` (organization suites) and focused client vitest on
+  the new/changed test files; `turbo:typecheck` before push.

--- a/packages/database/src/models/infra/admin/OrganizationModel.membershipOrgIds.test.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.membershipOrgIds.test.ts
@@ -44,3 +44,37 @@ describe('OrganizationRepository.findMembershipOrgIds', () => {
     expect(await organizationRepository.findMembershipOrgIds('u1')).toEqual([]);
   });
 });
+
+describe('OrganizationRepository.search - users[] ACL membership arm', () => {
+  setupMongoTest();
+
+  const searchByUser = async (userId: string) =>
+    (
+      await organizationRepository.search('', { userId }, { page: 1, limit: 10 }, { field: 'name', direction: 'asc' })
+    ).data.map(d => String(d._id));
+
+  it('a write-only ACL member finds the org (same predicate as findMembershipOrgIds)', async () => {
+    // Raw insert because no app write path can produce a write-only ACL row (writers hard-code
+    // ['read']) - the predicate is defensive against legacy/out-of-band data, and the schema
+    // enum must stay untouched.
+    const result = await Organization.collection.insertOne({
+      name: 'write-only-search',
+      userId: 'someone-else',
+      users: [{ userId: 'u1', permissions: ['write'] }],
+      groups: [],
+      isGlobalRead: false,
+      isGlobalWrite: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const orgId = String(result.insertedId);
+    expect(await searchByUser('u1')).toEqual([orgId]);
+    // The read-side set must agree - the whole point of the shared constant.
+    expect(await organizationRepository.findMembershipOrgIds('u1')).toEqual([orgId]);
+  });
+
+  it('a user with no ACL entry and no ownership matches nothing', async () => {
+    await makeOrg('unrelated', { users: [{ userId: 'someone', permissions: ['read'] }] });
+    expect(await searchByUser('u1')).toEqual([]);
+  });
+});

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -23,7 +23,13 @@ interface IOrganizationModel extends Model<IOrganizationDocument, {}> {
 // even when 'read' was never explicitly granted - the #1674 read-side set (findMembershipOrgIds)
 // already treats it so, and search() must agree or a write-only member can reach an org they
 // cannot find. Must stay the union used by BOTH call sites below.
-const MEMBER_PERMISSIONS = ['read', 'write'];
+//
+// 'write' is deliberately NOT a Permission enum member: adding it broke apps/client typecheck
+// (SkillShareDialog's Record<Permission, string> must be exhaustive) and would widen
+// UserShareableSchema's validator plus the public share/invite contracts. This array exists
+// only to match legacy/out-of-band rows - every app write path persists ['read'], so a
+// write-only row can only come from a raw-driver insert or old data.
+const MEMBER_PERMISSIONS = ['read', 'write'] as const;
 
 const OrganizationSchema = new Schema<IOrganizationDocument>(
   {

--- a/packages/database/src/models/infra/admin/OrganizationModel.ts
+++ b/packages/database/src/models/infra/admin/OrganizationModel.ts
@@ -19,6 +19,12 @@ interface IOrganizationModel extends Model<IOrganizationDocument, {}> {
   findShareAccessById: (userId: string, id: string) => Promise<IOrganizationDocument | null>;
 }
 
+// The users[] ACL permission values that constitute org membership. 'write' implies membership
+// even when 'read' was never explicitly granted - the #1674 read-side set (findMembershipOrgIds)
+// already treats it so, and search() must agree or a write-only member can reach an org they
+// cannot find. Must stay the union used by BOTH call sites below.
+const MEMBER_PERMISSIONS = ['read', 'write'];
+
 const OrganizationSchema = new Schema<IOrganizationDocument>(
   {
     ...ShareableDocumentSchema,
@@ -338,7 +344,7 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
           {
             $or: [
               { userId: filters.userId },
-              { users: { $elemMatch: { userId: filters.userId, permissions: { $in: ['read'] } } } },
+              { users: { $elemMatch: { userId: filters.userId, permissions: { $in: MEMBER_PERMISSIONS } } } },
             ],
           },
         ];
@@ -404,7 +410,7 @@ export class OrganizationRepository extends BaseRepository<IOrganizationDocument
     const docs = await this.organizationModel
       .find(
         {
-          $or: [{ userId }, { users: { $elemMatch: { userId, permissions: { $in: ['read', 'write'] } } } }],
+          $or: [{ userId }, { users: { $elemMatch: { userId, permissions: { $in: MEMBER_PERMISSIONS } } } }],
         },
         { _id: 1 }
       )


### PR DESCRIPTION
## What

The three follow-ups promised in the #1762 review thread, one commit each:

1. **Request-scoped membership memo.** New `getRequestMembershipOrgIds(req)` caches the caller's org-membership set on the request object, exactly as `getRequestEntitlements` caches entitlement keys. Wired into `toAccessContext` and into `resolveRetrievalLakeScope`'s `db.organizations` adapter (which serves the requesting user from the memo and any other id from the repository).
2. **Delete the dead `SlackIngestActor.organizationId`.** Nothing has read it since authorization switched to the membership set; the interface field, three test fixtures, and the one remaining pure writer in `pages/api/slack/events.ts` (plus its now-unused `normalizeId` import) are gone.
3. **One spelling for the users[] membership predicate.** `search()` said `['read']` while `findMembershipOrgIds()` said `['read','write']`. Both now use a shared `MEMBER_PERMISSIONS` constant.

## Notes for the reviewer

**The memo is insurance, not a measured saving.** No current request path resolves membership twice (`toAccessContext` runs once per handler; `resolveRetrievalLakeScope`'s only caller does not call it). The comment says so plainly. The point is that a second gate added later cannot silently double the query - the same reason the entitlements read is memoized.

**Item 3 is a deliberate behavior change:** a member holding only `write` in their `users[].permissions` now matches `search()`'s membership arm. Practically unreachable for app-created data - every membership writer persists `[Permission.read]`, and `'write'` is not in the `Permission` enum that `UserShareableSchema` validates against - so the predicate defends against legacy/out-of-band rows. The test fixture therefore inserts the row with the raw driver, mirroring the soft-delete test in the same file. `'write'` is deliberately NOT added to the `Permission` enum: doing so breaks the client typecheck (`SkillShareDialog`'s exhaustive `Record<Permission, string>`) and widens both `UserShareableSchema`'s validator and the public share/invite contracts. That reasoning is recorded on the constant so the mismatch is not "corrected" the wrong way later.

**Access decisions are otherwise untouched.** The memo is written only onto the request carrying that user and only for that user's id; the adapter wrapper never serves or seeds another user's set (a test now pins that arm specifically, so collapsing the wrapper to always use the memo fails the suite). No route mutates org membership and re-reads it in the same request; in the only plausible ordering a stale memo would be narrower (deny), never wider. `search()`'s two callers are an admin-gated billing panel and the org listing, where non-admins are forced to their own `userId`.

## Testing

- New `requestMembership.test.ts`: memoizes (two awaits, one repository call), empty set memoizes too (`??=` not `||=`), nullish user fails closed with no repository call.
- `resolveRetrievalLakeScope.test.ts`: adapter assertions updated, plus the cross-user leak guard described above.
- `OrganizationModel.membershipOrgIds.test.ts`: write-only ACL member appears in both `search()` and `findMembershipOrgIds`; a user with no ACL row matches neither.
- `@bike4mind/client` and `@bike4mind/database` typecheck clean; the touched client suites (25 tests) and the organization suite (7 tests) green; full database suite 1808 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
