### PR TITLE
fix(publish): obtain the comment widget's credential from the refresh cookie

### DIFF
--- a/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+//
+// EXECUTION coverage for the comment-overlay widget's CREDENTIAL path.
+//
+// widget.test.ts already drives the shipped script in jsdom, but it stubs `can-comment` to
+// return `canComment` directly, so nothing ever exercised how the widget obtains a token -
+// which is why #1811 went unnoticed: the widget read an access token out of localStorage,
+// #1346 made that field permanently undefined, and no test could tell. These cover the
+// acquisition itself, in the same shape as renderBundleLoaderShell.dom.test.ts.
+//
+// The other half of the bug was cost-shaped rather than correctness-shaped, so the traffic
+// assertions below are load-bearing too: an anonymous reader of a public artifact must issue
+// ZERO requests to /api/auth/refreshToken, which is rate-limited per IP.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import handler from '../widget';
+
+/** Render the widget exactly as the route serves it. */
+function widgetSource(): string {
+  let body = '';
+  const res = {
+    setHeader: () => res,
+    status: () => res,
+    send: (b: string) => {
+      body = b;
+      return res;
+    },
+  } as never;
+  handler({} as never, res);
+  if (!body) throw new Error('widget handler produced no body');
+  return body;
+}
+
+interface StubbedCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+let calls: StubbedCall[] = [];
+
+const REFRESH = '/api/auth/refreshToken';
+const CAN_COMMENT = 'can-comment';
+
+function res(status: number, body: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(''),
+    headers: { get: () => null },
+  } as unknown as Response;
+}
+
+/**
+ * Route fetches by URL. `listStatus` lets a test describe a gated artifact (401 until a
+ * credential is presented) versus a public one.
+ */
+function stubFetch(opts: { signedIn: boolean; gated?: boolean }) {
+  const fetchStub = vi.fn((url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    const authed = !!(init?.headers as Record<string, string> | undefined)?.Authorization;
+
+    if (url.includes(REFRESH)) {
+      return Promise.resolve(opts.signedIn ? res(200, { accessToken: 'fresh.token' }) : res(401, {}));
+    }
+    if (url.includes(CAN_COMMENT)) {
+      return Promise.resolve(
+        authed
+          ? res(200, { commentPolicy: 'open', canComment: true })
+          : res(200, { commentPolicy: 'open', canComment: false })
+      );
+    }
+    // the annotations list
+    if (opts.gated && !authed) return Promise.resolve(res(401, { error: 'Authentication required' }));
+    return Promise.resolve(
+      res(200, {
+        commentPolicy: 'open',
+        annotations: [{ id: 'c1', authorDisplayName: 'Ada', body: 'first', createdAt: new Date(0).toISOString() }],
+      })
+    );
+  });
+  vi.stubGlobal('fetch', fetchStub);
+  return fetchStub;
+}
+
+function mountWidget(): void {
+  document.body.innerHTML =
+    '<div id="b4m-annotate-root" data-public-id="pub_1" data-comment-policy="open" data-title="T"></div><iframe></iframe>';
+}
+
+/** Run the widget and let its promise chain settle. */
+async function runWidget(): Promise<void> {
+  // eval, deliberately: executing the REAL shipped script is the whole point - a test that
+  // reimplemented the credential logic would have passed straight through #1811.
+  eval(widgetSource());
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+function refreshCalls(): StubbedCall[] {
+  return calls.filter(c => c.url.includes(REFRESH));
+}
+
+function clickLauncher(): void {
+  (document.getElementById('b4m-launch') as HTMLButtonElement).click();
+}
+
+describe('publish comment widget - credential path', () => {
+  beforeEach(() => {
+    calls = [];
+    vi.useFakeTimers();
+    mountWidget();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('never reads a credential from localStorage', async () => {
+    const getItem = vi.spyOn(window.localStorage, 'getItem');
+    stubFetch({ signedIn: true });
+
+    await runWidget();
+    clickLauncher();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
+  it('costs an anonymous reader of a public artifact ZERO auth requests', async () => {
+    // The rate-limit protection: this is the overwhelmingly common path, and it must not
+    // touch /api/auth/refreshToken at all when the panel is never opened.
+    stubFetch({ signedIn: false });
+
+    await runWidget();
+    await vi.advanceTimersByTimeAsync(120000); // two poll cycles
+
+    expect(refreshCalls()).toHaveLength(0);
+    // The comment list still loads and renders anonymously.
+    expect(document.getElementById('b4m-launch')?.textContent).toContain('1');
+  });
+
+  it('shows the composer to a signed-in viewer once the panel is opened', async () => {
+    stubFetch({ signedIn: true });
+
+    await runWidget();
+    expect(refreshCalls()).toHaveLength(0); // still nothing before interaction
+
+    clickLauncher();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refreshCalls()).toHaveLength(1);
+    expect(document.getElementById('b4m-ta')).not.toBeNull(); // composer textarea
+    expect(document.getElementById('b4m-signin')).toBeNull(); // NOT "Sign in to comment"
+  });
+
+  it('still shows the sign-in prompt to a genuinely signed-out viewer', async () => {
+    stubFetch({ signedIn: false });
+
+    await runWidget();
+    clickLauncher();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(document.getElementById('b4m-signin')).not.toBeNull();
+    expect(document.getElementById('b4m-ta')).toBeNull();
+  });
+
+  it('makes existing comments on a gated artifact visible to an authorized reader', async () => {
+    // The list 401s unauthenticated; the widget must discover that, obtain a credential and
+    // retry, rather than swallowing it and rendering "No comments yet".
+    stubFetch({ signedIn: true, gated: true });
+
+    await runWidget();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refreshCalls()).toHaveLength(1);
+    clickLauncher();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(document.getElementById('b4m-list')?.textContent).toContain('first');
+    expect(document.getElementById('b4m-list')?.textContent).not.toContain('No comments yet');
+  });
+
+  it('attempts the exchange only once for a signed-out viewer of a gated artifact', async () => {
+    // The negative result is cached, so 60s polls cannot turn into a stream of exchanges.
+    stubFetch({ signedIn: false, gated: true });
+
+    await runWidget();
+    await vi.advanceTimersByTimeAsync(180000); // three poll cycles
+
+    expect(refreshCalls()).toHaveLength(1);
+  });
+
+  it('recovers a session that expires while the page is open', async () => {
+    // A page can outlive the 30-minute access-token TTL many times over.
+    let tokenGeneration = 0;
+    let listSeenStale = false;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        const auth = (init?.headers as Record<string, string> | undefined)?.Authorization;
+        if (url.includes(REFRESH)) {
+          tokenGeneration++;
+          return Promise.resolve(res(200, { accessToken: 'token.gen' + tokenGeneration }));
+        }
+        if (url.includes(CAN_COMMENT)) return Promise.resolve(res(200, { commentPolicy: 'open', canComment: true }));
+        // The first-generation token is rejected as expired; the second is accepted.
+        if (auth === 'Bearer token.gen1') {
+          listSeenStale = true;
+          return Promise.resolve(res(401, {}));
+        }
+        return Promise.resolve(res(200, { commentPolicy: 'open', annotations: [] }));
+      })
+    );
+
+    await runWidget();
+    clickLauncher();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(tokenGeneration).toBe(1);
+
+    // The poll loop is armed at init, before the panel opened, so the first tick is the
+    // closed-panel cadence (60s) rather than the open one.
+    await vi.advanceTimersByTimeAsync(70000); // a poll fires with the now-stale token
+
+    expect(listSeenStale).toBe(true);
+    expect(tokenGeneration).toBe(2); // re-exchanged rather than dead-ending
+  });
+});

