### PR TITLE
fix(selfhost): prevent fabFileChunkScan from re-enqueuing zero-chunk files

### DIFF
--- a/apps/client/server/queueHandlers/fabFileChunk.ts
+++ b/apps/client/server/queueHandlers/fabFileChunk.ts
@@ -273,6 +273,8 @@ export const dispatch = dispatchWithLogger(async (event, context, logger) => {
         { _id: fabFileId },
         {
           $set: {
+            chunked: true,
+            chunkCount: 0,
             notes: `${NO_EXTRACTABLE_TEXT_NOTE_PREFIX} - re-process or re-upload (e.g. image-only or unsupported content).`,
           },
         }

--- a/apps/client/server/worker/chunkScan.test.ts
+++ b/apps/client/server/worker/chunkScan.test.ts
@@ -51,6 +51,11 @@ describe('buildFabFileChunkScanFilter', () => {
     expect(matches(doc, filter)).toBe(false);
   });
 
+  it('skips a file with chunked: true even when chunkCount is 0', () => {
+    const doc = { status: 'complete', chunkCount: 0, chunked: true, isChunking: false, createdAt: old, deletedAt: null };
+    expect(matches(doc, filter)).toBe(false);
+  });
+
   it('skips a just-uploaded file still within the age window', () => {
     const recent = new Date('2026-01-01T00:01:00Z'); // after cutoff
     const doc = { status: 'complete', chunkCount: 0, isChunking: false, createdAt: recent, deletedAt: null };

--- a/apps/client/server/worker/chunkScan.ts
+++ b/apps/client/server/worker/chunkScan.ts
@@ -47,6 +47,7 @@ export const NO_EXTRACTABLE_TEXT_NOTE_PREFIX = 'No extractable text';
 
 export const buildFabFileChunkScanFilter = (cutoff: Date) => ({
   status: 'complete' as const,
+  chunked: { $ne: true },
   chunkCount: 0,
   isChunking: { $ne: true },
   createdAt: { $lt: cutoff },


### PR DESCRIPTION
## Summary
Files that produce zero chunks (or are already marked `chunked: true` with `chunkCount: 0`) were repeatedly re-selected by `fabFileChunkScan` and re-enqueued onto `fabFileChunkQueue` every cycle because `buildFabFileChunkScanFilter` lacked an exclusion for `chunked: { $ne: true }`. When the chunk queue handler received them, it returned early without updating the notes marker, creating an infinite loop.

This PR:
1. Adds `chunked: { $ne: true }` to `buildFabFileChunkScanFilter`.
2. Explicitly sets `chunked: true` and `chunkCount: 0` alongside notes when a file produces zero chunks in `fabFileChunk.ts`.
3. Adds unit test coverage verifying that `chunked: true` documents are skipped by the scan filter.

Fixes #967
