### PR TITLE
test(tavern): seed the history-cap fixtures instead of 500 sequential writes

### DIFF
--- a/packages/database/src/models/content/__tests__/TavernWorldModel.test.ts
+++ b/packages/database/src/models/content/__tests__/TavernWorldModel.test.ts
@@ -213,29 +213,44 @@ describe('TavernWorldModel', () => {
   // ---------------------------------------------------------------------------
 
   describe('applyEdits — history cap', () => {
+    /**
+     * Seed `count` history entries directly, with the version/undoPointer a run of that many user
+     * edits would have left behind.
+     *
+     * Driving this through 500 sequential applyEdits calls is what these two tests used to do, and it
+     * made them the slowest in the repo (~140s for the file) and reliably timeout-prone on a loaded
+     * CI runner even at an 8x-default 120s budget - see #1803. The cap and eviction are pure array
+     * arithmetic (MAX_HISTORY_ENTRIES, splice, undoPointer adjust), so the boundary is what needs
+     * exercising, not the 500 round-trips it takes to reach it. Seeding keeps both assertions exactly
+     * as they were and lets the final applyEdits do the real work.
+     */
+    async function seedHistory(count: number, worldId = 'user-1') {
+      const entries = Array.from({ length: count }, (_, i) => ({
+        batchId: `seed-${i}`,
+        timestamp: new Date(),
+        source: 'user' as const,
+        forward: [{ key: `ground:${i % 96},0`, gid: i + 1 }],
+        reverse: [{ key: `ground:${i % 96},0`, gid: null }],
+      }));
+      await TavernWorld.updateOne(
+        { worldId, floorId: 'surface' },
+        { $set: { editHistory: entries, undoPointer: count, version: count } }
+      );
+    }
+
     it('should cap editHistory at 500 entries', async () => {
       await createWorld();
-
-      // Apply edits in bulk batches to stay under timeout
-      // Each applyEdits call is one history entry, so we need 500+ calls
-      // Use a smaller batch to verify the cap mechanism works
-      for (let i = 0; i < 500; i++) {
-        await applyEdits('user-1', i, [{ key: `ground:${i % 96},0`, gid: i + 1 }]);
-      }
+      await seedHistory(500);
 
       // Apply one more - should evict oldest
       const result = await applyEdits('user-1', 500, [{ key: 'ground:0,1', gid: 999 }]);
       expect(result!.editHistory).toHaveLength(500);
       expect(result!.version).toBe(501);
-    }, 120000);
+    });
 
     it('should adjust undoPointer when entries are evicted', async () => {
       await createWorld();
-
-      // Fill history to 500
-      for (let i = 0; i < 500; i++) {
-        await applyEdits('user-1', i, [{ key: `ground:${i % 96},0`, gid: i + 1 }]);
-      }
+      await seedHistory(500);
 
       // Pointer should be at 500
       const before = await tavernWorldRepository.getOrCreateWorld('user-1', 'user-1');
@@ -246,7 +261,17 @@ describe('TavernWorldModel', () => {
       expect(result!.editHistory).toHaveLength(500);
       // Pointer should still be at end (500), not 501
       expect(result!.undoPointer).toBe(500);
-    }, 120000);
+    });
+
+    it('evicts exactly the OLDEST entry, not an arbitrary one', async () => {
+      await createWorld();
+      await seedHistory(500);
+
+      const result = await applyEdits('user-1', 500, [{ key: 'ground:0,1', gid: 999 }]);
+      // seed-0 is gone, seed-1 is now the front, and the new edit is the last entry.
+      expect(result!.editHistory[0].batchId).toBe('seed-1');
+      expect(result!.editHistory[499].forward[0]).toMatchObject({ key: 'ground:0,1', gid: 999 });
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/database/src/models/content/__tests__/TavernWorldModel.test.ts
+++ b/packages/database/src/models/content/__tests__/TavernWorldModel.test.ts
@@ -224,6 +224,10 @@ describe('TavernWorldModel', () => {
      * exercising, not the 500 round-trips it takes to reach it. Seeding keeps both assertions exactly
      * as they were and lets the final applyEdits do the real work.
      */
+    // Seeds editHistory only, leaving `edits` empty - so every `reverse` here is gid:null, which
+    // applyEdits would only produce on a first write. That is fine for the cap tests (pure array
+    // arithmetic, indifferent to entry contents); reverse-against-existing-tiles is covered by
+    // 'should record previous gid in reverse entries'.
     async function seedHistory(count: number, worldId = 'user-1') {
       const entries = Array.from({ length: count }, (_, i) => ({
         batchId: `seed-${i}`,


### PR DESCRIPTION
Closes #1803.

## Why

`TavernWorldModel.test.ts` has been failing on **`main`**, not just on feature branches - its most recent CI run (`3bd4ad68`) is red on exactly this:

```
FAIL  TavernWorldModel > applyEdits - history cap > should cap editHistory at 500 entries
Error: Test timed out in 120000ms.
Tests  1 failed | 1819 passed
```

Every other shard on that run was green. So every PR that lands in the `data` shard inherits a red check and a re-run - it cost PR #1730 two consecutive failed runs at one SHA, on a commit whose only change was a client-side test file.

## What was slow

Two tests each drove **500 sequential `applyEdits` calls**, one database round-trip per iteration, purely to reach the 500-entry boundary:

```ts
for (let i = 0; i < 500; i++) {
  await applyEdits('user-1', i, [{ key: `ground:${i % 96},0`, gid: i + 1 }]);
}
```

Both already carried an explicit `}, 120000)` - **8x** the 15s default from `vitest.shared.ts` - so the ceiling had been raised once and was still being hit. The test's own comment ("Apply edits in bulk batches to stay under timeout") shows the author knew it was close.

## What changed

Seed the fixtures directly, and let the final `applyEdits` do the real work. The cap is pure array arithmetic - `MAX_HISTORY_ENTRIES`, `splice`, `undoPointer` adjust - so the **boundary** is what needs exercising, not the 1000 round-trips it takes two tests to reach it.

**Both existing assertions are unchanged.** The explicit timeout overrides are gone because they are no longer needed.

**File runtime, like-for-like on one machine: 9.30s -> ~2.1-2.6s.** Same command (`pnpm exec vitest run src/models/content/__tests__/TavernWorldModel.test.ts`), before and after, on this laptop.

Two things that figure is deliberately *not*: the `~140s` in #1803 is a CI runner under parallel load and is not comparable to a local number, and there is no measurable saving in shard wall time (3m47s on the failing run, 4m07s on this branch's green one - dominated by other work and runner variance). The CI-side win is simply that the file stops hitting its 120s ceiling.

I also added a third case: **the evicted entry is the OLDEST one.** The previous fixtures could not distinguish that - every entry they generated was interchangeable, so a `splice` from the wrong end would have passed. The new seed gives entries distinct ids, so it can.

## Verification

**Load-bearing, proved by mutation rather than asserted.** Removing the eviction block from `TavernWorldModel.applyEdits`:

```
× should cap editHistory at 500 entries
× should adjust undoPointer when entries are evicted
× evicts exactly the OLDEST entry, not an arbitrary one
Tests  3 failed | 30 passed (33)
```

All three fail, then pass again once restored.

`@bike4mind/database`: 143 files, 1821 passed. Lint clean. **Test-only - `TavernWorldModel.ts` is untouched** (`git diff` on the model is empty).

## Note on the wider pattern

Two other real-Mongo suites showed the same signature in the same session - timeout under full-suite parallel load, pass in isolation:

- `apps/client/server/services/deleteOrganizationTransaction.e2e.test.ts`
- `apps/client/server/queueHandlers/dataLakeBatchRetryGating.e2e.test.ts`

Those are in the **client** shard, so not the same runner contention as this one, and I have not established they share a root cause - only the shape. This PR deliberately fixes the one test that is reliably red rather than generalising off two unverified data points. If they keep costing re-runs, a shard-level policy (a timeout floor for suites standing up a real Mongo, or serialising them) is worth considering separately.