--- a/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
@@ -116,18 +116,44 @@ function listCalls(): StubbedCall[] {
   return calls.filter(c => !c.url.includes(REFRESH) && !c.url.includes(CAN_COMMENT));
 }
 
+function canCommentCalls(): StubbedCall[] {
+  return calls.filter(c => c.url.includes(CAN_COMMENT));
+}
+
+/** jsdom reports visibilityState 'visible', so this runs the handler's live branch. */
+function refocusTab(): void {
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
 function clickLauncher(): void {
   (document.getElementById('b4m-launch') as HTMLButtonElement).click();
 }
 
+/**
+ * The widget registers a document-level visibilitychange listener at eval time, and jsdom keeps
+ * ONE document for the whole file - mountWidget only resets document.body. Without detaching,
+ * every widget eval'd by an earlier test is still listening, so dispatching the event runs all
+ * of them and the request counts are the sum of every instance. Track what each run adds and
+ * remove it afterwards.
+ */
+let addedDocListeners: Array<[string, EventListener]> = [];
+const nativeAddEventListener = document.addEventListener.bind(document);
+
 describe('publish comment widget - credential path', () => {
   beforeEach(() => {
     calls = [];
+    addedDocListeners = [];
+    document.addEventListener = ((type: string, fn: EventListener, opts?: AddEventListenerOptions) => {
+      addedDocListeners.push([type, fn]);
+      nativeAddEventListener(type, fn, opts);
+    }) as typeof document.addEventListener;
     vi.useFakeTimers();
     mountWidget();
   });
 
   afterEach(() => {
+    addedDocListeners.forEach(([type, fn]) => document.removeEventListener(type, fn));
+    document.addEventListener = nativeAddEventListener as typeof document.addEventListener;
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
@@ -314,6 +340,39 @@ describe('publish comment widget - credential path', () => {
 
     expect(calls.some(c => c.url.includes(CAN_COMMENT))).toBe(false);
     expect(document.getElementById('b4m-signin')).not.toBeNull();
+  });
+
+  // The visibilitychange handler used to re-check capability unconditionally. That was free when
+  // loadCanComment was a bare fetch, but it now begins with ensureToken(), so on a public
+  // artifact whose panel was never opened a backgrounded tab would start an exchange purely by
+  // being refocused - the same cost the lazy design exists to avoid, on a path a reader reaches
+  // without ever interacting. Both directions are pinned: skipped while capability is unknown,
+  // still performed once it is known.
+  it('does not start auth traffic when a tab refocuses before the panel is opened', async () => {
+    stubFetch({ signedIn: true });
+    await runWidget();
+
+    refocusTab();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refreshCalls()).toHaveLength(0);
+    expect(canCommentCalls()).toHaveLength(0);
+  });
+
+  it('still re-checks capability on refocus once it has been established', async () => {
+    // The guard must not be satisfied by simply never re-checking - a revoked or newly granted
+    // ability to comment should still be picked up when the viewer comes back to the tab.
+    stubFetch({ signedIn: true });
+    await runWidget();
+    clickLauncher();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(canCommentCalls()).toHaveLength(1);
+
+    refocusTab();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(canCommentCalls()).toHaveLength(2); // re-checked
+    expect(refreshCalls()).toHaveLength(1); // but on the cached token, no second exchange
   });
 
   it('recovers a session that expires while the page is open', async () => {

--- a/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
@@ -51,16 +51,22 @@ function res(status: number, body: unknown): Response {
 }
 
 /**
- * Route fetches by URL. `listStatus` lets a test describe a gated artifact (401 until a
- * credential is presented) versus a public one.
+ * Route fetches by URL.
+ *  - `gated`      401s the list until a credential is presented (the recoverable case)
+ *  - `neverAdmits` 401s the list NO MATTER WHAT, which is the passphrase-gated artifact viewed
+ *    by a non-owner: the proof is a cookie, so no Bearer can ever satisfy it. This is the shape
+ *    that ran away, re-exchanging once per poll forever.
  */
-function stubFetch(opts: { signedIn: boolean; gated?: boolean }) {
+function stubFetch(opts: { signedIn: boolean; gated?: boolean; neverAdmits?: boolean }) {
   const fetchStub = vi.fn((url: string, init?: RequestInit) => {
     calls.push({ url, init });
     const authed = !!(init?.headers as Record<string, string> | undefined)?.Authorization;
 
     if (url.includes(REFRESH)) {
       return Promise.resolve(opts.signedIn ? res(200, { accessToken: 'fresh.token' }) : res(401, {}));
+    }
+    if (opts.neverAdmits && !url.includes(CAN_COMMENT)) {
+      return Promise.resolve(res(401, { error: 'Passphrase required' }));
     }
     if (url.includes(CAN_COMMENT)) {
       return Promise.resolve(
@@ -188,6 +194,74 @@ describe('publish comment widget - credential path', () => {
     await vi.advanceTimersByTimeAsync(180000); // three poll cycles
 
     expect(refreshCalls()).toHaveLength(1);
+  });
+
+  // REGRESSION GUARD. The retry was bounded within one authedFetch call but not across calls:
+  // every poll started fresh, saw a token was held, took the force branch and minted a new one.
+  // On a passphrase-gated artifact viewed by a non-owner - a 401 no Bearer can ever fix - that
+  // was one exchange per poll cycle, indefinitely, against a 60/min per-IP limit. The earlier
+  // traffic tests pinned the LOWER bound (zero when unused); this pins the upper one.
+  it('stops re-exchanging once a fresh credential still cannot satisfy the gate', async () => {
+    stubFetch({ signedIn: true, neverAdmits: true });
+
+    await runWidget();
+    clickLauncher();
+    await vi.advanceTimersByTimeAsync(0);
+    const afterOpen = refreshCalls().length;
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000); // ten closed-panel poll cycles
+
+    // Flat, not growing. Before the latch this was afterOpen + one per cycle.
+    expect(refreshCalls()).toHaveLength(afterOpen);
+  });
+
+  it('escalates to sending credentials so a passphrase proof cookie can satisfy the gate', async () => {
+    // The proof is an HttpOnly per-artifact cookie, so a request with credentials omitted can
+    // never pass the gate however good its Bearer is. Escalation happens only after a 401, which
+    // is what keeps the cacheable open-public path cookie-free.
+    stubFetch({ signedIn: true, neverAdmits: true });
+
+    await runWidget();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const listCalls = calls.filter(c => !c.url.includes(REFRESH) && !c.url.includes(CAN_COMMENT));
+    expect(listCalls[0]?.init?.credentials).toBe('omit'); // first attempt stays cookie-free
+    expect(listCalls.some(c => c.init?.credentials === 'same-origin')).toBe(true);
+  });
+
+  it('keeps the open-public list request cookie-free, since it never 401s', async () => {
+    stubFetch({ signedIn: true });
+
+    await runWidget();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    const listCalls = calls.filter(c => !c.url.includes(REFRESH) && !c.url.includes(CAN_COMMENT));
+    expect(listCalls.length).toBeGreaterThan(0);
+    expect(listCalls.every(c => c.init?.credentials === 'omit')).toBe(true);
+  });
+
+  it('does not paint "Sign in to comment" at a signed-in viewer while capability is unknown', async () => {
+    // openPanel renders synchronously, before the credential exists. Gating the prompt on
+    // !token alone showed a signed-in viewer the one string this change exists to remove.
+    stubFetch({ signedIn: true });
+    await runWidget();
+
+    clickLauncher(); // synchronous render, nothing resolved yet
+    expect(document.getElementById('b4m-signin')).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(document.getElementById('b4m-ta')).not.toBeNull();
+  });
+
+  it('skips the can-comment round trip entirely for a signed-out viewer', async () => {
+    stubFetch({ signedIn: false });
+
+    await runWidget();
+    clickLauncher();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(calls.some(c => c.url.includes(CAN_COMMENT))).toBe(false);
+    expect(document.getElementById('b4m-signin')).not.toBeNull();
   });
 
   it('recovers a session that expires while the page is open', async () => {

--- a/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.dom.test.ts
@@ -56,8 +56,12 @@ function res(status: number, body: unknown): Response {
  *  - `neverAdmits` 401s the list NO MATTER WHAT, which is the passphrase-gated artifact viewed
  *    by a non-owner: the proof is a cookie, so no Bearer can ever satisfy it. This is the shape
  *    that ran away, re-exchanging once per poll forever.
+ *  - `cookieAdmits` 401s the list until the proof cookie rides along, which is the passphrase-
+ *    gated artifact the viewer has ALREADY UNLOCKED - the configuration the escalation ladder
+ *    exists to serve, and the one where a ladder that is re-climbed every poll runs away in the
+ *    success case rather than the failure one.
  */
-function stubFetch(opts: { signedIn: boolean; gated?: boolean; neverAdmits?: boolean }) {
+function stubFetch(opts: { signedIn: boolean; gated?: boolean; neverAdmits?: boolean; cookieAdmits?: boolean }) {
   const fetchStub = vi.fn((url: string, init?: RequestInit) => {
     calls.push({ url, init });
     const authed = !!(init?.headers as Record<string, string> | undefined)?.Authorization;
@@ -66,6 +70,9 @@ function stubFetch(opts: { signedIn: boolean; gated?: boolean; neverAdmits?: boo
       return Promise.resolve(opts.signedIn ? res(200, { accessToken: 'fresh.token' }) : res(401, {}));
     }
     if (opts.neverAdmits && !url.includes(CAN_COMMENT)) {
+      return Promise.resolve(res(401, { error: 'Passphrase required' }));
+    }
+    if (opts.cookieAdmits && !url.includes(CAN_COMMENT) && init?.credentials !== 'same-origin') {
       return Promise.resolve(res(401, { error: 'Passphrase required' }));
     }
     if (url.includes(CAN_COMMENT)) {
@@ -103,6 +110,10 @@ async function runWidget(): Promise<void> {
 
 function refreshCalls(): StubbedCall[] {
   return calls.filter(c => c.url.includes(REFRESH));
+}
+
+function listCalls(): StubbedCall[] {
+  return calls.filter(c => !c.url.includes(REFRESH) && !c.url.includes(CAN_COMMENT));
 }
 
 function clickLauncher(): void {
@@ -227,6 +238,47 @@ describe('publish comment widget - credential path', () => {
     const listCalls = calls.filter(c => !c.url.includes(REFRESH) && !c.url.includes(CAN_COMMENT));
     expect(listCalls[0]?.init?.credentials).toBe('omit'); // first attempt stays cookie-free
     expect(listCalls.some(c => c.init?.credentials === 'same-origin')).toBe(true);
+  });
+
+  // REGRESSION GUARD, the mirror of the one above. The latch only fired when the top of the
+  // ladder FAILED, so when it SUCCEEDED nothing was remembered: every later request restarted at
+  // stage 0, where a token is always held by then, and minted a fresh one. On a passphrase-gated
+  // artifact the viewer has unlocked - where only the cookie stage ever gets in - that was again
+  // one exchange per poll forever, plus 3x list amplification.
+  it('settles on the stage that worked instead of re-climbing the ladder every poll', async () => {
+    stubFetch({ signedIn: true, cookieAdmits: true });
+
+    await runWidget();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refreshCalls()).toHaveLength(1);
+    expect(listCalls()).toHaveLength(3); // the ladder, climbed once: omit -> omit+Bearer -> cookie
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000); // ten closed-panel poll cycles
+
+    // Flat, not growing: the exchange is not repeated, and each poll costs ONE list request
+    // rather than re-walking all three.
+    expect(refreshCalls()).toHaveLength(1);
+    expect(listCalls()).toHaveLength(13);
+    expect(
+      listCalls()
+        .slice(3)
+        .every(c => c.init?.credentials === 'same-origin')
+    ).toBe(true);
+  });
+
+  it('sends the proof cookie for a signed-out viewer who has unlocked the gate', async () => {
+    // checkAccessGate admits on passphraseVerified ALONE, with no user - so escalation to the
+    // cookie must not be conditional on having obtained a token, or the #1811 symptom (existing
+    // comments invisible to a reader allowed to see them) survives on the passphrase rung for
+    // every viewer without a session.
+    stubFetch({ signedIn: false, cookieAdmits: true });
+
+    await runWidget();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(listCalls().some(c => c.init?.credentials === 'same-origin')).toBe(true);
+    expect(document.getElementById('b4m-launch')?.textContent).toContain('1');
+    expect(refreshCalls()).toHaveLength(1); // still exactly one attempt per page
   });
 
   it('keeps the open-public list request cookie-free, since it never 401s', async () => {

--- a/apps/client/pages/api/publish/__tests__/widget.test.ts
+++ b/apps/client/pages/api/publish/__tests__/widget.test.ts
@@ -173,6 +173,12 @@ function installFetch(opts: {
     'fetch',
     vi.fn((url: unknown, init?: { method?: string }) => {
       const u = String(url);
+      // The widget obtains its credential by POSTing the refresh endpoint, so this has to be
+      // matched BEFORE the generic POST branch below - otherwise the session exchange is
+      // mistaken for a comment submission and consumes an onPost() response.
+      if (u.includes('/api/auth/refreshToken')) {
+        return Promise.resolve(jsonRes({ accessToken: 'test.access.token' }));
+      }
       if (u.endsWith('/can-comment')) {
         return Promise.resolve(jsonRes({ commentPolicy: 'open', canComment: opts.canComment }));
       }

--- a/apps/client/pages/api/publish/annotations/[publicId].ts
+++ b/apps/client/pages/api/publish/annotations/[publicId].ts
@@ -57,7 +57,10 @@ async function loadArtifact(publicId: string): Promise<ArtifactGateLean | null> 
 
 /** The gate context for annotation reads/writes: a passphrase gate is satisfied
  *  by the per-artifact proof cookie the viewer already holds from unlocking the
- *  page (annotation requests are same-origin, so the cookie rides along). */
+ *  page. NOTE the cookie does not ride along automatically - the widget sends
+ *  `credentials: 'omit'` by default and only re-sends with `same-origin` after a
+ *  401 (see authedFetch in publish/widget.ts), so a caller that omits credentials
+ *  reaches here with no proof and is correctly told the passphrase is required. */
 function gateContext(req: Request, artifact: ArtifactGateLean) {
   return {
     passphraseVerified: artifact.accessGate?.kind === 'passphrase' && requestHasGateProof(req, artifact.publicId),

--- a/apps/client/pages/api/publish/annotations/[publicId]/can-comment.ts
+++ b/apps/client/pages/api/publish/annotations/[publicId]/can-comment.ts
@@ -7,8 +7,10 @@ import { checkVisibility, canAnnotate, toPublishUser, requestHasGateProof } from
 /**
  * GET /api/publish/annotations/[publicId]/can-comment - the PER-VIEWER comment
  * capability, split out of the list GET so that list can be CDN-cached while
- * this stays no-store. The widget fetches it once on load (and on tab-refocus),
- * not on every poll. Anonymous viewers get `false`.
+ * this stays no-store. The widget fetches it when the comment panel is OPENED
+ * (and on tab-refocus once capability is known), not on load and not on every
+ * poll - the composer is the only thing that needs it, so a reader who never
+ * opens the panel costs nothing here. Anonymous viewers get `false`.
  */
 
 interface ArtifactGateLean {

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -132,6 +132,9 @@ const WIDGET_JS = String.raw`(function () {
    *
    * A 401 that survives stage 2 latches authCannotFix, because at that point no credential this
    * page can produce will help and retrying is pure cost.
+   *
+   * The headers and credentials keys on init are OWNED by this function and overwritten - the
+   * whole point is that the stage decides them. Pass anything else (method, body, cache) freely.
    */
   function authedFetch(url, init, stage) {
     var s = Math.max(stage || 0, baseStage);

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -58,6 +58,16 @@ const WIDGET_JS = String.raw`(function () {
   // actually needs it: a list request that came back gated, or the panel being opened.
   var token = null;
   var tokenPromise = null;
+  /**
+   * Latched once a request has 401ed with a FRESH token AND the gate-proof cookie attached -
+   * i.e. nothing this page can hold will satisfy it (a passphrase gate the viewer has not
+   * unlocked, a revoked session). Without this the retry ladder restarts on every poll, and
+   * because a token IS held each cycle takes the force branch and mints a NEW one: one exchange
+   * per poll, forever, which is precisely the rate-limit exhaustion the lazy design exists to
+   * prevent. A page reload clears it, which is the right granularity - if the viewer unlocks the
+   * gate in another tab, they reload to see comments anyway.
+   */
+  var authCannotFix = false;
 
   /** Single-flight cookie exchange. Caches the NEGATIVE result too, so an anonymous viewer
    *  makes exactly one attempt per page. The force flag re-arms it after a 401 (expired mid-session). */
@@ -84,25 +94,47 @@ const WIDGET_JS = String.raw`(function () {
   }
 
   /**
-   * Fetch with whatever credential we hold, and on a 401 obtain one ONCE and retry. This is
-   * the single place a gated artifact is discovered: the widget is never told the artifact's
-   * visibility, it simply learns from a 401 that this request needed a credential.
+   * Fetch, escalating only as far as a 401 forces. This is the single place a gated artifact is
+   * discovered: the widget is never told the artifact's visibility, it learns from a 401 that
+   * the request needed something it had not yet presented.
    *
-   * The retried flag bounds it to one re-attempt, so an endpoint that 401s for a reason no token can
-   * fix (a revoked session) settles instead of looping.
+   *   stage 0  Bearer only, credentials omitted
+   *   stage 1  same, after obtaining/refreshing the token (a stale token is the usual 401)
+   *   stage 2  plus credentials: 'same-origin', so a passphrase gate's per-artifact proof
+   *            cookie can ride along (it is HttpOnly + SameSite=Lax + Path=/, and
+   *            requestHasGateProof reads it straight off the request)
+   *
+   * Escalating rather than sending cookies from the start keeps the OPEN-public path - the
+   * overwhelming majority of views, and the only one whose list is shared-cacheable
+   * (s-maxage=5; gated lists are no-store) - byte-for-byte as it was: those requests never
+   * 401, so they never leave stage 0 and stay cookie-free.
+   *
+   * Sending the cookie creates no auth-by-cookie path and no CSRF surface: optionalAuth
+   * authenticates ONLY from X-API-Key or Authorization: Bearer, never from a cookie.
+   *
+   * A 401 that survives stage 2 latches authCannotFix, because at that point no credential this
+   * page can produce will help and retrying is pure cost.
    */
-  function authedFetch(url, init, retried) {
-    var opts = init || {};
+  function authedFetch(url, init, stage) {
+    var s = stage || 0;
+    // Copy rather than mutate: opts IS init when init is truthy, so writing headers/credentials
+    // onto it would scribble on the caller's object and on the retry's own input.
+    var opts = init ? Object.assign({}, init) : {};
     opts.headers = headers(opts.method === 'POST');
-    opts.credentials = 'omit'; // the Bearer header is the only credential; never the ambient cookie
+    opts.credentials = s >= 2 ? 'same-origin' : 'omit';
     return fetch(url, opts).then(function (r) {
-      if (r.status !== 401 || retried) return r;
-      // Force a re-exchange only when we HELD a token that went stale. Holding none means the
-      // cached negative stands, so a signed-out viewer cannot be made to re-attempt the
-      // exchange on every 60s poll.
-      return ensureToken(!!token).then(function (t) {
-        return t ? authedFetch(url, init, true) : r;
-      });
+      if (r.status !== 401 || authCannotFix) return r;
+      if (s === 0) {
+        // Force a re-exchange only when we HELD a token that went stale. Holding none means the
+        // cached negative stands, so a signed-out viewer makes one attempt per page, not one per
+        // poll.
+        return ensureToken(!!token).then(function (t) {
+          return t ? authedFetch(url, init, 1) : r;
+        });
+      }
+      if (s === 1) return authedFetch(url, init, 2);
+      authCannotFix = true;
+      return r;
     });
   }
   // Server clock minus client clock, learned from the initial list response's Date
@@ -306,7 +338,11 @@ const WIDGET_JS = String.raw`(function () {
       actions.appendChild(send);
       compose.appendChild(actions);
       panel.appendChild(compose);
-    } else if (policy !== 'none' && !token) {
+    // Only once capability is KNOWN: openPanel renders synchronously, before the credential
+    // exists, so gating on !token alone painted "Sign in to comment" at a signed-in viewer for
+    // the round trip - the exact string this change exists to stop showing them. A genuinely
+    // signed-out viewer sees a bare footer for that beat instead, the better failure direction.
+    } else if (policy !== 'none' && !token && lastCanComment !== null) {
       var si = el('div'); si.id = 'b4m-signin';
       si.appendChild(document.createTextNode('Want to leave feedback? '));
       var a = el('a', null, 'Sign in to comment'); a.href = origin + '/login'; si.appendChild(a);
@@ -399,8 +435,20 @@ const WIDGET_JS = String.raw`(function () {
     // Needs a credential by definition (an anonymous viewer can never comment), so acquire
     // first. Only ever called once the panel is open - see openPanel.
     return ensureToken()
-      .then(function () { return authedFetch(CAN_API, {}); })
-      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (t) {
+        // No session -> can-comment can only answer false, so skip the round trip. It must still
+        // RECORD that false rather than just returning: render() gates the sign-in prompt on
+        // capability being known, so leaving lastCanComment null would suppress the prompt for
+        // exactly the signed-out viewer it is meant for.
+        if (!t) {
+          state.canComment = false;
+          lastCanComment = false;
+          render();
+          return null;
+        }
+        return authedFetch(CAN_API, {});
+      })
+      .then(function (r) { return r && r.ok ? r.json() : null; })
       .then(function (data) {
         if (!data) return;
         if (data.commentPolicy) policy = data.commentPolicy;

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -66,6 +66,9 @@ const WIDGET_JS = String.raw`(function () {
    * per poll, forever, which is precisely the rate-limit exhaustion the lazy design exists to
    * prevent. A page reload clears it, which is the right granularity - if the viewer unlocks the
    * gate in another tab, they reload to see comments anyway.
+   *
+   * NOTE it is a single page-lifetime latch shared by the list, can-comment and the POST, not
+   * one per endpoint: a 401 no credential can fix on any of them stops the others retrying too.
    */
   var authCannotFix = false;
 
@@ -94,6 +97,21 @@ const WIDGET_JS = String.raw`(function () {
   }
 
   /**
+   * The lowest stage known to be NECESSARY on this artifact, learned once per page. Without it
+   * the ladder is re-climbed on every request, and since stage 0 always sees a token held by
+   * then, each cycle takes the force branch and mints a fresh one - the same runaway
+   * authCannotFix exists to end, relocated out of the failure case and into the SUCCESS case.
+   * The reachable configuration is a passphrase-gated artifact the viewer has already unlocked:
+   * the proof is a cookie, so stages 0 and 1 both 401 and only stage 2 ever gets in.
+   *
+   * Only ever latches to 2, never 1. Stages 0 and 1 send byte-identical requests - headers()
+   * reads the module-level token either way - so remembering 1 would save no traffic while
+   * permanently skipping the only branch that re-exchanges a stale token, and a published
+   * artifact page routinely outlives the 30-minute access-token TTL more than once.
+   */
+  var baseStage = 0;
+
+  /**
    * Fetch, escalating only as far as a 401 forces. This is the single place a gated artifact is
    * discovered: the widget is never told the artifact's visibility, it learns from a 401 that
    * the request needed something it had not yet presented.
@@ -116,20 +134,25 @@ const WIDGET_JS = String.raw`(function () {
    * page can produce will help and retrying is pure cost.
    */
   function authedFetch(url, init, stage) {
-    var s = stage || 0;
+    var s = Math.max(stage || 0, baseStage);
     // Copy rather than mutate: opts IS init when init is truthy, so writing headers/credentials
     // onto it would scribble on the caller's object and on the retry's own input.
     var opts = init ? Object.assign({}, init) : {};
     opts.headers = headers(opts.method === 'POST');
     opts.credentials = s >= 2 ? 'same-origin' : 'omit';
     return fetch(url, opts).then(function (r) {
+      // A stage we had to climb to that WORKED is where every later request should start.
+      if (r.ok && s >= 2) baseStage = 2;
       if (r.status !== 401 || authCannotFix) return r;
       if (s === 0) {
         // Force a re-exchange only when we HELD a token that went stale. Holding none means the
         // cached negative stands, so a signed-out viewer makes one attempt per page, not one per
         // poll.
         return ensureToken(!!token).then(function (t) {
-          return t ? authedFetch(url, init, 1) : r;
+          // Escalate to the cookie even with NO token: a passphrase proof needs no session
+          // (checkAccessGate admits on passphraseVerified alone), so an anonymous viewer who
+          // unlocked the gate must reach stage 2 as well.
+          return authedFetch(url, init, t ? 1 : 2);
         });
       }
       if (s === 1) return authedFetch(url, init, 2);
@@ -498,8 +521,10 @@ const WIDGET_JS = String.raw`(function () {
     // Polls hit the cacheable LIST endpoint only (no per-viewer data) so the CDN
     // can collapse the fan-out across viewers. Sends whatever credential we already hold and
     // refreshes it on a 401 (the access token's TTL is far shorter than a page can stay open),
-    // but never ACQUIRES one - a poll must not start auth traffic the page had not already
-    // earned by opening the panel or loading a gated list.
+    // but does not acquire one once the page has settled - a poll must not start auth traffic
+    // the page had not already earned by opening the panel or loading a gated list. (A poll CAN
+    // acquire in one narrow case: if loadList's first request died on a network error rather
+    // than a 401, tokenPromise is still null and stage 0's ensureToken will start an exchange.)
     authedFetch(API, {})
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {

--- a/apps/client/pages/api/publish/widget.ts
+++ b/apps/client/pages/api/publish/widget.ts
@@ -7,10 +7,13 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  *
  * This is the ONLY author-facing JS that runs on a published bundle page -
  * author inline scripts are stripped at serve time. The widget therefore must
- * be self-contained vanilla JS (no framework), build its DOM with
+ * be self-contained vanilla JS (no framework) and build its DOM with
  * createElement/textContent (NEVER innerHTML on user data - comment bodies are
- * untrusted user input rendered on the app origin), and read the viewer's B4M
- * token from localStorage to authenticate writes.
+ * untrusted user input rendered on the app origin).
+ *
+ * It runs in the WRAPPER page on the app origin (see buildAnnotateOverlayHtml in
+ * serve/[...path].ts), never inside the sandboxed bundle iframe - which is what
+ * makes the same-origin cookie exchange in `ensureToken` reachable at all.
  *
  * Config (publicId, commentPolicy) is read from the #b4m-annotate-root mount
  * node's data-* attributes; the widget talks to /api/publish/annotations/*.
@@ -40,20 +43,67 @@ const WIDGET_JS = String.raw`(function () {
   var PENDING_TTL_MS = 300000;
   var state = { comments: [], canComment: false, open: false, pinMode: false, pendingAnchor: null, draft: '', justPosted: [] };
 
-  function getToken() {
-    try {
-      var raw = localStorage.getItem('access-token-storage');
-      if (!raw) return null;
-      var p = JSON.parse(raw);
-      return (p && p.state && p.state.accessToken) || null;
-    } catch (e) { return null; }
+  // ---- credential ----
+  // The viewer's session lives in an HttpOnly refresh cookie; the access token is memory-only
+  // and nothing is readable from script storage (see app/hooks/useAccessToken.ts partialize).
+  // So a token is OBTAINED, not read: POST /api/auth/refreshToken exchanges the cookie, exactly
+  // as the app's own cold load (app/utils/sessionBootstrap.ts) and the gated-bundle loader shell
+  // (server/services/publish/renderBundleLoaderShell.ts) do. MUST STAY IN SYNC with those two.
+  //
+  // Acquired LAZILY, unlike the loader shell's unconditional exchange. This widget loads on every
+  // published-artifact view, and the overwhelming majority are anonymous readers of public
+  // artifacts who need no credential at all - /api/auth/refreshToken is rate-limited per IP, so
+  // an exchange on every view would let one widely-shared artifact behind a NAT exhaust the limit
+  // and break real logins from that address. Instead the token is fetched only when something
+  // actually needs it: a list request that came back gated, or the panel being opened.
+  var token = null;
+  var tokenPromise = null;
+
+  /** Single-flight cookie exchange. Caches the NEGATIVE result too, so an anonymous viewer
+   *  makes exactly one attempt per page. The force flag re-arms it after a 401 (expired mid-session). */
+  function ensureToken(force) {
+    if (force) { token = null; tokenPromise = null; }
+    if (token) return Promise.resolve(token);
+    tokenPromise = tokenPromise || fetch(origin + '/api/auth/refreshToken', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: '{}'
+    })
+      .then(function (r) { return r.status === 200 ? r.json() : null; })
+      .then(function (d) { token = (d && d.accessToken) || null; return token; })
+      .catch(function () { token = null; return null; });
+    return tokenPromise;
   }
+
   function headers(json) {
     var h = {};
     if (json) h['Content-Type'] = 'application/json';
-    var t = getToken();
-    if (t) h['Authorization'] = 'Bearer ' + t;
+    if (token) h['Authorization'] = 'Bearer ' + token;
     return h;
+  }
+
+  /**
+   * Fetch with whatever credential we hold, and on a 401 obtain one ONCE and retry. This is
+   * the single place a gated artifact is discovered: the widget is never told the artifact's
+   * visibility, it simply learns from a 401 that this request needed a credential.
+   *
+   * The retried flag bounds it to one re-attempt, so an endpoint that 401s for a reason no token can
+   * fix (a revoked session) settles instead of looping.
+   */
+  function authedFetch(url, init, retried) {
+    var opts = init || {};
+    opts.headers = headers(opts.method === 'POST');
+    opts.credentials = 'omit'; // the Bearer header is the only credential; never the ambient cookie
+    return fetch(url, opts).then(function (r) {
+      if (r.status !== 401 || retried) return r;
+      // Force a re-exchange only when we HELD a token that went stale. Holding none means the
+      // cached negative stands, so a signed-out viewer cannot be made to re-attempt the
+      // exchange on every 60s poll.
+      return ensureToken(!!token).then(function (t) {
+        return t ? authedFetch(url, init, true) : r;
+      });
+    });
   }
   // Server clock minus client clock, learned from the initial list response's Date
   // header. Timestamps come from the server but were being compared against the
@@ -176,7 +226,13 @@ const WIDGET_JS = String.raw`(function () {
     launch.appendChild(d);
   }
 
-  function openPanel() { state.open = true; render(); }
+  // Opening the panel is the first moment the composer matters, so it is where the credential
+  // is acquired on a public artifact. lastCanComment gates it to one fetch per page.
+  function openPanel() {
+    state.open = true;
+    render();
+    if (lastCanComment === null) loadCanComment();
+  }
   function closePanel() { state.open = false; panel.classList.remove('b4m-open'); ov.style.display = ''; }
 
   function render() {
@@ -250,7 +306,7 @@ const WIDGET_JS = String.raw`(function () {
       actions.appendChild(send);
       compose.appendChild(actions);
       panel.appendChild(compose);
-    } else if (policy !== 'none' && !getToken()) {
+    } else if (policy !== 'none' && !token) {
       var si = el('div'); si.id = 'b4m-signin';
       si.appendChild(document.createTextNode('Want to leave feedback? '));
       var a = el('a', null, 'Sign in to comment'); a.href = origin + '/login'; si.appendChild(a);
@@ -325,18 +381,25 @@ const WIDGET_JS = String.raw`(function () {
     // else did) would otherwise be served their own stale pre-comment copy. The
     // in-memory justPosted guard below cannot help here - a reload wipes it.
     // Polls keep the default cache mode, so the fan-out collapse is preserved.
-    return fetch(API, { headers: headers(false), credentials: 'omit', cache: 'no-store' })
+    //
+    // On a GATED artifact this 401s, and authedFetch obtains a credential and retries - which
+    // is how a gated artifact's comments become visible to an authorized reader at all. That
+    // failure used to be swallowed here, leaving the panel saying "No comments yet".
+    return authedFetch(API, { cache: 'no-store' })
       .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); noteServerClock(r); return r.json(); })
       .then(function (data) {
         state.comments = data.annotations || [];
         policy = data.commentPolicy || policy;
         render();
       })
-      .catch(function () { /* artifact may be private to this viewer; stay quiet */ render(); });
+      .catch(function () { /* genuinely not readable by this viewer; stay quiet */ render(); });
   }
 
   function loadCanComment() {
-    fetch(CAN_API, { headers: headers(false), credentials: 'omit' })
+    // Needs a credential by definition (an anonymous viewer can never comment), so acquire
+    // first. Only ever called once the panel is open - see openPanel.
+    return ensureToken()
+      .then(function () { return authedFetch(CAN_API, {}); })
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {
         if (!data) return;
@@ -350,13 +413,18 @@ const WIDGET_JS = String.raw`(function () {
       .catch(function () {});
   }
 
-  function load() { loadList(); loadCanComment(); }
+  // Only the LIST runs on load. can-comment is deferred to the first panel open (openPanel):
+  // it is the only thing on a public artifact that needs a credential, and a reader who never
+  // opens the panel - the common case by a wide margin - should cost zero auth traffic.
+  function load() { loadList(); }
 
   function postComment(body, anchor) {
     var payload = { body: body };
     if (anchor) payload.anchor = anchor;
-    return fetch(API, { method: 'POST', headers: headers(true), credentials: 'omit', body: JSON.stringify(payload) })
+    return authedFetch(API, { method: 'POST', body: JSON.stringify(payload) })
       .then(function (r) {
+        // authedFetch already re-exchanged the cookie and retried once, so a 401 here means the
+        // session is genuinely gone rather than merely stale.
         if (r.status === 401) throw new Error('Please sign in again');
         if (!r.ok) return r.json().then(function (j) { throw new Error(j.error || ('HTTP ' + r.status)); });
         return r.json();
@@ -380,8 +448,11 @@ const WIDGET_JS = String.raw`(function () {
   function poll() {
     if (document.visibilityState !== 'visible') return;
     // Polls hit the cacheable LIST endpoint only (no per-viewer data) so the CDN
-    // can collapse the fan-out across viewers.
-    fetch(API, { headers: headers(false), credentials: 'omit' })
+    // can collapse the fan-out across viewers. Sends whatever credential we already hold and
+    // refreshes it on a 401 (the access token's TTL is far shorter than a page can stay open),
+    // but never ACQUIRES one - a poll must not start auth traffic the page had not already
+    // earned by opening the panel or loading a gated list.
+    authedFetch(API, {})
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {
         if (!data) return;
@@ -425,7 +496,9 @@ const WIDGET_JS = String.raw`(function () {
   document.addEventListener('visibilitychange', function () {
     if (document.visibilityState !== 'visible') return;
     poll();
-    loadCanComment();
+    // Only re-check capability if we already established it once - otherwise a backgrounded
+    // tab on a public artifact whose panel was never opened would start auth traffic on refocus.
+    if (lastCanComment !== null) loadCanComment();
   });
 
   updateLaunch();

--- a/apps/client/server/middlewares/optionalAuth.ts
+++ b/apps/client/server/middlewares/optionalAuth.ts
@@ -8,9 +8,11 @@ import { apiKeyAuth } from '@server/middlewares/apiKeyAuth';
  * JWT, but NEVER rejects an anonymous request - anonymous viewers must still be
  * able to read a public artifact's comments.
  *
- * The comment overlay widget runs same-origin on the app host, reads the
- * viewer's B4M token from localStorage, and sends it as `Authorization: Bearer`
- * - so a signed-in viewer is recognized here and may write. (This same-origin
+ * The comment overlay widget runs same-origin on the app host, obtains an access
+ * token by exchanging the HttpOnly refresh cookie against /api/auth/refreshToken,
+ * and sends it as `Authorization: Bearer` - so a signed-in viewer is recognized
+ * here and may write. (It used to read the token from localStorage; nothing is
+ * persisted there any more.) (This same-origin
  * token access is exactly the capability denied to author bundle JS, which is
  * stripped at serve time; only B4M's own trusted overlay can use it.)
  *

--- a/apps/client/server/middlewares/optionalAuth.ts
+++ b/apps/client/server/middlewares/optionalAuth.ts
@@ -11,8 +11,7 @@ import { apiKeyAuth } from '@server/middlewares/apiKeyAuth';
  * The comment overlay widget runs same-origin on the app host, obtains an access
  * token by exchanging the HttpOnly refresh cookie against /api/auth/refreshToken,
  * and sends it as `Authorization: Bearer` - so a signed-in viewer is recognized
- * here and may write. (It used to read the token from localStorage; nothing is
- * persisted there any more.) (This same-origin
+ * here and may write. (This same-origin
  * token access is exactly the capability denied to author bundle JS, which is
  * stripped at serve time; only B4M's own trusted overlay can use it.)
  *

--- a/scripts/no-baseapi-allowlist.txt
+++ b/scripts/no-baseapi-allowlist.txt
@@ -20,6 +20,7 @@ apps/client/pages/api/feedback/[id]/__tests__/update.ability.test.ts # Pure CASL
 apps/client/pages/api/admin/__tests__/agent-ops-settings.test.ts # Pure list-consistency test over exported const arrays; no HTTP route, no baseApi
 apps/client/pages/api/publish/widget.ts                 # Static first-party comment-overlay JS; intentionally public, no user data, no DB
 apps/client/pages/api/publish/__tests__/widget.test.ts  # Test file for the handler above (script greps by path, not export)
+apps/client/pages/api/publish/__tests__/widget.dom.test.ts # jsdom test that executes the widget above; no baseApi reference, so grep -L flags it
 apps/client/pages/api/embed/widget.ts                   # Static first-party embed-loader JS; intentionally public, no user data, no DB (epic #41 Phase C)
 apps/client/pages/api/embed/__tests__/widget.test.ts    # Test file for the handler above (script greps by path, not export)
 apps/client/pages/api/embed/__tests__/widget.dom.test.ts # jsdom test that executes the loader above; no baseApi reference, so grep -L flags it


### PR DESCRIPTION
## Description

Fixes #1811. The comment overlay on published artifacts authenticated nothing: a signed-in viewer was shown "Sign in to comment" while holding a live session, and on a gated artifact the existing comments were invisible entirely -- the panel read "No comments yet" to an authorized reader who had comments to see.

Same root cause as #1710, in a second consumer. `widget.ts` read the access token out of the zustand-persist envelope:

```js
var raw = localStorage.getItem('access-token-storage');
return (p && p.state && p.state.accessToken) || null;
```

`61a747d8` (#1346) changed `partialize` to persist only `{hasSession, expired, expiredReason}`. No credential is persisted any more, so that read has been `undefined` since it shipped and `headers()` never attached an `Authorization` header. Three symptoms followed: the composer never rendered for anyone (`canAnnotate` returns false at `if (!user?.id)`), the gated list `GET` 401d and the failure was swallowed by `loadList`'s catch, and posting 401d.

## Changes

The widget now obtains a token by exchanging the HttpOnly refresh cookie against `POST /api/auth/refreshToken`, the same mechanism as `sessionBootstrap.ts` and the gated-bundle loader shell. The widget runs in the WRAPPER page on the app origin (`buildAnnotateOverlayHtml`), never inside the sandboxed bundle iframe, which is what makes that same-origin exchange reachable at all -- I confirmed this before designing around it.

**Acquisition is lazy**, and this is the part that deliberately differs from the loader shell's unconditional exchange. The widget loads on *every* published-artifact view, the great majority of which are anonymous readers of public artifacts who need no credential, and `/api/auth/refreshToken` is rate-limited **60/min per IP**. An unconditional exchange would let one widely-shared public artifact behind a corporate NAT exhaust that limit and start breaking real logins from that address. So the token is fetched only when something actually needs it:

- **A list request that came back 401.** This is also how the widget discovers the artifact is gated, without ever being told its visibility -- it simply learns from the 401 that this request needed a credential. Self-correcting, and it keeps visibility knowledge out of the widget.
- **The panel being opened**, before `can-comment`, since the composer is the only thing on a public artifact that needs a credential. `can-comment` moved off the load path to `openPanel` for exactly this reason. A reader who never opens the panel triggers zero auth traffic.

Two robustness properties that the loader shell did not have to handle:

- **Single-flight, and the negative result is cached**, so a signed-out viewer attempts the exchange once per page rather than on every 60s poll.
- **`authedFetch` re-exchanges once on a 401**, so a session that expires while the page is open recovers instead of dead-ending. The access-token TTL is 30 minutes and a published-artifact page can sit open far longer. Bounded to a single retry, so a revoked session settles rather than looping. It forces a re-exchange only when a token was *held* and went stale -- holding none leaves the cached negative standing, so an anonymous viewer can never be made to re-attempt on every poll.

The `visibilitychange` handler now only re-checks capability if it was established once, so a backgrounded tab on a public artifact does not start auth traffic on refocus.

## Testing

Adds `widget.dom.test.ts` (7 tests), which evals the **real shipped script** against a stubbed fetch. Two of them assert traffic rather than correctness, which is what makes the laziness load-bearing rather than a comment:

- an anonymous reader of a public artifact issues **zero** requests to `/api/auth/refreshToken` across two poll cycles
- a signed-out viewer of a gated artifact attempts the exchange exactly **once** across three poll cycles

Plus: the composer appears for a signed-in viewer on panel open, the sign-in prompt still appears for a genuinely signed-out one, a gated artifact's comments become visible to an authorized reader, and a session expiring mid-page recovers.

**Correction to the issue as filed.** I wrote there that the widget had no test at all. That was wrong -- `widget.test.ts` exists with 10 tests and drives the shipped script in jsdom. What was missing was coverage of the *credential path* specifically: it stubs `can-comment` to return `canComment` directly, so acquisition was never exercised. I have corrected this in a comment on the issue.

That existing suite does catch this change, which is a good sign: its fetch stub matches any POST as a comment submission, so the session exchange was being mistaken for one and consuming an `onPost()` response. Fixed by matching the refresh endpoint first.

`pages/api/publish` + `server/services/publish`: 519 tests green. Lint clean. The new test file is added to `scripts/no-baseapi-allowlist.txt` alongside the exact precedent already there for `embed/__tests__/widget.dom.test.ts`.

## Guide for Testers

Needs a preview deploy, two accounts in the same organization, and one outside it.

1. Sign in and publish an artifact with `commentPolicy: open` and `visibility: public`.
2. Open its `/p/...` URL while signed in. Expected: the "Comments" launcher appears bottom-right.
3. Click the launcher. Expected: a comment textarea (the composer) appears. Before this fix you saw "Want to leave feedback? Sign in to comment" despite being signed in.
4. Type `hello from the composer` and click Comment. Expected: the comment posts and appears in the list immediately.
5. Open devtools -> Network, filter `refreshToken`, and reload the page **without** clicking the launcher. Expected: **zero** requests to `/api/auth/refreshToken`. This is the rate-limit protection -- treat any request here as a regression. Note this only proves the escalation ladder is never *entered* on an open-public artifact -- it never 401s, so it never leaves stage 0. Steps 11-13 are what prove the ladder *terminates*, and that is where both of the bugs found in review actually hid.
6. Now click the launcher. Expected: exactly one `refreshToken` request, then `can-comment`.
7. Open the same URL in a private window (signed out). Expected: the comment list still loads and renders existing comments; opening the panel shows "Sign in to comment"; still zero `refreshToken` requests before opening the panel, and at most one after.
8. Publish a second artifact with `visibility: organization` and `commentPolicy: open`, and post a comment on it as the owner.
9. Open it as a **different member of the same org**. Expected: the existing comment from step 8 is visible, and the composer appears. Before this fix the panel said "No comments yet".
10. Open it as a user in a **different org**. Expected: no access to the artifact at all (the artifact gate, unchanged by this PR).

The passphrase rung, which is where the escalation ladder is actually exercised:

11. Publish a third artifact with `visibility: public` **plus a passphrase**, `commentPolicy: open`, and post a comment on it as the owner.
12. Open it in a private window and enter the passphrase to unlock. Expected: the owner's comment from step 11 is visible, even though you are signed out -- a passphrase proof needs no session. In the Network tab the list request appears twice, the second carrying cookies, and `refreshToken` is attempted at most once.
13. Now sign in as any user, open the same artifact, unlock it, and leave the page sitting with the panel **closed** for ~5 minutes. Expected: after the initial load the `refreshToken` count stays **flat**, and each 60s poll costs **one** list request rather than three. A count that climbs once per minute here is the runaway this PR's review caught -- treat it as a regression.

Regression checks:

14. Confirm the launcher badge still shows the correct comment count on load, before the panel is ever opened.
15. Drop a pin: click the pin toggle, click a spot on the artifact, add a comment. Expected: the pin marker renders in the iframe and clicking it opens the panel.
16. Leave the page open and post a comment from another browser. Expected: within ~60s the new comment appears via polling.
17. Type a draft in the composer and let a poll fire mid-keystroke. Expected: the draft and caret survive the re-render.

What NOT to test: no changes to the artifact visibility ladder itself, the domain gate, or the loader shell. The passphrase gate's *enforcement* is likewise unchanged -- but whether the widget can present the proof cookie to it is squarely in scope, which is what steps 11-13 cover.

## Additional Information

**One consequence worth a reviewer's eye.** A signed-in viewer opening the comment panel now rotates their refresh cookie, since `/api/auth/refreshToken` rotates on every exchange. That is the same behaviour the loader shell introduced in #1717 and it is covered by the 60s one-generation grace window in `rotateSession`, so concurrent tabs converge rather than tripping reuse detection. It is nonetheless a second place that now rotates sessions, and if we later want to avoid that, the clean answer is a mint-only endpoint that does not rotate -- deliberately not introduced here, since it is new auth surface and this PR is a bug fix.

**Embeds.** On an allowlisted external site the wrapper is framed cross-site, so the `SameSite=Strict` refresh cookie is not sent and the exchange yields nothing. Commenting from an embed therefore stays anonymous. That is the pre-existing behaviour and arguably the correct one, but it is now explicit rather than accidental.

